### PR TITLE
perf(itunes): parallelize enrichImportedBooks, reframe rate-limit circuit-breaker (CONC-11)

### DIFF
--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 // last-edited: 2026-07-05
 
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -86,7 +87,7 @@ type Importer struct {
 	eventBus         plugin.EventPublisher // may be nil; replaces OnBookCreated
 	cfg              Config
 	log              logger.Logger
-	mfs              *metafetch.Service
+	mfs              metadataFetcher
 	organizerFactory func() BookOrganizer
 	statusMap        importStatusMap
 
@@ -96,6 +97,25 @@ type Importer struct {
 	// purely as a test seam so a test can force the sequential path (1)
 	// and diff it against the parallel path (see organizeConcurrency).
 	organizeConcurrencyOverride int
+
+	// enrichConcurrencyOverride, when > 0, overrides the worker-pool size
+	// enrichImportedBooks passes to registry.RunItems. Zero (the default
+	// for every real Importer) means "use enrichConcurrency". Same test
+	// seam purpose as organizeConcurrencyOverride: lets a test force the
+	// sequential path (1) and diff it against a parallel path.
+	enrichConcurrencyOverride int
+}
+
+// metadataFetcher is the narrow, single-method subset of *metafetch.Service
+// that enrichImportedBooks depends on. enrichImportedBooks calls this
+// interface (rather than *metafetch.Service directly) purely as a test seam:
+// it lets tests fake FetchMetadataForBook's success/failure/timing to
+// exercise registry.RunItems' parallel fan-out and the CONC-11 circuit
+// breaker below without wiring a real metadata.MetadataSource +
+// database.Store pair through a live metafetch.Service. *metafetch.Service
+// satisfies this interface unmodified — newImporter's wiring is unaffected.
+type metadataFetcher interface {
+	FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error)
 }
 
 func newImporter(deps Deps) *Importer {
@@ -432,7 +452,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 	if req.FetchMetadata {
 		_ = operations.SaveCheckpoint(imp.store, opID, "itunes_import", "enriching", 0, 0)
 		log.Info("Starting metadata enrichment phase...")
-		imp.enrichImportedBooks(status, log)
+		imp.enrichImportedBooks(ctx, status, log)
 	}
 
 	// Phase 5: Organize
@@ -1018,7 +1038,56 @@ func sortTracksByDiscTrack(tracks []*itunes.Track) {
 	})
 }
 
-func (imp *Importer) enrichImportedBooks(status *itunesImportStatus, log logger.Logger) {
+// enrichConcurrency is the FIXED registry.RunItems worker-pool size for
+// enrichImportedBooks's FetchMetadataForBook calls (CONC-11). Unlike
+// organizeConcurrency (CPU/local-disk-bound work, sized to
+// runtime.NumCPU()), FetchMetadataForBook is a network call against an
+// external, rate-limited metadata source — adding more workers would just
+// let more goroutines hammer the same rate limit at once, so this is a
+// small named constant instead of scaling with core count.
+const enrichConcurrency = 4
+
+// enrichBreakerThreshold is the shared-aggregate-failure trip point for the
+// circuit breaker below, carried over from the pre-parallelization
+// `consecutiveErrors >= 5` check (see enrichImportedBooks's doc comment for
+// how its meaning changes under concurrency).
+const enrichBreakerThreshold = 5
+
+// enrichImportedBooks runs the per-book metadata-fetch (FetchMetadataForBook)
+// step over every LibraryState=="imported" book via registry.RunItems
+// (CONC-11), fanning out over a small FIXED enrichConcurrency worker pool
+// (see its doc comment for why fixed-vs-NumCPU).
+//
+// Circuit-breaker semantic change under parallelization (read carefully —
+// this is the correctness-critical part of CONC-11):
+//   - The original sequential loop tracked a *consecutive* failure counter
+//     (consecutiveErrors) that reset to 0 on any success and, upon
+//     reaching 5, slept 10s and reset back to 0 so the caller would keep
+//     going once the rate limit had presumably recovered. "Consecutive"
+//     only has a well-defined meaning when exactly one FetchMetadataForBook
+//     call is in flight at a time.
+//   - Under a worker pool, several calls run concurrently, so there is no
+//     single consecutive sequence to track. This reframes the breaker as a
+//     SHARED AGGREGATE failure counter (breakerFails, an atomic int32):
+//     every failure increments it, every success resets it to 0. When it
+//     reaches enrichBreakerThreshold, the tripping worker — exactly once,
+//     via breakerTripped (sync.Once), so concurrent trippers don't each
+//     log/cancel — cancels a context derived from the caller's ctx.
+//     registry.RunItems' worker pool stops launching new items once that
+//     context is canceled (workers already in flight still finish, mirror-
+//     ing the "let the current call complete" behavior of the original
+//     loop), which preserves the "stop hammering a rate-limited source"
+//     intent without a "sleep 10s and silently resume" step that has no
+//     race-free meaning across concurrent workers. This is a deliberate,
+//     documented semantic change: tripping the breaker now aborts the REST
+//     of this enrichment pass instead of pausing then continuing it.
+//   - itunesImportStatus counters: enrichImportedBooks does not update
+//     `status` today — the pre-existing sequential loop didn't either — so
+//     no new locking is needed there; the mutex-guarded helpers in
+//     status.go remain available if a future change starts using it.
+//   - The local `enriched` tally is guarded by its own mutex, same pattern
+//     as organizeImportedBooks' `organized` counter.
+func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImportStatus, log logger.Logger) {
 	if imp.mfs == nil {
 		log.Warn("Metadata enrichment skipped: no metafetch service wired")
 		return
@@ -1030,30 +1099,50 @@ func (imp *Importer) enrichImportedBooks(status *itunesImportStatus, log logger.
 		return
 	}
 
-	enriched := 0
-	consecutiveErrors := 0
-	for i, book := range books {
+	// Pre-filter to the books this phase actually enriches, same filter the
+	// original sequential loop applied inline per iteration. Keeps
+	// RunItems' Concurrency fan-out and progress denominator scoped to real
+	// work only (mirrors organizeImportedBooks' toOrganize pre-filter).
+	toEnrich := make([]*database.Book, 0, len(books))
+	for i := range books {
+		book := &books[i]
 		if book.LibraryState == nil || *book.LibraryState != "imported" {
 			continue
 		}
 		if book.ITunesImportSource == nil {
 			continue
 		}
+		toEnrich = append(toEnrich, book)
+	}
 
+	var mu sync.Mutex
+	enriched := 0
+
+	// breakerFails / breakerTripped implement the shared-aggregate circuit
+	// breaker described in the doc comment above.
+	var breakerFails int32
+	var breakerTripped sync.Once
+
+	enrichCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reporter := &loggerReporterAdapter{log: log}
+
+	runErr := registry.RunItems(enrichCtx, reporter, toEnrich, func(_ context.Context, book *database.Book) error {
 		resp, err := imp.mfs.FetchMetadataForBook(book.ID)
 		if err != nil {
 			log.Debug("No metadata found for '%s': %v", book.Title, err)
-			consecutiveErrors++
-			if consecutiveErrors >= 5 {
-				log.Info("Rate limit detected, pausing 10s...")
-				time.Sleep(10 * time.Second)
-				consecutiveErrors = 0
+			if atomic.AddInt32(&breakerFails, 1) >= enrichBreakerThreshold {
+				breakerTripped.Do(func() {
+					log.Info("Rate limit detected (%d aggregate failures), aborting remaining enrichment", enrichBreakerThreshold)
+					cancel()
+				})
 			}
-			continue
+			return nil
 		}
 
-		consecutiveErrors = 0
-		enriched++
+		atomic.StoreInt32(&breakerFails, 0)
+
 		if resp.Book != nil && resp.Book.AuthorID != nil {
 			existing, _ := imp.store.GetBookAuthors(book.ID)
 			if len(existing) <= 1 {
@@ -1063,12 +1152,38 @@ func (imp *Importer) enrichImportedBooks(status *itunesImportStatus, log logger.
 			}
 		}
 
-		if enriched%10 == 0 {
-			log.Info("Enriched %d books so far (processing %d/%d)...", enriched, i+1, len(books))
-			time.Sleep(2 * time.Second)
+		mu.Lock()
+		enriched++
+		n := enriched
+		mu.Unlock()
+		if n%10 == 0 {
+			log.Info("Enriched %d books so far", n)
 		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: imp.enrichConcurrency(),
+	})
+	if runErr != nil {
+		// The per-book fn above always returns nil (errors are handled
+		// in-line via the breaker, matching the serial loop's "keep going"
+		// behavior for a single failure), so this only fires on ctx
+		// cancellation — including the breaker's own cancel() above.
+		log.Warn("Enrichment phase interrupted: %v", runErr)
 	}
+
 	log.Info("Metadata enrichment complete: %d books enriched", enriched)
+}
+
+// enrichConcurrency returns the registry.RunItems worker-pool size for
+// enrichImportedBooks: the fixed enrichConcurrency const by default (see the
+// package-level const's doc comment for why fixed-vs-NumCPU), or
+// enrichConcurrencyOverride when a test has set it to force a specific
+// pool size (e.g. 1 for the sequential path).
+func (imp *Importer) enrichConcurrency() int {
+	if imp.enrichConcurrencyOverride > 0 {
+		return imp.enrichConcurrencyOverride
+	}
+	return enrichConcurrency
 }
 
 // organizeImportedBooks runs the per-book organize (file-move) + UpdateBook

--- a/internal/itunes/service/importer_enrich_parallel_test.go
+++ b/internal/itunes/service/importer_enrich_parallel_test.go
@@ -1,0 +1,255 @@
+// file: internal/itunes/service/importer_enrich_parallel_test.go
+// version: 1.0.0
+// guid: 8d3a5b1e-6f2c-4a97-9e1d-3c7b8f4a2d6e
+// last-edited: 2026-07-05
+
+package itunesservice
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMetadataFetcher is a metadataFetcher test double. It tracks every
+// FetchMetadataForBook call (count + max in-flight concurrency observed) and
+// decides success/failure per book ID via a caller-supplied predicate —
+// letting tests exercise both the happy path and the CONC-11 circuit
+// breaker without wiring a real metafetch.Service + metadata.MetadataSource
+// + database.Store chain.
+type fakeMetadataFetcher struct {
+	fails func(id string) bool
+
+	mu          sync.Mutex
+	calls       int
+	inFlight    int
+	maxInFlight int
+	seen        map[string]int
+}
+
+func newFakeMetadataFetcher(fails func(id string) bool) *fakeMetadataFetcher {
+	return &fakeMetadataFetcher{fails: fails, seen: map[string]int{}}
+}
+
+func (f *fakeMetadataFetcher) FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error) {
+	f.mu.Lock()
+	f.calls++
+	f.inFlight++
+	if f.inFlight > f.maxInFlight {
+		f.maxInFlight = f.inFlight
+	}
+	f.seen[id]++
+	f.mu.Unlock()
+
+	defer func() {
+		f.mu.Lock()
+		f.inFlight--
+		f.mu.Unlock()
+	}()
+
+	if f.fails != nil && f.fails(id) {
+		return nil, fmt.Errorf("no metadata found for %q from any source", id)
+	}
+
+	authorID := 42
+	return &metafetch.FetchMetadataResponse{
+		Message: "metadata fetched and applied",
+		Book:    &database.Book{ID: id, AuthorID: &authorID},
+		Source:  "fake",
+	}, nil
+}
+
+func (f *fakeMetadataFetcher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+var _ metadataFetcher = (*fakeMetadataFetcher)(nil)
+
+// buildEnrichFixture returns n "imported" books plus a mock store wired to
+// answer the GetAllBooks/GetBookAuthors/SetBookAuthors calls
+// enrichImportedBooks makes. Every book starts with zero existing authors,
+// so a successful fetch always exercises the SetBookAuthors call.
+func buildEnrichFixture(t *testing.T, n int) ([]database.Book, *dbmocks.MockStore) {
+	t.Helper()
+
+	imported := "imported"
+	src := "/mnt/itunes/Library.xml"
+
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		books[i] = database.Book{
+			ID:                 fmt.Sprintf("book-%d", i),
+			Title:              fmt.Sprintf("Title-%d", i),
+			LibraryState:       &imported,
+			ITunesImportSource: &src,
+		}
+	}
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetAllBooks(10000, 0).Return(books, nil)
+	for i := range books {
+		id := books[i].ID
+		m.EXPECT().GetBookAuthors(id).Return(nil, nil).Maybe()
+		m.EXPECT().SetBookAuthors(id, mock.Anything).Return(nil).Maybe()
+	}
+	return books, m
+}
+
+// TestEnrichImportedBooks_ParallelMatchesSerial runs enrichImportedBooks
+// twice against equivalent fixtures — once forced sequential
+// (enrichConcurrencyOverride=1) and once forced parallel
+// (enrichConcurrencyOverride=8, comfortably more than the real
+// enrichConcurrency=4 default so the worker pool actually overlaps workers)
+// — and asserts both runs fetch metadata for every imported book exactly
+// once and enrich the same result set (order-independent). Every book
+// succeeds in this fixture, so the breaker is never exercised here — see
+// TestEnrichImportedBooks_BreakerCancelsRemainingWork for that.
+//
+// Run with `go test -race`: the fakeMetadataFetcher's shared counters plus
+// enrichImportedBooks' own `enriched`/breakerFails state are exactly the
+// kind of concurrent access a missing lock/atomic would corrupt.
+func TestEnrichImportedBooks_ParallelMatchesSerial(t *testing.T) {
+	const totalBooks = 12
+
+	// --- Sequential run -------------------------------------------------
+	seqBooks, seqStore := buildEnrichFixture(t, totalBooks)
+	seqFetcher := newFakeMetadataFetcher(nil) // never fails
+	seqImp := &Importer{
+		store:                     seqStore,
+		mfs:                       seqFetcher,
+		enrichConcurrencyOverride: 1,
+	}
+	seqStatus := &itunesImportStatus{}
+	seqLog := logger.New("test-enrich-seq")
+
+	seqImp.enrichImportedBooks(context.Background(), seqStatus, seqLog)
+
+	require.Equal(t, totalBooks, seqFetcher.callCount(), "sequential run must fetch metadata for every imported book")
+	require.LessOrEqual(t, seqFetcher.maxInFlight, 1, "sequential run must never have concurrent FetchMetadataForBook calls")
+	for _, b := range seqBooks {
+		require.Equal(t, 1, seqFetcher.seen[b.ID], "each book fetched exactly once")
+	}
+
+	// --- Parallel run -----------------------------------------------------
+	parBooks, parStore := buildEnrichFixture(t, totalBooks)
+	parFetcher := newFakeMetadataFetcher(nil) // never fails
+	parImp := &Importer{
+		store:                     parStore,
+		mfs:                       parFetcher,
+		enrichConcurrencyOverride: 8,
+	}
+	parStatus := &itunesImportStatus{}
+	parLog := logger.New("test-enrich-par")
+
+	parImp.enrichImportedBooks(context.Background(), parStatus, parLog)
+
+	require.Equal(t, totalBooks, parFetcher.callCount(), "parallel run must fetch metadata for every imported book — same result set as serial")
+	for _, b := range parBooks {
+		require.Equal(t, 1, parFetcher.seen[b.ID], "each book fetched exactly once, no duplicate/dropped work under concurrency")
+	}
+}
+
+// TestEnrichImportedBooks_EmptyList exercises the zero-books path (no
+// imported books) — RunItems must be a no-op and must not panic.
+func TestEnrichImportedBooks_EmptyList(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetAllBooks(10000, 0).Return(nil, nil)
+
+	fetcher := newFakeMetadataFetcher(nil)
+	imp := &Importer{store: m, mfs: fetcher, enrichConcurrencyOverride: 4}
+	status := &itunesImportStatus{}
+	log := logger.New("test-enrich-empty")
+
+	imp.enrichImportedBooks(context.Background(), status, log)
+
+	require.Equal(t, 0, fetcher.callCount())
+}
+
+// TestEnrichImportedBooks_NoMetafetchService exercises the imp.mfs == nil
+// guard clause — must return immediately without touching the store.
+func TestEnrichImportedBooks_NoMetafetchService(t *testing.T) {
+	m := dbmocks.NewMockStore(t) // no .EXPECT() calls set up — any call fails the test
+	imp := &Importer{store: m, mfs: nil}
+	status := &itunesImportStatus{}
+	log := logger.New("test-enrich-no-mfs")
+
+	imp.enrichImportedBooks(context.Background(), status, log)
+}
+
+// TestEnrichImportedBooks_BreakerCancelsRemainingWork is the correctness-
+// critical CONC-11 test: with every FetchMetadataForBook call failing, the
+// shared-aggregate breaker (breakerFails >= enrichBreakerThreshold) must
+// cancel the RunItems context so registry.RunItems stops LAUNCHING new
+// items — the total number of attempted fetches must stay well below the
+// full book count instead of hammering every single one.
+//
+// Uses a large book count (50) relative to enrichConcurrency (4) and
+// enrichBreakerThreshold (5) so the "stopped early" signal is unambiguous
+// even accounting for the handful of workers already in flight when the
+// breaker trips.
+func TestEnrichImportedBooks_BreakerCancelsRemainingWork(t *testing.T) {
+	const totalBooks = 50
+
+	books, store := buildEnrichFixture(t, totalBooks)
+	_ = books
+	fetcher := newFakeMetadataFetcher(func(string) bool { return true }) // every call fails
+	imp := &Importer{store: store, mfs: fetcher, enrichConcurrencyOverride: 4}
+	status := &itunesImportStatus{}
+	log := logger.New("test-enrich-breaker")
+
+	imp.enrichImportedBooks(context.Background(), status, log)
+
+	attempted := fetcher.callCount()
+	require.Less(t, attempted, totalBooks/2,
+		"breaker must cancel remaining work — expected far fewer than %d attempts, got %d", totalBooks, attempted)
+	// Enough workers must have run to have actually crossed the threshold
+	// (otherwise the test would trivially pass on a broken/no-op breaker
+	// that just happens to run fewer than 50 items for some other reason).
+	require.GreaterOrEqual(t, attempted, enrichBreakerThreshold,
+		"expected at least enough attempts to trip the breaker, got %d", attempted)
+}
+
+// TestEnrichImportedBooks_BreakerResetsOnSuccess asserts the shared
+// aggregate failure counter resets on success rather than being a
+// cumulative lifetime tally — an alternating fail/succeed/fail/succeed
+// pattern (which never reaches enrichBreakerThreshold consecutively-ish)
+// must run to completion, same as the original consecutiveErrors design.
+func TestEnrichImportedBooks_BreakerResetsOnSuccess(t *testing.T) {
+	const totalBooks = 20
+
+	_, store := buildEnrichFixture(t, totalBooks)
+
+	var callN int32
+	fetcher := newFakeMetadataFetcher(func(string) bool {
+		// Fail every other call: 1 failure, 1 success, repeat. Never
+		// accumulates enrichBreakerThreshold(5) failures without an
+		// intervening reset, whether run sequentially or with the real
+		// worker pool (which serializes atomic increments/resets even
+		// though call ORDER across books is not guaranteed).
+		n := atomic.AddInt32(&callN, 1)
+		return n%2 == 1
+	})
+	// Force sequential so the fail/succeed/fail/succeed pattern is
+	// deterministic by call order (concurrent scheduling would make the
+	// exact interleaving non-deterministic, which isn't needed to prove
+	// the reset-on-success behavior).
+	imp := &Importer{store: store, mfs: fetcher, enrichConcurrencyOverride: 1}
+	status := &itunesImportStatus{}
+	log := logger.New("test-enrich-breaker-reset")
+
+	imp.enrichImportedBooks(context.Background(), status, log)
+
+	require.Equal(t, totalBooks, fetcher.callCount(),
+		"alternating fail/succeed must never trip the breaker (aggregate counter resets on success), all books attempted")
+}


### PR DESCRIPTION
Workstream **itunes-import** / TASK-02 (CONC-11) · ⚠ review-critical (circuit-breaker). Depends on TASK-01 (merged).

## What changed
- `internal/itunes/service/importer.go`: `enrichImportedBooks` (now takes `ctx`) parallelizes the per-book `FetchMetadataForBook` over `imported`-state books via `registry.RunItems`, `enrichConcurrency = 4` (fixed const — rate-limited external source), reusing TASK-01's `loggerReporterAdapter`.
- **Circuit-breaker reframe (the key call):** the old `consecutiveErrors` (pause-10s-and-resume at ≥5) has no race-free meaning across concurrent workers. Replaced with a shared `atomic.Int32 breakerFails` + `sync.Once breakerTripped`; on crossing `enrichBreakerThreshold = 5` exactly one worker logs and `cancel()`s a derived `enrichCtx` → RunItems stops launching new items (in-flight finish). **Documented semantic change: abort-remaining instead of pause-resume.** Dropped the redundant `%10==0 → sleep(2s)` soft throttle (the fixed Concurrency=4 is now the rate limiter); kept the `%10` log line.
- Added a narrow `metadataFetcher` interface for testability (`*metafetch.Service` satisfies it unmodified).
- `internal/itunes/service/importer_enrich_parallel_test.go` (new): 5 `-race` tests — parallel==serial, empty list, nil-mfs guard, breaker-cancels-remaining (re-run 20× under `-race`, no flakes), breaker-resets-on-success.

## Acceptance
- [x] Loop routes through `registry.RunItems`; breaker preserved as shared atomic + ctx-cancel
- [x] `go test -race ./internal/itunes/service/...` clean (`ok`)
- [x] `go build`/`go vet ./...` clean; headers bumped