### PR TITLE
refactor(metafetch): op-context logging for ISBN enrichment (SLOG-W13a)

### DIFF
--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -1,12 +1,12 @@
 // file: internal/metafetch/isbn.go
-// version: 1.4.1
+// version: 1.4.2
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
+// last-edited: 2026-07-01
 
 package metafetch
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
@@ -31,7 +31,7 @@ func NewISBNService(db database.Store, sources []metadata.MetadataSource) *ISBNS
 // EnrichBookISBN searches external sources for ISBN if the book doesn't have one.
 // It also back-fills ASIN from Audible when missing. Returns true if any
 // identifier was found and saved.
-func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
+func (s *ISBNService) EnrichBookISBN(ctx context.Context, bookID string) (bool, error) {
 	book, err := s.db.GetBookByID(bookID)
 	if err != nil || book == nil {
 		return false, err
@@ -66,7 +66,7 @@ func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return false, err
 			}
-						slog.Info("ISBN enrichment found for ()", "value", isbn, "value", title, "name", src.Name())
+						logging.Info(ctx, "ISBN enrichment found", "isbn", isbn, "title", title, "source", src.Name())
 			updated = true
 			break
 		}
@@ -86,7 +86,7 @@ func (s *ISBNService) EnrichBookISBN(bookID string) (bool, error) {
 			if _, err := s.db.UpdateBook(bookID, book); err != nil {
 				return updated, err
 			}
-						slog.Info("ASIN enrichment found for", "value", asin, "value", title)
+						logging.Info(ctx, "ASIN enrichment found", "asin", asin, "title", title)
 			updated = true
 			break
 		}
@@ -130,7 +130,7 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *acti
 			}
 
 			checked++
-			found, err := s.EnrichBookISBN(books[i].ID)
+			found, err := s.EnrichBookISBN(ctx, books[i].ID)
 			if err != nil {
 								logging.Warn(ctx, "ISBN enrichment failed for during batch scan", "id", books[i].ID, "error", err)
 			} else if found {

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package metafetch
 
@@ -30,7 +30,7 @@ func (mfs *Service) queueISBNEnrichment(id string, book *database.Book) {
 		return
 	}
 	go func(bid string) {
-		found, err := mfs.isbnEnrichment.EnrichBookISBN(bid)
+		found, err := mfs.isbnEnrichment.EnrichBookISBN(context.Background(), bid)
 		if err != nil {
 						slog.Warn("ISBN enrichment failed for", "id", bid, "error", err)
 		} else if found {

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-06-16
+// last-edited: 2026-07-01
 
 package metafetch
 
@@ -1648,7 +1648,7 @@ func TestEnrichBookISBN(t *testing.T) {
 			},
 		}
 		svc := NewISBNService(mock, nil)
-		found, err := svc.EnrichBookISBN("nonexistent")
+		found, err := svc.EnrichBookISBN(context.Background(), "nonexistent")
 		assert.NoError(t, err)
 		assert.False(t, found)
 	})
@@ -1662,7 +1662,7 @@ func TestEnrichBookISBN(t *testing.T) {
 			},
 		}
 		svc := NewISBNService(mock, nil)
-		found, err := svc.EnrichBookISBN("b1")
+		found, err := svc.EnrichBookISBN(context.Background(), "b1")
 		assert.NoError(t, err)
 		assert.False(t, found, "should not enrich when ISBN and ASIN already present")
 	})

--- a/internal/server/isbn_enrichment_test.go
+++ b/internal/server/isbn_enrichment_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/isbn_enrichment_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 5b7766bc-1f00-4f32-b8ca-8cb0e815c9a1
+// last-edited: 2026-07-01
 
 package server
 
@@ -35,7 +36,7 @@ func TestEnrichBookISBN_SkipsWhenAlreadyHasISBN(t *testing.T) {
 		},
 	}
 	svc := metafetch.NewISBNService(mock, nil)
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestEnrichBookISBN_FindsISBN13(t *testing.T) {
 		},
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestEnrichBookISBN_FindsISBN10(t *testing.T) {
 		},
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestEnrichBookISBN_FindsASIN(t *testing.T) {
 		},
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,7 +147,7 @@ func TestEnrichBookISBN_NoResultsReturnsFalse(t *testing.T) {
 		results: nil,
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,7 +169,7 @@ func TestEnrichBookISBN_StrictTitleMismatchSkips(t *testing.T) {
 		},
 	}
 	svc := metafetch.NewISBNService(mock, []metadata.MetadataSource{src})
-	found, err := svc.EnrichBookISBN("book-1")
+	found, err := svc.EnrichBookISBN(context.Background(), "book-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Sweep worker output. Threads ctx into EnrichBookISBN and swaps raw slog for logging.Info(ctx) in the ISBN enrichment path (+call sites/tests). Gate: build + metafetch/server ISBN tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)