### PR TITLE
fix(server,registry): close SYS-1/BUG-2 shutdown escape hatches

### DIFF
--- a/internal/operations/registry/registry_pebble_race_test.go
+++ b/internal/operations/registry/registry_pebble_race_test.go
@@ -1,0 +1,125 @@
+// file: internal/operations/registry/registry_pebble_race_test.go
+// version: 1.0.0
+// guid: 3f8a1c72-9d4e-4b06-8a53-1e7c2b9d0f45
+// last-edited: 2026-07-03
+
+// registry_pebble_race_test.go is the regression test for BUG-2 (TASK-19,
+// consultancy roadmap): Registry.Shutdown did not durably wait for the per-op
+// safeRun goroutine spawned in worker.go's executeRun.
+//
+// Failure mode (pre-fix): an op whose Run ignores ctx cancellation is
+// classified as abandoned during shutdown. The shutdown ctx expires during the
+// drain poll, Shutdown marks the op interrupted, cancels its internal context,
+// and reaches the final goroutineWG.Wait(). The worker goroutines ARE enrolled
+// in goroutineWG and exit quickly (after abandonGrace), so Wait() returns —
+// but the safeRun goroutine was NOT enrolled, so nothing waited for it.
+// Shutdown returned while plugin code was still writing to the store, and the
+// caller (cmd/root.go's deferred closeStore) closed the store underneath it.
+//
+// Note on the assertion style: a naive "close the store and let the straggler
+// write panic" repro (like shutdown_race_test.go uses for the dep-notify
+// goroutines) does NOT work here, because the straggler write happens inside
+// def.Run, which executes under safeRun's panic recovery — the "pebble:
+// closed" panic is recovered, converted to an error, and silently drained by
+// the abandoned-run monitor goroutine. So instead this test asserts the
+// ordering invariant directly, against a REAL PebbleStore: by the time
+// Shutdown returns, the abandoned run goroutine must have finished, and its
+// store write must have succeeded against a still-open store. Pre-fix this
+// fails deterministically (Shutdown returns ~abandonGrace after cancel, long
+// before the 400ms write); post-fix (safeRun enrolled in goroutineWG)
+// Shutdown's final Wait covers the goroutine and the write happens-before
+// store.Close().
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+func TestShutdownWaitsForAbandonedRunGoroutine_RealStore(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Repeat the start/run/shutdown/close cycle to widen the window; scheduler
+	// jitter under -race means a single iteration proves less.
+	for iter := range 5 {
+		store, cleanup := openTestPebbleStore(t)
+
+		reg := registry.NewWithOptions(store, logger, 2, registry.Options{
+			WatchdogInterval: 30 * time.Second,      // keep the watchdog out of the way
+			AbandonedCap:     10,                    // don't block dispatch
+			AbandonGrace:     20 * time.Millisecond, // classify-as-abandoned quickly
+			SweepInterval:    time.Hour,             // keep SweepTick out of the way
+		})
+
+		started := make(chan struct{})
+		var runFinished atomic.Bool
+		var writeErr atomic.Value // error from the post-cancel store write
+
+		def := makeValidDef("race.abandoned")
+		def.ID = "race.abandoned"
+		def.Plugin = "race-plugin"
+		def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+			// Deliberately ignore ctx cancellation for longer than both the
+			// shutdown ctx (5ms) and AbandonGrace (20ms) — mimics a slow or
+			// misbehaving plugin — then write to the REAL store. If Shutdown
+			// (and then store.Close) does not wait for this goroutine, this
+			// write lands on a closed store.
+			close(started)
+			time.Sleep(400 * time.Millisecond)
+			err := store.SetSetting("race_abandoned_marker", "true", "bool", false)
+			if err != nil {
+				writeErr.Store(err)
+			}
+			runFinished.Store(true)
+			return err
+		}
+		if err := reg.RegisterOp(def); err != nil {
+			t.Fatalf("iter %d: RegisterOp: %v", iter, err)
+		}
+
+		reg.Start(context.Background())
+
+		if _, err := reg.EnqueueOp(context.Background(), "race.abandoned", nil); err != nil {
+			t.Fatalf("iter %d: EnqueueOp: %v", iter, err)
+		}
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iter %d: op did not start within 5s", iter)
+		}
+
+		// Shutdown with a ctx that expires almost immediately, forcing the
+		// "ctx expired during drain poll" branch (the op is still running, the
+		// drain poll gives up, the op is marked interrupted) and sending
+		// Shutdown on to its final goroutineWG.Wait().
+		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		err := reg.Shutdown(shutCtx)
+		shutCancel()
+		if err == nil {
+			t.Fatalf("iter %d: expected Shutdown to report ctx expiry (drain poll must time out for this repro); got nil", iter)
+		}
+
+		// BUG-2 core assertion: Shutdown must not return while the abandoned
+		// run goroutine is still executing plugin code. The 400ms run fits
+		// inside goroutineWG.Wait's 2s escape hatch, so post-fix Shutdown
+		// blocks until the goroutine (and its store write) completes.
+		if !runFinished.Load() {
+			t.Fatalf("iter %d: Shutdown returned while the abandoned run goroutine was still executing (BUG-2: safeRun goroutine not enrolled in goroutineWG)", iter)
+		}
+		if we, ok := writeErr.Load().(error); ok && we != nil {
+			t.Fatalf("iter %d: abandoned run goroutine's store write failed: %v", iter, we)
+		}
+
+		// Production sequence: cmd/root.go's deferred closeStore runs right
+		// after shutdown. Post-fix this is safe because the write above
+		// happened-before Shutdown returned.
+		cleanup()
+	}
+}

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.8.0
+// version: 2.9.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-06-22
+// last-edited: 2026-07-03
 
 package registry
 
@@ -232,8 +232,20 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	}
 
 	// In-process path: run in a separate goroutine so we can detect abandonment.
+	// The goroutine is enrolled in goroutineWG for its full lifetime so
+	// Registry.Shutdown's final goroutineWG.Wait() genuinely covers plugin code
+	// (BUG-2): if the shutdown ctx expires during the drain poll and the op is
+	// marked interrupted, Shutdown must still wait for this goroutine before
+	// returning — otherwise the caller closes the store while Run is mid-write.
+	// No notifyStopped-style gate is needed here (unlike notifyDepCompletion/
+	// notifyDepFailed): this Add happens synchronously inside executeRun, which
+	// is called from the already-enrolled startWorker goroutine, whose own
+	// Done() has not run yet — so the counter is provably non-zero across this
+	// Add and can never be observed at zero by a concurrent Wait().
 	done := make(chan error, 1)
+	r.goroutineWG.Add(1)
 	go func() {
+		defer r.goroutineWG.Done()
 		done <- r.safeRun(runCtx, def, qr.params, reporter)
 	}()
 

--- a/internal/plugins/maintenance/backfill.go
+++ b/internal/plugins/maintenance/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f2a3b4c5-d6e7-8901-5678-123456789012
-// last-edited: 2026-05-07
+// last-edited: 2026-07-03
 
 package maintenance
 
@@ -62,9 +62,9 @@ func (p *Plugin) movementAtomCleanupDef() sdk.OperationDef {
 	}
 }
 
-func (p *Plugin) runMovementAtomCleanup(_ context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+func (p *Plugin) runMovementAtomCleanup(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting movement atom cleanup")
-	p.deps.StripMovementAtoms()
+	p.deps.StripMovementAtoms(ctx)
 	_ = reporter.Log(slog.LevelInfo, "Movement atom cleanup complete")
 	return nil
 }
@@ -87,9 +87,9 @@ func (p *Plugin) malformedM4BRemuxDef() sdk.OperationDef {
 	}
 }
 
-func (p *Plugin) runMalformedM4BRemux(_ context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+func (p *Plugin) runMalformedM4BRemux(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting malformed M4B remux")
-	p.deps.RemuxMalformedM4BFiles()
+	p.deps.RemuxMalformedM4BFiles(ctx)
 	_ = reporter.Log(slog.LevelInfo, "Malformed M4B remux complete")
 	return nil
 }
@@ -114,9 +114,9 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 	}
 }
 
-func (p *Plugin) runMalformedM4BTranscode(_ context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+func (p *Plugin) runMalformedM4BTranscode(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting malformed M4B transcode")
-	p.deps.TranscodeMalformedM4BFiles()
+	p.deps.TranscodeMalformedM4BFiles(ctx)
 	_ = reporter.Log(slog.LevelInfo, "Malformed M4B transcode complete")
 	return nil
 }

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-06-29
+// last-edited: 2026-07-03
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -41,9 +41,12 @@ type ServerDeps interface {
 	// ----- one-shot startup ops -----
 
 	BackfillExternalIDs()
-	StripMovementAtoms()
-	RemuxMalformedM4BFiles()
-	TranscodeMalformedM4BFiles()
+	// StripMovementAtoms, RemuxMalformedM4BFiles, and TranscodeMalformedM4BFiles
+	// take ctx so their per-file library walks stop early on cancellation
+	// (SYS-1); pass the op's run context.
+	StripMovementAtoms(ctx context.Context)
+	RemuxMalformedM4BFiles(ctx context.Context)
+	TranscodeMalformedM4BFiles(ctx context.Context)
 
 	// ----- store helpers called by ops -----
 

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-06-29
+// last-edited: 2026-07-03
 
 package maintenance
 
@@ -25,14 +25,14 @@ func (r *fakeReporter) Log(_ slog.Level, msg string, _ ...slog.Attr) error {
 	r.logs = append(r.logs, msg)
 	return nil
 }
-func (r *fakeReporter) Logger() *slog.Logger { return slog.Default() }
+func (r *fakeReporter) Logger() *slog.Logger   { return slog.Default() }
 func (r *fakeReporter) Checkpoint(_ any) error { return nil }
 func (r *fakeReporter) IsCanceled() bool       { return false }
 func (r *fakeReporter) RunPhase(_ context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
 	return fn(context.Background(), r)
 }
 func (r *fakeReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }
-func (r *fakeReporter) SetCurrentItem(_ string)                           {}
+func (r *fakeReporter) SetCurrentItem(_ string)                          {}
 
 var _ sdk.Reporter = (*fakeReporter)(nil)
 
@@ -51,24 +51,24 @@ func (d fakeDeps) RunMetadataRefreshScan(_ context.Context, _ operations.Progres
 func (d fakeDeps) RunBulkWriteBack(_ context.Context, _ string, _ []string, _ bool, _ int, _ operations.ProgressReporter) error {
 	return nil
 }
-func (d fakeDeps) RunAutoPurgeSoftDeleted(_ string)           {}
+func (d fakeDeps) RunAutoPurgeSoftDeleted(_ string) {}
 func (d fakeDeps) ExecuteSeriesPrune(_ context.Context, _ database.Store, _ operations.ProgressReporter, _ string) error {
 	return nil
 }
 func (d fakeDeps) ExecuteSeriesNormalizeCore(_ context.Context, _ database.Store, _ func(string)) ([]string, error) {
 	return nil, nil
 }
-func (d fakeDeps) BackfillExternalIDs()    {}
-func (d fakeDeps) StripMovementAtoms()     {}
-func (d fakeDeps) RemuxMalformedM4BFiles() {}
-func (d fakeDeps) TranscodeMalformedM4BFiles() {}
+func (d fakeDeps) BackfillExternalIDs()                            {}
+func (d fakeDeps) StripMovementAtoms(_ context.Context)            {}
+func (d fakeDeps) RemuxMalformedM4BFiles(_ context.Context)        {}
+func (d fakeDeps) TranscodeMalformedM4BFiles(_ context.Context)    {}
 func (d fakeDeps) CleanupOrphanedTempFiles(_ string, _ string) int { return 0 }
 func (d fakeDeps) CleanupTrashedVersions() int                     { return 0 }
 func (d fakeDeps) SweepArchivedBooks() int                         { return 0 }
 func (d fakeDeps) ActivityFlushOp(_ string)                        {}
 func (d fakeDeps) EnqueueWriteBack(_ string)                       {}
 func (d fakeDeps) PollBatch(_ context.Context) (int, error)        { return 0, nil }
-func (d fakeDeps) DedupLLMReview(_ context.Context) error { return nil }
+func (d fakeDeps) DedupLLMReview(_ context.Context) error          { return nil }
 func (d fakeDeps) DedupTriageExactPending(_ context.Context) (*TriageReport, error) {
 	return &TriageReport{}, nil
 }
@@ -82,15 +82,15 @@ func (d fakeDeps) PruneOldLogs(_ int) error   { return nil }
 func (d fakeDeps) CompactActivityLog(_ context.Context, _, _, _ int) (int, int, int, error) {
 	return 0, 0, 0, nil
 }
-func (d fakeDeps) HasDedupEngine() bool          { return false }
-func (d fakeDeps) HasMetadataFetchService() bool { return false }
-func (d fakeDeps) HasISBNEnrichment() bool       { return false }
-func (d fakeDeps) HasAIParsing() bool            { return false }
-func (d fakeDeps) HasBatchPoller() bool          { return false }
-func (d fakeDeps) RootDir() string               { return "/lib" }
-func (d fakeDeps) LogRetentionDays() int         { return 30 }
-func (d fakeDeps) PurgeSoftDeletedAfterDays() int { return 30 }
-func (d fakeDeps) ActivityLogCompactionDays() int { return 7 }
+func (d fakeDeps) HasDedupEngine() bool                { return false }
+func (d fakeDeps) HasMetadataFetchService() bool       { return false }
+func (d fakeDeps) HasISBNEnrichment() bool             { return false }
+func (d fakeDeps) HasAIParsing() bool                  { return false }
+func (d fakeDeps) HasBatchPoller() bool                { return false }
+func (d fakeDeps) RootDir() string                     { return "/lib" }
+func (d fakeDeps) LogRetentionDays() int               { return 30 }
+func (d fakeDeps) PurgeSoftDeletedAfterDays() int      { return 30 }
+func (d fakeDeps) ActivityLogCompactionDays() int      { return 7 }
 func (d fakeDeps) ActivityLogRetentionChangeDays() int { return 30 }
 func (d fakeDeps) ActivityLogRetentionDebugDays() int  { return 7 }
 func (d fakeDeps) BackupRetentionDays() int            { return 30 }

--- a/internal/remux/remux.go
+++ b/internal/remux/remux.go
@@ -1,10 +1,12 @@
 // file: internal/remux/remux.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-07-03
 
 package remux
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -40,8 +42,10 @@ func New(store Store) *Remuxer {
 // file that taglib cannot parse (malformed atom structure). Re-muxing with
 // ffmpeg -c copy rewrites the atom layout without re-encoding audio, making
 // the file readable by taglib, AtomicParsley, and Apple Devices. The output
-// is verified before replacing the original. Runs once at startup.
-func (r *Remuxer) RemuxMalformedFiles() {
+// is verified before replacing the original. Runs once at startup. The walk
+// checks ctx per file and stops early via fs.SkipAll when canceled (SYS-1);
+// a canceled run does not write the done flag, so the next startup resumes.
+func (r *Remuxer) RemuxMalformedFiles(ctx context.Context) {
 	if r.store == nil {
 		return
 	}
@@ -66,6 +70,13 @@ func (r *Remuxer) RemuxMalformedFiles() {
 	remuxed, clean, failed := 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
+		// without an error; WalkDir's return is discarded above by design.
+		select {
+		case <-ctx.Done():
+			return fs.SkipAll
+		default:
+		}
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}

--- a/internal/remux/remux_test.go
+++ b/internal/remux/remux_test.go
@@ -1,10 +1,12 @@
 // file: internal/remux/remux_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-07-03
 
 package remux
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,7 +55,7 @@ func TestRemuxerNew(t *testing.T) {
 
 func TestRemuxMalformedFilesWithoutStore(t *testing.T) {
 	remuxer := &Remuxer{store: nil}
-	remuxer.RemuxMalformedFiles() // Should not panic
+	remuxer.RemuxMalformedFiles(context.Background()) // Should not panic
 }
 
 func TestRemuxMalformedFilesAlreadyCompleted(t *testing.T) {
@@ -67,7 +69,7 @@ func TestRemuxMalformedFilesAlreadyCompleted(t *testing.T) {
 		},
 	}
 	remuxer := New(store)
-	remuxer.RemuxMalformedFiles() // Should skip due to already completed
+	remuxer.RemuxMalformedFiles(context.Background()) // Should skip due to already completed
 }
 
 func TestRemuxFileErrorsOnNonexistentFile(t *testing.T) {

--- a/internal/remux/transcode.go
+++ b/internal/remux/transcode.go
@@ -1,10 +1,12 @@
 // file: internal/remux/transcode.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
+// last-edited: 2026-07-03
 
 package remux
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io/fs"
@@ -40,8 +42,10 @@ func TranscodeSkipKey(path string) string {
 // TranscodeMalformedFiles walks the library and re-encodes any M4B/M4A
 // file that taglib cannot parse even after the remux pass. Full AAC transcode
 // at 64 kbps rebuilds the file from scratch, which fixes corruption that a
-// stream copy cannot repair. Runs once at startup.
-func (t *Transcoder) TranscodeMalformedFiles() {
+// stream copy cannot repair. Runs once at startup. The walk checks ctx per
+// file and stops early via fs.SkipAll when canceled (SYS-1); a canceled run
+// does not write the done flag, so the next startup resumes.
+func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 	if t.store == nil {
 		return
 	}
@@ -80,6 +84,13 @@ func (t *Transcoder) TranscodeMalformedFiles() {
 	transcoded, clean, failed, skipped := 0, 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
+		// without an error; WalkDir's return is discarded above by design.
+		select {
+		case <-ctx.Done():
+			return fs.SkipAll
+		default:
+		}
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}

--- a/internal/remux/transcode_test.go
+++ b/internal/remux/transcode_test.go
@@ -1,10 +1,12 @@
 // file: internal/remux/transcode_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-07-03
 
 package remux
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -28,7 +30,7 @@ func TestTranscoderNew(t *testing.T) {
 
 func TestTranscodeMalformedFilesWithoutStore(t *testing.T) {
 	transcoder := &Transcoder{store: nil}
-	transcoder.TranscodeMalformedFiles() // Should not panic
+	transcoder.TranscodeMalformedFiles(context.Background()) // Should not panic
 }
 
 func TestTranscodeMalformedFilesAlreadyCompleted(t *testing.T) {
@@ -42,7 +44,7 @@ func TestTranscodeMalformedFilesAlreadyCompleted(t *testing.T) {
 		},
 	}
 	transcoder := NewTranscoder(store)
-	transcoder.TranscodeMalformedFiles() // Should skip due to already completed
+	transcoder.TranscodeMalformedFiles(context.Background()) // Should skip due to already completed
 }
 
 func TestTranscodeSkipKey(t *testing.T) {

--- a/internal/server/malformed_m4b_wrappers.go
+++ b/internal/server/malformed_m4b_wrappers.go
@@ -1,21 +1,26 @@
 // file: internal/server/malformed_m4b_wrappers.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-07-03
 
 package server
 
 import (
+	"context"
+
 	"github.com/falkcorp/audiobook-organizer/internal/remux"
 )
 
 // remuxMalformedM4BFiles is a thin wrapper that delegates to the remux package.
-func (s *Server) remuxMalformedM4BFiles() {
+// ctx lets the library walk stop early on shutdown (SYS-1).
+func (s *Server) remuxMalformedM4BFiles(ctx context.Context) {
 	remuxer := remux.New(s.store)
-	remuxer.RemuxMalformedFiles()
+	remuxer.RemuxMalformedFiles(ctx)
 }
 
 // transcodeMalformedM4BFiles is a thin wrapper that delegates to the remux package.
-func (s *Server) transcodeMalformedM4BFiles() {
+// ctx lets the library walk stop early on shutdown (SYS-1).
+func (s *Server) transcodeMalformedM4BFiles(ctx context.Context) {
 	transcoder := remux.NewTranscoder(s.store)
-	transcoder.TranscodeMalformedFiles()
+	transcoder.TranscodeMalformedFiles(ctx)
 }

--- a/internal/server/movement_atom_cleanup.go
+++ b/internal/server/movement_atom_cleanup.go
@@ -1,6 +1,7 @@
 // file: internal/server/movement_atom_cleanup.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c2d3e4f5-a6b7-8c9d-0e1f-2a3b4c5d6e7f
+// last-edited: 2026-07-03
 
 package server
 
@@ -25,8 +26,11 @@ var movementAtoms = []string{"SHOWWORKMOVEMENT", "MOVEMENTNUMBER", "MOVEMENTNAME
 
 // stripMovementAtoms walks the library root once, removes the three movement
 // atoms from every M4B/M4A file that has them, then marks itself done via a
-// settings flag so it never runs again.
-func (s *Server) stripMovementAtoms() {
+// settings flag so it never runs again. The walk checks ctx per file and
+// stops early via fs.SkipAll when canceled (SYS-1), so shutdown's 30s grace
+// period is not blown by a first-run walk over a large library. A canceled
+// run does not write the done flag, so the next startup resumes the cleanup.
+func (s *Server) stripMovementAtoms(ctx context.Context) {
 	store := s.Store()
 	if store == nil {
 		return
@@ -50,6 +54,13 @@ func (s *Server) stripMovementAtoms() {
 	stripped, clean, failed := 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
+		// without an error; WalkDir's return is discarded above by design.
+		select {
+		case <-ctx.Done():
+			return fs.SkipAll
+		default:
+		}
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.38.0
+// version: 1.39.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package server
 
@@ -465,24 +465,23 @@ func (s *Server) Start(cfg ServerConfig) error {
 
 	// Strip shwm/©mvi/©mvn atoms from audiobook files (one-time). These
 	// classical-music atoms crash Apple Devices for Windows at sync.
-	// NOTE: stripMovementAtoms does not check bgCtx; it runs to completion
-	// once the "done" flag is missing. On the first run after upgrade this
-	// can take O(seconds–minutes) on large libraries and is a known
-	// contributor to the 30s grace-period timeout on shutdown.
+	// Checks bgCtx per file (SYS-1) so shutdown stops the walk early instead
+	// of blowing the 30s grace period on a first-run walk over a large
+	// library; a canceled run resumes on the next startup.
 	s.bgWG.Add("strip-movement-atoms")
 	go func() {
 		defer s.bgWG.Done("strip-movement-atoms")
-		s.stripMovementAtoms()
+		s.stripMovementAtoms(s.bgCtx)
 	}()
 
 	// Re-mux M4B/M4A files with malformed atom structures so taglib,
 	// AtomicParsley, and Apple Devices can read them (one-time).
-	// NOTE: remuxMalformedM4BFiles does not check bgCtx; same first-run
-	// latency caveat as stripMovementAtoms above.
+	// Checks bgCtx per file (SYS-1); same early-stop behavior as
+	// stripMovementAtoms above.
 	s.bgWG.Add("remux-malformed-m4b")
 	go func() {
 		defer s.bgWG.Done("remux-malformed-m4b")
-		s.remuxMalformedM4BFiles()
+		s.remuxMalformedM4BFiles(s.bgCtx)
 	}()
 
 	// Build the search index on first startup (or if it got wiped).
@@ -499,12 +498,12 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// One-time startup jobs: transcode malformed M4B files, then quarantine any
 	// that remained permanently unreadable. Run sequentially in a bgWG goroutine
 	// so shutdown waits for them and they don't race against the HTTP server.
-	// NOTE: transcodeMalformedM4BFiles does not check bgCtx; same first-run
-	// latency caveat as stripMovementAtoms above.
+	// transcodeMalformedM4BFiles checks bgCtx per file (SYS-1); same
+	// early-stop behavior as stripMovementAtoms above.
 	s.bgWG.Add("transcode+quarantine")
 	go func() {
 		defer s.bgWG.Done("transcode+quarantine")
-		s.transcodeMalformedM4BFiles()
+		s.transcodeMalformedM4BFiles(s.bgCtx)
 		s.quarantineKnownBadFiles()
 	}()
 

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-06-29
+// last-edited: 2026-07-03
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -60,16 +60,16 @@ func (s *Server) BackfillExternalIDs() {
 	s.backfillExternalIDs()
 }
 
-func (s *Server) StripMovementAtoms() {
-	s.stripMovementAtoms()
+func (s *Server) StripMovementAtoms(ctx context.Context) {
+	s.stripMovementAtoms(ctx)
 }
 
-func (s *Server) RemuxMalformedM4BFiles() {
-	s.remuxMalformedM4BFiles()
+func (s *Server) RemuxMalformedM4BFiles(ctx context.Context) {
+	s.remuxMalformedM4BFiles(ctx)
 }
 
-func (s *Server) TranscodeMalformedM4BFiles() {
-	s.transcodeMalformedM4BFiles()
+func (s *Server) TranscodeMalformedM4BFiles(ctx context.Context) {
+	s.transcodeMalformedM4BFiles(ctx)
 }
 
 // ---- store helpers ----


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-19, Opus tier).

Two shutdown holes in the PEBBLE-CLOSED class: (a) SYS-1 — three non-ctx-aware startup jobs (movement-atom strip, remux, transcode walks) now take ctx and honor s.bgCtx cancellation per file; (b) BUG-2 — executeRun's safeRun goroutine is now enrolled in the registry's goroutineWG, so Shutdown cannot return while an abandoned run goroutine still writes to Pebble. New real-Pebble -race regression test FAILED pre-fix (proving the bug) and passes 5×5 shutdown cycles post-fix. Timed escape hatches retained as logged last resorts.

Local CI evidence: make ci green in worktree; registry -race suite ok; remux/maintenance/server targeted tests ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1