### PR TITLE
fix(ai): allow keyless registration of embedclient/llmparser for local backends

### DIFF
--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -1,6 +1,6 @@
 // file: internal/ai/register.go
-// version: 1.2.1
-// last-edited: 2026-06-23
+// version: 1.3.0
+// last-edited: 2026-07-03
 
 // Service registry registrations for the AI cluster (W4).
 //
@@ -16,12 +16,30 @@
 package ai
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/serviceregistry"
 )
+
+// resolveAIEndpointKey decides whether an OpenAI-compatible client should be
+// constructed and what API key to hand it. When a real apiKey is configured
+// it's always used. When apiKey is empty but an explicit baseURL is
+// configured (a local OpenAI-compatible backend, e.g. Ollama, which ignores
+// the Authorization header), a dummy bearer is substituted so construction
+// proceeds. When neither is set, construction is skipped — the real-OpenAI
+// path (no baseURL) still requires a real key.
+func resolveAIEndpointKey(apiKey, baseURL string) (resolvedKey string, ok bool) {
+	if apiKey != "" {
+		return apiKey, true
+	}
+	if baseURL != "" {
+		return "ollama", true
+	}
+	return "", false
+}
 
 func init() {
 	// embedclient — OpenAI embedding client with optional cache.
@@ -32,10 +50,9 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
-			if cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled {
+			if !cfg.Embedding.Enabled {
 				return (*EmbeddingClient)(nil), nil
 			}
-			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, serviceregistry.KeyEmbeddingStore)
 			// Base URL is scoped to the embedding client ONLY (see
 			// NewEmbeddingClientWithOptions): cfg.Embedding.BaseURL points
 			// embeddings at a local OpenAI-compatible backend (e.g. Ollama)
@@ -46,7 +63,15 @@ func init() {
 			if baseURL == "" {
 				baseURL = os.Getenv("OPENAI_BASE_URL")
 			}
-			client := NewEmbeddingClientWithOptions(cfg.OpenAIAPIKey, cfg.Embedding.Model, baseURL)
+			resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)
+			if !ok {
+				return (*EmbeddingClient)(nil), nil
+			}
+			if cfg.OpenAIAPIKey == "" {
+				slog.Warn("embedclient: constructing with keyless/local backend (no OpenAIAPIKey, using explicit base URL)", "baseURL", baseURL)
+			}
+			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, serviceregistry.KeyEmbeddingStore)
+			client := NewEmbeddingClientWithOptions(resolvedKey, cfg.Embedding.Model, baseURL)
 			if embStore != nil {
 				client = client.WithCache(embStore)
 			}
@@ -62,10 +87,15 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
-			if cfg.OpenAIAPIKey == "" {
+			baseURL := os.Getenv("OPENAI_BASE_URL")
+			resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)
+			if !ok {
 				return (*OpenAIParser)(nil), nil
 			}
-			return NewOpenAIParser(cfg, cfg.OpenAIAPIKey, cfg.EnableAIParsing), nil
+			if cfg.OpenAIAPIKey == "" {
+				slog.Warn("llmparser: constructing with keyless/local backend (no OpenAIAPIKey, using OPENAI_BASE_URL env)", "baseURL", baseURL)
+			}
+			return NewOpenAIParser(cfg, resolvedKey, cfg.EnableAIParsing), nil
 		},
 	})
 

--- a/internal/ai/register_test.go
+++ b/internal/ai/register_test.go
@@ -1,0 +1,69 @@
+// file: internal/ai/register_test.go
+// version: 1.0.0
+// last-edited: 2026-07-03
+
+package ai
+
+import "testing"
+
+// TestResolveAIEndpointKey covers the 4 key/base-URL combinations documented
+// on resolveAIEndpointKey: a real key always wins, a dummy key is substituted
+// when only a base URL is present, and construction is skipped when neither
+// is configured.
+func TestResolveAIEndpointKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiKey     string
+		baseURL    string
+		wantKey    string
+		wantOK     bool
+		keyIsDummy bool
+	}{
+		{
+			name:    "real key, no base URL",
+			apiKey:  "sk-real-key",
+			baseURL: "",
+			wantKey: "sk-real-key",
+			wantOK:  true,
+		},
+		{
+			name:    "real key, with base URL (key takes priority)",
+			apiKey:  "sk-real-key",
+			baseURL: "http://localhost:11434/v1",
+			wantKey: "sk-real-key",
+			wantOK:  true,
+		},
+		{
+			name:       "no key, base URL configured (dummy key substituted)",
+			apiKey:     "",
+			baseURL:    "http://localhost:11434/v1",
+			wantOK:     true,
+			keyIsDummy: true,
+		},
+		{
+			name:    "no key, no base URL (construction skipped)",
+			apiKey:  "",
+			baseURL: "",
+			wantKey: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotKey, gotOK := resolveAIEndpointKey(tt.apiKey, tt.baseURL)
+			if gotOK != tt.wantOK {
+				t.Fatalf("resolveAIEndpointKey(%q, %q) ok = %v, want %v", tt.apiKey, tt.baseURL, gotOK, tt.wantOK)
+			}
+			if tt.keyIsDummy {
+				if gotKey == "" {
+					t.Fatalf("resolveAIEndpointKey(%q, %q) key = %q, want non-empty dummy key", tt.apiKey, tt.baseURL, gotKey)
+				}
+				return
+			}
+			if gotKey != tt.wantKey {
+				t.Fatalf("resolveAIEndpointKey(%q, %q) key = %q, want %q", tt.apiKey, tt.baseURL, gotKey, tt.wantKey)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-06).

register.go gated embedclient/llmparser on a non-empty OpenAIAPIKey even when embedding.base_url points at keyless local Ollama. New resolveAIEndpointKey helper substitutes a dummy bearer when an explicit base URL is configured; the real-OpenAI path (no base URL) still requires a key. slog.Warn fires when proceeding keyless. 4-combo unit tests added.

Local CI evidence: make ci green in worktree; go test ./internal/ai/... ok; go vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1