### PR TITLE
feat(dedup-dataset): NDJSON export of labeled examples (C7)

### DIFF
--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,11 +1,14 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
-// last-edited: 2026-06-23
+// last-edited: 2026-07-01
 
 package deduphandler
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -143,6 +146,56 @@ func (h *Handler) OverrideDedupLabel(c *gin.Context) {
 		return
 	}
 	httputil.RespondWithOK(c, gin.H{"status": "updated", "candidate_id": id, "label": ex.Label, "label_source": ex.LabelSource})
+}
+
+// ExportLabeledExamples handles GET /api/v1/dedup/labels/export (C7).
+//
+// Streams every dedup:label: labeled example as JSONL (one JSON object per
+// line), including the formula/feature version, for offline dataset analysis
+// and training. Read-only — it only reads via ListLabeledExamples, never
+// mutates a label.
+//
+// Query params (all optional, mirror LabeledExampleFilter — empty means "no
+// filter"): label, label_source, band, folder_relation, signature_relation.
+// Unlike ListDedupLabels this endpoint is unpaginated: it exports every row
+// matching the filter.
+func (h *Handler) ExportLabeledExamples(c *gin.Context) {
+	es := h.embeddingStore
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+
+	filter := database.LabeledExampleFilter{
+		Label:             c.Query("label"),
+		LabelSource:       c.Query("label_source"),
+		Band:              c.Query("band"),
+		FolderRelation:    c.Query("folder_relation"),
+		SignatureRelation: c.Query("signature_relation"),
+	}
+
+	items, err := es.ListLabeledExamples(filter)
+	if err != nil {
+		httputil.InternalError(c, "failed to list labeled examples for export", err)
+		return
+	}
+
+	filename := fmt.Sprintf("dedup-labels-%s.jsonl", time.Now().Format("20060102-150405"))
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	c.Header("Content-Type", "application/x-ndjson")
+	c.Status(http.StatusOK)
+
+	enc := json.NewEncoder(c.Writer)
+	flusher, canFlush := c.Writer.(http.Flusher)
+	for _, ex := range items {
+		if err := enc.Encode(ex); err != nil {
+			// Client likely disconnected mid-stream; nothing else to do.
+			return
+		}
+		if canFlush {
+			flusher.Flush()
+		}
+	}
 }
 
 // clampAtoi parses s as an int, falling back to def, then clamps to [lo, hi].

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -1,11 +1,13 @@
 // file: internal/server/handlers/dedup/label_review_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8a3e1c46-9b20-4d75-8f31-2a6e0c9d5b39
-// last-edited: 2026-06-19
+// last-edited: 2026-07-01
 
 package deduphandler_test
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -119,5 +121,101 @@ func TestOverrideDedupLabel_RejectsBadLabel(t *testing.T) {
 		map[string]string{"label": "garbage"}, gin.Params{{Key: "id", Value: "9"}})
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d want 400", w.Code)
+	}
+}
+
+// TestExportLabeledExamples_JSONL covers the C7 read-only JSONL export: every
+// dedup:label: row is streamed as one JSON object per line, including the
+// formula/feature version, and no mutation occurs.
+func TestExportLabeledExamples_JSONL(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 1, "true_dup", "human")
+	seedLabel(t, d, 2, "not_dup", "rule")
+	if err := d.es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: 3, EntityAID: "a", EntityBID: "b",
+		Layer: "exact", Label: "unsure", LabelSource: "llm_judge",
+		LabelReason: "seed", FormulaVersion: "v3",
+	}); err != nil {
+		t.Fatalf("UpsertLabeledExample: %v", err)
+	}
+
+	w := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/x-ndjson" {
+		t.Fatalf("content-type=%q want application/x-ndjson", ct)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(w.Body.Bytes()))
+	var (
+		lines          int
+		sawFormulaVer3 bool
+	)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		lines++
+		var ex database.LabeledExample
+		if err := json.Unmarshal(line, &ex); err != nil {
+			t.Fatalf("line %d not valid LabeledExample JSON: %v; line=%s", lines, err, line)
+		}
+		if ex.CandidateID == 3 && ex.FormulaVersion == "v3" {
+			sawFormulaVer3 = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if lines != 3 {
+		t.Fatalf("expected 3 JSONL lines, got %d; body=%s", lines, w.Body.String())
+	}
+	if !sawFormulaVer3 {
+		t.Fatalf("expected candidate 3 with formula_version=v3 in export; body=%s", w.Body.String())
+	}
+
+	// Read-only: no example should have been mutated by the export.
+	ex, err := d.es.GetLabeledExample(1)
+	if err != nil || ex == nil {
+		t.Fatalf("GetLabeledExample(1): %v", err)
+	}
+	if ex.Label != "true_dup" || ex.LabelSource != "human" {
+		t.Fatalf("export mutated example 1: label=%q source=%q", ex.Label, ex.LabelSource)
+	}
+}
+
+// TestExportLabeledExamples_FilterByLabelSource confirms the same filter
+// fields honored by ListDedupLabels are honored on the export path too.
+func TestExportLabeledExamples_FilterByLabelSource(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 1, "true_dup", "human")
+	seedLabel(t, d, 2, "not_dup", "rule")
+
+	w := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export?label_source=human", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(w.Body.Bytes()))
+	var lines int
+	for scanner.Scan() {
+		if len(scanner.Bytes()) == 0 {
+			continue
+		}
+		lines++
+	}
+	if lines != 1 {
+		t.Fatalf("expected 1 JSONL line for label_source=human filter, got %d; body=%s", lines, w.Body.String())
+	}
+}
+
+// TestExportLabeledExamples_NoEmbedStore mirrors the 503 nil-store guard used
+// throughout this package's other embedding-store-backed handlers.
+func TestExportLabeledExamples_NoEmbedStore(t *testing.T) {
+	h, _ := newHandler(t, noEmbed)
+	w := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export", nil, nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503; body=%s", w.Code, w.Body.String())
 	}
 }

--- a/internal/server/wire_dedup_routes.go
+++ b/internal/server/wire_dedup_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_dedup_routes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-4567-bcde-890123456789
-// last-edited: 2026-06-23
+// last-edited: 2026-07-01
 
 package server
 
@@ -39,6 +39,7 @@ func (s *Server) wireDedupRoutes(
 	// C6 — gold-dataset review (the dedup feedback-loop labels).
 	protected.GET("/dedup/labels", s.perm(auth.PermLibraryView), dedupH.ListDedupLabels)
 	protected.GET("/dedup/labels/stats", s.perm(auth.PermLibraryView), dedupH.GetDedupLabelStats)
+	protected.GET("/dedup/labels/export", s.perm(auth.PermLibraryView), dedupH.ExportLabeledExamples) // C7 — JSONL export of the labeled dataset.
 	protected.POST("/dedup/labels/:id/override", s.perm(auth.PermLibraryEditMetadata), dedupH.OverrideDedupLabel)
 	protected.POST("/dedup/candidates/merge-series", s.perm(auth.PermLibraryEditMetadata), dedupH.MergeDedupCandidateSeries)
 	protected.POST("/dedup/scan", s.perm(auth.PermScanTrigger), dedupH.TriggerDedupScan)


### PR DESCRIPTION
Sweep worker output. Adds GET /dedup/labels/export streaming one JSON LabeledExample per line (reuses ListLabeledExamples + same 5 filters; PermLibraryView to match sibling routes). +3 tests. No mock regen. Gate: build + mocks-check + dedup handler tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)