### PR TITLE
fix(database): guard UpdateBookFile against memdb-slim fingerprint wipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,33 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.111.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-05 -->
+<!-- last-edited: 2026-07-06 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 6, 2026 - fix(database): stop UpdateBookFile from wiping stored AcoustID fingerprints on memdb-slim writeback
+
+- **`fix(database)`** — `PebbleStore.UpdateBookFile` was a blind full-record
+  replace with no preserve-on-empty guard (unlike `UpsertBookFile` /
+  `BatchUpsertBookFiles`). Four whole-library maintenance jobs
+  (`recompute_itunes_paths`, `enrich_book_files`, `fix_book_file_paths`,
+  `repair_missing_files`) read book files via `GetAllBookFiles()` — the
+  memdb-slim projection that nils `AcoustIDFingerprint` under prod's
+  `UseMemDB=true` — tweaked one unrelated field, and wrote the whole struct
+  back, silently erasing the stored ~230 KB/file raw fingerprint in Pebble.
+  Two of those jobs default `DryRun=false`, so this was active data loss.
+- **Fix:** preserve-on-empty guard for `AcoustIDFingerprint` only (the field is
+  never intentionally cleared via this method; the fingerprint WRITE path in
+  `acoustid/backfill.go` always supplies a fresh non-empty value and
+  intentionally nil-clears the diagnostic fields on success, so those are
+  deliberately left unguarded here). Two-direction regression test proves the
+  fingerprint survives a slim round-trip AND a genuine write still overwrites +
+  clears failure diagnostics. See
+  [`docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`](docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md).
 
 #### July 5, 2026 - fix(ci): bump ghcommon pin for ghcommon-scripts ref-resolution fix (5th release-pipeline blocker)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.63.0 -->
+<!-- version: 9.64.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-05 -->
+<!-- last-edited: 2026-07-06 -->
 
 # Project TODO
 
@@ -19,6 +19,29 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## 🟡 UpdateBookFile memdb-writeback fingerprint wipe (2026-07-05)
+
+- **Found during STOREFID P3-W3 caller audit.** Full write-up:
+  [`docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`](docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md).
+  Independent of STOREFID — existed on `main`.
+- **Root cause:** `PebbleStore.UpdateBookFile` was a blind full-record replace with
+  no preserve-on-empty guard (unlike `UpsertBookFile` / `BatchUpsertBookFiles`). Jobs
+  that read `GetAllBookFiles()` (memdb-slim → `AcoustIDFingerprint` + 3 diagnostic
+  fields nil under prod `UseMemDB=true`) and write the struct back via bare
+  `UpdateBookFile` wiped the stored fingerprint in Pebble.
+- **PR-A (✅ done):** `AcoustIDFingerprint` preserve-on-empty guard on `UpdateBookFile`
+  + two-direction regression test. Stops the critical wipe for all 4 writeback jobs
+  (`recompute_itunes_paths`, `enrich_book_files` — DryRun false; `fix_book_file_paths`,
+  `repair_missing_files` — DryRun true). Diagnostic fields NOT guarded here (backfill.go
+  clears them on success via this method); the residual diagnostic wipe for failed-fp
+  books is closed structurally by W3.
+- **PR-B (open):** reroute the 3 HEAVY-READ fingerprint no-ops (`acoustid online_lookup`,
+  `lsh_backfill`, `dedup lsh_index_build`) to proxy-then-hydrate — they currently drop
+  every candidate under memdb and do nothing.
+- **PR-C = STOREFID W3:** retype `GetAllBookFiles → []BookFileCore`; the 4 writeback jobs
+  move to field-scoped update/hydrate. **W3 landmine:** those 4 must NOT use a
+  `BookFileCore.ToBookFile()` bridge then write back (re-introduces the wipe).
 
 ## ✅ BookSignatureScan memdb no-op fix (2026-07-05)
 

--- a/docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md
+++ b/docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md
@@ -1,0 +1,97 @@
+<!-- file: docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 3f9b1c22-7a4e-4d19-9c66-2e0a5b8d4471 -->
+<!-- last-edited: 2026-07-06 -->
+
+# UpdateBookFile memdb-writeback fingerprint wipe (discovered during STOREFID P3-W3 audit)
+
+## Summary
+
+Four whole-library maintenance jobs read book files via `GetAllBookFiles()` (which
+returns the **memdb-slim projection** under prod's `UseMemDB=true` default — with
+`AcoustIDFingerprint`, `AcoustIDSeg0..6`, `FingerprintFailureReason`,
+`FingerprintFailureDetail`, `FingerprintDiagnosticJSON` nil'd to save RAM), then write
+the slim struct back via the **bare, unguarded `PebbleStore.UpdateBookFile`**, which is a
+**blind full-record replace**. The nil fingerprint/diagnostic fields overwrite the real
+stored values → **silent fingerprint data loss in Pebble**.
+
+This is independent of the STOREFID type refactor — it exists on `main` today. STOREFID's
+`GetAllBookFiles → BookFileCore` retype is what surfaced it (the slim type makes the
+fidelity mismatch a compile error instead of a silent nil).
+
+## Root cause
+
+`UpdateBookFile` (`internal/database/pebble_store_bookfiles.go`) had **no
+preserve-on-empty guard**. Its siblings **already have the guard**:
+- `UpsertBookFile` — restores from `existing` when incoming is empty (comment cites PERF-7).
+- `BatchUpsertBookFiles` — same guard (comment names `tag-backfill`).
+
+`UpdateBookFile` was deliberately left unguarded because it doubles as the fingerprint
+**write** path: `internal/plugins/acoustid/backfill.go` calls it with a *fresh non-empty*
+`AcoustIDFingerprint` and **intentionally nil-clears the diagnostic fields on success** to
+drop a prior failure tombstone. A blanket 4-field guard (mirroring `UpsertBookFile`) would
+strand a stale failure reason forever.
+
+## Fix (PR-A — shipped)
+
+Add a preserve-on-empty guard to `UpdateBookFile` for **`AcoustIDFingerprint` only** — the
+critical ~230 KB/file field, provably never intentionally cleared via `UpdateBookFile`
+(the only non-empty writer is `backfill.go`; the two `AcoustIDFingerprint = nil` sites are
+`stripBookForMemdb`'s projection build and `ClearAllAcoustIDFingerprints`' raw bulk-clear,
+neither via `UpdateBookFile`). The 3 diagnostic fields are deliberately **not** guarded
+here so backfill's clear-on-success keeps working.
+
+Regression test asserts BOTH directions
+(`internal/database/pebble_bookfile_preserve_test.go`):
+- `TestUpdateBookFile_PreservesFingerprintOnEmptyIncoming` — slim round-trip keeps the fingerprint.
+- `TestUpdateBookFile_WritesFreshFingerprintAndClearsFailureDiagnostics` — a real write still overwrites the fingerprint AND clears diagnostics (guard did not over-fire).
+
+### Known residual gap (owned by W3, not unowned)
+
+The 3 diagnostic fields (`FingerprintFailureReason`/`Detail`/`DiagnosticJSON`) are still
+wiped for **failed-fp books** touched by the 4 slim-round-trip jobs. This is operationally
+minor: `FingerprintFailedAt` (which drives `backfill.go`'s skip logic) is memdb-**kept**, so
+correctness is unaffected — only the human-readable reason/detail is lost. The **structural**
+fix is STOREFID W3 (PR-C): once `GetAllBookFiles` returns `[]BookFileCore`, those 4 jobs can
+no longer write a whole `BookFile` back, forcing a field-scoped update or a full hydrate.
+
+## Affected callers
+
+### HEAVY-WRITEBACK — active/latent fingerprint wipe (prod)
+| Job | file:line | DryRun default | Exposure |
+|---|---|---|---|
+| `recompute_itunes_paths` | `internal/maintenance/jobs/recompute_itunes_paths.go:33,51` | **false** | **Active data loss** on every run that changes an iTunes path |
+| `enrich_book_files` | `internal/maintenance/jobs/enrich_book_files.go:38,64` | **false** | **Active data loss** on every run that sets a track number |
+| `fix_book_file_paths` | `internal/maintenance/jobs/fix_book_file_paths.go:33,51` | true | Wipes only when operator disables dry-run |
+| `repair_missing_files` | `internal/maintenance/jobs/repair_missing_files.go:48,542` | true | Same |
+
+PR-A's `AcoustIDFingerprint` guard stops the critical wipe for all four immediately; W3
+closes the diagnostic-field residue by making them field-scoped/hydrate.
+
+### HEAVY-READ — functional no-op under memdb (prod)  → PR-B
+| Op | file:line | Symptom |
+|---|---|---|
+| `acoustid online_lookup` | `internal/plugins/acoustid/online_lookup.go:97,112` | `len(f.AcoustIDFingerprint)==0` always true → drops every candidate → op reports success, does nothing. |
+| `acoustid lsh_backfill` | `internal/plugins/acoustid/lsh_backfill.go:80,97` | Identical pattern. |
+| `dedup lsh_index_build` | `internal/plugins/dedup/lsh_index_build.go:114,178` | Self-documented skip ("memdb strips AcoustIDFingerprint… Skip silently"). |
+
+Fix (PR-B) = **proxy-then-hydrate**: filter the slim list on KEPT proxy fields
+(`AcoustIDFingerprintDurationSec > 0`, `FingerprintFailedAt == nil`), then per candidate call
+`GetBookFiles(bookID)` (full/raw Pebble). No bulk-fingerprint getter (would reintroduce the
+RAM blowup memdb prevents).
+
+### TEST-FALLBACK — not a prod risk
+`acoustid reset_all` (`internal/plugins/acoustid/reset_all.go:88`) — the per-row
+`UpdateBookFile` path is gated behind a `*PebbleStore` type assertion for mock/sqlite
+tests; prod uses the bulk-clear path (`ClearAllAcoustIDFingerprints`). Unreachable in prod.
+
+## Fix sequencing
+
+1. **PR-A (shipped):** `AcoustIDFingerprint` preserve-on-empty guard on `UpdateBookFile` + two-direction regression test. Stops the critical wipe.
+2. **PR-B:** reroute the 3 HEAVY-READ fingerprint ops to proxy-then-hydrate (restores coverage).
+3. **PR-C (= STOREFID W3):** retype `GetAllBookFiles → []BookFileCore`; 13 LIGHT callers retype; the 4 writeback jobs move to field-scoped update/hydrate (closing the diagnostic residue). **W3 landmine: do NOT let the 4 writeback jobs use a `BookFileCore.ToBookFile()` bridge then write back — that reconstructs a nil-fingerprint `BookFile` and re-introduces the wipe (the guard only saves `AcoustIDFingerprint`, not diagnostics). Require field-scoped update or full hydrate.**
+
+## Full per-caller classification
+13 LIGHT, 3 HEAVY-READ, 4 HEAVY-WRITEBACK, 1 TEST-FALLBACK (of 21 external callers).
+`tag_backfill` + `backfill_file_hashes` write back but via the GUARDED
+`BatchUpsertBookFiles` / named-field `SetBookFileHash` respectively — safe.

--- a/internal/database/pebble_bookfile_preserve_test.go
+++ b/internal/database/pebble_bookfile_preserve_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_bookfile_preserve_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7e1a9c43-2b86-4d05-9f71-3c6e8a0d2b54
-// last-edited: 2026-06-22
+// last-edited: 2026-07-06
 
 package database
 
@@ -217,6 +217,118 @@ func TestUpsertBookFile_PreservesFingerprintViaPIDLookup(t *testing.T) {
 	files, _ := s.GetBookFiles(book.ID)
 	if len(files) != 1 || string(files[0].AcoustIDFingerprint) != string([]byte{5, 6, 7, 8}) {
 		t.Errorf("AcoustIDFingerprint WIPED via PID path: got %v", files[0].AcoustIDFingerprint)
+	}
+}
+
+// UpdateBookFile must NOT wipe the raw AcoustID fingerprint when a caller writes
+// back a memdb-slim struct (AcoustIDFingerprint nil'd by stripBookFileForMemdb).
+// This is the recompute_itunes_paths / enrich_book_files / fix_book_file_paths /
+// repair_missing_files footgun: those jobs read via GetAllBookFiles (memdb view),
+// tweak one unrelated field, and write the whole struct back via UpdateBookFile —
+// without the preserve-on-empty guard the nil fingerprint erases the stored value.
+func TestUpdateBookFile_PreservesFingerprintOnEmptyIncoming(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, err := s.CreateBook(&Book{Title: "Update FP Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	path := "/lib/Update FP Book/01.m4b"
+	if err := s.CreateBookFile(&BookFile{
+		BookID:              book.ID,
+		FilePath:            path,
+		FileHash:            "feedface",
+		Duration:            5400,
+		AcoustIDFingerprint: []byte{11, 22, 33, 44},
+	}); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+	created, err := s.GetBookFiles(book.ID)
+	if err != nil || len(created) != 1 {
+		t.Fatalf("GetBookFiles(created): err=%v len=%d", err, len(created))
+	}
+	id := created[0].ID
+
+	// Simulate a memdb-sourced maintenance write: fingerprint nil, an unrelated
+	// field (ITunesPath) changed. This is exactly what recompute_itunes_paths feeds.
+	slim := &BookFile{
+		ID:         id,
+		BookID:     book.ID,
+		FilePath:   path,
+		FileHash:   "feedface",
+		Duration:   5400,
+		ITunesPath: "/Music/Update FP Book/01.m4b",
+	}
+	if err := s.UpdateBookFile(id, slim); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+
+	got, err := s.GetBookFiles(book.ID) // pebble-direct → stored row
+	if err != nil || len(got) != 1 {
+		t.Fatalf("GetBookFiles: err=%v len=%d", err, len(got))
+	}
+	if string(got[0].AcoustIDFingerprint) != string([]byte{11, 22, 33, 44}) {
+		t.Errorf("AcoustIDFingerprint WIPED by UpdateBookFile: got %v, want [11 22 33 44]", got[0].AcoustIDFingerprint)
+	}
+	if got[0].ITunesPath != "/Music/Update FP Book/01.m4b" {
+		t.Errorf("ITunesPath not written: %q", got[0].ITunesPath)
+	}
+}
+
+// The other direction: UpdateBookFile is the fingerprint WRITE path
+// (internal/plugins/acoustid/backfill.go), which supplies a fresh non-empty
+// AcoustIDFingerprint AND nil'd diagnostic fields to clear a prior failure on
+// success. The guard must fire ONLY on empty incoming, so a genuine write still
+// overwrites the fingerprint and the intentional failure-diagnostic clear survives.
+// (This is the regression the guard could have introduced if it mirrored
+// UpsertBookFile's 4-field guard — it must not.)
+func TestUpdateBookFile_WritesFreshFingerprintAndClearsFailureDiagnostics(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, _ := s.CreateBook(&Book{Title: "Update FP Book 2"})
+	path := "/lib/Update FP Book 2/01.m4b"
+	reason := "fpcalc_missing"
+	detail := "binary not on PATH"
+	if err := s.CreateBookFile(&BookFile{
+		BookID:                   book.ID,
+		FilePath:                 path,
+		FingerprintFailureReason: &reason, // a prior failure tombstone
+		FingerprintFailureDetail: &detail,
+	}); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+	created, _ := s.GetBookFiles(book.ID)
+	id := created[0].ID
+
+	// Mimic backfill.go's success path: fresh non-empty fingerprint, diagnostics nil.
+	if err := s.UpdateBookFile(id, &BookFile{
+		ID:                       id,
+		BookID:                   book.ID,
+		FilePath:                 path,
+		AcoustIDFingerprint:      []byte{7, 7, 7, 7},
+		FingerprintFailureReason: nil,
+		FingerprintFailureDetail: nil,
+	}); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+
+	got, _ := s.GetBookFiles(book.ID)
+	if len(got) != 1 || string(got[0].AcoustIDFingerprint) != string([]byte{7, 7, 7, 7}) {
+		t.Errorf("fresh fingerprint not written: %v", got[0].AcoustIDFingerprint)
+	}
+	if got[0].FingerprintFailureReason != nil {
+		t.Errorf("failure reason NOT cleared on success (guard over-fired): %v", *got[0].FingerprintFailureReason)
+	}
+	if got[0].FingerprintFailureDetail != nil {
+		t.Errorf("failure detail NOT cleared on success (guard over-fired): %v", *got[0].FingerprintFailureDetail)
 	}
 }
 

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -253,6 +253,29 @@ func (s *PebbleStore) UpdateBookFile(id string, file *BookFile) error {
 	file.ID = id
 	file.CreatedAt = old.CreatedAt
 	file.UpdatedAt = time.Now()
+
+	// Preserve the memdb-stripped raw fingerprint on a slim round-trip.
+	// stripBookFileForMemdb nils AcoustIDFingerprint (~230 KB/file, expensive to
+	// recompute) in the memdb projection returned by GetAllBookFiles. A whole-library
+	// maintenance job that reads a slim BookFile, tweaks an unrelated field (path,
+	// track number, …), and writes the struct back here would otherwise blank the
+	// stored fingerprint — silent mass data-loss (recompute_itunes_paths /
+	// enrich_book_files / fix_book_file_paths / repair_missing_files). Restore from the
+	// stored row whenever the incoming value is empty. The fingerprint WRITE path
+	// (internal/plugins/acoustid/backfill.go) always supplies a fresh non-empty value,
+	// so this never blocks a real update.
+	//
+	// NOTE: unlike UpsertBookFile / BatchUpsertBookFiles, we deliberately do NOT guard
+	// the diagnostic fields (FingerprintFailureReason / Detail / DiagnosticJSON) here —
+	// backfill.go clears them to nil on a successful (re)fingerprint *via this method*,
+	// and a preserve-on-nil guard would strand a stale failure reason forever. Those 3
+	// fields are still wiped for failed-fp books touched by the slim-round-trip jobs
+	// above; FingerprintFailedAt (which drives backfill's skip logic) is memdb-KEPT so
+	// correctness is unaffected, and the structural fix is those callers moving to a
+	// field-scoped update under the GetAllBookFiles->BookFileCore retype (STOREFID W3).
+	if len(file.AcoustIDFingerprint) == 0 {
+		file.AcoustIDFingerprint = old.AcoustIDFingerprint
+	}
 
 	// T020: drop AcoustIDSeg0..6 from the stored value via a copy.
 	data, err := marshalBookFileDropSegs(file)


### PR DESCRIPTION
## Active prod data-loss fix (found during STOREFID P3-W3 audit)

`PebbleStore.UpdateBookFile` was a **blind full-record replace with no preserve-on-empty guard** — unlike its siblings `UpsertBookFile` / `BatchUpsertBookFiles`, which already guard (PERF-7). Four whole-library maintenance jobs read book files via `GetAllBookFiles()` (the **memdb-slim** projection that nils `AcoustIDFingerprint` under prod's `UseMemDB=true`), tweak one unrelated field, and write the whole struct back — **silently erasing the stored ~230 KB/file raw fingerprint** in Pebble:

| Job | DryRun default | Exposure |
|---|---|---|
| `recompute_itunes_paths` | **false** | Active data loss on every iTunes-path change |
| `enrich_book_files` | **false** | Active data loss on every track-number set |
| `fix_book_file_paths` | true | Wipes only if operator disables dry-run |
| `repair_missing_files` | true | Same |

## Fix

Preserve-on-empty guard for **`AcoustIDFingerprint` only**. It's provably never intentionally cleared via `UpdateBookFile` (the only non-empty writer is `acoustid/backfill.go`; the two `AcoustIDFingerprint = nil` sites are the memdb projection build and the raw `ClearAllAcoustIDFingerprints` bulk-clear, neither via this method). The 3 diagnostic fields are **deliberately not guarded here** — `backfill.go` clears them to nil on a successful (re)fingerprint *via this method*, so a preserve-on-nil guard would strand a stale failure reason forever.

## Test (both directions)

- `TestUpdateBookFile_PreservesFingerprintOnEmptyIncoming` — a memdb-slim writeback keeps the stored fingerprint.
- `TestUpdateBookFile_WritesFreshFingerprintAndClearsFailureDiagnostics` — a genuine write still overwrites the fingerprint AND clears failure diagnostics (guard does not over-fire).

## Scope / follow-ups
- This PR (PR-A) stops the critical wipe. Residual: the 3 diagnostic fields are still wiped for **failed-fp** books touched by those 4 jobs — operationally minor (`FingerprintFailedAt`, which drives backfill's skip logic, is memdb-kept), and closed structurally by STOREFID W3.
- PR-B (separate): reroute the 3 HEAVY-READ fingerprint no-ops (`acoustid online_lookup`/`lsh_backfill`, `dedup lsh_index_build`) to proxy-then-hydrate.
- Full analysis: `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)