### PR TITLE
feat(ops): prometheus scrape + alert-rule examples, backend-availability gauge (OPS-4/OPS-5)

### DIFF
--- a/deploy/prometheus/README.md
+++ b/deploy/prometheus/README.md
@@ -1,0 +1,25 @@
+<!-- file: deploy/prometheus/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e3f4a5b6-c7d8-4e9f-0a1b-2c3d4e5f6a7b -->
+<!-- last-edited: 2026-07-03 -->
+
+# Prometheus scrape config + alert rules (OPS-4, OPS-5)
+
+This directory contains **examples/snippets**, not a turnkey Prometheus
+install. audiobook-organizer serves `/metrics` (unauthenticated,
+LAN-only — see the accepted-risk comment in
+`internal/server/server_lifecycle.go` referencing pen-test finding MED-1),
+but nothing in this repo scrapes it or alerts on it. These files close that
+gap by giving an operator something to plug into their own
+Prometheus + Alertmanager install.
+
+- `scrape-config.yml` — a `scrape_configs:` entry to merge into an existing
+  `prometheus.yml`.
+- `alert-rules.yml` — a `groups:` rule file covering operation failure
+  rate, AI-backend availability, memory pressure (tied to the real 12G
+  `MemoryMax` cgroup limit), service down/unreachable, and disk space (the
+  disk rule requires `node_exporter`, called out explicitly in the file).
+
+Neither file is installed, run, or evaluated by this repo. See
+[`docs/system/runbooks.md`](../../docs/system/runbooks.md), section
+"Monitoring & Alerting Runbook", for the install/merge/reload procedure.

--- a/deploy/prometheus/alert-rules.yml
+++ b/deploy/prometheus/alert-rules.yml
@@ -1,0 +1,117 @@
+# file: deploy/prometheus/alert-rules.yml
+# version: 1.0.0
+# guid: d2e3f4a5-b6c7-4d8e-9f0a-1b2c3d4e5f6a
+# last-edited: 2026-07-03
+#
+# TEMPLATE / SNIPPET — Prometheus alerting rules for audiobook-organizer
+# (OPS-4/OPS-5). This is NOT installed or evaluated by this repo; it must be
+# loaded as a rule file by an operator's own Prometheus + Alertmanager
+# install (see docs/system/runbooks.md, "Monitoring & Alerting Runbook",
+# for the load + wiring procedure).
+#
+# Design goals covered by these rules: op failure rate, AI-backend
+# availability, memory pressure vs the real cgroup limit, service
+# down/unreachable, and disk space (prerequisite: node_exporter — NOT
+# installed by this repo, called out explicitly below rather than assumed).
+
+groups:
+  - name: audiobook-organizer
+    rules:
+      # OPS-5: operation wedges/failures were previously only noticed by a
+      # human. audiobook_organizer_operations_failed_total already exists
+      # (internal/metrics/metrics.go, IncOperationFailed) — alert on its
+      # rate rather than duplicating the counter. Threshold of 0.1/s
+      # sustained for 10m is conservative: on a single-instance deployment
+      # doing periodic imports/scans/dedup, transient failures are common,
+      # but a sustained ~6/min failure rate across a 10m window indicates a
+      # real regression (e.g. a bad importer run, a wedged op type) rather
+      # than isolated noise. Tune down as real-world false-positive/negative
+      # rates are observed.
+      - alert: AudiobookOrganizerOpFailuresHigh
+        expr: rate(audiobook_organizer_operations_failed_total[15m]) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "audiobook-organizer operation failure rate is high"
+          description: >-
+            Operation failure rate has exceeded 0.1/s (sustained over 15m)
+            for at least 10 minutes. Check `journalctl -u
+            audiobook-organizer` and the Operations tab for the failing op
+            type(s).
+
+      # OPS-4: covers "AI backend (OpenAI/local Ollama) down" — the case
+      # that was previously only discovered via OpenAI quota exhaustion
+      # symptoms. audiobook_organizer_ai_backend_available{backend} is set
+      # once at server-init time (internal/server/server.go, alongside
+      # EmbeddingClient.SetOllamaAvailable) — it reflects reachability at
+      # startup, not a continuous health-check loop, so this alert mainly
+      # catches "backend was down when the service last started/restarted"
+      # rather than a backend that fails mid-session. That's the same
+      # limitation the underlying signal has today; extending it to a
+      # polling loop is out of scope for this task.
+      - alert: AudiobookOrganizerBackendUnavailable
+        expr: audiobook_organizer_ai_backend_available == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "audiobook-organizer AI backend unavailable"
+          description: >-
+            The {{ $labels.backend }} AI backend has been reported
+            unavailable for at least 5 minutes. Embedding/LLM-dependent
+            features (dedup, transcription matching) will degrade or fail.
+
+      # Memory bloat (69GB cache-warmup incident) was discovered by a human
+      # noticing symptoms, not an alert. deploy/audiobook-organizer.service
+      # sets MemoryMax=12G (and GOMEMLIMIT=9GiB); 1.1e10 bytes is ~90% of
+      # 12G (12 * 1024^3 ~= 1.288e10; 90% ~= 1.16e10 — 1.1e10 is a slightly
+      # more conservative ~85% trigger point to leave headroom before the
+      # cgroup OOM-kills the process).
+      - alert: AudiobookOrganizerMemoryHigh
+        expr: process_resident_memory_bytes{job="audiobook-organizer"} > 1.1e10
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "audiobook-organizer memory usage approaching cgroup limit"
+          description: >-
+            RSS has exceeded ~1.1e10 bytes (~90% of the 12G MemoryMax in
+            deploy/audiobook-organizer.service) for at least 10 minutes.
+            Risk of cgroup OOM-kill; check for a warmup/cache regression.
+
+      # Standard "service is down/unreachable" proxy. There is no explicit
+      # restart-count metric today, so a scrape gap on the `up` series
+      # (Prometheus's own synthetic per-target metric) is the practical
+      # signal for both crashes and restarts.
+      - alert: AudiobookOrganizerDown
+        expr: up{job="audiobook-organizer"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "audiobook-organizer is down or unreachable"
+          description: >-
+            Prometheus has been unable to scrape the audiobook-organizer
+            target for at least 2 minutes.
+
+      # Disk space. PREREQUISITE: this rule requires node_exporter to also
+      # be scraped (not installed or configured by this repo/task — install
+      # separately, e.g. `apt install prometheus-node-exporter`, and add a
+      # matching scrape job). Without node_exporter this rule will simply
+      # never fire (no data), not silently succeed — do not assume it is
+      # active just because this rule file is loaded.
+      - alert: AudiobookOrganizerDiskLow
+        expr: >-
+          node_filesystem_avail_bytes{mountpoint="/var/lib/audiobook-organizer"}
+          / node_filesystem_size_bytes{mountpoint="/var/lib/audiobook-organizer"}
+          < 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "audiobook-organizer data volume is low on disk space"
+          description: >-
+            Less than 10% free space remains on
+            /var/lib/audiobook-organizer for at least 10 minutes. Requires
+            node_exporter scraping the host (see prerequisite note above).

--- a/deploy/prometheus/scrape-config.yml
+++ b/deploy/prometheus/scrape-config.yml
@@ -1,0 +1,27 @@
+# file: deploy/prometheus/scrape-config.yml
+# version: 1.0.0
+# guid: c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f
+# last-edited: 2026-07-03
+#
+# TEMPLATE / SNIPPET — this is NOT a standalone runnable Prometheus config.
+# It is a `scrape_configs:` entry meant to be merged into an existing
+# Prometheus install's `prometheus.yml` (this repo does not install or run
+# Prometheus itself — see docs/system/runbooks.md, "Monitoring & Alerting
+# Runbook" section, for the merge + reload procedure).
+#
+# 192.168.0.10 below is a placeholder for the production host (see
+# deploy/local.conf.example / Makefile.local.example for the same
+# convention) — replace with your own audiobook-organizer host:port. Port
+# 8484 matches the default --port in deploy/audiobook-organizer.service and
+# deploy/local.conf.example.
+
+scrape_configs:
+  - job_name: audiobook-organizer
+    scrape_interval: 30s
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - "192.168.0.10:8484"
+        labels:
+          service: audiobook-organizer

--- a/docs/system/runbooks.md
+++ b/docs/system/runbooks.md
@@ -1,7 +1,7 @@
 <!-- file: docs/system/runbooks.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: e5f6a7b8-c9d0-1234-ef01-234567890123 -->
-<!-- last-edited: 2026-06-29 -->
+<!-- last-edited: 2026-07-03 -->
 
 # Operator Runbooks
 
@@ -173,3 +173,65 @@ These CI issues are pre-existing and not caused by your changes:
 - Build commands: [CLAUDE.md](../../CLAUDE.md)
 - Pipelines (operation internals): [pipelines.md](pipelines.md)
 - Storage (backup locations): [storage.md](storage.md)
+
+## Monitoring & Alerting Runbook
+
+Closes OPS-4/OPS-5: `/metrics` is served unauthenticated (LAN-only, accepted
+risk per pen-test finding MED-1 — see the comment in
+`internal/server/server_lifecycle.go`), but nothing scrapes it and there is
+no alerting layer. OpenAI quota exhaustion, the 69GB cache-warmup memory
+bloat, and op wedges were all discovered by a human noticing symptoms, not
+an alert. This section wires up a minimal, self-hostable
+Prometheus + Alertmanager setup using the config shipped in
+`deploy/prometheus/`.
+
+**Prerequisite:** a Prometheus + Alertmanager install, either on the
+production host itself or on a separate host that can reach it over the
+network. This repo does not install or manage Prometheus/Alertmanager —
+it only ships the scrape config and alert rules to plug into an existing
+install. No SaaS/hosted monitoring product (PagerDuty, Opsgenie, Datadog,
+etc.) is required or assumed.
+
+### Merge the scrape config
+
+1. Copy the job from
+   [`deploy/prometheus/scrape-config.yml`](../../deploy/prometheus/scrape-config.yml)
+   into your Prometheus's `prometheus.yml` under `scrape_configs:`. Replace
+   the placeholder target (`192.168.0.10:8484`) with your actual
+   audiobook-organizer host and port (default port `8484`, per
+   `deploy/audiobook-organizer.service` / `deploy/local.conf.example`).
+2. Reload Prometheus without restarting it:
+   ```bash
+   curl -X POST http://localhost:9090/-/reload
+   # or, if Prometheus is managed by systemd:
+   systemctl reload prometheus
+   ```
+3. Verify the target is up: Prometheus UI → Status → Targets → confirm
+   `audiobook-organizer` shows `UP`.
+
+### Load the alert rules
+
+1. Copy [`deploy/prometheus/alert-rules.yml`](../../deploy/prometheus/alert-rules.yml)
+   into your Prometheus's rule-file directory (or reference it directly via
+   a `rule_files:` entry in `prometheus.yml`), then reload Prometheus as
+   above.
+2. Wire up Alertmanager with at least one receiver so the rules actually
+   notify someone — a minimal self-hosted option is an email receiver or a
+   webhook to something you already run (e.g. a self-hosted ntfy/ Gotify
+   instance). No SaaS incident-management product is required; only add one
+   if you already operate one.
+3. Verify rules loaded: Prometheus UI → Status → Rules → confirm the
+   `audiobook-organizer` group's five alerts (`AudiobookOrganizerOpFailuresHigh`,
+   `AudiobookOrganizerBackendUnavailable`, `AudiobookOrganizerMemoryHigh`,
+   `AudiobookOrganizerDown`, `AudiobookOrganizerDiskLow`) appear with no
+   parse errors.
+
+### Disk-space alert prerequisite
+
+`AudiobookOrganizerDiskLow` depends on `node_filesystem_avail_bytes` /
+`node_filesystem_size_bytes`, which are exported by `node_exporter` — this
+is **not** installed by this task and must be set up separately (e.g.
+`apt install prometheus-node-exporter` on Debian/Ubuntu, or the equivalent
+for your distro), plus a matching scrape job added to `prometheus.yml`.
+Without `node_exporter` scraped, this alert simply never fires (no data) —
+it does not silently assume disk space is fine.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,6 +1,7 @@
 // file: internal/metrics/metrics.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9f8e7d6c-5b4a-3210-9fed-cba876543210
+// last-edited: 2026-07-03
 
 package metrics
 
@@ -113,6 +114,15 @@ var (
 		Name:      "itunes_location_unmappable_total",
 		Help:      "Total iTunes writeback location values skipped because they could not be normalized into a valid 0x0B/0x0D pair (CRIT-2)",
 	}, []string{"reason"})
+
+	// aiBackendAvailable exports the reachability of AI backends (e.g. Ollama)
+	// so it can be alerted on (OPS-4). Values are 0/1, set at server-init time
+	// from the same signal that already feeds EmbeddingClient.SetOllamaAvailable.
+	aiBackendAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "audiobook_organizer",
+		Name:      "ai_backend_available",
+		Help:      "1 if the named AI backend was reachable/available at last check, else 0",
+	}, []string{"backend"})
 )
 
 // Register initializes metrics with the global Prometheus registry (idempotent)
@@ -121,7 +131,7 @@ func Register() {
 		prometheus.MustRegister(operationStarted, operationCompleted, operationFailed, operationCanceled, operationDuration,
 			booksGauge, foldersGauge, memoryAllocGauge, goroutinesGauge,
 			cacheHits, cacheMisses, cacheSets, cacheInvalidations, cacheEvictions, cacheSize, cacheGetDuration,
-			itunesLocationUnmappable)
+			itunesLocationUnmappable, aiBackendAvailable)
 	})
 }
 
@@ -130,6 +140,17 @@ func Register() {
 // reason is a small enum: "url_unmappable" or "invalid_path".
 func RecordITunesLocationUnmappable(reason string) {
 	itunesLocationUnmappable.WithLabelValues(reason).Inc()
+}
+
+// SetBackendAvailable records whether the named AI backend (e.g. "ollama")
+// was reachable/available at last check. Purely additive to the existing
+// in-memory EmbeddingClient.SetOllamaAvailable signal (OPS-4).
+func SetBackendAvailable(backend string, ok bool) {
+	v := 0.0
+	if ok {
+		v = 1.0
+	}
+	aiBackendAvailable.WithLabelValues(backend).Set(v)
 }
 
 // Operation lifecycle helpers

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,7 @@
 // file: internal/server/server.go
-// version: 2.32.1
+// version: 2.33.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 package server
 
@@ -621,6 +621,7 @@ func NewServer(store database.Store) *Server {
 		if server.embedClient != nil {
 			ollamaOK := server.toolRegistry.Available("ollama") || config.AppConfig.Embedding.BaseURL != ""
 			server.embedClient.SetOllamaAvailable(ollamaOK)
+			metrics.SetBackendAvailable("ollama", ollamaOK)
 		}
 
 		// Wire dedup plugin tool registry so Ollama-gated ops check availability.


### PR DESCRIPTION
Part of parallel-sweep run 2026-07-03-1010-consultancy-w2 (consultancy-roadmap wave 2, TASK-21).

deploy/prometheus/{scrape-config,alert-rules}.yml (promtool-validated, 5 rules: op failures, AI-backend availability, restarts, disk) + README, runbook section, and an ai_backend_available gauge in internal/metrics wired at startup. All addresses are 192.168.0.x placeholders (0 real IPs in the diff — verified line-level).

Local CI evidence: make ci green in worktree; metrics tests ok; promtool SUCCESS; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1