### PR TITLE
feat(ai): unified AI backend-mode toggle for LLM + embeddings (TASK-10)

### DIFF
--- a/docs/reference/config-api-shape.md
+++ b/docs/reference/config-api-shape.md
@@ -1,7 +1,7 @@
 <!-- file: docs/reference/config-api-shape.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 2b7f9c31-a4e8-4f1d-b8a2-6c5d9e3f2a17 -->
-<!-- last-edited: 2026-06-16 -->
+<!-- last-edited: 2026-07-03 -->
 
 # Config API Shape Reference
 
@@ -107,6 +107,7 @@ interface Config {
   embedding:       EmbeddingConfig;
   dedup:           DedupConfig;
   metadata_scoring: MetadataScoringConfig;
+  ai_backend:      AIBackendConfig;
   itunes:          ITunesConfig;
   maintenance:     MaintenanceConfig;
   scheduled:       ScheduledTasksConfig;
@@ -163,6 +164,60 @@ interface EmbeddingConfig {
 | `EMBEDDING_DIMENSIONS` | `embedding.dimensions` |
 | `EMBEDDING_BASE_URL` | `embedding.base_url` |
 | `VECTOR_INDEX_BACKEND` | `embedding.vector_backend` |
+
+---
+
+### AIBackendConfig — `config.ai_backend`
+
+Backend-mode toggle for the AI cluster. Selects, independently for embeddings and
+LLM/chat, whether the corresponding client runs against OpenAI, a local
+OpenAI-compatible backend (e.g. Ollama), or is disabled.
+
+```typescript
+interface AIBackendConfig {
+  embedding_mode: string;         // "" | "disabled" | "openai" | "local" | "openai-fallback-local"
+  llm_mode: string;               // same enum as embedding_mode
+  local_base_url: string;         // local OpenAI-compatible endpoint (default placeholder: "http://192.168.0.20:11434/v1")
+  local_embedding_model: string;  // model name for local embeddings (default: "bge-m3")
+  local_llm_model: string;        // model name for local LLM (default: "qwen2.5:7b-instruct")
+}
+```
+
+**Mode enum values:**
+| Value | Meaning |
+|---|---|
+| `""` (empty) | Mode is derived at load time from the legacy fields (see below). |
+| `disabled` | No client is constructed for that pipeline. |
+| `openai` | Real OpenAI cloud API (`openai_api_key` required). |
+| `local` | Local endpoint at `local_base_url`; the API key is ignored by the backend. |
+| `openai-fallback-local` | Primary OpenAI with a local fallback. At construction time it behaves like `openai`; the fallback *trigger* is wired in the retry/error-classification layer. |
+
+**Empty-mode derivation (legacy-field write-through).**
+The legacy flat fields `embedding.base_url`, `openai_api_key`, `enable_ai_parsing`,
+and `metadata_scoring.llm_enabled` remain readable on `GET` and are still accepted
+on `PUT` for one release. When a mode is empty, the effective mode is derived
+from them:
+
+- **embedding_mode**: `embedding.enabled == false` → `disabled`; else
+  `embedding.base_url != ""` → `local`; else `openai_api_key != ""` → `openai`;
+  else `disabled`.
+- **llm_mode**: `openai_api_key != "" && (enable_ai_parsing || metadata_scoring.llm_enabled)`
+  → `openai`; else `disabled`.
+
+On first load after upgrade, a one-time blob migration (`migrateAIBackendBlob`)
+writes the derived `ai_backend` object into the stored config. Setting a legacy
+field on `PUT` therefore updates the derived mode via the same rule on the next
+load (write-through). Note that `local_base_url` uses a placeholder host in
+committed defaults — real endpoints belong in local, gitignored config.
+
+**Environment variables:**
+| Env var | Config field |
+|---|---|
+| `AI_BACKEND_EMBEDDING_MODE` | `ai_backend.embedding_mode` |
+| `AI_BACKEND_LLM_MODE` | `ai_backend.llm_mode` |
+| `AI_BACKEND_LOCAL_BASE_URL` | `ai_backend.local_base_url` |
+| `AI_BACKEND_LOCAL_EMBEDDING_MODEL` | `ai_backend.local_embedding_model` |
+| `AI_BACKEND_LOCAL_LLM_MODEL` | `ai_backend.local_llm_model` |
 
 ---
 

--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-07-03
 
@@ -12,7 +12,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/openai/openai-go/v3"
@@ -24,6 +27,14 @@ import (
 // via SetOllamaAvailable(false). The caller should surface this to the user
 // as an actionable error rather than a silent failure.
 var ErrOllamaNotAvailable = errors.New("embedding: Ollama not available — install and enable via Settings → Tools")
+
+// ErrBatchUnsupported is returned by batch-only embedding paths (e.g. the OpenAI
+// Batch API used by EmbedBooksAsync) when the effective embedding backend is not
+// OpenAI. The OpenAI Batch API is a cloud-only feature; local backends (Ollama)
+// and disabled modes have no equivalent, so callers must fall back to the
+// synchronous per-book path instead of submitting a batch (TOGGLE-2). Lives in
+// internal/ai because the backend-mode concept belongs to the AI client layer.
+var ErrBatchUnsupported = errors.New("embedding: batch API unsupported for the configured backend (openai-only); use the synchronous path")
 
 // EmbeddingCache is the minimal surface EmbeddingClient needs from
 // a content-hash cache layer. It's an interface (not a concrete
@@ -74,12 +85,15 @@ type EmbeddingClient struct {
 	// path (where it does not).
 	baseURL string
 
-	// localOllamaOK is true when the Ollama daemon is available. It
-	// defaults to true so callers that never call SetOllamaAvailable
-	// continue to work unchanged. When false and baseURL is non-empty,
-	// EmbedBatch returns ErrOllamaNotAvailable without making any HTTP
-	// calls.
-	localOllamaOK bool
+	// localOllamaOK is true when the Ollama daemon is available. It is an
+	// atomic.Bool because it is written by the server's availability probe
+	// (SetOllamaAvailable) and by EmbedBatch's inline re-probe while being read
+	// concurrently by every EmbedBatch caller — a plain bool here was a
+	// data race (TOGGLE-5). It is set to true at construction so callers that
+	// never call SetOllamaAvailable continue to work unchanged. When false and
+	// baseURL is non-empty, EmbedBatch re-probes once and, if still
+	// unavailable, returns ErrOllamaNotAvailable without embedding.
+	localOllamaOK atomic.Bool
 }
 
 // defaultRequestTimeout is the per-attempt timeout applied to each
@@ -128,10 +142,48 @@ func NewEmbeddingClientWithOptions(apiKey, model, baseURL string) *EmbeddingClie
 		model:          model,
 		requestTimeout: defaultRequestTimeout,
 		baseURL:        baseURL,
-		localOllamaOK:  true,
 	}
+	// Default availability to true (atomic.Bool zero-value is false) so callers
+	// that never invoke SetOllamaAvailable are unaffected.
+	c.localOllamaOK.Store(true)
 	c.rawEmbed = c.embedBatchRaw
 	return c
+}
+
+// defaultProbeTimeout bounds a single Ollama availability probe. 2s is enough
+// for a healthy local endpoint to answer GET /api/tags and short enough not to
+// stall an embed call when the daemon is down.
+const defaultProbeTimeout = 2 * time.Second
+
+// ProbeOllamaAvailable reports whether a local Ollama-compatible endpoint is
+// reachable by issuing GET {baseURL}/api/tags with a bounded timeout. baseURL
+// may be the OpenAI-compatible ".../v1" form stored in config; the "/v1" suffix
+// is stripped because Ollama's native tags endpoint is served at /api/tags, not
+// under /v1. Returns true on any 2xx response received within timeout. A
+// non-positive timeout falls back to defaultProbeTimeout (2s). An empty baseURL
+// returns false.
+func ProbeOllamaAvailable(ctx context.Context, baseURL string, timeout time.Duration) bool {
+	if baseURL == "" {
+		return false
+	}
+	if timeout <= 0 {
+		timeout = defaultProbeTimeout
+	}
+	root := strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1")
+	url := strings.TrimRight(root, "/") + "/api/tags"
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
 // SetOllamaAvailable is called by server init with toolRegistry.Available("ollama").
@@ -139,7 +191,7 @@ func NewEmbeddingClientWithOptions(apiKey, model, baseURL string) *EmbeddingClie
 // ErrOllamaNotAvailable without making any HTTP calls. The default is true so
 // existing callers that never call this method are unaffected.
 func (c *EmbeddingClient) SetOllamaAvailable(ok bool) {
-	c.localOllamaOK = ok
+	c.localOllamaOK.Store(ok)
 }
 
 // WithRequestTimeout overrides the per-attempt timeout for each
@@ -190,8 +242,15 @@ func (c *EmbeddingClient) Model() string {
 // API errors. Cache I/O errors are logged but never fail the
 // call — the cache is an optimization, not a correctness layer.
 func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
-	if c.baseURL != "" && !c.localOllamaOK {
-		return nil, ErrOllamaNotAvailable
+	if c.baseURL != "" && !c.localOllamaOK.Load() {
+		// Cheap TTL-style recheck: the daemon may have come up since the
+		// last probe (e.g. the on-demand OllamaDaemon started it). Re-probe
+		// once inline before failing the batch.
+		if ProbeOllamaAvailable(ctx, c.baseURL, defaultProbeTimeout) {
+			c.localOllamaOK.Store(true)
+		} else {
+			return nil, ErrOllamaNotAvailable
+		}
 	}
 	if len(texts) == 0 {
 		return nil, nil

--- a/internal/ai/openai_parser.go
+++ b/internal/ai/openai_parser.go
@@ -1,7 +1,7 @@
 // file: internal/ai/openai_parser.go
-// version: 13.6.0
+// version: 13.7.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
-// last-edited: 2026-06-22
+// last-edited: 2026-07-03
 
 package ai
 
@@ -42,6 +42,13 @@ type OpenAIParser struct {
 	maxRetries    int
 	enabled       bool
 	responseCache *cache.Cache[*ParsedMetadata] // Application-level response cache
+
+	// defaultModelOverride replaces the package-level defaultModel constant as
+	// the fallback when a per-feature model field is empty. Set by
+	// NewOpenAIParserWithBaseURL so a local backend (e.g. Ollama) uses its own
+	// model name (e.g. "qwen2.5:7b-instruct") instead of the OpenAI-only
+	// "gpt-5-mini" default. Empty means fall back to defaultModel.
+	defaultModelOverride string
 }
 
 // Default cache TTL for AI responses (24 hours — metadata doesn't change often)
@@ -50,12 +57,22 @@ const aiResponseCacheTTL = 24 * time.Hour
 // defaultModel is the fallback when cfg is nil or the per-feature field is empty.
 const defaultModel = "gpt-5-mini"
 
+// fallbackModel returns the model to use when a per-feature field is empty:
+// the per-client override (set for local backends) if present, else the
+// package-level OpenAI default.
+func (p *OpenAIParser) fallbackModel() string {
+	if p.defaultModelOverride != "" {
+		return p.defaultModelOverride
+	}
+	return defaultModel
+}
+
 // filenameParseModel returns the configured model for filename/audiobook parsing.
 func (p *OpenAIParser) filenameParseModel() string {
 	if p.cfg != nil && p.cfg.FilenameParseModel != "" {
 		return p.cfg.FilenameParseModel
 	}
-	return defaultModel
+	return p.fallbackModel()
 }
 
 // coverArtModel returns the configured model for cover-art parsing.
@@ -63,7 +80,7 @@ func (p *OpenAIParser) coverArtModel() string {
 	if p.cfg != nil && p.cfg.CoverArtModel != "" {
 		return p.cfg.CoverArtModel
 	}
-	return defaultModel
+	return p.fallbackModel()
 }
 
 // metadataReviewModel returns the configured model for metadata review operations.
@@ -71,29 +88,52 @@ func (p *OpenAIParser) metadataReviewModel() string {
 	if p.cfg != nil && p.cfg.MetadataReviewModel != "" {
 		return p.cfg.MetadataReviewModel
 	}
-	return defaultModel
+	return p.fallbackModel()
 }
 
-// NewOpenAIParser creates a new OpenAI parser.
+// NewOpenAIParser creates a new OpenAI parser using the process-wide
+// OPENAI_BASE_URL env (if set) and the OpenAI default model. Preserved for
+// backward compatibility with existing callers; new callers that need a
+// per-client base URL / model (e.g. a local Ollama backend) should use
+// NewOpenAIParserWithBaseURL, which never consults OPENAI_BASE_URL.
+//
 // cfg may be nil; when provided, per-feature model fields override the default.
 func NewOpenAIParser(cfg *config.Config, apiKey string, enabled bool) *OpenAIParser {
+	return NewOpenAIParserWithBaseURL(cfg, apiKey, os.Getenv("OPENAI_BASE_URL"), defaultModel, enabled)
+}
+
+// NewOpenAIParserWithBaseURL creates an OpenAI parser pinned to an explicit
+// base URL and fallback model, without consulting the process-wide
+// OPENAI_BASE_URL env.
+//
+// baseURL scopes an OpenAI-compatible endpoint override to THIS parser only
+// (e.g. "http://127.0.0.1:11434/v1" for a local Ollama). This is deliberately a
+// parameter rather than the OPENAI_BASE_URL env, because that env applies to
+// every default OpenAI client in the process — including the embedding client,
+// which must NOT be silently redirected. An empty baseURL uses the OpenAI
+// default endpoint.
+//
+// model is the fallback model used when a per-feature model field on cfg is
+// empty; an empty model keeps the OpenAI-only defaultModel. cfg may be nil.
+func NewOpenAIParserWithBaseURL(cfg *config.Config, apiKey, baseURL, model string, enabled bool) *OpenAIParser {
 	if !enabled || apiKey == "" {
-		return &OpenAIParser{enabled: false, cfg: cfg}
+		return &OpenAIParser{enabled: false, cfg: cfg, defaultModelOverride: model}
 	}
 
 	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
-	if baseURL := os.Getenv("OPENAI_BASE_URL"); baseURL != "" {
+	if baseURL != "" {
 		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
 	}
 
 	client := openai.NewClient(clientOptions...)
 
 	return &OpenAIParser{
-		client:        &client,
-		cfg:           cfg,
-		maxRetries:    2,
-		enabled:       true,
-		responseCache: cache.New[*ParsedMetadata]("ai_response", aiResponseCacheTTL),
+		client:               &client,
+		cfg:                  cfg,
+		maxRetries:           2,
+		enabled:              true,
+		responseCache:        cache.New[*ParsedMetadata]("ai_response", aiResponseCacheTTL),
+		defaultModelOverride: model,
 	}
 }
 
@@ -169,8 +209,8 @@ Set confidence based on clarity of the filename structure.`
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:               shared.ChatModel(p.filenameParseModel()), // filename parsing uses FilenameParseModel
-		MaxCompletionTokens: param.NewOpt[int64](500),
+		Model:                shared.ChatModel(p.filenameParseModel()), // filename parsing uses FilenameParseModel
+		MaxCompletionTokens:  param.NewOpt[int64](500),
 		PromptCacheKey:       param.NewOpt("audiobook-filename-parser-v1"),
 		PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -274,8 +314,8 @@ Set confidence based on how much context was available and how unambiguous it is
 			openai.SystemMessage(systemPrompt),
 			openai.UserMessage(userPrompt),
 		},
-		Model:               shared.ChatModel(p.filenameParseModel()), // audiobook context parsing uses FilenameParseModel
-		MaxCompletionTokens: param.NewOpt[int64](500),
+		Model:                shared.ChatModel(p.filenameParseModel()), // audiobook context parsing uses FilenameParseModel
+		MaxCompletionTokens:  param.NewOpt[int64](500),
 		PromptCacheKey:       param.NewOpt("audiobook-context-parser-v1"),
 		PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -358,8 +398,8 @@ Set confidence based on clarity of the filename structure.`
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.filenameParseModel()), // batch filename parsing uses FilenameParseModel
-			MaxCompletionTokens: param.NewOpt[int64](2000),
+			Model:                shared.ChatModel(p.filenameParseModel()), // batch filename parsing uses FilenameParseModel
+			MaxCompletionTokens:  param.NewOpt[int64](2000),
 			PromptCacheKey:       param.NewOpt("audiobook-batch-parser-v1"),
 			PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -423,7 +463,7 @@ Set confidence based on how clearly the text is readable on the cover.`
 				openai.TextContentPart("Read the metadata from this audiobook cover image."),
 			}),
 		},
-		Model:               shared.ChatModel(p.coverArtModel()), // cover art parsing uses CoverArtModel
+		Model:                shared.ChatModel(p.coverArtModel()), // cover art parsing uses CoverArtModel
 		PromptCacheKey:       param.NewOpt("audiobook-cover-parser-v1"),
 		PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 		MaxCompletionTokens:  param.NewOpt[int64](500),
@@ -564,8 +604,8 @@ The roles object fields are all optional — only include roles that are detecte
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.metadataReviewModel()), // author dedup review uses MetadataReviewModel
-			MaxCompletionTokens: param.NewOpt[int64](32000),
+			Model:                shared.ChatModel(p.metadataReviewModel()), // author dedup review uses MetadataReviewModel
+			MaxCompletionTokens:  param.NewOpt[int64](32000),
 			PromptCacheKey:       param.NewOpt("audiobook-author-dedup-v4"),
 			PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
@@ -686,8 +726,8 @@ The roles object fields are all optional — only include roles that are detecte
 				openai.SystemMessage(systemPrompt),
 				openai.UserMessage(userPrompt),
 			},
-			Model:               shared.ChatModel(p.metadataReviewModel()), // author discovery review uses MetadataReviewModel
-			MaxCompletionTokens: param.NewOpt[int64](16000),
+			Model:                shared.ChatModel(p.metadataReviewModel()), // author discovery review uses MetadataReviewModel
+			MaxCompletionTokens:  param.NewOpt[int64](16000),
 			PromptCacheKey:       param.NewOpt("audiobook-author-discover-v4"),
 			PromptCacheRetention: openai.ChatCompletionNewParamsPromptCacheRetention24h,
 			ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{

--- a/internal/ai/openai_parser_baseurl_test.go
+++ b/internal/ai/openai_parser_baseurl_test.go
@@ -1,0 +1,86 @@
+// file: internal/ai/openai_parser_baseurl_test.go
+// version: 1.0.0
+// last-edited: 2026-07-03
+
+package ai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestNewOpenAIParserWithBaseURL_ModelOverride verifies the explicit-base-URL
+// constructor pins the fallback model and is independent of the process-wide
+// OPENAI_BASE_URL env (which must never influence this constructor).
+func TestNewOpenAIParserWithBaseURL_ModelOverride(t *testing.T) {
+	// Set a bogus OPENAI_BASE_URL; the WithBaseURL constructor must ignore it.
+	t.Setenv("OPENAI_BASE_URL", "http://should-not-be-read.invalid/v1")
+
+	p := NewOpenAIParserWithBaseURL(nil, "ollama", "http://192.168.0.20:11434/v1", "qwen2.5:7b-instruct", true)
+	if !p.IsEnabled() {
+		t.Fatal("expected enabled parser")
+	}
+	if got := p.fallbackModel(); got != "qwen2.5:7b-instruct" {
+		t.Fatalf("fallbackModel() = %q, want qwen2.5:7b-instruct", got)
+	}
+	// Per-feature helpers fall back to the override when cfg is nil.
+	if got := p.filenameParseModel(); got != "qwen2.5:7b-instruct" {
+		t.Fatalf("filenameParseModel() = %q, want qwen2.5:7b-instruct", got)
+	}
+
+	// Disabled construction still records the model override, so re-enabling a
+	// derived client would use the right fallback.
+	pd := NewOpenAIParserWithBaseURL(nil, "", "", "qwen2.5:7b-instruct", false)
+	if pd.IsEnabled() {
+		t.Fatal("expected disabled parser when apiKey empty")
+	}
+	if got := pd.fallbackModel(); got != "qwen2.5:7b-instruct" {
+		t.Fatalf("disabled parser fallbackModel() = %q, want qwen2.5:7b-instruct", got)
+	}
+}
+
+// TestNewOpenAIParser_DefaultModelFallback verifies the backward-compatible
+// wrapper keeps the OpenAI default model when no per-feature field is set.
+func TestNewOpenAIParser_DefaultModelFallback(t *testing.T) {
+	p := NewOpenAIParser(nil, "sk-real", true)
+	if got := p.fallbackModel(); got != defaultModel {
+		t.Fatalf("fallbackModel() = %q, want %q", got, defaultModel)
+	}
+}
+
+// TestProbeOllamaAvailable exercises the probe: 2xx on /api/tags -> true,
+// non-2xx -> false, unreachable host -> false, "/v1" suffix stripped so the
+// request targets /api/tags.
+func TestProbeOllamaAvailable(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Pass the OpenAI-compatible "/v1" form; probe must hit /api/tags.
+	if !ProbeOllamaAvailable(context.Background(), srv.URL+"/v1", time.Second) {
+		t.Fatal("expected available for a 2xx endpoint")
+	}
+	if gotPath != "/api/tags" {
+		t.Fatalf("probe requested %q, want /api/tags", gotPath)
+	}
+
+	// Non-2xx -> unavailable.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if ProbeOllamaAvailable(context.Background(), bad.URL, time.Second) {
+		t.Fatal("expected unavailable for a 5xx endpoint")
+	}
+
+	// Empty base URL -> unavailable, no panic.
+	if ProbeOllamaAvailable(context.Background(), "", time.Second) {
+		t.Fatal("expected unavailable for empty base URL")
+	}
+}

--- a/internal/ai/register.go
+++ b/internal/ai/register.go
@@ -1,5 +1,5 @@
 // file: internal/ai/register.go
-// version: 1.3.0
+// version: 1.4.0
 // last-edited: 2026-07-03
 
 // Service registry registrations for the AI cluster (W4).
@@ -24,54 +24,54 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/serviceregistry"
 )
 
-// resolveAIEndpointKey decides whether an OpenAI-compatible client should be
-// constructed and what API key to hand it. When a real apiKey is configured
-// it's always used. When apiKey is empty but an explicit baseURL is
-// configured (a local OpenAI-compatible backend, e.g. Ollama, which ignores
-// the Authorization header), a dummy bearer is substituted so construction
-// proceeds. When neither is set, construction is skipped — the real-OpenAI
-// path (no baseURL) still requires a real key.
-func resolveAIEndpointKey(apiKey, baseURL string) (resolvedKey string, ok bool) {
-	if apiKey != "" {
-		return apiKey, true
-	}
-	if baseURL != "" {
-		return "ollama", true
-	}
-	return "", false
-}
-
 func init() {
-	// embedclient — OpenAI embedding client with optional cache.
-	// Conditional on: OpenAIAPIKey set AND EmbeddingEnabled true.
+	// embedclient — embedding client, mode-gated by EffectiveEmbeddingMode.
+	//   - disabled: no client.
+	//   - local:    local OpenAI-compatible backend (Ollama) at LocalBaseURL,
+	//               constructed with a dummy key the backend ignores.
+	//   - openai / openai-fallback-local: real OpenAI (key required).
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "embedclient",
 		Needs:  []string{serviceregistry.KeyConfig, serviceregistry.KeyEmbeddingStore},
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
-			if !cfg.Embedding.Enabled {
+			mode := cfg.EffectiveEmbeddingMode()
+			if mode == config.AIBackendModeDisabled {
 				return (*EmbeddingClient)(nil), nil
 			}
-			// Base URL is scoped to the embedding client ONLY (see
-			// NewEmbeddingClientWithOptions): cfg.Embedding.BaseURL points
-			// embeddings at a local OpenAI-compatible backend (e.g. Ollama)
-			// without touching the LLM / metadata clients. Fall back to the
-			// OPENAI_BASE_URL env when the config field is empty for backward
-			// compatibility with env-based setups.
-			baseURL := cfg.Embedding.BaseURL
-			if baseURL == "" {
-				baseURL = os.Getenv("OPENAI_BASE_URL")
+
+			var client *EmbeddingClient
+			switch mode {
+			case config.AIBackendModeLocal:
+				// Read-time fallback keeps the getter pure: prefer the new
+				// AIBackend fields, fall back to the legacy Embedding fields
+				// for the migration-not-yet-applied case.
+				baseURL := cfg.AIBackend.LocalBaseURL
+				if baseURL == "" {
+					baseURL = cfg.Embedding.BaseURL
+				}
+				model := cfg.AIBackend.LocalEmbeddingModel
+				if model == "" {
+					model = cfg.Embedding.Model
+				}
+				slog.Info("embedclient: local backend", "baseURL", baseURL, "model", model)
+				// Dummy key "ollama" — a local OpenAI-compatible backend ignores
+				// the Authorization header.
+				client = NewEmbeddingClientWithOptions("ollama", model, baseURL)
+			default: // openai, openai-fallback-local
+				if cfg.OpenAIAPIKey == "" {
+					slog.Warn("embedclient: openai embedding mode but no OpenAIAPIKey — skipping", "mode", mode)
+					return (*EmbeddingClient)(nil), nil
+				}
+				baseURL := cfg.Embedding.BaseURL
+				if baseURL == "" {
+					baseURL = os.Getenv("OPENAI_BASE_URL")
+				}
+				client = NewEmbeddingClientWithOptions(cfg.OpenAIAPIKey, cfg.Embedding.Model, baseURL)
 			}
-			resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)
-			if !ok {
-				return (*EmbeddingClient)(nil), nil
-			}
-			if cfg.OpenAIAPIKey == "" {
-				slog.Warn("embedclient: constructing with keyless/local backend (no OpenAIAPIKey, using explicit base URL)", "baseURL", baseURL)
-			}
+
 			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, serviceregistry.KeyEmbeddingStore)
-			client := NewEmbeddingClientWithOptions(resolvedKey, cfg.Embedding.Model, baseURL)
 			if embStore != nil {
 				client = client.WithCache(embStore)
 			}
@@ -79,23 +79,38 @@ func init() {
 		},
 	})
 
-	// llmparser — OpenAIParser used by dedup Layer 3 review + metadata
-	// LLM reranker. Conditional on OpenAIAPIKey set.
+	// llmparser — OpenAIParser used by dedup Layer 3 review + metadata LLM
+	// reranker, mode-gated by EffectiveLLMMode.
+	//   - disabled: no parser.
+	//   - local:    local OpenAI-compatible backend at LocalBaseURL with a dummy
+	//               key and the local LLM model name.
+	//   - openai / openai-fallback-local: real OpenAI (key required).
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "llmparser",
 		Needs:  []string{serviceregistry.KeyConfig},
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
-			baseURL := os.Getenv("OPENAI_BASE_URL")
-			resolvedKey, ok := resolveAIEndpointKey(cfg.OpenAIAPIKey, baseURL)
-			if !ok {
+			mode := cfg.EffectiveLLMMode()
+			if mode == config.AIBackendModeDisabled {
 				return (*OpenAIParser)(nil), nil
 			}
-			if cfg.OpenAIAPIKey == "" {
-				slog.Warn("llmparser: constructing with keyless/local backend (no OpenAIAPIKey, using OPENAI_BASE_URL env)", "baseURL", baseURL)
+
+			switch mode {
+			case config.AIBackendModeLocal:
+				baseURL := cfg.AIBackend.LocalBaseURL
+				if baseURL == "" {
+					baseURL = cfg.Embedding.BaseURL
+				}
+				slog.Info("llmparser: local backend", "baseURL", baseURL, "model", cfg.AIBackend.LocalLLMModel)
+				return NewOpenAIParserWithBaseURL(cfg, "ollama", baseURL, cfg.AIBackend.LocalLLMModel, cfg.EnableAIParsing), nil
+			default: // openai, openai-fallback-local
+				if cfg.OpenAIAPIKey == "" {
+					slog.Warn("llmparser: openai LLM mode but no OpenAIAPIKey — skipping", "mode", mode)
+					return (*OpenAIParser)(nil), nil
+				}
+				return NewOpenAIParser(cfg, cfg.OpenAIAPIKey, cfg.EnableAIParsing), nil
 			}
-			return NewOpenAIParser(cfg, resolvedKey, cfg.EnableAIParsing), nil
 		},
 	})
 
@@ -120,12 +135,18 @@ func init() {
 	})
 
 	// metadatallmscorer — LLM-based metadata candidate rerank scorer.
-	// Conditional on llmparser being available.
+	// Conditional on llmparser being available AND the effective LLM mode not
+	// being disabled (TOGGLE-6: previously it built whenever a parser existed,
+	// even in a disabled-LLM configuration).
 	serviceregistry.Register(serviceregistry.ServiceDef{
 		Name:   "metadatallmscorer",
-		Needs:  []string{"llmparser"},
+		Needs:  []string{serviceregistry.KeyConfig, "llmparser"},
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
+			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
+			if cfg.EffectiveLLMMode() == config.AIBackendModeDisabled {
+				return (*LLMScorer)(nil), nil
+			}
 			parser, _ := serviceregistry.TryGet[*OpenAIParser](c, "llmparser")
 			if parser == nil {
 				return (*LLMScorer)(nil), nil

--- a/internal/ai/register_test.go
+++ b/internal/ai/register_test.go
@@ -1,69 +1,128 @@
 // file: internal/ai/register_test.go
-// version: 1.0.0
+// version: 2.0.0
 // last-edited: 2026-07-03
 
 package ai
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-// TestResolveAIEndpointKey covers the 4 key/base-URL combinations documented
-// on resolveAIEndpointKey: a real key always wins, a dummy key is substituted
-// when only a base URL is present, and construction is skipped when neither
-// is configured.
-func TestResolveAIEndpointKey(t *testing.T) {
-	tests := []struct {
-		name       string
-		apiKey     string
-		baseURL    string
-		wantKey    string
-		wantOK     bool
-		keyIsDummy bool
-	}{
-		{
-			name:    "real key, no base URL",
-			apiKey:  "sk-real-key",
-			baseURL: "",
-			wantKey: "sk-real-key",
-			wantOK:  true,
-		},
-		{
-			name:    "real key, with base URL (key takes priority)",
-			apiKey:  "sk-real-key",
-			baseURL: "http://localhost:11434/v1",
-			wantKey: "sk-real-key",
-			wantOK:  true,
-		},
-		{
-			name:       "no key, base URL configured (dummy key substituted)",
-			apiKey:     "",
-			baseURL:    "http://localhost:11434/v1",
-			wantOK:     true,
-			keyIsDummy: true,
-		},
-		{
-			name:    "no key, no base URL (construction skipped)",
-			apiKey:  "",
-			baseURL: "",
-			wantKey: "",
-			wantOK:  false,
-		},
-	}
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/serviceregistry"
+)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotKey, gotOK := resolveAIEndpointKey(tt.apiKey, tt.baseURL)
-			if gotOK != tt.wantOK {
-				t.Fatalf("resolveAIEndpointKey(%q, %q) ok = %v, want %v", tt.apiKey, tt.baseURL, gotOK, tt.wantOK)
-			}
-			if tt.keyIsDummy {
-				if gotKey == "" {
-					t.Fatalf("resolveAIEndpointKey(%q, %q) key = %q, want non-empty dummy key", tt.apiKey, tt.baseURL, gotKey)
-				}
-				return
-			}
-			if gotKey != tt.wantKey {
-				t.Fatalf("resolveAIEndpointKey(%q, %q) key = %q, want %q", tt.apiKey, tt.baseURL, gotKey, tt.wantKey)
-			}
-		})
+// buildEmbedClient builds only the embedclient service against the given config,
+// with a nil embedding store override so no cache is wired.
+func buildEmbedClient(t *testing.T, cfg *config.Config) *EmbeddingClient {
+	t.Helper()
+	c := serviceregistry.NewContainer().
+		Override(serviceregistry.KeyConfig, cfg).
+		Override(serviceregistry.KeyEmbeddingStore, (*database.EmbeddingStore)(nil)).
+		Include("embedclient")
+	if err := c.Build(context.Background()); err != nil {
+		t.Fatalf("build embedclient: %v", err)
 	}
+	client, _ := serviceregistry.TryGet[*EmbeddingClient](c, "embedclient")
+	return client
+}
+
+// buildLLMParser builds only the llmparser service against the given config.
+func buildLLMParser(t *testing.T, cfg *config.Config) *OpenAIParser {
+	t.Helper()
+	c := serviceregistry.NewContainer().
+		Override(serviceregistry.KeyConfig, cfg).
+		Include("llmparser")
+	if err := c.Build(context.Background()); err != nil {
+		t.Fatalf("build llmparser: %v", err)
+	}
+	parser, _ := serviceregistry.TryGet[*OpenAIParser](c, "llmparser")
+	return parser
+}
+
+// TestEmbedClientBuild_ModeGated verifies embedclient construction keys off
+// EffectiveEmbeddingMode: nil in disabled mode, a local-model client in local
+// mode (built with a dummy key), and a real-key client in openai mode.
+func TestEmbedClientBuild_ModeGated(t *testing.T) {
+	t.Run("disabled mode -> nil client", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Embedding.Enabled = false // no explicit mode; derives to disabled
+		if got := buildEmbedClient(t, cfg); got != nil {
+			t.Fatalf("expected nil client in disabled mode, got %#v (model=%q)", got, got.Model())
+		}
+	})
+
+	t.Run("local mode -> dummy-key client with local model", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.AIBackend.EmbeddingMode = config.AIBackendModeLocal
+		cfg.AIBackend.LocalBaseURL = "http://192.168.0.20:11434/v1"
+		cfg.AIBackend.LocalEmbeddingModel = "bge-m3"
+		got := buildEmbedClient(t, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil client in local mode")
+		}
+		if got.Model() != "bge-m3" {
+			t.Fatalf("local client model = %q, want bge-m3", got.Model())
+		}
+	})
+
+	t.Run("openai mode requires a key", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Embedding.Enabled = true
+		cfg.Embedding.Model = "text-embedding-3-large"
+		cfg.OpenAIAPIKey = "" // openai mode derivation needs a key; none -> disabled
+		if got := buildEmbedClient(t, cfg); got != nil {
+			t.Fatalf("expected nil client when openai mode lacks a key, got model=%q", got.Model())
+		}
+
+		cfg.OpenAIAPIKey = "sk-real"
+		got := buildEmbedClient(t, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil client in openai mode with a key")
+		}
+		if got.Model() != "text-embedding-3-large" {
+			t.Fatalf("openai client model = %q, want text-embedding-3-large", got.Model())
+		}
+	})
+}
+
+// TestLLMParserBuild_ModeGated verifies llmparser construction keys off
+// EffectiveLLMMode: nil in disabled mode, a constructed parser in local mode
+// with the local model as fallback, and a constructed parser in openai mode.
+func TestLLMParserBuild_ModeGated(t *testing.T) {
+	t.Run("disabled mode -> nil parser", func(t *testing.T) {
+		cfg := &config.Config{} // no key, nothing enabled -> disabled
+		if got := buildLLMParser(t, cfg); got != nil {
+			t.Fatalf("expected nil parser in disabled LLM mode, got %#v", got)
+		}
+	})
+
+	t.Run("local mode -> parser using local model fallback", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.AIBackend.LLMMode = config.AIBackendModeLocal
+		cfg.AIBackend.LocalBaseURL = "http://192.168.0.20:11434/v1"
+		cfg.AIBackend.LocalLLMModel = "qwen2.5:7b-instruct"
+		cfg.EnableAIParsing = true
+		got := buildLLMParser(t, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil parser in local LLM mode")
+		}
+		if m := got.fallbackModel(); m != "qwen2.5:7b-instruct" {
+			t.Fatalf("local parser fallback model = %q, want qwen2.5:7b-instruct", m)
+		}
+	})
+
+	t.Run("openai mode -> parser constructed", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.OpenAIAPIKey = "sk-real"
+		cfg.EnableAIParsing = true
+		got := buildLLMParser(t, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil parser in openai LLM mode")
+		}
+		if !got.IsEnabled() {
+			t.Fatal("expected enabled parser when EnableAIParsing=true and key set")
+		}
+	})
 }

--- a/internal/config/aibackend_test.go
+++ b/internal/config/aibackend_test.go
@@ -1,0 +1,112 @@
+// file: internal/config/aibackend_test.go
+// version: 1.0.0
+// last-edited: 2026-07-03
+
+package config
+
+import "testing"
+
+// TestEffectiveEmbeddingMode covers the derivation branches plus the explicit
+// override, matching the rule mirrored by migrateAIBackendBlob.
+func TestEffectiveEmbeddingMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(c *Config)
+		want string
+	}{
+		{
+			name: "explicit mode wins",
+			mut:  func(c *Config) { c.AIBackend.EmbeddingMode = AIBackendModeLocal; c.Embedding.Enabled = false },
+			want: AIBackendModeLocal,
+		},
+		{
+			name: "disabled when embedding off",
+			mut:  func(c *Config) { c.Embedding.Enabled = false; c.OpenAIAPIKey = "sk-x" },
+			want: AIBackendModeDisabled,
+		},
+		{
+			name: "local when base url set",
+			mut:  func(c *Config) { c.Embedding.Enabled = true; c.Embedding.BaseURL = "http://192.168.0.20:11434/v1" },
+			want: AIBackendModeLocal,
+		},
+		{
+			name: "openai when key set and no base url",
+			mut:  func(c *Config) { c.Embedding.Enabled = true; c.OpenAIAPIKey = "sk-x" },
+			want: AIBackendModeOpenAI,
+		},
+		{
+			name: "disabled when enabled but nothing configured",
+			mut:  func(c *Config) { c.Embedding.Enabled = true },
+			want: AIBackendModeDisabled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Config
+			tt.mut(&c)
+			if got := c.EffectiveEmbeddingMode(); got != tt.want {
+				t.Fatalf("EffectiveEmbeddingMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveLLMMode covers the LLM derivation branches plus override.
+func TestEffectiveLLMMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(c *Config)
+		want string
+	}{
+		{
+			name: "explicit mode wins",
+			mut:  func(c *Config) { c.AIBackend.LLMMode = AIBackendModeLocal },
+			want: AIBackendModeLocal,
+		},
+		{
+			name: "openai via enable_ai_parsing",
+			mut:  func(c *Config) { c.OpenAIAPIKey = "sk-x"; c.EnableAIParsing = true },
+			want: AIBackendModeOpenAI,
+		},
+		{
+			name: "openai via metadata llm enabled",
+			mut:  func(c *Config) { c.OpenAIAPIKey = "sk-x"; c.MetadataScoring.LLMEnabled = true },
+			want: AIBackendModeOpenAI,
+		},
+		{
+			name: "disabled without a key",
+			mut:  func(c *Config) { c.EnableAIParsing = true },
+			want: AIBackendModeDisabled,
+		},
+		{
+			name: "disabled with key but no consumer enabled",
+			mut:  func(c *Config) { c.OpenAIAPIKey = "sk-x" },
+			want: AIBackendModeDisabled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Config
+			tt.mut(&c)
+			if got := c.EffectiveLLMMode(); got != tt.want {
+				t.Fatalf("EffectiveLLMMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveMode_PureNoMutation asserts the helpers never write back to the
+// config (they must stay safe for concurrent readers of the global AppConfig).
+func TestEffectiveMode_PureNoMutation(t *testing.T) {
+	c := Config{}
+	c.Embedding.Enabled = true
+	c.Embedding.BaseURL = "http://192.168.0.20:11434/v1"
+	_ = c.EffectiveEmbeddingMode()
+	_ = c.EffectiveLLMMode()
+	if c.AIBackend.LocalBaseURL != "" {
+		t.Fatalf("EffectiveEmbeddingMode mutated LocalBaseURL to %q; helpers must be pure", c.AIBackend.LocalBaseURL)
+	}
+	if c.AIBackend.EmbeddingMode != "" || c.AIBackend.LLMMode != "" {
+		t.Fatal("effective-mode helpers must not write derived modes back into config")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.62.0
+// version: 1.63.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-07-03
 
@@ -219,6 +219,88 @@ type MetadataScoringConfig struct {
 	WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
 }
 
+// AIBackend mode constants. They control, independently for embeddings and
+// LLM/chat, which backend the corresponding client is constructed against.
+//
+//   - AIBackendModeDisabled: no client is constructed.
+//   - AIBackendModeOpenAI: the real OpenAI cloud API (requires OpenAIAPIKey).
+//   - AIBackendModeLocal: a local OpenAI-compatible endpoint (e.g. Ollama) at
+//     AIBackendConfig.LocalBaseURL; the API key is ignored by the backend.
+//   - AIBackendModeOpenAIFallbackLocal: primary OpenAI with a local fallback.
+//     The fallback *trigger* is not implemented by this config; it is wired by
+//     the error-classification layer (retry.go). At construction time this mode
+//     behaves like OpenAI (real key required).
+const (
+	AIBackendModeDisabled            = "disabled"
+	AIBackendModeOpenAI              = "openai"
+	AIBackendModeLocal               = "local"
+	AIBackendModeOpenAIFallbackLocal = "openai-fallback-local"
+)
+
+// AIBackendConfig holds the backend-mode toggle for the AI cluster. It nests
+// independent embedding / LLM mode enums plus the local endpoint coordinates so
+// operators can point each pipeline at OpenAI, a local Ollama-style backend, or
+// disable it — without the previous coupling of everything to a single
+// OpenAIAPIKey / OPENAI_BASE_URL pair.
+//
+// EmbeddingMode / LLMMode may be empty at rest; the effective mode is then
+// derived from the legacy flat fields (Embedding.BaseURL, OpenAIAPIKey,
+// EnableAIParsing, MetadataScoring.LLMEnabled) via Config.EffectiveEmbeddingMode
+// / Config.EffectiveLLMMode. Migration (migrateAIBackendBlob) fills these in on
+// load; the effective-mode helpers make even an un-migrated blob safe.
+type AIBackendConfig struct {
+	EmbeddingMode       string `json:"embedding_mode"        mapstructure:"embedding_mode"`
+	LLMMode             string `json:"llm_mode"              mapstructure:"llm_mode"`
+	LocalBaseURL        string `json:"local_base_url"        mapstructure:"local_base_url"`
+	LocalEmbeddingModel string `json:"local_embedding_model" mapstructure:"local_embedding_model"`
+	LocalLLMModel       string `json:"local_llm_model"       mapstructure:"local_llm_model"`
+}
+
+// EffectiveEmbeddingMode resolves the embedding backend mode. When
+// AIBackend.EmbeddingMode is set explicitly it wins. Otherwise the mode is
+// derived from the legacy flat fields, mirroring the pre-toggle behavior of the
+// embedclient registration:
+//
+//   - Embedding.Enabled == false -> disabled (master off-switch preserved).
+//   - Embedding.BaseURL != ""     -> local  (a local endpoint is configured).
+//   - OpenAIAPIKey != ""          -> openai.
+//   - otherwise                   -> disabled.
+//
+// This method is pure: it reads config and returns a string, mutating nothing,
+// so it is safe to call from concurrent readers (e.g. the dedup engine reading
+// the global AppConfig).
+func (c *Config) EffectiveEmbeddingMode() string {
+	if c.AIBackend.EmbeddingMode != "" {
+		return c.AIBackend.EmbeddingMode
+	}
+	if !c.Embedding.Enabled {
+		return AIBackendModeDisabled
+	}
+	if c.Embedding.BaseURL != "" {
+		return AIBackendModeLocal
+	}
+	if c.OpenAIAPIKey != "" {
+		return AIBackendModeOpenAI
+	}
+	return AIBackendModeDisabled
+}
+
+// EffectiveLLMMode resolves the LLM/chat backend mode. When AIBackend.LLMMode is
+// set explicitly it wins. Otherwise: openai when a key is configured and any LLM
+// consumer is enabled (EnableAIParsing or MetadataScoring.LLMEnabled), else
+// disabled. There is no legacy flat field for a local LLM endpoint, so local LLM
+// use must be selected explicitly via AIBackend.LLMMode. Pure (see
+// EffectiveEmbeddingMode).
+func (c *Config) EffectiveLLMMode() string {
+	if c.AIBackend.LLMMode != "" {
+		return c.AIBackend.LLMMode
+	}
+	if c.OpenAIAPIKey != "" && (c.EnableAIParsing || c.MetadataScoring.LLMEnabled) {
+		return AIBackendModeOpenAI
+	}
+	return AIBackendModeDisabled
+}
+
 // ScheduledTaskConfig holds per-task scheduler settings.
 type ScheduledTaskConfig struct {
 	Enabled   bool `json:"enabled"    mapstructure:"enabled"`
@@ -348,6 +430,11 @@ type Config struct {
 	// (embedding scoring, LLM rerank tier, and tag-write backup policy).
 	// Previously these were 7 flat fields; Wave 3 nests them here.
 	MetadataScoring MetadataScoringConfig `json:"metadata_scoring" mapstructure:"metadata_scoring"`
+
+	// AIBackend holds the backend-mode toggle for the embedding + LLM clients
+	// (independent EmbeddingMode / LLMMode enums, local endpoint coordinates).
+	// See AIBackendConfig and EffectiveEmbeddingMode / EffectiveLLMMode.
+	AIBackend AIBackendConfig `json:"ai_backend" mapstructure:"ai_backend"`
 
 	// API limits
 	APIRateLimitPerMinute  int  `json:"api_rate_limit_per_minute"`
@@ -745,6 +832,21 @@ func InitConfig() {
 	viper.SetDefault("metadata_scoring.llm_rerank_epsilon", 0.05)
 	viper.SetDefault("metadata_scoring.llm_rerank_top_k", 5)
 	viper.SetDefault("metadata_scoring.write_backup_before", true)
+
+	// AI backend-mode toggle. Modes default empty (resolved from legacy fields
+	// by EffectiveEmbeddingMode / EffectiveLLMMode). LocalBaseURL uses a
+	// placeholder host; real endpoints live in gitignored local config.
+	viper.SetDefault("ai_backend.embedding_mode", "")
+	viper.SetDefault("ai_backend.llm_mode", "")
+	viper.SetDefault("ai_backend.local_base_url", "http://192.168.0.20:11434/v1")
+	viper.SetDefault("ai_backend.local_embedding_model", "bge-m3")
+	viper.SetDefault("ai_backend.local_llm_model", "qwen2.5:7b-instruct")
+	viper.BindEnv("ai_backend.embedding_mode", "AI_BACKEND_EMBEDDING_MODE")               //nolint:errcheck
+	viper.BindEnv("ai_backend.llm_mode", "AI_BACKEND_LLM_MODE")                           //nolint:errcheck
+	viper.BindEnv("ai_backend.local_base_url", "AI_BACKEND_LOCAL_BASE_URL")               //nolint:errcheck
+	viper.BindEnv("ai_backend.local_embedding_model", "AI_BACKEND_LOCAL_EMBEDDING_MODEL") //nolint:errcheck
+	viper.BindEnv("ai_backend.local_llm_model", "AI_BACKEND_LOCAL_LLM_MODEL")             //nolint:errcheck
+
 	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")       //nolint:errcheck
 	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE")   //nolint:errcheck
 	viper.BindEnv("metadata_scoring.embedding_best_match", "METADATA_SCORING_EMBEDDING_BEST_MATCH") //nolint:errcheck
@@ -982,6 +1084,17 @@ func InitConfig() {
 				LLMRerankEpsilon:   viper.GetFloat64("metadata_scoring.llm_rerank_epsilon"),
 				LLMRerankTopK:      viper.GetInt("metadata_scoring.llm_rerank_top_k"),
 				WriteBackupBefore:  viper.GetBool("metadata_scoring.write_backup_before"),
+			},
+
+			// AI backend-mode toggle (nested sub-struct). Modes default empty
+			// (resolved by EffectiveEmbeddingMode / EffectiveLLMMode); local
+			// endpoint coordinates carry Ollama-style defaults.
+			AIBackend: AIBackendConfig{
+				EmbeddingMode:       viper.GetString("ai_backend.embedding_mode"),
+				LLMMode:             viper.GetString("ai_backend.llm_mode"),
+				LocalBaseURL:        viper.GetString("ai_backend.local_base_url"),
+				LocalEmbeddingModel: viper.GetString("ai_backend.local_embedding_model"),
+				LocalLLMModel:       viper.GetString("ai_backend.local_llm_model"),
 			},
 
 			// Scheduled background tasks (nested sub-struct)
@@ -1395,6 +1508,18 @@ func ResetToDefaults() {
 				LLMRerankEpsilon:   0.05,
 				LLMRerankTopK:      5,
 				WriteBackupBefore:  true,
+			},
+
+			// AI backend-mode toggle. Modes empty at rest (derived from legacy
+			// fields by EffectiveEmbeddingMode / EffectiveLLMMode); local
+			// endpoint coordinates carry Ollama defaults. LocalBaseURL uses a
+			// placeholder host — real endpoints live in gitignored local config.
+			AIBackend: AIBackendConfig{
+				EmbeddingMode:       "",
+				LLMMode:             "",
+				LocalBaseURL:        "http://192.168.0.20:11434/v1",
+				LocalEmbeddingModel: "bge-m3",
+				LocalLLMModel:       "qwen2.5:7b-instruct",
 			},
 
 			// Logging

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence.go
-// version: 1.27.0
+// version: 1.28.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
-// last-edited: 2026-06-16
+// last-edited: 2026-07-03
 
 package config
 
@@ -229,15 +229,15 @@ func migrateDedupBlob(blob string) (string, bool) {
 	}
 
 	flatToNested := map[string]string{
-		"dedup_book_high_threshold":           "book_high_threshold",
-		"dedup_book_low_threshold":            "book_low_threshold",
-		"dedup_author_high_threshold":         "author_high_threshold",
-		"dedup_author_low_threshold":          "author_low_threshold",
-		"dedup_auto_merge_enabled":            "auto_merge_enabled",
-		"dedup_embeddings_enabled":            "embeddings_enabled",
+		"dedup_book_high_threshold":            "book_high_threshold",
+		"dedup_book_low_threshold":             "book_low_threshold",
+		"dedup_author_high_threshold":          "author_high_threshold",
+		"dedup_author_low_threshold":           "author_low_threshold",
+		"dedup_auto_merge_enabled":             "auto_merge_enabled",
+		"dedup_embeddings_enabled":             "embeddings_enabled",
 		"dedup_llm_auto_merge_high_confidence": "llm_auto_merge_high_confidence",
-		"dedup_on_import_via_scheduler":       "on_import_via_scheduler",
-		"dedup_review_model":                  "review_model",
+		"dedup_on_import_via_scheduler":        "on_import_via_scheduler",
+		"dedup_review_model":                   "review_model",
 	}
 	for flat, short := range flatToNested {
 		if v, ok := raw[flat]; ok {
@@ -292,6 +292,95 @@ func migrateMetadataScoringBlob(blob string) (string, bool) {
 	delete(raw, "metadata_llm_rerank_epsilon")
 	delete(raw, "metadata_llm_rerank_top_k")
 	delete(raw, "write_backup_before_tag_write")
+	migrated, err := json.Marshal(raw)
+	if err != nil {
+		return blob, false
+	}
+	return string(migrated), true
+}
+
+// migrateAIBackendBlob derives the nested ai_backend object (backend-mode
+// toggle) from the legacy flat/nested AI signal fields (openai_api_key,
+// embedding.enabled/base_url/model, enable_ai_parsing, metadata_scoring.llm_enabled).
+// It mirrors Config.EffectiveEmbeddingMode / Config.EffectiveLLMMode so the
+// persisted modes match what those helpers would resolve at runtime. Safe to
+// call repeatedly: returns (blob, false) once ai_backend is present, or when no
+// legacy AI signal fields exist to derive from.
+//
+// Chained AFTER migrateMetadataScoringBlob so the embedding / metadata_scoring
+// sub-objects are already in their nested shape when we read them here.
+func migrateAIBackendBlob(blob string) (string, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(blob), &raw); err != nil {
+		return blob, false
+	}
+	// Idempotent: already migrated.
+	if _, ok := raw["ai_backend"]; ok {
+		return blob, false
+	}
+	// Need at least one legacy signal to derive a mode from; otherwise leave the
+	// blob untouched and let runtime effective-mode resolution handle it.
+	_, hasKey := raw["openai_api_key"]
+	_, hasEmbedding := raw["embedding"]
+	_, hasParsing := raw["enable_ai_parsing"]
+	_, hasMetaScoring := raw["metadata_scoring"]
+	if !hasKey && !hasEmbedding && !hasParsing && !hasMetaScoring {
+		return blob, false
+	}
+
+	apiKey, _ := raw["openai_api_key"].(string)
+	enableAIParsing, _ := raw["enable_ai_parsing"].(bool)
+
+	// Embedding.Enabled defaults true; an absent nested object counts as enabled.
+	embEnabled := true
+	embBaseURL := ""
+	embModel := ""
+	if emb, ok := raw["embedding"].(map[string]any); ok {
+		if v, ok := emb["enabled"].(bool); ok {
+			embEnabled = v
+		}
+		embBaseURL, _ = emb["base_url"].(string)
+		embModel, _ = emb["model"].(string)
+	}
+
+	llmEnabled := false
+	if ms, ok := raw["metadata_scoring"].(map[string]any); ok {
+		llmEnabled, _ = ms["llm_enabled"].(bool)
+	}
+
+	// Derive embedding mode (mirrors Config.EffectiveEmbeddingMode).
+	embeddingMode := AIBackendModeDisabled
+	switch {
+	case !embEnabled:
+		embeddingMode = AIBackendModeDisabled
+	case embBaseURL != "":
+		embeddingMode = AIBackendModeLocal
+	case apiKey != "":
+		embeddingMode = AIBackendModeOpenAI
+	}
+
+	// Derive LLM mode (mirrors Config.EffectiveLLMMode).
+	llmMode := AIBackendModeDisabled
+	if apiKey != "" && (enableAIParsing || llmEnabled) {
+		llmMode = AIBackendModeOpenAI
+	}
+
+	aiBackend := map[string]any{
+		"embedding_mode": embeddingMode,
+		"llm_mode":       llmMode,
+	}
+	// When a local embedding backend was configured via the legacy
+	// embedding.base_url field, carry those coordinates onto the new fields so a
+	// future explicit toggle (or the local register branch) has them. Safe to
+	// mutate: we're building a fresh map, not the shared AppConfig.
+	if embBaseURL != "" {
+		aiBackend["local_base_url"] = embBaseURL
+		if embModel != "" {
+			aiBackend["local_embedding_model"] = embModel
+		}
+	}
+	raw["ai_backend"] = aiBackend
+
 	migrated, err := json.Marshal(raw)
 	if err != nil {
 		return blob, false
@@ -609,6 +698,17 @@ func LoadConfigFromDatabase(store database.SettingsStore) error {
 			blobStr = migrated
 			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
 				slog.Warn("config: failed to persist migrated metadata_scoring blob", "err", saveErr)
+			}
+		}
+
+		// Derive the nested ai_backend object (backend-mode toggle) from the
+		// legacy AI signal fields (idempotent). Runs after the metadata_scoring
+		// migration so metadata_scoring.llm_enabled is in nested shape.
+		if migrated, changed := migrateAIBackendBlob(blobStr); changed {
+			slog.Info("config: derived ai_backend modes from legacy fields")
+			blobStr = migrated
+			if saveErr := saveRawBlob(store, migrated); saveErr != nil {
+				slog.Warn("config: failed to persist migrated ai_backend blob", "err", saveErr)
 			}
 		}
 

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence_test.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package config
 
@@ -1246,4 +1246,78 @@ func TestRemapAutoUpdateKeys_NoFlatKeys(t *testing.T) {
 	payload := map[string]any{"root_dir": "/data"}
 	result := applyLegacyRemaps(payload)
 	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
+}
+
+// TestMigrateAIBackend_LocalFromBaseURL: a nested embedding.base_url signals a
+// local embedding backend; embedding_mode derives to "local" and the local
+// coordinates are carried over.
+func TestMigrateAIBackend_LocalFromBaseURL(t *testing.T) {
+	blob := `{
+		"openai_api_key": "sk-x",
+		"enable_ai_parsing": true,
+		"embedding": {"enabled": true, "base_url": "http://192.168.0.20:11434/v1", "model": "bge-m3"}
+	}`
+	migrated, changed := migrateAIBackendBlob(blob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	ab, ok := result["ai_backend"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, AIBackendModeLocal, ab["embedding_mode"])
+	assert.Equal(t, AIBackendModeOpenAI, ab["llm_mode"]) // key + enable_ai_parsing
+	assert.Equal(t, "http://192.168.0.20:11434/v1", ab["local_base_url"])
+	assert.Equal(t, "bge-m3", ab["local_embedding_model"])
+}
+
+// TestMigrateAIBackend_OpenAIFromKey: a key with no embedding base_url derives
+// embedding_mode "openai"; llm_mode "openai" via enable_ai_parsing.
+func TestMigrateAIBackend_OpenAIFromKey(t *testing.T) {
+	blob := `{
+		"openai_api_key": "sk-x",
+		"enable_ai_parsing": true,
+		"embedding": {"enabled": true}
+	}`
+	migrated, changed := migrateAIBackendBlob(blob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	ab := result["ai_backend"].(map[string]any)
+	assert.Equal(t, AIBackendModeOpenAI, ab["embedding_mode"])
+	assert.Equal(t, AIBackendModeOpenAI, ab["llm_mode"])
+	assert.NotContains(t, ab, "local_base_url") // no local backend configured
+}
+
+// TestMigrateAIBackend_DisabledWhenNoSignals: an embedding block present but
+// disabled and no key derives both modes to "disabled".
+func TestMigrateAIBackend_DisabledWhenNoSignals(t *testing.T) {
+	blob := `{
+		"embedding": {"enabled": false},
+		"metadata_scoring": {"llm_enabled": false}
+	}`
+	migrated, changed := migrateAIBackendBlob(blob)
+	require.True(t, changed)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(migrated), &result))
+	ab := result["ai_backend"].(map[string]any)
+	assert.Equal(t, AIBackendModeDisabled, ab["embedding_mode"])
+	assert.Equal(t, AIBackendModeDisabled, ab["llm_mode"])
+}
+
+// TestMigrateAIBackend_Idempotent: once ai_backend exists, re-running is a
+// no-op; and a blob with no AI signal fields is left untouched.
+func TestMigrateAIBackend_Idempotent(t *testing.T) {
+	// Already migrated.
+	_, changed := migrateAIBackendBlob(`{"ai_backend": {"embedding_mode": "openai"}}`)
+	assert.False(t, changed)
+
+	// A first migration followed by a second returns changed=false.
+	blob := `{"openai_api_key": "sk-x", "embedding": {"enabled": true}}`
+	migrated, changed := migrateAIBackendBlob(blob)
+	require.True(t, changed)
+	_, changed2 := migrateAIBackendBlob(migrated)
+	assert.False(t, changed2)
+
+	// No AI signal fields at all -> untouched.
+	_, changed3 := migrateAIBackendBlob(`{"root_dir": "/data"}`)
+	assert.False(t, changed3)
 }

--- a/internal/dedup/embed_async_gate_test.go
+++ b/internal/dedup/embed_async_gate_test.go
@@ -1,0 +1,40 @@
+// file: internal/dedup/embed_async_gate_test.go
+// version: 1.0.0
+// last-edited: 2026-07-03
+
+package dedup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/ai"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+)
+
+// TestEmbedBooksAsync_HardGatedToOpenAI locks TOGGLE-2: the OpenAI Batch API
+// path must reject any non-openai effective embedding mode with
+// ai.ErrBatchUnsupported, so a local/disabled backend never submits a batch.
+func TestEmbedBooksAsync_HardGatedToOpenAI(t *testing.T) {
+	engine, _, _ := setupTestEngine(t)
+	// A client must exist so the gate (not the nil-client guard) is what fires.
+	engine.embedClient = ai.NewEmbeddingClientWithOptions("ollama", "bge-m3", "http://192.168.0.20:11434/v1")
+
+	saved := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = saved })
+
+	for _, mode := range []string{
+		config.AIBackendModeLocal,
+		config.AIBackendModeDisabled,
+		config.AIBackendModeOpenAIFallbackLocal,
+	} {
+		config.AppConfig = config.Config{}
+		config.AppConfig.AIBackend.EmbeddingMode = mode
+
+		_, _, err := engine.EmbedBooksAsync(context.Background())
+		if !errors.Is(err, ai.ErrBatchUnsupported) {
+			t.Errorf("mode %q: EmbedBooksAsync err = %v, want ai.ErrBatchUnsupported", mode, err)
+		}
+	}
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -2308,6 +2308,14 @@ func (de *Engine) EmbedBooksAsync(ctx context.Context) (batchID string, count in
 	if de.embedClient == nil {
 		return "", 0, fmt.Errorf("no embedding client configured")
 	}
+	// Hard-gate the OpenAI Batch API to openai-only embedding modes (TOGGLE-2).
+	// Local (Ollama) and disabled backends have no batch endpoint; a local
+	// backend would otherwise submit to OpenAI's Batch API with a dummy key.
+	// openai-fallback-local is intentionally also blocked — the Batch API has no
+	// fallback path. Callers should downgrade to the synchronous per-book path.
+	if mode := config.AppConfig.EffectiveEmbeddingMode(); mode != config.AIBackendModeOpenAI {
+		return "", 0, fmt.Errorf("%w (mode=%s)", ai.ErrBatchUnsupported, mode)
+	}
 
 	books, err := de.getAllBooks()
 	if err != nil {

--- a/internal/plugins/dedup/embed_scan.go
+++ b/internal/plugins/dedup/embed_scan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/embed_scan.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: e2f3a4b5-c6d7-8901-bcde-f12345678901
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 // T018: embed_scan.go is the canonical implementation for both
 // dedup.embed-scan (sync) and dedup.embed-async (async/batch API).
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -68,6 +69,18 @@ func (p *Plugin) runEmbedScan(ctx context.Context, raw json.RawMessage, reporter
 func (p *Plugin) runEmbedScanMode(ctx context.Context, async bool, reporter sdk.Reporter) error {
 	if p.engine == nil {
 		return errors.New("dedup engine not available (embedding may be disabled or API key not configured)")
+	}
+
+	// The OpenAI Batch API path is openai-only (TOGGLE-2). Under a local or
+	// disabled embedding backend, EmbedBooksAsync returns ai.ErrBatchUnsupported;
+	// downgrade to the synchronous per-book path here so the op still makes
+	// progress instead of erroring out.
+	if async {
+		if mode := config.AppConfig.EffectiveEmbeddingMode(); mode != config.AIBackendModeOpenAI {
+			reporter.Logger().Warn("dedup embed-scan: async batch requested but effective embedding backend is not openai — downgrading to synchronous embedding",
+				"mode", mode)
+			async = false
+		}
 	}
 
 	if async {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,5 @@
 // file: internal/server/server.go
-// version: 2.33.0
+// version: 2.34.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
 // last-edited: 2026-07-03
 
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 
-	"log"
 	"errors"
+	"log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -622,15 +622,24 @@ func NewServer(store database.Store) *Server {
 			server.hnswPersistDir = filepath.Join(filepath.Dir(config.AppConfig.DatabasePath), "hnsw")
 		}
 
-		// Gate embedding client on Ollama availability. The tool-registry check
-		// is a binary-on-PATH probe (exec.LookPath), which fails when Ollama runs
-		// as a system service / container the app can't see on PATH — even though
-		// its HTTP endpoint is reachable. So when an operator has EXPLICITLY
-		// configured an embedding base_url (an assertion that the endpoint exists,
-		// e.g. http://127.0.0.1:11434/v1 for local Ollama), trust it rather than
-		// let the missing binary block all embeds.
+		// Gate embedding client on Ollama availability. The old check was a
+		// binary-on-PATH probe (exec.LookPath) OR-ed with "a base_url is
+		// configured" (trust-without-verify). Both are unreliable: LookPath
+		// fails when Ollama runs as a service/container off PATH, and trusting a
+		// configured URL marks a down endpoint as available. Replace with an
+		// actual HTTP probe against the local endpoint's /api/tags. Fall back to
+		// the legacy Embedding.BaseURL when AIBackend.LocalBaseURL is empty (the
+		// migration-not-yet-applied case), and keep the LookPath signal as a
+		// secondary yes-vote for managed on-PATH installs.
 		if server.embedClient != nil {
-			ollamaOK := server.toolRegistry.Available("ollama") || config.AppConfig.Embedding.BaseURL != ""
+			localBaseURL := config.AppConfig.AIBackend.LocalBaseURL
+			if localBaseURL == "" {
+				localBaseURL = config.AppConfig.Embedding.BaseURL
+			}
+			ollamaOK := server.toolRegistry.Available("ollama")
+			if !ollamaOK && localBaseURL != "" {
+				ollamaOK = ai.ProbeOllamaAvailable(context.Background(), localBaseURL, 2*time.Second)
+			}
 			server.embedClient.SetOllamaAvailable(ollamaOK)
 			metrics.SetBackendAvailable("ollama", ollamaOK)
 		}


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-10** (wave 3, Opus): the backend-mode toggle core. One config block now controls which backend serves embeddings and LLM parsing:

- `AIBackendConfig` with modes `disabled | openai | local | openai-fallback-local`, per-capability effective-mode resolvers (pure functions), viper env bindings, and a legacy-field migration (`migrateAIBackendBlob`) so existing configs derive the right mode automatically
- `NewOpenAIParserWithBaseURL` — local LLM backends get their own base URL + model, never `OPENAI_BASE_URL`
- Ollama availability probe (`/api/tags`, 2s timeout) at startup + inline re-probe before `EmbedBatch`; `localOllamaOK` is now an `atomic.Bool`
- `EmbedBooksAsync` hard-gated to the OpenAI Batch API (`ErrBatchUnsupported` otherwise); `dedup.embed-scan` async path downgrades to sync with a warning under local modes
- `Embedding.Enabled` preserved as the master off-switch — no silent regression
- All committed defaults/docs/tests use `192.168.0.20` placeholders (verified: zero `172.16.*` in the diff)

## Test plan

- [x] New tests: mode resolvers (purity asserted), migration, base-URL parser, batch hard-gate — all green under `-race`
- [x] Full changed-package suites (`config`, `ai`, `dedup`, `plugins/dedup`) green; vet + gofmt clean
- [ ] Local honest gate (queued)
- [ ] Minimal CI green

Deferred follow-up: background TTL re-probe poller (inline single re-probe shipped per brief's allowance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1