### PR TITLE
feat(library-ui): saved filter presets (USER-QUICK-FILTERS)

### DIFF
--- a/web/src/components/library/LibraryToolbar.tsx
+++ b/web/src/components/library/LibraryToolbar.tsx
@@ -1,8 +1,9 @@
 // file: web/src/components/library/LibraryToolbar.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
 // last-edited: 2026-07-01
 
+import { useState } from 'react';
 import {
   Typography,
   Box,
@@ -13,6 +14,10 @@ import {
   CircularProgress,
   Drawer,
   Divider,
+  Menu,
+  MenuItem,
+  ListItemText,
+  IconButton,
 } from '@mui/material';
 import {
   FilterList as FilterListIcon,
@@ -20,11 +25,15 @@ import {
   DriveFolderUpload as ManualImportIcon,
   Delete as DeleteSweepIcon,
   Refresh as RefreshIcon,
+  Bookmark as BookmarkIcon,
+  Edit as EditIcon,
+  Close as CloseIcon,
 } from '@mui/icons-material';
 import { ColumnChooser } from '../audiobooks/ColumnChooser';
 import { BatchToolbar } from '../BatchToolbar';
 import type { Audiobook } from '../../types';
 import * as api from '../../services/api';
+import type { SavedFilterPreset } from '../../services/api';
 
 interface LibraryToolbarProps {
   hasSelection: boolean;
@@ -47,6 +56,11 @@ interface LibraryToolbarProps {
   toggleColumn: (id: string) => void;
   resetColumnsToDefaults: () => void;
   getActiveFilterCount: () => number;
+  savedPresets: SavedFilterPreset[];
+  onSaveCurrentAsPreset: () => void;
+  onApplyPreset: (preset: SavedFilterPreset) => void;
+  onRenamePreset: (preset: SavedFilterPreset) => void;
+  onDeletePreset: (preset: SavedFilterPreset) => void;
   onBatchEdit: () => void;
   onFetchReview: () => Promise<void>;
   onFetchAllUnmatched: () => Promise<void>;
@@ -91,6 +105,11 @@ export const LibraryToolbar = ({
   toggleColumn,
   resetColumnsToDefaults,
   getActiveFilterCount,
+  savedPresets,
+  onSaveCurrentAsPreset,
+  onApplyPreset,
+  onRenamePreset,
+  onDeletePreset,
   onBatchEdit,
   onFetchReview,
   onFetchAllUnmatched,
@@ -112,7 +131,12 @@ export const LibraryToolbar = ({
   onPurgeOpen,
   onStorageDrawerClose,
   navigate,
-}: LibraryToolbarProps) => (
+}: LibraryToolbarProps) => {
+  const [presetsMenuAnchor, setPresetsMenuAnchor] = useState<null | HTMLElement>(null);
+  const presetsMenuOpen = Boolean(presetsMenuAnchor);
+  const closePresetsMenu = () => setPresetsMenuAnchor(null);
+
+  return (
   <>
     {/* Unified toolbar — sticky, shows library actions or batch actions based on selection */}
     <Box
@@ -158,6 +182,58 @@ export const LibraryToolbar = ({
           <Button startIcon={<FilterListIcon />} onClick={onFilterOpen} variant="outlined" size="small">
             Filters{getActiveFilterCount() > 0 && <Chip label={getActiveFilterCount()} size="small" color="primary" sx={{ ml: 0.5, height: 18 }} />}
           </Button>
+          <Button
+            startIcon={<BookmarkIcon />}
+            onClick={(e) => setPresetsMenuAnchor(e.currentTarget)}
+            variant="outlined"
+            size="small"
+          >
+            Presets{savedPresets.length > 0 && <Chip label={savedPresets.length} size="small" color="primary" sx={{ ml: 0.5, height: 18 }} />}
+          </Button>
+          <Menu anchorEl={presetsMenuAnchor} open={presetsMenuOpen} onClose={closePresetsMenu}>
+            <MenuItem
+              onClick={() => {
+                closePresetsMenu();
+                onSaveCurrentAsPreset();
+              }}
+            >
+              Save current filters as preset...
+            </MenuItem>
+            {savedPresets.length > 0 && <Divider />}
+            {savedPresets.map((preset) => (
+              <MenuItem
+                key={preset.id}
+                onClick={() => {
+                  closePresetsMenu();
+                  onApplyPreset(preset);
+                }}
+              >
+                <ListItemText>{preset.name}</ListItemText>
+                <IconButton
+                  size="small"
+                  aria-label={`Rename ${preset.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closePresetsMenu();
+                    onRenamePreset(preset);
+                  }}
+                >
+                  <EditIcon fontSize="inherit" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  aria-label={`Delete ${preset.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closePresetsMenu();
+                    onDeletePreset(preset);
+                  }}
+                >
+                  <CloseIcon fontSize="inherit" />
+                </IconButton>
+              </MenuItem>
+            ))}
+          </Menu>
           <ColumnChooser visibleColumnIds={visibleColumnIds} onToggleColumn={toggleColumn} onResetDefaults={resetColumnsToDefaults} />
           <Button variant="outlined" size="small" startIcon={organizeRunning ? <CircularProgress size={16} /> : undefined} disabled={organizeRunning} onClick={onOrganizeLibrary}>{organizeRunning ? 'Organizing…' : 'Organize Library'}</Button>
           <Button variant="outlined" size="small" startIcon={activeScanOp !== null ? <CircularProgress size={16} /> : <RefreshIcon />} disabled={activeScanOp !== null} onClick={onFullRescan}>{activeScanOp !== null ? 'Scanning…' : 'Full Rescan'}</Button>
@@ -237,4 +313,5 @@ export const LibraryToolbar = ({
       </Box>
     </Drawer>
   </>
-);
+  );
+};

--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.bulkFetch.test.tsx
-// version: 1.4.0
+// version: 1.5.0
 // guid: 5b7b0d6f-5c2b-4d57-9b6c-8dbb7a9e9e2c
-// last-edited: 2026-05-08
+// last-edited: 2026-07-01
 
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -77,6 +77,8 @@ vi.mock('../services/api', () => {
     }),
     getOperationTimeline: vi.fn().mockResolvedValue([]),
     getActiveOperations: vi.fn().mockResolvedValue([]),
+    getSavedFilterPresets: vi.fn().mockResolvedValue([]),
+    saveSavedFilterPresets: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.5.0
+// version: 1.6.0
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
 // last-edited: 2026-07-01
 
@@ -91,6 +91,8 @@ vi.mock('../services/api', () => {
       trace_id: null,
       span_id: null,
     }),
+    getSavedFilterPresets: vi.fn().mockResolvedValue([]),
+    saveSavedFilterPresets: vi.fn().mockResolvedValue(undefined),
   };
 });
 

--- a/web/src/pages/Library.savedFilterPresets.test.tsx
+++ b/web/src/pages/Library.savedFilterPresets.test.tsx
@@ -1,0 +1,148 @@
+// file: web/src/pages/Library.savedFilterPresets.test.tsx
+// version: 1.0.0
+// guid: e7f8a9b0-c1d2-4e3f-8a9b-0c1d2e3f4a5b
+// last-edited: 2026-07-01
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { Library } from './Library';
+import * as api from '../services/api';
+import type { SavedFilterPreset } from '../services/api';
+
+vi.mock('../services/api', () => {
+  class ApiError extends Error {
+    status: number;
+    data?: unknown;
+    constructor(message: string, status: number, data?: unknown) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.data = data;
+    }
+  }
+  const existingPreset: SavedFilterPreset = {
+    id: 'preset-1',
+    name: 'My Preset',
+    filters: { author: 'Jane Doe' },
+    selectedTags: [],
+  };
+  return {
+    ApiError,
+    getOperationLogsTail: vi.fn().mockResolvedValue([]),
+    getOperationTimeline: vi.fn().mockResolvedValue([]),
+    getActiveOperations: vi.fn().mockResolvedValue([]),
+    getBooks: vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: 'id-1',
+          title: 'Test Book',
+          file_path: '/tmp/book.m4b',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          author_name: 'Author',
+        },
+      ],
+      count: 1,
+    }),
+    searchBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    searchBooksPage: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getImportPaths: vi.fn().mockResolvedValue([]),
+    countBooks: vi.fn().mockResolvedValue(1),
+    getBookFacets: vi.fn().mockResolvedValue({ genres: [], languages: [] }),
+    getAuthors: vi.fn().mockResolvedValue([]),
+    getSeries: vi.fn().mockResolvedValue([]),
+    getSystemStatus: vi.fn().mockResolvedValue({
+      status: 'ok',
+      library: { path: '/tmp', book_count: 1, total_size: 0 },
+      import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
+      memory: {},
+      runtime: {},
+      operations: { recent: [] },
+    }),
+    getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
+    getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getUserColumnConfig: vi.fn().mockResolvedValue(null),
+    saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
+    listAllUserTags: vi.fn().mockResolvedValue([]),
+    getSavedFilterPresets: vi.fn().mockResolvedValue([existingPreset]),
+    saveSavedFilterPresets: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('Library saved filter presets', () => {
+  it('applying a saved preset updates the active filters', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Library />
+      </MemoryRouter>
+    );
+
+    const presetsButton = await screen.findByRole('button', { name: /presets/i });
+    await user.click(presetsButton);
+
+    const presetItem = await screen.findByText('My Preset');
+    await user.click(presetItem);
+
+    await waitFor(() => {
+      const filtersButton = screen.getByRole('button', { name: /filters/i });
+      expect(filtersButton).toHaveTextContent('1');
+    });
+  });
+
+  it('saving the current filters as a new preset persists it', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Library />
+      </MemoryRouter>
+    );
+
+    const presetsButton = await screen.findByRole('button', { name: /presets/i });
+    await user.click(presetsButton);
+
+    const saveMenuItem = await screen.findByText(/save current filters as preset/i);
+    await user.click(saveMenuItem);
+
+    const nameField = await screen.findByLabelText(/preset name/i);
+    await user.type(nameField, 'New Preset');
+
+    const dialog = await screen.findByRole('dialog');
+    const saveButton = within(dialog).getByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    const saveMock = vi.mocked(api.saveSavedFilterPresets);
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalled();
+    });
+    const savedArg = saveMock.mock.calls[saveMock.mock.calls.length - 1][0];
+    expect(savedArg.some((p) => p.name === 'New Preset')).toBe(true);
+    expect(savedArg.some((p) => p.name === 'My Preset')).toBe(true);
+  });
+
+  it('deleting a preset removes it from the list', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Library />
+      </MemoryRouter>
+    );
+
+    const presetsButton = await screen.findByRole('button', { name: /presets/i });
+    await user.click(presetsButton);
+
+    await screen.findByText('My Preset');
+    const deleteButton = await screen.findByRole('button', { name: /delete my preset/i });
+    await user.click(deleteButton);
+
+    const saveMock = vi.mocked(api.saveSavedFilterPresets);
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalledWith([]);
+    });
+
+    await user.click(await screen.findByRole('button', { name: /presets/i }));
+    expect(screen.queryByText('My Preset')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,11 +1,19 @@
 // file: web/src/pages/Library.tsx
-// version: 1.74.0
+// version: 1.75.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-07-01
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Box, Button } from '@mui/material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+} from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CachedIcon from '@mui/icons-material/Cached';
 import { ViewMode } from '../components/audiobooks/SearchBar';
@@ -18,6 +26,7 @@ import type { Audiobook } from '../types';
 import { SortField, SortOrder } from '../types';
 import { parseSearch, type ParsedSearch } from '../utils/searchParser';
 import * as api from '../services/api';
+import type { SavedFilterPreset } from '../services/api';
 import {
   eventSourceManager,
   type EventSourceEvent,
@@ -161,6 +170,91 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   const [parsedSearch, setParsedSearch] = useState<ParsedSearch>(() => parseSearch(initialSearch));
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
   const [bulkRatingDialogOpen, setBulkRatingDialogOpen] = useState(false);
+
+  // Saved filter presets (USER-QUICK-FILTERS)
+  const [savedPresets, setSavedPresets] = useState<SavedFilterPreset[]>([]);
+  const [presetDialogOpen, setPresetDialogOpen] = useState(false);
+  const [presetDialogName, setPresetDialogName] = useState('');
+  const [editingPresetId, setEditingPresetId] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getSavedFilterPresets()
+      .then(setSavedPresets)
+      .catch((err) => {
+        console.error('Failed to load saved filter presets:', err);
+      });
+  }, []);
+
+  const handleOpenSavePresetDialog = useCallback(() => {
+    setEditingPresetId(null);
+    setPresetDialogName('');
+    setPresetDialogOpen(true);
+  }, []);
+
+  const handleOpenRenamePresetDialog = useCallback((preset: SavedFilterPreset) => {
+    setEditingPresetId(preset.id);
+    setPresetDialogName(preset.name);
+    setPresetDialogOpen(true);
+  }, []);
+
+  const handleClosePresetDialog = useCallback(() => {
+    setPresetDialogOpen(false);
+  }, []);
+
+  const handleConfirmPresetDialog = useCallback(async () => {
+    const name = presetDialogName.trim();
+    if (!name) return;
+    let updated: SavedFilterPreset[];
+    if (editingPresetId) {
+      updated = savedPresets.map((p) => (p.id === editingPresetId ? { ...p, name } : p));
+    } else {
+      const newPreset: SavedFilterPreset = {
+        id:
+          typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : `preset-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        name,
+        filters,
+        selectedTags,
+      };
+      updated = [...savedPresets, newPreset];
+    }
+    try {
+      await api.saveSavedFilterPresets(updated);
+      setSavedPresets(updated);
+      setPresetDialogOpen(false);
+      toast(editingPresetId ? 'Preset renamed' : 'Filter preset saved', 'success');
+    } catch (err) {
+      console.error('Failed to save filter preset:', err);
+      toast('Failed to save filter preset', 'error');
+    }
+  }, [presetDialogName, editingPresetId, savedPresets, filters, selectedTags, toast]);
+
+  const handleApplyPreset = useCallback(
+    (preset: SavedFilterPreset) => {
+      baseHandleFiltersChange(preset.filters);
+      if (preset.selectedTags) {
+        setSelectedTags(preset.selectedTags);
+      }
+    },
+    [baseHandleFiltersChange, setSelectedTags]
+  );
+
+  const handleDeletePreset = useCallback(
+    async (preset: SavedFilterPreset) => {
+      const updated = savedPresets.filter((p) => p.id !== preset.id);
+      try {
+        await api.saveSavedFilterPresets(updated);
+        setSavedPresets(updated);
+        toast('Filter preset deleted', 'success');
+      } catch (err) {
+        console.error('Failed to delete filter preset:', err);
+        toast('Failed to delete filter preset', 'error');
+      }
+    },
+    [savedPresets, toast]
+  );
 
   // Column config
   const {
@@ -1696,6 +1790,11 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         toggleColumn={toggleColumn}
         resetColumnsToDefaults={resetColumnsToDefaults}
         getActiveFilterCount={getActiveFilterCount}
+        savedPresets={savedPresets}
+        onSaveCurrentAsPreset={handleOpenSavePresetDialog}
+        onApplyPreset={handleApplyPreset}
+        onRenamePreset={handleOpenRenamePresetDialog}
+        onDeletePreset={handleDeletePreset}
         onBatchEdit={() => setBatchEditOpen(true)}
         onFetchReview={handleFetchReview}
         onFetchAllUnmatched={handleFetchAllUnmatched}
@@ -1945,6 +2044,26 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           batchPlaylistOpen={batchPlaylistOpen}
           setBatchPlaylistOpen={setBatchPlaylistOpen}
         />
+
+        <Dialog open={presetDialogOpen} onClose={handleClosePresetDialog}>
+          <DialogTitle>{editingPresetId ? 'Rename preset' : 'Save current filters as preset'}</DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              margin="dense"
+              label="Preset name"
+              fullWidth
+              value={presetDialogName}
+              onChange={(e) => setPresetDialogName(e.target.value)}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClosePresetDialog}>Cancel</Button>
+            <Button onClick={handleConfirmPresetDialog} disabled={!presetDialogName.trim()} variant="contained">
+              Save
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Box>
     </Box>
   );

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,10 +1,12 @@
 // file: web/src/services/api.ts
-// version: 2.48.0
+// version: 2.49.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-07-01
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
+
+import type { FilterOptions } from '../types';
 
 import { withOptimisticOperation } from '../utils/withOptimisticOperation';
 import { apiFetch } from '../utils/apiFetch';
@@ -4643,6 +4645,41 @@ export async function deleteUserColumnConfig(): Promise<void> {
   // Ignore 404 — config may not exist
   if (!response.ok && response.status !== 404) {
     throw await buildApiError(response, 'Failed to delete column config');
+  }
+}
+
+// --- Saved filter presets (USER-QUICK-FILTERS) ---
+
+export interface SavedFilterPreset {
+  id: string;
+  name: string;
+  filters: FilterOptions;
+  selectedTags?: string[];
+}
+
+const FILTER_PRESETS_KEY = 'library_filter_presets';
+
+export async function getSavedFilterPresets(): Promise<SavedFilterPreset[]> {
+  const response = await apiFetch(`${API_BASE}/preferences/${FILTER_PRESETS_KEY}`);
+  if (!response.ok) return [];
+  const data = await response.json();
+  if (!data.value) return [];
+  try {
+    const parsed = JSON.parse(data.value);
+    return Array.isArray(parsed) ? (parsed as SavedFilterPreset[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveSavedFilterPresets(presets: SavedFilterPreset[]): Promise<void> {
+  const response = await apiFetch(`${API_BASE}/preferences/${FILTER_PRESETS_KEY}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value: JSON.stringify(presets) }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to save filter presets');
   }
 }
 


### PR DESCRIPTION
Sweep worker output. Save current Library filter set as a named preset, persisted per-user via the existing /preferences library_filter_presets key (no new backend routes); apply/rename/delete from a Presets menu. +3 tests. Worker gate: npm build + 313 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)