### PR TITLE
fix(web): stop later-page selection bouncing back to page 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 — Library: selecting a later page no longer bounces back to page 1
+
+- **`fix(web)`** — the filters-sync effect in `useLibraryFilters` rebuilt the `filters` object on **every** `searchParams` change, including page-only navigation (the URL carries `?page=N`). The new object reference re-triggered the page-reset effect in `Library.tsx` (whose deps include `filters`), snapping the user back to page 1. The effect now preserves prev's non-URL fields (`tags`, etc.) and returns the **same reference** when no filter value actually changed (`shallowEqualFilters`), so page navigation no longer churns `filters`. Regression test in `useLibraryFilters.test.ts`.
+
 #### July 2, 2026 — Transcription/metadata matching: require title agreement, not just author
 
 - **`fix(metafetch,metabatch)`** — fixed "matches the author but not the actual book." The audio-derived (transcribed) author/narrator boosts in `transcriptionBoost` (`service_scoring.go`) multiplied the score **independently of title agreement** (author ×1.6, narrator ×1.4, stacked on curated-author ×1.5), so a same-author, wrong-title candidate could be carried to the top. Now those boosts are suppressed when a transcribed title is present but the candidate fails to match it; author/narrator remain a tiebreaker only when no transcribed title is available (not the bug case). Added hard title-agreement gates to the two auto-apply paths that lacked one: the auto-fetch apply (`service_fetch.go` — skip a candidate whose title disagrees with the transcribed title) and the batch upgrade (`metabatch/upgrade.go` — never auto-upgrade a transcribed book to a non-confirming candidate, instead of only discounting the threshold). Regression tests in `transcription_boost_test.go`. Does not affect books without transcription data.

--- a/web/src/hooks/useLibraryFilters.test.ts
+++ b/web/src/hooks/useLibraryFilters.test.ts
@@ -1,0 +1,55 @@
+// file: web/src/hooks/useLibraryFilters.test.ts
+// version: 1.0.0
+// guid: 6b2d9f14-3a7c-4e80-9c51-2f8e0d413a6b
+// last-edited: 2026-07-02
+
+import { describe, it, expect } from 'vitest';
+import { shallowEqualFilters } from './useLibraryFilters';
+import type { FilterOptions } from '../types';
+
+// Regression coverage for the "later page bounces back to page 1" bug. The
+// filters-sync effect rebuilds `filters` on every searchParams change (page
+// navigation included); returning a new object reference each time re-triggered
+// the page-reset effect. shallowEqualFilters lets the effect keep a stable
+// reference when nothing actually changed, so page navigation no longer churns
+// `filters` and no longer bounces the user to page 1.
+describe('shallowEqualFilters', () => {
+  it('treats value-identical filters as equal (stable reference path)', () => {
+    const a: FilterOptions = { author: 'Sanderson', libraryState: 'active' };
+    const b: FilterOptions = { author: 'Sanderson', libraryState: 'active' };
+    expect(shallowEqualFilters(a, b)).toBe(true);
+  });
+
+  it('detects a changed filter value', () => {
+    const a: FilterOptions = { author: 'Sanderson' };
+    const b: FilterOptions = { author: 'Tolkien' };
+    expect(shallowEqualFilters(a, b)).toBe(false);
+  });
+
+  it('detects an added/removed key', () => {
+    const a: FilterOptions = { author: 'Sanderson' };
+    const b: FilterOptions = { author: 'Sanderson', genre: 'Fantasy' };
+    expect(shallowEqualFilters(a, b)).toBe(false);
+  });
+
+  it('treats undefined vs missing key as equal', () => {
+    const a: FilterOptions = { author: 'Sanderson', genre: undefined };
+    const b: FilterOptions = { author: 'Sanderson' };
+    expect(shallowEqualFilters(a, b)).toBe(true);
+  });
+
+  it('preserves a tags array by reference (spread keeps the same ref → equal)', () => {
+    const tags = ['fantasy', 'scifi'];
+    const a: FilterOptions = { tags };
+    const b: FilterOptions = { tags }; // same reference, as the ...prev spread guarantees
+    expect(shallowEqualFilters(a, b)).toBe(true);
+  });
+
+  it('two arrays with equal contents but different references are NOT equal', () => {
+    // Documents the reference-compare semantics: correctness relies on the
+    // sync effect preserving prev.tags via `...prev`, not on deep array equality.
+    const a: FilterOptions = { tags: ['fantasy'] };
+    const b: FilterOptions = { tags: ['fantasy'] };
+    expect(shallowEqualFilters(a, b)).toBe(false);
+  });
+});

--- a/web/src/hooks/useLibraryFilters.ts
+++ b/web/src/hooks/useLibraryFilters.ts
@@ -1,11 +1,27 @@
 // file: web/src/hooks/useLibraryFilters.ts
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-26
+// last-edited: 2026-07-02
 
 import { useState, useEffect, useCallback } from 'react';
 import type { FilterOptions } from '../types';
 import * as api from '../services/api';
+
+// shallowEqualFilters compares two FilterOptions by value across the union of
+// their keys. Non-URL fields (e.g. `tags`) are preserved by reference via the
+// `...prev` spread in the sync effect, so a reference compare is correct for
+// them. Used to keep a stable `filters` reference when a searchParams change
+// (like page navigation) didn't actually change any filter value.
+export function shallowEqualFilters(a: FilterOptions, b: FilterOptions): boolean {
+  const keys = new Set<keyof FilterOptions>([
+    ...(Object.keys(a) as (keyof FilterOptions)[]),
+    ...(Object.keys(b) as (keyof FilterOptions)[]),
+  ]);
+  for (const k of keys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
 
 interface UseLibraryFiltersOptions {
   searchParams: URLSearchParams;
@@ -124,22 +140,33 @@ export function useLibraryFilters({
       });
   }, []);
 
-  // Sync filters whenever searchParams change (e.g., when navigating to /library with no params)
+  // Sync filters whenever searchParams change (e.g., when navigating to /library with no params).
+  //
+  // This effect fires on EVERY searchParams change, including page-only navigation
+  // (the URL carries ?page=N). Returning a brand-new object each time gave `filters`
+  // a fresh reference on page changes, which re-triggered the page-reset effect in
+  // Library.tsx (deps include `filters`) → the user got bounced back to page 1.
+  // Fix: preserve prev's non-URL fields (tags, showFailed, …) and return the SAME
+  // reference when nothing actually changed, so page navigation doesn't churn it.
   useEffect(() => {
-    setFilters({
-      author: searchParams.get('author') || undefined,
-      series: searchParams.get('series') || undefined,
-      genre: searchParams.get('genre') || undefined,
-      language: searchParams.get('language') || undefined,
-      libraryState: searchParams.get('state') || undefined,
-      hasFileErrors: (searchParams.get('has_file_errors') === 'true') || undefined,
-      fingerprintStatus: (searchParams.get('fingerprint_status') as "complete" | "partial" | "none" | null) || undefined,
-      coveragePercentMin: searchParams.get('coverage_percent_min') ? parseInt(searchParams.get('coverage_percent_min')!, 10) : undefined,
-      coveragePercentMax: searchParams.get('coverage_percent_max') ? parseInt(searchParams.get('coverage_percent_max')!, 10) : undefined,
-      missingCovers: (searchParams.get('missing_covers') === 'true') || undefined,
-      inImportPath: (searchParams.get('in_import_path') === 'true') || undefined,
-      noIsbn: (searchParams.get('no_isbn') === 'true') || undefined,
-      duplicatesFlagged: (searchParams.get('duplicates_flagged') === 'true') || undefined,
+    setFilters((prev) => {
+      const next: FilterOptions = {
+        ...prev,
+        author: searchParams.get('author') || undefined,
+        series: searchParams.get('series') || undefined,
+        genre: searchParams.get('genre') || undefined,
+        language: searchParams.get('language') || undefined,
+        libraryState: searchParams.get('state') || undefined,
+        hasFileErrors: (searchParams.get('has_file_errors') === 'true') || undefined,
+        fingerprintStatus: (searchParams.get('fingerprint_status') as "complete" | "partial" | "none" | null) || undefined,
+        coveragePercentMin: searchParams.get('coverage_percent_min') ? parseInt(searchParams.get('coverage_percent_min')!, 10) : undefined,
+        coveragePercentMax: searchParams.get('coverage_percent_max') ? parseInt(searchParams.get('coverage_percent_max')!, 10) : undefined,
+        missingCovers: (searchParams.get('missing_covers') === 'true') || undefined,
+        inImportPath: (searchParams.get('in_import_path') === 'true') || undefined,
+        noIsbn: (searchParams.get('no_isbn') === 'true') || undefined,
+        duplicatesFlagged: (searchParams.get('duplicates_flagged') === 'true') || undefined,
+      };
+      return shallowEqualFilters(prev, next) ? prev : next;
     });
   }, [searchParams]);
 


### PR DESCRIPTION
## Summary
Fixes the reported "picking a later page snaps me back to page 1" bug.

`useLibraryFilters`'s searchParams-sync effect rebuilt the `filters` object on **every** `searchParams` change — including page-only navigation (`?page=N` lives in the URL). The new object reference re-triggered the page-reset effect in `Library.tsx` (deps include `filters`), which calls `setPage(1)`.

## Fix
The sync effect now spreads `prev` (preserving non-URL fields like `tags`) and returns the **same reference** via `shallowEqualFilters` when no filter value actually changed — so page navigation no longer churns `filters`. Changing a real filter still yields a new reference and correctly resets to page 1.

## Test plan
- New `useLibraryFilters.test.ts` (6 cases for `shallowEqualFilters`, incl. tags-by-reference semantics).
- `tsc --noEmit` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)