### PR TITLE
fix(ci): skip redundant release-time go vet blocked on missing GOEXPERIMENT

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.8.3
+# version: 4.9.0
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-# last-edited: 2026-07-03
+# last-edited: 2026-07-05
 
 name: Production Release
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # v2.13.4
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a0b07902d63eb6d732290805181fb02da6ad4fbf # v2.14.0 (go-run-linters passthrough)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false
@@ -54,5 +54,9 @@ jobs:
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'
+      # gha-release-go's lint step doesn't set GOEXPERIMENT from go-experiment,
+      # so go vet fails on jsonv2 imports even though ci.yml already vetted
+      # this commit correctly. Skip until fixed upstream in gha-release-go.
+      go-run-linters: false
       previous-version: ${{ github.event.inputs.previous-version }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,27 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.108.0 -->
+<!-- version: 3.109.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-04 -->
+<!-- last-edited: 2026-07-05 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 5, 2026 - fix(release): unblock Production Release job stuck on missing GOEXPERIMENT in release-time go vet
+
+- **`fix(ci)`** — `release-prod.yml`'s Go build job started failing on
+  `go vet ./...` with `imports encoding/json/v2: build constraints exclude
+  all Go files`, even though `ci.yml`/`codeql.yml` vet the same commit
+  successfully. Root cause: `gha-release-go`'s "Run linters" step never
+  forwards its `go-experiment` input into `GOEXPERIMENT`, only the tag-push
+  and GoReleaser steps do — so `run-linters: true` (its default) always vets
+  without the experiment flag this repo requires. `falkcorp/github-common`
+  PR #314 adds a `go-run-linters` passthrough input to
+  `reusable-release.yml`; this repo now sets `go-run-linters: false` and
+  bumps the pin to that merge commit. Release-time linting was redundant
+  with `ci.yml` anyway. Root cause in `gha-release-go` itself is still open.
 
 #### July 4, 2026 - calibration observability: best-achieved precision + high-cosine not_dup sample (dedup.calibrate-embedding-thresholds)
 


### PR DESCRIPTION
## Summary
- `release-prod.yml`'s Go build job fails `go vet ./...` with `imports encoding/json/v2: build constraints exclude all Go files` — `gha-release-go`'s "Run linters" step never forwards its `go-experiment` input into `GOEXPERIMENT`, only the tag-push and GoReleaser steps do, so `go vet` always runs without `jsonv2` even though `ci.yml`/`codeql.yml` vet the same commit correctly.
- Bumps the `reusable-release.yml` pin to `falkcorp/github-common@a0b0790` (merged [#314](https://github.com/falkcorp/github-common/pull/314), which adds a `go-run-linters` passthrough input) and sets `go-run-linters: false` here — release-time linting was redundant with `ci.yml` anyway.
- Root cause (missing `GOEXPERIMENT` in `gha-release-go`'s lint/test steps) is still open upstream; this is a scoped workaround to unblock releases now.

## Test plan
- [ ] Merge, then `workflow_dispatch` a Production Release run and confirm the Go build job passes past the linters step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT