### PR TITLE
fix(web): clamp itemsPerPage upper bound (OOM URL vector, UI-eval F2)

### DIFF
--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.76.0
+// version: 1.77.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-07-03
 
@@ -133,11 +133,19 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     1,
     parseInt(searchParams.get('page') || localStorage.getItem(STORAGE_KEYS.LIBRARY_PAGE) || '1', 10)
   );
-  const initialItemsPerPage = Math.max(
-    10,
-    parseInt(
-      searchParams.get('limit') || localStorage.getItem(STORAGE_KEYS.LIBRARY_ITEMS_PER_PAGE) || '20',
-      10
+  // Clamp both ends: an unclamped ?limit= URL (or stale localStorage) can
+  // request the whole 44K-book library into the DOM — same OOM class as the
+  // useLibraryCache leak. 1000 is the largest offered page-size option.
+  const initialItemsPerPage = Math.min(
+    1000,
+    Math.max(
+      10,
+      parseInt(
+        searchParams.get('limit') ||
+          localStorage.getItem(STORAGE_KEYS.LIBRARY_ITEMS_PER_PAGE) ||
+          '20',
+        10
+      ) || 20
     )
   );
   const [searchQuery, setSearchQuery] = useState(initialSearch);


### PR DESCRIPTION
One-liner from the UI evaluation: `initialItemsPerPage` had a floor but no ceiling — `?limit=44929` (or stale localStorage) rendered the entire library into the DOM. Now clamped to [10, 1000] (1000 = largest offered page-size option), with NaN fallback to 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1