### PR TITLE
fix(database): harden HNSW derived index — staleness check, atomic export, safe Delete (TASK-20)

### DIFF
--- a/internal/database/hnsw_embedding_store.go
+++ b/internal/database/hnsw_embedding_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store.go
-// version: 1.5.2
+// version: 1.6.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 // HNSW-graph vector store (coder/hnsw) — a sub-linear ANN index alternative to
 // the brute-force chromem store. Selected via config.VectorIndexBackend="hnsw".
@@ -170,6 +170,21 @@ func (s *HNSWEmbeddingStore) safeAdd(g *hnsw.Graph[string], entityID string, vec
 	return nil
 }
 
+// safeDelete wraps coder/hnsw Graph.Delete so a library panic becomes an error
+// rather than crashing the process, mirroring safeAdd. Delete shares the same
+// per-layer-invariant panic class as Add (HNSW-CRASH-2026-06-18) and runs on
+// live paths (book merge/removal) from goroutines where an unrecovered panic
+// kills the process. Caller must hold s.mu.
+func (s *HNSWEmbeddingStore) safeDelete(g *hnsw.Graph[string], entityID string) (deleted bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("hnsw delete %s: recovered library panic: %v", entityID, r)
+		}
+	}()
+	deleted = g.Delete(entityID)
+	return deleted, nil
+}
+
 // Get returns a copy of an entity's metadata, or (nil, nil) if absent.
 func (s *HNSWEmbeddingStore) Get(_ context.Context, entityType, entityID string) (map[string]string, error) {
 	s.mu.RLock()
@@ -186,11 +201,18 @@ func (s *HNSWEmbeddingStore) Get(_ context.Context, entityType, entityID string)
 }
 
 // Delete removes an entity's vector + metadata. Absent keys are a no-op.
+// Deletion is best-effort: a recovered library panic from safeDelete is
+// logged, not propagated, matching this file's "single bad mirror cannot
+// abort" philosophy (see safeAdd) — the metadata sidecar entry is still
+// removed regardless.
 func (s *HNSWEmbeddingStore) Delete(_ context.Context, entityType, entityID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if g, ok := s.graphs[entityType]; ok {
-		g.Delete(entityID)
+		if _, err := s.safeDelete(g, entityID); err != nil {
+			slog.Warn("hnsw delete: recovered library panic; continuing best-effort",
+				"entity_type", entityType, "entity_id", entityID, "err", err)
+		}
 	}
 	if byID, ok := s.meta[entityType]; ok {
 		delete(byID, entityID)
@@ -338,29 +360,59 @@ func (s *HNSWEmbeddingStore) Export(dir string) error {
 		return fmt.Errorf("hnsw export: mkdir: %w", err)
 	}
 
+	// Each entity type is written to temp files first, then renamed into place
+	// only after both the .bin and .meta.json writes succeed (ARCH-2). A crash
+	// or write failure mid-export therefore cannot leave a truncated file at
+	// the final path, and a previously-committed good snapshot for that entity
+	// type is never clobbered by a failed export attempt.
 	for entityType, g := range s.graphs {
 		binPath := filepath.Join(dir, "hnsw-"+entityType+".bin")
-		f, err := os.Create(binPath)
+		binTmpPath := binPath + ".tmp"
+		f, err := os.Create(binTmpPath)
 		if err != nil {
-			return fmt.Errorf("hnsw export: create %s: %w", binPath, err)
+			return fmt.Errorf("hnsw export: create %s: %w", binTmpPath, err)
 		}
 		if err := g.Export(f); err != nil {
 			f.Close()
+			os.Remove(binTmpPath)
 			return fmt.Errorf("hnsw export: write graph %s: %w", entityType, err)
 		}
-		f.Close()
+		if err := f.Sync(); err != nil {
+			f.Close()
+			os.Remove(binTmpPath)
+			return fmt.Errorf("hnsw export: sync graph %s: %w", entityType, err)
+		}
+		if err := f.Close(); err != nil {
+			os.Remove(binTmpPath)
+			return fmt.Errorf("hnsw export: close graph %s: %w", entityType, err)
+		}
 
 		metaPath := filepath.Join(dir, "hnsw-"+entityType+".meta.json")
+		metaTmpPath := metaPath + ".tmp"
 		m := s.meta[entityType]
 		if m == nil {
 			m = map[string]map[string]string{}
 		}
 		b, err := json.Marshal(m)
 		if err != nil {
+			os.Remove(binTmpPath)
 			return fmt.Errorf("hnsw export: marshal meta %s: %w", entityType, err)
 		}
-		if err := os.WriteFile(metaPath, b, 0o644); err != nil {
+		if err := os.WriteFile(metaTmpPath, b, 0o644); err != nil {
+			os.Remove(binTmpPath)
 			return fmt.Errorf("hnsw export: write meta %s: %w", entityType, err)
+		}
+
+		// Both temp files are on disk and synced/written successfully — commit
+		// by renaming into place. os.Rename is atomic on POSIX filesystems.
+		if err := os.Rename(binTmpPath, binPath); err != nil {
+			os.Remove(binTmpPath)
+			os.Remove(metaTmpPath)
+			return fmt.Errorf("hnsw export: rename graph %s: %w", entityType, err)
+		}
+		if err := os.Rename(metaTmpPath, metaPath); err != nil {
+			os.Remove(metaTmpPath)
+			return fmt.Errorf("hnsw export: rename meta %s: %w", entityType, err)
 		}
 	}
 	slog.Info("hnsw: snapshot exported", "dir", dir, "entity_types", len(s.graphs))
@@ -369,14 +421,24 @@ func (s *HNSWEmbeddingStore) Export(dir string) error {
 
 // Import loads HNSW graphs and metadata sidecars from dir.
 // Returns ErrNoHNSWSnapshot if no snapshot files exist.
+//
+// Import is all-or-nothing (ARCH-2): entries are decoded into local maps
+// first, and s.graphs/s.meta are only replaced after every entity type has
+// either parsed successfully or been legitimately skipped for a dimension
+// mismatch (the existing discard path, unchanged in effect). Any other hard
+// failure (bin open/parse, or a meta read/unmarshal error that isn't "file
+// not found") aborts the whole call and returns before touching s.graphs/
+// s.meta at all, so the caller's existing hydrate-from-Pebble fallback (which
+// runs when CountByType==0) actually runs instead of operating on a partially
+// installed graph.
 func (s *HNSWEmbeddingStore) Import(dir string) error {
 	entries, err := filepath.Glob(filepath.Join(dir, "hnsw-*.bin"))
 	if err != nil || len(entries) == 0 {
 		return ErrNoHNSWSnapshot
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	newGraphs := map[string]*hnsw.Graph[string]{}
+	newMeta := map[string]map[string]map[string]string{}
 
 	for _, binPath := range entries {
 		base := filepath.Base(binPath)
@@ -408,13 +470,13 @@ func (s *HNSWEmbeddingStore) Import(dir string) error {
 				"entity_type", entityType, "snapshot_dims", g.Dims(), "config_dims", s.dims)
 			continue
 		}
-		s.graphs[entityType] = g
+		newGraphs[entityType] = g
 
 		metaPath := filepath.Join(dir, "hnsw-"+entityType+".meta.json")
 		b, err := os.ReadFile(metaPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				s.meta[entityType] = map[string]map[string]string{}
+				newMeta[entityType] = map[string]map[string]string{}
 				continue
 			}
 			return fmt.Errorf("hnsw import: read meta %s: %w", entityType, err)
@@ -423,9 +485,75 @@ func (s *HNSWEmbeddingStore) Import(dir string) error {
 		if err := json.Unmarshal(b, &m); err != nil {
 			return fmt.Errorf("hnsw import: unmarshal meta %s: %w", entityType, err)
 		}
-		s.meta[entityType] = m
+		newMeta[entityType] = m
 	}
+
+	s.mu.Lock()
+	s.graphs = newGraphs
+	s.meta = newMeta
+	s.mu.Unlock()
+
 	slog.Info("hnsw: snapshot imported", "dir", dir, "entity_types", len(entries))
+	return nil
+}
+
+// ImportWithStalenessCheck wraps Import with a staleness guard (ARCH-1): after
+// a successful on-disk import, it compares each imported entity type's
+// in-memory graph count against a caller-supplied Pebble-side truth count
+// (e.g. EmbeddingStore.CountByType, the emb: keyspace's source-of-truth
+// count). The HNSW snapshot fast-path otherwise skips Pebble hydration
+// unconditionally — after any unclean shutdown, every vector upserted since
+// the last clean-shutdown Export would be silently and permanently missing
+// from the graph. If the imported graph undercounts the truth for any entity
+// type at all (any undercount is unsafe — there is no positive tolerance),
+// the ENTIRE imported snapshot (all entity types) is discarded, not just the
+// stale one, so the caller's existing hydrate-from-Pebble fallback (which
+// runs when CountByType("book")==0) runs normally; no new hydration
+// mechanism is introduced here.
+//
+// Discarding all-or-nothing (rather than per-entity-type) is deliberate:
+// dedup/lifecycle.go's PostInit gates hydration on the "book" count alone,
+// and internal/dedup/engine.go's HydrateChromem re-populates BOTH "book" and
+// "author" together when it runs. A per-type discard that kept a fresh
+// "author" graph while discarding a stale "book" graph would cause
+// HydrateChromem to Add authors on top of the already-populated author
+// graph — the same Delete+Add per-layer-invariant class of bug
+// (HNSW-CRASH-2026-06-18) that safeAdd/safeDelete guard against, just
+// reached via a different path. Discarding every entity type when any one is
+// stale keeps hydration's "populate from empty" precondition intact.
+//
+// truth may be nil, in which case the staleness check is skipped entirely
+// (e.g. callers/tests without a Pebble store handy) and Import's result is
+// returned unchanged.
+func (s *HNSWEmbeddingStore) ImportWithStalenessCheck(dir string, truth func(entityType string) (int, error)) error {
+	if err := s.Import(dir); err != nil {
+		return err
+	}
+	if truth == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stale := false
+	for entityType, g := range s.graphs {
+		truthCount, err := truth(entityType)
+		if err != nil {
+			// Can't verify against the truth source; don't treat this entity
+			// type as stale on an unrelated error.
+			continue
+		}
+		if g.Len() < truthCount {
+			slog.Warn("hnsw import: snapshot undercounts pebble truth; discarding entire imported snapshot (will rehydrate from pebble)",
+				"entity_type", entityType, "graph_count", g.Len(), "truth_count", truthCount)
+			stale = true
+		}
+	}
+	if stale {
+		s.graphs = map[string]*hnsw.Graph[string]{}
+		s.meta = map[string]map[string]map[string]string{}
+	}
 	return nil
 }
 

--- a/internal/database/hnsw_embedding_store_test.go
+++ b/internal/database/hnsw_embedding_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/hnsw_embedding_store_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-06-18
+// last-edited: 2026-07-03
 
 package database
 
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -403,5 +405,267 @@ func TestHNSW_SnapshotSkipsHydration(t *testing.T) {
 	}
 	if got, _ := s2.CountByType(ctx, "book"); got != 51 {
 		t.Errorf("CountByType after new insert = %d, want 51", got)
+	}
+}
+
+// TestHNSW_ExportAtomic_BadWriteLeavesGoodSnapshotIntact locks ARCH-2's Export
+// half: a failed write for one entity type must not clobber a previously
+// committed good snapshot at the final path (temp+rename semantics).
+func TestHNSW_ExportAtomic_BadWriteLeavesGoodSnapshotIntact(t *testing.T) {
+	const dim = 4
+	ctx := context.Background()
+	s := NewHNSWEmbeddingStore(dim)
+
+	if err := s.Upsert(ctx, "book", "B1", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := s.Export(dir); err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	binPath := filepath.Join(dir, "hnsw-book.bin")
+	before, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("read committed snapshot: %v", err)
+	}
+
+	// Simulate an interrupted second export: pre-create the .bin temp path as
+	// a directory, so os.Create on it fails (EISDIR) partway through the next
+	// Export, without touching the already-committed good file.
+	s2 := NewHNSWEmbeddingStore(dim)
+	if err := s2.Upsert(ctx, "book", "B2", []float32{0, 1, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert into second store: %v", err)
+	}
+	tmpBinPath := binPath + ".tmp"
+	if err := os.Mkdir(tmpBinPath, 0o755); err != nil {
+		t.Fatalf("pre-create tmp path as dir: %v", err)
+	}
+	defer os.Remove(tmpBinPath)
+
+	if err := s2.Export(dir); err == nil {
+		t.Fatal("expected Export to fail when the .bin temp path cannot be created")
+	}
+
+	after, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("read snapshot after failed export: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("failed export clobbered the previously-committed good snapshot")
+	}
+}
+
+// TestHNSW_ImportAtomic_CorruptMetaAbortsWithoutPartialInstall locks ARCH-2's
+// Import half: a hard failure decoding one entity type's meta sidecar must
+// abort the whole call and leave s.graphs/s.meta at their pre-call state, not
+// partially installed — so the caller's hydrate-from-Pebble fallback actually
+// runs instead of operating on a corrupted graph.
+func TestHNSW_ImportAtomic_CorruptMetaAbortsWithoutPartialInstall(t *testing.T) {
+	const dim = 4
+	ctx := context.Background()
+	s1 := NewHNSWEmbeddingStore(dim)
+	if err := s1.Upsert(ctx, "book", "B1", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := s1.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// Corrupt the meta sidecar so json.Unmarshal fails (a hard error, not the
+	// os.IsNotExist "no sidecar" path).
+	metaPath := filepath.Join(dir, "hnsw-book.meta.json")
+	if err := os.WriteFile(metaPath, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatalf("corrupt meta: %v", err)
+	}
+
+	s2 := NewHNSWEmbeddingStore(dim)
+	// Pre-populate s2 with unrelated state to prove Import doesn't touch it
+	// on failure either.
+	if err := s2.Upsert(ctx, "author", "A1", []float32{0, 0, 1, 0}, nil); err != nil {
+		t.Fatalf("pre-populate author: %v", err)
+	}
+
+	if err := s2.Import(dir); err == nil {
+		t.Fatal("expected Import to fail on corrupt meta.json")
+	}
+
+	if _, ok := s2.graphs["book"]; ok {
+		t.Error("Import installed a partial 'book' graph despite returning an error")
+	}
+	n, err := s2.CountByType(ctx, "author")
+	if err != nil {
+		t.Fatalf("CountByType author: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("pre-existing 'author' state was mutated by a failed Import: CountByType = %d, want 1", n)
+	}
+}
+
+// TestHNSW_ImportWithStalenessCheck_DiscardsUndercountedSnapshot locks ARCH-1:
+// when the imported HNSW graph's count for an entity type is lower than the
+// Pebble-side truth count, the imported state for that entity type must be
+// discarded so the caller's existing hydrate-from-Pebble fallback (which
+// checks CountByType==0) runs instead of silently operating on a graph
+// missing vectors upserted since the last clean-shutdown export.
+func TestHNSW_ImportWithStalenessCheck_DiscardsUndercountedSnapshot(t *testing.T) {
+	const dim = 4
+	ctx := context.Background()
+	s1 := NewHNSWEmbeddingStore(dim)
+	if err := s1.Upsert(ctx, "book", "B1", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := s1.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	s2 := NewHNSWEmbeddingStore(dim)
+	// Truth (simulated Pebble EmbeddingStore.CountByType) reports 5 vectors
+	// for "book" — more than the 1 vector in the snapshot, simulating an
+	// unclean shutdown that stranded 4 upserts after the last clean export.
+	truth := func(entityType string) (int, error) {
+		if entityType == "book" {
+			return 5, nil
+		}
+		return 0, nil
+	}
+	if err := s2.ImportWithStalenessCheck(dir, truth); err != nil {
+		t.Fatalf("ImportWithStalenessCheck: %v", err)
+	}
+
+	n, err := s2.CountByType(ctx, "book")
+	if err != nil {
+		t.Fatalf("CountByType: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("stale snapshot was not discarded: CountByType(book) = %d, want 0", n)
+	}
+}
+
+// TestHNSW_ImportWithStalenessCheck_DiscardsAllTypesWhenAnyIsStale locks the
+// all-or-nothing discard semantics: dedup/lifecycle.go's PostInit gates
+// hydration on the "book" count alone, and HydrateChromem re-populates BOTH
+// "book" and "author" together when it runs. If only the stale "book" graph
+// were discarded while a fresh "author" graph were kept, HydrateChromem would
+// re-Add authors on top of the already-populated author graph — the same
+// Delete+Add per-layer-invariant class of bug (HNSW-CRASH-2026-06-18) that
+// safeAdd/safeDelete guard against. So a stale "book" count must discard the
+// entire snapshot, including an otherwise-fresh "author" graph.
+func TestHNSW_ImportWithStalenessCheck_DiscardsAllTypesWhenAnyIsStale(t *testing.T) {
+	const dim = 4
+	ctx := context.Background()
+	s1 := NewHNSWEmbeddingStore(dim)
+	if err := s1.Upsert(ctx, "book", "B1", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert book: %v", err)
+	}
+	if err := s1.Upsert(ctx, "author", "A1", []float32{0, 1, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert author: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := s1.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	s2 := NewHNSWEmbeddingStore(dim)
+	// "book" is stale (truth=5 > graph's 1); "author" is fresh (truth=1 ==
+	// graph's 1). The stale "book" must still cause "author" to be discarded.
+	truth := func(entityType string) (int, error) {
+		if entityType == "book" {
+			return 5, nil
+		}
+		return 1, nil
+	}
+	if err := s2.ImportWithStalenessCheck(dir, truth); err != nil {
+		t.Fatalf("ImportWithStalenessCheck: %v", err)
+	}
+
+	bookCount, err := s2.CountByType(ctx, "book")
+	if err != nil {
+		t.Fatalf("CountByType book: %v", err)
+	}
+	if bookCount != 0 {
+		t.Errorf("stale book snapshot not discarded: CountByType(book) = %d, want 0", bookCount)
+	}
+	authorCount, err := s2.CountByType(ctx, "author")
+	if err != nil {
+		t.Fatalf("CountByType author: %v", err)
+	}
+	if authorCount != 0 {
+		t.Errorf("fresh author graph was not discarded alongside stale book (all-or-nothing violated): CountByType(author) = %d, want 0", authorCount)
+	}
+}
+
+// TestHNSW_ImportWithStalenessCheck_KeepsFreshSnapshot is the counterpart to
+// the discard test: a graph count that meets or exceeds the truth count must
+// be kept (no unnecessary rehydration on every boot).
+func TestHNSW_ImportWithStalenessCheck_KeepsFreshSnapshot(t *testing.T) {
+	const dim = 4
+	ctx := context.Background()
+	s1 := NewHNSWEmbeddingStore(dim)
+	if err := s1.Upsert(ctx, "book", "B1", []float32{1, 0, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := s1.Export(dir); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	s2 := NewHNSWEmbeddingStore(dim)
+	truth := func(entityType string) (int, error) { return 1, nil }
+	if err := s2.ImportWithStalenessCheck(dir, truth); err != nil {
+		t.Fatalf("ImportWithStalenessCheck: %v", err)
+	}
+
+	n, err := s2.CountByType(ctx, "book")
+	if err != nil {
+		t.Fatalf("CountByType: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("fresh snapshot was discarded unnecessarily: CountByType(book) = %d, want 1", n)
+	}
+}
+
+// TestHNSW_SafeDelete_AbsentAndDoubleDeleteDoNotPanic locks ARCH-5: Delete
+// must never let a coder/hnsw Graph.Delete panic escape, mirroring the
+// existing safeAdd regression test. Deleting a key that was never added, and
+// deleting the same key twice, must both complete without crashing.
+func TestHNSW_SafeDelete_AbsentAndDoubleDeleteDoNotPanic(t *testing.T) {
+	ctx := context.Background()
+	s := NewHNSWEmbeddingStore(3)
+
+	// Delete of a key never added, on a graph that doesn't exist yet at all.
+	if err := s.Delete(ctx, "book", "never-added"); err != nil {
+		t.Fatalf("delete of absent key on absent graph: %v", err)
+	}
+
+	if err := s.Upsert(ctx, "book", "B1", []float32{1, 0, 0}, nil); err != nil {
+		t.Fatalf("upsert B1: %v", err)
+	}
+
+	// Delete of a key never added, on a graph that does exist.
+	if err := s.Delete(ctx, "book", "still-never-added"); err != nil {
+		t.Fatalf("delete of absent key on populated graph: %v", err)
+	}
+
+	// Double-delete of the same real key.
+	if err := s.Delete(ctx, "book", "B1"); err != nil {
+		t.Fatalf("first delete of B1: %v", err)
+	}
+	if err := s.Delete(ctx, "book", "B1"); err != nil {
+		t.Fatalf("second delete (double-delete) of B1: %v", err)
+	}
+
+	// The store must remain usable afterward: reaching this point at all
+	// proves no panic escaped Delete. A recovered-panic error from the
+	// underlying library on a subsequent Add is tolerated (same contract as
+	// safeAdd/TestHNSWUpsert_ReinsertDoesNotCrash) — a process crash is not.
+	if err := s.Upsert(ctx, "book", "B2", []float32{0, 1, 0}, nil); err != nil {
+		t.Logf("post-delete insert returned (recovered) error, tolerated: %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -441,7 +441,18 @@ func NewServer(store database.Store) *Server {
 		server.hnswPersistDir = hnswDir
 		if raw, ok := serviceregistry.TryGet[database.VectorANNStore](regContainer, "chromemstore"); ok && raw != nil {
 			if hnswStore, ok := raw.(*database.HNSWEmbeddingStore); ok {
-				if err := hnswStore.Import(hnswDir); err != nil {
+				// ARCH-1: guard the snapshot fast-path with a cheap staleness
+				// check against the Pebble source of truth. Without this, an
+				// unclean shutdown silently and permanently strands dedup
+				// Layer 2 on a graph missing every vector upserted since the
+				// last clean-shutdown Export (HNSW-CRASH-2026-06-18 note above
+				// still governs the Import-before-PostInit ordering; this
+				// check does not change that).
+				var truthCount func(string) (int, error)
+				if embStore, ok := serviceregistry.TryGet[*database.EmbeddingStore](regContainer, serviceregistry.KeyEmbeddingStore); ok && embStore != nil {
+					truthCount = embStore.CountByType
+				}
+				if err := hnswStore.ImportWithStalenessCheck(hnswDir, truthCount); err != nil {
 					if !errors.Is(err, database.ErrNoHNSWSnapshot) {
 						slog.Warn("hnsw: import failed, will hydrate from PebbleDB", "err", err)
 					}


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-20** (wave 2): hardens the HNSW embedding index against the failure modes found in the consultancy evaluation.

- **Staleness check on import** — snapshot with mismatched dimension/count vs PebbleDB source is discarded and rebuilt instead of served stale
- **Atomic export** — snapshot written to temp file + rename, so a crash mid-export can't leave a truncated snapshot
- **Safe Delete** — delete path no longer panics on IDs absent from the index; treated as no-op with a log line
- Server startup wiring updated accordingly (`internal/server/server.go`)

## Test plan

- [x] 268 lines of new/extended unit tests (`hnsw_embedding_store_test.go`)
- [ ] Local honest gate — queued serially after cr-13's gate
- [ ] Minimal CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1