### PR TITLE
feat(store): add BookFileCore projection type + BookFile.Core() (STOREFID P2-T2)

### DIFF
--- a/internal/database/bookfilecore.go
+++ b/internal/database/bookfilecore.go
@@ -1,0 +1,124 @@
+// file: internal/database/bookfilecore.go
+// version: 1.0.0
+// guid: 715f4b68-2d23-4f52-b1dd-1b3d0357a4f6
+// last-edited: 2026-07-05
+
+package database
+
+import "time"
+
+// BookFileCore is the projection of BookFile that survives the memdb strip
+// performed by stripBookFileForMemdb. It contains every BookFile field EXCEPT
+// the heavy fingerprint-diagnostic set that memdb clears before insertion:
+//
+//	FingerprintFailureReason, FingerprintFailureDetail, FingerprintDiagnosticJSON,
+//	AcoustIDFingerprint, AcoustIDSeg0..6
+//
+// Note the two fingerprint-adjacent fields that are intentionally RETAINED
+// (they are NOT stripped in memdb_strip.go and therefore belong on Core):
+//
+//	FingerprintFailedAt              — 24B/row, read by the LSH index builder.
+//	AcoustIDFingerprintDurationSec   — preserved as the fingerprint_status proxy.
+//
+// Keeping BookFileCore mechanically in sync with the strip set is enforced by
+// the reflection tests in bookfilecore_test.go: the name-set diff between
+// BookFile and BookFileCore must equal exactly the stripped set, and Core()
+// must copy every BookFileCore field.
+//
+// json tags are carried verbatim from BookFile so a BookFileCore serializes
+// identically to a stripped BookFile.
+type BookFileCore struct {
+	ID     string `json:"id"`
+	BookID string `json:"book_id"`
+
+	VersionID          string `json:"version_id,omitempty"`
+	FilePath           string `json:"file_path"`
+	OriginalFilename   string `json:"original_filename,omitempty"`
+	ITunesPath         string `json:"itunes_path,omitempty"`
+	ITunesPersistentID string `json:"itunes_persistent_id,omitempty"`
+	TrackNumber        int    `json:"track_number,omitempty"`
+	TrackCount         int    `json:"track_count,omitempty"`
+	DiscNumber         int    `json:"disc_number,omitempty"`
+	DiscCount          int    `json:"disc_count,omitempty"`
+	Title              string `json:"title,omitempty"`
+
+	RawTags          map[string]string `json:"raw_tags,omitempty"`
+	Format           string            `json:"format,omitempty"`
+	Codec            string            `json:"codec,omitempty"`
+	Duration         int               `json:"duration,omitempty"`
+	FileSize         int64             `json:"file_size,omitempty"`
+	BitrateKbps      int               `json:"bitrate_kbps,omitempty"`
+	SampleRateHz     int               `json:"sample_rate_hz,omitempty"`
+	Channels         int               `json:"channels,omitempty"`
+	BitDepth         int               `json:"bit_depth,omitempty"`
+	FileHash         string            `json:"file_hash,omitempty"`
+	OriginalFileHash string            `json:"original_file_hash,omitempty"`
+	PostMetadataHash string            `json:"post_metadata_hash,omitempty"`
+
+	// AcoustIDFingerprintDurationSec is RETAINED on Core (not stripped).
+	AcoustIDFingerprintDurationSec float64 `json:"acoustid_fingerprint_duration_sec,omitempty"`
+
+	// FingerprintFailedAt is RETAINED on Core (not stripped).
+	FingerprintFailedAt *time.Time `json:"fingerprint_failed_at,omitempty"`
+
+	AcoustIDOnlineRecordingID string     `json:"acoustid_online_recording_id,omitempty"`
+	AcoustIDOnlineScore       float64    `json:"acoustid_online_score,omitempty"`
+	AcoustIDOnlineLookedUpAt  *time.Time `json:"acoustid_online_looked_up_at,omitempty"`
+	OrganizeMethod            string     `json:"organize_method,omitempty"`
+	Missing                   bool       `json:"missing"`
+	SkipScan                  bool       `json:"skip_scan"`
+	CreatedAt                 time.Time  `json:"created_at"`
+	UpdatedAt                 time.Time  `json:"updated_at"`
+
+	DelugeHash           string     `json:"deluge_hash,omitempty"`
+	DownloadHash         string     `json:"download_hash,omitempty"`
+	DelugeOriginalPath   string     `json:"deluge_original_path,omitempty"`
+	ImportedFromDelugeAt *time.Time `json:"imported_from_deluge_at,omitempty"`
+}
+
+// Core returns the BookFileCore projection of f — every BookFile field that
+// survives the memdb strip, copied by value. The heavy fingerprint-diagnostic
+// fields (see BookFileCore doc) are dropped. Purely additive: it neither reads
+// nor mutates state beyond f.
+func (f *BookFile) Core() BookFileCore {
+	return BookFileCore{
+		ID:                             f.ID,
+		BookID:                         f.BookID,
+		VersionID:                      f.VersionID,
+		FilePath:                       f.FilePath,
+		OriginalFilename:               f.OriginalFilename,
+		ITunesPath:                     f.ITunesPath,
+		ITunesPersistentID:             f.ITunesPersistentID,
+		TrackNumber:                    f.TrackNumber,
+		TrackCount:                     f.TrackCount,
+		DiscNumber:                     f.DiscNumber,
+		DiscCount:                      f.DiscCount,
+		Title:                          f.Title,
+		RawTags:                        f.RawTags,
+		Format:                         f.Format,
+		Codec:                          f.Codec,
+		Duration:                       f.Duration,
+		FileSize:                       f.FileSize,
+		BitrateKbps:                    f.BitrateKbps,
+		SampleRateHz:                   f.SampleRateHz,
+		Channels:                       f.Channels,
+		BitDepth:                       f.BitDepth,
+		FileHash:                       f.FileHash,
+		OriginalFileHash:               f.OriginalFileHash,
+		PostMetadataHash:               f.PostMetadataHash,
+		AcoustIDFingerprintDurationSec: f.AcoustIDFingerprintDurationSec,
+		FingerprintFailedAt:            f.FingerprintFailedAt,
+		AcoustIDOnlineRecordingID:      f.AcoustIDOnlineRecordingID,
+		AcoustIDOnlineScore:            f.AcoustIDOnlineScore,
+		AcoustIDOnlineLookedUpAt:       f.AcoustIDOnlineLookedUpAt,
+		OrganizeMethod:                 f.OrganizeMethod,
+		Missing:                        f.Missing,
+		SkipScan:                       f.SkipScan,
+		CreatedAt:                      f.CreatedAt,
+		UpdatedAt:                      f.UpdatedAt,
+		DelugeHash:                     f.DelugeHash,
+		DownloadHash:                   f.DownloadHash,
+		DelugeOriginalPath:             f.DelugeOriginalPath,
+		ImportedFromDelugeAt:           f.ImportedFromDelugeAt,
+	}
+}

--- a/internal/database/bookfilecore_test.go
+++ b/internal/database/bookfilecore_test.go
@@ -1,0 +1,154 @@
+// file: internal/database/bookfilecore_test.go
+// version: 1.0.0
+// guid: 29325171-4866-4142-82c6-e010f724ae5e
+// last-edited: 2026-07-05
+
+package database
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+)
+
+// strippedBookFileFields is the authoritative heavy set that stripBookFileForMemdb
+// clears before memdb insertion — the exact fields BookFileCore must NOT contain.
+// FingerprintFailedAt and AcoustIDFingerprintDurationSec are deliberately absent
+// here (they are RETAINED on Core).
+var strippedBookFileFields = []string{
+	"AcoustIDFingerprint",
+	"AcoustIDSeg0",
+	"AcoustIDSeg1",
+	"AcoustIDSeg2",
+	"AcoustIDSeg3",
+	"AcoustIDSeg4",
+	"AcoustIDSeg5",
+	"AcoustIDSeg6",
+	"FingerprintDiagnosticJSON",
+	"FingerprintFailureDetail",
+	"FingerprintFailureReason",
+}
+
+func structFieldNames(t reflect.Type) map[string]struct{} {
+	names := make(map[string]struct{}, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		names[t.Field(i).Name] = struct{}{}
+	}
+	return names
+}
+
+// TestBookFileCoreIsBookFileMinusHeavyFields asserts the field-name set of
+// BookFileCore equals BookFile's set minus EXACTLY the stripped heavy set.
+func TestBookFileCoreIsBookFileMinusHeavyFields(t *testing.T) {
+	bfNames := structFieldNames(reflect.TypeOf(BookFile{}))
+	coreNames := structFieldNames(reflect.TypeOf(BookFileCore{}))
+
+	// (1) Every Core field must exist on BookFile (no invented fields).
+	for name := range coreNames {
+		if _, ok := bfNames[name]; !ok {
+			t.Errorf("BookFileCore has field %q that BookFile lacks", name)
+		}
+	}
+
+	// (2) The set BookFile - BookFileCore must equal the stripped set exactly.
+	var diff []string
+	for name := range bfNames {
+		if _, ok := coreNames[name]; !ok {
+			diff = append(diff, name)
+		}
+	}
+	sort.Strings(diff)
+
+	want := append([]string(nil), strippedBookFileFields...)
+	sort.Strings(want)
+
+	if !reflect.DeepEqual(diff, want) {
+		t.Errorf("BookFile - BookFileCore field diff mismatch\n got: %v\nwant: %v", diff, want)
+	}
+
+	// (3) Guard the retained pair explicitly — they must live on Core.
+	for _, kept := range []string{"FingerprintFailedAt", "AcoustIDFingerprintDurationSec"} {
+		if _, ok := coreNames[kept]; !ok {
+			t.Errorf("expected retained field %q on BookFileCore, but it is missing", kept)
+		}
+	}
+}
+
+// fillNonZero recursively populates every field of the struct pointed to by v
+// with a distinct non-zero value, so a later zero-check proves the copy is total.
+func fillNonZero(t *testing.T, v reflect.Value) {
+	t.Helper()
+	ts := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanSet() {
+			t.Fatalf("field %q is not settable", v.Type().Field(i).Name)
+		}
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("v_" + v.Type().Field(i).Name)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.SetInt(int64(i + 1))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			f.SetUint(uint64(i + 1))
+		case reflect.Float32, reflect.Float64:
+			f.SetFloat(float64(i) + 0.5)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Map:
+			m := reflect.MakeMap(f.Type())
+			m.SetMapIndex(reflect.ValueOf("k_"+v.Type().Field(i).Name), reflect.ValueOf("val"))
+			f.Set(m)
+		case reflect.Slice:
+			s := reflect.MakeSlice(f.Type(), 1, 1)
+			s.Index(0).Set(reflect.ValueOf(byte(i + 1)).Convert(f.Type().Elem()))
+			f.Set(s)
+		case reflect.Ptr:
+			// Only *time.Time appears in BookFile.
+			if f.Type().Elem() == reflect.TypeOf(time.Time{}) {
+				tt := ts.Add(time.Duration(i) * time.Hour)
+				f.Set(reflect.ValueOf(&tt))
+			} else {
+				np := reflect.New(f.Type().Elem())
+				f.Set(np)
+			}
+		case reflect.Struct:
+			if f.Type() == reflect.TypeOf(time.Time{}) {
+				f.Set(reflect.ValueOf(ts.Add(time.Duration(i) * time.Minute)))
+			} else {
+				fillNonZero(t, f)
+			}
+		default:
+			t.Fatalf("unhandled field kind %s for field %q", f.Kind(), v.Type().Field(i).Name)
+		}
+	}
+}
+
+// TestBookFileCoreCopiesAllFields populates every BookFile field with a distinct
+// non-zero value, projects via Core(), and asserts every BookFileCore field was
+// copied from the same-named BookFile field.
+func TestBookFileCoreCopiesAllFields(t *testing.T) {
+	var bf BookFile
+	fillNonZero(t, reflect.ValueOf(&bf).Elem())
+
+	// Sanity: confirm no BookFile field is still zero, so the copy check is meaningful.
+	bfv := reflect.ValueOf(bf)
+	for i := 0; i < bfv.NumField(); i++ {
+		if bfv.Field(i).IsZero() {
+			t.Fatalf("test setup failed: BookFile field %q left zero", bfv.Type().Field(i).Name)
+		}
+	}
+
+	core := bf.Core()
+	cv := reflect.ValueOf(core)
+	ct := cv.Type()
+	for i := 0; i < ct.NumField(); i++ {
+		name := ct.Field(i).Name
+		coreVal := cv.Field(i).Interface()
+		srcVal := bfv.FieldByName(name).Interface()
+		if !reflect.DeepEqual(coreVal, srcVal) {
+			t.Errorf("Core() field %q not copied: got %v, want %v", name, coreVal, srcVal)
+		}
+	}
+}


### PR DESCRIPTION
STOREFID Phase 2. Additive — new files only, no getter/interface/mock change. `BookFileCore` = `BookFile` minus the 11 memdb-stripped fields (FingerprintFailure*, AcoustIDFingerprint, AcoustIDSeg0..6); **retains** FingerprintFailedAt + AcoustIDFingerprintDurationSec (not stripped). `BookFile.Core()` projection + two reflection tests (name-set parity + copy-completeness). Build/vet/scoped-race green; full `./internal/database` suite green in-worker.