### PR TITLE
docs(changelog,todo): consultancy-roadmap wave-2 completion summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,30 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.100.0 -->
+<!-- version: 3.101.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-02 -->
+<!-- last-edited: 2026-07-03 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 3, 2026 - Consultancy-roadmap wave 2: 8 tasks shipped via parallel sweep (PRs #1761-#1770)
+
+Parallel-sweep run `2026-07-03-1010-consultancy-w2` — same coordinator pattern as wave 1 (Haiku ×3 / Sonnet ×3 / Opus ×2). All 8 wave-2 briefs merged; two prod-data ops shipped dry-run-only pending owner greenlight.
+
+- **`refactor(storage)`** #1770 — TASK-22 NutsDB retirement PR 1 of 2: activity + metrics cut over to Pebble-only, dual-write leg retired. Evidence: activity was dual-written (no NutsDB-only data), `metrics.nutsdb` 30-day history intentionally dropped (no backfill), Pebble TTL sweep already active. PR 2 (file/dependency removal) deferred pending prod soak + owner greenlight.
+- **`feat(dedup)`** #1768 — TASK-13 (Opus): dry-run-gated `dedup.drain-stale` op for the ~384K CONS-16/17-era mislabeled stale candidates; classifier + drain engine + plugin wiring (985 lines, mostly tests). Prod execution owner-gated.
+- **`fix(database)`** #1769 — TASK-20: HNSW derived-index hardening — staleness check discards mismatched snapshots on import, atomic temp-file+rename export, Delete no longer panics on absent IDs.
+- **`feat(server)`** #1763 — TASK-03 (Opus): BookSigV1/Description recovery audit op over `book_ver:` snapshots (dry-run-first; prod run owner-gated).
+- **`feat(ops)`** #1764 — TASK-21: Prometheus scrape config + alerting rules for the metrics endpoint (placeholder IPs only).
+- **`fix(covers)`** #1762 — TASK-24: cover-candidate filter ordering fixed (cheap filters before network fetches).
+- **`fix(metadata)`** #1761 — TASK-25: `IsGarbageValue` substring/prefix handling (incl. `"error "` prefix); conflicting legacy test expectation reconciled.
+- **`chore(ci)`** #1766 — TASK-29: coverage gate strengthened; `-timeout 25m` added to `test-short` (internal/server short suite runs ~10m).
+- **`fix(test)`** #1765 (aux) — removed `t.Parallel()` from config-mutating tests (data race found gating cr-05-adjacent suites).
+- **`chore(lint)`** #1767 (aux) — partial staticcheck cleanup (unused funcs); ~18 findings remain for a dedicated burndown.
+
+Follow-ups recorded in TODO.md: residual SweepTick leg of PEBBLE-CLOSED-SHUTDOWN-RACE (`registry.go:341` → `DepsScheduler.SweepTick` → `ListWaitingDepsOps` post-Close panic), `TestCreateIngestVersion_SecondVersionIsAlt` flake (SIGSEGV once, 16/16 local re-runs pass), staticcheck burndown (~18 findings), sdkguard violation (`pkg/plugin/sdk` imports `internal/logger` — fails `make ci` on main), Mock Freshness glob misses nested mocks dirs, NutsDB PR-2 removal after soak. Sweep state: `.claude/state/parallel-sweep-2026-07-03-1010-consultancy-w2.json`.
 
 #### July 3, 2026 - Consultancy-roadmap wave 1: 14 tasks shipped via parallel sweep (PRs #1744-#1759)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.55.0 -->
+<!-- version: 9.56.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-03 -->
 
@@ -27,9 +27,16 @@ adversarially verified). Ranked roadmap: [`docs/consultancy/00-ROADMAP.md`](docs
 
 > **Task briefs exist for all of these (2026-07-03):**
 > [`docs/agent-tasks/consultancy-roadmap/`](docs/agent-tasks/consultancy-roadmap/)
-> — 31 briefs, 6 waves, model-tiered. **Wave 1 (14 tasks) SHIPPED 2026-07-03, PRs #1744–#1759.** Next: wave 2 (T03, T13, T20, T21, T22, T24, T25, T29) (Haiku/Sonnet, Opus only for the 8 complex
-> items). CONSULT-1..8 map to TASK-01..09 there. Run via that folder's
-> `run.sh` + `orchestration.md`.
+> — 31 briefs, 6 waves, model-tiered. **Wave 1 (14 tasks) SHIPPED 2026-07-03, PRs #1744–#1759.**
+> **Wave 2 (8 tasks) SHIPPED 2026-07-03, PRs #1761–#1770** (T03 #1763, T13 #1768, T20 #1769,
+> T21 #1764, T22 #1770, T24 #1762, T25 #1761, T29 #1766; aux #1765/#1767). Next: wave 3
+> (T10 backend-toggle core [Opus], T14, T15 [Opus], T26). CONSULT-1..8 map to TASK-01..09
+> there. Run via that folder's `run.sh` + `orchestration.md`.
+>
+> **Owner-greenlight queue from wave 2 (dry-run ops merged, NOT yet run on prod):**
+> - `dedup.drain-stale` (#1768) — dry-run against the ~384K stale candidates, review report, then apply
+> - BookSig/Description recovery audit (#1763) — dry-run over `book_ver:` snapshots, review, then apply
+> - NutsDB retirement PR 2 (file/dep removal) — after prod soak of #1770's Pebble-only cutover
 
 Tier-0 items (high impact, low effort — do first):
 
@@ -898,6 +905,27 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ## 🐛 Open Bugs — May 17, 2026
 
+- [ ] **PEBBLE-CLOSED-SWEEPTICK-RESIDUAL** (2026-07-03, found by cr-22's gate during the wave-2
+  sweep) — a residual, separate leg of the shutdown race the entry below marked fixed: the ticker
+  path `registry.go:341` → `DepsScheduler.SweepTick` → `ListWaitingDepsOps` can still touch the
+  store after `Close()` and panic `pebble: closed`. The 2026-07-02 fix drained the dep-*notify*
+  goroutines and asserted SweepTick "was already enrolled" — the tick loop itself isn't gated by
+  `notifyStopped`, so a tick in flight at Close time races. Fix shape: gate the SweepTick body
+  behind the same `notifyStopped`/`r.mu` check (or stop the ticker before `goroutineWG.Wait()`)
+  + `-race` repro test mirroring `shutdown_race_test.go`.
+- [ ] **INGEST-VERSION-FLAKE** (2026-07-03, wave-2 gates) — `TestCreateIngestVersion_SecondVersionIsAlt`
+  SIGSEGV'd once on a GitHub runner; passes 16/16 locally under `-race`. Suspect ordering/teardown
+  sensitivity, not logic. Diagnose root cause per fix-flaky-tests policy; don't rerun-and-ignore.
+- [ ] **SDKGUARD-VIOLATION** (2026-07-03) — `pkg/plugin/sdk` imports `internal/logger`, so
+  `make ci` fails on main at the `sdkguard` step (masked all session by `| tail` swallowing exit
+  codes). Either break the import or add an allowlist entry in `tools/cmd/sdkguard/main.go` with
+  justification.
+- [ ] **STATICCHECK-BURNDOWN** (2026-07-03) — ~18 pre-existing findings remain after the partial
+  cleanup in #1767; `make ci`'s staticcheck step fails on main until drained. Good Haiku-sweep
+  candidate.
+- [ ] **MOCK-FRESHNESS-GLOB-GAP** (2026-07-03) — the Mock Freshness CI gate's `internal/*/mocks/`
+  glob misses nested mocks dirs (e.g. the dir holding `mock_dedup_engine.go`, stale since #1736
+  until hand-regenerated in #1757). Widen the glob to `internal/**/mocks/`.
 - [x] **PEBBLE-CLOSED-SHUTDOWN-RACE** (2026-07-01, found during the agent-task sweep) — ✅ **FIXED
   2026-07-02** (branch `fix/pebble-shutdown-race`). **Root cause was NOT `SweepTick`** as the
   original entry guessed — that path was already enrolled in `goroutineWG` and drained by


### PR DESCRIPTION
## Summary

Records wave-2 completion (8/8 tasks, PRs #1761–#1770 + aux #1765/#1767) in CHANGELOG.md and TODO.md:

- CHANGELOG: full wave-2 entry with per-PR breakdown and follow-ups
- TODO: wave status updated; **owner-greenlight queue** added (dedup.drain-stale dry-run, BookSig recovery audit dry-run, NutsDB PR-2 after soak); 5 new Open Bugs entries (SweepTick residual shutdown race, TestCreateIngestVersion flake, sdkguard violation, staticcheck burndown ~18, Mock Freshness glob gap)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1