### PR TITLE
fix(dedup): unresponsive cancellation in unified-scoring pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.109.0 -->
+<!-- version: 3.110.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-05 -->
 
@@ -8,6 +8,29 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 5, 2026 - fix(dedup): make FullScan's unified-scoring pass respond promptly to op cancellation
+
+- **`fix(dedup)`** — cancelling a running `dedup.full-scan` op tonight took
+  90+ seconds to take effect and eventually required a hard `systemctl
+  restart` to force it. Root cause:
+  `internal/dedup/engine.go`'s `runUnifiedScoringForBook` (invoked once per
+  book from `FullScan`'s unified composite-scoring pass) has an inner
+  `for _, ref := range embeddingCandIDs { ... }` loop over every pending
+  candidate for that one book, with zero cancellation check inside it. The
+  outer `FullScan` loop correctly checks `ctx.Err()` once per book, but a
+  single book with an unusually large pending-candidate set could keep that
+  inner loop running long after the op was cancelled, with no way to notice.
+  Added a `ctx.Err()` check at the top of the per-candidate loop, returning
+  `ctx.Err()` (the function's existing `error` contract) so cancellation is
+  now noticed at per-candidate granularity, not just per-book. Purely a
+  cancellation-check addition — no goroutines, worker pools, or other
+  concurrency mechanism (that's separate work being planned elsewhere). New
+  regression test `TestRunUnifiedScoringForBook_StopsPromptlyOnCancel`
+  (`internal/dedup/engine_cancellation_test.go`) seeds multiple pending
+  candidates for one book, cancels the context mid-loop via a
+  `GetBookByID` hook, and asserts the function returns `context.Canceled`
+  promptly instead of processing every candidate.
 
 #### July 5, 2026 - fix(release): unblock Production Release job stuck on missing GOEXPERIMENT in release-time go vet
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.61.0 -->
+<!-- version: 9.62.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-04 -->
+<!-- last-edited: 2026-07-05 -->
 
 # Project TODO
 
@@ -19,6 +19,21 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## ✅ FullScan cancel-responsiveness fix (2026-07-05)
+
+- **Incident:** cancelling a running `dedup.full-scan` op tonight took 90+
+  seconds to take effect and eventually required a hard `systemctl restart`.
+- **Root cause:** `runUnifiedScoringForBook`'s inner per-candidate loop
+  (`internal/dedup/engine.go`) had no `ctx.Err()` check — only the outer
+  FullScan per-book loop did. A book with an unusually large pending-candidate
+  set could keep the scan running well past cancellation.
+- **Fix shipped:** added a cancellation check at the top of the per-candidate
+  loop, returning `ctx.Err()` promptly. Regression test
+  `TestRunUnifiedScoringForBook_StopsPromptlyOnCancel`
+  (`internal/dedup/engine_cancellation_test.go`) verified to fail without the
+  fix and pass with it. No concurrency/worker-pool changes — that's separate,
+  larger work still to be scoped.
 
 ## 🧾 Consultancy Evaluation — [`docs/consultancy/`](docs/consultancy/) (2026-07-02)
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.45.0
+// version: 1.46.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-04
+// last-edited: 2026-07-05
 
 package dedup
 
@@ -554,6 +554,16 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	}
 
 	for _, ref := range embeddingCandIDs {
+		// Cancellation check per-candidate, not just per-book: a single book
+		// with an unusually large pending-candidate set can otherwise run
+		// for a long time after the caller (FullScan) has already given up
+		// on this scan, making op cancellation unresponsive. See the
+		// 2026-07-05 incident where a full-scan cancel took 90+s and
+		// required a hard service restart.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		candID := ref.otherID
 		otherBook, err := de.bookStore.GetBookByID(candID)
 		if err != nil || otherBook == nil {

--- a/internal/dedup/engine_cancellation_test.go
+++ b/internal/dedup/engine_cancellation_test.go
@@ -1,0 +1,71 @@
+// file: internal/dedup/engine_cancellation_test.go
+// version: 1.0.0
+// guid: 6a1d4c8e-9b32-4f71-8e05-3c9a7d2b5f16
+// last-edited: 2026-07-05
+
+// Regression guard for the 2026-07-05 unresponsive-cancel incident: a
+// dedup.full-scan op cancellation took 90+ seconds to take effect and
+// eventually required a hard systemctl restart. Root cause was
+// runUnifiedScoringForBook's per-candidate loop having no cancellation
+// check — only the outer FullScan per-book loop checked ctx.Err(). This
+// test locks in the fix: the per-candidate loop must notice a cancelled
+// context promptly and stop processing remaining candidates, rather than
+// grinding through all of them for a pathologically large candidate set.
+package dedup
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func TestRunUnifiedScoringForBook_StopsPromptlyOnCancel(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	book := primaryBook("BOOK_A", "Book A")
+	others := make(map[string]*database.Book)
+	const numCandidates = 5
+	for i := 0; i < numCandidates; i++ {
+		id := "OTHER_" + string(rune('0'+i))
+		others[id] = primaryBook(id, "Other Title "+string(rune('0'+i)))
+	}
+
+	// Seed one pending candidate between book and each of the "others" so
+	// runUnifiedScoringForBook has multiple candidates to iterate for this
+	// one book.
+	for id, other := range others {
+		if err := engine.upsertExactCandidate(book, other, "exact", 1.0); err != nil {
+			t.Fatalf("seed candidate %s: %v", id, err)
+		}
+	}
+	if got := len(pendingCandidates(t, es)); got != numCandidates {
+		t.Fatalf("setup: expected %d seeded candidates, got %d", numCandidates, got)
+	}
+
+	mock.GetBookFilesFunc = func(string) ([]database.BookFile, error) { return nil, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context partway through iteration, from inside the
+	// GetBookByID lookup the per-candidate loop makes for each pending
+	// candidate. This simulates the outer op being cancelled mid-scan.
+	var lookups int
+	const cancelAfter = 2
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		lookups++
+		if lookups == cancelAfter {
+			cancel()
+		}
+		return others[id], nil
+	}
+
+	err := engine.runUnifiedScoringForBook(ctx, book, "Author")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runUnifiedScoringForBook error = %v, want context.Canceled", err)
+	}
+	if lookups >= numCandidates {
+		t.Errorf("runUnifiedScoringForBook processed %d/%d candidates after cancel — cancellation check did not stop the loop promptly", lookups, numCandidates)
+	}
+}


### PR DESCRIPTION
## Summary
- Cancelling a running `dedup.full-scan` op on prod tonight took 90+ seconds and eventually required a hard `systemctl restart` to force it.
- Root cause: `runUnifiedScoringForBook`'s per-candidate loop (`for _, ref := range embeddingCandIDs`) had zero cancellation check. The outer `FullScan` loop correctly checks `ctx.Err()` once per book, but if a single book has an unusually large pending-candidate set, that inner loop can run for a long time with no way to notice the outer context was cancelled.
- Fix: add a `ctx.Err()` check at the top of the per-candidate loop.
- Explicitly narrow scope — no goroutines/worker pools/timeouts added; that's separate, larger parallelization work being planned elsewhere (see #1806's concurrency audit).

## Test plan
- [x] New test `TestRunUnifiedScoringForBook_StopsPromptlyOnCancel` — seeds 5 pending candidates, cancels mid-loop via a mock hook after the 2nd lookup, asserts prompt `context.Canceled` return. Verified the test fails without the fix and passes with it.
- [x] `go build ./...` clean
- [x] `go vet ./internal/dedup/...` clean
- [x] `go test ./internal/dedup/...` — all passing
- [ ] CI green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1