### PR TITLE
fix(dedup): re-embed on embedding-model change (model-aware cached-skip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 — Embedding backend cutover now actually re-embeds (model-aware skip)
+
+- **`fix(dedup)`** — `prepBookEmbed`'s cached-skip checked only the content hash, not the stored embedding **model**. Switching the embedding backend (e.g. OpenAI `text-embedding-3-large` 3072-dim → local `bge-m3` 1024-dim) therefore skipped every book whose text was unchanged, leaving stale wrong-dimension vectors that score 0 against the new model — so the "re-embed all" op no-oped (observed live: `skipped=all, new=0`). The skip now also requires the stored model to equal the wired client's model (`embeddingModelMatches`); an empty/legacy stored model counts as a mismatch and re-embeds. Enables the local-embedding cutover. Regression test `TestEmbedBooks_ReembedsOnModelChange`.
+
 #### July 2, 2026 — Dedup: AcoustID-conflict diagnostics (emission veto NOT wired — see prod dry-run finding)
 
 - **`feat(dedup)`** — investigated using book-level AcoustID signatures (`book_sig_v1`, synthesized from per-file chromaprints) to veto the "exact" title-match false-positive flood (`checkExactTitle`: same author + titles within Levenshtein 2 → similarity 1.0). Added the `acoustIDSignaturesConflict` helper, `ReevaluateAcoustIDConflicts(dryRun)`, and a diagnostic endpoint `POST /api/v1/dedup/purge-acoustid-conflicts` (dry-run by default). **A prod dry-run showed the veto is not viable as an emission gate, so it was intentionally NOT wired into `upsertExactCandidate`:** of 12,897 pending non-audio candidates, **65% (8,387) had no AcoustID fingerprint** (unjudgeable), and `BookSignatureSimilarityMasked` returns ~0.50 for *uncorrelated* audio (the noise floor — uncorrelated chromaprints differ in ~half their bits), so no defensible similarity threshold separates dups from non-dups on this data (only 5/4,510 comparable pairs fell below 0.50, at the floor). The real lever is **fingerprint coverage**, not a veto. The helper/endpoint are kept as diagnostics for a future, coverage-backed, distribution-validated threshold. Tests in `acoustid_veto_test.go`.

--- a/internal/dedup/embed_model_cutover_test.go
+++ b/internal/dedup/embed_model_cutover_test.go
@@ -1,0 +1,83 @@
+// file: internal/dedup/embed_model_cutover_test.go
+// version: 1.0.0
+// guid: 8a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9
+// last-edited: 2026-07-02
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/ai"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestEmbedBooks_ReembedsOnModelChange locks the fix for the embedding-backend
+// cutover bug: prepBookEmbed's cached-skip must also require the stored model to
+// match the wired client's model. Otherwise a content-hash hit skips every book
+// on a backend switch (e.g. OpenAI text-embedding-3-large -> local bge-m3),
+// leaving stale wrong-dimension vectors that score 0 against the new model.
+func TestEmbedBooks_ReembedsOnModelChange(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	primary := true
+	book := &database.Book{ID: "BOOK_R", Title: "A Real Audiobook", IsPrimaryVersion: &primary}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_R" {
+			return book, nil
+		}
+		return nil, nil
+	}
+
+	// First embed at model-A.
+	clientA := ai.NewEmbeddingClientWithOptions("k", "model-A", "")
+	clientA.SetRawEmbedForTest(func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 2, 3, 4}
+		}
+		return out, nil
+	})
+	engine.embedClient = clientA
+	if _, err := engine.EmbedBooks(context.Background(), []string{"BOOK_R"}); err != nil {
+		t.Fatalf("first EmbedBooks: %v", err)
+	}
+	first, _ := es.Get("book", "BOOK_R")
+	if first == nil || first.Model != "model-A" {
+		t.Fatalf("after first embed, stored model = %v, want model-A", first)
+	}
+
+	// Switch the client to model-B. Content hash is UNCHANGED, so the only reason
+	// to re-embed is the model change. Before the fix this was skipped (cached).
+	bCalls := 0
+	clientB := ai.NewEmbeddingClientWithOptions("k", "model-B", "")
+	clientB.SetRawEmbedForTest(func(_ context.Context, texts []string) ([][]float32, error) {
+		bCalls++
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{5, 6, 7, 8}
+		}
+		return out, nil
+	})
+	engine.embedClient = clientB
+	if _, err := engine.EmbedBooks(context.Background(), []string{"BOOK_R"}); err != nil {
+		t.Fatalf("second EmbedBooks: %v", err)
+	}
+	if bCalls == 0 {
+		t.Error("expected a re-embed API call after model change, but the book was skipped (cached)")
+	}
+	second, _ := es.Get("book", "BOOK_R")
+	if second == nil || second.Model != "model-B" {
+		t.Fatalf("after model change, stored model = %v, want model-B (re-embed)", second)
+	}
+
+	// Sanity: re-running at the SAME model with unchanged content DOES skip.
+	bCalls = 0
+	if _, err := engine.EmbedBooks(context.Background(), []string{"BOOK_R"}); err != nil {
+		t.Fatalf("third EmbedBooks: %v", err)
+	}
+	if bCalls != 0 {
+		t.Errorf("expected a cached skip when model+content unchanged, but re-embedded (%d calls)", bCalls)
+	}
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.41.1
+// version: 1.42.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-02
 
@@ -2091,11 +2091,27 @@ func (de *Engine) prepBookEmbed(ctx context.Context, bookID string) (
 	hash = ai.TextHash(text)
 
 	existing, getErr := de.embedStore.Get("book", bookID)
-	if getErr == nil && existing != nil && existing.TextHash == hash {
+	if getErr == nil && existing != nil && existing.TextHash == hash && de.embeddingModelMatches(existing.Model) {
 		de.mirrorBookToChromem(ctx, book, existing.Vector)
 		return book, text, hash, EmbedStatusCached, true, nil
 	}
 	return book, text, hash, 0, false, nil
+}
+
+// embeddingModelMatches reports whether a stored embedding's model matches the
+// currently-wired embedding client's model. A mismatch — e.g. after switching
+// the embedding backend from OpenAI (text-embedding-3-large, 3072-dim) to a
+// local model (bge-m3, 1024-dim) — must FORCE a re-embed even when the text
+// hash is unchanged. Without this, prepBookEmbed skips every book on a
+// content-hash hit and a model cutover silently no-ops, leaving stale vectors
+// of the wrong dimension (which then score 0 against the new model's vectors).
+// Empty stored model (pre-model-tagging rows) counts as a mismatch so those are
+// re-embedded too.
+func (de *Engine) embeddingModelMatches(storedModel string) bool {
+	if de.embedClient == nil {
+		return true // no client to compare against; don't force churn
+	}
+	return storedModel == de.embedClient.Model()
 }
 
 // EmbedBooks generates embeddings for the given book IDs in a single API call


### PR DESCRIPTION
## Summary
Blocks the local-embedding cutover: `prepBookEmbed`'s cached-skip checked only the content **hash**, not the stored embedding **model**. Switching the embedding backend (OpenAI `text-embedding-3-large` 3072-dim → local `bge-m3` 1024-dim) skipped every unchanged-text book, leaving stale wrong-dimension vectors. `CosineSimilarity` returns 0 on dimension mismatch, so metadata embedding scoring silently zeroed and the re-embed op no-oped (**observed live: `skipped=all, new=0`**).

## Fix
The cached-skip now also requires `existing.Model == embedClient.Model()` (`embeddingModelMatches`). Empty/legacy stored model → mismatch → re-embed.

## Test plan
- New `TestEmbedBooks_ReembedsOnModelChange` (re-embeds on model change; still skips when model+content unchanged).
- Existing `TestEmbedBooks_RecordsClientModel` green; `go vet` + `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)