### PR TITLE
fix(database): DeleteBook leaves orphaned stale-dimension embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.105.1 -->
+<!-- version: 3.106.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-04 -->
 
@@ -8,6 +8,41 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 4, 2026 - DeleteBook orphaned-embedding leak fix
+
+- **`fix(database)`** — `PebbleStore.DeleteBook` (`internal/database/pebble_store.go`)
+  now also deletes the book's embedding row (`emb:v:book:<id>`) inside the
+  same batch as the rest of the book-deletion cleanup. Previously it deleted
+  the book row, path index, version-group index, `metadata_state` rows, and
+  ISBN/ASIN index rows, but left the embedding row behind untouched. Since
+  `dedup.embed-scan` only ever iterates `GetAllBooks` — which by construction
+  never returns a deleted book — an orphaned embedding was never revisited or
+  re-embedded to a current model/dimension once its book was deleted (e.g. as
+  the "loser" side of a dedup merge/consolidate). This is likely a dominant
+  contributor to the `skipped_dim=2841` figure reported by
+  `dedup.calibrate-embedding-thresholds` (embedding present but wrong
+  `.Model`/dimension out of 5301 scored gold-label pairs), and is
+  directionally consistent with the `dedup.rebuild-gold-labels` dry-run
+  finding of 3,525/5,050 rule-sourced gold labels referencing candidates that
+  no longer exist — but this fix has **not** been verified end-to-end to
+  fully explain that count, and should be described as the likely dominant
+  contributor, not the sole cause. Confirmed (via grep across
+  `internal/dedup/engine.go`, `internal/dedup/book_dedup.go`,
+  `internal/dedup/split_book_merge.go`, `internal/merge/service.go`) that all
+  merge/consolidate "loser book" removal paths route through
+  `Store.DeleteBook` (directly, or via `merge.SoftDeleteBook`'s hard-delete
+  fallback), so this single fix covers those paths too — no separate
+  removal path needed its own patch. New test
+  `TestPebbleDeleteBook_RemovesEmbedding`
+  (`internal/database/pebble_store_test.go`) locks in the behavior: create a
+  book, upsert an embedding for it via `EmbeddingStore`, delete the book,
+  assert the embedding row is now gone.
+  - **Forward-only.** This does NOT retroactively clean up the (likely
+    thousands of) already-orphaned embedding rows left behind by historical
+    book deletions — that needs a separate, dry-run-gated maintenance/backfill
+    op and is explicitly out of scope here. Tracked as a follow-up in
+    TODO.md.
 
 #### July 4, 2026 - dedup gold-label rebuild op (dedup.rebuild-gold-labels)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.58.0 -->
+<!-- version: 9.59.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-04 -->
 
@@ -476,6 +476,34 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   New `EmbeddingStore.DeleteLabeledExamplesBySource` primitive. 3 unit tests.
   **Not yet run on prod** — dry-run first via `{"def_id":"dedup.rebuild-gold-labels","params":{}}`,
   review the diff, only then `apply=true` (owner greenlight).
+- [x] **C-orphan-embed / DeleteBook orphaned-embedding fix (2026-07-04)** —
+  `PebbleStore.DeleteBook` (`internal/database/pebble_store.go:1735`) deleted
+  the book row + path/version-group/metadata_state/ISBN/ASIN index rows but
+  never touched the book's embedding row (`emb:v:book:<id>`). Since
+  `dedup.embed-scan` only iterates `GetAllBooks`, a deleted book's embedding
+  was orphaned forever at its last model/dimension and never re-embedded.
+  This is **likely the dominant contributor** to the `skipped_dim` count
+  above (2,841/5,301) — directionally consistent with the rebuild-gold-labels
+  3,525/5,050-unlabelable finding — but is **not confirmed to be the sole
+  cause**; treat `skipped_dim` root-cause as still open until verified
+  post-deploy. Fix: delete `emb:v:book:<id>` in the same batch as the rest of
+  `DeleteBook`'s cleanup (atomic, no new `EmbeddingStore` plumbing). Verified
+  all merge/consolidate "loser book" removal paths (`internal/dedup/engine.go`,
+  `internal/dedup/book_dedup.go`, `internal/dedup/split_book_merge.go`,
+  `internal/merge/service.go`'s `SoftDeleteBook` hard-delete fallback) route
+  through `Store.DeleteBook`, so no separate path needs the same patch. New
+  test `TestPebbleDeleteBook_RemovesEmbedding`. **Forward-only** — does NOT
+  retroactively clean up already-orphaned embedding rows from historical
+  deletions; that needs its own dry-run-gated backfill/maintenance op
+  (tracked as a follow-up, not built here — see below).
+  - [ ] **Follow-up (not started):** dry-run-gated maintenance op to find and
+    purge/re-embed already-orphaned `emb:v:book:*` rows whose entity ID has
+    no corresponding live book (historical deletions predating this fix).
+    Needs its own brief — do not build ad hoc.
+  - [ ] **Follow-up (owner-gated, post-deploy):** re-run `dedup.embed-scan`
+    then `dedup.calibrate-embedding-thresholds` and confirm `skipped_dim`
+    trends down for newly-deleted books going forward (will NOT drop for
+    already-orphaned rows without the backfill op above).
 - [x] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path  ✅ shipped #1729 (agent-task sweep 2026-07-01)
   so each new candidate automatically gets a feature snapshot + deterministic label on
   creation (no separate backfill needed going forward).

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.102.0
+// version: 1.103.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-04
 
 package database
 
@@ -1793,6 +1793,21 @@ func (p *PebbleStore) DeleteBook(id string) error {
 			batch.Close()
 			return err
 		}
+	}
+
+	// Delete the book's embedding row (emb:v:book:<id>), if any. Without
+	// this, a deleted book's embedding is orphaned forever: dedup.embed-scan
+	// iterates GetAllBooks, which by construction never returns a deleted
+	// book, so the orphaned row is never revisited or re-embedded to a
+	// current model/dimension. This targets the same keyspace as
+	// EmbeddingStore.Delete("book", id) (see embVecKey in
+	// embedding_store.go); deleted directly in this batch for atomicity
+	// with the rest of the book removal rather than wiring in a separate
+	// EmbeddingStore dependency on PebbleStore.
+	embKey := []byte(embVecPfx + "book:" + id)
+	if err := batch.Delete(embKey, nil); err != nil {
+		batch.Close()
+		return err
 	}
 
 	if err := batch.Commit(pebble.Sync); err != nil {

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
 
 package database
@@ -176,6 +176,74 @@ func TestPebbleDeleteBook(t *testing.T) {
 	}
 	if deletedBook != nil {
 		t.Error("Expected book to be nil after deletion")
+	}
+}
+
+// TestPebbleDeleteBook_RemovesEmbedding locks in the fix for the orphaned-
+// embedding leak: DeleteBook must also delete the book's embedding row
+// (emb:v:book:<id>). Before this fix, deleting a book (e.g. the "loser" side
+// of a dedup merge) left its embedding behind forever at whatever
+// model/dimension it was last embedded with, since dedup.embed-scan only
+// ever iterates GetAllBooks and a deleted book never appears there again.
+func TestPebbleDeleteBook_RemovesEmbedding(t *testing.T) {
+	// Arrange
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	pebbleStore, ok := store.(*PebbleStore)
+	if !ok {
+		t.Fatalf("expected *PebbleStore, got %T", store)
+	}
+
+	book := &Book{
+		Title:    "Book With Embedding",
+		FilePath: "/test/path/embedded-book.mp3",
+	}
+	createdBook, err := store.CreateBook(book)
+	if err != nil {
+		t.Fatalf("Failed to create book: %v", err)
+	}
+
+	embStore := NewEmbeddingStore(pebbleStore.DB())
+	if err := embStore.Upsert(Embedding{
+		EntityType: "book",
+		EntityID:   createdBook.ID,
+		Vector:     []float32{0.1, 0.2, 0.3},
+		Model:      "text-embedding-3-large",
+	}); err != nil {
+		t.Fatalf("Failed to upsert embedding: %v", err)
+	}
+
+	// Sanity check: embedding is present before delete.
+	before, err := embStore.Get("book", createdBook.ID)
+	if err != nil {
+		t.Fatalf("Failed to get embedding before delete: %v", err)
+	}
+	if before == nil {
+		t.Fatal("Expected embedding to exist before DeleteBook")
+	}
+
+	// Act
+	if err := store.DeleteBook(createdBook.ID); err != nil {
+		t.Fatalf("Failed to delete book: %v", err)
+	}
+
+	// Assert - book row is gone
+	deletedBook, err := store.GetBookByID(createdBook.ID)
+	if err != nil {
+		t.Fatalf("Unexpected error when getting deleted book: %v", err)
+	}
+	if deletedBook != nil {
+		t.Error("Expected book to be nil after deletion")
+	}
+
+	// Assert - embedding row is gone too (the orphan-leak fix)
+	after, err := embStore.Get("book", createdBook.ID)
+	if err != nil {
+		t.Fatalf("Unexpected error when getting embedding after delete: %v", err)
+	}
+	if after != nil {
+		t.Error("Expected embedding to be deleted along with the book, but it still exists")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `PebbleStore.DeleteBook` deleted the book row, path index, version-group index, `metadata_state` rows, and ISBN/ASIN index rows — but never the book's embedding row (`emb:v:book:<id>`).
- Every book removed via merge/consolidate/purge left its embedding orphaned forever. `dedup.embed-scan` iterates `GetAllBooks`, which by construction never returns a deleted book, so the orphan is never revisited or re-embedded to the current model/dimension.
- Fix: delete the embedding key in the same batch as the rest of `DeleteBook`'s cleanup, for atomicity — no new `EmbeddingStore` dependency needed since it's the same underlying `*pebble.DB`.
- Confirmed all merge/consolidate "loser book" removal paths route through `DeleteBook` (directly or via `merge.SoftDeleteBook`'s hard-delete fallback) — this one fix covers all of them, no other path needs the same patch.

## Motivating evidence (not a proven full fix)
- `dedup.calibrate-embedding-thresholds` reports `skipped_dim=2841` of 5301 scored gold-label pairs (embedding present, wrong `.Model`/dimension).
- `dedup.rebuild-gold-labels` dry-run (run today) shows 3,525/5,050 rule-sourced gold labels reference candidates that no longer exist — consistent with orphaned-book embeddings being a major contributor.
- This fix is **forward-only**: it stops new orphans from being created going forward. It does **not** retroactively clean up embeddings already orphaned by historical deletions — that needs a separate dry-run-gated backfill op (tracked in TODO.md as a follow-up, not built here).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/database/...` clean
- [x] `go test ./internal/database/...` — all passing, including new `TestPebbleDeleteBook_RemovesEmbedding`
- [x] `go test ./internal/dedup/...` — all passing
- [ ] CI green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1