### PR TITLE
refactor(store): STOREFID Phase 1 — _Pebble cleanup, GetAllBooksFrom rename, slim-getter docs

### DIFF
--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,6 +1,6 @@
 // file: internal/batch/service_test.go
-// version: 1.0.4
-// last-edited: 2026-06-24
+// version: 1.0.5
+// last-edited: 2026-07-05
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -84,7 +84,7 @@ func (m *MockBookStore) DeleteBook(id string) error {
 
 // Stub implementations for other BookStore methods not used by BatchService
 func (m *MockBookStore) GetAllBooks(limit, offset int) ([]database.Book, error) { return nil, nil }
-func (m *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+func (m *MockBookStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	return nil, nil
 }
 func (m *MockBookStore) GetAllBookSummaries(limit, offset int) ([]database.BookSummary, error) {

--- a/internal/database/iface_author.go
+++ b/internal/database/iface_author.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_author.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 2e3b78c0-c989-48c0-a324-b88ea52b1ccd
-// last-edited: 2026-04-30
+// last-edited: 2026-07-05
 
 package database
 
@@ -16,6 +16,8 @@ type AuthorReader interface {
 	GetAllAuthorAliases() ([]AuthorAlias, error)
 	FindAuthorByAlias(aliasName string) (*Author, error)
 	GetBookAuthors(bookID string) ([]BookAuthor, error)
+	// GetBooksByAuthorIDWithRole is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBooksByAuthorIDWithRole(authorID int) ([]Book, error)
 	GetAllAuthorBookCounts() (map[int]int, error)
 	GetAllAuthorFileCounts() (map[int]int, error)

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-06-23
+// last-edited: 2026-07-05
 
 package database
 
@@ -26,12 +26,14 @@ type UpdateBookRatingRequest struct {
 // read books. See spec 2026-04-17-store-interface-segregation-design.md.
 type BookReader interface {
 	GetBookByID(id string) (*Book, error)
+	// GetAllBooks is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetAllBooks(limit, offset int) ([]Book, error)
-	// GetAllBooksFrom returns up to limit non-deleted books whose PebbleDB key
+	// GetAllBooksFullFrom returns up to limit non-deleted books whose PebbleDB key
 	// sorts after "book:<afterID>". Pass afterID="" to start from the beginning.
 	// This is an O(1) seek vs GetAllBooks's O(offset) skip — use for search
 	// index backfill and other full-table cursor scans.
-	GetAllBooksFrom(afterID string, limit int) ([]Book, error)
+	GetAllBooksFullFrom(afterID string, limit int) ([]Book, error)
 	// ListBookIDs returns just the IDs of all non-deleted books, without
 	// materializing Book structs. Saves ~50x memory vs GetAllBooks(0,0) when
 	// the caller only needs the ID set (e.g., diff'ing against another set).
@@ -44,10 +46,18 @@ type BookReader interface {
 	GetBookByOriginalHash(hash string) (*Book, error)
 	GetBookByOrganizedHash(hash string) (*Book, error)
 	GetDuplicateBooks() ([][]Book, error)
+	// GetFolderDuplicates is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetFolderDuplicates() ([][]Book, error)
+	// GetDuplicateBooksByMetadata is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error)
 	GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]Book, error)
+	// GetBooksBySeriesID is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBooksBySeriesID(seriesID int) ([]Book, error)
+	// GetBooksByAuthorID is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBooksByAuthorID(authorID int) ([]Book, error)
 	GetBooksByVersionGroup(groupID string) ([]Book, error)
 	GetBooksByMetadataSourceHash(hash string) ([]Book, error)

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package database
 
@@ -135,9 +135,14 @@ type BookFileStore interface {
 	CreateBookFile(file *BookFile) error
 	UpdateBookFile(id string, file *BookFile) error
 	GetBookFiles(bookID string) ([]BookFile, error)
+	// GetAllBookFiles is SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetAllBookFiles() ([]BookFile, error)
 	// GetBookFilesNeedingDelugeImport returns book_files that have a deluge_hash
 	// but have not yet been copied into the library (imported_from_deluge_at IS NULL).
+	//
+	// SLIM (memdb projection) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBookFilesNeedingDelugeImport() ([]BookFile, error)
 	GetBookFileByID(bookID, fileID string) (*BookFile, error)
 	GetBookFileByPID(itunesPID string) (*BookFile, error)

--- a/internal/database/memdb_summaries.go
+++ b/internal/database/memdb_summaries.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_summaries.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000008
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package database
 
@@ -129,7 +129,7 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 	}
 
 	// excludeDeleted: by default we drop marked_for_deletion=true rows
-	// (mirrors GetAllBookSummaries_Pebble). An explicit filter overrides.
+	// (mirrors getAllBookSummariesFull). An explicit filter overrides.
 	excludeDeleted := true
 	requireDeleted := false
 	if f.MarkedForDeletion != nil {

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.68.0
+// version: 1.69.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package database
 
@@ -35,7 +35,7 @@ type MockStore struct {
 	GetBookByIDFunc                 func(id string) (*Book, error)
 	GetBookByFilePathFunc           func(path string) (*Book, error)
 	GetAllBooksFunc                 func(limit, offset int) ([]Book, error)
-	GetAllBooksFromFunc             func(afterID string, limit int) ([]Book, error)
+	GetAllBooksFullFromFunc         func(afterID string, limit int) ([]Book, error)
 	ListBookIDsFunc                 func() ([]string, error)
 	GetAllBookSummariesFunc         func(limit, offset int) ([]BookSummary, error)
 	GetBooksByWorkIDFunc            func(workID string) ([]Book, error)
@@ -669,9 +669,9 @@ func (m *MockStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	return nil, nil
 }
 
-func (m *MockStore) GetAllBooksFrom(afterID string, limit int) ([]Book, error) {
-	if m.GetAllBooksFromFunc != nil {
-		return m.GetAllBooksFromFunc(afterID, limit)
+func (m *MockStore) GetAllBooksFullFrom(afterID string, limit int) ([]Book, error) {
+	if m.GetAllBooksFullFromFunc != nil {
+		return m.GetAllBooksFullFromFunc(afterID, limit)
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -2903,12 +2903,12 @@ func (_c *MockBookReader_GetAllBooks_Call) RunAndReturn(run func(limit int, offs
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -2931,19 +2931,19 @@ func (_mock *MockBookReader) GetAllBooksFrom(afterID string, limit int) ([]datab
 	return r0, r1
 }
 
-// MockBookReader_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockBookReader_GetAllBooksFrom_Call struct {
+// MockBookReader_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockBookReader_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockBookReader_Expecter) GetAllBooksFrom(afterID any, limit any) *MockBookReader_GetAllBooksFrom_Call {
-	return &MockBookReader_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockBookReader_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockBookReader_GetAllBooksFullFrom_Call {
+	return &MockBookReader_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockBookReader_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockBookReader_GetAllBooksFrom_Call {
+func (_c *MockBookReader_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockBookReader_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -2961,12 +2961,12 @@ func (_c *MockBookReader_GetAllBooksFrom_Call) Run(run func(afterID string, limi
 	return _c
 }
 
-func (_c *MockBookReader_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockBookReader_GetAllBooksFrom_Call {
+func (_c *MockBookReader_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockBookReader_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockBookReader_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookReader_GetAllBooksFrom_Call {
+func (_c *MockBookReader_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookReader_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6284,12 +6284,12 @@ func (_c *MockBookStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offse
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -6312,19 +6312,19 @@ func (_mock *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]databa
 	return r0, r1
 }
 
-// MockBookStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockBookStore_GetAllBooksFrom_Call struct {
+// MockBookStore_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockBookStore_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockBookStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockBookStore_GetAllBooksFrom_Call {
-	return &MockBookStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockBookStore_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockBookStore_GetAllBooksFullFrom_Call {
+	return &MockBookStore_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockBookStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockBookStore_GetAllBooksFrom_Call {
+func (_c *MockBookStore_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockBookStore_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -6342,12 +6342,12 @@ func (_c *MockBookStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit
 	return _c
 }
 
-func (_c *MockBookStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockBookStore_GetAllBooksFrom_Call {
+func (_c *MockBookStore_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockBookStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockBookStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookStore_GetAllBooksFrom_Call {
+func (_c *MockBookStore_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockBookStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -34199,12 +34199,12 @@ func (_c *MockStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset in
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockStore
-func (_mock *MockStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -34227,19 +34227,19 @@ func (_mock *MockStore) GetAllBooksFrom(afterID string, limit int) ([]database.B
 	return r0, r1
 }
 
-// MockStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockStore_GetAllBooksFrom_Call struct {
+// MockStore_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockStore_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockStore_GetAllBooksFrom_Call {
-	return &MockStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockStore_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockStore_GetAllBooksFullFrom_Call {
+	return &MockStore_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockStore_GetAllBooksFrom_Call {
+func (_c *MockStore_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockStore_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -34257,12 +34257,12 @@ func (_c *MockStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int
 	return _c
 }
 
-func (_c *MockStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockStore_GetAllBooksFrom_Call {
+func (_c *MockStore_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockStore_GetAllBooksFrom_Call {
+func (_c *MockStore_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_books_pagination_test.go
+++ b/internal/database/pebble_books_pagination_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_books_pagination_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 7f2a9c14-3b6d-4e81-9a2c-0d5f1e8b4a37
-// last-edited: 2026-06-26
+// last-edited: 2026-07-05
 
 package database
 
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGetAllBooksFrom_PaginatesPastDoubleLimit is a regression test for the
-// memdb-path bug where GetAllBooksFrom loaded only limit*2+1 books from the
+// TestGetAllBooksFullFrom_PaginatesPastDoubleLimit is a regression test for the
+// memdb-path bug where GetAllBooksFullFrom loaded only limit*2+1 books from the
 // start and searched for the cursor within that window. Cursor pagination
 // therefore stalled at the 2*limit boundary, so full-table backfills (intro
 // transcription, search index) only ever processed the first ~2 pages of the
 // library. See fix/transcribe-full-library.
-func TestGetAllBooksFrom_PaginatesPastDoubleLimit(t *testing.T) {
+func TestGetAllBooksFullFrom_PaginatesPastDoubleLimit(t *testing.T) {
 	store := setupTestPebbleStore(t)
 	store.WaitForWarmup()
 	require.True(t, store.UseMemDB, "test must exercise the memdb path")
@@ -47,7 +47,7 @@ func TestGetAllBooksFrom_PaginatesPastDoubleLimit(t *testing.T) {
 	cursor := ""
 	pages := 0
 	for {
-		page, err := store.GetAllBooksFrom(cursor, pageSize)
+		page, err := store.GetAllBooksFullFrom(cursor, pageSize)
 		require.NoError(t, err)
 		if len(page) == 0 {
 			break
@@ -70,10 +70,10 @@ func TestGetAllBooksFrom_PaginatesPastDoubleLimit(t *testing.T) {
 		total, len(seen), pageSize*2)
 }
 
-// TestGetAllBooksFrom_UnknownCursorEndsIteration verifies that a stale/unknown
+// TestGetAllBooksFullFrom_UnknownCursorEndsIteration verifies that a stale/unknown
 // cursor returns no rows (ending iteration) rather than restarting from the
 // top — which would loop forever.
-func TestGetAllBooksFrom_UnknownCursorEndsIteration(t *testing.T) {
+func TestGetAllBooksFullFrom_UnknownCursorEndsIteration(t *testing.T) {
 	store := setupTestPebbleStore(t)
 	store.WaitForWarmup()
 
@@ -84,7 +84,7 @@ func TestGetAllBooksFrom_UnknownCursorEndsIteration(t *testing.T) {
 		store.UpsertBookToMemDB(context.Background(), created)
 	}
 
-	page, err := store.GetAllBooksFrom("zzzz-nonexistent-cursor", 10)
+	page, err := store.GetAllBooksFullFrom("zzzz-nonexistent-cursor", 10)
 	require.NoError(t, err)
 	require.Empty(t, page, "unknown cursor must end iteration, not restart")
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.103.0
+// version: 1.104.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-04
+// last-edited: 2026-07-05
 
 package database
 
@@ -435,6 +435,11 @@ func (p *PebbleStore) migrateImportPathKeys() error {
 
 // Book operations
 
+// GetAllBooks is SLIM (memdb projection): returns rows with heavy fields nil'd —
+// Description, VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,
+// BookSigBuiltAt, BookSigCoveragePct, Author, Series. A caller that needs any
+// of those MUST fetch via GetBookByID / GetAllBooksFullFrom (full Pebble).
+// See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetAllBooks(limit, offset, nil)
@@ -480,11 +485,11 @@ func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	return books, nil
 }
 
-// GetAllBooksFrom returns up to limit non-deleted books in PebbleDB key order
+// GetAllBooksFullFrom returns up to limit non-deleted books in PebbleDB key order
 // after "book:<afterID>". Pass afterID="" to start from the beginning. This
 // is O(1) seek vs GetAllBooks's O(offset) linear scan — use for cursor-based
 // full-table iteration (e.g. search index backfill).
-func (p *PebbleStore) GetAllBooksFrom(afterID string, limit int) ([]Book, error) {
+func (p *PebbleStore) GetAllBooksFullFrom(afterID string, limit int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
 		// MemDB path. NOTE: this IS the production path — UseMemDB defaults to
 		// true. The previous implementation loaded only limit*2+1 books from the
@@ -619,7 +624,7 @@ func (p *PebbleStore) GetAllBookSummaries(limit, offset int) ([]BookSummary, err
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetBookSummaries(limit, offset, BookSummaryFilter{})
 	}
-	return p.GetAllBookSummaries_Pebble(limit, offset)
+	return p.getAllBookSummariesFull(limit, offset)
 }
 
 // CountBookSummariesFiltered returns the count of rows that would match
@@ -650,7 +655,7 @@ func (p *PebbleStore) GetAllBookSummariesFiltered(limit, offset int, f BookSumma
 	// Pebble fallback: filter manually after a full scan. Matches the
 	// historical service behavior so we never regress correctness when
 	// memdb is unavailable.
-	summaries, err := p.GetAllBookSummaries_Pebble(0, 0)
+	summaries, err := p.getAllBookSummariesFull(0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -682,10 +687,10 @@ func (p *PebbleStore) GetAllBookSummariesFiltered(limit, offset int, f BookSumma
 	return filtered[offset:end], nil
 }
 
-// GetAllBookSummaries_Pebble is the Pebble-backed implementation.
+// getAllBookSummariesFull is the Pebble-backed implementation.
 // It fetches all books via full iteration, then projects each Book into a BookSummary,
 // skipping books marked for deletion.
-func (p *PebbleStore) GetAllBookSummaries_Pebble(limit, offset int) ([]BookSummary, error) {
+func (p *PebbleStore) getAllBookSummariesFull(limit, offset int) ([]BookSummary, error) {
 	if limit <= 0 {
 		limit = 1_000_000
 	}
@@ -1030,26 +1035,44 @@ func (p *PebbleStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]B
 	return results, nil
 }
 
+// GetFolderDuplicates is SLIM (memdb projection): returns rows with heavy
+// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
+// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
+// caller that needs any of those MUST fetch via GetBookByID /
+// GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetFolderDuplicates() ([][]Book, error) {
 	// PebbleStore doesn't support folder-based duplicate detection efficiently.
 	return nil, nil
 }
 
 // GetDuplicateBooksByMetadata is not efficiently supported in PebbleStore.
+//
+// SLIM (memdb projection): returns rows with heavy fields nil'd — Description,
+// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series. A caller that needs any of those MUST
+// fetch via GetBookByID / GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error) {
 	return nil, nil
 }
 
+// GetBooksBySeriesID is SLIM (memdb projection): returns rows with heavy
+// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
+// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
+// caller that needs any of those MUST fetch via GetBookByID /
+// GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetBooksBySeriesID(seriesID, 0, 0)
 	}
-	return p.GetBooksBySeriesID_Pebble(seriesID)
+	return p.getBooksBySeriesIDFull(seriesID)
 }
 
-// GetBooksBySeriesID_Pebble performs a full Pebble book scan filtered by series ID.
+// getBooksBySeriesIDFull performs a full Pebble book scan filtered by series ID.
 // Fallback path after Task 3.4 index removal.
-func (p *PebbleStore) GetBooksBySeriesID_Pebble(seriesID int) ([]Book, error) {
+func (p *PebbleStore) getBooksBySeriesIDFull(seriesID int) ([]Book, error) {
 	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
@@ -1083,16 +1106,22 @@ func (p *PebbleStore) GetBooksBySeriesID_Pebble(seriesID int) ([]Book, error) {
 	return books, nil
 }
 
+// GetBooksByAuthorID is SLIM (memdb projection): returns rows with heavy
+// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
+// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
+// caller that needs any of those MUST fetch via GetBookByID /
+// GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetBooksByAuthorID(authorID int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetBooksByAuthorID(authorID, 0, 0)
 	}
-	return p.GetBooksByAuthorID_Pebble(authorID)
+	return p.getBooksByAuthorIDFull(authorID)
 }
 
-// GetBooksByAuthorID_Pebble performs a full Pebble book scan filtered by author ID.
+// getBooksByAuthorIDFull performs a full Pebble book scan filtered by author ID.
 // Fallback path after Task 3.4 index removal.
-func (p *PebbleStore) GetBooksByAuthorID_Pebble(authorID int) ([]Book, error) {
+func (p *PebbleStore) getBooksByAuthorIDFull(authorID int) ([]Book, error) {
 	var books []Book
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),
@@ -1129,6 +1158,12 @@ func (p *PebbleStore) GetBooksByAuthorID_Pebble(authorID int) ([]Book, error) {
 // GetBooksByAuthorIDWithRole returns all books where the author appears in
 // the book_authors junction table (any role). It also falls back to the
 // legacy AuthorID field for books not yet migrated to the junction table.
+//
+// SLIM (memdb projection): returns rows with heavy fields nil'd — Description,
+// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series. A caller that needs any of those MUST
+// fetch via GetBookByID / GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (p *PebbleStore) GetBooksByAuthorIDWithRole(authorID int) ([]Book, error) {
 	if p.UseMemDB && p.mem() != nil {
 		return p.mem().GetBooksByAuthorID(authorID, 0, 0)

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package database
 
@@ -334,6 +334,12 @@ func (s *PebbleStore) GetBookFiles(bookID string) ([]BookFile, error) {
 //
 // Pebble full-scan retained as fallback for cold-start (before memdb
 // publishes) and tests with no memdb.
+//
+// SLIM (memdb projection): returns rows with heavy fields nil'd —
+// FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
+// AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
+// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
+// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (s *PebbleStore) GetBookFilesForIDs(bookIDs []string) (map[string][]BookFile, error) {
 	if s.UseMemDB && s.mem() != nil {
 		return s.mem().GetBookFilesForIDs(bookIDs)
@@ -378,6 +384,12 @@ func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string
 //
 // Pebble full-scan retained as fallback for cold-start (before memdb
 // publishes) and tests with no memdb.
+//
+// SLIM (memdb projection): returns rows with heavy fields nil'd —
+// FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
+// AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
+// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
+// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (s *PebbleStore) GetAllBookFiles() ([]BookFile, error) {
 	if s.UseMemDB && s.mem() != nil {
 		return s.mem().GetAllBookFiles()
@@ -459,6 +471,12 @@ func (s *PebbleStore) getAllBooksPebbleScan() ([]Book, error) {
 // centralization plugin from a 308K full BookFile scan to walking just the
 // (much smaller) deluge-touched subset (H2 + H8). Pebble full-scan retained
 // as the cold-start fallback.
+//
+// SLIM (memdb projection): returns rows with heavy fields nil'd —
+// FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
+// AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
+// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
+// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 func (s *PebbleStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
 	if s.UseMemDB && s.mem() != nil {
 		return s.mem().GetBookFilesNeedingDelugeImport()

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.51.0
+// version: 1.52.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -3055,7 +3055,7 @@ func (de *Engine) getAllBooksUnfiltered() ([]database.Book, error) {
 }
 
 // getAllPrimaryBooksWithFullFields fetches all primary-version books via
-// GetAllBooksFrom instead of GetAllBooks. Under the production default
+// GetAllBooksFullFrom instead of GetAllBooks. Under the production default
 // (PebbleStore.UseMemDB=true), GetAllBooks(0,0) returns memdb-projected Book
 // copies with BookSigV1/BookSigV1Mask/BookSigSegments stripped to nil (see
 // stripBookForMemdb's doc comment: "Predicates that filter by these fields
@@ -3063,12 +3063,12 @@ func (de *Engine) getAllBooksUnfiltered() ([]database.Book, error) {
 // instead"). BookSignatureScan's own filter — `b.BookSigV1 != nil` — is
 // exactly such a predicate, so under UseMemDB=true it silently matched zero
 // books and every full-scan pairwise comparison compared nothing, with no
-// error surfaced. GetAllBooksFrom already implements the memdb-bypass
+// error surfaced. GetAllBooksFullFrom already implements the memdb-bypass
 // pattern the strip comment recommends (walks the ID index, then fetches
 // each book via GetBookByID, which always reads full Pebble JSON regardless
 // of UseMemDB) — reuse it here instead of adding a new store method.
 func (de *Engine) getAllPrimaryBooksWithFullFields() ([]database.Book, error) {
-	batch, err := de.bookStore.GetAllBooksFrom("", 0)
+	batch, err := de.bookStore.GetAllBooksFullFrom("", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dedup/engine_booksig_parallel_test.go
+++ b/internal/dedup/engine_booksig_parallel_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_booksig_parallel_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 3c9e7d21-6b48-4f0a-9d2e-8a1f5c04b7e6
 // last-edited: 2026-07-05
 
@@ -109,12 +109,12 @@ func TestParallelBookSignatureScan_SameCandidatesAsSerial(t *testing.T) {
 		copy(out, books)
 		return out, nil
 	}
-	// BookSignatureScan now sources from GetAllBooksFrom, not GetAllBooks (see
+	// BookSignatureScan now sources from GetAllBooksFullFrom, not GetAllBooks (see
 	// getAllPrimaryBooksWithFullFields's doc comment — GetAllBooks stands in
 	// for the memdb-projected, BookSigV1-stripped read path in production, so
 	// wiring it here too would make this test pass even if the scan regressed
 	// to reading the stripped source again).
-	mock.GetAllBooksFromFunc = func(afterID string, limit int) ([]database.Book, error) {
+	mock.GetAllBooksFullFromFunc = func(afterID string, limit int) ([]database.Book, error) {
 		out := make([]database.Book, len(books))
 		copy(out, books)
 		return out, nil
@@ -208,12 +208,12 @@ func TestParallelBookSignatureScan_SameCandidatesAsSerial(t *testing.T) {
 // TestBookSignatureScan_SurvivesMemdbStrippedGetAllBooks reproduces the
 // production shape directly: GetAllBooks stands in for PebbleStore's
 // UseMemDB=true default, which strips BookSigV1 before returning Book
-// copies (stripBookForMemdb). GetAllBooksFrom stands in for the bypass path
+// copies (stripBookForMemdb). GetAllBooksFullFrom stands in for the bypass path
 // (walks IDs, then GetBookByID per book, which always reads full Pebble
 // JSON regardless of UseMemDB). Before this fix, BookSignatureScan read
 // GetAllBooks and filtered on the now-nil BookSigV1, silently matching zero
 // books. This test fails on the pre-fix code (0 candidates) and passes
-// once the scan sources from GetAllBooksFrom instead.
+// once the scan sources from GetAllBooksFullFrom instead.
 func TestBookSignatureScan_SurvivesMemdbStrippedGetAllBooks(t *testing.T) {
 	engine, mock, es := setupTestEngine(t)
 
@@ -232,7 +232,7 @@ func TestBookSignatureScan_SurvivesMemdbStrippedGetAllBooks(t *testing.T) {
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return stripped, nil
 	}
-	mock.GetAllBooksFromFunc = func(afterID string, limit int) ([]database.Book, error) {
+	mock.GetAllBooksFullFromFunc = func(afterID string, limit int) ([]database.Book, error) {
 		return full, nil
 	}
 	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
@@ -253,6 +253,6 @@ func TestBookSignatureScan_SurvivesMemdbStrippedGetAllBooks(t *testing.T) {
 		t.Fatalf("ListCandidates: %v", err)
 	}
 	if len(cands) != 1 {
-		t.Fatalf("got %d candidates, want 1 (scan read the memdb-stripped GetAllBooks source instead of GetAllBooksFrom)", len(cands))
+		t.Fatalf("got %d candidates, want 1 (scan read the memdb-stripped GetAllBooks source instead of GetAllBooksFullFrom)", len(cands))
 	}
 }

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,6 +1,6 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.2
-// last-edited: 2026-06-23
+// version: 1.0.3
+// last-edited: 2026-07-05
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -18,7 +18,7 @@ type mockRebuildStore struct {
 	bookFiles map[string][]database.BookFile
 }
 
-func (m *mockRebuildStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+func (m *mockRebuildStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	return nil, nil
 }
 func (m *mockRebuildStore) GetAllBooks(pageSize, offset int) ([]database.Book, error) {

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.12.0
+// version: 3.12.1
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package maintenance
 
@@ -120,7 +120,7 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 
 	// Load the FULL, ordered list of book IDs up front. This is the proven
 	// uncapped primitive (memdb ID-index walk). The previous implementation
-	// paginated via GetAllBooksFrom, whose memdb path silently stopped after
+	// paginated via GetAllBooksFullFrom, whose memdb path silently stopped after
 	// 2*pageSize books — so only the first ~400 books of the library were ever
 	// transcribed. See fix/transcribe-full-library.
 	allIDs, err := store.ListBookIDs()

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -792,12 +792,12 @@ func (_c *MockMetadataStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -820,19 +820,19 @@ func (_mock *MockMetadataStore) GetAllBooksFrom(afterID string, limit int) ([]da
 	return r0, r1
 }
 
-// MockMetadataStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockMetadataStore_GetAllBooksFrom_Call struct {
+// MockMetadataStore_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockMetadataStore_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockMetadataStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockMetadataStore_GetAllBooksFrom_Call {
-	return &MockMetadataStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockMetadataStore_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockMetadataStore_GetAllBooksFullFrom_Call {
+	return &MockMetadataStore_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockMetadataStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockMetadataStore_GetAllBooksFrom_Call {
+func (_c *MockMetadataStore_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockMetadataStore_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -850,12 +850,12 @@ func (_c *MockMetadataStore_GetAllBooksFrom_Call) Run(run func(afterID string, l
 	return _c
 }
 
-func (_c *MockMetadataStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockMetadataStore_GetAllBooksFrom_Call {
+func (_c *MockMetadataStore_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockMetadataStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockMetadataStore_GetAllBooksFrom_Call {
+func (_c *MockMetadataStore_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockMetadataStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -503,12 +503,12 @@ func (_c *MockPlaylistStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -531,19 +531,19 @@ func (_mock *MockPlaylistStore) GetAllBooksFrom(afterID string, limit int) ([]da
 	return r0, r1
 }
 
-// MockPlaylistStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockPlaylistStore_GetAllBooksFrom_Call struct {
+// MockPlaylistStore_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockPlaylistStore_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockPlaylistStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockPlaylistStore_GetAllBooksFrom_Call {
-	return &MockPlaylistStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockPlaylistStore_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockPlaylistStore_GetAllBooksFullFrom_Call {
+	return &MockPlaylistStore_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockPlaylistStore_GetAllBooksFrom_Call {
+func (_c *MockPlaylistStore_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockPlaylistStore_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -561,12 +561,12 @@ func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Run(run func(afterID string, l
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetAllBooksFrom_Call {
+func (_c *MockPlaylistStore_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockPlaylistStore_GetAllBooksFrom_Call {
+func (_c *MockPlaylistStore_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockPlaylistStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -1703,12 +1703,12 @@ func (_c *MockOperationsStore_GetAllBooks_Call) RunAndReturn(run func(limit int,
 	return _c
 }
 
-// GetAllBooksFrom provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+// GetAllBooksFullFrom provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooksFrom")
+		panic("no return value specified for GetAllBooksFullFrom")
 	}
 
 	var r0 []database.Book
@@ -1731,19 +1731,19 @@ func (_mock *MockOperationsStore) GetAllBooksFrom(afterID string, limit int) ([]
 	return r0, r1
 }
 
-// MockOperationsStore_GetAllBooksFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFrom'
-type MockOperationsStore_GetAllBooksFrom_Call struct {
+// MockOperationsStore_GetAllBooksFullFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksFullFrom'
+type MockOperationsStore_GetAllBooksFullFrom_Call struct {
 	*mock.Call
 }
 
-// GetAllBooksFrom is a helper method to define mock.On call
+// GetAllBooksFullFrom is a helper method to define mock.On call
 //   - afterID string
 //   - limit int
-func (_e *MockOperationsStore_Expecter) GetAllBooksFrom(afterID any, limit any) *MockOperationsStore_GetAllBooksFrom_Call {
-	return &MockOperationsStore_GetAllBooksFrom_Call{Call: _e.mock.On("GetAllBooksFrom", afterID, limit)}
+func (_e *MockOperationsStore_Expecter) GetAllBooksFullFrom(afterID any, limit any) *MockOperationsStore_GetAllBooksFullFrom_Call {
+	return &MockOperationsStore_GetAllBooksFullFrom_Call{Call: _e.mock.On("GetAllBooksFullFrom", afterID, limit)}
 }
 
-func (_c *MockOperationsStore_GetAllBooksFrom_Call) Run(run func(afterID string, limit int)) *MockOperationsStore_GetAllBooksFrom_Call {
+func (_c *MockOperationsStore_GetAllBooksFullFrom_Call) Run(run func(afterID string, limit int)) *MockOperationsStore_GetAllBooksFullFrom_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -1761,12 +1761,12 @@ func (_c *MockOperationsStore_GetAllBooksFrom_Call) Run(run func(afterID string,
 	return _c
 }
 
-func (_c *MockOperationsStore_GetAllBooksFrom_Call) Return(books []database.Book, err error) *MockOperationsStore_GetAllBooksFrom_Call {
+func (_c *MockOperationsStore_GetAllBooksFullFrom_Call) Return(books []database.Book, err error) *MockOperationsStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(books, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_GetAllBooksFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockOperationsStore_GetAllBooksFrom_Call {
+func (_c *MockOperationsStore_GetAllBooksFullFrom_Call) RunAndReturn(run func(afterID string, limit int) ([]database.Book, error)) *MockOperationsStore_GetAllBooksFullFrom_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/server_search.go
+++ b/internal/server/server_search.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_search.go
-// version: 1.5.1
+// version: 1.5.2
 // guid: 12815699-f9ea-4788-9af3-2e854d710315
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package server
 
@@ -69,9 +69,9 @@ func (s *Server) buildSearchIndexIfEmpty() {
 			return
 		default:
 		}
-		books, err := store.GetAllBooksFrom(afterID, pageSize)
+		books, err := store.GetAllBooksFullFrom(afterID, pageSize)
 		if err != nil {
-			slog.Warn("search backfill GetAllBooksFrom", "err", err)
+			slog.Warn("search backfill GetAllBooksFullFrom", "err", err)
 			return
 		}
 		if len(books) == 0 {

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.0.3
+// version: 1.0.4
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
-// last-edited: 2026-06-24
+// last-edited: 2026-07-05
 
 package sweep
 
@@ -73,7 +73,7 @@ func (m *MockBookStore) GetAllBooks(limit, offset int) ([]database.Book, error) 
 // Stub out other required BookStore methods
 func (m *MockBookStore) CountPrimaryBooks() (int, error) { return 0, nil }
 func (m *MockBookStore) CountAllBooks() (int, error)     { return 0, nil }
-func (m *MockBookStore) GetAllBooksFrom(afterID string, limit int) ([]database.Book, error) {
+func (m *MockBookStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	return nil, nil
 }
 func (m *MockBookStore) CreateBook(book *database.Book) (*database.Book, error) { return nil, nil }


### PR DESCRIPTION
STOREFID Phase 1 (spec §6 consolidate + naming). No behavior change.
- **Unexport** the 3 zero-caller `_Pebble` full-fallback twins → internal.
- **Rename** `GetAllBooksFrom` → `GetAllBooksFullFrom` (2 callers incl. the BookSignatureScan fix) — kills the worst Full/slim name collision.
- **Doc-contract** the 9 memdb-slim getters with their exact stripped-field lists + full-fetch escape hatch.
- Scoped Store-mock regen (verified: only the renamed/removed methods; not a repo-wide v3.7.1 regen). `go build ./...` + `go vet` clean; 19 files, +205/-135.