### PR TITLE
feat(dedup): keep non-primary book embeddings as calibration datapoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,52 @@
   `GetBookByID` hook, and asserts the function returns `context.Canceled`
   promptly instead of processing every candidate.
 
+#### July 5, 2026 - feat(dedup): keep non-primary version embeddings as calibration/QA datapoints instead of deleting them
+
+- **`feat(dedup)`** — `internal/dedup/engine.go`'s `prepBookEmbed` used to
+  delete any existing embedding and skip generating a new one for any book
+  marked non-primary in a version group ("its identity is owned by the
+  primary"). That was the right call for "don't generate NEW dedup
+  candidates from a non-primary book" but wrong for "don't keep an
+  embedding at all" — a non-primary version's embedding is a useful
+  calibration/QA datapoint on its own, and its absence is the direct cause
+  of the `skipped_missing` count in `dedup.calibrate-embedding-thresholds`
+  (July 4 report: `skipped_missing=110`) and of dedup-candidate/gold-label
+  pairs that reference a non-primary book being unscorable forever. The
+  original skip-and-delete was a cost-saving measure from the OpenAI-billed
+  era; embeddings are local/free (Ollama) now, so that rationale no longer
+  applies.
+  - `prepBookEmbed` no longer special-cases `IsPrimaryVersion` — non-primary
+    books flow through the same text/hash/cache-check/embed path as
+    primary books. `EmbedStatusSkippedNonPrimary` is kept (still referenced
+    by `internal/server/embedding_backfill.go`'s status switch and its
+    tests) but is no longer produced by this path; doc comments updated.
+  - Candidate generation stays primary-only: `CheckBook` and `FullScan`'s
+    `flushChunk` now gate the `findSimilarBooks` call on the book's
+    primary-ness (`isNonPrimaryVersion`) instead of relying on the missing
+    embedding to make the book invisible. `FullScan` switches from
+    `getAllBooks()` (primary-only) to a new `getAllBooksUnfiltered()` so
+    non-primary books get an embedding refreshed on every full scan too;
+    Layer-1 emitters and unified scoring are unaffected (they already gate
+    on `isNonPrimaryVersion` via `upsertExactCandidate`, or no-op for a book
+    with zero pending candidates).
+  - Found and fixed a related gap while adding regression coverage:
+    `findSimilarBooks`'s SQLite linear-scan fallback (used whenever chromem
+    is nil or not yet populated) never filtered the *matched* book by
+    primary status — only the chromem ANN path's `is_primary_version`
+    filter did. Once non-primary books started getting real embeddings,
+    the fallback path could surface one as the "other" side of a primary
+    book's match, reintroducing exactly the candidate noise the original
+    skip was meant to prevent. `findSimilarBooks` now drops any match whose
+    other-side book is non-primary regardless of which path found it.
+  - New regression tests in `internal/dedup/engine_primary_gate_test.go`
+    cover: a non-primary book gets a real embedding (not
+    `EmbedStatusSkippedNonPrimary`); a pre-existing non-primary embedding
+    row survives instead of being deleted; `findSimilarBooks` is not called
+    for a non-primary book in either `CheckBook` or `FullScan`'s
+    `flushChunk` while still firing for a primary book in the same batch;
+    and the SQLite-fallback-surfaces-non-primary-as-other-side gap above.
+
 #### July 5, 2026 - fix(release): unblock Production Release job stuck on missing GOEXPERIMENT in release-time go vet
 
 - **`fix(ci)`** — `release-prod.yml`'s Go build job started failing on

--- a/TODO.md
+++ b/TODO.md
@@ -301,6 +301,19 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 > local embeddings (PR #1452, Ollama/bge-m3) + HNSW vector-index backend (PR #1453).
 > See `~/.claude/.../memory/project_embeddings_and_vector_index.md` and CHANGELOG (June 14, 2026).
 
+- [x] **EMB-5** ✅ 2026-07-05 — Non-primary version-group members now get a real
+  embedding computed/cached (calibration/QA datapoint) instead of having their
+  row deleted and generation skipped. Fixes the `skipped_missing` count in
+  `dedup.calibrate-embedding-thresholds` (110 as of the July 4 run) and
+  unscorable gold-label pairs referencing non-primary books. Candidate
+  generation stays primary-only (`findSimilarBooks` gated on
+  `isNonPrimaryVersion` in both `CheckBook` and `FullScan`); also closed a
+  related gap where the SQLite-fallback similarity path could surface a
+  non-primary book as the *other* side of a primary book's match (chromem's
+  ANN path already filtered this, the fallback didn't) —
+  `internal/dedup/engine.go` (`prepBookEmbed`, `CheckBook`, `FullScan`,
+  `findSimilarBooks`, new `getAllBooksUnfiltered`). See CHANGELOG.
+
 **Done**
 - [x] **VEC-1** HNSW backend flipped live on prod — `vector_index_backend=hnsw`, restarted 2026-06-15 (hydrates existing 3072-dim OpenAI vectors). Reversible: set back to `chromem` + restart.
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -426,7 +426,9 @@ func (de *Engine) CheckBook(ctx context.Context, bookID string) (bool, error) {
 	if de.embeddingsEnabled() {
 		if _, err := de.EmbedBook(ctx, bookID); err != nil {
 			slog.Error("dedup embed book error for", "bookID", bookID, "err", err)
-		} else {
+		} else if !isNonPrimaryVersion(book) {
+			// Non-primary books get embedded above (calibration/QA datapoint)
+			// but never seed new dedup candidates — that stays primary-only.
 			if err := de.findSimilarBooks(ctx, bookID); err != nil {
 				slog.Error("dedup similarity search error for", "bookID", bookID, "err", err)
 			}
@@ -1852,6 +1854,16 @@ func (de *Engine) findSimilarBooks(ctx context.Context, bookID string) error {
 			// Other book no longer exists — skip the candidate.
 			continue
 		}
+		// Drop candidates where the OTHER side is a non-primary version-group
+		// member. Non-primary books are now embedded (calibration/QA
+		// datapoint — see DEDUP-NONPRIMARY-EMBED-KEEP-2026-07), so the SQLite
+		// linear-scan fallback above can surface one as a similarity match
+		// even though the chromem ANN path already excludes them via its
+		// is_primary_version filter. Candidate generation stays primary-only
+		// on both sides regardless of which path found the match.
+		if isNonPrimaryVersion(otherBook) {
+			continue
+		}
 		// Drop candidates with no usable title on the other side. Their
 		// embedding is noise (same reason as the query-side guard above).
 		if !hasUsableTitle(otherBook.Title) {
@@ -1993,10 +2005,12 @@ const (
 	// library almost every book lands here.
 	EmbedStatusCached
 
-	// EmbedStatusSkippedNonPrimary means the book is a non-primary
-	// member of a version group (alternate format of another book).
-	// Its identity is owned by the primary, so it gets no embedding.
-	// Any stale row for the book is deleted on the way out.
+	// EmbedStatusSkippedNonPrimary is retained for backward compatibility
+	// with callers that switch on it (e.g. internal/server/embedding_backfill.go)
+	// but is no longer produced by prepBookEmbed/EmbedBook: non-primary
+	// version-group members now get a real embedding like any other book (kept
+	// as a calibration/QA datapoint), they just don't feed findSimilarBooks.
+	// See DEDUP-NONPRIMARY-EMBED-KEEP-2026-07.
 	EmbedStatusSkippedNonPrimary
 
 	// EmbedStatusSkippedEmptyTitle means the book has no usable title
@@ -2029,12 +2043,11 @@ func (s EmbedStatus) String() string {
 // distinguish live API calls from cache hits and skipped-by-policy books.
 //
 // Non-primary versions (members of a version group that are not the primary
-// representative) are skipped entirely: their embedding would be a duplicate
-// of the primary's by construction, and surfacing them as dedup candidates
-// just clutters the UI with noise. Any existing embedding for a non-primary
-// book is deleted on the spot so historical rows from earlier backfills get
-// cleaned up as we walk the library. Empty-title books are skipped with
-// the same cleanup behavior.
+// representative) are embedded exactly like any other book — the embedding
+// is retained as a calibration/QA datapoint even though the book itself will
+// never seed a new dedup candidate (see isNonPrimaryVersion gates around
+// findSimilarBooks in CheckBook/FullScan). Empty-title books are still
+// skipped, with any stale row for them deleted on the way out.
 func (de *Engine) EmbedBook(ctx context.Context, bookID string) (EmbedStatus, error) {
 	results, err := de.EmbedBooks(ctx, []string{bookID})
 	if err != nil {
@@ -2098,13 +2111,17 @@ func (de *Engine) prepBookEmbed(ctx context.Context, bookID string) (
 		return nil, "", "", 0, true, fmt.Errorf("book %s not found", bookID)
 	}
 
-	if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
-		if delErr := de.embedStore.Delete("book", bookID); delErr != nil {
-			slog.Info("dedup delete stale embedding for non-primary", "bookID", bookID, "delErr", delErr)
-		}
-		de.deleteBookFromChromem(ctx, bookID)
-		return book, "", "", EmbedStatusSkippedNonPrimary, true, nil
-	}
+	// Non-primary version-group members used to be skipped entirely (and
+	// their stale row deleted) because embeddings were OpenAI-billed and
+	// candidate generation is primary-only anyway. Embeddings are now local
+	// and free (Ollama), and skipping them entirely meant any dedup-candidate
+	// or gold-label pair referencing a non-primary book could never be
+	// scored during calibration (dedup.calibrate-embedding-thresholds counts
+	// it as skipped_missing since EmbeddingStore.Get returns nil). Non-primary
+	// books now flow through the same embed path as primary books — the
+	// embedding is retained as a calibration/QA datapoint. Candidate
+	// generation itself stays primary-only: see isNonPrimaryVersion gates at
+	// the findSimilarBooks call sites in CheckBook and FullScan.
 
 	if !hasUsableTitle(book.Title) {
 		if delErr := de.embedStore.Delete("book", bookID); delErr != nil {
@@ -2417,7 +2434,12 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 	_, span := dedupTracer.Start(ctx, "dedup.full_scan")
 	defer span.End()
 
-	books, err := de.getAllBooks()
+	// Unfiltered (includes non-primary version-group members): FullScan is
+	// also the mechanism that keeps non-primary embeddings fresh as
+	// calibration/QA datapoints. Layer-1 emitters and unified scoring are
+	// no-ops for non-primary books (see getAllBooksUnfiltered doc comment);
+	// only the Layer-2 findSimilarBooks call below needs an explicit gate.
+	books, err := de.getAllBooksUnfiltered()
 	if err != nil {
 		err := fmt.Errorf("get all books: %w", err)
 		span.RecordError(err)
@@ -2446,12 +2468,17 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 	span.SetAttributes(attribute.Int("total_books", total))
 	chunkIDs := make([]string, 0, embedChunkSize)
 	chunkStart := 0
+	// chunkIsPrimary tracks each ID's primary-ness alongside chunkIDs (the
+	// outer loop has the full book object in scope; flushChunk only has IDs).
+	// Reset alongside chunkIDs on every flush.
+	chunkIsPrimary := make(map[string]bool, embedChunkSize)
 
 	// flushChunk sends the accumulated book IDs to EmbedBooks and then runs
-	// findSimilarBooks for each successfully embedded book. It now returns the
-	// EmbedBooks error (if any) so the circuit-breaker above can count
-	// consecutive failures; chunkIDs is always reset so we advance past the
-	// failed chunk regardless.
+	// findSimilarBooks for each successfully embedded PRIMARY book. It now
+	// returns the EmbedBooks error (if any) so the circuit-breaker above can
+	// count consecutive failures; chunkIDs is always reset so we advance past
+	// the failed chunk regardless. Non-primary books still get embedded
+	// (calibration/QA datapoint) but never seed new dedup candidates.
 	flushChunk := func(endIdx int) error {
 		if len(chunkIDs) == 0 {
 			return nil
@@ -2465,6 +2492,9 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 			if !ok {
 				continue
 			}
+			if !chunkIsPrimary[id] {
+				continue
+			}
 			if st == EmbedStatusEmbedded || st == EmbedStatusCached {
 				if simErr := de.findSimilarBooks(ctx, id); simErr != nil {
 					slog.Error("dedup full scan similarity error for", "id", id, "simErr", simErr)
@@ -2472,6 +2502,9 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 			}
 		}
 		chunkIDs = chunkIDs[:0]
+		for k := range chunkIsPrimary {
+			delete(chunkIsPrimary, k)
+		}
 		chunkStart = endIdx
 		return err // return the EmbedBooks error for circuit-breaker accounting
 	}
@@ -2519,6 +2552,7 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 		// are unaffected and the scan completes normally.
 		if de.embeddingsEnabled() && !embeddingsGaveUp {
 			chunkIDs = append(chunkIDs, book.ID)
+			chunkIsPrimary[book.ID] = !isNonPrimaryVersion(&book)
 			if len(chunkIDs) >= embedChunkSize {
 				if err := flushChunk(i + 1); err != nil {
 					embedConsecutiveFails++
@@ -2848,10 +2882,17 @@ func (de *Engine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 	return deleted, nil
 }
 
-// getAllBooks fetches all PRIMARY-version books in a single pass.
-// Non-primary version-group members are filtered out so FullScan never
-// processes them (their identity is owned by the primary) and similarity
+// getAllBooks fetches all PRIMARY-version books in a single pass. It backs
+// the candidate-generation scans (AcoustIDScan, BookSignatureScan,
+// EmbedBooksAsync) that must only ever pair primary books against each other.
+// Non-primary version-group members are filtered out so those scans never
+// process them (their identity is owned by the primary) and similarity
 // scanning only produces primary-vs-primary candidate pairs.
+//
+// FullScan uses the unfiltered sibling getAllBooksUnfiltered instead, because
+// it also drives embedding generation (a non-primary book's embedding is a
+// useful calibration/QA datapoint even though it can't seed a new dedup
+// candidate — see isNonPrimaryVersion gates around findSimilarBooks).
 //
 // Previously this used batched pagination (500 per page, ~48 batches for
 // a 24K-book library). Each batch re-opened a Pebble iterator and walked
@@ -2874,6 +2915,20 @@ func (de *Engine) getAllBooks() ([]database.Book, error) {
 		filtered = append(filtered, b)
 	}
 	return filtered, nil
+}
+
+// getAllBooksUnfiltered fetches every book in the library, including
+// non-primary version-group members. FullScan uses this (instead of
+// getAllBooks) so non-primary books still get an embedding computed/cached
+// as a calibration/QA datapoint. This is safe for the rest of FullScan's
+// pipeline: every Layer-1 candidate emitter routes through
+// upsertExactCandidate, which already drops any pair where either side is
+// non-primary (isNonPrimaryVersion), and runUnifiedScoringForBook is a no-op
+// for a book with zero pending candidates — which a non-primary book always
+// has, since it can never appear in a candidate pair. Only the Layer-2
+// findSimilarBooks call needs an explicit gate; see flushChunk in FullScan.
+func (de *Engine) getAllBooksUnfiltered() ([]database.Book, error) {
+	return de.bookStore.GetAllBooks(0, 0)
 }
 
 // RunLLMReview processes ambiguous candidates through LLM review (Layer 3).

--- a/internal/dedup/engine_primary_gate_test.go
+++ b/internal/dedup/engine_primary_gate_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_primary_gate_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f7b4c19-6d83-4e50-9a12-7c5e0a8b3d46
-// last-edited: 2026-06-18
+// last-edited: 2026-07-05
 
 // Regression guard for DEDUP-CANDIDATE-EXPLOSION-2026-06-18: the exact-family
 // emitters must never produce a candidate that involves a NON-primary version-group
@@ -10,12 +10,17 @@
 // balloons the candidate set (observed: 387k exact candidates against ~49k final
 // books). Every exact emitter routes through Engine.upsertExactCandidate, which gates
 // on IsPrimaryVersion — these tests lock that invariant in place.
+//
+// Also covers DEDUP-NONPRIMARY-EMBED-KEEP-2026-07: non-primary books must still
+// get a real embedding computed/cached (a calibration/QA datapoint), they just
+// must never seed a new dedup candidate via findSimilarBooks.
 package dedup
 
 import (
 	"context"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/ai"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
@@ -147,5 +152,264 @@ func TestUpsertExactCandidate_GateUnit(t *testing.T) {
 	}
 	if cands[0].EntityAID == "NP" || cands[0].EntityBID == "NP" {
 		t.Errorf("non-primary leaked: %+v", cands[0])
+	}
+}
+
+// bareBook returns a minimal Book with no AuthorID/FileHash/ISBN/
+// MetadataSourceHash/Duration set, so every Layer-1 exact emitter in
+// CheckBook short-circuits to a no-op without needing extra mock wiring —
+// isolating the Layer-2 embedding/findSimilarBooks behavior under test.
+func bareBook(id, title string, primary *bool) *database.Book {
+	return &database.Book{ID: id, Title: title, IsPrimaryVersion: primary}
+}
+
+// wireMinimalMock wires just enough of MockStore for CheckBook's Layer-1
+// no-ops (via bareBook) plus GetBookByID lookups from the given map.
+func wireMinimalMock(mock *database.MockStore, books map[string]*database.Book) {
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return nil, nil }
+	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) { return nil, nil }
+}
+
+// TestEmbedBook_NonPrimary_KeepsEmbeddingInsteadOfDeleting is the core
+// regression guard for DEDUP-NONPRIMARY-EMBED-KEEP-2026-07: prepBookEmbed
+// used to delete any embedding row for a non-primary book and skip
+// generating a new one. Now embeddings are free (local Ollama) and a
+// non-primary book's embedding is a useful calibration/QA datapoint, so it
+// must be computed and stored exactly like any other book.
+func TestEmbedBook_NonPrimary_KeepsEmbeddingInsteadOfDeleting(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	primary := false
+	book := bareBook("NP_BOOK", "A Non-Primary Version", &primary)
+	wireMinimalMock(mock, map[string]*database.Book{"NP_BOOK": book})
+
+	client := ai.NewEmbeddingClientWithOptions("test-key", "test-model", "")
+	client.SetRawEmbedForTest(func(ctx context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	})
+	engine.embedClient = client
+
+	status, err := engine.EmbedBook(context.Background(), "NP_BOOK")
+	if err != nil {
+		t.Fatalf("EmbedBook: %v", err)
+	}
+	if status != EmbedStatusEmbedded {
+		t.Fatalf("status = %v, want EmbedStatusEmbedded (non-primary books must be embedded, not skipped)", status)
+	}
+
+	stored, err := es.Get("book", "NP_BOOK")
+	if err != nil {
+		t.Fatalf("Get embedding: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("expected a stored embedding for the non-primary book, got nil (still being deleted?)")
+	}
+}
+
+// TestEmbedBook_NonPrimary_PreExistingEmbeddingSurvives verifies that a
+// non-primary book's PRE-EXISTING embedding row is no longer deleted by
+// EmbedBook — it must be refreshed (or left as-is on a cache hit) like any
+// other book's row.
+func TestEmbedBook_NonPrimary_PreExistingEmbeddingSurvives(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	primary := false
+	book := bareBook("NP_BOOK2", "Another Non-Primary Version", &primary)
+	wireMinimalMock(mock, map[string]*database.Book{"NP_BOOK2": book})
+
+	// Seed a pre-existing row with a stale hash so EmbedBook must recompute
+	// (not hit the cache path) — the pre-fix code would have deleted this
+	// row outright before ever reaching the hash check.
+	if err := es.Upsert(database.Embedding{
+		EntityType: "book",
+		EntityID:   "NP_BOOK2",
+		TextHash:   "stale-hash-from-before-a-title-edit",
+		Vector:     []float32{0.5, 0.5, 0, 0},
+		Model:      "test-model",
+	}); err != nil {
+		t.Fatalf("seed pre-existing embedding: %v", err)
+	}
+
+	client := ai.NewEmbeddingClientWithOptions("test-key", "test-model", "")
+	client.SetRawEmbedForTest(func(ctx context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	})
+	engine.embedClient = client
+
+	status, err := engine.EmbedBook(context.Background(), "NP_BOOK2")
+	if err != nil {
+		t.Fatalf("EmbedBook: %v", err)
+	}
+	if status != EmbedStatusEmbedded {
+		t.Fatalf("status = %v, want EmbedStatusEmbedded (stale hash must trigger a refresh)", status)
+	}
+
+	stored, err := es.Get("book", "NP_BOOK2")
+	if err != nil {
+		t.Fatalf("Get embedding: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("pre-existing embedding row was deleted; non-primary rows must survive")
+	}
+}
+
+// TestCheckBook_NonPrimary_SkipsFindSimilarBooks_ButPrimaryStillMatches is the
+// call-site regression guard for DEDUP-NONPRIMARY-EMBED-KEEP-2026-07: CheckBook
+// must still embed a non-primary book (calibration datapoint) but must NOT call
+// findSimilarBooks for it, while a primary book in the same conditions still
+// gets a Layer-2 embedding candidate.
+func TestCheckBook_NonPrimary_SkipsFindSimilarBooks_ButPrimaryStillMatches(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+
+	primaryFlag := true
+	nonPrimaryFlag := false
+	other := bareBook("OTHER", "Unrelated Title", &primaryFlag)
+	npBook := bareBook("NP_TARGET", "Some Different Title", &nonPrimaryFlag)
+	pBook := bareBook("P_TARGET", "Yet Another Title", &primaryFlag)
+
+	wireMinimalMock(mock, map[string]*database.Book{
+		"OTHER":     other,
+		"NP_TARGET": npBook,
+		"P_TARGET":  pBook,
+	})
+
+	// Pre-seed "OTHER"'s embedding so any book whose own vector is identical
+	// will land above BookLowThreshold (0.85) via cosine similarity 1.0 and
+	// findSimilarBooks (if called) would emit a "embedding"-layer candidate.
+	if err := es.Upsert(database.Embedding{
+		EntityType: "book",
+		EntityID:   "OTHER",
+		TextHash:   "other-hash",
+		Vector:     []float32{1, 0, 0, 0},
+		Model:      "test-model",
+	}); err != nil {
+		t.Fatalf("seed OTHER embedding: %v", err)
+	}
+
+	client := ai.NewEmbeddingClientWithOptions("test-key", "test-model", "")
+	client.SetRawEmbedForTest(func(ctx context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	})
+	engine.embedClient = client
+
+	if _, err := engine.CheckBook(context.Background(), "NP_TARGET"); err != nil {
+		t.Fatalf("CheckBook(NP_TARGET): %v", err)
+	}
+
+	// The non-primary book must still have been embedded...
+	if stored, err := es.Get("book", "NP_TARGET"); err != nil || stored == nil {
+		t.Fatalf("expected NP_TARGET to have a stored embedding, err=%v stored=%v", err, stored)
+	}
+	// ...but findSimilarBooks must not have run for it.
+	npCands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Layer: "embedding"})
+	if err != nil {
+		t.Fatalf("ListCandidates after NP_TARGET: %v", err)
+	}
+	for _, c := range npCands {
+		if c.EntityAID == "NP_TARGET" || c.EntityBID == "NP_TARGET" {
+			t.Fatalf("findSimilarBooks ran for non-primary NP_TARGET; candidate leaked: %+v", c)
+		}
+	}
+
+	// Positive control: the same setup for a PRIMARY book must produce an
+	// embedding-layer candidate against OTHER, proving findSimilarBooks
+	// would have fired here if not gated.
+	if _, err := engine.CheckBook(context.Background(), "P_TARGET"); err != nil {
+		t.Fatalf("CheckBook(P_TARGET): %v", err)
+	}
+	pCands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Layer: "embedding"})
+	if err != nil {
+		t.Fatalf("ListCandidates after P_TARGET: %v", err)
+	}
+	found := false
+	for _, c := range pCands {
+		if (c.EntityAID == "P_TARGET" && c.EntityBID == "OTHER") || (c.EntityAID == "OTHER" && c.EntityBID == "P_TARGET") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an embedding-layer candidate between P_TARGET and OTHER, got: %+v", pCands)
+	}
+}
+
+// TestFullScan_NonPrimary_EmbedsButSkipsFindSimilarBooks is the FullScan
+// flushChunk regression guard: non-primary books flow through getAllBooksUnfiltered
+// and get embedded, but flushChunk's chunkIsPrimary gate must keep them out of
+// findSimilarBooks while a primary book in the same chunk still matches.
+func TestFullScan_NonPrimary_EmbedsButSkipsFindSimilarBooks(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+
+	primaryFlag := true
+	nonPrimaryFlag := false
+	other := bareBook("FS_OTHER", "Unrelated FullScan Title", &primaryFlag)
+	npBook := bareBook("FS_NP", "Some Different FullScan Title", &nonPrimaryFlag)
+	pBook := bareBook("FS_P", "Yet Another FullScan Title", &primaryFlag)
+
+	books := []database.Book{*other, *npBook, *pBook}
+	byID := map[string]*database.Book{"FS_OTHER": other, "FS_NP": npBook, "FS_P": pBook}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) { return books, nil }
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) { return byID[id], nil }
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return nil, nil }
+	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) { return nil, nil }
+
+	if err := es.Upsert(database.Embedding{
+		EntityType: "book",
+		EntityID:   "FS_OTHER",
+		TextHash:   "fs-other-hash",
+		Vector:     []float32{1, 0, 0, 0},
+		Model:      "test-model",
+	}); err != nil {
+		t.Fatalf("seed FS_OTHER embedding: %v", err)
+	}
+
+	client := ai.NewEmbeddingClientWithOptions("test-key", "test-model", "")
+	client.SetRawEmbedForTest(func(ctx context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	})
+	engine.embedClient = client
+
+	if err := engine.FullScan(context.Background(), nil); err != nil {
+		t.Fatalf("FullScan: %v", err)
+	}
+
+	if stored, err := es.Get("book", "FS_NP"); err != nil || stored == nil {
+		t.Fatalf("expected FS_NP to have a stored embedding after FullScan, err=%v stored=%v", err, stored)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Layer: "embedding"})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	foundPrimaryPair := false
+	for _, c := range cands {
+		if c.EntityAID == "FS_NP" || c.EntityBID == "FS_NP" {
+			t.Fatalf("findSimilarBooks ran for non-primary FS_NP in FullScan; candidate leaked: %+v", c)
+		}
+		if (c.EntityAID == "FS_P" && c.EntityBID == "FS_OTHER") || (c.EntityAID == "FS_OTHER" && c.EntityBID == "FS_P") {
+			foundPrimaryPair = true
+		}
+	}
+	if !foundPrimaryPair {
+		t.Fatalf("expected an embedding-layer candidate between FS_P and FS_OTHER, got: %+v", cands)
 	}
 }


### PR DESCRIPTION
## Summary
- Non-primary version-group members used to be skipped entirely: `prepBookEmbed` deleted any existing embedding and never computed a new one, and `FullScan`'s book list (`getAllBooks()`) filtered them out entirely.
- That was reasonable when embeddings were OpenAI-billed, but embeddings are now local/free (Ollama), and the skip has a real cost: any dedup-candidate or gold-label pair referencing a non-primary book can never be scored during calibration (`dedup.calibrate-embedding-thresholds` counts it as `skipped_missing`).
- Non-primary books now get embedded like any other book (retained as a calibration/QA datapoint) and are included in `FullScan` via a new `getAllBooksUnfiltered()`. New dedup-candidate generation stays **primary-only**: `findSimilarBooks` is gated on `isNonPrimaryVersion` at both call sites (`CheckBook`, `FullScan`'s `flushChunk`), and also drops any candidate whose other side is non-primary (covers the SQLite linear-scan fallback path).
- `EmbedStatusSkippedNonPrimary` is kept (still referenced elsewhere) but no longer produced by `prepBookEmbed`/`EmbedBook`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/dedup/...` clean
- [x] `go test ./internal/dedup/... ./internal/server/...` — all passing
- [ ] CI green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WW5gVz34iYsveXKu6UXHA1