### PR TITLE
perf(dedup): memoize book lookups + parallelize mine_gold_labels & dataset_backfill (CONC-8)

### DIFF
--- a/internal/plugins/dedup/dataset_backfill.go
+++ b/internal/plugins/dedup/dataset_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/dataset_backfill.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: 2d6f8a13-7c40-4e92-8b15-9a3e5c7d2f64
-// last-edited: 2026-06-13
+// last-edited: 2026-07-05
 
 // Package dedup — op dedup.dataset-backfill (spec C4 backfill).
 //
@@ -27,10 +27,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -74,6 +77,57 @@ func (b builderAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
 	return b.store.GetBookFiles(id)
 }
 
+// bookLookupResult is a memoized GetBook outcome (both the book and any error
+// are cached, so a candidate row referencing a not-found/errored book isn't
+// re-queried on every repeat occurrence either).
+type bookLookupResult struct {
+	book *database.Book
+	err  error
+}
+
+// memoizedBuilderAdapter wraps a builderAdapter with a mutex-guarded
+// book-lookup cache (CONC-8): dedup.mine-gold-labels and dedup.dataset-backfill
+// both iterate pending candidates where the same book can appear in many rows,
+// and previously re-read that book from the store every time. Mirrors the
+// bookCache pattern in internal/dedup/drain_stale.go and
+// internal/server/server_maintenance_deps.go, but mutex-guarded here because
+// the cache is shared across the registry.RunItems worker pool both callers
+// now use — a plain map would race under -race.
+//
+// Only GetBook is memoized, matching the referenced bookCache patterns;
+// GetBookFiles passes straight through to the inner adapter.
+type memoizedBuilderAdapter struct {
+	inner builderAdapter
+	mu    sync.Mutex
+	cache map[string]bookLookupResult
+}
+
+// newMemoizedBuilderAdapter returns a memoizedBuilderAdapter ready for
+// concurrent use across a registry.RunItems worker pool.
+func newMemoizedBuilderAdapter(inner builderAdapter) *memoizedBuilderAdapter {
+	return &memoizedBuilderAdapter{inner: inner, cache: make(map[string]bookLookupResult)}
+}
+
+func (m *memoizedBuilderAdapter) GetBook(id string) (*database.Book, error) {
+	m.mu.Lock()
+	if r, ok := m.cache[id]; ok {
+		m.mu.Unlock()
+		return r.book, r.err
+	}
+	m.mu.Unlock()
+
+	book, err := m.inner.GetBook(id)
+
+	m.mu.Lock()
+	m.cache[id] = bookLookupResult{book: book, err: err}
+	m.mu.Unlock()
+	return book, err
+}
+
+func (m *memoizedBuilderAdapter) GetBookFiles(id string) ([]database.BookFile, error) {
+	return m.inner.GetBookFiles(id)
+}
+
 // runDatasetBackfill implements the dedup.dataset-backfill op.
 func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
 	if p.embeddingStore == nil {
@@ -106,9 +160,16 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 
 	reporter.Logger().Info("dataset-backfill: candidates loaded", "count", len(cands))
 
-	adapter := builderAdapter{store: p.store}
+	// Book-lookup memoization (CONC-8): see memoizedBuilderAdapter doc comment.
+	// The cache is mutex-guarded because it's shared across the RunItems
+	// worker pool below.
+	adapter := newMemoizedBuilderAdapter(builderAdapter{store: p.store})
 
+	// statsMu guards the counters below, which every worker goroutine
+	// increments. Each candidate's own store reads/writes are independent and
+	// need no lock — only the shared summary counters do.
 	var (
+		statsMu    sync.Mutex
 		examined   int
 		labeled    int
 		suppressed int
@@ -119,34 +180,27 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 
 	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Processing %d candidates…", len(cands)))
 
-	for i := range cands {
+	err = registry.RunItems(ctx, reporter, cands, func(ctx context.Context, c database.DedupCandidate) error {
 		if reporter.IsCanceled() {
 			return context.Canceled
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
 
-		c := cands[i]
+		statsMu.Lock()
 		examined++
-
-		// Periodic progress update so the op doesn't appear frozen on large sets.
-		if examined%1000 == 0 {
-			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Processed %d/%d candidates…", examined, len(cands)))
-		}
+		statsMu.Unlock()
 
 		// Build feature vector for the candidate pair.
-		ex, err := dataset.BuildExample(adapter, c)
-		if err != nil {
+		ex, buildErr := dataset.BuildExample(adapter, c)
+		if buildErr != nil {
+			statsMu.Lock()
 			buildErrs++
+			statsMu.Unlock()
 			reporter.Logger().Warn("dataset-backfill: build error",
 				"candidate_id", c.ID,
 				"entity_a", c.EntityAID,
 				"entity_b", c.EntityBID,
-				"error", err)
-			continue
+				"error", buildErr)
+			return nil
 		}
 
 		// Run deterministic catchers.
@@ -157,9 +211,13 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 			ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
 			switch label {
 			case "not_dup":
+				statsMu.Lock()
 				notDup++
+				statsMu.Unlock()
 			case "true_dup":
+				statsMu.Lock()
 				trueDup++
+				statsMu.Unlock()
 			}
 		}
 		// If no catcher fired, ex.Label remains "" — example is unlabeled, written
@@ -172,7 +230,9 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 					"candidate_id", c.ID, "error", err)
 				// Continue — partial progress is better than aborting.
 			} else {
+				statsMu.Lock()
 				labeled++
+				statsMu.Unlock()
 			}
 
 			// Suppress only catchers-confirmed not_dup candidates.
@@ -181,10 +241,21 @@ func (p *Plugin) runDatasetBackfill(ctx context.Context, rawParams json.RawMessa
 					reporter.Logger().Error("dataset-backfill: suppress error",
 						"candidate_id", c.ID, "error", err)
 				} else {
+					statsMu.Lock()
 					suppressed++
+					statsMu.Unlock()
 				}
 			}
 		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Processed %d/%d candidates…", i+1, total)
+		},
+	})
+	if err != nil {
+		return err
 	}
 
 	summary := fmt.Sprintf(

--- a/internal/plugins/dedup/dataset_backfill_test.go
+++ b/internal/plugins/dedup/dataset_backfill_test.go
@@ -1,0 +1,126 @@
+// file: internal/plugins/dedup/dataset_backfill_test.go
+// version: 1.0.0
+// guid: 2f8ff156-b5ec-4480-ac97-27acc54fd013
+// last-edited: 2026-07-05
+
+// End-to-end test for the dedup.dataset-backfill op against a real PebbleStore
+// + EmbeddingStore, added alongside the CONC-8 memoize-then-parallelize change
+// (registry.RunItems over the candidate loop plus a mutex-guarded book-lookup
+// cache in memoizedBuilderAdapter).
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// createBookNoFiles (a book with zero BookFile rows, so BookFeatures.FilesExist
+// is false and dataset.Classify's missingFile rule fires "not_dup") is defined
+// once in rebuild_gold_labels_test.go and reused here.
+
+// TestDatasetBackfill_ParallelMatchesSerialOutput exercises the RunItems-backed
+// parallel path (CONC-8) with enough candidates to spread across every
+// runtime.NumCPU() worker, and with a single "hub" book referenced by every
+// candidate so the mutex-guarded book-lookup cache in
+// memoizedBuilderAdapter.GetBook is actually contended across goroutines.
+// Every candidate's classification is deterministic given the fixture
+// (missingFile fires not_dup; a normal-duration/size pair with no shared
+// signature is left unlabeled), independent of item order or worker count —
+// that determinism is the "parallel == serial" guarantee, since
+// registry.RunItems with Concurrency==1 and Concurrency>1 both drive the same
+// per-item function. Run with -race to catch any unguarded shared state.
+func TestDatasetBackfill_ParallelMatchesSerialOutput(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	const numLeaves = 60 // comfortably exceeds runtime.NumCPU() on any CI box
+	hub := createBookWithHashedFile(t, pebble, "BackfillHub", "backfillhubhash0001")
+
+	var wantNotDup, wantUnlabeled []int64
+	for i := 0; i < numLeaves; i++ {
+		missingFiles := i%2 == 0
+		var leaf string
+		if missingFiles {
+			leaf = createBookNoFiles(t, pebble, fmt.Sprintf("NoFileLeaf%03d", i))
+		} else {
+			// Same duration/size as the hub -> duration ratio 1.0, no
+			// part-vs-whole or stub signal, and no shared hash -> unlabeled.
+			leaf = createBookWithHashedFile(t, pebble, fmt.Sprintf("NormalLeaf%03d", i), fmt.Sprintf("distincthash%04d", i))
+		}
+		cand := candidateID(t, es, hub, leaf)
+		if missingFiles {
+			wantNotDup = append(wantNotDup, cand)
+		} else {
+			wantUnlabeled = append(wantUnlabeled, cand)
+		}
+	}
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	if err := p.runDatasetBackfill(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runDatasetBackfill: %v", err)
+	}
+
+	for _, cand := range wantNotDup {
+		ex, err := es.GetLabeledExample(cand)
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", cand, err)
+		}
+		if ex == nil {
+			t.Fatalf("candidate %d: expected not_dup/rule label, got nil", cand)
+		}
+		if ex.Label != "not_dup" || ex.LabelSource != "rule" {
+			t.Fatalf("candidate %d: label=%q source=%q; want not_dup/rule", cand, ex.Label, ex.LabelSource)
+		}
+		// missingFile candidates must be suppressed (status -> dismissed).
+		cands, _, err := es.ListCandidates(database.CandidateFilter{Status: "dismissed", Limit: 1_000_000})
+		if err != nil {
+			t.Fatalf("ListCandidates(dismissed): %v", err)
+		}
+		found := false
+		for _, c := range cands {
+			if c.ID == cand {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("candidate %d: expected status=dismissed after apply", cand)
+		}
+	}
+
+	for _, cand := range wantUnlabeled {
+		ex, err := es.GetLabeledExample(cand)
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", cand, err)
+		}
+		if ex == nil {
+			t.Fatalf("candidate %d: expected an unlabeled example row to still be written, got nil", cand)
+		}
+		if ex.Label != "" {
+			t.Fatalf("candidate %d: expected no rule label, got label=%q source=%q", cand, ex.Label, ex.LabelSource)
+		}
+	}
+}
+
+func TestDatasetBackfill_DryRunWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	hub := createBookWithHashedFile(t, pebble, "DryHub", "dryhubhash0001")
+	leaf := createBookNoFiles(t, pebble, "DryLeafNoFiles")
+	cand := candidateID(t, es, hub, leaf)
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	if err := p.runDatasetBackfill(context.Background(), json.RawMessage(`{}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runDatasetBackfill dry-run: %v", err)
+	}
+	if ex, err := es.GetLabeledExample(cand); err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	} else if ex != nil {
+		t.Fatal("dry-run must write nothing")
+	}
+}

--- a/internal/plugins/dedup/mine_gold_labels.go
+++ b/internal/plugins/dedup/mine_gold_labels.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/mine_gold_labels.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f4c2a16-5d70-4e93-bc28-1a6e9d3b7c52
-// last-edited: 2026-06-18
+// last-edited: 2026-07-05
 
 // Package dedup — op dedup.mine-gold-labels (dedup tuning dataset, positive miner).
 //
@@ -25,10 +25,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -78,63 +81,89 @@ func (p *Plugin) runMineGoldLabels(ctx context.Context, rawParams json.RawMessag
 	}
 	reporter.Logger().Info("mine-gold-labels: candidates loaded", "count", len(cands))
 
-	adapter := builderAdapter{store: p.store}
-	var examined, mined, written, errs int
+	// Book-lookup memoization: a book referenced by many candidate rows was
+	// re-read from the store on every occurrence (up to 4 reads/candidate with
+	// no reuse). Mirrors the bookCache pattern in drain_stale.go /
+	// server_maintenance_deps.go, wrapped in a mutex since the cache is now
+	// shared across the RunItems worker pool below (CONC-8).
+	adapter := newMemoizedBuilderAdapter(builderAdapter{store: p.store})
+
+	// examined/mined/written/errs are incremented from every worker goroutine
+	// below, so they're guarded by statsMu (the candidate processing itself —
+	// the store reads/writes — is independent per candidate and needs no lock).
+	var (
+		statsMu                        sync.Mutex
+		examined, mined, written, errs int
+	)
 
 	_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Mining %d candidates…", len(cands)))
-	for i := range cands {
+	err = registry.RunItems(ctx, reporter, cands, func(ctx context.Context, c database.DedupCandidate) error {
 		if reporter.IsCanceled() {
 			return context.Canceled
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
 
-		c := cands[i]
+		statsMu.Lock()
 		examined++
-		if examined%1000 == 0 {
-			_ = reporter.UpdateProgress(1, 2, fmt.Sprintf("Mined %d/%d…", examined, len(cands)))
-		}
+		statsMu.Unlock()
 
 		a, aErr := adapter.GetBook(c.EntityAID)
 		b, bErr := adapter.GetBook(c.EntityBID)
 		if aErr != nil || bErr != nil || a == nil || b == nil {
+			statsMu.Lock()
 			errs++
-			continue
+			statsMu.Unlock()
+			return nil
 		}
 		aFiles, afErr := adapter.GetBookFiles(c.EntityAID)
 		bFiles, bfErr := adapter.GetBookFiles(c.EntityBID)
 		if afErr != nil || bfErr != nil {
+			statsMu.Lock()
 			errs++
-			continue
+			statsMu.Unlock()
+			return nil
 		}
 
 		label, reason, fires := dataset.MineHighConfidenceDup(a, b, aFiles, bFiles)
 		if !fires {
-			continue
+			return nil
 		}
+		statsMu.Lock()
 		mined++
+		statsMu.Unlock()
 
 		if params.Apply {
 			ex, buildErr := dataset.BuildExample(adapter, c)
 			if buildErr != nil {
+				statsMu.Lock()
 				errs++
+				statsMu.Unlock()
 				reporter.Logger().Warn("mine-gold-labels: build example failed", "candidate_id", c.ID, "error", buildErr)
-				continue
+				return nil
 			}
 			ex.Label = label
 			ex.LabelSource = "auto_high_conf"
 			ex.LabelReason = reason
 			ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
 			if err := p.embeddingStore.UpsertLabeledExample(ex); err != nil {
+				statsMu.Lock()
 				errs++
+				statsMu.Unlock()
 				reporter.Logger().Error("mine-gold-labels: upsert error", "candidate_id", c.ID, "error", err)
-				continue
+				return nil
 			}
+			statsMu.Lock()
 			written++
+			statsMu.Unlock()
 		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Mined %d/%d…", i+1, total)
+		},
+	})
+	if err != nil {
+		return err
 	}
 
 	summary := fmt.Sprintf("examined=%d mined=%d written=%d errs=%d (apply=%v)", examined, mined, written, errs, params.Apply)

--- a/internal/plugins/dedup/mine_gold_labels_test.go
+++ b/internal/plugins/dedup/mine_gold_labels_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/mine_gold_labels_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c5a71e38-9b20-4d64-8f12-3e6a9c7b2d05
-// last-edited: 2026-06-18
+// last-edited: 2026-07-05
 
 // End-to-end test for the dedup.mine-gold-labels op against a real PebbleStore +
 // EmbeddingStore: a candidate whose two books share a file hash is labeled
@@ -11,6 +11,7 @@ package dedup
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -114,5 +115,67 @@ func TestMineGoldLabels_DryRunWritesNothing(t *testing.T) {
 		t.Fatalf("GetLabeledExample: %v", err)
 	} else if ex != nil {
 		t.Fatal("dry-run must write nothing")
+	}
+}
+
+// TestMineGoldLabels_ParallelMatchesSerialOutput exercises the RunItems-backed
+// parallel path (CONC-8) with enough candidates to spread across every
+// runtime.NumCPU() worker, and with a single "hub" book referenced by every
+// candidate so the mutex-guarded book-lookup cache in
+// memoizedBuilderAdapter.GetBook actually gets contended across goroutines.
+// The op's output (which candidates fire true_dup, counts) is fully
+// deterministic given the fixture, independent of item processing order or
+// worker count — that determinism IS the "parallel == serial" guarantee, since
+// registry.RunItems with Concurrency==1 (serial) and Concurrency>1 (parallel)
+// both drive the exact same per-item function. Run with -race to catch any
+// unguarded shared state.
+func TestMineGoldLabels_ParallelMatchesSerialOutput(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	const numLeaves = 60 // comfortably exceeds runtime.NumCPU() on any CI box
+	hub := createBookWithHashedFile(t, pebble, "Hub", "hubsharedhash0001")
+
+	var wantTrueDup, wantUnlabeled []int64
+	for i := 0; i < numLeaves; i++ {
+		fires := i%2 == 0
+		hash := "hubsharedhash0001" // shared with hub -> fires true_dup
+		if !fires {
+			hash = fmt.Sprintf("distincthash%04d", i) // unique -> no signal
+		}
+		leaf := createBookWithHashedFile(t, pebble, fmt.Sprintf("Leaf%03d", i), hash)
+		cand := candidateID(t, es, hub, leaf)
+		if fires {
+			wantTrueDup = append(wantTrueDup, cand)
+		} else {
+			wantUnlabeled = append(wantUnlabeled, cand)
+		}
+	}
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	if err := p.runMineGoldLabels(context.Background(), json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("runMineGoldLabels: %v", err)
+	}
+
+	for _, cand := range wantTrueDup {
+		ex, err := es.GetLabeledExample(cand)
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", cand, err)
+		}
+		if ex == nil {
+			t.Fatalf("candidate %d: expected true_dup/auto_high_conf label, got nil", cand)
+		}
+		if ex.Label != "true_dup" || ex.LabelSource != "auto_high_conf" {
+			t.Fatalf("candidate %d: label=%q source=%q; want true_dup/auto_high_conf", cand, ex.Label, ex.LabelSource)
+		}
+	}
+	for _, cand := range wantUnlabeled {
+		ex, err := es.GetLabeledExample(cand)
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", cand, err)
+		}
+		if ex != nil {
+			t.Fatalf("candidate %d: expected no label (no shared signal), got %+v", cand, ex)
+		}
 	}
 }


### PR DESCRIPTION
Workstream **backfill-pools** / TASK-04 (CONC-8). Adds mutex-guarded book-lookup memoization then parallelizes the candidate loops in `mine_gold_labels.go` and `dataset_backfill.go` via `registry.RunItems` (Concurrency=NumCPU). Only `GetBook` memoized; all shared counters + cache under `sync.Mutex` (mirrors CONC-14 sibling). Per-item fn returns nil to preserve 'never-abort-just-count' semantics. Used task-unique type names (memoizedBuilderAdapter/bookLookupResult) + reused existing test helper to avoid the plugins/dedup package collision with CONC-5. New: `TestMineGoldLabels_ParallelMatchesSerialOutput` + `TestDatasetBackfill_ParallelMatchesSerialOutput` + dry-run test (60 candidates, -count=5 -race clean). Acceptance: RunItems present, race-clean, headers bumped.