### PR TITLE
fix(ci): bump ghcommon pin for ghcommon-scripts ref-resolution fix

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.10.1
+# version: 2.10.2
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 # last-edited: 2026-07-05
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@e44a03f9da7de181d31fc05e173a3a1ddaeda941 # v2.14.1 (ghcommon repo-ref fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@c4ea62e7ca3794f13bb6e7a2546a04a90fcd3d1f # v2.14.2 (ghcommon ref-pin fix)
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.9.3
+# version: 4.9.4
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 # last-edited: 2026-07-05
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@e44a03f9da7de181d31fc05e173a3a1ddaeda941 # v2.14.1 (ghcommon repo-ref fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@c4ea62e7ca3794f13bb6e7a2546a04a90fcd3d1f # v2.14.2 (ghcommon ref-pin fix)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.111.0 -->
+<!-- version: 3.111.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-05 -->
 
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 5, 2026 - fix(ci): bump ghcommon pin for ghcommon-scripts ref-resolution fix (5th release-pipeline blocker)
+
+- **`fix(ci)`** — the first full end-to-end release attempt (Go + frontend +
+  Docker all enabled) hit a 5th distinct blocker after the prior 4 fixes:
+  "Create GitHub Release" failed reproducibly (2 consecutive attempts,
+  identical error) fetching ghcommon's helper scripts, because two of
+  `reusable-release.yml`'s three "Determine ghcommon workflow ref" steps
+  parsed `GITHUB_WORKFLOW_REF`, which in a reusable-workflow context
+  extracts the *calling* repo's own ref rather than one specific to
+  `github-common`. That ref name happened to also be valid in
+  `github-common`, but `actions/checkout`'s resolution of it hit a
+  GitHub Actions-side bug: it consistently returned a commit SHA that
+  doesn't exist in either repo (confirmed via the GitHub API and via a
+  direct `git ls-remote`, which resolves the same ref correctly outside
+  Actions). Fixed in `falkcorp/github-common#316` by unifying all three
+  occurrences to a pinned-file lookup (`.github/ghcommon-ref.txt`)
+  instead of live ref resolution. Bumped the pin to `c4ea62e` (v2.14.2)
+  here.
 
 #### July 5, 2026 - fix(dedup): BookSignatureScan silently no-op under prod's memdb default (CONC-16)
 


### PR DESCRIPTION
## Summary
- Bumps the `reusable-release.yml` pin to `falkcorp/github-common@c4ea62e` (v2.14.2, PR #316), which fixes a reproducible GitHub Actions-side bug where `refs/heads/main` resolved to a nonexistent commit SHA during the ghcommon-scripts checkout, failing "Create GitHub Release" every time.
- This is the 5th and (so far) final blocker found while validating the release pipeline end-to-end with all components enabled (Go + frontend + Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT