### PR TITLE
feat(dedup-dataset): live-capture labeled examples on candidate upsert (C5)

### DIFF
--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.4.0
-// last-edited: 2026-06-22
+// version: 2.5.0
+// last-edited: 2026-07-01
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -464,8 +464,19 @@ func (s *EmbeddingStore) nextID(b *pebble.Batch) (int64, error) {
 // downgraded by a less-specific one. LLM fields are always updated when non-empty.
 // Pairs are canonicalised before insert (lexicographically smaller ID is always A).
 func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
+	_, _, err := s.UpsertCandidateNew(c)
+	return err
+}
+
+// UpsertCandidateNew is UpsertCandidate but also reports the assigned
+// candidate ID and whether this call created a brand-new pair (true) or
+// updated an existing one (false). Callers that must react only when a
+// genuinely new candidate is created — e.g. C5 live dataset capture, which
+// must never re-label an existing pair on a score update — should call this
+// instead of UpsertCandidate.
+func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew bool, err error) {
 	if err := s.checkClosed(); err != nil {
-		return err
+		return 0, false, err
 	}
 	if c.EntityAID > c.EntityBID {
 		c.EntityAID, c.EntityBID = c.EntityBID, c.EntityAID
@@ -481,7 +492,7 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 	pairKey := dedupPairKey(c.EntityType, c.EntityAID, c.EntityBID)
 	existingIDBytes, closer, err := s.db.Get(pairKey)
 	if err != nil && err != pebble.ErrNotFound {
-		return fmt.Errorf("upsert candidate pair lookup: %w", err)
+		return 0, false, fmt.Errorf("upsert candidate pair lookup: %w", err)
 	}
 
 	b := s.db.NewBatch()
@@ -491,7 +502,7 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 		// New pair — assign sequential ID.
 		id, err := s.nextID(b)
 		if err != nil {
-			return err
+			return 0, false, err
 		}
 		rec := candRec{
 			EntityType:     c.EntityType,
@@ -510,40 +521,43 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 		}
 		data, err := json.Marshal(rec)
 		if err != nil {
-			return fmt.Errorf("marshal candidate: %w", err)
+			return 0, false, fmt.Errorf("marshal candidate: %w", err)
 		}
 		if err := b.Set(dedupRecKey(id), data, nil); err != nil {
-			return err
+			return 0, false, err
 		}
 		if err := b.Set(pairKey, []byte(fmt.Sprintf("%016x", id)), nil); err != nil {
-			return err
+			return 0, false, err
 		}
 		// Entity secondary index — both sides, so prefix-scan by entity is O(k).
 		if err := b.Set(dedupEntityKey(c.EntityType, c.EntityAID, id), nil, nil); err != nil {
-			return err
+			return 0, false, err
 		}
 		if err := b.Set(dedupEntityKey(c.EntityType, c.EntityBID, id), nil, nil); err != nil {
-			return err
+			return 0, false, err
 		}
-		return b.Commit(pebble.Sync)
+		if err := b.Commit(pebble.Sync); err != nil {
+			return 0, false, err
+		}
+		return id, true, nil
 	}
 
 	// Existing pair — update in-place.
 	idHex := string(existingIDBytes)
 	closer.Close()
-	id, err := strconv.ParseInt(idHex, 16, 64)
+	id, err = strconv.ParseInt(idHex, 16, 64)
 	if err != nil {
-		return fmt.Errorf("parse candidate id %q: %w", idHex, err)
+		return 0, false, fmt.Errorf("parse candidate id %q: %w", idHex, err)
 	}
 
 	val, existingCloser, err := s.db.Get(dedupRecKey(id))
 	if err != nil {
-		return fmt.Errorf("read existing candidate %d: %w", id, err)
+		return 0, false, fmt.Errorf("read existing candidate %d: %w", id, err)
 	}
 	var existing candRec
 	if err := json.Unmarshal(val, &existing); err != nil {
 		existingCloser.Close()
-		return fmt.Errorf("unmarshal existing candidate %d: %w", id, err)
+		return 0, false, fmt.Errorf("unmarshal existing candidate %d: %w", id, err)
 	}
 	existingCloser.Close()
 
@@ -584,19 +598,22 @@ func (s *EmbeddingStore) UpsertCandidate(c DedupCandidate) error {
 
 	data, err := json.Marshal(existing)
 	if err != nil {
-		return fmt.Errorf("marshal updated candidate: %w", err)
+		return 0, false, fmt.Errorf("marshal updated candidate: %w", err)
 	}
 	if err := b.Set(dedupRecKey(id), data, nil); err != nil {
-		return err
+		return 0, false, err
 	}
 	// Idempotent: ensure entity index entries exist (backfills pre-index records).
 	if err := b.Set(dedupEntityKey(existing.EntityType, existing.EntityAID, id), nil, nil); err != nil {
-		return err
+		return 0, false, err
 	}
 	if err := b.Set(dedupEntityKey(existing.EntityType, existing.EntityBID, id), nil, nil); err != nil {
-		return err
+		return 0, false, err
 	}
-	return b.Commit(pebble.Sync)
+	if err := b.Commit(pebble.Sync); err != nil {
+		return 0, false, err
+	}
+	return id, false, nil
 }
 
 // GetCandidateByID retrieves a single candidate by its ID.

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-07-01
 
@@ -51,6 +51,18 @@ const containmentOffsetSteps = 8
 type BuilderStore interface {
 	GetBook(id string) (*database.Book, error)
 	GetBookFiles(id string) ([]database.BookFile, error)
+}
+
+// StoreAdapter bridges a full database.Store onto the narrower BuilderStore
+// interface (database.Store exposes GetBookByID, not GetBook). Exported here
+// so callers that already hold a database.Store (the live dedup engine, the
+// dataset-backfill op) can share a single adapter instead of each defining an
+// identical private one.
+type StoreAdapter struct{ Store database.Store }
+
+func (a StoreAdapter) GetBook(id string) (*database.Book, error) { return a.Store.GetBookByID(id) }
+func (a StoreAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
+	return a.Store.GetBookFiles(id)
 }
 
 // BuildExample loads both books and computes every feature for the candidate pair.

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.39.0
+// version: 1.40.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-01
 
@@ -20,6 +20,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/ai/aijobs"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
@@ -668,7 +669,7 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		// 4. Persist: upsert with unified fields + back-compat Layer/Similarity.
 		sim := composed.Score / 100.0
 		layer := bestLayerFromSignals(signals)
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType:     "book",
 			EntityAID:      canonicalPair[0],
 			EntityBID:      canonicalPair[1],
@@ -685,6 +686,61 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	}
 
 	return nil
+}
+
+// upsertCandidateWithLiveLabel upserts a dedup candidate and, only when the
+// pair is brand new (never on a score/layer update to an existing pair),
+// builds a dataset.BuildExample/dataset.Classify snapshot and records it as a
+// labeled example with an auto (rule-based) label_source. This grows the
+// dedup tuning dataset continuously as candidates are created, instead of
+// only via human review (label_capture.go) or the periodic
+// dedup.dataset-backfill op (spec C5).
+//
+// Live-capture is best-effort: any failure building or persisting the
+// snapshot is logged and swallowed — it must never block the primary
+// candidate upsert, whose error (if any) is still returned.
+func (de *Engine) upsertCandidateWithLiveLabel(c database.DedupCandidate) error {
+	id, isNew, err := de.embedStore.UpsertCandidateNew(c)
+	if err != nil {
+		return err
+	}
+	if !isNew {
+		// Update to an existing pair — never re-label, per the guard in TASK-03/C5.
+		return nil
+	}
+	// Author-pair candidates aren't backed by database.Book rows; BuildExample
+	// loads books via GetBook, so live-capture only applies to "book" entities.
+	if c.EntityType != "book" || de.bookStore == nil {
+		return nil
+	}
+	c.ID = id
+	de.captureLiveLabel(c)
+	return nil
+}
+
+// captureLiveLabel builds and persists a Classify snapshot for a
+// newly-created candidate pair. Best-effort: any failure is logged at debug
+// level and swallowed so it can never affect the caller.
+func (de *Engine) captureLiveLabel(c database.DedupCandidate) {
+	ex, err := dataset.BuildExample(dataset.StoreAdapter{Store: de.bookStore}, c)
+	if err != nil {
+		slog.Debug("dedup live-capture: build example failed",
+			"candidate_id", c.ID, "entity_a", c.EntityAID, "entity_b", c.EntityBID, "err", err)
+		return
+	}
+	// Mirrors dataset_backfill.go: only rule-classified pairs get a Label;
+	// unfired pairs are still persisted (unlabeled) so their features are
+	// captured for future human/ML labeling.
+	if label, reason, fires := dataset.Classify(ex); fires {
+		ex.Label = label
+		ex.LabelSource = "rule"
+		ex.LabelReason = reason
+		ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if err := de.embedStore.UpsertLabeledExample(ex); err != nil {
+		slog.Debug("dedup live-capture: upsert labeled example failed",
+			"candidate_id", c.ID, "err", err)
+	}
 }
 
 // canonicalPairIDs returns [aID, bID] in lexicographically sorted order so
@@ -1292,7 +1348,7 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 			"book_a", a.ID, "book_b", b.ID, "layer", layer)
 		return nil
 	}
-	return de.embedStore.UpsertCandidate(database.DedupCandidate{
+	return de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 		EntityType: "book",
 		EntityAID:  a.ID,
 		EntityBID:  b.ID,
@@ -1621,7 +1677,7 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 			continue
 		}
 		sim := float64(r.Similarity)
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType: "book",
 			EntityAID:  bookID,
 			EntityBID:  r.EntityID,
@@ -1685,7 +1741,7 @@ func (de *Engine) CheckAuthor(ctx context.Context, authorID int) error {
 			continue
 		}
 		sim := float64(r.Similarity)
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType: "author",
 			EntityAID:  entityID,
 			EntityBID:  r.EntityID,
@@ -3107,7 +3163,7 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 			}
 		}
 		emitted[key] = struct{}{}
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType: "book",
 			EntityAID:  bookAID,
 			EntityBID:  bookBID,
@@ -3304,7 +3360,7 @@ func (de *Engine) BookSignatureScan(ctx context.Context, progress func(done, tot
 			return
 		}
 		emitted[key] = struct{}{}
-		if err := de.embedStore.UpsertCandidate(database.DedupCandidate{
+		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType: "book",
 			EntityAID:  bookAID,
 			EntityBID:  bookBID,

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_test.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
-// last-edited: 2026-06-28
+// last-edited: 2026-07-01
 
 package dedup
 
@@ -1421,5 +1421,122 @@ func TestEmbeddingClient_RequestTimeout_FieldIsSetAndNonZero(t *testing.T) {
 	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		// Allow wrapped errors (the SDK wraps ctx errors).
 		t.Logf("EmbedBatch returned non-context error (acceptable for SDK wrapping): %v", err)
+	}
+}
+
+// TestUpsertCandidateWithLiveLabel_NewPairCreatesLabeledExample verifies the
+// C5 live-capture wiring: the first upsert of a brand-new candidate pair must
+// build+classify a snapshot and persist it with an auto (rule-based)
+// label_source.
+func TestUpsertCandidateWithLiveLabel_NewPairCreatesLabeledExample(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := &database.Book{ID: "LIVE_A", Title: "Live Capture Book"}
+	bookB := &database.Book{ID: "LIVE_B", Title: "Live Capture Book"}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "LIVE_A":
+			return bookA, nil
+		case "LIVE_B":
+			return bookB, nil
+		}
+		return nil, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		return nil, nil
+	}
+
+	sim := 0.9
+	if err := engine.upsertCandidateWithLiveLabel(database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  "LIVE_A",
+		EntityBID:  "LIVE_B",
+		Layer:      "embedding",
+		Similarity: &sim,
+		Status:     "pending",
+	}); err != nil {
+		t.Fatalf("upsertCandidateWithLiveLabel: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending"})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected exactly one candidate, got %d", len(cands))
+	}
+	candID := cands[0].ID
+
+	ex, err := es.GetLabeledExample(candID)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if ex == nil {
+		t.Fatal("expected a labeled example to be created for the new pair, got nil")
+	}
+	if ex.LabelSource != "" && ex.LabelSource != "rule" {
+		t.Fatalf("expected label_source to be empty (unfired) or %q, got %q", "rule", ex.LabelSource)
+	}
+	if ex.EntityAID != "LIVE_A" || ex.EntityBID != "LIVE_B" {
+		t.Fatalf("unexpected entity IDs on labeled example: %+v", ex)
+	}
+}
+
+// TestUpsertCandidateWithLiveLabel_UpdateDoesNotDuplicate verifies that
+// calling the live-capture upsert path again for the *same* pair (an update,
+// not a new pair) never creates a second labeled example nor overwrites the
+// first one's snapshot.
+func TestUpsertCandidateWithLiveLabel_UpdateDoesNotDuplicate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	bookA := &database.Book{ID: "DUP_A", Title: "Update Should Not Duplicate"}
+	bookB := &database.Book{ID: "DUP_B", Title: "Update Should Not Duplicate"}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		switch id {
+		case "DUP_A":
+			return bookA, nil
+		case "DUP_B":
+			return bookB, nil
+		}
+		return nil, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		return nil, nil
+	}
+
+	sim := 0.9
+	cand := database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  "DUP_A",
+		EntityBID:  "DUP_B",
+		Layer:      "embedding",
+		Similarity: &sim,
+		Status:     "pending",
+	}
+	if err := engine.upsertCandidateWithLiveLabel(cand); err != nil {
+		t.Fatalf("first upsertCandidateWithLiveLabel: %v", err)
+	}
+
+	before, err := es.ListLabeledExamples(database.LabeledExampleFilter{})
+	if err != nil {
+		t.Fatalf("ListLabeledExamples (before): %v", err)
+	}
+	if len(before) != 1 {
+		t.Fatalf("expected exactly one labeled example after the first upsert, got %d", len(before))
+	}
+
+	// Second call for the identical pair — this is an update, not a new pair.
+	sim2 := 0.95
+	cand.Similarity = &sim2
+	if err := engine.upsertCandidateWithLiveLabel(cand); err != nil {
+		t.Fatalf("second upsertCandidateWithLiveLabel: %v", err)
+	}
+
+	after, err := es.ListLabeledExamples(database.LabeledExampleFilter{})
+	if err != nil {
+		t.Fatalf("ListLabeledExamples (after): %v", err)
+	}
+	if len(after) != 1 {
+		t.Fatalf("expected the update to NOT create a second labeled example, got %d", len(after))
 	}
 }


### PR DESCRIPTION
Sweep worker output. Wires BuildExample+Classify into the candidate-upsert path via upsertCandidateWithLiveLabel (new-pairs only, book entities only), reusing UpsertCandidateNew for id/isNew. Best-effort, failures swallowed at debug. +2 tests. Gate: build + mocks-check + dedup tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)