### PR TITLE
fix(ci): bump ghcommon pin for cleanup-step self-delete guard

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/prerelease.yml
-# version: 2.10.3
+# version: 2.10.4
 # guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 # last-edited: 2026-07-06
 
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f7e012d85bf1df8013304327c4831ab142eb209b # v2.14.3 (gha-release-go GORELEASER_CURRENT_TAG pin)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@b3f278f1b6fe7b08f428ce6335a1f24a961f1718 # v2.14.4 (cleanup-step self-delete guard)
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,5 +1,5 @@
 # file: .github/workflows/release-prod.yml
-# version: 4.9.5
+# version: 4.9.6
 # guid: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
 # last-edited: 2026-07-06
 
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@f7e012d85bf1df8013304327c4831ab142eb209b # v2.14.3 (gha-release-go GORELEASER_CURRENT_TAG pin)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@b3f278f1b6fe7b08f428ce6335a1f24a961f1718 # v2.14.4 (cleanup-step self-delete guard)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.111.2 -->
+<!-- version: 3.111.3 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-06 -->
 
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 6, 2026 - fix(ci): bump ghcommon pin for cleanup-step self-delete guard (7th release-pipeline blocker)
+
+- **`fix(ci)`** — after the `GORELEASER_CURRENT_TAG` fix resolved the tag
+  ambiguity, the very next Production Release run (`v0.217.6`) reported
+  full success end-to-end (binaries, Docker artifact, changelog all
+  uploaded, "🎉 Release ready" logged) — but `gh release view v0.217.6`
+  404'd immediately afterward. Traced to the same job's own
+  "Clean up superseded drafts and prereleases" step: its `gh release
+  list --json tagName,isDraft,isPrerelease` query returned the
+  just-created stable release's own tag as if it were a draft/prerelease
+  (likely a stale list read, or a leftover rolling-draft placeholder
+  reused under the same tag), and the step deleted it seconds after
+  publish (job log: `Deleting superseded release: v0.217.6 (base
+  0.217.6 <= 0.217.6)`). Fixed in `falkcorp/github-common#319` (v2.14.4)
+  by hard-guarding the cleanup loop against ever deleting a tag matching
+  `$STABLE_VERSION`, independent of what `isDraft`/`isPrerelease` report.
+  Bumped the `reusable-release.yml` pin here to
+  `falkcorp/github-common@b3f278f`.
 
 #### July 6, 2026 - fix(ci): bump ghcommon pin for GORELEASER_CURRENT_TAG fix (6th release-pipeline blocker)
 


### PR DESCRIPTION
## Summary

- The v0.217.6 Production Release run succeeded end-to-end (Build Go/Frontend/Docker, Create GitHub Release all green, assets uploaded, "🎉 Release ready" logged) but the release was immediately deleted by the same job's "Clean up superseded drafts and prereleases" step, which mistook the just-created stable release's own tag for a superseded draft/prerelease.
- Fixed upstream in `falkcorp/github-common#319` (v2.14.4): the cleanup loop now hard-guards against ever deleting a tag matching `$STABLE_VERSION`.
- Bumps the `reusable-release.yml` pin in both `prerelease.yml` and `release-prod.yml` to `falkcorp/github-common@b3f278f`.

## Test plan

- [ ] CI green on this PR
- [ ] Dispatch Production Release and confirm the resulting stable release persists (`gh release view <tag>` succeeds with `draft:false`, `prerelease:false`, binaries + Docker + changelog present)