### PR TITLE
fix(registry,server): ordered registry teardown + closed-store guards; latent deluge nil-deref

### DIFF
--- a/internal/database/pebble_ops_v2_closed_test.go
+++ b/internal/database/pebble_ops_v2_closed_test.go
@@ -1,48 +1,129 @@
 // file: internal/database/pebble_ops_v2_closed_test.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 9e4b2c17-5a6d-4f38-8c01-7d2e9f4a6b53
 // last-edited: 2026-07-03
 
 // pebble_ops_v2_closed_test.go covers the PEBBLE-CLOSED-SWEEPTICK-RESIDUAL
-// defense-in-depth guard: ListWaitingDepsOps on a closed PebbleStore must
+// defense-in-depth guard: every opv2 read/write on a closed PebbleStore must
 // return an error instead of propagating pebble's ErrClosed PANIC out of
-// NewIter and crashing the process. This is the read the DepsScheduler sweep
-// ticker performs on a periodic goroutine; a registry torn down without
+// Get/Set/NewIter/Commit and crashing the process. The op registry drives
+// these accesses from background goroutines (deps sweep ticker, dispatcher
+// cycle, dbReporter progress/log flushes); a registry torn down without
 // Shutdown (as internal/server test leaks can do) otherwise kills the whole
-// test binary minutes later.
+// test binary minutes later. Observed legs: ListWaitingDepsOps (sweep),
+// ListQueuedOperationsV2 (dispatcher), UpdateOpProgressV2 (dbReporter
+// flushProgressLazy).
 package database
 
 import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	ulid "github.com/oklog/ulid/v2"
 )
 
-func TestListWaitingDepsOps_ClosedStoreReturnsError(t *testing.T) {
+// openClosedOpsStore opens a fresh PebbleStore and immediately closes it,
+// returning the closed store for post-Close access tests.
+func openClosedOpsStore(t *testing.T) *PebbleStore {
+	t.Helper()
 	tmpdir := "/tmp/test_pebble_" + ulid.Make().String()
 	store, err := NewPebbleStore(tmpdir)
 	if err != nil {
 		t.Fatalf("NewPebbleStore: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
+	t.Cleanup(func() { os.RemoveAll(tmpdir) })
 	store.WaitForWarmup()
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+	return store
+}
+
+// requireClosedErr asserts the call surfaced pebble.ErrClosed as an error.
+func requireClosedErr(t *testing.T, op string, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected error on closed store, got nil", op)
+	}
+	if !errors.Is(err, pebble.ErrClosed) {
+		t.Fatalf("%s: expected error wrapping pebble.ErrClosed, got: %v", op, err)
+	}
+}
+
+func TestListWaitingDepsOps_ClosedStoreReturnsError(t *testing.T) {
+	store := openClosedOpsStore(t)
 
 	// Pre-guard this panicked "pebble: closed" (pebble panics ErrClosed from
 	// NewIter rather than returning it); post-guard it must be an error.
 	rows, err := store.ListWaitingDepsOps()
-	if err == nil {
-		t.Fatalf("expected error from ListWaitingDepsOps on closed store, got rows=%v", rows)
-	}
-	if !errors.Is(err, pebble.ErrClosed) {
-		t.Fatalf("expected error wrapping pebble.ErrClosed, got: %v", err)
-	}
+	requireClosedErr(t, "ListWaitingDepsOps", err)
 	if rows != nil {
 		t.Fatalf("expected nil rows on closed store, got %v", rows)
 	}
+}
+
+// TestOpsV2ClosedStore_AllPathsReturnErrors sweeps every opv2 access the op
+// registry's background goroutines can make after a leaked teardown. Each call
+// pre-guard PANICS the whole binary; post-guard each must return an error
+// wrapping pebble.ErrClosed.
+func TestOpsV2ClosedStore_AllPathsReturnErrors(t *testing.T) {
+	store := openClosedOpsStore(t)
+	now := time.Now().UTC()
+
+	// The observed third leg: dbReporter.flushProgressLazy → UpdateOpProgressV2
+	// → pebbleGetJSON → p.db.Get on the closed store.
+	requireClosedErr(t, "UpdateOpProgressV2", store.UpdateOpProgressV2("op-1", 1, 10, "msg"))
+
+	_, err := store.ListQueuedOperationsV2()
+	requireClosedErr(t, "ListQueuedOperationsV2", err)
+
+	requireClosedErr(t, "InsertOperationV2",
+		store.InsertOperationV2(OperationV2Row{ID: "op-1", Status: "queued", QueuedAt: now}))
+	requireClosedErr(t, "UpdateOperationV2Status",
+		store.UpdateOperationV2Status("op-1", "running", &now, nil, nil))
+	_, err = store.SetOperationV2StatusIfQueued("op-1", "running")
+	requireClosedErr(t, "SetOperationV2StatusIfQueued", err)
+	_, err = store.ListActiveOperationsV2()
+	requireClosedErr(t, "ListActiveOperationsV2", err)
+	_, err = store.GetOperationV2("op-1")
+	requireClosedErr(t, "GetOperationV2", err)
+	requireClosedErr(t, "IncrementResumeCountV2", store.IncrementResumeCountV2("op-1"))
+	requireClosedErr(t, "UpdateOpPhaseV2", store.UpdateOpPhaseV2("op-1", nil))
+	requireClosedErr(t, "UpdateOpCheckpointV2", store.UpdateOpCheckpointV2("op-1", 5))
+	requireClosedErr(t, "UpsertOpStateV2", store.UpsertOpStateV2(OpStateV2Row{OperationID: "op-1"}))
+	_, err = store.GetOpStateV2("op-1")
+	requireClosedErr(t, "GetOpStateV2", err)
+	requireClosedErr(t, "DeleteOpStateV2", store.DeleteOpStateV2("op-1"))
+	requireClosedErr(t, "UpdateOperationV2Params", store.UpdateOperationV2Params("op-1", []byte("{}")))
+	requireClosedErr(t, "AppendOpLogsV2",
+		store.AppendOpLogsV2([]OpLogV2Row{{OperationID: "op-1", CreatedAt: now}}))
+	requireClosedErr(t, "InsertOpErrorV2",
+		store.InsertOpErrorV2(OpErrorV2Row{OperationID: "op-1", OccurredAt: now}))
+	requireClosedErr(t, "InsertOpStrikeV2",
+		store.InsertOpStrikeV2(OpStrikeV2Row{DefID: "d", OperationID: "op-1", OccurredAt: now}))
+	_, err = store.ListOperationsV2Since(now.Add(-time.Hour), 10)
+	requireClosedErr(t, "ListOperationsV2Since", err)
+	_, err = store.GetOpLogsV2("op-1", 10)
+	requireClosedErr(t, "GetOpLogsV2", err)
+	requireClosedErr(t, "UpsertOpDefinitionV2", store.UpsertOpDefinitionV2(OpDefinitionV2Row{ID: "d"}))
+	requireClosedErr(t, "DeleteOrphanOpDefsV2", store.DeleteOrphanOpDefsV2(nil))
+
+	sub := OpSubject{Type: "book", ID: "b1"}
+	_, err = store.GetDepRev(sub)
+	requireClosedErr(t, "GetDepRev", err)
+	_, err = store.BumpDepRev(sub)
+	requireClosedErr(t, "BumpDepRev", err)
+	requireClosedErr(t, "RecordOpCompletion", store.RecordOpCompletion(sub, "scan", "", 1))
+	_, _, err = store.GetOpCompletion(sub, "scan")
+	requireClosedErr(t, "GetOpCompletion", err)
+	_, err = store.ListFileCompletions(sub, "scan")
+	requireClosedErr(t, "ListFileCompletions", err)
+	requireClosedErr(t, "PromoteToQueued", store.PromoteToQueued("op-1"))
+	requireClosedErr(t, "AddToBatchBucket", store.AddToBatchBucket("scan", sub))
+	_, err = store.ListBatchBucket("scan")
+	requireClosedErr(t, "ListBatchBucket", err)
+	requireClosedErr(t, "ClearBatchBucket", store.ClearBatchBucket("scan", []OpSubject{sub}))
 }

--- a/internal/database/pebble_store_ops_v2.go
+++ b/internal/database/pebble_store_ops_v2.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_ops_v2.go
-// version: 3.7.0
+// version: 3.8.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-07-03
 
@@ -69,7 +69,10 @@ func opv2StrikeKey(defID string, ts time.Time, opID string) []byte {
 }
 
 // pebbleGet reads a single key and JSON-decodes into dst. Returns nil, nil if not found.
-func (p *PebbleStore) pebbleGetJSON(key []byte, dst any) error {
+// Guarded by recoverPebbleClosed (see its doc): every opv2 method funneling
+// through this helper returns pebble.ErrClosed as an error instead of panicking.
+func (p *PebbleStore) pebbleGetJSON(key []byte, dst any) (err error) {
+	defer recoverPebbleClosed("pebbleGetJSON", &err)
 	val, closer, err := p.db.Get(key)
 	if errors.Is(err, pebble.ErrNotFound) {
 		return nil
@@ -81,7 +84,9 @@ func (p *PebbleStore) pebbleGetJSON(key []byte, dst any) error {
 	return json.Unmarshal(val, dst)
 }
 
-func (p *PebbleStore) pebbleSetJSON(key []byte, src any) error {
+// pebbleSetJSON JSON-encodes src and writes it at key. Guarded like pebbleGetJSON.
+func (p *PebbleStore) pebbleSetJSON(key []byte, src any) (err error) {
+	defer recoverPebbleClosed("pebbleSetJSON", &err)
 	data, err := json.Marshal(src)
 	if err != nil {
 		return err
@@ -95,7 +100,8 @@ func (p *PebbleStore) UpsertOpDefinitionV2(row OpDefinitionV2Row) error {
 }
 
 // DeleteOrphanOpDefsV2 removes definition rows whose ID is not in keepIDs.
-func (p *PebbleStore) DeleteOrphanOpDefsV2(keepIDs []string) error {
+func (p *PebbleStore) DeleteOrphanOpDefsV2(keepIDs []string) (err error) {
+	defer recoverPebbleClosed("DeleteOrphanOpDefsV2", &err)
 	keep := make(map[string]bool, len(keepIDs))
 	for _, id := range keepIDs {
 		keep[id] = true
@@ -134,7 +140,8 @@ func (p *PebbleStore) DeleteOrphanOpDefsV2(keepIDs []string) error {
 }
 
 // InsertOperationV2 inserts a new queued operation row and adds it to the queue index.
-func (p *PebbleStore) InsertOperationV2(row OperationV2Row) error {
+func (p *PebbleStore) InsertOperationV2(row OperationV2Row) (err error) {
+	defer recoverPebbleClosed("InsertOperationV2", &err)
 	if err := p.pebbleSetJSON(opv2OpKey(row.ID), &row); err != nil {
 		return err
 	}
@@ -214,7 +221,8 @@ func (p *PebbleStore) GetOperationV2(id string) (*OperationV2Row, error) {
 // order made the window trivially easy to hit under load). Making the row
 // update and the index maintenance atomic means readers never observe the
 // index and the row disagreeing.
-func (p *PebbleStore) UpdateOperationV2Status(id, status string, startedAt, completedAt *time.Time, errMsg *string) error {
+func (p *PebbleStore) UpdateOperationV2Status(id, status string, startedAt, completedAt *time.Time, errMsg *string) (err error) {
+	defer recoverPebbleClosed("UpdateOperationV2Status", &err)
 	p.opsMu.Lock()
 	defer p.opsMu.Unlock()
 
@@ -280,7 +288,8 @@ func (p *PebbleStore) UpdateOperationV2Status(id, status string, startedAt, comp
 // UpdateOperationV2Status: separate writes let a concurrent
 // ListActiveOperationsV2 scan observe a row whose status no longer matches
 // its active-index membership.
-func (p *PebbleStore) SetOperationV2StatusIfQueued(id, newStatus string) (bool, error) {
+func (p *PebbleStore) SetOperationV2StatusIfQueued(id, newStatus string) (updated bool, err error) {
+	defer recoverPebbleClosed("SetOperationV2StatusIfQueued", &err)
 	p.opsMu.Lock()
 	defer p.opsMu.Unlock()
 
@@ -318,7 +327,8 @@ func (p *PebbleStore) SetOperationV2StatusIfQueued(id, newStatus string) (bool, 
 }
 
 // ListActiveOperationsV2 returns ops with status 'queued' or 'running'.
-func (p *PebbleStore) ListActiveOperationsV2() ([]OperationV2Row, error) {
+func (p *PebbleStore) ListActiveOperationsV2() (rows []OperationV2Row, err error) {
+	defer recoverPebbleClosed("ListActiveOperationsV2", &err)
 	prefix := []byte("opv2:act:")
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
@@ -434,7 +444,8 @@ func (p *PebbleStore) GetOpStateV2(opID string) (*OpStateV2Row, error) {
 }
 
 // DeleteOpStateV2 removes the state blob for an op.
-func (p *PebbleStore) DeleteOpStateV2(opID string) error {
+func (p *PebbleStore) DeleteOpStateV2(opID string) (err error) {
+	defer recoverPebbleClosed("DeleteOpStateV2", &err)
 	return p.db.Delete(opv2StateKey(opID), pebble.Sync)
 }
 
@@ -455,7 +466,8 @@ func (p *PebbleStore) UpdateOperationV2Params(id string, params []byte) error {
 }
 
 // AppendOpLogsV2 bulk-inserts log rows.
-func (p *PebbleStore) AppendOpLogsV2(rows []OpLogV2Row) error {
+func (p *PebbleStore) AppendOpLogsV2(rows []OpLogV2Row) (err error) {
+	defer recoverPebbleClosed("AppendOpLogsV2", &err)
 	if len(rows) == 0 {
 		return nil
 	}
@@ -487,7 +499,8 @@ func (p *PebbleStore) InsertOpStrikeV2(row OpStrikeV2Row) error {
 
 // ListOperationsV2Since returns operations queued at or after `since`, ordered
 // by started_at DESC NULLS LAST, queued_at DESC, up to `limit` rows.
-func (p *PebbleStore) ListOperationsV2Since(since time.Time, limit int) ([]OperationV2Row, error) {
+func (p *PebbleStore) ListOperationsV2Since(since time.Time, limit int) (rows []OperationV2Row, err error) {
+	defer recoverPebbleClosed("ListOperationsV2Since", &err)
 	if limit <= 0 {
 		limit = 200
 	}
@@ -541,7 +554,8 @@ func (p *PebbleStore) ListOperationsV2Since(since time.Time, limit int) ([]Opera
 
 // GetOpLogsV2 returns up to `limit` log lines for the given operation, ordered by created_at ASC.
 // A limit ≤ 0 returns all rows.
-func (p *PebbleStore) GetOpLogsV2(opID string, limit int) ([]OpLogV2Row, error) {
+func (p *PebbleStore) GetOpLogsV2(opID string, limit int) (rows []OpLogV2Row, err error) {
+	defer recoverPebbleClosed("GetOpLogsV2", &err)
 	prefix := []byte("opv2:log:" + opID + ":")
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
@@ -634,7 +648,8 @@ func (p *PebbleStore) RecordOpCompletion(sub OpSubject, opType, fileID string, d
 // Returns (rev, true, nil) when found, (0, false, nil) when absent.
 // Uses a direct key-existence check (not the zero-value sentinel from pebbleGetJSON)
 // so that rev=0 completions (recorded before any BumpDepRev) are correctly found.
-func (p *PebbleStore) GetOpCompletion(sub OpSubject, opType string) (uint64, bool, error) {
+func (p *PebbleStore) GetOpCompletion(sub OpSubject, opType string) (rev uint64, found bool, err error) {
+	defer recoverPebbleClosed("GetOpCompletion", &err)
 	val, closer, err := p.db.Get(completionKey(sub, opType, ""))
 	if errors.Is(err, pebble.ErrNotFound) {
 		return 0, false, nil
@@ -652,7 +667,8 @@ func (p *PebbleStore) GetOpCompletion(sub OpSubject, opType string) (uint64, boo
 
 // ListFileCompletions returns a map of fileID→depRev for all per-file completion
 // records for opType on sub.
-func (p *PebbleStore) ListFileCompletions(sub OpSubject, opType string) (map[string]uint64, error) {
+func (p *PebbleStore) ListFileCompletions(sub OpSubject, opType string) (res map[string]uint64, err error) {
+	defer recoverPebbleClosed("ListFileCompletions", &err)
 	// Per-file keys have the form: op:completion:<type>:<id>:<opType>:<fileID>
 	// The book-level key (no fileID suffix) must be excluded.
 	bookLevelKey := string(completionKey(sub, opType, ""))
@@ -685,16 +701,20 @@ func (p *PebbleStore) ListFileCompletions(sub OpSubject, opType string) (map[str
 	return result, nil
 }
 
-// recoverPebbleClosed is a deferred guard for the ops-v2 reads that registry
-// background goroutines (DepsScheduler sweep ticker, dispatcher cycle) perform
-// on periodic tickers. If a registry is torn down without Shutdown (or a read
-// races a Close in a way the registry-side drain cannot see), pebble PANICS
-// ErrClosed from NewIter / iteration instead of returning an error, killing
-// the whole process (PEBBLE-CLOSED-SWEEPTICK-RESIDUAL). Recover ONLY that
-// sentinel (errors.Is(pebble.ErrClosed)) and surface it as an error — both
-// callers already log-and-skip on error. Any other panic is re-raised so real
-// bugs are not masked. Precedent: HNSWEmbeddingStore.safeAdd (commit 5b90d2f6)
-// containing library panics at the store boundary.
+// recoverPebbleClosed is a deferred guard applied to EVERY opv2 read/write in
+// this file (via the shared pebbleGetJSON/pebbleSetJSON helpers plus each
+// method that touches p.db or a batch directly). The op registry drives these
+// accesses from background goroutines — the DepsScheduler sweep ticker, the
+// dispatcher's 100ms cycle, dbReporter progress/log flushes, worker status
+// writes. If a registry is torn down without Shutdown (or an access races a
+// Close in a way the registry-side drain cannot see), pebble PANICS ErrClosed
+// from Get/Set/NewIter/Commit instead of returning an error, killing the whole
+// process (PEBBLE-CLOSED-SWEEPTICK-RESIDUAL family; legs observed via
+// ListWaitingDepsOps, ListQueuedOperationsV2, and UpdateOpProgressV2). Recover
+// ONLY that sentinel (errors.Is(pebble.ErrClosed)) and surface it as an
+// error — all registry callers already log-and-skip on error. Any other panic
+// is re-raised so real bugs are not masked. Precedent: HNSWEmbeddingStore
+// safeAdd (commit 5b90d2f6) containing library panics at the store boundary.
 func recoverPebbleClosed(op string, errp *error) {
 	if rec := recover(); rec != nil {
 		recErr, ok := rec.(error)
@@ -745,7 +765,8 @@ func (p *PebbleStore) ListWaitingDepsOps() (rows []OperationV2Row, err error) {
 //
 // Returns an error if the op does not exist or its current status is not
 // "waiting_deps".
-func (p *PebbleStore) PromoteToQueued(id string) error {
+func (p *PebbleStore) PromoteToQueued(id string) (err error) {
+	defer recoverPebbleClosed("PromoteToQueued", &err)
 	p.opsMu.Lock()
 	defer p.opsMu.Unlock()
 
@@ -796,7 +817,8 @@ func batchBucketPrefix(opType string) []byte {
 
 // AddToBatchBucket adds sub to the persistent pending bucket for opType.
 // Idempotent: if an entry already exists the call is a no-op (preserving AddedAt).
-func (p *PebbleStore) AddToBatchBucket(opType string, sub OpSubject) error {
+func (p *PebbleStore) AddToBatchBucket(opType string, sub OpSubject) (err error) {
+	defer recoverPebbleClosed("AddToBatchBucket", &err)
 	key := batchBucketKey(opType, sub)
 	// Check for existing entry to preserve AddedAt.
 	_, closer, err := p.db.Get(key)
@@ -821,7 +843,8 @@ func (p *PebbleStore) AddToBatchBucket(opType string, sub OpSubject) error {
 
 // ListBatchBucket returns all pending subjects for opType.
 // Returns an empty slice (not an error) when no bucket exists.
-func (p *PebbleStore) ListBatchBucket(opType string) ([]BatchBucketEntry, error) {
+func (p *PebbleStore) ListBatchBucket(opType string) (entries []BatchBucketEntry, err error) {
+	defer recoverPebbleClosed("ListBatchBucket", &err)
 	prefix := batchBucketPrefix(opType)
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
@@ -845,7 +868,8 @@ func (p *PebbleStore) ListBatchBucket(opType string) ([]BatchBucketEntry, error)
 
 // ClearBatchBucket removes the given subjects from the bucket for opType.
 // Subjects not present in the bucket are silently skipped.
-func (p *PebbleStore) ClearBatchBucket(opType string, subs []OpSubject) error {
+func (p *PebbleStore) ClearBatchBucket(opType string, subs []OpSubject) (err error) {
+	defer recoverPebbleClosed("ClearBatchBucket", &err)
 	for _, sub := range subs {
 		if err := p.db.Delete(batchBucketKey(opType, sub), pebble.Sync); err != nil {
 			return err

--- a/internal/deluge/integration.go
+++ b/internal/deluge/integration.go
@@ -1,7 +1,7 @@
 // file: internal/deluge/integration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1234-ef01-345678901234
-// last-edited: 2026-05-11
+// last-edited: 2026-07-03
 //
 // Deluge integration for library centralization.
 //
@@ -64,6 +64,20 @@ func GetClient() *Client {
 	}
 	globalDelugeClient = c
 	return c
+}
+
+// ResetGlobalClientForTest clears the cached global client. Tests that set
+// DelugeWebURL (or the download_client deluge host) and then exercise a code
+// path that calls GetClient — e.g. NewServer, whose deluge-plugin Build does —
+// MUST defer this: GetClient caches the constructed client in a package-level
+// singleton, so restoring the config string alone leaks a live client into
+// every later test in the process (under `go test -count=N` this crossed the
+// iteration boundary and made MockStore-based server tests fail with
+// unexpected UpsertOpDefinitionV2 calls from the deluge plugin's RegisterOp).
+func ResetGlobalClientForTest() {
+	globalDelugeClientMu.Lock()
+	globalDelugeClient = nil
+	globalDelugeClientMu.Unlock()
 }
 
 // SetGlobalClientForTest replaces the global deluge client for testing.

--- a/internal/deluge/protected_paths.go
+++ b/internal/deluge/protected_paths.go
@@ -1,6 +1,7 @@
 // file: internal/deluge/protected_paths.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d5b8e2a1-3c9f-4076-b7d4-0e8a2c5f1b93
+// last-edited: 2026-07-03
 
 // Package deluge provides integration with the Deluge BitTorrent client.
 package deluge
@@ -82,6 +83,30 @@ func (c *ProtectedPathCache) refresh() {
 
 	// Re-check under write lock in case another goroutine refreshed first.
 	if time.Since(c.lastRefresh) <= protectedPathTTL {
+		return
+	}
+
+	// No Deluge client (deluge not configured): serve the static extraPaths
+	// only. NewServer explicitly builds this cache with a nil client in that
+	// case ("the cache still works for the static paths") — without this
+	// guard, c.client.ListTorrents() → Login() dereferences the nil receiver
+	// and every tag write's IsProtected pre-flight panics (500 on the update
+	// endpoints; latent in the test suite because a leaked deluge client
+	// singleton from an earlier test masked it until the leak was fixed).
+	if c.client == nil {
+		fresh := make([]string, 0, len(c.extraPaths))
+		seenStatic := make(map[string]struct{}, len(c.extraPaths))
+		for _, p := range c.extraPaths {
+			if p == "" {
+				continue
+			}
+			if _, dup := seenStatic[p]; !dup {
+				seenStatic[p] = struct{}{}
+				fresh = append(fresh, p)
+			}
+		}
+		c.paths = fresh
+		c.lastRefresh = time.Now()
 		return
 	}
 

--- a/internal/operations/registry/live_tracker.go
+++ b/internal/operations/registry/live_tracker.go
@@ -1,0 +1,77 @@
+// file: internal/operations/registry/live_tracker.go
+// version: 1.0.0
+// guid: 5f8a3d21-9c47-4e06-b1d2-8e6f0a4c7b39
+// last-edited: 2026-07-03
+
+// live_tracker.go tracks every Registry that has been Start()ed and not yet
+// Shutdown() so that a store owner can drain leaked registries BEFORE closing
+// the store.
+//
+// WHY: internal/testutil's SetupIntegration cleanup closes the PebbleStore,
+// but each test is individually responsible for deferring
+// opRegistry.Shutdown. Any test that forgets (or fails before registering the
+// defer) leaks a running registry whose background goroutines — the
+// DepsScheduler sweep ticker, the dispatcher's 100ms cycle, dbReporter
+// progress/log flushes — keep touching the store for the remainder of the
+// package run and panic "pebble: closed" minutes after that store closed
+// (PEBBLE-CLOSED-SWEEPTICK-RESIDUAL family). The tracker gives the store
+// owner an ordered-teardown seam: ShutdownAllForStore(ctx, store) before
+// store.Close().
+//
+// The map is keyed per Registry and matched per store, so concurrent tests
+// (each with its own store) only ever drain their own registries. In
+// production there is exactly one process-lifetime registry, so the tracker
+// is a single map entry and ShutdownAllForStore is never called.
+
+package registry
+
+import (
+	"context"
+	"sync"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+var (
+	liveRegistriesMu sync.Mutex
+	liveRegistries   = map[*Registry]struct{}{}
+)
+
+// trackLiveRegistry records r as running. Called from Registry.Start.
+func trackLiveRegistry(r *Registry) {
+	liveRegistriesMu.Lock()
+	liveRegistries[r] = struct{}{}
+	liveRegistriesMu.Unlock()
+}
+
+// untrackLiveRegistry removes r. Called (deferred) from Registry.Shutdown so
+// an already-drained registry is never re-drained by ShutdownAllForStore.
+func untrackLiveRegistry(r *Registry) {
+	liveRegistriesMu.Lock()
+	delete(liveRegistries, r)
+	liveRegistriesMu.Unlock()
+}
+
+// ShutdownAllForStore drains every live (Started, not yet Shutdown) Registry
+// whose backing store is exactly `store` (interface identity — the same
+// concrete pointer), and returns how many it drained. Store owners MUST call
+// this before closing the store when they cannot prove every registry using
+// it was shut down — most importantly internal/testutil's SetupIntegration
+// cleanup. Registry.Shutdown is idempotent, so racing a test's own deferred
+// Shutdown is safe; the tracker simply finds nothing left to drain.
+func ShutdownAllForStore(ctx context.Context, store database.OpsV2Store) int {
+	liveRegistriesMu.Lock()
+	var matched []*Registry
+	for r := range liveRegistries {
+		if r.store == store {
+			matched = append(matched, r)
+		}
+	}
+	liveRegistriesMu.Unlock()
+
+	for _, r := range matched {
+		r.logger.Warn("registry: draining leaked registry before store close (Shutdown was never called — fix the owning test)")
+		_ = r.Shutdown(ctx)
+	}
+	return len(matched)
+}

--- a/internal/operations/registry/live_tracker_test.go
+++ b/internal/operations/registry/live_tracker_test.go
@@ -1,0 +1,70 @@
+// file: internal/operations/registry/live_tracker_test.go
+// version: 1.0.0
+// guid: 7a1c4e92-3b6f-4d58-a0e7-5c8d2f9b1a46
+// last-edited: 2026-07-03
+
+// live_tracker_test.go covers ShutdownAllForStore — the ordered-teardown seam
+// internal/testutil's SetupIntegration cleanup uses to drain leaked op
+// registries (Started, never Shutdown) before closing their PebbleStore.
+package registry_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// TestShutdownAllForStore_DrainsLeakedRegistry simulates the exact
+// internal/server leak: a registry Started against a real PebbleStore whose
+// owning test never calls Shutdown. ShutdownAllForStore must find it (scoped
+// by store identity), drain it, and leave nothing for a second call.
+func TestShutdownAllForStore_DrainsLeakedRegistry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	store, cleanup := openTestPebbleStore(t)
+	defer cleanup()
+	otherStore, otherCleanup := openTestPebbleStore(t)
+
+	// Leaked registry on `store` — Started, never Shutdown by its "owner".
+	leaked := registry.NewWithOptions(store, logger, 2, registry.Options{
+		SweepInterval: 10 * time.Millisecond,
+	})
+	leaked.SetDepsScheduler(registry.NewDepsScheduler(leaked, &pebbleSchedulerStore{PebbleStore: store}))
+	leaked.Start(context.Background())
+
+	// A registry on a DIFFERENT store must NOT be drained (parallel tests each
+	// own their own store).
+	other := registry.NewWithOptions(otherStore, logger, 2, registry.Options{})
+	other.Start(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if n := registry.ShutdownAllForStore(ctx, store); n != 1 {
+		t.Fatalf("expected to drain exactly 1 leaked registry, drained %d", n)
+	}
+	// Idempotent: the drained registry deregistered itself.
+	if n := registry.ShutdownAllForStore(ctx, store); n != 0 {
+		t.Fatalf("expected 0 on second drain, got %d", n)
+	}
+
+	// The other store's registry is still live; its own drain finds it.
+	if n := registry.ShutdownAllForStore(ctx, otherStore); n != 1 {
+		t.Fatalf("expected to drain 1 registry on otherStore, drained %d", n)
+	}
+	otherCleanup()
+
+	// A registry shut down by its owner is not double-drained.
+	owned := registry.NewWithOptions(store, logger, 2, registry.Options{})
+	owned.Start(context.Background())
+	if err := owned.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if n := registry.ShutdownAllForStore(ctx, store); n != 0 {
+		t.Fatalf("expected 0 after owner Shutdown, got %d", n)
+	}
+}

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/registry.go
-// version: 3.4.0
+// version: 3.5.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
 // last-edited: 2026-07-03
 
@@ -289,6 +289,7 @@ func (r *Registry) SetPluginMaxConcurrent(plugin string, max int) {
 // to re-queue or drop ops that were in-flight at the last shutdown.
 func (r *Registry) Start(ctx context.Context) {
 	r.logger.Info("registry: starting", "workers", r.workers)
+	trackLiveRegistry(r)
 	// Clear the notify gate in case this Registry is being restarted after a
 	// prior Shutdown (Shutdown sets notifyStopped to reject late enrollments).
 	r.mu.Lock()
@@ -799,6 +800,9 @@ func (r *Registry) Def(id string) (OperationDef, bool) {
 // as interrupted per their ResumePolicy and returns.
 func (r *Registry) Shutdown(ctx context.Context) error {
 	r.logger.Info("registry: shutting down")
+	// Deregister from the live-registry tracker on return: once Shutdown has
+	// run, ShutdownAllForStore must not re-drain this registry.
+	defer untrackLiveRegistry(r)
 	// Flip the shutdown flag before canceling handles so the abandoned-run
 	// watchdog (in worker.go executeRun) refuses to spawn replacement
 	// workers. Without this, a replacement worker is born just as the

--- a/internal/server/deluge_integration_test.go
+++ b/internal/server/deluge_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/deluge_integration_test.go
-// version: 2.0.1
+// version: 2.1.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-05-11
+// last-edited: 2026-07-03
 //
 // Integration tests for Deluge notification helpers and HTTP handlers.
 // Service logic moved to internal/deluge/integration.go; tests updated to
@@ -147,7 +147,16 @@ func TestHandleDelugeStatus_Configured(t *testing.T) {
 
 	origURL := config.AppConfig.DelugeWebURL
 	config.AppConfig.DelugeWebURL = "http://localhost:8112"
-	defer func() { config.AppConfig.DelugeWebURL = origURL }()
+	defer func() {
+		config.AppConfig.DelugeWebURL = origURL
+		// NewServer's deluge-plugin Build calls deluge.GetClient() while the
+		// URL above is set, which CACHES a live client in the package-level
+		// singleton. Restoring the URL string alone leaks that client into
+		// every later test in the process (and across -count=N iterations),
+		// where it flips the deluge plugin live inside MockStore-based server
+		// tests → unexpected UpsertOpDefinitionV2 mock failures.
+		deluge.ResetGlobalClientForTest()
+	}()
 
 	srv := NewServer(store)
 

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -1,6 +1,7 @@
 // file: internal/server/library_list_warmer.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 7e8d9a0b-1c2d-3e4f-5a6b-7c8d9e0f1a2b
+// last-edited: 2026-07-03
 
 // Pre-warms svc.audiobookService.listCache by firing the queries the UI
 // is most likely to hit on first load — library page (first few pages,
@@ -11,7 +12,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -216,11 +216,18 @@ func (s *Server) warmAudiobookListCache() {
 			slog.Warn("library list warm-up: memdb not ready after 5 min, skipping")
 			return
 		}
-		time.Sleep(2 * time.Second)
+		select {
+		case <-s.bgCtx.Done():
+			return // server shutting down — never touch the store again
+		case <-time.After(2 * time.Second):
+		}
 	}
 
 	started := time.Now()
-	ctx := context.Background()
+	// Warm-up queries run under bgCtx so Stop()'s bgCancel aborts them
+	// before the store closes. context.Background() here let the warmer
+	// keep reading the store after Close (panic "pebble: closed").
+	ctx := s.bgCtx
 
 	// Each query mirrors what the UI sends on a fresh library-page load.
 	// Pagination keys are independent cache entries, so we warm a lot of
@@ -561,6 +568,13 @@ func (s *Server) warmAudiobookListCache() {
 		eagerQueries = nil
 	}
 	for i, q := range eagerQueries {
+		// Abort between queries once shutdown begins — the store is about
+		// to close and any further read panics "pebble: closed".
+		if ctx.Err() != nil {
+			slog.Info("library list warm-up eager: aborting, server shutting down",
+				"completed", i, "remaining", len(eagerQueries)-i)
+			return
+		}
 		// Heap-pressure guard BETWEEN eager queries (skip for i==0;
 		// already covered by the pre-flight check above).
 		if i > 0 {
@@ -599,9 +613,18 @@ func (s *Server) warmAudiobookListCache() {
 	)
 
 	// Kick off the trickle warmer in its own goroutine so the startup
-	// path returns immediately. Trickle owns its own lifetime (runs
-	// until backlog drained, then exits).
-	go s.runTrickleWarmer(trickleQueries)
+	// path returns immediately. Trickle owns its own lifetime (runs until
+	// the backlog drains or bgCtx is canceled). Enrolled in bgWG — this
+	// goroutine runs ~30 min at the default 10s interval and, when it was
+	// fire-and-forget, outlived test servers and panicked "pebble: closed"
+	// against their closed stores. The Add happens while the parent
+	// warmer's own bgWG entry is still held, so it can never race a
+	// completed bgWG.Wait in Stop().
+	s.bgWG.Add("library-list-trickle-warmer")
+	go func() {
+		defer s.bgWG.Done("library-list-trickle-warmer")
+		s.runTrickleWarmer(trickleQueries)
+	}()
 }
 
 // runTrickleWarmer pops one query per tick from the backlog, runs it,
@@ -625,7 +648,11 @@ func (s *Server) runTrickleWarmer(backlog []qry) {
 	debug.FreeOSMemory()
 	baselineMB := readHeapAllocMB()
 	ceilingMB := baselineMB + deltaMB
-	ctx := context.Background()
+	// Trickle queries run under bgCtx so Stop()'s bgCancel aborts the
+	// warmer before the store closes. This loop runs ~30 min at the
+	// default 10s interval; with context.Background() it outlived test
+	// servers and panicked "pebble: closed" against their closed stores.
+	ctx := s.bgCtx
 	started := time.Now()
 	// F2: re-sample the baseline every 5 minutes inside the trickle loop
 	// to track real heap drift from concurrent workloads (dedup,
@@ -657,9 +684,21 @@ func (s *Server) runTrickleWarmer(backlog []qry) {
 		backoff    time.Duration
 	)
 	for idx < len(backlog) {
-		<-ticker.C
+		select {
+		case <-ctx.Done():
+			slog.Info("library list trickle warmer: aborting, server shutting down",
+				"completed", idx, "remaining", len(backlog)-idx)
+			return
+		case <-ticker.C:
+		}
 		if backoff > 0 {
-			time.Sleep(backoff)
+			select {
+			case <-ctx.Done():
+				slog.Info("library list trickle warmer: aborting during backoff, server shutting down",
+					"completed", idx, "remaining", len(backlog)-idx)
+				return
+			case <-time.After(backoff):
+			}
 		}
 
 		// F2: periodically re-sample baseline + recompute ceiling.

--- a/internal/server/server_coverage_phase2_test.go
+++ b/internal/server/server_coverage_phase2_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_coverage_phase2_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d5e6f7a8-b9c0-1d2e-3f4a-5b6c7d8e9f0a
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 package server
 
@@ -13,14 +13,29 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
+// pinEmptyRootDir pins config.AppConfig.RootDir to "" for the duration of a
+// MockStore-based test. The itunes/deluge plugin Build guards go LIVE whenever
+// the ambient RootDir is non-empty and then call UpsertOpDefinitionV2 on the
+// mock (no such expectation → testify FailNow). RootDir can be non-empty here
+// through cross-test — and, under `go test -count=N`, cross-iteration —
+// config pollution, so these tests must not trust ambient state.
+func pinEmptyRootDir(t *testing.T) {
+	t.Helper()
+	origCfg := config.AppConfig
+	config.AppConfig.RootDir = ""
+	t.Cleanup(func() { config.AppConfig = origCfg })
+}
+
 // TestGetAudiobookTagsErrors tests error scenarios for getAudiobookTags (59.3% → target 70%+)
 func TestGetAudiobookTagsErrors(t *testing.T) {
+	pinEmptyRootDir(t)
 	tests := []struct {
 		name       string
 		bookID     string
@@ -71,6 +86,7 @@ func TestGetAudiobookTagsErrors(t *testing.T) {
 
 // TestAddBlockedHashErrors tests error scenarios for addBlockedHash (60.0% → target 70%+)
 func TestAddBlockedHashErrors(t *testing.T) {
+	pinEmptyRootDir(t)
 	tests := []struct {
 		name       string
 		body       string
@@ -131,6 +147,7 @@ func TestAddBlockedHashErrors(t *testing.T) {
 
 // TestAddBlockedHashDatabaseError tests database failure in addBlockedHash
 func TestAddBlockedHashDatabaseError(t *testing.T) {
+	pinEmptyRootDir(t)
 	gin.SetMode(gin.TestMode)
 	mockStore := mocks.NewMockStore(t)
 
@@ -159,6 +176,7 @@ func TestAddBlockedHashDatabaseError(t *testing.T) {
 
 // TestDeleteWorkErrors tests error scenarios for deleteWork (63.6% → target 75%+)
 func TestDeleteWorkErrors(t *testing.T) {
+	pinEmptyRootDir(t)
 	tests := []struct {
 		name       string
 		workID     string

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.39.0
+// version: 1.40.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-07-03
 
@@ -272,8 +272,17 @@ func (s *Server) Start(cfg ServerConfig) error {
 	// Pre-warm the audiobook list cache after memdb is published. Fires
 	// the most common library-page queries (title asc/desc, -review:matched,
 	// library_state filter) so the user's first load doesn't pay the full
-	// cold-miss cost (~3 min on 50K-book library).
-	go s.warmAudiobookListCache()
+	// cold-miss cost (~3 min on 50K-book library). Enrolled in bgWG and
+	// gated on bgCtx (it also spawns the ~30-min trickle warmer): the old
+	// fire-and-forget launch outlived test servers and kept querying the
+	// store after Close() — panic "pebble: closed" from a trickle-warmer
+	// tick minutes into an internal/server package run
+	// (PEBBLE-CLOSED-SWEEPTICK-RESIDUAL family, warmer leg).
+	s.bgWG.Add("library-list-warmer")
+	go func() {
+		defer s.bgWG.Done("library-list-warmer")
+		s.warmAudiobookListCache()
+	}()
 	go s.warmAuthorsCache()
 	go s.warmSeriesCache()
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-234567890abc
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 // NOTE(fable5 T022): setupTestServer ported from NewSQLiteStore to NewPebbleStore.
 
@@ -106,6 +106,17 @@ func setupTestServerWithStore(t *testing.T, store database.Store) (*Server, func
 	// Set Gin to test mode
 	gin.SetMode(gin.TestMode)
 
+	// Hermetic config: callers pass MockStores with a fixed expectation set,
+	// but the plugin Build guards (itunes, deluge) go LIVE whenever the
+	// ambient config.AppConfig.RootDir is non-empty and then call
+	// UpsertOpDefinitionV2 on the mock, which has no such expectation —
+	// testify FailNow fires before the test's real assertions run. RootDir
+	// can be non-empty here through cross-test (and, under `go test
+	// -count=N`, cross-iteration) config pollution, so pin it to "" for the
+	// duration instead of trusting ambient state.
+	origCfg := config.AppConfig
+	config.AppConfig.RootDir = ""
+
 	// Set the global store to the provided store
 	database.SetGlobalStore(store)
 
@@ -120,6 +131,7 @@ func setupTestServerWithStore(t *testing.T, store database.Store) (*Server, func
 		if server.writeBackBatcher != nil {
 			_ = server.writeBackBatcher.Stop(context.Background())
 		}
+		config.AppConfig = origCfg
 		// Don't close the store - caller is responsible for cleanup
 	}
 

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,11 +1,12 @@
 // file: internal/testutil/integration.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package testutil
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/realtime"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
 	"github.com/stretchr/testify/require"
@@ -108,6 +110,21 @@ func SetupIntegration(t *testing.T) (*IntegrationEnv, func()) {
 		// panics ("pebble: closed"). Clearing early means hook calls are
 		// no-ops instead of panics; activity loss during teardown is acceptable.
 		scanner.SetScanHooks(nil)
+
+		// Ordered teardown: drain any op registries still running against THIS
+		// store BEFORE closing it. Each server test is responsible for its own
+		// deferred opRegistry.Shutdown, but any test that forgets leaks a
+		// running registry whose background goroutines (deps sweep ticker,
+		// dispatcher cycle, dbReporter progress/log flushes) keep touching the
+		// store for the remainder of the package run and panic
+		// "pebble: closed" minutes after this Close
+		// (PEBBLE-CLOSED-SWEEPTICK-RESIDUAL family). Scoped to this store, so
+		// parallel tests with their own stores are unaffected.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if n := opsregistry.ShutdownAllForStore(drainCtx, store); n > 0 {
+			t.Logf("testutil: drained %d leaked op registry(ies) before store close — add a deferred opRegistry.Shutdown to the owning test", n)
+		}
+		drainCancel()
 
 		database.SetGlobalStore(nil)
 		scanner.SetStore(nil)


### PR DESCRIPTION
## Summary

Closes the leaked-registry pebble-closed family for good (3 distinct legs struck gates today), plus collateral bugs its verification flushed out:

1. **Root teardown seam** — new registry live-tracker; `testutil/integration.go` cleanup drains every leaked registry wired to the store (pointer-matched) BEFORE `store.Close()`, logging the leaking test
2. **Choke-point guard** — `recoverPebbleClosed` extended to all ~18 opv2 store methods (incl. the `UpdateOpProgressV2` leg that struck last); only `pebble.ErrClosed` recovered, everything else re-panics; 30-call closed-store sweep test
3. **Warmer lifecycle** — `runTrickleWarmer` (fire-and-forget, ~30 min) enrolled in `bgWG`/gated on `bgCtx`; survived server Stop and panicked post-close
4. **Latent prod bug** — `ProtectedPathCache.refresh()` nil-derefed with Deluge unconfigured (documented nil-client path) → every tag-write pre-flight 500s; was masked by a test leaking a live client into the package singleton. Nil-guard + `ResetGlobalClientForTest` + RootDir test hermeticity

## Test plan

- [x] `go test ./internal/server/ -short -race -count=2` — ok, 951.6s (previously panicked/failed at 794s/1036s; logs preserved)
- [x] `go test ./internal/operations/registry/ -race -count=3` — ok
- [x] Closed-store sweep, live-tracker, deluge regression tests green; vet clean
- [ ] Minimal CI green

Follow-up noted for TODO: sibling warmers (facets/sizes/authors/series) are short-lived and left untouched per surgical-precision; worth enrolling in bgWG eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1