### PR TITLE
perf(backfill): parallelize startup embedding backfill over books and authors (CONC-6)

### DIFF
--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,19 +1,184 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-07-04
+// last-edited: 2026-07-05
 
 package server
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
 
 // backfillVersionMarker is delegated to the domain package.
 var backfillVersionMarker = dedup.BackfillVersionMarker
+
+// embeddingBackfillConcurrency bounds the startup embedding backfill's
+// worker pool (CONC-6). EmbedBook and EmbedAuthor both ultimately call out to
+// the configured embedding backend (local Ollama or OpenAI), which is
+// network/rate-limited rather than CPU-bound, so this is a small fixed knob
+// rather than runtime.NumCPU() — the same reasoning applied to the other
+// network-bound external-call hotspots in
+// docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md (fix
+// pattern #4).
+const embeddingBackfillConcurrency = 4
+
+// embeddingBackfillReporter is a minimal registry.Reporter adapter for the
+// startup embedding backfill loop. This loop runs as a plain background
+// goroutine kicked off from server.go rather than through the operation
+// registry, so — unlike op-registry plugins such as
+// internal/plugins/acoustid/backfill.go, which receive a real sdk.Reporter —
+// there is no Reporter already in scope here.
+//
+// Checkpoint/RunPhase/Trigger/Logger/SetCurrentItem are inert no-ops: this
+// loop has no checkpoint/resume state (the whole-backfill version marker in
+// runEmbeddingBackfill already makes the expensive work idempotent across
+// restarts) and no SSE/UI surface to update mid-run. UpdateProgress/
+// IsCanceled/Log delegate to slog and the loop's own ctx (nil-safe) so
+// interval progress logging and cancellation still work under
+// registry.RunItems.
+type embeddingBackfillReporter struct {
+	ctx context.Context
+	// logEvery gates UpdateProgress logging to roughly one line per N
+	// completed items (0 disables interval logging). Mirrors the previous
+	// nextProgressAt bucket-logging behavior without needing a shared
+	// mutable counter across goroutines: current is unique per item.
+	logEvery int
+}
+
+func (r *embeddingBackfillReporter) UpdateProgress(current, total int, message string) error {
+	if r.logEvery > 0 && (current%r.logEvery == 0 || current == total) {
+		slog.Info(message, "current", current, "total", total)
+	}
+	return nil
+}
+
+func (r *embeddingBackfillReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	slog.Default().LogAttrs(context.Background(), level, message, attrs...)
+	return nil
+}
+
+func (r *embeddingBackfillReporter) Logger() *slog.Logger { return slog.Default() }
+
+func (r *embeddingBackfillReporter) Checkpoint(state any) error { return nil }
+
+func (r *embeddingBackfillReporter) IsCanceled() bool {
+	return r.ctx != nil && r.ctx.Err() != nil
+}
+
+func (r *embeddingBackfillReporter) RunPhase(ctx context.Context, name string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, r)
+}
+
+func (r *embeddingBackfillReporter) Trigger(ctx context.Context, eventName string, payload any) error {
+	return nil
+}
+
+func (r *embeddingBackfillReporter) SetCurrentItem(label string) {}
+
+// embeddingBackfillStats is the honest per-status breakdown for the book
+// backfill loop. Kept as its own type (rather than five return values) so
+// embedBooksConcurrent can be unit tested against a fake embedFn without a
+// real dedup.Engine/store.
+type embeddingBackfillStats struct {
+	Embedded          int
+	Cached            int
+	SkippedNonPrimary int
+	SkippedEmptyTitle int
+	Errors            int
+	Visited           int
+}
+
+// embedBooksConcurrent runs embedFn over books via registry.RunItems with a
+// bounded worker pool, aggregating per-status counts under a mutex (the only
+// shared mutable state in this loop — everything else is per-worker-local or
+// delegated to embedFn, which the brief confirms has no cross-book shared
+// state of concern). Returns ctx.Err() when canceled mid-run; otherwise nil.
+//
+// Extracted from runEmbeddingBackfill so the concurrency behavior (parallel
+// output identical to serial output, order-independent) can be exercised in
+// a unit test with a fake embedFn instead of a live dedup.Engine.
+func embedBooksConcurrent(ctx context.Context, books []database.Book, concurrency int, embedFn func(ctx context.Context, bookID string) (dedup.EmbedStatus, error)) (embeddingBackfillStats, error) {
+	var (
+		mu    sync.Mutex
+		stats embeddingBackfillStats
+	)
+	reporter := &embeddingBackfillReporter{ctx: ctx, logEvery: 500}
+
+	err := registry.RunItems(ctx, reporter, books, func(ctx context.Context, book database.Book) error {
+		status, embedErr := embedFn(ctx, book.ID)
+
+		mu.Lock()
+		defer mu.Unlock()
+		stats.Visited++
+		if embedErr != nil {
+			slog.Warn("backfill embed book", "book", book.ID, "err", embedErr)
+			stats.Errors++
+			return nil
+		}
+		switch status {
+		case dedup.EmbedStatusEmbedded:
+			stats.Embedded++
+		case dedup.EmbedStatusCached:
+			stats.Cached++
+		case dedup.EmbedStatusSkippedNonPrimary:
+			stats.SkippedNonPrimary++
+		case dedup.EmbedStatusSkippedEmptyTitle:
+			stats.SkippedEmptyTitle++
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: concurrency,
+		Label: func(i, total int) string {
+			mu.Lock()
+			s := stats
+			mu.Unlock()
+			return fmt.Sprintf("Embedding backfill progress books visited=%d/%d embedded=%d cached=%d skipped_non_primary=%d skipped_empty_title=%d errors=%d",
+				i, total, s.Embedded, s.Cached, s.SkippedNonPrimary, s.SkippedEmptyTitle, s.Errors)
+		},
+	})
+	// RunItems has joined every worker goroutine by the time it returns
+	// (both runItemsSeq and runItemsPar block on completion/wg.Wait()), so
+	// reading stats without the mutex here is safe.
+	return stats, err
+}
+
+// embedAuthorsConcurrent is the author-loop analog of embedBooksConcurrent.
+// EmbedAuthor's success/failure is boolean (no status enum), so the only
+// shared mutable state is the completed-count.
+func embedAuthorsConcurrent(ctx context.Context, authors []database.Author, concurrency int, embedFn func(ctx context.Context, authorID int) error) (int, error) {
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	reporter := &embeddingBackfillReporter{ctx: ctx, logEvery: 500}
+
+	err := registry.RunItems(ctx, reporter, authors, func(ctx context.Context, author database.Author) error {
+		if embedErr := embedFn(ctx, author.ID); embedErr != nil {
+			slog.Warn("backfill embed author", "author", author.ID, "err", embedErr)
+			return nil
+		}
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: concurrency,
+		Label: func(i, total int) string {
+			mu.Lock()
+			c := count
+			mu.Unlock()
+			return fmt.Sprintf("Embedding backfill progress authors visited=%d/%d embedded=%d", i, total, c)
+		},
+	})
+	return count, err
+}
 
 // runEmbeddingBackfill embeds all books and authors on first startup and
 // re-runs once after each backfill version bump.
@@ -38,7 +203,22 @@ func (s *Server) runEmbeddingBackfill() {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	offset := 0
+
+	if ctx.Err() != nil {
+		slog.Info("Embedding backfill canceled before book loop started", "ctx", ctx.Err())
+		return
+	}
+
+	// Fetch the whole library up front (limit=0 is the documented "fetch
+	// all" sentinel — see internal/plugins/dedup/embed_scan.go's identical
+	// GetAllBooks(0, 0) call) so the book loop is a single registry.RunItems
+	// call rather than a nested per-page loop. Swallow the error exactly as
+	// the previous pagination loop did (it only used the error to stop
+	// fetching, never logged it).
+	books, err := store.GetAllBooks(0, 0)
+	if err != nil {
+		books = nil
+	}
 
 	// Honest counters: the previous version of this loop reported
 	// "N books embedded" for every successful EmbedBook return, which
@@ -48,85 +228,32 @@ func (s *Server) runEmbeddingBackfill() {
 	// roughly half the records were non-primary version siblings the
 	// scorer never touches. We now count each EmbedStatus into its own
 	// bucket and log a breakdown at the end.
-	var (
-		statEmbedded          int
-		statCached            int
-		statSkippedNonPrimary int
-		statSkippedEmptyTitle int
-		statErrors            int
-	)
-	visited := 0
-	nextProgressAt := 500
-
-	// Backfill books in batches
-	for {
-		// Honor shutdown — if the server is stopping, bail out fast so
-		// we're not holding iterators / DB connections when CloseStore
-		// runs. The marker stays unset on cancel, which is the right
-		// thing: we want the next startup to resume the backfill.
-		if ctx.Err() != nil {
-			slog.Info("Embedding backfill canceled during book loop at offset", "offset", offset, "ctx", ctx.Err())
-			return
-		}
-		books, err := store.GetAllBooks(100, offset)
-		if err != nil || len(books) == 0 {
-			break
-		}
-		for _, book := range books {
-			if ctx.Err() != nil {
-				slog.Info("Embedding backfill canceled mid-batch at offset", "offset", offset)
-				return
-			}
-			status, err := s.dedupEngine.EmbedBook(ctx, book.ID)
-			if err != nil {
-				slog.Warn("backfill embed book", "book", book.ID, "err", err)
-				statErrors++
-				visited++
-				continue
-			}
-			switch status {
-			case dedup.EmbedStatusEmbedded:
-				statEmbedded++
-			case dedup.EmbedStatusCached:
-				statCached++
-			case dedup.EmbedStatusSkippedNonPrimary:
-				statSkippedNonPrimary++
-			case dedup.EmbedStatusSkippedEmptyTitle:
-				statSkippedEmptyTitle++
-			}
-			visited++
-		}
-		offset += len(books)
-		if visited >= nextProgressAt {
-			slog.Info("Embedding backfill progress books visited (embedded cached skipped_non_primary skipped_empty_title)", "visited", visited, "statEmbedded", statEmbedded, "statCached", statCached, "statSkippedNonPrimary", statSkippedNonPrimary, "statSkippedEmptyTitle", statSkippedEmptyTitle)
-			for nextProgressAt <= visited {
-				nextProgressAt += 500
-			}
-		}
+	stats, runErr := embedBooksConcurrent(ctx, books, embeddingBackfillConcurrency, s.dedupEngine.EmbedBook)
+	if runErr != nil && ctx.Err() != nil {
+		slog.Info("Embedding backfill canceled during book loop", "visited", stats.Visited, "ctx", ctx.Err())
+		return
 	}
-	slog.Info("Book backfill complete visited embedded cached skipped_non_primary skipped_empty_title errors", "visited", visited, "statEmbedded", statEmbedded, "statCached", statCached, "statSkippedNonPrimary", statSkippedNonPrimary, "statSkippedEmptyTitle", statSkippedEmptyTitle, "statErrors", statErrors)
+	slog.Info("Book backfill complete visited embedded cached skipped_non_primary skipped_empty_title errors", "visited", stats.Visited, "statEmbedded", stats.Embedded, "statCached", stats.Cached, "statSkippedNonPrimary", stats.SkippedNonPrimary, "statSkippedEmptyTitle", stats.SkippedEmptyTitle, "statErrors", stats.Errors)
 
 	// Backfill authors
 	authorCount := 0
 	authors, err := store.GetAllAuthors()
 	if err != nil {
 		slog.Warn("backfill failed to get authors", "err", err)
+	} else if ctx.Err() != nil {
+		slog.Info("Embedding backfill canceled during author loop after authors", "authorCount", authorCount)
+		return
 	} else {
-		for _, author := range authors {
-			if ctx.Err() != nil {
-				slog.Info("Embedding backfill canceled during author loop after authors", "authorCount", authorCount)
-				return
-			}
-			if err := s.dedupEngine.EmbedAuthor(ctx, author.ID); err != nil {
-				slog.Warn("backfill embed author", "author", author.ID, "err", err)
-			} else {
-				authorCount++
-			}
+		var runErr error
+		authorCount, runErr = embedAuthorsConcurrent(ctx, authors, embeddingBackfillConcurrency, s.dedupEngine.EmbedAuthor)
+		if runErr != nil && ctx.Err() != nil {
+			slog.Info("Embedding backfill canceled during author loop after authors", "authorCount", authorCount)
+			return
 		}
 	}
 	slog.Info("Embedded authors", "authorCount", authorCount)
 
-	slog.Info("Embedding backfill complete books (embedded, cached), authors", "visited", visited, "statEmbedded", statEmbedded, "statCached", statCached, "authorCount", authorCount)
+	slog.Info("Embedding backfill complete books (embedded, cached), authors", "visited", stats.Visited, "statEmbedded", stats.Embedded, "statCached", stats.Cached, "authorCount", authorCount)
 
 	// Persist the backfill marker NOW, before FullScan runs. The embedding
 	// work itself is complete; FullScan is a follow-up exact-match/similarity

--- a/internal/server/embedding_backfill_test.go
+++ b/internal/server/embedding_backfill_test.go
@@ -1,13 +1,20 @@
 // file: internal/server/embedding_backfill_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4f81c2ae-6b39-47d5-9ae1-3c5d8b12f7a4
-// last-edited: 2026-07-04
+// last-edited: 2026-07-05
 
 package server
 
 import (
+	"context"
 	"fmt"
+	"strconv"
+	"sync"
 	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 )
 
 // TestDedupScanProgressLogger_BucketCrossings verifies that a callback driven
@@ -109,5 +116,178 @@ func TestDedupScanProgressLogger_NonPositiveInterval(t *testing.T) {
 	}
 	if count != 5 {
 		t.Errorf("interval=0 should log every call; got %d calls", count)
+	}
+}
+
+// fakeEmbedBookStatus deterministically maps a book ID to an EmbedStatus (or
+// an error), cycling through every bucket the real EmbedBook can return plus
+// an error case, so the aggregate stats exercise every branch of
+// embedBooksConcurrent's switch.
+func fakeEmbedBookStatus(id string) (dedup.EmbedStatus, error) {
+	n, _ := strconv.Atoi(id)
+	switch n % 5 {
+	case 0:
+		return dedup.EmbedStatusEmbedded, nil
+	case 1:
+		return dedup.EmbedStatusCached, nil
+	case 2:
+		return dedup.EmbedStatusSkippedNonPrimary, nil
+	case 3:
+		return dedup.EmbedStatusSkippedEmptyTitle, nil
+	default: // n % 5 == 4
+		return 0, fmt.Errorf("fake embed error for book %s", id)
+	}
+}
+
+// TestEmbedBooksConcurrent_ParallelMatchesSerial is the CONC-6 parallel==serial
+// regression test: run registry.RunItems-backed embedBooksConcurrent once
+// sequentially (Concurrency=1) and once with the production concurrency
+// (embeddingBackfillConcurrency), and assert every bucket count is identical.
+// The two runs use fresh mutable counters and a fake embedFn — no shared
+// state crosses runs — so any mismatch means the parallel path is dropping or
+// double-counting items. Run with -race (see Makefile gate) to confirm the
+// counters mutex actually prevents a data race under concurrency>1.
+func TestEmbedBooksConcurrent_ParallelMatchesSerial(t *testing.T) {
+	const n = 500
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		books[i] = database.Book{ID: strconv.Itoa(i)}
+	}
+
+	serial, err := embedBooksConcurrent(context.Background(), books, 1, func(_ context.Context, id string) (dedup.EmbedStatus, error) {
+		return fakeEmbedBookStatus(id)
+	})
+	if err != nil {
+		t.Fatalf("serial run: unexpected error: %v", err)
+	}
+
+	parallel, err := embedBooksConcurrent(context.Background(), books, embeddingBackfillConcurrency, func(_ context.Context, id string) (dedup.EmbedStatus, error) {
+		return fakeEmbedBookStatus(id)
+	})
+	if err != nil {
+		t.Fatalf("parallel run: unexpected error: %v", err)
+	}
+
+	if serial != parallel {
+		t.Fatalf("parallel stats diverged from serial: serial=%+v parallel=%+v", serial, parallel)
+	}
+	if parallel.Visited != n {
+		t.Fatalf("expected Visited=%d, got %d", n, parallel.Visited)
+	}
+	// n=500, n%5 buckets: 100 embedded, 100 cached, 100 skipped_non_primary,
+	// 100 skipped_empty_title, 100 errors.
+	want := embeddingBackfillStats{Embedded: 100, Cached: 100, SkippedNonPrimary: 100, SkippedEmptyTitle: 100, Errors: 100, Visited: 500}
+	if parallel != want {
+		t.Fatalf("unexpected stats: got %+v, want %+v", parallel, want)
+	}
+}
+
+// TestEmbedBooksConcurrent_ConcurrentCallsAreSerialized exercises the
+// counters mutex directly under high concurrency with a large item count and
+// an embedFn with no artificial delay, so the race detector has many
+// interleavings to catch if the mutex were ever removed.
+func TestEmbedBooksConcurrent_ConcurrentCallsAreSerialized(t *testing.T) {
+	const n = 2000
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		books[i] = database.Book{ID: strconv.Itoa(i)}
+	}
+
+	var calls sync.Map // set of visited IDs, to also confirm no double-processing
+	stats, err := embedBooksConcurrent(context.Background(), books, 16, func(_ context.Context, id string) (dedup.EmbedStatus, error) {
+		if _, dup := calls.LoadOrStore(id, true); dup {
+			t.Errorf("book %s processed more than once", id)
+		}
+		return dedup.EmbedStatusEmbedded, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.Visited != n || stats.Embedded != n {
+		t.Fatalf("expected Visited=Embedded=%d, got %+v", n, stats)
+	}
+}
+
+// TestEmbedAuthorsConcurrent_ParallelMatchesSerial mirrors the book test for
+// the author loop: EmbedAuthor's outcome is boolean (success/error), so the
+// only shared state is the completed count.
+func TestEmbedAuthorsConcurrent_ParallelMatchesSerial(t *testing.T) {
+	const n = 400
+	authors := make([]database.Author, n)
+	for i := 0; i < n; i++ {
+		authors[i] = database.Author{ID: i}
+	}
+	fakeEmbed := func(_ context.Context, id int) error {
+		if id%4 == 3 {
+			return fmt.Errorf("fake embed author error for %d", id)
+		}
+		return nil
+	}
+
+	serialCount, err := embedAuthorsConcurrent(context.Background(), authors, 1, fakeEmbed)
+	if err != nil {
+		t.Fatalf("serial run: unexpected error: %v", err)
+	}
+	parallelCount, err := embedAuthorsConcurrent(context.Background(), authors, embeddingBackfillConcurrency, fakeEmbed)
+	if err != nil {
+		t.Fatalf("parallel run: unexpected error: %v", err)
+	}
+
+	if serialCount != parallelCount {
+		t.Fatalf("parallel author count diverged from serial: serial=%d parallel=%d", serialCount, parallelCount)
+	}
+	// n=400, id%4==3 fails a quarter of the time: 300 successes.
+	if want := 300; parallelCount != want {
+		t.Fatalf("unexpected author count: got %d, want %d", parallelCount, want)
+	}
+}
+
+// TestEmbeddingBackfillReporter_CancelAndProgress exercises the Reporter
+// adapter's cancellation and interval-logging behavior directly, since
+// runEmbeddingBackfill itself requires a live Server/dedup.Engine/store to
+// exercise end-to-end.
+func TestEmbeddingBackfillReporter_CancelAndProgress(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &embeddingBackfillReporter{ctx: ctx, logEvery: 10}
+
+	if r.IsCanceled() {
+		t.Fatal("expected IsCanceled=false before cancel")
+	}
+	cancel()
+	if !r.IsCanceled() {
+		t.Fatal("expected IsCanceled=true after cancel")
+	}
+
+	// UpdateProgress/Log/Checkpoint/RunPhase/Trigger/SetCurrentItem must
+	// never error or panic even with the inert no-op paths.
+	if err := r.UpdateProgress(10, 100, "progress"); err != nil {
+		t.Errorf("UpdateProgress: %v", err)
+	}
+	if err := r.Checkpoint(struct{}{}); err != nil {
+		t.Errorf("Checkpoint: %v", err)
+	}
+	if err := r.Trigger(ctx, "event", nil); err != nil {
+		t.Errorf("Trigger: %v", err)
+	}
+	r.SetCurrentItem("label") // must not panic
+
+	ran := false
+	if err := r.RunPhase(ctx, "phase", func(_ context.Context, rep registry.Reporter) error {
+		ran = true
+		if rep != r {
+			t.Error("RunPhase should pass the same reporter through")
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("RunPhase: %v", err)
+	}
+	if !ran {
+		t.Error("RunPhase did not invoke fn")
+	}
+
+	// nil-ctx reporter must not panic.
+	nilCtxReporter := &embeddingBackfillReporter{}
+	if nilCtxReporter.IsCanceled() {
+		t.Error("nil-ctx reporter should report not canceled")
 	}
 }


### PR DESCRIPTION
Workstream **backfill-pools** / TASK-02 (CONC-6). Parallelizes the startup embedding backfill loops (books + authors) in `internal/server/embedding_backfill.go` via `registry.RunItems` with a small fixed concurrency (network/rate-limited). Shared progress/counters guarded. New `-race` parallel==serial test. `go test -race ./internal/server/` → ok; build/vet clean; headers bumped. (Coordinator note: the worker stashed its work mid-run to take a baseline and stalled; work was recovered from stash, re-verified, and committed by the coordinator.)