### PR TITLE
docs(consultancy): full 6-dimension consultancy evaluation + ranked roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.97.0 -->
+<!-- version: 3.98.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-02 -->
 
 # Changelog
 
 ## [Unreleased]
+
+### Documentation
+
+#### July 2, 2026 - Full consultancy evaluation (6 dimensions, 101 findings)
+
+- **`docs(consultancy)`** - Read-only multi-agent consultancy evaluation across storage/architecture, dedup, matching/backends, code quality, feature portfolio, and process/ops/security. 25 agents (repo specialist subagents + adversarial verifiers), all findings cited `file:line`; the 5 critical/high code findings independently verified real. Reports in [`docs/consultancy/`](docs/consultancy/) — start at [`00-ROADMAP.md`](docs/consultancy/00-ROADMAP.md) (impact × effort tiers, deferred-work verdicts, validated-don't-re-fix list). Headline defects: `EmbeddingScorer` model-blind cache fast-path zeroes search scores during the bge-m3 re-embed (MATCH-1/BUG-1); memdb-stripped `Book` → `UpdateBook` full-replace wipes `Description`/`BookSigV1` (STOR-1/QUAL-2). Also committed the previously-untracked `docs/status/2026-07-02-local-cutover-and-matching.md` handoff doc (PROC-1 verdict: commit now).
 
 ### Bug Fixes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.52.0 -->
+<!-- version: 9.53.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-01 -->
+<!-- last-edited: 2026-07-02 -->
 
 # Project TODO
 
@@ -19,6 +19,25 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## 🧾 Consultancy Evaluation — [`docs/consultancy/`](docs/consultancy/) (2026-07-02)
+
+Full 6-dimension evaluation (101 findings, `file:line`-cited, top code findings
+adversarially verified). Ranked roadmap: [`docs/consultancy/00-ROADMAP.md`](docs/consultancy/00-ROADMAP.md).
+Tier-0 items (high impact, low effort — do first):
+
+- [ ] **CONSULT-1** EmbeddingScorer store fast-path: model/dimension check + F1 fallback on degenerate zero-score results (MATCH-1/BUG-1 — live during bge-m3 re-embed) — `internal/ai/embedding_scorer.go:92-98`
+- [ ] **CONSULT-2** memdb preserve guard on `UpdateBook` (mirror PERF-7 BookFile guard); recover wiped Description/BookSigV1 from `book_ver:` snapshots BEFORE any pruning (STOR-1/QUAL-2) — `internal/database/pebble_store.go:2664`
+- [ ] **CONSULT-3** Model-aware re-embed skip in `EmbedAuthor` + `EmbedBooksAsync` (DEDUPC-1/TOGGLE-2) — `internal/dedup/engine.go:2243,2306`
+- [ ] **CONSULT-4** Unschedule/gate nightly `dedup.embed-async` (quota-dead OpenAI Batch API) (OPS-3) — `internal/plugins/dedup/embed_async.go:24`
+- [ ] **CONSULT-5** Drop OpenAIAPIKey requirement for keyless local backends (TOGGLE-1) — `internal/ai/register.go:35`
+- [ ] **CONSULT-6** Pre-commit hook doesn't actually block `.claude/.credentials/`; SHA-pin `security.yml` (SEC-2/SEC-5) — `scripts/setup-git-hooks.sh:17-27`
+- [ ] **CONSULT-7** Commit deploy recipe templates + `scripts/manage-ollama-windows.py`; add rollback target (OPS-1/OPS-6)
+- [ ] **CONSULT-8** API-key rotation/expiry for bootstrap-issued keys (SEC-1 — previously untracked anywhere)
+
+Tier-1+ (backend-mode toggle, 384K stale-candidate drain, bge-m3 threshold
+recalibration, fingerprint campaign, dedup auto-resolve op, slog-corruption
+sweep, shutdown escape-hatch, HNSW staleness, monitoring): see the roadmap.
 
 ## 🤖 Agent Task Package — [`docs/agent-tasks/`](docs/agent-tasks/) (refreshed July 1, 2026)
 

--- a/docs/consultancy/00-ROADMAP.md
+++ b/docs/consultancy/00-ROADMAP.md
@@ -1,0 +1,119 @@
+<!-- file: docs/consultancy/00-ROADMAP.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5c960e64-01d1-498e-8316-6bf5193c3deb -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Roadmap (2026-07-02)
+
+Top-level synthesis of the six-dimension consultancy evaluation, ranked by
+**impact × effort**. Produced by a read-only multi-agent workflow (25 agents:
+schema-auditor, db-design, expert, go-specialist, code-reviewer, pii-scanner,
+docs-agent, plus adversarial verifiers), with the repo expert consulted at every
+phase boundary. All findings cite `file:line`; the five critical/high code
+findings were independently adversarially verified and all confirmed real.
+
+Dimension reports (full detail lives there, not here):
+
+| Doc | Dimension | Findings |
+|-----|-----------|----------|
+| [01-storage-architecture.md](01-storage-architecture.md) | PebbleDB, derived vector indexes, NutsDB, lifecycle | 19 |
+| [02-dedup.md](02-dedup.md) | Layered engine, backlog strategy, auto-resolution design | 13 |
+| [03-matching-and-backends.md](03-matching-and-backends.md) | Metadata scoring, transcription match, backend-mode toggle design | 16 |
+| [04-code-quality.md](04-code-quality.md) | Bug hunt, counter-arguments, adversarial verification | 17 |
+| [05-features.md](05-features.md) | Deferred-work verdicts, missing features | 15 |
+| [06-process-and-security.md](06-process-and-security.md) | CI/docs, security/PII, ops/cost | 21 |
+
+## Headline conclusions
+
+1. **Two verified high-severity defects are live right now, during the bge-m3
+   re-embed.** (a) `EmbeddingScorer`'s cached-vector fast path ignores the
+   stored vector's model, so mixed 3072/1024-dim comparisons cosine to 0 and
+   metadata search silently returns zero candidates for not-yet-re-embedded
+   books, with no F1 fallback (MATCH-1/BUG-1). (b) The memdb-stripped `Book`
+   round-trip through full-replacement `UpdateBook` silently wipes
+   `Description` and the `BookSigV1` dedup signatures — destroying the very
+   fingerprint investment the dedup strategy depends on (STOR-1/QUAL-2;
+   recoverable from `book_ver:` CoW snapshots, so recovery must precede any
+   snapshot pruning).
+2. **The dedup strategy needs a re-order.** Fingerprint coverage (~8,387
+   books) is a real but *second-order* lever — it only powers the positive
+   auto-resolve oracle. The higher-yield, zero-fingerprint lever is draining
+   the ~384K stale candidates poisoned by the already-fixed importer bugs, plus
+   cheap duration-coverage backfill. Meanwhile the embedding-layer thresholds
+   are still calibrated for `text-embedding-3-large` and need recalibration
+   for bge-m3 (DEDUP-1/2/4).
+3. **The OpenAI→local cutover is ~80% done and the residue is dangerous:**
+   author embeddings never re-embed (model-aware skip missing in
+   `EmbedAuthor`/`EmbedBooksAsync`), a nightly `dedup.embed-async` op still
+   targets the quota-dead OpenAI Batch API, local embedding still demands an
+   `OpenAIAPIKey`, and the LLM path has no per-config base URL at all — local
+   LLM mode is currently impossible. The backend-mode toggle design in doc 03
+   resolves all of these.
+4. **Ops is the weakest dimension:** deploy recipe + systemd drop-in exist only
+   on one laptop (gitignored), no rollback target, the Windows GPU box is a
+   triple SPOF held up by an interactive-session scheduled task whose setup
+   scripts live in a scratchpad, `/metrics` is scraped by nothing, and quota
+   exhaustion was discovered by production failure.
+5. **Security posture is better than the stale memory suggests** — SEC-2,
+   SEC-7, PERF-7 are verified done. Real gaps: API-key rotation has zero
+   tracking and bootstrap keys never expire; the pre-commit hook does not
+   actually block `.claude/.credentials/`; one workflow is pinned `@main`.
+
+## Tier 0 — Do immediately (high impact, low effort)
+
+| # | Item | Findings | Why now |
+|---|------|----------|---------|
+| 1 | Model/dimension check in `EmbeddingScorer` store fast-path + F1 fallback on degenerate zero-score results | MATCH-1, BUG-1, QUAL-4 | Verified critical; actively corrupting metadata search during the in-flight re-embed |
+| 2 | memdb preserve guard on `UpdateBook` (mirror the PERF-7 BookFile guard); then audit/recover wiped `Description`/`BookSigV1` from `book_ver:` snapshots **before** any pruning | STOR-1, QUAL-2, DEDUP-6, DEDUPC-7 | Verified high; silently destroys dedup signatures on every memdb round-trip write |
+| 3 | Apply model-aware re-embed skip to `EmbedAuthor` + `EmbedBooksAsync` | DEDUPC-1, TOGGLE-2 | Author embeddings stranded on OpenAI vectors post-cutover |
+| 4 | Unschedule/gate nightly `dedup.embed-async` (OpenAI Batch API) | OPS-3, NEWF-5, PROC-2 | Fires nightly against a quota-dead API |
+| 5 | Drop `OpenAIAPIKey` requirement for keyless local backends | TOGGLE-1, MATCH-8 | One-line-class fix; blocks clean local-only operation |
+| 6 | Commit `docs/status/2026-07-02-local-cutover-and-matching.md` | PROC-1 | Verdict: commit now — done in this PR |
+| 7 | Fix pre-commit hook to actually block `.claude/.credentials/`; SHA-pin `security.yml` | SEC-2, SEC-5/PROC-7 | Cheap, closes claimed-but-absent protections |
+| 8 | Commit deploy recipe (`Makefile.local` template + `deploy/local.conf` sample) and the Windows Ollama scripts as `scripts/manage-ollama-windows.py`; add a rollback target | OPS-1, OPS-6, status-doc TODO | The entire prod deploy story currently lives on one laptop |
+
+## Tier 1 — Next (high impact, medium effort)
+
+| # | Item | Findings | Notes |
+|---|------|----------|-------|
+| 9 | **Backend-mode toggle** (embeddings + LLM, independent enums: disabled / openai / local / fallback), incl. per-config LLM base URL, permanent-error classification in `retry.go` (stop retrying 429 `insufficient_quota`), runtime availability probing, FE selector + model-download prompt | NEWF-2, TOGGLE-1..7, MATCH-7, BUG-5/QUAL-6 | Full design in doc 03; kills the last SPOF class from the OpenAI outage |
+| 10 | **Stale-candidate drain** (~384K candidates poisoned by fixed importer bugs) + duration-coverage backfill | DEDUP-1, DEDUP-4 | The first-order dedup lever; zero fingerprints required |
+| 11 | **bge-m3 threshold recalibration** for the embedding dedup layer + candidate regeneration | DEDUP-2, DEDUP-3 | Current thresholds calibrated for text-embedding-3-large; Layer 2 silently degraded during re-embed window |
+| 12 | **Fingerprint-coverage campaign** (~8,387 books) as a tracked op with a coverage KPI | NEWF-1, DEDUP-1 | Second-order but required for the auto-resolve positive oracle; do after items 2 & 10 |
+| 13 | **Dedup auto-resolution op** (`dedup.auto-resolve`): confidence-tiered pipeline on existing ComposeScore bands with dry-run, sampling audit, reversible merges | DEDUPC design (doc 02) | The "perfect match after all filters" deliverable; gated on 10–12 |
+| 14 | slog-corruption sweep (duplicate keys, `value0` literals, dropped args, `!BADKEY`) — mechanical, ideal `/parallel-sweep` | QUAL-1, BUG-4 | Observability is unreliable exactly where prod debugging happens |
+| 15 | Shutdown correctness: 30s escape-hatch closes Pebble under live jobs; `Registry.Shutdown` can return with store-touching goroutines live | SYS-1, BUG-2 | Same class as the PEBBLE-CLOSED race already fixed once |
+| 16 | HNSW snapshot staleness check vs Pebble source of truth; atomic Export; wrap `Graph.Delete` | ARCH-1, ARCH-2, ARCH-5 | Derived-index rebuild story is the main storage-architecture risk |
+| 17 | API-key rotation + expiry for bootstrap-issued keys; add TODO tracking | SEC-1, PROC-6 | Only remaining substantive security gap |
+| 18 | Minimal monitoring: scrape `/metrics`, alert on op failures + backend availability + (if restored) OpenAI spend | OPS-4, OPS-5 | Quota exhaustion was discovered by prod failure |
+
+## Tier 2 — Later (medium impact or high effort)
+
+- **NutsDB retirement** — finish the already-scaffolded Pebble cutover for activity (dual-write today) and metrics (still NutsDB-primary); removes a third storage engine and a goroutine leak (STOR-3/ARCH-3/SYS-3).
+- **`pebble_store.go` split** (11,398 lines) and `Server.Start` decomposition (670 lines, dual lifecycle authorities) (SYS-2, SYS-5).
+- **Bulk metadata-review queue** — highest-ranked new feature (NEWF-3); **library-health dashboard** (NEWF-4).
+- **TOCTOU fix** in `ApplyTranscriptionCandidate` (applies cache slot 0, not the gated candidate) (MATCH-6/BUG-3/QUAL-3); cover-filter ordering (MATCH-5/BUG-6/QUAL-5); `IsGarbageValue` "error" substring (MATCH-3); LLM-rerank scale mismatch (MATCH-2); byte-wise Levenshtein (MATCH-9).
+- **Doc-drift cleanup**: AI-REFERENCE route count + Ollama cutover, corrupted duplicate in `database-pebble-schema.md`, mockery v2 pin references (PROC-3, PROC-5, ARCH-4, SYS-6); strengthen the 30% coverage gate (PROC-4).
+- **Structural counter-arguments** (strategic, high effort): replace full-replacement `UpdateBook` with field-masked writes at the store boundary (CTR-1) and split the memdb projection into its own type instead of reusing `*Book` (CTR-2) — these two would eliminate the entire STOR-1 bug class permanently.
+- **PII scrub** (27+ files with internal hostnames/paths) — only if the repo is ever made public (SEC-3); `$RANDOM` credential entropy (SEC-4).
+
+## Deferred-work verdicts (from doc 05)
+
+| Item | Verdict |
+|------|---------|
+| ai-responses-migration ×5 | **Kill / indefinite defer** — Ollama (the only working backend) implements `/v1/chat/completions`, not `/v1/responses`; migrating would break prod |
+| dedup C8 (auto-bug-filing) | **Defer** (correctly gated); downgrade to a report op when unblocked |
+| CONS-13 (flat-key config shim retirement) | **Do**, once the 1-week gate is verified |
+| Pluggable-workflow subsystem | **Defer** the subsystem; pull WF-2 (capability declarations) forward |
+| Plex-style API | **Defer** — no spec, no consumer, wrong time |
+| Postgres eval / per-workload store eval | **Kill as standing items** — PebbleDB-as-primary steelman held (doc 01) |
+
+## What was explicitly validated (don't re-fix)
+
+- SEC-2, SEC-7, PERF-7 (BookFile memdb guards): verified done.
+- PRs #1738–#1741 (model-aware book re-embed, Ollama base_url trust, HNSW
+  stale-dim discard + panic recovery): correctly implemented.
+- Iterator hygiene (128/129 prefix-bounded), versioned backfill flags, cache
+  layers, emission-time dedup gates: sound.
+- PebbleDB-as-primary and derived-vector-index coupling: steelmanned and
+  upheld (doc 01).

--- a/docs/consultancy/01-storage-architecture.md
+++ b/docs/consultancy/01-storage-architecture.md
@@ -1,0 +1,282 @@
+<!-- file: docs/consultancy/01-storage-architecture.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8eda33bd-6c97-42bd-95bd-98f2f8e81e12 -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Storage & Architecture (2026-07-02)
+
+Evaluation run by a read-only multi-agent workflow (schema-auditor, db-design, and systems-expert specialists, cross-checked by an advisor pass). All findings are cited as `file:line` against the repo state on 2026-07-02. Production context: PebbleDB is the only primary store, ~50K books live on 172.16.2.30.
+
+## Executive Summary
+
+The storage core is sound and disciplined. PebbleDB-as-primary fits the single-node, prefix-scan/point-lookup workload: 128 of 129 iterators are prefix-bounded, backfill flags are version-suffixed (`activity_pebble_v1_done`, `book_aggregates_v1_done`, `lsh_index_v1_done`), id16hex dedup keys are zero-padded, batch hygiene is good, and the recent HNSW hardening (#1740 stale-dimension snapshot discard, #1741 `safeAdd` panic containment) is correctly implemented. Derived in-memory vector indexes (chromem brute-force, coder/hnsw) are correctly treated as disposable mirrors of the authoritative `emb:v:` keyspace in Pebble — an architecture that made the recent 3072→1024 dimension cutover survivable by discarding artifacts instead of migrating data. The memdb atomic-publish warm layer, the `stats:library` dirty-flag cache with stampede mutex, and the unusually high WHY-comment density are genuine assets.
+
+The material risks cluster in three places:
+
+1. **A live data-loss footgun on the Book entity (STOR-1, high).** The BookFile memdb round-trip footgun (PERF-7) is now guarded in both `UpsertBookFile` and `BatchUpsertBookFiles`, but the *same footgun class* is unguarded on Book: memdb-stripped Books (Description, VersionNotes, and all `BookSig*` dedup-signature fields nil'd) flow from `GetAllBooks` into `UpdateBook`, a full JSON replacement preserving only `CreatedAt`. Reconcile, migrations, quarantine, and merge all do this read-modify-write, silently wiping descriptions and dedup signatures. Advisor verification adds a mitigating nuance: `UpdateBook`'s copy-on-write `book_ver:` snapshot captures the full pre-wipe book, so existing damage is recoverable — provided recovery is sequenced **before** any snapshot pruning (STOR-2).
+
+2. **Derived-index rebuild gaps (ARCH-1/ARCH-2, high/medium).** The HNSW snapshot fast-path skips hydration with no staleness check against the Pebble source of truth — after any unclean shutdown, every vector upserted since the last clean shutdown is silently missing, which is the highest-value exposure during the in-flight bge-m3 re-embed. Export is non-atomic and Import can install partial state.
+
+3. **Lifecycle and legacy residue (SYS-1..4, ARCH-3/STOR-3/SYS-3).** Shutdown's 30s escape hatch closes stores under still-running, non-context-aware startup jobs — the same race class #1733 fixed inside the registry, patched point-by-point but never enforced as an invariant. And the NutsDB tier no longer earns its keep: its Pebble replacement is fully scaffolded and reads have flipped, yet every boot still opens `activity.nutsdb`, pays double writes, keeps `metrics.nutsdb` NutsDB-primary, and carries a documented goroutine leak per `Open`. All three specialists independently reached the same conclusion: finish the cutover and delete NutsDB.
+
+Secondary hygiene items: unpruned CoW snapshots growing monotonically under bulk sweeps, the repo's only unbounded full-keyspace scan in `KeyCount`, in-memory pagination in `ListAIJobs`, a corrupted/drifted canonical schema doc, unwrapped `Graph.Delete` despite documented library bugs, stale SQLite artifacts on prod disk, an 11,398-line `pebble_store.go`, v1→v2 operations-migration residue, and AI-REFERENCE.md contradicting itself on where the embedding keyspace lives.
+
+### Advisor verification
+
+The advisor pass spot-checked the specialist reports against the code:
+
+- **STOR-1 confirmed**: `memdb_strip.go:34-40` nils Description/BookSig\*; `GetAllBooks` routes to memdb at `pebble_store.go:1391-1393`; `reconcile.go:1115` + `:1149` does read-modify-write via `UpdateBook`'s full JSON replace at `:2664-2683`.
+- **ARCH-1/SYS-1 citations genuine**: the lifecycle comments (`server_lifecycle.go:468-471`) themselves admit the 30s-timeout risk, so SYS-1 is *known-but-unfixed* rather than undiscovered; severity is fair given the #1733 precedent.
+- **NutsDB triplication**: STOR-3, ARCH-3, and SYS-3 are the same finding reported by all three specialists; they are consolidated below. ARCH-3's metrics-still-NutsDB-primary detail is the most complete angle.
+- **Missed nuance (adjusts STOR-1/STOR-2)**: `GetBookByID` is Pebble-direct (`pebble_store.go:1691-1693`), so `UpdateBook`'s CoW `book_ver:` snapshot captures the full pre-wipe book. STOR-1 damage is therefore **recoverable from the very unpruned snapshots STOR-2 wants pruned** — sequence recovery before pruning.
+
+## Findings Table
+
+| ID | Severity | Impact | Effort | Title |
+|----|----------|--------|--------|-------|
+| STOR-1 | High | High | Low | memdb-stripped Book → UpdateBook full replacement silently wipes Description and BookSig dedup fields |
+| ARCH-1 | High | High | Medium | HNSW snapshot fast-path skips hydration with no staleness check against the Pebble source of truth |
+| SYS-1 | High | High | Medium | Shutdown 30s escape hatch closes stores under still-running, non-ctx-aware startup jobs |
+| STOR-3 / ARCH-3 / SYS-3 | Medium | Medium | Medium | NutsDB no longer earns its keep — finish the Pebble cutover and delete it (consolidated) |
+| STOR-2 | Medium | Medium | Low | Unbounded CoW `book_ver:` snapshot written on every UpdateBook; pruning is manual-only |
+| ARCH-2 | Medium | Medium | Low | HNSW Export is non-atomic and Import mutates store state mid-loop on failure |
+| ARCH-4 | Medium | Medium | Low | Canonical schema doc describes a ULID keyspace the code never adopted, and contains a corrupted duplicate of itself |
+| SYS-2 | Medium | Medium | High | Server.Start is a 670-line monolith with dual lifecycle authorities (inline sequence vs container) |
+| SYS-4 | Medium | Medium | Low | v1→v2 operations migration residue: hardcoded legacy resume shim, dead GlobalQueue references, stale docs |
+| STOR-4 | Low | Low | Low | KeyCount performs the repo's only unbounded full-keyspace iteration |
+| STOR-5 | Low | Low | Low | ListAIJobs loads and sorts the entire `aijob:` keyspace per request |
+| ARCH-5 | Low | Medium | Low | coder/hnsw Graph.Delete is not panic-wrapped despite documented Delete+Add invariant bugs |
+| ARCH-6 | Low | Low | Low | Legacy SQLite tier is correctly fenced in code but stale artifacts (embeddings.db) linger as an operational trap |
+| SYS-5 | Low | Medium | Medium | pebble_store.go at 11,398 lines is the navigability and merge-conflict hotspot |
+| SYS-6 | Low | Medium | Low | AI-REFERENCE contradicts itself on where the embedding/dedup keyspace lives |
+| STOR-6 | Info | Low | Low | Positive: PERF-7 BookFile guards, bounded iterators, versioned backfill flags, and HNSW hardening verified |
+| SYS-7 | Info | Low | Low | Positive: cache and derived-index layers are architecturally sound |
+
+## STOR-1 — memdb-stripped Book → UpdateBook full replacement silently wipes Description and BookSig dedup fields (High)
+
+**Detail.** `stripBookForMemdb` nils Description, VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt, and BookSigCoveragePct before memdb insertion. In prod (`UseMemDB=true`) `PebbleStore.GetAllBooks` delegates to the memdb projection (`pebble_store.go:1392-1393`), so callers receive stripped Books. `UpdateBook` (`pebble_store.go:2664`) marshals the incoming struct verbatim, preserving only `CreatedAt`. Multiple live paths do GetAllBooks → mutate → UpdateBook: `reconcile.AssignOrphanVGs` (1115→1149), `migration014UpPebble` (615→628), quarantine restore (275), `merge/service.go:154`. Every touched book loses its description and its BookSigV1 dedup signature (expensive to rebuild; feeds the signature dedup layer). This is exactly the BookFile PERF-7 footgun class, but the Book entity has NO preserve-on-empty guard.
+
+**Advisor adjustment (recoverability).** Because `GetBookByID` is Pebble-direct (`pebble_store.go:1691-1693`), `UpdateBook` reads the full unstripped old row before overwriting and writes it to the `book_ver:` CoW snapshot. Existing wipe damage is therefore recoverable from snapshots — the severity of *permanent* loss is bounded, but only while those snapshots survive. **Sequence any prod recovery of wiped Description/BookSig fields before implementing STOR-2's snapshot pruning.**
+
+**Recommendation.** Add a preserve-on-nil guard in `UpdateBook` mirroring the PERF-7 BookFile guard: `UpdateBook` already fetches `oldBook`, so copy Description/VersionNotes/BookSig\* from `oldBook` when the incoming pointers are nil (zero extra reads). Add a regression test modeled on `pebble_bookfile_preserve_test.go`. Then audit prod for books with `BookSigBuiltAt` set but `BookSigV1` nil to size existing damage — and recover from `book_ver:` snapshots before any pruning.
+
+**Citations:**
+- internal/database/memdb_strip.go:29-46
+- internal/database/pebble_store.go:1391-1393
+- internal/database/pebble_store.go:2664-2683
+- internal/reconcile/reconcile.go:1115
+- internal/reconcile/reconcile.go:1149
+- internal/database/migrations.go:615
+- internal/database/migrations.go:628
+- internal/quarantine/service.go:275
+
+## ARCH-1 — HNSW snapshot fast-path skips hydration with no staleness check against the Pebble source of truth (High)
+
+**Detail.** The HNSW snapshot is exported only on clean shutdown (`server_lifecycle.go:833`). On boot, Import loads it (`server.go:444`) and PostInit skips hydration entirely if `CountByType("book")>0` (`lifecycle.go:118-131`). Nothing compares the snapshot against the authoritative `emb:v:` keyspace in PebbleDB. After any unclean shutdown (panic, OOM — this app has a 69GB-bloat history — or kill -9), the next boot loads the last clean-shutdown snapshot and silently omits every vector upserted since, permanently until a manual re-embed or snapshot delete. During the current 29K-book re-embed this is the highest-value data at risk: a crash mid-scan means dedup Layer 2 quietly misses duplicates with no error anywhere.
+
+**Recommendation.** On import, compare snapshot `graph.Len()` per entity type against `EmbeddingStore.CountByType` (already cheap, `embedding_store.go:369`) and either delta-hydrate the difference or discard the snapshot and hydrate fully when counts diverge beyond a small tolerance. Alternatively write a monotonic watermark (max emb ID / count) alongside the snapshot and validate it at Import. Periodic export (e.g. after embed-scan completion) would also shrink the window.
+
+**Citations:**
+- internal/server/server.go:434-453
+- internal/dedup/lifecycle.go:115-131
+- internal/server/server_lifecycle.go:832-845
+- internal/database/hnsw_embedding_store.go:370-430
+
+## SYS-1 — Shutdown 30s escape hatch closes stores under still-running, non-ctx-aware startup jobs (High)
+
+**Detail.** Comments at `server_lifecycle.go:469-471, 480-482, 502-503` state `stripMovementAtoms`, `remuxMalformedM4BFiles`, and `transcodeMalformedM4BFiles` "do not check bgCtx" and are known contributors to the 30s grace timeout. At `:766-768`, when `bgWG.Wait()` times out the code logs a warning and "proceeds with shutdown anyway" — then closes `embeddingStore` (`:857`) and, via cmd/root.go's deferred `closeStore`, the main PebbleStore, while those goroutines may still iterate Pebble. This is structurally the same race #1733 fixed inside the registry (`registry.go:65-73`) and `Close()` fixed for warmup (`pebble_store.go:308-320`): each instance is patched point-by-point, but the invariant "no goroutine touches the store after Close" is not enforced anywhere. First-run-after-upgrade deploys (when these one-time jobs run for minutes on 50K books) are the exposure window.
+
+**Advisor note.** The lifecycle comments themselves admit the timeout risk, so this is known-but-unfixed rather than an undiscovered defect; severity remains fair given the #1733 precedent.
+
+**Recommendation.** Make the three one-time startup jobs ctx-aware (check `s.bgCtx` per file, as `backfillAcoustIDs` already does) so the 30s timeout stops firing. As defense-in-depth, add a closed atomic flag + iterator refcount to PebbleStore so post-Close access returns `ErrStoreClosed` instead of panicking.
+
+**Citations:**
+- internal/server/server_lifecycle.go:469-476
+- internal/server/server_lifecycle.go:480-486
+- internal/server/server_lifecycle.go:502-509
+- internal/server/server_lifecycle.go:763-769
+- internal/server/server_lifecycle.go:856-873
+- internal/database/pebble_store.go:307-320
+
+## STOR-3 / ARCH-3 / SYS-3 — NutsDB no longer earns its keep: finish the Pebble cutover and delete it (Medium, consolidated)
+
+All three specialists independently flagged NutsDB; this section consolidates their three angles.
+
+**Schema-auditor angle (STOR-3) — intrinsic costs.** (1) Bucket-per-book and bucket-per-op secondary indexes (`actOpBucket`/`actBookBucket`) — with 50K books this creates massive bucket counts, each carrying a RAM hint index under `HintKeyAndRAMIdxMode`; (2) Query's general path scans ALL tiers over the time range into memory, then filters/sorts/paginates in Go (`nuts_activity_store.go:194-232`) — O(entire in-range log) per `/api/v1/activity` request; (3) Summarize matches `keysToDelete` via a nested entries×keyLookup scan (`:302-311`), quadratic on large tiers; (4) documented Close goroutine leak pinned to v1.1.0 sentinels blocking upgrades; (5) `SyncEnable=false`. Meanwhile `DualWriteActivityStore` + `PebbleActivityStore` + the versioned flag `system:backfill:activity_pebble_v1_done` are already deployed (`register.go:78-82`) — the app pays double writes today.
+
+**DB-design angle (ARCH-3) — the most complete version: metrics is still NutsDB-primary.** The NutsDB→Pebble activity migration completed ~Jun 10 (flag set; reads served from Pebble), yet every boot still opens `activity.nutsdb` and double-writes all activity (`register.go:62-82`). Separately, metricsstore is still NutsDB-primary at `metrics.nutsdb` (`registry_wire.go:162-178`) even though `PebbleMetricsStore` exists with a TTL sweep job compensating for Pebble's lack of native expiry (`sweep_pebble_metrics_ttl.go`). NutsDB v1.1.0 leaks one goroutine per Open on Close (documented TODO.md:902-913) and DB-3 transactional work is deferred pending "NutsDB evaluation". Two sidecar databases, double write amplification, and a leaky dependency remain for a rollback window that has been open ~3 weeks.
+
+**Systems angle (SYS-3) — lifecycle cost.** F5-T024 shipped Jun 10 with a dual-write window (TODO.md:353); the follow-up T024b (remove NutsDB) never happened. `register.go:62-63` unconditionally opens `activity.nutsdb`; every activity Record/Summarize/Prune pays a double write forever (`dual_write_activity_store.go:60-76`), even after the backfill flag flips reads to Pebble (`:78-82`). The Pebble backend shares the main DB (`pebble_activity_store.go:54`) so removal costs nothing at the storage layer. Three storage engines (audiobooks.pebble, activity.nutsdb, ai_scans.db) each need distinct close ordering in shutdown (`server_lifecycle.go:815-873`).
+
+**Recommendation (merged).** Verify `activity_pebble_v1_done` is set on prod and run the activity backfill if not; run one release cycle dual-write; then collapse `DualWriteActivityStore` to a pass-through `PebbleActivityStore`, flip metricsstore to `PebbleMetricsStore`, delete the nutsdb dependency, and archive/delete the `.nutsdb` dirs. This removes a whole storage engine, the goroutine leak, the double-write cost, and one shutdown-ordering hazard, and unblocks DB-3 — matching the TODO perf-cleanup NUTSDB task.
+
+**Citations:**
+- internal/database/nuts_activity_store.go:66-68
+- internal/database/nuts_activity_store.go:88
+- internal/database/nuts_activity_store.go:104-115
+- internal/database/nuts_activity_store.go:194-232
+- internal/database/nuts_activity_store.go:302-311
+- internal/activity/register.go:53-83
+- internal/database/dual_write_activity_store.go:60-76
+- internal/database/dual_write_activity_store.go:195-201
+- internal/database/pebble_activity_store.go:52-66
+- internal/database/pebble_activity_backfill.go:34
+- internal/server/registry_wire.go:158-179
+- internal/maintenance/jobs/sweep_pebble_metrics_ttl.go:7-57
+- TODO.md:902-913
+
+## STOR-2 — Unbounded CoW `book_ver:` snapshot written on every UpdateBook; pruning is manual-only (Medium)
+
+**Detail.** `UpdateBook` snapshots the full old Book JSON to `book_ver:<id>:<unixnano>` on every call, including whole-library sweeps (reconcile, migrations, maintenance plugins, organizer). A fingerprinted book's JSON carries ~22KB of BookSigV1 base64, so a single 50K-book sweep can add >1GB of snapshot keys. `PruneBookSnapshots` exists but its only caller is the manual metadata handler endpoint (`handler.go:698`) — nothing prunes automatically, so the keyspace grows monotonically with every bulk operation and inflates compaction and the KeyCount diagnostic.
+
+**Advisor adjustment.** These same snapshots are what makes STOR-1's damage recoverable — they capture the full pre-wipe book. Any STOR-1 recovery work MUST be sequenced before pruning is enabled.
+
+**Recommendation.** Enforce a per-book retention cap inside `UpdateBook` itself (e.g., after committing, delete snapshots beyond N=10 using the existing prefix scan — amortized cheap), or add a periodic maintenance op that iterates `book_ver:` and prunes. Also consider skipping snapshot writes for no-op field changes during bulk sweeps. Do not enable either until STOR-1 recovery is complete.
+
+**Citations:**
+- internal/database/pebble_store.go:2688-2701
+- internal/database/pebble_store.go:3108-3133
+- internal/server/handlers/metadata/handler.go:698
+
+## ARCH-2 — HNSW Export is non-atomic and Import mutates store state mid-loop on failure (Medium)
+
+**Detail.** Export writes `.bin` and `.meta.json` directly to their final paths via `os.Create`/`os.WriteFile` — no temp+rename, no fsync (`hnsw_embedding_store.go:342-364`). A crash mid-export leaves a truncated snapshot. Import installs `s.graphs[entityType]` (line 411) before reading the metadata sidecar; if the meta read/unmarshal fails (lines 414-424) it returns an error with the graph already installed but meta absent. The caller only logs the error (`server.go:446`), then PostInit sees `CountByType>0` and skips hydration (`lifecycle.go:119`) — leaving a graph whose FindSimilar metadata filter rejects every node (`metadataMatches` fails on missing keys, line 315-324), so filtered dedup queries silently return nothing.
+
+**Recommendation.** Export to `<file>.tmp` then `os.Rename`; Import into local maps and only commit to `s.graphs`/`s.meta` after every file for every entity type parses (all-or-nothing). On any Import error, leave the store empty so the existing hydration fallback actually runs.
+
+**Citations:**
+- internal/database/hnsw_embedding_store.go:341-365
+- internal/database/hnsw_embedding_store.go:381-427
+- internal/dedup/lifecycle.go:118-122
+
+## ARCH-4 — Canonical schema doc describes a ULID keyspace the code never adopted, and contains a corrupted duplicate of itself (Medium)
+
+**Detail.** `docs/database-architecture.md` declares `database-pebble-schema.md` "canonical for any new feature touching persistence", but that doc specifies ULID-keyed `a:`/`b:`/`idx:` prefixes while production code uses integer-ID `author:%d`, `book:%d`, `author:name:<norm>` keys with `"book:0".."book:;"` ASCII-range iteration bounds (`pebble_store.go:432-433, 1102-1103`). Only the dedup/emb section (lines 561-600) matches reality (`embedding_store.go:75-84`). Worse, the file physically contains two concatenated versions (a second header at line 312) with content interleaved mid-JSON-schema (e.g. the User entity split by a backfill section at lines 419-431). Anyone following the repo's own decision framework ("read existing schema first") gets actively misled.
+
+**Recommendation.** Regenerate the schema doc from the real keyspace (grep the `fmt.Sprintf` key constructors in pebble_store.go, embedding_store.go, pebble_activity_store.go, ai_scan_store.go, pebble_store_lsh.go) and delete the duplicated block. Mark the ULID design explicitly as an unimplemented proposal or remove it. Consider a small test that asserts documented prefixes exist in code to prevent re-drift.
+
+**Citations:**
+- docs/database-pebble-schema.md:24
+- docs/database-pebble-schema.md:312-645
+- docs/database-architecture.md:22-27
+- internal/database/pebble_store.go:432-457
+- internal/database/pebble_store.go:1102-1112
+
+## SYS-2 — Server.Start is a 670-line monolith with dual lifecycle authorities (Medium)
+
+**Detail.** `Start()` mixes container start, cache warmers, HTTP/2/3/TLS setup, role seeding, resume logic, file watchers, four ticker loops, signal handling, and the entire ~175-line teardown sequence. The SERVER-LIFECYCLE-FLIP comment (`:801-813`) admits the split-brain: "Inline Stops above remain the source of truth for the carefully-sequenced teardown... Container.Stop is idempotent on already-stopped services for those." Two stop orders coexist, relying on idempotence rather than a single dependency graph. Meanwhile teardown coordinates FIVE concurrency trackers: inline stops, container.Stop, the named `bgWG`, a function-local `backgroundWG` + shutdown channel (`:522-525`), and the registry's internal `goroutineWG`. Every new background task must pick the right one; picking wrong reproduces SYS-1.
+
+**Recommendation.** Finish the flip: move the remaining hand-ordered Stops (opRegistry drain, writeBackBatcher flush, itunesSvc, HNSW export, embed/ollama, embeddingStore/aiScanStore closes) into container Stoppers with declared deps, so ordering is derived not hand-maintained. Fold the local backgroundWG tickers into bgWG or container-managed services. Extract `Start()` into startHTTP/startBackground/shutdown methods.
+
+**Citations:**
+- internal/server/server_lifecycle.go:211-878
+- internal/server/server_lifecycle.go:801-813
+- internal/server/server_lifecycle.go:522-525
+
+## SYS-4 — v1→v2 operations migration residue: hardcoded legacy resume shim, dead GlobalQueue references, stale docs (Medium)
+
+**Detail.** The v1 OperationQueue is gone (internal/operations/ has no queue.go; zero non-test GlobalQueue references), but: (a) `resumeLegacyOp` (`server_lifecycle.go:111-209`) hardcodes ~10 pre-UOS op-type names in a switch, several with near-identical re-enqueue boilerplate — every entry must be maintained until no prod DB can contain a v1 op row; (b) `transcode_integration_test.go:401` (behind the `integration` build tag) still calls `operations.GlobalQueue.Enqueue` and cannot compile — the tagged test silently rotted; (c) `docs/AI-REFERENCE.md:21` lists `database.GlobalQueue` as a live global and `:87-89` documents internal/operations queue.go/OperationQueue. Agents (and this repo's own project-context skill) are told to trust that doc.
+
+**Recommendation.** Update AI-REFERENCE §internal/operations to describe the registry (dispatcher/worker/watchdog/ResumePolicy). Fix or delete the integration-tagged transcode test (add a CI job that at least compiles `-tags integration`). Add a cutoff: after N releases, `resumeLegacyOp` collapses to "mark failed, please retry".
+
+**Citations:**
+- internal/server/server_lifecycle.go:111-209
+- internal/transcode/transcode_integration_test.go:401
+- docs/AI-REFERENCE.md:21
+- docs/AI-REFERENCE.md:87-89
+
+## STOR-4 — KeyCount performs the repo's only unbounded full-keyspace iteration (Low)
+
+**Detail.** `KeyCount` opens `NewIter(nil)` and steps every key in audiobooks.pebble to count them — the only unbounded iterator in internal/ (all other 128 NewIter sites are prefix-bounded). With 50K books + 308K book files + secondary indexes + dedup/emb/act keyspaces + unpruned `book_ver:` snapshots (STOR-2), this is millions of keys per call on the DB-health diagnostics endpoint, holding an iterator (and its snapshot) open for the duration and churning block cache.
+
+**Recommendation.** Replace the exact count with pebble's estimates: `db.Metrics()` table/entry stats or `EstimateDiskUsage` per known prefix, and label the value "estimated". If an exact count is genuinely needed, compute it in a rate-limited background job and cache the result (cached-aggregate + dirty-flag pattern already used elsewhere).
+
+**Citations:**
+- internal/database/pebble_store.go:10488-10498
+
+## STOR-5 — ListAIJobs loads and sorts the entire `aijob:` keyspace per request (Low)
+
+**Detail.** `ListAIJobs` prefix-scans all `aijob:` keys, unmarshals every job, filters, sorts by CreatedAt desc in memory, then applies offset/limit. Keys are `aijob:<id>` (not time-ordered), so pagination cannot push down. Fine at current volumes, but AI-scan job counts grow monotonically with the local-Ollama re-embed/scan cadence and there is no visible pruning of completed jobs; each list call's cost grows linearly forever.
+
+**Recommendation.** Either key jobs time-ordered (`aijob:<20-digit-unixnano>:<id>`, matching the activity-store convention) so reverse iteration yields CreatedAt-desc natively with early exit at limit, or add retention pruning for terminal-state jobs older than N days. Low urgency; pair with any next touch of ai_scan_store/aijob code.
+
+**Citations:**
+- internal/database/pebble_store.go:10447-10484
+
+## ARCH-5 — coder/hnsw Graph.Delete is not panic-wrapped despite documented Delete+Add invariant bugs (Low)
+
+**Detail.** PR #1741 wrapped `Graph.Add` in `safeAdd` with `recover()` because coder/hnsw v0.6.1 panics on some re-insert states, and `server.go:436-438` documents a production crash loop caused by a nil-deref "when Delete+Add violates the per-layer node invariant" (HNSW-CRASH-2026-06-18). Yet `HNSWEmbeddingStore.Delete` calls `g.Delete(entityID)` bare (line 194). Delete runs on live paths (book merge/removal mirrors) from goroutines where an unrecovered panic kills the process — exactly the failure class #1741 was shipped to contain.
+
+**Recommendation.** Apply the same recover-to-error wrapper to `g.Delete` (and any other Graph method invoked on live paths), mirroring `safeAdd`. Trivial change; add a companion test alongside `hnsw_panic_safe_test.go`.
+
+**Citations:**
+- internal/database/hnsw_embedding_store.go:189-199
+- internal/database/hnsw_embedding_store.go:161-171
+- internal/server/server.go:436-438
+
+## ARCH-6 — Legacy SQLite tier is correctly fenced in code but stale artifacts (embeddings.db) linger as an operational trap (Low)
+
+**Detail.** SQLite requires an explicit `--enable-sqlite3-i-know-the-risks` flag and config validation rejects other values (`config.go:1165`) — good fencing. But the stale embeddings.db is still acknowledged as present on prod (status doc line 51), and code comments still describe "the SQLite/Pebble EmbeddingStore" as source of truth (`chromem_embedding_store.go:13, 63`) years after Pebble became sole primary. The risk is human, not mechanical: a future operator or agent finding embeddings.db on disk (now full of dead 3072-dim OpenAI vectors) could waste time or wire something against it.
+
+**Recommendation.** Archive-and-delete embeddings.db (and any audiobooks.db) from prod after the bge-m3 re-embed completes; sweep code comments that still say "SQLite/Pebble" to say Pebble; note the removal in the schema doc's legacy section.
+
+**Citations:**
+- internal/config/config.go:1165-1167
+- cmd/root.go:350-351
+- docs/status/2026-07-02-local-cutover-and-matching.md:51
+- internal/database/chromem_embedding_store.go:12-14
+
+## SYS-5 — pebble_store.go at 11,398 lines is the navigability and merge-conflict hotspot (Low)
+
+**Detail.** One file implements the bulk of the ~36 role interfaces composing `Store` (store.go). It is 4x the next-largest non-generated file and the first thing a new engineer opens. The struct itself is clean (`pebble_store.go:120-141`: atomic memPtr, three scoped mutexes, warmup lifecycle fields, all with contract comments), and the team has already established the split pattern — pebble_store_lsh.go, pebble_store_ops_v2.go, pebble_store_isbn_index.go, pebble_quick_queries.go, pebble_store_book_aggregates.go exist as domain files. The remaining monolith is inertia, not design. Given the mandated parallel-subagent workflow (CLAUDE.md worktree discipline), a single 11K-line file is also the most likely rebase-conflict site across concurrent waves.
+
+**Recommendation.** Continue the established split: peel book/author/series/operation/settings method groups into `pebble_store_<domain>.go` files (same package, zero behavior change — a good /parallel-sweep candidate). Keep the key-schema header comment in one place and point the others at it.
+
+**Citations:**
+- internal/database/pebble_store.go:120-141
+- internal/database/store.go:1
+
+## SYS-6 — AI-REFERENCE contradicts itself on where the embedding/dedup keyspace lives (Low)
+
+**Detail.** `AI-REFERENCE.md:53` says EmbeddingStore "wrap[s] a separate PebbleDB for embeddings + dedup candidates", while the same doc's key-schema section (`:357`) correctly says the `emb:`/`dedup:` keyspace is "within the main audiobooks.pebble DB". Code confirms shared DB: `registry_wire.go:69` builds it with `database.NewEmbeddingStore(ps.DB())`. This is not cosmetic: an agent believing embeddings live in a separate DB could scope a backup, wipe, or restore to audiobooks.pebble alone and assume the dedup/labeled-dataset keyspace is unaffected (or vice versa). With the bge-m3 re-embed in flight and embeddings.db SQLite already stale/legacy per docs/status/2026-07-02, the number of places an engineer can look for "the embeddings" is confusing enough without the reference doc disagreeing with itself.
+
+**Recommendation.** One-line fix to AI-REFERENCE.md:53 ("backed by the main audiobooks.pebble DB"). Add a short "storage inventory" subsection listing all on-disk artifacts: audiobooks.pebble (incl. emb:/dedup:), ai_scans.db, activity.nutsdb, hnsw snapshot dir, legacy embeddings.db (dead).
+
+**Citations:**
+- docs/AI-REFERENCE.md:53
+- docs/AI-REFERENCE.md:357
+- internal/server/registry_wire.go:69
+- internal/database/embedding_store.go:206-208
+
+## STOR-6 — Positive: PERF-7 BookFile guards, bounded iterators, versioned backfill flags, and HNSW hardening verified (Info)
+
+**Detail.** Verified healthy: (1) the memdb AcoustIDFingerprint strip is now guarded in BOTH `UpsertBookFile` and `BatchUpsertBookFiles` (preserve-on-empty for fingerprint + 3 diagnostic pointers), closing the previously-latent UpsertBookFile gap; (2) AcoustIDSeg0-6 memdb stripping is safe because T020 drops segs from stored values entirely; (3) all migration/backfill flags are version-suffixed (activity_pebble_v1_done, book_aggregates_v1_done, versiongroup_index_v1_done, lsh_index_v1_done, book_isbn_index_v1_done); (4) HNSW `safeAdd` panic containment (#1741) and stale-dimension snapshot discard on Import (#1740) are correct — Import's discard path leaves the graph empty for rebuild-by-hydration as intended, and FindSimilar guards query-dim mismatch before the library can panic.
+
+**Recommendation.** No action. Keep the UpsertBookFile/BatchUpsertBookFiles guards in sync as commented, and extend the same discipline to Book writes per STOR-1.
+
+**Citations:**
+- internal/database/pebble_store.go:9969-9985
+- internal/database/pebble_store.go:10033-10053
+- internal/database/memdb_strip.go:87-114
+- internal/database/pebble_store_lsh.go:44
+- internal/database/pebble_activity_backfill.go:34
+- internal/database/hnsw_embedding_store.go:163-171
+- internal/database/hnsw_embedding_store.go:399-410
+
+## SYS-7 — Positive: cache and derived-index layers are architecturally sound (Info)
+
+**Detail.** Three patterns a reviewer should recognize as deliberate and defend: (1) `stats:library` cache — single k:v with lazy dirty-flag invalidation via NoSync delete (crash-safety reasoned in the comment at `pebble_store.go:196-199`), TTL fallback, and a recompute-stampede mutex (`:131`); (2) memdb warm layer — `atomic.Pointer` publish with reads falling back to Pebble until ready, and an explicitly documented `WaitForWarmup` test contract explaining the write-through race it prevents (`:154-170`); (3) HNSW as derived best-effort state — `safeAdd` recovers coder/hnsw library panics into errors precisely because "a single bad mirror cannot be allowed to abort a 44K-book re-embed" (`hnsw_embedding_store.go:145-150`), with stale-dim snapshot discard on Import (#1740). Startup warmers at `server_lifecycle.go:266-278` are fire-and-forget and now cache typed counts (post 69GB-bloat fix). The WHY-comment density in this codebase is well above industry norm and is a genuine asset for onboarding.
+
+**Recommendation.** No change. When adding new caches, copy the stats:library pattern (dirty flag + TTL + stampede mutex) per the documented feedback_cached_aggregates_dirty_flag convention; when adding derived indexes, copy the HNSW containment pattern.
+
+**Citations:**
+- internal/database/pebble_store.go:194-230
+- internal/database/pebble_store.go:126-170
+- internal/database/hnsw_embedding_store.go:143-171
+- internal/server/server_lifecycle.go:266-278
+
+## Steelman Analyses (db-design specialist)
+
+**(a) PebbleDB-as-primary.** Strongest case: this is a single-node, single-writer embedded app deployed cross-arch (amd64 Lenovo + arm64 RPi fleet); pure-Go Pebble gives one static binary with zero CGO, which SQLite demonstrably failed at (the scary opt-in flag exists because cross-compilation actually broke builds). The workload — 50K books, prefix scans, point lookups, write-heavy import/scan bursts — is precisely LSM-shaped, and every observed query pattern is served by hand-rolled secondary index keys plus the memdb read layer. Co-locating `dedup:`, `emb:`, `aiscan:`, and activity in one Pebble instance buys atomic cross-domain batches and one backup unit. Postgres would add a server, migrations, and ops surface to a homelab appliance for zero query-shape benefit; the 69GB incident and pagination caps were application-cache bugs, not storage-engine limits. VERDICT: correct decision — keep it. The tax is discipline costs (full-replacement UpdateBook, fingerprint-strip footguns, an 11,398-line pebble_store.go, doc drift per ARCH-4), which are cheaper to pay down than a migration.
+
+**(b) Derived vector indexes coupled to the primary store.** Strongest case: making PebbleDB's `emb:v:` keyspace the single source of truth and treating chromem/HNSW as disposable in-memory mirrors is what made the last month survivable. The 3072→1024 dimension cutover was resolved by discarding a derived artifact (#1740), not migrating data; coder/hnsw's crash bugs are containable (#1741) precisely because the graph is rebuildable; chromem's per-document gob persistence failure (MAYDEPLOY-D2) was absorbed by deleting persistence, not data. The VectorANNStore interface makes the buggy library swappable with zero data migration, and vectors ride the same backup/consistency domain as books. A standalone vector DB (qdrant/weaviate) would reintroduce a second source of truth, network sync, and drift. VERDICT: right architecture; the one betrayal of its own principle is the snapshot fast-path that skips rebuild-from-truth without a staleness check (ARCH-1). Fix that check and this design is exactly what a derived index should be.

--- a/docs/consultancy/02-dedup.md
+++ b/docs/consultancy/02-dedup.md
@@ -1,0 +1,360 @@
+<!-- file: docs/consultancy/02-dedup.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: eb002776-8824-40c5-915b-67f4f146e852 -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Dedup Engine & Strategy (2026-07-02)
+
+This report is one dimension of a software-consultancy evaluation of the audiobook-organizer repository, produced by a read-only multi-agent workflow (an expert strategy agent — findings `DEDUP-*` — and a Go specialist agent — findings `DEDUPC-*`), cross-checked by an advisor pass. All findings are cited as `file:line` against the repository state on 2026-07-02.
+
+## Executive Summary
+
+The layered dedup engine is well-guarded at its exact-emission chokepoint: the primary-version gate, identifier-conflict gate, boilerplate-title, short-duration, and part-vs-whole gates all funnel through `upsertExactCandidate` (`internal/dedup/engine.go:1327-1368`), and the dataset catchers are conservative and honest. The dominant problem is not engine logic but **backlog + calibration debt**.
+
+**Strategic verdict on the fingerprint question:** fingerprint coverage (~8,387 unfingerprinted books) is a **real but second-order lever**. It powers only the *positive* oracle — `wholeBookSignatureMatch` at similarity ≥0.95 → `true_dup` (`internal/dedup/dataset/rules.go:53-58`) — which is what gates auto-resolution. It cannot resurrect the pulled AcoustID veto (#1737): masked-similarity ~0.50 is the physical noise floor of uncorrelated chromaprints, so the negative direction stays useless at any coverage (`internal/dedup/engine.go:1351-1359`).
+
+The first-order levers, in priority order:
+
+1. **Drain the ~383,902 stale pre-fix exact candidates** (`TODO.md:188`) via re-detection/purge, now that the CONS-16/17 fixes and the duration-backfill have landed. Needs zero fingerprints — only the gated dry-run + user greenlight.
+2. **Recalibrate and re-scan the embedding layer for bge-m3** — thresholds (0.95/0.85) and confidence maps were calibrated on text-embedding-3-large, and nothing regenerates embedding candidates after the in-flight re-embed.
+3. **Duration coverage** (ffprobe-class scan) is ~100× cheaper than fpcalc and unlocks the `not_dup` catchers on the Duration=0-with-files residual that is unlabeled by design.
+4. **Then** fingerprint the 8,387 books to enable positive-oracle auto-resolve.
+
+Do (1)–(3) before spending GPU-days on (4).
+
+On the code side, the Go specialist confirmed the `upsertExactCandidate` chokepoint and that the #1738 model-aware re-embed fix is correct for the book sync path (`prepBookEmbed` + `embed_model_cutover_test.go`). Main defects found:
+
+1. The model-aware skip was **not** applied to `EmbedAuthor` or `EmbedBooksAsync`, so author embeddings never migrate off text-embedding-3-large — author dedup Layer 2 silently degrades to mixed 3072/1024-dim comparisons after the cutover (DEDUPC-1, the highest-severity code finding).
+2. `FullScan` omits `checkExactMetadataSourceHash`, so rescans never surface metadata-source-hash dups (DEDUPC-2).
+3. `AcoustIDScan` emits via `upsertCandidateWithLiveLabel` and, while it does replicate the boilerplate and identifier-conflict gates, it misses the primary-version and short-duration/part-vs-whole gates (DEDUPC-3, scope corrected by the advisor pass — see below).
+4. The identifier-conflict gate vetoes even byte-identical file-hash pairs (DEDUPC-5).
+5. Unified rescoring rewrites `Layer` to the strongest signal, silently removing pairs from `RunLLMReview`'s `layer=="embedding"` filter (DEDUPC-4).
+6. A 2–10% duration-delta dead zone produces neither candidate nor tag (DEDUPC-6).
+
+A full **auto-resolution design** is reproduced as its own section below. It builds on the existing `ComposeScore` bands (CERTAIN ≥97 / HIGH ≥90 / MEDIUM ≥75), `dataset.Classify` catchers, and the `ApplyVerdicts` auto-merge + tag + `CleanupCandidatesAfterMerge` machinery; Tier-2 is explicitly gated on fingerprinting the ~8,387 unfingerprinted books.
+
+**Cross-link to the storage workstream (STOR-1):** a `BookSigV1` wipe kills the positive oracle (`wholeBookSignatureMatch`), `BookSignatureScan`, and `ReevaluateAcoustIDConflicts` simultaneously — silently, since all three skip (never error) on missing data. DEDUP-6 and DEDUPC-7 report this same cross-link from two angles and are consolidated below.
+
+### Advisor verification
+
+The advisor pass verified the findings as largely accurate and well-cited:
+
+- **DEDUPC-1 confirmed**: `engine.go:2244` and `:2308` check only `TextHash`, with no `embeddingModelMatches` guard like `:2094`. Note that `EmbedBooksAsync` is the OpenAI Batch API path and is likely inert under Ollama, so **`EmbedAuthor` is the live exposure**.
+- Hardcoded thresholds at `engine.go:194-203` confirmed; `rules.go:53-58` positive oracle confirmed.
+- `CosineSimilarity` returning 0 on dimension mismatch (`embedding_store.go:1214`) confirms DEDUP-3's silent-degradation mechanism.
+- **DEDUPC-3 overreach corrected**: the original claim that the AcoustID emit path "bypasses the exact-chokepoint gates" overstates. The emit closure actually **replicates** the boilerplate gate (`engine.go:3353`) and the identifier-conflict gate (`:3360`), plus same-directory suppression. Only the **primary-version** and **short-duration/part-vs-whole** gates are missing. The finding text below reflects this correction.
+- **Redundancy noted**: DEDUP-6 and DEDUPC-7 are the same STOR-1 cross-link; they are presented as a consolidated section below.
+
+## Findings Table
+
+| ID | Severity | Impact | Effort | Title |
+|----|----------|--------|--------|-------|
+| DEDUP-1 | high | high | medium | Fingerprint coverage only feeds the positive oracle; the ~384K stale-candidate drain is the higher-yield, zero-fingerprint lever |
+| DEDUP-2 | high | high | medium | Embedding thresholds and confidence maps are calibrated for text-embedding-3-large; no recalibration or candidate regeneration exists for the bge-m3 cutover |
+| DEDUPC-1 | high | high | low | Model-aware re-embed skip missing in EmbedAuthor and EmbedBooksAsync — author embeddings stranded on OpenAI model after bge-m3 cutover |
+| DEDUP-3 | medium | medium | low | Layer 2 silently degraded during the re-embed window; the documented cutover sequence (Layer 2 OFF) was not followed by the in-flight run |
+| DEDUP-4 | medium | high | low | Duration coverage is the cheap complementary lever: the Duration=0-with-files residual is unlabeled by design and blocks the not_dup catchers |
+| DEDUP-5 | medium | medium | low | ReevaluateAcoustIDConflicts and dataset-backfill load up to 1M candidates and cache full unstripped Book signatures in memory |
+| DEDUP-6 / DEDUPC-7 | medium | high | low | (Consolidated) BookSigV1 dependency concentration: a STOR-1-style signature wipe silently disables the positive oracle, BookSignatureScan, and the conflict purge |
+| DEDUPC-2 | medium | medium | low | FullScan omits checkExactMetadataSourceHash — rescans never surface metadata-source-hash duplicates |
+| DEDUPC-3 | medium | medium | medium | AcoustIDScan emit path misses the primary-version and short-duration/part-vs-whole gates (scope corrected by advisor) |
+| DEDUPC-4 | medium | medium | medium | Unified rescoring rewrites Layer to strongest signal, silently removing pairs from RunLLMReview's layer="embedding" filter |
+| DEDUPC-5 | medium | medium | low | Identifier-conflict gate vetoes byte-identical file-hash matches; auto-merge path inconsistently bypasses the same gate |
+| DEDUPC-6 | low | low | low | Duration-match dead zone: 2–10% delta pairs with similar titles get neither candidate nor tag |
+
+## DEDUP-1 — Fingerprint coverage only feeds the positive oracle; the ~384K stale-candidate drain is the higher-yield, zero-fingerprint lever
+
+**Severity:** high · **Impact:** high · **Effort:** medium
+
+### Detail
+
+The pulled veto (#1737) is coverage-**independent** dead: `BookSignatureSimilarityMasked` ~0.50 is the noise floor for uncorrelated audio, so no threshold separates dups from non-dups even at 100% coverage — `engine.go:1351-1359` documents this in-code. What fingerprints DO unlock is `wholeBookSignatureMatch` (similarity ≥0.95 → `true_dup`, `rules.go:53-58`), the only strong positive oracle for auto-resolution.
+
+Meanwhile `TODO.md:188` records ~383,902 stale exact candidates computed before the CONS-16/17 duration-ms/title-leak fixes, with the duration-backfill already applied (17,684 files / 1,210 books ms→s). The drain is blocked only on the dry-run + user-OK gate (`TODO.md:170`), not on fingerprints. That drain shrinks the backlog by an order of magnitude more than any fingerprinting campaign.
+
+### Recommendation
+
+Sequence: (1) run maintenance re-scan + `dedup.quarantine-chapter-artifacts` dry-run post-backfill, present the list, get the greenlight, drain; (2) only then size the fingerprint campaign — target the ~8,387 books, framed explicitly as enabling positive-oracle auto-confirm (`true_dup`), not the veto.
+
+### Citations
+
+- `internal/dedup/dataset/rules.go:53-58`
+- `internal/dedup/engine.go:1351-1359`
+- `TODO.md:170`
+- `TODO.md:188`
+- `docs/status/2026-07-02-local-cutover-and-matching.md:63-66`
+
+## DEDUP-2 — Embedding thresholds and confidence maps are calibrated for text-embedding-3-large; no recalibration or candidate regeneration exists for the bge-m3 cutover
+
+**Severity:** high · **Impact:** high · **Effort:** medium
+
+### Detail
+
+`BookHighThreshold=0.95` / `BookLowThreshold=0.85` (`engine.go:194-197`) and the `SigEmbedHigh`/`SigEmbedMedium` confidence interpolations (`collectors_embedding.go:84-118`) encode the cosine distribution of OpenAI text-embedding-3-large. bge-m3 has a different similarity distribution; if its dup-pair cosines sit lower, `SigEmbedHigh` (≥0.95) may almost never fire and Layer 2 recall silently collapses post-cutover — with no error, just missing candidates.
+
+Additionally, candidate generation (`findSimilarBooks`) runs only in `CheckBook`/`FullScan`; the in-flight embed-scan only writes vectors, so existing embedding candidates still carry OpenAI-era similarities and no bge-m3 candidates exist until a `FullScan` runs. `DedupCandidate` rows carry no model tag, so old- and new-model similarities are indistinguishable in the store.
+
+### Recommendation
+
+After the re-embed completes: sample bge-m3 cosines for known `true_dup` pairs (the rule-labeled dataset exists for exactly this), adjust High/Low thresholds and the confidence ramps, then run a `FullScan` to regenerate embedding candidates. Consider tagging candidates with the producing embedding model.
+
+### Citations
+
+- `internal/dedup/engine.go:194-203`
+- `internal/dedup/collectors_embedding.go:70-75`
+- `internal/dedup/collectors_embedding.go:84-118`
+- `internal/plugins/dedup/reembed_embeddings.go:30-38`
+
+## DEDUP-3 — Layer 2 silently degraded during the re-embed window; the documented cutover sequence (Layer 2 OFF) was not followed by the in-flight run
+
+**Severity:** medium · **Impact:** medium · **Effort:** low
+
+### Detail
+
+`CosineSimilarity` returns 0 on dimension mismatch (`embedding_store.go:1213-1216`), so during the ~29K-book re-embed a fresh 1024-dim query scores 0 against every not-yet-re-embedded 3072-dim row — dedup-on-import `CheckBook` calls during this window find only already-cutover books and miss the rest permanently (nothing re-runs `findSimilarBooks` for them afterwards). `reembed_embeddings.go:30-38` documents the safe sequence (`dedup_embeddings_enabled:false` during re-embed, restart, re-enable), but the status doc shows the live run went via `dedup.embed-scan` with no mention of disabling Layer 2.
+
+### Recommendation
+
+Accept the transient gap but schedule a `FullScan` after re-embed completion (also required by DEDUP-2) so window-imported books get embedding candidates. For future cutovers, make embed-scan/reembed ops warn or auto-disable Layer 2 when a model mismatch is detected mid-corpus.
+
+### Citations
+
+- `internal/database/embedding_store.go:1213-1216`
+- `internal/plugins/dedup/reembed_embeddings.go:29-38`
+- `docs/status/2026-07-02-local-cutover-and-matching.md:55-58`
+
+## DEDUP-4 — Duration coverage is the cheap complementary lever: the Duration=0-with-files residual is unlabeled by design and blocks the not_dup catchers
+
+**Severity:** medium · **Impact:** high · **Effort:** low
+
+### Detail
+
+`partVsWhole` deliberately does not fire when either side has `TotalDurationSec==0` (`rules.go:101-111`), and `dataset_backfill.go:18-23` documents that the dominant residual class (stub/unscanned pairs with one side duration=0) escapes all catchers. `hasPlausibleAudio` (`engine.go:1650-1661`) also passes zero-duration books through on `FileSize` alone.
+
+Every one of these paths is unblocked by knowing durations — an ffprobe-class metadata scan, which is roughly two orders of magnitude cheaper per file than fpcalc fingerprinting (no full decode needed for duration in most containers). The duration-backfill already applied fixed ms→s corruption on existing values; books with NO duration still need a probe pass.
+
+### Recommendation
+
+Before mass fingerprinting, run a duration-probe backfill over books with files but Duration≤0, then re-run `dedup.dataset-backfill` (dry-run first). This converts a chunk of the unjudgeable residual into rule-labeled `not_dup` at near-zero GPU/CPU cost.
+
+### Citations
+
+- `internal/dedup/dataset/rules.go:101-111`
+- `internal/plugins/dedup/dataset_backfill.go:18-23`
+- `internal/dedup/engine.go:1650-1661`
+
+## DEDUP-5 — ReevaluateAcoustIDConflicts and dataset-backfill load up to 1M candidates and cache full unstripped Book signatures in memory
+
+**Severity:** medium · **Impact:** medium · **Effort:** low
+
+### Detail
+
+Both ops call `ListCandidates` with Limit 1,000,000 (`engine.go:1559-1563`; `dataset_backfill.go:98-105`). With ~384K pending candidates in prod, that materializes the whole set, and `ReevaluateAcoustIDConflicts` additionally builds an unbounded per-book cache map (`engine.go:1573`) whose entries hold `BookSigV1` strings (~22KB each per `memdb_strip.go`'s own math) fetched via pebble-direct `GetBookByID`. Worst case (most candidate books fingerprinted, ~50K distinct books) that cache alone is on the order of a gigabyte, in the same process that previously hit a 69GB warmup incident. Not a correctness bug, but a prod-memory foot-gun on the exact host where these ops will be run to execute the DEDUP-1 drain.
+
+### Recommendation
+
+Page `ListCandidates` in both ops (cursor/batch like `checkExactISBNScan`'s 500-row pattern) and store only (sig, mask) truncated to what `BookSignatureSimilarityMasked` needs, or bound the cache with an LRU. Cheap change; do it before running the drain at full backlog size.
+
+### Citations
+
+- `internal/dedup/engine.go:1559-1563`
+- `internal/dedup/engine.go:1569-1592`
+- `internal/plugins/dedup/dataset_backfill.go:98-105`
+
+## DEDUP-6 / DEDUPC-7 — (Consolidated) BookSigV1 dependency concentration: a STOR-1-style signature wipe silently disables the positive oracle, BookSignatureScan, and the conflict purge
+
+**Severity:** medium · **Impact:** high · **Effort:** low
+
+Both agents independently flagged this cross-link to the storage workstream; the advisor confirmed they are the same finding and directed consolidation.
+
+### Detail
+
+`stripBookForMemdb` clears `BookSigV1`, `BookSigV1Mask`, `BookSigSegments`, `BookSigBuiltAt`, `BookSigCoveragePct` (`memdb_strip.go:36-40`). The dedup engine itself defends correctly — `bookSignature()` re-fetches by ID from pebble-direct `GetBookByID` when the passed struct lacks the sig (`engine.go:1500-1521`) — but any write path elsewhere that round-trips a memdb-sourced Book through a full-replace update (the documented `UpdateBook` full-column-replacement footgun, same class as the `AcoustIDFingerprint` wipe fixed in #1552) erases the signature permanently.
+
+Three independent mechanisms all read `Book.BookSigV1`/`BookSigV1Mask`:
+
+1. `dataset.wholeBookSignatureMatch` — the ONLY `true_dup` rule catcher (`rules.go:54`);
+2. `BookSignatureScan`'s O(N²) pairwise layer (`engine.go:3555`);
+3. `ReevaluateAcoustIDConflicts` / `acoustIDSignaturesConflict` (`engine.go:1490`, `:1610`).
+
+All are conservative on missing data (skip, never veto), so a STOR-1-style `BookSigV1` wipe fails **silently**: labeled `true_dup` examples stop being generated, the `book_signature` layer emits zero pairs, and the conflict purge reports everything as Skipped. Since `book_sig_v1` is the sole input to the `true_dup` positive oracle and Tier-1/Tier-2 auto-resolution (design below) leans on the signature oracle, a wipe would silently freeze the auto-merge pipeline with no error anywhere — and would waste the planned 8,387-book fingerprint campaign.
+
+### Recommendation
+
+The root fix belongs to the storage workstream (STOR-1), but the dedup team should add cheap invariants:
+
+- A periodic count of books with `BookSigBuiltAt` set but `BookSigV1` empty (should be ~0), alerting on regression before/during the fingerprint campaign.
+- A coverage counter (books with non-empty `BookSigV1` / total primaries) exposed via the dedup status endpoint, alerting/logging when coverage drops between runs.
+- Make the auto-resolution op refuse to run Tier-2 when coverage regressed since its last run.
+
+### Citations
+
+- `internal/database/memdb_strip.go:29-47`
+- `internal/dedup/engine.go:1500-1521`
+- `internal/dedup/engine.go:3546-3558`
+- `internal/dedup/engine.go:1604-1614`
+- `internal/dedup/dataset/rules.go:53-58`
+
+## DEDUPC-1 — Model-aware re-embed skip missing in EmbedAuthor and EmbedBooksAsync — author embeddings stranded on OpenAI model after bge-m3 cutover
+
+**Severity:** high · **Impact:** high · **Effort:** low
+
+### Detail
+
+PR #1738 added `embeddingModelMatches` to `prepBookEmbed`'s cached-skip (`engine.go:2094`), forcing book re-embeds on a backend switch. But `EmbedAuthor` (`engine.go:2244`) and `EmbedBooksAsync` (`engine.go:2308`) still skip solely on `existing.TextHash == hash`. After the OpenAI→Ollama cutover, all ~8.8K author embeddings remain 3072-dim text-embedding-3-large vectors forever (text never changes for an unchanged author name), while any newly-created author embeds are 1024-dim bge-m3. `CheckAuthor`'s `FindSimilar` then compares mismatched-dimension vectors (linear-scan cosine yields garbage/zero; HNSW mixed-dim triggers the panics #1741 now recovers as errors), so author dedup Layer 2 silently returns nothing.
+
+`EmbedBooksAsync` is the OpenAI Batch path — currently unused and likely inert under Ollama (advisor: `EmbedAuthor` is the live exposure) — but it would silently no-op the re-embed if anyone runs `dedup.embed-async`.
+
+### Recommendation
+
+Add `&& de.embeddingModelMatches(existing.Model)` to the cached-skip in `EmbedAuthor` and `EmbedBooksAsync`, mirroring `prepBookEmbed`. Extend `embed_model_cutover_test.go` with an author-path case. Then trigger an author re-embed pass after the book re-embed completes.
+
+### Citations
+
+- `internal/dedup/engine.go:2243-2249`
+- `internal/dedup/engine.go:2306-2310`
+- `internal/dedup/engine.go:2094`
+- `internal/dedup/engine.go:2110-2115`
+
+## DEDUPC-2 — FullScan omits checkExactMetadataSourceHash — rescans never surface metadata-source-hash duplicates
+
+**Severity:** medium · **Impact:** medium · **Effort:** low
+
+### Detail
+
+`CheckBook` (the import-event path) runs five Layer-1 checks including `checkExactMetadataSourceHash` (`engine.go:413`). `FullScan`'s Layer-1 block (`engine.go:2443-2454`) runs only `checkExactFileHash`, `checkExactISBN`, `checkExactTitle`, and `checkDurationMatch`. `FullScan`'s own doc comment says it exists precisely because "Layer 1 used to only run on ingest... Running it inside FullScan populates the bucket" — but the 0.99-similarity `metadata_hash` layer (two books applied from the exact same external record, deliberately not gated by `hasPlausibleAudio`) is never populated by a rescan. Any pair whose shared `MetadataSourceHash` was set after import, or that predates the check, is permanently invisible.
+
+### Recommendation
+
+Add `de.checkExactMetadataSourceHash(&book)` to `FullScan`'s Layer-1 block alongside the other four checks.
+
+### Citations
+
+- `internal/dedup/engine.go:2443-2454`
+- `internal/dedup/engine.go:409-415`
+- `internal/dedup/engine.go:1024-1042`
+
+## DEDUPC-3 — AcoustIDScan emit path misses the primary-version and short-duration/part-vs-whole gates (scope corrected by advisor)
+
+**Severity:** medium · **Impact:** medium · **Effort:** medium
+
+### Detail
+
+> **Advisor correction applied:** the original finding claimed the AcoustID emit path "bypasses the exact-chokepoint gates." That overstates. The emit closure **does replicate** the boilerplate gate (`engine.go:3353`) and the identifier-conflict gate (`engine.go:3360`), plus same-directory suppression. What it misses are the **primary-version**, **short-duration**, and **part-vs-whole** gates.
+
+`upsertExactCandidate` centralizes the gates (non-primary version, identifier conflict, boilerplate title, short duration, part-vs-whole) with the explicit comment "ALL exact emitters route through here". But `AcoustIDScan`'s emit closure (`engine.go:3377`) calls `upsertCandidateWithLiveLabel` directly. It checks boilerplate + identifier conflict but NOT `isNonPrimaryVersion`, `hasKnownShortDuration`, or `isPartVsWholeMismatch`. The query loop iterates primaries only (`getAllBooks`), yet the OTHER side comes from file-level indexes — `LookupAcoustIDCandidates` (line 3447) and `GetBookFileByAcoustID` (line 3489) — which include non-primary books' files. Also, the candidate-side file is never checked with `knownShortFingerprintFile` (only the query side at line 3440), unlike `collectors_acoustid.go` which guards both sides (lines 139, 317). Resulting primary-vs-nonprimary acoustid pairs sit in the queue until the next `PurgeStaleCandidates` run; `PairEligibility` does not catch cross-group non-primaries either.
+
+### Recommendation
+
+In `emit()`, resolve both books (`bookForIdentifierGate` already does) and apply `isNonPrimaryVersion` + `hasKnownShortDuration` + `isPartVsWholeMismatch` — or route acoustid emissions through a shared gate helper extracted from `upsertExactCandidate`. Add `knownShortFingerprintFile(cand)` in the LSH and exact-hit branches.
+
+### Citations
+
+- `internal/dedup/engine.go:3352-3387`
+- `internal/dedup/engine.go:3446-3464`
+- `internal/dedup/engine.go:3489-3495`
+- `internal/dedup/engine.go:1327-1350`
+- `internal/dedup/collectors_acoustid.go:139`
+
+## DEDUPC-4 — Unified rescoring rewrites Layer to strongest signal, silently removing pairs from RunLLMReview's layer="embedding" filter
+
+**Severity:** medium · **Impact:** medium · **Effort:** medium
+
+### Detail
+
+`runUnifiedScoringForBook` re-upserts each scored pair with `Layer=bestLayerFromSignals` (`engine.go:671-681`) — e.g. an embedding-seeded pair that also has an ISBN signal becomes `layer="exact"`. `listAmbiguousCandidates` (`engine.go:2903-2910`) filters `Layer=="embedding"` only. So the Layer-3 LLM review permanently loses exactly the multi-signal ambiguous pairs the unified pipeline was built to score; only pure-embedding pairs (which unified scoring leaves at `layer="embedding"`) remain reviewable.
+
+Compounding: the default review model is `"gpt-5-mini"` via the OpenAI parser (`engine.go:2887-2890`), which is quota-dead until the LLM backend-mode toggle ships — Layer 3 is currently inert either way, but this filter bug will persist after the local-LLM cutover.
+
+### Recommendation
+
+Select LLM-review candidates by Band (MEDIUM/REVIEW from `ScoreBreakdown`) rather than the legacy Layer string, or include all non-llm layers within the similarity window. Wire the review model through the coming backend-mode toggle to qwen2.5:7b-instruct.
+
+### Citations
+
+- `internal/dedup/engine.go:669-685`
+- `internal/dedup/engine.go:785-813`
+- `internal/dedup/engine.go:2900-2913`
+
+## DEDUPC-5 — Identifier-conflict gate vetoes byte-identical file-hash matches; auto-merge path inconsistently bypasses the same gate
+
+**Severity:** medium · **Impact:** medium · **Effort:** low
+
+### Detail
+
+`checkExactFileHash` → `handleFileHashMatch`: with `AutoMergeEnabled` + same normalized title/author, `MergeBooks` fires with NO identifier-conflict check (`engine.go:886-893`). Without auto-merge, the pair goes to `upsertExactCandidate`, where `identifiersConflict` (`engine.go:1331`) silently drops it. A byte-identical file (same SHA) with a mis-tagged ASIN/ISBN on one side — common after bad metadata applies — is therefore either merged instantly or never surfaced at all, depending on a config flag. Physical hash identity is strictly stronger evidence than a metadata identifier mismatch; the mismatch is itself a signal the metadata is wrong.
+
+### Recommendation
+
+For `layer=exact` candidates originating from a file-hash match, bypass (or downgrade to a warning annotation) the `identifiersConflict` veto — e.g. pass an `origin` hint into `upsertExactCandidate`. Keep the veto for title/ISBN-seeded emitters where it protects against name collisions.
+
+### Citations
+
+- `internal/dedup/engine.go:874-897`
+- `internal/dedup/engine.go:1327-1338`
+
+## DEDUPC-6 — Duration-match dead zone: 2–10% delta pairs with similar titles get neither candidate nor tag
+
+**Severity:** low · **Impact:** low · **Effort:** low
+
+### Detail
+
+`checkDurationMatch` emits a candidate at pct ≤ 2% and an abridged tag at pct ≥ 10%; the code's own comment says "normal transcoding noise ends around 2-5%" (`engine.go:1275`). A real duplicate re-encoded with different silence trimming or VBR at 3–5% delta, whose title Levenshtein is 3–6 (too far for `checkExactTitle`'s <3), falls in the (2%, 10%) gap and produces nothing — no candidate, no tag. These pairs can still be caught by embedding cosine, but only if both sides are embedded and above 0.85.
+
+### Recommendation
+
+Either widen `durationMatchTolerance` to ~0.05 with a lower similarity value (e.g. 0.9 instead of 1.0) so the unified score reflects the weaker evidence, or emit a `SigDuration` supporting signal for the 2–10% band instead of dropping it entirely.
+
+### Citations
+
+- `internal/dedup/engine.go:1141-1149`
+- `internal/dedup/engine.go:1253-1283`
+
+## Steelman: "Fingerprint coverage is the real lever"
+
+Strongest case FOR the current "fingerprint coverage is the real lever" position: it is the only path to trustworthy AUTO-resolution. Every other signal in the engine is metadata-derived and was the source of the 380K-mislabel disaster; whole-book audio signatures are the one physical oracle that cannot be fooled by title leaks or ms/s corruption, and `rules.go` already wires sim≥0.95 as an auto `true_dup` label. With 65% of candidates having an unfingerprinted side, no amount of threshold tuning makes the oracle usable at scale — coverage is the binding constraint, exactly as the status doc concludes.
+
+**Verdict:** the position is directionally correct but incomplete — coverage unlocks the **positive oracle only** (the veto stays dead at any coverage), and the stale-candidate drain plus bge-m3 recalibration plus duration probing are cheaper and should land first (see DEDUP-1 through DEDUP-4).
+
+## Design: Auto-Resolution — Confidence-Tiered Pipeline on the Existing Unified Score
+
+All machinery exists: `ComposeScore` bands (CERTAIN ≥97 / HIGH ≥90 / MEDIUM ≥75 / REVIEW ≥60, DB-tunable via `SetBandThresholds`), `dataset.Classify` catchers, `mergeService.MergeBooks` + `CleanupCandidatesAfterMerge`, and the `ApplyVerdicts` auto-merge pattern (merge → status="merged" → provenance tag). Add one op, `dedup.auto-resolve`, dry-run by default like Rescore/dataset-backfill.
+
+### Tier 0 — auto-dismiss (live today)
+
+Run `dedup.dataset-backfill apply=true`: `Classify`'s `not_dup` catchers (missingFile, implausibleAudio, partVsWhole<0.5) dismiss rule-negatives. Plus `PurgeStaleCandidates` each pass. Known residual: Duration=0-with-files pairs stay unlabeled by design.
+
+### Tier 1 — auto-merge CERTAIN (live today, small volume)
+
+Merge when ALL hold:
+
+- Band == CERTAIN;
+- ≥2 independent primary signal kinds from {SigExactFile, SigExactAcoustID, SigISBNASIN, SigMetaSrcHash} OR dataset `wholeBookSignatureMatch` (sig sim ≥0.95);
+- empty Suppressors;
+- `hasPlausibleAudio` both sides;
+- no `identifiersConflict`.
+
+Execute exactly like `ApplyVerdicts`' high-confidence path: `MergeBooks(pair, "" auto-primary)`, `UpdateCandidateStatus("merged")`, tag survivor `dedup:merge-survivor:auto-certain`, `CleanupCandidatesAfterMerge`.
+
+### Tier 2 — auto-merge HIGH (90–97). Unblocked by fingerprint coverage
+
+Requires positive audio corroboration: SigExactAcoustID/SigLSHAcoustID signal or `book_sig_v1` similarity ≥0.95 with ≥512-word overlap. Gate: fingerprint the ~8,387 unfingerprinted books first (65% of pairs are unjudgeable today; masked-sim 0.50 is the noise floor — corroboration must be positive evidence, never a veto). Refuse to run if `BookSigV1` coverage regressed (DEDUPC-7).
+
+### Tier 3 — LLM triage (MEDIUM 75–90)
+
+Local qwen2.5:7b-instruct once the backend-mode toggle ships; reuse `RunLLMReview`/`ApplyVerdicts` with `LLMAutoMergeHighConfidence`, but select by Band not `layer=="embedding"` (DEDUPC-4). Verdicts land in review, not auto-merge, for the first N runs.
+
+### Safety rails
+
+1. Dry-run default returning `AcoustIDConflictSample`-style capped samples per tier.
+2. First apply run capped (`max_merges=200`) with a mandatory human sampling audit of ~30 merges before uncapping.
+3. Reversibility: `MergeBooks` builds version groups — losers become non-primary members, not deletions; log every auto-merge to a journal key (`dedup:automerge:<ts>`), and provide an unmerge op that re-promotes a member.
+4. Global kill switch config flag; band thresholds already runtime-tunable.
+
+### Backlog drain (~12.5K pending)
+
+1. `Rescore(apply=true)` to re-band everything under the current formula after CONS-16/17/18 forward fixes;
+2. dataset-backfill apply → Tier-0 dismissals;
+3. Tier-1 capped pass, audit, uncap;
+4. fingerprint 8,387 books → `BookSignatureScan` → Tier-2 pass (largest expected drain);
+5. residual MEDIUM → Tier-3 LLM / unified review tab.

--- a/docs/consultancy/03-matching-and-backends.md
+++ b/docs/consultancy/03-matching-and-backends.md
@@ -1,0 +1,263 @@
+<!-- file: docs/consultancy/03-matching-and-backends.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 74c1dd3a-9f40-4b1d-8826-406f0841f7ba -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Matching Methods & AI Backends (2026-07-02)
+
+Evaluation produced by a read-only multi-agent consultancy workflow. Two specialist reports feed this dimension: a matching-subsystem code review (MATCH-*) and a backend-toggle readiness review with a full design (TOGGLE-*). All findings cite `file:line` in the repo as of 2026-07-02. An independent advisor pass verified the phase's citations; its corrections are reflected inline and in the "Advisor verification" section.
+
+## Executive Summary
+
+The matching subsystem's recent fixes are sound: the #1734 title-gated transcription boost (`service_scoring.go:290-327`) and the apply-side hard gate (`transcribedTitleAgrees`, `service_fetch.go:235`) are correctly implemented. The most serious defect — MATCH-1, **confirmed critical and live during the current bge-m3 re-embed** — is that `EmbeddingScorer`'s BookID fast-path returns the stored (possibly 3072-dim OpenAI) vector with no model/dimension check, while candidates are embedded with the new 1024-dim client. `CosineSimilarity` returns 0 on length mismatch, the scorer returns all-zero scores with a nil error, no F1 fallback triggers, and every candidate is filtered below `EmbeddingMinScore` — searches for any not-yet-re-embedded book return zero results whenever embedding scoring is enabled.
+
+Second-tier issues: `RerankTopK` mixes clamped [0,1] LLM scores with the unclamped multiplied base-score tail (a scale-mismatch landmine for the pending local-LLM toggle — see advisor correction on MATCH-2); `IsGarbageValue`'s substring `"error"` check nukes legitimate titles/authors ("The Terror", "Comedy of Errors") from hints, boosts, and writes; the auto-match op's Search/Apply pair reads cache candidate[0] twice with no identity check (TOCTOU past the gates); per-source tier fallback can mix embedding-cosine and F1 scores in one ranked list; the cover filter can drop a top-scored exact ASIN/transcription match; `embedclient` registration requires an OpenAI key even for keyless Ollama; and retry paths have no permanent-error (429 quota) classification, which the fallback backend mode will need.
+
+On the backend side, current plumbing is halfway to a toggle: embeddings can point at Ollama via `embedding.base_url` (`config.go:94`, scoped per-client at `embedding_client.go:116-123`), embeddings are model-tagged (cache keyed by hash+model; dedup re-embed skip is model-aware via `embeddingModelMatches`, `engine.go:2110`), and availability gating exists (`server.go:616-625` trusts a configured base_url). But **there is no mode enum anywhere** — key presence is the de-facto backend selector: local embedding still requires a non-empty `OpenAIAPIKey` (`register.go:35`); the LLM side has NO per-config base URL at all — only the process-wide `OPENAI_BASE_URL` env (`openai_parser.go:85`), which would redirect every client; `retry.go` retries 429/insufficient_quota blindly with no fallback trigger; the OpenAI Batch API path (`EmbedBooksAsync` → `CreateEmbeddingBatch`) is not gated on backend and its skip-check also lacks the model-match guard; and Ollama availability is probed once at startup into a plain (non-atomic) bool. The full backend-mode toggle design (independent embedding/LLM mode enums, config migration, error-classified fallback, FE selector, model-pull prompt) is reproduced in the Design section below.
+
+## Advisor verification
+
+The P3 boundary advisor spot-checked citations and reports them accurate. Specific corrections and confirmations, reflected in this report:
+
+- **MATCH-1 confirmed end-to-end**: unchecked store fast-path (`embedding_scorer.go:92-95`) + `CosineSimilarity=0` on dim mismatch (`embedding_store.go:1214`) + nil-error acceptance (`service_scoring.go:492`) = no F1 fallback. **Genuinely critical during the live re-embed.**
+- **MATCH-2 slightly overstated as originally reported**: the code (`service_scoring.go:647-661`) deliberately avoids re-multiplying; the residual defect is a **scale mismatch** between clamped [0,1] LLM scores and the unclamped tail — real but conditional. "Systematic demotion" is too strong; the finding text below has been adjusted accordingly.
+- **MATCH-3 and TOGGLE-1 confirmed verbatim.**
+- **Omission noted by the advisor** (not in the specialist findings): mangled slog calls throughout the matching code — duplicate attribute keys, printf verbs left in messages, generic `"value"` keys (`service_scoring.go:607, 612, 642, 677`) — suggest a botched mechanical fmt→slog sweep. Flagged as a bug-hunt target for a follow-up phase (repo-wide grep for duplicate attr keys and `"value",` / `"count",` patterns with %-verbs still in messages).
+
+## Findings Table
+
+| ID | Severity | Impact | Effort | Title |
+|---|---|---|---|---|
+| MATCH-1 | critical | high | low | EmbeddingScorer store fast-path ignores model/dimension — mixed-dim query vs candidate vectors score 0 and silently kill all search candidates |
+| MATCH-2 | high | high | low | RerankTopK mixes clamped [0,1] LLM scores with unclamped multiplied base scores — scale mismatch can demote reranked winners below the tail |
+| TOGGLE-1 | high | high | low | Local Ollama embedding still requires a non-empty OpenAIAPIKey |
+| TOGGLE-2 | high | high | low | EmbedBooksAsync (OpenAI Batch API) is not gated on backend and its skip-check ignores the embedding model |
+| TOGGLE-3 | high | high | medium | No per-config base URL for the LLM path — local LLM mode is currently impossible without redirecting every client |
+| MATCH-3 | medium | medium | low | IsGarbageValue substring match on "error" rejects legitimate titles/authors (e.g. "The Terror", "Comedy of Errors") |
+| MATCH-4 | medium | medium | medium | Per-source scorer fallback can mix embedding-cosine and F1 scores in one ranked candidate list |
+| MATCH-5 | medium | medium | low | Cover filter runs after all scoring and can drop the highest-scored candidate |
+| MATCH-6 | medium | medium | low | Auto-match apply path re-reads cache candidate[0] independently of the gated search snapshot (TOCTOU past all three gates) |
+| MATCH-7 | medium | medium | medium | No permanent-error classification in retry paths — 429 insufficient_quota is retried like a transient failure |
+| MATCH-8 | medium | medium | low | embedclient and llmparser registrations gate on OpenAIAPIKey even for keyless local Ollama backends |
+| TOGGLE-4 | medium | medium | low | retry.go retries 429/insufficient_quota blindly; no error classification, no fallback hook |
+| TOGGLE-5 | medium | medium | medium | Ollama availability is a one-shot startup trust with a non-atomic flag — unsafe for runtime mode switching |
+| MATCH-9 | low | low | low | LevenshteinDistance operates on bytes, inflating distances for non-ASCII titles |
+| TOGGLE-6 | low | low | low | metadatallmscorer is built regardless of MetadataScoring.LLMEnabled; gate lives only at one call site |
+| TOGGLE-7 | low | medium | medium | Model names are OpenAI-specific defaults with no per-backend mapping |
+
+## MATCH-1 — EmbeddingScorer store fast-path ignores model/dimension (critical)
+
+**Advisor: confirmed end-to-end; genuinely critical during the live re-embed.**
+
+`queryVector` (`embedding_scorer.go:92-96`) returns `store.Get("book", bookID).Vector` with no model or dimension check. Candidates are embedded live with the current client (bge-m3, 1024-dim). During the in-flight re-embed, most of the ~50K stored vectors are still text-embedding-3-large (3072-dim). `CosineSimilarity` returns 0 on `len(a)!=len(b)` (`embedding_store.go:1214`), so `Score` returns all-zero scores with a nil error. `ScoreBaseCandidates` treats that as success (`tier="embedding"`, `service_scoring.go:492-493`) — the F1 fallback never fires — and every candidate is then dropped below `EmbeddingMinScore` (default 0.82) at `service_search.go:334`, and `pickBestMatchFromScored` never reaches `EmbeddingBestMatch` (0.88). Dedup fixed exactly this class with `embeddingModelMatches` (#1738, `engine.go:2110`) but the metadata scorer was not given the same guard.
+
+**Recommendation:** In `queryVector`, only use the stored vector when `existing.Model == client model` (Record already carries Model, `embedding_store.go:95`); otherwise fall through to `EmbedOne`. Defense-in-depth: in `Score`, if `len(qVec) != len(cv)`, return an error (not 0 scores) so `ScoreBaseCandidates` falls back to F1.
+
+**Citations:**
+- internal/ai/embedding_scorer.go:92-98
+- internal/database/embedding_store.go:1213-1216
+- internal/metafetch/service_scoring.go:491-500
+- internal/metafetch/service_search.go:330-337
+- internal/dedup/engine.go:2110-2115
+
+## MATCH-2 — RerankTopK score-scale mismatch between clamped LLM scores and unclamped tail (high)
+
+**Advisor correction applied:** the original report characterized this as "systematic demotion of reranked winners." The code (`service_scoring.go:647-661`) deliberately avoids re-multiplying; the residual defect is a scale mismatch between clamped [0,1] LLM scores and the unclamped tail — real but conditional, not systematic.
+
+`Candidate.Score` at rerank time carries the full multiplier stack (×1.5 author, ×1.3 narrator, ×1.15 narrator-present, ×2.0 transcription, ×1.3 duration — routinely 1.5–4.0, intentionally unclamped). `RerankTopK` overwrites the top-K scores with LLM scores hard-clamped to [0,1] (`llm_scorer.go:87-92`) and re-sorts the whole list against the untouched tail (`service_scoring.go:658-660`). Any tail candidate scoring >1.0 — common — outranks even an LLM-certain (1.0) reranked winner, undermining the rerank's intent whenever that condition holds. Dormant today (`metadata_scoring.llm_enabled=false` in prod) but this is the first thing the pending local-LLM (qwen2.5:7b-instruct) backend toggle would activate.
+
+**Recommendation:** Rescale LLM scores into the ambiguous window before re-sorting: map LLM [0,1] onto `[candidates[ambiguousEnd-1].Score, bestScore]` (rank-preserving within the window), or re-sort only the top-K slice and keep the tail fixed below it.
+
+**Citations:**
+- internal/metafetch/service_scoring.go:646-661
+- internal/ai/llm_scorer.go:86-93
+
+## MATCH-3 — IsGarbageValue substring match on "error" rejects legitimate titles/authors (medium)
+
+**Advisor: confirmed verbatim.**
+
+`IsGarbageValue` treats any string containing the substring "error" as garbage (`service_scoring.go:36`) — "terror", "errors", "terrorist" all contain it. Consequences: `hintsFromBook` drops a valid transcribed title like "The Terror" (`service_scoring.go:553`), disabling the transcription boost and the apply-side title gate for that book; `SearchMetadataForBookWithOptions` blanks `bookAuthor`/`bookNarrator` containing the substring (`service_search.go:188-197`), losing author boosts; `IsBetterValue`/`IsBetterStringPtr` (`service_scoring.go:44-65`) permanently refuse to write such titles/authors during metadata apply. Dan Simmons' "The Terror", Shakespeare's "The Comedy of Errors", any "...Terror..." thriller in a 50K library are affected.
+
+**Recommendation:** Restrict the HTML/error heuristic to patterns that can't occur in real titles: match `"<html"`, `"<!doctype"`, and anchored phrases like `"403 forbidden"`, `"error:"` / `"internal server error"` via word-boundary regex, not a bare `Contains("error")`.
+
+**Citations:**
+- internal/metafetch/service_scoring.go:35-38
+- internal/metafetch/service_scoring.go:547-562
+- internal/metafetch/service_search.go:188-197
+
+## MATCH-4 — Per-source scorer fallback can mix embedding-cosine and F1 scores in one ranked list (medium)
+
+`ScoreBaseCandidates` is invoked once per metadata source inside the source loop (`service_search.go:305`). If the embedding scorer succeeds for source A's batch but errors for source B's (Ollama hiccup, timeout — `embedBatchRaw` gives up after 3 attempts), source A candidates carry cosine-based scores (~0.8–1.0 band, threshold 0.82) while source B candidates carry F1 scores (0–1.15 band, threshold 0) — then all are sorted together at `service_search.go:527` and compete for the same top-50. The two scales are not comparable; F1=1.0 exact-token matches beat cosine 0.9 near-certain matches or vice versa depending on the mix. There is no per-candidate tier tag in `MetadataCandidate` to detect this downstream.
+
+**Recommendation:** Score once across all sources' merged results (single tier for the whole search), or record the tier per candidate and, on mixed tiers, re-score the whole set with F1 for comparability.
+
+**Citations:**
+- internal/metafetch/service_search.go:305
+- internal/metafetch/service_scoring.go:491-507
+- internal/metafetch/service_search.go:526-529
+
+## MATCH-5 — Cover filter runs after all scoring and can drop the highest-scored candidate (medium)
+
+After scoring, candidates without `CoverURL` are dropped whenever at least one candidate has a cover (`service_search.go:489-497`). The filter is unconditional on score: a transcription-boosted exact-title match (×2.0) or a direct ASIN lookup (`service_search.go:432-481` — Audnexus records frequently lack `CoverURL`) is silently removed while a low-scored wrong-book candidate with a cover survives and becomes the top result. For pipelines that auto-apply candidate[0] (auto-match-transcribed reads cached candidates[0]), this converts a cosmetic preference into a wrong-match driver.
+
+**Recommendation:** Exempt strong-evidence candidates from the cover filter: keep coverless candidates that are TranscriptionBoosted, came from direct ASIN lookup, or score within epsilon of the best; or demote coverless (×0.9) instead of deleting.
+
+**Citations:**
+- internal/metafetch/service_search.go:487-497
+- internal/metafetch/service_search.go:441-481
+
+## MATCH-6 — Auto-match apply path re-reads cache candidate[0] independently of the gated search snapshot (medium)
+
+`SearchTranscriptionCandidate` ignores its transcribed title/author arguments and returns cached candidates[0] (`server_maintenance_deps.go:354-370`); `runAutoMatchTranscribed` applies gates 1–3 to that snapshot, then calls `ApplyTranscriptionCandidate` — which also ignores its `candTitle`/`candAuthor` arguments and re-reads cache candidates[0] (`server_maintenance_deps.go:382-393`). If the candidate cache for that book is refreshed between the two reads (concurrent metadata fetch op, UI-triggered search), a different, never-gated candidate is applied. `ApplyMetadataCandidate`'s own audio-confirm check reduces but does not eliminate the exposure (it gates title, not the score/author gates). Also gate 3 uses raw `TranscribedAuthor` without `IsGarbageValue` (`auto_match_transcribed.go:158`), so garbage like "unknown" rejects every candidate (conservative, but silently zeroes eligibility).
+
+**Recommendation:** Pass the gated candidate (or its title+author+score identity) into `ApplyTranscriptionCandidate` and verify it still equals cache candidates[0] before applying; run `transAuthor` through `IsGarbageValue` before gate 3.
+
+**Citations:**
+- internal/server/server_maintenance_deps.go:354-371
+- internal/server/server_maintenance_deps.go:378-395
+- internal/plugins/maintenance/auto_match_transcribed.go:130-176
+
+## MATCH-7 — No permanent-error classification in retry paths (medium)
+
+`DoWithRetry` (`retry.go:31-44`) and `embedBatchRaw` (`embedding_client.go:287-310`) retry every error uniformly: with OpenAI quota-exhausted, each LLM/batch/embedding call to OpenAI burns 3 attempts plus 1s+4s (embed) or quadratic (`DoWithRetry`) backoff before failing, and nothing distinguishes "quota dead, switch backends" from "transient network blip." The proposed fallback backend mode (openai↔local) has no signal to trigger on; today the only availability gate is the boolean `localOllamaOK` for the local path (`embedding_client.go:193`). This also inflates wall time for every scorer failure that cascades to F1 fallback per source (see MATCH-4).
+
+**Recommendation:** Add `IsPermanentAPIError(err)` (429 insufficient_quota, 401/403, 404 model-not-found via openai-go's APIError status/code) — skip retries and return a typed error the backend selector can use to fail over and set a cooldown health flag.
+
+**Citations:**
+- internal/ai/retry.go:26-47
+- internal/ai/embedding_client.go:287-330
+
+## MATCH-8 — embedclient and llmparser registrations gate on OpenAIAPIKey even for keyless local Ollama (medium)
+
+`embedclient` returns nil when `cfg.OpenAIAPIKey` is empty (`register.go:35`), even when `Embedding.BaseURL` points at local Ollama, which requires no key. If the operator deletes the quota-dead OpenAI key, local embeddings silently disable (nil client → nil metadatascorer → silent F1 downgrade, no warning). Conversely, `llmparser` (`register.go:65-68`) is hardcoded to the OpenAI default endpoint with no base_url override at all — the LLM tier (rerank, dedup Layer-3 review, metadata LLM review) cannot use the local qwen2.5:7b-instruct backend and will 429 against OpenAI until the backend-mode toggle exists. The `server.go:621-624` trust fix (#1739/#1740) only gates availability, not construction.
+
+**Recommendation:** Relax the key gate: construct the embedding client when BaseURL is set regardless of key (pass a dummy key — Ollama ignores it). Give the LLM parser its own base_url/model config as part of the backend-mode design; log loudly when an AI tier is disabled by missing config.
+
+**Citations:**
+- internal/ai/register.go:35-49
+- internal/ai/register.go:65-68
+- internal/server/server.go:621-624
+
+## MATCH-9 — LevenshteinDistance operates on bytes, inflating distances for non-ASCII titles (low)
+
+`LevenshteinDistance` indexes `a[i-1]`/`b[j-1]` as bytes and uses byte `len()` (`fuzzy.go:23,40`), while `normalize` deliberately preserves all Unicode letters/digits (`fuzzy.go:144`). Accented or CJK characters are 2–4 bytes, so one substituted character counts as up to 4 edits and maxLen is byte-inflated — similarity scores for titles/authors like "Émile Zola" or Japanese titles are skewed low and asymmetric versus their ASCII-folded forms. The substring ratio at `fuzzy.go:77` has the same byte-length bias. Bounded impact: fuzzy scores feed 50–70-point tiers, so ASCII-dominant libraries are unaffected.
+
+**Recommendation:** Convert to `[]rune` before the DP loop and use rune counts for all length ratios; optionally fold diacritics in normalize (`golang.org/x/text/unicode/norm`) for accent-insensitive matching.
+
+**Citations:**
+- internal/matcher/fuzzy.go:19-48
+- internal/matcher/fuzzy.go:77
+- internal/matcher/fuzzy.go:140-149
+
+## TOGGLE-1 — Local Ollama embedding still requires a non-empty OpenAIAPIKey (high)
+
+**Advisor: confirmed verbatim.**
+
+`embedclient` Build returns nil when `cfg.OpenAIAPIKey==""` even if `Embedding.BaseURL` points at Ollama, which needs no key (`register.go:35`). `llmparser` has the same gate (`register.go:65`). With OpenAI quota-exhausted, the system only works because a now-useless OpenAI key is still configured; removing it would disable the local backend entirely. There is no mode concept — key presence is the de-facto backend selector.
+
+**Recommendation:** Backend-mode factories must decouple client construction from `OpenAIAPIKey`: in local mode pass a placeholder key (Ollama ignores Authorization) and require only `LocalBaseURL`; require the real key only for openai/fallback modes.
+
+**Citations:**
+- internal/ai/register.go:35
+- internal/ai/register.go:65
+
+## TOGGLE-2 — EmbedBooksAsync (OpenAI Batch API) not gated on backend; skip-check ignores embedding model (high)
+
+`EmbedBooksAsync` submits to `/v1/batches` via `CreateEmbeddingBatch` with no check that the client's baseURL is real OpenAI — Ollama does not implement the Batch API, so async embed-scan under local mode fails at runtime (or worse, would bill OpenAI if the SDK falls through to the default host). Separately, its already-embedded skip at `engine.go:2307` checks only TextHash equality, unlike `prepBookEmbed` (`engine.go:2094`) which also calls `embeddingModelMatches` — so the async path silently skips books carrying stale 3072-dim text-embedding-3-large vectors during the bge-m3 cutover, the exact bug #1738 fixed on the sync path.
+
+**Recommendation:** Gate all `openai_batch.go`/`embedding_batch.go` entry points on effective backend==openai (typed `ErrBatchUnsupported`; embed-scan async downgrades to sync). Add `embeddingModelMatches` to the `EmbedBooksAsync` skip-check.
+
+**Citations:**
+- internal/dedup/engine.go:2307
+- internal/dedup/engine.go:2318
+- internal/plugins/dedup/embed_scan.go:77
+- internal/ai/embedding_batch.go:32
+
+## TOGGLE-3 — No per-config base URL for the LLM path (high)
+
+`NewOpenAIParser` honors only the process-wide `OPENAI_BASE_URL` env (`openai_parser.go:85`). The embedding client deliberately avoids that env because it redirects ALL default clients (`embedding_client.go:107-112` comment), but the parser still uses it — so pointing the LLM at Ollama today would also redirect any client built without an explicit base URL, and there is no config field for an LLM endpoint at all. `LLMMode=local` for qwen2.5:7b-instruct is fully greenfield.
+
+**Recommendation:** Add `NewOpenAIParserWithBaseURL` taking an explicit per-client base URL + model from `AIBackendConfig` (`LocalBaseURL`/`LocalLLMModel`), mirroring the embedding-client pattern; deprecate `OPENAI_BASE_URL` env reliance in the parser.
+
+**Citations:**
+- internal/ai/openai_parser.go:85
+- internal/ai/embedding_client.go:107
+
+## TOGGLE-4 — retry.go retries 429/insufficient_quota blindly; no classification, no fallback hook (medium)
+
+`DoWithRetry` treats every error identically: quota-exhausted (429 insufficient_quota) and auth failures (401) are permanent but still get maxAttempts with quadratic backoff, wasting minutes per batch during the current OpenAI outage, and there is no signal a caller could use to trigger openai→local fallback. The fallback mode in the toggle design needs a permanent/transient classification here.
+
+**Recommendation:** Add an error classifier (openai SDK `*APIError`: 401 + 429/insufficient_quota = permanent, 5xx/timeouts = transient). `DoWithRetry` short-circuits permanent errors; fallback-mode clients switch backend on permanent classification and set a sticky flag exposed via the backend-status endpoint.
+
+**Citations:**
+- internal/ai/retry.go:26
+- internal/ai/retry.go:40
+
+## TOGGLE-5 — Ollama availability is a one-shot startup trust with a non-atomic flag (medium)
+
+`server.go:616-625` sets availability once at startup: binary-on-PATH probe OR unconditional trust of a non-empty base_url (#1739). A configured-but-down endpoint is "available" forever; a recovered endpoint after startup-probe failure stays blocked. `localOllamaOK` is a plain bool read by every `EmbedBatch` (`embedding_client.go:193`) and written by `SetOllamaAvailable` — a runtime settings toggle (the whole point of the backend-mode feature) would introduce a data race.
+
+**Recommendation:** Replace with an HTTP probe (`GET {base}/api/tags`, 2s timeout) cached with TTL and re-probed on failure; store availability in `atomic.Bool`. Surface probe result in the new backends-status API so the FE selector can show live health.
+
+**Citations:**
+- internal/server/server.go:616
+- internal/ai/embedding_client.go:82
+- internal/ai/embedding_client.go:141
+
+## TOGGLE-6 — metadatallmscorer built regardless of MetadataScoring.LLMEnabled (low)
+
+The registry constructs `LLMScorer` whenever `llmparser` exists (`register.go:94-105`) without consulting `MetadataScoring.LLMEnabled`; the only enforcement is the runtime check at `service_search.go:537`. Any future consumer of the `metadatallmscorer` service bypasses the prod `llm_enabled=false` setting. The mode enum should become the single source of truth (`LLMMode=disabled` ⇒ nil scorer), matching how `metadatascorer` checks `EmbeddingEnabled` at build (`register.go:80`).
+
+**Recommendation:** In the toggle implementation, have the `metadatallmscorer` Build return nil when effective `LLMMode==disabled` (and keep the call-site check for per-request opts), so config disablement is enforced at construction like the embedding scorer.
+
+**Citations:**
+- internal/ai/register.go:94
+- internal/metafetch/service_search.go:537
+
+## TOGGLE-7 — Model names are OpenAI-specific defaults with no per-backend mapping (low severity, medium impact)
+
+Dedup `ReviewModel` defaults to "gpt-5-mini" (`config.go:137`), `OpenAIParser` defaultModel is "gpt-5-mini" (`openai_parser.go:51`), and `defaultEmbeddingModel` is "text-embedding-3-large" (`embedding_client.go:92`). Under local mode these names are sent verbatim to Ollama and 404. A mode toggle that only swaps base URLs will break every LLM feature (filename parse, cover art, metadata review, dedup Layer-3) unless model selection is backend-aware.
+
+**Recommendation:** Resolve the effective model per backend at client-build time: local mode substitutes `LocalLLMModel`/`LocalEmbeddingModel` for all per-feature model fields (or exposes per-feature overrides later). The backends-status endpoint should verify the resolved model exists in Ollama `/api/tags` — this is the hook for the model-download prompt.
+
+**Citations:**
+- internal/config/config.go:137
+- internal/ai/openai_parser.go:51
+- internal/ai/embedding_client.go:92
+
+## Design: LLM/Embedding Backend-Mode Toggle
+
+Two design contributions were produced. The primary (from the backend-toggle specialist) follows; the matching specialist's sketch, which converges on the same architecture with a few additional wiring details, is appended after it.
+
+### Primary design (TOGGLE report)
+
+**Config shape** — new nested struct in the CFG blob:
+`AIBackendConfig { EmbeddingMode, LLMMode string; LocalBaseURL, LocalEmbeddingModel, LocalLLMModel string }`, modes: `disabled | openai | local | openai-fallback-local`, independent per subsystem. Local defaults: bge-m3 / qwen2.5:7b-instruct, base `http://172.16.3.22:11434/v1`.
+
+**Migration** (startup blob migration in persistence.go, plus legacy-key API shim per docs/reference/config-api-shape.md): if `EmbeddingMode` empty → `local` when `Embedding.BaseURL≠""` (copy to `LocalBaseURL`), else `openai` when `OpenAIAPIKey≠""&&Embedding.Enabled`, else `disabled`. `LLMMode` → `openai` when `OpenAIAPIKey≠""&&(EnableAIParsing||MetadataScoring.LLMEnabled)`, else `disabled`. Old fields remain readable shims; write-through both ways for one release.
+
+**Runtime per mode** — register.go factories key off effective mode, not `OpenAIAPIKey`: local mode uses placeholder API key ("ollama") so no OpenAI key is required; openai mode ignores base_url. LLM gets a second constructor `NewOpenAIParserWithBaseURL` (per-client option, mirroring `embedding_client.go:116-123` — never `OPENAI_BASE_URL` env). Availability: replace LookPath/trust-hack with HTTP probe `GET {LocalBaseURL}/api/tags` (2s timeout), TTL-cached + re-probed on failure; store in `atomic.Bool` replacing `localOllamaOK`. Fallback (`openai-fallback-local`): classify errors in retry.go — 401/429-insufficient_quota = permanent → flip a sticky "openai-down" flag and route to local; 5xx/timeout = retry then per-request fallback. **Embeddings fallback is NOT per-request**: switching model changes dimensions (bge-m3 1024 vs 3-large 3072; CosineSimilarity→0, HNSW dim mismatch), so embedding fallback resolves once at client build/probe time, tags vectors with the actual model, and raises a "model changed — re-embed required" event (banner + one-click dedup.embed-scan); `embeddingModelMatches` + (hash,model) cache keys already make re-embed safe. **OpenAI-only paths** (openai_batch.go, `CreateEmbeddingBatch`, `EmbedBooksAsync`, `BatchPoller`) return typed `ErrBatchUnsupported` unless effective backend==openai; embed-scan async=true downgrades to sync with a log.
+
+**FE** — "AI Backends" card in Settings (extend EmbeddingSettingsSection/MetadataScoringSection): two mode selects, local endpoint/model fields, Test Connection → new `GET /api/v1/ai/backends/status` (probes endpoint, lists pulled models via `/api/tags`, reports effective mode + last fallback reason).
+
+**Model-download prompt** — when local selected and status shows model absent: dialog "qwen2.5:7b-instruct not pulled (4.7GB) — Pull now?" → `POST /api/v1/ai/backends/pull-model`, runs `ollama pull` through the existing managed external-tool lifecycle (managed Ollama PIDFile/port wiring at `server.go:595`; TODO "Managed External-Tool Lifecycle"), streaming progress as an op-registry operation; mode stays pending-unavailable until probe passes.
+
+### Companion sketch (MATCH report)
+
+**LLM/embedding backend-mode toggle (greenfield — no BackendMode symbol exists).**
+
+Config: two independent enums, `embedding.backend_mode` and `llm.backend_mode` ∈ {`disabled`, `openai`, `local`, `local_with_openai_fallback`, `openai_with_local_fallback`} (covers "disable-all/OpenAI-only/local-only/fallback"). Per-backend blocks: `{base_url, model, api_key}` — local needs no key (fixes register.go:35 gate); local LLM target `qwen2.5:7b-instruct` at 172.16.3.22:11434/v1.
+
+Wiring: in register.go, replace the single `embedclient`/`llmparser` builders with a `BackendSelector` that constructs up to two `*EmbeddingClient`s (each pinned to its own model+baseURL, reusing `NewEmbeddingClientWithOptions`) and two chat clients. `Model()` already flows into cache keys (`embedding_client.go:212`) and dedup's `embeddingModelMatches` (`engine.go:2110-2115`) — fallback switching automatically forces model-tagged re-embeds and cache partitioning; no new tagging needed, but `EmbeddingScorer` must gain the same model check on its store fast-path (see MATCH-1) so a mid-fallback flip can't mix 3072/1024-dim vectors (CosineSimilarity→0, `embedding_store.go:1214`).
+
+Fallback trigger: add error classification in `internal/ai/retry.go` — `IsPermanent(err)`: HTTP 429 `insufficient_quota`, 401/403, 404 model-not-found → do NOT retry (today `embedBatchRaw` retries these 3× at `embedding_client.go:287-310`); instead return a typed `ErrBackendUnavailable{Backend}` that the selector catches to switch to the fallback backend, with a cooldown/health flag like `localOllamaOK` (`embedding_client.go:82`). Transient errors keep current retry behavior.
+
+OpenAI-only paths: `OpenAIParser.Batches.*` (`openai_batch.go:74,214,376`) and batch-file endpoints have no Ollama equivalent — under `local`/local-primary modes these must return a typed `ErrNotSupportedByBackend` (no-op with clear log), and EmbedBooksAsync/batch-submit UI actions should be hidden/disabled. Dedup Layer-3 review and metadata rerank go through the selected chat backend instead of the hardcoded OpenAI parser (`register.go:59-70` currently gates on `OpenAIAPIKey` only).
+
+Availability gating: keep `server.go:616-624` trust-the-configured-base_url logic per backend; `disabled` mode short-circuits before any client construction so nil-scorer paths (metafetch F1 fallback, `service_scoring.go:470-507`) engage cleanly.
+
+Migration: default mode derived from existing config (base_url set → `local`, else key set → `openai`) so no prod config change is required at deploy.
+
+### Reconciling the two designs
+
+Both converge on: independent embedding/LLM mode enums, keyless local client construction, per-client base URLs (never `OPENAI_BASE_URL`), error classification in retry.go driving fallback, typed errors gating OpenAI-only batch paths, and reuse of `embeddingModelMatches` + (hash,model) cache keys for re-embed safety. Differences to resolve at implementation time: (1) mode-enum vocabulary (primary uses `openai-fallback-local`; sketch adds `local_with_openai_fallback` — support both directions); (2) availability probing — the primary design's HTTP probe + atomic.Bool supersedes the sketch's keep-the-trust-hack; (3) the primary design's insight that **embedding fallback must resolve at build/probe time, not per-request** (dimension mismatch) should be treated as a hard constraint on either enum set.

--- a/docs/consultancy/04-code-quality.md
+++ b/docs/consultancy/04-code-quality.md
@@ -1,0 +1,243 @@
+<!-- file: docs/consultancy/04-code-quality.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e35c64b1-5c2f-408e-8b86-1e480f05c015 -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Code Quality & Bugs (2026-07-02)
+
+Evaluation run by a read-only multi-agent workflow (bug-hunt agent + code-review/counter-argument agent, followed by adversarial verification and an advisor boundary review). All findings are cited as `file:line` against the repo state on 2026-07-02.
+
+## Executive Summary
+
+Two specialist reports converge on three systemic problems and a set of concrete bugs, several of them live in production right now.
+
+**1. Embedding scoring is silently returning zero candidates during the live bge-m3 cutover (BUG-1 / QUAL-4).** `EmbeddingScorer.queryVector` returns the cached book vector without checking its `Model` field. Books not yet re-embedded hold OpenAI vectors (1536/3072-dim) while candidate vectors come fresh from Ollama at 1024-dim; `CosineSimilarity` returns 0 on length mismatch, every candidate falls below `EmbeddingMinScore` (0.82), and because the scorer returned a nil error there is no F1 fallback. Metadata search silently returns zero results for every not-yet-re-embedded book. The code-review agent independently found two interacting gaps in the same tier: the 0.82 threshold is applied to a post-penalty/pre-boost composite rather than raw similarity, and degenerate all-zero scorer success never triggers F1 fallback.
+
+**2. The memdb-projection write-back footgun is fixed for BookFile but NOT for Book (QUAL-2, CTR-1, CTR-2).** `stripBookForMemdb` clears Description/VersionNotes/BookSigV1* for the in-memory projection; `GetAllBooks` returns stripped rows on the production `UseMemDB` path; `UpdateBook` marshals the caller's struct verbatim with no preserve-on-empty guard (unlike `UpsertBookFile`/`BatchUpsertBookFiles`, which explicitly guard the equivalent fields after the #1552 fingerprint-wipe fix). `reconcile.AssignOrphanVGs` demonstrably reads stripped books and writes them back via `UpdateBook`, wiping Description and dedup book-signatures. The counter-argument findings generalize this: full-column-replacement `UpdateBook` puts an unenforceable merge contract on 149 call sites (CTR-1), and reusing the same `*Book`/`*BookFile` type for two incompatible representations is the root cause of the whole footgun class (CTR-2). Verification tempered severity from critical to high: `UpdateBook`'s CoW `book_ver:` snapshot captures the full pre-wipe row, so damage is recoverable.
+
+**3. A mass mechanical printf→slog conversion corrupted observability repo-wide (BUG-4 / QUAL-1).** Dozens of log calls have duplicate attr keys, literal `"value0"` strings logged as both key and value (25 sites), %-verbs left in messages with the args dropped entirely (`plugin/registry.go:34` loses the duplicate plugin ID outright), and bare positional args producing `!BADKEY` — exactly on the merge/quarantine/metafetch/fingerprint paths where prod debugging happens, directly hampering diagnosis of BUG-1.
+
+Additional confirmed defects: the MATCH-6 TOCTOU in transcription auto-match apply (BUG-3 / QUAL-3), the persisting PEBBLE-CLOSED shutdown race despite the mitigation (BUG-2), retry loops that burn full backoff cycles on permanent errors including the currently-live OpenAI `insufficient_quota` (BUG-5 / QUAL-6), a cover-presence hard filter that can discard the top-scoring candidate (BUG-6 / QUAL-5), unclamped multiplicative score stacking that makes thresholds tier-incomparable (CTR-3), init()-registered global plugin state (CTR-4), and a pagination-race guard that fixed one instance rather than the class (QUAL-7).
+
+Positive findings: the latent `UpsertBookFile` fingerprint-wipe is now guarded (`pebble_store.go:9974-9985`) with pebble-direct existing-row lookups, and the BookFile batch path carries the same guard.
+
+## Advisor Verification
+
+The advisor's P4 boundary assessment (independent spot-check of the raw findings):
+
+> Findings verify cleanly — I spot-checked BUG-1 (embedding_scorer.go:92-95 returns cached vector modelless; CosineSimilarity embedding_store.go:1214 returns 0 on dim mismatch), QUAL-2 (GetAllBooks memdb path pebble_store.go:1392, strip at memdb_strip.go:34-40, write-back reconcile.go:1149), BUG-3 (server_maintenance_deps.go:378-393 ignores identity params, applies cache slot 0), and BUG-4 slog sites (plugin/registry.go:34 drops the arg; embedding_client.go literal "value0"). One overreach: QUAL-2 "critical" is tempered by UpdateBook's CoW snapshot (pebble_store.go:2688-2698 writes old row to book_ver: before overwrite) — wipes are recoverable, so severity is high, not critical. The two reports duplicate ~5 findings (BUG-3=QUAL-3, BUG-4=QUAL-1, BUG-5=QUAL-6, BUG-6=QUAL-5, BUG-1≈QUAL-4); treat as one set. No fabricated citations found.
+
+Corrections applied in this report:
+
+- **QUAL-2 downgraded critical → high** inline (CoW `book_ver:` snapshots make wipes recoverable; trigger is a manual admin op, not automatic).
+- **QUAL-1/BUG-4 held at medium** per the verification verdict (real and widespread, but impact is confined to log quality/diagnostics, not behavior or data).
+- **Duplicates consolidated**: each deduplicated finding is presented once below with both IDs noted.
+
+Advisor engagement context worth keeping in mind when reading severities: PebbleDB is the only production store; the system is mid-cutover (OpenAI quota-dead, Ollama primary, bge-m3 re-embed in flight via `dedup.embed-scan`); prod is live with ~50K books, so all of these are production-affecting.
+
+## Adversarial Verification Verdicts
+
+An independent verification pass re-derived the top findings end-to-end from source:
+
+| Finding | Verdict | Severity after verification | Notes |
+| --- | --- | --- | --- |
+| BUG-1 | Real | High | Confirmed end-to-end: modelless cached-vector fast path → CosineSimilarity=0 on 1536-vs-1024 dim mismatch → nil error means no F1 fallback → +0.15 max bonus < 0.82 MinScore drops all candidates. Gated on `MetadataScoring.EmbeddingEnabled` (prod state unconfirmed), but ~12K skipped non-primary versions keep stale vectors permanently, so the exposure window is not just the cutover. |
+| QUAL-1 (= BUG-4) | Real | Medium (downgraded from high) | All ten citations verified by direct read. Real, widespread, on live code paths — but impact is confined to log quality/diagnostics, not behavior or data. |
+| QUAL-2 | Real | High (downgraded from critical) | Verified end-to-end (strip → memdb GetAllBooks → unguarded UpdateBook full replace; AssignOrphanVGs provably wipes fields, reachable via POST /operations/assign-orphan-vgs). Downgraded because CoW `book_ver:` snapshots retain old data and the trigger is a manual admin op, not automatic. |
+| CTR-1 | Real | High | UpdateBook confirmed full-replacement with no field preservation; stripped and canonical Books are type-indistinguishable; a concrete prod-reachable violation exists (AssignOrphanVGs); CoW then snapshots degraded rows. Quarantine citation is safe (direct Pebble scan), but the architectural footgun plus demonstrated instance stands. |
+| CTR-2 | Real | High | All citations verified: type-indistinguishable projections, silent representation switch on UseMemDB, manual "keep both in sync" guard on the BookFile side, zero Book-field preservation in UpdateBook today. The class already caused real data loss (PR #1552 fingerprint wipe), patched per-instance. |
+
+## Findings Table
+
+Duplicated findings across the two reports are merged (BUG-3=QUAL-3, BUG-4=QUAL-1, BUG-5=QUAL-6, BUG-6=QUAL-5, BUG-1≈QUAL-4). Severities reflect post-verification values.
+
+| ID | Severity | Impact | Effort | Title |
+| --- | --- | --- | --- | --- |
+| BUG-1 / QUAL-4 | High (verified) | High | Low | Stale-model cached query vector zeroes all embedding scores; min-score filter drops every candidate with no F1 fallback; MinScore also applied at the wrong point in the pipeline |
+| QUAL-2 | High (downgraded from critical) | High | Low | UpdateBook full-replacement lacks memdb preserve guard; AssignOrphanVGs provably wipes Description/BookSigV1 via memdb round-trip |
+| CTR-1 | High (verified) | High | Medium | Counter: full-column-replacement UpdateBook is the wrong write primitive for a 149-call-site codebase |
+| CTR-2 | High (verified) | High | High | Counter: memdb field-stripping reuses the same *Book/*BookFile type for two incompatible representations |
+| BUG-2 | Medium | Medium | Medium | Registry.Shutdown can return with store-touching goroutines still live (PEBBLE-CLOSED variant persists despite fix) |
+| BUG-3 / QUAL-3 | Medium | Medium | Low | MATCH-6 TOCTOU confirmed: ApplyTranscriptionCandidate applies whatever is cache slot 0 at apply time, not the gated candidate |
+| BUG-4 / QUAL-1 | Medium (downgraded from high) | Medium | Low–Medium | Repo-wide corrupted slog conversions: dropped values, literal "value0" pairs, bare values as keys, duplicate attr keys |
+| BUG-5 / QUAL-6 | Medium | Medium | Low | No permanent-error classification in either retry implementation; 4xx/insufficient_quota retried with full backoff |
+| CTR-3 | Medium | Medium | Medium | Counter: unclamped multiplicative score stacking makes thresholds tier-incomparable |
+| CTR-4 | Medium | Medium | Medium | Counter: init()-registered global plugin registry trades explicit wiring for import-order coupling and untestable global state |
+| BUG-6 / QUAL-5 | Low | Low–Medium | Low | Cover filter hard-drops cover-less candidates regardless of score, before sort and LLM rerank, including direct ASIN matches |
+| QUAL-7 | Low | Low | Medium | Fetch-race guard is instance-level (useLibraryQuery), not a shared abstraction — the pagination-race class is not structurally fixed |
+
+## Findings
+
+### BUG-1 / QUAL-4 — Stale-model cached query vector zeroes all embedding scores; min-score filter drops every candidate with no F1 fallback (High, verified)
+
+**Detail (BUG-1):** `EmbeddingScorer.queryVector` (embedding_scorer.go:93-97) returns the EmbeddingStore-cached book vector whenever one exists, without checking the record's `Model` field (which exists — embedding_store.go:95) against the client's current model. During the live bge-m3 cutover, books not yet re-embedded hold OpenAI vectors (1536/3072-dim); candidate vectors come fresh from Ollama at 1024-dim. `CosineSimilarity` returns 0 on length mismatch (embedding_store.go:1214-1216), so every candidate scores 0; `ApplyNonBaseAdjustments` adds at most +0.15 bonus, below `EmbeddingMinScore=0.82` (config.go:1351), so service_search.go:333-337 drops all candidates. Because `Score()` returned nil error, `ScoreBaseCandidates` never falls back to F1 (service_scoring.go:492-495). Even same-dim cross-model vectors give meaningless similarities. Result: metadata search silently returns zero candidates for every un-re-embedded book, right now in prod.
+
+**Detail (QUAL-4, same tier):** Two interacting gaps. (1) Ordering: the 0.82 `EmbeddingMinScore` (config.go:1351) is applied at service_search.go:334 to the score AFTER `ApplyNonBaseAdjustments` penalties (compilation/length) but BEFORE author (1.5x), narrator (1.3x), series (1.4x) boosts at :340-370. A 0.9-cosine candidate hit by a compilation penalty drops below 0.82 and is discarded even though boosts would have carried it far above threshold — the threshold semantically targets raw embedding similarity but is compared against a partially-adjusted composite. (2) Fallback asymmetry: `ScoreBaseCandidates` falls back to F1 only on scorer error or length mismatch (service_scoring.go:492-499). A scorer that succeeds with all-zero/near-zero vectors (empty embedding text, degraded Ollama model output) returns tier=embedding, every candidate fails `score <= 0.82`, and the search returns zero candidates where F1 would have matched. With Ollama now primary, this failure mode is live.
+
+**Verification note:** gated on `MetadataScoring.EmbeddingEnabled` (prod state unconfirmed); ~12K skipped non-primary versions keep stale vectors permanently, so the exposure window is not just the cutover.
+
+**Recommendation:** In `queryVector`, only use the cached vector when `existing.Model` equals the client's model (or at minimum `len(existing.Vector)` matches the expected dimension); otherwise embed the query live. In `ScoreBaseCandidates`, treat an all-zero score vector as scorer failure and fall through to F1. Apply `EmbeddingMinScore` to the base score (raw cosine) before adjustments, or move the check after boosts.
+
+**Citations:**
+- internal/ai/embedding_scorer.go:93-97
+- internal/ai/embedding_scorer.go:79-86
+- internal/database/embedding_store.go:1213-1216
+- internal/metafetch/service_search.go:328-337
+- internal/metafetch/service_search.go:330
+- internal/metafetch/service_search.go:334
+- internal/metafetch/service_search.go:340
+- internal/metafetch/service_scoring.go:491
+- internal/config/config.go:1351
+
+### QUAL-2 — UpdateBook full-replacement lacks memdb preserve guard; AssignOrphanVGs provably wipes Description/BookSigV1 via memdb round-trip (High, downgraded from critical)
+
+**Detail:** `stripBookForMemdb` clears Description, VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments (memdb_strip.go:33-40). `GetAllBooks` routes through memdb when `UseMemDB` (pebble_store.go:1392-1393) — production config — returning stripped rows. `UpdateBook` (pebble_store.go:2664) marshals the caller's struct verbatim with no preserve-on-empty guard, unlike `UpsertBookFile:9974-9985` and `BatchUpsertBookFiles:10042-10053` which explicitly guard the equivalent BookFile fields. Concrete instance: `reconcile.AssignOrphanVGs` pages the whole library via `store.GetAllBooks` (reconcile.go:1115), sets VG fields, and calls `UpdateBook` (reconcile.go:1149) — every orphan book processed loses its Description and dedup book-signature. With 149 `UpdateBook` call sites, any other memdb-sourced caller repeats this silently.
+
+**Severity adjustment (advisor + verification):** originally reported critical; downgraded to high because the CoW version snapshot (pebble_store.go:2688-2698 writes the old row to `book_ver:` before overwrite) preserves pre-wipe data — wipes are recoverable — and the demonstrated trigger (POST /operations/assign-orphan-vgs) is a manual admin op, not automatic. Note however that nothing automatically restores from snapshots, and per CTR-1 the snapshots themselves can capture progressively degraded rows.
+
+**Recommendation:** Add the same preserve-on-empty guard to `UpdateBook` for Description/VersionNotes/BookSigV1* (mirroring `UpsertBookFile`), or make `UpdateBook` merge from `oldBook` (already fetched at :2666). Audit other GetAllBooks→UpdateBook flows. Check prod for books with populated BookSigBuiltAt but nil BookSigV1 to measure existing damage — and sequence any recovery from `book_ver:` snapshots before any snapshot pruning.
+
+**Citations:**
+- internal/database/pebble_store.go:2664
+- internal/database/pebble_store.go:2683
+- internal/database/pebble_store.go:1391
+- internal/database/memdb_strip.go:29
+- internal/reconcile/reconcile.go:1115
+- internal/reconcile/reconcile.go:1149
+
+### CTR-1 — Counter: full-column-replacement UpdateBook is the wrong write primitive for a 149-call-site codebase (High, verified)
+
+**Detail:** The design puts merge responsibility on every one of 149 callers: each must hold a complete, canonical Book or silently destroy fields. That contract is unenforceable — the type system cannot distinguish a Pebble-canonical Book from a memdb-stripped one, and QUAL-2 shows a caller already violating it in prod-path code. It also composes badly with the CoW versioning at :2693: versions faithfully snapshot progressively-degraded rows, so the "undo" history itself can be full of stripped states. Every new bulk-maintenance job (quarantine, reconcile, VG assignment) re-inherits the footgun. The BookFile side already conceded the point by adding preserve-on-empty guards — the same argument applies a fortiori to Book, whose stripped fields (Description, BookSigV1) are more expensive to regenerate. Verification note: the quarantine citation turns out to be safe (direct Pebble scan), but the architectural footgun plus the demonstrated AssignOrphanVGs instance stands.
+
+**Recommendation:** Either (a) make `UpdateBook` merge-on-empty from `oldBook` for strip-list fields, or (b) introduce `UpdateBookFields(id, patch)` for the common set-two-pointers callers (most of the 149 sites set 1-3 fields) and deprecate whole-row Update outside the importer.
+
+**Citations:**
+- internal/database/pebble_store.go:2664
+- internal/database/pebble_store.go:2683
+- internal/reconcile/reconcile.go:1149
+- internal/quarantine/service.go:275
+
+### CTR-2 — Counter: memdb field-stripping reuses the same *Book/*BookFile type for two incompatible representations (High, verified)
+
+**Detail:** The 10GB→2GB RSS win is real, but the mechanism is a projection that is type-indistinguishable from the canonical row, and the store silently switches representation based on a runtime flag (pebble_store.go:1392: the same `GetAllBooks` returns stripped or full depending on `UseMemDB`). Consequences observed: per-write-path guard duplication with an explicit "keep both in sync" comment (pebble_store.go:9973) — a maintenance treadmill; predicate filters that "silently miss against stripped books" (memdb_strip.go:26-28); and QUAL-2, where the guard was simply never written for the Book entity. Every future heavy field added to Book must be added to the strip list AND every write-path guard, with no compiler help. The nil-means-both-"absent"-and-"projected" ambiguity is the root cause of the entire footgun class the team keeps patching instance by instance — the class already caused real data loss once (PR #1552 fingerprint wipe).
+
+**Recommendation:** Introduce a distinct `BookListRow` projection type for memdb (the compiler then prevents passing it to `UpdateBook`), or centralize all Book/BookFile writes through one merge function that always rehydrates strip-list fields from Pebble before marshal.
+
+**Citations:**
+- internal/database/memdb_strip.go:29
+- internal/database/memdb_strip.go:87
+- internal/database/pebble_store.go:1392
+- internal/database/pebble_store.go:9969
+
+### BUG-2 — Registry.Shutdown can return with store-touching goroutines still live (PEBBLE-CLOSED variant persists despite fix) (Medium)
+
+**Detail:** The comment at registry.go:838-841 claims Shutdown "guarantees callers can safely close the underlying store immediately after Shutdown returns". Two escape hatches break that guarantee: (1) if the shutdown ctx expires during the drain poll, remaining ops are marked interrupted and Shutdown proceeds while their run goroutines still execute plugin code that writes to the store (registry.go:820-836); (2) `goroutineWG.Wait` is bounded by a hard 2s timeout — "goroutines did not exit within 2s; proceeding" (registry.go:862-865). The in-process op run goroutine itself (worker.go:236-238, `done <- r.safeRun(...)`) is never enrolled in `goroutineWG`; during shutdown its run handle stays registered (worker.go:276-282) so only the ctx-bounded drain poll waits for it. A wedged plugin therefore survives both waits, and the caller's `store.Close()` races it → "pebble: closed" panic. TODO.md:64 confirms the residual race still reproduces under package-wide `-race`.
+
+**Recommendation:** Either make the safe-close guarantee real (block until goroutineWG and all run handles drain, no timeout) or make the failure explicit: have Shutdown return a sentinel "not drained" error and have callers skip/delay `store.Close()` on that path. Enroll the safeRun goroutine in goroutineWG.
+
+**Citations:**
+- internal/operations/registry/registry.go:838-841
+- internal/operations/registry/registry.go:855-866
+- internal/operations/registry/registry.go:820-836
+- internal/operations/registry/worker.go:236-238
+- internal/operations/registry/worker.go:276-282
+- TODO.md:64
+
+### BUG-3 / QUAL-3 — MATCH-6 TOCTOU confirmed: ApplyTranscriptionCandidate applies whatever is cache slot 0 at apply time, not the gated candidate (Medium)
+
+**Detail:** `SearchTranscriptionCandidate` returns `entry.Candidates[0]` from the metadata cache; auto_match_transcribed.go gates on that candidate's score (>= minScore), normalized-title equality, and author containment (lines 143-165). `ApplyTranscriptionCandidate` then discards the passed candTitle/candAuthor (parameters are `_, _` at server_maintenance_deps.go:379) and re-reads `GetCachedCandidates`, applying whatever is `Candidates[0]` at that moment. Any concurrent cache refresh for the same book (a user-triggered metadata search, another maintenance job, a metadata re-fetch op — the cache is shared) between the two calls can reorder or replace candidates, so an ungated candidate gets applied — and may set `MetadataReviewStatus=audio_confirmed` on the wrong metadata. The "auto-match-transcribed: applied" log (auto_match_transcribed.go:181-183) then reports the gated title even though a different one was written — actively misleading during incident triage.
+
+**Recommendation:** Pass identity through: have Apply accept the candidate (or an entry-version/hash token) and verify the cache entry still matches before applying — e.g. compare `Unmarshal(entry.Candidates[0]).Title/Author` against the passed candTitle/candAuthor and abort with a retryable error on mismatch, forcing re-triage. Cheap and fully backward compatible since callers already pass the values.
+
+**Citations:**
+- internal/server/server_maintenance_deps.go:354-372
+- internal/server/server_maintenance_deps.go:379-397
+- internal/server/server_maintenance_deps.go:390
+- internal/plugins/maintenance/auto_match_transcribed.go:130-183
+
+### BUG-4 / QUAL-1 — Repo-wide corrupted slog conversions: dropped values, literal "value0" pairs, bare values as keys, duplicate attr keys (Medium, downgraded from high)
+
+**Detail:** The printf→slog migration produced at least four distinct corruption shapes. (a) Data lost entirely: plugin/registry.go:34 logs "plugin %q already registered" with ZERO args — the duplicate plugin ID is unrecoverable from logs. (b) Literal-string values: 25 sites match the `"value0", "value0", "value1", x` pattern (embedding_client.go:215/235/260, quarantine/service.go:269,276, reconcile.go:687,695) — the literal string "value0" is logged as both key and value, the original first datum was deleted by the conversion, and real values get wrong keys (e.g. embedding_client.go:260: `slog.Warn("embedding cache put failed (hash)", "value0", "value0", "value1", hash[:8], ...)`). (c) Structure corrupted / !BADKEY: itunes/service/validate.go:81 passes two positional args after a %q-bearing message (req.From becomes the key, req.To its value); scan_composer_tags.go:196 appends bare `willWrite, w.filePath` after keyed pairs, making the written tag value the attr KEY; file_io_pool.go:338 similar. (d) Duplicate-key cluster ("value","value" / "count","count") across metafetch — service_apply.go:66 has "value" twice, :457 has "id" three times and "value" twice, validate.go:118 has "response" twice, service_scoring.go:498/607/612/642/677, service_search.go:254/265/335/541, service_writeback.go:123, service_fetch.go:141 — breaking structured-log queries and JSON log parsing, and making score/threshold drop reasons unreadable — directly hampering diagnosis of BUG-1.
+
+**Severity note (verification):** real, widespread, on live code paths — but impact is confined to log quality/diagnostics, not behavior or data, so medium not high.
+
+**Recommendation:** One mechanical sweep PR (good /parallel-sweep candidate): grep with `grep -rnE '"value[0-9]*",|%[sdqvf]' internal --include='*.go'` for slog messages still containing %-verbs, non-string bare args after the message, and repeated keys; rewrite each with distinct meaningful keys. Add `go vet` (the slog checker is in vet since Go 1.21) or a sloglint step to `make ci` to prevent recurrence.
+
+**Citations:**
+- internal/plugin/registry.go:34
+- internal/ai/embedding_client.go:215
+- internal/ai/embedding_client.go:235
+- internal/ai/embedding_client.go:260
+- internal/itunes/service/validate.go:81
+- internal/itunes/service/validate.go:118
+- internal/maintenance/jobs/scan_composer_tags.go:196
+- internal/server/file_io_pool.go:338
+- internal/metafetch/service_scoring.go:607
+- internal/metafetch/service_search.go:335
+- internal/metafetch/service_apply.go:66
+- internal/metafetch/service_apply.go:457
+- internal/quarantine/service.go:269
+- internal/reconcile/reconcile.go:687
+
+### BUG-5 / QUAL-6 — No permanent-error classification in either retry implementation; 4xx/insufficient_quota retried with full backoff (Medium)
+
+**Detail:** `ai.DoWithRetry` (retry.go:26-47) retries any non-nil error identically up to maxAttempts with quadratic backoff — no check for permanent failures (4xx/insufficient_quota/invalid-request). `embedBatchRaw` (embedding_client.go:287-312) is a second, independent inline retry loop (hardcoded 3 attempts, 1s/4s delays) that also retries unconditionally: any error from `Embeddings.New` → `lastErr = ...; continue`. HTTP 401 (bad key), 400 (input too long / oversized batch), and the currently-live OpenAI 429 `insufficient_quota` are all permanent, yet each embed call burns ~5s of sleeps plus 3 doomed API calls before failing. On batch scans (`dedup.embed-scan` iterating tens of thousands of items) a misconfigured/quota-dead backend turns into hours of futile retries instead of failing fast. Two divergent retry mechanisms in one package also mean fixes must land twice.
+
+**Recommendation:** Add an `IsPermanent(err)` classifier consulted by both loops: unwrap the openai SDK's `*openai.Error` and stop immediately on status 400/401/403/404 and on 429 with code `insufficient_quota` (retry only rate-limit 429s and 5xx/network errors). Better, make `embedBatchRaw` use `DoWithRetry` so there is one implementation.
+
+**Citations:**
+- internal/ai/retry.go:26-47
+- internal/ai/retry.go:40
+- internal/ai/embedding_client.go:287-312
+- internal/ai/embedding_client.go:309
+
+### CTR-3 — Counter: unclamped multiplicative score stacking makes thresholds tier-incomparable and lets boost products outvote base similarity (Medium)
+
+**Detail:** Scores intentionally exceed 100% (documented project decision), but the cost is now visible: boosts stack multiplicatively (author 1.5 × narrator 1.3 × series 1.4 × narrator-present 1.15 × series-number 2.0 ≈ 6.3x, service_search.go:345-519), so a base score of 0.15 with lucky metadata overlap beats a 0.9 exact match with sparse candidate metadata. Fixed thresholds are applied at inconsistent points on this unbounded scale: `EmbeddingMinScore` at 0.82 pre-boost (:334), ASIN floor of 1.0 (:446), DurationMismatch cutoffs — each calibrated to a different effective range, and F1-tier vs embedding-tier scores pass through identical multipliers despite different base distributions. Every new boost silently re-scales what "high confidence" means for auto-apply consumers of `Candidate.Score`, and there is no place to recalibrate because the scale has no ceiling.
+
+**Recommendation:** Keep the raw composite internally but expose a normalized/calibrated confidence (e.g. logistic over log-score, per-tier) for thresholds and auto-apply gates; alternatively convert boosts to additive log-space weights so individual signals cannot dominate combinatorially.
+
+**Citations:**
+- internal/metafetch/service_search.go:334
+- internal/metafetch/service_search.go:345
+- internal/metafetch/service_search.go:375
+- internal/metafetch/service_search.go:519
+- internal/metafetch/service_search.go:446
+
+### CTR-4 — Counter: init()-registered global plugin registry trades explicit wiring for import-order coupling and untestable global state (Medium)
+
+**Detail:** `Register` is invoked from package `init()` into a package-level singleton (registry.go:30-39, `Global()` at :43). Argued against: (1) duplicate registration is silently skipped with a Warn that — due to BUG-4/QUAL-1 — currently doesn't even log which plugin (:34), so a refactor that double-imports a plugin ships with no diagnosable signal; (2) the registry's contents depend on which packages the binary happens to import, so an API-only build vs full build can differ in registered ops with no compile-time manifest; (3) it is the same global-state pattern already causing the documented GlobalStore/GlobalQueue test flakiness — tests cannot construct isolated registries, so plugin tests share mutable state across the package's test binary. The convenience benefit (no wiring boilerplate) is small relative to a repo that already has an explicit Deps-injection pattern (internal/itunes/service).
+
+**Recommendation:** Keep init()-registration short-term but make `Register` return an error on duplicate and have a startup assertion log the full registered-plugin manifest; long-term, construct a Registry in main/server wiring (matching the itunes Deps pattern) so tests and alternate builds get explicit, isolated registries.
+
+**Citations:**
+- internal/plugin/registry.go:30
+- internal/plugin/registry.go:34
+- internal/plugin/registry.go:43
+
+### BUG-6 / QUAL-5 — Cover filter hard-drops cover-less candidates regardless of score, before sort and LLM rerank, including direct ASIN matches (Low)
+
+**Detail:** After all score computation (min-score gate, author/narrator multipliers, ASIN candidates), service_search.go:487-497 discards every candidate with empty CoverURL as long as at least one candidate has a cover, then sorts, caps at 50, and reranks (lines 526-539). Cover presence is a hard gate, not a ranking signal — a cover-less exact title+author+series match with score 2.0 is removed while a wrong-book candidate with a cover at 0.83 survives and gets applied. This includes the direct ASIN-lookup candidate appended at :456, which is supposed to be authoritative (score forced to >=1.0 at :446). Sources like OpenLibrary and Audnexus frequently return correct entries without cover URLs, and `ApplyNonBaseAdjustments` already awards a +0.05 cover bonus, so the hard filter double-counts and can invert correctness; the correct-match decision then feeds `ApplyMetadataCandidate` and auto-apply pipelines. Verdict from the bug-hunt agent: PLAUSIBLE — code behavior is verified; whether it misfires in practice depends on source cover coverage.
+
+**Recommendation:** Replace the hard drop with a score demotion (e.g. ×0.8–0.9 for missing cover), or only drop cover-less candidates whose score is below the top cover-less candidate by a margin; at minimum exempt candidates above a high-confidence score threshold and candidates from the ASIN-direct path.
+
+**Citations:**
+- internal/metafetch/service_search.go:487-497
+- internal/metafetch/service_search.go:526-539
+- internal/metafetch/service_search.go:456
+
+### QUAL-7 — Fetch-race guard is instance-level (useLibraryQuery), not a shared abstraction — the pagination-race class is not structurally fixed (Low)
+
+**Detail:** The PR #1706 page-size race fix landed as a hand-rolled `latestRequestIdRef` guard inside `useLibraryQuery` (:76, checked at :145/:185/:199). Other data-loading pages (Authors.tsx:317-332, Series, Works — grep shows zero requestId/AbortController/ignore-flag usage in pages/) use bare async-effect + setState with no staleness guard. Today those are mostly parameterless single fetches, so exposure is low, but the moment any of them gains server-side search/pagination params the same race recurs. There is no shared useAsyncData/query hook and no React Query-style library, so each new fetcher re-decides whether to guard.
+
+**Recommendation:** Extract the requestId/abort pattern from `useLibraryQuery` into a shared hook (or adopt TanStack Query for list endpoints) so the class is fixed once; lint or review-checklist new useEffect+fetch combinations.
+
+**Citations:**
+- web/src/hooks/useLibraryQuery.ts:76
+- web/src/hooks/useLibraryQuery.ts:145
+- web/src/pages/Authors.tsx:317
+- web/src/pages/Authors.tsx:330
+
+## Steelman and Design
+
+The specialist reports included empty `steelman` and `design` fields for this phase — no additional content to reproduce. The counter-argument findings (CTR-1 through CTR-4) serve as the design-critique component of this dimension, and each includes an acknowledgment of the design's real benefit (e.g. the 10GB→2GB RSS win from memdb stripping in CTR-2, wiring convenience in CTR-4) before the counter-argument.

--- a/docs/consultancy/05-features.md
+++ b/docs/consultancy/05-features.md
@@ -1,0 +1,266 @@
+<!-- file: docs/consultancy/05-features.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 40d501df-868a-4c5f-9ed4-cb64c1c6ff1c -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Feature Portfolio (2026-07-02)
+
+Evaluation run by a read-only multi-agent workflow; findings cited as `file:line` against the repository at the evaluation date. This dimension covers two reports: **do/defer/kill verdicts on deferred work** (FEAT-) and **missing-feature proposals** (NEWF-), followed by portfolio-optimization guidance.
+
+## Executive Summary
+
+Two specialist reports converge on the same portfolio thesis: for a personal ~50K-book organizer that just survived an OpenAI quota-out and cut over to local Ollama, **the highest-leverage work is not new surfaces but closing data-quality loops the docs already identify as blockers** — and several deferred items on the board are actively hazardous to run now.
+
+On the deferred-work side: the **ai-responses-migration ×5** workstream should be killed/indefinitely deferred — it migrates toward OpenAI's `/v1/responses` endpoint shape while the only working backend (Ollama, reached via the OpenAI-compatible `base_url` override at `internal/ai/openai_parser.go:85-87`) serves only `/v1/chat/completions`; migrating would break the sole functioning backend. **Dedup C8** auto-bug-filing stays correctly deferred behind the CONS-10 backfill gate and should be downgraded from GitHub-issue filing to an in-app dry-run report. **CONS-13** flat-key shim retirement is the one clear "do": small, briefed, cheap permanent-debt removal once its 1-week stability gate is verified. The **pluggable-workflow subsystem** stays deferred except WF-2 (capability declarations), which just acquired a concrete driver in the backend-mode toggle. The **Plex-style API** is deferred (no spec, no consumer, book identity mid-repair), and the **Postgres research tracks** (4.1/4.7) should be collapsed into a one-paragraph decision record — they contradict the PebbleDB-primary mandate with no driving pain.
+
+On the missing-feature side, the top three proposals all close loops: (1) a **fingerprint-coverage campaign + KPI** — ~8,387 unfingerprinted books block the AcoustID dedup veto, the status doc calls coverage "the real lever," yet TODO.md tracks nothing; (2) the **LLM/embedding backend-mode toggle** — the only remaining single point of failure from the OpenAI outage; (3) a **bulk metadata-review queue** — ~40% of transcribed books have low-quality metadata and review today is strictly one-by-one. A unified **library-health dashboard** would tie the quality signals together. On the over-built side: the deprecated `dedup.embed-async` op is still nightly-scheduled at 03:00 against the quota-dead OpenAI Batch API (recurring 429 noise every night), `GeneratePlaylistsForSeries` is a dead stub, and the backlog itself needs reconciliation — "duration/filesize aggregation" is already shipped, while the P4 bugs (BUG-1/QUAL-2) that should outrank every feature here are untracked in TODO.md.
+
+Advisor verification (below) spot-checked the key citations and confirmed the verdicts as well-calibrated, with two minor adjustments reflected inline: FEAT-6's "kill" overstates the change (4.1/4.7 are already `[hold]`-tagged), and NEWF-5 slightly undersells urgency (the nightly cron 429s every night).
+
+## Advisor Verification
+
+The engagement advisor's boundary assessment for this phase, reproduced and reflected in the findings below:
+
+- **Spot-checks pass:** `openai_parser.go:85-87` base_url override, `embed_async.go:23-37` nightly 03:00 deprecated op, and `embed_scan.go:73/90` confirming it submits to the OpenAI Batch API (Ollama serves neither `/v1/batches` nor `/v1/responses`) — so the FEAT-1 kill verdict and NEWF-5 are both solid.
+- **Citations verified verbatim:** TODO.md:173/1722/1728/1734 match. BUG-1/QUAL-2 and "fingerprint coverage" are genuinely absent from TODO.md, confirming NEWF-1 and NEWF-9.
+- **Minor quibble 1 (FEAT-6):** "kill" overstates the change — TODO items 4.1/4.7 are already `[hold]`-tagged; the recommendation is really a consolidation of already-parked items into a decision record, not a status change.
+- **Minor quibble 2 (NEWF-5):** urgency is slightly undersold — the nightly cron will 429 every night against the quota-dead OpenAI account, adding recurring error noise, so retirement is an ops-hygiene item, not merely cleanup.
+- **No overreach found; verdicts are well-calibrated.**
+
+## Verdicts on Deferred Work
+
+| Item | Verdict | Rationale (one line) |
+|---|---|---|
+| ai-responses-migration ×5 (AI-RESP-A/B/D/E/F) | **KILL / indefinite defer** | Targets `/v1/responses`, which Ollama (the only working backend) does not serve; Batch API path is quota-dead |
+| Dedup C8 auto-bug-filing | **DEFER** (correctly gated) | Hard-blocked on CONS-10 backfill; re-scope to dry-run report, drop GitHub-filing credential surface |
+| CONS-13 flat-key shim retirement | **DO** (after gate) | Effort S, fully briefed, clean rollback; verify 1-week stability window + frontend grep first |
+| Pluggable-workflow subsystem (WF-2..WF-6) | **DEFER subsystem; pull WF-2 forward** | WF-2 capability declarations have a live consumer (backend-mode toggle); WF-5 UI builder must not start |
+| Plex-style HTTP media API (3.8) | **DEFER** | No spec, no named consumer, L-size external surface while book identity is mid-repair |
+| Postgres eval (4.1) + per-workload store eval (4.7) | **KILL as standing items** (already `[hold]`; consolidate) | Contradicts PebbleDB-primary mandate; no driving pain at 50K books; fold into one decision record |
+
+## Findings Table
+
+| ID | Severity | Impact | Effort | Title |
+|---|---|---|---|---|
+| NEWF-1 | high | high | medium | Missing: fingerprint-coverage campaign op + coverage KPI (unblocks dedup auto-resolution) |
+| NEWF-2 | high | high | medium | Missing: LLM/embedding backend-mode toggle — single remaining SPOF from the OpenAI outage |
+| NEWF-3 | medium | high | high | Missing: bulk metadata-review queue (middle ground between auto-fetch and one-by-one dialog) |
+| NEWF-4 | medium | medium | medium | Missing: unified library-health / data-quality dashboard |
+| NEWF-5 | medium | medium | low | Over-built/stale: deprecated dedup.embed-async still nightly-scheduled against quota-dead OpenAI Batch API |
+| NEWF-6 | medium | medium | low | Portfolio optimization: park ai-responses-migration ×5; trim workflow subsystem to WF-2 only |
+| NEWF-7 | low | medium | high | Missing: consumption/player integration (progress-sync API) — foundations built, no consumer |
+| NEWF-9 | low | low | low | Backlog hygiene: duration/filesize aggregation already shipped; memory/TODO reconciliation needed (BUG-1/QUAL-2 untracked) |
+| NEWF-8 | info | medium | high | Community acoustic-fingerprint index: high-value differentiator, hard-gate on NEWF-1 coverage |
+| FEAT-1 | info | low | high | ai-responses-migration ×5 (AI-RESP-A/B/D/E/F): kill / indefinite defer |
+| FEAT-2 | info | low | medium | dedup C8 auto-bug-filing: defer (correctly gated); consider downgrading to a report op |
+| FEAT-3 | info | low | low | CONS-13 flat-key config shim retirement: do, once the 1-week gate is verified |
+| FEAT-4 | info | medium | medium | Pluggable-workflow subsystem: defer the subsystem; pull WF-2 (capability declarations) forward |
+| FEAT-5 | info | medium | high | Plex-style HTTP media server API (3.8): defer — no spec, no consumer, wrong time |
+| FEAT-6 | info | low | low | PostgreSQL research track (4.1) + per-workload store eval (4.7): consolidate already-held items into a decision record |
+
+---
+
+## Deferred-Work Verdicts (FEAT-)
+
+### FEAT-1 — ai-responses-migration ×5 (AI-RESP-A/B/D/E/F): kill / indefinite defer
+
+**Verdict: KILL / indefinite defer.**
+
+The migration's rationale (TODO.md:1538-1546: new models ship `/v1/responses`-first, `PreviousResponseID` token savings) assumed OpenAI as the live backend. OpenAI is now 429 `insufficient_quota` and the primary is local Ollama at 172.16.3.22, reached via the OpenAI-compatible `base_url` override in `openai_parser.go:85-87` (`OPENAI_BASE_URL`) — Ollama serves `/v1/chat/completions`, not `/v1/responses`, so migrating A/B/E/F would break the only working backend. AI-RESP-D (Batches) is doubly dead: `openai_batch.go` targets the OpenAI Batch API, which is unusable at zero quota (the status doc explicitly routes re-embed via `dedup.embed-scan`, NOT `embed-async`, for this reason). The pending LLM backend-mode toggle (status doc Pending #1) also needs the Chat Completions shape for its local-only mode.
+
+Advisor verification confirmed the load-bearing facts directly: `embed_scan.go:73/90` shows the async path submits to the OpenAI Batch API, and Ollama serves neither `/v1/batches` nor `/v1/responses`.
+
+**Recommendation:** Do not greenlight. Keep the briefs archived and AI-RESP-C (never migrate `embedding_client.go`) as a marker. Re-open only if (1) OpenAI quota is restored AND (2) the backend-mode toggle exists so `/v1/responses` can be an OpenAI-mode-only code path behind a provider abstraction. Sequence the backend-mode toggle first; it subsumes most of the value.
+
+**Citations:**
+- TODO.md:1538-1556
+- docs/agent-tasks/ai-responses-migration/README.md:1
+- internal/ai/openai_parser.go:85-87
+- docs/status/2026-07-02-local-cutover-and-matching.md:10-14
+- docs/status/2026-07-02-local-cutover-and-matching.md:70-77
+
+### FEAT-2 — dedup C8 auto-bug-filing: defer (correctly gated); consider downgrading to a report op
+
+**Verdict: DEFER (correctly gated); re-scope when unblocked.**
+
+C8 clusters `not_dup` labeled examples and files one GitHub issue per systematic false-positive cluster. It is hard-blocked on the prod labeled-dataset backfill, which is itself behind the CONS-10 drain sequence (duration-backfill + re-scan, a DATA-LOSS-gated prod operation per TODO CONS-10). The brief is well-designed (dry-run default, confirm-backfill-done flag) but the deliverable is questionable for a single-operator project: no GitHub-issue machinery exists in `internal/` (TASK-05:42-44), so it adds a new dependency and a token-bearing prod-to-GitHub write path purely to replace what the existing C6 label-review UI (`DedupLabels.tsx`, shipped) already surfaces interactively.
+
+**Recommendation:** Keep deferred; do not greenlight until CONS-10 backfill completes. When unblocked, re-scope: ship only the clustering + dry-run report (log/endpoint output), and add real GitHub filing only if triage volume proves the UI insufficient. That halves effort and removes the new credential surface.
+
+**Citations:**
+- TODO.md:432-434
+- docs/agent-tasks/dedup-dataset/TASK-05-autobug-not-dup-clusters.md:8-15
+- docs/agent-tasks/dedup-dataset/TASK-05-autobug-not-dup-clusters.md:42-44
+
+### FEAT-3 — CONS-13 flat-key config shim retirement: do, once the 1-week gate is verified
+
+**Verdict: DO (after two pre-flight checks).**
+
+Removes `legacyRemapGroup`/`configRemapGroups`/`applyLegacyRemaps` in the config update service so only nested config keys are accepted. Effort S, single-file plus tests, fully briefed with a clean rollback (revert restores compat). The only real risk is a client still sending flat keys — fields would silently stop applying (TASK-05:14-18) — and the brief already mandates the frontend grep (TASK-05:89-98) and a human-confirmed 1-week prod-stability window. Note the brief's target path (`internal/config/update_service.go`) and TODO.md:173 (`internal/server/update_service.go`) disagree — the executing agent must resolve which file actually holds the shim before editing.
+
+**Recommendation:** Greenlight after two checks: (1) grep prod logs / frontend for any flat-key payload in the last week; (2) reconcile the file-path discrepancy between TODO.md:173 and the brief. Then dispatch as-is. This is the cheapest permanent-debt removal in the portfolio; still ranks below BUG-1/QUAL-2.
+
+**Citations:**
+- TODO.md:173
+- docs/agent-tasks/perf-cleanup/TASK-05-retire-flatkey-shim.md:10-21
+- docs/agent-tasks/perf-cleanup/TASK-05-retire-flatkey-shim.md:89-98
+
+### FEAT-4 — Pluggable-workflow subsystem: defer the subsystem; pull WF-2 (capability declarations) forward
+
+**Verdict: DEFER subsystem; carve out WF-2.**
+
+TODO.md:283-285 already carries the correct stance: evolve UOS (op registry + plugins + the now-landed PR #1440 dependency scheduling, flag-off, commit 8282f818 per WF-1), resist Temporal/Conductor (breaks single-binary deploy), no code before a WF-0 brainstorm→spec session. WF-3 (persisted Workflow objects) and especially WF-5 (UI workflow builder, "biggest single cost") have no forcing function today. But WF-2 — action-level `requires: [ollama, openai, fpcalc]` declarations — just acquired a concrete driver: the OpenAI→Ollama cutover and the pending LLM backend-mode toggle (status doc Pending #1) both need per-op backend gating, which is currently ad-hoc (`SetOllamaAvailable`, `toolRegistry.Available` checks per TOOL-6).
+
+**Recommendation:** Keep WF-0 as the gate for WF-3/4/5/6 (defer). Carve WF-2 out and design it together with the LLM backend-mode toggle — one small mechanism serving an immediate need, de-risking the larger subsystem later. Do not start WF-5 under any priority scheme this quarter.
+
+**Citations:**
+- TODO.md:281-296
+- docs/agent-tasks/BREAKDOWN-2026-07-01.md:129
+- docs/status/2026-07-02-local-cutover-and-matching.md:70-72
+
+### FEAT-5 — Plex-style HTTP media server API (3.8): defer — no spec, no consumer, wrong time
+
+**Verdict: DEFER.**
+
+A one-line backlog entry (TODO.md:1722, size L) with no spec, no named client (no Plexamp/Prologue/Audiobookshelf-app target), and no design doc anywhere in `docs/specs/`. BREAKDOWN-2026-07-01.md:130 correctly classifies it as needs-brainstorm ("new external-facing subsystem"). It would add streaming/range-request, external auth, and library-browse API surface to a server whose core identity data is mid-repair: 380K mislabeled dedup candidates awaiting the CONS-10 drain, 49K iTunes-fragmented books awaiting re-group, ~8,387 books unfingerprinted. Serving a media API over unstable book identity bakes churn into external clients.
+
+**Recommendation:** Defer until the data-quality tracks (CONS-10 drain, iTunes re-group, fingerprint coverage) complete. Before any build: a brainstorm session that first evaluates exposing the existing REST API to one concrete client app vs. implementing a Plex/Audiobookshelf-compatible protocol — the latter only if a real playback client is named as the consumer.
+
+**Citations:**
+- TODO.md:1722
+- docs/agent-tasks/BREAKDOWN-2026-07-01.md:130
+
+### FEAT-6 — PostgreSQL research track (4.1) + per-workload store eval (4.7): consolidate already-held items into a decision record
+
+**Verdict: retire as standing backlog items.** (Per advisor verification: both items are already `[hold]`-tagged, so "kill" overstates the change — this is a consolidation of parked items, not a status reversal.)
+
+4.1 (XL, `[hold]`) and 4.7 (L, `[hold]`) are overlapping research tracks with no spec and no driving pain point. The architecture has since committed hard the other way: PebbleDB is the mandated sole production store (project memory: "always implement PebbleStore fully before shipping"), the memdb-optimization spec (`docs/specs/fable5-spec-memory-db-optimization.md`) invested in Pebble-side performance, vector data lives in Pebble's EmbeddingStore with chromem/HNSW as derived indexes (status doc:49-51), and SQLite is already legacy/stale. A Postgres migration would be the largest project in the backlog while every observed bottleneck (aggregates, cache warm-up, pagination caps) was fixed within the Pebble architecture. Keeping an XL "research" item alive invites periodic re-litigation cost.
+
+**Recommendation:** Remove 4.1 and fold 4.7 into a single one-paragraph decision record: "Pebble is primary; revisit only if a concrete relational/query requirement (multi-node, ad-hoc reporting, >500K books) emerges." That preserves the option without carrying an XL item on the board.
+
+**Citations:**
+- TODO.md:1728
+- TODO.md:1734
+- docs/agent-tasks/BREAKDOWN-2026-07-01.md:131
+- docs/status/2026-07-02-local-cutover-and-matching.md:49-51
+
+---
+
+## Proposed Features, Ranked (NEWF-)
+
+Ranked by leverage. Note the standing constraint from the P4 phase: bugs BUG-1/QUAL-2 outrank every item below (and are themselves untracked — see NEWF-9).
+
+### NEWF-1 — Missing: fingerprint-coverage campaign op + coverage KPI (unblocks dedup auto-resolution) — severity: high
+
+The status doc concludes the AcoustID dedup veto is "NOT viable at current coverage" (~65% of candidates have an unfingerprinted book; ~8,387 books unfingerprinted) and calls fingerprint coverage "the real lever." The mechanics exist — `fingerprint-rescan-missing` op (optimize.go:66), acoustid backfill plugin, per-book coverage fields (`ComputeFingerprintFields`, calculator.go:31) — but there is no library-wide coverage KPI, no campaign orchestration (rate-limited long-run over 8,387 books with perm-fail tombstone handling), and grep finds zero TODO.md items tracking it (advisor-confirmed). The single feature that converts 380K noisy dedup candidates into auto-resolvable pairs is untracked.
+
+**Recommendation:** Add a tracked workstream: (a) library-wide fingerprint-coverage stat in the system stats endpoint + Dashboard tile, (b) a resumable campaign op (reuse `fingerprint-rescan-missing` + acoustid backfill, honoring the 4,882 perm-fail tombstones), (c) re-run `ReevaluateAcoustIDConflicts` (#1736) when coverage crosses a threshold. Sequence before any new dedup feature and before the community index (NEWF-8).
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:64-66
+- docs/status/2026-07-02-local-cutover-and-matching.md:73-74
+- internal/plugins/maintenance/optimize.go:66
+- internal/fingerprint/calculator.go:31
+- internal/plugins/acoustid/backfill.go:247
+
+### NEWF-2 — Missing: LLM/embedding backend-mode toggle — single remaining SPOF from the OpenAI outage — severity: high
+
+The cutover to Ollama was done by hand-editing prod config (`embedding.base_url=http://172.16.3.22:11434/v1`, `metadata_scoring.llm_enabled=false`). Status doc pending item 1 specs the fix: a config enum + FE selector (disable-all / OpenAI-only / local-only / OpenAI+local-fallback) plus model-download prompt. Without it, any backend flap requires manual config surgery, and the LLM scoring feature stays globally disabled rather than falling back to qwen2.5:7b-instruct. This is the only planned feature that directly de-risks the incident that just happened.
+
+**Recommendation:** Build as specced in the status doc. Implement the fallback mode as a runtime health-check chain (reuse `ToolRegistry.Available` / `SetOllamaAvailable` gates from TOOL-6) rather than a static choice, so a dead backend degrades instead of erroring. This is also the concrete first consumer for WF-2 capability declarations (see NEWF-6 / FEAT-4).
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:70-72
+- docs/status/2026-07-02-local-cutover-and-matching.md:42-47
+
+### NEWF-3 — Missing: bulk metadata-review queue (middle ground between auto-fetch and one-by-one dialog) — severity: medium
+
+All metadata acceptance flows route through the per-book MetadataReviewDialog (e.g. the duration-mismatch chip at MetadataReviewDialog.tsx:604, cited from TODO.md:1469). With ~40% of transcribed books carrying low-quality/unparsed metadata (per the 2026-06-30 transcription status memory) and a pending scoped metadata refetch, reviewing tens of thousands of candidates one dialog at a time is the dominant remaining manual workflow. There is no triage queue: no "accept all candidates above confidence X", no batch-diff view, no keyboard-driven review stream. The differentiated residual-triage op (PH-2, TODO.md:103) generates populations to review but has no matching UI to consume them at scale.
+
+**Recommendation:** Build a review-queue page: server-side queue of (book, top-candidate, confidence, diff summary) sortable by confidence; bulk-accept above threshold with the existing persistent undo (AP-2); keyboard j/k/a/r flow for the gray zone. Feed it from PH-2 triage populations and the transcription quality gate. This multiplies the value of every upstream matching fix (#1734).
+
+**Citations:**
+- TODO.md:1469
+- TODO.md:103
+
+### NEWF-4 — Missing: unified library-health / data-quality dashboard — severity: medium
+
+Every data-quality signal lives in its own diagnostic endpoint: duration-mismatch scan (`GET /maintenance/scan-duration-mismatch`, TODO.md:1468), acoustid-conflict purge (`/dedup/purge-acoustid-conflicts`, #1736), per-book fingerprint coverage, transcription quality, embedding model-match (#1738). System stats expose only volume aggregates (totalDuration etc., system/handler.go:708). There is no single view answering "how healthy is my library and what should run next" — which is why gaps like the 8,387 unfingerprinted books and the stale 3072-dim vectors were discovered reactively during incidents rather than observed on a dashboard.
+
+**Recommendation:** Add a `GET /api/v1/library/health` endpoint aggregating counts: unfingerprinted, untranscribed/low-quality-transcript, embedding-model-stale, duration-mismatch, unresolved relinks, open dedup candidates by layer — each with a deep link to the fixing op. Render as a Dashboard section. Cheap to build (all counts derivable from existing stores; use the cached-aggregates + dirty-flag pattern already established).
+
+**Citations:**
+- internal/server/handlers/system/handler.go:708
+- TODO.md:1468
+- docs/status/2026-07-02-local-cutover-and-matching.md:23
+- internal/fingerprint/calculator.go:31
+
+### NEWF-5 — Over-built/stale: deprecated dedup.embed-async still nightly-scheduled against quota-dead OpenAI Batch API — severity: medium
+
+`embedAsyncDef` registers op `dedup.embed-async` ("Deprecated — use embed-scan with async:true") with `Schedule: "0 3 * * *"` — nightly submission of un-embedded books to the OpenAI Batch API. The status doc explicitly notes the cutover re-embed deliberately avoids this path because it "uses the OpenAI Batch API", and OpenAI is 429 `insufficient_quota`. The batch poller subsystem (batch_poller.go, batch_poller_register.go) exists to ingest results that will never arrive. Nightly failures at minimum generate noise; at worst they interact with the model-aware skip logic (#1738). Advisor verification adds urgency: the 03:00 cron will 429 **every night** against the quota-dead account — this is a recurring ops-hygiene problem, not passive cleanup.
+
+**Recommendation:** Retire the deprecated op ID now (its one-release grace window dates to 2026-06-10) and gate the async path + batch poller behind an "openai backend enabled" capability check — which falls out of NEWF-2's backend-mode enum. Verify on prod (server-logs) whether the 03:00 run is currently erroring nightly.
+
+**Citations:**
+- internal/plugins/dedup/embed_async.go:26-38
+- docs/status/2026-07-02-local-cutover-and-matching.md:55-57
+- internal/server/batch_poller_register.go:1
+- internal/plugins/maintenance/batch_poller.go:1
+
+### NEWF-6 — Portfolio optimization: park ai-responses-migration ×5; trim workflow subsystem to WF-2 only — severity: medium
+
+ai-responses-migration (Chat Completions → OpenAI `/v1/responses`, 5 tasks, already marked DEFERRED/optional at agent-tasks README:35) targets an API shape whose provider is quota-dead, while the now-primary Ollama backend is used precisely via OpenAI-compatible Chat Completions `/v1` (status doc prod config). Migrating to `/v1/responses` risks breaking local-backend compatibility for zero current benefit. Separately, the pluggable-workflow subsystem (TODO.md:281-292, EXPLORATORY, no code) spans WF-2..WF-6 including a UI workflow builder flagged as "biggest single cost"; only WF-2 (capability/requirement declarations `requires: [ollama, openai, fpcalc]`) has an immediate consumer — backend gating for NEWF-2/NEWF-5.
+
+**Recommendation:** Park ai-responses-migration until OpenAI is re-funded AND Ollama `/v1/responses` support is confirmed; record the decision in the workstream README. For workflows: build WF-2 only, defer WF-3..WF-5 indefinitely, and skip the WF-0 brainstorming session until a second concrete consumer exists. (Note: this differs slightly from FEAT-4, which keeps WF-0 as the gate for the rest of the subsystem; both agree WF-2 goes first and WF-5 does not start.)
+
+**Citations:**
+- docs/agent-tasks/README.md:35
+- TODO.md:281-292
+- docs/status/2026-07-02-local-cutover-and-matching.md:76-77
+
+### NEWF-7 — Missing: consumption/player integration (progress-sync API) — foundations already built, no consumer — severity: low
+
+A full listening-state model exists: `UserPosition` rows per file segment, `UserBookState` with auto-derived unstarted/in_progress/finished (≥95%) statuses, manual-override flags, and iTunes position sync (readstatus.go header). But the only writer is iTunes sync; there is no API for a modern player (Audiobookshelf/Plexamp-style, or the greenfield "Plex-style API" idea) to read the library or write positions, and no streaming/download endpoint pairing. Meanwhile the playlist package's series-playlist generator is a dead stub returning an error (playlist.go:34-37) since the fable5 SQLite removal. The organize/dedup half of the product is mature; the consume half is an unexposed data model plus dead code.
+
+**Recommendation:** Short term: delete `GeneratePlaylistsForSeries` (dead since T022). Medium term: greenfield-assess a minimal read/stream + position-write API (or an Audiobookshelf export/sync bridge) as the consumer for readstatus — spec first, no existing doc. Rank below NEWF-1..3.
+
+**Citations:**
+- internal/readstatus/readstatus.go:5-27
+- internal/playlist/playlist.go:28-37
+
+### NEWF-8 — Community acoustic-fingerprint index: high-value differentiator, hard-gate on NEWF-1 coverage — severity: info
+
+TODO.md:296-313 sketches a git-repo-backed community index ("AcoustID for audiobooks") with PR-bot loop, keyed on `internal/fingerprint/book_signature.go` whole-book signatures. It doubles as disaster recovery for the identity layer. But its value is proportional to local fingerprint coverage: with ~8,387 books unfingerprinted and 4,882 perm-fail tombstones, the exported index would be materially incomplete, and the open design questions (format, identity unit, governance, license) are all unresolved.
+
+**Recommendation:** Keep as needs-planning; schedule the brainstorming→spec session only after the NEWF-1 coverage campaign completes, so real coverage numbers inform the identity-unit and format decisions. Fold "disaster-recovery export of the identity layer" (fingerprints + verified metadata as a repo snapshot) out as a smaller standalone feature that does not need community governance.
+
+**Citations:**
+- TODO.md:296-313
+- docs/status/2026-07-02-local-cutover-and-matching.md:64-66
+
+### NEWF-9 — Backlog hygiene: "duration/filesize aggregation" is already shipped; memory/TODO reconciliation needed (and BUG-1/QUAL-2 untracked) — severity: low
+
+Two portfolio-tracking inaccuracies found. (1) The memory-listed missing feature "duration/filesize aggregation (Book shows snapshots not sums)" is implemented: `recompute-book-aggregates` job (MED-2) backfills sums and "PebbleStore BookFile create/update/delete hooks call RecomputeBookAggregates automatically" (recompute_book_aggregates.go:13-15; pebble_store_book_aggregates.go:138). Only residual: verify the `system:backfill:book_aggregates_v1_done` flag is set on prod. Similarly, the advisor-listed "unbuilt" tool-lifecycle/startup-wizard is fully shipped (TOOL-1..6, WIZ-1..3 all checked, PR #1465, TODO.md:263-279). (2) The P4 bugs BUG-1/QUAL-2 that should outrank all new features appear nowhere in TODO.md or docs/agent-tasks/ (grep: zero hits, advisor-confirmed) — they are untracked, violating the fix-or-document rule.
+
+**Recommendation:** One-time reconciliation pass: close the stale memory items, confirm the aggregates backfill flag on prod, and add BUG-1/QUAL-2 to TODO.md with root-cause hints so the prioritization rule (bugs before features) is enforceable.
+
+**Citations:**
+- internal/maintenance/jobs/recompute_book_aggregates.go:6-19
+- internal/database/pebble_store_book_aggregates.go:138
+- TODO.md:263-279
+
+---
+
+## Portfolio Optimization (What to Trim)
+
+Consolidated trim list, in order of ops urgency:
+
+1. **Retire `dedup.embed-async` now** (NEWF-5) — it 429s against OpenAI nightly at 03:00; gate the batch poller behind the backend-mode capability check. Ops-hygiene, effort low.
+2. **Park ai-responses-migration ×5** (FEAT-1 / NEWF-6) — record the decision in the workstream README; keep AI-RESP-C as a "never migrate embedding_client.go" marker.
+3. **Trim the workflow subsystem to WF-2 only** (FEAT-4 / NEWF-6) — WF-2 rides along with the backend-mode toggle; WF-3/4/5/6 stay behind WF-0; WF-5 (UI builder) does not start this quarter under any priority scheme.
+4. **Consolidate Postgres items 4.1 + 4.7** (FEAT-6) — both already `[hold]`; replace with a one-paragraph decision record naming the concrete re-open triggers (multi-node, ad-hoc reporting, >500K books).
+5. **Defer the Plex-style API** (FEAT-5) — and when revisited, evaluate exposing the existing REST API to one named client before building any Plex/Audiobookshelf-compatible protocol. NEWF-7's minimal position-write API is the smaller, better-grounded first step on the consumption side.
+6. **Delete dead code**: `GeneratePlaylistsForSeries` stub (NEWF-7).
+7. **Backlog reconciliation pass** (NEWF-9) — close stale memory items (duration/filesize aggregation, tool-lifecycle wizard), confirm the aggregates backfill flag on prod, and track BUG-1/QUAL-2 in TODO.md.
+
+Recommended build order for what remains: **BUG-1/QUAL-2 fixes → NEWF-2 backend-mode toggle (+WF-2) → NEWF-5 retirement (falls out of the toggle) → NEWF-1 fingerprint-coverage campaign → FEAT-3 CONS-13 shim retirement → NEWF-4 health dashboard → NEWF-3 bulk review queue**. Everything else waits on data-quality completion or a named consumer.

--- a/docs/consultancy/06-process-and-security.md
+++ b/docs/consultancy/06-process-and-security.md
@@ -1,0 +1,302 @@
+<!-- file: docs/consultancy/06-process-and-security.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4e1100f3-fcf8-47e2-86d7-d63f0dc1d80a -->
+<!-- last-edited: 2026-07-02 -->
+
+# Consultancy Evaluation — Process, Ops & Security (2026-07-02)
+
+This report was produced by a read-only multi-agent consultancy workflow evaluating the audiobook-organizer repository. Three specialist agents covered security/PII (SEC-), process/CI/docs (PROC-), and ops/cost (OPS-). All findings cite `file:line` locations verified against the working tree at evaluation time. No files outside this report were modified.
+
+## Executive Summary
+
+The security and process posture is materially **better than the stale June project memory suggests** — a central deliverable of this dimension is status reconciliation. Items SEC-2 ("auth disabled by default"), SEC-7 ("/cache/stats unauthenticated"), and PERF-7, all listed as open in the June audit-remediation memory, are **verified DONE**: `enable_auth` defaults true (`internal/config/config.go:519`), a WARN fires when auth is disabled (`internal/server/server_lifecycle.go:974`), `/cache/stats` sits behind `PermLibraryView` (TODO.md:1405), and the June-audit SEC-2 was renamed SEC-2-AUD (WriteStartupReadOnlyKey flag, default true, TODO.md:1406) after the ID collision was resolved in commit df2bd6f9. ARCH-4b (waves 1–3) and PERF-2b are likewise closed. **Nobody should re-fix these.** The genuinely open residue is small: SEC-AUDIT-11 (a GitHub-console CodeQL alert dismissal) and API-key rotation — which has **zero TODO.md tracking** despite bootstrap-issued keys being full-scope and permanent.
+
+The bootstrap auth flow is well-engineered post pen-test: raw tokens are never logged (CRIT-1 fixed), 10-minute TTL, hash-at-rest, one-time consume under mutex, per-IP rate limiting, and `SetTrustedProxies(nil)` blocking XFF spoofing. Remaining security gaps are the untracked key-rotation item, a pre-commit hook that claims to protect `.claude/.credentials/` but structurally cannot, weak (`$RANDOM`, ~27-bit) per-worktree credential passwords, internal-infrastructure PII saturating 27+ tracked files (a public-release blocker, acceptable while private), and a single `@main`-pinned reusable security workflow violating the repo's own SHA-pin policy.
+
+On process: the deflaking pattern is durable (root-cause fixes with regression proof, codified "never rerun-and-ignore" rule), the mockery v2-vs-v3 CI drift is resolved (though two docs still teach the old pin), and the 30% coverage gate exists but is weak — duplicate test run, swallowed output, static floor. Documentation drift is real: AI-REFERENCE.md claims 189 API routes against ~395 actual gin registrations and omits the Ollama/bge-m3 cutover entirely. **PROC-1 carries an explicit verdict: the untracked `docs/status/2026-07-02-local-cutover-and-matching.md` must be committed — and that commit is being executed in this very PR.**
+
+On ops: the deploy recipe (`Makefile.local` + `deploy/local.conf`, both gitignored) exists only on one laptop with no rollback path; the Windows GPU box at 172.16.3.22 is a triple single-point-of-failure (Whisper, embeddings, LLM) kept alive by an interactive-session scheduled task whose setup scripts live only in a scratchpad; the deprecated nightly `dedup.embed-async` op is still cron-scheduled against the quota-exhausted OpenAI Batch API; there is no cost/quota monitoring (the OpenAI exhaustion was discovered via runtime 429s); and `/metrics` exists but nothing scrapes it — prod observability is manual journalctl. The recurring meta-pattern is operational knowledge landing outside git.
+
+## Findings Table
+
+| ID | Severity | Impact | Effort | Title |
+|----|----------|--------|--------|-------|
+| SEC-1 | high | high | low | API-key rotation has zero tracking; bootstrap-issued full-scope keys never expire |
+| SEC-2 | medium | medium | low | Pre-commit hook claims to protect .claude/.credentials/ but does not |
+| SEC-3 | medium | medium | medium | Repo leaks internal infrastructure PII in 27+ files — public-release blocker |
+| SEC-4 | low | low | low | Per-worktree credential passwords generated with non-crypto $RANDOM (~27 bits entropy) |
+| SEC-5 | low | low | low | Reusable security workflow pinned to @main, violating the repo's SHA-pin policy |
+| SEC-6 | info | low | low | Status reconciliation: SEC-2/SEC-7/PERF-7 verified done; only SEC-AUDIT-11 and rotation remain open |
+| PROC-1 | high | high | low | Commit docs/status/2026-07-02-local-cutover-and-matching.md — verdict: COMMIT NOW |
+| PROC-2 | medium | medium | low | Deprecated nightly dedup.embed-async still cron-scheduled against quota-exhausted OpenAI Batch API |
+| PROC-3 | medium | medium | low | AI-REFERENCE.md drift: route count off by ~2x and no mention of the Ollama/local-embedding cutover |
+| PROC-4 | low | medium | medium | 30% coverage gate is real but weak: duplicate test run, swallowed output, static low bar |
+| PROC-5 | low | medium | low | Mockery pin drift is resolved in CI, but two docs still teach the old v2.53.6 pin and local targets don't enforce the version |
+| PROC-6 | medium | medium | low | API-key rotation has zero TODO.md tracking; stale memory reconciled |
+| PROC-7 | low | low | low | security.yml is the only workflow not SHA-pinned (uses @main) |
+| PROC-8 | info | low | low | Deflaking pattern is durable; installed pre-commit hook has drifted from the setup script |
+| OPS-1 | high | high | low | Deploy recipe is single-machine and has no rollback |
+| OPS-2 | high | high | medium | Windows GPU box is a triple single-point-of-failure held up by an interactive-session scheduled task |
+| OPS-3 | high | medium | low | Nightly dedup.embed-async still hardwired to OpenAI Batch API after Ollama cutover |
+| OPS-4 | medium | medium | medium | No cost/quota monitoring — OpenAI exhaustion was discovered by production failure |
+| OPS-5 | medium | medium | medium | /metrics exists but nothing scrapes it — no alerting layer at all |
+| OPS-6 | medium | medium | low | Recurring pattern: operational knowledge lands outside git |
+| OPS-7 | low | low | low | Agent dev-workflow is strong but CLAUDE.md triplicates rules and burns per-session tokens |
+
+## Security & PII Findings (SEC-)
+
+### SEC-1 — API-key rotation has zero tracking; bootstrap-issued full-scope keys never expire (high)
+
+**Detail:** `handleBootstrap` mints an API key with scopes = `auth.All()` and no `ExpiresAt` (bootstrap.go:340-349 sets ID/UserID/Name/TokenHash/Scopes/Status/CreatedAt only) — every bootstrap exchange produces a permanent god-key. Revocation exists (`DELETE /auth/api-keys/:id`, apikeys.go:314) and Create supports optional expiry, but there is no rotation endpoint, no max-age enforcement, and no re-key workflow. A grep for "rotation" in TODO.md returns nothing — the item the June audit memory lists as remaining is genuinely untracked. Given the `.claude/.api-token` file is shared across worktrees and repeatedly re-bootstrapped by agents, accumulated live full-scope keys in PebbleDB are the residual risk.
+
+**Recommendation:** Add a TODO.md item. Minimal fix: set `ExpiresAt` (e.g. 30d) on bootstrap-issued keys in `handleBootstrap`, and add a startup sweep that flags/expires active full-scope keys older than N days. Optional: `POST /auth/api-keys/:id/rotate` that atomically issues a new token and revokes the old.
+
+**Citations:**
+- internal/server/bootstrap.go:338
+- internal/server/bootstrap.go:340-349
+- internal/server/handlers/apikeys.go:314
+- internal/database/apikey_token.go:19-28
+
+### SEC-2 — Pre-commit hook claims to protect .claude/.credentials/ but does not (medium)
+
+**Detail:** The installed hook's `PROTECTED_FILES` array (setup-git-hooks.sh:17-22) contains only `.api-token`, `.claude/.api-token`, `.bootstrap-token`, `.readonly-key`. The success message (line 53) tells the user ".claude/.credentials/ (per-worktree username/password)" is protected, but the exact-match grep `^$FILE$` (line 27) can never match files inside a directory, and the directory is not in the array. `.gitignore:239` covers it as the primary defense, but a `git add -f` (which agents sometimes do to bypass ignore warnings) sails through the hook that the docs claim would block it. The same exact-match logic also misses these files staged from subdirectories.
+
+**Recommendation:** Add `.claude/.credentials/` to the array and change the match to a prefix test (`grep -q "^$FILE"` or case pattern), or match basenames anywhere in the tree. Add a generic content check for `abk_`/`abbs_` prefixes in staged diffs while there.
+
+**Citations:**
+- scripts/setup-git-hooks.sh:17-22
+- scripts/setup-git-hooks.sh:27
+- scripts/setup-git-hooks.sh:53
+- .gitignore:239
+
+### SEC-3 — Repo leaks internal infrastructure PII in 27+ files — public-release blocker (medium)
+
+**Detail:** `git grep` finds 172.16.x.x private IPs in 27 tracked files (docs/system/runbooks.md, incidents.md, scripts/transcribe_monitor.py, setup-ssh-from-mac.sh, skills/project-context/SKILL.md, docs/status/...) and 61 files containing the internal hostname "unimatrixzero" or `/mnt/bigdata` paths. Archived plans embed literal `ssh jdfalk@unimatrixzero.local` and `scp ... jdfalk@172.16.2.30` commands (failed-quarantine.md:1361-1362), exposing SSH username + host + home-dir layout. The new untracked docs/status/ file adds the Ollama box (172.16.3.22:11434). No live tokens or personal emails were found (docs use `abk_...` placeholders); `certs/localhost.key` is a documented snake-oil dev cert (certs/README.md warns explicitly). Risk is contingent: acceptable for a private repo, a blocker if published — and agents/pii-scanner.md exists precisely because this was anticipated.
+
+**Recommendation:** Keep the repo private, or before any public release run the existing pii-scanner agent and sweep: replace IPs/hostnames/usernames with `<your-server-ip>`/`<your-hostname>`/`<your-username>`, prioritizing docs/system/, docs/status/, scripts/, skills/. Note git history would also need rewriting.
+
+**Citations:**
+- docs/system/runbooks.md:61
+- docs/status/2026-07-02-local-cutover-and-matching.md:11
+- docs/status/2026-07-02-local-cutover-and-matching.md:43
+- docs/archive/superpowers/plans/2026-04-22-failed-quarantine.md:1361-1375
+- skills/project-context/SKILL.md:1
+
+### SEC-4 — Per-worktree credential passwords generated with non-crypto $RANDOM (~27 bits entropy) (low)
+
+**Detail:** `generate_password` picks 3 words from a 25-word list plus a 4-digit number using bash `$RANDOM` (a weak 15-bit LCG, often time-seeded): ~log2(25³ × 9000) ≈ 27 bits at best, less given `$RANDOM` predictability. These are real API-login credentials, typically used against localhost but `api_host` is configurable. Contrast: the Go server's `generateReadablePassword` (bootstrap.go:454-466) does the same word scheme but with `crypto/rand` and a 64-word list. Separately, `cred_file` (manage-credentials.sh:41-44) joins the raw branch name into the path — a branch like `feature/x` or `../x` escapes or fails outside `.claude/.credentials/` (username is sanitized at line 60, the filename is not).
+
+**Recommendation:** Generate the password from `/dev/urandom` (e.g. base64 of 16 bytes, or `openssl rand`) and sanitize the branch name for the filename the same way it is sanitized for the username.
+
+**Citations:**
+- scripts/manage-credentials.sh:22-38
+- scripts/manage-credentials.sh:41-44
+- internal/server/bootstrap.go:454-466
+
+### SEC-5 — Reusable security workflow pinned to @main, violating the repo's SHA-pin policy (low)
+
+**Detail:** A scan of `.github/workflows/*.yml` for non-SHA action refs finds exactly one: `falkcorp/github-common/.github/workflows/reusable-security.yml@main`. Everything else is pinned to 40-char SHAs, consistent with the repo's stated mandatory policy ("Pin all GitHub Action references to SHAs, not tags" in CLAUDE.md) and the recent burndown re-pin work (commit 28427b6f). The mutable `@main` ref is first-party (own org), which limits supply-chain exposure to a compromise of that repo — but it is the security workflow itself, so a malicious change there runs with this repo's secrets, and it contradicts the policy the repo enforces elsewhere.
+
+**Recommendation:** Pin reusable-security.yml to a commit SHA like the other refs; include it in the nightly-burndown re-pin routine so it doesn't drift stale.
+
+**Citations:**
+- .github/workflows (uses: falkcorp/github-common/.github/workflows/reusable-security.yml@main)
+- CLAUDE.md GitHub Operations section
+
+### SEC-6 — Status reconciliation: SEC-2/SEC-7/PERF-7 verified done; only SEC-AUDIT-11 and rotation remain open (info)
+
+> **Reconciliation notice — do not re-fix these items.** The stale June memory listed SEC-2, SEC-7, and PERF-7 as open. All three were verified DONE in this evaluation.
+
+**Detail:** The ID collision is resolved: original SEC-2 (auth-enabled default, TODO.md:1275) is done — `enable_auth` defaults true (config.go:519) and a WARN fires when disabled (server_lifecycle.go:974; the `:851` line ref in TODO.md is stale, code moved). The June-audit SEC-2 was renamed SEC-2-AUD (WriteStartupReadOnlyKey flag, default true, TODO.md:1406) and is shipped, as is SEC-7 (/cache/stats behind PermLibraryView, TODO.md:1405). ARCH-4b and PERF-2b listed as remaining in the June memory are also closed (TODO.md ARCH-4b waves 1-3, PERF-2b entries). Genuinely open: SEC-AUDIT-11 (TODO.md:1221 — CodeQL alert dismissal, a GitHub-console action, code work done) and API-key rotation (SEC-1 above, untracked). /metrics remains unauthenticated at server_lifecycle.go:907 by documented accepted risk (MED-1, noted at TODO.md:1405). The bootstrap flow itself is solid: no raw-token logging (CRIT-1 fixed, bootstrap.go:98-111,157-162), 10-min TTL, one-time consume, 5/hr/IP limit, `SetTrustedProxies(nil)` at server.go:351 prevents XFF rate-limit bypass.
+
+**Recommendation:** Update the stale June memory/audit doc to match TODO.md; add a one-line TODO entry for SEC-AUDIT-11's console action and for key rotation so nothing lives only in memory files.
+
+**Citations:**
+- TODO.md:1275
+- TODO.md:1405-1406
+- internal/config/config.go:519
+- internal/server/server_lifecycle.go:974
+- TODO.md:1221
+- internal/server/server_lifecycle.go:907
+
+## Process, CI & Documentation Findings (PROC-)
+
+### PROC-1 — Commit docs/status/2026-07-02-local-cutover-and-matching.md — verdict: COMMIT NOW (high)
+
+> **Note:** This verdict is being executed in this very PR — the status doc is committed as part of the consultancy change set.
+
+**Detail:** The file is untracked yet is the only written record of production-critical operational knowledge: the prod embedding config (base_url 172.16.3.22:11434, bge-m3, 1024-dim), the fact that Ollama survives only via the interactive-session scheduled task "OllamaServe", the PowerShell `-EncodedCommand` gotcha, and re-embed state. Its own Pending section (line 75) notes the Windows Ollama setup scripts exist only in a scratchpad. If the working tree or scratchpad is lost, reconstructing the local-backend cutover requires reverse-engineering a Windows box. The docs/status/ pattern itself is sound (dated, versioned header) — but only if tracked.
+
+**Recommendation:** Commit docs/status/ immediately (docs commit, no code risk). In the same change, commit the Windows Ollama scripts as `scripts/manage-ollama-windows.py` per the file's own TODO, so the doc and the automation land together.
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:30-47
+- docs/status/2026-07-02-local-cutover-and-matching.md:37-38
+- git status: `?? docs/status/`
+
+### PROC-2 — Deprecated nightly dedup.embed-async still cron-scheduled against quota-exhausted OpenAI Batch API (medium)
+
+**Detail:** `embedAsyncDef` registers `dedup.embed-async` with Schedule `"0 3 * * *"` (nightly 03:00) and its own DisplayName marks it "[deprecated — use embed-scan with async:true]". It delegates to `runEmbedScanMode(async=true)`, which per the status doc uses the OpenAI Batch API — the backend that is 429 insufficient_quota. Every night this op fires, fails against a dead backend, and generates error noise that can mask real failures; `ResumeRequeue` means it also re-queues after restarts. The live cutover path (`dedup.embed-scan` sync) does not need it.
+
+**Recommendation:** Remove or nil the Schedule on embed-async (or gate scheduling on the embedding backend being OpenAI and quota-healthy). Since the op is self-described as deprecated, deleting the nightly cron is the low-risk option; keep the op invocable manually.
+
+**Citations:**
+- internal/plugins/dedup/embed_async.go:24
+- internal/plugins/dedup/embed_async.go:27-36
+- docs/status/2026-07-02-local-cutover-and-matching.md:55-57
+
+### PROC-3 — AI-REFERENCE.md drift: route count off by ~2x and no mention of the Ollama/local-embedding cutover (medium)
+
+**Detail:** The header claims "Last updated: 2026-07-01 | Total API routes: 189", but a count of gin `.GET/.POST/.PUT/.DELETE/.PATCH` registrations across non-test files in internal/server (including wire_*_routes.go) yields ~395. Grep for "ollama" or "bge-m3" in AI-REFERENCE.md returns nothing; the doc still presents OpenAI as the AI backend (line 31 "→ AI parser → OpenAI API"; line 85 OpenAIParser; line 451 "AUTHOR dedup via OpenAI batch API"). Since the file's stated purpose is "Read this before making any changes" and every agent session loads it via the project-context skill, drift here propagates wrong assumptions into every automated task.
+
+**Recommendation:** Update the route count (or replace the hardcoded number with a "see wire_*_routes.go" pointer generated by a make target), and add an "Embedding/LLM backends" section covering the Ollama primary, bge-m3 1024-dim, and the stale embeddings.db SQLite. Consider a lightweight CI drift check comparing the header route count against a grep count.
+
+**Citations:**
+- docs/AI-REFERENCE.md:6
+- docs/AI-REFERENCE.md:31
+- docs/AI-REFERENCE.md:85
+- docs/AI-REFERENCE.md:451
+
+### PROC-4 — 30% coverage gate is real but weak: duplicate test run, swallowed output, static low bar (low)
+
+**Detail:** `coverage-check-short` re-runs `go test ./... -short` with `>/dev/null 2>&1` (Makefile:311) even though `make ci` (line 321) already ran test-all-short — doubling CI wall time — and any compile/test failure at the gate step produces no diagnostics, just a make failure with an empty screen. The 30% total-percentage threshold is a floor, not a signal: it cannot regress meaningfully (a large low-coverage package addition barely moves total %) and cannot catch a specific package dropping to 0%. It is meaningful only as a "tests still compile and run" tripwire.
+
+**Recommendation:** Have test-all-short emit coverage.out and make coverage-check-short consume it instead of re-running tests; drop the output redirect so failures are visible. Longer term, replace the flat 30% with a ratchet (fail if coverage drops >0.5% from committed baseline) or per-package floors on the packages that matter (dedup, database, server/handlers).
+
+**Citations:**
+- Makefile:309-318
+- Makefile:321
+
+### PROC-5 — Mockery pin drift is resolved in CI, but two docs still teach the old v2.53.6 pin and local targets don't enforce the version (low)
+
+**Detail:** CI now installs mockery v3.7.1 (ci.yml:83) matching Makefile comments and setup-mockery.sh — the v2/v3 drift in project memory is stale/fixed (PR #1718, CHANGELOG:62). Two residues: (1) docs/agent-tasks/ci-flaky-fixes/README.md still tells agents that CI pins "mockery/v2@v2.53.6" — an agent following that brief would reintroduce the exact repo-wide mock-churn footgun the brief warns about; (2) `make mocks` and `mocks-check` invoke whatever `mockery` is on PATH with only a comment ("check mockery version", Makefile:193) as protection — the historical failure mode was precisely a local binary at the wrong version.
+
+**Recommendation:** Update ci-flaky-fixes/README.md (TASK-01 is done — archive it). Add a version guard to the mocks/mocks-check targets: fail fast if `mockery version` != v3.7.1, or invoke via `go run github.com/vektra/mockery/v3@v3.7.1` so the pin is self-enforcing.
+
+**Citations:**
+- .github/workflows/ci.yml:83
+- Makefile:194-196
+- Makefile:203-205
+- scripts/setup-mockery.sh:8
+- docs/agent-tasks/ci-flaky-fixes/README.md:24-31
+
+### PROC-6 — API-key rotation has zero TODO.md tracking; stale memory reconciled (medium)
+
+> **Reconciliation notice (duplicate confirmation of SEC-6):** SEC-2, SEC-7, SEC-2-AUD, PERF-7, and PERF-2b are all marked done in TODO.md — the June memory listing them open is stale. Do not re-fix.
+
+**Detail:** Reconciliation confirmed: SEC-2 (auth-disabled WARN, TODO.md:1275), SEC-7 (/cache/stats behind PermLibraryView, TODO.md:1405), SEC-2-AUD (WriteStartupReadOnlyKey flag default true, TODO.md:1406), PERF-7 (TODO.md:1404) and PERF-2b (TODO.md:1398) are all marked done — the June memory file listing them open is stale. The genuinely open items are ARCH-4b residual (acoustid/reset_all.go, TODO.md:38 and the 2026-07-01 annotation at TODO.md:1395) and API-key rotation, which is completely untracked: grep for "rotation"/"rotate" in TODO.md returns nothing. Given `.claude/.api-token` is shared across worktrees with only an 8-hour auto-cleanup convention, rotation is a real residual audit item with no owner.
+
+**Recommendation:** Add a SEC-9 (or similar) TODO.md entry for API-key rotation/expiry (server-side key TTL + rotation endpoint), so the burndown bot can pick it up. Update the June audit-remediation memory note to reflect PERF-7/SEC-7/SEC-2 closure.
+
+**Citations:**
+- TODO.md:1275
+- TODO.md:1404-1406
+- TODO.md:38
+- TODO.md:1395
+
+### PROC-7 — security.yml is the only workflow not SHA-pinned (uses @main) (low)
+
+**Detail:** All other workflow refs are SHA-pinned with version comments (e.g. ci.yml:31, nightly-burndown.yml:28 re-pinned in commit 28427b6f, frontend-ci.yml:45). security.yml:30 references `falkcorp/github-common/.github/workflows/reusable-security.yml@main` — a mutable ref that violates the repo's own mandatory SHA-pinning rule (CLAUDE.md "Pin all GitHub Action references to SHAs, not tags"). Ironically it is the security workflow itself. Reusable workflows at @main also break reproducibility of past runs. (Same underlying issue as SEC-5, reported from the process angle.)
+
+**Recommendation:** Pin reusable-security.yml to the current github-common main SHA with a version comment, matching the pattern used in the other 8 workflows.
+
+**Citations:**
+- .github/workflows/security.yml:30
+
+### PROC-8 — Deflaking pattern is durable; installed pre-commit hook has drifted from the setup script (info)
+
+**Detail:** Positive: flaky tests are fixed at root cause with regression proof (dead os.Chdir race #1711; missing WaitForWarmup #1713; June 17/19 memdb-warmup flakes fixed at source), the rule "do not rerun-and-ignore, prove with -count=20" is codified in the workstream brief, and the residual known race (PEBBLE-CLOSED-SHUTDOWN-RACE) was filed then fixed (commit 5b90d2f6 lineage). One hygiene gap: the installed `.git/hooks/pre-commit` protects .api-token/.bootstrap-token but lacks `.readonly-key`, which the current scripts/setup-git-hooks.sh includes — hooks are copied, not referenced, so script updates never reach installed hooks.
+
+**Recommendation:** Re-run scripts/setup-git-hooks.sh in each checkout/worktree, or better, switch to `git config core.hooksPath scripts/hooks` with a versioned hook so updates propagate automatically.
+
+**Citations:**
+- docs/agent-tasks/ci-flaky-fixes/README.md:21-23
+- CHANGELOG.md:62
+- CHANGELOG.md:75
+- scripts/setup-git-hooks.sh:17-22
+- .git/hooks/pre-commit:4-8
+
+## Ops & Cost Findings (OPS-)
+
+### OPS-1 — Deploy recipe is single-machine and has no rollback (high)
+
+**Detail:** `make deploy` (Makefile.local:13-21) cross-compiles, scp's the binary, then `sudo mv` overwrites /usr/local/bin/audiobook-organizer and restarts systemd. No copy of the previous binary is kept, there is no rollback/versioned-release target — rollback means rebuilding an older commit locally. Both Makefile.local and deploy/local.conf are gitignored (verified via `git check-ignore`), yet local.conf explicitly says "It is NOT a template — it reflects the actual prod server" — the full prod ExecStart (TLS paths, DB path, WHISPER_REMOTE_URL, TimeoutStopSec) exists only on this one laptop. Loss of the machine loses the deploy pipeline.
+
+**Recommendation:** Commit a sanitized deploy/local.conf template plus a documented deploy runbook; add a deploy step that keeps the prior binary as /usr/local/bin/audiobook-organizer.prev and a `make rollback` target that swaps it back and restarts. Consider stamping deployed version (git describe is already in ldflags) into a /health field for verification.
+
+**Citations:**
+- Makefile.local:13-21
+- deploy/local.conf:10-11
+
+### OPS-2 — Windows GPU box is a triple single-point-of-failure held up by an interactive-session scheduled task (high)
+
+**Detail:** 172.16.3.22 now serves three production dependencies: Whisper transcription (WHISPER_REMOTE_URL in local.conf, itself started manually per a comment: `$env:WHISPER_PORT=...; uv run whisper_server.py`), bge-m3 embeddings, and the qwen2.5 LLM. Ollama survives only via scheduled task "OllamaServe" bound to an interactive session for GPU access — a logoff, reboot, or Windows Update silently kills embeddings and LLM. The setup/start scripts (setup-ollama.ps1, start-ollama.ps1) exist only in a session scratchpad (status doc lines 37-38, explicit TODO). Whisper's launcher appears equally ad-hoc. There is no health check on the server side alerting when 172.16.3.22 goes dark; embed failures would surface only as op errors in journalctl.
+
+**Recommendation:** Immediately commit the Windows management scripts as scripts/manage-ollama-windows.py (already TODO'd). Configure the scheduled task with "run whether user is logged on or not" + restart-on-failure, or move Ollama to a Windows service wrapper (NSSM). Add a periodic reachability probe of :11434 and :19847 exposed via /metrics so an outage is visible.
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:30-38
+- deploy/local.conf:26-28
+
+### OPS-3 — Nightly dedup.embed-async still hardwired to OpenAI Batch API after Ollama cutover (high)
+
+**Detail:** embed_async.go:36 schedules `"0 3 * * *"` and delegates to `runEmbedScanMode(async=true)`, which calls `EmbedBooksAsync` → `CreateEmbeddingBatch` against the OpenAI Batch API (Ollama's /v1 has no Batch endpoint). With OpenAI quota exhausted this fails every night at 03:00 ("submit embedding batch: 429") — pure ops noise. Worse: if quota is ever restored while the in-flight bge-m3 re-embed is incomplete, the batch would ingest 3072-dim OpenAI vectors into the 1024-dim index. The async skip check (engine.go:2306-2309) compares only TextHash, not embedding model — the model-aware skip shipped in #1738 applies to the sync path only, so the two paths disagree on what "needs embedding" means. (Overlaps PROC-2; this version adds the dimension-contamination risk.)
+
+**Recommendation:** Gate the nightly async op on the configured embedding backend: when embedding.base_url points at a non-OpenAI backend, either no-op with a logged skip or delegate to the sync path. Make the async skip model-aware to match #1738. Fold this into the pending LLM backend-mode toggle work.
+
+**Citations:**
+- internal/plugins/dedup/embed_async.go:24-38
+- internal/dedup/engine.go:2306-2323
+- internal/plugins/dedup/embed_scan.go:73-90
+
+### OPS-4 — No cost/quota monitoring — OpenAI exhaustion was discovered by production failure (medium)
+
+**Detail:** The cutover was forced, not planned: 429 insufficient_quota at runtime is the only spend signal that exists. A repo-wide search finds no cost, spend, or pricing tracking in code or docs — no per-op token accounting, no budget threshold, no quota alert. The economics actually favor local for this workload (a full ~29K-book re-embed on an owned RTX 2060 Super costs ~zero marginal dollars, and embedding text is short metadata strings), but the trade was paid in fragility (OPS-2) and unquantified quality (bge-m3 1024-dim vs text-embedding-3-large 3072-dim — no dedup-recall comparison recorded). The pending backend-mode toggle (status doc, Pending #1) is the right vehicle for an OpenAI-fallback posture but has no code yet.
+
+**Recommendation:** Keep local as primary — the economics are sound. Add: (a) a token/request counter per AI backend exposed on /metrics, (b) the backend-mode toggle with OpenAI+local-fallback so a restored OpenAI key is a config change not a code change, (c) a one-time dedup-recall spot-check comparing bge-m3 vs archived OpenAI embeddings before deleting legacy vectors.
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:10-14
+- docs/status/2026-07-02-local-cutover-and-matching.md:68-77
+
+### OPS-5 — /metrics exists but nothing scrapes it — no alerting layer at all (medium)
+
+**Detail:** server_lifecycle.go:907 registers an unauthenticated promhttp handler with a well-reasoned accepted-risk comment (pen-test MED-1) — that part is fine for a LAN-only server. But the deploy/ directory contains only service files; there is no Prometheus scrape config, no Grafana, no alertmanager, no healthcheck cron anywhere in the repo. Effective prod observability is manual journalctl pulls via the server-logs skill. Consequences already observed: OpenAI quota exhaustion, the 69GB cache-warmup bloat, and op wedges were all discovered by humans noticing symptoms, not by alerts. The nightly embed-async failures (OPS-3) will similarly rot silently.
+
+**Recommendation:** Stand up a minimal scrape+alert loop on 172.16.2.30 (single prometheus + alertmanager container, or even a cron curl of /metrics + /health with a threshold script). Alert on: service restarts, op failure counts, RSS above GOMEMLIMIT fraction, and reachability of 172.16.3.22 endpoints (per OPS-2).
+
+**Citations:**
+- internal/server/server_lifecycle.go:897-907
+- deploy/local.conf:1-36
+
+### OPS-6 — Recurring pattern: operational knowledge lands outside git (medium)
+
+**Detail:** Three independent instances of the same failure mode: (1) docs/status/ is untracked (`?? docs/status/` in git status) — the authoritative cutover record could be lost to a `git clean`; (2) Ollama setup scripts live only in a session scratchpad (status doc explicit TODO); (3) the deploy recipe is in gitignored Makefile.local whose header says "Local-only targets — not committed". Combined with per-worktree credentials in .claude/.credentials/ and .api-token, the bus factor for operating prod is one laptop. The agent memory system partially compensates (MEMORY.md index) but memory files are also machine-local.
+
+**Recommendation:** Commit docs/status/ now (it already has a proper version header — executed in this PR, see PROC-1). Establish a rule: any artifact referenced by prod (scripts, drop-ins, runbooks) must exist in-repo, with only secrets externalized. Track OPS-1's local.conf template under this same item.
+
+**Citations:**
+- docs/status/2026-07-02-local-cutover-and-matching.md:37-38
+- Makefile.local:1-6
+
+### OPS-7 — Agent dev-workflow is strong but CLAUDE.md triplicates rules and burns per-session tokens (low)
+
+**Detail:** The workflow itself is a strength: worktree-only discipline, parallel-sweep with per-task worktrees and sibling-rebase, honest status-count reporting, and a memory index that front-loads gotchas (memdb round-trip footgun, mockery drift). The inefficiency is structural: CLAUDE.md states the worktree/PR rule in three separate sections ("Worktree Discipline", "Workflow Discipline", "Quick Fix Workflow") and repeats plan-first twice, all loaded verbatim into every session for every agent — including narrow read-only subagents that never edit. Duplicated rules also drift independently (the three sections already differ on details like PLAN.md placement). Known breakdown points already documented in memory: mockery v3.7.1 vs pinned v2.53.6 regenerating all mocks, and overlapping sweep waves conflicting on rebase.
+
+**Recommendation:** Deduplicate CLAUDE.md to one canonical statement per rule with cross-references; move verbatim prompt templates to docs/ or skills. Pin mockery via a tools.go/mise version so local and CI cannot drift. No change needed to the sweep architecture itself.
+
+**Citations:**
+- CLAUDE.md:1-200
+
+## Steelman and Design
+
+The specialist reports for this dimension included no populated steelman or design sections (the ops report carried empty placeholders). No content omitted.
+
+## Cross-Report Overlaps
+
+- **SEC-5 = PROC-7:** same `@main`-pinned reusable-security.yml; fix once.
+- **PROC-2 ⊂ OPS-3:** same nightly embed-async cron; OPS-3 adds the 3072-dim vs 1024-dim index-contamination risk if OpenAI quota is restored mid-re-embed.
+- **SEC-1 = PROC-6 (rotation half):** API-key rotation untracked; one TODO.md entry closes both.
+- **SEC-6 = PROC-6 (reconciliation half):** independent confirmations that SEC-2/SEC-7/PERF-7 (and SEC-2-AUD, PERF-2b) are done.
+- **PROC-1 = OPS-6 item (1):** committing docs/status/ resolves both; executed in this PR.
+- **SEC-2 ↔ PROC-8:** both concern pre-commit hook gaps — SEC-2 the credentials-directory match logic, PROC-8 the copied-hook drift; a hooksPath-based versioned hook fixes both.

--- a/docs/status/2026-07-02-local-cutover-and-matching.md
+++ b/docs/status/2026-07-02-local-cutover-and-matching.md
@@ -1,0 +1,77 @@
+<!-- file: docs/status/2026-07-02-local-cutover-and-matching.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7f3a1c92-0b4e-4d21-9a6c-2e8f4b1d7c30 -->
+<!-- last-edited: 2026-07-02 -->
+
+# Status — Local Backend Cutover + Matching/Dedup Fixes (2026-07-02)
+
+## TL;DR
+
+OpenAI hit `insufficient_quota` (429). Switched embeddings + LLM to a **local
+Ollama backend on the Windows GPU box** (172.16.3.22), fixed the matching and
+dedup bugs that were reported, and shipped 9 PRs. A full re-embed to `bge-m3` is
+running on the GPU. Two tracks remain: the **LLM backend-mode toggle** and
+**fingerprint coverage** for dedup.
+
+## Shipped this session (all merged + deployed)
+
+| PR | Area | What |
+|----|------|------|
+| #1733 | reliability | PEBBLE-CLOSED-SHUTDOWN-RACE — enrol registry notify goroutines in `goroutineWG` + `notifyStopped` gate; real-Pebble `-race` repro |
+| #1734 | matching | Transcription boost requires title agreement (author/narrator no longer over-boost wrong book by right author) |
+| #1735 | frontend | Pagination bounce-to-page-1 fixed — `shallowEqualFilters` guard on the URL→filters sync effect |
+| #1736 | dedup | `ReevaluateAcoustIDConflicts` + `/dedup/purge-acoustid-conflicts` diagnostic endpoint |
+| #1737 | dedup | AcoustID emission veto — **pulled** (coverage-bound; not viable as a gate) |
+| #1738 | embeddings | Re-embed skip is model-aware (`embeddingModelMatches`) so a backend switch actually re-embeds |
+| #1739 | embeddings | Ollama availability trusts explicit `embedding.base_url` (`server.go:616`) |
+| #1740 | embeddings | HNSW `Import` discards stale-dim snapshot (3072 vs 1024) |
+| #1741 | embeddings | HNSW `Upsert` `safeAdd` recovers coder/hnsw library panics → error |
+
+## Local backend setup (Windows GPU box, 172.16.3.22)
+
+- Reached via `ssh windows-gpu` (key preinstalled). PowerShell over SSH mis-parses
+  scp'd `.ps1` — use `-EncodedCommand` (base64 UTF-16LE).
+- Ollama kept alive by scheduled task **"OllamaServe"** (interactive session for
+  GPU access; plain `ollama serve` over SSH dies on disconnect / headless auto-start).
+- Models pulled: **bge-m3** (1024-dim embeddings), **qwen2.5:7b-instruct** (LLM).
+- Setup scripts currently in scratchpad only: `setup-ollama.ps1`, `start-ollama.ps1`
+  → TODO commit as `scripts/manage-ollama-windows.py`.
+
+## Prod config
+
+```
+embedding.base_url        = http://172.16.3.22:11434/v1
+embedding.model           = bge-m3
+embedding.dimensions      = 1024
+metadata_scoring.llm_enabled = false
+```
+
+Vector indexes (chromem in-memory + coder/hnsw snapshot at
+`/var/lib/audiobook-organizer/hnsw`) are **derived** from PebbleDB's
+`EmbeddingStore`. `embeddings.db` SQLite is stale/legacy.
+
+## Re-embed status
+
+Running via `dedup.embed-scan` (sync, `POST /dedup/embed` — the model-cutover path;
+NOT `dedup.embed-async`, which uses the OpenAI Batch API). ~12K non-primary
+versions skipped, then ~29K primaries embedding via bge-m3 on the GPU. 0 errors,
+0 panics. Self-completing.
+
+## Matching / dedup findings
+
+- **Transcription:** fixed as above (#1734).
+- **AcoustID dedup veto:** NOT viable at current coverage. ~65% of candidates have
+  an unfingerprinted book; `BookSignatureSimilarityMasked ≈ 0.50` is the noise
+  floor for uncorrelated audio; only 5/4510 comparable pairs fell below it. The
+  real lever is **fingerprint coverage** (~8,387 books unfingerprinted).
+
+## Pending
+
+1. **LLM backend-mode toggle** — config enum + FE selector (disable-all /
+   OpenAI-only / local-only / OpenAI+local-fallback) + model-download prompt when
+   local. Local target = qwen2.5:7b-instruct on 172.16.3.22.
+2. **Fingerprint coverage** track — fingerprint the ~8,387 unfingerprinted books,
+   then the AcoustID veto + stronger dedup auto-resolution become viable.
+3. **Commit Windows Ollama scripts** as `scripts/manage-ollama-windows.py`.
+4. Deferred (gated — do NOT run without greenlight): ai-responses-migration ×5,
+   dedup C8, perf-cleanup CONS-13.


### PR DESCRIPTION
## Summary

Read-only multi-agent consultancy evaluation (25 agents: schema-auditor, db-design, expert, go-specialist, code-reviewer, pii-scanner, docs-agent + adversarial verifiers; advisor consulted at every phase boundary). 101 findings, all cited `file:line`; the 5 critical/high code findings were independently adversarially verified — all confirmed real.

- `docs/consultancy/00-ROADMAP.md` — impact × effort tiers, deferred-work verdicts, validated-don't-re-fix list
- `01-storage-architecture` (19) · `02-dedup` (13, incl. auto-resolution design) · `03-matching-and-backends` (16, incl. backend-mode toggle design) · `04-code-quality` (17 + verification table) · `05-features` (15) · `06-process-and-security` (21)
- Commits the previously-untracked `docs/status/2026-07-02-local-cutover-and-matching.md` (PROC-1 verdict: commit now)
- TODO.md: CONSULT-1..8 Tier-0 items; CHANGELOG entry

## Headline findings

1. **MATCH-1/BUG-1 (critical, verified):** `EmbeddingScorer` cached-vector fast path ignores model/dimension — during the live bge-m3 re-embed, mixed-dim cosine = 0 silently kills all metadata-search candidates with no F1 fallback.
2. **STOR-1/QUAL-2 (high, verified):** memdb-stripped `Book` → full-replacement `UpdateBook` wipes `Description`/`BookSigV1` (recoverable from `book_ver:` snapshots — recover before pruning).
3. Dedup: fingerprint coverage is real but **second-order**; the ~384K stale-candidate drain + bge-m3 threshold recalibration are first-order.
4. Cutover residue: author embeddings stranded on OpenAI vectors; nightly `dedup.embed-async` still targets the quota-dead Batch API; local LLM mode currently impossible (no per-config base URL).

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1