### PR TITLE
fix(web): cap 4 unbounded-growth paths — 20GB browser-tab leak

### DIFF
--- a/web/src/pages/ActivityLog.tsx
+++ b/web/src/pages/ActivityLog.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/ActivityLog.tsx
-// version: 2.18.0
+// version: 2.19.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-06-22
+// last-edited: 2026-07-03
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -318,7 +318,9 @@ export default function ActivityLog() {
   useEffect(() => {
     if (!latestLogEvent || latestLogEvent.op_id !== expandedOpId) return;
     setOpLogsLoaded(true);
-    setOpLogs((prev) => [...prev, latestLogEvent.message]);
+    // Cap retained log lines to avoid unbounded growth on long-running ops
+    // (mirrors OperationActivityPanel's per-op cap).
+    setOpLogs((prev) => [...prev, latestLogEvent.message].slice(-1000));
     const scrollTimeout = window.setTimeout(
       () => opLogsRef.current?.scrollTo({ top: opLogsRef.current.scrollHeight }),
       50,

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.75.0
+// version: 1.76.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -47,6 +47,7 @@ import type {
   DuplicateDialogState,
   OrganizeErrorState,
 } from './libraryTypes';
+import { evictOldestOpLogKey, MAX_OPERATION_LOG_KEYS } from './libraryOperationLogs';
 
 // Types ImportPath, BulkActionResult, BulkActionProgress, DuplicateAction,
 // DuplicateDialogState, OrganizeErrorState imported from './libraryTypes'
@@ -401,15 +402,18 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         try {
           const hist = await api.getOperationLogsTail(op.id, 100);
           if (hist && hist.length) {
-            setOperationLogs((prev) => ({
-              ...prev,
-              [op.id]: hist.map((h: api.OperationLog) => ({
-                level: h.level,
-                message: h.message,
-                details: h.details,
-                timestamp: Date.parse(h.created_at) || Date.now(),
-              })),
-            }));
+            setOperationLogs((prev) => {
+              const capped = evictOldestOpLogKey(prev, op.id, MAX_OPERATION_LOG_KEYS);
+              return {
+                ...capped,
+                [op.id]: hist.map((h: api.OperationLog) => ({
+                  level: h.level,
+                  message: h.message,
+                  details: h.details,
+                  timestamp: Date.parse(h.created_at) || Date.now(),
+                })),
+              };
+            });
           }
         } catch (_e) {
           // ignore hydration errors
@@ -425,7 +429,8 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         if (evt.type === 'operation.log' && evt.data?.operation_id) {
           const opId = String(evt.data.operation_id);
           setOperationLogs((prev) => {
-            const existing = prev[opId] || [];
+            const capped = evictOldestOpLogKey(prev, opId, MAX_OPERATION_LOG_KEYS);
+            const existing = capped[opId] || [];
             const next = [
               ...existing,
               {
@@ -435,7 +440,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
                 timestamp: Date.now(),
               },
             ];
-            return { ...prev, [opId]: next.slice(-200) };
+            return { ...capped, [opId]: next.slice(-200) };
           });
         } else if (evt.type === 'operation.progress' && evt.data?.operation_id) {
           const opId = String(evt.data.operation_id);

--- a/web/src/pages/libraryOperationLogs.test.ts
+++ b/web/src/pages/libraryOperationLogs.test.ts
@@ -1,0 +1,54 @@
+// file: web/src/pages/libraryOperationLogs.test.ts
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b
+// last-edited: 2026-07-03
+
+import { describe, it, expect } from 'vitest';
+import { evictOldestOpLogKey, MAX_OPERATION_LOG_KEYS } from './libraryOperationLogs';
+
+// Regression coverage for an unbounded-memory-growth bug: per-op log entries
+// were capped at 200 lines each, but the map of op-id -> entries itself was
+// never bounded, so it grew for the lifetime of the page as operations came
+// and went.
+
+type Entry = { level: string; message: string; timestamp: number };
+
+const entries = (n: number): Entry[] => [{ level: 'info', message: `msg-${n}`, timestamp: n }];
+
+describe('evictOldestOpLogKey', () => {
+  it('evicts the oldest-inserted key once the cap is reached', () => {
+    let logs: Record<string, Entry[]> = {};
+    for (let i = 0; i < MAX_OPERATION_LOG_KEYS; i++) {
+      const opId = `op-${i}`;
+      logs = evictOldestOpLogKey(logs, opId, MAX_OPERATION_LOG_KEYS);
+      logs = { ...logs, [opId]: entries(i) };
+    }
+    expect(Object.keys(logs)).toHaveLength(MAX_OPERATION_LOG_KEYS);
+
+    // Adding one more beyond the cap evicts op-0 (oldest inserted).
+    const newOpId = `op-${MAX_OPERATION_LOG_KEYS}`;
+    logs = evictOldestOpLogKey(logs, newOpId, MAX_OPERATION_LOG_KEYS);
+    logs = { ...logs, [newOpId]: entries(MAX_OPERATION_LOG_KEYS) };
+
+    expect(Object.keys(logs)).toHaveLength(MAX_OPERATION_LOG_KEYS);
+    expect(logs['op-0']).toBeUndefined();
+    expect(logs['op-1']).toBeDefined();
+    expect(logs[newOpId]).toBeDefined();
+  });
+
+  it('does not evict when the incoming opId already exists', () => {
+    const logs: Record<string, Entry[]> = {};
+    for (let i = 0; i < MAX_OPERATION_LOG_KEYS; i++) {
+      logs[`op-${i}`] = entries(i);
+    }
+    const result = evictOldestOpLogKey(logs, 'op-0', MAX_OPERATION_LOG_KEYS);
+    expect(result).toBe(logs); // same reference: no-op
+    expect(Object.keys(result)).toHaveLength(MAX_OPERATION_LOG_KEYS);
+  });
+
+  it('is a no-op while under the cap', () => {
+    const logs = { 'op-a': entries(1), 'op-b': entries(2) };
+    const result = evictOldestOpLogKey(logs, 'op-c', MAX_OPERATION_LOG_KEYS);
+    expect(result).toBe(logs);
+  });
+});

--- a/web/src/pages/libraryOperationLogs.ts
+++ b/web/src/pages/libraryOperationLogs.ts
@@ -1,0 +1,29 @@
+// file: web/src/pages/libraryOperationLogs.ts
+// version: 1.0.0
+// guid: 07a1b2c3-d4e5-4f60-8a7b-8c9d0e1f2a3b
+// last-edited: 2026-07-03
+
+// Per-op log entries in Library.tsx are already capped (200 lines each), but
+// the map of op-id -> entries itself was never bounded, so it grew for the
+// lifetime of the page as operations came and went. Cap the number of
+// retained op keys and evict the oldest-inserted one (by object key
+// insertion order) when adding a new key beyond the cap.
+export const MAX_OPERATION_LOG_KEYS = 20;
+
+export function evictOldestOpLogKey<T>(
+  logs: Record<string, T>,
+  newOpId: string,
+  maxKeys: number
+): Record<string, T> {
+  if (Object.prototype.hasOwnProperty.call(logs, newOpId)) {
+    return logs;
+  }
+  const keys = Object.keys(logs);
+  if (keys.length < maxKeys) {
+    return logs;
+  }
+  const oldestKey = keys[0];
+  const next = { ...logs };
+  delete next[oldestKey];
+  return next;
+}

--- a/web/src/stores/useAppStore.test.ts
+++ b/web/src/stores/useAppStore.test.ts
@@ -1,0 +1,39 @@
+// file: web/src/stores/useAppStore.test.ts
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-4f2a-8b3c-4d5e6f7a8b9c
+// last-edited: 2026-07-03
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAppStore } from './useAppStore';
+
+// Regression coverage for an unbounded-memory-growth bug: error/warning
+// notifications never auto-remove and the array had no length cap, so a
+// long-running session with recurring errors grew the array without bound.
+
+describe('useAppStore notifications', () => {
+  beforeEach(() => {
+    useAppStore.getState().clearNotifications();
+    vi.useRealTimers();
+  });
+
+  it('caps the notifications array at 100, dropping the oldest', () => {
+    const { addNotification } = useAppStore.getState();
+    for (let i = 0; i < 105; i++) {
+      addNotification(`error-${i}`, 'error');
+    }
+    const { notifications } = useAppStore.getState();
+    expect(notifications).toHaveLength(100);
+    expect(notifications[0].message).toBe('error-5');
+    expect(notifications[notifications.length - 1].message).toBe('error-104');
+  });
+
+  it('still auto-removes success/info notifications after the timeout', () => {
+    vi.useFakeTimers();
+    const { addNotification } = useAppStore.getState();
+    addNotification('saved', 'success');
+    expect(useAppStore.getState().notifications).toHaveLength(1);
+    vi.advanceTimersByTime(5000);
+    expect(useAppStore.getState().notifications).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});

--- a/web/src/stores/useAppStore.ts
+++ b/web/src/stores/useAppStore.ts
@@ -1,12 +1,18 @@
 // file: web/src/stores/useAppStore.ts
-// version: 1.4.0
+// version: 1.5.0
 // guid: 1e2f3a4b-5c6d-7e8f-9a0b-1c2d3e4f5a6b
+// last-edited: 2026-07-03
 
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { STORAGE_KEYS } from '../lib/storageKeys';
 
 type ThemeMode = 'dark' | 'light';
+
+// error/warning notifications persist (no auto-remove timer), so without a
+// cap the array grows unboundedly over a long session. Drop the oldest
+// entry once the cap is reached.
+const MAX_NOTIFICATIONS = 100;
 
 function readStoredThemeMode(): ThemeMode {
   if (typeof window === 'undefined') {
@@ -81,12 +87,16 @@ export const useAppStore = create<AppState>()(
       notifications: [],
       addNotification: (message, severity, action) => {
         const id = `${Date.now()}-${Math.random()}`;
-        set((state) => ({
-          notifications: [
+        set((state) => {
+          const next = [
             ...state.notifications,
             { id, message, severity, timestamp: Date.now(), action },
-          ],
-        }));
+          ];
+          return {
+            notifications:
+              next.length > MAX_NOTIFICATIONS ? next.slice(next.length - MAX_NOTIFICATIONS) : next,
+          };
+        });
         // Auto-remove success/info after 5 seconds; error/warning persist
         if (severity === 'success' || severity === 'info') {
           const timeoutId = setTimeout(() => {

--- a/web/src/stores/useLibraryCache.test.ts
+++ b/web/src/stores/useLibraryCache.test.ts
@@ -1,0 +1,105 @@
+// file: web/src/stores/useLibraryCache.test.ts
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-49c0-8d1e-2f3a4b5c6d7e
+// last-edited: 2026-07-03
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useLibraryCache } from './useLibraryCache';
+
+// Regression coverage for an unbounded-memory-growth bug: the module-level
+// cache had no entry cap and only evicted lazily on read of the exact key
+// that expired, so pages (up to ~1000 books / 2-4MB each) accumulated for
+// the lifetime of the session as the user paginated/searched/filtered.
+
+const makeEntry = (n: number) => ({
+  audiobooks: [],
+  totalCount: n,
+  totalPages: 1,
+  importPaths: [],
+});
+
+describe('useLibraryCache', () => {
+  beforeEach(() => {
+    useLibraryCache.getState().clear();
+    vi.useRealTimers();
+  });
+
+  it('enforces a hard entry cap, evicting the oldest entry first', () => {
+    const { setCached } = useLibraryCache.getState();
+    vi.useFakeTimers();
+    const base = new Date('2026-01-01T00:00:00Z').getTime();
+
+    for (let i = 0; i < 50; i++) {
+      vi.setSystemTime(base + i * 1000);
+      setCached(`key-${i}`, makeEntry(i));
+    }
+    expect(useLibraryCache.getState().cache.size).toBe(50);
+
+    // One more insert should evict the oldest (key-0).
+    vi.setSystemTime(base + 50 * 1000);
+    setCached('key-50', makeEntry(50));
+
+    const cache = useLibraryCache.getState().cache;
+    expect(cache.size).toBe(50);
+    expect(cache.has('key-0')).toBe(false);
+    expect(cache.has('key-1')).toBe(true);
+    expect(cache.has('key-50')).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('sweeps all TTL-expired entries on every write, not just the exact key', () => {
+    const { setCached, getCached } = useLibraryCache.getState();
+    vi.useFakeTimers();
+    const base = new Date('2026-01-01T00:00:00Z').getTime();
+
+    vi.setSystemTime(base);
+    setCached('stale-a', makeEntry(1));
+    setCached('stale-b', makeEntry(2));
+
+    // Advance well past the 1-minute TTL, then write an unrelated key.
+    vi.setSystemTime(base + 5 * 60 * 1000);
+    setCached('fresh', makeEntry(3));
+
+    const cache = useLibraryCache.getState().cache;
+    expect(cache.has('stale-a')).toBe(false);
+    expect(cache.has('stale-b')).toBe(false);
+    expect(cache.has('fresh')).toBe(true);
+
+    // Read path behavior is unchanged: fresh entry is retrievable.
+    expect(getCached('fresh')?.totalCount).toBe(3);
+
+    vi.useRealTimers();
+  });
+
+  it('leaves the read path unchanged: returns null for missing/expired, entry for fresh', () => {
+    const { setCached, getCached } = useLibraryCache.getState();
+    vi.useFakeTimers();
+    const base = new Date('2026-01-01T00:00:00Z').getTime();
+
+    vi.setSystemTime(base);
+    setCached('a', makeEntry(42));
+
+    expect(getCached('missing')).toBeNull();
+    expect(getCached('a')?.totalCount).toBe(42);
+
+    vi.setSystemTime(base + 5 * 60 * 1000);
+    expect(getCached('a')).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('updating an existing key does not count against the entry cap', () => {
+    const { setCached } = useLibraryCache.getState();
+    for (let i = 0; i < 50; i++) {
+      setCached(`key-${i}`, makeEntry(i));
+    }
+    expect(useLibraryCache.getState().cache.size).toBe(50);
+
+    // Re-setting an existing key should not evict anything else.
+    setCached('key-0', makeEntry(999));
+    const cache = useLibraryCache.getState().cache;
+    expect(cache.size).toBe(50);
+    expect(cache.get('key-0')?.totalCount).toBe(999);
+  });
+});

--- a/web/src/stores/useLibraryCache.ts
+++ b/web/src/stores/useLibraryCache.ts
@@ -1,6 +1,7 @@
 // file: web/src/stores/useLibraryCache.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-03
 
 import { create } from 'zustand';
 import type { Audiobook } from '../types';
@@ -23,6 +24,38 @@ interface LibraryStore {
 
 const CACHE_TTL_MS = 1 * 60 * 1000; // 1 minute cache
 
+// Hard cap on the number of cached pages. Without this the cache grows
+// unbounded as the user paginates/searches/filters (each combination is a
+// distinct key), retaining up to ~1000 books per entry indefinitely since
+// eviction previously only happened lazily on read of that exact key.
+const MAX_ENTRIES = 50;
+
+/** Removes all TTL-expired entries from the map (mutates and returns it). */
+function sweepExpired(cache: Map<string, LibraryCacheEntry>, maxAgeMs: number): void {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (now - entry.timestamp > maxAgeMs) {
+      cache.delete(key);
+    }
+  }
+}
+
+/** Evicts the oldest (by timestamp) entries until the map is under the cap. */
+function evictOldestUntilUnderCap(cache: Map<string, LibraryCacheEntry>, maxEntries: number): void {
+  while (cache.size >= maxEntries) {
+    let oldestKey: string | undefined;
+    let oldestTimestamp = Infinity;
+    for (const [key, entry] of cache) {
+      if (entry.timestamp < oldestTimestamp) {
+        oldestTimestamp = entry.timestamp;
+        oldestKey = key;
+      }
+    }
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+}
+
 export const useLibraryCache = create<LibraryStore>((set, get) => ({
   cache: new Map(),
 
@@ -42,6 +75,10 @@ export const useLibraryCache = create<LibraryStore>((set, get) => ({
   setCached: (key: string, entry) => {
     set((state) => {
       const newCache = new Map(state.cache);
+      sweepExpired(newCache, CACHE_TTL_MS);
+      if (!newCache.has(key)) {
+        evictOldestUntilUnderCap(newCache, MAX_ENTRIES);
+      }
       newCache.set(key, { ...entry, timestamp: Date.now() });
       return { cache: newCache };
     });


### PR DESCRIPTION
## Summary

Owner's browser tab hit ~20GB. Read-only investigation ranked 4 unbounded-accumulation paths; all now capped:

1. **`useLibraryCache` (the GB-scale one):** module-level Map of full book pages keyed by page/size/search/filters/sort — every distinct query minted a permanent multi-MB entry (up to 1000 books each); eviction only fired on exact-key re-read after TTL. Now: 50-entry hard cap with oldest-timestamp LRU eviction + full TTL sweep on every write. Read path and mutation-clear semantics unchanged.
2. **ActivityLog SSE append:** uncapped `[...prev, msg]` → `slice(-1000)` (mirrors OperationActivityPanel's existing cap)
3. **Library per-op log map:** 200-entry cap per op but op keys never evicted → 20-key LRU (helper extracted to `libraryOperationLogs.ts` for testability)
4. **Notifications:** error/warning toasts never removed → 100-entry cap, drop oldest

Also confirmed: `scripts/check-memory-leaks.py` is structurally blind to this class (state growth, stores/ out of scope) — follow-up noted in TODO.

## Test plan

- [x] 9 new unit tests (LRU/sweep/read-path, key eviction, notification cap) + 23 total across touched suites — all green
- [x] `tsc --noEmit`, eslint (0 errors), `npm run build` clean
- [ ] Minimal CI green

Until deployed, a page refresh fully resets the leak (in-tab state only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1