### PR TITLE
feat(store): add BookCore projection type + Book.Core() (STOREFID P2-T1)

### DIFF
--- a/internal/database/bookcore.go
+++ b/internal/database/bookcore.go
@@ -1,0 +1,269 @@
+// file: internal/database/bookcore.go
+// version: 1.0.0
+// guid: 7f3c1e28-9a4d-4b61-8c2f-bookcore000001
+// last-edited: 2026-07-05
+
+package database
+
+import "time"
+
+// BookCore is the compiler-enforced slim projection of Book: every Book field
+// EXCEPT the nine heavy, rarely-queried fields that stripBookForMemdb clears
+// before a Book is inserted into the in-memory radix tree (see memdb_strip.go).
+//
+// The excluded ("heavy") fields, which live ONLY on Book, are:
+//
+//	Description, VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,
+//	BookSigBuiltAt, BookSigCoveragePct, Author, Series
+//
+// BookCore therefore describes exactly the payload a memdb-resident Book is
+// guaranteed to carry. Making that partition a real type lets memdb-backed code
+// paths state, at compile time, that they never touch a stripped field. This is
+// purely additive today — nothing returns BookCore yet; Phase 3 wires it in.
+//
+// Field declarations (names, types, and struct tags) are copied verbatim from
+// Book; the two reflection tests in bookcore_test.go lock the partition and the
+// copy so drift is impossible.
+type BookCore struct {
+	ID             string `json:"id"` // ULID format
+	Title          string `json:"title"`
+	AuthorID       *int   `json:"author_id,omitempty"`
+	SeriesID       *int   `json:"series_id,omitempty"`
+	SeriesSequence *int   `json:"series_sequence,omitempty"`
+	FilePath       string `json:"file_path"`
+	Format         string `json:"format,omitempty"`
+	Duration       *int   `json:"duration,omitempty"`
+	// Extended metadata (optional)
+	WorkID   *string `json:"work_id,omitempty"`
+	Narrator *string `json:"narrator,omitempty"`
+	Edition  *string `json:"edition,omitempty"`
+	// Description is a heavy field — omitted from BookCore.
+	Language             *string `json:"language,omitempty"`
+	Publisher            *string `json:"publisher,omitempty"`
+	Genre                *string `json:"genre,omitempty"`
+	PrintYear            *int    `json:"print_year,omitempty"`
+	AudiobookReleaseYear *int    `json:"audiobook_release_year,omitempty"`
+	ISBN10               *string `json:"isbn10,omitempty"`
+	ISBN13               *string `json:"isbn13,omitempty"`
+	ASIN                 *string `json:"asin,omitempty"`
+	// External provider IDs
+	OpenLibraryID *string `json:"open_library_id,omitempty"`
+	HardcoverID   *string `json:"hardcover_id,omitempty"`
+	GoogleBooksID *string `json:"google_books_id,omitempty"`
+	// iTunes import fields
+	ITunesPersistentID *string    `json:"itunes_persistent_id,omitempty"`
+	ITunesDateAdded    *time.Time `json:"itunes_date_added,omitempty"`
+	ITunesPlayCount    *int       `json:"itunes_play_count,omitempty"`
+	ITunesLastPlayed   *time.Time `json:"itunes_last_played,omitempty"`
+	ITunesRating       *int       `json:"itunes_rating,omitempty"`
+	ITunesBookmark     *int64     `json:"itunes_bookmark,omitempty"`
+	ITunesImportSource *string    `json:"itunes_import_source,omitempty"`
+	// Deprecated: use book_files.itunes_path instead. Will be removed in a future migration.
+	ITunesPath       *string `json:"itunes_path,omitempty"`
+	OriginalFilename *string `json:"original_filename,omitempty"`
+	// Media info fields
+	Bitrate    *int    `json:"bitrate_kbps,omitempty"`
+	Codec      *string `json:"codec,omitempty"`
+	SampleRate *int    `json:"sample_rate_hz,omitempty"`
+	Channels   *int    `json:"channels,omitempty"`
+	BitDepth   *int    `json:"bit_depth,omitempty"`
+	Quality    *string `json:"quality,omitempty"`
+	// Version management
+	IsPrimaryVersion *bool   `json:"is_primary_version,omitempty"`
+	VersionGroupID   *string `json:"version_group_id,omitempty"`
+	// VersionNotes is a heavy field — omitted from BookCore.
+	// File hash tracking for deduplication
+	FileHash *string `json:"file_hash,omitempty"`
+	FileSize *int64  `json:"file_size,omitempty"`
+	// Lifecycle tracking
+	OriginalFileHash    *string    `json:"original_file_hash,omitempty"`
+	OrganizedFileHash   *string    `json:"organized_file_hash,omitempty"`
+	LibraryState        *string    `json:"library_state,omitempty"`
+	Quantity            *int       `json:"quantity,omitempty"`
+	MarkedForDeletion   *bool      `json:"marked_for_deletion,omitempty"`
+	MarkedForDeletionAt *time.Time `json:"marked_for_deletion_at,omitempty"`
+	// QuarantineReason is set when a file is moved to .failed/. Non-nil means quarantined.
+	QuarantineReason *string    `json:"quarantine_reason,omitempty"`
+	QuarantinedAt    *time.Time `json:"quarantined_at,omitempty"`
+	CreatedAt        *time.Time `json:"created_at,omitempty"`
+	// UpdatedAt is set on every DB write (system-level).
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	// MetadataUpdatedAt is set only when user-visible metadata fields change.
+	MetadataUpdatedAt *time.Time `json:"metadata_updated_at,omitempty"`
+	// LastWrittenAt is set when metadata is written back to the audio files on disk.
+	LastWrittenAt *time.Time `json:"last_written_at,omitempty"`
+	// LastOrganizeOperationID is the operation ID of the last organize run that processed this book.
+	LastOrganizeOperationID *string `json:"last_organize_operation_id,omitempty"`
+	// LastOrganizedAt is when this book was last stamped by an organize run (organized, re-organized, or confirmed correct).
+	LastOrganizedAt *time.Time `json:"last_organized_at,omitempty"`
+	// MetadataReviewStatus tracks manual metadata matching: null, "no_match", "matched".
+	MetadataReviewStatus *string `json:"metadata_review_status,omitempty"`
+	// MetadataSource records which provider supplied the last applied metadata.
+	MetadataSource *string `json:"metadata_source,omitempty"`
+	// BookSigV1, BookSigSegments, BookSigBuiltAt, BookSigV1Mask, BookSigCoveragePct
+	// are heavy fields — omitted from BookCore.
+	// ITunesSyncStatus tracks whether this book's metadata is in sync with the iTunes library.
+	ITunesSyncStatus *string `json:"itunes_sync_status,omitempty"`
+	// AudibleRuntimeMin is the runtime reported by Audible (in minutes) for the matched product.
+	AudibleRuntimeMin *int `json:"audible_runtime_min,omitempty"`
+	// DurationVerifiedAt is stamped by the duration-reextract op.
+	DurationVerifiedAt *time.Time `json:"duration_verified_at,omitempty"`
+	// MetadataSourceHash is sha256("{source}:{canonical_id}") set during metadata apply.
+	MetadataSourceHash *string `json:"metadata_source_hash,omitempty"`
+	// MergedIntoBookID is set when this book has been absorbed into a consolidated book.
+	MergedIntoBookID *string `json:"merged_into_book_id,omitempty"`
+	// Audible ratings (1–5 scale).
+	AudibleRatingOverall     *float64 `json:"audible_rating_overall,omitempty"`
+	AudibleRatingPerformance *float64 `json:"audible_rating_performance,omitempty"` // narrator/production
+	AudibleRatingStory       *float64 `json:"audible_rating_story,omitempty"`       // story/content
+	AudibleRatingCount       *int     `json:"audible_rating_count,omitempty"`
+	AudibleNumReviews        *int     `json:"audible_num_reviews,omitempty"`
+	// Google Books rating (1–5 scale).
+	GoogleRatingAverage *float64 `json:"google_rating_average,omitempty"`
+	GoogleRatingCount   *int     `json:"google_rating_count,omitempty"`
+	// User personal ratings (1–5 scale, independent of community ratings).
+	UserRatingOverall     *float64 `json:"user_rating_overall,omitempty"`
+	UserRatingStory       *float64 `json:"user_rating_story,omitempty"`
+	UserRatingPerformance *float64 `json:"user_rating_performance,omitempty"`
+	UserRatingNotes       *string  `json:"user_rating_notes,omitempty"`
+	// Cover art
+	CoverURL *string `json:"cover_url,omitempty"`
+	// Narrators as JSON array
+	NarratorsJSON *string `json:"narrators_json,omitempty"`
+	// SourceImportPath is the top-level import-path folder this book was FIRST discovered in.
+	SourceImportPath *string `json:"source_import_path,omitempty"`
+	// Scan cache for incremental scanning (set by scanner, not user-facing)
+	LastScanMtime *int64 `json:"last_scan_mtime,omitempty"`
+	LastScanSize  *int64 `json:"last_scan_size,omitempty"`
+	NeedsRescan   *bool  `json:"needs_rescan,omitempty"`
+	// IntroTranscription is the raw Whisper transcript of the first ~30 seconds.
+	IntroTranscription *string `json:"intro_transcription,omitempty"`
+	// TranscribedTitle / TranscribedAuthor / TranscribedNarrator parsed from IntroTranscription.
+	TranscribedTitle    *string `json:"transcribed_title,omitempty"`
+	TranscribedAuthor   *string `json:"transcribed_author,omitempty"`
+	TranscribedNarrator *string `json:"transcribed_narrator,omitempty"`
+	// IntroTranscribedAt is when IntroTranscription was last populated.
+	IntroTranscribedAt *time.Time `json:"intro_transcribed_at,omitempty"`
+	// TranscribeStatus records the outcome of the most recent transcription attempt.
+	TranscribeStatus *string `json:"transcribe_status,omitempty"`
+	// TranscribeError holds a short human-readable detail for a non-ok status.
+	TranscribeError *string `json:"transcribe_error,omitempty"`
+	// TranscribeAttemptedAt is when the most recent transcription attempt ran.
+	TranscribeAttemptedAt *time.Time `json:"transcribe_attempted_at,omitempty"`
+	// Fingerprinting fields (computed, not stored in DB)
+	FingerprintStatus      string     `json:"fingerprint_status,omitempty"` // "none", "partial", "complete"
+	FingerprintedFileCount int        `json:"fingerprinted_file_count,omitempty"`
+	TotalFileCount         int        `json:"total_file_count,omitempty"`
+	CoveragePercent        int        `json:"coverage_percent,omitempty"`
+	LastFingerprintedAt    *time.Time `json:"last_fingerprinted_at,omitempty"`
+	// Related objects (populated via joins, not stored in DB).
+	// Author and Series are heavy fields — omitted from BookCore.
+	Authors              []BookAuthor                       `json:"authors,omitempty" db:"-"`
+	MetadataProvenance   map[string]MetadataProvenanceEntry `json:"metadata_provenance,omitempty" db:"-"`
+	MetadataProvenanceAt *time.Time                         `json:"metadata_provenance_at,omitempty" db:"-"`
+}
+
+// Core returns the BookCore projection of b — a copy of every Book field that
+// survives the memdb strip (i.e. every field except the nine heavy ones listed
+// on BookCore). It is purely a projection: pointer, slice, and map fields are
+// copied by reference, exactly as a struct assignment would. TestBookCoreCopiesAllFields
+// asserts that no field is silently dropped here.
+func (b *Book) Core() BookCore {
+	return BookCore{
+		ID:                       b.ID,
+		Title:                    b.Title,
+		AuthorID:                 b.AuthorID,
+		SeriesID:                 b.SeriesID,
+		SeriesSequence:           b.SeriesSequence,
+		FilePath:                 b.FilePath,
+		Format:                   b.Format,
+		Duration:                 b.Duration,
+		WorkID:                   b.WorkID,
+		Narrator:                 b.Narrator,
+		Edition:                  b.Edition,
+		Language:                 b.Language,
+		Publisher:                b.Publisher,
+		Genre:                    b.Genre,
+		PrintYear:                b.PrintYear,
+		AudiobookReleaseYear:     b.AudiobookReleaseYear,
+		ISBN10:                   b.ISBN10,
+		ISBN13:                   b.ISBN13,
+		ASIN:                     b.ASIN,
+		OpenLibraryID:            b.OpenLibraryID,
+		HardcoverID:              b.HardcoverID,
+		GoogleBooksID:            b.GoogleBooksID,
+		ITunesPersistentID:       b.ITunesPersistentID,
+		ITunesDateAdded:          b.ITunesDateAdded,
+		ITunesPlayCount:          b.ITunesPlayCount,
+		ITunesLastPlayed:         b.ITunesLastPlayed,
+		ITunesRating:             b.ITunesRating,
+		ITunesBookmark:           b.ITunesBookmark,
+		ITunesImportSource:       b.ITunesImportSource,
+		ITunesPath:               b.ITunesPath,
+		OriginalFilename:         b.OriginalFilename,
+		Bitrate:                  b.Bitrate,
+		Codec:                    b.Codec,
+		SampleRate:               b.SampleRate,
+		Channels:                 b.Channels,
+		BitDepth:                 b.BitDepth,
+		Quality:                  b.Quality,
+		IsPrimaryVersion:         b.IsPrimaryVersion,
+		VersionGroupID:           b.VersionGroupID,
+		FileHash:                 b.FileHash,
+		FileSize:                 b.FileSize,
+		OriginalFileHash:         b.OriginalFileHash,
+		OrganizedFileHash:        b.OrganizedFileHash,
+		LibraryState:             b.LibraryState,
+		Quantity:                 b.Quantity,
+		MarkedForDeletion:        b.MarkedForDeletion,
+		MarkedForDeletionAt:      b.MarkedForDeletionAt,
+		QuarantineReason:         b.QuarantineReason,
+		QuarantinedAt:            b.QuarantinedAt,
+		CreatedAt:                b.CreatedAt,
+		UpdatedAt:                b.UpdatedAt,
+		MetadataUpdatedAt:        b.MetadataUpdatedAt,
+		LastWrittenAt:            b.LastWrittenAt,
+		LastOrganizeOperationID:  b.LastOrganizeOperationID,
+		LastOrganizedAt:          b.LastOrganizedAt,
+		MetadataReviewStatus:     b.MetadataReviewStatus,
+		MetadataSource:           b.MetadataSource,
+		ITunesSyncStatus:         b.ITunesSyncStatus,
+		AudibleRuntimeMin:        b.AudibleRuntimeMin,
+		DurationVerifiedAt:       b.DurationVerifiedAt,
+		MetadataSourceHash:       b.MetadataSourceHash,
+		MergedIntoBookID:         b.MergedIntoBookID,
+		AudibleRatingOverall:     b.AudibleRatingOverall,
+		AudibleRatingPerformance: b.AudibleRatingPerformance,
+		AudibleRatingStory:       b.AudibleRatingStory,
+		AudibleRatingCount:       b.AudibleRatingCount,
+		AudibleNumReviews:        b.AudibleNumReviews,
+		GoogleRatingAverage:      b.GoogleRatingAverage,
+		GoogleRatingCount:        b.GoogleRatingCount,
+		UserRatingOverall:        b.UserRatingOverall,
+		UserRatingStory:          b.UserRatingStory,
+		UserRatingPerformance:    b.UserRatingPerformance,
+		UserRatingNotes:          b.UserRatingNotes,
+		CoverURL:                 b.CoverURL,
+		NarratorsJSON:            b.NarratorsJSON,
+		SourceImportPath:         b.SourceImportPath,
+		LastScanMtime:            b.LastScanMtime,
+		LastScanSize:             b.LastScanSize,
+		NeedsRescan:              b.NeedsRescan,
+		IntroTranscription:       b.IntroTranscription,
+		TranscribedTitle:         b.TranscribedTitle,
+		TranscribedAuthor:        b.TranscribedAuthor,
+		TranscribedNarrator:      b.TranscribedNarrator,
+		IntroTranscribedAt:       b.IntroTranscribedAt,
+		TranscribeStatus:         b.TranscribeStatus,
+		TranscribeError:          b.TranscribeError,
+		TranscribeAttemptedAt:    b.TranscribeAttemptedAt,
+		FingerprintStatus:        b.FingerprintStatus,
+		FingerprintedFileCount:   b.FingerprintedFileCount,
+		TotalFileCount:           b.TotalFileCount,
+		CoveragePercent:          b.CoveragePercent,
+		LastFingerprintedAt:      b.LastFingerprintedAt,
+		Authors:                  b.Authors,
+		MetadataProvenance:       b.MetadataProvenance,
+		MetadataProvenanceAt:     b.MetadataProvenanceAt,
+	}
+}

--- a/internal/database/bookcore_test.go
+++ b/internal/database/bookcore_test.go
@@ -1,0 +1,170 @@
+// file: internal/database/bookcore_test.go
+// version: 1.0.0
+// guid: b2d9a610-4f37-4a8e-9c15-bookcoretest01
+// last-edited: 2026-07-05
+
+package database
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// heavyFields are the nine Book fields that BookCore intentionally omits — the
+// exact set that stripBookForMemdb clears (see memdb_strip.go). This is the
+// authoritative partition; the tests below lock BookCore to it.
+var heavyFields = map[string]struct{}{
+	"Description":        {},
+	"VersionNotes":       {},
+	"BookSigV1":          {},
+	"BookSigV1Mask":      {},
+	"BookSigSegments":    {},
+	"BookSigBuiltAt":     {},
+	"BookSigCoveragePct": {},
+	"Author":             {},
+	"Series":             {},
+}
+
+func structFieldNames(t reflect.Type) map[string]struct{} {
+	names := make(map[string]struct{}, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		names[t.Field(i).Name] = struct{}{}
+	}
+	return names
+}
+
+// TestBookCoreIsBookMinusHeavyFields locks the field partition: BookCore must be
+// Book minus exactly the nine heavy fields, and it must carry every shared
+// field's struct tag over verbatim.
+func TestBookCoreIsBookMinusHeavyFields(t *testing.T) {
+	bookT := reflect.TypeOf(Book{})
+	coreT := reflect.TypeOf(BookCore{})
+
+	bookNames := structFieldNames(bookT)
+	coreNames := structFieldNames(coreT)
+
+	// (1) BookCore must not introduce any field that Book lacks.
+	for name := range coreNames {
+		if _, ok := bookNames[name]; !ok {
+			t.Errorf("BookCore has field %q not present on Book", name)
+		}
+	}
+
+	// (2) The Book fields absent from BookCore must be EXACTLY the 9 heavy ones.
+	missing := map[string]struct{}{}
+	for name := range bookNames {
+		if _, ok := coreNames[name]; !ok {
+			missing[name] = struct{}{}
+		}
+	}
+	if !reflect.DeepEqual(missing, heavyFields) {
+		t.Errorf("Book\\BookCore field-name diff = %v, want exactly the 9 heavy fields %v", keys(missing), keys(heavyFields))
+	}
+
+	// (3) Every field shared by both structs must carry the identical struct tag
+	// (json + db) verbatim, so the projection can never quietly diverge.
+	for name := range coreNames {
+		bookField, ok := bookT.FieldByName(name)
+		if !ok {
+			continue // already reported by check (1)
+		}
+		coreField, _ := coreT.FieldByName(name)
+		if bookField.Tag != coreField.Tag {
+			t.Errorf("field %q struct tag mismatch:\n  Book:     %q\n  BookCore: %q", name, bookField.Tag, coreField.Tag)
+		}
+	}
+}
+
+// TestBookCoreCopiesAllFields populates every Book field with a non-zero value,
+// projects to BookCore via Core(), and asserts every BookCore field was copied.
+// This catches a Core() that forgets a field (a silent-drop bug): the dropped
+// field would stay zero while its Book counterpart is non-zero.
+//
+// Iterating reflectively means new fields are covered automatically. Crucially,
+// the test first asserts the Book source field is itself non-zero — otherwise a
+// setNonZero gap would let a zero==zero comparison pass a genuine drop.
+func TestBookCoreCopiesAllFields(t *testing.T) {
+	var b Book
+	setNonZero(reflect.ValueOf(&b).Elem())
+
+	core := b.Core()
+	coreV := reflect.ValueOf(core)
+	coreT := coreV.Type()
+	bookV := reflect.ValueOf(b)
+
+	for i := 0; i < coreT.NumField(); i++ {
+		name := coreT.Field(i).Name
+
+		src := bookV.FieldByName(name)
+		if !src.IsValid() {
+			t.Errorf("BookCore field %q has no matching Book field", name)
+			continue
+		}
+		// Guard the guard: the source must be non-zero, or the copy assertion
+		// below is vacuous (zero == zero would pass a real drop).
+		if src.IsZero() {
+			t.Errorf("test setup: Book.%s was not populated non-zero by setNonZero; the copy check for it would be vacuous", name)
+			continue
+		}
+		got := coreV.Field(i)
+		if !reflect.DeepEqual(got.Interface(), src.Interface()) {
+			t.Errorf("Core() dropped or miscopied field %q:\n  Book:     %#v\n  BookCore: %#v", name, src.Interface(), got.Interface())
+		}
+	}
+}
+
+// setNonZero recursively fills v with non-zero values so that every leaf field
+// is distinguishable from its zero value. Handles pointers, structs (with
+// time.Time special-cased so its unexported fields aren't touched), slices,
+// maps, interfaces, and scalars.
+func setNonZero(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Ptr:
+		v.Set(reflect.New(v.Type().Elem()))
+		setNonZero(v.Elem())
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			v.Set(reflect.ValueOf(time.Unix(1_730_000_000, 0).UTC()))
+			return
+		}
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if f.CanSet() {
+				setNonZero(f)
+			}
+		}
+	case reflect.Slice:
+		s := reflect.MakeSlice(v.Type(), 1, 1)
+		setNonZero(s.Index(0))
+		v.Set(s)
+	case reflect.Map:
+		m := reflect.MakeMap(v.Type())
+		k := reflect.New(v.Type().Key()).Elem()
+		setNonZero(k)
+		val := reflect.New(v.Type().Elem()).Elem()
+		setNonZero(val)
+		m.SetMapIndex(k, val)
+		v.Set(m)
+	case reflect.Interface:
+		v.Set(reflect.ValueOf("nonzero"))
+	case reflect.String:
+		v.SetString("nonzero")
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(1)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(1.5)
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
STOREFID Phase 2. Additive — new files only, store.go untouched. `BookCore` = `Book` minus the 9 memdb-stripped heavy fields (Description, VersionNotes, BookSig*, Author, Series) = 95 fields; json+db tags carried verbatim. `Book.Core()` projection + two reflection tests: name-set parity (diff == exactly the 9) and copy-completeness (fills every Book field non-zero, asserts each BookCore field copied; asserts source non-zero first so zero==zero can't mask a drop). Build/vet/scoped-race green; full `internal/database` suite green in-worker.