### PR TITLE
fix(ai): guard EmbeddingScorer model/dim mismatch and add F1 fallback on degenerate scores (MATCH-1)

### DIFF
--- a/internal/ai/embedding_scorer.go
+++ b/internal/ai/embedding_scorer.go
@@ -1,6 +1,7 @@
 // file: internal/ai/embedding_scorer.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f7a2c841-3b5e-4d9f-82c6-1e0d7f3a9b4c
+// last-edited: 2026-07-03
 
 package ai
 
@@ -18,6 +19,7 @@ import (
 type embeddingAPI interface {
 	EmbedOne(ctx context.Context, text string) ([]float32, error)
 	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+	Model() string
 }
 
 // EmbeddingScorer ranks metadata candidates by cosine similarity between the
@@ -90,10 +92,26 @@ func (s *EmbeddingScorer) Score(ctx context.Context, q Query, cands []Candidate)
 // and falling back to a live API embed otherwise.
 func (s *EmbeddingScorer) queryVector(ctx context.Context, q Query) ([]float32, error) {
 	if q.BookID != "" && s.store != nil {
-		if existing, err := s.store.Get("book", q.BookID); err == nil && existing != nil && len(existing.Vector) > 0 {
+		if existing, err := s.store.Get("book", q.BookID); err == nil && existing != nil &&
+			len(existing.Vector) > 0 && s.modelMatches(existing.Model) {
 			return existing.Vector, nil
 		}
 	}
 	text := BuildEmbeddingText("book", q.Title, q.Author, q.Narrator)
 	return s.api.EmbedOne(ctx, text)
+}
+
+// modelMatches reports whether a stored embedding's model matches the
+// scorer's live API model. A mismatch — e.g. after switching the embedding
+// backend from OpenAI (text-embedding-3-large, 3072-dim) to a local model
+// (bge-m3, 1024-dim) — must force a live re-embed even though a cached
+// vector exists; otherwise CosineSimilarity silently returns 0 against the
+// mismatched vector. Empty stored model (pre-model-tagging rows) counts as
+// a mismatch so those are re-embedded too. Mirrors
+// internal/dedup/engine.go's embeddingModelMatches.
+func (s *EmbeddingScorer) modelMatches(storedModel string) bool {
+	if storedModel == "" {
+		return false
+	}
+	return storedModel == s.api.Model()
 }

--- a/internal/ai/embedding_scorer_test.go
+++ b/internal/ai/embedding_scorer_test.go
@@ -1,6 +1,7 @@
 // file: internal/ai/embedding_scorer_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 9c3e5b17-6f8a-4d2e-b091-5a7c8d4e2f6a
+// last-edited: 2026-07-03
 
 package ai
 
@@ -24,7 +25,11 @@ type fakeEmbedAPI struct {
 	embedOne   int // call counts for assertions
 	embedBatch int
 	failNext   error
+	model      string // Model() return value; set explicitly when a test relies on the store fast-path
 }
+
+// Model implements embeddingAPI.
+func (f *fakeEmbedAPI) Model() string { return f.model }
 
 func (f *fakeEmbedAPI) EmbedOne(ctx context.Context, text string) ([]float32, error) {
 	f.embedOne++
@@ -177,7 +182,7 @@ func TestEmbeddingScorer_BookIDFastPath(t *testing.T) {
 		Model:      "text-embedding-3-large",
 	}))
 
-	api := &fakeEmbedAPI{textToVec: oneHotByPrefix}
+	api := &fakeEmbedAPI{textToVec: oneHotByPrefix, model: "text-embedding-3-large"}
 	scorer := NewEmbeddingScorerWithAPI(api, store)
 
 	scores, err := scorer.Score(context.Background(),
@@ -213,4 +218,75 @@ func TestEmbeddingScorer_BookIDMissFallsBackToEmbed(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, api.embedOne, "store miss should fall back to EmbedOne")
+}
+
+// oneHotByPrefix1024 is oneHotByPrefix's 1024-dim analog, used to simulate a
+// post-cutover live client (e.g. bge-m3) whose vector dimensionality differs
+// from a stale stored OpenAI (text-embedding-3-large, 3072-dim) vector.
+func oneHotByPrefix1024(text string) []float32 {
+	v := make([]float32, 1024)
+	if text == "" {
+		return v
+	}
+	switch text[0] {
+	case 'a', 'A':
+		v[0] = 1
+	case 'b', 'B':
+		v[1] = 1
+	case 'c', 'C':
+		v[2] = 1
+	default:
+		v[3] = 1
+	}
+	return v
+}
+
+// TestEmbeddingScorer_BookIDModelMismatchFallsBackToEmbed proves MATCH-1/BUG-1:
+// when the store holds a cached vector from a different embedding model (or
+// dimension) than the live client, the BookID fast-path must NOT be trusted
+// — it must fall through to a live re-embed rather than returning a stale
+// vector that would silently score 0 against every candidate via
+// CosineSimilarity's length mismatch.
+func TestEmbeddingScorer_BookIDModelMismatchFallsBackToEmbed(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := pebble.Open(tmpDir, &pebble.Options{})
+	require.NoError(t, err)
+	store := database.NewEmbeddingStore(db)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Seed a stale 3072-dim vector tagged with the old OpenAI model name.
+	staleVec := make([]float32, 3072)
+	staleVec[0] = 1
+	staleVec[1] = 0.5
+	require.NoError(t, store.Upsert(database.Embedding{
+		EntityType: "book",
+		EntityID:   "BOOK_A",
+		TextHash:   "hash-a",
+		Vector:     staleVec,
+		Model:      "text-embedding-3-large",
+	}))
+
+	// Live client reports a different model (post-cutover local model) and
+	// produces 1024-dim vectors.
+	api := &fakeEmbedAPI{textToVec: oneHotByPrefix1024, model: "bge-m3"}
+	scorer := NewEmbeddingScorerWithAPI(api, store)
+
+	scores, err := scorer.Score(context.Background(),
+		Query{BookID: "BOOK_A", Title: "whatever the title is"},
+		[]Candidate{
+			{Title: "abyss"},     // 'a' → matches live-embedded query vector
+			{Title: "different"}, // default → orthogonal to live-embedded query vector
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, scores, 2)
+
+	// "whatever the title is" starts with 'w' → default branch → v[3] = 1.
+	// So candidate 0 ('a' → v[0]=1) is orthogonal, candidate 1 (default →
+	// v[3]=1) matches.
+	assert.InDelta(t, 0.0, scores[0], 0.01, "mismatched-model fast path must not produce a stale-vector score")
+	assert.InDelta(t, 1.0, scores[1], 0.01, "post-fix score should be a real cosine value from a live re-embed")
+
+	assert.Equal(t, 1, api.embedOne,
+		"model mismatch must bypass the BookID fast-path and trigger a live re-embed")
 }

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -449,6 +449,23 @@ func ScoreOneResult(r metadata.BookMetadata, searchWords map[string]bool) float6
 	return ApplyNonBaseAdjustments(base, r, len(searchWords))
 }
 
+// allZero reports whether every score in the slice is exactly 0. A scorer
+// (e.g. EmbeddingScorer) can return err == nil with a fully-populated but
+// degenerate all-zero result — e.g. when every candidate's cached vector was
+// stale (wrong embedding model/dimension) and CosineSimilarity silently
+// returned 0 for each pair. Treating that as a successful "embedding" tier
+// result would suppress the F1 fallback and drop every candidate below the
+// downstream EmbeddingMinScore threshold, so ScoreBaseCandidates checks for
+// it explicitly.
+func allZero(scores []float64) bool {
+	for _, s := range scores {
+		if s != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // scoreBaseCandidates picks the highest-available base scorer tier and
 // returns one base score per input result, aligned to input order, along
 // with a short tier name for logs and UI badges ("embedding", "f1", ...).
@@ -489,13 +506,17 @@ func (mfs *Service) ScoreBaseCandidates(
 		}
 
 		scores, err := mfs.metadataScorer.Score(ctx, query, cands)
-		if err == nil && len(scores) == len(results) {
+		degenerate := len(scores) > 0 && allZero(scores)
+		if err == nil && len(scores) == len(results) && !degenerate {
 			return scores, mfs.metadataScorer.Name()
 		}
-		if err != nil {
-						slog.Warn("metadata-scorer failed, falling back to F1", "name", mfs.metadataScorer.Name(), "error", err)
-		} else {
-						slog.Warn("metadata-scorer returned scores for results, falling back to F1", "name", mfs.metadataScorer.Name(), "count", len(scores), "count", len(results))
+		switch {
+		case degenerate:
+			slog.Warn("metadata-scorer returned all-zero scores, falling back to F1", "name", mfs.metadataScorer.Name(), "count", len(scores))
+		case err != nil:
+			slog.Warn("metadata-scorer failed, falling back to F1", "name", mfs.metadataScorer.Name(), "error", err)
+		default:
+			slog.Warn("metadata-scorer returned scores for results, falling back to F1", "name", mfs.metadataScorer.Name(), "count", len(scores), "count", len(results))
 		}
 	}
 

--- a/internal/metafetch/service_scoring_test.go
+++ b/internal/metafetch/service_scoring_test.go
@@ -1,0 +1,141 @@
+// file: internal/metafetch/service_scoring_test.go
+// version: 1.0.0
+// guid: 7e3f6a1c-9b4d-4e2a-8c1f-6d5b3a2e9f70
+// last-edited: 2026-07-03
+
+package metafetch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/ai"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+)
+
+// fakeCandidateScorer is a minimal ai.MetadataCandidateScorer test double
+// that returns a fixed score slice (or error) regardless of input, so tests
+// can drive ScoreBaseCandidates' acceptance logic directly.
+type fakeCandidateScorer struct {
+	name   string
+	scores []float64
+	err    error
+}
+
+func (f *fakeCandidateScorer) Score(ctx context.Context, q ai.Query, cands []ai.Candidate) ([]float64, error) {
+	return f.scores, f.err
+}
+func (f *fakeCandidateScorer) Name() string {
+	if f.name == "" {
+		return "embedding"
+	}
+	return f.name
+}
+
+// withEmbeddingScoringEnabled sets config.AppConfig.MetadataScoring.EmbeddingEnabled
+// for the duration of the test and restores the prior value on cleanup.
+func withEmbeddingScoringEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := config.AppConfig.MetadataScoring.EmbeddingEnabled
+	config.AppConfig.MetadataScoring.EmbeddingEnabled = enabled
+	t.Cleanup(func() {
+		config.AppConfig.MetadataScoring.EmbeddingEnabled = prev
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ScoreBaseCandidates — degenerate all-zero scorer result falls back to F1
+// ---------------------------------------------------------------------------
+
+func TestScoreBaseCandidates_DegenerateAllZeroFallsBackToF1(t *testing.T) {
+	withEmbeddingScoringEnabled(t, true)
+
+	mock := &database.MockStore{}
+	svc := NewService(mock)
+	svc.SetMetadataScorer(&fakeCandidateScorer{
+		scores: []float64{0, 0},
+	})
+
+	book := &database.Book{ID: "b1", Title: "Mistborn"}
+	results := []metadata.BookMetadata{
+		{Title: "Mistborn"},
+		{Title: "Completely Different Book"},
+	}
+	searchWords := SignificantWords("Mistborn")
+
+	scores, tier := svc.ScoreBaseCandidates(context.Background(), book, results, searchWords)
+
+	require.Equal(t, "f1", tier, "an all-zero scorer result must be treated as failure and fall back to F1")
+	require.Len(t, scores, 2)
+	for i, r := range results {
+		assert.Equal(t, computeF1Base(r, searchWords), scores[i], "fallback scores should match computeF1Base directly")
+	}
+}
+
+// TestScoreBaseCandidates_NonDegenerateStaysOnEmbeddingTier proves the fix
+// doesn't over-trigger the fallback: a scorer returning genuine non-zero
+// scores must still win the "embedding" tier.
+func TestScoreBaseCandidates_NonDegenerateStaysOnEmbeddingTier(t *testing.T) {
+	withEmbeddingScoringEnabled(t, true)
+
+	mock := &database.MockStore{}
+	svc := NewService(mock)
+	svc.SetMetadataScorer(&fakeCandidateScorer{
+		scores: []float64{0.9, 0.1},
+	})
+
+	book := &database.Book{ID: "b1", Title: "Mistborn"}
+	results := []metadata.BookMetadata{
+		{Title: "Mistborn"},
+		{Title: "Completely Different Book"},
+	}
+	searchWords := SignificantWords("Mistborn")
+
+	scores, tier := svc.ScoreBaseCandidates(context.Background(), book, results, searchWords)
+
+	require.Equal(t, "embedding", tier, "a genuine non-zero scorer result must not be discarded")
+	require.Equal(t, []float64{0.9, 0.1}, scores)
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: a degenerate embedding tier must not zero out search results
+// (MATCH-1/BUG-1/QUAL-4 regression, service_search.go's threshold filter).
+// ---------------------------------------------------------------------------
+
+func TestSearchMetadataForBookWithOptions_DegenerateEmbeddingFallsBackToF1Results(t *testing.T) {
+	withEmbeddingScoringEnabled(t, true)
+
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{ID: id, Title: "Mistborn"}, nil
+		},
+	}
+	svc := NewService(mock)
+	svc.SetOverrideSources([]metadata.MetadataSource{
+		&mockMetadataSource{
+			name: "test-source",
+			results: []metadata.BookMetadata{
+				{Title: "Mistborn", Author: "Brandon Sanderson"},
+				{Title: "Mistborn: The Final Empire", Author: "Brandon Sanderson"},
+			},
+		},
+	})
+	// Simulate the degenerate case: every candidate scored exactly 0 by the
+	// embedding tier (e.g. a stale cross-model vector comparison). Before the
+	// fix, ScoreBaseCandidates would have accepted this as tier="embedding"
+	// and the threshold filter (minScore = EmbeddingMinScore, default 0.82)
+	// would have dropped every candidate, returning zero results.
+	svc.SetMetadataScorer(&fakeCandidateScorer{
+		scores: []float64{0, 0},
+	})
+
+	resp, err := svc.SearchMetadataForBookWithOptions("b1", "Mistborn", "", "", "", SearchOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Results, "F1 fallback should surface non-empty results even though the embedding tier degenerated to all-zero scores")
+}


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-01). Fixes the verified-critical MATCH-1/BUG-1: the BookID fast-path returned cached vectors without a model check, so mixed 3072/1024-dim comparisons cosine'd to 0 and silently killed all search candidates during the bge-m3 re-embed. Fast-path now requires modelMatches; ScoreBaseCandidates rejects degenerate all-zero scorer results and falls back to F1. Regression tests incl. end-to-end degenerate-fallback path.

Local CI evidence: make ci green in worktree; internal/ai + internal/metafetch suites ok; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1