### PR TITLE
fix(docs): replace real infrastructure IPs with 192.168.0.x placeholders in deploy examples

### DIFF
--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,5 +1,5 @@
 # file: Makefile.local.example
-# version: 1.0.0
+# version: 1.0.1
 # guid: a2b4c6d8-e0f2-4a6b-8c0d-2e4f6a8b0c2d
 # last-edited: 2026-07-03
 #
@@ -17,9 +17,9 @@
 # template's `.prev`-preserving step enables.
 
 # Hostname/alias of your production box (must resolve via ssh, e.g. an
-# ~/.ssh/config Host entry). 172.16.2.30 is the author's prod host — replace
+# ~/.ssh/config Host entry). 192.168.0.10 is the author's prod host — replace
 # with your own.
-DEPLOY_HOST := 172.16.2.30
+DEPLOY_HOST := 192.168.0.10
 
 # Absolute path to the deployed binary on DEPLOY_HOST. Required by the
 # committed `make rollback` target as well as this file's `deploy:` recipe.

--- a/deploy/local.conf.example
+++ b/deploy/local.conf.example
@@ -1,5 +1,5 @@
 # file: deploy/local.conf.example
-# version: 1.0.0
+# version: 1.0.1
 # guid: b3c5d7e9-f1a3-4b5c-9d7e-1f3a5b7c9d1e
 # last-edited: 2026-07-03
 #
@@ -15,8 +15,8 @@
 #
 # Real secrets/paths (TLS cert/key paths, actual DB path, real
 # WHISPER_REMOTE_URL host if different from your own GPU box) must be filled
-# in by the operator — nothing below is a real credential. 172.16.2.30 /
-# 172.16.3.22 are the author's own hosts, already public in
+# in by the operator — nothing below is a real credential. 192.168.0.10 /
+# 192.168.0.20 are placeholder addresses — substitute your own hosts in
 # docs/system/runbooks.md and docs/status/2026-07-02-local-cutover-and-matching.md.
 
 [Service]
@@ -36,5 +36,5 @@ TimeoutStopSec=30
 # running bge-m3 (1024-dim embeddings) and qwen2.5:7b-instruct. See
 # scripts/manage-ollama-windows.py for keeping that box's Ollama instance
 # alive.
-Environment=WHISPER_REMOTE_URL=http://172.16.3.22:8000
-Environment=OLLAMA_BASE_URL=http://172.16.3.22:11434/v1
+Environment=WHISPER_REMOTE_URL=http://192.168.0.20:8000
+Environment=OLLAMA_BASE_URL=http://192.168.0.20:11434/v1

--- a/docs/system/deploy-and-gpu-ops.md
+++ b/docs/system/deploy-and-gpu-ops.md
@@ -1,5 +1,5 @@
 <!-- file: docs/system/deploy-and-gpu-ops.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.0.1 -->
 <!-- guid: d5e7f9a1-b3c5-4d7e-9f1a-3b5c7d9e1f3a -->
 <!-- last-edited: 2026-07-03 -->
 
@@ -51,7 +51,7 @@ Once your real `Makefile.local`'s `deploy` target includes this same
    installing the new one and restarting the service.
 2. If the new deploy is bad, run the committed rollback target:
    ```bash
-   make rollback DEPLOY_HOST=172.16.2.30 DEPLOY_BIN=/usr/local/bin/audiobook-organizer
+   make rollback DEPLOY_HOST=192.168.0.10 DEPLOY_BIN=/usr/local/bin/audiobook-organizer
    ```
    (`DEPLOY_HOST`/`DEPLOY_BIN` are normally already set in your
    `Makefile.local`, so you can usually just run `make rollback`.)
@@ -72,7 +72,7 @@ deeper history, keep your own timestamped copies (see `make backup` in
 
 ## 3. Windows GPU Ollama keepalive (`scripts/manage-ollama-windows.py`)
 
-The Windows GPU box (`172.16.3.22`, reached via the `windows-gpu` SSH alias —
+The Windows GPU box (`192.168.0.20`, reached via the `windows-gpu` SSH alias —
 see `scripts/setup-ssh-from-mac.sh` for creating that alias) runs Ollama
 serving `bge-m3` (1024-dim embeddings) and `qwen2.5:7b-instruct` (LLM).
 Commands are sent as base64-encoded (UTF-16LE) PowerShell via

--- a/scripts/manage-ollama-windows.py
+++ b/scripts/manage-ollama-windows.py
@@ -1,5 +1,5 @@
 # file: scripts/manage-ollama-windows.py
-# version: 1.0.0
+# version: 1.0.1
 # guid: c4d6e8f0-a2b4-4c6d-8e0f-2a4b6c8d0e2f
 # last-edited: 2026-07-03
 #
@@ -43,7 +43,7 @@ import urllib.error
 import urllib.request
 
 HOST = "windows-gpu"
-IP = "172.16.3.22"
+IP = "192.168.0.20"
 PORT = 11434
 MODELS = ("bge-m3", "qwen2.5:7b-instruct")
 
@@ -182,7 +182,7 @@ def print_result(result: subprocess.CompletedProcess) -> None:
 
 
 def cmd_status() -> int:
-    """Probe http://172.16.3.22:11434/api/tags directly (no SSH needed) and
+    """Probe http://192.168.0.20:11434/api/tags directly (no SSH needed) and
     report which models are loaded."""
     url = f"http://{IP}:{PORT}/api/tags"
     print(f"==> Checking {url}")


### PR DESCRIPTION
Sanitizes the four files added by #1748: Makefile.local.example, deploy/local.conf.example, docs/system/deploy-and-gpu-ops.md, scripts/manage-ollama-windows.py. Real host addresses replaced with 192.168.0.10 (deploy target) / 192.168.0.20 (GPU box); comments now direct operators to substitute their own hosts. py_compile clean; zero remaining matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1