### PR TITLE
feat(dedup-dataset): offset/subsequence containment in signatureRelation (C5-sig)

### DIFF
--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.1.3
+// version: 1.2.0
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
-// last-edited: 2026-06-13
+// last-edited: 2026-07-01
 
 // Package dataset builds labeled dedup examples and runs deterministic catchers
 // over them. Pure: a store interface in, a database.LabeledExample out, no
@@ -10,7 +10,11 @@
 package dataset
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
+	"math/bits"
 	"path/filepath"
 	"strings"
 
@@ -21,6 +25,27 @@ import (
 // sigMatchThreshold is the BookSignatureSimilarity score at/above which two
 // whole-book signatures are treated as a content match (spec: 0.95).
 const sigMatchThreshold = 0.95
+
+// sigContainmentThreshold is the similarity required, over a resampled
+// candidate window (see signatureContainment), to declare offset/subsequence
+// containment. Set slightly below sigMatchThreshold to tolerate the extra
+// quantization noise introduced by nearest-neighbor resampling.
+const sigContainmentThreshold = 0.90
+
+// containmentFractions are the candidate window-length fractions of the full
+// fingerprint.BookSignatureFixedLength array tried when searching for offset/
+// subsequence containment (e.g. one book being an excerpt, or the first half,
+// of another). Both BookSigV1 signatures are always down-sampled to the same
+// fixed length, so containment cannot be found by a literal sub-slice
+// comparison; instead a candidate window of the longer book's "timeline" is
+// resampled back up to the fixed length and compared to the shorter book.
+var containmentFractions = []int{2, 3, 4, 6, 8}
+
+// containmentOffsetSteps bounds how many candidate start offsets are tried per
+// window length, keeping the search O(len(containmentFractions) *
+// containmentOffsetSteps) resamples-and-compares (a few dozen) instead of
+// scanning every one of the up to 4096 possible offsets.
+const containmentOffsetSteps = 8
 
 // BuilderStore is the narrow store surface BuildExample needs.
 type BuilderStore interface {
@@ -187,10 +212,14 @@ func sharesAny(a, b []string) bool {
 
 // signatureRelation reports the whole-book-signature relationship between two books.
 // Uses fingerprint.BookSignatureSimilarity with a 0.95 threshold for "match".
-// Returns one of: match, disjoint, unknown.
-// "unknown" is returned when either signature is absent or the comparator errors
-// (e.g. corrupt/short base64). Offset/subsequence containment (a_contains_b /
-// b_contains_a) is deferred to a later spec milestone.
+// Returns one of:
+//   - match: whole-signature similarity >= sigMatchThreshold.
+//   - a_contains_b: b's signature closely matches a resampled contiguous
+//     window of a's signature (b looks like an excerpt/partial re-record of a).
+//   - b_contains_a: the reverse of a_contains_b.
+//   - disjoint: neither a match nor a containment relationship was found.
+//   - unknown: either signature is absent or the comparator errors (e.g.
+//     corrupt/short base64).
 func signatureRelation(a, b *database.Book) string {
 	if a == nil || b == nil {
 		return "unknown"
@@ -205,5 +234,127 @@ func signatureRelation(a, b *database.Book) string {
 	if sim >= sigMatchThreshold {
 		return "match"
 	}
+	aWords, errA := decodeBookSigWords(*a.BookSigV1)
+	bWords, errB := decodeBookSigWords(*b.BookSigV1)
+	if errA == nil && errB == nil {
+		if rel, ok := signatureContainment(aWords, bWords); ok {
+			return rel
+		}
+	}
 	return "disjoint"
+}
+
+// decodeBookSigWords decodes a base64-encoded BookSigV1 string into its
+// little-endian []uint32 words. Mirrors the (unexported) decoding used by
+// fingerprint.BookSignatureSimilarity; duplicated here because that package
+// exposes no public decode helper and containment search needs the raw words,
+// not just a similarity score.
+func decodeBookSigWords(encoded string) ([]uint32, error) {
+	b, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	if len(b)%4 != 0 {
+		return nil, errSigNotWordAligned
+	}
+	words := make([]uint32, len(b)/4)
+	for i := range words {
+		words[i] = binary.LittleEndian.Uint32(b[i*4:])
+	}
+	return words, nil
+}
+
+// errSigNotWordAligned is returned by decodeBookSigWords when the decoded
+// byte length is not a multiple of 4.
+var errSigNotWordAligned = errors.New("decoded signature length is not word-aligned")
+
+// signatureContainment searches for evidence that one of a/b's signature is a
+// contiguous, possibly-resampled sub-sequence of the other's. Both signatures
+// are always fingerprint.BookSignatureFixedLength words long regardless of the
+// underlying audio duration, so "b is the first half of a" cannot be found by
+// literal sub-slicing; instead candidate windows of the longer book's
+// down-sampled timeline are resampled back up to the fixed length and
+// compared to the other signature. Returns ("a_contains_b", true),
+// ("b_contains_a", true), or ("", false) if no window search matched.
+func signatureContainment(a, b []uint32) (string, bool) {
+	if len(a) == 0 || len(a) != len(b) {
+		return "", false
+	}
+	if rel, ok := containmentDirection(a, b, "a_contains_b"); ok {
+		return rel, true
+	}
+	if rel, ok := containmentDirection(b, a, "b_contains_a"); ok {
+		return rel, true
+	}
+	return "", false
+}
+
+// containmentDirection checks whether some resampled window of long matches
+// short closely enough (>= sigContainmentThreshold) to report relation.
+func containmentDirection(long, short []uint32, relation string) (string, bool) {
+	n := len(long)
+	for _, frac := range containmentFractions {
+		winLen := n / frac
+		if winLen < 8 {
+			continue // too short a window to be a meaningful excerpt
+		}
+		maxStart := n - winLen
+		if maxStart <= 0 {
+			continue
+		}
+		for _, start := range containmentGridStarts(maxStart) {
+			window := resampleNearest(long, start, winLen, len(short))
+			if hammingSimilarity(window, short) >= sigContainmentThreshold {
+				return relation, true
+			}
+		}
+	}
+	return "", false
+}
+
+// containmentGridStarts returns a bounded grid of candidate start offsets in
+// [0, maxStart], spaced so at most containmentOffsetSteps+1 offsets are
+// tried per window length.
+func containmentGridStarts(maxStart int) []int {
+	if maxStart <= 0 {
+		return []int{0}
+	}
+	step := maxStart / containmentOffsetSteps
+	if step == 0 {
+		step = 1
+	}
+	starts := make([]int, 0, containmentOffsetSteps+1)
+	for start := 0; start <= maxStart; start += step {
+		starts = append(starts, start)
+	}
+	return starts
+}
+
+// resampleNearest nearest-neighbor resamples src[start:start+length] up (or
+// down) to targetLen words, so a sub-window of one signature can be compared
+// directly against another signature's full fixed-length representation.
+func resampleNearest(src []uint32, start, length, targetLen int) []uint32 {
+	out := make([]uint32, targetLen)
+	for i := 0; i < targetLen; i++ {
+		idx := start + i*length/targetLen
+		if idx >= start+length {
+			idx = start + length - 1
+		}
+		out[i] = src[idx]
+	}
+	return out
+}
+
+// hammingSimilarity scores two equal-length uint32 slices the same way
+// fingerprint.BookSignatureSimilarity scores two full signatures: 1.0 minus
+// the fraction of differing bits.
+func hammingSimilarity(a, b []uint32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var diff int
+	for i := range a {
+		diff += bits.OnesCount32(a[i] ^ b[i])
+	}
+	return 1.0 - float64(diff)/float64(len(a)*32)
 }

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.1.2
+// version: 1.2.0
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
-// last-edited: 2026-06-13
+// last-edited: 2026-07-01
 
 package dataset
 
@@ -22,6 +22,30 @@ func makeTestSig(seed uint32) string {
 	buf := make([]byte, n*4)
 	for i := 0; i < n; i++ {
 		binary.LittleEndian.PutUint32(buf[i*4:], seed)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// makeVariedWords builds a deterministic 4096-word array with well-spread
+// bits (a Knuth multiplicative hash of the index) so it looks like a
+// realistic fingerprint rather than a uniform constant — needed for
+// containment tests, where a uniform array would trivially "contain" any
+// other uniform array.
+func makeVariedWords() []uint32 {
+	const n = 4096
+	words := make([]uint32, n)
+	for i := range words {
+		words[i] = uint32(i) * 2654435761
+	}
+	return words
+}
+
+// encodeWords base64-encodes a []uint32 as little-endian bytes, mirroring
+// the BookSigV1 on-disk representation.
+func encodeWords(words []uint32) string {
+	buf := make([]byte, len(words)*4)
+	for i, w := range words {
+		binary.LittleEndian.PutUint32(buf[i*4:], w)
 	}
 	return base64.StdEncoding.EncodeToString(buf)
 }
@@ -166,6 +190,57 @@ func TestBuildExample_SignatureRelation_Disjoint(t *testing.T) {
 	}
 	if ex.SignatureRelation != "disjoint" {
 		t.Fatalf("SignatureRelation = %q, want disjoint (fully dissimilar sigs)", ex.SignatureRelation)
+	}
+}
+
+// TestSignatureRelation_Table covers all five signatureRelation outcomes:
+// match, a_contains_b, b_contains_a, disjoint, unknown.
+func TestSignatureRelation_Table(t *testing.T) {
+	whole := makeVariedWords()
+	wholeSig := encodeWords(whole)
+
+	// Pick a window (length = n/4) whose start offset lands exactly on the
+	// same grid signatureContainment searches, so the resampled window is a
+	// byte-for-byte match and containment is detected deterministically.
+	const n = 4096
+	winLen := n / 4
+	maxStart := n - winLen
+	starts := containmentGridStarts(maxStart)
+	prefixStart := starts[0]
+	suffixStart := starts[len(starts)-1]
+	middleStart := starts[len(starts)/2]
+
+	prefixExcerpt := encodeWords(resampleNearest(whole, prefixStart, winLen, n))
+	middleExcerpt := encodeWords(resampleNearest(whole, middleStart, winLen, n))
+	suffixExcerpt := encodeWords(resampleNearest(whole, suffixStart, winLen, n))
+
+	zeroSig := makeTestSig(0x00000000)
+	onesSig := makeTestSig(0xFFFFFFFF)
+
+	tests := []struct {
+		name string
+		a, b *string
+		want string
+	}{
+		{"identical_sigs_match", &wholeSig, &wholeSig, "match"},
+		{"b_is_prefix_of_a", &wholeSig, &prefixExcerpt, "a_contains_b"},
+		{"b_is_middle_of_a", &wholeSig, &middleExcerpt, "a_contains_b"},
+		{"b_is_suffix_of_a", &wholeSig, &suffixExcerpt, "a_contains_b"},
+		{"a_is_prefix_of_b", &prefixExcerpt, &wholeSig, "b_contains_a"},
+		{"unrelated_sigs_disjoint", &zeroSig, &onesSig, "disjoint"},
+		{"nil_sig_unknown", nil, &wholeSig, "unknown"},
+		{"empty_sig_unknown", func() *string { s := ""; return &s }(), &wholeSig, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bkA := &database.Book{ID: "a", Title: "A", BookSigV1: tt.a}
+			bkB := &database.Book{ID: "b", Title: "B", BookSigV1: tt.b}
+			got := signatureRelation(bkA, bkB)
+			if got != tt.want {
+				t.Fatalf("signatureRelation() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Sweep worker output. Adds a_contains_b/b_contains_a detection to signatureRelation via bounded resampling (fixed-length BookSigV1). 8 table tests. Gate: build + dataset tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)