### PR TITLE
perf(dedup): shard BookSignatureScan O(n²) pairwise loop across a worker pool (CONC-1)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.46.0
+// version: 1.47.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -3671,7 +3673,20 @@ func (de *Engine) BookSignatureScan(ctx context.Context, progress func(done, tot
 		}
 	}
 
+	// CONC-1 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
+	// This is an O(n²) pairwise scan and was previously a single-threaded loop
+	// that pinned one core for hours on a full library. The per-pair work is
+	// pure CPU (masked Hamming compare over in-memory signatures — no DB reads
+	// in the inner loop), so we shard the OUTER loop (index i) across a bounded
+	// worker pool sized to runtime.NumCPU() via registry.RunItems.
+	//
+	// Correctness: the triangular i<j loop still visits each unordered pair
+	// exactly once (worker for i only looks at j>i), so sharding cannot create
+	// duplicate or missing pairs. The only shared mutable state is the `emitted`
+	// map and the DB write inside emit(); both are serialized under emitMu below
+	// so the parallel pass emits the exact same candidate set as the serial one.
 	emitted := make(map[string]struct{})
+	var emitMu sync.Mutex
 	pairKey := func(a, b string) string {
 		if a > b {
 			a, b = b, a
@@ -3679,7 +3694,14 @@ func (de *Engine) BookSignatureScan(ctx context.Context, progress func(done, tot
 		return a + ":" + b
 	}
 
+	// emit is called concurrently from multiple shard workers. The whole body
+	// (map read-check-then-write + upsertCandidateWithLiveLabel DB write) runs
+	// under emitMu so neither the `emitted` map nor the candidate store races.
+	// Emits are rare (only sim>=FuzzyMinSimilarity pairs), so this lock is not
+	// on the hot path — the parallelized work is the CPU-bound comparison above.
 	emit := func(bookAID, bookBID string, sim float64) {
+		emitMu.Lock()
+		defer emitMu.Unlock()
 		key := pairKey(bookAID, bookBID)
 		if _, already := emitted[key]; already {
 			return
@@ -3698,13 +3720,11 @@ func (de *Engine) BookSignatureScan(ctx context.Context, progress func(done, tot
 	}
 
 	total := len(booksWithSig)
-	for i, bookA := range booksWithSig {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
 
+	// scanOuter runs the inner j-loop for a single outer index i (each unordered
+	// pair (i,j) with j>i visited once). Pure-CPU; the only side effect is emit().
+	scanOuter := func(i int) {
+		bookA := booksWithSig[i]
 		sigA := *bookA.BookSigV1
 		maskA := ""
 		if bookA.BookSigV1Mask != nil {
@@ -3734,12 +3754,68 @@ func (de *Engine) BookSignatureScan(ctx context.Context, progress func(done, tot
 				emit(bookA.ID, bookB.ID, sim)
 			}
 		}
+	}
 
-		if progress != nil {
-			progress(i+1, total)
-		}
+	// Shard the outer index across a pool sized to NumCPU. RunItems polls
+	// ctx.Done() between items and drives the progress adapter's UpdateProgress
+	// once per completed shard, preserving the original progress(done,total)
+	// callback (see progressCallbackReporter — mutex-serialized counter, no
+	// lost updates, serialized invocation for the non-thread-safe callback).
+	indices := make([]int, total)
+	for i := range indices {
+		indices[i] = i
+	}
+	err = registry.RunItems(ctx, &progressCallbackReporter{progress: progress}, indices,
+		func(_ context.Context, i int) error {
+			scanOuter(i)
+			return nil
+		},
+		registry.RunItemsOptions{Concurrency: runtime.NumCPU()},
+	)
+	if err != nil {
+		return err
 	}
 
 	slog.Info("[dedup] book signature scan complete books scanned, candidate pair(s) emitted", "total", total, "emitted_count", len(emitted))
 	return nil
 }
+
+// progressCallbackReporter adapts BookSignatureScan's plain progress(done,total)
+// callback to the registry.Reporter interface so the scan can drive
+// registry.RunItems without changing its public signature. RunItems only calls
+// UpdateProgress and SetCurrentItem; the remaining methods are inert no-ops.
+//
+// RunItems calls UpdateProgress concurrently from every shard worker, but the
+// wrapped progress callback (see book_signature_scan.go) is written for serial
+// invocation. The mutex therefore serializes every callback and, under the same
+// lock, increments a counter so the callback always sees a strictly increasing
+// done value with no lost updates. We intentionally ignore RunItems' per-item
+// `current` (== i+1, out of order under sharding) and report shards-finished.
+type progressCallbackReporter struct {
+	progress func(done, total int)
+	mu       sync.Mutex
+	done     int
+}
+
+func (p *progressCallbackReporter) UpdateProgress(_, total int, _ string) error {
+	if p.progress == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.done++
+	p.progress(p.done, total)
+	return nil
+}
+
+func (p *progressCallbackReporter) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
+func (p *progressCallbackReporter) Logger() *slog.Logger                             { return slog.Default() }
+func (p *progressCallbackReporter) Checkpoint(_ any) error                           { return nil }
+func (p *progressCallbackReporter) IsCanceled() bool                                 { return false }
+func (p *progressCallbackReporter) SetCurrentItem(_ string)                          {}
+
+func (p *progressCallbackReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, p)
+}
+
+func (p *progressCallbackReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }

--- a/internal/dedup/engine_booksig_parallel_test.go
+++ b/internal/dedup/engine_booksig_parallel_test.go
@@ -1,0 +1,196 @@
+// file: internal/dedup/engine_booksig_parallel_test.go
+// version: 1.0.0
+// guid: 3c9e7d21-6b48-4f0a-9d2e-8a1f5c04b7e6
+// last-edited: 2026-07-05
+
+// Regression tests for CONC-1: BookSignatureScan's O(n²) pairwise loop is now
+// sharded across a bounded worker pool (registry.RunItems) instead of running
+// single-threaded. These tests prove the parallel pass emits the EXACT same
+// candidate set as an independent serial reference (no lost/duplicated updates
+// through the mutex-guarded `emitted` map + DB write) and that the progress
+// callback stays monotonic with no lost increments. Run under -race to prove
+// the shared-state guarding is correct.
+
+package dedup
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// sigWord builds a valid base64 book signature whose 4096 uint32 words are all
+// equal to word. Two signatures built from the same word are identical (sim
+// 1.0); signatures from words with a large Hamming distance fall well below
+// FuzzyMinSimilarity. Empty mask => all-real => overlap == 4096 (>= 512).
+func sigWord(word uint32) string {
+	buf := make([]byte, fingerprint.BookSignatureFixedLength*4)
+	for i := 0; i < fingerprint.BookSignatureFixedLength; i++ {
+		binary.LittleEndian.PutUint32(buf[i*4:], word)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// pairKeyFor mirrors BookSignatureScan's canonical unordered pair key.
+func pairKeyFor(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + ":" + b
+}
+
+// serialReferencePairs recomputes the candidate pair set with a plain O(n²)
+// nested loop over the SAME books the engine scans, replicating the engine's
+// overlap>=512 and sim>=FuzzyMinSimilarity gates exactly. This is the ground
+// truth the parallel pass must match.
+func serialReferencePairs(t *testing.T, books []database.Book) map[string]struct{} {
+	t.Helper()
+	const minOverlapWords = 512
+	want := make(map[string]struct{})
+	for i := range books {
+		sigA := *books[i].BookSigV1
+		maskA := ""
+		if books[i].BookSigV1Mask != nil {
+			maskA = *books[i].BookSigV1Mask
+		}
+		for j := i + 1; j < len(books); j++ {
+			sigB := *books[j].BookSigV1
+			maskB := ""
+			if books[j].BookSigV1Mask != nil {
+				maskB = *books[j].BookSigV1Mask
+			}
+			sim, overlap, err := fingerprint.BookSignatureSimilarityMasked(sigA, sigB, maskA, maskB)
+			if err != nil || overlap < minOverlapWords {
+				continue
+			}
+			if sim >= fingerprint.FuzzyMinSimilarity {
+				want[pairKeyFor(books[i].ID, books[j].ID)] = struct{}{}
+			}
+		}
+	}
+	return want
+}
+
+func TestParallelBookSignatureScan_SameCandidatesAsSerial(t *testing.T) {
+	// MockStore-backed engine: feeds the fixture books (with signatures intact)
+	// straight into the scan via GetAllBooksFunc. This avoids the memdb read
+	// projection (which strips BookSigV1) and exercises the exact emit/guard
+	// path under test. Candidates land in the real EmbeddingStore (es).
+	engine, mock, es := setupTestEngine(t)
+
+	// Fixture sized well above NumCPU so the outer loop genuinely shards and
+	// many emit() calls contend on the guarded map/DB write. 4 groups of 10
+	// books, each group sharing one signature => 4*C(10,2)=180 matching pairs;
+	// cross-group signatures are far below FuzzyMinSimilarity, so they never
+	// emit. Distinct group words guarantee low cross-group similarity.
+	groupWords := []uint32{0x00000000, 0xFFFFFFFF, 0x0000FFFF, 0xFFFF0000}
+	const perGroup = 10
+	var books []database.Book
+	byID := make(map[string]database.Book)
+	for g, word := range groupWords {
+		sig := sigWord(word)
+		for k := 0; k < perGroup; k++ {
+			id := fmt.Sprintf("g%d-%02d", g, k)
+			b := database.Book{ID: id, Title: "Book " + id, BookSigV1: &sig}
+			books = append(books, b)
+			byID[id] = b
+		}
+	}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		// Return a defensive copy so the scan can never observe test-side
+		// mutation and vice-versa.
+		out := make([]database.Book, len(books))
+		copy(out, books)
+		return out, nil
+	}
+	// captureLiveLabel -> dataset.BuildExample reads books by ID; provide them
+	// so live-capture doesn't error (best-effort, but keeps the path realistic).
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if b, ok := byID[id]; ok {
+			return &b, nil
+		}
+		return nil, nil
+	}
+
+	// Ground truth: independent serial nested loop over the exact scanned set.
+	scanned, err := engine.getAllBooks()
+	if err != nil {
+		t.Fatalf("getAllBooks: %v", err)
+	}
+	withSig := scanned[:0:0]
+	for _, b := range scanned {
+		if b.BookSigV1 != nil && *b.BookSigV1 != "" {
+			withSig = append(withSig, b)
+		}
+	}
+	want := serialReferencePairs(t, withSig)
+	if len(want) == 0 {
+		t.Fatalf("fixture is vacuous: expected >0 matching pairs but got 0")
+	}
+
+	// Record every progress callback to prove the atomic counter is monotonic
+	// with no lost increments.
+	type prog struct{ done, total int }
+	var progs []prog
+
+	if err := engine.BookSignatureScan(context.Background(), func(done, total int) {
+		progs = append(progs, prog{done, total})
+	}); err != nil {
+		t.Fatalf("BookSignatureScan: %v", err)
+	}
+
+	// Exact candidate-set equality (both directions). Limit high so pagination
+	// (default 50) can't truncate the result.
+	cands, _, err := es.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	got := make(map[string]struct{}, len(cands))
+	for _, c := range cands {
+		key := pairKeyFor(c.EntityAID, c.EntityBID)
+		if _, dup := got[key]; dup {
+			t.Fatalf("duplicate candidate emitted for pair %s", key)
+		}
+		got[key] = struct{}{}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("candidate count mismatch: got %d, want %d", len(got), len(want))
+	}
+	for key := range want {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("missing expected candidate pair %s (lost update in parallel scan)", key)
+		}
+	}
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Fatalf("unexpected candidate pair %s (spurious emit in parallel scan)", key)
+		}
+	}
+
+	// Progress: at least one call, final done == total, monotonic non-decreasing,
+	// and total constant == number of scanned books.
+	if len(progs) == 0 {
+		t.Fatal("progress callback never invoked")
+	}
+	total := len(withSig)
+	last := 0
+	for i, p := range progs {
+		if p.total != total {
+			t.Fatalf("progress[%d].total = %d, want %d", i, p.total, total)
+		}
+		if p.done < last {
+			t.Fatalf("progress not monotonic: progress[%d].done=%d < previous %d", i, p.done, last)
+		}
+		last = p.done
+	}
+	if last != total {
+		t.Fatalf("final progress done = %d, want %d", last, total)
+	}
+}


### PR DESCRIPTION
Workstream **dedup-engine** / TASK-01 (CONC-1) · ⚠ review-critical · the confirmed single-threaded hot path.

## What changed
- `internal/dedup/engine.go`: `BookSignatureScan`'s O(n²) pairwise loop — shard the **outer** index `i` across a `registry.RunItems` pool sized to `runtime.NumCPU()`. Inner `j>i` loop unchanged, so each unordered pair is still visited exactly once. Pure-CPU masked-Hamming compare parallelizes; the rare `emit()` (map read-check-write + `upsertCandidateWithLiveLabel` DB write) is fully serialized under a single `sync.Mutex` (`emitMu`) → provably identical output. Progress preserved via a mutex-serialized `progressCallbackReporter` adapter (also closes a latent race in the serial callback).
- `internal/dedup/engine_booksig_parallel_test.go` (new): `TestParallelBookSignatureScan_SameCandidatesAsSerial` — independent serial reference loop, 40-book/180-pair fixture sized above NumCPU, exact set-equality both directions + no-dup + progress-monotonicity, under `-race`.

## Acceptance
- [x] Loop routes through `registry.RunItems`
- [x] `go test -race ./internal/dedup/...` clean; new same-candidates test passes
- [x] Parallel output identical to serial (emit fully serialized under `emitMu`)
- [x] `go build` + `go vet` clean; no new staticcheck findings (`bestSeg` U1000 is pre-existing)
- [x] File headers bumped
- [x] Coordinator line-review + advisor diff-review complete

> Note (out of scope, tracked): under `UseMemDB=true`, `getAllBooks()` may hand memdb-projected books with `BookSigV1` nil'd, which would make this scan a prod no-op — separate from CONC-1; to be verified independently.