### PR TITLE
fix(ai): classify permanent vs transient errors in retry paths (MATCH-7/TOGGLE-4)

### DIFF
--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,7 +1,7 @@
 // file: internal/ai/embedding_client.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-15
+// last-edited: 2026-07-03
 
 package ai
 
@@ -304,9 +304,20 @@ func (c *EmbeddingClient) embedBatchRaw(ctx context.Context, texts []string) ([]
 			},
 			Model: openai.EmbeddingModel(c.model),
 			User:  openai.String("ao-embeddings"),
-		})
+			// WithMaxRetries(0): the SDK's own built-in retry logic would
+			// otherwise silently retry 429/5xx responses before this loop
+			// ever sees the error, defeating both the permanent-error
+			// short-circuit (still burning 3 HTTP calls per attempt on a
+			// permanent 429) and the attempt bookkeeping this loop relies
+			// on. This loop is the sole retry authority for embedBatchRaw.
+		}, option.WithMaxRetries(0))
 		attemptCancel() // always release the child context, never defer in a loop
 		if err != nil {
+			// TODO(#TASK-12-followup): route embedBatchRaw through
+			// DoWithRetry to eliminate this duplicated per-attempt loop.
+			if isPermanentAIError(err) {
+				return nil, &PermanentError{Err: fmt.Errorf("embedding attempt %d: %w", attempt+1, err)}
+			}
 			lastErr = fmt.Errorf("embedding attempt %d: %w", attempt+1, err)
 			continue
 		}

--- a/internal/ai/embedding_client_retry_test.go
+++ b/internal/ai/embedding_client_retry_test.go
@@ -1,0 +1,62 @@
+// file: internal/ai/embedding_client_retry_test.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-0123-defa-345678901234
+// last-edited: 2026-07-03
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbedBatchRaw_PermanentErrorNoRetry proves embedBatchRaw makes exactly
+// one HTTP call when the server returns a permanent error (429 with OpenAI
+// error code "insufficient_quota") instead of exhausting all 3 attempts.
+func TestEmbedBatchRaw_PermanentErrorNoRetry(t *testing.T) {
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}`))
+	}))
+	defer server.Close()
+
+	c := NewEmbeddingClientWithOptions("k", "", server.URL)
+	_, err := c.embedBatchRaw(context.Background(), []string{"x"})
+
+	require.Error(t, err)
+	var pe *PermanentError
+	assert.True(t, errors.As(err, &pe), "expected a PermanentError, got %T: %v", err, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requests), "permanent error must not be retried")
+}
+
+// TestEmbedBatchRaw_TransientErrorRetriesAllAttempts proves the existing
+// transient-error behavior is preserved: a 500 response still exhausts all 3
+// attempts.
+func TestEmbedBatchRaw_TransientErrorRetriesAllAttempts(t *testing.T) {
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal server error","type":"server_error","code":"internal_error"}}`))
+	}))
+	defer server.Close()
+
+	c := NewEmbeddingClientWithOptions("k", "", server.URL)
+	_, err := c.embedBatchRaw(context.Background(), []string{"x"})
+
+	require.Error(t, err)
+	var pe *PermanentError
+	assert.False(t, errors.As(err, &pe), "transient error must not be wrapped as PermanentError")
+	assert.Equal(t, int32(3), atomic.LoadInt32(&requests), "transient error must retry all 3 attempts")
+}

--- a/internal/ai/retry.go
+++ b/internal/ai/retry.go
@@ -1,15 +1,55 @@
 // file: internal/ai/retry.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-2345-fabc-678901234567
-// last-edited: 2026-06-22
+// last-edited: 2026-07-03
 
 // Package ai — shared retry helper for OpenAI / Ollama API calls.
 package ai
 
 import (
 	"context"
+	"errors"
 	"time"
+
+	"github.com/openai/openai-go/v3"
 )
+
+// PermanentError wraps an error that is known to be non-retryable — e.g. an
+// HTTP 400/401/403/404 response or a 429 with OpenAI error code
+// "insufficient_quota". Callers can distinguish "will never succeed" from
+// "exhausted retries" via errors.As(err, &PermanentError{}).
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PermanentError) Unwrap() error {
+	return e.Err
+}
+
+// isPermanentAIError reports whether err is an OpenAI API error that can
+// never succeed on retry: HTTP 400/401/403/404, or HTTP 429 with error code
+// "insufficient_quota" (quota exhaustion is permanent; plain rate-limit 429s
+// are transient). Errors that are not *openai.Error (network/timeout errors,
+// context cancellation, etc.) are treated as transient/unknown and retried,
+// matching prior behavior.
+func isPermanentAIError(err error) bool {
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case 400, 401, 403, 404:
+		return true
+	case 429:
+		return apiErr.Code == "insufficient_quota"
+	default:
+		return false
+	}
+}
 
 // DoWithRetry calls fn up to maxAttempts times. Between attempts it sleeps
 // attempt² × base (quadratic back-off), respecting ctx cancellation.
@@ -38,6 +78,9 @@ func DoWithRetry(ctx context.Context, maxAttempts int, base time.Duration, fn fu
 			}
 		}
 		if err := fn(); err != nil {
+			if isPermanentAIError(err) {
+				return &PermanentError{Err: err}
+			}
 			lastErr = err
 			continue
 		}

--- a/internal/ai/retry_test.go
+++ b/internal/ai/retry_test.go
@@ -1,0 +1,83 @@
+// file: internal/ai/retry_test.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-9012-cdef-234567890123
+// last-edited: 2026-07-03
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsPermanentAIError_Classification table-tests isPermanentAIError
+// against the permanent/transient matrix described in TASK-12: HTTP
+// 400/401/403/404 and 429-with-insufficient_quota are permanent; plain 429s,
+// 5xx, and non-*openai.Error errors (network/timeout) are transient.
+func TestIsPermanentAIError_Classification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"400 bad request", &openai.Error{StatusCode: 400}, true},
+		{"401 unauthorized", &openai.Error{StatusCode: 401}, true},
+		{"403 forbidden", &openai.Error{StatusCode: 403}, true},
+		{"404 not found", &openai.Error{StatusCode: 404}, true},
+		{"429 insufficient_quota", &openai.Error{StatusCode: 429, Code: "insufficient_quota"}, true},
+		{"429 plain rate limit (no code)", &openai.Error{StatusCode: 429}, false},
+		{"429 different code", &openai.Error{StatusCode: 429, Code: "rate_limit_exceeded"}, false},
+		{"500 internal server error", &openai.Error{StatusCode: 500}, false},
+		{"503 service unavailable", &openai.Error{StatusCode: 503}, false},
+		{"plain non-openai error", errors.New("boom"), false},
+		{"context deadline exceeded", context.DeadlineExceeded, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isPermanentAIError(tc.err))
+		})
+	}
+}
+
+// TestDoWithRetry_PermanentErrorShortCircuits proves a permanent error
+// returned by fn causes exactly one call (no retries, no additional
+// backoff), and the returned error satisfies errors.As(..., &PermanentError{}).
+func TestDoWithRetry_PermanentErrorShortCircuits(t *testing.T) {
+	calls := 0
+	permErr := &openai.Error{StatusCode: 401}
+	err := DoWithRetry(context.Background(), 5, time.Millisecond, func() error {
+		calls++
+		return permErr
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "permanent error must short-circuit after exactly one attempt")
+
+	var pe *PermanentError
+	require.True(t, errors.As(err, &pe), "returned error must satisfy errors.As(..., &PermanentError{})")
+	assert.ErrorIs(t, err, permErr)
+}
+
+// TestDoWithRetry_TransientErrorStillRetries proves a transient error keeps
+// the existing retry behavior — fn is called up to maxAttempts times.
+func TestDoWithRetry_TransientErrorStillRetries(t *testing.T) {
+	calls := 0
+	transientErr := &openai.Error{StatusCode: 500}
+	err := DoWithRetry(context.Background(), 3, time.Millisecond, func() error {
+		calls++
+		return transientErr
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 3, calls, "transient error must retry up to maxAttempts")
+
+	var pe *PermanentError
+	assert.False(t, errors.As(err, &pe), "transient error must not be wrapped as PermanentError")
+}


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-12).

retry.go retried everything with full backoff, including 4xx and 429 insufficient_quota (permanent). Adds PermanentError type + classifier (errors.As on *openai.Error: 400/401/403/404, 429+insufficient_quota); DoWithRetry and embedBatchRaw short-circuit immediately. Also disables the SDK's hidden inner retry layer on the embeddings call (was silently tripling HTTP calls) so the hand-rolled loop is the sole retry authority. httptest-backed tests verify exact HTTP call counts.

Local CI evidence: make ci green in worktree (post-rebase onto #1745); internal/ai suite ok; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1