### PR TITLE
fix(testutil): deflake TestScanService_MultiChapterAudiobook — WaitForWarmup in SetupIntegration (flaky-scan)

### DIFF
--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,7 +1,7 @@
 // file: internal/testutil/integration.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-10
+// last-edited: 2026-07-01
 
 package testutil
 
@@ -49,6 +49,20 @@ func SetupIntegration(t *testing.T) (*IntegrationEnv, func()) {
 
 	store, err := database.NewPebbleStore(dbPath)
 	require.NoError(t, err)
+	// PebbleStore.WaitForWarmup: NewPebbleStore starts the in-memory query
+	// layer (memdb) warmup asynchronously. Without waiting here, a scan run
+	// immediately after SetupIntegration can create a book via CreateBook
+	// before warmup publishes its Pebble snapshot; CreateBook's memdb
+	// write-through silently no-ops while mem()==nil (see memSync in
+	// memdb_sync.go), and the eventual warmup snapshot can still miss a book
+	// that was written mid-snapshot, permanently hiding it from GetAllBooks()
+	// for the life of the store. On an idle dev machine warmup of a fresh,
+	// near-empty DB finishes before the first write, masking the bug; under
+	// CI/full-suite load the warmup goroutine can be scheduled late enough to
+	// race a real scan. This was the root cause of the intermittent
+	// TestScanService_MultiChapterAudiobook flake (asserted book count of 1,
+	// occasionally observed 0 under load). See PebbleStore.WaitForWarmup doc.
+	store.WaitForWarmup()
 
 	err = database.RunMigrations(store)
 	require.NoError(t, err)

--- a/internal/testutil/integration_test.go
+++ b/internal/testutil/integration_test.go
@@ -1,0 +1,66 @@
+// file: internal/testutil/integration_test.go
+// version: 1.0.0
+// guid: b7c8d9e0-f1a2-4b3c-8d9e-0f1a2b3c4d5e
+// last-edited: 2026-07-01
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestSetupIntegration_MemDBWarmupComplete is a regression test for the
+// flaky-scan root cause (TestScanService_MultiChapterAudiobook, CI-only
+// flake): SetupIntegration used to return before PebbleStore's async memdb
+// warmup goroutine had published its snapshot.
+//
+// A book created immediately after setup could race that goroutine: if the
+// memdb write-through triggered by CreateBook landed while mem()==nil
+// (warmup not yet published), memSync silently no-oped (see
+// internal/database/memdb_sync.go), and the eventual warmup snapshot could
+// still miss the book — permanently hiding it from GetAllBooks() for the
+// life of the store. On an idle dev machine, warmup of a fresh, near-empty
+// DB finishes before the first write, masking the bug; under CI/full-suite
+// load the warmup goroutine can be scheduled late enough to actually race a
+// scan's CreateBook call, which is why the scan test passed reliably in
+// isolation but failed intermittently in CI.
+//
+// The fix: SetupIntegration now calls store.WaitForWarmup() before
+// returning, guaranteeing the memdb snapshot is published (or PebbleStore
+// has permanently fallen back to direct Pebble reads) before any test code
+// runs. This test locks in that contract directly, rather than relying on
+// timing to reproduce the race.
+func TestSetupIntegration_MemDBWarmupComplete(t *testing.T) {
+	env, cleanup := SetupIntegration(t)
+	defer cleanup()
+
+	ps, ok := env.Store.(*database.PebbleStore)
+	if !ok {
+		t.Fatalf("expected env.Store to be *database.PebbleStore, got %T", env.Store)
+	}
+	if !ps.IsMemReady() {
+		t.Fatal("expected memdb warmup to be complete immediately after SetupIntegration returns; " +
+			"a scan starting now would race the warmup goroutine (see WaitForWarmup doc)")
+	}
+
+	book, err := ps.CreateBook(&database.Book{
+		Title:    "Warmup Race Regression",
+		FilePath: "/tmp/warmup-race-regression.mp3",
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	books, err := ps.GetAllBooks(100, 0)
+	if err != nil {
+		t.Fatalf("GetAllBooks: %v", err)
+	}
+	for _, b := range books {
+		if b.ID == book.ID {
+			return
+		}
+	}
+	t.Fatalf("created book %s not visible via GetAllBooks immediately after creation (memdb warmup race)", book.ID)
+}


### PR DESCRIPTION
Sweep worker output. Root cause: SetupIntegration didn't call PebbleStore.WaitForWarmup after NewPebbleStore, so a write-through to memdb could race the async warmup and permanently hide a book from GetAllBooks. Added WaitForWarmup + regression test. Determinism: 20/20. Gate green locally.

Note: independently re-confirmed the pre-existing 'pebble: closed' DepsScheduler.SweepTick shutdown race (out of scope, logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)