### PR TITLE
feat(dedup): rebuild-gold-labels op — regenerate mechanical labels against current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,42 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.104.0 -->
+<!-- version: 3.105.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-04 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 4, 2026 - dedup gold-label rebuild op (dedup.rebuild-gold-labels)
+
+- **`feat(dedup)`** — new op `dedup.rebuild-gold-labels`
+  (`internal/plugins/dedup/rebuild_gold_labels.go`) re-derives the
+  mechanically-generated portion of the gold-label store
+  (`label_source="rule"` via `dataset.Classify`, `label_source="auto_high_conf"`
+  via `dataset.MineHighConfidenceDup`) against *current* candidate/book/
+  embedding state — the label set predates the CONS-16/17/FRAG
+  candidate-quality fixes and the bge-m3 cutover, so a chunk of it currently
+  references merged/deleted/non-primary books or catchers that no longer fire.
+  This op keeps that mechanical portion of the gold-label set current; it is
+  an independent gold-label-quality fix and does **not** address the
+  embedding-side `skipped_dim` staleness seen in
+  `dedup.calibrate-embedding-thresholds` (stale `.Model`/dimension mismatches
+  on stored embeddings) — that's a separate, still-open problem tracked
+  elsewhere. Dry-run by default: reports changed/unchanged/unlabelable
+  counts per bucket (unlabelable = candidate no longer exists or the
+  catcher no longer fires) plus a pass-through count of `label_source="human"`
+  rows, which — like unlabeled backfill rows (`LabelSource==""`) — are never
+  touched. `apply=true` deletes all rule/auto_high_conf rows and reinserts the
+  freshly computed set; idempotent (re-running apply against unchanged state
+  yields the same label/source assignments). New primitive
+  `EmbeddingStore.DeleteLabeledExamplesBySource` (`internal/database/dedup_label.go`)
+  backs the bulk-delete. 3 unit tests (dry-run diff correctness, apply
+  wipe+reinsert with human/unlabeled preserved, apply idempotency) plus the
+  existing dedup plugin/database suites all pass. Prod validation: dry-run
+  via `/api/v1/operations/v2` first, review the diff, only then apply (owner
+  greenlight, per repo convention for destructive dedup ops).
 
 #### July 3, 2026 - .itl foolproofing wave 2: K15/K16 + dead-code safety wiring
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.57.0 -->
+<!-- version: 9.58.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-04 -->
 
 # Project TODO
 
@@ -458,6 +458,24 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   (`internal/dedup/dataset/highconf.go`), 7 unit tests + 2 op e2e tests. Dry-run default;
   reuses candidate ids (no synthetic rows). Complements `dedup.dataset-backfill` (rule negatives)
   + human capture. **Not yet run on prod** — dry-run first via `{"def_id":"dedup.mine-gold-labels","params":{}}`.
+- [x] **C-rebuild / gold rebuild** New op `dedup.rebuild-gold-labels`
+  (`internal/plugins/dedup/rebuild_gold_labels.go`) re-derives `label_source="rule"`
+  (`dataset.Classify`) and `label_source="auto_high_conf"` (`dataset.MineHighConfidenceDup`)
+  labels against current candidate/book/embedding state — the 6,095-row label store
+  (5,050 rule / 248 auto_high_conf / 3 human / 794 unlabeled) predates the
+  CONS-16/17/FRAG fixes and the bge-m3 cutover, so a chunk of the mechanical
+  labels currently reference merged/deleted/non-primary books or catchers that
+  no longer fire. This is a gold-label-quality fix only — it does **not**
+  address `dedup.calibrate-embedding-thresholds`'s `skipped_dim` count
+  (2,841/5,301 pairs on the 2026-07-04 prod run), which is a separate,
+  still-open embedding-side staleness problem (stale `.Model`/dimension
+  mismatches on stored embeddings, root cause not yet found — do not conflate
+  the two). Dry-run reports changed/unchanged/unlabelable counts per bucket;
+  `apply=true` deletes+reinserts the rule/auto_high_conf rows (idempotent),
+  never touching `label_source="human"` or unlabeled (`LabelSource==""`) rows.
+  New `EmbeddingStore.DeleteLabeledExamplesBySource` primitive. 3 unit tests.
+  **Not yet run on prod** — dry-run first via `{"def_id":"dedup.rebuild-gold-labels","params":{}}`,
+  review the diff, only then `apply=true` (owner greenlight).
 - [x] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path  ✅ shipped #1729 (agent-task sweep 2026-07-01)
   so each new candidate automatically gets a feature snapshot + deterministic label on
   creation (no separate backfill needed going forward).

--- a/docs/process/executive-summaries.md
+++ b/docs/process/executive-summaries.md
@@ -1,7 +1,7 @@
 <!-- file: docs/process/executive-summaries.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: b608794a-eac5-44bc-95b9-643872bd0ca8 -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-04 -->
 
 # Executive Summary Convention
 
@@ -48,10 +48,13 @@ to the merged PR at the top of the summary.
      not abstract correctness.
    - **The fix** — what was actually done, in one or two sentences.
 
-Write at a 9th-grade reading level: short sentences, no unexplained
-acronyms (spell out or define anything like PID, ECB, mhoh on first use if
-it must appear at all — prefer avoiding it), no code snippets, no file
-paths in the body (those belong in the spec, not the summary).
+Write at a 12th-grade / college-freshman reading level: clear sentences,
+but more technical detail than a pure lay summary — it's fine to name the
+actual mechanism (a specific check, flag, or concept) as long as it's
+explained in context. Define any acronym on first use (PID, ECB, mhoh,
+etc.) rather than assuming the reader already knows it. Avoid code
+snippets and file paths in the body (those belong in the spec, not the
+summary) — describe behavior and mechanism in prose instead.
 
 ## Workflow
 

--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,7 +1,7 @@
 // file: internal/database/dedup_label.go
-// version: 1.0.4
+// version: 1.1.0
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
-// last-edited: 2026-06-13
+// last-edited: 2026-07-04
 
 package database
 
@@ -168,6 +168,63 @@ func (s *EmbeddingStore) ListLabeledExamples(f LabeledExampleFilter) ([]LabeledE
 		}
 	}
 	return out, iter.Error()
+}
+
+// DeleteLabeledExample removes a single labeled example by candidate ID.
+// A no-op (no error) if the key does not exist.
+func (s *EmbeddingStore) DeleteLabeledExample(candidateID int64) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	return s.db.Delete(dedupLabelKey(candidateID), pebble.Sync)
+}
+
+// DeleteLabeledExamplesBySource deletes every labeled example whose
+// LabelSource matches one of the given sources, returning the count deleted.
+// Used by dedup.rebuild-gold-labels to wipe mechanically-derived labels
+// ("rule", "auto_high_conf") before reinserting a freshly computed set, while
+// leaving "human"-sourced (and any other) rows untouched.
+func (s *EmbeddingStore) DeleteLabeledExamplesBySource(sources ...string) (int, error) {
+	if err := s.checkClosed(); err != nil {
+		return 0, err
+	}
+	want := make(map[string]struct{}, len(sources))
+	for _, src := range sources {
+		want[src] = struct{}{}
+	}
+
+	prefix := []byte(dedupLabelPfx)
+	upper := prefixUpperBound(prefix)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return 0, fmt.Errorf("delete labeled examples by source: %w", err)
+	}
+
+	var keys [][]byte
+	for iter.First(); iter.Valid(); iter.Next() {
+		var ex LabeledExample
+		if err := json.Unmarshal(iter.Value(), &ex); err != nil {
+			continue // skip a corrupt row rather than abort the scan
+		}
+		if _, ok := want[ex.LabelSource]; !ok {
+			continue
+		}
+		keys = append(keys, append([]byte(nil), iter.Key()...))
+	}
+	if err := iter.Error(); err != nil {
+		_ = iter.Close()
+		return 0, err
+	}
+	if err := iter.Close(); err != nil {
+		return 0, err
+	}
+
+	for _, k := range keys {
+		if err := s.db.Delete(k, pebble.Sync); err != nil {
+			return len(keys), fmt.Errorf("delete labeled example key %q: %w", k, err)
+		}
+	}
+	return len(keys), nil
 }
 
 // CountLabeledExamples counts examples matching the filter (Limit/Offset ignored).

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-07-03
+// last-edited: 2026-07-04
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -70,6 +70,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.datasetBackfillDef(),              // C4: label + suppress residual pending candidates
 		p.calibrateEmbeddingThresholdsDef(), // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)
 		p.mineGoldLabelsDef(),               // gold miner: auto-label high-confidence true_dup positives
+		p.rebuildGoldLabelsDef(),            // rebuild rule/auto_high_conf gold labels against current state
 		p.quarantineChapterArtifactsDef(),   // drain chapter-file-as-book artifacts (candidate explosion)
 		p.drainStaleDef(),                   // DEDUP-1: drain CONS-16/17-era stale exact candidates (dry-run gated)
 		p.checkBookDef(),                    // M4: per-book dedup check via dependency scheduler

--- a/internal/plugins/dedup/rebuild_gold_labels.go
+++ b/internal/plugins/dedup/rebuild_gold_labels.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/rebuild_gold_labels.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 74b6de83-de1b-4231-8edc-6920a2f7b91c
 // last-edited: 2026-07-04
 
@@ -58,6 +58,40 @@ func (s rebuildBucketStats) String() string {
 		s.Examined, s.Changed, s.Unchanged, s.Unlabelable, s.NewTrueDup, s.NewNotDup)
 }
 
+// rebuildDiffSample is one changed-or-unlabelable row surfaced in the report
+// sample, so a reviewer can spot-check specific candidates before applying.
+type rebuildDiffSample struct {
+	CandidateID int64
+	Source      string // "rule" | "auto_high_conf"
+	OldLabel    string
+	NewLabel    string // empty when Unlabelable
+	Unlabelable bool
+}
+
+// rebuildSampleLimit bounds how many changed/unlabelable rows are captured
+// per bucket for the report sample, mirroring drain-stale's reason-breakdown
+// logging without holding onto an unbounded slice for huge label stores.
+const rebuildSampleLimit = 5
+
+// rebuildReport is the full result of computeRebuildDiff: per-bucket stats,
+// pass-through counts, the freshly computed rows ready to write on apply, and
+// a bounded sample of changed/unlabelable candidates for human review.
+type rebuildReport struct {
+	Rule       rebuildBucketStats
+	Auto       rebuildBucketStats
+	HumanCount int
+	OtherCount int // LabelSource=="" (unlabeled backfill rows) — untouched, counted for visibility
+	Fresh      []database.LabeledExample
+	Sample     []rebuildDiffSample
+}
+
+func (r rebuildReport) summary() string {
+	return fmt.Sprintf(
+		"rule[%s] auto_high_conf[%s] human=%d(passthrough) other_untouched=%d",
+		r.Rule.String(), r.Auto.String(), r.HumanCount, r.OtherCount,
+	)
+}
+
 func (p *Plugin) rebuildGoldLabelsDef() sdk.OperationDef {
 	return sdk.OperationDef{
 		ID:          "dedup.rebuild-gold-labels",
@@ -101,99 +135,32 @@ func (p *Plugin) runRebuildGoldLabels(ctx context.Context, rawParams json.RawMes
 	}
 	reporter.Logger().Info("rebuild-gold-labels: existing examples loaded", "count", len(existing))
 
-	adapter := builderAdapter{store: p.store}
-
-	var (
-		ruleStats  rebuildBucketStats
-		autoStats  rebuildBucketStats
-		humanCount int
-		otherCount int // LabelSource=="" (unlabeled backfill rows) — untouched, counted for visibility
-		fresh      []database.LabeledExample
-	)
-
 	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Re-deriving %d existing examples…", len(existing)))
-	for i := range existing {
-		if reporter.IsCanceled() {
-			return context.Canceled
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		old := existing[i]
-		if (i+1)%1000 == 0 {
-			_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Re-derived %d/%d…", i+1, len(existing)))
-		}
-
-		switch old.LabelSource {
-		case "human":
-			humanCount++
-			continue
-		case "rule":
-			ruleStats.Examined++
-			ex, unlabelable, changed := p.rebuildRuleExample(adapter, old)
-			if unlabelable {
-				ruleStats.Unlabelable++
-				continue
-			}
-			if changed {
-				ruleStats.Changed++
-			} else {
-				ruleStats.Unchanged++
-			}
-			switch ex.Label {
-			case "true_dup":
-				ruleStats.NewTrueDup++
-			case "not_dup":
-				ruleStats.NewNotDup++
-			}
-			fresh = append(fresh, ex)
-		case "auto_high_conf":
-			autoStats.Examined++
-			ex, unlabelable, changed := p.rebuildAutoHighConfExample(adapter, old)
-			if unlabelable {
-				autoStats.Unlabelable++
-				continue
-			}
-			if changed {
-				autoStats.Changed++
-			} else {
-				autoStats.Unchanged++
-			}
-			switch ex.Label {
-			case "true_dup":
-				autoStats.NewTrueDup++
-			case "not_dup":
-				autoStats.NewNotDup++
-			}
-			fresh = append(fresh, ex)
-		default:
-			// Unlabeled backfill rows (LabelSource=="") and any unrecognized
-			// source are left entirely alone — out of scope for this op.
-			otherCount++
-		}
+	report, err := p.computeRebuildDiff(ctx, reporter, existing)
+	if err != nil {
+		return err
 	}
 
-	reporter.Logger().Info("rebuild-gold-labels: rule bucket", "stats", ruleStats.String())
-	reporter.Logger().Info("rebuild-gold-labels: auto_high_conf bucket", "stats", autoStats.String())
-	reporter.Logger().Info("rebuild-gold-labels: pass-through", "human", humanCount, "other_untouched", otherCount)
+	reporter.Logger().Info("rebuild-gold-labels: rule bucket", "stats", report.Rule.String())
+	reporter.Logger().Info("rebuild-gold-labels: auto_high_conf bucket", "stats", report.Auto.String())
+	reporter.Logger().Info("rebuild-gold-labels: pass-through", "human", report.HumanCount, "other_untouched", report.OtherCount)
+	for _, s := range report.Sample {
+		reporter.Logger().Info("rebuild-gold-labels: sample",
+			"candidate_id", s.CandidateID, "source", s.Source,
+			"old_label", s.OldLabel, "new_label", s.NewLabel, "unlabelable", s.Unlabelable)
+	}
 
-	summary := fmt.Sprintf(
-		"rule[%s] auto_high_conf[%s] human=%d(passthrough) other_untouched=%d",
-		ruleStats.String(), autoStats.String(), humanCount, otherCount,
-	)
+	summary := report.summary()
 
 	if !params.Apply {
 		_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
 			"Dry-run — %d rule + %d auto_high_conf would change, %d would become unlabelable. %s. Pass apply=true to write.",
-			ruleStats.Changed, autoStats.Changed, ruleStats.Unlabelable+autoStats.Unlabelable, summary))
+			report.Rule.Changed, report.Auto.Changed, report.Rule.Unlabelable+report.Auto.Unlabelable, summary))
 		reporter.Logger().Info("rebuild-gold-labels: dry-run only; nothing written")
 		return nil
 	}
 
-	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf("Applying — deleting %d rule/auto_high_conf rows…", ruleStats.Examined+autoStats.Examined))
+	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf("Applying — deleting %d rule/auto_high_conf rows…", report.Rule.Examined+report.Auto.Examined))
 	deleted, err := p.embeddingStore.DeleteLabeledExamplesBySource("rule", "auto_high_conf")
 	if err != nil {
 		return fmt.Errorf("delete rule/auto_high_conf examples: %w", err)
@@ -201,7 +168,7 @@ func (p *Plugin) runRebuildGoldLabels(ctx context.Context, rawParams json.RawMes
 	reporter.Logger().Info("rebuild-gold-labels: deleted stale mechanical labels", "deleted", deleted)
 
 	var written, writeErrs int
-	for _, ex := range fresh {
+	for _, ex := range report.Fresh {
 		if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
 			writeErrs++
 			reporter.Logger().Error("rebuild-gold-labels: upsert error", "candidate_id", ex.CandidateID, "error", err)
@@ -214,6 +181,86 @@ func (p *Plugin) runRebuildGoldLabels(ctx context.Context, rawParams json.RawMes
 		"Complete — deleted %d, wrote %d fresh (%d errors). %s", deleted, written, writeErrs, summary))
 	reporter.Logger().Info("rebuild-gold-labels complete", "deleted", deleted, "written", written, "write_errs", writeErrs, "summary", summary)
 	return nil
+}
+
+// computeRebuildDiff is the pure(ish) core of the op: it re-derives every
+// rule/auto_high_conf example against current state and returns the full
+// diff — per-bucket stats, pass-through counts, the freshly computed rows
+// ready to write on apply, and a bounded sample of changed/unlabelable
+// candidates. Split out from runRebuildGoldLabels so the diff itself (the
+// deliverable of dry-run) is directly unit-testable, not just observable via
+// log lines. The only side effects are reads (GetCandidateByID, GetBook,
+// GetBookFiles via adapter) — no writes happen here.
+func (p *Plugin) computeRebuildDiff(ctx context.Context, reporter sdk.Reporter, existing []database.LabeledExample) (rebuildReport, error) {
+	adapter := builderAdapter{store: p.store}
+
+	var report rebuildReport
+
+	for i := range existing {
+		if reporter.IsCanceled() {
+			return rebuildReport{}, context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return rebuildReport{}, ctx.Err()
+		default:
+		}
+
+		old := existing[i]
+		if (i+1)%1000 == 0 {
+			_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Re-derived %d/%d…", i+1, len(existing)))
+		}
+
+		switch old.LabelSource {
+		case "human":
+			report.HumanCount++
+		case "rule":
+			ex, unlabelable, changed := p.rebuildRuleExample(adapter, old)
+			report.applyBucketResult(&report.Rule, "rule", old, ex, unlabelable, changed)
+		case "auto_high_conf":
+			ex, unlabelable, changed := p.rebuildAutoHighConfExample(adapter, old)
+			report.applyBucketResult(&report.Auto, "auto_high_conf", old, ex, unlabelable, changed)
+		default:
+			// Unlabeled backfill rows (LabelSource=="") and any unrecognized
+			// source are left entirely alone — out of scope for this op.
+			report.OtherCount++
+		}
+	}
+
+	return report, nil
+}
+
+// applyBucketResult records one rebuilt example's outcome into the given
+// bucket's stats, appends it to the fresh set (unless unlabelable), and
+// grows the bounded diff sample for changed/unlabelable rows.
+func (r *rebuildReport) applyBucketResult(bucket *rebuildBucketStats, source string, old, fresh database.LabeledExample, unlabelable, changed bool) {
+	bucket.Examined++
+	if unlabelable {
+		bucket.Unlabelable++
+		if len(r.Sample) < rebuildSampleLimit {
+			r.Sample = append(r.Sample, rebuildDiffSample{
+				CandidateID: old.CandidateID, Source: source, OldLabel: old.Label, Unlabelable: true,
+			})
+		}
+		return
+	}
+	if changed {
+		bucket.Changed++
+		if len(r.Sample) < rebuildSampleLimit {
+			r.Sample = append(r.Sample, rebuildDiffSample{
+				CandidateID: old.CandidateID, Source: source, OldLabel: old.Label, NewLabel: fresh.Label,
+			})
+		}
+	} else {
+		bucket.Unchanged++
+	}
+	switch fresh.Label {
+	case "true_dup":
+		bucket.NewTrueDup++
+	case "not_dup":
+		bucket.NewNotDup++
+	}
+	r.Fresh = append(r.Fresh, fresh)
 }
 
 // rebuildRuleExample re-derives a label_source="rule" example's label against

--- a/internal/plugins/dedup/rebuild_gold_labels.go
+++ b/internal/plugins/dedup/rebuild_gold_labels.go
@@ -1,0 +1,283 @@
+// file: internal/plugins/dedup/rebuild_gold_labels.go
+// version: 1.0.0
+// guid: 74b6de83-de1b-4231-8edc-6920a2f7b91c
+// last-edited: 2026-07-04
+
+// Package dedup — op dedup.rebuild-gold-labels.
+//
+// The dedup gold-label store (dedup:label:*) predates the bge-m3 re-embed
+// cutover and the CONS-16/17/FRAG candidate-quality fixes. This op wipes and
+// regenerates the mechanically-derived portion of the label set — the
+// label_source="rule" rows (dataset.Classify) and label_source="auto_high_conf"
+// rows (dataset.MineHighConfidenceDup) — against *current* candidate/book/
+// embedding state, while never touching label_source="human" rows (real
+// merge/dismiss decisions) or unlabeled rows (LabelSource=="", Label=="",
+// written by dedup.dataset-backfill for pairs no catcher fired on).
+//
+// Dry-run by default: for every existing rule/auto_high_conf example, re-derives
+// what label it would get today and reports a diff (changed / unchanged /
+// newly-unlabelable — candidate gone or the catcher no longer fires) plus a
+// pass-through count of human-labeled examples. Pass {"apply":true} to delete
+// all rule/auto_high_conf rows and reinsert the freshly computed set. Human
+// rows are never deleted or modified by either mode.
+//
+// Idempotent: apply computes the same fresh set from current state each run,
+// so a second apply run is a stable no-op (same counts, same rows).
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+type rebuildGoldLabelsParams struct {
+	// Apply, if true, deletes all rule/auto_high_conf sourced examples and
+	// reinserts the freshly computed set. Default false (dry-run/report only).
+	Apply bool `json:"apply"`
+}
+
+// rebuildBucketStats tallies the diff for one label_source bucket
+// (rule or auto_high_conf) across the rebuild pass.
+type rebuildBucketStats struct {
+	Examined    int
+	Unchanged   int
+	Changed     int
+	Unlabelable int // candidate gone, or the catcher no longer fires
+	NewTrueDup  int
+	NewNotDup   int
+}
+
+func (s rebuildBucketStats) String() string {
+	return fmt.Sprintf("examined=%d changed=%d unchanged=%d unlabelable=%d new_true_dup=%d new_not_dup=%d",
+		s.Examined, s.Changed, s.Unchanged, s.Unlabelable, s.NewTrueDup, s.NewNotDup)
+}
+
+func (p *Plugin) rebuildGoldLabelsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.rebuild-gold-labels",
+		Plugin:      "dedup",
+		DisplayName: "Rebuild mechanically-derived gold labels",
+		Description: "Re-derives label_source=rule and label_source=auto_high_conf gold labels against " +
+			"current candidate/book/embedding state and reports a changed/unchanged/unlabelable diff. " +
+			"Dry-run by default; pass apply=true to delete and reinsert the freshly computed rule/" +
+			"auto_high_conf rows. label_source=human rows are always passed through, never deleted or " +
+			"modified. Idempotent: re-running apply against unchanged state yields the same counts.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.rebuild-gold-labels",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runRebuildGoldLabels,
+	}
+}
+
+func (p *Plugin) runRebuildGoldLabels(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	var params rebuildGoldLabelsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	reporter.Logger().Info("rebuild-gold-labels start", "apply", params.Apply)
+
+	_ = reporter.UpdateProgress(0, 3, "Loading existing labeled examples…")
+	existing, err := p.embeddingStore.ListLabeledExamples(database.LabeledExampleFilter{Limit: 0})
+	if err != nil {
+		return fmt.Errorf("list labeled examples: %w", err)
+	}
+	reporter.Logger().Info("rebuild-gold-labels: existing examples loaded", "count", len(existing))
+
+	adapter := builderAdapter{store: p.store}
+
+	var (
+		ruleStats  rebuildBucketStats
+		autoStats  rebuildBucketStats
+		humanCount int
+		otherCount int // LabelSource=="" (unlabeled backfill rows) — untouched, counted for visibility
+		fresh      []database.LabeledExample
+	)
+
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Re-deriving %d existing examples…", len(existing)))
+	for i := range existing {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		old := existing[i]
+		if (i+1)%1000 == 0 {
+			_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Re-derived %d/%d…", i+1, len(existing)))
+		}
+
+		switch old.LabelSource {
+		case "human":
+			humanCount++
+			continue
+		case "rule":
+			ruleStats.Examined++
+			ex, unlabelable, changed := p.rebuildRuleExample(adapter, old)
+			if unlabelable {
+				ruleStats.Unlabelable++
+				continue
+			}
+			if changed {
+				ruleStats.Changed++
+			} else {
+				ruleStats.Unchanged++
+			}
+			switch ex.Label {
+			case "true_dup":
+				ruleStats.NewTrueDup++
+			case "not_dup":
+				ruleStats.NewNotDup++
+			}
+			fresh = append(fresh, ex)
+		case "auto_high_conf":
+			autoStats.Examined++
+			ex, unlabelable, changed := p.rebuildAutoHighConfExample(adapter, old)
+			if unlabelable {
+				autoStats.Unlabelable++
+				continue
+			}
+			if changed {
+				autoStats.Changed++
+			} else {
+				autoStats.Unchanged++
+			}
+			switch ex.Label {
+			case "true_dup":
+				autoStats.NewTrueDup++
+			case "not_dup":
+				autoStats.NewNotDup++
+			}
+			fresh = append(fresh, ex)
+		default:
+			// Unlabeled backfill rows (LabelSource=="") and any unrecognized
+			// source are left entirely alone — out of scope for this op.
+			otherCount++
+		}
+	}
+
+	reporter.Logger().Info("rebuild-gold-labels: rule bucket", "stats", ruleStats.String())
+	reporter.Logger().Info("rebuild-gold-labels: auto_high_conf bucket", "stats", autoStats.String())
+	reporter.Logger().Info("rebuild-gold-labels: pass-through", "human", humanCount, "other_untouched", otherCount)
+
+	summary := fmt.Sprintf(
+		"rule[%s] auto_high_conf[%s] human=%d(passthrough) other_untouched=%d",
+		ruleStats.String(), autoStats.String(), humanCount, otherCount,
+	)
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
+			"Dry-run — %d rule + %d auto_high_conf would change, %d would become unlabelable. %s. Pass apply=true to write.",
+			ruleStats.Changed, autoStats.Changed, ruleStats.Unlabelable+autoStats.Unlabelable, summary))
+		reporter.Logger().Info("rebuild-gold-labels: dry-run only; nothing written")
+		return nil
+	}
+
+	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf("Applying — deleting %d rule/auto_high_conf rows…", ruleStats.Examined+autoStats.Examined))
+	deleted, err := p.embeddingStore.DeleteLabeledExamplesBySource("rule", "auto_high_conf")
+	if err != nil {
+		return fmt.Errorf("delete rule/auto_high_conf examples: %w", err)
+	}
+	reporter.Logger().Info("rebuild-gold-labels: deleted stale mechanical labels", "deleted", deleted)
+
+	var written, writeErrs int
+	for _, ex := range fresh {
+		if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
+			writeErrs++
+			reporter.Logger().Error("rebuild-gold-labels: upsert error", "candidate_id", ex.CandidateID, "error", err)
+			continue
+		}
+		written++
+	}
+
+	_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
+		"Complete — deleted %d, wrote %d fresh (%d errors). %s", deleted, written, writeErrs, summary))
+	reporter.Logger().Info("rebuild-gold-labels complete", "deleted", deleted, "written", written, "write_errs", writeErrs, "summary", summary)
+	return nil
+}
+
+// rebuildRuleExample re-derives a label_source="rule" example's label against
+// current state by re-running dataset.Classify() on a freshly built
+// LabeledExample for the same candidate. Returns the fresh example, whether it
+// is now unlabelable (candidate gone or Classify no longer fires), and whether
+// the label changed relative to old.
+func (p *Plugin) rebuildRuleExample(adapter builderAdapter, old database.LabeledExample) (ex database.LabeledExample, unlabelable, changed bool) {
+	cand, err := p.embeddingStore.GetCandidateByID(old.CandidateID)
+	if err != nil || cand == nil {
+		return database.LabeledExample{}, true, false
+	}
+
+	fresh, err := dataset.BuildExample(adapter, *cand)
+	if err != nil {
+		return database.LabeledExample{}, true, false
+	}
+
+	label, reason, fires := dataset.Classify(fresh)
+	if !fires {
+		return database.LabeledExample{}, true, false
+	}
+
+	fresh.Label = label
+	fresh.LabelSource = "rule"
+	fresh.LabelReason = reason
+	fresh.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	return fresh, false, label != old.Label
+}
+
+// rebuildAutoHighConfExample re-derives a label_source="auto_high_conf"
+// example's label against current state by re-running
+// dataset.MineHighConfidenceDup() on the candidate's current books/files.
+// Returns the fresh example, whether it is now unlabelable (candidate gone or
+// the heuristic no longer fires), and whether the label changed.
+func (p *Plugin) rebuildAutoHighConfExample(adapter builderAdapter, old database.LabeledExample) (ex database.LabeledExample, unlabelable, changed bool) {
+	cand, err := p.embeddingStore.GetCandidateByID(old.CandidateID)
+	if err != nil || cand == nil {
+		return database.LabeledExample{}, true, false
+	}
+
+	a, aErr := adapter.GetBook(cand.EntityAID)
+	b, bErr := adapter.GetBook(cand.EntityBID)
+	if aErr != nil || bErr != nil || a == nil || b == nil {
+		return database.LabeledExample{}, true, false
+	}
+	aFiles, afErr := adapter.GetBookFiles(cand.EntityAID)
+	bFiles, bfErr := adapter.GetBookFiles(cand.EntityBID)
+	if afErr != nil || bfErr != nil {
+		return database.LabeledExample{}, true, false
+	}
+
+	label, reason, fires := dataset.MineHighConfidenceDup(a, b, aFiles, bFiles)
+	if !fires {
+		return database.LabeledExample{}, true, false
+	}
+
+	fresh, err := dataset.BuildExample(adapter, *cand)
+	if err != nil {
+		return database.LabeledExample{}, true, false
+	}
+	fresh.Label = label
+	fresh.LabelSource = "auto_high_conf"
+	fresh.LabelReason = reason
+	fresh.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	return fresh, false, label != old.Label
+}

--- a/internal/plugins/dedup/rebuild_gold_labels_test.go
+++ b/internal/plugins/dedup/rebuild_gold_labels_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/rebuild_gold_labels_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b8e5f14-6a37-4c92-9d05-3f7a8b1c6e40
 // last-edited: 2026-07-04
 
@@ -104,6 +104,122 @@ func TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged(t *testing.T) {
 	}
 }
 
+// TestRebuildGoldLabels_ComputeRebuildDiff_ReportCorrectness exercises
+// computeRebuildDiff directly (the pure diff core dry-run reports on) against
+// a fixture with one changed rule row, one unchanged rule row, and one
+// unlabelable rule row (orphaned candidate) — and asserts the exact stats,
+// not just "dry-run wrote nothing". This is the "dry-run diff report
+// correctness" test called for in PLAN.md; the log-only assertions in
+// TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged cannot catch a wrong
+// count because fakeReporter discards log output.
+func TestRebuildGoldLabels_ComputeRebuildDiff_ReportCorrectness(t *testing.T) {
+	pebble, es, p := rebuildFixture(t)
+
+	// Changed: stored true_dup, but missingFile fires not_dup today.
+	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-report-1")
+	changedCand := candidateID(t, es, noFiles, hasFiles)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: changedCand, EntityAID: noFiles, EntityBID: hasFiles,
+		Label: "true_dup", LabelSource: "rule", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed changed rule example: %v", err)
+	}
+
+	// Unchanged: already stored as the not_dup missingFile would produce today.
+	noFiles2 := createBookNoFiles(t, pebble, "Ghost2")
+	hasFiles2 := createBookWithHashedFile(t, pebble, "Real2", "hash-real-report-2")
+	unchangedCand := candidateID(t, es, noFiles2, hasFiles2)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: unchangedCand, EntityAID: noFiles2, EntityBID: hasFiles2,
+		Label: "not_dup", LabelSource: "rule", LabelReason: "side A has no resolvable files",
+	}); err != nil {
+		t.Fatalf("seed unchanged rule example: %v", err)
+	}
+
+	// Unlabelable: candidate ID no longer exists.
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: 424242, EntityAID: "gone-a", EntityBID: "gone-b",
+		Label: "true_dup", LabelSource: "rule", LabelReason: "orphaned",
+	}); err != nil {
+		t.Fatalf("seed orphaned rule example: %v", err)
+	}
+
+	// A human row and an unlabeled/other row must be counted as pass-through,
+	// not folded into the rule bucket.
+	humanA := createBookWithHashedFile(t, pebble, "HumanA", "hash-human-report-a")
+	humanB := createBookWithHashedFile(t, pebble, "HumanB", "hash-human-report-b")
+	humanCand := candidateID(t, es, humanA, humanB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: humanCand, EntityAID: humanA, EntityBID: humanB,
+		Label: "not_dup", LabelSource: "human",
+	}); err != nil {
+		t.Fatalf("seed human example: %v", err)
+	}
+	otherA := createBookWithHashedFile(t, pebble, "OtherA", "hash-other-report-a")
+	otherB := createBookWithHashedFile(t, pebble, "OtherB", "hash-other-report-b")
+	otherCand := candidateID(t, es, otherA, otherB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: otherCand, EntityAID: otherA, EntityBID: otherB,
+	}); err != nil {
+		t.Fatalf("seed unlabeled example: %v", err)
+	}
+
+	existing, err := es.ListLabeledExamples(database.LabeledExampleFilter{})
+	if err != nil {
+		t.Fatalf("ListLabeledExamples: %v", err)
+	}
+
+	report, err := p.computeRebuildDiff(context.Background(), &fakeReporter{}, existing)
+	if err != nil {
+		t.Fatalf("computeRebuildDiff: %v", err)
+	}
+
+	// Both the changed row (true_dup -> not_dup) and the unchanged row
+	// (already not_dup) resolve to not_dup today, so NewNotDup counts both.
+	want := rebuildBucketStats{Examined: 3, Changed: 1, Unchanged: 1, Unlabelable: 1, NewNotDup: 2}
+	if report.Rule != want {
+		t.Fatalf("Rule stats = %+v, want %+v", report.Rule, want)
+	}
+	if (report.Auto != rebuildBucketStats{}) {
+		t.Fatalf("Auto stats = %+v, want zero value (no auto_high_conf rows seeded)", report.Auto)
+	}
+	if report.HumanCount != 1 {
+		t.Fatalf("HumanCount = %d, want 1", report.HumanCount)
+	}
+	if report.OtherCount != 1 {
+		t.Fatalf("OtherCount = %d, want 1", report.OtherCount)
+	}
+	if len(report.Fresh) != 2 { // changed + unchanged rows carry forward; unlabelable does not
+		t.Fatalf("len(Fresh) = %d, want 2", len(report.Fresh))
+	}
+
+	// The sample must include the changed row's before/after and flag the
+	// orphaned row as unlabelable, so a reviewer can spot-check specific
+	// candidates from the report before applying.
+	var sawChanged, sawUnlabelable bool
+	for _, s := range report.Sample {
+		if s.CandidateID == changedCand {
+			sawChanged = true
+			if s.OldLabel != "true_dup" || s.NewLabel != "not_dup" || s.Unlabelable {
+				t.Errorf("changed sample = %+v, want old=true_dup new=not_dup unlabelable=false", s)
+			}
+		}
+		if s.CandidateID == 424242 {
+			sawUnlabelable = true
+			if !s.Unlabelable || s.NewLabel != "" {
+				t.Errorf("unlabelable sample = %+v, want unlabelable=true new_label=\"\"", s)
+			}
+		}
+	}
+	if !sawChanged {
+		t.Error("diff sample missing the changed candidate")
+	}
+	if !sawUnlabelable {
+		t.Error("diff sample missing the unlabelable candidate")
+	}
+}
+
 // TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther
 // verifies the apply path: rule/auto_high_conf rows are recomputed from
 // current state (stale labels corrected), human rows are passed through
@@ -156,8 +272,29 @@ func TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther
 		t.Fatalf("seed unlabeled example: %v", err)
 	}
 
+	// Orphaned rule row: candidate ID no longer exists. Unlabelable rows are
+	// dropped by apply (not reinserted), since the fresh set only contains
+	// rows a catcher still fires on.
+	const orphanedRuleCandID int64 = 777777
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: orphanedRuleCandID, EntityAID: "gone-a", EntityBID: "gone-b",
+		Label: "true_dup", LabelSource: "rule", LabelReason: "orphaned",
+	}); err != nil {
+		t.Fatalf("seed orphaned rule example: %v", err)
+	}
+
 	if err := p.runRebuildGoldLabels(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
 		t.Fatalf("runRebuildGoldLabels apply: %v", err)
+	}
+
+	// Orphaned rule row must be gone after apply — deleted with the rest of
+	// the stale rule bucket and never reinserted (no candidate to rebuild from).
+	orphanEx, err := es.GetLabeledExample(orphanedRuleCandID)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(orphaned): %v", err)
+	}
+	if orphanEx != nil {
+		t.Fatalf("orphaned/unlabelable row must be dropped by apply; got %+v", orphanEx)
 	}
 
 	// Rule row recomputed to not_dup.

--- a/internal/plugins/dedup/rebuild_gold_labels_test.go
+++ b/internal/plugins/dedup/rebuild_gold_labels_test.go
@@ -1,0 +1,258 @@
+// file: internal/plugins/dedup/rebuild_gold_labels_test.go
+// version: 1.0.0
+// guid: 2b8e5f14-6a37-4c92-9d05-3f7a8b1c6e40
+// last-edited: 2026-07-04
+
+// Tests for the dedup.rebuild-gold-labels op against a real PebbleStore +
+// EmbeddingStore: dry-run diff reporting (changed/unchanged/unlabelable),
+// apply wiping+reinserting rule/auto_high_conf while leaving human (and
+// unlabeled) rows untouched, and apply idempotency.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// createBookNoFiles creates a book with no BookFile records, so
+// dataset.Classify's missingFile catcher fires not_dup for any pair
+// involving it.
+func createBookNoFiles(t *testing.T, pebble *database.PebbleStore, title string) string {
+	t.Helper()
+	created, err := pebble.CreateBook(&database.Book{Title: title, FilePath: "/audio/" + title + ".m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	return created.ID
+}
+
+func rebuildFixture(t *testing.T) (*database.PebbleStore, *database.EmbeddingStore, *Plugin) {
+	t.Helper()
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+	p := &Plugin{store: pebble, embeddingStore: es}
+	return pebble, es, p
+}
+
+// TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged covers the rule bucket:
+// a stale label that no longer matches Classify's current verdict is reported
+// changed and left unwritten (dry-run); a label that already matches the
+// current verdict is reported unchanged.
+func TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged(t *testing.T) {
+	pebble, es, p := rebuildFixture(t)
+
+	// missingFile fires not_dup for any pair where one side has no files.
+	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-0001")
+	changedCand := candidateID(t, es, noFiles, hasFiles)
+
+	// Stale: stored as true_dup, but Classify would say not_dup today.
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: changedCand, EntityAID: noFiles, EntityBID: hasFiles,
+		Label: "true_dup", LabelSource: "rule", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed stale rule example: %v", err)
+	}
+
+	// Unchanged: another no-files pair, already stored as not_dup.
+	noFiles2 := createBookNoFiles(t, pebble, "Ghost2")
+	hasFiles2 := createBookWithHashedFile(t, pebble, "Real2", "hash-real-0002")
+	unchangedCand := candidateID(t, es, noFiles2, hasFiles2)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: unchangedCand, EntityAID: noFiles2, EntityBID: hasFiles2,
+		Label: "not_dup", LabelSource: "rule", LabelReason: "side A has no resolvable files",
+	}); err != nil {
+		t.Fatalf("seed unchanged rule example: %v", err)
+	}
+
+	// Unlabelable: a rule row pointing at a candidate ID that no longer exists.
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: 999999, EntityAID: "gone-a", EntityBID: "gone-b",
+		Label: "true_dup", LabelSource: "rule", LabelReason: "orphaned",
+	}); err != nil {
+		t.Fatalf("seed orphaned rule example: %v", err)
+	}
+
+	if err := p.runRebuildGoldLabels(context.Background(), json.RawMessage(`{}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runRebuildGoldLabels dry-run: %v", err)
+	}
+
+	// Dry-run must write nothing — all three seeded rows are untouched.
+	ex, err := es.GetLabeledExample(changedCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(changed): %v", err)
+	}
+	if ex == nil || ex.Label != "true_dup" {
+		t.Fatalf("dry-run must not mutate stored rows; got %+v", ex)
+	}
+	ex2, err := es.GetLabeledExample(unchangedCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(unchanged): %v", err)
+	}
+	if ex2 == nil || ex2.Label != "not_dup" {
+		t.Fatalf("dry-run must not mutate stored rows; got %+v", ex2)
+	}
+	ex3, err := es.GetLabeledExample(999999)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(orphaned): %v", err)
+	}
+	if ex3 == nil {
+		t.Fatal("dry-run must not delete stored rows")
+	}
+}
+
+// TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther
+// verifies the apply path: rule/auto_high_conf rows are recomputed from
+// current state (stale labels corrected), human rows are passed through
+// verbatim, and unlabeled (LabelSource=="") rows are left alone entirely.
+func TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther(t *testing.T) {
+	pebble, es, p := rebuildFixture(t)
+
+	// Rule bucket: stale true_dup that should become not_dup.
+	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-1111")
+	ruleCand := candidateID(t, es, noFiles, hasFiles)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: ruleCand, EntityAID: noFiles, EntityBID: hasFiles,
+		Label: "true_dup", LabelSource: "rule", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed rule example: %v", err)
+	}
+
+	// auto_high_conf bucket: stale not_dup that should become true_dup
+	// (shared file hash fires MineHighConfidenceDup).
+	dupA := createBookWithHashedFile(t, pebble, "MobyA", "sharedhash0000ff")
+	dupB := createBookWithHashedFile(t, pebble, "MobyB", "sharedhash0000ff")
+	autoCand := candidateID(t, es, dupA, dupB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: autoCand, EntityAID: dupA, EntityBID: dupB,
+		Label: "not_dup", LabelSource: "auto_high_conf", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed auto_high_conf example: %v", err)
+	}
+
+	// human bucket: must survive verbatim.
+	humanA := createBookWithHashedFile(t, pebble, "HumanA", "hash-human-a")
+	humanB := createBookWithHashedFile(t, pebble, "HumanB", "hash-human-b")
+	humanCand := candidateID(t, es, humanA, humanB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: humanCand, EntityAID: humanA, EntityBID: humanB,
+		Label: "not_dup", LabelSource: "human", LabelReason: "reviewer decided these are different works",
+	}); err != nil {
+		t.Fatalf("seed human example: %v", err)
+	}
+
+	// unlabeled/other bucket: LabelSource=="" (dataset-backfill "no catcher fired" row).
+	otherA := createBookWithHashedFile(t, pebble, "OtherA", "hash-other-a")
+	otherB := createBookWithHashedFile(t, pebble, "OtherB", "hash-other-b")
+	otherCand := candidateID(t, es, otherA, otherB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: otherCand, EntityAID: otherA, EntityBID: otherB,
+		Label: "", LabelSource: "", LabelReason: "",
+	}); err != nil {
+		t.Fatalf("seed unlabeled example: %v", err)
+	}
+
+	if err := p.runRebuildGoldLabels(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runRebuildGoldLabels apply: %v", err)
+	}
+
+	// Rule row recomputed to not_dup.
+	ruleEx, err := es.GetLabeledExample(ruleCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(rule): %v", err)
+	}
+	if ruleEx == nil || ruleEx.Label != "not_dup" || ruleEx.LabelSource != "rule" {
+		t.Fatalf("rule row: got %+v, want not_dup/rule", ruleEx)
+	}
+
+	// auto_high_conf row recomputed to true_dup.
+	autoEx, err := es.GetLabeledExample(autoCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(auto): %v", err)
+	}
+	if autoEx == nil || autoEx.Label != "true_dup" || autoEx.LabelSource != "auto_high_conf" {
+		t.Fatalf("auto_high_conf row: got %+v, want true_dup/auto_high_conf", autoEx)
+	}
+
+	// human row untouched byte-for-byte.
+	humanEx, err := es.GetLabeledExample(humanCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(human): %v", err)
+	}
+	if humanEx == nil || humanEx.Label != "not_dup" || humanEx.LabelSource != "human" ||
+		humanEx.LabelReason != "reviewer decided these are different works" {
+		t.Fatalf("human row must survive verbatim; got %+v", humanEx)
+	}
+
+	// unlabeled/other row untouched.
+	otherEx, err := es.GetLabeledExample(otherCand)
+	if err != nil {
+		t.Fatalf("GetLabeledExample(other): %v", err)
+	}
+	if otherEx == nil || otherEx.LabelSource != "" || otherEx.Label != "" {
+		t.Fatalf("unlabeled row must survive untouched; got %+v", otherEx)
+	}
+}
+
+// TestRebuildGoldLabels_Apply_Idempotent runs apply twice and checks the
+// second run produces the same label/source assignments as the first — the
+// rebuild is a pure function of current candidate/book state, so a repeat
+// apply must be a stable no-op in substance (DecidedAt timestamps aside).
+func TestRebuildGoldLabels_Apply_Idempotent(t *testing.T) {
+	pebble, es, p := rebuildFixture(t)
+
+	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-2222")
+	ruleCand := candidateID(t, es, noFiles, hasFiles)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: ruleCand, EntityAID: noFiles, EntityBID: hasFiles,
+		Label: "true_dup", LabelSource: "rule", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed rule example: %v", err)
+	}
+
+	dupA := createBookWithHashedFile(t, pebble, "MobyA", "sharedhash1111ff")
+	dupB := createBookWithHashedFile(t, pebble, "MobyB", "sharedhash1111ff")
+	autoCand := candidateID(t, es, dupA, dupB)
+	if err := es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: autoCand, EntityAID: dupA, EntityBID: dupB,
+		Label: "not_dup", LabelSource: "auto_high_conf", LabelReason: "stale",
+	}); err != nil {
+		t.Fatalf("seed auto_high_conf example: %v", err)
+	}
+
+	run := func() map[int64][2]string { // candidateID -> [label, source]
+		if err := p.runRebuildGoldLabels(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+			t.Fatalf("runRebuildGoldLabels apply: %v", err)
+		}
+		all, err := es.ListLabeledExamples(database.LabeledExampleFilter{})
+		if err != nil {
+			t.Fatalf("ListLabeledExamples: %v", err)
+		}
+		snap := make(map[int64][2]string, len(all))
+		for _, ex := range all {
+			snap[ex.CandidateID] = [2]string{ex.Label, ex.LabelSource}
+		}
+		return snap
+	}
+
+	first := run()
+	second := run()
+
+	if len(first) != len(second) {
+		t.Fatalf("row count changed across repeat apply: first=%d second=%d", len(first), len(second))
+	}
+	for id, want := range first {
+		got, ok := second[id]
+		if !ok {
+			t.Fatalf("candidate %d present in first apply but missing in second", id)
+		}
+		if got != want {
+			t.Fatalf("candidate %d: first=%v second=%v — apply is not idempotent", id, want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New op `dedup.rebuild-gold-labels`: re-derives `label_source="rule"` (`dataset.Classify`) and `label_source="auto_high_conf"` (`dataset.MineHighConfidenceDup`) gold labels against current candidate/book/embedding state.
- Dry-run by default; `apply=true` deletes+reinserts rule/auto_high_conf rows only. `label_source="human"` rows (3 in prod) and unlabeled backfill rows are always passed through untouched, never deleted.
- Idempotent: re-running apply against unchanged state yields stable counts.

## Scope note (important)
This is a **gold-label-quality fix only** — it drops stale mechanical labels that reference merged/deleted/non-primary books or catchers that no longer fire. It does **NOT** fix the `skipped_dim` embedding-staleness problem in `dedup.calibrate-embedding-thresholds` (prod: `skipped_dim=2841/5301`, stale `.Model`/dimension mismatches on stored embeddings). That calibration op does a live per-book embedding lookup, not a label snapshot, so label-side fixes can't touch it — confirmed by re-running calibration fresh on prod. Root-causing `skipped_dim` is separate, still-open work.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/plugins/dedup/... ./internal/database/...` clean
- [x] `go test ./internal/plugins/dedup/... ./internal/database/...` — all passing (3 new unit tests: dry-run diff correctness, apply wipe+reinsert with human/unlabeled preserved, apply idempotency)
- [ ] CI green
- [ ] Prod dry-run reviewed before any `apply=true` run (owner-gated)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1