### PR TITLE
fix(server): dedup engine builds on keyless local backends — prod regression from TASK-10

### DIFF
--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,5 +1,5 @@
 // file: internal/server/registry_wire.go
-// version: 1.17.0
+// version: 1.18.0
 // last-edited: 2026-07-03
 
 package server
@@ -130,14 +130,24 @@ func init() {
 		Groups: []string{"ai"},
 		Build: func(c *serviceregistry.Container) (any, error) {
 			cfg := serviceregistry.Get[*config.Config](c, serviceregistry.KeyConfig)
-			if cfg.OpenAIAPIKey == "" || !cfg.Embedding.Enabled {
+			// Keyless local backends are valid (TOGGLE-1/TASK-10): gate on the
+			// resolved effective mode, not on OpenAIAPIKey presence. The old
+			// key check silently disabled the whole dedup plugin on keyless
+			// prod once TASK-10 stopped injecting a dummy key into cfg.
+			if cfg.EffectiveEmbeddingMode() == config.AIBackendModeDisabled {
 				return (*dedup.Engine)(nil), nil
 			}
 			embStore, _ := serviceregistry.TryGet[*database.EmbeddingStore](c, serviceregistry.KeyEmbeddingStore)
 			embClient, _ := serviceregistry.TryGet[*ai.EmbeddingClient](c, "embedclient")
-			llmParser, _ := serviceregistry.TryGet[*ai.OpenAIParser](c, "llmparser")
-			if embStore == nil || embClient == nil || llmParser == nil {
+			if embStore == nil || embClient == nil {
 				return (*dedup.Engine)(nil), nil
+			}
+			// llmParser may legitimately be nil (EffectiveLLMMode disabled on a
+			// keyless local-embedding box) — NewEngine documents nil as "Layer 3
+			// LLM review disabled" and nil-guards every use.
+			llmParser, _ := serviceregistry.TryGet[*ai.OpenAIParser](c, "llmparser")
+			if llmParser == nil {
+				slog.Info("dedup engine: LLM parser unavailable (LLM mode disabled) — Layer 3 LLM review off")
 			}
 			store := serviceregistry.Get[database.Store](c, serviceregistry.KeyStore)
 			mergeSvc := serviceregistry.Get[*merge.Service](c, serviceregistry.KeyMerge)


### PR DESCRIPTION
## Summary

**Prod regression** (caught because `dedup.embed-scan` enqueue returned "unknown defID"): since the 17:51 deploy, the dedup engine failed to construct on prod, so the ENTIRE dedup plugin skipped registration — embed-scan, drain-stale, auto-resolve, calibrate-thresholds, full-scan all gone.

Root cause: TASK-10 (#1775) stopped injecting a dummy OpenAI key into cfg (correct), which exposed two stale gates in `registry_wire.go`'s engine build:
1. `cfg.OpenAIAPIKey == ""` → engine nil, even though prod is keyless local-embedding. Now gates on `EffectiveEmbeddingMode() == disabled`.
2. `llmParser == nil` → engine nil, even though `NewEngine` documents nil parser as "Layer 3 LLM review disabled" and nil-guards every use (`engine.go:179,2869`). Now optional with an INFO log.

Timeline evidence: `dedup.embed-scan` registered on the 15:19 and 17:19 boots, absent from 17:51 (first boot with #1775).

## Test plan

- [x] `internal/server` wiring tests + full `internal/dedup` suite green; build + vet clean
- [ ] Minimal CI green
- [ ] Post-deploy: `registered op id=dedup.embed-scan` in boot log + successful enqueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1