### PR TITLE
fix(database): recover coder/hnsw library panics in Upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug Fixes
 
+#### July 2, 2026 - HNSW: contain coder/hnsw library panics at the store boundary
+
+- **`fix(database)`** - `HNSWEmbeddingStore.Upsert` now recovers panics from the fragile coder/hnsw v0.6.1 `Graph.Add` (it panics `"node not added"` on some re-insert states, and `assertDims` on a dimension mismatch) and returns them as errors. The vector index is a DERIVED, best-effort structure hydrated from PebbleDB; a single bad mirror must never crash a 44K-book re-embed op (which it did). Callers already log and continue past Upsert errors. Regression test `hnsw_panic_safe_test.go`.
+
 #### July 2, 2026 - HNSW: discard a stale-dimension snapshot on import (embedding cutover)
 
 - **`fix(database)`** - switching the embedding backend from OpenAI `text-embedding-3-large` (3072-dim) to local `bge-m3` (1024-dim) crashed the re-embed op: `HNSWEmbeddingStore.Import` loaded the old 3072-dim on-disk snapshot without a dimension check, and the coder/hnsw library then **panicked** (`graph.go assertDims`) the moment a 1024-dim vector was added. Import now discards any snapshot whose dimension no longer matches the configured store dimension; the derived index rebuilds empty at the new dimension via hydration + re-embed. Regression tests in `hnsw_dim_reset_test.go`.

--- a/internal/database/hnsw_embedding_store.go
+++ b/internal/database/hnsw_embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/hnsw_embedding_store.go
-// version: 1.5.1
+// version: 1.5.2
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
 // last-edited: 2026-07-02
 
@@ -140,20 +140,33 @@ func (s *HNSWEmbeddingStore) Upsert(_ context.Context, entityType, entityID stri
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	g := s.graphFor(entityType)
-	// coder/hnsw v0.6.1 Graph.Add replaces an existing key. The typical
-	// call path (HydrateChromem on a fresh store, or adding a brand-new book)
-	// only inserts new keys, so the built-in replace path is never exercised.
-	// Re-inserting existing keys has a library bug (HNSW-CRASH-2026-06-18)
-	// that is avoided structurally: NewServer loads the HNSW snapshot BEFORE
-	// PostInit so dedup.Engine.PostInit detects the populated store and skips
-	// HydrateChromem entirely. See internal/server/server.go and
-	// internal/dedup/lifecycle.go for the fix.
-	g.Add(hnsw.MakeNode(entityID, vec))
+	// coder/hnsw v0.6.1 Graph.Add has known crash bugs: it panics "node not
+	// added" (graph.go:405) on some re-insert / concurrent-mutation states, and
+	// assertDims-panics on a dimension mismatch. This derived, best-effort ANN
+	// index must never crash a caller — a single bad mirror cannot be allowed to
+	// abort a 44K-book re-embed. Contain the library here: recover any panic and
+	// surface it as an error, which callers (mirrorBookToChromem) already log and
+	// continue past.
+	if err := s.safeAdd(g, entityID, vec); err != nil {
+		return err
+	}
 	if meta == nil {
 		meta = map[string]string{}
 	}
 	// Store a defensive copy so the caller can't mutate our sidecar.
 	s.meta[entityType][entityID] = copyMeta(meta)
+	return nil
+}
+
+// safeAdd wraps coder/hnsw Graph.Add so a library panic becomes an error rather
+// than crashing the process. Caller must hold s.mu.
+func (s *HNSWEmbeddingStore) safeAdd(g *hnsw.Graph[string], entityID string, vec []float32) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("hnsw add %s: recovered library panic: %v", entityID, r)
+		}
+	}()
+	g.Add(hnsw.MakeNode(entityID, vec))
 	return nil
 }
 

--- a/internal/database/hnsw_panic_safe_test.go
+++ b/internal/database/hnsw_panic_safe_test.go
@@ -1,0 +1,42 @@
+// file: internal/database/hnsw_panic_safe_test.go
+// version: 1.0.0
+// guid: 5d9e1a73-2c4b-4f80-a6d1-8b3e0f2c9a45
+// last-edited: 2026-07-02
+
+package database
+
+import (
+	"context"
+	"testing"
+)
+
+// TestHNSWUpsert_ReinsertDoesNotCrash locks the fix that contains coder/hnsw's
+// known crash bugs (e.g. the "node not added" panic on re-insert) at the store
+// boundary: a mirror that trips the library must surface an error, never crash
+// the process. Re-inserting the same key repeatedly is the documented trigger
+// (HNSW-CRASH-2026-06-18); this must complete without panicking.
+func TestHNSWUpsert_ReinsertDoesNotCrash(t *testing.T) {
+	ctx := context.Background()
+	s := NewHNSWEmbeddingStore(3)
+
+	// Fresh inserts (the common re-embed path) must succeed.
+	if err := s.Upsert(ctx, "book", "B1", []float32{1, 0, 0}, nil); err != nil {
+		t.Fatalf("fresh insert B1: %v", err)
+	}
+	if err := s.Upsert(ctx, "book", "B2", []float32{0, 1, 0}, nil); err != nil {
+		t.Fatalf("fresh insert B2: %v", err)
+	}
+
+	// Re-inserting an existing key is the documented "node not added" trigger
+	// (HNSW-CRASH-2026-06-18). It must NOT crash the process — a recovered-panic
+	// error is acceptable; a process crash is not. Reaching the assertion below
+	// at all proves no panic escaped.
+	for range 5 {
+		_ = s.Upsert(ctx, "book", "B1", []float32{0, 0, 1}, nil)
+	}
+
+	// The store is still usable for a brand-new key.
+	if err := s.Upsert(ctx, "book", "B3", []float32{1, 1, 1}, nil); err != nil {
+		t.Logf("post-reinsert fresh insert returned (recovered) error, tolerated: %v", err)
+	}
+}


### PR DESCRIPTION
Contains coder/hnsw v0.6.1 crash bugs (`node not added`, dim-mismatch) at the store boundary so a best-effort derived-index mirror can't crash a 44K-book re-embed. safeAdd recovers Graph.Add panics -> error; callers already log+continue. Test: hnsw_panic_safe_test.go. 🤖 Generated with [Claude Code](https://claude.com/claude-code)