### PR TITLE
fix(ci): bump ghcommon pin for GORELEASER_CURRENT_TAG fix

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.10.2
+# version: 2.10.3
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-# last-edited: 2026-07-05
+# last-edited: 2026-07-06
 
 name: Prerelease on Merge
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@c4ea62e7ca3794f13bb6e7a2546a04a90fcd3d1f # v2.14.2 (ghcommon ref-pin fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f7e012d85bf1df8013304327c4831ab142eb209b # v2.14.3 (gha-release-go GORELEASER_CURRENT_TAG pin)
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.9.4
+# version: 4.9.5
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-# last-edited: 2026-07-05
+# last-edited: 2026-07-06
 
 name: Production Release
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@c4ea62e7ca3794f13bb6e7a2546a04a90fcd3d1f # v2.14.2 (ghcommon ref-pin fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f7e012d85bf1df8013304327c4831ab142eb209b # v2.14.3 (gha-release-go GORELEASER_CURRENT_TAG pin)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.111.1 -->
+<!-- version: 3.111.2 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-06 -->
 
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 6, 2026 - fix(ci): bump ghcommon pin for GORELEASER_CURRENT_TAG fix (6th release-pipeline blocker)
+
+- **`fix(ci)`** — after the first 5 release-pipeline fixes, 3 consecutive
+  Production Release attempts still failed: each computed the correct
+  stable tag (e.g. `v0.217.3`, `v0.217.4`, `v0.217.5`), but GoReleaser's
+  `git describe`-based "current tag" detection non-deterministically
+  picked a concurrent RC tag instead whenever a `Prerelease on Merge` run
+  (triggered by an ordinary PR merge) tagged the same commit first —
+  causing asset uploads to collide with that RC's already-published
+  assets (`422 already_exists`). Root cause traced to `gha-release-go`
+  never setting `GORELEASER_CURRENT_TAG`, GoReleaser's own documented
+  mechanism for "cases where one git commit is referenced by multiple
+  git tags." Fixed in `falkcorp/gha-release-go#7` (v2.0.1) and bumped the
+  `reusable-release.yml` pin here to `falkcorp/github-common@f7e012d`
+  (v2.14.3, PR #318).
 
 #### July 6, 2026 - fix(database): stop UpdateBookFile from wiping stored AcoustID fingerprints on memdb-slim writeback
 


### PR DESCRIPTION
## Summary
- Bumps the `reusable-release.yml` pin to `falkcorp/github-common@f7e012d` (v2.14.3, PR #318), which bumps `gha-release-go` to v2.0.1 ([falkcorp/gha-release-go#7](https://github.com/falkcorp/gha-release-go/pull/7)) pinning `GORELEASER_CURRENT_TAG`.
- Fixes the 6th release-pipeline blocker found today: 3 consecutive Production Release attempts computed the correct stable tag but failed on asset-upload collision because GoReleaser's `git describe` non-deterministically picked a concurrent RC tag instead, whenever a routine PR-merge-triggered prerelease tagged the same commit first.

## Test plan
- [ ] Merge, then retry the Production Release dispatch and confirm it completes as a genuine stable release even under concurrent prerelease activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwFZuDA7Cr9y9Cm8T9e6KT