### PR TITLE
feat(dedup): confidence-tiered auto-resolve op — Band CERTAIN, dry-run + kill-switch gated (TASK-17)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.63.0
+// version: 1.64.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-07-03
 
@@ -130,6 +130,13 @@ type DedupConfig struct {
 	// LLMAutoMergeHighConfidence, when true, auto-applies merges when the LLM
 	// review returns a "duplicate" verdict with confidence "high" (default false — opt-in).
 	LLMAutoMergeHighConfidence bool `json:"llm_auto_merge_high_confidence" mapstructure:"llm_auto_merge_high_confidence"`
+	// AutoResolveEnabled is the global kill switch for the dedup.auto-resolve
+	// Tier-1 (Band CERTAIN) auto-merge op. When false (the default), an
+	// apply=true auto-resolve run is refused with an error and performs zero
+	// merges; the dry-run report is always producible regardless of this flag.
+	// Flipping this to true is an owner-greenlight action taken out-of-band
+	// after reviewing a dry-run report — it is never defaulted true.
+	AutoResolveEnabled bool `json:"auto_resolve_enabled" mapstructure:"auto_resolve_enabled"`
 	// OnImportViaScheduler routes the post-import dedup check through the UOS
 	// dependency scheduler instead of an eager goroutine (default false — opt-in).
 	OnImportViaScheduler bool `json:"on_import_via_scheduler" mapstructure:"on_import_via_scheduler"`
@@ -1065,6 +1072,7 @@ func InitConfig() {
 				AutoMergeEnabled:           viper.GetBool("dedup.auto_merge_enabled"),
 				EmbeddingsEnabled:          viper.GetBool("dedup.embeddings_enabled"),
 				LLMAutoMergeHighConfidence: viper.GetBool("dedup.llm_auto_merge_high_confidence"),
+				AutoResolveEnabled:         viper.GetBool("dedup.auto_resolve_enabled"),
 				OnImportViaScheduler:       viper.GetBool("dedup.on_import_via_scheduler"),
 				ReviewModel:                viper.GetString("dedup.review_model"),
 				Signals: DedupSignalConfig{
@@ -1489,6 +1497,7 @@ func ResetToDefaults() {
 				AutoMergeEnabled:           true,
 				EmbeddingsEnabled:          true, // opt-out: set false on no-internet boxes
 				LLMAutoMergeHighConfidence: false,
+				AutoResolveEnabled:         false, // owner-greenlight kill switch; never defaulted true
 				OnImportViaScheduler:       false, // opt-in
 				ReviewModel:                "gpt-5-mini",
 				Signals: DedupSignalConfig{

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.28.0
+// version: 1.29.0
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-07-03
 
@@ -1347,6 +1347,10 @@ func applySetting(key, value, typ string) error {
 		case "dedup_llm_auto_merge_high_confidence":
 			if b, err := strconv.ParseBool(value); err == nil {
 				c.Dedup.LLMAutoMergeHighConfidence = b
+			}
+		case "dedup_auto_resolve_enabled":
+			if b, err := strconv.ParseBool(value); err == nil {
+				c.Dedup.AutoResolveEnabled = b
 			}
 		case "dedup_on_import_via_scheduler":
 			if b, err := strconv.ParseBool(value); err == nil {

--- a/internal/database/dedup_automerge_journal.go
+++ b/internal/database/dedup_automerge_journal.go
@@ -1,0 +1,130 @@
+// file: internal/database/dedup_automerge_journal.go
+// version: 1.0.0
+// guid: 8b2f7d14-6c93-4a05-9e21-3f8a5c0d7e46
+// last-edited: 2026-07-03
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// dedupAutoMergeJournalPfx is the Pebble keyspace for auto-merge journal
+// entries written by the dedup.auto-resolve Tier-1 op. Each apply-path merge
+// writes exactly one entry so the merge can later be reversed via
+// Engine.UnmergeAuto (which restores the pre-merge book_ver snapshots).
+//
+// Key layout: dedup:automerge:<unix-nano, 16-hex> -> AutoMergeJournalEntry JSON.
+// The fixed-width hex suffix keeps range scans in chronological order.
+const dedupAutoMergeJournalPfx = "dedup:automerge:"
+
+// autoMergeJournalKey renders the fixed-width key for an entry's nanosecond
+// timestamp so prefix scans return rows in a stable, chronological order.
+func autoMergeJournalKey(unixNano int64) []byte {
+	return []byte(fmt.Sprintf("%s%016x", dedupAutoMergeJournalPfx, uint64(unixNano)))
+}
+
+// AutoMergeJournalEntry records one Tier-1 auto-merge so it can be reversed.
+//
+// WinnerPreMergeTS / LoserPreMergeTS are the book_ver copy-on-write snapshot
+// timestamps (nanoseconds) captured immediately after MergeBooks — the earliest
+// snapshot newer than the pre-merge state for each side, i.e. the genuine
+// pre-merge book record. UnmergeAuto reverts both books to those versions.
+type AutoMergeJournalEntry struct {
+	// Key is the full Pebble key this entry is stored at (dedup:automerge:...).
+	// Populated on read so callers can pass it straight to UnmergeAuto.
+	Key string `json:"key,omitempty"`
+
+	// CandidateID is the dedup candidate that triggered the merge.
+	CandidateID int64 `json:"candidate_id"`
+
+	// WinnerID / LoserID are the surviving primary and the soft-deleted loser.
+	WinnerID string `json:"winner_id"`
+	LoserID  string `json:"loser_id"`
+
+	// WinnerPreMergeTS / LoserPreMergeTS are book_ver snapshot timestamps
+	// (UnixNano) restoring each side to its pre-merge state. Zero means no
+	// pre-merge snapshot was located (UnmergeAuto skips that side).
+	WinnerPreMergeTS int64 `json:"winner_pre_merge_ts"`
+	LoserPreMergeTS  int64 `json:"loser_pre_merge_ts"`
+
+	// Tag is the survivor provenance tag applied at merge time.
+	Tag string `json:"tag"`
+
+	// MergedAt is the wall-clock time (UnixNano) the merge was applied; this is
+	// also the value embedded in Key.
+	MergedAt int64 `json:"merged_at"`
+}
+
+// PutAutoMergeJournalEntry writes an auto-merge journal entry keyed by
+// entry.MergedAt (nanoseconds). Mirrors UpsertLabeledExample's storage pattern.
+func (s *EmbeddingStore) PutAutoMergeJournalEntry(entry AutoMergeJournalEntry) (string, error) {
+	if err := s.checkClosed(); err != nil {
+		return "", err
+	}
+	key := autoMergeJournalKey(entry.MergedAt)
+	entry.Key = string(key)
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return "", fmt.Errorf("marshal automerge journal entry: %w", err)
+	}
+	if err := s.db.Set(key, data, pebble.Sync); err != nil {
+		return "", fmt.Errorf("write automerge journal entry: %w", err)
+	}
+	return entry.Key, nil
+}
+
+// GetAutoMergeJournalEntry returns the entry at the given full key, or nil if
+// absent.
+func (s *EmbeddingStore) GetAutoMergeJournalEntry(key string) (*AutoMergeJournalEntry, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	val, closer, err := s.db.Get([]byte(key))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get automerge journal entry %s: %w", key, err)
+	}
+	defer func() { _ = closer.Close() }()
+	var entry AutoMergeJournalEntry
+	if err := json.Unmarshal(val, &entry); err != nil {
+		return nil, fmt.Errorf("unmarshal automerge journal entry %s: %w", key, err)
+	}
+	entry.Key = key
+	return &entry, nil
+}
+
+// ListAutoMergeJournalEntries returns journal entries in chronological order,
+// capped at limit (0 = unlimited). Intended for a follow-on admin "undo merge"
+// listing; not used by the auto-resolve op itself.
+func (s *EmbeddingStore) ListAutoMergeJournalEntries(limit int) ([]AutoMergeJournalEntry, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	prefix := []byte(dedupAutoMergeJournalPfx)
+	upper := append([]byte(dedupAutoMergeJournalPfx), 0xff)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, fmt.Errorf("iter automerge journal: %w", err)
+	}
+	defer func() { _ = iter.Close() }()
+
+	var out []AutoMergeJournalEntry
+	for iter.First(); iter.Valid(); iter.Next() {
+		var entry AutoMergeJournalEntry
+		if err := json.Unmarshal(iter.Value(), &entry); err != nil {
+			continue // skip corrupt rows rather than abort the whole listing
+		}
+		entry.Key = string(iter.Key())
+		out = append(out, entry)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}

--- a/internal/dedup/auto_resolve.go
+++ b/internal/dedup/auto_resolve.go
@@ -1,0 +1,398 @@
+// file: internal/dedup/auto_resolve.go
+// version: 1.0.0
+// guid: 6d1e9b52-4f70-4c83-a2b9-1e5c8d0f7a34
+// last-edited: 2026-07-03
+
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+)
+
+// autoResolveSampleCapDefault bounds the per-run sample list in the dry-run
+// (and apply) report so the payload stays small regardless of corpus size.
+const autoResolveSampleCapDefault = 50
+
+// autoResolveMaxMergesDefault is the default hard cap on merges performed in a
+// single apply=true call.
+const autoResolveMaxMergesDefault = 200
+
+// autoResolvePrimaryKinds is the allow-list of PRIMARY signal kinds that count
+// toward the "≥2 distinct corroborating signal kinds" Tier-1 eligibility rule.
+// Supporting kinds (duration, folder) and the weaker embedding/fuzzy kinds are
+// intentionally excluded — a CERTAIN band alone is not sufficient; the design
+// (02-dedup, CONS-10 lesson) requires two independent strong signals or a
+// whole-book-signature true_dup label.
+var autoResolvePrimaryKinds = map[unified.SignalKind]bool{
+	unified.SigExactFile:     true,
+	unified.SigExactAcoustID: true,
+	unified.SigISBNASIN:      true,
+	unified.SigMetaSrcHash:   true,
+}
+
+// AutoResolveResult is the report returned by AutoResolveCertain. In dry-run
+// mode Merged is 0 and Samples enumerates the eligible pairs that WOULD merge.
+type AutoResolveResult struct {
+	Checked    int                 `json:"checked"`     // CERTAIN pending candidates examined
+	Eligible   int                 `json:"eligible"`    // passed every Tier-1 guard
+	Merged     int                 `json:"merged"`      // merges performed (0 when dry-run)
+	SkippedCap int                 `json:"skipped_cap"` // eligible pairs left unmerged because max_merges was hit
+	DryRun     bool                `json:"dry_run"`
+	Samples    []AutoResolveSample `json:"samples"`
+}
+
+// AutoResolveSample is one eligible candidate, for the dry-run/apply report.
+type AutoResolveSample struct {
+	CandidateID int64  `json:"candidate_id"`
+	BookAID     string `json:"book_a_id"`
+	BookBID     string `json:"book_b_id"`
+	TitleA      string `json:"title_a"`
+	TitleB      string `json:"title_b"`
+	Band        string `json:"band"`
+	Reason      string `json:"reason"` // why this pair is Tier-1 eligible
+	Merged      bool   `json:"merged"` // true only on the apply path once the merge succeeded
+	WinnerID    string `json:"winner_id,omitempty"`
+}
+
+// AutoResolveCertain runs the Tier-1 (Band CERTAIN) auto-resolution pass.
+//
+// Dry-run (apply=false, the default caller contract) never calls MergeBooks: it
+// counts eligible pairs and returns a capped sample with per-pair reasons. This
+// always works regardless of the AutoResolveEnabled kill switch so an operator
+// can produce the audit report before anything is greenlit.
+//
+// Apply (apply=true) requires config.AppConfig.Dedup.AutoResolveEnabled to be
+// true — otherwise it returns an error with zero merges. Eligible pairs are
+// merged via the existing mergeService.MergeBooks + CleanupCandidatesAfterMerge
+// path, the survivor is tagged dedup:merge-survivor:auto-certain, and a reversal
+// journal entry is written per merge. The run stops after maxMerges merges and
+// reports how many eligible pairs were skipped due to the cap.
+func (de *Engine) AutoResolveCertain(ctx context.Context, apply bool, maxMerges, sampleCap int) (AutoResolveResult, error) {
+	if sampleCap <= 0 {
+		sampleCap = autoResolveSampleCapDefault
+	}
+	if maxMerges <= 0 {
+		maxMerges = autoResolveMaxMergesDefault
+	}
+
+	res := AutoResolveResult{DryRun: !apply}
+
+	if de == nil || de.embedStore == nil || de.bookStore == nil {
+		return res, fmt.Errorf("auto-resolve: dedup engine not fully initialised (embed/book store nil)")
+	}
+
+	// Apply path is gated behind the global kill switch. This check lives here
+	// in the engine (not only the op wrapper) so calling the method directly
+	// cannot bypass the greenlight gate. Dry-run is exempt.
+	if apply && !config.AppConfig.Dedup.AutoResolveEnabled {
+		return res, fmt.Errorf("auto-resolve: apply=true requested but dedup.auto_resolve_enabled is false — owner greenlight required")
+	}
+	if apply && de.mergeService == nil {
+		return res, fmt.Errorf("auto-resolve: apply=true requested but merge service is unavailable (embeddings/merge disabled in this build)")
+	}
+
+	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Band:       unified.BandCertain,
+		Limit:      1_000_000,
+	})
+	if err != nil {
+		return res, fmt.Errorf("auto-resolve: list candidates: %w", err)
+	}
+
+	for _, c := range candidates {
+		select {
+		case <-ctx.Done():
+			return res, ctx.Err()
+		default:
+		}
+		res.Checked++
+
+		bookA, errA := de.bookStore.GetBookByID(c.EntityAID)
+		bookB, errB := de.bookStore.GetBookByID(c.EntityBID)
+		if errA != nil || errB != nil || bookA == nil || bookB == nil {
+			// Conservative: cannot judge a pair whose books we can't load.
+			continue
+		}
+		// Skip a pair whose book was already merged away earlier in this same
+		// run (candidates are snapshotted once up front; a shared book across
+		// two CERTAIN pairs would otherwise be double-merged). GetBookByID does
+		// not filter soft-deleted rows, so check the flag explicitly.
+		if bookSoftDeleted(bookA) || bookSoftDeleted(bookB) {
+			continue
+		}
+
+		eligible, reason := de.autoResolveEligible(c, bookA, bookB)
+		if !eligible {
+			continue
+		}
+		res.Eligible++
+
+		sample := AutoResolveSample{
+			CandidateID: c.ID,
+			BookAID:     c.EntityAID,
+			BookBID:     c.EntityBID,
+			TitleA:      bookA.Title,
+			TitleB:      bookB.Title,
+			Band:        c.Band,
+			Reason:      reason,
+		}
+
+		if !apply {
+			if len(res.Samples) < sampleCap {
+				res.Samples = append(res.Samples, sample)
+			}
+			continue
+		}
+
+		// Apply path.
+		if res.Merged >= maxMerges {
+			res.SkippedCap++
+			continue
+		}
+
+		winnerID, mergeErr := de.autoMergeCertain(c)
+		if mergeErr != nil {
+			slog.Error("dedup auto-resolve merge failed",
+				"candidate", c.ID, "a", c.EntityAID, "b", c.EntityBID, "err", mergeErr)
+			continue
+		}
+		res.Merged++
+		sample.Merged = true
+		sample.WinnerID = winnerID
+		if len(res.Samples) < sampleCap {
+			res.Samples = append(res.Samples, sample)
+		}
+	}
+
+	slog.Info("dedup auto-resolve pass complete",
+		"dry_run", res.DryRun, "checked", res.Checked, "eligible", res.Eligible,
+		"merged", res.Merged, "skipped_cap", res.SkippedCap)
+	return res, nil
+}
+
+// autoResolveEligible implements the Tier-1 eligibility rules (02-dedup design).
+// Returns (true, humanReason) only when EVERY guard holds. The reason string is
+// surfaced in the audit sample so an operator can see why each pair qualified.
+func (de *Engine) autoResolveEligible(c database.DedupCandidate, bookA, bookB *database.Book) (bool, string) {
+	if c.Band != unified.BandCertain {
+		return false, "band is not CERTAIN"
+	}
+	// A nil breakdown is a pre-T015 legacy row with nothing to audit — never
+	// auto-merge it.
+	if c.ScoreBreakdown == nil {
+		return false, "no score breakdown (legacy row)"
+	}
+	if len(c.ScoreBreakdown.Suppressors) > 0 {
+		return false, "score has active suppressors: " + strings.Join(c.ScoreBreakdown.Suppressors, ",")
+	}
+
+	// Both sides must look like real audio, and their identifiers must not
+	// actively disagree. These are independent of the signal-corroboration
+	// check and are kept as separate guards.
+	if !hasPlausibleAudio(bookA) || !hasPlausibleAudio(bookB) {
+		return false, "at least one side lacks plausible audio"
+	}
+	if identifiersConflict(bookA, bookB) {
+		return false, "identifiers conflict between the two books"
+	}
+
+	// Corroboration: ≥2 distinct primary signal kinds with Confidence>0, OR a
+	// whole-book-signature true_dup labeled example.
+	distinct := map[unified.SignalKind]bool{}
+	for _, sig := range c.ScoreBreakdown.Signals {
+		if sig.Confidence > 0 && autoResolvePrimaryKinds[sig.Kind] {
+			distinct[sig.Kind] = true
+		}
+	}
+	if len(distinct) >= 2 {
+		kinds := make([]string, 0, len(distinct))
+		for k := range distinct {
+			kinds = append(kinds, string(k))
+		}
+		return true, fmt.Sprintf("%d distinct primary signals: %s", len(distinct), strings.Join(kinds, "+"))
+	}
+
+	// Fallback: a whole-book-signature oracle label. Reuse the already-labeled
+	// example — do not recompute. GetLabeledExample errors are non-fatal: log
+	// and fall through to the (failed) count-based decision.
+	if ex, err := de.embedStore.GetLabeledExample(c.ID); err != nil {
+		slog.Warn("dedup auto-resolve: GetLabeledExample failed", "candidate", c.ID, "err", err)
+	} else if ex != nil && ex.Label == "true_dup" && strings.Contains(ex.LabelReason, "whole-book signatures match") {
+		return true, "whole-book-signature true_dup label"
+	}
+
+	return false, fmt.Sprintf("insufficient corroboration (%d primary signal kind(s), no whole-book-signature label)", len(distinct))
+}
+
+// autoMergeCertain performs a single Tier-1 merge for an eligible candidate,
+// mirroring Engine.ApplyVerdicts' auto-merge shape and additionally: cleaning up
+// residual candidates, and writing a reversal journal entry. Returns the
+// surviving primary book ID.
+func (de *Engine) autoMergeCertain(c database.DedupCandidate) (string, error) {
+	// Capture the newest pre-existing book_ver snapshot timestamp for each side
+	// BEFORE the merge. MergeBooks calls UpdateBook for every book (which writes
+	// the pre-update state to book_ver), so the earliest snapshot NEWER than
+	// this baseline is the genuine pre-merge record — the loser gets a second
+	// (soft-delete) snapshot on top, which is why "newest after merge" is wrong.
+	baseA := de.newestSnapshotNanos(c.EntityAID)
+	baseB := de.newestSnapshotNanos(c.EntityBID)
+
+	result, mergeErr := de.mergeService.MergeBooks(
+		[]string{c.EntityAID, c.EntityBID},
+		"", // auto-pick primary via bookIsBetter
+	)
+	if mergeErr != nil {
+		return "", fmt.Errorf("merge books: %w", mergeErr)
+	}
+	if result == nil || result.PrimaryID == "" {
+		return "", fmt.Errorf("merge returned no primary id")
+	}
+
+	winnerID := result.PrimaryID
+	loserID := c.EntityAID
+	if loserID == winnerID {
+		loserID = c.EntityBID
+	}
+
+	// Mark the candidate merged so it drops off the pending/review tab.
+	if err := de.embedStore.UpdateCandidateStatus(c.ID, "merged"); err != nil {
+		slog.Error("dedup auto-resolve: mark candidate merged failed", "candidate", c.ID, "err", err)
+	}
+
+	// Tag the survivor with the auto-certain provenance suffix (distinct from
+	// the LLM-verdict :llm-auto suffix so the two tiers are filterable apart).
+	tag := "dedup:merge-survivor:auto-certain"
+	if err := database.EnsureSingletonBookTag(
+		de.bookStore, winnerID, "dedup:merge-survivor", tag, "system",
+	); err != nil {
+		slog.Error("dedup auto-resolve: tag survivor failed", "winner", winnerID, "err", err)
+	}
+
+	// Clean up residual pending candidates referencing either merged-away book
+	// so they don't drift into the stale-candidate backlog.
+	de.CleanupCandidatesAfterMerge([]string{loserID})
+
+	// Locate the pre-merge snapshots and write the reversal journal entry.
+	winnerTS := de.preMergeSnapshotNanos(winnerID, baselineFor(winnerID, c.EntityAID, baseA, baseB))
+	loserTS := de.preMergeSnapshotNanos(loserID, baselineFor(loserID, c.EntityAID, baseA, baseB))
+
+	entry := database.AutoMergeJournalEntry{
+		CandidateID:      c.ID,
+		WinnerID:         winnerID,
+		LoserID:          loserID,
+		WinnerPreMergeTS: winnerTS,
+		LoserPreMergeTS:  loserTS,
+		Tag:              tag,
+		MergedAt:         time.Now().UnixNano(),
+	}
+	if _, err := de.embedStore.PutAutoMergeJournalEntry(entry); err != nil {
+		slog.Error("dedup auto-resolve: write journal entry failed", "candidate", c.ID, "err", err)
+	}
+
+	slog.Info("dedup auto-resolve merged CERTAIN pair",
+		"candidate", c.ID, "winner", winnerID, "loser", loserID)
+	return winnerID, nil
+}
+
+// bookSoftDeleted reports whether a book has been soft-deleted (marked for
+// deletion) — e.g. as a merge loser. GetBookByID returns such rows unfiltered.
+func bookSoftDeleted(b *database.Book) bool {
+	return b != nil && b.MarkedForDeletion != nil && *b.MarkedForDeletion
+}
+
+// baselineFor picks the correct pre-merge baseline nanos for a book ID given the
+// two baselines captured for EntityAID / EntityBID.
+func baselineFor(bookID, entityAID string, baseA, baseB int64) int64 {
+	if bookID == entityAID {
+		return baseA
+	}
+	return baseB
+}
+
+// newestSnapshotNanos returns the UnixNano of the newest existing book_ver
+// snapshot for a book, or 0 if none exists.
+func (de *Engine) newestSnapshotNanos(bookID string) int64 {
+	snaps, err := de.bookStore.GetBookSnapshots(bookID, 1)
+	if err != nil || len(snaps) == 0 {
+		return 0
+	}
+	return snaps[0].Timestamp.UnixNano()
+}
+
+// preMergeSnapshotNanos returns the UnixNano of the earliest book_ver snapshot
+// strictly newer than baselineNanos — i.e. the pre-merge book record written by
+// MergeBooks' first UpdateBook call. Returns 0 if none is found.
+func (de *Engine) preMergeSnapshotNanos(bookID string, baselineNanos int64) int64 {
+	snaps, err := de.bookStore.GetBookSnapshots(bookID, 0)
+	if err != nil {
+		slog.Warn("dedup auto-resolve: GetBookSnapshots failed", "book", bookID, "err", err)
+		return 0
+	}
+	// GetBookSnapshots returns newest-first; walk oldest-first to find the
+	// earliest snapshot newer than the baseline.
+	var best int64
+	for i := len(snaps) - 1; i >= 0; i-- {
+		ns := snaps[i].Timestamp.UnixNano()
+		if ns > baselineNanos {
+			best = ns
+			break
+		}
+	}
+	return best
+}
+
+// UnmergeAuto reverses a Tier-1 auto-merge recorded in the journal at journalKey
+// by reverting both the winner and loser books to their pre-merge book_ver
+// snapshots (restoring IsPrimaryVersion / VersionGroupID / MarkedForDeletion).
+//
+// SCOPE LIMIT: this restores the BOOK RECORD state only. It does NOT reverse the
+// external-ID reassignment (loser→winner) that MergeBooks performed, nor any
+// enqueued iTunes write-back removals. It exists so the "reversibility" safety
+// rail is buildable ahead of any human sign-off; a follow-on task wires it into
+// an admin "undo merge" endpoint that can also handle external-ID restoration.
+// It is deliberately NOT called by AutoResolveCertain / the op path.
+func (de *Engine) UnmergeAuto(journalKey string) error {
+	if de == nil || de.embedStore == nil || de.bookStore == nil {
+		return fmt.Errorf("unmerge-auto: engine not fully initialised")
+	}
+	entry, err := de.embedStore.GetAutoMergeJournalEntry(journalKey)
+	if err != nil {
+		return fmt.Errorf("unmerge-auto: read journal: %w", err)
+	}
+	if entry == nil {
+		return fmt.Errorf("unmerge-auto: no journal entry at %s", journalKey)
+	}
+
+	var errs []string
+	if entry.LoserPreMergeTS != 0 {
+		if _, err := de.bookStore.RevertBookToVersion(entry.LoserID, time.Unix(0, entry.LoserPreMergeTS)); err != nil {
+			errs = append(errs, fmt.Sprintf("loser %s: %v", entry.LoserID, err))
+		}
+	} else {
+		errs = append(errs, fmt.Sprintf("loser %s: no pre-merge snapshot recorded", entry.LoserID))
+	}
+	if entry.WinnerPreMergeTS != 0 {
+		if _, err := de.bookStore.RevertBookToVersion(entry.WinnerID, time.Unix(0, entry.WinnerPreMergeTS)); err != nil {
+			errs = append(errs, fmt.Sprintf("winner %s: %v", entry.WinnerID, err))
+		}
+	} else {
+		errs = append(errs, fmt.Sprintf("winner %s: no pre-merge snapshot recorded", entry.WinnerID))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("unmerge-auto: %s", strings.Join(errs, "; "))
+	}
+	slog.Info("dedup auto-resolve unmerged", "journal", journalKey,
+		"winner", entry.WinnerID, "loser", entry.LoserID)
+	return nil
+}

--- a/internal/dedup/auto_resolve_test.go
+++ b/internal/dedup/auto_resolve_test.go
@@ -1,0 +1,407 @@
+// file: internal/dedup/auto_resolve_test.go
+// version: 1.0.0
+// guid: 2f4b8c19-7a03-4d56-9e18-5c0d7f2a6b91
+// last-edited: 2026-07-03
+
+// Tests for the Tier-1 (Band CERTAIN) auto-resolution pass:
+// Engine.AutoResolveCertain, autoResolveEligible, and UnmergeAuto.
+//
+// Eligibility tests run against the MockStore-backed engine (no CoW needed).
+// Apply / journal / unmerge round-trip tests require a real PebbleStore because
+// the reversibility path depends on book_ver copy-on-write snapshots, which the
+// MockStore does not produce.
+
+package dedup
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+)
+
+// certainBreakdown builds a CERTAIN UnifiedDedupScore with the given primary
+// signal kinds (each at confidence 0.99) and no suppressors.
+func certainBreakdown(aID, bID string, kinds ...unified.SignalKind) *unified.UnifiedDedupScore {
+	sigs := make([]unified.Signal, 0, len(kinds))
+	for _, k := range kinds {
+		sigs = append(sigs, unified.Signal{Kind: k, Confidence: 0.99, Raw: 1})
+	}
+	return &unified.UnifiedDedupScore{
+		Pair:    [2]string{aID, bID},
+		Score:   100,
+		Band:    unified.BandCertain,
+		Signals: sigs,
+	}
+}
+
+func arPlausibleBook(id, title string) *database.Book {
+	d := 3600
+	return &database.Book{ID: id, Title: title, Duration: &d}
+}
+
+// --- Eligibility unit tests (MockStore) ---
+
+func TestAutoResolveEligible(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	bookA := arPlausibleBook("A", "Same Book")
+	bookB := arPlausibleBook("B", "Same Book")
+
+	base := func() database.DedupCandidate {
+		return database.DedupCandidate{
+			ID:             1,
+			EntityType:     "book",
+			EntityAID:      "A",
+			EntityBID:      "B",
+			Band:           unified.BandCertain,
+			Status:         "pending",
+			ScoreBreakdown: certainBreakdown("A", "B", unified.SigExactFile, unified.SigISBNASIN),
+		}
+	}
+
+	t.Run("accepts CERTAIN with 2 primary signals", func(t *testing.T) {
+		ok, reason := engine.autoResolveEligible(base(), bookA, bookB)
+		if !ok {
+			t.Fatalf("expected eligible, got not eligible: %s", reason)
+		}
+	})
+
+	t.Run("rejects band != CERTAIN", func(t *testing.T) {
+		c := base()
+		c.Band = unified.BandHigh
+		c.ScoreBreakdown.Band = unified.BandHigh
+		if ok, _ := engine.autoResolveEligible(c, bookA, bookB); ok {
+			t.Fatal("expected not eligible for HIGH band")
+		}
+	})
+
+	t.Run("rejects non-empty suppressors", func(t *testing.T) {
+		c := base()
+		c.ScoreBreakdown.Suppressors = []string{"series_volume_differs"}
+		if ok, _ := engine.autoResolveEligible(c, bookA, bookB); ok {
+			t.Fatal("expected not eligible with suppressors")
+		}
+	})
+
+	t.Run("rejects nil ScoreBreakdown", func(t *testing.T) {
+		c := base()
+		c.ScoreBreakdown = nil
+		if ok, _ := engine.autoResolveEligible(c, bookA, bookB); ok {
+			t.Fatal("expected not eligible with nil breakdown")
+		}
+	})
+
+	t.Run("rejects implausible audio on one side", func(t *testing.T) {
+		c := base()
+		bad := &database.Book{ID: "B", Title: "Same Book"} // no duration/size
+		if ok, _ := engine.autoResolveEligible(c, bookA, bad); ok {
+			t.Fatal("expected not eligible when a side lacks plausible audio")
+		}
+	})
+
+	t.Run("rejects identifier conflict", func(t *testing.T) {
+		c := base()
+		a := arPlausibleBook("A", "Same Book")
+		b := arPlausibleBook("B", "Same Book")
+		a.ISBN13 = strPtr("9780000000001")
+		b.ISBN13 = strPtr("9780000000002")
+		if ok, _ := engine.autoResolveEligible(c, a, b); ok {
+			t.Fatal("expected not eligible with conflicting ISBNs")
+		}
+	})
+
+	t.Run("rejects single primary signal without label", func(t *testing.T) {
+		c := base()
+		c.ScoreBreakdown = certainBreakdown("A", "B", unified.SigExactFile)
+		if ok, _ := engine.autoResolveEligible(c, bookA, bookB); ok {
+			t.Fatal("expected not eligible with only 1 primary signal and no label")
+		}
+	})
+
+	t.Run("accepts single primary signal WITH whole-book-signature label", func(t *testing.T) {
+		c := base()
+		c.ID = 42
+		c.ScoreBreakdown = certainBreakdown("A", "B", unified.SigExactFile)
+		if err := es.UpsertLabeledExample(database.LabeledExample{
+			CandidateID: 42,
+			Label:       "true_dup",
+			LabelReason: "whole-book signatures match",
+		}); err != nil {
+			t.Fatalf("UpsertLabeledExample: %v", err)
+		}
+		ok, reason := engine.autoResolveEligible(c, bookA, bookB)
+		if !ok {
+			t.Fatalf("expected eligible via label fallback, got: %s", reason)
+		}
+	})
+
+	t.Run("supporting signals do not count as primary", func(t *testing.T) {
+		c := base()
+		// Two signals but both SUPPORTING kinds — must not qualify.
+		c.ScoreBreakdown = certainBreakdown("A", "B", unified.SigDuration, unified.SigFolderPath)
+		if ok, _ := engine.autoResolveEligible(c, bookA, bookB); ok {
+			t.Fatal("expected not eligible with only supporting signals")
+		}
+	})
+}
+
+// --- Dry-run path (real EmbeddingStore + MockStore for book lookups) ---
+
+func TestAutoResolveCertain_DryRun(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	mergeCalled := false
+	mock.UpdateBookFunc = func(id string, b *database.Book) (*database.Book, error) {
+		mergeCalled = true // any UpdateBook implies a merge happened
+		return b, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return arPlausibleBook(id, "Same Book"), nil
+	}
+
+	// Two eligible CERTAIN candidates + one HIGH (must be ignored by the Band filter).
+	mustSeed(t, es, "A1", "B1", unified.BandCertain, unified.SigExactFile, unified.SigISBNASIN)
+	mustSeed(t, es, "A2", "B2", unified.BandCertain, unified.SigExactAcoustID, unified.SigMetaSrcHash)
+	mustSeed(t, es, "A3", "B3", unified.BandHigh, unified.SigExactFile, unified.SigISBNASIN)
+
+	res, err := engine.AutoResolveCertain(context.Background(), false, 200, 50)
+	if err != nil {
+		t.Fatalf("AutoResolveCertain: %v", err)
+	}
+	if !res.DryRun {
+		t.Fatal("expected DryRun=true")
+	}
+	if res.Checked != 2 {
+		t.Fatalf("expected Checked=2 (CERTAIN band only), got %d", res.Checked)
+	}
+	if res.Eligible != 2 {
+		t.Fatalf("expected Eligible=2, got %d", res.Eligible)
+	}
+	if res.Merged != 0 {
+		t.Fatalf("expected Merged=0 in dry-run, got %d", res.Merged)
+	}
+	if len(res.Samples) != 2 {
+		t.Fatalf("expected 2 samples, got %d", len(res.Samples))
+	}
+	for _, s := range res.Samples {
+		if s.Reason == "" {
+			t.Fatalf("expected non-empty eligibility reason in sample %d", s.CandidateID)
+		}
+		if s.Merged {
+			t.Fatal("dry-run samples must not be marked Merged")
+		}
+	}
+	if mergeCalled {
+		t.Fatal("dry-run must not call MergeBooks/UpdateBook")
+	}
+}
+
+func TestAutoResolveCertain_ApplyRequiresKillSwitch(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return arPlausibleBook(id, "Same Book"), nil
+	}
+	mustSeed(t, es, "A1", "B1", unified.BandCertain, unified.SigExactFile, unified.SigISBNASIN)
+
+	prev := config.AppConfig.Dedup.AutoResolveEnabled
+	config.AppConfig.Dedup.AutoResolveEnabled = false
+	t.Cleanup(func() { config.AppConfig.Dedup.AutoResolveEnabled = prev })
+
+	res, err := engine.AutoResolveCertain(context.Background(), true, 200, 50)
+	if err == nil {
+		t.Fatal("expected error when apply=true with kill switch off")
+	}
+	if res.Merged != 0 {
+		t.Fatalf("expected zero merges on gated apply, got %d", res.Merged)
+	}
+}
+
+// --- Apply path + journal + unmerge round-trip (real PebbleStore) ---
+
+func setupRealStoreEngine(t *testing.T) (*Engine, database.Store, *database.EmbeddingStore) {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	origStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+
+	edb, err := pebble.Open(t.TempDir(), &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open embed: %v", err)
+	}
+	es := database.NewEmbeddingStore(edb)
+	t.Cleanup(func() {
+		database.SetGlobalStore(origStore)
+		_ = edb.Close()
+		_ = store.Close()
+	})
+
+	ms := merge.NewService(store)
+	engine := NewEngine(es, store, nil, nil, ms)
+	return engine, store, es
+}
+
+func TestAutoResolveCertain_ApplyMergesAndJournals(t *testing.T) {
+	engine, store, es := setupRealStoreEngine(t)
+
+	prev := config.AppConfig.Dedup.AutoResolveEnabled
+	config.AppConfig.Dedup.AutoResolveEnabled = true
+	t.Cleanup(func() { config.AppConfig.Dedup.AutoResolveEnabled = prev })
+
+	// Create two eligible pairs (4 books) with plausible audio.
+	for _, id := range []string{"BA", "BB", "BC", "BD"} {
+		if _, err := store.CreateBook(arPlausibleBook(id, "Dup Title "+id)); err != nil {
+			t.Fatalf("CreateBook %s: %v", id, err)
+		}
+	}
+	mustSeed(t, es, "BA", "BB", unified.BandCertain, unified.SigExactFile, unified.SigISBNASIN)
+	mustSeed(t, es, "BC", "BD", unified.BandCertain, unified.SigExactAcoustID, unified.SigMetaSrcHash)
+
+	// max_merges=1 so we can prove the cap stops the second eligible pair.
+	res, err := engine.AutoResolveCertain(context.Background(), true, 1, 50)
+	if err != nil {
+		t.Fatalf("AutoResolveCertain apply: %v", err)
+	}
+	if res.Merged != 1 {
+		t.Fatalf("expected Merged=1 (cap), got %d", res.Merged)
+	}
+	if res.Eligible != 2 {
+		t.Fatalf("expected Eligible=2, got %d", res.Eligible)
+	}
+	if res.SkippedCap != 1 {
+		t.Fatalf("expected SkippedCap=1, got %d", res.SkippedCap)
+	}
+
+	// Journal written for the one merge.
+	entries, err := es.ListAutoMergeJournalEntries(0)
+	if err != nil {
+		t.Fatalf("ListAutoMergeJournalEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 journal entry, got %d", len(entries))
+	}
+	entry := entries[0]
+
+	// Survivor tagged :auto-certain.
+	tags, err := store.GetBookTags(entry.WinnerID)
+	if err != nil {
+		t.Fatalf("GetBookTags: %v", err)
+	}
+	if !arHasTag(tags, "dedup:merge-survivor:auto-certain") {
+		t.Fatalf("expected survivor tag :auto-certain, got %v", tags)
+	}
+
+	// Loser soft-deleted (MarkedForDeletion=true) post-merge.
+	loser, err := store.GetBookByID(entry.LoserID)
+	if err != nil || loser == nil {
+		t.Fatalf("GetBookByID loser: %v", err)
+	}
+	if loser.MarkedForDeletion == nil || !*loser.MarkedForDeletion {
+		t.Fatal("expected loser MarkedForDeletion=true after merge")
+	}
+
+	// --- Unmerge round-trip: both books restored to pre-merge state. ---
+	if err := engine.UnmergeAuto(entry.Key); err != nil {
+		t.Fatalf("UnmergeAuto: %v", err)
+	}
+	loserAfter, err := store.GetBookByID(entry.LoserID)
+	if err != nil || loserAfter == nil {
+		t.Fatalf("GetBookByID loser after unmerge: %v", err)
+	}
+	if loserAfter.MarkedForDeletion != nil && *loserAfter.MarkedForDeletion {
+		t.Fatal("expected loser MarkedForDeletion cleared after unmerge")
+	}
+	if loserAfter.VersionGroupID != nil {
+		t.Fatalf("expected loser VersionGroupID nil after unmerge, got %v", *loserAfter.VersionGroupID)
+	}
+	winnerAfter, err := store.GetBookByID(entry.WinnerID)
+	if err != nil || winnerAfter == nil {
+		t.Fatalf("GetBookByID winner after unmerge: %v", err)
+	}
+	if winnerAfter.VersionGroupID != nil {
+		t.Fatalf("expected winner VersionGroupID nil after unmerge, got %v", *winnerAfter.VersionGroupID)
+	}
+}
+
+// TestAutoResolveCertain_SkipsAlreadyMergedBook proves the apply loop does not
+// re-merge a book that was soft-deleted as a loser in a prior merge (the
+// shared-book-across-two-pairs case). Candidates are snapshotted once up front,
+// so the guard must re-check the live book state.
+func TestAutoResolveCertain_SkipsAlreadyMergedBook(t *testing.T) {
+	engine, store, es := setupRealStoreEngine(t)
+
+	prev := config.AppConfig.Dedup.AutoResolveEnabled
+	config.AppConfig.Dedup.AutoResolveEnabled = true
+	t.Cleanup(func() { config.AppConfig.Dedup.AutoResolveEnabled = prev })
+
+	for _, id := range []string{"PA", "PB", "PE"} {
+		if _, err := store.CreateBook(arPlausibleBook(id, "Dup Title "+id)); err != nil {
+			t.Fatalf("CreateBook %s: %v", id, err)
+		}
+	}
+	mustSeed(t, es, "PA", "PB", unified.BandCertain, unified.SigExactFile, unified.SigISBNASIN)
+
+	res, err := engine.AutoResolveCertain(context.Background(), true, 10, 50)
+	if err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if res.Merged != 1 {
+		t.Fatalf("expected Merged=1, got %d", res.Merged)
+	}
+	entries, err := es.ListAutoMergeJournalEntries(0)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 journal entry, got %d (err=%v)", len(entries), err)
+	}
+	loserID := entries[0].LoserID
+
+	// Seed a fresh CERTAIN candidate pairing the now-soft-deleted loser with PE.
+	mustSeed(t, es, loserID, "PE", unified.BandCertain, unified.SigExactFile, unified.SigISBNASIN)
+
+	res2, err := engine.AutoResolveCertain(context.Background(), true, 10, 50)
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if res2.Merged != 0 {
+		t.Fatalf("expected Merged=0 (soft-deleted book must be skipped), got %d", res2.Merged)
+	}
+	if res2.Eligible != 0 {
+		t.Fatalf("expected Eligible=0 (skipped before eligibility), got %d", res2.Eligible)
+	}
+}
+
+// --- helpers ---
+
+func mustSeed(t *testing.T, es *database.EmbeddingStore, aID, bID, band string, kinds ...unified.SignalKind) {
+	t.Helper()
+	sb := certainBreakdown(aID, bID, kinds...)
+	sb.Band = band
+	if err := es.UpsertCandidate(database.DedupCandidate{
+		EntityType:     "book",
+		EntityAID:      aID,
+		EntityBID:      bID,
+		Layer:          "exact",
+		Status:         "pending",
+		Band:           band,
+		FormulaVersion: "test",
+		ScoreBreakdown: sb,
+	}); err != nil {
+		t.Fatalf("UpsertCandidate(%s,%s): %v", aID, bID, err)
+	}
+}
+
+func arHasTag(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/dedup/auto_resolve.go
+++ b/internal/plugins/dedup/auto_resolve.go
@@ -1,0 +1,93 @@
+// file: internal/plugins/dedup/auto_resolve.go
+// version: 1.0.0
+// guid: 3a7c1f08-9d24-4e6b-8b15-2c9f0a5d7e61
+// last-edited: 2026-07-03
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// autoResolveParams are the JSON params for dedup.auto-resolve.
+//
+// apply defaults to false (dry-run report only). max_merges / sample_cap default
+// to 0, which the engine coerces to 200 / 50 respectively.
+type autoResolveParams struct {
+	Apply     bool `json:"apply"`
+	MaxMerges int  `json:"max_merges"`
+	SampleCap int  `json:"sample_cap"`
+}
+
+// autoResolveDef defines the dedup.auto-resolve operation: the Tier-1 (Band
+// CERTAIN) confidence-tiered auto-merge pass from the 02-dedup consultancy
+// design. It is dry-run by default and — for apply=true — gated behind the
+// dedup.auto_resolve_enabled kill switch and a max_merges cap. See
+// dedup.Engine.AutoResolveCertain for the eligibility rules and safety rails.
+func (p *Plugin) autoResolveDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "dedup.auto-resolve",
+		Plugin:          "dedup",
+		DisplayName:     "Auto-resolve CERTAIN dedup candidates (Tier 1)",
+		Description:     "Dry-run by default: reports which Band-CERTAIN dedup candidates WOULD auto-merge (≥2 primary signals or a whole-book-signature true_dup label). apply=true performs the merges, gated by the dedup.auto_resolve_enabled kill switch and a max_merges cap.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityHigh,
+		ConcurrencyKey:  "dedup.auto-resolve",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         30 * time.Minute,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+		},
+		Run: p.runAutoResolve,
+	}
+}
+
+func (p *Plugin) runAutoResolve(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return fmt.Errorf("dedup engine not available")
+	}
+
+	var params autoResolveParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("parse auto-resolve params: %w", err)
+		}
+	}
+
+	// Fail fast at the op boundary too (the engine also enforces this) so a
+	// misconfigured apply=true request is rejected before any candidate scan.
+	if params.Apply && !config.AppConfig.Dedup.AutoResolveEnabled {
+		return fmt.Errorf("auto-resolve apply=true requires dedup.auto_resolve_enabled=true (owner greenlight); refusing")
+	}
+
+	mode := "dry-run"
+	if params.Apply {
+		mode = "APPLY"
+	}
+	_ = reporter.UpdateProgress(0, 1,
+		fmt.Sprintf("Scanning CERTAIN candidates for Tier-1 auto-resolution (%s)…", mode))
+	reporter.Logger().Info("dedup auto-resolve start",
+		"apply", params.Apply, "max_merges", params.MaxMerges, "sample_cap", params.SampleCap)
+
+	res, err := p.engine.AutoResolveCertain(ctx, params.Apply, params.MaxMerges, params.SampleCap)
+	if err != nil {
+		reporter.Logger().Error("dedup auto-resolve error", "error", err)
+		return fmt.Errorf("auto-resolve: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf(
+		"Auto-resolve complete (%s) — checked %d, eligible %d, merged %d, skipped(cap) %d",
+		mode, res.Checked, res.Eligible, res.Merged, res.SkippedCap))
+	reporter.Logger().Info("dedup auto-resolve complete",
+		"dry_run", res.DryRun, "checked", res.Checked, "eligible", res.Eligible,
+		"merged", res.Merged, "skipped_cap", res.SkippedCap, "samples", len(res.Samples))
+	return nil
+}

--- a/internal/plugins/dedup/auto_resolve_test.go
+++ b/internal/plugins/dedup/auto_resolve_test.go
@@ -1,0 +1,110 @@
+// file: internal/plugins/dedup/auto_resolve_test.go
+// version: 1.0.0
+// guid: 7e0a5c93-2b18-4f64-9d07-1a6c8f3b0e52
+// last-edited: 2026-07-03
+
+// Tests for the dedup.auto-resolve op wrapper (TASK-17). The engine-level
+// eligibility, merge, journal, and unmerge behaviour is covered in
+// internal/dedup/auto_resolve_test.go; these assert the OperationDef metadata,
+// the dry-run contract, and the apply=true kill-switch guard at the op boundary.
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func autoResolveMockStore() *database.MockStore {
+	dur := 3600
+	books := map[string]*database.Book{
+		"AA": {ID: "AA", Title: "Same Book", Duration: &dur},
+		"BB": {ID: "BB", Title: "Same Book", Duration: &dur},
+	}
+	return &database.MockStore{
+		GetBookByIDFunc:  func(id string) (*database.Book, error) { return books[id], nil },
+		GetBookFilesFunc: func(string) ([]database.BookFile, error) { return nil, nil },
+	}
+}
+
+func seedCertainCandidate(t *testing.T, es *database.EmbeddingStore, aID, bID string) {
+	t.Helper()
+	sb := &unified.UnifiedDedupScore{
+		Pair:  [2]string{aID, bID},
+		Score: 100,
+		Band:  unified.BandCertain,
+		Signals: []unified.Signal{
+			{Kind: unified.SigExactFile, Confidence: 0.99},
+			{Kind: unified.SigISBNASIN, Confidence: 0.99},
+		},
+	}
+	require.NoError(t, es.UpsertCandidate(database.DedupCandidate{
+		EntityType:     "book",
+		EntityAID:      aID,
+		EntityBID:      bID,
+		Layer:          "exact",
+		Status:         "pending",
+		Band:           unified.BandCertain,
+		FormulaVersion: "test",
+		ScoreBreakdown: sb,
+	}))
+}
+
+func TestAutoResolveOp_Metadata(t *testing.T) {
+	p := &Plugin{}
+	def := p.autoResolveDef()
+	assert.Equal(t, "dedup.auto-resolve", def.ID)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryRead)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryWrite)
+
+	var params autoResolveParams
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &params))
+	assert.False(t, params.Apply, "apply must default to false (dry-run)")
+}
+
+func TestAutoResolveOp_DryRunProducesReport(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := autoResolveMockStore()
+	seedCertainCandidate(t, es, "AA", "BB")
+
+	p := buildPluginWithEngine(t, es, ms)
+	params, err := json.Marshal(autoResolveParams{Apply: false})
+	require.NoError(t, err)
+	require.NoError(t, p.runAutoResolve(context.Background(), params, &mockReporter{}))
+
+	// Dry-run leaves the candidate pending (no merge).
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, cands, 1)
+	assert.Equal(t, "pending", cands[0].Status, "dry-run must not mutate candidate status")
+}
+
+func TestAutoResolveOp_ApplyRefusedWithoutKillSwitch(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := autoResolveMockStore()
+	seedCertainCandidate(t, es, "AA", "BB")
+
+	prev := config.AppConfig.Dedup.AutoResolveEnabled
+	config.AppConfig.Dedup.AutoResolveEnabled = false
+	t.Cleanup(func() { config.AppConfig.Dedup.AutoResolveEnabled = prev })
+
+	p := buildPluginWithEngine(t, es, ms)
+	params, err := json.Marshal(autoResolveParams{Apply: true})
+	require.NoError(t, err)
+
+	err = p.runAutoResolve(context.Background(), params, &mockReporter{})
+	require.Error(t, err, "apply=true with kill switch off must error at the op boundary")
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, cands, 1)
+	assert.Equal(t, "pending", cands[0].Status, "gated apply must not mutate candidate status")
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-07-03
 
@@ -75,6 +75,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.checkBookDef(),                    // M4: per-book dedup check via dependency scheduler
 		p.buildISBNIndexDef(),               // T022: ISBN/ASIN secondary index backfill
 		p.reembedEmbeddingsDef(),            // Part B: re-embed corpus when the embedding model changes
+		p.autoResolveDef(),                  // TASK-17: Tier-1 CERTAIN auto-merge (dry-run default, kill-switch gated)
 	}
 
 	for _, op := range ops {


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-17** (wave 4, Opus): `dedup.auto-resolve` — Tier-1 auto-merge for Band CERTAIN candidates, designed against the post-drain pool (9,455 genuine candidates).

- **Eligibility (conservative, per brief + CONS-10 lesson):** Band CERTAIN, non-nil ScoreBreakdown, no suppressors, plausible audio both sides, no identifier conflict, AND ≥2 distinct primary signals ({exact_file, exact_acoustid, isbn_asin, metadata_hash}) or a labeled true-dup
- **Triple-gated:** dry-run default (report with counts + samples + reasons); `apply=true` requires the new `dedup.auto_resolve_enabled` kill switch (default **false**, enforced in the engine so direct calls can't bypass); `max_merges` cap
- **Reversible:** every auto-merge journaled (`dedup:automerge:*`) with pre-merge snapshot baselines; `UnmergeAuto` round-trip proven in tests. Deliberately captures each side's newest PRE-existing snapshot (the brief's post-merge suggestion would restore the loser to its soft-deleted state)
- Survivor tagged `dedup:merge-survivor:auto-certain`; `CleanupCandidatesAfterMerge` after every apply; already-merged books skipped within a run (double-merge guard + test)

## Test plan

- [x] Kill-switch refusal (engine + op wrapper: zero merges, no mutation), dry-run purity, apply+journal+unmerge round-trip, max_merges cap, double-merge guard — all green
- [x] Full `internal/dedup`, `internal/plugins/dedup`, `internal/config` suites; build + vet clean
- [ ] Local honest gate (running)
- [ ] Minimal CI green

**Owner-gated next steps (NOT in this PR):** prod dry-run → review samples → flip `dedup.auto_resolve_enabled` → capped apply. Recommended AFTER threshold calibration (post re-embed) regenerates the embedding layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1