### PR TITLE
fix(ci): bump ghcommon pin, revert test-only overrides on release pipeline

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.10.0
+# version: 2.10.1
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 # last-edited: 2026-07-05
 
@@ -28,21 +28,18 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a0b07902d63eb6d732290805181fb02da6ad4fbf # v2.14.0 (go-run-linters passthrough)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@e44a03f9da7de181d31fc05e173a3a1ddaeda941 # v2.14.1 (ghcommon repo-ref fix)
     with:
       release-type: 'auto'
       prerelease: true
       draft: false
       go-enabled: true
       frontend-enabled: true
-      docker-enabled: false
-      # TEMPORARY: docker-enabled: false doesn't actually skip Docker --
+      # NOTE: docker-enabled: false does not actually skip Docker --
       # reusable-release.yml treats false as "auto" (auto-detects the
-      # Dockerfile and builds anyway) -- this repo's prerelease builds have
-      # always built Docker images despite this flag. build-target is the
-      # real hard gate; restrict to 'go' while testing the tag-push
-      # ruleset fix, then revert to unset/'all' once confirmed working.
-      build-target: 'go'
+      # Dockerfile and builds anyway), so prerelease builds have always
+      # built Docker images despite this flag. Pre-existing, not fixed here.
+      docker-enabled: false
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.9.2
+# version: 4.9.3
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 # last-edited: 2026-07-05
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a0b07902d63eb6d732290805181fb02da6ad4fbf # v2.14.0 (go-run-linters passthrough)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@e44a03f9da7de181d31fc05e173a3a1ddaeda941 # v2.14.1 (ghcommon repo-ref fix)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false
@@ -51,12 +51,6 @@ jobs:
       go-enabled: true
       frontend-enabled: true
       docker-enabled: true
-      # TEMPORARY: docker-enabled: false doesn't actually skip Docker --
-      # reusable-release.yml treats false as "auto" (auto-detects the
-      # Dockerfile and builds anyway). build-target is the real hard gate;
-      # restrict to 'go' while testing the tag-push ruleset fix, then
-      # revert to unset/'all' once confirmed working end-to-end.
-      build-target: 'go'
       system-packages: 'libtag1-dev'
       pre-build-script: 'cd web && npm ci && npm run build'
       go-experiment: 'jsonv2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.110.0 -->
+<!-- version: 3.110.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-05 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 5, 2026 - fix(ci): unblock Production Release end-to-end (org ruleset + ghcommon repo-ref)
+
+- **`fix(ci)`** — the release pipeline was blocked by a chain of 4 issues,
+  now all resolved: (1) the `jdfalk-ci-bot` GitHub App was never
+  reinstalled on the `falkcorp` org after the June migration, causing
+  `create-github-app-token` to 404 on every release; (2) `gha-release-go`'s
+  lint step doesn't forward `GOEXPERIMENT`, so release-time `go vet` failed
+  on `jsonv2` imports CI had already vetted correctly — worked around via
+  `go-run-linters: false`; (3) an org ruleset added during the June 5
+  migration bundled `required_linear_history` onto all `v*` tag pushes,
+  which can never pass given this repo's pre-rebase-only history (old merge
+  commits like `95eaf063` are permanent ancestors of `main`) — confirmed via
+  3 independent tests that bypass_actors exemption doesn't work for
+  App-authenticated tag pushes, so the rule was removed org-wide rather than
+  chasing the bypass mechanism further; (4) `reusable-release.yml`'s
+  "Checkout ghcommon workflow scripts" step hardcoded the pre-migration
+  `jdfalk/ghcommon` repo path, 400'ing on every release's "Create GitHub
+  Release" job (`falkcorp/github-common#315`). Bumped the `reusable-release.yml`
+  pin to `e44a03f` (v2.14.1) in both `release-prod.yml` and `prerelease.yml`.
+  First clean end-to-end release verified: v0.217.1.
 
 #### July 5, 2026 - fix(dedup): make FullScan's unified-scoring pass respond promptly to op cancellation
 


### PR DESCRIPTION
## Summary
- Bumps the `reusable-release.yml` pin to `falkcorp/github-common@e44a03f` (v2.14.1, PR #315) in both `release-prod.yml` and `prerelease.yml` — fixes the hardcoded `jdfalk/ghcommon` repo-ref that 400'd on every "Create GitHub Release" job.
- Reverts the `build-target: 'go'` overrides from PR #1814 (test-only, used to speed up iteration while diagnosing the release pipeline). `release-prod.yml` now builds all components again.
- `prerelease.yml`'s pre-existing `docker-enabled: false` remains, still ineffective for the auto-detection reason noted inline — out of scope to fix here.

This is the final PR in today's release-pipeline debugging chain:
1. `jdfalk-ci-bot` App reinstalled on `falkcorp` org
2. `go-run-linters: false` workaround for missing `GOEXPERIMENT` in `gha-release-go`'s lint step
3. Org ruleset `required_linear_history` removed from `v*` tags (bypass_actors confirmed non-functional for App-authenticated pushes across 3 independent tests)
4. `falkcorp/github-common#315` — ghcommon repo-ref fix (this PR bumps to that pin)

First clean end-to-end release verified: **v0.217.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT