### PR TITLE
docs(plan): concurrency-parallelization planning package (CONC-1..15)

### DIFF
--- a/docs/agent-tasks/BREAKDOWN-2026-07-05.md
+++ b/docs/agent-tasks/BREAKDOWN-2026-07-05.md
@@ -1,0 +1,130 @@
+<!-- file: docs/agent-tasks/BREAKDOWN-2026-07-05.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: acf0805f-ce46-43e0-a822-0155831aab4f -->
+<!-- last-edited: 2026-07-05 -->
+
+# Agent-Task Breakdown & Fan-Out Plan — 2026-07-05
+
+Turns the approved concurrency-parallelization spec (`docs/specs/2026-07-05-concurrency-parallelization-design.md`) into
+weak-model-proof agent briefs plus a fan-out strategy. See
+[`ORCHESTRATION.md`](ORCHESTRATION.md) (coordinator + workers, dependency waves).
+
+## Method
+
+Every task was verified against the current codebase during planning (6 read-only
+scouts re-ran every anchor at HEAD — the audit's line numbers had drifted), then
+sorted into three buckets. **Only Bucket 1 becomes agent briefs.**
+
+---
+
+## Bucket 1 — Authored as agent briefs (15 tasks, 5 workstreams)
+
+### ⚠️ Same-file collision rule (drives wave ordering)
+
+| Shared file | Tasks that touch it | Resolution |
+|-------------|---------------------|------------|
+| `internal/dedup/engine.go` | TASK-01, TASK-02, TASK-03, TASK-04 | serialize: wave1=TASK-01, wave2=TASK-02, wave3=TASK-03, wave4=TASK-04 |
+| `internal/itunes/service/importer.go` | TASK-01, TASK-02 | serialize: wave1=TASK-01, wave2=TASK-02 |
+
+All other files are touched by exactly one task → those workstreams run their tasks
+in a single parallel wave.
+
+### WS-1 — dedup-engine (backend) · maps to CONC-1, CONC-2, CONC-3, CONC-4
+
+| Task | Src id | Title | Tier | Why tier | Wave |
+|------|--------|-------|------|----------|------|
+| TASK-01 | CONC-1 | Shard BookSignatureScan's O(n²) pairwise loop across a bounded worker pool | **Opus-class** | O(n²) hot path; sharding must guard the emitted map + DB write without changing dedup output — highest-risk change in the package. | 1 |
+| TASK-02 | CONC-2 | Parallelize FullScan's unified-scoring pass with a bounded worker pool | **Sonnet-class** | Confirmed prod bottleneck; per-item independent but touches shared stores — logic + store-safety judgment. | 2 |
+| TASK-03 | CONC-3 | Parallelize AcoustIDScan's per-book loop with a bounded pool and guard its four shared maps | **Sonnet-class** | Four unguarded shared maps + a counter to guard correctly under a pool — easy to introduce a data race. | 3 |
+| TASK-04 | CONC-4 | Parallelize FullScan main-pass Layer-1 checks while keeping Layer-2 embedding batching serial | **Sonnet-class** | Must split parallel Layer-1 from serial Layer-2 circuit-breaker state — design-adjacent, not mechanical. | 4 |
+
+Execution mode: SERIAL WAVES (coordinator-driven) — trigger: all four tasks edit internal/dedup/engine.go (collision table row 1); wave N+1 starts only after wave N merges and siblings rebase.
+### WS-2 — backfill-pools (backend) · maps to CONC-5, CONC-6, CONC-7, CONC-8
+
+| Task | Src id | Title | Tier | Why tier | Wave |
+|------|--------|-------|------|----------|------|
+| TASK-01 | CONC-5 | Parallelize dedup.embed-scan sync path with a rate-limited worker pool | **Sonnet-class** | Network-bound; concurrency must respect the embedding backend rate limit, not NumCPU. | 1 |
+| TASK-02 | CONC-6 | Parallelize the startup embedding backfill loops over books and authors | **Sonnet-class** | Two startup loops, network rate-limited; integration with the startup path Reporter. | 1 |
+| TASK-03 | CONC-7 | Parallelize the tag-backfill ExtractMetadata loop with a CPU-sized pool | **Sonnet-class** | Straightforward pool but I/O sizing + Reporter wiring warrant Sonnet. | 1 |
+| TASK-04 | CONC-8 | Add book-lookup memoization then parallelize mine_gold_labels and dataset_backfill | **Sonnet-class** | Adds memoization AND a pool with a shared-cache guarding decision. | 1 |
+
+Execution mode: /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+### WS-3 — acoustid-consolidation (backend) · maps to CONC-9
+
+| Task | Src id | Title | Tier | Why tier | Wave |
+|------|--------|-------|------|----------|------|
+| TASK-01 | CONC-9 | Delete the serial server-side AcoustID backfill and route startup to the parallel plugin op | **Opus-class** | Delete/redirect a code path with caller wiring + a possibly-shared helper — dangling-reference risk. | 1 |
+
+Execution mode: SINGLE-AGENT (strong model) — trigger: judgment work (delete/redirect a code path with caller wiring + a shared helper to check); ⚠ review-critical, coordinator line-review before merge.
+### WS-4 — itunes-import (backend) · maps to CONC-10, CONC-11
+
+| Task | Src id | Title | Tier | Why tier | Wave |
+|------|--------|-------|------|----------|------|
+| TASK-01 | CONC-10 | Parallelize organizeImportedBooks file-organize + UpdateBook over imported books | **Sonnet-class** | File-move parallelism must ensure no two books resolve to the same target path. | 1 |
+| TASK-02 | CONC-11 | Parallelize enrichImportedBooks metadata fetch with a bounded pool preserving the rate-limit circuit-breaker | **Sonnet-class** | Circuit-breaker semantics must survive parallelization — reframe 'consecutive' as a shared atomic. | 2 |
+
+Execution mode: SERIAL WAVES (coordinator-driven) — trigger: both tasks edit internal/itunes/service/importer.go (collision table row 2); enrich (TASK-02) serializes after organize (TASK-01).
+### WS-5 — bulk-ops-pools (backend) · maps to CONC-12, CONC-13, CONC-14, CONC-15
+
+| Task | Src id | Title | Tier | Why tier | Wave |
+|------|--------|-------|------|----------|------|
+| TASK-01 | CONC-12 | Parallelize bulkFetchMetadataImpl over req.BookIDs with a conservative request-scoped pool | **Sonnet-class** | Request-scoped; conservative sizing to avoid starving the server / tripping the source rate limit. | 1 |
+| TASK-02 | CONC-13 | Parallelize BatchUpdateMetadata and ImportMetadata per-item DB round-trips | **Sonnet-class** | Two request-driven loops in one file with guarded result aggregation. | 1 |
+| TASK-03 | CONC-14 | Parallelize the duration-backfill per-book GetBookFiles loop | **Haiku-class** | Mechanical mirror of the other backfill pools; fully specified. | 1 |
+| TASK-04 | CONC-15 | Parallelize the itunes path-reconcile per-book GetBookFiles loop | **Haiku-class** | Mechanical mirror of TASK-03; fully specified. | 1 |
+
+Execution mode: /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+
+### Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+---
+
+## Bucket 2 — NOT briefs: needs brainstorm/design first
+
+| Item | Why it needs design first |
+|------|---------------------------|
+| CONC-B2-1 — AutoResolveCertain (internal/dedup/auto_resolve.go:112) | Per-candidate MergeBooks; a naive pool could double-merge one book across two pairs processed concurrently in the same run. Needs a partition-by-disjoint-book-ID-set redesign, not a blind fan-out (fix-pattern #3). Design session first. |
+| CONC-B2-2 — applyRegroupPlan (internal/plugins/maintenance/itunes_regroup.go:244) | Sequential DB writes over shared book/PID state; likely intentionally serialized to keep PID reassignment consistent. Confirm the ordering invariant before touching — could be correct as-is (fix-pattern #3). |
+
+---
+
+## Bucket 3 — NOT tasks: operational / low-value (no brief)
+
+CONC-B3-1 (PurgeStaleCandidates) · CONC-B3-2 (One-time migrations/backfills).
+
+---
+
+## Cost / efficiency strategy (fan-out)
+
+- **Tier split:** Haiku-class for the two mechanical N+1 mirrors (WS-5/T03–T04);
+  Sonnet-class for the logic/integration tasks; Opus-class for the two ⚠
+  review-critical ones (WS-1/T01 O(n²) sharding, WS-3/T01 delete-redirect).
+- **Coordinator owns git/gh:** workers stay in their worktree and report done; only
+  the coordinator merges + rebases siblings (protocol above).
+- **Waves respect the collision table** — WS-1's four `engine.go` tasks and WS-4's two
+  `importer.go` tasks serialize; every other workstream is one parallel wave.
+- **Cheapest-first across workstreams:** all 5 workstreams touch disjoint files, so
+  the whole package can run concurrently; rank orders them by value when capacity is
+  limited (WS-1 first — the confirmed prod incident).
+- **Every task ships a `-race` test** proving identical output to the serial version;
+  a green `make ci` without the race test is not a pass for this initiative.

--- a/docs/agent-tasks/acoustid-consolidation/README.md
+++ b/docs/agent-tasks/acoustid-consolidation/README.md
@@ -1,0 +1,37 @@
+<!-- file: docs/agent-tasks/acoustid-consolidation/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 19cfbd09-ff52-4e17-a607-d9fa1fc14c61 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — acoustid backfill consolidation
+
+Delete the serial server-side AcoustID backfill duplicate and route startup fingerprinting to the already-parallel plugin op. From `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` and the design spec `docs/specs/2026-07-05-concurrency-parallelization-design.md`.
+
+**Execution mode:** SINGLE-AGENT (strong model) — trigger: judgment work (delete/redirect a code path with caller wiring + a shared helper to check); ⚠ review-critical, coordinator line-review before merge.
+
+| Task | Src id | Title | Priority | Effort | Tier | Wave |
+|------|--------|-------|----------|--------|------|------|
+| TASK-01 | CONC-9 | Delete the serial server-side AcoustID backfill and route startup to the parallel plugin op | P2 | M | Opus-class | 1 |
+
+## Wave table
+
+| Wave | Tasks | Prereq | Parallel-safe because |
+|---|---|---|---|
+| 1 | TASK-01 | none | single task |
+
+## Ground rules
+
+- Go only, in the files named by each task; every change is additive (parallelize an existing loop; identical output to the serial version).
+- Reuse `registry.RunItems` (`internal/operations/registry/run_items.go`) — do NOT hand-roll a worker pool or add a new concurrency constant.
+- Build + test gate for every task in this workstream:
+  ```bash
+  make ci
+  ```
+- **Verify every file:line anchor with `grep` before editing** — line numbers in each brief are a starting point, not a guarantee.
+- Every pool change ships a `go test -race` proving no data race on the shared state the brief names.
+
+## Collision / wave note
+
+These tasks touch **disjoint files** and all run concurrently in wave 1 — no same-file collision.
+
+See [ORCHESTRATION.md](../ORCHESTRATION.md) (one level up) for the coordinator + worker protocol.

--- a/docs/agent-tasks/acoustid-consolidation/TASK-01-delete-serial-server-backfill.md
+++ b/docs/agent-tasks/acoustid-consolidation/TASK-01-delete-serial-server-backfill.md
@@ -1,0 +1,87 @@
+<!-- file: docs/agent-tasks/acoustid-consolidation/TASK-01-delete-serial-server-backfill.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: de88000b-3250-4beb-b47f-3b3bef4c218e -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-01 — Delete the serial server-side AcoustID backfill and route startup to the parallel plugin op (CONC-9)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Opus-class · go-backend subagent · **Why:** Delete/redirect a code path with caller wiring + a possibly-shared helper — dangling-reference risk. · ⚠ review-critical · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/acoustid-consolidation-delete-serial-server-backfill" -b agent/acoustid-consolidation-delete-serial-server-backfill origin/main
+cd "$REPO/.worktrees/acoustid-consolidation-delete-serial-server-backfill"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Remove the single s.backfillAcoustIDs(s.bgCtx) call at server_lifecycle.go:~910 and delete internal/server/acoustid_backfill.go, ensuring the already-registered parallel plugin op `acoustid.backfill` (internal/plugins/acoustid/backfill.go, uses registry.RunItems) covers the startup fingerprinting need. VERIFY no other symbol in acoustid_backfill.go (e.g. synthesizeBookSignatureForBook, fingerprintBookFile) is referenced elsewhere before deleting — if a helper is shared, move it rather than delete it.
+
+This is a **delete-and-redirect** task, NOT a pool-add: the parallel path already exists in the plugin op `acoustid.backfill` (`internal/plugins/acoustid/backfill.go`, which uses `registry.RunItems`). Your job is to remove the serial duplicate and its single caller, after proving nothing else depends on the file.
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Consolidation (delete/redirect), not a pool-add: verify caller wiring, ensure the parallel op covers the case (fix-pattern: delete the serial duplicate).
+- Current behavior: The server variant duplicates the plugin's work but serially and with an explicit per-item sleep. The plugin sibling does the same via registry.RunItems with Concurrency.
+- **Correctness constraint (READ TWICE):** Deletion/redirect task — the risk is a dangling reference. Grep every symbol defined in acoustid_backfill.go for external callers before removing. This is why it is Opus-class and ⚠ review-critical, not mechanical.
+- Source audit finding: `CONC-9` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "func (s \*Server) backfillAcoustIDs" internal/server/acoustid_backfill.go   # expect: 1 hit (~line 109)
+  grep -rn "s.backfillAcoustIDs(" --include=*.go .   # expect: 1 hit: server_lifecycle.go ~line 910
+  grep -rn "func (p \*Plugin) runBackfill\|defID:  \"acoustid.backfill\"" --include=*.go internal/plugins/   # expect: runBackfill ~backfill.go:56; op id in maintenance/optimize.go:79
+  ```
+
+## Step-by-step
+
+1. Confirm the single caller: `grep -rn "s.backfillAcoustIDs(" --include=*.go .` — expect exactly ONE hit in `internal/server/server_lifecycle.go` (~line 910). If there is more than one, STOP and report.
+2. Enumerate every symbol defined in `internal/server/acoustid_backfill.go` and check for external references BEFORE deleting: `for sym in $(grep -oE 'func [A-Za-z]*\(?s? ?\*?Server?\)? ?[A-Za-z]+' internal/server/acoustid_backfill.go); do :; done` — or more simply, for each top-level func/type in that file, `grep -rn "<name>" --include=*.go . | grep -v acoustid_backfill.go`. Any hit means the symbol is shared (e.g. `synthesizeBookSignatureForBook`, `fingerprintBookFile`) — MOVE it to a shared location instead of deleting it. Record what you moved.
+3. Remove the `s.backfillAcoustIDs(s.bgCtx)` call at `internal/server/server_lifecycle.go:~910` (and any now-unused imports it required).
+4. Delete `internal/server/acoustid_backfill.go` (`git rm`) — unless step 2 found a shared symbol, in which case delete only the serial `backfillAcoustIDs` + its private helpers and keep/move the shared ones.
+5. Confirm the plugin op `acoustid.backfill` is still registered and covers the startup need: `grep -rn 'defID:  "acoustid.backfill"' --include=*.go internal/plugins/` — expect 1 hit. If startup previously relied on the server call firing automatically, note whether the plugin op runs on startup or on-demand and flag any gap in the PR description (do NOT silently drop startup fingerprinting).
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go build ./...
+go test ./internal/server/... ./internal/plugins/acoustid/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] `internal/server/acoustid_backfill.go` no longer defines the serial `backfillAcoustIDs` (verify: `! grep -rn "func (s \*Server) backfillAcoustIDs" internal/server/`).
+- [ ] No caller remains (verify: `grep -rn "s.backfillAcoustIDs(" --include=*.go .` returns 0 hits).
+- [ ] The parallel plugin op is intact (verify: `grep -rn 'defID:  "acoustid.backfill"' --include=*.go internal/plugins/` returns 1 hit).
+- [ ] Any shared symbol from the old file (if step 2 found one) was MOVED, not lost (verify: `go build ./...` clean).
+- [ ] Anti-over-suppression: N/A (this task deletes a serial duplicate; correctness = the parallel plugin op still covers the case, verified above — no filter/guard/veto path is added).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+refactor(server): delete the serial server-side AcoustID backfill and route startup to the parallel plugin op (CONC-9)
+
+The serial server-side backfill duplicated the already-parallel plugin op
+acoustid.backfill (registry.RunItems). Remove the duplicate and its single caller;
+startup fingerprinting is covered by the plugin op.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `! test -f internal/server/acoustid_backfill.go && ! grep -rq "s.backfillAcoustIDs(" --include=*.go .` — if the file is already gone AND no caller remains, this task is complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit to restore the file and its call site; no data or schema is touched.

--- a/docs/agent-tasks/acoustid-consolidation/orchestration.md
+++ b/docs/agent-tasks/acoustid-consolidation/orchestration.md
@@ -1,0 +1,53 @@
+<!-- file: docs/agent-tasks/acoustid-consolidation/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e858f312-c0d4-4e82-99f0-62f1991100a7 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Orchestration — acoustid-consolidation workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This file only adds the workstream-specific wave order.
+
+**Execution mode:** SINGLE-AGENT (strong model) — trigger: judgment work (delete/redirect a code path with caller wiring + a shared helper to check); ⚠ review-critical, coordinator line-review before merge.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      TASK01[TASK-01 delete-serial-server-backfill]
+    end
+```
+
+- **Wave 1** (single task): TASK-01.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/acoustid-consolidation/
+./run.sh                 # print task list + set up worktrees
+./run.sh 01
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as coordinator, then rebase remaining sibling worktrees onto `origin/main` before starting the next wave.

--- a/docs/agent-tasks/acoustid-consolidation/run.sh
+++ b/docs/agent-tasks/acoustid-consolidation/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/acoustid-consolidation/run.sh
+# version: 1.0.0
+# guid: f414daea-0d5a-40d8-9781-7d92ee728ec4
+# last-edited: 2026-07-05
+#
+# Thin wrapper for the acoustid-consolidation workstream. See orchestration.md for wave order
+# (some tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 03      # subset (two-digit task numbers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+if [ -x "$HERE/../run-sweep.sh" ]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+BRANCH_BASE="origin/main"
+for NN in "$@"; do
+  BRIEF=$(ls "$HERE"/TASK-"$NN"-*.md 2>/dev/null | head -1) || { echo "no brief TASK-$NN"; continue; }
+  SLUG=$(basename "$BRIEF" .md | sed 's/^TASK-[0-9]*-//')
+  git -C "$REPO" worktree add "$REPO/.worktrees/$WS-$SLUG" -b "agent/$WS-$SLUG" "$BRANCH_BASE" 2>/dev/null || true
+  {
+    echo "You are an autonomous coding agent. Execute this task exactly. Do not skip the START HERE setup. Stop and report if any acceptance criterion fails."
+    echo; cat "$BRIEF"
+  } > "$HERE/TASK-$NN.agent-prompt.txt"
+  echo "prepared TASK-$NN -> worktree .worktrees/$WS-$SLUG + TASK-$NN.agent-prompt.txt"
+done
+if [ $# -eq 0 ]; then ls "$HERE"/TASK-*.md; fi

--- a/docs/agent-tasks/backfill-pools/README.md
+++ b/docs/agent-tasks/backfill-pools/README.md
@@ -1,0 +1,40 @@
+<!-- file: docs/agent-tasks/backfill-pools/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a7ec7f2e-4374-4507-877a-24710f63f093 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — backfill worker pools
+
+Add bounded worker pools (registry.RunItems) to the embarrassingly-parallel whole-library backfills, each in its own file. From `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` and the design spec `docs/specs/2026-07-05-concurrency-parallelization-design.md`.
+
+**Execution mode:** /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+
+| Task | Src id | Title | Priority | Effort | Tier | Wave |
+|------|--------|-------|----------|--------|------|------|
+| TASK-01 | CONC-5 | Parallelize dedup.embed-scan sync path with a rate-limited worker pool | P2 | M | Sonnet-class | 1 |
+| TASK-02 | CONC-6 | Parallelize the startup embedding backfill loops over books and authors | P2 | M | Sonnet-class | 1 |
+| TASK-03 | CONC-7 | Parallelize the tag-backfill ExtractMetadata loop with a CPU-sized pool | P2 | M | Sonnet-class | 1 |
+| TASK-04 | CONC-8 | Add book-lookup memoization then parallelize mine_gold_labels and dataset_backfill | P2 | L | Sonnet-class | 1 |
+
+## Wave table
+
+| Wave | Tasks | Prereq | Parallel-safe because |
+|---|---|---|---|
+| 1 | TASK-01, TASK-02, TASK-03, TASK-04 | none | disjoint file sets (see collision table) |
+
+## Ground rules
+
+- Go only, in the files named by each task; every change is additive (parallelize an existing loop; identical output to the serial version).
+- Reuse `registry.RunItems` (`internal/operations/registry/run_items.go`) — do NOT hand-roll a worker pool or add a new concurrency constant.
+- Build + test gate for every task in this workstream:
+  ```bash
+  make ci
+  ```
+- **Verify every file:line anchor with `grep` before editing** — line numbers in each brief are a starting point, not a guarantee.
+- Every pool change ships a `go test -race` proving no data race on the shared state the brief names.
+
+## Collision / wave note
+
+These tasks touch **disjoint files** and all run concurrently in wave 1 — no same-file collision.
+
+See [ORCHESTRATION.md](../ORCHESTRATION.md) (one level up) for the coordinator + worker protocol.

--- a/docs/agent-tasks/backfill-pools/TASK-01-embed-scan-pool.md
+++ b/docs/agent-tasks/backfill-pools/TASK-01-embed-scan-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/backfill-pools/TASK-01-embed-scan-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: dcbc32b2-3c0a-4df3-963d-324b108d376a -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-01 — Parallelize dedup.embed-scan sync path with a rate-limited worker pool (CONC-5)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Network-bound; concurrency must respect the embedding backend rate limit, not NumCPU. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/backfill-pools-embed-scan-pool" -b agent/backfill-pools-embed-scan-pool origin/main
+cd "$REPO/.worktrees/backfill-pools-embed-scan-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Switch the per-book EmbedBook loop to registry.RunItems[T] with a CONSERVATIVE Concurrency (network-bound; respect the embedding backend's rate limit — do NOT use NumCPU). Copy the invocation pattern verbatim from internal/plugins/acoustid/backfill.go:118. Preserve the op-registry Reporter progress.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Rate-limited external calls: bounded pool respecting the backend rate limit (fix-pattern #4).
+- Current behavior: Network-bound per-book EmbedBook call; direct FullScan analogue. Already runs under a plugin op with a Reporter available.
+- **Shared mutable state / correctness constraint (READ TWICE):** None in-memory beyond the op status; the constraint is the embedding backend rate limit — pick a small fixed Concurrency (const knob), not NumCPU.
+- Source audit finding: `CONC-5` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "status, embedErr := p.engine.EmbedBook(ctx, book.ID)" internal/plugins/dedup/embed_scan.go   # expect: 1 hit (~line 135)
+  ```
+
+## Step-by-step
+
+1. Open `internal/plugins/dedup/embed_scan.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/plugins/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/plugins/dedup/embed_scan.go` returns ≥1).
+- [ ] `go test -race ./internal/plugins/dedup/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(backfill): parallelize dedup.embed-scan sync path with a rate-limited worker pool (CONC-5)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/plugins/dedup/embed_scan.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/backfill-pools/TASK-02-embedding-backfill-pool.md
+++ b/docs/agent-tasks/backfill-pools/TASK-02-embedding-backfill-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/backfill-pools/TASK-02-embedding-backfill-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7763d8c3-54cd-45ff-80d0-482eea4453a7 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-02 — Parallelize the startup embedding backfill loops over books and authors (CONC-6)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Two startup loops, network rate-limited; integration with the startup path Reporter. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/backfill-pools-embedding-backfill-pool" -b agent/backfill-pools-embedding-backfill-pool origin/main
+cd "$REPO/.worktrees/backfill-pools-embedding-backfill-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap both the books loop and the authors loop in registry.RunItems[T] with a conservative network-bound Concurrency (same rate-limit reasoning as embed-scan). Keep the two loops as two separate RunItems calls (books first, then authors).
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Rate-limited external calls: bounded pool respecting the backend rate limit (fix-pattern #4).
+- Current behavior: Whole-library startup backfill (~24-29K books/authors), no concurrency, network-bound EmbedBook/EmbedAuthor.
+- **Shared mutable state / correctness constraint (READ TWICE):** None in-memory of concern; network rate limit is the constraint. Startup path — confirm a Reporter (or a nil-safe progress) is available here as it is in the plugin path.
+- Source audit finding: `CONC-6` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "s.dedupEngine.EmbedBook(ctx, book.ID)\|s.dedupEngine.EmbedAuthor(ctx, author.ID)" internal/server/embedding_backfill.go   # expect: 2 hits (~lines 79, 119)
+  ```
+
+## Step-by-step
+
+1. Open `internal/server/embedding_backfill.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/server/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/server/embedding_backfill.go` returns ≥1).
+- [ ] `go test -race ./internal/server/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(backfill): parallelize the startup embedding backfill loops over books and authors (CONC-6)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/server/embedding_backfill.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/backfill-pools/TASK-03-tag-backfill-pool.md
+++ b/docs/agent-tasks/backfill-pools/TASK-03-tag-backfill-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/backfill-pools/TASK-03-tag-backfill-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 83b91700-d0a5-456e-9020-0123e40ff682 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-03 — Parallelize the tag-backfill ExtractMetadata loop with a CPU-sized pool (CONC-7)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Straightforward pool but I/O sizing + Reporter wiring warrant Sonnet. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/backfill-pools-tag-backfill-pool" -b agent/backfill-pools-tag-backfill-pool origin/main
+cd "$REPO/.worktrees/backfill-pools-tag-backfill-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Switch the per-book_file loop to registry.RunItems[T] with Concurrency sized for I/O+CPU (the repo precedent for I/O-bound tag reads is runtime.NumCPU()*4 — see internal/itunes/service/path_repair_resolver.go). Preserve the op Reporter progress.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel I/O-bound: bounded pool (fix-pattern #1).
+- Current behavior: Real file I/O + CPU per item (tag parse), no pool, potentially 29K+ book_files.
+- **Shared mutable state / correctness constraint (READ TWICE):** None in-memory of concern; per-item ExtractMetadata is independent. I/O-bound → NumCPU*4 is the established repo sizing.
+- Source audit finding: `CONC-7` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "meta, merr := metadata.ExtractMetadata(f.FilePath, nil)" internal/plugins/maintenance/tag_backfill.go   # expect: 1 hit (~line 125)
+  ```
+
+## Step-by-step
+
+1. Open `internal/plugins/maintenance/tag_backfill.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/plugins/maintenance/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/plugins/maintenance/tag_backfill.go` returns ≥1).
+- [ ] `go test -race ./internal/plugins/maintenance/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(backfill): parallelize the tag-backfill ExtractMetadata loop with a CPU-sized pool (CONC-7)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/plugins/maintenance/tag_backfill.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/backfill-pools/TASK-04-gold-label-memoize-pool.md
+++ b/docs/agent-tasks/backfill-pools/TASK-04-gold-label-memoize-pool.md
@@ -1,0 +1,90 @@
+<!-- file: docs/agent-tasks/backfill-pools/TASK-04-gold-label-memoize-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4208221f-a556-42ed-a778-b7d15740d81a -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-04 — Add book-lookup memoization then parallelize mine_gold_labels and dataset_backfill (CONC-8)
+
+**Priority:** P2 · **Effort:** L · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Adds memoization AND a pool with a shared-cache guarding decision. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/backfill-pools-gold-label-memoize-pool" -b agent/backfill-pools-gold-label-memoize-pool origin/main
+cd "$REPO/.worktrees/backfill-pools-gold-label-memoize-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Two-part, per file: FIRST add a book-lookup memoization cache mirroring the drain_stale.go / server_maintenance_deps.go bookCache pattern (a map[string]*database.Book + a getBook closure) so repeated candidate rows don't re-read the same book 4x; THEN wrap the candidate loop in registry.RunItems[T]. Because a shared cache under a pool needs guarding, prefer per-worker-local caches OR a sync.Mutex-guarded map.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): N+1 read fixed by memoization, then embarrassingly parallel: memoize-then-pool (fix-pattern #1 + explicit memoization).
+- Current behavior: Up to the 1,000,000-candidate op limit; 4 DB reads per candidate with NO memoization (worse than its memoized siblings dedup-exact-triage/drain-stale).
+- **Shared mutable state / correctness constraint (READ TWICE):** If you share one memoization map across workers it must be mutex-guarded (or use sync.Map); simplest correct shape is a per-worker-local cache. The candidate processing itself is independent.
+- Source audit finding: `CONC-8` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "a, aErr := adapter.GetBook(c.EntityAID)" internal/plugins/dedup/mine_gold_labels.go   # expect: 1 hit (~line 101)
+  grep -n "ex, err := dataset.BuildExample(adapter, c)" internal/plugins/dedup/dataset_backfill.go   # expect: 1 hit (~line 141)
+  grep -n "cache := make(map\|lookup := func(id string)" internal/dedup/drain_stale.go   # expect: the memoized lookup closure
+  ```
+
+## Step-by-step
+
+1. Open `internal/plugins/dedup/mine_gold_labels.go` and `internal/plugins/dedup/dataset_backfill.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). Apply the change to EACH of the files listed — they are separate loops with the same fix pattern.
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/plugins/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/plugins/dedup/mine_gold_labels.go` returns ≥1).
+- [ ] `go test -race ./internal/plugins/dedup/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(backfill): add book-lookup memoization then parallelize mine_gold_labels and dataset_backfill (CONC-8)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/plugins/dedup/mine_gold_labels.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/backfill-pools/orchestration.md
+++ b/docs/agent-tasks/backfill-pools/orchestration.md
@@ -1,0 +1,56 @@
+<!-- file: docs/agent-tasks/backfill-pools/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 20d17acb-06f5-471b-b41c-9c8786ad1766 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Orchestration — backfill-pools workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This file only adds the workstream-specific wave order.
+
+**Execution mode:** /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      TASK01[TASK-01 embed-scan-pool]
+      TASK02[TASK-02 embedding-backfill-pool]
+      TASK03[TASK-03 tag-backfill-pool]
+      TASK04[TASK-04 gold-label-memoize-pool]
+    end
+```
+
+- **Wave 1** (parallel, disjoint files): TASK-01, TASK-02, TASK-03, TASK-04.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/backfill-pools/
+./run.sh                 # print task list + set up worktrees
+./run.sh 01 02 03 04
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as coordinator, then rebase remaining sibling worktrees onto `origin/main` before starting the next wave.

--- a/docs/agent-tasks/backfill-pools/run.sh
+++ b/docs/agent-tasks/backfill-pools/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/backfill-pools/run.sh
+# version: 1.0.0
+# guid: 17bc126c-0360-4359-a775-a929959c44fa
+# last-edited: 2026-07-05
+#
+# Thin wrapper for the backfill-pools workstream. See orchestration.md for wave order
+# (some tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 03      # subset (two-digit task numbers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+if [ -x "$HERE/../run-sweep.sh" ]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+BRANCH_BASE="origin/main"
+for NN in "$@"; do
+  BRIEF=$(ls "$HERE"/TASK-"$NN"-*.md 2>/dev/null | head -1) || { echo "no brief TASK-$NN"; continue; }
+  SLUG=$(basename "$BRIEF" .md | sed 's/^TASK-[0-9]*-//')
+  git -C "$REPO" worktree add "$REPO/.worktrees/$WS-$SLUG" -b "agent/$WS-$SLUG" "$BRANCH_BASE" 2>/dev/null || true
+  {
+    echo "You are an autonomous coding agent. Execute this task exactly. Do not skip the START HERE setup. Stop and report if any acceptance criterion fails."
+    echo; cat "$BRIEF"
+  } > "$HERE/TASK-$NN.agent-prompt.txt"
+  echo "prepared TASK-$NN -> worktree .worktrees/$WS-$SLUG + TASK-$NN.agent-prompt.txt"
+done
+if [ $# -eq 0 ]; then ls "$HERE"/TASK-*.md; fi

--- a/docs/agent-tasks/bulk-ops-pools/README.md
+++ b/docs/agent-tasks/bulk-ops-pools/README.md
@@ -1,0 +1,40 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a10dca8-e134-4976-88d1-2a1d1ab7cf69 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — bulk + request-driven op pools
+
+Add conservative pools to the request-driven bulk metadata ops and the two remaining N+1 backfill reads. From `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` and the design spec `docs/specs/2026-07-05-concurrency-parallelization-design.md`.
+
+**Execution mode:** /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+
+| Task | Src id | Title | Priority | Effort | Tier | Wave |
+|------|--------|-------|----------|--------|------|------|
+| TASK-01 | CONC-12 | Parallelize bulkFetchMetadataImpl over req.BookIDs with a conservative request-scoped pool | P3 | M | Sonnet-class | 1 |
+| TASK-02 | CONC-13 | Parallelize BatchUpdateMetadata and ImportMetadata per-item DB round-trips | P3 | M | Sonnet-class | 1 |
+| TASK-03 | CONC-14 | Parallelize the duration-backfill per-book GetBookFiles loop | P3 | S | Haiku-class | 1 |
+| TASK-04 | CONC-15 | Parallelize the itunes path-reconcile per-book GetBookFiles loop | P3 | S | Haiku-class | 1 |
+
+## Wave table
+
+| Wave | Tasks | Prereq | Parallel-safe because |
+|---|---|---|---|
+| 1 | TASK-01, TASK-02, TASK-03, TASK-04 | none | disjoint file sets (see collision table) |
+
+## Ground rules
+
+- Go only, in the files named by each task; every change is additive (parallelize an existing loop; identical output to the serial version).
+- Reuse `registry.RunItems` (`internal/operations/registry/run_items.go`) — do NOT hand-roll a worker pool or add a new concurrency constant.
+- Build + test gate for every task in this workstream:
+  ```bash
+  make ci
+  ```
+- **Verify every file:line anchor with `grep` before editing** — line numbers in each brief are a starting point, not a guarantee.
+- Every pool change ships a `go test -race` proving no data race on the shared state the brief names.
+
+## Collision / wave note
+
+These tasks touch **disjoint files** and all run concurrently in wave 1 — no same-file collision.
+
+See [ORCHESTRATION.md](../ORCHESTRATION.md) (one level up) for the coordinator + worker protocol.

--- a/docs/agent-tasks/bulk-ops-pools/TASK-01-bulk-fetch-metadata-pool.md
+++ b/docs/agent-tasks/bulk-ops-pools/TASK-01-bulk-fetch-metadata-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/TASK-01-bulk-fetch-metadata-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: db1bd62e-54df-43f6-9ee8-1ec2ee0458ce -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-01 — Parallelize bulkFetchMetadataImpl over req.BookIDs with a conservative request-scoped pool (CONC-12)
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Request-scoped; conservative sizing to avoid starving the server / tripping the source rate limit. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/bulk-ops-pools-bulk-fetch-metadata-pool" -b agent/bulk-ops-pools-bulk-fetch-metadata-pool origin/main
+cd "$REPO/.worktrees/bulk-ops-pools-bulk-fetch-metadata-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap the per-bookID loop in registry.RunItems[T] with a SMALL fixed Concurrency (this runs inline on a user-facing HTTP request — conservative, not NumCPU, and respect the external metadata source's rate limit). Aggregate results into a slice guarded by a mutex or via RunItems' collected results.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Request-driven bulk op: conservative bounded pool (fix-pattern #5).
+- Current behavior: Runs inline on an HTTP request; req.BookIDs can be hundreds/thousands on 'select all'. Per book: DB read + external network search.
+- **Shared mutable state / correctness constraint (READ TWICE):** Request-scoped: keep concurrency low to avoid starving the server and tripping the metadata source's rate limit. Result aggregation slice needs guarding.
+- Source audit finding: `CONC-12` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "for _, bookID := range req.BookIDs" internal/server/handlers/metadata/handler.go   # expect: 1 hit (~line 794)
+  ```
+
+## Step-by-step
+
+1. Open `internal/server/handlers/metadata/handler.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/server/handlers/metadata/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/server/handlers/metadata/handler.go` returns ≥1).
+- [ ] `go test -race ./internal/server/handlers/metadata/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(bulk): parallelize bulkFetchMetadataImpl over req.BookIDs with a conservative request-scoped pool (CONC-12)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/server/handlers/metadata/handler.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/bulk-ops-pools/TASK-02-batch-update-import-metadata-pool.md
+++ b/docs/agent-tasks/bulk-ops-pools/TASK-02-batch-update-import-metadata-pool.md
@@ -1,0 +1,89 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/TASK-02-batch-update-import-metadata-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9c7ce743-1bf7-45af-9813-f72078de64df -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-02 — Parallelize BatchUpdateMetadata and ImportMetadata per-item DB round-trips (CONC-13)
+
+**Priority:** P3 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Two request-driven loops in one file with guarded result aggregation. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/bulk-ops-pools-batch-update-import-metadata-pool" -b agent/bulk-ops-pools-batch-update-import-metadata-pool origin/main
+cd "$REPO/.worktrees/bulk-ops-pools-batch-update-import-metadata-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap both per-item loops in registry.RunItems[T] with a conservative Concurrency (request/bulk-edit-payload scoped). Both loops are in enhanced.go, so this single task owns both to avoid a same-file split.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Request-driven bulk op: conservative bounded pool (fix-pattern #5).
+- Current behavior: Both are request-driven bulk ops with serial DB round-trips (Validate + GetBookByID + UpdateBook).
+- **Shared mutable state / correctness constraint (READ TWICE):** Result/error aggregation must be guarded. UpdateBook writes — confirm store goroutine-safety at the chosen concurrency.
+- Source audit finding: `CONC-13` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "for i, update := range updates" internal/metadata/enhanced.go   # expect: 1 hit (~line 166)
+  grep -n "for i, bookInterface := range booksData" internal/metadata/enhanced.go   # expect: 1 hit (~line 635)
+  ```
+
+## Step-by-step
+
+1. Open `internal/metadata/enhanced.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/metadata/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/metadata/enhanced.go` returns ≥1).
+- [ ] `go test -race ./internal/metadata/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(bulk): parallelize BatchUpdateMetadata and ImportMetadata per-item DB round-trips (CONC-13)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/metadata/enhanced.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/bulk-ops-pools/TASK-03-duration-backfill-pool.md
+++ b/docs/agent-tasks/bulk-ops-pools/TASK-03-duration-backfill-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/TASK-03-duration-backfill-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 457eeda3-f8c4-4200-ae5b-ce79a0d713e8 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-03 — Parallelize the duration-backfill per-book GetBookFiles loop (CONC-14)
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** Haiku-class · go-backend subagent · **Why:** Mechanical mirror of the other backfill pools; fully specified. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/bulk-ops-pools-duration-backfill-pool" -b agent/bulk-ops-pools-duration-backfill-pool origin/main
+cd "$REPO/.worktrees/bulk-ops-pools-duration-backfill-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Switch the per-book loop to registry.RunItems[T] (Concurrency NumCPU-ish; DB-read-bound). Mechanical mirror of the other backfill pool tasks — copy the acoustid/backfill.go:118 invocation pattern.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel DB-read: bounded pool (fix-pattern #1).
+- Current behavior: Classic N+1 read at full-library scale; per-book GetBookFiles then duration compute/UpdateBook.
+- **Shared mutable state / correctness constraint (READ TWICE):** Independent per book; guard any shared counter/result via the Reporter/atomics.
+- Source audit finding: `CONC-14` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "files, ferr := store.GetBookFiles(book.ID)" internal/plugins/maintenance/duration_backfill.go   # expect: 1 hit (~line 112)
+  ```
+
+## Step-by-step
+
+1. Open `internal/plugins/maintenance/duration_backfill.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/plugins/maintenance/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/plugins/maintenance/duration_backfill.go` returns ≥1).
+- [ ] `go test -race ./internal/plugins/maintenance/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(bulk): parallelize the duration-backfill per-book GetBookFiles loop (CONC-14)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/plugins/maintenance/duration_backfill.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/bulk-ops-pools/TASK-04-path-reconcile-pool.md
+++ b/docs/agent-tasks/bulk-ops-pools/TASK-04-path-reconcile-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/TASK-04-path-reconcile-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d83db9d-3db9-4fc7-9fd5-f789a32d02a8 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-04 — Parallelize the itunes path-reconcile per-book GetBookFiles loop (CONC-15)
+
+**Priority:** P3 · **Effort:** S · **Recommended subagent:** Haiku-class · go-backend subagent · **Why:** Mechanical mirror of TASK-03; fully specified. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/bulk-ops-pools-path-reconcile-pool" -b agent/bulk-ops-pools-path-reconcile-pool origin/main
+cd "$REPO/.worktrees/bulk-ops-pools-path-reconcile-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Switch the per-book loop to registry.RunItems[T] (Concurrency NumCPU-ish; DB-read-bound). Mechanical mirror of TASK-03 — copy the acoustid/backfill.go:118 invocation pattern.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel DB-read: bounded pool (fix-pattern #1).
+- Current behavior: Classic N+1 read at full-library scale; per-book GetBookFiles then path reconcile.
+- **Shared mutable state / correctness constraint (READ TWICE):** Independent per book; guard any shared reconcile accumulator via mutex/atomics.
+- Source audit finding: `CONC-15` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "bookFiles, _ := r.store.GetBookFiles(b.ID)" internal/itunes/service/path_reconcile.go   # expect: 1 hit (~line 89)
+  ```
+
+## Step-by-step
+
+1. Open `internal/itunes/service/path_reconcile.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/itunes/service/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/itunes/service/path_reconcile.go` returns ≥1).
+- [ ] `go test -race ./internal/itunes/service/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(bulk): parallelize the itunes path-reconcile per-book GetBookFiles loop (CONC-15)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/itunes/service/path_reconcile.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/bulk-ops-pools/orchestration.md
+++ b/docs/agent-tasks/bulk-ops-pools/orchestration.md
@@ -1,0 +1,56 @@
+<!-- file: docs/agent-tasks/bulk-ops-pools/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 48db0c96-31e8-4a56-b184-cef5adee3ae8 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Orchestration — bulk-ops-pools workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This file only adds the workstream-specific wave order.
+
+**Execution mode:** /parallel-sweep — trigger: 4 mechanically-similar tasks (≥3 threshold), disjoint files per the collision matrix, gate = `make ci`. Invocation: TASK-01,02,03,04 all in wave 1.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      TASK01[TASK-01 bulk-fetch-metadata-pool]
+      TASK02[TASK-02 batch-update-import-metadata-pool]
+      TASK03[TASK-03 duration-backfill-pool]
+      TASK04[TASK-04 path-reconcile-pool]
+    end
+```
+
+- **Wave 1** (parallel, disjoint files): TASK-01, TASK-02, TASK-03, TASK-04.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/bulk-ops-pools/
+./run.sh                 # print task list + set up worktrees
+./run.sh 01 02 03 04
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as coordinator, then rebase remaining sibling worktrees onto `origin/main` before starting the next wave.

--- a/docs/agent-tasks/bulk-ops-pools/run.sh
+++ b/docs/agent-tasks/bulk-ops-pools/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/bulk-ops-pools/run.sh
+# version: 1.0.0
+# guid: 834c309e-03f7-4805-a6f9-be67c727c7ec
+# last-edited: 2026-07-05
+#
+# Thin wrapper for the bulk-ops-pools workstream. See orchestration.md for wave order
+# (some tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 03      # subset (two-digit task numbers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+if [ -x "$HERE/../run-sweep.sh" ]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+BRANCH_BASE="origin/main"
+for NN in "$@"; do
+  BRIEF=$(ls "$HERE"/TASK-"$NN"-*.md 2>/dev/null | head -1) || { echo "no brief TASK-$NN"; continue; }
+  SLUG=$(basename "$BRIEF" .md | sed 's/^TASK-[0-9]*-//')
+  git -C "$REPO" worktree add "$REPO/.worktrees/$WS-$SLUG" -b "agent/$WS-$SLUG" "$BRANCH_BASE" 2>/dev/null || true
+  {
+    echo "You are an autonomous coding agent. Execute this task exactly. Do not skip the START HERE setup. Stop and report if any acceptance criterion fails."
+    echo; cat "$BRIEF"
+  } > "$HERE/TASK-$NN.agent-prompt.txt"
+  echo "prepared TASK-$NN -> worktree .worktrees/$WS-$SLUG + TASK-$NN.agent-prompt.txt"
+done
+if [ $# -eq 0 ]; then ls "$HERE"/TASK-*.md; fi

--- a/docs/agent-tasks/dedup-engine/README.md
+++ b/docs/agent-tasks/dedup-engine/README.md
@@ -1,0 +1,43 @@
+<!-- file: docs/agent-tasks/dedup-engine/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 368ccd37-d50a-47db-8b66-318b3b454e9b -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — dedup engine scan concurrency
+
+Parallelize the four whole-library scan loops inside internal/dedup/engine.go — the confirmed prod bottleneck and its neighbors. From `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` and the design spec `docs/specs/2026-07-05-concurrency-parallelization-design.md`.
+
+**Execution mode:** SERIAL WAVES (coordinator-driven) — trigger: all four tasks edit internal/dedup/engine.go (collision table row 1); wave N+1 starts only after wave N merges and siblings rebase.
+
+| Task | Src id | Title | Priority | Effort | Tier | Wave |
+|------|--------|-------|----------|--------|------|------|
+| TASK-01 | CONC-1 | Shard BookSignatureScan's O(n²) pairwise loop across a bounded worker pool | P1 | L | Opus-class | 1 |
+| TASK-02 | CONC-2 | Parallelize FullScan's unified-scoring pass with a bounded worker pool | P1 | M | Sonnet-class | 2 |
+| TASK-03 | CONC-3 | Parallelize AcoustIDScan's per-book loop with a bounded pool and guard its four shared maps | P2 | L | Sonnet-class | 3 |
+| TASK-04 | CONC-4 | Parallelize FullScan main-pass Layer-1 checks while keeping Layer-2 embedding batching serial | P2 | L | Sonnet-class | 4 |
+
+## Wave table
+
+| Wave | Tasks | Prereq | Parallel-safe because |
+|---|---|---|---|
+| 1 | TASK-01 | none | single task |
+| 2 | TASK-02 | wave 1 merged + siblings rebased | shares `internal/dedup/engine.go` with wave 1 |
+| 3 | TASK-03 | wave 2 merged + siblings rebased | shares `internal/dedup/engine.go` with wave 2 |
+| 4 | TASK-04 | wave 3 merged + siblings rebased | shares `internal/dedup/engine.go` with wave 3 |
+
+## Ground rules
+
+- Go only, in the files named by each task; every change is additive (parallelize an existing loop; identical output to the serial version).
+- Reuse `registry.RunItems` (`internal/operations/registry/run_items.go`) — do NOT hand-roll a worker pool or add a new concurrency constant.
+- Build + test gate for every task in this workstream:
+  ```bash
+  make ci
+  ```
+- **Verify every file:line anchor with `grep` before editing** — line numbers in each brief are a starting point, not a guarantee.
+- Every pool change ships a `go test -race` proving no data race on the shared state the brief names.
+
+## Collision / wave note
+
+**Every task here edits `internal/dedup/engine.go`.** They MUST run in different waves (each serialized after the previous merges) — running them in parallel would produce a same-file merge conflict on every rebase cycle.
+
+See [ORCHESTRATION.md](../ORCHESTRATION.md) (one level up) for the coordinator + worker protocol.

--- a/docs/agent-tasks/dedup-engine/TASK-01-booksigscan-shard.md
+++ b/docs/agent-tasks/dedup-engine/TASK-01-booksigscan-shard.md
@@ -1,0 +1,89 @@
+<!-- file: docs/agent-tasks/dedup-engine/TASK-01-booksigscan-shard.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 41860daf-fd12-4ec8-8f6d-f7039e85f967 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-01 — Shard BookSignatureScan's O(n²) pairwise loop across a bounded worker pool (CONC-1)
+
+**Priority:** P1 · **Effort:** L · **Recommended subagent:** Opus-class · go-backend subagent · **Why:** O(n²) hot path; sharding must guard the emitted map + DB write without changing dedup output — highest-risk change in the package. · ⚠ review-critical · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dedup-engine-booksigscan-shard" -b agent/dedup-engine-booksigscan-shard origin/main
+cd "$REPO/.worktrees/dedup-engine-booksigscan-shard"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Shard the OUTER loop (index i) across a bounded worker pool sized to runtime.NumCPU() (pure-CPU bitmask/Hamming compare). Each worker owns a contiguous i-range and runs its inner j-loop. Reuse registry.RunItems[T] over the outer index if it fits, or a plain errgroup/semaphore — the per-pair work is CPU-bound with no DB reads inside the inner loop.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Pairwise O(n²) with a shared dedup-set: shard outer loop, guard shared state (fix-pattern #2 in the audit).
+- Current behavior: The inner loop does pure-CPU fingerprint.BookSignatureSimilarityMasked (skip if overlap<512) and, on sim>=FuzzyMinSimilarity, emit() → upsertCandidateWithLiveLabel (DB write + dataset-example build). sigs are already in the in-memory booksWithSig slice (no DB reads in the inner loop).
+- **Shared mutable state / correctness constraint (READ TWICE):** The `emitted map[string]struct{}` (~line 3599, keyed by canonical pairKey) is read-check-then-written inside emit(). NOTE the triangular i<j loop already visits each unordered pair exactly once, so `emitted` never actually suppresses anything here — but sharding the outer loop still races the map AND the DB write. Guard `emitted` with a sync.Mutex (or a sharded map), OR drop it entirely and rely on upsertCandidateWithLiveLabel idempotency. Preserve the existing progress(done,total) callback (increment atomically).
+- Source audit finding: `CONC-1` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n 'for j := i + 1; j < len(booksWithSig); j++' internal/dedup/engine.go   # expect: 1 hit (~line 3638)
+  grep -n 'func (de \*Engine) BookSignatureScan\|emitted := make(map\[string\]struct{}' internal/dedup/engine.go   # expect: func ~3585, emitted map ~3599
+  ```
+
+## Step-by-step
+
+1. Open `internal/dedup/engine.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test proving the parallel pass produces the SAME candidate output as the serial version (no lost writes through the guarded shared state), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/dedup/engine.go` returns ≥1).
+- [ ] `go test -race ./internal/dedup/...` is clean (no data race on the shared state named above).
+- [ ] `TestParallel<Scan> SameCandidatesAsSerial` — the parallelized pass emits the EXACT same candidate set (and the guarded shared map/counter has no lost updates) as the pre-change serial version on a fixture library (anti-over-suppression / anti-race).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(dedup): shard BookSignatureScan's O(n²) pairwise loop across a bounded worker pool (CONC-1)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/dedup/engine.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/dedup-engine/TASK-02-fullscan-unified-pool.md
+++ b/docs/agent-tasks/dedup-engine/TASK-02-fullscan-unified-pool.md
@@ -1,0 +1,90 @@
+<!-- file: docs/agent-tasks/dedup-engine/TASK-02-fullscan-unified-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6dfe2997-82f7-43e8-8788-f22945c438f9 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-02 — Parallelize FullScan's unified-scoring pass with a bounded worker pool (CONC-2)
+
+**Priority:** P1 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Confirmed prod bottleneck; per-item independent but touches shared stores — logic + store-safety judgment. · **Depends on:** TASK-01
+
+> **Depends on TASK-01 (same file `internal/dedup/engine.go`).** Do NOT start until TASK-01's PR is merged to `origin/main` and this worktree is rebased on top — running them concurrently guarantees a rebase conflict.
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dedup-engine-fullscan-unified-pool" -b agent/dedup-engine-fullscan-unified-pool origin/main
+cd "$REPO/.worktrees/dedup-engine-fullscan-unified-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap the unified-scoring pass over `books` in registry.RunItems[T] with Concurrency sized for mixed CPU+DB work (start runtime.NumCPU(), leave a const knob). Each item independently: GetAuthorByID then runUnifiedScoringForBook. Preserve the existing progress(done,total) callback via the Reporter's UpdateProgress.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel per item (no shared mutable in-memory state): bounded worker pool (fix-pattern #1).
+- Current behavior: runUnifiedScoringForBook (def ~line 473) is self-contained per book — all per-book collector caches live on its own stack; no FullScan-layer in-memory shared state. It does many DB reads AND writes (DeleteCandidate, upsertCandidateWithLiveLabel + dataset-example persistence).
+- **Shared mutable state / correctness constraint (READ TWICE):** None in-memory at the FullScan layer. The ONLY hazard is the shared bookStore/embedStore backends (per-book reads and writes). CONFIRM those stores are goroutine-safe before enabling >1 concurrency; if not, that becomes the gating constraint. Keep the progress counter atomic.
+- Source audit finding: `CONC-2` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n 'runUnifiedScoringForBook(ctx, &book, authorName)' internal/dedup/engine.go   # expect: 1 hit (~line 2557)
+  ```
+
+## Step-by-step
+
+1. Open `internal/dedup/engine.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/dedup/engine.go` returns ≥1).
+- [ ] `go test -race ./internal/dedup/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(dedup): parallelize FullScan's unified-scoring pass with a bounded worker pool (CONC-2)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/dedup/engine.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/dedup-engine/TASK-03-acoustidscan-pool.md
+++ b/docs/agent-tasks/dedup-engine/TASK-03-acoustidscan-pool.md
@@ -1,0 +1,91 @@
+<!-- file: docs/agent-tasks/dedup-engine/TASK-03-acoustidscan-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7fe1f5d6-e372-4aea-b82e-1a4c79970aab -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-03 — Parallelize AcoustIDScan's per-book loop with a bounded pool and guard its four shared maps (CONC-3)
+
+**Priority:** P2 · **Effort:** L · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Four unguarded shared maps + a counter to guard correctly under a pool — easy to introduce a data race. · ⚠ review-critical · **Depends on:** TASK-02
+
+> **Depends on TASK-02 (same file `internal/dedup/engine.go`).** Do NOT start until TASK-02's PR is merged to `origin/main` and this worktree is rebased on top — running them concurrently guarantees a rebase conflict.
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dedup-engine-acoustidscan-pool" -b agent/dedup-engine-acoustidscan-pool origin/main
+cd "$REPO/.worktrees/dedup-engine-acoustidscan-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap the per-book loop in registry.RunItems[T] (Concurrency ~runtime.NumCPU(); mixed DB+CPU). The hard part is state: AcoustIDScan has FOUR unguarded shared maps plus a counter — guard each with a sync.Mutex (or use sync.Map / per-worker-local caches merged at the end).
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel per book BUT with heavy shared caches: bounded pool + mutex-guarded (or per-worker-local then merged) maps (fix-pattern #1 with #2's guarding discipline).
+- Current behavior: Per book: GetBookFiles + per-file LSH lookup (up to 200 candidates each doing GetBookFileByID + WholeFileSimilarity) + Tier-1 walk of 7 segment strings each doing GetBookFileByAcoustID. emit() → upsertCandidateWithLiveLabel.
+- **Shared mutable state / correctness constraint (READ TWICE):** FOUR unguarded maps + a counter, ALL mutated inside emit()/the loop and ALL must be guarded when sharding: `emitted map[string]struct{}` (~3348), `boilerplateBookCache map[string]bool` (~3328), `parentDirCache map[string]string` (~3358), `booksByID map[string]*database.Book` (~3323), and `identifierGateDrops int` (~3379). Heaviest shared-state burden of the engine.go findings — miss one and you get a data race. Preserve the progress callback.
+- Source audit finding: `CONC-3` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n 'cands, _ := lshStore.LookupAcoustIDCandidates' internal/dedup/engine.go   # expect: 1 hit (~line 3486)
+  grep -n 'func (de \*Engine) AcoustIDScan\|emitted := make\|booksByID :=\|boilerplateBookCache\|parentDirCache\|identifierGateDrops' internal/dedup/engine.go   # expect: all 5 shared-state sites: func ~3318; emitted ~3348; booksByID ~3323; boilerplateBookCache ~3328; parentDirCache ~3358; identifierGateDrops ~3379
+  ```
+
+## Step-by-step
+
+1. Open `internal/dedup/engine.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test proving the parallel pass produces the SAME candidate output as the serial version (no lost writes through the guarded shared state), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/dedup/engine.go` returns ≥1).
+- [ ] `go test -race ./internal/dedup/...` is clean (no data race on the shared state named above).
+- [ ] `TestParallel<Scan> SameCandidatesAsSerial` — the parallelized pass emits the EXACT same candidate set (and the guarded shared map/counter has no lost updates) as the pre-change serial version on a fixture library (anti-over-suppression / anti-race).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(dedup): parallelize AcoustIDScan's per-book loop with a bounded pool and guard its four shared maps (CONC-3)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/dedup/engine.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/dedup-engine/TASK-04-fullscan-main-split.md
+++ b/docs/agent-tasks/dedup-engine/TASK-04-fullscan-main-split.md
@@ -1,0 +1,90 @@
+<!-- file: docs/agent-tasks/dedup-engine/TASK-04-fullscan-main-split.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a81ae58f-8713-4e4c-a498-9ebe653ba0b1 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-04 — Parallelize FullScan main-pass Layer-1 checks while keeping Layer-2 embedding batching serial (CONC-4)
+
+**Priority:** P2 · **Effort:** L · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Must split parallel Layer-1 from serial Layer-2 circuit-breaker state — design-adjacent, not mechanical. · ⚠ review-critical · **Depends on:** TASK-03
+
+> **Depends on TASK-03 (same file `internal/dedup/engine.go`).** Do NOT start until TASK-03's PR is merged to `origin/main` and this worktree is rebased on top — running them concurrently guarantees a rebase conflict.
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/dedup-engine-fullscan-main-split" -b agent/dedup-engine-fullscan-main-split origin/main
+cd "$REPO/.worktrees/dedup-engine-fullscan-main-split"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Split the loop: parallelize the per-book-independent Layer-1 exact checks (checkExactFileHash/ISBN/Title/duration) via registry.RunItems[T], but KEEP the Layer-2 embedding batch-accumulation + flushChunk + circuit-breaker strictly serial (it is loop-carried state, not embarrassingly parallel). Simplest safe shape: a parallel Layer-1 stage over all books, then the existing serial Layer-2 batching stage — do NOT try to parallelize the flush.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Mixed: split parallelizable Layer-1 from inherently-serial Layer-2 batching (fix-pattern #1 for Layer-1 only).
+- Current behavior: Layer-1 comment says 'cheap and synchronous, no API calls'. Layer-2 batches book.IDs and every 64 calls EmbedBooks (network) + findSimilarBooks.
+- **Shared mutable state / correctness constraint (READ TWICE):** Loop-carried SERIAL state that makes this NOT embarrassingly parallel: `chunkIDs []string` (appended each iter, reset in flushChunk), `chunkStart int`, `embedConsecutiveFails int`, and `embeddingsGaveUp bool` (circuit-breaker). Parallelize ONLY Layer-1; the batch accumulation + circuit-breaker must stay sequential or you corrupt the batching and defeat the breaker.
+- Source audit finding: `CONC-4` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n 'de.checkExactFileHash(&book, authorName)' internal/dedup/engine.go   # expect: 1 hit (~line 2482)
+  ```
+
+## Step-by-step
+
+1. Open `internal/dedup/engine.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/dedup/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/dedup/engine.go` returns ≥1).
+- [ ] `go test -race ./internal/dedup/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(dedup): parallelize FullScan main-pass Layer-1 checks while keeping Layer-2 embedding batching serial (CONC-4)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/dedup/engine.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/dedup-engine/orchestration.md
+++ b/docs/agent-tasks/dedup-engine/orchestration.md
@@ -1,0 +1,68 @@
+<!-- file: docs/agent-tasks/dedup-engine/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: acf1fc91-eaf7-4fbf-897d-9f238020adbd -->
+<!-- last-edited: 2026-07-05 -->
+
+# Orchestration — dedup-engine workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This file only adds the workstream-specific wave order.
+
+**Execution mode:** SERIAL WAVES (coordinator-driven) — trigger: all four tasks edit internal/dedup/engine.go (collision table row 1); wave N+1 starts only after wave N merges and siblings rebase.
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      TASK01[TASK-01 booksigscan-shard]
+    end
+    subgraph Wave2
+      TASK02[TASK-02 fullscan-unified-pool]
+    end
+    subgraph Wave3
+      TASK03[TASK-03 acoustidscan-pool]
+    end
+    subgraph Wave4
+      TASK04[TASK-04 fullscan-main-split]
+    end
+    TASK01 --> TASK02
+    TASK02 --> TASK03
+    TASK03 --> TASK04
+```
+
+- **Wave 1** (single task): TASK-01.
+- **Wave 2** (serialized): TASK-02 — MUST NOT start until wave 1's PR is merged to `origin/main` and this worktree is rebased on top.
+- **Wave 3** (serialized): TASK-03 — MUST NOT start until wave 2's PR is merged to `origin/main` and this worktree is rebased on top.
+- **Wave 4** (serialized): TASK-04 — MUST NOT start until wave 3's PR is merged to `origin/main` and this worktree is rebased on top.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/dedup-engine/
+./run.sh                 # print task list + set up worktrees
+./run.sh 01 ./run.sh 02 ./run.sh 03 ./run.sh 04
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as coordinator, then rebase remaining sibling worktrees onto `origin/main` before starting the next wave.

--- a/docs/agent-tasks/dedup-engine/run.sh
+++ b/docs/agent-tasks/dedup-engine/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/dedup-engine/run.sh
+# version: 1.0.0
+# guid: b6bbc901-c389-4e11-9d0b-27589303f09a
+# last-edited: 2026-07-05
+#
+# Thin wrapper for the dedup-engine workstream. See orchestration.md for wave order
+# (some tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 03      # subset (two-digit task numbers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+if [ -x "$HERE/../run-sweep.sh" ]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+BRANCH_BASE="origin/main"
+for NN in "$@"; do
+  BRIEF=$(ls "$HERE"/TASK-"$NN"-*.md 2>/dev/null | head -1) || { echo "no brief TASK-$NN"; continue; }
+  SLUG=$(basename "$BRIEF" .md | sed 's/^TASK-[0-9]*-//')
+  git -C "$REPO" worktree add "$REPO/.worktrees/$WS-$SLUG" -b "agent/$WS-$SLUG" "$BRANCH_BASE" 2>/dev/null || true
+  {
+    echo "You are an autonomous coding agent. Execute this task exactly. Do not skip the START HERE setup. Stop and report if any acceptance criterion fails."
+    echo; cat "$BRIEF"
+  } > "$HERE/TASK-$NN.agent-prompt.txt"
+  echo "prepared TASK-$NN -> worktree .worktrees/$WS-$SLUG + TASK-$NN.agent-prompt.txt"
+done
+if [ $# -eq 0 ]; then ls "$HERE"/TASK-*.md; fi

--- a/docs/agent-tasks/itunes-import/README.md
+++ b/docs/agent-tasks/itunes-import/README.md
@@ -1,0 +1,39 @@
+<!-- file: docs/agent-tasks/itunes-import/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9e4c5837-1484-4266-8c1a-15981df6739f -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — itunes import concurrency
+
+Parallelize the two whole-library import passes in importer.go: file-organize (I/O) and metadata-enrich (rate-limited, circuit-breaker). From `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` and the design spec `docs/specs/2026-07-05-concurrency-parallelization-design.md`.
+
+**Execution mode:** SERIAL WAVES (coordinator-driven) — trigger: both tasks edit internal/itunes/service/importer.go (collision table row 2); enrich (TASK-02) serializes after organize (TASK-01).
+
+| Task | Src id | Title | Priority | Effort | Tier | Wave |
+|------|--------|-------|----------|--------|------|------|
+| TASK-01 | CONC-10 | Parallelize organizeImportedBooks file-organize + UpdateBook over imported books | P2 | M | Sonnet-class | 1 |
+| TASK-02 | CONC-11 | Parallelize enrichImportedBooks metadata fetch with a bounded pool preserving the rate-limit circuit-breaker | P3 | L | Sonnet-class | 2 |
+
+## Wave table
+
+| Wave | Tasks | Prereq | Parallel-safe because |
+|---|---|---|---|
+| 1 | TASK-01 | none | single task |
+| 2 | TASK-02 | wave 1 merged + siblings rebased | shares `internal/itunes/service/importer.go` with wave 1 |
+
+## Ground rules
+
+- Go only, in the files named by each task; every change is additive (parallelize an existing loop; identical output to the serial version).
+- Reuse `registry.RunItems` (`internal/operations/registry/run_items.go`) — do NOT hand-roll a worker pool or add a new concurrency constant.
+- Build + test gate for every task in this workstream:
+  ```bash
+  make ci
+  ```
+- **Verify every file:line anchor with `grep` before editing** — line numbers in each brief are a starting point, not a guarantee.
+- Every pool change ships a `go test -race` proving no data race on the shared state the brief names.
+
+## Collision / wave note
+
+**Every task here edits `internal/itunes/service/importer.go`.** They MUST run in different waves (each serialized after the previous merges) — running them in parallel would produce a same-file merge conflict on every rebase cycle.
+
+See [ORCHESTRATION.md](../ORCHESTRATION.md) (one level up) for the coordinator + worker protocol.

--- a/docs/agent-tasks/itunes-import/TASK-01-organize-imported-pool.md
+++ b/docs/agent-tasks/itunes-import/TASK-01-organize-imported-pool.md
@@ -1,0 +1,88 @@
+<!-- file: docs/agent-tasks/itunes-import/TASK-01-organize-imported-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d8cb07c6-f159-4357-b42e-2e151ee3e019 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-01 — Parallelize organizeImportedBooks file-organize + UpdateBook over imported books (CONC-10)
+
+**Priority:** P2 · **Effort:** M · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** File-move parallelism must ensure no two books resolve to the same target path. · **Depends on:** none
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/itunes-import-organize-imported-pool" -b agent/itunes-import-organize-imported-pool origin/main
+cd "$REPO/.worktrees/itunes-import-organize-imported-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap the per-book organize loop in registry.RunItems[T] (Concurrency for file I/O + DB write; NumCPU-ish). Guard the shared itunesImportStatus{mu sync.Mutex} counters (already mutex-bearing — use it). Preserve the operations.SaveCheckpoint progress cadence.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Embarrassingly parallel file I/O: bounded pool (fix-pattern #1), reusing the existing status mutex.
+- Current behavior: Per-book file rename/organize + UpdateBook over all LibraryState=="imported" books; real file I/O + DB write per item. Uses itunesImportStatus (has sync.Mutex) and logger.Logger.
+- **Shared mutable state / correctness constraint (READ TWICE):** itunesImportStatus already has a sync.Mutex — use it for the counters. File moves must not collide on paths; per-book book directories are disjoint, but verify no two imported books resolve to the same target path before enabling.
+- Source audit finding: `CONC-10` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "func (imp \*Importer) organizeImportedBooks" internal/itunes/service/importer.go   # expect: 1 hit (~line 1065)
+  ```
+
+## Step-by-step
+
+1. Open `internal/itunes/service/importer.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/itunes/service/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/itunes/service/importer.go` returns ≥1).
+- [ ] `go test -race ./internal/itunes/service/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(itunes): parallelize organizeImportedBooks file-organize + UpdateBook over imported books (CONC-10)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/itunes/service/importer.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/itunes-import/TASK-02-enrich-imported-pool.md
+++ b/docs/agent-tasks/itunes-import/TASK-02-enrich-imported-pool.md
@@ -1,0 +1,90 @@
+<!-- file: docs/agent-tasks/itunes-import/TASK-02-enrich-imported-pool.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c9c4e7fd-2e8c-41fc-b0c0-c1416c732d56 -->
+<!-- last-edited: 2026-07-05 -->
+
+# TASK-02 — Parallelize enrichImportedBooks metadata fetch with a bounded pool preserving the rate-limit circuit-breaker (CONC-11)
+
+**Priority:** P3 · **Effort:** L · **Recommended subagent:** Sonnet-class · go-backend subagent · **Why:** Circuit-breaker semantics must survive parallelization — reframe 'consecutive' as a shared atomic. · ⚠ review-critical · **Depends on:** TASK-01
+
+> **Depends on TASK-01 (same file `internal/itunes/service/importer.go`).** Do NOT start until TASK-01's PR is merged to `origin/main` and this worktree is rebased on top — running them concurrently guarantees a rebase conflict.
+
+## ⛔ START HERE (do this first, exactly)
+
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer   # adjust to your clone
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/itunes-import-enrich-imported-pool" -b agent/itunes-import-enrich-imported-pool origin/main
+cd "$REPO/.worktrees/itunes-import-enrich-imported-pool"
+git rebase origin/main
+```
+
+(Protocol is also in `docs/agent-tasks/ORCHESTRATION.md` — the inline block above is authoritative for this task.)
+
+## Goal
+
+Wrap the per-book FetchMetadataForBook loop in registry.RunItems[T] with a CONSERVATIVE Concurrency (network + external rate limit). CRITICAL: preserve the consecutiveErrors>=5 circuit-breaker semantics — a naive fan-out breaks it. Simplest safe shape: keep the breaker as a shared atomic counter that any worker can trip to cancel the ctx, so the bounded pool still aborts after 5 consecutive failures.
+
+Reuse the existing concurrency primitive — do NOT invent a new worker-pool helper or a new concurrency constant:
+
+- **`registry.RunItems[T]`** — `func RunItems[T any](ctx context.Context, r registry.Reporter, items []T, fn func(ctx context.Context, item T) error, opts ...registry.RunItemsOptions) error` (in `internal/operations/registry/run_items.go`). Options: `registry.RunItemsOptions{Concurrency int, PerItemTimeout time.Duration, ErrMode ErrMode, Label func(i,total)}`. Concurrency<1 defaults to a safe value; Concurrency==1 takes the sequential path (runItemsSeq); >1 uses runItemsPar. Reporter carries UpdateProgress(current,total,msg) so progress reporting is preserved for free.
+- Copy the invocation shape verbatim from a live caller — `internal/plugins/acoustid/backfill.go` (the `registry.RunItems(ctx, reporter, slice, func(ctx, b database.Book) error {...}, registry.RunItemsOptions{Concurrency: ...})` call). Re-locate it and the helper before using them (do not trust bare line numbers):
+  ```bash
+  grep -n "func RunItems\[" internal/operations/registry/run_items.go                                            # expect: 1 hit (the helper def)
+  grep -n "registry.RunItems" internal/plugins/acoustid/backfill.go   # expect: >=1 hit — copy this invocation shape verbatim
+  ```
+
+## Background (verify before editing)
+
+- Fix pattern (from `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`): Rate-limited external calls with a circuit-breaker: bounded pool preserving the breaker (fix-pattern #4).
+- Current behavior: Per-book metadata-fetch network call with deliberate rate-limit backoff + a consecutiveErrors>=5 breaker. Same file as TASK-01 (importer.go) → MUST serialize after it.
+- **Shared mutable state / correctness constraint (READ TWICE):** The consecutiveErrors circuit-breaker is loop-carried serial state. Under a pool, 'consecutive' loses meaning — reframe as a shared atomic fail counter that cancels the context at a threshold, or keep enrich at low concurrency. Do NOT drop the breaker. Guard itunesImportStatus via its mutex.
+- Source audit finding: `CONC-11` in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`.
+
+- **Re-verify these anchors before editing** — line numbers drift, they are a starting point only:
+  ```bash
+  grep -n "func (imp \*Importer) enrichImportedBooks\|consecutiveErrors >= 5\|imp.mfs.FetchMetadataForBook" internal/itunes/service/importer.go   # expect: func ~1012, breaker ~1038, fetch ~1034
+  ```
+
+## Step-by-step
+
+1. Open `internal/itunes/service/importer.go` and locate the target loop(s) via the grep(s) above (never trust the line number in this brief). 
+2. Replace the sequential `for` loop with `registry.RunItems[T]` over the same items, with a `Concurrency` value chosen per the Goal (CPU-bound → `runtime.NumCPU()`; network/rate-limited → a small fixed const with a named knob). Pass the existing Reporter/progress so progress reporting is preserved.
+3. **Guard the shared state exactly as described above** — this is where a wrong change becomes a silent data race. Prefer per-worker-local state merged at the end, or a `sync.Mutex`/`sync.Map`; if you drop a dedup map, justify it by upsert idempotency in the commit body.
+4. Keep the change purely additive to behavior: do NOT change the function signature, the emitted candidate semantics, or adjacent checks — the parallel version must produce the SAME output as the serial one.
+5. Add a test asserting the parallel loop yields the same result set / same writes as the serial version (order-independent), plus a `-race` run.
+6. Bump the file header (version + last-edited) on every file you touch; keep existing guids.
+
+## How to test
+
+```bash
+go test -race ./internal/itunes/service/... -count=1
+make ci
+```
+
+## Acceptance criteria
+
+- [ ] The target loop now runs through `registry.RunItems[T]` (verify: `grep -n "registry.RunItems" internal/itunes/service/importer.go` returns ≥1).
+- [ ] `go test -race ./internal/itunes/service/...` is clean (no data race on the shared state named above).
+- [ ] Anti-over-suppression: N/A (this task adds no filter/guard/veto/skip/dedupe path — it parallelizes an existing loop; correctness = identical output to the serial version).
+- [ ] `make ci` green; `go vet` clean.
+- [ ] File headers bumped on every changed file (`grep -n "last-edited: 2026-07-05" <file>`).
+
+## Commit message
+
+```
+perf(itunes): parallelize enrichImportedBooks metadata fetch with a bounded pool preserving the rate-limit circuit-breaker (CONC-11)
+
+Parallelize the previously single-threaded loop via registry.RunItems, guarding
+the shared state noted in the brief so the parallel pass produces identical output.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Done
+
+STOP — report done with exact counts; the coordinator owns push/PR/merge.
+
+## Idempotency / Rollback
+
+Idempotency: `grep -n "registry.RunItems" internal/itunes/service/importer.go` — if the target loop already routes through RunItems, this task may be complete; run the acceptance checks instead of re-applying. Rollback: revert the single commit; the loop returns to sequential, no data or schema is touched, siblings unaffected.

--- a/docs/agent-tasks/itunes-import/orchestration.md
+++ b/docs/agent-tasks/itunes-import/orchestration.md
@@ -1,0 +1,58 @@
+<!-- file: docs/agent-tasks/itunes-import/orchestration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 13e10220-b6f2-47c6-826c-1e1cdcb3121d -->
+<!-- last-edited: 2026-07-05 -->
+
+# Orchestration — itunes-import workstream
+
+Read the package-level [`../ORCHESTRATION.md`](../ORCHESTRATION.md) first. This file only adds the workstream-specific wave order.
+
+**Execution mode:** SERIAL WAVES (coordinator-driven) — trigger: both tasks edit internal/itunes/service/importer.go (collision table row 2); enrich (TASK-02) serializes after organize (TASK-01).
+
+## Waves (respect `Depends on:`)
+
+```mermaid
+flowchart LR
+    subgraph Wave1
+      TASK01[TASK-01 organize-imported-pool]
+    end
+    subgraph Wave2
+      TASK02[TASK-02 enrich-imported-pool]
+    end
+    TASK01 --> TASK02
+```
+
+- **Wave 1** (single task): TASK-01.
+- **Wave 2** (serialized): TASK-02 — MUST NOT start until wave 1's PR is merged to `origin/main` and this worktree is rebased on top.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+## Run it
+
+```bash
+# from docs/agent-tasks/itunes-import/
+./run.sh                 # print task list + set up worktrees
+./run.sh 01 ./run.sh 02
+```
+
+After each wave: gate each worktree with `make ci`, push/PR/merge as coordinator, then rebase remaining sibling worktrees onto `origin/main` before starting the next wave.

--- a/docs/agent-tasks/itunes-import/run.sh
+++ b/docs/agent-tasks/itunes-import/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# file: docs/agent-tasks/itunes-import/run.sh
+# version: 1.0.0
+# guid: 482418f2-4528-43bc-8926-22c0c5a3b3bf
+# last-edited: 2026-07-05
+#
+# Thin wrapper for the itunes-import workstream. See orchestration.md for wave order
+# (some tasks share files and must serialize).
+#   ./run.sh            # print task list + set up worktrees
+#   ./run.sh 01 03      # subset (two-digit task numbers)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(basename "$HERE")"
+echo "Workstream: $WS — see orchestration.md for wave order before running tasks in parallel."
+if [ -x "$HERE/../run-sweep.sh" ]; then
+  exec "$HERE/../run-sweep.sh" "$WS" "$@"
+fi
+REPO="$(git -C "$HERE" rev-parse --show-toplevel)"
+BRANCH_BASE="origin/main"
+for NN in "$@"; do
+  BRIEF=$(ls "$HERE"/TASK-"$NN"-*.md 2>/dev/null | head -1) || { echo "no brief TASK-$NN"; continue; }
+  SLUG=$(basename "$BRIEF" .md | sed 's/^TASK-[0-9]*-//')
+  git -C "$REPO" worktree add "$REPO/.worktrees/$WS-$SLUG" -b "agent/$WS-$SLUG" "$BRANCH_BASE" 2>/dev/null || true
+  {
+    echo "You are an autonomous coding agent. Execute this task exactly. Do not skip the START HERE setup. Stop and report if any acceptance criterion fails."
+    echo; cat "$BRIEF"
+  } > "$HERE/TASK-$NN.agent-prompt.txt"
+  echo "prepared TASK-$NN -> worktree .worktrees/$WS-$SLUG + TASK-$NN.agent-prompt.txt"
+done
+if [ $# -eq 0 ]; then ls "$HERE"/TASK-*.md; fi

--- a/docs/concurrency-parallelization/00-ROADMAP.md
+++ b/docs/concurrency-parallelization/00-ROADMAP.md
@@ -1,0 +1,39 @@
+<!-- file: docs/concurrency-parallelization/00-ROADMAP.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 334fbe0c-c953-40ef-99fc-90053336cb1f -->
+<!-- last-edited: 2026-07-05 -->
+
+# Concurrency Parallelization — Roadmap
+
+Initiative index for the 5 workstreams that turn `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` into
+execution-ready work. Design rationale + locked decisions: [`docs/specs/2026-07-05-concurrency-parallelization-design.md`](../specs/2026-07-05-concurrency-parallelization-design.md).
+Fan-out plan + buckets: [`../agent-tasks/BREAKDOWN-2026-07-05.md`](../agent-tasks/BREAKDOWN-2026-07-05.md).
+Implementation plan with the full dependency graph: [`../plans/2026-07-05-concurrency-parallelization.md`](../plans/2026-07-05-concurrency-parallelization.md).
+
+> Terminology note: **Rank** below is workstream execution order (0 = do first),
+> distinct from a task's **plan-op Tier** (S/M/L output size) and its **model tier**
+> (Haiku/Sonnet/Opus-class). All three appear in this package; do not conflate them.
+
+## Workstreams by rank
+
+| Rank | Workstream | What | Priority | Tasks | Execution mode |
+|---|---|---|---|---|---|
+| 1 | [`dedup-engine/`](../agent-tasks/dedup-engine/) | dedup engine scan concurrency | P1 | 4 | SERIAL WAVES (coordinator-driven) |
+| 2 | [`backfill-pools/`](../agent-tasks/backfill-pools/) | backfill worker pools | P2 | 4 | /parallel-sweep |
+| 3 | [`acoustid-consolidation/`](../agent-tasks/acoustid-consolidation/) | acoustid backfill consolidation | P2 | 1 | SINGLE-AGENT (strong model) |
+| 4 | [`itunes-import/`](../agent-tasks/itunes-import/) | itunes import concurrency | P2 | 2 | SERIAL WAVES (coordinator-driven) |
+| 5 | [`bulk-ops-pools/`](../agent-tasks/bulk-ops-pools/) | bulk + request-driven op pools | P3 | 4 | /parallel-sweep |
+
+## Sequencing
+
+- **Across workstreams:** every workstream touches a disjoint file set, so all 5 can run
+  concurrently. Rank orders them by value/risk when capacity is limited — do WS-1
+  (the confirmed prod incident) first.
+- **Within a workstream:** collision-bound workstreams (WS-1 `engine.go`, WS-4
+  `importer.go`) serialize their tasks into waves; the rest run their tasks in one
+  parallel wave. See each workstream's `README.md` wave table and `orchestration.md`.
+
+## Deferred (not in this initiative)
+
+- **Bucket 2 (needs design first):** AutoResolveCertain, applyRegroupPlan — correctness-constrained; see the BREAKDOWN.
+- **Bucket 3 (operational / low value):** PurgeStaleCandidates, One-time migrations/backfills.

--- a/docs/plans/2026-07-05-concurrency-parallelization.md
+++ b/docs/plans/2026-07-05-concurrency-parallelization.md
@@ -1,0 +1,377 @@
+<!-- file: docs/plans/2026-07-05-concurrency-parallelization.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 06b6cc79-6ae5-47c0-8dc6-ae0ffd787b6a -->
+<!-- last-edited: 2026-07-05 -->
+
+# Concurrency Parallelization Implementation Plan
+
+Companion to:
+- `docs/specs/2026-07-05-concurrency-parallelization-design.md` (CONC-1..15 findings)
+- `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md` (source audit)
+
+Coordination model: the coordinator reviews and owns ALL git/gh; worker subagents
+execute one task each in an isolated worktree, PR per task, rebase/FF merges,
+`make ci` gates every PR. Tasks marked **⚠ review-critical** change dedup output or
+delete a code path and require line-by-line coordinator review before merge.
+
+## Dependency graph
+
+```mermaid
+graph TD
+  subgraph WS1[dedup-engine]
+    dedupengine01[TASK-01 booksigscan-shard]
+    dedupengine02[TASK-02 fullscan-unified-pool]
+    dedupengine03[TASK-03 acoustidscan-pool]
+    dedupengine04[TASK-04 fullscan-main-split]
+  end
+  subgraph WS2[backfill-pools]
+    backfillpools01[TASK-01 embed-scan-pool]
+    backfillpools02[TASK-02 embedding-backfill-pool]
+    backfillpools03[TASK-03 tag-backfill-pool]
+    backfillpools04[TASK-04 gold-label-memoize-pool]
+  end
+  subgraph WS3[acoustid-consolidation]
+    acoustidconsolidation01[TASK-01 delete-serial-server-backfill]
+  end
+  subgraph WS4[itunes-import]
+    itunesimport01[TASK-01 organize-imported-pool]
+    itunesimport02[TASK-02 enrich-imported-pool]
+  end
+  subgraph WS5[bulk-ops-pools]
+    bulkopspools01[TASK-01 bulk-fetch-metadata-pool]
+    bulkopspools02[TASK-02 batch-update-import-metadata-pool]
+    bulkopspools03[TASK-03 duration-backfill-pool]
+    bulkopspools04[TASK-04 path-reconcile-pool]
+  end
+  dedupengine01 --> dedupengine02
+  dedupengine02 --> dedupengine03
+  dedupengine03 --> dedupengine04
+  itunesimport01 --> itunesimport02
+```
+
+## Model assignments (authoritative — overrides per-task `Agent:` lines)
+
+| Model | Tasks | Rationale |
+|---|---|---|
+| **Haiku-class** | bulk-ops-pools/TASK-03, bulk-ops-pools/TASK-04 | fully specified mechanical N+1 mirrors; failure cheap, caught by `make ci` |
+| **Sonnet-class** | dedup-engine/TASK-02, dedup-engine/TASK-03, dedup-engine/TASK-04, backfill-pools/TASK-01, backfill-pools/TASK-02, backfill-pools/TASK-03, backfill-pools/TASK-04, itunes-import/TASK-01, itunes-import/TASK-02, bulk-ops-pools/TASK-01, bulk-ops-pools/TASK-02 | pool + shared-state guarding + integration; ⚠-flagged get coordinator line-review |
+| **Opus-class** | dedup-engine/TASK-01, acoustid-consolidation/TASK-01 | O(n²) sharding correctness (WS-1/T01) and delete/redirect caller-wiring (WS-3/T01) — irreversible-shaped, strongest tier |
+
+## Parallel execution groups
+
+| Wave | Tasks (parallel within wave) | Execution mode / notes |
+|---|---|---|
+| dedup-engine W1 | TASK-01 | SERIAL WAVES (coordinator-driven) |
+| dedup-engine W2 | TASK-02 | SERIAL WAVES — shares internal/dedup/engine.go with wave 1 |
+| dedup-engine W3 | TASK-03 | SERIAL WAVES — shares internal/dedup/engine.go with wave 2 |
+| dedup-engine W4 | TASK-04 | SERIAL WAVES — shares internal/dedup/engine.go with wave 3 |
+| backfill-pools W1 | TASK-01, TASK-02, TASK-03, TASK-04 | /parallel-sweep — trigger: 4 similar tasks, disjoint files |
+| acoustid-consolidation W1 | TASK-01 | SINGLE-AGENT (strong model) |
+| itunes-import W1 | TASK-01 | SERIAL WAVES (coordinator-driven) |
+| itunes-import W2 | TASK-02 | SERIAL WAVES — shares internal/itunes/service/importer.go with wave 1 |
+| bulk-ops-pools W1 | TASK-01, TASK-02, TASK-03, TASK-04 | /parallel-sweep — trigger: 4 similar tasks, disjoint files |
+
+Same-file serialization: `internal/dedup/engine.go` (WS-1 T01→T02→T03→T04);
+`internal/itunes/service/importer.go` (WS-4 T01→T02). All other files are
+single-task. WS-1 (the confirmed incident) starts first.
+
+## Coordinator protocol (verbatim)
+
+> **Coordinator owns git. Workers never push.** Each worker operates only inside its
+> assigned worktree: edit, test, commit — then stop. Workers never run `git push`,
+> `gh pr`, or any merge command. The coordinator runs the gate (`make ci`) in each
+> finished worktree, opens the PR, merges (rebase/FF unless the repo profile says
+> otherwise), and then **rebases every open sibling worktree** before dispatching
+> anything else.
+>
+> **Per-merge sibling-rebase loop:** after EVERY merge to `origin/main`:
+> for each open sibling worktree, `git fetch origin && git rebase
+> origin/main`. A sibling that skips a rebase is a future conflict.
+>
+> **Conflict escalation ladder** (in order, never skip a rung): 1) clean rebase;
+> 2) conflict-resolver subagent (Sonnet-class, only when the conflict spans 1–3 small
+> files); 3) file-copy cherry-pick fallback — re-apply the task's file states onto a
+> fresh branch from HEAD; 4) mark `rebase_blocked`, stop the lane, escalate to a human.
+>
+> **A wave MUST NOT start** while any of: the previous wave has an unmerged PR; any
+> sibling worktree is un-rebased; the gate is red on `origin/main`; or a
+> `rebase_blocked` marker is unresolved.
+
+---
+
+### TASK-01 (dedup-engine): Shard BookSignatureScan's O(n²) pairwise loop across a bounded worker pool [⚠ review-critical]
+Priority: P1 · Effort: L · Agent: Opus-class · Depends on: none
+
+**Context.** CONC-1 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n 'for j := i + 1; j < len(booksWithSig); j++' internal/dedup/engine.go` (1 hit (~line 3638)). Shared state: The `emitted map[string]struct{}` (~line 3599, keyed by canonical pairKey) is read-check-then-written inside emit(). NOTE the triangular i<j loop already visits each unordered pair...
+
+**Exact files to change**
+- `internal/dedup/engine.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/dedup-engine/TASK-01-booksigscan-shard.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/dedup/engine.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-02 (dedup-engine): Parallelize FullScan's unified-scoring pass with a bounded worker pool
+Priority: P1 · Effort: M · Agent: Sonnet-class · Depends on: TASK-01
+
+**Context.** CONC-2 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n 'runUnifiedScoringForBook(ctx, &book, authorName)' internal/dedup/engine.go` (1 hit (~line 2557)). Shared state: None in-memory at the FullScan layer. The ONLY hazard is the shared bookStore/embedStore backends (per-book reads and writes). CONFIRM those stores are goroutine-safe before enabli...
+
+**Exact files to change**
+- `internal/dedup/engine.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/dedup-engine/TASK-02-fullscan-unified-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/dedup/engine.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-03 (dedup-engine): Parallelize AcoustIDScan's per-book loop with a bounded pool and guard its four shared maps [⚠ review-critical]
+Priority: P2 · Effort: L · Agent: Sonnet-class · Depends on: TASK-02
+
+**Context.** CONC-3 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n 'cands, _ := lshStore.LookupAcoustIDCandidates' internal/dedup/engine.go` (1 hit (~line 3486)). Shared state: FOUR unguarded maps + a counter, ALL mutated inside emit()/the loop and ALL must be guarded when sharding: `emitted map[string]struct{}` (~3348), `boilerplateBookCache map[string]b...
+
+**Exact files to change**
+- `internal/dedup/engine.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/dedup-engine/TASK-03-acoustidscan-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/dedup/engine.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-04 (dedup-engine): Parallelize FullScan main-pass Layer-1 checks while keeping Layer-2 embedding batching serial [⚠ review-critical]
+Priority: P2 · Effort: L · Agent: Sonnet-class · Depends on: TASK-03
+
+**Context.** CONC-4 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n 'de.checkExactFileHash(&book, authorName)' internal/dedup/engine.go` (1 hit (~line 2482)). Shared state: Loop-carried SERIAL state that makes this NOT embarrassingly parallel: `chunkIDs []string` (appended each iter, reset in flushChunk), `chunkStart int`, `embedConsecutiveFails int`,...
+
+**Exact files to change**
+- `internal/dedup/engine.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/dedup-engine/TASK-04-fullscan-main-split.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/dedup/engine.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-01 (backfill-pools): Parallelize dedup.embed-scan sync path with a rate-limited worker pool
+Priority: P2 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-5 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "status, embedErr := p.engine.EmbedBook(ctx, book.ID)" internal/plugins/dedup/embed_scan.go` (1 hit (~line 135)). Shared state: None in-memory beyond the op status; the constraint is the embedding backend rate limit — pick a small fixed Concurrency (const knob), not NumCPU....
+
+**Exact files to change**
+- `internal/plugins/dedup/embed_scan.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/plugins/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/backfill-pools/TASK-01-embed-scan-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/plugins/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/plugins/dedup/embed_scan.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-02 (backfill-pools): Parallelize the startup embedding backfill loops over books and authors
+Priority: P2 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-6 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "s.dedupEngine.EmbedBook(ctx, book.ID)\|s.dedupEngine.EmbedAuthor(ctx, author.ID)" internal/server/embedding_backfill.go` (2 hits (~lines 79, 119)). Shared state: None in-memory of concern; network rate limit is the constraint. Startup path — confirm a Reporter (or a nil-safe progress) is available here as it is in the plugin path....
+
+**Exact files to change**
+- `internal/server/embedding_backfill.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/server/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/backfill-pools/TASK-02-embedding-backfill-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/server/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/server/embedding_backfill.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-03 (backfill-pools): Parallelize the tag-backfill ExtractMetadata loop with a CPU-sized pool
+Priority: P2 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-7 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "meta, merr := metadata.ExtractMetadata(f.FilePath, nil)" internal/plugins/maintenance/tag_backfill.go` (1 hit (~line 125)). Shared state: None in-memory of concern; per-item ExtractMetadata is independent. I/O-bound → NumCPU*4 is the established repo sizing....
+
+**Exact files to change**
+- `internal/plugins/maintenance/tag_backfill.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/plugins/maintenance/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/backfill-pools/TASK-03-tag-backfill-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/plugins/maintenance/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/plugins/maintenance/tag_backfill.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-04 (backfill-pools): Add book-lookup memoization then parallelize mine_gold_labels and dataset_backfill
+Priority: P2 · Effort: L · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-8 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "a, aErr := adapter.GetBook(c.EntityAID)" internal/plugins/dedup/mine_gold_labels.go` (1 hit (~line 101)). Shared state: If you share one memoization map across workers it must be mutex-guarded (or use sync.Map); simplest correct shape is a per-worker-local cache. The candidate processing itself is i...
+
+**Exact files to change**
+- `internal/plugins/dedup/mine_gold_labels.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/plugins/dedup/dataset_backfill.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/plugins/dedup/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/backfill-pools/TASK-04-gold-label-memoize-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/plugins/dedup/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/plugins/dedup/mine_gold_labels.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-01 (acoustid-consolidation): Delete the serial server-side AcoustID backfill and route startup to the parallel plugin op [⚠ review-critical]
+Priority: P2 · Effort: M · Agent: Opus-class · Depends on: none
+
+**Context.** CONC-9 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "func (s \*Server) backfillAcoustIDs" internal/server/acoustid_backfill.go` (1 hit (~line 109)). Shared state: Deletion/redirect task — the risk is a dangling reference. Grep every symbol defined in acoustid_backfill.go for external callers before removing. This is why it is Opus-class and ...
+
+**Exact files to change**
+- `internal/server/acoustid_backfill.go` — DELETE the serial `backfillAcoustIDs` duplicate (move any shared helper first)
+- `internal/server/server_lifecycle.go` — remove the single `s.backfillAcoustIDs(s.bgCtx)` call site
+- verification: `go build ./...` + no-caller grep (no new test file; the parallel plugin op already has coverage)
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/acoustid-consolidation/TASK-01-delete-serial-server-backfill.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] `internal/server/acoustid_backfill.go`'s serial `backfillAcoustIDs` is gone and has no remaining caller (`grep -rn "s.backfillAcoustIDs(" --include=*.go .` → 0).
+- [ ] the parallel plugin op `acoustid.backfill` is intact; `go build ./...` clean (any shared helper moved, not lost).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `! test -f internal/server/acoustid_backfill.go && ! grep -rq "s.backfillAcoustIDs(" --include=*.go .`. **Rollback.** Revert the single commit to restore the file + its call site; no data/schema touched.
+
+### TASK-01 (itunes-import): Parallelize organizeImportedBooks file-organize + UpdateBook over imported books
+Priority: P2 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-10 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "func (imp \*Importer) organizeImportedBooks" internal/itunes/service/importer.go` (1 hit (~line 1065)). Shared state: itunesImportStatus already has a sync.Mutex — use it for the counters. File moves must not collide on paths; per-book book directories are disjoint, but verify no two imported book...
+
+**Exact files to change**
+- `internal/itunes/service/importer.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/itunes/service/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/itunes-import/TASK-01-organize-imported-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/itunes/service/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/itunes/service/importer.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-02 (itunes-import): Parallelize enrichImportedBooks metadata fetch with a bounded pool preserving the rate-limit circuit-breaker [⚠ review-critical]
+Priority: P3 · Effort: L · Agent: Sonnet-class · Depends on: TASK-01
+
+**Context.** CONC-11 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "func (imp \*Importer) enrichImportedBooks\|consecutiveErrors >= 5\|imp.mfs.FetchMetadataForBook" internal/itunes/service/importer.go` (func ~1012, breaker ~1038, fetch ~1034). Shared state: The consecutiveErrors circuit-breaker is loop-carried serial state. Under a pool, 'consecutive' loses meaning — reframe as a shared atomic fail counter that cancels the context at ...
+
+**Exact files to change**
+- `internal/itunes/service/importer.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/itunes/service/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/itunes-import/TASK-02-enrich-imported-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/itunes/service/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/itunes/service/importer.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-01 (bulk-ops-pools): Parallelize bulkFetchMetadataImpl over req.BookIDs with a conservative request-scoped pool
+Priority: P3 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-12 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "for _, bookID := range req.BookIDs" internal/server/handlers/metadata/handler.go` (1 hit (~line 794)). Shared state: Request-scoped: keep concurrency low to avoid starving the server and tripping the metadata source's rate limit. Result aggregation slice needs guarding....
+
+**Exact files to change**
+- `internal/server/handlers/metadata/handler.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/server/handlers/metadata/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/bulk-ops-pools/TASK-01-bulk-fetch-metadata-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/server/handlers/metadata/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/server/handlers/metadata/handler.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-02 (bulk-ops-pools): Parallelize BatchUpdateMetadata and ImportMetadata per-item DB round-trips
+Priority: P3 · Effort: M · Agent: Sonnet-class · Depends on: none
+
+**Context.** CONC-13 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "for i, update := range updates" internal/metadata/enhanced.go` (1 hit (~line 166)). Shared state: Result/error aggregation must be guarded. UpdateBook writes — confirm store goroutine-safety at the chosen concurrency....
+
+**Exact files to change**
+- `internal/metadata/enhanced.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/metadata/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/bulk-ops-pools/TASK-02-batch-update-import-metadata-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/metadata/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/metadata/enhanced.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-03 (bulk-ops-pools): Parallelize the duration-backfill per-book GetBookFiles loop
+Priority: P3 · Effort: S · Agent: Haiku-class · Depends on: none
+
+**Context.** CONC-14 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "files, ferr := store.GetBookFiles(book.ID)" internal/plugins/maintenance/duration_backfill.go` (1 hit (~line 112)). Shared state: Independent per book; guard any shared counter/result via the Reporter/atomics....
+
+**Exact files to change**
+- `internal/plugins/maintenance/duration_backfill.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/plugins/maintenance/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/bulk-ops-pools/TASK-03-duration-backfill-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/plugins/maintenance/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/plugins/maintenance/duration_backfill.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+### TASK-04 (bulk-ops-pools): Parallelize the itunes path-reconcile per-book GetBookFiles loop
+Priority: P3 · Effort: S · Agent: Haiku-class · Depends on: none
+
+**Context.** CONC-15 in `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`; spec C-component. Anchor: `grep -n "bookFiles, _ := r.store.GetBookFiles(b.ID)" internal/itunes/service/path_reconcile.go` (1 hit (~line 89)). Shared state: Independent per book; guard any shared reconcile accumulator via mutex/atomics....
+
+**Exact files to change**
+- `internal/itunes/service/path_reconcile.go` — parallelize the audited loop via registry.RunItems (+ guard shared state)
+- `internal/itunes/service/*_test.go` — NEW: parallel-same-as-serial + `-race` test
+
+**Step-by-step.** See the self-contained brief `docs/agent-tasks/bulk-ops-pools/TASK-04-path-reconcile-pool.md` (worktree block, re-verify greps, guarding, tests). Final step: `make ci`.
+
+**Acceptance criteria**
+- [ ] target loop routes through `registry.RunItems`; `go test -race ./internal/itunes/service/...` clean.
+- [ ] parallel output identical to serial (same-output test).
+- [ ] `make ci` green.
+
+**Idempotency.** Done if `grep -n "registry.RunItems" internal/itunes/service/path_reconcile.go` hits. **Rollback.** Revert the single commit; loop returns to sequential; no data/schema touched.
+
+
+## Review gates for the coordinator
+
+Line-by-line review mandatory: **dedup-engine/TASK-01, dedup-engine/TASK-03, dedup-engine/TASK-04, acoustid-consolidation/TASK-01, itunes-import/TASK-02** (O(n²) sharding correctness; file deletion + caller wiring). Standard review: all others. Every PR: `make ci` green + the task's acceptance checklist pasted and ticked in the PR description + a `-race` run + COMPLETED/REMAINING/BLOCKED counts in the final status comment.

--- a/docs/specs/2026-07-05-concurrency-parallelization-design.md
+++ b/docs/specs/2026-07-05-concurrency-parallelization-design.md
@@ -1,0 +1,141 @@
+<!-- file: docs/specs/2026-07-05-concurrency-parallelization-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e62615dc-7ad9-47df-992a-1592e26e301e -->
+<!-- last-edited: 2026-07-05 -->
+
+# Concurrency Parallelization — Design Spec
+
+**Status:** Draft <!-- flip to: Approved — ready for implementation planning, at Gate 2 -->
+**Scope:** Go backend only — the single-threaded whole-library/large-set loops catalogued in the concurrency audit. No schema changes, no API-surface changes, no frontend.
+**Parent audit:** `docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`
+
+---
+
+## Motivation
+
+On 2026-07-05 a prod `dedup.full-scan` run went **silent for 3+ hours at 100%+ CPU on a single core** — `Engine.FullScan`'s unified-scoring pass is a plain `for _, book := range books` loop over ~29,200 books with zero concurrency. PR #1805 added progress/ETA reporting for that pass, but the loop itself is still fully sequential. The follow-up audit (`docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`) swept the codebase with three read-only agents and catalogued **16 single-threaded hotspots** — 10 high-confidence, 6 medium — that do meaningful per-item CPU- or I/O-bound work with no worker pool, plus a fix-pattern taxonomy and a priority order.
+
+This spec turns that audit into an execution-ready plan: **15 parallelization tasks across 5 workstreams**, each reusing the existing `registry.RunItems` primitive, plus two correctness-constrained items deferred to a design session. Every anchor in every task was re-verified at HEAD during planning (the audit's line numbers had already drifted).
+
+**Goal:** eliminate the single-threaded whole-library hot paths by routing each catalogued loop through a bounded worker pool, with **identical output to the serial version** as the correctness bar.
+
+## Goals
+
+- Route every high/medium-confidence audit finding through `registry.RunItems` with an appropriately-sized `Concurrency`, preserving existing progress reporting.
+- Preserve output semantics exactly — a parallelized scan emits the same dedup candidates; a parallelized backfill writes the same rows. No behavior change beyond wall-clock.
+- Guard every shared mutable structure a pool touches (the audit's `emitted`/cache maps, counters, circuit-breakers) against data races, proven with `go test -race`.
+- Keep each task weak-model-executable in isolation and conflict-free under parallel execution (collision-derived waves).
+
+## Non-goals (v1)
+
+- Redesigning correctness-constrained apply paths (`AutoResolveCertain`'s merge, `applyRegroupPlan`'s PID mutation) — deferred to Bucket 2; a blind pool there is unsafe.
+- Tuning the LSH/HNSW index internals or the embedding backend — out of scope; we parallelize callers, not the stores.
+- Introducing a new concurrency framework — `registry.RunItems` already exists and is the standard; adding a second primitive is explicitly rejected.
+- Changing `Concurrency` defaults globally or adding a shared config surface — each task picks a local, documented value.
+
+## Decisions (locked during design)
+
+1. **Reuse `registry.RunItems[T]`, do not hand-roll pools.** `internal/operations/registry/run_items.go` already provides `RunItems[T](ctx, Reporter, items, fn, RunItemsOptions{Concurrency,...})` with a sequential path at `Concurrency==1`, a parallel path above, and Reporter-based progress. Live callers exist (`internal/plugins/acoustid/backfill.go:118`, `internal/reconcile/itunes_heal.go:731`, `internal/plugins/maintenance/intro_transcribe.go:190`). Rejected alternative: raw `errgroup`/`sync.WaitGroup` per site — would fragment the pattern and re-implement progress/error-mode handling five times.
+2. **Correctness bar is "identical output," not "faster."** Every task ships a test asserting the parallel pass produces the same result set / same writes as the serial version (order-independent) plus a `-race` run. This is the anti-over-suppression discipline applied to concurrency: a pool that silently drops writes through an unguarded map still "passes" a naive speed test.
+3. **Pool size by workload class, locally.** CPU-bound → `runtime.NumCPU()`; I/O-bound tag/file reads → `runtime.NumCPU()*4` (established precedent at `internal/itunes/service/path_repair_resolver.go`); network/rate-limited (embeddings, metadata sources) → a small fixed const with a named knob that respects the backend's existing rate limit. Rejected alternative: one global concurrency setting — wrong for the three different workload classes.
+4. **Shared-state hazards are per-task, named, and guarded.** The scouts found the burden is uneven: `FullScan`-unified has none (independent per book), `BookSignatureScan` has one `emitted` map, `AcoustIDScan` has **four** maps + a counter, `FullScan`-main has serial circuit-breaker state that must NOT be parallelized. Each brief names its exact shared state and the guarding approach.
+5. **`FullScan` main-pass is split, not blindly parallelized.** Its Layer-2 embedding batching + circuit-breaker (`chunkIDs`, `embedConsecutiveFails`, `embeddingsGaveUp`) is loop-carried serial state; only the Layer-1 exact checks parallelize. Rejected alternative: parallelize the whole loop — corrupts the batch accumulation and defeats the breaker.
+6. **`acoustid_backfill.go` is deleted, not fixed.** The serial server variant (`backfillAcoustIDs`, with a per-item `time.Sleep`) duplicates the already-parallel plugin op `acoustid.backfill`. It has exactly one caller (`server_lifecycle.go:910`); the fix is to remove that call and delete the file, after verifying no shared helper (e.g. `synthesizeBookSignatureForBook`) is referenced elsewhere. Rejected alternative: add a pool to the server variant — keeps two divergent implementations of the same job.
+7. **Design-judge panel skipped (auditable):** only one viable architecture per finding survives — the fix pattern is dictated by the workload class, and stakes are not an irreversible schema/data migration (every task is a revert-the-commit rollback). Per the plan-op rule, the skip is recorded here rather than paneled.
+
+## Data model
+
+No new persisted types. The only code-level shape introduced per task is the `RunItemsOptions` literal at each call site:
+
+```go
+// existing primitive — reused, not modified
+func RunItems[T any](
+    ctx context.Context,
+    r registry.Reporter,
+    items []T,
+    fn func(ctx context.Context, item T) error,
+    opts ...registry.RunItemsOptions,
+) error
+
+type RunItemsOptions struct {
+    Concurrency    int           // <1 => safe default; ==1 => sequential path; >1 => parallel
+    PerItemTimeout time.Duration
+    ErrMode        ErrMode       // ErrModeFail | ErrModeCollect
+    Label          func(i, total int) string
+}
+```
+
+### Persistence
+
+Unchanged. Every task reads and writes through the existing stores (`bookStore`, `embedStore`); the only new requirement is confirming those stores are goroutine-safe at the chosen `Concurrency` (Decision 2 gates enabling >1 on that confirmation).
+
+## Components
+
+### C1. dedup engine scans (`internal/dedup/engine.go`)
+
+The four whole-library scan loops. All in one file, so they **serialize** (WS-1, four waves). `BookSignatureScan` is O(n²) — the worst algorithmic shape and highest value; `AcoustIDScan` carries the heaviest shared-state burden (four maps + counter); `FullScan`-main requires the Layer-1/Layer-2 split. Fail-safe: if store goroutine-safety cannot be confirmed, the task ships at `Concurrency==1` (sequential path, no behavior change) and flags the blocker.
+
+### C2. whole-library backfills (`internal/plugins/**`, `internal/server/embedding_backfill.go`)
+
+Embarrassingly-parallel per-item backfills in disjoint files (WS-2, one parallel wave): `embed-scan`, startup embedding backfill, tag backfill, and the gold-label/dataset backfills (which additionally need book-lookup memoization mirroring `drain_stale.go` before the pool). Network-bound members use conservative fixed concurrency; I/O-bound use `NumCPU*4`.
+
+### C3. acoustid consolidation (`internal/server/acoustid_backfill.go`, `server_lifecycle.go`)
+
+Delete/redirect (WS-3, single task, ⚠ review-critical). Not a pool-add — a caller-wiring change.
+
+### C4. itunes import passes (`internal/itunes/service/importer.go`)
+
+`organizeImportedBooks` (file I/O) and `enrichImportedBooks` (network + a `consecutiveErrors>=5` circuit-breaker). Same file → serialize (WS-4, two waves). The enrich task must reframe "consecutive failures" as a shared atomic that cancels the context, since "consecutive" is meaningless under a pool.
+
+### C5. request-driven bulk ops (`internal/server/handlers/metadata/handler.go`, `internal/metadata/enhanced.go`, two remaining N+1 backfills)
+
+Conservative request-scoped pools (WS-5, one parallel wave, P3). Sized low because they run inline on user-facing HTTP requests.
+
+## Migration / integration
+
+Each task is a localized, additive edit: replace one `for` loop with a `registry.RunItems` call over the same items, add shared-state guarding, add a `-race` + same-output test. No caller of the changed function sees a signature or semantics change. The one exception is C3, which removes a call site and a file — its brief lists the single caller and mandates a pre-delete symbol-reference grep.
+
+## Milestones
+
+- **M1 — WS-1 dedup-engine (P1).** The confirmed incident and its neighbors; serial waves in `engine.go`. Highest value (`BookSignatureScan` O(n²) first).
+- **M2 — WS-2 backfill-pools (P2).** Parallel wave; the `/parallel-sweep` candidate.
+- **M3 — WS-3 acoustid-consolidation (P2).** Single ⚠ task; removes a serial duplicate.
+- **M4 — WS-4 itunes-import (P2).** Serial waves; rate-limit/circuit-breaker preservation.
+- **M5 — WS-5 bulk-ops (P3).** Conservative request-scoped pools.
+
+Each milestone is independently shippable and additive — no milestone depends on another (different files across workstreams), so M1–M5 may run concurrently across workstreams while serializing within the collision-bound ones.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `internal/dedup/engine.go` | 4 scan loops → pools (WS-1/T01–T04) |
+| `internal/plugins/dedup/embed_scan.go` | pool (WS-2/T01) |
+| `internal/server/embedding_backfill.go` | pool (WS-2/T02) |
+| `internal/plugins/maintenance/tag_backfill.go` | pool (WS-2/T03) |
+| `internal/plugins/dedup/mine_gold_labels.go`, `dataset_backfill.go` | memoize + pool (WS-2/T04) |
+| `internal/server/acoustid_backfill.go`, `internal/server/server_lifecycle.go` | delete + redirect (WS-3/T01) |
+| `internal/itunes/service/importer.go` | 2 import passes → pools (WS-4/T01–T02) |
+| `internal/server/handlers/metadata/handler.go`, `internal/metadata/enhanced.go` | pools (WS-5/T01–T02) |
+| `internal/plugins/maintenance/duration_backfill.go`, `internal/itunes/service/path_reconcile.go` | pools (WS-5/T03–T04) |
+
+## Testing
+
+| Test | Asserts |
+|---|---|
+| `Test<Scan>ParallelSameAsSerial` (per WS-1 task) | parallel pass emits the identical candidate set as the serial version on a fixture library; no lost writes through guarded shared state |
+| `go test -race ./internal/dedup/...` etc. | no data race on any named shared map/counter |
+| `Test<Backfill>ParallelSameWrites` (per WS-2/WS-5 task) | same rows written, order-independent |
+| WS-3 caller-reference grep | no symbol in `acoustid_backfill.go` is referenced after deletion |
+| `make ci` per PR | full gate green |
+
+## Rollback
+
+Every task is a single-commit `git revert` back to the sequential loop — no data, schema, or API is touched. WS-3 (the delete) reverts by restoring the file and its one call site. There is no feature flag because there is no behavior change to gate: the only observable difference is wall-clock, and `Concurrency==1` is always a safe fallback if a store turns out not to be goroutine-safe.
+
+## Open questions (resolved — recorded for the plan)
+
+1. ~~Are `bookStore`/`embedStore` goroutine-safe at `Concurrency>1`?~~ → Each WS-1/WS-2 task must confirm before enabling >1; if not, ship at `Concurrency==1` (sequential path) and file the store-safety blocker. Gating constraint, recorded in each brief.
+2. ~~Parallelize `FullScan` main-pass wholesale?~~ → No — split Layer-1 (parallel) from Layer-2 batching + circuit-breaker (serial). Locked in Decision 5.
+3. ~~Fix or delete the serial `acoustid_backfill.go`?~~ → Delete + redirect to the plugin op. Locked in Decision 6.
+4. ~~Include `AutoResolveCertain` / `applyRegroupPlan`?~~ → No — Bucket 2 (design session first; correctness-constrained). See the BREAKDOWN.


### PR DESCRIPTION
Planning-only Tier-L package that turns [`docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`](../blob/main/docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md) into execution-ready work. **No product code changes** — this PR adds docs only; the actual parallelization is done later by executing the briefs.

## What's here (34 files)

- **Design spec** — `docs/specs/2026-07-05-concurrency-parallelization-design.md` (7 locked decisions, fix-pattern taxonomy, non-goals, rollback)
- **Taskboard plan** — `docs/plans/2026-07-05-concurrency-parallelization.md` (dependency graph, model assignments, wave groups, coordinator protocol)
- **BREAKDOWN** — `docs/agent-tasks/BREAKDOWN-2026-07-05.md` (3-bucket sort, collision table)
- **Roadmap** — `docs/concurrency-parallelization/00-ROADMAP.md`
- **5 workstreams** (README + orchestration.md + run.sh) with **15 weak-model-proof TASK briefs**

## Workstreams

| Rank | Workstream | Tasks | Execution mode |
|---|---|---|---|
| 1 | dedup-engine | 4 | SERIAL WAVES (all `engine.go`) |
| 2 | backfill-pools | 4 | /parallel-sweep (disjoint files) |
| 3 | acoustid-consolidation | 1 | SINGLE-AGENT ⚠ (delete/redirect) |
| 4 | itunes-import | 2 | SERIAL WAVES (`importer.go`) |
| 5 | bulk-ops-pools | 4 | /parallel-sweep |

Every brief reuses `registry.RunItems`, names its shared-state hazard, and ships an identical-output-to-serial + `-race` acceptance test. All re-verify greps resolve at HEAD (checked by 6 scouts + a mechanical auditor; 15 brief-verifiers passed after two fix rounds).

**Deferred:** Bucket 2 (`AutoResolveCertain`, `applyRegroupPlan` — correctness-constrained, need design) and Bucket 3 (`PurgeStaleCandidates`, one-time backfills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)