### PR TITLE
perf(dedup): parallelize FullScan Layer-1 checks, keep Layer-2 batching serial (CONC-4)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.49.0
+// version: 1.50.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -175,6 +175,21 @@ type Engine struct {
 	// Set via SetISBNIndexStore. When nil, checkExactISBN falls back to
 	// the GetAllBooks scan (safe — just slow).
 	isbnIndexStore ISBNIndexStore
+
+	// mergeMu serializes calls into mergeService.MergeBooks.
+	//
+	// CONC-4 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
+	// FullScan's Layer-1 pass now runs checkExactFileHash for every book
+	// concurrently via registry.RunItems. handleFileHashMatch can call
+	// MergeBooks when AutoMergeEnabled is set, and merge.Service.MergeBooks
+	// does an unguarded read-then-write per book (no transaction/lock) — two
+	// workers independently discovering the same "other" book via two
+	// different file hashes could race and corrupt the version group. In the
+	// old strictly-serial loop this could never happen because merges always
+	// completed in book order before the next book's check ran. mergeMu
+	// restores that "only one merge in flight at a time" guarantee without
+	// serializing the (far more common) non-merge path.
+	mergeMu sync.Mutex
 }
 
 // NewEngine creates a Engine with sensible defaults.
@@ -902,7 +917,14 @@ func (de *Engine) handleFileHashMatch(book, other *database.Book, authorName str
 	sameTitle := normalizeTitle(book.Title) == normalizeTitle(other.Title)
 
 	if sameAuthor && sameTitle && de.AutoMergeEnabled && de.mergeService != nil {
+		// Serialize the actual merge (see mergeMu doc comment on Engine) —
+		// MergeBooks itself does an unguarded read-modify-write per book, so
+		// two FullScan Layer-1 workers merging into the same "other" book at
+		// once could race. This does not serialize the (far more common)
+		// non-merge candidate path above/below.
+		de.mergeMu.Lock()
 		_, err := de.mergeService.MergeBooks([]string{book.ID, other.ID}, other.ID)
+		de.mergeMu.Unlock()
 		if err != nil {
 			return false, fmt.Errorf("auto-merge failed: %w", err)
 		}
@@ -2511,35 +2533,99 @@ func (de *Engine) FullScan(ctx context.Context, progress func(phase string, done
 		return err // return the EmbedBooks error for circuit-breaker accounting
 	}
 
+	// --- Pass 1: Layer 1 exact checks (parallel) ---
+	//
+	// CONC-4 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
+	// this used to be the first half of a single `for range books` loop
+	// shared with the Layer-2 embedding batching below. checkExactFileHash/
+	// checkExactISBN/checkExactTitle/checkDurationMatch are each
+	// self-contained per book (they read `books[i]` plus whatever the
+	// bookStore returns for OTHER books; they never touch loop-carried state
+	// from a previous iteration), so they shard cleanly across a bounded
+	// worker pool exactly like the unified-scoring pass at the bottom of
+	// this function (CONC-2). Two shared-write paths were checked before
+	// parallelizing:
+	//
+	//   - Every check funnels candidate writes through upsertExactCandidate
+	//     -> EmbeddingStore.UpsertCandidateNew, which canonicalises the pair
+	//     key and does the read-check-write under its own s.mu (see
+	//     internal/database/embedding_store.go) — concurrent upserts of the
+	//     same pair from two workers are safe and idempotent. Verified by
+	//     TestFullScanLayer1ParallelMatchesSerialCandidates below.
+	//   - checkExactFileHash -> handleFileHashMatch can call
+	//     mergeService.MergeBooks when AutoMergeEnabled is set. MergeBooks
+	//     itself is an unguarded read-modify-write per book, so it is now
+	//     serialized via de.mergeMu (see that field's doc comment) rather
+	//     than relying on loop order the way the old serial code implicitly
+	//     did.
+	//
+	// The bookStore/embedStore backend (PebbleStore) is itself safe for
+	// concurrent reads/writes — see the CONC-2 comment on the scoring pass
+	// below for details.
+	//
+	// Layer 2's chunk accumulation + circuit-breaker (chunkIDs, chunkStart,
+	// chunkIsPrimary, embedConsecutiveFails, embeddingsGaveUp, flushChunk)
+	// is loop-carried serial state and stays in the plain sequential Pass 2
+	// loop below — it must NOT be parallelized.
+	layer1Indices := make([]int, total)
+	for i := range layer1Indices {
+		layer1Indices[i] = i
+	}
+	// layer1Progress adapts FullScan's phase-prefixed progress(phase, done,
+	// total) callback to progressCallbackReporter's plain progress(done,
+	// total) shape (reused unchanged from BookSignatureScan/TASK-01), closing
+	// over the "scan" phase name so Layer 1 progress reports under the same
+	// phase the combined loop used to.
+	layer1Progress := func(done, progTotal int) {
+		if progress != nil {
+			progress("scan", done, progTotal)
+		}
+	}
+	err = registry.RunItems(ctx, &progressCallbackReporter{progress: layer1Progress}, layer1Indices,
+		func(_ context.Context, i int) error {
+			book := books[i]
+
+			// Resolve author name once — used by Layer 1 title/hash checks.
+			authorName := ""
+			if book.AuthorID != nil {
+				if author, err := de.bookStore.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
+					authorName = author.Name
+				}
+			}
+
+			// Layer 1 exact checks (file hash, ISBN/ASIN, near-identical
+			// title, duration match). Cheap and synchronous, no API calls.
+			if _, err := de.checkExactFileHash(&book, authorName); err != nil {
+				slog.Error("dedup full scan hash check error for", "book", book.ID, "err", err)
+			}
+			if err := de.checkExactISBN(&book); err != nil {
+				slog.Error("dedup full scan ISBN check error for", "book", book.ID, "err", err)
+			}
+			if err := de.checkExactTitle(&book, authorName); err != nil {
+				slog.Error("dedup full scan title check error for", "book", book.ID, "err", err)
+			}
+			if err := de.checkDurationMatch(&book); err != nil {
+				slog.Error("dedup full scan duration check error for", "book", book.ID, "err", err)
+			}
+			return nil
+		},
+		registry.RunItemsOptions{Concurrency: runtime.NumCPU()},
+	)
+	if err != nil {
+		return err
+	}
+
+	// --- Pass 2: Layer 2 embedding batch accumulation + flush (serial) ---
+	//
+	// chunkIDs/chunkStart/chunkIsPrimary/embedConsecutiveFails/
+	// embeddingsGaveUp are mutated across iterations by flushChunk, so this
+	// pass stays a plain sequential loop exactly as before — see the Pass 1
+	// comment above for why it cannot be sharded.
 	for i, book := range books {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-		}
-
-		// Resolve author name once — used by Layer 1 title check below.
-		authorName := ""
-		if book.AuthorID != nil {
-			if author, err := de.bookStore.GetAuthorByID(*book.AuthorID); err == nil && author != nil {
-				authorName = author.Name
-			}
-		}
-
-		// Layer 1 exact checks (file hash, ISBN/ASIN, near-identical title,
-		// duration match). Cheap and synchronous, no API calls — runs
-		// inline regardless of embed batching or the circuit-breaker state.
-		if _, err := de.checkExactFileHash(&book, authorName); err != nil {
-			slog.Error("dedup full scan hash check error for", "book", book.ID, "err", err)
-		}
-		if err := de.checkExactISBN(&book); err != nil {
-			slog.Error("dedup full scan ISBN check error for", "book", book.ID, "err", err)
-		}
-		if err := de.checkExactTitle(&book, authorName); err != nil {
-			slog.Error("dedup full scan title check error for", "book", book.ID, "err", err)
-		}
-		if err := de.checkDurationMatch(&book); err != nil {
-			slog.Error("dedup full scan duration check error for", "book", book.ID, "err", err)
 		}
 
 		// Layer 2 embedding: accumulate IDs and flush in batches to keep

--- a/internal/dedup/engine_fullscan_layer1_parallel_test.go
+++ b/internal/dedup/engine_fullscan_layer1_parallel_test.go
@@ -1,0 +1,302 @@
+// file: internal/dedup/engine_fullscan_layer1_parallel_test.go
+// version: 1.0.0
+// guid: c3d4e5f6-a7b8-49c0-8d1e-2f3a4b5c6d7e
+// last-edited: 2026-07-05
+
+// Regression tests for CONC-4: FullScan's main pass now splits into a
+// parallel Pass 1 (Layer-1 exact checks — checkExactFileHash/ISBN/Title/
+// duration — sharded via registry.RunItems) followed by the unchanged
+// serial Pass 2 (Layer-2 embedding batch accumulation + circuit breaker,
+// which has loop-carried state and must stay sequential).
+//
+// TestFullScanLayer1Parallel_SameCandidatesAsSerial proves the two-pass
+// FullScan produces the EXACT same candidate set as an independent serial
+// reference over a fixture where all four Layer-1 checks fire for every
+// pair simultaneously (shared ISBN, shared near-identical title, shared
+// duration, shared file hash) — i.e. many emitters racing to
+// upsertCandidateWithLiveLabel the SAME pair from different signals at
+// once. Run under -race to prove EmbeddingStore.UpsertCandidateNew's
+// internal locking makes concurrent upserts of the same pair safe and
+// idempotent, as documented on the Pass 1 comment in FullScan.
+//
+// TestFullScanLayer1AutoMergeConcurrent_NoRace exercises the
+// review-critical addition this task made: handleFileHashMatch can call
+// mergeService.MergeBooks when AutoMergeEnabled is set, and MergeBooks
+// itself does an unguarded read-modify-write per book with no internal
+// locking. The fixture wires many DISJOINT auto-merge pairs so the
+// expected end state is fully deterministic regardless of goroutine
+// scheduling; the test proves every pair merged exactly once, into the
+// correct winner, with no data race on the shared mock store — verifying
+// the mergeMu guard documented on the Engine struct.
+package dedup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fullScanLayer1FixtureBooks builds n books that all share one ISBN13, one
+// near-identical title, one duration, one author, and one file hash — so
+// checkExactFileHash, checkExactISBN, checkExactTitle, and checkDurationMatch
+// ALL fire for (most) pairs, exercising concurrent upserts of the SAME pair
+// key from multiple Layer-1 signals at once. Duration is set so
+// hasPlausibleAudio/hasKnownShortDuration don't suppress the pair, and
+// IsPrimaryVersion is left nil (isNonPrimaryVersion treats nil as primary)
+// so upsertExactCandidate's primary gate passes.
+func fullScanLayer1FixtureBooks(n int) []database.Book {
+	isbn := "9780000000099"
+	dur := 3600
+	authorID := 1
+	fileHash := "SHARED-HASH-1"
+	books := make([]database.Book, n)
+	for i := 0; i < n; i++ {
+		books[i] = database.Book{
+			ID:       fmt.Sprintf("L1-%03d", i),
+			Title:    "The Same Layer1 Book",
+			ISBN13:   &isbn,
+			Duration: &dur,
+			AuthorID: &authorID,
+			FileHash: &fileHash,
+		}
+	}
+	return books
+}
+
+// wireFullScanLayer1Mock points a MockStore's read paths at the given book
+// set. GetBookByFileHash always resolves to books[0] (mirrors a real
+// unique file-hash index having exactly one owner per hash value, so
+// checkExactFileHash forms a "star" of pairs against books[0] rather than a
+// fabricated full clique) — the ISBN/title/duration checks independently
+// scan all books via GetAllBooks/GetBooksByAuthorID and form the full
+// clique on their own, so the combined want-set is still deterministic.
+func wireFullScanLayer1Mock(mock *database.MockStore, books []database.Book) {
+	byID := make(map[string]database.Book, len(books))
+	for _, b := range books {
+		byID[b.ID] = b
+	}
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		out := make([]database.Book, len(books))
+		copy(out, books)
+		return out, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if b, ok := byID[id]; ok {
+			return &b, nil
+		}
+		return nil, nil
+	}
+	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
+		return &database.Author{ID: id, Name: "Layer1 Author"}, nil
+	}
+	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
+		out := make([]database.Book, len(books))
+		copy(out, books)
+		return out, nil
+	}
+	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) {
+		b := books[0]
+		return &b, nil
+	}
+}
+
+// TestFullScanLayer1Parallel_SameCandidatesAsSerial is the CONC-4 parity
+// test: FullScan's parallel Layer-1 pass (registry.RunItems, Concurrency ==
+// runtime.NumCPU()) followed by the serial Layer-2/scoring passes must
+// persist the exact same candidate set that the pre-parallelization plain
+// serial loop (runFullScanLayer1AndScoreSerially, unchanged from the CONC-2
+// test) produces for the identical input.
+func TestFullScanLayer1Parallel_SameCandidatesAsSerial(t *testing.T) {
+	// Sized well above a typical runtime.NumCPU() so the RunItems pool
+	// genuinely shards work across multiple goroutines.
+	const numBooks = 16
+
+	// --- Serial reference: independent engine/store, same fixture. ---
+	engineB, mockB, esB := setupTestEngine(t)
+	booksB := fullScanLayer1FixtureBooks(numBooks)
+	wireFullScanLayer1Mock(mockB, booksB)
+	runFullScanLayer1AndScoreSerially(t, engineB, booksB)
+
+	wantCands, _, err := esB.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("serial reference ListCandidates: %v", err)
+	}
+	want := canonicalizeScoredCandidates(t, wantCands)
+	if len(want) == 0 {
+		t.Fatalf("fixture is vacuous: expected >0 candidate pairs but got 0")
+	}
+	// ISBN/title/duration each independently scan every book and form a
+	// full clique; file-hash's star is a subset of that clique.
+	wantPairCount := numBooks * (numBooks - 1) / 2
+	if len(want) != wantPairCount {
+		t.Fatalf("serial reference produced %d pairs, want %d (C(%d,2)) — fixture assumptions drifted", len(want), wantPairCount, numBooks)
+	}
+
+	// --- Parallel: through the real (two-pass) FullScan entry point. ---
+	engineA, mockA, esA := setupTestEngine(t)
+	booksA := fullScanLayer1FixtureBooks(numBooks)
+	wireFullScanLayer1Mock(mockA, booksA)
+
+	if err := engineA.FullScan(context.Background(), nil); err != nil {
+		t.Fatalf("FullScan: %v", err)
+	}
+
+	gotCands, _, err := esA.ListCandidates(database.CandidateFilter{EntityType: "book", Status: "pending", Limit: 1_000_000})
+	if err != nil {
+		t.Fatalf("parallel ListCandidates: %v", err)
+	}
+	got := canonicalizeScoredCandidates(t, gotCands)
+
+	if len(got) != len(want) {
+		t.Fatalf("candidate count mismatch: parallel got %d, serial want %d", len(got), len(want))
+	}
+	for key, w := range want {
+		g, ok := got[key]
+		if !ok {
+			t.Fatalf("missing expected pair %s (lost update in parallel Layer-1 pass)", key)
+		}
+		if g != w {
+			t.Fatalf("pair %s mismatch: parallel=%+v serial=%+v", key, g, w)
+		}
+	}
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			t.Fatalf("unexpected pair %s (spurious emit in parallel Layer-1 pass)", key)
+		}
+	}
+}
+
+// mergeRaceStore is a small mutex-guarded book map standing in for the
+// GetBookByID/UpdateBook halves of database.Store, used by
+// TestFullScanLayer1AutoMergeConcurrent_NoRace so MergeBooks' read-modify-
+// write sequence has somewhere real to land. Guarded by mu because,
+// absent the mergeMu fix under test, concurrent Layer-1 workers could call
+// MergeBooks at the same time and race on these very maps.
+type mergeRaceStore struct {
+	mu    sync.Mutex
+	books map[string]*database.Book
+}
+
+func newMergeRaceStore(books []database.Book) *mergeRaceStore {
+	s := &mergeRaceStore{books: make(map[string]*database.Book, len(books))}
+	for i := range books {
+		b := books[i]
+		s.books[b.ID] = &b
+	}
+	return s
+}
+
+func (s *mergeRaceStore) get(id string) *database.Book {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.books[id]
+	if !ok || b == nil {
+		return nil
+	}
+	cp := *b
+	return &cp
+}
+
+func (s *mergeRaceStore) update(id string, b *database.Book) (*database.Book, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *b
+	s.books[id] = &cp
+	out := cp
+	return &out, nil
+}
+
+// TestFullScanLayer1AutoMergeConcurrent_NoRace exercises the mergeMu guard:
+// with AutoMergeEnabled, checkExactFileHash's handleFileHashMatch calls the
+// UNguarded merge.Service.MergeBooks, so FullScan's parallel Layer-1 pass
+// must serialize those calls or risk two workers racing on the same
+// underlying book rows. The fixture wires numPairs DISJOINT auto-merge
+// pairs (own file hash + own matching title, no cross-pair overlap), so the
+// end state is fully deterministic: run under -race, then assert every
+// pair merged exactly once into the expected winner.
+func TestFullScanLayer1AutoMergeConcurrent_NoRace(t *testing.T) {
+	const numPairs = 20 // > typical runtime.NumCPU(); many pairs contend for mergeMu at once
+
+	type pair struct{ loserID, winnerID, hash string }
+	pairs := make([]pair, numPairs)
+	var fixture []database.Book
+	hashToWinner := make(map[string]string, numPairs)
+	for p := 0; p < numPairs; p++ {
+		loserID := fmt.Sprintf("MA-%03d", p)
+		winnerID := fmt.Sprintf("MB-%03d", p)
+		hash := fmt.Sprintf("HASH-%03d", p)
+		title := fmt.Sprintf("Merge Book %03d", p)
+		pairs[p] = pair{loserID: loserID, winnerID: winnerID, hash: hash}
+		hashToWinner[hash] = winnerID
+		fixture = append(fixture,
+			database.Book{ID: loserID, Title: title, FileHash: &hash},
+			database.Book{ID: winnerID, Title: title, FileHash: &hash},
+		)
+	}
+
+	rs := newMergeRaceStore(fixture)
+
+	engine, mock, _ := setupTestEngine(t)
+	engine.AutoMergeEnabled = true
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		out := make([]database.Book, len(fixture))
+		copy(out, fixture)
+		return out, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return rs.get(id), nil
+	}
+	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
+		return rs.update(id, book)
+	}
+	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) {
+		winnerID, ok := hashToWinner[hash]
+		if !ok {
+			return nil, nil
+		}
+		return rs.get(winnerID), nil
+	}
+	// No ISBN/AuthorID set on the fixture books, so checkExactISBN,
+	// checkExactTitle, and checkDurationMatch are all no-ops here — this
+	// test isolates the checkExactFileHash -> handleFileHashMatch ->
+	// MergeBooks path specifically.
+
+	if err := engine.FullScan(context.Background(), nil); err != nil {
+		t.Fatalf("FullScan: %v", err)
+	}
+
+	seenGroups := make(map[string]bool, numPairs)
+	for _, pr := range pairs {
+		loser := rs.get(pr.loserID)
+		winner := rs.get(pr.winnerID)
+		if loser == nil || winner == nil {
+			t.Fatalf("pair %s/%s: book missing from store after merge", pr.loserID, pr.winnerID)
+		}
+		if loser.MarkedForDeletion == nil || !*loser.MarkedForDeletion {
+			t.Fatalf("pair %s/%s: loser %s was not soft-deleted (merge did not run, or ran on the wrong side)", pr.loserID, pr.winnerID, pr.loserID)
+		}
+		if winner.MarkedForDeletion != nil && *winner.MarkedForDeletion {
+			t.Fatalf("pair %s/%s: winner %s was unexpectedly soft-deleted", pr.loserID, pr.winnerID, pr.winnerID)
+		}
+		if winner.IsPrimaryVersion == nil || !*winner.IsPrimaryVersion {
+			t.Fatalf("pair %s/%s: winner %s is not marked IsPrimaryVersion", pr.loserID, pr.winnerID, pr.winnerID)
+		}
+		if loser.VersionGroupID == nil || winner.VersionGroupID == nil || *loser.VersionGroupID == "" {
+			t.Fatalf("pair %s/%s: version group not set on both sides", pr.loserID, pr.winnerID)
+		}
+		if *loser.VersionGroupID != *winner.VersionGroupID {
+			t.Fatalf("pair %s/%s: version group mismatch loser=%s winner=%s", pr.loserID, pr.winnerID, *loser.VersionGroupID, *winner.VersionGroupID)
+		}
+		if seenGroups[*winner.VersionGroupID] {
+			t.Fatalf("version group %s reused across pairs — cross-pair contamination", *winner.VersionGroupID)
+		}
+		seenGroups[*winner.VersionGroupID] = true
+	}
+	if len(seenGroups) != numPairs {
+		t.Fatalf("got %d distinct version groups, want %d", len(seenGroups), numPairs)
+	}
+}


### PR DESCRIPTION
Workstream **dedup-engine** / TASK-04 (CONC-4) · ⚠ review-critical · the final engine.go task.

## Two-pass split
- **Pass 1 (parallel):** the four Layer-1 exact checks (`checkExactFileHash`/`checkExactISBN`/`checkExactTitle`/`checkDurationMatch` + author-resolve) now run over a book-index slice via `registry.RunItems` (Concurrency=NumCPU), reusing `progressCallbackReporter` via a `progress("scan", …)` closure.
- **Pass 2 (serial, unchanged):** the Layer-2 embedding batching (`chunkIDs`/`chunkStart`/`chunkIsPrimary`/`embedConsecutiveFails`/`embeddingsGaveUp`/`flushChunk`) — loop-carried serial state, byte-for-byte the same, including the ctx-cancel check.

## Concurrency-safety (the review-critical part — a real latent race, found + fixed)
- `upsertExactCandidate → UpsertCandidateNew` canonicalizes the pair key and read-checks-writes under its own `s.mu` → concurrent same-pair upserts safe & idempotent (verified; test fires all 4 Layer-1 signals on every pair at once).
- **`checkExactFileHash → handleFileHashMatch → mergeService.MergeBooks` was NOT concurrency-safe** — `MergeBooks` does an unguarded per-book read-modify-write that was only safe because the serial loop merged in order. **Fixed** with a new `Engine.mergeMu sync.Mutex` wrapping *only* the `MergeBooks` call (rare) — serializes merges without serializing the common non-merge candidate path.
- `EnsureSingletonBookTag`: unguarded read-then-write, but `prefix==fullTag` for all callers here → a race is at worst a redundant identical write; left unguarded as a documented low-risk tradeoff.

## Tests (new, `-race`, 3× no flakes)
- `TestFullScanLayer1Parallel_SameCandidatesAsSerial` — 16-book fixture, all signals firing on the same pairs; two-pass `FullScan()` output == serial reference (120 pairs).
- `TestFullScanLayer1AutoMergeConcurrent_NoRace` — 20 disjoint auto-merge pairs through real parallel `FullScan()`; each merges exactly once into the correct winner (exercises `mergeMu`).

## Acceptance
- [x] Layer-1 routes through `registry.RunItems`; Layer-2 stays serial
- [x] `go test -race ./internal/dedup/...` clean (28s); real merge race guarded
- [x] `go build`/`go vet ./...` clean; header bumped