### PR TITLE
feat(dedup): retroactive orphaned-embedding cleanup op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.106.0 -->
+<!-- version: 3.107.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-04 -->
 
@@ -8,6 +8,34 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 4, 2026 - retroactive orphaned-embedding cleanup op (dedup.cleanup-orphan-embeddings)
+
+- **`feat(dedup)`** — new op `dedup.cleanup-orphan-embeddings`
+  (`internal/plugins/dedup/cleanup_orphan_embeddings.go`) is the retroactive
+  counterpart to PR #1802's `DeleteBook` fix. #1802 stopped *new* orphaned
+  `emb:v:book:<id>` rows from being created, but did nothing about rows
+  orphaned by book deletions (merges/purges) that happened before it landed —
+  those pre-existing orphans are the likely dominant cause of the
+  `dedup.calibrate-embedding-thresholds` `skipped_dim=2841` figure (out of
+  5301 scored gold-label pairs): the referenced book is gone, so nothing ever
+  revisits or re-embeds the stale row. The op walks every `emb:v:book:*` row
+  (via `EmbeddingStore.ListByType`, which already existed — no new database
+  iteration primitive needed) and checks `GetBookByID` for each entity ID.
+  Dry-run by default: reports orphaned/live/lookup-error counts and a bounded
+  10-row sample of orphaned entity IDs + their stored `.Model`, for a
+  reviewer to spot-check. `apply=true` deletes only rows confirmed orphaned
+  (`GetBookByID` returned nil) — a row whose book still exists is never
+  touched, regardless of that embedding's model/dimension; a live book's
+  stale-model embedding remains in scope for `dedup.embed-scan`/
+  `dedup.reembed-embeddings`, not this op. Idempotent: a second apply run
+  after a clean pass finds nothing left to delete. Registered in
+  `internal/plugins/dedup/plugin.go`. Tests in
+  `internal/plugins/dedup/cleanup_orphan_embeddings_test.go` cover dry-run
+  (no mutation), apply (deletes only orphans, leaves a live book's
+  wrong-model embedding untouched), and idempotency (second apply is a
+  no-op). Local code-build task only — dry-run has **not** been run against
+  prod as part of this change; that owner-gated run is a follow-up.
 
 #### July 4, 2026 - DeleteBook orphaned-embedding leak fix
 
@@ -41,8 +69,8 @@
   - **Forward-only.** This does NOT retroactively clean up the (likely
     thousands of) already-orphaned embedding rows left behind by historical
     book deletions — that needs a separate, dry-run-gated maintenance/backfill
-    op and is explicitly out of scope here. Tracked as a follow-up in
-    TODO.md.
+    op and is explicitly out of scope here. Addressed by
+    `dedup.cleanup-orphan-embeddings` below (same day).
 
 #### July 4, 2026 - dedup gold-label rebuild op (dedup.rebuild-gold-labels)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.59.0 -->
+<!-- version: 9.60.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-04 -->
 
@@ -496,14 +496,25 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
   retroactively clean up already-orphaned embedding rows from historical
   deletions; that needs its own dry-run-gated backfill/maintenance op
   (tracked as a follow-up, not built here — see below).
-  - [ ] **Follow-up (not started):** dry-run-gated maintenance op to find and
-    purge/re-embed already-orphaned `emb:v:book:*` rows whose entity ID has
-    no corresponding live book (historical deletions predating this fix).
-    Needs its own brief — do not build ad hoc.
-  - [ ] **Follow-up (owner-gated, post-deploy):** re-run `dedup.embed-scan`
-    then `dedup.calibrate-embedding-thresholds` and confirm `skipped_dim`
-    trends down for newly-deleted books going forward (will NOT drop for
-    already-orphaned rows without the backfill op above).
+  - [x] **Follow-up built (2026-07-04):** `dedup.cleanup-orphan-embeddings`
+    (`internal/plugins/dedup/cleanup_orphan_embeddings.go`) — dry-run-gated
+    op that walks every `emb:v:book:*` row via the existing
+    `EmbeddingStore.ListByType("book")` (no new DB primitive needed), checks
+    `GetBookByID` per entity ID, and reports orphaned/live/lookup-error
+    counts + a bounded 10-row sample of orphaned IDs + `.Model`. `apply=true`
+    deletes only confirmed-orphaned rows; a live book's embedding is never
+    touched regardless of model (that's `dedup.embed-scan`/
+    `dedup.reembed-embeddings` territory, explicitly out of scope here).
+    Idempotent (second apply finds 0 orphans). 5 unit tests in
+    `internal/plugins/dedup/cleanup_orphan_embeddings_test.go`. **Not yet run
+    on prod** — dry-run first via
+    `{"def_id":"dedup.cleanup-orphan-embeddings","params":{}}`, review the
+    sample, only then `apply=true` (owner greenlight).
+  - [ ] **Follow-up (owner-gated, post-deploy):** run
+    `dedup.cleanup-orphan-embeddings` dry-run on prod, review, apply; then
+    re-run `dedup.embed-scan` and `dedup.calibrate-embedding-thresholds` and
+    confirm `skipped_dim` trends down (both from #1802 stopping new orphans
+    AND from this op clearing pre-existing ones).
 - [x] **C5** Live-capture: wire `BuildExample` + `Classify` into the candidate-upsert path  ✅ shipped #1729 (agent-task sweep 2026-07-01)
   so each new candidate automatically gets a feature snapshot + deterministic label on
   creation (no separate backfill needed going forward).

--- a/internal/plugins/dedup/cleanup_orphan_embeddings.go
+++ b/internal/plugins/dedup/cleanup_orphan_embeddings.go
@@ -1,0 +1,219 @@
+// file: internal/plugins/dedup/cleanup_orphan_embeddings.go
+// version: 1.0.0
+// guid: 9be49561-c03e-484c-ae53-723bbe299ebe
+// last-edited: 2026-07-04
+
+// Package dedup — op dedup.cleanup-orphan-embeddings.
+//
+// PR #1802 fixed PebbleStore.DeleteBook to also delete a book's embedding row
+// (emb:v:book:<id>) as part of the same batch that removes the book itself —
+// but that fix is forward-only. It stops NEW orphans from being created; it
+// does nothing about embeddings orphaned by book deletions that happened
+// BEFORE the fix landed (merges/purges over the project's history). Those
+// pre-existing orphans are the likely dominant cause of the
+// `dedup.calibrate-embedding-thresholds` `skipped_dim=2841` figure (out of
+// 5301 scored gold-label pairs) — the referenced book is gone, so nothing
+// ever revisits or re-embeds the stale row to the current model/dimension.
+//
+// This op is the retroactive counterpart to #1802: it walks every
+// `emb:v:book:*` row and, for each, checks whether GetBookByID still resolves
+// the entity ID to a live book.
+//
+//   - Dry-run (default): reports orphaned vs. live counts and a bounded sample
+//     of orphaned entity IDs + their stored .Model, for a reviewer to
+//     spot-check before applying.
+//   - Apply (apply=true): deletes ONLY the rows confirmed orphaned (GetBookByID
+//     returned nil). A row whose book still exists is NEVER touched by this
+//     op, regardless of that embedding's model/dimension — a live book's
+//     stale-model embedding is in scope for dedup.embed-scan/reembed-embeddings,
+//     not this cleanup op.
+//
+// Idempotent: apply only ever deletes rows it can currently prove orphaned, so
+// a second apply run finds nothing left to delete.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// cleanupOrphanSampleLimit bounds how many orphaned entity IDs are captured
+// for the report sample, mirroring rebuild-gold-labels' bounded diff sample.
+const cleanupOrphanSampleLimit = 10
+
+// cleanupOrphanEmbeddingsParams are the JSON parameters accepted by the op.
+type cleanupOrphanEmbeddingsParams struct {
+	// Apply, if true, deletes rows confirmed orphaned (book no longer exists).
+	// Default false (dry-run/report only).
+	Apply bool `json:"apply"`
+}
+
+// cleanupOrphanSample is one orphaned row surfaced in the report sample, so a
+// reviewer can spot-check specific entity IDs before applying.
+type cleanupOrphanSample struct {
+	EntityID string
+	Model    string
+}
+
+// cleanupOrphanReport is the full result of scanning emb:v:book:* rows:
+// total/orphaned/live counts and a bounded sample of orphaned rows. OrphanIDs
+// holds every orphaned entity ID found (not just the sample) so apply can
+// delete them without a second scan pass.
+type cleanupOrphanReport struct {
+	Total     int
+	Orphaned  int
+	Live      int
+	LookupErr int // GetBookByID returned an error; row skipped, never touched
+	Sample    []cleanupOrphanSample
+	OrphanIDs []string
+}
+
+func (r cleanupOrphanReport) summary() string {
+	return fmt.Sprintf("total=%d orphaned=%d live=%d lookup_errors=%d", r.Total, r.Orphaned, r.Live, r.LookupErr)
+}
+
+// cleanupOrphanEmbeddingsDef returns the OperationDef for
+// dedup.cleanup-orphan-embeddings.
+func (p *Plugin) cleanupOrphanEmbeddingsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.cleanup-orphan-embeddings",
+		Plugin:      "dedup",
+		DisplayName: "Clean up orphaned book embeddings",
+		Description: "Retroactive counterpart to PR #1802's DeleteBook fix: finds emb:v:book:* rows " +
+			"whose referenced book no longer exists (deleted before #1802 stopped new orphans from " +
+			"being created) and reports them. Dry-run by default; pass apply=true to delete only the " +
+			"confirmed-orphaned rows. A row whose book still exists is never touched by this op, " +
+			"regardless of that embedding's model/dimension. Idempotent: re-running apply after a " +
+			"clean pass finds nothing left to delete.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.cleanup-orphan-embeddings",
+		Cancellable:     true,
+		Timeout:         30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runCleanupOrphanEmbeddings,
+	}
+}
+
+// runCleanupOrphanEmbeddings implements the cleanup-orphan-embeddings op.
+func (p *Plugin) runCleanupOrphanEmbeddings(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	var params cleanupOrphanEmbeddingsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	reporter.Logger().Info("cleanup-orphan-embeddings start", "apply", params.Apply)
+
+	_ = reporter.UpdateProgress(0, 2, "Listing book embeddings…")
+	embeddings, err := p.embeddingStore.ListByType("book")
+	if err != nil {
+		return fmt.Errorf("list book embeddings: %w", err)
+	}
+	reporter.Logger().Info("cleanup-orphan-embeddings: embeddings loaded", "count", len(embeddings))
+
+	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Checking %d embeddings against live books…", len(embeddings)))
+	report, err := p.scanOrphanEmbeddings(ctx, reporter, embeddings)
+	if err != nil {
+		return err
+	}
+
+	reporter.Logger().Info("cleanup-orphan-embeddings: scan complete", "stats", report.summary())
+	for _, s := range report.Sample {
+		reporter.Logger().Info("cleanup-orphan-embeddings: sample orphan", "entity_id", s.EntityID, "model", s.Model)
+	}
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(2, 2, fmt.Sprintf(
+			"Dry-run — %d orphaned book embeddings found (%d live, %d lookup errors, %d total). Pass apply=true to delete.",
+			report.Orphaned, report.Live, report.LookupErr, report.Total))
+		reporter.Logger().Info("cleanup-orphan-embeddings: dry-run only; nothing deleted")
+		return nil
+	}
+
+	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Applying — deleting %d orphaned embeddings…", len(report.OrphanIDs)))
+	var deleted, deleteErrs int
+	for _, id := range report.OrphanIDs {
+		if reporter.IsCanceled() {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if err := p.embeddingStore.Delete("book", id); err != nil {
+			deleteErrs++
+			reporter.Logger().Error("cleanup-orphan-embeddings: delete error", "entity_id", id, "error", err)
+			continue
+		}
+		deleted++
+	}
+
+	_ = reporter.UpdateProgress(2, 2, fmt.Sprintf(
+		"Complete — deleted %d/%d orphaned embeddings (%d errors). %s",
+		deleted, len(report.OrphanIDs), deleteErrs, report.summary()))
+	reporter.Logger().Info("cleanup-orphan-embeddings complete",
+		"deleted", deleted, "delete_errs", deleteErrs, "summary", report.summary())
+	return nil
+}
+
+// scanOrphanEmbeddings is the pure(ish) core of the op: for every given
+// embedding it checks whether GetBookByID still resolves the entity ID to a
+// live book, and returns the full report — counts, a bounded sample, and the
+// complete list of orphaned entity IDs ready for apply to delete. Split out
+// from runCleanupOrphanEmbeddings so the scan itself (the deliverable of
+// dry-run) is directly unit-testable. The only side effect is reads
+// (GetBookByID) — no writes happen here.
+func (p *Plugin) scanOrphanEmbeddings(ctx context.Context, reporter sdk.Reporter, embeddings []database.Embedding) (cleanupOrphanReport, error) {
+	var report cleanupOrphanReport
+
+	for i := range embeddings {
+		if reporter.IsCanceled() {
+			return cleanupOrphanReport{}, context.Canceled
+		}
+		select {
+		case <-ctx.Done():
+			return cleanupOrphanReport{}, ctx.Err()
+		default:
+		}
+
+		e := embeddings[i]
+		report.Total++
+		if (i+1)%1000 == 0 {
+			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Checked %d/%d…", i+1, len(embeddings)))
+		}
+
+		book, err := p.store.GetBookByID(e.EntityID)
+		if err != nil {
+			report.LookupErr++
+			reporter.Logger().Warn("cleanup-orphan-embeddings: GetBookByID error; skipping (leaving row untouched)",
+				"entity_id", e.EntityID, "error", err)
+			continue
+		}
+		if book != nil {
+			report.Live++
+			continue
+		}
+
+		report.Orphaned++
+		report.OrphanIDs = append(report.OrphanIDs, e.EntityID)
+		if len(report.Sample) < cleanupOrphanSampleLimit {
+			report.Sample = append(report.Sample, cleanupOrphanSample{EntityID: e.EntityID, Model: e.Model})
+		}
+	}
+
+	return report, nil
+}

--- a/internal/plugins/dedup/cleanup_orphan_embeddings_test.go
+++ b/internal/plugins/dedup/cleanup_orphan_embeddings_test.go
@@ -1,0 +1,186 @@
+// file: internal/plugins/dedup/cleanup_orphan_embeddings_test.go
+// version: 1.0.0
+// guid: a53bc26a-3ecb-4aab-bef8-d6e76c174cd7
+// last-edited: 2026-07-04
+
+// Tests for the dedup.cleanup-orphan-embeddings op (retroactive counterpart to
+// PR #1802's DeleteBook fix).
+//
+// These wire an in-memory EmbeddingStore + MockStore (no real Engine needed —
+// the op only reads embeddings and looks up books), then exercise the op
+// wrapper: dry-run reports correct orphan/live counts without mutating,
+// apply deletes only orphaned rows and leaves live-book embeddings untouched
+// (including ones with a "wrong" model — out of scope for this op), and a
+// second apply run is idempotent (finds nothing left to delete).
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupOrphanMockStore returns a MockStore whose GetBookByID resolves only
+// the given live book IDs; any other ID returns (nil, nil) — the "book gone"
+// signal the op relies on.
+func cleanupOrphanMockStore(liveIDs ...string) *database.MockStore {
+	books := make(map[string]*database.Book, len(liveIDs))
+	for _, id := range liveIDs {
+		books[id] = &database.Book{ID: id, Title: "Live Book " + id}
+	}
+	return &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return books[id], nil
+		},
+	}
+}
+
+// seedEmbedding upserts a book embedding with the given entity ID and model.
+func seedEmbedding(t *testing.T, es *database.EmbeddingStore, entityID, model string) {
+	t.Helper()
+	require.NoError(t, es.Upsert(database.Embedding{
+		EntityType: "book",
+		EntityID:   entityID,
+		Model:      model,
+		Vector:     []float32{0.1, 0.2, 0.3},
+	}))
+}
+
+// TestCleanupOrphanEmbeddingsOp_Metadata asserts the OperationDef shape.
+func TestCleanupOrphanEmbeddingsOp_Metadata(t *testing.T) {
+	p := &Plugin{}
+	def := p.cleanupOrphanEmbeddingsDef()
+	assert.Equal(t, "dedup.cleanup-orphan-embeddings", def.ID)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryRead)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryWrite)
+
+	var params cleanupOrphanEmbeddingsParams
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &params))
+	assert.False(t, params.Apply, "apply must default to false")
+}
+
+// TestCleanupOrphanEmbeddingsOp_DryRunReportsCountsWithoutMutating asserts
+// dry-run correctly classifies orphaned vs. live embeddings and writes
+// nothing to the store.
+func TestCleanupOrphanEmbeddingsOp_DryRunReportsCountsWithoutMutating(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanMockStore("book-live-1", "book-live-2")
+
+	seedEmbedding(t, es, "book-live-1", "bge-m3")
+	seedEmbedding(t, es, "book-live-2", "text-embedding-3-large") // "wrong" model, but book is live
+	seedEmbedding(t, es, "book-gone-1", "text-embedding-3-large")
+	seedEmbedding(t, es, "book-gone-2", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanEmbeddingsParams{Apply: false})
+	require.NoError(t, err)
+	require.NoError(t, p.runCleanupOrphanEmbeddings(context.Background(), params, &mockReporter{}))
+
+	// Dry-run must not mutate: all 4 embeddings still present.
+	all, err := es.ListByType("book")
+	require.NoError(t, err)
+	assert.Len(t, all, 4, "dry-run must not delete any embedding")
+}
+
+// TestCleanupOrphanEmbeddingsOp_ScanClassifiesCorrectly directly exercises the
+// scan core to assert exact orphan/live counts and the sample contents.
+func TestCleanupOrphanEmbeddingsOp_ScanClassifiesCorrectly(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanMockStore("book-live-1", "book-live-2")
+
+	seedEmbedding(t, es, "book-live-1", "bge-m3")
+	seedEmbedding(t, es, "book-live-2", "text-embedding-3-large")
+	seedEmbedding(t, es, "book-gone-1", "text-embedding-3-large")
+	seedEmbedding(t, es, "book-gone-2", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	embeddings, err := es.ListByType("book")
+	require.NoError(t, err)
+
+	report, err := p.scanOrphanEmbeddings(context.Background(), &mockReporter{}, embeddings)
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, report.Total)
+	assert.Equal(t, 2, report.Orphaned)
+	assert.Equal(t, 2, report.Live)
+	assert.Equal(t, 0, report.LookupErr)
+	assert.ElementsMatch(t, []string{"book-gone-1", "book-gone-2"}, report.OrphanIDs)
+}
+
+// TestCleanupOrphanEmbeddingsOp_ApplyDeletesOnlyOrphans asserts apply=true
+// deletes only the rows whose book is confirmed gone, leaving live-book
+// embeddings — including one with a "wrong" model — untouched.
+func TestCleanupOrphanEmbeddingsOp_ApplyDeletesOnlyOrphans(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanMockStore("book-live-1", "book-live-2")
+
+	seedEmbedding(t, es, "book-live-1", "bge-m3")
+	seedEmbedding(t, es, "book-live-2", "text-embedding-3-large") // stale model, but out of scope: book is live
+	seedEmbedding(t, es, "book-gone-1", "text-embedding-3-large")
+	seedEmbedding(t, es, "book-gone-2", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanEmbeddingsParams{Apply: true})
+	require.NoError(t, err)
+	require.NoError(t, p.runCleanupOrphanEmbeddings(context.Background(), params, &mockReporter{}))
+
+	remaining, err := es.ListByType("book")
+	require.NoError(t, err)
+	require.Len(t, remaining, 2, "only the two orphaned rows should be deleted")
+
+	ids := make([]string, 0, len(remaining))
+	for _, e := range remaining {
+		ids = append(ids, e.EntityID)
+	}
+	assert.ElementsMatch(t, []string{"book-live-1", "book-live-2"}, ids)
+
+	// The live book with a "wrong" model must be untouched — model-aware
+	// re-embed is out of scope for this op.
+	live2, err := es.Get("book", "book-live-2")
+	require.NoError(t, err)
+	require.NotNil(t, live2)
+	assert.Equal(t, "text-embedding-3-large", live2.Model)
+
+	// Orphaned rows are gone.
+	gone1, err := es.Get("book", "book-gone-1")
+	require.NoError(t, err)
+	assert.Nil(t, gone1)
+	gone2, err := es.Get("book", "book-gone-2")
+	require.NoError(t, err)
+	assert.Nil(t, gone2)
+}
+
+// TestCleanupOrphanEmbeddingsOp_ApplyTwiceIsIdempotent asserts a second apply
+// run after a clean pass finds nothing left to delete.
+func TestCleanupOrphanEmbeddingsOp_ApplyTwiceIsIdempotent(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanMockStore("book-live-1")
+
+	seedEmbedding(t, es, "book-live-1", "bge-m3")
+	seedEmbedding(t, es, "book-gone-1", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanEmbeddingsParams{Apply: true})
+	require.NoError(t, err)
+
+	// First apply deletes the one orphan.
+	require.NoError(t, p.runCleanupOrphanEmbeddings(context.Background(), params, &mockReporter{}))
+	remaining, err := es.ListByType("book")
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "book-live-1", remaining[0].EntityID)
+
+	// Second apply against the now-clean store must be a no-op — nothing left
+	// to delete, and the live embedding is still present.
+	require.NoError(t, p.runCleanupOrphanEmbeddings(context.Background(), params, &mockReporter{}))
+	remaining, err = es.ListByType("book")
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "book-live-1", remaining[0].EntityID)
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-07-04
 
@@ -77,6 +77,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.buildISBNIndexDef(),               // T022: ISBN/ASIN secondary index backfill
 		p.reembedEmbeddingsDef(),            // Part B: re-embed corpus when the embedding model changes
 		p.autoResolveDef(),                  // TASK-17: Tier-1 CERTAIN auto-merge (dry-run default, kill-switch gated)
+		p.cleanupOrphanEmbeddingsDef(),      // retroactive counterpart to #1802: deletes emb:v:book:* rows whose book is gone
 	}
 
 	for _, op := range ops {


### PR DESCRIPTION
## Summary
- Retroactive counterpart to #1802's forward-only `DeleteBook` fix.
- New op `dedup.cleanup-orphan-embeddings`: walks all `emb:v:book:*` rows, checks each against `GetBookByID`, reports orphaned/live/lookup-error counts + a bounded sample.
- `apply=true` deletes ONLY rows confirmed orphaned (book gone). A live book's embedding is never touched by this op regardless of model/dimension — that's `dedup.embed-scan`'s job, not this one's.
- Dry-run by default, idempotent apply, same review-gate convention as `dedup.rebuild-gold-labels` (#1800).

## Motivating evidence
- `dedup.calibrate-embedding-thresholds` reports `skipped_dim=2841/5301` — embedding present, wrong `.Model`/dimension.
- These are books that were deleted (merges/purges) before #1802 landed, so their embeddings were never cleaned up and `embed_scan` can never revisit them (it iterates `GetAllBooks`, which never returns a deleted book).

## Scope note
This PR is dry-run-capability only — no prod apply happens as part of shipping this code. Running `apply=true` on prod stays gated for explicit owner review of the dry-run output first.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/plugins/dedup/... ./internal/database/...` clean
- [x] `go test` on both packages — 5 new tests (dry-run no-mutate, orphan/live/sample classification, apply deletes only orphans incl. leaving a live wrong-model embedding untouched, apply-twice idempotency)
- [ ] CI green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1