### PR TITLE
feat(provenance): DownloadHash field on BookFile + Deluge population + manual-set API (HASH-CHAIN-1)

### DIFF
--- a/internal/database/book_file_test.go
+++ b/internal/database/book_file_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/book_file_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b7c8d9e0-f1a2-3b4c-5d6e-7f8a9b0c1d2e
+// last-edited: 2026-07-01
 
 package database
 
@@ -97,6 +98,29 @@ func TestCreateBookFile(t *testing.T) {
 	assert.Equal(t, "sha256:abc123", got.FileHash)
 	assert.Equal(t, "sha256:original456", got.OriginalFileHash)
 	assert.False(t, got.Missing)
+}
+
+// TestCreateBookFile_DownloadHashRoundTrips verifies the DownloadHash
+// provenance field persists through CreateBookFile/GetBookFileByID unchanged.
+func TestCreateBookFile_DownloadHashRoundTrips(t *testing.T) {
+	store, bookID, cleanup := newTestStoreWithBook(t)
+	defer cleanup()
+
+	f := &BookFile{
+		BookID:       bookID,
+		FilePath:     "/mnt/books/narnia/download_hash_test.m4b",
+		DelugeHash:   "torrent-info-hash",
+		DownloadHash: "download-hash-value",
+	}
+	err := store.CreateBookFile(f)
+	require.NoError(t, err)
+	require.NotEmpty(t, f.ID)
+
+	got, err := store.GetBookFileByID(bookID, f.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "torrent-info-hash", got.DelugeHash)
+	assert.Equal(t, "download-hash-value", got.DownloadHash)
 }
 
 // TestGetBookFiles creates 3 files for one book with different disc/track

--- a/internal/database/pebble_store_mark_import.go
+++ b/internal/database/pebble_store_mark_import.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_mark_import.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e9f1a2b3-c4d5-6789-0abc-def123456789
-// last-edited: 2026-05-15
+// last-edited: 2026-07-01
 
 package database
 
@@ -34,6 +34,9 @@ func (p *PebbleStore) MarkFileImportedFromDeluge(ctx context.Context, originalPa
 			bf.ImportedFromDelugeAt = &now
 			if torrentHash != "" {
 				bf.DelugeHash = torrentHash
+				if bf.DownloadHash == "" {
+					bf.DownloadHash = torrentHash
+				}
 			}
 			return p.UpdateBookFile(bf.ID, bf)
 		}
@@ -66,6 +69,9 @@ func (p *PebbleStore) MarkFileImportedFromDeluge(ctx context.Context, originalPa
 				f.ImportedFromDelugeAt = &now
 				if torrentHash != "" {
 					f.DelugeHash = torrentHash
+					if f.DownloadHash == "" {
+						f.DownloadHash = torrentHash
+					}
 				}
 				return p.UpdateBookFile(f.ID, f)
 			}

--- a/internal/database/pebble_store_mark_import_test.go
+++ b/internal/database/pebble_store_mark_import_test.go
@@ -1,0 +1,138 @@
+// file: internal/database/pebble_store_mark_import_test.go
+// version: 1.0.0
+// guid: 7c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+// last-edited: 2026-07-01
+
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func newPebbleStoreForMarkImport(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "mark-import-db"))
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestMarkFileImportedFromDeluge_ByPath_PopulatesDownloadHashWhenEmpty covers
+// the "match by original path" branch: DownloadHash should be set from
+// torrentHash when it started empty.
+func TestMarkFileImportedFromDeluge_ByPath_PopulatesDownloadHashWhenEmpty(t *testing.T) {
+	store := newPebbleStoreForMarkImport(t)
+
+	bf := &BookFile{
+		BookID:   "book-1",
+		FilePath: "/downloads/original.mp3",
+	}
+	if err := store.CreateBookFile(bf); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	torrentHash := "abc123deadbeef"
+	if err := store.MarkFileImportedFromDeluge(context.Background(), "/downloads/original.mp3", "/library/final.mp3", torrentHash); err != nil {
+		t.Fatalf("MarkFileImportedFromDeluge: %v", err)
+	}
+
+	got, err := store.GetBookFileByID(bf.BookID, bf.ID)
+	if err != nil {
+		t.Fatalf("GetBookFileByID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected book file, got nil")
+	}
+	if got.DelugeHash != torrentHash {
+		t.Fatalf("DelugeHash = %q, want %q", got.DelugeHash, torrentHash)
+	}
+	if got.DownloadHash != torrentHash {
+		t.Fatalf("DownloadHash = %q, want %q (should auto-populate from empty)", got.DownloadHash, torrentHash)
+	}
+}
+
+// TestMarkFileImportedFromDeluge_ByPath_DoesNotClobberManualDownloadHash
+// ensures a pre-set (manual) DownloadHash is left untouched by the Deluge
+// import path.
+func TestMarkFileImportedFromDeluge_ByPath_DoesNotClobberManualDownloadHash(t *testing.T) {
+	store := newPebbleStoreForMarkImport(t)
+
+	manualHash := "manually-set-hash"
+	bf := &BookFile{
+		BookID:       "book-2",
+		FilePath:     "/downloads/original2.mp3",
+		DownloadHash: manualHash,
+	}
+	if err := store.CreateBookFile(bf); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	torrentHash := "different-torrent-hash"
+	if err := store.MarkFileImportedFromDeluge(context.Background(), "/downloads/original2.mp3", "/library/final2.mp3", torrentHash); err != nil {
+		t.Fatalf("MarkFileImportedFromDeluge: %v", err)
+	}
+
+	got, err := store.GetBookFileByID(bf.BookID, bf.ID)
+	if err != nil {
+		t.Fatalf("GetBookFileByID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected book file, got nil")
+	}
+	if got.DelugeHash != torrentHash {
+		t.Fatalf("DelugeHash = %q, want %q", got.DelugeHash, torrentHash)
+	}
+	if got.DownloadHash != manualHash {
+		t.Fatalf("DownloadHash = %q, want unchanged %q (manual value must not be clobbered)", got.DownloadHash, manualHash)
+	}
+}
+
+// TestMarkFileImportedFromDeluge_ByTorrentHash_PopulatesDownloadHash covers
+// the fallback "match by torrent hash via BookVersion" branch.
+func TestMarkFileImportedFromDeluge_ByTorrentHash_PopulatesDownloadHash(t *testing.T) {
+	store := newPebbleStoreForMarkImport(t)
+
+	torrentHash := "fallback-torrent-hash"
+	bv := &BookVersion{
+		BookID:      "book-3",
+		Status:      "active",
+		Format:      "mp3",
+		Source:      "deluge",
+		TorrentHash: torrentHash,
+	}
+	created, err := store.CreateBookVersion(bv)
+	if err != nil {
+		t.Fatalf("CreateBookVersion: %v", err)
+	}
+
+	bf := &BookFile{
+		BookID:    "book-3",
+		FilePath:  "/library/original-name.mp3",
+		VersionID: created.ID,
+	}
+	if err := store.CreateBookFile(bf); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	if err := store.MarkFileImportedFromDeluge(context.Background(), "", "/library/original-name.mp3", torrentHash); err != nil {
+		t.Fatalf("MarkFileImportedFromDeluge: %v", err)
+	}
+
+	got, err := store.GetBookFileByID(bf.BookID, bf.ID)
+	if err != nil {
+		t.Fatalf("GetBookFileByID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected book file, got nil")
+	}
+	if got.DelugeHash != torrentHash {
+		t.Fatalf("DelugeHash = %q, want %q", got.DelugeHash, torrentHash)
+	}
+	if got.DownloadHash != torrentHash {
+		t.Fatalf("DownloadHash = %q, want %q (should auto-populate from empty)", got.DownloadHash, torrentHash)
+	}
+}

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,5 +1,5 @@
 // file: internal/database/store.go
-// version: 2.81.0
+// version: 2.82.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
 // last-edited: 2026-07-01
 
@@ -765,7 +765,13 @@ type BookFile struct {
 	// DelugeHash is the torrent info-hash (40-char hex string).
 	// DelugeOriginalPath is the file path before copy-into-library.
 	// ImportedFromDelugeAt is when the copy completed.
-	DelugeHash           string     `json:"deluge_hash,omitempty"`
+	DelugeHash string `json:"deluge_hash,omitempty"`
+	// DownloadHash is the hash of the originally-downloaded file. It is
+	// distinct from DelugeHash (the torrent info-hash): DownloadHash is
+	// auto-populated from DelugeHash for files imported via Deluge, but may
+	// also be manually set/corrected for files that did not arrive via
+	// Deluge.
+	DownloadHash         string     `json:"download_hash,omitempty"`
 	DelugeOriginalPath   string     `json:"deluge_original_path,omitempty"`
 	ImportedFromDelugeAt *time.Time `json:"imported_from_deluge_at,omitempty"`
 }

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 82f8d1f7-46d5-4ead-b5c1-ba796fd785f9
-// last-edited: 2026-06-23
+// last-edited: 2026-07-01
 
 // File / segment endpoints for the audiobooks domain: segment listing,
 // book-file listing + patch, track-info extraction, relocate, and segment
@@ -139,6 +139,7 @@ func (h *Handler) ListBookFiles(c *gin.Context) {
 			"file_hash":            f.FileHash,
 			"original_file_hash":   f.OriginalFileHash,
 			"post_metadata_hash":   f.PostMetadataHash,
+			"download_hash":        f.DownloadHash,
 			// Acoustic fingerprint segments (0=intro, 1-5=body, 6=outro)
 			"acoustid_seg0":               f.AcoustIDSeg0,
 			"acoustid_seg1":               f.AcoustIDSeg1,
@@ -161,7 +162,7 @@ func (h *Handler) ListBookFiles(c *gin.Context) {
 	httputil.RespondWithOK(c, gin.H{"files": results, "count": len(results)})
 }
 
-// PatchBookFile updates a BookFile (currently only SkipScan).
+// PatchBookFile updates a BookFile (SkipScan, DownloadHash).
 // PATCH /audiobooks/:id/files/:file_id.
 func (h *Handler) PatchBookFile(c *gin.Context) {
 	bookID := c.Param("id")
@@ -174,7 +175,8 @@ func (h *Handler) PatchBookFile(c *gin.Context) {
 	}
 
 	var body struct {
-		SkipScan *bool `json:"skip_scan"`
+		SkipScan     *bool   `json:"skip_scan"`
+		DownloadHash *string `json:"download_hash"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		httputil.RespondWithBadRequest(c, "invalid request body")
@@ -197,6 +199,15 @@ func (h *Handler) PatchBookFile(c *gin.Context) {
 			"book_id", bookID,
 			"file_id", fileID,
 			"skip_scan", *body.SkipScan,
+		)
+	}
+
+	if body.DownloadHash != nil {
+		file.DownloadHash = *body.DownloadHash
+		slog.Info("file download_hash set",
+			"book_id", bookID,
+			"file_id", fileID,
+			"download_hash", *body.DownloadHash,
 		)
 	}
 

--- a/internal/server/handlers/audiobooks/handler_test.go
+++ b/internal/server/handlers/audiobooks/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5cd764d5-8036-425c-842e-c49d0d44acec
-// last-edited: 2026-06-23
+// last-edited: 2026-07-01
 
 // Tests for the audiobooks-domain handlers (main library list / CRUD). The
 // store / audiobook-service / updater / write-back / metadata-state /
@@ -338,6 +338,20 @@ func TestPatchBookFile_Success(t *testing.T) {
 	d.store.EXPECT().GetBookFileByID("b1", "f1").Return(&database.BookFile{ID: "f1"}, nil)
 	d.store.EXPECT().UpsertBookFile(mock.Anything).Return(nil)
 	c, w := newCtx("PATCH", "/audiobooks/b1/files/f1", map[string]any{"skip_scan": true},
+		gin.Params{{Key: "id", Value: "b1"}, {Key: "file_id", Value: "f1"}})
+	h.PatchBookFile(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func TestPatchBookFile_SetsDownloadHash(t *testing.T) {
+	h, d := newHandler(t)
+	d.store.EXPECT().GetBookFileByID("b1", "f1").Return(&database.BookFile{ID: "f1"}, nil)
+	d.store.EXPECT().UpsertBookFile(mock.MatchedBy(func(f *database.BookFile) bool {
+		return f.DownloadHash == "abc123"
+	})).Return(nil)
+	c, w := newCtx("PATCH", "/audiobooks/b1/files/f1", map[string]any{"download_hash": "abc123"},
 		gin.Params{{Key: "id", Value: "b1"}, {Key: "file_id", Value: "f1"}})
 	h.PatchBookFile(c)
 	if w.Code != http.StatusOK {


### PR DESCRIPTION
Sweep worker output. Adds BookFile.DownloadHash (PebbleDB), populated from Deluge torrent hash on import (not clobbering manual values), plus PATCH API to set it. +5 tests. No mock regen (struct field only). Gate: build + mocks-check + database tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)