### PR TITLE
feat(database): add fingerprint-coverage KPI to cached library stats (NEWF-1)

### DIFF
--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
+// last-edited: 2026-07-03
 
 package database
 
@@ -713,6 +714,11 @@ func (m *MemStore) ComputeLibraryStats(rootDir string, importPaths []ImportPath)
 	// Matches the Pebble semantics: count all files for primary books; books
 	// with no file rows still count as 1 (legacy single-file-no-row case).
 	bookActiveFiles := make(map[string]int, len(primaryBookIDs))
+	// bookFingerprintedFiles tallies, per primary book, how many of its active
+	// book_files have a fingerprint per BookFile.GetAcoustIDSeg0() (which
+	// already falls back to the memdb-safe AcoustIDFingerprintDurationSec
+	// proxy when AcoustIDSeg0 has been stripped — see bookfile_fingerprint.go).
+	bookFingerprintedFiles := make(map[string]int, len(primaryBookIDs))
 	fIter, err := txn.Get(memTableBookFiles, memIdxID)
 	if err != nil {
 		return nil, fmt.Errorf("memdb book_files scan: %w", err)
@@ -723,12 +729,27 @@ func (m *MemStore) ComputeLibraryStats(rootDir string, importPaths []ImportPath)
 			continue
 		}
 		bookActiveFiles[bf.BookID]++
+		if bf.GetAcoustIDSeg0() != "" {
+			bookFingerprintedFiles[bf.BookID]++
+		}
 	}
 	for id := range primaryBookIDs {
 		if n := bookActiveFiles[id]; n > 0 {
 			stats.TotalFiles += n
 		} else {
 			stats.TotalFiles++
+		}
+		// Classify fingerprint coverage: none/partial/complete, mirroring the
+		// semantics of fingerprint.ComputeFingerprintFields without importing
+		// it (that function takes a []FileWithFingerprint slice, which would
+		// mean building a throwaway slice per book for no benefit).
+		switch fp := bookFingerprintedFiles[id]; {
+		case fp == 0:
+			stats.UnfingerprintedBooks++
+		case fp == bookActiveFiles[id]:
+			stats.FingerprintedBooks++
+		default:
+			stats.PartiallyFingerprintedBooks++
 		}
 	}
 
@@ -744,6 +765,10 @@ func (m *MemStore) ComputeLibraryStats(rootDir string, importPaths []ImportPath)
 		for obj := sIter.Next(); obj != nil; obj = sIter.Next() {
 			stats.TotalSeries++
 		}
+	}
+
+	if stats.TotalBooks > 0 {
+		stats.FingerprintCoveragePercent = stats.FingerprintedBooks * 100 / stats.TotalBooks
 	}
 
 	return stats, nil

--- a/internal/database/memdb_reads_test.go
+++ b/internal/database/memdb_reads_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_reads_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000007
+// last-edited: 2026-07-03
 
 package database
 
@@ -446,10 +447,15 @@ func TestMemStore_ComputeLibraryStats(t *testing.T) {
 			MarkedForDeletion: ptrBool_mem(true), FileSize: ptrInt64_mem(999)},
 	}
 	files := []BookFile{
-		{ID: "f1", BookID: "b1"},
-		{ID: "f2", BookID: "b1"}, // b1 has 2 files
-		{ID: "f3", BookID: "b2"},
-		// b3 has no file rows → counted as 1
+		// b1: 2 files, one fingerprinted (AcoustIDSeg0, the primary/non-fallback
+		// path) and one not → partially fingerprinted.
+		{ID: "f1", BookID: "b1", AcoustIDSeg0: "seg0-data"},
+		{ID: "f2", BookID: "b1"},
+		// b2: 1 file, fingerprinted via the memdb-safe duration fallback proxy
+		// (AcoustIDSeg0 stripped, AcoustIDFingerprintDurationSec retained) →
+		// fully fingerprinted.
+		{ID: "f3", BookID: "b2", AcoustIDFingerprintDurationSec: 42.0},
+		// b3 has no file rows → counted as 1, and as unfingerprinted.
 	}
 	authors := []Author{{ID: 1, Name: "A"}, {ID: 2, Name: "B"}}
 	series := []Series{{ID: 1, Name: "S1"}}
@@ -505,6 +511,21 @@ func TestMemStore_ComputeLibraryStats(t *testing.T) {
 	}
 	if stats.ComputedAt.IsZero() {
 		t.Error("ComputedAt not set")
+	}
+	// Fingerprint coverage: b1 partial (1/2 files), b2 complete (1/1 via the
+	// duration fallback), b3 unfingerprinted (0 files). b4 is non-primary and
+	// excluded from classification.
+	if stats.FingerprintedBooks != 1 {
+		t.Errorf("FingerprintedBooks = %d, want 1 (b2)", stats.FingerprintedBooks)
+	}
+	if stats.PartiallyFingerprintedBooks != 1 {
+		t.Errorf("PartiallyFingerprintedBooks = %d, want 1 (b1)", stats.PartiallyFingerprintedBooks)
+	}
+	if stats.UnfingerprintedBooks != 1 {
+		t.Errorf("UnfingerprintedBooks = %d, want 1 (b3)", stats.UnfingerprintedBooks)
+	}
+	if stats.FingerprintCoveragePercent != 25 {
+		t.Errorf("FingerprintCoveragePercent = %d, want 25 (1/4 books)", stats.FingerprintCoveragePercent)
 	}
 }
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.100.0
+// version: 1.101.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package database
 
@@ -3763,14 +3763,18 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 	}
 	bookIter.Close()
 
-	// Pass 2: book_file: range — active file count per primary book
-	// Optimized: key-only scan to count files without deserializing
+	// Pass 2: book_file: range — active file count + fingerprint coverage per primary book.
+	// This path only runs as a rare fallback when memdb is unavailable (the fast-path
+	// branch at the top of this function returns early otherwise), so the added
+	// per-file JSON.Unmarshal cost (needed to call GetAcoustIDSeg0()) is acceptable —
+	// unlike before, we can no longer do a pure key-only scan here.
 	fileIter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book_file:"),
 		UpperBound: []byte("book_file;"),
 	})
 	if err == nil {
 		bookActiveFiles := make(map[string]int, len(primaryBookIDs))
+		bookFingerprintedFiles := make(map[string]int, len(primaryBookIDs))
 		for fileIter.First(); fileIter.Valid(); fileIter.Next() {
 			parts := strings.SplitN(string(fileIter.Key()), ":", 4)
 			if len(parts) != 3 {
@@ -3780,9 +3784,14 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 			if _, ok := primaryBookIDs[bookID]; !ok {
 				continue
 			}
-			// Count all files for primary books (fast path: no deserialization)
-			// Missing files are rare; counting them all is still much faster than deserializing each one
 			bookActiveFiles[bookID]++
+			var bf BookFile
+			if err := json.Unmarshal(fileIter.Value(), &bf); err != nil {
+				continue
+			}
+			if bf.GetAcoustIDSeg0() != "" {
+				bookFingerprintedFiles[bookID]++
+			}
 		}
 		fileIter.Close()
 		for id := range primaryBookIDs {
@@ -3790,6 +3799,18 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 				stats.TotalFiles += n
 			} else {
 				stats.TotalFiles++ // no file records → count as 1
+			}
+			// Classify fingerprint coverage: none/partial/complete, mirroring the
+			// semantics of fingerprint.ComputeFingerprintFields without importing
+			// it (that function takes a []FileWithFingerprint slice, which would
+			// mean building a throwaway slice per book for no benefit).
+			switch fp := bookFingerprintedFiles[id]; {
+			case fp == 0:
+				stats.UnfingerprintedBooks++
+			case fp == bookActiveFiles[id]:
+				stats.FingerprintedBooks++
+			default:
+				stats.PartiallyFingerprintedBooks++
 			}
 		}
 	}
@@ -3806,6 +3827,10 @@ func (p *PebbleStore) computeLibraryStats() (*LibraryStats, error) {
 	// Reuses the secondary index written by RecordFileError so no JSON deserialization needed.
 	if booksWithErrors, err := p.ListBooksWithFileErrors(); err == nil {
 		stats.BrokenFiles = len(booksWithErrors)
+	}
+
+	if stats.TotalBooks > 0 {
+		stats.FingerprintCoveragePercent = stats.FingerprintedBooks * 100 / stats.TotalBooks
 	}
 
 	return stats, nil

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.82.0
+// version: 2.83.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package database
 
@@ -982,7 +982,19 @@ type LibraryStats struct {
 	// TotalBooks/TotalFiles in computeLibraryStats so all three counts share a
 	// single cache entry and invalidation path.
 	BrokenFiles int       `json:"broken_files"`
-	ComputedAt  time.Time `json:"computed_at"`
+	// FingerprintedBooks/PartiallyFingerprintedBooks/UnfingerprintedBooks
+	// classify every non-deleted book by whether its active book_files have
+	// any/all/none of them fingerprinted (BookFile.GetAcoustIDSeg0() != "",
+	// which already falls back to the memdb-safe AcoustIDFingerprintDurationSec
+	// proxy — see bookfile_fingerprint.go). Computed alongside the existing
+	// book_file pass so no extra scan is added.
+	FingerprintedBooks          int `json:"fingerprinted_books"`
+	PartiallyFingerprintedBooks int `json:"partially_fingerprinted_books"`
+	UnfingerprintedBooks        int `json:"unfingerprinted_books"`
+	// FingerprintCoveragePercent = FingerprintedBooks * 100 / (TotalBooks
+	// excluding non-primary duplicates counted elsewhere); 0 when TotalBooks==0.
+	FingerprintCoveragePercent int       `json:"fingerprint_coverage_percent"`
+	ComputedAt                 time.Time `json:"computed_at"`
 }
 
 // DashboardStats is an alias kept for callers that haven't migrated to LibraryStats yet.

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 8475f406-df31-4286-95b0-30787397603e
-// last-edited: 2026-06-30
+// last-edited: 2026-07-03
 
 // Package system hosts the system-level HTTP handlers extracted from the server
 // package: health, status, announcements, storage, logs, activity-log,
@@ -709,6 +709,11 @@ func (h *Handler) GetDashboard(c *gin.Context) {
 		"organizedBooks":     stats.OrganizedBooks,
 		"unorganizedBooks":   stats.UnorganizedBooks,
 		"broken_file_count":  brokenFileCount,
+
+		"fingerprintedBooks":          stats.FingerprintedBooks,
+		"partiallyFingerprintedBooks": stats.PartiallyFingerprintedBooks,
+		"unfingerprintedBooks":        stats.UnfingerprintedBooks,
+		"fingerprintCoveragePercent":  stats.FingerprintCoveragePercent,
 	})
 }
 


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-16).

Adds fingerprinted/partial/unfingerprinted book counts + coverage percent to LibraryStats (both memdb and Pebble compute paths) and exposes them on the dashboard payload. The campaign op itself already exists (acoustid.backfill) — this is the missing KPI so coverage progress toward dedup auto-resolution is visible.

Local CI evidence: make ci green in worktree; ComputeLibraryStats + handlers/system tests pass; vet clean. Note: internal/database full (non-short) suite runs near 600s — pre-existing, verified against base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1