### PR TITLE
feat(dedup): progress + ETA for FullScan's silent unified-scoring pass

### DIFF
--- a/internal/dedup/backfill_progress.go
+++ b/internal/dedup/backfill_progress.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/backfill_progress.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-f2a3-b4c5-d6e7f8a9b0c1
+// last-edited: 2026-07-04
 
 package dedup
 
@@ -22,7 +23,7 @@ const BackfillVersionMarker = "embedding_backfill_v5_done"
 
 // NewDedupScanProgressLogger returns a progress callback suitable for
 // Engine.FullScan that logs once every `interval` books processed (plus
-// one final line at completion).
+// one final line at completion), per phase.
 //
 // It exists because FullScan passes `done = i+1` at a step of 10, so values
 // are 1, 11, 21, ... which never satisfy `done % interval == 0` for interval
@@ -30,14 +31,29 @@ const BackfillVersionMarker = "embedding_backfill_v5_done"
 // the next threshold internally and advances past it on each bucket crossing,
 // so progress lines appear at ~interval granularity regardless of the caller's
 // step size.
-func NewDedupScanProgressLogger(interval int, logf func(format string, args ...any)) func(done, total int) {
+//
+// FullScan now reports two phases — "scan" (Layer 1/2 exact + embedding
+// checks) and "score" (unified composite scoring) — each of which iterates
+// over all books independently. The bucket-crossing state (nextLog) is reset
+// whenever the phase changes so the second phase doesn't inherit the first
+// phase's already-advanced threshold and go silent for its own first
+// `interval` books.
+func NewDedupScanProgressLogger(interval int, logf func(format string, args ...any)) func(phase string, done, total int) {
 	if interval <= 0 {
 		interval = 1
 	}
 	nextLog := interval
-	return func(done, total int) {
+	lastPhase := ""
+	return func(phase string, done, total int) {
+		if phase != lastPhase {
+			if lastPhase != "" {
+				logf("[INFO] Dedup scan phase %q complete, starting phase %q", lastPhase, phase)
+			}
+			lastPhase = phase
+			nextLog = interval
+		}
 		if done >= nextLog || (total > 0 && done == total) {
-			logf("[INFO] Dedup scan progress: %d/%d", done, total)
+			logf("[INFO] Dedup scan progress (%s): %d/%d", phase, done, total)
 			for nextLog <= done {
 				nextLog += interval
 			}

--- a/internal/dedup/backfill_progress_test.go
+++ b/internal/dedup/backfill_progress_test.go
@@ -1,10 +1,12 @@
 // file: internal/dedup/backfill_progress_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b8c9d0-e1f2-a3b4-c5d6-e7f8a9b0c1d2
+// last-edited: 2026-07-04
 
 package dedup
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -17,19 +19,19 @@ func TestNewDedupScanProgressLoggerLogsAtIntervals(t *testing.T) {
 	progressFn := NewDedupScanProgressLogger(10, logf)
 
 	// At done=10, should log
-	progressFn(10, 100)
+	progressFn("scan", 10, 100)
 	if len(logs) != 1 {
 		t.Errorf("expected 1 log at done=10, got %d", len(logs))
 	}
 
 	// At done=15, no new log
-	progressFn(15, 100)
+	progressFn("scan", 15, 100)
 	if len(logs) != 1 {
 		t.Errorf("expected no new log at done=15, got %d total logs", len(logs))
 	}
 
 	// At done=20, should log
-	progressFn(20, 100)
+	progressFn("scan", 20, 100)
 	if len(logs) != 2 {
 		t.Errorf("expected 2 logs at done=20, got %d", len(logs))
 	}
@@ -44,9 +46,52 @@ func TestNewDedupScanProgressLoggerCompletion(t *testing.T) {
 	progressFn := NewDedupScanProgressLogger(100, logf)
 
 	// At total=100, done=100, should log completion
-	progressFn(100, 100)
+	progressFn("scan", 100, 100)
 	if len(logs) != 1 {
 		t.Errorf("expected 1 log at completion, got %d", len(logs))
+	}
+}
+
+// TestNewDedupScanProgressLoggerPhaseTransitionResetsBucket verifies the
+// bucket-crossing threshold resets when the phase changes, so the "score"
+// phase (which FullScan now reports after previously reporting nothing at
+// all) gets its own full interval of silence budget instead of inheriting
+// the "scan" phase's already-advanced threshold and staying silent for its
+// own first `interval` books.
+func TestNewDedupScanProgressLoggerPhaseTransitionResetsBucket(t *testing.T) {
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}
+
+	progressFn := NewDedupScanProgressLogger(10, logf)
+
+	// Drive the "scan" phase to completion (done=total=20): should log once
+	// at the bucket crossing (10) and once at completion (20).
+	progressFn("scan", 10, 20)
+	progressFn("scan", 20, 20)
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs after scan phase, got %d: %v", len(logs), logs)
+	}
+
+	// Transition to "score": done=10 should log again immediately (a phase
+	// transition log for "scan"->"score", then the score phase's own
+	// bucket-10 crossing) even though done=10 was already logged in the
+	// "scan" phase. If the bucket state weren't reset, done=10 for "score"
+	// would never fire (nextLog would already be at 20+ from "scan").
+	progressFn("score", 10, 20)
+	if len(logs) < 3 {
+		t.Fatalf("expected at least 3 logs after phase transition, got %d: %v", len(logs), logs)
+	}
+	last := logs[len(logs)-1]
+	if last != "[INFO] Dedup scan progress (score): 10/20" {
+		t.Errorf("expected score-phase bucket log, got %q", last)
+	}
+
+	progressFn("score", 20, 20)
+	lastLog := logs[len(logs)-1]
+	if lastLog != "[INFO] Dedup scan progress (score): 20/20" {
+		t.Errorf("expected score-phase completion log, got %q", lastLog)
 	}
 }
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.44.1
+// version: 1.45.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-03
+// last-edited: 2026-07-04
 
 package dedup
 
@@ -2390,15 +2390,20 @@ func (de *Engine) deleteBookFromChromem(ctx context.Context, bookID string) {
 }
 
 // FullScan re-embeds stale entities and runs both Layer 1 (exact) and
-// Layer 2 (embedding) dedup checks for every primary book in the library.
-// The progress callback is invoked periodically with (done, total).
+// Layer 2 (embedding) dedup checks for every primary book in the library,
+// followed by a second pass that composes the unified score for every book.
+// The progress callback is invoked periodically with (phase, done, total).
+// phase is "scan" during the Layer 1/2 pass and "score" during the unified
+// composite-scoring pass — the two phases each iterate over all books, so
+// callers should treat them as independent 0..total progressions rather than
+// summing them.
 //
 // Layer 1 used to only run on ingest and metadata-apply events, which meant
 // the `exact` bucket stayed at zero for libraries that hadn't seen new books
 // since the initial backfill. Running it inside FullScan populates the
 // bucket with the hash/ISBN/near-title-match candidates that were always
 // there but never surfaced.
-func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) error {
+func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done, total int)) error {
 	_, span := dedupTracer.Start(ctx, "dedup.full_scan")
 	defer span.End()
 
@@ -2522,7 +2527,7 @@ func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) 
 		}
 
 		if progress != nil && (i%10 == 0 || i == total-1) {
-			progress(i+1, total)
+			progress("scan", i+1, total)
 		}
 	}
 
@@ -2544,7 +2549,8 @@ func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) 
 	// runUnifiedScoringForBook) may not have run yet for a given book when we
 	// are still iterating the book loop above.  Running the scoring pass after
 	// flushChunk(total) guarantees all embedding candidates are written.
-	for _, book := range books {
+	scoreTotal := len(books)
+	for i, book := range books {
 		if ctx.Err() != nil {
 			break
 		}
@@ -2556,6 +2562,10 @@ func (de *Engine) FullScan(ctx context.Context, progress func(done, total int)) 
 		}
 		if err := de.runUnifiedScoringForBook(ctx, &book, authorName); err != nil {
 			slog.Error("dedup full scan unified scoring error for", "book", book.ID, "err", err)
+		}
+
+		if progress != nil && (i%10 == 0 || i == scoreTotal-1) {
+			progress("score", i+1, scoreTotal)
 		}
 	}
 

--- a/internal/plugins/dedup/full_scan.go
+++ b/internal/plugins/dedup/full_scan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/full_scan.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-10
+// last-edited: 2026-07-04
 
 // T018: full_scan.go enforces phase ordering for the full dedup scan:
 //
@@ -34,6 +34,35 @@ import (
 // (SQLite, mocks) that do not carry an LSH index should return false.
 type LSHFlagStore interface {
 	IsLSHIndexBuilt() bool
+}
+
+// etaSuffix renders a rough "(N.N books/sec, ~T remaining)" suffix for a
+// progress message, computed from how long the phase has been running and
+// how many of its items are done. It exists to answer "give us an ETA" for
+// the previously-silent unified-scoring pass, which can run for tens of
+// minutes on a large library with zero other feedback. Returns "" until at
+// least one item has completed (rate is undefined at done==0) or if elapsed
+// time is effectively zero (avoids a divide-by-near-zero rate spike right
+// after Start).
+func etaSuffix(phaseStart time.Time, done, total int) string {
+	if done <= 0 || phaseStart.IsZero() {
+		return ""
+	}
+	elapsed := time.Since(phaseStart)
+	if elapsed <= 0 {
+		return ""
+	}
+	rate := float64(done) / elapsed.Seconds()
+	if rate <= 0 {
+		return ""
+	}
+	remaining := total - done
+	if remaining < 0 {
+		remaining = 0
+	}
+	etaSeconds := float64(remaining) / rate
+	eta := time.Duration(etaSeconds * float64(time.Second))
+	return fmt.Sprintf(" (%.1f books/sec, ~%s remaining)", rate, eta.Round(time.Second))
 }
 
 func (p *Plugin) fullScanDef() sdk.OperationDef {
@@ -72,19 +101,43 @@ func (p *Plugin) runFullScan(ctx context.Context, _ json.RawMessage, reporter sd
 		reporter.Logger().Info("purged stale candidates before scan", "count", deleted)
 	}
 
-	// Phase 2 — Index: run exact + embedding collectors for every primary book.
-	// FullScan reports progress via a callback (done, total). Build the real
-	// Progress on the first callback once we know N.
-	var prog *sdk.Progress
-	fullScanErr := p.engine.FullScan(ctx, func(done, total int) {
+	// Phase 2 — Index + score: run exact + embedding collectors for every
+	// primary book ("scan" phase), then compose the unified score for every
+	// book ("score" phase). FullScan reports progress via a callback
+	// (phase, done, total) — both phases iterate over all books and used to
+	// report independently, but the "score" phase previously reported
+	// nothing at all, leaving the operation log silent for the CPU-heavy
+	// composite-scoring pass (observed: 25+ minutes silent on a ~29K-book
+	// library). Build a separate *sdk.Progress tracker per phase, lazily on
+	// that phase's first callback, same pattern as the original single
+	// tracker.
+	var (
+		prog      *sdk.Progress
+		scoreProg *sdk.Progress
+
+		scanStart  time.Time
+		scoreStart time.Time
+	)
+	fullScanErr := p.engine.FullScan(ctx, func(phase string, done, total int) {
 		if total <= 0 {
 			return
 		}
-		if prog == nil {
-			prog = sdk.NewProgress(reporter, total)
-			prog.Start(fmt.Sprintf("Scanning books: 0 / %d", total))
+		switch phase {
+		case "scan":
+			if prog == nil {
+				prog = sdk.NewProgress(reporter, total)
+				prog.Start(fmt.Sprintf("Scanning books: 0 / %d", total))
+				scanStart = time.Now()
+			}
+			prog.StepN(done, fmt.Sprintf("Scanning books: %d / %d%s", done, total, etaSuffix(scanStart, done, total)))
+		case "score":
+			if scoreProg == nil {
+				scoreProg = sdk.NewProgress(reporter, total)
+				scoreProg.Start(fmt.Sprintf("Composing scores: 0 / %d", total))
+				scoreStart = time.Now()
+			}
+			scoreProg.StepN(done, fmt.Sprintf("Composing scores: %d / %d%s", done, total, etaSuffix(scoreStart, done, total)))
 		}
-		prog.StepN(done, fmt.Sprintf("Scanning books: %d / %d", done, total))
 	})
 	if fullScanErr != nil {
 		reporter.Logger().Error("FullScan error", "error", fullScanErr)
@@ -95,6 +148,12 @@ func (p *Plugin) runFullScan(ctx context.Context, _ json.RawMessage, reporter sd
 		prog = sdk.NewProgress(reporter, 0)
 		prog.Start("Scanning books: 0 / 0")
 	}
+	if scoreProg == nil {
+		scoreProg = sdk.NewProgress(reporter, 0)
+		scoreProg.Start("Composing scores: 0 / 0")
+	}
+	scoreProg.Finalize("scoring complete")
+	scoreProg.Done("Composing scores complete")
 
 	// Phase 3 — LSH candidates: assert that the LSH index has been built
 	// before the engine's CollectLSHAcoustID collector runs. The collector

--- a/internal/plugins/dedup/full_scan_test.go
+++ b/internal/plugins/dedup/full_scan_test.go
@@ -1,0 +1,167 @@
+// file: internal/plugins/dedup/full_scan_test.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-49c0-b1d2-e3f4a5b6c7d8
+// last-edited: 2026-07-04
+
+// Tests for the dedup.full-scan op's dual-phase progress reporting.
+//
+// Context: Engine.FullScan runs two full passes over every book — a
+// "scan" pass (Layer 1 exact + Layer 2 embedding checks) and a "score" pass
+// (unified composite scoring). The "score" pass used to report progress
+// zero times, leaving the operation log silent for however long the
+// CPU-heavy scoring pass took (observed: 25+ minutes on a ~29K-book
+// library, 100% CPU, zero log output). These tests confirm both phases now
+// report progress through their own sdk.Progress tracker, and that the
+// progress messages carry a rate/ETA suffix.
+
+package dedup
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingReporter is a mockReporter that also records every
+// UpdateProgress message, so tests can assert on phase-tagged progress
+// text without needing a real operation-log backend.
+type recordingReporter struct {
+	mockReporter
+	messages []string
+}
+
+func (r *recordingReporter) UpdateProgress(current, total int, message string) error {
+	r.messages = append(r.messages, message)
+	return nil
+}
+
+// fullScanMockStore builds a MockStore with n primary books that have no
+// AuthorID, FileHash, or ISBN/ASIN — every Layer 1 exact-match check
+// (checkExactFileHash aside, which still calls GetBookFiles) short-circuits
+// immediately, and runUnifiedScoringForBook returns nil immediately because
+// there are no pending embedding candidates. This keeps the test fast and
+// deterministic while still exercising both of FullScan's real loops.
+func fullScanMockStore(n int) *database.MockStore {
+	primary := true
+	books := make([]database.Book, n)
+	for i := range books {
+		books[i] = database.Book{
+			ID:               "book-" + string(rune('a'+i%26)) + string(rune('0'+i/26)),
+			Title:            "Untitled",
+			IsPrimaryVersion: &primary,
+		}
+	}
+	return &database.MockStore{
+		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			return books, nil
+		},
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return nil, nil
+		},
+	}
+}
+
+// TestRunFullScan_ReportsBothPhasesDistinctly verifies that runFullScan
+// drives two separate progress trackers — one for the "scan" phase
+// (Layer 1/2) and one for the "score" phase (unified composite scoring) —
+// and that both surface distinct, phase-labeled messages culminating in
+// their own completion lines, ending with the overall "Dedup scan
+// complete" finisher.
+func TestRunFullScan_ReportsBothPhasesDistinctly(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := fullScanMockStore(25) // > 10 so the every-10th cadence fires mid-scan
+	eng := dedupengine.NewEngine(es, ms, nil, nil, merge.NewService(ms))
+
+	p := &Plugin{engine: eng, store: ms, embeddingStore: es}
+	reporter := &recordingReporter{}
+
+	err := p.runFullScan(context.Background(), nil, reporter)
+	require.NoError(t, err)
+
+	var scanMsgs, scoreMsgs []string
+	for _, m := range reporter.messages {
+		switch {
+		case strings.Contains(m, "Scanning books"):
+			scanMsgs = append(scanMsgs, m)
+		case strings.Contains(m, "Composing scores"):
+			scoreMsgs = append(scoreMsgs, m)
+		}
+	}
+
+	if len(scanMsgs) == 0 {
+		t.Fatal("expected at least one 'Scanning books' progress message")
+	}
+	if len(scoreMsgs) == 0 {
+		t.Fatal("expected at least one 'Composing scores' progress message — this is the previously-silent phase")
+	}
+
+	// At least one message per phase (after the first, which has no
+	// elapsed time to compute a rate from) should carry the rate/ETA
+	// suffix so operators get a rough completion estimate.
+	hasETA := func(msgs []string) bool {
+		for _, m := range msgs {
+			if strings.Contains(m, "books/sec") && strings.Contains(m, "remaining") {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasETA(scanMsgs) {
+		t.Errorf("expected at least one 'scan' phase message with a books/sec ETA suffix, got: %v", scanMsgs)
+	}
+	if !hasETA(scoreMsgs) {
+		t.Errorf("expected at least one 'score' phase message with a books/sec ETA suffix, got: %v", scoreMsgs)
+	}
+
+	// The score phase's own completion line must appear (distinct from the
+	// scan phase's "Scanning books: N / N" line), followed by the overall
+	// finisher.
+	foundScoreComplete := false
+	foundOverallComplete := false
+	for _, m := range reporter.messages {
+		if strings.Contains(m, "Composing scores complete") {
+			foundScoreComplete = true
+		}
+		if strings.Contains(m, "Dedup scan complete") {
+			foundOverallComplete = true
+		}
+	}
+	if !foundScoreComplete {
+		t.Error("expected a 'Composing scores complete' message for the score phase")
+	}
+	if !foundOverallComplete {
+		t.Error("expected the overall 'Dedup scan complete' finisher message")
+	}
+}
+
+// TestRunFullScan_EmptyLibraryStillReportsBothTrackers verifies that even
+// with zero books (FullScan's progress callback never fires because
+// total<=0 guards it), runFullScan still creates both the "scan" and
+// "score" fallback trackers so the op doesn't panic on a nil *sdk.Progress
+// and still emits a completion message.
+func TestRunFullScan_EmptyLibraryStillReportsBothTrackers(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := fullScanMockStore(0)
+	eng := dedupengine.NewEngine(es, ms, nil, nil, merge.NewService(ms))
+
+	p := &Plugin{engine: eng, store: ms, embeddingStore: es}
+	reporter := &recordingReporter{}
+
+	err := p.runFullScan(context.Background(), nil, reporter)
+	require.NoError(t, err)
+
+	foundOverallComplete := false
+	for _, m := range reporter.messages {
+		if strings.Contains(m, "Dedup scan complete") {
+			foundOverallComplete = true
+		}
+	}
+	if !foundOverallComplete {
+		t.Error("expected the overall 'Dedup scan complete' finisher message even for an empty library")
+	}
+}

--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,6 +1,7 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
+// last-edited: 2026-07-04
 
 package server
 
@@ -180,6 +181,6 @@ func (s *Server) runEmbeddingBackfill() {
 }
 
 // newDedupScanProgressLogger is a thin wrapper around the domain implementation.
-func newDedupScanProgressLogger(interval int, logf func(format string, args ...any)) func(done, total int) {
+func newDedupScanProgressLogger(interval int, logf func(format string, args ...any)) func(phase string, done, total int) {
 	return dedup.NewDedupScanProgressLogger(interval, logf)
 }

--- a/internal/server/embedding_backfill_test.go
+++ b/internal/server/embedding_backfill_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/embedding_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f81c2ae-6b39-47d5-9ae1-3c5d8b12f7a4
+// last-edited: 2026-07-04
 
 package server
 
@@ -21,11 +22,12 @@ func TestDedupScanProgressLogger_BucketCrossings(t *testing.T) {
 
 	progress := newDedupScanProgressLogger(1000, logf)
 
-	// Simulate FullScan calling progress(i+1, total) on every i where i%10 == 0.
+	// Simulate FullScan calling progress("scan", i+1, total) on every i where
+	// i%10 == 0.
 	const total = 2500
 	for i := 0; i < total; i++ {
 		if i%10 == 0 || i == total-1 {
-			progress(i+1, total)
+			progress("scan", i+1, total)
 		}
 	}
 
@@ -36,14 +38,14 @@ func TestDedupScanProgressLogger_BucketCrossings(t *testing.T) {
 		t.Fatalf("expected %d log lines, got %d: %v", want, got, lines)
 	}
 	// First two should be at bucket crossings near 1000 and 2000.
-	if lines[0] != "[INFO] Dedup scan progress: 1001/2500" {
+	if lines[0] != "[INFO] Dedup scan progress (scan): 1001/2500" {
 		t.Errorf("first log line = %q", lines[0])
 	}
-	if lines[1] != "[INFO] Dedup scan progress: 2001/2500" {
+	if lines[1] != "[INFO] Dedup scan progress (scan): 2001/2500" {
 		t.Errorf("second log line = %q", lines[1])
 	}
 	// Last one is the completion line.
-	if lines[2] != "[INFO] Dedup scan progress: 2500/2500" {
+	if lines[2] != "[INFO] Dedup scan progress (scan): 2500/2500" {
 		t.Errorf("final log line = %q", lines[2])
 	}
 }
@@ -60,7 +62,7 @@ func TestDedupScanProgressLogger_EveryItem(t *testing.T) {
 
 	const total = 350
 	for i := 0; i < total; i++ {
-		progress(i+1, total)
+		progress("scan", i+1, total)
 	}
 
 	// Expected: one log line at each of done=100, 200, 300, and the completion
@@ -81,14 +83,14 @@ func TestDedupScanProgressLogger_SmallTotal(t *testing.T) {
 	const total = 42
 	for i := 0; i < total; i++ {
 		if i%10 == 0 || i == total-1 {
-			progress(i+1, total)
+			progress("scan", i+1, total)
 		}
 	}
 
 	if len(lines) != 1 {
 		t.Fatalf("expected 1 log line (completion only), got %d: %v", len(lines), lines)
 	}
-	if lines[0] != "[INFO] Dedup scan progress: 42/42" {
+	if lines[0] != "[INFO] Dedup scan progress (scan): 42/42" {
 		t.Errorf("completion line = %q", lines[0])
 	}
 }
@@ -103,7 +105,7 @@ func TestDedupScanProgressLogger_NonPositiveInterval(t *testing.T) {
 		count++
 	})
 	for i := 0; i < 5; i++ {
-		progress(i+1, 5)
+		progress("scan", i+1, 5)
 	}
 	if count != 5 {
 		t.Errorf("interval=0 should log every call; got %d calls", count)


### PR DESCRIPTION
## Summary
- `Engine.FullScan` runs two full passes over every book: "scan" (Layer 1/2 exact + embedding) then "score" (unified composite scoring). The score pass reported zero progress — confirmed tonight, a real `dedup.full-scan` on prod went silent for 25+ minutes at 100% CPU after the scan phase hit 100%.
- Changes the progress callback signature to `func(phase string, done, total int)` (`"scan"`/`"score"`), so both phases report independently (they're not additive — each iterates all books).
- `dedup.full-scan`'s op builds a separate `sdk.Progress` tracker per phase and appends a rough ETA (`"N.N books/sec, ~T remaining"`) to both phases' messages.
- Updates `NewDedupScanProgressLogger` + its `embedding_backfill.go` caller to the new signature, preserving existing bucket-crossing cadence.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/dedup/... ./internal/plugins/dedup/... ./internal/server/...` clean
- [x] `go test` on all three packages — clean (note: an initial run hit a 10-minute default-timeout FAIL on `internal/server` under heavy local machine load from unrelated concurrent work; reran isolated with `-timeout 20m` → `ok 774.191s`, and confirmed the same package passes identically on unmodified `origin/main` — this was a load-related timeout artifact, not a regression from this change)
- [ ] CI green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1