### PR TITLE
docs(agent-tasks): consultancy-roadmap workstream — 31 executable task briefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.98.0 -->
+<!-- version: 3.99.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-02 -->
 
@@ -8,6 +8,10 @@
 ## [Unreleased]
 
 ### Documentation
+
+#### July 3, 2026 - Consultancy-roadmap workstream: 31 executable task briefs
+
+- **`docs(agent-tasks)`** - New [`docs/agent-tasks/consultancy-roadmap/`](docs/agent-tasks/consultancy-roadmap/) workstream converting every consultancy-roadmap item into a self-contained, weak-model-proof brief (exemplar pattern: START-HERE worktree block, verified + re-verifiable code anchors, step-by-step, acceptance criteria, rollback). 31 briefs across 6 waves with a same-file collision table; model-tiered per owner policy — Haiku for mechanical, Sonnet standard, Opus only for the 8 genuinely complex items (booksig recovery, backend-toggle core, 384K stale-candidate drain, bge-m3 recalibration, auto-resolve, shutdown concurrency, the two structural splits). Prod-data ops (TASK-03/13/15/17) are dry-run-first and owner-greenlight gated. Needs-brainstorm items (bulk metadata review, health dashboard, CTR-1/2 redesign) listed without briefs per BREAKDOWN convention.
 
 #### July 2, 2026 - Full consultancy evaluation (6 dimensions, 101 findings)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.53.0 -->
+<!-- version: 9.54.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-02 -->
+<!-- last-edited: 2026-07-03 -->
 
 # Project TODO
 
@@ -24,6 +24,13 @@ future agent) can scan the entire workspace in one page.
 
 Full 6-dimension evaluation (101 findings, `file:line`-cited, top code findings
 adversarially verified). Ranked roadmap: [`docs/consultancy/00-ROADMAP.md`](docs/consultancy/00-ROADMAP.md).
+
+> **Task briefs exist for all of these (2026-07-03):**
+> [`docs/agent-tasks/consultancy-roadmap/`](docs/agent-tasks/consultancy-roadmap/)
+> — 31 briefs, 6 waves, model-tiered (Haiku/Sonnet, Opus only for the 8 complex
+> items). CONSULT-1..8 map to TASK-01..09 there. Run via that folder's
+> `run.sh` + `orchestration.md`.
+
 Tier-0 items (high impact, low effort — do first):
 
 - [ ] **CONSULT-1** EmbeddingScorer store fast-path: model/dimension check + F1 fallback on degenerate zero-score results (MATCH-1/BUG-1 — live during bge-m3 re-embed) — `internal/ai/embedding_scorer.go:92-98`

--- a/docs/agent-tasks/README.md
+++ b/docs/agent-tasks/README.md
@@ -1,7 +1,7 @@
 <!-- file: docs/agent-tasks/README.md -->
-<!-- version: 2.0.0 -->
+<!-- version: 2.1.0 -->
 <!-- guid: 7a1e0c44-9d2b-4f08-bc31-2e5a6b7c8d90 -->
-<!-- last-edited: 2026-07-01 -->
+<!-- last-edited: 2026-07-03 -->
 
 # Agent Task Package
 
@@ -25,6 +25,7 @@ same-file collision→wave table).
 
 | Folder | What | Priority | Tasks |
 |--------|------|----------|-------|
+| [`consultancy-roadmap/`](consultancy-roadmap/) | **2026-07-02 consultancy evaluation** implementation tasks — Tier-0 live-defect fixes (CONSULT-1..8), backend-mode toggle, dedup drain/recalibration/auto-resolve, shutdown correctness, ops hardening ([roadmap](../consultancy/00-ROADMAP.md)) | **P0–P3** | 31 |
 | [`dedup-hardening/`](dedup-hardening/) | Close the residual exact-layer false-positive leak + defensive guards (DEDUP-INTRO-1 residual, CONS-15, CONS-FRAG-2) | **P1** | 3 |
 | [`ci-flaky-fixes/`](ci-flaky-fixes/) | Make the mock-freshness + 2 flaky-test gates trustworthy | **P1** | 3 |
 | [`library-ui/`](library-ui/) | Saved filter presets, tag search, Ollama link, Library stale-cache bugfix | P2 | 4 |

--- a/docs/agent-tasks/consultancy-roadmap/README.md
+++ b/docs/agent-tasks/consultancy-roadmap/README.md
@@ -1,0 +1,84 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: ac814b83-acb8-4935-b396-dacbfd889ef1 -->
+<!-- last-edited: 2026-07-03 -->
+
+# Workstream — Consultancy roadmap (2026-07-02 evaluation)
+
+Implementation tasks for the consultancy evaluation
+([`docs/consultancy/00-ROADMAP.md`](../../consultancy/00-ROADMAP.md), PR #1742,
+101 findings). One brief per roadmap item, weak-model-proof, worktree-disciplined.
+TODO.md tracks the Tier-0 subset as `CONSULT-1..8`.
+
+**Model-tier policy (owner-directed):** Haiku for mechanical/small, Sonnet for
+standard backend work, Opus ONLY for the genuinely complex items (concurrency,
+calibration methodology, the big toggle, data ops at 384K scale, structural
+splits).
+
+## Task table
+
+| Task | Source | Title | Pri | Effort | Tier | Wave | Depends on |
+|------|--------|-------|-----|--------|------|------|------------|
+| TASK-01 | CONSULT-1 (MATCH-1/BUG-1/QUAL-4) | EmbeddingScorer model/dim guard + F1 fallback on degenerate scores | P0 | M | Sonnet | 1 | — |
+| TASK-02 | CONSULT-2 (STOR-1/QUAL-2) | memdb preserve guard on `UpdateBook` (mirror PERF-7 BookFile guard) | P0 | M | Sonnet | 1 | — |
+| TASK-03 | CONSULT-2 (STOR-1) | BookSig/Description recovery audit from `book_ver:` snapshots (dry-run op) | P0 | M | **Opus** | 2 | TASK-02 |
+| TASK-04 | CONSULT-3 (DEDUPC-1/TOGGLE-2) | Model-aware re-embed skip in `EmbedAuthor` + `EmbedBooksAsync` | P0 | S | Sonnet | 1 | — |
+| TASK-05 | CONSULT-4 (OPS-3/NEWF-5/PROC-2) | Retire/gate nightly `dedup.embed-async` (quota-dead OpenAI Batch API) | P0 | S | Haiku | 1 | — |
+| TASK-06 | CONSULT-5 (TOGGLE-1/MATCH-8) | Keyless local-backend registration (drop OpenAIAPIKey requirement) | P0 | S | Sonnet | 1 | — |
+| TASK-07 | CONSULT-6 (SEC-2/SEC-5/PROC-7) | Fix pre-commit hook `.claude/.credentials/` block + SHA-pin `security.yml` | P0 | S | Haiku | 1 | — |
+| TASK-08 | CONSULT-7 (OPS-1/OPS-6) | Commit deploy recipe templates + `scripts/manage-ollama-windows.py` + rollback target | P0 | M | Sonnet | 1 | — |
+| TASK-09 | CONSULT-8 (SEC-1/PROC-6) | API-key rotation + expiry for bootstrap-issued keys | P1 | M | Sonnet | 1 | — |
+| TASK-10 | NEWF-2 (TOGGLE-1..7) | Backend-mode toggle core (embeddings + LLM enums, per-config LLM base URL) | P1 | L | **Opus** | 3 | TASK-04, 06, 12 |
+| TASK-11 | NEWF-2 | Backend-mode toggle frontend (settings selector + model-download prompt) | P1 | M | Sonnet | 4 | TASK-10 |
+| TASK-12 | MATCH-7/TOGGLE-4/BUG-5 | Permanent-error classification in retry paths (stop retrying 429 quota) | P1 | S | Sonnet | 1 | — |
+| TASK-13 | DEDUP-1 | Stale-candidate drain op (~384K importer-bug candidates, dry-run gated) | P1 | L | **Opus** | 2 | TASK-04 |
+| TASK-14 | DEDUP-4 | Duration-coverage backfill (unblock not_dup catchers) | P1 | S | Sonnet | 3 | TASK-13 |
+| TASK-15 | DEDUP-2/3 | bge-m3 embedding-threshold recalibration + candidate regeneration | P1 | M | **Opus** | 3 | TASK-13 |
+| TASK-16 | NEWF-1 | Fingerprint-coverage campaign op + coverage KPI (~8,387 books) | P1 | M | Sonnet | 1 | — |
+| TASK-17 | 02-dedup design | `dedup.auto-resolve` confidence-tiered op (dry-run, sampling audit, reversible) | P1 | L | **Opus** | 4 | TASK-13, 15, 16 |
+| TASK-18 | QUAL-1/BUG-4 | slog-corruption sweep (duplicate keys, `value0`, dropped args, `!BADKEY`) | P1 | M | Haiku ×N | 5 | run alone |
+| TASK-19 | SYS-1/BUG-2 | Shutdown escape-hatch + `Registry.Shutdown` goroutine-tracking fix | P1 | M | **Opus** | 1 | — |
+| TASK-20 | ARCH-1/2/5 | HNSW snapshot staleness check, atomic export, wrap `Graph.Delete` | P1 | M | Sonnet | 2 | TASK-06 |
+| TASK-21 | OPS-4/5 | Scrape `/metrics` + minimal alerting (op failures, backend availability) | P2 | M | Sonnet | 2 | TASK-08 |
+| TASK-22 | STOR-3/ARCH-3/SYS-3 | NutsDB retirement (activity dual-write cutover + metrics to Pebble) | P2 | M | Sonnet | 2 | TASK-19 |
+| TASK-23 | MATCH-6/BUG-3 | TOCTOU fix in `ApplyTranscriptionCandidate` (apply the gated candidate) | P2 | S | Sonnet | 1 | — |
+| TASK-24 | MATCH-5/BUG-6 | Cover-filter ordering (stop dropping top-scored candidates) | P2 | S | Haiku | 2 | TASK-01 |
+| TASK-25 | MATCH-3 | `IsGarbageValue` "error" substring false positives | P2 | S | Haiku | 2 | TASK-01 |
+| TASK-26 | MATCH-2/CTR-3 | LLM-rerank scale normalization (clamped vs unclamped score mixing) | P2 | M | Sonnet | 3 | TASK-25 |
+| TASK-27 | MATCH-9 | Rune-based Levenshtein (non-ASCII titles) | P3 | S | Haiku | 1 | — |
+| TASK-28 | PROC-3/5, ARCH-4, SYS-6 | Doc-drift cleanup (AI-REFERENCE, pebble-schema duplicate, mockery pins) | P2 | S | Haiku | 1 | — |
+| TASK-29 | PROC-4 | Strengthen the 30% coverage gate (dedupe run, surface output, ratchet) | P3 | S | Haiku | 2 | TASK-08 |
+| TASK-30 | SYS-5 | Split `pebble_store.go` (11,398 lines) into per-domain files | P3 | L | **Opus** | 6 | TASK-02, 03 |
+| TASK-31 | SYS-2 | Decompose `Server.Start` (670 lines, dual lifecycle authorities) | P3 | L | **Opus** | 6 | TASK-19, 22 |
+
+## Needs-brainstorm bucket (NO briefs — spec first, per BREAKDOWN convention)
+
+- **NEWF-3** bulk metadata-review queue — feature design needed before tasking.
+- **NEWF-4** library-health / data-quality dashboard.
+- **CTR-1/CTR-2** structural redesign: field-masked write primitive + separate
+  memdb projection type (would permanently eliminate the STOR-1 bug class; big).
+- **NEWF-7** progress-sync/player API · **NEWF-8** community fingerprint index.
+
+## Ground rules
+
+- Go tasks: `go build ./... && go test ./internal/<changed-pkg>/... -count=1 && go vet ./...`
+  minimum; run `make ci` before PR.
+- **Verify every file:line anchor with `grep` before editing** — the consultancy
+  citations are from 2026-07-02 and drift.
+- File headers bumped on every change; conventional commits; PR + rebase merge
+  (never squash, never direct-to-main).
+- Prod-data ops (TASK-03, 13, 15, 17) are **dry-run-first, owner-greenlight
+  gated** — the brief's acceptance criteria stop at "dry-run report produced".
+
+## Collision / wave notes
+
+Same-file groups that force serialization (see [orchestration.md](orchestration.md)):
+
+- `internal/dedup/engine.go`: T04 → T13 → T15 → T17 (one per wave).
+- `internal/metafetch/service_scoring.go` / `service_search.go`: T01 → {T24, T25} → T26.
+- `internal/ai/*`: T06/T12 (disjoint files, wave 1) → T10 (touches both areas, wave 3).
+- `internal/server/server_lifecycle.go`: T19 → T22 → T31.
+- `internal/database/pebble_store.go`: T02 → T03 → T30.
+- `Makefile` / `deploy/`: T08 → {T21, T29}.
+- T18 (slog sweep) touches dozens of files across packages — it runs **alone** in
+  wave 5, after waves 1–4 merge, to avoid rebasing against everything.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-01-embedding-scorer-model-guard.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-01-embedding-scorer-model-guard.md
@@ -1,0 +1,324 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-01-embedding-scorer-model-guard.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 91e70f13-83e9-4097-a24b-086e9d0fa911 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-01 — EmbeddingScorer model/dim guard + F1 fallback on degenerate scores (consultancy-roadmap)
+
+**Priority:** P0 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-01-embedding-scorer-model-guard" -b agent/cr-01-embedding-scorer-model-guard origin/main
+cd "$REPO/.worktrees/cr-01-embedding-scorer-model-guard"
+git rebase origin/main
+```
+
+## Goal
+
+Fix MATCH-1 / BUG-1 / QUAL-4: `EmbeddingScorer`'s BookID fast-path returns a
+cached vector with no model/dimension check, so during the live OpenAI
+(3072-dim) → bge-m3 (1024-dim) re-embed, `CosineSimilarity` silently returns 0
+for every not-yet-re-embedded book, the scorer returns a nil error, no F1
+fallback ever triggers, and every candidate is dropped below
+`EmbeddingMinScore` — metadata search returns **zero results** for any
+un-re-embedded book right now in prod. Fix both halves:
+
+1. The fast-path in `queryVector` must validate the stored vector's model (or
+   at minimum its dimension) against the live client before using it; on
+   mismatch it must fall through to a live re-embed instead of returning the
+   stale vector.
+2. `ScoreBaseCandidates` must treat a degenerate all-zero score result as
+   scorer failure and fall back to the F1 tier, instead of accepting it as a
+   successful (but useless) `tier="embedding"` result.
+
+## Background (verify before editing)
+
+- `internal/ai/embedding_scorer.go` — `EmbeddingScorer.queryVector` (verified
+  at lines 91-99 as of this writing) returns `existing.Vector` from the
+  `EmbeddingStore` BookID fast-path with **no check** of `existing.Model`
+  against the live client's model:
+  ```go
+  func (s *EmbeddingScorer) queryVector(ctx context.Context, q Query) ([]float32, error) {
+  	if q.BookID != "" && s.store != nil {
+  		if existing, err := s.store.Get("book", q.BookID); err == nil && existing != nil && len(existing.Vector) > 0 {
+  			return existing.Vector, nil
+  		}
+  	}
+  	text := BuildEmbeddingText("book", q.Title, q.Author, q.Narrator)
+  	return s.api.EmbedOne(ctx, text)
+  }
+  ```
+  `existing.Model` (the field exists — `database.Embedding.Model`,
+  `internal/database/embedding_store.go` struct around line 131, populated
+  from the persisted `embRec.Model` around line 95) is available but unused
+  here.
+- The `embeddingAPI` interface in the same file (around lines 17-20) currently
+  only exposes `EmbedOne` / `EmbedBatch` — it has **no** `Model()` method, so
+  there is nothing to compare `existing.Model` against yet. The production
+  implementation, `*ai.EmbeddingClient`, already has a `Model() string` method
+  (`internal/ai/embedding_client.go`, verify with the grep below) — the
+  interface just needs to expose it.
+- `database.CosineSimilarity` (`internal/database/embedding_store.go`, verify
+  line with grep below) returns `0` whenever `len(a) != len(b)` — this is the
+  mechanism that turns a stale 3072-dim cached vector plus a fresh 1024-dim
+  candidate vector into a silent zero score, not an error.
+- `internal/metafetch/service_scoring.go` — `ScoreBaseCandidates` (verify
+  current line range with the grep below) calls the scorer and accepts its
+  result as the winning tier whenever `err == nil && len(scores) ==
+  len(results)`, with no check that the scores aren't all degenerate (e.g. all
+  exactly `0`):
+  ```go
+  scores, err := mfs.metadataScorer.Score(ctx, query, cands)
+  if err == nil && len(scores) == len(results) {
+  	return scores, mfs.metadataScorer.Name()
+  }
+  ```
+  If this returns `(scores, "embedding")` with every entry `0`, the F1
+  fallback tail (a few lines below, using `computeF1Base`) never runs, and
+  `internal/metafetch/service_search.go`'s per-candidate threshold filter
+  (`if score <= minScore { continue }`, `minScore =
+  config.AppConfig.MetadataScoring.EmbeddingMinScore` — 0.82 by default) drops
+  every candidate.
+- **Precedent to imitate, not import:** `internal/dedup/engine.go` already
+  solved the exact same "stale cross-model vector" problem for the dedup
+  embed path with `embeddingModelMatches` (verify with grep below) — treating
+  an empty stored model as a mismatch (forces re-embed) and comparing
+  `storedModel == de.embedClient.Model()` otherwise. Mirror that logic inside
+  `internal/ai` (do not import `internal/dedup` from `internal/ai` — that
+  would invert the package dependency direction); write a small
+  package-local equivalent instead.
+- `service_search.go` is listed as an expected file for this task because the
+  regression test for this fix should exercise the full
+  `SearchMetadataForBookWithOptions` (or equivalent, verify current name)
+  path end-to-end, proving a real, non-empty result set survives the
+  threshold filter once the scorer is fixed — not because the production
+  code in that file is expected to change. If, after reading the current
+  threshold-filter loop, you find a change there is genuinely required to
+  make the F1 fallback observable, make the smallest change that achieves it
+  and explain why in the PR description; otherwise leave the file's
+  production code untouched and add only the test.
+
+- **Re-verify these anchors before editing** — line numbers in the
+  consultancy report and in this brief are from 2026-07-02/03 and may have
+  drifted:
+  ```bash
+  grep -n "func (s \*EmbeddingScorer) queryVector\|type embeddingAPI interface\|func (s \*EmbeddingScorer) Score(" internal/ai/embedding_scorer.go
+  grep -n "func (c \*EmbeddingClient) Model()" internal/ai/embedding_client.go
+  grep -n "func CosineSimilarity\|type Embedding struct\|Model  *string\|Model     string" internal/database/embedding_store.go
+  grep -n "func (mfs \*Service) ScoreBaseCandidates" -A 40 internal/metafetch/service_scoring.go
+  grep -n "EmbeddingMinScore\|minScore = 0.0\|if score <= minScore" internal/metafetch/service_search.go
+  grep -n "func (de \*Engine) embeddingModelMatches" -A 20 internal/dedup/engine.go
+  grep -n "type fakeEmbedAPI\|func (f \*fakeEmbedAPI)\|TestEmbeddingScorer_BookIDFastPath" internal/ai/embedding_scorer_test.go
+  ```
+  Confirm in particular that `TestEmbeddingScorer_BookIDFastPath` (in
+  `internal/ai/embedding_scorer_test.go`) still seeds
+  `Model: "text-embedding-3-large"` on the stored `database.Embedding` — this
+  existing test's fast-path assertion (`api.embedOne == 0`) will regress once
+  you add a model check unless `fakeEmbedAPI` reports a matching model (see
+  step 3 below).
+
+## Step-by-step
+
+1. **Expose the client's model through the scorer's API seam.**
+   In `internal/ai/embedding_scorer.go`, add `Model() string` to the
+   `embeddingAPI` interface. `*ai.EmbeddingClient` already implements this
+   (re-verify with the grep above) so production wiring needs no change.
+
+2. **Add a model-match guard and use it in `queryVector`.**
+   Add a small unexported method, e.g.:
+   ```go
+   // modelMatches reports whether a stored embedding's model matches the
+   // scorer's live API model. A mismatch — e.g. after switching the
+   // embedding backend from OpenAI (text-embedding-3-large, 3072-dim) to a
+   // local model (bge-m3, 1024-dim) — must force a live re-embed even though
+   // a cached vector exists; otherwise CosineSimilarity silently returns 0
+   // against the mismatched vector. Empty stored model (pre-model-tagging
+   // rows) counts as a mismatch so those are re-embedded too. Mirrors
+   // internal/dedup/engine.go's embeddingModelMatches.
+   func (s *EmbeddingScorer) modelMatches(storedModel string) bool {
+   	if storedModel == "" {
+   		return false
+   	}
+   	return storedModel == s.api.Model()
+   }
+   ```
+   Then change `queryVector`'s fast-path condition to also require
+   `s.modelMatches(existing.Model)`, e.g.:
+   ```go
+   if existing, err := s.store.Get("book", q.BookID); err == nil && existing != nil &&
+   	len(existing.Vector) > 0 && s.modelMatches(existing.Model) {
+   	return existing.Vector, nil
+   }
+   ```
+   On mismatch, fall through to the existing `s.api.EmbedOne(...)` live-embed
+   path unchanged.
+
+3. **Fix the test double so existing tests stay green.**
+   In `internal/ai/embedding_scorer_test.go`, add a `Model() string` method to
+   `fakeEmbedAPI` (a field like `model string`, defaulting to whatever the
+   existing fast-path test's seeded `Model` value is — `"text-embedding-3-large"`
+   — so `TestEmbeddingScorer_BookIDFastPath` keeps passing without
+   modification). Set this field explicitly wherever a test constructs
+   `fakeEmbedAPI` and relies on the fast path being taken.
+
+4. **Add the model-mismatch regression test.**
+   In `internal/ai/embedding_scorer_test.go`, add a new test (pattern after
+   `TestEmbeddingScorer_BookIDFastPath`) that:
+   - Seeds a `database.Embedding` for a book with `Model: "text-embedding-3-large"`
+     and a 3072-length `Vector` (values don't need to be realistic, just the
+     right length — e.g. `make([]float32, 3072)` with a couple of non-zero
+     entries).
+   - Constructs a `fakeEmbedAPI` whose `Model()` returns `"bge-m3"` (simulating
+     the post-cutover live client) and whose `textToVec` returns a
+     1024-length vector.
+   - Calls `scorer.Score(...)` with that book's `BookID` and asserts:
+     - `api.embedOne` is now `1` (the fast path was correctly bypassed due to
+       the model mismatch — contrast with the existing
+       `TestEmbeddingScorer_BookIDFastPath`, which asserts `0`).
+     - The returned scores are computed from the live 1024-dim query vector
+       against 1024-dim candidate vectors (i.e. real cosine values, not the
+       degenerate 0 that a naive 3072-vs-1024 comparison would have produced).
+
+5. **Fix the degenerate-all-zero-score gap in `ScoreBaseCandidates`.**
+   In `internal/metafetch/service_scoring.go`, change the accept condition so
+   an all-zero (or empty) scorer result is treated as failure and falls
+   through to the F1 tier below it, e.g.:
+   ```go
+   scores, err := mfs.metadataScorer.Score(ctx, query, cands)
+   degenerate := len(scores) > 0 && allZero(scores)
+   if err == nil && len(scores) == len(results) && !degenerate {
+   	return scores, mfs.metadataScorer.Name()
+   }
+   if degenerate {
+   	slog.Warn("metadata-scorer returned all-zero scores, falling back to F1",
+   		"name", mfs.metadataScorer.Name(), "count", len(scores))
+   } else if err != nil {
+   	slog.Warn("metadata-scorer failed, falling back to F1", "name", mfs.metadataScorer.Name(), "error", err)
+   } else {
+   	slog.Warn("metadata-scorer returned wrong score count, falling back to F1", "name", mfs.metadataScorer.Name(), "got", len(scores), "want", len(results))
+   }
+   ```
+   Add a small local helper `allZero(scores []float64) bool` (or inline the
+   loop) in the same file. Do not touch the existing F1 fallback tail itself
+   (the `computeF1Base` loop) — only the acceptance condition above it. Do
+   not attempt to fix the unrelated pre-existing malformed `slog.Warn` calls
+   you see nearby (duplicate `"value"`/`"count"` keys, stray `%.3f` left in a
+   message string elsewhere in this file) — those are a separate tracked
+   defect (BUG-4/QUAL-1), out of scope here; leave them as-is except for the
+   two `slog.Warn` lines you are directly editing in this step.
+
+6. **Add a `ScoreBaseCandidates` degenerate-fallback unit test.**
+   Add a new test in `internal/metafetch` (new file
+   `service_scoring_test.go` if one doesn't already exist — re-verify with
+   `ls internal/metafetch/*_test.go`) that:
+   - Builds a minimal `*Service` (mirror how `TestNewService` or other
+     existing `internal/metafetch` tests construct one) and calls
+     `SetMetadataScorer` with a fake `ai.MetadataCandidateScorer` whose
+     `Score` returns an all-zero slice and a nil error.
+   - Sets `config.AppConfig.MetadataScoring.EmbeddingEnabled = true` for the
+     duration of the test (save/restore the prior value).
+   - Calls `mfs.ScoreBaseCandidates(...)` with a couple of
+     `metadata.BookMetadata` results and asserts the returned tier is `"f1"`
+     (not `"embedding"`) and the scores match what `computeF1Base` would
+     produce directly.
+   - Add a second case with a scorer returning genuine non-zero scores and
+     assert the tier stays `"embedding"` (proves the fix doesn't over-trigger
+     the fallback).
+
+7. **End-to-end regression test (the `service_search.go` piece).**
+   Add or extend a test in `internal/metafetch` that drives the full search
+   path (`SearchMetadataForBookWithOptions` or the current equivalent —
+   re-verify the name) with a metadata scorer stub simulating the degenerate
+   all-zero case, and assert the search returns a non-empty result set
+   (proving the F1 fallback from step 5 actually reaches the caller through
+   the existing threshold-filter loop, with no production change needed in
+   `service_search.go` itself). If this test reveals the threshold-filter
+   loop needs an additional change to observe the fallback, make the minimal
+   change and document why in the PR description — do not silently expand
+   scope beyond what the test proves is necessary.
+
+8. Bump the file header (version bump + `last-edited`) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/ai/... -run EmbeddingScorer -count=1 -v
+go test ./internal/ai/... -count=1
+go test ./internal/metafetch/... -count=1
+go vet ./internal/ai/... ./internal/metafetch/...
+```
+
+## Acceptance criteria
+
+- [ ] `embeddingAPI` exposes `Model() string`; `*ai.EmbeddingClient` satisfies
+      it without modification.
+- [ ] `EmbeddingScorer.queryVector`'s BookID fast-path is skipped (falls
+      through to a live `EmbedOne`) whenever the stored vector's `Model`
+      does not match the live API's `Model()`, including when the stored
+      model is empty.
+- [ ] `TestEmbeddingScorer_BookIDFastPath` (pre-existing) still passes
+      unmodified in behavior (same-model fast path still short-circuits
+      `EmbedOne`).
+- [ ] New regression test proves a 3072-dim stored vector vs. a 1024-dim
+      live client bypasses the fast path and produces real (non-degenerate)
+      cosine scores.
+- [ ] `ScoreBaseCandidates` treats an all-zero (or empty) scorer result as
+      failure and returns the F1 tier instead, with a test proving both the
+      degenerate-fallback case and the non-degenerate (no over-trigger) case.
+- [ ] End-to-end test shows a search that would previously have returned
+      zero results (due to the degenerate embedding tier) now returns
+      results via the F1 fallback.
+- [ ] `go build ./...`, `go vet ./internal/ai/... ./internal/metafetch/...`,
+      and `go test ./internal/ai/... ./internal/metafetch/...` are all green.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(ai): guard EmbeddingScorer model/dim mismatch and add F1 fallback on degenerate scores (MATCH-1/BUG-1/QUAL-4)
+
+EmbeddingScorer's BookID fast-path returned the cached vector with no model
+check, so during the OpenAI(3072)->bge-m3(1024) re-embed, CosineSimilarity
+silently scored every not-yet-re-embedded book's candidates at 0 with a nil
+error, and ScoreBaseCandidates accepted that as a successful "embedding" tier
+result with no F1 fallback -- metadata search returned zero candidates for
+any un-re-embedded book. Add a model-match guard mirroring dedup's
+embeddingModelMatches, and treat an all-zero scorer result as failure so it
+falls through to F1.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-01-embedding-scorer-model-guard
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/ai/embedding_scorer.go`'s `queryVector` already checks
+`existing.Model` (or vector length) against the live client's model before
+using the fast-path vector, AND `internal/metafetch/service_scoring.go`'s
+`ScoreBaseCandidates` already rejects all-zero scorer results and falls back
+to F1, this task is done — verify with:
+
+```bash
+grep -n "modelMatches\|existing.Model" internal/ai/embedding_scorer.go
+grep -n "allZero\|degenerate" internal/metafetch/service_scoring.go
+```
+
+If the consultancy citations turn out to already be fixed (e.g. a prior PR
+added the guard under a different name), do not re-implement — note what you
+found in the PR description and close this task as a no-op rather than
+inventing duplicate work. Rollback = revert the commit; the pre-existing
+`isNonPrimaryVersion`-style call sites and the F1 fallback tail in
+`ScoreBaseCandidates` are untouched by this change and remain in effect.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-02-updatebook-memdb-preserve-guard.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-02-updatebook-memdb-preserve-guard.md
@@ -1,0 +1,255 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-02-updatebook-memdb-preserve-guard.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d2bd6191-8300-4366-9c1a-15f8bb516655 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-02 — memdb preserve guard on `UpdateBook` (mirror PERF-7 BookFile guard) (STOR-1 / QUAL-2 / CTR-1 / CTR-2)
+
+**Priority:** P0 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-02-updatebook-memdb-preserve-guard" -b agent/cr-02-updatebook-memdb-preserve-guard origin/main
+cd "$REPO/.worktrees/cr-02-updatebook-memdb-preserve-guard"
+git rebase origin/main
+```
+
+## Goal
+
+Close STOR-1 / QUAL-2 (High): a memdb-stripped `Book` read via `GetAllBooks`
+and written back via `UpdateBook` silently wipes `Description`, `VersionNotes`,
+and every `BookSig*` dedup-signature field. Add a preserve-on-nil guard inside
+`UpdateBook` — mirroring the PERF-7 guard already shipped for `BookFile` in
+`UpsertBookFile` / `BatchUpsertBookFiles` — so the fields are restored from the
+existing stored row whenever the incoming pointer is `nil`. Do this with **zero
+extra reads**: `UpdateBook` already fetches `oldBook` via `GetBookByID`
+(Pebble-direct, unstripped) before it does anything else.
+
+## Background (verify before editing)
+
+- `stripBookForMemdb` (`internal/database/memdb_strip.go`) nils
+  `Description`, `VersionNotes`, `BookSigV1`, `BookSigV1Mask`,
+  `BookSigSegments`, `BookSigBuiltAt`, and `BookSigCoveragePct` (plus
+  `Author`/`Series`, which are handled by a separate hydration path and are
+  NOT in scope for this task) before inserting the projection into memdb.
+- `PebbleStore.GetAllBooks` (`internal/database/pebble_store.go:1391-1393`)
+  delegates to the memdb projection when `p.UseMemDB && p.mem() != nil` — this
+  is the production path (`UseMemDB=true`). Callers therefore receive
+  stripped `Book` values with those seven fields nil'd.
+- `PebbleStore.UpdateBook` (`internal/database/pebble_store.go:2664` on)
+  marshals the incoming `*Book` **verbatim** — it only special-cases `ID` and
+  `CreatedAt` (copied from `oldBook`) and sets `UpdatedAt`. Every other field
+  on the incoming struct — including nil'd Description/BookSig* — overwrites
+  the stored row.
+- `oldBook, err := p.GetBookByID(id)` is the very first statement in
+  `UpdateBook` (currently line 2666) and `GetBookByID` is Pebble-direct
+  (`internal/database/pebble_store.go:1691`), so `oldBook` always carries the
+  full, unstripped row. This means the guard needs **no new lookup** — just
+  compare `book.<Field>` to nil and fall back to `oldBook.<Field>`.
+  `oldBook` is also marshalled into the `book_ver:` CoW snapshot
+  (`internal/database/pebble_store.go:2688-2693`) before the overwrite, which
+  is why prior wipes are recoverable from snapshot history — but new wipes
+  should stop happening going forward, which is what this task fixes.
+- Confirmed live callers that do `GetAllBooks` → mutate → `UpdateBook`
+  round-trips and are therefore exposed today:
+  `internal/reconcile/reconcile.go:1115` (`GetAllBooks`) →
+  `internal/reconcile/reconcile.go:1149` (`UpdateBook`), inside
+  `AssignOrphanVGs`, reachable via `POST /operations/assign-orphan-vgs`. There
+  are several other `GetAllBooks`/`UpdateBook` pairs in the same file (lines
+  202/571, 631/707+710, 721/777, 797/834, 862, 943) and in
+  `internal/merge/service.go`, `internal/quarantine/service.go`, and
+  `internal/database/migrations.go` — the guard fixes all of them at the
+  single chokepoint, no per-caller changes needed.
+- The exact BookFile analogue to mirror is in
+  `internal/database/pebble_store.go`:
+  - `UpsertBookFile` (function starts at `9941`) — preserve block currently at
+    `9969-9985`, guarding `AcoustIDFingerprint`, `FingerprintFailureReason`,
+    `FingerprintFailureDetail`, `FingerprintDiagnosticJSON` with
+    `if len(file.AcoustIDFingerprint) == 0 { file.AcoustIDFingerprint =
+    existing.AcoustIDFingerprint }` / `if file.<PtrField> == nil { file.<PtrField>
+    = existing.<PtrField> }` patterns.
+  - `BatchUpsertBookFiles` (function starts at `9994`) — same preserve block,
+    currently at `10033-10053`, with a comment explaining the maintenance
+    tag-backfill footgun this guards against — use this comment as the model
+    for the new comment on the Book side.
+- `Book` struct field types (`internal/database/store.go`): `Description
+  *string` (line 133), `VersionNotes *string` (line 167), `BookSigV1 *string`
+  (202), `BookSigSegments *int` (203), `BookSigBuiltAt *time.Time` (204),
+  `BookSigV1Mask *string` (205), `BookSigCoveragePct *int` (206) — all
+  pointer types, so a straightforward `if book.X == nil { book.X = oldBook.X
+  }` guard works for every one of them, exactly like the BookFile guard.
+- **Escape hatch already exists structurally — verify, do not add new
+  plumbing.** A grep across the repo for explicit `.Description = nil` /
+  `.BookSigV1 = nil` / etc. assignments on `UpdateBook`-bound structs found
+  none outside `stripBookForMemdb` itself. The one real user-facing edit path,
+  `internal/audiobooks/update_service.go` (`UpdateAudiobook`, around line
+  120), only sets `updates.Description = &desc` when the field key is present
+  in the request payload (`util.ExtractStringField(payload, "description")`);
+  an explicit "clear the description" edit produces `&""` (a non-nil pointer
+  to an empty string), not `nil`. Because the new guard only fires on `nil`,
+  explicit user-initiated clears (pointer-to-empty-string) pass through
+  untouched and are NOT blocked by this guard — nil strictly means "field not
+  supplied / stripped", never "explicitly cleared". Confirm this still holds
+  after your edit by re-running the grep in the test step below.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (p \*PebbleStore) UpdateBook\b\|func (p \*PebbleStore) GetBookByID\b\|func (p \*PebbleStore) GetAllBooks\b" internal/database/pebble_store.go
+  grep -n "func stripBookForMemdb" internal/database/memdb_strip.go
+  grep -n "func (s \*PebbleStore) UpsertBookFile\b\|func (s \*PebbleStore) BatchUpsertBookFiles\b" internal/database/pebble_store.go
+  ```
+  Confirm `UpdateBook`'s current body still opens with `oldBook, err :=
+  p.GetBookByID(id)` and still preserves only `book.ID` and
+  `book.CreatedAt` before marshalling:
+  ```bash
+  sed -n '/func (p \*PebbleStore) UpdateBook/,/json.Marshal(book)/p' internal/database/pebble_store.go
+  ```
+
+## Step-by-step
+
+1. Open `internal/database/pebble_store.go` and locate `UpdateBook` (re-verify
+   with the grep above — do not assume the line number from this brief).
+2. Immediately after the existing block that copies `CreatedAt` from
+   `oldBook` (and before `data, err := json.Marshal(book)`), add a preserve
+   block for the seven memdb-stripped fields:
+   ```go
+   // Preserve fields stripped by stripBookForMemdb (STOR-1). Callers that
+   // sourced `book` from the memdb projection (GetAllBooks on the production
+   // UseMemDB path) carry nil Description/VersionNotes/BookSig* even though
+   // the stored row has real values. Restoring from oldBook — already fetched
+   // above via the Pebble-direct GetBookByID — costs zero extra reads.
+   // Mirrors the UpsertBookFile/BatchUpsertBookFiles fingerprint-preserve
+   // guard (PERF-7) — keep both in sync.
+   if book.Description == nil {
+       book.Description = oldBook.Description
+   }
+   if book.VersionNotes == nil {
+       book.VersionNotes = oldBook.VersionNotes
+   }
+   if book.BookSigV1 == nil {
+       book.BookSigV1 = oldBook.BookSigV1
+   }
+   if book.BookSigV1Mask == nil {
+       book.BookSigV1Mask = oldBook.BookSigV1Mask
+   }
+   if book.BookSigSegments == nil {
+       book.BookSigSegments = oldBook.BookSigSegments
+   }
+   if book.BookSigBuiltAt == nil {
+       book.BookSigBuiltAt = oldBook.BookSigBuiltAt
+   }
+   if book.BookSigCoveragePct == nil {
+       book.BookSigCoveragePct = oldBook.BookSigCoveragePct
+   }
+   ```
+3. Do NOT touch any other part of `UpdateBook` — not the CoW snapshot write,
+   not the path-index/hash-index update logic, not the function signature.
+   This is a purely additive guard between the existing `CreatedAt`
+   preservation and the `json.Marshal(book)` call.
+4. Add a new test file `internal/database/pebble_book_preserve_test.go`
+   (model it directly on `internal/database/pebble_bookfile_preserve_test.go`
+   — same store-setup pattern, same doc-comment style) that:
+   - Creates a book with non-nil `Description`, `BookSigV1`, `BookSigV1Mask`,
+     `BookSigSegments`, `BookSigBuiltAt`, `BookSigCoveragePct`, and
+     `VersionNotes` set (via `CreateBook` then a direct `UpdateBook` to set
+     the BookSig* fields, since `CreateBook` likely doesn't accept them —
+     check `CreateBook`'s signature first).
+   - Calls `UpdateBook` with an incoming `*Book` that has all seven fields
+     nil (simulating a memdb-sourced round-trip) but changes an unrelated
+     field (e.g. `Title`) — asserts, via a follow-up `GetBookByID` (Pebble-direct,
+     reflects the real stored row), that all seven fields are still present
+     and unchanged, AND that `Title` was updated.
+   - Calls `UpdateBook` again with `Description` explicitly set to a pointer
+     to `""` (empty string, non-nil) — asserts the stored `Description` is
+     now `""`, proving explicit clears still work and are not blocked by the
+     new guard.
+5. Bump the file header (version bump + `last-edited` date) on every file you
+   touch — `internal/database/pebble_store.go` and the new test file — per
+   `.standards/instructions/file-headers.md`.
+6. Re-run the escape-hatch grep from the Background section to confirm no
+   caller intentionally sets any of the seven fields to `nil` on a struct
+   that flows into `UpdateBook` (this would now be silently overridden by
+   the preserve guard — if you find one, stop and flag it in the PR
+   description instead of silently changing behavior):
+   ```bash
+   grep -rn "\.Description = nil\|\.VersionNotes = nil\|\.BookSigV1 = nil\|\.BookSigV1Mask = nil\|\.BookSigSegments = nil\|\.BookSigBuiltAt = nil\|\.BookSigCoveragePct = nil" internal/ --include="*.go" | grep -v _test.go | grep -v memdb_strip.go
+   ```
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/database/... -run TestPebbleBookPreserve -v -count=1
+go test ./internal/database/... -count=1
+go test ./internal/reconcile/... -count=1
+go vet ./internal/database/...
+```
+
+## Acceptance criteria
+
+- [ ] `UpdateBook` preserves `Description`, `VersionNotes`, `BookSigV1`,
+      `BookSigV1Mask`, `BookSigSegments`, `BookSigBuiltAt`, and
+      `BookSigCoveragePct` from the existing stored row whenever the
+      incoming `*Book` has that field `nil`.
+- [ ] No extra Pebble read added — the guard reuses the `oldBook` already
+      fetched by the existing `GetBookByID` call at the top of `UpdateBook`.
+- [ ] An incoming `*Book` with an explicit non-nil value (including a pointer
+      to an empty string, for `Description`) still overwrites the stored
+      value — the guard only fires on `nil`, never on non-nil "clear" values.
+- [ ] New test `internal/database/pebble_book_preserve_test.go` covers both
+      the preserve-on-nil case and the explicit-clear-still-works case;
+      `go test ./internal/database/...` and `go vet ./internal/database/...`
+      are green.
+- [ ] `go test ./internal/reconcile/...` still passes (guards against
+      regressing `AssignOrphanVGs` and the other `GetAllBooks`/`UpdateBook`
+      round-trips in that package).
+- [ ] The escape-hatch grep in step 6 was run and its output (empty or
+      otherwise) is noted in the PR description.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(database): preserve memdb-stripped Book fields in UpdateBook (STOR-1)
+
+GetAllBooks on the production UseMemDB path returns Books with Description,
+VersionNotes, and all BookSig* dedup-signature fields nil'd by
+stripBookForMemdb. UpdateBook marshalled the incoming struct verbatim,
+so any GetAllBooks -> mutate -> UpdateBook round trip (AssignOrphanVGs,
+migrations, quarantine restore, merge) silently wiped those fields. Mirror
+the PERF-7 BookFile preserve guard: restore from the already-fetched
+oldBook whenever the incoming pointer is nil, at zero extra read cost.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-02-updatebook-memdb-preserve-guard
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `UpdateBook` already contains nil-checks that restore
+`Description`/`VersionNotes`/`BookSigV1`/`BookSigV1Mask`/`BookSigSegments`/
+`BookSigBuiltAt`/`BookSigCoveragePct` from `oldBook` before marshalling, this
+task is done — verify with:
+```bash
+sed -n '/func (p \*PebbleStore) UpdateBook/,/json.Marshal(book)/p' internal/database/pebble_store.go | grep -n "oldBook\."
+```
+and confirm all seven fields appear. If the consultancy citations have
+drifted and `UpdateBook` now reads differently (e.g. it has been refactored
+to take a diff/patch struct instead of a full `*Book`), this guard may
+already be structurally unnecessary — say so explicitly in the PR
+description rather than forcing the pattern in. Rollback = revert the
+commit; the existing `CreatedAt` preservation and CoW `book_ver:` snapshot
+behavior are untouched by this change and remain in effect (so any wipes
+that occurred before this fix ships remain recoverable from `book_ver:`
+snapshots per STOR-1's advisor note — sequence any such recovery before
+STOR-2's snapshot-pruning work).

--- a/docs/agent-tasks/consultancy-roadmap/TASK-03-booksig-recovery-audit.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-03-booksig-recovery-audit.md
@@ -1,0 +1,281 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-03-booksig-recovery-audit.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 34f759cc-a00c-4e92-b4d4-fd132421fe0b -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-03 — BookSig/Description recovery audit from `book_ver:` snapshots (dry-run op)
+
+**Priority:** P0 · **Effort:** M · **Recommended subagent:** Opus · **Wave:** 2 · **Depends on:** TASK-02
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-03-booksig-recovery-audit" -b agent/cr-03-booksig-recovery-audit origin/main
+cd "$REPO/.worktrees/cr-03-booksig-recovery-audit"
+git rebase origin/main
+```
+
+**Before starting:** confirm TASK-02 (memdb preserve guard on `UpdateBook`) has
+already merged to `origin/main` and this worktree includes it (`git log
+--oneline -5 -- internal/database/pebble_store.go` should show its commit).
+TASK-02 stops the *future* wipe; this task only reads existing history and
+does not touch `UpdateBook` itself, but it shares `pebble_store.go` so it must
+be based on top of TASK-02 to avoid a painful rebase, and because sizing "how
+much damage already happened" is only meaningful once the leak is closed.
+
+## Goal
+
+Build a **read-only, dry-run** maintenance op that scans all books, finds the
+ones whose current row is missing `Description` and/or `BookSigV1` while an
+older `book_ver:` CoW snapshot for that same book still has them, and reports
+counts + concrete examples. This sizes the blast radius of the STOR-1 memdb
+full-replacement wipe (docs/consultancy/01-storage-architecture.md) using the
+exact recovery mechanism the advisor pass identified: `UpdateBook`'s
+pre-overwrite CoW snapshot preserves the un-wiped book, so damage is
+recoverable **provided it is recovered before STOR-2's snapshot pruning is
+ever enabled.**
+
+This task's acceptance criteria stop at a dry-run report. Building/wiring an
+apply mode is optional scaffolding (owner-gated, off by default) — see
+"Apply mode" below. **Do not run apply mode against prod without the owner's
+explicit greenlight**, exactly like the M0 purge and CONS-10 precedents.
+
+## Background (verify before editing)
+
+- The consultancy finding (STOR-1, `docs/consultancy/01-storage-architecture.md`)
+  and its advisor addendum are the source of this task:
+  > Because `GetBookByID` is Pebble-direct, `UpdateBook` reads the full
+  > unstripped old row before overwriting and writes it to the `book_ver:` CoW
+  > snapshot. Existing wipe damage is therefore recoverable from snapshots —
+  > the severity of *permanent* loss is bounded, but only while those
+  > snapshots survive. Sequence any prod recovery of wiped Description/BookSig
+  > fields before implementing STOR-2's snapshot pruning.
+
+- **Re-verify every anchor below before writing code** — the consultancy doc
+  is dated 2026-07-02 and line numbers drift:
+  ```bash
+  grep -n "func (p \*PebbleStore) UpdateBook\|book_ver:\|func (p \*PebbleStore) GetBookSnapshots\|func (p \*PebbleStore) GetBookAtVersion\|func (p \*PebbleStore) PruneBookSnapshots\|func (p \*PebbleStore) GetAllBooks\b\|func (p \*PebbleStore) ListBookIDs\b" internal/database/pebble_store.go
+  ```
+  Confirmed at time of writing (audiobook-organizer-roadmap-tasks worktree,
+  2026-07-03):
+  - `UpdateBook` — `internal/database/pebble_store.go:2664`. It snapshots the
+    **old** (pre-overwrite) book JSON to key `book_ver:<id>:<unixnano>`
+    (`:2688-2701`) before writing the new row to `book:<id>`. This is the
+    recovery source.
+  - `GetBookSnapshots(id string, limit int) ([]BookSnapshot, error)` —
+    `:3039`. Prefix-scans `book_ver:<id>:`, returns newest-first, `limit<=0`
+    means "all". Reuse this — do not hand-roll another `book_ver:` iterator.
+  - `GetBookAtVersion(id string, ts time.Time) (*Book, error)` — `:3080`.
+    Point-reads one snapshot by exact timestamp. Reuse this for the apply path.
+  - `PruneBookSnapshots(id string, keepCount int) (int, error)` — `:3109`.
+    **Do not call this from the new op.** It exists but per STOR-2/advisor
+    sequencing this task must not enable or trigger pruning in any form.
+  - `GetAllBooks(limit, offset int) ([]Book, error)` — `:1391`. In prod
+    (`UseMemDB=true`) this routes through the **memdb-stripped** projection
+    (STOR-1's `stripBookForMemdb`, `internal/database/memdb_strip.go:29`),
+    so the "current" book fetched via `GetAllBooks` will *always* show
+    `Description`/`BookSigV1` as nil regardless of whether the underlying
+    Pebble row actually has them. **Do not use `GetAllBooks` to read the
+    "current" row for this audit** — it would report false positives for
+    every book, memdb-stripped or not. Use `GetBookByID(id)` instead, which
+    is Pebble-direct (`:1691`, confirmed by the advisor pass) and reflects
+    the true on-disk state. Use `ListBookIDs() ([]string, error)` (`:1532`)
+    or `GetAllBooks` (memdb-backed, fine for *enumeration only*) purely to
+    get the list of book IDs to iterate, then call `GetBookByID` per ID for
+    the actual field check.
+  - Book fields: `Description *string` (`internal/database/store.go:133`),
+    `BookSigV1 *string` (`:202`), `BookSigBuiltAt *time.Time` (`:204`),
+    `BookSigV1Mask *string` (`:205`). The consultancy report's recommended
+    damage-sizing signal is: **`BookSigBuiltAt` set (non-nil) but `BookSigV1`
+    nil** — this means a signature was built at some point but the current
+    row no longer carries it, i.e. it was wiped after being computed. Also
+    separately count/report `Description == nil` cases (Description has no
+    "was it ever set" marker field, so those are reported as raw counts +
+    samples, not cross-checked against a built-at marker).
+  - Maintenance-op pattern to copy verbatim: read
+    `internal/plugins/maintenance/duration_backfill.go` in full. It is the
+    closest existing analog: `sdk.OperationDef` with a `DryRun bool` param
+    defaulting to `true`, paginated `GetAllBooks(pageSize, offset)` scan,
+    time-batched heartbeat logging (`logInterval`), and a dry-run branch that
+    only counts + samples with **zero writes**. Follow its shape, not its
+    duration-specific logic.
+  - Plugin registration: `internal/plugins/maintenance/plugin.go` — add the
+    new op's `...Def()` method to the `defs := []sdk.OperationDef{...}` slice
+    inside `func (p *Plugin) Register(r sdk.Registry) error` (currently
+    `:32-100+`; re-verify with
+    `grep -n "func (p \*Plugin) Register" internal/plugins/maintenance/plugin.go`).
+    Add it near `p.durationBackfillDef()` / `p.titleBackfillDef()` under a new
+    `// --- booksig/description recovery audit ---` comment group.
+
+## Step-by-step
+
+1. Re-run all `grep` commands in "Background" and confirm every anchor before
+   writing any code. If TASK-02's preserve-guard is not yet present in
+   `UpdateBook`, STOP and escalate — this task assumes it merged first.
+2. Create `internal/plugins/maintenance/booksig_recovery_audit.go` modeled on
+   `duration_backfill.go`:
+   - Define `bookSigRecoveryAuditParams struct { DryRun bool \`json:"dryRun"\` }`
+     defaulting to `true` in the `Run` function (safe default, same pattern).
+   - Define an `sdk.OperationDef` (e.g. `ID: "maintenance.booksig-recovery-audit"`)
+     with `DefaultPriority: sdk.PriorityLow`, `Capabilities:
+     []sdk.Capability{sdk.CapLibraryRead}` for the dry-run path (read-only —
+     no `CapLibraryWrite` needed unless you implement apply mode; if you do,
+     gate the write capability declaration behind whether apply mode exists
+     in the def, or simply keep this task read-only and ship apply as a
+     documented follow-up — see "Apply mode" below for the recommended
+     minimal-scope choice).
+   - Enumerate all book IDs via `ListBookIDs()` (or paginated `GetAllBooks`
+     purely for ID enumeration — either is fine since IDs are memdb-safe;
+     memory-bounded either way per existing convention: page in batches of
+     500, do not load the whole ID list into one huge unbounded slice if
+     `ListBookIDs` returns everything at once — check its actual signature
+     first; if it already returns `[]string` for the whole library in one
+     call, that is the existing convention (books are ~50K, ~a few MB of
+     strings) and is acceptable, but do NOT additionally materialize full
+     `Book` structs for the whole library at once — fetch full books one ID
+     at a time or in small batches via `GetBookByID`).
+   - Per ID: `GetBookByID(id)` for the current row. If `Description == nil`
+     OR (`BookSigBuiltAt != nil AND BookSigV1 == nil`), it's a candidate for
+     recovery — call `GetBookSnapshots(id, 0)` (all snapshots, newest-first)
+     and scan for the newest snapshot where the missing field(s) are
+     *present*. Record: book ID, title, which field(s) missing, whether a
+     recoverable snapshot was found, and the snapshot's timestamp if found.
+   - Time-batch heartbeat logging exactly like `duration_backfill.go`'s
+     `heartbeat` closure (15s interval, small example ring buffer, ≤5
+     examples per heartbeat) — do not log per-book at INFO level across 50K
+     books.
+   - Dry-run report (the only mode this task must ship): total books
+     scanned; count with `Description` missing; count with `BookSigV1`
+     missing-but-was-built; of each, count with a recoverable snapshot found
+     vs. not found (i.e. wiped-and-then-the-snapshot-itself-later-pruned, or
+     never had one, e.g. new books); a handful of concrete examples
+     (`book_id`, title, missing field(s), recoverable snapshot timestamp or
+     "no recoverable snapshot").
+   - Respect `ctx.Err()` in the per-ID loop (same convention as
+     `duration_backfill.go`) so the op is cancellable.
+3. **Apply mode (owner-gated, minimal scope):** implement it only if trivial
+   to add without expanding this task's blast radius. If implemented:
+   - Require `params.DryRun == false` explicitly (never default to apply).
+   - For each recoverable book, copy only the missing field(s)
+     (`Description`, `BookSigV1`, and its siblings `BookSigV1Mask`,
+     `BookSigSegments`, `BookSigBuiltAt`, `BookSigCoveragePct` if restoring
+     the signature) from the newest snapshot that has them onto the current
+     book, then call `UpdateBook` — this itself writes yet another CoW
+     snapshot of the (still-partially-wiped) pre-restore state, which is
+     harmless and consistent with existing behavior.
+   - Batch writes conservatively (e.g. one `UpdateBook` call per book, no bulk
+     bypass) since this is a low-frequency, one-time healing op, not a
+     hot path.
+   - If apply mode feels like scope creep, ship dry-run only and note apply
+     as a documented follow-up in the op's `Description` string and in this
+     brief's PR description — that satisfies this task's acceptance criteria,
+     which stop at the dry-run report regardless.
+4. Register the new op in `internal/plugins/maintenance/plugin.go`'s
+   `Register` method (see Background for the exact insertion point).
+5. Add `internal/plugins/maintenance/booksig_recovery_audit_test.go` modeled
+   on `duration_backfill_test.go`'s structure (or the lighter
+   `title_backfill_test.go` harness if it's a better fit — check both,
+   re-verify with `grep -n "newTestPlugin\|newReextractPlugin\|database.MockStore" internal/plugins/maintenance/*_test.go`).
+   Cover:
+   - A book with `Description == nil` and a snapshot containing a
+     non-nil `Description` → reported as recoverable with correct
+     snapshot timestamp.
+   - A book with `BookSigBuiltAt` set, `BookSigV1` nil, and a snapshot
+     with `BookSigV1` present → reported recoverable.
+   - A book with `BookSigBuiltAt` nil (signature never built) → NOT
+     flagged as a BookSig-missing candidate (it isn't missing anything;
+     it never had one).
+   - A book with `Description == nil` and NO snapshot at all (new book,
+     never updated) → reported as missing but NOT recoverable (no
+     snapshot exists).
+   - `DryRun: true` (default) → op returns `nil` with a summary log/progress
+     update, and the mock store records **zero** `UpdateBook` calls.
+6. Bump the file header (version bump + `last-edited`) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/plugins/maintenance/... -run BookSigRecoveryAudit -count=1
+go test ./internal/plugins/maintenance/... -count=1
+go vet ./internal/plugins/maintenance/...
+```
+
+## Acceptance criteria
+
+- [ ] New op `maintenance.booksig-recovery-audit` (or equivalent ID) is
+      registered and runnable via the existing UOS op-registry path.
+- [ ] Dry-run mode (default) never calls `UpdateBook`, `PruneBookSnapshots`,
+      or any other write path — verified by a mock-store assertion in tests.
+- [ ] Report distinguishes `Description`-missing from `BookSigV1`-missing
+      (using the `BookSigBuiltAt`-set-but-`BookSigV1`-nil signal), and for
+      each, distinguishes recoverable (a snapshot with the field present
+      exists) from not-recoverable (no such snapshot).
+- [ ] `GetBookByID` (Pebble-direct) is used for the current-row check, NOT
+      `GetAllBooks`'s memdb-stripped projection — verified by code reading
+      and/or a test proving a memdb-stripped-but-actually-intact book is not
+      falsely flagged.
+- [ ] The op never calls `PruneBookSnapshots` or otherwise deletes/reduces
+      `book_ver:` snapshots — this task's whole point is preserving the
+      recovery source until STOR-2 pruning is separately approved.
+- [ ] Iteration is memory-bounded: full-`Book` structs are not all held in
+      memory simultaneously for the whole library (paginated/batched, per
+      existing `duration_backfill.go` convention).
+- [ ] Tests cover all four scenarios in step 5; `go test
+      ./internal/plugins/maintenance/...` is green; `go vet` is clean.
+- [ ] File headers bumped on every changed file.
+- [ ] **Acceptance stops here.** Applying recovered fields to prod (even if
+      apply mode is implemented per step 3) requires the owner's explicit
+      greenlight and is NOT part of this task's Definition of Done — do not
+      run apply mode against the production database as part of this task.
+
+## Commit message
+
+```
+feat(maintenance): add dry-run BookSig/Description recovery audit from book_ver snapshots (STOR-1/STOR-2)
+
+UpdateBook's memdb-stripped-Book full-replacement bug (STOR-1) has silently
+wiped Description and BookSigV1 dedup signatures on every Book touched by
+GetAllBooks-then-UpdateBook read-modify-write paths (reconcile, migrations,
+quarantine, merge). The advisor pass confirmed the damage is recoverable from
+UpdateBook's own book_ver: CoW snapshots, but only before any snapshot
+pruning runs. Add a read-only dry-run op that sizes existing damage and
+identifies which books have a recoverable snapshot, so recovery can be
+sequenced before STOR-2 pruning work ever starts. Apply mode is intentionally
+owner-gated and out of this task's acceptance scope.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-03-booksig-recovery-audit
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/plugins/maintenance/booksig_recovery_audit.go` already exists
+and is registered in `plugin.go`'s `Register`, this task is done — verify
+with `grep -rn "booksig-recovery-audit\|BookSigRecoveryAudit" internal/plugins/maintenance/`.
+
+If, when you check, `UpdateBook` no longer routes reads through
+`GetBookByID`/the memdb-stripped path at all (e.g. TASK-02 or a later
+refactor changed the read path so Description/BookSigV1 are never stripped
+before `UpdateBook` sees them), the underlying STOR-1 wipe may already be
+fully closed for *future* writes — but this task is about **past** damage
+already committed to disk, which still needs sizing regardless of whether
+the leak is closed going forward. Do not skip this task solely because
+TASK-02 merged; only skip it if the audit itself already exists.
+
+Rollback = revert the commit. The new op is additive (a new `OperationDef`
+registration) and read-only in its required (dry-run) mode, so reverting is
+safe with no data-migration concerns. If apply mode was implemented and run,
+rollback of *data* changes it made would itself need to go through
+`RevertBookToVersion`/`GetBookAtVersion` against the pre-apply snapshot —
+another reason apply mode is out of this task's required scope.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-04-author-embed-model-skip.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-04-author-embed-model-skip.md
@@ -1,0 +1,209 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-04-author-embed-model-skip.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: db161153-79d0-4a29-bd0d-9a5dab066737 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-04 — Model-aware re-embed skip in `EmbedAuthor` + `EmbedBooksAsync` (consultancy-roadmap: DEDUPC-1 / TOGGLE-2)
+
+**Priority:** P0 · **Effort:** S · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-04-author-embed-model-skip" -b agent/cr-04-author-embed-model-skip origin/main
+cd "$REPO/.worktrees/cr-04-author-embed-model-skip"
+git rebase origin/main
+```
+
+## Goal
+
+PR #1738 made the **book** re-embed cache-skip model-aware
+(`prepBookEmbed` now requires `de.embeddingModelMatches(existing.Model)` in
+addition to a `TextHash` match, so a backend cutover — e.g.
+text-embedding-3-large → bge-m3 — forces a re-embed even when the book's text
+is unchanged). `EmbedAuthor` and `EmbedBooksAsync` were never given the same
+guard: they skip on `TextHash` equality alone. Since an author's name almost
+never changes, every author embedding is permanently stranded on whatever
+model created it — after the OpenAI→Ollama cutover, all existing author
+vectors stay 3072-dim text-embedding-3-large forever while new authors get
+1024-dim bge-m3 vectors. `CheckAuthor`'s similarity search then compares
+mismatched-dimension vectors (linear-scan cosine returns 0/garbage; HNSW on
+mixed dims is the class of panic #1741 now recovers as an error), so author
+dedup Layer 2 silently returns nothing. This is DEDUPC-1 (severity high,
+effort low) and the author-path half of TOGGLE-2 in the consultancy findings.
+
+Apply the identical `embeddingModelMatches` guard used in `prepBookEmbed` to
+both `EmbedAuthor`'s and `EmbedBooksAsync`'s cached-skip checks. `EmbedBooksAsync`
+is the OpenAI Batch API path (`/v1/batches`); it is currently inert under an
+Ollama backend and is being gated on backend==openai separately in a later
+task (see TASK-05/TASK-10 in this same roadmap — do NOT add that gating here).
+Fix its model-skip anyway, for correctness and because the same-shaped bug is
+present regardless of whether the path is currently reachable.
+
+## Background (verify before editing)
+
+- `internal/dedup/engine.go` defines:
+  - `embeddingModelMatches(storedModel string) bool` — compares a stored
+    embedding's `Model` field against `de.embedClient.Model()`; returns `true`
+    (no forced churn) when `de.embedClient == nil`.
+  - `prepBookEmbed` — the reference implementation of the fix. Its cached-skip
+    condition is `existing.TextHash == hash && de.embeddingModelMatches(existing.Model)`.
+  - `EmbedAuthor(ctx context.Context, authorID int) error` — its cached-skip
+    condition is currently `existing.TextHash == hash` only (no model check).
+  - `EmbedBooksAsync(ctx context.Context) (batchID string, count int, err error)`
+    — its per-book cached-skip inside the build-items loop is currently
+    `existing.TextHash == hash` only (no model check).
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (de \*Engine) prepBookEmbed\|func (de \*Engine) embeddingModelMatches\|func (de \*Engine) EmbedAuthor\|func (de \*Engine) EmbedBooksAsync" internal/dedup/engine.go
+  ```
+  Confirm the exact cached-skip lines in each function (do not assume the line
+  numbers below — this brief was written 2026-07-03, verified against
+  `engine.go` at that commit, showing:
+  `prepBookEmbed` skip at line 2094 (`existing.TextHash == hash && de.embeddingModelMatches(existing.Model)`),
+  `EmbedAuthor` skip at line 2244 (`existing.TextHash == hash` — no model check),
+  `EmbedBooksAsync` skip at line 2308 (`existing.TextHash == hash` — no model check)):
+  ```bash
+  grep -n "existing.TextHash == hash" internal/dedup/engine.go
+  ```
+  If any of the three matches above already includes `embeddingModelMatches`,
+  stop and re-read the Idempotency section before making further changes —
+  that function's fix may already be shipped.
+
+## Step-by-step
+
+1. Open `internal/dedup/engine.go`. Re-verify anchors with the greps above.
+2. In `EmbedAuthor`, change:
+   ```go
+   existing, err := de.embedStore.Get("author", entityID)
+   if err == nil && existing != nil && existing.TextHash == hash {
+   ```
+   to:
+   ```go
+   existing, err := de.embedStore.Get("author", entityID)
+   if err == nil && existing != nil && existing.TextHash == hash && de.embeddingModelMatches(existing.Model) {
+   ```
+   Leave the rest of the function (the `mirrorAuthorToChromem` call, the
+   `return nil`, and the fallthrough embed-and-upsert path) untouched — the
+   existing fallthrough already re-embeds and re-upserts with the current
+   `de.embedClient.Model()`, so no other change is needed for the re-embed to
+   pick up the new model.
+3. In `EmbedBooksAsync`, change the per-book skip inside the `for _, book :=
+   range books` loop:
+   ```go
+   existing, getErr := de.embedStore.Get("book", book.ID)
+   if getErr == nil && existing != nil && existing.TextHash == hash {
+       continue
+   }
+   ```
+   to:
+   ```go
+   existing, getErr := de.embedStore.Get("book", book.ID)
+   if getErr == nil && existing != nil && existing.TextHash == hash && de.embeddingModelMatches(existing.Model) {
+       continue
+   }
+   ```
+   Do not add backend gating (openai-only) here — that is a separate,
+   later-wave task. This change only fixes the model-skip bug.
+4. Do not touch `embeddingModelMatches` itself, `prepBookEmbed`, or any other
+   function.
+5. Extend `internal/dedup/embed_model_cutover_test.go` (existing pattern:
+   `TestEmbedBooks_ReembedsOnModelChange`, using `setupTestEngine`,
+   `ai.NewEmbeddingClientWithOptions`, and `SetRawEmbedForTest`) with a new
+   test `TestEmbedAuthor_ReembedsOnModelChange`:
+   - Set `mock.GetAuthorByIDFunc` to return a fixed `*database.Author{ID: <n>,
+     Name: "A Real Author"}` for the target ID.
+   - Embed once with `clientA` (model "model-A") via `engine.EmbedAuthor(ctx,
+     authorID)`; assert the stored embedding row (`es.Get("author",
+     entityID)`, `entityID = strconv.Itoa(authorID)`) has `Model == "model-A"`.
+   - Switch `engine.embedClient` to `clientB` (model "model-B", same author
+     name so `TextHash` is unchanged); call `EmbedAuthor` again; assert
+     `clientB`'s raw-embed fake was invoked (re-embed happened, not skipped)
+     and the stored row now has `Model == "model-B"`.
+   - Sanity: call `EmbedAuthor` a third time at the same model/content;
+     assert the raw-embed fake is NOT invoked again (still skips on a true
+     cache hit).
+   This mirrors `TestEmbedBooks_ReembedsOnModelChange` exactly, adapted for
+   the author entity type.
+6. Optionally add a lighter analogous case for `EmbedBooksAsync` if it fits
+   cleanly with the existing mock surface (`mock.GetAllBooksFunc`,
+   `mock.GetAuthorByIDFunc`, `mock.GetSeriesByIDFunc`); this is not required
+   for acceptance if it would require substantially new test scaffolding — the
+   `EmbedAuthor` test is the load-bearing regression test since the advisor
+   pass identified `EmbedAuthor` as the live exposure (`EmbedBooksAsync` is
+   currently inert under Ollama).
+7. Bump the file header (version bump + `last-edited` date) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/dedup/... -run 'ReembedsOnModelChange|EmbedAuthor|EmbedBooksAsync' -count=1 -v
+go test ./internal/dedup/... -count=1
+go vet ./internal/dedup/...
+```
+
+## Acceptance criteria
+
+- [ ] `EmbedAuthor`'s cached-skip condition includes
+      `de.embeddingModelMatches(existing.Model)` in addition to the existing
+      `TextHash` check.
+- [ ] `EmbedBooksAsync`'s per-book cached-skip condition includes
+      `de.embeddingModelMatches(existing.Model)` in addition to the existing
+      `TextHash` check.
+- [ ] No backend/openai gating was added to `EmbedBooksAsync` in this change
+      (that belongs to a separate task).
+- [ ] `embeddingModelMatches` and `prepBookEmbed` are unmodified.
+- [ ] New test `TestEmbedAuthor_ReembedsOnModelChange` (or equivalently named)
+      proves: (a) same model + same content → skip (no re-embed call), (b)
+      different model + same content → forced re-embed, stored `Model`
+      updated to the new client's model.
+- [ ] `go test ./internal/dedup/...` is green; `go vet ./internal/dedup/...`
+      is clean; `go build ./...` succeeds.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(dedup): make EmbedAuthor and EmbedBooksAsync re-embed skips model-aware (DEDUPC-1)
+
+prepBookEmbed's cached-skip was fixed in #1738 to also check
+embeddingModelMatches, forcing a re-embed on a backend/model cutover even
+when the text hash is unchanged. EmbedAuthor and EmbedBooksAsync still
+skipped on TextHash alone, so after the OpenAI-to-Ollama cutover every
+author embedding stayed permanently stranded on the old 3072-dim
+text-embedding-3-large vectors (author names rarely change), silently
+degrading author dedup Layer 2 to mixed-dimension comparisons that score
+zero or panic. Apply the same guard used in prepBookEmbed to both.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-04-author-embed-model-skip
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `EmbedAuthor`'s and `EmbedBooksAsync`'s cached-skip conditions already
+include `de.embeddingModelMatches(...)`, this task is done — verify with:
+```bash
+grep -n "existing.TextHash == hash" internal/dedup/engine.go
+```
+and confirm every match is followed by `&& de.embeddingModelMatches(...)`. If
+only one of the two functions is missing the guard, apply the fix to that
+function only and note in the PR description which one was already fixed.
+Rollback = revert the commit; `prepBookEmbed`'s existing fixed behavior is
+untouched by this change and remains in effect either way. This task does
+**not** trigger a production author re-embed pass — that is an explicit
+follow-on operational step (running `dedup.embed-scan` or equivalent against
+authors) to be done separately, after this code fix merges and deploys, not
+as part of this task's acceptance criteria.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-05-retire-embed-async-nightly.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-05-retire-embed-async-nightly.md
@@ -1,0 +1,192 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-05-retire-embed-async-nightly.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9c5baaa3-5a2e-40b8-8c2a-b4fcd1a3f5ba -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-05 — Retire/gate nightly `dedup.embed-async` (quota-dead OpenAI Batch API)
+
+**Priority:** P0 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-05-retire-embed-async-nightly" -b agent/cr-05-retire-embed-async-nightly origin/main
+cd "$REPO/.worktrees/cr-05-retire-embed-async-nightly"
+git rebase origin/main
+```
+
+## Goal
+
+`dedup.embed-async` is nightly-scheduled (`"0 3 * * *"`) but always delegates
+to the OpenAI Batch API — which is quota-dead now that the primary embedding
+backend is local Ollama (bge-m3). Every night this either 429s against a dead
+OpenAI account (pure ops noise) or, worse, could one day submit vectors of the
+wrong dimension into the index if OpenAI quota is ever restored mid-cutover.
+Fix: (1) remove the op from the default nightly cron schedule, keeping it
+invocable manually for a future OpenAI-restored world, and (2) add a runtime
+guard inside the op's run function that skips with a clear `slog.Warn` when
+the configured embedding backend is not OpenAI, so manual invocation is also
+safe.
+
+## Background (verify before editing)
+
+- `internal/plugins/dedup/embed_async.go` defines `embedAsyncDef()`
+  (`sdk.OperationDef` for op ID `"dedup.embed-async"`) with
+  `Schedule: &sched` where `sched := "0 3 * * *"` — nightly 03:00 server
+  time. Its `Run` field points at `runEmbedAsync`, a one-line wrapper that
+  calls `p.runEmbedScanMode(ctx, true, reporter)`.
+  - `runEmbedScanMode(ctx, async=true, ...)` (in `embed_scan.go`) calls
+    `p.engine.EmbedBooksAsync(ctx)`, which (in `internal/dedup/engine.go`)
+    ends by calling `de.embedClient.CreateEmbeddingBatch(ctx, items)` —
+    the OpenAI Batch API. Ollama's `/v1` surface has no batch endpoint.
+  - The sync path (`dedup.embed-scan` without `async:true`) is what the
+    local-embeddings cutover actually uses
+    (`docs/status/2026-07-02-local-cutover-and-matching.md:55-57`
+    explicitly avoids `embed-async` for this reason).
+  - `sdk.OperationDef.Schedule` is `*string` (`internal/operations/registry/types.go:77`)
+    — setting it to `nil` removes the op from the cron scheduler entirely
+    while leaving the op ID registered and manually invocable (e.g. via
+    `POST /api/v1/dedup/embed-async`, wired in
+    `internal/server/wire_dedup_routes.go:56` →
+    `internal/server/handlers/dedup/handler.go:1611` `TriggerEmbedAsync`).
+  - Embedding backend config lives in `internal/config/config.go`:
+    `EmbeddingConfig.BaseURL` (`embedding.base_url`, env `EMBEDDING_BASE_URL`)
+    is empty by default (OpenAI) and non-empty when overridden to point at
+    Ollama or another local endpoint — the same signal already used at
+    `internal/server/server.go:622`
+    (`config.AppConfig.Embedding.BaseURL != ""` ⇒ non-OpenAI backend
+    configured). The separate `config.AppConfig.OpenAIAPIKey`
+    (`internal/config/config.go` ~line 262, `openai_api_key`) is the OpenAI
+    credential; empty means no OpenAI key is configured at all. Treat
+    **either** condition (`BaseURL != ""` OR `OpenAIAPIKey == ""`) as
+    "not an OpenAI backend" — gate on that combined check.
+  - `internal/plugins/dedup/reembed_embeddings.go` already imports
+    `"github.com/falkcorp/audiobook-organizer/internal/config"` from this
+    same package — use the identical import path.
+  - The package already uses `log/slog` elsewhere (e.g.
+    `internal/plugins/dedup/check_book.go:135` calls
+    `slog.Warn("dedup.check-book CheckBook error", "id", sub.ID, "err", err)`)
+    — match that key=value logging style.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (p \*Plugin) embedAsyncDef\|func (p \*Plugin) runEmbedAsync\|Schedule:\s*&sched\|sched :=" internal/plugins/dedup/embed_async.go
+  grep -n "Schedule \*string" internal/operations/registry/types.go
+  grep -n "BaseURL\s*string\|OpenAIAPIKey\s*string" internal/config/config.go
+  grep -n "p.embedAsyncDef()" internal/plugins/dedup/plugin.go
+  ```
+  Confirm the current body of `embedAsyncDef()` still sets
+  `Schedule: &sched` with `sched := "0 3 * * *"`, and that `runEmbedAsync`
+  is still the one-line delegate shown above — if either has already
+  changed (e.g. `Schedule` is already `nil`), stop and see
+  "Idempotency / Rollback" below instead of re-doing the change.
+
+## Step-by-step
+
+1. Open `internal/plugins/dedup/embed_async.go`.
+2. In `embedAsyncDef()`, remove the nightly cron schedule: delete the
+   `sched := "0 3 * * *"` local variable and change `Schedule: &sched` to
+   `Schedule: nil` (or simply omit the `Schedule` field — the zero value of
+   `*string` is `nil`). Update the comment `// nightly at 03:00 server time`
+   to explain the op is now manual-only (e.g. "manual invocation only —
+   nightly cron retired; OpenAI Batch API is quota-dead under the Ollama
+   cutover, see docs/status/2026-07-02-local-cutover-and-matching.md").
+3. Update `DisplayName` and `Description` if they reference "nightly" —
+   re-verify current text with `grep -n "DisplayName\|Description" internal/plugins/dedup/embed_async.go`
+   before editing, keep the "[deprecated — use embed-scan with async:true]"
+   suffix intact.
+4. In `runEmbedAsync`, before delegating to `runEmbedScanMode`, add a guard:
+   ```go
+   if config.AppConfig.Embedding.BaseURL == "" && config.AppConfig.OpenAIAPIKey == "" {
+       slog.Warn("dedup.embed-async skipped: no OpenAI backend configured (Ollama/local embedding is primary)", "base_url", config.AppConfig.Embedding.BaseURL)
+       return nil
+   }
+   ```
+   Adjust the condition to match what you verify in config.go — the intent
+   is: skip (do not error) whenever the effective embedding backend is not
+   OpenAI, i.e. either a non-empty override `BaseURL` is set (pointing at
+   Ollama/local) or there is no OpenAI API key configured at all. Add the
+   `"log/slog"` and
+   `"github.com/falkcorp/audiobook-organizer/internal/config"` imports to
+   `embed_async.go` (re-check they aren't already imported).
+5. Do NOT touch `embed_scan.go`, `engine.go`, `batch_poller.go`, or
+   `batch_poller_register.go` — this task is scoped to the schedule +
+   runtime guard on `embed_async.go` only. (Model-aware skip parity with
+   the sync path, mentioned in OPS-3, is a separate, larger follow-up —
+   do not attempt it here.)
+6. Add or extend a test in `internal/plugins/dedup/*_test.go` (find the
+   existing test file for this package with
+   `ls internal/plugins/dedup/*_test.go | xargs grep -l "embed_async\|embedAsyncDef\|runEmbedAsync"`;
+   if none exists, create `internal/plugins/dedup/embed_async_test.go`) that:
+   - Asserts `embedAsyncDef().Schedule` is `nil`.
+   - Asserts `runEmbedAsync` returns `nil` (no error, no batch submission)
+     when `config.AppConfig.Embedding.BaseURL` is empty and
+     `config.AppConfig.OpenAIAPIKey` is empty — save/restore
+     `config.AppConfig` around the test to avoid polluting other tests
+     (check how existing tests in this package snapshot/restore
+     `config.AppConfig`, e.g. `grep -n "config.AppConfig" internal/plugins/dedup/*_test.go`).
+7. Bump the file header (version + `last-edited`) on every file you touch,
+   per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/plugins/dedup/... -run 'EmbedAsync|Embed' -count=1 -v
+go vet ./internal/plugins/dedup/...
+```
+
+## Acceptance criteria
+
+- [ ] `embedAsyncDef().Schedule` is `nil` — the op no longer appears on any
+      cron schedule; `grep -n "Schedule" internal/plugins/dedup/embed_async.go`
+      shows no `"0 3 * * *"` literal.
+- [ ] The op ID `dedup.embed-async` remains registered (still returned by
+      `plugin.go`'s op list) and still reachable via
+      `POST /api/v1/dedup/embed-async` for manual invocation.
+- [ ] `runEmbedAsync` skips (returns `nil`, logs `slog.Warn`, does not call
+      `runEmbedScanMode`/`EmbedBooksAsync`) when the effective backend is not
+      OpenAI (empty `OpenAIAPIKey` and no override `BaseURL`, or an explicit
+      non-OpenAI `BaseURL`).
+- [ ] New/updated test covers both the nil-Schedule assertion and the
+      skip-guard behavior; `go test ./internal/plugins/dedup/...` is green.
+- [ ] `go build ./...` and `go vet ./internal/plugins/dedup/...` are clean.
+- [ ] File headers bumped on every changed file.
+- [ ] `embed_scan.go`, `engine.go`, and the batch-poller files are
+      untouched (confirm with `git diff --stat origin/main`).
+
+## Commit message
+
+```
+fix(dedup): retire nightly cron + gate dedup.embed-async on OpenAI backend
+
+dedup.embed-async was scheduled nightly at 03:00 against the OpenAI Batch
+API, which is quota-dead now that Ollama/bge-m3 is the primary embedding
+backend. This produced nightly 429 noise and risked ingesting wrong-dimension
+vectors if OpenAI quota is ever restored mid-cutover. Remove the cron
+schedule (manual invocation only) and add a runtime skip-with-warn guard so
+the op is a no-op whenever the configured backend isn't OpenAI.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-05-retire-embed-async-nightly
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `embedAsyncDef().Schedule` is already `nil` (verify with
+`grep -n "Schedule" internal/plugins/dedup/embed_async.go`) AND
+`runEmbedAsync` already contains a backend-gating check before calling
+`runEmbedScanMode`, this task is done — no further action needed. If only
+the schedule removal is done but the runtime guard is missing (or vice
+versa), do the missing half only. Rollback = revert the commit; the op ID,
+its registration in `plugin.go`, and the `POST /dedup/embed-async` route are
+untouched by this change and remain in effect either way.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-06-keyless-local-registration.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-06-keyless-local-registration.md
@@ -1,0 +1,218 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-06-keyless-local-registration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a6ea4580-aeb8-4e62-84c5-dd36cde278b2 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-06 — Keyless local-backend registration (drop `OpenAIAPIKey` requirement)
+
+**Priority:** P0 · **Effort:** S · **Recommended subagent:** Sonnet · go-backend subagent · **Depends on:** none · **Wave:** 1
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-06-keyless-local-registration" -b agent/cr-06-keyless-local-registration origin/main
+cd "$REPO/.worktrees/cr-06-keyless-local-registration"
+git rebase origin/main
+```
+
+## Goal
+
+Close TOGGLE-1 / MATCH-8 (`docs/consultancy/03-matching-and-backends.md`): the
+`embedclient` and `llmparser` service registrations in `internal/ai/register.go`
+currently refuse to construct their client at all when `cfg.OpenAIAPIKey` is
+empty — even when an explicit local OpenAI-compatible endpoint (e.g. Ollama) is
+configured and needs no key. If an operator removes a now-useless,
+quota-exhausted OpenAI key, the local backend silently goes dark (nil client →
+nil `metadatascorer` → silent F1 downgrade, no warning) even though the
+endpoint is fully reachable. Decouple "should we build this client" from "do we
+have a real OpenAI key" by keying off whether an explicit base URL is
+configured, passing a dummy bearer token when no real key is present. Do **not**
+weaken the real-OpenAI path: when no base URL is configured, a non-empty key is
+still mandatory.
+
+Out of scope (do not attempt): the full backend-mode toggle (TOGGLE-3), a
+dedicated LLM base-URL config field (`LocalBaseURL`/`LocalLLMModel` — that
+config surface does not exist yet), and 429/insufficient_quota error
+classification (TOGGLE-4). This task only removes the artificial key
+requirement for construction; it does not add new config fields.
+
+## Background (verify before editing)
+
+- `internal/ai/register.go` registers `embedclient` and `llmparser` via
+  `serviceregistry.Register`. As of this writing:
+  - `embedclient`'s `Build` func returns `(*EmbeddingClient)(nil), nil` when
+    `cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled` — this happens *before*
+    the existing `baseURL := cfg.Embedding.BaseURL` resolution that already
+    exists a few lines later (which falls back to `os.Getenv("OPENAI_BASE_URL")`
+    when the config field is empty). So a configured `Embedding.BaseURL`
+    pointing at local Ollama is never even consulted if the key is empty.
+  - `llmparser`'s `Build` func returns `(*OpenAIParser)(nil), nil` when
+    `cfg.OpenAIAPIKey == ""`, with no base-URL awareness of its own —
+    `NewOpenAIParser` (`internal/ai/openai_parser.go`) itself only consults the
+    process-wide `os.Getenv("OPENAI_BASE_URL")` env for its base URL (there is
+    no per-config LLM base-URL field yet — that's TOGGLE-3, a separate,
+    larger task).
+  - `NewEmbeddingClientWithOptions(apiKey, model, baseURL string) *EmbeddingClient`
+    (`internal/ai/embedding_client.go`) takes `apiKey` as a plain string and
+    only adds `option.WithAPIKey(apiKey)` — it does not itself validate the key
+    is non-empty, so passing a dummy value (e.g. `"ollama"`) is safe and Ollama
+    ignores the `Authorization` header entirely.
+  - `NewOpenAIParser(cfg *config.Config, apiKey string, enabled bool) *OpenAIParser`
+    (`internal/ai/openai_parser.go`) returns a disabled parser when
+    `apiKey == ""` (`!enabled || apiKey == ""`) — passing a non-empty dummy key
+    when a base URL is present makes it proceed to construct a real client
+    against that base URL.
+  - `internal/server/server.go` has a separate, already-correct availability
+    trust fix (PR #1739/#1740, comment "Gate embedding client on Ollama
+    availability..."): it treats an explicit `config.AppConfig.Embedding.BaseURL`
+    as proof the endpoint exists, independent of the `exec.LookPath` binary
+    probe. That logic runs on `server.embedClient` **after** it's constructed —
+    it is orthogonal to this task's construction-time gate and must NOT be
+    duplicated or altered; just confirm it still compiles/behaves the same once
+    `embedClient` is non-nil in more cases than before.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "OpenAIAPIKey == \"\"\|func NewEmbeddingClientWithOptions\|func NewOpenAIParser\b" \
+    internal/ai/register.go internal/ai/embedding_client.go internal/ai/openai_parser.go
+  ```
+  Confirm the server-side availability gate is unchanged in shape:
+  ```bash
+  grep -n "Gate embedding client on Ollama availability\|ollamaOK :=\|SetOllamaAvailable(ollamaOK)" \
+    internal/server/server.go
+  ```
+
+## Step-by-step
+
+1. In `internal/ai/register.go`, add a small unexported helper (place it above
+   the `init()` func, in the same file, so both registrations share one code
+   path):
+   ```go
+   // resolveAIEndpointKey decides whether an OpenAI-compatible client should be
+   // constructed and what API key to hand it. When a real apiKey is configured
+   // it's always used. When apiKey is empty but an explicit baseURL is
+   // configured (a local OpenAI-compatible backend, e.g. Ollama, which ignores
+   // the Authorization header), a dummy bearer is substituted so construction
+   // proceeds. When neither is set, construction is skipped — the real-OpenAI
+   // path (no baseURL) still requires a real key.
+   func resolveAIEndpointKey(apiKey, baseURL string) (resolvedKey string, ok bool) {
+       if apiKey != "" {
+           return apiKey, true
+       }
+       if baseURL != "" {
+           return "ollama", true
+       }
+       return "", false
+   }
+   ```
+2. In the `embedclient` `Build` func:
+   - Move the `baseURL` resolution (`cfg.Embedding.BaseURL`, falling back to
+     `os.Getenv("OPENAI_BASE_URL")`) so it happens *before* the key check.
+   - Replace the early-return condition `cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled`
+     with: return nil when `!cfg.Embedding.Enabled`, then call
+     `resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)` and
+     return `(*EmbeddingClient)(nil), nil` when `!ok`.
+   - Pass `resolvedKey` (not `cfg.OpenAIAPIKey`) into
+     `NewEmbeddingClientWithOptions(resolvedKey, cfg.Embedding.Model, baseURL)`.
+3. In the `llmparser` `Build` func:
+   - Resolve `baseURL := os.Getenv("OPENAI_BASE_URL")` (the only base-URL
+     signal `NewOpenAIParser` currently understands — do not invent a new
+     config field, that's TOGGLE-3).
+   - Replace `if cfg.OpenAIAPIKey == "" { return (*OpenAIParser)(nil), nil }`
+     with `resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)`
+     and return nil when `!ok`.
+   - Pass `resolvedKey` into `NewOpenAIParser(cfg, resolvedKey, cfg.EnableAIParsing)`.
+4. Add a log line at `slog.Warn` (or the package's existing logging
+   convention — grep for `slog.` usage elsewhere in `internal/ai/register.go`
+   or sibling files first) when a dummy key is substituted, so operators can
+   see in logs that a tier is running in local/keyless mode rather than
+   silently. If the file has no existing logging import, add `log/slog` and
+   keep the message factual (no PII, no key value).
+5. Do NOT change `internal/server/server.go` — re-verify its availability gate
+   still compiles and its semantics are unaffected (it only reacts to
+   `server.embedClient != nil`, which is now true in one more case: keyless +
+   explicit base URL — which is exactly the case it already special-cases via
+   `config.AppConfig.Embedding.BaseURL != ""`).
+6. Add unit tests in `internal/ai/register_test.go` (new file) covering the 4
+   combinations of `resolveAIEndpointKey`:
+   - `apiKey != "", baseURL == ""` → real key returned, `ok == true`.
+   - `apiKey != "", baseURL != ""` → real key returned (key takes priority),
+     `ok == true`.
+   - `apiKey == "", baseURL != ""` → dummy key returned, `ok == true`.
+   - `apiKey == "", baseURL == ""` → `ok == false` (construction skipped).
+   Test `resolveAIEndpointKey` directly (it's a pure function) rather than
+   driving the full `serviceregistry.Container` — that keeps the test fast and
+   avoids container-wiring boilerplate unrelated to this fix.
+7. Bump the file header (version bump + `last-edited` date) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/ai/... -run 'TestResolveAIEndpointKey|TestRegister' -count=1 -v
+go test ./internal/ai/... -count=1
+go vet ./internal/ai/...
+```
+
+## Acceptance criteria
+
+- [ ] `embedclient` constructs a client when `Embedding.Enabled` and either a
+      real `OpenAIAPIKey` OR an explicit `Embedding.BaseURL` (or
+      `OPENAI_BASE_URL` env) is set — not both required.
+- [ ] `embedclient` still returns nil when `Embedding.Enabled` is false,
+      regardless of key/base-URL.
+- [ ] `embedclient` still returns nil when neither a key nor a base URL is
+      configured (the "nothing configured" case is unchanged).
+- [ ] `llmparser` constructs a parser when either a real `OpenAIAPIKey` OR
+      `OPENAI_BASE_URL` env is set — not both required.
+- [ ] Real-OpenAI path (no base URL configured) still requires a non-empty key
+      — this task does not weaken that check.
+- [ ] `resolveAIEndpointKey` unit tests cover all 4 key/base-URL combinations
+      and pass.
+- [ ] `internal/server/server.go`'s Ollama-availability trust logic
+      (`ollamaOK := ... || config.AppConfig.Embedding.BaseURL != ""`) is
+      untouched and still compiles.
+- [ ] `go build ./...`, `go test ./internal/ai/...`, and `go vet ./internal/ai/...`
+      are green.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(ai): allow keyless registration of embedclient/llmparser for local backends
+
+embedclient and llmparser both gated construction on a non-empty
+OpenAIAPIKey even when an explicit base URL pointed at a local
+OpenAI-compatible backend (e.g. Ollama), which needs no key. Removing a
+quota-dead OpenAI key silently disabled local embeddings/LLM with no
+warning. Add resolveAIEndpointKey to substitute a dummy bearer when a
+base URL is configured but no key is set, while still requiring a real
+key on the no-base-URL (real OpenAI) path.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-06-keyless-local-registration
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `embedclient`'s `Build` func already resolves `baseURL` before checking the
+key, and both `embedclient` and `llmparser` already accept a dummy/placeholder
+key when a base URL is present, this task is done — verify with:
+```bash
+grep -n "resolveAIEndpointKey\|OpenAIAPIKey == \"\"" internal/ai/register.go
+```
+If `resolveAIEndpointKey` (or an equivalent helper) already exists and is
+wired into both `Build` funcs, skip this task. Rollback = revert the commit;
+the pre-existing behavior (key-required for both registrations) is fully
+restored since this change is additive/gating-only and does not alter
+`NewEmbeddingClientWithOptions`, `NewOpenAIParser`, or `server.go`.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-07-hook-credentials-and-sha-pin.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-07-hook-credentials-and-sha-pin.md
@@ -1,0 +1,299 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-07-hook-credentials-and-sha-pin.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5a80e2b2-c3a0-4b57-87fa-11e610be928e -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-07 — Fix pre-commit hook `.claude/.credentials/` block + SHA-pin security.yml
+
+**Priority:** P0 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-07-hook-credentials-and-sha-pin" -b agent/cr-07-hook-credentials-and-sha-pin origin/main
+cd "$REPO/.worktrees/cr-07-hook-credentials-and-sha-pin"
+git rebase origin/main
+```
+
+## Goal
+
+Two independent, small fixes, both security hygiene (SEC-2, SEC-5, PROC-7, PROC-8 from `docs/consultancy/06-process-and-security.md`):
+
+1. `scripts/setup-git-hooks.sh` documents that the pre-commit hook protects
+   `.claude/.credentials/` (a directory of per-worktree username/password
+   files), but the hook's match logic can never match anything inside a
+   directory — fix the array + matching so staged files under
+   `.claude/.credentials/` are actually rejected, add a self-test, and
+   reinstall the hook as part of verification (the installed hook has also
+   drifted from the script over time — PROC-8 — so reinstalling closes that
+   gap too).
+2. `.github/workflows/security.yml` references
+   `falkcorp/github-common/.github/workflows/reusable-security.yml@main` — the
+   only workflow reference in the repo not pinned to a SHA, violating the
+   repo's own mandatory SHA-pin policy. Pin it to the current `github-common`
+   `main` commit SHA, matching the pattern used by the other reusable-workflow
+   callers (`ci.yml`, `nightly-burndown.yml`, etc).
+
+## Background (verify before editing)
+
+- `scripts/setup-git-hooks.sh` writes `.git/hooks/pre-commit` from a heredoc.
+  As of this writing (verify with the greps below — do not trust these line
+  numbers blindly):
+  - `PROTECTED_FILES` array (lines ~17-22) contains only `.api-token`,
+    `.claude/.api-token`, `.bootstrap-token`, `.readonly-key` — plain
+    filenames, no directory entry for `.claude/.credentials/`.
+  - The match (line ~27) is `echo "$STAGED_FILES" | grep -q "^$FILE$"` — an
+    **exact full-line match**. A file staged as `.claude/.credentials/foo.json`
+    can never equal the literal string `.claude/.credentials/` (or any fixed
+    filename), so no entry you could add to the array as a bare string would
+    ever match a file *inside* that directory with this matching logic.
+  - The success message (line ~53) already claims
+    `".claude/.credentials/ (per-worktree username/password)"` is protected —
+    it is not, today.
+  - `.gitignore` covers `.claude/.credentials/` as the primary defense
+    (`grep -n "credentials" .gitignore`), but `git add -f` bypasses `.gitignore`
+    and sails straight through the hook that the docs claim would block it.
+  - There is no self-test for the hook logic anywhere in the repo (confirmed:
+    `grep -rl "setup-git-hooks" scripts/ 2>/dev/null` returns only the script
+    itself).
+
+- **Re-verify these anchors before editing:**
+  ```bash
+  grep -n "PROTECTED_FILES\|grep -q \"\^\$FILE\|\.claude/\.credentials" scripts/setup-git-hooks.sh
+  grep -n "credentials" .gitignore
+  ```
+
+- `.github/workflows/security.yml` line ~30 (verify with the grep below) has:
+  ```yaml
+  uses: falkcorp/github-common/.github/workflows/reusable-security.yml@main
+  ```
+  Every other reusable-workflow caller in this repo pins to a 40-char SHA with
+  a trailing version comment, e.g.:
+  ```
+  .github/workflows/ci.yml:31:               ...reusable-ci-minimal.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
+  .github/workflows/nightly-burndown.yml:28:  ...reusable-burndown.yml@66059b7eba8a00bee7e45a114c00251f0a6c3a07 # v1.11.2 + submodules:recursive + triage-poll pin fix
+  ```
+  `security.yml` is the sole `@main` holdout. The current HEAD of
+  `falkcorp/github-common` `main` (verified 2026-07-03) is
+  `1dec34cd8d8e2504d9be8298b522eff11448a401` — **re-verify this yourself**,
+  it may have moved since this brief was written:
+  ```bash
+  git ls-remote https://github.com/falkcorp/github-common.git refs/heads/main
+  ```
+  Use whatever SHA that command returns at the time you do the work, not the
+  one printed above, unless they match.
+
+- **Re-verify the security.yml anchor before editing:**
+  ```bash
+  grep -n "reusable-security.yml@" .github/workflows/security.yml
+  grep -rn "falkcorp/github-common" .github/workflows/*.yml
+  ```
+
+- **CAUTION — workflow file push restriction (repo rule):** `.github/workflows/*`
+  changes cannot be pushed with a plain `GITHUB_TOKEN` (needs `workflows:write`).
+  Do **not** attempt to push this change via any MCP GitHub "contents" API —
+  that has caused file corruption in this repo before. Push via normal `git
+  push` as the authenticated user (same as any other branch); if `git push`
+  is rejected for lacking `workflows:write` scope, stop and report that back
+  rather than working around it.
+
+## Step-by-step
+
+### Part A — pre-commit hook
+
+1. Open `scripts/setup-git-hooks.sh`. Re-verify the array and match logic with
+   the greps above.
+2. Add `".claude/.credentials/"` (with trailing slash) to the `PROTECTED_FILES`
+   array, immediately after `.readonly-key`.
+3. Replace the exact-match check with logic that treats array entries ending
+   in `/` as directory prefixes and everything else as before (exact filename
+   match). Example replacement for the loop body:
+   ```bash
+   for FILE in "${PROTECTED_FILES[@]}"; do
+       if [[ "$FILE" == */ ]]; then
+           MATCH=$(echo "$STAGED_FILES" | grep -q "^$FILE" && echo yes)
+       else
+           MATCH=$(echo "$STAGED_FILES" | grep -q "^$FILE$" && echo yes)
+       fi
+       if [[ "$MATCH" == "yes" ]]; then
+           echo "❌ Error: Attempting to commit protected file/path: $FILE"
+           echo ""
+           echo "This file contains secrets and should never be committed."
+           echo "It's in .gitignore and is auto-generated by scripts."
+           echo ""
+           echo "To unstage this file:"
+           echo "  git reset HEAD $FILE"
+           echo ""
+           exit 1
+       fi
+   done
+   ```
+   (Keep the rest of the heredoc — the `#!/bin/bash` line, the comment, `exit 0`
+   at the end — unchanged. The directory-prefix branch's `grep -q "^$FILE"`
+   without a trailing `$` deliberately matches any staged path that starts
+   with `.claude/.credentials/`.)
+4. Add a self-test script at `scripts/test-git-hooks.sh` that exercises the
+   hook logic in an isolated scratch git repo (does not touch the real repo
+   or its hooks):
+   ```bash
+   #!/bin/bash
+   # file: scripts/test-git-hooks.sh
+   # version: 1.0.0
+   # Self-test for scripts/setup-git-hooks.sh: verifies the installed
+   # pre-commit hook blocks protected files/dirs and allows normal files.
+   set -euo pipefail
+
+   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   TMPDIR=$(mktemp -d)
+   trap 'rm -rf "$TMPDIR"' EXIT
+
+   cd "$TMPDIR"
+   git init -q .
+   git config user.email test@example.com
+   git config user.name test
+   bash "$SCRIPT_DIR/setup-git-hooks.sh" >/dev/null
+
+   fail=0
+
+   # Case 1: file directly under the protected credentials directory must be blocked.
+   mkdir -p .claude/.credentials
+   echo '{"user":"x"}' > .claude/.credentials/some-branch.json
+   git add -f .claude/.credentials/some-branch.json
+   if git commit -q -m "should be blocked" >/tmp/hook-test-out 2>&1; then
+       echo "FAIL: commit of .claude/.credentials/some-branch.json was NOT blocked"
+       fail=1
+   else
+       echo "PASS: .claude/.credentials/some-branch.json blocked"
+   fi
+   git reset -q HEAD .claude/.credentials/some-branch.json 2>/dev/null || true
+
+   # Case 2: a normal file must NOT be blocked.
+   echo "hello" > normal-file.txt
+   git add normal-file.txt
+   if git commit -q -m "normal commit" >/tmp/hook-test-out2 2>&1; then
+       echo "PASS: normal-file.txt allowed"
+   else
+       echo "FAIL: normal-file.txt was incorrectly blocked"
+       cat /tmp/hook-test-out2
+       fail=1
+   fi
+
+   exit "$fail"
+   ```
+   Make it executable: `chmod +x scripts/test-git-hooks.sh`.
+5. Reinstall the hook in **this worktree** so the fix is actually active
+   (addresses PROC-8 — the installed hook drifts from the script until
+   re-run):
+   ```bash
+   bash scripts/setup-git-hooks.sh
+   bash scripts/test-git-hooks.sh
+   ```
+   Both self-test cases must print `PASS`.
+6. Bump the file header in `scripts/setup-git-hooks.sh` (version + last-edited)
+   and add a header to the new `scripts/test-git-hooks.sh`, per
+   `.standards/instructions/file-headers.md` (or the format shown in this
+   brief's own header if the submodule is absent locally).
+
+### Part B — SHA-pin security.yml
+
+7. Re-run the `git ls-remote` command above to get the current
+   `github-common` `main` SHA.
+8. In `.github/workflows/security.yml`, change:
+   ```yaml
+   uses: falkcorp/github-common/.github/workflows/reusable-security.yml@main
+   ```
+   to:
+   ```yaml
+   uses: falkcorp/github-common/.github/workflows/reusable-security.yml@<SHA> # main @ 2026-07-03, no tagged release yet
+   ```
+   substituting the real SHA and today's date. Match the existing comment
+   style used by `nightly-burndown.yml` (plain-language note, not necessarily
+   a version tag, since this SHA may be ahead of the latest `github-common`
+   tag).
+9. Bump the file header (`version`, `last-edited`) at the top of
+   `security.yml`.
+
+## How to test
+
+```bash
+# Part A
+bash scripts/setup-git-hooks.sh
+bash scripts/test-git-hooks.sh
+echo "exit: $?"          # must be 0, both cases must print PASS
+
+# Part B — YAML sanity (no live CI trigger needed for this brief)
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/security.yml'))"
+grep -n "reusable-security.yml@" .github/workflows/security.yml   # confirm SHA form, no @main left
+
+# Whole-repo sanity (docs/scripts/workflow change only, but confirm nothing else broke)
+go build ./...
+go vet ./...
+```
+
+## Acceptance criteria
+
+- [ ] `scripts/setup-git-hooks.sh`'s `PROTECTED_FILES` array includes
+      `.claude/.credentials/` and the match logic actually rejects staged
+      files inside that directory (not just the literal directory name).
+- [ ] `scripts/test-git-hooks.sh` exists, is executable, and both its
+      self-test cases (block credentials file, allow normal file) print PASS.
+- [ ] The hook has been reinstalled in this worktree
+      (`bash scripts/setup-git-hooks.sh` run) so the fix is live, not just
+      written — this also resolves the PROC-8 drift for this checkout.
+- [ ] `.github/workflows/security.yml` no longer references `@main` for the
+      `reusable-security.yml` call; it is pinned to a 40-char commit SHA with
+      a trailing comment, matching the style of the repo's other pinned
+      reusable-workflow calls.
+- [ ] File headers bumped on `scripts/setup-git-hooks.sh`,
+      `scripts/test-git-hooks.sh` (new), and `.github/workflows/security.yml`.
+- [ ] `go build ./...` and `go vet ./...` remain clean (this task touches no
+      Go code, but confirms nothing else in the working tree is broken).
+- [ ] PR pushed via plain `git push` (not the MCP GitHub contents API) — note
+      in the PR description if `workflows:write` permission was required and
+      whether the push succeeded normally.
+
+## Commit message
+
+```
+fix(security): repair credentials-dir hook match + SHA-pin security.yml (SEC-2, SEC-5, PROC-7, PROC-8)
+
+setup-git-hooks.sh claimed to protect .claude/.credentials/ but its exact-match
+grep could never match paths inside a directory, so `git add -f` sailed
+through undetected. Add a directory-prefix match branch, a self-test script,
+and reinstall the hook. Separately, security.yml was the only workflow still
+pinned to @main for a reusable workflow call, violating the repo's SHA-pin
+policy; pinned to the current github-common main commit.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-07-hook-credentials-and-sha-pin
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+- If `scripts/setup-git-hooks.sh`'s `PROTECTED_FILES` array already contains
+  a `/`-suffixed directory entry AND the match loop already branches on
+  trailing-slash entries (re-verify with
+  `grep -n "PROTECTED_FILES\|\*/\*)" scripts/setup-git-hooks.sh`), Part A is
+  already done — skip it, do not re-add a duplicate entry.
+- If `scripts/test-git-hooks.sh` already exists and passes, skip step 4;
+  just run it to confirm (step 5) rather than overwriting it.
+- If `.github/workflows/security.yml` no longer contains `@main` for the
+  `reusable-security.yml` reference (re-verify with
+  `grep -n "reusable-security.yml@" .github/workflows/security.yml`), Part B
+  is already done — do not re-pin to a different/older SHA than what is
+  already there.
+- Rollback: revert the commit. The hook change is purely additive (new array
+  entry + new match branch); reverting restores the previous (broken) exact-
+  match behavior, which was already the shipped behavior before this task, so
+  reverting is safe. The SHA pin revert restores `@main`, which is a security
+  regression but not a functional break — prefer a forward-fix (re-pin to a
+  newer SHA) over reverting if the pinned SHA turns out to be bad.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-08-deploy-recipe-and-ollama-scripts.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-08-deploy-recipe-and-ollama-scripts.md
@@ -1,0 +1,448 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-08-deploy-recipe-and-ollama-scripts.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e1113173-4516-4cb0-991b-ef5ae2fa78a8 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-08 — Commit deploy recipe templates + manage-ollama-windows.py + rollback target (OPS-1, OPS-2, OPS-6)
+
+**Priority:** P0 · **Effort:** M · **Recommended subagent:** Sonnet · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-08-deploy-recipe-and-ollama-scripts" -b agent/cr-08-deploy-recipe-and-ollama-scripts origin/main
+cd "$REPO/.worktrees/cr-08-deploy-recipe-and-ollama-scripts"
+git rebase origin/main
+```
+
+## Goal
+
+Close OPS-1 (single-machine deploy recipe, no rollback), OPS-2 (Windows GPU box
+kept alive by a scheduled task whose setup scripts exist only in a scratchpad),
+and the deploy/Ollama-script portions of OPS-6 (operational knowledge landing
+outside git). Concretely:
+
+1. Commit **sanitized templates** for the two gitignored local-only files that
+   currently hold the entire prod deploy recipe: `Makefile.local.example` and
+   `deploy/local.conf.example`.
+2. Add a `make rollback` target to the **committed** `Makefile` that restores a
+   previously-deployed binary and restarts the systemd unit, plus document (in
+   `docs/system/`) the one-line change the operator must make to their own
+   real (gitignored) `Makefile.local` `deploy` target so it actually preserves
+   a `.prev` copy before overwriting.
+3. Recreate the Windows Ollama keepalive — including registering the
+   **"OllamaServe" scheduled task** itself, not just the install/pull steps —
+   as `scripts/manage-ollama-windows.py` (Python — this repo's rule for
+   anything non-trivial; see `CLAUDE.md` "Critical Rules" §4), driven over
+   `ssh windows-gpu` using `-EncodedCommand` (base64 UTF-16LE), since a scp'd
+   `.ps1` misparses over that SSH path (see status doc, cited below). The
+   scheduled task is the actual keepalive mechanism OPS-2 flags as
+   undocumented; a script that only installs Ollama and pulls models without
+   registering the task leaves that gap open.
+4. Document all of the above in `docs/system/`.
+
+Do **not** touch the real (gitignored, machine-local) `Makefile.local` or
+`deploy/local.conf` files themselves — they are not in git and this task must
+be reproducible by an agent working in a fresh worktree that does not have
+them.
+
+## Background (verify before editing)
+
+- **OPS-1** (`docs/consultancy/06-process-and-security.md`, "OPS-1 — Deploy
+  recipe is single-machine and has no rollback"): `make deploy`
+  (`Makefile.local:13-21` on the author's laptop) cross-compiles, `scp`s the
+  binary, then `sudo mv` overwrites `/usr/local/bin/audiobook-organizer` and
+  restarts systemd. No copy of the previous binary is kept; rollback today
+  means rebuilding an older commit locally. `Makefile.local` and
+  `deploy/local.conf` are both gitignored (`.gitignore:7-8` as of this
+  writing — re-verify, see grep below) — the entire prod deploy recipe (TLS
+  paths, DB path, `WHISPER_REMOTE_URL`, `TimeoutStopSec`) exists only on one
+  machine.
+- **OPS-2** (same doc, "OPS-2 — Windows GPU box is a triple
+  single-point-of-failure held up by an interactive-session scheduled task"):
+  `172.16.3.22` serves Whisper transcription, bge-m3 embeddings, and the
+  qwen2.5 LLM. Ollama survives only via scheduled task **"OllamaServe"** bound
+  to an interactive session (GPU access requires it) — logoff/reboot/Windows
+  Update silently kills embeddings + LLM. The setup/start scripts exist **only
+  in a session scratchpad**, not in git.
+- **OPS-6** (same doc, "OPS-6 — Recurring pattern: operational knowledge lands
+  outside git"): names this exact case — `Makefile.local`'s header literally
+  says "Local-only targets — not committed", and the Ollama scripts are
+  scratchpad-only. The fix pattern: anything referenced by prod must exist in
+  git, with only secrets externalized.
+- **Status doc** `docs/status/2026-07-02-local-cutover-and-matching.md:30-38`
+  ("Local backend setup (Windows GPU box, 172.16.3.22)"): reached via
+  `ssh windows-gpu` (key preinstalled; alias defined in the operator's
+  `~/.ssh/config`, not in this repo). PowerShell over that SSH path
+  mis-parses scp'd `.ps1` — use `-EncodedCommand` (base64 UTF-16LE). Ollama is
+  kept alive by scheduled task "OllamaServe" (interactive session, because
+  `ollama serve` over plain SSH dies on disconnect / doesn't survive headless
+  auto-start). Models pulled: `bge-m3` (1024-dim embeddings),
+  `qwen2.5:7b-instruct` (LLM). Setup scripts named there:
+  `setup-ollama.ps1`, `start-ollama.ps1` — explicit TODO to commit as
+  `scripts/manage-ollama-windows.py` (status doc "Pending" item 3, and
+  "Local backend setup" bullet 4).
+
+- **Content of the actual (gitignored) files, for reference when writing the
+  sanitized `.example` templates** — read them directly if you have access to
+  the primary checkout (they will NOT exist in this worktree, since they are
+  gitignored and machine-local):
+  ```bash
+  cat "$REPO/Makefile.local" 2>/dev/null      # may not exist in your environment; that's fine
+  cat "$REPO/deploy/local.conf" 2>/dev/null
+  ```
+  If neither file is available to you, build the templates from the
+  citations above and the `Makefile`'s own `backup` target (see step 2 below)
+  — do not invent fields not implied by those sources. Redact real hostnames
+  down to what already appears in `docs/system/runbooks.md` (`172.16.2.30`)
+  and `docs/status/2026-07-02-local-cutover-and-matching.md` (`172.16.3.22`);
+  do **not** include any username, path under a real home directory, or token
+  that isn't already public in those two committed docs. Using these two IPs
+  in the `.example` templates and in `scripts/manage-ollama-windows.py` is
+  licensed specifically because both already appear, unredacted, in the two
+  committed docs cited above (`runbooks.md` for `172.16.2.30`, the status doc
+  for `172.16.3.22`) — this is not a new PII disclosure and does not reopen
+  the SEC-3 "internal infrastructure PII" finding, which concerns *other*
+  identifiers not already committed elsewhere.
+
+- **Re-verify these anchors before editing** — content may have drifted since
+  this brief was written:
+  ```bash
+  grep -n "Makefile.local\|local.conf" .gitignore
+  grep -n "^DEPLOY_HOST\|^BACKUP_DIR\|-include Makefile.local\|^backup:" Makefile
+  sed -n '1,40p' docs/system/runbooks.md
+  ls docs/system/
+  grep -rn "windows-gpu\|EncodedCommand" scripts/ docs/ 2>/dev/null
+  ```
+  Confirm the `Makefile` already defines `DEPLOY_HOST ?=` and `BACKUP_DIR ?=`
+  as overridable variables and does `-include Makefile.local` (so a
+  `rollback` target added to the committed `Makefile` can rely on
+  `DEPLOY_HOST`/`DEPLOY_BIN` being supplied by the operator's real
+  `Makefile.local`, exactly like the existing `backup` target does). Confirm
+  the existing `backup` target's guard-clause pattern
+  (`@[ -n "$(DEPLOY_HOST)" ] || (echo "ERROR: ..."; exit 1)`) — reuse it
+  verbatim style for `rollback`.
+
+## Step-by-step
+
+1. **`deploy/local.conf.example`** (new file): a sanitized copy of the real
+   `deploy/local.conf` systemd drop-in, based on the citations above. Keep the
+   structural shape (comment header explaining it's a *template*, `[Service]`
+   section, `TimeoutStopSec=`, `Environment=WHISPER_REMOTE_URL=...`, the
+   `ExecStart=` clear-and-reset pair with `serve --host --port --db
+   --tls-cert --tls-key --http3-port` flags) but mark clearly at the top that
+   real secrets/paths (TLS cert paths, actual DB path) must be filled in by
+   the operator, and that `WHISPER_REMOTE_URL` should point at their own
+   Windows GPU box. Use the `172.16.2.30` / `172.16.3.22` hosts since both
+   already appear in committed docs — no new PII.
+
+2. **`Makefile.local.example`** (new file, repo root): a sanitized template
+   covering the `deploy` and `deploy-debug` targets' *shape* — `DEPLOY_HOST`,
+   `DEPLOY_BIN` variables, a `deploy:` target that builds, scp's the binary +
+   service files, and restarts via `ssh $(DEPLOY_HOST) 'sudo mv ... &&
+   sudo systemctl restart ...'` — plus a comment block at the top explaining
+   this is a template (fill in your own `DEPLOY_HOST`), and add the `.prev`
+   preservation step described in the next bullet directly into the example's
+   `deploy:` recipe so new operators get rollback-safety by default:
+   ```
+   ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
+     sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && ...'
+   ```
+   (Adjust to match the real `deploy` target's structure if you were able to
+   read it in step 0 of Background; otherwise use the `backup` target's SSH
+   idiom as your style guide.)
+
+3. **`Makefile` — add a `rollback` target** (near the existing `backup`
+   target, same file, same section):
+   ```makefile
+   ## rollback: Swap in the previous deployed binary and restart (requires DEPLOY_HOST, DEPLOY_BIN)
+   .PHONY: rollback
+   rollback:
+   	@[ -n "$(DEPLOY_HOST)" ] || (echo "ERROR: DEPLOY_HOST is not set. Add it to Makefile.local or export it."; exit 1)
+   	@[ -n "$(DEPLOY_BIN)" ] || (echo "ERROR: DEPLOY_BIN is not set. Add it to Makefile.local or export it."; exit 1)
+   	@echo "→ Rolling back $(DEPLOY_BIN) on $(DEPLOY_HOST)..."
+   	@ssh $(DEPLOY_HOST) 'test -f $(DEPLOY_BIN).prev' || (echo "ERROR: no $(DEPLOY_BIN).prev found on $(DEPLOY_HOST) — nothing to roll back to."; exit 1)
+   	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).rolled-back && \
+   	  sudo cp $(DEPLOY_BIN).prev $(DEPLOY_BIN) && \
+   	  sudo systemctl restart audiobook-organizer.service'
+   	@echo "✅ Rolled back $(DEPLOY_BIN) to previous version and restarted."
+   ```
+   Add `DEPLOY_BIN ?=` next to the existing `DEPLOY_HOST ?=` /
+   `BACKUP_DIR ?=` overridable-variable block near the top of `Makefile`
+   (re-verify exact line with the grep above), and add `rollback` to the
+   `.PHONY` list alongside `backup`. This target is intentionally decoupled
+   from the (gitignored) `deploy` target — it only assumes the server-side
+   convention `$(DEPLOY_BIN).prev` exists, which `Makefile.local.example`'s
+   `deploy:` recipe now creates.
+   Bump the `Makefile` file header (version + `last-edited`).
+
+4. **`scripts/manage-ollama-windows.py`** (new file): recreate the Windows
+   Ollama keepalive as a single Python CLI, following the
+   header/docstring/argparse style of `scripts/manage-whisper-server.py`
+   (read it first for tone — shebang-less `uv run` header, `# ///script`
+   deps block, module docstring with Usage examples). Requirements, all
+   driven over the `windows-gpu` SSH alias (per the status doc — this is
+   `ssh`-based, NOT WinRM like `manage-whisper-server.py`; do not copy its
+   WinRM transport):
+   - `--status` — probe `http://172.16.3.22:11434/api/tags` (or run
+     `Invoke-RestMethod` remotely) and report which models are loaded;
+     confirm `bge-m3` and `qwen2.5:7b-instruct` are present.
+   - `--setup` — idempotent one-time setup: install Ollama via `winget` if
+     missing, set `OLLAMA_HOST=0.0.0.0:11434` (User + Machine scope, best
+     effort), open firewall port `11434`, `ollama pull bge-m3`,
+     `ollama pull qwen2.5:7b-instruct`, **and register the "OllamaServe"
+     scheduled task** (see below — this is the part that actually closes
+     OPS-2; installing Ollama without capturing the keepalive task leaves
+     the reproducibility gap open).
+   - `--restart` — kill any `ollama`/`ollama app`/`ollama_llama_server`
+     processes, relaunch `ollama serve` bound to `0.0.0.0:11434`, verify via
+     `/api/version`.
+   - `--install-task` (also callable standalone, and invoked by `--setup`) —
+     register a Windows Scheduled Task named exactly `OllamaServe` that runs
+     the start/relaunch logic. **Bind it to an interactive logon session
+     (`schtasks /create /tn OllamaServe /sc onlogon ...` or the
+     `Register-ScheduledTask` equivalent with `New-ScheduledTaskPrincipal
+     -LogonType Interactive`), matching the status doc's documented
+     constraint that Ollama needs GPU access only available in an
+     interactive session — plain `ollama serve` over SSH or a headless
+     service dies/loses GPU access.** Do NOT switch this to "run whether
+     user is logged on or not" (that plausibly breaks the GPU access the
+     interactive binding exists for) — that is a separate hardening step
+     OPS-2 flags as future work, not something to silently fold in here.
+     Document the current single-point-of-failure (logoff/reboot/Windows
+     Update kills it) in the docstring and in `docs/system/`, do not try to
+     fix it in this task.
+   - Implementation: build one PowerShell script string per subcommand and
+     base64-encode it as **UTF-16LE**
+     (`base64.b64encode(script.encode("utf-16-le"))`), then invoke via:
+     ```python
+     subprocess.run(
+         ["ssh", "windows-gpu", "powershell", "-NoProfile",
+          "-EncodedCommand", encoded],
+         capture_output=True, text=True, check=False,
+     )
+     ```
+     Print stdout/stderr, exit non-zero on remote failure.
+
+     Use the following verified PowerShell logic (captured from the actual
+     working scripts) as the basis for `--setup`/`--install-task` and
+     `--restart` — translate directly, do not re-derive from scratch:
+
+     **Setup / install-task body** (installs Ollama, sets `OLLAMA_HOST`,
+     opens the firewall, and — new for this task — registers the
+     `OllamaServe` scheduled task bound to interactive logon so that the
+     relaunch logic below runs automatically on session start):
+     ```powershell
+     $ErrorActionPreference = 'Continue'
+
+     Write-Host "=== 1. Ollama install check ==="
+     $exe = Get-Command ollama -ErrorAction SilentlyContinue
+     if (-not $exe) {
+         Write-Host "installing Ollama via winget..."
+         winget install --id Ollama.Ollama -e --silent --accept-source-agreements --accept-package-agreements
+         $env:Path += ";$env:LOCALAPPDATA\Programs\Ollama"
+         $exe = Get-Command ollama -ErrorAction SilentlyContinue
+     }
+     if ($exe) { Write-Host "ollama: $($exe.Source)" } else { Write-Host "ollama: STILL NOT FOUND (winget may have failed)" }
+
+     Write-Host "=== 2. OLLAMA_HOST=0.0.0.0:11434 (User + Machine) ==="
+     [Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','User')
+     try { [Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','Machine'); Write-Host "set Machine scope" } catch { Write-Host "Machine scope failed (needs admin); User scope set" }
+
+     Write-Host "=== 3. Firewall rule for 11434 ==="
+     try {
+         if (-not (Get-NetFirewallRule -DisplayName 'Ollama 11434' -ErrorAction SilentlyContinue)) {
+             New-NetFirewallRule -DisplayName 'Ollama 11434' -Direction Inbound -LocalPort 11434 -Protocol TCP -Action Allow -ErrorAction Stop | Out-Null
+             Write-Host "firewall rule added"
+         } else { Write-Host "firewall rule already present" }
+     } catch { Write-Host "firewall rule failed (needs admin): $($_.Exception.Message)" }
+
+     Write-Host "=== 4. Register OllamaServe scheduled task (interactive logon, current user) ==="
+     $scriptPath = "$env:USERPROFILE\ollama-start.ps1"   # written by --setup alongside this task
+     $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$scriptPath`""
+     $trigger = New-ScheduledTaskTrigger -AtLogOn
+     $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+     try {
+         Unregister-ScheduledTask -TaskName 'OllamaServe' -Confirm:$false -ErrorAction SilentlyContinue
+         Register-ScheduledTask -TaskName 'OllamaServe' -Action $action -Trigger $trigger -Principal $principal -Settings $settings | Out-Null
+         Write-Host "OllamaServe scheduled task registered (AtLogOn, interactive)"
+     } catch { Write-Host "scheduled task registration failed: $($_.Exception.Message)" }
+
+     Write-Host "=== 5. pull models ==="
+     & ollama pull bge-m3
+     & ollama pull qwen2.5:7b-instruct
+
+     Write-Host "=== 6. status ==="
+     try {
+         $t = Invoke-RestMethod -Uri 'http://127.0.0.1:11434/api/tags' -TimeoutSec 6
+         Write-Host ("api up. models: " + (($t.models | ForEach-Object { $_.name }) -join ', '))
+     } catch { Write-Host "api 11434 not responding: $($_.Exception.Message)" }
+     ```
+     Note: the task action above launches
+     `%USERPROFILE%\ollama-start.ps1` — have `--setup` also write that file
+     to the remote box (base64-encode it and `[System.IO.File]::WriteAllBytes`,
+     same pattern `manage-whisper-server.py`'s `cmd_deploy` already uses for
+     `whisper_server.py`) using this **relaunch body** for `--restart` /
+     the task's own trigger action:
+     ```powershell
+     $ErrorActionPreference = 'Continue'
+     $ProgressPreference = 'SilentlyContinue'
+     $exe = Join-Path $env:LOCALAPPDATA 'Programs\Ollama\ollama.exe'
+
+     Get-Process ollama,'ollama app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+     Start-Sleep -Seconds 2
+
+     $psi = New-Object System.Diagnostics.ProcessStartInfo
+     $psi.FileName = $exe
+     $psi.Arguments = 'serve'
+     $psi.EnvironmentVariables['OLLAMA_HOST'] = '0.0.0.0:11434'
+     $psi.UseShellExecute = $false
+     $psi.RedirectStandardError = $true
+     $psi.RedirectStandardOutput = $true
+     $p = [System.Diagnostics.Process]::Start($psi)
+     Write-Host "started ollama serve pid=$($p.Id)"
+     Start-Sleep -Seconds 8
+
+     Write-Host "=== netstat 11434 ==="
+     netstat -ano | Select-String ':11434' | ForEach-Object { $_.Line }
+
+     Write-Host "=== local api probe ==="
+     try { $t = Invoke-RestMethod 'http://127.0.0.1:11434/api/version' -TimeoutSec 5; Write-Host "api version: $($t.version)" } catch { Write-Host "api down: $($_.Exception.Message)" }
+     ```
+   - Document in the module docstring that this depends on the operator
+     having a `windows-gpu` `Host` alias in their own `~/.ssh/config`
+     (not committed — machine-local, same as the existing
+     `scripts/setup-ssh-from-mac.sh` which documents how to create it).
+   - Add the standard file header.
+
+5. **`docs/system/` documentation** — add a new "Deploy Rollback & Windows
+   GPU Keepalive" section (either a new file `docs/system/deploy-and-gpu-ops.md`
+   or appended to `docs/system/runbooks.md` under a new `##` heading — prefer
+   a new file if `runbooks.md`'s existing sections are already dense; check
+   its current length first). Cover:
+   - How to instantiate `Makefile.local.example` → `Makefile.local` and
+     `deploy/local.conf.example` → `deploy/local.conf` on a fresh operator
+     machine.
+   - The rollback flow: `make deploy` (operator's real target, once updated
+     per step 2) creates `.prev`; `make rollback` swaps back; note the
+     `.rolled-back` copy `rollback` leaves behind for forensics.
+   - How to run `scripts/manage-ollama-windows.py --status` /
+     `--setup` / `--install-task` / `--restart`, and the OPS-2 residual risk
+     this does NOT yet close: the `OllamaServe` task is still bound to an
+     interactive logon session (required for GPU access — do not "fix" this
+     by switching to a headless/service run, per the step-4 warning) and a
+     logoff/reboot/Windows Update can still kill it before the next logon;
+     a periodic reachability probe via `/metrics` is explicitly out of scope
+     for this task — leave as a follow-up note, do not build it here.
+   - Cross-reference `docs/status/2026-07-02-local-cutover-and-matching.md`
+     and `docs/consultancy/06-process-and-security.md` (OPS-1/OPS-2/OPS-6).
+
+6. Bump file headers on every file you touch/create (per
+   `.standards/instructions/file-headers.md`): `Makefile`,
+   `Makefile.local.example`, `deploy/local.conf.example`,
+   `scripts/manage-ollama-windows.py`, and the new/edited `docs/system/` file.
+
+## How to test
+
+This is a docs/scripts/Makefile task — no Go package changes are expected,
+but run the full gate anyway to catch accidental breakage (e.g. a `.PHONY`
+typo or Makefile syntax error breaking other targets):
+
+```bash
+go build ./...
+go vet ./...
+make -n rollback DEPLOY_HOST=test-host DEPLOY_BIN=/usr/local/bin/audiobook-organizer   # dry-run: prints the commands, does not execute
+python3 -m py_compile scripts/manage-ollama-windows.py
+```
+
+`make -n rollback ...` must print the guarded `ssh` commands without erroring
+(the `-n` flag makes `make` show what it would run without executing it —
+do NOT drop `-n` here, this must never actually touch a real host during
+review). Do not run `scripts/manage-ollama-windows.py` against the real
+`windows-gpu` host as part of this task's verification — a syntax/compile
+check (`py_compile`) is sufficient; live execution is the operator's call
+once merged.
+
+## Acceptance criteria
+
+- [ ] `deploy/local.conf.example` exists, is a generic template (no real
+      secrets/paths beyond what's already public in committed docs), and has
+      a file header.
+- [ ] `Makefile.local.example` exists at repo root, is a generic template
+      including a `.prev`-preserving `deploy:` recipe, and has a file header.
+- [ ] `Makefile` has a new `rollback` target next to `backup`, guarded on
+      `DEPLOY_HOST` and `DEPLOY_BIN` being set, added to `.PHONY`, and
+      `make -n rollback DEPLOY_HOST=test-host DEPLOY_BIN=/tmp/x` prints the
+      expected commands without error.
+- [ ] `scripts/manage-ollama-windows.py` exists, implements `--status`,
+      `--setup`, `--install-task`, `--restart` over
+      `ssh windows-gpu ... -EncodedCommand` (UTF-16LE base64), registers the
+      `OllamaServe` scheduled task bound to interactive logon (not headless),
+      has the standard file header, and passes `python3 -m py_compile`.
+- [ ] A new or extended file under `docs/system/` documents the rollback flow
+      and the Ollama script usage, cross-referencing the status doc and
+      OPS-1/OPS-2/OPS-6.
+- [ ] `go build ./...` and `go vet ./...` remain green (no Go files should
+      need changes for this task; if they do, something is out of scope —
+      stop and reconsider).
+- [ ] The real, gitignored `Makefile.local` and `deploy/local.conf` are
+      untouched (they should not exist in this worktree at all — if `ls
+      Makefile.local deploy/local.conf` finds them, you are not in a clean
+      worktree; stop).
+- [ ] File headers bumped on every changed/created file.
+
+## Commit message
+
+```
+feat(ops): commit sanitized deploy templates, rollback target, and Windows Ollama script (OPS-1/OPS-2/OPS-6)
+
+The entire prod deploy recipe lived only in gitignored Makefile.local +
+deploy/local.conf on one laptop, with no rollback path, and the Windows GPU
+box's Ollama keepalive (including the "OllamaServe" scheduled task) existed
+only as scratchpad scripts. Commit sanitized *.example templates, add a
+`make rollback` target that restores the previous deployed binary via a
+server-side .prev copy, and recreate the Windows setup/start/status/task
+scripts as scripts/manage-ollama-windows.py (ssh windows-gpu +
+-EncodedCommand, per the documented PowerShell-over-SSH parsing gotcha),
+including registering the OllamaServe scheduled task so the keepalive
+mechanism itself is reproducible from git.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-08-deploy-recipe-and-ollama-scripts
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `Makefile.local.example` and `deploy/local.conf.example` already exist,
+`scripts/manage-ollama-windows.py` already exists with `--status`/`--setup`/
+`--restart` implemented over the `windows-gpu` SSH alias, and `Makefile`
+already has a `rollback` target — this task is done. Verify with:
+
+```bash
+ls Makefile.local.example deploy/local.conf.example scripts/manage-ollama-windows.py
+grep -n "^rollback:\|^\.PHONY.*rollback" Makefile
+grep -n "EncodedCommand" scripts/manage-ollama-windows.py
+```
+
+If any of these already exist but are incomplete (e.g. the `.example`
+templates exist but `rollback` doesn't, or vice versa), only add the missing
+piece(s) — do not duplicate or overwrite work that's already landed.
+
+Rollback of this change = revert the commit. Reverting is safe: the new
+`rollback` Makefile target and `.example` files are additive (no existing
+target, variable, or file is modified in a breaking way — `DEPLOY_HOST ?=`
+and `BACKUP_DIR ?=` already existed; only `DEPLOY_BIN ?=` is newly added as
+an overridable default, which is backward compatible since the operator's
+real `Makefile.local` already sets it directly). The real `Makefile.local`
+and `deploy/local.conf` on the operator's laptop are never touched by this
+change, so reverting cannot break the live deploy pipeline.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-09-apikey-rotation-expiry.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-09-apikey-rotation-expiry.md
@@ -1,0 +1,306 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-09-apikey-rotation-expiry.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 771afe2f-e822-48a4-884f-7422cdd498c0 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-09 — API-key rotation + expiry for bootstrap-issued keys (SEC-1 / PROC-6)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-09-apikey-rotation-expiry" -b agent/cr-09-apikey-rotation-expiry origin/main
+cd "$REPO/.worktrees/cr-09-apikey-rotation-expiry"
+git rebase origin/main
+```
+
+## Goal
+
+Close SEC-1 / PROC-6: bootstrap-issued full-scope API keys currently never
+expire and there is no rotation workflow. Add (1) a config-driven TTL applied
+to bootstrap-issued keys, (2) a `POST /api/v1/auth/api-keys/:id/rotate`
+endpoint that issues a new key and lets the old one keep working for a short
+grace window instead of being killed instantly, and (3) a low-frequency
+background sweep that logs a `slog.Warn` for keys approaching expiry (and a
+one-time-per-process deprecation warning for legacy keys that have no
+expiry at all). Treat existing prod keys with `ExpiresAt == nil` as
+**legacy-valid — never lock them out**; the deprecation warning is
+observability only, not enforcement.
+
+## Background (verify before editing)
+
+- **Bootstrap issuance has no expiry today.** `handleBootstrap` in
+  `internal/server/bootstrap.go` builds the `database.APIKey{}` literal with
+  `ID`/`UserID`/`Name`/`Description`/`TokenHash`/`Scopes`/`Status`/`CreatedAt`
+  only — no `ExpiresAt` field is set, so every bootstrap exchange mints a
+  permanent full-scope (`auth.All()`) key. Confirm before editing:
+  ```bash
+  grep -n "func (s \*Server) handleBootstrap" internal/server/bootstrap.go
+  grep -n "scopes := auth.All()" -A 12 internal/server/bootstrap.go
+  ```
+  As of this writing that's around lines 277 (func start) and 338-349 (the
+  `key := &database.APIKey{...}` literal) — **re-verify, don't trust these
+  numbers.**
+
+- **Expiry enforcement in the auth middleware ALREADY EXISTS** — this part of
+  the consultancy finding's authoritative direction is already implemented,
+  do not re-add it. `handleAPIKeyAuth` in
+  `internal/server/middleware/auth.go` already checks:
+  ```bash
+  grep -n "key.ExpiresAt != nil && time.Now().After" internal/server/middleware/auth.go
+  ```
+  and responds `401` with body `"API key has expired"` via
+  `httputil.RespondWithUnauthorized`. **Do not duplicate this check** — the
+  only gap is that bootstrap-issued keys never get an `ExpiresAt` set in the
+  first place, so the existing check never fires for them.
+
+- **`database.APIKey` already has `ExpiresAt *time.Time`** (`internal/database/store.go`
+  around line 618) and `handlers.Create` (`internal/server/handlers/apikeys.go`,
+  `expires_in_days` request field, ~line 173-176) already shows the pattern for
+  computing an expiry: `time.Now().Add(time.Duration(req.ExpiresInDays) * 24 * time.Hour)`.
+  Reuse that exact pattern for the TTL config value.
+
+- **No rotation endpoint exists.** `internal/server/handlers/apikeys.go` has
+  `Create`, `List`, `Get`, `UpdateStatus`, `Revoke` (`DELETE /:id`, ~line 314)
+  but nothing that atomically issues-new + retires-old. Routes are wired in
+  `internal/server/wire_auth_routes.go`:
+  ```bash
+  grep -n "api-keys" internal/server/wire_auth_routes.go
+  ```
+  `RevokeAPIKey` (`internal/database/pebble_store.go`, ~line 6031) sets
+  `Status = "revoked"` **immediately** — that's too abrupt for a grace window
+  (the auth middleware aborts on `Status == "revoked"` right away, see
+  `internal/server/middleware/auth.go` ~line 189). For the grace window, set
+  the OLD key's `ExpiresAt` to `now + grace` instead of revoking it outright,
+  so the existing (already-implemented) expiry check in the middleware
+  retires it naturally. There is currently no store method that updates only
+  `ExpiresAt` on an existing key — you will need to add one.
+
+- **`APIKeyStore` interface** (`internal/database/iface_misc.go` ~line 73) —
+  re-verify the current method set:
+  ```bash
+  grep -n "type APIKeyStore interface" -A 12 internal/database/iface_misc.go
+  ```
+  `PebbleStore.SetAPIKeyStatus` (`internal/database/pebble_store.go` ~line
+  6035) is a read-modify-write you can pattern-match for the new
+  `SetAPIKeyExpiry(id string, at time.Time) error` method.
+
+- **No existing config field for a bootstrap-key TTL.** `internal/config/config.go`
+  has `MetadataFetchCacheTTLDays` (~line 341) as the closest style precedent
+  (comment explaining default + 0-means-never-expire convention). Add a
+  sibling field, e.g. `BootstrapKeyTTLDays int` with default `30`, following
+  the same viper-binding pattern used for `MetadataFetchCacheTTLDays`:
+  ```bash
+  grep -n "MetadataFetchCacheTTLDays" internal/config/config.go
+  ```
+  (appears in the struct, the viper-load block, and the defaults block —
+  three sites to mirror.)
+
+- **Background sweep placement.** `Server.Start` in
+  `internal/server/server_lifecycle.go` already kicks off several
+  fire-and-forget cache warmers as goroutines right after HNSW load:
+  ```bash
+  grep -n "go s.warmFacetsCache\|go s.warmAuthorsCache\|go s.warmSeriesCache" internal/server/server_lifecycle.go
+  ```
+  (around lines 266-278). Add the new sweep goroutine in the same block.
+  `internal/server/library_list_warmer.go` is a good structural model for a
+  ticker-driven background loop with `slog.Warn` logging
+  (`runTrickleWarmer`, ~line 613, uses `time.NewTicker`).
+
+- **Mocks.** `internal/database/mock_store.go` implements `APIKeyStore` for
+  tests (`CreateAPIKey` ~1588, `RevokeAPIKey` ~1623, `SetAPIKeyStatus` ~1630).
+  Any new interface method needs a mock implementation too, or `go build`
+  breaks every package that uses `MockStore` as `database.Store`.
+
+## Step-by-step
+
+1. **Config TTL.** In `internal/config/config.go`, add `BootstrapKeyTTLDays int
+   json:"bootstrap_key_ttl_days"` next to `MetadataFetchCacheTTLDays`, with a
+   doc comment stating default 30, and `0` or negative falls back to 30 (never
+   "never expire" — bootstrap keys are full-scope, they must always expire).
+   Wire it through the viper-load block and the defaults block exactly where
+   `MetadataFetchCacheTTLDays` appears (grep above), defaulting to `30`.
+
+2. **Apply TTL at bootstrap issuance.** In `internal/server/bootstrap.go`,
+   inside `handleBootstrap`, compute
+   `ttlDays := config.AppConfig.BootstrapKeyTTLDays; if ttlDays <= 0 { ttlDays = 30 }`
+   and set `ExpiresAt: &expiresAt` on the `database.APIKey{}` literal, where
+   `expiresAt := time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour)`.
+   Also add `expires_at` to the `bootstrapResp` JSON so callers (including the
+   `server-bootstrap` skill) can see it. Do not change any other field on the
+   literal.
+
+3. **Add `SetAPIKeyExpiry` to the store layer.**
+   - `internal/database/iface_misc.go`: add `SetAPIKeyExpiry(id string, at
+     time.Time) error` to `APIKeyStore`.
+   - `internal/database/pebble_store.go`: implement it as a read-modify-write
+     next to `SetAPIKeyStatus` — load the key, set `k.ExpiresAt = &at`, marshal,
+     write back with the same `apikey:` key (do not touch the `idx:` entries).
+   - `internal/database/mock_store.go`: add a matching mock implementation
+     (store the value in the mock's in-memory map, mirroring how
+     `SetAPIKeyStatus` is mocked there).
+
+4. **Rotation endpoint.**
+   - `internal/server/handlers/apikeys.go`: add `Rotate(c *gin.Context)`
+     handling `POST /auth/api-keys/:id/rotate`. Logic:
+     - Require caller auth (`servermiddleware.CurrentUser`), same ownership
+       check as `Revoke` (owner or `isAdminUser`).
+     - Load the old key via `h.store.GetAPIKey(id)`; 404 if missing.
+     - Generate a new token (`database.GenerateAPIKeyToken()`), build a new
+       `database.APIKey` copying `UserID`, `Name` (suffix e.g. `" (rotated)"`
+       optional — keep simple, just copy `Name`), `Description`, `Scopes`
+       from the old key, `Status: "active"`, and a fresh `ExpiresAt` computed
+       the same way as bootstrap issuance (reuse the `BootstrapKeyTTLDays`
+       config value if the old key has no custom expiry pattern — simplest:
+       always use `BootstrapKeyTTLDays`-based expiry for the new key).
+       Persist via `h.store.CreateAPIKey`.
+     - Set the OLD key's `ExpiresAt` to `time.Now().Add(graceWindow)` via the
+       new `SetAPIKeyExpiry` store method — **do not call `RevokeAPIKey`**,
+       that would kill it immediately instead of giving a grace window. Use a
+       package-level const `const apiKeyRotationGraceWindow = 1 * time.Hour`.
+     - Respond `201`/`200` with the new raw token (shape similar to
+       `CreateAPIKeyResponse`), and log at `slog.Info` (id, user, old key id,
+       grace window) mirroring the existing `"apikey created"` / `"apikey
+       revoked"` log lines in this file.
+   - `internal/server/wire_auth_routes.go`: add
+     `authProtected.POST("/api-keys/:id/rotate", apiKeyH.Rotate)` next to the
+     existing `api-keys` routes.
+
+5. **Expiry-approaching WARN sweep.**
+   - Add a new file `internal/server/apikey_expiry_sweep.go` (or a function
+     in `server_lifecycle.go` if you prefer — pick one and keep the file
+     header correct either way) with `func (s *Server)
+     warnExpiringAPIKeys()`. Pattern it after `runTrickleWarmer`'s
+     ticker loop in `internal/server/library_list_warmer.go`:
+     - Ticker interval: something coarse like 6h (this is observability, not
+       a hot path).
+     - Each tick: `keys, err := s.Store().ListAllAPIKeys()`; for each key with
+       `Status == "active"`:
+       - If `ExpiresAt == nil`: log `slog.Warn` **once per key ID per process**
+         (keep a `map[string]bool` of already-warned IDs in the sweep's
+         closure state, guarded by a mutex or just owned by the single
+         goroutine) — message like `"api key has no expiry (legacy) — set one via rotate"`,
+         fields `key_id`, `user_id`, `name`. This is the deprecation warning;
+         it must NEVER cause the key to be rejected — enforcement stays solely
+         in the untouched middleware `ExpiresAt != nil` branch.
+       - If `ExpiresAt != nil` and within a threshold window (e.g. 7 days) of
+         now and not yet expired: log `slog.Warn` with fields `key_id`,
+         `user_id`, `name`, `expires_at`. Track "already warned this window"
+         similarly to avoid spamming every 6h.
+   - Wire `go s.warnExpiringAPIKeys()` into `Server.Start` in
+     `internal/server/server_lifecycle.go`, next to the other `go
+     s.warm*Cache()` calls (grep above for the exact insertion point).
+
+6. **Tests.**
+   - `internal/server/bootstrap_test.go` (or wherever bootstrap tests live —
+     `grep -rl "handleBootstrap\|TestBootstrap" internal/server/*_test.go`):
+     assert the created key has a non-nil `ExpiresAt` roughly `TTLDays` days
+     in the future.
+   - `internal/database/*_test.go`: test `SetAPIKeyExpiry` round-trips
+     through `PebbleStore` (create key, set expiry, `GetAPIKey`, assert
+     `ExpiresAt` matches).
+   - `internal/server/handlers/apikeys_test.go` (check it exists: `ls
+     internal/server/handlers/apikeys_test.go`): test `Rotate` — old key
+     still has `Status == "active"` but `ExpiresAt` is now within the grace
+     window (not nil, not far-future); new key exists with fresh `ExpiresAt`
+     and inherited scopes.
+   - Confirm the existing auth-middleware expiry test still passes unchanged
+     (do not modify `internal/server/middleware/auth_test.go` unless a new
+     legacy-nil-expiry case is worth adding there — optional, not required).
+
+7. **Skill doc.** `.claude/skills/server-bootstrap/SKILL.md`'s example
+   bootstrap response (the `Bootstrap Token Exchange` section) does not show
+   `expires_at`. Add it to the example JSON response so the doc matches the
+   new field. Do not change the 8-hour client-side `.claude/.api-token`
+   cleanup convention — that is unrelated to the new server-side key TTL
+   (client cleanup is much shorter than the 30-day server TTL, so no
+   conflict).
+
+8. Bump the file header (version + `last-edited`) on every file touched, per
+   `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go vet ./internal/server/... ./internal/database/... ./internal/config/...
+go test ./internal/server/... ./internal/database/... ./internal/config/... -count=1
+```
+
+## Acceptance criteria
+
+- [ ] Bootstrap-issued keys (`handleBootstrap`) get a non-nil `ExpiresAt`
+      derived from `config.AppConfig.BootstrapKeyTTLDays` (default 30d if
+      unset/non-positive).
+- [ ] `bootstrapResp` JSON includes `expires_at`.
+- [ ] `POST /api/v1/auth/api-keys/:id/rotate` exists, requires auth, enforces
+      the same ownership rule as `Revoke` (owner or admin), issues a new key
+      with inherited scopes, and puts the OLD key on a short grace-window
+      expiry (via `SetAPIKeyExpiry`) rather than immediate revocation.
+- [ ] `SetAPIKeyExpiry` is added to `APIKeyStore`, implemented in
+      `PebbleStore`, and mocked in `MockStore` — `go build ./...` is clean.
+- [ ] A background sweep logs `slog.Warn` for active keys approaching expiry
+      and for legacy active keys with `ExpiresAt == nil`, without rejecting or
+      modifying those keys (enforcement remains only in the pre-existing
+      middleware `ExpiresAt != nil && time.Now().After(...)` check — verify
+      that check is unchanged: `git diff origin/main -- internal/server/middleware/auth.go`
+      should be empty for this task).
+- [ ] Existing keys with `ExpiresAt == nil` (legacy prod keys) are NOT
+      rejected by anything added in this task — confirmed by test and by the
+      unchanged middleware diff above.
+- [ ] `.claude/skills/server-bootstrap/SKILL.md` example response shows
+      `expires_at`.
+- [ ] All new/updated tests pass; `go build ./...`, `go vet`, and `go test`
+      (scoped packages above) are green.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+feat(auth): add TTL + rotation for bootstrap-issued API keys (SEC-1/PROC-6)
+
+Bootstrap-issued full-scope keys never expired and had no rotation path.
+Add a config-driven TTL applied at bootstrap issuance, a rotate endpoint
+that grace-windows the old key instead of an abrupt revoke, and a
+background sweep that WARN-logs keys nearing expiry or lacking one
+(legacy keys stay valid — this is observability only). The auth
+middleware's expiry enforcement already existed and is unchanged.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-09-apikey-rotation-expiry
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, re-verify the premise — if `handleBootstrap` already sets
+`ExpiresAt` on the issued key (`grep -n "ExpiresAt" internal/server/bootstrap.go`
+shows a hit inside the `database.APIKey{}` literal, not just in
+`ConsumeBootstrapToken`'s own struct), SEC-1's core gap is already closed;
+only the rotation endpoint and WARN sweep would remain to build. If a
+`/rotate` endpoint already exists (`grep -n "rotate" internal/server/wire_auth_routes.go
+internal/server/handlers/apikeys.go`), skip step 4. If a `warnExpiring*`
+sweep already exists (`grep -rn "warnExpiring\|ExpiresAt == nil" internal/server/*.go`),
+skip step 5.
+
+**Migration safety:** this task must never cause existing prod keys (which
+have `ExpiresAt == nil`) to be rejected — the middleware's enforcement branch
+(`internal/server/middleware/auth.go`, `key.ExpiresAt != nil && ...`) already
+treats `nil` as "never expires" and this task does not change that branch.
+Do not add any code path that treats a `nil` `ExpiresAt` as "expired" or
+otherwise locks out legacy keys — the WARN sweep is log-only.
+
+Rollback = revert the commit. `BootstrapKeyTTLDays` config addition is
+additive (defaults preserve prior behavior only if you also revert the
+bootstrap.go change — reverting the whole commit restores true
+never-expiring bootstrap keys). `SetAPIKeyExpiry` and the `/rotate` route are
+new additions with no other callers, safe to remove wholesale.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-10-backend-mode-toggle-core.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-10-backend-mode-toggle-core.md
@@ -1,0 +1,374 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-10-backend-mode-toggle-core.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a43e97e3-2f83-4c92-bb60-3b0bdc738315 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-10 — Backend-mode toggle core (embedding + LLM mode enums, per-config LLM base URL)
+
+**Priority:** P1 · **Effort:** L · **Recommended subagent:** Opus · go-backend subagent · **Depends on:** TASK-04, TASK-06, TASK-12 · **Wave:** 3
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-10-backend-mode-toggle-core" -b agent/cr-10-backend-mode-toggle-core origin/main
+cd "$REPO/.worktrees/cr-10-backend-mode-toggle-core"
+git rebase origin/main
+```
+
+## Read this FIRST, before touching any code
+
+Read the full **"Design: LLM/Embedding Backend-Mode Toggle"** section of
+`docs/consultancy/03-matching-and-backends.md` (both the "Primary design
+(TOGGLE report)" and "Companion sketch (MATCH report)" subsections, plus
+"Reconciling the two designs") in the roadmap-tasks checkout at
+`docs/consultancy/03-matching-and-backends.md`. It is reproduced in essence
+below, but the source doc has the full reasoning and is the tie-breaker if
+this brief and the code disagree. Also skim findings TOGGLE-1 through
+TOGGLE-7 (same file) — each documents one concrete gap this task closes.
+
+This is the **Wave 3 capstone**: it assumes TASK-04 (embedding-model skip
+fix), TASK-06 (keyless local registration), and TASK-12 (whatever P2 task
+precedes it — verify it exists and is merged; if TASK-12 does not exist in
+this repo yet, treat its intent as already covered by TASK-04/06 and proceed)
+are already merged to `origin/main`. Re-run
+`git log --oneline origin/main | grep -i "keyless\|embed-model-skip"` after
+your `git fetch` above to confirm TASK-06 and TASK-04 landed before you start
+— if they haven't, STOP and flag it; this task builds directly on their
+registration-gate changes in `internal/ai/register.go`.
+
+## Goal
+
+Implement the backend-mode toggle **core**: a nested `AIBackendConfig` in the
+config blob with independent `EmbeddingMode` / `LLMMode` enums
+(`disabled | openai | local | openai-fallback-local`), a per-config LLM base
+URL (closing TOGGLE-3 — today `NewOpenAIParser` only honors the process-wide
+`OPENAI_BASE_URL` env), a startup blob migration mapping legacy fields onto
+the new modes (following the existing `migrateEmbeddingBlob` /
+`migrateDedupBlob` / `migrateMetadataScoringBlob` pattern in
+`internal/config/persistence.go`), registration wired to honor the effective
+mode, and replacement of the one-shot non-atomic `localOllamaOK` startup
+flag (TOGGLE-5) with a runtime HTTP-probe-backed `atomic.Bool`. This task does
+**not** implement the fallback *trigger* itself (that is TASK-12's error
+classification in `retry.go`) — it wires the mode enum and availability plumbing
+that the fallback trigger will consume, and gates `EmbedBooksAsync`/batch
+paths hard to openai-only modes (TOGGLE-2).
+
+Out of scope for this task (leave for follow-ups): the FE "AI Backends"
+Settings card, the `GET /api/v1/ai/backends/status` endpoint, the
+model-download-prompt / `ollama pull` op-registry integration, and
+per-feature model-name mapping beyond `LocalEmbeddingModel`/`LocalLLMModel`
+(TOGGLE-7 is a separate, smaller follow-up). Do not build FE or new HTTP
+endpoints in this task — config + core Go wiring only.
+
+## Background (verify before editing — line numbers drift, re-grep first)
+
+```bash
+grep -n "func (de \*Engine)\|EmbedBooksAsync\|embeddingModelMatches" internal/dedup/engine.go | head -20
+grep -n "type Config struct\|OpenAIAPIKey\|EnableAIParsing\|Embedding EmbeddingConfig\|MetadataScoring MetadataScoringConfig\|ReviewModel" internal/config/config.go
+grep -n "func init\|embedclient\|llmparser\|OpenAIAPIKey" internal/ai/register.go
+grep -n "func NewOpenAIParser\|OPENAI_BASE_URL\|defaultModel" internal/ai/openai_parser.go
+grep -n "func NewEmbeddingClient\|localOllamaOK\|SetOllamaAvailable\|defaultEmbeddingModel\|OPENAI_BASE_URL" internal/ai/embedding_client.go
+grep -n "func DoWithRetry" internal/ai/retry.go
+grep -n "localOllamaOK\|SetOllamaAvailable\|ollamaDaemon\|toolsCfg.Ollama" internal/server/server.go
+grep -n "^func migrate.*Blob\|migrateEmbeddingBlob(blobStr)\|migrateDedupBlob(blobStr)\|migrateMetadataScoringBlob(blobStr)" internal/config/persistence.go
+```
+
+As of the roadmap-tasks snapshot (2026-07-02/03), verified in this worktree:
+
+- **`internal/ai/register.go`**: `embedclient` `Build` returns nil when
+  `cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled` (line ~35), before
+  resolving `baseURL := cfg.Embedding.BaseURL` a few lines later.
+  `llmparser` `Build` returns nil when `cfg.OpenAIAPIKey == ""` (line ~65) and
+  constructs via `NewOpenAIParser(cfg, cfg.OpenAIAPIKey, cfg.EnableAIParsing)`
+  with no base-URL parameter at all. **If TASK-06 already merged, the key
+  gates here should be relaxed to check `Embedding.BaseURL`/an equivalent
+  local-base-URL field instead of blocking on key presence — build on top of
+  that, don't re-add the key gate.**
+- **`internal/ai/openai_parser.go`**: `NewOpenAIParser` (line ~79) reads
+  `os.Getenv("OPENAI_BASE_URL")` (line ~85) to set `option.WithBaseURL(...)`.
+  `defaultModel = "gpt-5-mini"` (line ~51). There is no
+  `NewOpenAIParserWithBaseURL` and no per-client base URL parameter — this is
+  the TOGGLE-3 gap, fully greenfield.
+- **`internal/ai/embedding_client.go`**: `NewEmbeddingClientWithOptions(apiKey,
+  model, baseURL string)` (line ~116) already takes an explicit `baseURL`
+  parameter and deliberately avoids `OPENAI_BASE_URL` (see the comment at
+  line ~96-112 explaining why — it would redirect every client built without
+  an explicit base URL). `defaultEmbeddingModel = "text-embedding-3-large"`
+  (line ~92). `localOllamaOK bool` (line ~82, plain bool, not atomic) is set
+  once via `SetOllamaAvailable` (line ~141) and read in the batch path (near
+  line ~193). This is the TOGGLE-5 data-race-prone flag — mirror the
+  `NewEmbeddingClientWithOptions` base-URL pattern for the new
+  `NewOpenAIParserWithBaseURL`, and replace `localOllamaOK bool` with
+  `localOllamaOK atomic.Bool`.
+- **`internal/server/server.go`**: around line ~590-625, wires
+  `toolRegistry`/`ollamaDaemon`, and at ~614-624 does a one-shot
+  `exec.LookPath`-or-trust-configured-base-URL check, then calls
+  `server.embedClient.SetOllamaAvailable(ollamaOK)` exactly once at startup.
+  This is the TOGGLE-5 chokepoint to replace with a TTL-cached HTTP probe
+  (`GET {LocalBaseURL}/api/tags`, 2s timeout) re-probed on failure.
+- **`internal/ai/retry.go`**: `DoWithRetry` (line ~26) treats every error
+  identically — no permanent/transient classification exists yet. **Do not
+  implement the classifier in this task** (that's TASK-12); this task only
+  needs `DoWithRetry`'s signature to remain stable so TASK-12 can add
+  classification later without touching this task's callers.
+- **`internal/config/config.go`**: `ReviewModel` (Dedup config, line ~137,
+  default `"gpt-5-mini"`), `EnableAIParsing`/`OpenAIAPIKey` (Config struct,
+  line ~261-262), `Embedding EmbeddingConfig` (line ~308),
+  `MetadataScoring MetadataScoringConfig` (line ~316). Defaults are set in a
+  large struct literal further down (search for `EnableAIParsing:` and
+  `ReviewModel:` — there are two occurrences each, one in the
+  viper-load path ~line 782+, one in the hardcoded-defaults path ~line
+  1286+). Both must be updated when adding the new nested config.
+- **`internal/config/persistence.go`**: the established blob-migration
+  pattern is a `migrateXBlob(blob string) (string, bool)` function
+  (idempotent: returns `(blob, false)` if already in the new shape or no
+  flat legacy keys present) called from the blob-load path (search
+  `migrateEmbeddingBlob(blobStr)`, `migrateDedupBlob(blobStr)`,
+  `migrateMetadataScoringBlob(blobStr)` for the call sites — all three are
+  chained: migrate, then `saveRawBlob` if changed, then feed the mutated
+  `blobStr` into the next migration). Your new `migrateAIBackendBlob` must
+  follow this exact idempotent shape and be chained in the same place,
+  after the existing three.
+- **`internal/dedup/engine.go`**: `EmbedBooksAsync` (search
+  `EmbedBooksAsync`) submits to the OpenAI Batch API with no backend check;
+  its already-embedded skip check (near where `TextHash` is compared) does
+  NOT call `embeddingModelMatches`, unlike `prepBookEmbed`'s skip check
+  (search `embeddingModelMatches` for both call sites) — this is the
+  TOGGLE-2 gap. `internal/plugins/dedup/embed_scan.go` (search `async`) is
+  the caller that must downgrade to sync when effective embedding backend
+  is not `openai`.
+
+## Step-by-step
+
+1. **Config shape** — in `internal/config/config.go`, add:
+   ```go
+   type AIBackendConfig struct {
+       EmbeddingMode       string `json:"embedding_mode" mapstructure:"embedding_mode"`
+       LLMMode             string `json:"llm_mode" mapstructure:"llm_mode"`
+       LocalBaseURL        string `json:"local_base_url" mapstructure:"local_base_url"`
+       LocalEmbeddingModel string `json:"local_embedding_model" mapstructure:"local_embedding_model"`
+       LocalLLMModel       string `json:"local_llm_model" mapstructure:"local_llm_model"`
+   }
+   ```
+   Modes are the string constants `"disabled"`, `"openai"`, `"local"`,
+   `"openai-fallback-local"` — define them as exported consts
+   (`AIBackendModeDisabled`, etc.) next to the struct so callers don't hardcode
+   string literals. Add `AIBackend AIBackendConfig` field to the main `Config`
+   struct near `Embedding`/`MetadataScoring`. Wire it into both the
+   viper-load path and the hardcoded-defaults path (the two locations you
+   found in Background) with defaults: `LocalBaseURL:
+   "http://172.16.3.22:11434/v1"`, `LocalEmbeddingModel: "bge-m3"`,
+   `LocalLLMModel: "qwen2.5:7b-instruct"`, both modes empty string (resolved
+   by migration/effective-mode logic, not hardcoded to a mode at rest).
+
+2. **Effective-mode resolution helper** — add a small helper (e.g.
+   `func (c *Config) EffectiveEmbeddingMode() string` /
+   `EffectiveLLMMode() string`) that returns the configured mode if
+   non-empty, else applies the exact fallback-derivation rule from the design
+   doc (`EmbeddingMode` empty → `local` when `Embedding.BaseURL != ""` (and
+   copy it into `LocalBaseURL` if that field is still empty), else `openai`
+   when `OpenAIAPIKey != "" && Embedding.Enabled`, else `disabled`; `LLMMode`
+   empty → `openai` when `OpenAIAPIKey != "" && (EnableAIParsing ||
+   MetadataScoring.LLMEnabled)`, else `disabled`). This lets migration be
+   optional/defensive — even if the blob migration step is skipped for any
+   reason, effective-mode resolution never crashes on an empty mode.
+
+3. **Blob migration** — in `internal/config/persistence.go`, add
+   `migrateAIBackendBlob(blob string) (string, bool)` mirroring
+   `migrateEmbeddingBlob`'s shape exactly (unmarshal to `map[string]any`,
+   check for absence of the new `ai_backend` nested key combined with
+   presence of legacy flat signal fields, apply the same derivation rule as
+   step 2, write the nested `ai_backend` object, return `(blob, false)` if
+   already migrated or no legacy signal present). Chain it into the blob-load
+   path immediately after the existing `migrateMetadataScoringBlob` call,
+   following the exact `slog.Info` + `saveRawBlob` + reassign `blobStr`
+   pattern used by the three existing migrations.
+
+4. **Config API shim** — update `docs/reference/config-api-shape.md`: document
+   the new `ai_backend` nested object in the `GET /config` / `PUT /config`
+   shape, and note that the legacy `embedding.base_url` / `openai_api_key` /
+   `enable_ai_parsing` fields remain readable and are still accepted on `PUT`
+   for one release (write-through: setting a legacy field also updates the
+   derived `ai_backend` mode via the same effective-mode helper from step 2 on
+   next load). Bump that file's version header.
+
+5. **`internal/ai/openai_parser.go`** — add
+   `NewOpenAIParserWithBaseURL(cfg *config.Config, apiKey, baseURL, model
+   string, enabled bool) *OpenAIParser` that mirrors `NewOpenAIParser` but
+   takes an explicit `baseURL` and `model` instead of relying on
+   `os.Getenv("OPENAI_BASE_URL")` and `defaultModel`. Keep `NewOpenAIParser`
+   as a thin wrapper that calls the new constructor with
+   `os.Getenv("OPENAI_BASE_URL")` and `defaultModel` for backward
+   compatibility with any direct callers you don't touch in this task.
+
+6. **`internal/ai/embedding_client.go`** — change `localOllamaOK bool` to
+   `localOllamaOK atomic.Bool` (import `sync/atomic`); update
+   `SetOllamaAvailable` to `c.localOllamaOK.Store(ok)` and all reads (e.g. the
+   batch-path check near line ~193) to `c.localOllamaOK.Load()`. Add a new
+   exported prober, e.g. `func ProbeOllamaAvailable(ctx context.Context,
+   baseURL string, timeout time.Duration) bool` that does `GET
+   {baseURL}/api/tags` and returns true on 2xx within `timeout` (default 2s).
+   Do not wire a background poller/goroutine in this task if that would
+   require new lifecycle plumbing beyond `server.go` — a single re-probe
+   inline before `EmbedBatch` calls when `!localOllamaOK.Load()` (cheap
+   TTL-style recheck) is sufficient scope for this task; note in the PR
+   description if you defer a full background TTL-cache poller as a
+   follow-up.
+
+7. **`internal/server/server.go`** — replace the one-shot
+   `LookPath`-or-trust check (the block you verified in Background,
+   ~line 614-624) with a call to the new `ProbeOllamaAvailable` against
+   `cfg.AIBackend.LocalBaseURL` (falling back to `cfg.Embedding.BaseURL` if
+   `LocalBaseURL` is empty, for the migration-not-yet-applied case), still
+   calling `server.embedClient.SetOllamaAvailable(...)` with the probe result.
+
+8. **`internal/ai/register.go`** — update the `embedclient` and `llmparser`
+   `Build` funcs to key off `cfg.EffectiveEmbeddingMode()` /
+   `cfg.EffectiveLLMMode()` instead of raw `OpenAIAPIKey`/`BaseURL` presence
+   checks (building on top of whatever TASK-06 already changed here — do not
+   revert TASK-06's keyless-construction fix):
+   - `EffectiveEmbeddingMode() == AIBackendModeDisabled` → nil client (no
+     warning needed, this is deliberate).
+   - `== AIBackendModeLocal` → `NewEmbeddingClientWithOptions("ollama",
+     cfg.AIBackend.LocalEmbeddingModel, cfg.AIBackend.LocalBaseURL)` (dummy
+     key "ollama", Ollama ignores it).
+   - `== AIBackendModeOpenAI` or `AIBackendModeOpenAIFallbackLocal` → real key
+     required, current OpenAI construction path.
+   - Same triage for `llmparser`, using the new
+     `NewOpenAIParserWithBaseURL` from step 5 with `cfg.AIBackend.LocalBaseURL`
+     / `cfg.AIBackend.LocalLLMModel` in local mode.
+   - `metadatallmscorer` (TOGGLE-6, search `register.go` near where
+     `MetadataScoring.EmbeddingEnabled` is checked at ~line 80): make it
+     return nil when `EffectiveLLMMode() == AIBackendModeDisabled`, matching
+     how `metadatascorer` already checks `EmbeddingEnabled` at build.
+
+9. **`EmbedBooksAsync` hard-gate (TOGGLE-2)** — in `internal/dedup/engine.go`,
+   add a check at the top of `EmbedBooksAsync` that returns a typed error
+   (define `ErrBatchUnsupported` in the same package or `internal/ai` — pick
+   whichever avoids an import cycle, verify with `go build` — err on
+   `internal/ai` since that's where the client mode concept lives) when
+   `EffectiveEmbeddingMode() != AIBackendModeOpenAI`. In
+   `internal/plugins/dedup/embed_scan.go`, when `async=true` is requested but
+   the effective mode isn't `openai`, log a warning and downgrade to the sync
+   path instead of calling `EmbedBooksAsync`. While you're in
+   `EmbedBooksAsync`'s already-embedded skip check, add the missing
+   `embeddingModelMatches` call so it matches `prepBookEmbed`'s skip logic
+   (this closes the second half of TOGGLE-2 — stale-dimension vectors
+   currently get silently skipped in the async path).
+
+10. **Tests** — add/extend `internal/config/persistence_test.go` (or the
+    file holding the other blob-migration tests) covering
+    `migrateAIBackendBlob`: legacy `embedding.base_url` set → `EmbeddingMode
+    == "local"`; legacy `openai_api_key` set + no base_url → `"openai"`;
+    neither → `"disabled"`; idempotent on already-migrated blob (second call
+    returns `changed == false`). Add `internal/ai` tests for
+    `NewOpenAIParserWithBaseURL` (verify it sets the base URL, doesn't touch
+    `OPENAI_BASE_URL` env) and for the `register.go` mode-gated construction
+    (nil client in disabled mode, dummy-key construction in local mode). Add
+    an `internal/dedup` test asserting `EmbedBooksAsync` returns
+    `ErrBatchUnsupported` when effective mode is `local`/`disabled`.
+
+11. Bump file headers (version + `last-edited`) on every file touched:
+    `internal/config/config.go`, `internal/config/persistence.go`,
+    `internal/ai/register.go`, `internal/ai/embedding_client.go`,
+    `internal/ai/openai_parser.go`, `internal/ai/retry.go` (only if touched —
+    if you left it untouched per step-by-step scope, do not bump it),
+    `internal/server/server.go`, `internal/dedup/engine.go`,
+    `internal/plugins/dedup/embed_scan.go`,
+    `docs/reference/config-api-shape.md`, plus any new/edited `_test.go`
+    files.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/config/... ./internal/ai/... ./internal/dedup/... ./internal/plugins/dedup/... -count=1
+go vet ./internal/config/... ./internal/ai/... ./internal/dedup/... ./internal/plugins/dedup/... ./internal/server/...
+```
+
+If `make ci` is faster to reason about for the full gate, use it instead —
+check `grep -E '^[a-z-]+:' Makefile` first and prefer `make ci` if it covers
+the same packages with mocks/staticcheck.
+
+## Acceptance criteria
+
+- [ ] `AIBackendConfig` exists in `internal/config/config.go` with
+      `EmbeddingMode`, `LLMMode`, `LocalBaseURL`, `LocalEmbeddingModel`,
+      `LocalLLMModel`, wired into both the viper-load and hardcoded-defaults
+      paths, with local defaults `bge-m3` / `qwen2.5:7b-instruct` /
+      `http://172.16.3.22:11434/v1`.
+- [ ] `EffectiveEmbeddingMode()`/`EffectiveLLMMode()` (or equivalent) resolve
+      an empty mode from legacy fields per the design doc's derivation rule,
+      with tests covering all three derivation branches plus idempotency.
+- [ ] `migrateAIBackendBlob` follows the existing
+      `migrateEmbeddingBlob`/`migrateDedupBlob`/`migrateMetadataScoringBlob`
+      idempotent shape and is chained into the blob-load path in
+      `persistence.go` immediately after the existing three migrations.
+- [ ] `NewOpenAIParserWithBaseURL` exists in `internal/ai/openai_parser.go`
+      taking an explicit base URL and model (never `OPENAI_BASE_URL` env);
+      `NewOpenAIParser` still works unchanged for existing callers.
+- [ ] `localOllamaOK` is an `atomic.Bool`, not a plain `bool`; `Store`/`Load`
+      used consistently at all read/write sites.
+- [ ] `server.go`'s startup Ollama-availability check is replaced with an
+      HTTP probe against `{LocalBaseURL}/api/tags` (or the equivalent
+      fallback field), not just LookPath-or-trust.
+- [ ] `register.go`'s `embedclient`/`llmparser`/`metadatallmscorer` Build
+      funcs key off `EffectiveEmbeddingMode()`/`EffectiveLLMMode()`, not raw
+      key/URL presence, and construct with a dummy key in local mode.
+- [ ] `EmbedBooksAsync` returns a typed `ErrBatchUnsupported` (or equivalent)
+      when the effective embedding backend isn't `openai`; its
+      already-embedded skip check now also calls `embeddingModelMatches`;
+      `embed_scan.go`'s async path downgrades to sync with a log line under
+      non-openai modes.
+- [ ] `docs/reference/config-api-shape.md` documents the new `ai_backend`
+      nested config object and legacy-field write-through behavior.
+- [ ] `go build ./...`, targeted `go test`, and `go vet` are all green.
+- [ ] File headers bumped on every changed file (test files included).
+
+## Commit message
+
+```
+feat(config): add AIBackendConfig mode toggle core (embedding+LLM, per-config LLM base URL)
+
+Implements the backend-mode toggle core from docs/consultancy/03-matching-and-backends.md:
+nested AIBackendConfig with independent EmbeddingMode/LLMMode enums, startup blob
+migration from legacy flat fields, per-config LLM base URL via
+NewOpenAIParserWithBaseURL (closing TOGGLE-3), atomic Ollama-availability flag with
+an HTTP probe replacing the one-shot LookPath-or-trust startup check (TOGGLE-5),
+mode-gated client registration building on TASK-06's keyless construction, and a
+hard gate on EmbedBooksAsync/batch paths to openai-only modes with the missing
+embeddingModelMatches check restored on the async skip path (TOGGLE-2).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-10-backend-mode-toggle-core
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `AIBackendConfig` already exists in `internal/config/config.go` with all
+five fields and `migrateAIBackendBlob` is already chained in
+`persistence.go`, re-verify with:
+```bash
+grep -n "type AIBackendConfig\|EffectiveEmbeddingMode\|EffectiveLLMMode" internal/config/config.go
+grep -n "migrateAIBackendBlob" internal/config/persistence.go
+grep -n "NewOpenAIParserWithBaseURL" internal/ai/openai_parser.go
+grep -n "localOllamaOK atomic.Bool\|localOllamaOK  *atomic" internal/ai/embedding_client.go
+grep -n "ErrBatchUnsupported" internal/dedup/engine.go
+```
+If all five checks find matches, this task is already done — do not
+re-implement; instead diff against the acceptance criteria above to find any
+partial gaps (e.g. migration exists but register.go still checks raw
+`OpenAIAPIKey`) and close only those gaps. Rollback = revert the commit; the
+legacy flat config fields (`Embedding.BaseURL`, `OpenAIAPIKey`,
+`EnableAIParsing`, `MetadataScoring.LLMEnabled`) are untouched and remain the
+source of truth if the migration/effective-mode helper is reverted, so a
+revert is safe and non-destructive to existing configs.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-11-backend-mode-toggle-frontend.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-11-backend-mode-toggle-frontend.md
@@ -1,0 +1,272 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-11-backend-mode-toggle-frontend.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0628f4f5-5e44-4212-9bf4-63f7c7e4cdb0 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-11 — Backend-mode toggle frontend (settings selector + model-download prompt)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Sonnet · frontend/webui subagent · **Wave:** 4 · **Depends on:** TASK-10 (backend-mode toggle, backend: config shape, `register.go` selector, `GET/POST /api/v1/ai/backends/*` endpoints)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-11-backend-mode-toggle-frontend" -b agent/cr-11-backend-mode-toggle-frontend origin/main
+cd "$REPO/.worktrees/cr-11-backend-mode-toggle-frontend"
+git rebase origin/main
+```
+
+**Before writing any frontend code, confirm TASK-10 has actually merged to
+`main` and rebase onto it** — this task is pure UI/wiring on top of the
+config fields and endpoints TASK-10 introduces. If `internal/ai` has no
+`BackendMode`/`AIBackendConfig` symbols yet (see verification grep below),
+STOP: TASK-10 has not landed, and this brief's endpoint paths and field names
+are the *design intent*, not verified fact — do not guess a shape and ship a
+UI against it.
+
+```bash
+grep -rn "AIBackendConfig\|BackendMode\|ai/backends" internal/ web/src --include="*.go" --include="*.ts" --include="*.tsx"
+```
+
+If that grep is empty, this task is blocked — comment on the tracking issue
+and stop here rather than inventing a config shape.
+
+## Goal
+
+Give operators a Settings UI to choose the embeddings/LLM backend mode
+(`disabled | openai | local | openai-fallback-local`, per TASK-10's config),
+enter local endpoint/model overrides when a local mode is selected, and — when
+a local mode is selected but the target model isn't pulled into Ollama yet —
+prompt to pull it with visible progress, instead of the feature silently
+404'ing against Ollama. This closes the FE half of TOGGLE-1..6 /
+MATCH-8 (`docs/consultancy/03-matching-and-backends.md`, Design section,
+"FE" + "Model-download prompt" paragraphs).
+
+## Background (verify before editing)
+
+- Source finding (consultancy doc, Design: LLM/Embedding Backend-Mode Toggle,
+  primary design): *"FE — 'AI Backends' card in Settings (extend
+  EmbeddingSettingsSection/MetadataScoringSection): two mode selects, local
+  endpoint/model fields, Test Connection → new `GET
+  /api/v1/ai/backends/status` (probes endpoint, lists pulled models via
+  `/api/tags`, reports effective mode + last fallback reason)."* and
+  *"Model-download prompt — when local selected and status shows model
+  absent: dialog 'qwen2.5:7b-instruct not pulled (4.7GB) — Pull now?' → `POST
+  /api/v1/ai/backends/pull-model`, runs `ollama pull` through the existing
+  managed external-tool lifecycle ... streaming progress as an op-registry
+  operation; mode stays pending-unavailable until probe passes."*
+- As of this writing (2026-07-03, before TASK-10), **none of this backend
+  plumbing exists** — `grep -rn "AIBackendConfig\|BackendMode\|ai/backends"`
+  across `internal/` and `web/src/` returns nothing. TASK-10 is expected to
+  add: the `AIBackendConfig{EmbeddingMode, LLMMode, LocalBaseURL,
+  LocalEmbeddingModel, LocalLLMModel}` struct to the config blob, a
+  `register.go` backend selector, and the two endpoints named above. **This
+  brief's endpoint paths/field names may drift once TASK-10 actually lands —
+  re-verify against TASK-10's PR/diff, not just this doc, before wiring
+  `apiFetch` calls.**
+- Existing FE patterns to reuse (confirmed present in this worktree, re-verify
+  the grep below):
+  - `web/src/components/settings/EmbeddingSettingsSection.tsx` — the existing
+    embedding settings card (`enabled` switch, `model`/`base_url` text
+    fields, `vector_backend` select), driven by a `config`/`onChange(patch)`
+    prop pair from `web/src/pages/Settings.tsx`. This is the sibling
+    component to extend or place a new "AI Backends" card next to (per the
+    design doc's "extend EmbeddingSettingsSection/MetadataScoringSection").
+  - `web/src/components/settings/MetadataScoringSection.tsx` — same
+    `config`/`onChange` pattern, LLM-side settings (`llm_enabled`, model
+    fields).
+  - `web/src/pages/Settings.tsx` tab index 3 (`TabPanel value={tabValue}
+    index={3}`) composes `DedupSettingsSection`, `EmbeddingSettingsSection`,
+    `MetadataScoringSection`, `ScheduledTasksSection` in sequence inside
+    `<Box sx={{ mt: 4 }}>` wrappers — this is the "CFG-2" settings-UI layout
+    convention (PR #1514) to follow for the new "AI Backends" card.
+  - `web/src/services/api.ts` — `apiFetch` wrapper convention: every API call
+    is `export async function xyz(...): Promise<T> { const response =
+    await apiFetch(`${API_BASE}/...`, {...}); ... }`. `EmbeddingConfig`
+    interface is defined near line 626 and referenced from the `Config`
+    interface (`embedding?: EmbeddingConfig`).
+  - `web/src/components/tools/ToolsPanel.tsx` — the existing
+    "managed external-tool lifecycle" pull/install UI pattern referenced by
+    the design doc: `getTools()` on mount, `installTool(name)` on click with
+    a per-tool `installing` boolean map, re-fetching `getTools()` after
+    install completes. This is a simple poll-after-action pattern (no SSE
+    streaming) — use it as the baseline shape for the model-pull button;
+    only add streaming/op-registry progress polling if TASK-10's
+    `pull-model` endpoint actually returns an op ID to poll (verify this
+    against TASK-10's implementation, don't assume).
+  - `web/src/components/settings/ToolsSettingsTab.tsx` — shows the
+    `useAdvancedSettings` hook pattern for gating advanced fields
+    (`showAdvanced`), useful if the local base-url/model fields should be
+    hidden by default.
+  - TODO.md "🧰 Managed External-Tool Lifecycle" section (search
+    `Managed External-Tool Lifecycle` in `TODO.md`) — TOOL-1..6, already
+    shipped in PR #1465: `ToolRegistry`, `POST
+    /api/v1/tools/:name/install`, `OllamaDaemon` PID-file lifecycle. The
+    model-pull backend endpoint (TASK-10) is expected to reuse this
+    lifecycle rather than shell out ad hoc — this FE task just needs to call
+    whatever endpoint TASK-10 exposes and render its result/progress.
+
+- **Re-verify these anchors before editing** — file contents may have
+  changed since this brief was written:
+  ```bash
+  grep -n "interface EmbeddingSettingsSectionProps\|export function EmbeddingSettingsSection" web/src/components/settings/EmbeddingSettingsSection.tsx
+  grep -n "export interface EmbeddingConfig" web/src/services/api.ts
+  grep -n "TabPanel value={tabValue} index={3}" web/src/pages/Settings.tsx
+  grep -n "export async function getTools\|export async function installTool\|export interface ToolStatus" web/src/services/api.ts
+  grep -rn "AIBackendConfig\|BackendMode\|ai/backends/status\|ai/backends/pull-model" internal/ web/src
+  ```
+  The last grep is the gate: it must show TASK-10's symbols/endpoints before
+  you proceed past step 1 below.
+
+## Step-by-step
+
+1. Confirm TASK-10 has landed (grep above). Note the **actual** field names
+   of `AIBackendConfig` (or whatever it was named) and the **actual**
+   request/response shape of the status/pull-model endpoints from TASK-10's
+   Go code (`internal/api` or wherever the handlers live) — do not copy the
+   field names in this brief verbatim without checking, since TASK-10 may
+   have adjusted them during implementation.
+2. In `web/src/services/api.ts`, add:
+   - An `AIBackendConfig` (or matching TASK-10 name) TypeScript interface
+     mirroring the Go struct, added to the `Config` interface the same way
+     `embedding?: EmbeddingConfig` is (grep `embedding?: EmbeddingConfig` to
+     find the exact spot).
+   - `getAIBackendsStatus(): Promise<AIBackendsStatus>` — `GET
+     ${API_BASE}/ai/backends/status`, following the `apiFetch` convention
+     used by `getTools()`.
+   - `pullAIBackendModel(model: string): Promise<...>` — `POST
+     ${API_BASE}/ai/backends/pull-model`, mirroring `installTool()`'s
+     `apiFetch(..., { method: 'POST', body: JSON.stringify({ name }) })`
+     shape (check `installTool`'s actual body shape first).
+3. Create `web/src/components/settings/AIBackendsSection.tsx` (new file,
+   sibling to `EmbeddingSettingsSection.tsx`), following that file's
+   `config`/`onChange(patch: Partial<AIBackendConfig>)` prop convention:
+   - Two `TextField select` mode pickers (embedding mode, LLM mode), options
+     = the four modes from TASK-10's config (`disabled | openai | local |
+     openai-fallback-local` — confirm exact string values from the Go
+     const/enum, don't assume spelling).
+   - When either mode select is `local` or `openai-fallback-local`, reveal
+     `LocalBaseURL` / `LocalEmbeddingModel` / `LocalLLMModel` text fields
+     (conditionally rendered, same pattern as `showAdvanced` conditional
+     blocks in `ToolsSettingsTab.tsx`).
+   - A "Test Connection" button that calls `getAIBackendsStatus()` and
+     displays effective mode + last fallback reason + per-model
+     pulled/absent status in a small results panel (reuse MUI `Alert`/
+     `Chip` components already imported elsewhere in `settings/` files —
+     grep `from '@mui/material'` in `EmbeddingSettingsSection.tsx` for the
+     import style).
+   - When status reports a selected local model absent, render a
+     confirmation dialog (MUI `Dialog`) — "`<model>` not pulled (`<size if
+     known>`) — Pull now?" — Confirm calls `pullAIBackendModel(model)` and
+     shows an "Installing…"/progress state modeled on
+     `ToolsPanel.tsx`'s `installing` boolean map, re-calling
+     `getAIBackendsStatus()` afterward to confirm the probe now passes.
+4. Wire the new section into `web/src/pages/Settings.tsx` tab index 3,
+   alongside `EmbeddingSettingsSection`/`MetadataScoringSection` (same
+   `<Box sx={{ mt: 4 }}>` wrapper pattern), with its own
+   `aiBackendConfig`/`handleAIBackendChange` state plumbing mirroring
+   `embeddingConfig`/`handleEmbeddingChange` (grep those two names in
+   `Settings.tsx` to find the exact `useState`/handler pattern to copy).
+5. Add `web/src/components/settings/AIBackendsSection.test.tsx` mirroring
+   `EmbeddingSettingsSection.test.tsx`'s structure: render with a default
+   config, assert the mode selects render, assert `onChange` fires with the
+   right patch on selection, assert local fields are hidden/shown based on
+   mode, assert the pull-model dialog appears when a mocked
+   `getAIBackendsStatus()` response reports the model absent.
+6. Add (or extend, if `web/tests/e2e/settings-ai-persistence.spec.ts` already
+   covers the AI backends card once TASK-10's fields exist) a Playwright
+   spec under `web/tests/e2e/` exercising: switching to local mode reveals
+   the local fields, saving persists them (reuse
+   `settings-configuration.spec.ts`'s save/reload pattern — grep it for the
+   exact save-and-reload assertion idiom), and the pull-model dialog
+   flow with a mocked/absent-model status response.
+7. Bump the file header (version bump + `last-edited`) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+8. Update `docs/reference/config-api-shape.md` with the new
+   `AIBackendConfig` fields in the `GET /config` / `PUT /config` shape
+   (follow that file's existing table/section format — do not replace the
+   whole document, only add the new fields).
+
+## How to test
+
+```bash
+cd web
+npm run build
+npx vitest run src/components/settings/AIBackendsSection.test.tsx src/components/settings/EmbeddingSettingsSection.test.tsx
+npx eslint src/components/settings/AIBackendsSection.tsx src/pages/Settings.tsx src/services/api.ts
+npx tsc --noEmit
+```
+
+If Playwright coverage was added:
+```bash
+cd web
+npx playwright test tests/e2e/settings-ai-persistence.spec.ts
+```
+
+Then, from the repo root, confirm the embedded build still compiles (this
+task should not touch Go code, but a broken frontend build breaks
+`embed_frontend`):
+```bash
+go build ./...
+go vet ./...
+```
+
+## Acceptance criteria
+
+- [ ] TASK-10's `AIBackendConfig`/mode-enum/endpoint symbols were confirmed
+      present in `main` before any FE code was written (grep output pasted
+      into the PR description).
+- [ ] New "AI Backends" settings card renders two mode selectors (embedding,
+      LLM) with the four modes from TASK-10's config.
+- [ ] Local base-url/model fields are shown only when a local-involving mode
+      is selected for the corresponding subsystem.
+- [ ] "Test Connection" calls the status endpoint and displays effective
+      mode, last fallback reason, and per-model pulled/absent state.
+- [ ] Selecting a local mode with an absent model surfaces a confirmation
+      dialog; confirming calls the pull-model endpoint and shows progress,
+      then re-probes status.
+- [ ] New card is wired into `Settings.tsx` tab index 3 using the same
+      `config`/`onChange` plumbing as `EmbeddingSettingsSection`.
+- [ ] `docs/reference/config-api-shape.md` documents the new config fields.
+- [ ] `npx vitest run` (new + existing settings tests) is green;
+      `npx tsc --noEmit` and `npx eslint` are clean; `go build ./...` and
+      `go vet ./...` remain clean (no Go files should need changes).
+- [ ] File headers bumped on every changed/new file.
+
+## Commit message
+
+```
+feat(settings): add AI backend-mode selector and model-pull prompt to Settings UI
+
+TOGGLE-1..6/MATCH-8 (consultancy 03-matching-and-backends.md) call for FE
+wiring on top of the backend-mode toggle: independent embedding/LLM mode
+selects, local endpoint/model fields, a Test Connection status probe, and a
+model-download confirmation dialog reusing the managed external-tool
+lifecycle pull pattern. Adds the AI Backends settings card and wires it into
+the existing CFG-2 Settings tab layout.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-11-backend-mode-toggle-frontend
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, run the verification grep from "START HERE" — if
+`AIBackendConfig`/`BackendMode`/`ai/backends` symbols don't exist anywhere in
+`internal/` or `web/src/`, TASK-10 has not landed and this task cannot
+proceed; do not stub out a fake shape. If a card matching "AI Backends" (or
+equivalent mode selectors + model-pull dialog) already exists in
+`web/src/components/settings/`, this task is done — verify with `grep -rln
+"pull-model\|AIBackendConfig" web/src/components/settings/` and confirm a
+component renders both mode selects and the pull-model dialog described
+above. Rollback = revert the commit; this task touches only frontend
+files and `docs/reference/config-api-shape.md`, so revert is a pure UI
+regression with no data-model or backend impact.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-12-retry-permanent-error-classes.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-12-retry-permanent-error-classes.md
@@ -1,0 +1,205 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-12-retry-permanent-error-classes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0b9347fa-a649-440a-a504-a1f4c6ebdf6e -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-12 — Permanent-error classification in AI retry paths (MATCH-7 / TOGGLE-4 / BUG-5 / QUAL-6)
+
+**Priority:** P1 · **Effort:** S · **Recommended subagent:** Sonnet · go-backend subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-12-retry-permanent-error-classes" -b agent/cr-12-retry-permanent-error-classes origin/main
+cd "$REPO/.worktrees/cr-12-retry-permanent-error-classes"
+git rebase origin/main
+```
+
+## Goal
+
+Both retry implementations in `internal/ai` — the shared `DoWithRetry` helper
+and the independent inline loop inside `EmbeddingClient.embedBatchRaw` —
+currently retry every error identically with full backoff, including errors
+that can never succeed on retry: HTTP 400/401/403/404 and HTTP 429 with an
+OpenAI error code of `insufficient_quota` (quota exhaustion is permanent;
+plain rate-limit 429s are transient and should still retry). During a live
+OpenAI quota outage this burns minutes of wasted backoff per call and gives
+the (future, out of scope here) backend-fallback selector no signal to act
+on. Add a shared error classifier and make both retry loops short-circuit on
+permanent errors, returning a typed `PermanentError` so callers can
+distinguish "will never succeed" from "exhausted retries."
+
+Do **not** implement backend fallback, cooldown flags, or a backend-status
+endpoint in this task — that is TASK-10's job. This task only adds the
+classifier and typed error, and wires both retry loops to consult it.
+
+## Background (verify before editing)
+
+- `DoWithRetry` lives in `internal/ai/retry.go` (currently the whole file is
+  ~47 lines). It loops `attempt` from 0 to `maxAttempts-1`, sleeps
+  `attempt² × base` between attempts, calls `fn()`, and on any non-nil error
+  just does `lastErr = err; continue` — no inspection of `err` at all.
+- `EmbeddingClient.embedBatchRaw` in `internal/ai/embedding_client.go` is a
+  **second, independent** retry loop (hardcoded 3 attempts, delays
+  `1s, 4s`) that calls `c.client.Embeddings.New(...)` (the OpenAI Go SDK v3)
+  and on error does `lastErr = fmt.Errorf(...); continue` — same problem,
+  duplicated.
+- The OpenAI SDK (`github.com/openai/openai-go/v3`, confirmed in `go.mod` as
+  `v3.41.0`) exposes API errors as `openai.Error`, which is a type alias:
+  `type Error = apierror.Error` (package
+  `github.com/openai/openai-go/v3/internal/apierror`). Verify with:
+  ```bash
+  go doc github.com/openai/openai-go/v3.Error
+  ```
+  Relevant fields on `*openai.Error` (it implements `error` via a pointer
+  receiver, so use `errors.As(err, &apiErr)` with `var apiErr *openai.Error`):
+  - `Code string` — the OpenAI error code, e.g. `"insufficient_quota"`,
+    `"invalid_api_key"`, `"model_not_found"`.
+  - `StatusCode int` — the HTTP status code.
+  - `Message string`, `Param string`, `Type string`.
+- Classification to implement (per both consultancy findings, which agree):
+  - **Permanent** (stop retrying immediately):
+    - `StatusCode` is 400, 401, 403, or 404, **or**
+    - `StatusCode == 429 && Code == "insufficient_quota"`.
+  - **Transient** (keep the existing retry behavior):
+    - Any other 429 (plain rate limiting).
+    - 5xx status codes.
+    - Network/timeout errors that never reach `errors.As` as `*openai.Error`
+      at all (e.g. `context.DeadlineExceeded`, connection refused) — treat
+      anything that does not classify as `*openai.Error` as transient/unknown
+      and retry it, matching current behavior.
+- `internal/ai` also has two other `DoWithRetry` callers —
+  `internal/ai/openai_parser.go` and `internal/ai/metadata_llm_review.go` —
+  that get the permanent-error short-circuit automatically once `DoWithRetry`
+  is fixed. Do not modify those two files; confirm they compile unchanged.
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func DoWithRetry" internal/ai/retry.go
+  grep -n "func (c \*EmbeddingClient) embedBatchRaw\|lastErr = fmt.Errorf" internal/ai/embedding_client.go
+  grep -rln "DoWithRetry" internal/ai/*.go
+  go doc github.com/openai/openai-go/v3.Error
+  ```
+
+## Step-by-step
+
+1. In `internal/ai/retry.go`, add:
+   - A `PermanentError` type wrapping the underlying error (implements
+     `Error() string` and `Unwrap() error` so `errors.Is`/`errors.As` still
+     work against the wrapped cause).
+   - An unexported (or exported, your call — keep it minimal) classifier,
+     e.g. `func isPermanentAIError(err error) bool`, that does the
+     `errors.As(err, &apiErr)` check described above against `*openai.Error`
+     and returns true only for the permanent cases listed in Background.
+     This requires importing `github.com/openai/openai-go/v3` and `errors`
+     into `retry.go`.
+2. In `DoWithRetry`, after `if err := fn(); err != nil {`, check
+   `isPermanentAIError(err)` — if true, wrap `err` in `PermanentError` and
+   `return` immediately (no further attempts, no additional backoff sleep).
+   Otherwise keep the existing `lastErr = err; continue` behavior unchanged.
+3. In `internal/ai/embedding_client.go`, inside `embedBatchRaw`'s loop, after
+   `if err != nil {`, check `isPermanentAIError(err)` the same way — if true,
+   wrap in `PermanentError` and `return nil, err` immediately instead of
+   `continue`-ing into the remaining attempts/delays. Otherwise keep the
+   existing `lastErr = ...; continue` behavior unchanged.
+4. Do not merge the two loops into one implementation in this task (the
+   consultancy "better" suggestion of routing `embedBatchRaw` through
+   `DoWithRetry` is a larger refactor — out of scope; leave a `// TODO(#TASK-12-followup):`
+   comment at most, do not restructure `embedBatchRaw`'s signature or its
+   per-attempt bounded-context pattern).
+5. Add `internal/ai/retry_test.go` (new file) with table-driven tests for
+   `isPermanentAIError` covering: 400, 401, 403, 404 → permanent; 429 with
+   `Code == "insufficient_quota"` → permanent; plain 429 (no code / different
+   code) → transient; 500/503 → transient; a plain non-`*openai.Error` error
+   (e.g. `errors.New("boom")`, `context.DeadlineExceeded`) → transient. Also
+   add a `DoWithRetry`-level test proving a permanent error returned by `fn`
+   causes exactly one call to `fn` (no retries) and the returned error
+   satisfies `errors.As(..., &PermanentError{})`, versus a transient error
+   still retrying up to `maxAttempts`.
+6. Add a test (in `internal/ai/embedding_client_test.go` or a new file) that
+   spins up an `httptest.Server` returning a canned OpenAI-shaped error body
+   (`{"error":{"message":"...","type":"insufficient_quota","code":"insufficient_quota"}}`)
+   with HTTP status 429, points `NewEmbeddingClientWithOptions("k", "", server.URL)`
+   at it, calls `c.embedBatchRaw(ctx, []string{"x"})` directly, and asserts
+   the test server received exactly **1** request (proving no retries) and
+   the returned error is a `PermanentError`. Add a second case with a 500
+   response asserting the server received all 3 attempts (existing behavior
+   preserved for transient errors).
+7. Bump the file header (version bump + `last-edited` date) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/ai/... -run 'Retry|Permanent|EmbedBatch' -count=1 -v
+go test ./internal/ai/... -count=1
+go vet ./internal/ai/...
+```
+
+## Acceptance criteria
+
+- [ ] `internal/ai/retry.go` defines `PermanentError` and a classifier that
+      identifies 400/401/403/404 and 429-with-`insufficient_quota` as
+      permanent via `errors.As` against `*openai.Error`.
+- [ ] `DoWithRetry` returns immediately (no further sleep/attempts) on a
+      permanent error, wrapped so `errors.As(err, &PermanentError{})` succeeds.
+- [ ] `embedBatchRaw` returns immediately (no further sleep/attempts) on a
+      permanent error, using the same classifier — no duplicated
+      classification logic between the two call sites.
+- [ ] Plain rate-limit 429s (no `insufficient_quota` code), 5xx errors, and
+      non-`*openai.Error` errors (network/timeout) still retry exactly as
+      before (no behavior change for the transient path).
+- [ ] `internal/ai/retry_test.go` (new) table-tests the classifier and proves
+      `DoWithRetry`'s short-circuit behavior for both permanent and transient
+      cases.
+- [ ] An `httptest.Server`-backed test proves `embedBatchRaw` makes exactly 1
+      HTTP call on a permanent (429/insufficient_quota) response and all 3
+      attempts on a transient (5xx) response.
+- [ ] `internal/ai/openai_parser.go` and `internal/ai/metadata_llm_review.go`
+      compile unchanged (they inherit the fix via `DoWithRetry` with no edits
+      needed) — confirm with `go build ./internal/ai/...`.
+- [ ] `go test ./internal/ai/...` is green; `go vet ./internal/ai/...` is clean.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(ai): classify permanent vs transient errors in retry paths (MATCH-7/TOGGLE-4/BUG-5/QUAL-6)
+
+DoWithRetry and embedBatchRaw retried every error identically with full
+quadratic/fixed backoff, including HTTP 400/401/403/404 and 429
+insufficient_quota — none of which can succeed on retry. During the live
+OpenAI quota outage this burned minutes per call for a doomed result. Add
+a shared classifier consulted by both loops so permanent errors fail fast
+as a typed PermanentError, while rate-limit 429s, 5xx, and network errors
+keep retrying as before.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-12-retry-permanent-error-classes
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/ai/retry.go` already defines a `PermanentError` type (or
+equivalent) and `DoWithRetry` already short-circuits on
+400/401/403/404/insufficient_quota-429, this task is done — verify with:
+
+```bash
+grep -n "PermanentError\|isPermanentAIError\|insufficient_quota" internal/ai/retry.go internal/ai/embedding_client.go
+```
+
+If only one of the two loops has been fixed (e.g. `DoWithRetry` classifies
+but `embedBatchRaw` still retries unconditionally), do the remaining half
+only — do not duplicate the classifier, import and call the one already
+added to `retry.go`. Rollback = revert the commit; both retry loops fall
+back to unconditional-retry behavior, which is the pre-existing (working,
+just slow-to-fail) state — no data-affecting side effects to unwind.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-13-stale-candidate-drain.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-13-stale-candidate-drain.md
@@ -1,0 +1,314 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-13-stale-candidate-drain.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 128d31ac-5703-4821-8766-f0ed9edaa08d -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-13 — Stale-candidate drain op (~384K importer-bug candidates, dry-run gated) (consultancy-roadmap: DEDUP-1 / DEDUP-5)
+
+**Priority:** P1 · **Effort:** L · **Recommended subagent:** Opus · go-backend subagent · **Wave:** 2 · **Depends on:** TASK-04
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-13-stale-candidate-drain" -b agent/cr-13-stale-candidate-drain origin/main
+cd "$REPO/.worktrees/cr-13-stale-candidate-drain"
+git rebase origin/main
+```
+
+## Goal
+
+Build a new op, `dedup.drain-stale`, that re-evaluates the ~383,902 exact-layer
+dedup candidates emitted **before** the CONS-16 (duration-ms) and CONS-17
+(multi-file title-leak) importer bugs were fixed against **today's** emission
+gates in `upsertExactCandidate`. Most of that backlog is poisoned data from the
+two now-fixed bugs, not real duplicates (per `TODO.md` CONS-9/CONS-10 and
+`docs/consultancy/02-dedup.md` DEDUP-1: this is the single highest-yield,
+zero-fingerprint lever for shrinking the candidate backlog). The op must be
+**dry-run by default**, produce a counts+samples report, and gate any write
+("apply") behind an explicit owner greenlight — do not purge or dismiss
+anything as part of this task's acceptance criteria. Must also respect the
+DEDUP-5 memory bound: never materialize the full ~384K-row candidate set or a
+full-`database.Book` cache in one shot.
+
+## Background (verify before editing)
+
+- **DEDUP-1** (`docs/consultancy/02-dedup.md`): the ~383,902 stale exact
+  candidates recorded in `TODO.md` were computed before two importer bugs were
+  fixed:
+  - CONS-16 (duration stored in milliseconds instead of seconds — fixed,
+    `trackDurationSeconds()` in `internal/itunes/service/importer.go`, plus the
+    `maintenance.duration-backfill` op that already ran on prod: 17,684 files /
+    1,210 books corrected);
+  - CONS-17 (multi-file title leak — a chapter's per-track tag name leaking in
+    as the book title — fixed in `buildBookFromAlbumGroup` and the filesystem
+    scanner's `AssembleBookMetadata` routing).
+  Candidates created while those bugs were live were emitted against corrupt
+  duration/title data and never re-checked once the data self-healed. The
+  `dedup.quarantine-chapter-artifacts` op (already shipped, CONS-9) found only
+  ~53 short idents this way — confirming most of the 380K is corrupt-metadata
+  false positives, not chapter artifacts, and needs a **different, gate-based**
+  drain (this task), not a title-collision heuristic.
+- **The chokepoint to re-run candidates through** is `upsertExactCandidate` in
+  `internal/dedup/engine.go`. As of this writing (verify below — TASK-01
+  already landed and added two of these gates) its body runs, in order:
+  `isNonPrimaryVersion` → `identifiersConflict` → `isBoilerplateTitle` (either
+  side) → `hasKnownShortDuration` (either side, threshold
+  `minFingerprintMatchSeconds` = 60s) → `de.isPartVsWholeMismatch`. A pending
+  `layer="exact"` candidate whose two books **would not pass this chain today**
+  (using their current, corrected `Duration`/`Title`/file data) is exactly the
+  kind of stale-from-bug row DEDUP-1 wants drained. This task does **not**
+  change `upsertExactCandidate` itself — it reuses the same predicates against
+  existing rows.
+- **DEDUP-5 memory bound** (`docs/consultancy/02-dedup.md`): both
+  `ReevaluateAcoustIDConflicts` and `dataset_backfill.go` call
+  `de.embedStore.ListCandidates` with `Limit: 1000000`, materializing the
+  entire candidate set, and `ReevaluateAcoustIDConflicts` additionally builds
+  an unbounded `map[string]bookMeta`-shaped cache holding full `BookSigV1`
+  strings. On the same host that hit a 69GB warm-up incident, doing this again
+  at ~384K candidates is a foot-gun. This new op must page `ListCandidates` in
+  bounded batches (the existing `checkExactISBNScan` 500-row batching pattern
+  in `internal/dedup/engine.go` is the reference; `CandidateFilter` already has
+  `Limit`/`Offset` fields — verify below) and must cache only the small set of
+  book fields the gates need (id, title, duration, isbn/asin, version-group,
+  file count/paths) — mirror `PurgeStaleCandidates`'s `bookMeta` struct
+  pattern, which already avoids caching full `Book`/`BookSigV1` blobs. Do NOT
+  add a second unbounded per-book cache.
+- **Owner-gated apply, M0 precedent**: `dedup.purge-legacy-fp-candidates`
+  (`internal/plugins/dedup/purge_legacy_fp.go`) is the precedent for this
+  pattern — dry-run by default, `apply=true` param to write, a versioned
+  "done" flag in Settings to prevent an accidental double-run, and rows are
+  **soft-classified** (`status` changed to a new value, e.g. `"stale-drain"`)
+  rather than hard-deleted, so the run is auditable and reversible. This task
+  builds the **dry-run report only** (see Acceptance criteria) — the apply
+  path may be scaffolded but must not be exercised or relied upon without a
+  separate, explicit user greenlight per CLAUDE.md's data-loss-gate discipline
+  (same gate `TODO.md` CONS-10 already documents: "Quarantining before
+  backfill = DATA LOSS... get explicit user OK before any apply").
+- **Checkpoint/resumable**: `internal/operations/state.go` exposes
+  `SaveCheckpoint(store database.OperationStore, opID, opType, phase string,
+  index, total int) error`, `LoadCheckpoint(store, opID) (*OperationState,
+  error)`, and `ClearState(store, opID) error` — the pattern used by
+  `internal/maintenance/jobs/backfill_file_hashes.go` (load a checkpoint at
+  start, save one every ~50 items in the main loop, clear on clean
+  completion). Use the candidate offset as the checkpoint index so a
+  restarted run resumes mid-backlog instead of rescanning from zero.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (de \*Engine) upsertExactCandidate\|func hasKnownShortDuration\|func isBoilerplateTitle\|func identifiersConflict\|func (de \*Engine) isPartVsWholeMismatch\|const minFingerprintMatchSeconds\|func (de \*Engine) checkExactISBNScan\|func (de \*Engine) PurgeStaleCandidates" internal/dedup/engine.go
+  grep -n "type CandidateFilter\|func (s \*EmbeddingStore) ListCandidates\|func (s \*EmbeddingStore) UpdateCandidateStatus\|func (s \*EmbeddingStore) DeleteCandidate" internal/database/embedding_store.go
+  grep -n "func SaveCheckpoint\|func LoadCheckpoint\|func ClearState" internal/operations/state.go
+  grep -n "purgeLegacyFPDoneFlag\|purgeLegacyFPDefaultCutover" internal/plugins/dedup/purge_legacy_fp.go
+  ```
+  Confirm the exact ordering/names of `upsertExactCandidate`'s guard chain
+  matches the Background section above — if it has drifted (more/fewer
+  guards, renamed helpers), rebuild the re-evaluation predicate list to match
+  what the function **actually does today**, not what this brief says.
+
+## Step-by-step
+
+1. Add a `DrainStaleCandidates` method on `*dedup.Engine` in
+   `internal/dedup/engine.go` (or a new `internal/dedup/drain_stale.go` file if
+   you prefer to keep `engine.go`'s size down — match whichever the repo's
+   recent convention favors; `PurgeStaleCandidates` lives directly in
+   `engine.go` today) with signature:
+   ```go
+   type DrainStaleResult struct {
+       Inspected int
+       WouldPurge int
+       Kept int
+       // ReasonCounts buckets WouldPurge by which gate rejected the pair:
+       // "boilerplate_title", "short_duration", "part_vs_whole",
+       // "identifier_conflict", "missing_book".
+       ReasonCounts map[string]int
+       // Samples holds up to a small cap (e.g. 50) per reason, for the
+       // dry-run report — candidate IDs + book IDs + the rejecting reason.
+       Samples map[string][]DrainStaleSample
+   }
+   type DrainStaleSample struct {
+       CandidateID int64
+       BookAID, BookBID string
+       Reason string
+   }
+   func (de *Engine) DrainStaleCandidates(ctx context.Context, opID string, apply bool) (*DrainStaleResult, error)
+   ```
+2. Implement it to only ever touch `layer="exact"`, `status="pending"`
+   candidates (mirror `PurgeStaleCandidates`'s status filter — merged/dismissed
+   rows are historical and must never be touched).
+3. Page through candidates in bounded batches (e.g. 500 per page) via
+   `de.embedStore.ListCandidates(database.CandidateFilter{EntityType: "book",
+   Status: "pending", Layer: "exact", Limit: batchSize, Offset: offset})`,
+   looping until a short page ends the scan — do not pass `Limit: 1000000`.
+4. For each candidate in a page, look up both books via a small local cache
+   (memoize by book ID within the run, storing only: `ID`, `Title`,
+   `Duration`, `ISBN10/13`, `ASIN`, `IsPrimaryVersion`, `VersionGroupID`, file
+   count/paths needed by `isPartVsWholeMismatch` — NOT the full `database.Book`
+   struct and never `BookSigV1`). Missing book on either side → count as
+   `WouldPurge` with reason `"missing_book"` (same conservative treatment
+   `PurgeStaleCandidates` gives missing books).
+5. Re-run the same predicate chain `upsertExactCandidate` uses (excluding
+   `isNonPrimaryVersion`, which `PurgeStaleCandidates` already separately
+   drains today — do not duplicate it here unless it is missing; verify with
+   the grep above) against the pair's **current** data:
+   `identifiersConflict` → `isBoilerplateTitle` (either side) →
+   `hasKnownShortDuration` (either side) → `de.isPartVsWholeMismatch`. First
+   predicate that fires decides the reason bucket; if none fire, the candidate
+   is `Kept`.
+6. On `apply=false` (default): only tally `Inspected`/`WouldPurge`/`Kept`/
+   `ReasonCounts`/`Samples` — write nothing to the store.
+7. On `apply=true`: for each `WouldPurge` candidate, call
+   `de.embedStore.UpdateCandidateStatus(c.ID, "stale-drain")` (soft
+   reclassification, matching the M0 `purge_legacy_fp` precedent — never hard
+   `DeleteCandidate` here, so the run is auditable/reversible). Gate this apply
+   path behind a versioned Settings done-flag analogous to
+   `purgeLegacyFPDoneFlag` (e.g. `dedup_stale_drain_v1_done`) so a second
+   `apply=true` run after completion is a safe no-op, mirroring
+   `purge_legacy_fp.go`'s pattern — verify the exact flag-read/write helper it
+   uses and reuse the same one.
+8. Wire checkpoint/resume: at the top, if `opID != ""`, call
+   `operations.LoadCheckpoint(store, opID)` and resume from its `PhaseIndex` as
+   the starting `Offset`; inside the page loop, after each page, call
+   `operations.SaveCheckpoint(store, opID, "dedup:drain-stale", "scanning",
+   offset, totalPendingExactCount)`; on clean completion call
+   `operations.ClearState(store, opID)`. `totalPendingExactCount` can come from
+   a first `ListCandidates` call with a small `Limit` to read the total count
+   the store returns (or from an existing stats helper — check
+   `de.embedStore` for a `CandidateStat`/count method before writing a new
+   one).
+9. Create `internal/plugins/dedup/drain_stale.go` following the
+   `purge_legacy_fp.go` op-wrapper shape: an `sdk.OperationDef` with
+   `ID: "dedup.drain-stale"`, `Capabilities: []sdk.Capability{sdk.CapLibraryRead,
+   sdk.CapLibraryWrite}`, dry-run-by-default `apply bool` JSON param, a
+   `Run` function that calls `p.engine.DrainStaleCandidates(ctx, opID, params.Apply)`
+   and reports progress/results through `reporter` (log the full
+   `ReasonCounts` breakdown and total counts via `reporter.Logger().Info(...)`
+   and `reporter.UpdateProgress(...)`, matching `runPurgeStale`'s /
+   `runDatasetBackfill`'s shape).
+10. Register the new op in `internal/plugins/dedup/plugin.go`'s `Register`
+    method's `ops := []sdk.OperationDef{...}` slice (add
+    `p.drainStaleDef(), // DEDUP-1: drain CONS-16/17-era stale exact candidates`
+    near `p.purgeStaleDef()` / `p.quarantineChapterArtifactsDef()`).
+11. Add `internal/dedup/drain_stale_test.go` (or extend `engine_test.go`)
+    covering:
+    - a pending exact candidate whose current book data now fails
+      `isBoilerplateTitle` → counted `WouldPurge`, reason `boilerplate_title`;
+    - a pending exact candidate whose current book data now fails
+      `hasKnownShortDuration` → counted `WouldPurge`, reason `short_duration`;
+    - a pending exact candidate that still passes every gate → counted `Kept`,
+      untouched;
+    - a pending exact candidate referencing a since-deleted book ID → counted
+      `WouldPurge`, reason `missing_book`;
+    - `apply=false` never calls `UpdateCandidateStatus`/`DeleteCandidate`
+      (assert via a fake/mock store call-count of zero, or by re-listing
+      candidates after the dry run and asserting status is unchanged);
+    - `apply=true` sets status to `"stale-drain"` on `WouldPurge` rows only,
+      and a second `apply=true` run after the done-flag is set is a no-op
+      (candidate count / status unchanged).
+    - a paging test with more than one batch's worth of candidates (e.g. set
+      the batch size low via a test-only constant or table-drive the loop) to
+      prove the loop doesn't skip or double-count rows across page boundaries.
+12. Add `internal/plugins/dedup/drain_stale_test.go` for the op wrapper: dry
+    run produces a report and writes nothing; verify `OperationDef.ID`,
+    capabilities, and default `apply=false`.
+13. Bump the file header (version bump + `last-edited`) on every file you
+    touch per `.standards/instructions/file-headers.md`.
+14. Update `TODO.md`'s CONS-10 entry to note that `dedup.drain-stale` now
+    exists as the dry-run tool for the drain, and that the dry-run report must
+    still be shown to the user and explicitly approved before any
+    `apply=true` run against prod — do not change CONS-10's checkbox state to
+    checked; this task ships the tool, not the executed drain.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/dedup/... ./internal/plugins/dedup/... -count=1
+go vet ./internal/dedup/... ./internal/plugins/dedup/...
+```
+
+## Acceptance criteria
+
+- [ ] New `dedup.drain-stale` op exists, registered in
+      `internal/plugins/dedup/plugin.go`, dry-run (`apply=false`) by default.
+- [ ] Dry run pages through pending `layer="exact"` candidates in bounded
+      batches (never `Limit: 1000000`) and never caches a full `database.Book`
+      or `BookSigV1` string per candidate.
+- [ ] Dry run re-evaluates each candidate's current book data against
+      `upsertExactCandidate`'s guard chain (identifier conflict, boilerplate
+      title, short duration, part-vs-whole) and produces a report: total
+      inspected, total would-purge, total kept, a reason-code breakdown, and
+      capped samples per reason.
+- [ ] Dry run (`apply=false`) writes nothing to the candidate store — verified
+      by test.
+- [ ] `apply=true` path is implemented and covered by tests (soft
+      reclassification to `"stale-drain"`, versioned done-flag prevents a
+      double-run) but this task's acceptance **stops at the dry-run report
+      being correct and safe** — running `apply=true` against production data
+      requires a separate, explicit owner greenlight after the dry-run
+      counts/samples have been reviewed (per `TODO.md` CONS-10's existing
+      data-loss gate). Do not run `apply=true` against prod as part of this
+      task.
+- [ ] Checkpoint/resume wired via `operations.SaveCheckpoint` /
+      `LoadCheckpoint` / `ClearState` so an interrupted dry run resumes from
+      its last offset instead of rescanning from zero.
+- [ ] All new/updated tests green; `go build ./...`, `go vet
+      ./internal/dedup/... ./internal/plugins/dedup/...` clean.
+- [ ] File headers bumped on every changed file.
+- [ ] `TODO.md` CONS-10 entry updated to reference the new tool without
+      marking the drain itself as executed/complete.
+
+## Commit message
+
+```
+feat(dedup): add dry-run-gated dedup.drain-stale op for CONS-16/17-era stale candidates
+
+~383,902 exact-layer dedup candidates were emitted before the duration-ms
+(CONS-16) and multi-file title-leak (CONS-17) importer bugs were fixed, and
+have never been re-checked against corrected book data. Add
+dedup.drain-stale: pages pending exact candidates in bounded batches (DEDUP-5
+memory bound — no 1M-row loads, no full-Book caching), re-runs each pair
+through upsertExactCandidate's current guard chain, and reports counts/samples
+by rejection reason. Dry-run by default; apply path soft-reclassifies to
+stale-drain behind a versioned done-flag (M0 purge precedent) but is not
+exercised against prod by this change — that requires a separate owner
+greenlight per the existing CONS-10 data-loss gate.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-13-stale-candidate-drain
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/plugins/dedup/drain_stale.go` and a `DrainStaleCandidates` method
+on `*dedup.Engine` already exist and are registered in `plugin.go`'s op list,
+this task is done — verify with:
+```bash
+grep -n "drain-stale\|DrainStaleCandidates" internal/plugins/dedup/*.go internal/dedup/engine.go
+```
+If the grep for `upsertExactCandidate`'s guard chain (Background section)
+shows the gates have changed shape (e.g. a guard was removed, or the CONS-16/17
+bugs were fixed differently than described here), stop and re-derive the
+re-evaluation predicate list from the function's actual current body rather
+than proceeding with a stale predicate list — do not invent gates that no
+longer exist. If the ~384K candidate backlog has already been drained by some
+other mechanism (check via
+`grep -n "stale-drain\|dedup_stale_drain" TODO.md CHANGELOG.md` and a candidate
+count check against prod), narrow this task to just landing the tool for
+future regressions and note in the PR description that the historical backlog
+is already clear.
+
+Rollback: this change is purely additive (new op, new engine method, new
+tests) and does not modify `upsertExactCandidate` or any other existing
+emitter/gate — revert the commit to remove it. The `apply=true` path, even if
+merged, defaults to off and requires an explicit param plus (per this task's
+gate) a separate owner greenlight before ever running against prod, so merging
+this PR does not by itself change any candidate's status.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-14-duration-coverage-backfill.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-14-duration-coverage-backfill.md
@@ -1,0 +1,234 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-14-duration-coverage-backfill.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 38ef7e96-6bb2-498f-91df-c01f795cb219 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-14 — Duration-coverage backfill to unblock `not_dup` catchers (DEDUP-4)
+
+**Priority:** P1 · **Effort:** S · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 3 · **Depends on:** TASK-13
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-14-duration-coverage-backfill" -b agent/cr-14-duration-coverage-backfill origin/main
+cd "$REPO/.worktrees/cr-14-duration-coverage-backfill"
+git rebase origin/main
+```
+
+## Goal
+
+`partVsWhole` (the dataset catcher that rejects part-vs-whole pairs as
+`not_dup`) deliberately refuses to fire whenever either side's duration is
+unknown (`TotalDurationSec <= 0`), and `implausibleAudio` only catches the
+zero-duration+tiny-file stub case — a zero-duration book with a *large*
+unscanned file passes through unlabeled by design. That means every pending
+dedup candidate touching a Duration=0-with-files book is stuck "unjudgeable"
+forever, even though the fix is cheap: just measure the duration. This task
+adds an **opt-in duration-only scoping filter** to the existing
+`maintenance.duration-reextract` op so it can be run cheaply and specifically
+over the residual (rather than the whole library), and documents/tests the
+two-step sequence — reextract (scoped) → `dedup.dataset-backfill` — that
+converts a slice of the unjudgeable backlog into rule-labeled `not_dup`.
+
+This is a **prod-data-adjacent maintenance op change**, not a data migration —
+you are not writing a new backfill job from scratch. `maintenance.duration-reextract`
+already re-derives real durations for zero-duration books (see Background); the
+only gap is that it always scans the *entire* library, which is wasteful when
+you specifically want to target the Duration=0 residual. Do not build a
+parallel ffprobe pipeline — extend the existing op with a filter flag.
+
+## Background (verify before editing)
+
+- `internal/dedup/dataset/rules.go` — `partVsWhole` (~line 106) explicitly
+  does not fire when `ex.A.TotalDurationSec <= 0 || ex.B.TotalDurationSec <= 0`
+  (comment above it says so directly: "when either side has
+  `TotalDurationSec == 0` ... this catcher deliberately does not fire"). This
+  citation was verified against the current file — accurate as of this task.
+- `internal/plugins/dedup/dataset_backfill.go` — the package doc comment
+  (top of file) states the dominant unlabeled residual class is exactly this:
+  "stub/unscanned-file pairs with one side duration=0" that "is NOT caught by
+  the duration-ratio or missing-file catchers when file records exist but the
+  file is 0-second." This is the op you re-run in step 2 below — no changes
+  needed to this file itself.
+- `internal/dedup/engine.go` `hasPlausibleAudio` (grep for the exact line
+  below) also treats zero-duration + large-file books as "plausible audio"
+  and lets them through rather than suppressing — consistent with `rules.go`'s
+  `implausibleAudio`, which only suppresses zero-duration + **small** file
+  (< `minPlausibleAudioBytes`, 256 KiB). Large-file zero-duration books are the
+  gap this task closes (by giving them a real duration, not by changing the
+  suppression logic).
+- **The actual fix lever is `internal/plugins/maintenance/duration_reextract.go`**
+  (op `maintenance.duration-reextract`). Read its package doc comment in full
+  before editing — it already:
+  - Iterates every book via `sdk.PageBooks` (paged, 500/page).
+  - For books with `BookFile` segments, re-derives each segment's real
+    duration: fingerprint-stored value first (`AcoustIDFingerprintDurationSec`,
+    fast/no-shell-out), then a stored non-iTunes `Duration` fast path, then
+    ffprobe as the last resort (`extractWithTimeout`).
+  - For virtual single-file books (no `BookFile` rows), probes `Book.FilePath`
+    directly with ffprobe.
+  - Writes corrected segments and calls `RecomputeBookAggregates` (via the
+    write path used elsewhere in the op) so `Book.Duration` reflects the sum.
+  - Is dry-run by default (`DryRun` param), idempotent, cancellable, and
+    already supports a `Workers` param (default 4, max 16) controlling ffprobe
+    concurrency — this is the "existing ffprobe infra" and "4-worker pattern"
+    referenced by this task; there is nothing new to build there.
+  - This op **already handles zero-duration books** — `processBookForReextract`
+    computes `oldDur` from `book.Duration` (0 if `nil`) and always attempts to
+    derive `newDur`, regardless of what the stored value was. The only
+    inefficiency is that it does this over the *entire* library on every run,
+    including books whose duration is already known-good, which wastes the
+    fingerprint-fast-path lookups (cheap) but especially the ffprobe fallback
+    tail (slow) on files that don't need re-checking.
+  - There is an existing precedent for an opt-in boolean scoping param in this
+    same package: `internal/plugins/maintenance/intro_transcribe.go`'s
+    `OnlyMissing *bool` (defaults to skip-if-already-present semantics). Match
+    that naming/nil-handling convention for the new param.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func partVsWhole\|TotalDurationSec == 0\|TotalDurationSec <= 0" internal/dedup/dataset/rules.go
+  grep -n "func sideImplausibleAudio\|minPlausibleAudioBytes" internal/dedup/dataset/rules.go
+  grep -n "func hasPlausibleAudio" internal/dedup/engine.go
+  grep -n "ID:.*maintenance.duration-reextract\|type durationReextractParams\|func processBookForReextract\|func (p \*Plugin) runDurationReextract\|sdk.PageBooks" internal/plugins/maintenance/duration_reextract.go
+  grep -n "OnlyMissing \*bool" internal/plugins/maintenance/intro_transcribe.go
+  grep -n "ID:.*dedup.dataset-backfill\|type datasetBackfillParams" internal/plugins/dedup/dataset_backfill.go
+  ```
+  Confirm `durationReextractParams` and the producer callback still look like
+  this (fields may have grown — do not delete existing fields):
+  ```bash
+  sed -n '/type durationReextractParams struct/,/^}/p' internal/plugins/maintenance/duration_reextract.go
+  ```
+
+## Step-by-step
+
+1. Open `internal/plugins/maintenance/duration_reextract.go` and re-verify the
+   anchors above.
+2. Add a new field to `durationReextractParams`:
+   ```go
+   // OnlyMissingDuration, if true, skips books whose Duration is already known
+   // and positive (Book.Duration != nil && *Book.Duration > 0). Use this to
+   // scope a run to the Duration=0/nil residual (DEDUP-4) instead of
+   // re-checking the whole library. Default false (preserves existing
+   // whole-library behavior for all current callers/schedules).
+   OnlyMissingDuration bool `json:"onlyMissingDuration"`
+   ```
+3. In the producer closure inside `runDurationReextract` (the
+   `sdk.PageBooks(ctx, store, reporter, pageSize, func(book database.Book) error { ... })`
+   callback), add the filter immediately after the `params.Limit` check and
+   before `dispatched++`/the `jobCh <- book` send:
+   ```go
+   if params.OnlyMissingDuration && book.Duration != nil && *book.Duration > 0 {
+       return nil // skip: duration already known, out of scope for this run
+   }
+   ```
+   Do not touch `params.Limit` semantics — a skipped book must not count
+   against `dispatched`/`Limit`, since `Limit` bounds *examined* eligible
+   books, not raw library size. Place the new check so skipped books never
+   increment `dispatched`.
+4. Update the op's `Description` string in `durationReextractDef()` to mention
+   the new param (one clause, e.g. "Set onlyMissingDuration=true to scope the
+   run to books with no known duration.").
+5. Add a test in `internal/plugins/maintenance/duration_reextract_test.go`
+   (model it on `TestDurationReextract_MixedFingerprintAndFfprobe` /
+   `TestDurationReextract_EmptyLibrary` for store-fixture setup) that:
+   - Seeds two books: one with `Duration` already set to a positive value and
+     a `BookFile`, one with `Duration == nil` (or `0`) and a `BookFile`.
+   - Runs `runDatasetBackfill`... no — runs `runDurationReextract` with
+     `OnlyMissingDuration: true, DryRun: true`.
+   - Asserts the already-durationed book is NOT examined/eligible (does not
+     appear in the eligible count or trigger an ffprobe/fingerprint lookup —
+     use the existing counters/log fields the other tests already assert on),
+     and the zero-duration book IS eligible.
+   - Add a second small test (or extend the same one) confirming
+     `OnlyMissingDuration: false` (default) still examines both books —
+     proving the new param is additive and does not change default behavior.
+6. Do **not** modify `internal/dedup/dataset/rules.go` or
+   `internal/plugins/dedup/dataset_backfill.go` — both already behave exactly
+   as needed (see Background); this task's code change is scoped entirely to
+   the reextract op's filter.
+7. Bump the file header (version + `last-edited`) on every file you touch,
+   per `.standards/instructions/file-headers.md`.
+8. Do **not** run the ops against the production database as part of this
+   task. This brief ships the code change and its unit-test proof only. The
+   actual prod sequencing (run `maintenance.duration-reextract` with
+   `onlyMissingDuration=true, dryRun=true` first, review the eligible/would-change
+   counts, then `apply=false` → `apply=true` on `dedup.dataset-backfill`) is an
+   **owner-greenlit operational step**, not something this PR executes.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/plugins/maintenance/... -run TestDurationReextract -count=1 -v
+go test ./internal/plugins/maintenance/... -count=1
+go vet ./internal/plugins/maintenance/...
+```
+
+## Acceptance criteria
+
+- [ ] `durationReextractParams` has a new `OnlyMissingDuration bool` field
+      (json tag `onlyMissingDuration`), default `false`.
+- [ ] When `OnlyMissingDuration: true`, books with a known positive
+      `Book.Duration` are skipped by the producer before dispatch (not merely
+      filtered post-hoc) and do not consume `Limit`.
+- [ ] When `OnlyMissingDuration: false` (or omitted), behavior is byte-for-byte
+      identical to before this change — full-library scan, unaffected.
+- [ ] New/updated tests prove both the scoped-skip and the default-unchanged
+      behavior; `go test ./internal/plugins/maintenance/...` is green.
+- [ ] `go vet ./internal/plugins/maintenance/...` is clean.
+- [ ] `internal/dedup/dataset/rules.go` and
+      `internal/plugins/dedup/dataset_backfill.go` are untouched by this PR
+      (verified already correct for the stated purpose — see Idempotency).
+- [ ] File headers bumped on every changed file.
+- [ ] **STOP HERE for this PR.** Running `maintenance.duration-reextract`
+      with `onlyMissingDuration=true` against the production database, or
+      following it with `dedup.dataset-backfill --apply=true`, requires an
+      explicit owner greenlight after reviewing a dry-run report first. Do
+      not execute either op against prod as part of this task or PR.
+
+## Commit message
+
+```
+feat(maintenance): scope duration-reextract to unknown-duration books (dedup-residual)
+
+partVsWhole and implausibleAudio in the dedup dataset catchers both leave
+Duration=0-with-large-files pairs unjudgeable by design, since duration is
+the only signal that could resolve them. maintenance.duration-reextract
+already re-derives real durations (fingerprint-first, ffprobe fallback) but
+always scans the whole library. Add an opt-in onlyMissingDuration filter so
+the Duration=0 residual can be probed cheaply on its own, ahead of a
+dataset-backfill re-run that will convert a slice of the unjudgeable backlog
+into rule-labeled not_dup.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-14-duration-coverage-backfill
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+- If `durationReextractParams` already has an `OnlyMissingDuration` (or
+  equivalently-named) field wired into the `sdk.PageBooks` producer callback,
+  this task is done — verify with
+  `grep -n "OnlyMissingDuration" internal/plugins/maintenance/duration_reextract.go`
+  and confirm the producer callback references it.
+- If `partVsWhole` or `implausibleAudio` have since been changed to fire on
+  zero-duration pairs directly (making this filter moot), stop and re-check
+  DEDUP-4 against the current `rules.go` before proceeding — the premise of
+  this task (duration is the missing signal) may no longer hold, and the
+  right fix might live in `rules.go` instead. As of this brief's verification
+  pass, `rules.go` still explicitly skips zero-duration pairs by design (see
+  Background), so no rules.go change was made.
+- Rollback = revert the commit. The new field is additive and defaults to
+  `false`, so no scheduled/existing invocation of `maintenance.duration-reextract`
+  changes behavior; reverting is a pure no-op for anyone not passing the new
+  param.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-15-bgem3-threshold-recalibration.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-15-bgem3-threshold-recalibration.md
@@ -1,0 +1,315 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-15-bgem3-threshold-recalibration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 90b16f4c-0985-40c7-9893-63ba0b98f2b5 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-15 — bge-m3 embedding-threshold recalibration + candidate regeneration (consultancy-roadmap)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Opus · go-backend subagent · **Depends on:** TASK-13
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-15-bgem3-threshold-recalibration" -b agent/cr-15-bgem3-threshold-recalibration origin/main
+cd "$REPO/.worktrees/cr-15-bgem3-threshold-recalibration"
+git rebase origin/main
+```
+
+## Goal
+
+Fix DEDUP-2 / DEDUP-3: the Layer-2 (embedding) similarity thresholds and
+confidence ramps are hard-coded numbers calibrated for OpenAI
+`text-embedding-3-large` (3072-dim, cosine distribution X). The corpus is
+mid-cutover to a local Ollama `bge-m3` model (1024-dim), which has a different
+cosine distribution — the OpenAI-era thresholds have never been validated
+against it. If bge-m3's true-duplicate cosines cluster lower than 0.95, the
+high-confidence tier silently stops firing post-cutover with no error, just
+missing candidates (recall collapse).
+
+This task does **three** things, in order:
+
+1. Make the book-embedding thresholds **per-embedding-model** and
+   config/DB-tunable (a map keyed by model name), defaulting to the current
+   hard-coded values for the legacy OpenAI model key so behavior is
+   byte-for-byte unchanged until an operator opts a new model in.
+2. Build a **calibration harness** (a new dry-run-only op) that scores the
+   existing labeled gold dataset (`true_dup`/`not_dup` examples already in the
+   dedup dataset store) using whatever embeddings are actually stored for
+   `bge-m3`, sweeps candidate thresholds, and emits a report recommending
+   thresholds that hit a target precision (≥0.98 for the "high" band) for the
+   bge-m3 model — it does **not** write the recommendation into config.
+3. Document (not implement) the follow-up step: after the re-embed finishes
+   and an operator has reviewed/applied the harness's recommended thresholds,
+   a `FullScan` must be run to regenerate embedding-layer candidates under the
+   new thresholds — this run is owner-gated and out of scope for this task's
+   acceptance criteria.
+
+**Do not** change `AutoMergeEnabled` behavior, touch Layer 1 (exact) or Layer 3
+(LLM) logic, or attempt to trigger a production re-embed or `FullScan`
+yourself.
+
+## Background (verify before editing — line numbers drift)
+
+- `internal/dedup/engine.go` — `Engine.BookHighThreshold` / `BookLowThreshold`
+  fields (currently plain `float64`, no model dimension) are set as constants
+  in `NewEngine`:
+  ```bash
+  grep -n "BookHighThreshold\|BookLowThreshold" internal/dedup/engine.go
+  ```
+  As of this writing (verify — do not trust the line numbers in this brief),
+  `NewEngine` sets `BookHighThreshold: 0.95, BookLowThreshold: 0.85` around
+  line 194-195, and these are copied into `EmbeddingCollectorConfig` in
+  `PostInit`/collector wiring around line 507-508
+  (`embCfg.HighThreshold = de.BookHighThreshold`).
+- `internal/dedup/collectors_embedding.go` — `embedHighConfidence` and
+  `embedMediumConfidence` (verify with
+  `grep -n "func embedHighConfidence\|func embedMediumConfidence\|func DefaultEmbeddingCollectorConfig" internal/dedup/collectors_embedding.go`)
+  hard-code the same 0.95/0.85 cut points and interpolate confidence within
+  each band. These must become a function of the *active* threshold pair, not
+  new hard-coded literals, so a future model swap only requires new threshold
+  values, not a code change.
+- `internal/config/config.go` — `DedupConfig` (verify with
+  `grep -n "type DedupConfig struct" -A 20 internal/config/config.go`) has
+  flat `BookHighThreshold`/`BookLowThreshold` fields with viper bindings
+  (`dedup.book_high_threshold` / `dedup.book_low_threshold`) and a runtime
+  PUT-persisted path in `internal/config/persistence.go` (verify with
+  `grep -n "BookHighThreshold\|BookLowThreshold" internal/config/persistence.go`).
+  There is currently **no per-model** threshold concept anywhere in config.
+- `internal/database/embedding_store.go` — `Embedding.Model` field (verify
+  with `grep -n "type Embedding struct" -A 10 internal/database/embedding_store.go`)
+  already tags every stored vector with the producing model name (e.g.
+  `text-embedding-3-large` or the configured Ollama model id such as
+  `bge-m3`). `CosineSimilarity(a, b []float32) float32` (verify with
+  `grep -n "func CosineSimilarity" internal/database/embedding_store.go`)
+  returns 0 on dimension mismatch (DEDUP-3's mechanism) — the harness must
+  only compare same-model, same-dimension pairs, never mix models.
+- `internal/database/dedup_label.go` — `LabeledExample` (verify with
+  `grep -n "type LabeledExample struct" -A 25 internal/database/dedup_label.go`)
+  has `EntityAID`, `EntityBID`, and `Label` (`true_dup`/`not_dup`/`unsure`)
+  fields. `(*EmbeddingStore).ListLabeledExamples(f LabeledExampleFilter)`
+  (verify with `grep -n "func.*ListLabeledExamples" internal/database/dedup_label.go`)
+  is the existing accessor — filter by `Label: "true_dup"` and a second pass
+  with `Label: "not_dup"` to get both classes. This dataset is populated by
+  the `dedup.dataset-backfill` and `dedup.mine-gold-labels` ops (already
+  shipped — do not build dataset population, only consume it).
+- `internal/plugins/dedup/reembed_embeddings.go` — already-shipped op
+  `dedup.reembed-embeddings` documents the cutover sequence (Layer 2 OFF
+  during re-embed, restart, re-embed, restart, re-enable). Its package doc
+  comment (verify with `sed -n '1,45p' internal/plugins/dedup/reembed_embeddings.go`)
+  is the authoritative source for "after re-embed, run FullScan" — this task
+  does not modify that file, only reads it for context.
+- `internal/plugins/dedup/dataset_backfill.go` is the closest existing
+  precedent for a dry-run-only op that reads the labeled dataset and reports
+  counts without mutating dedup state — mirror its shape (params struct with
+  an `Apply`-style flag if you add one, `sdk.OperationDef`, `Run` function,
+  `reporter.Logger()` for structured logging) for the new calibration op.
+  Registration precedent: `internal/plugins/dedup/plugin.go` lists every op
+  def in a slice (verify with
+  `grep -n "p\..*Def()," internal/plugins/dedup/plugin.go`); add the new op
+  there following the existing one-per-line-with-comment style.
+
+## Step-by-step
+
+### Part A — Per-model threshold plumbing (config + engine)
+
+1. In `internal/config/config.go`, extend `DedupConfig` with a new field,
+   e.g. `EmbeddingThresholdsByModel map[string]EmbeddingModelThresholds`
+   (define `EmbeddingModelThresholds{ High, Low float64 }` alongside it).
+   Keep the existing flat `BookHighThreshold`/`BookLowThreshold` fields
+   as-is — they become the **default fallback** entry used when the active
+   embedding model has no entry in the map (this guarantees zero behavior
+   change for the current OpenAI-era config and for any model not yet
+   calibrated).
+2. Add a small resolver, e.g.
+   `func (c DedupConfig) ThresholdsForModel(model string) (high, low float64)`,
+   that looks up `model` in `EmbeddingThresholdsByModel`; if absent, returns
+   `c.BookHighThreshold, c.BookLowThreshold`. Add a unit test for both branches
+   (present in map / absent-falls-back).
+3. In `internal/dedup/engine.go`, thread the active embedding model name
+   through to threshold selection. The engine already knows the model via
+   `de.embedClient` (verify the accessor —
+   `grep -n "func (c \*ai.EmbeddingClient) Model\|embedClient.Model()" internal/dedup/*.go internal/ai/*.go`).
+   Where `de.BookHighThreshold`/`de.BookLowThreshold` are currently read
+   directly (the `embCfg.HighThreshold = de.BookHighThreshold` site and any
+   other read sites found via
+   `grep -n "de.BookHighThreshold\|de.BookLowThreshold" internal/dedup/*.go`),
+   replace with a call to `config.AppConfig.Dedup.ThresholdsForModel(de.embedClient.Model())`
+   (guard for `de.embedClient == nil`, falling back to the existing
+   `de.BookHighThreshold`/`de.BookLowThreshold` fields unchanged — those
+   fields remain the test-injection seam, do not remove them).
+4. Update `internal/dedup/collectors_embedding.go`'s `embedHighConfidence`/
+   `embedMediumConfidence` so the band cut-points (`0.95`, `0.85`) are
+   **parameters derived from the resolved thresholds**, not hard-coded
+   literals — e.g. change signatures to `embedHighConfidence(cos float32, high, low float64) float64`
+   (or thread an `EmbeddingCollectorConfig` through) so a non-default
+   threshold pair reshapes the confidence ramp consistently instead of
+   silently using stale 0.95/0.85 cut-points while similarity comparisons use
+   the new thresholds. Update all call sites and existing tests in
+   `internal/dedup/collectors_embedding_test.go` (verify filename with
+   `ls internal/dedup/*embedding*test*`).
+5. Persist the new config plumbing per the existing runtime-config pattern in
+   `internal/config/persistence.go` (verify the read/merge pattern around the
+   existing `BookHighThreshold`/`BookLowThreshold` handling before adding the
+   map — a nested map may need explicit JSON marshal/unmarshal handling
+   distinct from the flat float fields; follow whatever pattern the file
+   already uses for structured sub-objects, or add a narrowly-scoped
+   `map[string]json.RawMessage`-free approach if the existing persistence
+   layer doesn't support nested maps — do not invent a new persistence
+   mechanism, extend the existing one).
+
+### Part B — Calibration harness (new dry-run-only op)
+
+6. Create `internal/plugins/dedup/calibrate_embedding_thresholds.go` modeled
+   on `dataset_backfill.go`'s structure:
+   - New op ID: `dedup.calibrate-embedding-thresholds`.
+   - Params: `{"model": "bge-m3", "target_precision": 0.98}` (both optional;
+     default `model` to the currently-configured embed client model via
+     `de.embedClient.Model()`, default `target_precision` to `0.98`).
+   - Logic: call `ListLabeledExamples` twice (`Label: "true_dup"`,
+     `Label: "not_dup"`); for each labeled pair, fetch both entities'
+     embeddings via `embeddingStore.Get("book", entityAID)` /
+     `Get("book", entityBID")`; **skip the pair** (count it as skipped, do
+     not error) if either embedding is missing, or either embedding's
+     `.Model` field does not equal the target `model` param, or the two
+     vectors have different lengths. For surviving pairs compute
+     `database.CosineSimilarity(vecA, vecB)` and bucket by label.
+   - Sweep a fixed grid of candidate high-band cut-points (e.g. every 0.01
+     from 0.80 to 0.99) and, for each, compute precision = true_dup pairs at
+     or above the cut-point ÷ (true_dup + not_dup pairs at or above the
+     cut-point). Pick the **lowest** cut-point whose precision is ≥
+     `target_precision` (maximizes recall subject to the precision floor);
+     if no cut-point reaches the target, report that explicitly (do not pick
+     a value silently).
+   - Do the same sweep for a low/medium-band cut-point using a lower default
+     target (document the choice — e.g. reuse the same target_precision
+     parameter, or add a second `target_precision_low` param defaulting to a
+     looser value; pick one and state the rationale in a doc comment).
+   - Emit the result via `reporter` (structured log fields: `model`,
+     `sample_true_dup`, `sample_not_dup`, `skipped_dimension_mismatch`,
+     `skipped_missing_embedding`, `recommended_high_threshold`,
+     `recommended_high_precision`, `recommended_low_threshold`,
+     `recommended_low_precision`, or `no_threshold_met_target: true` when
+     applicable) and also return a JSON summary as the op's result payload
+     (follow whatever result-payload convention `dataset_backfill.go` or
+     `mine_gold_labels.go` uses — verify with
+     `grep -n "reporter.Result\|return.*nil.*//.*result\|OpResult" internal/plugins/dedup/dataset_backfill.go internal/plugins/dedup/mine_gold_labels.go`).
+   - This op is **read-only** — it must never call `UpsertCandidate`,
+     `SetScoreConfig`, or write to `config.AppConfig`. It only reads the
+     labeled dataset and embedding store and reports.
+7. Register the new op in `internal/plugins/dedup/plugin.go`'s op-def slice
+   (mirror the existing one-per-line style, e.g. add
+   `p.calibrateEmbeddingThresholdsDef(), // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)`
+   near `p.datasetBackfillDef()`).
+8. Add `internal/plugins/dedup/calibrate_embedding_thresholds_test.go`
+   covering:
+   - Synthetic labeled examples + a fake/stub embedding store where
+     true_dup pairs cluster at high cosine and not_dup pairs cluster lower —
+     assert the harness recommends a threshold between the two clusters and
+     reports the expected precision.
+   - A case where model/dimension mismatch causes a pair to be skipped
+     (skip counters increment, no panic, no false precision inflation).
+   - A case where no cut-point reaches `target_precision` — assert the op
+     reports `no_threshold_met_target` (or equivalent) rather than fabricating
+     a recommendation.
+
+### Part C — Document the deferred regeneration step
+
+9. In the calibration op's doc comment (top of the new file) and in this
+   task's PR description, state explicitly: *"After the re-embed
+   (`dedup.reembed-embeddings`) completes and an operator has reviewed this
+   report and updated `dedup.embedding_thresholds_by_model` (or equivalent)
+   accordingly, run `dedup.full-scan` to regenerate embedding-layer
+   candidates under the new thresholds. This step is owner-gated and is not
+   performed by this task."* Do not add code that auto-triggers `FullScan`.
+
+10. Bump the file header (version + `last-edited`) on every file you touch,
+    per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/config/... -run Threshold -count=1
+go test ./internal/dedup/... -count=1
+go test ./internal/plugins/dedup/... -count=1
+go vet ./internal/config/... ./internal/dedup/... ./internal/plugins/dedup/...
+```
+
+## Acceptance criteria
+
+- [ ] `DedupConfig` supports a per-embedding-model threshold map with a
+      resolver that falls back to the existing flat `BookHighThreshold`/
+      `BookLowThreshold` for any model not present in the map (default
+      behavior for the current OpenAI-era config is byte-for-byte unchanged).
+- [ ] Engine threshold reads (collector config wiring, any other read sites
+      found via the grep in step 3) go through the resolver keyed by the
+      active embedding client's model name, not the flat fields directly.
+- [ ] `embedHighConfidence`/`embedMediumConfidence` band cut-points derive
+      from the resolved thresholds, not hard-coded 0.95/0.85 literals, and
+      existing collector tests are updated accordingly and pass.
+- [ ] New op `dedup.calibrate-embedding-thresholds` exists, is registered in
+      `plugin.go`, is read-only (no candidate/config mutation), consumes only
+      the existing labeled dataset + embedding store, and emits a report with
+      recommended high/low thresholds (or an explicit "target not met"
+      result) plus sample-size and skip counters.
+- [ ] New tests cover: correct threshold recommendation on synthetic
+      clustered data, correct skip behavior on model/dimension mismatch, and
+      correct "no threshold met target" reporting.
+- [ ] The deferred `FullScan` regeneration step is documented (doc comment +
+      PR description) as owner-gated, and this task's acceptance criteria do
+      **not** require it to have run — applying new thresholds to prod config
+      or triggering `FullScan` is explicitly out of scope for this PR.
+- [ ] `go build ./...`, targeted `go test`, and `go vet` are all clean.
+- [ ] File headers bumped on every changed/added file.
+
+## Commit message
+
+```
+feat(dedup): per-model embedding thresholds + bge-m3 calibration harness (DEDUP-2/3)
+
+BookHighThreshold/BookLowThreshold and the embedding confidence ramps were
+hard-coded for OpenAI text-embedding-3-large's cosine distribution, with no
+recalibration path for the bge-m3 cutover. Add a per-embedding-model
+threshold map (falls back to the existing flat values for any unlisted
+model), thread the active model through threshold resolution, and add a
+read-only dedup.calibrate-embedding-thresholds op that sweeps the labeled
+gold dataset's bge-m3 cosines and reports precision-targeted threshold
+recommendations. Applying the recommendation to prod config and running
+FullScan to regenerate candidates remains an owner-gated follow-up.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-15-bgem3-threshold-recalibration
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `DedupConfig` already has a per-model threshold map wired through to both
+the engine's threshold reads and `embedHighConfidence`/`embedMediumConfidence`,
+and a read-only `dedup.calibrate-embedding-thresholds`-equivalent op already
+exists and is registered in `plugin.go`, this task is done — verify with:
+
+```bash
+grep -n "EmbeddingThresholdsByModel\|ThresholdsForModel" internal/config/config.go
+grep -n "calibrate.*embedding\|calibrate-embedding-thresholds" internal/plugins/dedup/*.go
+```
+
+If the consultancy citation is stale (e.g. thresholds have already been made
+per-model by another task, or the calibration harness already exists under a
+different name), do not duplicate the work — note in the PR description which
+existing mechanism already covers DEDUP-2/DEDUP-3 and stop.
+
+Rollback = revert the commit. The change is additive (new config field with
+a safe fallback, new op, parameterized confidence functions with the same
+default cut-points) — no existing behavior changes for models not present in
+the new per-model map, so rollback carries no data-migration risk. The
+calibration op never mutates dedup state, so there is nothing to undo on the
+data side even without a code revert.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-16-fingerprint-coverage-campaign.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-16-fingerprint-coverage-campaign.md
@@ -1,0 +1,302 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-16-fingerprint-coverage-campaign.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f1cb71e9-055b-41d2-a39e-6988aadcf285 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-16 — Fingerprint-coverage KPI in cached library stats (consultancy NEWF-1, scope corrected)
+
+**Priority:** P1 · **Effort:** M (scoped down from consultancy brief — see Background) · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-16-fingerprint-coverage-campaign" -b agent/cr-16-fingerprint-coverage-campaign origin/main
+cd "$REPO/.worktrees/cr-16-fingerprint-coverage-campaign"
+git rebase origin/main
+```
+
+## Goal
+
+Add a library-wide **fingerprint-coverage KPI** (fingerprinted / partial /
+unfingerprinted book counts + a coverage percentage) to the existing cached
+`LibraryStats` (`stats:library`) so operators can see, without a manual query,
+how close the library is to the coverage level the dedup positive-oracle
+auto-resolution work (`docs/consultancy/02-dedup.md` DEDUP-1/steelman) needs.
+Surface it in the `GET /dashboard` response alongside the other stats fields.
+
+**This brief intentionally does NOT build a new "campaign op."** See
+Background — the campaign already exists and is already scheduled. Read that
+section before writing any code; it changes the scope of this task
+substantially from what a naive reading of the consultancy finding would
+suggest.
+
+## Background (verify before editing)
+
+### The consultancy citation is half right, half already-shipped — re-verify, don't take it on faith
+
+`docs/consultancy/05-features.md` NEWF-1 ("Missing: fingerprint-coverage
+campaign op + coverage KPI") claims **both** the campaign orchestration and
+the KPI are missing, citing `internal/plugins/maintenance/optimize.go:66` and
+`internal/plugins/acoustid/backfill.go:247` as supporting ingredients only.
+Direct code inspection shows this undersells what already exists:
+
+- **The resumable, checkpointed, rate-limited, tombstone-respecting campaign
+  op already exists and already runs nightly.** It is `acoustid.backfill`
+  (`internal/plugins/acoustid/backfill.go`, `func (p *Plugin) runBackfill`):
+  - `ResumePolicy: sdk.ResumeRestart` with a `Schedule: "0 3 * * *"` (nightly
+    cron) — already what NEWF-1 asks for.
+  - Checkpointed via `BackfillParams{LastProcessedBookID}` and
+    `reporter.Checkpoint(cp)` inside the `registry.RunItems(...,
+    CheckpointFn: ...)` callback — resumable across restarts, exactly the
+    "resumable via checkpoints" requirement.
+  - Rate-limited via `fingerprintThrottle = 10 * time.Millisecond` sleep
+    after each successful fingerprint (`time.Sleep(fingerprintThrottle)`).
+  - Tombstone-respecting: every file goes through
+    `fingerprintEligibility(f, force)` (`internal/plugins/acoustid/backfill.go`),
+    which returns `fingerprintOutcomeIneligible, "permanent_failure", true`
+    when `f.FingerprintFailedAt != nil && !force` — permanently-failed files
+    (PR #1422's tombstones) are never re-enqueued.
+  - Uses the exact memdb-safe "has fingerprint" proxy named in the task spec:
+    `len(f.AcoustIDFingerprint) > 0 || f.AcoustIDSeg0 != "" ||
+    f.AcoustIDFingerprintDurationSec > 0`.
+  - There is a **second**, on-demand op, `acoustid.fingerprint-rescan`
+    (`internal/plugins/acoustid/fingerprint_rescan.go`), with `scope:
+    "missing"|"all"|"books"` — this is the one referenced at
+    `optimize.go:66` inside the `library.optimize` sweep. It is not
+    checkpointed (`ResumePolicy: sdk.ResumeDrop`) but shares the same
+    `fingerprintEligibility` gate, so it also respects tombstones.
+
+  **Do not build a third op.** If a future task wants the on-demand
+  `fingerprint-rescan` op to also be checkpoint-resumable, that is a
+  separate, narrowly-scoped follow-up — out of scope here.
+
+- **The coverage KPI genuinely does not exist** — this part of NEWF-1 is
+  correct and is the actual deliverable of this task:
+  - `database.Book` has denormalized `FingerprintStatus`, `CoveragePercent`,
+    `LastFingerprintedAt` fields (`internal/database/store.go:289-293`), but
+    **they are never persisted** — grep confirms the only writers are
+    transient API-response enrichment in
+    `internal/server/audiobooks_helpers.go:84` and
+    `internal/server/handlers/audiobooks/handler.go:373`, both computed
+    per-request from `fingerprint.ComputeFingerprintFields(fpFiles)`
+    (`internal/fingerprint/calculator.go:31`). Raw `Book` rows read directly
+    from Pebble/memdb during stats computation always have these fields
+    empty — do not read `b.FingerprintStatus` inside `computeLibraryStats` /
+    `MemStore.ComputeLibraryStats`; it will be blank.
+  - `database.LibraryStats` (`internal/database/store.go:965-986`, cached
+    under `stats:library`, computed by `PebbleStore.computeLibraryStats`
+    (`internal/database/pebble_store.go:3673`) and the ~150×-faster memdb
+    fast path `MemStore.ComputeLibraryStats`
+    (`internal/database/memdb_reads.go:648`) has zero fingerprint-related
+    fields today.
+  - The per-file "has fingerprint" proxy needed to compute this per book is
+    `BookFile.GetAcoustIDSeg0()` (`internal/database/bookfile_fingerprint.go:24`),
+    which already falls back to `AcoustIDFingerprintDurationSec > 0` when
+    `AcoustIDSeg0` has been stripped from memdb rows
+    (`internal/database/memdb_strip.go` documents this fallback explicitly)
+    — reuse this method, do not re-derive the proxy logic.
+  - A **quick-filter count for "no fingerprints" already exists** —
+    `internal/database/pebble_quick_queries.go:63` defines
+    `{id: "no_fingerprints", label: "No fingerprints", filter:
+    {"fingerprintStatus": "none"}}` as one of the six cached quick-query
+    presets. This gives a raw count of `fingerprintStatus=="none"` books but
+    no percentage-of-library KPI and no "partial" breakdown — the new
+    `LibraryStats` fields are a natural complement to it, not a replacement.
+    No change to `pebble_quick_queries.go` is required by this task.
+  - `GET /dashboard` (`internal/server/handlers/system/handler.go`, function
+    `GetDashboard`) hand-builds a `gin.H{...}` response from the `LibraryStats`
+    struct and does not pass the whole struct through — every new field must
+    be added to this literal explicitly or it will silently not appear in the
+    API response even after the struct gains the field.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (p \*PebbleStore) computeLibraryStats" internal/database/pebble_store.go
+  grep -n "func (m \*MemStore) ComputeLibraryStats" internal/database/memdb_reads.go
+  grep -n "type LibraryStats struct" internal/database/store.go
+  grep -n "func (h \*Handler) GetDashboard" internal/server/handlers/system/handler.go
+  grep -n "func (bf \*BookFile) GetAcoustIDSeg0" internal/database/bookfile_fingerprint.go
+  grep -n "id:.*no_fingerprints" internal/database/pebble_quick_queries.go
+  ```
+  Confirm the pass-2 book_file loops still look the way this brief describes
+  (Pebble does a key-only scan for perf; memdb already deserializes each
+  `*BookFile`):
+  ```bash
+  sed -n '3760,3800p' internal/database/pebble_store.go
+  sed -n '710,735p' internal/database/memdb_reads.go
+  ```
+
+## Step-by-step
+
+1. **Add the KPI fields to `LibraryStats`** in `internal/database/store.go`
+   (near the existing `BrokenFiles` field, same comment style):
+   ```go
+   // FingerprintedBooks/PartiallyFingerprintedBooks/UnfingerprintedBooks
+   // classify every non-deleted book by whether its active book_files have
+   // any/all/none of them fingerprinted (BookFile.GetAcoustIDSeg0() != "",
+   // which already falls back to the memdb-safe AcoustIDFingerprintDurationSec
+   // proxy — see bookfile_fingerprint.go). Computed alongside the existing
+   // book_file pass so no extra scan is added.
+   FingerprintedBooks           int `json:"fingerprinted_books"`
+   PartiallyFingerprintedBooks  int `json:"partially_fingerprinted_books"`
+   UnfingerprintedBooks         int `json:"unfingerprinted_books"`
+   // FingerprintCoveragePercent = FingerprintedBooks * 100 / (TotalBooks
+   // excluding non-primary duplicates counted elsewhere); 0 when TotalBooks==0.
+   FingerprintCoveragePercent int `json:"fingerprint_coverage_percent"`
+   ```
+
+2. **`MemStore.ComputeLibraryStats`** (`internal/database/memdb_reads.go`,
+   pass 2 / book_file loop): the loop already does
+   `bf := obj.(*BookFile)` and tallies `bookActiveFiles[bf.BookID]++` for
+   primary books only. Add a parallel `map[string]int` (e.g.
+   `bookFingerprintedFiles`) incremented when `bf.GetAcoustIDSeg0() != ""`.
+   After the existing `for id := range primaryBookIDs { ... }` block that
+   finalizes `TotalFiles`, classify each primary book:
+   - `bookFingerprintedFiles[id] == 0` → `UnfingerprintedBooks++`
+   - `bookFingerprintedFiles[id] == bookActiveFiles[id]` (and `> 0`) →
+     `FingerprintedBooks++`
+   - otherwise → `PartiallyFingerprintedBooks++`
+
+   This mirrors the status semantics of `fingerprint.ComputeFingerprintFields`
+   (none/partial/complete) — do not import that function here (it takes a
+   `[]FileWithFingerprint` slice, which would mean building a throwaway slice
+   per book for no benefit); replicate only the three-way classification
+   inline as a comment-documented equivalent.
+
+3. **`PebbleStore.computeLibraryStats`** (`internal/database/pebble_store.go`,
+   pass 2 / book_file range scan): this pass is currently a **key-only**
+   scan (comment: "Optimized: key-only scan to count files without
+   deserializing") for performance, because this path only runs as a rare
+   fallback when memdb is unavailable (`p.mem()` returns `nil` — see the
+   fast-path branch at the top of `computeLibraryStats`). Extend it to
+   `json.Unmarshal` each file's value into a `BookFile` (same pattern
+   pass 1 already uses for `Book`) and apply the identical classification
+   logic from step 2. Document in a comment that this path is the rare
+   fallback so the added deserialization cost is acceptable.
+
+4. **Wire into `GetDashboard`**
+   (`internal/server/handlers/system/handler.go`): add four keys to the
+   `gin.H{...}` response literal:
+   ```go
+   "fingerprintedBooks":          stats.FingerprintedBooks,
+   "partiallyFingerprintedBooks": stats.PartiallyFingerprintedBooks,
+   "unfingerprintedBooks":        stats.UnfingerprintedBooks,
+   "fingerprintCoveragePercent":  stats.FingerprintCoveragePercent,
+   ```
+
+5. **Set `FingerprintCoveragePercent`** in both `computeLibraryStats` and
+   `MemStore.ComputeLibraryStats` right before returning `stats`:
+   ```go
+   if stats.TotalBooks > 0 {
+       stats.FingerprintCoveragePercent = stats.FingerprintedBooks * 100 / stats.TotalBooks
+   }
+   ```
+
+6. **Tests** — extend `TestMemStore_ComputeLibraryStats`
+   (`internal/database/memdb_reads_test.go:422`): add book_files with
+   `AcoustIDFingerprintDurationSec` set on some and left zero on others
+   (covering all three buckets: none/partial/complete) across the existing
+   `b1`/`b2`/`b3` fixture books (or add a new book), and assert
+   `FingerprintedBooks`, `PartiallyFingerprintedBooks`,
+   `UnfingerprintedBooks`, and `FingerprintCoveragePercent` match the
+   expected counts. Also add one case where `AcoustIDSeg0` (not duration) is
+   set, to prove the primary (non-fallback) path is still honored by
+   `GetAcoustIDSeg0()`.
+
+7. Bump the file header (version bump + `last-edited`) on every file
+   touched, per `.standards/instructions/file-headers.md`:
+   `internal/database/store.go`, `internal/database/memdb_reads.go`,
+   `internal/database/pebble_store.go`,
+   `internal/server/handlers/system/handler.go`,
+   `internal/database/memdb_reads_test.go`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/database/... -run ComputeLibraryStats -count=1 -v
+go test ./internal/database/... -count=1
+go test ./internal/server/... -count=1
+go vet ./internal/database/... ./internal/server/...
+```
+
+## Acceptance criteria
+
+- [ ] `LibraryStats` gains `FingerprintedBooks`, `PartiallyFingerprintedBooks`,
+      `UnfingerprintedBooks`, `FingerprintCoveragePercent`, all persisted in
+      the `stats:library` cache like every other field on the struct (no new
+      cache key, no new TTL/invalidation path).
+- [ ] Both `MemStore.ComputeLibraryStats` (fast path) and
+      `PebbleStore.computeLibraryStats` (fallback path) populate all four
+      fields identically for the same input data — verified by a test that
+      seeds the same books/files into both a `MemStore` and a `PebbleStore`
+      (if a Pebble test harness exists in-package; otherwise memdb coverage
+      alone is acceptable given memdb is the production fast path).
+- [ ] `GetAcoustIDSeg0()` (existing method, with its existing
+      `AcoustIDFingerprintDurationSec` memdb fallback) is reused for the
+      per-file "has fingerprint" check — no new proxy logic invented.
+- [ ] Permanently-failed files (`FingerprintFailedAt` set) are **not**
+      specially excluded from the coverage denominator by this task — they
+      correctly count as "unfingerprinted" (this task reports raw coverage,
+      not campaign-eligible coverage; that distinction is a documented
+      follow-up, not a defect).
+- [ ] `GET /dashboard` response includes `fingerprintedBooks`,
+      `partiallyFingerprintedBooks`, `unfingerprintedBooks`,
+      `fingerprintCoveragePercent`.
+- [ ] No new operation, no new plugin, no new cron schedule was added — the
+      existing `acoustid.backfill` (nightly, checkpointed) and
+      `acoustid.fingerprint-rescan` (on-demand) ops are untouched.
+- [ ] `go build ./...`, targeted `go test`, and `go vet` all clean per "How
+      to test".
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+feat(database): add fingerprint-coverage KPI to cached library stats
+
+NEWF-1 asked for a campaign op + coverage KPI. The campaign already exists
+(acoustid.backfill: nightly, checkpointed, tombstone-respecting) — only the
+KPI was missing. Add FingerprintedBooks/PartiallyFingerprintedBooks/
+UnfingerprintedBooks/FingerprintCoveragePercent to LibraryStats, computed in
+the existing book_file pass of both the memdb fast path and the Pebble
+fallback, reusing BookFile.GetAcoustIDSeg0()'s existing memdb-safe proxy.
+Surfaced in GET /dashboard.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-16-fingerprint-coverage-campaign
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+**Scope correction, not a dry-run gate:** unlike prod-data tasks in this
+package, there is no owner-greenlight gate here — this is pure code/schema
+addition to an existing cache struct, no prod data mutation, no backfill run.
+
+If `LibraryStats` already has `FingerprintedBooks`/`FingerprintCoveragePercent`
+(or equivalently-named fields) populated by both `computeLibraryStats` and
+`MemStore.ComputeLibraryStats`, and `GetDashboard` already returns them, this
+task is done — verify with:
+```bash
+grep -n "FingerprintedBooks\|FingerprintCoveragePercent" internal/database/store.go internal/database/memdb_reads.go internal/database/pebble_store.go internal/server/handlers/system/handler.go
+```
+Rollback = revert the commit; `stats:library` is recomputed on next TTL
+expiry/invalidation with the old field set (extra JSON fields are additive
+and backward-compatible — no migration needed either direction).
+
+**Do not re-litigate the campaign-op question** on retry: `acoustid.backfill`
+and `acoustid.fingerprint-rescan` are confirmed (by direct code read, not by
+citation) to already satisfy the "resumable, rate-limited, tombstone-aware
+campaign" half of NEWF-1. If a future coverage read shows the KPI stuck at a
+low percentage, the correct next action is triggering/monitoring
+`acoustid.backfill` runs (already scheduled nightly) or widening its
+concurrency/throttle — not building new orchestration.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-17-dedup-auto-resolve.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-17-dedup-auto-resolve.md
@@ -1,0 +1,303 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-17-dedup-auto-resolve.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 34655e2f-96ff-4c4d-b888-3479ba4b8eb4 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-17 — `dedup.auto-resolve` confidence-tiered op (dry-run, sampling audit, reversible)
+
+**Priority:** P1 · **Effort:** L · **Recommended subagent:** Opus · **Wave:** 4 · **Depends on:** TASK-13 (stale-candidate drain), TASK-15 (bge-m3 recalibration + candidate regeneration), TASK-16 (fingerprint-coverage campaign)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-17-dedup-auto-resolve" -b agent/cr-17-dedup-auto-resolve origin/main
+cd "$REPO/.worktrees/cr-17-dedup-auto-resolve"
+git rebase origin/main
+```
+
+## Read first
+
+Read the full **"Design: Auto-Resolution — Confidence-Tiered Pipeline on the
+Existing Unified Score"** section of `docs/consultancy/02-dedup.md` (search for
+that exact heading) before writing any code. It defines Tier 0/1/2/3, the
+safety rails, and the backlog-drain sequencing that this brief implements
+Tier 1 of. Do not skip it — this brief only restates the parts needed to
+implement Tier 1; the doc has the full rationale and the steelman on why
+fingerprint coverage (not threshold tuning) is the real lever for Tier 2.
+
+## Goal
+
+Add a new op, `dedup.auto-resolve`, that auto-merges **Tier 1 (Band ==
+CERTAIN)** dedup candidates through the existing `mergeService.MergeBooks` +
+`CleanupCandidatesAfterMerge` path, gated by a hard cap, a global kill switch,
+and a mandatory dry-run report. This task builds Tier 1 only — Tier 2 (HIGH,
+needs fingerprint corroboration) and Tier 3 (MEDIUM, LLM triage) are follow-on
+tasks per the roadmap table, not in scope here.
+
+**This task's acceptance criteria stop at "dry-run report produced."** Do
+**not** flip the new `AutoResolveEnabled` kill switch to `true` in any config
+default, do not wire `apply=true` into any scheduled/nightly trigger, and do
+not run `apply=true` against production data. The owner reviews the dry-run
+report and the sampling-audit output and explicitly greenlights the first
+capped `apply=true` run out-of-band from this brief.
+
+## Background (verify before editing)
+
+- **Bands already exist and are DB-tunable.** `internal/dedup/unified/score.go`
+  defines `BandCertain = "CERTAIN"` (score ≥ 97), `BandHigh`, `BandMedium`,
+  `BandReview` as constants, and `internal/dedup/unified/config.go` has
+  `SetBandThresholds(certainMin, highMin, mediumMin, reviewMin float64)` for
+  DB-persisted overrides. `database.DedupCandidate.Band` (string field,
+  `internal/database/embedding_store.go`) is populated by the existing
+  scoring pipeline (`unified.ComposeScore`, called from
+  `internal/dedup/engine.go` around the `composed := unified.ComposeScore(...)`
+  call). `database.CandidateFilter.Band` already supports filtering
+  `ListCandidates` by band — use it, don't hand-roll a band comparison.
+
+- **The auto-merge pattern to mirror already exists**: `Engine.ApplyVerdicts`
+  in `internal/dedup/engine.go` (search `func (de \*Engine) ApplyVerdicts`) is
+  the LLM-verdict analogue of what you're building for Tier 1. Follow its
+  shape exactly:
+  1. `de.mergeService.MergeBooks([]string{candidate.EntityAID, candidate.EntityBID}, "")` (empty primaryID = auto-pick via `BookIsBetter`);
+  2. on success, `de.embedStore.UpdateCandidateStatus(candidate.ID, "merged")`;
+  3. tag the survivor via `database.EnsureSingletonBookTag(de.bookStore, result.PrimaryID, "dedup:merge-survivor", "dedup:merge-survivor:auto-certain", "system")` — use the `:auto-certain` suffix (not `:llm-auto`) so this tier's merges are filterable separately from the LLM-verdict auto-merges;
+  4. `de.mergeService` may be `nil` (embeddings/merge disabled in this build) — skip with a log line exactly like `ApplyVerdicts` does, don't panic.
+  5. Then call `de.CleanupCandidatesAfterMerge([]string{loserID})` (search `func (de \*Engine) CleanupCandidatesAfterMerge`) — `ApplyVerdicts` does NOT currently call this; you must add the call for the new Tier-1 path (it exists and is exercised elsewhere, e.g. the merge HTTP handler — search `CleanupCandidatesAfterMerge(` to see the other call site) so residual pending candidates referencing either merged-away book ID are cleaned up immediately instead of drifting into the stale-candidate backlog TASK-13 exists to drain.
+
+- **Eligibility check (Tier 1 from the design doc), all of which must hold**:
+  - `candidate.Band == unified.BandCertain`;
+  - `len(candidate.ScoreBreakdown.Suppressors) == 0` (re-verify the field name
+    with `grep -n "Suppressors" internal/dedup/unified/score.go` — it lives on
+    `UnifiedDedupScore`, which `DedupCandidate.ScoreBreakdown` points to; `nil`
+    `ScoreBreakdown` means pre-T015 legacy row — treat as **not eligible**,
+    do not merge rows with no breakdown to audit);
+  - at least 2 distinct primary signal kinds present in
+    `candidate.ScoreBreakdown.Signals` with `Confidence > 0`, from the set
+    `{unified.SigExactFile, unified.SigExactAcoustID, unified.SigISBNASIN,
+    unified.SigMetaSrcHash}` (re-verify these constant names with
+    `grep -n "SigExactFile\|SigExactAcoustID\|SigISBNASIN\|SigMetaSrcHash" internal/dedup/unified/score.go`),
+    **OR** the candidate has a `true_dup` labeled example from the
+    whole-book-signature oracle: `s.embeddingStore.GetLabeledExample(candidate.ID)`
+    returns a non-nil `*database.LabeledExample` with `.Label == "true_dup"`
+    and `.LabelReason` containing `"whole-book signatures match"` (this is
+    `dataset.wholeBookSignatureMatch`, `internal/dedup/dataset/rules.go:53-58`
+    as of this writing — **re-verify the line numbers**, they are cited from
+    2026-07-02 and this file has since had at least one version bump; the
+    stable anchor is the function name `wholeBookSignatureMatch`, not the line
+    number: `grep -n "func wholeBookSignatureMatch" internal/dedup/dataset/rules.go`).
+    Do not call `dataset.BuildExample` + `dataset.Classify` yourself here —
+    reuse the already-labeled example if `dedup.dataset-backfill apply=true`
+    has run (TASK-13 depends on this being current); if `GetLabeledExample`
+    returns `nil` (never backfilled), the candidate falls back to the
+    signal-kind-count check above, not an automatic pass;
+  - `hasPlausibleAudio` (search `func hasPlausibleAudio` in `engine.go`) is
+    true for **both** `EntityAID` and `EntityBID` books — fetch via
+    `p.store.GetBookByID`;
+  - `!identifiersConflict(bookA, bookB)` (search `func identifiersConflict`)
+    — this is a second, independent guard beyond the signal-kind check above;
+    keep both.
+
+- **Reversibility gap — this is a real prerequisite, not paperwork.** The
+  consultancy doc says "`MergeBooks` builds version groups — losers become
+  non-primary members, not deletions." That is imprecise: read
+  `internal/merge/service.go`'s `MergeBooks` doc comment and body — losers are
+  marked `IsPrimaryVersion=false` **and** soft-deleted
+  (`MarkedForDeletion=true`, via the per-loser cleanup loop after the
+  `ms.db.UpdateBook` calls). There is **no existing unmerge/restore helper**
+  anywhere in the codebase (`grep -rn "func.*Unmerge\|func.*RestoreBook" internal/`
+  returns nothing). What *does* already exist and is sufficient to build on:
+  every `UpdateBook` call performs copy-on-write versioning — it writes the
+  **pre-update** book state to `book_ver:<id>:<unix-nano>` before applying the
+  new state (`internal/database/pebble_store.go`, inside `UpdateBook`, search
+  `versionKey := []byte(fmt.Sprintf("book_ver:`), and there's already
+  `GetBookSnapshots(id, limit)`, `GetBookAtVersion(id, ts)`, and
+  `RevertBookToVersion(id, ts) (*Book, error)` (search
+  `func (p \*PebbleStore) RevertBookToVersion`). Since `MergeBooks` calls
+  `ms.db.UpdateBook` for every book in the pair (winner included) before the
+  soft-delete step, a full pre-merge snapshot of both sides already lands in
+  `book_ver:` automatically — you do not need to add new snapshot-writing
+  code. What you must add:
+  1. A journal entry per auto-merge, at key `dedup:automerge:<unix-nano>`
+     (use the DB's existing generic key/value put — check
+     `internal/database/embedding_store.go` or `pebble_store.go` for the
+     lowest-friction existing "put arbitrary JSON at a string key" helper,
+     e.g. search for how `dedup:label:` keys are written in
+     `internal/database/dedup_label.go` and mirror that pattern) containing:
+     candidate ID, winner ID, loser ID, the winner's and loser's pre-merge
+     `book_ver` timestamp (capture `time.Now()` immediately before calling
+     `MergeBooks`, then look up the closest `book_ver:` entry ≤ that timestamp
+     via `GetBookSnapshots` — or simpler: call `GetBookSnapshots(id, 1)` for
+     each book **immediately after** `MergeBooks` returns, since the just-written
+     snapshot is the newest one), and the tag applied.
+  2. A small `UnmergeAuto(journalKey string) error` method (naming your
+     choice, document it) that reads the journal entry and calls
+     `p.store.RevertBookToVersion(id, ts)` for both winner and loser IDs,
+     restoring pre-merge `IsPrimaryVersion`/`VersionGroupID`/
+     `MarkedForDeletion` state. **Do not wire this into the op's dry-run or
+     capped-apply path for this task** — implement it, unit-test it in
+     isolation (merge two books, call `UnmergeAuto`, assert both books are
+     back to their pre-merge state), and leave it uncalled by
+     `dedup.auto-resolve` itself. It exists so the safety-rail requirement
+     ("reversibility") is actually buildable before any human clicks apply,
+     and so a follow-on task can wire it into an admin "undo merge" endpoint.
+
+- **Safety rails required by the design doc, all must be implemented**:
+  1. Dry-run by default (`apply` param defaults to `false`), returning a
+     capped sample per outcome bucket — mirror the shape of
+     `AcoustIDConflictResult`/`AcoustIDConflictSample` in `engine.go` (search
+     `type AcoustIDConflictSample struct`): a result struct with
+     `Checked`, `Eligible`, `Merged` (0 when dry-run), `DryRun bool`, and
+     `Samples []AutoResolveSample` capped at e.g. 50 entries, each with
+     candidate ID, both book IDs/titles, band, and the eligibility reason.
+  2. `max_merges` param, default `200`, hard cap on the number of merges
+     performed in a single `apply=true` call — stop (not just warn) once hit,
+     report how many were skipped due to the cap.
+  3. Global kill switch: add `AutoResolveEnabled bool` to `DedupConfig` in
+     `internal/config/config.go` (mirror `AutoMergeEnabled`'s doc-comment
+     style, default `false`), wire it through `internal/config/persistence.go`
+     exactly like `AutoMergeEnabled`/`LLMAutoMergeHighConfidence` (re-verify
+     both files' current shape with
+     `grep -n "AutoMergeEnabled\|LLMAutoMergeHighConfidence" internal/config/config.go internal/config/persistence.go`
+     before editing — do not assume the line numbers above are current). The
+     op must check this flag and return an error (not silently no-op) if
+     `apply=true` is requested while the flag is `false`; dry-run (`apply=false`)
+     must work regardless of the flag so the report can always be generated.
+
+## Step-by-step
+
+1. Re-verify every anchor named above with the grep commands given before
+   touching any file. If any anchor has moved or no longer exists, adapt the
+   plan to the current code and note the discrepancy in your PR description.
+2. `internal/config/config.go` + `internal/config/persistence.go`: add
+   `AutoResolveEnabled bool` to `DedupConfig`, default `false`, following the
+   exact pattern of `AutoMergeEnabled`.
+3. `internal/dedup/engine.go`: add
+   `AutoResolveResult`, `AutoResolveSample` types (mirroring
+   `AcoustIDConflictResult`/`AcoustIDConflictSample`) and a new method
+   `func (de *Engine) AutoResolveCertain(ctx context.Context, apply bool, maxMerges, sampleCap int) (AutoResolveResult, error)` implementing:
+   - `de.embedStore.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Band: unified.BandCertain, Limit: 1_000_000})`;
+   - for each candidate, run the eligibility check from Background above;
+   - dry-run: count eligible, append capped samples, do not merge;
+   - apply: perform the merge exactly as in the "auto-merge pattern to mirror"
+     section above, write the journal entry, stop at `maxMerges`, report
+     `Merged` and `SkippedCap` counts.
+4. Add the `UnmergeAuto` helper (Background item above) — in
+   `internal/dedup/engine.go` (or a new small file in the same package if
+   `engine.go` is getting unwieldy — check current line count with
+   `wc -l internal/dedup/engine.go` first) with its own unit test proving a
+   merge-then-unmerge round-trip restores both books' pre-merge state.
+5. New file `internal/plugins/dedup/auto_resolve.go`: thin op wrapper
+   `autoResolveDef() sdk.OperationDef` (`ID: "dedup.auto-resolve"`) with
+   JSON params `{apply bool, max_merges int, sample_cap int}` (defaults
+   `false`/`200`/`50`), calling `p.engine.AutoResolveCertain(...)`, following
+   the exact shape of `internal/plugins/dedup/purge_stale.go` (progress
+   updates, `reporter.Logger()` start/end lines, `Isolate: false`,
+   reasonable `Timeout`). Return an error immediately if
+   `params.Apply && !config.AppConfig.Dedup.AutoResolveEnabled`.
+6. Register the op in `internal/plugins/dedup/plugin.go`'s `ops` slice
+   (append `p.autoResolveDef()`, with a one-line comment like the existing
+   entries).
+7. Tests (new `internal/dedup/auto_resolve_test.go` and
+   `internal/plugins/dedup/auto_resolve_test.go` as applicable):
+   - eligibility check accepts a CERTAIN candidate with 2 primary signals,
+     empty Suppressors, plausible audio both sides, no identifier conflict;
+   - eligibility check rejects: Band != CERTAIN, non-empty Suppressors,
+     `hasPlausibleAudio` false on either side, `identifiersConflict` true,
+     `ScoreBreakdown == nil`, and only 1 primary signal kind with no
+     `true_dup` labeled example fallback;
+   - eligibility check accepts a candidate with only 1 primary signal kind
+     but a `GetLabeledExample` returning `Label == "true_dup"` with the
+     whole-book-signature reason;
+   - dry-run (`apply=false`) never calls `MergeBooks`, returns the expected
+     `Checked`/`Eligible` counts and capped samples;
+   - apply path merges eligible candidates, respects `max_merges`, calls
+     `CleanupCandidatesAfterMerge`, tags the survivor
+     `dedup:merge-survivor:auto-certain`, writes a journal entry;
+   - apply path returns an error (no merges performed) when
+     `AutoResolveEnabled` is `false`;
+   - `UnmergeAuto` round-trip test (merge two books, unmerge, assert restored
+     state).
+8. Bump the file header on every file you touch (version bump + `last-edited`)
+   per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/dedup/... ./internal/plugins/dedup/... ./internal/config/... -count=1
+go vet ./internal/dedup/... ./internal/plugins/dedup/... ./internal/config/...
+```
+
+## Acceptance criteria
+
+- [ ] `dedup.auto-resolve` op registered, dry-run by default (`apply=false`).
+- [ ] Dry-run report includes `Checked`, `Eligible`, `DryRun=true`, and a
+      capped sample list with per-candidate eligibility reasons — verified by
+      test, not just by inspection.
+- [ ] Apply path is implemented and unit-tested but is **not** enabled by
+      default: `AutoResolveEnabled` defaults to `false`, and `apply=true`
+      against a build with the flag `false` returns an error with zero merges.
+- [ ] Eligibility logic matches the Background section exactly: Band ==
+      CERTAIN, empty Suppressors, ≥2 primary signal kinds OR a `true_dup`
+      whole-book-signature labeled example, `hasPlausibleAudio` both sides,
+      no `identifiersConflict`.
+- [ ] `max_merges` cap is enforced and reported (skipped-due-to-cap count).
+- [ ] Survivor tagged `dedup:merge-survivor:auto-certain` (not reusing the
+      `:llm-auto` suffix) on every apply-path merge.
+- [ ] `CleanupCandidatesAfterMerge` is called after every apply-path merge.
+- [ ] A journal entry is written per auto-merge sufficient for `UnmergeAuto`
+      to restore both books; `UnmergeAuto` has a passing round-trip test.
+- [ ] `go build ./...`, the targeted `go test`, and `go vet` are all green.
+- [ ] File headers bumped on every changed file.
+- [ ] **Owner-greenlight gate**: this brief's scope ends at a working,
+      tested dry-run + sampling-audit report. Do not flip
+      `AutoResolveEnabled` to `true` anywhere, do not schedule `apply=true`,
+      and do not run `apply=true` against production data — that requires
+      explicit owner sign-off after reviewing a dry-run report, handled
+      outside this brief.
+
+## Commit message
+
+```
+feat(dedup): add dedup.auto-resolve Tier-1 CERTAIN auto-merge op (dry-run default)
+
+Add the confidence-tiered auto-resolution op from the 02-dedup consultancy
+design: Tier 1 (Band CERTAIN, corroborated by ≥2 primary signal kinds or a
+whole-book-signature true_dup label) auto-merges via the existing
+MergeBooks/CleanupCandidatesAfterMerge path, gated by a global kill switch,
+a max_merges cap, and a dry-run-first default. Adds an UnmergeAuto helper
+built on the existing book_ver CoW snapshots so the reversibility safety
+rail is buildable ahead of any human sign-off to enable apply=true.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-17-dedup-auto-resolve
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/plugins/dedup/plugin.go` already registers a `dedup.auto-resolve`
+op, this task is done — verify with
+`grep -rn "dedup.auto-resolve" internal/plugins/dedup/` and read the existing
+implementation against the eligibility/safety-rail checklist above rather than
+re-adding it. If `Engine` already has an `AutoResolveCertain`-equivalent
+method, confirm it implements the same eligibility checks before concluding
+the task is redundant — a same-named stub that skips the Suppressors/
+identifiersConflict/hasPlausibleAudio checks is not equivalent and should be
+hardened, not left alone.
+
+Rollback = revert the commit. The op is additive (new file, new op
+registration, new config field defaulting to its old absent-equivalent
+`false`, new Engine method); no existing op, handler, or config default is
+modified. `AutoResolveEnabled` defaulting to `false` means reverting is safe
+even if the PR merged and was live for a period — no `apply=true` run could
+have happened without both the flag being manually flipped and the caller
+explicitly passing `apply=true`, which this brief's scope never does.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-18-slog-corruption-sweep.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-18-slog-corruption-sweep.md
@@ -1,0 +1,302 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-18-slog-corruption-sweep.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c139ec52-9bbb-4ece-809f-bce1de4b3e77 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-18 — Repo-wide slog-corruption sweep: duplicate keys, `"value0"` literals, dropped args, `!BADKEY` (QUAL-1/BUG-4)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Haiku ×N (parallel-sweep), Sonnet coordinator · **Wave:** 5 · **Depends on:** none functionally, but runs ALONE after waves 1–4 complete and merge (touches dozens of files repo-wide — do not run concurrently with any other wave to avoid rebase storms)
+
+## ⛔ START HERE (do this first, exactly)
+
+This brief is a **sweep spec**, not a single-worktree task — it is meant to be
+handed to the `/parallel-sweep` slash command (see
+`docs/superpowers/specs/parallel-sweep.md`), which will create one worktree +
+branch **per package** listed in "Wave partitioning" below. Do NOT hand-edit
+dozens of files in one worktree.
+
+Coordinator (Sonnet) setup:
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-18-slog-corruption-sweep" -b agent/cr-18-slog-corruption-sweep origin/main
+cd "$REPO/.worktrees/cr-18-slog-corruption-sweep"
+git rebase origin/main
+```
+
+Each Haiku child spawned by `/parallel-sweep` gets its OWN worktree +
+sub-branch (e.g. `agent/cr-18-slog-corruption-sweep/internal-ai`) and owns one
+or more **whole packages** — never a partial file, never a file another child
+also touches. The coordinator worktree above is only for running the
+repo-wide detection pass and final rollup PR bookkeeping.
+
+## Goal
+
+A mass printf→slog conversion (pre-dating this task) corrupted logging calls
+across dozens of files. Fix every occurrence of these four defect classes
+without changing any non-logging behavior:
+
+- **(a) Data dropped entirely** — a slog message string still contains a
+  `%`-verb (`%q`, `%s`, `%d`, ...) but the call passes **zero** args, so the
+  interpolated value is unrecoverable from logs.
+- **(b) `%`-verb left in the message with args passed positionally after
+  it** — the message text still has `%q`/`%s` placeholders, and the
+  corresponding data is appended as bare (non-keyed) args after already-keyed
+  attrs. `log/slog`'s alternating key/value parser then treats the first bare
+  arg as an attr **key** and the next as its **value**, corrupting the log
+  record (this is the `!BADKEY` failure mode when the types don't line up).
+- **(c) Literal `"value0"` (and `"value1"`, `"value2"`, ...) used as an attr
+  key** — the conversion tool synthesized placeholder key names and never
+  replaced them; worse, several sites also pass the literal string
+  `"value0"` as the *value* of the `"value0"` key (`"value0", "value0", ...`),
+  meaning the real original datum was discarded and replaced with the
+  placeholder string itself.
+- **(d) Duplicate real-looking keys in one call** — the same key literal
+  (`"id"`, `"count"`, `"value"`, `"response"`, ...) appears twice or three
+  times in a single `slog.*` call, each time paired with a *different*
+  variable, silently overwriting one field with another in structured-log
+  output (breaks JSON log parsing / log-query filters).
+
+None of these are behavior bugs — only log quality/diagnostics — but they sit
+directly on the merge/quarantine/metafetch/fingerprint/plugin-registry paths
+where prod debugging happens (see QUAL-1/BUG-4 in
+`docs/consultancy/04-code-quality.md:158-181`), and per CTR-4
+(`docs/consultancy/04-code-quality.md:207-216`) the plugin-registry instance
+(class a) is actively hiding which plugin double-registers.
+
+## Background (verify before editing — counts drift as code changes)
+
+Verified against the worktree on 2026-07-03. Re-run these before starting
+work; do not trust the numbers below without re-running:
+
+```bash
+# Class (c): literal "value0" key — the cleanest, highest-confidence signature.
+grep -rnE '"value0"' internal --include='*.go' | grep -v _test.go | wc -l
+# → 55 call sites across 23 non-test files as of this writing:
+grep -rlE '"value0"' internal --include='*.go' | grep -v _test.go | sort
+
+# Class (a)/(b): %-verb still present inside a slog message string.
+grep -rnE 'slog\.(Debug|Info|Warn|Error)\("[^"]*%[a-zA-Z]' internal --include='*.go' | grep -v _test.go
+# → 4 sites as of this writing: internal/plugin/registry.go:34,
+#   internal/itunes/service/validate.go:81,
+#   internal/server/file_io_pool.go:338 (message text stale, args already
+#   correctly keyed — cosmetic only, see note below),
+#   internal/maintenance/jobs/scan_composer_tags.go:196
+
+# Class (d): duplicate key literals — NOT reliably greppable across
+# multi-line calls; grep only surfaces candidates, every hit needs a Read to
+# confirm the call boundaries and that both instances are truly duplicate
+# keys within the SAME call (not two adjacent calls):
+grep -rnE '"(value|count|id|response)", .*"(value|count|id|response)",' internal --include='*.go' | grep -v _test.go | wc -l
+# → 41 candidate lines as of this writing (many are true positives per the
+#   citations below, but confirm each one — do not blind-fix).
+```
+
+Do NOT trust the consultancy doc's line numbers as ground truth — re-verify
+every citation with the greps above and a `Read` of the surrounding function
+before editing. Citations below were spot-checked 2026-07-03 and matched
+exactly, but drift is expected as other waves land first.
+
+**Confirmed exemplar sites** (verified by direct read, one per defect class):
+
+- Class (a), total data loss:
+  `internal/plugin/registry.go:34` — `slog.Warn("plugin %q already registered, skipping duplicate")`
+  with **zero** args. The duplicate plugin ID is unrecoverable. This is also
+  CTR-4's cited blocker for diagnosing double-registration.
+- Class (b), verb-in-message + bare positional args:
+  `internal/itunes/service/validate.go:81` —
+  `slog.Info("iTunes test-mapping from%q to%q", req.From, req.To)` — `req.From`
+  becomes an attr **key**, `req.To` its value; the message's `%q` verbs are
+  never interpolated (slog ignores them, they aren't `fmt`).
+  `internal/maintenance/jobs/scan_composer_tags.go:196` —
+  `slog.Info("scan-composer-tags COMPOSER %q→%q", "opID", opID, "composer", composer, willWrite, w.filePath)`
+  — the trailing bare `willWrite, w.filePath` after already-keyed pairs makes
+  `willWrite` (the tag value just written) become an attr **key**.
+- Class (c), `"value0"` literal key+value:
+  `internal/ai/embedding_client.go:215` —
+  `slog.Warn("embedding cache get failed (hash)", "value0", "value0", "value1", hash[:8], "err", err)`
+  — the intended key was almost certainly `"hash"` (paired with `hash[:8]`);
+  `"value1"` should simply be dropped as a key, its value re-keyed.
+  `internal/ai/embedding_client.go:235` —
+  `slog.Debug("embedding cache / hits, 0 API calls", "value0", "hits", "hits", hits, "value1", len(texts))`
+  — note `"hits"` appears BOTH as the value of `"value0"` and as its own
+  correct key two args later; drop the spurious `"value0", "hits"` pair
+  entirely and rekey `"value1"` → `"total"` (matches the sibling log two
+  lines down: `"hits", hits, "total", len(texts)`).
+  `internal/ai/embedding_client.go:260` — same shape as :215, key should be
+  `"hash"`.
+- Class (d), duplicate real keys:
+  `internal/metafetch/service_apply.go:66` — `"value", extractedAuthor,
+  "value", *book.Narrator, "name", existingAuthor.Name, "id", book.ID` — two
+  different variables both keyed `"value"`; rename to `"extracted_author"` and
+  `"narrator"`.
+  `internal/metafetch/service_scoring.go:607` — `"value", epsilon, "value",
+  bestScore` → rename to `"epsilon"`, `"best_score"`.
+  `internal/itunes/service/validate.go:118` — `"response", response.Tested,
+  "response", response.Found, "count", len(response.Examples)` → rename to
+  `"tested"`, `"found"`.
+
+**Re-verify anchors before editing** (do not assume any line number in this
+brief without re-running):
+
+```bash
+grep -n "already registered" internal/plugin/registry.go
+grep -n 'value0\|value1' internal/ai/embedding_client.go
+grep -n '"value"' internal/metafetch/service_scoring.go internal/metafetch/service_apply.go
+```
+
+## Fix rules per defect class
+
+Apply these mechanically, but every rename requires reading the enclosing
+function to pick a key name that reflects what the variable actually is —
+never leave a `"value0"`/`"value1"`/duplicate key in the diff.
+
+1. **Class (a) — zero args, verb(s) in message:** Strip the `%`-verbs from
+   the message (make it a plain, verb-free string), and add explicit
+   `key, value` pairs for whatever data was being interpolated (read the
+   surrounding code — e.g. `p.ID()` for `registry.go:34` → add `"id", p.ID()`).
+2. **Class (b) — verb(s) in message + bare trailing args:** Strip the
+   `%`-verbs from the message. Convert every bare trailing arg into an
+   explicit `"key", value` pair using a key name derived from the variable
+   name or its role in the message (e.g. `req.From`/`req.To` → `"from"`,
+   `"to"`; `willWrite`/`w.filePath` → `"newValue"`, `"filePath"` — do not
+   collide with the existing `"composer"` key already in that call).
+3. **Class (c) — literal `"value0"`/`"value1"`/... keys:** Delete the
+   `"valueN"` key and, if its paired value is itself the literal string
+   `"value0"`/`"hits"`/etc. (i.e., the real datum was already deleted by the
+   original conversion), recover the real key name from context (adjacent
+   sibling log lines in the same function are often the best evidence — see
+   the `embedding_client.go:235` example above) and re-key the *next* pair
+   (currently keyed `"valueN+1"`) with that recovered name. If the original
+   datum truly cannot be recovered from context, keep the value but give it
+   the most accurate key you can infer from the variable name at the call
+   site (never leave `"valueN"` in the diff).
+4. **Class (d) — duplicate key literal in one call:** Rename each duplicate
+   occurrence to a distinct, meaningful key based on the variable each is
+   paired with (e.g. two `"id"` keys where one variable is a book ID and the
+   other a candidate/library-copy ID → `"book_id"`, `"candidate_id"`). Keep
+   key naming consistent with existing non-duplicated keys already used
+   elsewhere in the same file (e.g. this repo already uses `book_id`,
+   `bookID`, `id` inconsistently — match whatever convention the enclosing
+   file already uses for that call's package rather than inventing a new one).
+
+Do not touch: log level (`Debug`/`Info`/`Warn`/`Error` — never change),
+whether a log call fires at all, any non-logging control flow, or any
+already-correct keyed attrs in a call you're editing (only fix what's broken).
+
+## Wave partitioning (per-package worktrees, no same-file overlap)
+
+Coordinator runs the full-repo detection grep, then assigns whole packages
+(never partial files) to Haiku children as separate `/parallel-sweep` tasks.
+Based on the 2026-07-03 detection pass, partition into these child tasks
+(re-run the detection grep first — this list may have grown/shrunk):
+
+- `internal/ai` (embedding_client.go, aijobs/aijobs.go, dedup_review.go)
+- `internal/plugin` (registry.go, events.go)
+- `internal/itunes/service` (validate.go, track_provisioner.go)
+- `internal/metafetch` (service_apply.go, service_scoring.go, service_search.go,
+  service_writeback.go, service_fetch.go, service_files.go, service.go,
+  openlibrary.go)
+- `internal/quarantine` + `internal/reconcile` (service.go, reconcile.go)
+- `internal/server` (file_io_pool.go, itl_rebuild.go, middleware/auth.go,
+  server_search.go, handlers/audiobooks/handler_files.go,
+  handlers/operations/handler.go)
+- `internal/maintenance/jobs` (scan_composer_tags.go)
+- `internal/sweep` + `internal/remux` + `internal/transcode` + `internal/updater`
+  + `internal/scheduler` + `internal/watcher` + `internal/openlibrary`
+  (archive_sweep.go, sweeper.go, temp_cleanup.go, remux.go, transcode.go,
+  updater.go, scheduler.go, scheduler.go (updater), watcher.go, downloader.go,
+  store.go — grouped because each is a single small file with few hits)
+
+Each child's task prompt: "Run `grep -n '\"value0\"\|%[a-zA-Z]' <files>` in
+your assigned package, fix every hit per the four fix-rule classes above, run
+`go build ./... && go test ./<pkg>/... -count=1 && go vet ./<pkg>/...`, commit,
+push, open PR against the sweep's integration branch." No child touches a
+file outside its assigned package list.
+
+## How to test (per child, and again at rollup)
+
+```bash
+go build ./...
+go test ./<changed-package>/... -count=1
+go vet ./...
+```
+
+Additionally, at rollup (coordinator, after all children merge), re-run the
+three detection greps from "Background" above and report before/after counts:
+
+```bash
+echo "value0 sites remaining:"; grep -rnE '"value0"' internal --include='*.go' | grep -v _test.go | wc -l
+echo "verb-in-message sites remaining:"; grep -rnE 'slog\.(Debug|Info|Warn|Error)\("[^"]*%[a-zA-Z]' internal --include='*.go' | grep -v _test.go | wc -l
+```
+
+Target: both counts at 0 (class (d) duplicate-key candidates require manual
+confirmation per-hit and won't hit exactly 0 via grep alone — report the
+before/after count and spot-check a sample of remaining hits to confirm
+they're false positives, e.g. two adjacent-but-separate calls each using
+`"id"` once).
+
+## Acceptance criteria
+
+- [ ] `grep -rnE '"value0"' internal --include='*.go' | grep -v _test.go` returns 0 hits.
+- [ ] `grep -rnE 'slog\.(Debug|Info|Warn|Error)\("[^"]*%[a-zA-Z]' internal --include='*.go' | grep -v _test.go` returns 0 hits.
+- [ ] All four cited exemplar sites (`internal/plugin/registry.go:34`,
+      `internal/itunes/service/validate.go:81` and `:118`,
+      `internal/ai/embedding_client.go:215/235/260`,
+      `internal/maintenance/jobs/scan_composer_tags.go:196`,
+      `internal/metafetch/service_apply.go:66`,
+      `internal/metafetch/service_scoring.go:607/612/642/677`) have distinct,
+      meaningful, non-duplicated keys and no stray `%`-verbs in their messages.
+- [ ] No log level, call-site behavior, or already-correct attr was changed.
+- [ ] `go build ./...`, `go vet ./...` clean repo-wide; `go test ./...` green
+      (or at minimum every changed package's tests green — full suite gated by
+      whatever CI already gates on `main`).
+- [ ] Before/after counts for both detection greps reported in the rollup PR
+      description.
+- [ ] File headers bumped on every changed file per
+      `.standards/instructions/file-headers.md`.
+- [ ] (Stretch, not blocking) a `sloglint`-style check or a small analyzer
+      script added to `make ci` to prevent recurrence — only if time permits;
+      do not let this block merging the sweep itself.
+
+## Commit message
+
+Each child commits with its own scoped message; coordinator's rollup (if a
+rollup commit/PR is used) follows this shape:
+
+```
+fix(logging): repair corrupted slog call sites from printf-to-slog conversion (QUAL-1/BUG-4)
+
+A mass printf->slog conversion left duplicate attr keys, literal "value0"
+placeholder keys/values, dropped interpolation args, and %-verbs still
+embedded in message strings across dozens of call sites on the
+merge/quarantine/metafetch/fingerprint/plugin-registry paths. Fix is
+log-quality only — no behavior, level, or control-flow changes.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+Per-child (parallel-sweep default):
+
+```bash
+git push -u origin agent/cr-18-slog-corruption-sweep/<package-slug>
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If a re-run of the detection greps in "How to test" already returns 0 for
+both `"value0"` and verb-in-message patterns, this sweep is done — verify with
+the two grep commands above before starting any child task, and skip any
+package where they're already clean. Class (d) duplicate-key candidates
+should also be spot-checked with a fresh
+`grep -rnE '"(value|count|id|response)", .*"(value|count|id|response)",' internal --include='*.go' | grep -v _test.go`
+— if the hit count is unchanged from a prior run and every remaining hit is a
+false positive (two separate calls, not one duplicated call), the sweep is
+complete. Rollback = revert the relevant child's PR commit; each child's
+changes are independent (different packages), so a single revert never
+affects another child's files.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-19-shutdown-escape-hatch.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-19-shutdown-escape-hatch.md
@@ -1,0 +1,314 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-19-shutdown-escape-hatch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7afb30fd-c2ee-4994-8704-edf9ff35a64a -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-19 — Shutdown escape-hatch + Registry.Shutdown goroutine-tracking fix (SYS-1 / BUG-2)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Opus · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-19-shutdown-escape-hatch" -b agent/cr-19-shutdown-escape-hatch origin/main
+cd "$REPO/.worktrees/cr-19-shutdown-escape-hatch"
+git rebase origin/main
+```
+
+## Goal
+
+Close two related shutdown races, same class as `PEBBLE-CLOSED-SHUTDOWN-RACE`
+(fixed 2026-07-02, see `internal/operations/registry/shutdown_race_test.go`
+and `TODO.md` "Open Bugs" entry for that ID — read both before touching
+anything):
+
+- **SYS-1** — `Server.Start`'s three one-time startup jobs
+  (`stripMovementAtoms`, `remuxMalformedM4BFiles`, `transcodeMalformedM4BFiles`)
+  are **not** context-aware. On first boot after upgrade they can run for
+  minutes over a large library. Shutdown's `bgWG.Wait()` has only a 30s grace
+  period (`server_lifecycle.go`, see grep below) before it logs a warning and
+  "proceeds with shutdown anyway" — closing the embedding store and, via
+  `cmd/root.go`'s deferred `closeStore`, the main PebbleStore, while those
+  goroutines may still be mid-walk touching the store.
+- **BUG-2** — `Registry.Shutdown` has two goroutines it does NOT reliably wait
+  for: (a) if the shutdown ctx passed to `Shutdown` expires during the drain
+  poll, remaining ops are marked interrupted and `Shutdown` proceeds to cancel
+  its internal context and return, while the abandoned op's `safeRun`
+  goroutine (spawned in `worker.go`'s `executeRun`) may still be running
+  plugin code that writes to the store; (b) the final `goroutineWG.Wait()` in
+  `Shutdown` has its own hard 2s timeout and "proceeds" regardless. The
+  `notifyDepCompletion`/`notifyDepFailed` goroutines ARE enrolled in
+  `goroutineWG` (that was the actual `PEBBLE-CLOSED-SHUTDOWN-RACE` fix) — but
+  the per-op `safeRun` goroutine is not, so nothing durably waits for it once
+  the ctx-bounded drain poll gives up.
+
+This is subtle concurrency work. **Before changing anything**, read
+`shutdown_race_test.go` end to end and understand all the mechanisms already
+in play: inline `Stop`s in `server_lifecycle.go`, `container.Stop`, the named
+`s.bgWG` (bounded WaitGroup with names, in `internal/server`), and the
+registry's internal `goroutineWG` (plain `sync.WaitGroup`, gated by
+`r.notifyStopped` under `r.mu` to prevent Add-after-Wait races). Do not
+introduce a fifth ad hoc tracking mechanism — reuse these four.
+
+## Background (verify before editing — line numbers below were correct as of
+2026-07-03 but WILL drift; re-run the greps first)
+
+### SYS-1 anchors
+
+```bash
+grep -n "stripMovementAtoms\|remuxMalformedM4BFiles\|transcodeMalformedM4BFiles\|bgWG\.Wait\|proceeding\|bgCtx" internal/server/server_lifecycle.go
+```
+
+Confirm the shape: three `s.bgWG.Add("...")` / `go func(){ defer s.bgWG.Done(...); s.xxx() }()`
+blocks around the area the comments already flag ("NOTE: ... does not check
+bgCtx"), and the 30s `select { case <-bgDone: ...; case <-time.After(30 *
+time.Second): slog.Warn("Background goroutines did not stop within 30s —
+proceeding with shutdown anyway", ...) }` later in the same function, well
+before `embeddingStore.Close()`.
+
+None of the three job functions take a `context.Context` today:
+
+```bash
+grep -n "func (s \*Server) stripMovementAtoms\|func (s \*Server) remuxMalformedM4BFiles\|func (s \*Server) transcodeMalformedM4BFiles" internal/server/*.go
+grep -n "func (r \*Remuxer) RemuxMalformedFiles\|func (t \*Transcoder) TranscodeMalformedFiles" internal/remux/*.go
+```
+
+Compare against the existing ctx-aware convention already used by
+`backfillAcoustIDs` (same file group, already correct — copy this pattern,
+do not invent a new one):
+
+```bash
+grep -n "func (s \*Server) backfillAcoustIDs" -A 25 internal/server/acoustid_backfill.go
+```
+
+It takes `ctx context.Context`, and inside its per-book loop does:
+
+```go
+select {
+case <-ctx.Done():
+    return
+default:
+}
+```
+
+`stripMovementAtoms` and `RemuxMalformedFiles`/`TranscodeMalformedFiles` all
+iterate via `filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr
+error) error { ... })`. The ctx check goes inside that closure, per-file,
+returning `fs.SkipAll` (Go 1.20+) to stop the walk early and cleanly when
+canceled — do NOT return a bare error from inside the callback if it would be
+swallowed by an existing `_ = filepath.WalkDir(...)` (verify with grep how the
+return value is currently handled at each site; today it's discarded with
+`_ =`, so `fs.SkipAll` is safe and idiomatic here).
+
+### BUG-2 anchors
+
+```bash
+grep -n "func (r \*Registry) Shutdown" -A 95 internal/operations/registry/registry.go
+grep -n "goroutineWG\|notifyStopped\|shuttingDown" internal/operations/registry/registry.go
+grep -n "done := make(chan error, 1)\|r.safeRun(runCtx" -A 3 internal/operations/registry/worker.go
+grep -n "func (r \*Registry) executeRun\|func (r \*Registry) startWorker" -A 5 internal/operations/registry/worker.go
+```
+
+Confirm: `executeRun` is called **synchronously** from inside `startWorker`'s
+loop body (`case qr := <-r.nextRun: abandoned := r.executeRun(ctx, qr)`), and
+`startWorker` itself is already enrolled in `goroutineWG` via
+`r.goroutineWG.Add(1)` / `go func(slot int){ defer r.goroutineWG.Done(); ...
+}(i)` before it starts looping. That means `executeRun`'s own `goroutineWG.Add(1)`
+for the `safeRun` goroutine (see Step 2 below) happens while its parent
+worker goroutine is still alive and has not called its own `Done()` — so the
+counter cannot be observed at zero between this `Add` and any concurrent
+`Wait()`, and no extra `notifyStopped`-style gate is needed for this specific
+enrollment (unlike `notifyDepCompletion`/`notifyDepFailed`, which are spawned
+from contexts that are NOT guaranteed to still hold an outstanding `Add`).
+Verify this call chain yourself with the grep above before relying on this
+reasoning — this is exactly the kind of assumption that a `-race` repro test
+will falsify if wrong.
+
+## Step-by-step
+
+### Part A — SYS-1: make the three startup jobs ctx-aware
+
+1. `internal/server/movement_atom_cleanup.go`:
+   - Change `func (s *Server) stripMovementAtoms()` to
+     `func (s *Server) stripMovementAtoms(ctx context.Context)`.
+   - Inside the `filepath.WalkDir` callback, before the extension check, add:
+     ```go
+     select {
+     case <-ctx.Done():
+         return fs.SkipAll
+     default:
+     }
+     ```
+   - Update the call site in `server_lifecycle.go` (`s.stripMovementAtoms()`
+     → `s.stripMovementAtoms(s.bgCtx)`).
+2. `internal/remux/remux.go` and `internal/remux/transcode.go`:
+   - Change `func (r *Remuxer) RemuxMalformedFiles()` to
+     `func (r *Remuxer) RemuxMalformedFiles(ctx context.Context)`, same for
+     `Transcoder.TranscodeMalformedFiles`.
+   - Add the identical `select { case <-ctx.Done(): return fs.SkipAll;
+     default: }` guard inside each `filepath.WalkDir` callback.
+   - Add `"context"` to each file's imports.
+3. `internal/server/malformed_m4b_wrappers.go`:
+   - Update `remuxMalformedM4BFiles()` / `transcodeMalformedM4BFiles()`
+     wrappers to accept and forward `ctx context.Context` to the
+     `remux`/`Transcoder` calls. Add `"context"` to imports.
+   - Update the call sites in `server_lifecycle.go` to pass `s.bgCtx`.
+4. Do **not** change the `s.bgWG.Add("...")`/`Done("...")` tracking around
+   these three jobs — it's correct and already named per-job; ctx-awareness
+   is additive, shortening the worst case, not replacing the existing guard.
+5. Leave the 30s `bgWG.Wait()` timeout and its warning log in place as
+   defense-in-depth (do not remove it or turn it into a hard error) — the
+   consultancy recommendation's primary fix is making the jobs finish inside
+   the window, not raising the window.
+
+### Part B — BUG-2: enroll the per-op run goroutine in `goroutineWG`
+
+6. In `internal/operations/registry/worker.go`, inside `executeRun`, find the
+   in-process run block:
+   ```go
+   done := make(chan error, 1)
+   go func() {
+       done <- r.safeRun(runCtx, def, qr.params, reporter)
+   }()
+   ```
+   Wrap it so the goroutine is enrolled in `goroutineWG` for its full
+   lifetime, mirroring `notifyDepCompletion`'s comment style:
+   ```go
+   done := make(chan error, 1)
+   r.goroutineWG.Add(1)
+   go func() {
+       defer r.goroutineWG.Done()
+       done <- r.safeRun(runCtx, def, qr.params, reporter)
+   }()
+   ```
+   Add a comment explaining why no `notifyStopped`-style gate is required
+   here (see Background) — this call happens synchronously inside
+   `executeRun`, itself called from the already-`goroutineWG`-enrolled
+   `startWorker` goroutine, so the counter is guaranteed non-zero across the
+   `Add`.
+7. This also covers the "abandoned during shutdown" path (`worker.go` ~line
+   276-281, the `go func() { <-done; r.releaseRunHandle(...); ... }()`
+   monitor) for free: `goroutineWG.Done()` fires when `r.safeRun` actually
+   returns and sends to `done`, regardless of which goroutine drains that
+   channel value.
+8. Do not touch `Registry.Shutdown`'s existing 2s `goroutineWG.Wait()`
+   timeout or its "proceeding" warning log — leave the escape hatch itself
+   as a logged, deliberate decision; the fix is making the wait actually
+   cover this goroutine, not eliminating the timeout.
+
+### Part C — regression test proving the BUG-2 gap is now closed
+
+9. Add a new test, `internal/operations/registry/registry_pebble_race_test.go`,
+   following the exact pattern of `shutdown_race_test.go` (real `PebbleStore`,
+   not a mock — the whole point of that prior fix was that mocks didn't catch
+   this class of bug). Design:
+   - Register an op definition whose `Run` blocks past the test's shutdown
+     ctx deadline (e.g. sleeps on a channel closed after a short delay, or
+     ignores `ctx.Done()` briefly to simulate a slow/misbehaving plugin) and
+     then performs a real store write (e.g. `store.UpdateOperationV2Status`
+     or another store call) after that delay.
+   - Enqueue the op, let it start running, then call `Shutdown` with a ctx
+     that expires almost immediately (forcing the SYS-1/BUG-2 "ctx expired
+     during drain poll" branch at `registry.go`'s `case <-ctx.Done():` inside
+     the outer `select`).
+   - Immediately after `Shutdown` returns, call `store.Close()` (matching
+     what `cmd/root.go`'s deferred `closeStore` does in production).
+   - Run under `-race` and assert no panic — before this task's fix, this
+     should reproduce the "pebble: closed" panic (or a `-race` data race);
+     after the fix in Part B, it should not, because `goroutineWG.Wait()`
+     inside `Shutdown` — even bounded by its own 2s timeout — now has enough
+     of a chance to observe the enrolled run goroutine, and more importantly
+     the run goroutine's write happens-before `Shutdown`'s `goroutineWG.Done()`
+     is only reachable after the write completes.
+   - If the repro does NOT panic even before your fix (e.g. because the test
+     op's `Run` finishes fast enough in practice), tighten the timing
+     (larger sleep in `Run`, shorter shutdown ctx) until it reliably
+     reproduces pre-fix and passes post-fix. Do not commit a test that can't
+     demonstrate the bug.
+10. Bump the file header (version bump + `last-edited`) on every file you
+    touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/server/... -run 'MovementAtom|Remux|Transcode' -count=1
+go test ./internal/remux/... -count=1
+go test ./internal/operations/registry/... -race -count=1 -timeout 5m
+go vet ./internal/server/... ./internal/remux/... ./internal/operations/registry/...
+```
+
+If `go test ./internal/operations/registry/... -race` runs long locally,
+scope to the new test first (`-run TestRegistryPebbleRace` or whatever name
+you choose) before running the full `-race` package.
+
+## Acceptance criteria
+
+- [ ] `stripMovementAtoms`, `RemuxMalformedFiles`, and
+      `TranscodeMalformedFiles` all accept and honor a `context.Context`,
+      stopping their `filepath.WalkDir` early via `fs.SkipAll` when the
+      context is done.
+- [ ] All three call sites in `server_lifecycle.go` pass `s.bgCtx`.
+- [ ] The existing 30s `bgWG.Wait()` timeout and its warning log are
+      unchanged — this is defense-in-depth, not removed.
+- [ ] The per-op `safeRun` goroutine in `executeRun` (`worker.go`) is
+      enrolled in `r.goroutineWG` for its full lifetime.
+- [ ] A new real-Pebble `-race` regression test (`registry_pebble_race_test.go`
+      or equivalent name) demonstrates the pre-fix panic/race and passes
+      clean post-fix.
+- [ ] `go build ./...`, the targeted `go test` commands above, and `go vet`
+      on the three touched packages are all green.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(server,registry): close SYS-1/BUG-2 shutdown escape hatches (consultancy-roadmap)
+
+Three one-time startup jobs (stripMovementAtoms, remux/transcode malformed
+M4Bs) ran without checking bgCtx, so the 30s shutdown grace period could
+expire and proceed to close the store while they were still mid-walk
+(SYS-1). Separately, Registry.Shutdown's per-op safeRun goroutine was never
+enrolled in goroutineWG — only the notifyDepCompletion/notifyDepFailed
+goroutines were, from the prior PEBBLE-CLOSED-SHUTDOWN-RACE fix — so a
+ctx-timeout during the drain poll could let Shutdown return while a plugin
+goroutine still wrote to the store (BUG-2). Both are the same race class:
+make the jobs ctx-aware and enroll the goroutine in the wait group that
+actually guards store.Close().
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-19-shutdown-escape-hatch
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, check whether either half is already fixed:
+
+```bash
+grep -n "func (s \*Server) stripMovementAtoms(ctx" internal/server/movement_atom_cleanup.go
+grep -n "func (r \*Remuxer) RemuxMalformedFiles(ctx\|func (t \*Transcoder) TranscodeMalformedFiles(ctx" internal/remux/*.go
+grep -n "r.goroutineWG.Add(1)" -B 2 -A 4 internal/operations/registry/worker.go
+```
+
+If the three job functions already take `ctx context.Context` AND
+`worker.go`'s `safeRun` launch already wraps with `r.goroutineWG.Add(1)` /
+`defer r.goroutineWG.Done()`, Part A and Part B are both done — verify the
+regression test in Part C exists and is green, and if so this task is
+complete with no further changes needed. If only one half is already fixed,
+implement the other half only (do not touch the already-fixed one beyond
+re-verifying it still passes `-race`).
+
+Rollback = revert the commit. The three job functions regain their
+no-context signatures (reintroducing the SYS-1 exposure), and the `safeRun`
+goroutine reverts to being un-enrolled (reintroducing the BUG-2 gap) — no
+other invariants are affected, since `s.bgWG`, `container.Stop`, and the
+registry's `notifyStopped` gating are all left untouched by this change.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-20-hnsw-staleness-atomic-export.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-20-hnsw-staleness-atomic-export.md
@@ -1,0 +1,317 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-20-hnsw-staleness-atomic-export.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d9bebcab-eae7-4162-9c13-f209b7248608 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-20 — HNSW snapshot staleness check, atomic export, wrap Graph.Delete
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 2 · **Depends on:** TASK-06 (both touch `internal/server/server.go`; sequence to avoid a wave-2 rebase collision)
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-20-hnsw-staleness-atomic-export" -b agent/cr-20-hnsw-staleness-atomic-export origin/main
+cd "$REPO/.worktrees/cr-20-hnsw-staleness-atomic-export"
+git rebase origin/main
+```
+
+## Goal
+
+Close three related derived-index hardening gaps on the HNSW vector-ANN store
+(source: `docs/consultancy/01-storage-architecture.md`, findings **ARCH-1**,
+**ARCH-2**, **ARCH-5**):
+
+- **ARCH-1 (High).** The HNSW snapshot fast-path skips Pebble hydration with
+  **no staleness check**. After any unclean shutdown, every vector upserted
+  since the last clean-shutdown export is silently missing from the graph,
+  permanently, until a manual re-embed or snapshot delete — with zero error
+  anywhere. Add a cheap comparison against the Pebble source of truth
+  (`emb:` keyspace via `EmbeddingStore.CountByType`) and fall back to a full
+  rebuild-by-hydration when the snapshot looks stale.
+- **ARCH-2 (Medium).** `Export` writes `.bin`/`.meta.json` directly to their
+  final paths (no temp+rename, no fsync) — a crash mid-export leaves a
+  truncated snapshot. `Import` installs a graph into `s.graphs[entityType]`
+  before its metadata sidecar is confirmed to parse; a meta failure leaves a
+  graph installed with no metadata, and `FindSimilar`'s metadata filter then
+  silently rejects every node. Make both operations all-or-nothing.
+- **ARCH-5 (Low).** `Graph.Delete` is called bare, unlike `Graph.Add` which
+  was wrapped in `safeAdd` (PR #1741) specifically because coder/hnsw v0.6.1
+  has documented Delete+Add per-layer-invariant panics
+  (`HNSW-CRASH-2026-06-18`, see `server.go:436-438`). `Delete` runs on live
+  paths (book merge/removal) from goroutines where an unrecovered panic kills
+  the process. Add a `safeDelete` mirroring `safeAdd`.
+
+## Background (verify before editing)
+
+All three findings live in `internal/database/hnsw_embedding_store.go`, with
+two call sites in `internal/server/server.go` and `internal/dedup/lifecycle.go`.
+**Line numbers below are from this brief's authoring pass (2026-07-03) and
+may have drifted — re-verify with the greps in each subsection before
+editing.**
+
+### ARCH-1 — staleness check
+
+- `HNSWEmbeddingStore.Import` (verified at `hnsw_embedding_store.go:372-430`)
+  loads `.bin`/`.meta.json` files from disk into `s.graphs[entityType]` with
+  **no comparison to the Pebble source of truth**. It already has one
+  discard path — a dimension mismatch (`g.Dims() != s.dims`) causes it to
+  `continue` and skip that entity type (lines ~406-410) — but nothing checks
+  vector *count*.
+- The caller, `internal/server/server.go` (verified at lines ~439-453),
+  calls `hnswStore.Import(hnswDir)` **before** `regContainer.Build`'s
+  `dedup.Engine.PostInit` runs (comment at server.go:434-438 explains why:
+  reordering caused a documented crash loop, HNSW-CRASH-2026-06-18 — do
+  **not** reorder these two calls).
+- `internal/dedup/lifecycle.go`'s `PostInit` (verified at lines ~85-134, the
+  relevant block ~115-131) then checks
+  `chromemStore.CountByType(ctx, "book")` — if `>0` it sets
+  `alreadyPopulated = true` and **skips hydration entirely**
+  (`// Snapshot was loaded — nothing to hydrate.`). This is the exact skip
+  path the finding describes: if the snapshot is stale (missing vectors
+  upserted after the last clean-shutdown export), this skip permanently
+  strands dedup Layer 2 in a degraded state.
+- The Pebble source of truth's own count is `EmbeddingStore.CountByType`
+  (verified at `internal/database/embedding_store.go:369`) — a cheap
+  Pebble-side count already used elsewhere. This is a **different type**
+  (`*database.EmbeddingStore`, the Pebble-backed store) from
+  `HNSWEmbeddingStore.CountByType` (`hnsw_embedding_store.go:276-284`, the
+  in-memory graph count) — do not conflate them.
+- **Re-verify:**
+  ```bash
+  grep -n "func (s \*HNSWEmbeddingStore) Import\|func (s \*HNSWEmbeddingStore) CountByType\|Dims() != s.dims" internal/database/hnsw_embedding_store.go
+  grep -n "func (s \*EmbeddingStore) CountByType" internal/database/embedding_store.go
+  grep -n "hnswStore.Import\|HNSW-CRASH-2026-06-18" internal/server/server.go
+  grep -n "CountByType(ctx, \"book\")\|alreadyPopulated" internal/dedup/lifecycle.go
+  ```
+
+### ARCH-2 — atomic export/import
+
+- `Export` (verified at `hnsw_embedding_store.go:333-368`) does
+  `os.Create(binPath)` and `os.WriteFile(metaPath, ...)` directly to their
+  final names inside a loop over `s.graphs` — a crash between the `.bin`
+  write and the `.meta.json` write (or mid-write of either) leaves a
+  truncated/mismatched pair on disk for that entity type.
+- `Import` (verified at `hnsw_embedding_store.go:372-430`) assigns
+  `s.graphs[entityType] = g` (line ~411) **before** reading/unmarshalling
+  the `.meta.json` sidecar (lines ~413-426). If the meta read/unmarshal
+  returns a non-`os.IsNotExist` error, `Import` returns an error to its
+  caller — but `s.graphs[entityType]` was already mutated in place (no
+  rollback), so the store is left in a partial state for that entity type,
+  and because the caller only logs a warning on error (server.go:446), the
+  process continues running with that corrupted graph.
+- **Re-verify:**
+  ```bash
+  grep -n "func (s \*HNSWEmbeddingStore) Export\|func (s \*HNSWEmbeddingStore) Import" internal/database/hnsw_embedding_store.go
+  sed -n '333,430p' internal/database/hnsw_embedding_store.go
+  ```
+
+### ARCH-5 — wrap Graph.Delete
+
+- `HNSWEmbeddingStore.Delete` (verified at `hnsw_embedding_store.go:189-199`)
+  calls `g.Delete(entityID)` bare — no recover. `hnsw.Graph.Delete` (coder/hnsw
+  v0.6.1, `graph.go:460`, `func (h *Graph[K]) Delete(key K) bool`) shares the
+  same per-layer-invariant class of bug as `Add` (see `safeAdd`'s comment,
+  `hnsw_embedding_store.go:143-150`, and `server.go:436-438`'s
+  HNSW-CRASH-2026-06-18 note).
+- `safeAdd` (verified at `hnsw_embedding_store.go:163-171`) is the pattern to
+  mirror: recover any panic from the library call and turn it into an
+  `error` return, never letting it escape.
+- `hnsw_panic_safe_test.go` (verified, root of `internal/database/`) is the
+  existing regression-test pattern for `safeAdd` (repeated re-insert must not
+  crash the process) — add a companion test for `safeDelete` alongside it.
+- **Re-verify:**
+  ```bash
+  grep -n "func (s \*HNSWEmbeddingStore) Delete\|func (s \*HNSWEmbeddingStore) safeAdd\|g.Delete(entityID)" internal/database/hnsw_embedding_store.go
+  grep -n "func.*Delete" "$(go env GOPATH)/pkg/mod/github.com/coder/hnsw@v0.6.1/graph.go"
+  ```
+
+## Step-by-step
+
+1. **ARCH-5 first (smallest, unblocks nothing else — do it first to warm up
+   on the file):**
+   - Add `safeDelete(g *hnsw.Graph[string], entityID string) (deleted bool, err error)`
+     next to `safeAdd`, recovering any panic into `err` exactly like `safeAdd`
+     does, and returning `g.Delete(entityID)`'s bool result on the
+     non-panicking path.
+   - In `Delete`, replace the bare `g.Delete(entityID)` call with
+     `safeDelete`, logging at `slog.Warn` (mirroring the log shape used
+     elsewhere in this file, e.g. the Import dimension-mismatch warning) if
+     an error is returned, and still proceeding to delete the metadata
+     sidecar entry regardless (deletion must remain best-effort, matching
+     the file's "single bad mirror cannot abort" philosophy documented on
+     `safeAdd`). `Delete`'s exported signature (`error` return) does not need
+     to change — a recovered panic should be logged, not propagated as a
+     hard error, to match `safeAdd`'s "never crash the caller" contract.
+   - Add a test in `internal/database/hnsw_panic_safe_test.go` (or a new
+     adjacent file) that deletes a key that was never added (and/or deletes
+     the same key twice) and asserts no panic escapes.
+
+2. **ARCH-2 — atomic Export:**
+   - In `Export`, for each entity type write `.bin` to
+     `binPath+".tmp"` and `.meta.json` to `metaPath+".tmp"` first (still via
+     `os.Create`/`os.WriteFile`), `f.Sync()` the `.bin` file handle before
+     `f.Close()`, then `os.Rename(tmpPath, finalPath)` for each of the two
+     files only after both writes for that entity type have succeeded. If
+     any step fails, return the error before renaming anything for that
+     entity type (leave the previously-committed snapshot, if any, intact —
+     do not delete a good existing snapshot just because a new export
+     failed).
+
+3. **ARCH-2 — atomic Import:**
+   - Change `Import` to build into **local** maps
+     (`newGraphs := map[string]*hnsw.Graph[string]{}`,
+     `newMeta := map[string]map[string]map[string]string{}`) instead of
+     writing directly into `s.graphs`/`s.meta` inside the loop. Keep the
+     existing dimension-mismatch discard behavior (skip that entity type,
+     it's not a hard failure), but any **hard** error (bin open/parse
+     failure, meta unmarshal failure that isn't "file not found") aborts the
+     whole `Import` call — return the error without touching `s.graphs`/
+     `s.meta` at all, so the caller's existing hydration-fallback path
+     (`dedup/lifecycle.go`'s `alreadyPopulated` check seeing `CountByType==0`)
+     actually runs, per the ARCH-2 recommendation. Only after every entity
+     type in the loop parses successfully (or is legitimately skipped for
+     dimension mismatch), commit: `s.graphs = newGraphs; s.meta = newMeta`
+     under `s.mu.Lock()` (which is already held for the duration of `Import`).
+
+4. **ARCH-1 — staleness check:**
+   - Give `HNSWEmbeddingStore.Import` (or its caller in `server.go`) access to
+     a Pebble-side truth count. The cleanest seam: change `Import`'s
+     signature to accept an optional truth-count function
+     `truthCount func(entityType string) (int, error)` (nil-safe — pass
+     `nil` from any test/caller that doesn't have a Pebble store handy), OR
+     add a second method `ImportWithStalenessCheck(dir string, truth
+     func(entityType string) (int, error)) error` that wraps `Import` and
+     performs the check, to avoid changing the existing `Import` signature
+     used elsewhere. Prefer the wrapping-method approach — smaller, additive,
+     matches this codebase's "additive guard" convention (see
+     `dedup-hardening/TASK-01` for the established style of adding a guard
+     without touching an existing function's signature).
+   - In `server.go`'s HNSW-load block (~lines 439-453), after a successful
+     `hnswStore.Import(hnswDir)`, for each entity type compare
+     `hnswStore.CountByType(ctx, entityType)` (in-memory graph count) against
+     `embeddingStore.CountByType(entityType)` (Pebble truth count, resolved
+     from the registry the same way `chromemstore` is resolved). Use "book"
+     as the entity type to check (the type dedup Layer 2 cares about,
+     matching what `dedup/lifecycle.go` already checks). If the graph count
+     is more than a small tolerance below the truth count (e.g. graph count
+     `< truthCount` at all, since any undercounting is unsafe — no positive
+     tolerance is safe here per the finding's "silently misses duplicates"
+     risk), treat the snapshot as stale: drop the imported HNSW state for
+     that entity type (or all entity types, simplest) so `dedup/lifecycle.go`'s
+     `alreadyPopulated` check sees `CountByType==0` and the existing
+     hydration-from-Pebble path runs normally. Do not invent a new hydration
+     mechanism — reuse the one that already exists and already runs when
+     `CountByType==0`.
+   - Log at `slog.Warn` when discarding a stale snapshot, including both
+     counts, mirroring the existing dimension-mismatch warning's log-field
+     shape (`entity_type`, plus the two counts).
+   - Keep this check cheap: both `CountByType` calls are O(1)/map-lookup-ish
+     (verified: HNSW's is `g.Len()`, Pebble's is a stored aggregate per the
+     citation `embedding_store.go:369`) — no full scans.
+
+5. Bump the file header (version bump + `last-edited`) on every file touched,
+   per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/database/... -run HNSW -count=1 -v
+go test ./internal/database/... -count=1
+go test ./internal/dedup/... -count=1
+go test ./internal/server/... -count=1
+go vet ./internal/database/... ./internal/dedup/... ./internal/server/...
+```
+
+Add/extend tests to cover:
+- `safeDelete` on an absent key and a double-delete do not panic.
+- `Export` followed by a simulated interrupted write (e.g. by making one of
+  the two files fail to write) leaves any prior good snapshot for that
+  entity type untouched (no partial overwrite of the final `.bin`/`.meta.json`).
+- `Import` on a directory with a valid `.bin` but a corrupt/truncated
+  `.meta.json` for one entity type returns an error and leaves `s.graphs`/
+  `s.meta` at their pre-call state (nothing partially installed).
+- A staleness scenario: HNSW graph count lower than the Pebble truth count
+  causes the imported snapshot to be discarded and hydration to proceed
+  (assert via the same "alreadyPopulated stays false / CountByType==0"
+  behavior `dedup/lifecycle.go` already relies on — an integration-style
+  test at the `HNSWEmbeddingStore` + `EmbeddingStore` boundary, not a full
+  server boot).
+
+## Acceptance criteria
+
+- [ ] `HNSWEmbeddingStore.Delete` no longer calls `g.Delete` bare; a
+      `safeDelete` helper mirroring `safeAdd` recovers any library panic,
+      and a regression test proves a delete-of-absent-key / double-delete
+      does not crash the process.
+- [ ] `Export` writes via temp file + rename (with fsync on the `.bin`
+      handle) so a crash mid-export cannot leave a truncated file at the
+      final path, and does not clobber a prior good snapshot on failure.
+- [ ] `Import` is all-or-nothing per call: any hard failure (not the
+      existing dimension-mismatch discard) leaves `s.graphs`/`s.meta`
+      completely untouched, so the caller's existing hydrate-from-Pebble
+      fallback actually runs.
+- [ ] After HNSW snapshot import, a staleness check compares the graph's
+      "book" count against the Pebble `emb:` truth count
+      (`EmbeddingStore.CountByType`) and discards the imported state
+      (triggering the existing hydration path) when the graph undercounts
+      the truth.
+- [ ] The existing dimension-mismatch discard behavior in `Import` is
+      unchanged in effect (still skips/rebuilds that entity type at the new
+      dimension).
+- [ ] The existing HNSW-CRASH-2026-06-18 ordering constraint (Import before
+      PostInit) in `server.go` is preserved — do not reorder those calls.
+- [ ] `go build ./...`, the targeted `go test` runs, and `go vet` are green.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(database): harden HNSW derived index (staleness check, atomic export/import, safe Delete)
+
+The HNSW snapshot fast-path skipped Pebble hydration with no staleness check
+(ARCH-1), so any unclean shutdown silently stranded dedup Layer 2 on a graph
+missing every vector upserted since the last clean export. Export wrote
+directly to final paths and Import could install a partial graph on a meta
+read failure (ARCH-2). Graph.Delete ran unwrapped despite the same
+Delete+Add per-layer-invariant panics that safeAdd (#1741) already contains
+for Add (ARCH-5). Add a truth-count staleness check against
+EmbeddingStore.CountByType, make Export/Import atomic (temp+rename, build-
+then-swap), and add safeDelete mirroring safeAdd.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-20-hnsw-staleness-atomic-export
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, re-run the verification greps above. If they show:
+- `Delete` already calls a `safeDelete`/recover-wrapped helper — ARCH-5 is
+  done; skip step 1.
+- `Export` already writes to a `.tmp` path and renames — ARCH-2's export half
+  is done; skip step 2.
+- `Import` already builds into local maps before committing to
+  `s.graphs`/`s.meta` — ARCH-2's import half is done; skip step 3.
+- `server.go`'s HNSW-load block already compares an HNSW count against a
+  Pebble/`EmbeddingStore` truth count and discards on mismatch — ARCH-1 is
+  done; skip step 4.
+
+If all four are already present, this task is fully done — verify with:
+```bash
+grep -n "safeDelete\|\.tmp\"\|newGraphs\|truthCount\|CountByType" internal/database/hnsw_embedding_store.go internal/server/server.go
+```
+and report the finding as pre-fixed rather than duplicating work.
+
+Rollback = revert the commit. `safeAdd`, the existing dimension-mismatch
+discard path, and the HNSW-CRASH-2026-06-18 Import-before-PostInit ordering
+in `server.go` are untouched by this change and remain in effect regardless
+of rollback.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-21-metrics-scrape-alerting.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-21-metrics-scrape-alerting.md
@@ -1,0 +1,218 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-21-metrics-scrape-alerting.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: aede36e2-91a9-4adc-a985-7f25769fa3b8 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-21 — Scrape /metrics + minimal alerting (OPS-4, OPS-5)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet · **Wave:** 2 · **Depends on:** TASK-08
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-21-metrics-scrape-alerting" -b agent/cr-21-metrics-scrape-alerting origin/main
+cd "$REPO/.worktrees/cr-21-metrics-scrape-alerting"
+git rebase origin/main
+```
+
+## Goal
+
+Close OPS-4/OPS-5: `/metrics` is served but nothing scrapes it and there is no
+alerting layer at all — OpenAI quota exhaustion, the 69GB cache-warmup memory
+bloat, and op wedges were all discovered by a human noticing symptoms, not by
+an alert. Deliver a minimal, self-hostable Prometheus scrape config + Alertmanager
+rule set committed under `deploy/`, a runbook for installing them on
+`172.16.2.30`, and (only if genuinely absent after verification) a small gauge
+exporting AI-backend reachability. Keep it self-hostable — no SaaS/hosted
+monitoring product.
+
+## Background (verify before editing)
+
+- `/metrics` is registered unauthenticated at `internal/server/server_lifecycle.go`
+  inside `setupRoutes()`: `s.router.GET("/metrics", gin.WrapH(promhttp.Handler()))`,
+  with an accepted-risk comment referencing pen-test finding MED-1 (LAN-only,
+  no auth). Do **not** add auth here — that decision is already made and
+  documented; this task is scrape+alert, not endpoint hardening.
+- `internal/metrics/metrics.go` already registers the metrics you need for
+  alerting, so this is mostly config authoring, not new instrumentation:
+  - `operations_failed_total{type}` (Counter) — op failure count. Already
+    exists; alert on `rate()` of this, do not add a duplicate.
+  - `process_memory_alloc_bytes` (Gauge, `SetMemoryAlloc`) — Go-runtime alloc.
+  - The Prometheus client library auto-registers `process_resident_memory_bytes`
+    and Go-collector metrics (`go_goroutines`, `go_memstats_*`) at package
+    `init()` in `prometheus.DefaultRegisterer` — verify with the grep below
+    before assuming you need to add RSS yourself.
+  - There is **no** metric today for AI-backend (Ollama) reachability. The
+    closest existing signal is `EmbeddingClient.SetOllamaAvailable(bool)` in
+    `internal/ai/embedding_client.go`, called once from
+    `internal/server/server.go` (`ollamaOK := server.toolRegistry.Available("ollama") || config.AppConfig.Embedding.BaseURL != ""; server.embedClient.SetOllamaAvailable(ollamaOK)`)
+    — this only sets an in-memory bool, it is not exported as a gauge. Add a
+    `NewGaugeVec` (e.g. `ai_backend_available{backend}`, values 0/1) in
+    `internal/metrics/metrics.go` with a `SetBackendAvailable(backend string, ok bool)`
+    helper, and call it from the same `server.go` call site right alongside the
+    existing `SetOllamaAvailable` call (label value `"ollama"`). Keep this
+    addition small — one gauge, one setter, one call site. Do not build a
+    polling/health-check loop; this task reuses the availability signal that
+    already exists at server-init time.
+  - `deploy/` currently contains only systemd/launchd unit files and
+    `local.conf` (gitignored) — no Prometheus scrape config, no Grafana, no
+    Alertmanager, no healthcheck cron anywhere in the repo. Confirm with the
+    grep below.
+  - `deploy/audiobook-organizer.service` sets `MemoryMax=12G` and
+    `GOMEMLIMIT=9GiB` — use these as the basis for the memory alert threshold
+    (e.g. alert when `process_resident_memory_bytes` exceeds ~90% of 12G, i.e.
+    ~11.1e9 bytes).
+  - `docs/system/runbooks.md` already exists (Deploy Runbook, Systemd service
+    sections) with a versioned header and a `172.16.2.30` production-host
+    convention — append a new `## Monitoring & Alerting Runbook` section to it
+    rather than creating a separate doc.
+  - Prod already runs on `172.16.2.30` — target that host as
+    `172.16.2.30:8484` in the scrape config's `targets:` (adjust the port to
+    match whatever `--port` prod actually uses; verify via
+    `grep -rn "\-\-port\|ExecStart=" deploy/local.conf 2>/dev/null` if that
+    gitignored file exists locally, otherwise default to `8484` per the
+    systemd unit's `ExecStart`).
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "s.router.GET(\"/metrics\"" internal/server/server_lifecycle.go
+  grep -n "func Register\|MustRegister\|NewGaugeVec\|operationFailed\|SetMemoryAlloc" internal/metrics/metrics.go
+  grep -n "SetOllamaAvailable" internal/ai/embedding_client.go internal/server/server.go
+  grep -rn "prometheus\|grafana\|alertmanager\|scrape" deploy/ 2>/dev/null
+  grep -n "MemoryMax\|GOMEMLIMIT" deploy/audiobook-organizer.service
+  ```
+  Confirm the auto-registered process/go collector metrics exist without any
+  in-repo code (this is a client_golang library default, not something this
+  repo defines):
+  ```bash
+  grep -n "NewProcessCollector\|NewGoCollector" $(go env GOPATH)/pkg/mod/github.com/prometheus/client_golang*/prometheus/registry.go 2>/dev/null || echo "vendor path differs; confirm via 'go doc github.com/prometheus/client_golang/prometheus.init' or by curling /metrics on a running instance and grepping for process_resident_memory_bytes"
+  ```
+
+## Step-by-step
+
+1. Add the backend-availability gauge (small, additive):
+   - In `internal/metrics/metrics.go`, add
+     `aiBackendAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{Namespace: "audiobook_organizer", Name: "ai_backend_available", Help: "1 if the named AI backend was reachable/available at last check, else 0"}, []string{"backend"})`,
+     register it in `Register()`, and add
+     `func SetBackendAvailable(backend string, ok bool) { v := 0.0; if ok { v = 1.0 }; aiBackendAvailable.WithLabelValues(backend).Set(v) }`.
+   - In `internal/server/server.go`, immediately after the existing
+     `server.embedClient.SetOllamaAvailable(ollamaOK)` line, add
+     `metrics.SetBackendAvailable("ollama", ollamaOK)` (import the metrics
+     package if not already imported in that file — check first).
+2. Create `deploy/prometheus/scrape-config.yml` — a minimal, commented
+   Prometheus `scrape_configs` snippet targeting `172.16.2.30:8484` on the
+   `/metrics` path, `scrape_interval: 30s`, job name `audiobook-organizer`.
+   Include a comment explaining this is a **snippet** to merge into an
+   existing `prometheus.yml`, not a standalone runnable file.
+3. Create `deploy/prometheus/alert-rules.yml` — Prometheus alerting rules
+   (`groups:` format) covering at minimum:
+   - `AudiobookOrganizerOpFailuresHigh` — `rate(audiobook_organizer_operations_failed_total[15m]) > <threshold>` (pick a conservative threshold, e.g. `0.1` per second sustained, document the reasoning in a comment), `for: 10m`, severity warning.
+   - `AudiobookOrganizerBackendUnavailable` — `audiobook_organizer_ai_backend_available == 0`, `for: 5m`, severity warning. Comment that this covers OPS-4's "OpenAI/local backend down" case.
+   - `AudiobookOrganizerMemoryHigh` — `process_resident_memory_bytes > 1.1e10` (~90% of the 12G `MemoryMax` cgroup limit), `for: 10m`, severity critical. Comment referencing `MemoryMax=12G` in `deploy/audiobook-organizer.service`.
+   - `AudiobookOrganizerDown` — standard `up{job="audiobook-organizer"} == 0`, `for: 2m`, severity critical (covers "service restarts"/reachability; a restart shows up as a scrape gap here since there's no restart-count metric — call this out as the practical proxy in a comment).
+   - `AudiobookOrganizerDiskLow` — `node_filesystem_avail_bytes{mountpoint="/var/lib/audiobook-organizer"} / node_filesystem_size_bytes{mountpoint="/var/lib/audiobook-organizer"} < 0.1` guarded with a comment that this rule requires `node_exporter` to also be scraped (out of scope to install here — call it out as a prerequisite, do not silently assume it exists).
+4. Create `deploy/prometheus/README.md` (or extend `deploy/README.md` if one
+   exists — check first) documenting: what these two files are, that they are
+   snippets/examples (not turnkey), and a one-line pointer to the runbook
+   section for the install procedure.
+5. Append a `## Monitoring & Alerting Runbook` section to
+   `docs/system/runbooks.md` (after the existing sections — do not reorder or
+   rewrite existing content) covering:
+   - Prerequisite: a Prometheus + Alertmanager install on `172.16.2.30` (or a
+     separate host that can reach it) — this task does not install Prometheus
+     itself, only ships the config to plug into one.
+   - How to merge `deploy/prometheus/scrape-config.yml` into that
+     Prometheus's `prometheus.yml` and reload (`curl -X POST
+     http://localhost:9090/-/reload` or `systemctl reload prometheus`).
+   - How to load `deploy/prometheus/alert-rules.yml` as a rule file and wire
+     Alertmanager (mention a minimal Alertmanager receiver, e.g. email or a
+     self-hosted webhook — explicitly no SaaS like PagerDuty/Opsgenie unless
+     the operator already has one).
+   - A note that `AudiobookOrganizerDiskLow` requires `node_exporter` as a
+     prerequisite, with a one-line pointer to installing it (`apt install
+     prometheus-node-exporter` or equivalent) — do not install it as part of
+     this task.
+6. Bump the file header on every file you touch (version bump + `last-edited`
+   date) per `.standards/instructions/file-headers.md`, including
+   `internal/metrics/metrics.go`, `internal/server/server.go`, and
+   `docs/system/runbooks.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/metrics/... ./internal/server/... -count=1
+go vet ./internal/metrics/... ./internal/server/...
+# Validate the Prometheus rule file syntax if promtool is available locally
+# (skip gracefully if not installed — do not add it as a new dependency):
+command -v promtool >/dev/null && promtool check rules deploy/prometheus/alert-rules.yml || echo "promtool not installed locally; rule syntax reviewed by hand"
+```
+
+## Acceptance criteria
+
+- [ ] `internal/metrics/metrics.go` exports an `ai_backend_available{backend}`
+      gauge and a `SetBackendAvailable` helper, registered in `Register()`.
+- [ ] `internal/server/server.go` calls `metrics.SetBackendAvailable("ollama", ollamaOK)`
+      at the same point it calls `SetOllamaAvailable`.
+- [ ] `deploy/prometheus/scrape-config.yml` and `deploy/prometheus/alert-rules.yml`
+      exist, are valid YAML, and (if `promtool` is available) pass
+      `promtool check rules`.
+- [ ] Alert rules cover: op failure rate, AI-backend availability, memory
+      pressure (tied to the real `MemoryMax=12G` limit), service
+      down/unreachable, and disk (with the `node_exporter` prerequisite called
+      out explicitly, not silently assumed).
+- [ ] `docs/system/runbooks.md` has a new "Monitoring & Alerting Runbook"
+      section with install/reload steps; existing sections are untouched.
+- [ ] `go build ./...`, targeted `go test`, and `go vet` are all clean.
+- [ ] File headers bumped on every changed file.
+- [ ] No SaaS monitoring dependency introduced; everything is self-hostable
+      config/docs.
+
+This task ships config and docs only — it does not install Prometheus/Alertmanager
+on `172.16.2.30` itself and does not require prod access. No owner-greenlight
+gate is needed beyond normal PR review (no prod-data mutation, no dry-run
+report required).
+
+## Commit message
+
+```
+feat(observability): add Prometheus scrape config + alert rules for /metrics (OPS-4, OPS-5)
+
+/metrics has been served since server_lifecycle.go registered promhttp.Handler,
+but nothing scrapes it and there is no alerting layer — OpenAI quota exhaustion,
+the 69GB cache-warmup bloat, and op wedges were all discovered by a human
+noticing symptoms, not an alert. Add a minimal self-hostable Prometheus
+scrape-config snippet and alert rules (op failures, AI-backend availability,
+memory vs the 12G MemoryMax limit, service down, disk) under deploy/, a small
+ai_backend_available gauge to make backend reachability alertable, and a
+runbook section for installing them.
+
+Co-Authored-By: Claude <model> <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-21-metrics-scrape-alerting
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `internal/metrics/metrics.go` already exports a backend-availability gauge
+(grep for `ai_backend_available` or any `*_available` GaugeVec) and
+`deploy/prometheus/` already contains a scrape config and alert rules, this
+task is done — verify with:
+```bash
+grep -n "available" internal/metrics/metrics.go
+ls deploy/prometheus/ 2>/dev/null
+grep -n "Monitoring & Alerting Runbook" docs/system/runbooks.md
+```
+Rollback = revert the commit. The new gauge and metrics call are purely
+additive (no existing metric renamed or removed), so reverting cannot break
+any existing scrape or dashboard. The `deploy/prometheus/` files and runbook
+section are new, standalone additions with no effect on the running service
+until an operator actually installs Prometheus and loads them.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-22-nutsdb-retirement.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-22-nutsdb-retirement.md
@@ -1,0 +1,329 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-22-nutsdb-retirement.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 065970de-8d58-4ac9-9021-6682a4ac19d4 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-22 — NutsDB retirement (activity dual-write cutover + metrics to Pebble)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend
+subagent · **Wave:** 2 · **Depends on:** TASK-19
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-22-nutsdb-retirement" -b agent/cr-22-nutsdb-retirement origin/main
+cd "$REPO/.worktrees/cr-22-nutsdb-retirement"
+git rebase origin/main
+```
+
+## Goal
+
+Finish the NutsDB→Pebble migration that has been sitting in its "safe rollback
+window" since ~2026-06-10 and stop paying its costs forever: (1) collapse
+`DualWriteActivityStore` to a Pebble-only pass-through so activity stops
+double-writing and NutsDB stops being opened at every boot (this also
+eliminates the accepted-but-annoying `NutsActivityStore.Close()` goroutine
+leak, because NutsDB will no longer be opened at all — see Background); (2)
+flip `metricsstore` in `registry_wire.go` from `NutsMetricsStore` to the
+already-built `PebbleMetricsStore` (its TTL sweep job already exists and is
+registered); (3) verify (do not assume) whether anything is retained in
+NutsDB that never made it to Pebble before any deletion; (4) remove the
+`github.com/nutsdb/nutsdb` dependency and delete the NutsDB source files as a
+**separate, later commit**, gated on a soak period — do not do this in the
+same PR as steps 1–2.
+
+This task is split into two PRs on purpose. PR 1 (steps 1–3) is safe to ship
+immediately once tests pass. PR 2 (step 4, dependency removal) requires an
+owner greenlight after a soak window — see Acceptance criteria.
+
+## Background (verify before editing)
+
+- **Activity dual-write.** `internal/activity/register.go` unconditionally
+  opens `activity.nutsdb` (`database.NewNutsActivityStore`) at every boot and
+  wraps it with `database.NewDualWriteActivityStore(nutsStore, pebbleStore,
+  readFromPebble)` whenever a Pebble backend is available. `readFromPebble` is
+  computed once at startup from `database.IsActivityPebbleBackfillDone(pebbleStore.DB())`
+  — i.e. the flag `system:backfill:activity_pebble_v1_done` set in Pebble.
+  As of this writing that flag has been set on prod (per `docs/consultancy/01-storage-architecture.md`
+  and `TODO.md`), meaning reads already come from Pebble; only writes are
+  still duplicated to NutsDB with no read benefit.
+- **`DualWriteActivityStore`** (`internal/database/dual_write_activity_store.go`)
+  writes to both `nuts` and `pebble` on every mutating call (`Record`,
+  `Summarize`, `Prune`, `WipeAllActivity`, `CompactByDay`,
+  `MigrateSystemActivityLogs`, `RecompactDigests`) and its `Close()` (verified
+  at lines ~195-201) closes both backends — this is where the NutsDB
+  `Close()` goroutine (see next bullet) gets triggered in every process that
+  builds this wrapper.
+- **The NutsDB goroutine "leak" is a known, accepted, third-party limitation** —
+  see `TODO.md` entry `NUTSDB-CLOSE-GOROUTINE-LEAK` (investigated
+  2026-07-01, marked benign because the activity store is a process-lifetime
+  singleton). Do NOT attempt to patch nutsdb itself or add workarounds inside
+  `nuts_activity_store.go` — the fix here is to stop opening NutsDB at all,
+  which makes the leak moot rather than "fixed" per se. State this precisely
+  in the commit message; don't claim you "fixed a goroutine leak" — you
+  removed the code path that triggered it.
+- **`PebbleActivityStore`** (`internal/database/pebble_activity_store.go`)
+  already implements the full `ActivityStorer` interface standalone
+  (`Record`, `Query`, `Summarize`, `Prune`, `GetDistinctSources`,
+  `WipeAllActivity`, `CompactByDay`, `MigrateSystemActivityLogs`,
+  `RecompactDigests`, `Close`) and shares the main PebbleDB instance
+  (constructed from `ps.DB()` in `register.go`, no separate file). This means
+  the activity cutover is "delete the wrapper, return the Pebble store
+  directly" — no new store code is needed.
+- **Metrics.** `internal/server/registry_wire.go` registers a service named
+  `"metricsstore"` (verify line numbers — see re-verify grep below) that
+  builds a `database.NutsMetricsStore` at `{dirname(DatabasePath)}/metrics.nutsdb`
+  and returns `(*database.NutsMetricsStore)(nil)` on any error or when
+  `DatabasePath` is empty (test paths). `database.PebbleMetricsStore`
+  (`internal/database/pebble_metrics_store.go`) already implements the full
+  `MetricsStorer` interface (`RecordCacheStatsSnapshots`,
+  `GetCacheStatsHistory`, `PruneCacheStatsHistory`, `Close`) **plus**
+  `SweepExpiredMetrics() (int64, error)` to compensate for Pebble having no
+  native per-key TTL — and that sweep is already wired as a maintenance job
+  in `internal/maintenance/jobs/sweep_pebble_metrics_ttl.go` (registered via
+  `maintenance.Register(&sweepPebbleMetricsTTLJob{})` in that file's `init()`).
+  There is nothing left to build for metrics — only the registry wiring needs
+  to change.
+- **`MetricsStorer` interface** is defined in `internal/database/activity_storer.go`
+  (verify — same file as `ActivityStorer`, not a separate `metrics_storer.go`).
+  Its doc comment currently says "NutsMetricsStore is the production
+  implementation" — update that comment when you flip the wiring.
+- **Retained-only-in-NutsDB check (step 3).** Before deleting/soaking,
+  confirm there is no data that exists in NutsDB but never migrated to
+  Pebble. The activity backfill flag mechanism
+  (`internal/database/pebble_activity_backfill.go`) implies a one-time
+  backfill op already ran; find it (grep for `activity_pebble_v1_done` or
+  `ActivityPebbleBackfillKey` usage in `internal/maintenance/jobs/` or
+  `internal/operations/`) and confirm it covers full history, not just
+  forward writes since the flag was introduced. Metrics (`metrics.nutsdb`)
+  has **no equivalent backfill** — `NutsMetricsStore` and `PebbleMetricsStore`
+  are independent stores that were never cross-migrated; `metrics.nutsdb`
+  history (cache-stats snapshots) will NOT carry forward automatically when
+  you flip the registry wiring. Since `CacheStatsSnapshot` data is a rolling
+  30-day operational metric (not user data), losing continuity at cutover is
+  low-risk, but you must say this explicitly in the PR description rather
+  than silently dropping history — do not build a metrics backfill op unless
+  asked; just document the gap.
+
+**Re-verify these anchors before editing — line numbers drift:**
+
+```bash
+grep -n "func init\|NewNutsActivityStore\|NewDualWriteActivityStore\|IsActivityPebbleBackfillDone\|pebble-activitystore\|KeyActivityStore" internal/activity/register.go
+grep -n "func (d \*DualWriteActivityStore)\|func NewDualWriteActivityStore" internal/database/dual_write_activity_store.go
+grep -n "metricsstore\|NutsMetricsStore\|PebbleMetricsStore" internal/server/registry_wire.go
+grep -n "type ActivityStorer\|type MetricsStorer" internal/database/activity_storer.go
+grep -n "func New\|func (s \*PebbleActivityStore)\|func (s \*PebbleMetricsStore)" internal/database/pebble_activity_store.go internal/database/pebble_metrics_store.go
+grep -n "NUTSDB-CLOSE-GOROUTINE-LEAK" TODO.md
+```
+
+## Step-by-step
+
+### PR 1 — activity + metrics cutover (ship immediately once green)
+
+1. In `internal/activity/register.go`, in the `activitystore` service's
+   `Build` func:
+   - Keep opening `pebbleStore` via the existing `"pebble-activitystore"`
+     dependency exactly as today.
+   - Remove the `database.NewNutsActivityStore(activityDir)` call and the
+     `activityDir := filepath.Join(...)` line entirely — do not open
+     `activity.nutsdb` at all.
+   - Remove the `database.NewDualWriteActivityStore(...)` call; return
+     `pebbleStore` directly (it already satisfies `ActivityStorer`).
+   - Keep the existing nil/non-Pebble fallback behavior conceptually, but
+     since there's no NutsDB fallback anymore, a missing Pebble backend
+     should now be a hard error (`fmt.Errorf("activitystore: pebble activity
+     store not available")`) rather than a NutsDB-only degraded mode — there
+     is no more degraded mode to fall back to.
+   - Update the package doc comment at the top of the file (the "WHY backend
+     selection during the migration window (T024)" block) — remove the
+     stale forward-looking language about NutsDB/dual-write/T024b, replace
+     with a short note that the migration is complete and reads/writes are
+     Pebble-only.
+   - Drop the now-unused `filepath` import if nothing else in the file uses
+     it — verify with `goimports`/`go build` rather than assuming.
+2. In `internal/database/dual_write_activity_store.go`: do NOT delete this
+   file yet (see PR 2). Add a doc comment at the top marking it
+   **unused-as-of-<date>, retained for one release cycle as a rollback
+   reference; delete in the NutsDB-removal PR**. Do not wire it anywhere in
+   PR 1 — leaving it merely present-but-unreferenced is fine and avoids an
+   unnecessary file-deletion diff in the same PR as the behavior change.
+3. In `internal/server/registry_wire.go`, in the `"metricsstore"` service's
+   `Build` func:
+   - Replace the `database.NewNutsMetricsStore(dir)` call with
+     `database.NewPebbleMetricsStore(...)`. It needs a `*pebble.DB` — get it
+     the same way `"pebble-activitystore"` does in `register.go`
+     (`serviceregistry.Get[database.Store](c, serviceregistry.KeyStore)`,
+     type-assert to `*database.PebbleStore`, call `.DB()`). Add
+     `serviceregistry.KeyStore` to this service's `Needs` list if not
+     already present.
+   - On a non-Pebble backend (test doubles, SQLite), fall back to returning
+     `(*database.PebbleMetricsStore)(nil)` — mirror the existing nil-fallback
+     pattern used elsewhere in this file, do not panic.
+   - Remove the now-unused `dir := filepath.Join(...)` NutsDB path
+     construction and the `database.NewNutsMetricsStore` call.
+   - Update the comment above the service registration (currently says
+     "NutsDB-backed cache-stats snapshot store... Lives at
+     {dirname(DatabasePath)}/metrics.nutsdb") to describe the Pebble-backed
+     store instead.
+   - Update the `MetricsStorer` interface doc comment in
+     `internal/database/activity_storer.go` ("NutsMetricsStore is the
+     production implementation") to name `PebbleMetricsStore` instead.
+4. Confirm `sweep-pebble-metrics-ttl` (already registered in
+   `internal/maintenance/jobs/sweep_pebble_metrics_ttl.go`) is enabled by
+   default / on the standard maintenance schedule — if it's currently
+   dormant because `PebbleMetricsStore` was never the primary, check how
+   maintenance jobs get their store dependency (likely via the same
+   `"metricsstore"` service) and confirm this cutover activates it without
+   further changes. Do not build a new job.
+5. Run the NutsDB-only-retained-history check from Background step 3. Write
+   your findings (what you checked, what you found) into the PR description
+   verbatim — this is required evidence, not optional color.
+6. Update/extend tests:
+   - `internal/activity` tests that assert dual-write or NutsDB-specific
+     behavior in the `activitystore` service build path need updating to
+     assert a plain `*database.PebbleActivityStore` (or the
+     `ActivityStorer` interface) is returned instead.
+   - `internal/server` tests covering `"metricsstore"` wiring need updating
+     to assert a `*database.PebbleMetricsStore` is returned.
+   - Do not delete or weaken existing `NutsActivityStore`/`NutsMetricsStore`
+     unit tests themselves in PR 1 — those stores still exist as files,
+     just unwired. They get deleted in PR 2 along with the files.
+7. Bump the file header (version bump + `last-edited`) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+### PR 2 — dependency removal (separate PR, after soak — see Acceptance)
+
+8. After the soak window has passed and an owner has greenlit removal:
+   delete `internal/database/nuts_activity_store.go`,
+   `internal/database/nuts_metrics_store.go`,
+   `internal/database/dual_write_activity_store.go`, their `*_test.go`
+   companions, and the `github.com/nutsdb/nutsdb` line from `go.mod`
+   (run `go mod tidy` after). Also remove/gate any one-time backfill op
+   code and the `ActivityPebbleBackfillKey` sentinel machinery if it is no
+   longer referenced by anything (verify with `grep -rn
+   ActivityPebbleBackfillKey` first — it may still be read by a
+   still-useful migration-status check; do not remove blindly).
+   Add a `TODO.md` entry closing out `NUTSDB-CLOSE-GOROUTINE-LEAK` as
+   "resolved by removal" rather than leaving it as an accepted limitation.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/activity/... ./internal/database/... ./internal/server/... ./internal/maintenance/... -count=1
+go vet ./internal/activity/... ./internal/database/... ./internal/server/...
+```
+
+For PR 2 additionally run `go mod tidy && go build ./...` and confirm no
+remaining references:
+
+```bash
+grep -rn "nutsdb" --include="*.go" internal/ | grep -v _test.go
+```
+
+## Acceptance criteria
+
+**PR 1 (ship immediately once green):**
+
+- [ ] `internal/activity/register.go` no longer opens `activity.nutsdb`;
+      `activitystore` service returns the Pebble activity store directly
+      (no `DualWriteActivityStore` in the live path).
+- [ ] `internal/server/registry_wire.go`'s `"metricsstore"` service builds
+      and returns a `PebbleMetricsStore`, not `NutsMetricsStore`.
+- [ ] `sweep-pebble-metrics-ttl` maintenance job is confirmed active against
+      the now-primary Pebble metrics store.
+- [ ] PR description documents the NutsDB-only-retained-history check
+      (Background step 3 / step-by-step step 5) with concrete findings —
+      not a bare assertion that it's fine.
+- [ ] PR description explicitly states the `metrics.nutsdb` cache-stats
+      history-continuity gap (no backfill exists) rather than silently
+      dropping it.
+- [ ] All updated/existing tests green; `go vet` clean.
+- [ ] File headers bumped on every changed file.
+- [ ] `dual_write_activity_store.go` retained (not deleted) in this PR,
+      marked as unused/pending-removal.
+
+**PR 2 (dependency removal) — STOP HERE without owner greenlight:**
+
+- [ ] Do not open PR 2 until an owner has explicitly approved that the soak
+      period (one release cycle, per the original T024 plan) has completed
+      with no rollback needed.
+- [ ] Once greenlit: `nutsdb`/`NutsActivityStore`/`NutsMetricsStore`/
+      `DualWriteActivityStore` files deleted, `go.mod` no longer lists
+      `github.com/nutsdb/nutsdb`, `go mod tidy` clean, full build/test green.
+- [ ] `TODO.md`'s `NUTSDB-CLOSE-GOROUTINE-LEAK` entry updated to record
+      resolution-by-removal.
+
+## Commit message
+
+PR 1:
+
+```
+refactor(storage): cut activity + metrics over to Pebble-only, retire NutsDB dual-write
+
+Activity has dual-written to NutsDB and Pebble since the T024 migration
+window opened ~2026-06-10; the backfill flag has been set and reads already
+come from Pebble, so the NutsDB write is pure cost with no benefit. Metrics
+was still NutsDB-primary despite PebbleMetricsStore (with TTL sweep) already
+being fully built. Collapse activitystore to PebbleActivityStore directly and
+flip metricsstore to PebbleMetricsStore; this also stops NutsDB from being
+opened at all, which is the real fix for the previously-accepted
+NutsDB-Close goroutine limitation (not opening it is better than living with
+it). NutsDB source files and the go.mod dependency are retained pending a
+soak period — removed in a follow-up PR.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+PR 2 (separate commit, after greenlight):
+
+```
+chore(storage): remove NutsDB dependency after activity/metrics soak
+
+Soak period for the Pebble-only activity/metrics cutover has passed with no
+rollback needed. Delete NutsActivityStore, NutsMetricsStore,
+DualWriteActivityStore and their tests; drop github.com/nutsdb/nutsdb from
+go.mod. Closes NUTSDB-CLOSE-GOROUTINE-LEAK by removal.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-22-nutsdb-retirement
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+Open PR 2 as its own branch/worktree off main after PR 1 has merged and the
+soak/greenlight condition is met — do not bundle both into one PR.
+
+## Idempotency / Rollback
+
+If `internal/activity/register.go`'s `activitystore` service already returns
+a bare `*database.PebbleActivityStore` (no `DualWriteActivityStore` in the
+build path) **and** `registry_wire.go`'s `"metricsstore"` service already
+builds a `PebbleMetricsStore`, PR 1 of this task is done — verify with:
+
+```bash
+grep -n "NewDualWriteActivityStore\|NewNutsActivityStore" internal/activity/register.go
+grep -n "NewNutsMetricsStore\|NewPebbleMetricsStore" internal/server/registry_wire.go
+```
+
+If both greps show only the Pebble constructors (or no matches for the Nuts
+ones) in the live build paths, stop — do not re-do the cutover. If
+`github.com/nutsdb/nutsdb` is already absent from `go.mod`, PR 2 is also
+done; do not attempt to remove it again.
+
+Rollback for PR 1 = revert the commit; this restores
+`DualWriteActivityStore`/`NutsMetricsStore` wiring, which still exist as
+files and still function (assuming PR 2 has not yet run). Rollback for PR 2
+is **not simple revert** — once NutsDB files/dependency are deleted, a
+revert only restores source; any data written exclusively to Pebble in the
+interim needs no backfill (Pebble was already the source of truth for
+activity reads), but restarting NutsDB-backed metrics after a gap will start
+from an empty `metrics.nutsdb` file. Do not attempt PR 2's rollback by
+reverting alone without re-confirming this.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-23-transcription-apply-toctou.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-23-transcription-apply-toctou.md
@@ -1,0 +1,229 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-23-transcription-apply-toctou.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: fc1d8998-b00b-45c1-a8a2-f4a5bbfa4016 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-23 — TOCTOU fix in `ApplyTranscriptionCandidate` (consultancy-roadmap)
+
+**Priority:** P2 · **Effort:** S · **Recommended subagent:** Sonnet · go-backend subagent · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-23-transcription-apply-toctou" -b agent/cr-23-transcription-apply-toctou origin/main
+cd "$REPO/.worktrees/cr-23-transcription-apply-toctou"
+git rebase origin/main
+```
+
+## Goal
+
+Close the TOCTOU window in the transcription auto-match apply path
+(consultancy findings MATCH-6 / BUG-3 / QUAL-3, verified real). Today
+`ApplyTranscriptionCandidate` ignores the `candTitle`/`candAuthor` identity of
+the candidate that was actually gated by `runAutoMatchTranscribed`, and
+instead blindly re-reads the metadata cache and applies whatever sits in
+`Candidates[0]` at apply time. If the cache is refreshed between the gate and
+the apply (a concurrent metadata search, another maintenance op, a UI-driven
+re-fetch — the cache is shared and keyed only by book ID), an **ungated**
+candidate gets applied and `MetadataReviewStatus` may be set to
+`audio_confirmed` on the wrong metadata, while the "applied" log line still
+reports the (stale, gated) title. Fix: make `ApplyTranscriptionCandidate`
+actually use the identity parameters it already receives — verify the
+re-read cache slot 0 still matches the gated `candTitle`/`candAuthor` before
+applying, and error out (which the caller already treats as "skip + log")
+on mismatch.
+
+## Background (verify before editing)
+
+- `internal/server/server_maintenance_deps.go` implements
+  `maintenance.ServerDeps` on `*Server`. Two methods are relevant:
+  - `SearchTranscriptionCandidate(_ context.Context, bookID, _, _ string) (string, string, float64, bool, error)`
+    — note the transcribed-title/author parameters are already discarded
+    (`_, _`); it reads `s.metadataFetchService.GetCachedCandidates(bookID)`
+    and returns `Candidates[0]`'s title/author/score. **This method's own
+    query-param-ignoring behavior is a separate, lower-priority issue — out
+    of scope for this task.** Do not change its signature or behavior.
+  - `ApplyTranscriptionCandidate(_ context.Context, bookID, _, _ string) error`
+    — this is the actual bug target. Its `candTitle`/`candAuthor` parameters
+    are *also* discarded (`_, _`), even though the caller
+    (`runAutoMatchTranscribed` in
+    `internal/plugins/maintenance/auto_match_transcribed.go`) passes the
+    exact gated candidate's title/author into it at the call site
+    (`p.deps.ApplyTranscriptionCandidate(ctx, id, candTitle, candAuthor)`).
+    The function re-reads `GetCachedCandidates(bookID)` independently and
+    applies `Candidates[0]` from that fresh read — which may differ from the
+    candidate that was gated moments earlier.
+  - Gates applied by the caller before calling `ApplyTranscriptionCandidate`
+    (see `runAutoMatchTranscribed`, roughly lines 130-183): Gate 1 — score
+    `>= minScore`; Gate 2 — `util.NormalizeTitle(candTitle) ==
+    util.NormalizeTitle(transTitle)`; Gate 3 — author containment via
+    `strings.Contains` (case-insensitive) when `transAuthor` is longer than 3
+    chars. These gates run against the `candTitle`/`candAuthor` returned by
+    `SearchTranscriptionCandidate` — the exact same values then thrown away
+    by `ApplyTranscriptionCandidate`.
+  - **The fix does NOT require changing the `maintenance.ServerDeps`
+    interface or the call site** — the identity parameters
+    (`candTitle`, `candAuthor`) already flow end-to-end; they are simply
+    unused (`_, _`) inside `ApplyTranscriptionCandidate`. Rename them to
+    real parameter names and use them.
+  - `util.NormalizeTitle` (`internal/util/normalize.go`) does
+    `strings.ToLower(strings.TrimSpace(s))` — reuse it for the title
+    comparison (matches Gate 2's normalization exactly, so a book that
+    passed the caller's gate cannot spuriously fail the apply-time check due
+    to a different normalization rule). `internal/util/normalize.go` also
+    has `NormalizeAuthor` — reuse it (or the same `strings.Contains`
+    substring-containment rule the caller's Gate 3 uses) for the author
+    comparison; do not require exact author equality since Gate 3 itself
+    only requires containment.
+  - `metafetch.MetadataCandidate` (`internal/metafetch/service.go`) has
+    `Title string` and `Author string` fields (JSON `title`/`author`) — this
+    is the type `Candidates[0]` unmarshals into in both methods.
+  - The caller (`runAutoMatchTranscribed`) already treats a non-nil error
+    from `ApplyTranscriptionCandidate` as "non-fatal, skip and log a warning
+    with `applyErr`" — see the `log.Warn("auto-match-transcribed: apply
+    failed", ...)` branch. Returning a descriptive error on mismatch is
+    therefore sufficient; no new caller-side handling is needed.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (s \*Server) SearchTranscriptionCandidate\|func (s \*Server) ApplyTranscriptionCandidate" internal/server/server_maintenance_deps.go
+  grep -n "p.deps.ApplyTranscriptionCandidate\|p.deps.SearchTranscriptionCandidate\|// Gate 1\|// Gate 2\|// Gate 3" internal/plugins/maintenance/auto_match_transcribed.go
+  grep -n "ApplyTranscriptionCandidate\|SearchTranscriptionCandidate" internal/plugins/maintenance/deps.go
+  ```
+  Confirm `ApplyTranscriptionCandidate`'s current body still discards its
+  last two string params and unmarshals `entry.Candidates[0]` directly into
+  a `metafetch.MetadataCandidate` with no comparison against those params
+  before calling `s.metadataFetchService.ApplyMetadataCandidate(...)`.
+
+## Step-by-step
+
+1. In `internal/server/server_maintenance_deps.go`, change
+   `ApplyTranscriptionCandidate`'s signature from
+   `(_ context.Context, bookID, _, _ string) error` to name the last two
+   parameters (e.g. `gatedTitle, gatedAuthor string`) — do NOT change the
+   parameter types, count, or return type (the `maintenance.ServerDeps`
+   interface in `internal/plugins/maintenance/deps.go` is unchanged).
+2. After unmarshaling `entry.Candidates[0]` into `cand
+   metafetch.MetadataCandidate` (existing code), add a check before the
+   `ApplyMetadataCandidate` call:
+   - If `util.NormalizeTitle(cand.Title) != util.NormalizeTitle(gatedTitle)`,
+     OR the author check fails (mirror the caller's Gate 3: only enforce
+     when `gatedAuthor` is non-trivial, e.g. `len(gatedAuthor) > 3`, using a
+     case-insensitive substring-containment check consistent with
+     `auto_match_transcribed.go`'s Gate 3 — do not require exact author
+     equality),
+   - then return a descriptive, non-nil error (e.g.
+     `fmt.Errorf("cached candidate for book %s changed since gating (want %q/%q, got %q/%q)", bookID, gatedTitle, gatedAuthor, cand.Title, cand.Author)`)
+     and do **not** call `ApplyMetadataCandidate`.
+   - Add a `slog.Warn` (or reuse the existing logger convention in this
+     file — check whether this file already imports `log/slog`; if not, add
+     it) at the point of mismatch, with fields `book_id`, `gated_title`,
+     `cache_title` so the "apply failed" warning downstream in
+     `auto_match_transcribed.go` has enough context without needing a second
+     log line.
+3. Leave `SearchTranscriptionCandidate` untouched — it is out of scope for
+   this task (see Background).
+4. Leave `auto_match_transcribed.go`'s call site
+   (`p.deps.ApplyTranscriptionCandidate(ctx, id, candTitle, candAuthor)`)
+   untouched — it already passes the correct identity; only the callee
+   needed to start using it.
+5. Add a regression test that reproduces the TOCTOU window and proves it is
+   closed. Recommended shape, in a new file
+   `internal/server/server_maintenance_deps_test.go` (verify this file does
+   not already exist before creating it — `ls internal/server/ | grep
+   maintenance_deps` — if it exists, extend it instead):
+   - Build a `*database.MockStore` whose `GetMetadataCacheFunc` returns a
+     **different** `MetadataCandidateCache` on its second invocation than its
+     first (use a call counter closure) — simulating a cache refresh between
+     the gate (first read, via `SearchTranscriptionCandidate`) and the apply
+     (second read, inside `ApplyTranscriptionCandidate`). Also stub
+     `GetBookByIDFunc` to return a minimal valid `*database.Book` (needed by
+     `ApplyMetadataCandidate`) and `GetBookTagsFunc` to return no tags (see
+     `internal/metafetch/service_apply.go`'s `ApplyMetadataCandidate` for
+     what it reads from the store — follow the existing pattern in
+     `internal/server/metadata_ops_fastpath_test.go` for constructing
+     `&Server{store: store, metadataFetchService: metafetch.NewService(store)}`).
+   - Call `s.SearchTranscriptionCandidate(ctx, bookID, "irrelevant", "irrelevant")`
+     to get `(candTitle, candAuthor, score, found, err)` from the first cache
+     read (this is what the real caller does).
+   - Call `s.ApplyTranscriptionCandidate(ctx, bookID, candTitle, candAuthor)`
+     — this triggers the second (now-different) cache read internally.
+   - Assert: the call returns a non-nil error, AND
+     `ApplyMetadataCandidate`/the underlying store write was never invoked
+     with the second candidate's data (e.g. assert on a
+     `PutBookFunc`/write-path spy not being called with the mismatched
+     title, or that the returned error message names the mismatch).
+   - Add a second case: cache returns the **same** candidate on both reads —
+     assert `ApplyTranscriptionCandidate` succeeds (no regression / no
+     over-suppression of the legitimate, unmodified-cache path).
+6. Bump the file header (version bump + `last-edited` date) on every file
+   you touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/server/... ./internal/plugins/maintenance/... -count=1
+go vet ./internal/server/... ./internal/plugins/maintenance/...
+```
+
+## Acceptance criteria
+
+- [ ] `ApplyTranscriptionCandidate` no longer discards its `candTitle`/
+      `candAuthor` parameters — it compares them against the re-read cache's
+      `Candidates[0]` before applying.
+- [ ] On a title/author mismatch (simulating a cache refresh between gate
+      and apply), `ApplyTranscriptionCandidate` returns a non-nil,
+      descriptive error and does **not** call `ApplyMetadataCandidate`.
+- [ ] On a matching cache read (no concurrent refresh), behavior is
+      unchanged — `ApplyTranscriptionCandidate` still succeeds and applies
+      the candidate.
+- [ ] `maintenance.ServerDeps` interface signature is unchanged; `auto_match_transcribed.go`'s
+      call site is unchanged (it already passes the right values).
+- [ ] `SearchTranscriptionCandidate` is untouched (out of scope).
+- [ ] New/updated regression test covers both the mismatch case and the
+      matching case; `go test ./internal/server/... ./internal/plugins/maintenance/...`
+      is green; `go vet` is clean.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(server): verify gated candidate identity before apply in ApplyTranscriptionCandidate (MATCH-6/BUG-3/QUAL-3)
+
+ApplyTranscriptionCandidate discarded its candTitle/candAuthor parameters and
+re-read the metadata cache independently, applying whatever sat in
+Candidates[0] at apply time. A cache refresh between the auto-match gate and
+the apply call (concurrent metadata search, another maintenance op) could
+apply an ungated candidate while the "applied" log line still reported the
+gated title. Use the identity parameters the caller already passes to verify
+the re-read cache slot still matches before applying; error (skip + log) on
+mismatch instead of blindly applying slot 0.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-23-transcription-apply-toctou
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `ApplyTranscriptionCandidate` already compares its `candTitle`/
+`candAuthor` parameters against the re-read `Candidates[0]` before calling
+`ApplyMetadataCandidate` (i.e. the parameters are no longer named `_, _`),
+this task is done — verify with:
+```bash
+grep -n "func (s \*Server) ApplyTranscriptionCandidate" -A 20 internal/server/server_maintenance_deps.go
+```
+and confirm a title/author comparison appears between the cache unmarshal
+and the `ApplyMetadataCandidate` call. Rollback = revert the commit; the
+caller-side gates (score/title/author in `runAutoMatchTranscribed`) and
+`SearchTranscriptionCandidate` are untouched by this change and remain in
+effect either way.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-24-cover-filter-ordering.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-24-cover-filter-ordering.md
@@ -1,0 +1,223 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-24-cover-filter-ordering.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0c3dc53a-2cac-43b1-985a-4b4014b1bc66 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-24 — Cover-filter ordering: stop dropping top-scored candidates (MATCH-5 / BUG-6 / QUAL-5)
+
+**Priority:** P2 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 2 · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-24-cover-filter-ordering" -b agent/cr-24-cover-filter-ordering origin/main
+cd "$REPO/.worktrees/cr-24-cover-filter-ordering"
+git rebase origin/main
+```
+
+## Goal
+
+Stop the metadata-search cover filter from unconditionally deleting
+cover-less candidates that are strong evidence: candidates from the direct
+ASIN lookup, transcription-confirmed matches, and (at minimum) the
+single highest-scored candidate in the batch. Replace the unconditional
+hard-drop with a filter that exempts those cases, without touching how
+scoring, sorting, capping, or rerank work.
+
+## Background (verify before editing)
+
+- `internal/metafetch/service_search.go` — `SearchMetadataForBookWithOptions`
+  builds a `[]MetadataCandidate` slice from all configured sources, then
+  appends a direct ASIN-lookup result (if the query looks like/contains an
+  ASIN) as its own candidate with `Source: "Audnexus (Audible)"` and a score
+  forced to `1.0` when the computed score is `<= 0`. **Immediately after
+  that**, a cover-presence filter runs: it builds `withCover` containing only
+  candidates with non-empty `CoverURL`, and — if `withCover` is non-empty —
+  replaces `candidates` with `withCover`, unconditionally dropping every
+  cover-less candidate regardless of score. This happens **before** the
+  series-number tiebreaker, **before** `sort.Slice` by score, **before** the
+  50-cap, and **before** the optional LLM rerank (`RerankTopK`). A cover-less
+  exact match (including the ASIN candidate, which frequently has no
+  `CoverURL` from Audnexus) can therefore be deleted while a low-scored
+  wrong-book candidate with a cover survives and becomes the top (and,
+  in auto-apply paths, the auto-applied) result.
+- There is **no existing config knob** that toggles or disables this cover
+  filter (verified: `grep -rn "CoversRequired\|RequireCover\|covers_required\|require_cover"
+  internal/config internal/metafetch` returns nothing). Do not invent one —
+  just change the filter's exemption logic in place.
+- There is **no separate direct-ISBN-lookup path** in this function (ISBN is
+  only passed as search context to sources, not looked up directly the way
+  ASIN is) — despite the consultancy note mentioning "ASIN/ISBN", only the
+  ASIN direct-lookup candidate needs the identifier exemption. Identify it by
+  `c.Source == "Audnexus (Audible)"` (the literal string used at the ASIN
+  branch's candidate-construction site — re-verify below).
+- `MetadataCandidate` (in `internal/metafetch/service.go`) already carries a
+  `TranscriptionBoosted bool` field — true when the candidate matched the
+  book's Whisper-transcribed title/author/narrator. Use it as the second
+  exemption category.
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "Filter out results without cover\|var withCover\|if len(withCover) > 0\|Source: *\"Audnexus (Audible)\"\|TranscriptionBoosted: *transcriptionBoosted\|func (mfs \*Service) SearchMetadataForBookWithOptions\|sort.Slice(candidates" internal/metafetch/service_search.go
+  ```
+  Confirm the filter block still looks like:
+  ```go
+  // Filter out results without cover images — they're typically low-quality
+  // entries that clutter the results. Keep them only if ALL results lack covers.
+  var withCover []MetadataCandidate
+  for _, c := range candidates {
+      if c.CoverURL != "" {
+          withCover = append(withCover, c)
+      }
+  }
+  if len(withCover) > 0 {
+      candidates = withCover
+  }
+  ```
+  and that it runs strictly before the "Series-number tiebreaker" comment
+  block and the `sort.Slice(candidates, ...)` call.
+
+## Step-by-step
+
+1. In `internal/metafetch/service_search.go`, extract the cover-filter block
+   into a standalone, exported-from-package-but-lowercase helper function so
+   it is unit-testable in isolation:
+   ```go
+   // filterCoverlessCandidates drops candidates with no CoverURL, except:
+   //   - the direct ASIN-lookup candidate (Source == "Audnexus (Audible)"),
+   //   - any TranscriptionBoosted candidate,
+   //   - the single highest-scored candidate in the input slice.
+   // If every candidate lacks a cover, the input is returned unchanged.
+   func filterCoverlessCandidates(candidates []MetadataCandidate) []MetadataCandidate {
+       if len(candidates) == 0 {
+           return candidates
+       }
+       bestIdx := 0
+       for i := range candidates {
+           if candidates[i].Score > candidates[bestIdx].Score {
+               bestIdx = i
+           }
+       }
+       var withCover []MetadataCandidate
+       for i, c := range candidates {
+           switch {
+           case c.CoverURL != "":
+               withCover = append(withCover, c)
+           case c.Source == "Audnexus (Audible)":
+               withCover = append(withCover, c)
+           case c.TranscriptionBoosted:
+               withCover = append(withCover, c)
+           case i == bestIdx:
+               withCover = append(withCover, c)
+           }
+       }
+       if len(withCover) > 0 {
+           return withCover
+       }
+       return candidates
+   }
+   ```
+   Place it near the other small helpers in the file (e.g. next to
+   `computeDurationScore` / `durationScoreMultiplier` — re-verify their
+   location with `grep -n "^func " internal/metafetch/service_search.go`).
+2. Replace the inline filter block in `SearchMetadataForBookWithOptions` with
+   a single call: `candidates = filterCoverlessCandidates(candidates)`.
+   Do not move where in the function this call happens — it must still run
+   before the series-number tiebreaker and `sort.Slice`.
+3. Do not change `MetadataCandidate`, the ASIN-lookup branch, the
+   `TranscriptionBoosted` field, scoring, sorting, the 50-cap, or
+   `RerankTopK`. This is a pure extraction + exemption change.
+4. Add `internal/metafetch/service_search_test.go` (new file — none of the
+   existing `internal/metafetch/*_test.go` cover this filter) with table-style
+   tests calling `filterCoverlessCandidates` directly:
+   - **ASIN candidate survives:** one cover-less candidate with
+     `Source: "Audnexus (Audible)"` and `Score: 1.0`, one candidate with a
+     cover and a lower score → both candidates remain in the output.
+   - **Transcription-boosted candidate survives:** one cover-less candidate
+     with `TranscriptionBoosted: true`, one candidate with a cover and a
+     higher score → both remain.
+   - **Top-scored cover-less candidate survives even with no special flag:**
+     one cover-less candidate with the highest `Score` and no
+     `TranscriptionBoosted`/ASIN `Source`, one lower-scored candidate with a
+     cover → both remain, and the cover-less one is still present (order is
+     not asserted, only membership).
+   - **Ordinary cover-less non-top candidate is still dropped:** three
+     candidates — one with a cover (mid score), one cover-less top-scored,
+     one cover-less low-scored with no special flag → the low-scored
+     cover-less one is dropped, the other two remain (regression guard for
+     the original filter's intent).
+   - **All-coverless input is returned unchanged** (existing behavior,
+     `len(withCover) == 0` fallback path) — one or two cover-less candidates,
+     none matching any exemption → both remain untouched.
+5. Bump the file header (version bump + `last-edited`) on every file touched
+   per `.standards/instructions/file-headers.md`, including the new test
+   file.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/metafetch/... -run TestFilterCoverless -v -count=1
+go test ./internal/metafetch/... -count=1
+go vet ./internal/metafetch/...
+```
+
+## Acceptance criteria
+
+- [ ] Cover filter logic lives in a standalone `filterCoverlessCandidates`
+      function, called from `SearchMetadataForBookWithOptions` at the same
+      point in the pipeline (before the series-number tiebreaker and sort).
+- [ ] A cover-less candidate from the direct ASIN lookup
+      (`Source == "Audnexus (Audible)"`) is never dropped for lacking a cover.
+- [ ] A cover-less `TranscriptionBoosted` candidate is never dropped for
+      lacking a cover.
+- [ ] The single highest-scored candidate in the batch is never dropped for
+      lacking a cover, even without a special flag.
+- [ ] A cover-less candidate that is neither the top score nor
+      ASIN/transcription-flagged is still dropped when at least one other
+      candidate has a cover (no regression on the filter's original intent).
+- [ ] All-cover-less input is returned unchanged (existing fallback
+      preserved).
+- [ ] `go test ./internal/metafetch/...` is green; `go vet` is clean.
+- [ ] File headers bumped on every changed/added file.
+
+## Commit message
+
+```
+fix(metafetch): exempt strong-evidence candidates from cover-presence filter (MATCH-5/BUG-6)
+
+The cover filter in SearchMetadataForBookWithOptions ran after scoring but
+before sort/cap/rerank and unconditionally dropped every cover-less
+candidate whenever at least one candidate had a cover — including the
+direct ASIN-lookup candidate (Audnexus frequently omits CoverURL) and the
+single highest-scored candidate overall. Extract the filter into
+filterCoverlessCandidates and exempt ASIN-direct, TranscriptionBoosted, and
+top-scored candidates so a cosmetic preference can no longer displace the
+best-evidence match.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-24-cover-filter-ordering
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `filterCoverlessCandidates` (or an equivalently named helper) already
+exists and already exempts ASIN-direct, `TranscriptionBoosted`, and
+top-scored candidates, this task is done — verify with
+`grep -n "filterCoverlessCandidates\|Source == \"Audnexus (Audible)\"" internal/metafetch/service_search.go`
+and confirm the exemptions are present in the filter body, not just the ASIN
+branch. If the consultancy citation has drifted (e.g. the filter block has
+moved to a different file or the ASIN `Source` string literal has changed),
+re-locate it with the grep commands in Background before assuming the issue
+is already fixed. Rollback = revert the commit; this change is purely
+additive to the exemption logic and does not alter scoring, sorting, capping,
+or rerank, so reverting restores the exact prior (unconditional-drop)
+behavior with no other side effects.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-25-isgarbagevalue-substring.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-25-isgarbagevalue-substring.md
@@ -1,0 +1,184 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-25-isgarbagevalue-substring.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f5ac3df8-9d37-4ff2-954c-599e0839b139 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-25 — `IsGarbageValue` "error" substring false positives (consultancy MATCH-3)
+
+**Priority:** P2 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 2 · **Depends on:** TASK-01
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-25-isgarbagevalue-substring" -b agent/cr-25-isgarbagevalue-substring origin/main
+cd "$REPO/.worktrees/cr-25-isgarbagevalue-substring"
+git rebase origin/main
+```
+
+## Goal
+
+Fix `IsGarbageValue` in `internal/metafetch/service_scoring.go` so it no longer
+rejects legitimate titles/authors that merely contain the substring "error"
+(or other marker words) — e.g. "The Terror", "The Comedy of Errors",
+"Terrorbyte" — while still rejecting genuine garbage values ("unknown",
+empty-ish strings) and genuine HTML/error-page leaks ("403 Forbidden",
+"internal server error", raw HTML fragments from a failed fetch).
+
+## Background (verify before editing)
+
+- `IsGarbageValue(s string) bool` lives in `internal/metafetch/service_scoring.go`.
+  It lower-cases and trims the input, then does an exact-match check against a
+  blocklist (`"unknown"`, `"narrator"`, `"various"`, `"n/a"`, `"none"`,
+  `"null"`, `"undefined"`, `""`, `"test"`, `"untitled"`, `"no title"`,
+  `"no author"`, `"various authors"`, `"various artists"`) — that part is
+  already anchored to the *whole trimmed value* and is fine, do not change it.
+- The bug is the second block: it does `strings.Contains(lower, "error")` (plus
+  `"<html"`, `"<!doctype"`, `"403 forbidden"`) against the **whole string**,
+  so any legitimate title/author containing "error" as a substring —
+  "The Terror", "The Comedy of Errors", "Terrorbyte", "Erroll Garner" — is
+  incorrectly classified as garbage.
+- `IsGarbageValue` gates real behavior downstream, not just this one function:
+  - `IsBetterValue` / `IsBetterStringPtr` (same file) call `IsGarbageValue` to
+    decide whether to accept a new metadata value during apply — a false
+    positive here permanently blocks writing a real title/author.
+  - `hintsFromBook` (same file) calls `IsGarbageValue` to clean transcribed
+    title/author/narrator before transcription-boost scoring — a false
+    positive silently disables the transcription boost for that book.
+  - `service_search.go` calls `IsGarbageValue(bookAuthor)` and
+    `IsGarbageValue(bookNarrator)` to decide whether to blank those fields
+    before search — a false positive loses the author/narrator boost for that
+    search.
+  - `service_fetch.go` and `service_apply.go` also call `IsGarbageValue` at
+    several points to gate whether an existing/incoming value is usable.
+  - None of these callers need to change — fixing `IsGarbageValue` itself
+    fixes all of them, since it's the single source of truth.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func IsGarbageValue\|func IsBetterValue\|func IsBetterStringPtr\|func hintsFromBook" internal/metafetch/service_scoring.go
+  grep -rn "IsGarbageValue(" internal/metafetch/*.go
+  ```
+  Confirm the current body of `IsGarbageValue` matches what's described above
+  (exact-match blocklist loop, then a `strings.Contains` block for HTML/error
+  patterns) before editing — read the full function, do not assume the line
+  numbers in this brief are still correct.
+
+## Step-by-step
+
+1. Open `internal/metafetch/service_scoring.go`, locate `IsGarbageValue`
+   (re-verify with the grep above).
+2. Keep the existing exact-match blocklist loop over the trimmed, lowercased
+   full value unchanged.
+3. Replace the `strings.Contains(lower, "error")` check with **anchored**
+   checks that can't match inside a real title/author:
+   - Keep `strings.Contains(lower, "<html")` and
+     `strings.Contains(lower, "<!doctype")` — these are safe; no real title
+     contains a literal `<html` or `<!doctype` tag.
+   - Keep `strings.Contains(lower, "403 forbidden")` — safe for the same
+     reason (and add other literal HTTP-status phrases you find worth
+     covering, e.g. `"404 not found"`, `"500 internal server error"`, if you
+     want extra coverage — optional, not required for the acceptance
+     criteria).
+   - Replace the bare `strings.Contains(lower, "error")` with prefix/anchored
+     checks for actual error-message shapes only, such as:
+     - `strings.HasPrefix(lower, "error:")` (or `"error :"` with a space
+       before the colon, if useful)
+     - `strings.Contains(lower, "http error")`
+     - `strings.Contains(lower, "internal server error")`
+     - Do **not** add a bare `strings.Contains(lower, "error")` anywhere —
+       that is the exact defect being fixed.
+4. Update `internal/metafetch/service_test.go`'s `TestIsGarbageValue` table:
+   - The existing case `{"some error occurred", true}` is testing the buggy
+     behavior — change it to `{"some error occurred", false}` (a sentence
+     merely containing "error" is not an error-page leak and must now pass
+     through as a legitimate, non-garbage string).
+   - Add new table-driven cases that must return `false` (legitimate values
+     containing the marker substring):
+     - `{"The Terror", false}`
+     - `{"The Comedy of Errors", false}`
+     - `{"Terrorbyte", false}`
+     - `{"Erroll Garner", false}`
+   - Add new table-driven cases that must still return `true` (genuine
+     garbage/error-page leaks):
+     - `{"Error: connection refused", true}`
+     - `{"HTTP Error 500", true}` (via the `"http error"` check — adjust
+       casing/wording to match whatever anchored pattern you implement, and
+       make sure the test case actually exercises it)
+     - Keep `{"<html>something</html>", true}`, `{"<!DOCTYPE html>", true}`,
+       `{"403 Forbidden", true}` as-is — these already pass and must keep
+       passing.
+5. Grep for any other place in the repo that special-cases the string
+   `"error"` inside a garbage/value-quality check (not general error
+   handling) to make sure you're not leaving a duplicate bare-substring check
+   elsewhere:
+   ```bash
+   grep -rn 'Contains(lower, "error"\|Contains(.*"error")' internal/metafetch/
+   ```
+   If this task's target function is the only hit, no further changes are
+   needed.
+6. Bump the file header (version bump + `last-edited` date) on every file you
+   touch, per `.standards/instructions/file-headers.md` — at minimum
+   `internal/metafetch/service_scoring.go` and
+   `internal/metafetch/service_test.go`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/metafetch/... -run TestIsGarbageValue -v -count=1
+go test ./internal/metafetch/... -count=1
+go vet ./internal/metafetch/...
+```
+
+## Acceptance criteria
+
+- [ ] `IsGarbageValue("The Terror")`, `IsGarbageValue("The Comedy of Errors")`,
+      `IsGarbageValue("Terrorbyte")`, and `IsGarbageValue("Erroll Garner")` all
+      return `false`.
+- [ ] Genuine garbage/error-leak values (`"unknown"`, `"<html>...</html>"`,
+      `"<!DOCTYPE html>"`, `"403 Forbidden"`, an anchored error-message shape
+      like `"Error: connection refused"`) still return `true`.
+- [ ] No bare `strings.Contains(lower, "error")` (or equivalent) remains in
+      `IsGarbageValue`.
+- [ ] `TestIsGarbageValue` in `internal/metafetch/service_test.go` is updated
+      to cover both the false-positive fix and the still-must-reject cases,
+      and passes.
+- [ ] `go test ./internal/metafetch/...` is green; `go build ./...` and
+      `go vet ./internal/metafetch/...` are clean.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(metafetch): stop IsGarbageValue rejecting titles/authors containing "error" (MATCH-3)
+
+IsGarbageValue used a bare substring match on "error", so legitimate titles
+and authors like "The Terror" or "The Comedy of Errors" were misclassified as
+garbage — blocking metadata writes, transcription-boost hints, and
+author/narrator search boosts for any affected book. Replace the bare
+substring check with anchored error-message-shape checks (prefix "error:",
+"http error", "internal server error") that can't match inside a real title.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-25-isgarbagevalue-substring
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `IsGarbageValue` no longer contains a bare `strings.Contains(lower, "error")`
+call (verify with
+`grep -n 'Contains(lower, "error")' internal/metafetch/service_scoring.go`),
+this task is already done — confirm the anchored checks exist and the test
+table covers the "The Terror" / "Comedy of Errors" cases, then stop.
+Rollback = revert the commit; the exact-match blocklist loop and the
+`<html`/`<!doctype`/`403 forbidden` checks are untouched by this change and
+remain in effect either way.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-26-rerank-scale-normalization.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-26-rerank-scale-normalization.md
@@ -1,0 +1,254 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-26-rerank-scale-normalization.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2956a92b-2c58-4463-80ea-52e3192c0877 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-26 — LLM-rerank scale normalization (MATCH-2 / CTR-3)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet · go-backend subagent · **Wave:** 3 · **Depends on:** TASK-25
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-26-rerank-scale-normalization" -b agent/cr-26-rerank-scale-normalization origin/main
+cd "$REPO/.worktrees/cr-26-rerank-scale-normalization"
+git rebase origin/main
+```
+
+## Goal
+
+Fix the score-scale mismatch in `RerankTopK`: today it overwrites the top-K
+candidates' scores with LLM scores hard-clamped to `[0,1]`, then re-sorts the
+**whole** candidate list (top-K + untouched tail) by `Score`. The untouched
+tail carries the full unclamped multiplier stack (author ×1.5, narrator ×1.3,
+narrator-present ×1.15, series ×1.4/×2.0 — routinely 1.5–4.0, intentionally
+unclamped per this codebase's design). Any tail candidate scoring `>1.0` — not
+rare — outranks even an LLM-certain (`1.0`) reranked winner, silently
+defeating the rerank whenever that condition holds. This is dormant in prod
+today (`metadata_scoring.llm_enabled=false`) but is the first thing the
+pending local-LLM (qwen2.5:7b-instruct) toggle will activate.
+
+**Advisor-corrected framing (do not re-litigate):** the code at the
+`for i := range topCands { candidates[i].Score = llmScores[i] }` line
+*deliberately* avoids re-multiplying the LLM score by the boost stack — the
+LLM prompt already sees author/narrator/series and re-multiplying would
+double-count that evidence. That design choice is correct and must be kept.
+The defect is purely the **scale mismatch** between the now-clamped top-K and
+the never-clamped tail, not "systematic demotion." Do NOT globally clamp
+scores elsewhere in this codebase — scores exceeding 100% (i.e. `>1.0`) are
+an intentional, documented design decision used throughout matching/dedup.
+Your fix must be scoped to the rerank window only.
+
+## Background (verify before editing)
+
+- `RerankTopK` lives in `internal/metafetch/service_scoring.go`. As of this
+  writing the relevant section is around lines 576–662 (**re-verify — do not
+  trust this line number**, see grep below). Its shape:
+  1. Sort `candidates` descending by `Score`.
+  2. Compute `bestScore := candidates[0].Score` and walk forward while each
+     next candidate is within `config.AppConfig.MetadataScoring.LLMRerankEpsilon`
+     of `bestScore`, up to `LLMRerankTopK` (default 5), building `ambiguousEnd`.
+  3. `topCands := candidates[:ambiguousEnd]` — the ambiguous window to rerank.
+  4. Call `mfs.llmScorer.Score(ctx, query, llmCands)` → `llmScores []float64`,
+     each entry already clamped to `[0,1]` inside `internal/ai/llm_scorer.go`
+     (`LLMScorer.Score`, the `if score < 0 { score = 0 }` / `if score > 1 { score = 1 }`
+     block — re-verify line numbers below).
+  5. `for i := range topCands { candidates[i].Score = llmScores[i] }` —
+     **direct overwrite, no rescaling.**
+  6. Re-sort the **full** `candidates` slice (topCands + untouched tail) by
+     `Score` and return it.
+- The bug: step 6 compares clamped `[0,1]` values (steps 4–5) against
+  untouched tail values that can exceed `1.0`. There is no rescaling step.
+- The fix must rescale the LLM-derived scores back into the **original**
+  score range observed for the ambiguous window *before* the overwrite, so the
+  reranked top-K remains comparable to the never-touched tail on the same
+  unclamped scale the rest of the codebase uses. Concretely:
+  - Before overwriting anything, capture `origMax := candidates[0].Score` (the
+    window's original best) and `origMin := candidates[ambiguousEnd-1].Score`
+    (the window's original worst — still ≥ the tail's max in the common case
+    since the list was sorted descending and this window is contiguous at the
+    top, though not guaranteed if the tail itself has an inflated boost
+    outlier — that's exactly the scenario this fix targets).
+  - For each candidate `i` in `topCands`, min-max normalize its **original**
+    (pre-overwrite) `Score` into `[0,1]` relative to the window:
+    `normBase := (candidates[i].Score - origMin) / (origMax - origMin)` (guard
+    `origMax == origMin` → `normBase := 1.0` for all, since the window has no
+    internal spread).
+  - Blend the normalized base with the clamped LLM score for that candidate —
+    the LLM score is authoritative for *ranking* (it already reflects the
+    boost evidence per the existing code comment), so use it directly as the
+    blended normalized value: `normFinal := llmScores[i]`. (Do not average or
+    otherwise dilute it — a straight substitution at the normalized layer is
+    the "blend": normalize base to match the LLM's scale, then let the LLM
+    value stand in for the window's position on the *original* scale via the
+    rescale step below. This preserves the existing "don't re-multiply"
+    design intent while fixing the scale.)
+  - Rescale back into the original window's range:
+    `candidates[i].Score = origMin + normFinal*(origMax-origMin)`. This keeps
+    every reranked score within `[origMin, origMax]` — the same bounds it
+    occupied before rerank — so its position relative to the untouched tail is
+    preserved (a reranked candidate can never leap into or fall out of the
+    unclamped tail's range due to clamp mismatch alone).
+  - Everywhere else in the codebase (dedup, base scoring, boost multipliers)
+    remains untouched and unclamped — this fix is scoped entirely inside
+    `RerankTopK`.
+
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func (mfs \*Service) RerankTopK\|ambiguousEnd\|topCands\[" internal/metafetch/service_scoring.go
+  grep -n "func (s \*LLMScorer) Score\|score < 0\|score > 1" internal/ai/llm_scorer.go
+  grep -n "LLMRerankEpsilon\|LLMRerankTopK\|LLMEnabled" internal/config/config.go
+  ```
+- Confirm the exact overwrite/re-sort block still matches this brief's
+  description:
+  ```bash
+  grep -n "candidates\[i\].Score = llmScores\[i\]\|sort.SliceStable(candidates" internal/metafetch/service_scoring.go
+  ```
+- Test harness reference: `internal/metafetch/service_wiring.go` exposes
+  `(mfs *Service) SetMetadataLLMScorer(scorer ai.MetadataCandidateScorer)` to
+  inject a scorer for tests. `internal/ai/mocks` contains an exported,
+  mockery-generated `mocks.MockMetadataCandidateScorer` (see
+  `internal/ai/metadata_scorer_test.go` for usage pattern) — use that mock
+  from `internal/metafetch` tests rather than trying to reach the unexported
+  `metadataLLMBackend` interface in package `ai`. Existing rerank tests live in
+  `internal/metafetch/service_mock_test.go` under the
+  `// RerankTopK` section (`TestRerankTopK`) — extend that function, don't
+  create a parallel one.
+
+## Step-by-step
+
+1. Re-run the grep commands above and read the current body of `RerankTopK`
+   and `LLMScorer.Score` to confirm line numbers and confirm no prior fix has
+   landed (see Idempotency section).
+2. In `RerankTopK`, immediately before the
+   `for i := range topCands { candidates[i].Score = llmScores[i] }` loop,
+   capture `origMax := candidates[0].Score` and
+   `origMin := candidates[ambiguousEnd-1].Score` (both read **before** any
+   mutation — `candidates[0]` at this point is still `bestScore`, so you may
+   reuse the existing `bestScore` variable instead of re-reading
+   `candidates[0].Score` if that's cleaner).
+3. Replace the direct-overwrite loop with the rescale logic described in
+   Background: compute `normFinal := llmScores[i]` (clamped `[0,1]` — already
+   guaranteed by `LLMScorer.Score`), guard the degenerate `origMax == origMin`
+   case, and set
+   `candidates[i].Score = origMin + normFinal*(origMax-origMin)`.
+4. Leave everything else in `RerankTopK` unchanged: the ambiguous-window
+   detection, the LLM call and its error handling, the final
+   `sort.SliceStable` re-sort of the full list, and the early-return paths
+   (`len(candidates) < 2`, `mfs.llmScorer == nil`, `ambiguousEnd < 2`,
+   LLM error / length mismatch).
+5. Do NOT touch `internal/ai/llm_scorer.go`'s clamp — it is correct and
+   required as-is (`Score` must return one comparable `[0,1]` value per
+   candidate regardless of caller-side rescaling). Read it only to confirm
+   the clamp bounds you're rescaling against.
+6. Add a new subtest inside `TestRerankTopK` in
+   `internal/metafetch/service_mock_test.go` that reproduces the exact
+   boost-stacked-tail defect and proves it's fixed:
+   - Build a `Service` via `NewService(mock)` then call
+     `svc.SetMetadataLLMScorer(...)` with a `mocks.MockMetadataCandidateScorer`
+     (from `internal/ai/mocks`) configured via `.EXPECT().Score(...)` (or
+     `.On("Score", ...)`, matching the existing mockery-v3 usage pattern
+     elsewhere in the repo — check `internal/ai/metadata_scorer_test.go` for
+     the exact call shape) to return LLM scores such that the window's
+     highest-original-score candidate gets a **lower** LLM score than a
+     sibling in the window (proving the LLM reorders within the window), e.g.
+     `llmScores := []float64{0.6, 0.95}` for a 2-candidate window whose
+     original scores were `{2.0, 1.9}` (simulating a boost-stacked pair).
+   - Add a third candidate **outside** the window (the "tail") with an
+     unclamped score below `origMin` of the window (e.g. `Score: 1.5`, if
+     `origMin` in your window is `1.9`) to prove the tail does NOT leapfrog
+     the rescaled window purely due to clamp mismatch — assert the tail
+     candidate's relative position versus the window is unchanged /
+     consistent with its original score, and that both window candidates
+     still land in `[origMin, origMax]` after rerank.
+   - Assert the LLM's *preference* is honored: the candidate the LLM scored
+     higher (`0.95`) ends up with a higher final `Score` than the sibling
+     scored `0.6`, and both final scores lie within `[origMin, origMax]`
+     (e.g. `assert.InDelta` / range assertions, not exact floats, since the
+     rescale is a linear map you're allowed to state as a formula in the
+     test).
+   - Keep the three existing subtests (`no_llm_scorer`, `single_candidate`,
+     `empty_candidates`) passing unchanged — they exercise the early-return
+     paths this change does not touch.
+7. Bump the file header (version bump + `last-edited`) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/metafetch/... -run TestRerankTopK -v -count=1
+go test ./internal/metafetch/... -count=1
+go test ./internal/ai/... -count=1
+go vet ./internal/metafetch/... ./internal/ai/...
+```
+
+## Acceptance criteria
+
+- [ ] `RerankTopK` no longer directly overwrites `topCands[i].Score` with a
+      raw clamped LLM score; the assigned score is rescaled into the window's
+      original `[origMin, origMax]` range.
+- [ ] The LLM's relative preference among `topCands` is preserved after
+      rescale (higher LLM score → higher final `Score`, within the window).
+- [ ] A boost-stacked tail candidate (score `>1.0`, outside the rerank
+      window) is not spuriously outranked-or-outranking purely due to the
+      clamp/unclamp scale mismatch — new test demonstrates this concretely.
+- [ ] `internal/ai/llm_scorer.go`'s `[0,1]` clamp is unchanged — no global
+      clamping introduced anywhere else in the codebase (dedup, base scoring,
+      boost multipliers all remain intentionally unclamped).
+- [ ] The three pre-existing `TestRerankTopK` subtests
+      (`no_llm_scorer`, `single_candidate`, `empty_candidates`) still pass
+      unmodified.
+- [ ] `go test ./internal/metafetch/...` and `go test ./internal/ai/...` are
+      green; `go vet` clean on both packages.
+- [ ] File headers bumped on every changed file.
+
+## Commit message
+
+```
+fix(metafetch): rescale LLM rerank scores into original window range (MATCH-2)
+
+RerankTopK overwrote the ambiguous top-K's scores with LLM scores hard-clamped
+to [0,1], then re-sorted against an untouched tail carrying the full unclamped
+boost-multiplier stack (routinely 1.5-4.0, intentionally unclamped by design).
+Any tail candidate scoring >1.0 could outrank even an LLM-certain (1.0)
+reranked winner. Rescale the clamped LLM score back into the window's original
+[origMin, origMax] range before re-sorting, preserving the LLM's relative
+ranking within the window while keeping it comparable to the never-touched
+tail on the same scale. Dormant today (llm_enabled=false) but is the first
+thing the pending local-LLM toggle activates.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-26-rerank-scale-normalization
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `RerankTopK` already rescales the LLM score into the ambiguous window's
+original range (or otherwise demonstrably keeps reranked top-K scores
+comparable to the untouched tail's unclamped scale — e.g. via a documented
+per-tier normalized confidence, per the CTR-3 recommendation in
+`docs/consultancy/04-code-quality.md`) rather than assigning the raw clamped
+`[0,1]` LLM score directly to `candidates[i].Score`, this task is done —
+verify with:
+```bash
+grep -n "candidates\[i\].Score = llmScores\[i\]\|origMin\|origMax" internal/metafetch/service_scoring.go
+```
+If the direct-overwrite line (`candidates[i].Score = llmScores[i]`) is gone
+and replaced by a rescale expression, no further work is needed — just
+confirm the new `TestRerankTopK` boost-stacked-tail subtest (or an equivalent
+one) already exists; if it does not, add it per Step 6 as a standalone
+follow-up without touching the (already-fixed) production code.
+
+Rollback = revert the commit; `LLMScorer.Score`'s `[0,1]` clamp and every
+other scoring path (dedup, base scoring, boost multipliers) are untouched by
+this change and remain in effect either way.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-27-levenshtein-runes.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-27-levenshtein-runes.md
@@ -1,0 +1,164 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-27-levenshtein-runes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8843eb55-093b-4afa-85bc-f4e2bd909924 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-27 — Rune-based Levenshtein for non-ASCII titles (consultancy MATCH-9)
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-27-levenshtein-runes" -b agent/cr-27-levenshtein-runes origin/main
+cd "$REPO/.worktrees/cr-27-levenshtein-runes"
+git rebase origin/main
+```
+
+## Goal
+
+Fix consultancy finding MATCH-9: `LevenshteinDistance` in
+`internal/matcher/fuzzy.go` indexes and measures strings as **bytes**, while
+`normalize` deliberately preserves all Unicode letters/digits. Accented
+(e.g. "Émile Zola") or CJK titles have characters that are 2-4 bytes each, so
+a single substituted character counts as up to 4 edits, and `len()`-based
+length ratios are byte-inflated. This skews fuzzy-match scores low and
+asymmetric for non-ASCII titles/authors versus their ASCII-folded forms.
+Convert the distance computation and its length-based callers to operate on
+`[]rune`, not bytes.
+
+## Background (verify before editing)
+
+- `LevenshteinDistance(a, b string) int` in `internal/matcher/fuzzy.go`
+  currently does `strings.ToLower`, then uses `len(a)`/`len(b)` (byte length)
+  for the DP grid dimensions, and indexes `a[i-1]`/`b[j-1]` as raw bytes
+  inside the double loop. Any multi-byte UTF-8 rune therefore contributes
+  multiple "positions" to the DP matrix instead of one.
+- `ScoreMatch(query, target string) int` calls `normalize()` first (which
+  keeps all Unicode letters/digits/spaces — no ASCII-only assumption), then:
+  - a substring-match length ratio: `ratio := float64(len(q)) / float64(len(t))`
+    — byte length, same bias.
+  - a whole-string fuzzy pass: `dist := LevenshteinDistance(q, t)` followed by
+    `maxLen := max(len(q), len(t))` — byte length again, mismatched against
+    rune-based `dist` if you fix `LevenshteinDistance` alone without also
+    fixing this call site.
+  - a per-word fuzzy pass: `dist := LevenshteinDistance(q, w)` followed by
+    `wLen := max(len(q), len(w))` — same byte-length issue.
+  - `normalize(s string) string` already iterates `for _, r := range s` (runes)
+    and is unaffected — no change needed there.
+- **Re-verify these anchors before editing** — line numbers drift:
+  ```bash
+  grep -n "func LevenshteinDistance\|func ScoreMatch\|func normalize\|ratio :=\|dist := LevenshteinDistance\|maxLen :=\|wLen :=" internal/matcher/fuzzy.go
+  ```
+  As of this writing (verified against a fresh checkout):
+  - `func LevenshteinDistance` at line 19 (body through ~46).
+  - `func ScoreMatch` at line 51.
+  - substring ratio (`ratio := ...`) at line 77.
+  - whole-string `dist :=` / `maxLen :=` at lines 92-93.
+  - per-word `dist :=` / `wLen :=` at lines 105-106.
+  - `func normalize` at line 140.
+  If these don't match, trust the grep output over this brief.
+
+## Step-by-step
+
+1. In `internal/matcher/fuzzy.go`, rewrite `LevenshteinDistance` to convert
+   both inputs to `[]rune` right after lowercasing (`ra := []rune(a)`,
+   `rb := []rune(b)`), use `len(ra)`/`len(rb)` for the DP dimensions, and index
+   `ra[i-1]`/`rb[j-1]` in the comparison — do not change the function
+   signature (still `func LevenshteinDistance(a, b string) int`) or the
+   single-row DP algorithm shape, only the byte-vs-rune indexing.
+2. In `ScoreMatch`, fix the three length-ratio call sites so they use rune
+   counts consistent with the (now rune-based) `LevenshteinDistance` result:
+   - Substring ratio at ~line 77: replace `len(q)`/`len(t)` with
+     `len([]rune(q))`/`len([]rune(t))` (or precompute rune slices once near
+     the top of `ScoreMatch` and reuse them — either is fine, prefer whichever
+     keeps the diff smallest).
+   - Whole-string `maxLen` at ~line 93: replace `len(q)`/`len(t)` with rune
+     counts.
+   - Per-word `wLen` at ~line 106: replace `len(q)`/`len(w)` with rune counts.
+   - Leave `strings.HasPrefix`, `strings.Contains`, and `strings.Fields`
+     untouched — those are correctness-neutral for this bug (Go's UTF-8
+     string operations already work correctly at the byte level for these;
+     only length/index arithmetic was wrong).
+3. Do not change `normalize` — it already iterates by rune and needs no fix.
+4. Add test cases (extend `TestLevenshteinDistance` and/or `TestScoreMatch` in
+   `internal/matcher/fuzzy_test.go`, matching the existing table-driven style)
+   covering:
+   - An accented pair, e.g. `LevenshteinDistance("Émile Zola", "Emile Zola")`
+     — before the fix this counts as 2 edits (byte-level diff of "É" (2
+     bytes) vs "E" (1 byte)); after the fix it must be exactly `1` (one rune
+     substituted).
+   - A CJK pair, e.g. `LevenshteinDistance("東京", "東京都")` (Tokyo vs Tokyo-to)
+     — must be `1` (one rune inserted), not `3` (byte-inflated).
+   - A mixed ASCII/non-ASCII pair to confirm no regression on plain ASCII
+     inputs, e.g. `LevenshteinDistance("kitten", "sitting")` must still be `3`
+     (this case already exists in the table — keep it passing).
+   - A `ScoreMatch` case demonstrating the ratio fix doesn't crash or
+     misbehave on non-ASCII input, e.g.
+     `ScoreMatch("Zola", "Émile Zola")` returns a sane positive score (assert
+     it's `> 0`, not an exact byte-sensitive value, to keep the test robust).
+   Benchmarks are optional — do not add one unless it's trivial.
+5. Bump the file header (version + `last-edited`) on every file you touch
+   per `.standards/instructions/file-headers.md` — that's `internal/matcher/fuzzy.go`
+   and `internal/matcher/fuzzy_test.go`.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/matcher/... -run . -v -count=1
+go vet ./internal/matcher/...
+```
+
+## Acceptance criteria
+
+- [ ] `LevenshteinDistance` computes distance over `[]rune`, not bytes, for
+      both inputs.
+- [ ] `ScoreMatch`'s substring ratio, whole-string `maxLen`, and per-word
+      `wLen` all use rune counts consistent with the rune-based distance.
+- [ ] `LevenshteinDistance("Émile Zola", "Emile Zola") == 1` (not 2).
+- [ ] A CJK insertion/deletion case (e.g. "東京" vs "東京都") returns `1`
+      (not byte-inflated to 3).
+- [ ] Existing ASCII cases (e.g. `"kitten"`/`"sitting"` == 3) still pass
+      unchanged — no regression on ASCII-only libraries.
+- [ ] `go test ./internal/matcher/...` is green; `go vet` is clean.
+- [ ] File headers bumped on both changed files.
+
+## Commit message
+
+```
+fix(matcher): compute Levenshtein distance over runes, not bytes (MATCH-9)
+
+LevenshteinDistance indexed strings as bytes while normalize() preserves all
+Unicode letters/digits, so accented and CJK titles counted each multi-byte
+character as up to 4 edits, skewing fuzzy-match scores low and asymmetric for
+non-ASCII titles/authors. Convert the DP loop and ScoreMatch's length ratios
+to operate on rune counts.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-27-levenshtein-runes
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `LevenshteinDistance` already converts to `[]rune` before the DP loop (or
+if `ScoreMatch`'s ratio/maxLen/wLen calculations already use rune counts),
+this task is done — verify with
+`grep -n "\[\]rune" internal/matcher/fuzzy.go` and confirm rune conversion
+appears both inside `LevenshteinDistance` and at the three length-ratio call
+sites in `ScoreMatch` (not just one or the other — a partial fix that
+runifies the distance but leaves `maxLen`/`wLen`/`ratio` on byte `len()` is
+still buggy, since rune-based distances compared against byte-based lengths
+produce nonsensical similarity ratios). Rollback = revert the commit; this
+change touches only distance/length arithmetic, no signatures, no callers
+outside this file are affected (`ScoreMatch`, `RankResults` signatures
+unchanged).

--- a/docs/agent-tasks/consultancy-roadmap/TASK-28-doc-drift-cleanup.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-28-doc-drift-cleanup.md
@@ -1,0 +1,345 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-28-doc-drift-cleanup.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 17de70d5-3c21-4056-8d1b-d0143ad494ac -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-28 — Doc-drift cleanup (AI-REFERENCE, pebble-schema duplicate, mockery pins)
+
+**Priority:** P2 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 1 · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-28-doc-drift-cleanup" -b agent/cr-28-doc-drift-cleanup origin/main
+cd "$REPO/.worktrees/cr-28-doc-drift-cleanup"
+git rebase origin/main
+```
+
+## Goal
+
+Fix four independently-verified doc-drift defects (consultancy findings
+PROC-3, PROC-5, ARCH-4, SYS-6). This is a **pure docs task** — no Go code
+changes, no behavior changes. Every claim below was verified against the
+current codebase on 2026-07-03; **re-verify with the grep commands given**
+before editing, because line numbers drift.
+
+1. `docs/AI-REFERENCE.md` header route count is stated as 189 but the real
+   count (grep of gin route registrations) is ~395, and the file never
+   mentions the Ollama/bge-m3 local-embedding cutover — it still presents
+   OpenAI as the AI/embedding backend in three places.
+2. `docs/AI-REFERENCE.md` contradicts itself: line 53 says the embedding/dedup
+   store lives in "a separate PebbleDB"; line 357 correctly says it lives
+   "within the main audiobooks.pebble DB". Code confirms the keyspace is
+   **shared**, not separate.
+3. `docs/database-pebble-schema.md` physically contains the entire document
+   concatenated twice (a second `# PebbleDB Keyspace Schema and Data Model`
+   header appears partway through, HTML-entity-corrupted in spots), and its
+   "Conventions" section claims all entity IDs are ULID strings — production
+   code actually uses integer IDs (`author:%d`, `book:%d`) for those entities.
+   The **one part of the duplicated block that IS accurate** is the "Dedup /
+   Embedding store" subsection (id16hex-keyed `dedup:`/`emb:` candidates) —
+   that subsection only exists in the second (duplicate) copy and must be
+   preserved, not deleted with the rest.
+4. Two docs under `docs/agent-tasks/ci-flaky-fixes/` still teach agents that
+   CI pins mockery at `v2.53.6` (`go install .../mockery/v2@v2.53.6`). CI,
+   the Makefile, and `scripts/setup-mockery.sh` have pinned `v3.7.1` since PR
+   #1718 (2026-07-01, "Mock Freshness" — already ✅ FIXED per TODO.md). An
+   agent following either doc verbatim would reintroduce the exact
+   repo-wide-mock-churn footgun the docs warn about.
+
+## Background (verify before editing)
+
+**Re-verify every claim below before touching a file — do not trust the line
+numbers here, they are a snapshot from 2026-07-03.**
+
+### 1 & 2 — `docs/AI-REFERENCE.md`
+
+```bash
+grep -n "Total API routes\|Last updated" docs/AI-REFERENCE.md
+grep -c '\.GET(\|\.POST(\|\.PUT(\|\.DELETE(\|\.PATCH(' internal/server/*.go
+grep -rn '\.GET(\|\.POST(\|\.PUT(\|\.DELETE(\|\.PATCH(' --include='*.go' internal/server | grep -v _test.go | wc -l
+grep -n "OpenAI API\|OpenAIParser\|OpenAI batch API" docs/AI-REFERENCE.md
+grep -n "separate PebbleDB for embeddings\|within the main audiobooks.pebble DB" docs/AI-REFERENCE.md
+grep -n "func NewEmbeddingStore\|func (p \*PebbleStore) DB(" internal/database/embedding_store.go internal/database/pebble_store.go
+grep -n "NewEmbeddingStore(ps.DB())" internal/server/registry_wire.go
+```
+
+As of this writing:
+- `docs/AI-REFERENCE.md:6` says `**Total API routes**: 189`. The real count
+  (non-test `.GET/.POST/.PUT/.DELETE/.PATCH` registrations under
+  `internal/server`) is **395**. Do not hardcode a new magic number that will
+  drift again — replace it with a pointer to how to compute it.
+- `docs/AI-REFERENCE.md:31, 85, 451` mention OpenAI as the AI/embedding
+  backend (`→ AI parser → OpenAI API`, `OpenAIParser` method list, "AUTHOR
+  dedup via OpenAI batch API"). None of these are wrong on their own (the
+  `OpenAIParser` type still exists and is still used for some flows) — but the
+  doc has **zero** mention of Ollama or bge-m3, even though
+  `internal/ai/embedding_client.go`, `internal/database/hnsw_embedding_store.go`,
+  `internal/dedup/engine.go`, and `internal/server/registry_wire.go` all
+  reference `ollama`/`bge-m3` for the current embedding backend (per the local
+  embeddings cutover). The doc is silently incomplete, not necessarily
+  factually wrong about what remains of OpenAI usage — do not delete the
+  OpenAI mentions, add the missing Ollama/bge-m3 context alongside them.
+- `docs/AI-REFERENCE.md:53` — `EmbeddingStore` "wrapping **a separate
+  PebbleDB**". `docs/AI-REFERENCE.md:357` — the `emb:`/`dedup:` keyspace is
+  "**within the main audiobooks.pebble DB**". These two lines contradict each
+  other in the same file. Verified in code: `registry_wire.go:69` constructs
+  it as `database.NewEmbeddingStore(ps.DB())`, and `PebbleStore.DB()`
+  (`internal/database/pebble_store.go`) returns the store's own live
+  `*pebble.DB` handle — i.e. the SAME database file as everything else, not a
+  second one. Line 357 is correct; line 53 is the drift. Fix line 53 only —
+  do not touch line 357's wording (it's already right), just make sure the two
+  don't disagree after your edit.
+
+### 3 — `docs/database-pebble-schema.md`
+
+```bash
+grep -n "^# PebbleDB Keyspace Schema and Data Model\|^## Dedup / Embedding store\|^## Conventions" docs/database-pebble-schema.md
+wc -l docs/database-pebble-schema.md
+grep -n "ULID strings" docs/database-pebble-schema.md
+grep -n "id16hex" docs/database-pebble-schema.md
+```
+
+As of this writing, the file is 645 lines and the top-level header
+`# PebbleDB Keyspace Schema and Data Model` appears **twice**: once at line 6
+(the file's real start) and again at line 317, i.e. the whole document is
+concatenated with itself starting around line 311/312. The second copy has
+HTML-entity corruption in places (literal `&lt;`/`&gt;` instead of `<`/`>`,
+and its own embedded stray file-header comment block around line 311-314).
+
+**Do not blindly delete lines 312-645.** The second copy is not a pure
+redundant repeat — it contains one section the first copy is missing
+entirely: `## Dedup / Embedding store (within the main audiobooks.pebble DB)`
+(around line 561-599 as of this writing), covering the `emb:`/`dedup:`
+keyspace with `id16hex` (`fmt.Sprintf("%016x", uint64(candidateID))`)
+zero-padded hex keys. This subsection is the **one part of the whole
+document verified accurate against code** (`internal/database/embedding_store.go`,
+`internal/dedup/engine.go`). Everything else in the file (both copies) — the
+`## Conventions` section's "IDs: ULID strings (26-char Crockford base32)" and
+the ULID-keyed `a:`/`b:`/`u:`/`s:`/`w:` prefixes in `## Key prefixes` — was
+**never implemented**; production code uses integer IDs (verify below).
+
+```bash
+grep -n 'LowerBound: \[\]byte("author:0")\|LowerBound: \[\]byte("book:0")' internal/database/pebble_store.go
+grep -n 'fmt.Sprintf("author:%d"\|fmt.Sprintf("book:%d"' internal/database/pebble_store.go
+```
+
+Confirms `internal/database/pebble_store.go` uses `author:%d` / `book:%d`
+integer-keyed prefixes with ASCII-range iteration bounds (`"author:0"` ..
+`"author:;"`), not ULID strings.
+
+`docs/database-architecture.md` (around lines 17-27) calls
+`database-pebble-schema.md` "canonical for any new feature touching
+persistence" — re-verify with:
+```bash
+grep -n "canonical for any new feature" docs/database-architecture.md
+```
+
+### 4 — mockery version docs
+
+```bash
+grep -rn "2.53.6" docs/agent-tasks/ci-flaky-fixes/
+grep -n "Install mockery\|mockery/v3@v3.7.1" .github/workflows/ci.yml
+grep -n "MOCKERY_VERSION" scripts/setup-mockery.sh
+grep -n "mock-freshness\|Mock Freshness" TODO.md
+```
+
+As of this writing, CI (`.github/workflows/ci.yml`, "Install mockery" step)
+and `scripts/setup-mockery.sh` both pin `v3.7.1` (module
+`github.com/vektra/mockery/v3`), and TODO.md's "Mock Freshness" entry is
+marked `✅ FIXED (#1718, 2026-07-01)`. But
+`docs/agent-tasks/ci-flaky-fixes/README.md` and
+`docs/agent-tasks/ci-flaky-fixes/TASK-01-mockery-pin.md` both still instruct
+`go install github.com/vektra/mockery/v2@v2.53.6` and describe the v2/v3 pin
+drift as an open problem to fix. `TASK-01` in that workstream is the exact
+"mock-freshness" task TODO.md says is already done.
+
+Note: `docs/agent-tasks/ci-flaky-fixes/README.md`'s existing header comment is
+itself HTML-entity-corrupted (`&lt;!-- file: ... --&gt;` instead of
+`<!-- file: ... -->`) — when you bump its header per file-headers.md, write it
+with real `<!--`/`-->` delimiters, which fixes this incidentally.
+
+## Step-by-step
+
+1. **`docs/AI-REFERENCE.md`**:
+   - Re-run the route-count grep from Background. Replace the hardcoded route
+     count in the header line with either the freshly-verified number or (
+     preferred, so it can't drift again) a phrase like "**Total API routes**:
+     see `grep -rn '\.GET(\|\.POST(\|\.PUT(\|\.DELETE(\|\.PATCH(' --include='*.go' internal/server | grep -v _test.go | wc -l`
+     for current count (~395 as of 2026-07-03)".
+   - Fix line 53 (`EmbeddingStore` description) to say the store is backed by
+     "the main audiobooks.pebble DB" (or equivalent wording), matching line
+     357. Do not edit line 357.
+   - Add a short new subsection (near the existing AI-integration section
+     around line 85, or immediately after it) titled something like
+     "Embedding/LLM backends" documenting: Ollama is the primary local
+     embedding + LLM backend (bge-m3, 1024-dim vectors; see
+     `internal/ai/embedding_client.go`, `internal/dedup/engine.go`,
+     `internal/database/hnsw_embedding_store.go`); OpenAI (`OpenAIParser`,
+     `internal/ai/openai_parser.go`) remains in use for the flows already
+     documented nearby — do not claim OpenAI was fully removed, only that
+     Ollama is the current embedding/LLM path added on top of it. Keep it to a
+     few lines; this is a pointer, not a full rewrite.
+   - Bump the file header (version + `last-edited`).
+
+2. **`docs/database-pebble-schema.md`**:
+   - Re-run the header-count and Dedup-section greps from Background to
+     locate the current duplicate boundary and the `## Dedup / Embedding
+     store` subsection's exact current line range — the ranges here (312-645,
+     561-599) are 2026-07-03 snapshots and may have shifted if anyone touched
+     the file since.
+   - Copy the entire `## Dedup / Embedding store (within the main
+     audiobooks.pebble DB)` subsection (including its `### Embedding
+     keyspace`, `### Dedup candidate keyspace`, `### Labeled dataset
+     keyspace` children, and the `id16hex` explanation paragraph) out of the
+     duplicate block.
+   - Delete the whole duplicate block (the second copy of the document,
+     starting at its repeated `# PebbleDB Keyspace Schema and Data Model`
+     header through end-of-file), **except** for the section you just copied
+     out.
+   - Insert the copied `## Dedup / Embedding store` section into the
+     first (retained) copy, placed after its `## Query patterns` section and
+     before `## Write patterns & atomicity` (matching where it sits in the
+     original second copy, relative to the sections that already exist once
+     in the first copy).
+   - In the `## Conventions` section (first copy, "IDs: ULID strings..."
+     bullet), add a clarifying note that this ULID design was never
+     implemented for the core entities — production code uses integer IDs
+     (`author:%d`, `book:%d`, etc., see `internal/database/pebble_store.go`)
+     — and that the `## Dedup / Embedding store` section's `id16hex` keys are
+     the one part of this document that matches the live schema. Do not
+     attempt to rewrite the rest of the document's ULID-based entity sections
+     to match reality in this task — that is a much larger regeneration
+     effort (tracked separately per the consultancy recommendation); this task
+     only removes the corrupted duplicate and adds an accurate caveat.
+   - Confirm the file no longer contains a second top-level `#
+     PebbleDB Keyspace Schema and Data Model` header and no `&lt;`/`&gt;`
+     entity artifacts remain (`grep -c '&lt;\|&gt;' docs/database-pebble-schema.md`
+     should be `0`).
+   - Bump the file header (version + `last-edited`).
+
+3. **`docs/database-architecture.md`**:
+   - Re-verify with `grep -n "canonical for any new feature"
+     docs/database-architecture.md`.
+   - Add one short caveat sentence next to the existing "canonical for any
+     new feature touching persistence" claim, noting that the linked doc's
+     entity-ID convention (ULID) does not match the current integer-ID
+     implementation, and pointing at the `## Dedup / Embedding store` section
+     of that doc as the part that IS verified accurate. Keep this to 1-2
+     sentences — do not restructure the file.
+   - Bump the file header (version + `last-edited`).
+
+4. **`docs/agent-tasks/ci-flaky-fixes/README.md`** and
+   **`docs/agent-tasks/ci-flaky-fixes/TASK-01-mockery-pin.md`**:
+   - Re-run `grep -rn "2.53.6" docs/agent-tasks/ci-flaky-fixes/` to confirm
+     current occurrences.
+   - In both files, replace every `mockery/v2@v2.53.6` reference (install
+     commands, prose, commit-message text, idempotency-check text) with the
+     current pin: `go install github.com/vektra/mockery/v3@v3.7.1` /
+     `v3.7.1` (module `github.com/vektra/mockery/v3`), matching
+     `.github/workflows/ci.yml`'s "Install mockery" step and
+     `scripts/setup-mockery.sh`.
+   - Since TODO.md already marks "Mock Freshness" ✅ FIXED (#1718), add a note
+     at the top of `README.md`'s TASK-01 table row (or directly above it)
+     stating TASK-01 is already done/superseded by #1718 and should be
+     treated as archived — do not remove the row (keep it as workstream
+     history) but make it clearly not-actionable for a new agent. Do the same
+     at the top of `TASK-01-mockery-pin.md` (a one-line "DONE — see #1718"
+     banner near the title is sufficient; do not delete the rest of the file's
+     content, it remains useful history).
+   - When bumping `README.md`'s file header, write plain `<!-- ... -->`
+     comment delimiters (fixing the pre-existing `&lt;!--`/`--&gt;`
+     entity-corruption noted in Background as a side effect).
+   - Bump the file header (version + `last-edited`) on both files.
+
+## How to test
+
+This is a docs-only change — no Go build/test coverage applies to prose, but
+confirm nothing else broke:
+
+```bash
+go build ./...
+go vet ./...
+grep -c "PebbleDB Keyspace Schema and Data Model" docs/database-pebble-schema.md   # expect: 1
+grep -c '&lt;\|&gt;' docs/database-pebble-schema.md                                # expect: 0
+grep -c '&lt;\|&gt;' docs/agent-tasks/ci-flaky-fixes/README.md                     # expect: 0
+grep -n "v2.53.6" docs/agent-tasks/ci-flaky-fixes/README.md docs/agent-tasks/ci-flaky-fixes/TASK-01-mockery-pin.md   # expect: no matches
+grep -n "id16hex" docs/database-pebble-schema.md                                   # expect: still present
+grep -n "separate PebbleDB" docs/AI-REFERENCE.md                                   # expect: no matches
+```
+
+## Acceptance criteria
+
+- [ ] `docs/AI-REFERENCE.md` header route count is no longer the stale `189`
+      (either a corrected number or a self-updating pointer/grep command).
+- [ ] `docs/AI-REFERENCE.md` no longer says the embedding store lives in "a
+      separate PebbleDB"; it matches the (unedited) line 357 claim that it's
+      in the main audiobooks.pebble DB.
+- [ ] `docs/AI-REFERENCE.md` has a new short section mentioning
+      Ollama/bge-m3 as the current embedding/LLM backend, without deleting
+      the existing (still-valid) OpenAI mentions.
+- [ ] `docs/database-pebble-schema.md` contains exactly one copy of the
+      document (one `# PebbleDB Keyspace Schema and Data Model` header) and
+      zero `&lt;`/`&gt;` entity-corruption artifacts.
+- [ ] `docs/database-pebble-schema.md` still contains the `## Dedup /
+      Embedding store` section with its `id16hex` explanation — it was
+      preserved, not deleted along with the rest of the duplicate block.
+- [ ] `docs/database-pebble-schema.md`'s `## Conventions` section now notes
+      the ULID entity-ID design was never implemented (production uses
+      integer IDs) and that the Dedup/Embedding section is the verified-
+      accurate part.
+- [ ] `docs/database-architecture.md` has a short caveat next to its
+      "canonical" claim pointing out the ULID/integer-ID mismatch.
+- [ ] Neither `docs/agent-tasks/ci-flaky-fixes/README.md` nor
+      `docs/agent-tasks/ci-flaky-fixes/TASK-01-mockery-pin.md` mentions
+      `v2.53.6`/`mockery/v2` as the pin anymore; both reference `v3.7.1`
+      (`mockery/v3`), matching CI/Makefile/setup script.
+- [ ] Both mockery docs clearly flag TASK-01/mock-freshness as already done
+      (#1718) rather than presenting it as open work.
+- [ ] `go build ./...` and `go vet ./...` still pass (should be unaffected —
+      docs-only change; this just confirms nothing else in the worktree is
+      broken).
+- [ ] File headers bumped on every changed file: `docs/AI-REFERENCE.md`,
+      `docs/database-pebble-schema.md`, `docs/database-architecture.md`,
+      `docs/agent-tasks/ci-flaky-fixes/README.md`,
+      `docs/agent-tasks/ci-flaky-fixes/TASK-01-mockery-pin.md`.
+
+## Commit message
+
+```
+docs: fix AI-REFERENCE drift, dedupe pebble-schema doc, update mockery pins (consultancy-roadmap)
+
+AI-REFERENCE.md had a stale ~2x-off route count, no mention of the Ollama/
+bge-m3 local-embedding cutover, and a self-contradiction on where the dedup/
+embedding keyspace lives. database-pebble-schema.md contained a corrupted
+duplicate of itself with a never-implemented ULID key convention; the
+duplicate is removed while preserving its one verified-accurate section
+(id16hex-keyed dedup/embedding candidates). Two ci-flaky-fixes docs still
+taught the old mockery v2.53.6 pin after CI/Makefile moved to v3.7.1 (#1718),
+risking a repeat of the exact mock-churn footgun they warn about.
+
+Co-Authored-By: Claude Haiku <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-28-doc-drift-cleanup
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, re-run the Background greps. If
+`docs/database-pebble-schema.md` already has only one top-level header and no
+`&lt;`/`&gt;` artifacts, if `docs/AI-REFERENCE.md`'s route count and
+embedding-store description already match code, and if neither mockery doc
+mentions `v2.53.6`, this task is already done — do not re-edit, just confirm
+and stop. If any single sub-item (e.g. only the mockery docs) is already
+fixed but others aren't, do only the remaining sub-items — each of the four
+fixes is independent and can be committed/skipped separately without
+affecting the others. Rollback = revert the commit; this is a pure docs
+change with no runtime or schema effect, so revert is always safe.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-29-coverage-gate-strengthen.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-29-coverage-gate-strengthen.md
@@ -1,0 +1,275 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-29-coverage-gate-strengthen.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e5aaaade-6f38-4b18-91a7-5567dcbdce77 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-29 — Strengthen the 30% coverage gate (consultancy-roadmap, PROC-4)
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** Haiku · **Wave:** 2 · **Depends on:** TASK-08
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-29-coverage-gate-strengthen" -b agent/cr-29-coverage-gate-strengthen origin/main
+cd "$REPO/.worktrees/cr-29-coverage-gate-strengthen"
+git rebase origin/main
+```
+
+**Wave note:** This task is Wave 2 (not Wave 1) because TASK-08 also edits the
+`Makefile`. Do not start this task's worktree until TASK-08 has merged to
+`main` and you have rebased onto the latest `origin/main` (the `git rebase
+origin/main` step above will fail loudly with conflict markers if TASK-08
+hasn't landed yet — if that happens, stop and re-fetch/re-check rather than
+resolving Makefile conflicts blind).
+
+## Goal
+
+Fix `coverage-check-short` in the `Makefile` so it:
+
+1. Does **not** re-run the entire test suite a second time just to measure
+   coverage (today it runs `go test ./...` once via `test-short` inside `ci`,
+   then runs `go test ./...` again inside `coverage-check-short` — doubling
+   `make ci` wall time).
+2. Does **not** swallow test/compile failures silently (`>/dev/null 2>&1`
+   currently hides all diagnostics when the coverage run itself fails).
+3. Prints the per-package coverage summary to CI output, not just the total.
+4. Keeps the 30% floor, but adds a lightweight ratchet: a committed
+   coverage-floor value that can only be raised, plus a WARN (non-failing) when
+   the just-measured total coverage drops versus the last recorded value.
+5. Leaves `make ci` wall-clock time flat or better (the whole point is
+   eliminating the duplicate test run).
+
+## Background (verify before editing)
+
+- The consultancy finding (PROC-4, `docs/consultancy/06-process-and-security.md`)
+  cites `Makefile:309-318` and `Makefile:321`. As of this writing (verify
+  yourself — line numbers drift) the relevant targets are:
+  - `test-short` (around line 173) runs `go test ./... -short -race` — no
+    coverprofile, not swallowed.
+  - `test-all-short` (around line 251-252) = `test-short web-test`.
+  - `coverage-check-short` (around line 308-318) independently re-runs
+    `go test ./... -short -coverprofile=coverage.out -covermode=atomic
+    >/dev/null 2>&1`, then greps `go tool cover -func=coverage.out` for the
+    `total` line and compares against a hardcoded `30`.
+  - `ci` (around line 321): `ci: mocks-check check-mock-fresh staticcheck
+    sdkguard test-all-short coverage-check-short` — this is exactly the
+    "duplicate test run" PROC-4 describes: `test-all-short` already runs
+    `go test ./... -short -race` once (via `test-short`), then
+    `coverage-check-short` runs `go test ./... -short` a second time (with
+    `-coverprofile` instead of `-race`) purely to get a coverage number.
+  - There is a separate `coverage-check` (around line 296-306, full suite, no
+    `-short`) used by `test-nightly` (around line 255) — do NOT touch this one
+    unless you also fix the analogous duplication there; this task is scoped
+    to the `-short`/`ci` path only per the finding. If you have time, apply the
+    same profile-reuse pattern to `coverage-check`/`test-nightly` too, but it
+    is not required for acceptance.
+  - There is no existing coverage-floor/baseline file anywhere in the repo
+    (verified: no `.coverage-floor`, `.coverage-baseline`, or similar file
+    exists as of this writing). You are creating this convention fresh — do
+    not assume a prior format to match.
+
+- **Re-verify these anchors before editing** — line numbers in this brief and
+  in the consultancy doc are from 2026-07-02/03 and may have drifted, and
+  TASK-08 (which runs first) also touches this file:
+  ```bash
+  grep -n "^test-short:\|^test-all-short:\|^coverage-check-short:\|^coverage-check:\|^ci:\|^test-nightly:" Makefile
+  ```
+  Read the full body of `coverage-check-short` and `ci` before changing
+  anything:
+  ```bash
+  sed -n '/^coverage-check-short:/,/^$/p' Makefile
+  sed -n '/^ci:/,/^$/p' Makefile
+  ```
+
+## Step-by-step
+
+1. Re-run the grep/sed commands above in your worktree to get current line
+   numbers and exact target bodies — do not trust the line numbers quoted
+   above.
+2. Modify `test-short` so it produces a coverage profile as a side effect of
+   the one test run it already does, e.g.:
+   ```makefile
+   test-short: vet
+   	@echo "🧪 Running backend tests (-short — slow prop tests skipped)..."
+   	@go test ./... -short -race -coverprofile=coverage.out -covermode=atomic
+   	@echo "✅ Short backend tests passed"
+   ```
+   (Confirm `-race` and `-coverprofile` can coexist in this codebase — they
+   can in standard `go test`; if you hit an actual incompatibility specific to
+   this repo's test setup, note it in the PR description and fall back to a
+   separate `go test ./... -short -coverprofile=coverage.out -covermode=atomic`
+   line appended to `test-short` instead of merging the flag into the `-race`
+   invocation.)
+3. Rewrite `coverage-check-short` to **consume** the `coverage.out` produced by
+   `test-short` instead of re-running the suite. It must:
+   - Fail with a clear error (do not silently exit 0) if `coverage.out` does
+     not exist — this makes the target still runnable standalone (e.g.
+     `make coverage-check-short` alone after a manual `go test ... -coverprofile=coverage.out`),
+     while catching the case where someone runs it out of order.
+   - Print the per-package summary, not just the total:
+     ```makefile
+     @go tool cover -func=coverage.out | grep -v total
+     ```
+     followed by the total line, so CI logs show which packages are
+     contributing/dragging the number.
+   - Remove the `>/dev/null 2>&1` redirect entirely so any underlying failure
+     is visible in CI output.
+   - Keep the existing 30% floor check (do not lower or remove it).
+   - Add the ratchet: read a committed floor file (create it at
+     `.ci/coverage-floor.txt` containing a single number, e.g. `30`, decided
+     by measuring current total coverage and rounding down to a safe integer —
+     compute it by running `go tool cover -func=coverage.out | grep total` in
+     your worktree after step 2, and set the floor file to that value; do NOT
+     hardcode `30` if actual coverage is meaningfully higher — set the floor
+     file to the *current* measured value so it acts as a real ratchet from
+     day one). Compare the measured coverage against the floor file value:
+     - If below the floor file value → fail (same failure behavior as today,
+       message should reference the floor file).
+     - If below the previous recorded value in `.ci/coverage-last.txt` (a
+       second, non-committed-required, informational file — create it if
+       absent, print a `WARN:` line if coverage dropped vs. the last recorded
+       run, but do not fail the build on this WARN) → print WARN only.
+     - Update `.ci/coverage-last.txt` with the newly measured value at the end
+       of a successful run (this file tracks recent local/CI runs; it does
+       not need to be a strictly-committed ratchet artifact — keep it simple,
+       a plain last-write-wins text file is fine; if you'd rather avoid an
+       uncommitted-file-write footgun in CI, it is acceptable to skip the WARN
+       history feature entirely and rely solely on the committed
+       `.ci/coverage-floor.txt` hard floor — note whichever choice you make in
+       the PR description).
+   - The floor file (`.ci/coverage-floor.txt`) is committed to the repo and
+     can only be *raised* by a human/agent in a follow-up commit — document
+     this in a one-line comment above the target in the Makefile.
+3a. Add `.ci/` to be tracked normally (it is not build output, so do not add it
+    to `.gitignore`).
+4. Update the `ci` target so it no longer runs `coverage-check-short` as a
+   step that re-executes tests — since `test-short`/`test-all-short` now
+   produces `coverage.out` as a side effect, `coverage-check-short` becomes a
+   pure "read coverage.out and assert" step with no test execution. Leave the
+   target ordering (`ci: mocks-check check-mock-fresh staticcheck sdkguard
+   test-all-short coverage-check-short`) unchanged — `coverage-check-short`
+   still needs to run *after* `test-all-short` so `coverage.out` exists by
+   then; you are only changing what happens *inside* each target, not the
+   dependency order.
+5. Update the `## comment` lines above both targets (the `##` doc-comments
+   used by `make help`) to reflect the new behavior (no more "using -short
+   suite" re-run wording; mention the floor-file ratchet).
+6. Bump the file header on `Makefile` if it has one (check the top of the
+   file); if `Makefile` has no version-header convention (Makefiles often
+   don't), skip — do not invent a header format not already used elsewhere in
+   this file. Add proper headers to any new files you create
+   (`.ci/coverage-floor.txt` is a plain data file — a one-line `# floor` style
+   header is fine but not required if no other `.ci/*` files in the repo use
+   one; check `ls .ci/ 2>/dev/null` first).
+7. Time `make ci` before and after your change (or at minimum, count how many
+   times `go test ./...` invocations occur in the target chain before vs.
+   after) and note the comparison in the PR description — this is the
+   acceptance-relevant proof that runtime is flat or better.
+
+## How to test
+
+```bash
+go build ./...
+go vet ./...
+# Exercise the new flow directly (this IS the test — there's no Go test file
+# for a Makefile target; verify behavior empirically):
+make test-short          # should now leave coverage.out on disk
+ls -la coverage.out
+make coverage-check-short # should read the existing coverage.out, print
+                          # per-package + total, and pass/fail against
+                          # .ci/coverage-floor.txt without re-running go test
+make ci                  # full gate; confirm it still passes end-to-end
+```
+
+Also verify the failure path manually:
+
+```bash
+rm -f coverage.out
+make coverage-check-short   # should fail with a clear, non-empty error
+                            # message (not the old silent >/dev/null failure)
+```
+
+And verify the ratchet floor actually gates:
+
+```bash
+# Temporarily set an unreachable floor to confirm the target fails correctly,
+# then restore the real value before committing.
+echo "99" > .ci/coverage-floor.txt
+make test-short && make coverage-check-short   # expect failure, clear message
+git checkout .ci/coverage-floor.txt            # restore real value
+```
+
+## Acceptance criteria
+
+- [ ] `test-short` (and therefore `test-all-short`) produces `coverage.out` as
+      part of its single test run — no second `go test ./...` invocation
+      exists anywhere in the `ci` target's dependency chain.
+- [ ] `coverage-check-short` no longer runs `go test`; it reads the existing
+      `coverage.out` and fails clearly (non-empty error) if the file is
+      missing.
+- [ ] The `>/dev/null 2>&1` redirect is removed; a failing coverage run (or a
+      missing `coverage.out`) produces visible diagnostic output.
+- [ ] Per-package coverage lines are printed to output (not just `total`).
+- [ ] A committed `.ci/coverage-floor.txt` exists, its value reflects real
+      measured coverage at the time of this change (not an arbitrary
+      re-statement of `30`), and `coverage-check-short` fails when coverage
+      drops below it.
+- [ ] `make ci` still passes end-to-end after the change.
+- [ ] `make ci` wall time is flat or improved versus before (documented in the
+      PR description with before/after timing or invocation counts).
+- [ ] `go build ./...` and `go vet ./...` are clean.
+- [ ] File headers bumped on every changed/created file that already follows
+      a header convention in this repo (Makefile: only if it already has one;
+      new `.ci/` files: only if sibling files in that directory use headers).
+
+## Commit message
+
+```
+fix(ci): stop double-running tests in coverage-check-short and add a coverage floor ratchet
+
+coverage-check-short re-ran the entire -short test suite a second time just to
+measure coverage (test-all-short already ran it once), doubling make ci wall
+time, and swallowed all diagnostic output via >/dev/null 2>&1. Reuse the
+coverage.out produced by test-short, surface per-package coverage in CI logs,
+and add a committed .ci/coverage-floor.txt ratchet so the 30% bar can only be
+raised, not silently eroded.
+
+Co-Authored-By: Claude Haiku <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-29-coverage-gate-strengthen
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+If `coverage-check-short` no longer contains a `go test` invocation (i.e. it
+only runs `go tool cover -func=coverage.out ...` and reads a floor file), and
+`test-short`/`test-all-short` already writes `coverage.out`, this task is
+done — verify with:
+
+```bash
+grep -n "go test" Makefile | grep -i coverage
+grep -n "coverprofile" Makefile
+ls .ci/coverage-floor.txt 2>/dev/null
+```
+
+If the first grep returns a hit inside `coverage-check-short`'s body, the
+duplicate-run problem still exists and the task is not done. If `.ci/` already
+has a coverage-floor convention with a different filename, reuse the existing
+file rather than creating a second one — check `ls .ci/ 2>/dev/null` and
+`grep -rn "coverage-floor\|coverage_floor" Makefile scripts/ .github/` before
+deciding the task is unstarted.
+
+Rollback = revert the commit; the pre-existing behavior (duplicate test run,
+swallowed output, flat 30% floor, no ratchet) is restored exactly, since this
+task only rewrites the bodies of two existing Makefile targets and adds new
+files under `.ci/` — nothing else in the repo depends on `coverage.out` being
+produced by `coverage-check-short` specifically, only on it existing by the
+time that target runs.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-30-pebble-store-split.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-30-pebble-store-split.md
@@ -1,0 +1,275 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-30-pebble-store-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: cf0a92e5-002a-41d8-84d2-4150c3eae799 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-30 — Split `pebble_store.go` into per-domain files (consultancy SYS-5)
+
+**Priority:** P3 · **Effort:** L · **Recommended subagent:** Opus · **Wave:** 6
+· **Depends on:** TASK-02, TASK-03
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-30-pebble-store-split" -b agent/cr-30-pebble-store-split origin/main
+cd "$REPO/.worktrees/cr-30-pebble-store-split"
+git rebase origin/main
+```
+
+**This task runs LAST (wave 6).** It touches almost every method on
+`PebbleStore` and will conflict with anything else editing
+`internal/database/pebble_store*.go`. Do not start it until TASK-02 and
+TASK-03 (its declared dependencies) have merged, and confirm no other
+in-flight branch touches `internal/database/pebble_store.go` before you begin
+(`git log --oneline origin/main -20 -- internal/database/pebble_store.go`).
+
+## Goal
+
+Consultancy finding **SYS-5** (`docs/consultancy/01-storage-architecture.md`):
+`internal/database/pebble_store.go` is 11,398 lines — the single largest file
+in the repo by ~4x, and (per CLAUDE.md's mandated parallel-subagent worktree
+workflow) the most likely merge-conflict hotspot across concurrent waves.
+
+This is a **pure mechanical split**: move existing method bodies into new
+`pebble_store_<domain>.go` files in the same `database` package. **Zero
+behavior change. Zero signature change. Zero logic change.** Do not "improve"
+anything you touch — if you spot a bug while moving code, do NOT fix it here;
+log it as a follow-up (new TODO.md entry or a one-line note in your final PR
+description) and move on. Mixing refactor-with-behavior-change into a
+move-only PR makes it unreviewable and unrevertable.
+
+## Background (verify before editing)
+
+- The team has already established the split pattern. These per-domain files
+  already exist and should be treated as the naming precedent — **do not
+  duplicate or rename them**:
+  ```
+  internal/database/pebble_store_book_aggregates.go
+  internal/database/pebble_store_isbn_index.go
+  internal/database/pebble_store_lsh.go
+  internal/database/pebble_store_ops_v2.go
+  internal/database/pebble_store_mark_import.go
+  internal/database/pebble_store_metadata_cache.go
+  internal/database/pebble_store_versiongroup_backfill.go
+  ```
+- **Correction to the task-spec's example file list:** the consultancy brief
+  that spawned this task mentions splitting off `..._dedup.go` and
+  `..._embeddings.go`. As of this writing, dedup and embeddings are **already
+  in separate files** (`internal/database/dedup_label.go`,
+  `internal/database/embedding_store.go`, `internal/database/
+  hnsw_embedding_store.go`, `internal/database/chromem_embedding_store.go`) —
+  none of that logic lives in `pebble_store.go`. Verify this before doing any
+  work in that area:
+  ```bash
+  grep -n "Embedding\|Dedup" internal/database/pebble_store.go
+  ```
+  If this still returns nothing but comments, skip dedup/embeddings entirely —
+  there is nothing to move there. Do not invent new files for domains that
+  aren't actually present in `pebble_store.go`.
+- As of this writing `pebble_store.go` is 11,398 lines and defines ~388
+  methods on `(p *PebbleStore)` / `(s *PebbleStore)` (both receiver names are
+  used inconsistently in the existing file — **preserve each method's existing
+  receiver name verbatim when moving it**, do not normalize it as part of this
+  task). Confirm current scope:
+  ```bash
+  wc -l internal/database/pebble_store.go
+  grep -c -E "^func \([a-zA-Z]+ \*PebbleStore\)" internal/database/pebble_store.go
+  ```
+
+### Re-verify the method inventory before planning
+
+Line numbers below are from this writing and **will have drifted** — do not
+trust them. Regenerate the authoritative list yourself:
+
+```bash
+grep -noE "^func \([a-zA-Z]+ \*PebbleStore\) [A-Za-z0-9_]+" internal/database/pebble_store.go
+```
+
+### Recommended domain grouping (starting point, not gospel)
+
+This grouping was derived by reading the method inventory above. Use it as
+your starting plan, but you own the final grouping — if two domains are so
+entangled that splitting them creates awkward cross-file private-helper
+sharing, merge them into one file instead of forcing the split. The goal is
+navigability, not a fixed file count.
+
+| New file | Method groups (representative names — regenerate exact list) |
+|---|---|
+| `pebble_store_authors.go` | `GetAllAuthors`, `GetAuthorByID`, `CreateAuthor`, `DeleteAuthor`, `UpdateAuthorName`, `*AuthorAlias*`, `CreateNarrator`/`*Narrator*`, `GetBookAuthors`/`SetBookAuthors`, `GetAuthorsByBookIDs`, `*AuthorTag*`, `GetAuthorsByTag`, `CreateAuthorTombstone`/`GetAuthorTombstone`/`ResolveTombstoneChains` |
+| `pebble_store_series.go` | `GetAllSeries*`, `GetSeriesByID/Name/IDs`, `CreateSeries`, `DeleteSeries`, `UpdateSeriesName`, `GetAllSeriesBookCounts*`, `GetAllSeriesFileCounts`, `*SeriesTag*`, `GetSeriesByTag` |
+| `pebble_store_works.go` | `GetAllWorks*`, `GetWorkByID`, `CreateWork`, `UpdateWork`, `DeleteWork`, `GetBooksByWorkID`, `GetAllWorkBookCounts` |
+| `pebble_store_books.go` (or split further into `..._books_core.go` / `..._books_versions.go` / `..._books_tags.go` if you judge it too big) | `GetAllBooks*`, `GetBookBy*`, `CreateBook`, `UpdateBook`, `DeleteBook`, `SearchBooks`, `Count*Books`, `GetDuplicateBooks*`, `GetBooksBy*`, `*BookSnapshot*`/`*BookVersion*`, `MergeChapterBooks`, `ListSoftDeletedBooks`, `GetBookUserTags`/`SetBookUserTags`/`*BookAlternativeTitle*`, `*BookSegment*` |
+| `pebble_store_bookfiles.go` | everything currently receiver `(s *PebbleStore)` around `getBookFileByID`…`MoveBookFilesToBook`, plus `UpdateBookFileHashes`, `SetBookFileHash`, `ClearAllAcoustIDFingerprints`, `SweepBookFileSegDrop`, `LookupAcoustIDCandidates`, `HasLSHIndex` |
+| `pebble_store_importpaths.go` | `GetAllImportPaths*`, `GetImportPathByID/Path`, `CreateImportPath`, `UpdateImportPath`, `DeleteImportPath`, `CountBooksByPathPrefix` |
+| `pebble_store_operations.go` | `CreateOperation`, `GetOperationByID`, `*Operation*` (status/error/result/log/summary), `SaveOperationState/Params`, `DeleteOperationState`, `DeleteOperationsByStatus`, `DeleteOperationWithLogs`, `GetInterruptedOperations`, `CreateOperationResult*`, `GetOperationResults*`, `GetRecentCompletedOperations`, `CreateOperationChange`, `GetOperationChanges`, `RevertOperationChanges` |
+| `pebble_store_metadata.go` | `metadataStateKey`, `*MetadataFieldState*`, `RecordMetadataChange`, `GetMetadataChangeHistory`, `GetBookChangeHistory`, `AddMetadataRejection`, `GetMetadataRejections`, `DeleteMetadataRejections` |
+| `pebble_store_preferences.go` | `GetUserPreference`/`SetUserPreference`/`GetAllUserPreferences*`, `*PreferenceForUser*` |
+| `pebble_store_playlists.go` | `CreatePlaylist`, `GetPlaylistByID`, `GetPlaylistBySeriesID`, `*PlaylistItem*`, `*UserPlaylist*` |
+| `pebble_store_auth.go` | `CreateUser`/`GetUserBy*`/`UpdateUser`/`ListUsers`/`CountUsers`, `*Role*`, `*APIKey*`, `*Invite*`, `*Session*` |
+| `pebble_store_playback.go` | `SetUserPosition`, `GetUserPosition`, `ListUserPositions*`, `ClearUserPositions`, `SetUserBookState`, `GetUserBookState`, `ListUserBookStatesByStatus`, `AddPlaybackEvent`, `ListPlaybackEvents`, `UpdatePlaybackProgress`, `GetPlaybackProgress`, `IncrementBookPlayStats`, `GetBookStats`, `IncrementUserListenStats`, `GetUserStats`, `readIntKey`, `incrementIntKey` |
+| `pebble_store_blocklist.go` | `IsHashBlocked`, `AddBlockedHash`, `RemoveBlockedHash`, `GetAllBlockedHashes*`, `GetBlockedHashByHash` |
+| `pebble_store_itunes.go` | `SetLastWrittenAt`, `MarkITunesSynced`, `GetITunesPurgePendingBooks`, `GetITunesDirtyBooks`, `ClearITunesPID`, `GetBookFileByPID`, `*DeferredITunesUpdate*` |
+| `pebble_store_externalids.go` | `CreateExternalIDMapping`, `GetBookByExternalID`, `GetExternalIDsForBook`, `IsExternalIDTombstoned`, `TombstoneExternalID`, `ReassignExternalID*`, `BulkCreateExternalIDMappings`, `MarkExternalIDRemoved`, `SetExternalIDProvenance`, `GetRemovedExternalIDs` |
+| `pebble_store_tags.go` | `AddBookTag*`, `RemoveBookTag*`, `GetBookTags*`, `SetBookTags`, `ListAllTags`, `GetBooksByTag`, `pebbleAddTag`/`pebbleRemoveTag`/`pebbleGetTags*`/`pebbleSetTags`/`pebbleListAllTags`/`pebbleEntitiesByTag` (shared generic-tag helpers used by author/series tag wrappers above — keep these together, they're the implementation the thin author/series wrappers call into) |
+| `pebble_store_aijobs.go` | `CreateAIJob`, `GetAIJob*`, `MarkAIJobSubmitted/Completed/Failed`, `ListAIJobs` |
+| `pebble_store_activity.go` | `AddSystemActivityLog`, `GetSystemActivityLogs`, `PruneOperationLogs`, `PruneOperationChanges`, `PruneSystemActivityLogs` |
+| `pebble_store_scancache.go` | `GetScanCacheMap`, `UpdateScanCache`, `MarkNeedsRescan`, `GetDirtyBookFolders`, `RecordPathChange`, `GetBookPathHistory` |
+| `pebble_store_quarantine.go` | `GetQuarantinedBooks`, `CountQuarantinedBooks`, `GetScanFailCount`, `IncrScanFailCount`, `ResetScanFailCount` |
+| `pebble_store_stats.go` | `CountFiles`, `CountAuthors`, `CountSeries`, `GetBookCountsByLocation`, `GetBookSizesByLocation`, `GetDashboardStats`, `computeLibraryStats`, `GetDuplicateFilesByHash`, `GetBookFileHashStats`, `GetBookMetadataHashStats`, `GetAcoustIDStats`, `GetFilesWithFingerprintFailures`, `SaveLibraryFingerprint`, `GetLibraryFingerprint` |
+| `pebble_store.go` (stays — core/lifecycle) | `type PebbleStore struct`, `NewPebbleStore`, `mem`, `IsMemReady`, `WaitForWarmup`, `SetRootDir`, `InvalidateLibraryStats`, `readCachedLibraryStats`/`writeCachedLibraryStats`, `Close`, `Checkpoint`, `DB`, `nextID`, `migrateImportPathKeys`, `Reset`, `WipeByPrefixes`, `Optimize`, `CountByPrefix`, `SetRaw`/`GetRaw`/`DeleteRaw`/`ScanPrefix`/`CountPrefix`, `KeyCount` — anything that is truly cross-cutting store infrastructure rather than a single domain |
+
+## Step-by-step
+
+1. Regenerate the method inventory (grep command above) and write your own
+   final method→file mapping as a plain list (keep it in your PR description
+   or a scratch file — it does not need to ship). Diff it against the table
+   above; adjust groupings where files would end up too small (<50 lines —
+   fold into a neighboring domain) or too large (>1500 lines — split further,
+   e.g. `pebble_store_books_core.go` / `pebble_store_books_versions.go` /
+   `pebble_store_books_tags.go`).
+2. For each target file, create it with the standard file header (bump
+   version per `.standards/instructions/file-headers.md`; these are new files
+   so start at `version: 1.0.0`), `package database`, and only the imports
+   that file's moved methods actually need (run `goimports` or let `go build`
+   tell you — do not copy the full original import block into every new
+   file).
+3. Move method bodies verbatim (cut from `pebble_store.go`, paste into the
+   target file) — same signature, same receiver name, same body. Also move
+   any unexported helper function or const that is used ONLY by methods in
+   that domain (e.g. `isbnIndexKey`-style key-builder helpers, `metadataStateKey`).
+   If a helper is shared across domains you're splitting into different
+   files, leave it in `pebble_store.go` (or promote it to a small shared
+   `pebble_store_keys.go` if there are several) rather than duplicating it.
+4. Do the move as a **small number of large commits**, not 388 tiny ones —
+   one commit per target file (or a few closely-related files together) is
+   the right grain. After each commit, run the full test gate below before
+   moving to the next file, so a break is bisectable to a single domain move.
+5. After all domain files are extracted, confirm `pebble_store.go` itself has
+   shrunk to roughly the "core/lifecycle" scope in the table above — if
+   substantial method groups are still left over that don't fit the table,
+   add one more domain file for them rather than leaving a second monolith.
+6. Do **not** touch `store.go` (the `Store` interface definition) or any
+   caller of these methods anywhere else in the repo — this task is a
+   same-package file reorganization only; no interface, signature, or call
+   site changes.
+7. Bump the file header (version + `last-edited`) on `pebble_store.go` itself
+   (it's still being edited) and on every new file you create.
+
+## How to test
+
+Run after every domain-file commit, and again at the end:
+
+```bash
+go build ./...
+go vet ./...
+go test ./internal/database/... -count=1
+```
+
+Also sanity-check that git still tracks history correctly for moved code
+(this doesn't affect correctness but confirms you moved rather than
+copy-pasted-and-left-behind):
+
+```bash
+git log --oneline --follow -- internal/database/pebble_store_authors.go | head -5
+```
+
+Full regression pass before opening the PR:
+
+```bash
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] `internal/database/pebble_store.go` line count has dropped substantially
+      (target: under ~2,000 lines of core/lifecycle code; state the final
+      count in the PR description).
+- [ ] Every method that existed on `PebbleStore` before this change still
+      exists, with the identical signature and receiver name, just in a
+      different file (`grep -c -E "^func \([a-zA-Z]+ \*PebbleStore\)"` across
+      all `internal/database/pebble_store*.go` files sums to the same total
+      as the pre-change count on `pebble_store.go` alone).
+- [ ] `go build ./...`, `go vet ./...`, and `go test ./internal/database/...`
+      are green after the final commit.
+- [ ] `make ci` passes.
+- [ ] No caller outside `internal/database` needed to change (verify with
+      `git diff origin/main --stat` — no non-`internal/database` files should
+      appear, except possibly CHANGELOG.md/TODO.md).
+- [ ] No logic, condition, or behavior was changed in any moved method — diffs
+      should read as pure cut/paste plus import-list edits and file headers.
+      Any bug noticed while moving code is logged as a follow-up, not fixed
+      inline.
+- [ ] File headers bumped on every touched/created file.
+- [ ] CHANGELOG.md and TODO.md updated per repo convention (this is a
+      structural change worth one line in each).
+
+## Commit message
+
+Use one commit per domain file (adjust the domain name per commit), e.g.:
+
+```
+refactor(database): split author/narrator methods out of pebble_store.go (SYS-5)
+
+pebble_store.go was 11,398 lines — the largest file in the repo and the most
+likely merge-conflict site across concurrent parallel-subagent waves per
+CLAUDE.md's worktree discipline. Move author, narrator, and author-tag methods
+into pebble_store_authors.go, following the existing pebble_store_<domain>.go
+split pattern (book_aggregates, isbn_index, lsh, ops_v2). Pure move — no
+signature or behavior change.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+And a final summary commit or PR description covering the whole set, e.g.:
+
+```
+refactor(database): finish splitting pebble_store.go into per-domain files (SYS-5)
+
+Closes out the SYS-5 navigability/merge-conflict-hotspot finding from the
+2026-07 storage-architecture consultancy review. pebble_store.go dropped from
+11,398 lines to <final count> lines of core store lifecycle code; the
+remaining ~370 methods now live in <N> pebble_store_<domain>.go files
+following the pattern already established by pebble_store_book_aggregates.go
+et al. No behavior, signature, or call-site changes.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-30-pebble-store-split
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+Because this PR touches a very large fraction of `internal/database/`, expect
+`gh pr merge --rebase` to require a fresh rebase if anything else landed on
+`internal/database/pebble_store*.go` while this was in flight — this is
+exactly the wave-6-runs-last precaution called out at the top of this brief.
+If it conflicts, re-run `git rebase origin/main`, resolve by re-applying the
+same cut/paste (never by re-deriving logic), and re-run the full test gate
+before pushing again.
+
+## Idempotency / Rollback
+
+- If `internal/database/pebble_store.go` is already close to the "core"
+  scope in the grouping table (roughly under 2,000 lines, with the domain
+  method groups already split out), this task is done — verify with
+  `wc -l internal/database/pebble_store.go` and
+  `ls internal/database/pebble_store_*.go`.
+- The dedup/embeddings portion of the original consultancy example file list
+  does not apply — verified during Background research that
+  dedup (`dedup_label.go`) and embeddings (`embedding_store.go`,
+  `hnsw_embedding_store.go`, `chromem_embedding_store.go`) are already
+  separate files untouched by `pebble_store.go`. Do not create empty
+  `pebble_store_dedup.go` / `pebble_store_embeddings.go` files to satisfy the
+  letter of the original ticket text — there is nothing to move.
+- Rollback = revert the domain-file commits in reverse order (each commit is
+  self-contained: it removes methods from `pebble_store.go` and adds a new
+  file, so reverting restores the monolith exactly). Because this is a
+  same-package move with no behavior change, a partial rollback (reverting
+  only some domain-file commits) is also safe — the remaining split files and
+  the shrunk `pebble_store.go` continue to compile together either way.

--- a/docs/agent-tasks/consultancy-roadmap/TASK-31-server-start-decomposition.md
+++ b/docs/agent-tasks/consultancy-roadmap/TASK-31-server-start-decomposition.md
@@ -1,0 +1,312 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/TASK-31-server-start-decomposition.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3b6372c5-9f85-417d-badc-16d3949e7f28 -->
+<!-- last-edited: 2026-07-03 -->
+
+# TASK-31 — Decompose Server.Start + single lifecycle authority (SYS-2 / SYS-4)
+
+**Priority:** P3 · **Effort:** L · **Recommended subagent:** Opus · **Wave:** 6 · **Depends on:** TASK-19, TASK-22
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/cr-31-server-start-decomposition" -b agent/cr-31-server-start-decomposition origin/main
+cd "$REPO/.worktrees/cr-31-server-start-decomposition"
+git rebase origin/main
+```
+
+**Before doing anything else:** read the merged diffs for TASK-19
+(shutdown escape-hatch + `Registry.Shutdown` goroutine-tracking fix) and
+TASK-22 (NutsDB retirement) on `origin/main`:
+
+```bash
+git log --oneline --all --grep "cr-19-shutdown-escape-hatch\|cr-22-nutsdb-retirement" -20
+git log -p --follow -- internal/server/server_lifecycle.go | less   # skim for TASK-19/22 commits
+```
+
+Both tasks touch the exact teardown sequence this brief decomposes. If either
+is not yet merged, STOP and escalate — do not attempt this refactor against a
+moving target.
+
+## Goal
+
+`Server.Start` (in `internal/server/server_lifecycle.go`) is a ~665-line
+function mixing container start, cache warmers, HTTP/2/3/TLS setup, role
+seeding, v1→v2 operation resume, file watchers, four ticker loops, signal
+handling, and a ~175-line hand-sequenced teardown — with **two competing
+lifecycle authorities** (inline `Stop` calls vs `container.Stop`) and **four
+separate goroutine-tracking mechanisms**. This task:
+
+1. Splits `Start` into named, testable phase methods.
+2. Makes the `container` (`internal/serviceregistry`) the **single** lifecycle
+   authority — registration order defines teardown order, with no parallel
+   hand-maintained Stop sequence relying on idempotence as a safety net.
+3. Folds the ad hoc goroutine trackers into the `bgWG` (`namedWaitGroup`)
+   pattern already used for embedding/backfill goroutines, eliminating the
+   local `backgroundWG` + shutdown-channel duplication where the underlying
+   goroutine can instead be tracked via `bgWG` or a container `Stopper`.
+4. Adds a startup guard that counts remaining v1-format operation rows before
+   `resumeLegacyOp` runs, as a precondition for eventually deleting the shim
+   (see SYS-4) — this task does NOT delete `resumeLegacyOp` itself, only adds
+   the counting/telemetry gate. Deletion is a separate, later task once the
+   count is verified zero in prod over a full release cycle.
+
+This is a **high-risk refactor** on the server's boot/shutdown path. Work in
+small, separately-testable commits; keep the full test suite plus any
+`-race` lifecycle tests green after every commit, not just at the end.
+
+## Background (verify before editing)
+
+Findings are drawn from `docs/consultancy/01-storage-architecture.md` findings
+SYS-2 and SYS-4. Both cite `internal/server/server_lifecycle.go`. Line numbers
+in that doc are dated 2026-07-02 and may have drifted further since — always
+re-verify with the greps below before editing.
+
+**SYS-2 (dual lifecycle authorities):**
+
+- `func (s *Server) Start(cfg ServerConfig) error` currently starts at
+  `server_lifecycle.go:211` and its closing `return nil` / `}` is around
+  `:877` (verify — do not trust this number, re-grep as shown below).
+- A comment block literally named `SERVER-LIFECYCLE-FLIP` appears twice:
+  once near the top of `Start` (around `:214`, describing that
+  `container.Start` runs Starter services in resolved dep order) and again
+  in the teardown section (around `:799-807`), which admits the split-brain
+  directly in its own text: *"Inline Stops above remain the source of truth
+  for the carefully-sequenced teardown (opRegistry drain before bgCancel,
+  writeBackBatcher flush before itunesSvc.Shutdown, etc.); Container.Stop is
+  idempotent on already-stopped services for those."* Two stop orders coexist
+  today, relying on idempotence rather than a single declared dependency
+  graph.
+- Teardown coordinates (at least) four separate concurrency trackers:
+  - `s.bgWG` — a `namedWaitGroup` field on `*Server` (declared in
+    `internal/server/server.go`, used throughout `Start` for background
+    goroutines such as `index-worker`, `external-id-backfill`,
+    `acoustid-backfill`, `versiongroup-backfill`, `strip-movement-atoms`,
+    `remux-malformed-m4b`, `build-search-index`, `transcode+quarantine`).
+  - A function-local `var backgroundWG sync.WaitGroup` declared inside
+    `Start` itself (around `:525`), used for the scheduler, ticker loops, and
+    signal-handling goroutine, coordinated with a local `shutdown` channel.
+  - The operation registry's own internal `goroutineWG` (in
+    `internal/operations/registry/registry.go`), which tracks the
+    dispatcher/watchdog/worker/dep-notify goroutines and is drained inside
+    the registry's own `Shutdown`, a *different* mechanism than either of the
+    above two.
+  - `container.Stop` (`internal/serviceregistry/container.go:214`), which
+    walks registered `Stopper`s in reverse-resolved order.
+  - Every new background task added to `Start` must pick the *correct* one of
+    these four, or it silently escapes shutdown tracking — this is exactly
+    the class of bug TASK-19 fixed once (`Registry.Shutdown` goroutine-tracking,
+    SYS-1/BUG-2). Read that PR's diff (see START HERE) to avoid regressing it.
+
+**SYS-4 (v1→v2 legacy resume shim):**
+
+- `func (s *Server) resumeLegacyOp(opID, opType string)` (around `:111-206`)
+  hardcodes a `switch` over ~10 pre-UOS v1 operation type name strings
+  (`"itunes_import"`, `"scan"`, `"organize"`, `"bulk_write_back"`,
+  `"isbn-enrichment"`, `"metadata-refresh"`, `"itunes_path_reconcile"`,
+  `"itunes_path_repair"`, `"transcode"`, `"diagnostics_export"`,
+  `"diagnostics_ai"`, `"itunes_sync"`, `"reconcile_scan"`), each with
+  near-identical re-enqueue-via-registry boilerplate, plus a `default` branch
+  that falls back to `maintenance.job` resume. This must be kept until no
+  production DB can contain a v1-format operation row — this task must NOT
+  delete it. It only adds a startup count/telemetry gate as a precondition
+  for a future deletion task.
+- The v1 `OperationQueue` itself is already gone from
+  `internal/operations/` (no `queue.go`, zero non-test `GlobalQueue`
+  references in production code) — confirm this is still true with the grep
+  below before writing the count-gate, since if v1 rows genuinely cannot
+  exist anymore the count will always be zero and the gate is trivial
+  (which is fine — the point is to make that fact *observable*, not to
+  assume it).
+
+**Re-verify these anchors before editing** — line numbers drift:
+
+```bash
+grep -n "^func (s \*Server) Start\|^func (s \*Server) resumeLegacyOp\|^func (s \*Server) resumeInterruptedOperations\|SERVER-LIFECYCLE-FLIP\|var backgroundWG\|s\.bgWG\.\|container\.Stop(" internal/server/server_lifecycle.go
+grep -n "bgWG\s\+namedWaitGroup\|type namedWaitGroup" internal/server/server.go internal/server/*.go
+grep -n "goroutineWG" internal/operations/registry/registry.go
+grep -n "^func (c \*Container) Stop\|^type Stopper interface" internal/serviceregistry/container.go internal/serviceregistry/lifecycle.go
+grep -rn "GlobalQueue" --include='*.go' internal/ | grep -v _test.go
+```
+
+Confirm the shape of the teardown section (should show the
+`SERVER-LIFECYCLE-FLIP` comment immediately before `s.container.Stop(...)`,
+following a long sequence of hand-ordered inline Stop calls):
+
+```bash
+grep -n "opRegistry\|writeBackBatcher\|itunesSvc\|hnswPersistDir\|embedQueue\|ollamaDaemon\|embeddingStore\|aiScanStore" internal/server/server_lifecycle.go
+```
+
+## Step-by-step
+
+1. **Read TASK-19 and TASK-22's merged diffs first** (see START HERE). Note
+   any teardown-order changes they made so this refactor builds on the
+   current state, not a stale mental model.
+
+2. **Map the current teardown order exactly**, top to bottom, from the
+   inline Stop sequence through `s.container.Stop(...)` to the final
+   `backgroundWG.Wait()`. Write this order down (as a code comment or a
+   scratch note) before changing anything — this is the invariant you must
+   preserve unless you are deliberately fixing an ordering bug found in
+   TASK-19/22.
+
+3. **Extract `Start` into named phase methods** on `*Server`, each taking
+   `cfg ServerConfig` or narrower params as needed, called in sequence from a
+   slimmed-down `Start`. Suggested split (adjust names/boundaries to match
+   what the actual code supports — do not force an unnatural boundary):
+   - `storesUp(cfg) error` — container start, store/index wiring
+     (the `indexedStore` wrap section).
+   - `resumeOps()` — the `resumeInterruptedOperations` / `resumeLegacyOp` call
+     site (already a separate function; just make sure `Start` calls it
+     explicitly as a named phase rather than inline).
+   - `backfillsUp()` — the `bgWG`-tracked backfill goroutines
+     (external-id, acoustid, versiongroup, strip-movement-atoms,
+     remux-malformed-m4b, build-search-index, transcode+quarantine).
+   - `registryUp()` / `schedulerUp()` — scheduler + ticker loop goroutines
+     currently tracked by the local `backgroundWG`.
+   - `httpUp(cfg) error` — HTTP/2/3/TLS listener setup and signal handling.
+   - `shutdown(ctx) error` (or keep as an existing method if one already
+     exists under a different name — grep for it) — the teardown sequence.
+   Each phase method should be independently unit-testable (construct a
+   minimal `*Server`, call the phase, assert on its side effects) where the
+   existing test harness supports it — do not invent a new test harness from
+   scratch if `internal/server/server_more_test.go` or similar already has
+   one; extend it.
+
+4. **Single lifecycle authority**: for every service currently stopped by an
+   inline hand-ordered call in the teardown section AND already registered
+   as a `Stopper` in the container (or straightforward to register as one —
+   e.g. `opRegistry`, `writeBackBatcher`, `itunesSvc`, HNSW export,
+   `embedQueue`/`ollamaDaemon`, `embeddingStore`/`aiScanStore` closes), move
+   the Stop logic into a `Stopper` implementation registered with the
+   container at the correct dependency position, and delete the
+   corresponding inline call. Registration order in the container becomes
+   the sole source of teardown order — the `SERVER-LIFECYCLE-FLIP` comments
+   (both occurrences) should be deleted once their split-brain is resolved,
+   not left as historical documentation of a fixed bug.
+   - If a service's stop sequencing genuinely cannot be expressed as a
+     simple reverse-dep-order `Stopper` (e.g. it must happen strictly
+     between two other steps that aren't dependencies of each other), do NOT
+     force it — leave it inline, add a comment explaining why, and note it in
+     the PR description as a known remaining exception. Do not invent a
+     dependency-graph feature in `serviceregistry` for this task; that's a
+     larger change.
+
+5. **Fold goroutine trackers**: replace the function-local `backgroundWG` +
+   shutdown-channel pattern with `s.bgWG` where the tracked goroutine can be
+   named and drained the same way the existing backfill goroutines are
+   (`s.bgWG.Add("name")` / `defer s.bgWG.Done("name")`). Do not touch the
+   operation registry's internal `goroutineWG` — that is a different
+   package's internal concern and already fixed by TASK-19; only reference it
+   here as one of the "four trackers" to explain in comments why it is
+   intentionally left alone.
+
+6. **v1 resume-shim count gate (SYS-4)**: add a small startup check —
+   inside or adjacent to `resumeInterruptedOperations` — that counts
+   operations whose `Type` matches one of the hardcoded v1 legacy names in
+   `resumeLegacyOp`'s switch, and logs the count at `slog.Info` (e.g.
+   `slog.Info("legacy v1 op rows pending resume", "count", n)`) or exposes it
+   as a metric if the codebase already has a metrics-emission convention for
+   startup counts (grep for an existing pattern before inventing one). Do
+   **not** delete `resumeLegacyOp` or change its behavior — this is
+   observability only, laying groundwork for a future deletion task gated on
+   the count staying at zero across a release cycle.
+
+7. Bump the file header (version bump + `last-edited` date) on every file you
+   touch, per `.standards/instructions/file-headers.md`.
+
+## How to test
+
+```bash
+cd internal/server && go build ./...
+go vet ./internal/server/... ./internal/serviceregistry/... ./internal/operations/...
+go test ./internal/server/... -count=1 -race
+go test ./internal/serviceregistry/... -count=1 -race
+go test ./internal/operations/... -count=1 -race
+go build ./...
+```
+
+Run the full targeted suite after **every** commit in this refactor, not
+just once at the end — a shutdown-ordering regression is exactly the kind of
+bug that passes a quick `go build` and fails only under `-race` or in a real
+restart.
+
+## Acceptance criteria
+
+- [ ] `Start` is decomposed into named phase methods; no single method in
+      `server_lifecycle.go` handling boot mixes container start, HTTP setup,
+      backfills, and teardown in one ~600+ line body.
+- [ ] Both `SERVER-LIFECYCLE-FLIP` comments are gone, replaced by a single
+      teardown authority (the container's registered `Stopper`s in
+      reverse-resolved order), OR — if some services genuinely cannot be
+      expressed as `Stopper`s — the remaining inline exceptions are
+      explicitly documented with a reason in a PR-description list.
+  - [ ] No `Stop` call for a container-registered service is duplicated
+      inline "just in case" — idempotence is no longer relied upon as the
+      safety net for ordering.
+- [ ] The function-local `backgroundWG` + shutdown-channel pattern is folded
+      into `s.bgWG` wherever the tracked goroutine can be named/drained the
+      same way as existing backfills, OR left in place with a comment
+      explaining why it couldn't be folded.
+- [ ] `resumeLegacyOp` is untouched behaviorally; a new startup count/log of
+      pending v1-format op rows exists and is verifiable in test.
+- [ ] `go build ./...`, `go vet` on the three packages above, and
+      `go test ./internal/server/... ./internal/serviceregistry/...
+      ./internal/operations/... -count=1 -race` are all green.
+- [ ] File headers bumped on every changed file.
+- [ ] PR description explicitly lists: (a) any Stoppers newly registered,
+      (b) any inline Stop exceptions kept and why, (c) the count-gate log
+      line added for SYS-4.
+
+## Commit message
+
+```
+refactor(server): decompose Server.Start into phases, single lifecycle authority (SYS-2/SYS-4)
+
+Server.Start mixed container start, HTTP setup, background backfills, and a
+hand-sequenced ~175-line teardown in one ~665-line function with two
+competing lifecycle authorities (inline Stops vs container.Stop) relying on
+idempotence instead of a declared dependency graph, plus four separate
+goroutine-tracking mechanisms. Split into named phase methods, make the
+container the single source of teardown order, fold the local backgroundWG
+into bgWG where possible, and add an observability gate counting remaining
+v1-format legacy op rows ahead of a future resumeLegacyOp removal.
+
+Co-Authored-By: Claude Opus <noreply@anthropic.com>
+```
+
+## PR + merge
+
+```bash
+git push -u origin agent/cr-31-server-start-decomposition
+gh pr create --fill
+gh pr merge <number> --rebase
+```
+
+## Idempotency / Rollback
+
+Before starting, re-check whether this work is already done or partially
+done:
+
+```bash
+grep -n "SERVER-LIFECYCLE-FLIP" internal/server/server_lifecycle.go
+```
+
+- If this grep returns **no matches**, the split-brain comment is already
+  gone — check whether a prior PR already did this decomposition (`git log
+  --oneline -- internal/server/server_lifecycle.go`) before redoing the work.
+- If `Start`'s body is already under ~150 lines with clearly named phase
+  calls, this task is substantially complete — verify against the acceptance
+  criteria above and only fill genuine gaps (e.g. the SYS-4 count gate may
+  still be missing even if the SYS-2 decomposition is done).
+- If TASK-19 or TASK-22 changed the teardown sequence significantly since
+  this brief was written, prefer their current code shape over anything
+  described here — the anchors and step order in this brief are illustrative
+  of the pattern to apply, not a literal diff to replay.
+
+**Rollback:** revert the commit(s). This refactor is behavior-preserving by
+design (no new external-facing functionality) — a clean revert should be
+sufficient. If the count-gate log line was picked up by an external
+dashboard/alert before rollback, note that in the revert PR description.

--- a/docs/agent-tasks/consultancy-roadmap/orchestration.md
+++ b/docs/agent-tasks/consultancy-roadmap/orchestration.md
@@ -1,0 +1,112 @@
+<!-- file: docs/agent-tasks/consultancy-roadmap/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2d551ac6-ccfb-433e-aa65-3777b23f8d02 -->
+<!-- last-edited: 2026-07-03 -->
+
+# Orchestration — consultancy-roadmap workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This
+file adds the workstream-specific wave order. 31 tasks, 6 waves.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph W1["Wave 1 (13 tasks, parallel)"]
+      T01[T01 embedding-scorer guard]
+      T02[T02 UpdateBook memdb guard]
+      T04[T04 author-embed model skip]
+      T05[T05 retire embed-async]
+      T06[T06 keyless local backend]
+      T07[T07 hook + SHA-pin]
+      T08[T08 deploy recipe + ollama scripts]
+      T09[T09 apikey rotation]
+      T12[T12 retry error classes]
+      T16[T16 fingerprint campaign]
+      T19[T19 shutdown fix]
+      T23[T23 apply TOCTOU]
+      T27[T27 levenshtein runes]
+      T28[T28 doc drift]
+    end
+    subgraph W2["Wave 2"]
+      T03[T03 booksig recovery audit]
+      T13[T13 stale-candidate drain]
+      T20[T20 hnsw staleness]
+      T21[T21 metrics + alerts]
+      T22[T22 nutsdb retirement]
+      T24[T24 cover filter]
+      T25[T25 IsGarbageValue]
+      T29[T29 coverage gate]
+    end
+    subgraph W3["Wave 3"]
+      T10[T10 backend toggle core]
+      T14[T14 duration backfill]
+      T15[T15 bge-m3 recalibration]
+      T26[T26 rerank scale]
+    end
+    subgraph W4["Wave 4"]
+      T11[T11 toggle frontend]
+      T17[T17 auto-resolve op]
+    end
+    subgraph W5["Wave 5 (alone)"]
+      T18[T18 slog sweep]
+    end
+    subgraph W6["Wave 6"]
+      T30[T30 pebble_store split]
+      T31[T31 Server.Start decomposition]
+    end
+    T02 --> T03
+    T04 --> T13
+    T06 --> T20
+    T08 --> T21
+    T08 --> T29
+    T19 --> T22
+    T01 --> T24
+    T01 --> T25
+    T04 --> T10
+    T06 --> T10
+    T12 --> T10
+    T13 --> T14
+    T13 --> T15
+    T10 --> T11
+    T13 --> T17
+    T15 --> T17
+    T16 --> T17
+    T25 --> T26
+    W4 --> T18
+    T03 --> T30
+    T22 --> T31
+```
+
+- **Wave 1** — all files disjoint; run up to 14 in parallel (T01, T02, T04, T05,
+  T06, T07, T08, T09, T12, T16, T19, T23, T27, T28).
+- **Wave 2** — starts only after its specific dependency merges (not the whole
+  wave): T03 (needs T02), T13 (T04, `engine.go`), T20 (T06, `server.go`),
+  T21 + T29 (T08, `Makefile`/`deploy/`), T22 (T19, `server_lifecycle.go`),
+  T24 + T25 (T01, `metafetch`; T24 edits `service_search.go`, T25 edits
+  `service_scoring.go` — disjoint, so parallel with each other).
+- **Wave 3** — T10 (Opus; after T04/T06/T12), T14 + T15 (after T13; T14 edits
+  dataset/backfill files, T15 edits `engine.go` — verify no overlap before
+  running in parallel; if both touch `engine.go`, serialize T14 after T15),
+  T26 (after T25, `service_scoring.go`).
+- **Wave 4** — T11 (after T10), T17 (Opus; after T13/T15/T16).
+- **Wave 5** — T18 slog sweep runs ALONE (dozens of files repo-wide). Use
+  `/parallel-sweep` with per-package child tasks if desired.
+- **Wave 6** — the two structural splits (T30, T31), lowest priority, Opus.
+
+## Prod-data gates
+
+T03, T13, T15, T17 end at a **dry-run report**. Applying to prod requires the
+owner's explicit greenlight, exactly like the M0 purge and CONS-10 precedents.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/consultancy-roadmap/
+./run.sh                                       # print task list + set up worktrees
+./run.sh 01 02 04 05 06 07 08 09 12 16 19 23 27 28   # wave 1
+# merge wave 1, rebase siblings, then per-dependency wave 2+ (see above)
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as
+coordinator, rebase remaining siblings onto `origin/main` before the next wave.

--- a/docs/agent-tasks/consultancy-roadmap/run.sh
+++ b/docs/agent-tasks/consultancy-roadmap/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/consultancy-roadmap/run.sh
+# version: 1.0.0
+# guid: 45e1a238-4e66-4de8-8f9b-6011f45243d4
+# last-edited: 2026-07-03
+#
+# Thin wrapper over ../run-sweep.sh for the consultancy-roadmap workstream.
+# See orchestration.md for wave order (many tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 04 12   # subset
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+exec "$HERE/../run-sweep.sh" "$WS" "$@"


### PR DESCRIPTION
## Summary

One brief per consultancy-roadmap item (docs/consultancy/00-ROADMAP.md, PR #1742), following the established agent-tasks pattern (self-contained, weak-model-proof, worktree-disciplined). Each brief was authored by an agent that re-verified the consultancy citations against current code before writing.

- 31 briefs, 6 waves, same-file collision table in `README.md` + `orchestration.md` (mermaid DAG)
- Model tiers: Haiku ×7 (mechanical), Sonnet ×16, **Opus ×8** (recovery audit, backend-toggle core, 384K stale-candidate drain, bge-m3 recalibration, auto-resolve, shutdown concurrency, pebble_store split, Server.Start decomposition)
- Prod-data ops (TASK-03/13/15/17) are dry-run-first, owner-greenlight gated
- CONSULT-1..8 (TODO.md Tier-0) map to TASK-01..09; TODO.md/CHANGELOG/agent-tasks index updated
- Ground-truth corrections captured: fingerprint campaign op already exists → TASK-16 is KPI-only; duration re-extraction already exists → TASK-14 is a scoping filter

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1