### PR TITLE
feat(itunes): .itl foolproofing — identity/magnitude guards, K15-K17, safety wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.102.0 -->
+<!-- version: 3.103.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-03 -->
 
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 3, 2026 - .itl deep dive: library-identity & expected-magnitude guards (K13/K14)
+
+Full-format deep dive triggered by the `.itunes-writeback` 374-track cloud
+stub (an intentionally-planted fresh iTunes library) **passing all 8 safety
+guards** — proving the contract certifies well-formedness but not "this is
+our library at plausible size".
+
+- **`feat(itunes)`** — SPEC 3 Tier 1: `library-identity` guard (K13) with a
+  persisted `.identity.json` sidecar fingerprint (Library PID @0x34 + ≤1024
+  evenly-spaced track PIDs; ≥90% overlap required; explicit `AdoptLibrary`
+  bless for deliberate swaps) and `expected-magnitude` guard (K14, ±10% vs an
+  external track count). Sidecar lifecycle wired into `SafeWriteITL`
+  (load-before-mutate fail-closed, refresh-after-landing). End-to-end test
+  rejects the stub-class replacement byte-identically.
+- **`docs(specs)`** — SPEC 3 (`2026-07-03-itl-identity-and-external-truth-hardening.md`,
+  normative K13–K16 + Tier 2–4 roadmap) and the full deep-dive record
+  (`2026-07-03-itl-format-and-foolproofing-deep-dive.md`): byte-level format
+  map incl. known unknowns, server-wide library census (13 libraries
+  audited), adversarial guard vacuity map, swallowed-error sites, dead-code
+  safety hooks (`PinLastKnownGood`/`SetLibraryNotInUse` have no production
+  callers), FM-1..FM-17 failure taxonomy, and the K16 mhoh decoder
+  misclassification that makes `location-form` fire on every known-good
+  library.
 
 #### July 3, 2026 - Consultancy-roadmap wave 3 + flake eradication (PRs #1772-#1781, #1688)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.103.0 -->
+<!-- version: 3.104.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-03 -->
 
@@ -8,6 +8,28 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 3, 2026 - .itl foolproofing wave 2: K15/K16 + dead-code safety wiring
+
+- **`fix(itunes)`** — **K16: the mhoh at24 encoding semantics were inverted
+  (1↔3)** — at24=1 is UTF-16LE, at24=3 is Windows-1252, exactly opposite to
+  the T002 table. Fixed decode + encode; the golden master and live library
+  now audit fully clean (first time ever). Guard follow-ups: bare `%` in real
+  filenames no longer flags (only `%XX` triples), and 0x0D/0x0B pair
+  consistency is a no-NEW check (iTunes itself leaves stale pairs). New
+  `TestGoldenCorpusAuditClean` fails the build if any guard fires on the
+  checked-in iTunes-authored testdata.
+- **`feat(itunes)`** — K15: nuclear rebuild refuses a >50% shrink without
+  `acknowledge_shrink=true`; always logs blast radius; identity guard armed
+  on distinct-path ApplyITLOperations. Bounded-delta is now PID-set based and
+  symmetric (removal, insertion, AND replacement all bounded).
+- **`feat(itunes)`** — wired the dead-code safety hooks: FileActivityLibraryCheck
+  (iTunes-in-use gate from library/journal mtimes, 2m window) set at service
+  construction; PinLastKnownGood after every successful flush (.bak-lkg now
+  actually exists). Batcher flush failures re-enqueue with a 3-attempt cap
+  instead of WARN+drop; parse failure defers instead of blind-writing; the
+  service wrapper re-reads the temp file and runs the FULL contract before
+  rename (step 4b); MarkExternalIDRemoved failures are logged.
 
 #### July 3, 2026 - .itl deep dive: library-identity & expected-magnitude guards (K13/K14)
 

--- a/docs/specs/2026-07-03-itl-format-and-foolproofing-deep-dive.md
+++ b/docs/specs/2026-07-03-itl-format-and-foolproofing-deep-dive.md
@@ -1,0 +1,327 @@
+<!-- file: docs/specs/2026-07-03-itl-format-and-foolproofing-deep-dive.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9e5d7c3b-2a4f-4d8e-b1c6-7f0a9b8c2d3e -->
+<!-- last-edited: 2026-07-03 -->
+
+# .itl Format & Writeback Foolproofing — Full Deep Dive (2026-07-03)
+
+This is the complete record of the July 2026 deep dive: the byte-level format
+as this codebase understands it, the empirical census of every library on the
+server, the adversarial audit of the safety pipeline, the documented failure
+history, and the full hardening roadmap. SPEC 3
+(`2026-07-03-itl-identity-and-external-truth-hardening.md`) is the normative
+subset that is being implemented; this document is the evidence base and the
+everything-else. Companion docs: SPEC 2
+(`fable5-spec-itunes-writeback-hardening.md`), findings
+(`fable5-review-findings.md`), `docs/itl-binary-format.md`.
+
+---
+
+## Part A — The .itl binary format (as implemented in `internal/itunes`)
+
+### A.1 Envelope: `hdfm` header (plaintext, big-endian)
+
+`hdfmHeader` / `parseHdfmHeader` (`itl.go:419-484`):
+
+| file offset | size | field |
+|---|---|---|
+| 0x00 | 4 | magic `"hdfm"` |
+| 0x04 | 4 BE | `headerLen` (payload starts here) |
+| 0x08 | 4 BE | `fileLen` |
+| 0x0C | 4 BE | `unknown` — **opaque, preserved verbatim** |
+| 0x10 | 1 | version-string length |
+| 0x11 | N | version string (e.g. `"12.13.10.3"`) |
+| 0x34 | 8 | **Library Persistent ID** (matches the Album Artwork cache dir name; empirical, added for K13) |
+| 0x44/0x48/0x4C/0x54 | 4 BE each | track/playlist/album/artist counts (CRIT-3 fields) |
+| 0x5C | 4 BE | `maxCryptSize` (read iff headerLen > 96) — AES boundary |
+| 17+len(ver) → headerLen | rest | `headerRemainder` — **opaque blob**, only the 4 counts (+ nothing else) patched on write |
+
+`headerFixedPrefix = 17`; a field at file offset F lives at remainder offset
+`F − (17 + len(version))`.
+
+### A.2 Encryption and compression
+
+- **AES-128-ECB**, hardcoded key `"BHUILuilfghuila3"` (`itl.go:27`), block-wise,
+  no IV. **Only a prefix is encrypted**: for version ≥ 10, `limit =
+  maxCryptSize` if non-zero else capped at **102400 bytes**; floored to a
+  16-byte multiple; the rest of the payload is cleartext (`itl.go:240-251`).
+  Pre-v10 encrypts the whole payload.
+- **zlib**: detected by leading `0x78`; absent → passthrough. Inflation is
+  fail-closed (T010) with a 2 GiB cap. Deflation MUST use `zlib.BestSpeed`
+  (level 1) — iTunes rejects Go's default level-6 output.
+- Order: decrypt → inflate on read; deflate → encrypt on write
+  (`parseITLData` `itl.go:516-548`, `encodeITLPayload` `itl.go:967-981`).
+
+### A.3 Two chunk vocabularies (LE vs BE)
+
+`detectLE` (`itl.go:176`): payload starting with `"msdh"` → LE; else BE.
+
+- **LE (v10+, all production)**: `msdh` section containers with `blockType`
+  at +12 (1=tracks, 2=playlists, 9=albums, 11=artists; also 4, 12–16, 19–23
+  observed, semantics unknown). Inside: `mlth`/`mlph`/`mlah`/`mlih`
+  (list headers carrying a **semantic count at +8, not a byte length** —
+  advance by `headerLen` only), `mith` (track), `miph` (playlist), `mtph`
+  (playlist item), `miah`/`miih` (album/artist items), `mhoh` (string).
+- **BE (legacy PowerPC)**: `hdsm`/`htim`/`hpim`/`hptm`/`hohm`. Parse
+  supported (`itl_be.go`); **writeback refused** (`ErrBEWritebackUnsupported`,
+  K12).
+- **The central parsing subtlety** (HIGH-2, the bug that blinded all string
+  diagnostics until T001): every chunk has `headerLen` at +4 and `totalLen`
+  at +8; for container tags (`mith`,`mhoh`,`miah`,`miph`,`miih`) the outer
+  cursor advances by `totalLen` but children live in
+  `[offset+headerLen, offset+totalLen)` and must be inner-walked. Two layouts
+  exist in the wild: nested (children inside the mith span) and flat-sibling
+  (`itl_le.go:123-133`).
+- **PID byte order differs**: LE stores track PIDs reversed on disk
+  (`parseMithLE` reverses `data[base+135-i]`); BE stores MSB-first. Hex form
+  everywhere in code/XML is MSB-first.
+- Track field offsets differ per variant (e.g. TrackNumber: LE u16@+44, BE
+  u32@+44; DiscNumber: LE u16@+104, BE byte@+104). Annotated layouts:
+  `parseMithLE` (`itl_le.go:220`), `parseHtimBE` (`itl_be.go:128-228`).
+
+### A.4 `mhoh` string blocks (the historic corruption epicenter)
+
+40-byte fixed header (`mhohFixedHeaderTotal=40`, legal `headerLen`=**24**,
+100% uniform across 965,223 golden blocks):
+
+| offset | field |
+|---|---|
+| +0 | `"mhoh"` |
+| +4 u32 | headerLen (must be 24; damaged libs had 41–210 → K5) |
+| +8 u32 | totalLen = 40 + strLen (K7) |
+| +12 u32 | hohmType |
+| +24 u32 | **encoding indicator (the real one)**: 0=ASCII, 1=Win-1252, 2=UTF-8, 3=UTF-16**LE** |
+| +27 byte | legacy flag — iTunes writes **0x00 always**; our old writer stamped 1/3 here → K3/CRIT-1 |
+| +28 u32 | strDataLen |
+| +32..39 | reserved, zero |
+| +40… | string payload |
+
+- hohmType map: 0x02 Name, 0x03 Album, 0x04 Artist, 0x05 Genre, 0x06 Kind,
+  0x08 Comment, **0x0B LocalURL** (`file://localhost/…`, percent-escaped),
+  0x0C Composer, **0x0D Location** (native Windows path, `W:\…`), 0x64
+  playlist Name, 0x65/0x66 smart-criteria **binary blobs** (never decoded),
+  ~40 more in `mhoh_encoding_table.go:94-292` (corpus-derived, 2026-06-09).
+- Three types (0x15, 0x69, 0x6C) have non-standard length layout — exempt
+  from len-arithmetic/tail-zero checks.
+- **Two encoding conventions share the same numbers with different meanings**
+  (legacy +27: 1=UTF-16**BE**, 3=Win-1252; corpus +24: 1=Win-1252,
+  3=UTF-16**LE**). `decodeMhohBlock` (`mhoh_string.go:261-300`) discriminates
+  on `+27==0`. **K16 (open defect):** this discriminator misclassifies large
+  classes of iTunes-authored blocks in both directions — golden-library
+  Locations render as byte-swapped CJK mojibake (ASCII decoded as UTF-16LE)
+  and real UTF-16LE renders as NUL-interleaved 8-bit. Consequence:
+  `location-form` reports ~2× tracks-with-location violations on every
+  known-good library, and any decode→encode round-trip of a misclassified
+  string would write real corruption.
+- Writer (`encodeMhohITunes`, `mhoh_string.go:99-139`) is corpus-table-driven
+  and errors rather than guesses on unknown types; out-of-corpus blocks are
+  preserved byte-for-byte with a WARN.
+- The 0x0D/0x0B **LocationPair invariant** (SPEC 2 §1b): one canonical
+  Windows path, rendered twice (0x0D plain, 0x0B `file://localhost/` +
+  percent-escaping); always written as a pair; URL-in-0x0D is
+  unrepresentable via `LocationPair` (K4/CRIT-2 fix).
+
+### A.5 Known unknowns (fields treated as opaque)
+
+- hdfm `unknown` @0x0C; entire `headerRemainder` minus 4 counts (+ now the
+  Library PID read for K13).
+- BE `htim` unknowns at +24/+52/+56/+62/+80/+84/+109/+124/+136; `hptm`/`mtph`
+  16 bytes at +8..23 (checked-state flag not parsed — TODO `itl_be.go:70`).
+- Smart criteria/info blobs (0x65/0x66) — copied raw.
+- Playlist folder detection unsolved (`ITLPlaylist.IsFolder` TODO,
+  `itl.go:36`); `Bookmarkable` assumed true (`itl_convert.go:51`).
+- msdh blockTypes 4, 12–16, 19–23: inventoried, semantics unknown; copied
+  as-is on rewrite.
+- `maxCryptSize == 0` → magic 102400 fallback: boundary heuristic, untested
+  against iTunes variants that might use another value.
+
+**Foolproofing implication of every opaque field:** we cannot detect desync
+in what we cannot read. The mitigation is not to parse everything — it is to
+(a) preserve byte-exactly, (b) verify round-trip byte-identity where nothing
+was mutated, and (c) anchor to external truth for what the file *means*.
+
+---
+
+## Part B — Empirical census (server audit, 2026-07-03)
+
+`itl-check` (cross-compiled linux/amd64) against every library on
+`172.16.2.30`:
+
+| Library | Tracks | Playlists | Ver | Verdict | Notes |
+|---|---|---|---|---|---|
+| `books/itunes/iTunes Library.itl` (live, Jun 25) | 95,238 (93,677 loc) | 353 | 12.13.10.3 | FAIL location-form only | K16 false positive; +4,338 tracks vs golden |
+| `.itunes-master/iTunes Library.golden.itl` (RO, Apr 2) | 90,900 (89,339 loc) | 335 | 12.13.10.3 | FAIL location-form only | K16 false positive |
+| `.itunes-writeback/iTunes Library.itl` (Jul 1) | **374 (0 loc)** | 14 | 12.13.10.3 | **PASS all 8** | the stub; operator-planted baseline (see SPEC 3 §1) |
+| `…writeback/*.bak-2026062x/070x` (×5) | 374 | 14 | | PASS | byte-identical stub copies — rotation had consumed all slots |
+| `…(Damaged).itl` | 90,898 | 335 | | FAIL ×4 | hdr 90,900≠90,898 (K2), 2 dangling mtph (K1), 1.48M mhoh (K3/K5), URL-in-0x0D (K4) |
+| `…(Damaged) 1.itl` | 90,898 | 335 | | FAIL ×3 | as above minus dangling refs |
+| `…(Damaged) 2.itl` | 90,900 | 335 | | FAIL ×2 | itl-repair'd twin of damaged-1; **still iTunes-rejected** |
+| `…(Damaged) 3.itl` | 90,863 | 335 | | FAIL ×2 | only 646 bad mhoh + `.itunes-writeback/` staging-path leak |
+| `….itl.repaired-bak-20260502-083408` | 90,900 | 335 | | K16-only | the successful May 2 repair output |
+| `….itl.rebuild-bak-20260502-075930` | 0 | 14 | | FAIL parse | failed rebuild attempt |
+| `….itl.tiny-snapshot-20260502-183252` | 65 | 0 | | FAIL ×4 | failed intermediate |
+| `Previous iTunes Libraries/…2022-12-22.itl` | 40,913 | 165 | 12.12.6.1 | K16-only | historical |
+| repo `testdata/itunes/iTunes Library.itl` | 85,579 | 313 | 12.13.9.1 | K16-only | CI corpus candidate |
+
+Other findings: `iT 1.tmp` (131 MB) is an **XML export**, not an .itl;
+`bkup/itunesgood/` is a full known-good set matching the Apr 2 golden;
+`books/itunes/Backup/` is iOS device backups (unrelated). XML `<key>Track
+ID</key>` grep-counts are inflated ~4× by playlist membership entries — only
+the binary parse is authoritative.
+
+**Stub forensics (K13 exemplar):** same Library PID `48E87F59865568B0` as
+golden, **0/374 shared track PIDs**, all-music cloud-only content (no
+Locations). Operator-confirmed provenance: iTunes failed to load its library,
+rebuilt fresh, pulled the account's cloud music; the operator then copied it
+in as a deliberate safe baseline. Passing all 8 guards is the finding.
+
+---
+
+## Part C — The safety pipeline, adversarially
+
+### C.1 Architecture
+
+- Hardened chokepoint `itunes.SafeWriteITL` (`itl_safe_write.go:180`):
+  8-step protocol — in-use gate (unwired) → read/parse/refuse-BE → mutate a
+  copy → **regenerate header counts** → in-memory contract → `.itl.new` +
+  fsync → **re-read from disk, contract again** → `.bak-<RFC3339>` + atomic
+  rename + dir fsync → rotate (keep 10, `.bak-lkg` pinned).
+- **Second, weaker wrapper** `itunesservice.SafeWriteITL`
+  (`writeback_batcher.go:582`): only `ValidateITL` around
+  `ApplyITLOperations` → `.tmp` → rename; own `.bak-YYYYMMDD-HHMMSS` keep-5
+  scheme. This is what the batcher flush and `server/itl_rebuild.go` call.
+  (It reaches the real contract indirectly via `safeEncodeITL`, but skips the
+  re-read verification, lkg pinning, and unified rotation.)
+
+### C.2 Guard-by-guard: detects vs blind
+
+| Guard | Detects | Blind to |
+|---|---|---|
+| parse-roundtrip | non-LE, unlocatable master list, 0 tracks; fail-closed | any magnitude > 0; semantics |
+| container-tiling | truncation/splice/gap | valid-but-wrong content |
+| count-coherence | internal mlth/mith + header/payload desync (K2), per-miph counts (K8) | **anything external — header is regenerated from the same payload first (self-referential)** |
+| no-new-dangling-refs | new orphan mtph (K1); fail-closed | removals that also fix playlists; rebuilt-empty playlists |
+| mhoh-format | +27≠0 (K3), headerLen≠24 (K5), len arithmetic (K7), bad +24 | byte-perfect wrong content; missing blocks |
+| location-form | URL-in-0x0D (K4), staging-path leak, unpaired 0x0B | **vacuous at 0 locations; permanently noisy via K16** |
+| tid-pid-sanity | TID order/dupes (K6/K11), zero/dup PIDs (K9) | count loss |
+| expected-magnitude *(new)* | K14 shrink/growth vs external count | disarmed unless caller wires ExpectedTrackCount |
+| library-identity *(new)* | K13 library swap / population replacement | disarmed on first run (no sidecar) |
+| bounded-delta | >5000 removals, >20% mhoh rewrite | **before==nil (all audit use); Force (rebuild/export always); replacement-shaped shrink** |
+
+### C.3 Swallowed errors / dead code (exact sites)
+
+- `writeback_batcher.go:353-363` — diff-step parse failure: WARN + writes all
+  updates anyway.
+- `writeback_batcher.go:533-536` — flush `SafeWriteITL` error: WARN + drop
+  (no retry/alert).
+- `writeback_batcher.go:596-597` — backup failure: WARN, proceeds with no
+  rollback anchor. `:216-220` — `MarkExternalIDRemoved` discarded in a
+  goroutine. `:543-547` — `MarkITunesSynced` WARN-only. `:370-372,406` —
+  per-item DB errors skipped.
+- `itl_le_verify.go:80-85` — exported legacy `VerifyITLNoDanglingRefsLE`
+  still **fail-open** (nil when master list unlocatable); the contract's G4
+  fixed this only inside the contract.
+- `PinLastKnownGood` — **zero production callers** (test-only) → `.bak-lkg`
+  never exists. `SetLibraryNotInUse`/`WithLibraryNotInUse` — **zero
+  production callers** → in-use gate always WARN-and-proceeds.
+- `rebuild.go:140-142,176-178` — `GetBookFiles` errors fall through to
+  empty/default Location.
+
+### C.4 Rebuild path blast radius
+
+`RebuildITLFromDB` (`rebuild.go:249-305`, `POST /api/v1/itunes/rebuild-full`)
+removes ALL tracks and re-adds only DB books with `IsPrimaryVersion && !
+MarkedForDeletion && ITunesPersistentID != ""`, under
+`ForceContractConfig()`. An under-populated/mid-migration DB → a tiny,
+guard-passing library written in place. `BuildExportITL` shares the Force
+blindness (export-only). This is the highest-leverage K15 site.
+
+---
+
+## Part D — Failure history (chronological taxonomy)
+
+Sources: `fable5-review-findings.md`, `fable5-spec-itunes-writeback-hardening.md`,
+`docs/itunes-sync-diagnostic-suite.md`, git log. Four production "(Damaged)"
+libraries are the evidence base (all produced by this tool's writeback).
+
+**Phase 1 — May 2026 (point-patch era):**
+- FM-1 (May 2, `23b127ab`): `RemoveTracksByPIDLE` left dangling mtph → K1.
+  "Fix" = neuter removal to a no-op + fail-open verifier. Point patch on the
+  *minority* class.
+- FM-2 (`ec641693`): `cmd/itl-repair` strips orphan mtph. Proof of
+  insufficiency: damaged-2 = repaired damaged-1, **still rejected** (K2/K3/K5
+  remained).
+- FM-3 (`9bc0c19c`): sync diagnostic suite (Apple Devices crash at
+  "Determining tracks to sync"); surfaced clues, fixed nothing.
+- FM-4 (`fbb3bfc9`): flush circuit-breaker → later generalized into
+  bounded-delta.
+
+**Phase 2 — late May:** corruption still live 27 days post-"fix"; PD-2
+bisect over 275 commits proposed, **never executed** (resolved by forward-fix
+instead — consistent with a *class* of writer defects, not one regression).
+
+**Phase 3 — June 2026 (structural era):**
+- FM-8 (Jun 5, `3b5ce221`): K5 headerLen writer fix — but no read-time
+  detector (HIGH-6), and the dominant K3 stayed live 4 more days.
+- FM-9 (Jun 9): fable5 review names the real classes — CRIT-1 (+27 flag),
+  CRIT-2 (URL-in-0x0D), CRIT-3 (stale header counts) — all still LIVE.
+- FM-10..16 (Jun 9–10): T001 mhoh-descent parser fix (strings were never
+  read!), T002 encoding corpus, T010 fail-closed inflate, T003 the 8-guard
+  contract, T004 SafeWriteITL + header regeneration, T005 conformant
+  encoders, T006 LocationPair, T007 honest itl-diff/itl-check, T008
+  diff-before-write.
+- FM-17 (Jun 26): `itunes-heal` — adjacent DB-reference staleness (~19,922
+  tracks) from the June organize bug; ongoing mop-up, not .itl damage.
+
+**Recurrence patterns (the meta-lessons):**
+1. Point patches on minority classes let the majority class run ~5 more weeks.
+2. **Fail-open shipped twice independently** (verifier + inflate) — passing
+   exactly when the library was most damaged.
+3. Partial fixes ordered by ease, not dominance (K5 before K3).
+4. Diagnostic tools produced false confidence during a live incident
+   ("0 changed" on 167K-block rewrites) because the parser never read
+   strings.
+5. **July 2026 continues the pattern one level up:** structure got fixed;
+   *identity and magnitude* — semantics — were the next unmodeled class, and
+   the stub sailed through. Each era's guards perfectly catch the previous
+   era's failures.
+
+---
+
+## Part E — Roadmap (normative list; SPEC 3 holds the implemented detail)
+
+**Tier 1 — external truth anchors (IMPLEMENTED 2026-07-03,
+`feat/itl-identity-guards`):** `library-identity` guard (K13, sidecar
+fingerprint: Library PID + ≤1024-PID sample, ≥90% overlap, `AdoptLibrary`
+bless), `expected-magnitude` guard (K14, ±10% vs external count), sidecar
+lifecycle in `SafeWriteITL`, 7 tests incl. end-to-end stub-rejection.
+
+**Tier 2 — close the bypasses (K15):** de-hardcode Force in
+rebuild/export + report-mode bounded-delta under Force; symmetric
+bounded-delta (|Δ| + replacement ratio); unify both write wrappers on the
+hardened path; flush errors → metric+alert; wire `PinLastKnownGood` and
+`SetLibraryNotInUse`; batcher parse failure → abort+re-enqueue.
+
+**Tier 3 — fix the decoder, then trust the guards (K16):** repair
+`decodeMhohBlock` discrimination (both-directions mojibake on golden);
+acceptance = **0 location-form violations on the golden master**; CI-audit
+the checked-in testdata golden so a guard failing on known-good data fails
+the build.
+
+**Tier 4 — model iTunes as co-writer:** record post-write file checksum;
+on next write, mismatch → re-parse + identity re-check + require the foreign
+diff to be explainable (play counts/dates) before layering mutations;
+`ExpectedTrackCount` wired from the DB census on every batcher flush.
+
+**Standing principles distilled from the whole history:**
+- Fail closed everywhere; a check that can't run is a failure, not a pass.
+- No self-referential validation — every "coherence" needs an anchor outside
+  the bytes being validated.
+- Bypasses are per-write operator acts (`AdoptLibrary`), never baked into a
+  call site (`ForceContractConfig()` in rebuild).
+- A guard that fires on known-good data is worse than no guard (alarm
+  fatigue); golden-corpus CI keeps guards honest.
+- Preserve opaque bytes exactly; verify byte-identity of everything not
+  deliberately mutated.
+- iTunes co-authors the file; validate continuity on read, not just
+  correctness on write.

--- a/docs/specs/2026-07-03-itl-identity-and-external-truth-hardening.md
+++ b/docs/specs/2026-07-03-itl-identity-and-external-truth-hardening.md
@@ -1,0 +1,172 @@
+<!-- file: docs/specs/2026-07-03-itl-identity-and-external-truth-hardening.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6c2e8f4a-1b7d-4e9c-a3f5-8d0b1c2e3f4a -->
+<!-- last-edited: 2026-07-03 -->
+
+# SPEC 3: iTunes Library Identity & External-Truth Hardening
+
+Goal: close the class of failures the June 2026 contract (SPEC 2) structurally
+cannot see — **semantically-valid wrong content**. The SPEC 2 guards certify
+"this is a well-formed iTunes library"; nothing certifies "this is *our*
+library at *plausible* size". This spec adds the missing external truth
+anchors, closes the known guard bypasses, and fixes the decoder defect that
+makes one guard permanently noisy.
+
+## 1. Motivating evidence: the July 2026 374-track cloud stub
+
+Observed at `/mnt/bigdata/books/audiobook-organizer/.itunes-writeback/iTunes
+Library.itl` (2026-07-01, 1,058,546 bytes; every `.bak` since 2026-06-21
+byte-identical). `itl-check`: **all 8 guards PASS.** `itl-diff` vs the golden
+master (90,900 tracks):
+
+| Property | Golden | Stub |
+|---|---|---|
+| Tracks | 90,900 | 374 |
+| Playlists | 335 | 14 |
+| Tracks with Location | 89,339 | **0** |
+| Library Persistent ID @0x34 | `48E87F59865568B0` | `48E87F59865568B0` (same) |
+| Shared track PIDs | — | **0 of 374** |
+| Content | audiobooks + music | cloud-only music entries |
+
+Provenance (operator-confirmed): iTunes on the Windows box failed to load its
+library, created a fresh one, and populated it from the account's cloud music
+list; the stub was then deliberately copied into the staging dir as a safe
+test baseline. The point stands regardless of intent: **a different library
+with 0.4% of the tracks, at the same path, with the same Library PID, passes
+every guard.** iTunes is a co-writer of this file and the contract only
+models our own writes.
+
+### Why each guard passed (the vacuity map)
+
+- `count-coherence` — self-referential: `regenerateHeaderCounts` rewrites the
+  header from the same payload the guard then compares it to; equal by
+  construction. It can catch internal desync, never a wholesale shrink.
+- `location-form` — a track with no `0x0D` block returns early; at 0 locations
+  the guard passes vacuously on every track.
+- `bounded-delta` — the only magnitude guard, bypassed three ways:
+  (a) `before == nil` (all audit-mode use, incl. `cmd/itl-check`),
+  (b) `cfg.Force` — passed **unconditionally** by `RebuildITLFromDB` and
+  `BuildExportITL`, the two paths most capable of mass loss,
+  (c) it bounds only *removals*, so remove-all-then-add-few replacement
+  passes even without Force.
+- Everything else is structural and the stub is internally coherent.
+
+### Compounding exposures found in the same audit
+
+- `PinLastKnownGood` / `.bak-lkg` — **no production caller**; rotation
+  (keep 10) had already reduced every backup to a copy of the stub.
+- `SetLibraryNotInUse` / `WithLibraryNotInUse` — **no production caller**;
+  the "iTunes may have it open" gate always WARN-and-proceeds.
+- The batcher flush swallows `SafeWriteITL` errors as `slog.Warn` (no retry,
+  no alert); its parse-failure branch logs WARN and proceeds to write.
+- Two divergent write wrappers: `itunesservice.SafeWriteITL` (weak
+  `ValidateITL` checks, own 5-backup scheme) vs the hardened
+  `itunes.SafeWriteITL` (8-step protocol).
+- `decodeMhohBlock` misclassifies string encodings on iTunes-authored
+  libraries **in both directions** (ASCII decoded as UTF-16LE → CJK mojibake;
+  UTF-16LE decoded as 8-bit), which makes `location-form` report ~2×
+  tracks-with-location violations on **every known-good library including the
+  golden master**. A guard that is always red on good data has effectively
+  never been exercised.
+
+## 2. New corruption/loss classes
+
+Extending SPEC 2 §1's K-table:
+
+| # | Class | Status | Evidence | Disposition |
+|---|---|---|---|---|
+| K13 | Same path, different library (library swapped underneath the writer — by iTunes rebuild, wrong file copied in, or population-replacing mutation). Library PID is NOT sufficient identity: the stub kept it with zero track-PID overlap. | **OBSERVED** (2026-07, benign instance) | stub vs golden: 0/374 shared track PIDs, same Library PID | `library-identity` guard (§3), **implemented v1** |
+| K14 | Structurally-perfect library at implausible magnitude (rebuild from under-populated DB; fresh iTunes library; truncated import) | **OBSERVED** (same instance: 99.6% shrink, all guards green) | stub: 374 vs 90,900 | `expected-magnitude` guard (§3), **implemented v1** |
+| K15 | Guard bypass via unconditional `Force` on rebuild/export paths | LATENT | `rebuild.go` passes `ForceContractConfig()` always | §5, planned |
+| K16 | mhoh encoding misclassification at read time (decode-side twin of K3; corrupts strings if any path round-trips decode→encode; renders `location-form` permanently noisy) | **OBSERVED** (display/audit level) | golden master "fails" location-form with byte-swap mojibake; violation count = 2× tracks-with-location | §6, planned |
+
+## 3. NORMATIVE: the identity fingerprint (K13/K14, implemented)
+
+New module `internal/itunes/itl_identity.go`; guards registered in
+`orderedGuards()` between `tid-pid-sanity` and `bounded-delta`.
+
+**Sidecar.** After every successful `SafeWriteITL`, the bytes that actually
+landed on disk (step-5 re-read payload + header) are fingerprinted into
+`<library>.itl.identity.json`:
+
+```json
+{
+  "schema_version": 1,
+  "library_pid": "48e87f59865568b0",
+  "track_count": 90900,
+  "playlist_count": 335,
+  "sample_stride": 88,
+  "pid_sample": ["<up to 1024 evenly-spaced track PIDs, payload order>"],
+  "updated_at": "2026-07-03T00:00:00Z"
+}
+```
+
+Sidecar write failure is WARN-only (the library write already landed; a stale
+sidecar only makes the next check stricter). Sidecar **read** failure is a
+hard error — a corrupt anchor must not degrade to "no anchor". A missing
+sidecar is a legitimate first-run state (guard disarmed for that write, then
+the sidecar is created).
+
+**Guard `library-identity` (K13).** Armed when `cfg.ExpectedIdentity != nil`
+(SafeWriteITL populates it from the sidecar unless the caller already set it).
+Violations:
+- proposed header's Library PID ≠ fingerprint's (when both present);
+- `SampleOverlapPct(after)` < `cfg.IdentityMinOverlapPct` (default **90**);
+- fingerprint unassessable (empty sample) — fail closed.
+
+Bypass is `cfg.AdoptLibrary` only: an explicit per-write operator
+acknowledgment ("this is intentionally a different library"), after which the
+new population is fingerprinted. `Force` does **not** bypass identity.
+
+**Guard `expected-magnitude` (K14).** Armed when
+`cfg.ExpectedTrackCount > 0`; `after`'s track count must be within
+`cfg.MagnitudeTolerancePct` (default **10**) of it. The expected count comes
+from *outside* the file — the DB's synced-book census or the sidecar's
+`track_count`. This is the non-self-referential complement to
+`count-coherence`.
+
+Against the motivating incident: the stub write is rejected by
+`library-identity` (overlap 0% < 90%) even though the Library PID matches,
+and by `expected-magnitude` once callers wire an expected count. Verified
+end-to-end in `TestSafeWrite_IdentityLifecycle`.
+
+## 4. Wire the dead-code safety machinery (planned)
+
+- Call `PinLastKnownGood` after a write that (a) passed identity and (b) is
+  followed by evidence iTunes opened the result (sentinel mtime advance), or
+  via an explicit operator bless command. Without this, keep-10 rotation
+  guarantees a stub eventually owns every backup slot.
+- Wire `SetLibraryNotInUse` from the service's iTunes-running heartbeat.
+- Route the batcher flush and `server/itl_rebuild.go` through
+  `itunes.SafeWriteITL`; retire `itunesservice.SafeWriteITL` and its parallel
+  backup scheme. Flush failures become metric + alert, not WARN.
+- Batcher parse-failure branch: abort + re-enqueue, never proceed-and-write.
+
+## 5. Close the Force bypasses (K15, planned)
+
+- `RebuildITLFromDB` / `BuildExportITL`: `Force` becomes an explicit caller
+  argument, not baked in; even under Force, `bounded-delta` runs in report
+  mode so the log records "this write removes N tracks".
+- `bounded-delta` becomes symmetric: bound |Δtracks| and the replacement
+  ratio (fraction of `after` PIDs absent from `before`), not removals only.
+
+## 6. Fix the decoder, then trust the guards (K16, planned)
+
+- Diagnose `decodeMhohBlock`'s discriminator against the golden corpus
+  (`cmd/itl-audit-encoding`); the observed both-directions mojibake says the
+  `+27 == 0` branch applies the wrong table to common types.
+- **Acceptance:** `AuditITL` on the golden master reports **0
+  `location-form` violations.** Add the checked-in `testdata` golden to CI:
+  any guard failing on known-good data fails the build.
+
+## 7. Test matrix (v1 implemented portion)
+
+| Test | Asserts |
+|---|---|
+| `TestExtractLibraryPIDHex` | PID read at 0x34; zero/absent → "" |
+| `TestComputeLibraryIdentity` | counts, stride, sample; unparseable payload errors (never a vacuous anchor) |
+| `TestSampleOverlapPct` | 100 on self, 0 on disjoint, −1 unassessable |
+| `TestGuardLibraryIdentity` | disarmed / adopt / continuation / replaced / PID-change / fail-closed |
+| `TestGuardExpectedMagnitude` | disarmed / exact / tolerance / 99.6%-shrink / growth |
+| `TestIdentitySidecarRoundtrip` | missing→(nil,nil); roundtrip; corrupt→error |
+| `TestSafeWrite_IdentityLifecycle` | fingerprint on first write; stub-class replacement rejected byte-identically; AdoptLibrary blesses and re-anchors |

--- a/internal/itunes/itl_combined_mutate.go
+++ b/internal/itunes/itl_combined_mutate.go
@@ -95,6 +95,25 @@ func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet, cfg .
 	}
 
 	contractCfg := contractCfgOrDefault(cfg)
+
+	// K13/K14/K17: arm the external-truth guards from the input library's
+	// sidecar for BOTH write routes. Identity (K13) anchors the population;
+	// ExpectedTrackCount (K14) is the sidecar's validated count adjusted by
+	// this operation's own add/remove delta — a flush landing far from that
+	// projection means the file under us is not the state we think it is.
+	if contractCfg.ExpectedIdentity == nil && !contractCfg.AdoptLibrary {
+		sidecarID, idErr := LoadLibraryIdentity(inputPath)
+		if idErr != nil {
+			return nil, fmt.Errorf("ApplyITLOperations: identity sidecar for %s: %w", inputPath, idErr)
+		}
+		contractCfg.ExpectedIdentity = sidecarID
+		if contractCfg.ExpectedTrackCount == 0 && sidecarID != nil && sidecarID.TrackCount > 0 {
+			if exp := sidecarID.TrackCount + len(ops.Adds) - len(ops.Removes); exp > 0 {
+				contractCfg.ExpectedTrackCount = exp
+			}
+		}
+	}
+
 	totalUpdated := 0
 	mutate := applyOpsMutate(ops, &totalUpdated)
 
@@ -112,16 +131,6 @@ func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet, cfg .
 	raw, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading ITL: %w", err)
-	}
-	// K13: the distinct-output path bypasses SafeWriteITL's sidecar load, so
-	// arm the library-identity guard from the INPUT library's sidecar here —
-	// otherwise rebuild/export-to-tmp writes escape identity checking.
-	if contractCfg.ExpectedIdentity == nil && !contractCfg.AdoptLibrary {
-		sidecarID, idErr := LoadLibraryIdentity(inputPath)
-		if idErr != nil {
-			return nil, fmt.Errorf("ApplyITLOperations: identity sidecar for %s: %w", inputPath, idErr)
-		}
-		contractCfg.ExpectedIdentity = sidecarID
 	}
 	outBytes, err := safeEncodeITL(raw, mutate, contractCfg)
 	if err != nil {

--- a/internal/itunes/itl_combined_mutate.go
+++ b/internal/itunes/itl_combined_mutate.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/itl_combined_mutate.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f7a8b9c0-d1e2-3f4a-5b6c-7d8e9f0a1b2c
+// last-edited: 2026-07-03
 //
 // Combined ITL mutation: applies removes, adds, and location patches in a
 // single read-modify-write pass. This avoids redundant decrypt/compress
@@ -111,6 +112,16 @@ func ApplyITLOperations(inputPath, outputPath string, ops ITLOperationSet, cfg .
 	raw, err := os.ReadFile(inputPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading ITL: %w", err)
+	}
+	// K13: the distinct-output path bypasses SafeWriteITL's sidecar load, so
+	// arm the library-identity guard from the INPUT library's sidecar here —
+	// otherwise rebuild/export-to-tmp writes escape identity checking.
+	if contractCfg.ExpectedIdentity == nil && !contractCfg.AdoptLibrary {
+		sidecarID, idErr := LoadLibraryIdentity(inputPath)
+		if idErr != nil {
+			return nil, fmt.Errorf("ApplyITLOperations: identity sidecar for %s: %w", inputPath, idErr)
+		}
+		contractCfg.ExpectedIdentity = sidecarID
 	}
 	outBytes, err := safeEncodeITL(raw, mutate, contractCfg)
 	if err != nil {

--- a/internal/itunes/itl_golden_audit_test.go
+++ b/internal/itunes/itl_golden_audit_test.go
@@ -1,0 +1,75 @@
+// file: internal/itunes/itl_golden_audit_test.go
+// version: 1.0.0
+// guid: 5a7e9c1d-3b2f-4e6a-8d0c-9f1b2a3c4d5f
+// last-edited: 2026-07-03
+//
+// Golden-corpus audit regression (SPEC 3 §6 / K16 acceptance).
+//
+// WHY: a guard that fires on known-good data is worse than no guard — it
+// trains operators to ignore red. Before the K16 fix, location-form reported
+// ~2× tracks-with-location violations on EVERY iTunes-authored library
+// (including the golden master) because the mhoh string decoder had the
+// at24 1/3 semantics swapped, so the guard was auditing mojibake. This test
+// pins the acceptance criterion: the checked-in iTunes-authored testdata
+// library must pass every guard with zero violations. Any future guard or
+// decoder change that regresses on real iTunes output fails the build here.
+
+package itunes
+
+import (
+	"os"
+	"testing"
+)
+
+const goldenTestdataITL = "../../testdata/itunes/iTunes Library.itl"
+
+func TestGoldenCorpusAuditClean(t *testing.T) {
+	raw, err := os.ReadFile(goldenTestdataITL)
+	if err != nil {
+		t.Skipf("golden testdata library unavailable: %v", err)
+	}
+
+	verdict := AuditITL(raw)
+	for _, r := range verdict.Results {
+		if r.Pass() {
+			continue
+		}
+		max := len(r.Violations)
+		if max > 5 {
+			max = 5
+		}
+		for _, v := range r.Violations[:max] {
+			t.Errorf("guard %s: [%d/%s] %s", r.Guard, v.Offset, v.Chunk, v.Message)
+		}
+		if len(r.Violations) > max {
+			t.Errorf("guard %s: ...and %d more violations", r.Guard, len(r.Violations)-max)
+		}
+	}
+	if !verdict.Pass {
+		t.Fatalf("iTunes-authored golden library must pass every guard; failed: %v", verdict.FailedGuards())
+	}
+
+	// The decoder must also produce sane strings: every 0x0D Location in an
+	// iTunes-authored library is a Windows absolute path, so a decode that
+	// yields mojibake (the K16 signature) fails the drive-letter shape check.
+	_, payload, err := decodeITLForContract(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked, bad := 0, 0
+	forEachTrackLocations(payload, func(_ int, loc0D, _ string, has0D, _ bool) {
+		if !has0D {
+			return
+		}
+		checked++
+		if len(loc0D) < 3 || loc0D[1] != ':' || loc0D[2] != '\\' {
+			bad++
+		}
+	})
+	if checked == 0 {
+		t.Fatal("no 0x0D locations decoded — walker regression")
+	}
+	if bad > 0 {
+		t.Fatalf("%d of %d decoded Locations are not drive-letter Windows paths (K16 decode regression)", bad, checked)
+	}
+}

--- a/internal/itunes/itl_identity.go
+++ b/internal/itunes/itl_identity.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_identity.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f8a2b1c-9d3e-4c7a-b5f6-1e2d3c4b5a69
 // last-edited: 2026-07-03
 //
@@ -24,6 +24,8 @@
 package itunes
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,7 +62,28 @@ type LibraryIdentity struct {
 	PlaylistCount int       `json:"playlist_count"`
 	SampleStride  int       `json:"sample_stride"`
 	PIDSample     []string  `json:"pid_sample"` // evenly-spaced track PIDs, payload order
-	UpdatedAt     time.Time `json:"updated_at"`
+	// FileSHA256 is the hex SHA-256 of the exact ON-DISK bytes our last
+	// successful write produced (Tier 4 / K17): a mismatch on the next read
+	// means an external writer (iTunes) touched the file in between, so the
+	// content guards must vet a foreign state, not our own last output.
+	FileSHA256 string    `json:"file_sha256,omitempty"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// FileSHA256Hex returns the hex SHA-256 of raw library file bytes, the value
+// stored in LibraryIdentity.FileSHA256.
+func FileSHA256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// MatchesFileSHA reports whether data hashes to the recorded FileSHA256.
+// Returns true when no checksum is recorded (nothing to contradict).
+func (id *LibraryIdentity) MatchesFileSHA(data []byte) bool {
+	if id == nil || id.FileSHA256 == "" {
+		return true
+	}
+	return FileSHA256Hex(data) == id.FileSHA256
 }
 
 // ExtractLibraryPIDHex returns the Library Persistent ID from an hdfm header

--- a/internal/itunes/itl_identity.go
+++ b/internal/itunes/itl_identity.go
@@ -1,0 +1,189 @@
+// file: internal/itunes/itl_identity.go
+// version: 1.0.0
+// guid: 4f8a2b1c-9d3e-4c7a-b5f6-1e2d3c4b5a69
+// last-edited: 2026-07-03
+//
+// Library identity fingerprinting for the ITLSafetyContract (SPEC 3 / K13–K14).
+//
+// The June 2026 contract (T003) certifies that a payload is a well-formed
+// iTunes library, but nothing certifies that it is *our* library: a fresh
+// library authored by iTunes itself (same path, same Library Persistent ID,
+// disjoint track PIDs — the July 2026 "374-track cloud stub") passes all
+// eight structural guards. This module supplies the external truth anchor:
+// a persisted fingerprint of the last successfully-written library, checked
+// before the next mutation is allowed to proceed.
+//
+// The fingerprint is stored in a JSON sidecar next to the library file
+// (<library>.identity.json) and carries the Library Persistent ID, the track
+// and playlist counts, and an evenly-spaced sample of track Persistent IDs.
+// Continuity is asserted by requiring (a) an unchanged Library PID and (b) a
+// minimum overlap between the sampled PIDs and the candidate payload's PID
+// set. Adopting a genuinely new library is an explicit operator action
+// (ContractConfig.AdoptLibrary), never an inference.
+
+package itunes
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"time"
+)
+
+// identitySidecarSuffix is appended to the library path to form the sidecar
+// path: "iTunes Library.itl" → "iTunes Library.itl.identity.json".
+const identitySidecarSuffix = ".identity.json"
+
+// identitySampleMax bounds the number of track PIDs persisted in the sidecar.
+// 1024 evenly-spaced PIDs detects wholesale replacement with high confidence
+// while keeping the sidecar a few tens of KB even for 100k-track libraries.
+const identitySampleMax = 1024
+
+// identitySchemaVersion is bumped on any incompatible sidecar layout change;
+// readers reject sidecars with a newer schema than they understand.
+const identitySchemaVersion = 1
+
+// libraryPIDFileOffset is the absolute file offset of the 8-byte Library
+// Persistent ID inside the hdfm header (empirical: matches the Album Artwork
+// cache directory name and is stable across golden/live/stub libraries).
+// Like the count fields at 0x44..0x54 it lives inside headerRemainder at
+// remainder offset (0x34 - (17 + len(version))).
+const libraryPIDFileOffset = 0x34
+
+// LibraryIdentity is the persisted fingerprint of a known-good library state.
+type LibraryIdentity struct {
+	SchemaVersion int       `json:"schema_version"`
+	LibraryPID    string    `json:"library_pid"` // 16 lowercase hex chars
+	TrackCount    int       `json:"track_count"`
+	PlaylistCount int       `json:"playlist_count"`
+	SampleStride  int       `json:"sample_stride"`
+	PIDSample     []string  `json:"pid_sample"` // evenly-spaced track PIDs, payload order
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ExtractLibraryPIDHex returns the Library Persistent ID from an hdfm header
+// as 16 lowercase hex chars (MSB-first, matching the Album Artwork cache dir
+// name), or "" when the header is nil or too short to carry the field.
+func ExtractLibraryPIDHex(hdr *hdfmHeader) string {
+	if hdr == nil {
+		return ""
+	}
+	relOff := libraryPIDFileOffset - (headerFixedPrefix + len(hdr.version))
+	if relOff < 0 || relOff+8 > len(hdr.headerRemainder) {
+		return ""
+	}
+	var pid [8]byte
+	copy(pid[:], hdr.headerRemainder[relOff:relOff+8])
+	if pid == ([8]byte{}) {
+		return ""
+	}
+	return fmt.Sprintf("%02x%02x%02x%02x%02x%02x%02x%02x",
+		pid[0], pid[1], pid[2], pid[3], pid[4], pid[5], pid[6], pid[7])
+}
+
+// ComputeLibraryIdentity fingerprints a decoded (decrypted+inflated) LE
+// payload and its header. Returns an error when the master track list cannot
+// be located — an unfingerprintable library must not silently produce an
+// empty identity that future writes would then "match".
+func ComputeLibraryIdentity(payload []byte, hdr *hdfmHeader) (*LibraryIdentity, error) {
+	_, pids := collectMithTidsPids(payload)
+	if pids == nil {
+		return nil, errors.New("ComputeLibraryIdentity: master track list not locatable")
+	}
+	playlists, _ := countPlaylistsAndCheckMiph(payload)
+
+	stride := 1
+	if len(pids) > identitySampleMax {
+		stride = len(pids) / identitySampleMax
+	}
+	sample := make([]string, 0, identitySampleMax+1)
+	for i := 0; i < len(pids); i += stride {
+		sample = append(sample, pids[i])
+	}
+
+	return &LibraryIdentity{
+		SchemaVersion: identitySchemaVersion,
+		LibraryPID:    ExtractLibraryPIDHex(hdr),
+		TrackCount:    len(pids),
+		PlaylistCount: playlists,
+		SampleStride:  stride,
+		PIDSample:     sample,
+		UpdatedAt:     time.Now().UTC(),
+	}, nil
+}
+
+// IdentitySidecarPath returns the sidecar path for a library path.
+func IdentitySidecarPath(libraryPath string) string {
+	return libraryPath + identitySidecarSuffix
+}
+
+// LoadLibraryIdentity reads the identity sidecar for libraryPath. A missing
+// sidecar returns (nil, nil) — absence is a legitimate first-run state, not
+// an error. A present-but-unreadable or newer-schema sidecar is an error:
+// fail closed rather than treat a corrupt anchor as "no anchor".
+func LoadLibraryIdentity(libraryPath string) (*LibraryIdentity, error) {
+	data, err := os.ReadFile(IdentitySidecarPath(libraryPath))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("LoadLibraryIdentity: %w", err)
+	}
+	var id LibraryIdentity
+	if err := json.Unmarshal(data, &id); err != nil {
+		return nil, fmt.Errorf("LoadLibraryIdentity: unmarshal %s: %w", IdentitySidecarPath(libraryPath), err)
+	}
+	if id.SchemaVersion > identitySchemaVersion {
+		return nil, fmt.Errorf("LoadLibraryIdentity: sidecar schema %d newer than supported %d", id.SchemaVersion, identitySchemaVersion)
+	}
+	return &id, nil
+}
+
+// SaveLibraryIdentity persists the identity sidecar atomically (temp file +
+// rename in the same directory).
+func SaveLibraryIdentity(libraryPath string, id *LibraryIdentity) error {
+	if id == nil {
+		return errors.New("SaveLibraryIdentity: nil identity")
+	}
+	data, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		return fmt.Errorf("SaveLibraryIdentity: marshal: %w", err)
+	}
+	target := IdentitySidecarPath(libraryPath)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("SaveLibraryIdentity: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("SaveLibraryIdentity: rename: %w", err)
+	}
+	return nil
+}
+
+// SampleOverlapPct returns the percentage (0–100) of the identity's sampled
+// PIDs present in the given payload's master track list. Returns -1 when the
+// sample is empty or the payload's master list is unlocatable (callers must
+// treat -1 as "cannot assess", not as 0%).
+func (id *LibraryIdentity) SampleOverlapPct(payload []byte) int {
+	if id == nil || len(id.PIDSample) == 0 {
+		return -1
+	}
+	_, pids := collectMithTidsPids(payload)
+	if pids == nil {
+		return -1
+	}
+	present := make(map[string]struct{}, len(pids))
+	for _, p := range pids {
+		present[p] = struct{}{}
+	}
+	hits := 0
+	for _, s := range id.PIDSample {
+		if _, ok := present[s]; ok {
+			hits++
+		}
+	}
+	return hits * 100 / len(id.PIDSample)
+}

--- a/internal/itunes/itl_identity_test.go
+++ b/internal/itunes/itl_identity_test.go
@@ -208,6 +208,79 @@ func TestIdentitySidecarRoundtrip(t *testing.T) {
 	}
 }
 
+// TestChecksumContinuity (K17): a successful write records the SHA-256 of the
+// exact on-disk bytes; a subsequent external modification is detectable.
+func TestChecksumContinuity(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+
+	if _, err := SafeWriteITL(path, identityMutate); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	id, err := LoadLibraryIdentity(path)
+	if err != nil || id == nil {
+		t.Fatalf("sidecar: %v", err)
+	}
+	if id.FileSHA256 == "" {
+		t.Fatal("FileSHA256 not recorded after successful write")
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !id.MatchesFileSHA(onDisk) {
+		t.Fatal("recorded checksum must match the bytes on disk")
+	}
+	// External writer (iTunes) modifies the file → continuity broken.
+	if id.MatchesFileSHA(append(append([]byte(nil), onDisk...), 0x00)) {
+		t.Fatal("modified bytes must not match the recorded checksum")
+	}
+	// No recorded checksum → nothing to contradict.
+	if !(&LibraryIdentity{}).MatchesFileSHA(onDisk) {
+		t.Fatal("empty checksum must match (no anchor)")
+	}
+}
+
+// TestApplyOps_MagnitudeArming (K14/K17): ApplyITLOperations derives
+// ExpectedTrackCount from the sidecar's validated count plus the op delta, so
+// a library whose real size is far from the sidecar projection is rejected.
+func TestApplyOps_MagnitudeArming(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload()) // 3 tracks
+
+	payload := buildCleanPayload()
+	id, err := ComputeLibraryIdentity(payload, buildHeaderFor(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar claims the validated state had 100 tracks; the file has 3.
+	id.TrackCount = 100
+	if err := SaveLibraryIdentity(path, id); err != nil {
+		t.Fatal(err)
+	}
+
+	ops := ITLOperationSet{MetadataUpdates: []ITLMetadataUpdate{{
+		PersistentID: "100000000000000a", Name: "Renamed", Album: "Renamed", Artist: "A", Genre: "Audiobook",
+	}}}
+	// One metadata update rewrites 50% of the tiny fixture's mhoh blocks, so
+	// relax the (unrelated) rewrite cap to isolate expected-magnitude.
+	cfg := DefaultContractConfig()
+	cfg.RewrittenMhohPctMax = 100
+	_, err = ApplyITLOperations(path, path, ops, cfg)
+	if err == nil || !strings.Contains(err.Error(), "expected-magnitude") {
+		t.Fatalf("expected expected-magnitude rejection, got: %v", err)
+	}
+
+	// With an accurate sidecar count the same op succeeds.
+	id.TrackCount = 3
+	if err := SaveLibraryIdentity(path, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyITLOperations(path, path, ops, cfg); err != nil {
+		t.Fatalf("accurate projection must pass: %v", err)
+	}
+}
+
 // TestSafeWrite_IdentityLifecycle is the end-to-end K13 scenario: the first
 // write fingerprints the library; swapping in a disjoint population is then
 // rejected; AdoptLibrary blesses the swap and re-anchors to it.

--- a/internal/itunes/itl_identity_test.go
+++ b/internal/itunes/itl_identity_test.go
@@ -1,0 +1,259 @@
+// file: internal/itunes/itl_identity_test.go
+// version: 1.0.0
+// guid: 8b3c4d5e-6f7a-4b8c-9d0e-2f3a4b5c6d7e
+// last-edited: 2026-07-03
+//
+// Tests for the library-identity fingerprint (K13) and expected-magnitude
+// (K14) guards — the external-truth anchors added after the July 2026
+// "374-track cloud stub" demonstrated that a completely different library
+// (same path, same Library PID, zero track-PID overlap, 0.4% of the tracks)
+// passes all eight structural guards.
+//
+// Reuses the LE fixture builders from itl_safety_contract_test.go
+// (buildPayloadFromTracks / cleanTracks / buildHeaderFor / buildITLFile).
+
+package itunes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// headerWithLibraryPID returns a fixture header with the 8-byte Library PID
+// planted at file offset 0x34.
+func headerWithLibraryPID(payload []byte, pid [8]byte) *hdfmHeader {
+	hdr := buildHeaderFor(payload)
+	relOff := libraryPIDFileOffset - (headerFixedPrefix + len(hdr.version))
+	copy(hdr.headerRemainder[relOff:relOff+8], pid[:])
+	return hdr
+}
+
+var fxLibraryPID = [8]byte{0x48, 0xE8, 0x7F, 0x59, 0x86, 0x55, 0x68, 0xB0}
+
+const fxLibraryPIDHex = "48e87f59865568b0"
+
+// disjointTracks returns a track population sharing no PIDs with cleanTracks()
+// (PIDs are derived from TIDs in buildMith, so distinct TIDs => distinct PIDs).
+func disjointTracks(n int) []fxTrack {
+	tracks := make([]fxTrack, 0, n)
+	for i := 0; i < n; i++ {
+		tracks = append(tracks, fxTrack{
+			tid:      uint32(1000 + i*10),
+			name:     fmt.Sprintf("Cloud Song %d", i),
+			location: fmt.Sprintf(`W:\itunes\Media\Music\Cloud\%02d.mp3`, i),
+		})
+	}
+	return tracks
+}
+
+func TestExtractLibraryPIDHex(t *testing.T) {
+	payload := buildCleanPayload()
+
+	if got := ExtractLibraryPIDHex(headerWithLibraryPID(payload, fxLibraryPID)); got != fxLibraryPIDHex {
+		t.Fatalf("ExtractLibraryPIDHex = %q, want %q", got, fxLibraryPIDHex)
+	}
+	// All-zero PID (fixture default) must read as "not present", not a value
+	// that could spuriously match another zeroed header.
+	if got := ExtractLibraryPIDHex(buildHeaderFor(payload)); got != "" {
+		t.Fatalf("zero PID: got %q, want \"\"", got)
+	}
+	if got := ExtractLibraryPIDHex(nil); got != "" {
+		t.Fatalf("nil header: got %q, want \"\"", got)
+	}
+}
+
+func TestComputeLibraryIdentity(t *testing.T) {
+	payload := buildCleanPayload()
+	hdr := headerWithLibraryPID(payload, fxLibraryPID)
+
+	id, err := ComputeLibraryIdentity(payload, hdr)
+	if err != nil {
+		t.Fatalf("ComputeLibraryIdentity: %v", err)
+	}
+	if id.LibraryPID != fxLibraryPIDHex {
+		t.Errorf("LibraryPID = %q, want %q", id.LibraryPID, fxLibraryPIDHex)
+	}
+	if id.TrackCount != 3 || id.PlaylistCount != 1 {
+		t.Errorf("counts = %d tracks / %d playlists, want 3/1", id.TrackCount, id.PlaylistCount)
+	}
+	if id.SampleStride != 1 || len(id.PIDSample) != 3 {
+		t.Errorf("sample = %d PIDs stride %d, want 3 stride 1", len(id.PIDSample), id.SampleStride)
+	}
+
+	// A payload with no locatable master list must be an error, never a
+	// degenerate identity future writes would "match".
+	if _, err := ComputeLibraryIdentity([]byte("garbage"), hdr); err == nil {
+		t.Error("garbage payload: expected error, got nil")
+	}
+}
+
+func TestSampleOverlapPct(t *testing.T) {
+	payload := buildCleanPayload()
+	id, err := ComputeLibraryIdentity(payload, buildHeaderFor(payload))
+	if err != nil {
+		t.Fatalf("ComputeLibraryIdentity: %v", err)
+	}
+
+	if pct := id.SampleOverlapPct(payload); pct != 100 {
+		t.Errorf("self overlap = %d%%, want 100", pct)
+	}
+	stub := buildPayloadFromTracks(disjointTracks(5))
+	if pct := id.SampleOverlapPct(stub); pct != 0 {
+		t.Errorf("disjoint overlap = %d%%, want 0", pct)
+	}
+	empty := &LibraryIdentity{}
+	if pct := empty.SampleOverlapPct(payload); pct != -1 {
+		t.Errorf("empty sample = %d, want -1 (unassessable)", pct)
+	}
+}
+
+func TestGuardLibraryIdentity(t *testing.T) {
+	golden := buildCleanPayload()
+	goldenHdr := headerWithLibraryPID(golden, fxLibraryPID)
+	goldenID, err := ComputeLibraryIdentity(golden, goldenHdr)
+	if err != nil {
+		t.Fatalf("ComputeLibraryIdentity: %v", err)
+	}
+	// The July 2026 stub scenario: same Library PID, disjoint track PIDs.
+	stub := buildPayloadFromTracks(disjointTracks(5))
+	stubHdr := headerWithLibraryPID(stub, fxLibraryPID)
+
+	cases := []struct {
+		name     string
+		after    []byte
+		hdr      *hdfmHeader
+		cfg      ContractConfig
+		wantPass bool
+		wantMsg  string
+	}{
+		{"disarmed without expectation", stub, stubHdr, ContractConfig{}, true, ""},
+		{"adopt bypasses", stub, stubHdr, ContractConfig{ExpectedIdentity: goldenID, AdoptLibrary: true}, true, ""},
+		{"continuation passes", golden, goldenHdr, ContractConfig{ExpectedIdentity: goldenID}, true, ""},
+		{"population replaced fails", stub, stubHdr, ContractConfig{ExpectedIdentity: goldenID}, false, "library population replaced"},
+		{"library PID change fails", golden, headerWithLibraryPID(golden, [8]byte{1, 2, 3, 4, 5, 6, 7, 8}), ContractConfig{ExpectedIdentity: goldenID}, false, "library PID changed"},
+		{"empty fingerprint fails closed", golden, goldenHdr, ContractConfig{ExpectedIdentity: &LibraryIdentity{LibraryPID: fxLibraryPIDHex}}, false, "unassessable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := guardLibraryIdentity(nil, tc.after, tc.hdr, normalizeConfig(tc.cfg))
+			if res.Pass() != tc.wantPass {
+				t.Fatalf("pass = %v, want %v (violations: %+v)", res.Pass(), tc.wantPass, res.Violations)
+			}
+			if !tc.wantPass && !strings.Contains(res.Violations[0].Message, tc.wantMsg) {
+				t.Fatalf("violation %q does not contain %q", res.Violations[0].Message, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestGuardExpectedMagnitude(t *testing.T) {
+	payload := buildCleanPayload() // 3 tracks
+
+	cases := []struct {
+		name     string
+		cfg      ContractConfig
+		wantPass bool
+	}{
+		{"disarmed when unset", ContractConfig{}, true},
+		{"exact match", ContractConfig{ExpectedTrackCount: 3}, true},
+		{"within tolerance", ContractConfig{ExpectedTrackCount: 3, MagnitudeTolerancePct: 40}, true},
+		// The stub scenario at real scale: expected ~90900, got a fraction.
+		{"catastrophic shrink", ContractConfig{ExpectedTrackCount: 90900}, false},
+		{"unexpected growth", ContractConfig{ExpectedTrackCount: 2}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := guardExpectedMagnitude(nil, payload, nil, normalizeConfig(tc.cfg))
+			if res.Pass() != tc.wantPass {
+				t.Fatalf("pass = %v, want %v (violations: %+v)", res.Pass(), tc.wantPass, res.Violations)
+			}
+		})
+	}
+}
+
+func TestIdentitySidecarRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	libPath := filepath.Join(dir, "iTunes Library.itl")
+
+	// Missing sidecar is a legitimate first-run state.
+	if id, err := LoadLibraryIdentity(libPath); id != nil || err != nil {
+		t.Fatalf("missing sidecar: got (%+v, %v), want (nil, nil)", id, err)
+	}
+
+	payload := buildCleanPayload()
+	id, err := ComputeLibraryIdentity(payload, headerWithLibraryPID(payload, fxLibraryPID))
+	if err != nil {
+		t.Fatalf("ComputeLibraryIdentity: %v", err)
+	}
+	if err := SaveLibraryIdentity(libPath, id); err != nil {
+		t.Fatalf("SaveLibraryIdentity: %v", err)
+	}
+	got, err := LoadLibraryIdentity(libPath)
+	if err != nil {
+		t.Fatalf("LoadLibraryIdentity: %v", err)
+	}
+	if got.LibraryPID != id.LibraryPID || got.TrackCount != id.TrackCount || len(got.PIDSample) != len(id.PIDSample) {
+		t.Fatalf("roundtrip mismatch: got %+v, want %+v", got, id)
+	}
+
+	// A corrupt sidecar must fail closed, not read as "no anchor".
+	if err := os.WriteFile(IdentitySidecarPath(libPath), []byte("{corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadLibraryIdentity(libPath); err == nil {
+		t.Fatal("corrupt sidecar: expected error, got nil")
+	}
+}
+
+// TestSafeWrite_IdentityLifecycle is the end-to-end K13 scenario: the first
+// write fingerprints the library; swapping in a disjoint population is then
+// rejected; AdoptLibrary blesses the swap and re-anchors to it.
+func TestSafeWrite_IdentityLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixtureITL(t, dir, "iTunes Library.itl", buildCleanPayload())
+
+	// Write 1 (no sidecar yet): guard disarmed, sidecar created on success.
+	if _, err := SafeWriteITL(path, identityMutate); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if _, err := os.Stat(IdentitySidecarPath(path)); err != nil {
+		t.Fatalf("sidecar not created: %v", err)
+	}
+
+	// Write 2: a mutate that replaces the entire population (the stub class)
+	// must be rejected by library-identity, leaving the file byte-identical.
+	orig, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replaceMutate := func(_ []byte) ([]byte, error) {
+		return buildPayloadFromTracks(disjointTracks(5)), nil
+	}
+	_, err = SafeWriteITL(path, replaceMutate)
+	if err == nil || !strings.Contains(err.Error(), "library-identity") {
+		t.Fatalf("expected library-identity rejection, got: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(orig) != string(after) {
+		t.Fatal("rejected write modified the library")
+	}
+
+	// Write 3: the same replacement under AdoptLibrary is allowed, and the
+	// sidecar re-anchors to the new population...
+	adoptCfg := DefaultContractConfig()
+	adoptCfg.AdoptLibrary = true
+	adoptCfg.Force = true // replacement also trips bounded-delta's rewrite cap
+	if _, err := SafeWriteITL(path, replaceMutate, WithContractConfig(adoptCfg)); err != nil {
+		t.Fatalf("adopt write: %v", err)
+	}
+	// ...so a no-op write against the adopted library now passes.
+	if _, err := SafeWriteITL(path, identityMutate); err != nil {
+		t.Fatalf("post-adopt write: %v", err)
+	}
+}

--- a/internal/itunes/itl_safe_write.go
+++ b/internal/itunes/itl_safe_write.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/itl_safe_write.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
+// last-edited: 2026-07-03
 //
 // SafeWriteITL — the single atomic iTunes-library writeback chokepoint
 // (fable5 TASK-004). Implements SPEC 2 §3 (the 8-step atomic write protocol,
@@ -206,6 +207,18 @@ func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err err
 		return nil, fmt.Errorf("SafeWriteITL: detecting compression: %w", err)
 	}
 
+	// K13: arm the library-identity guard from the .identity.json sidecar
+	// unless the caller supplied its own expectation or is explicitly adopting
+	// a new library. A missing sidecar (first run) leaves the guard disarmed;
+	// a corrupt/unreadable sidecar fails closed.
+	if o.contractCfg.ExpectedIdentity == nil && !o.contractCfg.AdoptLibrary {
+		sidecarID, idErr := LoadLibraryIdentity(path)
+		if idErr != nil {
+			return nil, fmt.Errorf("SafeWriteITL: identity sidecar for %s: %w", path, idErr)
+		}
+		o.contractCfg.ExpectedIdentity = sidecarID
+	}
+
 	// safeEncodeITL does steps 1(parse done) → 3: BE refusal, mutate, header
 	// regeneration, in-memory contract. It returns the final on-disk bytes. The
 	// in-memory verdict is already known-passing here; the authoritative verdict
@@ -273,6 +286,17 @@ func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err err
 	// Rotation: keep the 10 newest .bak-<RFC3339>; never touch .bak-lkg.
 	if err := rotateBackups(path, o.backupRetention); err != nil {
 		slog.Warn("SafeWriteITL: backup rotation failed", "path", path, "err", err)
+	}
+
+	// K13: refresh the identity sidecar from the bytes that actually landed on
+	// disk (re-read payload + header), so the next write is anchored to THIS
+	// library state. Failure is WARN-only — the write already succeeded — and
+	// errs in the safe direction: a stale sidecar can only make the next
+	// identity check stricter, never looser.
+	if newID, idErr := ComputeLibraryIdentity(rrPayload, rrHdr); idErr != nil {
+		slog.Warn("SafeWriteITL: identity fingerprint failed; sidecar not updated", "path", path, "err", idErr)
+	} else if saveErr := SaveLibraryIdentity(path, newID); saveErr != nil {
+		slog.Warn("SafeWriteITL: identity sidecar save failed", "path", path, "err", saveErr)
 	}
 
 	slog.Info("SafeWriteITL applied",

--- a/internal/itunes/itl_safe_write.go
+++ b/internal/itunes/itl_safe_write.go
@@ -219,6 +219,16 @@ func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err err
 		o.contractCfg.ExpectedIdentity = sidecarID
 	}
 
+	// K17 (Tier 4): checksum continuity. If the on-disk bytes differ from the
+	// SHA-256 our last successful write recorded, an external writer (iTunes)
+	// touched the library in between — expected co-authorship, but worth a
+	// visible record: the identity/magnitude guards are now vetting a foreign
+	// state, and this log line is the marker forensics will look for.
+	if exp := o.contractCfg.ExpectedIdentity; exp != nil && !exp.MatchesFileSHA(raw) {
+		slog.Info("SafeWriteITL: library modified by external writer since our last write (checksum continuity broken); guards will vet the foreign state",
+			"op", "itl-safe-write", "path", path, "last_write", exp.UpdatedAt)
+	}
+
 	// safeEncodeITL does steps 1(parse done) → 3: BE refusal, mutate, header
 	// regeneration, in-memory contract. It returns the final on-disk bytes. The
 	// in-memory verdict is already known-passing here; the authoritative verdict
@@ -295,8 +305,13 @@ func SafeWriteITL(path string, mutate func(before []byte) (after []byte, err err
 	// identity check stricter, never looser.
 	if newID, idErr := ComputeLibraryIdentity(rrPayload, rrHdr); idErr != nil {
 		slog.Warn("SafeWriteITL: identity fingerprint failed; sidecar not updated", "path", path, "err", idErr)
-	} else if saveErr := SaveLibraryIdentity(path, newID); saveErr != nil {
-		slog.Warn("SafeWriteITL: identity sidecar save failed", "path", path, "err", saveErr)
+	} else {
+		// K17: record the checksum of the exact bytes on disk so the next
+		// write can detect an external writer touching the file in between.
+		newID.FileSHA256 = FileSHA256Hex(diskBytes)
+		if saveErr := SaveLibraryIdentity(path, newID); saveErr != nil {
+			slog.Warn("SafeWriteITL: identity sidecar save failed", "path", path, "err", saveErr)
+		}
 	}
 
 	slog.Info("SafeWriteITL applied",

--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -786,14 +786,19 @@ func guardLibraryIdentity(_, after []byte, hdr *hdfmHeader, cfg ContractConfig) 
 // Guard: bounded-delta  (blast-radius cap for HIGH-3-style bugs)
 // ---------------------------------------------------------------------------
 
-// guardBoundedDelta is the guardrail: a single writeback may not remove more
-// than cfg.RemovedTracksMax tracks (default 5000) nor rewrite more than
-// cfg.RewrittenMhohPctMax percent of mhoh blocks (default 20) unless cfg.Force.
-// In audit mode (before == nil) there is no delta to bound, so it passes.
+// guardBoundedDelta is the guardrail: a single writeback may not remove OR
+// introduce more than cfg.RemovedTracksMax tracks (default 5000) nor rewrite
+// more than cfg.RewrittenMhohPctMax percent of mhoh blocks (default 20) unless
+// cfg.Force. In audit mode (before == nil) there is no delta to bound, so it
+// passes.
+//
+// The delta is PID-SET based, not count-subtraction based (K15 symmetry fix):
+// a remove-all-then-add-equal replacement leaves the count unchanged but swaps
+// the entire population — counting PIDs present on only one side catches it.
 //
 // Catches: the blast-radius class behind HIGH-3 (writeback that re-stamps nearly
-// the whole library every sync) — a runaway removal or rewrite is refused before
-// it reaches disk.
+// the whole library every sync) — a runaway removal, mass insertion, or
+// wholesale replacement is refused before it reaches disk.
 func guardBoundedDelta(before, after []byte, _ *hdfmHeader, cfg ContractConfig) GuardResult {
 	const name = "bounded-delta"
 	if before == nil || cfg.Force {
@@ -801,11 +806,32 @@ func guardBoundedDelta(before, after []byte, _ *hdfmHeader, cfg ContractConfig) 
 	}
 	var viol []Violation
 
-	beforeTracks, _ := countMasterTracks(before)
-	afterTracks, _ := countMasterTracks(after)
-	removed := beforeTracks - afterTracks
+	_, beforePIDs := collectMithTidsPids(before)
+	_, afterPIDs := collectMithTidsPids(after)
+	beforeSet := make(map[string]struct{}, len(beforePIDs))
+	for _, p := range beforePIDs {
+		beforeSet[p] = struct{}{}
+	}
+	afterSet := make(map[string]struct{}, len(afterPIDs))
+	for _, p := range afterPIDs {
+		afterSet[p] = struct{}{}
+	}
+	removed, introduced := 0, 0
+	for p := range beforeSet {
+		if _, ok := afterSet[p]; !ok {
+			removed++
+		}
+	}
+	for p := range afterSet {
+		if _, ok := beforeSet[p]; !ok {
+			introduced++
+		}
+	}
 	if removed > cfg.RemovedTracksMax {
 		viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: fmt.Sprintf("writeback removes %d tracks > cap %d (set Force to override)", removed, cfg.RemovedTracksMax)})
+	}
+	if introduced > cfg.RemovedTracksMax {
+		viol = append(viol, Violation{Offset: -1, Chunk: "mith", Message: fmt.Sprintf("writeback introduces %d new track PIDs > cap %d — population replacement (set Force to override)", introduced, cfg.RemovedTracksMax)})
 	}
 
 	beforeMhoh := countMhohBlocks(before)

--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -24,6 +24,7 @@ package itunes
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -539,9 +540,17 @@ func mhohNonStandardLen(hohmType uint32) bool {
 //     markers (damaged-4 leaked staging-dir paths).
 //
 // Catches: K4 (URL written into 0x0D) and the staging-path leak.
-func guardLocationForm(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+func guardLocationForm(before, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
 	const name = "location-form"
 	var viol []Violation
+
+	// Pair-consistency (0x0B decodes to the same path as 0x0D) is a NO-NEW
+	// check: the golden corpus proves iTunes itself leaves stale pairs behind
+	// (e.g. a 0x0D missing "iTunes Media" while its 0x0B still has it), so an
+	// absolute assertion fails known-good libraries forever (K16 follow-up).
+	// Format checks below remain absolute. In audit mode (before == nil)
+	// pre-existing mismatches are iTunes-authored warts, not our corruption.
+	preMismatch := collectPairMismatchPaths(before)
 
 	forEachTrackLocations(after, func(trackOffset int, loc0D, loc0B string, has0D, has0B bool) {
 		// Staging-dir leak: applies to either field, present or not.
@@ -567,8 +576,12 @@ func guardLocationForm(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardRe
 		if strings.Contains(strings.ToLower(loc0D), "file://") {
 			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location contains 'file://' — iTunes stores a native path here (K4): %q", truncStr(loc0D))})
 		}
-		if strings.Contains(loc0D, "%") {
-			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location contains '%%'-escape — native path must be unescaped (K4): %q", truncStr(loc0D))})
+		// Only an actual %XX escape TRIPLE marks an escaped path leaking into
+		// 0x0D
+		// — real filenames legitimately contain bare '%' ("Still 100% Human",
+		// "1% Lifesteal"; both present in the golden corpus).
+		if containsEscapeTriple(loc0D) {
+			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0D Location contains '%%XX'-escape — native path must be unescaped (K4): %q", truncStr(loc0D))})
 		}
 
 		// Sibling 0x0B must be a round-tripping file://localhost/ URL.
@@ -580,12 +593,67 @@ func guardLocationForm(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardRe
 			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0B LocalURL is not a 'file://localhost/' URL: %q", truncStr(loc0B))})
 			return
 		}
-		if want := winPathToLocalURL(loc0D); want != loc0B {
-			viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0B LocalURL does not round-trip 0x0D path: got %q, want %q", truncStr(loc0B), truncStr(want))})
+		// Round-trip comparison is SEMANTIC (percent-decoded), not byte-exact:
+		// iTunes leaves RFC-3986 sub-delims like '(' ')' ',' unescaped in 0x0B
+		// while winPathToLocalURL escapes them — both render the same path
+		// (K16 follow-up: 22,902 golden blocks differ only in escape strictness).
+		// And it is a NO-NEW check: mismatched pairs already in `before` (or, in
+		// audit mode, in the library itself) are iTunes-authored, not ours.
+		if want := winPathToLocalURL(loc0D); want != loc0B && !localURLsEquivalent(want, loc0B) {
+			if _, preexisting := preMismatch[loc0D]; !preexisting && before != nil {
+				viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("0x0B LocalURL does not round-trip 0x0D path (newly introduced): got %q, want %q", truncStr(loc0B), truncStr(want))})
+			}
 		}
 	})
 
 	return GuardResult{Guard: name, Violations: viol}
+}
+
+// localURLsEquivalent reports whether two file://localhost/ URLs decode to the
+// same path — equal after percent-decoding. WHY: escape STRICTNESS varies
+// (iTunes leaves '(' ')' ',' etc. raw; RFC-3986 encoders escape them) but the
+// decoded path is the identity that matters. Malformed escapes fail closed.
+func localURLsEquivalent(a, b string) bool {
+	da, errA := url.PathUnescape(a)
+	db, errB := url.PathUnescape(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return da == db
+}
+
+// containsEscapeTriple reports whether s contains a %XX percent-escape triple —
+// the K4 signature of an escaped URL leaking into the native-path 0x0D field.
+// A bare '%' is NOT flagged: real filenames contain it ("Still 100% Human").
+func containsEscapeTriple(s string) bool {
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] == '%' && isHexDigit(s[i+1]) && isHexDigit(s[i+2]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+// collectPairMismatchPaths returns the set of 0x0D paths in `data` whose 0x0B
+// sibling does not (semantically) round-trip. nil input → empty set.
+func collectPairMismatchPaths(data []byte) map[string]struct{} {
+	out := make(map[string]struct{})
+	if data == nil {
+		return out
+	}
+	forEachTrackLocations(data, func(_ int, loc0D, loc0B string, has0D, has0B bool) {
+		if !has0D || !has0B {
+			return
+		}
+		if want := winPathToLocalURL(loc0D); want != loc0B && !localURLsEquivalent(want, loc0B) {
+			out[loc0D] = struct{}{}
+		}
+	})
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/itl_safety_contract.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 404bbed1-87ba-4e56-b9e4-a492a2281163
+// last-edited: 2026-07-03
 //
 // ITLSafetyContract — the iTunes writeback write-safety contract (fable5 TASK-003).
 //
@@ -107,6 +108,30 @@ type ContractConfig struct {
 	// Force overrides the bounded-delta guardrail only. It does NOT disable any
 	// structural guard — corruption is never opt-out.
 	Force bool
+
+	// ExpectedIdentity, when non-nil, arms the library-identity guard (K13):
+	// the `after` payload must carry the same Library PID and retain at least
+	// IdentityMinOverlapPct of the fingerprinted track-PID sample. SafeWriteITL
+	// populates this from the .identity.json sidecar when present.
+	ExpectedIdentity *LibraryIdentity
+	// IdentityMinOverlapPct is the minimum percentage of ExpectedIdentity's
+	// PID sample that must be present in `after`. Default 90.
+	IdentityMinOverlapPct int
+	// AdoptLibrary is the explicit operator acknowledgment that the library at
+	// this path is intentionally a different library (fresh iTunes rebuild,
+	// deliberate baseline swap). It bypasses the library-identity guard for
+	// ONE write, after which the new identity is fingerprinted. Unlike Force
+	// it never affects any other guard.
+	AdoptLibrary bool
+
+	// ExpectedTrackCount, when > 0, arms the expected-magnitude guard (K14):
+	// the `after` track count must be within MagnitudeTolerancePct of it.
+	// Callers derive it from external truth (the DB's synced-book count, or
+	// the identity sidecar's TrackCount).
+	ExpectedTrackCount int
+	// MagnitudeTolerancePct is the allowed deviation for expected-magnitude.
+	// Default 10.
+	MagnitudeTolerancePct int
 }
 
 // DefaultContractConfig returns the SPEC-mandated defaults.
@@ -132,6 +157,8 @@ func orderedGuards() []guardFn {
 		guardMhohFormat,
 		guardLocationForm,
 		guardTidPidSanity,
+		guardExpectedMagnitude,
+		guardLibraryIdentity,
 		guardBoundedDelta,
 	}
 }
@@ -596,6 +623,92 @@ func guardTidPidSanity(_, after []byte, _ *hdfmHeader, _ ContractConfig) GuardRe
 			break
 		}
 		seen[p] = struct{}{}
+	}
+
+	return GuardResult{Guard: name, Violations: viol}
+}
+
+// ---------------------------------------------------------------------------
+// Guard: expected-magnitude  (K14 — external truth anchor for counts)
+// ---------------------------------------------------------------------------
+
+// guardExpectedMagnitude asserts the `after` track count is within
+// cfg.MagnitudeTolerancePct of cfg.ExpectedTrackCount. Unlike count-coherence
+// (which is self-referential — the header is regenerated from the same payload
+// it is compared to), the expected count comes from OUTSIDE the file: the DB's
+// synced-book census or the identity sidecar. Disarmed (vacuous pass) when
+// ExpectedTrackCount <= 0.
+//
+// Catches: K14 — a structurally-perfect library that is simply the wrong size
+// (rebuild from an under-populated DB; iTunes-authored fresh library; the
+// July 2026 374-track cloud stub, a 99.6% shrink that passed all 8 guards).
+func guardExpectedMagnitude(_, after []byte, _ *hdfmHeader, cfg ContractConfig) GuardResult {
+	const name = "expected-magnitude"
+	if cfg.ExpectedTrackCount <= 0 {
+		return pass(name)
+	}
+	_, actual := countMasterTracks(after)
+	deviation := actual - cfg.ExpectedTrackCount
+	if deviation < 0 {
+		deviation = -deviation
+	}
+	if deviation*100 > cfg.ExpectedTrackCount*cfg.MagnitudeTolerancePct {
+		return GuardResult{Guard: name, Violations: []Violation{{
+			Offset: -1, Chunk: "msdh",
+			Message: fmt.Sprintf("track count %d deviates from expected %d by more than %d%% (K14)",
+				actual, cfg.ExpectedTrackCount, cfg.MagnitudeTolerancePct),
+		}}}
+	}
+	return pass(name)
+}
+
+// ---------------------------------------------------------------------------
+// Guard: library-identity  (K13 — continuity with the last known library)
+// ---------------------------------------------------------------------------
+
+// guardLibraryIdentity asserts the `after` payload is a continuation of the
+// fingerprinted library in cfg.ExpectedIdentity: same Library Persistent ID
+// in the proposed header, and at least cfg.IdentityMinOverlapPct of the
+// fingerprint's track-PID sample still present. Disarmed when
+// ExpectedIdentity is nil (first run, no sidecar) or cfg.AdoptLibrary is set
+// (explicit operator baseline swap).
+//
+// Catches: K13 — "same path, different library": iTunes recreating a fresh
+// library after a failed load (same Library PID is NOT sufficient — the July
+// 2026 stub kept the Library PID with zero track-PID overlap), a wrong file
+// copied over the staging target, or a mutation that silently replaced the
+// track population. Structural guards cannot see this class at all.
+func guardLibraryIdentity(_, after []byte, hdr *hdfmHeader, cfg ContractConfig) GuardResult {
+	const name = "library-identity"
+	if cfg.ExpectedIdentity == nil || cfg.AdoptLibrary {
+		return pass(name)
+	}
+	var viol []Violation
+
+	if want := cfg.ExpectedIdentity.LibraryPID; want != "" {
+		if got := ExtractLibraryPIDHex(hdr); got != "" && got != want {
+			viol = append(viol, Violation{
+				Offset: -1, Chunk: "hdfm",
+				Message: fmt.Sprintf("library PID changed: %s != expected %s (K13); use AdoptLibrary to bless a new library", got, want),
+			})
+		}
+	}
+
+	switch overlap := cfg.ExpectedIdentity.SampleOverlapPct(after); {
+	case overlap < 0:
+		// Cannot assess (empty sample or unlocatable master list). The master
+		// list case is already a parse-roundtrip failure; an empty sample means
+		// the fingerprint itself is degenerate — fail closed rather than let
+		// every future write "match" a vacuous anchor.
+		viol = append(viol, Violation{
+			Offset: -1, Chunk: "mith",
+			Message: "identity fingerprint unassessable (empty PID sample or unlocatable master list) (K13)",
+		})
+	case overlap < cfg.IdentityMinOverlapPct:
+		viol = append(viol, Violation{
+			Offset: -1, Chunk: "mith",
+			Message: fmt.Sprintf("track-PID overlap %d%% below required %d%%: library population replaced (K13); use AdoptLibrary to bless a new library", overlap, cfg.IdentityMinOverlapPct),
+		})
 	}
 
 	return GuardResult{Guard: name, Violations: viol}
@@ -1145,6 +1258,12 @@ func normalizeConfig(cfg ContractConfig) ContractConfig {
 	}
 	if cfg.RewrittenMhohPctMax == 0 {
 		cfg.RewrittenMhohPctMax = 20
+	}
+	if cfg.IdentityMinOverlapPct == 0 {
+		cfg.IdentityMinOverlapPct = 90
+	}
+	if cfg.MagnitudeTolerancePct == 0 {
+		cfg.MagnitudeTolerancePct = 10
 	}
 	return cfg
 }

--- a/internal/itunes/itl_safety_contract_test.go
+++ b/internal/itunes/itl_safety_contract_test.go
@@ -547,6 +547,46 @@ func TestContract_TidUnsorted(t *testing.T) {
 	assertOnlyGuardFires(t, nil, after, hdr, defCfg(), "tid-pid-sanity")
 }
 
+// TestContract_BoundedDeltaSymmetric: the delta is PID-set based, so both a
+// wholesale population REPLACEMENT (count unchanged, all PIDs swapped) and a
+// mass INSERTION trip bounded-delta — count subtraction alone sees neither.
+func TestContract_BoundedDeltaSymmetric(t *testing.T) {
+	before := buildCleanPayload() // 3 tracks, tids 10/20/30
+	cfg := defCfg()
+	cfg.RemovedTracksMax = 2
+	cfg.RewrittenMhohPctMax = 100 // isolate the PID-delta checks
+
+	// Replacement: same track count, entirely new PIDs.
+	replaced := buildPayloadFromTracks([]fxTrack{
+		{tid: 110, name: "New One", location: `W:\m\n1.mp3`},
+		{tid: 120, name: "New Two", location: `W:\m\n2.mp3`},
+		{tid: 130, name: "New Three", location: `W:\m\n3.mp3`},
+	})
+	res := guardBoundedDelta(before, replaced, nil, normalizeConfig(cfg))
+	if res.Pass() {
+		t.Fatal("full population replacement with unchanged count must trip bounded-delta")
+	}
+
+	// Insertion: all original tracks retained, 3 new PIDs added (growth only).
+	grown := buildPayloadFromTracks(append(cleanTracks(),
+		fxTrack{tid: 110, name: "New One", location: `W:\m\n1.mp3`},
+		fxTrack{tid: 120, name: "New Two", location: `W:\m\n2.mp3`},
+		fxTrack{tid: 130, name: "New Three", location: `W:\m\n3.mp3`},
+	))
+	res = guardBoundedDelta(before, grown, nil, normalizeConfig(cfg))
+	if res.Pass() {
+		t.Fatal("mass insertion beyond the cap must trip bounded-delta")
+	}
+
+	// A small in-cap change stays green.
+	small := buildPayloadFromTracks(append(cleanTracks(),
+		fxTrack{tid: 110, name: "New One", location: `W:\m\n1.mp3`},
+	))
+	if res := guardBoundedDelta(before, small, nil, normalizeConfig(cfg)); !res.Pass() {
+		t.Fatalf("in-cap insertion must pass bounded-delta: %+v", res.Violations)
+	}
+}
+
 // TestContract_TruncatedContainer: shrink an msdh totalLen so the containers no
 // longer tile the payload exactly (the truncation/splice class).
 //

--- a/internal/itunes/itl_safety_contract_test.go
+++ b/internal/itunes/itl_safety_contract_test.go
@@ -76,7 +76,8 @@ func buildMhoh(hohmType uint32, at24 uint32, encFlag byte, str []byte) []byte {
 }
 
 // asciiMhoh builds a clean ASCII-encoded text mhoh. For 0x0D/0x0B fields iTunes
-// uses at24=1 (Windows-1252) for 0x0D and at24=0 (ASCII) for 0x0B URLs.
+// uses at24=3 (Windows-1252, K16-corrected) for 0x0D and at24=0 (ASCII) for
+// 0x0B URLs.
 func asciiMhoh(hohmType uint32, at24 uint32, s string) []byte {
 	return buildMhoh(hohmType, at24, 0x00, []byte(s))
 }
@@ -149,9 +150,9 @@ func buildMsdh(blockType int, body []byte) []byte {
 // children (or just Name+URL for podcasts with empty location).
 func buildTrackMith(tr fxTrack) []byte {
 	var children []byte
-	children = append(children, asciiMhoh(0x02, 1, tr.name)...)
+	children = append(children, asciiMhoh(0x02, 3, tr.name)...)
 	if tr.location != "" {
-		children = append(children, asciiMhoh(0x0D, 1, tr.location)...)
+		children = append(children, asciiMhoh(0x0D, 3, tr.location)...)
 		children = append(children, asciiMhoh(0x0B, 0, winPathToLocalURL(tr.location))...)
 	} else {
 		// Podcast: no 0x0D; 0x0B carries the http(s):// URL as given.
@@ -713,8 +714,8 @@ func TestLocationForm_PodcastExempt(t *testing.T) {
 // TestLocationForm_MissingSibling0B: a track with 0x0D but no 0x0B sibling fails.
 func TestLocationForm_MissingSibling0B(t *testing.T) {
 	// Build a mith with only a 0x0D child (no 0x0B).
-	children := asciiMhoh(0x02, 1, "Name")
-	children = append(children, asciiMhoh(0x0D, 1, `W:\m\a.mp3`)...)
+	children := asciiMhoh(0x02, 3, "Name")
+	children = append(children, asciiMhoh(0x0D, 3, `W:\m\a.mp3`)...)
 	mith := buildMith(10, children)
 	trackBody := append(buildMlth(1), mith...)
 	trackMsdh := buildMsdh(1, trackBody)
@@ -727,20 +728,34 @@ func TestLocationForm_MissingSibling0B(t *testing.T) {
 	}
 }
 
-// TestLocationForm_BadURLRoundTrip: a 0x0B URL that does not round-trip the 0x0D
-// path fails location-form.
+// TestLocationForm_BadURLRoundTrip: a NEWLY-INTRODUCED 0x0B URL that does not
+// round-trip the 0x0D path fails location-form in write mode. Pair
+// consistency is a no-new check (iTunes itself leaves stale pairs — see the
+// golden corpus), so audit mode (before == nil) tolerates pre-existing
+// mismatches; a clean `before` makes this mismatch new.
 func TestLocationForm_BadURLRoundTrip(t *testing.T) {
-	children := asciiMhoh(0x02, 1, "Name")
-	children = append(children, asciiMhoh(0x0D, 1, `W:\m\a.mp3`)...)
-	children = append(children, asciiMhoh(0x0B, 0, "file://localhost/W:/WRONG/path.mp3")...)
-	mith := buildMith(10, children)
-	trackMsdh := buildMsdh(1, append(buildMlth(1), mith...))
-	plMsdh := buildMsdh(2, append(buildMlph(1), buildMiph(1, buildMtph(10))...))
-	payload := append(append([]byte{}, trackMsdh...), plMsdh...)
+	buildWith0B := func(url string) []byte {
+		children := asciiMhoh(0x02, 3, "Name")
+		children = append(children, asciiMhoh(0x0D, 3, `W:\m\a.mp3`)...)
+		children = append(children, asciiMhoh(0x0B, 0, url)...)
+		mith := buildMith(10, children)
+		trackMsdh := buildMsdh(1, append(buildMlth(1), mith...))
+		plMsdh := buildMsdh(2, append(buildMlph(1), buildMiph(1, buildMtph(10))...))
+		return append(append([]byte{}, trackMsdh...), plMsdh...)
+	}
+	before := buildWith0B("file://localhost/W:/m/a.mp3")
+	after := buildWith0B("file://localhost/W:/WRONG/path.mp3")
 
-	res := guardLocationForm(nil, payload, nil, defCfg())
-	if res.Pass() {
-		t.Fatal("non-round-tripping 0x0B should fail location-form")
+	if res := guardLocationForm(before, after, nil, defCfg()); res.Pass() {
+		t.Fatal("newly non-round-tripping 0x0B should fail location-form in write mode")
+	}
+	// The same mismatch pre-existing in `before` is tolerated (no-new).
+	if res := guardLocationForm(after, after, nil, defCfg()); !res.Pass() {
+		t.Fatalf("pre-existing pair mismatch must not fail location-form: %+v", res.Violations)
+	}
+	// Audit mode tolerates iTunes-authored mismatches too.
+	if res := guardLocationForm(nil, after, nil, defCfg()); !res.Pass() {
+		t.Fatalf("audit mode must tolerate pre-existing pair mismatch: %+v", res.Violations)
 	}
 }
 

--- a/internal/itunes/library_activity.go
+++ b/internal/itunes/library_activity.go
@@ -1,0 +1,65 @@
+// file: internal/itunes/library_activity.go
+// version: 1.0.0
+// guid: 2d6f8a1b-4c3e-4f7a-9b0d-5e8c1a2b3c4d
+// last-edited: 2026-07-03
+//
+// FileActivityLibraryCheck — a concrete "is iTunes using the library?" signal
+// (SPEC 2 §3 step 8 / SPEC 3 §4). iTunes on the Windows box accesses the
+// library over the network share, so process-level checks (lsof etc.) cannot
+// see it from the server. What IS visible is write activity: while iTunes has
+// the library open it touches the .itl and its journal siblings ("Temp File
+// N.tmp", "iT N.tmp", "sentinel") continuously. Recent mtime on any of them
+// is treated as "in use"; the batcher then defers the flush and re-enqueues,
+// so a false positive costs one debounce cycle, never data.
+
+package itunes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// libraryActivityGlobs are the sibling files iTunes touches while it has the
+// library open (journal/temp files and the sentinel), checked alongside the
+// library file itself.
+var libraryActivityGlobs = []string{"Temp File*.tmp", "iT*.tmp", "sentinel"}
+
+// FileActivityLibraryCheck returns a precondition function for
+// SetLibraryNotInUse / WithLibraryNotInUse: it errors when the library at
+// path — or any iTunes journal sibling in its directory — was modified within
+// `window` of the call. A missing library file yields nil (no signal: first
+// run or not yet provisioned); only observed recent activity blocks a write.
+func FileActivityLibraryCheck(path string, window time.Duration) func() error {
+	if window <= 0 {
+		window = 2 * time.Minute
+	}
+	return func() error {
+		cutoff := time.Now().Add(-window)
+
+		if fi, err := os.Stat(path); err == nil && fi.ModTime().After(cutoff) {
+			return fmt.Errorf("library %s modified %s ago (< %s window): iTunes may have it open",
+				filepath.Base(path), time.Since(fi.ModTime()).Round(time.Second), window)
+		}
+
+		dir := filepath.Dir(path)
+		for _, pattern := range libraryActivityGlobs {
+			matches, err := filepath.Glob(filepath.Join(dir, pattern))
+			if err != nil {
+				continue // malformed pattern cannot happen with the fixed globs above
+			}
+			for _, m := range matches {
+				fi, err := os.Stat(m)
+				if err != nil {
+					continue
+				}
+				if fi.ModTime().After(cutoff) {
+					return fmt.Errorf("iTunes journal file %s modified %s ago (< %s window): library may be open",
+						filepath.Base(m), time.Since(fi.ModTime()).Round(time.Second), window)
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/internal/itunes/mhoh_encoding_table.go
+++ b/internal/itunes/mhoh_encoding_table.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/mhoh_encoding_table.go
-// version: 1.1.0
+// version: 2.0.0
 // guid: a0dacfc4-01c3-4a83-9404-b510ca4d051a
+// last-edited: 2026-07-03
 
 // ITunesMhohEncoding is the authoritative per-hohmType encoding constant table
 // for mhoh string blocks in iTunes-authored .itl files.
@@ -40,9 +41,16 @@
 //
 // Encoding indicator values at byte +24 (not +27 as our old code assumed):
 //   0 = ASCII/percent-encoded (used exclusively by 0x0B LocalURL and similar)
-//   1 = Windows-1252 / Latin-1 (used for Latin text)
+//   1 = UTF-16LE (used for non-Latin text with characters > U+00FF)
 //   2 = UTF-8 / pure ASCII (used by 0x0B LocalURL for encoded URLs)
-//   3 = UTF-16LE (used for non-Latin text with characters > U+00FF)
+//   3 = Windows-1252 / Latin-1 (used for Latin text)
+//
+// K16 CORRECTION (2026-07-03): the 2026-06-09 derivation recorded the VALUE
+// SETS correctly but assigned the 1/3 semantics backwards. Byte-level probes
+// of golden blocks (see mhoh_string.go and SPEC 3 §6) prove at24==3 carries
+// single-byte text and at24==1 carries UTF-16LE. The AllowedAt24 sets below
+// are unchanged (they are numeric observations); only per-type semantic
+// commentary has been corrected.
 //
 // Note: this table covers ALL 44 text string hohmTypes found in the corpus.
 // The guard-critical types (used by our writers) are 0x02, 0x03, 0x04, 0x05,
@@ -60,7 +68,7 @@ type MhohEncodingEntry struct {
 	// encoding indicator field) in the corpus. The guard rejects any block
 	// whose +24 value is not in this set.
 	//
-	// Values seen: 0=ASCII/percent-encoded, 1=Windows-1252, 2=UTF-8, 3=UTF-16LE.
+	// Values seen: 0=ASCII/percent-encoded, 1=UTF-16LE, 2=UTF-8, 3=Windows-1252.
 	AllowedAt24 []uint32
 
 	// At27Uniform records whether byte +27 was exclusively 0x00 in the corpus.
@@ -96,8 +104,8 @@ var ITunesMhohEncoding = map[uint32]MhohEncodingEntry{
 	// --------------- Core track metadata (written by our writers) ---------------
 
 	// 0x02 = Name (track title).
-	// Corpus: 94,575 blocks. at24 ∈ {1=latin1, 3=utf16le}. +27=0 uniform.
-	// Non-zero count of 3 (utf16le) for titles with non-Latin characters.
+	// Corpus: 94,575 blocks. at24 ∈ {1=utf16le, 3=latin1}. +27=0 uniform.
+	// The minority value 1 (utf16le) appears for titles with non-Latin chars.
 	0x02: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 94575},
 
 	// 0x03 = Album.
@@ -114,9 +122,8 @@ var ITunesMhohEncoding = map[uint32]MhohEncodingEntry{
 
 	// 0x06 = Kind (file format description, e.g. "AAC audio file").
 	// Corpus: 93,539 blocks. ONLY at24=3 observed — iTunes encodes "Kind"
-	// as UTF-16LE exclusively, even for pure-ASCII strings. +27=0 uniform.
-	// WHY: possibly because Kind strings always come from an internal enum,
-	// never from user input, and iTunes chose a uniform encoding for them.
+	// as single-byte Windows-1252 exclusively (K16-corrected; the strings are
+	// pure-ASCII values from an internal enum). +27=0 uniform.
 	0x06: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 93539},
 
 	// 0x0B = LocalURL (file://localhost/... percent-encoded URL, or https:// for podcasts).
@@ -130,8 +137,8 @@ var ITunesMhohEncoding = map[uint32]MhohEncodingEntry{
 	0x0B: {HeaderLen: 24, AllowedAt24: []uint32{0, 2}, At27Uniform: true, Count: 94201},
 
 	// 0x0D = Location (native Windows path, e.g. W:\itunes\...).
-	// Corpus: 93,014 blocks (1,736 are UTF-16LE-encoded for non-ASCII paths;
-	// 91,278 are Latin-1/Windows-1252).
+	// Corpus: 93,014 blocks (1,736 UTF-16LE at at24=1 for non-ASCII paths;
+	// 91,278 Latin-1/Windows-1252 at at24=3).
 	// at24 ∈ {1, 3}. +27=0 uniform; tail_zero=true.
 	0x0D: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 93014},
 
@@ -150,7 +157,7 @@ var ITunesMhohEncoding = map[uint32]MhohEncodingEntry{
 	0x0C: {HeaderLen: 24, AllowedAt24: []uint32{1, 3}, At27Uniform: true, Count: 32289},
 
 	// 0x0E = Series / Work name (rare).
-	// Corpus: 1,915 blocks. Only at24=3 (UTF-16LE).
+	// Corpus: 1,915 blocks. Only at24=3 (Windows-1252, K16-corrected).
 	0x0E: {HeaderLen: 24, AllowedAt24: []uint32{3}, At27Uniform: true, Count: 1915},
 
 	// 0x12 = Sort Artist.

--- a/internal/itunes/mhoh_string.go
+++ b/internal/itunes/mhoh_string.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/mhoh_string.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 6f3b9d12-4a87-4c0e-9b21-7e5d2a8c1f04
+// last-edited: 2026-07-03
 
 // iTunes-conformant mhoh string encoders/decoders (fable5 TASK-005, CRIT-1).
 //
@@ -17,13 +18,22 @@
 //     is a corruption signature foreign to iTunes (CRIT-1 / SPEC §1 K3).
 //
 //  2. iTunes signals string encoding at byte +24 (a little-endian u32), NOT at
-//     +27. Corpus-observed values: 0=ASCII/percent-encoded, 1=Windows-1252 /
-//     Latin-1, 2=UTF-8, 3=UTF-16LE. The allowed set per hohmType is the
+//     +27. Corpus-observed values: 0=ASCII/percent-encoded, 1=UTF-16LE,
+//     2=UTF-8, 3=Windows-1252/Latin-1. The allowed set per hohmType is the
 //     authoritative ITunesMhohEncoding table (T002).
 //
+//     K16 CORRECTION (2026-07-03, SPEC 3): the original T002/T005 work assigned
+//     1=Latin-1 and 3=UTF-16LE — EXACTLY SWAPPED. Byte-level probes of
+//     golden-library blocks are unambiguous: at24==3 blocks hold single-byte
+//     text ("W:\itunes\...", "MPEG audio file") and at24==1 blocks hold
+//     UTF-16LE (curly quotes as `19 20`). The inverted table made every
+//     decoded golden string mojibake (location-form fired on known-good
+//     libraries) and made our writer stamp at24 values iTunes interprets as
+//     the OTHER charset — real write-path corruption on rewritten strings.
+//
 //  3. The OLD code, when it fell back to UTF-16, wrote UTF-16 BIG-endian. The
-//     corpus shows iTunes uses at24==3 == UTF-16 LITTLE-endian. Writing the
-//     correct Unicode string with the wrong byte order is itself corruption
+//     corpus shows iTunes' UTF-16 blocks (at24==1) are LITTLE-endian. Writing
+//     the correct Unicode string with the wrong byte order is itself corruption
 //     (SPEC §1b rule 4). encodeMhohITunes emits UTF-16LE.
 //
 // encodeMhohITunes is the single iTunes-conformant encoder. It is driven by the
@@ -61,9 +71,9 @@ const mhohFixedHeaderTotal = 40
 // These are the LITTLE-ENDIAN u32 written at byte offset +24 of an mhoh block.
 const (
 	at24ASCII   uint32 = 0 // ASCII / percent-encoded (0x0B LocalURL, advisory strings)
-	at24Latin1  uint32 = 1 // Windows-1252 / Latin-1 (Latin text)
+	at24UTF16LE uint32 = 1 // UTF-16 LITTLE-endian (non-Latin text) — K16-corrected
 	at24UTF8    uint32 = 2 // UTF-8 / pure ASCII (0x0B encoded URLs)
-	at24UTF16LE uint32 = 3 // UTF-16 LITTLE-endian (non-Latin text)
+	at24Latin1  uint32 = 3 // Windows-1252 / Latin-1 (Latin text) — K16-corrected
 )
 
 // MhohHeaderBytes carries the deterministic per-block header values the LE
@@ -90,12 +100,12 @@ type MhohHeaderBytes struct {
 //   - {0} or {2}: ASCII/percent-encoded field (e.g. 0x0B LocalURL). Encoded as
 //     raw bytes; at24 = the single allowed value (2 preferred over 0 when both
 //     are allowed, matching iTunes' dominant rendering for encoded URLs).
-//   - {3} only: UTF-16LE always, even for ASCII (e.g. 0x06 Kind — iTunes encodes
-//     Kind as UTF-16LE uniformly).
-//   - contains both 1 and 3: latin1 when every rune <= 0xFF, else UTF-16LE.
-//   - {1} only: Latin-1 (errors if a rune is non-representable — handled by
-//     falling back to the type's behaviour; {1}-only types in the corpus only
-//     ever hold Latin text).
+//   - {3} only: Windows-1252 always (e.g. 0x06 Kind — iTunes encodes Kind as
+//     single-byte text uniformly; the strings come from an internal enum).
+//   - contains both 1 and 3: latin1 (3) when every rune <= 0xFF, else
+//     UTF-16LE (1) — matching the golden distribution (Latin-representable
+//     names/locations dominate at 3; curly-quote/CJK strings carry 1).
+//   - {1} only: UTF-16LE always.
 func encodeMhohITunes(hohmType uint32, s string) ([]byte, MhohHeaderBytes, error) {
 	entry, ok := ITunesMhohEncoding[hohmType]
 	if !ok {
@@ -140,13 +150,13 @@ func encodeMhohITunes(hohmType uint32, s string) ([]byte, MhohHeaderBytes, error
 
 // chooseAt24 picks the corpus-allowed encoding indicator for s given the type's
 // AllowedAt24 set. WHY the priority order: it mirrors what iTunes itself writes —
-// UTF-16-only types always 3; URL/ASCII types take their single allowed code;
-// {1,3} text types use latin1 for Latin-representable strings and UTF-16LE
-// otherwise.
+// UTF-16-only types always 1; URL/ASCII types take their single allowed code;
+// {1,3} text types use latin1 (3) for Latin-representable strings and
+// UTF-16LE (1) otherwise.
 func chooseAt24(entry MhohEncodingEntry, s string) uint32 {
 	allows := func(v uint32) bool { return entry.AllowedAt24Contains(v) }
 
-	// UTF-16LE-only types (e.g. 0x06 Kind): always 3.
+	// UTF-16LE-only types: always 1.
 	if allows(at24UTF16LE) && !allows(at24Latin1) && !allows(at24ASCII) && !allows(at24UTF8) {
 		return at24UTF16LE
 	}
@@ -193,8 +203,8 @@ func isLatin1Representable(s string) bool {
 	return true
 }
 
-// encodeUTF16LE encodes s as UTF-16 LITTLE-endian (at24==3). WHY little-endian:
-// the corpus shows iTunes' at24==3 blocks are UTF-16LE; our OLD encoder wrote
+// encodeUTF16LE encodes s as UTF-16 LITTLE-endian (at24==1). WHY little-endian:
+// byte-level probes show iTunes' UTF-16 blocks are LE; our OLD encoder wrote
 // big-endian, which was part of the CRIT-1 corruption (SPEC §1b rule 4).
 // Astral-plane runes (> U+FFFF) are emitted as surrogate pairs.
 func encodeUTF16LE(s string) []byte {
@@ -217,7 +227,7 @@ func encodeUTF16LE(s string) []byte {
 	return buf
 }
 
-// decodeMhohUTF16LE decodes UTF-16 LITTLE-endian bytes (at24==3) into a string,
+// decodeMhohUTF16LE decodes UTF-16 LITTLE-endian bytes (at24==1) into a string,
 // handling surrogate pairs and embedded NULs. The inverse of encodeUTF16LE.
 // (Distinct from smart_criteria_reader.go's decodeUTF16LE, which stops at the
 // first NUL and ignores surrogates — wrong for full mhoh string payloads.)
@@ -253,7 +263,8 @@ func decodeMhohUTF16LE(data []byte) string {
 //     legacy flag at +27 (decodeHohmString: 1=UTF-16BE, 2=UTF-8, 3=Win-1252,
 //     0=ASCII). This keeps libraries we previously wrote parseable.
 //   - byte +27 == 0  → iTunes-conformant block. Read the +24 u32 indicator and
-//     decode per the corpus semantics (0/2=ASCII/UTF-8, 1=Latin-1, 3=UTF-16LE).
+//     decode per the corpus semantics (0/2=ASCII/UTF-8, 1=UTF-16LE, 3=Latin-1;
+//     K16-corrected 2026-07-03 — the original assignment had 1 and 3 swapped).
 //
 // The dual path is required because the two conventions assign DIFFERENT
 // meanings to the same numeric value (legacy 3 = Win-1252; corpus 3 = UTF-16LE),

--- a/internal/itunes/mhoh_string_test.go
+++ b/internal/itunes/mhoh_string_test.go
@@ -43,7 +43,7 @@ func TestEncodeMhohITunes_RoundTrip(t *testing.T) {
 		hohmType uint32
 		value    string
 	}{
-		// 0x02 (Name) allows {1=latin1, 3=utf16le}.
+		// 0x02 (Name) allows {1=utf16le, 3=latin1} (K16-corrected).
 		{"ascii_name", 0x02, "The Way of Kings"},
 		{"latin1_name", 0x02, "Café Société — naïve"},
 		{"cjk_name", 0x02, "日本語のタイトル"},
@@ -54,9 +54,10 @@ func TestEncodeMhohITunes_RoundTrip(t *testing.T) {
 		{"cjk_album", 0x03, "村上春樹"},
 		{"latin1_genre", 0x05, "Fiction"},
 		{"latin1_composer", 0x0C, "Michael Kramer & Kate Reading"},
-		// 0x06 (Kind) is UTF-16LE-only in the corpus, even for ASCII.
-		{"kind_ascii_utf16", 0x06, "MPEG audio file"},
-		{"kind_unicode", 0x06, "AAC オーディオ"},
+		// 0x06 (Kind) is {3}-only = Windows-1252-only (K16-corrected): its
+		// values are ASCII enum strings. Non-Latin Kind is unrepresentable and
+		// must error — covered by TestEncodeMhohITunes_KindNonLatinErrors.
+		{"kind_ascii", 0x06, "MPEG audio file"},
 		// 0x0D (Location) Windows path, Latin-1 representable.
 		{"location_latin1", 0x0D, `W:\itunes\iTunes Media\Audiobooks\Author\book.mp3`},
 		{"location_unicode", 0x0D, `W:\itunes\著者\タイトル.m4b`},
@@ -82,7 +83,17 @@ func TestEncodeMhohITunes_Plus27AlwaysZero(t *testing.T) {
 	for _, ht := range []uint32{0x02, 0x03, 0x04, 0x05, 0x06, 0x0B, 0x0C, 0x0D, 0x64} {
 		for _, s := range []string{"ascii", "café", "日本語", "x’y"} {
 			block, ok := buildMhohLE(ht, s)
-			require.True(t, ok)
+			if !ok {
+				// Latin-1-only types (e.g. 0x06 Kind, K16-corrected) must
+				// refuse non-representable strings rather than invent an
+				// indicator; that refusal is the correct outcome here.
+				entry := ITunesMhohEncoding[ht]
+				require.False(t, entry.AllowedAt24Contains(at24UTF16LE),
+					"type 0x%X value %q: encode refused despite UTF-16LE being allowed", ht, s)
+				require.False(t, isLatin1Representable(s),
+					"type 0x%X value %q: encode refused a representable string", ht, s)
+				continue
+			}
 			require.GreaterOrEqual(t, len(block), 40)
 			assert.Equal(t, byte(0), block[27],
 				"type 0x%X value %q: byte +27 must be 0x00 (K3)", ht, s)
@@ -99,14 +110,19 @@ func TestEncodeMhohITunes_Plus27AlwaysZero(t *testing.T) {
 }
 
 // TestEncodeMhohITunes_UTF16IsLittleEndian proves the byte order: the OLD code
-// wrote UTF-16 BIG-endian; the corpus (at24==3) is LITTLE-endian. For "日" (U+65E5)
-// the LE bytes are 0xE5 0x65, NOT 0x65 0xE5.
+// wrote UTF-16 BIG-endian; iTunes' UTF-16 blocks (at24==1, K16-corrected) are
+// LITTLE-endian. For "日" (U+65E5) the LE bytes are 0xE5 0x65, NOT 0x65 0xE5.
 func TestEncodeMhohITunes_UTF16IsLittleEndian(t *testing.T) {
 	block, ok := buildMhohLE(0x02, "日") // U+65E5
 	require.True(t, ok)
 
-	// at24 must be 3 (UTF-16LE).
-	assert.Equal(t, uint32(3), binary.LittleEndian.Uint32(block[24:28]), "non-Latin → UTF-16LE (at24=3)")
+	// at24 must be 1 (UTF-16LE, K16-corrected).
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(block[24:28]), "non-Latin → UTF-16LE (at24=1)")
+
+	// And a non-Latin Kind (a {3}=latin1-only type) must refuse to encode
+	// rather than invent an indicator iTunes never writes for that field.
+	_, _, err := encodeMhohITunes(0x06, "AAC オーディオ")
+	assert.Error(t, err, "non-Latin Kind must error (latin1-only type)")
 
 	strLen := int(binary.LittleEndian.Uint32(block[28:32]))
 	require.Equal(t, 2, strLen, "one BMP rune → 2 bytes")

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -1,12 +1,13 @@
 // file: internal/itunes/rebuild.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 3f2e1d0c-9b8a-7c6d-5e4f-3a2b1c0d9e8f
-// last-edited: 2026-05-17
+// last-edited: 2026-07-03
 
 package itunes
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -246,7 +247,14 @@ type ITLRebuildResult struct {
 // The existing ITL is used as a structural template so the container format,
 // compression, and encryption are preserved — only the track data is replaced.
 // The result is written to outputPath via ApplyITLOperations.
-func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string) (*ITLRebuildResult, error) {
+//
+// K15: acknowledgeShrink is the explicit operator gate for a rebuild that
+// would shrink the library by more than half. WHY: rebuild sources its track
+// list from the DB; an under-populated / mid-migration DB silently turns
+// "rebuild" into "mass deletion" (the July 2026 stub class), and Force
+// (needed legitimately for bounded-delta here) would otherwise be the only
+// gate. A >50% shrink without acknowledgment is an error, never a write.
+func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledgeShrink bool) (*ITLRebuildResult, error) {
 	lib, err := ParseITL(itlPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse ITL: %w", err)
@@ -292,10 +300,25 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string) (*ITLRebui
 		ToAdd:       len(adds),
 	}
 
+	// K15 shrink gate: a rebuild that halves the library needs an explicit
+	// operator acknowledgment — Force alone must not be able to authorize it.
+	if len(lib.Tracks) > 0 && len(adds)*2 < len(lib.Tracks) && !acknowledgeShrink {
+		return nil, fmt.Errorf(
+			"rebuild would shrink library from %d to %d tracks (>50%%); refusing without acknowledge_shrink — the DB may be under-populated (K15)",
+			len(lib.Tracks), len(adds))
+	}
+	// Report-mode magnitude: always leave the blast radius in the log, even
+	// when the write is authorized (K15 — Force must never be silent).
+	slog.Warn("RebuildITLFromDB applying nuclear rebuild",
+		"op", "itl-rebuild", "tracks_before", len(lib.Tracks),
+		"tracks_after", len(adds), "removes", len(removes),
+		"acknowledge_shrink", acknowledgeShrink)
+
 	// Nuclear rebuild removes EVERY existing track then re-adds from the DB, so
 	// it intentionally blows past the bounded-delta cap — pass Force (SPEC §2;
-	// structural guards still apply). Without this the contract would reject a
-	// real rebuild of a tens-of-thousands-track library.
+	// structural guards still apply, and the library-identity guard (K13) still
+	// checks PID continuity against the sidecar: a healthy DB re-adds the same
+	// PIDs, an under-populated one fails the overlap check).
 	ops := ITLOperationSet{Removes: removes, Adds: adds}
 	if _, err := ApplyITLOperations(itlPath, outputPath, ops, ForceContractConfig()); err != nil {
 		return nil, fmt.Errorf("apply rebuild ops: %w", err)

--- a/internal/itunes/service/service.go
+++ b/internal/itunes/service/service.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/service.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 81ccaec6-42b0-4828-83c8-7a96680112d9
+// last-edited: 2026-07-03
 
 package itunesservice
 
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
@@ -99,6 +101,15 @@ func New(deps Deps) (*Service, error) {
 		ITLWriteBackEnabled: deps.Config.ITLWriteBackEnabled,
 		LibraryWritePath:    deps.Config.LibraryWritePath,
 	}, deps.Store)
+
+	// SPEC 3 §4: wire the iTunes-in-use precondition. File-activity on the
+	// library and its journal siblings is the only signal visible from this
+	// side of the share; a hit defers the flush one debounce cycle (work is
+	// re-enqueued, never lost). Before this, SetLibraryNotInUse had no
+	// production caller and every write raced a potentially-open iTunes.
+	if p := deps.Config.LibraryWritePath; p != "" {
+		svc.Batcher.SetLibraryNotInUse(itunes.FileActivityLibraryCheck(p, 2*time.Minute))
+	}
 
 	// M1 step 1: Provisioner. Gets the real batcher directly — no
 	// SetEnqueuer hop needed now that Batcher is wired above.

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/writeback_batcher.go
-// version: 5.3.0
+// version: 5.4.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
+// last-edited: 2026-07-03
 //
 // Combined write-back batcher: handles location updates, track additions,
 // and track removals in a single ITL read-modify-write cycle.
@@ -118,7 +119,18 @@ type WriteBackBatcher struct {
 	// the batch is re-queued on the next timer tick rather than lost.
 	// Set via SetLibraryNotInUse. Safe to call after construction.
 	libraryNotInUse func() error
+
+	// flushFailures counts CONSECUTIVE failed flush attempts (parse or
+	// write errors). Failed batches are re-enqueued for retry up to
+	// maxFlushFailures; after that the batch is dropped with a loud
+	// error so a persistent fault (contract rejection, corrupt library)
+	// cannot hot-loop a 30MB re-encode forever. Reset on any success.
+	flushFailures int
 }
+
+// maxFlushFailures caps consecutive failed-flush retries before the
+// pending batch is dropped (see WriteBackBatcher.flushFailures).
+const maxFlushFailures = 3
 
 // NewWriteBackBatcher creates a batcher with the given debounce delay.
 func NewWriteBackBatcher(delay time.Duration, cfg WriteBackBatcherConfig, store WriteBackStore) *WriteBackBatcher {
@@ -257,6 +269,25 @@ func (b *WriteBackBatcher) hasPending() bool {
 	return len(b.pendingBooks) > 0 || len(b.pendingAdds) > 0 || len(b.pendingRemoves) > 0
 }
 
+// reEnqueue restores a snapshotted-and-cleared batch into the pending state
+// and re-arms the timer, so a deferred or failed flush is retried on the next
+// tick instead of lost. Mirrors the Enqueue* locking discipline.
+func (b *WriteBackBatcher) reEnqueue(bookIDs []string, adds []itunes.ITLNewTrack, removes map[string]bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, id := range bookIDs {
+		b.pendingBooks[id] = true
+	}
+	b.pendingAdds = append(b.pendingAdds, adds...)
+	for pid := range removes {
+		b.pendingRemoves[pid] = true
+	}
+	if b.firstEnqueue.IsZero() && len(bookIDs)+len(adds)+len(removes) > 0 {
+		b.firstEnqueue = time.Now()
+	}
+	b.resetTimer()
+}
+
 // flush writes all pending operations to the iTunes ITL binary in one pass.
 func (b *WriteBackBatcher) flush() {
 	b.mu.Lock()
@@ -320,21 +351,7 @@ func (b *WriteBackBatcher) flush() {
 	if notInUse != nil {
 		if err := notInUse(); err != nil {
 			slog.Warn("iTunes write-back deferred: library in use", "reason", err)
-			// Re-enqueue so the work is not lost. resetTimer must be called
-			// while b.mu is held (same as Enqueue / EnqueueAdd / EnqueueRemove).
-			b.mu.Lock()
-			for _, id := range bookIDs {
-				b.pendingBooks[id] = true
-			}
-			b.pendingAdds = append(b.pendingAdds, adds...)
-			for pid := range removes {
-				b.pendingRemoves[pid] = true
-			}
-			if b.firstEnqueue.IsZero() && len(bookIDs)+len(adds)+len(removes) > 0 {
-				b.firstEnqueue = time.Now()
-			}
-			b.resetTimer()
-			b.mu.Unlock()
+			b.reEnqueue(bookIDs, adds, removes)
 			return
 		}
 	}
@@ -345,14 +362,29 @@ func (b *WriteBackBatcher) flush() {
 	// ~90K mhoh blocks every sync when only a handful of tracks have
 	// actually changed (HIGH-3 / T008 fix).
 	//
-	// Parse failure is non-fatal: if we can't read the library (e.g.
-	// first-run or file temporarily locked), we skip the metadata diff
-	// and write everything. The safety contract in SafeWriteITL still
-	// validates the output before landing it.
+	// Parse failure DEFERS the flush (SPEC 3 §4): an unreadable library
+	// means we cannot know what we would be writing over — a transiently
+	// locked file heals on the next tick, and a persistently unreadable
+	// one hits the maxFlushFailures cap instead of being blind-written.
+	// The old behavior (WARN + write ALL metadata updates without a diff)
+	// was the HIGH-3 blast-radius amplifier running exactly when the
+	// library was least trustworthy.
 	var tracksByPID map[string]*itunes.ITLTrack
 	if lib, err := parseITLFn(writePath); err != nil {
-		slog.Warn("iTunes write-back could not parse library for diff; writing all metadata updates",
-			"err", err, "path", writePath)
+		b.mu.Lock()
+		b.flushFailures++
+		failures := b.flushFailures
+		b.mu.Unlock()
+		if failures >= maxFlushFailures {
+			slog.Error("iTunes write-back DROPPING batch: library unparseable after retries",
+				"err", err, "path", writePath, "attempts", failures,
+				"dropped_updates", len(bookIDs), "dropped_adds", len(adds), "dropped_removes", len(removes))
+			return
+		}
+		slog.Warn("iTunes write-back deferred: library unparseable, will retry",
+			"err", err, "path", writePath, "attempt", failures)
+		b.reEnqueue(bookIDs, adds, removes)
+		return
 	} else {
 		tracksByPID = make(map[string]*itunes.ITLTrack, len(lib.Tracks))
 		for i := range lib.Tracks {
@@ -531,8 +563,35 @@ func (b *WriteBackBatcher) flush() {
 
 	itlPath := writePath // from b.flushEnabled() above
 	if err := SafeWriteITL(itlPath, ops); err != nil {
-		slog.Warn("iTunes write-back failed", "err", err)
+		b.mu.Lock()
+		b.flushFailures++
+		failures := b.flushFailures
+		b.mu.Unlock()
+		if failures >= maxFlushFailures {
+			// A persistent failure (contract rejection, corrupt library) —
+			// dropping after N attempts prevents a 30MB re-encode hot loop,
+			// and ERROR (not the old silent WARN) makes the loss visible.
+			slog.Error("iTunes write-back DROPPING batch after repeated failures",
+				"err", err, "attempts", failures,
+				"dropped_updates", len(bookIDs), "dropped_adds", len(adds), "dropped_removes", len(removes))
+			return
+		}
+		slog.Error("iTunes write-back failed; batch re-enqueued for retry",
+			"err", err, "attempt", failures)
+		b.reEnqueue(bookIDs, adds, removes)
 		return
+	}
+
+	// Success: reset the consecutive-failure counter and pin this state as
+	// the last-known-good anchor. .bak-lkg is exempt from rotation, so even
+	// after keep-10 churns through timestamped backups a validated copy of a
+	// successfully-written library survives (SPEC 3 §4 — before this wiring,
+	// PinLastKnownGood had no production caller and .bak-lkg never existed).
+	b.mu.Lock()
+	b.flushFailures = 0
+	b.mu.Unlock()
+	if err := itlPinLKGFn(itlPath); err != nil {
+		slog.Warn("iTunes write-back could not pin last-known-good", "err", err, "path", itlPath)
 	}
 
 	// Mark the books we wrote as iTunes-synced so downstream UI /
@@ -558,6 +617,7 @@ var (
 	itlValidateFn        = itunes.ValidateITL
 	itlApplyOperationsFn = itunes.ApplyITLOperations
 	parseITLFn           = itunes.ParseITL
+	itlPinLKGFn          = itunes.PinLastKnownGood
 )
 
 // SafeWriteITL performs a backup → write-temp → validate-temp →

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -224,10 +224,16 @@ func (b *WriteBackBatcher) EnqueueRemove(pid string) {
 	b.pendingRemoves[strings.ToLower(pid)] = true
 	b.resetTimer()
 
-	// Mark as removed in DB (best-effort, outside lock)
+	// Mark as removed in DB (best-effort, outside lock). Failure leaves a
+	// stale external-id mapping that later re-triggers dispatch for an
+	// already-removed track — log it so the drift is visible instead of
+	// discarding the error.
 	go func() {
-		if b.store != nil {
-			_ = b.store.MarkExternalIDRemoved("itunes", pid)
+		if b.store == nil {
+			return
+		}
+		if err := b.store.MarkExternalIDRemoved("itunes", pid); err != nil {
+			slog.Warn("iTunes write-back MarkExternalIDRemoved failed; external-id map now stale", "pid", pid, "err", err)
 		}
 	}()
 }
@@ -618,7 +624,22 @@ var (
 	itlApplyOperationsFn = itunes.ApplyITLOperations
 	parseITLFn           = itunes.ParseITL
 	itlPinLKGFn          = itunes.PinLastKnownGood
+	itlAuditFileFn       = auditITLFile
 )
+
+// auditITLFile re-reads a written ITL and runs the full ITLSafetyContract
+// (AuditITL) on it — the service wrapper's equivalent of the hardened
+// path's step-5 re-read validation.
+func auditITLFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-reading %s: %w", path, err)
+	}
+	if v := itunes.AuditITL(data); !v.Pass {
+		return fmt.Errorf("%s", v.Error())
+	}
+	return nil
+}
 
 // SafeWriteITL performs a backup → write-temp → validate-temp →
 // rename → validate-final → cleanup cycle for ITL write-back. At
@@ -675,6 +696,16 @@ func SafeWriteITL(itlPath string, ops itunes.ITLOperationSet) error {
 	if err := itlValidateFn(tmpPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("validation of temp ITL failed (original preserved): %w", err)
+	}
+
+	// Step 4b: run the FULL safety contract on the re-read temp bytes —
+	// the same step-5 re-read audit the hardened itunes.SafeWriteITL
+	// performs. ValidateITL only proves the header decodes and a track
+	// exists; AuditITL catches encode/encrypt/deflate-path corruption
+	// (the historic risk area) before the rename lands it.
+	if err := itlAuditFileFn(tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("contract audit of temp ITL failed (original preserved): %w", err)
 	}
 
 	// Step 5: rename .tmp over the original.

--- a/internal/itunes/service/writeback_batcher_test.go
+++ b/internal/itunes/service/writeback_batcher_test.go
@@ -1,12 +1,14 @@
 // file: internal/itunes/service/writeback_batcher_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0123-def4-56789abcdef0
+// last-edited: 2026-07-03
 
 package itunesservice
 
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,9 +35,16 @@ func withFakeITLHooks(t *testing.T, validate func(string) error, apply func(in, 
 	itlApplyOperationsFn = func(in, out string, ops itunes.ITLOperationSet, _ ...itunes.ContractConfig) (*itunes.ITLWriteBackResult, error) {
 		return apply(in, out, ops)
 	}
+	// The full-contract audit hook (step 4b) is neutralized by default —
+	// these tests drive validate/apply flow control with placeholder files
+	// that no real audit could pass. TestSafeWriteITL_AuditRejection covers
+	// the audit path explicitly.
+	prevAudit := itlAuditFileFn
+	itlAuditFileFn = func(string) error { return nil }
 	t.Cleanup(func() {
 		itlValidateFn = prevValidate
 		itlApplyOperationsFn = prevApply
+		itlAuditFileFn = prevAudit
 	})
 }
 
@@ -109,6 +118,44 @@ func TestSafeWriteITL_HappyPath(t *testing.T) {
 	// No .tmp left over.
 	if _, err := os.Stat(itlPath + ".tmp"); !os.IsNotExist(err) {
 		t.Error("expected .tmp to be cleaned up")
+	}
+}
+
+// TestSafeWriteITL_AuditRejection: the step-4b full-contract audit of the
+// temp file rejects the write and preserves the original — the service
+// wrapper's equivalent of the hardened path's re-read validation.
+func TestSafeWriteITL_AuditRejection(t *testing.T) {
+	dir := t.TempDir()
+	itlPath := makeITL(t, dir, "library.itl", "original-content")
+
+	withFakeITLHooks(t,
+		func(string) error { return nil },
+		func(in, out string, _ itunes.ITLOperationSet) (*itunes.ITLWriteBackResult, error) {
+			data, err := os.ReadFile(in)
+			if err != nil {
+				return nil, err
+			}
+			if err := os.WriteFile(out, append(data, '!'), 0o644); err != nil {
+				return nil, err
+			}
+			return &itunes.ITLWriteBackResult{UpdatedCount: 1, OutputPath: out}, nil
+		},
+	)
+	itlAuditFileFn = func(string) error { return fmt.Errorf("mhoh-format: fake violation") }
+
+	err := SafeWriteITL(itlPath, itunes.ITLOperationSet{
+		LocationUpdates: []itunes.ITLLocationUpdate{{PersistentID: "aa", NewLocation: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "contract audit") {
+		t.Fatalf("expected contract-audit rejection, got: %v", err)
+	}
+	// Original untouched, no temp left behind.
+	out, _ := os.ReadFile(itlPath)
+	if string(out) != "original-content" {
+		t.Errorf("original modified after audit rejection: %q", string(out))
+	}
+	if _, err := os.Stat(itlPath + ".tmp"); !os.IsNotExist(err) {
+		t.Error("expected .tmp to be cleaned up after audit rejection")
 	}
 }
 

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -103,7 +103,10 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 // rebuildITLFullHandler handles POST /api/v1/itunes/rebuild-full.
 // Strips ALL tracks from the ITL and re-inserts every DB book with an iTunes PID.
 // This is the "nuclear" reset path — use rebuildITLHandler (incremental diff) first.
-// Query param: dry_run=true returns a preview without applying.
+// Query params: dry_run=true returns a preview without applying;
+// acknowledge_shrink=true is the explicit K15 operator gate required when the
+// rebuild would shrink the library by more than half (under-populated DB
+// protection — without it such a rebuild is refused).
 func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 	rawPath := config.AppConfig.ITunes.LibraryWritePath
 	if rawPath == "" {
@@ -136,7 +139,7 @@ func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 		return
 	}
 
-	result, err := itunes.RebuildITLFromDB(store, itlPath, itlPath)
+	result, err := itunes.RebuildITLFromDB(store, itlPath, itlPath, c.Query("acknowledge_shrink") == "true")
 	if err != nil {
 		httputil.RespondWithInternalError(c, fmt.Sprintf("full rebuild failed: %v", err))
 		return


### PR DESCRIPTION
## Summary

Full hardening wave from the 2026-07-03 .itl deep dive (SPEC 3). The motivating finding: a 374-track cloud-stub library — same path, same Library PID, zero track-PID overlap, 0.4% of the tracks — passed all 8 structural guards. Structure was certified; identity, magnitude, and co-writer semantics were not. This PR closes all four tiers:

- **K13/K14** — `library-identity` guard (`.identity.json` sidecar fingerprint: Library PID @0x34 + ≤1024 sampled track PIDs, ≥90% overlap, explicit `AdoptLibrary` bless) and `expected-magnitude` guard, wired into `SafeWriteITL` and `ApplyITLOperations`.
- **K16** — the mhoh `at24` encoding semantics were inverted (1=UTF-16LE, 3=Win-1252, opposite of the T002 table): fixed decode + encode; `location-form` recalibrated (bare `%` filenames, no-new pair-consistency). The golden master and live library now audit fully clean — first time ever. `TestGoldenCorpusAuditClean` pins this in CI.
- **K15** — nuclear rebuild refuses >50% shrink without `acknowledge_shrink=true`; blast radius always logged; bounded-delta is PID-set based and symmetric (removal/insertion/replacement).
- **K17 (Tier 4)** — checksum continuity: each write records the SHA-256 of the landed bytes; the next write detects external (iTunes) modification. `expected-magnitude` armed on every write from sidecar count + op delta.
- **Safety wiring** — `FileActivityLibraryCheck` in-use gate wired at service construction; `PinLastKnownGood` after every flush (`.bak-lkg` now exists); flush failures re-enqueue with a 3-attempt cap instead of WARN+drop; parse failure defers instead of blind-writing; service wrapper re-reads temp and runs the full contract (step 4b); `MarkExternalIDRemoved` errors surfaced.
- **Docs** — SPEC 3 (normative K13–K17) + the complete deep-dive record (format map, 13-library census, guard vacuity map, FM-1..17 failure taxonomy).

## Test plan

- `go test ./internal/itunes/... ./internal/server/` green (incl. 12 new tests: identity lifecycle, checksum continuity, magnitude arming, symmetric bounded-delta, audit rejection, golden-corpus audit).
- `itl-check` (cross-compiled) verified against the production golden master (90,900 tracks) and live library (95,238): all guards PASS.
- `go vet` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KUfATK5tSuowZ5VcGGGz7