### PR TITLE
perf(dedup): parallelize FullScan's unified-scoring pass with a bounded worker pool (CONC-2)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.47.0
+// version: 1.48.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -2595,24 +2595,59 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 	// runUnifiedScoringForBook) may not have run yet for a given book when we
 	// are still iterating the book loop above.  Running the scoring pass after
 	// flushChunk(total) guarantees all embedding candidates are written.
+	//
+	// CONC-2 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
+	// This loop was a single-threaded `for range books` that pinned one core
+	// for hours on a full library. Each book is scored independently —
+	// runUnifiedScoringForBook is self-contained per book (its collector
+	// caches live on its own stack; see the function body above), so we shard
+	// it across a bounded worker pool sized to runtime.NumCPU() via
+	// registry.RunItems. The only shared resource touched concurrently is the
+	// bookStore/embedStore backend (PebbleStore), which is safe for
+	// concurrent reads/writes (internal mutexes around counter/op-CAS state,
+	// an atomic pointer for the warm in-memory query layer, and the
+	// underlying cockroachdb/pebble.DB is itself concurrency-safe) — see
+	// internal/database/pebble_store.go.
+	//
+	// Per-book errors are logged and swallowed (never returned), exactly as
+	// the serial loop did, so a scoring failure for one book cannot abort or
+	// skip the rest. registry.RunItems polls ctx.Done() between items itself,
+	// so the manual `if ctx.Err() != nil { break }` check the serial loop used
+	// is dropped here; on cancellation RunItems returns ctx.Err(), which is
+	// now propagated (the sibling BookSignatureScan shard above does the
+	// same) rather than silently swallowed.
 	scoreTotal := len(books)
-	for i, book := range books {
-		if ctx.Err() != nil {
-			break
+	scoreIndices := make([]int, scoreTotal)
+	for i := range scoreIndices {
+		scoreIndices[i] = i
+	}
+	// scoreProgress adapts FullScan's phase-prefixed progress(phase, done,
+	// total) callback to progressCallbackReporter's plain progress(done,
+	// total) shape (reused unchanged from BookSignatureScan/TASK-01) by
+	// closing over the "score" phase name.
+	scoreProgress := func(done, total int) {
+		if progress != nil {
+			progress("score", done, total)
 		}
-		authorName := ""
-		if book.AuthorID != nil {
-			if author, err := de.bookStore.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
-				authorName = author.Name
+	}
+	err = registry.RunItems(ctx, &progressCallbackReporter{progress: scoreProgress}, scoreIndices,
+		func(ctx context.Context, i int) error {
+			book := books[i]
+			authorName := ""
+			if book.AuthorID != nil {
+				if author, err := de.bookStore.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+					authorName = author.Name
+				}
 			}
-		}
-		if err := de.runUnifiedScoringForBook(ctx, &book, authorName); err != nil {
-			slog.Error("dedup full scan unified scoring error for", "book", book.ID, "err", err)
-		}
-
-		if progress != nil && (i%10 == 0 || i == scoreTotal-1) {
-			progress("score", i+1, scoreTotal)
-		}
+			if err := de.runUnifiedScoringForBook(ctx, &book, authorName); err != nil {
+				slog.Error("dedup full scan unified scoring error for", "book", book.ID, "err", err)
+			}
+			return nil
+		},
+		registry.RunItemsOptions{Concurrency: runtime.NumCPU()},
+	)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/dedup/engine_fullscan_score_parallel_test.go
+++ b/internal/dedup/engine_fullscan_score_parallel_test.go
@@ -1,0 +1,224 @@
+// file: internal/dedup/engine_fullscan_score_parallel_test.go
+// version: 1.0.0
+// guid: 7e5b9f24-4a3d-4b8e-9c2a-1d6f8e0b3a57
+// last-edited: 2026-07-05
+
+// Regression test for CONC-2: FullScan's unified-scoring second pass is now
+// sharded across a bounded worker pool (registry.RunItems) instead of running
+// single-threaded. This proves the parallel pass persists the EXACT same
+// candidate set (Layer/Band/FormulaVersion/Similarity per pair) as an
+// independently-run serial reference that calls the same per-book Layer-1 +
+// runUnifiedScoringForBook methods directly in a plain `for` loop — i.e. the
+// same code path the pre-parallelization loop used. Run under -race to prove
+// the shared PebbleStore-backed EmbeddingStore/bookStore have no data race
+// under concurrent per-book scoring.
+
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fullScanScoreFixtureBooks builds N books that all share one ISBN13 (and an
+// identical title), so checkExactISBN's O(N) scan path writes a pending
+// "exact" candidate for every pair, which the unified-scoring pass then
+// re-scores (ISBN match is high-confidence, so composed.Band is non-empty
+// and the pair is persisted with unified fields). Duration is set above
+// minFingerprintMatchSeconds so hasKnownShortDuration/hasPlausibleAudio don't
+// suppress the pair, and IsPrimaryVersion is left nil (isNonPrimaryVersion
+// treats nil as primary) so upsertExactCandidate's primary gate passes.
+func fullScanScoreFixtureBooks(n int) []database.Book {
+	isbn := "9780000000042"
+	dur := 3600
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		books[i] = database.Book{
+			ID:       fmt.Sprintf("SB%03d", i),
+			Title:    "The Same Scored Book",
+			ISBN13:   &isbn,
+			Duration: &dur,
+		}
+	}
+	return books
+}
+
+// wireFullScanScoreMock points a MockStore's GetAllBooks/GetBookByID at the
+// given book set (defensive copies so the engine can never observe test-side
+// mutation and vice versa).
+func wireFullScanScoreMock(mock *database.MockStore, books []database.Book) {
+	byID := make(map[string]database.Book, len(books))
+	for _, b := range books {
+		byID[b.ID] = b
+	}
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		out := make([]database.Book, len(books))
+		copy(out, books)
+		return out, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if b, ok := byID[id]; ok {
+			return &b, nil
+		}
+		return nil, nil
+	}
+}
+
+// canonicalizeScoredCandidates projects the persisted candidate rows to a
+// map keyed by the canonical unordered pair, dropping volatile fields (row
+// ID, timestamps) that are allowed to differ between two independent stores
+// while everything scoring-relevant must match exactly.
+type scoredPair struct {
+	layer          string
+	band           string
+	formulaVersion string
+	similarity     float64
+}
+
+func canonicalizeScoredCandidates(t *testing.T, cands []database.DedupCandidate) map[string]scoredPair {
+	t.Helper()
+	out := make(map[string]scoredPair, len(cands))
+	for _, c := range cands {
+		key := pairKeyFor(c.EntityAID, c.EntityBID)
+		if _, dup := out[key]; dup {
+			t.Fatalf("duplicate candidate row for pair %s", key)
+		}
+		var sim float64
+		if c.Similarity != nil {
+			sim = *c.Similarity
+		}
+		out[key] = scoredPair{layer: c.Layer, band: c.Band, formulaVersion: c.FormulaVersion, similarity: sim}
+	}
+	return out
+}
+
+// runFullScanLayer1AndScoreSerially replicates the PRE-CONC-2 sequential
+// loop bodies directly (Layer 1 checks, then a plain serial for-loop calling
+// runUnifiedScoringForBook once per book) to produce the ground-truth serial
+// candidate set on an independent engine/store, without duplicating any
+// scoring/collector logic.
+func runFullScanLayer1AndScoreSerially(t *testing.T, engine *Engine, books []database.Book) {
+	t.Helper()
+	ctx := context.Background()
+
+	for i := range books {
+		book := &books[i]
+		authorName := ""
+		if _, err := engine.checkExactFileHash(book, authorName); err != nil {
+			t.Fatalf("checkExactFileHash(%s): %v", book.ID, err)
+		}
+		if err := engine.checkExactISBN(book); err != nil {
+			t.Fatalf("checkExactISBN(%s): %v", book.ID, err)
+		}
+		if err := engine.checkExactTitle(book, authorName); err != nil {
+			t.Fatalf("checkExactTitle(%s): %v", book.ID, err)
+		}
+		if err := engine.checkDurationMatch(book); err != nil {
+			t.Fatalf("checkDurationMatch(%s): %v", book.ID, err)
+		}
+	}
+
+	for i := range books {
+		book := &books[i]
+		if err := engine.runUnifiedScoringForBook(ctx, book, ""); err != nil {
+			t.Fatalf("runUnifiedScoringForBook(%s): %v", book.ID, err)
+		}
+	}
+}
+
+// TestParallelFullScanUnifiedScoring_SameResultAsSerial is the CONC-2 parity
+// test: FullScan's parallel scoring pass (registry.RunItems, Concurrency ==
+// runtime.NumCPU()) must persist the exact same candidate set that a plain
+// serial loop over runUnifiedScoringForBook produces for the identical input.
+func TestParallelFullScanUnifiedScoring_SameResultAsSerial(t *testing.T) {
+	// Sized well above a typical runtime.NumCPU() so the RunItems pool
+	// genuinely shards work across multiple goroutines, and every book's
+	// candidate set is contended (fully-connected clique via shared ISBN —
+	// C(n,2) pairs) so upsertCandidateWithLiveLabel races on the same rows
+	// from both directions of each pair.
+	const numBooks = 14
+
+	// --- Serial reference: independent engine/store, same fixture. ---
+	engineB, mockB, esB := setupTestEngine(t)
+	booksB := fullScanScoreFixtureBooks(numBooks)
+	wireFullScanScoreMock(mockB, booksB)
+	runFullScanLayer1AndScoreSerially(t, engineB, booksB)
+
+	wantCands, _, err := esB.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("serial reference ListCandidates: %v", err)
+	}
+	want := canonicalizeScoredCandidates(t, wantCands)
+	if len(want) == 0 {
+		t.Fatalf("fixture is vacuous: expected >0 scored candidate pairs but got 0")
+	}
+	// Full clique: C(numBooks,2) unordered pairs expected.
+	wantPairCount := numBooks * (numBooks - 1) / 2
+	if len(want) != wantPairCount {
+		t.Fatalf("serial reference produced %d pairs, want %d (C(%d,2)) — fixture assumptions drifted", len(want), wantPairCount, numBooks)
+	}
+
+	// --- Parallel: through the real FullScan entry point. ---
+	engineA, mockA, esA := setupTestEngine(t)
+	booksA := fullScanScoreFixtureBooks(numBooks)
+	wireFullScanScoreMock(mockA, booksA)
+
+	type prog struct{ done, total int }
+	var progs []prog
+	err = engineA.FullScan(context.Background(), func(phase string, done, total int) {
+		if phase != "score" {
+			return
+		}
+		progs = append(progs, prog{done, total})
+	})
+	if err != nil {
+		t.Fatalf("FullScan: %v", err)
+	}
+
+	gotCands, _, err := esA.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("parallel ListCandidates: %v", err)
+	}
+	got := canonicalizeScoredCandidates(t, gotCands)
+
+	if len(got) != len(want) {
+		t.Fatalf("candidate count mismatch: parallel got %d, serial want %d", len(got), len(want))
+	}
+	for key, w := range want {
+		g, ok := got[key]
+		if !ok {
+			t.Fatalf("missing expected scored pair %s (lost update in parallel scan)", key)
+		}
+		if g != w {
+			t.Fatalf("scored pair %s mismatch: parallel=%+v serial=%+v", key, g, w)
+		}
+	}
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Fatalf("unexpected scored pair %s (spurious emit in parallel scan)", key)
+		}
+	}
+
+	// Progress: "score"-phase callbacks only, final done == total == numBooks,
+	// monotonically non-decreasing (mutex-serialized counter in
+	// progressCallbackReporter), no lost/duplicated increments.
+	if len(progs) == 0 {
+		t.Fatal("score-phase progress callback never invoked")
+	}
+	last := 0
+	for i, p := range progs {
+		if p.total != numBooks {
+			t.Fatalf("progress[%d].total = %d, want %d", i, p.total, numBooks)
+		}
+		if p.done < last {
+			t.Fatalf("progress not monotonic: progress[%d].done=%d < previous %d", i, p.done, last)
+		}
+		last = p.done
+	}
+	if last != numBooks {
+		t.Fatalf("final score progress done = %d, want %d", last, numBooks)
+	}
+}


### PR DESCRIPTION
Workstream **dedup-engine** / TASK-02 (CONC-2) — **the confirmed 3-hour single-threaded incident** (the `dedup.full-scan` unified-scoring pass that pinned one core).

## What changed
- `internal/dedup/engine.go`: FullScan's `for i, book := range books { ... runUnifiedScoringForBook ... }` loop → `registry.RunItems[int]` over book indices, `Concurrency: runtime.NumCPU()`. `runUnifiedScoringForBook` is self-contained per book (collector caches on its own stack) — no FullScan-layer shared in-memory state; PebbleStore confirmed goroutine-safe. Reuses TASK-01's `progressCallbackReporter` via a closure (`progress("score", done, total)`) — no duplication, BookSignatureScan untouched. Dropped the now-redundant manual `ctx.Err()` check (RunItems polls ctx); now propagates cancellation instead of silently swallowing it (documented).
- `internal/dedup/engine_fullscan_score_parallel_test.go` (new): `TestParallelFullScanUnifiedScoring_SameResultAsSerial` — 14-book ISBN clique (91 pairs), independent serial reference vs. real parallel `FullScan`, asserts identical persisted candidate set + monotonic progress, under `-race`.

## Acceptance
- [x] Loop routes through `registry.RunItems`
- [x] `go test -race ./internal/dedup/...` clean (`ok`, all 3 subpkgs)
- [x] Parallel output identical to serial (parity test)
- [x] `go build`/`go vet` clean; headers bumped