### PR TITLE
refactor(store): migrate GetBookFilesForIDs -> GetBookFilesForIDsCore + fix P2 test-helper collision (STOREFID P3-W1)

### DIFF
--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/audiobook_service_unit_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-01
+// last-edited: 2026-07-05
 
 package audiobooks
 
@@ -540,8 +540,8 @@ func TestAudiobookService_EnrichAudiobooksWithNames_WithAuthorAndSeries(t *testi
 	}
 
 	// aggregateFileMetadata (called by EnrichAudiobooksWithNames) tries
-	// GetBookFilesForIDs first, then falls back to per-book GetBookFiles.
-	// MockStore doesn't implement GetBookFilesForIDs, so the per-book path
+	// GetBookFilesForIDsCore first, then falls back to per-book GetBookFiles.
+	// MockStore doesn't implement GetBookFilesForIDsCore, so the per-book path
 	// is taken. The test doesn't care about file aggregates — return empty.
 	mockStore.EXPECT().GetBookFiles("e1").Return(nil, nil).Maybe()
 	mockStore.EXPECT().GetBookFiles("e2").Return(nil, nil).Maybe()

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package audiobooks
 
@@ -737,7 +737,7 @@ func splitMultipleNames(name string) []string {
 }
 
 // aggregateFileMetadata calculates total duration and file size from files
-// for each book. Uses GetBookFilesForIDs to fetch ONLY the files for the
+// for each book. Uses GetBookFilesForIDsCore to fetch ONLY the files for the
 // passed-in books — not GetAllBookFiles, which materialized all 308K+
 // book_file rows (~46GB heap) on every library list query and trampolined
 // the process to 67GB the moment the filter-pushdown warmer started.
@@ -758,9 +758,17 @@ func (svc *AudiobookService) aggregateFileMetadata(books []database.Book) {
 // book_id index, with the same unwrap + fallback semantics as the original
 // aggregateFileMetadata. Returns a non-nil map (possibly empty) so callers
 // can safely range over it without nil checks.
-func (svc *AudiobookService) FetchBookFilesForBooks(books []database.Book) map[string][]database.BookFile {
+//
+// Core-typed (STOREFID): returns BookFileCore, not BookFile. Every current
+// consumer of this map (duration/file-size aggregation, fingerprint_status
+// badge via fingerprint.FileWithFingerprint) only reads light/retained
+// fields, so this is not a behavior change — see
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md. A future
+// caller that needs a heavy fingerprint-diagnostic field must fetch it via
+// svc.store.GetBookFiles(bookID) instead of adding it here.
+func (svc *AudiobookService) FetchBookFilesForBooks(books []database.Book) map[string][]database.BookFileCore {
 	if svc.store == nil || len(books) == 0 {
-		return map[string][]database.BookFile{}
+		return map[string][]database.BookFileCore{}
 	}
 	bookIDs := make([]string, 0, len(books))
 	for _, b := range books {
@@ -768,16 +776,16 @@ func (svc *AudiobookService) FetchBookFilesForBooks(books []database.Book) map[s
 	}
 
 	type batchFilesStore interface {
-		GetBookFilesForIDs(ids []string) (map[string][]database.BookFile, error)
+		GetBookFilesForIDsCore(ids []string) (map[string][]database.BookFileCore, error)
 	}
-	var filesByBookID map[string][]database.BookFile
+	var filesByBookID map[string][]database.BookFileCore
 	if fs, ok := svc.store.(batchFilesStore); ok {
-		if m, err := fs.GetBookFilesForIDs(bookIDs); err == nil {
+		if m, err := fs.GetBookFilesForIDsCore(bookIDs); err == nil {
 			filesByBookID = m
 		}
 	} else if uw, ok := svc.store.(interface{ Unwrap() database.Store }); ok {
 		if fs, ok2 := uw.Unwrap().(batchFilesStore); ok2 {
-			if m, err := fs.GetBookFilesForIDs(bookIDs); err == nil {
+			if m, err := fs.GetBookFilesForIDsCore(bookIDs); err == nil {
 				filesByBookID = m
 			}
 		}
@@ -785,28 +793,32 @@ func (svc *AudiobookService) FetchBookFilesForBooks(books []database.Book) map[s
 	if filesByBookID == nil {
 		// Store doesn't expose the batched method — fall back to per-book
 		// fetch. Slow (N+1) but bounded by len(books) (typically 20).
-		filesByBookID = make(map[string][]database.BookFile, len(books))
+		filesByBookID = make(map[string][]database.BookFileCore, len(books))
 		for _, id := range bookIDs {
 			files, err := svc.store.GetBookFiles(id)
 			if err != nil {
 				slog.Warn("FetchBookFilesForBooks: GetBookFiles failed", "book_id", id, "err", err)
 				continue
 			}
-			filesByBookID[id] = files
+			cores := make([]database.BookFileCore, len(files))
+			for i, f := range files {
+				cores[i] = f.Core()
+			}
+			filesByBookID[id] = cores
 		}
 	}
 	return filesByBookID
 }
 
 // aggregateFileMetadataWithFiles applies duration/file-size aggregation
-// using a pre-fetched files map. Skips the GetBookFilesForIDs call,
+// using a pre-fetched files map. Skips the GetBookFilesForIDsCore call,
 // allowing callers that already have the map to reuse it.
-func (svc *AudiobookService) aggregateFileMetadataWithFiles(books []database.Book, filesByBookID map[string][]database.BookFile) {
+func (svc *AudiobookService) aggregateFileMetadataWithFiles(books []database.Book, filesByBookID map[string][]database.BookFileCore) {
 	if len(books) == 0 {
 		return
 	}
 	if filesByBookID == nil {
-		filesByBookID = map[string][]database.BookFile{}
+		filesByBookID = map[string][]database.BookFileCore{}
 	}
 
 	bookIDMap := make(map[string]int, len(books))

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-06-28
+// last-edited: 2026-07-05
 
 package audiobooks
 
@@ -422,7 +422,7 @@ func (svc *AudiobookService) CountAudiobooksFiltered(ctx context.Context, filter
 //
 // This is the fetch-then-enrich wrapper. Callers that have already fetched
 // the book_files map should use EnrichAudiobooksWithNamesAndFiles to avoid
-// a duplicate GetBookFilesForIDs call.
+// a duplicate GetBookFilesForIDsCore call.
 func (svc *AudiobookService) EnrichAudiobooksWithNames(books []database.Book) []AudiobookDetail {
 	filesByBookID := svc.FetchBookFilesForBooks(books)
 	return svc.EnrichAudiobooksWithNamesAndFiles(books, filesByBookID)
@@ -430,9 +430,9 @@ func (svc *AudiobookService) EnrichAudiobooksWithNames(books []database.Book) []
 
 // EnrichAudiobooksWithNamesAndFiles is the variant that accepts a pre-fetched
 // files map and threads it into aggregation, avoiding a duplicate
-// GetBookFilesForIDs call when the caller already has the map (e.g. the
+// GetBookFilesForIDsCore call when the caller already has the map (e.g. the
 // list handler uses it again for fingerprint compute).
-func (svc *AudiobookService) EnrichAudiobooksWithNamesAndFiles(books []database.Book, filesByBookID map[string][]database.BookFile) []AudiobookDetail {
+func (svc *AudiobookService) EnrichAudiobooksWithNamesAndFiles(books []database.Book, filesByBookID map[string][]database.BookFileCore) []AudiobookDetail {
 	// Aggregate file metadata for all books at once (avoids N+1)
 	svc.aggregateFileMetadataWithFiles(books, filesByBookID)
 

--- a/internal/database/bookfile_fingerprint.go
+++ b/internal/database/bookfile_fingerprint.go
@@ -1,7 +1,7 @@
 // file: internal/database/bookfile_fingerprint.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d1e2f3g4-h5i6-7890-jkml-no1234567890
-// last-edited: 2026-06-10
+// last-edited: 2026-07-05
 
 package database
 
@@ -42,4 +42,32 @@ func (bf *BookFile) GetUpdatedAt() time.Time {
 		return time.Time{}
 	}
 	return bf.UpdatedAt
+}
+
+// GetAcoustIDSeg0 satisfies fingerprint.FileWithFingerprint for BookFileCore
+// (the STOREFID-typed projection returned by GetBookFilesForIDsCore).
+// BookFileCore never carries the raw AcoustIDSeg0 field (it is one of the
+// heavy fields stripped from the memdb projection — see BookFileCore's doc
+// comment), so this always uses the AcoustIDFingerprintDurationSec presence
+// proxy described on (*BookFile).GetAcoustIDSeg0 above. This is not a
+// behavior change for memdb-sourced callers: AcoustIDSeg0 is already always
+// "" for memdb rows, so (*BookFile).GetAcoustIDSeg0 already fell through to
+// this same proxy for every caller of the old GetBookFilesForIDs.
+func (c *BookFileCore) GetAcoustIDSeg0() string {
+	if c == nil {
+		return ""
+	}
+	if c.AcoustIDFingerprintDurationSec > 0 {
+		return "wf" // non-empty sentinel; callers only test != ""
+	}
+	return ""
+}
+
+// GetUpdatedAt returns the UpdatedAt field for use with
+// fingerprint.FileWithFingerprint interface.
+func (c *BookFileCore) GetUpdatedAt() time.Time {
+	if c == nil {
+		return time.Time{}
+	}
+	return c.UpdatedAt
 }

--- a/internal/database/bookfilecore_test.go
+++ b/internal/database/bookfilecore_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/bookfilecore_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 29325171-4866-4142-82c6-e010f724ae5e
 // last-edited: 2026-07-05
 
@@ -30,13 +30,8 @@ var strippedBookFileFields = []string{
 	"FingerprintFailureReason",
 }
 
-func structFieldNames(t reflect.Type) map[string]struct{} {
-	names := make(map[string]struct{}, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		names[t.Field(i).Name] = struct{}{}
-	}
-	return names
-}
+// structFieldNames is defined once in bookcore_test.go (same package) and
+// reused here — both *core_test.go files need the identical helper.
 
 // TestBookFileCoreIsBookFileMinusHeavyFields asserts the field-name set of
 // BookFileCore equals BookFile's set minus EXACTLY the stripped heavy set.

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package database
 
@@ -774,15 +774,22 @@ func (m *MemStore) ComputeLibraryStats(rootDir string, importPaths []ImportPath)
 	return stats, nil
 }
 
-// GetBookFilesForIDs returns book files grouped by bookID, using the memdb
-// book_id index — O(sum-of-files-for-IDs), NOT O(all 308K book_files) like
-// the Pebble full-scan implementation. For a 500-book page query, this drops
-// from ~15s to <5ms.
+// GetBookFilesForIDsCore returns book files grouped by bookID, as the
+// BookFileCore projection, using the memdb book_id index —
+// O(sum-of-files-for-IDs), NOT O(all 308K book_files) like the Pebble
+// full-scan implementation. For a 500-book page query, this drops from ~15s
+// to <5ms.
 //
 // Returns an empty map for empty input. Caller-supplied IDs absent from
 // memdb appear as missing keys in the result (caller filters as needed).
-func (m *MemStore) GetBookFilesForIDs(bookIDs []string) (map[string][]BookFile, error) {
-	result := make(map[string][]BookFile, len(bookIDs))
+//
+// Core-typed (STOREFID): memdb rows are already the stripped BookFile
+// projection (stripBookFileForMemdb), so .Core() here is a lossless
+// re-projection onto BookFileCore — no additional fields are dropped beyond
+// what memdb already strips. See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (m *MemStore) GetBookFilesForIDsCore(bookIDs []string) (map[string][]BookFileCore, error) {
+	result := make(map[string][]BookFileCore, len(bookIDs))
 	if len(bookIDs) == 0 {
 		return result, nil
 	}
@@ -798,7 +805,7 @@ func (m *MemStore) GetBookFilesForIDs(bookIDs []string) (map[string][]BookFile, 
 			if !ok {
 				continue
 			}
-			result[id] = append(result[id], *bf)
+			result[id] = append(result[id], bf.Core())
 		}
 	}
 	return result, nil

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
-// last-edited: 2026-06-11
+// last-edited: 2026-07-05
 
 package database
 
@@ -72,8 +72,9 @@ func stripBookForMemdb(src *Book) *Book {
 // AcoustIDSeg0..6 strip rationale (fable5 T019):
 //
 // Before T013: Seg0 was the last live memdb reader — fingerprint.ComputeFingerprintFields
-// called GetAcoustIDSeg0() on memdb-sourced BookFile rows (via GetBookFilesForIDs)
-// to compute the per-book fingerprint_status badge on every /api/v1/audiobooks list.
+// called GetAcoustIDSeg0() on memdb-sourced BookFile rows (via GetBookFilesForIDsCore,
+// renamed from GetBookFilesForIDs in STOREFID Phase 3) to compute the per-book
+// fingerprint_status badge on every /api/v1/audiobooks list.
 // Seg1..6 were read by MemStore.GetBookFileByAcoustIDFuzzy (the O(N) dedup path).
 //
 // After T013: the O(N) fuzzy scan (GetBookFileByAcoustIDFuzzy) is retired — the
@@ -100,7 +101,7 @@ func stripBookFileForMemdb(src *BookFile) *BookFile {
 	// AcoustIDSeg0..6: deprecated 7-segment fields (store.go:685-694).
 	// Stripped as of fable5 T019 — all memdb readers retired by T013:
 	//   - O(N) fuzzy scan (GetBookFileByAcoustIDFuzzy): deleted by T013.
-	//   - fingerprint_status badge (GetAcoustIDSeg0 via GetBookFilesForIDs):
+	//   - fingerprint_status badge (GetAcoustIDSeg0 via GetBookFilesForIDsCore):
 	//     migrated to AcoustIDFingerprintDurationSec proxy in T019.
 	// Pebble-direct paths (dedup engine, handler_files, dedup comparison
 	// handler) remain unaffected — they read via GetBookFiles / GetBookFile.

--- a/internal/database/memdb_strip_test.go
+++ b/internal/database/memdb_strip_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: e6f7a8b9-c0d1-4e2f-3a4b-5c6d7e8f9012
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package database
 
@@ -199,7 +199,7 @@ func TestStripBookFileForMemdb_AlreadyEmpty(t *testing.T) {
 // even when AcoustIDSeg0 is empty (stripped by stripBookFileForMemdb).
 //
 // This is the regression test for the fingerprint_status badge path:
-//   GetBookFilesForIDs → ComputeFingerprintFields → GetAcoustIDSeg0()
+//   GetBookFilesForIDsCore → ComputeFingerprintFields → GetAcoustIDSeg0()
 //
 // Without this fallback, stripping Seg0 from memdb would make every book
 // appear as "fingerprint_status: none" on the /api/v1/audiobooks list.

--- a/internal/database/pebble_store_authors.go
+++ b/internal/database/pebble_store_authors.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_authors.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1f8b9fd2-e424-4a09-9ee4-7b5b64660605
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package database
 
@@ -634,9 +634,9 @@ func (p *PebbleStore) GetAllAuthorFileCounts_Pebble() (map[int]int, error) {
 		bookIDs[i] = ab.BookID
 	}
 
-	filesMap := make(map[string][]BookFile)
+	filesMap := make(map[string][]BookFileCore)
 	if len(bookIDs) > 0 {
-		if bfm, err := p.GetBookFilesForIDs(bookIDs); err == nil {
+		if bfm, err := p.GetBookFilesForIDsCore(bookIDs); err == nil {
 			filesMap = bfm
 		}
 	}

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
 // last-edited: 2026-07-05
 
@@ -325,30 +325,31 @@ func (s *PebbleStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	return files, nil
 }
 
-// GetBookFilesForIDs returns book files grouped by bookID. When memdb is
-// published, uses the memdb book_id index — O(sum of files per ID), not
-// O(all 308K book_files) like the Pebble full-scan fallback. For a
-// 500-book page query, this drops the call from ~15s to <5ms; for a
-// 20-book query, from ~15s to <1ms. The Pebble full-scan was the actual
-// killer behind 500-per-page taking 3m51s pre-fix.
+// GetBookFilesForIDsCore returns book files grouped by bookID, as the
+// BookFileCore projection. When memdb is published, uses the memdb book_id
+// index — O(sum of files per ID), not O(all 308K book_files) like the
+// Pebble full-scan fallback. For a 500-book page query, this drops the call
+// from ~15s to <5ms; for a 20-book query, from ~15s to <1ms. The Pebble
+// full-scan was the actual killer behind 500-per-page taking 3m51s pre-fix.
 //
 // Pebble full-scan retained as fallback for cold-start (before memdb
 // publishes) and tests with no memdb.
 //
-// SLIM (memdb projection): returns rows with heavy fields nil'd —
-// FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
-// AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
-// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
-// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (s *PebbleStore) GetBookFilesForIDs(bookIDs []string) (map[string][]BookFile, error) {
+// Core-typed (STOREFID): the return type is BookFileCore, not BookFile, so
+// the missing heavy fingerprint fields (FingerprintFailureReason/Detail/
+// DiagnosticJSON, AcoustIDFingerprint, AcoustIDSeg0..6) are compiler-enforced
+// rather than silently nil'd. A caller that needs any of those MUST fetch via
+// GetBookFiles(bookID) (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (s *PebbleStore) GetBookFilesForIDsCore(bookIDs []string) (map[string][]BookFileCore, error) {
 	if s.UseMemDB && s.mem() != nil {
-		return s.mem().GetBookFilesForIDs(bookIDs)
+		return s.mem().GetBookFilesForIDsCore(bookIDs)
 	}
 	return s.getBookFilesForIDsPebbleScan(bookIDs)
 }
 
-func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string][]BookFile, error) {
-	result := make(map[string][]BookFile)
+func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string][]BookFileCore, error) {
+	result := make(map[string][]BookFileCore)
 	if len(bookIDs) == 0 {
 		return result, nil
 	}
@@ -371,7 +372,7 @@ func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string
 			return nil, err
 		}
 		if idSet[f.BookID] {
-			result[f.BookID] = append(result[f.BookID], f)
+			result[f.BookID] = append(result[f.BookID], f.Core())
 		}
 	}
 	return result, nil
@@ -380,7 +381,7 @@ func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string
 // GetAllBookFiles returns every BookFile in the database. When memdb is
 // published, iterates the in-memory book_files table — a pointer walk over
 // ~308K rows — instead of a Pebble prefix scan with per-row JSON unmarshal.
-// Mirrors the GetBookFilesForIDs fastpath from PR #1153.
+// Mirrors the GetBookFilesForIDsCore fastpath from PR #1153.
 //
 // Pebble full-scan retained as fallback for cold-start (before memdb
 // publishes) and tests with no memdb.

--- a/internal/server/audiobooks_helpers.go
+++ b/internal/server/audiobooks_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/audiobooks_helpers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 439aa827-edea-481d-8918-ddacd2c140b7
-// last-edited: 2026-06-28
+// last-edited: 2026-07-05
 
 // Server-package helpers relocated out of audiobooks_handlers.go when the
 // audiobooks HTTP handlers were extracted into the handlers/audiobooks
@@ -69,7 +69,7 @@ func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset i
 
 	// Fetch book_files ONCE up front; thread the map into both enrichment
 	// (for duration/file-size aggregation) and the fingerprint compute loop
-	// below. Previously each path independently called GetBookFilesForIDs.
+	// below. Previously each path independently called GetBookFilesForIDsCore.
 	bookFilesMap := s.audiobookService.FetchBookFilesForBooks(books)
 
 	enriched := s.audiobookService.EnrichAudiobooksWithNamesAndFiles(books, bookFilesMap)

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
-// last-edited: 2026-06-23
+// last-edited: 2026-07-05
 
 // Package audiobookshandler hosts the main library list / CRUD HTTP handlers
 // extracted from the server package's audiobooks_handlers.go: book listing
@@ -79,7 +79,7 @@ type Handler struct {
 	// from this field directly (no lazy provider needed — no post-wire swap for
 	// this package's store). The concrete store value (un-stripped) is preserved
 	// so the handlers' inline type assertions (Unwrap / ListBooksWithFileErrors /
-	// GetAllBookIDsForQuickQuery / GetBookFilesForIDs / InvalidateLibraryStats)
+	// GetAllBookIDsForQuickQuery / GetBookFilesForIDsCore / InvalidateLibraryStats)
 	// still resolve against the dynamic type.
 	store AudiobooksStore
 
@@ -345,18 +345,18 @@ func (h *Handler) ListAudiobooks(c *gin.Context) {
 			qqBookIDs[i] = book.ID
 		}
 
-		qqBookFilesMap := make(map[string][]database.BookFile)
+		qqBookFilesMap := make(map[string][]database.BookFileCore)
 		if qqGgf, ok := store.(interface {
-			GetBookFilesForIDs(ids []string) (map[string][]database.BookFile, error)
+			GetBookFilesForIDsCore(ids []string) (map[string][]database.BookFileCore, error)
 		}); ok {
-			if qqBfm, err := qqGgf.GetBookFilesForIDs(qqBookIDs); err == nil {
+			if qqBfm, err := qqGgf.GetBookFilesForIDsCore(qqBookIDs); err == nil {
 				qqBookFilesMap = qqBfm
 			}
 		} else if qqUw, ok := store.(interface{ Unwrap() database.Store }); ok {
 			if qqInner, ok2 := qqUw.Unwrap().(interface {
-				GetBookFilesForIDs(ids []string) (map[string][]database.BookFile, error)
+				GetBookFilesForIDsCore(ids []string) (map[string][]database.BookFileCore, error)
 			}); ok2 {
-				if qqBfm, err := qqInner.GetBookFilesForIDs(qqBookIDs); err == nil {
+				if qqBfm, err := qqInner.GetBookFilesForIDsCore(qqBookIDs); err == nil {
 					qqBookFilesMap = qqBfm
 				}
 			}

--- a/internal/server/handlers/audiobooks/interfaces.go
+++ b/internal/server/handlers/audiobooks/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 110386de-3e07-4ef3-b0e0-2e717a249e91
-// last-edited: 2026-06-03
+// last-edited: 2026-07-05
 
 // Narrow dependency interfaces for the audiobooks-domain HTTP handlers (the
 // main library list / CRUD domain: list, count, facets, soft-delete /
@@ -50,7 +50,7 @@ import (
 //
 // NOTE: the handlers ALSO probe the live store for optional/decorator-only
 // methods via inline type assertions (ListBooksWithFileErrors,
-// GetAllBookIDsForQuickQuery, GetBookFilesForIDs, Unwrap, InvalidateLibraryStats).
+// GetAllBookIDsForQuickQuery, GetBookFilesForIDsCore, Unwrap, InvalidateLibraryStats).
 // Those are intentionally NOT listed here — they resolve against the dynamic
 // type of the value the provider returns (s.Store(), the concrete store), so
 // they keep working as long as getStore returns the un-stripped store.

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.15.0
+// version: 2.16.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-03
+// last-edited: 2026-07-05
 
 package server
 
@@ -449,7 +449,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// test swaps server.store post-wire; s.Store() returns the database.Store
 	// interface (un-stripped) so the handlers' inline type assertions
 	// (Unwrap / ListBooksWithFileErrors / GetAllBookIDsForQuickQuery /
-	// GetBookFilesForIDs / InvalidateLibraryStats) still resolve against the
+	// GetBookFilesForIDsCore / InvalidateLibraryStats) still resolve against the
 	// dynamic type. The caches are concrete (*cache.Cache[T], the cache exception).
 	//
 	// buildListResponse wraps the relocated *Server.buildAudiobookListResponse


### PR DESCRIPTION
STOREFID Phase 3 wave 1. Migrates `GetBookFilesForIDs` → `GetBookFilesForIDsCore` (`map[string][]BookFileCore`).

**Also fixes a broken main:** P2-T1 and P2-T2 each added a `structFieldNames` test helper to the `database` package → duplicate declaration once both merged (test package wouldn't compile). Removed the dup from bookfilecore_test.go.

Discovery: `GetBookFilesForIDs` is NOT on the `Store` interface (probed via ad-hoc local interfaces) → no mock regen. All 4 callers **retyped** (none needed reroute): filter/aggregate paths read only light fields; the quick-query fast path's `AcoustIDSeg0` already falls back to the `AcoustIDFingerprintDurationSec` proxy (fable5 T019), so behavior is preserved by adding that proxy method to BookFileCore. Build/vet/test green (database 309s, audiobooks 83s, handlers 0.6s).