### PR TITLE
perf(server): TTL-cache import paths for isProtectedPath (MAYDEPLOY-H7)

### DIFF
--- a/internal/audiobooks/helpers.go
+++ b/internal/audiobooks/helpers.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/helpers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234560010
-// last-edited: 2026-06-16
+// last-edited: 2026-07-01
 //
 // Private utilities needed by the audiobooks service package. These mirror
 // equivalent helpers from internal/server/ but are standalone so that the
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
@@ -235,6 +236,37 @@ type importPathLister interface {
 	GetAllImportPaths() ([]database.ImportPath, error)
 }
 
+// importPathCacheTTLForHelper controls how long cachedImportPathsForHelper
+// reuses a previously fetched import-path list before re-querying the
+// store. Import paths change extremely infrequently (an admin action via
+// the settings UI), so a short TTL-only cache is sufficient here — no
+// invalidation hook is wired into the import-path mutation endpoints
+// (MAYDEPLOY-H7). Not a const so tests can shrink it.
+var importPathCacheTTLForHelper = 5 * time.Second
+
+var (
+	importPathCacheForHelperMu sync.Mutex
+	importPathCacheForHelper   []database.ImportPath
+	importPathCacheForHelperAt time.Time
+)
+
+// cachedImportPathsForHelper returns store.GetAllImportPaths(), reusing the
+// previous result if it was fetched within importPathCacheTTLForHelper.
+func cachedImportPathsForHelper(store importPathLister) ([]database.ImportPath, error) {
+	importPathCacheForHelperMu.Lock()
+	defer importPathCacheForHelperMu.Unlock()
+	if time.Since(importPathCacheForHelperAt) < importPathCacheTTLForHelper {
+		return importPathCacheForHelper, nil
+	}
+	paths, err := store.GetAllImportPaths()
+	if err != nil {
+		return nil, err
+	}
+	importPathCacheForHelper = paths
+	importPathCacheForHelperAt = time.Now()
+	return paths, nil
+}
+
 // isProtectedPath returns true if filePath is under a configured import
 // path, an iTunes library path, or another protected location. Takes an
 // explicit importPathLister so callers thread their own database
@@ -245,7 +277,7 @@ func isProtectedPath(store importPathLister, filePath string) bool {
 	absPath, _ := filepath.Abs(filePath)
 
 	if store != nil {
-		importPaths, err := store.GetAllImportPaths()
+		importPaths, err := cachedImportPathsForHelper(store)
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)

--- a/internal/audiobooks/helpers_test.go
+++ b/internal/audiobooks/helpers_test.go
@@ -1,0 +1,61 @@
+// file: internal/audiobooks/helpers_test.go
+// version: 1.0.0
+// guid: 9d2b6f1c-4a3e-4d5f-8b2a-1c6e9f0a7d21
+// last-edited: 2026-07-01
+
+package audiobooks
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeImportPathLister is a minimal importPathLister used to count how many
+// times GetAllImportPaths is actually invoked, independent of any cache.
+type fakeImportPathLister struct {
+	calls int32
+	paths []database.ImportPath
+}
+
+func (f *fakeImportPathLister) GetAllImportPaths() ([]database.ImportPath, error) {
+	atomic.AddInt32(&f.calls, 1)
+	return f.paths, nil
+}
+
+// TestIsProtectedPathCachesImportPaths verifies that repeated calls to the
+// package-level isProtectedPath within the TTL window reuse the cached
+// import-path list instead of re-fetching from the store every call
+// (MAYDEPLOY-H7).
+func TestIsProtectedPathCachesImportPaths(t *testing.T) {
+	// Reset shared cache state so this test is isolated from others.
+	importPathCacheForHelperMu.Lock()
+	importPathCacheForHelper = nil
+	importPathCacheForHelperAt = time.Time{}
+	importPathCacheForHelperMu.Unlock()
+
+	origTTL := importPathCacheTTLForHelper
+	importPathCacheTTLForHelper = 20 * time.Millisecond
+	t.Cleanup(func() { importPathCacheTTLForHelper = origTTL })
+
+	store := &fakeImportPathLister{paths: []database.ImportPath{{Path: "/library/imports"}}}
+
+	if !isProtectedPath(store, "/library/imports/book.m4b") {
+		t.Fatalf("expected /library/imports/book.m4b to be protected")
+	}
+	if !isProtectedPath(store, "/library/imports/book2.m4b") {
+		t.Fatalf("expected second call to also report protected")
+	}
+	if got := atomic.LoadInt32(&store.calls); got != 1 {
+		t.Fatalf("expected GetAllImportPaths to be called once within TTL, got %d", got)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	isProtectedPath(store, "/library/imports/book3.m4b")
+	if got := atomic.LoadInt32(&store.calls); got != 2 {
+		t.Fatalf("expected GetAllImportPaths to be re-fetched after TTL expiry, got %d", got)
+	}
+}

--- a/internal/server/server_middleware.go
+++ b/internal/server/server_middleware.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_middleware.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 6a093405-441a-4c14-a9c5-46326ea767c1
-// last-edited: 2026-06-22
+// last-edited: 2026-07-01
 
 package server
 
@@ -12,11 +12,44 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/gin-gonic/gin"
 )
+
+// importPathCacheTTL controls how long cachedImportPaths reuses a previously
+// fetched import-path list before re-querying the store. Import paths change
+// extremely infrequently (an admin action via the settings UI), so a short
+// TTL-only cache is sufficient here — no invalidation hook is wired into the
+// import-path mutation endpoints (MAYDEPLOY-H7). Not a const so tests can
+// shrink it.
+var importPathCacheTTL = 5 * time.Second
+
+var (
+	importPathCacheMu sync.Mutex
+	importPathCache   []database.ImportPath
+	importPathCacheAt time.Time
+)
+
+// cachedImportPaths returns store.GetAllImportPaths(), reusing the previous
+// result if it was fetched within importPathCacheTTL.
+func cachedImportPaths(store database.Store) ([]database.ImportPath, error) {
+	importPathCacheMu.Lock()
+	defer importPathCacheMu.Unlock()
+	if time.Since(importPathCacheAt) < importPathCacheTTL {
+		return importPathCache, nil
+	}
+	paths, err := store.GetAllImportPaths()
+	if err != nil {
+		return nil, err
+	}
+	importPathCache = paths
+	importPathCacheAt = time.Now()
+	return paths, nil
+}
 
 func corsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -90,7 +123,7 @@ func (s *Server) isProtectedPath(filePath string) bool {
 
 	// Check import paths
 	if store := s.Store(); store != nil {
-		importPaths, err := store.GetAllImportPaths()
+		importPaths, err := cachedImportPaths(store)
 		if err == nil {
 			for _, ip := range importPaths {
 				ipAbs, _ := filepath.Abs(ip.Path)

--- a/internal/server/server_middleware_test.go
+++ b/internal/server/server_middleware_test.go
@@ -1,0 +1,56 @@
+// file: internal/server/server_middleware_test.go
+// version: 1.0.0
+// guid: 6f3f3e2a-8f1a-4b3e-9c2d-7a1e5f8b9c10
+// last-edited: 2026-07-01
+
+package server
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestIsProtectedPathCachesImportPaths verifies that repeated calls to
+// isProtectedPath within the TTL window reuse the cached import-path list
+// instead of re-fetching from the store on every call (MAYDEPLOY-H7).
+func TestIsProtectedPathCachesImportPaths(t *testing.T) {
+	// Reset shared cache state so this test is isolated from others.
+	importPathCacheMu.Lock()
+	importPathCache = nil
+	importPathCacheAt = time.Time{}
+	importPathCacheMu.Unlock()
+
+	origTTL := importPathCacheTTL
+	importPathCacheTTL = 20 * time.Millisecond
+	t.Cleanup(func() { importPathCacheTTL = origTTL })
+
+	var calls int32
+	mock := &database.MockStore{
+		GetAllImportPathsFunc: func() ([]database.ImportPath, error) {
+			atomic.AddInt32(&calls, 1)
+			return []database.ImportPath{{Path: "/library/imports"}}, nil
+		},
+	}
+
+	srv := NewServer(mock)
+
+	if !srv.isProtectedPath("/library/imports/book.m4b") {
+		t.Fatalf("expected /library/imports/book.m4b to be protected")
+	}
+	if !srv.isProtectedPath("/library/imports/book2.m4b") {
+		t.Fatalf("expected second call to also report protected")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected GetAllImportPaths to be called once within TTL, got %d", got)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	srv.isProtectedPath("/library/imports/book3.m4b")
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected GetAllImportPaths to be re-fetched after TTL expiry, got %d", got)
+	}
+}


### PR DESCRIPTION
Sweep worker output. Adds a mutex-guarded TTL cache for GetAllImportPaths at the two isProtectedPath hot sites (server_middleware.go + audiobooks/helpers.go). +2 tests. Gate: build + Protected/ImportPath tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)