### PR TITLE
fix(itunes): route multi-file books to OrganizeBookDirectory (CONS-FRAG-2)

### DIFF
--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-06-19
+// last-edited: 2026-07-01
 
 package itunesservice
 
@@ -1111,6 +1111,20 @@ func (imp *Importer) organizeOneBook(book *database.Book, log logger.Logger) err
 	}
 
 	org := imp.organizerFactory()
+
+	// Merged multi-file iTunes books have their tracks scattered across
+	// multiple book_files rows; FilePath on the book itself resolves to a
+	// directory, and OrganizeBook safely (but silently) refuses to touch
+	// directories. Route those books through OrganizeBookDirectory instead
+	// so they don't get stuck at library_state=imported forever (CONS-FRAG-2).
+	var files []database.BookFile
+	if imp.store != nil {
+		files, _ = imp.store.GetBookFiles(book.ID)
+	}
+	if len(files) > 1 {
+		return imp.organizeMultiFileBook(org, book, files, log)
+	}
+
 	newPath, _, err := org.OrganizeBook(book)
 	if err != nil {
 		return err
@@ -1119,6 +1133,43 @@ func (imp *Importer) organizeOneBook(book *database.Book, log logger.Logger) err
 		book.FilePath = newPath
 		imp.applyOrganizedFileMetadata(book, newPath)
 		log.Info("Organized '%s' to %s", book.Title, newPath)
+	}
+	return nil
+}
+
+// organizeMultiFileBook routes a merged, multi-file book through
+// OrganizeBookDirectory, then updates the book's FilePath and each
+// BookFile's FilePath to reflect the new organized locations.
+func (imp *Importer) organizeMultiFileBook(org BookOrganizer, book *database.Book, files []database.BookFile, log logger.Logger) error {
+	segmentPaths := make([]string, 0, len(files))
+	for _, f := range files {
+		if f.FilePath == "" {
+			continue
+		}
+		segmentPaths = append(segmentPaths, f.FilePath)
+	}
+
+	targetDir, pathMap, err := org.OrganizeBookDirectory(book, segmentPaths)
+	if err != nil {
+		return err
+	}
+	if targetDir != "" && targetDir != book.FilePath {
+		book.FilePath = targetDir
+		log.Info("Organized '%s' to %s", book.Title, targetDir)
+	}
+
+	if imp.store != nil {
+		for _, f := range files {
+			newPath, ok := pathMap[f.FilePath]
+			if !ok || newPath == "" || newPath == f.FilePath {
+				continue
+			}
+			updated := f
+			updated.FilePath = newPath
+			if uErr := imp.store.UpdateBookFile(f.ID, &updated); uErr != nil {
+				log.Warn("failed to update book file path for '%s' (file=%s): %v", book.Title, f.ID, uErr)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/itunes/service/importer_error_paths_test.go
+++ b/internal/itunes/service/importer_error_paths_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer_error_paths_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7c3f2e1-4d8b-4e6a-9f0c-2b5d7e3a8c1f
-// last-edited: 2026-05-05
+// last-edited: 2026-07-01
 
 // Package itunesservice - error and edge-case tests for importer.go (TODO 4.13d).
 //
@@ -589,6 +589,94 @@ func TestOrganizeOneBook_NoFactory_Error(t *testing.T) {
 	err := imp.organizeOneBook(book, log)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
+}
+
+// ---------------------------------------------------------------------------
+// organizeOneBook — multi-file (merged) book routes to OrganizeBookDirectory
+// instead of the single-file OrganizeBook path (CONS-FRAG-2).
+// ---------------------------------------------------------------------------
+
+// fakeDirOrganizer is a minimal BookOrganizer whose OrganizeBook always fails
+// (mirroring the real Organizer's directory-path refusal) and whose
+// OrganizeBookDirectory succeeds, recording the segment paths it was called
+// with so the test can assert routing.
+type fakeDirOrganizer struct {
+	calledDirectory bool
+	segmentPaths    []string
+	targetDir       string
+	pathMap         map[string]string
+}
+
+func (f *fakeDirOrganizer) OrganizeBook(book *database.Book) (string, string, error) {
+	return "", "", fmt.Errorf("file_path %s is a directory but single-file organize was requested", book.FilePath)
+}
+
+func (f *fakeDirOrganizer) OrganizeBookDirectory(book *database.Book, segmentPaths []string) (string, map[string]string, error) {
+	f.calledDirectory = true
+	f.segmentPaths = segmentPaths
+	return f.targetDir, f.pathMap, nil
+}
+
+func TestOrganizeOneBook_MultiFile_RoutesToOrganizeBookDirectory(t *testing.T) {
+	book := &database.Book{ID: "book-multi", Title: "Multi File Book", FilePath: "/mnt/books/imported/multi-file-book"}
+	files := []database.BookFile{
+		{ID: "f1", BookID: book.ID, FilePath: "/mnt/books/imported/multi-file-book/track1.mp3"},
+		{ID: "f2", BookID: book.ID, FilePath: "/mnt/books/imported/multi-file-book/track2.mp3"},
+	}
+
+	targetDir := "/mnt/books/organized/Multi File Book"
+	pathMap := map[string]string{
+		files[0].FilePath: targetDir + "/track1.mp3",
+		files[1].FilePath: targetDir + "/track2.mp3",
+	}
+	fake := &fakeDirOrganizer{targetDir: targetDir, pathMap: pathMap}
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookFiles(book.ID).Return(files, nil)
+	m.EXPECT().UpdateBookFile("f1", mock.MatchedBy(func(bf *database.BookFile) bool {
+		return bf.FilePath == pathMap[files[0].FilePath]
+	})).Return(nil)
+	m.EXPECT().UpdateBookFile("f2", mock.MatchedBy(func(bf *database.BookFile) bool {
+		return bf.FilePath == pathMap[files[1].FilePath]
+	})).Return(nil)
+
+	imp := newMockImporter(m)
+	imp.organizerFactory = func() BookOrganizer { return fake }
+
+	log := logger.New("test")
+	err := imp.organizeOneBook(book, log)
+	require.NoError(t, err)
+
+	assert.True(t, fake.calledDirectory, "expected OrganizeBookDirectory to be called for a multi-file book")
+	assert.ElementsMatch(t, []string{files[0].FilePath, files[1].FilePath}, fake.segmentPaths)
+	assert.Equal(t, targetDir, book.FilePath, "book.FilePath should be updated to the new organized directory")
+}
+
+// TestOrganizeOneBook_SingleFile_StillUsesOrganizeBook verifies that this
+// change is strictly additive: books with 0 or 1 BookFile continue to use
+// the existing single-file OrganizeBook path unchanged.
+func TestOrganizeOneBook_SingleFile_StillUsesOrganizeBook(t *testing.T) {
+	book := &database.Book{ID: "book-single", Title: "Single File Book", FilePath: "/mnt/books/imported/single.m4b"}
+	files := []database.BookFile{
+		{ID: "f1", BookID: book.ID, FilePath: book.FilePath},
+	}
+
+	fake := &fakeDirOrganizer{}
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetBookFiles(book.ID).Return(files, nil)
+
+	imp := newMockImporter(m)
+	imp.organizerFactory = func() BookOrganizer { return fake }
+
+	log := logger.New("test")
+	err := imp.organizeOneBook(book, log)
+
+	// The fake's OrganizeBook always errors (mirroring the real directory
+	// refusal); a single-file book must still hit that path, so the error
+	// must propagate and OrganizeBookDirectory must never be called.
+	require.Error(t, err)
+	assert.False(t, fake.calledDirectory, "single-file book must not route through OrganizeBookDirectory")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/service/types.go
+++ b/internal/itunes/service/types.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/types.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 43dcecba-4cba-4139-bd4c-5047a9a1f0c0
 
 package itunesservice
@@ -11,6 +11,11 @@ import "github.com/falkcorp/audiobook-organizer/internal/database"
 // package never imports internal/config.
 type BookOrganizer interface {
 	OrganizeBook(book *database.Book) (newPath, sidecar string, err error)
+	// OrganizeBookDirectory organizes a multi-file (merged) book by moving
+	// each of its per-track segment paths into the book's target directory.
+	// Returns the new target directory and a map of old segment path ->
+	// new segment path so callers can update per-file records.
+	OrganizeBookDirectory(book *database.Book, segmentPaths []string) (targetDir string, pathMap map[string]string, err error)
 }
 
 // ValidateRequest is the wire type for POST /itunes/validate.


### PR DESCRIPTION
Sweep worker output. Routes BookFiles>1 books to OrganizeBookDirectory in organizeOneBook so scattered multi-file iTunes books organize instead of staying 'imported'. Gate: go build + go test ./internal/itunes/... ./internal/organizer/... all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)