### PR TITLE
refactor(store): GetBooksByAuthorID → GetBooksByAuthorIDCore ([]BookCore) (STOREFID P3-W2)

### DIFF
--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/audiobook_service_unit_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 // last-edited: 2026-07-05
 
@@ -164,8 +164,8 @@ func TestAudiobookService_GetAudiobooks_ByAuthorID(t *testing.T) {
 	svc := NewAudiobookService(mockStore)
 
 	authorID := 42
-	expected := []database.Book{{ID: "b1"}, {ID: "b2"}}
-	mockStore.EXPECT().GetBooksByAuthorID(42).Return(expected, nil)
+	expected := []database.BookCore{{ID: "b1"}, {ID: "b2"}}
+	mockStore.EXPECT().GetBooksByAuthorIDCore(42).Return(expected, nil)
 
 	books, err := svc.GetAudiobooks(context.Background(), 10, 0, "", &authorID, nil)
 	assert.NoError(t, err)

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
 // last-edited: 2026-07-05
 
@@ -72,7 +72,18 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			books, err = svc.store.SearchBooks(search, limit, offset)
 		}
 	} else if authorID != nil {
-		books, err = svc.store.GetBooksByAuthorID(*authorID)
+		// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2); GetAudiobooks'
+		// public signature ([]database.Book, shared with SearchBooks/
+		// GetBooksBySeriesID below and the caller's downstream filtering) is
+		// out of scope to retype here, so convert back via BookCore.ToBook().
+		var booksCore []database.BookCore
+		booksCore, err = svc.store.GetBooksByAuthorIDCore(*authorID)
+		if err == nil {
+			books = make([]database.Book, len(booksCore))
+			for i := range booksCore {
+				books[i] = booksCore[i].ToBook()
+			}
+		}
 	} else if seriesID != nil {
 		books, err = svc.store.GetBooksBySeriesID(*seriesID)
 	}

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,5 +1,5 @@
 // file: internal/batch/service_test.go
-// version: 1.0.5
+// version: 1.0.6
 // last-edited: 2026-07-05
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
@@ -109,7 +109,9 @@ func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([
 	return nil, nil
 }
 func (m *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) { return nil, nil }
-func (m *MockBookStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBooksByVersionGroup(groupID string) ([]database.Book, error) {
 	return nil, nil
 }

--- a/internal/database/bookcore.go
+++ b/internal/database/bookcore.go
@@ -1,5 +1,5 @@
 // file: internal/database/bookcore.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f3c1e28-9a4d-4b61-8c2f-bookcore000001
 // last-edited: 2026-07-05
 
@@ -265,5 +265,117 @@ func (b *Book) Core() BookCore {
 		Authors:                  b.Authors,
 		MetadataProvenance:       b.MetadataProvenance,
 		MetadataProvenanceAt:     b.MetadataProvenanceAt,
+	}
+}
+
+// ToBook reconstructs a Book from its BookCore projection. The nine heavy
+// fields (Description, VersionNotes, BookSigV1, BookSigV1Mask,
+// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series) are
+// left at their zero value — BookCore never carried them, so this is not a
+// lossy conversion relative to what the caller already had.
+//
+// This exists for call sites that receive a Core-typed result (e.g. from
+// GetBooksByAuthorIDCore) but must hand it to shared code that still takes
+// *Book/[]Book and is used elsewhere with genuinely full-fidelity Book
+// values (so widening THAT code's signature to BookCore is out of scope).
+// Added alongside STOREFID P3-W2; see
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (c *BookCore) ToBook() Book {
+	return Book{
+		ID:                       c.ID,
+		Title:                    c.Title,
+		AuthorID:                 c.AuthorID,
+		SeriesID:                 c.SeriesID,
+		SeriesSequence:           c.SeriesSequence,
+		FilePath:                 c.FilePath,
+		Format:                   c.Format,
+		Duration:                 c.Duration,
+		WorkID:                   c.WorkID,
+		Narrator:                 c.Narrator,
+		Edition:                  c.Edition,
+		Language:                 c.Language,
+		Publisher:                c.Publisher,
+		Genre:                    c.Genre,
+		PrintYear:                c.PrintYear,
+		AudiobookReleaseYear:     c.AudiobookReleaseYear,
+		ISBN10:                   c.ISBN10,
+		ISBN13:                   c.ISBN13,
+		ASIN:                     c.ASIN,
+		OpenLibraryID:            c.OpenLibraryID,
+		HardcoverID:              c.HardcoverID,
+		GoogleBooksID:            c.GoogleBooksID,
+		ITunesPersistentID:       c.ITunesPersistentID,
+		ITunesDateAdded:          c.ITunesDateAdded,
+		ITunesPlayCount:          c.ITunesPlayCount,
+		ITunesLastPlayed:         c.ITunesLastPlayed,
+		ITunesRating:             c.ITunesRating,
+		ITunesBookmark:           c.ITunesBookmark,
+		ITunesImportSource:       c.ITunesImportSource,
+		ITunesPath:               c.ITunesPath,
+		OriginalFilename:         c.OriginalFilename,
+		Bitrate:                  c.Bitrate,
+		Codec:                    c.Codec,
+		SampleRate:               c.SampleRate,
+		Channels:                 c.Channels,
+		BitDepth:                 c.BitDepth,
+		Quality:                  c.Quality,
+		IsPrimaryVersion:         c.IsPrimaryVersion,
+		VersionGroupID:           c.VersionGroupID,
+		FileHash:                 c.FileHash,
+		FileSize:                 c.FileSize,
+		OriginalFileHash:         c.OriginalFileHash,
+		OrganizedFileHash:        c.OrganizedFileHash,
+		LibraryState:             c.LibraryState,
+		Quantity:                 c.Quantity,
+		MarkedForDeletion:        c.MarkedForDeletion,
+		MarkedForDeletionAt:      c.MarkedForDeletionAt,
+		QuarantineReason:         c.QuarantineReason,
+		QuarantinedAt:            c.QuarantinedAt,
+		CreatedAt:                c.CreatedAt,
+		UpdatedAt:                c.UpdatedAt,
+		MetadataUpdatedAt:        c.MetadataUpdatedAt,
+		LastWrittenAt:            c.LastWrittenAt,
+		LastOrganizeOperationID:  c.LastOrganizeOperationID,
+		LastOrganizedAt:          c.LastOrganizedAt,
+		MetadataReviewStatus:     c.MetadataReviewStatus,
+		MetadataSource:           c.MetadataSource,
+		ITunesSyncStatus:         c.ITunesSyncStatus,
+		AudibleRuntimeMin:        c.AudibleRuntimeMin,
+		DurationVerifiedAt:       c.DurationVerifiedAt,
+		MetadataSourceHash:       c.MetadataSourceHash,
+		MergedIntoBookID:         c.MergedIntoBookID,
+		AudibleRatingOverall:     c.AudibleRatingOverall,
+		AudibleRatingPerformance: c.AudibleRatingPerformance,
+		AudibleRatingStory:       c.AudibleRatingStory,
+		AudibleRatingCount:       c.AudibleRatingCount,
+		AudibleNumReviews:        c.AudibleNumReviews,
+		GoogleRatingAverage:      c.GoogleRatingAverage,
+		GoogleRatingCount:        c.GoogleRatingCount,
+		UserRatingOverall:        c.UserRatingOverall,
+		UserRatingStory:          c.UserRatingStory,
+		UserRatingPerformance:    c.UserRatingPerformance,
+		UserRatingNotes:          c.UserRatingNotes,
+		CoverURL:                 c.CoverURL,
+		NarratorsJSON:            c.NarratorsJSON,
+		SourceImportPath:         c.SourceImportPath,
+		LastScanMtime:            c.LastScanMtime,
+		LastScanSize:             c.LastScanSize,
+		NeedsRescan:              c.NeedsRescan,
+		IntroTranscription:       c.IntroTranscription,
+		TranscribedTitle:         c.TranscribedTitle,
+		TranscribedAuthor:        c.TranscribedAuthor,
+		TranscribedNarrator:      c.TranscribedNarrator,
+		IntroTranscribedAt:       c.IntroTranscribedAt,
+		TranscribeStatus:         c.TranscribeStatus,
+		TranscribeError:          c.TranscribeError,
+		TranscribeAttemptedAt:    c.TranscribeAttemptedAt,
+		FingerprintStatus:        c.FingerprintStatus,
+		FingerprintedFileCount:   c.FingerprintedFileCount,
+		TotalFileCount:           c.TotalFileCount,
+		CoveragePercent:          c.CoveragePercent,
+		LastFingerprintedAt:      c.LastFingerprintedAt,
+		Authors:                  c.Authors,
+		MetadataProvenance:       c.MetadataProvenance,
+		MetadataProvenanceAt:     c.MetadataProvenanceAt,
 	}
 }

--- a/internal/database/coverage_test.go
+++ b/internal/database/coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/coverage_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 3b82b22e-cd28-49b8-8b9c-e0a34b18e631
-// last-edited: 2026-06-10
+// last-edited: 2026-07-05
 
 // NOTE(fable5 T022): TestInitializeStoreAndClose, TestDBInterfaceWrapper,
 // and TestWebHelpers removed — they tested SQLite initialisation and global
@@ -216,8 +216,8 @@ func TestMockStore_AllMethods(t *testing.T) {
 	if books, err := mock.GetBooksBySeriesID(1); err != nil || books != nil {
 		t.Errorf("GetBooksBySeriesID() = %v, %v; want nil, nil", books, err)
 	}
-	if books, err := mock.GetBooksByAuthorID(1); err != nil || books != nil {
-		t.Errorf("GetBooksByAuthorID() = %v, %v; want nil, nil", books, err)
+	if books, err := mock.GetBooksByAuthorIDCore(1); err != nil || books != nil {
+		t.Errorf("GetBooksByAuthorIDCore() = %v, %v; want nil, nil", books, err)
 	}
 	if book, err := mock.CreateBook(&Book{}); err != nil || book != nil {
 		t.Errorf("CreateBook() = %v, %v; want nil, nil", book, err)

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_book.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
 // last-edited: 2026-07-05
 
@@ -56,9 +56,15 @@ type BookReader interface {
 	// GetBooksBySeriesID is SLIM (memdb projection) — see
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBooksBySeriesID(seriesID int) ([]Book, error)
-	// GetBooksByAuthorID is SLIM (memdb projection) — see
+	// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2): the memdb
+	// projection is stripped of the nine heavy fields (Description,
+	// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,
+	// BookSigBuiltAt, BookSigCoveragePct, Author, Series), and that fact is
+	// now enforced by the return TYPE rather than left as a comment a caller
+	// can miss. A caller that needs any of those MUST fetch via GetBookByID
+	// / GetAllBooksFullFrom (full Pebble). See
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetBooksByAuthorID(authorID int) ([]Book, error)
+	GetBooksByAuthorIDCore(authorID int) ([]BookCore, error)
 	GetBooksByVersionGroup(groupID string) ([]Book, error)
 	GetBooksByMetadataSourceHash(hash string) ([]Book, error)
 	// GetBookIDsByISBNASIN returns the distinct book IDs whose ISBN10, ISBN13,

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-07-05
 
@@ -407,6 +407,15 @@ func (m *MemStore) GetBooksBySeriesID(seriesID int, limit, offset int) ([]Book, 
 // AuthorID field on the Book row. No default sort — matches the Pebble path
 // (which returned books in key/ULID order) and avoids per-call sort cost.
 // Callers that need a specific order should sort the slice themselves.
+//
+// Intentionally NOT renamed/retyped to *Core (STOREFID P3-W2): this helper
+// is shared by two PebbleStore callers with different fidelity contracts —
+// GetBooksByAuthorIDCore (Core-typed, maps this result via .Core()) and
+// GetBooksByAuthorIDWithRole (still []Book, not yet migrated — see the
+// GetBooksByAuthorIDWithRoleCore row in
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md). Retyping
+// this method's return would force GetBooksByAuthorIDWithRole to convert
+// back to []Book, which is out of scope for P3-W2.
 func (m *MemStore) GetBooksByAuthorID(authorID int, limit, offset int) ([]Book, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.69.0
+// version: 1.70.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-05
 
@@ -40,7 +40,8 @@ type MockStore struct {
 	GetAllBookSummariesFunc         func(limit, offset int) ([]BookSummary, error)
 	GetBooksByWorkIDFunc            func(workID string) ([]Book, error)
 	GetBooksBySeriesIDFunc          func(seriesID int) ([]Book, error)
-	GetBooksByAuthorIDFunc          func(authorID int) ([]Book, error)
+	GetBooksByAuthorIDCoreFunc      func(authorID int) ([]BookCore, error)
+	GetBooksByAuthorIDWithRoleFunc  func(authorID int) ([]Book, error)
 	GetBookByITunesPersistentIDFunc func(persistentID string) (*Book, error)
 	ListBooksByITunesPIDFunc        func(limit, offset int) ([]Book, error)
 	GetBookByFileHashFunc           func(hash string) (*Book, error)
@@ -768,9 +769,9 @@ func (m *MockStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
 	return nil, nil
 }
 
-func (m *MockStore) GetBooksByAuthorID(authorID int) ([]Book, error) {
-	if m.GetBooksByAuthorIDFunc != nil {
-		return m.GetBooksByAuthorIDFunc(authorID)
+func (m *MockStore) GetBooksByAuthorIDCore(authorID int) ([]BookCore, error) {
+	if m.GetBooksByAuthorIDCoreFunc != nil {
+		return m.GetBooksByAuthorIDCoreFunc(authorID)
 	}
 	return nil, nil
 }
@@ -784,7 +785,14 @@ func (m *MockStore) SetBookAuthors(bookID string, authors []BookAuthor) error {
 }
 
 func (m *MockStore) GetBooksByAuthorIDWithRole(authorID int) ([]Book, error) {
-	return m.GetBooksByAuthorID(authorID)
+	// Can no longer delegate to GetBooksByAuthorIDCore (STOREFID P3-W2
+	// retyped it to []BookCore); GetBooksByAuthorIDWithRole itself is out of
+	// scope for this wave and stays []Book. Use its own func field —
+	// defaults to the same nil,nil zero-value stub as before when unset.
+	if m.GetBooksByAuthorIDWithRoleFunc != nil {
+		return m.GetBooksByAuthorIDWithRoleFunc(authorID)
+	}
+	return nil, nil
 }
 
 func (m *MockStore) GetAllAuthorBookCounts() (map[int]int, error) {

--- a/internal/database/mock_store_coverage_test.go
+++ b/internal/database/mock_store_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store_coverage_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9f8e7d6c-5b4a-3c2d-1e0f-a9b8c7d6e5f4
-// last-edited: 2026-06-14
+// last-edited: 2026-07-05
 
 package database
 
@@ -54,7 +54,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	mock.GetBookByOrganizedHashFunc = func(string) (*Book, error) { return nil, nil }
 	mock.GetDuplicateBooksFunc = func() ([][]Book, error) { return nil, nil }
 	mock.GetBooksBySeriesIDFunc = func(int) ([]Book, error) { return nil, nil }
-	mock.GetBooksByAuthorIDFunc = func(int) ([]Book, error) { return nil, nil }
+	mock.GetBooksByAuthorIDCoreFunc = func(int) ([]BookCore, error) { return nil, nil }
 	mock.CreateBookFunc = func(*Book) (*Book, error) { return nil, nil }
 	mock.UpdateBookFunc = func(string, *Book) (*Book, error) { return nil, nil }
 	mock.DeleteBookFunc = func(string) error { return nil }
@@ -173,7 +173,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	_, _ = mock.GetBookByOrganizedHash("hash")
 	_, _ = mock.GetDuplicateBooks()
 	_, _ = mock.GetBooksBySeriesID(1)
-	_, _ = mock.GetBooksByAuthorID(1)
+	_, _ = mock.GetBooksByAuthorIDCore(1)
 	_, _ = mock.CreateBook(&Book{})
 	_, _ = mock.UpdateBook("book-1", &Book{})
 	_ = mock.DeleteBook("book-1")

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3615,24 +3615,24 @@ func (_c *MockBookReader_GetBookTombstone_Call) RunAndReturn(run func(id string)
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -3643,18 +3643,18 @@ func (_mock *MockBookReader) GetBooksByAuthorID(authorID int) ([]database.Book, 
 	return r0, r1
 }
 
-// MockBookReader_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockBookReader_GetBooksByAuthorID_Call struct {
+// MockBookReader_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockBookReader_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockBookReader_Expecter) GetBooksByAuthorID(authorID any) *MockBookReader_GetBooksByAuthorID_Call {
-	return &MockBookReader_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockBookReader_Expecter) GetBooksByAuthorIDCore(authorID any) *MockBookReader_GetBooksByAuthorIDCore_Call {
+	return &MockBookReader_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockBookReader_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockBookReader_GetBooksByAuthorID_Call {
+func (_c *MockBookReader_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockBookReader_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -3667,12 +3667,12 @@ func (_c *MockBookReader_GetBooksByAuthorID_Call) Run(run func(authorID int)) *M
 	return _c
 }
 
-func (_c *MockBookReader_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockBookReader_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockBookReader_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockBookReader_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockBookReader_GetBooksByAuthorID_Call {
+func (_c *MockBookReader_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockBookReader_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6996,24 +6996,24 @@ func (_c *MockBookStore_GetBookTombstone_Call) RunAndReturn(run func(id string) 
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -7024,18 +7024,18 @@ func (_mock *MockBookStore) GetBooksByAuthorID(authorID int) ([]database.Book, e
 	return r0, r1
 }
 
-// MockBookStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockBookStore_GetBooksByAuthorID_Call struct {
+// MockBookStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockBookStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockBookStore_Expecter) GetBooksByAuthorID(authorID any) *MockBookStore_GetBooksByAuthorID_Call {
-	return &MockBookStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockBookStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockBookStore_GetBooksByAuthorIDCore_Call {
+	return &MockBookStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockBookStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockBookStore_GetBooksByAuthorID_Call {
+func (_c *MockBookStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockBookStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -7048,12 +7048,12 @@ func (_c *MockBookStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *Mo
 	return _c
 }
 
-func (_c *MockBookStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockBookStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockBookStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockBookStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockBookStore_GetBooksByAuthorID_Call {
+func (_c *MockBookStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockBookStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -37720,24 +37720,24 @@ func (_c *MockStore_GetBookVersionsByBookID_Call) RunAndReturn(run func(bookID s
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockStore
-func (_mock *MockStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -37748,18 +37748,18 @@ func (_mock *MockStore) GetBooksByAuthorID(authorID int) ([]database.Book, error
 	return r0, r1
 }
 
-// MockStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockStore_GetBooksByAuthorID_Call struct {
+// MockStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockStore_Expecter) GetBooksByAuthorID(authorID any) *MockStore_GetBooksByAuthorID_Call {
-	return &MockStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockStore_GetBooksByAuthorIDCore_Call {
+	return &MockStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockStore_GetBooksByAuthorID_Call {
+func (_c *MockStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -37772,12 +37772,12 @@ func (_c *MockStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockSt
 	return _c
 }
 
-func (_c *MockStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockStore_GetBooksByAuthorID_Call {
+func (_c *MockStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.104.0
+// version: 1.105.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-07-05
 
@@ -39,7 +39,7 @@ func prefixEnd(prefix []byte) []byte {
 }
 
 // serializeBookForIndex marshals a Book to JSON for index storage.
-// This enables GetBooksBySeriesID and GetBooksByAuthorID to deserialize
+// This enables GetBooksBySeriesID and GetBooksByAuthorIDCore to deserialize
 // directly from the index without secondary point lookups.
 func serializeBookForIndex(book *Book) ([]byte, error) {
 	return json.Marshal(book)
@@ -92,7 +92,7 @@ func isValidULID(s string) bool {
 // - book:<id>                  -> Book JSON
 // - book:path:<path>           -> book_id (for lookups)
 // NOTE: book:series and book:author prefix indexes were removed in Task 3.4.
-//       GetBooksBySeriesID and GetBooksByAuthorID fall back to a full Pebble scan
+//       GetBooksBySeriesID and GetBooksByAuthorIDCore fall back to a full Pebble scan
 //       (the in-memory query layer covers the hot paths).
 // - import_path:<id>           -> ImportPath JSON
 // - import_path:path:<path>    -> import_path_id (for lookups)
@@ -1106,17 +1106,34 @@ func (p *PebbleStore) getBooksBySeriesIDFull(seriesID int) ([]Book, error) {
 	return books, nil
 }
 
-// GetBooksByAuthorID is SLIM (memdb projection): returns rows with heavy
-// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
-// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
-// caller that needs any of those MUST fetch via GetBookByID /
+// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2): the return type is
+// BookCore, not Book, so the nine heavy fields (Description, VersionNotes,
+// BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series) being absent is compiler-enforced
+// rather than silently nil'd. Both the memdb-fast-path rows and the
+// getBooksByAuthorIDFull scan fallback are already stripped of those fields
+// at the source (memdb never carries them; the Pebble scan below returns
+// full Book only as an intermediate before projecting to Core) — mapping
+// via .Core() here just makes that guarantee visible in the type system. A
+// caller that needs any of the heavy fields MUST fetch via GetBookByID /
 // GetAllBooksFullFrom (full Pebble). See
 // docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (p *PebbleStore) GetBooksByAuthorID(authorID int) ([]Book, error) {
+func (p *PebbleStore) GetBooksByAuthorIDCore(authorID int) ([]BookCore, error) {
+	var books []Book
+	var err error
 	if p.UseMemDB && p.mem() != nil {
-		return p.mem().GetBooksByAuthorID(authorID, 0, 0)
+		books, err = p.mem().GetBooksByAuthorID(authorID, 0, 0)
+	} else {
+		books, err = p.getBooksByAuthorIDFull(authorID)
 	}
-	return p.getBooksByAuthorIDFull(authorID)
+	if err != nil {
+		return nil, err
+	}
+	cores := make([]BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+	return cores, nil
 }
 
 // getBooksByAuthorIDFull performs a full Pebble book scan filtered by author ID.

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -1,6 +1,7 @@
 // file: internal/database/pebble_store_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-07-05
 
 package database
 
@@ -329,8 +330,8 @@ func TestPebbleGetBooksBySeriesID(t *testing.T) {
 	}
 }
 
-// TestPebbleGetBooksByAuthorID tests filtering books by author
-func TestPebbleGetBooksByAuthorID(t *testing.T) {
+// TestPebbleGetBooksByAuthorIDCore tests filtering books by author
+func TestPebbleGetBooksByAuthorIDCore(t *testing.T) {
 	// Arrange
 	store, cleanup := setupPebbleTestDB(t)
 	defer cleanup()
@@ -355,7 +356,7 @@ func TestPebbleGetBooksByAuthorID(t *testing.T) {
 	}
 
 	// Act - Get books by author
-	authorBooks, err := store.GetBooksByAuthorID(author.ID)
+	authorBooks, err := store.GetBooksByAuthorIDCore(author.ID)
 	if err != nil {
 		t.Fatalf("Failed to get books by author: %v", err)
 	}

--- a/internal/database/store_extra_test.go
+++ b/internal/database/store_extra_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_extra_test.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 68b2b2f9-2b8f-4f7f-9d8f-26e6306a3c8e
-// last-edited: 2026-06-10
+// last-edited: 2026-07-05
 
 // NOTE(fable5 T022): SQLiteStore type assertions replaced with PebbleStore;
 // TestSQLiteExtendedFeatures renamed to TestPebbleExtendedFeatures.
@@ -344,8 +344,8 @@ func exerciseStoreCommon(t *testing.T, store Store) {
 	if _, err := store.GetBooksBySeriesID(series.ID); err != nil {
 		t.Fatalf("GetBooksBySeriesID failed: %v", err)
 	}
-	if _, err := store.GetBooksByAuthorID(author.ID); err != nil {
-		t.Fatalf("GetBooksByAuthorID failed: %v", err)
+	if _, err := store.GetBooksByAuthorIDCore(author.ID); err != nil {
+		t.Fatalf("GetBooksByAuthorIDCore failed: %v", err)
 	}
 	if _, err := store.SearchBooks("Coverage", 10, 0); err != nil {
 		t.Fatalf("SearchBooks failed: %v", err)

--- a/internal/dedup/author.go
+++ b/internal/dedup/author.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/author.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
 
 package dedup
@@ -740,12 +740,12 @@ type authorPrecomputed struct {
 // Returns a map of authorID → slice of normalized series names (lowercased, trimmed).
 // This is an optional input to FindDuplicateAuthors for series cross-referencing.
 func BuildAuthorSeriesMap(store interface {
-	GetBooksByAuthorID(authorID int) ([]database.Book, error)
+	GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error)
 	GetSeriesByID(id int) (*database.Series, error)
 }, authors []database.Author) map[int][]string {
 	result := make(map[int][]string, len(authors))
 	for _, a := range authors {
-		books, err := store.GetBooksByAuthorID(a.ID)
+		books, err := store.GetBooksByAuthorIDCore(a.ID)
 		if err != nil {
 			continue
 		}

--- a/internal/dedup/collectors_metadata.go
+++ b/internal/dedup/collectors_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_metadata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e1f2a3b4-c5d6-4e7f-8a0b-1c2d3e4f5a6b
-// last-edited: 2026-06-10
+// last-edited: 2026-07-05
 
 // Package dedup — metadata-based collector family (fable5 T014).
 //
@@ -54,7 +54,7 @@ import (
 // In production code, the caller passes the same *database.PebbleStore
 // (or MockStore) for both parameters.
 type DurationCollectorStore interface {
-	GetBooksByAuthorID(authorID int) ([]database.Book, error)
+	GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error)
 	GetBookAlternativeTitles(bookID string) ([]database.BookAlternativeTitle, error)
 }
 
@@ -161,10 +161,11 @@ func CollectDuration(
 		return nil, nil
 	}
 
-	others, err := store.GetBooksByAuthorID(*book.AuthorID)
+	othersCore, err := store.GetBooksByAuthorIDCore(*book.AuthorID)
 	if err != nil {
 		return nil, fmt.Errorf("CollectDuration get books by author: %w", err)
 	}
+	others := booksFromCore(othersCore)
 
 	bookDur := float64(*book.Duration)
 	bookNorm := normalizeTitle(book.Title)

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.52.0
+// version: 1.53.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-05
 
@@ -1081,6 +1081,33 @@ func (de *Engine) checkExactMetadataSourceHash(book *database.Book) error {
 	return nil
 }
 
+// booksFromCore reconstructs []database.Book from the BookCore (memdb-slim)
+// projection returned by GetBooksByAuthorIDCore, via the reciprocal
+// database.BookCore.ToBook() projection. The nine heavy fields (Description,
+// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series) are left at their zero value —
+// exactly matching what GetBooksByAuthorID already returned before
+// STOREFID P3-W2, since memdb never carried them in the first place.
+//
+// This exists ONLY so checkExactTitle/checkDurationMatch/CollectDuration can
+// keep passing author-sibling books through the shared, Book-typed helpers
+// (hasPlausibleAudio, seriesNumberOf, sameMultiFileBook,
+// allNormalizedTitleForms(ForStore), upsertExactCandidate/identifiersConflict
+// et al.) unchanged. Those helpers are called from many other sites with
+// genuinely full Book values (e.g. GetBookByID results), so widening their
+// signatures to accept BookCore would ripple far outside this task's scope.
+// None of book/other's heavy fields are read anywhere in these three
+// functions or their callees — verified by inspection during STOREFID
+// P3-W2 — so this reconstruction is behavior-preserving, not a fidelity
+// downgrade.
+func booksFromCore(cores []database.BookCore) []database.Book {
+	books := make([]database.Book, len(cores))
+	for i := range cores {
+		books[i] = cores[i].ToBook()
+	}
+	return books
+}
+
 // checkExactTitle checks all books by the same author for near-identical
 // titles. Near-identical is defined as Levenshtein distance < 3 on the
 // normalized titles, WITH a series-volume safety check: if both books
@@ -1105,10 +1132,11 @@ func (de *Engine) checkExactTitle(book *database.Book, authorName string) error 
 		return nil // stub / unscanned shell — never anchor an exact-title match
 	}
 
-	others, err := de.bookStore.GetBooksByAuthorID(*book.AuthorID)
+	othersCore, err := de.bookStore.GetBooksByAuthorIDCore(*book.AuthorID)
 	if err != nil {
 		return fmt.Errorf("get books by author: %w", err)
 	}
+	others := booksFromCore(othersCore)
 
 	bookForms := de.allNormalizedTitleForms(book)
 	bookSeriesNum := seriesNumberOf(book)
@@ -1224,10 +1252,11 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 		return nil
 	}
 
-	others, err := de.bookStore.GetBooksByAuthorID(*book.AuthorID)
+	othersCore, err := de.bookStore.GetBooksByAuthorIDCore(*book.AuthorID)
 	if err != nil {
 		return fmt.Errorf("get books by author: %w", err)
 	}
+	others := booksFromCore(othersCore)
 
 	bookDur := float64(*book.Duration)
 	bookNorm := normalizeTitle(book.Title)

--- a/internal/dedup/engine_fullscan_layer1_parallel_test.go
+++ b/internal/dedup/engine_fullscan_layer1_parallel_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_fullscan_layer1_parallel_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-49c0-8d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-05
 
@@ -71,7 +71,7 @@ func fullScanLayer1FixtureBooks(n int) []database.Book {
 // unique file-hash index having exactly one owner per hash value, so
 // checkExactFileHash forms a "star" of pairs against books[0] rather than a
 // fabricated full clique) — the ISBN/title/duration checks independently
-// scan all books via GetAllBooks/GetBooksByAuthorID and form the full
+// scan all books via GetAllBooks/GetBooksByAuthorIDCore and form the full
 // clique on their own, so the combined want-set is still deterministic.
 func wireFullScanLayer1Mock(mock *database.MockStore, books []database.Book) {
 	byID := make(map[string]database.Book, len(books))
@@ -92,9 +92,11 @@ func wireFullScanLayer1Mock(mock *database.MockStore, books []database.Book) {
 	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
 		return &database.Author{ID: id, Name: "Layer1 Author"}, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
-		out := make([]database.Book, len(books))
-		copy(out, books)
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
+		out := make([]database.BookCore, len(books))
+		for i := range books {
+			out[i] = books[i].Core()
+		}
 		return out, nil
 	}
 	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) {

--- a/internal/dedup/engine_primary_gate_test.go
+++ b/internal/dedup/engine_primary_gate_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine_primary_gate_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2f7b4c19-6d83-4e50-9a12-7c5e0a8b3d46
 // last-edited: 2026-07-05
 
@@ -35,7 +35,13 @@ func wireExactTitleOnly(mock *database.MockStore, books map[string]*database.Boo
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return nil, nil }
 	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) { return nil, nil }
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) { return nil, nil }
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) { return byAuthor, nil }
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
+		out := make([]database.BookCore, len(byAuthor))
+		for i := range byAuthor {
+			out[i] = byAuthor[i].Core()
+		}
+		return out, nil
+	}
 	mock.GetBooksByMetadataSourceHashFunc = func(h string) ([]database.Book, error) { return nil, nil }
 }
 

--- a/internal/dedup/engine_test.go
+++ b/internal/dedup/engine_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_test.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 2a7e4d91-c538-4f06-b1d3-9e8c5a6f0d72
-// last-edited: 2026-07-01
+// last-edited: 2026-07-05
 
 package dedup
 
@@ -161,8 +161,8 @@ func TestEngine_ExactMatch_FileHash(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil // No separate files
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
-		return []database.Book{*bookA, *bookB}, nil
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
+		return []database.BookCore{bookA.Core(), bookB.Core()}, nil
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return nil, nil // No ISBN matching needed
@@ -230,8 +230,8 @@ func TestEngine_ExactMatch_FileHash_AutoMerge(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
-		return []database.Book{*bookA, *bookB}, nil
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
+		return []database.BookCore{bookA.Core(), bookB.Core()}, nil
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return nil, nil
@@ -296,8 +296,8 @@ func TestEngine_DurationMatch_EmitsCandidate(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
-		return []database.Book{*bookA, *bookB}, nil
+	mock.GetBooksByAuthorIDCoreFunc = func(id int) ([]database.BookCore, error) {
+		return []database.BookCore{bookA.Core(), bookB.Core()}, nil
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return nil, nil
@@ -354,13 +354,13 @@ func TestEngine_DurationMatch_RejectsAbridged(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
+	mock.GetBooksByAuthorIDCoreFunc = func(id int) ([]database.BookCore, error) {
 		// checkExactTitle path — SAME titles would normally
 		// match, we specifically want to test that the
 		// duration signal's abridged guard doesn't emit a
 		// duration-based candidate. (checkExactTitle WILL
 		// emit its own candidate because titles match.)
-		return []database.Book{*bookA, *bookB}, nil
+		return []database.BookCore{bookA.Core(), bookB.Core()}, nil
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return nil, nil
@@ -414,7 +414,7 @@ func TestEngine_ExactMatch_ISBN(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
 		return nil, nil // No title matches
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
@@ -477,9 +477,9 @@ func TestEngine_ExactMatch_NoMatch(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, nil
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
 		if authorID == 1 {
-			return []database.Book{*bookA}, nil // Only the book itself, no others
+			return []database.BookCore{bookA.Core()}, nil // Only the book itself, no others
 		}
 		return nil, nil
 	}
@@ -1194,8 +1194,8 @@ func TestEngine_ExactTitle_RejectsStubFile(t *testing.T) {
 
 	real := &database.Book{ID: "book-real", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(254_192_471)}
 	stub := &database.Book{ID: "book-stub", Title: "Iron and Blood", AuthorID: &authorID, FileSize: sz(32)}
-	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
-		return []database.Book{*real, *stub}, nil
+	mock.GetBooksByAuthorIDCoreFunc = func(id int) ([]database.BookCore, error) {
+		return []database.BookCore{real.Core(), stub.Core()}, nil
 	}
 
 	if err := engine.checkExactTitle(real, "Joshua Dalzelle"); err != nil {
@@ -1219,8 +1219,8 @@ func TestEngine_ExactTitle_KeepsGenuineLargePair(t *testing.T) {
 	a := &database.Book{ID: "book-a", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
 	// Genuine same-file copy in another folder: large size, not yet scanned.
 	b := &database.Book{ID: "book-b", Title: "Departure from the Script", AuthorID: &authorID, FileSize: sz(184_741_714)}
-	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) {
-		return []database.Book{*a, *b}, nil
+	mock.GetBooksByAuthorIDCoreFunc = func(id int) ([]database.BookCore, error) {
+		return []database.BookCore{a.Core(), b.Core()}, nil
 	}
 
 	if err := engine.checkExactTitle(a, "Jae"); err != nil {
@@ -1279,7 +1279,7 @@ func buildFullScanMock(books []database.Book) *database.MockStore {
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) { return books, nil }
 	mock.GetBookByIDFunc = func(id string) (*database.Book, error) { return byID[id], nil }
 	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) { return nil, nil }
-	mock.GetBooksByAuthorIDFunc = func(id int) ([]database.Book, error) { return nil, nil }
+	mock.GetBooksByAuthorIDCoreFunc = func(id int) ([]database.BookCore, error) { return nil, nil }
 	mock.GetBookByFileHashFunc = func(hash string) (*database.Book, error) { return nil, nil }
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return nil, nil }
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) { return books, nil }

--- a/internal/dedup/engine_unit_test.go
+++ b/internal/dedup/engine_unit_test.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/engine_unit_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f1a2b3c4-d5e6-7890-abcd-1234567890ab
+// last-edited: 2026-07-05
 
 package dedup
 
@@ -164,8 +165,8 @@ func TestCheckBook_FileHashCheckError_ContinuesGracefully(t *testing.T) {
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
 		return nil, fmt.Errorf("file lookup failed")
 	}
-	mock.GetBooksByAuthorIDFunc = func(authorID int) ([]database.Book, error) {
-		return []database.Book{*book}, nil // only itself
+	mock.GetBooksByAuthorIDCoreFunc = func(authorID int) ([]database.BookCore, error) {
+		return []database.BookCore{book.Core()}, nil // only itself
 	}
 	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
 		return nil, nil

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.3
+// version: 1.0.4
 // last-edited: 2026-07-05
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
@@ -93,7 +93,7 @@ func (m *mockRebuildStore) GetBooksBySeriesID(seriesID int) ([]database.Book, er
 	return nil, nil
 }
 
-func (m *mockRebuildStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+func (m *mockRebuildStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	return nil, nil
 }
 

--- a/internal/server/handlers/entities/handler.go
+++ b/internal/server/handlers/entities/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b02a07d8-1806-4c86-bb72-f0688d6caff3
-// last-edited: 2026-06-03
+// last-edited: 2026-07-05
 
 // Package entities hosts the entity-domain HTTP handlers extracted from the
 // server package: works, authors, series, and narrators — CRUD plus merges,
@@ -516,7 +516,7 @@ func (h *Handler) DeleteAuthor(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "invalid author ID")
 		return
 	}
-	books, err := h.store.GetBooksByAuthorID(authorID)
+	books, err := h.store.GetBooksByAuthorIDCore(authorID)
 	if err != nil {
 		httputil.InternalError(c, "failed to get author books", err)
 		return
@@ -547,7 +547,7 @@ func (h *Handler) BulkDeleteAuthors(c *gin.Context) {
 	skipped := 0
 	var errors []string
 	for _, id := range req.IDs {
-		books, err := h.store.GetBooksByAuthorID(id)
+		books, err := h.store.GetBooksByAuthorIDCore(id)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("author %d: %v", id, err))
 			continue
@@ -580,10 +580,20 @@ func (h *Handler) GetAuthorBooks(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "invalid author ID")
 		return
 	}
-	books, err := h.store.GetBooksByAuthorID(authorID)
+	booksCore, err := h.store.GetBooksByAuthorIDCore(authorID)
 	if err != nil {
 		httputil.InternalError(c, "failed to get author books", err)
 		return
+	}
+	// h.enrichBooks (injected from package server, see wire_handlers.go) is
+	// shared with full-fidelity Book sources elsewhere, so its signature
+	// stays []database.Book — convert back via BookCore.ToBook() rather than
+	// widening that shared response-building code (out of scope for
+	// STOREFID P3-W2). The heavy fields it would enrich with were already
+	// absent from this SLIM getter before this change; no behavior change.
+	books := make([]database.Book, len(booksCore))
+	for i := range booksCore {
+		books[i] = booksCore[i].ToBook()
 	}
 
 	enriched := h.enrichBooks(books)

--- a/internal/server/handlers/entities/handler_test.go
+++ b/internal/server/handlers/entities/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 163bc668-0761-43eb-9d85-f4983e8b014b
-// last-edited: 2026-06-03
+// last-edited: 2026-07-05
 
 package entities_test
 
@@ -288,7 +288,7 @@ func TestMergeAuthors_EmptyMergeIDs(t *testing.T) {
 
 func TestDeleteAuthor(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksByAuthorID(5).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetBooksByAuthorIDCore(5).Return([]database.BookCore{}, nil)
 	d.store.EXPECT().DeleteAuthor(5).Return(nil)
 	c, w := newCtx(http.MethodDelete, "/authors/5", "", idParam("5"))
 	h.DeleteAuthor(c)
@@ -297,7 +297,7 @@ func TestDeleteAuthor(t *testing.T) {
 
 func TestDeleteAuthor_HasBooks(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksByAuthorID(5).Return([]database.Book{{ID: "b1"}}, nil)
+	d.store.EXPECT().GetBooksByAuthorIDCore(5).Return([]database.BookCore{{ID: "b1"}}, nil)
 	c, w := newCtx(http.MethodDelete, "/authors/5", "", idParam("5"))
 	h.DeleteAuthor(c)
 	assert.Equal(t, http.StatusConflict, w.Code)
@@ -305,9 +305,9 @@ func TestDeleteAuthor_HasBooks(t *testing.T) {
 
 func TestBulkDeleteAuthors(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksByAuthorID(1).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetBooksByAuthorIDCore(1).Return([]database.BookCore{}, nil)
 	d.store.EXPECT().DeleteAuthor(1).Return(nil)
-	d.store.EXPECT().GetBooksByAuthorID(2).Return([]database.Book{{ID: "b"}}, nil) // skipped
+	d.store.EXPECT().GetBooksByAuthorIDCore(2).Return([]database.BookCore{{ID: "b"}}, nil) // skipped
 	c, w := newCtx(http.MethodPost, "/authors/bulk-delete", `{"ids":[1,2]}`, nil)
 	h.BulkDeleteAuthors(c)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -322,7 +322,7 @@ func TestBulkDeleteAuthors_BadJSON(t *testing.T) {
 
 func TestGetAuthorBooks(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksByAuthorID(5).Return([]database.Book{{ID: "b1"}, {ID: "b2"}}, nil)
+	d.store.EXPECT().GetBooksByAuthorIDCore(5).Return([]database.BookCore{{ID: "b1"}, {ID: "b2"}}, nil)
 	c, w := newCtx(http.MethodGet, "/authors/5/books", "", idParam("5"))
 	h.GetAuthorBooks(c)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/internal/server/handlers/entities/interfaces.go
+++ b/internal/server/handlers/entities/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 43710377-fdb3-490c-872e-fd03309163be
-// last-edited: 2026-06-03
+// last-edited: 2026-07-05
 
 // Narrow dependency interfaces for the entities domain handlers (authors,
 // series, narrators, works). Each interface lists only the methods the
@@ -33,7 +33,9 @@ type EntitiesStore interface {
 	GetAuthorAliases(authorID int) ([]database.AuthorAlias, error)
 	CreateAuthorAlias(authorID int, aliasName string, aliasType string) (*database.AuthorAlias, error)
 	DeleteAuthorAlias(id int) error
-	GetBooksByAuthorID(authorID int) ([]database.Book, error)
+	// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+	GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error)
 	GetBooksByAuthorIDWithRole(authorID int) ([]database.Book, error)
 
 	// Book authors / narrators join tables

--- a/internal/server/handlers/entities/mocks/mock_entities_store.go
+++ b/internal/server/handlers/entities/mocks/mock_entities_store.go
@@ -1117,24 +1117,24 @@ func (_c *MockEntitiesStore_GetBookNarrators_Call) RunAndReturn(run func(bookID 
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockEntitiesStore
-func (_mock *MockEntitiesStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockEntitiesStore
+func (_mock *MockEntitiesStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1145,18 +1145,18 @@ func (_mock *MockEntitiesStore) GetBooksByAuthorID(authorID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockEntitiesStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockEntitiesStore_GetBooksByAuthorID_Call struct {
+// MockEntitiesStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockEntitiesStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorID(authorID any) *MockEntitiesStore_GetBooksByAuthorID_Call {
-	return &MockEntitiesStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockEntitiesStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockEntitiesStore_GetBooksByAuthorIDCore_Call {
+	return &MockEntitiesStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockEntitiesStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockEntitiesStore_GetBooksByAuthorID_Call {
+func (_c *MockEntitiesStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockEntitiesStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1169,12 +1169,12 @@ func (_c *MockEntitiesStore_GetBooksByAuthorID_Call) Run(run func(authorID int))
 	return _c
 }
 
-func (_c *MockEntitiesStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockEntitiesStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockEntitiesStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockEntitiesStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockEntitiesStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockEntitiesStore_GetBooksByAuthorID_Call {
+func (_c *MockEntitiesStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockEntitiesStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
 // last-edited: 2026-07-05
 
@@ -1180,7 +1180,20 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 	var err error
 
 	if req.Filter.AuthorID != nil {
-		books, err = store.GetBooksByAuthorID(*req.Filter.AuthorID)
+		// store.GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2); the
+		// GetBooksBySeriesID/GetAllBooks branches below are not yet migrated
+		// and still return []database.Book, so `books` stays []database.Book
+		// here too — convert back via BookCore.ToBook(). Only book.ID,
+		// MarkedForDeletion, FilePath, and LibraryState (all Core-safe, no
+		// heavy fields) are read from `books`/`filtered` below.
+		var booksCore []database.BookCore
+		booksCore, err = store.GetBooksByAuthorIDCore(*req.Filter.AuthorID)
+		if err == nil {
+			books = make([]database.Book, len(booksCore))
+			for i := range booksCore {
+				books[i] = booksCore[i].ToBook()
+			}
+		}
 	} else if req.Filter.SeriesID != nil {
 		books, err = store.GetBooksBySeriesID(*req.Filter.SeriesID)
 	} else {

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-06-03
+// last-edited: 2026-07-05
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -69,7 +69,11 @@ type MetadataStore interface {
 	PruneBookSnapshots(id string, keepCount int) (int, error)
 
 	// Filtered book queries (handleBulkWriteBack).
-	GetBooksByAuthorID(authorID int) ([]database.Book, error)
+	// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2) — already
+	// required via the embedded database.BookStore above; redeclared here
+	// (matching the GetBooksBySeriesID convention below) purely for the
+	// "what this handler touches" documentation grouping.
+	GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error)
 	GetBooksBySeriesID(seriesID int) ([]database.Book, error)
 
 	// Legacy supervisor op row (batchWriteBackAudiobooks).

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -1566,24 +1566,24 @@ func (_c *MockMetadataStore_GetBookTombstone_Call) RunAndReturn(run func(id stri
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1594,18 +1594,18 @@ func (_mock *MockMetadataStore) GetBooksByAuthorID(authorID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockMetadataStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockMetadataStore_GetBooksByAuthorID_Call struct {
+// MockMetadataStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockMetadataStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockMetadataStore_Expecter) GetBooksByAuthorID(authorID any) *MockMetadataStore_GetBooksByAuthorID_Call {
-	return &MockMetadataStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockMetadataStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockMetadataStore_GetBooksByAuthorIDCore_Call {
+	return &MockMetadataStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockMetadataStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockMetadataStore_GetBooksByAuthorID_Call {
+func (_c *MockMetadataStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockMetadataStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1618,12 +1618,12 @@ func (_c *MockMetadataStore_GetBooksByAuthorID_Call) Run(run func(authorID int))
 	return _c
 }
 
-func (_c *MockMetadataStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockMetadataStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockMetadataStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockMetadataStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockMetadataStore_GetBooksByAuthorID_Call {
+func (_c *MockMetadataStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockMetadataStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -1215,24 +1215,24 @@ func (_c *MockPlaylistStore_GetBookTombstone_Call) RunAndReturn(run func(id stri
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1243,18 +1243,18 @@ func (_mock *MockPlaylistStore) GetBooksByAuthorID(authorID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockPlaylistStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockPlaylistStore_GetBooksByAuthorID_Call struct {
+// MockPlaylistStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockPlaylistStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockPlaylistStore_Expecter) GetBooksByAuthorID(authorID any) *MockPlaylistStore_GetBooksByAuthorID_Call {
-	return &MockPlaylistStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockPlaylistStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockPlaylistStore_GetBooksByAuthorIDCore_Call {
+	return &MockPlaylistStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockPlaylistStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockPlaylistStore_GetBooksByAuthorID_Call {
+func (_c *MockPlaylistStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockPlaylistStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1267,12 +1267,12 @@ func (_c *MockPlaylistStore_GetBooksByAuthorID_Call) Run(run func(authorID int))
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockPlaylistStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockPlaylistStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockPlaylistStore_GetBooksByAuthorID_Call {
+func (_c *MockPlaylistStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockPlaylistStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -3032,24 +3032,24 @@ func (_c *MockOperationsStore_GetBookTombstone_Call) RunAndReturn(run func(id st
 	return _c
 }
 
-// GetBooksByAuthorID provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) {
+// GetBooksByAuthorIDCore provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	ret := _mock.Called(authorID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByAuthorID")
+		panic("no return value specified for GetBooksByAuthorIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(authorID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(authorID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -3060,18 +3060,18 @@ func (_mock *MockOperationsStore) GetBooksByAuthorID(authorID int) ([]database.B
 	return r0, r1
 }
 
-// MockOperationsStore_GetBooksByAuthorID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorID'
-type MockOperationsStore_GetBooksByAuthorID_Call struct {
+// MockOperationsStore_GetBooksByAuthorIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByAuthorIDCore'
+type MockOperationsStore_GetBooksByAuthorIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksByAuthorID is a helper method to define mock.On call
+// GetBooksByAuthorIDCore is a helper method to define mock.On call
 //   - authorID int
-func (_e *MockOperationsStore_Expecter) GetBooksByAuthorID(authorID any) *MockOperationsStore_GetBooksByAuthorID_Call {
-	return &MockOperationsStore_GetBooksByAuthorID_Call{Call: _e.mock.On("GetBooksByAuthorID", authorID)}
+func (_e *MockOperationsStore_Expecter) GetBooksByAuthorIDCore(authorID any) *MockOperationsStore_GetBooksByAuthorIDCore_Call {
+	return &MockOperationsStore_GetBooksByAuthorIDCore_Call{Call: _e.mock.On("GetBooksByAuthorIDCore", authorID)}
 }
 
-func (_c *MockOperationsStore_GetBooksByAuthorID_Call) Run(run func(authorID int)) *MockOperationsStore_GetBooksByAuthorID_Call {
+func (_c *MockOperationsStore_GetBooksByAuthorIDCore_Call) Run(run func(authorID int)) *MockOperationsStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -3084,12 +3084,12 @@ func (_c *MockOperationsStore_GetBooksByAuthorID_Call) Run(run func(authorID int
 	return _c
 }
 
-func (_c *MockOperationsStore_GetBooksByAuthorID_Call) Return(books []database.Book, err error) *MockOperationsStore_GetBooksByAuthorID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockOperationsStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database.BookCore, err error) *MockOperationsStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_GetBooksByAuthorID_Call) RunAndReturn(run func(authorID int) ([]database.Book, error)) *MockOperationsStore_GetBooksByAuthorID_Call {
+func (_c *MockOperationsStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockOperationsStore_GetBooksByAuthorIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
@@ -1127,7 +1127,7 @@ func TestHandler_DeleteAuthorAlias_InvalidID(t *testing.T) {
 func TestHandler_DeleteAuthor_Success(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksByAuthorID(42).Return([]database.Book{}, nil)
+	mockStore.EXPECT().GetBooksByAuthorIDCore(42).Return([]database.BookCore{}, nil)
 	mockStore.EXPECT().DeleteAuthor(42).Return(nil)
 
 	router.DELETE("/authors/:id", newEntitiesHandler(srv).DeleteAuthor)
@@ -1142,7 +1142,7 @@ func TestHandler_DeleteAuthor_Success(t *testing.T) {
 func TestHandler_DeleteAuthor_HasBooks(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksByAuthorID(42).Return([]database.Book{{ID: "b1"}}, nil)
+	mockStore.EXPECT().GetBooksByAuthorIDCore(42).Return([]database.BookCore{{ID: "b1"}}, nil)
 
 	router.DELETE("/authors/:id", newEntitiesHandler(srv).DeleteAuthor)
 

--- a/internal/server/server_bulk_delete_test.go
+++ b/internal/server/server_bulk_delete_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/server_bulk_delete_test.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-05
 
 package server
 
@@ -154,7 +155,7 @@ func TestBulkDeleteAuthors_NonexistentIDs(t *testing.T) {
 	server, cleanup := setupTestServer(t)
 	defer cleanup()
 
-	// IDs that don't exist — GetBooksByAuthorID returns empty, DeleteAuthor may error or succeed
+	// IDs that don't exist — GetBooksByAuthorIDCore returns empty, DeleteAuthor may error or succeed
 	w := postJSON(server, "/api/v1/authors/bulk-delete", map[string]interface{}{
 		"ids": []int{99999, 99998},
 	})
@@ -215,7 +216,7 @@ func TestBulkDeleteAuthors_MixedResults(t *testing.T) {
 
 func TestBulkDeleteAuthors_StoreError(t *testing.T) {
 	mock := &database.MockStore{
-		GetBooksByAuthorIDFunc: func(authorID int) ([]database.Book, error) {
+		GetBooksByAuthorIDCoreFunc: func(authorID int) ([]database.BookCore, error) {
 			if authorID == 1 {
 				return nil, fmt.Errorf("db connection lost")
 			}
@@ -248,7 +249,7 @@ func TestBulkDeleteAuthors_StoreError(t *testing.T) {
 
 func TestBulkDeleteAuthors_DeleteError(t *testing.T) {
 	mock := &database.MockStore{
-		GetBooksByAuthorIDFunc: func(authorID int) ([]database.Book, error) {
+		GetBooksByAuthorIDCoreFunc: func(authorID int) ([]database.BookCore, error) {
 			return nil, nil // no books
 		},
 		DeleteAuthorFunc: func(id int) error {

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,5 +1,5 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.0.4
+// version: 1.0.5
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
 // last-edited: 2026-07-05
 
@@ -105,7 +105,9 @@ func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([
 	return nil, nil
 }
 func (m *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) { return nil, nil }
-func (m *MockBookStore) GetBooksByAuthorID(authorID int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBooksByVersionGroup(groupID string) ([]database.Book, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## STOREFID Phase 3 — Wave 2

Migrates `GetBooksByAuthorID` → `GetBooksByAuthorIDCore` returning `[]BookCore`, carrying memdb/slim fidelity in the type per the [store-getter fidelity unification spec](docs/specs/2026-07-05-store-getter-fidelity-unification.md).

### Cascade (all edited)
- `Store`/`BookReader` interface (`iface_book.go`), `PebbleStore` impl (both memdb + full-scan-fallback branches mapped through `.Core()`)
- Hand-written `MockStore` + 5 mockery-generated mocks (database, entities, metadata, playlist, operations)
- dedup's 2 local narrow interfaces + call sites; entities/metadata handler interfaces + handlers; audiobooks `service_query`
- `MemStore.GetBooksByAuthorID` **intentionally unchanged** (`[]Book`) — shared by out-of-scope `GetBooksByAuthorIDWithRole` (W2b)

### New
- `BookCore.ToBook()` — behavior-preserving reciprocal to `Book.Core()`; bridges Core results into shared `[]Book` sinks that don't read heavy fields (those sinks flip to BookCore when `GetAllBooks`/`GetBooksBySeriesID` migrate).

### Heavy-field audit
All dedup call sites (engine.go:1108/1227, collectors_metadata.go:164, author.go:748) and handler sites verified: **no heavy fields read** — either pure retype or `ToBook()` reroute where a shared full-`Book` sink required it.

### Verification
`go build ./...` + `go vet ./...` clean. `go test ./internal/database/ ./internal/dedup/ ./internal/server/handlers/entities/ ./internal/server/handlers/metadata/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)