### PR TITLE
fix(server): restore startup AcoustID fingerprint backfill via the parallel op (CONC-9 follow-up)

### DIFF
--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.42.0
+// version: 1.43.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-07-05
 
@@ -904,11 +904,26 @@ func (s *Server) startBackfills() {
 		s.backfillExternalIDs()
 	}()
 
-	// AcoustID fingerprint backfill is handled by the parallel plugin op
+	// AcoustID fingerprint backfill. CONC-9 removed the serial server-side
+	// duplicate (backfillAcoustIDs) in favor of the parallel plugin op
 	// acoustid.backfill (internal/plugins/acoustid/backfill.go, registry.RunItems
-	// with bounded Concurrency), a child of the library.optimize maintenance
-	// sweep. The serial server-side duplicate (backfillAcoustIDs) was removed in
-	// CONC-9; it fingerprinted one file at a time with an explicit per-item sleep.
+	// with bounded Concurrency). That deletion left startup no longer
+	// auto-fingerprinting — coverage only advanced when an operator ran the
+	// on-demand library.optimize sweep. Restore the original boot behavior by
+	// enqueuing the parallel op once at startup. It is idempotent (skips files
+	// that already have a fingerprint) and runs in the registry's own worker
+	// pool, so this is fire-and-forget — no bgWG enrollment (the op's lifecycle
+	// is owned by opRegistry, not the backfill WaitGroup).
+	go func() {
+		if err := s.bgCtx.Err(); err != nil {
+			return
+		}
+		if _, err := s.opRegistry.EnqueueOp(s.bgCtx, "acoustid.backfill", nil); err != nil {
+			slog.Warn("startup acoustid.backfill enqueue failed", "err", err)
+		} else {
+			slog.Info("startup: enqueued acoustid.backfill fingerprint op")
+		}
+	}()
 
 	// PERF-VERSIONS: write the book:versiongroup:<gid>:<id> secondary
 	// index for every existing book once so /audiobooks/:id/versions


### PR DESCRIPTION
Follow-up to **CONC-9** (which deleted the serial `backfillAcoustIDs` that ran on every startup).

## Problem
CONC-9's replacement — the parallel `acoustid.backfill` plugin op — was only a child of the **on-demand** `library.optimize` sweep. Net effect: **server startup no longer auto-fingerprints**, so AcoustID fingerprint coverage stalls until an operator manually runs optimize.

## Fix
`startBackfills()` now enqueues the parallel `acoustid.backfill` op once at boot via `s.opRegistry.EnqueueOp(s.bgCtx, "acoustid.backfill", nil)` — restoring the original startup behavior but using the bounded-concurrency parallel op instead of the deleted serial loop. Idempotent (skips already-fingerprinted files); fire-and-forget (lifecycle owned by the op registry, not `bgWG`).

## Verification
- `go build ./...` + `go vet ./internal/server/...` clean.
- `go test ./internal/server/ -run 'Backfill|Lifecycle'` → ok.