### PR TITLE
feat(dedup): AcoustID veto for the title-match false-positive flood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 — Dedup: AcoustID veto for the title-match false-positive flood
+
+- **`feat(dedup)`** — the "exact" dedup layer is dominated by fuzzy **title** matches (`checkExactTitle`: same author + normalized titles within Levenshtein 2 → similarity 1.0), which produced a large backlog of false "duplicates" between different audio. Added an **AcoustID veto** at the exact chokepoint (`upsertExactCandidate`): when both books have book-level AcoustID signatures (`book_sig_v1`, synthesized from per-file chromaprints) that clearly disagree (masked similarity < 0.50 with ≥512-word overlap), the candidate is suppressed. Deliberately conservative — never vetoes on missing/partial signatures or borderline similarity, since a false veto would silently hide a real duplicate. New endpoint `POST /api/v1/dedup/purge-acoustid-conflicts` (dry-run by default; `{"apply":true}` deletes) re-evaluates the existing pending backlog against the same rule and reports counts + a sample. Skips the audio-positive `acoustid`/`book_signature` layers. Regression tests in `acoustid_veto_test.go`.
+
 #### July 2, 2026 — Library: selecting a later page no longer bounces back to page 1
 
 - **`fix(web)`** — the filters-sync effect in `useLibraryFilters` rebuilt the `filters` object on **every** `searchParams` change, including page-only navigation (the URL carries `?page=N`). The new object reference re-triggered the page-reset effect in `Library.tsx` (whose deps include `filters`), snapping the user back to page 1. The effect now preserves prev's non-URL fields (`tags`, etc.) and returns the **same reference** when no filter value actually changed (`shallowEqualFilters`), so page navigation no longer churns `filters`. Regression test in `useLibraryFilters.test.ts`.

--- a/internal/dedup/acoustid_veto_test.go
+++ b/internal/dedup/acoustid_veto_test.go
@@ -1,0 +1,79 @@
+// file: internal/dedup/acoustid_veto_test.go
+// version: 1.0.0
+// guid: 4e7c1a92-6d38-45b1-8f0a-3c2e9d514b70
+// last-edited: 2026-07-02
+
+package dedup
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// makeBookSig builds a valid base64 book_sig_v1 whose 4096 words are all `word`.
+// Two all-zero sigs are identical (similarity 1.0); an all-zero vs an
+// all-0xFFFFFFFF sig differ in every bit (similarity 0.0).
+func makeBookSig(word uint32) string {
+	buf := make([]byte, fingerprint.BookSignatureFixedLength*4)
+	for i := range fingerprint.BookSignatureFixedLength {
+		binary.LittleEndian.PutUint32(buf[i*4:], word)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func TestAcoustIDSignaturesConflict(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	books := map[string]*database.Book{}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+	mk := func(id, sig string) *database.Book {
+		b := &database.Book{ID: id}
+		if sig != "" {
+			s := sig
+			b.BookSigV1 = &s
+		}
+		books[id] = b
+		return b
+	}
+
+	zero := makeBookSig(0)
+	ones := makeBookSig(0xFFFFFFFF)
+
+	t.Run("clearly different audio is vetoed", func(t *testing.T) {
+		if !engine.acoustIDSignaturesConflict(mk("a1", zero), mk("b1", ones)) {
+			t.Error("expected conflict (veto) for opposite signatures")
+		}
+	})
+	t.Run("identical audio is NOT vetoed", func(t *testing.T) {
+		if engine.acoustIDSignaturesConflict(mk("a2", zero), mk("b2", zero)) {
+			t.Error("identical signatures must never be vetoed (would hide a real duplicate)")
+		}
+	})
+	t.Run("missing signature on one side is not vetoed", func(t *testing.T) {
+		if engine.acoustIDSignaturesConflict(mk("a3", zero), mk("b3", "")) {
+			t.Error("must not veto when one signature is missing (conservative)")
+		}
+	})
+	t.Run("both signatures missing is not vetoed", func(t *testing.T) {
+		if engine.acoustIDSignaturesConflict(mk("a4", ""), mk("b4", "")) {
+			t.Error("must not veto when both signatures are missing")
+		}
+	})
+	t.Run("fetch fallback: signature pulled from store when not on the struct", func(t *testing.T) {
+		mk("a5", zero)
+		mk("b5", ones)
+		// Pass stripped structs (no signature); the helper must re-fetch by ID.
+		if !engine.acoustIDSignaturesConflict(&database.Book{ID: "a5"}, &database.Book{ID: "b5"}) {
+			t.Error("expected conflict via store fetch fallback")
+		}
+	})
+	t.Run("nil books are safe", func(t *testing.T) {
+		if engine.acoustIDSignaturesConflict(nil, mk("b6", zero)) {
+			t.Error("nil book must not veto")
+		}
+	})
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.40.0
+// version: 1.41.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-01
+// last-edited: 2026-07-02
 
 package dedup
 
@@ -1348,6 +1348,15 @@ func (de *Engine) upsertExactCandidate(a, b *database.Book, layer string, sim fl
 			"book_a", a.ID, "book_b", b.ID, "layer", layer)
 		return nil
 	}
+	if de.acoustIDSignaturesConflict(a, b) {
+		// Two books whose book-level AcoustID audio signatures clearly disagree
+		// cannot be the same recording, no matter how similar their title/author
+		// metadata is. This is the AcoustID veto: a title-fuzzy "exact" match
+		// between different audio is a false positive.
+		slog.Debug("dedup exact candidate dropped by acoustid-signature gate",
+			"book_a", a.ID, "book_b", b.ID, "layer", layer)
+		return nil
+	}
 	return de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 		EntityType: "book",
 		EntityAID:  a.ID,
@@ -1437,6 +1446,192 @@ func (de *Engine) isPartVsWholeMismatch(a, b *database.Book) bool {
 		return false
 	}
 	return float64(partDuration) < partVsWholeDurationRatioMax*float64(wholeDuration)
+}
+
+const (
+	// acoustIDVetoMaxSimilarity is the book-level AcoustID signature similarity
+	// BELOW which two books are treated as clearly different audio, so a
+	// title/metadata "exact" candidate between them is a false positive that
+	// gets vetoed. Set well below fingerprint.FuzzyMinSimilarity (0.80, the
+	// positive-match threshold) so only clearly-different audio is vetoed;
+	// borderline pairs (0.50–0.80) are left for manual review, never hidden.
+	acoustIDVetoMaxSimilarity = 0.50
+	// acoustIDVetoMinOverlap is the minimum number of overlapping signature
+	// words required for a reliable masked comparison, mirroring
+	// BookSignatureScan's floor. Below this, the comparison is skipped (no veto).
+	acoustIDVetoMinOverlap = 512
+)
+
+// acoustIDSignaturesConflict reports whether books a and b have book-level
+// AcoustID audio signatures (book_sig_v1, synthesized from per-file chromaprint
+// segments) that CLEARLY disagree — strong evidence they are not the same
+// recording. This is the veto primitive for the exact chokepoint.
+//
+// Deliberately conservative: a false veto silently hides a real duplicate, which
+// is worse than a false positive sitting in the review queue. It therefore
+// returns false (no veto) unless BOTH books have a usable signature, the masked
+// comparison has enough overlap to be reliable, and the similarity is well below
+// the match threshold. Book signatures are book-level (not per-file), so a real
+// duplicate chaptered 1-file-vs-many still compares correctly and is not vetoed.
+//
+// When a passed book lacks its signature (e.g. a stripped summary row), it is
+// re-fetched by ID so the veto still applies. This runs only per emitted
+// candidate (the chokepoint), not per pairwise comparison, so the lookup cost is
+// bounded.
+func (de *Engine) acoustIDSignaturesConflict(a, b *database.Book) bool {
+	if a == nil || b == nil || de.bookStore == nil {
+		return false
+	}
+	sigA, maskA, okA := de.bookSignature(a)
+	sigB, maskB, okB := de.bookSignature(b)
+	if !okA || !okB {
+		return false // conservative: never veto on missing signature data
+	}
+	sim, overlap, err := fingerprint.BookSignatureSimilarityMasked(sigA, sigB, maskA, maskB)
+	if err != nil || overlap < acoustIDVetoMinOverlap {
+		return false
+	}
+	return sim < acoustIDVetoMaxSimilarity
+}
+
+// bookSignature returns a book's book_sig_v1 signature and mask, re-fetching the
+// full record by ID when the passed struct doesn't carry the signature. The
+// bool is false when no usable signature is available.
+func (de *Engine) bookSignature(b *database.Book) (sig, mask string, ok bool) {
+	if b == nil {
+		return "", "", false
+	}
+	if b.BookSigV1 == nil || *b.BookSigV1 == "" {
+		if de.bookStore == nil {
+			return "", "", false
+		}
+		full, err := de.bookStore.GetBookByID(b.ID)
+		if err != nil || full == nil {
+			return "", "", false
+		}
+		b = full
+	}
+	if b.BookSigV1 == nil || *b.BookSigV1 == "" {
+		return "", "", false
+	}
+	if b.BookSigV1Mask != nil {
+		mask = *b.BookSigV1Mask
+	}
+	return *b.BookSigV1, mask, true
+}
+
+// AcoustIDConflictResult summarizes a ReevaluateAcoustIDConflicts run.
+type AcoustIDConflictResult struct {
+	Checked   int                      `json:"checked"`   // pending non-audio candidates examined
+	Skipped   int                      `json:"skipped"`   // no usable signature / insufficient overlap
+	Conflicts int                      `json:"conflicts"` // pairs whose AcoustID audio clearly disagrees
+	Deleted   int                      `json:"deleted"`   // rows removed (0 when dryRun)
+	DryRun    bool                     `json:"dry_run"`
+	Samples   []AcoustIDConflictSample `json:"samples"`
+}
+
+// AcoustIDConflictSample is one conflicting candidate, for the dry-run report.
+type AcoustIDConflictSample struct {
+	CandidateID int64   `json:"candidate_id"`
+	Layer       string  `json:"layer"`
+	BookAID     string  `json:"book_a_id"`
+	BookBID     string  `json:"book_b_id"`
+	TitleA      string  `json:"title_a"`
+	TitleB      string  `json:"title_b"`
+	Similarity  float64 `json:"similarity"`
+}
+
+const acoustIDConflictSampleCap = 50
+
+// ReevaluateAcoustIDConflicts walks PENDING book dedup candidates and finds
+// those whose two books have clearly-disagreeing book-level AcoustID signatures
+// — the false positives from the title/metadata "exact" layers that the new
+// acoustid veto now suppresses at emission time. The "acoustid" and
+// "book_signature" layers are skipped (they ARE the positive audio evidence, so
+// vetoing them by audio would be circular).
+//
+// When dryRun is true nothing is mutated: the result reports how many WOULD be
+// removed, plus a capped sample for inspection.
+func (de *Engine) ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) (*AcoustIDConflictResult, error) {
+	if de.embedStore == nil || de.bookStore == nil {
+		return &AcoustIDConflictResult{DryRun: dryRun}, nil
+	}
+	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Limit:      1000000,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list candidates: %w", err)
+	}
+
+	res := &AcoustIDConflictResult{DryRun: dryRun}
+	type sigMeta struct {
+		sig, mask, title string
+		ok               bool
+	}
+	cache := make(map[string]sigMeta, len(candidates)*2)
+	lookup := func(id string) sigMeta {
+		if m, ok := cache[id]; ok {
+			return m
+		}
+		m := sigMeta{}
+		b, err := de.bookStore.GetBookByID(id)
+		if err == nil && b != nil {
+			m.title = b.Title
+			if b.BookSigV1 != nil && *b.BookSigV1 != "" {
+				m.sig = *b.BookSigV1
+				if b.BookSigV1Mask != nil {
+					m.mask = *b.BookSigV1Mask
+				}
+				m.ok = true
+			}
+		}
+		cache[id] = m
+		return m
+	}
+
+	for _, c := range candidates {
+		select {
+		case <-ctx.Done():
+			return res, ctx.Err()
+		default:
+		}
+		if c.Layer == "acoustid" || c.Layer == "book_signature" {
+			continue // audio-positive layers: never vetoed by audio
+		}
+		res.Checked++
+		a := lookup(c.EntityAID)
+		b := lookup(c.EntityBID)
+		if !a.ok || !b.ok {
+			res.Skipped++ // conservative: can't judge without both signatures
+			continue
+		}
+		sim, overlap, err := fingerprint.BookSignatureSimilarityMasked(a.sig, b.sig, a.mask, b.mask)
+		if err != nil || overlap < acoustIDVetoMinOverlap {
+			res.Skipped++
+			continue
+		}
+		if sim >= acoustIDVetoMaxSimilarity {
+			continue // audio agrees or is borderline — leave for manual review
+		}
+		res.Conflicts++
+		if len(res.Samples) < acoustIDConflictSampleCap {
+			res.Samples = append(res.Samples, AcoustIDConflictSample{
+				CandidateID: c.ID, Layer: c.Layer,
+				BookAID: c.EntityAID, BookBID: c.EntityBID,
+				TitleA: a.title, TitleB: b.title, Similarity: sim,
+			})
+		}
+		if !dryRun {
+			if err := de.embedStore.DeleteCandidate(c.ID); err != nil {
+				slog.Info("dedup acoustid-conflict delete", "c", c.ID, "err", err)
+				continue
+			}
+			res.Deleted++
+		}
+	}
+	return res, nil
 }
 
 // sumBookFileDurations totals the Duration (seconds) of the given BookFiles.

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/handler.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: d1b9e024-d28c-4d62-8f90-96d7064559c4
-// last-edited: 2026-06-23
+// last-edited: 2026-07-02
 
 // Package deduphandler hosts the dedup-domain HTTP handlers extracted from the
 // server package: dedup candidate / cluster / series listing, merge / dismiss /
@@ -419,6 +419,34 @@ func (h *Handler) RescoreDedupCandidates(c *gin.Context) {
 	result, err := h.dedupEngine.Rescore(c.Request.Context(), body.Apply)
 	if err != nil {
 		httputil.InternalError(c, "rescore failed", err)
+		return
+	}
+
+	httputil.RespondWithOK(c, result)
+}
+
+// PurgeAcoustIDConflicts handles POST /api/v1/dedup/purge-acoustid-conflicts.
+//
+// Finds PENDING non-audio dedup candidates whose two books have clearly
+// disagreeing book-level AcoustID signatures — the title/metadata false
+// positives the new acoustid veto suppresses at emission time. Dry-run by
+// default (returns counts + a sample, mutates nothing); pass {"apply": true} to
+// delete the conflicting candidates.
+func (h *Handler) PurgeAcoustIDConflicts(c *gin.Context) {
+	if h.dedupEngine == nil {
+		httputil.RespondWithServiceUnavailable(c, "dedup engine not available")
+		return
+	}
+
+	var body struct {
+		Apply bool `json:"apply"`
+	}
+	// Ignore parse errors; missing body → dry-run (apply=false).
+	_ = c.ShouldBindJSON(&body)
+
+	result, err := h.dedupEngine.ReevaluateAcoustIDConflicts(c.Request.Context(), !body.Apply)
+	if err != nil {
+		httputil.InternalError(c, "acoustid-conflict reevaluation failed", err)
 		return
 	}
 

--- a/internal/server/handlers/dedup/interfaces.go
+++ b/internal/server/handlers/dedup/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/interfaces.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e84f746d-28e9-4c8a-9520-66191e582881
-// last-edited: 2026-06-10
+// last-edited: 2026-07-02
 
 // Narrow dependency interfaces for the dedup-domain HTTP handlers (candidate /
 // cluster / series listing, merge / dismiss / remove, bulk merge, stats,
@@ -78,6 +78,11 @@ type DedupEngine interface {
 	// apply=true persists new bands and scores. Returns a delta summary
 	// suitable for the HTTP response body.
 	Rescore(ctx context.Context, apply bool) (dedup.RescoreResult, error)
+	// ReevaluateAcoustIDConflicts finds pending non-audio candidates whose two
+	// books have clearly-disagreeing book-level AcoustID signatures (false
+	// positives the new acoustid veto suppresses at emission). dryRun=true
+	// reports counts + a sample without mutating; dryRun=false deletes them.
+	ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) (*dedup.AcoustIDConflictResult, error)
 }
 
 // OperationsRegistry is the narrow operations-registry subset the dedup scan

--- a/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
@@ -127,6 +127,33 @@ func (_e *MockDedupEngine_Expecter) Rescore(ctx any, apply any) *MockDedupEngine
 	return &MockDedupEngine_Rescore_Call{Call: _e.mock.On("Rescore", ctx, apply)}
 }
 
+func (_mock *MockDedupEngine) ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) (*dedup.AcoustIDConflictResult, error) {
+	ret := _mock.Called(ctx, dryRun)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReevaluateAcoustIDConflicts")
+	}
+
+	var r0 *dedup.AcoustIDConflictResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (*dedup.AcoustIDConflictResult, error)); ok {
+		return returnFunc(ctx, dryRun)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) *dedup.AcoustIDConflictResult); ok {
+		r0 = returnFunc(ctx, dryRun)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dedup.AcoustIDConflictResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
+		r1 = returnFunc(ctx, dryRun)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 func (_c *MockDedupEngine_Rescore_Call) Run(run func(ctx context.Context, apply bool)) *MockDedupEngine_Rescore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context

--- a/internal/server/wire_dedup_routes.go
+++ b/internal/server/wire_dedup_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_dedup_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b8c9d0e1-f2a3-4567-bcde-890123456789
-// last-edited: 2026-07-01
+// last-edited: 2026-07-02
 
 package server
 
@@ -29,6 +29,7 @@ func (s *Server) wireDedupRoutes(
 	// T016: breakdown and rescore endpoints (frozen API contract for T017).
 	protected.GET("/dedup/candidates/:id/breakdown", s.perm(auth.PermLibraryView), dedupH.GetDedupCandidateBreakdown)
 	protected.POST("/dedup/rescore", s.perm(auth.PermScanTrigger), dedupH.RescoreDedupCandidates)
+	protected.POST("/dedup/purge-acoustid-conflicts", s.perm(auth.PermScanTrigger), dedupH.PurgeAcoustIDConflicts)
 	protected.POST("/dedup/candidates/:id/merge", s.perm(auth.PermLibraryEditMetadata), dedupH.MergeDedupCandidate)
 	protected.POST("/dedup/candidates/:id/dismiss", s.perm(auth.PermLibraryEditMetadata), dedupH.DismissDedupCandidate)
 	protected.POST("/dedup/candidates/bulk-merge", s.perm(auth.PermLibraryEditMetadata), dedupH.BulkMergeDedupCandidates)


### PR DESCRIPTION
## Summary
Addresses the reported dedup problem: ~12.5K "exact" candidates that are false positives. The "exact" layer is dominated by **fuzzy title matches** (`checkExactTitle`: same author + titles within Levenshtein 2 → similarity 1.0), and there was **no AcoustID veto** — different-audio books with similar titles were flagged as 100% duplicates.

## Changes
- **`upsertExactCandidate`** — new `acoustIDSignaturesConflict` veto, sibling to the ISBN/ASIN `identifiersConflict` guard. Uses the **book-level** `book_sig_v1` signature (synthesized from per-file AcoustID chromaprints) via `BookSignatureSimilarityMasked`. Fires **only** when both books have a usable signature, ≥512-word overlap, and similarity < 0.50 (well below the 0.80 match threshold). Conservative on missing/partial data — a false veto would silently hide a real duplicate. Book-level (not per-file) so a real dup chaptered 1-file-vs-many isn't false-vetoed.
- **`ReevaluateAcoustIDConflicts(ctx, dryRun)`** — re-evaluates the existing pending backlog against the same rule (skips the audio-positive `acoustid`/`book_signature` layers). Dry-run reports counts + a capped sample; apply deletes.
- **New endpoint** `POST /api/v1/dedup/purge-acoustid-conflicts` — dry-run by default; `{"apply":true}` to delete.

## Test plan
- `acoustid_veto_test.go`: opposite signatures → veto; identical → no veto; missing signature → no veto; store fetch fallback; nil-safe.
- `go test ./internal/dedup/ ./internal/server/handlers/dedup/` green; `go vet` clean; `go build ./...` clean.

Plan: deploy, then run the endpoint in **dry-run** to report how many of the ~12.5K would be dismissed before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)