### PR TITLE
fix(library-ui): invalidate client cache on all mutation handlers (library-cache-bug)

### DIFF
--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
 // last-edited: 2026-07-01
 
@@ -8,6 +8,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Library } from './Library';
 import * as api from '../services/api';
+import { useLibraryCache } from '../stores/useLibraryCache';
 
 vi.mock('../services/api', () => {
   class ApiError extends Error {
@@ -95,6 +96,7 @@ vi.mock('../services/api', () => {
 
 afterEach(() => {
   vi.useRealTimers();
+  useLibraryCache.getState().clear();
 });
 
 describe('Library import dialog', () => {
@@ -119,6 +121,50 @@ describe('Library import dialog', () => {
     const importFileMock = vi.mocked(api.importFile);
     await waitFor(() => {
       expect(importFileMock).toHaveBeenCalledWith('/tmp/book.m4b', true);
+    });
+  });
+
+  it('clears useLibraryCache before reloading after a file import (library-cache-bug)', async () => {
+    // Regression test for the stale-cache bug: handleImportFile used to call
+    // loadAudiobooks() after a successful import without first clearing
+    // useLibraryCache, so a page cached before the import could be served
+    // as-is (missing the newly imported book) for up to the cache's 60s TTL.
+    const getBooksMock = vi.mocked(api.getBooks);
+
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Library />
+      </MemoryRouter>
+    );
+
+    // Wait for the initial load to complete and populate useLibraryCache.
+    await screen.findByText('Test Book');
+    await waitFor(() => {
+      expect(getBooksMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(useLibraryCache.getState().cache.size).toBeGreaterThan(0);
+    const callsBeforeImport = getBooksMock.mock.calls.length;
+
+    const openButton = await screen.findByRole('button', {
+      name: /import files/i,
+    });
+    fireEvent.click(openButton);
+
+    const pathField = await screen.findByLabelText(/import file path/i);
+    fireEvent.change(pathField, { target: { value: '/tmp/book.m4b' } });
+
+    const importButton = await screen.findByRole('button', { name: 'Import' });
+    fireEvent.click(importButton);
+
+    await waitFor(() => {
+      expect(api.importFile).toHaveBeenCalledWith('/tmp/book.m4b', true);
+    });
+
+    // If the cache were still populated, the post-import reload would be
+    // served from the stale cached entry and getBooks would NOT be called
+    // again. Asserting a fresh call proves clearLibraryCache() ran first.
+    await waitFor(() => {
+      expect(getBooksMock.mock.calls.length).toBeGreaterThan(callsBeforeImport);
     });
   });
 

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.73.0
+// version: 1.74.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-07-01
 
@@ -642,6 +642,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       setImportFileDialogOpen(false);
       setImportFilePath('');
       setImportFilePaths([]);
+      clearLibraryCache();
       await loadAudiobooks();
     } catch (error) {
       console.error('Failed to import file:', error);
@@ -680,6 +681,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
             setManualImportDialogOpen(false);
             setManualImportPath('');
             setManualImportError(null);
+            clearLibraryCache();
             await loadAudiobooks();
           } else {
             const message = op.error_message || 'Manual import failed.';
@@ -808,6 +810,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       toast(`${baseMessage}${blockNotice}`, severity);
       setDeleteDialogOpen(false);
       setBookPendingDelete(null);
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -851,6 +854,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       }
       setCrossPageFilter(null);
       setSelectedAudiobooks([]);
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -871,6 +875,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       toast(`Restored ${deletedBooks.length} selected audiobooks.`, 'success');
       setSelectedAudiobooks([]);
       setCrossPageFilter(null);
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -940,6 +945,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       await api.deleteBook(book.id, { softDelete: false, blockHash: false });
       toast(`"${book.title}" was purged from the library.`, 'success');
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -955,6 +961,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       await api.restoreSoftDeletedBook(book.id);
       toast(`"${book.title}" was restored to the library.`, 'success');
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -975,6 +982,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       );
       setPurgeDialogOpen(false);
       setPurgeDeleteFiles(false);
+      clearLibraryCache();
       await loadAudiobooks();
       await loadSoftDeleted();
     } catch (error) {
@@ -1003,6 +1011,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           'success'
         );
       }
+      clearLibraryCache();
       loadAudiobooks();
       setSelectedAudiobooks([]);
       setCrossPageFilter(null);
@@ -1036,6 +1045,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   };
 
   const handleVersionUpdate = () => {
+    clearLibraryCache();
     loadAudiobooks();
   };
 
@@ -1043,6 +1053,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       await api.fetchBookMetadata(audiobook.id);
       // Reload audiobooks to show updated data
+      clearLibraryCache();
       loadAudiobooks();
     } catch (error) {
       console.error('Failed to fetch metadata:', error);
@@ -1313,6 +1324,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       }
 
       if (!bulkOrganizeCancelRef.current && !encounteredError) {
+        clearLibraryCache();
         await loadAudiobooks();
       }
     } catch (error) {
@@ -1355,6 +1367,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
       }
       toast('Rollback complete.', 'success');
       setBulkOrganizeError(null);
+      clearLibraryCache();
       await loadAudiobooks();
     } catch (error) {
       console.error('Failed to rollback organize:', error);
@@ -1366,6 +1379,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     try {
       await api.parseAudiobookWithAI(audiobook.id);
       // Reload audiobooks to show updated data
+      clearLibraryCache();
       loadAudiobooks();
     } catch (error) {
       console.error('Failed to parse with AI:', error);
@@ -1507,6 +1521,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           setOrganizeRunning(false);
           setActiveOrganizeOp(op);
         }
+        clearLibraryCache();
         loadAudiobooks();
         pollingCleanupRef.current = null; // Clear when operation completes
       },


### PR DESCRIPTION
Sweep worker output. Adds clearLibraryCache() before loadAudiobooks() in 13 mutation handlers in Library.tsx (purge/restore/delete/batch/version/metadata/organize/import) so mutated pages aren't served stale from the 60s TTL cache. +regression test. Worker gate: npm build + full vitest (309) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)