### PR TITLE
fix(ci): pin mockery to v3.7.1 to fix Mock Freshness gate (mock-freshness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.3
+# version: 3.0.4
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-06-22
+# last-edited: 2026-07-01
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -71,12 +71,21 @@ jobs:
       - name: Install system packages
         run: sudo apt-get update && sudo apt-get install -y libtag1-dev
 
+      # Pinned mockery version: v3.7.1 (module github.com/vektra/mockery/v3).
+      # Must match scripts/setup-mockery.sh. The committed mocks (including
+      # the merged internal/database/mocks/mock_store.go) were generated
+      # with mockery v3, which supports package-based config and merging
+      # multiple interfaces into one output file — mockery v2.53.6 does NOT
+      # support merging into a shared filename (each interface's generation
+      # overwrites the previous one), so v2 cannot regenerate this repo's
+      # mocks at all. Do not downgrade this pin to v2.
       - name: Install mockery
-        run: go install github.com/vektra/mockery/v2@v2.53.6
+        run: go install github.com/vektra/mockery/v3@v3.7.1
 
       - name: Check mockery mocks are fresh
         run: |
-          mockery >/dev/null 2>&1
+          set -e
+          mockery
           if ! git diff --quiet -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; then
             echo "❌ Committed mocks are stale. Run 'make mocks' and commit."
             git diff --stat -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.13.0
+# version: 2.14.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-06-23
+# last-edited: 2026-07-01
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -184,6 +184,13 @@ vet:
 
 ## mocks: Regenerate mockery-managed mocks from .mockery.yaml.
 ## Run this after editing an interface listed in .mockery.yaml.
+## Pinned mockery version: v3.7.1 (module github.com/vektra/mockery/v3).
+## Install via scripts/setup-mockery.sh. Mockery v2.x cannot regenerate
+## these mocks: it does not support merging multiple interfaces into one
+## shared output file (e.g. internal/database/mocks/mock_store.go), so
+## running an older/newer mockery binary here will silently corrupt or
+## truncate that file. If `make mocks` produces a huge, repo-wide diff,
+## you are running the wrong mockery version — check `mockery version`.
 mocks:
 	@echo "🎭 Regenerating mockery-managed mocks..."
 	@mockery
@@ -191,10 +198,11 @@ mocks:
 
 ## mocks-check: Verify committed mocks match what mockery would generate
 ## right now. Fails CI if someone edited an interface without re-running
-## mockery. Backlog 5.9.
+## mockery. Pinned mockery version: v3.7.1 (see scripts/setup-mockery.sh).
+## Backlog 5.9.
 mocks-check:
 	@echo "🎭 Checking that committed mocks are up to date..."
-	@mockery >/dev/null 2>&1
+	@mockery --log-level warn
 	@if ! git diff --quiet -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; then \
 		echo "❌ Committed mocks are stale. Run 'make mocks' and commit the result."; \
 		git diff --stat -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; \

--- a/internal/ai/mock_metadata_llm_backend_test.go
+++ b/internal/ai/mock_metadata_llm_backend_test.go
@@ -74,7 +74,7 @@ type mockMetadataLLMBackend_ScoreMetadataCandidates_Call struct {
 //   - ctx context.Context
 //   - query MetadataLLMQuery
 //   - candidates []MetadataLLMCandidate
-func (_e *mockMetadataLLMBackend_Expecter) ScoreMetadataCandidates(ctx interface{}, query interface{}, candidates interface{}) *mockMetadataLLMBackend_ScoreMetadataCandidates_Call {
+func (_e *mockMetadataLLMBackend_Expecter) ScoreMetadataCandidates(ctx any, query any, candidates any) *mockMetadataLLMBackend_ScoreMetadataCandidates_Call {
 	return &mockMetadataLLMBackend_ScoreMetadataCandidates_Call{Call: _e.mock.On("ScoreMetadataCandidates", ctx, query, candidates)}
 }
 

--- a/internal/metadata/mock_metadata_extractor_test.go
+++ b/internal/metadata/mock_metadata_extractor_test.go
@@ -68,7 +68,7 @@ type mockMetadataExtractorInternal_ExtractMetadata_Call struct {
 
 // ExtractMetadata is a helper method to define mock.On call
 //   - filePath string
-func (_e *mockMetadataExtractorInternal_Expecter) ExtractMetadata(filePath interface{}) *mockMetadataExtractorInternal_ExtractMetadata_Call {
+func (_e *mockMetadataExtractorInternal_Expecter) ExtractMetadata(filePath any) *mockMetadataExtractorInternal_ExtractMetadata_Call {
 	return &mockMetadataExtractorInternal_ExtractMetadata_Call{Call: _e.mock.On("ExtractMetadata", filePath)}
 }
 

--- a/internal/server/handlers/duplicates/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/duplicates/mocks/mock_dedup_engine.go
@@ -59,7 +59,7 @@ type MockDedupEngine_CleanupCandidatesAfterMerge_Call struct {
 
 // CleanupCandidatesAfterMerge is a helper method to define mock.On call
 //   - mergedAwayBookIDs []string
-func (_e *MockDedupEngine_Expecter) CleanupCandidatesAfterMerge(mergedAwayBookIDs interface{}) *MockDedupEngine_CleanupCandidatesAfterMerge_Call {
+func (_e *MockDedupEngine_Expecter) CleanupCandidatesAfterMerge(mergedAwayBookIDs any) *MockDedupEngine_CleanupCandidatesAfterMerge_Call {
 	return &MockDedupEngine_CleanupCandidatesAfterMerge_Call{Call: _e.mock.On("CleanupCandidatesAfterMerge", mergedAwayBookIDs)}
 }
 

--- a/scripts/setup-mockery.sh
+++ b/scripts/setup-mockery.sh
@@ -1,22 +1,33 @@
 #!/bin/bash
 # file: scripts/setup-mockery.sh
-# version: 1.2.0
+# version: 1.3.0
 # guid: c3d4e5f6-a7b8-9012-cdef-345678901abc
 
-# Setup script for integrating mockery v3 into the project
+# Setup script for integrating mockery v3 into the project.
+#
+# PINNED VERSION: v3.7.1 (module github.com/vektra/mockery/v3). This must
+# match the version installed in .github/workflows/ci.yml's mocks-check job.
+# Do NOT use @latest — it drifts silently (e.g. resolving to a newer mockery
+# major/minor than CI expects) and produces spurious formatting-only diffs
+# (interface{} -> any, receiver renames, etc.) that make `make mocks-check`
+# fail locally even though CI is green. If you see a large, repo-wide mock
+# diff after running `make mocks`, you are almost certainly running the
+# wrong mockery version — check `mockery version` against the pin above.
 
 set -euo pipefail
+
+MOCKERY_VERSION="v3.7.1"
 
 echo "🔧 Setting up mockery for improved test coverage..."
 
 # Check if mockery is installed
 if ! command -v mockery &> /dev/null; then
-    echo "📦 Installing mockery..."
-    go install github.com/vektra/mockery/v2@latest
+    echo "📦 Installing mockery ${MOCKERY_VERSION}..."
+    go install "github.com/vektra/mockery/v3@${MOCKERY_VERSION}"
 fi
 
-echo "✅ Mockery is installed"
-mockery --version
+echo "✅ Mockery is installed (expected version: ${MOCKERY_VERSION})"
+mockery version
 
 # Generate mocks using configuration
 echo "🔨 Generating mocks for Store interface..."


### PR DESCRIPTION
Sweep worker output. CI/Makefile were pinned to mockery v2.53.6, but the repo's merged-file .mockery.yaml is v3-only (v2 can't merge interfaces into one file). Pinned CI + setup script + Makefile to v3.7.1 (the version that reproduces the committed mocks). Mock diff is 3 files / 6 lines (interface{}->any patch churn). Gate: make mocks-check ✅, go build ✅.

Unblocks the Mock Freshness CI check that was red on every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)