### PR TITLE
feat(ops): commit sanitized deploy templates, rollback target, and Windows Ollama script (OPS-1/OPS-2/OPS-6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.14.0
+# version: 2.15.0
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-07-01
+# last-edited: 2026-07-03
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -12,6 +12,7 @@ export GOEXPERIMENT := jsonv2
 
 # Overridable deployment variables (set in Makefile.local or via environment)
 DEPLOY_HOST ?=
+DEPLOY_BIN  ?=
 BACKUP_DIR  ?= $(CURDIR)/backups
 
 # Include local overrides (not committed — see Makefile.local.example)
@@ -25,7 +26,8 @@ BACKUP_DIR  ?= $(CURDIR)/backups
         docker docker-run docker-stop \
         release-dry-run release-snapshot version \
         build-mtls-bridge build-mtls-bridge-windows \
-        manual-smoke smoke-create-books smoke-run-demo
+        manual-smoke smoke-create-books smoke-run-demo \
+        rollback
 
 # Default: full build (frontend + backend with embed)
 all: build
@@ -388,6 +390,18 @@ backup:
 		scp $(DEPLOY_HOST):/tmp/aobackup-$$STAMP.tar.gz $(BACKUP_DIR)/; \
 		ssh $(DEPLOY_HOST) "rm -f /tmp/aobackup-$$STAMP.tar.gz"; \
 		echo "✅ Backup saved to $(BACKUP_DIR)/aobackup-$$STAMP.tar.gz"
+
+## rollback: Swap in the previous deployed binary and restart (requires DEPLOY_HOST, DEPLOY_BIN)
+.PHONY: rollback
+rollback:
+	@[ -n "$(DEPLOY_HOST)" ] || (echo "ERROR: DEPLOY_HOST is not set. Add it to Makefile.local or export it."; exit 1)
+	@[ -n "$(DEPLOY_BIN)" ] || (echo "ERROR: DEPLOY_BIN is not set. Add it to Makefile.local or export it."; exit 1)
+	@echo "→ Rolling back $(DEPLOY_BIN) on $(DEPLOY_HOST)..."
+	@ssh $(DEPLOY_HOST) 'test -f $(DEPLOY_BIN).prev' || (echo "ERROR: no $(DEPLOY_BIN).prev found on $(DEPLOY_HOST) — nothing to roll back to."; exit 1)
+	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).rolled-back && \
+	  sudo cp $(DEPLOY_BIN).prev $(DEPLOY_BIN) && \
+	  sudo systemctl restart audiobook-organizer.service'
+	@echo "✅ Rolled back $(DEPLOY_BIN) to previous version and restarted."
 
 # Quick aliases
 .PHONY: t c b v

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,0 +1,52 @@
+# file: Makefile.local.example
+# version: 1.0.0
+# guid: a2b4c6d8-e0f2-4a6b-8c0d-2e4f6a8b0c2d
+# last-edited: 2026-07-03
+#
+# TEMPLATE — copy to Makefile.local (gitignored) and fill in your own values.
+# Makefile.local is included by the committed Makefile via `-include
+# Makefile.local` and supplies the machine-local deployment variables
+# (DEPLOY_HOST, DEPLOY_BIN) plus the `deploy`/`deploy-debug` targets. None of
+# this is committed — only this sanitized example is.
+#
+# Usage:
+#   cp Makefile.local.example Makefile.local
+#   $EDITOR Makefile.local   # fill in DEPLOY_HOST and any real paths
+#
+# See docs/system/deploy-and-gpu-ops.md for the full rollback flow this
+# template's `.prev`-preserving step enables.
+
+# Hostname/alias of your production box (must resolve via ssh, e.g. an
+# ~/.ssh/config Host entry). 172.16.2.30 is the author's prod host — replace
+# with your own.
+DEPLOY_HOST := 172.16.2.30
+
+# Absolute path to the deployed binary on DEPLOY_HOST. Required by the
+# committed `make rollback` target as well as this file's `deploy:` recipe.
+DEPLOY_BIN := /usr/local/bin/audiobook-organizer
+
+## deploy: Cross-compile, ship the binary, preserve a .prev copy, and restart
+.PHONY: deploy
+deploy: build-api
+	@echo "→ Cross-compiling linux/amd64 binary..."
+	GOOS=linux GOARCH=amd64 go build -tags embed_frontend -o dist/$(BINARY)-linux-amd64 .
+	@echo "→ Copying binary to $(DEPLOY_HOST)..."
+	scp dist/$(BINARY)-linux-amd64 $(DEPLOY_HOST):/home/USER/audiobook-organizer
+	@echo "→ Preserving previous binary as .prev, installing new binary, restarting service..."
+	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
+	  sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && \
+	  sudo systemctl restart audiobook-organizer.service'
+	@echo "✅ Deployed to $(DEPLOY_HOST). Roll back with: make rollback DEPLOY_HOST=$(DEPLOY_HOST) DEPLOY_BIN=$(DEPLOY_BIN)"
+
+## deploy-debug: Same as deploy, but ships a debug (non-stripped) build
+.PHONY: deploy-debug
+deploy-debug: build-api
+	@echo "→ Cross-compiling linux/amd64 debug binary..."
+	GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -tags embed_frontend -o dist/$(BINARY)-linux-amd64-debug .
+	@echo "→ Copying debug binary to $(DEPLOY_HOST)..."
+	scp dist/$(BINARY)-linux-amd64-debug $(DEPLOY_HOST):/home/USER/audiobook-organizer
+	@echo "→ Preserving previous binary as .prev, installing new binary, restarting service..."
+	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
+	  sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && \
+	  sudo systemctl restart audiobook-organizer.service'
+	@echo "✅ Debug build deployed to $(DEPLOY_HOST)."

--- a/deploy/local.conf.example
+++ b/deploy/local.conf.example
@@ -1,0 +1,40 @@
+# file: deploy/local.conf.example
+# version: 1.0.0
+# guid: b3c5d7e9-f1a3-4b5c-9d7e-1f3a5b7c9d1e
+# last-edited: 2026-07-03
+#
+# TEMPLATE — this is a systemd drop-in for audiobook-organizer.service.
+# Copy to deploy/local.conf (gitignored) and fill in your own TLS cert
+# paths, DB path, and Windows GPU transcription/embedding endpoint. Deploy it
+# to the server at:
+#   /etc/systemd/system/audiobook-organizer.service.d/local.conf
+# then `sudo systemctl daemon-reload && sudo systemctl restart audiobook-organizer`.
+#
+# See deploy/audiobook-organizer.service for the base unit this overrides,
+# and docs/system/deploy-and-gpu-ops.md for the full deploy/rollback flow.
+#
+# Real secrets/paths (TLS cert/key paths, actual DB path, real
+# WHISPER_REMOTE_URL host if different from your own GPU box) must be filled
+# in by the operator — nothing below is a real credential. 172.16.2.30 /
+# 172.16.3.22 are the author's own hosts, already public in
+# docs/system/runbooks.md and docs/status/2026-07-02-local-cutover-and-matching.md.
+
+[Service]
+# Clear the base unit's ExecStart, then set the full production command line.
+ExecStart=
+ExecStart=/usr/local/bin/audiobook-organizer serve --host 0.0.0.0 --port 8484 \
+      --db /path/to/audiobooks.pebble \
+      --tls-cert /path/to/server.crt --tls-key /path/to/server.key \
+      --http3-port 8484
+
+# How long systemd waits for a graceful shutdown before SIGKILL. Raise this
+# if large in-flight operations (fingerprint rescans, dedup purges) need time
+# to finish cleanly on stop/restart.
+TimeoutStopSec=30
+
+# Point at your own Windows GPU box (or other Ollama-compatible endpoint)
+# running bge-m3 (1024-dim embeddings) and qwen2.5:7b-instruct. See
+# scripts/manage-ollama-windows.py for keeping that box's Ollama instance
+# alive.
+Environment=WHISPER_REMOTE_URL=http://172.16.3.22:8000
+Environment=OLLAMA_BASE_URL=http://172.16.3.22:11434/v1

--- a/docs/system/deploy-and-gpu-ops.md
+++ b/docs/system/deploy-and-gpu-ops.md
@@ -1,0 +1,115 @@
+<!-- file: docs/system/deploy-and-gpu-ops.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d5e7f9a1-b3c5-4d7e-9f1a-3b5c7d9e1f3a -->
+<!-- last-edited: 2026-07-03 -->
+
+# Deploy Rollback & Windows GPU Keepalive
+
+This document closes the operational gaps flagged in
+[`docs/consultancy/06-process-and-security.md`](../consultancy/06-process-and-security.md)
+as **OPS-1** (single-machine deploy recipe, no rollback), **OPS-2** (Windows
+GPU box kept alive by a scheduled task whose setup scripts existed only in a
+scratchpad), and **OPS-6** (operational knowledge landing outside git). See
+also [`docs/status/2026-07-02-local-cutover-and-matching.md`](../status/2026-07-02-local-cutover-and-matching.md)
+for the local-backend cutover this Windows box supports.
+
+## 1. Instantiating the local, gitignored config from the committed templates
+
+Both `Makefile.local` and `deploy/local.conf` are gitignored (they hold
+machine-local paths, TLS cert locations, and the real `DEPLOY_HOST`). Two
+sanitized templates are committed instead:
+
+```bash
+cp Makefile.local.example Makefile.local
+$EDITOR Makefile.local          # set DEPLOY_HOST, DEPLOY_BIN, fix the scp source path
+
+cp deploy/local.conf.example deploy/local.conf
+$EDITOR deploy/local.conf       # set real TLS cert/key paths, DB path, WHISPER_REMOTE_URL
+```
+
+`deploy/local.conf` is deployed as a systemd drop-in at
+`/etc/systemd/system/audiobook-organizer.service.d/local.conf` (see
+[`runbooks.md`](runbooks.md#systemd-service) for the existing deploy runbook);
+`Makefile.local` is picked up automatically by the committed `Makefile` via
+`-include Makefile.local`.
+
+## 2. Rollback flow
+
+`Makefile.local.example`'s `deploy:` recipe now preserves the previously
+deployed binary before overwriting it:
+
+```
+ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
+  sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && ...'
+```
+
+Once your real `Makefile.local`'s `deploy` target includes this same
+`.prev`-preserving line, the flow is:
+
+1. `make deploy` — builds, ships, and (via the line above) copies the
+   currently-running binary to `$(DEPLOY_BIN).prev` on the server before
+   installing the new one and restarting the service.
+2. If the new deploy is bad, run the committed rollback target:
+   ```bash
+   make rollback DEPLOY_HOST=172.16.2.30 DEPLOY_BIN=/usr/local/bin/audiobook-organizer
+   ```
+   (`DEPLOY_HOST`/`DEPLOY_BIN` are normally already set in your
+   `Makefile.local`, so you can usually just run `make rollback`.)
+3. `rollback` first checks that `$(DEPLOY_BIN).prev` exists on the server
+   (errors out cleanly if not — e.g. right after a fresh install with no
+   prior deploy), then copies the *currently installed* (bad) binary to
+   `$(DEPLOY_BIN).rolled-back` for forensics, restores `.prev` back to
+   `$(DEPLOY_BIN)`, and restarts `audiobook-organizer.service`.
+4. Dry-run without touching any host:
+   ```bash
+   make -n rollback DEPLOY_HOST=test-host DEPLOY_BIN=/tmp/x
+   ```
+
+Note this only preserves **one** prior version — a second consecutive `make
+deploy` overwrites `.prev` with the (now second-to-last) binary. If you need
+deeper history, keep your own timestamped copies (see `make backup` in
+`Makefile` for the equivalent pattern applied to data directories).
+
+## 3. Windows GPU Ollama keepalive (`scripts/manage-ollama-windows.py`)
+
+The Windows GPU box (`172.16.3.22`, reached via the `windows-gpu` SSH alias —
+see `scripts/setup-ssh-from-mac.sh` for creating that alias) runs Ollama
+serving `bge-m3` (1024-dim embeddings) and `qwen2.5:7b-instruct` (LLM).
+Commands are sent as base64-encoded (UTF-16LE) PowerShell via
+`ssh windows-gpu powershell -NoProfile -EncodedCommand ...`, because a
+scp'd `.ps1` mis-parses over that SSH path (documented in the status doc
+cited above).
+
+```bash
+uv run scripts/manage-ollama-windows.py --status         # report loaded models
+uv run scripts/manage-ollama-windows.py --setup           # install, firewall, register task, pull models
+uv run scripts/manage-ollama-windows.py --install-task    # register OllamaServe only
+uv run scripts/manage-ollama-windows.py --restart         # kill + relaunch ollama serve
+```
+
+`--setup` and `--install-task` register a Windows Scheduled Task named
+**`OllamaServe`**, bound to an interactive logon session
+(`New-ScheduledTaskPrincipal -LogonType Interactive`). This is the actual
+keepalive mechanism OPS-2 flagged as undocumented — recreating the
+install/pull steps without registering this task would leave the
+reproducibility gap open.
+
+### Residual risk (OPS-2 — not closed by this script)
+
+`OllamaServe` is bound to an interactive logon session because `ollama
+serve` needs GPU access that is unavailable in a headless/service context —
+plain `ollama serve` over SSH or a "run whether user is logged on or not"
+service dies or loses GPU access. **Do not** switch the task to headless
+mode to "fix" this; that plausibly breaks the GPU access the interactive
+binding exists for. Practical consequence: a logoff, reboot, or Windows
+Update can still kill the Ollama process before the next interactive logon,
+and nothing currently pages an operator when that happens. A periodic
+reachability probe (e.g. hitting `/metrics` or `--status` on a schedule) is
+explicitly **out of scope** for this task — treat it as a follow-up
+hardening item, not something silently folded in here.
+
+## Cross-references
+
+- [`docs/consultancy/06-process-and-security.md`](../consultancy/06-process-and-security.md) — OPS-1, OPS-2, OPS-6 findings this document addresses.
+- [`docs/status/2026-07-02-local-cutover-and-matching.md`](../status/2026-07-02-local-cutover-and-matching.md) — origin of the Windows GPU setup and the `-EncodedCommand` gotcha.
+- [`runbooks.md`](runbooks.md) — general deploy runbook and systemd service management.

--- a/scripts/manage-ollama-windows.py
+++ b/scripts/manage-ollama-windows.py
@@ -1,0 +1,277 @@
+# file: scripts/manage-ollama-windows.py
+# version: 1.0.0
+# guid: c4d6e8f0-a2b4-4c6d-8e0f-2a4b6c8d0e2f
+# last-edited: 2026-07-03
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+#
+# Manages Ollama on the Windows GPU machine over plain SSH (NOT WinRM like
+# manage-whisper-server.py — see docs/status/2026-07-02-local-cutover-and-matching.md).
+# PowerShell scripts shipped over that SSH path via scp mis-parse; every
+# remote command here is base64-encoded (UTF-16LE, as PowerShell requires
+# for -EncodedCommand) and invoked with
+# `ssh windows-gpu powershell -NoProfile -EncodedCommand <blob>`.
+#
+# Recreates the Windows Ollama keepalive that previously existed only as
+# scratchpad scripts (setup-ollama.ps1, start-ollama.ps1) — including
+# registering the "OllamaServe" scheduled task itself, which is the actual
+# keepalive mechanism. The task is bound to an interactive logon session
+# because `ollama serve` needs GPU access that is not available in a
+# headless/service context; a logoff, reboot, or Windows Update can still
+# kill it before the next interactive logon. That residual single point of
+# failure is intentionally NOT fixed here — see docs/system/deploy-and-gpu-ops.md.
+#
+# Prerequisites:
+#   - A `windows-gpu` Host alias in your own ~/.ssh/config (not committed —
+#     machine-local, same as scripts/setup-ssh-from-mac.sh documents).
+#   - Key-based SSH auth already working: `ssh windows-gpu hostname`
+#
+# Usage:
+#   uv run scripts/manage-ollama-windows.py --status
+#   uv run scripts/manage-ollama-windows.py --setup          # install + pull models + register task
+#   uv run scripts/manage-ollama-windows.py --install-task   # register OllamaServe only
+#   uv run scripts/manage-ollama-windows.py --restart        # kill + relaunch ollama serve
+
+import argparse
+import base64
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+HOST = "windows-gpu"
+IP = "172.16.3.22"
+PORT = 11434
+MODELS = ("bge-m3", "qwen2.5:7b-instruct")
+
+# Written to the remote box by --setup / --install-task; this is the body
+# the "OllamaServe" scheduled task actually runs on logon, and what
+# --restart re-runs interactively.
+RESTART_SCRIPT = r"""
+$ErrorActionPreference = 'Continue'
+$ProgressPreference = 'SilentlyContinue'
+$exe = Join-Path $env:LOCALAPPDATA 'Programs\Ollama\ollama.exe'
+
+Get-Process ollama,'ollama app' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $exe
+$psi.Arguments = 'serve'
+$psi.EnvironmentVariables['OLLAMA_HOST'] = '0.0.0.0:11434'
+$psi.UseShellExecute = $false
+$psi.RedirectStandardError = $true
+$psi.RedirectStandardOutput = $true
+$p = [System.Diagnostics.Process]::Start($psi)
+Write-Host "started ollama serve pid=$($p.Id)"
+Start-Sleep -Seconds 8
+
+Write-Host "=== netstat 11434 ==="
+netstat -ano | Select-String ':11434' | ForEach-Object { $_.Line }
+
+Write-Host "=== local api probe ==="
+try { $t = Invoke-RestMethod 'http://127.0.0.1:11434/api/version' -TimeoutSec 5; Write-Host "api version: $($t.version)" } catch { Write-Host "api down: $($_.Exception.Message)" }
+"""
+
+# Installs Ollama, sets OLLAMA_HOST, opens the firewall, writes
+# ollama-start.ps1 (the RESTART_SCRIPT above) to the remote box, registers
+# the OllamaServe scheduled task bound to interactive logon, and pulls
+# models. This is the part that actually closes OPS-2: without registering
+# the task, the keepalive mechanism itself remains undocumented/unreproducible.
+SETUP_SCRIPT_TEMPLATE = r"""
+$ErrorActionPreference = 'Continue'
+
+Write-Host "=== 0. Write ollama-start.ps1 ==="
+$scriptPath = "$env:USERPROFILE\ollama-start.ps1"
+$bytes = [Convert]::FromBase64String('__RESTART_SCRIPT_B64__')
+[System.IO.File]::WriteAllBytes($scriptPath, $bytes)
+Write-Host "wrote $($bytes.Length) bytes to $scriptPath"
+
+Write-Host "=== 1. Ollama install check ==="
+$exe = Get-Command ollama -ErrorAction SilentlyContinue
+if (-not $exe) {
+    Write-Host "installing Ollama via winget..."
+    winget install --id Ollama.Ollama -e --silent --accept-source-agreements --accept-package-agreements
+    $env:Path += ";$env:LOCALAPPDATA\Programs\Ollama"
+    $exe = Get-Command ollama -ErrorAction SilentlyContinue
+}
+if ($exe) { Write-Host "ollama: $($exe.Source)" } else { Write-Host "ollama: STILL NOT FOUND (winget may have failed)" }
+
+Write-Host "=== 2. OLLAMA_HOST=0.0.0.0:11434 (User + Machine) ==="
+[Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','User')
+try { [Environment]::SetEnvironmentVariable('OLLAMA_HOST','0.0.0.0:11434','Machine'); Write-Host "set Machine scope" } catch { Write-Host "Machine scope failed (needs admin); User scope set" }
+
+Write-Host "=== 3. Firewall rule for 11434 ==="
+try {
+    if (-not (Get-NetFirewallRule -DisplayName 'Ollama 11434' -ErrorAction SilentlyContinue)) {
+        New-NetFirewallRule -DisplayName 'Ollama 11434' -Direction Inbound -LocalPort 11434 -Protocol TCP -Action Allow -ErrorAction Stop | Out-Null
+        Write-Host "firewall rule added"
+    } else { Write-Host "firewall rule already present" }
+} catch { Write-Host "firewall rule failed (needs admin): $($_.Exception.Message)" }
+
+Write-Host "=== 4. Register OllamaServe scheduled task (interactive logon, current user) ==="
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$scriptPath`""
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+try {
+    Unregister-ScheduledTask -TaskName 'OllamaServe' -Confirm:$false -ErrorAction SilentlyContinue
+    Register-ScheduledTask -TaskName 'OllamaServe' -Action $action -Trigger $trigger -Principal $principal -Settings $settings | Out-Null
+    Write-Host "OllamaServe scheduled task registered (AtLogOn, interactive)"
+} catch { Write-Host "scheduled task registration failed: $($_.Exception.Message)" }
+
+Write-Host "=== 5. pull models ==="
+& ollama pull bge-m3
+& ollama pull qwen2.5:7b-instruct
+
+Write-Host "=== 6. status ==="
+try {
+    $t = Invoke-RestMethod -Uri 'http://127.0.0.1:11434/api/tags' -TimeoutSec 6
+    Write-Host ("api up. models: " + (($t.models | ForEach-Object { $_.name }) -join ', '))
+} catch { Write-Host "api 11434 not responding: $($_.Exception.Message)" }
+"""
+
+# Registers the OllamaServe task only, without the install/firewall/pull
+# steps — useful if Ollama is already installed but the scheduled task
+# needs to be (re)created.
+INSTALL_TASK_SCRIPT_TEMPLATE = r"""
+$ErrorActionPreference = 'Continue'
+
+Write-Host "=== Write ollama-start.ps1 ==="
+$scriptPath = "$env:USERPROFILE\ollama-start.ps1"
+$bytes = [Convert]::FromBase64String('__RESTART_SCRIPT_B64__')
+[System.IO.File]::WriteAllBytes($scriptPath, $bytes)
+Write-Host "wrote $($bytes.Length) bytes to $scriptPath"
+
+Write-Host "=== Register OllamaServe scheduled task (interactive logon, current user) ==="
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$scriptPath`""
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable
+try {
+    Unregister-ScheduledTask -TaskName 'OllamaServe' -Confirm:$false -ErrorAction SilentlyContinue
+    Register-ScheduledTask -TaskName 'OllamaServe' -Action $action -Trigger $trigger -Principal $principal -Settings $settings | Out-Null
+    Write-Host "OllamaServe scheduled task registered (AtLogOn, interactive)"
+} catch { Write-Host "scheduled task registration failed: $($_.Exception.Message)" }
+"""
+
+
+def encode_ps(script: str) -> str:
+    """Base64-encode a PowerShell script as UTF-16LE, per -EncodedCommand's requirement."""
+    return base64.b64encode(script.encode("utf-16-le")).decode()
+
+
+def run_remote_ps(script: str) -> subprocess.CompletedProcess:
+    encoded = encode_ps(script)
+    return subprocess.run(
+        ["ssh", HOST, "powershell", "-NoProfile", "-EncodedCommand", encoded],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def print_result(result: subprocess.CompletedProcess) -> None:
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+
+
+def cmd_status() -> int:
+    """Probe http://172.16.3.22:11434/api/tags directly (no SSH needed) and
+    report which models are loaded."""
+    url = f"http://{IP}:{PORT}/api/tags"
+    print(f"==> Checking {url}")
+    try:
+        with urllib.request.urlopen(url, timeout=6) as r:
+            import json
+
+            data = json.loads(r.read())
+            names = [m.get("name", "?") for m in data.get("models", [])]
+            print(f"  api up. models: {', '.join(names) if names else '(none)'}")
+            missing = [m for m in MODELS if not any(m in n for n in names)]
+            if missing:
+                print(f"  WARNING: expected model(s) not found: {', '.join(missing)}")
+                return 1
+            print("  OK — bge-m3 and qwen2.5:7b-instruct both present")
+            return 0
+    except (urllib.error.URLError, OSError) as e:
+        print(f"  NOT RESPONDING: {e}")
+        return 1
+
+
+def cmd_setup() -> int:
+    print(f"==> Running --setup on {HOST} ({IP}) over SSH -EncodedCommand")
+    script = SETUP_SCRIPT_TEMPLATE.replace("__RESTART_SCRIPT_B64__", encode_ps(RESTART_SCRIPT))
+    result = run_remote_ps(script)
+    print_result(result)
+    if result.returncode != 0:
+        print(f"  ssh exited {result.returncode}", file=sys.stderr)
+    return result.returncode
+
+
+def cmd_install_task() -> int:
+    print(f"==> Registering OllamaServe scheduled task on {HOST} ({IP})")
+    script = INSTALL_TASK_SCRIPT_TEMPLATE.replace(
+        "__RESTART_SCRIPT_B64__", encode_ps(RESTART_SCRIPT)
+    )
+    result = run_remote_ps(script)
+    print_result(result)
+    if result.returncode != 0:
+        print(f"  ssh exited {result.returncode}", file=sys.stderr)
+    return result.returncode
+
+
+def cmd_restart() -> int:
+    print(f"==> Restarting ollama serve on {HOST} ({IP})")
+    result = run_remote_ps(RESTART_SCRIPT)
+    print_result(result)
+    if result.returncode != 0:
+        print(f"  ssh exited {result.returncode}", file=sys.stderr)
+    return result.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Manage Ollama on the Windows GPU machine over ssh windows-gpu"
+    )
+    parser.add_argument("--status", action="store_true", help="Probe /api/tags, report loaded models")
+    parser.add_argument(
+        "--setup",
+        action="store_true",
+        help="Idempotent setup: install Ollama, set OLLAMA_HOST, open firewall, "
+        "register the OllamaServe scheduled task, pull models",
+    )
+    parser.add_argument(
+        "--install-task",
+        action="store_true",
+        help="Register the OllamaServe scheduled task only (also run by --setup)",
+    )
+    parser.add_argument(
+        "--restart",
+        action="store_true",
+        help="Kill and relaunch ollama serve (0.0.0.0:11434), verify via /api/version",
+    )
+    args = parser.parse_args()
+
+    if not any([args.status, args.setup, args.install_task, args.restart]):
+        args.status = True
+
+    rc = 0
+    if args.setup:
+        rc |= cmd_setup()
+    if args.install_task:
+        rc |= cmd_install_task()
+    if args.restart:
+        rc |= cmd_restart()
+    if args.status:
+        rc |= cmd_status()
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-08).

The prod deploy recipe existed only in gitignored files on one laptop. Adds Makefile.local.example + deploy/local.conf.example (sanitized), a guarded make rollback target (.prev binary swap + restart), scripts/manage-ollama-windows.py (OllamaServe scheduled task over ssh windows-gpu with -EncodedCommand), and docs/system/deploy-and-gpu-ops.md.

Local CI evidence: make ci green in worktree; py_compile + make -n rollback verified; no Go files touched (pre-existing go vet failure in cmd/commands_test.go confirmed to predate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1