### PR TITLE
refactor(scanner): op-context logging + ctx threading in scan deep paths (SLOG-W13c)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 // file: cmd/root.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-// last-edited: 2026-06-22
+// last-edited: 2026-07-01
 
 package cmd
 
@@ -40,7 +40,7 @@ var metadataInspectFile string
 var (
 	initializeStore        = database.InitializeStore
 	closeStore             = database.CloseStore
-	scanDirectory          = scanner.ScanDirectory // func(string, logger.Logger) ([]Book, error)
+	scanDirectory          = scanner.ScanDirectory // func(context.Context, string, logger.Logger) ([]Book, error)
 	processBooks           = scanner.ProcessBooks  // func([]Book, logger.Logger) error
 	generatePlaylists      = playlist.GeneratePlaylistsForSeries
 	updateSeriesTags       = tagger.UpdateSeriesTags
@@ -92,7 +92,7 @@ var scanCmd = &cobra.Command{
 		fmt.Printf("Scanning directory: %s\n", config.AppConfig.RootDir)
 
 		// Start scanning
-		books, err := scanDirectory(config.AppConfig.RootDir, nil)
+		books, err := scanDirectory(cmd.Context(), config.AppConfig.RootDir, nil)
 		if err != nil {
 			return fmt.Errorf("scan error: %w", err)
 		}
@@ -184,7 +184,7 @@ var organizeCmd = &cobra.Command{
 		// Step 1: Scan files
 		fmt.Printf("Using database: %s (%s)\n", config.AppConfig.DatabasePath, config.AppConfig.DatabaseType)
 		fmt.Printf("Scanning directory: %s\n", config.AppConfig.RootDir)
-		books, err := scanDirectory(config.AppConfig.RootDir, nil)
+		books, err := scanDirectory(cmd.Context(), config.AppConfig.RootDir, nil)
 		if err != nil {
 			return fmt.Errorf("scan error: %w", err)
 		}

--- a/internal/scanner/chapter_consolidation.go
+++ b/internal/scanner/chapter_consolidation.go
@@ -1,17 +1,18 @@
 // file: internal/scanner/chapter_consolidation.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f9a0b1c2-d3e4-5f60-a7b8-c9d0e1f2a3b4
-// last-edited: 2026-04-30
+// last-edited: 2026-07-01
 
 package scanner
 
 import (
-	"log/slog"
+	"context"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/internal/mediainfo"
 )
 
@@ -41,7 +42,7 @@ func normalizeChapterTitle(stem string) string {
 // Files that show no numeric prefix are passed through unchanged.
 // Groups that contain at least one file exceeding the threshold are not
 // consolidated (mixed durations → likely separate books with similar names).
-func consolidateChapterGroups(files []string) []Book {
+func consolidateChapterGroups(ctx context.Context, files []string) []Book {
 	if len(files) == 0 {
 		return nil
 	}
@@ -132,7 +133,7 @@ func consolidateChapterGroups(files []string) []Book {
 		for i, c := range group {
 			paths[i] = c.path
 		}
-		slog.Info("scanner chapter consolidation merging files", "count", len(group), "key", key, "avg_sec_per_file", avgSec, "total_sec", totalSec)
+		logging.Info(ctx, "scanner chapter consolidation merging files", "count", len(group), "key", key, "avg_sec_per_file", avgSec, "total_sec", totalSec)
 		books = append(books, Book{
 			FilePath:     paths[0],
 			Format:       strings.ToLower(filepath.Ext(paths[0])),

--- a/internal/scanner/integration_format_test.go
+++ b/internal/scanner/integration_format_test.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/integration_format_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-24
+// last-edited: 2026-07-01
 
 package scanner
 
@@ -70,7 +70,7 @@ func TestIntegrationRealWorldMixedFormats(t *testing.T) {
 	}
 
 	// Test scanning
-	books, err := ScanDirectoryParallel(tmpDir, 4, nil)
+	books, err := ScanDirectoryParallel(context.Background(), tmpDir, 4, nil)
 	if err != nil {
 		t.Fatalf("Integration scan failed: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestIntegrationProcessingMixedFormats(t *testing.T) {
 	}
 
 	// Scan and process
-	books, err := ScanDirectory(tmpDir, nil)
+	books, err := ScanDirectory(context.Background(), tmpDir, nil)
 	if err != nil {
 		t.Fatalf("Scan failed: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestIntegrationLargeScaleMixedFormats(t *testing.T) {
 	workerCounts := []int{1, 2, 4, 8}
 	for _, workers := range workerCounts {
 		t.Run(fmt.Sprintf("workers_%d", workers), func(t *testing.T) {
-			books, err := ScanDirectoryParallel(tmpDir, workers, nil)
+			books, err := ScanDirectoryParallel(context.Background(), tmpDir, workers, nil)
 			if err != nil {
 				t.Fatalf("Scan with %d workers failed: %v", workers, err)
 			}

--- a/internal/scanner/mocks/mock_scanner.go
+++ b/internal/scanner/mocks/mock_scanner.go
@@ -300,8 +300,8 @@ func (_c *MockScanner_ScanDirectory_Call) RunAndReturn(run func(rootDir string, 
 }
 
 // ScanDirectoryParallel provides a mock function for the type MockScanner
-func (_mock *MockScanner) ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) ([]scanner.Book, error) {
-	ret := _mock.Called(rootDir, workers, scanLog)
+func (_mock *MockScanner) ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, scanLog logger.Logger) ([]scanner.Book, error) {
+	ret := _mock.Called(ctx, rootDir, workers, scanLog)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ScanDirectoryParallel")
@@ -309,18 +309,18 @@ func (_mock *MockScanner) ScanDirectoryParallel(rootDir string, workers int, sca
 
 	var r0 []scanner.Book
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, int, logger.Logger) ([]scanner.Book, error)); ok {
-		return returnFunc(rootDir, workers, scanLog)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, logger.Logger) ([]scanner.Book, error)); ok {
+		return returnFunc(ctx, rootDir, workers, scanLog)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, int, logger.Logger) []scanner.Book); ok {
-		r0 = returnFunc(rootDir, workers, scanLog)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int, logger.Logger) []scanner.Book); ok {
+		r0 = returnFunc(ctx, rootDir, workers, scanLog)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]scanner.Book)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, int, logger.Logger) error); ok {
-		r1 = returnFunc(rootDir, workers, scanLog)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int, logger.Logger) error); ok {
+		r1 = returnFunc(ctx, rootDir, workers, scanLog)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -333,31 +333,37 @@ type MockScanner_ScanDirectoryParallel_Call struct {
 }
 
 // ScanDirectoryParallel is a helper method to define mock.On call
+//   - ctx context.Context
 //   - rootDir string
 //   - workers int
 //   - scanLog logger.Logger
-func (_e *MockScanner_Expecter) ScanDirectoryParallel(rootDir any, workers any, scanLog any) *MockScanner_ScanDirectoryParallel_Call {
-	return &MockScanner_ScanDirectoryParallel_Call{Call: _e.mock.On("ScanDirectoryParallel", rootDir, workers, scanLog)}
+func (_e *MockScanner_Expecter) ScanDirectoryParallel(ctx any, rootDir any, workers any, scanLog any) *MockScanner_ScanDirectoryParallel_Call {
+	return &MockScanner_ScanDirectoryParallel_Call{Call: _e.mock.On("ScanDirectoryParallel", ctx, rootDir, workers, scanLog)}
 }
 
-func (_c *MockScanner_ScanDirectoryParallel_Call) Run(run func(rootDir string, workers int, scanLog logger.Logger)) *MockScanner_ScanDirectoryParallel_Call {
+func (_c *MockScanner_ScanDirectoryParallel_Call) Run(run func(ctx context.Context, rootDir string, workers int, scanLog logger.Logger)) *MockScanner_ScanDirectoryParallel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(string)
 		}
-		var arg2 logger.Logger
+		var arg2 int
 		if args[2] != nil {
-			arg2 = args[2].(logger.Logger)
+			arg2 = args[2].(int)
+		}
+		var arg3 logger.Logger
+		if args[3] != nil {
+			arg3 = args[3].(logger.Logger)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -368,7 +374,7 @@ func (_c *MockScanner_ScanDirectoryParallel_Call) Return(books []scanner.Book, e
 	return _c
 }
 
-func (_c *MockScanner_ScanDirectoryParallel_Call) RunAndReturn(run func(rootDir string, workers int, scanLog logger.Logger) ([]scanner.Book, error)) *MockScanner_ScanDirectoryParallel_Call {
+func (_c *MockScanner_ScanDirectoryParallel_Call) RunAndReturn(run func(ctx context.Context, rootDir string, workers int, scanLog logger.Logger) ([]scanner.Book, error)) *MockScanner_ScanDirectoryParallel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/scanner/multi_format_test.go
+++ b/internal/scanner/multi_format_test.go
@@ -1,10 +1,12 @@
 // file: internal/scanner/multi_format_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-01
 
 package scanner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,7 +87,7 @@ func TestMultiFormatSupport(t *testing.T) {
 			}
 
 			// Scan directory
-			books, err := ScanDirectory(tmpDir, nil)
+			books, err := ScanDirectory(context.Background(), tmpDir, nil)
 			if err != nil {
 				t.Fatalf("ScanDirectory failed: %v", err)
 			}
@@ -162,7 +164,7 @@ func TestParallelScanWithMixedFormats(t *testing.T) {
 	// Test with different worker counts
 	for workers := 1; workers <= 4; workers++ {
 		t.Run("workers_"+string(rune(workers+'0')), func(t *testing.T) {
-			books, err := ScanDirectoryParallel(tmpDir, workers, nil)
+			books, err := ScanDirectoryParallel(context.Background(), tmpDir, workers, nil)
 			if err != nil {
 				t.Fatalf("Parallel scan failed: %v", err)
 			}
@@ -210,7 +212,7 @@ func TestFormatPreservation(t *testing.T) {
 		}
 	}
 
-	books, err := ScanDirectory(tmpDir, nil)
+	books, err := ScanDirectory(context.Background(), tmpDir, nil)
 	if err != nil {
 		t.Fatalf("Scan failed: %v", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.46.0
+// version: 1.47.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-06-23
+// last-edited: 2026-07-01
 
 package scanner
 
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/internal/matcher"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
@@ -47,7 +47,7 @@ var defaultLog = logger.New("scanner")
 // Tests can swap in a mock implementation via SetScanner.
 type Scanner interface {
 	ScanDirectory(rootDir string, scanLog logger.Logger) ([]Book, error)
-	ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) ([]Book, error)
+	ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, scanLog logger.Logger) ([]Book, error)
 	ProcessBooks(books []Book, scanLog logger.Logger) error
 	ProcessBooksParallel(ctx context.Context, books []Book, workers int, progressFn func(processed int, total int, bookPath string), scanLog logger.Logger) error
 	ComputeFileHash(filePath string) (string, error)
@@ -339,18 +339,18 @@ type Book struct {
 
 // ScanDirectory scans the given directory for audiobook files.
 // If scanLog is nil, a default logger is used.
-func ScanDirectory(rootDir string, scanLog logger.Logger) ([]Book, error) {
+func ScanDirectory(ctx context.Context, rootDir string, scanLog logger.Logger) ([]Book, error) {
 	if activeScanner != nil {
 		return activeScanner.ScanDirectory(rootDir, scanLog)
 	}
-	return ScanDirectoryParallel(rootDir, 1, scanLog)
+	return ScanDirectoryParallel(ctx, rootDir, 1, scanLog)
 }
 
 // ScanDirectoryParallel scans directory with parallel workers for improved performance.
 // If scanLog is nil, a default logger is used.
-func ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) ([]Book, error) {
+func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, scanLog logger.Logger) ([]Book, error) {
 	if activeScanner != nil {
-		return activeScanner.ScanDirectoryParallel(rootDir, workers, scanLog)
+		return activeScanner.ScanDirectoryParallel(ctx, rootDir, workers, scanLog)
 	}
 	if scanLog == nil {
 		scanLog = logger.New("scanner")
@@ -458,7 +458,7 @@ func ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) (
 			}
 
 			// Group files into logical books using album tags
-			localBooks := groupFilesIntoBooks(audioFiles)
+			localBooks := groupFilesIntoBooks(ctx, audioFiles)
 
 			// Merge results
 			if len(localBooks) > 0 {
@@ -477,9 +477,9 @@ func ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) (
 	// Path-based + prefix⊆parent guard; gated OFF by default (see CoalesceShatteredSiblings).
 	if config.AppConfig.CoalesceShatteredSiblings {
 		before := len(books)
-		books = coalesceShatteredSiblings(books)
+		books = coalesceShatteredSiblings(ctx, books)
 		if len(books) != before {
-			slog.Info("scanner shattered-sibling coalesce", "books_before", before, "books_after", len(books))
+			logging.Info(ctx, "scanner shattered-sibling coalesce", "books_before", before, "books_after", len(books))
 		}
 	}
 
@@ -1541,7 +1541,7 @@ func quickReadMultiFileInfo(filePath string) MultiFileInfo {
 // When all files in a directory share the same non-empty album tag, they become a
 // single directory-based Book (with segments created later). Otherwise, each file
 // is treated as an individual Book (existing hash-based dedup handles linking).
-func groupFilesIntoBooks(files []string) []Book {
+func groupFilesIntoBooks(ctx context.Context, files []string) []Book {
 	if len(files) <= 1 {
 		var books []Book
 		for _, f := range files {
@@ -1568,7 +1568,7 @@ func groupFilesIntoBooks(files []string) []Book {
 			for i, s := range sorted {
 				segs[i] = s.Path
 			}
-			slog.Info("scanner multi-file group detected",
+			logging.Info(ctx, "scanner multi-file group detected",
 				"dir", filepath.Dir(segs[0]),
 				"count", len(segs),
 				"first", filepath.Base(segs[0]),
@@ -1673,7 +1673,7 @@ func groupFilesIntoBooks(files []string) []Book {
 	// Apply chapter consolidation to files with no album tag and no playlist
 	// claim. Groups of ≥ 3 files sharing a numbered base title that are
 	// individually short are merged into one multi-file book.
-	books = append(books, consolidateChapterGroups(noAlbum)...)
+	books = append(books, consolidateChapterGroups(ctx, noAlbum)...)
 	return books
 }
 

--- a/internal/scanner/scanner_coverage_test.go
+++ b/internal/scanner/scanner_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner_coverage_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 7d8e9f0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a
-// last-edited: 2026-06-10
+// last-edited: 2026-07-01
 
 // NOTE(fable5 T022): Removed tests that used database.DB, database.Initialize,
 // or database.Close (legacy SQLite path removed). TestSaveBookToDatabaseWithoutStore
@@ -382,7 +382,7 @@ func TestScanDirectoryParallelReadDirError(t *testing.T) {
 
 	// This should not panic even if ReadDir fails on the file
 	config.AppConfig.SupportedExtensions = []string{".m4b"}
-	books, err := ScanDirectoryParallel(tmp, 2, nil)
+	books, err := ScanDirectoryParallel(context.Background(), tmp, 2, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestScanDirectoryParallelReadDirError(t *testing.T) {
 // TestScanDirectoryParallelWalkError tests error handling when Walk fails
 func TestScanDirectoryParallelWalkError(t *testing.T) {
 	config.AppConfig.SupportedExtensions = []string{".m4b"}
-	_, err := ScanDirectoryParallel("/completely/nonexistent/path/12345", 2, nil)
+	_, err := ScanDirectoryParallel(context.Background(), "/completely/nonexistent/path/12345", 2, nil)
 	if err == nil {
 		t.Error("expected error for nonexistent directory")
 	}
@@ -588,7 +588,7 @@ func TestScanDirectoryParallelMultipleWorkers(t *testing.T) {
 	workers := []int{0, 1, 2, 4, 8}
 	for _, w := range workers {
 		t.Run(fmt.Sprintf("workers_%d", w), func(t *testing.T) {
-			books, err := ScanDirectoryParallel(tmp, w, nil)
+			books, err := ScanDirectoryParallel(context.Background(), tmp, w, nil)
 			if err != nil {
 				t.Fatalf("scan error: %v", err)
 			}
@@ -643,7 +643,7 @@ func TestScanDirectoryGlobalScanner(t *testing.T) {
 		books: []Book{{FilePath: "/mock/book.m4b", Title: "Mock Book"}},
 	})
 
-	books, err := ScanDirectory("/any/dir", nil)
+	books, err := ScanDirectory(context.Background(), "/any/dir", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -660,7 +660,7 @@ func (m *fullMockScanner) ScanDirectory(rootDir string, _ logger.Logger) ([]Book
 	return m.books, nil
 }
 
-func (m *fullMockScanner) ScanDirectoryParallel(rootDir string, workers int, _ logger.Logger) ([]Book, error) {
+func (m *fullMockScanner) ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, _ logger.Logger) ([]Book, error) {
 	return m.books, nil
 }
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,6 +1,7 @@
 // file: internal/scanner/scanner_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5c1a2b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+// last-edited: 2026-07-01
 
 package scanner
 
@@ -44,7 +45,7 @@ func TestScanDirectoryParallelFiltersExtensions(t *testing.T) {
 		t.Fatalf("write other: %v", err)
 	}
 
-	books, err := ScanDirectoryParallel(dir, 2, nil)
+	books, err := ScanDirectoryParallel(context.Background(), dir, 2, nil)
 	if err != nil {
 		t.Fatalf("ScanDirectoryParallel error: %v", err)
 	}
@@ -178,7 +179,7 @@ func TestScanDirectory(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	books, err := ScanDirectory(dir, nil)
+	books, err := ScanDirectory(context.Background(), dir, nil)
 	if err != nil {
 		t.Fatalf("ScanDirectory error: %v", err)
 	}
@@ -338,7 +339,7 @@ func TestScanDirectoryParallelNegativeWorkers(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	books, err := ScanDirectoryParallel(dir, -1, nil)
+	books, err := ScanDirectoryParallel(context.Background(), dir, -1, nil)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-05-05
+// last-edited: 2026-07-01
 package scanner
 
 import (
@@ -278,7 +278,7 @@ func (ss *ScanService) scanFolder(ctx context.Context, folderIdx int, folderPath
 	if workers < 1 {
 		workers = 4
 	}
-	books, err := ScanDirectoryParallel(folderPath, workers, log.With("scanner"))
+	books, err := ScanDirectoryParallel(ctx, folderPath, workers, log.With("scanner"))
 	if err != nil {
 		return fmt.Errorf("failed to scan folder: %w", err)
 	}

--- a/internal/scanner/shattered_coalesce.go
+++ b/internal/scanner/shattered_coalesce.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/shattered_coalesce.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9b4e2a17-6c08-4d35-8f91-3a7d05c2e6b4
-// last-edited: 2026-06-21
+// last-edited: 2026-07-01
 
 // Package scanner — scan-time prevention of the "shattered book" defect.
 //
@@ -26,12 +26,14 @@
 package scanner
 
 import (
-	"log/slog"
+	"context"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 )
 
 // shatterChapterDirRe matches a chapter subdir basename "<prefix> - <number>".
@@ -71,7 +73,7 @@ func normShatterPrefix(s string) string {
 // shattered book (sibling "<prefix> - N" subdirs under a book-named folder) into
 // ONE multi-file Book with SegmentFiles ordered by chapter number. All other
 // books pass through untouched. Returns the input unchanged when nothing merges.
-func coalesceShatteredSiblings(books []Book) []Book {
+func coalesceShatteredSiblings(ctx context.Context, books []Book) []Book {
 	type key struct{ parent, prefix string }
 	groups := map[key][]int{}
 	for i := range books {
@@ -115,7 +117,7 @@ func coalesceShatteredSiblings(books []Book) []Book {
 			Format:       strings.ToLower(filepath.Ext(segs[0])),
 			SegmentFiles: segs,
 		}
-		slog.Info("scanner coalesced shattered siblings",
+		logging.Info(ctx, "scanner coalesced shattered siblings",
 			"book", k.prefix, "chapters", len(segs), "dir", k.parent)
 	}
 	if len(coalesced) == 0 {

--- a/internal/scanner/shattered_coalesce_test.go
+++ b/internal/scanner/shattered_coalesce_test.go
@@ -1,11 +1,12 @@
 // file: internal/scanner/shattered_coalesce_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c7e9a02-8d31-4b65-9f80-1a3c6d2e7b59
-// last-edited: 2026-06-21
+// last-edited: 2026-07-01
 
 package scanner
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
@@ -21,7 +22,7 @@ func TestCoalesce_ShatteredMergesToOneBook(t *testing.T) {
 		sf(base + "/Cage of Souls - 2/01.mp3"),
 		sf(base + "/Cage of Souls - 3/01.mp3"),
 	}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 1 {
 		t.Fatalf("got %d books, want 1: %+v", len(out), out)
 	}
@@ -44,7 +45,7 @@ func TestCoalesce_OrdersChaptersNumerically(t *testing.T) {
 		sf(base + "/Elantris - 1/f.mp3"),
 		sf(base + "/Elantris - 10/f.mp3"),
 	}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 1 {
 		t.Fatalf("got %d books, want 1", len(out))
 	}
@@ -66,7 +67,7 @@ func TestCoalesce_FlatDumpNotMerged(t *testing.T) {
 		sf("/mnt/bigdata/books/abooks/Throne of Jade - 1/f.mp3"),
 		sf("/mnt/bigdata/books/abooks/Throne of Jade - 2/f.mp3"),
 	}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 2 {
 		t.Errorf("flat dump merged (got %d, want 2 untouched): %+v", len(out), out)
 	}
@@ -80,7 +81,7 @@ func TestCoalesce_SeriesVolumesNotMerged(t *testing.T) {
 		sf("/lib/Brandon Sanderson/Stormlight - 2/book.m4b"),
 		sf("/lib/Brandon Sanderson/Stormlight - 3/book.m4b"),
 	}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 3 {
 		t.Errorf("series volumes merged (got %d, want 3 untouched): %+v", len(out), out)
 	}
@@ -97,7 +98,7 @@ func TestCoalesce_BoxSetDistinctPrefixesSeparate(t *testing.T) {
 		sf("/lib/Author/Other Book - Other Book/Other Book - 1/f.mp3"),
 		sf("/lib/Author/Other Book - Other Book/Other Book - 2/f.mp3"),
 	}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 2 {
 		t.Fatalf("got %d books, want 2 (one per distinct prefix): %+v", len(out), out)
 	}
@@ -111,7 +112,7 @@ func TestCoalesce_BoxSetDistinctPrefixesSeparate(t *testing.T) {
 // A lone chapter (single member of a group) is not a shattered book.
 func TestCoalesce_LoneChapterNotMerged(t *testing.T) {
 	in := []Book{sf("/lib/A/Solo - Solo/Solo - 1/f.mp3")}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 1 || len(out[0].SegmentFiles) != 0 {
 		t.Errorf("lone chapter altered: %+v", out)
 	}
@@ -122,7 +123,7 @@ func TestCoalesce_PassThroughNonCandidates(t *testing.T) {
 	multi := Book{FilePath: "/lib/A/Book/01.mp3", SegmentFiles: []string{"/lib/A/Book/01.mp3", "/lib/A/Book/02.mp3"}}
 	other := sf("/lib/A/Standalone/whole.m4b")
 	in := []Book{multi, other}
-	out := coalesceShatteredSiblings(in)
+	out := coalesceShatteredSiblings(context.Background(), in)
 	if len(out) != 2 {
 		t.Fatalf("got %d, want 2", len(out))
 	}

--- a/internal/scanner/unit_test.go
+++ b/internal/scanner/unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/unit_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-06-22
+// last-edited: 2026-07-01
 
 package scanner
 
@@ -366,19 +366,19 @@ func TestParseM3UFile(t *testing.T) {
 
 func TestGroupFilesIntoBooks(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
-		books := groupFilesIntoBooks(nil)
+		books := groupFilesIntoBooks(context.Background(), nil)
 		assert.Empty(t, books)
 	})
 
 	t.Run("single file", func(t *testing.T) {
-		books := groupFilesIntoBooks([]string{"/tmp/only.m4b"})
+		books := groupFilesIntoBooks(context.Background(), []string{"/tmp/only.m4b"})
 		require.Len(t, books, 1)
 		assert.Equal(t, "/tmp/only.m4b", books[0].FilePath)
 		assert.Equal(t, ".m4b", books[0].Format)
 	})
 
 	t.Run("single file mp3", func(t *testing.T) {
-		books := groupFilesIntoBooks([]string{"/tmp/song.mp3"})
+		books := groupFilesIntoBooks(context.Background(), []string{"/tmp/song.mp3"})
 		require.Len(t, books, 1)
 		assert.Equal(t, ".mp3", books[0].Format)
 	})
@@ -564,7 +564,7 @@ func TestGroupFilesIntoBooksNoAlbumMultipleFiles(t *testing.T) {
 		files[i] = p
 	}
 
-	books := groupFilesIntoBooks(files)
+	books := groupFilesIntoBooks(context.Background(), files)
 	// With no album tags, each becomes its own book (no album grouping)
 	assert.GreaterOrEqual(t, len(books), 1)
 }
@@ -1416,7 +1416,7 @@ func (m *mockScannerImpl) ScanDirectory(rootDir string, scanLog logger.Logger) (
 	return nil, nil
 }
 
-func (m *mockScannerImpl) ScanDirectoryParallel(rootDir string, workers int, scanLog logger.Logger) ([]Book, error) {
+func (m *mockScannerImpl) ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, scanLog logger.Logger) ([]Book, error) {
 	return nil, nil
 }
 
@@ -1925,7 +1925,7 @@ func TestGroupFilesIntoBooksMultiFileAlbum(t *testing.T) {
 		files[i] = p
 	}
 
-	books := groupFilesIntoBooks(files)
+	books := groupFilesIntoBooks(context.Background(), files)
 	// Without real audio tags, all go to noAlbum path -> each is individual
 	assert.GreaterOrEqual(t, len(books), 1)
 	for _, b := range books {
@@ -1955,7 +1955,7 @@ FILE "ch2.mp3" MP3
 `
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, "book.cue"), []byte(cueContent), 0o644))
 
-	books := groupFilesIntoBooks(files)
+	books := groupFilesIntoBooks(context.Background(), files)
 	// Should create at least 2 books: one grouped + one individual
 	assert.GreaterOrEqual(t, len(books), 1)
 }

--- a/internal/server/folder_autoscan_op.go
+++ b/internal/server/folder_autoscan_op.go
@@ -1,7 +1,7 @@
 // file: internal/server/folder_autoscan_op.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7b3e9f2a-4c1d-4e85-a6b8-2f0d5c8e1a93
-// last-edited: 2026-05-10
+// last-edited: 2026-07-01
 //
 // folder_autoscan_op registers the "library.folder-auto-scan" UOS v2 OperationDef.
 // This op is enqueued when a new import path is added to the library; it replicates
@@ -71,7 +71,7 @@ func (s *Server) RegisterFolderAutoScanOp(reg *opsregistry.Registry) error {
 			if workers < 1 {
 				workers = 4
 			}
-			books, err := scanner.ScanDirectoryParallel(folderPath, workers, scanLog)
+			books, err := scanner.ScanDirectoryParallel(ctx, folderPath, workers, scanLog)
 			if err != nil {
 				return fmt.Errorf("failed to scan folder: %w", err)
 			}

--- a/internal/server/handlers/filesystem.go
+++ b/internal/server/handlers/filesystem.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/filesystem.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c4d5e6f7-a8b9-0123-cdef-012345678901
-// last-edited: 2026-06-17
+// last-edited: 2026-07-01
 
 // Package handlers — FilesystemHandler covers home-directory, filesystem
 // browse, exclusion CRUD, import-path CRUD, and the on-demand single-file
@@ -269,7 +269,7 @@ func (h *FilesystemHandler) AddImportPath(c *gin.Context) {
 	// Fallback: synchronous scan when op registry is unavailable.
 	if folder.Enabled && h.opEnqueuer == nil {
 		if _, statErr := os.Stat(folder.Path); statErr == nil {
-			books, scanErr := scanner.ScanDirectory(folder.Path, nil)
+			books, scanErr := scanner.ScanDirectory(c.Request.Context(), folder.Path, nil)
 			if scanErr == nil {
 				if len(books) > 0 {
 					_ = scanner.ProcessBooks(books, nil)


### PR DESCRIPTION
Sweep worker output. Swaps raw slog for logging.Info(ctx) in scanner deep paths; required widening ScanDirectory/ScanDirectoryParallel/groupFilesIntoBooks with ctx and updating all 14 call sites (incl cmd/root.go, filesystem.go) + hand-editing the scanner mock (scoped, mocks-check green). Gate: full go build ./... + make mocks-check + scanner tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)