### PR TITLE
perf(metadata): parallelize bulkFetchMetadataImpl over req.BookIDs (CONC-12)

### DIFF
--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-06-23
+// last-edited: 2026-07-05
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -54,6 +54,7 @@ import (
 	"math"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -63,6 +64,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	metadatapkg "github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	ulid "github.com/oklog/ulid/v2"
@@ -194,6 +196,48 @@ type bulkFetchMetadataResult struct {
 	AppliedFields []string `json:"applied_fields,omitempty"`
 	FetchedFields []string `json:"fetched_fields,omitempty"`
 }
+
+// bulkFetchMetadataConcurrency bounds how many book IDs bulkFetchMetadataImpl
+// fetches from external metadata sources in parallel (CONC-12). This loop
+// runs inline on a user-facing HTTP request — not a background maintenance
+// job — and each iteration makes a network call to a rate-limited external
+// metadata source, so the pool is a small fixed constant (not
+// runtime.NumCPU()) to avoid starving the server and tripping the source's
+// rate limit on a "select all" bulk request with hundreds/thousands of IDs.
+const bulkFetchMetadataConcurrency = 4
+
+// bulkFetchNoopReporter is a tiny inert registry.Reporter adapter used only to
+// satisfy RunItems' Reporter parameter for bulkFetchMetadataImpl, which has no
+// backing async operation/run row — it is a synchronous HTTP request, not an
+// op-registry job. RunItems' concurrent path (runItemsPar) only ever calls
+// SetCurrentItem and UpdateProgress per item; the remaining methods are
+// unreachable from that path but are implemented as safe, nil-safe no-ops so
+// the type fully satisfies registry.Reporter.
+type bulkFetchNoopReporter struct{}
+
+func (bulkFetchNoopReporter) UpdateProgress(current, total int, message string) error {
+	return nil
+}
+
+func (bulkFetchNoopReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	return nil
+}
+
+func (bulkFetchNoopReporter) Logger() *slog.Logger { return slog.Default() }
+
+func (bulkFetchNoopReporter) Checkpoint(state any) error { return nil }
+
+func (bulkFetchNoopReporter) IsCanceled() bool { return false }
+
+func (r bulkFetchNoopReporter) RunPhase(ctx context.Context, name string, fn func(context.Context, opsregistry.Reporter) error) error {
+	return fn(ctx, r)
+}
+
+func (bulkFetchNoopReporter) Trigger(ctx context.Context, eventName string, payload any) error {
+	return nil
+}
+
+func (bulkFetchNoopReporter) SetCurrentItem(label string) {}
 
 // bulkWriteBackOpParams mirrors the server-private op-param struct
 // (library_writeback_op.go) byte-for-byte so the JSON enqueued via
@@ -788,10 +832,39 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 		onlyMissing = *req.OnlyMissing
 	}
 
-	results := make([]bulkFetchMetadataResult, 0, len(req.BookIDs))
+	// results is pre-sized and written by index (results[i], not append) so
+	// the parallel pass below preserves the exact input order of req.BookIDs,
+	// matching the original serial loop's output byte-for-byte. updatedCount
+	// and the results slice are the shared mutable state across workers (per
+	// CONC-12); both are guarded by resultsMu via setResult.
+	results := make([]bulkFetchMetadataResult, len(req.BookIDs))
 	updatedCount := 0
+	var resultsMu sync.Mutex
 
-	for _, bookID := range req.BookIDs {
+	setResult := func(i int, r bulkFetchMetadataResult) {
+		resultsMu.Lock()
+		results[i] = r
+		if r.Status == "updated" {
+			updatedCount++
+		}
+		resultsMu.Unlock()
+	}
+
+	// indices (not req.BookIDs directly) so each worker can write its result
+	// into the correct output slot via setResult(i, ...).
+	indices := make([]int, len(req.BookIDs))
+	for i := range indices {
+		indices[i] = i
+	}
+
+	// context.Background(), not c.Request.Context(): a client disconnect must
+	// not truncate the run and leave zero-value entries in results — the
+	// parallel pass must always run to completion, same as the serial loop
+	// did. Concurrency is a small fixed constant (bulkFetchMetadataConcurrency)
+	// because this is a request-scoped, network-bound, rate-limited fetch —
+	// not a CPU-bound background job.
+	_ = opsregistry.RunItems(context.Background(), bulkFetchNoopReporter{}, indices, func(_ context.Context, i int) error {
+		bookID := req.BookIDs[i]
 		result := bulkFetchMetadataResult{
 			BookID: bookID,
 			Status: "skipped",
@@ -801,22 +874,22 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 		if err != nil || book == nil {
 			result.Status = "not_found"
 			result.Message = "audiobook not found"
-			results = append(results, result)
-			continue
+			setResult(i, result)
+			return nil
 		}
 
 		if strings.TrimSpace(book.Title) == "" {
 			result.Message = "missing title"
-			results = append(results, result)
-			continue
+			setResult(i, result)
+			return nil
 		}
 
 		state, err := h.loadMetadataState(bookID)
 		if err != nil {
 			result.Status = "error"
 			result.Message = "failed to load metadata state"
-			results = append(results, result)
-			continue
+			setResult(i, result)
+			return nil
 		}
 		if state == nil {
 			state = map[string]metafetch.MetadataFieldState{}
@@ -831,14 +904,14 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 		if searchErr != nil {
 			result.Status = "error"
 			result.Message = fmt.Sprintf("search failed: %v", searchErr)
-			results = append(results, result)
-			continue
+			setResult(i, result)
+			return nil
 		}
 		if searchResp == nil || len(searchResp.Results) == 0 {
 			result.Status = "not_found"
 			result.Message = "no metadata found from any source"
-			results = append(results, result)
-			continue
+			setResult(i, result)
+			return nil
 		}
 
 		// Pick best match from service's scored candidates (first is already best)
@@ -931,16 +1004,16 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 				if err != nil {
 					result.Status = "error"
 					result.Message = "failed to resolve author"
-					results = append(results, result)
-					continue
+					setResult(i, result)
+					return nil
 				}
 				if author == nil {
 					author, err = store.CreateAuthor(meta.Author)
 					if err != nil {
 						result.Status = "error"
 						result.Message = "failed to create author"
-						results = append(results, result)
-						continue
+						setResult(i, result)
+						return nil
 					}
 				}
 				book.AuthorID = &author.ID
@@ -1015,8 +1088,8 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 				book.AudibleRatingPerformance = &v2
 				v3 := meta.AudibleRatingStory
 				book.AudibleRatingStory = &v3
-				c := meta.AudibleRatingCount
-				book.AudibleRatingCount = &c
+				cnt := meta.AudibleRatingCount
+				book.AudibleRatingCount = &cnt
 				r := meta.AudibleNumReviews
 				book.AudibleNumReviews = &r
 				appliedFields = append(appliedFields, "audible_ratings")
@@ -1030,8 +1103,8 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 			if shouldApply("google_rating_average", hasBookValue("google_rating_average")) {
 				v := meta.GoogleRatingAverage
 				book.GoogleRatingAverage = &v
-				c := meta.GoogleRatingCount
-				book.GoogleRatingCount = &c
+				cnt := meta.GoogleRatingCount
+				book.GoogleRatingCount = &cnt
 				appliedFields = append(appliedFields, "google_rating")
 				didUpdate = true
 			}
@@ -1050,10 +1123,9 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 			if _, err := store.UpdateBook(bookID, book); err != nil {
 				result.Status = "error"
 				result.Message = fmt.Sprintf("failed to update book: %v", err)
-				results = append(results, result)
-				continue
+				setResult(i, result)
+				return nil
 			}
-			updatedCount++
 			result.Status = "updated"
 
 			// System tag the source and language so the review UI
@@ -1065,8 +1137,11 @@ func (h *Handler) bulkFetchMetadataImpl(c *gin.Context) {
 
 		result.AppliedFields = appliedFields
 		result.FetchedFields = fetchedFields
-		results = append(results, result)
-	}
+		setResult(i, result)
+		return nil
+	}, opsregistry.RunItemsOptions{
+		Concurrency: bulkFetchMetadataConcurrency,
+	})
 
 	httputil.RespondWithOK(c, gin.H{
 		"updated_count": updatedCount,

--- a/internal/server/handlers/metadata/handler_test.go
+++ b/internal/server/handlers/metadata/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1d31ef73-7c7a-4c3b-a840-01b0865023d7
-// last-edited: 2026-06-23
+// last-edited: 2026-07-05
 
 // Tests for the metadata-domain handlers. The store / metadata-fetch-service /
 // write-back-enqueuer / operations-registry / file-io-pool deps are generated
@@ -16,8 +16,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -408,6 +410,149 @@ func TestBulkFetchMetadata_Updates(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
 	}
+}
+
+// TestBulkFetchMetadata_ParallelPreservesOrderAndCounts exercises
+// bulkFetchMetadataImpl's registry.RunItems-based parallel pass (CONC-12)
+// with 6 book IDs against a concurrency of 4 (bulkFetchMetadataConcurrency),
+// so multiple workers are guaranteed to run at once. It asserts the response
+// is byte-for-byte what the old serial `for` loop would have produced:
+// results in the exact input order (written via results[i], not append) with
+// the expected per-book status, and the correct aggregate updated_count. Run
+// under `go test -race`, this also exercises the mutex guarding the shared
+// results slice / updatedCount (the "shared mutable state" named in the
+// CONC-12 brief) — the store/service mocks are testify mocks, which are
+// internally mutex-guarded and safe to call concurrently.
+//
+// The Handler here is built directly (not via the shared newHandler/recorders
+// helper used by the rest of this file) because recorders.updatedFetchedValues
+// is a plain unguarded field write — fine for the existing single-book,
+// strictly-sequential tests, but multiple of the book IDs below have
+// non-empty fetched values, so concurrent workers would race on that shared
+// field. The closures below are either pure (loadMetadataState) or
+// mutex-guarded (updateFetchedMetadataState) instead.
+func TestBulkFetchMetadata_ParallelPreservesOrderAndCounts(t *testing.T) {
+	store := metadatamocks.NewMockMetadataStore(t)
+	mfs := metadatamocks.NewMockMetadataFetchService(t)
+
+	// b0: book not found.
+	store.EXPECT().GetBookByID("b0").Return(nil, nil)
+
+	// b1: found but title is blank/whitespace-only → "missing title", status
+	// stays the zero-value "skipped".
+	store.EXPECT().GetBookByID("b1").Return(&database.Book{ID: "b1", Title: "  "}, nil)
+
+	// b2: search errors out.
+	store.EXPECT().GetBookByID("b2").Return(&database.Book{ID: "b2", Title: "T2"}, nil)
+	mfs.EXPECT().SearchMetadataForBookWithOptions("b2", "", "", "", "", mock.Anything).
+		Return(nil, errors.New("boom"))
+
+	// b3: search returns no candidates.
+	store.EXPECT().GetBookByID("b3").Return(&database.Book{ID: "b3", Title: "T3"}, nil)
+	mfs.EXPECT().SearchMetadataForBookWithOptions("b3", "", "", "", "", mock.Anything).
+		Return(&metafetch.SearchMetadataResponse{Results: nil}, nil)
+
+	// b4: candidate title fetched but not applied (book already has a title
+	// and onlyMissing defaults true) → status "fetched", no write-back.
+	store.EXPECT().GetBookByID("b4").Return(&database.Book{ID: "b4", Title: "Old4"}, nil)
+	mfs.EXPECT().SearchMetadataForBookWithOptions("b4", "", "", "", "", mock.Anything).
+		Return(&metafetch.SearchMetadataResponse{Results: []metafetch.MetadataCandidate{
+			{Title: "New4", Source: "google"},
+		}}, nil)
+
+	// b5: publisher is missing on the book, so the fetched publisher gets
+	// applied → didUpdate → status "updated" (the only one counted in
+	// updated_count).
+	store.EXPECT().GetBookByID("b5").Return(&database.Book{ID: "b5", Title: "Old5"}, nil)
+	mfs.EXPECT().SearchMetadataForBookWithOptions("b5", "", "", "", "", mock.Anything).
+		Return(&metafetch.SearchMetadataResponse{Results: []metafetch.MetadataCandidate{
+			{Title: "Old5", Source: "audible", Publisher: "Pub5"},
+		}}, nil)
+	mfs.EXPECT().RecordChangeHistory(mock.Anything, mock.Anything, "audible").Return()
+	store.EXPECT().UpdateBook("b5", mock.Anything).Return(&database.Book{ID: "b5"}, nil)
+	mfs.EXPECT().ApplyMetadataSystemTags("b5", "audible", "").Return()
+
+	var utMu sync.Mutex
+	utValues := map[string]map[string]any{}
+
+	h := metadatahandler.New(
+		store,
+		mfs,
+		func() metadatahandler.WriteBackEnqueuer { return nil },
+		nil, // opRegistry: unused by bulkFetchMetadataImpl
+		nil, // fileIOPool: unused by bulkFetchMetadataImpl
+		cache.New[gin.H]("meta-test-parallel", time.Minute),
+		func(b *database.Book) any { return gin.H{"id": b.ID} },
+		func(p string) bool { return false },
+		func(bookID string) (map[string]metafetch.MetadataFieldState, error) {
+			return map[string]metafetch.MetadataFieldState{}, nil // pure — safe for concurrent calls
+		},
+		func(bookID string, values map[string]any) error {
+			utMu.Lock()
+			defer utMu.Unlock()
+			utValues[bookID] = values
+			return nil
+		},
+		func(ctx context.Context, e plugin.Event) {},
+	)
+
+	bookIDs := []string{"b0", "b1", "b2", "b3", "b4", "b5"}
+	w := doReq(h.BulkFetchMetadata, http.MethodPost, "/metadata/bulk-fetch",
+		map[string]any{"book_ids": bookIDs}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envelope struct {
+		Data struct {
+			UpdatedCount int `json:"updated_count"`
+			TotalCount   int `json:"total_count"`
+			Results      []struct {
+				BookID string `json:"book_id"`
+				Status string `json:"status"`
+			} `json:"results"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v: %s", err, w.Body.String())
+	}
+	resp := envelope.Data
+
+	if resp.TotalCount != len(bookIDs) {
+		t.Fatalf("total_count = %d, want %d", resp.TotalCount, len(bookIDs))
+	}
+	if resp.UpdatedCount != 1 {
+		t.Fatalf("updated_count = %d, want 1", resp.UpdatedCount)
+	}
+	if len(resp.Results) != len(bookIDs) {
+		t.Fatalf("len(results) = %d, want %d", len(resp.Results), len(bookIDs))
+	}
+
+	wantStatus := map[string]string{
+		"b0": "not_found",
+		"b1": "skipped",
+		"b2": "error",
+		"b3": "not_found",
+		"b4": "fetched",
+		"b5": "updated",
+	}
+	for i, id := range bookIDs {
+		if resp.Results[i].BookID != id {
+			t.Fatalf("results[%d].book_id = %q, want %q (order not preserved)", i, resp.Results[i].BookID, id)
+		}
+		if want := wantStatus[id]; resp.Results[i].Status != want {
+			t.Fatalf("results[%d] (%s).status = %q, want %q", i, id, resp.Results[i].Status, want)
+		}
+	}
+
+	utMu.Lock()
+	if len(utValues["b4"]) == 0 {
+		t.Fatalf("expected fetched-metadata-state write for b4 (title fetched but not applied)")
+	}
+	if len(utValues["b5"]) == 0 {
+		t.Fatalf("expected fetched-metadata-state write for b5")
+	}
+	utMu.Unlock()
 }
 
 // ── bulk / batch write-back enqueue ──────────────────────────────────────────


### PR DESCRIPTION
Workstream **bulk-ops-pools** / TASK-01 (CONC-12). `bulkFetchMetadataImpl`'s per-book loop → `registry.RunItems` over an index slice, Concurrency=4 (request-scoped, rate-limited source). Results slice pre-sized + written by index under `sync.Mutex` → byte-identical order to serial. Uses `context.Background()` so a client disconnect can't truncate the run. Inert reporter (RunItems only calls UpdateProgress/SetCurrentItem). New `TestBulkFetchMetadata_ParallelPreservesOrderAndCounts` (6 mixed outcomes, -count=5 -race clean). Documented (out-of-scope) pre-existing gap: concurrent same-new-author create is a DB-level logical race, not a memory race. Build/vet clean; headers bumped.