### PR TITLE
feat(auth): add TTL + rotation for bootstrap-issued API keys (SEC-1)

### DIFF
--- a/.claude/skills/server-bootstrap/SKILL.md
+++ b/.claude/skills/server-bootstrap/SKILL.md
@@ -61,9 +61,15 @@ Returns:
   "key_id": "...",
   "user_id": "...",
   "username": "admin",
-  "scopes": ["all"]
+  "scopes": ["all"],
+  "expires_at": "2026-08-02T12:00:00Z"
 }
 ```
+
+`expires_at` is the server-side expiry of the issued key (default 30 days,
+config `bootstrap_key_ttl_days`; SEC-1/PROC-6). This is unrelated to the
+8-hour client-side `.claude/.api-token` cleanup convention above — the
+server TTL is much longer, so there's no conflict between the two.
 
 See [references/bootstrap-api.md](references/bootstrap-api.md) for full API details.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.60.0
+// version: 1.61.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-06-22
+// last-edited: 2026-07-03
 
 package config
 
@@ -339,6 +339,13 @@ type Config struct {
 	// fetch cache (Audible/Audnexus/etc. API results) is considered fresh.
 	// 0 means never expire. Default 7.
 	MetadataFetchCacheTTLDays int `json:"metadata_fetch_cache_ttl_days"`
+	// BootstrapKeyTTLDays is how long (in days) a bootstrap-issued, full-scope
+	// API key remains valid before the auth middleware's existing expiry check
+	// rejects it. Unlike MetadataFetchCacheTTLDays, 0 (or any non-positive
+	// value) does NOT mean "never expire" — bootstrap keys are full-scope
+	// admin credentials and must always expire, so a non-positive value falls
+	// back to the default of 30. (SEC-1/PROC-6)
+	BootstrapKeyTTLDays int `json:"bootstrap_key_ttl_days"`
 	MemoryLimitPercent        int `json:"memory_limit_percent"` // % of system memory
 	MemoryLimitMB             int `json:"memory_limit_mb"`      // absolute MB
 
@@ -526,6 +533,7 @@ func InitConfig() {
 	viper.SetDefault("memory_limit_type", "items")
 	viper.SetDefault("cache_size", 1000)
 	viper.SetDefault("metadata_fetch_cache_ttl_days", 180)
+	viper.SetDefault("bootstrap_key_ttl_days", 30)
 	viper.SetDefault("memory_limit_percent", 25)
 	viper.SetDefault("memory_limit_mb", 512)
 
@@ -806,6 +814,7 @@ func InitConfig() {
 			MemoryLimitType:           viper.GetString("memory_limit_type"),
 			CacheSize:                 viper.GetInt("cache_size"),
 			MetadataFetchCacheTTLDays: viper.GetInt("metadata_fetch_cache_ttl_days"),
+			BootstrapKeyTTLDays:       viper.GetInt("bootstrap_key_ttl_days"),
 			MemoryLimitPercent:        viper.GetInt("memory_limit_percent"),
 			MemoryLimitMB:             viper.GetInt("memory_limit_mb"),
 

--- a/internal/database/apikey_invite_test.go
+++ b/internal/database/apikey_invite_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/apikey_invite_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5d1e8a2f-4c3b-4f70-a9d6-2e7f0c1b9a48
+// last-edited: 2026-07-03
 
 package database
 
@@ -65,6 +66,50 @@ func TestAPIKey_Lifecycle(t *testing.T) {
 	}
 	if got.UseCount != 1 {
 		t.Errorf("UseCount = %d, want 1", got.UseCount)
+	}
+}
+
+// SetAPIKeyExpiry round-trips through PebbleStore (SEC-1/PROC-6 rotation
+// grace window): it updates only ExpiresAt, leaving Status untouched so the
+// key keeps working until the new expiry via the existing middleware check.
+func TestAPIKey_SetAPIKeyExpiry_RoundTrips(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	key, err := store.CreateAPIKey(&APIKey{UserID: "u1", Name: "rotated-key", Status: "active"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if key.ExpiresAt != nil {
+		t.Fatalf("expected nil ExpiresAt on creation, got %v", key.ExpiresAt)
+	}
+
+	grace := time.Now().Add(1 * time.Hour)
+	if err := store.SetAPIKeyExpiry(key.ID, grace); err != nil {
+		t.Fatalf("SetAPIKeyExpiry: %v", err)
+	}
+
+	got, err := store.GetAPIKey(key.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get: %v / %v", got, err)
+	}
+	if got.ExpiresAt == nil {
+		t.Fatal("ExpiresAt should be non-nil after SetAPIKeyExpiry")
+	}
+	if got.ExpiresAt.Unix() != grace.Unix() {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, grace)
+	}
+	// Status must be untouched — SetAPIKeyExpiry is not a revoke.
+	if got.Status != "active" {
+		t.Errorf("Status = %q, want %q (SetAPIKeyExpiry must not revoke)", got.Status, "active")
+	}
+
+	// Unknown ID is a silent no-op (mirrors SetAPIKeyStatus's nil-key contract).
+	if err := store.SetAPIKeyExpiry("does-not-exist", grace); err != nil {
+		t.Errorf("SetAPIKeyExpiry on unknown id: %v, want nil error", err)
 	}
 }
 

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 package database
 
@@ -78,6 +78,11 @@ type APIKeyStore interface {
 	ListAllAPIKeys() ([]APIKey, error)
 	RevokeAPIKey(id string) error
 	SetAPIKeyStatus(id, status string, at time.Time) error
+	// SetAPIKeyExpiry updates only the ExpiresAt field on an existing key,
+	// leaving Status untouched. Used for the rotation grace window, where the
+	// old key must keep working until `at` rather than being revoked
+	// immediately (SEC-1/PROC-6).
+	SetAPIKeyExpiry(id string, at time.Time) error
 	TouchAPIKeyLastUsed(id string, at time.Time, ip string) error
 }
 

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.67.0
+// version: 1.68.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-28
+// last-edited: 2026-07-03
 
 package database
 
@@ -264,6 +264,7 @@ type MockStore struct {
 	ListAllAPIKeysFunc      func() ([]APIKey, error)
 	RevokeAPIKeyFunc        func(id string) error
 	SetAPIKeyStatusFunc     func(id, status string, at time.Time) error
+	SetAPIKeyExpiryFunc     func(id string, at time.Time) error
 	TouchAPIKeyLastUsedFunc func(id string, at time.Time, ip string) error
 
 	// Invites
@@ -1630,6 +1631,13 @@ func (m *MockStore) RevokeAPIKey(id string) error {
 func (m *MockStore) SetAPIKeyStatus(id, status string, at time.Time) error {
 	if m.SetAPIKeyStatusFunc != nil {
 		return m.SetAPIKeyStatusFunc(id, status, at)
+	}
+	return nil
+}
+
+func (m *MockStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	if m.SetAPIKeyExpiryFunc != nil {
+		return m.SetAPIKeyExpiryFunc(id, at)
 	}
 	return nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -12163,6 +12163,63 @@ func (_c *MockAPIKeyStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id string,
 	return _c
 }
 
+// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyStore
+func (_mock *MockAPIKeyStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockAPIKeyStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockAPIKeyStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockAPIKeyStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	return &MockAPIKeyStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TouchAPIKeyLastUsed provides a mock function for the type MockAPIKeyStore
 func (_mock *MockAPIKeyStore) TouchAPIKeyLastUsed(id string, at time.Time, ip string) error {
 	ret := _mock.Called(id, at, ip)
@@ -48191,6 +48248,63 @@ func (_c *MockStore_SetAPIKeyStatus_Call) Return(err error) *MockStore_SetAPIKey
 }
 
 func (_c *MockStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id string, status string, at time.Time) error) *MockStore_SetAPIKeyStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetAPIKeyExpiry provides a mock function for the type MockStore
+func (_mock *MockStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockStore_SetAPIKeyExpiry_Call {
+	return &MockStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) Return(err error) *MockStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockStore_SetAPIKeyExpiry_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -12100,6 +12100,63 @@ func (_c *MockAPIKeyStore_RevokeAPIKey_Call) RunAndReturn(run func(id string) er
 	return _c
 }
 
+// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyStore
+func (_mock *MockAPIKeyStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockAPIKeyStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockAPIKeyStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockAPIKeyStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	return &MockAPIKeyStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetAPIKeyStatus provides a mock function for the type MockAPIKeyStore
 func (_mock *MockAPIKeyStore) SetAPIKeyStatus(id string, status string, at time.Time) error {
 	ret := _mock.Called(id, status, at)
@@ -12159,63 +12216,6 @@ func (_c *MockAPIKeyStore_SetAPIKeyStatus_Call) Return(err error) *MockAPIKeySto
 }
 
 func (_c *MockAPIKeyStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id string, status string, at time.Time) error) *MockAPIKeyStore_SetAPIKeyStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyStore
-func (_mock *MockAPIKeyStore) SetAPIKeyExpiry(id string, at time.Time) error {
-	ret := _mock.Called(id, at)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetAPIKeyExpiry")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
-		r0 = returnFunc(id, at)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockAPIKeyStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
-type MockAPIKeyStore_SetAPIKeyExpiry_Call struct {
-	*mock.Call
-}
-
-// SetAPIKeyExpiry is a helper method to define mock.On call
-//   - id string
-//   - at time.Time
-func (_e *MockAPIKeyStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
-	return &MockAPIKeyStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
-}
-
-func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 time.Time
-		if args[1] != nil {
-			arg1 = args[1].(time.Time)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockAPIKeyStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyStore_SetAPIKeyExpiry_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -48189,6 +48189,63 @@ func (_c *MockStore_SearchBooks_Call) RunAndReturn(run func(query string, limit 
 	return _c
 }
 
+// SetAPIKeyExpiry provides a mock function for the type MockStore
+func (_mock *MockStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockStore_SetAPIKeyExpiry_Call {
+	return &MockStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) Return(err error) *MockStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetAPIKeyStatus provides a mock function for the type MockStore
 func (_mock *MockStore) SetAPIKeyStatus(id string, status string, at time.Time) error {
 	ret := _mock.Called(id, status, at)
@@ -48248,63 +48305,6 @@ func (_c *MockStore_SetAPIKeyStatus_Call) Return(err error) *MockStore_SetAPIKey
 }
 
 func (_c *MockStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id string, status string, at time.Time) error) *MockStore_SetAPIKeyStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetAPIKeyExpiry provides a mock function for the type MockStore
-func (_mock *MockStore) SetAPIKeyExpiry(id string, at time.Time) error {
-	ret := _mock.Called(id, at)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetAPIKeyExpiry")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
-		r0 = returnFunc(id, at)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
-type MockStore_SetAPIKeyExpiry_Call struct {
-	*mock.Call
-}
-
-// SetAPIKeyExpiry is a helper method to define mock.On call
-//   - id string
-//   - at time.Time
-func (_e *MockStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockStore_SetAPIKeyExpiry_Call {
-	return &MockStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
-}
-
-func (_c *MockStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockStore_SetAPIKeyExpiry_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 time.Time
-		if args[1] != nil {
-			arg1 = args[1].(time.Time)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockStore_SetAPIKeyExpiry_Call) Return(err error) *MockStore_SetAPIKeyExpiry_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockStore_SetAPIKeyExpiry_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.100.0
+// version: 1.101.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package database
 
@@ -6049,6 +6049,27 @@ func (p *PebbleStore) SetAPIKeyStatus(id, status string, at time.Time) error {
 	case "active":
 		k.DeactivatedAt = nil
 	}
+	data, err := json.Marshal(k)
+	if err != nil {
+		return err
+	}
+	return p.db.Set([]byte("apikey:"+id), data, pebble.Sync)
+}
+
+// SetAPIKeyExpiry updates only the ExpiresAt field on an existing key,
+// leaving Status (and idx: entries) untouched. Used by the rotation grace
+// window (SEC-1/PROC-6): the old key gets a short future ExpiresAt instead
+// of being revoked outright, so the pre-existing middleware expiry check
+// retires it naturally after the grace period.
+func (p *PebbleStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	k, err := p.GetAPIKey(id)
+	if err != nil {
+		return err
+	}
+	if k == nil {
+		return nil
+	}
+	k.ExpiresAt = &at
 	data, err := json.Marshal(k)
 	if err != nil {
 		return err

--- a/internal/server/apikey_expiry_sweep.go
+++ b/internal/server/apikey_expiry_sweep.go
@@ -1,0 +1,107 @@
+// file: internal/server/apikey_expiry_sweep.go
+// version: 1.0.0
+// guid: 481f65a7-e54a-4be2-b43e-d6d992fcbd60
+// last-edited: 2026-07-03
+
+package server
+
+import (
+	"log/slog"
+	"time"
+)
+
+const (
+	// apiKeyExpirySweepInterval is coarse on purpose — this is observability,
+	// not a hot path.
+	apiKeyExpirySweepInterval = 6 * time.Hour
+	// apiKeyExpiryWarnWindow is how far ahead of expiry a key starts getting
+	// warned about.
+	apiKeyExpiryWarnWindow = 7 * 24 * time.Hour
+)
+
+// warnExpiringAPIKeys is a low-frequency, observability-only background
+// sweep (SEC-1/PROC-6): it logs slog.Warn for active API keys approaching
+// expiry, and a one-time-per-process deprecation warning for legacy active
+// keys that have no expiry at all (ExpiresAt == nil). It NEVER rejects,
+// revokes, or otherwise modifies a key — enforcement remains solely in the
+// pre-existing middleware check (internal/server/middleware/auth.go,
+// `key.ExpiresAt != nil && time.Now().After(*key.ExpiresAt)`), which already
+// treats a nil ExpiresAt as "never expires". This function must not change
+// that behavior.
+//
+// It runs forever until s.bgCtx is canceled (intended to be started from
+// Server.Start via `s.bgWG.Add("apikey-expiry-sweep"); go func() { defer
+// s.bgWG.Done("apikey-expiry-sweep"); s.warnExpiringAPIKeys() }()`, mirroring
+// the other long-lived store-touching goroutines) ticking every
+// apiKeyExpirySweepInterval and logging slog.Warn for:
+//   - active keys with ExpiresAt == nil (legacy, never-expiring keys) — once
+//     per key ID per process, so restarts re-warn but a long-running process
+//     doesn't spam every tick.
+//   - active keys with ExpiresAt != nil that are within apiKeyExpiryWarnWindow
+//     of expiring (and not yet expired) — once per key ID until expiry is
+//     observed to have moved (e.g. the key was rotated), tracked by the
+//     expiry timestamp itself so a rotation naturally re-arms the warning.
+//
+// This goroutine owns its state exclusively (no shared mutable state with
+// other goroutines beyond the store), so no mutex is needed.
+func (s *Server) warnExpiringAPIKeys() {
+	store := s.Store()
+	if store == nil {
+		return
+	}
+
+	// warnedLegacy tracks key IDs already warned about having no expiry at
+	// all. warnedExpiring maps key ID -> the ExpiresAt value last warned
+	// about, so a rotation (which changes ExpiresAt) re-arms the warning.
+	warnedLegacy := map[string]bool{}
+	warnedExpiring := map[string]time.Time{}
+
+	ticker := time.NewTicker(apiKeyExpirySweepInterval)
+	defer ticker.Stop()
+
+	sweep := func() {
+		keys, err := store.ListAllAPIKeys()
+		if err != nil {
+			slog.Warn("apikey expiry sweep: failed to list keys", "err", err)
+			return
+		}
+		now := time.Now()
+		for _, k := range keys {
+			if k.Status != "active" {
+				continue
+			}
+			if k.ExpiresAt == nil {
+				if !warnedLegacy[k.ID] {
+					warnedLegacy[k.ID] = true
+					slog.Warn("api key has no expiry (legacy) — set one via rotate",
+						"key_id", k.ID, "user_id", k.UserID, "name", k.Name)
+				}
+				continue
+			}
+			if now.After(*k.ExpiresAt) {
+				// Already expired — the middleware handles rejection; the
+				// sweep has nothing new to warn about for this key.
+				continue
+			}
+			if k.ExpiresAt.Sub(now) > apiKeyExpiryWarnWindow {
+				continue
+			}
+			if last, ok := warnedExpiring[k.ID]; ok && last.Equal(*k.ExpiresAt) {
+				continue
+			}
+			warnedExpiring[k.ID] = *k.ExpiresAt
+			slog.Warn("api key approaching expiry",
+				"key_id", k.ID, "user_id", k.UserID, "name", k.Name,
+				"expires_at", k.ExpiresAt.Format(time.RFC3339))
+		}
+	}
+
+	for {
+		select {
+		case <-s.bgCtx.Done():
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -1,7 +1,7 @@
 // file: internal/server/bootstrap.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: 3e7c9a12-4f6b-4d8e-b5a1-2c8f0e3d9b47
-// last-edited: 2026-06-09
+// last-edited: 2026-07-03
 
 package server
 
@@ -337,6 +337,15 @@ func (s *Server) handleBootstrap(c *gin.Context) {
 
 	scopes := auth.All()
 
+	// Bootstrap-issued keys are full-scope admin credentials and must always
+	// expire (SEC-1/PROC-6) — a non-positive configured TTL falls back to the
+	// default of 30 days rather than "never expire".
+	ttlDays := config.AppConfig.BootstrapKeyTTLDays
+	if ttlDays <= 0 {
+		ttlDays = 30
+	}
+	expiresAt := time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour)
+
 	key := &database.APIKey{
 		ID:          ulid.Make().String(),
 		UserID:      adminUser.ID,
@@ -346,6 +355,7 @@ func (s *Server) handleBootstrap(c *gin.Context) {
 		Scopes:      scopes,
 		Status:      "active",
 		CreatedAt:   time.Now(),
+		ExpiresAt:   &expiresAt,
 	}
 
 	created, err := store.CreateAPIKey(key)
@@ -358,22 +368,24 @@ func (s *Server) handleBootstrap(c *gin.Context) {
 	slog.Info("Token consumed new API key created user key_id ip", "adminUser", adminUser.Username, "created", created.ID, "ip", ip)
 
 	type bootstrapResp struct {
-		APIKey            string   `json:"api_key"`
-		KeyID             string   `json:"key_id"`
-		UserID            string   `json:"user_id"`
-		Username          string   `json:"username"`
-		Scopes            []string `json:"scopes"`
-		Message           string   `json:"message"`
-		GeneratedPassword string   `json:"generated_password,omitempty"`
-		PasswordMessage   string   `json:"password_message,omitempty"`
+		APIKey            string     `json:"api_key"`
+		KeyID             string     `json:"key_id"`
+		UserID            string     `json:"user_id"`
+		Username          string     `json:"username"`
+		Scopes            []string   `json:"scopes"`
+		Message           string     `json:"message"`
+		ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+		GeneratedPassword string     `json:"generated_password,omitempty"`
+		PasswordMessage   string     `json:"password_message,omitempty"`
 	}
 	rsp := bootstrapResp{
-		APIKey:   raw,
-		KeyID:    created.ID,
-		UserID:   adminUser.ID,
-		Username: adminUser.Username,
-		Scopes:   scopes,
-		Message:  "Bootstrap token consumed. This key will not be shown again.",
+		APIKey:    raw,
+		KeyID:     created.ID,
+		UserID:    adminUser.ID,
+		Username:  adminUser.Username,
+		Scopes:    scopes,
+		Message:   "Bootstrap token consumed. This key will not be shown again.",
+		ExpiresAt: created.ExpiresAt,
 	}
 	if generatedPassword != "" {
 		rsp.GeneratedPassword = generatedPassword

--- a/internal/server/bootstrap_security_test.go
+++ b/internal/server/bootstrap_security_test.go
@@ -1,14 +1,21 @@
 // file: internal/server/bootstrap_security_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 2b9d4e6a-1c3f-4a8b-bd72-5e0a9c4f1d36
-// last-edited: 2026-06-09
+// last-edited: 2026-07-03
 
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
@@ -87,5 +94,83 @@ func TestConsumeBootstrapToken_CorrectTokenConsumes(t *testing.T) {
 	// Token must be gone after consumption (single-use).
 	if _, err := store.GetSetting(bootstrapTokenKey); err == nil {
 		t.Fatal("expected token key to be deleted after consumption")
+	}
+}
+
+// TestHandleBootstrap_IssuesExpiringKey verifies SEC-1/PROC-6: bootstrap-issued
+// keys now carry a non-nil ExpiresAt derived from
+// config.AppConfig.BootstrapKeyTTLDays (default 30d when unset/non-positive),
+// and the JSON response surfaces expires_at.
+func TestHandleBootstrap_IssuesExpiringKey(t *testing.T) {
+	origCfg := config.AppConfig
+	defer func() { config.AppConfig = origCfg }()
+	config.AppConfig.BootstrapKeyTTLDays = 0 // exercise the <=0 -> 30 fallback
+	config.AppConfig.DatabasePath = t.TempDir() + "/db"
+
+	settings := newFakeSettingsStore()
+	_ = settings.SetSetting(bootstrapTokenKey, hashBootstrapToken("abbs_correct"), "string", false)
+
+	adminUser := &database.User{ID: "admin-1", Username: "admin", Roles: []string{"admin"}}
+	adminRole := &database.Role{ID: "admin", Name: "admin", Permissions: []string{string(auth.PermUsersManage)}}
+
+	var createdKey *database.APIKey
+	mockStore := &database.MockStore{
+		GetSettingFunc:    settings.GetSetting,
+		SetSettingFunc:    settings.SetSetting,
+		DeleteSettingFunc: settings.DeleteSetting,
+		GetRoleByNameFunc: func(name string) (*database.Role, error) {
+			if name == "admin" {
+				return adminRole, nil
+			}
+			return nil, nil
+		},
+		ListUsersFunc: func() ([]database.User, error) {
+			return []database.User{*adminUser}, nil
+		},
+		CreateAPIKeyFunc: func(key *database.APIKey) (*database.APIKey, error) {
+			key.ID = "key-bootstrap-1"
+			createdKey = key
+			return key, nil
+		},
+	}
+
+	s := &Server{store: mockStore}
+
+	gin.SetMode(gin.TestMode)
+	body, _ := json.Marshal(map[string]string{"token": "abbs_correct"})
+	req := httptest.NewRequest("POST", "/api/v1/auth/bootstrap", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.77:12345"
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+
+	s.handleBootstrap(c)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if createdKey == nil {
+		t.Fatal("CreateAPIKey was not called")
+	}
+	if createdKey.ExpiresAt == nil {
+		t.Fatal("bootstrap-issued key must have a non-nil ExpiresAt")
+	}
+	wantMin := time.Now().Add(29 * 24 * time.Hour)
+	wantMax := time.Now().Add(31 * 24 * time.Hour)
+	if createdKey.ExpiresAt.Before(wantMin) || createdKey.ExpiresAt.After(wantMax) {
+		t.Errorf("ExpiresAt = %v, want roughly 30 days from now (between %v and %v)", createdKey.ExpiresAt, wantMin, wantMax)
+	}
+
+	var resp struct {
+		Data struct {
+			ExpiresAt *time.Time `json:"expires_at"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Data.ExpiresAt == nil {
+		t.Fatal("bootstrapResp JSON must include a non-nil expires_at")
 	}
 }

--- a/internal/server/handlers/apikeys.go
+++ b/internal/server/handlers/apikeys.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/apikeys.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
-// last-edited: 2026-06-01
+// last-edited: 2026-07-03
 
 package handlers
 
@@ -11,10 +11,17 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
 )
+
+// apiKeyRotationGraceWindow is how long the OLD key keeps working after a
+// rotation before the pre-existing middleware expiry check retires it. This
+// gives in-flight clients/scripts holding the old key a chance to pick up
+// the new one instead of failing instantly (SEC-1/PROC-6).
+const apiKeyRotationGraceWindow = 1 * time.Hour
 
 // ---- Request / response types -----------------------------------------------
 
@@ -70,6 +77,7 @@ type APIKeyHandlerStore interface {
 	ListAPIKeysForUser(userID string) ([]database.APIKey, error)
 	RevokeAPIKey(id string) error
 	SetAPIKeyStatus(id, status string, at time.Time) error
+	SetAPIKeyExpiry(id string, at time.Time) error
 }
 
 // ---- Handler -----------------------------------------------------------------
@@ -337,4 +345,76 @@ func (h *APIKeyHandler) Revoke(c *gin.Context) {
 	}
 	slog.Info("apikey revoked", "id", id, "caller", caller.ID, "name", key.Name)
 	httputil.RespondWithNoContent(c)
+}
+
+// Rotate handles POST /auth/api-keys/:id/rotate. It issues a fresh key that
+// inherits the old key's scopes, and instead of revoking the old key
+// immediately it puts it on a short grace-window expiry via
+// SetAPIKeyExpiry — the pre-existing middleware expiry check
+// (key.ExpiresAt != nil && time.Now().After(*key.ExpiresAt)) retires it
+// naturally once the grace window elapses. This avoids breaking in-flight
+// clients that haven't picked up the new key yet (SEC-1/PROC-6).
+func (h *APIKeyHandler) Rotate(c *gin.Context) {
+	caller, ok := servermiddleware.CurrentUser(c)
+	if !ok || caller == nil {
+		httputil.RespondWithUnauthorized(c, "authentication required")
+		return
+	}
+	id := c.Param("id")
+	oldKey, err := h.store.GetAPIKey(id)
+	if err != nil {
+		httputil.InternalError(c, "failed to get api key", err)
+		return
+	}
+	if oldKey == nil {
+		httputil.RespondWithNotFound(c, "api key", id)
+		return
+	}
+	if oldKey.UserID != caller.ID && !isAdminUser(c) {
+		httputil.RespondWithForbidden(c, "access denied")
+		return
+	}
+
+	rawToken, hash, err := database.GenerateAPIKeyToken()
+	if err != nil {
+		httputil.InternalError(c, "failed to generate token", err)
+		return
+	}
+
+	ttlDays := config.AppConfig.BootstrapKeyTTLDays
+	if ttlDays <= 0 {
+		ttlDays = 30
+	}
+	newExpiresAt := time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour)
+
+	newKey := &database.APIKey{
+		UserID:      oldKey.UserID,
+		Name:        oldKey.Name,
+		Description: oldKey.Description,
+		TokenHash:   hash,
+		Scopes:      oldKey.Scopes,
+		Status:      "active",
+		ExpiresAt:   &newExpiresAt,
+	}
+	created, err := h.store.CreateAPIKey(newKey)
+	if err != nil {
+		httputil.InternalError(c, "failed to create api key", err)
+		return
+	}
+
+	graceExpiresAt := time.Now().Add(apiKeyRotationGraceWindow)
+	if err := h.store.SetAPIKeyExpiry(oldKey.ID, graceExpiresAt); err != nil {
+		httputil.InternalError(c, "failed to grace-window old api key", err)
+		return
+	}
+
+	slog.Info("apikey rotated", "id", created.ID, "user", oldKey.UserID, "old_key_id", oldKey.ID, "grace_window", apiKeyRotationGraceWindow.String())
+	httputil.RespondWithCreated(c, CreateAPIKeyResponse{
+		ID:        created.ID,
+		Name:      created.Name,
+		Token:     rawToken,
+		Scopes:    created.Scopes,
+		ExpiresAt: created.ExpiresAt,
+		CreatedAt: created.CreatedAt,
+	})
 }

--- a/internal/server/handlers/apikeys_test.go
+++ b/internal/server/handlers/apikeys_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/apikeys_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e6f7a8b9-c0d1-2345-6789-0abcdef01234
-// last-edited: 2026-06-01
+// last-edited: 2026-07-03
 
 package handlers_test
 
@@ -166,4 +166,100 @@ func TestAPIKeyHandler_Revoke_NotOwner_Forbidden(t *testing.T) {
 	h.Revoke(c)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// Rotate (SEC-1/PROC-6): the old key must NOT be revoked outright — it gets
+// a short grace-window ExpiresAt via SetAPIKeyExpiry instead, so in-flight
+// callers keep working briefly. The new key inherits scopes and gets a
+// fresh, far-future ExpiresAt.
+func TestAPIKeyHandler_Rotate_Success(t *testing.T) {
+	caller := &database.User{ID: "user-1"}
+	oldKey := &database.APIKey{
+		ID: "key-1", UserID: "user-1", Name: "My Key", Description: "desc",
+		TokenHash: "abcdefghij", Scopes: []string{"library.view", "library.edit"},
+		Status: "active", CreatedAt: time.Now(),
+	}
+
+	store := handlersmocks.NewMockAPIKeyHandlerStore(t)
+	store.EXPECT().GetAPIKey("key-1").Return(oldKey, nil)
+	store.EXPECT().CreateAPIKey(mock.MatchedBy(func(k *database.APIKey) bool {
+		if k.UserID != "user-1" || k.Status != "active" {
+			return false
+		}
+		if len(k.Scopes) != 2 || k.Scopes[0] != "library.view" || k.Scopes[1] != "library.edit" {
+			return false
+		}
+		if k.ExpiresAt == nil || !k.ExpiresAt.After(time.Now().Add(29*24*time.Hour)) {
+			return false // fresh expiry should be ~30d out, well past the 1h grace window
+		}
+		return true
+	})).Return(&database.APIKey{
+		ID: "key-2", UserID: "user-1", Name: "My Key", Scopes: oldKey.Scopes,
+		Status: "active", CreatedAt: time.Now(),
+		ExpiresAt: func() *time.Time { t := time.Now().Add(30 * 24 * time.Hour); return &t }(),
+	}, nil)
+	store.EXPECT().SetAPIKeyExpiry("key-1", mock.MatchedBy(func(at time.Time) bool {
+		// Grace window is short (1h) — must be far short of the new key's ~30d expiry.
+		return at.After(time.Now()) && at.Before(time.Now().Add(2*time.Hour))
+	})).Return(nil)
+
+	h := handlers.NewAPIKeyHandler(store)
+	c, w := newAuthCtx("POST", "/auth/api-keys/key-1/rotate", nil)
+	c.Params = gin.Params{{Key: "id", Value: "key-1"}}
+	setAuthUser(c, caller)
+	h.Rotate(c)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var resp struct {
+		Data struct {
+			ID     string   `json:"id"`
+			Token  string   `json:"token"`
+			Scopes []string `json:"scopes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "key-2", resp.Data.ID)
+	assert.NotEmpty(t, resp.Data.Token)
+}
+
+func TestAPIKeyHandler_Rotate_NotOwner_Forbidden(t *testing.T) {
+	caller := &database.User{ID: "user-1"}
+	oldKey := &database.APIKey{ID: "key-1", UserID: "user-2", TokenHash: "abcdefghij", Status: "active", CreatedAt: time.Now()}
+
+	store := handlersmocks.NewMockAPIKeyHandlerStore(t)
+	store.EXPECT().GetAPIKey("key-1").Return(oldKey, nil)
+
+	h := handlers.NewAPIKeyHandler(store)
+	c, w := newAuthCtx("POST", "/auth/api-keys/key-1/rotate", nil)
+	c.Params = gin.Params{{Key: "id", Value: "key-1"}}
+	setAuthUser(c, caller)
+	h.Rotate(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestAPIKeyHandler_Rotate_NotFound(t *testing.T) {
+	caller := &database.User{ID: "user-1"}
+
+	store := handlersmocks.NewMockAPIKeyHandlerStore(t)
+	store.EXPECT().GetAPIKey("missing").Return(nil, nil)
+
+	h := handlers.NewAPIKeyHandler(store)
+	c, w := newAuthCtx("POST", "/auth/api-keys/missing/rotate", nil)
+	c.Params = gin.Params{{Key: "id", Value: "missing"}}
+	setAuthUser(c, caller)
+	h.Rotate(c)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAPIKeyHandler_Rotate_Unauthenticated(t *testing.T) {
+	store := handlersmocks.NewMockAPIKeyHandlerStore(t)
+
+	h := handlers.NewAPIKeyHandler(store)
+	c, w := newAuthCtx("POST", "/auth/api-keys/key-1/rotate", nil)
+	c.Params = gin.Params{{Key: "id", Value: "key-1"}}
+	h.Rotate(c)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
@@ -89,6 +89,74 @@ func (_c *MockDedupEngine_CleanupCandidatesAfterMerge_Call) RunAndReturn(run fun
 	return _c
 }
 
+// ReevaluateAcoustIDConflicts provides a mock function for the type MockDedupEngine
+func (_mock *MockDedupEngine) ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) (*dedup.AcoustIDConflictResult, error) {
+	ret := _mock.Called(ctx, dryRun)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReevaluateAcoustIDConflicts")
+	}
+
+	var r0 *dedup.AcoustIDConflictResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (*dedup.AcoustIDConflictResult, error)); ok {
+		return returnFunc(ctx, dryRun)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) *dedup.AcoustIDConflictResult); ok {
+		r0 = returnFunc(ctx, dryRun)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dedup.AcoustIDConflictResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
+		r1 = returnFunc(ctx, dryRun)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDedupEngine_ReevaluateAcoustIDConflicts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReevaluateAcoustIDConflicts'
+type MockDedupEngine_ReevaluateAcoustIDConflicts_Call struct {
+	*mock.Call
+}
+
+// ReevaluateAcoustIDConflicts is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dryRun bool
+func (_e *MockDedupEngine_Expecter) ReevaluateAcoustIDConflicts(ctx any, dryRun any) *MockDedupEngine_ReevaluateAcoustIDConflicts_Call {
+	return &MockDedupEngine_ReevaluateAcoustIDConflicts_Call{Call: _e.mock.On("ReevaluateAcoustIDConflicts", ctx, dryRun)}
+}
+
+func (_c *MockDedupEngine_ReevaluateAcoustIDConflicts_Call) Run(run func(ctx context.Context, dryRun bool)) *MockDedupEngine_ReevaluateAcoustIDConflicts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDedupEngine_ReevaluateAcoustIDConflicts_Call) Return(acoustIDConflictResult *dedup.AcoustIDConflictResult, err error) *MockDedupEngine_ReevaluateAcoustIDConflicts_Call {
+	_c.Call.Return(acoustIDConflictResult, err)
+	return _c
+}
+
+func (_c *MockDedupEngine_ReevaluateAcoustIDConflicts_Call) RunAndReturn(run func(ctx context.Context, dryRun bool) (*dedup.AcoustIDConflictResult, error)) *MockDedupEngine_ReevaluateAcoustIDConflicts_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Rescore provides a mock function for the type MockDedupEngine
 func (_mock *MockDedupEngine) Rescore(ctx context.Context, apply bool) (dedup.RescoreResult, error) {
 	ret := _mock.Called(ctx, apply)
@@ -125,33 +193,6 @@ type MockDedupEngine_Rescore_Call struct {
 //   - apply bool
 func (_e *MockDedupEngine_Expecter) Rescore(ctx any, apply any) *MockDedupEngine_Rescore_Call {
 	return &MockDedupEngine_Rescore_Call{Call: _e.mock.On("Rescore", ctx, apply)}
-}
-
-func (_mock *MockDedupEngine) ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) (*dedup.AcoustIDConflictResult, error) {
-	ret := _mock.Called(ctx, dryRun)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ReevaluateAcoustIDConflicts")
-	}
-
-	var r0 *dedup.AcoustIDConflictResult
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) (*dedup.AcoustIDConflictResult, error)); ok {
-		return returnFunc(ctx, dryRun)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, bool) *dedup.AcoustIDConflictResult); ok {
-		r0 = returnFunc(ctx, dryRun)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dedup.AcoustIDConflictResult)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, bool) error); ok {
-		r1 = returnFunc(ctx, dryRun)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
 }
 
 func (_c *MockDedupEngine_Rescore_Call) Run(run func(ctx context.Context, apply bool)) *MockDedupEngine_Rescore_Call {

--- a/internal/server/handlers/mocks/mock_api_key_handler_store.go
+++ b/internal/server/handlers/mocks/mock_api_key_handler_store.go
@@ -454,3 +454,60 @@ func (_c *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id 
 	_c.Call.Return(run)
 	return _c
 }
+
+// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyHandlerStore
+func (_mock *MockAPIKeyHandlerStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockAPIKeyHandlerStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	return &MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/server/handlers/mocks/mock_api_key_handler_store.go
+++ b/internal/server/handlers/mocks/mock_api_key_handler_store.go
@@ -392,6 +392,63 @@ func (_c *MockAPIKeyHandlerStore_RevokeAPIKey_Call) RunAndReturn(run func(id str
 	return _c
 }
 
+// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyHandlerStore
+func (_mock *MockAPIKeyHandlerStore) SetAPIKeyExpiry(id string, at time.Time) error {
+	ret := _mock.Called(id, at)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAPIKeyExpiry")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
+		r0 = returnFunc(id, at)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
+type MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call struct {
+	*mock.Call
+}
+
+// SetAPIKeyExpiry is a helper method to define mock.On call
+//   - id string
+//   - at time.Time
+func (_e *MockAPIKeyHandlerStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	return &MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetAPIKeyStatus provides a mock function for the type MockAPIKeyHandlerStore
 func (_mock *MockAPIKeyHandlerStore) SetAPIKeyStatus(id string, status string, at time.Time) error {
 	ret := _mock.Called(id, status, at)
@@ -451,63 +508,6 @@ func (_c *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call) Return(err error) *MockAP
 }
 
 func (_c *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call) RunAndReturn(run func(id string, status string, at time.Time) error) *MockAPIKeyHandlerStore_SetAPIKeyStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetAPIKeyExpiry provides a mock function for the type MockAPIKeyHandlerStore
-func (_mock *MockAPIKeyHandlerStore) SetAPIKeyExpiry(id string, at time.Time) error {
-	ret := _mock.Called(id, at)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetAPIKeyExpiry")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, time.Time) error); ok {
-		r0 = returnFunc(id, at)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetAPIKeyExpiry'
-type MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call struct {
-	*mock.Call
-}
-
-// SetAPIKeyExpiry is a helper method to define mock.On call
-//   - id string
-//   - at time.Time
-func (_e *MockAPIKeyHandlerStore_Expecter) SetAPIKeyExpiry(id any, at any) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
-	return &MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call{Call: _e.mock.On("SetAPIKeyExpiry", id, at)}
-}
-
-func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Run(run func(id string, at time.Time)) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
-		if args[0] != nil {
-			arg0 = args[0].(string)
-		}
-		var arg1 time.Time
-		if args[1] != nil {
-			arg1 = args[1].(time.Time)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) Return(err error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call) RunAndReturn(run func(id string, at time.Time) error) *MockAPIKeyHandlerStore_SetAPIKeyExpiry_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -277,6 +277,15 @@ func (s *Server) Start(cfg ServerConfig) error {
 	go s.warmAuthorsCache()
 	go s.warmSeriesCache()
 
+	// Low-frequency background sweep that WARN-logs API keys approaching
+	// expiry or lacking one entirely (legacy keys) — observability only,
+	// never enforcement (SEC-1/PROC-6).
+	s.bgWG.Add("apikey-expiry-sweep")
+	go func() {
+		defer s.bgWG.Done("apikey-expiry-sweep")
+		s.warnExpiringAPIKeys()
+	}()
+
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf("%s:%s", cfg.Host, cfg.Port),
 		Handler:           s.router,

--- a/internal/server/wire_auth_routes.go
+++ b/internal/server/wire_auth_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_auth_routes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package server
 
@@ -43,5 +43,6 @@ func (s *Server) wireAuthRoutes(
 		authProtected.GET("/api-keys/:id", apiKeyH.Get)
 		authProtected.PATCH("/api-keys/:id", apiKeyH.UpdateStatus)
 		authProtected.DELETE("/api-keys/:id", apiKeyH.Revoke)
+		authProtected.POST("/api-keys/:id/rotate", apiKeyH.Rotate)
 	}
 }


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-0429-consultancy-w1 (consultancy-roadmap wave 1, TASK-09).

Bootstrap-issued keys get a config-driven TTL (default 30d, expires_at in the bootstrap response); new POST /auth/api-keys/:id/rotate issues a replacement (scopes inherited) and grace-windows the old key (1h, via SetAPIKeyExpiry — never revoke); a 6h background sweep WARN-logs legacy nil-expiry keys and keys within 7d of expiry. MIGRATION SAFE: enforcement middleware untouched (diff-verified) — existing prod keys keep working, legacy keys only get a deprecation WARN. server-bootstrap skill doc updated.

Local CI evidence: make ci green in worktree; apikey/bootstrap/handler suites pass incl. 6 new tests; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1