### PR TITLE
fix(database): preserve memdb-stripped Book fields in UpdateBook (STOR-1)

### DIFF
--- a/internal/database/pebble_book_preserve_test.go
+++ b/internal/database/pebble_book_preserve_test.go
@@ -1,0 +1,143 @@
+// file: internal/database/pebble_book_preserve_test.go
+// version: 1.0.0
+// guid: 9a2f1c6e-4d3b-4a71-8e2c-6b7d8f9012ab
+// last-edited: 2026-07-03
+
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+// UpdateBook must NOT wipe Description/VersionNotes/BookSig* when the
+// incoming row leaves them nil (STOR-1). This is the memdb-round-trip
+// footgun: callers source `book` from GetAllBooks on the production
+// UseMemDB path (stripBookForMemdb nils these seven fields) and write it
+// back via UpdateBook. Without the preserve-on-nil guard, that round trip
+// silently erases the fields from the stored row. GetBookByID is
+// pebble-direct so it reflects the actually-stored row, not the stripped
+// memdb copy.
+func TestUpdateBook_PreservesMemDBStrippedFieldsOnNilIncoming(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, err := s.CreateBook(&Book{Title: "Sig Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	desc := "a great book"
+	notes := "v2 remaster"
+	sig := "base64sigdata"
+	mask := "base64maskdata"
+	segments := 4096
+	builtAt := time.Now().Truncate(time.Second)
+	coverage := 87
+
+	// Set the seven fields via a direct UpdateBook call (simulating the
+	// original, unstripped write path).
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:                 book.ID,
+		Title:              book.Title,
+		Description:        &desc,
+		VersionNotes:       &notes,
+		BookSigV1:          &sig,
+		BookSigV1Mask:      &mask,
+		BookSigSegments:    &segments,
+		BookSigBuiltAt:     &builtAt,
+		BookSigCoveragePct: &coverage,
+	}); err != nil {
+		t.Fatalf("UpdateBook (seed): %v", err)
+	}
+
+	// Simulate a memdb-sourced round trip: incoming *Book has all seven
+	// fields nil (as stripBookForMemdb would leave them) but changes an
+	// unrelated field.
+	newTitle := "Sig Book Renamed"
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:    book.ID,
+		Title: newTitle,
+	}); err != nil {
+		t.Fatalf("UpdateBook (memdb round trip): %v", err)
+	}
+
+	got, err := s.GetBookByID(book.ID) // pebble-direct → the stored row
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID: err=%v got=%v", err, got)
+	}
+
+	if got.Title != newTitle {
+		t.Errorf("Title not updated: got %q, want %q", got.Title, newTitle)
+	}
+	if got.Description == nil || *got.Description != desc {
+		t.Errorf("Description WIPED: got %v, want %q", got.Description, desc)
+	}
+	if got.VersionNotes == nil || *got.VersionNotes != notes {
+		t.Errorf("VersionNotes WIPED: got %v, want %q", got.VersionNotes, notes)
+	}
+	if got.BookSigV1 == nil || *got.BookSigV1 != sig {
+		t.Errorf("BookSigV1 WIPED: got %v, want %q", got.BookSigV1, sig)
+	}
+	if got.BookSigV1Mask == nil || *got.BookSigV1Mask != mask {
+		t.Errorf("BookSigV1Mask WIPED: got %v, want %q", got.BookSigV1Mask, mask)
+	}
+	if got.BookSigSegments == nil || *got.BookSigSegments != segments {
+		t.Errorf("BookSigSegments WIPED: got %v, want %d", got.BookSigSegments, segments)
+	}
+	if got.BookSigBuiltAt == nil || !got.BookSigBuiltAt.Equal(builtAt) {
+		t.Errorf("BookSigBuiltAt WIPED: got %v, want %v", got.BookSigBuiltAt, builtAt)
+	}
+	if got.BookSigCoveragePct == nil || *got.BookSigCoveragePct != coverage {
+		t.Errorf("BookSigCoveragePct WIPED: got %v, want %d", got.BookSigCoveragePct, coverage)
+	}
+}
+
+// A genuine explicit clear (pointer-to-empty-string for Description) must
+// still overwrite the stored value — the preserve guard only fires on nil,
+// never on a non-nil "clear" value. This proves the escape hatch for
+// user-initiated edits (internal/audiobooks/update_service.go) still works.
+func TestUpdateBook_ExplicitClearStillOverwrites(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, err := s.CreateBook(&Book{Title: "Clear Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	desc := "will be cleared"
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:          book.ID,
+		Title:       book.Title,
+		Description: &desc,
+	}); err != nil {
+		t.Fatalf("UpdateBook (seed): %v", err)
+	}
+
+	empty := ""
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:          book.ID,
+		Title:       book.Title,
+		Description: &empty,
+	}); err != nil {
+		t.Fatalf("UpdateBook (explicit clear): %v", err)
+	}
+
+	got, err := s.GetBookByID(book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID: err=%v got=%v", err, got)
+	}
+	if got.Description == nil {
+		t.Fatal("Description became nil — explicit clear should store pointer-to-empty-string, not nil")
+	}
+	if *got.Description != "" {
+		t.Errorf("Description not cleared: got %q, want empty string", *got.Description)
+	}
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.100.0
+// version: 1.101.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package database
 
@@ -2679,6 +2679,35 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	}
 	now := time.Now()
 	book.UpdatedAt = &now
+
+	// Preserve fields stripped by stripBookForMemdb (STOR-1). Callers that
+	// sourced `book` from the memdb projection (GetAllBooks on the production
+	// UseMemDB path) carry nil Description/VersionNotes/BookSig* even though
+	// the stored row has real values. Restoring from oldBook — already fetched
+	// above via the Pebble-direct GetBookByID — costs zero extra reads.
+	// Mirrors the UpsertBookFile/BatchUpsertBookFiles fingerprint-preserve
+	// guard (PERF-7) — keep both in sync.
+	if book.Description == nil {
+		book.Description = oldBook.Description
+	}
+	if book.VersionNotes == nil {
+		book.VersionNotes = oldBook.VersionNotes
+	}
+	if book.BookSigV1 == nil {
+		book.BookSigV1 = oldBook.BookSigV1
+	}
+	if book.BookSigV1Mask == nil {
+		book.BookSigV1Mask = oldBook.BookSigV1Mask
+	}
+	if book.BookSigSegments == nil {
+		book.BookSigSegments = oldBook.BookSigSegments
+	}
+	if book.BookSigBuiltAt == nil {
+		book.BookSigBuiltAt = oldBook.BookSigBuiltAt
+	}
+	if book.BookSigCoveragePct == nil {
+		book.BookSigCoveragePct = oldBook.BookSigCoveragePct
+	}
 
 	data, err := json.Marshal(book)
 	if err != nil {


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-02).

UpdateBook full-replacement wiped Description/BookSigV1* when fed a memdb-stripped Book (the round-trip footgun already fixed for BookFile in PERF-7). Adds the same preserve-on-nil guard for the seven stripped fields; verified no caller intentionally nils them. Regression tests for preserve + explicit-clear behavior.

Local CI evidence: make ci green in worktree; full internal/database suite ok (298s); vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1