### PR TITLE
fix(server): trust explicit embedding base_url for Ollama availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 — Local embeddings: trust an explicitly-configured Ollama base_url
+
+- **`fix(server)`** — the embedding client's Ollama-availability gate was set from `toolRegistry.Available("ollama")`, which is a binary-on-PATH probe (`exec.LookPath`). When Ollama runs as a system service / container the app can't see on `PATH` (its HTTP endpoint still reachable on `:11434`), the probe failed and `EmbedBatch` refused every call with `ErrOllamaNotAvailable` — so a local-embedding cutover produced `new=0, errors=all` even though Ollama was up. Now, when an operator has explicitly set an embedding `base_url` (an assertion the endpoint exists), Ollama is treated as available regardless of the binary probe. Unblocks local (bge-m3) embeddings.
+
 #### July 2, 2026 — Embedding backend cutover now actually re-embeds (model-aware skip)
 
 - **`fix(dedup)`** — `prepBookEmbed`'s cached-skip checked only the content hash, not the stored embedding **model**. Switching the embedding backend (e.g. OpenAI `text-embedding-3-large` 3072-dim → local `bge-m3` 1024-dim) therefore skipped every book whose text was unchanged, leaving stale wrong-dimension vectors that score 0 against the new model — so the "re-embed all" op no-oped (observed live: `skipped=all, new=0`). The skip now also requires the stored model to equal the wired client's model (`embeddingModelMatches`); an empty/legacy stored model counts as a mismatch and re-embeds. Enables the local-embedding cutover. Regression test `TestEmbedBooks_ReembedsOnModelChange`.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.32.0
+// version: 2.32.1
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-06-22
+// last-edited: 2026-07-02
 
 package server
 
@@ -611,9 +611,16 @@ func NewServer(store database.Store) *Server {
 			server.hnswPersistDir = filepath.Join(filepath.Dir(config.AppConfig.DatabasePath), "hnsw")
 		}
 
-		// Gate embedding client on Ollama availability.
+		// Gate embedding client on Ollama availability. The tool-registry check
+		// is a binary-on-PATH probe (exec.LookPath), which fails when Ollama runs
+		// as a system service / container the app can't see on PATH — even though
+		// its HTTP endpoint is reachable. So when an operator has EXPLICITLY
+		// configured an embedding base_url (an assertion that the endpoint exists,
+		// e.g. http://127.0.0.1:11434/v1 for local Ollama), trust it rather than
+		// let the missing binary block all embeds.
 		if server.embedClient != nil {
-			server.embedClient.SetOllamaAvailable(server.toolRegistry.Available("ollama"))
+			ollamaOK := server.toolRegistry.Available("ollama") || config.AppConfig.Embedding.BaseURL != ""
+			server.embedClient.SetOllamaAvailable(ollamaOK)
 		}
 
 		// Wire dedup plugin tool registry so Ollama-gated ops check availability.


### PR DESCRIPTION
## Summary
Unblocks local (bge-m3) embeddings. The embedding client's Ollama-availability gate was set from `toolRegistry.Available("ollama")` — a binary-on-PATH probe (`exec.LookPath`). When Ollama runs as a system service / container the app can't see on `PATH` (endpoint still reachable on `:11434`), the probe fails and `EmbedBatch` refuses every call with `ErrOllamaNotAvailable`. A local-embedding cutover then produces `new=0, errors=all` even though Ollama is up (observed live).

## Fix
When an operator has explicitly set an embedding `base_url`, treat Ollama as available regardless of the binary probe — an explicit base_url is an assertion the endpoint exists.

## Test plan
- `go build ./...` clean.
- Empirical: after deploy, the `dedup.embed-scan` op re-embeds via Ollama (new>0) instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)