### PR TITLE
fix(fingerprint): restore 3 fingerprint ops that silently no-op under prod memdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@
   `reusable-release.yml` pin here to `falkcorp/github-common@f7e012d`
   (v2.14.3, PR #318).
 
+#### July 6, 2026 - fix(fingerprint): reroute memdb-slim fingerprint no-ops to proxy-then-hydrate
+
+- **`fix(fingerprint)`** — three whole-library fingerprint ops (`acoustid.lsh-backfill`,
+  `dedup.lsh-index-build`, `acoustid.online-lookup`) gated on
+  `len(AcoustIDFingerprint) == 0`, which is **always true** under prod's memdb
+  projection (`stripBookFileForMemdb` nils the raw blob). They silently skipped
+  every file → reported success while doing nothing, stalling LSH indexing and
+  online AcoustID coverage. Fixed by gating on the memdb-safe
+  `AcoustIDFingerprintDurationSec` proxy and hydrating the real fingerprint on
+  demand via `GetBookFiles(bookID)` (raw Pebble): `lsh-backfill` leverages the
+  new `UpdateBookFile` guard (restores the blob on re-save); `lsh-index-build`
+  hydrates per book and was converted to a `registry.RunItems` pool
+  (`Concurrency=NumCPU`, partitioned by BookID) per the multi-core mandate;
+  `online-lookup` hydrates per candidate at API-call time. Empty-blob-after-hydrate
+  (data drift) is counted as an error, never sent to the API.
+
 #### July 6, 2026 - fix(database): stop UpdateBookFile from wiping stored AcoustID fingerprints on memdb-slim writeback
 
 - **`fix(database)`** — `PebbleStore.UpdateBookFile` was a blind full-record

--- a/TODO.md
+++ b/TODO.md
@@ -69,9 +69,17 @@ future agent) can scan the entire workspace in one page.
   `repair_missing_files` — DryRun true). Diagnostic fields NOT guarded here (backfill.go
   clears them on success via this method); the residual diagnostic wipe for failed-fp
   books is closed structurally by W3.
-- **PR-B (open):** reroute the 3 HEAVY-READ fingerprint no-ops (`acoustid online_lookup`,
-  `lsh_backfill`, `dedup lsh_index_build`) to proxy-then-hydrate — they currently drop
-  every candidate under memdb and do nothing.
+- **PR-B (✅ done):** rerouted the 3 HEAVY-READ fingerprint no-ops (`acoustid online_lookup`,
+  `lsh_backfill`, `dedup lsh_index_build`) to proxy-then-hydrate (gate on
+  `AcoustIDFingerprintDurationSec`, hydrate via `GetBookFiles`). `lsh_index_build`
+  converted to a `RunItems` pool partitioned by BookID (index-map grouping to avoid
+  doubling BookFile RSS). Restores LSH/online-lookup coverage that was silently a
+  no-op under prod memdb. Race-safe (mock mutex; prod code was already safe).
+  - **Follow-up (verify invariant):** all 3 ops gate on `AcoustIDFingerprintDurationSec > 0`
+    as the memdb-safe "has whole-file fp" proxy, assuming `AcoustIDFingerprint set ⇒
+    DurationSec > 0` (backfill.go writes both together). A historical row with a blob but
+    `DurationSec == 0` would be silently skipped. Verify with a prod query; if any exist,
+    backfill DurationSec or broaden the gate.
 - **PR-C = STOREFID W3:** retype `GetAllBookFiles → []BookFileCore`; the 4 writeback jobs
   move to field-scoped update/hydrate. **W3 landmine:** those 4 must NOT use a
   `BookFileCore.ToBookFile()` bridge then write back (re-introduces the wipe).

--- a/internal/plugins/acoustid/lsh_backfill.go
+++ b/internal/plugins/acoustid/lsh_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/lsh_backfill.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2c4d6e80-3b5a-4f9c-9b1d-7e8f0a2b4c6d
-// last-edited: 2026-06-24
+// last-edited: 2026-07-06
 
 package acoustid
 
@@ -16,10 +16,6 @@ import (
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
-// lshBackfillProgressEvery controls how often we emit a progress frame
-// during the walk. Matches the per-row fallback in resetAllDef.
-const lshBackfillProgressEvery = 500
-
 // lshIndexChecker is satisfied by any store that can answer "do I already
 // have an LSH index row for this BookFile?". The PebbleStore agent on the
 // sibling branch is adding this method; until it ships, the type assertion
@@ -30,14 +26,26 @@ type lshIndexChecker interface {
 }
 
 // lshBackfillDef registers acoustid.lsh-backfill — the one-shot admin op
-// that walks every BookFile with a stored AcoustIDFingerprint and forces
+// that walks every BookFile with a whole-file fingerprint and forces
 // the LSH secondary index (`fpidx:` + `fpidx_meta:`) to be (re)written.
 //
 // The index hook fires inside PebbleStore.UpdateBookFile, so the operation
-// itself does nothing fancy: it filters for rows that have a raw fp but no
-// existing fpidx_meta entry, then re-saves them. Safe to re-run — if the
-// index is already present the row is skipped (via HasLSHIndex when the
+// itself does nothing fancy: it filters for rows that have a whole-file fp
+// but no existing fpidx_meta entry, then re-saves them. Safe to re-run — if
+// the index is already present the row is skipped (via HasLSHIndex when the
 // store implements it) or harmlessly rewritten (when it does not).
+//
+// Gate uses AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file fingerprint
+// exists) rather than len(AcoustIDFingerprint) == 0, because GetAllBookFiles
+// returns the memdb-slim projection in production (UseMemDB=true) where
+// stripBookFileForMemdb nils the raw AcoustIDFingerprint blob to save RAM —
+// the byte-length gate was always true under memdb, making this op a silent
+// no-op. The row we re-save still carries a nil AcoustIDFingerprint, but
+// PebbleStore.UpdateBookFile restores the stored blob from Pebble whenever
+// the incoming value is empty (the "preserve-on-empty" guard added for the
+// same memdb-slim-roundtrip class of bug) *before* writeBookFileSecondaryIndexes
+// runs, so writeFingerprintLSHIndexes still sees the real fingerprint bytes.
+// No hydrate call is needed here — UpdateBookFile does it for us.
 //
 // Use after deploying the LSH index code to populate the existing ~308K
 // fingerprinted rows without re-running fpcalc.
@@ -94,7 +102,11 @@ func (p *Plugin) runLSHBackfill(ctx context.Context, _ json.RawMessage, reporter
 	var indexed, skippedNoFP, skippedAlreadyIndexed, failed int
 
 	if err := registry.RunItems(ctx, reporter, files, func(ctx context.Context, f database.BookFile) error {
-		if len(f.AcoustIDFingerprint) == 0 {
+		// Proxy gate: AcoustIDFingerprintDurationSec > 0 means a whole-file
+		// fingerprint was computed, even when the memdb-slim row we're
+		// holding has AcoustIDFingerprint stripped to nil. See the doc
+		// comment above for why this is safe to re-save unmodified.
+		if f.AcoustIDFingerprintDurationSec == 0 {
 			skippedNoFP++
 		} else if hasChecker && checker.HasLSHIndex(f.ID) {
 			skippedAlreadyIndexed++

--- a/internal/plugins/acoustid/lsh_backfill_test.go
+++ b/internal/plugins/acoustid/lsh_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/lsh_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3d5e7f91-4c6b-5a0d-ac2e-8f9a1b3c5d7e
-// last-edited: 2026-05-30
+// last-edited: 2026-07-06
 
 package acoustid
 
@@ -65,11 +65,11 @@ func (i *indexableMockStore) HasLSHIndex(id string) bool {
 // should fire.
 func TestLSHBackfill_FiltersAndUpdates(t *testing.T) {
 	files := []database.BookFile{
-		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0xde, 0xad, 0xbe, 0xef}},
+		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0xde, 0xad, 0xbe, 0xef}, AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f2", BookID: "b2"}, // no fp
-		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0xfe, 0xed, 0xfa, 0xce}},
+		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0xfe, 0xed, 0xfa, 0xce}, AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f4", BookID: "b4"}, // no fp
-		{ID: "f5", BookID: "b5", AcoustIDFingerprint: []byte{0xca, 0xfe, 0xba, 0xbe}},
+		{ID: "f5", BookID: "b5", AcoustIDFingerprint: []byte{0xca, 0xfe, 0xba, 0xbe}, AcoustIDFingerprintDurationSec: 1800},
 	}
 
 	var (
@@ -126,9 +126,9 @@ func TestLSHBackfill_FiltersAndUpdates(t *testing.T) {
 // Models the second-run case after a previous successful backfill.
 func TestLSHBackfill_IdempotentWithHasLSHIndex(t *testing.T) {
 	files := []database.BookFile{
-		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0x01, 0x02, 0x03, 0x04}},
-		{ID: "f2", BookID: "b2", AcoustIDFingerprint: []byte{0x05, 0x06, 0x07, 0x08}},
-		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0x09, 0x0a, 0x0b, 0x0c}},
+		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0x01, 0x02, 0x03, 0x04}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f2", BookID: "b2", AcoustIDFingerprint: []byte{0x05, 0x06, 0x07, 0x08}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0x09, 0x0a, 0x0b, 0x0c}, AcoustIDFingerprintDurationSec: 1800},
 	}
 
 	updateCalls := 0
@@ -170,9 +170,9 @@ func TestLSHBackfill_IdempotentWithHasLSHIndex(t *testing.T) {
 // fp are updated.
 func TestLSHBackfill_PartialIndex(t *testing.T) {
 	files := []database.BookFile{
-		{ID: "f1", AcoustIDFingerprint: []byte{1}},
-		{ID: "f2", AcoustIDFingerprint: []byte{2}},
-		{ID: "f3", AcoustIDFingerprint: []byte{3}},
+		{ID: "f1", AcoustIDFingerprint: []byte{1}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f2", AcoustIDFingerprint: []byte{2}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f3", AcoustIDFingerprint: []byte{3}, AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f4"}, // no fp at all
 	}
 	var updates []string
@@ -205,8 +205,9 @@ func TestLSHBackfill_CancelMidRun(t *testing.T) {
 	files := make([]database.BookFile, 100)
 	for i := range files {
 		files[i] = database.BookFile{
-			ID:                  string(rune('a'+i%26)) + "-" + string(rune('0'+i%10)),
-			AcoustIDFingerprint: []byte{byte(i)},
+			ID:                             string(rune('a'+i%26)) + "-" + string(rune('0'+i%10)),
+			AcoustIDFingerprint:            []byte{byte(i)},
+			AcoustIDFingerprintDurationSec: 1800,
 		}
 	}
 
@@ -236,6 +237,48 @@ func TestLSHBackfill_CancelMidRun(t *testing.T) {
 	}
 	if updates >= len(files) {
 		t.Errorf("expected updates < total after cancel, got %d/%d", updates, len(files))
+	}
+}
+
+// TestLSHBackfill_MemdbSlimRowStillTriggersUpdate is the regression test for
+// the memdb-slim no-op bug: GetAllBookFiles returns the memdb-slim projection
+// in production (UseMemDB=true), where stripBookFileForMemdb nils the raw
+// AcoustIDFingerprint blob but preserves AcoustIDFingerprintDurationSec.
+// Before the fix, the gate was len(AcoustIDFingerprint)==0 — always true for
+// a memdb-slim row — so this op silently skipped every fingerprinted file in
+// prod. This test supplies exactly that shape (nil blob, DurationSec>0) and
+// asserts UpdateBookFile still fires; PebbleStore.UpdateBookFile's own
+// preserve-on-empty guard (merged separately) is what restores the real
+// bytes before the LSH secondary index is written.
+func TestLSHBackfill_MemdbSlimRowStillTriggersUpdate(t *testing.T) {
+	files := []database.BookFile{
+		// Memdb-slim shape: blob stripped, duration proxy survives.
+		{ID: "f1", BookID: "b1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
+		// Genuinely unfingerprinted: neither blob nor duration.
+		{ID: "f2", BookID: "b2"},
+	}
+
+	var updates []string
+	store := &database.MockStore{
+		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
+			updates = append(updates, id)
+			return nil
+		},
+	}
+
+	p := &Plugin{store: store}
+	r := &lshTestReporter{}
+
+	if err := p.runLSHBackfill(context.Background(), nil, r); err != nil {
+		t.Fatalf("runLSHBackfill: %v", err)
+	}
+
+	if got, want := len(updates), 1; got != want {
+		t.Fatalf("UpdateBookFile calls = %d, want %d (%v)", got, want, updates)
+	}
+	if updates[0] != "f1" {
+		t.Errorf("expected UpdateBookFile(f1) (memdb-slim, has fp per DurationSec proxy), got %v", updates)
 	}
 }
 

--- a/internal/plugins/acoustid/online_lookup.go
+++ b/internal/plugins/acoustid/online_lookup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/online_lookup.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6e7f8091-a2b3-c4d5-e6f7-08192a3b4c5d
-// last-edited: 2026-05-31
+// last-edited: 2026-07-06
 
 package acoustid
 
@@ -101,30 +101,46 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 
 	// Filter to candidates: must have a whole-file fp, must not already
 	// be looked up (unless Force).
+	//
+	// The gate uses AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file
+	// fingerprint was computed) rather than len(AcoustIDFingerprint)==0,
+	// because GetAllBookFiles returns the memdb-slim projection in
+	// production (UseMemDB=true): stripBookFileForMemdb nils the raw
+	// AcoustIDFingerprint blob to save RAM but keeps DurationSec. The old
+	// byte-length gate was always true under memdb, so this op silently
+	// found zero candidates in prod. The raw bytes themselves are hydrated
+	// per-candidate at API-call time below (this loop is already
+	// network-bound and rate-limited, so a per-candidate Pebble read is
+	// negligible) — we deliberately do NOT stash `raw` from the slim struct
+	// here.
 	type candidate struct {
-		idx  int // original index in files
-		dur  int
-		raw  []byte
+		idx int // original index in files
+		dur int
 	}
 	cands := make([]candidate, 0, 8192)
 	for i := range files {
 		f := &files[i]
-		if len(f.AcoustIDFingerprint) == 0 {
+		dur := int(f.AcoustIDFingerprintDurationSec)
+		if dur <= 0 {
+			// No whole-file fingerprint recorded for this file. NOTE: under
+			// memdb the raw blob is stripped, so DurationSec is the ONLY
+			// surviving "has whole-file fp" signal. This assumes the invariant
+			// "AcoustIDFingerprint set ⇒ AcoustIDFingerprintDurationSec > 0"
+			// (backfill.go writes both together). A historical row with a blob
+			// but DurationSec==0 would be silently skipped here — see the
+			// follow-up in TODO.md (verify with a prod query) before relying on
+			// this for a completeness-critical sweep.
 			continue
 		}
 		if !req.Force && f.AcoustIDOnlineLookedUpAt != nil {
 			continue
-		}
-		dur := int(f.AcoustIDFingerprintDurationSec)
-		if dur <= 0 {
-			dur = int(f.Duration)
 		}
 		if dur < 30 {
 			// Sub-30s fingerprints won't survive AcoustID's matching;
 			// don't burn quota on them.
 			continue
 		}
-		cands = append(cands, candidate{idx: i, dur: dur, raw: f.AcoustIDFingerprint})
+		cands = append(cands, candidate{idx: i, dur: dur})
 	}
 
 	if req.Limit > 0 && len(cands) > req.Limit {
@@ -153,11 +169,46 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 		}
 
 		f := &files[c.idx]
-		// Encode raw bytes to the canonical chromaprint base64+header form
-		// that AcoustID expects.
-		fpStr := fingerprint.EncodeWholeFingerprint(c.raw)
 
-		res, lerr := client.Lookup(ctx, fpStr, c.dur)
+		// Hydrate the raw whole-file fingerprint at API-call time.
+		// GetAllBookFiles strips AcoustIDFingerprint under memdb
+		// (stripBookFileForMemdb); the candidate filter above only checked
+		// the memdb-safe DurationSec proxy, so most candidates land here
+		// with a nil blob. GetBookFiles reads raw Pebble unconditionally
+		// (no UseMemDB check), so it always returns the real bytes.
+		raw := f.AcoustIDFingerprint
+		var hydrateErr error
+		if len(raw) == 0 {
+			if bookFiles, herr := p.store.GetBookFiles(f.BookID); herr != nil {
+				hydrateErr = fmt.Errorf("hydrate GetBookFiles: %w", herr)
+			} else {
+				for _, hf := range bookFiles {
+					if hf.ID == f.ID {
+						raw = hf.AcoustIDFingerprint
+						break
+					}
+				}
+				if len(raw) == 0 {
+					// Data drift: the DurationSec proxy claimed a fingerprint
+					// exists but the raw row has no blob either.
+					hydrateErr = fmt.Errorf("hydrate: no fingerprint bytes for file %s (data drift)", f.ID)
+				}
+			}
+		}
+
+		var res acoustid.LookupResult
+		var lerr error
+		if hydrateErr != nil {
+			// Skip the API call rather than send empty bytes; count it the
+			// same as any other failed lookup so the run's accounting stays
+			// honest and the file gets retried on the next pass.
+			lerr = hydrateErr
+		} else {
+			// Encode raw bytes to the canonical chromaprint base64+header form
+			// that AcoustID expects.
+			fpStr := fingerprint.EncodeWholeFingerprint(raw)
+			res, lerr = client.Lookup(ctx, fpStr, c.dur)
+		}
 		now := time.Now().UTC()
 		if lerr != nil {
 			failed++

--- a/internal/plugins/dedup/lsh_index_build.go
+++ b/internal/plugins/dedup/lsh_index_build.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e61b955e-93bf-4ea6-bb1f-7acd30491fdb
-// last-edited: 2026-06-11
+// last-edited: 2026-07-06
 
 package dedup
 
@@ -10,19 +10,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
-
-// lshBuildBatchSize is the number of BookFiles processed per PebbleDB
-// batch write. 1000 keeps individual batch sizes well under Pebble's
-// internal 4 MB recommendation while amortizing commit overhead across
-// a large library (~15K whole-file fingerprints × 64 bands each = ~1 M
-// key writes for a full rebuild).
-const lshBuildBatchSize = 1000
 
 // LSHIndexStore is the narrow store interface required by the
 // lsh-index-build op. Using a narrow interface keeps the op decoupled
@@ -90,15 +86,28 @@ func (p *Plugin) lshIndexBuildDef() sdk.OperationDef {
 // runLSHIndexBuild is the op runner for dedup.lsh-index-build.
 //
 // Algorithm:
-//  1. Load all BookFiles.
-//  2. For each file with a whole-file fingerprint, derive subprints via
-//     fingerprint.Subprints, then call PutLSHEntries — unless HasLSHIndex
-//     already returns true (incremental skip).
-//  3. Files without a fingerprint are collected by BookID; on completion,
+//  1. Load all BookFiles (memdb-slim projection: AcoustIDFingerprint is nil'd
+//     by stripBookFileForMemdb; AcoustIDFingerprintDurationSec survives as the
+//     memdb-safe proxy for "a whole-file fingerprint exists").
+//  2. Group files by BookID and fan the groups out over a bounded worker pool
+//     (registry.RunItems, Concurrency=runtime.NumCPU()) per the CLAUDE.md
+//     whole-library-concurrency mandate — this loop now does a per-book
+//     Pebble read (hydrate) plus CPU Subprints work per file, which stalled
+//     a single core for hours before CONC remediation. Grouping by book
+//     means each worker touches a disjoint BookID, so no per-file lock or
+//     shared hydrate cache is needed.
+//  3. For each file with a whole-file fp (DurationSec>0) whose blob was
+//     memdb-stripped (len(AcoustIDFingerprint)==0), hydrate the real bytes
+//     via p.store.GetBookFiles(bookID) — a raw Pebble read, never memdb —
+//     once per book, then derive subprints and call PutLSHEntries — unless
+//     HasLSHIndex already returns true (incremental skip).
+//  4. Files without a fingerprint are collected by BookID; on completion,
 //     acoustid.fingerprint-rescan is enqueued for those books so the next
 //     lsh-index-build run can pick them up.
-//  4. Report progress every lshBuildBatchSize files.
-//  5. On completion, set lsh_index_v1_done so T013 can gate on it.
+//  5. Progress is reported per book (RunItems' Label/UpdateProgress) with a
+//     running file-level tally in the label text; a slog heartbeat fires at
+//     most once per logInterval to avoid flooding the log on a ~275K-file run.
+//  6. On completion, set lsh_index_v1_done so T013 can gate on it.
 func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// Obtain the LSH-capable store via type assertion. The concrete
 	// *PebbleStore satisfies LSHIndexStore; SQLite and mock stores may not.
@@ -123,101 +132,202 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	}
 	slog.Info("lsh-index-build: loaded files", "total", total)
 
+	// Group files by BookID so each worker hydrates a book's full BookFile
+	// rows (via p.store.GetBookFiles, a raw Pebble read that bypasses memdb
+	// stripping) at most once, and so registry.RunItems can process disjoint
+	// books in parallel with no shared per-file state. We store INDICES into
+	// `files` (not copies of the BookFile structs) to avoid holding a second
+	// full copy of the whole-library slice — at ~275K+ rows that doubling is
+	// real RSS on a swap-pressured host. `files` and `groups` are built
+	// sequentially and only READ (never mutated) once RunItems starts, so
+	// concurrent reads from worker goroutines are race-free without a lock.
+	bookOrder := make([]string, 0, total)
+	groups := make(map[string][]int, total)
+	for i := range files {
+		bookID := files[i].BookID
+		if _, seen := groups[bookID]; !seen {
+			bookOrder = append(bookOrder, bookID)
+		}
+		groups[bookID] = append(groups[bookID], i)
+	}
+
 	prog := sdk.NewProgress(reporter, total)
 	prog.Start(fmt.Sprintf("Indexing LSH bands: 0 / %d files", total))
 
-	var indexed, skipped, noFP, noFPPermFailed, errs int
+	var mu sync.Mutex
+	var indexed, skipped, noFP, noFPPermFailed, errs, processedFiles int
 	// Track unique book IDs whose files lack a fingerprint so we can
 	// enqueue acoustid.fingerprint-rescan for them after the main loop.
 	// Books are only added if at least one file has never been tried
 	// (FingerprintFailedAt == nil) — permanently-failed files are excluded
-	// to prevent an infinite rescan loop.
+	// to prevent an infinite rescan loop. Guarded by mu (written by every
+	// worker goroutine).
 	noFPBookSet := make(map[string]struct{})
 
-	for i, f := range files {
-		// Respect cancellation at each file boundary.
+	const logInterval = 15 * time.Second
+	lastLog := time.Now()
+
+	runErr := registry.RunItems(ctx, reporter, bookOrder, func(ctx context.Context, bookID string) error {
 		if reporter.IsCanceled() {
-			slog.Info("lsh-index-build: canceled", "processed", i, "indexed", indexed)
 			return context.Canceled
 		}
-		select {
-		case <-ctx.Done():
-			slog.Info("lsh-index-build: context done", "processed", i, "indexed", indexed)
-			return ctx.Err()
-		default:
-		}
 
-		// Files without a fingerprint: only enqueue for fingerprinting if
-		// they haven't permanently failed. Permanently-failed files (too short,
-		// corrupt, DRM) will never yield a fingerprint — don't trigger an
-		// infinite rescan loop. AcoustIDFingerprintDurationSec > 0 is the
-		// memdb-safe proxy for "has whole-file fp" (fingerprint blob stripped
-		// from memdb rows by stripBookFileForMemdb).
-		if len(f.AcoustIDFingerprint) == 0 && f.AcoustIDFingerprintDurationSec == 0 {
-			noFP++
-			if f.FingerprintFailedAt == nil {
-				noFPBookSet[f.BookID] = struct{}{}
-			} else {
-				noFPPermFailed++
+		idxs := groups[bookID] // indices into the read-only `files` slice
+
+		// Does any file in this book carry the proxy (DurationSec>0) but a
+		// memdb-stripped blob (AcoustIDFingerprint==nil)? Only then do we pay
+		// for a hydrate read — most files either have no fp at all (skip) or
+		// (in a cold-start / Pebble-direct run) already carry the real bytes.
+		needsHydrate := false
+		for _, idx := range idxs {
+			f := &files[idx]
+			if f.AcoustIDFingerprintDurationSec > 0 && len(f.AcoustIDFingerprint) == 0 {
+				needsHydrate = true
+				break
 			}
-			continue
 		}
 
-		// Incremental resume: skip files that already have an fpidx_meta row.
-		// PutLSHEntries is idempotent, but the skip avoids unnecessary writes
-		// when re-running after a partial build.
-		if lshStore.HasLSHIndex(f.ID) {
-			skipped++
-			continue
-		}
-
-		// If the fingerprint bytes are nil but the duration proxy indicates a
-		// fingerprint was written (memdb strips AcoustIDFingerprint to save RAM),
-		// we cannot compute subprints. Skip silently; a Pebble-direct run
-		// (UseMemDB=false or cold-start) will index this file on the next pass.
-		if len(f.AcoustIDFingerprint) == 0 {
-			continue
-		}
-
-		subs, bands, fpErr := fingerprint.Subprints(f.AcoustIDFingerprint)
-		if fpErr != nil {
-			// Misaligned fingerprint bytes — log and continue. Don't abort
-			// the entire build for one corrupt row.
-			reporter.Logger().Error("lsh-index-build: Subprints error",
-				"file_id", f.ID, "error", fpErr)
-			errs++
-			continue
-		}
-		if len(subs) == 0 {
-			// Fingerprint too short to sample (< 4 frames after edge trim).
-			// Apply same permanent-failure exclusion as the noFP path above.
-			noFP++
-			if f.FingerprintFailedAt == nil {
-				noFPBookSet[f.BookID] = struct{}{}
+		var hydrated map[string]database.BookFile
+		if needsHydrate {
+			if full, ferr := p.store.GetBookFiles(bookID); ferr != nil {
+				reporter.Logger().Error("lsh-index-build: hydrate GetBookFiles error",
+					"book_id", bookID, "error", ferr)
+				// hydrated stays nil; affected files below fall through to the
+				// "no bytes after hydrate" error path instead of silently
+				// vanishing from the accounting.
 			} else {
-				noFPPermFailed++
+				hydrated = make(map[string]database.BookFile, len(full))
+				for _, hf := range full {
+					hydrated[hf.ID] = hf
+				}
 			}
-			continue
 		}
 
-		if putErr := lshStore.PutLSHEntries(f.ID, f.BookID, subs, bands); putErr != nil {
-			reporter.Logger().Error("lsh-index-build: PutLSHEntries error",
-				"file_id", f.ID, "error", putErr)
-			errs++
-			continue
-		}
-		indexed++
+		var (
+			localIndexed, localSkipped, localNoFP, localNoFPPermFailed, localErrs int
+			localNoFPBooks                                                        []string
+		)
 
-		// Progress every lshBuildBatchSize files and at the last file.
-		if (i+1)%lshBuildBatchSize == 0 || i == total-1 {
-			prog.StepN(i+1, fmt.Sprintf(
-				"Indexing LSH bands: %d / %d files (indexed=%d skipped=%d noFP=%d permFailed=%d errors=%d)",
-				i+1, total, indexed, skipped, noFP, noFPPermFailed, errs))
+		for _, idx := range idxs {
+			f := files[idx]
+			if reporter.IsCanceled() {
+				return context.Canceled
+			}
+
+			// AcoustIDFingerprintDurationSec > 0 is the memdb-safe proxy for
+			// "has whole-file fp" (the blob itself may be stripped to nil).
+			hasWholeFP := len(f.AcoustIDFingerprint) > 0 || f.AcoustIDFingerprintDurationSec > 0
+			if !hasWholeFP {
+				localNoFP++
+				if f.FingerprintFailedAt == nil {
+					localNoFPBooks = append(localNoFPBooks, f.BookID)
+				} else {
+					localNoFPPermFailed++
+				}
+				continue
+			}
+
+			// Incremental resume: skip files that already have an fpidx_meta
+			// row. PutLSHEntries is idempotent, but the skip avoids
+			// unnecessary writes when re-running after a partial build.
+			if lshStore.HasLSHIndex(f.ID) {
+				localSkipped++
+				continue
+			}
+
+			fp := f.AcoustIDFingerprint
+			if len(fp) == 0 {
+				// Memdb-stripped: hydrate from the raw-Pebble read above.
+				if hydrated != nil {
+					if hf, ok := hydrated[f.ID]; ok {
+						fp = hf.AcoustIDFingerprint
+					}
+					if len(fp) == 0 {
+						reporter.Logger().Warn("lsh-index-build: hydrate returned empty fingerprint (data drift)",
+							"file_id", f.ID, "book_id", f.BookID)
+					}
+				}
+				if len(fp) == 0 {
+					// Hydrate failed, or the raw row genuinely has no blob
+					// despite the DurationSec proxy claiming one exists.
+					// Count as an error (not noFP) so it isn't misrouted into
+					// the rescan-enqueue path — the file DOES have a
+					// fingerprint on record, we just couldn't read it this run.
+					localErrs++
+					continue
+				}
+			}
+
+			subs, bands, fpErr := fingerprint.Subprints(fp)
+			if fpErr != nil {
+				// Misaligned fingerprint bytes — log and continue. Don't abort
+				// the entire build for one corrupt row.
+				reporter.Logger().Error("lsh-index-build: Subprints error",
+					"file_id", f.ID, "error", fpErr)
+				localErrs++
+				continue
+			}
+			if len(subs) == 0 {
+				// Fingerprint too short to sample (< 4 frames after edge trim).
+				// Apply same permanent-failure exclusion as the noFP path above.
+				localNoFP++
+				if f.FingerprintFailedAt == nil {
+					localNoFPBooks = append(localNoFPBooks, f.BookID)
+				} else {
+					localNoFPPermFailed++
+				}
+				continue
+			}
+
+			if putErr := lshStore.PutLSHEntries(f.ID, f.BookID, subs, bands); putErr != nil {
+				reporter.Logger().Error("lsh-index-build: PutLSHEntries error",
+					"file_id", f.ID, "error", putErr)
+				localErrs++
+				continue
+			}
+			localIndexed++
+		}
+
+		mu.Lock()
+		indexed += localIndexed
+		skipped += localSkipped
+		noFP += localNoFP
+		noFPPermFailed += localNoFPPermFailed
+		errs += localErrs
+		processedFiles += len(idxs)
+		for _, id := range localNoFPBooks {
+			noFPBookSet[id] = struct{}{}
+		}
+		curProcessed, curIndexed, curSkipped, curNoFP, curPermFailed, curErrs :=
+			processedFiles, indexed, skipped, noFP, noFPPermFailed, errs
+		shouldLog := time.Since(lastLog) >= logInterval || curProcessed >= total
+		if shouldLog {
+			lastLog = time.Now()
+		}
+		mu.Unlock()
+
+		if shouldLog {
 			slog.Info("lsh-index-build: progress",
-				"processed", i+1, "total", total,
-				"indexed", indexed, "skipped", skipped,
-				"no_fp", noFP, "no_fp_perm_failed", noFPPermFailed, "errors", errs)
+				"processed", curProcessed, "total", total,
+				"indexed", curIndexed, "skipped", curSkipped,
+				"no_fp", curNoFP, "no_fp_perm_failed", curPermFailed, "errors", curErrs)
 		}
+
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, t int) string {
+			mu.Lock()
+			curProcessed, curIndexed, curSkipped, curNoFP, curPermFailed, curErrs :=
+				processedFiles, indexed, skipped, noFP, noFPPermFailed, errs
+			mu.Unlock()
+			return fmt.Sprintf("Indexing LSH bands: %d/%d files (indexed=%d skipped=%d noFP=%d permFailed=%d errors=%d) [book %d/%d]",
+				curProcessed, total, curIndexed, curSkipped, curNoFP, curPermFailed, curErrs, i+1, t)
+		},
+	})
+	if runErr != nil {
+		slog.Info("lsh-index-build: stopped", "processed", processedFiles, "indexed", indexed, "error", runErr)
+		return runErr
 	}
 
 	prog.Finalize("writing completion flag…")

--- a/internal/plugins/dedup/lsh_index_build_test.go
+++ b/internal/plugins/dedup/lsh_index_build_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/lsh_index_build_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c1cf5590-1bc1-4f88-9031-62333bcb593f
-// last-edited: 2026-06-11
+// last-edited: 2026-07-06
 
 package dedup
 
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,8 +40,29 @@ func synthRawLSH(seed int64, frames int) []byte {
 type mockLSHStore struct {
 	files        []database.BookFile
 	indexedFiles map[string]bool // HasLSHIndex returns true for these IDs
+	mu           sync.Mutex      // guards putCalls (written concurrently by RunItems workers)
 	putCalls     []string        // fileIDs passed to PutLSHEntries
 	flagSet      bool
+
+	// hydrateFiles simulates the raw-Pebble GetBookFiles(bookID) read that
+	// the hydrate path falls back to when a memdb-slim BookFile row (from
+	// GetAllBookFiles) has AcoustIDFingerprintDurationSec > 0 but a nil
+	// AcoustIDFingerprint blob. Keyed by BookID.
+	hydrateFiles map[string][]database.BookFile
+	// hydrateErr, when non-nil, makes GetBookFiles fail for every book —
+	// simulates a Pebble read error during hydrate.
+	hydrateErr error
+}
+
+// GetBookFiles simulates the raw-Pebble read used to hydrate a memdb-slim
+// BookFile's stripped AcoustIDFingerprint blob. Unlike GetAllBookFiles, a
+// real PebbleStore.GetBookFiles never goes through memdb, so it always
+// returns full rows — the mock mirrors that by returning hydrateFiles as-is.
+func (m *mockLSHStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	if m.hydrateErr != nil {
+		return nil, m.hydrateErr
+	}
+	return m.hydrateFiles[bookID], nil
 }
 
 // database.Store compliance: use nil for the plugin.store field — the
@@ -53,7 +75,9 @@ func (m *mockLSHStore) HasLSHIndex(id string) bool {
 	return m.indexedFiles[id]
 }
 func (m *mockLSHStore) PutLSHEntries(fileID, _ string, _ []fingerprint.Subprint, _ []byte) error {
+	m.mu.Lock()
 	m.putCalls = append(m.putCalls, fileID)
+	m.mu.Unlock()
 	return nil
 }
 func (m *mockLSHStore) IsLSHIndexBuilt() bool {
@@ -107,9 +131,14 @@ type mockLSHStoreAdapter struct {
 	inner          *mockLSHStore
 }
 
-// Override only the LSHIndexStore methods.
+// Override only the LSHIndexStore methods (plus GetBookFiles, used by the
+// hydrate path — it is part of database.BookFileStore/database.Store, not
+// LSHIndexStore, but runLSHIndexBuild calls it via p.store directly).
 func (a *mockLSHStoreAdapter) GetAllBookFiles() ([]database.BookFile, error) {
 	return a.inner.GetAllBookFiles()
+}
+func (a *mockLSHStoreAdapter) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	return a.inner.GetBookFiles(bookID)
 }
 func (a *mockLSHStoreAdapter) HasLSHIndex(id string) bool {
 	return a.inner.HasLSHIndex(id)
@@ -354,5 +383,90 @@ func TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue(t *testing.T) {
 		if id == "book-perm-fail" {
 			t.Errorf("book-perm-fail (all files permanently failed) should not be enqueued")
 		}
+	}
+}
+
+// TestLSHIndexBuild_HydratesMemdbStrippedFingerprint is the regression test
+// for the memdb-slim no-op bug: GetAllBookFiles (the memdb-slim projection
+// under prod's UseMemDB=true) nils AcoustIDFingerprint while preserving
+// AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file fingerprint exists on
+// the raw row). Before the fix, the gate was len(AcoustIDFingerprint)==0,
+// which is always true for a memdb-slim row, so every such file was silently
+// skipped and PutLSHEntries was never called — the op reported success but
+// indexed nothing.
+//
+// This test simulates that shape: file-1 arrives from GetAllBookFiles with a
+// nil blob + DurationSec>0, and GetBookFiles(bookID) — standing in for the
+// real PebbleStore.GetBookFiles, which always reads raw Pebble and is never
+// memdb-stripped — returns the same file WITH the real fingerprint bytes.
+// Asserts the hydrate path recovers the blob and the file gets indexed.
+func TestLSHIndexBuild_HydratesMemdbStrippedFingerprint(t *testing.T) {
+	fp := synthRawLSH(99, 57600)
+
+	ms := &mockLSHStore{
+		files: []database.BookFile{
+			// Memdb-slim projection: DurationSec survives, blob is nil'd.
+			{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
+		},
+		indexedFiles: map[string]bool{},
+		hydrateFiles: map[string][]database.BookFile{
+			"book-1": {
+				{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: fp, AcoustIDFingerprintDurationSec: 1800},
+			},
+		},
+	}
+
+	p := &Plugin{store: &mockLSHStoreAdapter{inner: ms}}
+
+	if err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{}); err != nil {
+		t.Fatalf("runLSHIndexBuild: %v", err)
+	}
+
+	found := false
+	for _, id := range ms.putCalls {
+		if id == "file-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("file-1 (memdb-stripped fingerprint) should have been hydrated via GetBookFiles and indexed via PutLSHEntries; got calls=%v", ms.putCalls)
+	}
+	if !ms.flagSet {
+		t.Errorf("completion flag not set after successful op run")
+	}
+}
+
+// TestLSHIndexBuild_HydrateDataDriftCountsAsErrorNotNoFP verifies that when
+// the proxy (AcoustIDFingerprintDurationSec>0) claims a fingerprint exists
+// but the hydrate read (GetBookFiles) comes back empty — either because it
+// errored or because the raw row genuinely has no blob (data drift) — the
+// file is NOT misclassified as "no fingerprint" (which would enqueue a
+// pointless acoustid.fingerprint-rescan for a book that actually IS
+// fingerprinted). It should be skipped cleanly with no PutLSHEntries call
+// and no rescan enqueue.
+func TestLSHIndexBuild_HydrateDataDriftCountsAsErrorNotNoFP(t *testing.T) {
+	ms := &mockLSHStore{
+		files: []database.BookFile{
+			{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
+		},
+		indexedFiles: map[string]bool{},
+		hydrateFiles: map[string][]database.BookFile{
+			// GetBookFiles "succeeds" but returns no matching file / empty blob.
+			"book-1": {},
+		},
+	}
+
+	reg := &mockRegistry{}
+	p := &Plugin{store: &mockLSHStoreAdapter{inner: ms}, registry: reg}
+
+	if err := p.runLSHIndexBuild(context.Background(), json.RawMessage("{}"), &fakeReporter{}); err != nil {
+		t.Fatalf("runLSHIndexBuild: %v", err)
+	}
+
+	if len(ms.putCalls) != 0 {
+		t.Errorf("expected no PutLSHEntries calls for a data-drift hydrate miss, got %v", ms.putCalls)
+	}
+	if len(reg.enqueuedDefs) != 0 {
+		t.Errorf("book-1 has a fingerprint per the DurationSec proxy — it must NOT be enqueued for fingerprint-rescan, got %d enqueue(s)", len(reg.enqueuedDefs))
 	}
 }


### PR DESCRIPTION
## What was broken

Three whole-library fingerprint ops (`acoustid.lsh-backfill`, `dedup.lsh-index-build`, `acoustid.online-lookup`) gated on `len(f.AcoustIDFingerprint) == 0`. Under prod's `UseMemDB=true`, the memdb projection (`stripBookFileForMemdb`) nils the raw ~230 KB fingerprint blob, so that check was **always true** → every file skipped → the ops reported success while doing nothing. This is why LSH indexing and online AcoustID coverage had stalled. (Found during the STOREFID P3-W3 audit; follow-up to #1839.)

## The fix

memdb strips the blob but **keeps** `AcoustIDFingerprintDurationSec` — so a valid "has whole-file fingerprint" signal survives. Each op now gates on that surviving field and gets the real bytes from raw Pebble (`GetBookFiles(bookID)`) only where actually needed:

| Op | Change |
|---|---|
| `acoustid/lsh_backfill.go` | Gate → `DurationSec`. No extra read — the existing re-save path + #1839's `UpdateBookFile` guard restores the stored blob before `writeFingerprintLSHIndexes`. |
| `dedup/lsh_index_build.go` | Gate → `DurationSec`; hydrate the blob per book via `GetBookFiles`; **sequential loop → `registry.RunItems` pool** (`Concurrency=NumCPU`, partitioned by BookID → disjoint, mutex-guarded counters, index-map grouping so we don't hold a 2nd copy of the ~275K-row slice). Preserves `HasLSHIndex` skip, the no-fp→`fingerprint-rescan` enqueue, cancellation, and the `lsh_index_v1_done` flag. |
| `acoustid/online_lookup.go` | Gate → `DurationSec`; hydrate the raw blob per candidate at API-call time (network-bound, kept sequential). |

Empty-blob-after-hydrate (data drift) is counted as an error, never sent to the AcoustID API.

### Why gate on the kept field here (vs #1830 BookSignatureScan)
`BookSignatureScan` had to fall back to full-hydrate because `stripBookForMemdb` nils **every** signature field — no surviving signal. Here `AcoustIDFingerprintDurationSec` is deliberately kept, so gating on it is correct and read-count-comparable to hydrate-all.

## Review fixes (this revision)
- 🔴 **`-race` blocker fixed:** the test `mockLSHStore.PutLSHEntries` appended to a slice concurrently → CI race gate red. Added a mutex to the mock (prod `PebbleStore.PutLSHEntries` was already safe — `NewBatch/Set/Commit`, no shared maps). `go test -race ./internal/plugins/dedup/... ./internal/plugins/acoustid/...` now green, which also validates the plugin-level guarding the aborting test never reached.
- **Memory:** `lsh_index_build` grouping switched to an index map (`map[string][]int`) to avoid doubling BookFile RSS on a swap-pressured host.
- **Follow-up flagged (TODO + code comment):** the `DurationSec>0` gate assumes `AcoustIDFingerprint set ⇒ DurationSec>0` (backfill writes both together). A historical row with a blob but `DurationSec==0` would be silently skipped — to be verified with a prod query.

## Tests
`TestLSHBackfill_MemdbSlimRowStillTriggersUpdate`, `TestLSHIndexBuild_HydratesMemdbStrippedFingerprint`, `TestLSHIndexBuild_HydrateDataDriftCountsAsErrorNotNoFP`; 4 pre-existing lsh_backfill fixtures corrected (real fingerprinted rows always carry both blob + DurationSec). `build`/`vet`/`-race` (`dedup`+`acoustid`) + full `database` package green.

Full analysis: `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)