### PR TITLE
fix(logging): repo-wide slog corruption sweep — 79 call sites, 4 defect classes (TASK-18)

### DIFF
--- a/internal/ai/aijobs/aijobs.go
+++ b/internal/ai/aijobs/aijobs.go
@@ -1,6 +1,7 @@
 // file: internal/ai/aijobs/aijobs.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: 8231e2ae-fa34-4594-80fd-f0f9dc60bc3b
+// last-edited: 2026-07-03
 
 package aijobs
 
@@ -146,7 +147,7 @@ func Submit(ctx context.Context, deps Deps, req SubmitRequest) (string, error) {
 	if err := deps.Store.MarkAIJobSubmitted(jobID, batchID); err != nil {
 		return jobID, fmt.Errorf("aijobs.Submit: mark submitted: %w", err)
 	}
-	slog.Info("aijobs submitted job type batch items", "value0", "jobID", "jobID", jobID, "value2", "value1", "req", req.Type, "batchID", batchID, "value3", req.ItemCount)
+	slog.Info("aijobs submitted job type batch items", "jobID", jobID, "reqType", req.Type, "batchID", batchID, "itemCount", req.ItemCount)
 	return jobID, nil
 }
 
@@ -199,6 +200,6 @@ func Dispatch(ctx context.Context, store database.AIJobsStore, batchID string, r
 	if err := store.MarkAIJobCompleted(job.ID, status, successCount, errorCount, rowErrors); err != nil {
 		return fmt.Errorf("aijobs.Dispatch: mark completed: %w", err)
 	}
-	slog.Info("aijobs dispatched job type success errors", "value0", "value0", "job", job.ID, "value2", "value1", "job", job.Type, "successCount", successCount, "errorCount", errorCount)
+	slog.Info("aijobs dispatched job type success errors", "jobID", job.ID, "jobType", job.Type, "successCount", successCount, "errorCount", errorCount)
 	return nil
 }

--- a/internal/ai/dedup_review.go
+++ b/internal/ai/dedup_review.go
@@ -1,6 +1,7 @@
 // file: internal/ai/dedup_review.go
-// version: 2.0.1
+// version: 2.0.2
 // guid: b2e7c3d1-4a58-4f96-9e0b-7d3a1c8f5b24
+// last-edited: 2026-07-03
 
 package ai
 
@@ -174,7 +175,7 @@ func dedupReviewCallback(ctx context.Context, itemsJSON []byte, results []aijobs
 	for pairIdx, candID := range payload.ByIndex {
 		c, ok := dedupVerdictApplier.LookupCandidate(candID)
 		if !ok {
-			slog.Info("dedup_review candidate (pair ) not found — skipping", "value0", "candID", "candID", candID, "pairIdx", pairIdx)
+			slog.Info("dedup_review candidate (pair) not found — skipping", "candID", candID, "pairIdx", pairIdx)
 			continue
 		}
 		byIndex[pairIdx] = c

--- a/internal/ai/embedding_client.go
+++ b/internal/ai/embedding_client.go
@@ -1,5 +1,5 @@
 // file: internal/ai/embedding_client.go
-// version: 1.9.0
+// version: 1.9.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-07-03
 
@@ -271,7 +271,7 @@ func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]f
 			vec, err := c.cache.GetCachedEmbedding(hash, c.model)
 			if err != nil {
 				// Cache read failure — treat as miss, log once.
-				slog.Warn("embedding cache get failed (hash)", "value0", "value0", "value1", hash[:8], "err", err)
+				slog.Warn("embedding cache get failed (hash)", "hash", hash[:8], "err", err)
 			}
 			if err == nil && vec != nil {
 				results[i] = vec
@@ -291,7 +291,7 @@ func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]f
 
 	// All cache hits? Return without touching the API at all.
 	if len(missTexts) == 0 {
-		slog.Debug("embedding cache / hits, 0 API calls", "value0", "hits", "hits", hits, "value1", len(texts))
+		slog.Debug("embedding cache / hits, 0 API calls", "hits", hits, "total", len(texts))
 		return results, nil
 	}
 
@@ -316,7 +316,7 @@ func (c *EmbeddingClient) EmbedBatch(ctx context.Context, texts []string) ([][]f
 		if c.cache != nil {
 			hash := TextHash(missTexts[j])
 			if putErr := c.cache.PutCachedEmbedding(hash, c.model, vec); putErr != nil {
-				slog.Warn("embedding cache put failed (hash)", "value0", "value0", "value1", hash[:8], "putErr", putErr)
+				slog.Warn("embedding cache put failed (hash)", "hash", hash[:8], "putErr", putErr)
 			}
 		}
 	}

--- a/internal/audiobooks/service_single.go
+++ b/internal/audiobooks/service_single.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_single.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: d6a0e5f4-a7b8-9c01-bd2e-3f4a5b6c7d8e
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package audiobooks
 
@@ -351,7 +351,7 @@ func (svc *AudiobookService) PurgeSoftDeletedBooks(ctx context.Context, deleteFi
 		// Step 3: Delete file if requested (only from organizer root, never from protected/import paths)
 		if deleteFiles && book.FilePath != "" {
 			if isProtectedPath(svc.store, book.FilePath) {
-				slog.Debug("purge skipping file deletion for — protected path", "book", book.ID, "book", book.FilePath)
+				slog.Debug("purge skipping file deletion for — protected path", "bookID", book.ID, "filePath", book.FilePath)
 			} else {
 				info, statErr := os.Stat(book.FilePath)
 				if statErr == nil && info.IsDir() {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -1,5 +1,5 @@
 // file: internal/config/persistence.go
-// version: 1.29.0
+// version: 1.29.1
 // guid: 9c8d7e6f-5a4b-3c2d-1e0f-9a8b7c6d5e4f
 // last-edited: 2026-07-03
 
@@ -881,7 +881,7 @@ func MigrateMaintenanceWindow(store database.SettingsStore) {
 	})
 
 	_ = store.SetSetting("maintenance_window_migrated", "true", "bool", false)
-	slog.Info("Maintenance window migration complete (start, end)", "appConfig", logStart, "appConfig", logEnd)
+	slog.Info("Maintenance window migration complete (start, end)", "windowStart", logStart, "windowEnd", logEnd)
 }
 
 // applySetting applies a single setting to AppConfig.

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.44.0
+// version: 1.44.1
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-03
 
@@ -3092,7 +3092,7 @@ func (de *Engine) ApplyVerdicts(verdicts []ai.DedupPairVerdict, byIndex map[int]
 			"", // auto-pick primary via bookIsBetter
 		)
 		if mergeErr != nil {
-			slog.Error("dedup LLM auto-merge failed for candidate ( + )", "candidate", candidate.ID, "candidate", candidate.EntityAID, "candidate", candidate.EntityBID, "mergeErr", mergeErr)
+			slog.Error("dedup LLM auto-merge failed for candidate ( + )", "candidateID", candidate.ID, "entityAID", candidate.EntityAID, "entityBID", candidate.EntityBID, "mergeErr", mergeErr)
 			continue
 		}
 
@@ -3119,7 +3119,7 @@ func (de *Engine) ApplyVerdicts(verdicts []ai.DedupPairVerdict, byIndex map[int]
 		}
 
 		autoMerged++
-		slog.Info("dedup LLM auto-merged candidate ( + ) — reason", "candidate", candidate.ID, "candidate", candidate.EntityAID, "candidate", candidate.EntityBID, "reason", reason)
+		slog.Info("dedup LLM auto-merged candidate ( + ) — reason", "candidateID", candidate.ID, "entityAID", candidate.EntityAID, "entityBID", candidate.EntityBID, "reason", reason)
 	}
 	if autoMerged > 0 {
 		slog.Info("dedup LLM auto-merge fired on high-confidence pair(s)", "autoMerged", autoMerged)

--- a/internal/itunes/import.go
+++ b/internal/itunes/import.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/import.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 4b58a17d-b2b4-4743-9b7e-3462e2ed55ac
+// last-edited: 2026-07-03
 
 package itunes
 
@@ -314,7 +315,7 @@ func ValidateImport(opts ImportOptions) (*ValidationResult, error) {
 	for sr := range results {
 		processed++
 		if processed%10000 == 0 {
-			slog.Info("iTunes validate checked / audiobooks ( found, missing)...", "processed", processed, "checks_count", len(checks), "result", result.FilesFound, "result", result.FilesMissing)
+			slog.Info("iTunes validate checked / audiobooks ( found, missing)...", "processed", processed, "checks_count", len(checks), "filesFound", result.FilesFound, "filesMissing", result.FilesMissing)
 		}
 		tc := checks[sr.idx]
 		if !tc.decodeOK {

--- a/internal/itunes/service/track_provisioner.go
+++ b/internal/itunes/service/track_provisioner.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/track_provisioner.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 8e768742-5ace-4e4b-8495-9550ed4620b5
+// last-edited: 2026-07-03
 //
 // TrackProvisioner generates ITL tracks for books that weren't imported
 // from iTunes (e.g. books added via scan or manual upload). For each
@@ -158,7 +159,7 @@ func (p *TrackProvisioner) ProvisionAll(book *database.Book) error {
 	}
 	for i := range files {
 		if err := p.Provision(book, &files[i]); err != nil {
-			slog.Warn("Failed to provision ITL track for file", "value0", files[i].ID, "err", err)
+			slog.Warn("Failed to provision ITL track for file", "fileID", files[i].ID, "err", err)
 		}
 	}
 	return nil

--- a/internal/itunes/service/validate.go
+++ b/internal/itunes/service/validate.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/validate.go
-// version: 1.1.0
+// version: 1.1.2
 // guid: 9e3a7f2b-5d1c-4b8e-a6f0-3c8d5e7b9a1f
+// last-edited: 2026-07-03
 
 package itunesservice
 
@@ -55,7 +56,7 @@ func Validate(req ValidateRequest) (ValidateResponse, error) {
 		missingPaths = missingPaths[:100]
 	}
 
-	slog.Info("iTunes validate complete audiobooks, found, missing, prefixes", "result", result.AudiobookTracks, "result", result.FilesFound, "result", result.FilesMissing, "result", result.PathPrefixes)
+	slog.Info("iTunes validate complete audiobooks, found, missing, prefixes", "audiobookTracks", result.AudiobookTracks, "filesFound", result.FilesFound, "filesMissing", result.FilesMissing, "pathPrefixes", result.PathPrefixes)
 
 	return ValidateResponse{
 		TotalTracks:     result.TotalTracks,
@@ -78,7 +79,7 @@ func TestMapping(req TestMappingRequest) (TestMappingResponse, error) {
 		return TestMappingResponse{}, fmt.Errorf("failed to parse library: %w", err)
 	}
 
-	slog.Info("iTunes test-mapping from%q to%q", req.From, req.To)
+	slog.Info("iTunes test-mapping", "from", req.From, "to", req.To)
 	mapping := itunes.PathMapping{From: req.From, To: req.To}
 	opts := itunes.ImportOptions{PathMappings: []itunes.PathMapping{mapping}}
 
@@ -115,6 +116,6 @@ func TestMapping(req TestMappingRequest) (TestMappingResponse, error) {
 		}
 	}
 
-	slog.Info("iTunes test-mapping tested found examples", "response", response.Tested, "response", response.Found, "count", len(response.Examples))
+	slog.Info("iTunes test-mapping tested found examples", "tested", response.Tested, "found", response.Found, "count", len(response.Examples))
 	return response, nil
 }

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.0.1
+// version: 2.0.2
 // guid: a1000012-0000-0000-0000-000000000012
-// last-edited: 2026-05-05
+// last-edited: 2026-07-03
 
 package jobs
 
@@ -104,7 +104,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		}
 
 		if audioPath == "" {
-			slog.Warn("no audio file for book (), skipping", "b", b.ID, "b", b.Title)
+			slog.Warn("no audio file for book (), skipping", "bookID", b.ID, "bookTitle", b.Title)
 			skipped++
 			continue
 		}
@@ -141,7 +141,7 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 		}
 
 		if authorName == "" {
-			slog.Warn("no author found in tags for book ()", "b", b.ID, "b", b.Title)
+			slog.Warn("no author found in tags for book ()", "bookID", b.ID, "bookTitle", b.Title)
 			skipped++
 			continue
 		}

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-// last-edited: 2026-04-28
+// last-edited: 2026-07-03
 
 package jobs
 
@@ -193,7 +193,7 @@ func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, rep
 							slog.Warn("scan-composer-tags write failed", "opID", opID, "w", w.filePath, "writeErr", writeErr)
 						} else {
 							r.Applied = true
-							slog.Info("scan-composer-tags COMPOSER %q→%q", "opID", opID, "composer", composer, willWrite, w.filePath)
+							slog.Info("scan-composer-tags COMPOSER", "opID", opID, "composer", composer, "newValue", willWrite, "filePath", w.filePath)
 						}
 					}
 				}

--- a/internal/metadata/circuitbreaker.go
+++ b/internal/metadata/circuitbreaker.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/circuitbreaker.go
-// version: 1.2.1
+// version: 1.2.2
 // guid: e2f3a4b5-c6d7-8901-ef23-456789abcdef
+// last-edited: 2026-07-03
 
 package metadata
 
@@ -91,7 +92,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 
 	if cb.failures >= cb.threshold {
 		cb.state = StateOpen
-		slog.Warn("circuit breaker opened after consecutive failures", "cb", cb.sourceName, "cb", cb.failures)
+		slog.Warn("circuit breaker opened after consecutive failures", "source", cb.sourceName, "failures", cb.failures)
 	}
 }
 

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
-// last-edited: 2026-06-28
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -63,11 +63,11 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 		if book.AuthorID != nil && book.Narrator != nil {
 			if existingAuthor, aErr := mfs.db.GetAuthorByID(*book.AuthorID); aErr == nil && existingAuthor != nil {
 				if strings.EqualFold(extractedAuthor, *book.Narrator) && !strings.EqualFold(extractedAuthor, existingAuthor.Name) {
-					slog.Info("applyMetadataToBook extracted artist matches narrator but not author for book — skipping author update", "value", extractedAuthor, "value", *book.Narrator, "name", existingAuthor.Name, "id", book.ID)
+					slog.Info("applyMetadataToBook extracted artist matches narrator but not author for book — skipping author update", "extracted_author", extractedAuthor, "narrator", *book.Narrator, "name", existingAuthor.Name, "id", book.ID)
 					extractedAuthor = ""
 				} else if !strings.EqualFold(extractedAuthor, existingAuthor.Name) && !strings.EqualFold(extractedAuthor, *book.Narrator) {
 					// Extracted artist doesn't match either stored author or narrator — log mismatch for review
-					slog.Warn("applyMetadataToBook extracted artist matches neither author nor narrator for book", "value", extractedAuthor, "name", existingAuthor.Name, "value", *book.Narrator, "id", book.ID)
+					slog.Warn("applyMetadataToBook extracted artist matches neither author nor narrator for book", "extracted_author", extractedAuthor, "name", existingAuthor.Name, "narrator", *book.Narrator, "id", book.ID)
 				}
 			}
 		}
@@ -233,7 +233,7 @@ func (mfs *Service) syncMetadataToLibraryCopy(original, libCopy *database.Book) 
 	if _, err := mfs.db.UpdateBook(libCopy.ID, libCopy); err != nil {
 		slog.Warn("failed to sync metadata to library copy", "id", libCopy.ID, "error", err)
 	} else {
-		slog.Info("synced metadata from to library copy", "id", original.ID, "id", libCopy.ID)
+		slog.Info("synced metadata from to library copy", "originalID", original.ID, "libCopyID", libCopy.ID)
 	}
 
 	// Also sync author associations
@@ -281,7 +281,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 		if err == nil {
 			for i := range siblings {
 				if siblings[i].ID != book.ID && strings.HasPrefix(siblings[i].FilePath, config.AppConfig.RootDir) {
-					slog.Info("using existing library copy for protected book", "id", siblings[i].ID, "id", book.ID)
+					slog.Info("using existing library copy for protected book", "siblingID", siblings[i].ID, "bookID", book.ID)
 					return &siblings[i]
 				}
 			}
@@ -381,7 +381,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 				newBF.ITunesPath = ComputeITunesPath(newPath)
 			}
 			if err := mfs.db.CreateBookFile(&newBF); err != nil {
-				slog.Warn("failed to copy book_file for library book", "id", bf.ID, "id", created.ID, "error", err)
+				slog.Warn("failed to copy book_file for library book", "bookFileID", bf.ID, "newBookID", created.ID, "error", err)
 			}
 		}
 	}
@@ -391,7 +391,7 @@ func (mfs *Service) ensureLibraryCopy(book *database.Book) *database.Book {
 	book.IsPrimaryVersion = &isNotPrimary
 	_, _ = mfs.db.UpdateBook(book.ID, book)
 
-	slog.Info("created library copy -> for protected book ( file(s))", "path", newBookPath, "id", created.ID, "id", book.ID, "file", len(activeFiles))
+	slog.Info("created library copy -> for protected book ( file(s))", "path", newBookPath, "newBookID", created.ID, "originalBookID", book.ID, "file", len(activeFiles))
 	return created
 }
 func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMetadata) {
@@ -454,7 +454,7 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		if book.Duration != nil {
 			bookDurSec = *book.Duration
 		}
-		slog.Warn("duration-mismatch apply book title candidate deltas (books audibles) wrong match or abridged version", "id", id, "value", book.Title, "id", candidate.Title, "id", candidate.DurationDeltaSec, "value", bookDurSec, "id", candidate.DurationSec)
+		slog.Warn("duration-mismatch apply book title candidate deltas (books audibles) wrong match or abridged version", "bookID", id, "bookTitle", book.Title, "candidateTitle", candidate.Title, "durationDeltaSec", candidate.DurationDeltaSec, "bookDurationSec", bookDurSec, "candidateDurationSec", candidate.DurationSec)
 	}
 
 	meta := metadata.BookMetadata{
@@ -682,9 +682,9 @@ func (mfs *Service) checkMetadataSourceHashDuplicates(bookID, hash string) {
 			continue
 		}
 		if err := mfs.db.FlagMetadataHashDuplicate(primaryID, id); err != nil {
-			slog.Warn("MATCH-4 failed to flag book as duplicate of", "id", id, "id", primaryID, "error", err)
+			slog.Warn("MATCH-4 failed to flag book as duplicate of", "dupID", id, "primaryID", primaryID, "error", err)
 		} else {
-			slog.Info("MATCH-4 auto-flagged book as merged into primary (hash )", "id", id, "id", primaryID, "hash", hash)
+			slog.Info("MATCH-4 auto-flagged book as merged into primary (hash )", "dupID", id, "primaryID", primaryID, "hash", hash)
 		}
 	}
 }

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
-// last-edited: 2026-07-02
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -138,7 +138,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) == 0 && currentAuthor != "" {
 				results, searchErr = src.SearchByTitleAndAuthor(context.Background(), searchTitle, currentAuthor)
 				if searchErr != nil {
-										slog.Warn("title+author search failed for by", "name", src.Name(), "value", searchTitle, "value", currentAuthor, "error", searchErr)
+										slog.Warn("title+author search failed for by", "name", src.Name(), "searchTitle", searchTitle, "currentAuthor", currentAuthor, "error", searchErr)
 				}
 			}
 

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.5.3
+// version: 1.5.4
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
 // last-edited: 2026-07-03
 
@@ -518,7 +518,7 @@ func (mfs *Service) ScoreBaseCandidates(
 		case err != nil:
 			slog.Warn("metadata-scorer failed, falling back to F1", "name", mfs.metadataScorer.Name(), "error", err)
 		default:
-			slog.Warn("metadata-scorer returned scores for results, falling back to F1", "name", mfs.metadataScorer.Name(), "count", len(scores), "count", len(results))
+			slog.Warn("metadata-scorer returned scores for results, falling back to F1", "name", mfs.metadataScorer.Name(), "scoreCount", len(scores), "resultCount", len(results))
 		}
 	}
 
@@ -627,12 +627,12 @@ func (mfs *Service) RerankTopK(
 	}
 	if ambiguousEnd < 2 {
 		// Only one candidate within epsilon — nothing to resolve.
-				slog.Debug("metadata-search rerank skipped — only 1 candidate within %.3f of best (%.3f)", "value", epsilon, "value", bestScore)
+				slog.Debug("metadata-search rerank skipped — only 1 candidate within epsilon of best", "epsilon", epsilon, "bestScore", bestScore)
 		return candidates
 	}
 
 	topCands := candidates[:ambiguousEnd]
-		slog.Debug("metadata-search rerank firing on top candidates (epsilon%.3f, bestScore%.3f)", "count", len(topCands), "value", epsilon, "value", bestScore)
+		slog.Debug("metadata-search rerank firing on top candidates", "count", len(topCands), "epsilon", epsilon, "bestScore", bestScore)
 
 	// Resolve the book's author name for the query payload.
 	authorName := ""
@@ -662,7 +662,7 @@ func (mfs *Service) RerankTopK(
 		if err != nil {
 						slog.Warn("metadata-search rerank LLM call failed, keeping base scores", "error", err)
 		} else {
-						slog.Warn("metadata-search rerank returned scores for candidates, keeping base scores", "count", len(llmScores), "count", len(topCands))
+						slog.Warn("metadata-search rerank returned scores for candidates, keeping base scores", "llmScoreCount", len(llmScores), "candidateCount", len(topCands))
 		}
 		return candidates
 	}
@@ -716,7 +716,7 @@ func ApplySeriesPositionFilter(
 	wantPos := strconv.Itoa(knownPosition)
 	best := results[0]
 	if best.SeriesPosition != "" && best.SeriesPosition != wantPos {
-				slog.Debug("scorer rejecting result (series position ! expected )", "value", best.Title, "value", best.SeriesPosition, "value", wantPos)
+				slog.Debug("scorer rejecting result (series position ! expected )", "title", best.Title, "seriesPosition", best.SeriesPosition, "wantPos", wantPos)
 		return nil
 	}
 	return results

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_search.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
 // last-edited: 2026-07-03
 
@@ -251,7 +251,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 					allResults = append(allResults, results...)
 				} else {
 					lastErr = serr
-					slog.Debug("metadata-search SearchByTitleAndAuthor( ) error", "name", src.Name(), "value", searchTitle, "value", searchAuthor, "error", serr)
+					slog.Debug("metadata-search SearchByTitleAndAuthor( ) error", "name", src.Name(), "searchTitle", searchTitle, "searchAuthor", searchAuthor, "error", serr)
 				}
 			}
 
@@ -262,7 +262,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				if results, serr := src.SearchByTitleAndAuthor(context.Background(), searchTitle, bookNarrator); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
-					slog.Debug("metadata-search narrator-as-author fallback( ) error", "name", src.Name(), "value", searchTitle, "value", bookNarrator, "error", serr)
+					slog.Debug("metadata-search narrator-as-author fallback( ) error", "name", src.Name(), "searchTitle", searchTitle, "narrator", bookNarrator, "error", serr)
 				}
 			}
 
@@ -287,7 +287,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				sourcesFailed[src.Name()] = lastErr.Error()
 			}
 
-			slog.Debug("metadata-search returned raw results for", "name", src.Name(), "count", len(allResults), "value", searchTitle)
+			slog.Debug("metadata-search returned raw results for", "name", src.Name(), "count", len(allResults), "searchTitle", searchTitle)
 
 			// Write to cache on a successful non-empty fetch.
 			// Empty and error cases are not cached so they can
@@ -303,7 +303,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		}
 
 		baseScores, baseTier := mfs.ScoreBaseCandidates(context.Background(), book, allResults, searchWords)
-		slog.Debug("metadata-search scored results from with tier", "count", len(allResults), "name", src.Name(), "value", baseTier)
+		slog.Debug("metadata-search scored results from with tier", "count", len(allResults), "name", src.Name(), "baseTier", baseTier)
 
 		for i, r := range allResults {
 			key := strings.ToLower(r.Title + "|" + r.Author)
@@ -332,7 +332,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				minScore = config.AppConfig.MetadataScoring.EmbeddingMinScore
 			}
 			if score <= minScore {
-				slog.Debug("metadata-search adjusted score%.3f (tier) below threshold for by from", "value", score, "value", baseTier, "value", r.Title, "value", r.Author, "name", src.Name())
+				slog.Debug("metadata-search adjusted score (tier) below threshold for by from", "score", score, "baseTier", baseTier, "title", r.Title, "author", r.Author, "name", src.Name())
 				continue
 			}
 
@@ -531,7 +531,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		candidates = mfs.RerankTopK(context.Background(), book, candidates)
 	}
 
-	slog.Debug("metadata-search returning candidates for (search words )", "id", len(candidates), "value", searchTitle, "value", searchWords)
+	slog.Debug("metadata-search returning candidates for (search words )", "candidateCount", len(candidates), "searchTitle", searchTitle, "searchWords", searchWords)
 
 	return &SearchMetadataResponse{
 		Results:       candidates,

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_writeback.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: fad73c11-30c2-4fdc-addd-45afef25d792
-// last-edited: 2026-06-10
+// last-edited: 2026-07-03
 
 package metafetch
 
@@ -120,7 +120,7 @@ func (mfs *Service) writeBackMetadata(book *database.Book, meta metadata.BookMet
 		tagMap := mfs.BuildFullTagMap(book, bookTitle, bookTitle, artistStr, narratorStr, year, "")
 				slog.Debug("write-back full tag map has entries for", "count", len(tagMap), "path", book.FilePath)
 		for k, v := range tagMap {
-						slog.Debug("write-back", "value", k, "value", v)
+						slog.Debug("write-back", "tagKey", k, "tagValue", v)
 		}
 
 		dirFiles := AudioFilesInDir(book.FilePath)
@@ -501,7 +501,7 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 						slog.Warn("runApplyPipeline no library copy for protected book , skipping", "id", id)
 			return nil
 		}
-				slog.Info("runApplyPipeline using library copy for protected book", "id", libCopy.ID, "id", id)
+				slog.Info("runApplyPipeline using library copy for protected book", "libCopyID", libCopy.ID, "bookID", id)
 		id = libCopy.ID
 		book = libCopy
 	}

--- a/internal/openlibrary/downloader.go
+++ b/internal/openlibrary/downloader.go
@@ -1,6 +1,7 @@
 // file: internal/openlibrary/downloader.go
-// version: 1.1.1
+// version: 1.1.2
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
+// last-edited: 2026-07-03
 
 package openlibrary
 
@@ -105,7 +106,7 @@ func DownloadDump(dumpType string, targetDir string, tracker *DownloadTracker) e
 		if err == nil {
 			return nil
 		}
-		slog.Warn("Download from failed , trying next source", "value0", "sourceURL", "sourceURL", sourceURL, "err", err)
+		slog.Warn("Download from failed, trying next source", "sourceURL", sourceURL, "err", err)
 		lastErr = err
 	}
 

--- a/internal/openlibrary/store.go
+++ b/internal/openlibrary/store.go
@@ -1,6 +1,7 @@
 // file: internal/openlibrary/store.go
-// version: 2.3.1
+// version: 2.3.2
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-07-03
 
 package openlibrary
 
@@ -33,7 +34,7 @@ func NewOLStore(path string) (*OLStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open OL store: %w", err)
 	}
-	slog.Info("OL PebbleDB opened at (format version )", "value0", "path", "path", path, "value1", db.FormatMajorVersion())
+	slog.Info("OL PebbleDB opened", "path", path, "formatVersion", db.FormatMajorVersion())
 	return &OLStore{db: db}, nil
 }
 
@@ -117,9 +118,9 @@ func (s *OLStore) ImportDump(dumpType, filePath string, progress func(int)) erro
 		}
 		if prev.LinesProcessed > 0 && prev.ImportProgress < 1.0 && prev.FileSize == fileSize {
 			skipLines = prev.LinesProcessed
-			slog.Info("Resuming import from line", "value0", "dumpType", "dumpType", dumpType, "skipLines", skipLines)
+			slog.Info("Resuming import from line", "dumpType", dumpType, "skipLines", skipLines)
 		} else if prev.ImportProgress >= 1.0 && prev.FileSize == fileSize {
-			slog.Info("import already complete ( records), skipping", "value0", "dumpType", "dumpType", dumpType, "value1", prev.RecordCount)
+			slog.Info("import already complete, skipping", "dumpType", dumpType, "recordCount", prev.RecordCount)
 			if progress != nil {
 				progress(int(prev.RecordCount))
 			}

--- a/internal/plugin/events.go
+++ b/internal/plugin/events.go
@@ -1,5 +1,7 @@
 // file: internal/plugin/events.go
-// version: 1.2.1
+// version: 1.2.2
+// guid: 819005bd-b9fa-482f-af3b-d454a7746bab
+// last-edited: 2026-07-03
 
 package plugin
 
@@ -90,11 +92,11 @@ func (b *EventBus) Publish(ctx context.Context, event Event) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("plugin event handler panicked for", "value0", "value0", "event", event.Type, "r", r)
+					slog.Error("plugin event handler panicked for", "event", event.Type, "r", r)
 				}
 			}()
 			if err := h(ctx, event); err != nil {
-				slog.Warn("plugin event handler error for", "value0", "value0", "event", event.Type, "err", err)
+				slog.Warn("plugin event handler error for", "event", event.Type, "err", err)
 			}
 		}()
 	}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,5 +1,7 @@
 // file: internal/plugin/registry.go
-// version: 1.2.1
+// version: 1.2.2
+// guid: 73ed97c1-8466-4a1b-bc07-cb81ce34c502
+// last-edited: 2026-07-03
 
 package plugin
 
@@ -31,7 +33,7 @@ func Register(p Plugin) {
 	globalRegistry.mu.Lock()
 	defer globalRegistry.mu.Unlock()
 	if _, exists := globalRegistry.plugins[p.ID()]; exists {
-		slog.Warn("plugin %q already registered, skipping duplicate")
+		slog.Warn("plugin already registered, skipping duplicate", "id", p.ID())
 		return
 	}
 	globalRegistry.plugins[p.ID()] = p

--- a/internal/quarantine/service.go
+++ b/internal/quarantine/service.go
@@ -1,7 +1,7 @@
 // file: internal/quarantine/service.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2025-07-21
+// last-edited: 2026-07-03
 
 package quarantine
 
@@ -122,7 +122,7 @@ func (qs *QuarantineService) QuarantineBook(bookID, reason string) error {
 	if _, err := qs.store.UpdateBook(bookID, book); err != nil {
 		// Rollback: move file back before returning the error.
 		if rollbackErr := os.Rename(dest, oldPath); rollbackErr != nil {
-			slog.Error("QuarantineBook DB update failed and file rollback failed (original )", "value0", "rollbackErr", "rollbackErr", rollbackErr, "err", err)
+			slog.Error("QuarantineBook DB update failed and file rollback failed", "originalPath", oldPath, "rollbackErr", rollbackErr, "err", err)
 		}
 		return fmt.Errorf("update book: %w", err)
 	}
@@ -197,7 +197,7 @@ func (qs *QuarantineService) UnquarantineBook(bookID string) error {
 	if _, err := qs.store.UpdateBook(bookID, book); err != nil {
 		// Rollback: move file back to quarantine location.
 		if rollbackErr := os.Rename(origPath, quarPath); rollbackErr != nil {
-			slog.Error("UnquarantineBook DB update failed and file rollback failed (original )", "value0", "rollbackErr", "rollbackErr", rollbackErr, "err", err)
+			slog.Error("UnquarantineBook DB update failed and file rollback failed", "originalPath", origPath, "rollbackErr", rollbackErr, "err", err)
 		}
 		return fmt.Errorf("update book: %w", err)
 	}
@@ -209,7 +209,7 @@ func (qs *QuarantineService) UnquarantineBook(bookID string) error {
 		ChangeType: "unquarantine",
 	})
 
-	slog.Info("UnquarantineBook →", "value0", "quarPath", "quarPath", quarPath, "origPath", origPath)
+	slog.Info("UnquarantineBook →", "quarPath", quarPath, "origPath", origPath)
 
 	qs.events.Publish(context.Background(), plugin.NewEvent(plugin.EventBookUnquarantined, bookID, map[string]any{
 		"file_path":       origPath,
@@ -239,7 +239,7 @@ func (qs *QuarantineService) AutoQuarantineFailedScans() {
 			}
 			n, _ := qs.store.GetScanFailCount(scanFailKey(b.FilePath))
 			if n >= scanFailThreshold {
-				slog.Info("auto-quarantine (fail count )", "value0", "value0", "b", b.FilePath, "n", n)
+				slog.Info("auto-quarantine (fail count)", "filePath", b.FilePath, "failCount", n)
 				_ = qs.QuarantineBook(b.ID, fmt.Sprintf("taglib failed to read file after %d consecutive scan attempts", n))
 			}
 		}
@@ -266,14 +266,14 @@ func (qs *QuarantineService) ProcessITunesPurgePending() {
 			continue
 		}
 		qs.batcher.EnqueueRemove(*b.ITunesPersistentID)
-		slog.Info("ProcessITunesPurgePending queued ITL removal for (book )", "value0", "value0", "value1", *b.ITunesPersistentID, "value1", b.ID)
+		slog.Info("ProcessITunesPurgePending queued ITL removal for", "persistentID", *b.ITunesPersistentID, "bookID", b.ID)
 
 		// Clear iTunes linkage so the book is no longer tied to iTunes.
 		cleared := "unlinked"
 		b.ITunesSyncStatus = &cleared
 		b.ITunesPersistentID = nil
 		if _, err := qs.store.UpdateBook(b.ID, &b); err != nil {
-			slog.Warn("ProcessITunesPurgePending UpdateBook", "value0", "value0", "b", b.ID, "err", err)
+			slog.Warn("ProcessITunesPurgePending UpdateBook", "bookID", b.ID, "err", err)
 		}
 	}
 }

--- a/internal/realtime/events.go
+++ b/internal/realtime/events.go
@@ -1,6 +1,7 @@
 // file: internal/realtime/events.go
-// version: 1.2.1
+// version: 1.2.2
 // guid: 9e8d7f6a-5c4b-3a21-0f9e-8d7c6b5a4392
+// last-edited: 2026-07-03
 
 package realtime
 
@@ -55,7 +56,7 @@ func (c *Client) Subscribe(operationID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.Operations[operationID] = true
-	slog.Info("Client subscribed to operation", "value0", "value0", "c", c.ID, "operationID", operationID)
+	slog.Info("Client subscribed to operation", "clientID", c.ID, "operationID", operationID)
 }
 
 // Unsubscribe unsubscribes the client from an operation
@@ -63,7 +64,7 @@ func (c *Client) Unsubscribe(operationID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.Operations, operationID)
-	slog.Info("Client unsubscribed from operation", "value0", "value0", "c", c.ID, "operationID", operationID)
+	slog.Info("Client unsubscribed from operation", "clientID", c.ID, "operationID", operationID)
 }
 
 // IsSubscribed checks if client is subscribed to an operation
@@ -91,7 +92,7 @@ func (h *EventHub) RegisterClient(client *Client) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.clients[client.ID] = client
-	slog.Info("Client registered, total clients", "value0", "value0", "client", client.ID, "value1", len(h.clients))
+	slog.Info("Client registered, total clients", "client", client.ID, "totalClients", len(h.clients))
 }
 
 // UnregisterClient removes a client
@@ -105,7 +106,7 @@ func (h *EventHub) UnregisterClient(clientID string) {
 		close(client.Channel)
 		client.mu.Unlock()
 		delete(h.clients, clientID)
-		slog.Info("Client unregistered, remaining clients", "value0", "clientID", "clientID", clientID, "value1", len(h.clients))
+		slog.Info("Client unregistered, remaining clients", "clientID", clientID, "remainingClients", len(h.clients))
 	}
 }
 
@@ -269,7 +270,7 @@ func (h *EventHub) HandleSSE(c *gin.Context) {
 			// Write SSE format: data: {json}\n\n
 			_, err = c.Writer.Write([]byte(fmt.Sprintf("data: %s\n\n", data)))
 			if err != nil {
-				slog.Info("Error writing to client", "value0", "clientID", "clientID", clientID, "err", err)
+				slog.Info("Error writing to client", "clientID", clientID, "err", err)
 				return
 			}
 
@@ -280,7 +281,7 @@ func (h *EventHub) HandleSSE(c *gin.Context) {
 			// Comments are ignored by clients but prevent proxy timeouts
 			_, err := c.Writer.Write([]byte(": ping\n\n"))
 			if err != nil {
-				slog.Info("Error writing heartbeat to client", "value0", "clientID", "clientID", clientID, "err", err)
+				slog.Info("Error writing heartbeat to client", "clientID", clientID, "err", err)
 				return
 			}
 			c.Writer.Flush()

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-06-16
+// last-edited: 2026-07-03
 
 package reconcile
 
@@ -495,7 +495,7 @@ func FindUntrackedFiles(store Store, knownPaths map[string]bool) ([]string, erro
 			return nil
 		})
 		if err != nil {
-			slog.Warn("reconcile error walking", "value0", "dir", "dir", dir, "err", err)
+			slog.Warn("reconcile error walking", "dir", dir, "err", err)
 		}
 	}
 
@@ -684,7 +684,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 				if rootDir != "" && strings.HasPrefix(dup.FilePath, rootDir) {
 					if _, err := os.Stat(dup.FilePath); err == nil {
 						if err := os.Remove(dup.FilePath); err != nil {
-							slog.Warn("failed to delete duplicate file", "value0", "value0", "dup", dup.FilePath, "err", err)
+							slog.Warn("failed to delete duplicate file", "dup", dup.FilePath, "err", err)
 						} else {
 							result.FilesDeleted++
 						}
@@ -692,7 +692,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 				}
 				// Delete the book record
 				if err := store.DeleteBook(dup.ID); err != nil {
-					slog.Warn("failed to delete duplicate book record", "value0", "value0", "dup", dup.ID, "err", err)
+					slog.Warn("failed to delete duplicate book record", "dup", dup.ID, "err", err)
 				}
 			}
 			result.DuplicatesRemoved++
@@ -775,7 +775,7 @@ func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, err
 			book.MarkedForDeletion = boolPtr(true)
 			book.MarkedForDeletionAt = &now
 			if _, uerr := store.UpdateBook(book.ID, &book); uerr != nil {
-				slog.Warn("failed to mark broken book", "value0", "value0", "book", book.ID, "uerr", uerr)
+				slog.Warn("failed to mark broken book", "book", book.ID, "uerr", uerr)
 			} else {
 				result.MarkedForReview++
 			}
@@ -860,7 +860,7 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 		if !dryRun {
 			if len(merged) > 0 {
 				if _, err := store.UpdateBook(primary.ID, primary); err != nil {
-					slog.Warn("merge-dupes failed to update primary", "value0", "value0", "primary", primary.ID, "err", err)
+					slog.Warn("merge-dupes failed to update primary", "primary", primary.ID, "err", err)
 					entry.Action = "error"
 					result.Errors++
 					result.Details = append(result.Details, entry)
@@ -869,7 +869,7 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 				result.MetadataMerged++
 			}
 			if err := softDelete(dupe); err != nil {
-				slog.Warn("merge-dupes failed to soft-delete", "value0", "value0", "dupe", dupe.ID, "err", err)
+				slog.Warn("merge-dupes failed to soft-delete", "dupe", dupe.ID, "err", err)
 				entry.Action = "error"
 				result.Errors++
 			} else {
@@ -941,13 +941,13 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 			if !dryRun {
 				if len(merged) > 0 {
 					if _, err := store.UpdateBook(keeper.ID, keeper); err != nil {
-						slog.Warn("merge-self-dupes failed to update keeper", "value0", "value0", "keeper", keeper.ID, "err", err)
+						slog.Warn("merge-self-dupes failed to update keeper", "keeper", keeper.ID, "err", err)
 					} else {
 						result.MetadataMerged++
 					}
 				}
 				if err := softDelete(dupe); err != nil {
-					slog.Warn("merge-self-dupes failed to soft-delete", "value0", "value0", "dupe", dupe.ID, "err", err)
+					slog.Warn("merge-self-dupes failed to soft-delete", "dupe", dupe.ID, "err", err)
 					entry.Action = "error"
 					result.Errors++
 				} else {

--- a/internal/remux/remux.go
+++ b/internal/remux/remux.go
@@ -1,5 +1,5 @@
 // file: internal/remux/remux.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-07-03
 
@@ -97,14 +97,14 @@ func (r *Remuxer) RemuxMalformedFiles(ctx context.Context) {
 
 		// taglib failed — attempt to remux with ffmpeg.
 		if err := RemuxFile(path); err != nil {
-			slog.Warn("malformed M4B remux failed for", "value0", "path", "path", path, "err", err)
+			slog.Warn("malformed M4B remux failed for", "path", path, "err", err)
 			failed++
 			return nil
 		}
 
 		// Verify the output is now readable.
 		if _, err := taglib.ReadTags(path); err != nil {
-			slog.Warn("malformed M4B remux produced unreadable file for", "value0", "path", "path", path, "err", err)
+			slog.Warn("malformed M4B remux produced unreadable file for", "path", path, "err", err)
 			failed++
 			return nil
 		}

--- a/internal/remux/transcode.go
+++ b/internal/remux/transcode.go
@@ -1,5 +1,5 @@
 // file: internal/remux/transcode.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-03
 
@@ -118,7 +118,7 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 
 		// taglib failed — attempt full AAC transcode.
 		if err := TranscodeFile(path); err != nil {
-			slog.Warn("malformed M4B transcode failed for", "value0", "path", "path", path, "err", err)
+			slog.Warn("malformed M4B transcode failed for", "path", path, "err", err)
 			_ = t.store.SetSetting(TranscodeSkipKey(path), "true", "bool", false)
 			failed++
 			return nil
@@ -126,7 +126,7 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 
 		// Verify the output is now readable.
 		if _, err := taglib.ReadTags(path); err != nil {
-			slog.Warn("malformed M4B transcode produced unreadable file for", "value0", "path", "path", path, "err", err)
+			slog.Warn("malformed M4B transcode produced unreadable file for", "path", path, "err", err)
 			_ = t.store.SetSetting(TranscodeSkipKey(path), "true", "bool", false)
 			failed++
 			return nil
@@ -137,7 +137,7 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 		return nil
 	})
 
-	slog.Info("Malformed M4B transcode transcoded, already readable, failed ( permanently skipped)", "value0", "transcoded", "transcoded", transcoded, "value2", "clean", "clean", clean, "failed", failed, "skipped", skipped)
+	slog.Info("Malformed M4B transcode transcoded, already readable, failed, permanently skipped", "transcoded", transcoded, "clean", clean, "failed", failed, "skipped", skipped)
 	_ = t.store.SetSetting(TranscodeKey, "true", "bool", false)
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/scheduler.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 3f7a9c21-b4d8-4e05-a6f2-8c1d0e3b7a94
-// last-edited: 2026-06-16
+// last-edited: 2026-07-03
 
 // Package scheduler implements the unified task scheduling system.
 // TaskScheduler manages all registered tasks, their schedules, and manual
@@ -185,7 +185,7 @@ func (ts *TaskScheduler) Start(shutdown chan struct{}, wg *sync.WaitGroup) {
 			defer wg.Done()
 			ticker := time.NewTicker(60 * time.Second)
 			defer ticker.Stop()
-			slog.Info("Maintenance window enabled 00 - 00", "value0", config.AppConfig.Maintenance.WindowStart, "value1", config.AppConfig.Maintenance.WindowEnd)
+			slog.Info("Maintenance window enabled", "windowStart", config.AppConfig.Maintenance.WindowStart, "windowEnd", config.AppConfig.Maintenance.WindowEnd)
 			for {
 				select {
 				case <-ticker.C:

--- a/internal/server/bench.go
+++ b/internal/server/bench.go
@@ -1,6 +1,7 @@
 // file: internal/server/bench.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 5e6f7a8b-9c0d-1234-ef01-555555555555
+// last-edited: 2026-07-03
 
 //go:build bench
 
@@ -142,7 +143,7 @@ func (s *Server) benchSubmit(c *gin.Context) {
 	// Run in background
 	go func() {
 		ctx := context.Background()
-		slog.Info("bench Starting run models mode server", "req", req.Models, "req", req.Mode, "serverURL", serverURL)
+		slog.Info("bench Starting run models mode server", "models", req.Models, "mode", req.Mode, "serverURL", serverURL)
 
 		authorData, err := benchFetchAuthors(serverURL)
 		if err != nil {

--- a/internal/server/file_io_pool.go
+++ b/internal/server/file_io_pool.go
@@ -1,7 +1,7 @@
 // file: internal/server/file_io_pool.go
-// version: 2.3.2
+// version: 2.3.4
 // guid: c4d5e6f7-a8b9-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-05-19
+// last-edited: 2026-07-03
 //
 // Bounded worker pool for file I/O operations (cover embed, tag write,
 // rename). Tracks pending jobs in PebbleDB so they survive restarts.
@@ -122,7 +122,7 @@ func (p *FileIOPool) worker(id int) {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("file I/O worker panicked on book (op)", "id", id, "job", job.bookID, "job", job.opType, "r", r)
+					slog.Error("file I/O worker panicked on book (op)", "workerID", id, "bookID", job.bookID, "opType", job.opType, "r", r)
 				}
 			}()
 			job.fn()
@@ -335,7 +335,7 @@ func recoverInterruptedFileOps(pool *FileIOPool) {
 
 		fn, ok := lookupFileOpRecovery(job.OpType)
 		if !ok {
-			slog.Warn("no recovery handler for op type %q (book ), removing stale key", "opType", job.OpType, "bookID", job.BookID)
+			slog.Warn("no recovery handler for op type, removing stale key", "opType", job.OpType, "bookID", job.BookID)
 			_ = store.DeleteRaw(kv.Key)
 			continue
 		}

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_files.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 82f8d1f7-46d5-4ead-b5c1-ba796fd785f9
-// last-edited: 2026-07-01
+// last-edited: 2026-07-03
 
 // File / segment endpoints for the audiobooks domain: segment listing,
 // book-file listing + patch, track-info extraction, relocate, and segment
@@ -298,7 +298,7 @@ func (h *Handler) ExtractTrackInfo(c *gin.Context) {
 			files[i].TrackCount = *info.TotalTracks
 		}
 		if err := store.UpdateBookFile(files[i].ID, &files[i]); err != nil {
-			slog.Warn("failed to update book file track info", "value0", files[i].ID, "err", err)
+			slog.Warn("failed to update book file track info", "fileID", files[i].ID, "err", err)
 			continue
 		}
 		updated++

--- a/internal/server/handlers/versions.go
+++ b/internal/server/handlers/versions.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/versions.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 7e3c1a92-4b8d-4f60-9a2e-1c0d5f8b6a47
-// last-edited: 2026-06-03
+// last-edited: 2026-07-03
 
 package handlers
 
@@ -550,7 +550,7 @@ func (h *VersionsHandler) reassignExternalIDsForFiles(sourceBookID, targetBookID
 
 		m.BookID = targetBookID
 		if createErr := h.store.CreateExternalIDMapping(&m); createErr != nil {
-			slog.Warn("reassignExternalIDsForFiles failed to reassign to", "m", m.Source, "m", m.ExternalID, "targetBookID", targetBookID, "createErr", createErr)
+			slog.Warn("reassignExternalIDsForFiles failed to reassign to", "source", m.Source, "externalID", m.ExternalID, "targetBookID", targetBookID, "createErr", createErr)
 		}
 	}
 

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,7 +1,7 @@
 // file: internal/server/itl_rebuild.go
-// version: 3.2.0
+// version: 3.2.2
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
-// last-edited: 2026-06-16
+// last-edited: 2026-07-03
 //
 // iTunes library rebuild service: diffs the current DB state
 // against the current ITL file and computes the minimal set of
@@ -92,7 +92,7 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 		return
 	}
 
-	slog.Info("ITL rebuild removed , added , updated-meta , updated-loc", "preview", preview.ToRemove, "preview", preview.ToAdd, "preview", preview.ToUpdateMeta, "preview", preview.ToUpdateLoc)
+	slog.Info("ITL rebuild removed , added , updated-meta , updated-loc", "toRemove", preview.ToRemove, "toAdd", preview.ToAdd, "toUpdateMeta", preview.ToUpdateMeta, "toUpdateLoc", preview.ToUpdateLoc)
 
 	httputil.RespondWithOK(c, itunes.ITLRebuildResult{
 		Preview: *preview,
@@ -142,7 +142,7 @@ func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 		return
 	}
 
-	slog.Info("ITL full-rebuild removed existing tracks, inserted DB books", "value0", result.Preview.ToRemove, "value1", result.Preview.ToAdd)
+	slog.Info("ITL full-rebuild removed existing tracks, inserted DB books", "toRemove", result.Preview.ToRemove, "toAdd", result.Preview.ToAdd)
 	httputil.RespondWithOK(c, result)
 }
 

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -1,7 +1,7 @@
 // file: internal/server/middleware/auth.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: 83c42ecb-1df2-4baf-9890-3f91ab4db6fe
-// last-edited: 2026-06-04
+// last-edited: 2026-07-03
 
 package middleware
 
@@ -176,7 +176,7 @@ func handleAPIKeyAuth(c *gin.Context, store interface {
 	hash := database.HashAPIKeyToken(rawToken)
 	key, err := store.GetAPIKeyByHash(hash)
 	if err != nil {
-		slog.Info("lookup error hash err", "value0", hash[:8], "err", err)
+		slog.Info("lookup error hash err", "hashPrefix", hash[:8], "err", err)
 		httputil.RespondWithInternalError(c, "internal error")
 		c.Abort()
 		return

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_search.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
-// last-edited: 2026-06-23
+// last-edited: 2026-07-03
 
 package server
 
@@ -86,7 +86,7 @@ func (s *Server) buildSearchIndexIfEmpty() {
 			}
 			doc := search.BookToDoc(store, &books[i])
 			if err := s.searchIndex.IndexBook(doc); err != nil {
-				slog.Warn("search backfill index", "value0", books[i].ID, "err", err)
+				slog.Warn("search backfill index", "bookID", books[i].ID, "err", err)
 				continue
 			}
 			indexed++

--- a/internal/sweep/archive_sweep.go
+++ b/internal/sweep/archive_sweep.go
@@ -1,6 +1,7 @@
 // file: internal/sweep/archive_sweep.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: a9f8e7d6-c5b4-3a21-9087-654321fedcba
+// last-edited: 2026-07-03
 //
 // Archive sweep for soft-deleted books (backlog 7.10).
 //
@@ -49,14 +50,14 @@ func SweepArchivedBooks(store interface {
 		for _, f := range files {
 			if f.FilePath != "" {
 				if err := os.Remove(f.FilePath); err != nil && !os.IsNotExist(err) {
-					slog.Warn("archive sweep remove", "value0", "value0", "f", f.FilePath, "err", err)
+					slog.Warn("archive sweep remove", "f", f.FilePath, "err", err)
 				}
 			}
 		}
 
 		// Hard-delete the book record.
 		if err := store.DeleteBook(book.ID); err != nil {
-			slog.Warn("archive sweep delete", "value0", "value0", "book", book.ID, "err", err)
+			slog.Warn("archive sweep delete", "book", book.ID, "err", err)
 			continue
 		}
 		cleaned++

--- a/internal/sweep/sweeper.go
+++ b/internal/sweep/sweeper.go
@@ -1,6 +1,7 @@
 // file: internal/sweep/sweeper.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: a1b2c3d4-e5f6-4789-abcd-ef2345678901
+// last-edited: 2026-07-03
 
 package sweep
 
@@ -57,7 +58,7 @@ func SweepTombstones(store database.BookStore) (*SweeperResult, error) {
 					result.Errors = append(result.Errors, fmt.Sprintf("tombstone %s: failed to delete orphaned file %s: %v", tomb.ID, tomb.FilePath, err))
 					continue
 				}
-				slog.Info("sweeper deleted orphaned file (tombstone )", "value0", "value0", "tomb", tomb.FilePath, "value1", tomb.ID)
+				slog.Info("sweeper deleted orphaned file (tombstone)", "path", tomb.FilePath, "tombstoneID", tomb.ID)
 			}
 			// File gone or just deleted — clean up tombstone
 		}
@@ -95,6 +96,6 @@ func AuditFileConsistency(store database.BookStore) (*SweeperResult, error) {
 		}
 	}
 
-	slog.Info("sweeper audit complete — books checked, missing files", "value0", "value0", "books_count", len(books), "value1", len(result.MissingFiles))
+	slog.Info("sweeper audit complete — books checked, missing files", "books_count", len(books), "missing_count", len(result.MissingFiles))
 	return result, nil
 }

--- a/internal/sweep/temp_cleanup.go
+++ b/internal/sweep/temp_cleanup.go
@@ -1,6 +1,7 @@
 // file: internal/sweep/temp_cleanup.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: f7e6d5c4-b3a2-1908-7654-321fedcba987
+// last-edited: 2026-07-03
 
 package sweep
 
@@ -32,7 +33,7 @@ func CleanupOrphanedTempFiles(root string, w *activity.Writer, opID string) int 
 		name := filepath.Base(path)
 		if isOrphanedTempFile(name) {
 			if rmErr := os.Remove(path); rmErr != nil {
-				slog.Warn("temp file cleanup could not remove", "value0", "path", "path", path, "rmErr", rmErr)
+				slog.Warn("temp file cleanup could not remove", "path", path, "rmErr", rmErr)
 			} else {
 				removed++
 				activity.LogBatch(w, opID, "temp-file-cleanup", "temp-file-cleanup",

--- a/internal/transcode/transcode.go
+++ b/internal/transcode/transcode.go
@@ -1,6 +1,7 @@
 // file: internal/transcode/transcode.go
-// version: 1.5.1
+// version: 1.5.2
 // guid: f8a1b2c3-d4e5-6789-abcd-ef0123456789
+// last-edited: 2026-07-03
 
 package transcode
 
@@ -380,7 +381,7 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 			chapterCmd := exec.CommandContext(ctx, ffmpegPath, chapterArgs...)
 			chOut, err := chapterCmd.CombinedOutput()
 			if err != nil {
-				slog.Warn("transcode chapter muxing failed, using unchaptered output \noutput", "value0", "err", "err", err, "value1", string(chOut))
+				slog.Warn("transcode chapter muxing failed, using unchaptered output", "err", err, "ffmpegOutput", string(chOut))
 			} else {
 				os.Remove(tmpOutput)
 				tmpOutput = chapteredOutput
@@ -408,7 +409,7 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 			}
 			coverCmd := exec.CommandContext(ctx, ffmpegPath, coverArgs...)
 			if coverOut, err := coverCmd.CombinedOutput(); err != nil {
-				slog.Warn("transcode cover art embedding failed \noutput", "value0", "err", "err", err, "value1", string(coverOut))
+				slog.Warn("transcode cover art embedding failed", "err", err, "ffmpegOutput", string(coverOut))
 			} else {
 				os.Remove(tmpOutput)
 				tmpOutput = coverOutput
@@ -425,7 +426,7 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 	progress.UpdateProgress(5, 5, "Complete")
 	progress.Log("info", fmt.Sprintf("Transcode complete: %s → %s", book.FilePath, outputPath), nil)
 
-	slog.Info("transcode completed →", "value0", "value0", "book", book.FilePath, "outputPath", outputPath)
+	slog.Info("transcode completed", "book", book.FilePath, "outputPath", outputPath)
 	return outputPath, nil
 }
 
@@ -463,7 +464,7 @@ func CleanupStaleTempFiles(rootDir string, maxAge time.Duration) int {
 		if strings.Contains(name, "-transcode.tmp") || strings.HasSuffix(name, ".ch.m4b") {
 			if time.Since(info.ModTime()) > maxAge {
 				if err := os.Remove(path); err == nil {
-					slog.Info("transcode cleaned up stale temp file (age )", "value0", "path", "path", path, "value1", time.Since(info.ModTime()).Round(time.Minute))
+					slog.Info("transcode cleaned up stale temp file", "path", path, "age", time.Since(info.ModTime()).Round(time.Minute))
 					cleaned++
 				}
 			}

--- a/internal/updater/scheduler.go
+++ b/internal/updater/scheduler.go
@@ -1,6 +1,7 @@
 // file: internal/updater/scheduler.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
+// last-edited: 2026-07-03
 
 package updater
 
@@ -87,7 +88,7 @@ func (s *Scheduler) tick() {
 	}
 
 	if !info.UpdateAvailable {
-		slog.Debug("Auto-update check no update available (current, latest)", "value0", "value0", "info", info.CurrentVersion, "value1", info.LatestVersion)
+		slog.Debug("Auto-update check no update available", "currentVersion", info.CurrentVersion, "latestVersion", info.LatestVersion)
 		return
 	}
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,6 +1,7 @@
 // file: internal/updater/updater.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
+// last-edited: 2026-07-03
 
 package updater
 
@@ -278,7 +279,7 @@ func (u *Updater) DownloadAndReplace(info *UpdateInfo) error {
 	// Clean up old binary (best effort)
 	os.Remove(oldPath)
 
-	slog.Info("Update applied successfully ->", "value0", "value0", "info", info.CurrentVersion, "value1", info.LatestVersion)
+	slog.Info("Update applied successfully", "currentVersion", info.CurrentVersion, "latestVersion", info.LatestVersion)
 	return nil
 }
 

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,6 +1,7 @@
 // file: internal/watcher/watcher.go
-// version: 2.1.1
+// version: 2.1.2
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
+// last-edited: 2026-07-03
 
 package watcher
 
@@ -120,7 +121,7 @@ func (w *Watcher) addRecursive(root string) error {
 		}
 		if d.IsDir() {
 			if watchErr := w.fsWatcher.Add(path); watchErr != nil {
-				slog.Warn("watcher cannot watch", "value0", "path", "path", path, "watchErr", watchErr)
+				slog.Warn("watcher cannot watch", "path", path, "watchErr", watchErr)
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary

Consultancy roadmap **TASK-18** (wave 5, runs alone): repo-wide sweep of corrupted structured-log calls.

- `value0` orphan-key sites: 55 → 0
- printf verbs in slog messages: 4 → 0
- true duplicate-key calls: 0 remaining (17 regex candidates confirmed false positives via per-call key extraction)
- 79 sites fixed across 41 files / 22 packages; all brief exemplars done (registry.go CTR-4, validate.go, embedding_client.go, scan_composer_tags.go, service_apply/scoring)
- Log-only diff: no levels, no control flow changed; missing guids added to 2 headers

## Test plan

- [x] `go build ./...` (+bench tag), `go vet ./...` clean
- [x] `go test -count=1` on all 22 touched package trees — zero failures (server 722s, database 393s)
- [ ] Minimal CI green

Skipped per brief: _test.go files; sloglint CI check (stretch goal → follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1