### PR TITLE
feat(metafetch): transcription-aware filters in metadata review dialog

### DIFF
--- a/internal/ai/mocks/mock_metadata_candidate_scorer.go
+++ b/internal/ai/mocks/mock_metadata_candidate_scorer.go
@@ -119,7 +119,7 @@ type MockMetadataCandidateScorer_Score_Call struct {
 //   - ctx context.Context
 //   - q ai.Query
 //   - cands []ai.Candidate
-func (_e *MockMetadataCandidateScorer_Expecter) Score(ctx interface{}, q interface{}, cands interface{}) *MockMetadataCandidateScorer_Score_Call {
+func (_e *MockMetadataCandidateScorer_Expecter) Score(ctx any, q any, cands any) *MockMetadataCandidateScorer_Score_Call {
 	return &MockMetadataCandidateScorer_Score_Call{Call: _e.mock.On("Score", ctx, q, cands)}
 }
 

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -74,7 +74,7 @@ type MockAuthorReader_FindAuthorByAlias_Call struct {
 
 // FindAuthorByAlias is a helper method to define mock.On call
 //   - aliasName string
-func (_e *MockAuthorReader_Expecter) FindAuthorByAlias(aliasName interface{}) *MockAuthorReader_FindAuthorByAlias_Call {
+func (_e *MockAuthorReader_Expecter) FindAuthorByAlias(aliasName any) *MockAuthorReader_FindAuthorByAlias_Call {
 	return &MockAuthorReader_FindAuthorByAlias_Call{Call: _e.mock.On("FindAuthorByAlias", aliasName)}
 }
 
@@ -356,7 +356,7 @@ type MockAuthorReader_GetAuthorAliases_Call struct {
 
 // GetAuthorAliases is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockAuthorReader_Expecter) GetAuthorAliases(authorID interface{}) *MockAuthorReader_GetAuthorAliases_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorAliases(authorID any) *MockAuthorReader_GetAuthorAliases_Call {
 	return &MockAuthorReader_GetAuthorAliases_Call{Call: _e.mock.On("GetAuthorAliases", authorID)}
 }
 
@@ -418,7 +418,7 @@ type MockAuthorReader_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorReader_Expecter) GetAuthorByID(id interface{}) *MockAuthorReader_GetAuthorByID_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorByID(id any) *MockAuthorReader_GetAuthorByID_Call {
 	return &MockAuthorReader_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -480,7 +480,7 @@ type MockAuthorReader_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockAuthorReader_Expecter) GetAuthorByName(name interface{}) *MockAuthorReader_GetAuthorByName_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorByName(name any) *MockAuthorReader_GetAuthorByName_Call {
 	return &MockAuthorReader_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -540,7 +540,7 @@ type MockAuthorReader_GetAuthorTombstone_Call struct {
 
 // GetAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
-func (_e *MockAuthorReader_Expecter) GetAuthorTombstone(oldID interface{}) *MockAuthorReader_GetAuthorTombstone_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorTombstone(oldID any) *MockAuthorReader_GetAuthorTombstone_Call {
 	return &MockAuthorReader_GetAuthorTombstone_Call{Call: _e.mock.On("GetAuthorTombstone", oldID)}
 }
 
@@ -603,7 +603,7 @@ type MockAuthorReader_GetAuthorsByBookIDs_Call struct {
 // GetAuthorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockAuthorReader_Expecter) GetAuthorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockAuthorReader_GetAuthorsByBookIDs_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorsByBookIDs(ctx any, bookIDs any) *MockAuthorReader_GetAuthorsByBookIDs_Call {
 	return &MockAuthorReader_GetAuthorsByBookIDs_Call{Call: _e.mock.On("GetAuthorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -670,7 +670,7 @@ type MockAuthorReader_GetAuthorsByIDs_Call struct {
 
 // GetAuthorsByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockAuthorReader_Expecter) GetAuthorsByIDs(ids interface{}) *MockAuthorReader_GetAuthorsByIDs_Call {
+func (_e *MockAuthorReader_Expecter) GetAuthorsByIDs(ids any) *MockAuthorReader_GetAuthorsByIDs_Call {
 	return &MockAuthorReader_GetAuthorsByIDs_Call{Call: _e.mock.On("GetAuthorsByIDs", ids)}
 }
 
@@ -732,7 +732,7 @@ type MockAuthorReader_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAuthorReader_Expecter) GetBookAuthors(bookID interface{}) *MockAuthorReader_GetBookAuthors_Call {
+func (_e *MockAuthorReader_Expecter) GetBookAuthors(bookID any) *MockAuthorReader_GetBookAuthors_Call {
 	return &MockAuthorReader_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -794,7 +794,7 @@ type MockAuthorReader_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockAuthorReader_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockAuthorReader_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockAuthorReader_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockAuthorReader_GetBooksByAuthorIDWithRole_Call {
 	return &MockAuthorReader_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -883,7 +883,7 @@ type MockAuthorWriter_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockAuthorWriter_Expecter) CreateAuthor(name interface{}) *MockAuthorWriter_CreateAuthor_Call {
+func (_e *MockAuthorWriter_Expecter) CreateAuthor(name any) *MockAuthorWriter_CreateAuthor_Call {
 	return &MockAuthorWriter_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -947,7 +947,7 @@ type MockAuthorWriter_CreateAuthorAlias_Call struct {
 //   - authorID int
 //   - aliasName string
 //   - aliasType string
-func (_e *MockAuthorWriter_Expecter) CreateAuthorAlias(authorID interface{}, aliasName interface{}, aliasType interface{}) *MockAuthorWriter_CreateAuthorAlias_Call {
+func (_e *MockAuthorWriter_Expecter) CreateAuthorAlias(authorID any, aliasName any, aliasType any) *MockAuthorWriter_CreateAuthorAlias_Call {
 	return &MockAuthorWriter_CreateAuthorAlias_Call{Call: _e.mock.On("CreateAuthorAlias", authorID, aliasName, aliasType)}
 }
 
@@ -1009,7 +1009,7 @@ type MockAuthorWriter_CreateAuthorTombstone_Call struct {
 // CreateAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
 //   - canonicalID int
-func (_e *MockAuthorWriter_Expecter) CreateAuthorTombstone(oldID interface{}, canonicalID interface{}) *MockAuthorWriter_CreateAuthorTombstone_Call {
+func (_e *MockAuthorWriter_Expecter) CreateAuthorTombstone(oldID any, canonicalID any) *MockAuthorWriter_CreateAuthorTombstone_Call {
 	return &MockAuthorWriter_CreateAuthorTombstone_Call{Call: _e.mock.On("CreateAuthorTombstone", oldID, canonicalID)}
 }
 
@@ -1065,7 +1065,7 @@ type MockAuthorWriter_DeleteAuthor_Call struct {
 
 // DeleteAuthor is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorWriter_Expecter) DeleteAuthor(id interface{}) *MockAuthorWriter_DeleteAuthor_Call {
+func (_e *MockAuthorWriter_Expecter) DeleteAuthor(id any) *MockAuthorWriter_DeleteAuthor_Call {
 	return &MockAuthorWriter_DeleteAuthor_Call{Call: _e.mock.On("DeleteAuthor", id)}
 }
 
@@ -1116,7 +1116,7 @@ type MockAuthorWriter_DeleteAuthorAlias_Call struct {
 
 // DeleteAuthorAlias is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorWriter_Expecter) DeleteAuthorAlias(id interface{}) *MockAuthorWriter_DeleteAuthorAlias_Call {
+func (_e *MockAuthorWriter_Expecter) DeleteAuthorAlias(id any) *MockAuthorWriter_DeleteAuthorAlias_Call {
 	return &MockAuthorWriter_DeleteAuthorAlias_Call{Call: _e.mock.On("DeleteAuthorAlias", id)}
 }
 
@@ -1221,7 +1221,7 @@ type MockAuthorWriter_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockAuthorWriter_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockAuthorWriter_SetBookAuthors_Call {
+func (_e *MockAuthorWriter_Expecter) SetBookAuthors(bookID any, authors any) *MockAuthorWriter_SetBookAuthors_Call {
 	return &MockAuthorWriter_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -1278,7 +1278,7 @@ type MockAuthorWriter_UpdateAuthorName_Call struct {
 // UpdateAuthorName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockAuthorWriter_Expecter) UpdateAuthorName(id interface{}, name interface{}) *MockAuthorWriter_UpdateAuthorName_Call {
+func (_e *MockAuthorWriter_Expecter) UpdateAuthorName(id any, name any) *MockAuthorWriter_UpdateAuthorName_Call {
 	return &MockAuthorWriter_UpdateAuthorName_Call{Call: _e.mock.On("UpdateAuthorName", id, name)}
 }
 
@@ -1372,7 +1372,7 @@ type MockAuthorStore_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockAuthorStore_Expecter) CreateAuthor(name interface{}) *MockAuthorStore_CreateAuthor_Call {
+func (_e *MockAuthorStore_Expecter) CreateAuthor(name any) *MockAuthorStore_CreateAuthor_Call {
 	return &MockAuthorStore_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -1436,7 +1436,7 @@ type MockAuthorStore_CreateAuthorAlias_Call struct {
 //   - authorID int
 //   - aliasName string
 //   - aliasType string
-func (_e *MockAuthorStore_Expecter) CreateAuthorAlias(authorID interface{}, aliasName interface{}, aliasType interface{}) *MockAuthorStore_CreateAuthorAlias_Call {
+func (_e *MockAuthorStore_Expecter) CreateAuthorAlias(authorID any, aliasName any, aliasType any) *MockAuthorStore_CreateAuthorAlias_Call {
 	return &MockAuthorStore_CreateAuthorAlias_Call{Call: _e.mock.On("CreateAuthorAlias", authorID, aliasName, aliasType)}
 }
 
@@ -1498,7 +1498,7 @@ type MockAuthorStore_CreateAuthorTombstone_Call struct {
 // CreateAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
 //   - canonicalID int
-func (_e *MockAuthorStore_Expecter) CreateAuthorTombstone(oldID interface{}, canonicalID interface{}) *MockAuthorStore_CreateAuthorTombstone_Call {
+func (_e *MockAuthorStore_Expecter) CreateAuthorTombstone(oldID any, canonicalID any) *MockAuthorStore_CreateAuthorTombstone_Call {
 	return &MockAuthorStore_CreateAuthorTombstone_Call{Call: _e.mock.On("CreateAuthorTombstone", oldID, canonicalID)}
 }
 
@@ -1554,7 +1554,7 @@ type MockAuthorStore_DeleteAuthor_Call struct {
 
 // DeleteAuthor is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorStore_Expecter) DeleteAuthor(id interface{}) *MockAuthorStore_DeleteAuthor_Call {
+func (_e *MockAuthorStore_Expecter) DeleteAuthor(id any) *MockAuthorStore_DeleteAuthor_Call {
 	return &MockAuthorStore_DeleteAuthor_Call{Call: _e.mock.On("DeleteAuthor", id)}
 }
 
@@ -1605,7 +1605,7 @@ type MockAuthorStore_DeleteAuthorAlias_Call struct {
 
 // DeleteAuthorAlias is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorStore_Expecter) DeleteAuthorAlias(id interface{}) *MockAuthorStore_DeleteAuthorAlias_Call {
+func (_e *MockAuthorStore_Expecter) DeleteAuthorAlias(id any) *MockAuthorStore_DeleteAuthorAlias_Call {
 	return &MockAuthorStore_DeleteAuthorAlias_Call{Call: _e.mock.On("DeleteAuthorAlias", id)}
 }
 
@@ -1667,7 +1667,7 @@ type MockAuthorStore_FindAuthorByAlias_Call struct {
 
 // FindAuthorByAlias is a helper method to define mock.On call
 //   - aliasName string
-func (_e *MockAuthorStore_Expecter) FindAuthorByAlias(aliasName interface{}) *MockAuthorStore_FindAuthorByAlias_Call {
+func (_e *MockAuthorStore_Expecter) FindAuthorByAlias(aliasName any) *MockAuthorStore_FindAuthorByAlias_Call {
 	return &MockAuthorStore_FindAuthorByAlias_Call{Call: _e.mock.On("FindAuthorByAlias", aliasName)}
 }
 
@@ -1949,7 +1949,7 @@ type MockAuthorStore_GetAuthorAliases_Call struct {
 
 // GetAuthorAliases is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockAuthorStore_Expecter) GetAuthorAliases(authorID interface{}) *MockAuthorStore_GetAuthorAliases_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorAliases(authorID any) *MockAuthorStore_GetAuthorAliases_Call {
 	return &MockAuthorStore_GetAuthorAliases_Call{Call: _e.mock.On("GetAuthorAliases", authorID)}
 }
 
@@ -2011,7 +2011,7 @@ type MockAuthorStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockAuthorStore_Expecter) GetAuthorByID(id interface{}) *MockAuthorStore_GetAuthorByID_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorByID(id any) *MockAuthorStore_GetAuthorByID_Call {
 	return &MockAuthorStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -2073,7 +2073,7 @@ type MockAuthorStore_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockAuthorStore_Expecter) GetAuthorByName(name interface{}) *MockAuthorStore_GetAuthorByName_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorByName(name any) *MockAuthorStore_GetAuthorByName_Call {
 	return &MockAuthorStore_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -2133,7 +2133,7 @@ type MockAuthorStore_GetAuthorTombstone_Call struct {
 
 // GetAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
-func (_e *MockAuthorStore_Expecter) GetAuthorTombstone(oldID interface{}) *MockAuthorStore_GetAuthorTombstone_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorTombstone(oldID any) *MockAuthorStore_GetAuthorTombstone_Call {
 	return &MockAuthorStore_GetAuthorTombstone_Call{Call: _e.mock.On("GetAuthorTombstone", oldID)}
 }
 
@@ -2196,7 +2196,7 @@ type MockAuthorStore_GetAuthorsByBookIDs_Call struct {
 // GetAuthorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockAuthorStore_Expecter) GetAuthorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockAuthorStore_GetAuthorsByBookIDs_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorsByBookIDs(ctx any, bookIDs any) *MockAuthorStore_GetAuthorsByBookIDs_Call {
 	return &MockAuthorStore_GetAuthorsByBookIDs_Call{Call: _e.mock.On("GetAuthorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -2263,7 +2263,7 @@ type MockAuthorStore_GetAuthorsByIDs_Call struct {
 
 // GetAuthorsByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockAuthorStore_Expecter) GetAuthorsByIDs(ids interface{}) *MockAuthorStore_GetAuthorsByIDs_Call {
+func (_e *MockAuthorStore_Expecter) GetAuthorsByIDs(ids any) *MockAuthorStore_GetAuthorsByIDs_Call {
 	return &MockAuthorStore_GetAuthorsByIDs_Call{Call: _e.mock.On("GetAuthorsByIDs", ids)}
 }
 
@@ -2325,7 +2325,7 @@ type MockAuthorStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAuthorStore_Expecter) GetBookAuthors(bookID interface{}) *MockAuthorStore_GetBookAuthors_Call {
+func (_e *MockAuthorStore_Expecter) GetBookAuthors(bookID any) *MockAuthorStore_GetBookAuthors_Call {
 	return &MockAuthorStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -2387,7 +2387,7 @@ type MockAuthorStore_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockAuthorStore_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockAuthorStore_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockAuthorStore_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockAuthorStore_GetBooksByAuthorIDWithRole_Call {
 	return &MockAuthorStore_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -2492,7 +2492,7 @@ type MockAuthorStore_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockAuthorStore_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockAuthorStore_SetBookAuthors_Call {
+func (_e *MockAuthorStore_Expecter) SetBookAuthors(bookID any, authors any) *MockAuthorStore_SetBookAuthors_Call {
 	return &MockAuthorStore_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -2549,7 +2549,7 @@ type MockAuthorStore_UpdateAuthorName_Call struct {
 // UpdateAuthorName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockAuthorStore_Expecter) UpdateAuthorName(id interface{}, name interface{}) *MockAuthorStore_UpdateAuthorName_Call {
+func (_e *MockAuthorStore_Expecter) UpdateAuthorName(id any, name any) *MockAuthorStore_UpdateAuthorName_Call {
 	return &MockAuthorStore_UpdateAuthorName_Call{Call: _e.mock.On("UpdateAuthorName", id, name)}
 }
 
@@ -2608,6 +2608,59 @@ func (_m *MockBookReader) EXPECT() *MockBookReader_Expecter {
 	return &MockBookReader_Expecter{mock: &_m.Mock}
 }
 
+// CountAllBooks provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) CountAllBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAllBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockBookReader_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockBookReader_Expecter) CountAllBooks() *MockBookReader_CountAllBooks_Call {
+	return &MockBookReader_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockBookReader_CountAllBooks_Call) Run(run func()) *MockBookReader_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockBookReader_CountAllBooks_Call) Return(n int, err error) *MockBookReader_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockBookReader_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockBookReader_CountAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountPrimaryBooks provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) CountPrimaryBooks() (int, error) {
 	ret := _mock.Called()
@@ -2657,50 +2710,6 @@ func (_c *MockBookReader_CountPrimaryBooks_Call) Return(n int, err error) *MockB
 }
 
 func (_c *MockBookReader_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockBookReader_CountPrimaryBooks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-func (_mock *MockBookReader) CountAllBooks() (int, error) {
-	ret := _mock.Called()
-	if len(ret) == 0 {
-		panic("no return value specified for CountAllBooks")
-	}
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockBookReader_CountAllBooks_Call struct{ *mock.Call }
-
-func (_e *MockBookReader_Expecter) CountAllBooks() *MockBookReader_CountAllBooks_Call {
-	return &MockBookReader_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
-}
-
-func (_c *MockBookReader_CountAllBooks_Call) Run(run func()) *MockBookReader_CountAllBooks_Call {
-	_c.Call.Run(func(args mock.Arguments) { run() })
-	return _c
-}
-
-func (_c *MockBookReader_CountAllBooks_Call) Return(n int, err error) *MockBookReader_CountAllBooks_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *MockBookReader_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockBookReader_CountAllBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2794,7 +2803,7 @@ type MockBookReader_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookReader_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockBookReader_GetAllBookSummaries_Call {
+func (_e *MockBookReader_Expecter) GetAllBookSummaries(limit any, offset any) *MockBookReader_GetAllBookSummaries_Call {
 	return &MockBookReader_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -2862,7 +2871,7 @@ type MockBookReader_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookReader_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockBookReader_GetAllBooks_Call {
+func (_e *MockBookReader_Expecter) GetAllBooks(limit any, offset any) *MockBookReader_GetAllBooks_Call {
 	return &MockBookReader_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -2930,7 +2939,7 @@ type MockBookReader_GetAllBooksFrom_Call struct {
 // GetAllBooksFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockBookReader_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockBookReader_GetAllBooksFrom_Call {
+func (_e *MockBookReader_Expecter) GetAllBooksFrom(afterID any, limit any) *MockBookReader_GetAllBooksFrom_Call {
 	return &MockBookReader_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
 
@@ -2944,7 +2953,10 @@ func (_c *MockBookReader_GetAllBooksFrom_Call) Run(run func(afterID string, limi
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -2954,7 +2966,7 @@ func (_c *MockBookReader_GetAllBooksFrom_Call) Return(books []database.Book, err
 	return _c
 }
 
-func (_c *MockBookReader_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockBookReader_GetAllBooksFrom_Call {
+func (_c *MockBookReader_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookReader_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2995,7 +3007,7 @@ type MockBookReader_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockBookReader_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockBookReader_GetBookAtVersion_Call {
+func (_e *MockBookReader_Expecter) GetBookAtVersion(id any, ts any) *MockBookReader_GetBookAtVersion_Call {
 	return &MockBookReader_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -3062,7 +3074,7 @@ type MockBookReader_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookReader_Expecter) GetBookByFileHash(hash interface{}) *MockBookReader_GetBookByFileHash_Call {
+func (_e *MockBookReader_Expecter) GetBookByFileHash(hash any) *MockBookReader_GetBookByFileHash_Call {
 	return &MockBookReader_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -3124,7 +3136,7 @@ type MockBookReader_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockBookReader_Expecter) GetBookByFilePath(path interface{}) *MockBookReader_GetBookByFilePath_Call {
+func (_e *MockBookReader_Expecter) GetBookByFilePath(path any) *MockBookReader_GetBookByFilePath_Call {
 	return &MockBookReader_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -3186,7 +3198,7 @@ type MockBookReader_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookReader_Expecter) GetBookByID(id interface{}) *MockBookReader_GetBookByID_Call {
+func (_e *MockBookReader_Expecter) GetBookByID(id any) *MockBookReader_GetBookByID_Call {
 	return &MockBookReader_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -3248,7 +3260,7 @@ type MockBookReader_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockBookReader_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockBookReader_GetBookByITunesPersistentID_Call {
+func (_e *MockBookReader_Expecter) GetBookByITunesPersistentID(persistentID any) *MockBookReader_GetBookByITunesPersistentID_Call {
 	return &MockBookReader_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -3310,7 +3322,7 @@ type MockBookReader_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookReader_Expecter) GetBookByOrganizedHash(hash interface{}) *MockBookReader_GetBookByOrganizedHash_Call {
+func (_e *MockBookReader_Expecter) GetBookByOrganizedHash(hash any) *MockBookReader_GetBookByOrganizedHash_Call {
 	return &MockBookReader_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -3372,7 +3384,7 @@ type MockBookReader_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookReader_Expecter) GetBookByOriginalHash(hash interface{}) *MockBookReader_GetBookByOriginalHash_Call {
+func (_e *MockBookReader_Expecter) GetBookByOriginalHash(hash any) *MockBookReader_GetBookByOriginalHash_Call {
 	return &MockBookReader_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -3395,6 +3407,80 @@ func (_c *MockBookReader_GetBookByOriginalHash_Call) Return(book *database.Book,
 }
 
 func (_c *MockBookReader_GetBookByOriginalHash_Call) RunAndReturn(run func(hash string) (*database.Book, error)) *MockBookReader_GetBookByOriginalHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockBookReader_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockBookReader_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	return &MockBookReader_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockBookReader_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockBookReader_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3435,7 +3521,7 @@ type MockBookReader_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockBookReader_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockBookReader_GetBookSnapshots_Call {
+func (_e *MockBookReader_Expecter) GetBookSnapshots(id any, limit any) *MockBookReader_GetBookSnapshots_Call {
 	return &MockBookReader_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -3502,7 +3588,7 @@ type MockBookReader_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookReader_Expecter) GetBookTombstone(id interface{}) *MockBookReader_GetBookTombstone_Call {
+func (_e *MockBookReader_Expecter) GetBookTombstone(id any) *MockBookReader_GetBookTombstone_Call {
 	return &MockBookReader_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -3564,7 +3650,7 @@ type MockBookReader_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockBookReader_Expecter) GetBooksByAuthorID(authorID interface{}) *MockBookReader_GetBooksByAuthorID_Call {
+func (_e *MockBookReader_Expecter) GetBooksByAuthorID(authorID any) *MockBookReader_GetBooksByAuthorID_Call {
 	return &MockBookReader_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -3626,7 +3712,7 @@ type MockBookReader_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookReader_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookReader_GetBooksByMetadataSourceHash_Call {
+func (_e *MockBookReader_Expecter) GetBooksByMetadataSourceHash(hash any) *MockBookReader_GetBooksByMetadataSourceHash_Call {
 	return &MockBookReader_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -3649,76 +3735,6 @@ func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) Return(books []datab
 }
 
 func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookReader_GetBooksByMetadataSourceHash_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookIDsByISBNASIN provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
-	ret := _mock.Called(isbn10, isbn13, asin)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookIDsByISBNASIN")
-	}
-
-	var r0 []string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
-		return returnFunc(isbn10, isbn13, asin)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
-		r0 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockBookReader_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
-type MockBookReader_GetBookIDsByISBNASIN_Call struct {
-	*mock.Call
-}
-
-// GetBookIDsByISBNASIN is a helper method to define mock.On call
-//   - isbn10 string
-//   - isbn13 string
-//   - asin string
-func (_e *MockBookReader_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockBookReader_GetBookIDsByISBNASIN_Call {
-	return &MockBookReader_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
-}
-
-func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookReader_GetBookIDsByISBNASIN_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(arg0, arg1, arg2)
-	})
-	return _c
-}
-
-func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockBookReader_GetBookIDsByISBNASIN_Call {
-	_c.Call.Return(ids, err)
-	return _c
-}
-
-func (_c *MockBookReader_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockBookReader_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3758,7 +3774,7 @@ type MockBookReader_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockBookReader_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockBookReader_GetBooksBySeriesID_Call {
+func (_e *MockBookReader_Expecter) GetBooksBySeriesID(seriesID any) *MockBookReader_GetBooksBySeriesID_Call {
 	return &MockBookReader_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -3821,7 +3837,7 @@ type MockBookReader_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockBookReader_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockBookReader_GetBooksByTitleInDir_Call {
+func (_e *MockBookReader_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockBookReader_GetBooksByTitleInDir_Call {
 	return &MockBookReader_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -3888,7 +3904,7 @@ type MockBookReader_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockBookReader_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockBookReader_GetBooksByVersionGroup_Call {
+func (_e *MockBookReader_Expecter) GetBooksByVersionGroup(groupID any) *MockBookReader_GetBooksByVersionGroup_Call {
 	return &MockBookReader_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -4115,7 +4131,7 @@ type MockBookReader_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockBookReader_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockBookReader_GetDuplicateBooksByMetadata_Call {
+func (_e *MockBookReader_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockBookReader_GetDuplicateBooksByMetadata_Call {
 	return &MockBookReader_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -4343,7 +4359,7 @@ type MockBookReader_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookReader_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockBookReader_GetQuarantinedBooks_Call {
+func (_e *MockBookReader_Expecter) GetQuarantinedBooks(limit any, offset any) *MockBookReader_GetQuarantinedBooks_Call {
 	return &MockBookReader_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -4465,7 +4481,7 @@ type MockBookReader_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockBookReader_Expecter) ListBookTombstones(limit interface{}) *MockBookReader_ListBookTombstones_Call {
+func (_e *MockBookReader_Expecter) ListBookTombstones(limit any) *MockBookReader_ListBookTombstones_Call {
 	return &MockBookReader_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -4528,7 +4544,7 @@ type MockBookReader_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookReader_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockBookReader_ListBooksByITunesPID_Call {
+func (_e *MockBookReader_Expecter) ListBooksByITunesPID(limit any, offset any) *MockBookReader_ListBooksByITunesPID_Call {
 	return &MockBookReader_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -4597,7 +4613,7 @@ type MockBookReader_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockBookReader_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockBookReader_ListSoftDeletedBooks_Call {
+func (_e *MockBookReader_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockBookReader_ListSoftDeletedBooks_Call {
 	return &MockBookReader_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -4671,7 +4687,7 @@ type MockBookReader_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockBookReader_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockBookReader_SearchBooks_Call {
+func (_e *MockBookReader_Expecter) SearchBooks(query any, limit any, offset any) *MockBookReader_SearchBooks_Call {
 	return &MockBookReader_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -4770,7 +4786,7 @@ type MockBookWriter_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockBookWriter_Expecter) CreateBook(book interface{}) *MockBookWriter_CreateBook_Call {
+func (_e *MockBookWriter_Expecter) CreateBook(book any) *MockBookWriter_CreateBook_Call {
 	return &MockBookWriter_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -4821,7 +4837,7 @@ type MockBookWriter_CreateBookTombstone_Call struct {
 
 // CreateBookTombstone is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockBookWriter_Expecter) CreateBookTombstone(book interface{}) *MockBookWriter_CreateBookTombstone_Call {
+func (_e *MockBookWriter_Expecter) CreateBookTombstone(book any) *MockBookWriter_CreateBookTombstone_Call {
 	return &MockBookWriter_CreateBookTombstone_Call{Call: _e.mock.On("CreateBookTombstone", book)}
 }
 
@@ -4872,7 +4888,7 @@ type MockBookWriter_DeleteBook_Call struct {
 
 // DeleteBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookWriter_Expecter) DeleteBook(id interface{}) *MockBookWriter_DeleteBook_Call {
+func (_e *MockBookWriter_Expecter) DeleteBook(id any) *MockBookWriter_DeleteBook_Call {
 	return &MockBookWriter_DeleteBook_Call{Call: _e.mock.On("DeleteBook", id)}
 }
 
@@ -4923,7 +4939,7 @@ type MockBookWriter_DeleteBookTombstone_Call struct {
 
 // DeleteBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookWriter_Expecter) DeleteBookTombstone(id interface{}) *MockBookWriter_DeleteBookTombstone_Call {
+func (_e *MockBookWriter_Expecter) DeleteBookTombstone(id any) *MockBookWriter_DeleteBookTombstone_Call {
 	return &MockBookWriter_DeleteBookTombstone_Call{Call: _e.mock.On("DeleteBookTombstone", id)}
 }
 
@@ -4975,7 +4991,7 @@ type MockBookWriter_FlagMetadataHashDuplicate_Call struct {
 // FlagMetadataHashDuplicate is a helper method to define mock.On call
 //   - primaryID string
 //   - duplicateID string
-func (_e *MockBookWriter_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookWriter_FlagMetadataHashDuplicate_Call {
+func (_e *MockBookWriter_Expecter) FlagMetadataHashDuplicate(primaryID any, duplicateID any) *MockBookWriter_FlagMetadataHashDuplicate_Call {
 	return &MockBookWriter_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
 }
 
@@ -5003,51 +5019,6 @@ func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) Return(err error) *Mock
 }
 
 func (_c *MockBookWriter_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockBookWriter_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecomputeBookAggregates provides a mock function for the type MockBookWriter
-func (_mock *MockBookWriter) RecomputeBookAggregates(bookID string) error {
-	ret := _mock.Called(bookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecomputeBookAggregates")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockBookWriter_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
-type MockBookWriter_RecomputeBookAggregates_Call struct {
-	*mock.Call
-}
-
-// RecomputeBookAggregates is a helper method to define mock.On call
-//   - bookID string
-func (_e *MockBookWriter_Expecter) RecomputeBookAggregates(bookID interface{}) *MockBookWriter_RecomputeBookAggregates_Call {
-	return &MockBookWriter_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
-}
-
-func (_c *MockBookWriter_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockBookWriter_RecomputeBookAggregates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockBookWriter_RecomputeBookAggregates_Call) Return(err error) *MockBookWriter_RecomputeBookAggregates_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockBookWriter_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockBookWriter_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5085,7 +5056,7 @@ type MockBookWriter_GetScanFailCount_Call struct {
 
 // GetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookWriter_Expecter) GetScanFailCount(pathHash interface{}) *MockBookWriter_GetScanFailCount_Call {
+func (_e *MockBookWriter_Expecter) GetScanFailCount(pathHash any) *MockBookWriter_GetScanFailCount_Call {
 	return &MockBookWriter_GetScanFailCount_Call{Call: _e.mock.On("GetScanFailCount", pathHash)}
 }
 
@@ -5145,7 +5116,7 @@ type MockBookWriter_IncrScanFailCount_Call struct {
 
 // IncrScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookWriter_Expecter) IncrScanFailCount(pathHash interface{}) *MockBookWriter_IncrScanFailCount_Call {
+func (_e *MockBookWriter_Expecter) IncrScanFailCount(pathHash any) *MockBookWriter_IncrScanFailCount_Call {
 	return &MockBookWriter_IncrScanFailCount_Call{Call: _e.mock.On("IncrScanFailCount", pathHash)}
 }
 
@@ -5205,7 +5176,7 @@ type MockBookWriter_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockBookWriter_Expecter) MarkITunesSynced(bookIDs interface{}) *MockBookWriter_MarkITunesSynced_Call {
+func (_e *MockBookWriter_Expecter) MarkITunesSynced(bookIDs any) *MockBookWriter_MarkITunesSynced_Call {
 	return &MockBookWriter_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -5259,7 +5230,7 @@ type MockBookWriter_MergeChapterBooks_Call struct {
 //   - srcIDs []string
 //   - commonTitle string
 //   - totalDuration float64
-func (_e *MockBookWriter_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockBookWriter_MergeChapterBooks_Call {
+func (_e *MockBookWriter_Expecter) MergeChapterBooks(primaryID any, srcIDs any, commonTitle any, totalDuration any) *MockBookWriter_MergeChapterBooks_Call {
 	return &MockBookWriter_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
 }
 
@@ -5335,7 +5306,7 @@ type MockBookWriter_PruneBookSnapshots_Call struct {
 // PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockBookWriter_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockBookWriter_PruneBookSnapshots_Call {
+func (_e *MockBookWriter_Expecter) PruneBookSnapshots(id any, keepCount any) *MockBookWriter_PruneBookSnapshots_Call {
 	return &MockBookWriter_PruneBookSnapshots_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
@@ -5367,6 +5338,57 @@ func (_c *MockBookWriter_PruneBookSnapshots_Call) RunAndReturn(run func(id strin
 	return _c
 }
 
+// RecomputeBookAggregates provides a mock function for the type MockBookWriter
+func (_mock *MockBookWriter) RecomputeBookAggregates(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeBookAggregates")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookWriter_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
+type MockBookWriter_RecomputeBookAggregates_Call struct {
+	*mock.Call
+}
+
+// RecomputeBookAggregates is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockBookWriter_Expecter) RecomputeBookAggregates(bookID any) *MockBookWriter_RecomputeBookAggregates_Call {
+	return &MockBookWriter_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
+}
+
+func (_c *MockBookWriter_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockBookWriter_RecomputeBookAggregates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookWriter_RecomputeBookAggregates_Call) Return(err error) *MockBookWriter_RecomputeBookAggregates_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookWriter_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockBookWriter_RecomputeBookAggregates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResetScanFailCount provides a mock function for the type MockBookWriter
 func (_mock *MockBookWriter) ResetScanFailCount(pathHash string) error {
 	ret := _mock.Called(pathHash)
@@ -5391,7 +5413,7 @@ type MockBookWriter_ResetScanFailCount_Call struct {
 
 // ResetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookWriter_Expecter) ResetScanFailCount(pathHash interface{}) *MockBookWriter_ResetScanFailCount_Call {
+func (_e *MockBookWriter_Expecter) ResetScanFailCount(pathHash any) *MockBookWriter_ResetScanFailCount_Call {
 	return &MockBookWriter_ResetScanFailCount_Call{Call: _e.mock.On("ResetScanFailCount", pathHash)}
 }
 
@@ -5454,7 +5476,7 @@ type MockBookWriter_RevertBookToVersion_Call struct {
 // RevertBookToVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockBookWriter_Expecter) RevertBookToVersion(id interface{}, ts interface{}) *MockBookWriter_RevertBookToVersion_Call {
+func (_e *MockBookWriter_Expecter) RevertBookToVersion(id any, ts any) *MockBookWriter_RevertBookToVersion_Call {
 	return &MockBookWriter_RevertBookToVersion_Call{Call: _e.mock.On("RevertBookToVersion", id, ts)}
 }
 
@@ -5511,7 +5533,7 @@ type MockBookWriter_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - id string
 //   - t time.Time
-func (_e *MockBookWriter_Expecter) SetLastWrittenAt(id interface{}, t interface{}) *MockBookWriter_SetLastWrittenAt_Call {
+func (_e *MockBookWriter_Expecter) SetLastWrittenAt(id any, t any) *MockBookWriter_SetLastWrittenAt_Call {
 	return &MockBookWriter_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", id, t)}
 }
 
@@ -5579,7 +5601,7 @@ type MockBookWriter_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockBookWriter_Expecter) UpdateBook(id interface{}, book interface{}) *MockBookWriter_UpdateBook_Call {
+func (_e *MockBookWriter_Expecter) UpdateBook(id any, book any) *MockBookWriter_UpdateBook_Call {
 	return &MockBookWriter_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -5636,7 +5658,7 @@ type MockBookWriter_UpdateBookRating_Call struct {
 // UpdateBookRating is a helper method to define mock.On call
 //   - id string
 //   - req database.UpdateBookRatingRequest
-func (_e *MockBookWriter_Expecter) UpdateBookRating(id interface{}, req interface{}) *MockBookWriter_UpdateBookRating_Call {
+func (_e *MockBookWriter_Expecter) UpdateBookRating(id any, req any) *MockBookWriter_UpdateBookRating_Call {
 	return &MockBookWriter_UpdateBookRating_Call{Call: _e.mock.On("UpdateBookRating", id, req)}
 }
 
@@ -5695,6 +5717,59 @@ func (_m *MockBookStore) EXPECT() *MockBookStore_Expecter {
 	return &MockBookStore_Expecter{mock: &_m.Mock}
 }
 
+// CountAllBooks provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) CountAllBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAllBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockBookStore_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockBookStore_Expecter) CountAllBooks() *MockBookStore_CountAllBooks_Call {
+	return &MockBookStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockBookStore_CountAllBooks_Call) Run(run func()) *MockBookStore_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockBookStore_CountAllBooks_Call) Return(n int, err error) *MockBookStore_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockBookStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockBookStore_CountAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CountPrimaryBooks provides a mock function for the type MockBookStore
 func (_mock *MockBookStore) CountPrimaryBooks() (int, error) {
 	ret := _mock.Called()
@@ -5721,29 +5796,29 @@ func (_mock *MockBookStore) CountPrimaryBooks() (int, error) {
 	return r0, r1
 }
 
-// MockBookStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockBookStore_CountBooks_Call struct {
+// MockBookStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockBookStore_CountPrimaryBooks_Call struct {
 	*mock.Call
 }
 
 // CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockBookStore_Expecter) CountPrimaryBooks() *MockBookStore_CountBooks_Call {
-	return &MockBookStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+func (_e *MockBookStore_Expecter) CountPrimaryBooks() *MockBookStore_CountPrimaryBooks_Call {
+	return &MockBookStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
 }
 
-func (_c *MockBookStore_CountBooks_Call) Run(run func()) *MockBookStore_CountBooks_Call {
+func (_c *MockBookStore_CountPrimaryBooks_Call) Run(run func()) *MockBookStore_CountPrimaryBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBookStore_CountBooks_Call) Return(n int, err error) *MockBookStore_CountBooks_Call {
+func (_c *MockBookStore_CountPrimaryBooks_Call) Return(n int, err error) *MockBookStore_CountPrimaryBooks_Call {
 	_c.Call.Return(n, err)
 	return _c
 }
 
-func (_c *MockBookStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockBookStore_CountBooks_Call {
+func (_c *MockBookStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockBookStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5836,7 +5911,7 @@ type MockBookStore_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockBookStore_Expecter) CreateBook(book interface{}) *MockBookStore_CreateBook_Call {
+func (_e *MockBookStore_Expecter) CreateBook(book any) *MockBookStore_CreateBook_Call {
 	return &MockBookStore_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -5887,7 +5962,7 @@ type MockBookStore_CreateBookTombstone_Call struct {
 
 // CreateBookTombstone is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockBookStore_Expecter) CreateBookTombstone(book interface{}) *MockBookStore_CreateBookTombstone_Call {
+func (_e *MockBookStore_Expecter) CreateBookTombstone(book any) *MockBookStore_CreateBookTombstone_Call {
 	return &MockBookStore_CreateBookTombstone_Call{Call: _e.mock.On("CreateBookTombstone", book)}
 }
 
@@ -5938,7 +6013,7 @@ type MockBookStore_DeleteBook_Call struct {
 
 // DeleteBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookStore_Expecter) DeleteBook(id interface{}) *MockBookStore_DeleteBook_Call {
+func (_e *MockBookStore_Expecter) DeleteBook(id any) *MockBookStore_DeleteBook_Call {
 	return &MockBookStore_DeleteBook_Call{Call: _e.mock.On("DeleteBook", id)}
 }
 
@@ -5989,7 +6064,7 @@ type MockBookStore_DeleteBookTombstone_Call struct {
 
 // DeleteBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookStore_Expecter) DeleteBookTombstone(id interface{}) *MockBookStore_DeleteBookTombstone_Call {
+func (_e *MockBookStore_Expecter) DeleteBookTombstone(id any) *MockBookStore_DeleteBookTombstone_Call {
 	return &MockBookStore_DeleteBookTombstone_Call{Call: _e.mock.On("DeleteBookTombstone", id)}
 }
 
@@ -6041,7 +6116,7 @@ type MockBookStore_FlagMetadataHashDuplicate_Call struct {
 // FlagMetadataHashDuplicate is a helper method to define mock.On call
 //   - primaryID string
 //   - duplicateID string
-func (_e *MockBookStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockBookStore_FlagMetadataHashDuplicate_Call {
+func (_e *MockBookStore_Expecter) FlagMetadataHashDuplicate(primaryID any, duplicateID any) *MockBookStore_FlagMetadataHashDuplicate_Call {
 	return &MockBookStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
 }
 
@@ -6069,51 +6144,6 @@ func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockB
 }
 
 func (_c *MockBookStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockBookStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecomputeBookAggregates provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) RecomputeBookAggregates(bookID string) error {
-	ret := _mock.Called(bookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecomputeBookAggregates")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockBookStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
-type MockBookStore_RecomputeBookAggregates_Call struct {
-	*mock.Call
-}
-
-// RecomputeBookAggregates is a helper method to define mock.On call
-//   - bookID string
-func (_e *MockBookStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockBookStore_RecomputeBookAggregates_Call {
-	return &MockBookStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
-}
-
-func (_c *MockBookStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockBookStore_RecomputeBookAggregates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockBookStore_RecomputeBookAggregates_Call) Return(err error) *MockBookStore_RecomputeBookAggregates_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockBookStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockBookStore_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6154,7 +6184,7 @@ type MockBookStore_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookStore_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockBookStore_GetAllBookSummaries_Call {
+func (_e *MockBookStore_Expecter) GetAllBookSummaries(limit any, offset any) *MockBookStore_GetAllBookSummaries_Call {
 	return &MockBookStore_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -6222,7 +6252,7 @@ type MockBookStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockBookStore_GetAllBooks_Call {
+func (_e *MockBookStore_Expecter) GetAllBooks(limit any, offset any) *MockBookStore_GetAllBooks_Call {
 	return &MockBookStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -6290,7 +6320,7 @@ type MockBookStore_GetAllBooksFrom_Call struct {
 // GetAllBooksFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockBookStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockBookStore_GetAllBooksFrom_Call {
+func (_e *MockBookStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockBookStore_GetAllBooksFrom_Call {
 	return &MockBookStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
 
@@ -6304,7 +6334,10 @@ func (_c *MockBookStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -6314,7 +6347,7 @@ func (_c *MockBookStore_GetAllBooksFrom_Call) Return(books []database.Book, err 
 	return _c
 }
 
-func (_c *MockBookStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockBookStore_GetAllBooksFrom_Call {
+func (_c *MockBookStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6355,7 +6388,7 @@ type MockBookStore_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockBookStore_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockBookStore_GetBookAtVersion_Call {
+func (_e *MockBookStore_Expecter) GetBookAtVersion(id any, ts any) *MockBookStore_GetBookAtVersion_Call {
 	return &MockBookStore_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -6422,7 +6455,7 @@ type MockBookStore_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookStore_Expecter) GetBookByFileHash(hash interface{}) *MockBookStore_GetBookByFileHash_Call {
+func (_e *MockBookStore_Expecter) GetBookByFileHash(hash any) *MockBookStore_GetBookByFileHash_Call {
 	return &MockBookStore_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -6484,7 +6517,7 @@ type MockBookStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockBookStore_Expecter) GetBookByFilePath(path interface{}) *MockBookStore_GetBookByFilePath_Call {
+func (_e *MockBookStore_Expecter) GetBookByFilePath(path any) *MockBookStore_GetBookByFilePath_Call {
 	return &MockBookStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -6546,7 +6579,7 @@ type MockBookStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookStore_Expecter) GetBookByID(id interface{}) *MockBookStore_GetBookByID_Call {
+func (_e *MockBookStore_Expecter) GetBookByID(id any) *MockBookStore_GetBookByID_Call {
 	return &MockBookStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -6608,7 +6641,7 @@ type MockBookStore_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockBookStore_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockBookStore_GetBookByITunesPersistentID_Call {
+func (_e *MockBookStore_Expecter) GetBookByITunesPersistentID(persistentID any) *MockBookStore_GetBookByITunesPersistentID_Call {
 	return &MockBookStore_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -6670,7 +6703,7 @@ type MockBookStore_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookStore_Expecter) GetBookByOrganizedHash(hash interface{}) *MockBookStore_GetBookByOrganizedHash_Call {
+func (_e *MockBookStore_Expecter) GetBookByOrganizedHash(hash any) *MockBookStore_GetBookByOrganizedHash_Call {
 	return &MockBookStore_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -6732,7 +6765,7 @@ type MockBookStore_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookStore_Expecter) GetBookByOriginalHash(hash interface{}) *MockBookStore_GetBookByOriginalHash_Call {
+func (_e *MockBookStore_Expecter) GetBookByOriginalHash(hash any) *MockBookStore_GetBookByOriginalHash_Call {
 	return &MockBookStore_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -6755,6 +6788,80 @@ func (_c *MockBookStore_GetBookByOriginalHash_Call) Return(book *database.Book, 
 }
 
 func (_c *MockBookStore_GetBookByOriginalHash_Call) RunAndReturn(run func(hash string) (*database.Book, error)) *MockBookStore_GetBookByOriginalHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockBookStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockBookStore_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	return &MockBookStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockBookStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockBookStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6795,7 +6902,7 @@ type MockBookStore_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockBookStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockBookStore_GetBookSnapshots_Call {
+func (_e *MockBookStore_Expecter) GetBookSnapshots(id any, limit any) *MockBookStore_GetBookSnapshots_Call {
 	return &MockBookStore_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -6862,7 +6969,7 @@ type MockBookStore_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookStore_Expecter) GetBookTombstone(id interface{}) *MockBookStore_GetBookTombstone_Call {
+func (_e *MockBookStore_Expecter) GetBookTombstone(id any) *MockBookStore_GetBookTombstone_Call {
 	return &MockBookStore_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -6924,7 +7031,7 @@ type MockBookStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockBookStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockBookStore_GetBooksByAuthorID_Call {
+func (_e *MockBookStore_Expecter) GetBooksByAuthorID(authorID any) *MockBookStore_GetBooksByAuthorID_Call {
 	return &MockBookStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -6986,7 +7093,7 @@ type MockBookStore_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockBookStore_GetBooksByMetadataSourceHash_Call {
+func (_e *MockBookStore_Expecter) GetBooksByMetadataSourceHash(hash any) *MockBookStore_GetBooksByMetadataSourceHash_Call {
 	return &MockBookStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -7009,76 +7116,6 @@ func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) Return(books []databa
 }
 
 func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockBookStore_GetBooksByMetadataSourceHash_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookIDsByISBNASIN provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
-	ret := _mock.Called(isbn10, isbn13, asin)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookIDsByISBNASIN")
-	}
-
-	var r0 []string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
-		return returnFunc(isbn10, isbn13, asin)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
-		r0 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockBookStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
-type MockBookStore_GetBookIDsByISBNASIN_Call struct {
-	*mock.Call
-}
-
-// GetBookIDsByISBNASIN is a helper method to define mock.On call
-//   - isbn10 string
-//   - isbn13 string
-//   - asin string
-func (_e *MockBookStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockBookStore_GetBookIDsByISBNASIN_Call {
-	return &MockBookStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
-}
-
-func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockBookStore_GetBookIDsByISBNASIN_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(arg0, arg1, arg2)
-	})
-	return _c
-}
-
-func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockBookStore_GetBookIDsByISBNASIN_Call {
-	_c.Call.Return(ids, err)
-	return _c
-}
-
-func (_c *MockBookStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockBookStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7118,7 +7155,7 @@ type MockBookStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockBookStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockBookStore_GetBooksBySeriesID_Call {
+func (_e *MockBookStore_Expecter) GetBooksBySeriesID(seriesID any) *MockBookStore_GetBooksBySeriesID_Call {
 	return &MockBookStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -7181,7 +7218,7 @@ type MockBookStore_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockBookStore_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockBookStore_GetBooksByTitleInDir_Call {
+func (_e *MockBookStore_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockBookStore_GetBooksByTitleInDir_Call {
 	return &MockBookStore_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -7248,7 +7285,7 @@ type MockBookStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockBookStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockBookStore_GetBooksByVersionGroup_Call {
+func (_e *MockBookStore_Expecter) GetBooksByVersionGroup(groupID any) *MockBookStore_GetBooksByVersionGroup_Call {
 	return &MockBookStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -7475,7 +7512,7 @@ type MockBookStore_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockBookStore_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockBookStore_GetDuplicateBooksByMetadata_Call {
+func (_e *MockBookStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockBookStore_GetDuplicateBooksByMetadata_Call {
 	return &MockBookStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -7703,7 +7740,7 @@ type MockBookStore_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookStore_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockBookStore_GetQuarantinedBooks_Call {
+func (_e *MockBookStore_Expecter) GetQuarantinedBooks(limit any, offset any) *MockBookStore_GetQuarantinedBooks_Call {
 	return &MockBookStore_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -7768,7 +7805,7 @@ type MockBookStore_GetScanFailCount_Call struct {
 
 // GetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookStore_Expecter) GetScanFailCount(pathHash interface{}) *MockBookStore_GetScanFailCount_Call {
+func (_e *MockBookStore_Expecter) GetScanFailCount(pathHash any) *MockBookStore_GetScanFailCount_Call {
 	return &MockBookStore_GetScanFailCount_Call{Call: _e.mock.On("GetScanFailCount", pathHash)}
 }
 
@@ -7828,7 +7865,7 @@ type MockBookStore_IncrScanFailCount_Call struct {
 
 // IncrScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookStore_Expecter) IncrScanFailCount(pathHash interface{}) *MockBookStore_IncrScanFailCount_Call {
+func (_e *MockBookStore_Expecter) IncrScanFailCount(pathHash any) *MockBookStore_IncrScanFailCount_Call {
 	return &MockBookStore_IncrScanFailCount_Call{Call: _e.mock.On("IncrScanFailCount", pathHash)}
 }
 
@@ -7945,7 +7982,7 @@ type MockBookStore_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockBookStore_Expecter) ListBookTombstones(limit interface{}) *MockBookStore_ListBookTombstones_Call {
+func (_e *MockBookStore_Expecter) ListBookTombstones(limit any) *MockBookStore_ListBookTombstones_Call {
 	return &MockBookStore_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -8008,7 +8045,7 @@ type MockBookStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockBookStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockBookStore_ListBooksByITunesPID_Call {
+func (_e *MockBookStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockBookStore_ListBooksByITunesPID_Call {
 	return &MockBookStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -8077,7 +8114,7 @@ type MockBookStore_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockBookStore_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockBookStore_ListSoftDeletedBooks_Call {
+func (_e *MockBookStore_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockBookStore_ListSoftDeletedBooks_Call {
 	return &MockBookStore_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -8147,7 +8184,7 @@ type MockBookStore_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockBookStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockBookStore_MarkITunesSynced_Call {
+func (_e *MockBookStore_Expecter) MarkITunesSynced(bookIDs any) *MockBookStore_MarkITunesSynced_Call {
 	return &MockBookStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -8201,7 +8238,7 @@ type MockBookStore_MergeChapterBooks_Call struct {
 //   - srcIDs []string
 //   - commonTitle string
 //   - totalDuration float64
-func (_e *MockBookStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockBookStore_MergeChapterBooks_Call {
+func (_e *MockBookStore_Expecter) MergeChapterBooks(primaryID any, srcIDs any, commonTitle any, totalDuration any) *MockBookStore_MergeChapterBooks_Call {
 	return &MockBookStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
 }
 
@@ -8277,7 +8314,7 @@ type MockBookStore_PruneBookSnapshots_Call struct {
 // PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockBookStore_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockBookStore_PruneBookSnapshots_Call {
+func (_e *MockBookStore_Expecter) PruneBookSnapshots(id any, keepCount any) *MockBookStore_PruneBookSnapshots_Call {
 	return &MockBookStore_PruneBookSnapshots_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
@@ -8309,6 +8346,57 @@ func (_c *MockBookStore_PruneBookSnapshots_Call) RunAndReturn(run func(id string
 	return _c
 }
 
+// RecomputeBookAggregates provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) RecomputeBookAggregates(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeBookAggregates")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
+type MockBookStore_RecomputeBookAggregates_Call struct {
+	*mock.Call
+}
+
+// RecomputeBookAggregates is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockBookStore_Expecter) RecomputeBookAggregates(bookID any) *MockBookStore_RecomputeBookAggregates_Call {
+	return &MockBookStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
+}
+
+func (_c *MockBookStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockBookStore_RecomputeBookAggregates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_RecomputeBookAggregates_Call) Return(err error) *MockBookStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockBookStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResetScanFailCount provides a mock function for the type MockBookStore
 func (_mock *MockBookStore) ResetScanFailCount(pathHash string) error {
 	ret := _mock.Called(pathHash)
@@ -8333,7 +8421,7 @@ type MockBookStore_ResetScanFailCount_Call struct {
 
 // ResetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockBookStore_Expecter) ResetScanFailCount(pathHash interface{}) *MockBookStore_ResetScanFailCount_Call {
+func (_e *MockBookStore_Expecter) ResetScanFailCount(pathHash any) *MockBookStore_ResetScanFailCount_Call {
 	return &MockBookStore_ResetScanFailCount_Call{Call: _e.mock.On("ResetScanFailCount", pathHash)}
 }
 
@@ -8396,7 +8484,7 @@ type MockBookStore_RevertBookToVersion_Call struct {
 // RevertBookToVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockBookStore_Expecter) RevertBookToVersion(id interface{}, ts interface{}) *MockBookStore_RevertBookToVersion_Call {
+func (_e *MockBookStore_Expecter) RevertBookToVersion(id any, ts any) *MockBookStore_RevertBookToVersion_Call {
 	return &MockBookStore_RevertBookToVersion_Call{Call: _e.mock.On("RevertBookToVersion", id, ts)}
 }
 
@@ -8465,7 +8553,7 @@ type MockBookStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockBookStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockBookStore_SearchBooks_Call {
+func (_e *MockBookStore_Expecter) SearchBooks(query any, limit any, offset any) *MockBookStore_SearchBooks_Call {
 	return &MockBookStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -8527,7 +8615,7 @@ type MockBookStore_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - id string
 //   - t time.Time
-func (_e *MockBookStore_Expecter) SetLastWrittenAt(id interface{}, t interface{}) *MockBookStore_SetLastWrittenAt_Call {
+func (_e *MockBookStore_Expecter) SetLastWrittenAt(id any, t any) *MockBookStore_SetLastWrittenAt_Call {
 	return &MockBookStore_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", id, t)}
 }
 
@@ -8595,7 +8683,7 @@ type MockBookStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockBookStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockBookStore_UpdateBook_Call {
+func (_e *MockBookStore_Expecter) UpdateBook(id any, book any) *MockBookStore_UpdateBook_Call {
 	return &MockBookStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -8652,7 +8740,7 @@ type MockBookStore_UpdateBookRating_Call struct {
 // UpdateBookRating is a helper method to define mock.On call
 //   - id string
 //   - req database.UpdateBookRatingRequest
-func (_e *MockBookStore_Expecter) UpdateBookRating(id interface{}, req interface{}) *MockBookStore_UpdateBookRating_Call {
+func (_e *MockBookStore_Expecter) UpdateBookRating(id any, req any) *MockBookStore_UpdateBookRating_Call {
 	return &MockBookStore_UpdateBookRating_Call{Call: _e.mock.On("UpdateBookRating", id, req)}
 }
 
@@ -8739,7 +8827,7 @@ type MockITunesStateStore_CreateDeferredITunesUpdate_Call struct {
 //   - oldPath string
 //   - newPath string
 //   - updateType string
-func (_e *MockITunesStateStore_Expecter) CreateDeferredITunesUpdate(bookID interface{}, persistentID interface{}, oldPath interface{}, newPath interface{}, updateType interface{}) *MockITunesStateStore_CreateDeferredITunesUpdate_Call {
+func (_e *MockITunesStateStore_Expecter) CreateDeferredITunesUpdate(bookID any, persistentID any, oldPath any, newPath any, updateType any) *MockITunesStateStore_CreateDeferredITunesUpdate_Call {
 	return &MockITunesStateStore_CreateDeferredITunesUpdate_Call{Call: _e.mock.On("CreateDeferredITunesUpdate", bookID, persistentID, oldPath, newPath, updateType)}
 }
 
@@ -8821,7 +8909,7 @@ type MockITunesStateStore_GetDeferredITunesUpdatesByBookID_Call struct {
 
 // GetDeferredITunesUpdatesByBookID is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockITunesStateStore_Expecter) GetDeferredITunesUpdatesByBookID(bookID interface{}) *MockITunesStateStore_GetDeferredITunesUpdatesByBookID_Call {
+func (_e *MockITunesStateStore_Expecter) GetDeferredITunesUpdatesByBookID(bookID any) *MockITunesStateStore_GetDeferredITunesUpdatesByBookID_Call {
 	return &MockITunesStateStore_GetDeferredITunesUpdatesByBookID_Call{Call: _e.mock.On("GetDeferredITunesUpdatesByBookID", bookID)}
 }
 
@@ -8883,7 +8971,7 @@ type MockITunesStateStore_GetLibraryFingerprint_Call struct {
 
 // GetLibraryFingerprint is a helper method to define mock.On call
 //   - path string
-func (_e *MockITunesStateStore_Expecter) GetLibraryFingerprint(path interface{}) *MockITunesStateStore_GetLibraryFingerprint_Call {
+func (_e *MockITunesStateStore_Expecter) GetLibraryFingerprint(path any) *MockITunesStateStore_GetLibraryFingerprint_Call {
 	return &MockITunesStateStore_GetLibraryFingerprint_Call{Call: _e.mock.On("GetLibraryFingerprint", path)}
 }
 
@@ -8989,7 +9077,7 @@ type MockITunesStateStore_MarkDeferredITunesUpdateApplied_Call struct {
 
 // MarkDeferredITunesUpdateApplied is a helper method to define mock.On call
 //   - id int
-func (_e *MockITunesStateStore_Expecter) MarkDeferredITunesUpdateApplied(id interface{}) *MockITunesStateStore_MarkDeferredITunesUpdateApplied_Call {
+func (_e *MockITunesStateStore_Expecter) MarkDeferredITunesUpdateApplied(id any) *MockITunesStateStore_MarkDeferredITunesUpdateApplied_Call {
 	return &MockITunesStateStore_MarkDeferredITunesUpdateApplied_Call{Call: _e.mock.On("MarkDeferredITunesUpdateApplied", id)}
 }
 
@@ -9043,7 +9131,7 @@ type MockITunesStateStore_SaveLibraryFingerprint_Call struct {
 //   - size int64
 //   - modTime time.Time
 //   - crc32 uint32
-func (_e *MockITunesStateStore_Expecter) SaveLibraryFingerprint(path interface{}, size interface{}, modTime interface{}, crc32 interface{}) *MockITunesStateStore_SaveLibraryFingerprint_Call {
+func (_e *MockITunesStateStore_Expecter) SaveLibraryFingerprint(path any, size any, modTime any, crc32 any) *MockITunesStateStore_SaveLibraryFingerprint_Call {
 	return &MockITunesStateStore_SaveLibraryFingerprint_Call{Call: _e.mock.On("SaveLibraryFingerprint", path, size, modTime, crc32)}
 }
 
@@ -9136,7 +9224,7 @@ type MockExternalIDStore_BulkCreateExternalIDMappings_Call struct {
 
 // BulkCreateExternalIDMappings is a helper method to define mock.On call
 //   - mappings []database.ExternalIDMapping
-func (_e *MockExternalIDStore_Expecter) BulkCreateExternalIDMappings(mappings interface{}) *MockExternalIDStore_BulkCreateExternalIDMappings_Call {
+func (_e *MockExternalIDStore_Expecter) BulkCreateExternalIDMappings(mappings any) *MockExternalIDStore_BulkCreateExternalIDMappings_Call {
 	return &MockExternalIDStore_BulkCreateExternalIDMappings_Call{Call: _e.mock.On("BulkCreateExternalIDMappings", mappings)}
 }
 
@@ -9187,7 +9275,7 @@ type MockExternalIDStore_CreateExternalIDMapping_Call struct {
 
 // CreateExternalIDMapping is a helper method to define mock.On call
 //   - mapping *database.ExternalIDMapping
-func (_e *MockExternalIDStore_Expecter) CreateExternalIDMapping(mapping interface{}) *MockExternalIDStore_CreateExternalIDMapping_Call {
+func (_e *MockExternalIDStore_Expecter) CreateExternalIDMapping(mapping any) *MockExternalIDStore_CreateExternalIDMapping_Call {
 	return &MockExternalIDStore_CreateExternalIDMapping_Call{Call: _e.mock.On("CreateExternalIDMapping", mapping)}
 }
 
@@ -9248,7 +9336,7 @@ type MockExternalIDStore_GetBookByExternalID_Call struct {
 // GetBookByExternalID is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockExternalIDStore_Expecter) GetBookByExternalID(source interface{}, externalID interface{}) *MockExternalIDStore_GetBookByExternalID_Call {
+func (_e *MockExternalIDStore_Expecter) GetBookByExternalID(source any, externalID any) *MockExternalIDStore_GetBookByExternalID_Call {
 	return &MockExternalIDStore_GetBookByExternalID_Call{Call: _e.mock.On("GetBookByExternalID", source, externalID)}
 }
 
@@ -9315,7 +9403,7 @@ type MockExternalIDStore_GetExternalIDsForBook_Call struct {
 
 // GetExternalIDsForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockExternalIDStore_Expecter) GetExternalIDsForBook(bookID interface{}) *MockExternalIDStore_GetExternalIDsForBook_Call {
+func (_e *MockExternalIDStore_Expecter) GetExternalIDsForBook(bookID any) *MockExternalIDStore_GetExternalIDsForBook_Call {
 	return &MockExternalIDStore_GetExternalIDsForBook_Call{Call: _e.mock.On("GetExternalIDsForBook", bookID)}
 }
 
@@ -9377,7 +9465,7 @@ type MockExternalIDStore_GetRemovedExternalIDs_Call struct {
 
 // GetRemovedExternalIDs is a helper method to define mock.On call
 //   - source string
-func (_e *MockExternalIDStore_Expecter) GetRemovedExternalIDs(source interface{}) *MockExternalIDStore_GetRemovedExternalIDs_Call {
+func (_e *MockExternalIDStore_Expecter) GetRemovedExternalIDs(source any) *MockExternalIDStore_GetRemovedExternalIDs_Call {
 	return &MockExternalIDStore_GetRemovedExternalIDs_Call{Call: _e.mock.On("GetRemovedExternalIDs", source)}
 }
 
@@ -9438,7 +9526,7 @@ type MockExternalIDStore_IsExternalIDTombstoned_Call struct {
 // IsExternalIDTombstoned is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockExternalIDStore_Expecter) IsExternalIDTombstoned(source interface{}, externalID interface{}) *MockExternalIDStore_IsExternalIDTombstoned_Call {
+func (_e *MockExternalIDStore_Expecter) IsExternalIDTombstoned(source any, externalID any) *MockExternalIDStore_IsExternalIDTombstoned_Call {
 	return &MockExternalIDStore_IsExternalIDTombstoned_Call{Call: _e.mock.On("IsExternalIDTombstoned", source, externalID)}
 }
 
@@ -9495,7 +9583,7 @@ type MockExternalIDStore_MarkExternalIDRemoved_Call struct {
 // MarkExternalIDRemoved is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockExternalIDStore_Expecter) MarkExternalIDRemoved(source interface{}, externalID interface{}) *MockExternalIDStore_MarkExternalIDRemoved_Call {
+func (_e *MockExternalIDStore_Expecter) MarkExternalIDRemoved(source any, externalID any) *MockExternalIDStore_MarkExternalIDRemoved_Call {
 	return &MockExternalIDStore_MarkExternalIDRemoved_Call{Call: _e.mock.On("MarkExternalIDRemoved", source, externalID)}
 }
 
@@ -9527,6 +9615,69 @@ func (_c *MockExternalIDStore_MarkExternalIDRemoved_Call) RunAndReturn(run func(
 	return _c
 }
 
+// ReassignExternalID provides a mock function for the type MockExternalIDStore
+func (_mock *MockExternalIDStore) ReassignExternalID(source string, externalID string, newBookID string) error {
+	ret := _mock.Called(source, externalID, newBookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReassignExternalID")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) error); ok {
+		r0 = returnFunc(source, externalID, newBookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockExternalIDStore_ReassignExternalID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReassignExternalID'
+type MockExternalIDStore_ReassignExternalID_Call struct {
+	*mock.Call
+}
+
+// ReassignExternalID is a helper method to define mock.On call
+//   - source string
+//   - externalID string
+//   - newBookID string
+func (_e *MockExternalIDStore_Expecter) ReassignExternalID(source any, externalID any, newBookID any) *MockExternalIDStore_ReassignExternalID_Call {
+	return &MockExternalIDStore_ReassignExternalID_Call{Call: _e.mock.On("ReassignExternalID", source, externalID, newBookID)}
+}
+
+func (_c *MockExternalIDStore_ReassignExternalID_Call) Run(run func(source string, externalID string, newBookID string)) *MockExternalIDStore_ReassignExternalID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockExternalIDStore_ReassignExternalID_Call) Return(err error) *MockExternalIDStore_ReassignExternalID_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockExternalIDStore_ReassignExternalID_Call) RunAndReturn(run func(source string, externalID string, newBookID string) error) *MockExternalIDStore_ReassignExternalID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ReassignExternalIDs provides a mock function for the type MockExternalIDStore
 func (_mock *MockExternalIDStore) ReassignExternalIDs(oldBookID string, newBookID string) error {
 	ret := _mock.Called(oldBookID, newBookID)
@@ -9552,7 +9703,7 @@ type MockExternalIDStore_ReassignExternalIDs_Call struct {
 // ReassignExternalIDs is a helper method to define mock.On call
 //   - oldBookID string
 //   - newBookID string
-func (_e *MockExternalIDStore_Expecter) ReassignExternalIDs(oldBookID interface{}, newBookID interface{}) *MockExternalIDStore_ReassignExternalIDs_Call {
+func (_e *MockExternalIDStore_Expecter) ReassignExternalIDs(oldBookID any, newBookID any) *MockExternalIDStore_ReassignExternalIDs_Call {
 	return &MockExternalIDStore_ReassignExternalIDs_Call{Call: _e.mock.On("ReassignExternalIDs", oldBookID, newBookID)}
 }
 
@@ -9610,7 +9761,7 @@ type MockExternalIDStore_SetExternalIDProvenance_Call struct {
 //   - source string
 //   - externalID string
 //   - provenance string
-func (_e *MockExternalIDStore_Expecter) SetExternalIDProvenance(source interface{}, externalID interface{}, provenance interface{}) *MockExternalIDStore_SetExternalIDProvenance_Call {
+func (_e *MockExternalIDStore_Expecter) SetExternalIDProvenance(source any, externalID any, provenance any) *MockExternalIDStore_SetExternalIDProvenance_Call {
 	return &MockExternalIDStore_SetExternalIDProvenance_Call{Call: _e.mock.On("SetExternalIDProvenance", source, externalID, provenance)}
 }
 
@@ -9672,7 +9823,7 @@ type MockExternalIDStore_TombstoneExternalID_Call struct {
 // TombstoneExternalID is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockExternalIDStore_Expecter) TombstoneExternalID(source interface{}, externalID interface{}) *MockExternalIDStore_TombstoneExternalID_Call {
+func (_e *MockExternalIDStore_Expecter) TombstoneExternalID(source any, externalID any) *MockExternalIDStore_TombstoneExternalID_Call {
 	return &MockExternalIDStore_TombstoneExternalID_Call{Call: _e.mock.On("TombstoneExternalID", source, externalID)}
 }
 
@@ -9766,7 +9917,7 @@ type MockPathHistoryStore_GetBookPathHistory_Call struct {
 
 // GetBookPathHistory is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockPathHistoryStore_Expecter) GetBookPathHistory(bookID interface{}) *MockPathHistoryStore_GetBookPathHistory_Call {
+func (_e *MockPathHistoryStore_Expecter) GetBookPathHistory(bookID any) *MockPathHistoryStore_GetBookPathHistory_Call {
 	return &MockPathHistoryStore_GetBookPathHistory_Call{Call: _e.mock.On("GetBookPathHistory", bookID)}
 }
 
@@ -9817,7 +9968,7 @@ type MockPathHistoryStore_RecordPathChange_Call struct {
 
 // RecordPathChange is a helper method to define mock.On call
 //   - change *database.BookPathChange
-func (_e *MockPathHistoryStore_Expecter) RecordPathChange(change interface{}) *MockPathHistoryStore_RecordPathChange_Call {
+func (_e *MockPathHistoryStore_Expecter) RecordPathChange(change any) *MockPathHistoryStore_RecordPathChange_Call {
 	return &MockPathHistoryStore_RecordPathChange_Call{Call: _e.mock.On("RecordPathChange", change)}
 }
 
@@ -10021,7 +10172,7 @@ type MockNarratorStore_CreateNarrator_Call struct {
 
 // CreateNarrator is a helper method to define mock.On call
 //   - name string
-func (_e *MockNarratorStore_Expecter) CreateNarrator(name interface{}) *MockNarratorStore_CreateNarrator_Call {
+func (_e *MockNarratorStore_Expecter) CreateNarrator(name any) *MockNarratorStore_CreateNarrator_Call {
 	return &MockNarratorStore_CreateNarrator_Call{Call: _e.mock.On("CreateNarrator", name)}
 }
 
@@ -10083,7 +10234,7 @@ type MockNarratorStore_GetBookNarrators_Call struct {
 
 // GetBookNarrators is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockNarratorStore_Expecter) GetBookNarrators(bookID interface{}) *MockNarratorStore_GetBookNarrators_Call {
+func (_e *MockNarratorStore_Expecter) GetBookNarrators(bookID any) *MockNarratorStore_GetBookNarrators_Call {
 	return &MockNarratorStore_GetBookNarrators_Call{Call: _e.mock.On("GetBookNarrators", bookID)}
 }
 
@@ -10145,7 +10296,7 @@ type MockNarratorStore_GetNarratorByID_Call struct {
 
 // GetNarratorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockNarratorStore_Expecter) GetNarratorByID(id interface{}) *MockNarratorStore_GetNarratorByID_Call {
+func (_e *MockNarratorStore_Expecter) GetNarratorByID(id any) *MockNarratorStore_GetNarratorByID_Call {
 	return &MockNarratorStore_GetNarratorByID_Call{Call: _e.mock.On("GetNarratorByID", id)}
 }
 
@@ -10207,7 +10358,7 @@ type MockNarratorStore_GetNarratorByName_Call struct {
 
 // GetNarratorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockNarratorStore_Expecter) GetNarratorByName(name interface{}) *MockNarratorStore_GetNarratorByName_Call {
+func (_e *MockNarratorStore_Expecter) GetNarratorByName(name any) *MockNarratorStore_GetNarratorByName_Call {
 	return &MockNarratorStore_GetNarratorByName_Call{Call: _e.mock.On("GetNarratorByName", name)}
 }
 
@@ -10270,7 +10421,7 @@ type MockNarratorStore_GetNarratorsByBookIDs_Call struct {
 // GetNarratorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockNarratorStore_Expecter) GetNarratorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockNarratorStore_GetNarratorsByBookIDs_Call {
+func (_e *MockNarratorStore_Expecter) GetNarratorsByBookIDs(ctx any, bookIDs any) *MockNarratorStore_GetNarratorsByBookIDs_Call {
 	return &MockNarratorStore_GetNarratorsByBookIDs_Call{Call: _e.mock.On("GetNarratorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -10382,7 +10533,7 @@ type MockNarratorStore_SetBookNarrators_Call struct {
 // SetBookNarrators is a helper method to define mock.On call
 //   - bookID string
 //   - narrators []database.BookNarrator
-func (_e *MockNarratorStore_Expecter) SetBookNarrators(bookID interface{}, narrators interface{}) *MockNarratorStore_SetBookNarrators_Call {
+func (_e *MockNarratorStore_Expecter) SetBookNarrators(bookID any, narrators any) *MockNarratorStore_SetBookNarrators_Call {
 	return &MockNarratorStore_SetBookNarrators_Call{Call: _e.mock.On("SetBookNarrators", bookID, narrators)}
 }
 
@@ -10476,7 +10627,7 @@ type MockWorkStore_CreateWork_Call struct {
 
 // CreateWork is a helper method to define mock.On call
 //   - work *database.Work
-func (_e *MockWorkStore_Expecter) CreateWork(work interface{}) *MockWorkStore_CreateWork_Call {
+func (_e *MockWorkStore_Expecter) CreateWork(work any) *MockWorkStore_CreateWork_Call {
 	return &MockWorkStore_CreateWork_Call{Call: _e.mock.On("CreateWork", work)}
 }
 
@@ -10527,7 +10678,7 @@ type MockWorkStore_DeleteWork_Call struct {
 
 // DeleteWork is a helper method to define mock.On call
 //   - id string
-func (_e *MockWorkStore_Expecter) DeleteWork(id interface{}) *MockWorkStore_DeleteWork_Call {
+func (_e *MockWorkStore_Expecter) DeleteWork(id any) *MockWorkStore_DeleteWork_Call {
 	return &MockWorkStore_DeleteWork_Call{Call: _e.mock.On("DeleteWork", id)}
 }
 
@@ -10699,7 +10850,7 @@ type MockWorkStore_GetBooksByWorkID_Call struct {
 
 // GetBooksByWorkID is a helper method to define mock.On call
 //   - workID string
-func (_e *MockWorkStore_Expecter) GetBooksByWorkID(workID interface{}) *MockWorkStore_GetBooksByWorkID_Call {
+func (_e *MockWorkStore_Expecter) GetBooksByWorkID(workID any) *MockWorkStore_GetBooksByWorkID_Call {
 	return &MockWorkStore_GetBooksByWorkID_Call{Call: _e.mock.On("GetBooksByWorkID", workID)}
 }
 
@@ -10761,7 +10912,7 @@ type MockWorkStore_GetWorkByID_Call struct {
 
 // GetWorkByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockWorkStore_Expecter) GetWorkByID(id interface{}) *MockWorkStore_GetWorkByID_Call {
+func (_e *MockWorkStore_Expecter) GetWorkByID(id any) *MockWorkStore_GetWorkByID_Call {
 	return &MockWorkStore_GetWorkByID_Call{Call: _e.mock.On("GetWorkByID", id)}
 }
 
@@ -10824,7 +10975,7 @@ type MockWorkStore_UpdateWork_Call struct {
 // UpdateWork is a helper method to define mock.On call
 //   - id string
 //   - work *database.Work
-func (_e *MockWorkStore_Expecter) UpdateWork(id interface{}, work interface{}) *MockWorkStore_UpdateWork_Call {
+func (_e *MockWorkStore_Expecter) UpdateWork(id any, work any) *MockWorkStore_UpdateWork_Call {
 	return &MockWorkStore_UpdateWork_Call{Call: _e.mock.On("UpdateWork", id, work)}
 }
 
@@ -10921,7 +11072,7 @@ type MockSessionStore_CreateSession_Call struct {
 //   - ip string
 //   - userAgent string
 //   - ttl time.Duration
-func (_e *MockSessionStore_Expecter) CreateSession(userID interface{}, ip interface{}, userAgent interface{}, ttl interface{}) *MockSessionStore_CreateSession_Call {
+func (_e *MockSessionStore_Expecter) CreateSession(userID any, ip any, userAgent any, ttl any) *MockSessionStore_CreateSession_Call {
 	return &MockSessionStore_CreateSession_Call{Call: _e.mock.On("CreateSession", userID, ip, userAgent, ttl)}
 }
 
@@ -10996,7 +11147,7 @@ type MockSessionStore_DeleteExpiredSessions_Call struct {
 
 // DeleteExpiredSessions is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockSessionStore_Expecter) DeleteExpiredSessions(now interface{}) *MockSessionStore_DeleteExpiredSessions_Call {
+func (_e *MockSessionStore_Expecter) DeleteExpiredSessions(now any) *MockSessionStore_DeleteExpiredSessions_Call {
 	return &MockSessionStore_DeleteExpiredSessions_Call{Call: _e.mock.On("DeleteExpiredSessions", now)}
 }
 
@@ -11058,7 +11209,7 @@ type MockSessionStore_GetSession_Call struct {
 
 // GetSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockSessionStore_Expecter) GetSession(id interface{}) *MockSessionStore_GetSession_Call {
+func (_e *MockSessionStore_Expecter) GetSession(id any) *MockSessionStore_GetSession_Call {
 	return &MockSessionStore_GetSession_Call{Call: _e.mock.On("GetSession", id)}
 }
 
@@ -11120,7 +11271,7 @@ type MockSessionStore_ListUserSessions_Call struct {
 
 // ListUserSessions is a helper method to define mock.On call
 //   - userID string
-func (_e *MockSessionStore_Expecter) ListUserSessions(userID interface{}) *MockSessionStore_ListUserSessions_Call {
+func (_e *MockSessionStore_Expecter) ListUserSessions(userID any) *MockSessionStore_ListUserSessions_Call {
 	return &MockSessionStore_ListUserSessions_Call{Call: _e.mock.On("ListUserSessions", userID)}
 }
 
@@ -11171,7 +11322,7 @@ type MockSessionStore_RevokeSession_Call struct {
 
 // RevokeSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockSessionStore_Expecter) RevokeSession(id interface{}) *MockSessionStore_RevokeSession_Call {
+func (_e *MockSessionStore_Expecter) RevokeSession(id any) *MockSessionStore_RevokeSession_Call {
 	return &MockSessionStore_RevokeSession_Call{Call: _e.mock.On("RevokeSession", id)}
 }
 
@@ -11260,7 +11411,7 @@ type MockRoleStore_CreateRole_Call struct {
 
 // CreateRole is a helper method to define mock.On call
 //   - role *database.Role
-func (_e *MockRoleStore_Expecter) CreateRole(role interface{}) *MockRoleStore_CreateRole_Call {
+func (_e *MockRoleStore_Expecter) CreateRole(role any) *MockRoleStore_CreateRole_Call {
 	return &MockRoleStore_CreateRole_Call{Call: _e.mock.On("CreateRole", role)}
 }
 
@@ -11311,7 +11462,7 @@ type MockRoleStore_DeleteRole_Call struct {
 
 // DeleteRole is a helper method to define mock.On call
 //   - id string
-func (_e *MockRoleStore_Expecter) DeleteRole(id interface{}) *MockRoleStore_DeleteRole_Call {
+func (_e *MockRoleStore_Expecter) DeleteRole(id any) *MockRoleStore_DeleteRole_Call {
 	return &MockRoleStore_DeleteRole_Call{Call: _e.mock.On("DeleteRole", id)}
 }
 
@@ -11373,7 +11524,7 @@ type MockRoleStore_GetRoleByID_Call struct {
 
 // GetRoleByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockRoleStore_Expecter) GetRoleByID(id interface{}) *MockRoleStore_GetRoleByID_Call {
+func (_e *MockRoleStore_Expecter) GetRoleByID(id any) *MockRoleStore_GetRoleByID_Call {
 	return &MockRoleStore_GetRoleByID_Call{Call: _e.mock.On("GetRoleByID", id)}
 }
 
@@ -11435,7 +11586,7 @@ type MockRoleStore_GetRoleByName_Call struct {
 
 // GetRoleByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockRoleStore_Expecter) GetRoleByName(name interface{}) *MockRoleStore_GetRoleByName_Call {
+func (_e *MockRoleStore_Expecter) GetRoleByName(name any) *MockRoleStore_GetRoleByName_Call {
 	return &MockRoleStore_GetRoleByName_Call{Call: _e.mock.On("GetRoleByName", name)}
 }
 
@@ -11541,7 +11692,7 @@ type MockRoleStore_UpdateRole_Call struct {
 
 // UpdateRole is a helper method to define mock.On call
 //   - role *database.Role
-func (_e *MockRoleStore_Expecter) UpdateRole(role interface{}) *MockRoleStore_UpdateRole_Call {
+func (_e *MockRoleStore_Expecter) UpdateRole(role any) *MockRoleStore_UpdateRole_Call {
 	return &MockRoleStore_UpdateRole_Call{Call: _e.mock.On("UpdateRole", role)}
 }
 
@@ -11630,7 +11781,7 @@ type MockAPIKeyStore_CreateAPIKey_Call struct {
 
 // CreateAPIKey is a helper method to define mock.On call
 //   - key *database.APIKey
-func (_e *MockAPIKeyStore_Expecter) CreateAPIKey(key interface{}) *MockAPIKeyStore_CreateAPIKey_Call {
+func (_e *MockAPIKeyStore_Expecter) CreateAPIKey(key any) *MockAPIKeyStore_CreateAPIKey_Call {
 	return &MockAPIKeyStore_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", key)}
 }
 
@@ -11692,7 +11843,7 @@ type MockAPIKeyStore_GetAPIKey_Call struct {
 
 // GetAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockAPIKeyStore_Expecter) GetAPIKey(id interface{}) *MockAPIKeyStore_GetAPIKey_Call {
+func (_e *MockAPIKeyStore_Expecter) GetAPIKey(id any) *MockAPIKeyStore_GetAPIKey_Call {
 	return &MockAPIKeyStore_GetAPIKey_Call{Call: _e.mock.On("GetAPIKey", id)}
 }
 
@@ -11754,7 +11905,7 @@ type MockAPIKeyStore_GetAPIKeyByHash_Call struct {
 
 // GetAPIKeyByHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockAPIKeyStore_Expecter) GetAPIKeyByHash(hash interface{}) *MockAPIKeyStore_GetAPIKeyByHash_Call {
+func (_e *MockAPIKeyStore_Expecter) GetAPIKeyByHash(hash any) *MockAPIKeyStore_GetAPIKeyByHash_Call {
 	return &MockAPIKeyStore_GetAPIKeyByHash_Call{Call: _e.mock.On("GetAPIKeyByHash", hash)}
 }
 
@@ -11816,7 +11967,7 @@ type MockAPIKeyStore_ListAPIKeysForUser_Call struct {
 
 // ListAPIKeysForUser is a helper method to define mock.On call
 //   - userID string
-func (_e *MockAPIKeyStore_Expecter) ListAPIKeysForUser(userID interface{}) *MockAPIKeyStore_ListAPIKeysForUser_Call {
+func (_e *MockAPIKeyStore_Expecter) ListAPIKeysForUser(userID any) *MockAPIKeyStore_ListAPIKeysForUser_Call {
 	return &MockAPIKeyStore_ListAPIKeysForUser_Call{Call: _e.mock.On("ListAPIKeysForUser", userID)}
 }
 
@@ -11922,7 +12073,7 @@ type MockAPIKeyStore_RevokeAPIKey_Call struct {
 
 // RevokeAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockAPIKeyStore_Expecter) RevokeAPIKey(id interface{}) *MockAPIKeyStore_RevokeAPIKey_Call {
+func (_e *MockAPIKeyStore_Expecter) RevokeAPIKey(id any) *MockAPIKeyStore_RevokeAPIKey_Call {
 	return &MockAPIKeyStore_RevokeAPIKey_Call{Call: _e.mock.On("RevokeAPIKey", id)}
 }
 
@@ -11975,7 +12126,7 @@ type MockAPIKeyStore_SetAPIKeyStatus_Call struct {
 //   - id string
 //   - status string
 //   - at time.Time
-func (_e *MockAPIKeyStore_Expecter) SetAPIKeyStatus(id interface{}, status interface{}, at interface{}) *MockAPIKeyStore_SetAPIKeyStatus_Call {
+func (_e *MockAPIKeyStore_Expecter) SetAPIKeyStatus(id any, status any, at any) *MockAPIKeyStore_SetAPIKeyStatus_Call {
 	return &MockAPIKeyStore_SetAPIKeyStatus_Call{Call: _e.mock.On("SetAPIKeyStatus", id, status, at)}
 }
 
@@ -12038,7 +12189,7 @@ type MockAPIKeyStore_TouchAPIKeyLastUsed_Call struct {
 //   - id string
 //   - at time.Time
 //   - ip string
-func (_e *MockAPIKeyStore_Expecter) TouchAPIKeyLastUsed(id interface{}, at interface{}, ip interface{}) *MockAPIKeyStore_TouchAPIKeyLastUsed_Call {
+func (_e *MockAPIKeyStore_Expecter) TouchAPIKeyLastUsed(id any, at any, ip any) *MockAPIKeyStore_TouchAPIKeyLastUsed_Call {
 	return &MockAPIKeyStore_TouchAPIKeyLastUsed_Call{Call: _e.mock.On("TouchAPIKeyLastUsed", id, at, ip)}
 }
 
@@ -12139,7 +12290,7 @@ type MockInviteStore_ConsumeInvite_Call struct {
 //   - token string
 //   - passwordHashAlgo string
 //   - passwordHash string
-func (_e *MockInviteStore_Expecter) ConsumeInvite(token interface{}, passwordHashAlgo interface{}, passwordHash interface{}) *MockInviteStore_ConsumeInvite_Call {
+func (_e *MockInviteStore_Expecter) ConsumeInvite(token any, passwordHashAlgo any, passwordHash any) *MockInviteStore_ConsumeInvite_Call {
 	return &MockInviteStore_ConsumeInvite_Call{Call: _e.mock.On("ConsumeInvite", token, passwordHashAlgo, passwordHash)}
 }
 
@@ -12211,7 +12362,7 @@ type MockInviteStore_CreateInvite_Call struct {
 
 // CreateInvite is a helper method to define mock.On call
 //   - invite *database.Invite
-func (_e *MockInviteStore_Expecter) CreateInvite(invite interface{}) *MockInviteStore_CreateInvite_Call {
+func (_e *MockInviteStore_Expecter) CreateInvite(invite any) *MockInviteStore_CreateInvite_Call {
 	return &MockInviteStore_CreateInvite_Call{Call: _e.mock.On("CreateInvite", invite)}
 }
 
@@ -12262,7 +12413,7 @@ type MockInviteStore_DeleteInvite_Call struct {
 
 // DeleteInvite is a helper method to define mock.On call
 //   - token string
-func (_e *MockInviteStore_Expecter) DeleteInvite(token interface{}) *MockInviteStore_DeleteInvite_Call {
+func (_e *MockInviteStore_Expecter) DeleteInvite(token any) *MockInviteStore_DeleteInvite_Call {
 	return &MockInviteStore_DeleteInvite_Call{Call: _e.mock.On("DeleteInvite", token)}
 }
 
@@ -12324,7 +12475,7 @@ type MockInviteStore_GetInvite_Call struct {
 
 // GetInvite is a helper method to define mock.On call
 //   - token string
-func (_e *MockInviteStore_Expecter) GetInvite(token interface{}) *MockInviteStore_GetInvite_Call {
+func (_e *MockInviteStore_Expecter) GetInvite(token any) *MockInviteStore_GetInvite_Call {
 	return &MockInviteStore_GetInvite_Call{Call: _e.mock.On("GetInvite", token)}
 }
 
@@ -12468,7 +12619,7 @@ type MockUserPreferenceStore_GetAllPreferencesForUser_Call struct {
 
 // GetAllPreferencesForUser is a helper method to define mock.On call
 //   - userID string
-func (_e *MockUserPreferenceStore_Expecter) GetAllPreferencesForUser(userID interface{}) *MockUserPreferenceStore_GetAllPreferencesForUser_Call {
+func (_e *MockUserPreferenceStore_Expecter) GetAllPreferencesForUser(userID any) *MockUserPreferenceStore_GetAllPreferencesForUser_Call {
 	return &MockUserPreferenceStore_GetAllPreferencesForUser_Call{Call: _e.mock.On("GetAllPreferencesForUser", userID)}
 }
 
@@ -12585,7 +12736,7 @@ type MockUserPreferenceStore_GetUserPreference_Call struct {
 
 // GetUserPreference is a helper method to define mock.On call
 //   - key string
-func (_e *MockUserPreferenceStore_Expecter) GetUserPreference(key interface{}) *MockUserPreferenceStore_GetUserPreference_Call {
+func (_e *MockUserPreferenceStore_Expecter) GetUserPreference(key any) *MockUserPreferenceStore_GetUserPreference_Call {
 	return &MockUserPreferenceStore_GetUserPreference_Call{Call: _e.mock.On("GetUserPreference", key)}
 }
 
@@ -12648,7 +12799,7 @@ type MockUserPreferenceStore_GetUserPreferenceForUser_Call struct {
 // GetUserPreferenceForUser is a helper method to define mock.On call
 //   - userID string
 //   - key string
-func (_e *MockUserPreferenceStore_Expecter) GetUserPreferenceForUser(userID interface{}, key interface{}) *MockUserPreferenceStore_GetUserPreferenceForUser_Call {
+func (_e *MockUserPreferenceStore_Expecter) GetUserPreferenceForUser(userID any, key any) *MockUserPreferenceStore_GetUserPreferenceForUser_Call {
 	return &MockUserPreferenceStore_GetUserPreferenceForUser_Call{Call: _e.mock.On("GetUserPreferenceForUser", userID, key)}
 }
 
@@ -12705,7 +12856,7 @@ type MockUserPreferenceStore_SetUserPreference_Call struct {
 // SetUserPreference is a helper method to define mock.On call
 //   - key string
 //   - value string
-func (_e *MockUserPreferenceStore_Expecter) SetUserPreference(key interface{}, value interface{}) *MockUserPreferenceStore_SetUserPreference_Call {
+func (_e *MockUserPreferenceStore_Expecter) SetUserPreference(key any, value any) *MockUserPreferenceStore_SetUserPreference_Call {
 	return &MockUserPreferenceStore_SetUserPreference_Call{Call: _e.mock.On("SetUserPreference", key, value)}
 }
 
@@ -12763,7 +12914,7 @@ type MockUserPreferenceStore_SetUserPreferenceForUser_Call struct {
 //   - userID string
 //   - key string
 //   - value string
-func (_e *MockUserPreferenceStore_Expecter) SetUserPreferenceForUser(userID interface{}, key interface{}, value interface{}) *MockUserPreferenceStore_SetUserPreferenceForUser_Call {
+func (_e *MockUserPreferenceStore_Expecter) SetUserPreferenceForUser(userID any, key any, value any) *MockUserPreferenceStore_SetUserPreferenceForUser_Call {
 	return &MockUserPreferenceStore_SetUserPreferenceForUser_Call{Call: _e.mock.On("SetUserPreferenceForUser", userID, key, value)}
 }
 
@@ -12852,7 +13003,7 @@ type MockUserPositionStore_ClearUserPositions_Call struct {
 // ClearUserPositions is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockUserPositionStore_Expecter) ClearUserPositions(userID interface{}, bookID interface{}) *MockUserPositionStore_ClearUserPositions_Call {
+func (_e *MockUserPositionStore_Expecter) ClearUserPositions(userID any, bookID any) *MockUserPositionStore_ClearUserPositions_Call {
 	return &MockUserPositionStore_ClearUserPositions_Call{Call: _e.mock.On("ClearUserPositions", userID, bookID)}
 }
 
@@ -12920,7 +13071,7 @@ type MockUserPositionStore_GetUserBookState_Call struct {
 // GetUserBookState is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockUserPositionStore_Expecter) GetUserBookState(userID interface{}, bookID interface{}) *MockUserPositionStore_GetUserBookState_Call {
+func (_e *MockUserPositionStore_Expecter) GetUserBookState(userID any, bookID any) *MockUserPositionStore_GetUserBookState_Call {
 	return &MockUserPositionStore_GetUserBookState_Call{Call: _e.mock.On("GetUserBookState", userID, bookID)}
 }
 
@@ -12988,7 +13139,7 @@ type MockUserPositionStore_GetUserPosition_Call struct {
 // GetUserPosition is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockUserPositionStore_Expecter) GetUserPosition(userID interface{}, bookID interface{}) *MockUserPositionStore_GetUserPosition_Call {
+func (_e *MockUserPositionStore_Expecter) GetUserPosition(userID any, bookID any) *MockUserPositionStore_GetUserPosition_Call {
 	return &MockUserPositionStore_GetUserPosition_Call{Call: _e.mock.On("GetUserPosition", userID, bookID)}
 }
 
@@ -13058,7 +13209,7 @@ type MockUserPositionStore_ListUserBookStatesByStatus_Call struct {
 //   - status string
 //   - limit int
 //   - offset int
-func (_e *MockUserPositionStore_Expecter) ListUserBookStatesByStatus(userID interface{}, status interface{}, limit interface{}, offset interface{}) *MockUserPositionStore_ListUserBookStatesByStatus_Call {
+func (_e *MockUserPositionStore_Expecter) ListUserBookStatesByStatus(userID any, status any, limit any, offset any) *MockUserPositionStore_ListUserBookStatesByStatus_Call {
 	return &MockUserPositionStore_ListUserBookStatesByStatus_Call{Call: _e.mock.On("ListUserBookStatesByStatus", userID, status, limit, offset)}
 }
 
@@ -13136,7 +13287,7 @@ type MockUserPositionStore_ListUserPositionsForBook_Call struct {
 // ListUserPositionsForBook is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockUserPositionStore_Expecter) ListUserPositionsForBook(userID interface{}, bookID interface{}) *MockUserPositionStore_ListUserPositionsForBook_Call {
+func (_e *MockUserPositionStore_Expecter) ListUserPositionsForBook(userID any, bookID any) *MockUserPositionStore_ListUserPositionsForBook_Call {
 	return &MockUserPositionStore_ListUserPositionsForBook_Call{Call: _e.mock.On("ListUserPositionsForBook", userID, bookID)}
 }
 
@@ -13204,7 +13355,7 @@ type MockUserPositionStore_ListUserPositionsSince_Call struct {
 // ListUserPositionsSince is a helper method to define mock.On call
 //   - userID string
 //   - t time.Time
-func (_e *MockUserPositionStore_Expecter) ListUserPositionsSince(userID interface{}, t interface{}) *MockUserPositionStore_ListUserPositionsSince_Call {
+func (_e *MockUserPositionStore_Expecter) ListUserPositionsSince(userID any, t any) *MockUserPositionStore_ListUserPositionsSince_Call {
 	return &MockUserPositionStore_ListUserPositionsSince_Call{Call: _e.mock.On("ListUserPositionsSince", userID, t)}
 }
 
@@ -13260,7 +13411,7 @@ type MockUserPositionStore_SetUserBookState_Call struct {
 
 // SetUserBookState is a helper method to define mock.On call
 //   - state *database.UserBookState
-func (_e *MockUserPositionStore_Expecter) SetUserBookState(state interface{}) *MockUserPositionStore_SetUserBookState_Call {
+func (_e *MockUserPositionStore_Expecter) SetUserBookState(state any) *MockUserPositionStore_SetUserBookState_Call {
 	return &MockUserPositionStore_SetUserBookState_Call{Call: _e.mock.On("SetUserBookState", state)}
 }
 
@@ -13314,7 +13465,7 @@ type MockUserPositionStore_SetUserPosition_Call struct {
 //   - bookID string
 //   - segmentID string
 //   - positionSeconds float64
-func (_e *MockUserPositionStore_Expecter) SetUserPosition(userID interface{}, bookID interface{}, segmentID interface{}, positionSeconds interface{}) *MockUserPositionStore_SetUserPosition_Call {
+func (_e *MockUserPositionStore_Expecter) SetUserPosition(userID any, bookID any, segmentID any, positionSeconds any) *MockUserPositionStore_SetUserPosition_Call {
 	return &MockUserPositionStore_SetUserPosition_Call{Call: _e.mock.On("SetUserPosition", userID, bookID, segmentID, positionSeconds)}
 }
 
@@ -13418,7 +13569,7 @@ type MockBookVersionStore_CreateBookVersion_Call struct {
 
 // CreateBookVersion is a helper method to define mock.On call
 //   - v *database.BookVersion
-func (_e *MockBookVersionStore_Expecter) CreateBookVersion(v interface{}) *MockBookVersionStore_CreateBookVersion_Call {
+func (_e *MockBookVersionStore_Expecter) CreateBookVersion(v any) *MockBookVersionStore_CreateBookVersion_Call {
 	return &MockBookVersionStore_CreateBookVersion_Call{Call: _e.mock.On("CreateBookVersion", v)}
 }
 
@@ -13469,7 +13620,7 @@ type MockBookVersionStore_DeleteBookVersion_Call struct {
 
 // DeleteBookVersion is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookVersionStore_Expecter) DeleteBookVersion(id interface{}) *MockBookVersionStore_DeleteBookVersion_Call {
+func (_e *MockBookVersionStore_Expecter) DeleteBookVersion(id any) *MockBookVersionStore_DeleteBookVersion_Call {
 	return &MockBookVersionStore_DeleteBookVersion_Call{Call: _e.mock.On("DeleteBookVersion", id)}
 }
 
@@ -13531,7 +13682,7 @@ type MockBookVersionStore_GetActiveVersionForBook_Call struct {
 
 // GetActiveVersionForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockBookVersionStore_Expecter) GetActiveVersionForBook(bookID interface{}) *MockBookVersionStore_GetActiveVersionForBook_Call {
+func (_e *MockBookVersionStore_Expecter) GetActiveVersionForBook(bookID any) *MockBookVersionStore_GetActiveVersionForBook_Call {
 	return &MockBookVersionStore_GetActiveVersionForBook_Call{Call: _e.mock.On("GetActiveVersionForBook", bookID)}
 }
 
@@ -13593,7 +13744,7 @@ type MockBookVersionStore_GetBookVersion_Call struct {
 
 // GetBookVersion is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookVersionStore_Expecter) GetBookVersion(id interface{}) *MockBookVersionStore_GetBookVersion_Call {
+func (_e *MockBookVersionStore_Expecter) GetBookVersion(id any) *MockBookVersionStore_GetBookVersion_Call {
 	return &MockBookVersionStore_GetBookVersion_Call{Call: _e.mock.On("GetBookVersion", id)}
 }
 
@@ -13655,7 +13806,7 @@ type MockBookVersionStore_GetBookVersionByTorrentHash_Call struct {
 
 // GetBookVersionByTorrentHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookVersionStore_Expecter) GetBookVersionByTorrentHash(hash interface{}) *MockBookVersionStore_GetBookVersionByTorrentHash_Call {
+func (_e *MockBookVersionStore_Expecter) GetBookVersionByTorrentHash(hash any) *MockBookVersionStore_GetBookVersionByTorrentHash_Call {
 	return &MockBookVersionStore_GetBookVersionByTorrentHash_Call{Call: _e.mock.On("GetBookVersionByTorrentHash", hash)}
 }
 
@@ -13717,7 +13868,7 @@ type MockBookVersionStore_GetBookVersionsByBookID_Call struct {
 
 // GetBookVersionsByBookID is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockBookVersionStore_Expecter) GetBookVersionsByBookID(bookID interface{}) *MockBookVersionStore_GetBookVersionsByBookID_Call {
+func (_e *MockBookVersionStore_Expecter) GetBookVersionsByBookID(bookID any) *MockBookVersionStore_GetBookVersionsByBookID_Call {
 	return &MockBookVersionStore_GetBookVersionsByBookID_Call{Call: _e.mock.On("GetBookVersionsByBookID", bookID)}
 }
 
@@ -13878,7 +14029,7 @@ type MockBookVersionStore_UpdateBookVersion_Call struct {
 
 // UpdateBookVersion is a helper method to define mock.On call
 //   - v *database.BookVersion
-func (_e *MockBookVersionStore_Expecter) UpdateBookVersion(v interface{}) *MockBookVersionStore_UpdateBookVersion_Call {
+func (_e *MockBookVersionStore_Expecter) UpdateBookVersion(v any) *MockBookVersionStore_UpdateBookVersion_Call {
 	return &MockBookVersionStore_UpdateBookVersion_Call{Call: _e.mock.On("UpdateBookVersion", v)}
 }
 
@@ -13956,7 +14107,7 @@ type MockBookFileStore_BatchUpsertBookFiles_Call struct {
 
 // BatchUpsertBookFiles is a helper method to define mock.On call
 //   - files []*database.BookFile
-func (_e *MockBookFileStore_Expecter) BatchUpsertBookFiles(files interface{}) *MockBookFileStore_BatchUpsertBookFiles_Call {
+func (_e *MockBookFileStore_Expecter) BatchUpsertBookFiles(files any) *MockBookFileStore_BatchUpsertBookFiles_Call {
 	return &MockBookFileStore_BatchUpsertBookFiles_Call{Call: _e.mock.On("BatchUpsertBookFiles", files)}
 }
 
@@ -14016,7 +14167,7 @@ type MockBookFileStore_ClearITunesPID_Call struct {
 
 // ClearITunesPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockBookFileStore_Expecter) ClearITunesPID(itunesPID interface{}) *MockBookFileStore_ClearITunesPID_Call {
+func (_e *MockBookFileStore_Expecter) ClearITunesPID(itunesPID any) *MockBookFileStore_ClearITunesPID_Call {
 	return &MockBookFileStore_ClearITunesPID_Call{Call: _e.mock.On("ClearITunesPID", itunesPID)}
 }
 
@@ -14067,7 +14218,7 @@ type MockBookFileStore_CreateBookFile_Call struct {
 
 // CreateBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockBookFileStore_Expecter) CreateBookFile(file interface{}) *MockBookFileStore_CreateBookFile_Call {
+func (_e *MockBookFileStore_Expecter) CreateBookFile(file any) *MockBookFileStore_CreateBookFile_Call {
 	return &MockBookFileStore_CreateBookFile_Call{Call: _e.mock.On("CreateBookFile", file)}
 }
 
@@ -14118,7 +14269,7 @@ type MockBookFileStore_DeleteBookFile_Call struct {
 
 // DeleteBookFile is a helper method to define mock.On call
 //   - id string
-func (_e *MockBookFileStore_Expecter) DeleteBookFile(id interface{}) *MockBookFileStore_DeleteBookFile_Call {
+func (_e *MockBookFileStore_Expecter) DeleteBookFile(id any) *MockBookFileStore_DeleteBookFile_Call {
 	return &MockBookFileStore_DeleteBookFile_Call{Call: _e.mock.On("DeleteBookFile", id)}
 }
 
@@ -14169,7 +14320,7 @@ type MockBookFileStore_DeleteBookFilesForBook_Call struct {
 
 // DeleteBookFilesForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockBookFileStore_Expecter) DeleteBookFilesForBook(bookID interface{}) *MockBookFileStore_DeleteBookFilesForBook_Call {
+func (_e *MockBookFileStore_Expecter) DeleteBookFilesForBook(bookID any) *MockBookFileStore_DeleteBookFilesForBook_Call {
 	return &MockBookFileStore_DeleteBookFilesForBook_Call{Call: _e.mock.On("DeleteBookFilesForBook", bookID)}
 }
 
@@ -14341,7 +14492,7 @@ type MockBookFileStore_GetBookBySegmentFileHash_Call struct {
 
 // GetBookBySegmentFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockBookFileStore_Expecter) GetBookBySegmentFileHash(hash interface{}) *MockBookFileStore_GetBookBySegmentFileHash_Call {
+func (_e *MockBookFileStore_Expecter) GetBookBySegmentFileHash(hash any) *MockBookFileStore_GetBookBySegmentFileHash_Call {
 	return &MockBookFileStore_GetBookBySegmentFileHash_Call{Call: _e.mock.On("GetBookBySegmentFileHash", hash)}
 }
 
@@ -14403,7 +14554,7 @@ type MockBookFileStore_GetBookFileByAcoustID_Call struct {
 
 // GetBookFileByAcoustID is a helper method to define mock.On call
 //   - fingerprint string
-func (_e *MockBookFileStore_Expecter) GetBookFileByAcoustID(fingerprint interface{}) *MockBookFileStore_GetBookFileByAcoustID_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFileByAcoustID(fingerprint any) *MockBookFileStore_GetBookFileByAcoustID_Call {
 	return &MockBookFileStore_GetBookFileByAcoustID_Call{Call: _e.mock.On("GetBookFileByAcoustID", fingerprint)}
 }
 
@@ -14466,7 +14617,7 @@ type MockBookFileStore_GetBookFileByAcoustIDFuzzy_Call struct {
 // GetBookFileByAcoustIDFuzzy is a helper method to define mock.On call
 //   - fingerprint string
 //   - minSimilarity float64
-func (_e *MockBookFileStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint interface{}, minSimilarity interface{}) *MockBookFileStore_GetBookFileByAcoustIDFuzzy_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint any, minSimilarity any) *MockBookFileStore_GetBookFileByAcoustIDFuzzy_Call {
 	return &MockBookFileStore_GetBookFileByAcoustIDFuzzy_Call{Call: _e.mock.On("GetBookFileByAcoustIDFuzzy", fingerprint, minSimilarity)}
 }
 
@@ -14534,7 +14685,7 @@ type MockBookFileStore_GetBookFileByID_Call struct {
 // GetBookFileByID is a helper method to define mock.On call
 //   - bookID string
 //   - fileID string
-func (_e *MockBookFileStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockBookFileStore_GetBookFileByID_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFileByID(bookID any, fileID any) *MockBookFileStore_GetBookFileByID_Call {
 	return &MockBookFileStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
 }
 
@@ -14601,7 +14752,7 @@ type MockBookFileStore_GetBookFileByPID_Call struct {
 
 // GetBookFileByPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockBookFileStore_Expecter) GetBookFileByPID(itunesPID interface{}) *MockBookFileStore_GetBookFileByPID_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFileByPID(itunesPID any) *MockBookFileStore_GetBookFileByPID_Call {
 	return &MockBookFileStore_GetBookFileByPID_Call{Call: _e.mock.On("GetBookFileByPID", itunesPID)}
 }
 
@@ -14663,7 +14814,7 @@ type MockBookFileStore_GetBookFileByPath_Call struct {
 
 // GetBookFileByPath is a helper method to define mock.On call
 //   - filePath string
-func (_e *MockBookFileStore_Expecter) GetBookFileByPath(filePath interface{}) *MockBookFileStore_GetBookFileByPath_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFileByPath(filePath any) *MockBookFileStore_GetBookFileByPath_Call {
 	return &MockBookFileStore_GetBookFileByPath_Call{Call: _e.mock.On("GetBookFileByPath", filePath)}
 }
 
@@ -14780,7 +14931,7 @@ type MockBookFileStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockBookFileStore_Expecter) GetBookFiles(bookID interface{}) *MockBookFileStore_GetBookFiles_Call {
+func (_e *MockBookFileStore_Expecter) GetBookFiles(bookID any) *MockBookFileStore_GetBookFiles_Call {
 	return &MockBookFileStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -14952,7 +15103,7 @@ type MockBookFileStore_GetDuplicateFilesByHash_Call struct {
 
 // GetDuplicateFilesByHash is a helper method to define mock.On call
 //   - limit int
-func (_e *MockBookFileStore_Expecter) GetDuplicateFilesByHash(limit interface{}) *MockBookFileStore_GetDuplicateFilesByHash_Call {
+func (_e *MockBookFileStore_Expecter) GetDuplicateFilesByHash(limit any) *MockBookFileStore_GetDuplicateFilesByHash_Call {
 	return &MockBookFileStore_GetDuplicateFilesByHash_Call{Call: _e.mock.On("GetDuplicateFilesByHash", limit)}
 }
 
@@ -15022,7 +15173,7 @@ type MockBookFileStore_GetFilesWithFingerprintFailures_Call struct {
 //   - reason string
 //   - limit int
 //   - offset int
-func (_e *MockBookFileStore_Expecter) GetFilesWithFingerprintFailures(reason interface{}, limit interface{}, offset interface{}) *MockBookFileStore_GetFilesWithFingerprintFailures_Call {
+func (_e *MockBookFileStore_Expecter) GetFilesWithFingerprintFailures(reason any, limit any, offset any) *MockBookFileStore_GetFilesWithFingerprintFailures_Call {
 	return &MockBookFileStore_GetFilesWithFingerprintFailures_Call{Call: _e.mock.On("GetFilesWithFingerprintFailures", reason, limit, offset)}
 }
 
@@ -15086,7 +15237,7 @@ type MockBookFileStore_MarkFileImportedFromDeluge_Call struct {
 //   - originalPath string
 //   - libraryPath string
 //   - torrentHash string
-func (_e *MockBookFileStore_Expecter) MarkFileImportedFromDeluge(ctx interface{}, originalPath interface{}, libraryPath interface{}, torrentHash interface{}) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
+func (_e *MockBookFileStore_Expecter) MarkFileImportedFromDeluge(ctx any, originalPath any, libraryPath any, torrentHash any) *MockBookFileStore_MarkFileImportedFromDeluge_Call {
 	return &MockBookFileStore_MarkFileImportedFromDeluge_Call{Call: _e.mock.On("MarkFileImportedFromDeluge", ctx, originalPath, libraryPath, torrentHash)}
 }
 
@@ -15154,7 +15305,7 @@ type MockBookFileStore_MoveBookFilesToBook_Call struct {
 //   - fileIDs []string
 //   - sourceBookID string
 //   - targetBookID string
-func (_e *MockBookFileStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockBookFileStore_MoveBookFilesToBook_Call {
+func (_e *MockBookFileStore_Expecter) MoveBookFilesToBook(fileIDs any, sourceBookID any, targetBookID any) *MockBookFileStore_MoveBookFilesToBook_Call {
 	return &MockBookFileStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
 }
 
@@ -15216,7 +15367,7 @@ type MockBookFileStore_SetBookFileHash_Call struct {
 // SetBookFileHash is a helper method to define mock.On call
 //   - id string
 //   - hash string
-func (_e *MockBookFileStore_Expecter) SetBookFileHash(id interface{}, hash interface{}) *MockBookFileStore_SetBookFileHash_Call {
+func (_e *MockBookFileStore_Expecter) SetBookFileHash(id any, hash any) *MockBookFileStore_SetBookFileHash_Call {
 	return &MockBookFileStore_SetBookFileHash_Call{Call: _e.mock.On("SetBookFileHash", id, hash)}
 }
 
@@ -15273,7 +15424,7 @@ type MockBookFileStore_UpdateBookFile_Call struct {
 // UpdateBookFile is a helper method to define mock.On call
 //   - id string
 //   - file *database.BookFile
-func (_e *MockBookFileStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockBookFileStore_UpdateBookFile_Call {
+func (_e *MockBookFileStore_Expecter) UpdateBookFile(id any, file any) *MockBookFileStore_UpdateBookFile_Call {
 	return &MockBookFileStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
 }
 
@@ -15331,7 +15482,7 @@ type MockBookFileStore_UpdateBookFileHashes_Call struct {
 //   - id string
 //   - originalHash string
 //   - postMetadataHash string
-func (_e *MockBookFileStore_Expecter) UpdateBookFileHashes(id interface{}, originalHash interface{}, postMetadataHash interface{}) *MockBookFileStore_UpdateBookFileHashes_Call {
+func (_e *MockBookFileStore_Expecter) UpdateBookFileHashes(id any, originalHash any, postMetadataHash any) *MockBookFileStore_UpdateBookFileHashes_Call {
 	return &MockBookFileStore_UpdateBookFileHashes_Call{Call: _e.mock.On("UpdateBookFileHashes", id, originalHash, postMetadataHash)}
 }
 
@@ -15392,7 +15543,7 @@ type MockBookFileStore_UpsertBookFile_Call struct {
 
 // UpsertBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockBookFileStore_Expecter) UpsertBookFile(file interface{}) *MockBookFileStore_UpsertBookFile_Call {
+func (_e *MockBookFileStore_Expecter) UpsertBookFile(file any) *MockBookFileStore_UpsertBookFile_Call {
 	return &MockBookFileStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
 }
 
@@ -15482,7 +15633,7 @@ type MockBookSegmentStore_CreateBookSegment_Call struct {
 // CreateBookSegment is a helper method to define mock.On call
 //   - bookNumericID int
 //   - segment *database.BookSegment
-func (_e *MockBookSegmentStore_Expecter) CreateBookSegment(bookNumericID interface{}, segment interface{}) *MockBookSegmentStore_CreateBookSegment_Call {
+func (_e *MockBookSegmentStore_Expecter) CreateBookSegment(bookNumericID any, segment any) *MockBookSegmentStore_CreateBookSegment_Call {
 	return &MockBookSegmentStore_CreateBookSegment_Call{Call: _e.mock.On("CreateBookSegment", bookNumericID, segment)}
 }
 
@@ -15549,7 +15700,7 @@ type MockBookSegmentStore_GetBookSegmentByID_Call struct {
 
 // GetBookSegmentByID is a helper method to define mock.On call
 //   - segmentID string
-func (_e *MockBookSegmentStore_Expecter) GetBookSegmentByID(segmentID interface{}) *MockBookSegmentStore_GetBookSegmentByID_Call {
+func (_e *MockBookSegmentStore_Expecter) GetBookSegmentByID(segmentID any) *MockBookSegmentStore_GetBookSegmentByID_Call {
 	return &MockBookSegmentStore_GetBookSegmentByID_Call{Call: _e.mock.On("GetBookSegmentByID", segmentID)}
 }
 
@@ -15611,7 +15762,7 @@ type MockBookSegmentStore_ListBookSegments_Call struct {
 
 // ListBookSegments is a helper method to define mock.On call
 //   - bookNumericID int
-func (_e *MockBookSegmentStore_Expecter) ListBookSegments(bookNumericID interface{}) *MockBookSegmentStore_ListBookSegments_Call {
+func (_e *MockBookSegmentStore_Expecter) ListBookSegments(bookNumericID any) *MockBookSegmentStore_ListBookSegments_Call {
 	return &MockBookSegmentStore_ListBookSegments_Call{Call: _e.mock.On("ListBookSegments", bookNumericID)}
 }
 
@@ -15664,7 +15815,7 @@ type MockBookSegmentStore_MergeBookSegments_Call struct {
 //   - bookNumericID int
 //   - newSegment *database.BookSegment
 //   - supersedeIDs []string
-func (_e *MockBookSegmentStore_Expecter) MergeBookSegments(bookNumericID interface{}, newSegment interface{}, supersedeIDs interface{}) *MockBookSegmentStore_MergeBookSegments_Call {
+func (_e *MockBookSegmentStore_Expecter) MergeBookSegments(bookNumericID any, newSegment any, supersedeIDs any) *MockBookSegmentStore_MergeBookSegments_Call {
 	return &MockBookSegmentStore_MergeBookSegments_Call{Call: _e.mock.On("MergeBookSegments", bookNumericID, newSegment, supersedeIDs)}
 }
 
@@ -15726,7 +15877,7 @@ type MockBookSegmentStore_MoveSegmentsToBook_Call struct {
 // MoveSegmentsToBook is a helper method to define mock.On call
 //   - segmentIDs []string
 //   - targetBookNumericID int
-func (_e *MockBookSegmentStore_Expecter) MoveSegmentsToBook(segmentIDs interface{}, targetBookNumericID interface{}) *MockBookSegmentStore_MoveSegmentsToBook_Call {
+func (_e *MockBookSegmentStore_Expecter) MoveSegmentsToBook(segmentIDs any, targetBookNumericID any) *MockBookSegmentStore_MoveSegmentsToBook_Call {
 	return &MockBookSegmentStore_MoveSegmentsToBook_Call{Call: _e.mock.On("MoveSegmentsToBook", segmentIDs, targetBookNumericID)}
 }
 
@@ -15782,7 +15933,7 @@ type MockBookSegmentStore_UpdateBookSegment_Call struct {
 
 // UpdateBookSegment is a helper method to define mock.On call
 //   - segment *database.BookSegment
-func (_e *MockBookSegmentStore_Expecter) UpdateBookSegment(segment interface{}) *MockBookSegmentStore_UpdateBookSegment_Call {
+func (_e *MockBookSegmentStore_Expecter) UpdateBookSegment(segment any) *MockBookSegmentStore_UpdateBookSegment_Call {
 	return &MockBookSegmentStore_UpdateBookSegment_Call{Call: _e.mock.On("UpdateBookSegment", segment)}
 }
 
@@ -15862,7 +16013,7 @@ type MockPlaylistStore_AddPlaylistItem_Call struct {
 //   - playlistID int
 //   - bookID int
 //   - position int
-func (_e *MockPlaylistStore_Expecter) AddPlaylistItem(playlistID interface{}, bookID interface{}, position interface{}) *MockPlaylistStore_AddPlaylistItem_Call {
+func (_e *MockPlaylistStore_Expecter) AddPlaylistItem(playlistID any, bookID any, position any) *MockPlaylistStore_AddPlaylistItem_Call {
 	return &MockPlaylistStore_AddPlaylistItem_Call{Call: _e.mock.On("AddPlaylistItem", playlistID, bookID, position)}
 }
 
@@ -15936,7 +16087,7 @@ type MockPlaylistStore_CreatePlaylist_Call struct {
 //   - name string
 //   - seriesID *int
 //   - filePath string
-func (_e *MockPlaylistStore_Expecter) CreatePlaylist(name interface{}, seriesID interface{}, filePath interface{}) *MockPlaylistStore_CreatePlaylist_Call {
+func (_e *MockPlaylistStore_Expecter) CreatePlaylist(name any, seriesID any, filePath any) *MockPlaylistStore_CreatePlaylist_Call {
 	return &MockPlaylistStore_CreatePlaylist_Call{Call: _e.mock.On("CreatePlaylist", name, seriesID, filePath)}
 }
 
@@ -16008,7 +16159,7 @@ type MockPlaylistStore_GetPlaylistByID_Call struct {
 
 // GetPlaylistByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockPlaylistStore_Expecter) GetPlaylistByID(id interface{}) *MockPlaylistStore_GetPlaylistByID_Call {
+func (_e *MockPlaylistStore_Expecter) GetPlaylistByID(id any) *MockPlaylistStore_GetPlaylistByID_Call {
 	return &MockPlaylistStore_GetPlaylistByID_Call{Call: _e.mock.On("GetPlaylistByID", id)}
 }
 
@@ -16070,7 +16221,7 @@ type MockPlaylistStore_GetPlaylistBySeriesID_Call struct {
 
 // GetPlaylistBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockPlaylistStore_Expecter) GetPlaylistBySeriesID(seriesID interface{}) *MockPlaylistStore_GetPlaylistBySeriesID_Call {
+func (_e *MockPlaylistStore_Expecter) GetPlaylistBySeriesID(seriesID any) *MockPlaylistStore_GetPlaylistBySeriesID_Call {
 	return &MockPlaylistStore_GetPlaylistBySeriesID_Call{Call: _e.mock.On("GetPlaylistBySeriesID", seriesID)}
 }
 
@@ -16132,7 +16283,7 @@ type MockPlaylistStore_GetPlaylistItems_Call struct {
 
 // GetPlaylistItems is a helper method to define mock.On call
 //   - playlistID int
-func (_e *MockPlaylistStore_Expecter) GetPlaylistItems(playlistID interface{}) *MockPlaylistStore_GetPlaylistItems_Call {
+func (_e *MockPlaylistStore_Expecter) GetPlaylistItems(playlistID any) *MockPlaylistStore_GetPlaylistItems_Call {
 	return &MockPlaylistStore_GetPlaylistItems_Call{Call: _e.mock.On("GetPlaylistItems", playlistID)}
 }
 
@@ -16221,7 +16372,7 @@ type MockUserPlaylistStore_CreateUserPlaylist_Call struct {
 
 // CreateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockUserPlaylistStore_Expecter) CreateUserPlaylist(pl interface{}) *MockUserPlaylistStore_CreateUserPlaylist_Call {
+func (_e *MockUserPlaylistStore_Expecter) CreateUserPlaylist(pl any) *MockUserPlaylistStore_CreateUserPlaylist_Call {
 	return &MockUserPlaylistStore_CreateUserPlaylist_Call{Call: _e.mock.On("CreateUserPlaylist", pl)}
 }
 
@@ -16272,7 +16423,7 @@ type MockUserPlaylistStore_DeleteUserPlaylist_Call struct {
 
 // DeleteUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockUserPlaylistStore_Expecter) DeleteUserPlaylist(id interface{}) *MockUserPlaylistStore_DeleteUserPlaylist_Call {
+func (_e *MockUserPlaylistStore_Expecter) DeleteUserPlaylist(id any) *MockUserPlaylistStore_DeleteUserPlaylist_Call {
 	return &MockUserPlaylistStore_DeleteUserPlaylist_Call{Call: _e.mock.On("DeleteUserPlaylist", id)}
 }
 
@@ -16334,7 +16485,7 @@ type MockUserPlaylistStore_GetUserPlaylist_Call struct {
 
 // GetUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylist(id interface{}) *MockUserPlaylistStore_GetUserPlaylist_Call {
+func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylist(id any) *MockUserPlaylistStore_GetUserPlaylist_Call {
 	return &MockUserPlaylistStore_GetUserPlaylist_Call{Call: _e.mock.On("GetUserPlaylist", id)}
 }
 
@@ -16396,7 +16547,7 @@ type MockUserPlaylistStore_GetUserPlaylistByITunesPID_Call struct {
 
 // GetUserPlaylistByITunesPID is a helper method to define mock.On call
 //   - pid string
-func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylistByITunesPID(pid interface{}) *MockUserPlaylistStore_GetUserPlaylistByITunesPID_Call {
+func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylistByITunesPID(pid any) *MockUserPlaylistStore_GetUserPlaylistByITunesPID_Call {
 	return &MockUserPlaylistStore_GetUserPlaylistByITunesPID_Call{Call: _e.mock.On("GetUserPlaylistByITunesPID", pid)}
 }
 
@@ -16458,7 +16609,7 @@ type MockUserPlaylistStore_GetUserPlaylistByName_Call struct {
 
 // GetUserPlaylistByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylistByName(name interface{}) *MockUserPlaylistStore_GetUserPlaylistByName_Call {
+func (_e *MockUserPlaylistStore_Expecter) GetUserPlaylistByName(name any) *MockUserPlaylistStore_GetUserPlaylistByName_Call {
 	return &MockUserPlaylistStore_GetUserPlaylistByName_Call{Call: _e.mock.On("GetUserPlaylistByName", name)}
 }
 
@@ -16583,7 +16734,7 @@ type MockUserPlaylistStore_ListUserPlaylists_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockUserPlaylistStore_Expecter) ListUserPlaylists(playlistType interface{}, limit interface{}, offset interface{}) *MockUserPlaylistStore_ListUserPlaylists_Call {
+func (_e *MockUserPlaylistStore_Expecter) ListUserPlaylists(playlistType any, limit any, offset any) *MockUserPlaylistStore_ListUserPlaylists_Call {
 	return &MockUserPlaylistStore_ListUserPlaylists_Call{Call: _e.mock.On("ListUserPlaylists", playlistType, limit, offset)}
 }
 
@@ -16664,7 +16815,7 @@ type MockUserPlaylistStore_ListUserPlaylistsForUser_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockUserPlaylistStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
+func (_e *MockUserPlaylistStore_Expecter) ListUserPlaylistsForUser(userID any, playlistType any, limit any, offset any) *MockUserPlaylistStore_ListUserPlaylistsForUser_Call {
 	return &MockUserPlaylistStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
 }
 
@@ -16730,7 +16881,7 @@ type MockUserPlaylistStore_UpdateUserPlaylist_Call struct {
 
 // UpdateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockUserPlaylistStore_Expecter) UpdateUserPlaylist(pl interface{}) *MockUserPlaylistStore_UpdateUserPlaylist_Call {
+func (_e *MockUserPlaylistStore_Expecter) UpdateUserPlaylist(pl any) *MockUserPlaylistStore_UpdateUserPlaylist_Call {
 	return &MockUserPlaylistStore_UpdateUserPlaylist_Call{Call: _e.mock.On("UpdateUserPlaylist", pl)}
 }
 
@@ -16817,7 +16968,7 @@ type MockImportPathStore_CountBooksByPathPrefix_Call struct {
 
 // CountBooksByPathPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockImportPathStore_Expecter) CountBooksByPathPrefix(prefix interface{}) *MockImportPathStore_CountBooksByPathPrefix_Call {
+func (_e *MockImportPathStore_Expecter) CountBooksByPathPrefix(prefix any) *MockImportPathStore_CountBooksByPathPrefix_Call {
 	return &MockImportPathStore_CountBooksByPathPrefix_Call{Call: _e.mock.On("CountBooksByPathPrefix", prefix)}
 }
 
@@ -16880,7 +17031,7 @@ type MockImportPathStore_CreateImportPath_Call struct {
 // CreateImportPath is a helper method to define mock.On call
 //   - path string
 //   - name string
-func (_e *MockImportPathStore_Expecter) CreateImportPath(path interface{}, name interface{}) *MockImportPathStore_CreateImportPath_Call {
+func (_e *MockImportPathStore_Expecter) CreateImportPath(path any, name any) *MockImportPathStore_CreateImportPath_Call {
 	return &MockImportPathStore_CreateImportPath_Call{Call: _e.mock.On("CreateImportPath", path, name)}
 }
 
@@ -16936,7 +17087,7 @@ type MockImportPathStore_DeleteImportPath_Call struct {
 
 // DeleteImportPath is a helper method to define mock.On call
 //   - id int
-func (_e *MockImportPathStore_Expecter) DeleteImportPath(id interface{}) *MockImportPathStore_DeleteImportPath_Call {
+func (_e *MockImportPathStore_Expecter) DeleteImportPath(id any) *MockImportPathStore_DeleteImportPath_Call {
 	return &MockImportPathStore_DeleteImportPath_Call{Call: _e.mock.On("DeleteImportPath", id)}
 }
 
@@ -17053,7 +17204,7 @@ type MockImportPathStore_GetImportPathByID_Call struct {
 
 // GetImportPathByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockImportPathStore_Expecter) GetImportPathByID(id interface{}) *MockImportPathStore_GetImportPathByID_Call {
+func (_e *MockImportPathStore_Expecter) GetImportPathByID(id any) *MockImportPathStore_GetImportPathByID_Call {
 	return &MockImportPathStore_GetImportPathByID_Call{Call: _e.mock.On("GetImportPathByID", id)}
 }
 
@@ -17115,7 +17266,7 @@ type MockImportPathStore_GetImportPathByPath_Call struct {
 
 // GetImportPathByPath is a helper method to define mock.On call
 //   - path string
-func (_e *MockImportPathStore_Expecter) GetImportPathByPath(path interface{}) *MockImportPathStore_GetImportPathByPath_Call {
+func (_e *MockImportPathStore_Expecter) GetImportPathByPath(path any) *MockImportPathStore_GetImportPathByPath_Call {
 	return &MockImportPathStore_GetImportPathByPath_Call{Call: _e.mock.On("GetImportPathByPath", path)}
 }
 
@@ -17167,7 +17318,7 @@ type MockImportPathStore_UpdateImportPath_Call struct {
 // UpdateImportPath is a helper method to define mock.On call
 //   - id int
 //   - importPath *database.ImportPath
-func (_e *MockImportPathStore_Expecter) UpdateImportPath(id interface{}, importPath interface{}) *MockImportPathStore_UpdateImportPath_Call {
+func (_e *MockImportPathStore_Expecter) UpdateImportPath(id any, importPath any) *MockImportPathStore_UpdateImportPath_Call {
 	return &MockImportPathStore_UpdateImportPath_Call{Call: _e.mock.On("UpdateImportPath", id, importPath)}
 }
 
@@ -17253,7 +17404,7 @@ type MockMetadataStore_AddBookAlternativeTitle_Call struct {
 //   - title string
 //   - source string
 //   - language string
-func (_e *MockMetadataStore_Expecter) AddBookAlternativeTitle(bookID interface{}, title interface{}, source interface{}, language interface{}) *MockMetadataStore_AddBookAlternativeTitle_Call {
+func (_e *MockMetadataStore_Expecter) AddBookAlternativeTitle(bookID any, title any, source any, language any) *MockMetadataStore_AddBookAlternativeTitle_Call {
 	return &MockMetadataStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
 }
 
@@ -17320,7 +17471,7 @@ type MockMetadataStore_DeleteMetadataFieldState_Call struct {
 // DeleteMetadataFieldState is a helper method to define mock.On call
 //   - bookID string
 //   - field string
-func (_e *MockMetadataStore_Expecter) DeleteMetadataFieldState(bookID interface{}, field interface{}) *MockMetadataStore_DeleteMetadataFieldState_Call {
+func (_e *MockMetadataStore_Expecter) DeleteMetadataFieldState(bookID any, field any) *MockMetadataStore_DeleteMetadataFieldState_Call {
 	return &MockMetadataStore_DeleteMetadataFieldState_Call{Call: _e.mock.On("DeleteMetadataFieldState", bookID, field)}
 }
 
@@ -17387,7 +17538,7 @@ type MockMetadataStore_GetBookAlternativeTitles_Call struct {
 
 // GetBookAlternativeTitles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockMetadataStore_GetBookAlternativeTitles_Call {
+func (_e *MockMetadataStore_Expecter) GetBookAlternativeTitles(bookID any) *MockMetadataStore_GetBookAlternativeTitles_Call {
 	return &MockMetadataStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
 }
 
@@ -17450,7 +17601,7 @@ type MockMetadataStore_GetBookChangeHistory_Call struct {
 // GetBookChangeHistory is a helper method to define mock.On call
 //   - bookID string
 //   - limit int
-func (_e *MockMetadataStore_Expecter) GetBookChangeHistory(bookID interface{}, limit interface{}) *MockMetadataStore_GetBookChangeHistory_Call {
+func (_e *MockMetadataStore_Expecter) GetBookChangeHistory(bookID any, limit any) *MockMetadataStore_GetBookChangeHistory_Call {
 	return &MockMetadataStore_GetBookChangeHistory_Call{Call: _e.mock.On("GetBookChangeHistory", bookID, limit)}
 }
 
@@ -17519,7 +17670,7 @@ type MockMetadataStore_GetMetadataChangeHistory_Call struct {
 //   - bookID string
 //   - field string
 //   - limit int
-func (_e *MockMetadataStore_Expecter) GetMetadataChangeHistory(bookID interface{}, field interface{}, limit interface{}) *MockMetadataStore_GetMetadataChangeHistory_Call {
+func (_e *MockMetadataStore_Expecter) GetMetadataChangeHistory(bookID any, field any, limit any) *MockMetadataStore_GetMetadataChangeHistory_Call {
 	return &MockMetadataStore_GetMetadataChangeHistory_Call{Call: _e.mock.On("GetMetadataChangeHistory", bookID, field, limit)}
 }
 
@@ -17591,7 +17742,7 @@ type MockMetadataStore_GetMetadataFieldStates_Call struct {
 
 // GetMetadataFieldStates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataStore_Expecter) GetMetadataFieldStates(bookID interface{}) *MockMetadataStore_GetMetadataFieldStates_Call {
+func (_e *MockMetadataStore_Expecter) GetMetadataFieldStates(bookID any) *MockMetadataStore_GetMetadataFieldStates_Call {
 	return &MockMetadataStore_GetMetadataFieldStates_Call{Call: _e.mock.On("GetMetadataFieldStates", bookID)}
 }
 
@@ -17642,7 +17793,7 @@ type MockMetadataStore_RecordMetadataChange_Call struct {
 
 // RecordMetadataChange is a helper method to define mock.On call
 //   - record *database.MetadataChangeRecord
-func (_e *MockMetadataStore_Expecter) RecordMetadataChange(record interface{}) *MockMetadataStore_RecordMetadataChange_Call {
+func (_e *MockMetadataStore_Expecter) RecordMetadataChange(record any) *MockMetadataStore_RecordMetadataChange_Call {
 	return &MockMetadataStore_RecordMetadataChange_Call{Call: _e.mock.On("RecordMetadataChange", record)}
 }
 
@@ -17694,7 +17845,7 @@ type MockMetadataStore_RemoveBookAlternativeTitle_Call struct {
 // RemoveBookAlternativeTitle is a helper method to define mock.On call
 //   - bookID string
 //   - title string
-func (_e *MockMetadataStore_Expecter) RemoveBookAlternativeTitle(bookID interface{}, title interface{}) *MockMetadataStore_RemoveBookAlternativeTitle_Call {
+func (_e *MockMetadataStore_Expecter) RemoveBookAlternativeTitle(bookID any, title any) *MockMetadataStore_RemoveBookAlternativeTitle_Call {
 	return &MockMetadataStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
 }
 
@@ -17751,7 +17902,7 @@ type MockMetadataStore_SetBookAlternativeTitles_Call struct {
 // SetBookAlternativeTitles is a helper method to define mock.On call
 //   - bookID string
 //   - titles []database.BookAlternativeTitle
-func (_e *MockMetadataStore_Expecter) SetBookAlternativeTitles(bookID interface{}, titles interface{}) *MockMetadataStore_SetBookAlternativeTitles_Call {
+func (_e *MockMetadataStore_Expecter) SetBookAlternativeTitles(bookID any, titles any) *MockMetadataStore_SetBookAlternativeTitles_Call {
 	return &MockMetadataStore_SetBookAlternativeTitles_Call{Call: _e.mock.On("SetBookAlternativeTitles", bookID, titles)}
 }
 
@@ -17807,7 +17958,7 @@ type MockMetadataStore_UpsertMetadataFieldState_Call struct {
 
 // UpsertMetadataFieldState is a helper method to define mock.On call
 //   - state *database.MetadataFieldState
-func (_e *MockMetadataStore_Expecter) UpsertMetadataFieldState(state interface{}) *MockMetadataStore_UpsertMetadataFieldState_Call {
+func (_e *MockMetadataStore_Expecter) UpsertMetadataFieldState(state any) *MockMetadataStore_UpsertMetadataFieldState_Call {
 	return &MockMetadataStore_UpsertMetadataFieldState_Call{Call: _e.mock.On("UpsertMetadataFieldState", state)}
 }
 
@@ -17886,7 +18037,7 @@ type MockHashBlocklistStore_AddBlockedHash_Call struct {
 // AddBlockedHash is a helper method to define mock.On call
 //   - hash string
 //   - reason string
-func (_e *MockHashBlocklistStore_Expecter) AddBlockedHash(hash interface{}, reason interface{}) *MockHashBlocklistStore_AddBlockedHash_Call {
+func (_e *MockHashBlocklistStore_Expecter) AddBlockedHash(hash any, reason any) *MockHashBlocklistStore_AddBlockedHash_Call {
 	return &MockHashBlocklistStore_AddBlockedHash_Call{Call: _e.mock.On("AddBlockedHash", hash, reason)}
 }
 
@@ -18008,7 +18159,7 @@ type MockHashBlocklistStore_GetBlockedHashByHash_Call struct {
 
 // GetBlockedHashByHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockHashBlocklistStore_Expecter) GetBlockedHashByHash(hash interface{}) *MockHashBlocklistStore_GetBlockedHashByHash_Call {
+func (_e *MockHashBlocklistStore_Expecter) GetBlockedHashByHash(hash any) *MockHashBlocklistStore_GetBlockedHashByHash_Call {
 	return &MockHashBlocklistStore_GetBlockedHashByHash_Call{Call: _e.mock.On("GetBlockedHashByHash", hash)}
 }
 
@@ -18068,7 +18219,7 @@ type MockHashBlocklistStore_IsHashBlocked_Call struct {
 
 // IsHashBlocked is a helper method to define mock.On call
 //   - hash string
-func (_e *MockHashBlocklistStore_Expecter) IsHashBlocked(hash interface{}) *MockHashBlocklistStore_IsHashBlocked_Call {
+func (_e *MockHashBlocklistStore_Expecter) IsHashBlocked(hash any) *MockHashBlocklistStore_IsHashBlocked_Call {
 	return &MockHashBlocklistStore_IsHashBlocked_Call{Call: _e.mock.On("IsHashBlocked", hash)}
 }
 
@@ -18119,7 +18270,7 @@ type MockHashBlocklistStore_RemoveBlockedHash_Call struct {
 
 // RemoveBlockedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockHashBlocklistStore_Expecter) RemoveBlockedHash(hash interface{}) *MockHashBlocklistStore_RemoveBlockedHash_Call {
+func (_e *MockHashBlocklistStore_Expecter) RemoveBlockedHash(hash any) *MockHashBlocklistStore_RemoveBlockedHash_Call {
 	return &MockHashBlocklistStore_RemoveBlockedHash_Call{Call: _e.mock.On("RemoveBlockedHash", hash)}
 }
 
@@ -18206,7 +18357,7 @@ type MockRawKVStore_CountPrefix_Call struct {
 
 // CountPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockRawKVStore_Expecter) CountPrefix(prefix interface{}) *MockRawKVStore_CountPrefix_Call {
+func (_e *MockRawKVStore_Expecter) CountPrefix(prefix any) *MockRawKVStore_CountPrefix_Call {
 	return &MockRawKVStore_CountPrefix_Call{Call: _e.mock.On("CountPrefix", prefix)}
 }
 
@@ -18257,7 +18408,7 @@ type MockRawKVStore_DeleteRaw_Call struct {
 
 // DeleteRaw is a helper method to define mock.On call
 //   - key string
-func (_e *MockRawKVStore_Expecter) DeleteRaw(key interface{}) *MockRawKVStore_DeleteRaw_Call {
+func (_e *MockRawKVStore_Expecter) DeleteRaw(key any) *MockRawKVStore_DeleteRaw_Call {
 	return &MockRawKVStore_DeleteRaw_Call{Call: _e.mock.On("DeleteRaw", key)}
 }
 
@@ -18319,7 +18470,7 @@ type MockRawKVStore_GetRaw_Call struct {
 
 // GetRaw is a helper method to define mock.On call
 //   - key string
-func (_e *MockRawKVStore_Expecter) GetRaw(key interface{}) *MockRawKVStore_GetRaw_Call {
+func (_e *MockRawKVStore_Expecter) GetRaw(key any) *MockRawKVStore_GetRaw_Call {
 	return &MockRawKVStore_GetRaw_Call{Call: _e.mock.On("GetRaw", key)}
 }
 
@@ -18381,7 +18532,7 @@ type MockRawKVStore_ScanPrefix_Call struct {
 
 // ScanPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockRawKVStore_Expecter) ScanPrefix(prefix interface{}) *MockRawKVStore_ScanPrefix_Call {
+func (_e *MockRawKVStore_Expecter) ScanPrefix(prefix any) *MockRawKVStore_ScanPrefix_Call {
 	return &MockRawKVStore_ScanPrefix_Call{Call: _e.mock.On("ScanPrefix", prefix)}
 }
 
@@ -18433,7 +18584,7 @@ type MockRawKVStore_SetRaw_Call struct {
 // SetRaw is a helper method to define mock.On call
 //   - key string
 //   - value []byte
-func (_e *MockRawKVStore_Expecter) SetRaw(key interface{}, value interface{}) *MockRawKVStore_SetRaw_Call {
+func (_e *MockRawKVStore_Expecter) SetRaw(key any, value any) *MockRawKVStore_SetRaw_Call {
 	return &MockRawKVStore_SetRaw_Call{Call: _e.mock.On("SetRaw", key, value)}
 }
 
@@ -18516,7 +18667,7 @@ type MockPlaybackStore_AddPlaybackEvent_Call struct {
 
 // AddPlaybackEvent is a helper method to define mock.On call
 //   - event *database.PlaybackEvent
-func (_e *MockPlaybackStore_Expecter) AddPlaybackEvent(event interface{}) *MockPlaybackStore_AddPlaybackEvent_Call {
+func (_e *MockPlaybackStore_Expecter) AddPlaybackEvent(event any) *MockPlaybackStore_AddPlaybackEvent_Call {
 	return &MockPlaybackStore_AddPlaybackEvent_Call{Call: _e.mock.On("AddPlaybackEvent", event)}
 }
 
@@ -18578,7 +18729,7 @@ type MockPlaybackStore_GetBookStats_Call struct {
 
 // GetBookStats is a helper method to define mock.On call
 //   - bookNumericID int
-func (_e *MockPlaybackStore_Expecter) GetBookStats(bookNumericID interface{}) *MockPlaybackStore_GetBookStats_Call {
+func (_e *MockPlaybackStore_Expecter) GetBookStats(bookNumericID any) *MockPlaybackStore_GetBookStats_Call {
 	return &MockPlaybackStore_GetBookStats_Call{Call: _e.mock.On("GetBookStats", bookNumericID)}
 }
 
@@ -18641,7 +18792,7 @@ type MockPlaybackStore_GetPlaybackProgress_Call struct {
 // GetPlaybackProgress is a helper method to define mock.On call
 //   - userID string
 //   - bookNumericID int
-func (_e *MockPlaybackStore_Expecter) GetPlaybackProgress(userID interface{}, bookNumericID interface{}) *MockPlaybackStore_GetPlaybackProgress_Call {
+func (_e *MockPlaybackStore_Expecter) GetPlaybackProgress(userID any, bookNumericID any) *MockPlaybackStore_GetPlaybackProgress_Call {
 	return &MockPlaybackStore_GetPlaybackProgress_Call{Call: _e.mock.On("GetPlaybackProgress", userID, bookNumericID)}
 }
 
@@ -18708,7 +18859,7 @@ type MockPlaybackStore_GetUserStats_Call struct {
 
 // GetUserStats is a helper method to define mock.On call
 //   - userID string
-func (_e *MockPlaybackStore_Expecter) GetUserStats(userID interface{}) *MockPlaybackStore_GetUserStats_Call {
+func (_e *MockPlaybackStore_Expecter) GetUserStats(userID any) *MockPlaybackStore_GetUserStats_Call {
 	return &MockPlaybackStore_GetUserStats_Call{Call: _e.mock.On("GetUserStats", userID)}
 }
 
@@ -18760,7 +18911,7 @@ type MockPlaybackStore_IncrementBookPlayStats_Call struct {
 // IncrementBookPlayStats is a helper method to define mock.On call
 //   - bookNumericID int
 //   - seconds int
-func (_e *MockPlaybackStore_Expecter) IncrementBookPlayStats(bookNumericID interface{}, seconds interface{}) *MockPlaybackStore_IncrementBookPlayStats_Call {
+func (_e *MockPlaybackStore_Expecter) IncrementBookPlayStats(bookNumericID any, seconds any) *MockPlaybackStore_IncrementBookPlayStats_Call {
 	return &MockPlaybackStore_IncrementBookPlayStats_Call{Call: _e.mock.On("IncrementBookPlayStats", bookNumericID, seconds)}
 }
 
@@ -18817,7 +18968,7 @@ type MockPlaybackStore_IncrementUserListenStats_Call struct {
 // IncrementUserListenStats is a helper method to define mock.On call
 //   - userID string
 //   - seconds int
-func (_e *MockPlaybackStore_Expecter) IncrementUserListenStats(userID interface{}, seconds interface{}) *MockPlaybackStore_IncrementUserListenStats_Call {
+func (_e *MockPlaybackStore_Expecter) IncrementUserListenStats(userID any, seconds any) *MockPlaybackStore_IncrementUserListenStats_Call {
 	return &MockPlaybackStore_IncrementUserListenStats_Call{Call: _e.mock.On("IncrementUserListenStats", userID, seconds)}
 }
 
@@ -18886,7 +19037,7 @@ type MockPlaybackStore_ListPlaybackEvents_Call struct {
 //   - userID string
 //   - bookNumericID int
 //   - limit int
-func (_e *MockPlaybackStore_Expecter) ListPlaybackEvents(userID interface{}, bookNumericID interface{}, limit interface{}) *MockPlaybackStore_ListPlaybackEvents_Call {
+func (_e *MockPlaybackStore_Expecter) ListPlaybackEvents(userID any, bookNumericID any, limit any) *MockPlaybackStore_ListPlaybackEvents_Call {
 	return &MockPlaybackStore_ListPlaybackEvents_Call{Call: _e.mock.On("ListPlaybackEvents", userID, bookNumericID, limit)}
 }
 
@@ -18947,7 +19098,7 @@ type MockPlaybackStore_UpdatePlaybackProgress_Call struct {
 
 // UpdatePlaybackProgress is a helper method to define mock.On call
 //   - progress *database.PlaybackProgress
-func (_e *MockPlaybackStore_Expecter) UpdatePlaybackProgress(progress interface{}) *MockPlaybackStore_UpdatePlaybackProgress_Call {
+func (_e *MockPlaybackStore_Expecter) UpdatePlaybackProgress(progress any) *MockPlaybackStore_UpdatePlaybackProgress_Call {
 	return &MockPlaybackStore_UpdatePlaybackProgress_Call{Call: _e.mock.On("UpdatePlaybackProgress", progress)}
 }
 
@@ -19025,7 +19176,7 @@ type MockSettingsStore_DeleteSetting_Call struct {
 
 // DeleteSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockSettingsStore_Expecter) DeleteSetting(key interface{}) *MockSettingsStore_DeleteSetting_Call {
+func (_e *MockSettingsStore_Expecter) DeleteSetting(key any) *MockSettingsStore_DeleteSetting_Call {
 	return &MockSettingsStore_DeleteSetting_Call{Call: _e.mock.On("DeleteSetting", key)}
 }
 
@@ -19142,7 +19293,7 @@ type MockSettingsStore_GetSetting_Call struct {
 
 // GetSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockSettingsStore_Expecter) GetSetting(key interface{}) *MockSettingsStore_GetSetting_Call {
+func (_e *MockSettingsStore_Expecter) GetSetting(key any) *MockSettingsStore_GetSetting_Call {
 	return &MockSettingsStore_GetSetting_Call{Call: _e.mock.On("GetSetting", key)}
 }
 
@@ -19196,7 +19347,7 @@ type MockSettingsStore_SetSetting_Call struct {
 //   - value string
 //   - typ string
 //   - isSecret bool
-func (_e *MockSettingsStore_Expecter) SetSetting(key interface{}, value interface{}, typ interface{}, isSecret interface{}) *MockSettingsStore_SetSetting_Call {
+func (_e *MockSettingsStore_Expecter) SetSetting(key any, value any, typ any, isSecret any) *MockSettingsStore_SetSetting_Call {
 	return &MockSettingsStore_SetSetting_Call{Call: _e.mock.On("SetSetting", key, value, typ, isSecret)}
 }
 
@@ -19463,7 +19614,7 @@ type MockStatsStore_GetBookCountsByLocation_Call struct {
 
 // GetBookCountsByLocation is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStatsStore_Expecter) GetBookCountsByLocation(rootDir interface{}) *MockStatsStore_GetBookCountsByLocation_Call {
+func (_e *MockStatsStore_Expecter) GetBookCountsByLocation(rootDir any) *MockStatsStore_GetBookCountsByLocation_Call {
 	return &MockStatsStore_GetBookCountsByLocation_Call{Call: _e.mock.On("GetBookCountsByLocation", rootDir)}
 }
 
@@ -19529,7 +19680,7 @@ type MockStatsStore_GetBookSizesByLocation_Call struct {
 
 // GetBookSizesByLocation is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStatsStore_Expecter) GetBookSizesByLocation(rootDir interface{}) *MockStatsStore_GetBookSizesByLocation_Call {
+func (_e *MockStatsStore_Expecter) GetBookSizesByLocation(rootDir any) *MockStatsStore_GetBookSizesByLocation_Call {
 	return &MockStatsStore_GetBookSizesByLocation_Call{Call: _e.mock.On("GetBookSizesByLocation", rootDir)}
 }
 
@@ -19657,7 +19808,7 @@ type MockStatsStore_SetRootDir_Call struct {
 
 // SetRootDir is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStatsStore_Expecter) SetRootDir(rootDir interface{}) *MockStatsStore_SetRootDir_Call {
+func (_e *MockStatsStore_Expecter) SetRootDir(rootDir any) *MockStatsStore_SetRootDir_Call {
 	return &MockStatsStore_SetRootDir_Call{Call: _e.mock.On("SetRootDir", rootDir)}
 }
 
@@ -19845,7 +19996,7 @@ type MockMaintenanceStore_MarkNeedsRescan_Call struct {
 
 // MarkNeedsRescan is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMaintenanceStore_Expecter) MarkNeedsRescan(bookID interface{}) *MockMaintenanceStore_MarkNeedsRescan_Call {
+func (_e *MockMaintenanceStore_Expecter) MarkNeedsRescan(bookID any) *MockMaintenanceStore_MarkNeedsRescan_Call {
 	return &MockMaintenanceStore_MarkNeedsRescan_Call{Call: _e.mock.On("MarkNeedsRescan", bookID)}
 }
 
@@ -19942,7 +20093,7 @@ type MockMaintenanceStore_UpdateScanCache_Call struct {
 //   - bookID string
 //   - mtime int64
 //   - size int64
-func (_e *MockMaintenanceStore_Expecter) UpdateScanCache(bookID interface{}, mtime interface{}, size interface{}) *MockMaintenanceStore_UpdateScanCache_Call {
+func (_e *MockMaintenanceStore_Expecter) UpdateScanCache(bookID any, mtime any, size any) *MockMaintenanceStore_UpdateScanCache_Call {
 	return &MockMaintenanceStore_UpdateScanCache_Call{Call: _e.mock.On("UpdateScanCache", bookID, mtime, size)}
 }
 
@@ -20032,7 +20183,7 @@ type MockSystemActivityStore_AddSystemActivityLog_Call struct {
 //   - source string
 //   - level string
 //   - message string
-func (_e *MockSystemActivityStore_Expecter) AddSystemActivityLog(source interface{}, level interface{}, message interface{}) *MockSystemActivityStore_AddSystemActivityLog_Call {
+func (_e *MockSystemActivityStore_Expecter) AddSystemActivityLog(source any, level any, message any) *MockSystemActivityStore_AddSystemActivityLog_Call {
 	return &MockSystemActivityStore_AddSystemActivityLog_Call{Call: _e.mock.On("AddSystemActivityLog", source, level, message)}
 }
 
@@ -20105,7 +20256,7 @@ type MockSystemActivityStore_GetSystemActivityLogs_Call struct {
 // GetSystemActivityLogs is a helper method to define mock.On call
 //   - source string
 //   - limit int
-func (_e *MockSystemActivityStore_Expecter) GetSystemActivityLogs(source interface{}, limit interface{}) *MockSystemActivityStore_GetSystemActivityLogs_Call {
+func (_e *MockSystemActivityStore_Expecter) GetSystemActivityLogs(source any, limit any) *MockSystemActivityStore_GetSystemActivityLogs_Call {
 	return &MockSystemActivityStore_GetSystemActivityLogs_Call{Call: _e.mock.On("GetSystemActivityLogs", source, limit)}
 }
 
@@ -20170,7 +20321,7 @@ type MockSystemActivityStore_PruneSystemActivityLogs_Call struct {
 
 // PruneSystemActivityLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockSystemActivityStore_Expecter) PruneSystemActivityLogs(olderThan interface{}) *MockSystemActivityStore_PruneSystemActivityLogs_Call {
+func (_e *MockSystemActivityStore_Expecter) PruneSystemActivityLogs(olderThan any) *MockSystemActivityStore_PruneSystemActivityLogs_Call {
 	return &MockSystemActivityStore_PruneSystemActivityLogs_Call{Call: _e.mock.On("PruneSystemActivityLogs", olderThan)}
 }
 
@@ -20248,7 +20399,7 @@ type MockRejectedMetadataStore_AddMetadataRejection_Call struct {
 
 // AddMetadataRejection is a helper method to define mock.On call
 //   - r database.MetadataRejection
-func (_e *MockRejectedMetadataStore_Expecter) AddMetadataRejection(r interface{}) *MockRejectedMetadataStore_AddMetadataRejection_Call {
+func (_e *MockRejectedMetadataStore_Expecter) AddMetadataRejection(r any) *MockRejectedMetadataStore_AddMetadataRejection_Call {
 	return &MockRejectedMetadataStore_AddMetadataRejection_Call{Call: _e.mock.On("AddMetadataRejection", r)}
 }
 
@@ -20299,7 +20450,7 @@ type MockRejectedMetadataStore_DeleteMetadataRejections_Call struct {
 
 // DeleteMetadataRejections is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockRejectedMetadataStore_Expecter) DeleteMetadataRejections(bookID interface{}) *MockRejectedMetadataStore_DeleteMetadataRejections_Call {
+func (_e *MockRejectedMetadataStore_Expecter) DeleteMetadataRejections(bookID any) *MockRejectedMetadataStore_DeleteMetadataRejections_Call {
 	return &MockRejectedMetadataStore_DeleteMetadataRejections_Call{Call: _e.mock.On("DeleteMetadataRejections", bookID)}
 }
 
@@ -20361,7 +20512,7 @@ type MockRejectedMetadataStore_GetMetadataRejections_Call struct {
 
 // GetMetadataRejections is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockRejectedMetadataStore_Expecter) GetMetadataRejections(bookID interface{}) *MockRejectedMetadataStore_GetMetadataRejections_Call {
+func (_e *MockRejectedMetadataStore_Expecter) GetMetadataRejections(bookID any) *MockRejectedMetadataStore_GetMetadataRejections_Call {
 	return &MockRejectedMetadataStore_GetMetadataRejections_Call{Call: _e.mock.On("GetMetadataRejections", bookID)}
 }
 
@@ -20442,7 +20593,7 @@ type MockOperationStore_AddOperationLog_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockOperationStore_Expecter) AddOperationLog(operationID interface{}, level interface{}, message interface{}, details interface{}) *MockOperationStore_AddOperationLog_Call {
+func (_e *MockOperationStore_Expecter) AddOperationLog(operationID any, level any, message any, details any) *MockOperationStore_AddOperationLog_Call {
 	return &MockOperationStore_AddOperationLog_Call{Call: _e.mock.On("AddOperationLog", operationID, level, message, details)}
 }
 
@@ -20521,7 +20672,7 @@ type MockOperationStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockOperationStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockOperationStore_CreateOperation_Call {
+func (_e *MockOperationStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockOperationStore_CreateOperation_Call {
 	return &MockOperationStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -20582,7 +20733,7 @@ type MockOperationStore_CreateOperationChange_Call struct {
 
 // CreateOperationChange is a helper method to define mock.On call
 //   - change *database.OperationChange
-func (_e *MockOperationStore_Expecter) CreateOperationChange(change interface{}) *MockOperationStore_CreateOperationChange_Call {
+func (_e *MockOperationStore_Expecter) CreateOperationChange(change any) *MockOperationStore_CreateOperationChange_Call {
 	return &MockOperationStore_CreateOperationChange_Call{Call: _e.mock.On("CreateOperationChange", change)}
 }
 
@@ -20633,7 +20784,7 @@ type MockOperationStore_CreateOperationResult_Call struct {
 
 // CreateOperationResult is a helper method to define mock.On call
 //   - result *database.OperationResult
-func (_e *MockOperationStore_Expecter) CreateOperationResult(result interface{}) *MockOperationStore_CreateOperationResult_Call {
+func (_e *MockOperationStore_Expecter) CreateOperationResult(result any) *MockOperationStore_CreateOperationResult_Call {
 	return &MockOperationStore_CreateOperationResult_Call{Call: _e.mock.On("CreateOperationResult", result)}
 }
 
@@ -20684,7 +20835,7 @@ type MockOperationStore_DeleteOperationState_Call struct {
 
 // DeleteOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationStore_Expecter) DeleteOperationState(opID interface{}) *MockOperationStore_DeleteOperationState_Call {
+func (_e *MockOperationStore_Expecter) DeleteOperationState(opID any) *MockOperationStore_DeleteOperationState_Call {
 	return &MockOperationStore_DeleteOperationState_Call{Call: _e.mock.On("DeleteOperationState", opID)}
 }
 
@@ -20707,6 +20858,57 @@ func (_c *MockOperationStore_DeleteOperationState_Call) Return(err error) *MockO
 }
 
 func (_c *MockOperationStore_DeleteOperationState_Call) RunAndReturn(run func(opID string) error) *MockOperationStore_DeleteOperationState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteOperationWithLogs provides a mock function for the type MockOperationStore
+func (_mock *MockOperationStore) DeleteOperationWithLogs(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOperationWithLogs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOperationStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
+type MockOperationStore_DeleteOperationWithLogs_Call struct {
+	*mock.Call
+}
+
+// DeleteOperationWithLogs is a helper method to define mock.On call
+//   - id string
+func (_e *MockOperationStore_Expecter) DeleteOperationWithLogs(id any) *MockOperationStore_DeleteOperationWithLogs_Call {
+	return &MockOperationStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
+}
+
+func (_c *MockOperationStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockOperationStore_DeleteOperationWithLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationStore_DeleteOperationWithLogs_Call) Return(err error) *MockOperationStore_DeleteOperationWithLogs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOperationStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(id string) error) *MockOperationStore_DeleteOperationWithLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -20744,7 +20946,7 @@ type MockOperationStore_DeleteOperationsByStatus_Call struct {
 
 // DeleteOperationsByStatus is a helper method to define mock.On call
 //   - statuses []string
-func (_e *MockOperationStore_Expecter) DeleteOperationsByStatus(statuses interface{}) *MockOperationStore_DeleteOperationsByStatus_Call {
+func (_e *MockOperationStore_Expecter) DeleteOperationsByStatus(statuses any) *MockOperationStore_DeleteOperationsByStatus_Call {
 	return &MockOperationStore_DeleteOperationsByStatus_Call{Call: _e.mock.On("DeleteOperationsByStatus", statuses)}
 }
 
@@ -20767,51 +20969,6 @@ func (_c *MockOperationStore_DeleteOperationsByStatus_Call) Return(n int, err er
 }
 
 func (_c *MockOperationStore_DeleteOperationsByStatus_Call) RunAndReturn(run func(statuses []string) (int, error)) *MockOperationStore_DeleteOperationsByStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteOperationWithLogs provides a mock function for the type MockOperationStore
-func (_mock *MockOperationStore) DeleteOperationWithLogs(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteOperationWithLogs")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOperationStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
-type MockOperationStore_DeleteOperationWithLogs_Call struct {
-	*mock.Call
-}
-
-// DeleteOperationWithLogs is a helper method to define mock.On call
-//   - id string
-func (_e *MockOperationStore_Expecter) DeleteOperationWithLogs(id interface{}) *MockOperationStore_DeleteOperationWithLogs_Call {
-	return &MockOperationStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
-}
-
-func (_c *MockOperationStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockOperationStore_DeleteOperationWithLogs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockOperationStore_DeleteOperationWithLogs_Call) Return(err error) *MockOperationStore_DeleteOperationWithLogs_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOperationStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(string) error) *MockOperationStore_DeleteOperationWithLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -20851,7 +21008,7 @@ type MockOperationStore_GetBookChanges_Call struct {
 
 // GetBookChanges is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOperationStore_Expecter) GetBookChanges(bookID interface{}) *MockOperationStore_GetBookChanges_Call {
+func (_e *MockOperationStore_Expecter) GetBookChanges(bookID any) *MockOperationStore_GetBookChanges_Call {
 	return &MockOperationStore_GetBookChanges_Call{Call: _e.mock.On("GetBookChanges", bookID)}
 }
 
@@ -20968,7 +21125,7 @@ type MockOperationStore_GetOperationByID_Call struct {
 
 // GetOperationByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationStore_Expecter) GetOperationByID(id interface{}) *MockOperationStore_GetOperationByID_Call {
+func (_e *MockOperationStore_Expecter) GetOperationByID(id any) *MockOperationStore_GetOperationByID_Call {
 	return &MockOperationStore_GetOperationByID_Call{Call: _e.mock.On("GetOperationByID", id)}
 }
 
@@ -21030,7 +21187,7 @@ type MockOperationStore_GetOperationChanges_Call struct {
 
 // GetOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationStore_Expecter) GetOperationChanges(operationID interface{}) *MockOperationStore_GetOperationChanges_Call {
+func (_e *MockOperationStore_Expecter) GetOperationChanges(operationID any) *MockOperationStore_GetOperationChanges_Call {
 	return &MockOperationStore_GetOperationChanges_Call{Call: _e.mock.On("GetOperationChanges", operationID)}
 }
 
@@ -21092,7 +21249,7 @@ type MockOperationStore_GetOperationLogs_Call struct {
 
 // GetOperationLogs is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationStore_Expecter) GetOperationLogs(operationID interface{}) *MockOperationStore_GetOperationLogs_Call {
+func (_e *MockOperationStore_Expecter) GetOperationLogs(operationID any) *MockOperationStore_GetOperationLogs_Call {
 	return &MockOperationStore_GetOperationLogs_Call{Call: _e.mock.On("GetOperationLogs", operationID)}
 }
 
@@ -21154,7 +21311,7 @@ type MockOperationStore_GetOperationParams_Call struct {
 
 // GetOperationParams is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationStore_Expecter) GetOperationParams(opID interface{}) *MockOperationStore_GetOperationParams_Call {
+func (_e *MockOperationStore_Expecter) GetOperationParams(opID any) *MockOperationStore_GetOperationParams_Call {
 	return &MockOperationStore_GetOperationParams_Call{Call: _e.mock.On("GetOperationParams", opID)}
 }
 
@@ -21216,7 +21373,7 @@ type MockOperationStore_GetOperationResults_Call struct {
 
 // GetOperationResults is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationStore_Expecter) GetOperationResults(operationID interface{}) *MockOperationStore_GetOperationResults_Call {
+func (_e *MockOperationStore_Expecter) GetOperationResults(operationID any) *MockOperationStore_GetOperationResults_Call {
 	return &MockOperationStore_GetOperationResults_Call{Call: _e.mock.On("GetOperationResults", operationID)}
 }
 
@@ -21286,7 +21443,7 @@ type MockOperationStore_GetOperationResultsPage_Call struct {
 //   - operationID string
 //   - limit int
 //   - offset int
-func (_e *MockOperationStore_Expecter) GetOperationResultsPage(operationID interface{}, limit interface{}, offset interface{}) *MockOperationStore_GetOperationResultsPage_Call {
+func (_e *MockOperationStore_Expecter) GetOperationResultsPage(operationID any, limit any, offset any) *MockOperationStore_GetOperationResultsPage_Call {
 	return &MockOperationStore_GetOperationResultsPage_Call{Call: _e.mock.On("GetOperationResultsPage", operationID, limit, offset)}
 }
 
@@ -21358,7 +21515,7 @@ type MockOperationStore_GetOperationState_Call struct {
 
 // GetOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationStore_Expecter) GetOperationState(opID interface{}) *MockOperationStore_GetOperationState_Call {
+func (_e *MockOperationStore_Expecter) GetOperationState(opID any) *MockOperationStore_GetOperationState_Call {
 	return &MockOperationStore_GetOperationState_Call{Call: _e.mock.On("GetOperationState", opID)}
 }
 
@@ -21420,7 +21577,7 @@ type MockOperationStore_GetOperationSummaryLog_Call struct {
 
 // GetOperationSummaryLog is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationStore_Expecter) GetOperationSummaryLog(id interface{}) *MockOperationStore_GetOperationSummaryLog_Call {
+func (_e *MockOperationStore_Expecter) GetOperationSummaryLog(id any) *MockOperationStore_GetOperationSummaryLog_Call {
 	return &MockOperationStore_GetOperationSummaryLog_Call{Call: _e.mock.On("GetOperationSummaryLog", id)}
 }
 
@@ -21482,7 +21639,7 @@ type MockOperationStore_GetRecentCompletedOperations_Call struct {
 
 // GetRecentCompletedOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockOperationStore_Expecter) GetRecentCompletedOperations(limit interface{}) *MockOperationStore_GetRecentCompletedOperations_Call {
+func (_e *MockOperationStore_Expecter) GetRecentCompletedOperations(limit any) *MockOperationStore_GetRecentCompletedOperations_Call {
 	return &MockOperationStore_GetRecentCompletedOperations_Call{Call: _e.mock.On("GetRecentCompletedOperations", limit)}
 }
 
@@ -21544,7 +21701,7 @@ type MockOperationStore_GetRecentOperations_Call struct {
 
 // GetRecentOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockOperationStore_Expecter) GetRecentOperations(limit interface{}) *MockOperationStore_GetRecentOperations_Call {
+func (_e *MockOperationStore_Expecter) GetRecentOperations(limit any) *MockOperationStore_GetRecentOperations_Call {
 	return &MockOperationStore_GetRecentOperations_Call{Call: _e.mock.On("GetRecentOperations", limit)}
 }
 
@@ -21607,7 +21764,7 @@ type MockOperationStore_ListOperationSummaryLogs_Call struct {
 // ListOperationSummaryLogs is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationStore_Expecter) ListOperationSummaryLogs(limit interface{}, offset interface{}) *MockOperationStore_ListOperationSummaryLogs_Call {
+func (_e *MockOperationStore_Expecter) ListOperationSummaryLogs(limit any, offset any) *MockOperationStore_ListOperationSummaryLogs_Call {
 	return &MockOperationStore_ListOperationSummaryLogs_Call{Call: _e.mock.On("ListOperationSummaryLogs", limit, offset)}
 }
 
@@ -21681,7 +21838,7 @@ type MockOperationStore_ListOperations_Call struct {
 // ListOperations is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationStore_Expecter) ListOperations(limit interface{}, offset interface{}) *MockOperationStore_ListOperations_Call {
+func (_e *MockOperationStore_Expecter) ListOperations(limit any, offset any) *MockOperationStore_ListOperations_Call {
 	return &MockOperationStore_ListOperations_Call{Call: _e.mock.On("ListOperations", limit, offset)}
 }
 
@@ -21746,7 +21903,7 @@ type MockOperationStore_PruneOperationChanges_Call struct {
 
 // PruneOperationChanges is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockOperationStore_Expecter) PruneOperationChanges(olderThan interface{}) *MockOperationStore_PruneOperationChanges_Call {
+func (_e *MockOperationStore_Expecter) PruneOperationChanges(olderThan any) *MockOperationStore_PruneOperationChanges_Call {
 	return &MockOperationStore_PruneOperationChanges_Call{Call: _e.mock.On("PruneOperationChanges", olderThan)}
 }
 
@@ -21806,7 +21963,7 @@ type MockOperationStore_PruneOperationLogs_Call struct {
 
 // PruneOperationLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockOperationStore_Expecter) PruneOperationLogs(olderThan interface{}) *MockOperationStore_PruneOperationLogs_Call {
+func (_e *MockOperationStore_Expecter) PruneOperationLogs(olderThan any) *MockOperationStore_PruneOperationLogs_Call {
 	return &MockOperationStore_PruneOperationLogs_Call{Call: _e.mock.On("PruneOperationLogs", olderThan)}
 }
 
@@ -21857,7 +22014,7 @@ type MockOperationStore_RevertOperationChanges_Call struct {
 
 // RevertOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationStore_Expecter) RevertOperationChanges(operationID interface{}) *MockOperationStore_RevertOperationChanges_Call {
+func (_e *MockOperationStore_Expecter) RevertOperationChanges(operationID any) *MockOperationStore_RevertOperationChanges_Call {
 	return &MockOperationStore_RevertOperationChanges_Call{Call: _e.mock.On("RevertOperationChanges", operationID)}
 }
 
@@ -21909,7 +22066,7 @@ type MockOperationStore_SaveOperationParams_Call struct {
 // SaveOperationParams is a helper method to define mock.On call
 //   - opID string
 //   - params []byte
-func (_e *MockOperationStore_Expecter) SaveOperationParams(opID interface{}, params interface{}) *MockOperationStore_SaveOperationParams_Call {
+func (_e *MockOperationStore_Expecter) SaveOperationParams(opID any, params any) *MockOperationStore_SaveOperationParams_Call {
 	return &MockOperationStore_SaveOperationParams_Call{Call: _e.mock.On("SaveOperationParams", opID, params)}
 }
 
@@ -21966,7 +22123,7 @@ type MockOperationStore_SaveOperationState_Call struct {
 // SaveOperationState is a helper method to define mock.On call
 //   - opID string
 //   - state []byte
-func (_e *MockOperationStore_Expecter) SaveOperationState(opID interface{}, state interface{}) *MockOperationStore_SaveOperationState_Call {
+func (_e *MockOperationStore_Expecter) SaveOperationState(opID any, state any) *MockOperationStore_SaveOperationState_Call {
 	return &MockOperationStore_SaveOperationState_Call{Call: _e.mock.On("SaveOperationState", opID, state)}
 }
 
@@ -22022,7 +22179,7 @@ type MockOperationStore_SaveOperationSummaryLog_Call struct {
 
 // SaveOperationSummaryLog is a helper method to define mock.On call
 //   - op *database.OperationSummaryLog
-func (_e *MockOperationStore_Expecter) SaveOperationSummaryLog(op interface{}) *MockOperationStore_SaveOperationSummaryLog_Call {
+func (_e *MockOperationStore_Expecter) SaveOperationSummaryLog(op any) *MockOperationStore_SaveOperationSummaryLog_Call {
 	return &MockOperationStore_SaveOperationSummaryLog_Call{Call: _e.mock.On("SaveOperationSummaryLog", op)}
 }
 
@@ -22074,7 +22231,7 @@ type MockOperationStore_UpdateOperationError_Call struct {
 // UpdateOperationError is a helper method to define mock.On call
 //   - id string
 //   - errorMessage string
-func (_e *MockOperationStore_Expecter) UpdateOperationError(id interface{}, errorMessage interface{}) *MockOperationStore_UpdateOperationError_Call {
+func (_e *MockOperationStore_Expecter) UpdateOperationError(id any, errorMessage any) *MockOperationStore_UpdateOperationError_Call {
 	return &MockOperationStore_UpdateOperationError_Call{Call: _e.mock.On("UpdateOperationError", id, errorMessage)}
 }
 
@@ -22131,7 +22288,7 @@ type MockOperationStore_UpdateOperationResultData_Call struct {
 // UpdateOperationResultData is a helper method to define mock.On call
 //   - id string
 //   - resultData string
-func (_e *MockOperationStore_Expecter) UpdateOperationResultData(id interface{}, resultData interface{}) *MockOperationStore_UpdateOperationResultData_Call {
+func (_e *MockOperationStore_Expecter) UpdateOperationResultData(id any, resultData any) *MockOperationStore_UpdateOperationResultData_Call {
 	return &MockOperationStore_UpdateOperationResultData_Call{Call: _e.mock.On("UpdateOperationResultData", id, resultData)}
 }
 
@@ -22191,7 +22348,7 @@ type MockOperationStore_UpdateOperationStatus_Call struct {
 //   - progress int
 //   - total int
 //   - message string
-func (_e *MockOperationStore_Expecter) UpdateOperationStatus(id interface{}, status interface{}, progress interface{}, total interface{}, message interface{}) *MockOperationStore_UpdateOperationStatus_Call {
+func (_e *MockOperationStore_Expecter) UpdateOperationStatus(id any, status any, progress any, total any, message any) *MockOperationStore_UpdateOperationStatus_Call {
 	return &MockOperationStore_UpdateOperationStatus_Call{Call: _e.mock.On("UpdateOperationStatus", id, status, progress, total, message)}
 }
 
@@ -22265,6 +22422,63 @@ func (_m *MockOpsV2Store) EXPECT() *MockOpsV2Store_Expecter {
 	return &MockOpsV2Store_Expecter{mock: &_m.Mock}
 }
 
+// AddToBatchBucket provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) AddToBatchBucket(opType string, sub database.OpSubject) error {
+	ret := _mock.Called(opType, sub)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddToBatchBucket")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, database.OpSubject) error); ok {
+		r0 = returnFunc(opType, sub)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOpsV2Store_AddToBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBatchBucket'
+type MockOpsV2Store_AddToBatchBucket_Call struct {
+	*mock.Call
+}
+
+// AddToBatchBucket is a helper method to define mock.On call
+//   - opType string
+//   - sub database.OpSubject
+func (_e *MockOpsV2Store_Expecter) AddToBatchBucket(opType any, sub any) *MockOpsV2Store_AddToBatchBucket_Call {
+	return &MockOpsV2Store_AddToBatchBucket_Call{Call: _e.mock.On("AddToBatchBucket", opType, sub)}
+}
+
+func (_c *MockOpsV2Store_AddToBatchBucket_Call) Run(run func(opType string, sub database.OpSubject)) *MockOpsV2Store_AddToBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 database.OpSubject
+		if args[1] != nil {
+			arg1 = args[1].(database.OpSubject)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_AddToBatchBucket_Call) Return(err error) *MockOpsV2Store_AddToBatchBucket_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_AddToBatchBucket_Call) RunAndReturn(run func(opType string, sub database.OpSubject) error) *MockOpsV2Store_AddToBatchBucket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AppendOpLogsV2 provides a mock function for the type MockOpsV2Store
 func (_mock *MockOpsV2Store) AppendOpLogsV2(rows []database.OpLogV2Row) error {
 	ret := _mock.Called(rows)
@@ -22289,7 +22503,7 @@ type MockOpsV2Store_AppendOpLogsV2_Call struct {
 
 // AppendOpLogsV2 is a helper method to define mock.On call
 //   - rows []database.OpLogV2Row
-func (_e *MockOpsV2Store_Expecter) AppendOpLogsV2(rows interface{}) *MockOpsV2Store_AppendOpLogsV2_Call {
+func (_e *MockOpsV2Store_Expecter) AppendOpLogsV2(rows any) *MockOpsV2Store_AppendOpLogsV2_Call {
 	return &MockOpsV2Store_AppendOpLogsV2_Call{Call: _e.mock.On("AppendOpLogsV2", rows)}
 }
 
@@ -22312,6 +22526,123 @@ func (_c *MockOpsV2Store_AppendOpLogsV2_Call) Return(err error) *MockOpsV2Store_
 }
 
 func (_c *MockOpsV2Store_AppendOpLogsV2_Call) RunAndReturn(run func(rows []database.OpLogV2Row) error) *MockOpsV2Store_AppendOpLogsV2_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// BumpDepRev provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) BumpDepRev(sub database.OpSubject) (uint64, error) {
+	ret := _mock.Called(sub)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BumpDepRev")
+	}
+
+	var r0 uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
+		return returnFunc(sub)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
+		r0 = returnFunc(sub)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
+		r1 = returnFunc(sub)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOpsV2Store_BumpDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BumpDepRev'
+type MockOpsV2Store_BumpDepRev_Call struct {
+	*mock.Call
+}
+
+// BumpDepRev is a helper method to define mock.On call
+//   - sub database.OpSubject
+func (_e *MockOpsV2Store_Expecter) BumpDepRev(sub any) *MockOpsV2Store_BumpDepRev_Call {
+	return &MockOpsV2Store_BumpDepRev_Call{Call: _e.mock.On("BumpDepRev", sub)}
+}
+
+func (_c *MockOpsV2Store_BumpDepRev_Call) Run(run func(sub database.OpSubject)) *MockOpsV2Store_BumpDepRev_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_BumpDepRev_Call) Return(v uint64, err error) *MockOpsV2Store_BumpDepRev_Call {
+	_c.Call.Return(v, err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_BumpDepRev_Call) RunAndReturn(run func(sub database.OpSubject) (uint64, error)) *MockOpsV2Store_BumpDepRev_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ClearBatchBucket provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) ClearBatchBucket(opType string, subs []database.OpSubject) error {
+	ret := _mock.Called(opType, subs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClearBatchBucket")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []database.OpSubject) error); ok {
+		r0 = returnFunc(opType, subs)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOpsV2Store_ClearBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearBatchBucket'
+type MockOpsV2Store_ClearBatchBucket_Call struct {
+	*mock.Call
+}
+
+// ClearBatchBucket is a helper method to define mock.On call
+//   - opType string
+//   - subs []database.OpSubject
+func (_e *MockOpsV2Store_Expecter) ClearBatchBucket(opType any, subs any) *MockOpsV2Store_ClearBatchBucket_Call {
+	return &MockOpsV2Store_ClearBatchBucket_Call{Call: _e.mock.On("ClearBatchBucket", opType, subs)}
+}
+
+func (_c *MockOpsV2Store_ClearBatchBucket_Call) Run(run func(opType string, subs []database.OpSubject)) *MockOpsV2Store_ClearBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []database.OpSubject
+		if args[1] != nil {
+			arg1 = args[1].([]database.OpSubject)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_ClearBatchBucket_Call) Return(err error) *MockOpsV2Store_ClearBatchBucket_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_ClearBatchBucket_Call) RunAndReturn(run func(opType string, subs []database.OpSubject) error) *MockOpsV2Store_ClearBatchBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -22349,7 +22680,7 @@ type MockOpsV2Store_CountRunningByPluginV2_Call struct {
 
 // CountRunningByPluginV2 is a helper method to define mock.On call
 //   - plugin string
-func (_e *MockOpsV2Store_Expecter) CountRunningByPluginV2(plugin interface{}) *MockOpsV2Store_CountRunningByPluginV2_Call {
+func (_e *MockOpsV2Store_Expecter) CountRunningByPluginV2(plugin any) *MockOpsV2Store_CountRunningByPluginV2_Call {
 	return &MockOpsV2Store_CountRunningByPluginV2_Call{Call: _e.mock.On("CountRunningByPluginV2", plugin)}
 }
 
@@ -22400,7 +22731,7 @@ type MockOpsV2Store_DeleteOpStateV2_Call struct {
 
 // DeleteOpStateV2 is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOpsV2Store_Expecter) DeleteOpStateV2(opID interface{}) *MockOpsV2Store_DeleteOpStateV2_Call {
+func (_e *MockOpsV2Store_Expecter) DeleteOpStateV2(opID any) *MockOpsV2Store_DeleteOpStateV2_Call {
 	return &MockOpsV2Store_DeleteOpStateV2_Call{Call: _e.mock.On("DeleteOpStateV2", opID)}
 }
 
@@ -22451,7 +22782,7 @@ type MockOpsV2Store_DeleteOrphanOpDefsV2_Call struct {
 
 // DeleteOrphanOpDefsV2 is a helper method to define mock.On call
 //   - keepIDs []string
-func (_e *MockOpsV2Store_Expecter) DeleteOrphanOpDefsV2(keepIDs interface{}) *MockOpsV2Store_DeleteOrphanOpDefsV2_Call {
+func (_e *MockOpsV2Store_Expecter) DeleteOrphanOpDefsV2(keepIDs any) *MockOpsV2Store_DeleteOrphanOpDefsV2_Call {
 	return &MockOpsV2Store_DeleteOrphanOpDefsV2_Call{Call: _e.mock.On("DeleteOrphanOpDefsV2", keepIDs)}
 }
 
@@ -22474,74 +22805,6 @@ func (_c *MockOpsV2Store_DeleteOrphanOpDefsV2_Call) Return(err error) *MockOpsV2
 }
 
 func (_c *MockOpsV2Store_DeleteOrphanOpDefsV2_Call) RunAndReturn(run func(keepIDs []string) error) *MockOpsV2Store_DeleteOrphanOpDefsV2_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOpLogsV2 provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) GetOpLogsV2(opID string, limit int) ([]database.OpLogV2Row, error) {
-	ret := _mock.Called(opID, limit)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOpLogsV2")
-	}
-
-	var r0 []database.OpLogV2Row
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.OpLogV2Row, error)); ok {
-		return returnFunc(opID, limit)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, int) []database.OpLogV2Row); ok {
-		r0 = returnFunc(opID, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.OpLogV2Row)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
-		r1 = returnFunc(opID, limit)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockOpsV2Store_GetOpLogsV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOpLogsV2'
-type MockOpsV2Store_GetOpLogsV2_Call struct {
-	*mock.Call
-}
-
-// GetOpLogsV2 is a helper method to define mock.On call
-//   - opID string
-//   - limit int
-func (_e *MockOpsV2Store_Expecter) GetOpLogsV2(opID interface{}, limit interface{}) *MockOpsV2Store_GetOpLogsV2_Call {
-	return &MockOpsV2Store_GetOpLogsV2_Call{Call: _e.mock.On("GetOpLogsV2", opID, limit)}
-}
-
-func (_c *MockOpsV2Store_GetOpLogsV2_Call) Run(run func(opID string, limit int)) *MockOpsV2Store_GetOpLogsV2_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 int
-		if args[1] != nil {
-			arg1 = args[1].(int)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_GetOpLogsV2_Call) Return(opLogV2Rows []database.OpLogV2Row, err error) *MockOpsV2Store_GetOpLogsV2_Call {
-	_c.Call.Return(opLogV2Rows, err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_GetOpLogsV2_Call) RunAndReturn(run func(opID string, limit int) ([]database.OpLogV2Row, error)) *MockOpsV2Store_GetOpLogsV2_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -22579,7 +22842,7 @@ type MockOpsV2Store_GetDepRev_Call struct {
 
 // GetDepRev is a helper method to define mock.On call
 //   - sub database.OpSubject
-func (_e *MockOpsV2Store_Expecter) GetDepRev(sub interface{}) *MockOpsV2Store_GetDepRev_Call {
+func (_e *MockOpsV2Store_Expecter) GetDepRev(sub any) *MockOpsV2Store_GetDepRev_Call {
 	return &MockOpsV2Store_GetDepRev_Call{Call: _e.mock.On("GetDepRev", sub)}
 }
 
@@ -22589,139 +22852,19 @@ func (_c *MockOpsV2Store_GetDepRev_Call) Run(run func(sub database.OpSubject)) *
 		if args[0] != nil {
 			arg0 = args[0].(database.OpSubject)
 		}
-		run(arg0)
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
 
-func (_c *MockOpsV2Store_GetDepRev_Call) Return(u uint64, err error) *MockOpsV2Store_GetDepRev_Call {
-	_c.Call.Return(u, err)
+func (_c *MockOpsV2Store_GetDepRev_Call) Return(v uint64, err error) *MockOpsV2Store_GetDepRev_Call {
+	_c.Call.Return(v, err)
 	return _c
 }
 
-func (_c *MockOpsV2Store_GetDepRev_Call) RunAndReturn(run func(database.OpSubject) (uint64, error)) *MockOpsV2Store_GetDepRev_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// BumpDepRev provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) BumpDepRev(sub database.OpSubject) (uint64, error) {
-	ret := _mock.Called(sub)
-
-	if len(ret) == 0 {
-		panic("no return value specified for BumpDepRev")
-	}
-
-	var r0 uint64
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
-		return returnFunc(sub)
-	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
-		r0 = returnFunc(sub)
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
-		r1 = returnFunc(sub)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockOpsV2Store_BumpDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BumpDepRev'
-type MockOpsV2Store_BumpDepRev_Call struct {
-	*mock.Call
-}
-
-// BumpDepRev is a helper method to define mock.On call
-//   - sub database.OpSubject
-func (_e *MockOpsV2Store_Expecter) BumpDepRev(sub interface{}) *MockOpsV2Store_BumpDepRev_Call {
-	return &MockOpsV2Store_BumpDepRev_Call{Call: _e.mock.On("BumpDepRev", sub)}
-}
-
-func (_c *MockOpsV2Store_BumpDepRev_Call) Run(run func(sub database.OpSubject)) *MockOpsV2Store_BumpDepRev_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_BumpDepRev_Call) Return(u uint64, err error) *MockOpsV2Store_BumpDepRev_Call {
-	_c.Call.Return(u, err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_BumpDepRev_Call) RunAndReturn(run func(database.OpSubject) (uint64, error)) *MockOpsV2Store_BumpDepRev_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecordOpCompletion provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) RecordOpCompletion(sub database.OpSubject, opType string, fileID string, depRev uint64) error {
-	ret := _mock.Called(sub, opType, fileID, depRev)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecordOpCompletion")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string, string, uint64) error); ok {
-		r0 = returnFunc(sub, opType, fileID, depRev)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOpsV2Store_RecordOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordOpCompletion'
-type MockOpsV2Store_RecordOpCompletion_Call struct {
-	*mock.Call
-}
-
-// RecordOpCompletion is a helper method to define mock.On call
-//   - sub database.OpSubject
-//   - opType string
-//   - fileID string
-//   - depRev uint64
-func (_e *MockOpsV2Store_Expecter) RecordOpCompletion(sub interface{}, opType interface{}, fileID interface{}, depRev interface{}) *MockOpsV2Store_RecordOpCompletion_Call {
-	return &MockOpsV2Store_RecordOpCompletion_Call{Call: _e.mock.On("RecordOpCompletion", sub, opType, fileID, depRev)}
-}
-
-func (_c *MockOpsV2Store_RecordOpCompletion_Call) Run(run func(sub database.OpSubject, opType string, fileID string, depRev uint64)) *MockOpsV2Store_RecordOpCompletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 uint64
-		if args[3] != nil {
-			arg3 = args[3].(uint64)
-		}
-		run(arg0, arg1, arg2, arg3)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_RecordOpCompletion_Call) Return(err error) *MockOpsV2Store_RecordOpCompletion_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_RecordOpCompletion_Call) RunAndReturn(run func(database.OpSubject, string, string, uint64) error) *MockOpsV2Store_RecordOpCompletion_Call {
+func (_c *MockOpsV2Store_GetDepRev_Call) RunAndReturn(run func(sub database.OpSubject) (uint64, error)) *MockOpsV2Store_GetDepRev_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -22766,7 +22909,7 @@ type MockOpsV2Store_GetOpCompletion_Call struct {
 // GetOpCompletion is a helper method to define mock.On call
 //   - sub database.OpSubject
 //   - opType string
-func (_e *MockOpsV2Store_Expecter) GetOpCompletion(sub interface{}, opType interface{}) *MockOpsV2Store_GetOpCompletion_Call {
+func (_e *MockOpsV2Store_Expecter) GetOpCompletion(sub any, opType any) *MockOpsV2Store_GetOpCompletion_Call {
 	return &MockOpsV2Store_GetOpCompletion_Call{Call: _e.mock.On("GetOpCompletion", sub, opType)}
 }
 
@@ -22780,137 +22923,88 @@ func (_c *MockOpsV2Store_GetOpCompletion_Call) Run(run func(sub database.OpSubje
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
 
-func (_c *MockOpsV2Store_GetOpCompletion_Call) Return(u uint64, b bool, err error) *MockOpsV2Store_GetOpCompletion_Call {
-	_c.Call.Return(u, b, err)
+func (_c *MockOpsV2Store_GetOpCompletion_Call) Return(rev uint64, ok bool, err error) *MockOpsV2Store_GetOpCompletion_Call {
+	_c.Call.Return(rev, ok, err)
 	return _c
 }
 
-func (_c *MockOpsV2Store_GetOpCompletion_Call) RunAndReturn(run func(database.OpSubject, string) (uint64, bool, error)) *MockOpsV2Store_GetOpCompletion_Call {
+func (_c *MockOpsV2Store_GetOpCompletion_Call) RunAndReturn(run func(sub database.OpSubject, opType string) (uint64, bool, error)) *MockOpsV2Store_GetOpCompletion_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListFileCompletions provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) ListFileCompletions(sub database.OpSubject, opType string) (map[string]uint64, error) {
-	ret := _mock.Called(sub, opType)
+// GetOpLogsV2 provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) GetOpLogsV2(opID string, limit int) ([]database.OpLogV2Row, error) {
+	ret := _mock.Called(opID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for ListFileCompletions")
+		panic("no return value specified for GetOpLogsV2")
 	}
 
-	var r0 map[string]uint64
+	var r0 []database.OpLogV2Row
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (map[string]uint64, error)); ok {
-		return returnFunc(sub, opType)
+	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.OpLogV2Row, error)); ok {
+		return returnFunc(opID, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) map[string]uint64); ok {
-		r0 = returnFunc(sub, opType)
+	if returnFunc, ok := ret.Get(0).(func(string, int) []database.OpLogV2Row); ok {
+		r0 = returnFunc(opID, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]uint64)
+			r0 = ret.Get(0).([]database.OpLogV2Row)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) error); ok {
-		r1 = returnFunc(sub, opType)
+	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = returnFunc(opID, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockOpsV2Store_ListFileCompletions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFileCompletions'
-type MockOpsV2Store_ListFileCompletions_Call struct {
+// MockOpsV2Store_GetOpLogsV2_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOpLogsV2'
+type MockOpsV2Store_GetOpLogsV2_Call struct {
 	*mock.Call
 }
 
-// ListFileCompletions is a helper method to define mock.On call
-//   - sub database.OpSubject
-//   - opType string
-func (_e *MockOpsV2Store_Expecter) ListFileCompletions(sub interface{}, opType interface{}) *MockOpsV2Store_ListFileCompletions_Call {
-	return &MockOpsV2Store_ListFileCompletions_Call{Call: _e.mock.On("ListFileCompletions", sub, opType)}
+// GetOpLogsV2 is a helper method to define mock.On call
+//   - opID string
+//   - limit int
+func (_e *MockOpsV2Store_Expecter) GetOpLogsV2(opID any, limit any) *MockOpsV2Store_GetOpLogsV2_Call {
+	return &MockOpsV2Store_GetOpLogsV2_Call{Call: _e.mock.On("GetOpLogsV2", opID, limit)}
 }
 
-func (_c *MockOpsV2Store_ListFileCompletions_Call) Run(run func(sub database.OpSubject, opType string)) *MockOpsV2Store_ListFileCompletions_Call {
+func (_c *MockOpsV2Store_GetOpLogsV2_Call) Run(run func(opID string, limit int)) *MockOpsV2Store_GetOpLogsV2_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
+		var arg0 string
 		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
+			arg0 = args[0].(string)
 		}
-		var arg1 string
+		var arg1 int
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(int)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
 
-func (_c *MockOpsV2Store_ListFileCompletions_Call) Return(stringToUint64 map[string]uint64, err error) *MockOpsV2Store_ListFileCompletions_Call {
-	_c.Call.Return(stringToUint64, err)
+func (_c *MockOpsV2Store_GetOpLogsV2_Call) Return(opLogV2Rows []database.OpLogV2Row, err error) *MockOpsV2Store_GetOpLogsV2_Call {
+	_c.Call.Return(opLogV2Rows, err)
 	return _c
 }
 
-func (_c *MockOpsV2Store_ListFileCompletions_Call) RunAndReturn(run func(database.OpSubject, string) (map[string]uint64, error)) *MockOpsV2Store_ListFileCompletions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListWaitingDepsOps provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) ListWaitingDepsOps() ([]database.OperationV2Row, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListWaitingDepsOps")
-	}
-
-	var r0 []database.OperationV2Row
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.OperationV2Row, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []database.OperationV2Row); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.OperationV2Row)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockOpsV2Store_ListWaitingDepsOps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListWaitingDepsOps'
-type MockOpsV2Store_ListWaitingDepsOps_Call struct {
-	*mock.Call
-}
-
-// ListWaitingDepsOps is a helper method to define mock.On call
-func (_e *MockOpsV2Store_Expecter) ListWaitingDepsOps() *MockOpsV2Store_ListWaitingDepsOps_Call {
-	return &MockOpsV2Store_ListWaitingDepsOps_Call{Call: _e.mock.On("ListWaitingDepsOps")}
-}
-
-func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) Run(run func()) *MockOpsV2Store_ListWaitingDepsOps_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) Return(operationV2Rows []database.OperationV2Row, err error) *MockOpsV2Store_ListWaitingDepsOps_Call {
-	_c.Call.Return(operationV2Rows, err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) RunAndReturn(run func() ([]database.OperationV2Row, error)) *MockOpsV2Store_ListWaitingDepsOps_Call {
+func (_c *MockOpsV2Store_GetOpLogsV2_Call) RunAndReturn(run func(opID string, limit int) ([]database.OpLogV2Row, error)) *MockOpsV2Store_GetOpLogsV2_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -22950,7 +23044,7 @@ type MockOpsV2Store_GetOpStateV2_Call struct {
 
 // GetOpStateV2 is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOpsV2Store_Expecter) GetOpStateV2(opID interface{}) *MockOpsV2Store_GetOpStateV2_Call {
+func (_e *MockOpsV2Store_Expecter) GetOpStateV2(opID any) *MockOpsV2Store_GetOpStateV2_Call {
 	return &MockOpsV2Store_GetOpStateV2_Call{Call: _e.mock.On("GetOpStateV2", opID)}
 }
 
@@ -23012,7 +23106,7 @@ type MockOpsV2Store_GetOperationV2_Call struct {
 
 // GetOperationV2 is a helper method to define mock.On call
 //   - id string
-func (_e *MockOpsV2Store_Expecter) GetOperationV2(id interface{}) *MockOpsV2Store_GetOperationV2_Call {
+func (_e *MockOpsV2Store_Expecter) GetOperationV2(id any) *MockOpsV2Store_GetOperationV2_Call {
 	return &MockOpsV2Store_GetOperationV2_Call{Call: _e.mock.On("GetOperationV2", id)}
 }
 
@@ -23063,7 +23157,7 @@ type MockOpsV2Store_IncrementResumeCountV2_Call struct {
 
 // IncrementResumeCountV2 is a helper method to define mock.On call
 //   - id string
-func (_e *MockOpsV2Store_Expecter) IncrementResumeCountV2(id interface{}) *MockOpsV2Store_IncrementResumeCountV2_Call {
+func (_e *MockOpsV2Store_Expecter) IncrementResumeCountV2(id any) *MockOpsV2Store_IncrementResumeCountV2_Call {
 	return &MockOpsV2Store_IncrementResumeCountV2_Call{Call: _e.mock.On("IncrementResumeCountV2", id)}
 }
 
@@ -23114,7 +23208,7 @@ type MockOpsV2Store_InsertOpErrorV2_Call struct {
 
 // InsertOpErrorV2 is a helper method to define mock.On call
 //   - row database.OpErrorV2Row
-func (_e *MockOpsV2Store_Expecter) InsertOpErrorV2(row interface{}) *MockOpsV2Store_InsertOpErrorV2_Call {
+func (_e *MockOpsV2Store_Expecter) InsertOpErrorV2(row any) *MockOpsV2Store_InsertOpErrorV2_Call {
 	return &MockOpsV2Store_InsertOpErrorV2_Call{Call: _e.mock.On("InsertOpErrorV2", row)}
 }
 
@@ -23165,7 +23259,7 @@ type MockOpsV2Store_InsertOpStrikeV2_Call struct {
 
 // InsertOpStrikeV2 is a helper method to define mock.On call
 //   - row database.OpStrikeV2Row
-func (_e *MockOpsV2Store_Expecter) InsertOpStrikeV2(row interface{}) *MockOpsV2Store_InsertOpStrikeV2_Call {
+func (_e *MockOpsV2Store_Expecter) InsertOpStrikeV2(row any) *MockOpsV2Store_InsertOpStrikeV2_Call {
 	return &MockOpsV2Store_InsertOpStrikeV2_Call{Call: _e.mock.On("InsertOpStrikeV2", row)}
 }
 
@@ -23216,7 +23310,7 @@ type MockOpsV2Store_InsertOperationV2_Call struct {
 
 // InsertOperationV2 is a helper method to define mock.On call
 //   - row database.OperationV2Row
-func (_e *MockOpsV2Store_Expecter) InsertOperationV2(row interface{}) *MockOpsV2Store_InsertOperationV2_Call {
+func (_e *MockOpsV2Store_Expecter) InsertOperationV2(row any) *MockOpsV2Store_InsertOperationV2_Call {
 	return &MockOpsV2Store_InsertOperationV2_Call{Call: _e.mock.On("InsertOperationV2", row)}
 }
 
@@ -23298,6 +23392,136 @@ func (_c *MockOpsV2Store_ListActiveOperationsV2_Call) RunAndReturn(run func() ([
 	return _c
 }
 
+// ListBatchBucket provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) ListBatchBucket(opType string) ([]database.BatchBucketEntry, error) {
+	ret := _mock.Called(opType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListBatchBucket")
+	}
+
+	var r0 []database.BatchBucketEntry
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BatchBucketEntry, error)); ok {
+		return returnFunc(opType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.BatchBucketEntry); ok {
+		r0 = returnFunc(opType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BatchBucketEntry)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(opType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOpsV2Store_ListBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBatchBucket'
+type MockOpsV2Store_ListBatchBucket_Call struct {
+	*mock.Call
+}
+
+// ListBatchBucket is a helper method to define mock.On call
+//   - opType string
+func (_e *MockOpsV2Store_Expecter) ListBatchBucket(opType any) *MockOpsV2Store_ListBatchBucket_Call {
+	return &MockOpsV2Store_ListBatchBucket_Call{Call: _e.mock.On("ListBatchBucket", opType)}
+}
+
+func (_c *MockOpsV2Store_ListBatchBucket_Call) Run(run func(opType string)) *MockOpsV2Store_ListBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListBatchBucket_Call) Return(batchBucketEntrys []database.BatchBucketEntry, err error) *MockOpsV2Store_ListBatchBucket_Call {
+	_c.Call.Return(batchBucketEntrys, err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListBatchBucket_Call) RunAndReturn(run func(opType string) ([]database.BatchBucketEntry, error)) *MockOpsV2Store_ListBatchBucket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListFileCompletions provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) ListFileCompletions(sub database.OpSubject, opType string) (map[string]uint64, error) {
+	ret := _mock.Called(sub, opType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListFileCompletions")
+	}
+
+	var r0 map[string]uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (map[string]uint64, error)); ok {
+		return returnFunc(sub, opType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) map[string]uint64); ok {
+		r0 = returnFunc(sub, opType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]uint64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) error); ok {
+		r1 = returnFunc(sub, opType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOpsV2Store_ListFileCompletions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFileCompletions'
+type MockOpsV2Store_ListFileCompletions_Call struct {
+	*mock.Call
+}
+
+// ListFileCompletions is a helper method to define mock.On call
+//   - sub database.OpSubject
+//   - opType string
+func (_e *MockOpsV2Store_Expecter) ListFileCompletions(sub any, opType any) *MockOpsV2Store_ListFileCompletions_Call {
+	return &MockOpsV2Store_ListFileCompletions_Call{Call: _e.mock.On("ListFileCompletions", sub, opType)}
+}
+
+func (_c *MockOpsV2Store_ListFileCompletions_Call) Run(run func(sub database.OpSubject, opType string)) *MockOpsV2Store_ListFileCompletions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListFileCompletions_Call) Return(stringToUint64 map[string]uint64, err error) *MockOpsV2Store_ListFileCompletions_Call {
+	_c.Call.Return(stringToUint64, err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListFileCompletions_Call) RunAndReturn(run func(sub database.OpSubject, opType string) (map[string]uint64, error)) *MockOpsV2Store_ListFileCompletions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListOperationsV2Since provides a mock function for the type MockOpsV2Store
 func (_mock *MockOpsV2Store) ListOperationsV2Since(since time.Time, limit int) ([]database.OperationV2Row, error) {
 	ret := _mock.Called(since, limit)
@@ -23334,7 +23558,7 @@ type MockOpsV2Store_ListOperationsV2Since_Call struct {
 // ListOperationsV2Since is a helper method to define mock.On call
 //   - since time.Time
 //   - limit int
-func (_e *MockOpsV2Store_Expecter) ListOperationsV2Since(since interface{}, limit interface{}) *MockOpsV2Store_ListOperationsV2Since_Call {
+func (_e *MockOpsV2Store_Expecter) ListOperationsV2Since(since any, limit any) *MockOpsV2Store_ListOperationsV2Since_Call {
 	return &MockOpsV2Store_ListOperationsV2Since_Call{Call: _e.mock.On("ListOperationsV2Since", since, limit)}
 }
 
@@ -23421,6 +23645,181 @@ func (_c *MockOpsV2Store_ListQueuedOperationsV2_Call) RunAndReturn(run func() ([
 	return _c
 }
 
+// ListWaitingDepsOps provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) ListWaitingDepsOps() ([]database.OperationV2Row, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListWaitingDepsOps")
+	}
+
+	var r0 []database.OperationV2Row
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.OperationV2Row, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.OperationV2Row); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.OperationV2Row)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOpsV2Store_ListWaitingDepsOps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListWaitingDepsOps'
+type MockOpsV2Store_ListWaitingDepsOps_Call struct {
+	*mock.Call
+}
+
+// ListWaitingDepsOps is a helper method to define mock.On call
+func (_e *MockOpsV2Store_Expecter) ListWaitingDepsOps() *MockOpsV2Store_ListWaitingDepsOps_Call {
+	return &MockOpsV2Store_ListWaitingDepsOps_Call{Call: _e.mock.On("ListWaitingDepsOps")}
+}
+
+func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) Run(run func()) *MockOpsV2Store_ListWaitingDepsOps_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) Return(operationV2Rows []database.OperationV2Row, err error) *MockOpsV2Store_ListWaitingDepsOps_Call {
+	_c.Call.Return(operationV2Rows, err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_ListWaitingDepsOps_Call) RunAndReturn(run func() ([]database.OperationV2Row, error)) *MockOpsV2Store_ListWaitingDepsOps_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PromoteToQueued provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) PromoteToQueued(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PromoteToQueued")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOpsV2Store_PromoteToQueued_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PromoteToQueued'
+type MockOpsV2Store_PromoteToQueued_Call struct {
+	*mock.Call
+}
+
+// PromoteToQueued is a helper method to define mock.On call
+//   - id string
+func (_e *MockOpsV2Store_Expecter) PromoteToQueued(id any) *MockOpsV2Store_PromoteToQueued_Call {
+	return &MockOpsV2Store_PromoteToQueued_Call{Call: _e.mock.On("PromoteToQueued", id)}
+}
+
+func (_c *MockOpsV2Store_PromoteToQueued_Call) Run(run func(id string)) *MockOpsV2Store_PromoteToQueued_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_PromoteToQueued_Call) Return(err error) *MockOpsV2Store_PromoteToQueued_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_PromoteToQueued_Call) RunAndReturn(run func(id string) error) *MockOpsV2Store_PromoteToQueued_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecordOpCompletion provides a mock function for the type MockOpsV2Store
+func (_mock *MockOpsV2Store) RecordOpCompletion(sub database.OpSubject, opType string, fileID string, depRev uint64) error {
+	ret := _mock.Called(sub, opType, fileID, depRev)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecordOpCompletion")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string, string, uint64) error); ok {
+		r0 = returnFunc(sub, opType, fileID, depRev)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockOpsV2Store_RecordOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordOpCompletion'
+type MockOpsV2Store_RecordOpCompletion_Call struct {
+	*mock.Call
+}
+
+// RecordOpCompletion is a helper method to define mock.On call
+//   - sub database.OpSubject
+//   - opType string
+//   - fileID string
+//   - depRev uint64
+func (_e *MockOpsV2Store_Expecter) RecordOpCompletion(sub any, opType any, fileID any, depRev any) *MockOpsV2Store_RecordOpCompletion_Call {
+	return &MockOpsV2Store_RecordOpCompletion_Call{Call: _e.mock.On("RecordOpCompletion", sub, opType, fileID, depRev)}
+}
+
+func (_c *MockOpsV2Store_RecordOpCompletion_Call) Run(run func(sub database.OpSubject, opType string, fileID string, depRev uint64)) *MockOpsV2Store_RecordOpCompletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 uint64
+		if args[3] != nil {
+			arg3 = args[3].(uint64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOpsV2Store_RecordOpCompletion_Call) Return(err error) *MockOpsV2Store_RecordOpCompletion_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockOpsV2Store_RecordOpCompletion_Call) RunAndReturn(run func(sub database.OpSubject, opType string, fileID string, depRev uint64) error) *MockOpsV2Store_RecordOpCompletion_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetOperationV2StatusIfQueued provides a mock function for the type MockOpsV2Store
 func (_mock *MockOpsV2Store) SetOperationV2StatusIfQueued(id string, newStatus string) (bool, error) {
 	ret := _mock.Called(id, newStatus)
@@ -23455,7 +23854,7 @@ type MockOpsV2Store_SetOperationV2StatusIfQueued_Call struct {
 // SetOperationV2StatusIfQueued is a helper method to define mock.On call
 //   - id string
 //   - newStatus string
-func (_e *MockOpsV2Store_Expecter) SetOperationV2StatusIfQueued(id interface{}, newStatus interface{}) *MockOpsV2Store_SetOperationV2StatusIfQueued_Call {
+func (_e *MockOpsV2Store_Expecter) SetOperationV2StatusIfQueued(id any, newStatus any) *MockOpsV2Store_SetOperationV2StatusIfQueued_Call {
 	return &MockOpsV2Store_SetOperationV2StatusIfQueued_Call{Call: _e.mock.On("SetOperationV2StatusIfQueued", id, newStatus)}
 }
 
@@ -23512,7 +23911,7 @@ type MockOpsV2Store_UpdateOpCheckpointV2_Call struct {
 // UpdateOpCheckpointV2 is a helper method to define mock.On call
 //   - id string
 //   - newHWM int
-func (_e *MockOpsV2Store_Expecter) UpdateOpCheckpointV2(id interface{}, newHWM interface{}) *MockOpsV2Store_UpdateOpCheckpointV2_Call {
+func (_e *MockOpsV2Store_Expecter) UpdateOpCheckpointV2(id any, newHWM any) *MockOpsV2Store_UpdateOpCheckpointV2_Call {
 	return &MockOpsV2Store_UpdateOpCheckpointV2_Call{Call: _e.mock.On("UpdateOpCheckpointV2", id, newHWM)}
 }
 
@@ -23569,7 +23968,7 @@ type MockOpsV2Store_UpdateOpPhaseV2_Call struct {
 // UpdateOpPhaseV2 is a helper method to define mock.On call
 //   - id string
 //   - phase *string
-func (_e *MockOpsV2Store_Expecter) UpdateOpPhaseV2(id interface{}, phase interface{}) *MockOpsV2Store_UpdateOpPhaseV2_Call {
+func (_e *MockOpsV2Store_Expecter) UpdateOpPhaseV2(id any, phase any) *MockOpsV2Store_UpdateOpPhaseV2_Call {
 	return &MockOpsV2Store_UpdateOpPhaseV2_Call{Call: _e.mock.On("UpdateOpPhaseV2", id, phase)}
 }
 
@@ -23628,7 +24027,7 @@ type MockOpsV2Store_UpdateOpProgressV2_Call struct {
 //   - current int
 //   - total int
 //   - message string
-func (_e *MockOpsV2Store_Expecter) UpdateOpProgressV2(id interface{}, current interface{}, total interface{}, message interface{}) *MockOpsV2Store_UpdateOpProgressV2_Call {
+func (_e *MockOpsV2Store_Expecter) UpdateOpProgressV2(id any, current any, total any, message any) *MockOpsV2Store_UpdateOpProgressV2_Call {
 	return &MockOpsV2Store_UpdateOpProgressV2_Call{Call: _e.mock.On("UpdateOpProgressV2", id, current, total, message)}
 }
 
@@ -23670,7 +24069,6 @@ func (_c *MockOpsV2Store_UpdateOpProgressV2_Call) RunAndReturn(run func(id strin
 	return _c
 }
 
-// UpdateOperationV2Status provides a mock function for the type MockOpsV2Store
 // UpdateOperationV2Params provides a mock function for the type MockOpsV2Store
 func (_mock *MockOpsV2Store) UpdateOperationV2Params(id string, params []byte) error {
 	ret := _mock.Called(id, params)
@@ -23696,7 +24094,7 @@ type MockOpsV2Store_UpdateOperationV2Params_Call struct {
 // UpdateOperationV2Params is a helper method to define mock.On call
 //   - id string
 //   - params []byte
-func (_e *MockOpsV2Store_Expecter) UpdateOperationV2Params(id interface{}, params interface{}) *MockOpsV2Store_UpdateOperationV2Params_Call {
+func (_e *MockOpsV2Store_Expecter) UpdateOperationV2Params(id any, params any) *MockOpsV2Store_UpdateOperationV2Params_Call {
 	return &MockOpsV2Store_UpdateOperationV2Params_Call{Call: _e.mock.On("UpdateOperationV2Params", id, params)}
 }
 
@@ -23710,7 +24108,10 @@ func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) Run(run func(id string, p
 		if args[1] != nil {
 			arg1 = args[1].([]byte)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -23720,11 +24121,12 @@ func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) Return(err error) *MockOp
 	return _c
 }
 
-func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) RunAndReturn(run func(string, []byte) error) *MockOpsV2Store_UpdateOperationV2Params_Call {
+func (_c *MockOpsV2Store_UpdateOperationV2Params_Call) RunAndReturn(run func(id string, params []byte) error) *MockOpsV2Store_UpdateOperationV2Params_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
+// UpdateOperationV2Status provides a mock function for the type MockOpsV2Store
 func (_mock *MockOpsV2Store) UpdateOperationV2Status(id string, status string, startedAt *time.Time, completedAt *time.Time, errMsg *string) error {
 	ret := _mock.Called(id, status, startedAt, completedAt, errMsg)
 
@@ -23752,7 +24154,7 @@ type MockOpsV2Store_UpdateOperationV2Status_Call struct {
 //   - startedAt *time.Time
 //   - completedAt *time.Time
 //   - errMsg *string
-func (_e *MockOpsV2Store_Expecter) UpdateOperationV2Status(id interface{}, status interface{}, startedAt interface{}, completedAt interface{}, errMsg interface{}) *MockOpsV2Store_UpdateOperationV2Status_Call {
+func (_e *MockOpsV2Store_Expecter) UpdateOperationV2Status(id any, status any, startedAt any, completedAt any, errMsg any) *MockOpsV2Store_UpdateOperationV2Status_Call {
 	return &MockOpsV2Store_UpdateOperationV2Status_Call{Call: _e.mock.On("UpdateOperationV2Status", id, status, startedAt, completedAt, errMsg)}
 }
 
@@ -23823,7 +24225,7 @@ type MockOpsV2Store_UpsertOpDefinitionV2_Call struct {
 
 // UpsertOpDefinitionV2 is a helper method to define mock.On call
 //   - row database.OpDefinitionV2Row
-func (_e *MockOpsV2Store_Expecter) UpsertOpDefinitionV2(row interface{}) *MockOpsV2Store_UpsertOpDefinitionV2_Call {
+func (_e *MockOpsV2Store_Expecter) UpsertOpDefinitionV2(row any) *MockOpsV2Store_UpsertOpDefinitionV2_Call {
 	return &MockOpsV2Store_UpsertOpDefinitionV2_Call{Call: _e.mock.On("UpsertOpDefinitionV2", row)}
 }
 
@@ -23874,7 +24276,7 @@ type MockOpsV2Store_UpsertOpStateV2_Call struct {
 
 // UpsertOpStateV2 is a helper method to define mock.On call
 //   - row database.OpStateV2Row
-func (_e *MockOpsV2Store_Expecter) UpsertOpStateV2(row interface{}) *MockOpsV2Store_UpsertOpStateV2_Call {
+func (_e *MockOpsV2Store_Expecter) UpsertOpStateV2(row any) *MockOpsV2Store_UpsertOpStateV2_Call {
 	return &MockOpsV2Store_UpsertOpStateV2_Call{Call: _e.mock.On("UpsertOpStateV2", row)}
 }
 
@@ -23897,225 +24299,6 @@ func (_c *MockOpsV2Store_UpsertOpStateV2_Call) Return(err error) *MockOpsV2Store
 }
 
 func (_c *MockOpsV2Store_UpsertOpStateV2_Call) RunAndReturn(run func(row database.OpStateV2Row) error) *MockOpsV2Store_UpsertOpStateV2_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// PromoteToQueued provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) PromoteToQueued(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PromoteToQueued")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOpsV2Store_PromoteToQueued_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PromoteToQueued'
-type MockOpsV2Store_PromoteToQueued_Call struct {
-	*mock.Call
-}
-
-// PromoteToQueued is a helper method to define mock.On call
-//   - id string
-func (_e *MockOpsV2Store_Expecter) PromoteToQueued(id interface{}) *MockOpsV2Store_PromoteToQueued_Call {
-	return &MockOpsV2Store_PromoteToQueued_Call{Call: _e.mock.On("PromoteToQueued", id)}
-}
-
-func (_c *MockOpsV2Store_PromoteToQueued_Call) Run(run func(id string)) *MockOpsV2Store_PromoteToQueued_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_PromoteToQueued_Call) Return(err error) *MockOpsV2Store_PromoteToQueued_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_PromoteToQueued_Call) RunAndReturn(run func(id string) error) *MockOpsV2Store_PromoteToQueued_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AddToBatchBucket provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) AddToBatchBucket(opType string, sub database.OpSubject) error {
-	ret := _mock.Called(opType, sub)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddToBatchBucket")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, database.OpSubject) error); ok {
-		r0 = returnFunc(opType, sub)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOpsV2Store_AddToBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBatchBucket'
-type MockOpsV2Store_AddToBatchBucket_Call struct {
-	*mock.Call
-}
-
-// AddToBatchBucket is a helper method to define mock.On call
-//   - opType string
-//   - sub database.OpSubject
-func (_e *MockOpsV2Store_Expecter) AddToBatchBucket(opType interface{}, sub interface{}) *MockOpsV2Store_AddToBatchBucket_Call {
-	return &MockOpsV2Store_AddToBatchBucket_Call{Call: _e.mock.On("AddToBatchBucket", opType, sub)}
-}
-
-func (_c *MockOpsV2Store_AddToBatchBucket_Call) Run(run func(opType string, sub database.OpSubject)) *MockOpsV2Store_AddToBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 database.OpSubject
-		if args[1] != nil {
-			arg1 = args[1].(database.OpSubject)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_AddToBatchBucket_Call) Return(err error) *MockOpsV2Store_AddToBatchBucket_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_AddToBatchBucket_Call) RunAndReturn(run func(string, database.OpSubject) error) *MockOpsV2Store_AddToBatchBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListBatchBucket provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) ListBatchBucket(opType string) ([]database.BatchBucketEntry, error) {
-	ret := _mock.Called(opType)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListBatchBucket")
-	}
-
-	var r0 []database.BatchBucketEntry
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BatchBucketEntry, error)); ok {
-		return returnFunc(opType)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) []database.BatchBucketEntry); ok {
-		r0 = returnFunc(opType)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BatchBucketEntry)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(opType)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockOpsV2Store_ListBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBatchBucket'
-type MockOpsV2Store_ListBatchBucket_Call struct {
-	*mock.Call
-}
-
-// ListBatchBucket is a helper method to define mock.On call
-//   - opType string
-func (_e *MockOpsV2Store_Expecter) ListBatchBucket(opType interface{}) *MockOpsV2Store_ListBatchBucket_Call {
-	return &MockOpsV2Store_ListBatchBucket_Call{Call: _e.mock.On("ListBatchBucket", opType)}
-}
-
-func (_c *MockOpsV2Store_ListBatchBucket_Call) Run(run func(opType string)) *MockOpsV2Store_ListBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_ListBatchBucket_Call) Return(entries []database.BatchBucketEntry, err error) *MockOpsV2Store_ListBatchBucket_Call {
-	_c.Call.Return(entries, err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_ListBatchBucket_Call) RunAndReturn(run func(string) ([]database.BatchBucketEntry, error)) *MockOpsV2Store_ListBatchBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ClearBatchBucket provides a mock function for the type MockOpsV2Store
-func (_mock *MockOpsV2Store) ClearBatchBucket(opType string, subs []database.OpSubject) error {
-	ret := _mock.Called(opType, subs)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ClearBatchBucket")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []database.OpSubject) error); ok {
-		r0 = returnFunc(opType, subs)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockOpsV2Store_ClearBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearBatchBucket'
-type MockOpsV2Store_ClearBatchBucket_Call struct {
-	*mock.Call
-}
-
-// ClearBatchBucket is a helper method to define mock.On call
-//   - opType string
-//   - subs []database.OpSubject
-func (_e *MockOpsV2Store_Expecter) ClearBatchBucket(opType interface{}, subs interface{}) *MockOpsV2Store_ClearBatchBucket_Call {
-	return &MockOpsV2Store_ClearBatchBucket_Call{Call: _e.mock.On("ClearBatchBucket", opType, subs)}
-}
-
-func (_c *MockOpsV2Store_ClearBatchBucket_Call) Run(run func(opType string, subs []database.OpSubject)) *MockOpsV2Store_ClearBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 []database.OpSubject
-		if args[1] != nil {
-			arg1 = args[1].([]database.OpSubject)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockOpsV2Store_ClearBatchBucket_Call) Return(err error) *MockOpsV2Store_ClearBatchBucket_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockOpsV2Store_ClearBatchBucket_Call) RunAndReturn(run func(string, []database.OpSubject) error) *MockOpsV2Store_ClearBatchBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -24347,7 +24530,7 @@ type MockSeriesReader_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockSeriesReader_Expecter) GetSeriesByID(id interface{}) *MockSeriesReader_GetSeriesByID_Call {
+func (_e *MockSeriesReader_Expecter) GetSeriesByID(id any) *MockSeriesReader_GetSeriesByID_Call {
 	return &MockSeriesReader_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 
@@ -24409,7 +24592,7 @@ type MockSeriesReader_GetSeriesByIDs_Call struct {
 
 // GetSeriesByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockSeriesReader_Expecter) GetSeriesByIDs(ids interface{}) *MockSeriesReader_GetSeriesByIDs_Call {
+func (_e *MockSeriesReader_Expecter) GetSeriesByIDs(ids any) *MockSeriesReader_GetSeriesByIDs_Call {
 	return &MockSeriesReader_GetSeriesByIDs_Call{Call: _e.mock.On("GetSeriesByIDs", ids)}
 }
 
@@ -24472,7 +24655,7 @@ type MockSeriesReader_GetSeriesByName_Call struct {
 // GetSeriesByName is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockSeriesReader_Expecter) GetSeriesByName(name interface{}, authorID interface{}) *MockSeriesReader_GetSeriesByName_Call {
+func (_e *MockSeriesReader_Expecter) GetSeriesByName(name any, authorID any) *MockSeriesReader_GetSeriesByName_Call {
 	return &MockSeriesReader_GetSeriesByName_Call{Call: _e.mock.On("GetSeriesByName", name, authorID)}
 }
 
@@ -24567,7 +24750,7 @@ type MockSeriesWriter_CreateSeries_Call struct {
 // CreateSeries is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockSeriesWriter_Expecter) CreateSeries(name interface{}, authorID interface{}) *MockSeriesWriter_CreateSeries_Call {
+func (_e *MockSeriesWriter_Expecter) CreateSeries(name any, authorID any) *MockSeriesWriter_CreateSeries_Call {
 	return &MockSeriesWriter_CreateSeries_Call{Call: _e.mock.On("CreateSeries", name, authorID)}
 }
 
@@ -24623,7 +24806,7 @@ type MockSeriesWriter_DeleteSeries_Call struct {
 
 // DeleteSeries is a helper method to define mock.On call
 //   - id int
-func (_e *MockSeriesWriter_Expecter) DeleteSeries(id interface{}) *MockSeriesWriter_DeleteSeries_Call {
+func (_e *MockSeriesWriter_Expecter) DeleteSeries(id any) *MockSeriesWriter_DeleteSeries_Call {
 	return &MockSeriesWriter_DeleteSeries_Call{Call: _e.mock.On("DeleteSeries", id)}
 }
 
@@ -24675,7 +24858,7 @@ type MockSeriesWriter_UpdateSeriesName_Call struct {
 // UpdateSeriesName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockSeriesWriter_Expecter) UpdateSeriesName(id interface{}, name interface{}) *MockSeriesWriter_UpdateSeriesName_Call {
+func (_e *MockSeriesWriter_Expecter) UpdateSeriesName(id any, name any) *MockSeriesWriter_UpdateSeriesName_Call {
 	return &MockSeriesWriter_UpdateSeriesName_Call{Call: _e.mock.On("UpdateSeriesName", id, name)}
 }
 
@@ -24770,7 +24953,7 @@ type MockSeriesStore_CreateSeries_Call struct {
 // CreateSeries is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockSeriesStore_Expecter) CreateSeries(name interface{}, authorID interface{}) *MockSeriesStore_CreateSeries_Call {
+func (_e *MockSeriesStore_Expecter) CreateSeries(name any, authorID any) *MockSeriesStore_CreateSeries_Call {
 	return &MockSeriesStore_CreateSeries_Call{Call: _e.mock.On("CreateSeries", name, authorID)}
 }
 
@@ -24826,7 +25009,7 @@ type MockSeriesStore_DeleteSeries_Call struct {
 
 // DeleteSeries is a helper method to define mock.On call
 //   - id int
-func (_e *MockSeriesStore_Expecter) DeleteSeries(id interface{}) *MockSeriesStore_DeleteSeries_Call {
+func (_e *MockSeriesStore_Expecter) DeleteSeries(id any) *MockSeriesStore_DeleteSeries_Call {
 	return &MockSeriesStore_DeleteSeries_Call{Call: _e.mock.On("DeleteSeries", id)}
 }
 
@@ -25053,7 +25236,7 @@ type MockSeriesStore_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockSeriesStore_Expecter) GetSeriesByID(id interface{}) *MockSeriesStore_GetSeriesByID_Call {
+func (_e *MockSeriesStore_Expecter) GetSeriesByID(id any) *MockSeriesStore_GetSeriesByID_Call {
 	return &MockSeriesStore_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 
@@ -25115,7 +25298,7 @@ type MockSeriesStore_GetSeriesByIDs_Call struct {
 
 // GetSeriesByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockSeriesStore_Expecter) GetSeriesByIDs(ids interface{}) *MockSeriesStore_GetSeriesByIDs_Call {
+func (_e *MockSeriesStore_Expecter) GetSeriesByIDs(ids any) *MockSeriesStore_GetSeriesByIDs_Call {
 	return &MockSeriesStore_GetSeriesByIDs_Call{Call: _e.mock.On("GetSeriesByIDs", ids)}
 }
 
@@ -25178,7 +25361,7 @@ type MockSeriesStore_GetSeriesByName_Call struct {
 // GetSeriesByName is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockSeriesStore_Expecter) GetSeriesByName(name interface{}, authorID interface{}) *MockSeriesStore_GetSeriesByName_Call {
+func (_e *MockSeriesStore_Expecter) GetSeriesByName(name any, authorID any) *MockSeriesStore_GetSeriesByName_Call {
 	return &MockSeriesStore_GetSeriesByName_Call{Call: _e.mock.On("GetSeriesByName", name, authorID)}
 }
 
@@ -25235,7 +25418,7 @@ type MockSeriesStore_UpdateSeriesName_Call struct {
 // UpdateSeriesName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockSeriesStore_Expecter) UpdateSeriesName(id interface{}, name interface{}) *MockSeriesStore_UpdateSeriesName_Call {
+func (_e *MockSeriesStore_Expecter) UpdateSeriesName(id any, name any) *MockSeriesStore_UpdateSeriesName_Call {
 	return &MockSeriesStore_UpdateSeriesName_Call{Call: _e.mock.On("UpdateSeriesName", id, name)}
 }
 
@@ -25319,7 +25502,7 @@ type MockTagStore_AddAuthorTag_Call struct {
 // AddAuthorTag is a helper method to define mock.On call
 //   - authorID int
 //   - tag string
-func (_e *MockTagStore_Expecter) AddAuthorTag(authorID interface{}, tag interface{}) *MockTagStore_AddAuthorTag_Call {
+func (_e *MockTagStore_Expecter) AddAuthorTag(authorID any, tag any) *MockTagStore_AddAuthorTag_Call {
 	return &MockTagStore_AddAuthorTag_Call{Call: _e.mock.On("AddAuthorTag", authorID, tag)}
 }
 
@@ -25377,7 +25560,7 @@ type MockTagStore_AddAuthorTagWithSource_Call struct {
 //   - authorID int
 //   - tag string
 //   - source string
-func (_e *MockTagStore_Expecter) AddAuthorTagWithSource(authorID interface{}, tag interface{}, source interface{}) *MockTagStore_AddAuthorTagWithSource_Call {
+func (_e *MockTagStore_Expecter) AddAuthorTagWithSource(authorID any, tag any, source any) *MockTagStore_AddAuthorTagWithSource_Call {
 	return &MockTagStore_AddAuthorTagWithSource_Call{Call: _e.mock.On("AddAuthorTagWithSource", authorID, tag, source)}
 }
 
@@ -25439,7 +25622,7 @@ type MockTagStore_AddBookTag_Call struct {
 // AddBookTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockTagStore_Expecter) AddBookTag(bookID interface{}, tag interface{}) *MockTagStore_AddBookTag_Call {
+func (_e *MockTagStore_Expecter) AddBookTag(bookID any, tag any) *MockTagStore_AddBookTag_Call {
 	return &MockTagStore_AddBookTag_Call{Call: _e.mock.On("AddBookTag", bookID, tag)}
 }
 
@@ -25497,7 +25680,7 @@ type MockTagStore_AddBookTagWithSource_Call struct {
 //   - bookID string
 //   - tag string
 //   - source string
-func (_e *MockTagStore_Expecter) AddBookTagWithSource(bookID interface{}, tag interface{}, source interface{}) *MockTagStore_AddBookTagWithSource_Call {
+func (_e *MockTagStore_Expecter) AddBookTagWithSource(bookID any, tag any, source any) *MockTagStore_AddBookTagWithSource_Call {
 	return &MockTagStore_AddBookTagWithSource_Call{Call: _e.mock.On("AddBookTagWithSource", bookID, tag, source)}
 }
 
@@ -25559,7 +25742,7 @@ type MockTagStore_AddSeriesTag_Call struct {
 // AddSeriesTag is a helper method to define mock.On call
 //   - seriesID int
 //   - tag string
-func (_e *MockTagStore_Expecter) AddSeriesTag(seriesID interface{}, tag interface{}) *MockTagStore_AddSeriesTag_Call {
+func (_e *MockTagStore_Expecter) AddSeriesTag(seriesID any, tag any) *MockTagStore_AddSeriesTag_Call {
 	return &MockTagStore_AddSeriesTag_Call{Call: _e.mock.On("AddSeriesTag", seriesID, tag)}
 }
 
@@ -25617,7 +25800,7 @@ type MockTagStore_AddSeriesTagWithSource_Call struct {
 //   - seriesID int
 //   - tag string
 //   - source string
-func (_e *MockTagStore_Expecter) AddSeriesTagWithSource(seriesID interface{}, tag interface{}, source interface{}) *MockTagStore_AddSeriesTagWithSource_Call {
+func (_e *MockTagStore_Expecter) AddSeriesTagWithSource(seriesID any, tag any, source any) *MockTagStore_AddSeriesTagWithSource_Call {
 	return &MockTagStore_AddSeriesTagWithSource_Call{Call: _e.mock.On("AddSeriesTagWithSource", seriesID, tag, source)}
 }
 
@@ -25689,7 +25872,7 @@ type MockTagStore_GetAuthorTags_Call struct {
 
 // GetAuthorTags is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockTagStore_Expecter) GetAuthorTags(authorID interface{}) *MockTagStore_GetAuthorTags_Call {
+func (_e *MockTagStore_Expecter) GetAuthorTags(authorID any) *MockTagStore_GetAuthorTags_Call {
 	return &MockTagStore_GetAuthorTags_Call{Call: _e.mock.On("GetAuthorTags", authorID)}
 }
 
@@ -25751,7 +25934,7 @@ type MockTagStore_GetAuthorTagsDetailed_Call struct {
 
 // GetAuthorTagsDetailed is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockTagStore_Expecter) GetAuthorTagsDetailed(authorID interface{}) *MockTagStore_GetAuthorTagsDetailed_Call {
+func (_e *MockTagStore_Expecter) GetAuthorTagsDetailed(authorID any) *MockTagStore_GetAuthorTagsDetailed_Call {
 	return &MockTagStore_GetAuthorTagsDetailed_Call{Call: _e.mock.On("GetAuthorTagsDetailed", authorID)}
 }
 
@@ -25813,7 +25996,7 @@ type MockTagStore_GetAuthorsByTag_Call struct {
 
 // GetAuthorsByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockTagStore_Expecter) GetAuthorsByTag(tag interface{}) *MockTagStore_GetAuthorsByTag_Call {
+func (_e *MockTagStore_Expecter) GetAuthorsByTag(tag any) *MockTagStore_GetAuthorsByTag_Call {
 	return &MockTagStore_GetAuthorsByTag_Call{Call: _e.mock.On("GetAuthorsByTag", tag)}
 }
 
@@ -25875,7 +26058,7 @@ type MockTagStore_GetBookTags_Call struct {
 
 // GetBookTags is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockTagStore_Expecter) GetBookTags(bookID interface{}) *MockTagStore_GetBookTags_Call {
+func (_e *MockTagStore_Expecter) GetBookTags(bookID any) *MockTagStore_GetBookTags_Call {
 	return &MockTagStore_GetBookTags_Call{Call: _e.mock.On("GetBookTags", bookID)}
 }
 
@@ -25937,7 +26120,7 @@ type MockTagStore_GetBookTagsDetailed_Call struct {
 
 // GetBookTagsDetailed is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockTagStore_Expecter) GetBookTagsDetailed(bookID interface{}) *MockTagStore_GetBookTagsDetailed_Call {
+func (_e *MockTagStore_Expecter) GetBookTagsDetailed(bookID any) *MockTagStore_GetBookTagsDetailed_Call {
 	return &MockTagStore_GetBookTagsDetailed_Call{Call: _e.mock.On("GetBookTagsDetailed", bookID)}
 }
 
@@ -25999,7 +26182,7 @@ type MockTagStore_GetBooksByTag_Call struct {
 
 // GetBooksByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockTagStore_Expecter) GetBooksByTag(tag interface{}) *MockTagStore_GetBooksByTag_Call {
+func (_e *MockTagStore_Expecter) GetBooksByTag(tag any) *MockTagStore_GetBooksByTag_Call {
 	return &MockTagStore_GetBooksByTag_Call{Call: _e.mock.On("GetBooksByTag", tag)}
 }
 
@@ -26061,7 +26244,7 @@ type MockTagStore_GetSeriesByTag_Call struct {
 
 // GetSeriesByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockTagStore_Expecter) GetSeriesByTag(tag interface{}) *MockTagStore_GetSeriesByTag_Call {
+func (_e *MockTagStore_Expecter) GetSeriesByTag(tag any) *MockTagStore_GetSeriesByTag_Call {
 	return &MockTagStore_GetSeriesByTag_Call{Call: _e.mock.On("GetSeriesByTag", tag)}
 }
 
@@ -26123,7 +26306,7 @@ type MockTagStore_GetSeriesTags_Call struct {
 
 // GetSeriesTags is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockTagStore_Expecter) GetSeriesTags(seriesID interface{}) *MockTagStore_GetSeriesTags_Call {
+func (_e *MockTagStore_Expecter) GetSeriesTags(seriesID any) *MockTagStore_GetSeriesTags_Call {
 	return &MockTagStore_GetSeriesTags_Call{Call: _e.mock.On("GetSeriesTags", seriesID)}
 }
 
@@ -26185,7 +26368,7 @@ type MockTagStore_GetSeriesTagsDetailed_Call struct {
 
 // GetSeriesTagsDetailed is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockTagStore_Expecter) GetSeriesTagsDetailed(seriesID interface{}) *MockTagStore_GetSeriesTagsDetailed_Call {
+func (_e *MockTagStore_Expecter) GetSeriesTagsDetailed(seriesID any) *MockTagStore_GetSeriesTagsDetailed_Call {
 	return &MockTagStore_GetSeriesTagsDetailed_Call{Call: _e.mock.On("GetSeriesTagsDetailed", seriesID)}
 }
 
@@ -26402,7 +26585,7 @@ type MockTagStore_RemoveAuthorTag_Call struct {
 // RemoveAuthorTag is a helper method to define mock.On call
 //   - authorID int
 //   - tag string
-func (_e *MockTagStore_Expecter) RemoveAuthorTag(authorID interface{}, tag interface{}) *MockTagStore_RemoveAuthorTag_Call {
+func (_e *MockTagStore_Expecter) RemoveAuthorTag(authorID any, tag any) *MockTagStore_RemoveAuthorTag_Call {
 	return &MockTagStore_RemoveAuthorTag_Call{Call: _e.mock.On("RemoveAuthorTag", authorID, tag)}
 }
 
@@ -26460,7 +26643,7 @@ type MockTagStore_RemoveAuthorTagsByPrefix_Call struct {
 //   - authorID int
 //   - prefix string
 //   - source string
-func (_e *MockTagStore_Expecter) RemoveAuthorTagsByPrefix(authorID interface{}, prefix interface{}, source interface{}) *MockTagStore_RemoveAuthorTagsByPrefix_Call {
+func (_e *MockTagStore_Expecter) RemoveAuthorTagsByPrefix(authorID any, prefix any, source any) *MockTagStore_RemoveAuthorTagsByPrefix_Call {
 	return &MockTagStore_RemoveAuthorTagsByPrefix_Call{Call: _e.mock.On("RemoveAuthorTagsByPrefix", authorID, prefix, source)}
 }
 
@@ -26522,7 +26705,7 @@ type MockTagStore_RemoveBookTag_Call struct {
 // RemoveBookTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockTagStore_Expecter) RemoveBookTag(bookID interface{}, tag interface{}) *MockTagStore_RemoveBookTag_Call {
+func (_e *MockTagStore_Expecter) RemoveBookTag(bookID any, tag any) *MockTagStore_RemoveBookTag_Call {
 	return &MockTagStore_RemoveBookTag_Call{Call: _e.mock.On("RemoveBookTag", bookID, tag)}
 }
 
@@ -26580,7 +26763,7 @@ type MockTagStore_RemoveBookTagsByPrefix_Call struct {
 //   - bookID string
 //   - prefix string
 //   - source string
-func (_e *MockTagStore_Expecter) RemoveBookTagsByPrefix(bookID interface{}, prefix interface{}, source interface{}) *MockTagStore_RemoveBookTagsByPrefix_Call {
+func (_e *MockTagStore_Expecter) RemoveBookTagsByPrefix(bookID any, prefix any, source any) *MockTagStore_RemoveBookTagsByPrefix_Call {
 	return &MockTagStore_RemoveBookTagsByPrefix_Call{Call: _e.mock.On("RemoveBookTagsByPrefix", bookID, prefix, source)}
 }
 
@@ -26642,7 +26825,7 @@ type MockTagStore_RemoveSeriesTag_Call struct {
 // RemoveSeriesTag is a helper method to define mock.On call
 //   - seriesID int
 //   - tag string
-func (_e *MockTagStore_Expecter) RemoveSeriesTag(seriesID interface{}, tag interface{}) *MockTagStore_RemoveSeriesTag_Call {
+func (_e *MockTagStore_Expecter) RemoveSeriesTag(seriesID any, tag any) *MockTagStore_RemoveSeriesTag_Call {
 	return &MockTagStore_RemoveSeriesTag_Call{Call: _e.mock.On("RemoveSeriesTag", seriesID, tag)}
 }
 
@@ -26700,7 +26883,7 @@ type MockTagStore_RemoveSeriesTagsByPrefix_Call struct {
 //   - seriesID int
 //   - prefix string
 //   - source string
-func (_e *MockTagStore_Expecter) RemoveSeriesTagsByPrefix(seriesID interface{}, prefix interface{}, source interface{}) *MockTagStore_RemoveSeriesTagsByPrefix_Call {
+func (_e *MockTagStore_Expecter) RemoveSeriesTagsByPrefix(seriesID any, prefix any, source any) *MockTagStore_RemoveSeriesTagsByPrefix_Call {
 	return &MockTagStore_RemoveSeriesTagsByPrefix_Call{Call: _e.mock.On("RemoveSeriesTagsByPrefix", seriesID, prefix, source)}
 }
 
@@ -26762,7 +26945,7 @@ type MockTagStore_SetAuthorTags_Call struct {
 // SetAuthorTags is a helper method to define mock.On call
 //   - authorID int
 //   - tags []string
-func (_e *MockTagStore_Expecter) SetAuthorTags(authorID interface{}, tags interface{}) *MockTagStore_SetAuthorTags_Call {
+func (_e *MockTagStore_Expecter) SetAuthorTags(authorID any, tags any) *MockTagStore_SetAuthorTags_Call {
 	return &MockTagStore_SetAuthorTags_Call{Call: _e.mock.On("SetAuthorTags", authorID, tags)}
 }
 
@@ -26819,7 +27002,7 @@ type MockTagStore_SetBookTags_Call struct {
 // SetBookTags is a helper method to define mock.On call
 //   - bookID string
 //   - tags []string
-func (_e *MockTagStore_Expecter) SetBookTags(bookID interface{}, tags interface{}) *MockTagStore_SetBookTags_Call {
+func (_e *MockTagStore_Expecter) SetBookTags(bookID any, tags any) *MockTagStore_SetBookTags_Call {
 	return &MockTagStore_SetBookTags_Call{Call: _e.mock.On("SetBookTags", bookID, tags)}
 }
 
@@ -26876,7 +27059,7 @@ type MockTagStore_SetSeriesTags_Call struct {
 // SetSeriesTags is a helper method to define mock.On call
 //   - seriesID int
 //   - tags []string
-func (_e *MockTagStore_Expecter) SetSeriesTags(seriesID interface{}, tags interface{}) *MockTagStore_SetSeriesTags_Call {
+func (_e *MockTagStore_Expecter) SetSeriesTags(seriesID any, tags any) *MockTagStore_SetSeriesTags_Call {
 	return &MockTagStore_SetSeriesTags_Call{Call: _e.mock.On("SetSeriesTags", seriesID, tags)}
 }
 
@@ -26960,7 +27143,7 @@ type MockUserTagStore_AddBookUserTag_Call struct {
 // AddBookUserTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockUserTagStore_Expecter) AddBookUserTag(bookID interface{}, tag interface{}) *MockUserTagStore_AddBookUserTag_Call {
+func (_e *MockUserTagStore_Expecter) AddBookUserTag(bookID any, tag any) *MockUserTagStore_AddBookUserTag_Call {
 	return &MockUserTagStore_AddBookUserTag_Call{Call: _e.mock.On("AddBookUserTag", bookID, tag)}
 }
 
@@ -27027,7 +27210,7 @@ type MockUserTagStore_GetBookUserTags_Call struct {
 
 // GetBookUserTags is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockUserTagStore_Expecter) GetBookUserTags(bookID interface{}) *MockUserTagStore_GetBookUserTags_Call {
+func (_e *MockUserTagStore_Expecter) GetBookUserTags(bookID any) *MockUserTagStore_GetBookUserTags_Call {
 	return &MockUserTagStore_GetBookUserTags_Call{Call: _e.mock.On("GetBookUserTags", bookID)}
 }
 
@@ -27079,7 +27262,7 @@ type MockUserTagStore_RemoveBookUserTag_Call struct {
 // RemoveBookUserTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockUserTagStore_Expecter) RemoveBookUserTag(bookID interface{}, tag interface{}) *MockUserTagStore_RemoveBookUserTag_Call {
+func (_e *MockUserTagStore_Expecter) RemoveBookUserTag(bookID any, tag any) *MockUserTagStore_RemoveBookUserTag_Call {
 	return &MockUserTagStore_RemoveBookUserTag_Call{Call: _e.mock.On("RemoveBookUserTag", bookID, tag)}
 }
 
@@ -27136,7 +27319,7 @@ type MockUserTagStore_SetBookUserTags_Call struct {
 // SetBookUserTags is a helper method to define mock.On call
 //   - bookID string
 //   - tags []string
-func (_e *MockUserTagStore_Expecter) SetBookUserTags(bookID interface{}, tags interface{}) *MockUserTagStore_SetBookUserTags_Call {
+func (_e *MockUserTagStore_Expecter) SetBookUserTags(bookID any, tags any) *MockUserTagStore_SetBookUserTags_Call {
 	return &MockUserTagStore_SetBookUserTags_Call{Call: _e.mock.On("SetBookUserTags", bookID, tags)}
 }
 
@@ -27283,7 +27466,7 @@ type MockUserReader_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - email string
-func (_e *MockUserReader_Expecter) GetUserByEmail(email interface{}) *MockUserReader_GetUserByEmail_Call {
+func (_e *MockUserReader_Expecter) GetUserByEmail(email any) *MockUserReader_GetUserByEmail_Call {
 	return &MockUserReader_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
 }
 
@@ -27345,7 +27528,7 @@ type MockUserReader_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockUserReader_Expecter) GetUserByID(id interface{}) *MockUserReader_GetUserByID_Call {
+func (_e *MockUserReader_Expecter) GetUserByID(id any) *MockUserReader_GetUserByID_Call {
 	return &MockUserReader_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -27407,7 +27590,7 @@ type MockUserReader_GetUserByUsername_Call struct {
 
 // GetUserByUsername is a helper method to define mock.On call
 //   - username string
-func (_e *MockUserReader_Expecter) GetUserByUsername(username interface{}) *MockUserReader_GetUserByUsername_Call {
+func (_e *MockUserReader_Expecter) GetUserByUsername(username any) *MockUserReader_GetUserByUsername_Call {
 	return &MockUserReader_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", username)}
 }
 
@@ -27556,7 +27739,7 @@ type MockUserWriter_CreateUser_Call struct {
 //   - passwordHash string
 //   - roles []string
 //   - status string
-func (_e *MockUserWriter_Expecter) CreateUser(username interface{}, email interface{}, passwordHashAlgo interface{}, passwordHash interface{}, roles interface{}, status interface{}) *MockUserWriter_CreateUser_Call {
+func (_e *MockUserWriter_Expecter) CreateUser(username any, email any, passwordHashAlgo any, passwordHash any, roles any, status any) *MockUserWriter_CreateUser_Call {
 	return &MockUserWriter_CreateUser_Call{Call: _e.mock.On("CreateUser", username, email, passwordHashAlgo, passwordHash, roles, status)}
 }
 
@@ -27632,7 +27815,7 @@ type MockUserWriter_UpdateUser_Call struct {
 
 // UpdateUser is a helper method to define mock.On call
 //   - user *database.User
-func (_e *MockUserWriter_Expecter) UpdateUser(user interface{}) *MockUserWriter_UpdateUser_Call {
+func (_e *MockUserWriter_Expecter) UpdateUser(user any) *MockUserWriter_UpdateUser_Call {
 	return &MockUserWriter_UpdateUser_Call{Call: _e.mock.On("UpdateUser", user)}
 }
 
@@ -27779,7 +27962,7 @@ type MockUserStore_CreateUser_Call struct {
 //   - passwordHash string
 //   - roles []string
 //   - status string
-func (_e *MockUserStore_Expecter) CreateUser(username interface{}, email interface{}, passwordHashAlgo interface{}, passwordHash interface{}, roles interface{}, status interface{}) *MockUserStore_CreateUser_Call {
+func (_e *MockUserStore_Expecter) CreateUser(username any, email any, passwordHashAlgo any, passwordHash any, roles any, status any) *MockUserStore_CreateUser_Call {
 	return &MockUserStore_CreateUser_Call{Call: _e.mock.On("CreateUser", username, email, passwordHashAlgo, passwordHash, roles, status)}
 }
 
@@ -27866,7 +28049,7 @@ type MockUserStore_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - email string
-func (_e *MockUserStore_Expecter) GetUserByEmail(email interface{}) *MockUserStore_GetUserByEmail_Call {
+func (_e *MockUserStore_Expecter) GetUserByEmail(email any) *MockUserStore_GetUserByEmail_Call {
 	return &MockUserStore_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
 }
 
@@ -27928,7 +28111,7 @@ type MockUserStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockUserStore_Expecter) GetUserByID(id interface{}) *MockUserStore_GetUserByID_Call {
+func (_e *MockUserStore_Expecter) GetUserByID(id any) *MockUserStore_GetUserByID_Call {
 	return &MockUserStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -27990,7 +28173,7 @@ type MockUserStore_GetUserByUsername_Call struct {
 
 // GetUserByUsername is a helper method to define mock.On call
 //   - username string
-func (_e *MockUserStore_Expecter) GetUserByUsername(username interface{}) *MockUserStore_GetUserByUsername_Call {
+func (_e *MockUserStore_Expecter) GetUserByUsername(username any) *MockUserStore_GetUserByUsername_Call {
 	return &MockUserStore_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", username)}
 }
 
@@ -28096,7 +28279,7 @@ type MockUserStore_UpdateUser_Call struct {
 
 // UpdateUser is a helper method to define mock.On call
 //   - user *database.User
-func (_e *MockUserStore_Expecter) UpdateUser(user interface{}) *MockUserStore_UpdateUser_Call {
+func (_e *MockUserStore_Expecter) UpdateUser(user any) *MockUserStore_UpdateUser_Call {
 	return &MockUserStore_UpdateUser_Call{Call: _e.mock.On("UpdateUser", user)}
 }
 
@@ -28175,7 +28358,7 @@ type MockStore_AddAuthorTag_Call struct {
 // AddAuthorTag is a helper method to define mock.On call
 //   - authorID int
 //   - tag string
-func (_e *MockStore_Expecter) AddAuthorTag(authorID interface{}, tag interface{}) *MockStore_AddAuthorTag_Call {
+func (_e *MockStore_Expecter) AddAuthorTag(authorID any, tag any) *MockStore_AddAuthorTag_Call {
 	return &MockStore_AddAuthorTag_Call{Call: _e.mock.On("AddAuthorTag", authorID, tag)}
 }
 
@@ -28233,7 +28416,7 @@ type MockStore_AddAuthorTagWithSource_Call struct {
 //   - authorID int
 //   - tag string
 //   - source string
-func (_e *MockStore_Expecter) AddAuthorTagWithSource(authorID interface{}, tag interface{}, source interface{}) *MockStore_AddAuthorTagWithSource_Call {
+func (_e *MockStore_Expecter) AddAuthorTagWithSource(authorID any, tag any, source any) *MockStore_AddAuthorTagWithSource_Call {
 	return &MockStore_AddAuthorTagWithSource_Call{Call: _e.mock.On("AddAuthorTagWithSource", authorID, tag, source)}
 }
 
@@ -28295,7 +28478,7 @@ type MockStore_AddBlockedHash_Call struct {
 // AddBlockedHash is a helper method to define mock.On call
 //   - hash string
 //   - reason string
-func (_e *MockStore_Expecter) AddBlockedHash(hash interface{}, reason interface{}) *MockStore_AddBlockedHash_Call {
+func (_e *MockStore_Expecter) AddBlockedHash(hash any, reason any) *MockStore_AddBlockedHash_Call {
 	return &MockStore_AddBlockedHash_Call{Call: _e.mock.On("AddBlockedHash", hash, reason)}
 }
 
@@ -28354,7 +28537,7 @@ type MockStore_AddBookAlternativeTitle_Call struct {
 //   - title string
 //   - source string
 //   - language string
-func (_e *MockStore_Expecter) AddBookAlternativeTitle(bookID interface{}, title interface{}, source interface{}, language interface{}) *MockStore_AddBookAlternativeTitle_Call {
+func (_e *MockStore_Expecter) AddBookAlternativeTitle(bookID any, title any, source any, language any) *MockStore_AddBookAlternativeTitle_Call {
 	return &MockStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
 }
 
@@ -28421,7 +28604,7 @@ type MockStore_AddBookTag_Call struct {
 // AddBookTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockStore_Expecter) AddBookTag(bookID interface{}, tag interface{}) *MockStore_AddBookTag_Call {
+func (_e *MockStore_Expecter) AddBookTag(bookID any, tag any) *MockStore_AddBookTag_Call {
 	return &MockStore_AddBookTag_Call{Call: _e.mock.On("AddBookTag", bookID, tag)}
 }
 
@@ -28479,7 +28662,7 @@ type MockStore_AddBookTagWithSource_Call struct {
 //   - bookID string
 //   - tag string
 //   - source string
-func (_e *MockStore_Expecter) AddBookTagWithSource(bookID interface{}, tag interface{}, source interface{}) *MockStore_AddBookTagWithSource_Call {
+func (_e *MockStore_Expecter) AddBookTagWithSource(bookID any, tag any, source any) *MockStore_AddBookTagWithSource_Call {
 	return &MockStore_AddBookTagWithSource_Call{Call: _e.mock.On("AddBookTagWithSource", bookID, tag, source)}
 }
 
@@ -28541,7 +28724,7 @@ type MockStore_AddBookUserTag_Call struct {
 // AddBookUserTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockStore_Expecter) AddBookUserTag(bookID interface{}, tag interface{}) *MockStore_AddBookUserTag_Call {
+func (_e *MockStore_Expecter) AddBookUserTag(bookID any, tag any) *MockStore_AddBookUserTag_Call {
 	return &MockStore_AddBookUserTag_Call{Call: _e.mock.On("AddBookUserTag", bookID, tag)}
 }
 
@@ -28597,7 +28780,7 @@ type MockStore_AddMetadataRejection_Call struct {
 
 // AddMetadataRejection is a helper method to define mock.On call
 //   - r database.MetadataRejection
-func (_e *MockStore_Expecter) AddMetadataRejection(r interface{}) *MockStore_AddMetadataRejection_Call {
+func (_e *MockStore_Expecter) AddMetadataRejection(r any) *MockStore_AddMetadataRejection_Call {
 	return &MockStore_AddMetadataRejection_Call{Call: _e.mock.On("AddMetadataRejection", r)}
 }
 
@@ -28651,7 +28834,7 @@ type MockStore_AddOperationLog_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockStore_Expecter) AddOperationLog(operationID interface{}, level interface{}, message interface{}, details interface{}) *MockStore_AddOperationLog_Call {
+func (_e *MockStore_Expecter) AddOperationLog(operationID any, level any, message any, details any) *MockStore_AddOperationLog_Call {
 	return &MockStore_AddOperationLog_Call{Call: _e.mock.On("AddOperationLog", operationID, level, message, details)}
 }
 
@@ -28717,7 +28900,7 @@ type MockStore_AddPlaybackEvent_Call struct {
 
 // AddPlaybackEvent is a helper method to define mock.On call
 //   - event *database.PlaybackEvent
-func (_e *MockStore_Expecter) AddPlaybackEvent(event interface{}) *MockStore_AddPlaybackEvent_Call {
+func (_e *MockStore_Expecter) AddPlaybackEvent(event any) *MockStore_AddPlaybackEvent_Call {
 	return &MockStore_AddPlaybackEvent_Call{Call: _e.mock.On("AddPlaybackEvent", event)}
 }
 
@@ -28770,7 +28953,7 @@ type MockStore_AddPlaylistItem_Call struct {
 //   - playlistID int
 //   - bookID int
 //   - position int
-func (_e *MockStore_Expecter) AddPlaylistItem(playlistID interface{}, bookID interface{}, position interface{}) *MockStore_AddPlaylistItem_Call {
+func (_e *MockStore_Expecter) AddPlaylistItem(playlistID any, bookID any, position any) *MockStore_AddPlaylistItem_Call {
 	return &MockStore_AddPlaylistItem_Call{Call: _e.mock.On("AddPlaylistItem", playlistID, bookID, position)}
 }
 
@@ -28832,7 +29015,7 @@ type MockStore_AddSeriesTag_Call struct {
 // AddSeriesTag is a helper method to define mock.On call
 //   - seriesID int
 //   - tag string
-func (_e *MockStore_Expecter) AddSeriesTag(seriesID interface{}, tag interface{}) *MockStore_AddSeriesTag_Call {
+func (_e *MockStore_Expecter) AddSeriesTag(seriesID any, tag any) *MockStore_AddSeriesTag_Call {
 	return &MockStore_AddSeriesTag_Call{Call: _e.mock.On("AddSeriesTag", seriesID, tag)}
 }
 
@@ -28890,7 +29073,7 @@ type MockStore_AddSeriesTagWithSource_Call struct {
 //   - seriesID int
 //   - tag string
 //   - source string
-func (_e *MockStore_Expecter) AddSeriesTagWithSource(seriesID interface{}, tag interface{}, source interface{}) *MockStore_AddSeriesTagWithSource_Call {
+func (_e *MockStore_Expecter) AddSeriesTagWithSource(seriesID any, tag any, source any) *MockStore_AddSeriesTagWithSource_Call {
 	return &MockStore_AddSeriesTagWithSource_Call{Call: _e.mock.On("AddSeriesTagWithSource", seriesID, tag, source)}
 }
 
@@ -28953,7 +29136,7 @@ type MockStore_AddSystemActivityLog_Call struct {
 //   - source string
 //   - level string
 //   - message string
-func (_e *MockStore_Expecter) AddSystemActivityLog(source interface{}, level interface{}, message interface{}) *MockStore_AddSystemActivityLog_Call {
+func (_e *MockStore_Expecter) AddSystemActivityLog(source any, level any, message any) *MockStore_AddSystemActivityLog_Call {
 	return &MockStore_AddSystemActivityLog_Call{Call: _e.mock.On("AddSystemActivityLog", source, level, message)}
 }
 
@@ -28990,6 +29173,63 @@ func (_c *MockStore_AddSystemActivityLog_Call) RunAndReturn(run func(source stri
 	return _c
 }
 
+// AddToBatchBucket provides a mock function for the type MockStore
+func (_mock *MockStore) AddToBatchBucket(opType string, sub database.OpSubject) error {
+	ret := _mock.Called(opType, sub)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddToBatchBucket")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, database.OpSubject) error); ok {
+		r0 = returnFunc(opType, sub)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_AddToBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBatchBucket'
+type MockStore_AddToBatchBucket_Call struct {
+	*mock.Call
+}
+
+// AddToBatchBucket is a helper method to define mock.On call
+//   - opType string
+//   - sub database.OpSubject
+func (_e *MockStore_Expecter) AddToBatchBucket(opType any, sub any) *MockStore_AddToBatchBucket_Call {
+	return &MockStore_AddToBatchBucket_Call{Call: _e.mock.On("AddToBatchBucket", opType, sub)}
+}
+
+func (_c *MockStore_AddToBatchBucket_Call) Run(run func(opType string, sub database.OpSubject)) *MockStore_AddToBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 database.OpSubject
+		if args[1] != nil {
+			arg1 = args[1].(database.OpSubject)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_AddToBatchBucket_Call) Return(err error) *MockStore_AddToBatchBucket_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_AddToBatchBucket_Call) RunAndReturn(run func(opType string, sub database.OpSubject) error) *MockStore_AddToBatchBucket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AppendOpLogsV2 provides a mock function for the type MockStore
 func (_mock *MockStore) AppendOpLogsV2(rows []database.OpLogV2Row) error {
 	ret := _mock.Called(rows)
@@ -29014,7 +29254,7 @@ type MockStore_AppendOpLogsV2_Call struct {
 
 // AppendOpLogsV2 is a helper method to define mock.On call
 //   - rows []database.OpLogV2Row
-func (_e *MockStore_Expecter) AppendOpLogsV2(rows interface{}) *MockStore_AppendOpLogsV2_Call {
+func (_e *MockStore_Expecter) AppendOpLogsV2(rows any) *MockStore_AppendOpLogsV2_Call {
 	return &MockStore_AppendOpLogsV2_Call{Call: _e.mock.On("AppendOpLogsV2", rows)}
 }
 
@@ -29065,7 +29305,7 @@ type MockStore_BatchUpsertBookFiles_Call struct {
 
 // BatchUpsertBookFiles is a helper method to define mock.On call
 //   - files []*database.BookFile
-func (_e *MockStore_Expecter) BatchUpsertBookFiles(files interface{}) *MockStore_BatchUpsertBookFiles_Call {
+func (_e *MockStore_Expecter) BatchUpsertBookFiles(files any) *MockStore_BatchUpsertBookFiles_Call {
 	return &MockStore_BatchUpsertBookFiles_Call{Call: _e.mock.On("BatchUpsertBookFiles", files)}
 }
 
@@ -29116,7 +29356,7 @@ type MockStore_BulkCreateExternalIDMappings_Call struct {
 
 // BulkCreateExternalIDMappings is a helper method to define mock.On call
 //   - mappings []database.ExternalIDMapping
-func (_e *MockStore_Expecter) BulkCreateExternalIDMappings(mappings interface{}) *MockStore_BulkCreateExternalIDMappings_Call {
+func (_e *MockStore_Expecter) BulkCreateExternalIDMappings(mappings any) *MockStore_BulkCreateExternalIDMappings_Call {
 	return &MockStore_BulkCreateExternalIDMappings_Call{Call: _e.mock.On("BulkCreateExternalIDMappings", mappings)}
 }
 
@@ -29139,6 +29379,123 @@ func (_c *MockStore_BulkCreateExternalIDMappings_Call) Return(err error) *MockSt
 }
 
 func (_c *MockStore_BulkCreateExternalIDMappings_Call) RunAndReturn(run func(mappings []database.ExternalIDMapping) error) *MockStore_BulkCreateExternalIDMappings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// BumpDepRev provides a mock function for the type MockStore
+func (_mock *MockStore) BumpDepRev(sub database.OpSubject) (uint64, error) {
+	ret := _mock.Called(sub)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BumpDepRev")
+	}
+
+	var r0 uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
+		return returnFunc(sub)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
+		r0 = returnFunc(sub)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
+		r1 = returnFunc(sub)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_BumpDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BumpDepRev'
+type MockStore_BumpDepRev_Call struct {
+	*mock.Call
+}
+
+// BumpDepRev is a helper method to define mock.On call
+//   - sub database.OpSubject
+func (_e *MockStore_Expecter) BumpDepRev(sub any) *MockStore_BumpDepRev_Call {
+	return &MockStore_BumpDepRev_Call{Call: _e.mock.On("BumpDepRev", sub)}
+}
+
+func (_c *MockStore_BumpDepRev_Call) Run(run func(sub database.OpSubject)) *MockStore_BumpDepRev_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_BumpDepRev_Call) Return(v uint64, err error) *MockStore_BumpDepRev_Call {
+	_c.Call.Return(v, err)
+	return _c
+}
+
+func (_c *MockStore_BumpDepRev_Call) RunAndReturn(run func(sub database.OpSubject) (uint64, error)) *MockStore_BumpDepRev_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ClearBatchBucket provides a mock function for the type MockStore
+func (_mock *MockStore) ClearBatchBucket(opType string, subs []database.OpSubject) error {
+	ret := _mock.Called(opType, subs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ClearBatchBucket")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []database.OpSubject) error); ok {
+		r0 = returnFunc(opType, subs)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_ClearBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearBatchBucket'
+type MockStore_ClearBatchBucket_Call struct {
+	*mock.Call
+}
+
+// ClearBatchBucket is a helper method to define mock.On call
+//   - opType string
+//   - subs []database.OpSubject
+func (_e *MockStore_Expecter) ClearBatchBucket(opType any, subs any) *MockStore_ClearBatchBucket_Call {
+	return &MockStore_ClearBatchBucket_Call{Call: _e.mock.On("ClearBatchBucket", opType, subs)}
+}
+
+func (_c *MockStore_ClearBatchBucket_Call) Run(run func(opType string, subs []database.OpSubject)) *MockStore_ClearBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []database.OpSubject
+		if args[1] != nil {
+			arg1 = args[1].([]database.OpSubject)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ClearBatchBucket_Call) Return(err error) *MockStore_ClearBatchBucket_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_ClearBatchBucket_Call) RunAndReturn(run func(opType string, subs []database.OpSubject) error) *MockStore_ClearBatchBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -29176,7 +29533,7 @@ type MockStore_ClearITunesPID_Call struct {
 
 // ClearITunesPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockStore_Expecter) ClearITunesPID(itunesPID interface{}) *MockStore_ClearITunesPID_Call {
+func (_e *MockStore_Expecter) ClearITunesPID(itunesPID any) *MockStore_ClearITunesPID_Call {
 	return &MockStore_ClearITunesPID_Call{Call: _e.mock.On("ClearITunesPID", itunesPID)}
 }
 
@@ -29228,7 +29585,7 @@ type MockStore_ClearUserPositions_Call struct {
 // ClearUserPositions is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockStore_Expecter) ClearUserPositions(userID interface{}, bookID interface{}) *MockStore_ClearUserPositions_Call {
+func (_e *MockStore_Expecter) ClearUserPositions(userID any, bookID any) *MockStore_ClearUserPositions_Call {
 	return &MockStore_ClearUserPositions_Call{Call: _e.mock.On("ClearUserPositions", userID, bookID)}
 }
 
@@ -29341,7 +29698,7 @@ type MockStore_ConsumeInvite_Call struct {
 //   - token string
 //   - passwordHashAlgo string
 //   - passwordHash string
-func (_e *MockStore_Expecter) ConsumeInvite(token interface{}, passwordHashAlgo interface{}, passwordHash interface{}) *MockStore_ConsumeInvite_Call {
+func (_e *MockStore_Expecter) ConsumeInvite(token any, passwordHashAlgo any, passwordHash any) *MockStore_ConsumeInvite_Call {
 	return &MockStore_ConsumeInvite_Call{Call: _e.mock.On("ConsumeInvite", token, passwordHashAlgo, passwordHash)}
 }
 
@@ -29374,6 +29731,59 @@ func (_c *MockStore_ConsumeInvite_Call) Return(user *database.User, err error) *
 }
 
 func (_c *MockStore_ConsumeInvite_Call) RunAndReturn(run func(token string, passwordHashAlgo string, passwordHash string) (*database.User, error)) *MockStore_ConsumeInvite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CountAllBooks provides a mock function for the type MockStore
+func (_mock *MockStore) CountAllBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountAllBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockStore_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockStore_Expecter) CountAllBooks() *MockStore_CountAllBooks_Call {
+	return &MockStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockStore_CountAllBooks_Call) Run(run func()) *MockStore_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_CountAllBooks_Call) Return(n int, err error) *MockStore_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockStore_CountAllBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -29431,103 +29841,6 @@ func (_c *MockStore_CountAuthors_Call) RunAndReturn(run func() (int, error)) *Mo
 	return _c
 }
 
-// CountPrimaryBooks provides a mock function for the type MockStore
-func (_mock *MockStore) CountPrimaryBooks() (int, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for CountPrimaryBooks")
-	}
-
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-func (_mock *MockStore) CountAllBooks() (int, error) {
-	ret := _mock.Called()
-	if len(ret) == 0 {
-		panic("no return value specified for CountAllBooks")
-	}
-	var r0 int
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() int); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockStore_CountAllBooks_Call struct{ *mock.Call }
-
-func (_e *MockStore_Expecter) CountAllBooks() *MockStore_CountAllBooks_Call {
-	return &MockStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
-}
-
-func (_c *MockStore_CountAllBooks_Call) Run(run func()) *MockStore_CountAllBooks_Call {
-	_c.Call.Run(func(args mock.Arguments) { run() })
-	return _c
-}
-
-func (_c *MockStore_CountAllBooks_Call) Return(n int, err error) *MockStore_CountAllBooks_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *MockStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockStore_CountAllBooks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// MockStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockStore_CountBooks_Call struct {
-	*mock.Call
-}
-
-// CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockStore_Expecter) CountPrimaryBooks() *MockStore_CountBooks_Call {
-	return &MockStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
-}
-
-func (_c *MockStore_CountBooks_Call) Run(run func()) *MockStore_CountBooks_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockStore_CountBooks_Call) Return(n int, err error) *MockStore_CountBooks_Call {
-	_c.Call.Return(n, err)
-	return _c
-}
-
-func (_c *MockStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockStore_CountBooks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CountBooksByPathPrefix provides a mock function for the type MockStore
 func (_mock *MockStore) CountBooksByPathPrefix(prefix string) (int, error) {
 	ret := _mock.Called(prefix)
@@ -29561,7 +29874,7 @@ type MockStore_CountBooksByPathPrefix_Call struct {
 
 // CountBooksByPathPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockStore_Expecter) CountBooksByPathPrefix(prefix interface{}) *MockStore_CountBooksByPathPrefix_Call {
+func (_e *MockStore_Expecter) CountBooksByPathPrefix(prefix any) *MockStore_CountBooksByPathPrefix_Call {
 	return &MockStore_CountBooksByPathPrefix_Call{Call: _e.mock.On("CountBooksByPathPrefix", prefix)}
 }
 
@@ -29674,7 +29987,7 @@ type MockStore_CountPrefix_Call struct {
 
 // CountPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockStore_Expecter) CountPrefix(prefix interface{}) *MockStore_CountPrefix_Call {
+func (_e *MockStore_Expecter) CountPrefix(prefix any) *MockStore_CountPrefix_Call {
 	return &MockStore_CountPrefix_Call{Call: _e.mock.On("CountPrefix", prefix)}
 }
 
@@ -29697,6 +30010,59 @@ func (_c *MockStore_CountPrefix_Call) Return(n int64, err error) *MockStore_Coun
 }
 
 func (_c *MockStore_CountPrefix_Call) RunAndReturn(run func(prefix string) (int64, error)) *MockStore_CountPrefix_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CountPrimaryBooks provides a mock function for the type MockStore
+func (_mock *MockStore) CountPrimaryBooks() (int, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountPrimaryBooks")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockStore_CountPrimaryBooks_Call struct {
+	*mock.Call
+}
+
+// CountPrimaryBooks is a helper method to define mock.On call
+func (_e *MockStore_Expecter) CountPrimaryBooks() *MockStore_CountPrimaryBooks_Call {
+	return &MockStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+}
+
+func (_c *MockStore_CountPrimaryBooks_Call) Run(run func()) *MockStore_CountPrimaryBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_CountPrimaryBooks_Call) Return(n int, err error) *MockStore_CountPrimaryBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -29787,7 +30153,7 @@ type MockStore_CountRunningByPluginV2_Call struct {
 
 // CountRunningByPluginV2 is a helper method to define mock.On call
 //   - plugin string
-func (_e *MockStore_Expecter) CountRunningByPluginV2(plugin interface{}) *MockStore_CountRunningByPluginV2_Call {
+func (_e *MockStore_Expecter) CountRunningByPluginV2(plugin any) *MockStore_CountRunningByPluginV2_Call {
 	return &MockStore_CountRunningByPluginV2_Call{Call: _e.mock.On("CountRunningByPluginV2", plugin)}
 }
 
@@ -29945,7 +30311,7 @@ type MockStore_CreateAIJob_Call struct {
 // CreateAIJob is a helper method to define mock.On call
 //   - job database.AIJob
 //   - payloadJSON []byte
-func (_e *MockStore_Expecter) CreateAIJob(job interface{}, payloadJSON interface{}) *MockStore_CreateAIJob_Call {
+func (_e *MockStore_Expecter) CreateAIJob(job any, payloadJSON any) *MockStore_CreateAIJob_Call {
 	return &MockStore_CreateAIJob_Call{Call: _e.mock.On("CreateAIJob", job, payloadJSON)}
 }
 
@@ -30012,7 +30378,7 @@ type MockStore_CreateAPIKey_Call struct {
 
 // CreateAPIKey is a helper method to define mock.On call
 //   - key *database.APIKey
-func (_e *MockStore_Expecter) CreateAPIKey(key interface{}) *MockStore_CreateAPIKey_Call {
+func (_e *MockStore_Expecter) CreateAPIKey(key any) *MockStore_CreateAPIKey_Call {
 	return &MockStore_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", key)}
 }
 
@@ -30074,7 +30440,7 @@ type MockStore_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) CreateAuthor(name interface{}) *MockStore_CreateAuthor_Call {
+func (_e *MockStore_Expecter) CreateAuthor(name any) *MockStore_CreateAuthor_Call {
 	return &MockStore_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -30138,7 +30504,7 @@ type MockStore_CreateAuthorAlias_Call struct {
 //   - authorID int
 //   - aliasName string
 //   - aliasType string
-func (_e *MockStore_Expecter) CreateAuthorAlias(authorID interface{}, aliasName interface{}, aliasType interface{}) *MockStore_CreateAuthorAlias_Call {
+func (_e *MockStore_Expecter) CreateAuthorAlias(authorID any, aliasName any, aliasType any) *MockStore_CreateAuthorAlias_Call {
 	return &MockStore_CreateAuthorAlias_Call{Call: _e.mock.On("CreateAuthorAlias", authorID, aliasName, aliasType)}
 }
 
@@ -30200,7 +30566,7 @@ type MockStore_CreateAuthorTombstone_Call struct {
 // CreateAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
 //   - canonicalID int
-func (_e *MockStore_Expecter) CreateAuthorTombstone(oldID interface{}, canonicalID interface{}) *MockStore_CreateAuthorTombstone_Call {
+func (_e *MockStore_Expecter) CreateAuthorTombstone(oldID any, canonicalID any) *MockStore_CreateAuthorTombstone_Call {
 	return &MockStore_CreateAuthorTombstone_Call{Call: _e.mock.On("CreateAuthorTombstone", oldID, canonicalID)}
 }
 
@@ -30267,7 +30633,7 @@ type MockStore_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockStore_Expecter) CreateBook(book interface{}) *MockStore_CreateBook_Call {
+func (_e *MockStore_Expecter) CreateBook(book any) *MockStore_CreateBook_Call {
 	return &MockStore_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -30318,7 +30684,7 @@ type MockStore_CreateBookFile_Call struct {
 
 // CreateBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockStore_Expecter) CreateBookFile(file interface{}) *MockStore_CreateBookFile_Call {
+func (_e *MockStore_Expecter) CreateBookFile(file any) *MockStore_CreateBookFile_Call {
 	return &MockStore_CreateBookFile_Call{Call: _e.mock.On("CreateBookFile", file)}
 }
 
@@ -30381,7 +30747,7 @@ type MockStore_CreateBookSegment_Call struct {
 // CreateBookSegment is a helper method to define mock.On call
 //   - bookNumericID int
 //   - segment *database.BookSegment
-func (_e *MockStore_Expecter) CreateBookSegment(bookNumericID interface{}, segment interface{}) *MockStore_CreateBookSegment_Call {
+func (_e *MockStore_Expecter) CreateBookSegment(bookNumericID any, segment any) *MockStore_CreateBookSegment_Call {
 	return &MockStore_CreateBookSegment_Call{Call: _e.mock.On("CreateBookSegment", bookNumericID, segment)}
 }
 
@@ -30437,7 +30803,7 @@ type MockStore_CreateBookTombstone_Call struct {
 
 // CreateBookTombstone is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockStore_Expecter) CreateBookTombstone(book interface{}) *MockStore_CreateBookTombstone_Call {
+func (_e *MockStore_Expecter) CreateBookTombstone(book any) *MockStore_CreateBookTombstone_Call {
 	return &MockStore_CreateBookTombstone_Call{Call: _e.mock.On("CreateBookTombstone", book)}
 }
 
@@ -30499,7 +30865,7 @@ type MockStore_CreateBookVersion_Call struct {
 
 // CreateBookVersion is a helper method to define mock.On call
 //   - v *database.BookVersion
-func (_e *MockStore_Expecter) CreateBookVersion(v interface{}) *MockStore_CreateBookVersion_Call {
+func (_e *MockStore_Expecter) CreateBookVersion(v any) *MockStore_CreateBookVersion_Call {
 	return &MockStore_CreateBookVersion_Call{Call: _e.mock.On("CreateBookVersion", v)}
 }
 
@@ -30554,7 +30920,7 @@ type MockStore_CreateDeferredITunesUpdate_Call struct {
 //   - oldPath string
 //   - newPath string
 //   - updateType string
-func (_e *MockStore_Expecter) CreateDeferredITunesUpdate(bookID interface{}, persistentID interface{}, oldPath interface{}, newPath interface{}, updateType interface{}) *MockStore_CreateDeferredITunesUpdate_Call {
+func (_e *MockStore_Expecter) CreateDeferredITunesUpdate(bookID any, persistentID any, oldPath any, newPath any, updateType any) *MockStore_CreateDeferredITunesUpdate_Call {
 	return &MockStore_CreateDeferredITunesUpdate_Call{Call: _e.mock.On("CreateDeferredITunesUpdate", bookID, persistentID, oldPath, newPath, updateType)}
 }
 
@@ -30625,7 +30991,7 @@ type MockStore_CreateExternalIDMapping_Call struct {
 
 // CreateExternalIDMapping is a helper method to define mock.On call
 //   - mapping *database.ExternalIDMapping
-func (_e *MockStore_Expecter) CreateExternalIDMapping(mapping interface{}) *MockStore_CreateExternalIDMapping_Call {
+func (_e *MockStore_Expecter) CreateExternalIDMapping(mapping any) *MockStore_CreateExternalIDMapping_Call {
 	return &MockStore_CreateExternalIDMapping_Call{Call: _e.mock.On("CreateExternalIDMapping", mapping)}
 }
 
@@ -30688,7 +31054,7 @@ type MockStore_CreateImportPath_Call struct {
 // CreateImportPath is a helper method to define mock.On call
 //   - path string
 //   - name string
-func (_e *MockStore_Expecter) CreateImportPath(path interface{}, name interface{}) *MockStore_CreateImportPath_Call {
+func (_e *MockStore_Expecter) CreateImportPath(path any, name any) *MockStore_CreateImportPath_Call {
 	return &MockStore_CreateImportPath_Call{Call: _e.mock.On("CreateImportPath", path, name)}
 }
 
@@ -30755,7 +31121,7 @@ type MockStore_CreateInvite_Call struct {
 
 // CreateInvite is a helper method to define mock.On call
 //   - invite *database.Invite
-func (_e *MockStore_Expecter) CreateInvite(invite interface{}) *MockStore_CreateInvite_Call {
+func (_e *MockStore_Expecter) CreateInvite(invite any) *MockStore_CreateInvite_Call {
 	return &MockStore_CreateInvite_Call{Call: _e.mock.On("CreateInvite", invite)}
 }
 
@@ -30817,7 +31183,7 @@ type MockStore_CreateNarrator_Call struct {
 
 // CreateNarrator is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) CreateNarrator(name interface{}) *MockStore_CreateNarrator_Call {
+func (_e *MockStore_Expecter) CreateNarrator(name any) *MockStore_CreateNarrator_Call {
 	return &MockStore_CreateNarrator_Call{Call: _e.mock.On("CreateNarrator", name)}
 }
 
@@ -30881,7 +31247,7 @@ type MockStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockStore_CreateOperation_Call {
+func (_e *MockStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockStore_CreateOperation_Call {
 	return &MockStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -30942,7 +31308,7 @@ type MockStore_CreateOperationChange_Call struct {
 
 // CreateOperationChange is a helper method to define mock.On call
 //   - change *database.OperationChange
-func (_e *MockStore_Expecter) CreateOperationChange(change interface{}) *MockStore_CreateOperationChange_Call {
+func (_e *MockStore_Expecter) CreateOperationChange(change any) *MockStore_CreateOperationChange_Call {
 	return &MockStore_CreateOperationChange_Call{Call: _e.mock.On("CreateOperationChange", change)}
 }
 
@@ -30993,7 +31359,7 @@ type MockStore_CreateOperationResult_Call struct {
 
 // CreateOperationResult is a helper method to define mock.On call
 //   - result *database.OperationResult
-func (_e *MockStore_Expecter) CreateOperationResult(result interface{}) *MockStore_CreateOperationResult_Call {
+func (_e *MockStore_Expecter) CreateOperationResult(result any) *MockStore_CreateOperationResult_Call {
 	return &MockStore_CreateOperationResult_Call{Call: _e.mock.On("CreateOperationResult", result)}
 }
 
@@ -31057,7 +31423,7 @@ type MockStore_CreatePlaylist_Call struct {
 //   - name string
 //   - seriesID *int
 //   - filePath string
-func (_e *MockStore_Expecter) CreatePlaylist(name interface{}, seriesID interface{}, filePath interface{}) *MockStore_CreatePlaylist_Call {
+func (_e *MockStore_Expecter) CreatePlaylist(name any, seriesID any, filePath any) *MockStore_CreatePlaylist_Call {
 	return &MockStore_CreatePlaylist_Call{Call: _e.mock.On("CreatePlaylist", name, seriesID, filePath)}
 }
 
@@ -31129,7 +31495,7 @@ type MockStore_CreateRole_Call struct {
 
 // CreateRole is a helper method to define mock.On call
 //   - role *database.Role
-func (_e *MockStore_Expecter) CreateRole(role interface{}) *MockStore_CreateRole_Call {
+func (_e *MockStore_Expecter) CreateRole(role any) *MockStore_CreateRole_Call {
 	return &MockStore_CreateRole_Call{Call: _e.mock.On("CreateRole", role)}
 }
 
@@ -31192,7 +31558,7 @@ type MockStore_CreateSeries_Call struct {
 // CreateSeries is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockStore_Expecter) CreateSeries(name interface{}, authorID interface{}) *MockStore_CreateSeries_Call {
+func (_e *MockStore_Expecter) CreateSeries(name any, authorID any) *MockStore_CreateSeries_Call {
 	return &MockStore_CreateSeries_Call{Call: _e.mock.On("CreateSeries", name, authorID)}
 }
 
@@ -31262,7 +31628,7 @@ type MockStore_CreateSession_Call struct {
 //   - ip string
 //   - userAgent string
 //   - ttl time.Duration
-func (_e *MockStore_Expecter) CreateSession(userID interface{}, ip interface{}, userAgent interface{}, ttl interface{}) *MockStore_CreateSession_Call {
+func (_e *MockStore_Expecter) CreateSession(userID any, ip any, userAgent any, ttl any) *MockStore_CreateSession_Call {
 	return &MockStore_CreateSession_Call{Call: _e.mock.On("CreateSession", userID, ip, userAgent, ttl)}
 }
 
@@ -31344,7 +31710,7 @@ type MockStore_CreateUser_Call struct {
 //   - passwordHash string
 //   - roles []string
 //   - status string
-func (_e *MockStore_Expecter) CreateUser(username interface{}, email interface{}, passwordHashAlgo interface{}, passwordHash interface{}, roles interface{}, status interface{}) *MockStore_CreateUser_Call {
+func (_e *MockStore_Expecter) CreateUser(username any, email any, passwordHashAlgo any, passwordHash any, roles any, status any) *MockStore_CreateUser_Call {
 	return &MockStore_CreateUser_Call{Call: _e.mock.On("CreateUser", username, email, passwordHashAlgo, passwordHash, roles, status)}
 }
 
@@ -31431,7 +31797,7 @@ type MockStore_CreateUserPlaylist_Call struct {
 
 // CreateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockStore_Expecter) CreateUserPlaylist(pl interface{}) *MockStore_CreateUserPlaylist_Call {
+func (_e *MockStore_Expecter) CreateUserPlaylist(pl any) *MockStore_CreateUserPlaylist_Call {
 	return &MockStore_CreateUserPlaylist_Call{Call: _e.mock.On("CreateUserPlaylist", pl)}
 }
 
@@ -31493,7 +31859,7 @@ type MockStore_CreateWork_Call struct {
 
 // CreateWork is a helper method to define mock.On call
 //   - work *database.Work
-func (_e *MockStore_Expecter) CreateWork(work interface{}) *MockStore_CreateWork_Call {
+func (_e *MockStore_Expecter) CreateWork(work any) *MockStore_CreateWork_Call {
 	return &MockStore_CreateWork_Call{Call: _e.mock.On("CreateWork", work)}
 }
 
@@ -31544,7 +31910,7 @@ type MockStore_DeleteAuthor_Call struct {
 
 // DeleteAuthor is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) DeleteAuthor(id interface{}) *MockStore_DeleteAuthor_Call {
+func (_e *MockStore_Expecter) DeleteAuthor(id any) *MockStore_DeleteAuthor_Call {
 	return &MockStore_DeleteAuthor_Call{Call: _e.mock.On("DeleteAuthor", id)}
 }
 
@@ -31595,7 +31961,7 @@ type MockStore_DeleteAuthorAlias_Call struct {
 
 // DeleteAuthorAlias is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) DeleteAuthorAlias(id interface{}) *MockStore_DeleteAuthorAlias_Call {
+func (_e *MockStore_Expecter) DeleteAuthorAlias(id any) *MockStore_DeleteAuthorAlias_Call {
 	return &MockStore_DeleteAuthorAlias_Call{Call: _e.mock.On("DeleteAuthorAlias", id)}
 }
 
@@ -31646,7 +32012,7 @@ type MockStore_DeleteBook_Call struct {
 
 // DeleteBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteBook(id interface{}) *MockStore_DeleteBook_Call {
+func (_e *MockStore_Expecter) DeleteBook(id any) *MockStore_DeleteBook_Call {
 	return &MockStore_DeleteBook_Call{Call: _e.mock.On("DeleteBook", id)}
 }
 
@@ -31697,7 +32063,7 @@ type MockStore_DeleteBookFile_Call struct {
 
 // DeleteBookFile is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteBookFile(id interface{}) *MockStore_DeleteBookFile_Call {
+func (_e *MockStore_Expecter) DeleteBookFile(id any) *MockStore_DeleteBookFile_Call {
 	return &MockStore_DeleteBookFile_Call{Call: _e.mock.On("DeleteBookFile", id)}
 }
 
@@ -31748,7 +32114,7 @@ type MockStore_DeleteBookFilesForBook_Call struct {
 
 // DeleteBookFilesForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) DeleteBookFilesForBook(bookID interface{}) *MockStore_DeleteBookFilesForBook_Call {
+func (_e *MockStore_Expecter) DeleteBookFilesForBook(bookID any) *MockStore_DeleteBookFilesForBook_Call {
 	return &MockStore_DeleteBookFilesForBook_Call{Call: _e.mock.On("DeleteBookFilesForBook", bookID)}
 }
 
@@ -31799,7 +32165,7 @@ type MockStore_DeleteBookTombstone_Call struct {
 
 // DeleteBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteBookTombstone(id interface{}) *MockStore_DeleteBookTombstone_Call {
+func (_e *MockStore_Expecter) DeleteBookTombstone(id any) *MockStore_DeleteBookTombstone_Call {
 	return &MockStore_DeleteBookTombstone_Call{Call: _e.mock.On("DeleteBookTombstone", id)}
 }
 
@@ -31850,7 +32216,7 @@ type MockStore_DeleteBookVersion_Call struct {
 
 // DeleteBookVersion is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteBookVersion(id interface{}) *MockStore_DeleteBookVersion_Call {
+func (_e *MockStore_Expecter) DeleteBookVersion(id any) *MockStore_DeleteBookVersion_Call {
 	return &MockStore_DeleteBookVersion_Call{Call: _e.mock.On("DeleteBookVersion", id)}
 }
 
@@ -31910,7 +32276,7 @@ type MockStore_DeleteExpiredSessions_Call struct {
 
 // DeleteExpiredSessions is a helper method to define mock.On call
 //   - now time.Time
-func (_e *MockStore_Expecter) DeleteExpiredSessions(now interface{}) *MockStore_DeleteExpiredSessions_Call {
+func (_e *MockStore_Expecter) DeleteExpiredSessions(now any) *MockStore_DeleteExpiredSessions_Call {
 	return &MockStore_DeleteExpiredSessions_Call{Call: _e.mock.On("DeleteExpiredSessions", now)}
 }
 
@@ -31961,7 +32327,7 @@ type MockStore_DeleteImportPath_Call struct {
 
 // DeleteImportPath is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) DeleteImportPath(id interface{}) *MockStore_DeleteImportPath_Call {
+func (_e *MockStore_Expecter) DeleteImportPath(id any) *MockStore_DeleteImportPath_Call {
 	return &MockStore_DeleteImportPath_Call{Call: _e.mock.On("DeleteImportPath", id)}
 }
 
@@ -32012,7 +32378,7 @@ type MockStore_DeleteInvite_Call struct {
 
 // DeleteInvite is a helper method to define mock.On call
 //   - token string
-func (_e *MockStore_Expecter) DeleteInvite(token interface{}) *MockStore_DeleteInvite_Call {
+func (_e *MockStore_Expecter) DeleteInvite(token any) *MockStore_DeleteInvite_Call {
 	return &MockStore_DeleteInvite_Call{Call: _e.mock.On("DeleteInvite", token)}
 }
 
@@ -32063,7 +32429,7 @@ type MockStore_DeleteMetadataCache_Call struct {
 
 // DeleteMetadataCache is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) DeleteMetadataCache(bookID interface{}) *MockStore_DeleteMetadataCache_Call {
+func (_e *MockStore_Expecter) DeleteMetadataCache(bookID any) *MockStore_DeleteMetadataCache_Call {
 	return &MockStore_DeleteMetadataCache_Call{Call: _e.mock.On("DeleteMetadataCache", bookID)}
 }
 
@@ -32115,7 +32481,7 @@ type MockStore_DeleteMetadataFieldState_Call struct {
 // DeleteMetadataFieldState is a helper method to define mock.On call
 //   - bookID string
 //   - field string
-func (_e *MockStore_Expecter) DeleteMetadataFieldState(bookID interface{}, field interface{}) *MockStore_DeleteMetadataFieldState_Call {
+func (_e *MockStore_Expecter) DeleteMetadataFieldState(bookID any, field any) *MockStore_DeleteMetadataFieldState_Call {
 	return &MockStore_DeleteMetadataFieldState_Call{Call: _e.mock.On("DeleteMetadataFieldState", bookID, field)}
 }
 
@@ -32171,7 +32537,7 @@ type MockStore_DeleteMetadataRejections_Call struct {
 
 // DeleteMetadataRejections is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) DeleteMetadataRejections(bookID interface{}) *MockStore_DeleteMetadataRejections_Call {
+func (_e *MockStore_Expecter) DeleteMetadataRejections(bookID any) *MockStore_DeleteMetadataRejections_Call {
 	return &MockStore_DeleteMetadataRejections_Call{Call: _e.mock.On("DeleteMetadataRejections", bookID)}
 }
 
@@ -32222,7 +32588,7 @@ type MockStore_DeleteOpStateV2_Call struct {
 
 // DeleteOpStateV2 is a helper method to define mock.On call
 //   - opID string
-func (_e *MockStore_Expecter) DeleteOpStateV2(opID interface{}) *MockStore_DeleteOpStateV2_Call {
+func (_e *MockStore_Expecter) DeleteOpStateV2(opID any) *MockStore_DeleteOpStateV2_Call {
 	return &MockStore_DeleteOpStateV2_Call{Call: _e.mock.On("DeleteOpStateV2", opID)}
 }
 
@@ -32273,7 +32639,7 @@ type MockStore_DeleteOperationState_Call struct {
 
 // DeleteOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockStore_Expecter) DeleteOperationState(opID interface{}) *MockStore_DeleteOperationState_Call {
+func (_e *MockStore_Expecter) DeleteOperationState(opID any) *MockStore_DeleteOperationState_Call {
 	return &MockStore_DeleteOperationState_Call{Call: _e.mock.On("DeleteOperationState", opID)}
 }
 
@@ -32296,6 +32662,57 @@ func (_c *MockStore_DeleteOperationState_Call) Return(err error) *MockStore_Dele
 }
 
 func (_c *MockStore_DeleteOperationState_Call) RunAndReturn(run func(opID string) error) *MockStore_DeleteOperationState_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteOperationWithLogs provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteOperationWithLogs(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOperationWithLogs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
+type MockStore_DeleteOperationWithLogs_Call struct {
+	*mock.Call
+}
+
+// DeleteOperationWithLogs is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) DeleteOperationWithLogs(id any) *MockStore_DeleteOperationWithLogs_Call {
+	return &MockStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
+}
+
+func (_c *MockStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockStore_DeleteOperationWithLogs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteOperationWithLogs_Call) Return(err error) *MockStore_DeleteOperationWithLogs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteOperationWithLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -32333,7 +32750,7 @@ type MockStore_DeleteOperationsByStatus_Call struct {
 
 // DeleteOperationsByStatus is a helper method to define mock.On call
 //   - statuses []string
-func (_e *MockStore_Expecter) DeleteOperationsByStatus(statuses interface{}) *MockStore_DeleteOperationsByStatus_Call {
+func (_e *MockStore_Expecter) DeleteOperationsByStatus(statuses any) *MockStore_DeleteOperationsByStatus_Call {
 	return &MockStore_DeleteOperationsByStatus_Call{Call: _e.mock.On("DeleteOperationsByStatus", statuses)}
 }
 
@@ -32356,51 +32773,6 @@ func (_c *MockStore_DeleteOperationsByStatus_Call) Return(n int, err error) *Moc
 }
 
 func (_c *MockStore_DeleteOperationsByStatus_Call) RunAndReturn(run func(statuses []string) (int, error)) *MockStore_DeleteOperationsByStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// DeleteOperationWithLogs provides a mock function for the type MockStore
-func (_mock *MockStore) DeleteOperationWithLogs(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteOperationWithLogs")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_DeleteOperationWithLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOperationWithLogs'
-type MockStore_DeleteOperationWithLogs_Call struct {
-	*mock.Call
-}
-
-// DeleteOperationWithLogs is a helper method to define mock.On call
-//   - id string
-func (_e *MockStore_Expecter) DeleteOperationWithLogs(id interface{}) *MockStore_DeleteOperationWithLogs_Call {
-	return &MockStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
-}
-
-func (_c *MockStore_DeleteOperationWithLogs_Call) Run(run func(id string)) *MockStore_DeleteOperationWithLogs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockStore_DeleteOperationWithLogs_Call) Return(err error) *MockStore_DeleteOperationWithLogs_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_DeleteOperationWithLogs_Call) RunAndReturn(run func(string) error) *MockStore_DeleteOperationWithLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -32429,7 +32801,7 @@ type MockStore_DeleteOrphanOpDefsV2_Call struct {
 
 // DeleteOrphanOpDefsV2 is a helper method to define mock.On call
 //   - keepIDs []string
-func (_e *MockStore_Expecter) DeleteOrphanOpDefsV2(keepIDs interface{}) *MockStore_DeleteOrphanOpDefsV2_Call {
+func (_e *MockStore_Expecter) DeleteOrphanOpDefsV2(keepIDs any) *MockStore_DeleteOrphanOpDefsV2_Call {
 	return &MockStore_DeleteOrphanOpDefsV2_Call{Call: _e.mock.On("DeleteOrphanOpDefsV2", keepIDs)}
 }
 
@@ -32480,7 +32852,7 @@ type MockStore_DeleteRaw_Call struct {
 
 // DeleteRaw is a helper method to define mock.On call
 //   - key string
-func (_e *MockStore_Expecter) DeleteRaw(key interface{}) *MockStore_DeleteRaw_Call {
+func (_e *MockStore_Expecter) DeleteRaw(key any) *MockStore_DeleteRaw_Call {
 	return &MockStore_DeleteRaw_Call{Call: _e.mock.On("DeleteRaw", key)}
 }
 
@@ -32531,7 +32903,7 @@ type MockStore_DeleteRole_Call struct {
 
 // DeleteRole is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteRole(id interface{}) *MockStore_DeleteRole_Call {
+func (_e *MockStore_Expecter) DeleteRole(id any) *MockStore_DeleteRole_Call {
 	return &MockStore_DeleteRole_Call{Call: _e.mock.On("DeleteRole", id)}
 }
 
@@ -32582,7 +32954,7 @@ type MockStore_DeleteSeries_Call struct {
 
 // DeleteSeries is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) DeleteSeries(id interface{}) *MockStore_DeleteSeries_Call {
+func (_e *MockStore_Expecter) DeleteSeries(id any) *MockStore_DeleteSeries_Call {
 	return &MockStore_DeleteSeries_Call{Call: _e.mock.On("DeleteSeries", id)}
 }
 
@@ -32633,7 +33005,7 @@ type MockStore_DeleteSetting_Call struct {
 
 // DeleteSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockStore_Expecter) DeleteSetting(key interface{}) *MockStore_DeleteSetting_Call {
+func (_e *MockStore_Expecter) DeleteSetting(key any) *MockStore_DeleteSetting_Call {
 	return &MockStore_DeleteSetting_Call{Call: _e.mock.On("DeleteSetting", key)}
 }
 
@@ -32684,7 +33056,7 @@ type MockStore_DeleteUserPlaylist_Call struct {
 
 // DeleteUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteUserPlaylist(id interface{}) *MockStore_DeleteUserPlaylist_Call {
+func (_e *MockStore_Expecter) DeleteUserPlaylist(id any) *MockStore_DeleteUserPlaylist_Call {
 	return &MockStore_DeleteUserPlaylist_Call{Call: _e.mock.On("DeleteUserPlaylist", id)}
 }
 
@@ -32735,7 +33107,7 @@ type MockStore_DeleteWork_Call struct {
 
 // DeleteWork is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) DeleteWork(id interface{}) *MockStore_DeleteWork_Call {
+func (_e *MockStore_Expecter) DeleteWork(id any) *MockStore_DeleteWork_Call {
 	return &MockStore_DeleteWork_Call{Call: _e.mock.On("DeleteWork", id)}
 }
 
@@ -32797,7 +33169,7 @@ type MockStore_FindAuthorByAlias_Call struct {
 
 // FindAuthorByAlias is a helper method to define mock.On call
 //   - aliasName string
-func (_e *MockStore_Expecter) FindAuthorByAlias(aliasName interface{}) *MockStore_FindAuthorByAlias_Call {
+func (_e *MockStore_Expecter) FindAuthorByAlias(aliasName any) *MockStore_FindAuthorByAlias_Call {
 	return &MockStore_FindAuthorByAlias_Call{Call: _e.mock.On("FindAuthorByAlias", aliasName)}
 }
 
@@ -32849,7 +33221,7 @@ type MockStore_FlagMetadataHashDuplicate_Call struct {
 // FlagMetadataHashDuplicate is a helper method to define mock.On call
 //   - primaryID string
 //   - duplicateID string
-func (_e *MockStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockStore_FlagMetadataHashDuplicate_Call {
+func (_e *MockStore_Expecter) FlagMetadataHashDuplicate(primaryID any, duplicateID any) *MockStore_FlagMetadataHashDuplicate_Call {
 	return &MockStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
 }
 
@@ -32877,51 +33249,6 @@ func (_c *MockStore_FlagMetadataHashDuplicate_Call) Return(err error) *MockStore
 }
 
 func (_c *MockStore_FlagMetadataHashDuplicate_Call) RunAndReturn(run func(primaryID string, duplicateID string) error) *MockStore_FlagMetadataHashDuplicate_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecomputeBookAggregates provides a mock function for the type MockStore
-func (_mock *MockStore) RecomputeBookAggregates(bookID string) error {
-	ret := _mock.Called(bookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecomputeBookAggregates")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(bookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
-type MockStore_RecomputeBookAggregates_Call struct {
-	*mock.Call
-}
-
-// RecomputeBookAggregates is a helper method to define mock.On call
-//   - bookID string
-func (_e *MockStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockStore_RecomputeBookAggregates_Call {
-	return &MockStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
-}
-
-func (_c *MockStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockStore_RecomputeBookAggregates_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockStore_RecomputeBookAggregates_Call) Return(err error) *MockStore_RecomputeBookAggregates_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockStore_RecomputeBookAggregates_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -32959,7 +33286,7 @@ type MockStore_GetAIJob_Call struct {
 
 // GetAIJob is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetAIJob(id interface{}) *MockStore_GetAIJob_Call {
+func (_e *MockStore_Expecter) GetAIJob(id any) *MockStore_GetAIJob_Call {
 	return &MockStore_GetAIJob_Call{Call: _e.mock.On("GetAIJob", id)}
 }
 
@@ -33019,7 +33346,7 @@ type MockStore_GetAIJobByBatchID_Call struct {
 
 // GetAIJobByBatchID is a helper method to define mock.On call
 //   - batchID string
-func (_e *MockStore_Expecter) GetAIJobByBatchID(batchID interface{}) *MockStore_GetAIJobByBatchID_Call {
+func (_e *MockStore_Expecter) GetAIJobByBatchID(batchID any) *MockStore_GetAIJobByBatchID_Call {
 	return &MockStore_GetAIJobByBatchID_Call{Call: _e.mock.On("GetAIJobByBatchID", batchID)}
 }
 
@@ -33081,7 +33408,7 @@ type MockStore_GetAIJobPayload_Call struct {
 
 // GetAIJobPayload is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetAIJobPayload(id interface{}) *MockStore_GetAIJobPayload_Call {
+func (_e *MockStore_Expecter) GetAIJobPayload(id any) *MockStore_GetAIJobPayload_Call {
 	return &MockStore_GetAIJobPayload_Call{Call: _e.mock.On("GetAIJobPayload", id)}
 }
 
@@ -33143,7 +33470,7 @@ type MockStore_GetAPIKey_Call struct {
 
 // GetAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetAPIKey(id interface{}) *MockStore_GetAPIKey_Call {
+func (_e *MockStore_Expecter) GetAPIKey(id any) *MockStore_GetAPIKey_Call {
 	return &MockStore_GetAPIKey_Call{Call: _e.mock.On("GetAPIKey", id)}
 }
 
@@ -33205,7 +33532,7 @@ type MockStore_GetAPIKeyByHash_Call struct {
 
 // GetAPIKeyByHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetAPIKeyByHash(hash interface{}) *MockStore_GetAPIKeyByHash_Call {
+func (_e *MockStore_Expecter) GetAPIKeyByHash(hash any) *MockStore_GetAPIKeyByHash_Call {
 	return &MockStore_GetAPIKeyByHash_Call{Call: _e.mock.On("GetAPIKeyByHash", hash)}
 }
 
@@ -33322,7 +33649,7 @@ type MockStore_GetActiveVersionForBook_Call struct {
 
 // GetActiveVersionForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetActiveVersionForBook(bookID interface{}) *MockStore_GetActiveVersionForBook_Call {
+func (_e *MockStore_Expecter) GetActiveVersionForBook(bookID any) *MockStore_GetActiveVersionForBook_Call {
 	return &MockStore_GetActiveVersionForBook_Call{Call: _e.mock.On("GetActiveVersionForBook", bookID)}
 }
 
@@ -33715,7 +34042,7 @@ type MockStore_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockStore_GetAllBookSummaries_Call {
+func (_e *MockStore_Expecter) GetAllBookSummaries(limit any, offset any) *MockStore_GetAllBookSummaries_Call {
 	return &MockStore_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -33783,7 +34110,7 @@ type MockStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockStore_GetAllBooks_Call {
+func (_e *MockStore_Expecter) GetAllBooks(limit any, offset any) *MockStore_GetAllBooks_Call {
 	return &MockStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -33851,7 +34178,7 @@ type MockStore_GetAllBooksFrom_Call struct {
 // GetAllBooksFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockStore_GetAllBooksFrom_Call {
+func (_e *MockStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockStore_GetAllBooksFrom_Call {
 	return &MockStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
 
@@ -33865,7 +34192,10 @@ func (_c *MockStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -33875,7 +34205,7 @@ func (_c *MockStore_GetAllBooksFrom_Call) Return(books []database.Book, err erro
 	return _c
 }
 
-func (_c *MockStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockStore_GetAllBooksFrom_Call {
+func (_c *MockStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -33970,7 +34300,7 @@ type MockStore_GetAllPreferencesForUser_Call struct {
 
 // GetAllPreferencesForUser is a helper method to define mock.On call
 //   - userID string
-func (_e *MockStore_Expecter) GetAllPreferencesForUser(userID interface{}) *MockStore_GetAllPreferencesForUser_Call {
+func (_e *MockStore_Expecter) GetAllPreferencesForUser(userID any) *MockStore_GetAllPreferencesForUser_Call {
 	return &MockStore_GetAllPreferencesForUser_Call{Call: _e.mock.On("GetAllPreferencesForUser", userID)}
 }
 
@@ -34417,7 +34747,7 @@ type MockStore_GetAuthorAliases_Call struct {
 
 // GetAuthorAliases is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetAuthorAliases(authorID interface{}) *MockStore_GetAuthorAliases_Call {
+func (_e *MockStore_Expecter) GetAuthorAliases(authorID any) *MockStore_GetAuthorAliases_Call {
 	return &MockStore_GetAuthorAliases_Call{Call: _e.mock.On("GetAuthorAliases", authorID)}
 }
 
@@ -34479,7 +34809,7 @@ type MockStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) GetAuthorByID(id interface{}) *MockStore_GetAuthorByID_Call {
+func (_e *MockStore_Expecter) GetAuthorByID(id any) *MockStore_GetAuthorByID_Call {
 	return &MockStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -34541,7 +34871,7 @@ type MockStore_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) GetAuthorByName(name interface{}) *MockStore_GetAuthorByName_Call {
+func (_e *MockStore_Expecter) GetAuthorByName(name any) *MockStore_GetAuthorByName_Call {
 	return &MockStore_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -34603,7 +34933,7 @@ type MockStore_GetAuthorTags_Call struct {
 
 // GetAuthorTags is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetAuthorTags(authorID interface{}) *MockStore_GetAuthorTags_Call {
+func (_e *MockStore_Expecter) GetAuthorTags(authorID any) *MockStore_GetAuthorTags_Call {
 	return &MockStore_GetAuthorTags_Call{Call: _e.mock.On("GetAuthorTags", authorID)}
 }
 
@@ -34665,7 +34995,7 @@ type MockStore_GetAuthorTagsDetailed_Call struct {
 
 // GetAuthorTagsDetailed is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetAuthorTagsDetailed(authorID interface{}) *MockStore_GetAuthorTagsDetailed_Call {
+func (_e *MockStore_Expecter) GetAuthorTagsDetailed(authorID any) *MockStore_GetAuthorTagsDetailed_Call {
 	return &MockStore_GetAuthorTagsDetailed_Call{Call: _e.mock.On("GetAuthorTagsDetailed", authorID)}
 }
 
@@ -34725,7 +35055,7 @@ type MockStore_GetAuthorTombstone_Call struct {
 
 // GetAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
-func (_e *MockStore_Expecter) GetAuthorTombstone(oldID interface{}) *MockStore_GetAuthorTombstone_Call {
+func (_e *MockStore_Expecter) GetAuthorTombstone(oldID any) *MockStore_GetAuthorTombstone_Call {
 	return &MockStore_GetAuthorTombstone_Call{Call: _e.mock.On("GetAuthorTombstone", oldID)}
 }
 
@@ -34788,7 +35118,7 @@ type MockStore_GetAuthorsByBookIDs_Call struct {
 // GetAuthorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockStore_Expecter) GetAuthorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockStore_GetAuthorsByBookIDs_Call {
+func (_e *MockStore_Expecter) GetAuthorsByBookIDs(ctx any, bookIDs any) *MockStore_GetAuthorsByBookIDs_Call {
 	return &MockStore_GetAuthorsByBookIDs_Call{Call: _e.mock.On("GetAuthorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -34855,7 +35185,7 @@ type MockStore_GetAuthorsByIDs_Call struct {
 
 // GetAuthorsByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockStore_Expecter) GetAuthorsByIDs(ids interface{}) *MockStore_GetAuthorsByIDs_Call {
+func (_e *MockStore_Expecter) GetAuthorsByIDs(ids any) *MockStore_GetAuthorsByIDs_Call {
 	return &MockStore_GetAuthorsByIDs_Call{Call: _e.mock.On("GetAuthorsByIDs", ids)}
 }
 
@@ -34917,7 +35247,7 @@ type MockStore_GetAuthorsByTag_Call struct {
 
 // GetAuthorsByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockStore_Expecter) GetAuthorsByTag(tag interface{}) *MockStore_GetAuthorsByTag_Call {
+func (_e *MockStore_Expecter) GetAuthorsByTag(tag any) *MockStore_GetAuthorsByTag_Call {
 	return &MockStore_GetAuthorsByTag_Call{Call: _e.mock.On("GetAuthorsByTag", tag)}
 }
 
@@ -34979,7 +35309,7 @@ type MockStore_GetBlockedHashByHash_Call struct {
 
 // GetBlockedHashByHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBlockedHashByHash(hash interface{}) *MockStore_GetBlockedHashByHash_Call {
+func (_e *MockStore_Expecter) GetBlockedHashByHash(hash any) *MockStore_GetBlockedHashByHash_Call {
 	return &MockStore_GetBlockedHashByHash_Call{Call: _e.mock.On("GetBlockedHashByHash", hash)}
 }
 
@@ -35041,7 +35371,7 @@ type MockStore_GetBookAlternativeTitles_Call struct {
 
 // GetBookAlternativeTitles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockStore_GetBookAlternativeTitles_Call {
+func (_e *MockStore_Expecter) GetBookAlternativeTitles(bookID any) *MockStore_GetBookAlternativeTitles_Call {
 	return &MockStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
 }
 
@@ -35104,7 +35434,7 @@ type MockStore_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockStore_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockStore_GetBookAtVersion_Call {
+func (_e *MockStore_Expecter) GetBookAtVersion(id any, ts any) *MockStore_GetBookAtVersion_Call {
 	return &MockStore_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -35171,7 +35501,7 @@ type MockStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookAuthors(bookID interface{}) *MockStore_GetBookAuthors_Call {
+func (_e *MockStore_Expecter) GetBookAuthors(bookID any) *MockStore_GetBookAuthors_Call {
 	return &MockStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -35232,7 +35562,7 @@ type MockStore_GetBookByExternalID_Call struct {
 // GetBookByExternalID is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockStore_Expecter) GetBookByExternalID(source interface{}, externalID interface{}) *MockStore_GetBookByExternalID_Call {
+func (_e *MockStore_Expecter) GetBookByExternalID(source any, externalID any) *MockStore_GetBookByExternalID_Call {
 	return &MockStore_GetBookByExternalID_Call{Call: _e.mock.On("GetBookByExternalID", source, externalID)}
 }
 
@@ -35299,7 +35629,7 @@ type MockStore_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBookByFileHash(hash interface{}) *MockStore_GetBookByFileHash_Call {
+func (_e *MockStore_Expecter) GetBookByFileHash(hash any) *MockStore_GetBookByFileHash_Call {
 	return &MockStore_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -35361,7 +35691,7 @@ type MockStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockStore_Expecter) GetBookByFilePath(path interface{}) *MockStore_GetBookByFilePath_Call {
+func (_e *MockStore_Expecter) GetBookByFilePath(path any) *MockStore_GetBookByFilePath_Call {
 	return &MockStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -35423,7 +35753,7 @@ type MockStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetBookByID(id interface{}) *MockStore_GetBookByID_Call {
+func (_e *MockStore_Expecter) GetBookByID(id any) *MockStore_GetBookByID_Call {
 	return &MockStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -35485,7 +35815,7 @@ type MockStore_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockStore_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockStore_GetBookByITunesPersistentID_Call {
+func (_e *MockStore_Expecter) GetBookByITunesPersistentID(persistentID any) *MockStore_GetBookByITunesPersistentID_Call {
 	return &MockStore_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -35547,7 +35877,7 @@ type MockStore_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBookByOrganizedHash(hash interface{}) *MockStore_GetBookByOrganizedHash_Call {
+func (_e *MockStore_Expecter) GetBookByOrganizedHash(hash any) *MockStore_GetBookByOrganizedHash_Call {
 	return &MockStore_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -35609,7 +35939,7 @@ type MockStore_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBookByOriginalHash(hash interface{}) *MockStore_GetBookByOriginalHash_Call {
+func (_e *MockStore_Expecter) GetBookByOriginalHash(hash any) *MockStore_GetBookByOriginalHash_Call {
 	return &MockStore_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -35671,7 +36001,7 @@ type MockStore_GetBookBySegmentFileHash_Call struct {
 
 // GetBookBySegmentFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBookBySegmentFileHash(hash interface{}) *MockStore_GetBookBySegmentFileHash_Call {
+func (_e *MockStore_Expecter) GetBookBySegmentFileHash(hash any) *MockStore_GetBookBySegmentFileHash_Call {
 	return &MockStore_GetBookBySegmentFileHash_Call{Call: _e.mock.On("GetBookBySegmentFileHash", hash)}
 }
 
@@ -35734,7 +36064,7 @@ type MockStore_GetBookChangeHistory_Call struct {
 // GetBookChangeHistory is a helper method to define mock.On call
 //   - bookID string
 //   - limit int
-func (_e *MockStore_Expecter) GetBookChangeHistory(bookID interface{}, limit interface{}) *MockStore_GetBookChangeHistory_Call {
+func (_e *MockStore_Expecter) GetBookChangeHistory(bookID any, limit any) *MockStore_GetBookChangeHistory_Call {
 	return &MockStore_GetBookChangeHistory_Call{Call: _e.mock.On("GetBookChangeHistory", bookID, limit)}
 }
 
@@ -35801,7 +36131,7 @@ type MockStore_GetBookChanges_Call struct {
 
 // GetBookChanges is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookChanges(bookID interface{}) *MockStore_GetBookChanges_Call {
+func (_e *MockStore_Expecter) GetBookChanges(bookID any) *MockStore_GetBookChanges_Call {
 	return &MockStore_GetBookChanges_Call{Call: _e.mock.On("GetBookChanges", bookID)}
 }
 
@@ -35867,7 +36197,7 @@ type MockStore_GetBookCountsByLocation_Call struct {
 
 // GetBookCountsByLocation is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStore_Expecter) GetBookCountsByLocation(rootDir interface{}) *MockStore_GetBookCountsByLocation_Call {
+func (_e *MockStore_Expecter) GetBookCountsByLocation(rootDir any) *MockStore_GetBookCountsByLocation_Call {
 	return &MockStore_GetBookCountsByLocation_Call{Call: _e.mock.On("GetBookCountsByLocation", rootDir)}
 }
 
@@ -35929,7 +36259,7 @@ type MockStore_GetBookFileByAcoustID_Call struct {
 
 // GetBookFileByAcoustID is a helper method to define mock.On call
 //   - fingerprint string
-func (_e *MockStore_Expecter) GetBookFileByAcoustID(fingerprint interface{}) *MockStore_GetBookFileByAcoustID_Call {
+func (_e *MockStore_Expecter) GetBookFileByAcoustID(fingerprint any) *MockStore_GetBookFileByAcoustID_Call {
 	return &MockStore_GetBookFileByAcoustID_Call{Call: _e.mock.On("GetBookFileByAcoustID", fingerprint)}
 }
 
@@ -35992,7 +36322,7 @@ type MockStore_GetBookFileByAcoustIDFuzzy_Call struct {
 // GetBookFileByAcoustIDFuzzy is a helper method to define mock.On call
 //   - fingerprint string
 //   - minSimilarity float64
-func (_e *MockStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint interface{}, minSimilarity interface{}) *MockStore_GetBookFileByAcoustIDFuzzy_Call {
+func (_e *MockStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint any, minSimilarity any) *MockStore_GetBookFileByAcoustIDFuzzy_Call {
 	return &MockStore_GetBookFileByAcoustIDFuzzy_Call{Call: _e.mock.On("GetBookFileByAcoustIDFuzzy", fingerprint, minSimilarity)}
 }
 
@@ -36060,7 +36390,7 @@ type MockStore_GetBookFileByID_Call struct {
 // GetBookFileByID is a helper method to define mock.On call
 //   - bookID string
 //   - fileID string
-func (_e *MockStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockStore_GetBookFileByID_Call {
+func (_e *MockStore_Expecter) GetBookFileByID(bookID any, fileID any) *MockStore_GetBookFileByID_Call {
 	return &MockStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
 }
 
@@ -36127,7 +36457,7 @@ type MockStore_GetBookFileByPID_Call struct {
 
 // GetBookFileByPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockStore_Expecter) GetBookFileByPID(itunesPID interface{}) *MockStore_GetBookFileByPID_Call {
+func (_e *MockStore_Expecter) GetBookFileByPID(itunesPID any) *MockStore_GetBookFileByPID_Call {
 	return &MockStore_GetBookFileByPID_Call{Call: _e.mock.On("GetBookFileByPID", itunesPID)}
 }
 
@@ -36189,7 +36519,7 @@ type MockStore_GetBookFileByPath_Call struct {
 
 // GetBookFileByPath is a helper method to define mock.On call
 //   - filePath string
-func (_e *MockStore_Expecter) GetBookFileByPath(filePath interface{}) *MockStore_GetBookFileByPath_Call {
+func (_e *MockStore_Expecter) GetBookFileByPath(filePath any) *MockStore_GetBookFileByPath_Call {
 	return &MockStore_GetBookFileByPath_Call{Call: _e.mock.On("GetBookFileByPath", filePath)}
 }
 
@@ -36306,7 +36636,7 @@ type MockStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookFiles(bookID interface{}) *MockStore_GetBookFiles_Call {
+func (_e *MockStore_Expecter) GetBookFiles(bookID any) *MockStore_GetBookFiles_Call {
 	return &MockStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -36384,6 +36714,80 @@ func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) Return(bookFiles []dat
 }
 
 func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBookIDsByISBNASIN provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
+	ret := _mock.Called(isbn10, isbn13, asin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBookIDsByISBNASIN")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
+		return returnFunc(isbn10, isbn13, asin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
+		r0 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(isbn10, isbn13, asin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
+type MockStore_GetBookIDsByISBNASIN_Call struct {
+	*mock.Call
+}
+
+// GetBookIDsByISBNASIN is a helper method to define mock.On call
+//   - isbn10 string
+//   - isbn13 string
+//   - asin string
+func (_e *MockStore_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockStore_GetBookIDsByISBNASIN_Call {
+	return &MockStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) Return(strings []string, err error) *MockStore_GetBookIDsByISBNASIN_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(isbn10 string, isbn13 string, asin string) ([]string, error)) *MockStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -36478,7 +36882,7 @@ type MockStore_GetBookNarrators_Call struct {
 
 // GetBookNarrators is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookNarrators(bookID interface{}) *MockStore_GetBookNarrators_Call {
+func (_e *MockStore_Expecter) GetBookNarrators(bookID any) *MockStore_GetBookNarrators_Call {
 	return &MockStore_GetBookNarrators_Call{Call: _e.mock.On("GetBookNarrators", bookID)}
 }
 
@@ -36540,7 +36944,7 @@ type MockStore_GetBookPathHistory_Call struct {
 
 // GetBookPathHistory is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookPathHistory(bookID interface{}) *MockStore_GetBookPathHistory_Call {
+func (_e *MockStore_Expecter) GetBookPathHistory(bookID any) *MockStore_GetBookPathHistory_Call {
 	return &MockStore_GetBookPathHistory_Call{Call: _e.mock.On("GetBookPathHistory", bookID)}
 }
 
@@ -36602,7 +37006,7 @@ type MockStore_GetBookSegmentByID_Call struct {
 
 // GetBookSegmentByID is a helper method to define mock.On call
 //   - segmentID string
-func (_e *MockStore_Expecter) GetBookSegmentByID(segmentID interface{}) *MockStore_GetBookSegmentByID_Call {
+func (_e *MockStore_Expecter) GetBookSegmentByID(segmentID any) *MockStore_GetBookSegmentByID_Call {
 	return &MockStore_GetBookSegmentByID_Call{Call: _e.mock.On("GetBookSegmentByID", segmentID)}
 }
 
@@ -36668,7 +37072,7 @@ type MockStore_GetBookSizesByLocation_Call struct {
 
 // GetBookSizesByLocation is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStore_Expecter) GetBookSizesByLocation(rootDir interface{}) *MockStore_GetBookSizesByLocation_Call {
+func (_e *MockStore_Expecter) GetBookSizesByLocation(rootDir any) *MockStore_GetBookSizesByLocation_Call {
 	return &MockStore_GetBookSizesByLocation_Call{Call: _e.mock.On("GetBookSizesByLocation", rootDir)}
 }
 
@@ -36731,7 +37135,7 @@ type MockStore_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockStore_GetBookSnapshots_Call {
+func (_e *MockStore_Expecter) GetBookSnapshots(id any, limit any) *MockStore_GetBookSnapshots_Call {
 	return &MockStore_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -36798,7 +37202,7 @@ type MockStore_GetBookStats_Call struct {
 
 // GetBookStats is a helper method to define mock.On call
 //   - bookNumericID int
-func (_e *MockStore_Expecter) GetBookStats(bookNumericID interface{}) *MockStore_GetBookStats_Call {
+func (_e *MockStore_Expecter) GetBookStats(bookNumericID any) *MockStore_GetBookStats_Call {
 	return &MockStore_GetBookStats_Call{Call: _e.mock.On("GetBookStats", bookNumericID)}
 }
 
@@ -36860,7 +37264,7 @@ type MockStore_GetBookTags_Call struct {
 
 // GetBookTags is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookTags(bookID interface{}) *MockStore_GetBookTags_Call {
+func (_e *MockStore_Expecter) GetBookTags(bookID any) *MockStore_GetBookTags_Call {
 	return &MockStore_GetBookTags_Call{Call: _e.mock.On("GetBookTags", bookID)}
 }
 
@@ -36922,7 +37326,7 @@ type MockStore_GetBookTagsDetailed_Call struct {
 
 // GetBookTagsDetailed is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookTagsDetailed(bookID interface{}) *MockStore_GetBookTagsDetailed_Call {
+func (_e *MockStore_Expecter) GetBookTagsDetailed(bookID any) *MockStore_GetBookTagsDetailed_Call {
 	return &MockStore_GetBookTagsDetailed_Call{Call: _e.mock.On("GetBookTagsDetailed", bookID)}
 }
 
@@ -36984,7 +37388,7 @@ type MockStore_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetBookTombstone(id interface{}) *MockStore_GetBookTombstone_Call {
+func (_e *MockStore_Expecter) GetBookTombstone(id any) *MockStore_GetBookTombstone_Call {
 	return &MockStore_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -37046,7 +37450,7 @@ type MockStore_GetBookUserTags_Call struct {
 
 // GetBookUserTags is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookUserTags(bookID interface{}) *MockStore_GetBookUserTags_Call {
+func (_e *MockStore_Expecter) GetBookUserTags(bookID any) *MockStore_GetBookUserTags_Call {
 	return &MockStore_GetBookUserTags_Call{Call: _e.mock.On("GetBookUserTags", bookID)}
 }
 
@@ -37108,7 +37512,7 @@ type MockStore_GetBookVersion_Call struct {
 
 // GetBookVersion is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetBookVersion(id interface{}) *MockStore_GetBookVersion_Call {
+func (_e *MockStore_Expecter) GetBookVersion(id any) *MockStore_GetBookVersion_Call {
 	return &MockStore_GetBookVersion_Call{Call: _e.mock.On("GetBookVersion", id)}
 }
 
@@ -37170,7 +37574,7 @@ type MockStore_GetBookVersionByTorrentHash_Call struct {
 
 // GetBookVersionByTorrentHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBookVersionByTorrentHash(hash interface{}) *MockStore_GetBookVersionByTorrentHash_Call {
+func (_e *MockStore_Expecter) GetBookVersionByTorrentHash(hash any) *MockStore_GetBookVersionByTorrentHash_Call {
 	return &MockStore_GetBookVersionByTorrentHash_Call{Call: _e.mock.On("GetBookVersionByTorrentHash", hash)}
 }
 
@@ -37232,7 +37636,7 @@ type MockStore_GetBookVersionsByBookID_Call struct {
 
 // GetBookVersionsByBookID is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetBookVersionsByBookID(bookID interface{}) *MockStore_GetBookVersionsByBookID_Call {
+func (_e *MockStore_Expecter) GetBookVersionsByBookID(bookID any) *MockStore_GetBookVersionsByBookID_Call {
 	return &MockStore_GetBookVersionsByBookID_Call{Call: _e.mock.On("GetBookVersionsByBookID", bookID)}
 }
 
@@ -37294,7 +37698,7 @@ type MockStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockStore_GetBooksByAuthorID_Call {
+func (_e *MockStore_Expecter) GetBooksByAuthorID(authorID any) *MockStore_GetBooksByAuthorID_Call {
 	return &MockStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -37356,7 +37760,7 @@ type MockStore_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockStore_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockStore_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockStore_GetBooksByAuthorIDWithRole_Call {
 	return &MockStore_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -37418,7 +37822,7 @@ type MockStore_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockStore_GetBooksByMetadataSourceHash_Call {
+func (_e *MockStore_Expecter) GetBooksByMetadataSourceHash(hash any) *MockStore_GetBooksByMetadataSourceHash_Call {
 	return &MockStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -37441,76 +37845,6 @@ func (_c *MockStore_GetBooksByMetadataSourceHash_Call) Return(books []database.B
 }
 
 func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(hash string) ([]database.Book, error)) *MockStore_GetBooksByMetadataSourceHash_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetBookIDsByISBNASIN provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookIDsByISBNASIN(isbn10 string, isbn13 string, asin string) ([]string, error) {
-	ret := _mock.Called(isbn10, isbn13, asin)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBookIDsByISBNASIN")
-	}
-
-	var r0 []string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) ([]string, error)); ok {
-		return returnFunc(isbn10, isbn13, asin)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, string, string) []string); ok {
-		r0 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
-		r1 = returnFunc(isbn10, isbn13, asin)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_GetBookIDsByISBNASIN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookIDsByISBNASIN'
-type MockStore_GetBookIDsByISBNASIN_Call struct {
-	*mock.Call
-}
-
-// GetBookIDsByISBNASIN is a helper method to define mock.On call
-//   - isbn10 string
-//   - isbn13 string
-//   - asin string
-func (_e *MockStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockStore_GetBookIDsByISBNASIN_Call {
-	return &MockStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
-}
-
-func (_c *MockStore_GetBookIDsByISBNASIN_Call) Run(run func(isbn10 string, isbn13 string, asin string)) *MockStore_GetBookIDsByISBNASIN_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(arg0, arg1, arg2)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBookIDsByISBNASIN_Call) Return(ids []string, err error) *MockStore_GetBookIDsByISBNASIN_Call {
-	_c.Call.Return(ids, err)
-	return _c
-}
-
-func (_c *MockStore_GetBookIDsByISBNASIN_Call) RunAndReturn(run func(string, string, string) ([]string, error)) *MockStore_GetBookIDsByISBNASIN_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -37550,7 +37884,7 @@ type MockStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockStore_GetBooksBySeriesID_Call {
+func (_e *MockStore_Expecter) GetBooksBySeriesID(seriesID any) *MockStore_GetBooksBySeriesID_Call {
 	return &MockStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -37612,7 +37946,7 @@ type MockStore_GetBooksByTag_Call struct {
 
 // GetBooksByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockStore_Expecter) GetBooksByTag(tag interface{}) *MockStore_GetBooksByTag_Call {
+func (_e *MockStore_Expecter) GetBooksByTag(tag any) *MockStore_GetBooksByTag_Call {
 	return &MockStore_GetBooksByTag_Call{Call: _e.mock.On("GetBooksByTag", tag)}
 }
 
@@ -37675,7 +38009,7 @@ type MockStore_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockStore_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockStore_GetBooksByTitleInDir_Call {
+func (_e *MockStore_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockStore_GetBooksByTitleInDir_Call {
 	return &MockStore_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -37742,7 +38076,7 @@ type MockStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockStore_GetBooksByVersionGroup_Call {
+func (_e *MockStore_Expecter) GetBooksByVersionGroup(groupID any) *MockStore_GetBooksByVersionGroup_Call {
 	return &MockStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -37804,7 +38138,7 @@ type MockStore_GetBooksByWorkID_Call struct {
 
 // GetBooksByWorkID is a helper method to define mock.On call
 //   - workID string
-func (_e *MockStore_Expecter) GetBooksByWorkID(workID interface{}) *MockStore_GetBooksByWorkID_Call {
+func (_e *MockStore_Expecter) GetBooksByWorkID(workID any) *MockStore_GetBooksByWorkID_Call {
 	return &MockStore_GetBooksByWorkID_Call{Call: _e.mock.On("GetBooksByWorkID", workID)}
 }
 
@@ -37921,7 +38255,7 @@ type MockStore_GetDeferredITunesUpdatesByBookID_Call struct {
 
 // GetDeferredITunesUpdatesByBookID is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetDeferredITunesUpdatesByBookID(bookID interface{}) *MockStore_GetDeferredITunesUpdatesByBookID_Call {
+func (_e *MockStore_Expecter) GetDeferredITunesUpdatesByBookID(bookID any) *MockStore_GetDeferredITunesUpdatesByBookID_Call {
 	return &MockStore_GetDeferredITunesUpdatesByBookID_Call{Call: _e.mock.On("GetDeferredITunesUpdatesByBookID", bookID)}
 }
 
@@ -37944,6 +38278,66 @@ func (_c *MockStore_GetDeferredITunesUpdatesByBookID_Call) Return(deferredITunes
 }
 
 func (_c *MockStore_GetDeferredITunesUpdatesByBookID_Call) RunAndReturn(run func(bookID string) ([]database.DeferredITunesUpdate, error)) *MockStore_GetDeferredITunesUpdatesByBookID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetDepRev provides a mock function for the type MockStore
+func (_mock *MockStore) GetDepRev(sub database.OpSubject) (uint64, error) {
+	ret := _mock.Called(sub)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDepRev")
+	}
+
+	var r0 uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
+		return returnFunc(sub)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
+		r0 = returnFunc(sub)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
+		r1 = returnFunc(sub)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDepRev'
+type MockStore_GetDepRev_Call struct {
+	*mock.Call
+}
+
+// GetDepRev is a helper method to define mock.On call
+//   - sub database.OpSubject
+func (_e *MockStore_Expecter) GetDepRev(sub any) *MockStore_GetDepRev_Call {
+	return &MockStore_GetDepRev_Call{Call: _e.mock.On("GetDepRev", sub)}
+}
+
+func (_c *MockStore_GetDepRev_Call) Run(run func(sub database.OpSubject)) *MockStore_GetDepRev_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetDepRev_Call) Return(v uint64, err error) *MockStore_GetDepRev_Call {
+	_c.Call.Return(v, err)
+	return _c
+}
+
+func (_c *MockStore_GetDepRev_Call) RunAndReturn(run func(sub database.OpSubject) (uint64, error)) *MockStore_GetDepRev_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -38203,7 +38597,7 @@ type MockStore_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockStore_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockStore_GetDuplicateBooksByMetadata_Call {
+func (_e *MockStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockStore_GetDuplicateBooksByMetadata_Call {
 	return &MockStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -38265,7 +38659,7 @@ type MockStore_GetDuplicateFilesByHash_Call struct {
 
 // GetDuplicateFilesByHash is a helper method to define mock.On call
 //   - limit int
-func (_e *MockStore_Expecter) GetDuplicateFilesByHash(limit interface{}) *MockStore_GetDuplicateFilesByHash_Call {
+func (_e *MockStore_Expecter) GetDuplicateFilesByHash(limit any) *MockStore_GetDuplicateFilesByHash_Call {
 	return &MockStore_GetDuplicateFilesByHash_Call{Call: _e.mock.On("GetDuplicateFilesByHash", limit)}
 }
 
@@ -38327,7 +38721,7 @@ type MockStore_GetExternalIDsForBook_Call struct {
 
 // GetExternalIDsForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetExternalIDsForBook(bookID interface{}) *MockStore_GetExternalIDsForBook_Call {
+func (_e *MockStore_Expecter) GetExternalIDsForBook(bookID any) *MockStore_GetExternalIDsForBook_Call {
 	return &MockStore_GetExternalIDsForBook_Call{Call: _e.mock.On("GetExternalIDsForBook", bookID)}
 }
 
@@ -38397,7 +38791,7 @@ type MockStore_GetFilesWithFingerprintFailures_Call struct {
 //   - reason string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) GetFilesWithFingerprintFailures(reason interface{}, limit interface{}, offset interface{}) *MockStore_GetFilesWithFingerprintFailures_Call {
+func (_e *MockStore_Expecter) GetFilesWithFingerprintFailures(reason any, limit any, offset any) *MockStore_GetFilesWithFingerprintFailures_Call {
 	return &MockStore_GetFilesWithFingerprintFailures_Call{Call: _e.mock.On("GetFilesWithFingerprintFailures", reason, limit, offset)}
 }
 
@@ -38634,7 +39028,7 @@ type MockStore_GetImportPathByID_Call struct {
 
 // GetImportPathByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) GetImportPathByID(id interface{}) *MockStore_GetImportPathByID_Call {
+func (_e *MockStore_Expecter) GetImportPathByID(id any) *MockStore_GetImportPathByID_Call {
 	return &MockStore_GetImportPathByID_Call{Call: _e.mock.On("GetImportPathByID", id)}
 }
 
@@ -38696,7 +39090,7 @@ type MockStore_GetImportPathByPath_Call struct {
 
 // GetImportPathByPath is a helper method to define mock.On call
 //   - path string
-func (_e *MockStore_Expecter) GetImportPathByPath(path interface{}) *MockStore_GetImportPathByPath_Call {
+func (_e *MockStore_Expecter) GetImportPathByPath(path any) *MockStore_GetImportPathByPath_Call {
 	return &MockStore_GetImportPathByPath_Call{Call: _e.mock.On("GetImportPathByPath", path)}
 }
 
@@ -38813,7 +39207,7 @@ type MockStore_GetInvite_Call struct {
 
 // GetInvite is a helper method to define mock.On call
 //   - token string
-func (_e *MockStore_Expecter) GetInvite(token interface{}) *MockStore_GetInvite_Call {
+func (_e *MockStore_Expecter) GetInvite(token any) *MockStore_GetInvite_Call {
 	return &MockStore_GetInvite_Call{Call: _e.mock.On("GetInvite", token)}
 }
 
@@ -38875,7 +39269,7 @@ type MockStore_GetLibraryFingerprint_Call struct {
 
 // GetLibraryFingerprint is a helper method to define mock.On call
 //   - path string
-func (_e *MockStore_Expecter) GetLibraryFingerprint(path interface{}) *MockStore_GetLibraryFingerprint_Call {
+func (_e *MockStore_Expecter) GetLibraryFingerprint(path any) *MockStore_GetLibraryFingerprint_Call {
 	return &MockStore_GetLibraryFingerprint_Call{Call: _e.mock.On("GetLibraryFingerprint", path)}
 }
 
@@ -38937,7 +39331,7 @@ type MockStore_GetMetadataCache_Call struct {
 
 // GetMetadataCache is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetMetadataCache(bookID interface{}) *MockStore_GetMetadataCache_Call {
+func (_e *MockStore_Expecter) GetMetadataCache(bookID any) *MockStore_GetMetadataCache_Call {
 	return &MockStore_GetMetadataCache_Call{Call: _e.mock.On("GetMetadataCache", bookID)}
 }
 
@@ -39001,7 +39395,7 @@ type MockStore_GetMetadataChangeHistory_Call struct {
 //   - bookID string
 //   - field string
 //   - limit int
-func (_e *MockStore_Expecter) GetMetadataChangeHistory(bookID interface{}, field interface{}, limit interface{}) *MockStore_GetMetadataChangeHistory_Call {
+func (_e *MockStore_Expecter) GetMetadataChangeHistory(bookID any, field any, limit any) *MockStore_GetMetadataChangeHistory_Call {
 	return &MockStore_GetMetadataChangeHistory_Call{Call: _e.mock.On("GetMetadataChangeHistory", bookID, field, limit)}
 }
 
@@ -39073,7 +39467,7 @@ type MockStore_GetMetadataFieldStates_Call struct {
 
 // GetMetadataFieldStates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetMetadataFieldStates(bookID interface{}) *MockStore_GetMetadataFieldStates_Call {
+func (_e *MockStore_Expecter) GetMetadataFieldStates(bookID any) *MockStore_GetMetadataFieldStates_Call {
 	return &MockStore_GetMetadataFieldStates_Call{Call: _e.mock.On("GetMetadataFieldStates", bookID)}
 }
 
@@ -39135,7 +39529,7 @@ type MockStore_GetMetadataRejections_Call struct {
 
 // GetMetadataRejections is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) GetMetadataRejections(bookID interface{}) *MockStore_GetMetadataRejections_Call {
+func (_e *MockStore_Expecter) GetMetadataRejections(bookID any) *MockStore_GetMetadataRejections_Call {
 	return &MockStore_GetMetadataRejections_Call{Call: _e.mock.On("GetMetadataRejections", bookID)}
 }
 
@@ -39197,7 +39591,7 @@ type MockStore_GetNarratorByID_Call struct {
 
 // GetNarratorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) GetNarratorByID(id interface{}) *MockStore_GetNarratorByID_Call {
+func (_e *MockStore_Expecter) GetNarratorByID(id any) *MockStore_GetNarratorByID_Call {
 	return &MockStore_GetNarratorByID_Call{Call: _e.mock.On("GetNarratorByID", id)}
 }
 
@@ -39259,7 +39653,7 @@ type MockStore_GetNarratorByName_Call struct {
 
 // GetNarratorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) GetNarratorByName(name interface{}) *MockStore_GetNarratorByName_Call {
+func (_e *MockStore_Expecter) GetNarratorByName(name any) *MockStore_GetNarratorByName_Call {
 	return &MockStore_GetNarratorByName_Call{Call: _e.mock.On("GetNarratorByName", name)}
 }
 
@@ -39322,7 +39716,7 @@ type MockStore_GetNarratorsByBookIDs_Call struct {
 // GetNarratorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockStore_Expecter) GetNarratorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockStore_GetNarratorsByBookIDs_Call {
+func (_e *MockStore_Expecter) GetNarratorsByBookIDs(ctx any, bookIDs any) *MockStore_GetNarratorsByBookIDs_Call {
 	return &MockStore_GetNarratorsByBookIDs_Call{Call: _e.mock.On("GetNarratorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -39350,6 +39744,78 @@ func (_c *MockStore_GetNarratorsByBookIDs_Call) Return(stringToNarrators map[str
 }
 
 func (_c *MockStore_GetNarratorsByBookIDs_Call) RunAndReturn(run func(ctx context.Context, bookIDs []string) (map[string][]database.Narrator, error)) *MockStore_GetNarratorsByBookIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetOpCompletion provides a mock function for the type MockStore
+func (_mock *MockStore) GetOpCompletion(sub database.OpSubject, opType string) (uint64, bool, error) {
+	ret := _mock.Called(sub, opType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetOpCompletion")
+	}
+
+	var r0 uint64
+	var r1 bool
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (uint64, bool, error)); ok {
+		return returnFunc(sub, opType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) uint64); ok {
+		r0 = returnFunc(sub, opType)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) bool); ok {
+		r1 = returnFunc(sub, opType)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	if returnFunc, ok := ret.Get(2).(func(database.OpSubject, string) error); ok {
+		r2 = returnFunc(sub, opType)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockStore_GetOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOpCompletion'
+type MockStore_GetOpCompletion_Call struct {
+	*mock.Call
+}
+
+// GetOpCompletion is a helper method to define mock.On call
+//   - sub database.OpSubject
+//   - opType string
+func (_e *MockStore_Expecter) GetOpCompletion(sub any, opType any) *MockStore_GetOpCompletion_Call {
+	return &MockStore_GetOpCompletion_Call{Call: _e.mock.On("GetOpCompletion", sub, opType)}
+}
+
+func (_c *MockStore_GetOpCompletion_Call) Run(run func(sub database.OpSubject, opType string)) *MockStore_GetOpCompletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetOpCompletion_Call) Return(rev uint64, ok bool, err error) *MockStore_GetOpCompletion_Call {
+	_c.Call.Return(rev, ok, err)
+	return _c
+}
+
+func (_c *MockStore_GetOpCompletion_Call) RunAndReturn(run func(sub database.OpSubject, opType string) (uint64, bool, error)) *MockStore_GetOpCompletion_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -39390,7 +39856,7 @@ type MockStore_GetOpLogsV2_Call struct {
 // GetOpLogsV2 is a helper method to define mock.On call
 //   - opID string
 //   - limit int
-func (_e *MockStore_Expecter) GetOpLogsV2(opID interface{}, limit interface{}) *MockStore_GetOpLogsV2_Call {
+func (_e *MockStore_Expecter) GetOpLogsV2(opID any, limit any) *MockStore_GetOpLogsV2_Call {
 	return &MockStore_GetOpLogsV2_Call{Call: _e.mock.On("GetOpLogsV2", opID, limit)}
 }
 
@@ -39457,7 +39923,7 @@ type MockStore_GetOpStateV2_Call struct {
 
 // GetOpStateV2 is a helper method to define mock.On call
 //   - opID string
-func (_e *MockStore_Expecter) GetOpStateV2(opID interface{}) *MockStore_GetOpStateV2_Call {
+func (_e *MockStore_Expecter) GetOpStateV2(opID any) *MockStore_GetOpStateV2_Call {
 	return &MockStore_GetOpStateV2_Call{Call: _e.mock.On("GetOpStateV2", opID)}
 }
 
@@ -39519,7 +39985,7 @@ type MockStore_GetOperationByID_Call struct {
 
 // GetOperationByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetOperationByID(id interface{}) *MockStore_GetOperationByID_Call {
+func (_e *MockStore_Expecter) GetOperationByID(id any) *MockStore_GetOperationByID_Call {
 	return &MockStore_GetOperationByID_Call{Call: _e.mock.On("GetOperationByID", id)}
 }
 
@@ -39581,7 +40047,7 @@ type MockStore_GetOperationChanges_Call struct {
 
 // GetOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockStore_Expecter) GetOperationChanges(operationID interface{}) *MockStore_GetOperationChanges_Call {
+func (_e *MockStore_Expecter) GetOperationChanges(operationID any) *MockStore_GetOperationChanges_Call {
 	return &MockStore_GetOperationChanges_Call{Call: _e.mock.On("GetOperationChanges", operationID)}
 }
 
@@ -39643,7 +40109,7 @@ type MockStore_GetOperationLogs_Call struct {
 
 // GetOperationLogs is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockStore_Expecter) GetOperationLogs(operationID interface{}) *MockStore_GetOperationLogs_Call {
+func (_e *MockStore_Expecter) GetOperationLogs(operationID any) *MockStore_GetOperationLogs_Call {
 	return &MockStore_GetOperationLogs_Call{Call: _e.mock.On("GetOperationLogs", operationID)}
 }
 
@@ -39705,7 +40171,7 @@ type MockStore_GetOperationParams_Call struct {
 
 // GetOperationParams is a helper method to define mock.On call
 //   - opID string
-func (_e *MockStore_Expecter) GetOperationParams(opID interface{}) *MockStore_GetOperationParams_Call {
+func (_e *MockStore_Expecter) GetOperationParams(opID any) *MockStore_GetOperationParams_Call {
 	return &MockStore_GetOperationParams_Call{Call: _e.mock.On("GetOperationParams", opID)}
 }
 
@@ -39767,7 +40233,7 @@ type MockStore_GetOperationResults_Call struct {
 
 // GetOperationResults is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockStore_Expecter) GetOperationResults(operationID interface{}) *MockStore_GetOperationResults_Call {
+func (_e *MockStore_Expecter) GetOperationResults(operationID any) *MockStore_GetOperationResults_Call {
 	return &MockStore_GetOperationResults_Call{Call: _e.mock.On("GetOperationResults", operationID)}
 }
 
@@ -39837,7 +40303,7 @@ type MockStore_GetOperationResultsPage_Call struct {
 //   - operationID string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) GetOperationResultsPage(operationID interface{}, limit interface{}, offset interface{}) *MockStore_GetOperationResultsPage_Call {
+func (_e *MockStore_Expecter) GetOperationResultsPage(operationID any, limit any, offset any) *MockStore_GetOperationResultsPage_Call {
 	return &MockStore_GetOperationResultsPage_Call{Call: _e.mock.On("GetOperationResultsPage", operationID, limit, offset)}
 }
 
@@ -39909,7 +40375,7 @@ type MockStore_GetOperationState_Call struct {
 
 // GetOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockStore_Expecter) GetOperationState(opID interface{}) *MockStore_GetOperationState_Call {
+func (_e *MockStore_Expecter) GetOperationState(opID any) *MockStore_GetOperationState_Call {
 	return &MockStore_GetOperationState_Call{Call: _e.mock.On("GetOperationState", opID)}
 }
 
@@ -39971,7 +40437,7 @@ type MockStore_GetOperationSummaryLog_Call struct {
 
 // GetOperationSummaryLog is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetOperationSummaryLog(id interface{}) *MockStore_GetOperationSummaryLog_Call {
+func (_e *MockStore_Expecter) GetOperationSummaryLog(id any) *MockStore_GetOperationSummaryLog_Call {
 	return &MockStore_GetOperationSummaryLog_Call{Call: _e.mock.On("GetOperationSummaryLog", id)}
 }
 
@@ -40033,7 +40499,7 @@ type MockStore_GetOperationV2_Call struct {
 
 // GetOperationV2 is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetOperationV2(id interface{}) *MockStore_GetOperationV2_Call {
+func (_e *MockStore_Expecter) GetOperationV2(id any) *MockStore_GetOperationV2_Call {
 	return &MockStore_GetOperationV2_Call{Call: _e.mock.On("GetOperationV2", id)}
 }
 
@@ -40151,7 +40617,7 @@ type MockStore_GetPlaybackProgress_Call struct {
 // GetPlaybackProgress is a helper method to define mock.On call
 //   - userID string
 //   - bookNumericID int
-func (_e *MockStore_Expecter) GetPlaybackProgress(userID interface{}, bookNumericID interface{}) *MockStore_GetPlaybackProgress_Call {
+func (_e *MockStore_Expecter) GetPlaybackProgress(userID any, bookNumericID any) *MockStore_GetPlaybackProgress_Call {
 	return &MockStore_GetPlaybackProgress_Call{Call: _e.mock.On("GetPlaybackProgress", userID, bookNumericID)}
 }
 
@@ -40218,7 +40684,7 @@ type MockStore_GetPlaylistByID_Call struct {
 
 // GetPlaylistByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) GetPlaylistByID(id interface{}) *MockStore_GetPlaylistByID_Call {
+func (_e *MockStore_Expecter) GetPlaylistByID(id any) *MockStore_GetPlaylistByID_Call {
 	return &MockStore_GetPlaylistByID_Call{Call: _e.mock.On("GetPlaylistByID", id)}
 }
 
@@ -40280,7 +40746,7 @@ type MockStore_GetPlaylistBySeriesID_Call struct {
 
 // GetPlaylistBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockStore_Expecter) GetPlaylistBySeriesID(seriesID interface{}) *MockStore_GetPlaylistBySeriesID_Call {
+func (_e *MockStore_Expecter) GetPlaylistBySeriesID(seriesID any) *MockStore_GetPlaylistBySeriesID_Call {
 	return &MockStore_GetPlaylistBySeriesID_Call{Call: _e.mock.On("GetPlaylistBySeriesID", seriesID)}
 }
 
@@ -40342,7 +40808,7 @@ type MockStore_GetPlaylistItems_Call struct {
 
 // GetPlaylistItems is a helper method to define mock.On call
 //   - playlistID int
-func (_e *MockStore_Expecter) GetPlaylistItems(playlistID interface{}) *MockStore_GetPlaylistItems_Call {
+func (_e *MockStore_Expecter) GetPlaylistItems(playlistID any) *MockStore_GetPlaylistItems_Call {
 	return &MockStore_GetPlaylistItems_Call{Call: _e.mock.On("GetPlaylistItems", playlistID)}
 }
 
@@ -40405,7 +40871,7 @@ type MockStore_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockStore_GetQuarantinedBooks_Call {
+func (_e *MockStore_Expecter) GetQuarantinedBooks(limit any, offset any) *MockStore_GetQuarantinedBooks_Call {
 	return &MockStore_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -40472,7 +40938,7 @@ type MockStore_GetRaw_Call struct {
 
 // GetRaw is a helper method to define mock.On call
 //   - key string
-func (_e *MockStore_Expecter) GetRaw(key interface{}) *MockStore_GetRaw_Call {
+func (_e *MockStore_Expecter) GetRaw(key any) *MockStore_GetRaw_Call {
 	return &MockStore_GetRaw_Call{Call: _e.mock.On("GetRaw", key)}
 }
 
@@ -40534,7 +41000,7 @@ type MockStore_GetRecentCompletedOperations_Call struct {
 
 // GetRecentCompletedOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockStore_Expecter) GetRecentCompletedOperations(limit interface{}) *MockStore_GetRecentCompletedOperations_Call {
+func (_e *MockStore_Expecter) GetRecentCompletedOperations(limit any) *MockStore_GetRecentCompletedOperations_Call {
 	return &MockStore_GetRecentCompletedOperations_Call{Call: _e.mock.On("GetRecentCompletedOperations", limit)}
 }
 
@@ -40596,7 +41062,7 @@ type MockStore_GetRecentOperations_Call struct {
 
 // GetRecentOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockStore_Expecter) GetRecentOperations(limit interface{}) *MockStore_GetRecentOperations_Call {
+func (_e *MockStore_Expecter) GetRecentOperations(limit any) *MockStore_GetRecentOperations_Call {
 	return &MockStore_GetRecentOperations_Call{Call: _e.mock.On("GetRecentOperations", limit)}
 }
 
@@ -40658,7 +41124,7 @@ type MockStore_GetRemovedExternalIDs_Call struct {
 
 // GetRemovedExternalIDs is a helper method to define mock.On call
 //   - source string
-func (_e *MockStore_Expecter) GetRemovedExternalIDs(source interface{}) *MockStore_GetRemovedExternalIDs_Call {
+func (_e *MockStore_Expecter) GetRemovedExternalIDs(source any) *MockStore_GetRemovedExternalIDs_Call {
 	return &MockStore_GetRemovedExternalIDs_Call{Call: _e.mock.On("GetRemovedExternalIDs", source)}
 }
 
@@ -40720,7 +41186,7 @@ type MockStore_GetRoleByID_Call struct {
 
 // GetRoleByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetRoleByID(id interface{}) *MockStore_GetRoleByID_Call {
+func (_e *MockStore_Expecter) GetRoleByID(id any) *MockStore_GetRoleByID_Call {
 	return &MockStore_GetRoleByID_Call{Call: _e.mock.On("GetRoleByID", id)}
 }
 
@@ -40782,7 +41248,7 @@ type MockStore_GetRoleByName_Call struct {
 
 // GetRoleByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) GetRoleByName(name interface{}) *MockStore_GetRoleByName_Call {
+func (_e *MockStore_Expecter) GetRoleByName(name any) *MockStore_GetRoleByName_Call {
 	return &MockStore_GetRoleByName_Call{Call: _e.mock.On("GetRoleByName", name)}
 }
 
@@ -40897,7 +41363,7 @@ type MockStore_GetScanFailCount_Call struct {
 
 // GetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockStore_Expecter) GetScanFailCount(pathHash interface{}) *MockStore_GetScanFailCount_Call {
+func (_e *MockStore_Expecter) GetScanFailCount(pathHash any) *MockStore_GetScanFailCount_Call {
 	return &MockStore_GetScanFailCount_Call{Call: _e.mock.On("GetScanFailCount", pathHash)}
 }
 
@@ -40959,7 +41425,7 @@ type MockStore_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) GetSeriesByID(id interface{}) *MockStore_GetSeriesByID_Call {
+func (_e *MockStore_Expecter) GetSeriesByID(id any) *MockStore_GetSeriesByID_Call {
 	return &MockStore_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 
@@ -41021,7 +41487,7 @@ type MockStore_GetSeriesByIDs_Call struct {
 
 // GetSeriesByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockStore_Expecter) GetSeriesByIDs(ids interface{}) *MockStore_GetSeriesByIDs_Call {
+func (_e *MockStore_Expecter) GetSeriesByIDs(ids any) *MockStore_GetSeriesByIDs_Call {
 	return &MockStore_GetSeriesByIDs_Call{Call: _e.mock.On("GetSeriesByIDs", ids)}
 }
 
@@ -41084,7 +41550,7 @@ type MockStore_GetSeriesByName_Call struct {
 // GetSeriesByName is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockStore_Expecter) GetSeriesByName(name interface{}, authorID interface{}) *MockStore_GetSeriesByName_Call {
+func (_e *MockStore_Expecter) GetSeriesByName(name any, authorID any) *MockStore_GetSeriesByName_Call {
 	return &MockStore_GetSeriesByName_Call{Call: _e.mock.On("GetSeriesByName", name, authorID)}
 }
 
@@ -41151,7 +41617,7 @@ type MockStore_GetSeriesByTag_Call struct {
 
 // GetSeriesByTag is a helper method to define mock.On call
 //   - tag string
-func (_e *MockStore_Expecter) GetSeriesByTag(tag interface{}) *MockStore_GetSeriesByTag_Call {
+func (_e *MockStore_Expecter) GetSeriesByTag(tag any) *MockStore_GetSeriesByTag_Call {
 	return &MockStore_GetSeriesByTag_Call{Call: _e.mock.On("GetSeriesByTag", tag)}
 }
 
@@ -41213,7 +41679,7 @@ type MockStore_GetSeriesTags_Call struct {
 
 // GetSeriesTags is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockStore_Expecter) GetSeriesTags(seriesID interface{}) *MockStore_GetSeriesTags_Call {
+func (_e *MockStore_Expecter) GetSeriesTags(seriesID any) *MockStore_GetSeriesTags_Call {
 	return &MockStore_GetSeriesTags_Call{Call: _e.mock.On("GetSeriesTags", seriesID)}
 }
 
@@ -41275,7 +41741,7 @@ type MockStore_GetSeriesTagsDetailed_Call struct {
 
 // GetSeriesTagsDetailed is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockStore_Expecter) GetSeriesTagsDetailed(seriesID interface{}) *MockStore_GetSeriesTagsDetailed_Call {
+func (_e *MockStore_Expecter) GetSeriesTagsDetailed(seriesID any) *MockStore_GetSeriesTagsDetailed_Call {
 	return &MockStore_GetSeriesTagsDetailed_Call{Call: _e.mock.On("GetSeriesTagsDetailed", seriesID)}
 }
 
@@ -41337,7 +41803,7 @@ type MockStore_GetSession_Call struct {
 
 // GetSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetSession(id interface{}) *MockStore_GetSession_Call {
+func (_e *MockStore_Expecter) GetSession(id any) *MockStore_GetSession_Call {
 	return &MockStore_GetSession_Call{Call: _e.mock.On("GetSession", id)}
 }
 
@@ -41399,7 +41865,7 @@ type MockStore_GetSetting_Call struct {
 
 // GetSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockStore_Expecter) GetSetting(key interface{}) *MockStore_GetSetting_Call {
+func (_e *MockStore_Expecter) GetSetting(key any) *MockStore_GetSetting_Call {
 	return &MockStore_GetSetting_Call{Call: _e.mock.On("GetSetting", key)}
 }
 
@@ -41462,7 +41928,7 @@ type MockStore_GetSystemActivityLogs_Call struct {
 // GetSystemActivityLogs is a helper method to define mock.On call
 //   - source string
 //   - limit int
-func (_e *MockStore_Expecter) GetSystemActivityLogs(source interface{}, limit interface{}) *MockStore_GetSystemActivityLogs_Call {
+func (_e *MockStore_Expecter) GetSystemActivityLogs(source any, limit any) *MockStore_GetSystemActivityLogs_Call {
 	return &MockStore_GetSystemActivityLogs_Call{Call: _e.mock.On("GetSystemActivityLogs", source, limit)}
 }
 
@@ -41530,7 +41996,7 @@ type MockStore_GetUserBookState_Call struct {
 // GetUserBookState is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockStore_Expecter) GetUserBookState(userID interface{}, bookID interface{}) *MockStore_GetUserBookState_Call {
+func (_e *MockStore_Expecter) GetUserBookState(userID any, bookID any) *MockStore_GetUserBookState_Call {
 	return &MockStore_GetUserBookState_Call{Call: _e.mock.On("GetUserBookState", userID, bookID)}
 }
 
@@ -41597,7 +42063,7 @@ type MockStore_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - email string
-func (_e *MockStore_Expecter) GetUserByEmail(email interface{}) *MockStore_GetUserByEmail_Call {
+func (_e *MockStore_Expecter) GetUserByEmail(email any) *MockStore_GetUserByEmail_Call {
 	return &MockStore_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", email)}
 }
 
@@ -41659,7 +42125,7 @@ type MockStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetUserByID(id interface{}) *MockStore_GetUserByID_Call {
+func (_e *MockStore_Expecter) GetUserByID(id any) *MockStore_GetUserByID_Call {
 	return &MockStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -41721,7 +42187,7 @@ type MockStore_GetUserByUsername_Call struct {
 
 // GetUserByUsername is a helper method to define mock.On call
 //   - username string
-func (_e *MockStore_Expecter) GetUserByUsername(username interface{}) *MockStore_GetUserByUsername_Call {
+func (_e *MockStore_Expecter) GetUserByUsername(username any) *MockStore_GetUserByUsername_Call {
 	return &MockStore_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", username)}
 }
 
@@ -41783,7 +42249,7 @@ type MockStore_GetUserPlaylist_Call struct {
 
 // GetUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetUserPlaylist(id interface{}) *MockStore_GetUserPlaylist_Call {
+func (_e *MockStore_Expecter) GetUserPlaylist(id any) *MockStore_GetUserPlaylist_Call {
 	return &MockStore_GetUserPlaylist_Call{Call: _e.mock.On("GetUserPlaylist", id)}
 }
 
@@ -41845,7 +42311,7 @@ type MockStore_GetUserPlaylistByITunesPID_Call struct {
 
 // GetUserPlaylistByITunesPID is a helper method to define mock.On call
 //   - pid string
-func (_e *MockStore_Expecter) GetUserPlaylistByITunesPID(pid interface{}) *MockStore_GetUserPlaylistByITunesPID_Call {
+func (_e *MockStore_Expecter) GetUserPlaylistByITunesPID(pid any) *MockStore_GetUserPlaylistByITunesPID_Call {
 	return &MockStore_GetUserPlaylistByITunesPID_Call{Call: _e.mock.On("GetUserPlaylistByITunesPID", pid)}
 }
 
@@ -41907,7 +42373,7 @@ type MockStore_GetUserPlaylistByName_Call struct {
 
 // GetUserPlaylistByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockStore_Expecter) GetUserPlaylistByName(name interface{}) *MockStore_GetUserPlaylistByName_Call {
+func (_e *MockStore_Expecter) GetUserPlaylistByName(name any) *MockStore_GetUserPlaylistByName_Call {
 	return &MockStore_GetUserPlaylistByName_Call{Call: _e.mock.On("GetUserPlaylistByName", name)}
 }
 
@@ -41970,7 +42436,7 @@ type MockStore_GetUserPosition_Call struct {
 // GetUserPosition is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockStore_Expecter) GetUserPosition(userID interface{}, bookID interface{}) *MockStore_GetUserPosition_Call {
+func (_e *MockStore_Expecter) GetUserPosition(userID any, bookID any) *MockStore_GetUserPosition_Call {
 	return &MockStore_GetUserPosition_Call{Call: _e.mock.On("GetUserPosition", userID, bookID)}
 }
 
@@ -42037,7 +42503,7 @@ type MockStore_GetUserPreference_Call struct {
 
 // GetUserPreference is a helper method to define mock.On call
 //   - key string
-func (_e *MockStore_Expecter) GetUserPreference(key interface{}) *MockStore_GetUserPreference_Call {
+func (_e *MockStore_Expecter) GetUserPreference(key any) *MockStore_GetUserPreference_Call {
 	return &MockStore_GetUserPreference_Call{Call: _e.mock.On("GetUserPreference", key)}
 }
 
@@ -42100,7 +42566,7 @@ type MockStore_GetUserPreferenceForUser_Call struct {
 // GetUserPreferenceForUser is a helper method to define mock.On call
 //   - userID string
 //   - key string
-func (_e *MockStore_Expecter) GetUserPreferenceForUser(userID interface{}, key interface{}) *MockStore_GetUserPreferenceForUser_Call {
+func (_e *MockStore_Expecter) GetUserPreferenceForUser(userID any, key any) *MockStore_GetUserPreferenceForUser_Call {
 	return &MockStore_GetUserPreferenceForUser_Call{Call: _e.mock.On("GetUserPreferenceForUser", userID, key)}
 }
 
@@ -42167,7 +42633,7 @@ type MockStore_GetUserStats_Call struct {
 
 // GetUserStats is a helper method to define mock.On call
 //   - userID string
-func (_e *MockStore_Expecter) GetUserStats(userID interface{}) *MockStore_GetUserStats_Call {
+func (_e *MockStore_Expecter) GetUserStats(userID any) *MockStore_GetUserStats_Call {
 	return &MockStore_GetUserStats_Call{Call: _e.mock.On("GetUserStats", userID)}
 }
 
@@ -42229,7 +42695,7 @@ type MockStore_GetWorkByID_Call struct {
 
 // GetWorkByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) GetWorkByID(id interface{}) *MockStore_GetWorkByID_Call {
+func (_e *MockStore_Expecter) GetWorkByID(id any) *MockStore_GetWorkByID_Call {
 	return &MockStore_GetWorkByID_Call{Call: _e.mock.On("GetWorkByID", id)}
 }
 
@@ -42289,7 +42755,7 @@ type MockStore_IncrScanFailCount_Call struct {
 
 // IncrScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockStore_Expecter) IncrScanFailCount(pathHash interface{}) *MockStore_IncrScanFailCount_Call {
+func (_e *MockStore_Expecter) IncrScanFailCount(pathHash any) *MockStore_IncrScanFailCount_Call {
 	return &MockStore_IncrScanFailCount_Call{Call: _e.mock.On("IncrScanFailCount", pathHash)}
 }
 
@@ -42341,7 +42807,7 @@ type MockStore_IncrementBookPlayStats_Call struct {
 // IncrementBookPlayStats is a helper method to define mock.On call
 //   - bookNumericID int
 //   - seconds int
-func (_e *MockStore_Expecter) IncrementBookPlayStats(bookNumericID interface{}, seconds interface{}) *MockStore_IncrementBookPlayStats_Call {
+func (_e *MockStore_Expecter) IncrementBookPlayStats(bookNumericID any, seconds any) *MockStore_IncrementBookPlayStats_Call {
 	return &MockStore_IncrementBookPlayStats_Call{Call: _e.mock.On("IncrementBookPlayStats", bookNumericID, seconds)}
 }
 
@@ -42397,7 +42863,7 @@ type MockStore_IncrementResumeCountV2_Call struct {
 
 // IncrementResumeCountV2 is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) IncrementResumeCountV2(id interface{}) *MockStore_IncrementResumeCountV2_Call {
+func (_e *MockStore_Expecter) IncrementResumeCountV2(id any) *MockStore_IncrementResumeCountV2_Call {
 	return &MockStore_IncrementResumeCountV2_Call{Call: _e.mock.On("IncrementResumeCountV2", id)}
 }
 
@@ -42449,7 +42915,7 @@ type MockStore_IncrementUserListenStats_Call struct {
 // IncrementUserListenStats is a helper method to define mock.On call
 //   - userID string
 //   - seconds int
-func (_e *MockStore_Expecter) IncrementUserListenStats(userID interface{}, seconds interface{}) *MockStore_IncrementUserListenStats_Call {
+func (_e *MockStore_Expecter) IncrementUserListenStats(userID any, seconds any) *MockStore_IncrementUserListenStats_Call {
 	return &MockStore_IncrementUserListenStats_Call{Call: _e.mock.On("IncrementUserListenStats", userID, seconds)}
 }
 
@@ -42505,7 +42971,7 @@ type MockStore_InsertOpErrorV2_Call struct {
 
 // InsertOpErrorV2 is a helper method to define mock.On call
 //   - row database.OpErrorV2Row
-func (_e *MockStore_Expecter) InsertOpErrorV2(row interface{}) *MockStore_InsertOpErrorV2_Call {
+func (_e *MockStore_Expecter) InsertOpErrorV2(row any) *MockStore_InsertOpErrorV2_Call {
 	return &MockStore_InsertOpErrorV2_Call{Call: _e.mock.On("InsertOpErrorV2", row)}
 }
 
@@ -42556,7 +43022,7 @@ type MockStore_InsertOpStrikeV2_Call struct {
 
 // InsertOpStrikeV2 is a helper method to define mock.On call
 //   - row database.OpStrikeV2Row
-func (_e *MockStore_Expecter) InsertOpStrikeV2(row interface{}) *MockStore_InsertOpStrikeV2_Call {
+func (_e *MockStore_Expecter) InsertOpStrikeV2(row any) *MockStore_InsertOpStrikeV2_Call {
 	return &MockStore_InsertOpStrikeV2_Call{Call: _e.mock.On("InsertOpStrikeV2", row)}
 }
 
@@ -42607,7 +43073,7 @@ type MockStore_InsertOperationV2_Call struct {
 
 // InsertOperationV2 is a helper method to define mock.On call
 //   - row database.OperationV2Row
-func (_e *MockStore_Expecter) InsertOperationV2(row interface{}) *MockStore_InsertOperationV2_Call {
+func (_e *MockStore_Expecter) InsertOperationV2(row any) *MockStore_InsertOperationV2_Call {
 	return &MockStore_InsertOperationV2_Call{Call: _e.mock.On("InsertOperationV2", row)}
 }
 
@@ -42701,7 +43167,7 @@ type MockStore_IsExternalIDTombstoned_Call struct {
 // IsExternalIDTombstoned is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockStore_Expecter) IsExternalIDTombstoned(source interface{}, externalID interface{}) *MockStore_IsExternalIDTombstoned_Call {
+func (_e *MockStore_Expecter) IsExternalIDTombstoned(source any, externalID any) *MockStore_IsExternalIDTombstoned_Call {
 	return &MockStore_IsExternalIDTombstoned_Call{Call: _e.mock.On("IsExternalIDTombstoned", source, externalID)}
 }
 
@@ -42766,7 +43232,7 @@ type MockStore_IsHashBlocked_Call struct {
 
 // IsHashBlocked is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) IsHashBlocked(hash interface{}) *MockStore_IsHashBlocked_Call {
+func (_e *MockStore_Expecter) IsHashBlocked(hash any) *MockStore_IsHashBlocked_Call {
 	return &MockStore_IsHashBlocked_Call{Call: _e.mock.On("IsHashBlocked", hash)}
 }
 
@@ -42831,7 +43297,7 @@ type MockStore_ListAIJobs_Call struct {
 //   - statusFilter string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListAIJobs(typeFilter interface{}, statusFilter interface{}, limit interface{}, offset interface{}) *MockStore_ListAIJobs_Call {
+func (_e *MockStore_Expecter) ListAIJobs(typeFilter any, statusFilter any, limit any, offset any) *MockStore_ListAIJobs_Call {
 	return &MockStore_ListAIJobs_Call{Call: _e.mock.On("ListAIJobs", typeFilter, statusFilter, limit, offset)}
 }
 
@@ -42908,7 +43374,7 @@ type MockStore_ListAPIKeysForUser_Call struct {
 
 // ListAPIKeysForUser is a helper method to define mock.On call
 //   - userID string
-func (_e *MockStore_Expecter) ListAPIKeysForUser(userID interface{}) *MockStore_ListAPIKeysForUser_Call {
+func (_e *MockStore_Expecter) ListAPIKeysForUser(userID any) *MockStore_ListAPIKeysForUser_Call {
 	return &MockStore_ListAPIKeysForUser_Call{Call: _e.mock.On("ListAPIKeysForUser", userID)}
 }
 
@@ -43265,6 +43731,68 @@ func (_c *MockStore_ListAllTags_Call) RunAndReturn(run func() ([]database.TagWit
 	return _c
 }
 
+// ListBatchBucket provides a mock function for the type MockStore
+func (_mock *MockStore) ListBatchBucket(opType string) ([]database.BatchBucketEntry, error) {
+	ret := _mock.Called(opType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListBatchBucket")
+	}
+
+	var r0 []database.BatchBucketEntry
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BatchBucketEntry, error)); ok {
+		return returnFunc(opType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []database.BatchBucketEntry); ok {
+		r0 = returnFunc(opType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BatchBucketEntry)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(opType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBatchBucket'
+type MockStore_ListBatchBucket_Call struct {
+	*mock.Call
+}
+
+// ListBatchBucket is a helper method to define mock.On call
+//   - opType string
+func (_e *MockStore_Expecter) ListBatchBucket(opType any) *MockStore_ListBatchBucket_Call {
+	return &MockStore_ListBatchBucket_Call{Call: _e.mock.On("ListBatchBucket", opType)}
+}
+
+func (_c *MockStore_ListBatchBucket_Call) Run(run func(opType string)) *MockStore_ListBatchBucket_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListBatchBucket_Call) Return(batchBucketEntrys []database.BatchBucketEntry, err error) *MockStore_ListBatchBucket_Call {
+	_c.Call.Return(batchBucketEntrys, err)
+	return _c
+}
+
+func (_c *MockStore_ListBatchBucket_Call) RunAndReturn(run func(opType string) ([]database.BatchBucketEntry, error)) *MockStore_ListBatchBucket_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListBookIDs provides a mock function for the type MockStore
 func (_mock *MockStore) ListBookIDs() ([]string, error) {
 	ret := _mock.Called()
@@ -43355,7 +43883,7 @@ type MockStore_ListBookSegments_Call struct {
 
 // ListBookSegments is a helper method to define mock.On call
 //   - bookNumericID int
-func (_e *MockStore_Expecter) ListBookSegments(bookNumericID interface{}) *MockStore_ListBookSegments_Call {
+func (_e *MockStore_Expecter) ListBookSegments(bookNumericID any) *MockStore_ListBookSegments_Call {
 	return &MockStore_ListBookSegments_Call{Call: _e.mock.On("ListBookSegments", bookNumericID)}
 }
 
@@ -43417,7 +43945,7 @@ type MockStore_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockStore_Expecter) ListBookTombstones(limit interface{}) *MockStore_ListBookTombstones_Call {
+func (_e *MockStore_Expecter) ListBookTombstones(limit any) *MockStore_ListBookTombstones_Call {
 	return &MockStore_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -43480,7 +44008,7 @@ type MockStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockStore_ListBooksByITunesPID_Call {
+func (_e *MockStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockStore_ListBooksByITunesPID_Call {
 	return &MockStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -43563,6 +44091,74 @@ func (_c *MockStore_ListDirtyUserPlaylists_Call) Return(userPlaylists []database
 }
 
 func (_c *MockStore_ListDirtyUserPlaylists_Call) RunAndReturn(run func() ([]database.UserPlaylist, error)) *MockStore_ListDirtyUserPlaylists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListFileCompletions provides a mock function for the type MockStore
+func (_mock *MockStore) ListFileCompletions(sub database.OpSubject, opType string) (map[string]uint64, error) {
+	ret := _mock.Called(sub, opType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListFileCompletions")
+	}
+
+	var r0 map[string]uint64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (map[string]uint64, error)); ok {
+		return returnFunc(sub, opType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) map[string]uint64); ok {
+		r0 = returnFunc(sub, opType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]uint64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) error); ok {
+		r1 = returnFunc(sub, opType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListFileCompletions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFileCompletions'
+type MockStore_ListFileCompletions_Call struct {
+	*mock.Call
+}
+
+// ListFileCompletions is a helper method to define mock.On call
+//   - sub database.OpSubject
+//   - opType string
+func (_e *MockStore_Expecter) ListFileCompletions(sub any, opType any) *MockStore_ListFileCompletions_Call {
+	return &MockStore_ListFileCompletions_Call{Call: _e.mock.On("ListFileCompletions", sub, opType)}
+}
+
+func (_c *MockStore_ListFileCompletions_Call) Run(run func(sub database.OpSubject, opType string)) *MockStore_ListFileCompletions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListFileCompletions_Call) Return(stringToUint64 map[string]uint64, err error) *MockStore_ListFileCompletions_Call {
+	_c.Call.Return(stringToUint64, err)
+	return _c
+}
+
+func (_c *MockStore_ListFileCompletions_Call) RunAndReturn(run func(sub database.OpSubject, opType string) (map[string]uint64, error)) *MockStore_ListFileCompletions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -43713,7 +44309,7 @@ type MockStore_ListOperationSummaryLogs_Call struct {
 // ListOperationSummaryLogs is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListOperationSummaryLogs(limit interface{}, offset interface{}) *MockStore_ListOperationSummaryLogs_Call {
+func (_e *MockStore_Expecter) ListOperationSummaryLogs(limit any, offset any) *MockStore_ListOperationSummaryLogs_Call {
 	return &MockStore_ListOperationSummaryLogs_Call{Call: _e.mock.On("ListOperationSummaryLogs", limit, offset)}
 }
 
@@ -43787,7 +44383,7 @@ type MockStore_ListOperations_Call struct {
 // ListOperations is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListOperations(limit interface{}, offset interface{}) *MockStore_ListOperations_Call {
+func (_e *MockStore_Expecter) ListOperations(limit any, offset any) *MockStore_ListOperations_Call {
 	return &MockStore_ListOperations_Call{Call: _e.mock.On("ListOperations", limit, offset)}
 }
 
@@ -43855,7 +44451,7 @@ type MockStore_ListOperationsV2Since_Call struct {
 // ListOperationsV2Since is a helper method to define mock.On call
 //   - since time.Time
 //   - limit int
-func (_e *MockStore_Expecter) ListOperationsV2Since(since interface{}, limit interface{}) *MockStore_ListOperationsV2Since_Call {
+func (_e *MockStore_Expecter) ListOperationsV2Since(since any, limit any) *MockStore_ListOperationsV2Since_Call {
 	return &MockStore_ListOperationsV2Since_Call{Call: _e.mock.On("ListOperationsV2Since", since, limit)}
 }
 
@@ -43924,7 +44520,7 @@ type MockStore_ListPlaybackEvents_Call struct {
 //   - userID string
 //   - bookNumericID int
 //   - limit int
-func (_e *MockStore_Expecter) ListPlaybackEvents(userID interface{}, bookNumericID interface{}, limit interface{}) *MockStore_ListPlaybackEvents_Call {
+func (_e *MockStore_Expecter) ListPlaybackEvents(userID any, bookNumericID any, limit any) *MockStore_ListPlaybackEvents_Call {
 	return &MockStore_ListPlaybackEvents_Call{Call: _e.mock.On("ListPlaybackEvents", userID, bookNumericID, limit)}
 }
 
@@ -44163,7 +44759,7 @@ type MockStore_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockStore_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockStore_ListSoftDeletedBooks_Call {
+func (_e *MockStore_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockStore_ListSoftDeletedBooks_Call {
 	return &MockStore_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -44293,7 +44889,7 @@ type MockStore_ListUserBookStatesByStatus_Call struct {
 //   - status string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListUserBookStatesByStatus(userID interface{}, status interface{}, limit interface{}, offset interface{}) *MockStore_ListUserBookStatesByStatus_Call {
+func (_e *MockStore_Expecter) ListUserBookStatesByStatus(userID any, status any, limit any, offset any) *MockStore_ListUserBookStatesByStatus_Call {
 	return &MockStore_ListUserBookStatesByStatus_Call{Call: _e.mock.On("ListUserBookStatesByStatus", userID, status, limit, offset)}
 }
 
@@ -44378,7 +44974,7 @@ type MockStore_ListUserPlaylists_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListUserPlaylists(playlistType interface{}, limit interface{}, offset interface{}) *MockStore_ListUserPlaylists_Call {
+func (_e *MockStore_Expecter) ListUserPlaylists(playlistType any, limit any, offset any) *MockStore_ListUserPlaylists_Call {
 	return &MockStore_ListUserPlaylists_Call{Call: _e.mock.On("ListUserPlaylists", playlistType, limit, offset)}
 }
 
@@ -44459,7 +45055,7 @@ type MockStore_ListUserPlaylistsForUser_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockStore_ListUserPlaylistsForUser_Call {
+func (_e *MockStore_Expecter) ListUserPlaylistsForUser(userID any, playlistType any, limit any, offset any) *MockStore_ListUserPlaylistsForUser_Call {
 	return &MockStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
 }
 
@@ -44537,7 +45133,7 @@ type MockStore_ListUserPositionsForBook_Call struct {
 // ListUserPositionsForBook is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockStore_Expecter) ListUserPositionsForBook(userID interface{}, bookID interface{}) *MockStore_ListUserPositionsForBook_Call {
+func (_e *MockStore_Expecter) ListUserPositionsForBook(userID any, bookID any) *MockStore_ListUserPositionsForBook_Call {
 	return &MockStore_ListUserPositionsForBook_Call{Call: _e.mock.On("ListUserPositionsForBook", userID, bookID)}
 }
 
@@ -44605,7 +45201,7 @@ type MockStore_ListUserPositionsSince_Call struct {
 // ListUserPositionsSince is a helper method to define mock.On call
 //   - userID string
 //   - t time.Time
-func (_e *MockStore_Expecter) ListUserPositionsSince(userID interface{}, t interface{}) *MockStore_ListUserPositionsSince_Call {
+func (_e *MockStore_Expecter) ListUserPositionsSince(userID any, t any) *MockStore_ListUserPositionsSince_Call {
 	return &MockStore_ListUserPositionsSince_Call{Call: _e.mock.On("ListUserPositionsSince", userID, t)}
 }
 
@@ -44672,7 +45268,7 @@ type MockStore_ListUserSessions_Call struct {
 
 // ListUserSessions is a helper method to define mock.On call
 //   - userID string
-func (_e *MockStore_Expecter) ListUserSessions(userID interface{}) *MockStore_ListUserSessions_Call {
+func (_e *MockStore_Expecter) ListUserSessions(userID any) *MockStore_ListUserSessions_Call {
 	return &MockStore_ListUserSessions_Call{Call: _e.mock.On("ListUserSessions", userID)}
 }
 
@@ -44754,6 +45350,61 @@ func (_c *MockStore_ListUsers_Call) RunAndReturn(run func() ([]database.User, er
 	return _c
 }
 
+// ListWaitingDepsOps provides a mock function for the type MockStore
+func (_mock *MockStore) ListWaitingDepsOps() ([]database.OperationV2Row, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListWaitingDepsOps")
+	}
+
+	var r0 []database.OperationV2Row
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.OperationV2Row, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.OperationV2Row); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.OperationV2Row)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_ListWaitingDepsOps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListWaitingDepsOps'
+type MockStore_ListWaitingDepsOps_Call struct {
+	*mock.Call
+}
+
+// ListWaitingDepsOps is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ListWaitingDepsOps() *MockStore_ListWaitingDepsOps_Call {
+	return &MockStore_ListWaitingDepsOps_Call{Call: _e.mock.On("ListWaitingDepsOps")}
+}
+
+func (_c *MockStore_ListWaitingDepsOps_Call) Run(run func()) *MockStore_ListWaitingDepsOps_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ListWaitingDepsOps_Call) Return(operationV2Rows []database.OperationV2Row, err error) *MockStore_ListWaitingDepsOps_Call {
+	_c.Call.Return(operationV2Rows, err)
+	return _c
+}
+
+func (_c *MockStore_ListWaitingDepsOps_Call) RunAndReturn(run func() ([]database.OperationV2Row, error)) *MockStore_ListWaitingDepsOps_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarkAIJobCompleted provides a mock function for the type MockStore
 func (_mock *MockStore) MarkAIJobCompleted(id string, status string, successCount int, errorCount int, rowErrors []database.AIJobRowError) error {
 	ret := _mock.Called(id, status, successCount, errorCount, rowErrors)
@@ -44782,7 +45433,7 @@ type MockStore_MarkAIJobCompleted_Call struct {
 //   - successCount int
 //   - errorCount int
 //   - rowErrors []database.AIJobRowError
-func (_e *MockStore_Expecter) MarkAIJobCompleted(id interface{}, status interface{}, successCount interface{}, errorCount interface{}, rowErrors interface{}) *MockStore_MarkAIJobCompleted_Call {
+func (_e *MockStore_Expecter) MarkAIJobCompleted(id any, status any, successCount any, errorCount any, rowErrors any) *MockStore_MarkAIJobCompleted_Call {
 	return &MockStore_MarkAIJobCompleted_Call{Call: _e.mock.On("MarkAIJobCompleted", id, status, successCount, errorCount, rowErrors)}
 }
 
@@ -44854,7 +45505,7 @@ type MockStore_MarkAIJobFailed_Call struct {
 // MarkAIJobFailed is a helper method to define mock.On call
 //   - id string
 //   - errMsg string
-func (_e *MockStore_Expecter) MarkAIJobFailed(id interface{}, errMsg interface{}) *MockStore_MarkAIJobFailed_Call {
+func (_e *MockStore_Expecter) MarkAIJobFailed(id any, errMsg any) *MockStore_MarkAIJobFailed_Call {
 	return &MockStore_MarkAIJobFailed_Call{Call: _e.mock.On("MarkAIJobFailed", id, errMsg)}
 }
 
@@ -44911,7 +45562,7 @@ type MockStore_MarkAIJobSubmitted_Call struct {
 // MarkAIJobSubmitted is a helper method to define mock.On call
 //   - id string
 //   - batchID string
-func (_e *MockStore_Expecter) MarkAIJobSubmitted(id interface{}, batchID interface{}) *MockStore_MarkAIJobSubmitted_Call {
+func (_e *MockStore_Expecter) MarkAIJobSubmitted(id any, batchID any) *MockStore_MarkAIJobSubmitted_Call {
 	return &MockStore_MarkAIJobSubmitted_Call{Call: _e.mock.On("MarkAIJobSubmitted", id, batchID)}
 }
 
@@ -44967,7 +45618,7 @@ type MockStore_MarkDeferredITunesUpdateApplied_Call struct {
 
 // MarkDeferredITunesUpdateApplied is a helper method to define mock.On call
 //   - id int
-func (_e *MockStore_Expecter) MarkDeferredITunesUpdateApplied(id interface{}) *MockStore_MarkDeferredITunesUpdateApplied_Call {
+func (_e *MockStore_Expecter) MarkDeferredITunesUpdateApplied(id any) *MockStore_MarkDeferredITunesUpdateApplied_Call {
 	return &MockStore_MarkDeferredITunesUpdateApplied_Call{Call: _e.mock.On("MarkDeferredITunesUpdateApplied", id)}
 }
 
@@ -45019,7 +45670,7 @@ type MockStore_MarkExternalIDRemoved_Call struct {
 // MarkExternalIDRemoved is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockStore_Expecter) MarkExternalIDRemoved(source interface{}, externalID interface{}) *MockStore_MarkExternalIDRemoved_Call {
+func (_e *MockStore_Expecter) MarkExternalIDRemoved(source any, externalID any) *MockStore_MarkExternalIDRemoved_Call {
 	return &MockStore_MarkExternalIDRemoved_Call{Call: _e.mock.On("MarkExternalIDRemoved", source, externalID)}
 }
 
@@ -45078,7 +45729,7 @@ type MockStore_MarkFileImportedFromDeluge_Call struct {
 //   - originalPath string
 //   - libraryPath string
 //   - torrentHash string
-func (_e *MockStore_Expecter) MarkFileImportedFromDeluge(ctx interface{}, originalPath interface{}, libraryPath interface{}, torrentHash interface{}) *MockStore_MarkFileImportedFromDeluge_Call {
+func (_e *MockStore_Expecter) MarkFileImportedFromDeluge(ctx any, originalPath any, libraryPath any, torrentHash any) *MockStore_MarkFileImportedFromDeluge_Call {
 	return &MockStore_MarkFileImportedFromDeluge_Call{Call: _e.mock.On("MarkFileImportedFromDeluge", ctx, originalPath, libraryPath, torrentHash)}
 }
 
@@ -45153,7 +45804,7 @@ type MockStore_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockStore_MarkITunesSynced_Call {
+func (_e *MockStore_Expecter) MarkITunesSynced(bookIDs any) *MockStore_MarkITunesSynced_Call {
 	return &MockStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -45204,7 +45855,7 @@ type MockStore_MarkNeedsRescan_Call struct {
 
 // MarkNeedsRescan is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockStore_Expecter) MarkNeedsRescan(bookID interface{}) *MockStore_MarkNeedsRescan_Call {
+func (_e *MockStore_Expecter) MarkNeedsRescan(bookID any) *MockStore_MarkNeedsRescan_Call {
 	return &MockStore_MarkNeedsRescan_Call{Call: _e.mock.On("MarkNeedsRescan", bookID)}
 }
 
@@ -45257,7 +45908,7 @@ type MockStore_MergeBookSegments_Call struct {
 //   - bookNumericID int
 //   - newSegment *database.BookSegment
 //   - supersedeIDs []string
-func (_e *MockStore_Expecter) MergeBookSegments(bookNumericID interface{}, newSegment interface{}, supersedeIDs interface{}) *MockStore_MergeBookSegments_Call {
+func (_e *MockStore_Expecter) MergeBookSegments(bookNumericID any, newSegment any, supersedeIDs any) *MockStore_MergeBookSegments_Call {
 	return &MockStore_MergeBookSegments_Call{Call: _e.mock.On("MergeBookSegments", bookNumericID, newSegment, supersedeIDs)}
 }
 
@@ -45321,7 +45972,7 @@ type MockStore_MergeChapterBooks_Call struct {
 //   - srcIDs []string
 //   - commonTitle string
 //   - totalDuration float64
-func (_e *MockStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockStore_MergeChapterBooks_Call {
+func (_e *MockStore_Expecter) MergeChapterBooks(primaryID any, srcIDs any, commonTitle any, totalDuration any) *MockStore_MergeChapterBooks_Call {
 	return &MockStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
 }
 
@@ -45389,7 +46040,7 @@ type MockStore_MoveBookFilesToBook_Call struct {
 //   - fileIDs []string
 //   - sourceBookID string
 //   - targetBookID string
-func (_e *MockStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockStore_MoveBookFilesToBook_Call {
+func (_e *MockStore_Expecter) MoveBookFilesToBook(fileIDs any, sourceBookID any, targetBookID any) *MockStore_MoveBookFilesToBook_Call {
 	return &MockStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
 }
 
@@ -45451,7 +46102,7 @@ type MockStore_MoveSegmentsToBook_Call struct {
 // MoveSegmentsToBook is a helper method to define mock.On call
 //   - segmentIDs []string
 //   - targetBookNumericID int
-func (_e *MockStore_Expecter) MoveSegmentsToBook(segmentIDs interface{}, targetBookNumericID interface{}) *MockStore_MoveSegmentsToBook_Call {
+func (_e *MockStore_Expecter) MoveSegmentsToBook(segmentIDs any, targetBookNumericID any) *MockStore_MoveSegmentsToBook_Call {
 	return &MockStore_MoveSegmentsToBook_Call{Call: _e.mock.On("MoveSegmentsToBook", segmentIDs, targetBookNumericID)}
 }
 
@@ -45527,6 +46178,57 @@ func (_c *MockStore_Optimize_Call) RunAndReturn(run func() error) *MockStore_Opt
 	return _c
 }
 
+// PromoteToQueued provides a mock function for the type MockStore
+func (_mock *MockStore) PromoteToQueued(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PromoteToQueued")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_PromoteToQueued_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PromoteToQueued'
+type MockStore_PromoteToQueued_Call struct {
+	*mock.Call
+}
+
+// PromoteToQueued is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) PromoteToQueued(id any) *MockStore_PromoteToQueued_Call {
+	return &MockStore_PromoteToQueued_Call{Call: _e.mock.On("PromoteToQueued", id)}
+}
+
+func (_c *MockStore_PromoteToQueued_Call) Run(run func(id string)) *MockStore_PromoteToQueued_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_PromoteToQueued_Call) Return(err error) *MockStore_PromoteToQueued_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_PromoteToQueued_Call) RunAndReturn(run func(id string) error) *MockStore_PromoteToQueued_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PruneBookSnapshots provides a mock function for the type MockStore
 func (_mock *MockStore) PruneBookSnapshots(id string, keepCount int) (int, error) {
 	ret := _mock.Called(id, keepCount)
@@ -45561,7 +46263,7 @@ type MockStore_PruneBookSnapshots_Call struct {
 // PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockStore_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockStore_PruneBookSnapshots_Call {
+func (_e *MockStore_Expecter) PruneBookSnapshots(id any, keepCount any) *MockStore_PruneBookSnapshots_Call {
 	return &MockStore_PruneBookSnapshots_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
@@ -45626,7 +46328,7 @@ type MockStore_PruneOperationChanges_Call struct {
 
 // PruneOperationChanges is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockStore_Expecter) PruneOperationChanges(olderThan interface{}) *MockStore_PruneOperationChanges_Call {
+func (_e *MockStore_Expecter) PruneOperationChanges(olderThan any) *MockStore_PruneOperationChanges_Call {
 	return &MockStore_PruneOperationChanges_Call{Call: _e.mock.On("PruneOperationChanges", olderThan)}
 }
 
@@ -45686,7 +46388,7 @@ type MockStore_PruneOperationLogs_Call struct {
 
 // PruneOperationLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockStore_Expecter) PruneOperationLogs(olderThan interface{}) *MockStore_PruneOperationLogs_Call {
+func (_e *MockStore_Expecter) PruneOperationLogs(olderThan any) *MockStore_PruneOperationLogs_Call {
 	return &MockStore_PruneOperationLogs_Call{Call: _e.mock.On("PruneOperationLogs", olderThan)}
 }
 
@@ -45746,7 +46448,7 @@ type MockStore_PruneSystemActivityLogs_Call struct {
 
 // PruneSystemActivityLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockStore_Expecter) PruneSystemActivityLogs(olderThan interface{}) *MockStore_PruneSystemActivityLogs_Call {
+func (_e *MockStore_Expecter) PruneSystemActivityLogs(olderThan any) *MockStore_PruneSystemActivityLogs_Call {
 	return &MockStore_PruneSystemActivityLogs_Call{Call: _e.mock.On("PruneSystemActivityLogs", olderThan)}
 }
 
@@ -45797,7 +46499,7 @@ type MockStore_PutMetadataCache_Call struct {
 
 // PutMetadataCache is a helper method to define mock.On call
 //   - entry *database.MetadataCandidateCache
-func (_e *MockStore_Expecter) PutMetadataCache(entry interface{}) *MockStore_PutMetadataCache_Call {
+func (_e *MockStore_Expecter) PutMetadataCache(entry any) *MockStore_PutMetadataCache_Call {
 	return &MockStore_PutMetadataCache_Call{Call: _e.mock.On("PutMetadataCache", entry)}
 }
 
@@ -45820,63 +46522,6 @@ func (_c *MockStore_PutMetadataCache_Call) Return(err error) *MockStore_PutMetad
 }
 
 func (_c *MockStore_PutMetadataCache_Call) RunAndReturn(run func(entry *database.MetadataCandidateCache) error) *MockStore_PutMetadataCache_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ReassignExternalIDs provides a mock function for the type MockStore
-func (_mock *MockStore) ReassignExternalIDs(oldBookID string, newBookID string) error {
-	ret := _mock.Called(oldBookID, newBookID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ReassignExternalIDs")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(oldBookID, newBookID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_ReassignExternalIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReassignExternalIDs'
-type MockStore_ReassignExternalIDs_Call struct {
-	*mock.Call
-}
-
-// ReassignExternalIDs is a helper method to define mock.On call
-//   - oldBookID string
-//   - newBookID string
-func (_e *MockStore_Expecter) ReassignExternalIDs(oldBookID interface{}, newBookID interface{}) *MockStore_ReassignExternalIDs_Call {
-	return &MockStore_ReassignExternalIDs_Call{Call: _e.mock.On("ReassignExternalIDs", oldBookID, newBookID)}
-}
-
-func (_c *MockStore_ReassignExternalIDs_Call) Run(run func(oldBookID string, newBookID string)) *MockStore_ReassignExternalIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockStore_ReassignExternalIDs_Call) Return(err error) *MockStore_ReassignExternalIDs_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_ReassignExternalIDs_Call) RunAndReturn(run func(oldBookID string, newBookID string) error) *MockStore_ReassignExternalIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -45907,7 +46552,7 @@ type MockStore_ReassignExternalID_Call struct {
 //   - source string
 //   - externalID string
 //   - newBookID string
-func (_e *MockStore_Expecter) ReassignExternalID(source interface{}, externalID interface{}, newBookID interface{}) *MockStore_ReassignExternalID_Call {
+func (_e *MockStore_Expecter) ReassignExternalID(source any, externalID any, newBookID any) *MockStore_ReassignExternalID_Call {
 	return &MockStore_ReassignExternalID_Call{Call: _e.mock.On("ReassignExternalID", source, externalID, newBookID)}
 }
 
@@ -45944,6 +46589,114 @@ func (_c *MockStore_ReassignExternalID_Call) RunAndReturn(run func(source string
 	return _c
 }
 
+// ReassignExternalIDs provides a mock function for the type MockStore
+func (_mock *MockStore) ReassignExternalIDs(oldBookID string, newBookID string) error {
+	ret := _mock.Called(oldBookID, newBookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReassignExternalIDs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = returnFunc(oldBookID, newBookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_ReassignExternalIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReassignExternalIDs'
+type MockStore_ReassignExternalIDs_Call struct {
+	*mock.Call
+}
+
+// ReassignExternalIDs is a helper method to define mock.On call
+//   - oldBookID string
+//   - newBookID string
+func (_e *MockStore_Expecter) ReassignExternalIDs(oldBookID any, newBookID any) *MockStore_ReassignExternalIDs_Call {
+	return &MockStore_ReassignExternalIDs_Call{Call: _e.mock.On("ReassignExternalIDs", oldBookID, newBookID)}
+}
+
+func (_c *MockStore_ReassignExternalIDs_Call) Run(run func(oldBookID string, newBookID string)) *MockStore_ReassignExternalIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ReassignExternalIDs_Call) Return(err error) *MockStore_ReassignExternalIDs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_ReassignExternalIDs_Call) RunAndReturn(run func(oldBookID string, newBookID string) error) *MockStore_ReassignExternalIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecomputeBookAggregates provides a mock function for the type MockStore
+func (_mock *MockStore) RecomputeBookAggregates(bookID string) error {
+	ret := _mock.Called(bookID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecomputeBookAggregates")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(bookID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RecomputeBookAggregates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecomputeBookAggregates'
+type MockStore_RecomputeBookAggregates_Call struct {
+	*mock.Call
+}
+
+// RecomputeBookAggregates is a helper method to define mock.On call
+//   - bookID string
+func (_e *MockStore_Expecter) RecomputeBookAggregates(bookID any) *MockStore_RecomputeBookAggregates_Call {
+	return &MockStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
+}
+
+func (_c *MockStore_RecomputeBookAggregates_Call) Run(run func(bookID string)) *MockStore_RecomputeBookAggregates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RecomputeBookAggregates_Call) Return(err error) *MockStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RecordMetadataChange provides a mock function for the type MockStore
 func (_mock *MockStore) RecordMetadataChange(record *database.MetadataChangeRecord) error {
 	ret := _mock.Called(record)
@@ -45968,7 +46721,7 @@ type MockStore_RecordMetadataChange_Call struct {
 
 // RecordMetadataChange is a helper method to define mock.On call
 //   - record *database.MetadataChangeRecord
-func (_e *MockStore_Expecter) RecordMetadataChange(record interface{}) *MockStore_RecordMetadataChange_Call {
+func (_e *MockStore_Expecter) RecordMetadataChange(record any) *MockStore_RecordMetadataChange_Call {
 	return &MockStore_RecordMetadataChange_Call{Call: _e.mock.On("RecordMetadataChange", record)}
 }
 
@@ -45991,6 +46744,75 @@ func (_c *MockStore_RecordMetadataChange_Call) Return(err error) *MockStore_Reco
 }
 
 func (_c *MockStore_RecordMetadataChange_Call) RunAndReturn(run func(record *database.MetadataChangeRecord) error) *MockStore_RecordMetadataChange_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecordOpCompletion provides a mock function for the type MockStore
+func (_mock *MockStore) RecordOpCompletion(sub database.OpSubject, opType string, fileID string, depRev uint64) error {
+	ret := _mock.Called(sub, opType, fileID, depRev)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecordOpCompletion")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string, string, uint64) error); ok {
+		r0 = returnFunc(sub, opType, fileID, depRev)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_RecordOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordOpCompletion'
+type MockStore_RecordOpCompletion_Call struct {
+	*mock.Call
+}
+
+// RecordOpCompletion is a helper method to define mock.On call
+//   - sub database.OpSubject
+//   - opType string
+//   - fileID string
+//   - depRev uint64
+func (_e *MockStore_Expecter) RecordOpCompletion(sub any, opType any, fileID any, depRev any) *MockStore_RecordOpCompletion_Call {
+	return &MockStore_RecordOpCompletion_Call{Call: _e.mock.On("RecordOpCompletion", sub, opType, fileID, depRev)}
+}
+
+func (_c *MockStore_RecordOpCompletion_Call) Run(run func(sub database.OpSubject, opType string, fileID string, depRev uint64)) *MockStore_RecordOpCompletion_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.OpSubject
+		if args[0] != nil {
+			arg0 = args[0].(database.OpSubject)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 uint64
+		if args[3] != nil {
+			arg3 = args[3].(uint64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_RecordOpCompletion_Call) Return(err error) *MockStore_RecordOpCompletion_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_RecordOpCompletion_Call) RunAndReturn(run func(sub database.OpSubject, opType string, fileID string, depRev uint64) error) *MockStore_RecordOpCompletion_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -46019,7 +46841,7 @@ type MockStore_RecordPathChange_Call struct {
 
 // RecordPathChange is a helper method to define mock.On call
 //   - change *database.BookPathChange
-func (_e *MockStore_Expecter) RecordPathChange(change interface{}) *MockStore_RecordPathChange_Call {
+func (_e *MockStore_Expecter) RecordPathChange(change any) *MockStore_RecordPathChange_Call {
 	return &MockStore_RecordPathChange_Call{Call: _e.mock.On("RecordPathChange", change)}
 }
 
@@ -46071,7 +46893,7 @@ type MockStore_RemoveAuthorTag_Call struct {
 // RemoveAuthorTag is a helper method to define mock.On call
 //   - authorID int
 //   - tag string
-func (_e *MockStore_Expecter) RemoveAuthorTag(authorID interface{}, tag interface{}) *MockStore_RemoveAuthorTag_Call {
+func (_e *MockStore_Expecter) RemoveAuthorTag(authorID any, tag any) *MockStore_RemoveAuthorTag_Call {
 	return &MockStore_RemoveAuthorTag_Call{Call: _e.mock.On("RemoveAuthorTag", authorID, tag)}
 }
 
@@ -46129,7 +46951,7 @@ type MockStore_RemoveAuthorTagsByPrefix_Call struct {
 //   - authorID int
 //   - prefix string
 //   - source string
-func (_e *MockStore_Expecter) RemoveAuthorTagsByPrefix(authorID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveAuthorTagsByPrefix_Call {
+func (_e *MockStore_Expecter) RemoveAuthorTagsByPrefix(authorID any, prefix any, source any) *MockStore_RemoveAuthorTagsByPrefix_Call {
 	return &MockStore_RemoveAuthorTagsByPrefix_Call{Call: _e.mock.On("RemoveAuthorTagsByPrefix", authorID, prefix, source)}
 }
 
@@ -46190,7 +47012,7 @@ type MockStore_RemoveBlockedHash_Call struct {
 
 // RemoveBlockedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockStore_Expecter) RemoveBlockedHash(hash interface{}) *MockStore_RemoveBlockedHash_Call {
+func (_e *MockStore_Expecter) RemoveBlockedHash(hash any) *MockStore_RemoveBlockedHash_Call {
 	return &MockStore_RemoveBlockedHash_Call{Call: _e.mock.On("RemoveBlockedHash", hash)}
 }
 
@@ -46242,7 +47064,7 @@ type MockStore_RemoveBookAlternativeTitle_Call struct {
 // RemoveBookAlternativeTitle is a helper method to define mock.On call
 //   - bookID string
 //   - title string
-func (_e *MockStore_Expecter) RemoveBookAlternativeTitle(bookID interface{}, title interface{}) *MockStore_RemoveBookAlternativeTitle_Call {
+func (_e *MockStore_Expecter) RemoveBookAlternativeTitle(bookID any, title any) *MockStore_RemoveBookAlternativeTitle_Call {
 	return &MockStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
 }
 
@@ -46299,7 +47121,7 @@ type MockStore_RemoveBookTag_Call struct {
 // RemoveBookTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockStore_Expecter) RemoveBookTag(bookID interface{}, tag interface{}) *MockStore_RemoveBookTag_Call {
+func (_e *MockStore_Expecter) RemoveBookTag(bookID any, tag any) *MockStore_RemoveBookTag_Call {
 	return &MockStore_RemoveBookTag_Call{Call: _e.mock.On("RemoveBookTag", bookID, tag)}
 }
 
@@ -46357,7 +47179,7 @@ type MockStore_RemoveBookTagsByPrefix_Call struct {
 //   - bookID string
 //   - prefix string
 //   - source string
-func (_e *MockStore_Expecter) RemoveBookTagsByPrefix(bookID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveBookTagsByPrefix_Call {
+func (_e *MockStore_Expecter) RemoveBookTagsByPrefix(bookID any, prefix any, source any) *MockStore_RemoveBookTagsByPrefix_Call {
 	return &MockStore_RemoveBookTagsByPrefix_Call{Call: _e.mock.On("RemoveBookTagsByPrefix", bookID, prefix, source)}
 }
 
@@ -46419,7 +47241,7 @@ type MockStore_RemoveBookUserTag_Call struct {
 // RemoveBookUserTag is a helper method to define mock.On call
 //   - bookID string
 //   - tag string
-func (_e *MockStore_Expecter) RemoveBookUserTag(bookID interface{}, tag interface{}) *MockStore_RemoveBookUserTag_Call {
+func (_e *MockStore_Expecter) RemoveBookUserTag(bookID any, tag any) *MockStore_RemoveBookUserTag_Call {
 	return &MockStore_RemoveBookUserTag_Call{Call: _e.mock.On("RemoveBookUserTag", bookID, tag)}
 }
 
@@ -46476,7 +47298,7 @@ type MockStore_RemoveSeriesTag_Call struct {
 // RemoveSeriesTag is a helper method to define mock.On call
 //   - seriesID int
 //   - tag string
-func (_e *MockStore_Expecter) RemoveSeriesTag(seriesID interface{}, tag interface{}) *MockStore_RemoveSeriesTag_Call {
+func (_e *MockStore_Expecter) RemoveSeriesTag(seriesID any, tag any) *MockStore_RemoveSeriesTag_Call {
 	return &MockStore_RemoveSeriesTag_Call{Call: _e.mock.On("RemoveSeriesTag", seriesID, tag)}
 }
 
@@ -46534,7 +47356,7 @@ type MockStore_RemoveSeriesTagsByPrefix_Call struct {
 //   - seriesID int
 //   - prefix string
 //   - source string
-func (_e *MockStore_Expecter) RemoveSeriesTagsByPrefix(seriesID interface{}, prefix interface{}, source interface{}) *MockStore_RemoveSeriesTagsByPrefix_Call {
+func (_e *MockStore_Expecter) RemoveSeriesTagsByPrefix(seriesID any, prefix any, source any) *MockStore_RemoveSeriesTagsByPrefix_Call {
 	return &MockStore_RemoveSeriesTagsByPrefix_Call{Call: _e.mock.On("RemoveSeriesTagsByPrefix", seriesID, prefix, source)}
 }
 
@@ -46639,7 +47461,7 @@ type MockStore_ResetScanFailCount_Call struct {
 
 // ResetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockStore_Expecter) ResetScanFailCount(pathHash interface{}) *MockStore_ResetScanFailCount_Call {
+func (_e *MockStore_Expecter) ResetScanFailCount(pathHash any) *MockStore_ResetScanFailCount_Call {
 	return &MockStore_ResetScanFailCount_Call{Call: _e.mock.On("ResetScanFailCount", pathHash)}
 }
 
@@ -46755,7 +47577,7 @@ type MockStore_RevertBookToVersion_Call struct {
 // RevertBookToVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockStore_Expecter) RevertBookToVersion(id interface{}, ts interface{}) *MockStore_RevertBookToVersion_Call {
+func (_e *MockStore_Expecter) RevertBookToVersion(id any, ts any) *MockStore_RevertBookToVersion_Call {
 	return &MockStore_RevertBookToVersion_Call{Call: _e.mock.On("RevertBookToVersion", id, ts)}
 }
 
@@ -46811,7 +47633,7 @@ type MockStore_RevertOperationChanges_Call struct {
 
 // RevertOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockStore_Expecter) RevertOperationChanges(operationID interface{}) *MockStore_RevertOperationChanges_Call {
+func (_e *MockStore_Expecter) RevertOperationChanges(operationID any) *MockStore_RevertOperationChanges_Call {
 	return &MockStore_RevertOperationChanges_Call{Call: _e.mock.On("RevertOperationChanges", operationID)}
 }
 
@@ -46862,7 +47684,7 @@ type MockStore_RevokeAPIKey_Call struct {
 
 // RevokeAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) RevokeAPIKey(id interface{}) *MockStore_RevokeAPIKey_Call {
+func (_e *MockStore_Expecter) RevokeAPIKey(id any) *MockStore_RevokeAPIKey_Call {
 	return &MockStore_RevokeAPIKey_Call{Call: _e.mock.On("RevokeAPIKey", id)}
 }
 
@@ -46913,7 +47735,7 @@ type MockStore_RevokeSession_Call struct {
 
 // RevokeSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockStore_Expecter) RevokeSession(id interface{}) *MockStore_RevokeSession_Call {
+func (_e *MockStore_Expecter) RevokeSession(id any) *MockStore_RevokeSession_Call {
 	return &MockStore_RevokeSession_Call{Call: _e.mock.On("RevokeSession", id)}
 }
 
@@ -46967,7 +47789,7 @@ type MockStore_SaveLibraryFingerprint_Call struct {
 //   - size int64
 //   - modTime time.Time
 //   - crc32 uint32
-func (_e *MockStore_Expecter) SaveLibraryFingerprint(path interface{}, size interface{}, modTime interface{}, crc32 interface{}) *MockStore_SaveLibraryFingerprint_Call {
+func (_e *MockStore_Expecter) SaveLibraryFingerprint(path any, size any, modTime any, crc32 any) *MockStore_SaveLibraryFingerprint_Call {
 	return &MockStore_SaveLibraryFingerprint_Call{Call: _e.mock.On("SaveLibraryFingerprint", path, size, modTime, crc32)}
 }
 
@@ -47034,7 +47856,7 @@ type MockStore_SaveOperationParams_Call struct {
 // SaveOperationParams is a helper method to define mock.On call
 //   - opID string
 //   - params []byte
-func (_e *MockStore_Expecter) SaveOperationParams(opID interface{}, params interface{}) *MockStore_SaveOperationParams_Call {
+func (_e *MockStore_Expecter) SaveOperationParams(opID any, params any) *MockStore_SaveOperationParams_Call {
 	return &MockStore_SaveOperationParams_Call{Call: _e.mock.On("SaveOperationParams", opID, params)}
 }
 
@@ -47091,7 +47913,7 @@ type MockStore_SaveOperationState_Call struct {
 // SaveOperationState is a helper method to define mock.On call
 //   - opID string
 //   - state []byte
-func (_e *MockStore_Expecter) SaveOperationState(opID interface{}, state interface{}) *MockStore_SaveOperationState_Call {
+func (_e *MockStore_Expecter) SaveOperationState(opID any, state any) *MockStore_SaveOperationState_Call {
 	return &MockStore_SaveOperationState_Call{Call: _e.mock.On("SaveOperationState", opID, state)}
 }
 
@@ -47147,7 +47969,7 @@ type MockStore_SaveOperationSummaryLog_Call struct {
 
 // SaveOperationSummaryLog is a helper method to define mock.On call
 //   - op *database.OperationSummaryLog
-func (_e *MockStore_Expecter) SaveOperationSummaryLog(op interface{}) *MockStore_SaveOperationSummaryLog_Call {
+func (_e *MockStore_Expecter) SaveOperationSummaryLog(op any) *MockStore_SaveOperationSummaryLog_Call {
 	return &MockStore_SaveOperationSummaryLog_Call{Call: _e.mock.On("SaveOperationSummaryLog", op)}
 }
 
@@ -47209,7 +48031,7 @@ type MockStore_ScanPrefix_Call struct {
 
 // ScanPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockStore_Expecter) ScanPrefix(prefix interface{}) *MockStore_ScanPrefix_Call {
+func (_e *MockStore_Expecter) ScanPrefix(prefix any) *MockStore_ScanPrefix_Call {
 	return &MockStore_ScanPrefix_Call{Call: _e.mock.On("ScanPrefix", prefix)}
 }
 
@@ -47273,7 +48095,7 @@ type MockStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockStore_SearchBooks_Call {
+func (_e *MockStore_Expecter) SearchBooks(query any, limit any, offset any) *MockStore_SearchBooks_Call {
 	return &MockStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -47336,7 +48158,7 @@ type MockStore_SetAPIKeyStatus_Call struct {
 //   - id string
 //   - status string
 //   - at time.Time
-func (_e *MockStore_Expecter) SetAPIKeyStatus(id interface{}, status interface{}, at interface{}) *MockStore_SetAPIKeyStatus_Call {
+func (_e *MockStore_Expecter) SetAPIKeyStatus(id any, status any, at any) *MockStore_SetAPIKeyStatus_Call {
 	return &MockStore_SetAPIKeyStatus_Call{Call: _e.mock.On("SetAPIKeyStatus", id, status, at)}
 }
 
@@ -47398,7 +48220,7 @@ type MockStore_SetAuthorTags_Call struct {
 // SetAuthorTags is a helper method to define mock.On call
 //   - authorID int
 //   - tags []string
-func (_e *MockStore_Expecter) SetAuthorTags(authorID interface{}, tags interface{}) *MockStore_SetAuthorTags_Call {
+func (_e *MockStore_Expecter) SetAuthorTags(authorID any, tags any) *MockStore_SetAuthorTags_Call {
 	return &MockStore_SetAuthorTags_Call{Call: _e.mock.On("SetAuthorTags", authorID, tags)}
 }
 
@@ -47455,7 +48277,7 @@ type MockStore_SetBookAlternativeTitles_Call struct {
 // SetBookAlternativeTitles is a helper method to define mock.On call
 //   - bookID string
 //   - titles []database.BookAlternativeTitle
-func (_e *MockStore_Expecter) SetBookAlternativeTitles(bookID interface{}, titles interface{}) *MockStore_SetBookAlternativeTitles_Call {
+func (_e *MockStore_Expecter) SetBookAlternativeTitles(bookID any, titles any) *MockStore_SetBookAlternativeTitles_Call {
 	return &MockStore_SetBookAlternativeTitles_Call{Call: _e.mock.On("SetBookAlternativeTitles", bookID, titles)}
 }
 
@@ -47512,7 +48334,7 @@ type MockStore_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockStore_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockStore_SetBookAuthors_Call {
+func (_e *MockStore_Expecter) SetBookAuthors(bookID any, authors any) *MockStore_SetBookAuthors_Call {
 	return &MockStore_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -47569,7 +48391,7 @@ type MockStore_SetBookFileHash_Call struct {
 // SetBookFileHash is a helper method to define mock.On call
 //   - id string
 //   - hash string
-func (_e *MockStore_Expecter) SetBookFileHash(id interface{}, hash interface{}) *MockStore_SetBookFileHash_Call {
+func (_e *MockStore_Expecter) SetBookFileHash(id any, hash any) *MockStore_SetBookFileHash_Call {
 	return &MockStore_SetBookFileHash_Call{Call: _e.mock.On("SetBookFileHash", id, hash)}
 }
 
@@ -47626,7 +48448,7 @@ type MockStore_SetBookNarrators_Call struct {
 // SetBookNarrators is a helper method to define mock.On call
 //   - bookID string
 //   - narrators []database.BookNarrator
-func (_e *MockStore_Expecter) SetBookNarrators(bookID interface{}, narrators interface{}) *MockStore_SetBookNarrators_Call {
+func (_e *MockStore_Expecter) SetBookNarrators(bookID any, narrators any) *MockStore_SetBookNarrators_Call {
 	return &MockStore_SetBookNarrators_Call{Call: _e.mock.On("SetBookNarrators", bookID, narrators)}
 }
 
@@ -47683,7 +48505,7 @@ type MockStore_SetBookTags_Call struct {
 // SetBookTags is a helper method to define mock.On call
 //   - bookID string
 //   - tags []string
-func (_e *MockStore_Expecter) SetBookTags(bookID interface{}, tags interface{}) *MockStore_SetBookTags_Call {
+func (_e *MockStore_Expecter) SetBookTags(bookID any, tags any) *MockStore_SetBookTags_Call {
 	return &MockStore_SetBookTags_Call{Call: _e.mock.On("SetBookTags", bookID, tags)}
 }
 
@@ -47740,7 +48562,7 @@ type MockStore_SetBookUserTags_Call struct {
 // SetBookUserTags is a helper method to define mock.On call
 //   - bookID string
 //   - tags []string
-func (_e *MockStore_Expecter) SetBookUserTags(bookID interface{}, tags interface{}) *MockStore_SetBookUserTags_Call {
+func (_e *MockStore_Expecter) SetBookUserTags(bookID any, tags any) *MockStore_SetBookUserTags_Call {
 	return &MockStore_SetBookUserTags_Call{Call: _e.mock.On("SetBookUserTags", bookID, tags)}
 }
 
@@ -47798,7 +48620,7 @@ type MockStore_SetExternalIDProvenance_Call struct {
 //   - source string
 //   - externalID string
 //   - provenance string
-func (_e *MockStore_Expecter) SetExternalIDProvenance(source interface{}, externalID interface{}, provenance interface{}) *MockStore_SetExternalIDProvenance_Call {
+func (_e *MockStore_Expecter) SetExternalIDProvenance(source any, externalID any, provenance any) *MockStore_SetExternalIDProvenance_Call {
 	return &MockStore_SetExternalIDProvenance_Call{Call: _e.mock.On("SetExternalIDProvenance", source, externalID, provenance)}
 }
 
@@ -47860,7 +48682,7 @@ type MockStore_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - id string
 //   - t time.Time
-func (_e *MockStore_Expecter) SetLastWrittenAt(id interface{}, t interface{}) *MockStore_SetLastWrittenAt_Call {
+func (_e *MockStore_Expecter) SetLastWrittenAt(id any, t any) *MockStore_SetLastWrittenAt_Call {
 	return &MockStore_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", id, t)}
 }
 
@@ -47926,7 +48748,7 @@ type MockStore_SetOperationV2StatusIfQueued_Call struct {
 // SetOperationV2StatusIfQueued is a helper method to define mock.On call
 //   - id string
 //   - newStatus string
-func (_e *MockStore_Expecter) SetOperationV2StatusIfQueued(id interface{}, newStatus interface{}) *MockStore_SetOperationV2StatusIfQueued_Call {
+func (_e *MockStore_Expecter) SetOperationV2StatusIfQueued(id any, newStatus any) *MockStore_SetOperationV2StatusIfQueued_Call {
 	return &MockStore_SetOperationV2StatusIfQueued_Call{Call: _e.mock.On("SetOperationV2StatusIfQueued", id, newStatus)}
 }
 
@@ -47983,7 +48805,7 @@ type MockStore_SetRaw_Call struct {
 // SetRaw is a helper method to define mock.On call
 //   - key string
 //   - value []byte
-func (_e *MockStore_Expecter) SetRaw(key interface{}, value interface{}) *MockStore_SetRaw_Call {
+func (_e *MockStore_Expecter) SetRaw(key any, value any) *MockStore_SetRaw_Call {
 	return &MockStore_SetRaw_Call{Call: _e.mock.On("SetRaw", key, value)}
 }
 
@@ -48028,7 +48850,7 @@ type MockStore_SetRootDir_Call struct {
 
 // SetRootDir is a helper method to define mock.On call
 //   - rootDir string
-func (_e *MockStore_Expecter) SetRootDir(rootDir interface{}) *MockStore_SetRootDir_Call {
+func (_e *MockStore_Expecter) SetRootDir(rootDir any) *MockStore_SetRootDir_Call {
 	return &MockStore_SetRootDir_Call{Call: _e.mock.On("SetRootDir", rootDir)}
 }
 
@@ -48080,7 +48902,7 @@ type MockStore_SetSeriesTags_Call struct {
 // SetSeriesTags is a helper method to define mock.On call
 //   - seriesID int
 //   - tags []string
-func (_e *MockStore_Expecter) SetSeriesTags(seriesID interface{}, tags interface{}) *MockStore_SetSeriesTags_Call {
+func (_e *MockStore_Expecter) SetSeriesTags(seriesID any, tags any) *MockStore_SetSeriesTags_Call {
 	return &MockStore_SetSeriesTags_Call{Call: _e.mock.On("SetSeriesTags", seriesID, tags)}
 }
 
@@ -48139,7 +48961,7 @@ type MockStore_SetSetting_Call struct {
 //   - value string
 //   - typ string
 //   - isSecret bool
-func (_e *MockStore_Expecter) SetSetting(key interface{}, value interface{}, typ interface{}, isSecret interface{}) *MockStore_SetSetting_Call {
+func (_e *MockStore_Expecter) SetSetting(key any, value any, typ any, isSecret any) *MockStore_SetSetting_Call {
 	return &MockStore_SetSetting_Call{Call: _e.mock.On("SetSetting", key, value, typ, isSecret)}
 }
 
@@ -48205,7 +49027,7 @@ type MockStore_SetUserBookState_Call struct {
 
 // SetUserBookState is a helper method to define mock.On call
 //   - state *database.UserBookState
-func (_e *MockStore_Expecter) SetUserBookState(state interface{}) *MockStore_SetUserBookState_Call {
+func (_e *MockStore_Expecter) SetUserBookState(state any) *MockStore_SetUserBookState_Call {
 	return &MockStore_SetUserBookState_Call{Call: _e.mock.On("SetUserBookState", state)}
 }
 
@@ -48259,7 +49081,7 @@ type MockStore_SetUserPosition_Call struct {
 //   - bookID string
 //   - segmentID string
 //   - positionSeconds float64
-func (_e *MockStore_Expecter) SetUserPosition(userID interface{}, bookID interface{}, segmentID interface{}, positionSeconds interface{}) *MockStore_SetUserPosition_Call {
+func (_e *MockStore_Expecter) SetUserPosition(userID any, bookID any, segmentID any, positionSeconds any) *MockStore_SetUserPosition_Call {
 	return &MockStore_SetUserPosition_Call{Call: _e.mock.On("SetUserPosition", userID, bookID, segmentID, positionSeconds)}
 }
 
@@ -48326,7 +49148,7 @@ type MockStore_SetUserPreference_Call struct {
 // SetUserPreference is a helper method to define mock.On call
 //   - key string
 //   - value string
-func (_e *MockStore_Expecter) SetUserPreference(key interface{}, value interface{}) *MockStore_SetUserPreference_Call {
+func (_e *MockStore_Expecter) SetUserPreference(key any, value any) *MockStore_SetUserPreference_Call {
 	return &MockStore_SetUserPreference_Call{Call: _e.mock.On("SetUserPreference", key, value)}
 }
 
@@ -48384,7 +49206,7 @@ type MockStore_SetUserPreferenceForUser_Call struct {
 //   - userID string
 //   - key string
 //   - value string
-func (_e *MockStore_Expecter) SetUserPreferenceForUser(userID interface{}, key interface{}, value interface{}) *MockStore_SetUserPreferenceForUser_Call {
+func (_e *MockStore_Expecter) SetUserPreferenceForUser(userID any, key any, value any) *MockStore_SetUserPreferenceForUser_Call {
 	return &MockStore_SetUserPreferenceForUser_Call{Call: _e.mock.On("SetUserPreferenceForUser", userID, key, value)}
 }
 
@@ -48446,7 +49268,7 @@ type MockStore_TombstoneExternalID_Call struct {
 // TombstoneExternalID is a helper method to define mock.On call
 //   - source string
 //   - externalID string
-func (_e *MockStore_Expecter) TombstoneExternalID(source interface{}, externalID interface{}) *MockStore_TombstoneExternalID_Call {
+func (_e *MockStore_Expecter) TombstoneExternalID(source any, externalID any) *MockStore_TombstoneExternalID_Call {
 	return &MockStore_TombstoneExternalID_Call{Call: _e.mock.On("TombstoneExternalID", source, externalID)}
 }
 
@@ -48504,7 +49326,7 @@ type MockStore_TouchAPIKeyLastUsed_Call struct {
 //   - id string
 //   - at time.Time
 //   - ip string
-func (_e *MockStore_Expecter) TouchAPIKeyLastUsed(id interface{}, at interface{}, ip interface{}) *MockStore_TouchAPIKeyLastUsed_Call {
+func (_e *MockStore_Expecter) TouchAPIKeyLastUsed(id any, at any, ip any) *MockStore_TouchAPIKeyLastUsed_Call {
 	return &MockStore_TouchAPIKeyLastUsed_Call{Call: _e.mock.On("TouchAPIKeyLastUsed", id, at, ip)}
 }
 
@@ -48566,7 +49388,7 @@ type MockStore_UpdateAuthorName_Call struct {
 // UpdateAuthorName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockStore_Expecter) UpdateAuthorName(id interface{}, name interface{}) *MockStore_UpdateAuthorName_Call {
+func (_e *MockStore_Expecter) UpdateAuthorName(id any, name any) *MockStore_UpdateAuthorName_Call {
 	return &MockStore_UpdateAuthorName_Call{Call: _e.mock.On("UpdateAuthorName", id, name)}
 }
 
@@ -48634,7 +49456,7 @@ type MockStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockStore_UpdateBook_Call {
+func (_e *MockStore_Expecter) UpdateBook(id any, book any) *MockStore_UpdateBook_Call {
 	return &MockStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -48691,7 +49513,7 @@ type MockStore_UpdateBookFile_Call struct {
 // UpdateBookFile is a helper method to define mock.On call
 //   - id string
 //   - file *database.BookFile
-func (_e *MockStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockStore_UpdateBookFile_Call {
+func (_e *MockStore_Expecter) UpdateBookFile(id any, file any) *MockStore_UpdateBookFile_Call {
 	return &MockStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
 }
 
@@ -48749,7 +49571,7 @@ type MockStore_UpdateBookFileHashes_Call struct {
 //   - id string
 //   - originalHash string
 //   - postMetadataHash string
-func (_e *MockStore_Expecter) UpdateBookFileHashes(id interface{}, originalHash interface{}, postMetadataHash interface{}) *MockStore_UpdateBookFileHashes_Call {
+func (_e *MockStore_Expecter) UpdateBookFileHashes(id any, originalHash any, postMetadataHash any) *MockStore_UpdateBookFileHashes_Call {
 	return &MockStore_UpdateBookFileHashes_Call{Call: _e.mock.On("UpdateBookFileHashes", id, originalHash, postMetadataHash)}
 }
 
@@ -48811,7 +49633,7 @@ type MockStore_UpdateBookRating_Call struct {
 // UpdateBookRating is a helper method to define mock.On call
 //   - id string
 //   - req database.UpdateBookRatingRequest
-func (_e *MockStore_Expecter) UpdateBookRating(id interface{}, req interface{}) *MockStore_UpdateBookRating_Call {
+func (_e *MockStore_Expecter) UpdateBookRating(id any, req any) *MockStore_UpdateBookRating_Call {
 	return &MockStore_UpdateBookRating_Call{Call: _e.mock.On("UpdateBookRating", id, req)}
 }
 
@@ -48867,7 +49689,7 @@ type MockStore_UpdateBookSegment_Call struct {
 
 // UpdateBookSegment is a helper method to define mock.On call
 //   - segment *database.BookSegment
-func (_e *MockStore_Expecter) UpdateBookSegment(segment interface{}) *MockStore_UpdateBookSegment_Call {
+func (_e *MockStore_Expecter) UpdateBookSegment(segment any) *MockStore_UpdateBookSegment_Call {
 	return &MockStore_UpdateBookSegment_Call{Call: _e.mock.On("UpdateBookSegment", segment)}
 }
 
@@ -48918,7 +49740,7 @@ type MockStore_UpdateBookVersion_Call struct {
 
 // UpdateBookVersion is a helper method to define mock.On call
 //   - v *database.BookVersion
-func (_e *MockStore_Expecter) UpdateBookVersion(v interface{}) *MockStore_UpdateBookVersion_Call {
+func (_e *MockStore_Expecter) UpdateBookVersion(v any) *MockStore_UpdateBookVersion_Call {
 	return &MockStore_UpdateBookVersion_Call{Call: _e.mock.On("UpdateBookVersion", v)}
 }
 
@@ -48970,7 +49792,7 @@ type MockStore_UpdateImportPath_Call struct {
 // UpdateImportPath is a helper method to define mock.On call
 //   - id int
 //   - importPath *database.ImportPath
-func (_e *MockStore_Expecter) UpdateImportPath(id interface{}, importPath interface{}) *MockStore_UpdateImportPath_Call {
+func (_e *MockStore_Expecter) UpdateImportPath(id any, importPath any) *MockStore_UpdateImportPath_Call {
 	return &MockStore_UpdateImportPath_Call{Call: _e.mock.On("UpdateImportPath", id, importPath)}
 }
 
@@ -49027,7 +49849,7 @@ type MockStore_UpdateOpCheckpointV2_Call struct {
 // UpdateOpCheckpointV2 is a helper method to define mock.On call
 //   - id string
 //   - newHWM int
-func (_e *MockStore_Expecter) UpdateOpCheckpointV2(id interface{}, newHWM interface{}) *MockStore_UpdateOpCheckpointV2_Call {
+func (_e *MockStore_Expecter) UpdateOpCheckpointV2(id any, newHWM any) *MockStore_UpdateOpCheckpointV2_Call {
 	return &MockStore_UpdateOpCheckpointV2_Call{Call: _e.mock.On("UpdateOpCheckpointV2", id, newHWM)}
 }
 
@@ -49084,7 +49906,7 @@ type MockStore_UpdateOpPhaseV2_Call struct {
 // UpdateOpPhaseV2 is a helper method to define mock.On call
 //   - id string
 //   - phase *string
-func (_e *MockStore_Expecter) UpdateOpPhaseV2(id interface{}, phase interface{}) *MockStore_UpdateOpPhaseV2_Call {
+func (_e *MockStore_Expecter) UpdateOpPhaseV2(id any, phase any) *MockStore_UpdateOpPhaseV2_Call {
 	return &MockStore_UpdateOpPhaseV2_Call{Call: _e.mock.On("UpdateOpPhaseV2", id, phase)}
 }
 
@@ -49143,7 +49965,7 @@ type MockStore_UpdateOpProgressV2_Call struct {
 //   - current int
 //   - total int
 //   - message string
-func (_e *MockStore_Expecter) UpdateOpProgressV2(id interface{}, current interface{}, total interface{}, message interface{}) *MockStore_UpdateOpProgressV2_Call {
+func (_e *MockStore_Expecter) UpdateOpProgressV2(id any, current any, total any, message any) *MockStore_UpdateOpProgressV2_Call {
 	return &MockStore_UpdateOpProgressV2_Call{Call: _e.mock.On("UpdateOpProgressV2", id, current, total, message)}
 }
 
@@ -49210,7 +50032,7 @@ type MockStore_UpdateOperationError_Call struct {
 // UpdateOperationError is a helper method to define mock.On call
 //   - id string
 //   - errorMessage string
-func (_e *MockStore_Expecter) UpdateOperationError(id interface{}, errorMessage interface{}) *MockStore_UpdateOperationError_Call {
+func (_e *MockStore_Expecter) UpdateOperationError(id any, errorMessage any) *MockStore_UpdateOperationError_Call {
 	return &MockStore_UpdateOperationError_Call{Call: _e.mock.On("UpdateOperationError", id, errorMessage)}
 }
 
@@ -49267,7 +50089,7 @@ type MockStore_UpdateOperationResultData_Call struct {
 // UpdateOperationResultData is a helper method to define mock.On call
 //   - id string
 //   - resultData string
-func (_e *MockStore_Expecter) UpdateOperationResultData(id interface{}, resultData interface{}) *MockStore_UpdateOperationResultData_Call {
+func (_e *MockStore_Expecter) UpdateOperationResultData(id any, resultData any) *MockStore_UpdateOperationResultData_Call {
 	return &MockStore_UpdateOperationResultData_Call{Call: _e.mock.On("UpdateOperationResultData", id, resultData)}
 }
 
@@ -49327,7 +50149,7 @@ type MockStore_UpdateOperationStatus_Call struct {
 //   - progress int
 //   - total int
 //   - message string
-func (_e *MockStore_Expecter) UpdateOperationStatus(id interface{}, status interface{}, progress interface{}, total interface{}, message interface{}) *MockStore_UpdateOperationStatus_Call {
+func (_e *MockStore_Expecter) UpdateOperationStatus(id any, status any, progress any, total any, message any) *MockStore_UpdateOperationStatus_Call {
 	return &MockStore_UpdateOperationStatus_Call{Call: _e.mock.On("UpdateOperationStatus", id, status, progress, total, message)}
 }
 
@@ -49399,7 +50221,7 @@ type MockStore_UpdateOperationV2Params_Call struct {
 // UpdateOperationV2Params is a helper method to define mock.On call
 //   - id string
 //   - params []byte
-func (_e *MockStore_Expecter) UpdateOperationV2Params(id interface{}, params interface{}) *MockStore_UpdateOperationV2Params_Call {
+func (_e *MockStore_Expecter) UpdateOperationV2Params(id any, params any) *MockStore_UpdateOperationV2Params_Call {
 	return &MockStore_UpdateOperationV2Params_Call{Call: _e.mock.On("UpdateOperationV2Params", id, params)}
 }
 
@@ -49413,7 +50235,10 @@ func (_c *MockStore_UpdateOperationV2Params_Call) Run(run func(id string, params
 		if args[1] != nil {
 			arg1 = args[1].([]byte)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -49423,7 +50248,7 @@ func (_c *MockStore_UpdateOperationV2Params_Call) Return(err error) *MockStore_U
 	return _c
 }
 
-func (_c *MockStore_UpdateOperationV2Params_Call) RunAndReturn(run func(string, []byte) error) *MockStore_UpdateOperationV2Params_Call {
+func (_c *MockStore_UpdateOperationV2Params_Call) RunAndReturn(run func(id string, params []byte) error) *MockStore_UpdateOperationV2Params_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -49456,7 +50281,7 @@ type MockStore_UpdateOperationV2Status_Call struct {
 //   - startedAt *time.Time
 //   - completedAt *time.Time
 //   - errMsg *string
-func (_e *MockStore_Expecter) UpdateOperationV2Status(id interface{}, status interface{}, startedAt interface{}, completedAt interface{}, errMsg interface{}) *MockStore_UpdateOperationV2Status_Call {
+func (_e *MockStore_Expecter) UpdateOperationV2Status(id any, status any, startedAt any, completedAt any, errMsg any) *MockStore_UpdateOperationV2Status_Call {
 	return &MockStore_UpdateOperationV2Status_Call{Call: _e.mock.On("UpdateOperationV2Status", id, status, startedAt, completedAt, errMsg)}
 }
 
@@ -49527,7 +50352,7 @@ type MockStore_UpdatePlaybackProgress_Call struct {
 
 // UpdatePlaybackProgress is a helper method to define mock.On call
 //   - progress *database.PlaybackProgress
-func (_e *MockStore_Expecter) UpdatePlaybackProgress(progress interface{}) *MockStore_UpdatePlaybackProgress_Call {
+func (_e *MockStore_Expecter) UpdatePlaybackProgress(progress any) *MockStore_UpdatePlaybackProgress_Call {
 	return &MockStore_UpdatePlaybackProgress_Call{Call: _e.mock.On("UpdatePlaybackProgress", progress)}
 }
 
@@ -49578,7 +50403,7 @@ type MockStore_UpdateRole_Call struct {
 
 // UpdateRole is a helper method to define mock.On call
 //   - role *database.Role
-func (_e *MockStore_Expecter) UpdateRole(role interface{}) *MockStore_UpdateRole_Call {
+func (_e *MockStore_Expecter) UpdateRole(role any) *MockStore_UpdateRole_Call {
 	return &MockStore_UpdateRole_Call{Call: _e.mock.On("UpdateRole", role)}
 }
 
@@ -49631,7 +50456,7 @@ type MockStore_UpdateScanCache_Call struct {
 //   - bookID string
 //   - mtime int64
 //   - size int64
-func (_e *MockStore_Expecter) UpdateScanCache(bookID interface{}, mtime interface{}, size interface{}) *MockStore_UpdateScanCache_Call {
+func (_e *MockStore_Expecter) UpdateScanCache(bookID any, mtime any, size any) *MockStore_UpdateScanCache_Call {
 	return &MockStore_UpdateScanCache_Call{Call: _e.mock.On("UpdateScanCache", bookID, mtime, size)}
 }
 
@@ -49693,7 +50518,7 @@ type MockStore_UpdateSeriesName_Call struct {
 // UpdateSeriesName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockStore_Expecter) UpdateSeriesName(id interface{}, name interface{}) *MockStore_UpdateSeriesName_Call {
+func (_e *MockStore_Expecter) UpdateSeriesName(id any, name any) *MockStore_UpdateSeriesName_Call {
 	return &MockStore_UpdateSeriesName_Call{Call: _e.mock.On("UpdateSeriesName", id, name)}
 }
 
@@ -49749,7 +50574,7 @@ type MockStore_UpdateUser_Call struct {
 
 // UpdateUser is a helper method to define mock.On call
 //   - user *database.User
-func (_e *MockStore_Expecter) UpdateUser(user interface{}) *MockStore_UpdateUser_Call {
+func (_e *MockStore_Expecter) UpdateUser(user any) *MockStore_UpdateUser_Call {
 	return &MockStore_UpdateUser_Call{Call: _e.mock.On("UpdateUser", user)}
 }
 
@@ -49800,7 +50625,7 @@ type MockStore_UpdateUserPlaylist_Call struct {
 
 // UpdateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockStore_Expecter) UpdateUserPlaylist(pl interface{}) *MockStore_UpdateUserPlaylist_Call {
+func (_e *MockStore_Expecter) UpdateUserPlaylist(pl any) *MockStore_UpdateUserPlaylist_Call {
 	return &MockStore_UpdateUserPlaylist_Call{Call: _e.mock.On("UpdateUserPlaylist", pl)}
 }
 
@@ -49863,7 +50688,7 @@ type MockStore_UpdateWork_Call struct {
 // UpdateWork is a helper method to define mock.On call
 //   - id string
 //   - work *database.Work
-func (_e *MockStore_Expecter) UpdateWork(id interface{}, work interface{}) *MockStore_UpdateWork_Call {
+func (_e *MockStore_Expecter) UpdateWork(id any, work any) *MockStore_UpdateWork_Call {
 	return &MockStore_UpdateWork_Call{Call: _e.mock.On("UpdateWork", id, work)}
 }
 
@@ -49919,7 +50744,7 @@ type MockStore_UpsertBookFile_Call struct {
 
 // UpsertBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockStore_Expecter) UpsertBookFile(file interface{}) *MockStore_UpsertBookFile_Call {
+func (_e *MockStore_Expecter) UpsertBookFile(file any) *MockStore_UpsertBookFile_Call {
 	return &MockStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
 }
 
@@ -49970,7 +50795,7 @@ type MockStore_UpsertMetadataFieldState_Call struct {
 
 // UpsertMetadataFieldState is a helper method to define mock.On call
 //   - state *database.MetadataFieldState
-func (_e *MockStore_Expecter) UpsertMetadataFieldState(state interface{}) *MockStore_UpsertMetadataFieldState_Call {
+func (_e *MockStore_Expecter) UpsertMetadataFieldState(state any) *MockStore_UpsertMetadataFieldState_Call {
 	return &MockStore_UpsertMetadataFieldState_Call{Call: _e.mock.On("UpsertMetadataFieldState", state)}
 }
 
@@ -50021,7 +50846,7 @@ type MockStore_UpsertOpDefinitionV2_Call struct {
 
 // UpsertOpDefinitionV2 is a helper method to define mock.On call
 //   - row database.OpDefinitionV2Row
-func (_e *MockStore_Expecter) UpsertOpDefinitionV2(row interface{}) *MockStore_UpsertOpDefinitionV2_Call {
+func (_e *MockStore_Expecter) UpsertOpDefinitionV2(row any) *MockStore_UpsertOpDefinitionV2_Call {
 	return &MockStore_UpsertOpDefinitionV2_Call{Call: _e.mock.On("UpsertOpDefinitionV2", row)}
 }
 
@@ -50072,7 +50897,7 @@ type MockStore_UpsertOpStateV2_Call struct {
 
 // UpsertOpStateV2 is a helper method to define mock.On call
 //   - row database.OpStateV2Row
-func (_e *MockStore_Expecter) UpsertOpStateV2(row interface{}) *MockStore_UpsertOpStateV2_Call {
+func (_e *MockStore_Expecter) UpsertOpStateV2(row any) *MockStore_UpsertOpStateV2_Call {
 	return &MockStore_UpsertOpStateV2_Call{Call: _e.mock.On("UpsertOpStateV2", row)}
 }
 
@@ -50095,594 +50920,6 @@ func (_c *MockStore_UpsertOpStateV2_Call) Return(err error) *MockStore_UpsertOpS
 }
 
 func (_c *MockStore_UpsertOpStateV2_Call) RunAndReturn(run func(row database.OpStateV2Row) error) *MockStore_UpsertOpStateV2_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetDepRev provides a mock function for the type MockStore
-func (_mock *MockStore) GetDepRev(sub database.OpSubject) (uint64, error) {
-	ret := _mock.Called(sub)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetDepRev")
-	}
-
-	var r0 uint64
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
-		return returnFunc(sub)
-	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
-		r0 = returnFunc(sub)
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
-		r1 = returnFunc(sub)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_GetDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDepRev'
-type MockStore_GetDepRev_Call struct {
-	*mock.Call
-}
-
-// GetDepRev is a helper method to define mock.On call
-//   - sub database.OpSubject
-func (_e *MockStore_Expecter) GetDepRev(sub interface{}) *MockStore_GetDepRev_Call {
-	return &MockStore_GetDepRev_Call{Call: _e.mock.On("GetDepRev", sub)}
-}
-
-func (_c *MockStore_GetDepRev_Call) Run(run func(sub database.OpSubject)) *MockStore_GetDepRev_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetDepRev_Call) Return(u uint64, err error) *MockStore_GetDepRev_Call {
-	_c.Call.Return(u, err)
-	return _c
-}
-
-func (_c *MockStore_GetDepRev_Call) RunAndReturn(run func(database.OpSubject) (uint64, error)) *MockStore_GetDepRev_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// BumpDepRev provides a mock function for the type MockStore
-func (_mock *MockStore) BumpDepRev(sub database.OpSubject) (uint64, error) {
-	ret := _mock.Called(sub)
-
-	if len(ret) == 0 {
-		panic("no return value specified for BumpDepRev")
-	}
-
-	var r0 uint64
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) (uint64, error)); ok {
-		return returnFunc(sub)
-	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject) uint64); ok {
-		r0 = returnFunc(sub)
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject) error); ok {
-		r1 = returnFunc(sub)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_BumpDepRev_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BumpDepRev'
-type MockStore_BumpDepRev_Call struct {
-	*mock.Call
-}
-
-// BumpDepRev is a helper method to define mock.On call
-//   - sub database.OpSubject
-func (_e *MockStore_Expecter) BumpDepRev(sub interface{}) *MockStore_BumpDepRev_Call {
-	return &MockStore_BumpDepRev_Call{Call: _e.mock.On("BumpDepRev", sub)}
-}
-
-func (_c *MockStore_BumpDepRev_Call) Run(run func(sub database.OpSubject)) *MockStore_BumpDepRev_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_BumpDepRev_Call) Return(u uint64, err error) *MockStore_BumpDepRev_Call {
-	_c.Call.Return(u, err)
-	return _c
-}
-
-func (_c *MockStore_BumpDepRev_Call) RunAndReturn(run func(database.OpSubject) (uint64, error)) *MockStore_BumpDepRev_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// RecordOpCompletion provides a mock function for the type MockStore
-func (_mock *MockStore) RecordOpCompletion(sub database.OpSubject, opType string, fileID string, depRev uint64) error {
-	ret := _mock.Called(sub, opType, fileID, depRev)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RecordOpCompletion")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string, string, uint64) error); ok {
-		r0 = returnFunc(sub, opType, fileID, depRev)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_RecordOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordOpCompletion'
-type MockStore_RecordOpCompletion_Call struct {
-	*mock.Call
-}
-
-// RecordOpCompletion is a helper method to define mock.On call
-//   - sub database.OpSubject
-//   - opType string
-//   - fileID string
-//   - depRev uint64
-func (_e *MockStore_Expecter) RecordOpCompletion(sub interface{}, opType interface{}, fileID interface{}, depRev interface{}) *MockStore_RecordOpCompletion_Call {
-	return &MockStore_RecordOpCompletion_Call{Call: _e.mock.On("RecordOpCompletion", sub, opType, fileID, depRev)}
-}
-
-func (_c *MockStore_RecordOpCompletion_Call) Run(run func(sub database.OpSubject, opType string, fileID string, depRev uint64)) *MockStore_RecordOpCompletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		var arg3 uint64
-		if args[3] != nil {
-			arg3 = args[3].(uint64)
-		}
-		run(arg0, arg1, arg2, arg3)
-	})
-	return _c
-}
-
-func (_c *MockStore_RecordOpCompletion_Call) Return(err error) *MockStore_RecordOpCompletion_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_RecordOpCompletion_Call) RunAndReturn(run func(database.OpSubject, string, string, uint64) error) *MockStore_RecordOpCompletion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetOpCompletion provides a mock function for the type MockStore
-func (_mock *MockStore) GetOpCompletion(sub database.OpSubject, opType string) (uint64, bool, error) {
-	ret := _mock.Called(sub, opType)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOpCompletion")
-	}
-
-	var r0 uint64
-	var r1 bool
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (uint64, bool, error)); ok {
-		return returnFunc(sub, opType)
-	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) uint64); ok {
-		r0 = returnFunc(sub, opType)
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) bool); ok {
-		r1 = returnFunc(sub, opType)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-	if returnFunc, ok := ret.Get(2).(func(database.OpSubject, string) error); ok {
-		r2 = returnFunc(sub, opType)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
-}
-
-// MockStore_GetOpCompletion_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOpCompletion'
-type MockStore_GetOpCompletion_Call struct {
-	*mock.Call
-}
-
-// GetOpCompletion is a helper method to define mock.On call
-//   - sub database.OpSubject
-//   - opType string
-func (_e *MockStore_Expecter) GetOpCompletion(sub interface{}, opType interface{}) *MockStore_GetOpCompletion_Call {
-	return &MockStore_GetOpCompletion_Call{Call: _e.mock.On("GetOpCompletion", sub, opType)}
-}
-
-func (_c *MockStore_GetOpCompletion_Call) Run(run func(sub database.OpSubject, opType string)) *MockStore_GetOpCompletion_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetOpCompletion_Call) Return(u uint64, b bool, err error) *MockStore_GetOpCompletion_Call {
-	_c.Call.Return(u, b, err)
-	return _c
-}
-
-func (_c *MockStore_GetOpCompletion_Call) RunAndReturn(run func(database.OpSubject, string) (uint64, bool, error)) *MockStore_GetOpCompletion_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListFileCompletions provides a mock function for the type MockStore
-func (_mock *MockStore) ListFileCompletions(sub database.OpSubject, opType string) (map[string]uint64, error) {
-	ret := _mock.Called(sub, opType)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListFileCompletions")
-	}
-
-	var r0 map[string]uint64
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) (map[string]uint64, error)); ok {
-		return returnFunc(sub, opType)
-	}
-	if returnFunc, ok := ret.Get(0).(func(database.OpSubject, string) map[string]uint64); ok {
-		r0 = returnFunc(sub, opType)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]uint64)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(database.OpSubject, string) error); ok {
-		r1 = returnFunc(sub, opType)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_ListFileCompletions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFileCompletions'
-type MockStore_ListFileCompletions_Call struct {
-	*mock.Call
-}
-
-// ListFileCompletions is a helper method to define mock.On call
-//   - sub database.OpSubject
-//   - opType string
-func (_e *MockStore_Expecter) ListFileCompletions(sub interface{}, opType interface{}) *MockStore_ListFileCompletions_Call {
-	return &MockStore_ListFileCompletions_Call{Call: _e.mock.On("ListFileCompletions", sub, opType)}
-}
-
-func (_c *MockStore_ListFileCompletions_Call) Run(run func(sub database.OpSubject, opType string)) *MockStore_ListFileCompletions_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 database.OpSubject
-		if args[0] != nil {
-			arg0 = args[0].(database.OpSubject)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_ListFileCompletions_Call) Return(stringToUint64 map[string]uint64, err error) *MockStore_ListFileCompletions_Call {
-	_c.Call.Return(stringToUint64, err)
-	return _c
-}
-
-func (_c *MockStore_ListFileCompletions_Call) RunAndReturn(run func(database.OpSubject, string) (map[string]uint64, error)) *MockStore_ListFileCompletions_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListWaitingDepsOps provides a mock function for the type MockStore
-func (_mock *MockStore) ListWaitingDepsOps() ([]database.OperationV2Row, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListWaitingDepsOps")
-	}
-
-	var r0 []database.OperationV2Row
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.OperationV2Row, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() []database.OperationV2Row); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.OperationV2Row)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_ListWaitingDepsOps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListWaitingDepsOps'
-type MockStore_ListWaitingDepsOps_Call struct {
-	*mock.Call
-}
-
-// ListWaitingDepsOps is a helper method to define mock.On call
-func (_e *MockStore_Expecter) ListWaitingDepsOps() *MockStore_ListWaitingDepsOps_Call {
-	return &MockStore_ListWaitingDepsOps_Call{Call: _e.mock.On("ListWaitingDepsOps")}
-}
-
-func (_c *MockStore_ListWaitingDepsOps_Call) Run(run func()) *MockStore_ListWaitingDepsOps_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockStore_ListWaitingDepsOps_Call) Return(operationV2Rows []database.OperationV2Row, err error) *MockStore_ListWaitingDepsOps_Call {
-	_c.Call.Return(operationV2Rows, err)
-	return _c
-}
-
-func (_c *MockStore_ListWaitingDepsOps_Call) RunAndReturn(run func() ([]database.OperationV2Row, error)) *MockStore_ListWaitingDepsOps_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// PromoteToQueued provides a mock function for the type MockStore
-func (_mock *MockStore) PromoteToQueued(id string) error {
-	ret := _mock.Called(id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PromoteToQueued")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_PromoteToQueued_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PromoteToQueued'
-type MockStore_PromoteToQueued_Call struct {
-	*mock.Call
-}
-
-// PromoteToQueued is a helper method to define mock.On call
-//   - id string
-func (_e *MockStore_Expecter) PromoteToQueued(id interface{}) *MockStore_PromoteToQueued_Call {
-	return &MockStore_PromoteToQueued_Call{Call: _e.mock.On("PromoteToQueued", id)}
-}
-
-func (_c *MockStore_PromoteToQueued_Call) Run(run func(id string)) *MockStore_PromoteToQueued_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockStore_PromoteToQueued_Call) Return(err error) *MockStore_PromoteToQueued_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_PromoteToQueued_Call) RunAndReturn(run func(id string) error) *MockStore_PromoteToQueued_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// AddToBatchBucket provides a mock function for the type MockStore
-func (_mock *MockStore) AddToBatchBucket(opType string, sub database.OpSubject) error {
-	ret := _mock.Called(opType, sub)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AddToBatchBucket")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, database.OpSubject) error); ok {
-		r0 = returnFunc(opType, sub)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_AddToBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddToBatchBucket'
-type MockStore_AddToBatchBucket_Call struct {
-	*mock.Call
-}
-
-// AddToBatchBucket is a helper method to define mock.On call
-//   - opType string
-//   - sub database.OpSubject
-func (_e *MockStore_Expecter) AddToBatchBucket(opType interface{}, sub interface{}) *MockStore_AddToBatchBucket_Call {
-	return &MockStore_AddToBatchBucket_Call{Call: _e.mock.On("AddToBatchBucket", opType, sub)}
-}
-
-func (_c *MockStore_AddToBatchBucket_Call) Run(run func(opType string, sub database.OpSubject)) *MockStore_AddToBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 database.OpSubject
-		if args[1] != nil {
-			arg1 = args[1].(database.OpSubject)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_AddToBatchBucket_Call) Return(err error) *MockStore_AddToBatchBucket_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_AddToBatchBucket_Call) RunAndReturn(run func(string, database.OpSubject) error) *MockStore_AddToBatchBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ListBatchBucket provides a mock function for the type MockStore
-func (_mock *MockStore) ListBatchBucket(opType string) ([]database.BatchBucketEntry, error) {
-	ret := _mock.Called(opType)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListBatchBucket")
-	}
-
-	var r0 []database.BatchBucketEntry
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]database.BatchBucketEntry, error)); ok {
-		return returnFunc(opType)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string) []database.BatchBucketEntry); ok {
-		r0 = returnFunc(opType)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BatchBucketEntry)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(opType)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_ListBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBatchBucket'
-type MockStore_ListBatchBucket_Call struct {
-	*mock.Call
-}
-
-// ListBatchBucket is a helper method to define mock.On call
-//   - opType string
-func (_e *MockStore_Expecter) ListBatchBucket(opType interface{}) *MockStore_ListBatchBucket_Call {
-	return &MockStore_ListBatchBucket_Call{Call: _e.mock.On("ListBatchBucket", opType)}
-}
-
-func (_c *MockStore_ListBatchBucket_Call) Run(run func(opType string)) *MockStore_ListBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		run(arg0)
-	})
-	return _c
-}
-
-func (_c *MockStore_ListBatchBucket_Call) Return(entries []database.BatchBucketEntry, err error) *MockStore_ListBatchBucket_Call {
-	_c.Call.Return(entries, err)
-	return _c
-}
-
-func (_c *MockStore_ListBatchBucket_Call) RunAndReturn(run func(string) ([]database.BatchBucketEntry, error)) *MockStore_ListBatchBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ClearBatchBucket provides a mock function for the type MockStore
-func (_mock *MockStore) ClearBatchBucket(opType string, subs []database.OpSubject) error {
-	ret := _mock.Called(opType, subs)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ClearBatchBucket")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []database.OpSubject) error); ok {
-		r0 = returnFunc(opType, subs)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_ClearBatchBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ClearBatchBucket'
-type MockStore_ClearBatchBucket_Call struct {
-	*mock.Call
-}
-
-// ClearBatchBucket is a helper method to define mock.On call
-//   - opType string
-//   - subs []database.OpSubject
-func (_e *MockStore_Expecter) ClearBatchBucket(opType interface{}, subs interface{}) *MockStore_ClearBatchBucket_Call {
-	return &MockStore_ClearBatchBucket_Call{Call: _e.mock.On("ClearBatchBucket", opType, subs)}
-}
-
-func (_c *MockStore_ClearBatchBucket_Call) Run(run func(opType string, subs []database.OpSubject)) *MockStore_ClearBatchBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 []database.OpSubject
-		if args[1] != nil {
-			arg1 = args[1].([]database.OpSubject)
-		}
-		run(arg0, arg1)
-	})
-	return _c
-}
-
-func (_c *MockStore_ClearBatchBucket_Call) Return(err error) *MockStore_ClearBatchBucket_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_ClearBatchBucket_Call) RunAndReturn(run func(string, []database.OpSubject) error) *MockStore_ClearBatchBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/logger/mocks/mock_activity_log_writer.go
+++ b/internal/logger/mocks/mock_activity_log_writer.go
@@ -61,7 +61,7 @@ type MockActivityLogWriter_AddSystemActivityLog_Call struct {
 //   - source string
 //   - level string
 //   - message string
-func (_e *MockActivityLogWriter_Expecter) AddSystemActivityLog(source interface{}, level interface{}, message interface{}) *MockActivityLogWriter_AddSystemActivityLog_Call {
+func (_e *MockActivityLogWriter_Expecter) AddSystemActivityLog(source any, level any, message any) *MockActivityLogWriter_AddSystemActivityLog_Call {
 	return &MockActivityLogWriter_AddSystemActivityLog_Call{Call: _e.mock.On("AddSystemActivityLog", source, level, message)}
 }
 

--- a/internal/logger/mocks/mock_operation_store.go
+++ b/internal/logger/mocks/mock_operation_store.go
@@ -62,7 +62,7 @@ type MockOperationStore_AddOperationLog_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockOperationStore_Expecter) AddOperationLog(operationID interface{}, level interface{}, message interface{}, details interface{}) *MockOperationStore_AddOperationLog_Call {
+func (_e *MockOperationStore_Expecter) AddOperationLog(operationID any, level any, message any, details any) *MockOperationStore_AddOperationLog_Call {
 	return &MockOperationStore_AddOperationLog_Call{Call: _e.mock.On("AddOperationLog", operationID, level, message, details)}
 }
 
@@ -128,7 +128,7 @@ type MockOperationStore_CreateOperationChange_Call struct {
 
 // CreateOperationChange is a helper method to define mock.On call
 //   - change interface{}
-func (_e *MockOperationStore_Expecter) CreateOperationChange(change interface{}) *MockOperationStore_CreateOperationChange_Call {
+func (_e *MockOperationStore_Expecter) CreateOperationChange(change any) *MockOperationStore_CreateOperationChange_Call {
 	return &MockOperationStore_CreateOperationChange_Call{Call: _e.mock.On("CreateOperationChange", change)}
 }
 
@@ -182,7 +182,7 @@ type MockOperationStore_UpdateOperationProgress_Call struct {
 //   - current int
 //   - total int
 //   - message string
-func (_e *MockOperationStore_Expecter) UpdateOperationProgress(id interface{}, current interface{}, total interface{}, message interface{}) *MockOperationStore_UpdateOperationProgress_Call {
+func (_e *MockOperationStore_Expecter) UpdateOperationProgress(id any, current any, total any, message any) *MockOperationStore_UpdateOperationProgress_Call {
 	return &MockOperationStore_UpdateOperationProgress_Call{Call: _e.mock.On("UpdateOperationProgress", id, current, total, message)}
 }
 

--- a/internal/logger/mocks/mock_realtime_hub.go
+++ b/internal/logger/mocks/mock_realtime_hub.go
@@ -51,7 +51,7 @@ type MockRealtimeHub_SendOperationLog_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockRealtimeHub_Expecter) SendOperationLog(operationID interface{}, level interface{}, message interface{}, details interface{}) *MockRealtimeHub_SendOperationLog_Call {
+func (_e *MockRealtimeHub_Expecter) SendOperationLog(operationID any, level any, message any, details any) *MockRealtimeHub_SendOperationLog_Call {
 	return &MockRealtimeHub_SendOperationLog_Call{Call: _e.mock.On("SendOperationLog", operationID, level, message, details)}
 }
 
@@ -109,7 +109,7 @@ type MockRealtimeHub_SendOperationProgress_Call struct {
 //   - current int
 //   - total int
 //   - message string
-func (_e *MockRealtimeHub_Expecter) SendOperationProgress(operationID interface{}, current interface{}, total interface{}, message interface{}) *MockRealtimeHub_SendOperationProgress_Call {
+func (_e *MockRealtimeHub_Expecter) SendOperationProgress(operationID any, current any, total any, message any) *MockRealtimeHub_SendOperationProgress_Call {
 	return &MockRealtimeHub_SendOperationProgress_Call{Call: _e.mock.On("SendOperationProgress", operationID, current, total, message)}
 }
 

--- a/internal/logger/mocks/mock_retention_store.go
+++ b/internal/logger/mocks/mock_retention_store.go
@@ -70,7 +70,7 @@ type MockRetentionStore_PruneOperationChanges_Call struct {
 
 // PruneOperationChanges is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockRetentionStore_Expecter) PruneOperationChanges(olderThan interface{}) *MockRetentionStore_PruneOperationChanges_Call {
+func (_e *MockRetentionStore_Expecter) PruneOperationChanges(olderThan any) *MockRetentionStore_PruneOperationChanges_Call {
 	return &MockRetentionStore_PruneOperationChanges_Call{Call: _e.mock.On("PruneOperationChanges", olderThan)}
 }
 
@@ -130,7 +130,7 @@ type MockRetentionStore_PruneOperationLogs_Call struct {
 
 // PruneOperationLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockRetentionStore_Expecter) PruneOperationLogs(olderThan interface{}) *MockRetentionStore_PruneOperationLogs_Call {
+func (_e *MockRetentionStore_Expecter) PruneOperationLogs(olderThan any) *MockRetentionStore_PruneOperationLogs_Call {
 	return &MockRetentionStore_PruneOperationLogs_Call{Call: _e.mock.On("PruneOperationLogs", olderThan)}
 }
 
@@ -190,7 +190,7 @@ type MockRetentionStore_PruneSystemActivityLogs_Call struct {
 
 // PruneSystemActivityLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockRetentionStore_Expecter) PruneSystemActivityLogs(olderThan interface{}) *MockRetentionStore_PruneSystemActivityLogs_Call {
+func (_e *MockRetentionStore_Expecter) PruneSystemActivityLogs(olderThan any) *MockRetentionStore_PruneSystemActivityLogs_Call {
 	return &MockRetentionStore_PruneSystemActivityLogs_Call{Call: _e.mock.On("PruneSystemActivityLogs", olderThan)}
 }
 

--- a/internal/metabatch/candidates.go
+++ b/internal/metabatch/candidates.go
@@ -1,7 +1,7 @@
 // file: internal/metabatch/candidates.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-05-11
+// last-edited: 2026-07-01
 //
 // Package metabatch contains pure service types and logic for the
 // metadata candidate batch fetch / apply pipeline. HTTP handlers live
@@ -45,6 +45,11 @@ type CandidateBookInfo struct {
 	// Empty when the book has no language set, in which case the
 	// filter is a no-op for that row.
 	Language string `json:"language,omitempty"`
+	// TranscribedTitle is the Whisper-parsed title from the book's audio intro.
+	// Non-empty means transcription data was available during candidate scoring.
+	// Lets the review UI offer a "has transcription" filter to focus on books
+	// where audio-derived metadata could confirm or reject the match.
+	TranscribedTitle string `json:"transcribed_title,omitempty"`
 }
 
 // CandidateResult holds the metadata candidate search result for a single book.
@@ -133,6 +138,9 @@ func BuildCandidateBookInfo(store BookFilesGetter, book *database.Book) Candidat
 	}
 	if book.Language != nil {
 		info.Language = *book.Language
+	}
+	if book.TranscribedTitle != nil && *book.TranscribedTitle != "" {
+		info.TranscribedTitle = *book.TranscribedTitle
 	}
 	return info
 }

--- a/internal/metadata/mocks/mock_contextual_search.go
+++ b/internal/metadata/mocks/mock_contextual_search.go
@@ -71,7 +71,7 @@ type MockContextualSearch_SearchByContext_Call struct {
 
 // SearchByContext is a helper method to define mock.On call
 //   - ctx *metadata.SearchContext
-func (_e *MockContextualSearch_Expecter) SearchByContext(ctx interface{}) *MockContextualSearch_SearchByContext_Call {
+func (_e *MockContextualSearch_Expecter) SearchByContext(ctx any) *MockContextualSearch_SearchByContext_Call {
 	return &MockContextualSearch_SearchByContext_Call{Call: _e.mock.On("SearchByContext", ctx)}
 }
 

--- a/internal/metadata/mocks/mock_metadata_extractor.go
+++ b/internal/metadata/mocks/mock_metadata_extractor.go
@@ -69,7 +69,7 @@ type MockMetadataExtractor_ExtractMetadata_Call struct {
 
 // ExtractMetadata is a helper method to define mock.On call
 //   - filePath string
-func (_e *MockMetadataExtractor_Expecter) ExtractMetadata(filePath interface{}) *MockMetadataExtractor_ExtractMetadata_Call {
+func (_e *MockMetadataExtractor_Expecter) ExtractMetadata(filePath any) *MockMetadataExtractor_ExtractMetadata_Call {
 	return &MockMetadataExtractor_ExtractMetadata_Call{Call: _e.mock.On("ExtractMetadata", filePath)}
 }
 

--- a/internal/metadata/mocks/mock_metadata_source.go
+++ b/internal/metadata/mocks/mock_metadata_source.go
@@ -118,7 +118,7 @@ type MockMetadataSource_SearchByTitle_Call struct {
 // SearchByTitle is a helper method to define mock.On call
 //   - ctx context.Context
 //   - title string
-func (_e *MockMetadataSource_Expecter) SearchByTitle(ctx interface{}, title interface{}) *MockMetadataSource_SearchByTitle_Call {
+func (_e *MockMetadataSource_Expecter) SearchByTitle(ctx any, title any) *MockMetadataSource_SearchByTitle_Call {
 	return &MockMetadataSource_SearchByTitle_Call{Call: _e.mock.On("SearchByTitle", ctx, title)}
 }
 
@@ -187,7 +187,7 @@ type MockMetadataSource_SearchByTitleAndAuthor_Call struct {
 //   - ctx context.Context
 //   - title string
 //   - author string
-func (_e *MockMetadataSource_Expecter) SearchByTitleAndAuthor(ctx interface{}, title interface{}, author interface{}) *MockMetadataSource_SearchByTitleAndAuthor_Call {
+func (_e *MockMetadataSource_Expecter) SearchByTitleAndAuthor(ctx any, title any, author any) *MockMetadataSource_SearchByTitleAndAuthor_Call {
 	return &MockMetadataSource_SearchByTitleAndAuthor_Call{Call: _e.mock.On("SearchByTitleAndAuthor", ctx, title, author)}
 }
 

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 5.1.0
+// version: 5.2.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
-// last-edited: 2026-05-01
+// last-edited: 2026-07-01
 
 package metafetch
 
@@ -92,6 +92,12 @@ type MetadataCandidate struct {
 	//   < 5%  → +20,  < 10% → +15,  < 20% → +10,
 	//   > 50% → -10,  > 100% → -20.
 	DurationScore float64 `json:"duration_score,omitempty"`
+	// TranscriptionBoosted is true when this candidate's title, author, or
+	// narrator matched the book's Whisper-transcribed intro fields, causing a
+	// score multiplier to be applied. Lets the review UI surface a
+	// "matched on transcription" filter so users can focus on books where
+	// audio-derived metadata was the deciding factor.
+	TranscriptionBoosted bool `json:"transcription_boosted,omitempty"`
 	// AudibleRatingOverall is the Audible overall star rating (1–5 scale).
 	// Zero means the source did not provide a rating.
 	AudibleRatingOverall float64 `json:"audible_rating_overall,omitempty"`

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package metafetch
 
@@ -286,21 +286,27 @@ func containsCI(a, b string) bool {
 // intentionally NOT clamped — bonuses add on top (see scoring memo). An exact
 // (normalized) transcribed-title match is the strongest signal because the title
 // is read aloud verbatim in the intro.
-func transcriptionBoost(score float64, r metadata.BookMetadata, th transcriptionHints) float64 {
+// Returns (adjusted score, true) when any boost was applied; (score, false) otherwise.
+func transcriptionBoost(score float64, r metadata.BookMetadata, th transcriptionHints) (float64, bool) {
+	boosted := false
 	if th.title != "" && r.Title != "" {
 		if util.NormalizeTitle(r.Title) == util.NormalizeTitle(th.title) {
 			score *= 2.0
+			boosted = true
 		} else if containsCI(r.Title, th.title) {
 			score *= 1.4
+			boosted = true
 		}
 	}
 	if th.author != "" && containsCI(r.Author, th.author) {
 		score *= 1.6
+		boosted = true
 	}
 	if th.narrator != "" && containsCI(r.Narrator, th.narrator) {
 		score *= 1.4
+		boosted = true
 	}
-	return score
+	return score, boosted
 }
 
 func pickBestMatchFromScored(
@@ -379,7 +385,7 @@ func pickBestMatchFromScored(
 		// audio-derived title/author/narrator, that is strong evidence of a
 		// correct match. No-op when no transcription hints were supplied.
 		if !th.empty() {
-			score = transcriptionBoost(score, r, th)
+			score, _ = transcriptionBoost(score, r, th)
 		}
 
 		// Duration-based scoring: compare candidate runtime against the book's

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_search.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package metafetch
 
@@ -377,8 +377,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				score *= 0.85 // Penalize results without narrator info (likely non-audiobook sources)
 			}
 
+			var transcriptionBoosted bool
 			if !th.empty() {
-				score = transcriptionBoost(score, r, th)
+				score, transcriptionBoosted = transcriptionBoost(score, r, th)
 			}
 
 			// Duration-based scoring: compare candidate runtime vs. local file duration.
@@ -412,6 +413,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				DurationScore:        computeDurationScore(bookDurationSec, r.DurationSec),
 				CategoryTags:         r.CategoryTags,
 				DurationMismatch:     durationDelta > 600,
+				TranscriptionBoosted: transcriptionBoosted,
 				AudibleRatingOverall: r.AudibleRatingOverall,
 				AudibleRatingCount:   r.AudibleRatingCount,
 				GoogleRatingAverage:  r.GoogleRatingAverage,

--- a/internal/operations/mocks/mock_progress_reporter.go
+++ b/internal/operations/mocks/mock_progress_reporter.go
@@ -105,7 +105,7 @@ type MockProgressReporter_Log_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockProgressReporter_Expecter) Log(level interface{}, message interface{}, details interface{}) *MockProgressReporter_Log_Call {
+func (_e *MockProgressReporter_Expecter) Log(level any, message any, details any) *MockProgressReporter_Log_Call {
 	return &MockProgressReporter_Log_Call{Call: _e.mock.On("Log", level, message, details)}
 }
 
@@ -168,7 +168,7 @@ type MockProgressReporter_UpdateProgress_Call struct {
 //   - current int
 //   - total int
 //   - message string
-func (_e *MockProgressReporter_Expecter) UpdateProgress(current interface{}, total interface{}, message interface{}) *MockProgressReporter_UpdateProgress_Call {
+func (_e *MockProgressReporter_Expecter) UpdateProgress(current any, total any, message any) *MockProgressReporter_UpdateProgress_Call {
 	return &MockProgressReporter_UpdateProgress_Call{Call: _e.mock.On("UpdateProgress", current, total, message)}
 }
 

--- a/internal/operations/registry/registry_test.go
+++ b/internal/operations/registry/registry_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
-// last-edited: 2026-06-13
+// last-edited: 2026-07-01
 
 package registry_test
 
@@ -507,17 +507,19 @@ func TestDepsScheduler_WakeOnCompletion(t *testing.T) {
 		t.Fatalf("OnOpCompleted: %v", err)
 	}
 
-	// After wakeup, the dependent should be promoted to "queued".
+	// After wakeup, the dependent should be promoted to "queued" or "completed"
+	// (4 workers may pick it up and finish before our poll loop observes "queued").
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if store.statusOf(depOpID) == "queued" {
+		s := store.statusOf(depOpID)
+		if s == "queued" || s == "completed" {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if store.statusOf(depOpID) != "queued" {
-		t.Errorf("expected dep to be promoted to queued after prereq completion, got %q",
-			store.statusOf(depOpID))
+	s := store.statusOf(depOpID)
+	if s != "queued" && s != "completed" {
+		t.Errorf("expected dep to be promoted to queued or completed after prereq completion, got %q", s)
 	}
 }
 

--- a/internal/scanner/mocks/mock_scanner.go
+++ b/internal/scanner/mocks/mock_scanner.go
@@ -72,7 +72,7 @@ type MockScanner_ComputeFileHash_Call struct {
 
 // ComputeFileHash is a helper method to define mock.On call
 //   - filePath string
-func (_e *MockScanner_Expecter) ComputeFileHash(filePath interface{}) *MockScanner_ComputeFileHash_Call {
+func (_e *MockScanner_Expecter) ComputeFileHash(filePath any) *MockScanner_ComputeFileHash_Call {
 	return &MockScanner_ComputeFileHash_Call{Call: _e.mock.On("ComputeFileHash", filePath)}
 }
 
@@ -124,7 +124,7 @@ type MockScanner_ProcessBooks_Call struct {
 // ProcessBooks is a helper method to define mock.On call
 //   - books []scanner.Book
 //   - scanLog logger.Logger
-func (_e *MockScanner_Expecter) ProcessBooks(books interface{}, scanLog interface{}) *MockScanner_ProcessBooks_Call {
+func (_e *MockScanner_Expecter) ProcessBooks(books any, scanLog any) *MockScanner_ProcessBooks_Call {
 	return &MockScanner_ProcessBooks_Call{Call: _e.mock.On("ProcessBooks", books, scanLog)}
 }
 
@@ -184,7 +184,7 @@ type MockScanner_ProcessBooksParallel_Call struct {
 //   - workers int
 //   - progressFn func(processed int, total int, bookPath string)
 //   - scanLog logger.Logger
-func (_e *MockScanner_Expecter) ProcessBooksParallel(ctx interface{}, books interface{}, workers interface{}, progressFn interface{}, scanLog interface{}) *MockScanner_ProcessBooksParallel_Call {
+func (_e *MockScanner_Expecter) ProcessBooksParallel(ctx any, books any, workers any, progressFn any, scanLog any) *MockScanner_ProcessBooksParallel_Call {
 	return &MockScanner_ProcessBooksParallel_Call{Call: _e.mock.On("ProcessBooksParallel", ctx, books, workers, progressFn, scanLog)}
 }
 
@@ -267,7 +267,7 @@ type MockScanner_ScanDirectory_Call struct {
 // ScanDirectory is a helper method to define mock.On call
 //   - rootDir string
 //   - scanLog logger.Logger
-func (_e *MockScanner_Expecter) ScanDirectory(rootDir interface{}, scanLog interface{}) *MockScanner_ScanDirectory_Call {
+func (_e *MockScanner_Expecter) ScanDirectory(rootDir any, scanLog any) *MockScanner_ScanDirectory_Call {
 	return &MockScanner_ScanDirectory_Call{Call: _e.mock.On("ScanDirectory", rootDir, scanLog)}
 }
 
@@ -336,7 +336,7 @@ type MockScanner_ScanDirectoryParallel_Call struct {
 //   - rootDir string
 //   - workers int
 //   - scanLog logger.Logger
-func (_e *MockScanner_Expecter) ScanDirectoryParallel(rootDir interface{}, workers interface{}, scanLog interface{}) *MockScanner_ScanDirectoryParallel_Call {
+func (_e *MockScanner_Expecter) ScanDirectoryParallel(rootDir any, workers any, scanLog any) *MockScanner_ScanDirectoryParallel_Call {
 	return &MockScanner_ScanDirectoryParallel_Call{Call: _e.mock.On("ScanDirectoryParallel", rootDir, workers, scanLog)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_audiobook_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_audiobook_service.go
@@ -74,7 +74,7 @@ type MockAudiobookService_BatchUpdateUserTags_Call struct {
 //   - bookIDs []string
 //   - addTags []string
 //   - removeTags []string
-func (_e *MockAudiobookService_Expecter) BatchUpdateUserTags(bookIDs interface{}, addTags interface{}, removeTags interface{}) *MockAudiobookService_BatchUpdateUserTags_Call {
+func (_e *MockAudiobookService_Expecter) BatchUpdateUserTags(bookIDs any, addTags any, removeTags any) *MockAudiobookService_BatchUpdateUserTags_Call {
 	return &MockAudiobookService_BatchUpdateUserTags_Call{Call: _e.mock.On("BatchUpdateUserTags", bookIDs, addTags, removeTags)}
 }
 
@@ -144,7 +144,7 @@ type MockAudiobookService_CountAudiobooks_Call struct {
 
 // CountAudiobooks is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAudiobookService_Expecter) CountAudiobooks(ctx interface{}) *MockAudiobookService_CountAudiobooks_Call {
+func (_e *MockAudiobookService_Expecter) CountAudiobooks(ctx any) *MockAudiobookService_CountAudiobooks_Call {
 	return &MockAudiobookService_CountAudiobooks_Call{Call: _e.mock.On("CountAudiobooks", ctx)}
 }
 
@@ -208,7 +208,7 @@ type MockAudiobookService_DeleteAudiobook_Call struct {
 //   - ctx context.Context
 //   - id string
 //   - opts *audiobooks.DeleteAudiobookOptions
-func (_e *MockAudiobookService_Expecter) DeleteAudiobook(ctx interface{}, id interface{}, opts interface{}) *MockAudiobookService_DeleteAudiobook_Call {
+func (_e *MockAudiobookService_Expecter) DeleteAudiobook(ctx any, id any, opts any) *MockAudiobookService_DeleteAudiobook_Call {
 	return &MockAudiobookService_DeleteAudiobook_Call{Call: _e.mock.On("DeleteAudiobook", ctx, id, opts)}
 }
 
@@ -271,7 +271,7 @@ type MockAudiobookService_EnrichAudiobooksWithNames_Call struct {
 
 // EnrichAudiobooksWithNames is a helper method to define mock.On call
 //   - books []database.Book
-func (_e *MockAudiobookService_Expecter) EnrichAudiobooksWithNames(books interface{}) *MockAudiobookService_EnrichAudiobooksWithNames_Call {
+func (_e *MockAudiobookService_Expecter) EnrichAudiobooksWithNames(books any) *MockAudiobookService_EnrichAudiobooksWithNames_Call {
 	return &MockAudiobookService_EnrichAudiobooksWithNames_Call{Call: _e.mock.On("EnrichAudiobooksWithNames", books)}
 }
 
@@ -334,7 +334,7 @@ type MockAudiobookService_GetAudiobook_Call struct {
 // GetAudiobook is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockAudiobookService_Expecter) GetAudiobook(ctx interface{}, id interface{}) *MockAudiobookService_GetAudiobook_Call {
+func (_e *MockAudiobookService_Expecter) GetAudiobook(ctx any, id any) *MockAudiobookService_GetAudiobook_Call {
 	return &MockAudiobookService_GetAudiobook_Call{Call: _e.mock.On("GetAudiobook", ctx, id)}
 }
 
@@ -404,7 +404,7 @@ type MockAudiobookService_GetAudiobookTags_Call struct {
 //   - id string
 //   - compareID string
 //   - snapshotTS string
-func (_e *MockAudiobookService_Expecter) GetAudiobookTags(ctx interface{}, id interface{}, compareID interface{}, snapshotTS interface{}) *MockAudiobookService_GetAudiobookTags_Call {
+func (_e *MockAudiobookService_Expecter) GetAudiobookTags(ctx any, id any, compareID any, snapshotTS any) *MockAudiobookService_GetAudiobookTags_Call {
 	return &MockAudiobookService_GetAudiobookTags_Call{Call: _e.mock.On("GetAudiobookTags", ctx, id, compareID, snapshotTS)}
 }
 
@@ -481,7 +481,7 @@ type MockAudiobookService_GetBookUserTags_Call struct {
 
 // GetBookUserTags is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobookService_Expecter) GetBookUserTags(bookID interface{}) *MockAudiobookService_GetBookUserTags_Call {
+func (_e *MockAudiobookService_Expecter) GetBookUserTags(bookID any) *MockAudiobookService_GetBookUserTags_Call {
 	return &MockAudiobookService_GetBookUserTags_Call{Call: _e.mock.On("GetBookUserTags", bookID)}
 }
 
@@ -546,7 +546,7 @@ type MockAudiobookService_GetSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThanDays *int
-func (_e *MockAudiobookService_Expecter) GetSoftDeletedBooks(ctx interface{}, limit interface{}, offset interface{}, olderThanDays interface{}) *MockAudiobookService_GetSoftDeletedBooks_Call {
+func (_e *MockAudiobookService_Expecter) GetSoftDeletedBooks(ctx any, limit any, offset any, olderThanDays any) *MockAudiobookService_GetSoftDeletedBooks_Call {
 	return &MockAudiobookService_GetSoftDeletedBooks_Call{Call: _e.mock.On("GetSoftDeletedBooks", ctx, limit, offset, olderThanDays)}
 }
 
@@ -713,7 +713,7 @@ type MockAudiobookService_PurgeSoftDeletedBooks_Call struct {
 //   - ctx context.Context
 //   - deleteFiles bool
 //   - olderThanDays *int
-func (_e *MockAudiobookService_Expecter) PurgeSoftDeletedBooks(ctx interface{}, deleteFiles interface{}, olderThanDays interface{}) *MockAudiobookService_PurgeSoftDeletedBooks_Call {
+func (_e *MockAudiobookService_Expecter) PurgeSoftDeletedBooks(ctx any, deleteFiles any, olderThanDays any) *MockAudiobookService_PurgeSoftDeletedBooks_Call {
 	return &MockAudiobookService_PurgeSoftDeletedBooks_Call{Call: _e.mock.On("PurgeSoftDeletedBooks", ctx, deleteFiles, olderThanDays)}
 }
 
@@ -786,7 +786,7 @@ type MockAudiobookService_RestoreAudiobook_Call struct {
 // RestoreAudiobook is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-func (_e *MockAudiobookService_Expecter) RestoreAudiobook(ctx interface{}, id interface{}) *MockAudiobookService_RestoreAudiobook_Call {
+func (_e *MockAudiobookService_Expecter) RestoreAudiobook(ctx any, id any) *MockAudiobookService_RestoreAudiobook_Call {
 	return &MockAudiobookService_RestoreAudiobook_Call{Call: _e.mock.On("RestoreAudiobook", ctx, id)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_audiobook_updater.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_audiobook_updater.go
@@ -75,7 +75,7 @@ type MockAudiobookUpdater_UpdateAudiobook_Call struct {
 //   - ctx context.Context
 //   - id string
 //   - payload map[string]any
-func (_e *MockAudiobookUpdater_Expecter) UpdateAudiobook(ctx interface{}, id interface{}, payload interface{}) *MockAudiobookUpdater_UpdateAudiobook_Call {
+func (_e *MockAudiobookUpdater_Expecter) UpdateAudiobook(ctx any, id any, payload any) *MockAudiobookUpdater_UpdateAudiobook_Call {
 	return &MockAudiobookUpdater_UpdateAudiobook_Call{Call: _e.mock.On("UpdateAudiobook", ctx, id, payload)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_audiobooks_store.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_audiobooks_store.go
@@ -65,7 +65,7 @@ type MockAudiobooksStore_AddBookAlternativeTitle_Call struct {
 //   - title string
 //   - source string
 //   - language string
-func (_e *MockAudiobooksStore_Expecter) AddBookAlternativeTitle(bookID interface{}, title interface{}, source interface{}, language interface{}) *MockAudiobooksStore_AddBookAlternativeTitle_Call {
+func (_e *MockAudiobooksStore_Expecter) AddBookAlternativeTitle(bookID any, title any, source any, language any) *MockAudiobooksStore_AddBookAlternativeTitle_Call {
 	return &MockAudiobooksStore_AddBookAlternativeTitle_Call{Call: _e.mock.On("AddBookAlternativeTitle", bookID, title, source, language)}
 }
 
@@ -142,7 +142,7 @@ type MockAudiobooksStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockAudiobooksStore_Expecter) GetAuthorByID(id interface{}) *MockAudiobooksStore_GetAuthorByID_Call {
+func (_e *MockAudiobooksStore_Expecter) GetAuthorByID(id any) *MockAudiobooksStore_GetAuthorByID_Call {
 	return &MockAudiobooksStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -204,7 +204,7 @@ type MockAudiobooksStore_GetBookAlternativeTitles_Call struct {
 
 // GetBookAlternativeTitles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookAlternativeTitles(bookID interface{}) *MockAudiobooksStore_GetBookAlternativeTitles_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookAlternativeTitles(bookID any) *MockAudiobooksStore_GetBookAlternativeTitles_Call {
 	return &MockAudiobooksStore_GetBookAlternativeTitles_Call{Call: _e.mock.On("GetBookAlternativeTitles", bookID)}
 }
 
@@ -266,7 +266,7 @@ type MockAudiobooksStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookAuthors(bookID interface{}) *MockAudiobooksStore_GetBookAuthors_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookAuthors(bookID any) *MockAudiobooksStore_GetBookAuthors_Call {
 	return &MockAudiobooksStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -328,7 +328,7 @@ type MockAudiobooksStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockAudiobooksStore_Expecter) GetBookByID(id interface{}) *MockAudiobooksStore_GetBookByID_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookByID(id any) *MockAudiobooksStore_GetBookByID_Call {
 	return &MockAudiobooksStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -391,7 +391,7 @@ type MockAudiobooksStore_GetBookChangeHistory_Call struct {
 // GetBookChangeHistory is a helper method to define mock.On call
 //   - bookID string
 //   - limit int
-func (_e *MockAudiobooksStore_Expecter) GetBookChangeHistory(bookID interface{}, limit interface{}) *MockAudiobooksStore_GetBookChangeHistory_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookChangeHistory(bookID any, limit any) *MockAudiobooksStore_GetBookChangeHistory_Call {
 	return &MockAudiobooksStore_GetBookChangeHistory_Call{Call: _e.mock.On("GetBookChangeHistory", bookID, limit)}
 }
 
@@ -458,7 +458,7 @@ type MockAudiobooksStore_GetBookChanges_Call struct {
 
 // GetBookChanges is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookChanges(bookID interface{}) *MockAudiobooksStore_GetBookChanges_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookChanges(bookID any) *MockAudiobooksStore_GetBookChanges_Call {
 	return &MockAudiobooksStore_GetBookChanges_Call{Call: _e.mock.On("GetBookChanges", bookID)}
 }
 
@@ -521,7 +521,7 @@ type MockAudiobooksStore_GetBookFileByID_Call struct {
 // GetBookFileByID is a helper method to define mock.On call
 //   - bookID string
 //   - fileID string
-func (_e *MockAudiobooksStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockAudiobooksStore_GetBookFileByID_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookFileByID(bookID any, fileID any) *MockAudiobooksStore_GetBookFileByID_Call {
 	return &MockAudiobooksStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
 }
 
@@ -588,7 +588,7 @@ type MockAudiobooksStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookFiles(bookID interface{}) *MockAudiobooksStore_GetBookFiles_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookFiles(bookID any) *MockAudiobooksStore_GetBookFiles_Call {
 	return &MockAudiobooksStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -650,7 +650,7 @@ type MockAudiobooksStore_GetBookNarrators_Call struct {
 
 // GetBookNarrators is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookNarrators(bookID interface{}) *MockAudiobooksStore_GetBookNarrators_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookNarrators(bookID any) *MockAudiobooksStore_GetBookNarrators_Call {
 	return &MockAudiobooksStore_GetBookNarrators_Call{Call: _e.mock.On("GetBookNarrators", bookID)}
 }
 
@@ -712,7 +712,7 @@ type MockAudiobooksStore_GetBookPathHistory_Call struct {
 
 // GetBookPathHistory is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookPathHistory(bookID interface{}) *MockAudiobooksStore_GetBookPathHistory_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookPathHistory(bookID any) *MockAudiobooksStore_GetBookPathHistory_Call {
 	return &MockAudiobooksStore_GetBookPathHistory_Call{Call: _e.mock.On("GetBookPathHistory", bookID)}
 }
 
@@ -774,7 +774,7 @@ type MockAudiobooksStore_GetBookTagsDetailed_Call struct {
 
 // GetBookTagsDetailed is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockAudiobooksStore_Expecter) GetBookTagsDetailed(bookID interface{}) *MockAudiobooksStore_GetBookTagsDetailed_Call {
+func (_e *MockAudiobooksStore_Expecter) GetBookTagsDetailed(bookID any) *MockAudiobooksStore_GetBookTagsDetailed_Call {
 	return &MockAudiobooksStore_GetBookTagsDetailed_Call{Call: _e.mock.On("GetBookTagsDetailed", bookID)}
 }
 
@@ -948,7 +948,7 @@ type MockAudiobooksStore_GetMetadataChangeHistory_Call struct {
 //   - bookID string
 //   - field string
 //   - limit int
-func (_e *MockAudiobooksStore_Expecter) GetMetadataChangeHistory(bookID interface{}, field interface{}, limit interface{}) *MockAudiobooksStore_GetMetadataChangeHistory_Call {
+func (_e *MockAudiobooksStore_Expecter) GetMetadataChangeHistory(bookID any, field any, limit any) *MockAudiobooksStore_GetMetadataChangeHistory_Call {
 	return &MockAudiobooksStore_GetMetadataChangeHistory_Call{Call: _e.mock.On("GetMetadataChangeHistory", bookID, field, limit)}
 }
 
@@ -1020,7 +1020,7 @@ type MockAudiobooksStore_GetNarratorByID_Call struct {
 
 // GetNarratorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockAudiobooksStore_Expecter) GetNarratorByID(id interface{}) *MockAudiobooksStore_GetNarratorByID_Call {
+func (_e *MockAudiobooksStore_Expecter) GetNarratorByID(id any) *MockAudiobooksStore_GetNarratorByID_Call {
 	return &MockAudiobooksStore_GetNarratorByID_Call{Call: _e.mock.On("GetNarratorByID", id)}
 }
 
@@ -1071,7 +1071,7 @@ type MockAudiobooksStore_RecordMetadataChange_Call struct {
 
 // RecordMetadataChange is a helper method to define mock.On call
 //   - record *database.MetadataChangeRecord
-func (_e *MockAudiobooksStore_Expecter) RecordMetadataChange(record interface{}) *MockAudiobooksStore_RecordMetadataChange_Call {
+func (_e *MockAudiobooksStore_Expecter) RecordMetadataChange(record any) *MockAudiobooksStore_RecordMetadataChange_Call {
 	return &MockAudiobooksStore_RecordMetadataChange_Call{Call: _e.mock.On("RecordMetadataChange", record)}
 }
 
@@ -1123,7 +1123,7 @@ type MockAudiobooksStore_RemoveBookAlternativeTitle_Call struct {
 // RemoveBookAlternativeTitle is a helper method to define mock.On call
 //   - bookID string
 //   - title string
-func (_e *MockAudiobooksStore_Expecter) RemoveBookAlternativeTitle(bookID interface{}, title interface{}) *MockAudiobooksStore_RemoveBookAlternativeTitle_Call {
+func (_e *MockAudiobooksStore_Expecter) RemoveBookAlternativeTitle(bookID any, title any) *MockAudiobooksStore_RemoveBookAlternativeTitle_Call {
 	return &MockAudiobooksStore_RemoveBookAlternativeTitle_Call{Call: _e.mock.On("RemoveBookAlternativeTitle", bookID, title)}
 }
 
@@ -1180,7 +1180,7 @@ type MockAudiobooksStore_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - bookID string
 //   - t time.Time
-func (_e *MockAudiobooksStore_Expecter) SetLastWrittenAt(bookID interface{}, t interface{}) *MockAudiobooksStore_SetLastWrittenAt_Call {
+func (_e *MockAudiobooksStore_Expecter) SetLastWrittenAt(bookID any, t any) *MockAudiobooksStore_SetLastWrittenAt_Call {
 	return &MockAudiobooksStore_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", bookID, t)}
 }
 
@@ -1248,7 +1248,7 @@ type MockAudiobooksStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockAudiobooksStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockAudiobooksStore_UpdateBook_Call {
+func (_e *MockAudiobooksStore_Expecter) UpdateBook(id any, book any) *MockAudiobooksStore_UpdateBook_Call {
 	return &MockAudiobooksStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -1305,7 +1305,7 @@ type MockAudiobooksStore_UpdateBookFile_Call struct {
 // UpdateBookFile is a helper method to define mock.On call
 //   - id string
 //   - file *database.BookFile
-func (_e *MockAudiobooksStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockAudiobooksStore_UpdateBookFile_Call {
+func (_e *MockAudiobooksStore_Expecter) UpdateBookFile(id any, file any) *MockAudiobooksStore_UpdateBookFile_Call {
 	return &MockAudiobooksStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
 }
 
@@ -1361,7 +1361,7 @@ type MockAudiobooksStore_UpsertBookFile_Call struct {
 
 // UpsertBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockAudiobooksStore_Expecter) UpsertBookFile(file interface{}) *MockAudiobooksStore_UpsertBookFile_Call {
+func (_e *MockAudiobooksStore_Expecter) UpsertBookFile(file any) *MockAudiobooksStore_UpsertBookFile_Call {
 	return &MockAudiobooksStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_batch_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_batch_service.go
@@ -62,7 +62,7 @@ type MockBatchService_ExecuteOperations_Call struct {
 
 // ExecuteOperations is a helper method to define mock.On call
 //   - req *batch.BatchOperationsRequest
-func (_e *MockBatchService_Expecter) ExecuteOperations(req interface{}) *MockBatchService_ExecuteOperations_Call {
+func (_e *MockBatchService_Expecter) ExecuteOperations(req any) *MockBatchService_ExecuteOperations_Call {
 	return &MockBatchService_ExecuteOperations_Call{Call: _e.mock.On("ExecuteOperations", req)}
 }
 
@@ -115,7 +115,7 @@ type MockBatchService_UpdateAudiobooks_Call struct {
 
 // UpdateAudiobooks is a helper method to define mock.On call
 //   - req *batch.BatchUpdateRequest
-func (_e *MockBatchService_Expecter) UpdateAudiobooks(req interface{}) *MockBatchService_UpdateAudiobooks_Call {
+func (_e *MockBatchService_Expecter) UpdateAudiobooks(req any) *MockBatchService_UpdateAudiobooks_Call {
 	return &MockBatchService_UpdateAudiobooks_Call{Call: _e.mock.On("UpdateAudiobooks", req)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_changelog_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_changelog_service.go
@@ -71,7 +71,7 @@ type MockChangelogService_GetBookChangelog_Call struct {
 
 // GetBookChangelog is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockChangelogService_Expecter) GetBookChangelog(bookID interface{}) *MockChangelogService_GetBookChangelog_Call {
+func (_e *MockChangelogService_Expecter) GetBookChangelog(bookID any) *MockChangelogService_GetBookChangelog_Call {
 	return &MockChangelogService_GetBookChangelog_Call{Call: _e.mock.On("GetBookChangelog", bookID)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_external_id_store.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_external_id_store.go
@@ -71,7 +71,7 @@ type MockExternalIDStore_GetExternalIDsForBook_Call struct {
 
 // GetExternalIDsForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockExternalIDStore_Expecter) GetExternalIDsForBook(bookID interface{}) *MockExternalIDStore_GetExternalIDsForBook_Call {
+func (_e *MockExternalIDStore_Expecter) GetExternalIDsForBook(bookID any) *MockExternalIDStore_GetExternalIDsForBook_Call {
 	return &MockExternalIDStore_GetExternalIDsForBook_Call{Call: _e.mock.On("GetExternalIDsForBook", bookID)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_metadata_fetch_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_metadata_fetch_service.go
@@ -59,7 +59,7 @@ type MockMetadataFetchService_InvalidateCachedCandidates_Call struct {
 
 // InvalidateCachedCandidates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataFetchService_Expecter) InvalidateCachedCandidates(bookID interface{}) *MockMetadataFetchService_InvalidateCachedCandidates_Call {
+func (_e *MockMetadataFetchService_Expecter) InvalidateCachedCandidates(bookID any) *MockMetadataFetchService_InvalidateCachedCandidates_Call {
 	return &MockMetadataFetchService_InvalidateCachedCandidates_Call{Call: _e.mock.On("InvalidateCachedCandidates", bookID)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_metadata_state_service.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_metadata_state_service.go
@@ -60,7 +60,7 @@ type MockMetadataStateService_ClearOverride_Call struct {
 // ClearOverride is a helper method to define mock.On call
 //   - bookID string
 //   - field string
-func (_e *MockMetadataStateService_Expecter) ClearOverride(bookID interface{}, field interface{}) *MockMetadataStateService_ClearOverride_Call {
+func (_e *MockMetadataStateService_Expecter) ClearOverride(bookID any, field any) *MockMetadataStateService_ClearOverride_Call {
 	return &MockMetadataStateService_ClearOverride_Call{Call: _e.mock.On("ClearOverride", bookID, field)}
 }
 
@@ -119,7 +119,7 @@ type MockMetadataStateService_SetOverride_Call struct {
 //   - field string
 //   - value any
 //   - locked bool
-func (_e *MockMetadataStateService_Expecter) SetOverride(bookID interface{}, field interface{}, value interface{}, locked interface{}) *MockMetadataStateService_SetOverride_Call {
+func (_e *MockMetadataStateService_Expecter) SetOverride(bookID any, field any, value any, locked any) *MockMetadataStateService_SetOverride_Call {
 	return &MockMetadataStateService_SetOverride_Call{Call: _e.mock.On("SetOverride", bookID, field, value, locked)}
 }
 

--- a/internal/server/handlers/audiobooks/mocks/mock_write_back_enqueuer.go
+++ b/internal/server/handlers/audiobooks/mocks/mock_write_back_enqueuer.go
@@ -48,7 +48,7 @@ type MockWriteBackEnqueuer_Enqueue_Call struct {
 
 // Enqueue is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID interface{}) *MockWriteBackEnqueuer_Enqueue_Call {
+func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID any) *MockWriteBackEnqueuer_Enqueue_Call {
 	return &MockWriteBackEnqueuer_Enqueue_Call{Call: _e.mock.On("Enqueue", bookID)}
 }
 

--- a/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
@@ -62,7 +62,7 @@ type MockDedupEngine_CleanupCandidatesAfterMerge_Call struct {
 
 // CleanupCandidatesAfterMerge is a helper method to define mock.On call
 //   - mergedAwayBookIDs []string
-func (_e *MockDedupEngine_Expecter) CleanupCandidatesAfterMerge(mergedAwayBookIDs interface{}) *MockDedupEngine_CleanupCandidatesAfterMerge_Call {
+func (_e *MockDedupEngine_Expecter) CleanupCandidatesAfterMerge(mergedAwayBookIDs any) *MockDedupEngine_CleanupCandidatesAfterMerge_Call {
 	return &MockDedupEngine_CleanupCandidatesAfterMerge_Call{Call: _e.mock.On("CleanupCandidatesAfterMerge", mergedAwayBookIDs)}
 }
 
@@ -123,7 +123,7 @@ type MockDedupEngine_Rescore_Call struct {
 // Rescore is a helper method to define mock.On call
 //   - ctx context.Context
 //   - apply bool
-func (_e *MockDedupEngine_Expecter) Rescore(ctx interface{}, apply interface{}) *MockDedupEngine_Rescore_Call {
+func (_e *MockDedupEngine_Expecter) Rescore(ctx any, apply any) *MockDedupEngine_Rescore_Call {
 	return &MockDedupEngine_Rescore_Call{Call: _e.mock.On("Rescore", ctx, apply)}
 }
 

--- a/internal/server/handlers/dedup/mocks/mock_dedup_store.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_store.go
@@ -71,7 +71,7 @@ type MockDedupStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockDedupStore_Expecter) GetAuthorByID(id interface{}) *MockDedupStore_GetAuthorByID_Call {
+func (_e *MockDedupStore_Expecter) GetAuthorByID(id any) *MockDedupStore_GetAuthorByID_Call {
 	return &MockDedupStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -133,7 +133,7 @@ type MockDedupStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockDedupStore_Expecter) GetBookByID(id interface{}) *MockDedupStore_GetBookByID_Call {
+func (_e *MockDedupStore_Expecter) GetBookByID(id any) *MockDedupStore_GetBookByID_Call {
 	return &MockDedupStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -195,7 +195,7 @@ type MockDedupStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockDedupStore_Expecter) GetBookFiles(bookID interface{}) *MockDedupStore_GetBookFiles_Call {
+func (_e *MockDedupStore_Expecter) GetBookFiles(bookID any) *MockDedupStore_GetBookFiles_Call {
 	return &MockDedupStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -257,7 +257,7 @@ type MockDedupStore_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockDedupStore_Expecter) GetSeriesByID(id interface{}) *MockDedupStore_GetSeriesByID_Call {
+func (_e *MockDedupStore_Expecter) GetSeriesByID(id any) *MockDedupStore_GetSeriesByID_Call {
 	return &MockDedupStore_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 

--- a/internal/server/handlers/dedup/mocks/mock_embedding_store.go
+++ b/internal/server/handlers/dedup/mocks/mock_embedding_store.go
@@ -71,7 +71,7 @@ type MockEmbeddingStore_GetCandidateByID_Call struct {
 
 // GetCandidateByID is a helper method to define mock.On call
 //   - id int64
-func (_e *MockEmbeddingStore_Expecter) GetCandidateByID(id interface{}) *MockEmbeddingStore_GetCandidateByID_Call {
+func (_e *MockEmbeddingStore_Expecter) GetCandidateByID(id any) *MockEmbeddingStore_GetCandidateByID_Call {
 	return &MockEmbeddingStore_GetCandidateByID_Call{Call: _e.mock.On("GetCandidateByID", id)}
 }
 
@@ -194,7 +194,7 @@ type MockEmbeddingStore_ListCandidates_Call struct {
 
 // ListCandidates is a helper method to define mock.On call
 //   - f database.CandidateFilter
-func (_e *MockEmbeddingStore_Expecter) ListCandidates(f interface{}) *MockEmbeddingStore_ListCandidates_Call {
+func (_e *MockEmbeddingStore_Expecter) ListCandidates(f any) *MockEmbeddingStore_ListCandidates_Call {
 	return &MockEmbeddingStore_ListCandidates_Call{Call: _e.mock.On("ListCandidates", f)}
 }
 
@@ -246,7 +246,7 @@ type MockEmbeddingStore_UpdateCandidateStatus_Call struct {
 // UpdateCandidateStatus is a helper method to define mock.On call
 //   - id int64
 //   - status string
-func (_e *MockEmbeddingStore_Expecter) UpdateCandidateStatus(id interface{}, status interface{}) *MockEmbeddingStore_UpdateCandidateStatus_Call {
+func (_e *MockEmbeddingStore_Expecter) UpdateCandidateStatus(id any, status any) *MockEmbeddingStore_UpdateCandidateStatus_Call {
 	return &MockEmbeddingStore_UpdateCandidateStatus_Call{Call: _e.mock.On("UpdateCandidateStatus", id, status)}
 }
 

--- a/internal/server/handlers/dedup/mocks/mock_merge_service.go
+++ b/internal/server/handlers/dedup/mocks/mock_merge_service.go
@@ -72,7 +72,7 @@ type MockMergeService_MergeBooks_Call struct {
 // MergeBooks is a helper method to define mock.On call
 //   - bookIDs []string
 //   - primaryID string
-func (_e *MockMergeService_Expecter) MergeBooks(bookIDs interface{}, primaryID interface{}) *MockMergeService_MergeBooks_Call {
+func (_e *MockMergeService_Expecter) MergeBooks(bookIDs any, primaryID any) *MockMergeService_MergeBooks_Call {
 	return &MockMergeService_MergeBooks_Call{Call: _e.mock.On("MergeBooks", bookIDs, primaryID)}
 }
 

--- a/internal/server/handlers/dedup/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/dedup/mocks/mock_operations_registry.go
@@ -80,9 +80,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {

--- a/internal/server/handlers/duplicates/mocks/mock_audiobook_service.go
+++ b/internal/server/handlers/duplicates/mocks/mock_audiobook_service.go
@@ -73,7 +73,7 @@ type MockAudiobookService_GetDuplicateBooks_Call struct {
 
 // GetDuplicateBooks is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockAudiobookService_Expecter) GetDuplicateBooks(ctx interface{}) *MockAudiobookService_GetDuplicateBooks_Call {
+func (_e *MockAudiobookService_Expecter) GetDuplicateBooks(ctx any) *MockAudiobookService_GetDuplicateBooks_Call {
 	return &MockAudiobookService_GetDuplicateBooks_Call{Call: _e.mock.On("GetDuplicateBooks", ctx)}
 }
 

--- a/internal/server/handlers/duplicates/mocks/mock_duplicates_store.go
+++ b/internal/server/handlers/duplicates/mocks/mock_duplicates_store.go
@@ -73,7 +73,7 @@ type MockDuplicatesStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockDuplicatesStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockDuplicatesStore_CreateOperation_Call {
+func (_e *MockDuplicatesStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockDuplicatesStore_CreateOperation_Call {
 	return &MockDuplicatesStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -145,7 +145,7 @@ type MockDuplicatesStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockDuplicatesStore_Expecter) GetBookByID(id interface{}) *MockDuplicatesStore_GetBookByID_Call {
+func (_e *MockDuplicatesStore_Expecter) GetBookByID(id any) *MockDuplicatesStore_GetBookByID_Call {
 	return &MockDuplicatesStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -207,7 +207,7 @@ type MockDuplicatesStore_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockDuplicatesStore_Expecter) GetSeriesByID(id interface{}) *MockDuplicatesStore_GetSeriesByID_Call {
+func (_e *MockDuplicatesStore_Expecter) GetSeriesByID(id any) *MockDuplicatesStore_GetSeriesByID_Call {
 	return &MockDuplicatesStore_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 

--- a/internal/server/handlers/duplicates/mocks/mock_merge_service.go
+++ b/internal/server/handlers/duplicates/mocks/mock_merge_service.go
@@ -91,7 +91,11 @@ func (_c *MockMergeService_CombineBooks_Call) Run(run func(bookIDs []string, pri
 		if args[2] != nil {
 			arg2 = args[2].(*merge.CombineOverride)
 		}
-		run(arg0, arg1, arg2)
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
 	})
 	return _c
 }

--- a/internal/server/handlers/duplicates/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/duplicates/mocks/mock_operations_registry.go
@@ -80,9 +80,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {

--- a/internal/server/handlers/entities/mocks/mock_entities_store.go
+++ b/internal/server/handlers/entities/mocks/mock_entities_store.go
@@ -177,7 +177,7 @@ type MockEntitiesStore_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockEntitiesStore_Expecter) CreateAuthor(name interface{}) *MockEntitiesStore_CreateAuthor_Call {
+func (_e *MockEntitiesStore_Expecter) CreateAuthor(name any) *MockEntitiesStore_CreateAuthor_Call {
 	return &MockEntitiesStore_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -241,7 +241,7 @@ type MockEntitiesStore_CreateAuthorAlias_Call struct {
 //   - authorID int
 //   - aliasName string
 //   - aliasType string
-func (_e *MockEntitiesStore_Expecter) CreateAuthorAlias(authorID interface{}, aliasName interface{}, aliasType interface{}) *MockEntitiesStore_CreateAuthorAlias_Call {
+func (_e *MockEntitiesStore_Expecter) CreateAuthorAlias(authorID any, aliasName any, aliasType any) *MockEntitiesStore_CreateAuthorAlias_Call {
 	return &MockEntitiesStore_CreateAuthorAlias_Call{Call: _e.mock.On("CreateAuthorAlias", authorID, aliasName, aliasType)}
 }
 
@@ -313,7 +313,7 @@ type MockEntitiesStore_CreateNarrator_Call struct {
 
 // CreateNarrator is a helper method to define mock.On call
 //   - name string
-func (_e *MockEntitiesStore_Expecter) CreateNarrator(name interface{}) *MockEntitiesStore_CreateNarrator_Call {
+func (_e *MockEntitiesStore_Expecter) CreateNarrator(name any) *MockEntitiesStore_CreateNarrator_Call {
 	return &MockEntitiesStore_CreateNarrator_Call{Call: _e.mock.On("CreateNarrator", name)}
 }
 
@@ -377,7 +377,7 @@ type MockEntitiesStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockEntitiesStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockEntitiesStore_CreateOperation_Call {
+func (_e *MockEntitiesStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockEntitiesStore_CreateOperation_Call {
 	return &MockEntitiesStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -450,7 +450,7 @@ type MockEntitiesStore_CreateSeries_Call struct {
 // CreateSeries is a helper method to define mock.On call
 //   - name string
 //   - authorID *int
-func (_e *MockEntitiesStore_Expecter) CreateSeries(name interface{}, authorID interface{}) *MockEntitiesStore_CreateSeries_Call {
+func (_e *MockEntitiesStore_Expecter) CreateSeries(name any, authorID any) *MockEntitiesStore_CreateSeries_Call {
 	return &MockEntitiesStore_CreateSeries_Call{Call: _e.mock.On("CreateSeries", name, authorID)}
 }
 
@@ -506,7 +506,7 @@ type MockEntitiesStore_DeleteAuthor_Call struct {
 
 // DeleteAuthor is a helper method to define mock.On call
 //   - id int
-func (_e *MockEntitiesStore_Expecter) DeleteAuthor(id interface{}) *MockEntitiesStore_DeleteAuthor_Call {
+func (_e *MockEntitiesStore_Expecter) DeleteAuthor(id any) *MockEntitiesStore_DeleteAuthor_Call {
 	return &MockEntitiesStore_DeleteAuthor_Call{Call: _e.mock.On("DeleteAuthor", id)}
 }
 
@@ -557,7 +557,7 @@ type MockEntitiesStore_DeleteAuthorAlias_Call struct {
 
 // DeleteAuthorAlias is a helper method to define mock.On call
 //   - id int
-func (_e *MockEntitiesStore_Expecter) DeleteAuthorAlias(id interface{}) *MockEntitiesStore_DeleteAuthorAlias_Call {
+func (_e *MockEntitiesStore_Expecter) DeleteAuthorAlias(id any) *MockEntitiesStore_DeleteAuthorAlias_Call {
 	return &MockEntitiesStore_DeleteAuthorAlias_Call{Call: _e.mock.On("DeleteAuthorAlias", id)}
 }
 
@@ -608,7 +608,7 @@ type MockEntitiesStore_DeleteSeries_Call struct {
 
 // DeleteSeries is a helper method to define mock.On call
 //   - id int
-func (_e *MockEntitiesStore_Expecter) DeleteSeries(id interface{}) *MockEntitiesStore_DeleteSeries_Call {
+func (_e *MockEntitiesStore_Expecter) DeleteSeries(id any) *MockEntitiesStore_DeleteSeries_Call {
 	return &MockEntitiesStore_DeleteSeries_Call{Call: _e.mock.On("DeleteSeries", id)}
 }
 
@@ -780,7 +780,7 @@ type MockEntitiesStore_GetAuthorAliases_Call struct {
 
 // GetAuthorAliases is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockEntitiesStore_Expecter) GetAuthorAliases(authorID interface{}) *MockEntitiesStore_GetAuthorAliases_Call {
+func (_e *MockEntitiesStore_Expecter) GetAuthorAliases(authorID any) *MockEntitiesStore_GetAuthorAliases_Call {
 	return &MockEntitiesStore_GetAuthorAliases_Call{Call: _e.mock.On("GetAuthorAliases", authorID)}
 }
 
@@ -842,7 +842,7 @@ type MockEntitiesStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockEntitiesStore_Expecter) GetAuthorByID(id interface{}) *MockEntitiesStore_GetAuthorByID_Call {
+func (_e *MockEntitiesStore_Expecter) GetAuthorByID(id any) *MockEntitiesStore_GetAuthorByID_Call {
 	return &MockEntitiesStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -904,7 +904,7 @@ type MockEntitiesStore_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockEntitiesStore_Expecter) GetAuthorByName(name interface{}) *MockEntitiesStore_GetAuthorByName_Call {
+func (_e *MockEntitiesStore_Expecter) GetAuthorByName(name any) *MockEntitiesStore_GetAuthorByName_Call {
 	return &MockEntitiesStore_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -966,7 +966,7 @@ type MockEntitiesStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockEntitiesStore_Expecter) GetBookAuthors(bookID interface{}) *MockEntitiesStore_GetBookAuthors_Call {
+func (_e *MockEntitiesStore_Expecter) GetBookAuthors(bookID any) *MockEntitiesStore_GetBookAuthors_Call {
 	return &MockEntitiesStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -1028,7 +1028,7 @@ type MockEntitiesStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockEntitiesStore_Expecter) GetBookByID(id interface{}) *MockEntitiesStore_GetBookByID_Call {
+func (_e *MockEntitiesStore_Expecter) GetBookByID(id any) *MockEntitiesStore_GetBookByID_Call {
 	return &MockEntitiesStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -1090,7 +1090,7 @@ type MockEntitiesStore_GetBookNarrators_Call struct {
 
 // GetBookNarrators is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockEntitiesStore_Expecter) GetBookNarrators(bookID interface{}) *MockEntitiesStore_GetBookNarrators_Call {
+func (_e *MockEntitiesStore_Expecter) GetBookNarrators(bookID any) *MockEntitiesStore_GetBookNarrators_Call {
 	return &MockEntitiesStore_GetBookNarrators_Call{Call: _e.mock.On("GetBookNarrators", bookID)}
 }
 
@@ -1152,7 +1152,7 @@ type MockEntitiesStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockEntitiesStore_GetBooksByAuthorID_Call {
+func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorID(authorID any) *MockEntitiesStore_GetBooksByAuthorID_Call {
 	return &MockEntitiesStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -1214,7 +1214,7 @@ type MockEntitiesStore_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockEntitiesStore_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockEntitiesStore_GetBooksByAuthorIDWithRole_Call {
 	return &MockEntitiesStore_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -1276,7 +1276,7 @@ type MockEntitiesStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockEntitiesStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockEntitiesStore_GetBooksBySeriesID_Call {
+func (_e *MockEntitiesStore_Expecter) GetBooksBySeriesID(seriesID any) *MockEntitiesStore_GetBooksBySeriesID_Call {
 	return &MockEntitiesStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -1338,7 +1338,7 @@ type MockEntitiesStore_GetBooksByWorkID_Call struct {
 
 // GetBooksByWorkID is a helper method to define mock.On call
 //   - workID string
-func (_e *MockEntitiesStore_Expecter) GetBooksByWorkID(workID interface{}) *MockEntitiesStore_GetBooksByWorkID_Call {
+func (_e *MockEntitiesStore_Expecter) GetBooksByWorkID(workID any) *MockEntitiesStore_GetBooksByWorkID_Call {
 	return &MockEntitiesStore_GetBooksByWorkID_Call{Call: _e.mock.On("GetBooksByWorkID", workID)}
 }
 
@@ -1400,7 +1400,7 @@ type MockEntitiesStore_GetNarratorByName_Call struct {
 
 // GetNarratorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockEntitiesStore_Expecter) GetNarratorByName(name interface{}) *MockEntitiesStore_GetNarratorByName_Call {
+func (_e *MockEntitiesStore_Expecter) GetNarratorByName(name any) *MockEntitiesStore_GetNarratorByName_Call {
 	return &MockEntitiesStore_GetNarratorByName_Call{Call: _e.mock.On("GetNarratorByName", name)}
 }
 
@@ -1462,7 +1462,7 @@ type MockEntitiesStore_GetSeriesByID_Call struct {
 
 // GetSeriesByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockEntitiesStore_Expecter) GetSeriesByID(id interface{}) *MockEntitiesStore_GetSeriesByID_Call {
+func (_e *MockEntitiesStore_Expecter) GetSeriesByID(id any) *MockEntitiesStore_GetSeriesByID_Call {
 	return &MockEntitiesStore_GetSeriesByID_Call{Call: _e.mock.On("GetSeriesByID", id)}
 }
 
@@ -1569,7 +1569,7 @@ type MockEntitiesStore_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockEntitiesStore_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockEntitiesStore_SetBookAuthors_Call {
+func (_e *MockEntitiesStore_Expecter) SetBookAuthors(bookID any, authors any) *MockEntitiesStore_SetBookAuthors_Call {
 	return &MockEntitiesStore_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -1626,7 +1626,7 @@ type MockEntitiesStore_SetBookNarrators_Call struct {
 // SetBookNarrators is a helper method to define mock.On call
 //   - bookID string
 //   - narrators []database.BookNarrator
-func (_e *MockEntitiesStore_Expecter) SetBookNarrators(bookID interface{}, narrators interface{}) *MockEntitiesStore_SetBookNarrators_Call {
+func (_e *MockEntitiesStore_Expecter) SetBookNarrators(bookID any, narrators any) *MockEntitiesStore_SetBookNarrators_Call {
 	return &MockEntitiesStore_SetBookNarrators_Call{Call: _e.mock.On("SetBookNarrators", bookID, narrators)}
 }
 
@@ -1683,7 +1683,7 @@ type MockEntitiesStore_UpdateAuthorName_Call struct {
 // UpdateAuthorName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockEntitiesStore_Expecter) UpdateAuthorName(id interface{}, name interface{}) *MockEntitiesStore_UpdateAuthorName_Call {
+func (_e *MockEntitiesStore_Expecter) UpdateAuthorName(id any, name any) *MockEntitiesStore_UpdateAuthorName_Call {
 	return &MockEntitiesStore_UpdateAuthorName_Call{Call: _e.mock.On("UpdateAuthorName", id, name)}
 }
 
@@ -1751,7 +1751,7 @@ type MockEntitiesStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockEntitiesStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockEntitiesStore_UpdateBook_Call {
+func (_e *MockEntitiesStore_Expecter) UpdateBook(id any, book any) *MockEntitiesStore_UpdateBook_Call {
 	return &MockEntitiesStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -1808,7 +1808,7 @@ type MockEntitiesStore_UpdateSeriesName_Call struct {
 // UpdateSeriesName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockEntitiesStore_Expecter) UpdateSeriesName(id interface{}, name interface{}) *MockEntitiesStore_UpdateSeriesName_Call {
+func (_e *MockEntitiesStore_Expecter) UpdateSeriesName(id any, name any) *MockEntitiesStore_UpdateSeriesName_Call {
 	return &MockEntitiesStore_UpdateSeriesName_Call{Call: _e.mock.On("UpdateSeriesName", id, name)}
 }
 

--- a/internal/server/handlers/entities/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/entities/mocks/mock_operations_registry.go
@@ -80,9 +80,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {

--- a/internal/server/handlers/entities/mocks/mock_work_service.go
+++ b/internal/server/handlers/entities/mocks/mock_work_service.go
@@ -72,7 +72,7 @@ type MockWorkService_CreateWork_Call struct {
 
 // CreateWork is a helper method to define mock.On call
 //   - w *database.Work
-func (_e *MockWorkService_Expecter) CreateWork(w interface{}) *MockWorkService_CreateWork_Call {
+func (_e *MockWorkService_Expecter) CreateWork(w any) *MockWorkService_CreateWork_Call {
 	return &MockWorkService_CreateWork_Call{Call: _e.mock.On("CreateWork", w)}
 }
 
@@ -123,7 +123,7 @@ type MockWorkService_DeleteWork_Call struct {
 
 // DeleteWork is a helper method to define mock.On call
 //   - id string
-func (_e *MockWorkService_Expecter) DeleteWork(id interface{}) *MockWorkService_DeleteWork_Call {
+func (_e *MockWorkService_Expecter) DeleteWork(id any) *MockWorkService_DeleteWork_Call {
 	return &MockWorkService_DeleteWork_Call{Call: _e.mock.On("DeleteWork", id)}
 }
 
@@ -185,7 +185,7 @@ type MockWorkService_GetWork_Call struct {
 
 // GetWork is a helper method to define mock.On call
 //   - id string
-func (_e *MockWorkService_Expecter) GetWork(id interface{}) *MockWorkService_GetWork_Call {
+func (_e *MockWorkService_Expecter) GetWork(id any) *MockWorkService_GetWork_Call {
 	return &MockWorkService_GetWork_Call{Call: _e.mock.On("GetWork", id)}
 }
 
@@ -303,7 +303,7 @@ type MockWorkService_UpdateWork_Call struct {
 // UpdateWork is a helper method to define mock.On call
 //   - id string
 //   - w *database.Work
-func (_e *MockWorkService_Expecter) UpdateWork(id interface{}, w interface{}) *MockWorkService_UpdateWork_Call {
+func (_e *MockWorkService_Expecter) UpdateWork(id any, w any) *MockWorkService_UpdateWork_Call {
 	return &MockWorkService_UpdateWork_Call{Call: _e.mock.On("UpdateWork", id, w)}
 }
 

--- a/internal/server/handlers/metadata/mocks/mock_file_io_pool.go
+++ b/internal/server/handlers/metadata/mocks/mock_file_io_pool.go
@@ -49,7 +49,7 @@ type MockFileIOPool_Submit_Call struct {
 // Submit is a helper method to define mock.On call
 //   - bookID string
 //   - fn func()
-func (_e *MockFileIOPool_Expecter) Submit(bookID interface{}, fn interface{}) *MockFileIOPool_Submit_Call {
+func (_e *MockFileIOPool_Expecter) Submit(bookID any, fn any) *MockFileIOPool_Submit_Call {
 	return &MockFileIOPool_Submit_Call{Call: _e.mock.On("Submit", bookID, fn)}
 }
 

--- a/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
@@ -77,7 +77,7 @@ type MockMetadataFetchService_ApplyMetadataCandidate_Call struct {
 //   - id string
 //   - candidate metafetch.MetadataCandidate
 //   - fields []string
-func (_e *MockMetadataFetchService_Expecter) ApplyMetadataCandidate(id interface{}, candidate interface{}, fields interface{}) *MockMetadataFetchService_ApplyMetadataCandidate_Call {
+func (_e *MockMetadataFetchService_Expecter) ApplyMetadataCandidate(id any, candidate any, fields any) *MockMetadataFetchService_ApplyMetadataCandidate_Call {
 	return &MockMetadataFetchService_ApplyMetadataCandidate_Call{Call: _e.mock.On("ApplyMetadataCandidate", id, candidate, fields)}
 }
 
@@ -127,7 +127,7 @@ type MockMetadataFetchService_ApplyMetadataFileIO_Call struct {
 
 // ApplyMetadataFileIO is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataFetchService_Expecter) ApplyMetadataFileIO(id interface{}) *MockMetadataFetchService_ApplyMetadataFileIO_Call {
+func (_e *MockMetadataFetchService_Expecter) ApplyMetadataFileIO(id any) *MockMetadataFetchService_ApplyMetadataFileIO_Call {
 	return &MockMetadataFetchService_ApplyMetadataFileIO_Call{Call: _e.mock.On("ApplyMetadataFileIO", id)}
 }
 
@@ -169,7 +169,7 @@ type MockMetadataFetchService_ApplyMetadataSystemTags_Call struct {
 //   - bookID string
 //   - sourceName string
 //   - language string
-func (_e *MockMetadataFetchService_Expecter) ApplyMetadataSystemTags(bookID interface{}, sourceName interface{}, language interface{}) *MockMetadataFetchService_ApplyMetadataSystemTags_Call {
+func (_e *MockMetadataFetchService_Expecter) ApplyMetadataSystemTags(bookID any, sourceName any, language any) *MockMetadataFetchService_ApplyMetadataSystemTags_Call {
 	return &MockMetadataFetchService_ApplyMetadataSystemTags_Call{Call: _e.mock.On("ApplyMetadataSystemTags", bookID, sourceName, language)}
 }
 
@@ -247,7 +247,7 @@ type MockMetadataFetchService_FetchAndCache_Call struct {
 //   - narrator string
 //   - series string
 //   - opts metafetch.SearchOptions
-func (_e *MockMetadataFetchService_Expecter) FetchAndCache(ctx interface{}, bookID interface{}, query interface{}, author interface{}, narrator interface{}, series interface{}, opts interface{}) *MockMetadataFetchService_FetchAndCache_Call {
+func (_e *MockMetadataFetchService_Expecter) FetchAndCache(ctx any, bookID any, query any, author any, narrator any, series any, opts any) *MockMetadataFetchService_FetchAndCache_Call {
 	return &MockMetadataFetchService_FetchAndCache_Call{Call: _e.mock.On("FetchAndCache", ctx, bookID, query, author, narrator, series, opts)}
 }
 
@@ -339,7 +339,7 @@ type MockMetadataFetchService_FetchMetadataForBook_Call struct {
 
 // FetchMetadataForBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataFetchService_Expecter) FetchMetadataForBook(id interface{}) *MockMetadataFetchService_FetchMetadataForBook_Call {
+func (_e *MockMetadataFetchService_Expecter) FetchMetadataForBook(id any) *MockMetadataFetchService_FetchMetadataForBook_Call {
 	return &MockMetadataFetchService_FetchMetadataForBook_Call{Call: _e.mock.On("FetchMetadataForBook", id)}
 }
 
@@ -407,7 +407,7 @@ type MockMetadataFetchService_GetCachedCandidates_Call struct {
 
 // GetCachedCandidates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataFetchService_Expecter) GetCachedCandidates(bookID interface{}) *MockMetadataFetchService_GetCachedCandidates_Call {
+func (_e *MockMetadataFetchService_Expecter) GetCachedCandidates(bookID any) *MockMetadataFetchService_GetCachedCandidates_Call {
 	return &MockMetadataFetchService_GetCachedCandidates_Call{Call: _e.mock.On("GetCachedCandidates", bookID)}
 }
 
@@ -458,7 +458,7 @@ type MockMetadataFetchService_InvalidateCachedCandidates_Call struct {
 
 // InvalidateCachedCandidates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataFetchService_Expecter) InvalidateCachedCandidates(bookID interface{}) *MockMetadataFetchService_InvalidateCachedCandidates_Call {
+func (_e *MockMetadataFetchService_Expecter) InvalidateCachedCandidates(bookID any) *MockMetadataFetchService_InvalidateCachedCandidates_Call {
 	return &MockMetadataFetchService_InvalidateCachedCandidates_Call{Call: _e.mock.On("InvalidateCachedCandidates", bookID)}
 }
 
@@ -509,7 +509,7 @@ type MockMetadataFetchService_MarkNoMatch_Call struct {
 
 // MarkNoMatch is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataFetchService_Expecter) MarkNoMatch(id interface{}) *MockMetadataFetchService_MarkNoMatch_Call {
+func (_e *MockMetadataFetchService_Expecter) MarkNoMatch(id any) *MockMetadataFetchService_MarkNoMatch_Call {
 	return &MockMetadataFetchService_MarkNoMatch_Call{Call: _e.mock.On("MarkNoMatch", id)}
 }
 
@@ -551,7 +551,7 @@ type MockMetadataFetchService_RecordChangeHistory_Call struct {
 //   - book *database.Book
 //   - meta metadata.BookMetadata
 //   - sourceName string
-func (_e *MockMetadataFetchService_Expecter) RecordChangeHistory(book interface{}, meta interface{}, sourceName interface{}) *MockMetadataFetchService_RecordChangeHistory_Call {
+func (_e *MockMetadataFetchService_Expecter) RecordChangeHistory(book any, meta any, sourceName any) *MockMetadataFetchService_RecordChangeHistory_Call {
 	return &MockMetadataFetchService_RecordChangeHistory_Call{Call: _e.mock.On("RecordChangeHistory", book, meta, sourceName)}
 }
 
@@ -613,7 +613,7 @@ type MockMetadataFetchService_RunApplyPipelineRenameOnly_Call struct {
 // RunApplyPipelineRenameOnly is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockMetadataFetchService_Expecter) RunApplyPipelineRenameOnly(id interface{}, book interface{}) *MockMetadataFetchService_RunApplyPipelineRenameOnly_Call {
+func (_e *MockMetadataFetchService_Expecter) RunApplyPipelineRenameOnly(id any, book any) *MockMetadataFetchService_RunApplyPipelineRenameOnly_Call {
 	return &MockMetadataFetchService_RunApplyPipelineRenameOnly_Call{Call: _e.mock.On("RunApplyPipelineRenameOnly", id, book)}
 }
 
@@ -685,7 +685,7 @@ type MockMetadataFetchService_SearchMetadataForBookWithOptions_Call struct {
 //   - narrator string
 //   - series string
 //   - opts metafetch.SearchOptions
-func (_e *MockMetadataFetchService_Expecter) SearchMetadataForBookWithOptions(id interface{}, query interface{}, author interface{}, narrator interface{}, series interface{}, opts interface{}) *MockMetadataFetchService_SearchMetadataForBookWithOptions_Call {
+func (_e *MockMetadataFetchService_Expecter) SearchMetadataForBookWithOptions(id any, query any, author any, narrator any, series any, opts any) *MockMetadataFetchService_SearchMetadataForBookWithOptions_Call {
 	return &MockMetadataFetchService_SearchMetadataForBookWithOptions_Call{Call: _e.mock.On("SearchMetadataForBookWithOptions", id, query, author, narrator, series, opts)}
 }
 
@@ -777,9 +777,9 @@ type MockMetadataFetchService_WriteBackMetadataForBook_Call struct {
 // WriteBackMetadataForBook is a helper method to define mock.On call
 //   - id string
 //   - segmentFilter ...[]string
-func (_e *MockMetadataFetchService_Expecter) WriteBackMetadataForBook(id interface{}, segmentFilter ...interface{}) *MockMetadataFetchService_WriteBackMetadataForBook_Call {
+func (_e *MockMetadataFetchService_Expecter) WriteBackMetadataForBook(id any, segmentFilter ...any) *MockMetadataFetchService_WriteBackMetadataForBook_Call {
 	return &MockMetadataFetchService_WriteBackMetadataForBook_Call{Call: _e.mock.On("WriteBackMetadataForBook",
-		append([]interface{}{id}, segmentFilter...)...)}
+		append([]any{id}, segmentFilter...)...)}
 }
 
 func (_c *MockMetadataFetchService_WriteBackMetadataForBook_Call) Run(run func(id string, segmentFilter ...[]string)) *MockMetadataFetchService_WriteBackMetadataForBook_Call {

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -62,7 +62,7 @@ type MockMetadataStore_AddMetadataRejection_Call struct {
 
 // AddMetadataRejection is a helper method to define mock.On call
 //   - r database.MetadataRejection
-func (_e *MockMetadataStore_Expecter) AddMetadataRejection(r interface{}) *MockMetadataStore_AddMetadataRejection_Call {
+func (_e *MockMetadataStore_Expecter) AddMetadataRejection(r any) *MockMetadataStore_AddMetadataRejection_Call {
 	return &MockMetadataStore_AddMetadataRejection_Call{Call: _e.mock.On("AddMetadataRejection", r)}
 }
 
@@ -168,29 +168,29 @@ func (_mock *MockMetadataStore) CountPrimaryBooks() (int, error) {
 	return r0, r1
 }
 
-// MockMetadataStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockMetadataStore_CountBooks_Call struct {
+// MockMetadataStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockMetadataStore_CountPrimaryBooks_Call struct {
 	*mock.Call
 }
 
 // CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockMetadataStore_Expecter) CountPrimaryBooks() *MockMetadataStore_CountBooks_Call {
-	return &MockMetadataStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+func (_e *MockMetadataStore_Expecter) CountPrimaryBooks() *MockMetadataStore_CountPrimaryBooks_Call {
+	return &MockMetadataStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
 }
 
-func (_c *MockMetadataStore_CountBooks_Call) Run(run func()) *MockMetadataStore_CountBooks_Call {
+func (_c *MockMetadataStore_CountPrimaryBooks_Call) Run(run func()) *MockMetadataStore_CountPrimaryBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockMetadataStore_CountBooks_Call) Return(n int, err error) *MockMetadataStore_CountBooks_Call {
+func (_c *MockMetadataStore_CountPrimaryBooks_Call) Return(n int, err error) *MockMetadataStore_CountPrimaryBooks_Call {
 	_c.Call.Return(n, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockMetadataStore_CountBooks_Call {
+func (_c *MockMetadataStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockMetadataStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -283,7 +283,7 @@ type MockMetadataStore_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockMetadataStore_Expecter) CreateAuthor(name interface{}) *MockMetadataStore_CreateAuthor_Call {
+func (_e *MockMetadataStore_Expecter) CreateAuthor(name any) *MockMetadataStore_CreateAuthor_Call {
 	return &MockMetadataStore_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -345,7 +345,7 @@ type MockMetadataStore_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockMetadataStore_Expecter) CreateBook(book interface{}) *MockMetadataStore_CreateBook_Call {
+func (_e *MockMetadataStore_Expecter) CreateBook(book any) *MockMetadataStore_CreateBook_Call {
 	return &MockMetadataStore_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -396,7 +396,7 @@ type MockMetadataStore_CreateBookTombstone_Call struct {
 
 // CreateBookTombstone is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockMetadataStore_Expecter) CreateBookTombstone(book interface{}) *MockMetadataStore_CreateBookTombstone_Call {
+func (_e *MockMetadataStore_Expecter) CreateBookTombstone(book any) *MockMetadataStore_CreateBookTombstone_Call {
 	return &MockMetadataStore_CreateBookTombstone_Call{Call: _e.mock.On("CreateBookTombstone", book)}
 }
 
@@ -460,7 +460,7 @@ type MockMetadataStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockMetadataStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockMetadataStore_CreateOperation_Call {
+func (_e *MockMetadataStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockMetadataStore_CreateOperation_Call {
 	return &MockMetadataStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -521,7 +521,7 @@ type MockMetadataStore_DeleteBook_Call struct {
 
 // DeleteBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataStore_Expecter) DeleteBook(id interface{}) *MockMetadataStore_DeleteBook_Call {
+func (_e *MockMetadataStore_Expecter) DeleteBook(id any) *MockMetadataStore_DeleteBook_Call {
 	return &MockMetadataStore_DeleteBook_Call{Call: _e.mock.On("DeleteBook", id)}
 }
 
@@ -572,7 +572,7 @@ type MockMetadataStore_DeleteBookTombstone_Call struct {
 
 // DeleteBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataStore_Expecter) DeleteBookTombstone(id interface{}) *MockMetadataStore_DeleteBookTombstone_Call {
+func (_e *MockMetadataStore_Expecter) DeleteBookTombstone(id any) *MockMetadataStore_DeleteBookTombstone_Call {
 	return &MockMetadataStore_DeleteBookTombstone_Call{Call: _e.mock.On("DeleteBookTombstone", id)}
 }
 
@@ -624,7 +624,7 @@ type MockMetadataStore_FlagMetadataHashDuplicate_Call struct {
 // FlagMetadataHashDuplicate is a helper method to define mock.On call
 //   - primaryID string
 //   - duplicateID string
-func (_e *MockMetadataStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockMetadataStore_FlagMetadataHashDuplicate_Call {
+func (_e *MockMetadataStore_Expecter) FlagMetadataHashDuplicate(primaryID any, duplicateID any) *MockMetadataStore_FlagMetadataHashDuplicate_Call {
 	return &MockMetadataStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
 }
 
@@ -692,7 +692,7 @@ type MockMetadataStore_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockMetadataStore_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockMetadataStore_GetAllBookSummaries_Call {
+func (_e *MockMetadataStore_Expecter) GetAllBookSummaries(limit any, offset any) *MockMetadataStore_GetAllBookSummaries_Call {
 	return &MockMetadataStore_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -760,7 +760,7 @@ type MockMetadataStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockMetadataStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockMetadataStore_GetAllBooks_Call {
+func (_e *MockMetadataStore_Expecter) GetAllBooks(limit any, offset any) *MockMetadataStore_GetAllBooks_Call {
 	return &MockMetadataStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -795,9 +795,11 @@ func (_c *MockMetadataStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 // GetAllBooksFrom provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
+
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllBooksFrom")
 	}
+
 	var r0 []database.Book
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
@@ -818,20 +820,42 @@ func (_mock *MockMetadataStore) GetAllBooksFrom(afterID string, limit int) ([]da
 	return r0, r1
 }
 
-type MockMetadataStore_GetAllBooksFrom_Call struct{ *mock.Call }
+// MockMetadataStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockMetadataStore_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
 
-func (_e *MockMetadataStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockMetadataStore_GetAllBooksFrom_Call {
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockMetadataStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockMetadataStore_GetAllBooksFrom_Call {
 	return &MockMetadataStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
-func (_c *MockMetadataStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockMetadataStore_GetAllBooksFrom_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
+
+func (_c *MockMetadataStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockMetadataStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
 	return _c
 }
+
 func (_c *MockMetadataStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockMetadataStore_GetAllBooksFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
-func (_c *MockMetadataStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockMetadataStore_GetAllBooksFrom_Call {
+
+func (_c *MockMetadataStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockMetadataStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -871,7 +895,7 @@ type MockMetadataStore_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockMetadataStore_Expecter) GetAuthorByName(name interface{}) *MockMetadataStore_GetAuthorByName_Call {
+func (_e *MockMetadataStore_Expecter) GetAuthorByName(name any) *MockMetadataStore_GetAuthorByName_Call {
 	return &MockMetadataStore_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -934,7 +958,7 @@ type MockMetadataStore_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockMetadataStore_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockMetadataStore_GetBookAtVersion_Call {
+func (_e *MockMetadataStore_Expecter) GetBookAtVersion(id any, ts any) *MockMetadataStore_GetBookAtVersion_Call {
 	return &MockMetadataStore_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -1001,7 +1025,7 @@ type MockMetadataStore_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockMetadataStore_Expecter) GetBookByFileHash(hash interface{}) *MockMetadataStore_GetBookByFileHash_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByFileHash(hash any) *MockMetadataStore_GetBookByFileHash_Call {
 	return &MockMetadataStore_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -1063,7 +1087,7 @@ type MockMetadataStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockMetadataStore_Expecter) GetBookByFilePath(path interface{}) *MockMetadataStore_GetBookByFilePath_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByFilePath(path any) *MockMetadataStore_GetBookByFilePath_Call {
 	return &MockMetadataStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -1125,7 +1149,7 @@ type MockMetadataStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataStore_Expecter) GetBookByID(id interface{}) *MockMetadataStore_GetBookByID_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByID(id any) *MockMetadataStore_GetBookByID_Call {
 	return &MockMetadataStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -1187,7 +1211,7 @@ type MockMetadataStore_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockMetadataStore_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockMetadataStore_GetBookByITunesPersistentID_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByITunesPersistentID(persistentID any) *MockMetadataStore_GetBookByITunesPersistentID_Call {
 	return &MockMetadataStore_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -1249,7 +1273,7 @@ type MockMetadataStore_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockMetadataStore_Expecter) GetBookByOrganizedHash(hash interface{}) *MockMetadataStore_GetBookByOrganizedHash_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByOrganizedHash(hash any) *MockMetadataStore_GetBookByOrganizedHash_Call {
 	return &MockMetadataStore_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -1311,7 +1335,7 @@ type MockMetadataStore_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockMetadataStore_Expecter) GetBookByOriginalHash(hash interface{}) *MockMetadataStore_GetBookByOriginalHash_Call {
+func (_e *MockMetadataStore_Expecter) GetBookByOriginalHash(hash any) *MockMetadataStore_GetBookByOriginalHash_Call {
 	return &MockMetadataStore_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -1375,7 +1399,7 @@ type MockMetadataStore_GetBookIDsByISBNASIN_Call struct {
 //   - isbn10 string
 //   - isbn13 string
 //   - asin string
-func (_e *MockMetadataStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
+func (_e *MockMetadataStore_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockMetadataStore_GetBookIDsByISBNASIN_Call {
 	return &MockMetadataStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
 }
 
@@ -1448,7 +1472,7 @@ type MockMetadataStore_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockMetadataStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockMetadataStore_GetBookSnapshots_Call {
+func (_e *MockMetadataStore_Expecter) GetBookSnapshots(id any, limit any) *MockMetadataStore_GetBookSnapshots_Call {
 	return &MockMetadataStore_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -1515,7 +1539,7 @@ type MockMetadataStore_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataStore_Expecter) GetBookTombstone(id interface{}) *MockMetadataStore_GetBookTombstone_Call {
+func (_e *MockMetadataStore_Expecter) GetBookTombstone(id any) *MockMetadataStore_GetBookTombstone_Call {
 	return &MockMetadataStore_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -1577,7 +1601,7 @@ type MockMetadataStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockMetadataStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockMetadataStore_GetBooksByAuthorID_Call {
+func (_e *MockMetadataStore_Expecter) GetBooksByAuthorID(authorID any) *MockMetadataStore_GetBooksByAuthorID_Call {
 	return &MockMetadataStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -1639,7 +1663,7 @@ type MockMetadataStore_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockMetadataStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockMetadataStore_GetBooksByMetadataSourceHash_Call {
+func (_e *MockMetadataStore_Expecter) GetBooksByMetadataSourceHash(hash any) *MockMetadataStore_GetBooksByMetadataSourceHash_Call {
 	return &MockMetadataStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -1701,7 +1725,7 @@ type MockMetadataStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockMetadataStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockMetadataStore_GetBooksBySeriesID_Call {
+func (_e *MockMetadataStore_Expecter) GetBooksBySeriesID(seriesID any) *MockMetadataStore_GetBooksBySeriesID_Call {
 	return &MockMetadataStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -1764,7 +1788,7 @@ type MockMetadataStore_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockMetadataStore_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockMetadataStore_GetBooksByTitleInDir_Call {
+func (_e *MockMetadataStore_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockMetadataStore_GetBooksByTitleInDir_Call {
 	return &MockMetadataStore_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -1831,7 +1855,7 @@ type MockMetadataStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockMetadataStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockMetadataStore_GetBooksByVersionGroup_Call {
+func (_e *MockMetadataStore_Expecter) GetBooksByVersionGroup(groupID any) *MockMetadataStore_GetBooksByVersionGroup_Call {
 	return &MockMetadataStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -2058,7 +2082,7 @@ type MockMetadataStore_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockMetadataStore_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
+func (_e *MockMetadataStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
 	return &MockMetadataStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -2285,7 +2309,7 @@ type MockMetadataStore_GetMetadataRejections_Call struct {
 
 // GetMetadataRejections is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataStore_Expecter) GetMetadataRejections(bookID interface{}) *MockMetadataStore_GetMetadataRejections_Call {
+func (_e *MockMetadataStore_Expecter) GetMetadataRejections(bookID any) *MockMetadataStore_GetMetadataRejections_Call {
 	return &MockMetadataStore_GetMetadataRejections_Call{Call: _e.mock.On("GetMetadataRejections", bookID)}
 }
 
@@ -2348,7 +2372,7 @@ type MockMetadataStore_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockMetadataStore_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockMetadataStore_GetQuarantinedBooks_Call {
+func (_e *MockMetadataStore_Expecter) GetQuarantinedBooks(limit any, offset any) *MockMetadataStore_GetQuarantinedBooks_Call {
 	return &MockMetadataStore_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -2413,7 +2437,7 @@ type MockMetadataStore_GetScanFailCount_Call struct {
 
 // GetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockMetadataStore_Expecter) GetScanFailCount(pathHash interface{}) *MockMetadataStore_GetScanFailCount_Call {
+func (_e *MockMetadataStore_Expecter) GetScanFailCount(pathHash any) *MockMetadataStore_GetScanFailCount_Call {
 	return &MockMetadataStore_GetScanFailCount_Call{Call: _e.mock.On("GetScanFailCount", pathHash)}
 }
 
@@ -2473,7 +2497,7 @@ type MockMetadataStore_IncrScanFailCount_Call struct {
 
 // IncrScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockMetadataStore_Expecter) IncrScanFailCount(pathHash interface{}) *MockMetadataStore_IncrScanFailCount_Call {
+func (_e *MockMetadataStore_Expecter) IncrScanFailCount(pathHash any) *MockMetadataStore_IncrScanFailCount_Call {
 	return &MockMetadataStore_IncrScanFailCount_Call{Call: _e.mock.On("IncrScanFailCount", pathHash)}
 }
 
@@ -2590,7 +2614,7 @@ type MockMetadataStore_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockMetadataStore_Expecter) ListBookTombstones(limit interface{}) *MockMetadataStore_ListBookTombstones_Call {
+func (_e *MockMetadataStore_Expecter) ListBookTombstones(limit any) *MockMetadataStore_ListBookTombstones_Call {
 	return &MockMetadataStore_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -2653,7 +2677,7 @@ type MockMetadataStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockMetadataStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockMetadataStore_ListBooksByITunesPID_Call {
+func (_e *MockMetadataStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockMetadataStore_ListBooksByITunesPID_Call {
 	return &MockMetadataStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -2722,7 +2746,7 @@ type MockMetadataStore_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockMetadataStore_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockMetadataStore_ListSoftDeletedBooks_Call {
+func (_e *MockMetadataStore_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockMetadataStore_ListSoftDeletedBooks_Call {
 	return &MockMetadataStore_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -2792,7 +2816,7 @@ type MockMetadataStore_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockMetadataStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockMetadataStore_MarkITunesSynced_Call {
+func (_e *MockMetadataStore_Expecter) MarkITunesSynced(bookIDs any) *MockMetadataStore_MarkITunesSynced_Call {
 	return &MockMetadataStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -2846,7 +2870,7 @@ type MockMetadataStore_MergeChapterBooks_Call struct {
 //   - srcIDs []string
 //   - commonTitle string
 //   - totalDuration float64
-func (_e *MockMetadataStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockMetadataStore_MergeChapterBooks_Call {
+func (_e *MockMetadataStore_Expecter) MergeChapterBooks(primaryID any, srcIDs any, commonTitle any, totalDuration any) *MockMetadataStore_MergeChapterBooks_Call {
 	return &MockMetadataStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
 }
 
@@ -2922,7 +2946,7 @@ type MockMetadataStore_PruneBookSnapshots_Call struct {
 // PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockMetadataStore_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockMetadataStore_PruneBookSnapshots_Call {
+func (_e *MockMetadataStore_Expecter) PruneBookSnapshots(id any, keepCount any) *MockMetadataStore_PruneBookSnapshots_Call {
 	return &MockMetadataStore_PruneBookSnapshots_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
@@ -2978,7 +3002,7 @@ type MockMetadataStore_RecomputeBookAggregates_Call struct {
 
 // RecomputeBookAggregates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockMetadataStore_RecomputeBookAggregates_Call {
+func (_e *MockMetadataStore_Expecter) RecomputeBookAggregates(bookID any) *MockMetadataStore_RecomputeBookAggregates_Call {
 	return &MockMetadataStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
 }
 
@@ -3029,7 +3053,7 @@ type MockMetadataStore_ResetScanFailCount_Call struct {
 
 // ResetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockMetadataStore_Expecter) ResetScanFailCount(pathHash interface{}) *MockMetadataStore_ResetScanFailCount_Call {
+func (_e *MockMetadataStore_Expecter) ResetScanFailCount(pathHash any) *MockMetadataStore_ResetScanFailCount_Call {
 	return &MockMetadataStore_ResetScanFailCount_Call{Call: _e.mock.On("ResetScanFailCount", pathHash)}
 }
 
@@ -3092,7 +3116,7 @@ type MockMetadataStore_RevertBookToVersion_Call struct {
 // RevertBookToVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockMetadataStore_Expecter) RevertBookToVersion(id interface{}, ts interface{}) *MockMetadataStore_RevertBookToVersion_Call {
+func (_e *MockMetadataStore_Expecter) RevertBookToVersion(id any, ts any) *MockMetadataStore_RevertBookToVersion_Call {
 	return &MockMetadataStore_RevertBookToVersion_Call{Call: _e.mock.On("RevertBookToVersion", id, ts)}
 }
 
@@ -3161,7 +3185,7 @@ type MockMetadataStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockMetadataStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockMetadataStore_SearchBooks_Call {
+func (_e *MockMetadataStore_Expecter) SearchBooks(query any, limit any, offset any) *MockMetadataStore_SearchBooks_Call {
 	return &MockMetadataStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -3223,7 +3247,7 @@ type MockMetadataStore_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - id string
 //   - t time.Time
-func (_e *MockMetadataStore_Expecter) SetLastWrittenAt(id interface{}, t interface{}) *MockMetadataStore_SetLastWrittenAt_Call {
+func (_e *MockMetadataStore_Expecter) SetLastWrittenAt(id any, t any) *MockMetadataStore_SetLastWrittenAt_Call {
 	return &MockMetadataStore_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", id, t)}
 }
 
@@ -3291,7 +3315,7 @@ type MockMetadataStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockMetadataStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockMetadataStore_UpdateBook_Call {
+func (_e *MockMetadataStore_Expecter) UpdateBook(id any, book any) *MockMetadataStore_UpdateBook_Call {
 	return &MockMetadataStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -3348,7 +3372,7 @@ type MockMetadataStore_UpdateBookRating_Call struct {
 // UpdateBookRating is a helper method to define mock.On call
 //   - id string
 //   - req database.UpdateBookRatingRequest
-func (_e *MockMetadataStore_Expecter) UpdateBookRating(id interface{}, req interface{}) *MockMetadataStore_UpdateBookRating_Call {
+func (_e *MockMetadataStore_Expecter) UpdateBookRating(id any, req any) *MockMetadataStore_UpdateBookRating_Call {
 	return &MockMetadataStore_UpdateBookRating_Call{Call: _e.mock.On("UpdateBookRating", id, req)}
 }
 

--- a/internal/server/handlers/metadata/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/metadata/mocks/mock_operations_registry.go
@@ -80,9 +80,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {

--- a/internal/server/handlers/metadata/mocks/mock_write_back_enqueuer.go
+++ b/internal/server/handlers/metadata/mocks/mock_write_back_enqueuer.go
@@ -48,7 +48,7 @@ type MockWriteBackEnqueuer_Enqueue_Call struct {
 
 // Enqueue is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID interface{}) *MockWriteBackEnqueuer_Enqueue_Call {
+func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID any) *MockWriteBackEnqueuer_Enqueue_Call {
 	return &MockWriteBackEnqueuer_Enqueue_Call{Call: _e.mock.On("Enqueue", bookID)}
 }
 

--- a/internal/server/handlers/mocks/mock_activity_ops_store.go
+++ b/internal/server/handlers/mocks/mock_activity_ops_store.go
@@ -72,7 +72,7 @@ type MockActivityOpsStore_GetOpLogsV2_Call struct {
 // GetOpLogsV2 is a helper method to define mock.On call
 //   - opID string
 //   - limit int
-func (_e *MockActivityOpsStore_Expecter) GetOpLogsV2(opID interface{}, limit interface{}) *MockActivityOpsStore_GetOpLogsV2_Call {
+func (_e *MockActivityOpsStore_Expecter) GetOpLogsV2(opID any, limit any) *MockActivityOpsStore_GetOpLogsV2_Call {
 	return &MockActivityOpsStore_GetOpLogsV2_Call{Call: _e.mock.On("GetOpLogsV2", opID, limit)}
 }
 

--- a/internal/server/handlers/mocks/mock_activity_service.go
+++ b/internal/server/handlers/mocks/mock_activity_service.go
@@ -73,7 +73,7 @@ type MockActivityService_CompactByDay_Call struct {
 // CompactByDay is a helper method to define mock.On call
 //   - ctx context.Context
 //   - cutoff time.Time
-func (_e *MockActivityService_Expecter) CompactByDay(ctx interface{}, cutoff interface{}) *MockActivityService_CompactByDay_Call {
+func (_e *MockActivityService_Expecter) CompactByDay(ctx any, cutoff any) *MockActivityService_CompactByDay_Call {
 	return &MockActivityService_CompactByDay_Call{Call: _e.mock.On("CompactByDay", ctx, cutoff)}
 }
 
@@ -140,7 +140,7 @@ type MockActivityService_GetDistinctSources_Call struct {
 
 // GetDistinctSources is a helper method to define mock.On call
 //   - filter database.ActivityFilter
-func (_e *MockActivityService_Expecter) GetDistinctSources(filter interface{}) *MockActivityService_GetDistinctSources_Call {
+func (_e *MockActivityService_Expecter) GetDistinctSources(filter any) *MockActivityService_GetDistinctSources_Call {
 	return &MockActivityService_GetDistinctSources_Call{Call: _e.mock.On("GetDistinctSources", filter)}
 }
 
@@ -208,7 +208,7 @@ type MockActivityService_Query_Call struct {
 
 // Query is a helper method to define mock.On call
 //   - filter database.ActivityFilter
-func (_e *MockActivityService_Expecter) Query(filter interface{}) *MockActivityService_Query_Call {
+func (_e *MockActivityService_Expecter) Query(filter any) *MockActivityService_Query_Call {
 	return &MockActivityService_Query_Call{Call: _e.mock.On("Query", filter)}
 }
 
@@ -268,7 +268,7 @@ type MockActivityService_RecompactDigests_Call struct {
 
 // RecompactDigests is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockActivityService_Expecter) RecompactDigests(ctx interface{}) *MockActivityService_RecompactDigests_Call {
+func (_e *MockActivityService_Expecter) RecompactDigests(ctx any) *MockActivityService_RecompactDigests_Call {
 	return &MockActivityService_RecompactDigests_Call{Call: _e.mock.On("RecompactDigests", ctx)}
 }
 

--- a/internal/server/handlers/mocks/mock_ai_pipeline.go
+++ b/internal/server/handlers/mocks/mock_ai_pipeline.go
@@ -62,7 +62,7 @@ type MockAIPipeline_CancelScan_Call struct {
 
 // CancelScan is a helper method to define mock.On call
 //   - scanID int
-func (_e *MockAIPipeline_Expecter) CancelScan(scanID interface{}) *MockAIPipeline_CancelScan_Call {
+func (_e *MockAIPipeline_Expecter) CancelScan(scanID any) *MockAIPipeline_CancelScan_Call {
 	return &MockAIPipeline_CancelScan_Call{Call: _e.mock.On("CancelScan", scanID)}
 }
 
@@ -125,7 +125,7 @@ type MockAIPipeline_StartScan_Call struct {
 // StartScan is a helper method to define mock.On call
 //   - ctx context.Context
 //   - mode string
-func (_e *MockAIPipeline_Expecter) StartScan(ctx interface{}, mode interface{}) *MockAIPipeline_StartScan_Call {
+func (_e *MockAIPipeline_Expecter) StartScan(ctx any, mode any) *MockAIPipeline_StartScan_Call {
 	return &MockAIPipeline_StartScan_Call{Call: _e.mock.On("StartScan", ctx, mode)}
 }
 

--- a/internal/server/handlers/mocks/mock_ai_scan_store.go
+++ b/internal/server/handlers/mocks/mock_ai_scan_store.go
@@ -60,7 +60,7 @@ type MockAIScanStore_DeleteScan_Call struct {
 
 // DeleteScan is a helper method to define mock.On call
 //   - id int
-func (_e *MockAIScanStore_Expecter) DeleteScan(id interface{}) *MockAIScanStore_DeleteScan_Call {
+func (_e *MockAIScanStore_Expecter) DeleteScan(id any) *MockAIScanStore_DeleteScan_Call {
 	return &MockAIScanStore_DeleteScan_Call{Call: _e.mock.On("DeleteScan", id)}
 }
 
@@ -122,7 +122,7 @@ type MockAIScanStore_GetPhases_Call struct {
 
 // GetPhases is a helper method to define mock.On call
 //   - scanID int
-func (_e *MockAIScanStore_Expecter) GetPhases(scanID interface{}) *MockAIScanStore_GetPhases_Call {
+func (_e *MockAIScanStore_Expecter) GetPhases(scanID any) *MockAIScanStore_GetPhases_Call {
 	return &MockAIScanStore_GetPhases_Call{Call: _e.mock.On("GetPhases", scanID)}
 }
 
@@ -184,7 +184,7 @@ type MockAIScanStore_GetScan_Call struct {
 
 // GetScan is a helper method to define mock.On call
 //   - id int
-func (_e *MockAIScanStore_Expecter) GetScan(id interface{}) *MockAIScanStore_GetScan_Call {
+func (_e *MockAIScanStore_Expecter) GetScan(id any) *MockAIScanStore_GetScan_Call {
 	return &MockAIScanStore_GetScan_Call{Call: _e.mock.On("GetScan", id)}
 }
 
@@ -246,7 +246,7 @@ type MockAIScanStore_GetScanResults_Call struct {
 
 // GetScanResults is a helper method to define mock.On call
 //   - scanID int
-func (_e *MockAIScanStore_Expecter) GetScanResults(scanID interface{}) *MockAIScanStore_GetScanResults_Call {
+func (_e *MockAIScanStore_Expecter) GetScanResults(scanID any) *MockAIScanStore_GetScanResults_Call {
 	return &MockAIScanStore_GetScanResults_Call{Call: _e.mock.On("GetScanResults", scanID)}
 }
 
@@ -353,7 +353,7 @@ type MockAIScanStore_MarkResultApplied_Call struct {
 // MarkResultApplied is a helper method to define mock.On call
 //   - scanID int
 //   - resultID int
-func (_e *MockAIScanStore_Expecter) MarkResultApplied(scanID interface{}, resultID interface{}) *MockAIScanStore_MarkResultApplied_Call {
+func (_e *MockAIScanStore_Expecter) MarkResultApplied(scanID any, resultID any) *MockAIScanStore_MarkResultApplied_Call {
 	return &MockAIScanStore_MarkResultApplied_Call{Call: _e.mock.On("MarkResultApplied", scanID, resultID)}
 }
 

--- a/internal/server/handlers/mocks/mock_api_key_handler_store.go
+++ b/internal/server/handlers/mocks/mock_api_key_handler_store.go
@@ -73,7 +73,7 @@ type MockAPIKeyHandlerStore_CreateAPIKey_Call struct {
 
 // CreateAPIKey is a helper method to define mock.On call
 //   - key *database.APIKey
-func (_e *MockAPIKeyHandlerStore_Expecter) CreateAPIKey(key interface{}) *MockAPIKeyHandlerStore_CreateAPIKey_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) CreateAPIKey(key any) *MockAPIKeyHandlerStore_CreateAPIKey_Call {
 	return &MockAPIKeyHandlerStore_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", key)}
 }
 
@@ -135,7 +135,7 @@ type MockAPIKeyHandlerStore_GetAPIKey_Call struct {
 
 // GetAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockAPIKeyHandlerStore_Expecter) GetAPIKey(id interface{}) *MockAPIKeyHandlerStore_GetAPIKey_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) GetAPIKey(id any) *MockAPIKeyHandlerStore_GetAPIKey_Call {
 	return &MockAPIKeyHandlerStore_GetAPIKey_Call{Call: _e.mock.On("GetAPIKey", id)}
 }
 
@@ -197,7 +197,7 @@ type MockAPIKeyHandlerStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockAPIKeyHandlerStore_Expecter) GetUserByID(id interface{}) *MockAPIKeyHandlerStore_GetUserByID_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) GetUserByID(id any) *MockAPIKeyHandlerStore_GetUserByID_Call {
 	return &MockAPIKeyHandlerStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -259,7 +259,7 @@ type MockAPIKeyHandlerStore_ListAPIKeysForUser_Call struct {
 
 // ListAPIKeysForUser is a helper method to define mock.On call
 //   - userID string
-func (_e *MockAPIKeyHandlerStore_Expecter) ListAPIKeysForUser(userID interface{}) *MockAPIKeyHandlerStore_ListAPIKeysForUser_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) ListAPIKeysForUser(userID any) *MockAPIKeyHandlerStore_ListAPIKeysForUser_Call {
 	return &MockAPIKeyHandlerStore_ListAPIKeysForUser_Call{Call: _e.mock.On("ListAPIKeysForUser", userID)}
 }
 
@@ -365,7 +365,7 @@ type MockAPIKeyHandlerStore_RevokeAPIKey_Call struct {
 
 // RevokeAPIKey is a helper method to define mock.On call
 //   - id string
-func (_e *MockAPIKeyHandlerStore_Expecter) RevokeAPIKey(id interface{}) *MockAPIKeyHandlerStore_RevokeAPIKey_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) RevokeAPIKey(id any) *MockAPIKeyHandlerStore_RevokeAPIKey_Call {
 	return &MockAPIKeyHandlerStore_RevokeAPIKey_Call{Call: _e.mock.On("RevokeAPIKey", id)}
 }
 
@@ -418,7 +418,7 @@ type MockAPIKeyHandlerStore_SetAPIKeyStatus_Call struct {
 //   - id string
 //   - status string
 //   - at time.Time
-func (_e *MockAPIKeyHandlerStore_Expecter) SetAPIKeyStatus(id interface{}, status interface{}, at interface{}) *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call {
+func (_e *MockAPIKeyHandlerStore_Expecter) SetAPIKeyStatus(id any, status any, at any) *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call {
 	return &MockAPIKeyHandlerStore_SetAPIKeyStatus_Call{Call: _e.mock.On("SetAPIKeyStatus", id, status, at)}
 }
 

--- a/internal/server/handlers/mocks/mock_audiobook_updater.go
+++ b/internal/server/handlers/mocks/mock_audiobook_updater.go
@@ -75,7 +75,7 @@ type MockAudiobookUpdater_UpdateAudiobook_Call struct {
 //   - ctx context.Context
 //   - id string
 //   - payload map[string]any
-func (_e *MockAudiobookUpdater_Expecter) UpdateAudiobook(ctx interface{}, id interface{}, payload interface{}) *MockAudiobookUpdater_UpdateAudiobook_Call {
+func (_e *MockAudiobookUpdater_Expecter) UpdateAudiobook(ctx any, id any, payload any) *MockAudiobookUpdater_UpdateAudiobook_Call {
 	return &MockAudiobookUpdater_UpdateAudiobook_Call{Call: _e.mock.On("UpdateAudiobook", ctx, id, payload)}
 }
 

--- a/internal/server/handlers/mocks/mock_auth_store.go
+++ b/internal/server/handlers/mocks/mock_auth_store.go
@@ -129,7 +129,7 @@ type MockAuthStore_CreateSession_Call struct {
 //   - ip string
 //   - userAgent string
 //   - ttl time.Duration
-func (_e *MockAuthStore_Expecter) CreateSession(userID interface{}, ip interface{}, userAgent interface{}, ttl interface{}) *MockAuthStore_CreateSession_Call {
+func (_e *MockAuthStore_Expecter) CreateSession(userID any, ip any, userAgent any, ttl any) *MockAuthStore_CreateSession_Call {
 	return &MockAuthStore_CreateSession_Call{Call: _e.mock.On("CreateSession", userID, ip, userAgent, ttl)}
 }
 
@@ -211,7 +211,7 @@ type MockAuthStore_CreateUser_Call struct {
 //   - passwordHash string
 //   - roles []string
 //   - status string
-func (_e *MockAuthStore_Expecter) CreateUser(username interface{}, email interface{}, passwordHashAlgo interface{}, passwordHash interface{}, roles interface{}, status interface{}) *MockAuthStore_CreateUser_Call {
+func (_e *MockAuthStore_Expecter) CreateUser(username any, email any, passwordHashAlgo any, passwordHash any, roles any, status any) *MockAuthStore_CreateUser_Call {
 	return &MockAuthStore_CreateUser_Call{Call: _e.mock.On("CreateUser", username, email, passwordHashAlgo, passwordHash, roles, status)}
 }
 
@@ -298,7 +298,7 @@ type MockAuthStore_GetRoleByID_Call struct {
 
 // GetRoleByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockAuthStore_Expecter) GetRoleByID(id interface{}) *MockAuthStore_GetRoleByID_Call {
+func (_e *MockAuthStore_Expecter) GetRoleByID(id any) *MockAuthStore_GetRoleByID_Call {
 	return &MockAuthStore_GetRoleByID_Call{Call: _e.mock.On("GetRoleByID", id)}
 }
 
@@ -360,7 +360,7 @@ type MockAuthStore_GetRoleByName_Call struct {
 
 // GetRoleByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockAuthStore_Expecter) GetRoleByName(name interface{}) *MockAuthStore_GetRoleByName_Call {
+func (_e *MockAuthStore_Expecter) GetRoleByName(name any) *MockAuthStore_GetRoleByName_Call {
 	return &MockAuthStore_GetRoleByName_Call{Call: _e.mock.On("GetRoleByName", name)}
 }
 
@@ -422,7 +422,7 @@ type MockAuthStore_GetSession_Call struct {
 
 // GetSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockAuthStore_Expecter) GetSession(id interface{}) *MockAuthStore_GetSession_Call {
+func (_e *MockAuthStore_Expecter) GetSession(id any) *MockAuthStore_GetSession_Call {
 	return &MockAuthStore_GetSession_Call{Call: _e.mock.On("GetSession", id)}
 }
 
@@ -484,7 +484,7 @@ type MockAuthStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockAuthStore_Expecter) GetUserByID(id interface{}) *MockAuthStore_GetUserByID_Call {
+func (_e *MockAuthStore_Expecter) GetUserByID(id any) *MockAuthStore_GetUserByID_Call {
 	return &MockAuthStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -546,7 +546,7 @@ type MockAuthStore_GetUserByUsername_Call struct {
 
 // GetUserByUsername is a helper method to define mock.On call
 //   - username string
-func (_e *MockAuthStore_Expecter) GetUserByUsername(username interface{}) *MockAuthStore_GetUserByUsername_Call {
+func (_e *MockAuthStore_Expecter) GetUserByUsername(username any) *MockAuthStore_GetUserByUsername_Call {
 	return &MockAuthStore_GetUserByUsername_Call{Call: _e.mock.On("GetUserByUsername", username)}
 }
 
@@ -608,7 +608,7 @@ type MockAuthStore_ListUserSessions_Call struct {
 
 // ListUserSessions is a helper method to define mock.On call
 //   - userID string
-func (_e *MockAuthStore_Expecter) ListUserSessions(userID interface{}) *MockAuthStore_ListUserSessions_Call {
+func (_e *MockAuthStore_Expecter) ListUserSessions(userID any) *MockAuthStore_ListUserSessions_Call {
 	return &MockAuthStore_ListUserSessions_Call{Call: _e.mock.On("ListUserSessions", userID)}
 }
 
@@ -659,7 +659,7 @@ type MockAuthStore_RevokeSession_Call struct {
 
 // RevokeSession is a helper method to define mock.On call
 //   - id string
-func (_e *MockAuthStore_Expecter) RevokeSession(id interface{}) *MockAuthStore_RevokeSession_Call {
+func (_e *MockAuthStore_Expecter) RevokeSession(id any) *MockAuthStore_RevokeSession_Call {
 	return &MockAuthStore_RevokeSession_Call{Call: _e.mock.On("RevokeSession", id)}
 }
 
@@ -710,7 +710,7 @@ type MockAuthStore_UpdateUser_Call struct {
 
 // UpdateUser is a helper method to define mock.On call
 //   - user *database.User
-func (_e *MockAuthStore_Expecter) UpdateUser(user interface{}) *MockAuthStore_UpdateUser_Call {
+func (_e *MockAuthStore_Expecter) UpdateUser(user any) *MockAuthStore_UpdateUser_Call {
 	return &MockAuthStore_UpdateUser_Call{Call: _e.mock.On("UpdateUser", user)}
 }
 

--- a/internal/server/handlers/mocks/mock_cache_metadata_store.go
+++ b/internal/server/handlers/mocks/mock_cache_metadata_store.go
@@ -68,7 +68,7 @@ type MockCacheMetadataStore_CountPrefix_Call struct {
 
 // CountPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockCacheMetadataStore_Expecter) CountPrefix(prefix interface{}) *MockCacheMetadataStore_CountPrefix_Call {
+func (_e *MockCacheMetadataStore_Expecter) CountPrefix(prefix any) *MockCacheMetadataStore_CountPrefix_Call {
 	return &MockCacheMetadataStore_CountPrefix_Call{Call: _e.mock.On("CountPrefix", prefix)}
 }
 

--- a/internal/server/handlers/mocks/mock_cache_metrics_store.go
+++ b/internal/server/handlers/mocks/mock_cache_metrics_store.go
@@ -75,7 +75,7 @@ type MockCacheMetricsStore_GetCacheStatsHistory_Call struct {
 //   - cacheName string
 //   - since time.Time
 //   - limit int
-func (_e *MockCacheMetricsStore_Expecter) GetCacheStatsHistory(cacheName interface{}, since interface{}, limit interface{}) *MockCacheMetricsStore_GetCacheStatsHistory_Call {
+func (_e *MockCacheMetricsStore_Expecter) GetCacheStatsHistory(cacheName any, since any, limit any) *MockCacheMetricsStore_GetCacheStatsHistory_Call {
 	return &MockCacheMetricsStore_GetCacheStatsHistory_Call{Call: _e.mock.On("GetCacheStatsHistory", cacheName, since, limit)}
 }
 

--- a/internal/server/handlers/mocks/mock_event_publisher.go
+++ b/internal/server/handlers/mocks/mock_event_publisher.go
@@ -52,7 +52,7 @@ type MockEventPublisher_Publish_Call struct {
 // Publish is a helper method to define mock.On call
 //   - ctx context.Context
 //   - event plugin.Event
-func (_e *MockEventPublisher_Expecter) Publish(ctx interface{}, event interface{}) *MockEventPublisher_Publish_Call {
+func (_e *MockEventPublisher_Expecter) Publish(ctx any, event any) *MockEventPublisher_Publish_Call {
 	return &MockEventPublisher_Publish_Call{Call: _e.mock.On("Publish", ctx, event)}
 }
 

--- a/internal/server/handlers/mocks/mock_file_importer.go
+++ b/internal/server/handlers/mocks/mock_file_importer.go
@@ -71,7 +71,7 @@ type MockFileImporter_ImportFile_Call struct {
 
 // ImportFile is a helper method to define mock.On call
 //   - req *importer.ImportFileRequest
-func (_e *MockFileImporter_Expecter) ImportFile(req interface{}) *MockFileImporter_ImportFile_Call {
+func (_e *MockFileImporter_Expecter) ImportFile(req any) *MockFileImporter_ImportFile_Call {
 	return &MockFileImporter_ImportFile_Call{Call: _e.mock.On("ImportFile", req)}
 }
 

--- a/internal/server/handlers/mocks/mock_filesystem_browser.go
+++ b/internal/server/handlers/mocks/mock_filesystem_browser.go
@@ -74,7 +74,7 @@ type MockFilesystemBrowser_BrowseDirectory_Call struct {
 // BrowseDirectory is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFilesystemBrowser_Expecter) BrowseDirectory(ctx interface{}, path interface{}) *MockFilesystemBrowser_BrowseDirectory_Call {
+func (_e *MockFilesystemBrowser_Expecter) BrowseDirectory(ctx any, path any) *MockFilesystemBrowser_BrowseDirectory_Call {
 	return &MockFilesystemBrowser_BrowseDirectory_Call{Call: _e.mock.On("BrowseDirectory", ctx, path)}
 }
 
@@ -131,7 +131,7 @@ type MockFilesystemBrowser_CreateExclusion_Call struct {
 // CreateExclusion is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFilesystemBrowser_Expecter) CreateExclusion(ctx interface{}, path interface{}) *MockFilesystemBrowser_CreateExclusion_Call {
+func (_e *MockFilesystemBrowser_Expecter) CreateExclusion(ctx any, path any) *MockFilesystemBrowser_CreateExclusion_Call {
 	return &MockFilesystemBrowser_CreateExclusion_Call{Call: _e.mock.On("CreateExclusion", ctx, path)}
 }
 
@@ -188,7 +188,7 @@ type MockFilesystemBrowser_RemoveExclusion_Call struct {
 // RemoveExclusion is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFilesystemBrowser_Expecter) RemoveExclusion(ctx interface{}, path interface{}) *MockFilesystemBrowser_RemoveExclusion_Call {
+func (_e *MockFilesystemBrowser_Expecter) RemoveExclusion(ctx any, path any) *MockFilesystemBrowser_RemoveExclusion_Call {
 	return &MockFilesystemBrowser_RemoveExclusion_Call{Call: _e.mock.On("RemoveExclusion", ctx, path)}
 }
 

--- a/internal/server/handlers/mocks/mock_filesystem_store.go
+++ b/internal/server/handlers/mocks/mock_filesystem_store.go
@@ -69,7 +69,7 @@ type MockFilesystemStore_CountBooksByPathPrefix_Call struct {
 
 // CountBooksByPathPrefix is a helper method to define mock.On call
 //   - prefix string
-func (_e *MockFilesystemStore_Expecter) CountBooksByPathPrefix(prefix interface{}) *MockFilesystemStore_CountBooksByPathPrefix_Call {
+func (_e *MockFilesystemStore_Expecter) CountBooksByPathPrefix(prefix any) *MockFilesystemStore_CountBooksByPathPrefix_Call {
 	return &MockFilesystemStore_CountBooksByPathPrefix_Call{Call: _e.mock.On("CountBooksByPathPrefix", prefix)}
 }
 
@@ -133,7 +133,7 @@ type MockFilesystemStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockFilesystemStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockFilesystemStore_CreateOperation_Call {
+func (_e *MockFilesystemStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockFilesystemStore_CreateOperation_Call {
 	return &MockFilesystemStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -194,7 +194,7 @@ type MockFilesystemStore_DeleteImportPath_Call struct {
 
 // DeleteImportPath is a helper method to define mock.On call
 //   - id int
-func (_e *MockFilesystemStore_Expecter) DeleteImportPath(id interface{}) *MockFilesystemStore_DeleteImportPath_Call {
+func (_e *MockFilesystemStore_Expecter) DeleteImportPath(id any) *MockFilesystemStore_DeleteImportPath_Call {
 	return &MockFilesystemStore_DeleteImportPath_Call{Call: _e.mock.On("DeleteImportPath", id)}
 }
 
@@ -311,7 +311,7 @@ type MockFilesystemStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockFilesystemStore_Expecter) GetBookByFilePath(path interface{}) *MockFilesystemStore_GetBookByFilePath_Call {
+func (_e *MockFilesystemStore_Expecter) GetBookByFilePath(path any) *MockFilesystemStore_GetBookByFilePath_Call {
 	return &MockFilesystemStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -429,7 +429,7 @@ type MockFilesystemStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockFilesystemStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockFilesystemStore_UpdateBook_Call {
+func (_e *MockFilesystemStore_Expecter) UpdateBook(id any, book any) *MockFilesystemStore_UpdateBook_Call {
 	return &MockFilesystemStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -486,7 +486,7 @@ type MockFilesystemStore_UpdateImportPath_Call struct {
 // UpdateImportPath is a helper method to define mock.On call
 //   - id int
 //   - path *database.ImportPath
-func (_e *MockFilesystemStore_Expecter) UpdateImportPath(id interface{}, path interface{}) *MockFilesystemStore_UpdateImportPath_Call {
+func (_e *MockFilesystemStore_Expecter) UpdateImportPath(id any, path any) *MockFilesystemStore_UpdateImportPath_Call {
 	return &MockFilesystemStore_UpdateImportPath_Call{Call: _e.mock.On("UpdateImportPath", id, path)}
 }
 

--- a/internal/server/handlers/mocks/mock_i_tunes_importer.go
+++ b/internal/server/handlers/mocks/mock_i_tunes_importer.go
@@ -164,7 +164,7 @@ type MockITunesImporter_GetStatus_Call struct {
 
 // GetStatus is a helper method to define mock.On call
 //   - opID string
-func (_e *MockITunesImporter_Expecter) GetStatus(opID interface{}) *MockITunesImporter_GetStatus_Call {
+func (_e *MockITunesImporter_Expecter) GetStatus(opID any) *MockITunesImporter_GetStatus_Call {
 	return &MockITunesImporter_GetStatus_Call{Call: _e.mock.On("GetStatus", opID)}
 }
 
@@ -217,7 +217,7 @@ type MockITunesImporter_GetStatusBulk_Call struct {
 
 // GetStatusBulk is a helper method to define mock.On call
 //   - ids []string
-func (_e *MockITunesImporter_Expecter) GetStatusBulk(ids interface{}) *MockITunesImporter_GetStatusBulk_Call {
+func (_e *MockITunesImporter_Expecter) GetStatusBulk(ids any) *MockITunesImporter_GetStatusBulk_Call {
 	return &MockITunesImporter_GetStatusBulk_Call{Call: _e.mock.On("GetStatusBulk", ids)}
 }
 

--- a/internal/server/handlers/mocks/mock_i_tunes_store.go
+++ b/internal/server/handlers/mocks/mock_i_tunes_store.go
@@ -73,7 +73,7 @@ type MockITunesStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockITunesStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockITunesStore_CreateOperation_Call {
+func (_e *MockITunesStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockITunesStore_CreateOperation_Call {
 	return &MockITunesStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -145,7 +145,7 @@ type MockITunesStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockITunesStore_Expecter) GetAuthorByID(id interface{}) *MockITunesStore_GetAuthorByID_Call {
+func (_e *MockITunesStore_Expecter) GetAuthorByID(id any) *MockITunesStore_GetAuthorByID_Call {
 	return &MockITunesStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -207,7 +207,7 @@ type MockITunesStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockITunesStore_Expecter) GetBookByID(id interface{}) *MockITunesStore_GetBookByID_Call {
+func (_e *MockITunesStore_Expecter) GetBookByID(id any) *MockITunesStore_GetBookByID_Call {
 	return &MockITunesStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -269,7 +269,7 @@ type MockITunesStore_GetLibraryFingerprint_Call struct {
 
 // GetLibraryFingerprint is a helper method to define mock.On call
 //   - path string
-func (_e *MockITunesStore_Expecter) GetLibraryFingerprint(path interface{}) *MockITunesStore_GetLibraryFingerprint_Call {
+func (_e *MockITunesStore_Expecter) GetLibraryFingerprint(path any) *MockITunesStore_GetLibraryFingerprint_Call {
 	return &MockITunesStore_GetLibraryFingerprint_Call{Call: _e.mock.On("GetLibraryFingerprint", path)}
 }
 
@@ -331,7 +331,7 @@ type MockITunesStore_GetOperationByID_Call struct {
 
 // GetOperationByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockITunesStore_Expecter) GetOperationByID(id interface{}) *MockITunesStore_GetOperationByID_Call {
+func (_e *MockITunesStore_Expecter) GetOperationByID(id any) *MockITunesStore_GetOperationByID_Call {
 	return &MockITunesStore_GetOperationByID_Call{Call: _e.mock.On("GetOperationByID", id)}
 }
 
@@ -394,7 +394,7 @@ type MockITunesStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockITunesStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockITunesStore_ListBooksByITunesPID_Call {
+func (_e *MockITunesStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockITunesStore_ListBooksByITunesPID_Call {
 	return &MockITunesStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -459,7 +459,7 @@ type MockITunesStore_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockITunesStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockITunesStore_MarkITunesSynced_Call {
+func (_e *MockITunesStore_Expecter) MarkITunesSynced(bookIDs any) *MockITunesStore_MarkITunesSynced_Call {
 	return &MockITunesStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -523,7 +523,7 @@ type MockITunesStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockITunesStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockITunesStore_SearchBooks_Call {
+func (_e *MockITunesStore_Expecter) SearchBooks(query any, limit any, offset any) *MockITunesStore_SearchBooks_Call {
 	return &MockITunesStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 

--- a/internal/server/handlers/mocks/mock_import_path_creator.go
+++ b/internal/server/handlers/mocks/mock_import_path_creator.go
@@ -72,7 +72,7 @@ type MockImportPathCreator_CreateImportPath_Call struct {
 // CreateImportPath is a helper method to define mock.On call
 //   - path string
 //   - name string
-func (_e *MockImportPathCreator_Expecter) CreateImportPath(path interface{}, name interface{}) *MockImportPathCreator_CreateImportPath_Call {
+func (_e *MockImportPathCreator_Expecter) CreateImportPath(path any, name any) *MockImportPathCreator_CreateImportPath_Call {
 	return &MockImportPathCreator_CreateImportPath_Call{Call: _e.mock.On("CreateImportPath", path, name)}
 }
 

--- a/internal/server/handlers/mocks/mock_merge_service.go
+++ b/internal/server/handlers/mocks/mock_merge_service.go
@@ -72,7 +72,7 @@ type MockMergeService_MergeBooks_Call struct {
 // MergeBooks is a helper method to define mock.On call
 //   - bookIDs []string
 //   - primaryID string
-func (_e *MockMergeService_Expecter) MergeBooks(bookIDs interface{}, primaryID interface{}) *MockMergeService_MergeBooks_Call {
+func (_e *MockMergeService_Expecter) MergeBooks(bookIDs any, primaryID any) *MockMergeService_MergeBooks_Call {
 	return &MockMergeService_MergeBooks_Call{Call: _e.mock.On("MergeBooks", bookIDs, primaryID)}
 }
 

--- a/internal/server/handlers/mocks/mock_metadata_cache_book_store.go
+++ b/internal/server/handlers/mocks/mock_metadata_cache_book_store.go
@@ -71,7 +71,7 @@ type MockMetadataCacheBookStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockMetadataCacheBookStore_Expecter) GetBookByID(id interface{}) *MockMetadataCacheBookStore_GetBookByID_Call {
+func (_e *MockMetadataCacheBookStore_Expecter) GetBookByID(id any) *MockMetadataCacheBookStore_GetBookByID_Call {
 	return &MockMetadataCacheBookStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -133,7 +133,7 @@ type MockMetadataCacheBookStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataCacheBookStore_Expecter) GetBookFiles(bookID interface{}) *MockMetadataCacheBookStore_GetBookFiles_Call {
+func (_e *MockMetadataCacheBookStore_Expecter) GetBookFiles(bookID any) *MockMetadataCacheBookStore_GetBookFiles_Call {
 	return &MockMetadataCacheBookStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -196,7 +196,7 @@ type MockMetadataCacheBookStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockMetadataCacheBookStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockMetadataCacheBookStore_UpdateBook_Call {
+func (_e *MockMetadataCacheBookStore_Expecter) UpdateBook(id any, book any) *MockMetadataCacheBookStore_UpdateBook_Call {
 	return &MockMetadataCacheBookStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 

--- a/internal/server/handlers/mocks/mock_metadata_cache_fetch_service.go
+++ b/internal/server/handlers/mocks/mock_metadata_cache_fetch_service.go
@@ -75,7 +75,7 @@ type MockMetadataCacheFetchService_ApplyMetadataCandidate_Call struct {
 //   - id string
 //   - candidate metafetch.MetadataCandidate
 //   - fields []string
-func (_e *MockMetadataCacheFetchService_Expecter) ApplyMetadataCandidate(id interface{}, candidate interface{}, fields interface{}) *MockMetadataCacheFetchService_ApplyMetadataCandidate_Call {
+func (_e *MockMetadataCacheFetchService_Expecter) ApplyMetadataCandidate(id any, candidate any, fields any) *MockMetadataCacheFetchService_ApplyMetadataCandidate_Call {
 	return &MockMetadataCacheFetchService_ApplyMetadataCandidate_Call{Call: _e.mock.On("ApplyMetadataCandidate", id, candidate, fields)}
 }
 
@@ -153,7 +153,7 @@ type MockMetadataCacheFetchService_GetCachedCandidates_Call struct {
 
 // GetCachedCandidates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataCacheFetchService_Expecter) GetCachedCandidates(bookID interface{}) *MockMetadataCacheFetchService_GetCachedCandidates_Call {
+func (_e *MockMetadataCacheFetchService_Expecter) GetCachedCandidates(bookID any) *MockMetadataCacheFetchService_GetCachedCandidates_Call {
 	return &MockMetadataCacheFetchService_GetCachedCandidates_Call{Call: _e.mock.On("GetCachedCandidates", bookID)}
 }
 
@@ -204,7 +204,7 @@ type MockMetadataCacheFetchService_InvalidateCachedCandidates_Call struct {
 
 // InvalidateCachedCandidates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockMetadataCacheFetchService_Expecter) InvalidateCachedCandidates(bookID interface{}) *MockMetadataCacheFetchService_InvalidateCachedCandidates_Call {
+func (_e *MockMetadataCacheFetchService_Expecter) InvalidateCachedCandidates(bookID any) *MockMetadataCacheFetchService_InvalidateCachedCandidates_Call {
 	return &MockMetadataCacheFetchService_InvalidateCachedCandidates_Call{Call: _e.mock.On("InvalidateCachedCandidates", bookID)}
 }
 
@@ -266,7 +266,7 @@ type MockMetadataCacheFetchService_ListCachedSummaries_Call struct {
 
 // ListCachedSummaries is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockMetadataCacheFetchService_Expecter) ListCachedSummaries(ctx interface{}) *MockMetadataCacheFetchService_ListCachedSummaries_Call {
+func (_e *MockMetadataCacheFetchService_Expecter) ListCachedSummaries(ctx any) *MockMetadataCacheFetchService_ListCachedSummaries_Call {
 	return &MockMetadataCacheFetchService_ListCachedSummaries_Call{Call: _e.mock.On("ListCachedSummaries", ctx)}
 }
 

--- a/internal/server/handlers/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/mocks/mock_operations_registry.go
@@ -108,7 +108,7 @@ type MockOperationsRegistry_Cancel_Call struct {
 
 // Cancel is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsRegistry_Expecter) Cancel(opID interface{}) *MockOperationsRegistry_Cancel_Call {
+func (_e *MockOperationsRegistry_Expecter) Cancel(opID any) *MockOperationsRegistry_Cancel_Call {
 	return &MockOperationsRegistry_Cancel_Call{Call: _e.mock.On("Cancel", opID)}
 }
 
@@ -177,9 +177,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {
@@ -246,7 +246,7 @@ type MockOperationsRegistry_GetCurrentItem_Call struct {
 
 // GetCurrentItem is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsRegistry_Expecter) GetCurrentItem(opID interface{}) *MockOperationsRegistry_GetCurrentItem_Call {
+func (_e *MockOperationsRegistry_Expecter) GetCurrentItem(opID any) *MockOperationsRegistry_GetCurrentItem_Call {
 	return &MockOperationsRegistry_GetCurrentItem_Call{Call: _e.mock.On("GetCurrentItem", opID)}
 }
 

--- a/internal/server/handlers/mocks/mock_organize_preview_servicer.go
+++ b/internal/server/handlers/mocks/mock_organize_preview_servicer.go
@@ -71,7 +71,7 @@ type MockOrganizePreviewServicer_PreviewOrganize_Call struct {
 
 // PreviewOrganize is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOrganizePreviewServicer_Expecter) PreviewOrganize(bookID interface{}) *MockOrganizePreviewServicer_PreviewOrganize_Call {
+func (_e *MockOrganizePreviewServicer_Expecter) PreviewOrganize(bookID any) *MockOrganizePreviewServicer_PreviewOrganize_Call {
 	return &MockOrganizePreviewServicer_PreviewOrganize_Call{Call: _e.mock.On("PreviewOrganize", bookID)}
 }
 

--- a/internal/server/handlers/mocks/mock_organize_servicer.go
+++ b/internal/server/handlers/mocks/mock_organize_servicer.go
@@ -78,7 +78,7 @@ type MockOrganizeServicer_CreateOrganizedVersion_Call struct {
 //   - isDir bool
 //   - operationID string
 //   - log logger.Logger
-func (_e *MockOrganizeServicer_Expecter) CreateOrganizedVersion(org interface{}, book interface{}, newPath interface{}, isDir interface{}, operationID interface{}, log interface{}) *MockOrganizeServicer_CreateOrganizedVersion_Call {
+func (_e *MockOrganizeServicer_Expecter) CreateOrganizedVersion(org any, book any, newPath any, isDir any, operationID any, log any) *MockOrganizeServicer_CreateOrganizedVersion_Call {
 	return &MockOrganizeServicer_CreateOrganizedVersion_Call{Call: _e.mock.On("CreateOrganizedVersion", org, book, newPath, isDir, operationID, log)}
 }
 
@@ -165,7 +165,7 @@ type MockOrganizeServicer_OrganizeDirectoryBook_Call struct {
 //   - org *organizer.Organizer
 //   - book *database.Book
 //   - log logger.Logger
-func (_e *MockOrganizeServicer_Expecter) OrganizeDirectoryBook(org interface{}, book interface{}, log interface{}) *MockOrganizeServicer_OrganizeDirectoryBook_Call {
+func (_e *MockOrganizeServicer_Expecter) OrganizeDirectoryBook(org any, book any, log any) *MockOrganizeServicer_OrganizeDirectoryBook_Call {
 	return &MockOrganizeServicer_OrganizeDirectoryBook_Call{Call: _e.mock.On("OrganizeDirectoryBook", org, book, log)}
 }
 
@@ -236,7 +236,7 @@ type MockOrganizeServicer_ReOrganizeInPlace_Call struct {
 // ReOrganizeInPlace is a helper method to define mock.On call
 //   - book *database.Book
 //   - log logger.Logger
-func (_e *MockOrganizeServicer_Expecter) ReOrganizeInPlace(book interface{}, log interface{}) *MockOrganizeServicer_ReOrganizeInPlace_Call {
+func (_e *MockOrganizeServicer_Expecter) ReOrganizeInPlace(book any, log any) *MockOrganizeServicer_ReOrganizeInPlace_Call {
 	return &MockOrganizeServicer_ReOrganizeInPlace_Call{Call: _e.mock.On("ReOrganizeInPlace", book, log)}
 }
 

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -63,7 +63,7 @@ type MockPlaylistStore_ClearUserPositions_Call struct {
 // ClearUserPositions is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockPlaylistStore_Expecter) ClearUserPositions(userID interface{}, bookID interface{}) *MockPlaylistStore_ClearUserPositions_Call {
+func (_e *MockPlaylistStore_Expecter) ClearUserPositions(userID any, bookID any) *MockPlaylistStore_ClearUserPositions_Call {
 	return &MockPlaylistStore_ClearUserPositions_Call{Call: _e.mock.On("ClearUserPositions", userID, bookID)}
 }
 
@@ -174,29 +174,29 @@ func (_mock *MockPlaylistStore) CountPrimaryBooks() (int, error) {
 	return r0, r1
 }
 
-// MockPlaylistStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockPlaylistStore_CountBooks_Call struct {
+// MockPlaylistStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockPlaylistStore_CountPrimaryBooks_Call struct {
 	*mock.Call
 }
 
 // CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockPlaylistStore_Expecter) CountPrimaryBooks() *MockPlaylistStore_CountBooks_Call {
-	return &MockPlaylistStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+func (_e *MockPlaylistStore_Expecter) CountPrimaryBooks() *MockPlaylistStore_CountPrimaryBooks_Call {
+	return &MockPlaylistStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
 }
 
-func (_c *MockPlaylistStore_CountBooks_Call) Run(run func()) *MockPlaylistStore_CountBooks_Call {
+func (_c *MockPlaylistStore_CountPrimaryBooks_Call) Run(run func()) *MockPlaylistStore_CountPrimaryBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockPlaylistStore_CountBooks_Call) Return(n int, err error) *MockPlaylistStore_CountBooks_Call {
+func (_c *MockPlaylistStore_CountPrimaryBooks_Call) Return(n int, err error) *MockPlaylistStore_CountPrimaryBooks_Call {
 	_c.Call.Return(n, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockPlaylistStore_CountBooks_Call {
+func (_c *MockPlaylistStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockPlaylistStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -289,7 +289,7 @@ type MockPlaylistStore_CreateUserPlaylist_Call struct {
 
 // CreateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockPlaylistStore_Expecter) CreateUserPlaylist(pl interface{}) *MockPlaylistStore_CreateUserPlaylist_Call {
+func (_e *MockPlaylistStore_Expecter) CreateUserPlaylist(pl any) *MockPlaylistStore_CreateUserPlaylist_Call {
 	return &MockPlaylistStore_CreateUserPlaylist_Call{Call: _e.mock.On("CreateUserPlaylist", pl)}
 }
 
@@ -340,7 +340,7 @@ type MockPlaylistStore_DeleteUserPlaylist_Call struct {
 
 // DeleteUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockPlaylistStore_Expecter) DeleteUserPlaylist(id interface{}) *MockPlaylistStore_DeleteUserPlaylist_Call {
+func (_e *MockPlaylistStore_Expecter) DeleteUserPlaylist(id any) *MockPlaylistStore_DeleteUserPlaylist_Call {
 	return &MockPlaylistStore_DeleteUserPlaylist_Call{Call: _e.mock.On("DeleteUserPlaylist", id)}
 }
 
@@ -403,7 +403,7 @@ type MockPlaylistStore_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockPlaylistStore_GetAllBookSummaries_Call {
+func (_e *MockPlaylistStore_Expecter) GetAllBookSummaries(limit any, offset any) *MockPlaylistStore_GetAllBookSummaries_Call {
 	return &MockPlaylistStore_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -471,7 +471,7 @@ type MockPlaylistStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockPlaylistStore_GetAllBooks_Call {
+func (_e *MockPlaylistStore_Expecter) GetAllBooks(limit any, offset any) *MockPlaylistStore_GetAllBooks_Call {
 	return &MockPlaylistStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -506,9 +506,11 @@ func (_c *MockPlaylistStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 // GetAllBooksFrom provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
+
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllBooksFrom")
 	}
+
 	var r0 []database.Book
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
@@ -529,20 +531,42 @@ func (_mock *MockPlaylistStore) GetAllBooksFrom(afterID string, limit int) ([]da
 	return r0, r1
 }
 
-type MockPlaylistStore_GetAllBooksFrom_Call struct{ *mock.Call }
+// MockPlaylistStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
+type MockPlaylistStore_GetAllBooksFrom_Call struct {
+	*mock.Call
+}
 
-func (_e *MockPlaylistStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockPlaylistStore_GetAllBooksFrom_Call {
+// GetAllBooksFrom is a helper method to define mock.On call
+//   - afterID string
+//   - limit int
+func (_e *MockPlaylistStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockPlaylistStore_GetAllBooksFrom_Call {
 	return &MockPlaylistStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
-func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockPlaylistStore_GetAllBooksFrom_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
+
+func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockPlaylistStore_GetAllBooksFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
 	return _c
 }
+
 func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetAllBooksFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
-func (_c *MockPlaylistStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockPlaylistStore_GetAllBooksFrom_Call {
+
+func (_c *MockPlaylistStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockPlaylistStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -583,7 +607,7 @@ type MockPlaylistStore_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockPlaylistStore_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockPlaylistStore_GetBookAtVersion_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookAtVersion(id any, ts any) *MockPlaylistStore_GetBookAtVersion_Call {
 	return &MockPlaylistStore_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -650,7 +674,7 @@ type MockPlaylistStore_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockPlaylistStore_Expecter) GetBookByFileHash(hash interface{}) *MockPlaylistStore_GetBookByFileHash_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByFileHash(hash any) *MockPlaylistStore_GetBookByFileHash_Call {
 	return &MockPlaylistStore_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -712,7 +736,7 @@ type MockPlaylistStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockPlaylistStore_Expecter) GetBookByFilePath(path interface{}) *MockPlaylistStore_GetBookByFilePath_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByFilePath(path any) *MockPlaylistStore_GetBookByFilePath_Call {
 	return &MockPlaylistStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -774,7 +798,7 @@ type MockPlaylistStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockPlaylistStore_Expecter) GetBookByID(id interface{}) *MockPlaylistStore_GetBookByID_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByID(id any) *MockPlaylistStore_GetBookByID_Call {
 	return &MockPlaylistStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -836,7 +860,7 @@ type MockPlaylistStore_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockPlaylistStore_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockPlaylistStore_GetBookByITunesPersistentID_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByITunesPersistentID(persistentID any) *MockPlaylistStore_GetBookByITunesPersistentID_Call {
 	return &MockPlaylistStore_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -898,7 +922,7 @@ type MockPlaylistStore_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockPlaylistStore_Expecter) GetBookByOrganizedHash(hash interface{}) *MockPlaylistStore_GetBookByOrganizedHash_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByOrganizedHash(hash any) *MockPlaylistStore_GetBookByOrganizedHash_Call {
 	return &MockPlaylistStore_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -960,7 +984,7 @@ type MockPlaylistStore_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockPlaylistStore_Expecter) GetBookByOriginalHash(hash interface{}) *MockPlaylistStore_GetBookByOriginalHash_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookByOriginalHash(hash any) *MockPlaylistStore_GetBookByOriginalHash_Call {
 	return &MockPlaylistStore_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -1024,7 +1048,7 @@ type MockPlaylistStore_GetBookIDsByISBNASIN_Call struct {
 //   - isbn10 string
 //   - isbn13 string
 //   - asin string
-func (_e *MockPlaylistStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockPlaylistStore_GetBookIDsByISBNASIN_Call {
 	return &MockPlaylistStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
 }
 
@@ -1097,7 +1121,7 @@ type MockPlaylistStore_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockPlaylistStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockPlaylistStore_GetBookSnapshots_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookSnapshots(id any, limit any) *MockPlaylistStore_GetBookSnapshots_Call {
 	return &MockPlaylistStore_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -1164,7 +1188,7 @@ type MockPlaylistStore_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockPlaylistStore_Expecter) GetBookTombstone(id interface{}) *MockPlaylistStore_GetBookTombstone_Call {
+func (_e *MockPlaylistStore_Expecter) GetBookTombstone(id any) *MockPlaylistStore_GetBookTombstone_Call {
 	return &MockPlaylistStore_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -1226,7 +1250,7 @@ type MockPlaylistStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockPlaylistStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockPlaylistStore_GetBooksByAuthorID_Call {
+func (_e *MockPlaylistStore_Expecter) GetBooksByAuthorID(authorID any) *MockPlaylistStore_GetBooksByAuthorID_Call {
 	return &MockPlaylistStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -1288,7 +1312,7 @@ type MockPlaylistStore_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockPlaylistStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockPlaylistStore_GetBooksByMetadataSourceHash_Call {
+func (_e *MockPlaylistStore_Expecter) GetBooksByMetadataSourceHash(hash any) *MockPlaylistStore_GetBooksByMetadataSourceHash_Call {
 	return &MockPlaylistStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -1350,7 +1374,7 @@ type MockPlaylistStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockPlaylistStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockPlaylistStore_GetBooksBySeriesID_Call {
+func (_e *MockPlaylistStore_Expecter) GetBooksBySeriesID(seriesID any) *MockPlaylistStore_GetBooksBySeriesID_Call {
 	return &MockPlaylistStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -1413,7 +1437,7 @@ type MockPlaylistStore_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockPlaylistStore_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockPlaylistStore_GetBooksByTitleInDir_Call {
+func (_e *MockPlaylistStore_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockPlaylistStore_GetBooksByTitleInDir_Call {
 	return &MockPlaylistStore_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -1480,7 +1504,7 @@ type MockPlaylistStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockPlaylistStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockPlaylistStore_GetBooksByVersionGroup_Call {
+func (_e *MockPlaylistStore_Expecter) GetBooksByVersionGroup(groupID any) *MockPlaylistStore_GetBooksByVersionGroup_Call {
 	return &MockPlaylistStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -1707,7 +1731,7 @@ type MockPlaylistStore_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockPlaylistStore_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
+func (_e *MockPlaylistStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
 	return &MockPlaylistStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -1935,7 +1959,7 @@ type MockPlaylistStore_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockPlaylistStore_GetQuarantinedBooks_Call {
+func (_e *MockPlaylistStore_Expecter) GetQuarantinedBooks(limit any, offset any) *MockPlaylistStore_GetQuarantinedBooks_Call {
 	return &MockPlaylistStore_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -2003,7 +2027,7 @@ type MockPlaylistStore_GetUserBookState_Call struct {
 // GetUserBookState is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockPlaylistStore_Expecter) GetUserBookState(userID interface{}, bookID interface{}) *MockPlaylistStore_GetUserBookState_Call {
+func (_e *MockPlaylistStore_Expecter) GetUserBookState(userID any, bookID any) *MockPlaylistStore_GetUserBookState_Call {
 	return &MockPlaylistStore_GetUserBookState_Call{Call: _e.mock.On("GetUserBookState", userID, bookID)}
 }
 
@@ -2070,7 +2094,7 @@ type MockPlaylistStore_GetUserPlaylist_Call struct {
 
 // GetUserPlaylist is a helper method to define mock.On call
 //   - id string
-func (_e *MockPlaylistStore_Expecter) GetUserPlaylist(id interface{}) *MockPlaylistStore_GetUserPlaylist_Call {
+func (_e *MockPlaylistStore_Expecter) GetUserPlaylist(id any) *MockPlaylistStore_GetUserPlaylist_Call {
 	return &MockPlaylistStore_GetUserPlaylist_Call{Call: _e.mock.On("GetUserPlaylist", id)}
 }
 
@@ -2132,7 +2156,7 @@ type MockPlaylistStore_GetUserPlaylistByITunesPID_Call struct {
 
 // GetUserPlaylistByITunesPID is a helper method to define mock.On call
 //   - pid string
-func (_e *MockPlaylistStore_Expecter) GetUserPlaylistByITunesPID(pid interface{}) *MockPlaylistStore_GetUserPlaylistByITunesPID_Call {
+func (_e *MockPlaylistStore_Expecter) GetUserPlaylistByITunesPID(pid any) *MockPlaylistStore_GetUserPlaylistByITunesPID_Call {
 	return &MockPlaylistStore_GetUserPlaylistByITunesPID_Call{Call: _e.mock.On("GetUserPlaylistByITunesPID", pid)}
 }
 
@@ -2194,7 +2218,7 @@ type MockPlaylistStore_GetUserPlaylistByName_Call struct {
 
 // GetUserPlaylistByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockPlaylistStore_Expecter) GetUserPlaylistByName(name interface{}) *MockPlaylistStore_GetUserPlaylistByName_Call {
+func (_e *MockPlaylistStore_Expecter) GetUserPlaylistByName(name any) *MockPlaylistStore_GetUserPlaylistByName_Call {
 	return &MockPlaylistStore_GetUserPlaylistByName_Call{Call: _e.mock.On("GetUserPlaylistByName", name)}
 }
 
@@ -2257,7 +2281,7 @@ type MockPlaylistStore_GetUserPosition_Call struct {
 // GetUserPosition is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockPlaylistStore_Expecter) GetUserPosition(userID interface{}, bookID interface{}) *MockPlaylistStore_GetUserPosition_Call {
+func (_e *MockPlaylistStore_Expecter) GetUserPosition(userID any, bookID any) *MockPlaylistStore_GetUserPosition_Call {
 	return &MockPlaylistStore_GetUserPosition_Call{Call: _e.mock.On("GetUserPosition", userID, bookID)}
 }
 
@@ -2379,7 +2403,7 @@ type MockPlaylistStore_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockPlaylistStore_Expecter) ListBookTombstones(limit interface{}) *MockPlaylistStore_ListBookTombstones_Call {
+func (_e *MockPlaylistStore_Expecter) ListBookTombstones(limit any) *MockPlaylistStore_ListBookTombstones_Call {
 	return &MockPlaylistStore_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -2442,7 +2466,7 @@ type MockPlaylistStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockPlaylistStore_ListBooksByITunesPID_Call {
+func (_e *MockPlaylistStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockPlaylistStore_ListBooksByITunesPID_Call {
 	return &MockPlaylistStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -2566,7 +2590,7 @@ type MockPlaylistStore_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockPlaylistStore_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockPlaylistStore_ListSoftDeletedBooks_Call {
+func (_e *MockPlaylistStore_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockPlaylistStore_ListSoftDeletedBooks_Call {
 	return &MockPlaylistStore_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -2641,7 +2665,7 @@ type MockPlaylistStore_ListUserBookStatesByStatus_Call struct {
 //   - status string
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) ListUserBookStatesByStatus(userID interface{}, status interface{}, limit interface{}, offset interface{}) *MockPlaylistStore_ListUserBookStatesByStatus_Call {
+func (_e *MockPlaylistStore_Expecter) ListUserBookStatesByStatus(userID any, status any, limit any, offset any) *MockPlaylistStore_ListUserBookStatesByStatus_Call {
 	return &MockPlaylistStore_ListUserBookStatesByStatus_Call{Call: _e.mock.On("ListUserBookStatesByStatus", userID, status, limit, offset)}
 }
 
@@ -2726,7 +2750,7 @@ type MockPlaylistStore_ListUserPlaylists_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) ListUserPlaylists(playlistType interface{}, limit interface{}, offset interface{}) *MockPlaylistStore_ListUserPlaylists_Call {
+func (_e *MockPlaylistStore_Expecter) ListUserPlaylists(playlistType any, limit any, offset any) *MockPlaylistStore_ListUserPlaylists_Call {
 	return &MockPlaylistStore_ListUserPlaylists_Call{Call: _e.mock.On("ListUserPlaylists", playlistType, limit, offset)}
 }
 
@@ -2807,7 +2831,7 @@ type MockPlaylistStore_ListUserPlaylistsForUser_Call struct {
 //   - playlistType string
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) ListUserPlaylistsForUser(userID interface{}, playlistType interface{}, limit interface{}, offset interface{}) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
+func (_e *MockPlaylistStore_Expecter) ListUserPlaylistsForUser(userID any, playlistType any, limit any, offset any) *MockPlaylistStore_ListUserPlaylistsForUser_Call {
 	return &MockPlaylistStore_ListUserPlaylistsForUser_Call{Call: _e.mock.On("ListUserPlaylistsForUser", userID, playlistType, limit, offset)}
 }
 
@@ -2885,7 +2909,7 @@ type MockPlaylistStore_ListUserPositionsForBook_Call struct {
 // ListUserPositionsForBook is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockPlaylistStore_Expecter) ListUserPositionsForBook(userID interface{}, bookID interface{}) *MockPlaylistStore_ListUserPositionsForBook_Call {
+func (_e *MockPlaylistStore_Expecter) ListUserPositionsForBook(userID any, bookID any) *MockPlaylistStore_ListUserPositionsForBook_Call {
 	return &MockPlaylistStore_ListUserPositionsForBook_Call{Call: _e.mock.On("ListUserPositionsForBook", userID, bookID)}
 }
 
@@ -2953,7 +2977,7 @@ type MockPlaylistStore_ListUserPositionsSince_Call struct {
 // ListUserPositionsSince is a helper method to define mock.On call
 //   - userID string
 //   - t time.Time
-func (_e *MockPlaylistStore_Expecter) ListUserPositionsSince(userID interface{}, t interface{}) *MockPlaylistStore_ListUserPositionsSince_Call {
+func (_e *MockPlaylistStore_Expecter) ListUserPositionsSince(userID any, t any) *MockPlaylistStore_ListUserPositionsSince_Call {
 	return &MockPlaylistStore_ListUserPositionsSince_Call{Call: _e.mock.On("ListUserPositionsSince", userID, t)}
 }
 
@@ -3022,7 +3046,7 @@ type MockPlaylistStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockPlaylistStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockPlaylistStore_SearchBooks_Call {
+func (_e *MockPlaylistStore_Expecter) SearchBooks(query any, limit any, offset any) *MockPlaylistStore_SearchBooks_Call {
 	return &MockPlaylistStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -3083,7 +3107,7 @@ type MockPlaylistStore_SetUserBookState_Call struct {
 
 // SetUserBookState is a helper method to define mock.On call
 //   - state *database.UserBookState
-func (_e *MockPlaylistStore_Expecter) SetUserBookState(state interface{}) *MockPlaylistStore_SetUserBookState_Call {
+func (_e *MockPlaylistStore_Expecter) SetUserBookState(state any) *MockPlaylistStore_SetUserBookState_Call {
 	return &MockPlaylistStore_SetUserBookState_Call{Call: _e.mock.On("SetUserBookState", state)}
 }
 
@@ -3137,7 +3161,7 @@ type MockPlaylistStore_SetUserPosition_Call struct {
 //   - bookID string
 //   - segmentID string
 //   - positionSeconds float64
-func (_e *MockPlaylistStore_Expecter) SetUserPosition(userID interface{}, bookID interface{}, segmentID interface{}, positionSeconds interface{}) *MockPlaylistStore_SetUserPosition_Call {
+func (_e *MockPlaylistStore_Expecter) SetUserPosition(userID any, bookID any, segmentID any, positionSeconds any) *MockPlaylistStore_SetUserPosition_Call {
 	return &MockPlaylistStore_SetUserPosition_Call{Call: _e.mock.On("SetUserPosition", userID, bookID, segmentID, positionSeconds)}
 }
 
@@ -3203,7 +3227,7 @@ type MockPlaylistStore_UpdateUserPlaylist_Call struct {
 
 // UpdateUserPlaylist is a helper method to define mock.On call
 //   - pl *database.UserPlaylist
-func (_e *MockPlaylistStore_Expecter) UpdateUserPlaylist(pl interface{}) *MockPlaylistStore_UpdateUserPlaylist_Call {
+func (_e *MockPlaylistStore_Expecter) UpdateUserPlaylist(pl any) *MockPlaylistStore_UpdateUserPlaylist_Call {
 	return &MockPlaylistStore_UpdateUserPlaylist_Call{Call: _e.mock.On("UpdateUserPlaylist", pl)}
 }
 

--- a/internal/server/handlers/mocks/mock_plugin_registrar.go
+++ b/internal/server/handlers/mocks/mock_plugin_registrar.go
@@ -95,7 +95,7 @@ type MockPluginRegistrar_Disable_Call struct {
 
 // Disable is a helper method to define mock.On call
 //   - id string
-func (_e *MockPluginRegistrar_Expecter) Disable(id interface{}) *MockPluginRegistrar_Disable_Call {
+func (_e *MockPluginRegistrar_Expecter) Disable(id any) *MockPluginRegistrar_Disable_Call {
 	return &MockPluginRegistrar_Disable_Call{Call: _e.mock.On("Disable", id)}
 }
 
@@ -135,7 +135,7 @@ type MockPluginRegistrar_Enable_Call struct {
 
 // Enable is a helper method to define mock.On call
 //   - id string
-func (_e *MockPluginRegistrar_Expecter) Enable(id interface{}) *MockPluginRegistrar_Enable_Call {
+func (_e *MockPluginRegistrar_Expecter) Enable(id any) *MockPluginRegistrar_Enable_Call {
 	return &MockPluginRegistrar_Enable_Call{Call: _e.mock.On("Enable", id)}
 }
 
@@ -197,7 +197,7 @@ type MockPluginRegistrar_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - id string
-func (_e *MockPluginRegistrar_Expecter) Get(id interface{}) *MockPluginRegistrar_Get_Call {
+func (_e *MockPluginRegistrar_Expecter) Get(id any) *MockPluginRegistrar_Get_Call {
 	return &MockPluginRegistrar_Get_Call{Call: _e.mock.On("Get", id)}
 }
 
@@ -248,7 +248,7 @@ type MockPluginRegistrar_IsEnabled_Call struct {
 
 // IsEnabled is a helper method to define mock.On call
 //   - id string
-func (_e *MockPluginRegistrar_Expecter) IsEnabled(id interface{}) *MockPluginRegistrar_IsEnabled_Call {
+func (_e *MockPluginRegistrar_Expecter) IsEnabled(id any) *MockPluginRegistrar_IsEnabled_Call {
 	return &MockPluginRegistrar_IsEnabled_Call{Call: _e.mock.On("IsEnabled", id)}
 }
 

--- a/internal/server/handlers/mocks/mock_reading_store.go
+++ b/internal/server/handlers/mocks/mock_reading_store.go
@@ -63,7 +63,7 @@ type MockReadingStore_BatchUpsertBookFiles_Call struct {
 
 // BatchUpsertBookFiles is a helper method to define mock.On call
 //   - files []*database.BookFile
-func (_e *MockReadingStore_Expecter) BatchUpsertBookFiles(files interface{}) *MockReadingStore_BatchUpsertBookFiles_Call {
+func (_e *MockReadingStore_Expecter) BatchUpsertBookFiles(files any) *MockReadingStore_BatchUpsertBookFiles_Call {
 	return &MockReadingStore_BatchUpsertBookFiles_Call{Call: _e.mock.On("BatchUpsertBookFiles", files)}
 }
 
@@ -123,7 +123,7 @@ type MockReadingStore_ClearITunesPID_Call struct {
 
 // ClearITunesPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockReadingStore_Expecter) ClearITunesPID(itunesPID interface{}) *MockReadingStore_ClearITunesPID_Call {
+func (_e *MockReadingStore_Expecter) ClearITunesPID(itunesPID any) *MockReadingStore_ClearITunesPID_Call {
 	return &MockReadingStore_ClearITunesPID_Call{Call: _e.mock.On("ClearITunesPID", itunesPID)}
 }
 
@@ -175,7 +175,7 @@ type MockReadingStore_ClearUserPositions_Call struct {
 // ClearUserPositions is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockReadingStore_Expecter) ClearUserPositions(userID interface{}, bookID interface{}) *MockReadingStore_ClearUserPositions_Call {
+func (_e *MockReadingStore_Expecter) ClearUserPositions(userID any, bookID any) *MockReadingStore_ClearUserPositions_Call {
 	return &MockReadingStore_ClearUserPositions_Call{Call: _e.mock.On("ClearUserPositions", userID, bookID)}
 }
 
@@ -231,7 +231,7 @@ type MockReadingStore_CreateBookFile_Call struct {
 
 // CreateBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockReadingStore_Expecter) CreateBookFile(file interface{}) *MockReadingStore_CreateBookFile_Call {
+func (_e *MockReadingStore_Expecter) CreateBookFile(file any) *MockReadingStore_CreateBookFile_Call {
 	return &MockReadingStore_CreateBookFile_Call{Call: _e.mock.On("CreateBookFile", file)}
 }
 
@@ -282,7 +282,7 @@ type MockReadingStore_DeleteBookFile_Call struct {
 
 // DeleteBookFile is a helper method to define mock.On call
 //   - id string
-func (_e *MockReadingStore_Expecter) DeleteBookFile(id interface{}) *MockReadingStore_DeleteBookFile_Call {
+func (_e *MockReadingStore_Expecter) DeleteBookFile(id any) *MockReadingStore_DeleteBookFile_Call {
 	return &MockReadingStore_DeleteBookFile_Call{Call: _e.mock.On("DeleteBookFile", id)}
 }
 
@@ -333,7 +333,7 @@ type MockReadingStore_DeleteBookFilesForBook_Call struct {
 
 // DeleteBookFilesForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockReadingStore_Expecter) DeleteBookFilesForBook(bookID interface{}) *MockReadingStore_DeleteBookFilesForBook_Call {
+func (_e *MockReadingStore_Expecter) DeleteBookFilesForBook(bookID any) *MockReadingStore_DeleteBookFilesForBook_Call {
 	return &MockReadingStore_DeleteBookFilesForBook_Call{Call: _e.mock.On("DeleteBookFilesForBook", bookID)}
 }
 
@@ -505,7 +505,7 @@ type MockReadingStore_GetBookBySegmentFileHash_Call struct {
 
 // GetBookBySegmentFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockReadingStore_Expecter) GetBookBySegmentFileHash(hash interface{}) *MockReadingStore_GetBookBySegmentFileHash_Call {
+func (_e *MockReadingStore_Expecter) GetBookBySegmentFileHash(hash any) *MockReadingStore_GetBookBySegmentFileHash_Call {
 	return &MockReadingStore_GetBookBySegmentFileHash_Call{Call: _e.mock.On("GetBookBySegmentFileHash", hash)}
 }
 
@@ -567,7 +567,7 @@ type MockReadingStore_GetBookFileByAcoustID_Call struct {
 
 // GetBookFileByAcoustID is a helper method to define mock.On call
 //   - fingerprint string
-func (_e *MockReadingStore_Expecter) GetBookFileByAcoustID(fingerprint interface{}) *MockReadingStore_GetBookFileByAcoustID_Call {
+func (_e *MockReadingStore_Expecter) GetBookFileByAcoustID(fingerprint any) *MockReadingStore_GetBookFileByAcoustID_Call {
 	return &MockReadingStore_GetBookFileByAcoustID_Call{Call: _e.mock.On("GetBookFileByAcoustID", fingerprint)}
 }
 
@@ -630,7 +630,7 @@ type MockReadingStore_GetBookFileByAcoustIDFuzzy_Call struct {
 // GetBookFileByAcoustIDFuzzy is a helper method to define mock.On call
 //   - fingerprint string
 //   - minSimilarity float64
-func (_e *MockReadingStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint interface{}, minSimilarity interface{}) *MockReadingStore_GetBookFileByAcoustIDFuzzy_Call {
+func (_e *MockReadingStore_Expecter) GetBookFileByAcoustIDFuzzy(fingerprint any, minSimilarity any) *MockReadingStore_GetBookFileByAcoustIDFuzzy_Call {
 	return &MockReadingStore_GetBookFileByAcoustIDFuzzy_Call{Call: _e.mock.On("GetBookFileByAcoustIDFuzzy", fingerprint, minSimilarity)}
 }
 
@@ -698,7 +698,7 @@ type MockReadingStore_GetBookFileByID_Call struct {
 // GetBookFileByID is a helper method to define mock.On call
 //   - bookID string
 //   - fileID string
-func (_e *MockReadingStore_Expecter) GetBookFileByID(bookID interface{}, fileID interface{}) *MockReadingStore_GetBookFileByID_Call {
+func (_e *MockReadingStore_Expecter) GetBookFileByID(bookID any, fileID any) *MockReadingStore_GetBookFileByID_Call {
 	return &MockReadingStore_GetBookFileByID_Call{Call: _e.mock.On("GetBookFileByID", bookID, fileID)}
 }
 
@@ -765,7 +765,7 @@ type MockReadingStore_GetBookFileByPID_Call struct {
 
 // GetBookFileByPID is a helper method to define mock.On call
 //   - itunesPID string
-func (_e *MockReadingStore_Expecter) GetBookFileByPID(itunesPID interface{}) *MockReadingStore_GetBookFileByPID_Call {
+func (_e *MockReadingStore_Expecter) GetBookFileByPID(itunesPID any) *MockReadingStore_GetBookFileByPID_Call {
 	return &MockReadingStore_GetBookFileByPID_Call{Call: _e.mock.On("GetBookFileByPID", itunesPID)}
 }
 
@@ -827,7 +827,7 @@ type MockReadingStore_GetBookFileByPath_Call struct {
 
 // GetBookFileByPath is a helper method to define mock.On call
 //   - filePath string
-func (_e *MockReadingStore_Expecter) GetBookFileByPath(filePath interface{}) *MockReadingStore_GetBookFileByPath_Call {
+func (_e *MockReadingStore_Expecter) GetBookFileByPath(filePath any) *MockReadingStore_GetBookFileByPath_Call {
 	return &MockReadingStore_GetBookFileByPath_Call{Call: _e.mock.On("GetBookFileByPath", filePath)}
 }
 
@@ -944,7 +944,7 @@ type MockReadingStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockReadingStore_Expecter) GetBookFiles(bookID interface{}) *MockReadingStore_GetBookFiles_Call {
+func (_e *MockReadingStore_Expecter) GetBookFiles(bookID any) *MockReadingStore_GetBookFiles_Call {
 	return &MockReadingStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -1116,7 +1116,7 @@ type MockReadingStore_GetDuplicateFilesByHash_Call struct {
 
 // GetDuplicateFilesByHash is a helper method to define mock.On call
 //   - limit int
-func (_e *MockReadingStore_Expecter) GetDuplicateFilesByHash(limit interface{}) *MockReadingStore_GetDuplicateFilesByHash_Call {
+func (_e *MockReadingStore_Expecter) GetDuplicateFilesByHash(limit any) *MockReadingStore_GetDuplicateFilesByHash_Call {
 	return &MockReadingStore_GetDuplicateFilesByHash_Call{Call: _e.mock.On("GetDuplicateFilesByHash", limit)}
 }
 
@@ -1186,7 +1186,7 @@ type MockReadingStore_GetFilesWithFingerprintFailures_Call struct {
 //   - reason string
 //   - limit int
 //   - offset int
-func (_e *MockReadingStore_Expecter) GetFilesWithFingerprintFailures(reason interface{}, limit interface{}, offset interface{}) *MockReadingStore_GetFilesWithFingerprintFailures_Call {
+func (_e *MockReadingStore_Expecter) GetFilesWithFingerprintFailures(reason any, limit any, offset any) *MockReadingStore_GetFilesWithFingerprintFailures_Call {
 	return &MockReadingStore_GetFilesWithFingerprintFailures_Call{Call: _e.mock.On("GetFilesWithFingerprintFailures", reason, limit, offset)}
 }
 
@@ -1259,7 +1259,7 @@ type MockReadingStore_GetUserBookState_Call struct {
 // GetUserBookState is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockReadingStore_Expecter) GetUserBookState(userID interface{}, bookID interface{}) *MockReadingStore_GetUserBookState_Call {
+func (_e *MockReadingStore_Expecter) GetUserBookState(userID any, bookID any) *MockReadingStore_GetUserBookState_Call {
 	return &MockReadingStore_GetUserBookState_Call{Call: _e.mock.On("GetUserBookState", userID, bookID)}
 }
 
@@ -1327,7 +1327,7 @@ type MockReadingStore_GetUserPosition_Call struct {
 // GetUserPosition is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockReadingStore_Expecter) GetUserPosition(userID interface{}, bookID interface{}) *MockReadingStore_GetUserPosition_Call {
+func (_e *MockReadingStore_Expecter) GetUserPosition(userID any, bookID any) *MockReadingStore_GetUserPosition_Call {
 	return &MockReadingStore_GetUserPosition_Call{Call: _e.mock.On("GetUserPosition", userID, bookID)}
 }
 
@@ -1397,7 +1397,7 @@ type MockReadingStore_ListUserBookStatesByStatus_Call struct {
 //   - status string
 //   - limit int
 //   - offset int
-func (_e *MockReadingStore_Expecter) ListUserBookStatesByStatus(userID interface{}, status interface{}, limit interface{}, offset interface{}) *MockReadingStore_ListUserBookStatesByStatus_Call {
+func (_e *MockReadingStore_Expecter) ListUserBookStatesByStatus(userID any, status any, limit any, offset any) *MockReadingStore_ListUserBookStatesByStatus_Call {
 	return &MockReadingStore_ListUserBookStatesByStatus_Call{Call: _e.mock.On("ListUserBookStatesByStatus", userID, status, limit, offset)}
 }
 
@@ -1475,7 +1475,7 @@ type MockReadingStore_ListUserPositionsForBook_Call struct {
 // ListUserPositionsForBook is a helper method to define mock.On call
 //   - userID string
 //   - bookID string
-func (_e *MockReadingStore_Expecter) ListUserPositionsForBook(userID interface{}, bookID interface{}) *MockReadingStore_ListUserPositionsForBook_Call {
+func (_e *MockReadingStore_Expecter) ListUserPositionsForBook(userID any, bookID any) *MockReadingStore_ListUserPositionsForBook_Call {
 	return &MockReadingStore_ListUserPositionsForBook_Call{Call: _e.mock.On("ListUserPositionsForBook", userID, bookID)}
 }
 
@@ -1543,7 +1543,7 @@ type MockReadingStore_ListUserPositionsSince_Call struct {
 // ListUserPositionsSince is a helper method to define mock.On call
 //   - userID string
 //   - t time.Time
-func (_e *MockReadingStore_Expecter) ListUserPositionsSince(userID interface{}, t interface{}) *MockReadingStore_ListUserPositionsSince_Call {
+func (_e *MockReadingStore_Expecter) ListUserPositionsSince(userID any, t any) *MockReadingStore_ListUserPositionsSince_Call {
 	return &MockReadingStore_ListUserPositionsSince_Call{Call: _e.mock.On("ListUserPositionsSince", userID, t)}
 }
 
@@ -1602,7 +1602,7 @@ type MockReadingStore_MarkFileImportedFromDeluge_Call struct {
 //   - originalPath string
 //   - libraryPath string
 //   - torrentHash string
-func (_e *MockReadingStore_Expecter) MarkFileImportedFromDeluge(ctx interface{}, originalPath interface{}, libraryPath interface{}, torrentHash interface{}) *MockReadingStore_MarkFileImportedFromDeluge_Call {
+func (_e *MockReadingStore_Expecter) MarkFileImportedFromDeluge(ctx any, originalPath any, libraryPath any, torrentHash any) *MockReadingStore_MarkFileImportedFromDeluge_Call {
 	return &MockReadingStore_MarkFileImportedFromDeluge_Call{Call: _e.mock.On("MarkFileImportedFromDeluge", ctx, originalPath, libraryPath, torrentHash)}
 }
 
@@ -1670,7 +1670,7 @@ type MockReadingStore_MoveBookFilesToBook_Call struct {
 //   - fileIDs []string
 //   - sourceBookID string
 //   - targetBookID string
-func (_e *MockReadingStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockReadingStore_MoveBookFilesToBook_Call {
+func (_e *MockReadingStore_Expecter) MoveBookFilesToBook(fileIDs any, sourceBookID any, targetBookID any) *MockReadingStore_MoveBookFilesToBook_Call {
 	return &MockReadingStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
 }
 
@@ -1732,7 +1732,7 @@ type MockReadingStore_SetBookFileHash_Call struct {
 // SetBookFileHash is a helper method to define mock.On call
 //   - id string
 //   - hash string
-func (_e *MockReadingStore_Expecter) SetBookFileHash(id interface{}, hash interface{}) *MockReadingStore_SetBookFileHash_Call {
+func (_e *MockReadingStore_Expecter) SetBookFileHash(id any, hash any) *MockReadingStore_SetBookFileHash_Call {
 	return &MockReadingStore_SetBookFileHash_Call{Call: _e.mock.On("SetBookFileHash", id, hash)}
 }
 
@@ -1788,7 +1788,7 @@ type MockReadingStore_SetUserBookState_Call struct {
 
 // SetUserBookState is a helper method to define mock.On call
 //   - state *database.UserBookState
-func (_e *MockReadingStore_Expecter) SetUserBookState(state interface{}) *MockReadingStore_SetUserBookState_Call {
+func (_e *MockReadingStore_Expecter) SetUserBookState(state any) *MockReadingStore_SetUserBookState_Call {
 	return &MockReadingStore_SetUserBookState_Call{Call: _e.mock.On("SetUserBookState", state)}
 }
 
@@ -1842,7 +1842,7 @@ type MockReadingStore_SetUserPosition_Call struct {
 //   - bookID string
 //   - segmentID string
 //   - positionSeconds float64
-func (_e *MockReadingStore_Expecter) SetUserPosition(userID interface{}, bookID interface{}, segmentID interface{}, positionSeconds interface{}) *MockReadingStore_SetUserPosition_Call {
+func (_e *MockReadingStore_Expecter) SetUserPosition(userID any, bookID any, segmentID any, positionSeconds any) *MockReadingStore_SetUserPosition_Call {
 	return &MockReadingStore_SetUserPosition_Call{Call: _e.mock.On("SetUserPosition", userID, bookID, segmentID, positionSeconds)}
 }
 
@@ -1909,7 +1909,7 @@ type MockReadingStore_UpdateBookFile_Call struct {
 // UpdateBookFile is a helper method to define mock.On call
 //   - id string
 //   - file *database.BookFile
-func (_e *MockReadingStore_Expecter) UpdateBookFile(id interface{}, file interface{}) *MockReadingStore_UpdateBookFile_Call {
+func (_e *MockReadingStore_Expecter) UpdateBookFile(id any, file any) *MockReadingStore_UpdateBookFile_Call {
 	return &MockReadingStore_UpdateBookFile_Call{Call: _e.mock.On("UpdateBookFile", id, file)}
 }
 
@@ -1967,7 +1967,7 @@ type MockReadingStore_UpdateBookFileHashes_Call struct {
 //   - id string
 //   - originalHash string
 //   - postMetadataHash string
-func (_e *MockReadingStore_Expecter) UpdateBookFileHashes(id interface{}, originalHash interface{}, postMetadataHash interface{}) *MockReadingStore_UpdateBookFileHashes_Call {
+func (_e *MockReadingStore_Expecter) UpdateBookFileHashes(id any, originalHash any, postMetadataHash any) *MockReadingStore_UpdateBookFileHashes_Call {
 	return &MockReadingStore_UpdateBookFileHashes_Call{Call: _e.mock.On("UpdateBookFileHashes", id, originalHash, postMetadataHash)}
 }
 
@@ -2028,7 +2028,7 @@ type MockReadingStore_UpsertBookFile_Call struct {
 
 // UpsertBookFile is a helper method to define mock.On call
 //   - file *database.BookFile
-func (_e *MockReadingStore_Expecter) UpsertBookFile(file interface{}) *MockReadingStore_UpsertBookFile_Call {
+func (_e *MockReadingStore_Expecter) UpsertBookFile(file any) *MockReadingStore_UpsertBookFile_Call {
 	return &MockReadingStore_UpsertBookFile_Call{Call: _e.mock.On("UpsertBookFile", file)}
 }
 

--- a/internal/server/handlers/mocks/mock_rename_servicer.go
+++ b/internal/server/handlers/mocks/mock_rename_servicer.go
@@ -72,7 +72,7 @@ type MockRenameServicer_ApplyRename_Call struct {
 // ApplyRename is a helper method to define mock.On call
 //   - bookID string
 //   - operationID string
-func (_e *MockRenameServicer_Expecter) ApplyRename(bookID interface{}, operationID interface{}) *MockRenameServicer_ApplyRename_Call {
+func (_e *MockRenameServicer_Expecter) ApplyRename(bookID any, operationID any) *MockRenameServicer_ApplyRename_Call {
 	return &MockRenameServicer_ApplyRename_Call{Call: _e.mock.On("ApplyRename", bookID, operationID)}
 }
 
@@ -139,7 +139,7 @@ type MockRenameServicer_PreviewRename_Call struct {
 
 // PreviewRename is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockRenameServicer_Expecter) PreviewRename(bookID interface{}) *MockRenameServicer_PreviewRename_Call {
+func (_e *MockRenameServicer_Expecter) PreviewRename(bookID any) *MockRenameServicer_PreviewRename_Call {
 	return &MockRenameServicer_PreviewRename_Call{Call: _e.mock.On("PreviewRename", bookID)}
 }
 

--- a/internal/server/handlers/mocks/mock_split_book_candidate_store.go
+++ b/internal/server/handlers/mocks/mock_split_book_candidate_store.go
@@ -60,7 +60,7 @@ type MockSplitBookCandidateStore_Delete_Call struct {
 
 // Delete is a helper method to define mock.On call
 //   - id string
-func (_e *MockSplitBookCandidateStore_Expecter) Delete(id interface{}) *MockSplitBookCandidateStore_Delete_Call {
+func (_e *MockSplitBookCandidateStore_Expecter) Delete(id any) *MockSplitBookCandidateStore_Delete_Call {
 	return &MockSplitBookCandidateStore_Delete_Call{Call: _e.mock.On("Delete", id)}
 }
 
@@ -122,7 +122,7 @@ type MockSplitBookCandidateStore_Get_Call struct {
 
 // Get is a helper method to define mock.On call
 //   - id string
-func (_e *MockSplitBookCandidateStore_Expecter) Get(id interface{}) *MockSplitBookCandidateStore_Get_Call {
+func (_e *MockSplitBookCandidateStore_Expecter) Get(id any) *MockSplitBookCandidateStore_Get_Call {
 	return &MockSplitBookCandidateStore_Get_Call{Call: _e.mock.On("Get", id)}
 }
 

--- a/internal/server/handlers/mocks/mock_split_book_op_enqueuer.go
+++ b/internal/server/handlers/mocks/mock_split_book_op_enqueuer.go
@@ -80,9 +80,9 @@ type MockSplitBookOpEnqueuer_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockSplitBookOpEnqueuer_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockSplitBookOpEnqueuer_EnqueueOp_Call {
+func (_e *MockSplitBookOpEnqueuer_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockSplitBookOpEnqueuer_EnqueueOp_Call {
 	return &MockSplitBookOpEnqueuer_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockSplitBookOpEnqueuer_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockSplitBookOpEnqueuer_EnqueueOp_Call {

--- a/internal/server/handlers/mocks/mock_user_store.go
+++ b/internal/server/handlers/mocks/mock_user_store.go
@@ -75,7 +75,7 @@ type MockUserStore_ConsumeInvite_Call struct {
 //   - token string
 //   - algo string
 //   - hash string
-func (_e *MockUserStore_Expecter) ConsumeInvite(token interface{}, algo interface{}, hash interface{}) *MockUserStore_ConsumeInvite_Call {
+func (_e *MockUserStore_Expecter) ConsumeInvite(token any, algo any, hash any) *MockUserStore_ConsumeInvite_Call {
 	return &MockUserStore_ConsumeInvite_Call{Call: _e.mock.On("ConsumeInvite", token, algo, hash)}
 }
 
@@ -147,7 +147,7 @@ type MockUserStore_CreateInvite_Call struct {
 
 // CreateInvite is a helper method to define mock.On call
 //   - invite *database.Invite
-func (_e *MockUserStore_Expecter) CreateInvite(invite interface{}) *MockUserStore_CreateInvite_Call {
+func (_e *MockUserStore_Expecter) CreateInvite(invite any) *MockUserStore_CreateInvite_Call {
 	return &MockUserStore_CreateInvite_Call{Call: _e.mock.On("CreateInvite", invite)}
 }
 
@@ -212,7 +212,7 @@ type MockUserStore_CreateSession_Call struct {
 //   - ip string
 //   - ua string
 //   - ttl time.Duration
-func (_e *MockUserStore_Expecter) CreateSession(userID interface{}, ip interface{}, ua interface{}, ttl interface{}) *MockUserStore_CreateSession_Call {
+func (_e *MockUserStore_Expecter) CreateSession(userID any, ip any, ua any, ttl any) *MockUserStore_CreateSession_Call {
 	return &MockUserStore_CreateSession_Call{Call: _e.mock.On("CreateSession", userID, ip, ua, ttl)}
 }
 
@@ -278,7 +278,7 @@ type MockUserStore_DeleteInvite_Call struct {
 
 // DeleteInvite is a helper method to define mock.On call
 //   - token string
-func (_e *MockUserStore_Expecter) DeleteInvite(token interface{}) *MockUserStore_DeleteInvite_Call {
+func (_e *MockUserStore_Expecter) DeleteInvite(token any) *MockUserStore_DeleteInvite_Call {
 	return &MockUserStore_DeleteInvite_Call{Call: _e.mock.On("DeleteInvite", token)}
 }
 
@@ -340,7 +340,7 @@ type MockUserStore_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockUserStore_Expecter) GetUserByID(id interface{}) *MockUserStore_GetUserByID_Call {
+func (_e *MockUserStore_Expecter) GetUserByID(id any) *MockUserStore_GetUserByID_Call {
 	return &MockUserStore_GetUserByID_Call{Call: _e.mock.On("GetUserByID", id)}
 }
 
@@ -501,7 +501,7 @@ type MockUserStore_UpdateUser_Call struct {
 
 // UpdateUser is a helper method to define mock.On call
 //   - user *database.User
-func (_e *MockUserStore_Expecter) UpdateUser(user interface{}) *MockUserStore_UpdateUser_Call {
+func (_e *MockUserStore_Expecter) UpdateUser(user any) *MockUserStore_UpdateUser_Call {
 	return &MockUserStore_UpdateUser_Call{Call: _e.mock.On("UpdateUser", user)}
 }
 

--- a/internal/server/handlers/mocks/mock_versions_store.go
+++ b/internal/server/handlers/mocks/mock_versions_store.go
@@ -71,7 +71,7 @@ type MockVersionsStore_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockVersionsStore_Expecter) CreateBook(book interface{}) *MockVersionsStore_CreateBook_Call {
+func (_e *MockVersionsStore_Expecter) CreateBook(book any) *MockVersionsStore_CreateBook_Call {
 	return &MockVersionsStore_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -122,7 +122,7 @@ type MockVersionsStore_CreateExternalIDMapping_Call struct {
 
 // CreateExternalIDMapping is a helper method to define mock.On call
 //   - mapping *database.ExternalIDMapping
-func (_e *MockVersionsStore_Expecter) CreateExternalIDMapping(mapping interface{}) *MockVersionsStore_CreateExternalIDMapping_Call {
+func (_e *MockVersionsStore_Expecter) CreateExternalIDMapping(mapping any) *MockVersionsStore_CreateExternalIDMapping_Call {
 	return &MockVersionsStore_CreateExternalIDMapping_Call{Call: _e.mock.On("CreateExternalIDMapping", mapping)}
 }
 
@@ -173,7 +173,7 @@ type MockVersionsStore_DeleteRaw_Call struct {
 
 // DeleteRaw is a helper method to define mock.On call
 //   - key string
-func (_e *MockVersionsStore_Expecter) DeleteRaw(key interface{}) *MockVersionsStore_DeleteRaw_Call {
+func (_e *MockVersionsStore_Expecter) DeleteRaw(key any) *MockVersionsStore_DeleteRaw_Call {
 	return &MockVersionsStore_DeleteRaw_Call{Call: _e.mock.On("DeleteRaw", key)}
 }
 
@@ -235,7 +235,7 @@ type MockVersionsStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockVersionsStore_Expecter) GetBookAuthors(bookID interface{}) *MockVersionsStore_GetBookAuthors_Call {
+func (_e *MockVersionsStore_Expecter) GetBookAuthors(bookID any) *MockVersionsStore_GetBookAuthors_Call {
 	return &MockVersionsStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -297,7 +297,7 @@ type MockVersionsStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockVersionsStore_Expecter) GetBookByID(id interface{}) *MockVersionsStore_GetBookByID_Call {
+func (_e *MockVersionsStore_Expecter) GetBookByID(id any) *MockVersionsStore_GetBookByID_Call {
 	return &MockVersionsStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -359,7 +359,7 @@ type MockVersionsStore_GetBookFiles_Call struct {
 
 // GetBookFiles is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockVersionsStore_Expecter) GetBookFiles(bookID interface{}) *MockVersionsStore_GetBookFiles_Call {
+func (_e *MockVersionsStore_Expecter) GetBookFiles(bookID any) *MockVersionsStore_GetBookFiles_Call {
 	return &MockVersionsStore_GetBookFiles_Call{Call: _e.mock.On("GetBookFiles", bookID)}
 }
 
@@ -421,7 +421,7 @@ type MockVersionsStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockVersionsStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockVersionsStore_GetBooksByVersionGroup_Call {
+func (_e *MockVersionsStore_Expecter) GetBooksByVersionGroup(groupID any) *MockVersionsStore_GetBooksByVersionGroup_Call {
 	return &MockVersionsStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -483,7 +483,7 @@ type MockVersionsStore_GetExternalIDsForBook_Call struct {
 
 // GetExternalIDsForBook is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockVersionsStore_Expecter) GetExternalIDsForBook(bookID interface{}) *MockVersionsStore_GetExternalIDsForBook_Call {
+func (_e *MockVersionsStore_Expecter) GetExternalIDsForBook(bookID any) *MockVersionsStore_GetExternalIDsForBook_Call {
 	return &MockVersionsStore_GetExternalIDsForBook_Call{Call: _e.mock.On("GetExternalIDsForBook", bookID)}
 }
 
@@ -536,7 +536,7 @@ type MockVersionsStore_MoveBookFilesToBook_Call struct {
 //   - fileIDs []string
 //   - sourceBookID string
 //   - targetBookID string
-func (_e *MockVersionsStore_Expecter) MoveBookFilesToBook(fileIDs interface{}, sourceBookID interface{}, targetBookID interface{}) *MockVersionsStore_MoveBookFilesToBook_Call {
+func (_e *MockVersionsStore_Expecter) MoveBookFilesToBook(fileIDs any, sourceBookID any, targetBookID any) *MockVersionsStore_MoveBookFilesToBook_Call {
 	return &MockVersionsStore_MoveBookFilesToBook_Call{Call: _e.mock.On("MoveBookFilesToBook", fileIDs, sourceBookID, targetBookID)}
 }
 
@@ -598,7 +598,7 @@ type MockVersionsStore_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockVersionsStore_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockVersionsStore_SetBookAuthors_Call {
+func (_e *MockVersionsStore_Expecter) SetBookAuthors(bookID any, authors any) *MockVersionsStore_SetBookAuthors_Call {
 	return &MockVersionsStore_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -666,7 +666,7 @@ type MockVersionsStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockVersionsStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockVersionsStore_UpdateBook_Call {
+func (_e *MockVersionsStore_Expecter) UpdateBook(id any, book any) *MockVersionsStore_UpdateBook_Call {
 	return &MockVersionsStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 

--- a/internal/server/handlers/mocks/mock_write_back_enqueuer.go
+++ b/internal/server/handlers/mocks/mock_write_back_enqueuer.go
@@ -48,7 +48,7 @@ type MockWriteBackEnqueuer_Enqueue_Call struct {
 
 // Enqueue is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID interface{}) *MockWriteBackEnqueuer_Enqueue_Call {
+func (_e *MockWriteBackEnqueuer_Expecter) Enqueue(bookID any) *MockWriteBackEnqueuer_Enqueue_Call {
 	return &MockWriteBackEnqueuer_Enqueue_Call{Call: _e.mock.On("Enqueue", bookID)}
 }
 

--- a/internal/server/handlers/operations/mocks/mock_operations_registry.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_registry.go
@@ -62,7 +62,7 @@ type MockOperationsRegistry_Cancel_Call struct {
 
 // Cancel is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsRegistry_Expecter) Cancel(opID interface{}) *MockOperationsRegistry_Cancel_Call {
+func (_e *MockOperationsRegistry_Expecter) Cancel(opID any) *MockOperationsRegistry_Cancel_Call {
 	return &MockOperationsRegistry_Cancel_Call{Call: _e.mock.On("Cancel", opID)}
 }
 
@@ -131,9 +131,9 @@ type MockOperationsRegistry_EnqueueOp_Call struct {
 //   - defID string
 //   - params any
 //   - opts ...registry.EnqueueOption
-func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx interface{}, defID interface{}, params interface{}, opts ...interface{}) *MockOperationsRegistry_EnqueueOp_Call {
+func (_e *MockOperationsRegistry_Expecter) EnqueueOp(ctx any, defID any, params any, opts ...any) *MockOperationsRegistry_EnqueueOp_Call {
 	return &MockOperationsRegistry_EnqueueOp_Call{Call: _e.mock.On("EnqueueOp",
-		append([]interface{}{ctx, defID, params}, opts...)...)}
+		append([]any{ctx, defID, params}, opts...)...)}
 }
 
 func (_c *MockOperationsRegistry_EnqueueOp_Call) Run(run func(ctx context.Context, defID string, params any, opts ...registry.EnqueueOption)) *MockOperationsRegistry_EnqueueOp_Call {

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -66,7 +66,7 @@ type MockOperationsStore_AddOperationLog_Call struct {
 //   - level string
 //   - message string
 //   - details *string
-func (_e *MockOperationsStore_Expecter) AddOperationLog(operationID interface{}, level interface{}, message interface{}, details interface{}) *MockOperationsStore_AddOperationLog_Call {
+func (_e *MockOperationsStore_Expecter) AddOperationLog(operationID any, level any, message any, details any) *MockOperationsStore_AddOperationLog_Call {
 	return &MockOperationsStore_AddOperationLog_Call{Call: _e.mock.On("AddOperationLog", operationID, level, message, details)}
 }
 
@@ -111,9 +111,11 @@ func (_c *MockOperationsStore_AddOperationLog_Call) RunAndReturn(run func(operat
 // CountAllBooks provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) CountAllBooks() (int, error) {
 	ret := _mock.Called()
+
 	if len(ret) == 0 {
 		panic("no return value specified for CountAllBooks")
 	}
+
 	var r0 int
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func() (int, error)); ok {
@@ -130,6 +132,33 @@ func (_mock *MockOperationsStore) CountAllBooks() (int, error) {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
+}
+
+// MockOperationsStore_CountAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountAllBooks'
+type MockOperationsStore_CountAllBooks_Call struct {
+	*mock.Call
+}
+
+// CountAllBooks is a helper method to define mock.On call
+func (_e *MockOperationsStore_Expecter) CountAllBooks() *MockOperationsStore_CountAllBooks_Call {
+	return &MockOperationsStore_CountAllBooks_Call{Call: _e.mock.On("CountAllBooks")}
+}
+
+func (_c *MockOperationsStore_CountAllBooks_Call) Run(run func()) *MockOperationsStore_CountAllBooks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_CountAllBooks_Call) Return(n int, err error) *MockOperationsStore_CountAllBooks_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_CountAllBooks_Call) RunAndReturn(run func() (int, error)) *MockOperationsStore_CountAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CountPrimaryBooks provides a mock function for the type MockOperationsStore
@@ -158,29 +187,29 @@ func (_mock *MockOperationsStore) CountPrimaryBooks() (int, error) {
 	return r0, r1
 }
 
-// MockOperationsStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockOperationsStore_CountBooks_Call struct {
+// MockOperationsStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockOperationsStore_CountPrimaryBooks_Call struct {
 	*mock.Call
 }
 
 // CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockOperationsStore_Expecter) CountPrimaryBooks() *MockOperationsStore_CountBooks_Call {
-	return &MockOperationsStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+func (_e *MockOperationsStore_Expecter) CountPrimaryBooks() *MockOperationsStore_CountPrimaryBooks_Call {
+	return &MockOperationsStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
 }
 
-func (_c *MockOperationsStore_CountBooks_Call) Run(run func()) *MockOperationsStore_CountBooks_Call {
+func (_c *MockOperationsStore_CountPrimaryBooks_Call) Run(run func()) *MockOperationsStore_CountPrimaryBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockOperationsStore_CountBooks_Call) Return(n int, err error) *MockOperationsStore_CountBooks_Call {
+func (_c *MockOperationsStore_CountPrimaryBooks_Call) Return(n int, err error) *MockOperationsStore_CountPrimaryBooks_Call {
 	_c.Call.Return(n, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockOperationsStore_CountBooks_Call {
+func (_c *MockOperationsStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockOperationsStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -273,7 +302,7 @@ type MockOperationsStore_CreateAuthor_Call struct {
 
 // CreateAuthor is a helper method to define mock.On call
 //   - name string
-func (_e *MockOperationsStore_Expecter) CreateAuthor(name interface{}) *MockOperationsStore_CreateAuthor_Call {
+func (_e *MockOperationsStore_Expecter) CreateAuthor(name any) *MockOperationsStore_CreateAuthor_Call {
 	return &MockOperationsStore_CreateAuthor_Call{Call: _e.mock.On("CreateAuthor", name)}
 }
 
@@ -337,7 +366,7 @@ type MockOperationsStore_CreateAuthorAlias_Call struct {
 //   - authorID int
 //   - aliasName string
 //   - aliasType string
-func (_e *MockOperationsStore_Expecter) CreateAuthorAlias(authorID interface{}, aliasName interface{}, aliasType interface{}) *MockOperationsStore_CreateAuthorAlias_Call {
+func (_e *MockOperationsStore_Expecter) CreateAuthorAlias(authorID any, aliasName any, aliasType any) *MockOperationsStore_CreateAuthorAlias_Call {
 	return &MockOperationsStore_CreateAuthorAlias_Call{Call: _e.mock.On("CreateAuthorAlias", authorID, aliasName, aliasType)}
 }
 
@@ -399,7 +428,7 @@ type MockOperationsStore_CreateAuthorTombstone_Call struct {
 // CreateAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
 //   - canonicalID int
-func (_e *MockOperationsStore_Expecter) CreateAuthorTombstone(oldID interface{}, canonicalID interface{}) *MockOperationsStore_CreateAuthorTombstone_Call {
+func (_e *MockOperationsStore_Expecter) CreateAuthorTombstone(oldID any, canonicalID any) *MockOperationsStore_CreateAuthorTombstone_Call {
 	return &MockOperationsStore_CreateAuthorTombstone_Call{Call: _e.mock.On("CreateAuthorTombstone", oldID, canonicalID)}
 }
 
@@ -466,7 +495,7 @@ type MockOperationsStore_CreateBook_Call struct {
 
 // CreateBook is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockOperationsStore_Expecter) CreateBook(book interface{}) *MockOperationsStore_CreateBook_Call {
+func (_e *MockOperationsStore_Expecter) CreateBook(book any) *MockOperationsStore_CreateBook_Call {
 	return &MockOperationsStore_CreateBook_Call{Call: _e.mock.On("CreateBook", book)}
 }
 
@@ -517,7 +546,7 @@ type MockOperationsStore_CreateBookTombstone_Call struct {
 
 // CreateBookTombstone is a helper method to define mock.On call
 //   - book *database.Book
-func (_e *MockOperationsStore_Expecter) CreateBookTombstone(book interface{}) *MockOperationsStore_CreateBookTombstone_Call {
+func (_e *MockOperationsStore_Expecter) CreateBookTombstone(book any) *MockOperationsStore_CreateBookTombstone_Call {
 	return &MockOperationsStore_CreateBookTombstone_Call{Call: _e.mock.On("CreateBookTombstone", book)}
 }
 
@@ -579,7 +608,7 @@ type MockOperationsStore_CreateNarrator_Call struct {
 
 // CreateNarrator is a helper method to define mock.On call
 //   - name string
-func (_e *MockOperationsStore_Expecter) CreateNarrator(name interface{}) *MockOperationsStore_CreateNarrator_Call {
+func (_e *MockOperationsStore_Expecter) CreateNarrator(name any) *MockOperationsStore_CreateNarrator_Call {
 	return &MockOperationsStore_CreateNarrator_Call{Call: _e.mock.On("CreateNarrator", name)}
 }
 
@@ -643,7 +672,7 @@ type MockOperationsStore_CreateOperation_Call struct {
 //   - id string
 //   - opType string
 //   - folderPath *string
-func (_e *MockOperationsStore_Expecter) CreateOperation(id interface{}, opType interface{}, folderPath interface{}) *MockOperationsStore_CreateOperation_Call {
+func (_e *MockOperationsStore_Expecter) CreateOperation(id any, opType any, folderPath any) *MockOperationsStore_CreateOperation_Call {
 	return &MockOperationsStore_CreateOperation_Call{Call: _e.mock.On("CreateOperation", id, opType, folderPath)}
 }
 
@@ -704,7 +733,7 @@ type MockOperationsStore_CreateOperationChange_Call struct {
 
 // CreateOperationChange is a helper method to define mock.On call
 //   - change *database.OperationChange
-func (_e *MockOperationsStore_Expecter) CreateOperationChange(change interface{}) *MockOperationsStore_CreateOperationChange_Call {
+func (_e *MockOperationsStore_Expecter) CreateOperationChange(change any) *MockOperationsStore_CreateOperationChange_Call {
 	return &MockOperationsStore_CreateOperationChange_Call{Call: _e.mock.On("CreateOperationChange", change)}
 }
 
@@ -755,7 +784,7 @@ type MockOperationsStore_CreateOperationResult_Call struct {
 
 // CreateOperationResult is a helper method to define mock.On call
 //   - result *database.OperationResult
-func (_e *MockOperationsStore_Expecter) CreateOperationResult(result interface{}) *MockOperationsStore_CreateOperationResult_Call {
+func (_e *MockOperationsStore_Expecter) CreateOperationResult(result any) *MockOperationsStore_CreateOperationResult_Call {
 	return &MockOperationsStore_CreateOperationResult_Call{Call: _e.mock.On("CreateOperationResult", result)}
 }
 
@@ -806,7 +835,7 @@ type MockOperationsStore_DeleteAuthor_Call struct {
 
 // DeleteAuthor is a helper method to define mock.On call
 //   - id int
-func (_e *MockOperationsStore_Expecter) DeleteAuthor(id interface{}) *MockOperationsStore_DeleteAuthor_Call {
+func (_e *MockOperationsStore_Expecter) DeleteAuthor(id any) *MockOperationsStore_DeleteAuthor_Call {
 	return &MockOperationsStore_DeleteAuthor_Call{Call: _e.mock.On("DeleteAuthor", id)}
 }
 
@@ -857,7 +886,7 @@ type MockOperationsStore_DeleteAuthorAlias_Call struct {
 
 // DeleteAuthorAlias is a helper method to define mock.On call
 //   - id int
-func (_e *MockOperationsStore_Expecter) DeleteAuthorAlias(id interface{}) *MockOperationsStore_DeleteAuthorAlias_Call {
+func (_e *MockOperationsStore_Expecter) DeleteAuthorAlias(id any) *MockOperationsStore_DeleteAuthorAlias_Call {
 	return &MockOperationsStore_DeleteAuthorAlias_Call{Call: _e.mock.On("DeleteAuthorAlias", id)}
 }
 
@@ -908,7 +937,7 @@ type MockOperationsStore_DeleteBook_Call struct {
 
 // DeleteBook is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) DeleteBook(id interface{}) *MockOperationsStore_DeleteBook_Call {
+func (_e *MockOperationsStore_Expecter) DeleteBook(id any) *MockOperationsStore_DeleteBook_Call {
 	return &MockOperationsStore_DeleteBook_Call{Call: _e.mock.On("DeleteBook", id)}
 }
 
@@ -959,7 +988,7 @@ type MockOperationsStore_DeleteBookTombstone_Call struct {
 
 // DeleteBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) DeleteBookTombstone(id interface{}) *MockOperationsStore_DeleteBookTombstone_Call {
+func (_e *MockOperationsStore_Expecter) DeleteBookTombstone(id any) *MockOperationsStore_DeleteBookTombstone_Call {
 	return &MockOperationsStore_DeleteBookTombstone_Call{Call: _e.mock.On("DeleteBookTombstone", id)}
 }
 
@@ -1010,7 +1039,7 @@ type MockOperationsStore_DeleteOperationState_Call struct {
 
 // DeleteOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsStore_Expecter) DeleteOperationState(opID interface{}) *MockOperationsStore_DeleteOperationState_Call {
+func (_e *MockOperationsStore_Expecter) DeleteOperationState(opID any) *MockOperationsStore_DeleteOperationState_Call {
 	return &MockOperationsStore_DeleteOperationState_Call{Call: _e.mock.On("DeleteOperationState", opID)}
 }
 
@@ -1061,7 +1090,7 @@ type MockOperationsStore_DeleteOperationWithLogs_Call struct {
 
 // DeleteOperationWithLogs is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) DeleteOperationWithLogs(id interface{}) *MockOperationsStore_DeleteOperationWithLogs_Call {
+func (_e *MockOperationsStore_Expecter) DeleteOperationWithLogs(id any) *MockOperationsStore_DeleteOperationWithLogs_Call {
 	return &MockOperationsStore_DeleteOperationWithLogs_Call{Call: _e.mock.On("DeleteOperationWithLogs", id)}
 }
 
@@ -1121,7 +1150,7 @@ type MockOperationsStore_DeleteOperationsByStatus_Call struct {
 
 // DeleteOperationsByStatus is a helper method to define mock.On call
 //   - statuses []string
-func (_e *MockOperationsStore_Expecter) DeleteOperationsByStatus(statuses interface{}) *MockOperationsStore_DeleteOperationsByStatus_Call {
+func (_e *MockOperationsStore_Expecter) DeleteOperationsByStatus(statuses any) *MockOperationsStore_DeleteOperationsByStatus_Call {
 	return &MockOperationsStore_DeleteOperationsByStatus_Call{Call: _e.mock.On("DeleteOperationsByStatus", statuses)}
 }
 
@@ -1172,7 +1201,7 @@ type MockOperationsStore_DeleteSetting_Call struct {
 
 // DeleteSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockOperationsStore_Expecter) DeleteSetting(key interface{}) *MockOperationsStore_DeleteSetting_Call {
+func (_e *MockOperationsStore_Expecter) DeleteSetting(key any) *MockOperationsStore_DeleteSetting_Call {
 	return &MockOperationsStore_DeleteSetting_Call{Call: _e.mock.On("DeleteSetting", key)}
 }
 
@@ -1234,7 +1263,7 @@ type MockOperationsStore_FindAuthorByAlias_Call struct {
 
 // FindAuthorByAlias is a helper method to define mock.On call
 //   - aliasName string
-func (_e *MockOperationsStore_Expecter) FindAuthorByAlias(aliasName interface{}) *MockOperationsStore_FindAuthorByAlias_Call {
+func (_e *MockOperationsStore_Expecter) FindAuthorByAlias(aliasName any) *MockOperationsStore_FindAuthorByAlias_Call {
 	return &MockOperationsStore_FindAuthorByAlias_Call{Call: _e.mock.On("FindAuthorByAlias", aliasName)}
 }
 
@@ -1286,7 +1315,7 @@ type MockOperationsStore_FlagMetadataHashDuplicate_Call struct {
 // FlagMetadataHashDuplicate is a helper method to define mock.On call
 //   - primaryID string
 //   - duplicateID string
-func (_e *MockOperationsStore_Expecter) FlagMetadataHashDuplicate(primaryID interface{}, duplicateID interface{}) *MockOperationsStore_FlagMetadataHashDuplicate_Call {
+func (_e *MockOperationsStore_Expecter) FlagMetadataHashDuplicate(primaryID any, duplicateID any) *MockOperationsStore_FlagMetadataHashDuplicate_Call {
 	return &MockOperationsStore_FlagMetadataHashDuplicate_Call{Call: _e.mock.On("FlagMetadataHashDuplicate", primaryID, duplicateID)}
 }
 
@@ -1574,7 +1603,7 @@ type MockOperationsStore_GetAllBookSummaries_Call struct {
 // GetAllBookSummaries is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) GetAllBookSummaries(limit interface{}, offset interface{}) *MockOperationsStore_GetAllBookSummaries_Call {
+func (_e *MockOperationsStore_Expecter) GetAllBookSummaries(limit any, offset any) *MockOperationsStore_GetAllBookSummaries_Call {
 	return &MockOperationsStore_GetAllBookSummaries_Call{Call: _e.mock.On("GetAllBookSummaries", limit, offset)}
 }
 
@@ -1642,7 +1671,7 @@ type MockOperationsStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockOperationsStore_GetAllBooks_Call {
+func (_e *MockOperationsStore_Expecter) GetAllBooks(limit any, offset any) *MockOperationsStore_GetAllBooks_Call {
 	return &MockOperationsStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -1710,7 +1739,7 @@ type MockOperationsStore_GetAllBooksFrom_Call struct {
 // GetAllBooksFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockOperationsStore_GetAllBooksFrom_Call {
+func (_e *MockOperationsStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockOperationsStore_GetAllBooksFrom_Call {
 	return &MockOperationsStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
 }
 
@@ -1724,7 +1753,10 @@ func (_c *MockOperationsStore_GetAllBooksFrom_Call) Run(run func(afterID string,
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
-		run(arg0, arg1)
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
@@ -1734,7 +1766,7 @@ func (_c *MockOperationsStore_GetAllBooksFrom_Call) Return(books []database.Book
 	return _c
 }
 
-func (_c *MockOperationsStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockOperationsStore_GetAllBooksFrom_Call {
+func (_c *MockOperationsStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockOperationsStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1829,7 +1861,7 @@ type MockOperationsStore_GetAuthorAliases_Call struct {
 
 // GetAuthorAliases is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockOperationsStore_Expecter) GetAuthorAliases(authorID interface{}) *MockOperationsStore_GetAuthorAliases_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorAliases(authorID any) *MockOperationsStore_GetAuthorAliases_Call {
 	return &MockOperationsStore_GetAuthorAliases_Call{Call: _e.mock.On("GetAuthorAliases", authorID)}
 }
 
@@ -1891,7 +1923,7 @@ type MockOperationsStore_GetAuthorByID_Call struct {
 
 // GetAuthorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockOperationsStore_Expecter) GetAuthorByID(id interface{}) *MockOperationsStore_GetAuthorByID_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorByID(id any) *MockOperationsStore_GetAuthorByID_Call {
 	return &MockOperationsStore_GetAuthorByID_Call{Call: _e.mock.On("GetAuthorByID", id)}
 }
 
@@ -1953,7 +1985,7 @@ type MockOperationsStore_GetAuthorByName_Call struct {
 
 // GetAuthorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockOperationsStore_Expecter) GetAuthorByName(name interface{}) *MockOperationsStore_GetAuthorByName_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorByName(name any) *MockOperationsStore_GetAuthorByName_Call {
 	return &MockOperationsStore_GetAuthorByName_Call{Call: _e.mock.On("GetAuthorByName", name)}
 }
 
@@ -2013,7 +2045,7 @@ type MockOperationsStore_GetAuthorTombstone_Call struct {
 
 // GetAuthorTombstone is a helper method to define mock.On call
 //   - oldID int
-func (_e *MockOperationsStore_Expecter) GetAuthorTombstone(oldID interface{}) *MockOperationsStore_GetAuthorTombstone_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorTombstone(oldID any) *MockOperationsStore_GetAuthorTombstone_Call {
 	return &MockOperationsStore_GetAuthorTombstone_Call{Call: _e.mock.On("GetAuthorTombstone", oldID)}
 }
 
@@ -2076,7 +2108,7 @@ type MockOperationsStore_GetAuthorsByBookIDs_Call struct {
 // GetAuthorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockOperationsStore_Expecter) GetAuthorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockOperationsStore_GetAuthorsByBookIDs_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorsByBookIDs(ctx any, bookIDs any) *MockOperationsStore_GetAuthorsByBookIDs_Call {
 	return &MockOperationsStore_GetAuthorsByBookIDs_Call{Call: _e.mock.On("GetAuthorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -2143,7 +2175,7 @@ type MockOperationsStore_GetAuthorsByIDs_Call struct {
 
 // GetAuthorsByIDs is a helper method to define mock.On call
 //   - ids []int
-func (_e *MockOperationsStore_Expecter) GetAuthorsByIDs(ids interface{}) *MockOperationsStore_GetAuthorsByIDs_Call {
+func (_e *MockOperationsStore_Expecter) GetAuthorsByIDs(ids any) *MockOperationsStore_GetAuthorsByIDs_Call {
 	return &MockOperationsStore_GetAuthorsByIDs_Call{Call: _e.mock.On("GetAuthorsByIDs", ids)}
 }
 
@@ -2206,7 +2238,7 @@ type MockOperationsStore_GetBookAtVersion_Call struct {
 // GetBookAtVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockOperationsStore_Expecter) GetBookAtVersion(id interface{}, ts interface{}) *MockOperationsStore_GetBookAtVersion_Call {
+func (_e *MockOperationsStore_Expecter) GetBookAtVersion(id any, ts any) *MockOperationsStore_GetBookAtVersion_Call {
 	return &MockOperationsStore_GetBookAtVersion_Call{Call: _e.mock.On("GetBookAtVersion", id, ts)}
 }
 
@@ -2273,7 +2305,7 @@ type MockOperationsStore_GetBookAuthors_Call struct {
 
 // GetBookAuthors is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOperationsStore_Expecter) GetBookAuthors(bookID interface{}) *MockOperationsStore_GetBookAuthors_Call {
+func (_e *MockOperationsStore_Expecter) GetBookAuthors(bookID any) *MockOperationsStore_GetBookAuthors_Call {
 	return &MockOperationsStore_GetBookAuthors_Call{Call: _e.mock.On("GetBookAuthors", bookID)}
 }
 
@@ -2335,7 +2367,7 @@ type MockOperationsStore_GetBookByFileHash_Call struct {
 
 // GetBookByFileHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockOperationsStore_Expecter) GetBookByFileHash(hash interface{}) *MockOperationsStore_GetBookByFileHash_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByFileHash(hash any) *MockOperationsStore_GetBookByFileHash_Call {
 	return &MockOperationsStore_GetBookByFileHash_Call{Call: _e.mock.On("GetBookByFileHash", hash)}
 }
 
@@ -2397,7 +2429,7 @@ type MockOperationsStore_GetBookByFilePath_Call struct {
 
 // GetBookByFilePath is a helper method to define mock.On call
 //   - path string
-func (_e *MockOperationsStore_Expecter) GetBookByFilePath(path interface{}) *MockOperationsStore_GetBookByFilePath_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByFilePath(path any) *MockOperationsStore_GetBookByFilePath_Call {
 	return &MockOperationsStore_GetBookByFilePath_Call{Call: _e.mock.On("GetBookByFilePath", path)}
 }
 
@@ -2459,7 +2491,7 @@ type MockOperationsStore_GetBookByID_Call struct {
 
 // GetBookByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) GetBookByID(id interface{}) *MockOperationsStore_GetBookByID_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByID(id any) *MockOperationsStore_GetBookByID_Call {
 	return &MockOperationsStore_GetBookByID_Call{Call: _e.mock.On("GetBookByID", id)}
 }
 
@@ -2521,7 +2553,7 @@ type MockOperationsStore_GetBookByITunesPersistentID_Call struct {
 
 // GetBookByITunesPersistentID is a helper method to define mock.On call
 //   - persistentID string
-func (_e *MockOperationsStore_Expecter) GetBookByITunesPersistentID(persistentID interface{}) *MockOperationsStore_GetBookByITunesPersistentID_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByITunesPersistentID(persistentID any) *MockOperationsStore_GetBookByITunesPersistentID_Call {
 	return &MockOperationsStore_GetBookByITunesPersistentID_Call{Call: _e.mock.On("GetBookByITunesPersistentID", persistentID)}
 }
 
@@ -2583,7 +2615,7 @@ type MockOperationsStore_GetBookByOrganizedHash_Call struct {
 
 // GetBookByOrganizedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockOperationsStore_Expecter) GetBookByOrganizedHash(hash interface{}) *MockOperationsStore_GetBookByOrganizedHash_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByOrganizedHash(hash any) *MockOperationsStore_GetBookByOrganizedHash_Call {
 	return &MockOperationsStore_GetBookByOrganizedHash_Call{Call: _e.mock.On("GetBookByOrganizedHash", hash)}
 }
 
@@ -2645,7 +2677,7 @@ type MockOperationsStore_GetBookByOriginalHash_Call struct {
 
 // GetBookByOriginalHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockOperationsStore_Expecter) GetBookByOriginalHash(hash interface{}) *MockOperationsStore_GetBookByOriginalHash_Call {
+func (_e *MockOperationsStore_Expecter) GetBookByOriginalHash(hash any) *MockOperationsStore_GetBookByOriginalHash_Call {
 	return &MockOperationsStore_GetBookByOriginalHash_Call{Call: _e.mock.On("GetBookByOriginalHash", hash)}
 }
 
@@ -2707,7 +2739,7 @@ type MockOperationsStore_GetBookChanges_Call struct {
 
 // GetBookChanges is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOperationsStore_Expecter) GetBookChanges(bookID interface{}) *MockOperationsStore_GetBookChanges_Call {
+func (_e *MockOperationsStore_Expecter) GetBookChanges(bookID any) *MockOperationsStore_GetBookChanges_Call {
 	return &MockOperationsStore_GetBookChanges_Call{Call: _e.mock.On("GetBookChanges", bookID)}
 }
 
@@ -2771,7 +2803,7 @@ type MockOperationsStore_GetBookIDsByISBNASIN_Call struct {
 //   - isbn10 string
 //   - isbn13 string
 //   - asin string
-func (_e *MockOperationsStore_Expecter) GetBookIDsByISBNASIN(isbn10 interface{}, isbn13 interface{}, asin interface{}) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
+func (_e *MockOperationsStore_Expecter) GetBookIDsByISBNASIN(isbn10 any, isbn13 any, asin any) *MockOperationsStore_GetBookIDsByISBNASIN_Call {
 	return &MockOperationsStore_GetBookIDsByISBNASIN_Call{Call: _e.mock.On("GetBookIDsByISBNASIN", isbn10, isbn13, asin)}
 }
 
@@ -2843,7 +2875,7 @@ type MockOperationsStore_GetBookNarrators_Call struct {
 
 // GetBookNarrators is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOperationsStore_Expecter) GetBookNarrators(bookID interface{}) *MockOperationsStore_GetBookNarrators_Call {
+func (_e *MockOperationsStore_Expecter) GetBookNarrators(bookID any) *MockOperationsStore_GetBookNarrators_Call {
 	return &MockOperationsStore_GetBookNarrators_Call{Call: _e.mock.On("GetBookNarrators", bookID)}
 }
 
@@ -2906,7 +2938,7 @@ type MockOperationsStore_GetBookSnapshots_Call struct {
 // GetBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetBookSnapshots(id interface{}, limit interface{}) *MockOperationsStore_GetBookSnapshots_Call {
+func (_e *MockOperationsStore_Expecter) GetBookSnapshots(id any, limit any) *MockOperationsStore_GetBookSnapshots_Call {
 	return &MockOperationsStore_GetBookSnapshots_Call{Call: _e.mock.On("GetBookSnapshots", id, limit)}
 }
 
@@ -2973,7 +3005,7 @@ type MockOperationsStore_GetBookTombstone_Call struct {
 
 // GetBookTombstone is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) GetBookTombstone(id interface{}) *MockOperationsStore_GetBookTombstone_Call {
+func (_e *MockOperationsStore_Expecter) GetBookTombstone(id any) *MockOperationsStore_GetBookTombstone_Call {
 	return &MockOperationsStore_GetBookTombstone_Call{Call: _e.mock.On("GetBookTombstone", id)}
 }
 
@@ -3035,7 +3067,7 @@ type MockOperationsStore_GetBooksByAuthorID_Call struct {
 
 // GetBooksByAuthorID is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockOperationsStore_Expecter) GetBooksByAuthorID(authorID interface{}) *MockOperationsStore_GetBooksByAuthorID_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksByAuthorID(authorID any) *MockOperationsStore_GetBooksByAuthorID_Call {
 	return &MockOperationsStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
 }
 
@@ -3097,7 +3129,7 @@ type MockOperationsStore_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockOperationsStore_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockOperationsStore_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockOperationsStore_GetBooksByAuthorIDWithRole_Call {
 	return &MockOperationsStore_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -3159,7 +3191,7 @@ type MockOperationsStore_GetBooksByMetadataSourceHash_Call struct {
 
 // GetBooksByMetadataSourceHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockOperationsStore_Expecter) GetBooksByMetadataSourceHash(hash interface{}) *MockOperationsStore_GetBooksByMetadataSourceHash_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksByMetadataSourceHash(hash any) *MockOperationsStore_GetBooksByMetadataSourceHash_Call {
 	return &MockOperationsStore_GetBooksByMetadataSourceHash_Call{Call: _e.mock.On("GetBooksByMetadataSourceHash", hash)}
 }
 
@@ -3221,7 +3253,7 @@ type MockOperationsStore_GetBooksBySeriesID_Call struct {
 
 // GetBooksBySeriesID is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockOperationsStore_Expecter) GetBooksBySeriesID(seriesID interface{}) *MockOperationsStore_GetBooksBySeriesID_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksBySeriesID(seriesID any) *MockOperationsStore_GetBooksBySeriesID_Call {
 	return &MockOperationsStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
 }
 
@@ -3284,7 +3316,7 @@ type MockOperationsStore_GetBooksByTitleInDir_Call struct {
 // GetBooksByTitleInDir is a helper method to define mock.On call
 //   - normalizedTitle string
 //   - dirPath string
-func (_e *MockOperationsStore_Expecter) GetBooksByTitleInDir(normalizedTitle interface{}, dirPath interface{}) *MockOperationsStore_GetBooksByTitleInDir_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksByTitleInDir(normalizedTitle any, dirPath any) *MockOperationsStore_GetBooksByTitleInDir_Call {
 	return &MockOperationsStore_GetBooksByTitleInDir_Call{Call: _e.mock.On("GetBooksByTitleInDir", normalizedTitle, dirPath)}
 }
 
@@ -3351,7 +3383,7 @@ type MockOperationsStore_GetBooksByVersionGroup_Call struct {
 
 // GetBooksByVersionGroup is a helper method to define mock.On call
 //   - groupID string
-func (_e *MockOperationsStore_Expecter) GetBooksByVersionGroup(groupID interface{}) *MockOperationsStore_GetBooksByVersionGroup_Call {
+func (_e *MockOperationsStore_Expecter) GetBooksByVersionGroup(groupID any) *MockOperationsStore_GetBooksByVersionGroup_Call {
 	return &MockOperationsStore_GetBooksByVersionGroup_Call{Call: _e.mock.On("GetBooksByVersionGroup", groupID)}
 }
 
@@ -3578,7 +3610,7 @@ type MockOperationsStore_GetDuplicateBooksByMetadata_Call struct {
 
 // GetDuplicateBooksByMetadata is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockOperationsStore_Expecter) GetDuplicateBooksByMetadata(threshold interface{}) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
+func (_e *MockOperationsStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
 	return &MockOperationsStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
 }
 
@@ -3860,7 +3892,7 @@ type MockOperationsStore_GetNarratorByID_Call struct {
 
 // GetNarratorByID is a helper method to define mock.On call
 //   - id int
-func (_e *MockOperationsStore_Expecter) GetNarratorByID(id interface{}) *MockOperationsStore_GetNarratorByID_Call {
+func (_e *MockOperationsStore_Expecter) GetNarratorByID(id any) *MockOperationsStore_GetNarratorByID_Call {
 	return &MockOperationsStore_GetNarratorByID_Call{Call: _e.mock.On("GetNarratorByID", id)}
 }
 
@@ -3922,7 +3954,7 @@ type MockOperationsStore_GetNarratorByName_Call struct {
 
 // GetNarratorByName is a helper method to define mock.On call
 //   - name string
-func (_e *MockOperationsStore_Expecter) GetNarratorByName(name interface{}) *MockOperationsStore_GetNarratorByName_Call {
+func (_e *MockOperationsStore_Expecter) GetNarratorByName(name any) *MockOperationsStore_GetNarratorByName_Call {
 	return &MockOperationsStore_GetNarratorByName_Call{Call: _e.mock.On("GetNarratorByName", name)}
 }
 
@@ -3985,7 +4017,7 @@ type MockOperationsStore_GetNarratorsByBookIDs_Call struct {
 // GetNarratorsByBookIDs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - bookIDs []string
-func (_e *MockOperationsStore_Expecter) GetNarratorsByBookIDs(ctx interface{}, bookIDs interface{}) *MockOperationsStore_GetNarratorsByBookIDs_Call {
+func (_e *MockOperationsStore_Expecter) GetNarratorsByBookIDs(ctx any, bookIDs any) *MockOperationsStore_GetNarratorsByBookIDs_Call {
 	return &MockOperationsStore_GetNarratorsByBookIDs_Call{Call: _e.mock.On("GetNarratorsByBookIDs", ctx, bookIDs)}
 }
 
@@ -4053,7 +4085,7 @@ type MockOperationsStore_GetOpLogsV2_Call struct {
 // GetOpLogsV2 is a helper method to define mock.On call
 //   - opID string
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetOpLogsV2(opID interface{}, limit interface{}) *MockOperationsStore_GetOpLogsV2_Call {
+func (_e *MockOperationsStore_Expecter) GetOpLogsV2(opID any, limit any) *MockOperationsStore_GetOpLogsV2_Call {
 	return &MockOperationsStore_GetOpLogsV2_Call{Call: _e.mock.On("GetOpLogsV2", opID, limit)}
 }
 
@@ -4120,7 +4152,7 @@ type MockOperationsStore_GetOperationByID_Call struct {
 
 // GetOperationByID is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) GetOperationByID(id interface{}) *MockOperationsStore_GetOperationByID_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationByID(id any) *MockOperationsStore_GetOperationByID_Call {
 	return &MockOperationsStore_GetOperationByID_Call{Call: _e.mock.On("GetOperationByID", id)}
 }
 
@@ -4182,7 +4214,7 @@ type MockOperationsStore_GetOperationChanges_Call struct {
 
 // GetOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationsStore_Expecter) GetOperationChanges(operationID interface{}) *MockOperationsStore_GetOperationChanges_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationChanges(operationID any) *MockOperationsStore_GetOperationChanges_Call {
 	return &MockOperationsStore_GetOperationChanges_Call{Call: _e.mock.On("GetOperationChanges", operationID)}
 }
 
@@ -4244,7 +4276,7 @@ type MockOperationsStore_GetOperationLogs_Call struct {
 
 // GetOperationLogs is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationsStore_Expecter) GetOperationLogs(operationID interface{}) *MockOperationsStore_GetOperationLogs_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationLogs(operationID any) *MockOperationsStore_GetOperationLogs_Call {
 	return &MockOperationsStore_GetOperationLogs_Call{Call: _e.mock.On("GetOperationLogs", operationID)}
 }
 
@@ -4306,7 +4338,7 @@ type MockOperationsStore_GetOperationParams_Call struct {
 
 // GetOperationParams is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsStore_Expecter) GetOperationParams(opID interface{}) *MockOperationsStore_GetOperationParams_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationParams(opID any) *MockOperationsStore_GetOperationParams_Call {
 	return &MockOperationsStore_GetOperationParams_Call{Call: _e.mock.On("GetOperationParams", opID)}
 }
 
@@ -4368,7 +4400,7 @@ type MockOperationsStore_GetOperationResults_Call struct {
 
 // GetOperationResults is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationsStore_Expecter) GetOperationResults(operationID interface{}) *MockOperationsStore_GetOperationResults_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationResults(operationID any) *MockOperationsStore_GetOperationResults_Call {
 	return &MockOperationsStore_GetOperationResults_Call{Call: _e.mock.On("GetOperationResults", operationID)}
 }
 
@@ -4438,7 +4470,7 @@ type MockOperationsStore_GetOperationResultsPage_Call struct {
 //   - operationID string
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) GetOperationResultsPage(operationID interface{}, limit interface{}, offset interface{}) *MockOperationsStore_GetOperationResultsPage_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationResultsPage(operationID any, limit any, offset any) *MockOperationsStore_GetOperationResultsPage_Call {
 	return &MockOperationsStore_GetOperationResultsPage_Call{Call: _e.mock.On("GetOperationResultsPage", operationID, limit, offset)}
 }
 
@@ -4510,7 +4542,7 @@ type MockOperationsStore_GetOperationState_Call struct {
 
 // GetOperationState is a helper method to define mock.On call
 //   - opID string
-func (_e *MockOperationsStore_Expecter) GetOperationState(opID interface{}) *MockOperationsStore_GetOperationState_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationState(opID any) *MockOperationsStore_GetOperationState_Call {
 	return &MockOperationsStore_GetOperationState_Call{Call: _e.mock.On("GetOperationState", opID)}
 }
 
@@ -4572,7 +4604,7 @@ type MockOperationsStore_GetOperationSummaryLog_Call struct {
 
 // GetOperationSummaryLog is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) GetOperationSummaryLog(id interface{}) *MockOperationsStore_GetOperationSummaryLog_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationSummaryLog(id any) *MockOperationsStore_GetOperationSummaryLog_Call {
 	return &MockOperationsStore_GetOperationSummaryLog_Call{Call: _e.mock.On("GetOperationSummaryLog", id)}
 }
 
@@ -4634,7 +4666,7 @@ type MockOperationsStore_GetOperationV2_Call struct {
 
 // GetOperationV2 is a helper method to define mock.On call
 //   - id string
-func (_e *MockOperationsStore_Expecter) GetOperationV2(id interface{}) *MockOperationsStore_GetOperationV2_Call {
+func (_e *MockOperationsStore_Expecter) GetOperationV2(id any) *MockOperationsStore_GetOperationV2_Call {
 	return &MockOperationsStore_GetOperationV2_Call{Call: _e.mock.On("GetOperationV2", id)}
 }
 
@@ -4697,7 +4729,7 @@ type MockOperationsStore_GetQuarantinedBooks_Call struct {
 // GetQuarantinedBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) GetQuarantinedBooks(limit interface{}, offset interface{}) *MockOperationsStore_GetQuarantinedBooks_Call {
+func (_e *MockOperationsStore_Expecter) GetQuarantinedBooks(limit any, offset any) *MockOperationsStore_GetQuarantinedBooks_Call {
 	return &MockOperationsStore_GetQuarantinedBooks_Call{Call: _e.mock.On("GetQuarantinedBooks", limit, offset)}
 }
 
@@ -4764,7 +4796,7 @@ type MockOperationsStore_GetRecentCompletedOperations_Call struct {
 
 // GetRecentCompletedOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetRecentCompletedOperations(limit interface{}) *MockOperationsStore_GetRecentCompletedOperations_Call {
+func (_e *MockOperationsStore_Expecter) GetRecentCompletedOperations(limit any) *MockOperationsStore_GetRecentCompletedOperations_Call {
 	return &MockOperationsStore_GetRecentCompletedOperations_Call{Call: _e.mock.On("GetRecentCompletedOperations", limit)}
 }
 
@@ -4826,7 +4858,7 @@ type MockOperationsStore_GetRecentOperations_Call struct {
 
 // GetRecentOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetRecentOperations(limit interface{}) *MockOperationsStore_GetRecentOperations_Call {
+func (_e *MockOperationsStore_Expecter) GetRecentOperations(limit any) *MockOperationsStore_GetRecentOperations_Call {
 	return &MockOperationsStore_GetRecentOperations_Call{Call: _e.mock.On("GetRecentOperations", limit)}
 }
 
@@ -4886,7 +4918,7 @@ type MockOperationsStore_GetScanFailCount_Call struct {
 
 // GetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockOperationsStore_Expecter) GetScanFailCount(pathHash interface{}) *MockOperationsStore_GetScanFailCount_Call {
+func (_e *MockOperationsStore_Expecter) GetScanFailCount(pathHash any) *MockOperationsStore_GetScanFailCount_Call {
 	return &MockOperationsStore_GetScanFailCount_Call{Call: _e.mock.On("GetScanFailCount", pathHash)}
 }
 
@@ -4948,7 +4980,7 @@ type MockOperationsStore_GetSetting_Call struct {
 
 // GetSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockOperationsStore_Expecter) GetSetting(key interface{}) *MockOperationsStore_GetSetting_Call {
+func (_e *MockOperationsStore_Expecter) GetSetting(key any) *MockOperationsStore_GetSetting_Call {
 	return &MockOperationsStore_GetSetting_Call{Call: _e.mock.On("GetSetting", key)}
 }
 
@@ -5008,7 +5040,7 @@ type MockOperationsStore_IncrScanFailCount_Call struct {
 
 // IncrScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockOperationsStore_Expecter) IncrScanFailCount(pathHash interface{}) *MockOperationsStore_IncrScanFailCount_Call {
+func (_e *MockOperationsStore_Expecter) IncrScanFailCount(pathHash any) *MockOperationsStore_IncrScanFailCount_Call {
 	return &MockOperationsStore_IncrScanFailCount_Call{Call: _e.mock.On("IncrScanFailCount", pathHash)}
 }
 
@@ -5125,7 +5157,7 @@ type MockOperationsStore_ListBookTombstones_Call struct {
 
 // ListBookTombstones is a helper method to define mock.On call
 //   - limit int
-func (_e *MockOperationsStore_Expecter) ListBookTombstones(limit interface{}) *MockOperationsStore_ListBookTombstones_Call {
+func (_e *MockOperationsStore_Expecter) ListBookTombstones(limit any) *MockOperationsStore_ListBookTombstones_Call {
 	return &MockOperationsStore_ListBookTombstones_Call{Call: _e.mock.On("ListBookTombstones", limit)}
 }
 
@@ -5188,7 +5220,7 @@ type MockOperationsStore_ListBooksByITunesPID_Call struct {
 // ListBooksByITunesPID is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) ListBooksByITunesPID(limit interface{}, offset interface{}) *MockOperationsStore_ListBooksByITunesPID_Call {
+func (_e *MockOperationsStore_Expecter) ListBooksByITunesPID(limit any, offset any) *MockOperationsStore_ListBooksByITunesPID_Call {
 	return &MockOperationsStore_ListBooksByITunesPID_Call{Call: _e.mock.On("ListBooksByITunesPID", limit, offset)}
 }
 
@@ -5311,7 +5343,7 @@ type MockOperationsStore_ListOperationSummaryLogs_Call struct {
 // ListOperationSummaryLogs is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) ListOperationSummaryLogs(limit interface{}, offset interface{}) *MockOperationsStore_ListOperationSummaryLogs_Call {
+func (_e *MockOperationsStore_Expecter) ListOperationSummaryLogs(limit any, offset any) *MockOperationsStore_ListOperationSummaryLogs_Call {
 	return &MockOperationsStore_ListOperationSummaryLogs_Call{Call: _e.mock.On("ListOperationSummaryLogs", limit, offset)}
 }
 
@@ -5385,7 +5417,7 @@ type MockOperationsStore_ListOperations_Call struct {
 // ListOperations is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) ListOperations(limit interface{}, offset interface{}) *MockOperationsStore_ListOperations_Call {
+func (_e *MockOperationsStore_Expecter) ListOperations(limit any, offset any) *MockOperationsStore_ListOperations_Call {
 	return &MockOperationsStore_ListOperations_Call{Call: _e.mock.On("ListOperations", limit, offset)}
 }
 
@@ -5454,7 +5486,7 @@ type MockOperationsStore_ListSoftDeletedBooks_Call struct {
 //   - limit int
 //   - offset int
 //   - olderThan *time.Time
-func (_e *MockOperationsStore_Expecter) ListSoftDeletedBooks(limit interface{}, offset interface{}, olderThan interface{}) *MockOperationsStore_ListSoftDeletedBooks_Call {
+func (_e *MockOperationsStore_Expecter) ListSoftDeletedBooks(limit any, offset any, olderThan any) *MockOperationsStore_ListSoftDeletedBooks_Call {
 	return &MockOperationsStore_ListSoftDeletedBooks_Call{Call: _e.mock.On("ListSoftDeletedBooks", limit, offset, olderThan)}
 }
 
@@ -5524,7 +5556,7 @@ type MockOperationsStore_MarkITunesSynced_Call struct {
 
 // MarkITunesSynced is a helper method to define mock.On call
 //   - bookIDs []string
-func (_e *MockOperationsStore_Expecter) MarkITunesSynced(bookIDs interface{}) *MockOperationsStore_MarkITunesSynced_Call {
+func (_e *MockOperationsStore_Expecter) MarkITunesSynced(bookIDs any) *MockOperationsStore_MarkITunesSynced_Call {
 	return &MockOperationsStore_MarkITunesSynced_Call{Call: _e.mock.On("MarkITunesSynced", bookIDs)}
 }
 
@@ -5578,7 +5610,7 @@ type MockOperationsStore_MergeChapterBooks_Call struct {
 //   - srcIDs []string
 //   - commonTitle string
 //   - totalDuration float64
-func (_e *MockOperationsStore_Expecter) MergeChapterBooks(primaryID interface{}, srcIDs interface{}, commonTitle interface{}, totalDuration interface{}) *MockOperationsStore_MergeChapterBooks_Call {
+func (_e *MockOperationsStore_Expecter) MergeChapterBooks(primaryID any, srcIDs any, commonTitle any, totalDuration any) *MockOperationsStore_MergeChapterBooks_Call {
 	return &MockOperationsStore_MergeChapterBooks_Call{Call: _e.mock.On("MergeChapterBooks", primaryID, srcIDs, commonTitle, totalDuration)}
 }
 
@@ -5654,7 +5686,7 @@ type MockOperationsStore_PruneBookSnapshots_Call struct {
 // PruneBookSnapshots is a helper method to define mock.On call
 //   - id string
 //   - keepCount int
-func (_e *MockOperationsStore_Expecter) PruneBookSnapshots(id interface{}, keepCount interface{}) *MockOperationsStore_PruneBookSnapshots_Call {
+func (_e *MockOperationsStore_Expecter) PruneBookSnapshots(id any, keepCount any) *MockOperationsStore_PruneBookSnapshots_Call {
 	return &MockOperationsStore_PruneBookSnapshots_Call{Call: _e.mock.On("PruneBookSnapshots", id, keepCount)}
 }
 
@@ -5719,7 +5751,7 @@ type MockOperationsStore_PruneOperationChanges_Call struct {
 
 // PruneOperationChanges is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockOperationsStore_Expecter) PruneOperationChanges(olderThan interface{}) *MockOperationsStore_PruneOperationChanges_Call {
+func (_e *MockOperationsStore_Expecter) PruneOperationChanges(olderThan any) *MockOperationsStore_PruneOperationChanges_Call {
 	return &MockOperationsStore_PruneOperationChanges_Call{Call: _e.mock.On("PruneOperationChanges", olderThan)}
 }
 
@@ -5779,7 +5811,7 @@ type MockOperationsStore_PruneOperationLogs_Call struct {
 
 // PruneOperationLogs is a helper method to define mock.On call
 //   - olderThan time.Time
-func (_e *MockOperationsStore_Expecter) PruneOperationLogs(olderThan interface{}) *MockOperationsStore_PruneOperationLogs_Call {
+func (_e *MockOperationsStore_Expecter) PruneOperationLogs(olderThan any) *MockOperationsStore_PruneOperationLogs_Call {
 	return &MockOperationsStore_PruneOperationLogs_Call{Call: _e.mock.On("PruneOperationLogs", olderThan)}
 }
 
@@ -5830,7 +5862,7 @@ type MockOperationsStore_RecomputeBookAggregates_Call struct {
 
 // RecomputeBookAggregates is a helper method to define mock.On call
 //   - bookID string
-func (_e *MockOperationsStore_Expecter) RecomputeBookAggregates(bookID interface{}) *MockOperationsStore_RecomputeBookAggregates_Call {
+func (_e *MockOperationsStore_Expecter) RecomputeBookAggregates(bookID any) *MockOperationsStore_RecomputeBookAggregates_Call {
 	return &MockOperationsStore_RecomputeBookAggregates_Call{Call: _e.mock.On("RecomputeBookAggregates", bookID)}
 }
 
@@ -5881,7 +5913,7 @@ type MockOperationsStore_ResetScanFailCount_Call struct {
 
 // ResetScanFailCount is a helper method to define mock.On call
 //   - pathHash string
-func (_e *MockOperationsStore_Expecter) ResetScanFailCount(pathHash interface{}) *MockOperationsStore_ResetScanFailCount_Call {
+func (_e *MockOperationsStore_Expecter) ResetScanFailCount(pathHash any) *MockOperationsStore_ResetScanFailCount_Call {
 	return &MockOperationsStore_ResetScanFailCount_Call{Call: _e.mock.On("ResetScanFailCount", pathHash)}
 }
 
@@ -5997,7 +6029,7 @@ type MockOperationsStore_RevertBookToVersion_Call struct {
 // RevertBookToVersion is a helper method to define mock.On call
 //   - id string
 //   - ts time.Time
-func (_e *MockOperationsStore_Expecter) RevertBookToVersion(id interface{}, ts interface{}) *MockOperationsStore_RevertBookToVersion_Call {
+func (_e *MockOperationsStore_Expecter) RevertBookToVersion(id any, ts any) *MockOperationsStore_RevertBookToVersion_Call {
 	return &MockOperationsStore_RevertBookToVersion_Call{Call: _e.mock.On("RevertBookToVersion", id, ts)}
 }
 
@@ -6053,7 +6085,7 @@ type MockOperationsStore_RevertOperationChanges_Call struct {
 
 // RevertOperationChanges is a helper method to define mock.On call
 //   - operationID string
-func (_e *MockOperationsStore_Expecter) RevertOperationChanges(operationID interface{}) *MockOperationsStore_RevertOperationChanges_Call {
+func (_e *MockOperationsStore_Expecter) RevertOperationChanges(operationID any) *MockOperationsStore_RevertOperationChanges_Call {
 	return &MockOperationsStore_RevertOperationChanges_Call{Call: _e.mock.On("RevertOperationChanges", operationID)}
 }
 
@@ -6105,7 +6137,7 @@ type MockOperationsStore_SaveOperationParams_Call struct {
 // SaveOperationParams is a helper method to define mock.On call
 //   - opID string
 //   - params []byte
-func (_e *MockOperationsStore_Expecter) SaveOperationParams(opID interface{}, params interface{}) *MockOperationsStore_SaveOperationParams_Call {
+func (_e *MockOperationsStore_Expecter) SaveOperationParams(opID any, params any) *MockOperationsStore_SaveOperationParams_Call {
 	return &MockOperationsStore_SaveOperationParams_Call{Call: _e.mock.On("SaveOperationParams", opID, params)}
 }
 
@@ -6162,7 +6194,7 @@ type MockOperationsStore_SaveOperationState_Call struct {
 // SaveOperationState is a helper method to define mock.On call
 //   - opID string
 //   - state []byte
-func (_e *MockOperationsStore_Expecter) SaveOperationState(opID interface{}, state interface{}) *MockOperationsStore_SaveOperationState_Call {
+func (_e *MockOperationsStore_Expecter) SaveOperationState(opID any, state any) *MockOperationsStore_SaveOperationState_Call {
 	return &MockOperationsStore_SaveOperationState_Call{Call: _e.mock.On("SaveOperationState", opID, state)}
 }
 
@@ -6218,7 +6250,7 @@ type MockOperationsStore_SaveOperationSummaryLog_Call struct {
 
 // SaveOperationSummaryLog is a helper method to define mock.On call
 //   - op *database.OperationSummaryLog
-func (_e *MockOperationsStore_Expecter) SaveOperationSummaryLog(op interface{}) *MockOperationsStore_SaveOperationSummaryLog_Call {
+func (_e *MockOperationsStore_Expecter) SaveOperationSummaryLog(op any) *MockOperationsStore_SaveOperationSummaryLog_Call {
 	return &MockOperationsStore_SaveOperationSummaryLog_Call{Call: _e.mock.On("SaveOperationSummaryLog", op)}
 }
 
@@ -6282,7 +6314,7 @@ type MockOperationsStore_SearchBooks_Call struct {
 //   - query string
 //   - limit int
 //   - offset int
-func (_e *MockOperationsStore_Expecter) SearchBooks(query interface{}, limit interface{}, offset interface{}) *MockOperationsStore_SearchBooks_Call {
+func (_e *MockOperationsStore_Expecter) SearchBooks(query any, limit any, offset any) *MockOperationsStore_SearchBooks_Call {
 	return &MockOperationsStore_SearchBooks_Call{Call: _e.mock.On("SearchBooks", query, limit, offset)}
 }
 
@@ -6344,7 +6376,7 @@ type MockOperationsStore_SetBookAuthors_Call struct {
 // SetBookAuthors is a helper method to define mock.On call
 //   - bookID string
 //   - authors []database.BookAuthor
-func (_e *MockOperationsStore_Expecter) SetBookAuthors(bookID interface{}, authors interface{}) *MockOperationsStore_SetBookAuthors_Call {
+func (_e *MockOperationsStore_Expecter) SetBookAuthors(bookID any, authors any) *MockOperationsStore_SetBookAuthors_Call {
 	return &MockOperationsStore_SetBookAuthors_Call{Call: _e.mock.On("SetBookAuthors", bookID, authors)}
 }
 
@@ -6401,7 +6433,7 @@ type MockOperationsStore_SetBookNarrators_Call struct {
 // SetBookNarrators is a helper method to define mock.On call
 //   - bookID string
 //   - narrators []database.BookNarrator
-func (_e *MockOperationsStore_Expecter) SetBookNarrators(bookID interface{}, narrators interface{}) *MockOperationsStore_SetBookNarrators_Call {
+func (_e *MockOperationsStore_Expecter) SetBookNarrators(bookID any, narrators any) *MockOperationsStore_SetBookNarrators_Call {
 	return &MockOperationsStore_SetBookNarrators_Call{Call: _e.mock.On("SetBookNarrators", bookID, narrators)}
 }
 
@@ -6458,7 +6490,7 @@ type MockOperationsStore_SetLastWrittenAt_Call struct {
 // SetLastWrittenAt is a helper method to define mock.On call
 //   - id string
 //   - t time.Time
-func (_e *MockOperationsStore_Expecter) SetLastWrittenAt(id interface{}, t interface{}) *MockOperationsStore_SetLastWrittenAt_Call {
+func (_e *MockOperationsStore_Expecter) SetLastWrittenAt(id any, t any) *MockOperationsStore_SetLastWrittenAt_Call {
 	return &MockOperationsStore_SetLastWrittenAt_Call{Call: _e.mock.On("SetLastWrittenAt", id, t)}
 }
 
@@ -6517,7 +6549,7 @@ type MockOperationsStore_SetSetting_Call struct {
 //   - value string
 //   - typ string
 //   - isSecret bool
-func (_e *MockOperationsStore_Expecter) SetSetting(key interface{}, value interface{}, typ interface{}, isSecret interface{}) *MockOperationsStore_SetSetting_Call {
+func (_e *MockOperationsStore_Expecter) SetSetting(key any, value any, typ any, isSecret any) *MockOperationsStore_SetSetting_Call {
 	return &MockOperationsStore_SetSetting_Call{Call: _e.mock.On("SetSetting", key, value, typ, isSecret)}
 }
 
@@ -6584,7 +6616,7 @@ type MockOperationsStore_UpdateAuthorName_Call struct {
 // UpdateAuthorName is a helper method to define mock.On call
 //   - id int
 //   - name string
-func (_e *MockOperationsStore_Expecter) UpdateAuthorName(id interface{}, name interface{}) *MockOperationsStore_UpdateAuthorName_Call {
+func (_e *MockOperationsStore_Expecter) UpdateAuthorName(id any, name any) *MockOperationsStore_UpdateAuthorName_Call {
 	return &MockOperationsStore_UpdateAuthorName_Call{Call: _e.mock.On("UpdateAuthorName", id, name)}
 }
 
@@ -6652,7 +6684,7 @@ type MockOperationsStore_UpdateBook_Call struct {
 // UpdateBook is a helper method to define mock.On call
 //   - id string
 //   - book *database.Book
-func (_e *MockOperationsStore_Expecter) UpdateBook(id interface{}, book interface{}) *MockOperationsStore_UpdateBook_Call {
+func (_e *MockOperationsStore_Expecter) UpdateBook(id any, book any) *MockOperationsStore_UpdateBook_Call {
 	return &MockOperationsStore_UpdateBook_Call{Call: _e.mock.On("UpdateBook", id, book)}
 }
 
@@ -6709,7 +6741,7 @@ type MockOperationsStore_UpdateBookRating_Call struct {
 // UpdateBookRating is a helper method to define mock.On call
 //   - id string
 //   - req database.UpdateBookRatingRequest
-func (_e *MockOperationsStore_Expecter) UpdateBookRating(id interface{}, req interface{}) *MockOperationsStore_UpdateBookRating_Call {
+func (_e *MockOperationsStore_Expecter) UpdateBookRating(id any, req any) *MockOperationsStore_UpdateBookRating_Call {
 	return &MockOperationsStore_UpdateBookRating_Call{Call: _e.mock.On("UpdateBookRating", id, req)}
 }
 
@@ -6766,7 +6798,7 @@ type MockOperationsStore_UpdateOperationError_Call struct {
 // UpdateOperationError is a helper method to define mock.On call
 //   - id string
 //   - errorMessage string
-func (_e *MockOperationsStore_Expecter) UpdateOperationError(id interface{}, errorMessage interface{}) *MockOperationsStore_UpdateOperationError_Call {
+func (_e *MockOperationsStore_Expecter) UpdateOperationError(id any, errorMessage any) *MockOperationsStore_UpdateOperationError_Call {
 	return &MockOperationsStore_UpdateOperationError_Call{Call: _e.mock.On("UpdateOperationError", id, errorMessage)}
 }
 
@@ -6823,7 +6855,7 @@ type MockOperationsStore_UpdateOperationResultData_Call struct {
 // UpdateOperationResultData is a helper method to define mock.On call
 //   - id string
 //   - resultData string
-func (_e *MockOperationsStore_Expecter) UpdateOperationResultData(id interface{}, resultData interface{}) *MockOperationsStore_UpdateOperationResultData_Call {
+func (_e *MockOperationsStore_Expecter) UpdateOperationResultData(id any, resultData any) *MockOperationsStore_UpdateOperationResultData_Call {
 	return &MockOperationsStore_UpdateOperationResultData_Call{Call: _e.mock.On("UpdateOperationResultData", id, resultData)}
 }
 
@@ -6883,7 +6915,7 @@ type MockOperationsStore_UpdateOperationStatus_Call struct {
 //   - progress int
 //   - total int
 //   - message string
-func (_e *MockOperationsStore_Expecter) UpdateOperationStatus(id interface{}, status interface{}, progress interface{}, total interface{}, message interface{}) *MockOperationsStore_UpdateOperationStatus_Call {
+func (_e *MockOperationsStore_Expecter) UpdateOperationStatus(id any, status any, progress any, total any, message any) *MockOperationsStore_UpdateOperationStatus_Call {
 	return &MockOperationsStore_UpdateOperationStatus_Call{Call: _e.mock.On("UpdateOperationStatus", id, status, progress, total, message)}
 }
 

--- a/internal/server/handlers/operations/mocks/mock_scan_canceler.go
+++ b/internal/server/handlers/operations/mocks/mock_scan_canceler.go
@@ -59,7 +59,7 @@ type MockScanCanceler_CancelScan_Call struct {
 
 // CancelScan is a helper method to define mock.On call
 //   - scanID int
-func (_e *MockScanCanceler_Expecter) CancelScan(scanID interface{}) *MockScanCanceler_CancelScan_Call {
+func (_e *MockScanCanceler_Expecter) CancelScan(scanID any) *MockScanCanceler_CancelScan_Call {
 	return &MockScanCanceler_CancelScan_Call{Call: _e.mock.On("CancelScan", scanID)}
 }
 

--- a/internal/server/handlers/operations/mocks/mock_scheduler.go
+++ b/internal/server/handlers/operations/mocks/mock_scheduler.go
@@ -197,7 +197,7 @@ type MockScheduler_RunMaintenanceWindow_Call struct {
 
 // RunMaintenanceWindow is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockScheduler_Expecter) RunMaintenanceWindow(ctx interface{}) *MockScheduler_RunMaintenanceWindow_Call {
+func (_e *MockScheduler_Expecter) RunMaintenanceWindow(ctx any) *MockScheduler_RunMaintenanceWindow_Call {
 	return &MockScheduler_RunMaintenanceWindow_Call{Call: _e.mock.On("RunMaintenanceWindow", ctx)}
 }
 
@@ -259,7 +259,7 @@ type MockScheduler_RunTaskManual_Call struct {
 
 // RunTaskManual is a helper method to define mock.On call
 //   - name string
-func (_e *MockScheduler_Expecter) RunTaskManual(name interface{}) *MockScheduler_RunTaskManual_Call {
+func (_e *MockScheduler_Expecter) RunTaskManual(name any) *MockScheduler_RunTaskManual_Call {
 	return &MockScheduler_RunTaskManual_Call{Call: _e.mock.On("RunTaskManual", name)}
 }
 

--- a/internal/server/handlers/system/mocks/mock_config_update_service.go
+++ b/internal/server/handlers/system/mocks/mock_config_update_service.go
@@ -60,7 +60,7 @@ type MockConfigUpdateService_MaskSecrets_Call struct {
 
 // MaskSecrets is a helper method to define mock.On call
 //   - cfg config.Config
-func (_e *MockConfigUpdateService_Expecter) MaskSecrets(cfg interface{}) *MockConfigUpdateService_MaskSecrets_Call {
+func (_e *MockConfigUpdateService_Expecter) MaskSecrets(cfg any) *MockConfigUpdateService_MaskSecrets_Call {
 	return &MockConfigUpdateService_MaskSecrets_Call{Call: _e.mock.On("MaskSecrets", cfg)}
 }
 
@@ -122,7 +122,7 @@ type MockConfigUpdateService_UpdateConfig_Call struct {
 
 // UpdateConfig is a helper method to define mock.On call
 //   - payload map[string]any
-func (_e *MockConfigUpdateService_Expecter) UpdateConfig(payload interface{}) *MockConfigUpdateService_UpdateConfig_Call {
+func (_e *MockConfigUpdateService_Expecter) UpdateConfig(payload any) *MockConfigUpdateService_UpdateConfig_Call {
 	return &MockConfigUpdateService_UpdateConfig_Call{Call: _e.mock.On("UpdateConfig", payload)}
 }
 

--- a/internal/server/handlers/system/mocks/mock_event_streamer.go
+++ b/internal/server/handlers/system/mocks/mock_event_streamer.go
@@ -49,7 +49,7 @@ type MockEventStreamer_HandleSSE_Call struct {
 
 // HandleSSE is a helper method to define mock.On call
 //   - c *gin.Context
-func (_e *MockEventStreamer_Expecter) HandleSSE(c interface{}) *MockEventStreamer_HandleSSE_Call {
+func (_e *MockEventStreamer_Expecter) HandleSSE(c any) *MockEventStreamer_HandleSSE_Call {
 	return &MockEventStreamer_HandleSSE_Call{Call: _e.mock.On("HandleSSE", c)}
 }
 

--- a/internal/server/handlers/system/mocks/mock_operation_logs_provider.go
+++ b/internal/server/handlers/system/mocks/mock_operation_logs_provider.go
@@ -49,7 +49,7 @@ type MockOperationLogsProvider_GetOperationLogs_Call struct {
 
 // GetOperationLogs is a helper method to define mock.On call
 //   - c *gin.Context
-func (_e *MockOperationLogsProvider_Expecter) GetOperationLogs(c interface{}) *MockOperationLogsProvider_GetOperationLogs_Call {
+func (_e *MockOperationLogsProvider_Expecter) GetOperationLogs(c any) *MockOperationLogsProvider_GetOperationLogs_Call {
 	return &MockOperationLogsProvider_GetOperationLogs_Call{Call: _e.mock.On("GetOperationLogs", c)}
 }
 

--- a/internal/server/handlers/system/mocks/mock_system_service.go
+++ b/internal/server/handlers/system/mocks/mock_system_service.go
@@ -80,7 +80,7 @@ type MockSystemService_CollectSystemLogs_Call struct {
 //   - search string
 //   - limit int
 //   - offset int
-func (_e *MockSystemService_Expecter) CollectSystemLogs(level interface{}, search interface{}, limit interface{}, offset interface{}) *MockSystemService_CollectSystemLogs_Call {
+func (_e *MockSystemService_Expecter) CollectSystemLogs(level any, search any, limit any, offset any) *MockSystemService_CollectSystemLogs_Call {
 	return &MockSystemService_CollectSystemLogs_Call{Call: _e.mock.On("CollectSystemLogs", level, search, limit, offset)}
 }
 

--- a/internal/server/handlers/system/mocks/mock_system_store.go
+++ b/internal/server/handlers/system/mocks/mock_system_store.go
@@ -61,7 +61,7 @@ type MockSystemStore_AddBlockedHash_Call struct {
 // AddBlockedHash is a helper method to define mock.On call
 //   - hash string
 //   - reason string
-func (_e *MockSystemStore_Expecter) AddBlockedHash(hash interface{}, reason interface{}) *MockSystemStore_AddBlockedHash_Call {
+func (_e *MockSystemStore_Expecter) AddBlockedHash(hash any, reason any) *MockSystemStore_AddBlockedHash_Call {
 	return &MockSystemStore_AddBlockedHash_Call{Call: _e.mock.On("AddBlockedHash", hash, reason)}
 }
 
@@ -172,29 +172,29 @@ func (_mock *MockSystemStore) CountPrimaryBooks() (int, error) {
 	return r0, r1
 }
 
-// MockSystemStore_CountBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
-type MockSystemStore_CountBooks_Call struct {
+// MockSystemStore_CountPrimaryBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPrimaryBooks'
+type MockSystemStore_CountPrimaryBooks_Call struct {
 	*mock.Call
 }
 
 // CountPrimaryBooks is a helper method to define mock.On call
-func (_e *MockSystemStore_Expecter) CountPrimaryBooks() *MockSystemStore_CountBooks_Call {
-	return &MockSystemStore_CountBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
+func (_e *MockSystemStore_Expecter) CountPrimaryBooks() *MockSystemStore_CountPrimaryBooks_Call {
+	return &MockSystemStore_CountPrimaryBooks_Call{Call: _e.mock.On("CountPrimaryBooks")}
 }
 
-func (_c *MockSystemStore_CountBooks_Call) Run(run func()) *MockSystemStore_CountBooks_Call {
+func (_c *MockSystemStore_CountPrimaryBooks_Call) Run(run func()) *MockSystemStore_CountPrimaryBooks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockSystemStore_CountBooks_Call) Return(n int, err error) *MockSystemStore_CountBooks_Call {
+func (_c *MockSystemStore_CountPrimaryBooks_Call) Return(n int, err error) *MockSystemStore_CountPrimaryBooks_Call {
 	_c.Call.Return(n, err)
 	return _c
 }
 
-func (_c *MockSystemStore_CountBooks_Call) RunAndReturn(run func() (int, error)) *MockSystemStore_CountBooks_Call {
+func (_c *MockSystemStore_CountPrimaryBooks_Call) RunAndReturn(run func() (int, error)) *MockSystemStore_CountPrimaryBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -276,7 +276,7 @@ type MockSystemStore_DeleteSetting_Call struct {
 
 // DeleteSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockSystemStore_Expecter) DeleteSetting(key interface{}) *MockSystemStore_DeleteSetting_Call {
+func (_e *MockSystemStore_Expecter) DeleteSetting(key any) *MockSystemStore_DeleteSetting_Call {
 	return &MockSystemStore_DeleteSetting_Call{Call: _e.mock.On("DeleteSetting", key)}
 }
 
@@ -449,7 +449,7 @@ type MockSystemStore_GetAllBooks_Call struct {
 // GetAllBooks is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockSystemStore_Expecter) GetAllBooks(limit interface{}, offset interface{}) *MockSystemStore_GetAllBooks_Call {
+func (_e *MockSystemStore_Expecter) GetAllBooks(limit any, offset any) *MockSystemStore_GetAllBooks_Call {
 	return &MockSystemStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
 }
 
@@ -477,50 +477,6 @@ func (_c *MockSystemStore_GetAllBooks_Call) Return(books []database.Book, err er
 }
 
 func (_c *MockSystemStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockSystemStore_GetAllBooks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAllBooksFrom provides a mock function for the type MockSystemStore
-func (_mock *MockSystemStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
-	ret := _mock.Called(afterID, limit)
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
-	}
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int) ([]database.Book, error)); ok {
-		return returnFunc(afterID, limit)
-	}
-	if returnFunc, ok := ret.Get(0).(func(string, int) []database.Book); ok {
-		r0 = returnFunc(afterID, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(string, int) error); ok {
-		r1 = returnFunc(afterID, limit)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-type MockSystemStore_GetAllBooksFrom_Call struct{ *mock.Call }
-
-func (_e *MockSystemStore_Expecter) GetAllBooksFrom(afterID interface{}, limit interface{}) *MockSystemStore_GetAllBooksFrom_Call {
-	return &MockSystemStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
-}
-func (_c *MockSystemStore_GetAllBooksFrom_Call) Run(run func(string, int)) *MockSystemStore_GetAllBooksFrom_Call {
-	_c.Call.Run(func(args mock.Arguments) { run(args[0].(string), args[1].(int)) })
-	return _c
-}
-func (_c *MockSystemStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockSystemStore_GetAllBooksFrom_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-func (_c *MockSystemStore_GetAllBooksFrom_Call) RunAndReturn(run func(string, int) ([]database.Book, error)) *MockSystemStore_GetAllBooksFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -615,7 +571,7 @@ type MockSystemStore_GetBooksByAuthorIDWithRole_Call struct {
 
 // GetBooksByAuthorIDWithRole is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockSystemStore_Expecter) GetBooksByAuthorIDWithRole(authorID interface{}) *MockSystemStore_GetBooksByAuthorIDWithRole_Call {
+func (_e *MockSystemStore_Expecter) GetBooksByAuthorIDWithRole(authorID any) *MockSystemStore_GetBooksByAuthorIDWithRole_Call {
 	return &MockSystemStore_GetBooksByAuthorIDWithRole_Call{Call: _e.mock.On("GetBooksByAuthorIDWithRole", authorID)}
 }
 
@@ -732,7 +688,7 @@ type MockSystemStore_GetRecentOperations_Call struct {
 
 // GetRecentOperations is a helper method to define mock.On call
 //   - limit int
-func (_e *MockSystemStore_Expecter) GetRecentOperations(limit interface{}) *MockSystemStore_GetRecentOperations_Call {
+func (_e *MockSystemStore_Expecter) GetRecentOperations(limit any) *MockSystemStore_GetRecentOperations_Call {
 	return &MockSystemStore_GetRecentOperations_Call{Call: _e.mock.On("GetRecentOperations", limit)}
 }
 
@@ -794,7 +750,7 @@ type MockSystemStore_GetSetting_Call struct {
 
 // GetSetting is a helper method to define mock.On call
 //   - key string
-func (_e *MockSystemStore_Expecter) GetSetting(key interface{}) *MockSystemStore_GetSetting_Call {
+func (_e *MockSystemStore_Expecter) GetSetting(key any) *MockSystemStore_GetSetting_Call {
 	return &MockSystemStore_GetSetting_Call{Call: _e.mock.On("GetSetting", key)}
 }
 
@@ -857,7 +813,7 @@ type MockSystemStore_GetSystemActivityLogs_Call struct {
 // GetSystemActivityLogs is a helper method to define mock.On call
 //   - source string
 //   - limit int
-func (_e *MockSystemStore_Expecter) GetSystemActivityLogs(source interface{}, limit interface{}) *MockSystemStore_GetSystemActivityLogs_Call {
+func (_e *MockSystemStore_Expecter) GetSystemActivityLogs(source any, limit any) *MockSystemStore_GetSystemActivityLogs_Call {
 	return &MockSystemStore_GetSystemActivityLogs_Call{Call: _e.mock.On("GetSystemActivityLogs", source, limit)}
 }
 
@@ -924,7 +880,7 @@ type MockSystemStore_GetUserPreference_Call struct {
 
 // GetUserPreference is a helper method to define mock.On call
 //   - key string
-func (_e *MockSystemStore_Expecter) GetUserPreference(key interface{}) *MockSystemStore_GetUserPreference_Call {
+func (_e *MockSystemStore_Expecter) GetUserPreference(key any) *MockSystemStore_GetUserPreference_Call {
 	return &MockSystemStore_GetUserPreference_Call{Call: _e.mock.On("GetUserPreference", key)}
 }
 
@@ -1008,7 +964,7 @@ type MockSystemStore_RemoveBlockedHash_Call struct {
 
 // RemoveBlockedHash is a helper method to define mock.On call
 //   - hash string
-func (_e *MockSystemStore_Expecter) RemoveBlockedHash(hash interface{}) *MockSystemStore_RemoveBlockedHash_Call {
+func (_e *MockSystemStore_Expecter) RemoveBlockedHash(hash any) *MockSystemStore_RemoveBlockedHash_Call {
 	return &MockSystemStore_RemoveBlockedHash_Call{Call: _e.mock.On("RemoveBlockedHash", hash)}
 }
 
@@ -1106,7 +1062,7 @@ type MockSystemStore_SetSetting_Call struct {
 //   - value string
 //   - typ string
 //   - isSecret bool
-func (_e *MockSystemStore_Expecter) SetSetting(key interface{}, value interface{}, typ interface{}, isSecret interface{}) *MockSystemStore_SetSetting_Call {
+func (_e *MockSystemStore_Expecter) SetSetting(key any, value any, typ any, isSecret any) *MockSystemStore_SetSetting_Call {
 	return &MockSystemStore_SetSetting_Call{Call: _e.mock.On("SetSetting", key, value, typ, isSecret)}
 }
 
@@ -1173,7 +1129,7 @@ type MockSystemStore_SetUserPreference_Call struct {
 // SetUserPreference is a helper method to define mock.On call
 //   - key string
 //   - value string
-func (_e *MockSystemStore_Expecter) SetUserPreference(key interface{}, value interface{}) *MockSystemStore_SetUserPreference_Call {
+func (_e *MockSystemStore_Expecter) SetUserPreference(key any, value any) *MockSystemStore_SetUserPreference_Call {
 	return &MockSystemStore_SetUserPreference_Call{Call: _e.mock.On("SetUserPreference", key, value)}
 }
 

--- a/web/src/components/audiobooks/MetadataReviewDialog.tsx
+++ b/web/src/components/audiobooks/MetadataReviewDialog.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/audiobooks/MetadataReviewDialog.tsx
-// version: 1.12.0
+// version: 1.13.0
 // guid: e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b
+// last-edited: 2026-07-01
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -171,6 +172,8 @@ export function MetadataReviewDialog({
   const [hideSkipped, setHideSkipped] = useState(false);
   const [matchLanguage, setMatchLanguage] = useState<boolean>(loadLanguageFilter);
   const [titleFilter, setTitleFilter] = useState('');
+  const [onlyWithTranscription, setOnlyWithTranscription] = useState(false);
+  const [onlyTranscriptionMatched, setOnlyTranscriptionMatched] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   // Books in this set have been manually split from their duplicate group and
   // render as standalone rows. Reset when the page changes.
@@ -289,12 +292,16 @@ export function MetadataReviewDialog({
       const candLang = normalizeLanguage(r.candidate.language);
       if (!bookLang || !candLang) return true;
       return bookLang === candLang;
-    });
+    })
+    // Transcription filters: optional narrow-down to books where Whisper
+    // intro data exists, and/or where it was the deciding scoring factor.
+    .filter((r) => !onlyWithTranscription || !!r.book.transcribed_title)
+    .filter((r) => !onlyTranscriptionMatched || !!r.candidate?.transcription_boosted);
 
   // Reset to page 1 when filters change so the user sees the first filtered result.
   useEffect(() => {
     setServerPage(1);
-  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideSkipped, hideNoMatch, matchLanguage, titleFilter]);
+  }, [sourceFilter, confidenceThreshold, hideApplied, hideRejected, hideSkipped, hideNoMatch, matchLanguage, titleFilter, onlyWithTranscription, onlyTranscriptionMatched]);
 
   // Go back to page 1 on manual refresh.
   useEffect(() => {
@@ -1388,6 +1395,30 @@ export function MetadataReviewDialog({
                       />
                     }
                     label={<Typography variant="body2">Match Language</Typography>}
+                  />
+                </Tooltip>
+                <Tooltip title="Show only books that have Whisper-transcribed intro data (title extracted from audio).">
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        size="small"
+                        checked={onlyWithTranscription}
+                        onChange={(e) => setOnlyWithTranscription(e.target.checked)}
+                      />
+                    }
+                    label={<Typography variant="body2">Has Transcription</Typography>}
+                  />
+                </Tooltip>
+                <Tooltip title="Show only books where the candidate score was boosted by matching the Whisper-transcribed title, author, or narrator.">
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        size="small"
+                        checked={onlyTranscriptionMatched}
+                        onChange={(e) => setOnlyTranscriptionMatched(e.target.checked)}
+                      />
+                    }
+                    label={<Typography variant="body2">Transcription Matched</Typography>}
                   />
                 </Tooltip>
               </Stack>

--- a/web/src/components/library/LibraryToolbar.tsx
+++ b/web/src/components/library/LibraryToolbar.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryToolbar.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 import {
   Typography,
@@ -162,7 +162,7 @@ export const LibraryToolbar = ({
           <Button variant="outlined" size="small" startIcon={organizeRunning ? <CircularProgress size={16} /> : undefined} disabled={organizeRunning} onClick={onOrganizeLibrary}>{organizeRunning ? 'Organizing…' : 'Organize Library'}</Button>
           <Button variant="outlined" size="small" startIcon={activeScanOp !== null ? <CircularProgress size={16} /> : <RefreshIcon />} disabled={activeScanOp !== null} onClick={onFullRescan}>{activeScanOp !== null ? 'Scanning…' : 'Full Rescan'}</Button>
           <Button variant="outlined" size="small" onClick={onFetchAllUnmatched}>Fetch Unmatched</Button>
-          <Button variant="outlined" size="small" onClick={onResumeReview} title="Open review dialog for books with cached candidates pending review">Review Unmatched</Button>
+          <Button variant="contained" size="small" onClick={onResumeReview} title="Open review dialog for books with cached metadata candidates">Review Matches</Button>
           <Button startIcon={<DeleteSweepIcon />} onClick={onPurgeOpen} variant="outlined" size="small" color="secondary" disabled={softDeletedCount === 0}>Purge Deleted{softDeletedCount > 0 ? ` (${softDeletedCount})` : ''}</Button>
         </Stack>
       )}

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -23,6 +23,7 @@ vi.mock('../services/api', () => {
   return {
     ApiError,
     getOperationLogsTail: vi.fn().mockResolvedValue([]),
+    getOperationTimeline: vi.fn().mockResolvedValue([]),
     getBooks: vi.fn().mockResolvedValue({
       items: [
         {
@@ -122,7 +123,9 @@ describe('Library import dialog', () => {
   });
 
   it('starts a manual library import operation and polls it to completion', async () => {
-    vi.useFakeTimers();
+    // shouldAdvanceTime keeps the testing-library polling timers running
+    // while still letting us fast-forward the app's 1500ms reload timers.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     render(
       <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <Library />

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.47.0
+// version: 2.48.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -2733,6 +2733,10 @@ export interface MetadataCandidate {
   google_rating_average?: number;
   /** Number of Google Books ratings. */
   google_rating_count?: number;
+  /** True when this candidate's title, author, or narrator matched the book's
+   *  Whisper-transcribed intro, causing a score multiplier to be applied.
+   *  Use as a filter to find books where audio data confirmed the match. */
+  transcription_boosted?: boolean;
 }
 
 export interface SearchMetadataResponse {
@@ -3336,6 +3340,10 @@ export interface CandidateBookInfo {
   // whose language disagrees with the book's. Empty means
   // "unknown" — filter is a no-op for that row.
   language?: string;
+  // Whisper-parsed title from the book's audio intro. Non-empty means
+  // transcription data was available when candidates were scored.
+  // Lets the review dialog filter to "only books with transcription data".
+  transcribed_title?: string;
 }
 
 export interface CandidateResult {


### PR DESCRIPTION
## Summary

- **`MetadataCandidate`** gets a `transcription_boosted` flag — set to `true` when the candidate's title, author, or narrator matched the book's Whisper-transcribed intro fields (causing a ×1.4–×2.0 score multiplier). The flag survives JSON serialization into the candidate cache, so it's available in the review UI immediately.
- **`CandidateBookInfo`** gets `transcribed_title` — non-empty means this book has been transcribed. Populated from `book.TranscribedTitle` in `BuildCandidateBookInfo`.
- **`transcriptionBoost()`** return type changed from `float64` to `(float64, bool)`. The auto-fetch pick path discards the bool with `_`; the search path captures it.
- **`MetadataReviewDialog`**: two new filter toggles (both off by default):
  - **Has Transcription** — narrows to books where `book.transcribed_title` is set
  - **Transcription Matched** — narrows to books where `candidate.transcription_boosted` is true
- **`LibraryToolbar`**: "Review Unmatched" renamed to **"Review Matches"** with `variant="contained"` so the always-visible review-without-selection button is easier to spot.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/metafetch/... ./internal/metabatch/... -short` — both `ok`
- [ ] Open review dialog, toggle "Has Transcription" — should filter to books with non-empty `transcribed_title`
- [ ] Toggle "Transcription Matched" — should show only candidates where `transcription_boosted: true`
- [ ] Both filters off (default) — existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vQBpT24Mio3sP3R9QKKqa