### PR TITLE
fix(dedup): make EmbedAuthor and EmbedBooksAsync re-embed skips model-aware (DEDUPC-1)

### DIFF
--- a/internal/dedup/embed_model_cutover_test.go
+++ b/internal/dedup/embed_model_cutover_test.go
@@ -1,12 +1,13 @@
 // file: internal/dedup/embed_model_cutover_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 package dedup
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/ai"
@@ -76,6 +77,79 @@ func TestEmbedBooks_ReembedsOnModelChange(t *testing.T) {
 	bCalls = 0
 	if _, err := engine.EmbedBooks(context.Background(), []string{"BOOK_R"}); err != nil {
 		t.Fatalf("third EmbedBooks: %v", err)
+	}
+	if bCalls != 0 {
+		t.Errorf("expected a cached skip when model+content unchanged, but re-embedded (%d calls)", bCalls)
+	}
+}
+
+// TestEmbedAuthor_ReembedsOnModelChange locks the DEDUPC-1 fix: EmbedAuthor's
+// cached-skip must also require the stored model to match the wired client's
+// model, mirroring prepBookEmbed / TestEmbedBooks_ReembedsOnModelChange above.
+// Author names almost never change, so without this guard every author
+// embedding stays permanently stranded on whatever model created it after a
+// backend cutover (e.g. OpenAI text-embedding-3-large -> local bge-m3),
+// silently degrading author dedup Layer 2 to mixed-dimension comparisons.
+func TestEmbedAuthor_ReembedsOnModelChange(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	const authorID = 42
+	entityID := strconv.Itoa(authorID)
+	author := &database.Author{ID: authorID, Name: "A Real Author"}
+	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
+		if id == authorID {
+			return author, nil
+		}
+		return nil, nil
+	}
+
+	// First embed at model-A.
+	clientA := ai.NewEmbeddingClientWithOptions("k", "model-A", "")
+	clientA.SetRawEmbedForTest(func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 2, 3, 4}
+		}
+		return out, nil
+	})
+	engine.embedClient = clientA
+	if err := engine.EmbedAuthor(context.Background(), authorID); err != nil {
+		t.Fatalf("first EmbedAuthor: %v", err)
+	}
+	first, _ := es.Get("author", entityID)
+	if first == nil || first.Model != "model-A" {
+		t.Fatalf("after first embed, stored model = %v, want model-A", first)
+	}
+
+	// Switch the client to model-B. Content hash is UNCHANGED (author name did
+	// not change), so the only reason to re-embed is the model change. Before
+	// the fix this was skipped (cached).
+	bCalls := 0
+	clientB := ai.NewEmbeddingClientWithOptions("k", "model-B", "")
+	clientB.SetRawEmbedForTest(func(_ context.Context, texts []string) ([][]float32, error) {
+		bCalls++
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{5, 6, 7, 8}
+		}
+		return out, nil
+	})
+	engine.embedClient = clientB
+	if err := engine.EmbedAuthor(context.Background(), authorID); err != nil {
+		t.Fatalf("second EmbedAuthor: %v", err)
+	}
+	if bCalls == 0 {
+		t.Error("expected a re-embed API call after model change, but the author was skipped (cached)")
+	}
+	second, _ := es.Get("author", entityID)
+	if second == nil || second.Model != "model-B" {
+		t.Fatalf("after model change, stored model = %v, want model-B (re-embed)", second)
+	}
+
+	// Sanity: re-running at the SAME model with unchanged content DOES skip.
+	bCalls = 0
+	if err := engine.EmbedAuthor(context.Background(), authorID); err != nil {
+		t.Fatalf("third EmbedAuthor: %v", err)
 	}
 	if bCalls != 0 {
 		t.Errorf("expected a cached skip when model+content unchanged, but re-embedded (%d calls)", bCalls)

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.42.0
+// version: 1.43.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 package dedup
 
@@ -2241,7 +2241,7 @@ func (de *Engine) EmbedAuthor(ctx context.Context, authorID int) error {
 	entityID := strconv.Itoa(authorID)
 
 	existing, err := de.embedStore.Get("author", entityID)
-	if err == nil && existing != nil && existing.TextHash == hash {
+	if err == nil && existing != nil && existing.TextHash == hash && de.embeddingModelMatches(existing.Model) {
 		// Mirror to chromem on cache hits too — see mirrorBookToChromem
 		// for the rationale (keeps ANN index in sync with sqlite).
 		de.mirrorAuthorToChromem(ctx, entityID, existing.Vector)
@@ -2305,7 +2305,7 @@ func (de *Engine) EmbedBooksAsync(ctx context.Context) (batchID string, count in
 
 		// Skip books that already have a current embedding.
 		existing, getErr := de.embedStore.Get("book", book.ID)
-		if getErr == nil && existing != nil && existing.TextHash == hash {
+		if getErr == nil && existing != nil && existing.TextHash == hash && de.embeddingModelMatches(existing.Model) {
 			continue
 		}
 		items = append(items, ai.EmbedBatchItem{BookID: book.ID, Text: text})


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-04).

EmbedAuthor and EmbedBooksAsync skipped re-embedding on TextHash alone, stranding author embeddings on the old OpenAI model after the bge-m3 cutover. Both skips now also require embeddingModelMatches, mirroring the PR #1738 book-path fix. Regression test TestEmbedAuthor_ReembedsOnModelChange added.

Local CI evidence: make ci green in worktree (mocks/staticcheck/short tests + coverage gate), go test ./internal/dedup/... ok, go vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1