### PR TITLE
feat(settings): Ollama download deep-link on embeddings section (EMB-UI-1)

### DIFF
--- a/web/src/components/settings/EmbeddingSettingsSection.test.tsx
+++ b/web/src/components/settings/EmbeddingSettingsSection.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/EmbeddingSettingsSection.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: a9b8c7d6-e5f4-3210-abcd-ef9876543210
-// last-edited: 2026-06-19
+// last-edited: 2026-07-01
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
@@ -70,5 +70,14 @@ describe('EmbeddingSettingsSection', () => {
     const modelField = screen.getByLabelText('Model');
     fireEvent.change(modelField, { target: { value: 'text-embedding-3-large' } });
     expect(onChange).toHaveBeenCalledWith({ model: 'text-embedding-3-large' });
+  });
+
+  it('renders a link to download the latest Ollama', () => {
+    const onChange = vi.fn();
+    render(<EmbeddingSettingsSection config={defaultConfig} onChange={onChange} />);
+    const link = screen.getByRole('link', { name: /download the latest ollama/i });
+    expect(link).toHaveAttribute('href', 'https://ollama.com/download');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });

--- a/web/src/components/settings/EmbeddingSettingsSection.tsx
+++ b/web/src/components/settings/EmbeddingSettingsSection.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/EmbeddingSettingsSection.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-19
+// last-edited: 2026-07-01
 
 import {
   Box,
@@ -11,6 +11,7 @@ import {
   Switch,
   MenuItem,
   Grid,
+  Link,
 } from '@mui/material';
 import * as api from '../../services/api';
 
@@ -25,6 +26,12 @@ export function EmbeddingSettingsSection({ config, onChange }: EmbeddingSettings
       <Typography variant="h6" gutterBottom>
         Embedding Settings
       </Typography>
+
+      <Box mb={2}>
+        <Link href="https://ollama.com/download" target="_blank" rel="noopener noreferrer">
+          Download the latest Ollama
+        </Link>
+      </Box>
 
       <Grid container spacing={2}>
         <Grid item xs={12}>


### PR DESCRIPTION
Sweep worker output. Adds a 'Download the latest Ollama' link (https://ollama.com/download) above the embeddings settings. Worker gate: npm run build + full npm test (309 tests) green. Isolated 2-file frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)