### PR TITLE
feat(maintenance): scope duration-reextract to unknown-duration books (TASK-14)

### DIFF
--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_reextract.go
-// version: 3.8.0
+// version: 3.9.0
 // guid: 9c2f7a14-6d83-4e51-b0a9-2f5c8e1d4b67
-// last-edited: 2026-06-24
+// last-edited: 2026-07-03
 
 // Package maintenance — op maintenance.duration-reextract.
 //
@@ -86,6 +86,12 @@ type durationReextractParams struct {
 	SkipAgeDays int `json:"skipAgeDays"`
 	// Force ignores DurationVerifiedAt entirely and re-examines every book.
 	Force bool `json:"force"`
+	// OnlyMissingDuration, if true, skips books whose Duration is already known
+	// and positive (Book.Duration != nil && *Book.Duration > 0). Use this to
+	// scope a run to the Duration=0/nil residual (DEDUP-4) instead of
+	// re-checking the whole library. Default false (preserves existing
+	// whole-library behavior for all current callers/schedules).
+	OnlyMissingDuration bool `json:"onlyMissingDuration"`
 }
 
 // durationChangeThresholds: a book is corrected only when the freshly extracted
@@ -152,7 +158,8 @@ func (p *Plugin) durationReextractDef() sdk.OperationDef {
 			"Corrects Book.Duration where the old fileSize÷bitrate estimate was wrong (PR #1555; m4b/m4a were ~2× too short). " +
 			"Never overwrites a real duration with an estimate, and skips books with any unreadable segment. " +
 			"Default dry-run previews counts (incl. fingerprint vs ffprobe split); set dryRun=false to apply. " +
-			"Workers param (default 4) controls ffprobe concurrency — higher = faster ffprobe tail.",
+			"Workers param (default 4) controls ffprobe concurrency — higher = faster ffprobe tail. " +
+			"Set onlyMissingDuration=true to scope the run to books with no known duration.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.duration-reextract",
@@ -394,6 +401,9 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 		err := sdk.PageBooks(ctx, store, reporter, pageSize, func(book database.Book) error {
 			if params.Limit > 0 && dispatched >= params.Limit {
 				return errLimitReached
+			}
+			if params.OnlyMissingDuration && book.Duration != nil && *book.Duration > 0 {
+				return nil // skip: duration already known, out of scope for this run
 			}
 			dispatched++
 			select {

--- a/internal/plugins/maintenance/duration_reextract_test.go
+++ b/internal/plugins/maintenance/duration_reextract_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_reextract_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 4a7d1e92-8c63-4f50-a1b8-3e6c9d2f5a04
-// last-edited: 2026-06-24
+// last-edited: 2026-07-03
 
 package maintenance
 
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -437,5 +438,98 @@ func TestDurationReextract_FingerprintIdempotent(t *testing.T) {
 	}
 	if writes != 0 {
 		t.Errorf("already-correct book must be skipped on re-run, got %d writes", writes)
+	}
+}
+
+// onlyMissingDurationTestBooks returns one book with a known positive
+// Duration and one with Duration==nil, both virtual (no BookFile rows,
+// empty FilePath so processBookForReextract short-circuits on noPath
+// without touching the filesystem). Used by the OnlyMissingDuration tests
+// below, which only care about whether a book was DISPATCHED (i.e. counted
+// in "examined"), not how it was ultimately triaged.
+func onlyMissingDurationTestBooks() []database.Book {
+	return []database.Book{
+		{ID: "known", Title: "Known duration", Duration: intPtr(3600)},
+		{ID: "unknown", Title: "Unknown duration", Duration: nil},
+	}
+}
+
+func newOnlyMissingDurationStore(books []database.Book) *database.MockStore {
+	return &database.MockStore{
+		CountAllBooksFunc: func() (int, error) { return len(books), nil },
+		GetAllBooksFunc: func(_, offset int) ([]database.Book, error) {
+			if offset >= len(books) {
+				return nil, nil
+			}
+			return books, nil
+		},
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) { return nil, nil },
+	}
+}
+
+// examinedCountFromSummary extracts the "examined=N" value from the final
+// summary log line emitted at the end of runDurationReextract.
+func examinedCountFromSummary(t *testing.T, logs []string) int {
+	t.Helper()
+	for _, l := range logs {
+		idx := strings.Index(l, "examined=")
+		if idx < 0 {
+			continue
+		}
+		var examined int
+		if _, err := fmt.Sscanf(l[idx:], "examined=%d", &examined); err == nil {
+			return examined
+		}
+	}
+	t.Fatalf("no summary log line containing examined=N found in %v", logs)
+	return -1
+}
+
+// TestDurationReextract_OnlyMissingDuration_SkipsKnownDuration is the scoped-skip
+// half of the acceptance criteria: with OnlyMissingDuration=true, a book whose
+// Duration is already known and positive must never be dispatched to a worker
+// — it should not appear in the "examined" count at all (skipped in the
+// producer, before dispatched++), leaving only the zero/nil-duration book.
+func TestDurationReextract_OnlyMissingDuration_SkipsKnownDuration(t *testing.T) {
+	books := onlyMissingDurationTestBooks()
+	store := newOnlyMissingDurationStore(books)
+	p := New(fakeDeps{store: store})
+	reporter := &fakeReporter{}
+
+	params, err := json.Marshal(durationReextractParams{DryRun: true, OnlyMissingDuration: true})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	if err := p.runDurationReextract(context.Background(), params, reporter); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := examinedCountFromSummary(t, reporter.logs)
+	if got != 1 {
+		t.Errorf("examined = %d, want 1 (only the unknown-duration book should be dispatched)", got)
+	}
+}
+
+// TestDurationReextract_OnlyMissingDuration_DefaultExaminesAll is the
+// additive-not-breaking half: with OnlyMissingDuration left at its zero value
+// (false), behavior must be unchanged from before this task — every book is
+// still dispatched regardless of its current Duration.
+func TestDurationReextract_OnlyMissingDuration_DefaultExaminesAll(t *testing.T) {
+	books := onlyMissingDurationTestBooks()
+	store := newOnlyMissingDurationStore(books)
+	p := New(fakeDeps{store: store})
+	reporter := &fakeReporter{}
+
+	params, err := json.Marshal(durationReextractParams{DryRun: true})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	if err := p.runDurationReextract(context.Background(), params, reporter); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got := examinedCountFromSummary(t, reporter.logs)
+	if got != 2 {
+		t.Errorf("examined = %d, want 2 (OnlyMissingDuration=false must examine both books)", got)
 	}
 }


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-14** (wave 3): adds `onlyMissingDuration` param to the existing `maintenance.duration-reextract` op so the duration backfill can target only books with unknown duration instead of re-examining the whole library. Skip happens producer-side, before dispatch, so skipped books don't consume the op's `Limit`.

- `internal/plugins/maintenance/duration_reextract.go` — new bool param + producer-side skip + description update
- `internal/plugins/maintenance/duration_reextract_test.go` — 2 new tests: skip-known-duration proof + default-false examines-all proof (additive, non-breaking)

Code only — **no prod op execution** (per brief's STOP-HERE). The owner-gated next step is a prod dry-run with `onlyMissingDuration=true`, review counts, then apply.

## Test plan

- [x] `go test ./internal/plugins/maintenance/... -run TestDurationReextract` — 11/11 pass (9 pre-existing + 2 new)
- [x] `go vet` clean; 2-file diff verified
- [ ] Local honest gate (queued behind running wave-3 children)
- [ ] Minimal CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1