### PR TITLE
fix(metafetch): stop IsGarbageValue rejecting titles/authors containing "error" (MATCH-3)

### DIFF
--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.5.0
+// version: 1.5.2
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
 // last-edited: 2026-07-03
 
@@ -32,8 +32,10 @@ func IsGarbageValue(s string) bool {
 		}
 	}
 	// Reject HTML fragments or error messages that may leak from Wikipedia/API errors
+	// Use anchored checks to avoid matching legitimate titles/authors containing "error" as a substring
 	if strings.Contains(lower, "<html") || strings.Contains(lower, "<!doctype") ||
-		strings.Contains(lower, "403 forbidden") || strings.Contains(lower, "error") {
+		strings.Contains(lower, "403 forbidden") || strings.HasPrefix(lower, "error:") || strings.HasPrefix(lower, "error ") ||
+		strings.Contains(lower, "http error") || strings.Contains(lower, "internal server error") {
 		return true
 	}
 	return false

--- a/internal/metafetch/service_test.go
+++ b/internal/metafetch/service_test.go
@@ -1,6 +1,7 @@
 // file: internal/metafetch/service_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -57,7 +58,15 @@ func TestIsGarbageValue(t *testing.T) {
 		{"<html>something</html>", true},
 		{"<!DOCTYPE html>", true},
 		{"403 Forbidden", true},
-		{"some error occurred", true},
+		{"some error occurred", false},
+		// Legitimate titles/authors containing "error" substring should pass
+		{"The Terror", false},
+		{"The Comedy of Errors", false},
+		{"Terrorbyte", false},
+		{"Erroll Garner", false},
+		// Genuine error-page leaks should still be rejected
+		{"Error: connection refused", true},
+		{"HTTP Error 500", true},
 		// Edge cases
 		{"  Unknown  ", true},
 		{"Test", true},


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-1010-consultancy-w2 (consultancy-roadmap wave 2, TASK-25).

Bare substring match on "error" rejected legitimate values like "The Terror", "The Comedy of Errors", "Erroll Garner" across all 7 IsGarbageValue call sites. Replaced with anchored error-message-shape checks (error:/http error/internal server error prefixes); genuine error-page leaks still rejected. 31-case table test.

Local CI evidence: make ci green in worktree; metafetch suite + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1