### PR TITLE
fix(registry): drain dep-notify goroutines on Shutdown (PEBBLE-CLOSED-SHUTDOWN-RACE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.95.0 -->
+<!-- version: 3.96.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-01 -->
+<!-- last-edited: 2026-07-02 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Bug Fixes
+
+#### July 2, 2026 — Fix `PEBBLE-CLOSED-SHUTDOWN-RACE` (op-registry shutdown)
+
+- **`fix(registry)`** — `Registry.Shutdown()` no longer returns while dep-notify goroutines are still touching the store. The fire-and-forget goroutines in `notifyDepCompletion`/`notifyDepFailed` used `context.Background()` and were not enrolled in `goroutineWG`, so `Shutdown`'s `goroutineWG.Wait()` didn't drain them — a caller that closed the store immediately after `Shutdown` could race a live `OnOpCompleted → RecordOpCompletion` and panic `pebble: closed`, crashing the test binary under package-wide `-race`. Both goroutines are now enrolled in `goroutineWG`, gated under `r.mu` against a `notifyStopped` flag that `Shutdown` sets just before `Wait()` (closes the Add-after-Wait window, since `releaseRunHandle` removes the op from `r.running` before the notify call). Regression test `TestShutdownDrainsDepNotifyGoroutines_RealStore` uses a real PebbleStore (10/10 panic pre-fix, green post-fix under `-race`). Corrects the original triage, which mis-attributed the leak to `DepsScheduler.SweepTick` (that path was already drained).
 
 ### Features
 

--- a/TODO.md
+++ b/TODO.md
@@ -872,17 +872,21 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ## 🐛 Open Bugs — May 17, 2026
 
-- [ ] **PEBBLE-CLOSED-SHUTDOWN-RACE** (2026-07-01, found during the agent-task sweep) — Under
-  `go test -race` (package-wide, e.g. `internal/server`), a leaked `DepsScheduler.SweepTick`
-  goroutine can outlive a test's `store.Close()` and panic with `pebble: closed`, crashing the
-  whole test binary. Path: `operations/registry.Registry.Start` (registry.go:~318) launches the
-  sweep goroutine → `DepsScheduler.SweepTick` (deps_scheduler.go:~176) → `PebbleStore.ListWaitingDepsOps`
-  (pebble_store_ops_v2.go:~638) reads the DB after it's closed. **Independently reproduced by two
-  sweep workers** (the `flaky-backup` and `flaky-scan` fixes) as an out-of-scope side-finding.
-  Fix direction: give the sweep goroutine a stop signal (context/channel) tied to `Registry.Stop`/
-  test cleanup so it joins before the store closes, OR make `ListWaitingDepsOps` tolerate a closed DB.
-  Not the cause of the two deflaked tests (#1711/#1713) — a separate lifecycle bug. Re-verify line
-  numbers with grep before fixing.
+- [x] **PEBBLE-CLOSED-SHUTDOWN-RACE** (2026-07-01, found during the agent-task sweep) — ✅ **FIXED
+  2026-07-02** (branch `fix/pebble-shutdown-race`). **Root cause was NOT `SweepTick`** as the
+  original entry guessed — that path was already enrolled in `goroutineWG` and drained by
+  `Shutdown`. Reproduced with a real PebbleStore (`shutdown_race_test.go`, 10/10 panic pre-fix):
+  the actual leak is the fire-and-forget dep-notify goroutines at `registry.go:210,226`
+  (`notifyDepCompletion`/`notifyDepFailed`). They used `context.Background()` and were **not**
+  enrolled in `goroutineWG`, so `Registry.Shutdown()`'s `goroutineWG.Wait()` returned without
+  draining them → `OnOpCompleted → RecordOpCompletion` read/wrote the store after `store.Close()`
+  → `pebble: closed` crash. Fix: enroll both notify goroutines in `goroutineWG`, gated under `r.mu`
+  against a new `notifyStopped` flag that `Shutdown` sets (under `mu`) just before `Wait()` — this
+  closes the Add-after-Wait window created by `releaseRunHandle` removing the op from `r.running`
+  (worker.go:303) *before* the notify call (worker.go:331). Late notifies during teardown are
+  skipped safely (terminal status already persisted; next `Start`'s `SweepTick` re-evaluates).
+  Verified: repro 10/10 pass under `-race`, full `internal/operations/registry` package green under
+  `-race`. Not the cause of the two deflaked tests (#1711/#1713) — a separate lifecycle bug.
 - [x] **CI-FRONTEND-UNITTESTS-STALE** (2026-06-13) ✅ **FIXED 2026-06-17** — `UnifiedDedupTab.test.tsx`
   updated: `mockCandidate` now carries inline `book_a`/`book_b` (the `include_books` shape)
   and the 2 stale tests assert on the rendered card **title** (`Dune (FLAC rip)`) instead of

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.1.1
+// version: 3.2.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-06-14
+// last-edited: 2026-07-02
 
 package registry
 
@@ -62,7 +62,15 @@ type Registry struct {
 	// Shutdown() calls this after draining running ops to stop the
 	// dispatcher, watchdog, and idle workers before returning.
 	cancelFn    context.CancelFunc
-	goroutineWG sync.WaitGroup // tracks dispatcher + watchdog + workers
+	goroutineWG sync.WaitGroup // tracks dispatcher + watchdog + workers + dep-notify goroutines
+
+	// notifyStopped is set (under mu) in Shutdown just before goroutineWG.Wait()
+	// so no new dep-notify goroutine can Add to the WaitGroup after the Wait has
+	// begun. releaseRunHandle removes an op from r.running BEFORE the worker
+	// calls notifyDepCompletion, so Shutdown's drain loop can reach Wait() in the
+	// gap before a notify goroutine enrolls — gating the Add under mu against
+	// this flag closes that "Add after Wait" window. Reset in Start() for restart.
+	notifyStopped bool
 
 	// Tunable intervals for testing. Zero means use defaults.
 	watchdogInterval time.Duration
@@ -201,13 +209,19 @@ func (c *combinedDepStoreImpl) GetBookByID(id string) (*database.Book, error) {
 // notifyDepCompletion notifies the scheduler (if wired) that opID completed for
 // the given subject asynchronously so the worker is never blocked.
 func (r *Registry) notifyDepCompletion(sub Subject, opType string) {
-	r.mu.RLock()
+	// Enroll the goroutine in goroutineWG under mu so Shutdown drains it before
+	// the caller closes the store (avoids a "pebble: closed" panic). The mu-gated
+	// notifyStopped check prevents Add-after-Wait once Shutdown has begun waiting.
+	r.mu.Lock()
 	sched := r.depsScheduler
-	r.mu.RUnlock()
-	if sched == nil {
+	if sched == nil || r.notifyStopped {
+		r.mu.Unlock()
 		return
 	}
+	r.goroutineWG.Add(1)
+	r.mu.Unlock()
 	go func() {
+		defer r.goroutineWG.Done()
 		if err := sched.OnOpCompleted(context.Background(), sub, opType); err != nil {
 			r.logger.Warn("deps_scheduler: OnOpCompleted error", "op_type", opType, "error", err)
 		}
@@ -217,13 +231,17 @@ func (r *Registry) notifyDepCompletion(sub Subject, opType string) {
 // notifyDepFailed notifies the scheduler (if wired) that opID failed for the
 // given subject asynchronously so the worker is never blocked.
 func (r *Registry) notifyDepFailed(sub Subject, opType string) {
-	r.mu.RLock()
+	// See notifyDepCompletion for why enrollment is gated under mu.
+	r.mu.Lock()
 	sched := r.depsScheduler
-	r.mu.RUnlock()
-	if sched == nil {
+	if sched == nil || r.notifyStopped {
+		r.mu.Unlock()
 		return
 	}
+	r.goroutineWG.Add(1)
+	r.mu.Unlock()
 	go func() {
+		defer r.goroutineWG.Done()
 		if err := sched.OnOpFailed(context.Background(), sub, opType); err != nil {
 			r.logger.Warn("deps_scheduler: OnOpFailed error", "op_type", opType, "error", err)
 		}
@@ -260,6 +278,11 @@ func (r *Registry) SetPluginMaxConcurrent(plugin string, max int) {
 // to re-queue or drop ops that were in-flight at the last shutdown.
 func (r *Registry) Start(ctx context.Context) {
 	r.logger.Info("registry: starting", "workers", r.workers)
+	// Clear the notify gate in case this Registry is being restarted after a
+	// prior Shutdown (Shutdown sets notifyStopped to reject late enrollments).
+	r.mu.Lock()
+	r.notifyStopped = false
+	r.mu.Unlock()
 	// Resume must complete before the dispatcher starts accepting new work.
 	r.resumeAfterStartup(ctx)
 	// Reload any journaled batch buckets from the previous run and re-arm their
@@ -821,6 +844,13 @@ func (r *Registry) Shutdown(ctx context.Context) error {
 	if r.cancelFn != nil {
 		r.cancelFn()
 	}
+	// Reject any further dep-notify enrollment before we wait, so a worker
+	// finishing its last op during teardown cannot Add to goroutineWG after the
+	// Wait below has started. The op's terminal status is already persisted; the
+	// next Start()'s SweepTick re-evaluates any waiting_deps ops for the subject.
+	r.mu.Lock()
+	r.notifyStopped = true
+	r.mu.Unlock()
 	goroutinesDone := make(chan struct{})
 	go func() {
 		r.goroutineWG.Wait()

--- a/internal/operations/registry/shutdown_race_test.go
+++ b/internal/operations/registry/shutdown_race_test.go
@@ -1,0 +1,101 @@
+// file: internal/operations/registry/shutdown_race_test.go
+// version: 1.0.0
+// guid: 7d2e9a41-6c3b-4f80-9a1e-2b5c8d0f3e64
+// last-edited: 2026-07-02
+
+// shutdown_race_test.go is the regression test for PEBBLE-CLOSED-SHUTDOWN-RACE.
+//
+// When an op completes, worker.go calls Registry.notifyDepCompletion for each
+// subject, which spawns a fire-and-forget goroutine that calls
+// DepsScheduler.OnOpCompleted -> store.GetDepRev(...). Historically that
+// goroutine used context.Background() and was NOT enrolled in goroutineWG, so
+// Registry.Shutdown() (which cancels the internal context and waits on
+// goroutineWG) returned WITHOUT draining it. A caller that closed the store
+// immediately after Shutdown() could then race the lingering goroutine, whose
+// GetDepRev read panics with "pebble: closed" and crashes the whole test binary.
+//
+// This test reproduces that race against a REAL PebbleStore: it runs many ops
+// (each with a book subject so a notify goroutine is spawned), calls Shutdown(),
+// then closes the store — repeatedly. A leaked goroutine touching the closed
+// store panics; a properly drained one does not.
+package registry_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+func TestShutdownDrainsDepNotifyGoroutines_RealStore(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Repeat the start/run/shutdown/close cycle to widen the race window. Under
+	// -race the scheduler delay between op completion and the notify goroutine's
+	// GetDepRev read is large enough that a single iteration often misses; the
+	// loop makes reproduction reliable.
+	for iter := range 8 {
+		store, cleanup := openTestPebbleStore(t)
+		schedStore := &pebbleSchedulerStore{PebbleStore: store}
+
+		reg := registry.NewWithOptions(store, logger, 4, registry.Options{
+			SweepInterval: time.Hour, // isolate the notify path from SweepTick
+		})
+		sched := registry.NewDepsScheduler(reg, schedStore)
+		reg.SetDepsScheduler(sched)
+
+		def := makeValidDef("race.op")
+		def.ID = "race.op"
+		if err := reg.RegisterOp(def); err != nil {
+			t.Fatalf("iter %d: RegisterOp: %v", iter, err)
+		}
+
+		reg.Start(context.Background())
+
+		// Enqueue several ops, each with a distinct book subject so the worker
+		// derives a subject and calls notifyDepCompletion on completion.
+		const n = 12
+		ids := make([]string, 0, n)
+		for range n {
+			params := map[string]any{"book_id": "book-" + ulid.Make().String()}
+			id, err := reg.EnqueueOp(context.Background(), "race.op", params)
+			if err != nil {
+				t.Fatalf("iter %d: EnqueueOp: %v", iter, err)
+			}
+			ids = append(ids, id)
+		}
+
+		// Wait for all ops to finish executing (status "completed"). The notify
+		// goroutine is spawned around this point and is NOT waited on by us.
+		for _, id := range ids {
+			deadline := time.Now().Add(10 * time.Second)
+			for {
+				row, err := store.GetOperationV2(id)
+				if err == nil && row != nil && row.Status == "completed" {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("iter %d: op %s never reached completed", iter, id)
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+
+		// Shutdown SHOULD drain every goroutine that can still touch the store,
+		// including the dep-notify goroutines. If it does not, the close below
+		// races them.
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := reg.Shutdown(shutCtx); err != nil {
+			t.Fatalf("iter %d: Shutdown: %v", iter, err)
+		}
+		shutCancel()
+
+		// If a dep-notify goroutine survived Shutdown, its GetDepRev read here
+		// panics with "pebble: closed" and crashes the test binary.
+		cleanup()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes `PEBBLE-CLOSED-SHUTDOWN-RACE`: `Registry.Shutdown()` could return while dep-notify goroutines were still touching the store, so a caller closing the store immediately after `Shutdown` could race a live `OnOpCompleted → RecordOpCompletion` and panic `pebble: closed` — crashing the test binary under package-wide `-race`.

`notifyDepCompletion`/`notifyDepFailed` spawned fire-and-forget goroutines using `context.Background()` that were **not** enrolled in `goroutineWG`, so `Shutdown`'s `goroutineWG.Wait()` never drained them. Both are now enrolled in `goroutineWG`, gated under `r.mu` against a new `notifyStopped` flag that `Shutdown` sets (under `mu`) just before `Wait()`. This closes the Add-after-Wait window created by `releaseRunHandle` removing the op from `r.running` (worker.go:303) *before* the notify call (worker.go:331). Late notifies during teardown are skipped safely — terminal status is already persisted and the next `Start`'s `SweepTick` re-evaluates waiting_deps ops.

Corrects the original triage, which mis-attributed the leak to `DepsScheduler.SweepTick` (that path was already enrolled/drained).

## Test plan

- New `TestShutdownDrainsDepNotifyGoroutines_RealStore` (real PebbleStore): **10/10 panic pre-fix, green post-fix** under `-race`.
- Full `internal/operations/registry` package green under `-race`.
- `internal/server` package-wide `-race` green (500s, exit 0, zero `pebble: closed`) — the original reported context.
- `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)