### PR TITLE
ci: bump github-common pin — go test -timeout 30m (kills CI 10m-timeout flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.4
+# version: 3.0.5
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-07-01
+# last-edited: 2026-07-03
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -28,7 +28,7 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
+    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/frontend-ci.yml
-# version: 2.9.2
+# version: 2.9.3
 # guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
-# last-edited: 2026-05-01
+# last-edited: 2026-07-03
 
 name: Frontend CI
 
@@ -51,7 +51,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/nightly.yml
-# version: 1.0.2
+# version: 1.0.3
 # guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-# last-edited: 2026-05-01
+# last-edited: 2026-07-03
 
 # Nightly full CI: property tests, coverage check, E2E, staticcheck.
 # Runs the complete reusable-ci.yml suite on a schedule.
@@ -28,7 +28,7 @@ permissions:
 jobs:
   full-ci:
     name: Full CI Suite
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v1.12.1
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.9.3
+# version: 2.9.4
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-# last-edited: 2026-06-09
+# last-edited: 2026-07-03
 
 name: Prerelease on Merge
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v2.13.4
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # v2.13.4
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.8.2
+# version: 4.8.3
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-# last-edited: 2026-06-09
+# last-edited: 2026-07-03
 
 name: Production Release
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f602707c96a8c979ecb9d2f4b0b95874673b2392 # v2.13.4
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # v2.13.4
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false


### PR DESCRIPTION
## Summary

Bumps all 5 `falkcorp/github-common` SHA pins from v1.12.1 (`f602707c`) to current main (`1dec34cd`). Picks up:

- `07aa2e7` — `go test -short -race -timeout 30m` in reusable-ci-minimal: kills the recurring `panic: test timed out after 10m0s` on internal/server (2 wave-1 re-runs + today's #1774 failure; the commit was written for this repo and the pin bump never landed)
- `6694e50` — `submodules: recursive` on checkout steps

Files: ci.yml, frontend-ci.yml, release-prod.yml, nightly.yml, prerelease.yml (pin + version header only).

## Test plan

- [ ] Minimal CI green on this PR (runs the new pin itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6EXHA1