### PR TITLE
docs(todo): file pre-existing pebble:closed registry shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.93.0 -->
+<!-- version: 3.94.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-01 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Documentation
+
+#### July 1, 2026 — Log pre-existing `pebble: closed` shutdown race (found during agent-task sweep)
+
+- **`docs(todo)`** — Filed `PEBBLE-CLOSED-SHUTDOWN-RACE` in TODO.md Open Bugs: a leaked `DepsScheduler.SweepTick` goroutine (`operations/registry.Registry.Start` → `DepsScheduler.SweepTick` → `PebbleStore.ListWaitingDepsOps`) can outlive a test's `store.Close()` and panic `pebble: closed` under package-wide `go test -race`. Independently reproduced by two sweep workers (the flaky-backup and flaky-scan deflakes, PRs #1711/#1713) as an out-of-scope side-finding; not the cause of those two flakes. Fix direction: stop-signal the sweep goroutine on `Registry.Stop`/cleanup, or make `ListWaitingDepsOps` tolerate a closed DB.
 
 #### July 1, 2026 — Agent-task package refresh (archive shipped, author remaining)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.50.0 -->
+<!-- version: 9.51.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-01 -->
 
@@ -871,6 +871,17 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ## 🐛 Open Bugs — May 17, 2026
 
+- [ ] **PEBBLE-CLOSED-SHUTDOWN-RACE** (2026-07-01, found during the agent-task sweep) — Under
+  `go test -race` (package-wide, e.g. `internal/server`), a leaked `DepsScheduler.SweepTick`
+  goroutine can outlive a test's `store.Close()` and panic with `pebble: closed`, crashing the
+  whole test binary. Path: `operations/registry.Registry.Start` (registry.go:~318) launches the
+  sweep goroutine → `DepsScheduler.SweepTick` (deps_scheduler.go:~176) → `PebbleStore.ListWaitingDepsOps`
+  (pebble_store_ops_v2.go:~638) reads the DB after it's closed. **Independently reproduced by two
+  sweep workers** (the `flaky-backup` and `flaky-scan` fixes) as an out-of-scope side-finding.
+  Fix direction: give the sweep goroutine a stop signal (context/channel) tied to `Registry.Stop`/
+  test cleanup so it joins before the store closes, OR make `ListWaitingDepsOps` tolerate a closed DB.
+  Not the cause of the two deflaked tests (#1711/#1713) — a separate lifecycle bug. Re-verify line
+  numbers with grep before fixing.
 - [x] **CI-FRONTEND-UNITTESTS-STALE** (2026-06-13) ✅ **FIXED 2026-06-17** — `UnifiedDedupTab.test.tsx`
   updated: `mockCandidate` now carries inline `book_a`/`book_b` (the `include_books` shape)
   and the 2 stale tests assert on the rendered card **title** (`Dune (FLAC rip)`) instead of


### PR DESCRIPTION
Logs a real side-finding from the agent-task sweep: a leaked DepsScheduler.SweepTick goroutine panics 'pebble: closed' under package-wide go test -race when it outlives a test's store.Close(). Independently reproduced by two sweep workers (#1711, #1713). Docs-only (TODO Open Bugs + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)