### PR TITLE
feat(dedup): per-model embedding thresholds + read-only calibration op (TASK-15)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.61.0
+// version: 1.62.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-07-03
 
@@ -137,6 +137,40 @@ type DedupConfig struct {
 	ReviewModel string `json:"review_model" mapstructure:"review_model"`
 	// Signals holds the unified scoring band thresholds.
 	Signals DedupSignalConfig `json:"signals" mapstructure:"signals"`
+	// EmbeddingThresholdsByModel holds per-embedding-model overrides for the
+	// book high/low cosine thresholds, keyed by the producing model name
+	// (e.g. "text-embedding-3-large" or "bge-m3"). DEDUP-2/3: the flat
+	// BookHighThreshold/BookLowThreshold above were calibrated for OpenAI
+	// text-embedding-3-large's cosine distribution; a different embedding model
+	// (bge-m3) has a different distribution and needs its own thresholds.
+	// Any model NOT present in this map falls back to the flat
+	// BookHighThreshold/BookLowThreshold — so behaviour is byte-for-byte
+	// unchanged for the legacy model and any not-yet-calibrated model. Populate
+	// via the dedup.calibrate-embedding-thresholds report (owner-reviewed).
+	EmbeddingThresholdsByModel map[string]EmbeddingModelThresholds `json:"embedding_thresholds_by_model,omitempty" mapstructure:"embedding_thresholds_by_model"`
+}
+
+// EmbeddingModelThresholds is a per-model override of the book cosine-similarity
+// high/low thresholds. Used as the value type of
+// DedupConfig.EmbeddingThresholdsByModel.
+type EmbeddingModelThresholds struct {
+	// High is the cosine-similarity floor for the "high confidence" band.
+	High float64 `json:"high" mapstructure:"high"`
+	// Low is the cosine-similarity floor for the "low confidence" band.
+	Low float64 `json:"low" mapstructure:"low"`
+}
+
+// ThresholdsForModel resolves the book high/low cosine thresholds for the given
+// embedding model name. If the model has a calibrated entry in
+// EmbeddingThresholdsByModel, that entry is returned; otherwise the flat
+// BookHighThreshold/BookLowThreshold values are returned as the default
+// fallback. This guarantees zero behaviour change for any model not explicitly
+// calibrated (DEDUP-2/3).
+func (c DedupConfig) ThresholdsForModel(model string) (high, low float64) {
+	if t, ok := c.EmbeddingThresholdsByModel[model]; ok {
+		return t.High, t.Low
+	}
+	return c.BookHighThreshold, c.BookLowThreshold
 }
 
 // ITunesConfig holds all settings for the iTunes sync and write-back subsystem.
@@ -346,8 +380,8 @@ type Config struct {
 	// admin credentials and must always expire, so a non-positive value falls
 	// back to the default of 30. (SEC-1/PROC-6)
 	BootstrapKeyTTLDays int `json:"bootstrap_key_ttl_days"`
-	MemoryLimitPercent        int `json:"memory_limit_percent"` // % of system memory
-	MemoryLimitMB             int `json:"memory_limit_mb"`      // absolute MB
+	MemoryLimitPercent  int `json:"memory_limit_percent"` // % of system memory
+	MemoryLimitMB       int `json:"memory_limit_mb"`      // absolute MB
 
 	// Lifecycle / retention
 	PurgeSoftDeletedAfterDays   int  `json:"purge_soft_deleted_after_days"`
@@ -571,29 +605,29 @@ func InitConfig() {
 	viper.SetDefault("scheduled.reconcile.interval", 0)
 	viper.SetDefault("scheduled.reconcile.on_startup", false)
 	// BindEnv maps env vars so SCHEDULED_* overrides work even without AutomaticEnv.
-	viper.BindEnv("scheduled.dedup_refresh.enabled", "SCHEDULED_DEDUP_REFRESH_ENABLED")                               //nolint:errcheck
-	viper.BindEnv("scheduled.dedup_refresh.interval", "SCHEDULED_DEDUP_REFRESH_INTERVAL")                             //nolint:errcheck
-	viper.BindEnv("scheduled.dedup_refresh.on_startup", "SCHEDULED_DEDUP_REFRESH_ON_STARTUP")                         //nolint:errcheck
-	viper.BindEnv("scheduled.author_split.enabled", "SCHEDULED_AUTHOR_SPLIT_ENABLED")                                 //nolint:errcheck
-	viper.BindEnv("scheduled.author_split.interval", "SCHEDULED_AUTHOR_SPLIT_INTERVAL")                               //nolint:errcheck
-	viper.BindEnv("scheduled.author_split.on_startup", "SCHEDULED_AUTHOR_SPLIT_ON_STARTUP")                           //nolint:errcheck
-	viper.BindEnv("scheduled.db_optimize.enabled", "SCHEDULED_DB_OPTIMIZE_ENABLED")                                   //nolint:errcheck
-	viper.BindEnv("scheduled.db_optimize.interval", "SCHEDULED_DB_OPTIMIZE_INTERVAL")                                 //nolint:errcheck
-	viper.BindEnv("scheduled.db_optimize.on_startup", "SCHEDULED_DB_OPTIMIZE_ON_STARTUP")                             //nolint:errcheck
-	viper.BindEnv("scheduled.metadata_refresh.enabled", "SCHEDULED_METADATA_REFRESH_ENABLED")                         //nolint:errcheck
-	viper.BindEnv("scheduled.metadata_refresh.interval", "SCHEDULED_METADATA_REFRESH_INTERVAL")                       //nolint:errcheck
-	viper.BindEnv("scheduled.metadata_refresh.on_startup", "SCHEDULED_METADATA_REFRESH_ON_STARTUP")                   //nolint:errcheck
-	viper.BindEnv("scheduled.resolve_production_authors.enabled", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_ENABLED")     //nolint:errcheck
-	viper.BindEnv("scheduled.resolve_production_authors.interval", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_INTERVAL")   //nolint:errcheck
-	viper.BindEnv("scheduled.series_prune.enabled", "SCHEDULED_SERIES_PRUNE_ENABLED")                                 //nolint:errcheck
-	viper.BindEnv("scheduled.series_prune.interval", "SCHEDULED_SERIES_PRUNE_INTERVAL")                               //nolint:errcheck
-	viper.BindEnv("scheduled.series_prune.on_startup", "SCHEDULED_SERIES_PRUNE_ON_STARTUP")                           //nolint:errcheck
-	viper.BindEnv("scheduled.ai_dedup_batch.enabled", "SCHEDULED_AI_DEDUP_BATCH_ENABLED")                             //nolint:errcheck
-	viper.BindEnv("scheduled.ai_dedup_batch.interval", "SCHEDULED_AI_DEDUP_BATCH_INTERVAL")                           //nolint:errcheck
-	viper.BindEnv("scheduled.ai_dedup_batch.on_startup", "SCHEDULED_AI_DEDUP_BATCH_ON_STARTUP")                       //nolint:errcheck
-	viper.BindEnv("scheduled.reconcile.enabled", "SCHEDULED_RECONCILE_ENABLED")                                       //nolint:errcheck
-	viper.BindEnv("scheduled.reconcile.interval", "SCHEDULED_RECONCILE_INTERVAL")                                     //nolint:errcheck
-	viper.BindEnv("scheduled.reconcile.on_startup", "SCHEDULED_RECONCILE_ON_STARTUP")                                 //nolint:errcheck
+	viper.BindEnv("scheduled.dedup_refresh.enabled", "SCHEDULED_DEDUP_REFRESH_ENABLED")                             //nolint:errcheck
+	viper.BindEnv("scheduled.dedup_refresh.interval", "SCHEDULED_DEDUP_REFRESH_INTERVAL")                           //nolint:errcheck
+	viper.BindEnv("scheduled.dedup_refresh.on_startup", "SCHEDULED_DEDUP_REFRESH_ON_STARTUP")                       //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.enabled", "SCHEDULED_AUTHOR_SPLIT_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.interval", "SCHEDULED_AUTHOR_SPLIT_INTERVAL")                             //nolint:errcheck
+	viper.BindEnv("scheduled.author_split.on_startup", "SCHEDULED_AUTHOR_SPLIT_ON_STARTUP")                         //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.enabled", "SCHEDULED_DB_OPTIMIZE_ENABLED")                                 //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.interval", "SCHEDULED_DB_OPTIMIZE_INTERVAL")                               //nolint:errcheck
+	viper.BindEnv("scheduled.db_optimize.on_startup", "SCHEDULED_DB_OPTIMIZE_ON_STARTUP")                           //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.enabled", "SCHEDULED_METADATA_REFRESH_ENABLED")                       //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.interval", "SCHEDULED_METADATA_REFRESH_INTERVAL")                     //nolint:errcheck
+	viper.BindEnv("scheduled.metadata_refresh.on_startup", "SCHEDULED_METADATA_REFRESH_ON_STARTUP")                 //nolint:errcheck
+	viper.BindEnv("scheduled.resolve_production_authors.enabled", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_ENABLED")   //nolint:errcheck
+	viper.BindEnv("scheduled.resolve_production_authors.interval", "SCHEDULED_RESOLVE_PRODUCTION_AUTHORS_INTERVAL") //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.enabled", "SCHEDULED_SERIES_PRUNE_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.interval", "SCHEDULED_SERIES_PRUNE_INTERVAL")                             //nolint:errcheck
+	viper.BindEnv("scheduled.series_prune.on_startup", "SCHEDULED_SERIES_PRUNE_ON_STARTUP")                         //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.enabled", "SCHEDULED_AI_DEDUP_BATCH_ENABLED")                           //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.interval", "SCHEDULED_AI_DEDUP_BATCH_INTERVAL")                         //nolint:errcheck
+	viper.BindEnv("scheduled.ai_dedup_batch.on_startup", "SCHEDULED_AI_DEDUP_BATCH_ON_STARTUP")                     //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.enabled", "SCHEDULED_RECONCILE_ENABLED")                                     //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.interval", "SCHEDULED_RECONCILE_INTERVAL")                                   //nolint:errcheck
+	viper.BindEnv("scheduled.reconcile.on_startup", "SCHEDULED_RECONCILE_ON_STARTUP")                               //nolint:errcheck
 
 	// iTunes sync defaults (nested under "itunes.*").
 	// BindEnv maps env vars so ITUNES_SYNC_ENABLED etc. override even without AutomaticEnv.
@@ -606,10 +640,10 @@ func InitConfig() {
 	viper.SetDefault("itunes.path_trim_enabled", false)
 	viper.SetDefault("itunes.windows_root_path", "")
 	viper.SetDefault("itunes.media_root", "")
-	viper.BindEnv("itunes.sync_enabled", "ITUNES_SYNC_ENABLED")           //nolint:errcheck
-	viper.BindEnv("itunes.sync_interval", "ITUNES_SYNC_INTERVAL")         //nolint:errcheck
+	viper.BindEnv("itunes.sync_enabled", "ITUNES_SYNC_ENABLED")             //nolint:errcheck
+	viper.BindEnv("itunes.sync_interval", "ITUNES_SYNC_INTERVAL")           //nolint:errcheck
 	viper.BindEnv("itunes.write_back_enabled", "ITUNES_WRITE_BACK_ENABLED") //nolint:errcheck
-	viper.BindEnv("itunes.auto_write_back", "ITUNES_AUTO_WRITE_BACK")     //nolint:errcheck
+	viper.BindEnv("itunes.auto_write_back", "ITUNES_AUTO_WRITE_BACK")       //nolint:errcheck
 
 	// Auto-update defaults
 	viper.SetDefault("auto_update.enabled", false)
@@ -617,11 +651,11 @@ func InitConfig() {
 	viper.SetDefault("auto_update.check_minutes", 60)
 	viper.SetDefault("auto_update.window_start", 2)
 	viper.SetDefault("auto_update.window_end", 5)
-	viper.BindEnv("auto_update.enabled", "AUTO_UPDATE_ENABLED")           //nolint:errcheck
-	viper.BindEnv("auto_update.channel", "AUTO_UPDATE_CHANNEL")           //nolint:errcheck
+	viper.BindEnv("auto_update.enabled", "AUTO_UPDATE_ENABLED")             //nolint:errcheck
+	viper.BindEnv("auto_update.channel", "AUTO_UPDATE_CHANNEL")             //nolint:errcheck
 	viper.BindEnv("auto_update.check_minutes", "AUTO_UPDATE_CHECK_MINUTES") //nolint:errcheck
-	viper.BindEnv("auto_update.window_start", "AUTO_UPDATE_WINDOW_START") //nolint:errcheck
-	viper.BindEnv("auto_update.window_end", "AUTO_UPDATE_WINDOW_END")     //nolint:errcheck
+	viper.BindEnv("auto_update.window_start", "AUTO_UPDATE_WINDOW_START")   //nolint:errcheck
+	viper.BindEnv("auto_update.window_end", "AUTO_UPDATE_WINDOW_END")       //nolint:errcheck
 
 	// Maintenance window defaults
 	viper.SetDefault("maintenance.enabled", true)
@@ -647,11 +681,11 @@ func InitConfig() {
 	viper.SetDefault("maintenance.acoustid_online_lookup", false)
 	viper.SetDefault("maintenance.acoustid_nightly_limit", 5000)
 	// BindEnv maps env vars so MAINTENANCE_ENABLED etc. override even without AutomaticEnv.
-	viper.BindEnv("maintenance.enabled", "MAINTENANCE_ENABLED")                                //nolint:errcheck
-	viper.BindEnv("maintenance.window_start", "MAINTENANCE_WINDOW_START")                      //nolint:errcheck
-	viper.BindEnv("maintenance.window_end", "MAINTENANCE_WINDOW_END")                          //nolint:errcheck
-	viper.BindEnv("maintenance.acoustid_online_lookup", "MAINTENANCE_ACOUSTID_ONLINE_LOOKUP")  //nolint:errcheck
-	viper.BindEnv("maintenance.acoustid_nightly_limit", "MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT")  //nolint:errcheck
+	viper.BindEnv("maintenance.enabled", "MAINTENANCE_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("maintenance.window_start", "MAINTENANCE_WINDOW_START")                     //nolint:errcheck
+	viper.BindEnv("maintenance.window_end", "MAINTENANCE_WINDOW_END")                         //nolint:errcheck
+	viper.BindEnv("maintenance.acoustid_online_lookup", "MAINTENANCE_ACOUSTID_ONLINE_LOOKUP") //nolint:errcheck
+	viper.BindEnv("maintenance.acoustid_nightly_limit", "MAINTENANCE_ACOUSTID_NIGHTLY_LIMIT") //nolint:errcheck
 
 	// Download client defaults
 	viper.SetDefault("download_client.torrent.type", "")
@@ -698,9 +732,9 @@ func InitConfig() {
 	viper.SetDefault("dedup.author_high_threshold", 0.92)
 	viper.SetDefault("dedup.author_low_threshold", 0.80)
 	viper.SetDefault("dedup.auto_merge_enabled", true)
-	viper.SetDefault("dedup.embeddings_enabled", true)                 // opt-out: set false on no-internet boxes
-	viper.SetDefault("dedup.llm_auto_merge_high_confidence", false)   // opt-in
-	viper.SetDefault("dedup.on_import_via_scheduler", false)          // opt-in — keep eager path until M4 confirmed
+	viper.SetDefault("dedup.embeddings_enabled", true)              // opt-out: set false on no-internet boxes
+	viper.SetDefault("dedup.llm_auto_merge_high_confidence", false) // opt-in
+	viper.SetDefault("dedup.on_import_via_scheduler", false)        // opt-in — keep eager path until M4 confirmed
 
 	// Metadata candidate scoring defaults (nested under "metadata_scoring.*").
 	// BindEnv maps env vars so METADATA_SCORING_* overrides even without AutomaticEnv.
@@ -711,13 +745,13 @@ func InitConfig() {
 	viper.SetDefault("metadata_scoring.llm_rerank_epsilon", 0.05)
 	viper.SetDefault("metadata_scoring.llm_rerank_top_k", 5)
 	viper.SetDefault("metadata_scoring.write_backup_before", true)
-	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")     //nolint:errcheck
-	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE") //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")       //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE")   //nolint:errcheck
 	viper.BindEnv("metadata_scoring.embedding_best_match", "METADATA_SCORING_EMBEDDING_BEST_MATCH") //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_enabled", "METADATA_SCORING_LLM_ENABLED")                //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")  //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")      //nolint:errcheck
-	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE") //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_enabled", "METADATA_SCORING_LLM_ENABLED")                   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")     //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")         //nolint:errcheck
+	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE")   //nolint:errcheck
 
 	// Unified dedup scoring defaults (SPEC 1 §3–4, T011).
 	// These are consumed by internal/dedup/unified.LoadScoreConfig via Viper.
@@ -901,9 +935,9 @@ func InitConfig() {
 			},
 
 			// Path formatting & apply pipeline
-			PathFormat:           viper.GetString("path_format"),
-			SegmentTitleFormat:   viper.GetString("segment_title_format"),
-			AutoRenameOnApply:    viper.GetBool("auto_rename_on_apply"),
+			PathFormat:              viper.GetString("path_format"),
+			SegmentTitleFormat:      viper.GetString("segment_title_format"),
+			AutoRenameOnApply:       viper.GetBool("auto_rename_on_apply"),
 			AutoWriteTagsOnApply:    viper.GetBool("auto_write_tags_on_apply"),
 			VerifyAfterWrite:        viper.GetBool("verify_after_write"),
 			WriteStartupReadOnlyKey: viper.GetBool("write_startup_readonly_key"),
@@ -994,7 +1028,6 @@ func InitConfig() {
 			},
 		}
 
-
 		// Managed external-tool lifecycle
 		c.Tools = tools.ToolsConfig{
 			ManagedDir:          "/var/lib/audiobook-organizer/tools",
@@ -1003,7 +1036,6 @@ func InitConfig() {
 			AllowPeriodicOllama: false,
 			OllamaDebounceMin:   10,
 		}
-
 
 		// Default Open Library dump dir to {RootDir}/openlibrary-dumps if not set
 		if c.OpenLibraryDumpDir == "" && c.RootDir != "" {
@@ -1342,7 +1374,7 @@ func ResetToDefaults() {
 				AuthorHighThreshold:        0.92,
 				AuthorLowThreshold:         0.80,
 				AutoMergeEnabled:           true,
-				EmbeddingsEnabled:          true,  // opt-out: set false on no-internet boxes
+				EmbeddingsEnabled:          true, // opt-out: set false on no-internet boxes
 				LLMAutoMergeHighConfidence: false,
 				OnImportViaScheduler:       false, // opt-in
 				ReviewModel:                "gpt-5-mini",
@@ -1381,20 +1413,20 @@ func ResetToDefaults() {
 
 			// Maintenance window
 			Maintenance: MaintenanceConfig{
-				Enabled:          true,
-				WindowStart:      1,
-				WindowEnd:        4,
-				DedupRefresh:     true,
-				SeriesPrune:      true,
-				AuthorSplit:      true,
-				TombstoneCleanup: true,
-				Reconcile:        true,
-				PurgeDeleted:     true,
-				PurgeOldLogs:     true,
-				DbOptimize:       true,
-				LibraryScan:      false,
-				LibraryOrganize:  false,
-				MetadataRefresh:  false,
+				Enabled:            true,
+				WindowStart:        1,
+				WindowEnd:          4,
+				DedupRefresh:       true,
+				SeriesPrune:        true,
+				AuthorSplit:        true,
+				TombstoneCleanup:   true,
+				Reconcile:          true,
+				PurgeDeleted:       true,
+				PurgeOldLogs:       true,
+				DbOptimize:         true,
+				LibraryScan:        false,
+				LibraryOrganize:    false,
+				MetadataRefresh:    false,
 				LibrarySizeRefresh: true,
 				// AcoustID online lookup is OFF by default — uses third-party
 				// quota and only helps users who set ACOUSTID_API_KEY. Opt-in
@@ -1439,8 +1471,8 @@ func ResetToDefaults() {
 			},
 
 			// Path formatting & apply pipeline
-			PathFormat:           "{author}/{series_prefix}{title}/{track_title}.{ext}",
-			SegmentTitleFormat:   "{title} - {track}/{total_tracks}",
+			PathFormat:              "{author}/{series_prefix}{title}/{track_title}.{ext}",
+			SegmentTitleFormat:      "{title} - {track}/{total_tracks}",
 			AutoRenameOnApply:       true,
 			AutoWriteTagsOnApply:    true,
 			VerifyAfterWrite:        true,

--- a/internal/config/dedup_thresholds_test.go
+++ b/internal/config/dedup_thresholds_test.go
@@ -1,0 +1,49 @@
+// file: internal/config/dedup_thresholds_test.go
+// version: 1.0.0
+// guid: 4e2b7c91-8d3a-4f60-9b21-6c5e0a1f7d84
+// last-edited: 2026-07-03
+
+package config
+
+import "testing"
+
+// TestThresholdsForModel_FallsBackToFlat verifies that a model with no entry in
+// EmbeddingThresholdsByModel resolves to the flat BookHighThreshold/
+// BookLowThreshold values (byte-for-byte unchanged default behaviour).
+func TestThresholdsForModel_FallsBackToFlat(t *testing.T) {
+	c := DedupConfig{
+		BookHighThreshold: 0.95,
+		BookLowThreshold:  0.85,
+	}
+
+	high, low := c.ThresholdsForModel("text-embedding-3-large")
+	if high != 0.95 || low != 0.85 {
+		t.Fatalf("absent model: got high=%v low=%v, want 0.95/0.85", high, low)
+	}
+
+	// Nil map is also a valid absent case.
+	c.EmbeddingThresholdsByModel = map[string]EmbeddingModelThresholds{
+		"bge-m3": {High: 0.90, Low: 0.78},
+	}
+	high, low = c.ThresholdsForModel("some-other-model")
+	if high != 0.95 || low != 0.85 {
+		t.Fatalf("unlisted model: got high=%v low=%v, want flat 0.95/0.85", high, low)
+	}
+}
+
+// TestThresholdsForModel_UsesPerModelEntry verifies that a model present in the
+// map resolves to its calibrated override, not the flat fallback.
+func TestThresholdsForModel_UsesPerModelEntry(t *testing.T) {
+	c := DedupConfig{
+		BookHighThreshold: 0.95,
+		BookLowThreshold:  0.85,
+		EmbeddingThresholdsByModel: map[string]EmbeddingModelThresholds{
+			"bge-m3": {High: 0.90, Low: 0.78},
+		},
+	}
+
+	high, low := c.ThresholdsForModel("bge-m3")
+	if high != 0.90 || low != 0.78 {
+		t.Fatalf("present model: got high=%v low=%v, want 0.90/0.78", high, low)
+	}
+}

--- a/internal/dedup/collectors_composite_test.go
+++ b/internal/dedup/collectors_composite_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_composite_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: c3d4e5f6-a7b8-4c9d-8e0f-1a2b3c4d5e6f
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 package dedup
 
@@ -49,7 +49,8 @@ func (s *stubEmbedStore) FindSimilar(entityType string, vector []float32, minSim
 
 // TestCompositeScore_EmbeddingPlusDuration verifies the acceptance criterion:
 // "A pair matched by embedding+duration produces a composed score with
-//  2-signal breakdown."
+//
+//	2-signal breakdown."
 //
 // The test constructs signals directly (skipping collector I/O) and feeds them
 // to ComposeScore, then checks the resulting UnifiedDedupScore fields.
@@ -60,7 +61,7 @@ func TestCompositeScore_EmbeddingPlusDuration(t *testing.T) {
 		{
 			Kind:       unified.SigEmbedHigh,
 			Raw:        float64(cosine),
-			Confidence: embedHighConfidence(cosine), // should be ~0.894
+			Confidence: embedHighConfidence(cosine, 0.95), // should be ~0.894
 			Evidence:   "embedding cosine 0.9700 (high tier): book A ↔ book B",
 		},
 		{
@@ -106,7 +107,7 @@ func TestCompositeScore_EmbeddingMediumPlusMetaFuzzy(t *testing.T) {
 		{
 			Kind:       unified.SigEmbedMedium,
 			Raw:        0.90,
-			Confidence: embedMediumConfidence(0.90), // 0.65 + (0.90-0.85)/(0.95-0.85)*0.15 = 0.65+0.075 = 0.725
+			Confidence: embedMediumConfidence(0.90, 0.85, 0.95), // 0.65 + (0.90-0.85)/(0.95-0.85)*0.15 = 0.65+0.075 = 0.725
 			Evidence:   "embedding cosine 0.9000 (medium tier): book A ↔ book B",
 		},
 		{
@@ -331,8 +332,8 @@ func TestNormalizedLevenshteinSimilarity(t *testing.T) {
 // TestBestLayerFromSignals verifies the layer priority ordering.
 func TestBestLayerFromSignals(t *testing.T) {
 	tests := []struct {
-		name     string
-		signals  []unified.Signal
+		name      string
+		signals   []unified.Signal
 		wantLayer string
 	}{
 		{

--- a/internal/dedup/collectors_embedding.go
+++ b/internal/dedup/collectors_embedding.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_embedding.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d0e1f2a3-b4c5-4d6e-9f0a-1b2c3d4e5f6a
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 // Package dedup — embedding collector (fable5 T014).
 //
@@ -74,46 +74,55 @@ func DefaultEmbeddingCollectorConfig() EmbeddingCollectorConfig {
 	}
 }
 
-// embedHighConfidence maps a cosine similarity in [0.95, 1.00] to a confidence
+// embedHighConfidence maps a cosine similarity in [high, 1.00] to a confidence
 // in [0.88, 0.95] using linear interpolation.
 //
-// WHY: a cosine of 0.95 is a near-certainty for text embeddings in this domain;
-// the confidence floor of 0.88 reflects that embeddings can be tricked by
-// stylistic similarity (same author, different series).  The ceiling of 0.95
-// is below 1.0 to keep the noisy-OR product separable from exact-file (1.00).
-func embedHighConfidence(cos float32) float64 {
+// DEDUP-2/3: the lower cut-point (`high`) is now a parameter derived from the
+// active per-model threshold, not a hard-coded 0.95 literal — a model whose
+// true-duplicate cosines cluster lower (e.g. bge-m3) reshapes the ramp so the
+// confidence interpolation stays consistent with the similarity comparison. The
+// confidence endpoints (0.88..0.95) are intentionally NOT parameterized: they
+// express how much trust a high-tier embedding match earns, independent of
+// which model produced the cosine.
+//
+// WHY the 0.88 floor: embeddings can be tricked by stylistic similarity (same
+// author, different series). The 0.95 ceiling stays below 1.0 to keep the
+// noisy-OR product separable from exact-file (1.00).
+func embedHighConfidence(cos float32, high float64) float64 {
 	const (
-		cosMin  = 0.95
 		cosMax  = 1.00
 		confMin = 0.88
 		confMax = 0.95
 	)
-	if cos <= cosMin {
+	cosMin := high
+	if float64(cos) <= cosMin {
 		return confMin
 	}
-	if cos >= cosMax {
+	if float64(cos) >= cosMax {
 		return confMax
 	}
-	frac := float64(cos-cosMin) / float64(cosMax-cosMin)
+	frac := (float64(cos) - cosMin) / (cosMax - cosMin)
 	return confMin + frac*(confMax-confMin)
 }
 
-// embedMediumConfidence maps a cosine similarity in [0.85, 0.95) to a
-// confidence in [0.65, 0.80].
-func embedMediumConfidence(cos float32) float64 {
+// embedMediumConfidence maps a cosine similarity in [low, high) to a confidence
+// in [0.65, 0.80]. Like embedHighConfidence, the band cut-points (`low`, `high`)
+// derive from the active per-model thresholds; the confidence endpoints
+// (0.65..0.80) are fixed (DEDUP-2/3).
+func embedMediumConfidence(cos float32, low, high float64) float64 {
 	const (
-		cosMin  = 0.85
-		cosMax  = 0.95
 		confMin = 0.65
 		confMax = 0.80
 	)
-	if cos <= cosMin {
+	cosMin := low
+	cosMax := high
+	if float64(cos) <= cosMin {
 		return confMin
 	}
-	if cos >= cosMax {
+	if float64(cos) >= cosMax {
 		return confMax
 	}
-	frac := float64(cos-cosMin) / float64(cosMax-cosMin)
+	frac := (float64(cos) - cosMin) / (cosMax - cosMin)
 	return confMin + frac*(confMax-confMin)
 }
 
@@ -186,7 +195,7 @@ func CollectEmbedding(
 			sig = unified.Signal{
 				Kind:       unified.SigEmbedHigh,
 				Raw:        float64(r.Similarity),
-				Confidence: embedHighConfidence(r.Similarity),
+				Confidence: embedHighConfidence(r.Similarity, cfg.HighThreshold),
 				Evidence: fmt.Sprintf(
 					"embedding cosine %.4f (high tier): book %s ↔ %s",
 					r.Similarity, bookID, r.EntityID,
@@ -196,7 +205,7 @@ func CollectEmbedding(
 			sig = unified.Signal{
 				Kind:       unified.SigEmbedMedium,
 				Raw:        float64(r.Similarity),
-				Confidence: embedMediumConfidence(r.Similarity),
+				Confidence: embedMediumConfidence(r.Similarity, cfg.LowThreshold, cfg.HighThreshold),
 				Evidence: fmt.Sprintf(
 					"embedding cosine %.4f (medium tier): book %s ↔ %s",
 					r.Similarity, bookID, r.EntityID,

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.43.0
+// version: 1.44.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-03
 
@@ -504,8 +504,12 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 
 	cfg := de.getScoreConfig()
 	embCfg := DefaultEmbeddingCollectorConfig()
-	embCfg.HighThreshold = de.BookHighThreshold
-	embCfg.LowThreshold = de.BookLowThreshold
+	// DEDUP-2/3: resolve the active embedding model's per-model thresholds
+	// (falls back to the engine's BookHighThreshold/BookLowThreshold fields for
+	// any model without a calibrated override — byte-for-byte unchanged).
+	embHigh, embLow := de.resolvedBookThresholds()
+	embCfg.HighThreshold = embHigh
+	embCfg.LowThreshold = embLow
 	durCfg := DefaultDurationCollectorConfig()
 	fuzCfg := DefaultMetaFuzzyConfig()
 	lshCfg := DefaultLSHAcoustIDConfig()
@@ -612,7 +616,7 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 				signals = append(signals, unified.Signal{
 					Kind:       unified.SigEmbedHigh,
 					Raw:        cos,
-					Confidence: embedHighConfidence(cos32),
+					Confidence: embedHighConfidence(cos32, embCfg.HighThreshold),
 					Evidence: fmt.Sprintf(
 						"embedding cosine %.4f (high tier): book %s ↔ %s",
 						cos32, book.ID, candID),
@@ -621,7 +625,7 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 				signals = append(signals, unified.Signal{
 					Kind:       unified.SigEmbedMedium,
 					Raw:        cos,
-					Confidence: embedMediumConfidence(cos32),
+					Confidence: embedMediumConfidence(cos32, embCfg.LowThreshold, embCfg.HighThreshold),
 					Evidence: fmt.Sprintf(
 						"embedding cosine %.4f (medium tier): book %s ↔ %s",
 						cos32, book.ID, candID),
@@ -1795,6 +1799,11 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 		querySeriesNum = seriesNumberOf(queryBook)
 	}
 
+	// DEDUP-2/3: resolve the active embedding model's low threshold (the
+	// candidate-emission floor). Falls back to de.BookLowThreshold for any model
+	// without a per-model override — byte-for-byte unchanged.
+	_, bookLow := de.resolvedBookThresholds()
+
 	var results []database.SimilarityResult
 	if de.chromemStore != nil {
 		filter := map[string]string{"is_primary_version": "true"}
@@ -1803,7 +1812,7 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 			return cErr
 		}
 		for _, cr := range chromemResults {
-			if cr.Similarity >= float32(de.BookLowThreshold) {
+			if cr.Similarity >= float32(bookLow) {
 				results = append(results, database.SimilarityResult{
 					EntityID:   cr.EntityID,
 					Similarity: cr.Similarity,
@@ -1817,7 +1826,7 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 	// SQLite full-scan + cosine is ~50-200ms per query for 42K books vs
 	// chromem's <10ms; dedup queries are rare so the tradeoff is fine.
 	if len(results) == 0 && de.embedStore != nil {
-		fallback, fErr := de.embedStore.FindSimilar("book", emb.Vector, float32(de.BookLowThreshold), 20)
+		fallback, fErr := de.embedStore.FindSimilar("book", emb.Vector, float32(bookLow), 20)
 		if fErr != nil {
 			return fErr
 		}
@@ -2034,6 +2043,28 @@ func (de *Engine) EmbeddingModel() string {
 		return ""
 	}
 	return de.embedClient.Model()
+}
+
+// resolvedBookThresholds returns the active book high/low cosine thresholds for
+// the wired embedding client's model (DEDUP-2/3).
+//
+// It diverges from the engine's BookHighThreshold/BookLowThreshold fields ONLY
+// when the active model has an explicit calibrated entry in
+// config.AppConfig.Dedup.EmbeddingThresholdsByModel. For any model without such
+// an entry — including the legacy OpenAI model and every not-yet-calibrated
+// model — and when no embedding client is wired (the test-injection path), it
+// returns the engine's field values unchanged, guaranteeing byte-for-byte
+// behaviour and preserving the direct-field-set test seam.
+func (de *Engine) resolvedBookThresholds() (high, low float64) {
+	high, low = de.BookHighThreshold, de.BookLowThreshold
+	if de.embedClient == nil {
+		return high, low
+	}
+	model := de.embedClient.Model()
+	if _, ok := config.AppConfig.Dedup.EmbeddingThresholdsByModel[model]; ok {
+		return config.AppConfig.Dedup.ThresholdsForModel(model)
+	}
+	return high, low
 }
 
 // prepBookEmbed runs the per-book skip-checks and builds the embedding text +

--- a/internal/plugins/dedup/calibrate_embedding_thresholds.go
+++ b/internal/plugins/dedup/calibrate_embedding_thresholds.go
@@ -1,0 +1,361 @@
+// file: internal/plugins/dedup/calibrate_embedding_thresholds.go
+// version: 1.0.0
+// guid: 6f1d2e3a-4b5c-4d6e-8f90-1a2b3c4d5e6f
+// last-edited: 2026-07-03
+
+// Package dedup — op dedup.calibrate-embedding-thresholds (DEDUP-2/3).
+//
+// # Why this op exists
+//
+// The Layer-2 (embedding) book high/low cosine thresholds (0.95/0.85) and the
+// confidence ramps were hand-calibrated for OpenAI text-embedding-3-large's
+// cosine distribution. The corpus is mid-cutover to a local Ollama bge-m3 model
+// (1024-dim) whose cosine distribution is different — the OpenAI-era thresholds
+// have never been validated against it. If bge-m3's true-duplicate cosines
+// cluster lower than 0.95, the high-confidence tier silently stops firing with
+// no error, just missing candidates (recall collapse).
+//
+// This op is a READ-ONLY calibration harness. It scores the existing labeled
+// gold dataset (true_dup / not_dup examples populated by dedup.dataset-backfill
+// and dedup.mine-gold-labels) using whatever embeddings are actually stored for
+// the target model, sweeps candidate cosine cut-points, and REPORTS the
+// thresholds that hit a target precision. It NEVER writes the recommendation
+// into config, never mutates candidates, and never triggers a re-embed or scan.
+//
+// # DEDUP-3 contamination guard
+//
+// database.CosineSimilarity returns 0 on a dimension mismatch, so mixing a
+// 3072-dim OpenAI vector with a 1024-dim bge-m3 vector would silently produce
+// cosine 0 and poison the sweep. The harness therefore compares only pairs
+// where BOTH stored embeddings carry the target model's `.Model` tag and have
+// equal vector length; any other pair is skipped and counted, never scored.
+//
+// # Deferred, owner-gated follow-up (NOT performed by this op)
+//
+// After the re-embed (dedup.reembed-embeddings) completes and an operator has
+// reviewed this report and updated dedup.embedding_thresholds_by_model (the
+// per-model override map added in DEDUP-2) accordingly, a dedup.full-scan must
+// be run to regenerate embedding-layer candidates under the new thresholds.
+// That step changes live matching behaviour on production data, so it is
+// owner-gated and explicitly out of scope for this op — this harness only
+// reports; it does not apply.
+//
+// Usage:
+//
+//	POST /api/v1/operations/v2  {"def_id":"dedup.calibrate-embedding-thresholds"}
+//	POST /api/v1/operations/v2  {"def_id":"dedup.calibrate-embedding-thresholds",
+//	                             "params":{"model":"bge-m3","target_precision":0.98}}
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// Sweep-grid bounds for the candidate cosine cut-points. The grid is inclusive
+// of both ends and stepped by sweepGridStep. These are the search space for the
+// recommendation, NOT the recommendation itself.
+const (
+	sweepGridLo   = 0.80
+	sweepGridHi   = 0.99
+	sweepGridStep = 0.01
+
+	// defaultTargetPrecisionHigh is the precision floor for the high band.
+	// A high-tier embedding match should be a near-certain duplicate.
+	defaultTargetPrecisionHigh = 0.98
+	// defaultTargetPrecisionLow is the precision floor for the low/medium band.
+	// The medium band feeds noisy-OR composition and LLM review rather than
+	// auto-merge, so it tolerates more false positives in exchange for recall.
+	// Rationale for a single looser default (0.90): the medium tier's whole job
+	// is to surface plausible-but-uncertain pairs for a downstream check, so a
+	// precision floor materially below the high band is intentional.
+	defaultTargetPrecisionLow = 0.90
+)
+
+// calibrateEmbeddingThresholdsParams are the JSON parameters accepted by the op.
+type calibrateEmbeddingThresholdsParams struct {
+	// Model is the embedding model whose stored vectors + thresholds are
+	// calibrated. Optional; defaults to the currently-configured embed client
+	// model (engine.EmbeddingModel()).
+	Model string `json:"model"`
+	// TargetPrecision is the precision floor for the HIGH band. Optional;
+	// defaults to 0.98.
+	TargetPrecision float64 `json:"target_precision"`
+	// TargetPrecisionLow is the precision floor for the LOW/medium band.
+	// Optional; defaults to 0.90.
+	TargetPrecisionLow float64 `json:"target_precision_low"`
+}
+
+// calibrateEmbeddingThresholdsDef returns the OperationDef for
+// dedup.calibrate-embedding-thresholds.
+func (p *Plugin) calibrateEmbeddingThresholdsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.calibrate-embedding-thresholds",
+		Plugin:      "dedup",
+		DisplayName: "Calibrate embedding thresholds (report only)",
+		Description: "Read-only DEDUP-2/3 harness: scores the labeled gold dataset with the " +
+			"stored embeddings for a target model, sweeps candidate cosine cut-points, and " +
+			"reports precision-targeted high/low threshold recommendations. Writes nothing — " +
+			"applying the recommendation and running full-scan is an owner-gated follow-up.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.calibrate-embedding-thresholds",
+		Cancellable:     true,
+		Timeout:         30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead},
+		Run:             p.runCalibrateEmbeddingThresholds,
+	}
+}
+
+// embeddingGetter is the narrow read-only accessor the calibration logic needs.
+// *database.EmbeddingStore satisfies it; tests supply a map-backed fake.
+type embeddingGetter interface {
+	Get(entityType, entityID string) (*database.Embedding, error)
+}
+
+// calibrationPair is a single labeled cosine used by the threshold sweep.
+type calibrationPair struct {
+	label  string // "true_dup" | "not_dup"
+	cosine float64
+}
+
+// collectCalibrationPairs turns labeled examples into scored (label, cosine)
+// pairs using only same-model, same-dimension embeddings for the target model.
+//
+// Skip rules (DEDUP-3 contamination guard) — a skipped pair is counted, never
+// scored:
+//   - either embedding missing (Get errors or returns nil) → skippedMissing
+//   - either embedding's .Model != target model, or the two vectors differ in
+//     length → skippedMismatch
+//
+// It is a pure function of its inputs (the getter is the only side channel), so
+// the sweep and skip behaviour are unit-testable with synthetic data.
+func collectCalibrationPairs(
+	examples []database.LabeledExample,
+	getter embeddingGetter,
+	model string,
+) (pairs []calibrationPair, skippedMissing, skippedMismatch int) {
+	for i := range examples {
+		ex := examples[i]
+		a, aErr := getter.Get("book", ex.EntityAID)
+		if aErr != nil || a == nil {
+			skippedMissing++
+			continue
+		}
+		b, bErr := getter.Get("book", ex.EntityBID)
+		if bErr != nil || b == nil {
+			skippedMissing++
+			continue
+		}
+		if a.Model != model || b.Model != model {
+			skippedMismatch++
+			continue
+		}
+		if len(a.Vector) != len(b.Vector) {
+			skippedMismatch++
+			continue
+		}
+		cos := float64(database.CosineSimilarity(a.Vector, b.Vector))
+		pairs = append(pairs, calibrationPair{label: ex.Label, cosine: cos})
+	}
+	return pairs, skippedMissing, skippedMismatch
+}
+
+// bandRecommendation is the sweep result for one band.
+type bandRecommendation struct {
+	// Met is true when at least one cut-point reached the target precision.
+	Met bool `json:"met"`
+	// Threshold is the recommended cosine cut-point (valid only when Met).
+	Threshold float64 `json:"threshold"`
+	// Precision is the precision achieved at Threshold (valid only when Met).
+	Precision float64 `json:"precision"`
+	// Recall is true_dup pairs at/above Threshold ÷ total true_dup pairs
+	// (valid only when Met) — reported so an operator can weigh the tradeoff.
+	Recall float64 `json:"recall"`
+}
+
+// sweepThreshold finds the LOWEST cut-point in [sweepGridLo, sweepGridHi]
+// (stepped by sweepGridStep) whose precision >= targetPrecision, maximising
+// recall subject to the precision floor. Precision at cut-point t is
+// (#true_dup with cos>=t) ÷ (#(true_dup+not_dup) with cos>=t); a cut-point with
+// no pairs at/above it is not eligible (precision undefined). If no cut-point
+// reaches the target, the returned recommendation has Met=false — the caller
+// must report that explicitly rather than fabricating a value.
+func sweepThreshold(pairs []calibrationPair, targetPrecision float64) bandRecommendation {
+	totalTrue := 0
+	for _, pr := range pairs {
+		if pr.label == "true_dup" {
+			totalTrue++
+		}
+	}
+
+	// Iterate cut-points ascending so the FIRST meeting the target is the
+	// lowest (max recall). Use integer stepping to avoid float accumulation.
+	span := sweepGridHi - sweepGridLo
+	steps := int(span/sweepGridStep + 0.5) //nolint:gocritic // runtime float→int, not a const conversion
+	for i := 0; i <= steps; i++ {
+		t := sweepGridLo + float64(i)*sweepGridStep
+		tp, fp := 0, 0
+		for _, pr := range pairs {
+			if pr.cosine < t {
+				continue
+			}
+			switch pr.label {
+			case "true_dup":
+				tp++
+			case "not_dup":
+				fp++
+			}
+		}
+		if tp+fp == 0 {
+			continue // no pairs at/above this cut-point — precision undefined
+		}
+		precision := float64(tp) / float64(tp+fp)
+		if precision >= targetPrecision {
+			recall := 0.0
+			if totalTrue > 0 {
+				recall = float64(tp) / float64(totalTrue)
+			}
+			return bandRecommendation{Met: true, Threshold: t, Precision: precision, Recall: recall}
+		}
+	}
+	return bandRecommendation{Met: false}
+}
+
+// runCalibrateEmbeddingThresholds implements the op. It is read-only: it reads
+// the labeled dataset and the embedding store and reports; it never writes.
+func (p *Plugin) runCalibrateEmbeddingThresholds(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+
+	// --- Parse params ---
+	var params calibrateEmbeddingThresholdsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	model := params.Model
+	if model == "" {
+		if p.engine == nil {
+			return fmt.Errorf("model param empty and dedup engine not available to resolve default")
+		}
+		model = p.engine.EmbeddingModel()
+	}
+	if model == "" {
+		return fmt.Errorf("could not resolve a target embedding model (no param, no wired embed client)")
+	}
+	targetHigh := params.TargetPrecision
+	if targetHigh <= 0 {
+		targetHigh = defaultTargetPrecisionHigh
+	}
+	targetLow := params.TargetPrecisionLow
+	if targetLow <= 0 {
+		targetLow = defaultTargetPrecisionLow
+	}
+
+	log := reporter.Logger()
+	log.Info("calibrate-embedding-thresholds start",
+		"model", model,
+		"target_precision_high", targetHigh,
+		"target_precision_low", targetLow)
+
+	// --- Load labeled dataset (both classes) ---
+	_ = reporter.UpdateProgress(0, 3, "Loading labeled examples…")
+	trueDup, err := p.embeddingStore.ListLabeledExamples(database.LabeledExampleFilter{Label: "true_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list true_dup examples: %w", err)
+	}
+	notDup, err := p.embeddingStore.ListLabeledExamples(database.LabeledExampleFilter{Label: "not_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list not_dup examples: %w", err)
+	}
+	if reporter.IsCanceled() {
+		return context.Canceled
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	examples := make([]database.LabeledExample, 0, len(trueDup)+len(notDup))
+	examples = append(examples, trueDup...)
+	examples = append(examples, notDup...)
+
+	// --- Score pairs (same-model, same-dim only) ---
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Scoring %d labeled pairs…", len(examples)))
+	pairs, skippedMissing, skippedMismatch := collectCalibrationPairs(examples, p.embeddingStore, model)
+
+	var sampleTrue, sampleNot int
+	for _, pr := range pairs {
+		switch pr.label {
+		case "true_dup":
+			sampleTrue++
+		case "not_dup":
+			sampleNot++
+		}
+	}
+
+	// --- Sweep both bands ---
+	_ = reporter.UpdateProgress(2, 3, "Sweeping candidate thresholds…")
+	high := sweepThreshold(pairs, targetHigh)
+	low := sweepThreshold(pairs, targetLow)
+
+	// --- Report (structured log fields — read-only, no result sink to write) ---
+	fields := []any{
+		"model", model,
+		"sample_true_dup", sampleTrue,
+		"sample_not_dup", sampleNot,
+		"skipped_dimension_mismatch", skippedMismatch,
+		"skipped_missing_embedding", skippedMissing,
+		"target_precision_high", targetHigh,
+		"target_precision_low", targetLow,
+	}
+	if high.Met {
+		fields = append(fields,
+			"recommended_high_threshold", high.Threshold,
+			"recommended_high_precision", high.Precision,
+			"recommended_high_recall", high.Recall)
+	} else {
+		fields = append(fields, "no_high_threshold_met_target", true)
+	}
+	if low.Met {
+		fields = append(fields,
+			"recommended_low_threshold", low.Threshold,
+			"recommended_low_precision", low.Precision,
+			"recommended_low_recall", low.Recall)
+	} else {
+		fields = append(fields, "no_low_threshold_met_target", true)
+	}
+	// no_threshold_met_target is set when NEITHER band reached its target, so a
+	// consumer scanning for a single flag still sees the total-miss case.
+	if !high.Met && !low.Met {
+		fields = append(fields, "no_threshold_met_target", true)
+	}
+	log.Info("calibrate-embedding-thresholds report", fields...)
+
+	summary := fmt.Sprintf(
+		"model=%s sample_true=%d sample_not=%d skipped_dim=%d skipped_missing=%d high=%s low=%s",
+		model, sampleTrue, sampleNot, skippedMismatch, skippedMissing,
+		describeBand(high), describeBand(low),
+	)
+	log.Info("calibrate-embedding-thresholds complete", "summary", summary)
+	_ = reporter.UpdateProgress(3, 3, "Calibration report complete — "+summary+
+		". Recommendation is report-only; applying thresholds + full-scan is owner-gated.")
+	return nil
+}
+
+// describeBand renders a band recommendation for the human-readable summary.
+func describeBand(b bandRecommendation) string {
+	if !b.Met {
+		return "target-not-met"
+	}
+	return fmt.Sprintf("thr=%.2f(p=%.3f,r=%.3f)", b.Threshold, b.Precision, b.Recall)
+}

--- a/internal/plugins/dedup/calibrate_embedding_thresholds_test.go
+++ b/internal/plugins/dedup/calibrate_embedding_thresholds_test.go
@@ -1,0 +1,123 @@
+// file: internal/plugins/dedup/calibrate_embedding_thresholds_test.go
+// version: 1.0.0
+// guid: 8a7b6c5d-4e3f-4a2b-9c1d-0e9f8a7b6c5d
+// last-edited: 2026-07-03
+
+package dedup
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeEmbGetter is a map-backed embeddingGetter for the calibration tests.
+// A missing key returns (nil, nil), which the collector treats as a missing
+// embedding (skippedMissing).
+type fakeEmbGetter struct {
+	m map[string]*database.Embedding
+}
+
+func (f fakeEmbGetter) Get(_ /*entityType*/, entityID string) (*database.Embedding, error) {
+	return f.m[entityID], nil
+}
+
+// TestSweepThreshold_RecommendsBetweenClusters verifies that when true_dup
+// cosines cluster high and not_dup cosines cluster low, the sweep recommends a
+// cut-point between the two clusters at the target precision.
+func TestSweepThreshold_RecommendsBetweenClusters(t *testing.T) {
+	pairs := []calibrationPair{
+		{label: "true_dup", cosine: 0.96},
+		{label: "true_dup", cosine: 0.97},
+		{label: "true_dup", cosine: 0.98},
+		{label: "not_dup", cosine: 0.80},
+		{label: "not_dup", cosine: 0.81},
+		{label: "not_dup", cosine: 0.82},
+	}
+
+	rec := sweepThreshold(pairs, 0.98)
+	if !rec.Met {
+		t.Fatalf("expected a threshold to meet target 0.98, got Met=false")
+	}
+	// Recommendation must separate the clusters: above the highest not_dup
+	// (0.82) and at/below the lowest true_dup (0.96).
+	if rec.Threshold <= 0.82 || rec.Threshold > 0.96 {
+		t.Fatalf("threshold %.4f not between clusters (0.82, 0.96]", rec.Threshold)
+	}
+	if rec.Precision < 0.98 {
+		t.Fatalf("precision %.4f below target 0.98", rec.Precision)
+	}
+	// Lowest qualifying cut-point maximises recall; here all 3 true_dup are
+	// captured with zero false positives → precision 1.0, recall 1.0.
+	if rec.Precision != 1.0 || rec.Recall != 1.0 {
+		t.Fatalf("expected precision=1.0 recall=1.0, got p=%.4f r=%.4f", rec.Precision, rec.Recall)
+	}
+}
+
+// TestSweepThreshold_NoThresholdMeetsTarget verifies that when the classes
+// overlap so no cut-point can reach the target precision, the sweep reports
+// Met=false rather than fabricating a recommendation.
+func TestSweepThreshold_NoThresholdMeetsTarget(t *testing.T) {
+	// not_dup pairs sit ABOVE the true_dup pairs, so every cut-point that
+	// captures a true_dup also captures a not_dup — precision can never reach
+	// 0.98.
+	pairs := []calibrationPair{
+		{label: "true_dup", cosine: 0.88},
+		{label: "true_dup", cosine: 0.89},
+		{label: "not_dup", cosine: 0.90},
+		{label: "not_dup", cosine: 0.91},
+		{label: "not_dup", cosine: 0.92},
+	}
+
+	rec := sweepThreshold(pairs, 0.98)
+	if rec.Met {
+		t.Fatalf("expected Met=false (no separating cut-point), got threshold=%.4f p=%.4f", rec.Threshold, rec.Precision)
+	}
+}
+
+// TestCollectCalibrationPairs_SkipsMismatchAndMissing verifies the DEDUP-3
+// contamination guard: cross-model, dimension-mismatched, and missing-embedding
+// pairs are skipped and counted, never scored — no panic, no precision
+// inflation.
+func TestCollectCalibrationPairs_SkipsMismatchAndMissing(t *testing.T) {
+	const model = "bge-m3"
+	vec3 := []float32{0.1, 0.2, 0.3}
+	vec3b := []float32{0.3, 0.2, 0.1}
+	vec2 := []float32{0.5, 0.5} // wrong dimension
+
+	getter := fakeEmbGetter{m: map[string]*database.Embedding{
+		// Valid same-model, same-dim pair → scored.
+		"good_a": {Model: model, Vector: vec3},
+		"good_b": {Model: model, Vector: vec3b},
+		// Wrong model on one side → skippedMismatch.
+		"wrongmodel_a": {Model: model, Vector: vec3},
+		"wrongmodel_b": {Model: "text-embedding-3-large", Vector: vec3b},
+		// Dimension mismatch (both tagged bge-m3 but different lengths) → skippedMismatch.
+		"dim_a": {Model: model, Vector: vec3},
+		"dim_b": {Model: model, Vector: vec2},
+		// "missing_b" intentionally absent → skippedMissing.
+		"missing_a": {Model: model, Vector: vec3},
+	}}
+
+	examples := []database.LabeledExample{
+		{EntityAID: "good_a", EntityBID: "good_b", Label: "true_dup"},
+		{EntityAID: "wrongmodel_a", EntityBID: "wrongmodel_b", Label: "true_dup"},
+		{EntityAID: "dim_a", EntityBID: "dim_b", Label: "not_dup"},
+		{EntityAID: "missing_a", EntityBID: "missing_b", Label: "true_dup"},
+	}
+
+	pairs, skippedMissing, skippedMismatch := collectCalibrationPairs(examples, getter, model)
+
+	if len(pairs) != 1 {
+		t.Fatalf("expected exactly 1 scored pair, got %d", len(pairs))
+	}
+	if pairs[0].label != "true_dup" {
+		t.Fatalf("scored pair label = %q, want true_dup", pairs[0].label)
+	}
+	if skippedMismatch != 2 {
+		t.Fatalf("skippedMismatch = %d, want 2 (wrong-model + wrong-dim)", skippedMismatch)
+	}
+	if skippedMissing != 1 {
+		t.Fatalf("skippedMissing = %d, want 1", skippedMissing)
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-07-03
 
@@ -20,7 +20,7 @@ type Plugin struct {
 	engine         *dedupengine.Engine
 	store          database.Store
 	embeddingStore *database.EmbeddingStore
-	registry       sdk.Registry                    // set in Register; used by ops that enqueue follow-on work
+	registry       sdk.Registry                        // set in Register; used by ops that enqueue follow-on work
 	toolRegistry   interface{ Available(string) bool } // optional; guards ops that require external binaries
 }
 
@@ -64,16 +64,17 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.splitBookScanDef(),
 		p.purgeStaleDef(),
 		p.lshIndexBuildDef(),
-		p.purgeLegacyFPDef(),     // T015: legacy fingerprint purge op
-		p.embReencodeDef(),       // T021: float16+zstd re-encode op
-		p.bookfileSegDropDef(),   // T020: drop AcoustID segment fields from stored values
-		p.datasetBackfillDef(),   // C4: label + suppress residual pending candidates
-		p.mineGoldLabelsDef(),    // gold miner: auto-label high-confidence true_dup positives
-		p.quarantineChapterArtifactsDef(), // drain chapter-file-as-book artifacts (candidate explosion)
-		p.drainStaleDef(), // DEDUP-1: drain CONS-16/17-era stale exact candidates (dry-run gated)
-		p.checkBookDef(),         // M4: per-book dedup check via dependency scheduler
-		p.buildISBNIndexDef(),    // T022: ISBN/ASIN secondary index backfill
-		p.reembedEmbeddingsDef(), // Part B: re-embed corpus when the embedding model changes
+		p.purgeLegacyFPDef(),                // T015: legacy fingerprint purge op
+		p.embReencodeDef(),                  // T021: float16+zstd re-encode op
+		p.bookfileSegDropDef(),              // T020: drop AcoustID segment fields from stored values
+		p.datasetBackfillDef(),              // C4: label + suppress residual pending candidates
+		p.calibrateEmbeddingThresholdsDef(), // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)
+		p.mineGoldLabelsDef(),               // gold miner: auto-label high-confidence true_dup positives
+		p.quarantineChapterArtifactsDef(),   // drain chapter-file-as-book artifacts (candidate explosion)
+		p.drainStaleDef(),                   // DEDUP-1: drain CONS-16/17-era stale exact candidates (dry-run gated)
+		p.checkBookDef(),                    // M4: per-book dedup check via dependency scheduler
+		p.buildISBNIndexDef(),               // T022: ISBN/ASIN secondary index backfill
+		p.reembedEmbeddingsDef(),            // Part B: re-embed corpus when the embedding model changes
 	}
 
 	for _, op := range ops {


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-15** (wave 3, Opus): dedup similarity thresholds were still calibrated for text-embedding-3-large while prod now embeds with bge-m3. Adds:

- `EmbeddingThresholdsByModel` config map + `ThresholdsForModel` resolver (falls back to flat thresholds for unlisted models — **default behavior byte-for-byte unchanged**)
- Engine routes all three threshold read sites through a nil-safe resolver keyed on the active embed client's model
- Confidence band cut-points parameterized in `collectors_embedding.go` (fixed endpoints preserved)
- New read-only op `dedup.calibrate-embedding-thresholds` (CapLibraryRead): sweeps 0.80–0.99 against the labeled gold dataset for target precision (0.98 high / 0.90 low), skips cross-model/dimension-mismatch pairs (DEDUP-3 guard), reports via structured logs. **Never writes config or candidates.**

**Owner-gated deferred step (not in this PR):** after re-embed completes, run the calibration op, review recommendations, set `dedup.embedding_thresholds_by_model`, then `dedup.full-scan`.

## Test plan

- [x] 5/5 new tests pass (resolver both branches; calibration clustered/skip/no-target cases)
- [x] Full `internal/dedup`, `internal/plugins/dedup`, `internal/config` suites green; vet + gofmt clean
- [ ] Local honest gate (queued)
- [ ] Minimal CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1