### PR TITLE
fix(dedup): boilerplate-title + short-duration guard in upsertExactCandidate (DEDUP-INTRO-1 residual)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.37.0
+// version: 1.38.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-06-30
+// last-edited: 2026-07-01
 
 package dedup
 
@@ -1270,6 +1270,16 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 			"book_a", a.ID, "book_b", b.ID, "layer", layer)
 		return nil
 	}
+	if isBoilerplateTitle(a.Title) || isBoilerplateTitle(b.Title) {
+		slog.Debug("dedup exact candidate dropped by boilerplate-title gate",
+			"book_a", a.ID, "book_b", b.ID, "layer", layer)
+		return nil
+	}
+	if hasKnownShortDuration(a) || hasKnownShortDuration(b) {
+		slog.Debug("dedup exact candidate dropped by min-duration gate",
+			"book_a", a.ID, "book_b", b.ID, "layer", layer)
+		return nil
+	}
 	return de.embedStore.UpsertCandidate(database.DedupCandidate{
 		EntityType: "book",
 		EntityAID:  a.ID,
@@ -1307,6 +1317,17 @@ func normalizeISBN(v string) string {
 
 func normalizeASIN(v string) string {
 	return strings.ToUpper(strings.TrimSpace(v))
+}
+
+// hasKnownShortDuration reports whether book has a known, positive Duration
+// strictly under minFingerprintMatchSeconds. Unknown or non-positive durations
+// (nil or <= 0) are conservative and never treated as "short" — matches the
+// hasPlausibleAudio convention of not disqualifying on missing data.
+func hasKnownShortDuration(book *database.Book) bool {
+	if book == nil || book.Duration == nil || *book.Duration <= 0 {
+		return false
+	}
+	return *book.Duration < minFingerprintMatchSeconds
 }
 
 func hasPlausibleAudio(book *database.Book) bool {

--- a/internal/dedup/engine_exact_guard_test.go
+++ b/internal/dedup/engine_exact_guard_test.go
@@ -1,0 +1,108 @@
+// file: internal/dedup/engine_exact_guard_test.go
+// version: 1.0.0
+// guid: 4a1e6d3f-9c72-4a0b-8e35-1f6b2c7d9e40
+// last-edited: 2026-07-01
+
+// Regression guard for DEDUP-INTRO-1 (residual): upsertExactCandidate is the
+// shared chokepoint for every exact-family emitter. It must reject pairs
+// where either book has a boilerplate publisher-intro/outro title, and pairs
+// where either book has a known, positive Duration under
+// minFingerprintMatchSeconds — while still allowing genuine duplicates
+// (normal titles, durations well above the threshold) through.
+package dedup
+
+import (
+	"testing"
+)
+
+func TestUpsertExactCandidate_BoilerplateTitleGuard(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "This is Audible")
+	b := primaryBook("B", "This is Audible")
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 0 {
+		t.Errorf("expected 0 candidates for boilerplate-title pair, got %d: %+v", len(cands), cands)
+	}
+}
+
+func TestUpsertExactCandidate_MinDurationGuard(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	shortDur := 30
+	a.Duration = &shortDur
+	b := primaryBook("B", "Real Book Title")
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 0 {
+		t.Errorf("expected 0 candidates for short-duration pair, got %d: %+v", len(cands), cands)
+	}
+}
+
+func TestUpsertExactCandidate_UnknownDurationNotSuppressed(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	a.Duration = nil
+	b := primaryBook("B", "Real Book Title")
+	b.Duration = nil
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Errorf("expected 1 candidate for unknown-duration pair (no over-suppression), got %d: %+v", len(cands), cands)
+	}
+}
+
+func TestUpsertExactCandidate_GenuineDuplicateStillPersisted(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Genuine Duplicate Book")
+	b := primaryBook("B", "Genuine Duplicate Book")
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Fatalf("expected exactly 1 candidate for genuine duplicate pair, got %d: %+v", len(cands), cands)
+	}
+	if cands[0].EntityAID != "A" || cands[0].EntityBID != "B" {
+		t.Errorf("unexpected candidate pair: %+v", cands[0])
+	}
+}
+
+// TestUpsertExactCandidate_ZeroDurationNotSuppressed locks in the "<=0 means
+// unknown" convention: a zero Duration must not be mistaken for a genuinely
+// short clip.
+func TestUpsertExactCandidate_ZeroDurationNotSuppressed(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	zero := 0
+	a.Duration = &zero
+	b := primaryBook("B", "Real Book Title")
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Errorf("expected 1 candidate for zero-duration pair (treated as unknown), got %d: %+v", len(cands), cands)
+	}
+}


### PR DESCRIPTION
Sweep worker output. Adds boilerplate-title + min-duration guards at the upsertExactCandidate chokepoint so intro/outro-title and short-clip collisions can't be persisted via any exact emitter. 5 new tests. Gate: go build + go test ./internal/dedup/... all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)