### PR TITLE
fix(database): discard stale-dimension HNSW snapshot on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 - HNSW: discard a stale-dimension snapshot on import (embedding cutover)
+
+- **`fix(database)`** - switching the embedding backend from OpenAI `text-embedding-3-large` (3072-dim) to local `bge-m3` (1024-dim) crashed the re-embed op: `HNSWEmbeddingStore.Import` loaded the old 3072-dim on-disk snapshot without a dimension check, and the coder/hnsw library then **panicked** (`graph.go assertDims`) the moment a 1024-dim vector was added. Import now discards any snapshot whose dimension no longer matches the configured store dimension; the derived index rebuilds empty at the new dimension via hydration + re-embed. Regression tests in `hnsw_dim_reset_test.go`.
+
 #### July 2, 2026 — Local embeddings: trust an explicitly-configured Ollama base_url
 
 - **`fix(server)`** — the embedding client's Ollama-availability gate was set from `toolRegistry.Available("ollama")`, which is a binary-on-PATH probe (`exec.LookPath`). When Ollama runs as a system service / container the app can't see on `PATH` (its HTTP endpoint still reachable on `:11434`), the probe failed and `EmbedBatch` refused every call with `ErrOllamaNotAvailable` — so a local-embedding cutover produced `new=0, errors=all` even though Ollama was up. Now, when an operator has explicitly set an embedding `base_url` (an assertion the endpoint exists), Ollama is treated as available regardless of the binary probe. Unblocks local (bge-m3) embeddings.

--- a/internal/database/hnsw_dim_reset_test.go
+++ b/internal/database/hnsw_dim_reset_test.go
@@ -1,0 +1,76 @@
+// file: internal/database/hnsw_dim_reset_test.go
+// version: 1.0.0
+// guid: 2f7b8c19-4d3e-4a60-9b1c-5e8f0a2d6b74
+// last-edited: 2026-07-02
+
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// TestHNSWImport_DiscardsStaleDimSnapshot locks the embedding-backend cutover
+// fix: a persisted HNSW snapshot whose dimension no longer matches the store's
+// configured dimension (e.g. OpenAI 3072 -> local bge-m3 1024) must be
+// discarded on Import, not loaded — otherwise coder/hnsw panics the moment a
+// new-dimension vector is added. The index rebuilds empty at the new dimension.
+func TestHNSWImport_DiscardsStaleDimSnapshot(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Snapshot written by a 3-dim store (stand-in for the old 3072-dim index).
+	old := NewHNSWEmbeddingStore(3)
+	if err := old.Upsert(ctx, "book", "B1", []float32{1, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert into old store: %v", err)
+	}
+	if err := old.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// A new store configured for a DIFFERENT dimension imports that snapshot.
+	newStore := NewHNSWEmbeddingStore(4)
+	if err := newStore.Import(dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// The stale 3-dim book graph must have been discarded.
+	n, err := newStore.CountByType(ctx, "book")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected stale-dim snapshot discarded (count 0), got %d", n)
+	}
+
+	// And a correctly-dimensioned vector must now insert without panicking.
+	if err := newStore.Upsert(ctx, "book", "B2", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert new-dim vector after discard: %v", err)
+	}
+	if n, _ := newStore.CountByType(ctx, "book"); n != 1 {
+		t.Fatalf("expected 1 after new-dim upsert, got %d", n)
+	}
+}
+
+// TestHNSWImport_KeepsMatchingDimSnapshot ensures a same-dimension snapshot is
+// still loaded normally (no regression to the happy path).
+func TestHNSWImport_KeepsMatchingDimSnapshot(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	old := NewHNSWEmbeddingStore(3)
+	if err := old.Upsert(ctx, "book", "B1", []float32{1, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := old.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	same := NewHNSWEmbeddingStore(3)
+	if err := same.Import(dir); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if n, _ := same.CountByType(ctx, "book"); n != 1 {
+		t.Fatalf("matching-dim snapshot should load (count 1), got %d", n)
+	}
+}

--- a/internal/database/hnsw_embedding_store.go
+++ b/internal/database/hnsw_embedding_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-06-18
+// last-edited: 2026-07-02
 
 // HNSW-graph vector store (coder/hnsw) — a sub-linear ANN index alternative to
 // the brute-force chromem store. Selected via config.VectorIndexBackend="hnsw".
@@ -383,6 +383,18 @@ func (s *HNSWEmbeddingStore) Import(dir string) error {
 			return fmt.Errorf("hnsw import: read graph %s: %w", entityType, err)
 		}
 		f.Close()
+		// Discard a snapshot whose dimension no longer matches the configured
+		// store dimension — e.g. after switching the embedding backend from
+		// OpenAI text-embedding-3-large (3072) to local bge-m3 (1024). Loading
+		// the stale graph would make the coder/hnsw library PANIC the moment a
+		// new-dimension vector is added (graph.go assertDims). The index is a
+		// derived structure; skipping the snapshot lets it rebuild empty at the
+		// new dimension via hydration + re-embed.
+		if s.dims > 0 && g.Len() > 0 && g.Dims() != s.dims {
+			slog.Warn("hnsw import: snapshot dimension mismatch; discarding stale snapshot (index will rebuild at new dimension)",
+				"entity_type", entityType, "snapshot_dims", g.Dims(), "config_dims", s.dims)
+			continue
+		}
 		s.graphs[entityType] = g
 
 		metaPath := filepath.Join(dir, "hnsw-"+entityType+".meta.json")


### PR DESCRIPTION
## Summary
Switching the embedding backend (OpenAI `text-embedding-3-large` 3072-dim → local `bge-m3` 1024-dim) crashed the re-embed op with `panic: embedding dimension mismatch: 3072 != 1024` (coder/hnsw `graph.go assertDims`).

`HNSWEmbeddingStore.Import` loaded the old 3072-dim on-disk snapshot with **no dimension check**; the library then panicked the moment a 1024-dim vector was added. (On prod the snapshot is loaded at boot and hydration skipped, so the stale snapshot is the sole 3072 source.)

## Fix
`Import` now discards any snapshot whose dimension ≠ the store's configured `s.dims`; the derived index rebuilds empty at the new dimension via hydration + re-embed. No data loss (index is derived from PebbleDB).

## Test plan
- New `hnsw_dim_reset_test.go`: stale-dim snapshot discarded (+ new-dim upsert then succeeds); matching-dim snapshot still loads.
- `go vet` + `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)