### PR TITLE
test(ci): use build-target to actually skip docker during release testing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.9.4
+# version: 2.10.0
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-# last-edited: 2026-07-03
+# last-edited: 2026-07-05
 
 name: Prerelease on Merge
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # v2.13.4
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a0b07902d63eb6d732290805181fb02da6ad4fbf # v2.14.0 (go-run-linters passthrough)
     with:
       release-type: 'auto'
       prerelease: true
@@ -36,7 +36,18 @@ jobs:
       go-enabled: true
       frontend-enabled: true
       docker-enabled: false
+      # TEMPORARY: docker-enabled: false doesn't actually skip Docker --
+      # reusable-release.yml treats false as "auto" (auto-detects the
+      # Dockerfile and builds anyway) -- this repo's prerelease builds have
+      # always built Docker images despite this flag. build-target is the
+      # real hard gate; restrict to 'go' while testing the tag-push
+      # ruleset fix, then revert to unset/'all' once confirmed working.
+      build-target: 'go'
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'
+      # gha-release-go's lint step doesn't set GOEXPERIMENT from go-experiment,
+      # so go vet fails on jsonv2 imports even though ci.yml already vetted
+      # this commit correctly. Skip until fixed upstream in gha-release-go.
+      go-run-linters: false
     secrets: inherit

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.9.1
+# version: 4.9.2
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 # last-edited: 2026-07-05
 
@@ -50,9 +50,13 @@ jobs:
       stable: true
       go-enabled: true
       frontend-enabled: true
-      # TEMPORARY: disabled for release-pipeline testing (tag-push ruleset fix).
-      # Re-enable once Go build / tag push / GitHub Release are confirmed working.
-      docker-enabled: false
+      docker-enabled: true
+      # TEMPORARY: docker-enabled: false doesn't actually skip Docker --
+      # reusable-release.yml treats false as "auto" (auto-detects the
+      # Dockerfile and builds anyway). build-target is the real hard gate;
+      # restrict to 'go' while testing the tag-push ruleset fix, then
+      # revert to unset/'all' once confirmed working end-to-end.
+      build-target: 'go'
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'


### PR DESCRIPTION
## Summary
- Corrects PR #1810's approach: `docker-enabled: false` doesn't disable Docker in `reusable-release.yml` — it's treated as `'auto'` (auto-detects the Dockerfile and builds anyway). `build-target: 'go'` is the actual hard gate (its `if:` checks `build-target == 'all' || == '<job>'` per job).
- Applies the fix to both `release-prod.yml` and `prerelease.yml` (the latter's existing `docker-enabled: false` has never actually worked either — worth noting, not fixing further here).
- Also bumps `prerelease.yml`'s `github-common` pin and adds `go-run-linters: false`, since it hits the identical `GOEXPERIMENT` gap as `release-prod.yml` did.
- All of this is temporary scaffolding for verifying the tag-push ruleset fix end-to-end; will be reverted once confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT