### PR TITLE
fix(dedup): part-vs-whole defense-in-depth guard in upsertExactCandidate (CONS-15)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.38.0
+// version: 1.39.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-01
 
@@ -95,6 +95,13 @@ func isBoilerplateTitle(title string) bool {
 // intro/outro clips, not book content — their fingerprints must not seed or
 // strengthen a duplicate pair. See dedup-intro-falsepositive FINDINGS.md.
 const minFingerprintMatchSeconds = 60
+
+// partVsWholeDurationRatioMax is the duration-ratio ceiling below which a
+// single-file book is treated as a plausible fragment of a multi-file book
+// it is being compared against (CONS-15). Conservative on purpose: genuine
+// single-file duplicates of comparable length must never be suppressed, only
+// pairs where the single-file side is clearly a small slice of the whole.
+const partVsWholeDurationRatioMax = 0.6
 
 // Engine orchestrates a 3-layer dedup system:
 //   - Layer 1: Exact matching (free, instant) — same file hash, ISBN/ASIN, or near-identical titles
@@ -1280,6 +1287,11 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 			"book_a", a.ID, "book_b", b.ID, "layer", layer)
 		return nil
 	}
+	if de.isPartVsWholeMismatch(a, b) {
+		slog.Debug("dedup exact candidate dropped by part-vs-whole gate",
+			"book_a", a.ID, "book_b", b.ID, "layer", layer)
+		return nil
+	}
 	return de.embedStore.UpsertCandidate(database.DedupCandidate{
 		EntityType: "book",
 		EntityAID:  a.ID,
@@ -1328,6 +1340,60 @@ func hasKnownShortDuration(book *database.Book) bool {
 		return false
 	}
 	return *book.Duration < minFingerprintMatchSeconds
+}
+
+// isPartVsWholeMismatch reports whether a and b look like a single-file part
+// being compared against a multi-file whole — e.g. one side has exactly one
+// BookFile whose total duration is a small fraction of the other side's
+// total duration. Such pairs must not be emitted as 100%-confidence exact
+// duplicates even if titles/identifiers otherwise match, since a mis-tagged
+// chapter file is common and an incorrect merge is destructive.
+//
+// Unknown or zero durations/file counts are conservative and never trigger
+// the guard — this only fires when both sides' file counts and durations are
+// known and clearly mismatched, mirroring hasPlausibleAudio's convention.
+func (de *Engine) isPartVsWholeMismatch(a, b *database.Book) bool {
+	if a == nil || b == nil || de.bookStore == nil {
+		return false
+	}
+	filesA, err := de.bookStore.GetBookFiles(a.ID)
+	if err != nil || len(filesA) == 0 {
+		return false
+	}
+	filesB, err := de.bookStore.GetBookFiles(b.ID)
+	if err != nil || len(filesB) == 0 {
+		return false
+	}
+
+	var partFiles, wholeFiles []database.BookFile
+	switch {
+	case len(filesA) == 1 && len(filesB) >= 2:
+		partFiles, wholeFiles = filesA, filesB
+	case len(filesB) == 1 && len(filesA) >= 2:
+		partFiles, wholeFiles = filesB, filesA
+	default:
+		return false
+	}
+
+	partDuration := sumBookFileDurations(partFiles)
+	wholeDuration := sumBookFileDurations(wholeFiles)
+	if partDuration <= 0 || wholeDuration <= 0 {
+		return false
+	}
+	return float64(partDuration) < partVsWholeDurationRatioMax*float64(wholeDuration)
+}
+
+// sumBookFileDurations totals the Duration (seconds) of the given BookFiles.
+// Non-positive durations contribute 0, consistent with the "unknown" convention
+// used elsewhere in the dedup guards.
+func sumBookFileDurations(files []database.BookFile) int {
+	total := 0
+	for _, f := range files {
+		if f.Duration > 0 {
+			total += f.Duration
+		}
+	}
+	return total
 }
 
 func hasPlausibleAudio(book *database.Book) bool {

--- a/internal/dedup/engine_part_vs_whole_test.go
+++ b/internal/dedup/engine_part_vs_whole_test.go
@@ -1,0 +1,77 @@
+// file: internal/dedup/engine_part_vs_whole_test.go
+// version: 1.0.0
+// guid: 6d3a9f21-4b7c-4e58-9a01-2f5c8d6e7b34
+// last-edited: 2026-07-01
+
+// Regression guard for CONS-15: upsertExactCandidate must reject a pair where
+// one side is a single-file book whose duration is a small fraction of the
+// other side's multi-file total duration, even when titles/identifiers
+// otherwise match — a lone chapter mis-tagged with the whole book's metadata
+// must not be merged as a 100%-confidence exact duplicate. Ordinary
+// single-file-vs-single-file duplicates of comparable duration must still be
+// emitted normally.
+package dedup
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestUpsertExactCandidate_PartVsWholeGuard(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	b := primaryBook("B", "Real Book Title")
+
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "A":
+			// Single file, short duration relative to B's total.
+			return []database.BookFile{{ID: "FA1", BookID: "A", Duration: 600}}, nil
+		case "B":
+			// Ten files totalling far more than A's single file.
+			files := make([]database.BookFile, 0, 10)
+			for i := 0; i < 10; i++ {
+				files = append(files, database.BookFile{ID: "FB" + string(rune('0'+i)), BookID: "B", Duration: 3600})
+			}
+			return files, nil
+		}
+		return nil, nil
+	}
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 0 {
+		t.Errorf("expected 0 candidates for part-vs-whole pair, got %d: %+v", len(cands), cands)
+	}
+}
+
+func TestUpsertExactCandidate_ComparableSingleFilesStillPersisted(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	b := primaryBook("B", "Real Book Title")
+
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "A":
+			return []database.BookFile{{ID: "FA1", BookID: "A", Duration: 3600}}, nil
+		case "B":
+			return []database.BookFile{{ID: "FB1", BookID: "B", Duration: 3650}}, nil
+		}
+		return nil, nil
+	}
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Errorf("expected 1 candidate for comparable single-file pair, got %d: %+v", len(cands), cands)
+	}
+}


### PR DESCRIPTION
Sweep worker output. Suppresses a single part pairing 100% against a whole multi-file book (duration-ratio guard, partVsWholeDurationRatioMax=0.6). 2 new tests. Gate: build + go test ./internal/dedup/... green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)