### PR TITLE
feat(library-ui): frequency-sized tag cloud on library page (TAG-SEARCH)

### DIFF
--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.5.2
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 import {
   Typography,
@@ -30,6 +30,7 @@ import { BookGrid } from '../BookGrid';
 import { FilterSidebar } from '../audiobooks/FilterSidebar';
 import type { LibrarySoftDeletedSectionProps } from './LibrarySoftDeletedSection';
 import { LibrarySoftDeletedSection } from './LibrarySoftDeletedSection';
+import { TagCloud } from './TagCloud';
 import type { ColumnDefinition } from '../../config/columnDefinitions';
 import type { Audiobook, FilterOptions, SortField, SortOrder } from '../../types';
 import type { ViewMode } from '../audiobooks/SearchBar';
@@ -247,6 +248,14 @@ export const LibraryBookGrid = ({
           onViewModeChange={setViewMode}
           onLibraryInfoClick={() => setStorageDrawerOpen(true)}
         />
+
+        {availableTags.length > 0 && (
+          <TagCloud
+            availableTags={availableTags}
+            selectedTags={selectedTags}
+            onTagsChange={handleTagFilterChange}
+          />
+        )}
 
         {/* Select All bar — always visible */}
         <Stack direction="row" spacing={1} alignItems="center" sx={{ px: 0.5, mt: -0.5, mb: -1 }}>

--- a/web/src/components/library/TagCloud.test.tsx
+++ b/web/src/components/library/TagCloud.test.tsx
@@ -1,0 +1,88 @@
+// file: web/src/components/library/TagCloud.test.tsx
+// version: 1.0.0
+// guid: 4f3d2c1b-8a9e-4d7c-b6a5-2e1f9c8d7b6a
+// last-edited: 2026-07-01
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { TagCloud } from './TagCloud';
+
+function defaultProps(overrides: Partial<Parameters<typeof TagCloud>[0]> = {}) {
+  return {
+    availableTags: [
+      { tag: 'fantasy', count: 100 },
+      { tag: 'scifi', count: 5 },
+      { tag: 'mystery', count: 20 },
+    ],
+    selectedTags: [] as string[],
+    onTagsChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TagCloud', () => {
+  it('renders a chip for every available tag', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    expect(screen.getByText('fantasy (100)')).toBeInTheDocument();
+    expect(screen.getByText('scifi (5)')).toBeInTheDocument();
+    expect(screen.getByText('mystery (20)')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no available tags', () => {
+    const { container } = renderWithProviders(<TagCloud {...defaultProps({ availableTags: [] })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('sizes chips proportionally to their count', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    const highCountChip = screen.getByText('fantasy (100)').closest('.MuiChip-root');
+    const lowCountChip = screen.getByText('scifi (5)').closest('.MuiChip-root');
+    expect(highCountChip).not.toBeNull();
+    expect(lowCountChip).not.toBeNull();
+
+    const highFontSize = parseFloat(getComputedStyle(highCountChip as HTMLElement).fontSize);
+    const lowFontSize = parseFloat(getComputedStyle(lowCountChip as HTMLElement).fontSize);
+    expect(highFontSize).toBeGreaterThan(lowFontSize);
+  });
+
+  it('calls onTagsChange with the tag added when an unselected tag is clicked', () => {
+    const onTagsChange = vi.fn();
+    renderWithProviders(<TagCloud {...defaultProps({ onTagsChange })} />);
+
+    fireEvent.click(screen.getByText('fantasy (100)'));
+
+    expect(onTagsChange).toHaveBeenCalledWith(['fantasy']);
+  });
+
+  it('calls onTagsChange with the tag removed when a selected tag is clicked', () => {
+    const onTagsChange = vi.fn();
+    renderWithProviders(
+      <TagCloud {...defaultProps({ selectedTags: ['fantasy', 'mystery'], onTagsChange })} />
+    );
+
+    fireEvent.click(screen.getByText('fantasy (100)'));
+
+    expect(onTagsChange).toHaveBeenCalledWith(['mystery']);
+  });
+
+  it('renders selected tags in the filled/primary style', () => {
+    renderWithProviders(<TagCloud {...defaultProps({ selectedTags: ['fantasy'] })} />);
+    const selectedChip = screen.getByText('fantasy (100)').closest('.MuiChip-root');
+    expect(selectedChip).toHaveClass('MuiChip-filled');
+    expect(selectedChip).toHaveClass('MuiChip-colorPrimary');
+  });
+
+  it('toggles collapse when the header is clicked', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    expect(screen.getByLabelText('Collapse tag cloud')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Browse by Tag'));
+
+    expect(screen.getByLabelText('Expand tag cloud')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/library/TagCloud.tsx
+++ b/web/src/components/library/TagCloud.tsx
@@ -1,0 +1,104 @@
+// file: web/src/components/library/TagCloud.tsx
+// version: 1.0.0
+// guid: 7e6c9a1d-3f2b-4c8e-9a5d-1b6f8e2c4d9a
+// last-edited: 2026-07-01
+
+import { useMemo, useState } from 'react';
+import { Box, Chip, Collapse, IconButton, Stack, Typography } from '@mui/material';
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+
+export interface TagCloudProps {
+  availableTags: Array<{ tag: string; count: number }>;
+  selectedTags: string[];
+  onTagsChange: (tags: string[]) => void;
+}
+
+const MIN_FONT_SIZE = 0.75; // rem
+const MAX_FONT_SIZE = 1.5; // rem
+
+/**
+ * Compute a font size (in rem) for a tag proportional to its count relative
+ * to the maximum count in the set. Uses a log scale so a single outlier tag
+ * doesn't dwarf the rest of the cloud, and clamps to [MIN_FONT_SIZE,
+ * MAX_FONT_SIZE] so the layout stays stable.
+ */
+function fontSizeForCount(count: number, maxCount: number): number {
+  if (maxCount <= 1) return MIN_FONT_SIZE;
+  const logCount = Math.log(Math.max(count, 1) + 1);
+  const logMax = Math.log(maxCount + 1);
+  const ratio = logMax === 0 ? 0 : logCount / logMax;
+  const size = MIN_FONT_SIZE + ratio * (MAX_FONT_SIZE - MIN_FONT_SIZE);
+  return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, size));
+}
+
+/**
+ * Browsable tag cloud for the main Library page. Reuses the existing
+ * selectedTags/onTagsChange (handleTagFilterChange) state shared with
+ * FilterSidebar so both UIs stay in sync. Tag chip font-size scales with
+ * frequency (count) so heavily-used tags are visually larger.
+ */
+export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloudProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  const maxCount = useMemo(
+    () => availableTags.reduce((max, t) => Math.max(max, t.count), 0),
+    [availableTags]
+  );
+
+  if (availableTags.length === 0) {
+    return null;
+  }
+
+  const handleToggleTag = (tag: string) => {
+    const exists = selectedTags.includes(tag);
+    const newTags = exists ? selectedTags.filter((x) => x !== tag) : [...selectedTags, tag];
+    onTagsChange(newTags);
+  };
+
+  return (
+    <Box sx={{ p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ cursor: 'pointer' }}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <Typography variant="subtitle2">Browse by Tag</Typography>
+        <IconButton
+          size="small"
+          aria-label={expanded ? 'Collapse tag cloud' : 'Expand tag cloud'}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((prev) => !prev);
+          }}
+        >
+          <ExpandMoreIcon
+            sx={{
+              transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s',
+            }}
+          />
+        </IconButton>
+      </Stack>
+      <Collapse in={expanded}>
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1 }}>
+          {availableTags.map((t) => {
+            const isSelected = selectedTags.includes(t.tag);
+            const fontSize = fontSizeForCount(t.count, maxCount);
+            return (
+              <Chip
+                key={t.tag}
+                label={`${t.tag} (${t.count})`}
+                onClick={() => handleToggleTag(t.tag)}
+                color={isSelected ? 'primary' : undefined}
+                variant={isSelected ? 'filled' : 'outlined'}
+                sx={{ fontSize: `${fontSize}rem`, height: 'auto', py: 0.5 }}
+              />
+            );
+          })}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}


### PR DESCRIPTION
Sweep worker output. Adds a collapsible, frequency-sized TagCloud on the library page reusing existing selectedTags/handleTagFilterChange state (no OR-mode, no backend change). +7 tests. Worker gate: npm build + 320 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)