### PR TITLE
docs(plan): store-getter fidelity unification — spec + plan (STOREFID, planning only)

### DIFF
--- a/docs/agent-tasks/store-fidelity/P1-T1-unexport-pebble-twins.md
+++ b/docs/agent-tasks/store-fidelity/P1-T1-unexport-pebble-twins.md
@@ -1,0 +1,57 @@
+<!-- file: docs/agent-tasks/store-fidelity/P1-T1-unexport-pebble-twins.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a66fa6cd-34fb-4f2c-86e9-02e1d74c870f -->
+<!-- last-edited: 2026-07-05 -->
+
+# P1-T1 — Unexport the zero-caller `_Pebble` full-fallback twins
+
+**Tier:** Haiku · **Depends on:** none · **Risk:** near-zero (0 external callers)
+
+## ⛔ START HERE
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/storefid-p1t1" -b agent/storefid-p1t1 origin/main
+cd "$REPO/.worktrees/storefid-p1t1"
+```
+
+## Goal
+Three exported `..._Pebble` methods are the `UseMemDB=false` full-fidelity fallbacks called
+ONLY by their own slim wrappers — they have **zero external callers**. Unexport them (lowercase
+first letter) so they stop polluting the public `Store` surface with a misleading name. Do NOT
+change behavior.
+
+Targets (re-verify each has 0 callers outside its wrapper before editing):
+```bash
+grep -rn "GetBooksByAuthorID_Pebble\|GetBooksBySeriesID_Pebble\|GetAllBookSummaries_Pebble" --include='*.go' . | grep -v "_test.go"
+# expect: only the definition + the call from its own slim wrapper (GetBooksByAuthorID, etc.)
+```
+
+## Steps
+1. For each of `GetBooksByAuthorID_Pebble`, `GetBooksBySeriesID_Pebble`, `GetAllBookSummaries_Pebble`:
+   rename to unexported `getBooksByAuthorIDFull` / `getBooksBySeriesIDFull` / `getAllBookSummariesFull`
+   (camelCase, `Full` suffix — matches the spec's naming). Update the single internal caller (the
+   slim wrapper's `return p.<name>(...)`).
+2. If any is declared on the `Store` interface (`internal/database/store.go`), remove it from the
+   interface (it's an impl detail now). Check: `grep -n "_Pebble" internal/database/store.go`.
+3. If removed from the interface, regenerate the MockStore mock **scoped only**:
+   `mockery --name Store --dir internal/database` (verify the diff drops only these 3 methods; do
+   NOT commit an unscoped repo-wide mock regen). If they were never on the interface, no mock change.
+4. Bump version headers on every changed file (`last-edited: 2026-07-05`).
+
+## Gate
+```bash
+go build ./... && go vet ./internal/database/ && go test -race ./internal/database/ -count=1
+```
+
+## Acceptance
+- [ ] `grep -rn "_Pebble" --include='*.go' internal/database/` → 0 (or only unrelated names).
+- [ ] the three methods are unexported; their single callers updated; behavior unchanged.
+- [ ] `go build ./...` clean; mock diff (if any) scoped to these 3 methods only.
+- [ ] headers bumped.
+
+## Commit
+```
+refactor(store): unexport the zero-caller _Pebble full-fallback twins (STOREFID P1-T1)
+```
+## Done — STOP; coordinator owns push/PR/merge.

--- a/docs/agent-tasks/store-fidelity/P1-T2-rename-getallbooksfrom.md
+++ b/docs/agent-tasks/store-fidelity/P1-T2-rename-getallbooksfrom.md
@@ -1,0 +1,51 @@
+<!-- file: docs/agent-tasks/store-fidelity/P1-T2-rename-getallbooksfrom.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d18b61ce-6b40-46c5-87bd-9c6869d6ae94 -->
+<!-- last-edited: 2026-07-05 -->
+
+# P1-T2 — Rename `GetAllBooksFrom` → `GetAllBooksFullFrom`
+
+**Tier:** Haiku · **Depends on:** none · **Risk:** low (2 callers)
+
+## ⛔ START HERE
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/storefid-p1t2" -b agent/storefid-p1t2 origin/main
+cd "$REPO/.worktrees/storefid-p1t2"
+```
+
+## Goal
+`GetAllBooksFrom` returns FULL rows (it takes the memdb branch but re-hydrates each book via
+`GetBookByID`), yet its name collides conceptually with the SLIM `GetAllBooks`. Rename it to
+`GetAllBooksFullFrom` so the fidelity is explicit. Pure rename — behavior unchanged.
+
+Re-verify sites before editing:
+```bash
+grep -rn "GetAllBooksFrom" --include='*.go' .   # interface (store.go) + PebbleStore def + MemStore? + ~2 prod + ~2 test callers
+```
+Known caller: `internal/dedup/engine.go` `getAllPrimaryBooksWithFullFields` (from PR #1830).
+
+## Steps
+1. Rename the method on the `Store` interface (`internal/database/store.go`), `PebbleStore`
+   (`pebble_store.go`), and any other impl (MemStore/MockStore) that declares it.
+2. Update all callers (`grep` list above) to `GetAllBooksFullFrom`.
+3. Regenerate the Store mock **scoped only** (`mockery --name Store --dir internal/database`);
+   verify the diff renames just this one method.
+4. Bump version headers on every changed file.
+
+## Gate
+```bash
+go build ./... && go vet ./internal/... && go test -race ./internal/database/ ./internal/dedup/ -count=1
+```
+
+## Acceptance
+- [ ] `grep -rn "GetAllBooksFrom\b" --include='*.go' .` → 0 (all now `GetAllBooksFullFrom`).
+- [ ] behavior unchanged; `go build ./...` clean; mock diff scoped to the one rename.
+- [ ] headers bumped.
+
+## Commit
+```
+refactor(store): rename GetAllBooksFrom -> GetAllBooksFullFrom for explicit fidelity (STOREFID P1-T2)
+```
+## Done — STOP; coordinator owns push/PR/merge.

--- a/docs/agent-tasks/store-fidelity/P1-T3-doc-contract-slim-getters.md
+++ b/docs/agent-tasks/store-fidelity/P1-T3-doc-contract-slim-getters.md
@@ -1,0 +1,55 @@
+<!-- file: docs/agent-tasks/store-fidelity/P1-T3-doc-contract-slim-getters.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4c1417d3-bb83-4af6-964d-41f06ffd2345 -->
+<!-- last-edited: 2026-07-05 -->
+
+# P1-T3 — Doc-contract the 9 slim (memdb-projection) getters
+
+**Tier:** Haiku · **Depends on:** none · **Risk:** none (comments only)
+
+## ⛔ START HERE
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/storefid-p1t3" -b agent/storefid-p1t3 origin/main
+cd "$REPO/.worktrees/storefid-p1t3"
+```
+
+## Goal
+Until the typed `BookCore` migration lands (Phase 3), make the fidelity trap visible in docs.
+Add a doc comment to each of the 9 SLIM getters naming the stripped fields + the full-fetch
+escape hatch. **Comments only — no code changes.** (This is a stopgap; the type is the real fix.)
+
+The 9 slim getters (each delegates to `p.mem()` in `PebbleStore`):
+`GetAllBooks`, `GetBooksBySeriesID`, `GetAllBookFiles`, `GetBooksByAuthorID`,
+`GetBooksByAuthorIDWithRole`, `GetBookFilesForIDs`, `GetBookFilesNeedingDelugeImport`,
+`GetDuplicateBooksByMetadata`, `GetFolderDuplicates`.
+
+Stripped fields to cite — Book: `Description, VersionNotes, BookSigV1, BookSigV1Mask,
+BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series`. BookFile:
+`FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint, AcoustIDSeg0..6`
+(kept: `FingerprintFailedAt`, `AcoustIDFingerprintDurationSec`).
+
+## Steps
+1. Above each of the 9 getter definitions on `PebbleStore`, add:
+   `// SLIM (memdb projection): returns rows with heavy fields nil'd — <the relevant stripped`
+   `// list>. A caller that needs any of those MUST fetch via GetBookByID / GetBookFiles(bookID)`
+   `// / GetAllBooksFullFrom (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.`
+   (Use the Book list for book getters, the BookFile list for file getters.)
+2. Also add a one-line pointer on the `Store` interface declaration of each.
+3. Bump version headers on every changed file.
+
+## Gate
+```bash
+go build ./... && go vet ./internal/database/
+```
+
+## Acceptance
+- [ ] all 9 getters carry the stripped-field doc comment; interface decls point to the spec.
+- [ ] no behavioral/signature change (`git diff` is comments + headers only).
+
+## Commit
+```
+docs(store): document the stripped fields on the 9 memdb-slim getters (STOREFID P1-T3)
+```
+## Done — STOP; coordinator owns push/PR/merge.

--- a/docs/agent-tasks/store-fidelity/P2-T1-bookcore-type.md
+++ b/docs/agent-tasks/store-fidelity/P2-T1-bookcore-type.md
@@ -1,0 +1,62 @@
+<!-- file: docs/agent-tasks/store-fidelity/P2-T1-bookcore-type.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 42b1abf4-b3eb-4765-ac56-070e4dd5dc39 -->
+<!-- last-edited: 2026-07-05 -->
+
+# P2-T1 — Introduce `BookCore` + `Book.Core()` (additive)
+
+**Tier:** Opus · **Depends on:** none · **Risk:** low (purely additive; no getter changes)
+
+## ⛔ START HERE
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/storefid-p2t1" -b agent/storefid-p2t1 origin/main
+cd "$REPO/.worktrees/storefid-p2t1"
+```
+
+## Goal
+Add the compiler-enforced slim type `BookCore` (the fields that SURVIVE the memdb strip) plus a
+`Book.Core()` projection. **Purely additive** — nothing returns `BookCore` yet (that's Phase 3),
+so this task cannot break callers and stays trivially green. Getting the field partition exactly
+right is the whole job; two tests lock it.
+
+## The partition (authoritative)
+`BookCore` = every `Book` field EXCEPT these 9 heavy fields, which stay ONLY on `Book`:
+`Description, VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+BookSigCoveragePct, Author, Series`.
+Enumerate the live `Book` fields first — do not hand-transcribe from memory:
+```bash
+awk '/^type Book struct/{f=1} f{print} f&&/^}/{exit}' internal/database/store.go
+grep -n "cp\.\w* = nil" internal/database/memdb_strip.go   # the strip = the heavy set; must match the 9 above
+```
+
+## Steps
+1. In `internal/database/` define `type BookCore struct { … }` containing every `Book` field
+   except the 9 heavy ones, **with the same `json:"…"` struct tags** copied verbatim from `Book`.
+2. Add `func (b *Book) Core() BookCore { return BookCore{ …copy every BookCore field… } }`.
+3. Add two tests (`internal/database/bookcore_test.go`):
+   - `TestBookCoreIsBookMinusHeavyFields` (reflection): `fieldNames(Book) − fieldNames(BookCore)`
+     equals exactly the 9 heavy names.
+   - `TestBookCoreCopiesAllFields` (reflection): set EVERY `Book` field to a non-zero value, call
+     `Core()`, assert every `BookCore` field equals its `Book` counterpart (catches a `Core()`
+     that forgets to copy a field — a silent-drop bug hiding in the fix). Iterate fields
+     reflectively so new fields are covered automatically.
+4. Do NOT change any getter or the `Store` interface. Bump the header on `store.go` (or wherever
+   `BookCore` lands).
+
+## Gate
+```bash
+go build ./... && go vet ./internal/database/ && go test -race ./internal/database/ -run 'BookCore' -count=1 && go test ./internal/database/ -count=1
+```
+
+## Acceptance
+- [ ] `BookCore` = Book minus exactly the 9 heavy fields; json tags carried over.
+- [ ] `Book.Core()` copies every `BookCore` field; both reflection tests pass.
+- [ ] no getter/interface/mock change (`git diff` adds only the type + method + test + header).
+
+## Commit
+```
+feat(store): add BookCore projection type + Book.Core() with parity+copy tests (STOREFID P2-T1)
+```
+## Done — STOP; coordinator owns push/PR/merge.

--- a/docs/agent-tasks/store-fidelity/P2-T2-bookfilecore-type.md
+++ b/docs/agent-tasks/store-fidelity/P2-T2-bookfilecore-type.md
@@ -1,0 +1,59 @@
+<!-- file: docs/agent-tasks/store-fidelity/P2-T2-bookfilecore-type.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 46664a8a-bcf4-423f-8e2e-f3a508081350 -->
+<!-- last-edited: 2026-07-05 -->
+
+# P2-T2 — Introduce `BookFileCore` + `BookFile.Core()` (additive)
+
+**Tier:** Opus · **Depends on:** none · **Risk:** low (purely additive)
+
+## ⛔ START HERE
+```bash
+REPO=/Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git -C "$REPO" fetch origin
+git -C "$REPO" worktree add "$REPO/.worktrees/storefid-p2t2" -b agent/storefid-p2t2 origin/main
+cd "$REPO/.worktrees/storefid-p2t2"
+```
+(Independent of P2-T1 — different type; safe to run in parallel. If both edit `store.go`, the
+coordinator sibling-rebases.)
+
+## Goal
+Add `BookFileCore` (fields surviving the memdb strip) + `BookFile.Core()`. Purely additive.
+
+## The partition (authoritative)
+`BookFileCore` = every `BookFile` field EXCEPT the heavy set stripped by `stripBookFileForMemdb`:
+`FingerprintFailureReason, FingerprintFailureDetail, FingerprintDiagnosticJSON,
+AcoustIDFingerprint, AcoustIDSeg0, AcoustIDSeg1, AcoustIDSeg2, AcoustIDSeg3, AcoustIDSeg4,
+AcoustIDSeg5, AcoustIDSeg6`.
+**KEEP on Core (NOT stripped — verify in memdb_strip.go):** `FingerprintFailedAt`,
+`AcoustIDFingerprintDurationSec`.
+Enumerate first:
+```bash
+awk '/^type BookFile struct/{f=1} f{print} f&&/^}/{exit}' internal/database/store.go
+sed -n '/func stripBookFileForMemdb/,/^}/p' internal/database/memdb_strip.go | grep "= nil"
+```
+
+## Steps
+1. Define `type BookFileCore struct { … }` = `BookFile` minus the stripped set, json tags carried.
+2. Add `func (f *BookFile) Core() BookFileCore { … }` copying every `BookFileCore` field.
+3. Two reflection tests (`internal/database/bookfilecore_test.go`):
+   `TestBookFileCoreIsBookFileMinusHeavyFields` (name-set diff == the stripped set) and
+   `TestBookFileCoreCopiesAllFields` (populate-all → `Core()` → every field copied).
+4. No getter/interface/mock change. Bump header.
+
+## Gate
+```bash
+go build ./... && go vet ./internal/database/ && go test -race ./internal/database/ -run 'BookFileCore' -count=1 && go test ./internal/database/ -count=1
+```
+
+## Acceptance
+- [ ] `BookFileCore` = BookFile minus exactly the stripped set (FingerprintFailedAt +
+  AcoustIDFingerprintDurationSec RETAINED); json tags carried.
+- [ ] `BookFile.Core()` copies every field; both reflection tests pass.
+- [ ] additive only (`git diff` = type + method + test + header).
+
+## Commit
+```
+feat(store): add BookFileCore projection type + BookFile.Core() with parity+copy tests (STOREFID P2-T2)
+```
+## Done — STOP; coordinator owns push/PR/merge.

--- a/docs/agent-tasks/store-fidelity/README.md
+++ b/docs/agent-tasks/store-fidelity/README.md
@@ -1,0 +1,47 @@
+<!-- file: docs/agent-tasks/store-fidelity/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8570de43-ebd1-4468-8c24-135ec1fa9a61 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Workstream — store-getter fidelity unification (STOREFID)
+
+Executes [`docs/specs/2026-07-05-store-getter-fidelity-unification.md`](../../specs/2026-07-05-store-getter-fidelity-unification.md)
+per [`docs/plans/2026-07-05-store-getter-fidelity-unification.md`](../../plans/2026-07-05-store-getter-fidelity-unification.md).
+
+Goal: make Full vs Core (memdb-slim) fidelity **explicit and compiler-enforced** so the
+`BookSignatureScan`-class silent no-op (a Core row read where Full was needed) becomes a
+compile error. Root cause + full rename table + type design: the spec.
+
+## Ground rules
+- Reuse the spec's locked names/types exactly — do NOT invent alternative names.
+- Store getters live on the `database.Store` interface + `PebbleStore` + `MemStore` +
+  `MockStore` + **mockery-generated mocks**. **Regenerate mocks SCOPED to the changed
+  interface only** (local mockery v3.7.1 vs pinned v2.53.6 — an unscoped regen rewrites every
+  mock repo-wide). Hand-verify the mock diff.
+- Local gate: `go build ./... && go vet ./<pkg> && go test -race ./<pkg>`. Authoritative gate:
+  GitHub **Minimal CI** (NOT local `make ci` — its staticcheck is red on main from backlog).
+- Worktree per task; version headers mandatory; coordinator owns git/gh.
+
+## Waves
+
+| Wave | Task | What | Tier | Depends |
+|---|---|---|---|---|
+| **Phase 1** (cleanup, parallel) | P1-T1 | unexport the 0-caller `_Pebble` twins | Haiku | — |
+| | P1-T2 | `GetAllBooksFrom` → `GetAllBooksFullFrom` | Haiku | — |
+| | P1-T3 | doc-contract the 9 slim getters (stripped-field list) | Haiku | — |
+| **Phase 2** (types, parallel w/ P1) | P2-T1 | `BookCore` + `Book.Core()` + parity & copy-completeness tests | Opus | — |
+| | P2-T2 | `BookFileCore` + `BookFile.Core()` + same tests | Opus | — |
+| **⛔ HARD CHECKPOINT** | — | STOP; re-evaluate appetite + option (B) projection vs (C) memdb-native before Phase 3 | — | P1,P2 merged |
+| **Phase 3** (per-getter, SERIALIZED, ascending) | P3-W1..W6 | migrate each slim getter → `…Core`/`[]BookCore`, fix callers | Sonnet/Haiku | Phase 2 |
+| **Phase 4** | P4-T1 | naming lint (no exported getter returns Book while delegating to mem()) | Sonnet | Phase 3 |
+
+Phase-3 wave order (ascending call count so the pattern proves small first): W1
+`GetBookFilesForIDs` (4) → W2 `GetBooksByAuthorID[WithRole]` (9) → W3 `GetAllBookFiles` (18)
+→ W4 `GetBooksBySeriesID` (22) → W5 `GetAllBooks` (79) → W6 the three ≤2-caller getters.
+**Phase 3 briefs are generated after the checkpoint** — they depend on the (B)-vs-(C) decision.
+
+## Orchestration
+Phase 1 (3 tasks) and Phase 2 (2 tasks) touch mostly disjoint files and run in one parallel
+wave; only `store.go` is shared (P1-T2 renames one interface line; P2 adds new type decls —
+different regions, sibling-rebase resolves). After all 5 merge → the hard checkpoint. Phase 3
+waves SERIALIZE (shared `Store` interface + mock file). See the plan's dependency graph.

--- a/docs/plans/2026-07-05-store-getter-fidelity-unification.md
+++ b/docs/plans/2026-07-05-store-getter-fidelity-unification.md
@@ -1,0 +1,132 @@
+<!-- file: docs/plans/2026-07-05-store-getter-fidelity-unification.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0d615a3c-953e-4df7-8682-6899af0a9b25 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Implementation Plan — Store getter fidelity unification (STOREFID)
+
+Companion to [`docs/specs/2026-07-05-store-getter-fidelity-unification.md`](../specs/2026-07-05-store-getter-fidelity-unification.md).
+**Plan only — no code changes until GATE-2 approval of the spec.** Per-task weak-model-proof
+briefs are generated *after* approval (they depend on the locked naming/type decisions).
+
+## Choke points & cross-cutting rules
+
+- Every getter is declared on the `database.Store` interface and implemented in **four**
+  places: `PebbleStore`, `MemStore`, `MockStore`, and **mockery-generated mocks**. Every
+  rename touches all four.
+- **Mockery gotcha (hard rule for every brief):** local mockery is v3.7.1 vs the repo's pinned
+  v2.53.6 — regenerate mocks **scoped to the changed interface only**, never repo-wide, and
+  hand-verify the diff. An unscoped regen rewrites every mock in the repo.
+- **Gate:** GitHub **Minimal CI** (`ci.yml`) is the authoritative per-PR gate — NOT local
+  `make ci` (its `staticcheck` step is red on `main` from a pre-existing backlog). Local gate =
+  `go build ./... && go vet ./<pkg> && go test -race ./<pkg>`.
+- Worktree per wave; version headers mandatory; rebase/FF merges; coordinator owns all git/gh.
+
+## Phases & waves
+
+Ordered so each is independently shippable and green. Sizes are the getter's non-test / test
+call counts (the migration weight).
+
+### Phase 1 — Cleanup (no type change, near-zero risk)
+- **P1-T1 · unexport the dead `_Pebble` twins.** `GetBooksByAuthorID_Pebble`,
+  `GetBooksBySeriesID_Pebble`, `GetAllBookSummaries_Pebble` — **0 external callers**. Unexport
+  to `get…Full` (or inline into their wrappers). Removes 3 misleading public names. *(Haiku.)*
+- **P1-T2 · rename the mis-named full getter.** `GetAllBooksFrom` → `GetAllBooksFullFrom`
+  (2 callers, incl. `Engine.getAllPrimaryBooksWithFullFields`). *(Haiku.)*
+- **P1-T3 · doc-contract the 9 slim getters.** Add a doc comment to each listing the exact
+  stripped fields + "route through the Full variant / GetBookByID if you need them." Pure
+  comments. *(Haiku.)*
+
+### Phase 2 — Types foundation (additive, trivially green)
+- **P2-T1 · introduce `BookCore` + `Book.Core()` + TWO tests:** (1) field-name parity
+  (`fields(Book) − fields(BookCore) == the 9 heavy names`); (2) **copy-completeness reflection
+  test** (`TestBookCoreCopiesAllFields`: populate every `Book` field non-zero, call `Core()`,
+  assert every `BookCore` field is copied) — this one guards against a `Core()` that forgets a
+  field, which parity alone misses. Purely additive — nothing returns `BookCore` yet. *(Opus —
+  get the field partition exactly right; both tests lock it.)*
+- **P2-T2 · introduce `BookFileCore` + `BookFile.Core()` + the same two tests** (heavy set:
+  `FingerprintFailure*`, `AcoustIDFingerprint`, `AcoustIDSeg0..6`; keep `FingerprintFailedAt`,
+  `AcoustIDFingerprintDurationSec`). *(Opus.)*
+
+> **HARD CHECKPOINT after Phase 2 — STOP and re-evaluate before Phase 3.** Phases 1–2 are
+> independently green and near-zero-risk, and together with the P4 lint + doc contracts they
+> capture most of the *bug-prevention* value. Phase 3 is where cost and merge risk concentrate:
+> 6 waves that all serialize on the shared `Store` interface + mock file (the `engine.go`-chain
+> pattern, 6 deep), culminating in the 79-caller `GetAllBooks` wave. Do not run the tail on
+> autopilot — reassess appetite (and whether option 4(C) should replace per-read projection)
+> at this checkpoint.
+
+### Phase 3 — Per-getter migration (wave-batched ascending by call count)
+Each wave: rename getter → `…Core` on the interface + PebbleStore + MemStore + MockStore,
+change return type to `[]…Core`, regen the mock scoped, then **fix that getter's callers**.
+Ascending order proves the pattern on 4-caller getters before the 79-caller one.
+
+| Wave | Getter → new | callers | tier |
+|---|---|---|---|
+| P3-W1 | `GetBookFilesForIDs` → `…Core` (`map[string][]BookFileCore`) | 4 | Sonnet |
+| P3-W2 | `GetBooksByAuthorID[WithRole]` → `…Core` | 9 | Sonnet |
+| P3-W3 | `GetAllBookFiles` → `…Core` | 18 | Sonnet |
+| P3-W4 | `GetBooksBySeriesID` → `…Core` | 22 | Sonnet |
+| P3-W5 | `GetAllBooks` → `GetAllBooksCore` | **79** | Sonnet (⚠ largest; may split by package) |
+| P3-W6 | `GetDuplicateBooksByMetadata`, `GetFolderDuplicates`, `GetBookFilesNeedingDelugeImport` → `…Core` | 1+2+n | Haiku |
+
+### Phase 4 — Regression guard
+- **P4-T1 · naming lint.** CI test asserting: no exported `Store` getter returns `Book`/`[]Book`/
+  `BookFile` while its `PebbleStore` body delegates to `p.mem()`; no new exported `_Pebble`
+  method. *(Sonnet.)*
+
+## Mechanical vs judgment (the real review work)
+
+- **Mechanical (compiler-driven):** the renames and, at each call site, swapping `Book`→`BookCore`
+  in the type. `go build` enumerates every site; most are one-token changes.
+- **Judgment (⚠ where latent bugs hide):** at each migrated call site, ask *does this caller
+  need a heavy field — and is it a hot path?* If it needs a heavy field it must be **re-routed
+  to the Full getter** (e.g. `GetBookByID` / `GetAllBooksFullFrom`), not just retyped — a
+  `BookCore` that needed a heavy field is a `BookSignatureScan`-class bug. **But** the full bulk
+  path (`GetAllBooksFullFrom`) is N `GetBookByID` point-reads: fine for a batch scan, a latent
+  regression on a hot request path — so a rerouted *hot* site needs a targeted read (fetch only
+  the ids it needs), not a full-library hydration. **This audit is the point of the whole
+  initiative**; every brief must call it out per call site, and the compile error makes each one
+  impossible to skip.
+
+## Dependency graph
+
+```
+P1-T1 ─┐
+P1-T2 ─┼─(independent, any order)
+P1-T3 ─┘
+P2-T1 ── P2-T2   (types; must precede all of Phase 3)
+        └────────> P3-W1 → W2 → W3 → W4 → W5 → W6   (serialize: all touch the Store interface
+                                                       + mock; sibling-rebase between waves)
+P3-* ────────────> P4-T1   (lint after the getters are typed)
+```
+Phase 1 can run concurrently with Phase 2. Phase 3 waves **serialize** (shared interface + mock
+file → same-file collisions), each rebasing on the prior merge — same discipline as the
+concurrency sweep's `engine.go` chain.
+
+## Test strategy
+
+- P2 parity tests lock the field partition (drift → red).
+- Each P3 wave: `go test -race ./<changed pkgs>` + the getter's existing tests still pass
+  (renamed). Add one test per Core getter asserting the returned `BookCore` has the safe fields
+  populated (guards against a bad `.Core()` projection dropping a surviving field).
+- P4 lint runs in CI on every future PR.
+
+## Rollback
+
+- Phase 1: revert the single rename commit (mechanical).
+- Phase 2: `BookCore` is additive with no callers — deleting it is a clean revert.
+- Each Phase 3 wave: independent revert (rename back + retype); no data/schema touched — this is
+  a pure API-surface refactor, zero persisted-state risk.
+
+## Out of scope (per spec §8)
+
+Not un-stripping memdb; not merging `BookSummary`; not renaming the 24 unambiguous Full getters;
+no JSON/API wire changes; non-object getters (IDs/counts/tags/stats) untouched.
+
+## Estimate
+
+~11 tasks across 4 phases. Phase 1 (3× Haiku) + Phase 2 (2× Opus) are days. Phase 3 is the bulk
+(~132 call-site edits over 6 serialized waves, mostly mechanical with per-site judgment). Full
+package = design spec (this) + plan (this) + 11 weak-model-proof briefs — briefs generated on
+GATE-2 approval.

--- a/docs/specs/2026-07-05-store-getter-fidelity-unification.md
+++ b/docs/specs/2026-07-05-store-getter-fidelity-unification.md
@@ -1,0 +1,225 @@
+<!-- file: docs/specs/2026-07-05-store-getter-fidelity-unification.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9feb8526-a9ba-4e3d-8368-aa1ccef47499 -->
+<!-- last-edited: 2026-07-05 -->
+
+# Design Spec — `database.Store` getter fidelity unification (STOREFID)
+
+**Status:** proposed · **Tier:** L · **Author:** plan-op (manual, tooling-blocked) · **Companion plan:** [`docs/plans/2026-07-05-store-getter-fidelity-unification.md`](../plans/2026-07-05-store-getter-fidelity-unification.md)
+
+Plan only — no code changes here. This spec locks the naming scheme, the concrete
+types, and the consolidate/split decisions; the plan sequences the migration.
+
+## 1. Problem
+
+`PebbleStore` getters silently return one of **two different payloads** for the same
+Go type. Under the production default (`UseMemDB=true`), some getters return the
+**full** Pebble row and others return a **memdb projection** with heavy fields nil'd
+to save RAM (`stripBookForMemdb`/`stripBookFileForMemdb`, `internal/database/memdb_strip.go`
+— cuts the in-memory radix tree ~10 GB → ~2 GB at 392 K books; **the strip must stay**).
+
+The fidelity is **invisible at the call site and un-learnable from the name**:
+
+- `GetAllBooks` is slim, but `GetAllBooksFrom` (same `GetAll…Books` root) is full.
+- `GetBookFiles(bookID)` is full, but `GetBookFilesForIDs(ids)` is slim.
+- The team already hit this and bolted on an **ad-hoc `_Pebble` "full" suffix** on exactly
+  two of ten slim methods (`GetBooksByAuthorID_Pebble`, `GetBooksBySeriesID_Pebble`).
+
+**This has already caused a production bug and a wrong analysis.** `BookSignatureScan`
+filtered on the memdb-stripped `Book.BookSigV1` and silently scanned **zero books** — no
+error — for an unknown duration (fixed reactively in PR #1830 / `0abc0ed2`). During review
+of that fix, a second analysis wrongly claimed `AcoustIDScan` had the same bug (it does
+not — it reads fingerprints via the full `GetBookFiles`). Both errors trace to the same
+root: **fidelity is a runtime property with no type or name signal.**
+
+## 2. The fidelity model (three tiers, not two)
+
+The audit found the payload space is **three** tiers, which the current single `Book`
+type conflates:
+
+| Tier | Fields | Source | Today's type |
+|---|---|---|---|
+| **Full** | all ~100 `Book` fields | raw Pebble (`GetBookByID`, iterators) | `Book` |
+| **Core** (memdb projection) | ~91 — everything **except** the 9 heavy fields | memdb radix tree | `Book` (heavy fields nil) |
+| **Summary** | 27 curated list fields | dedicated `book:summary:` projection | `BookSummary` ✅ already distinct |
+
+**Heavy fields stripped from Core** — `Book`: `Description`, `VersionNotes`, `BookSigV1`,
+`BookSigV1Mask`, `BookSigSegments`, `BookSigBuiltAt`, `BookSigCoveragePct`, `Author`,
+`Series`. `BookFile`: `FingerprintFailureReason/Detail/DiagnosticJSON`,
+`AcoustIDFingerprint`, `AcoustIDSeg0..6`. **Deliberately kept in Core** (do not touch):
+`FingerprintFailedAt` (LSH builder reads it), `AcoustIDFingerprintDurationSec` (the
+memdb-safe "has-fingerprint" proxy).
+
+The bug space is **Full ⇄ Core confusion** — they are the *same type* today, so the
+compiler and the reader cannot tell them apart. `Summary` is already safe (distinct type)
+and is largely **out of scope** except for naming consistency.
+
+## 3. Inventory (36 book/book-file object getters)
+
+Call-site counts (non-test / test) drive every decision below.
+
+**Core / slim (9)** — delegate to `p.mem()`, return stripped rows:
+`GetAllBooks` (79/63), `GetBooksBySeriesID` (22/12), `GetAllBookFiles` (18/2),
+`GetBooksByAuthorID` (9/13), `GetBookFilesForIDs` (4/0), `GetFolderDuplicates` (2/3),
+`GetDuplicateBooksByMetadata` (1/1), `GetBooksByAuthorIDWithRole` (n/a), `GetBookFilesNeedingDelugeImport` (n/a).
+
+**Full-but-mis-named (3)** — return full data, name hides it:
+`GetAllBooksFrom` (2/2, memdb branch **re-hydrates** via `GetBookByID`),
+`GetBooksByAuthorID_Pebble` (**0/0**), `GetBooksBySeriesID_Pebble` (**0/0**).
+
+**Full (24)** — raw Pebble, unambiguous by being the only variant: `GetBookByID` (181/191),
+`GetBookFiles` (94/70), `GetBookFileByID`, all `GetBookBy<hash|path|pid>`,
+`GetBooksByVersionGroup/WorkID/TitleInDir/MetadataSourceHash`, `GetQuarantinedBooks`,
+`ListBooksByITunesPID`, `ListSoftDeletedBooks`, `GetDuplicateBooks`, … (full list in the plan).
+
+**Two facts that shape everything:**
+1. **The `_Pebble` twins have zero callers** — pure internal fallbacks. Cleaning them up is free and invisible to the public API.
+2. **The blast radius is wildly asymmetric.** Renaming the *full* getters (`GetBookByID` 181, `GetBookFiles` 94) is pure churn for zero safety gain — they are already the correct, unambiguous default. The danger — and the only place worth spending churn — is the *slim* getters.
+
+## 4. Locked decisions
+
+**LD-1 — Fidelity is carried by the TYPE, not just the name.** Introduce compiler-enforced
+Core types so reading a stripped field off a slim result is a **compile error**, not a
+silent runtime nil. Naming alone (rejected as the *sole* fix) documents the trap but does
+not prevent re-introducing it. The user explicitly asked for concrete types; this is the
+guarantee.
+
+**LD-2 — Core as a distinct type reached via a `Core()` projection; NOT struct embedding.**
+Two shapes were weighed:
+
+- **(A) Embedding** — `type Book struct { BookCore; <9 heavy fields> }`. DRY (no field
+  duplication) and JSON stays flat, BUT it **breaks every `Book{Title: …}` struct literal**
+  that sets a now-promoted field — potentially hundreds of construction sites across tests,
+  importers, and write paths, all in one non-splittable struct-redefinition PR. Rejected as
+  the primary approach: the blast radius is enormous and orthogonal to the actual bug.
+
+- **(B, CHOSEN) Distinct type + projection** — leave `Book` **exactly as it is** (flat, all
+  fields; zero construction-site churn). Add:
+
+  ```go
+  // BookCore = the ~91 fields that survive the memdb strip. No heavy fields exist
+  // on this type, so reading e.g. .BookSigV1 off a BookCore is a COMPILE ERROR.
+  type BookCore struct { ID, Title, AuthorID, …, IsPrimaryVersion, VersionGroupID, … }
+
+  func (b *Book) Core() BookCore { return BookCore{ID: b.ID, Title: b.Title, …} }
+  ```
+
+  Slim getters return `[]BookCore`; the store builds them via `.Core()` (or directly from
+  the memdb row). **Blast radius is confined to the ~9 slim getters and their callers** — a
+  caller that only reads safe fields just swaps the type name; a caller that reads a stripped
+  field **fails to compile** (the bug caught). Same shape for `BookFileCore` / `BookFile`.
+
+  **The projection has one trap it must guard against (see §7).** A hand-written `Core()` that
+  *forgets to copy a field* silently zeroes it in every slim result — the same silent-drop
+  bug class, reintroduced inside the fix. A field-name parity test does NOT catch this. The
+  required guard is a **copy-completeness reflection test**: fully-populate a `Book` (every
+  field non-zero), call `Core()`, and assert every `BookCore` field equals its `Book`
+  counterpart. O(1), catches every dropped/mis-copied field.
+
+- **(C, viable alternative — record the trade-off) memdb stores `BookCore` natively.** The
+  partition already maps cleanly onto the layers: memdb *is* the slim layer, Pebble-direct *is*
+  full. If the memdb radix tree held `BookCore` instead of a stripped `Book`, then
+  `stripBookForMemdb` **becomes** the single `Book→BookCore` constructor (at insertion — the
+  one site that already exists and is already tested), slim getters return `[]BookCore` with
+  **zero per-read projection copy**, and the copy-completeness risk of (B) collapses into that
+  one well-tested conversion. Cost: more churn inside the memdb read methods (`memdb_reads.go`),
+  which currently return `Book`. **Chosen (B) over (C) for staging**: (B) is purely additive at
+  the type layer (Phase 2 introduces `BookCore` with no memdb-internals change and stays green),
+  and (C) can be adopted later as an internal optimization *behind* the same `[]BookCore` API
+  without touching callers. If Phase 3 review finds the per-read `.Core()` copy is a measurable
+  cost, promote to (C). Recorded so reviewers don't ask "why project on every read?"
+
+`BookCore` carries the same `json` tags as its `Book` fields; for any slim getter surfaced
+through the API, the wire format is preserved **provided the heavy fields are `omitempty`**
+(else null-vs-absent differs) — verify per API-surfaced getter during migration.
+
+**LD-3 — Every getter's name is unambiguous about fidelity; retire silent bare names.**
+Convention: `Get[All]<Entity><Fidelity>[By<Key>|From]`, `Fidelity ∈ {∅ = Full, Core, Summary}`.
+- **Full** getters keep the plain name (default = full, complete payload). No `…Full` suffix — it would churn 275+ call sites for zero gain, and "plain = full" is the safe reading.
+- **Core** getters get an explicit `Core` in the name **and** return `[]BookCore` — double signal (grep-able name + compiler-enforced type).
+- `GetAllBooksFrom` → `GetAllBooksFullFrom` (kills the worst collision; only 2 callers).
+- The bare, currently-slim name `GetAllBooks` is **retired** (not silently re-pointed at full — that would be an invisible semantic flip for 79 callers). Callers move to `GetAllBooksCore` (slim, the common case) or the full cursor reader, each an explicit choice.
+
+**LD-4 — `Summary` stays a third tier, untouched except name consistency.** `BookSummary`
+is a deliberate 27-field list projection, already a distinct type and already safe. No
+merge with Core (Core is 91 fields; Summary is 27 — different purposes).
+
+## 5. Naming scheme + rename table (all getters)
+
+Fidelity suffix: **`Core`** (memdb projection) · **∅** (full) · **`Summary`** (list projection).
+Cardinality/key stay as today (`ByID`, `ByAuthorID`, `From`, `All`).
+
+| Old | New | Return type | Fidelity | Notes |
+|---|---|---|---|---|
+| `GetAllBooks(limit,off)` | `GetAllBooksCore(limit,off)` | `[]BookCore` | Core | 79 callers — largest wave |
+| `GetBooksBySeriesID` | `GetBooksBySeriesIDCore` | `[]BookCore` | Core | 22 callers |
+| `GetAllBookFiles` | `GetAllBookFilesCore` | `[]BookFileCore` | Core | 18 callers |
+| `GetBooksByAuthorID` | `GetBooksByAuthorIDCore` | `[]BookCore` | Core | 9 callers |
+| `GetBooksByAuthorIDWithRole` | `GetBooksByAuthorIDWithRoleCore` | `[]BookCore` | Core | |
+| `GetBookFilesForIDs` | `GetBookFilesForIDsCore` | `map[string][]BookFileCore` | Core | 4 callers |
+| `GetBookFilesNeedingDelugeImport` | `GetBookFilesNeedingDelugeImportCore` | `[]BookFileCore` | Core | |
+| `GetDuplicateBooksByMetadata` | `GetDuplicateBooksByMetadataCore` | `[][]BookCore` | Core | |
+| `GetFolderDuplicates` | `GetFolderDuplicatesCore` | `[][]BookCore` | Core | |
+| `GetAllBooksFrom` | `GetAllBooksFullFrom` | `[]Book` | Full | 2 callers — kills the collision |
+| `GetBooksByAuthorID_Pebble` | *(unexport → `getBooksByAuthorIDFull` or inline)* | `[]Book` | Full | **0 callers** — internal only |
+| `GetBooksBySeriesID_Pebble` | *(unexport → `getBooksBySeriesIDFull` or inline)* | `[]Book` | Full | **0 callers** — internal only |
+| `GetBookByID`, `GetBookFiles`, `GetBookFileByID`, `GetBookBy*`, `GetBooksByVersionGroup/WorkID/TitleInDir/MetadataSourceHash`, `GetQuarantinedBooks`, `ListBooksByITunesPID`, `ListSoftDeletedBooks`, `GetDuplicateBooks` | **unchanged** | `Book`/`[]Book`/`BookFile` | Full | plain = full; no churn |
+| `GetAllBookSummaries`, `…Filtered` | unchanged | `[]BookSummary` | Summary | already distinct |
+| `GetAllBookSummaries_Pebble` | *(unexport)* | `[]BookSummary` | Summary | internal fallback |
+
+## 6. Consolidate / split analysis
+
+**Consolidate:**
+- **`_Pebble` twins → internal, unexported.** `GetBooksByAuthorID_Pebble` /
+  `GetBooksBySeriesID_Pebble` / `GetAllBookSummaries_Pebble` have **zero external callers**;
+  they exist only as the `UseMemDB=false` fallback inside their public wrappers. Unexport to
+  `get…Full` (or inline) — removes 3 misleading public names at zero call-site cost.
+- **Do NOT** collapse Core+Full into one method with a `full bool` param. A boolean flag is
+  exactly the invisible-fidelity trap in a new coat — the type (`BookCore` vs `Book`) is the
+  point. Two names, two types.
+
+**Split:**
+- **`GetAllBooksFrom` is doing two jobs** under one name: cursor pagination *and* full-fidelity
+  hydration. Rename makes the fidelity explicit (`GetAllBooksFullFrom`); its cursor semantics
+  stay. No behavioral split needed — the name split suffices.
+- No other getter serves two masters once the Core/Full type split lands.
+
+**Neither consolidate nor split — leave alone:** the 24 unambiguous Full getters and the
+`Summary` family. Touching them is churn without safety gain.
+
+## 7. Regression guard
+
+Three layers so this cannot silently come back:
+1. **The type system (primary).** Once slim getters return `BookCore`, a caller that needs a
+   heavy field *cannot compile* against a Core result — the `BookSignatureScan` bug becomes
+   impossible, not just documented.
+2. **Copy-completeness reflection test (guards the fix itself).** `TestBookCoreCopiesAllFields`:
+   fully-populate a `Book` (every field non-zero via reflection), call `Core()`, assert every
+   `BookCore` field equals its `Book` counterpart. Catches a `Core()` that adds a field to the
+   struct but forgets to copy it — otherwise a fresh silent-drop bug hiding inside the fix.
+   (Under option 4(C) this collapses into testing the single `stripBookForMemdb` constructor.)
+3. **A naming lint (secondary).** A CI grep/`go vet`-style check asserting: (a) no exported
+   store getter returns `[]Book`/`Book`/`BookFile` while its `PebbleStore` body delegates to
+   `p.mem()`; (b) no new `_Pebble`-suffixed exported method. Catches a future getter added on
+   the wrong tier before review.
+
+## 8. Non-goals
+
+- Not un-stripping memdb (the strip is load-bearing for RAM).
+- Not merging `BookSummary` into Core.
+- Not renaming the 24 unambiguous Full getters.
+- Not changing JSON/API wire formats (embedding keeps them flat).
+- Not touching non-object getters (IDs, counts, tags, stats) — unaffected by the strip.
+
+## 9. Open questions for GATE-2 approval
+
+1. **Type rollout appetite.** LD-2(B) confines churn to the 9 slim getters + their callers
+   (no `Book` struct-literal break), so the type change is tractable in one initiative. Still
+   worth staging for safety: **Phase 1** = `_Pebble`/`GetAllBooksFrom` cleanup + doc contracts
+   (0–2 callers, days) → **Phase 2** = introduce `BookCore`/`BookFileCore` + parity tests →
+   **Phase 3** = migrate each slim getter to `…Core`/typed, wave-batched ascending by call
+   count (4 → 9 → 18 → 22 → 79) so the pattern is proven small before the 79-caller `GetAllBooks`
+   wave. *Recommendation: proceed staged; each phase is independently shippable and green.*
+2. **`Core` vs another suffix** (`Lite`, `Projected`, `Slim`). Recommendation: `Core` (it is the
+   core/common fields, not a lossy "lite").
+3. Whether the naming lint (§7.2) is worth building now or deferred to Phase 2.


### PR DESCRIPTION
Planning package (no code changes) for unifying the `database.Store` book/book-file getters around explicit data-fidelity. Root cause: Full vs Core(memdb-stripped) rows share the `Book` type → invisible, un-learnable, caused the BookSignatureScan prod no-op (#1830).

**Spec:** `docs/specs/2026-07-05-store-getter-fidelity-unification.md` — 3-tier fidelity model, naming scheme + full 36-getter rename table, `BookCore`/`BookFileCore` projection types (compiler-enforced; reading a stripped field won't compile), consolidate/split analysis (the `_Pebble` twins have 0 callers → unexport), regression guards.
**Plan:** `docs/plans/2026-07-05-store-getter-fidelity-unification.md` — 4 phases / ~11 tasks, ascending wave-batching by call-count (4→9→18→22→79), mockery-scoped-regen rule, mechanical-vs-judgment split, hard STOP checkpoint after the type foundation.

⚠ This is the GATE-2 artifact — **awaiting design approval before task briefs are generated / any code changes.** Not for merge-and-run.