### PR TITLE
perf(metadata): parallelize BatchUpdateMetadata + ImportMetadata DB round-trips (CONC-13)

### DIFF
--- a/internal/metadata/enhanced.go
+++ b/internal/metadata/enhanced.go
@@ -1,10 +1,12 @@
 // file: internal/metadata/enhanced.go
-// version: 1.9.1
+// version: 1.10.0
 // guid: 7e8d9c0b-1a2f-3e4d-5c6b-7a8d9c0b1a2f
+// last-edited: 2026-07-05
 
 package metadata
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,11 +14,44 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
+
+// metadataBulkOpConcurrency bounds the worker pool for BatchUpdateMetadata and
+// ImportMetadata (CONC-13). Both are request-driven bulk ops that run inline
+// on a user-facing HTTP request rather than as a background op with its own
+// budget, so concurrency is a small fixed value (fix-pattern #5 in
+// docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md) — not
+// runtime.NumCPU() — to avoid starving the server on a large payload.
+const metadataBulkOpConcurrency = 4
+
+// inertMetadataReporter is a minimal registry.Reporter for BatchUpdateMetadata
+// and ImportMetadata, which are synchronous helpers called directly from HTTP
+// handlers (see internal/server/handlers/metadata/handler.go) with no live
+// operations.Reporter in scope. registry.RunItems's concurrent path only ever
+// calls UpdateProgress and SetCurrentItem (see run_items.go's runOne), so the
+// remaining methods are safe no-ops.
+type inertMetadataReporter struct{}
+
+func (inertMetadataReporter) UpdateProgress(current, total int, message string) error { return nil }
+func (inertMetadataReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	return nil
+}
+func (inertMetadataReporter) Logger() *slog.Logger       { return slog.Default() }
+func (inertMetadataReporter) Checkpoint(state any) error { return nil }
+func (inertMetadataReporter) IsCanceled() bool           { return false }
+func (inertMetadataReporter) RunPhase(ctx context.Context, name string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, inertMetadataReporter{})
+}
+func (inertMetadataReporter) Trigger(ctx context.Context, eventName string, payload any) error {
+	return nil
+}
+func (inertMetadataReporter) SetCurrentItem(label string) {}
 
 // MetadataUpdate represents a metadata update operation
 type MetadataUpdate struct {
@@ -157,27 +192,59 @@ func ValidateMetadata(updates map[string]interface{}, rules map[string]Validatio
 	return errors
 }
 
-// BatchUpdateMetadata applies metadata updates to multiple books with validation
+// BatchUpdateMetadata applies metadata updates to multiple books with validation.
+//
+// Parallelized via registry.RunItems (CONC-13): each worker processes one
+// update (validate → GetBookByID → mutate → UpdateBook) independently. The
+// only state shared across workers is the result aggregation (errs,
+// successCount), which is guarded by mu so the parallel pass produces the
+// same result set as the original serial loop (order-independent — item
+// index i is preserved in error messages for identification, but completion
+// order across workers is not guaranteed to match input order).
+//
+// Store-safety: store.UpdateBook (PebbleStore) commits via a Pebble batch
+// (safe for concurrent writers) and write-throughs to memdb via memSync,
+// which serializes on hashicorp/go-memdb's Txn(true) exclusive writer lock —
+// concurrent UpdateBook calls cannot race or corrupt state at this
+// concurrency. rules is read-only after construction, so sharing it across
+// workers needs no lock.
 func BatchUpdateMetadata(updates []MetadataUpdate, store database.BookStore, validate bool) ([]error, int) {
-	var errors []error
-	successCount := 0
 	rules := DefaultValidationRules()
 
-	for i, update := range updates {
+	var mu sync.Mutex
+	var errs []error
+	successCount := 0
+
+	// RunItems's fn signature doesn't carry the item's original index, and
+	// the error messages below identify updates by their request-payload
+	// index — so iterate over indices into updates rather than the updates
+	// themselves.
+	indices := make([]int, len(updates))
+	for i := range indices {
+		indices[i] = i
+	}
+
+	_ = registry.RunItems(context.Background(), inertMetadataReporter{}, indices, func(_ context.Context, i int) error {
+		update := updates[i]
+
 		// Validate if requested
 		if validate || update.Validate {
 			validationErrors := ValidateMetadata(update.Updates, rules)
 			if len(validationErrors) > 0 {
-				errors = append(errors, fmt.Errorf("update %d (book %s): %v", i, update.BookID, validationErrors))
-				continue
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("update %d (book %s): %v", i, update.BookID, validationErrors))
+				mu.Unlock()
+				return nil
 			}
 		}
 
 		// Get current book
 		book, err := store.GetBookByID(update.BookID)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("update %d: failed to get book %s: %w", i, update.BookID, err))
-			continue
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("update %d: failed to get book %s: %w", i, update.BookID, err))
+			mu.Unlock()
+			return nil
 		}
 
 		// Apply updates
@@ -193,16 +260,20 @@ func BatchUpdateMetadata(updates []MetadataUpdate, store database.BookStore, val
 		}
 
 		// Update in database
-		_, err = store.UpdateBook(update.BookID, book)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("update %d: failed to update book %s: %w", i, update.BookID, err))
-			continue
+		if _, err := store.UpdateBook(update.BookID, book); err != nil {
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("update %d: failed to update book %s: %w", i, update.BookID, err))
+			mu.Unlock()
+			return nil
 		}
 
+		mu.Lock()
 		successCount++
-	}
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{Concurrency: metadataBulkOpConcurrency})
 
-	return errors, successCount
+	return errs, successCount
 }
 
 // WriteMetadataToFile safely writes metadata to an audiobook file
@@ -622,29 +693,57 @@ func ExportMetadata(books []database.Book) (map[string]interface{}, error) {
 	return result, nil
 }
 
-// ImportMetadata imports book metadata from a structured format
+// ImportMetadata imports book metadata from a structured format.
+//
+// Parallelized via registry.RunItems (CONC-13): each worker processes one
+// book entry (decode → validate → CreateBook) independently. The only state
+// shared across workers is the result aggregation (errs, importCount),
+// guarded by mu so the parallel pass produces the same result set as the
+// original serial loop (order-independent — item index i is preserved in
+// error messages for identification).
+//
+// Store-safety: store.CreateBook (PebbleStore) generates its own ULID with a
+// call-local monotonic entropy source (no shared/global counter), commits via
+// a Pebble batch (safe for concurrent writers), and write-throughs to memdb
+// via memSync, which serializes on hashicorp/go-memdb's Txn(true) exclusive
+// writer lock — concurrent CreateBook calls cannot race or corrupt state at
+// this concurrency.
 func ImportMetadata(data map[string]interface{}, store database.BookStore, validate bool) (int, []error) {
-	var errors []error
-	importCount := 0
-
 	booksData, ok := data["books"].([]interface{})
 	if !ok {
 		return 0, []error{fmt.Errorf("invalid data format: books field missing or invalid")}
 	}
 
-	for i, bookInterface := range booksData {
-		bookData, ok := bookInterface.(map[string]interface{})
+	var mu sync.Mutex
+	var errs []error
+	importCount := 0
+
+	// RunItems's fn signature doesn't carry the item's original index, and
+	// the error messages below identify books by their request-payload
+	// index — so iterate over indices into booksData rather than the
+	// entries themselves.
+	indices := make([]int, len(booksData))
+	for i := range indices {
+		indices[i] = i
+	}
+
+	_ = registry.RunItems(context.Background(), inertMetadataReporter{}, indices, func(_ context.Context, i int) error {
+		bookData, ok := booksData[i].(map[string]interface{})
 		if !ok {
-			errors = append(errors, fmt.Errorf("book %d: invalid book data format", i))
-			continue
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("book %d: invalid book data format", i))
+			mu.Unlock()
+			return nil
 		}
 
 		// Validate if requested
 		if validate {
 			validationErrors := ValidateMetadata(bookData, DefaultValidationRules())
 			if len(validationErrors) > 0 {
-				errors = append(errors, fmt.Errorf("book %d: validation failed: %v", i, validationErrors))
-				continue
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("book %d: validation failed: %v", i, validationErrors))
+				mu.Unlock()
+				return nil
 			}
 		}
 
@@ -661,16 +760,20 @@ func ImportMetadata(data map[string]interface{}, store database.BookStore, valid
 		}
 
 		// Create or update book
-		_, err := store.CreateBook(book)
-		if err != nil {
-			errors = append(errors, fmt.Errorf("book %d: failed to import: %w", i, err))
-			continue
+		if _, err := store.CreateBook(book); err != nil {
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("book %d: failed to import: %w", i, err))
+			mu.Unlock()
+			return nil
 		}
 
+		mu.Lock()
 		importCount++
-	}
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{Concurrency: metadataBulkOpConcurrency})
 
-	return importCount, errors
+	return importCount, errs
 }
 
 // Helper functions for type-safe field extraction

--- a/internal/metadata/enhanced_concurrency_test.go
+++ b/internal/metadata/enhanced_concurrency_test.go
@@ -1,0 +1,130 @@
+// file: internal/metadata/enhanced_concurrency_test.go
+// version: 1.0.0
+// guid: 3f4a5b6c-7d8e-49f0-a1b2-c3d4e5f60718
+// last-edited: 2026-07-05
+
+package metadata
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestBatchUpdateMetadata_ParallelManyItems exercises BatchUpdateMetadata's
+// registry.RunItems-based worker pool (CONC-13) with enough items to force
+// all metadataBulkOpConcurrency workers active concurrently, mixing success,
+// validation-failure, and not-found outcomes so both the successCount++ and
+// errs append aggregation paths race across goroutines. Run with `go test
+// -race` (see gate in TASK-02) to confirm the mutex-guarded aggregation has
+// no data race, and that the parallel pass produces the same result set as
+// the original serial loop: each item's outcome depends only on its own
+// BookID/Updates, never on execution order, so the expected counts below are
+// exactly what the old serial `for i, update := range updates` loop would
+// have produced too.
+func TestBatchUpdateMetadata_ParallelManyItems(t *testing.T) {
+	store := newMockStore(t)
+
+	const (
+		numOK          = 12
+		numValidateErr = 5
+		numNotFound    = 5
+	)
+	total := numOK + numValidateErr + numNotFound
+
+	updates := make([]MetadataUpdate, 0, total)
+
+	// numOK: real books present in the store, title update should apply and
+	// succeed for every one of them regardless of goroutine interleaving.
+	for i := 0; i < numOK; i++ {
+		id := fmt.Sprintf("ok-book-%d", i)
+		newTitle := fmt.Sprintf("Updated Title %d", i)
+		book := &database.Book{ID: id, Title: fmt.Sprintf("Old Title %d", i), Format: "mp3"}
+		store.EXPECT().GetBookByID(id).Return(book, nil).Once()
+		store.EXPECT().UpdateBook(id, mock.MatchedBy(func(b *database.Book) bool {
+			return b != nil && b.Title == newTitle
+		})).Return(book, nil).Once()
+		updates = append(updates, MetadataUpdate{
+			BookID:  id,
+			Updates: map[string]interface{}{"title": newTitle},
+		})
+	}
+
+	// numValidateErr: Validate:true with an empty (required) title, fails
+	// ValidateMetadata before ever touching the store.
+	for i := 0; i < numValidateErr; i++ {
+		id := fmt.Sprintf("bad-validate-%d", i)
+		updates = append(updates, MetadataUpdate{
+			BookID:   id,
+			Validate: true,
+			Updates:  map[string]interface{}{"title": ""},
+		})
+	}
+
+	// numNotFound: GetBookByID fails for these IDs.
+	for i := 0; i < numNotFound; i++ {
+		id := fmt.Sprintf("missing-%d", i)
+		store.EXPECT().GetBookByID(id).Return(nil, fmt.Errorf("book not found")).Once()
+		updates = append(updates, MetadataUpdate{
+			BookID:  id,
+			Updates: map[string]interface{}{"title": "won't matter"},
+		})
+	}
+
+	errs, successCount := BatchUpdateMetadata(updates, store, false)
+
+	if successCount != numOK {
+		t.Errorf("successCount = %d, want %d", successCount, numOK)
+	}
+	if len(errs) != numValidateErr+numNotFound {
+		t.Errorf("len(errs) = %d, want %d (errs=%v)", len(errs), numValidateErr+numNotFound, errs)
+	}
+}
+
+// TestImportMetadata_ParallelManyItems is the ImportMetadata analogue of
+// TestBatchUpdateMetadata_ParallelManyItems: enough items to keep all
+// metadataBulkOpConcurrency workers busy, mixing successful creates,
+// validation failures, and malformed entries so the mutex-guarded
+// importCount/errs aggregation is exercised on every path under -race.
+func TestImportMetadata_ParallelManyItems(t *testing.T) {
+	store := newMockStore(t)
+
+	const (
+		numOK      = 12
+		numBadData = 5
+		numInvalid = 5
+	)
+
+	books := make([]interface{}, 0, numOK+numBadData+numInvalid)
+
+	for i := 0; i < numOK; i++ {
+		title := fmt.Sprintf("Imported Book %d", i)
+		store.EXPECT().CreateBook(mock.MatchedBy(func(b *database.Book) bool {
+			return b != nil && b.Title == title
+		})).Return(&database.Book{ID: fmt.Sprintf("created-%d", i), Title: title}, nil).Once()
+		books = append(books, map[string]interface{}{"title": title, "format": "m4b"})
+	}
+
+	// numBadData: not a map — fails the type assertion before any store call.
+	for i := 0; i < numBadData; i++ {
+		books = append(books, fmt.Sprintf("not-a-map-%d", i))
+	}
+
+	// numInvalid: required "title" validation fails.
+	for i := 0; i < numInvalid; i++ {
+		books = append(books, map[string]interface{}{"title": ""})
+	}
+
+	data := map[string]interface{}{"books": books}
+
+	count, errs := ImportMetadata(data, store, true)
+
+	if count != numOK {
+		t.Errorf("count = %d, want %d", count, numOK)
+	}
+	if len(errs) != numBadData+numInvalid {
+		t.Errorf("len(errs) = %d, want %d (errs=%v)", len(errs), numBadData+numInvalid, errs)
+	}
+}


### PR DESCRIPTION
Workstream **bulk-ops-pools** / TASK-02 (CONC-13). `BatchUpdateMetadata` and `ImportMetadata` per-item DB round-trips now run through `registry.RunItems` (Concurrency=4 const — inline on user-facing HTTP requests). Aggregation (`errs`, `successCount`, `importCount`) mutex-guarded; per-item fn returns nil to preserve 'record-error-continue' semantics. Store-safety traced: PebbleStore.UpdateBook/CreateBook commit via Pebble batch + memdb Txn (serialized writers), per-call ULID entropy. Inert reporter (RunItems only calls UpdateProgress/SetCurrentItem). New: `TestBatchUpdateMetadata_ParallelManyItems` + `TestImportMetadata_ParallelManyItems` (22 mixed items each, -race). Acceptance: RunItems present, race-clean, headers bumped.