### PR TITLE
fix(metafetch): rescale LLM rerank scores into original candidate score window (TASK-26)

### DIFF
--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -13,7 +13,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	tmock "github.com/stretchr/testify/mock"
 
+	"github.com/falkcorp/audiobook-organizer/internal/ai/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 )
@@ -1470,6 +1473,87 @@ func TestRerankTopK(t *testing.T) {
 	t.Run("empty_candidates", func(t *testing.T) {
 		result := svc.RerankTopK(context.TODO(), &database.Book{}, nil)
 		assert.Nil(t, result)
+	})
+
+	// boost_stacked_tail_rescale reproduces MATCH-2: an ambiguous top-K window
+	// whose original (boost-inflated) scores exceed 1.0, plus an untouched
+	// tail candidate also above 1.0 but below the window's floor. Before the
+	// fix, the LLM's clamped [0,1] scores overwrote the window directly, so
+	// the window could fall below or collide with the tail purely due to the
+	// clamp/unclamp scale mismatch. After the fix, the LLM's relative
+	// preference is preserved but rescaled back into the window's original
+	// [origMin, origMax] range, so the tail's relative position is
+	// unaffected.
+	t.Run("boost_stacked_tail_rescale", func(t *testing.T) {
+		rerankSvc := NewService(mock)
+
+		origEpsilon := config.AppConfig.MetadataScoring.LLMRerankEpsilon
+		origTopK := config.AppConfig.MetadataScoring.LLMRerankTopK
+		config.AppConfig.MetadataScoring.LLMRerankEpsilon = 0.2
+		config.AppConfig.MetadataScoring.LLMRerankTopK = 5
+		t.Cleanup(func() {
+			config.AppConfig.MetadataScoring.LLMRerankEpsilon = origEpsilon
+			config.AppConfig.MetadataScoring.LLMRerankTopK = origTopK
+		})
+
+		llmMock := mocks.NewMockMetadataCandidateScorer(t)
+		llmMock.EXPECT().Score(tmock.Anything, tmock.Anything, tmock.Anything).
+			Return([]float64{0.6, 0.95}, nil).Once()
+		rerankSvc.SetMetadataLLMScorer(llmMock)
+
+		const (
+			origMax = 2.0 // window best, boost-stacked (e.g. author x1.5 x series x1.4)
+			origMin = 1.9 // window worst, also boost-stacked
+			tail    = 1.5 // untouched tail candidate, below origMin
+		)
+		candidates := []MetadataCandidate{
+			{Title: "Window Best (pre-rerank)", Score: origMax},
+			{Title: "Window Second (pre-rerank)", Score: origMin},
+			{Title: "Tail (untouched)", Score: tail},
+		}
+
+		result := rerankSvc.RerankTopK(context.TODO(), &database.Book{}, candidates)
+		require.Len(t, result, 3)
+
+		var windowBest, windowSecond, tailCand *MetadataCandidate
+		for i := range result {
+			switch result[i].Title {
+			case "Window Best (pre-rerank)":
+				windowBest = &result[i]
+			case "Window Second (pre-rerank)":
+				windowSecond = &result[i]
+			case "Tail (untouched)":
+				tailCand = &result[i]
+			}
+		}
+		require.NotNil(t, windowBest)
+		require.NotNil(t, windowSecond)
+		require.NotNil(t, tailCand)
+
+		// The LLM scored "Window Second" (0.95) higher than "Window Best"
+		// (0.6) — its preference must be honored after rescale.
+		assert.Greater(t, windowSecond.Score, windowBest.Score,
+			"LLM's preferred candidate must end up with the higher final score")
+
+		// Both reranked window candidates must land within the window's
+		// original [origMin, origMax] range — never leaping into or out of
+		// the untouched tail's range purely due to clamp/unclamp mismatch.
+		assert.GreaterOrEqual(t, windowBest.Score, origMin)
+		assert.LessOrEqual(t, windowBest.Score, origMax)
+		assert.GreaterOrEqual(t, windowSecond.Score, origMin)
+		assert.LessOrEqual(t, windowSecond.Score, origMax)
+
+		// The tail candidate is untouched and remains below the rescaled
+		// window — no spurious leapfrogging in either direction.
+		assert.Equal(t, tail, tailCand.Score)
+		assert.Less(t, tailCand.Score, windowBest.Score)
+		assert.Less(t, tailCand.Score, windowSecond.Score)
+
+		// Final ordering: window candidates (by LLM preference) then tail.
+		require.Len(t, result, 3)
+		assert.Equal(t, "Window Second (pre-rerank)", result[0].Title)
+		assert.Equal(t, "Window Best (pre-rerank)", result[1].Title)
+		assert.Equal(t, "Tail (untouched)", result[2].Title)
 	})
 }
 

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.5.2
+// version: 1.5.3
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
 // last-edited: 2026-07-03
 
@@ -667,13 +667,32 @@ func (mfs *Service) RerankTopK(
 		return candidates
 	}
 
-	// Replace top-K base scores with LLM scores directly — do not apply the
-	// author/narrator/series bonus multipliers again. The LLM prompt already
-	// sees those fields and judges them as part of its score; re-multiplying
-	// would double-count the same evidence and distort the top-K's position
-	// relative to the non-reranked tail.
+	// Replace top-K base scores with LLM scores — but rescale them back into
+	// the window's original [origMin, origMax] range first. The LLM scores
+	// come back hard-clamped to [0,1] (see LLMScorer.Score), while the
+	// untouched tail carries the full unclamped boost-multiplier stack
+	// (author/narrator/series, routinely 1.5-4.0 by design). Assigning the
+	// clamped LLM score directly would compare apples to oranges once the
+	// full list is re-sorted below: a tail candidate scoring >1.0 could
+	// outrank even an LLM-certain (1.0) reranked winner. Rescaling preserves
+	// the LLM's relative ranking within the window while keeping the window
+	// on the same scale as the tail.
+	//
+	// Do not apply the author/narrator/series bonus multipliers again when
+	// rescaling. The LLM prompt already sees those fields and judges them as
+	// part of its score; re-multiplying would double-count the same
+	// evidence.
+	origMax := bestScore
+	origMin := candidates[ambiguousEnd-1].Score
 	for i := range topCands {
-		candidates[i].Score = llmScores[i]
+		normFinal := llmScores[i]
+		if origMax == origMin {
+			// No spread in the original window — every candidate rescales
+			// to the same point.
+			candidates[i].Score = origMax
+			continue
+		}
+		candidates[i].Score = origMin + normFinal*(origMax-origMin)
 	}
 
 	// Resort the full list so the reranked top-K is in correct order against

--- a/internal/server/metadata_scoring_refactor_test.go
+++ b/internal/server/metadata_scoring_refactor_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/metadata_scoring_refactor_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3a7c2b1d-e84f-4d59-9f16-0e5a8b2c4d7e
 
 package server
@@ -222,7 +222,7 @@ func TestMetadataScorer_WiredEndToEnd(t *testing.T) {
 
 // TestRerankTopK_FiresOnAmbiguousTop checks that rerankTopK sends exactly the
 // candidates within MetadataLLMRerankEpsilon of the best score to the LLM,
-// and replaces their Score fields with the LLM's output.
+// and rescales the LLM's output into the original score window (MATCH-2).
 func TestRerankTopK_FiresOnAmbiguousTop(t *testing.T) {
 	// LLM says candidate 1 is actually the winner (0.95) even though
 	// candidate 0 had a higher base score (0.90).
@@ -253,14 +253,17 @@ func TestRerankTopK_FiresOnAmbiguousTop(t *testing.T) {
 	assert.Equal(t, 1, llm.callCount, "LLM should be called exactly once")
 	require.Len(t, got, 4)
 
-	// After rerank + resort, candidate B (0.95) should be first, A (0.60)
-	// should be pushed down, C (0.70) and D (0.50) should be unchanged.
+	// After rerank + resort, LLM scores are rescaled into the original
+	// ambiguous window [0.88, 0.90] (MATCH-2): B = 0.88+0.95*0.02 = 0.899,
+	// A = 0.88+0.60*0.02 = 0.892. Reranked candidates stay within their
+	// original window, so the un-reranked tail (C 0.70, D 0.50) can no
+	// longer leapfrog a demoted window member.
 	assert.Equal(t, "B", got[0].Title)
-	assert.InDelta(t, 0.95, got[0].Score, 0.0001)
-	assert.Equal(t, "C", got[1].Title, "C's 0.70 should now outrank A's demoted 0.60")
-	assert.InDelta(t, 0.70, got[1].Score, 0.0001)
-	assert.Equal(t, "A", got[2].Title)
-	assert.InDelta(t, 0.60, got[2].Score, 0.0001)
+	assert.InDelta(t, 0.899, got[0].Score, 0.0001)
+	assert.Equal(t, "A", got[1].Title, "A stays within the original window, above the un-reranked tail")
+	assert.InDelta(t, 0.892, got[1].Score, 0.0001)
+	assert.Equal(t, "C", got[2].Title)
+	assert.InDelta(t, 0.70, got[2].Score, 0.0001)
 	assert.Equal(t, "D", got[3].Title)
 	assert.InDelta(t, 0.50, got[3].Score, 0.0001)
 }


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-26** (wave 3): `RerankTopK` was overwriting candidate scores in the ambiguous window with raw `[0,1]` LLM scores, letting un-reranked tail candidates (e.g. score 1.5) outrank the LLM's top pick (0.95). Scores are now rescaled into the original window: `origMin + llmScore*(origMax-origMin)`, with an equal-bounds guard. Window detection, LLM call paths, and final stable sort untouched.

- `internal/metafetch/service_scoring.go` — rescale in `RerankTopK`
- `internal/metafetch/service_mock_test.go` — new `boost_stacked_tail_rescale` subtest (mock scorer, epsilon/topK config override with `t.Cleanup` restore)

## Test plan

- [x] `TestRerankTopK` 4/4 subtests pass incl. new rescale proof
- [x] Full `internal/metafetch` + `internal/ai` suites green; vet clean
- [x] `llm_scorer.go`'s `[0,1]` clamp verified untouched
- [ ] Local honest gate (queued behind running wave-3 children)
- [ ] Minimal CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1