### PR TITLE
feat(webui,server): AI backend-mode toggle UI + /api/v1/ai/backends endpoints (TASK-11)

### DIFF
--- a/docs/reference/config-api-shape.md
+++ b/docs/reference/config-api-shape.md
@@ -1,5 +1,5 @@
 <!-- file: docs/reference/config-api-shape.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 2b7f9c31-a4e8-4f1d-b8a2-6c5d9e3f2a17 -->
 <!-- last-edited: 2026-07-03 -->
 
@@ -218,6 +218,52 @@ committed defaults — real endpoints belong in local, gitignored config.
 | `AI_BACKEND_LOCAL_BASE_URL` | `ai_backend.local_base_url` |
 | `AI_BACKEND_LOCAL_EMBEDDING_MODEL` | `ai_backend.local_embedding_model` |
 | `AI_BACKEND_LOCAL_LLM_MODEL` | `ai_backend.local_llm_model` |
+
+**Status probe and model-pull endpoints (TASK-11).** These are separate from
+`GET`/`PUT /config` — they probe the live local backend and, on demand, pull a
+model into it via the managed Ollama lifecycle (the same `ToolRegistry`/
+`OllamaDaemon` machinery behind `/api/v1/tools/:name/install`).
+
+```
+GET /api/v1/ai/backends/status
+```
+
+Response `data`:
+```typescript
+interface AIBackendsStatus {
+  embedding_mode: string;          // effective mode, see EffectiveEmbeddingMode
+  llm_mode: string;                // effective mode, see EffectiveLLMMode
+  local_base_url: string;
+  local_reachable: boolean;        // GET {local_base_url}/api/tags succeeded
+  embedding_model?: { name: string; pulled: boolean };
+  llm_model?: { name: string; pulled: boolean };
+  fallback_reason?: string;        // set when local_reachable is false
+}
+```
+
+The probe is skipped (all fields default) when neither `embedding_mode` nor
+`llm_mode` resolves to `local`/`openai-fallback-local`, or when
+`local_base_url` is empty.
+
+```
+POST /api/v1/ai/backends/pull-model
+Content-Type: application/json
+
+{ "model": "bge-m3" }
+```
+
+Resolves the managed `ollama` binary via `ToolRegistry`, ensures the managed
+`OllamaDaemon` is running, then runs `ollama pull <model>` synchronously
+(bounded by a server-side timeout) and stops the daemon back down when idle.
+There is no streaming/op-registry progress channel for this endpoint — the
+frontend re-polls `GET /ai/backends/status` after this call returns to
+confirm the model is now pulled. Response `data`: `{ "model": string,
+"pulled": true }`. Returns `503` if the tool registry or a resolvable
+`ollama` binary is unavailable, and `500` if the pull itself fails (with the
+`ollama` CLI's combined output in the error message).
+
+Both endpoints require `settings.manage` permission, matching the tools
+lifecycle endpoints.
 
 ---
 

--- a/internal/server/handlers/aibackends/aibackends.go
+++ b/internal/server/handlers/aibackends/aibackends.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/aibackends/aibackends.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c3d9e21-4a5b-4f6c-9d8e-1a2b3c4d5e6f
 // last-edited: 2026-07-03
 
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -125,6 +126,12 @@ type pullModelRequest struct {
 	Model string `json:"model" binding:"required"`
 }
 
+// modelNameRe matches valid Ollama model references (name[:tag], optional
+// registry/namespace path segments). Anything else — in particular values
+// starting with "-", which the ollama CLI would parse as flags (argv
+// injection) — is rejected before reaching exec.
+var modelNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*(?:/[a-zA-Z0-9][a-zA-Z0-9._-]*)*(?::[a-zA-Z0-9][a-zA-Z0-9._-]*)?$`)
+
 // PullModel shells out to the managed `ollama` binary (resolved through
 // ToolRegistry, the same lifecycle backing /api/v1/tools/:name/install) to
 // pull req.Model. It runs synchronously and returns once the pull completes
@@ -137,6 +144,10 @@ func (h *Handler) PullModel(c *gin.Context) {
 	var req pullModelRequest
 	if err := c.ShouldBindJSON(&req); err != nil || req.Model == "" {
 		httputil.RespondWithBadRequest(c, "model is required")
+		return
+	}
+	if !modelNameRe.MatchString(req.Model) {
+		httputil.RespondWithBadRequest(c, "invalid model name")
 		return
 	}
 

--- a/internal/server/handlers/aibackends/aibackends.go
+++ b/internal/server/handlers/aibackends/aibackends.go
@@ -1,0 +1,235 @@
+// file: internal/server/handlers/aibackends/aibackends.go
+// version: 1.0.0
+// guid: 7c3d9e21-4a5b-4f6c-9d8e-1a2b3c4d5e6f
+// last-edited: 2026-07-03
+
+// Package aibackendshandler provides HTTP handlers for the AI backend-mode
+// toggle (TASK-10's AIBackendConfig): a status probe that reports the
+// effective embedding/LLM mode plus whether the configured local models are
+// pulled into Ollama, and a pull-model endpoint that shells out to the
+// managed Ollama binary (reusing internal/tools.ToolRegistry, the same
+// lifecycle used by the "Managed External-Tool Lifecycle" /api/v1/tools
+// endpoints) to pull a model on demand.
+package aibackendshandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/falkcorp/audiobook-organizer/internal/tools"
+)
+
+// pullTimeout bounds a single `ollama pull` invocation. Model pulls can be
+// several GB; 30 minutes is generous enough for a slow connection while still
+// giving up rather than hanging the handler goroutine forever.
+const pullTimeout = 30 * time.Minute
+
+// statusProbeTimeout bounds the GET /api/tags probe used to determine
+// reachability and list pulled models. Kept short so Settings page loads
+// don't stall waiting on a down local endpoint.
+const statusProbeTimeout = 3 * time.Second
+
+// Handler provides HTTP handlers for /api/v1/ai/backends.
+type Handler struct {
+	registry *tools.ToolRegistry
+	daemon   *tools.OllamaDaemon
+}
+
+// New constructs a Handler. registry may be nil in tests that only exercise
+// Status (pull-model requires a non-nil registry to resolve the ollama
+// binary). daemon may also be nil (e.g. Ollama tool mode disabled); PullModel
+// then falls back to invoking the CLI directly without ensuring a managed
+// daemon is running.
+func New(registry *tools.ToolRegistry, daemon *tools.OllamaDaemon) *Handler {
+	return &Handler{registry: registry, daemon: daemon}
+}
+
+// ModelStatus reports whether a single named model has been pulled into the
+// probed local endpoint.
+type ModelStatus struct {
+	Name   string `json:"name"`
+	Pulled bool   `json:"pulled"`
+}
+
+// StatusResponse is the response body for GET /api/v1/ai/backends/status.
+type StatusResponse struct {
+	EmbeddingMode  string       `json:"embedding_mode"`
+	LLMMode        string       `json:"llm_mode"`
+	LocalBaseURL   string       `json:"local_base_url"`
+	LocalReachable bool         `json:"local_reachable"`
+	EmbeddingModel *ModelStatus `json:"embedding_model,omitempty"`
+	LLMModel       *ModelStatus `json:"llm_model,omitempty"`
+	FallbackReason string       `json:"fallback_reason,omitempty"`
+}
+
+// usesLocal reports whether mode requires a reachable local endpoint.
+func usesLocal(mode string) bool {
+	return mode == config.AIBackendModeLocal || mode == config.AIBackendModeOpenAIFallbackLocal
+}
+
+// Status probes the configured local backend (if either pipeline is in a
+// local-involving mode) and reports the effective mode plus per-model pulled
+// state, so the Settings UI can decide whether to prompt for a model pull.
+//
+//	GET /api/v1/ai/backends/status
+func (h *Handler) Status(c *gin.Context) {
+	cfg := &config.AppConfig
+	resp := StatusResponse{
+		EmbeddingMode: cfg.EffectiveEmbeddingMode(),
+		LLMMode:       cfg.EffectiveLLMMode(),
+		LocalBaseURL:  cfg.AIBackend.LocalBaseURL,
+	}
+
+	needsLocal := usesLocal(resp.EmbeddingMode) || usesLocal(resp.LLMMode)
+	if !needsLocal || cfg.AIBackend.LocalBaseURL == "" {
+		httputil.RespondWithOK(c, resp)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), statusProbeTimeout)
+	defer cancel()
+
+	pulled, err := listPulledModels(ctx, cfg.AIBackend.LocalBaseURL)
+	resp.LocalReachable = err == nil
+	if err != nil {
+		resp.FallbackReason = "local endpoint unreachable: " + err.Error()
+	}
+
+	if usesLocal(resp.EmbeddingMode) && cfg.AIBackend.LocalEmbeddingModel != "" {
+		resp.EmbeddingModel = &ModelStatus{
+			Name:   cfg.AIBackend.LocalEmbeddingModel,
+			Pulled: modelPresent(pulled, cfg.AIBackend.LocalEmbeddingModel),
+		}
+	}
+	if usesLocal(resp.LLMMode) && cfg.AIBackend.LocalLLMModel != "" {
+		resp.LLMModel = &ModelStatus{
+			Name:   cfg.AIBackend.LocalLLMModel,
+			Pulled: modelPresent(pulled, cfg.AIBackend.LocalLLMModel),
+		}
+	}
+
+	httputil.RespondWithOK(c, resp)
+}
+
+// pullModelRequest is the request body for POST /api/v1/ai/backends/pull-model.
+type pullModelRequest struct {
+	Model string `json:"model" binding:"required"`
+}
+
+// PullModel shells out to the managed `ollama` binary (resolved through
+// ToolRegistry, the same lifecycle backing /api/v1/tools/:name/install) to
+// pull req.Model. It runs synchronously and returns once the pull completes
+// or pullTimeout elapses — there is no op-registry/streaming progress channel
+// for this endpoint; the frontend re-polls Status after this call returns,
+// mirroring the existing ToolsPanel install-then-refetch pattern.
+//
+//	POST /api/v1/ai/backends/pull-model
+func (h *Handler) PullModel(c *gin.Context) {
+	var req pullModelRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.Model == "" {
+		httputil.RespondWithBadRequest(c, "model is required")
+		return
+	}
+
+	if h.registry == nil {
+		httputil.RespondWithServiceUnavailable(c, "tool registry not configured")
+		return
+	}
+
+	binPath, err := h.registry.Resolve("ollama")
+	if err != nil {
+		httputil.RespondWithServiceUnavailable(c, "ollama is not available: "+err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), pullTimeout)
+	defer cancel()
+
+	// The ollama CLI's "pull" subcommand talks to a running "ollama serve"
+	// daemon over the local API, so ensure the managed daemon is up first
+	// (same pre-flight as drainEmbedQueue). Stop it back down once the pull
+	// finishes so an on-demand pull doesn't leave the daemon resident.
+	if h.daemon != nil {
+		if err := h.daemon.EnsureRunningOrAdopt(ctx); err != nil {
+			httputil.RespondWithServiceUnavailable(c, "failed to start ollama: "+err.Error())
+			return
+		}
+		defer h.daemon.StopWhenIdle(ctx) //nolint:errcheck
+	}
+
+	cmd := exec.CommandContext(ctx, binPath, "pull", req.Model)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		httputil.RespondWithInternalError(c, "ollama pull failed: "+err.Error()+": "+string(out))
+		return
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"model":  req.Model,
+		"pulled": true,
+	})
+}
+
+// ollamaTagsResponse mirrors the subset of Ollama's native GET /api/tags
+// response body this package needs.
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
+// listPulledModels fetches GET {baseURL}/api/tags (stripping a trailing "/v1"
+// since Ollama's native tags endpoint is unversioned, matching
+// ai.ProbeOllamaAvailable's URL handling) and returns the pulled model names.
+func listPulledModels(ctx context.Context, baseURL string) ([]string, error) {
+	root := strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1")
+	url := strings.TrimRight(root, "/") + "/api/tags"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		names = append(names, m.Name)
+	}
+	return names, nil
+}
+
+// modelPresent reports whether want matches any pulled model name. Ollama tag
+// names commonly include a ":tag" suffix (e.g. "bge-m3:latest"); a bare model
+// name configured without a tag should still match the tagged entry, so this
+// compares both the exact name and the name with its tag suffix stripped.
+func modelPresent(pulled []string, want string) bool {
+	for _, name := range pulled {
+		if name == want {
+			return true
+		}
+		if base, _, ok := strings.Cut(name, ":"); ok && base == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/handlers/aibackends/aibackends_test.go
+++ b/internal/server/handlers/aibackends/aibackends_test.go
@@ -1,0 +1,120 @@
+// file: internal/server/handlers/aibackends/aibackends_test.go
+// version: 1.0.0
+// guid: 8d4e0f32-5b6c-4a7d-8e9f-2b3c4d5e6f7a
+// last-edited: 2026-07-03
+
+package aibackendshandler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	aibackendshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/aibackends"
+)
+
+func TestHandlerStatusDisabledModesSkipProbe(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := config.AppConfig
+	defer func() { config.AppConfig = orig }()
+	config.AppConfig = config.Config{
+		AIBackend: config.AIBackendConfig{
+			EmbeddingMode: config.AIBackendModeDisabled,
+			LLMMode:       config.AIBackendModeDisabled,
+		},
+	}
+
+	h := aibackendshandler.New(nil, nil)
+	r := gin.New()
+	r.GET("/ai/backends/status", h.Status)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/ai/backends/status", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data aibackendshandler.StatusResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, config.AIBackendModeDisabled, body.Data.EmbeddingMode)
+	require.Equal(t, config.AIBackendModeDisabled, body.Data.LLMMode)
+	require.False(t, body.Data.LocalReachable)
+	require.Nil(t, body.Data.EmbeddingModel)
+	require.Nil(t, body.Data.LLMModel)
+}
+
+func TestHandlerStatusLocalModeUnreachableEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := config.AppConfig
+	defer func() { config.AppConfig = orig }()
+	config.AppConfig = config.Config{
+		AIBackend: config.AIBackendConfig{
+			EmbeddingMode:       config.AIBackendModeLocal,
+			LLMMode:             config.AIBackendModeDisabled,
+			LocalBaseURL:        "http://127.0.0.1:1/v1", // nothing listens here
+			LocalEmbeddingModel: "bge-m3",
+		},
+	}
+
+	h := aibackendshandler.New(nil, nil)
+	r := gin.New()
+	r.GET("/ai/backends/status", h.Status)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/ai/backends/status", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Data aibackendshandler.StatusResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, config.AIBackendModeLocal, body.Data.EmbeddingMode)
+	require.False(t, body.Data.LocalReachable)
+	require.NotEmpty(t, body.Data.FallbackReason)
+	require.NotNil(t, body.Data.EmbeddingModel)
+	require.Equal(t, "bge-m3", body.Data.EmbeddingModel.Name)
+	require.False(t, body.Data.EmbeddingModel.Pulled)
+}
+
+func TestHandlerPullModelRequiresModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := aibackendshandler.New(nil, nil)
+	r := gin.New()
+	r.POST("/ai/backends/pull-model", h.PullModel)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/ai/backends/pull-model", nil)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandlerPullModelNoRegistryReturnsUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := aibackendshandler.New(nil, nil)
+	r := gin.New()
+	r.POST("/ai/backends/pull-model", h.PullModel)
+
+	w := httptest.NewRecorder()
+	body := []byte(`{"model":"bge-m3"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/ai/backends/pull-model", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}

--- a/internal/server/handlers/aibackends/aibackends_test.go
+++ b/internal/server/handlers/aibackends/aibackends_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/aibackends/aibackends_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8d4e0f32-5b6c-4a7d-8e9f-2b3c4d5e6f7a
 // last-edited: 2026-07-03
 
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -117,4 +118,21 @@ func TestHandlerPullModelNoRegistryReturnsUnavailable(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandlerPullModelRejectsArgvInjection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := aibackendshandler.New(nil, nil)
+	r := gin.New()
+	r.POST("/ai/backends/pull-model", h.PullModel)
+
+	for _, bad := range []string{"--insecure", "-q", "a b", "a;b", "a$(x)", ":tag", "/leading", "a//b"} {
+		w := httptest.NewRecorder()
+		body := strings.NewReader(`{"model":"` + bad + `"}`)
+		req, _ := http.NewRequest(http.MethodPost, "/ai/backends/pull-model", body)
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equalf(t, http.StatusBadRequest, w.Code, "model %q must be rejected", bad)
+	}
 }

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.14.0
+// version: 2.15.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 package server
 
@@ -12,6 +12,7 @@ import (
 	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	aibackendshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/aibackends"
 	audiobookshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/audiobooks"
 	deduphandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/dedup"
 	duplicates "github.com/falkcorp/audiobook-organizer/internal/server/handlers/duplicates"
@@ -567,9 +568,14 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// Tools lifecycle handler (instantiated here so wireMediaRoutes receives it).
 	toolsH := toolshandler.New(s.toolRegistry, &config.AppConfig.Tools, nil)
 
+	// AI backend-mode status/pull-model handler (TASK-11, FE half of TASK-10's
+	// AIBackendConfig toggle). Reuses the same ToolRegistry/OllamaDaemon
+	// lifecycle as the tools handler above.
+	aiBackendsH := aibackendshandler.New(s.toolRegistry, s.ollamaDaemon)
+
 	// ── Register protected routes via per-domain methods ─────────────────────
 	s.wireLibraryRoutes(protected, cacheH, activityH, splitBookH, filesystemH, organizeH, metaCacheH, readingH, playlistH, userH, versionsH)
-	s.wireMediaRoutes(protected, itunesH, aiH, diagH, toolsH, pluginsH)
+	s.wireMediaRoutes(protected, itunesH, aiH, diagH, toolsH, aiBackendsH, pluginsH)
 	s.wireEntitiesRoutes(protected, entitiesH)
 	s.wireOperationsRoutes(protected, opsV2H, operationsH)
 	s.wireSystemRoutes(protected, systemH)

--- a/internal/server/wire_media_routes.go
+++ b/internal/server/wire_media_routes.go
@@ -1,25 +1,28 @@
 // file: internal/server/wire_media_routes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c9d0e1f2-a3b4-5678-cdef-901234567890
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package server
 
 import (
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	aibackendshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/aibackends"
 	toolshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/tools"
 	"github.com/gin-gonic/gin"
 )
 
-// wireMediaRoutes registers iTunes, AI, diagnostics, tools, and plugins routes
-// on the protected group. Handler instantiation stays in wireHandlers.
+// wireMediaRoutes registers iTunes, AI, diagnostics, tools, AI-backend, and
+// plugins routes on the protected group. Handler instantiation stays in
+// wireHandlers.
 func (s *Server) wireMediaRoutes(
 	protected *gin.RouterGroup,
 	itunesH *handlers.ITunesHandler,
 	aiH *handlers.AIHandler,
 	diagH *handlers.DiagnosticsHandler,
 	toolsH *toolshandler.Handler,
+	aiBackendsH *aibackendshandler.Handler,
 	pluginsH *handlers.PluginsHandler,
 ) {
 	// iTunes (12 migrated routes; survivors stay in server_lifecycle.go).
@@ -73,6 +76,10 @@ func (s *Server) wireMediaRoutes(
 	protected.GET("/tools", s.perm(auth.PermSettingsManage), toolsH.List)
 	protected.GET("/tools/:name/status", s.perm(auth.PermSettingsManage), toolsH.Status)
 	protected.POST("/tools/:name/install", s.perm(auth.PermSettingsManage), toolsH.Install)
+
+	// AI backend-mode toggle (TASK-11): status probe + on-demand model pull.
+	protected.GET("/ai/backends/status", s.perm(auth.PermSettingsManage), aiBackendsH.Status)
+	protected.POST("/ai/backends/pull-model", s.perm(auth.PermSettingsManage), aiBackendsH.PullModel)
 
 	// Plugins
 	plugins := protected.Group("/plugins")

--- a/web/src/components/settings/AIBackendsSection.test.tsx
+++ b/web/src/components/settings/AIBackendsSection.test.tsx
@@ -1,0 +1,131 @@
+// file: web/src/components/settings/AIBackendsSection.test.tsx
+// version: 1.0.0
+// guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-07-03
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AIBackendsSection } from './AIBackendsSection';
+import type { AIBackendConfig, AIBackendsStatus } from '../../services/api';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api', async () => {
+  const actual = await vi.importActual<typeof api>('../../services/api');
+  return {
+    ...actual,
+    getAIBackendsStatus: vi.fn(),
+    pullAIBackendModel: vi.fn(),
+  };
+});
+
+const defaultConfig: AIBackendConfig = {
+  embedding_mode: 'disabled',
+  llm_mode: 'disabled',
+  local_base_url: '',
+  local_embedding_model: '',
+  local_llm_model: '',
+};
+
+describe('AIBackendsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the section heading', () => {
+    render(<AIBackendsSection config={defaultConfig} onChange={vi.fn()} />);
+    expect(screen.getByText('AI Backends')).toBeInTheDocument();
+  });
+
+  it('renders both mode selects', () => {
+    render(<AIBackendsSection config={defaultConfig} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('Embedding mode')).toBeInTheDocument();
+    expect(screen.getByLabelText('LLM mode')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the new embedding mode when selected', async () => {
+    const onChange = vi.fn();
+    render(<AIBackendsSection config={defaultConfig} onChange={onChange} />);
+    const select = screen.getByLabelText('Embedding mode');
+    fireEvent.mouseDown(select);
+    const option = await screen.findByRole('option', { name: 'Local (Ollama)' });
+    fireEvent.click(option);
+    expect(onChange).toHaveBeenCalledWith({ embedding_mode: 'local' });
+  });
+
+  it('hides local fields when neither mode is local-involving', () => {
+    render(<AIBackendsSection config={defaultConfig} onChange={vi.fn()} />);
+    expect(screen.queryByLabelText('Local base URL')).not.toBeInTheDocument();
+  });
+
+  it('shows local fields when embedding mode is local', () => {
+    render(
+      <AIBackendsSection
+        config={{ ...defaultConfig, embedding_mode: 'local' }}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('Local base URL')).toBeInTheDocument();
+    expect(screen.getByLabelText('Local embedding model')).toBeInTheDocument();
+    expect(screen.getByLabelText('Local LLM model')).toBeInTheDocument();
+  });
+
+  it('shows local fields when llm mode is openai-fallback-local', () => {
+    render(
+      <AIBackendsSection
+        config={{ ...defaultConfig, llm_mode: 'openai-fallback-local' }}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('Local base URL')).toBeInTheDocument();
+  });
+
+  it('calls getAIBackendsStatus and displays effective mode on Test Connection', async () => {
+    const status: AIBackendsStatus = {
+      embedding_mode: 'local',
+      llm_mode: 'disabled',
+      local_base_url: 'http://192.168.0.20:11434/v1',
+      local_reachable: true,
+    };
+    vi.mocked(api.getAIBackendsStatus).mockResolvedValue(status);
+
+    render(
+      <AIBackendsSection config={{ ...defaultConfig, embedding_mode: 'local' }} onChange={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Embedding: local')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Local endpoint reachable')).toBeInTheDocument();
+  });
+
+  it('shows a pull-model dialog when status reports the model absent, and pulls on confirm', async () => {
+    const status: AIBackendsStatus = {
+      embedding_mode: 'local',
+      llm_mode: 'disabled',
+      local_base_url: 'http://192.168.0.20:11434/v1',
+      local_reachable: true,
+      embedding_model: { name: 'bge-m3', pulled: false },
+    };
+    vi.mocked(api.getAIBackendsStatus).mockResolvedValue(status);
+    vi.mocked(api.pullAIBackendModel).mockResolvedValue({ model: 'bge-m3', pulled: true });
+
+    render(
+      <AIBackendsSection config={{ ...defaultConfig, embedding_mode: 'local' }} onChange={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText('Test Connection'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Not pulled')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Pull now'));
+    expect(screen.getByText('bge-m3 not pulled — Pull now?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => {
+      expect(api.pullAIBackendModel).toHaveBeenCalledWith('bge-m3');
+    });
+  });
+});

--- a/web/src/components/settings/AIBackendsSection.tsx
+++ b/web/src/components/settings/AIBackendsSection.tsx
@@ -1,0 +1,255 @@
+// file: web/src/components/settings/AIBackendsSection.tsx
+// version: 1.0.0
+// guid: 9e1f2a3b-4c5d-6e7f-8a9b-0c1d2e3f4a5b
+// last-edited: 2026-07-03
+
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  MenuItem,
+  Grid,
+  Button,
+  Alert,
+  Chip,
+  Stack,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@mui/material';
+import * as api from '../../services/api';
+
+interface AIBackendsSectionProps {
+  config: api.AIBackendConfig;
+  onChange: (patch: Partial<api.AIBackendConfig>) => void;
+}
+
+const MODE_OPTIONS: { value: api.AIBackendMode; label: string }[] = [
+  { value: 'disabled', label: 'Disabled' },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'local', label: 'Local (Ollama)' },
+  { value: 'openai-fallback-local', label: 'OpenAI (fallback to local)' },
+];
+
+function usesLocal(mode: string): boolean {
+  return mode === 'local' || mode === 'openai-fallback-local';
+}
+
+export function AIBackendsSection({ config, onChange }: AIBackendsSectionProps) {
+  const [status, setStatus] = useState<api.AIBackendsStatus | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [pullTarget, setPullTarget] = useState<{ model: string; label: string } | null>(null);
+  const [pulling, setPulling] = useState(false);
+  const [pullError, setPullError] = useState<string | null>(null);
+
+  const showLocalFields = usesLocal(config.embedding_mode) || usesLocal(config.llm_mode);
+
+  const runStatusCheck = async () => {
+    setTesting(true);
+    setTestError(null);
+    try {
+      const result = await api.getAIBackendsStatus();
+      setStatus(result);
+    } catch (e: unknown) {
+      setTestError((e as Error).message);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handlePullConfirm = async () => {
+    if (!pullTarget) return;
+    setPulling(true);
+    setPullError(null);
+    try {
+      await api.pullAIBackendModel(pullTarget.model);
+      setPullTarget(null);
+      const result = await api.getAIBackendsStatus();
+      setStatus(result);
+    } catch (e: unknown) {
+      setPullError((e as Error).message);
+    } finally {
+      setPulling(false);
+    }
+  };
+
+  const absentModels = status
+    ? [status.embedding_model, status.llm_model].filter(
+        (m): m is api.AIBackendModelStatus => !!m && !m.pulled
+      )
+    : [];
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        AI Backends
+      </Typography>
+      <Typography variant="body2" color="text.secondary" mb={2}>
+        Choose which backend serves embeddings and LLM/chat requests, independently.
+      </Typography>
+
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <TextField
+            select
+            fullWidth
+            label="Embedding mode"
+            value={config.embedding_mode || 'disabled'}
+            onChange={(e) => onChange({ embedding_mode: e.target.value })}
+            size="small"
+          >
+            {MODE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        <Grid item xs={12} sm={6}>
+          <TextField
+            select
+            fullWidth
+            label="LLM mode"
+            value={config.llm_mode || 'disabled'}
+            onChange={(e) => onChange({ llm_mode: e.target.value })}
+            size="small"
+          >
+            {MODE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+
+        {showLocalFields && (
+          <>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                fullWidth
+                label="Local base URL"
+                value={config.local_base_url}
+                onChange={(e) => onChange({ local_base_url: e.target.value })}
+                helperText="e.g. http://192.168.0.20:11434/v1"
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                fullWidth
+                label="Local embedding model"
+                value={config.local_embedding_model}
+                onChange={(e) => onChange({ local_embedding_model: e.target.value })}
+                helperText="e.g. bge-m3"
+                size="small"
+              />
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <TextField
+                fullWidth
+                label="Local LLM model"
+                value={config.local_llm_model}
+                onChange={(e) => onChange({ local_llm_model: e.target.value })}
+                helperText="e.g. qwen2.5:7b-instruct"
+                size="small"
+              />
+            </Grid>
+          </>
+        )}
+
+        <Grid item xs={12}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={runStatusCheck}
+            disabled={testing}
+            startIcon={testing ? <CircularProgress size={14} /> : undefined}
+          >
+            {testing ? 'Testing…' : 'Test Connection'}
+          </Button>
+        </Grid>
+
+        {testError && (
+          <Grid item xs={12}>
+            <Alert severity="error">{testError}</Alert>
+          </Grid>
+        )}
+
+        {status && (
+          <Grid item xs={12}>
+            <Stack spacing={1}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Chip size="small" label={`Embedding: ${status.embedding_mode}`} />
+                <Chip size="small" label={`LLM: ${status.llm_mode}`} />
+                <Chip
+                  size="small"
+                  label={status.local_reachable ? 'Local endpoint reachable' : 'Local endpoint unreachable'}
+                  color={status.local_reachable ? 'success' : 'default'}
+                />
+              </Stack>
+              {status.fallback_reason && (
+                <Alert severity="warning">{status.fallback_reason}</Alert>
+              )}
+              {[status.embedding_model, status.llm_model]
+                .filter((m): m is api.AIBackendModelStatus => !!m)
+                .map((m) => (
+                  <Stack key={m.name} direction="row" spacing={1} alignItems="center">
+                    <Typography variant="body2">{m.name}</Typography>
+                    <Chip
+                      size="small"
+                      label={m.pulled ? 'Pulled' : 'Not pulled'}
+                      color={m.pulled ? 'success' : 'warning'}
+                    />
+                    {!m.pulled && (
+                      <Button
+                        size="small"
+                        onClick={() => setPullTarget({ model: m.name, label: m.name })}
+                      >
+                        Pull now
+                      </Button>
+                    )}
+                  </Stack>
+                ))}
+              {absentModels.length === 0 && status.local_reachable && (
+                <Alert severity="success">All configured local models are pulled.</Alert>
+              )}
+            </Stack>
+          </Grid>
+        )}
+      </Grid>
+
+      <Dialog open={!!pullTarget} onClose={() => (pulling ? undefined : setPullTarget(null))}>
+        <DialogTitle>Pull model?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {pullTarget ? `${pullTarget.label} not pulled — Pull now?` : ''}
+          </DialogContentText>
+          {pullError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {pullError}
+            </Alert>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPullTarget(null)} disabled={pulling}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handlePullConfirm}
+            variant="contained"
+            disabled={pulling}
+            startIcon={pulling ? <CircularProgress size={14} /> : undefined}
+          >
+            {pulling ? 'Installing…' : 'Confirm'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/web/src/hooks/useSettingsHandlers.ts
+++ b/web/src/hooks/useSettingsHandlers.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useSettingsHandlers.ts
-// version: 1.4.0
+// version: 1.5.0
 // guid: b8c9d0e1-f2a3-4567-bcde-678901234567
-// last-edited: 2026-06-24
+// last-edited: 2026-07-03
 
 import { ChangeEvent, Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { NavigateFunction } from 'react-router-dom';
@@ -48,6 +48,7 @@ export interface UseSettingsHandlersParams {
   setConfigLoaded: Dispatch<SetStateAction<boolean>>;
   setDedupConfig: Dispatch<SetStateAction<api.DedupConfig>>;
   setEmbeddingConfig: Dispatch<SetStateAction<api.EmbeddingConfig>>;
+  setAIBackendConfig: Dispatch<SetStateAction<api.AIBackendConfig>>;
   setMetadataScoringConfig: Dispatch<SetStateAction<api.MetadataScoringConfig>>;
   setMaintenanceConfig: Dispatch<SetStateAction<api.MaintenanceConfig>>;
   setScheduledConfig: Dispatch<SetStateAction<api.ScheduledTasksConfig | null>>;
@@ -107,6 +108,7 @@ export interface UseSettingsHandlersParams {
   blocker: Blocker;
   dedupConfig: api.DedupConfig;
   embeddingConfig: api.EmbeddingConfig;
+  aiBackendConfig: api.AIBackendConfig;
   metadataScoringConfig: api.MetadataScoringConfig;
   maintenanceConfig: api.MaintenanceConfig;
   scheduledConfig: api.ScheduledTasksConfig | null;
@@ -126,6 +128,7 @@ export interface UseSettingsHandlersReturn {
   handleChange: (field: string, value: string | boolean | number | string[]) => void;
   handleDedupChange: (patch: Partial<api.DedupConfig>) => void;
   handleEmbeddingChange: (patch: Partial<api.EmbeddingConfig>) => void;
+  handleAIBackendChange: (patch: Partial<api.AIBackendConfig>) => void;
   handleMetadataScoringChange: (patch: Partial<api.MetadataScoringConfig>) => void;
   handleMaintenanceChange: (patch: Partial<api.MaintenanceConfig>) => void;
   handleScheduledChange: (patch: Partial<api.ScheduledTasksConfig>) => void;
@@ -181,6 +184,7 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
     setConfigLoaded: _setConfigLoaded,
     setDedupConfig,
     setEmbeddingConfig,
+    setAIBackendConfig,
     setMetadataScoringConfig,
     setMaintenanceConfig,
     setScheduledConfig,
@@ -239,6 +243,7 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
     blocker,
     dedupConfig,
     embeddingConfig,
+    aiBackendConfig,
     metadataScoringConfig,
     maintenanceConfig,
     scheduledConfig,
@@ -290,6 +295,11 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
 
   const handleEmbeddingChange = (patch: Partial<api.EmbeddingConfig>) => {
     setEmbeddingConfig((prev) => ({ ...prev, ...patch }));
+    setSaved(false);
+  };
+
+  const handleAIBackendChange = (patch: Partial<api.AIBackendConfig>) => {
+    setAIBackendConfig((prev) => ({ ...prev, ...patch }));
     setSaved(false);
   };
 
@@ -479,6 +489,7 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
         maintenance_window_end: maintenanceConfig.window_end,
         maintenance: maintenanceConfig,
         embedding: embeddingConfig,
+        ai_backend: aiBackendConfig,
         dedup: dedupConfig,
         metadata_scoring: metadataScoringConfig,
         ...(scheduledConfig ? { scheduled: scheduledConfig } : {}),
@@ -907,6 +918,7 @@ export function useSettingsHandlers(params: UseSettingsHandlersParams): UseSetti
     handleChange,
     handleDedupChange,
     handleEmbeddingChange,
+    handleAIBackendChange,
     handleMetadataScoringChange,
     handleMaintenanceChange,
     handleScheduledChange,

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Settings.tsx
-// version: 1.53.0
+// version: 1.54.0
 // guid: 7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-06-19
+// last-edited: 2026-07-03
 
 import { useState, useEffect, useMemo, useRef, ChangeEvent } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -40,6 +40,7 @@ import { ITunesImport } from '../components/settings/ITunesImport';
 import { ITunesTransfer } from '../components/settings/ITunesTransfer';
 import { SystemInfoTab } from '../components/system/SystemInfoTab';
 import { EmbeddingSettingsSection } from '../components/settings/EmbeddingSettingsSection';
+import { AIBackendsSection } from '../components/settings/AIBackendsSection';
 import { DedupSettingsSection } from '../components/settings/DedupSettingsSection';
 import { MetadataScoringSection } from '../components/settings/MetadataScoringSection';
 import { MaintenanceSettingsSection } from '../components/settings/MaintenanceSettingsSection';
@@ -368,6 +369,13 @@ export function Settings() {
     base_url: '',
     vector_backend: 'hnsw',
   });
+  const [aiBackendConfig, setAIBackendConfig] = useState<api.AIBackendConfig>({
+    embedding_mode: 'disabled',
+    llm_mode: 'disabled',
+    local_base_url: '',
+    local_embedding_model: '',
+    local_llm_model: '',
+  });
   const [metadataScoringConfig, setMetadataScoringConfig] = useState<api.MetadataScoringConfig>({
     embedding_enabled: false,
     embedding_min_score: 0.82,
@@ -599,6 +607,7 @@ export function Settings() {
       };
       if (config.dedup) setDedupConfig(config.dedup);
       if (config.embedding) setEmbeddingConfig(config.embedding);
+      if (config.ai_backend) setAIBackendConfig(config.ai_backend);
       if (config.metadata_scoring) setMetadataScoringConfig(config.metadata_scoring);
       if (config.maintenance) setMaintenanceConfig(config.maintenance);
       if (config.scheduled) setScheduledConfig(config.scheduled);
@@ -619,6 +628,7 @@ export function Settings() {
     handleChange,
     handleDedupChange,
     handleEmbeddingChange,
+    handleAIBackendChange,
     handleMetadataScoringChange,
     handleMaintenanceChange,
     handleScheduledChange,
@@ -661,7 +671,7 @@ export function Settings() {
     handleCancelNavigation,
   } = useSettingsHandlers({
     settings, setSettings, setSaved, setSavedApiKeyMask, setConfigLoaded,
-    setDedupConfig, setEmbeddingConfig, setMetadataScoringConfig,
+    setDedupConfig, setEmbeddingConfig, setAIBackendConfig, setMetadataScoringConfig,
     setMaintenanceConfig, setScheduledConfig, setToolsConfig,
     setLibraryPathError, setOpenaiKeyError, setExtensionsError, setExcludePatternError,
     setImportFolders, setScanStatuses, setCancelScanTarget,
@@ -678,7 +688,7 @@ export function Settings() {
     restoreTarget, restoreVerify, deleteBackupTarget, cancelScanTarget,
     scanStatuses, importPayload, importFileName, savedSettings,
     extensionsInput, excludePatternInput, newFolderPath, selectedPath,
-    blocker, dedupConfig, embeddingConfig, metadataScoringConfig,
+    blocker, dedupConfig, embeddingConfig, aiBackendConfig, metadataScoringConfig,
     maintenanceConfig, scheduledConfig, toolsConfig,
     importInputRef, loadConfig, initialSettings,
   });
@@ -804,6 +814,9 @@ export function Settings() {
           <DedupSettingsSection config={dedupConfig} onChange={handleDedupChange} />
           <Box sx={{ mt: 4 }}>
             <EmbeddingSettingsSection config={embeddingConfig} onChange={handleEmbeddingChange} />
+          </Box>
+          <Box sx={{ mt: 4 }}>
+            <AIBackendsSection config={aiBackendConfig} onChange={handleAIBackendChange} />
           </Box>
           <Box sx={{ mt: 4 }}>
             <MetadataScoringSection config={metadataScoringConfig} onChange={handleMetadataScoringChange} />

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.49.0
+// version: 2.50.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -631,6 +631,19 @@ export interface EmbeddingConfig {
   vector_backend: string;
 }
 
+// AI backend-mode toggle (TASK-10). embedding_mode/llm_mode select,
+// independently, whether the embedding/LLM pipeline runs against OpenAI, a
+// local OpenAI-compatible endpoint (e.g. Ollama), or is disabled.
+export type AIBackendMode = 'disabled' | 'openai' | 'local' | 'openai-fallback-local';
+
+export interface AIBackendConfig {
+  embedding_mode: string;
+  llm_mode: string;
+  local_base_url: string;
+  local_embedding_model: string;
+  local_llm_model: string;
+}
+
 export interface DedupSignalConfig {
   band_certain_min: number;
   band_high_min: number;
@@ -818,6 +831,7 @@ export interface Config {
 
   // Sub-structs (CFG-1 nested fields)
   embedding?: EmbeddingConfig;
+  ai_backend?: AIBackendConfig;
   dedup?: DedupConfig;
   metadata_scoring?: MetadataScoringConfig;
   itunes?: ITunesConfig;
@@ -5707,4 +5721,46 @@ export async function installTool(name: string): Promise<{ path: string; version
     throw await buildApiError(response, `Failed to install ${name}`);
   }
   return response.json();
+}
+
+// --- AI backend-mode toggle (TASK-11: FE for TASK-10's AIBackendConfig) ---
+
+export interface AIBackendModelStatus {
+  name: string;
+  pulled: boolean;
+}
+
+export interface AIBackendsStatus {
+  embedding_mode: string;
+  llm_mode: string;
+  local_base_url: string;
+  local_reachable: boolean;
+  embedding_model?: AIBackendModelStatus;
+  llm_model?: AIBackendModelStatus;
+  fallback_reason?: string;
+}
+
+export async function getAIBackendsStatus(): Promise<AIBackendsStatus> {
+  const response = await apiFetch(`${API_BASE}/ai/backends/status`, {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to fetch AI backend status');
+  }
+  const body = await response.json();
+  return body.data;
+}
+
+export async function pullAIBackendModel(model: string): Promise<{ model: string; pulled: boolean }> {
+  const response = await apiFetch(`${API_BASE}/ai/backends/pull-model`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model }),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, `Failed to pull model ${model}`);
+  }
+  const body = await response.json();
+  return body.data;
 }

--- a/web/tests/e2e/settings-ai-persistence.spec.ts
+++ b/web/tests/e2e/settings-ai-persistence.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/settings-ai-persistence.spec.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1e2d3c4-b5a6-7890-abcd-123456789abc
 
 import { test, expect, type Page } from '@playwright/test';
@@ -98,6 +98,71 @@ test.describe('AI Key Persistence', () => {
     await page.getByRole('button', { name: 'Test Connection' }).click();
 
     await expect(page.getByText('Connection failed')).toBeVisible();
+  });
+});
+
+test.describe('AI Backends (TASK-11)', () => {
+  test('switching embedding mode to local reveals local fields', async ({ page }) => {
+    await openSettings(page);
+
+    await page.getByRole('tab', { name: 'Dedup' }).click();
+    await expect(page.getByLabel('Local base URL')).not.toBeVisible();
+
+    await page.getByLabel('Embedding mode').click();
+    await page.getByRole('option', { name: 'Local (Ollama)' }).click();
+
+    await expect(page.getByLabel('Local base URL')).toBeVisible();
+    await expect(page.getByLabel('Local embedding model')).toBeVisible();
+    await expect(page.getByLabel('Local LLM model')).toBeVisible();
+  });
+
+  test('saves local mode and endpoint fields, and they persist on reload', async ({ page }) => {
+    await openSettings(page);
+
+    await page.getByRole('tab', { name: 'Dedup' }).click();
+    await page.getByLabel('Embedding mode').click();
+    await page.getByRole('option', { name: 'Local (Ollama)' }).click();
+
+    await page.getByLabel('Local base URL').fill('http://192.168.0.20:11434/v1');
+    await page.getByLabel('Local embedding model').fill('bge-m3');
+
+    await page.getByRole('button', { name: 'Save Settings' }).click();
+    await expect(page.getByText('Settings saved successfully!')).toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('tab', { name: 'Dedup' }).click();
+
+    await expect(page.getByLabel('Local base URL')).toHaveValue('http://192.168.0.20:11434/v1');
+    await expect(page.getByLabel('Local embedding model')).toHaveValue('bge-m3');
+  });
+
+  test('Test Connection with an absent local model shows the pull-model dialog', async ({ page }) => {
+    await openSettings(page, {
+      config: {
+        ai_backend: {
+          embedding_mode: 'local',
+          local_base_url: 'http://192.168.0.20:11434/v1',
+          local_embedding_model: 'bge-m3',
+        },
+      },
+      aiBackendsStatus: {
+        embedding_mode: 'local',
+        local_base_url: 'http://192.168.0.20:11434/v1',
+        local_reachable: true,
+        embedding_model: { name: 'bge-m3', pulled: false },
+      },
+    });
+
+    await page.getByRole('tab', { name: 'Dedup' }).click();
+    await page.getByRole('button', { name: 'Test Connection' }).click();
+
+    await expect(page.getByText('Not pulled')).toBeVisible();
+    await page.getByRole('button', { name: 'Pull now' }).click();
+    await expect(page.getByText('bge-m3 not pulled — Pull now?')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await expect(page.getByRole('dialog')).not.toBeVisible();
   });
 });
 

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/utils/test-helpers.ts
-// version: 2.7.0
+// version: 2.8.0
 // guid: a1b2c3d4-e5f6-7890-abcd-e1f2a3b4c5d6
-// last-edited: 2026-02-15
+// last-edited: 2026-07-03
 
 import { Page } from '@playwright/test';
 
@@ -55,6 +55,13 @@ export interface MockConfig {
   api_keys: Record<string, never>;
   supported_extensions: string[];
   exclude_patterns?: string[];
+  ai_backend?: {
+    embedding_mode?: string;
+    llm_mode?: string;
+    local_base_url?: string;
+    local_embedding_model?: string;
+    local_llm_model?: string;
+  };
 }
 
 interface MockImportPath {
@@ -251,6 +258,15 @@ export interface MockApiOptions {
   systemStatus?: Record<string, unknown>;
   authorDedup?: { groups: MockAuthorDedupGroup[]; needs_refresh?: boolean };
   seriesDedup?: { groups: MockSeriesDupGroup[]; total_series?: number };
+  aiBackendsStatus?: {
+    embedding_mode?: string;
+    llm_mode?: string;
+    local_base_url?: string;
+    local_reachable?: boolean;
+    embedding_model?: { name: string; pulled: boolean };
+    llm_model?: { name: string; pulled: boolean };
+    fallback_reason?: string;
+  };
 }
 
 export interface TestBook {
@@ -374,6 +390,13 @@ export async function setupMockApiRoutes(
     failures: options.failures || {},
     authorDedup: options.authorDedup || { groups: [] },
     seriesDedup: options.seriesDedup || { groups: [], total_series: 0 },
+    aiBackendsStatus: {
+      embedding_mode: 'disabled',
+      llm_mode: 'disabled',
+      local_base_url: '',
+      local_reachable: false,
+      ...options.aiBackendsStatus,
+    },
   };
 
   // Use addInitScript to set localStorage and basic state
@@ -1213,6 +1236,32 @@ export async function setupMockApiRoutes(
       }
       return route.fulfill(jsonResponse({ success: true, message: 'Connection successful' }));
     }
+
+    // AI backend-mode status/pull-model (TASK-11). Must come before the
+    // "/api/v1/ai/" prefix catch-all below, which would otherwise shadow
+    // these with a generic { message: 'OK' } response.
+    if (pathname === '/api/v1/ai/backends/status' && method === 'GET') {
+      return route.fulfill(jsonResponse({ data: mockState.aiBackendsStatus }));
+    }
+
+    if (pathname === '/api/v1/ai/backends/pull-model' && method === 'POST') {
+      let model = '';
+      try {
+        const body = route.request().postDataJSON();
+        model = (body && body.model) || '';
+      } catch {
+        // ignore parse errors
+      }
+      const status = mockState.aiBackendsStatus as Record<string, unknown>;
+      if (status.embedding_model && (status.embedding_model as { name: string }).name === model) {
+        status.embedding_model = { name: model, pulled: true };
+      }
+      if (status.llm_model && (status.llm_model as { name: string }).name === model) {
+        status.llm_model = { name: model, pulled: true };
+      }
+      return route.fulfill(jsonResponse({ data: { model, pulled: true } }));
+    }
+
     if (pathname.startsWith('/api/v1/ai/')) {
       return route.fulfill(jsonResponse({ message: 'OK' }));
     }


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-11** (wave 4): Settings UI for TASK-10's backend-mode toggle, plus the HTTP endpoints TASK-10 didn't ship (added per brief's fallback):

- **Backend:** new `aibackends` handler — `GET /api/v1/ai/backends/status` (effective modes, local-endpoint probe, per-model pulled state) and `POST /api/v1/ai/backends/pull-model` (via ToolRegistry/OllamaDaemon, synchronous); wired with `PermSettingsManage`
- **Frontend:** `AIBackendsSection` on the Settings Dedup tab — embedding/LLM mode selectors, conditional local fields, Test Connection, pull-model confirm dialog; `api.ts` types + calls mirroring the embedding-config pattern
- **e2e:** 3 Playwright specs; fixed a pre-existing mock-route catch-all (`/api/v1/ai/` prefix) that silently shadowed newer routes with generic OK responses

## Test plan

- [x] vitest 16/16 (new section + neighbor regression); tsc, eslint, `npm run build` clean
- [x] `internal/server/handlers/aibackends` 4/4; go build + vet clean
- [x] Playwright chromium 12/13 — the 1 failure is a pre-existing untouched spec (`AI Key Persistence > test connection works with saved key`), content unmodified per git diff
- [ ] Local honest gate (queued behind cr-17's)
- [ ] Minimal CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1