### PR TITLE
perf(dedup): parallelize AcoustIDScan per-book loop, guard its 4 shared maps (CONC-3)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.48.0
+// version: 1.49.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -3441,6 +3441,22 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 	for _, b := range books {
 		boilerplateBookCache[b.ID] = isBoilerplateTitle(b.Title)
 	}
+
+	// CONC-3 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
+	// This per-book loop is embarrassingly parallel — each book's LSH lookup
+	// + Tier-1 segment walk only reads that book's own files — but it shares
+	// FOUR maps + a counter across every book, all mutated inside emit()/the
+	// loop: booksByID, boilerplateBookCache, parentDirCache, emitted, and
+	// identifierGateDrops. mu guards all five. Following TASK-01's
+	// (BookSignatureScan) pattern, the ENTIRE emit() body runs under mu: the
+	// emitted-key check-then-set must be atomic across workers (splitting it
+	// into separate lock/unlock windows would let two workers both pass the
+	// "not already emitted" check for the same pair and double-upsert), and
+	// emits are rare relative to the LSH/segment-walk traffic that stays
+	// lock-free, so this keeps the parallelized work on the hot path.
+	var mu sync.Mutex
+	// isBoilerplateBook is only called from within the locked emit() body
+	// below — mu is already held, so no internal locking here.
 	isBoilerplateBook := func(bookID string) bool {
 		if blocked, ok := boilerplateBookCache[bookID]; ok {
 			return blocked
@@ -3456,7 +3472,7 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	// emitted tracks canonical pair keys we've already inserted this run so we
 	// don't call UpsertCandidate multiple times for the same pair (can happen
-	// when two books share several segments).
+	// when two books share several segments). Guarded by mu.
 	emitted := make(map[string]struct{})
 	pairKey := func(a, b string) string {
 		if a > b {
@@ -3467,6 +3483,9 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	// Per-book parent-directory cache so we don't fetch BookFiles twice per
 	// comparison. Empty string = unknown / no files / different parents.
+	// Guarded by mu: populated both by the per-book priming step in the
+	// RunItems callback below and lazily inside parentDirForBook (which, like
+	// isBoilerplateBook, is only called from within the locked emit() body).
 	parentDirCache := make(map[string]string)
 	parentDirForBook := func(bookID string) string {
 		if v, ok := parentDirCache[bookID]; ok {
@@ -3489,6 +3508,8 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 	}
 
 	identifierGateDrops := 0
+	// bookForIdentifierGate is only called from within the locked emit()
+	// body below — mu is already held, so no internal locking here.
 	bookForIdentifierGate := func(bookID string) *database.Book {
 		if b := booksByID[bookID]; b != nil {
 			return b
@@ -3500,7 +3521,13 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		booksByID[bookID] = b
 		return b
 	}
+	// emit runs the full pair decision + all four-map/counter mutation under
+	// mu (see CONC-3 comment above), so concurrent workers can never
+	// interleave on the same pair key and the guarded state sees exactly the
+	// same sequence of updates the serial scan produced.
 	emit := func(bookAID, bookBID string, sim float64) {
+		mu.Lock()
+		defer mu.Unlock()
 		if isBoilerplateBook(bookAID) || isBoilerplateBook(bookBID) {
 			return
 		}
@@ -3538,120 +3565,121 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 	}
 
 	total := len(books)
-	for i, book := range books {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	err = registry.RunItems(ctx, &progressCallbackReporter{progress: progress}, books,
+		func(_ context.Context, book database.Book) error {
+			files, err := de.bookStore.GetBookFiles(book.ID)
+			if err != nil {
+				slog.Info("[dedup] acoustid scan get files for", "book", book.ID, "err", err)
+				return nil
+			}
 
-		files, err := de.bookStore.GetBookFiles(book.ID)
-		if err != nil {
-			slog.Info("[dedup] acoustid scan get files for", "book", book.ID, "err", err)
-			continue
-		}
-
-		// Prime cache for this book (avoids the duplicate GetBookFiles
-		// inside parentDirForBook when emit is called for this side).
-		if _, cached := parentDirCache[book.ID]; !cached {
-			if len(files) == 0 {
-				parentDirCache[book.ID] = ""
-			} else {
-				dir := filepath.Dir(files[0].FilePath)
-				ok := true
-				for _, bf := range files[1:] {
-					if filepath.Dir(bf.FilePath) != dir {
-						ok = false
-						break
-					}
-				}
-				if ok {
-					parentDirCache[book.ID] = dir
-				} else {
+			// Prime cache for this book (avoids the duplicate GetBookFiles
+			// inside parentDirForBook when emit is called for this side).
+			// Pure in-memory (files already fetched above) — cheap even
+			// though every worker takes this lock once per book.
+			mu.Lock()
+			if _, cached := parentDirCache[book.ID]; !cached {
+				if len(files) == 0 {
 					parentDirCache[book.ID] = ""
-				}
-			}
-		}
-
-		// LSH-backed candidate lookup is optional — only PebbleStore
-		// implements it. SQLite/mock stores skip this path and fall
-		// through to the segment walk below.
-		lshStore, _ := de.bookStore.(interface {
-			LookupAcoustIDCandidates(fp []byte, maxCandidates int) ([]string, error)
-			GetBookFileByID(bookID, fileID string) (*database.BookFile, error)
-		})
-
-		for _, f := range files {
-			if isBoilerplateTitle(f.Title) {
-				continue
-			}
-			// Skip files whose fingerprint duration is below the minimum — these
-			// are typically short publisher jingles or intro clips that appear on
-			// many unrelated books and produce false-positive pairs.
-			if knownShortFingerprintFile(f) {
-				continue
-			}
-			// Tier-0: whole-file LSH candidate set + Hamming refine.
-			// Sub-linear via the fpidx: secondary index, so it runs
-			// unconditionally (index caps candidates, so work is bounded).
-			if lshStore != nil && len(f.AcoustIDFingerprint) > 0 {
-				cands, _ := lshStore.LookupAcoustIDCandidates(f.AcoustIDFingerprint, 200)
-				for _, candID := range cands {
-					if candID == f.ID {
-						continue
+				} else {
+					dir := filepath.Dir(files[0].FilePath)
+					ok := true
+					for _, bf := range files[1:] {
+						if filepath.Dir(bf.FilePath) != dir {
+							ok = false
+							break
+						}
 					}
-					cand, _ := lshStore.GetBookFileByID("", candID)
-					if cand == nil || cand.BookID == book.ID || len(cand.AcoustIDFingerprint) == 0 ||
-						isBoilerplateTitle(cand.Title) {
-						continue
-					}
-					sim, simErr := fingerprint.WholeFileSimilarity(f.AcoustIDFingerprint, cand.AcoustIDFingerprint)
-					if simErr != nil {
-						continue
-					}
-					if sim >= fingerprint.FuzzyMinSimilarity {
-						emit(book.ID, cand.BookID, sim)
+					if ok {
+						parentDirCache[book.ID] = dir
+					} else {
+						parentDirCache[book.ID] = ""
 					}
 				}
 			}
+			mu.Unlock()
 
-			// Tier-1 (exact) and Tier-2 (legacy fuzzy walk) over seg
-			// strings — still useful for rows that haven't been
-			// re-fingerprinted to whole-file yet (no AcoustIDFingerprint).
-			segs := []string{
-				f.AcoustIDSeg0, f.AcoustIDSeg1, f.AcoustIDSeg2,
-				f.AcoustIDSeg3, f.AcoustIDSeg4, f.AcoustIDSeg5,
-				f.AcoustIDSeg6,
-			}
-			for _, seg := range segs {
-				if seg == "" {
+			// LSH-backed candidate lookup is optional — only PebbleStore
+			// implements it. SQLite/mock stores skip this path and fall
+			// through to the segment walk below.
+			lshStore, _ := de.bookStore.(interface {
+				LookupAcoustIDCandidates(fp []byte, maxCandidates int) ([]string, error)
+				GetBookFileByID(bookID, fileID string) (*database.BookFile, error)
+			})
+
+			for _, f := range files {
+				if isBoilerplateTitle(f.Title) {
 					continue
 				}
-				// Reject degenerate fingerprints (e.g. "AQAAAA" sentinel
-				// from a failed ffmpeg seek). They'd otherwise match every
-				// other book carrying the same sentinel at similarity 1.0.
-				// The writer now drops these, but old rows in production
-				// still need this guard until reset-and-rescan clears them.
-				if !fingerprint.IsUsefulFingerprint(seg) {
+				// Skip files whose fingerprint duration is below the minimum — these
+				// are typically short publisher jingles or intro clips that appear on
+				// many unrelated books and produce false-positive pairs.
+				if knownShortFingerprintFile(f) {
 					continue
 				}
+				// Tier-0: whole-file LSH candidate set + Hamming refine.
+				// Sub-linear via the fpidx: secondary index, so it runs
+				// unconditionally (index caps candidates, so work is bounded).
+				if lshStore != nil && len(f.AcoustIDFingerprint) > 0 {
+					cands, _ := lshStore.LookupAcoustIDCandidates(f.AcoustIDFingerprint, 200)
+					for _, candID := range cands {
+						if candID == f.ID {
+							continue
+						}
+						cand, _ := lshStore.GetBookFileByID("", candID)
+						if cand == nil || cand.BookID == book.ID || len(cand.AcoustIDFingerprint) == 0 ||
+							isBoilerplateTitle(cand.Title) {
+							continue
+						}
+						sim, simErr := fingerprint.WholeFileSimilarity(f.AcoustIDFingerprint, cand.AcoustIDFingerprint)
+						if simErr != nil {
+							continue
+						}
+						if sim >= fingerprint.FuzzyMinSimilarity {
+							emit(book.ID, cand.BookID, sim)
+						}
+					}
+				}
 
-				// Tier 1: exact match (O(1) via Pebble book_file_acoustid: index).
-				exactHit, _ := de.bookStore.GetBookFileByAcoustID(seg)
-				if exactHit != nil && exactHit.BookID != book.ID {
-					if isBoilerplateTitle(exactHit.Title) {
+				// Tier-1 (exact) and Tier-2 (legacy fuzzy walk) over seg
+				// strings — still useful for rows that haven't been
+				// re-fingerprinted to whole-file yet (no AcoustIDFingerprint).
+				segs := []string{
+					f.AcoustIDSeg0, f.AcoustIDSeg1, f.AcoustIDSeg2,
+					f.AcoustIDSeg3, f.AcoustIDSeg4, f.AcoustIDSeg5,
+					f.AcoustIDSeg6,
+				}
+				for _, seg := range segs {
+					if seg == "" {
 						continue
 					}
-					emit(book.ID, exactHit.BookID, 1.0)
-					continue
+					// Reject degenerate fingerprints (e.g. "AQAAAA" sentinel
+					// from a failed ffmpeg seek). They'd otherwise match every
+					// other book carrying the same sentinel at similarity 1.0.
+					// The writer now drops these, but old rows in production
+					// still need this guard until reset-and-rescan clears them.
+					if !fingerprint.IsUsefulFingerprint(seg) {
+						continue
+					}
+
+					// Tier 1: exact match (O(1) via Pebble book_file_acoustid: index).
+					exactHit, _ := de.bookStore.GetBookFileByAcoustID(seg)
+					if exactHit != nil && exactHit.BookID != book.ID {
+						if isBoilerplateTitle(exactHit.Title) {
+							continue
+						}
+						emit(book.ID, exactHit.BookID, 1.0)
+						continue
+					}
+
 				}
-
 			}
-		}
-
-		if progress != nil && (i%50 == 0 || i == total-1) {
-			progress(i+1, total)
-		}
+			return nil
+		},
+		registry.RunItemsOptions{Concurrency: runtime.NumCPU()},
+	)
+	if err != nil {
+		return err
 	}
 
 	slog.Info("[dedup] acoustid scan complete books scanned, candidate pair(s) emitted",

--- a/internal/dedup/engine_acoustid_parallel_test.go
+++ b/internal/dedup/engine_acoustid_parallel_test.go
@@ -1,0 +1,175 @@
+// file: internal/dedup/engine_acoustid_parallel_test.go
+// version: 1.0.0
+// guid: 9d3b6f1a-2c47-4e8b-9a0d-5f61c8e0a3b2
+// last-edited: 2026-07-05
+
+// Regression tests for CONC-3: AcoustIDScan's per-book loop is now sharded
+// across a bounded worker pool (registry.RunItems) instead of running
+// single-threaded. AcoustIDScan mutates FOUR shared maps + a counter inside
+// emit()/the loop (booksByID, boilerplateBookCache, parentDirCache, emitted,
+// identifierGateDrops) — this test proves the parallel pass emits the EXACT
+// same candidate set as an independent ground truth (no lost/duplicated
+// updates through the guarded state) and exercises every one of the four
+// gates (boilerplate book, conflicting identifiers, same-parent-dir
+// suppression, and a genuine match) concurrently under -race.
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestParallelAcoustIDScan_SameCandidatesAsSerial builds a "hub" fixture: a
+// single HUB book and many satellite books that all share one AcoustID
+// segment fingerprint. The mock's exact-match lookup always resolves that
+// shared segment to HUB's file, so every satellite book's scan should emit
+// exactly one candidate pairing it with HUB (HUB's own lookup of its own
+// segment resolves to itself and is skipped — never a self-pair).
+//
+// The fixture is sized well above runtime.NumCPU() so the outer RunItems
+// shard genuinely parallelizes and many emit() calls contend on the
+// mutex-guarded maps/counter. Three additional satellites each test one of
+// the other three gates so all four guarded maps + the counter are exercised
+// under concurrency:
+//   - book-boilerplate: boilerplate title -> isBoilerplateBook excludes it
+//     (boilerplateBookCache).
+//   - book-samedir: files live in the same parent directory as HUB -> the
+//     same-directory suppression excludes it (parentDirCache).
+//   - book-conflict: conflicting ISBN13 vs HUB -> identifiersConflict drops it
+//     (booksByID, identifierGateDrops), while still marking the pair emitted
+//     (emitted) so it can never double-fire.
+func TestParallelAcoustIDScan_SameCandidatesAsSerial(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	const numSatellites = 60
+	hubISBN := "9780000000001"
+	conflictISBN := "9780000000002"
+
+	var books []database.Book
+	filesByBook := make(map[string][]database.BookFile)
+
+	books = append(books, database.Book{ID: "HUB", Title: "The Hub Book", ISBN13: &hubISBN})
+	filesByBook["HUB"] = []database.BookFile{{
+		ID: "F_HUB", BookID: "HUB", FilePath: "/lib/hub/book.mp3", AcoustIDSeg0: validFP80,
+	}}
+
+	books = append(books, database.Book{ID: "book-boilerplate", Title: "  THIS   IS\tAUDIBLE  "})
+	filesByBook["book-boilerplate"] = []database.BookFile{{
+		ID: "F_boilerplate", BookID: "book-boilerplate", FilePath: "/lib/dboilerplate/book.mp3", AcoustIDSeg0: validFP80,
+	}}
+
+	books = append(books, database.Book{ID: "book-samedir", Title: "Same Dir Book"})
+	filesByBook["book-samedir"] = []database.BookFile{{
+		ID: "F_samedir", BookID: "book-samedir", FilePath: "/lib/hub/other.mp3", AcoustIDSeg0: validFP80,
+	}}
+
+	books = append(books, database.Book{ID: "book-conflict", Title: "Conflicting ISBN Book", ISBN13: &conflictISBN})
+	filesByBook["book-conflict"] = []database.BookFile{{
+		ID: "F_conflict", BookID: "book-conflict", FilePath: "/lib/dconflict/book.mp3", AcoustIDSeg0: validFP80,
+	}}
+
+	var wantMatches []string // satellite book IDs expected to pair with HUB
+	for i := 0; i < numSatellites; i++ {
+		id := fmt.Sprintf("book-%02d", i)
+		books = append(books, database.Book{ID: id, Title: fmt.Sprintf("Real Book %02d", i)})
+		filesByBook[id] = []database.BookFile{{
+			ID: "F_" + id, BookID: id, FilePath: fmt.Sprintf("/lib/d%02d/book.mp3", i), AcoustIDSeg0: validFP80,
+		}}
+		wantMatches = append(wantMatches, id)
+	}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		return books, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		return filesByBook[bookID], nil
+	}
+	// The real store's exact-match index maps one fingerprint value to a
+	// single file. Every book here shares validFP80, so wire the lookup to
+	// always resolve to HUB's file — this deterministically creates a
+	// "star" topology (every satellite matches HUB, never each other) that
+	// is easy to verify independently of the scan under test.
+	mock.GetBookFileByAcoustIDFunc = func(fp string) (*database.BookFile, error) {
+		if fp != validFP80 {
+			return nil, nil
+		}
+		hubFile := filesByBook["HUB"][0]
+		return &hubFile, nil
+	}
+
+	// Ground truth computed independently of AcoustIDScan: exactly one
+	// candidate per wantMatches entry, pairing it with HUB. The three special
+	// satellites (boilerplate/samedir/conflict) must NOT appear.
+	want := make(map[string]struct{}, len(wantMatches))
+	for _, id := range wantMatches {
+		want[pairKeyFor(id, "HUB")] = struct{}{}
+	}
+
+	type prog struct{ done, total int }
+	var progs []prog
+
+	if err := engine.AcoustIDScan(context.Background(), func(done, total int) {
+		progs = append(progs, prog{done, total})
+	}); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book", Layer: "acoustid", Status: "pending", Limit: 1_000_000,
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	got := make(map[string]struct{}, len(cands))
+	for _, c := range cands {
+		key := pairKeyFor(c.EntityAID, c.EntityBID)
+		if _, dup := got[key]; dup {
+			t.Fatalf("duplicate candidate emitted for pair %s", key)
+		}
+		got[key] = struct{}{}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("candidate count mismatch: got %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for key := range want {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("missing expected candidate pair %s (lost update in parallel scan)", key)
+		}
+	}
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Fatalf("unexpected candidate pair %s (spurious emit, e.g. a suppressed gate leaked through)", key)
+		}
+	}
+
+	// Explicitly confirm the three gated satellites never produced a
+	// candidate with HUB (redundant with the set comparison above, but
+	// pins down which gate each one exercises for future readers).
+	for _, gated := range []string{"book-boilerplate", "book-samedir", "book-conflict"} {
+		if _, ok := got[pairKeyFor(gated, "HUB")]; ok {
+			t.Fatalf("gated satellite %s unexpectedly produced a candidate with HUB", gated)
+		}
+	}
+
+	if len(progs) == 0 {
+		t.Fatal("progress callback never invoked")
+	}
+	total := len(books)
+	last := 0
+	for i, p := range progs {
+		if p.total != total {
+			t.Fatalf("progress[%d].total = %d, want %d", i, p.total, total)
+		}
+		if p.done < last {
+			t.Fatalf("progress not monotonic: progress[%d].done=%d < previous %d", i, p.done, last)
+		}
+		last = p.done
+	}
+	if last != total {
+		t.Fatalf("final progress done = %d, want %d", last, total)
+	}
+}


### PR DESCRIPTION
Workstream **dedup-engine** / TASK-03 (CONC-3) · ⚠ review-critical (4 shared maps + counter).

## What changed
- `internal/dedup/engine.go`: `AcoustIDScan`'s per-book loop → `registry.RunItems` (Concurrency=NumCPU), reusing TASK-01's `progressCallbackReporter`. A single `mu sync.Mutex` guards all shared state; `emit()` holds `mu` for its **entire** body (atomic check-then-set of the pair key — avoids a TOCTOU double-upsert), matching TASK-01's `emitMu` pattern.
- **The 4 maps + counter, each guarded:** `booksByID`, `boilerplateBookCache`, `parentDirCache` (touched under lock at the callback priming site + inside the locked `emit()` via `parentDirForBook`), `emitted`, and the `identifierGateDrops` counter. Helpers (`isBoilerplateBook`/`bookForIdentifierGate`/`parentDirForBook`) are called ONLY from within the locked `emit()` body, so they carry no internal locking → no self-deadlock.
- `internal/dedup/engine_acoustid_parallel_test.go` (new): `TestParallelAcoustIDScan_SameCandidatesAsSerial` — 64 books (star topology + gate-exercise satellites), exact candidate-set match vs independent ground truth, no dups, monotonic progress; 5/5 under `-race`. 9 pre-existing AcoustIDScan tests still pass.

## Acceptance
- [x] Loop routes through `registry.RunItems`
- [x] `go test -race ./internal/dedup/...` clean; parity test passes 5/5
- [x] Parallel output identical to serial (all 4 maps + counter guarded)
- [x] `go build`/`go vet ./...` clean; headers bumped