### PR TITLE
perf(itunes): parallelize organizeImportedBooks with per-destination collision guard (CONC-10)

### DIFF
--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package itunesservice
 
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -23,6 +24,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
 	"github.com/oklog/ulid/v2"
@@ -87,6 +89,13 @@ type Importer struct {
 	mfs              *metafetch.Service
 	organizerFactory func() BookOrganizer
 	statusMap        importStatusMap
+
+	// organizeConcurrencyOverride, when > 0, overrides the worker-pool size
+	// organizeImportedBooks passes to registry.RunItems. Zero (the default
+	// for every real Importer) means "use runtime.NumCPU()". This exists
+	// purely as a test seam so a test can force the sequential path (1)
+	// and diff it against the parallel path (see organizeConcurrency).
+	organizeConcurrencyOverride int
 }
 
 func newImporter(deps Deps) *Importer {
@@ -430,7 +439,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 	if importMode == itunes.ImportModeOrganize && !req.PreserveLocation {
 		_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "organizing", 0, 0)
 		log.Info("Starting organize phase...")
-		imp.organizeImportedBooks(status, log)
+		imp.organizeImportedBooks(ctx, status, log)
 	}
 
 	_ = operations.ClearState(imp.store, opID)
@@ -1062,14 +1071,44 @@ func (imp *Importer) enrichImportedBooks(status *itunesImportStatus, log logger.
 	log.Info("Metadata enrichment complete: %d books enriched", enriched)
 }
 
-func (imp *Importer) organizeImportedBooks(status *itunesImportStatus, log logger.Logger) {
+// organizeImportedBooks runs the per-book organize (file-move) + UpdateBook
+// step over every LibraryState=="imported" book via registry.RunItems
+// (CONC-10). File I/O + a DB write per book is embarrassingly parallel
+// across DISTINCT books, so this fans out over a worker pool instead of a
+// plain sequential for-loop.
+//
+// Shared-state correctness:
+//   - itunesImportStatus counters: already guarded by status.mu via the
+//     recordImportFailure/incImport* helpers in status.go — reused as-is,
+//     no new locking needed there.
+//   - the local `organized` tally: guarded by its own mutex (mirrors the
+//     resultMu pattern in path_reconcile.go's CONC-15 fix).
+//   - destination path collisions: per-book target directories are NOT
+//     guaranteed disjoint — organizer.generateTargetPath derives the
+//     target from book metadata (title/author/narrator/series), not book
+//     ID, so two DIFFERENT imported books with identical metadata CAN
+//     resolve to the same destination. That's exactly the case
+//     organizer.OrganizeBook's stat-then-write + ErrTargetOccupied check
+//     exists to catch for a single caller — but that check is NOT atomic,
+//     so two goroutines racing on the same destination could both pass
+//     the "target doesn't exist yet" check and corrupt/overwrite each
+//     other's file. organizeDestKey + destLocks below serialize only the
+//     colliding pair (via a per-destination mutex), so the common case
+//     (distinct destinations) still runs fully in parallel while the rare
+//     colliding case gets the same one-wins/one-fails outcome the serial
+//     loop always produced (order-independent, same result set).
+func (imp *Importer) organizeImportedBooks(ctx context.Context, status *itunesImportStatus, log logger.Logger) {
 	books, err := imp.store.GetAllBooks(100000, 0)
 	if err != nil {
 		log.Error("Failed to list books for organize: %v", err)
 		return
 	}
 
-	organized := 0
+	// Pre-filter to the books this phase actually organizes, same filter
+	// the original sequential loop applied inline per iteration. Keeps
+	// RunItems' Concurrency fan-out and progress denominator scoped to
+	// real work only.
+	toOrganize := make([]*database.Book, 0, len(books))
 	for i := range books {
 		book := &books[i]
 		if book.LibraryState == nil || *book.LibraryState != "imported" {
@@ -1078,28 +1117,184 @@ func (imp *Importer) organizeImportedBooks(status *itunesImportStatus, log logge
 		if book.ITunesImportSource == nil {
 			continue
 		}
+		toOrganize = append(toOrganize, book)
+	}
+
+	var mu sync.Mutex
+	organized := 0
+
+	// destLocks serializes concurrent workers whose books resolve to the
+	// same destination path — see the doc comment above for why this is
+	// a correctness requirement, not just an optimization.
+	var destLocks sync.Map // map[string]*sync.Mutex
+
+	reporter := &loggerReporterAdapter{log: log}
+
+	runErr := registry.RunItems(ctx, reporter, toOrganize, func(_ context.Context, book *database.Book) error {
+		var files []database.BookFile
+		if imp.store != nil {
+			files, _ = imp.store.GetBookFiles(book.ID)
+		}
+
+		destKey := imp.organizeDestKey(book, files)
+		lockAny, _ := destLocks.LoadOrStore(destKey, &sync.Mutex{})
+		destMu := lockAny.(*sync.Mutex)
+		destMu.Lock()
+		defer destMu.Unlock()
 
 		oldPath := book.FilePath
 		if err := imp.organizeOneBook(book, log); err != nil {
 			recordImportFailure(status, fmt.Sprintf("Failed to organize '%s': %v", book.Title, err))
 			log.Warn("Failed to organize '%s': %v", book.Title, err)
-		} else {
-			book.LibraryState = strPtr("organized")
-			if _, err := imp.store.UpdateBook(book.ID, book); err != nil {
-				log.Error("Failed to update organized path for '%s': %v — rolling back", book.Title, err)
-				if book.FilePath != oldPath {
-					if rbErr := os.Rename(book.FilePath, oldPath); rbErr != nil {
-						log.Error("CRITICAL: rollback failed for %s: file at %s, DB expects %s", book.ID, book.FilePath, oldPath)
-					} else {
-						book.FilePath = oldPath
-					}
-				}
-			} else {
-				organized++
-			}
+			return nil
 		}
+
+		book.LibraryState = strPtr("organized")
+		if _, err := imp.store.UpdateBook(book.ID, book); err != nil {
+			log.Error("Failed to update organized path for '%s': %v — rolling back", book.Title, err)
+			if book.FilePath != oldPath {
+				if rbErr := os.Rename(book.FilePath, oldPath); rbErr != nil {
+					log.Error("CRITICAL: rollback failed for %s: file at %s, DB expects %s", book.ID, book.FilePath, oldPath)
+				} else {
+					book.FilePath = oldPath
+				}
+			}
+			return nil
+		}
+
+		mu.Lock()
+		organized++
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: imp.organizeConcurrency(),
+	})
+	if runErr != nil {
+		// The per-book fn above always returns nil (errors are recorded via
+		// recordImportFailure, matching the serial loop's "keep going"
+		// behavior), so this only fires on ctx cancellation.
+		log.Warn("Organize phase interrupted: %v", runErr)
 	}
+
 	log.Info("Organize phase complete: %d books organized", organized)
+}
+
+// organizeConcurrency returns the registry.RunItems worker-pool size for
+// organizeImportedBooks: runtime.NumCPU() by default (CPU/local-disk-bound
+// work — file copy/hardlink/reflink + a DB write, same shape as the
+// CONC-15/CONC-14 fixes), or organizeConcurrencyOverride when a test has
+// set it to force the sequential path.
+func (imp *Importer) organizeConcurrency() int {
+	if imp.organizeConcurrencyOverride > 0 {
+		return imp.organizeConcurrencyOverride
+	}
+	return runtime.NumCPU()
+}
+
+// organizeDestKey returns the destination path organizeOneBook will
+// resolve for book via imp.organizerFactory: the full target file path for
+// single-file books, or the target directory for merged multi-file books.
+// Used as the destLocks key in organizeImportedBooks so two books that
+// would collide on the same destination are never run through
+// organizeOneBook concurrently (see organizeImportedBooks' doc comment).
+//
+// If organizerFactory is nil or the constructed organizer doesn't expose
+// the path-preview API (e.g. a test double implementing only the
+// BookOrganizer interface), falls back to book.ID — a unique key that
+// serializes nothing, which is safe because organizeOneBook itself will
+// hit the same "not configured" / whatever-the-fake-does error path with
+// no destination-lock protection needed for those cases.
+func (imp *Importer) organizeDestKey(book *database.Book, files []database.BookFile) string {
+	if imp.organizerFactory == nil {
+		return book.ID
+	}
+	org := imp.organizerFactory()
+
+	type targetPather interface {
+		GenerateTargetPath(book *database.Book) (string, error)
+		GenerateTargetDirPath(book *database.Book) (string, error)
+	}
+	tp, ok := org.(targetPather)
+	if !ok {
+		return book.ID
+	}
+
+	if len(files) > 1 {
+		if dir, err := tp.GenerateTargetDirPath(book); err == nil && dir != "" {
+			return dir
+		}
+		return book.ID
+	}
+	if path, err := tp.GenerateTargetPath(book); err == nil && path != "" {
+		return path
+	}
+	return book.ID
+}
+
+// loggerReporterAdapter implements registry.Reporter by delegating to an
+// existing logger.Logger, so organizeImportedBooks can drive
+// registry.RunItems without changing its logger.Logger-based signature.
+// Checkpoint/RunPhase/Trigger/SetCurrentItem are inert no-ops:
+// organizeImportedBooks doesn't do per-item checkpointing (the caller
+// already calls operations.SaveCheckpoint once for the whole "organizing"
+// phase — see Execute) or emit registry-level trigger events.
+type loggerReporterAdapter struct {
+	log logger.Logger
+
+	// mu serializes UpdateProgress calls from concurrent RunItems workers;
+	// logger.Logger implementations are not documented as goroutine-safe.
+	mu sync.Mutex
+}
+
+func (a *loggerReporterAdapter) UpdateProgress(current, total int, message string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.log.UpdateProgress(current, total, message)
+	return nil
+}
+
+func (a *loggerReporterAdapter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	switch {
+	case level >= slog.LevelError:
+		a.log.Error("%s", message)
+	case level >= slog.LevelWarn:
+		a.log.Warn("%s", message)
+	case level >= slog.LevelInfo:
+		a.log.Info("%s", message)
+	default:
+		a.log.Debug("%s", message)
+	}
+	return nil
+}
+
+func (a *loggerReporterAdapter) Logger() *slog.Logger {
+	// Inert: registry.RunItems never calls Logger() itself; it's only
+	// here to satisfy the Reporter interface.
+	return slog.Default()
+}
+
+func (a *loggerReporterAdapter) Checkpoint(state any) error {
+	return nil
+}
+
+func (a *loggerReporterAdapter) IsCanceled() bool {
+	return a.log.IsCanceled()
+}
+
+func (a *loggerReporterAdapter) RunPhase(ctx context.Context, name string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, a)
+}
+
+func (a *loggerReporterAdapter) Trigger(ctx context.Context, eventName string, payload any) error {
+	return nil
+}
+
+func (a *loggerReporterAdapter) SetCurrentItem(label string) {
+	// Inert: RunItems calls this before every item, but organizeImportedBooks
+	// had no per-item "current item" concept before this change and adding
+	// one is out of scope here.
 }
 
 func (imp *Importer) organizeOneBook(book *database.Book, log logger.Logger) error {

--- a/internal/itunes/service/importer_organize_parallel_test.go
+++ b/internal/itunes/service/importer_organize_parallel_test.go
@@ -1,0 +1,208 @@
+// file: internal/itunes/service/importer_organize_parallel_test.go
+// version: 1.0.0
+// guid: 3f9a1c7e-2b6d-4a58-9e0f-7c1d5b8a4e2f
+// last-edited: 2026-07-05
+
+package itunesservice
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// concurrencyTrackingOrganizer is a BookOrganizer test double for
+// CONC-10 that also implements the (unexported, structurally-matched)
+// targetPather interface organizeDestKey type-asserts for
+// (GenerateTargetPath / GenerateTargetDirPath), so organizeImportedBooks'
+// destination-collision guard is actually exercised by the test below.
+//
+// It derives the "destination" purely from book.Title (mirroring
+// organizer.Organizer's real title/author-driven naming pattern) and
+// tracks, per destination key, how many OrganizeBook calls are
+// concurrently in flight. If organizeImportedBooks' per-destination
+// locking were missing or broken, two books sharing a title would be
+// able to run OrganizeBook concurrently and maxInFlight for that key
+// would exceed 1 — exactly the silent-corruption class of bug the
+// lock exists to prevent.
+type concurrencyTrackingOrganizer struct {
+	mu          sync.Mutex
+	inFlight    map[string]int
+	maxInFlight map[string]int
+	calls       int
+}
+
+func newConcurrencyTrackingOrganizer() *concurrencyTrackingOrganizer {
+	return &concurrencyTrackingOrganizer{
+		inFlight:    map[string]int{},
+		maxInFlight: map[string]int{},
+	}
+}
+
+func (o *concurrencyTrackingOrganizer) destFor(book *database.Book) string {
+	return "/organized/" + book.Title + ".m4b"
+}
+
+func (o *concurrencyTrackingOrganizer) OrganizeBook(book *database.Book) (string, string, error) {
+	key := o.destFor(book)
+
+	o.mu.Lock()
+	o.calls++
+	o.inFlight[key]++
+	if o.inFlight[key] > o.maxInFlight[key] {
+		o.maxInFlight[key] = o.inFlight[key]
+	}
+	o.mu.Unlock()
+
+	// Hold the "critical section" open long enough that, absent the
+	// destLocks guard, a second goroutine racing on the same key would
+	// almost certainly overlap with this one.
+	time.Sleep(5 * time.Millisecond)
+
+	o.mu.Lock()
+	o.inFlight[key]--
+	o.mu.Unlock()
+
+	return key, "copy", nil
+}
+
+func (o *concurrencyTrackingOrganizer) OrganizeBookDirectory(book *database.Book, segmentPaths []string) (string, map[string]string, error) {
+	return "", nil, fmt.Errorf("not exercised by this test: all books are single-file")
+}
+
+func (o *concurrencyTrackingOrganizer) GenerateTargetPath(book *database.Book) (string, error) {
+	return o.destFor(book), nil
+}
+
+func (o *concurrencyTrackingOrganizer) GenerateTargetDirPath(book *database.Book) (string, error) {
+	return "/organized/" + book.Title, nil
+}
+
+var _ BookOrganizer = (*concurrencyTrackingOrganizer)(nil)
+
+// buildOrganizeFixture returns N "imported" books, split across
+// distinctTitles distinct titles (so books sharing a title exercise the
+// destLocks collision guard) plus a mock store wired to answer the
+// GetAllBooks/GetBookFiles/UpdateBook calls organizeImportedBooks makes.
+func buildOrganizeFixture(t *testing.T, n, distinctTitles int) ([]database.Book, *dbmocks.MockStore) {
+	t.Helper()
+
+	imported := "imported"
+	src := "/mnt/itunes/Library.xml"
+
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		title := fmt.Sprintf("Title-%d", i%distinctTitles)
+		books[i] = database.Book{
+			ID:                 fmt.Sprintf("book-%d", i),
+			Title:              title,
+			FilePath:           fmt.Sprintf("/mnt/itunes/imported/%d.m4b", i),
+			LibraryState:       &imported,
+			ITunesImportSource: &src,
+		}
+	}
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetAllBooks(100000, 0).Return(books, nil)
+	for i := range books {
+		id := books[i].ID
+		// organizeDestKey and organizeOneBook each call GetBookFiles once
+		// per book (two calls total) — the mock permits unlimited calls
+		// by default (no .Once()), matching that.
+		m.EXPECT().GetBookFiles(id).Return(nil, nil)
+		m.EXPECT().UpdateBook(id, mock.Anything).Return(&database.Book{}, nil)
+	}
+	return books, m
+}
+
+// TestOrganizeImportedBooks_ParallelMatchesSerial_NoDestinationRace runs
+// organizeImportedBooks twice — once forced sequential
+// (organizeConcurrencyOverride=1) and once forced parallel
+// (organizeConcurrencyOverride=8, comfortably more than runtime.NumCPU()
+// on most CI runners so the worker pool actually overlaps workers) —
+// against fixtures with colliding titles, and asserts:
+//  1. both runs organize every book (same result set, order-independent);
+//  2. the parallel run's organizer never sees more than one concurrent
+//     OrganizeBook call for the same destination key (the destLocks
+//     collision guard actually serializes colliding books).
+//
+// Run with `go test -race` per the task brief; the concurrent map/int
+// accesses inside concurrencyTrackingOrganizer plus organizeImportedBooks'
+// own shared counters make this a meaningful race-detector target.
+func TestOrganizeImportedBooks_ParallelMatchesSerial_NoDestinationRace(t *testing.T) {
+	const totalBooks = 12
+	const distinctTitles = 4 // 3 books share each title → guaranteed collisions
+
+	// --- Sequential run -----------------------------------------------
+	seqBooks, seqStore := buildOrganizeFixture(t, totalBooks, distinctTitles)
+	seqOrg := newConcurrencyTrackingOrganizer()
+	seqImp := &Importer{
+		store:                       seqStore,
+		organizerFactory:            func() BookOrganizer { return seqOrg },
+		organizeConcurrencyOverride: 1,
+	}
+	seqStatus := &itunesImportStatus{}
+	seqLog := logger.New("test-seq")
+
+	seqImp.organizeImportedBooks(context.Background(), seqStatus, seqLog)
+
+	require.Equal(t, totalBooks, seqOrg.calls, "sequential run must organize every imported book")
+	for key, max := range seqOrg.maxInFlight {
+		require.LessOrEqualf(t, max, 1, "sequential run must never see concurrent OrganizeBook calls for %s", key)
+	}
+	for _, b := range seqBooks {
+		require.NotNil(t, b.LibraryState)
+	}
+
+	// --- Parallel run ---------------------------------------------------
+	_, parStore := buildOrganizeFixture(t, totalBooks, distinctTitles)
+	parOrg := newConcurrencyTrackingOrganizer()
+	parImp := &Importer{
+		store:                       parStore,
+		organizerFactory:            func() BookOrganizer { return parOrg },
+		organizeConcurrencyOverride: 8,
+	}
+	parStatus := &itunesImportStatus{}
+	parLog := logger.New("test-par")
+
+	parImp.organizeImportedBooks(context.Background(), parStatus, parLog)
+
+	require.Equal(t, totalBooks, parOrg.calls, "parallel run must organize every imported book — same result set as serial")
+
+	// The core correctness assertion: even with Concurrency=8 (>> the
+	// number of distinct destinations), no destination ever had more than
+	// one OrganizeBook call in flight at once.
+	require.Len(t, parOrg.maxInFlight, distinctTitles, "expected one destination key per distinct title")
+	for key, max := range parOrg.maxInFlight {
+		require.LessOrEqualf(t, max, 1, "destLocks must serialize concurrent OrganizeBook calls for colliding destination %s (data-race / corruption risk otherwise)", key)
+	}
+
+	// Same failure/success counts as the sequential run (order-independent
+	// "same result set" check from the task brief).
+	require.Equal(t, 0, seqStatus.Failed, "sequential run: no book should fail to organize in this fixture")
+	require.Equal(t, 0, parStatus.Failed, "parallel run: no book should fail to organize in this fixture")
+}
+
+// TestOrganizeImportedBooks_EmptyList exercises the zero-books path (no
+// imported books) for both concurrency settings — RunItems must be a
+// no-op and must not panic on an empty slice.
+func TestOrganizeImportedBooks_EmptyList(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetAllBooks(100000, 0).Return(nil, nil)
+
+	imp := &Importer{store: m, organizeConcurrencyOverride: 4}
+	status := &itunesImportStatus{}
+	log := logger.New("test-empty")
+
+	imp.organizeImportedBooks(context.Background(), status, log)
+
+	require.Equal(t, 0, status.Failed)
+}


### PR DESCRIPTION
Workstream **itunes-import** / TASK-01 (CONC-10). Parallelizes `organizeImportedBooks` (file-organize + `UpdateBook`) via `registry.RunItems` (Concurrency=NumCPU).

## Correctness: destination-collision guard (the key call)
iTunes destination paths are **NOT** disjoint by book ID — they're derived from metadata (title/author/narrator/series), so two same-metadata books resolve to the same target. `OrganizeBook`'s occupancy check is a non-atomic `os.Stat`→`MkdirAll`→copy, which two goroutines could both pass. Guard: `organizeDestKey(book, files)` computes the exact resolved destination (via the organizer's existing `GenerateTargetPath`/`GenerateTargetDirPath` preview API) and serializes per-destination-key with a `sync.Map`-backed mutex (`destLocks`). Falls back to `book.ID` (no real FS collision risk) when the organizer doesn't implement the preview API.

## Other
- Existing `itunesImportStatus` counters already route through mutex-guarded `status.go` helpers — unchanged. Local `organized` tally guarded by its own mutex. Added `loggerReporterAdapter` (wraps `logger.Logger`; UpdateProgress/Log mutex-serialized; Checkpoint/RunPhase/Trigger/SetCurrentItem inert).

## Acceptance
- [x] Loop routes through `registry.RunItems`
- [x] `go test -race ./internal/itunes/service/...` clean (`ok`) — test validated against a deliberately-broken lock (fails 5/5 without guard, passes 5/5 with)
- [x] `go build`/`go vet ./...` clean; headers bumped