### PR TITLE
refactor(storage): cut activity + metrics over to Pebble-only, retire NutsDB dual-write (TASK-22)

### DIFF
--- a/internal/activity/register.go
+++ b/internal/activity/register.go
@@ -1,22 +1,22 @@
 // file: internal/activity/register.go
-// version: 1.2.1
-// last-edited: 2026-06-23
+// version: 1.3.0
+// last-edited: 2026-07-03
 // guid: c4d5e6f7-a8b9-0009-2345-000000000009
 
 // Package activity — service registry wiring for the activity log.
 //
-// WHY backend selection during the migration window (T024):
-//   - Before the "activity_pebble_v1_done" backfill flag is set in Pebble, reads
-//     come from NutsDB (source of truth). Both backends receive every write.
-//   - After the flag is set, reads flip to Pebble. NutsDB still receives writes
-//     so a rollback (flip ReadFromPebble=false) is safe without data loss.
-//   - The dual-write window ends when NutsDB is removed (follow-up task T024b).
+// WHY Pebble-only (TASK-22, 2026-07-03):
+//   - The NutsDB→Pebble migration (T024) is complete: the
+//     "activity_pebble_v1_done" backfill flag has been set on prod, so reads
+//     have already been coming from Pebble with no read benefit left in
+//     NutsDB. Activity is now Pebble-only — NutsDB is no longer opened here at
+//     all, which also removes the process-lifetime NutsDB Close() goroutine
+//     from this path (see TODO.md NUTSDB-CLOSE-GOROUTINE-LEAK).
 package activity
 
 import (
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -46,10 +46,10 @@ func init() {
 		},
 	})
 
-	// activitystore: activity log backend, wired to dual-write when Pebble is available.
-	// Lives in {dirname(DatabasePath)}/activity.nutsdb (NutsDB sidecar).
-	// Returns nil when DatabasePath is unset — host code must Override serviceregistry.KeyActivityStore
-	// with a pre-built instance in that case (test paths).
+	// activitystore: Pebble-only activity log backend (NutsDB retired — see
+	// package doc). Returns nil when DatabasePath is unset — host code must
+	// Override serviceregistry.KeyActivityStore with a pre-built instance in
+	// that case (test paths).
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   serviceregistry.KeyActivityStore,
 		Needs:  []string{serviceregistry.KeyConfig, "pebble-activitystore"},
@@ -59,27 +59,16 @@ func init() {
 			if cfg.DatabasePath == "" {
 				return nil, fmt.Errorf("activitystore: DatabasePath not configured")
 			}
-			activityDir := filepath.Join(filepath.Dir(cfg.DatabasePath), "activity.nutsdb")
-			nutsStore, err := database.NewNutsActivityStore(activityDir)
-			if err != nil {
-				return nil, fmt.Errorf("activitystore: open nutsdb: %w", err)
-			}
 
-			// Try to wrap in dual-write if the Pebble backend is available.
 			pebbleStore, hasPebble := serviceregistry.TryGet[*database.PebbleActivityStore](c, "pebble-activitystore")
 			if !hasPebble || pebbleStore == nil {
-				// Pebble backend not available — NutsDB-only (degraded / test mode).
-				slog.Info("[activity] Pebble activity store not available; using NutsDB-only")
-				return nutsStore, nil
+				// No more NutsDB fallback — a missing Pebble backend is now a
+				// hard error rather than a degraded mode.
+				return nil, fmt.Errorf("activitystore: pebble activity store not available")
 			}
 
-			// Determine read source from backfill flag.
-			// Checked once at startup — the flag is not expected to change at runtime.
-			readFromPebble := database.IsActivityPebbleBackfillDone(pebbleStore.DB())
-			slog.Info("[activity] dual-write mode enabled",
-				"read_from_pebble", readFromPebble,
-				"flag", database.ActivityPebbleBackfillKey)
-			return database.NewDualWriteActivityStore(nutsStore, pebbleStore, readFromPebble), nil
+			slog.Info("[activity] Pebble-only activity store wired")
+			return pebbleStore, nil
 		},
 	})
 

--- a/internal/database/activity_storer.go
+++ b/internal/database/activity_storer.go
@@ -1,6 +1,7 @@
 // file: internal/database/activity_storer.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-0001-abcd-000000000001
+// last-edited: 2026-07-03
 
 package database
 
@@ -10,7 +11,8 @@ import (
 )
 
 // ActivityStorer is the minimal interface required by activity.Service and
-// activity.Writer. NutsActivityStore is the production implementation.
+// activity.Writer. PebbleActivityStore is the production implementation
+// (NutsActivityStore retired as of TASK-22, retained unwired pending removal).
 type ActivityStorer interface {
 	Record(ActivityEntry) (int64, error)
 	Query(ActivityFilter) ([]ActivityEntry, int, error)
@@ -25,7 +27,8 @@ type ActivityStorer interface {
 }
 
 // MetricsStorer is the minimal interface required by server cache handlers.
-// NutsMetricsStore is the production implementation.
+// PebbleMetricsStore is the production implementation (NutsMetricsStore
+// retired as of TASK-22, retained unwired pending removal).
 type MetricsStorer interface {
 	RecordCacheStatsSnapshots([]CacheStatsSnapshot) error
 	GetCacheStatsHistory(cacheName string, since time.Time, limit int) ([]CacheStatsSnapshot, error)

--- a/internal/database/dual_write_activity_store.go
+++ b/internal/database/dual_write_activity_store.go
@@ -1,10 +1,18 @@
 // file: internal/database/dual_write_activity_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-0006-f012-000000000006
+// last-edited: 2026-07-03
 
 // Package database — dual-write wrapper for the activity migration window.
 //
-// WHY a dual-write wrapper:
+// UNUSED as of 2026-07-03 (TASK-22): the activitystore service in
+// internal/activity/register.go now returns *PebbleActivityStore directly.
+// This wrapper is retained, unwired, for one release cycle as a rollback
+// reference; it will be deleted (along with NutsActivityStore/
+// NutsMetricsStore and the nutsdb dependency) in the follow-up NutsDB-removal
+// PR once the soak period has passed and an owner has greenlit removal.
+//
+// WHY a dual-write wrapper (historical):
 //   - The NutsDB → Pebble migration requires a hot-deploy cutover window during
 //     which BOTH backends receive every write. This prevents data loss if the
 //     Pebble flag is not yet set (e.g., prod hasn't backfilled yet).

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,6 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.16.0
-// last-edited: 2026-06-23
+// version: 1.17.0
+// last-edited: 2026-07-03
 
 package server
 
@@ -155,26 +155,29 @@ func init() {
 		},
 	})
 
-	// metricsstore — NutsDB-backed cache-stats snapshot store. Lives at
-	// {dirname(DatabasePath)}/metrics.nutsdb. Returns nil + logs when
-	// DatabasePath is empty (test paths) or open fails — server code
-	// nil-checks before use.
+	// metricsstore — Pebble-backed cache-stats snapshot store (TASK-22 cutover
+	// from NutsMetricsStore). Shares the main PebbleDB instance under the
+	// "met:" key prefix; TTL is emulated via the sweep-pebble-metrics-ttl
+	// maintenance job rather than NutsDB's native per-key expiry. Returns a
+	// nil *PebbleMetricsStore + logs when DatabasePath is empty (test paths)
+	// or the store isn't a *database.PebbleStore — server code nil-checks
+	// before use.
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "metricsstore",
-		Needs:  []string{serviceregistry.KeyConfig},
+		Needs:  []string{serviceregistry.KeyConfig, serviceregistry.KeyStore},
 		Groups: []string{"core"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
 			if cfg.DatabasePath == "" {
-				return (*database.NutsMetricsStore)(nil), nil
+				return (*database.PebbleMetricsStore)(nil), nil
 			}
-			dir := filepath.Join(filepath.Dir(cfg.DatabasePath), "metrics.nutsdb")
-			store, err := database.NewNutsMetricsStore(dir)
-			if err != nil {
-				slog.Warn("Failed to open metrics store", "err", err)
-				return (*database.NutsMetricsStore)(nil), nil
+			store := serviceregistry.Get[database.Store](c, serviceregistry.KeyStore)
+			ps, ok := store.(*database.PebbleStore)
+			if !ok {
+				slog.Warn("metricsstore: backend is not PebbleStore, metrics disabled")
+				return (*database.PebbleMetricsStore)(nil), nil
 			}
-			return store, nil
+			return database.NewPebbleMetricsStore(ps.DB()), nil
 		},
 	})
 


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-22** (wave 2), NutsDB retirement **PR 1 of 2**: switches the activity log and metrics paths to PebbleDB-only, removing the NutsDB leg of the dual-write. NutsDB file/dependency removal is deliberately deferred to PR 2 pending a prod soak period.

- `internal/activity/register.go` + `registry_wire.go` — activity storer wiring now resolves to the Pebble store directly
- `internal/database/dual_write_activity_store.go` — dual-write path retired from the default wiring (kept for the soak window)
- `internal/database/activity_storer.go` — interface cleanup

## Required evidence (per brief)

- **Activity backfill:** the backfill flag has been set and activity has been dual-written to Pebble, so there is **no NutsDB-only activity data** — cutover loses nothing
- **Metrics history:** `metrics.nutsdb` ~30-day history is **intentionally dropped** with no backfill (short-retention operational data, per brief)
- **TTL sweep:** Pebble-side TTL sweep for activity/metrics is already active, so retention behavior is preserved post-cutover

## Test plan

- [x] Local honest gate GREEN: mocks-check, mock freshness, backend short suite (97 pkgs ok / 0 fail), frontend tests, coverage 40.5% ≥ 30%
- [ ] Minimal CI green
- [ ] Prod soak before PR 2 (NutsDB file/dep removal) — owner greenlight required

## Follow-up found during this task

Residual **SweepTick leg of PEBBLE-CLOSED-SHUTDOWN-RACE**: `registry.go:341` → `DepsScheduler.SweepTick` → `ListWaitingDepsOps` can panic post-Close. Recorded for the wave-2 summary; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1