### PR TITLE
refactor(server): remove dead v1→v2 migration handler residue + orphaned helpers

### DIFF
--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -1,5 +1,5 @@
 // file: internal/server/operations_v2_handlers.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
 // last-edited: 2026-06-23
 
@@ -11,13 +11,11 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
-	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
 
 // operationV2Response is the JSON shape returned by the timeline and single-op
@@ -158,63 +156,6 @@ func (s *Server) handleCancelOperationV2(c *gin.Context) {
 	httputil.RespondWithNoContent(c)
 }
 
-// handleTriggerOperationV2 implements POST /api/v1/operations/v2.
-// Body: { "def_id": "...", "params": {...} }
-func (s *Server) handleTriggerOperationV2(c *gin.Context) {
-	if s.opRegistry == nil {
-		httputil.RespondWithInternalError(c, "operations registry not initialized")
-		return
-	}
-
-	var body struct {
-		DefID  string `json:"def_id"`
-		Params any    `json:"params"`
-	}
-	if err := c.ShouldBindJSON(&body); err != nil || body.DefID == "" {
-		httputil.RespondWithBadRequest(c, "body must include def_id")
-		return
-	}
-
-	opID, err := s.opRegistry.EnqueueOp(c.Request.Context(), body.DefID, body.Params)
-	if err != nil {
-		httputil.InternalError(c, "enqueue failed", err)
-		return
-	}
-
-	c.JSON(http.StatusAccepted, gin.H{"op_id": opID})
-}
-
-// handleListOpDefs implements GET /api/v1/op-defs.
-// Returns the set of registered OperationDefs.
-func (s *Server) handleListOpDefs(c *gin.Context) {
-	if s.opRegistry == nil {
-		httputil.RespondWithOK(c, gin.H{"defs": []opDefResponse{}})
-		return
-	}
-	defs := s.opRegistry.ActiveDefs()
-	resp := make([]opDefResponse, 0, len(defs))
-	for _, d := range defs {
-		resp = append(resp, defToResponse(d))
-	}
-	httputil.RespondWithOK(c, gin.H{"defs": resp})
-}
-
-// handleGetOpDef implements GET /api/v1/op-defs/:id.
-func (s *Server) handleGetOpDef(c *gin.Context) {
-	id := c.Param("id")
-	if s.opRegistry == nil {
-		httputil.RespondWithNotFound(c, "op-def", id)
-		return
-	}
-	for _, d := range s.opRegistry.ActiveDefs() {
-		if d.ID == id {
-			httputil.RespondWithOK(c, gin.H{"def": defToResponse(d)})
-			return
-		}
-	}
-	httputil.RespondWithNotFound(c, "op-def", id)
-}
-
 // handleOperationsSSE implements GET /api/v1/operations/events.
 // Streams SSE events from the opHub to the client until the client disconnects.
 func (s *Server) handleOperationsSSE(c *gin.Context) {
@@ -345,40 +286,6 @@ func logRowToResponse(l database.OpLogV2Row) opLogV2Response {
 		Message:     l.Message,
 		Attrs:       attrsAny,
 		CreatedAt:   l.CreatedAt,
-	}
-}
-
-// defToResponse converts a registry.OperationDef to the HTTP response shape.
-func defToResponse(d opsregistry.OperationDef) opDefResponse {
-	triggers := make([]string, 0, len(d.Triggers))
-	for _, t := range d.Triggers {
-		triggers = append(triggers, t.EventName)
-	}
-	depends := make([]string, len(d.DependsOn))
-	copy(depends, d.DependsOn)
-
-	rp := "unspecified"
-	switch d.ResumePolicy {
-	case opsregistry.ResumeRestart:
-		rp = "restart"
-	case opsregistry.ResumeRequeue:
-		rp = "requeue"
-	case opsregistry.ResumeDrop:
-		rp = "drop"
-	case opsregistry.ResumeAsk:
-		rp = "ask"
-	}
-
-	return opDefResponse{
-		ID:           d.ID,
-		Plugin:       d.Plugin,
-		DisplayName:  d.DisplayName,
-		Description:  d.Description,
-		Cancellable:  d.Cancellable,
-		Isolate:      d.Isolate,
-		ResumePolicy: rp,
-		Triggers:     triggers,
-		DependsOn:    depends,
 	}
 }
 

--- a/internal/server/server_helpers.go
+++ b/internal/server/server_helpers.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_helpers.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 8a40b808-2bf2-4a35-893c-ad5e3351dbae
 // last-edited: 2026-05-25
 
@@ -49,13 +49,6 @@ func intPtrHelper(i int) *int {
 
 func boolPtr(b bool) *bool {
 	return &b
-}
-
-func ptrStr(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }
 
 func stringVal(p *string) any {

--- a/internal/server/server_title_helpers.go
+++ b/internal/server/server_title_helpers.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_title_helpers.go
-// version: 1.0.0
+// version: 1.0.2
 // guid: b4b0048c-d778-43c9-871e-21f9a9b6705d
 // last-edited: 2026-05-01
 
@@ -7,8 +7,6 @@ package server
 
 import (
 	"fmt"
-	"log/slog"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -175,87 +173,3 @@ func stripSubtitle(title string) string {
 	return title
 }
 
-func extractTitleFromSegmentFilename(filename string) string {
-	// Strip extension
-	name := strings.TrimSuffix(filename, filepath.Ext(filename))
-
-	// Try to find title after " - " separator (common pattern)
-	if idx := strings.Index(name, " - "); idx >= 0 {
-		title := strings.TrimSpace(name[idx+3:])
-		if title != "" {
-			return title
-		}
-	}
-
-	// Try after " – " (em dash)
-	if idx := strings.Index(name, " – "); idx >= 0 {
-		title := strings.TrimSpace(name[idx+len(" – "):])
-		if title != "" {
-			return title
-		}
-	}
-
-	// Strip leading track numbers like "01 ", "01. "
-	stripped := regexp.MustCompile(`^\d{1,3}[\s.\-]+`).ReplaceAllString(name, "")
-	if stripped != "" {
-		return strings.TrimSpace(stripped)
-	}
-
-	return name
-}
-
-// reassignExternalIDsForFiles is now a method on *Server so it uses
-// the server's resolved store rather than the package-level
-// GetGlobalStore (SERVER-GLOBAL-STORE-AUDIT phase 3a).
-func (s *Server) reassignExternalIDsForFiles(sourceBookID, targetBookID string, files []database.BookFile) {
-	store := s.Store()
-	if store == nil {
-		return
-	}
-	eidStore := asExternalIDStore(store)
-	if eidStore == nil {
-		return
-	}
-
-	mappings, err := eidStore.GetExternalIDsForBook(sourceBookID)
-	if err != nil || len(mappings) == 0 {
-		return
-	}
-
-	// Build lookup sets from the moved files
-	movedPaths := make(map[string]bool, len(files))
-	movedPIDs := make(map[string]bool, len(files))
-	for _, f := range files {
-		if f.FilePath != "" {
-			movedPaths[f.FilePath] = true
-		}
-		if f.ITunesPersistentID != "" {
-			movedPIDs[f.ITunesPersistentID] = true
-		}
-	}
-
-	// Collect only the mappings that belong to the moved files
-	var toMove []database.ExternalIDMapping
-	for _, m := range mappings {
-		if (m.FilePath != "" && movedPaths[m.FilePath]) ||
-			(m.ExternalID != "" && movedPIDs[m.ExternalID]) {
-			toMove = append(toMove, m)
-		}
-	}
-	if len(toMove) == 0 {
-		return
-	}
-
-	// Reassign each mapping: delete old reverse key, update primary, add new reverse key
-	for _, m := range toMove {
-		oldReverseKey := fmt.Sprintf("ext_id:book:%s:%s:%s", sourceBookID, m.Source, m.ExternalID)
-		_ = store.DeleteRaw(oldReverseKey)
-
-		m.BookID = targetBookID
-		if createErr := eidStore.CreateExternalIDMapping(&m); createErr != nil {
-			slog.Warn("reassignExternalIDsForFiles failed to reassign to", "m", m.Source, "m", m.ExternalID, "targetBookID", targetBookID, "createErr", createErr)
-		}
-	}
-
-	slog.Info("reassigned external ID mapping(s) from book to", "toMove_count", len(toMove), "sourceBookID", sourceBookID, "targetBookID", targetBookID)
-}


### PR DESCRIPTION
First slice of the staticcheck burndown: 7 unused symbols in internal/server (unwired v2-handler cluster + orphaned helpers + dead imports), verified unreferenced (build green, operations tests pass). ~18 findings remain repo-wide — tracked as a follow-up; make ci's staticcheck step fails on main today wherever staticcheck is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1