### PR TITLE
fix(dedup): retire nightly cron + gate dedup.embed-async on OpenAI backend (OPS-3)

### DIFF
--- a/internal/plugins/dedup/embed_async.go
+++ b/internal/plugins/dedup/embed_async.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/embed_async.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: b1c2d3e4-f5a6-7890-bcde-f01234567890
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 // T018: embed_async.go is a thin wrapper that delegates to runEmbedScanMode
 // (in embed_scan.go) with async=true.
@@ -15,13 +15,14 @@ package dedup
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
 func (p *Plugin) embedAsyncDef() sdk.OperationDef {
-	sched := "0 3 * * *"
 	return sdk.OperationDef{
 		ID:              "dedup.embed-async",
 		Plugin:          "dedup",
@@ -33,7 +34,7 @@ func (p *Plugin) embedAsyncDef() sdk.OperationDef {
 		Cancellable:     false,
 		Isolate:         false,
 		Timeout:         10 * time.Minute,
-		Schedule:        &sched, // nightly at 03:00 server time
+		Schedule:        nil, // manual invocation only — nightly cron retired; OpenAI Batch API is quota-dead under the Ollama cutover, see docs/status/2026-07-02-local-cutover-and-matching.md
 		Run:             p.runEmbedAsync,
 	}
 }
@@ -43,5 +44,11 @@ func (p *Plugin) embedAsyncDef() sdk.OperationDef {
 // method expression stored in OperationDef.Run so sdk.Registry can
 // identify and invoke it correctly.
 func (p *Plugin) runEmbedAsync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	// Skip if backend is not OpenAI — the OpenAI Batch API is quota-dead now
+	// that Ollama/bge-m3 is the primary embedding backend.
+	if config.AppConfig.Embedding.BaseURL != "" || config.AppConfig.OpenAIAPIKey == "" {
+		slog.Warn("dedup.embed-async skipped: no OpenAI backend configured (Ollama/local embedding is primary)", "base_url", config.AppConfig.Embedding.BaseURL)
+		return nil
+	}
 	return p.runEmbedScanMode(ctx, true, reporter)
 }

--- a/internal/plugins/dedup/embed_async_test.go
+++ b/internal/plugins/dedup/embed_async_test.go
@@ -1,0 +1,88 @@
+// file: internal/plugins/dedup/embed_async_test.go
+// version: 1.0.0
+// guid: c1d2e3f4-a5b6-7890-cdef-012345678901
+// last-edited: 2026-07-03
+
+// Tests for the dedup.embed-async op retirement.
+//
+// Verifies that:
+// 1. The op's nightly cron schedule has been removed (Schedule is nil).
+// 2. The op is a no-op (returns nil) when backend is not OpenAI.
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbedAsyncDef_ScheduleIsNil(t *testing.T) {
+	t.Parallel()
+	p := &Plugin{}
+	def := p.embedAsyncDef()
+
+	assert.Nil(t, def.Schedule,
+		"embedAsyncDef().Schedule must be nil — nightly cron should be retired")
+}
+
+func TestRunEmbedAsync_SkipsWhenOllamaBaseURLConfigured(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore config
+	origConfig := config.AppConfig
+	t.Cleanup(func() {
+		config.AppConfig = origConfig
+	})
+
+	// Configure non-empty BaseURL (Ollama) — signals non-OpenAI backend
+	config.AppConfig.Embedding.BaseURL = "http://localhost:11434"
+	config.AppConfig.OpenAIAPIKey = "sk-test-key"
+
+	p := &Plugin{} // engine is nil; runEmbedAsync should not attempt to use it
+	err := p.runEmbedAsync(context.Background(), json.RawMessage(`{}`), &mockReporter{})
+
+	require.NoError(t, err, "runEmbedAsync should return nil when BaseURL is configured (non-OpenAI backend)")
+}
+
+func TestRunEmbedAsync_SkipsWhenNoOpenAIAPIKey(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore config
+	origConfig := config.AppConfig
+	t.Cleanup(func() {
+		config.AppConfig = origConfig
+	})
+
+	// Configure empty OpenAI key and empty BaseURL — signals non-OpenAI backend
+	config.AppConfig.Embedding.BaseURL = ""
+	config.AppConfig.OpenAIAPIKey = ""
+
+	p := &Plugin{} // engine is nil; runEmbedAsync should not attempt to use it
+	err := p.runEmbedAsync(context.Background(), json.RawMessage(`{}`), &mockReporter{})
+
+	require.NoError(t, err, "runEmbedAsync should return nil when OpenAIAPIKey is empty (non-OpenAI backend)")
+}
+
+func TestRunEmbedAsync_SkipsWhenBothConditionsMet(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore config
+	origConfig := config.AppConfig
+	t.Cleanup(func() {
+		config.AppConfig = origConfig
+	})
+
+	// Configure both conditions that signal non-OpenAI backend
+	config.AppConfig.Embedding.BaseURL = "http://localhost:11434"
+	config.AppConfig.OpenAIAPIKey = ""
+
+	p := &Plugin{} // engine is nil; runEmbedAsync should not attempt to use it
+	err := p.runEmbedAsync(context.Background(), json.RawMessage(`{}`), &mockReporter{})
+
+	require.NoError(t, err, "runEmbedAsync should return nil when both BaseURL and OpenAIAPIKey indicate non-OpenAI backend")
+}

--- a/internal/plugins/dedup/t018_scan_rationalization_test.go
+++ b/internal/plugins/dedup/t018_scan_rationalization_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/t018_scan_rationalization_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: f4a7b2c1-d3e5-4f89-a0b2-c1d3e5f7a9b0
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 // T018 acceptance tests for scan op rationalization.
 //
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -137,6 +138,14 @@ func TestT018_BothOpIDsRegistered(t *testing.T) {
 //     different line — but given the error text is the same, we rely on the
 //     param-parsing path.
 func TestT018_EmbedAsyncDelegatesWithAsyncTrue(t *testing.T) {
+	// Set up config for OpenAI backend so the skip-guard doesn't trigger
+	origConfig := config.AppConfig
+	t.Cleanup(func() {
+		config.AppConfig = origConfig
+	})
+	config.AppConfig.OpenAIAPIKey = "sk-test-key"
+	config.AppConfig.Embedding.BaseURL = ""
+
 	// Nil-engine plugin so both paths immediately return at the nil guard.
 	p := &Plugin{engine: nil}
 	reporter := &fakeReporter{}


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-05).

dedup.embed-async fired nightly against the quota-dead OpenAI Batch API (and is wrong under the Ollama backend — dedup.embed-scan is the sync path). Schedule removed (op stays manually invocable); runtime guard skips with a WARN when the embedding backend is not OpenAI. Tests for nil-schedule + skip-guard.

Local CI evidence: make ci green in worktree; plugins/dedup tests + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1