### PR TITLE
refactor(store): GetAllBookFiles → GetAllBookFilesCore ([]BookFileCore) (STOREFID W3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.111.3 -->
+<!-- version: 3.112.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-06 -->
 
@@ -8,6 +8,26 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 6, 2026 - refactor(store): GetAllBookFiles → GetAllBookFilesCore ([]BookFileCore) (STOREFID W3)
+
+- **`refactor(store)`** — renamed the slim store getter `GetAllBookFiles()` →
+  `GetAllBookFilesCore()` returning `[]BookFileCore`, so any caller that reads a
+  memdb-stripped fingerprint field is now a **compile error** instead of a silent
+  nil read. Atomic across the `Store` interface, `PebbleStore`, `MemStore`, the
+  hand-written `MockStore`, and the mockery-generated mock.
+- **Fingerprint-wipe closure** — the retype compile-forced **8 whole-library
+  writeback jobs** off the "read memdb-slim → write the whole struct back"
+  anti-pattern (which wiped stored fingerprint diagnostics) and onto
+  hydrate-mutate-update (`GetBookFiles(bookID)` → mutate the full row →
+  `UpdateBookFile`): recompute_itunes_paths, enrich_book_files, fix_book_file_paths,
+  repair_missing_files, tag_backfill, reset_all (slow path), acoustid online_lookup,
+  acoustid lsh_backfill. The compile audit also corrected the caller census: two of
+  these (tag_backfill, reset_all) were originally mis-classified as safe/test-only.
+- The deluge getter `GetBookFilesNeedingDelugeImport` is kept byte-identical (its
+  non-memdb branch re-points to the internal full `getAllBookFilesPebbleScan()`); the
+  3 indirect deluge import writeback vectors it feeds are documented and deferred to a
+  fast-follow (see TODO / the memdb-writeback audit doc).
 
 #### July 6, 2026 - fix(ci): bump ghcommon pin for cleanup-step self-delete guard (7th release-pipeline blocker)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.65.0 -->
+<!-- version: 9.66.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-06 -->
 
@@ -17,6 +17,32 @@ future agent) can scan the entire workspace in one page.
 - [`docs/implementation-guide.md`](docs/implementation-guide.md) — integration guide for open items
 - [`docs/codebase-evaluation.md`](docs/codebase-evaluation.md) — 2026-04-30 codebase audit (12 issue groups, 38 bot-tasks)
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
+
+---
+
+## 🟠 PR-D: deluge import fingerprint-wipe (3 impls) — fast-follow after STOREFID W3 (2026-07-06)
+
+- **NEW finding** during STOREFID W3 caller audit. Three deluge import paths read a
+  BookFile from `GetBookFilesNeedingDelugeImport` (memdb-slim in prod) and write it
+  back via `UpdateBookFile`, wiping fingerprint **diagnostic** fields (the
+  `AcoustIDFingerprint` blob is guarded by PR-A #1839):
+  - `internal/deluge/import.go` `ImportToLibrary` (~L68-72)
+  - `internal/maintenance/jobs/bulk_deluge_import.go` `bdi_importToLibrary` (~L200-202)
+  - `internal/plugins/deluge/centralization.go` (~L144-146)
+- **Fix:** hydrate the full row via `GetBookFiles(bookID)` at each writeback point
+  (same shape as the W3 jobs). Do NOT make the getter return full via bulk hydrate —
+  `maxBooks` defaults to 0 (uncapped) and caps AFTER the getter, so a full-blob slice
+  would reintroduce the memdb RAM anti-pattern.
+- Root cause + census: `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.
+
+## 🟡 Verify DurationSec invariant for the 3 PR-B fingerprint ops (2026-07-06)
+
+- The 3 rerouted ops (lsh_backfill / lsh_index_build / online_lookup) gate on
+  `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has a whole-file
+  fingerprint". This assumes `AcoustIDFingerprint set ⇒ DurationSec > 0`. **Run a prod
+  query** for `book_file` rows with a non-empty fingerprint blob but `DurationSec == 0`;
+  if any exist they are silently skipped — backfill `DurationSec` or broaden the gate.
+  Code comment in `internal/plugins/acoustid/online_lookup.go`.
 
 ---
 

--- a/docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md
+++ b/docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md
@@ -1,5 +1,5 @@
 <!-- file: docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 3f9b1c22-7a4e-4d19-9c66-2e0a5b8d4471 -->
 <!-- last-edited: 2026-07-06 -->
 
@@ -68,6 +68,17 @@ no longer write a whole `BookFile` back, forcing a field-scoped update or a full
 PR-A's `AcoustIDFingerprint` guard stops the critical wipe for all four immediately; W3
 closes the diagnostic-field residue by making them field-scoped/hydrate.
 
+**W3 caller-audit correction (2026-07-06):** the `GetAllBookFilesCore` retype (W3/PR-C)
+compile-surfaced **two more direct writeback sites the original census under-classified** —
+both now on hydrate-mutate-update in W3:
+- `tag_backfill` (`internal/plugins/maintenance/tag_backfill.go`) — builds `pending` from the
+  slim list and writes via `BatchUpsertBookFiles`. The batch guard protects the
+  `AcoustIDFingerprint` blob but NOT the 3 diagnostic fields; originally listed as "safe".
+- `reset_all` slow path (`internal/plugins/acoustid/reset_all.go`) — writes back `AcoustIDSeg0..6`;
+  those fields are memdb-STRIPPED (not on Core), so the retype forces a hydrate to even read
+  them. Prod still uses the `ClearAllAcoustIDFingerprints` fast path (this path is mock/sqlite
+  only), so no prod exposure — but it is a writeback of stripped fields, not a pure test-fallback.
+
 ### HEAVY-READ — functional no-op under memdb (prod)  → PR-B
 | Op | file:line | Symptom |
 |---|---|---|
@@ -85,13 +96,36 @@ RAM blowup memdb prevents).
 `UpdateBookFile` path is gated behind a `*PebbleStore` type assertion for mock/sqlite
 tests; prod uses the bulk-clear path (`ClearAllAcoustIDFingerprints`). Unreachable in prod.
 
+### INDIRECT (via `GetBookFilesNeedingDelugeImport`) — NEW finding 2026-07-06, deferred to PR-D
+The original census scanned only **direct** `GetAllBookFiles` callers. `GetBookFilesNeedingDelugeImport`
+also returns the memdb-slim projection under prod, and **three deluge import paths** read a file
+struct from it and write it back via `UpdateBookFile`:
+| Path | file:line | mutates |
+|---|---|---|
+| shared `ImportToLibrary` | `internal/deluge/import.go` (~68-72) | `DelugeOriginalPath`, `FilePath`, `ImportedFromDelugeAt` |
+| `bulk_deluge_import` | `internal/maintenance/jobs/bulk_deluge_import.go` (`bdi_importToLibrary` ~200-202) | `ImportedFromDelugeAt` |
+| `deluge centralization` | `internal/plugins/deluge/centralization.go` (~144-146) | `ImportedFromDelugeAt` |
+
+Post-PR-A the `AcoustIDFingerprint` blob is guarded; the 3 diagnostic fields are still wiped for
+any fingerprinted file these paths import. **NOT fixed in W3** — W3 keeps
+`GetBookFilesNeedingDelugeImport` byte-identical (its non-memdb branch was re-pointed to the
+internal full `getAllBookFilesPebbleScan()`; the memdb branch is unchanged). Fix rides in a
+fast-follow **PR-D**: hydrate the full row at each of the three writeback points (same
+hydrate-mutate-update shape as the W3 jobs). Option Y (making the getter return full via a bulk
+hydrate) was rejected — `bulk_deluge_import`'s `maxBooks` defaults to 0 and caps AFTER the getter
+returns, so a full-blob slice of the whole un-imported subset would reintroduce the RAM anti-pattern.
+
 ## Fix sequencing
 
 1. **PR-A (shipped):** `AcoustIDFingerprint` preserve-on-empty guard on `UpdateBookFile` + two-direction regression test. Stops the critical wipe.
 2. **PR-B:** reroute the 3 HEAVY-READ fingerprint ops to proxy-then-hydrate (restores coverage).
 3. **PR-C (= STOREFID W3):** retype `GetAllBookFiles → []BookFileCore`; 13 LIGHT callers retype; the 4 writeback jobs move to field-scoped update/hydrate (closing the diagnostic residue). **W3 landmine: do NOT let the 4 writeback jobs use a `BookFileCore.ToBookFile()` bridge then write back — that reconstructs a nil-fingerprint `BookFile` and re-introduces the wipe (the guard only saves `AcoustIDFingerprint`, not diagnostics). Require field-scoped update or full hydrate.**
 
-## Full per-caller classification
-13 LIGHT, 3 HEAVY-READ, 4 HEAVY-WRITEBACK, 1 TEST-FALLBACK (of 21 external callers).
-`tag_backfill` + `backfill_file_hashes` write back but via the GUARDED
-`BatchUpsertBookFiles` / named-field `SetBookFileHash` respectively — safe.
+## Full per-caller classification (revised after W3 compile audit, 2026-07-06)
+Direct `GetAllBookFiles` callers: **~11 LIGHT**, 3 HEAVY-READ, **6 HEAVY-WRITEBACK**
+(recompute_itunes_paths, enrich_book_files, fix_book_file_paths, repair_missing_files,
+**tag_backfill**, **reset_all** slow path), all moved to hydrate-mutate-update in W3.
+`backfill_file_hashes` writes via the named-field `SetBookFileHash` — safe, stays LIGHT.
+`fs_regroup_xml` reads only `BookID` from the slim list; its `UpdateBookFile` writes a
+separately-fetched `GetBookFileByPath` full row — safe, stays LIGHT. Plus 3 INDIRECT deluge
+vectors via `GetBookFilesNeedingDelugeImport` (see above) — deferred to PR-D.

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -135,9 +135,12 @@ type BookFileStore interface {
 	CreateBookFile(file *BookFile) error
 	UpdateBookFile(id string, file *BookFile) error
 	GetBookFiles(bookID string) ([]BookFile, error)
-	// GetAllBookFiles is SLIM (memdb projection) — see
-	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetAllBookFiles() ([]BookFile, error)
+	// GetAllBookFilesCore returns the BookFileCore projection (SLIM — memdb
+	// projection under UseMemDB, projected via .Core() under Pebble-direct) —
+	// see docs/specs/2026-07-05-store-getter-fidelity-unification.md. The
+	// BookFileCore return type makes reading a stripped fingerprint field a
+	// compile error instead of a silent nil.
+	GetAllBookFilesCore() ([]BookFileCore, error)
 	// GetBookFilesNeedingDelugeImport returns book_files that have a deluge_hash
 	// but have not yet been copied into the library (imported_from_deluge_at IS NULL).
 	//

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -821,24 +821,25 @@ func (m *MemStore) GetBookFilesForIDsCore(bookIDs []string) (map[string][]BookFi
 	return result, nil
 }
 
-// GetAllBookFiles returns every BookFile in the memdb book_files table by
-// iterating the primary ID index. O(N) pointer walk over the in-memory table
-// — no JSON unmarshal, no Pebble disk scan. For 308K book_files this is
-// roughly two orders of magnitude faster than the Pebble full-scan fallback.
-func (m *MemStore) GetAllBookFiles() ([]BookFile, error) {
+// GetAllBookFilesCore returns the BookFileCore projection of every BookFile
+// in the memdb book_files table by iterating the primary ID index. O(N)
+// pointer walk over the in-memory table — no JSON unmarshal, no Pebble disk
+// scan. For 308K book_files this is roughly two orders of magnitude faster
+// than the Pebble full-scan fallback.
+func (m *MemStore) GetAllBookFilesCore() ([]BookFileCore, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
 	iter, err := txn.Get(memTableBookFiles, memIdxID)
 	if err != nil {
 		return nil, fmt.Errorf("memdb book_files scan: %w", err)
 	}
-	var files []BookFile
+	var files []BookFileCore
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		bf, ok := obj.(*BookFile)
 		if !ok {
 			continue
 		}
-		files = append(files, *bf)
+		files = append(files, bf.Core())
 	}
 	return files, nil
 }

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.71.0
+// version: 1.72.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -340,7 +340,7 @@ type MockStore struct {
 
 	// BookFile methods
 	CreateBookFileFunc                  func(file *BookFile) error
-	GetAllBookFilesFunc                 func() ([]BookFile, error)
+	GetAllBookFilesCoreFunc             func() ([]BookFileCore, error)
 	UpdateBookFileFunc                  func(id string, file *BookFile) error
 	UpdateBookFileHashesFunc            func(id, originalHash, postMetadataHash string) error
 	GetBookFilesFunc                    func(bookID string) ([]BookFile, error)
@@ -2388,9 +2388,9 @@ func (m *MockStore) GetBookFiles(bookID string) ([]BookFile, error) {
 	}
 	return nil, nil
 }
-func (m *MockStore) GetAllBookFiles() ([]BookFile, error) {
-	if m.GetAllBookFilesFunc != nil {
-		return m.GetAllBookFilesFunc()
+func (m *MockStore) GetAllBookFilesCore() ([]BookFileCore, error) {
+	if m.GetAllBookFilesCoreFunc != nil {
+		return m.GetAllBookFilesCoreFunc()
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -14459,24 +14459,24 @@ func (_c *MockBookFileStore_GetAcoustIDStats_Call) RunAndReturn(run func() (*dat
 	return _c
 }
 
-// GetAllBookFiles provides a mock function for the type MockBookFileStore
-func (_mock *MockBookFileStore) GetAllBookFiles() ([]database.BookFile, error) {
+// GetAllBookFilesCore provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) GetAllBookFilesCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBookFiles")
+		panic("no return value specified for GetAllBookFilesCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -14487,29 +14487,29 @@ func (_mock *MockBookFileStore) GetAllBookFiles() ([]database.BookFile, error) {
 	return r0, r1
 }
 
-// MockBookFileStore_GetAllBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFiles'
-type MockBookFileStore_GetAllBookFiles_Call struct {
+// MockBookFileStore_GetAllBookFilesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFilesCore'
+type MockBookFileStore_GetAllBookFilesCore_Call struct {
 	*mock.Call
 }
 
-// GetAllBookFiles is a helper method to define mock.On call
-func (_e *MockBookFileStore_Expecter) GetAllBookFiles() *MockBookFileStore_GetAllBookFiles_Call {
-	return &MockBookFileStore_GetAllBookFiles_Call{Call: _e.mock.On("GetAllBookFiles")}
+// GetAllBookFilesCore is a helper method to define mock.On call
+func (_e *MockBookFileStore_Expecter) GetAllBookFilesCore() *MockBookFileStore_GetAllBookFilesCore_Call {
+	return &MockBookFileStore_GetAllBookFilesCore_Call{Call: _e.mock.On("GetAllBookFilesCore")}
 }
 
-func (_c *MockBookFileStore_GetAllBookFiles_Call) Run(run func()) *MockBookFileStore_GetAllBookFiles_Call {
+func (_c *MockBookFileStore_GetAllBookFilesCore_Call) Run(run func()) *MockBookFileStore_GetAllBookFilesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBookFileStore_GetAllBookFiles_Call) Return(bookFiles []database.BookFile, err error) *MockBookFileStore_GetAllBookFiles_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockBookFileStore_GetAllBookFilesCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockBookFileStore_GetAllBookFilesCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockBookFileStore_GetAllBookFiles_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockBookFileStore_GetAllBookFiles_Call {
+func (_c *MockBookFileStore_GetAllBookFilesCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockBookFileStore_GetAllBookFilesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -34008,24 +34008,24 @@ func (_c *MockStore_GetAllBlockedHashes_Call) RunAndReturn(run func() ([]databas
 	return _c
 }
 
-// GetAllBookFiles provides a mock function for the type MockStore
-func (_mock *MockStore) GetAllBookFiles() ([]database.BookFile, error) {
+// GetAllBookFilesCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllBookFilesCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBookFiles")
+		panic("no return value specified for GetAllBookFilesCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -34036,29 +34036,29 @@ func (_mock *MockStore) GetAllBookFiles() ([]database.BookFile, error) {
 	return r0, r1
 }
 
-// MockStore_GetAllBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFiles'
-type MockStore_GetAllBookFiles_Call struct {
+// MockStore_GetAllBookFilesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFilesCore'
+type MockStore_GetAllBookFilesCore_Call struct {
 	*mock.Call
 }
 
-// GetAllBookFiles is a helper method to define mock.On call
-func (_e *MockStore_Expecter) GetAllBookFiles() *MockStore_GetAllBookFiles_Call {
-	return &MockStore_GetAllBookFiles_Call{Call: _e.mock.On("GetAllBookFiles")}
+// GetAllBookFilesCore is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetAllBookFilesCore() *MockStore_GetAllBookFilesCore_Call {
+	return &MockStore_GetAllBookFilesCore_Call{Call: _e.mock.On("GetAllBookFilesCore")}
 }
 
-func (_c *MockStore_GetAllBookFiles_Call) Run(run func()) *MockStore_GetAllBookFiles_Call {
+func (_c *MockStore_GetAllBookFilesCore_Call) Run(run func()) *MockStore_GetAllBookFilesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockStore_GetAllBookFiles_Call) Return(bookFiles []database.BookFile, err error) *MockStore_GetAllBookFiles_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockStore_GetAllBookFilesCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockStore_GetAllBookFilesCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockStore_GetAllBookFiles_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockStore_GetAllBookFiles_Call {
+func (_c *MockStore_GetAllBookFilesCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockStore_GetAllBookFilesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_bookfile_preserve_test.go
+++ b/internal/database/pebble_bookfile_preserve_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_bookfile_preserve_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 7e1a9c43-2b86-4d05-9f71-3c6e8a0d2b54
 // last-edited: 2026-07-06
 
@@ -336,9 +336,9 @@ func TestUpdateBookFile_WritesFreshFingerprintAndClearsFailureDiagnostics(t *tes
 func strPtr(s string) *string { return &s }
 
 // BatchUpsertBookFiles must refresh the memdb view so batch-written rows are
-// immediately visible to memdb-backed reads (GetAllBookFiles / the UI). Without
-// the post-commit UpsertBookFileToMemDB, the row would be absent from memdb until
-// the next warmup — the tag-backfill non-convergence bug.
+// immediately visible to memdb-backed reads (GetAllBookFilesCore / the UI).
+// Without the post-commit UpsertBookFileToMemDB, the row would be absent
+// from memdb until the next warmup — the tag-backfill non-convergence bug.
 func TestBatchUpsertBookFiles_RefreshesMemDB(t *testing.T) {
 	s, err := NewPebbleStore(t.TempDir())
 	if err != nil {
@@ -358,9 +358,9 @@ func TestBatchUpsertBookFiles_RefreshesMemDB(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("BatchUpsertBookFiles: %v", err)
 	}
-	all, err := s.GetAllBookFiles() // memdb-backed view
+	all, err := s.GetAllBookFilesCore() // memdb-backed view
 	if err != nil {
-		t.Fatalf("GetAllBookFiles: %v", err)
+		t.Fatalf("GetAllBookFilesCore: %v", err)
 	}
 	found := false
 	for i := range all {

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
 // last-edited: 2026-07-06
 
@@ -401,24 +401,35 @@ func (s *PebbleStore) getBookFilesForIDsPebbleScan(bookIDs []string) (map[string
 	return result, nil
 }
 
-// GetAllBookFiles returns every BookFile in the database. When memdb is
-// published, iterates the in-memory book_files table — a pointer walk over
-// ~308K rows — instead of a Pebble prefix scan with per-row JSON unmarshal.
-// Mirrors the GetBookFilesForIDsCore fastpath from PR #1153.
+// GetAllBookFilesCore returns the BookFileCore projection of every BookFile
+// in the database. When memdb is published, iterates the in-memory
+// book_files table — a pointer walk over ~308K rows — instead of a Pebble
+// prefix scan with per-row JSON unmarshal. Mirrors the GetBookFilesForIDsCore
+// fastpath from PR #1153.
 //
 // Pebble full-scan retained as fallback for cold-start (before memdb
-// publishes) and tests with no memdb.
+// publishes) and tests with no memdb; rows are projected via .Core() so the
+// return type is identical (slim) regardless of path.
 //
-// SLIM (memdb projection): returns rows with heavy fields nil'd —
+// SLIM: BookFileCore drops the heavy fields nil'd by the memdb strip —
 // FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
 // AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
-// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
-// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (s *PebbleStore) GetAllBookFiles() ([]BookFile, error) {
+// kept on Core). A caller that needs any of those MUST fetch via
+// GetBookFiles(bookID) (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (s *PebbleStore) GetAllBookFilesCore() ([]BookFileCore, error) {
 	if s.UseMemDB && s.mem() != nil {
-		return s.mem().GetAllBookFiles()
+		return s.mem().GetAllBookFilesCore()
 	}
-	return s.getAllBookFilesPebbleScan()
+	full, err := s.getAllBookFilesPebbleScan()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]BookFileCore, len(full))
+	for i := range full {
+		out[i] = full[i].Core()
+	}
+	return out, nil
 }
 
 func (s *PebbleStore) getAllBookFilesPebbleScan() ([]BookFile, error) {
@@ -505,7 +516,7 @@ func (s *PebbleStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
 	if s.UseMemDB && s.mem() != nil {
 		return s.mem().GetBookFilesNeedingDelugeImport()
 	}
-	all, err := s.GetAllBookFiles()
+	all, err := s.getAllBookFilesPebbleScan()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
-// last-edited: 2026-07-03
+// last-edited: 2026-07-06
 
 package database
 
@@ -462,7 +462,7 @@ func (p *PebbleStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, 
 	if limit <= 0 {
 		limit = 50
 	}
-	files, err := p.GetAllBookFiles()
+	files, err := p.GetAllBookFilesCore()
 	if err != nil {
 		return nil, fmt.Errorf("GetDuplicateFilesByHash: %w", err)
 	}
@@ -477,7 +477,7 @@ func (p *PebbleStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, 
 	}
 
 	type group struct {
-		files []BookFile
+		files []BookFileCore
 	}
 	byHash := make(map[string]*group)
 	for i := range files {
@@ -533,7 +533,7 @@ func (p *PebbleStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, 
 // returns aggregate hash-coverage statistics, including a per-library breakdown
 // derived from each file's source_import_path on its parent book.
 func (p *PebbleStore) GetBookFileHashStats() (*BookFileHashStats, error) {
-	files, err := p.GetAllBookFiles()
+	files, err := p.GetAllBookFilesCore()
 	if err != nil {
 		return nil, fmt.Errorf("GetBookFileHashStats: %w", err)
 	}
@@ -653,8 +653,9 @@ func (p *PebbleStore) GetBookMetadataHashStats() (*BookMetadataHashStats, error)
 // GetAcoustIDStats returns fingerprint coverage across all book files, grouped by
 // library root (the parent book's source_import_path).
 //
-// Uses getAllBookFilesPebbleScan (Pebble-direct) rather than GetAllBookFiles
-// so that the hasFP check reads the full AcoustIDSeg0..6 fields from storage.
+// Uses getAllBookFilesPebbleScan (Pebble-direct) rather than
+// GetAllBookFilesCore so that the hasFP check reads the full AcoustIDSeg0..6
+// fields from storage.
 // After fable5 T019 those fields are stripped from memdb projections; reading
 // them from memdb would return all-zeros and undercount fingerprinted files.
 func (p *PebbleStore) GetAcoustIDStats() (*AcoustIDStats, error) {

--- a/internal/maintenance/jobs/backfill_file_hashes.go
+++ b/internal/maintenance/jobs/backfill_file_hashes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_file_hashes.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: a1000014-0000-0000-0000-000000000014
-// last-edited: 2026-05-16
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -28,7 +28,7 @@ func (j *backfillFileHashesJob) Description() string { return "Compute and store
 // Job supports checkpoint-based resume after restart.
 func (j *backfillFileHashesJob) CanResume() bool { return true }
 func (j *backfillFileHashesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err
 	}

--- a/internal/maintenance/jobs/backfill_file_hashes_test.go
+++ b/internal/maintenance/jobs/backfill_file_hashes_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_file_hashes_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
-// last-edited: 2026-05-16
+// last-edited: 2026-07-06
 
 package jobs_test
 
@@ -35,10 +35,10 @@ func TestBackfillFileHashesJob_Metadata(t *testing.T) {
 
 func TestBackfillFileHashesJob_SkipsAlreadyHashed(t *testing.T) {
 	hash := "existinghash"
-	files := []database.BookFile{{ID: "f1", FilePath: "/tmp/audio.m4b", FileHash: hash}}
+	files := []database.BookFileCore{{ID: "f1", FilePath: "/tmp/audio.m4b", FileHash: hash}}
 	var setCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
 	}
 
@@ -60,10 +60,10 @@ func TestBackfillFileHashesJob_HashesNewFile(t *testing.T) {
 	wantSum := sha256.Sum256(content)
 	wantHash := fmt.Sprintf("%x", wantSum)
 
-	files := []database.BookFile{{ID: "f2", FilePath: f.Name(), FileHash: ""}}
+	files := []database.BookFileCore{{ID: "f2", FilePath: f.Name(), FileHash: ""}}
 	var gotHash string
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		SetBookFileHashFunc: func(id, h string) error { gotHash = h; return nil },
 	}
 
@@ -79,10 +79,10 @@ func TestBackfillFileHashesJob_DryRun_SkipsWrite(t *testing.T) {
 	_, _ = f.WriteString("audio")
 	f.Close()
 
-	files := []database.BookFile{{ID: "f3", FilePath: f.Name(), FileHash: ""}}
+	files := []database.BookFileCore{{ID: "f3", FilePath: f.Name(), FileHash: ""}}
 	var setCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
 	}
 
@@ -93,11 +93,11 @@ func TestBackfillFileHashesJob_DryRun_SkipsWrite(t *testing.T) {
 }
 
 func TestBackfillFileHashesJob_MissingFile_Warns(t *testing.T) {
-	files := []database.BookFile{{ID: "f4", FilePath: "/nonexistent/path/audio.m4b", FileHash: ""}}
+	files := []database.BookFileCore{{ID: "f4", FilePath: "/nonexistent/path/audio.m4b", FileHash: ""}}
 	var setCalled bool
 	rep := &noopReporter{}
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		SetBookFileHashFunc: func(id, h string) error { setCalled = true; return nil },
 	}
 
@@ -109,12 +109,12 @@ func TestBackfillFileHashesJob_MissingFile_Warns(t *testing.T) {
 }
 
 func TestBackfillFileHashesJob_Cancellation(t *testing.T) {
-	files := make([]database.BookFile, 10)
+	files := make([]database.BookFileCore, 10)
 	for i := range files {
-		files[i] = database.BookFile{ID: fmt.Sprintf("f%d", i), FilePath: "/tmp/x.m4b", FileHash: ""}
+		files[i] = database.BookFileCore{ID: fmt.Sprintf("f%d", i), FilePath: "/tmp/x.m4b", FileHash: ""}
 	}
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/maintenance/jobs/enrich_book_files.go
+++ b/internal/maintenance/jobs/enrich_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/enrich_book_files.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000009-0000-0000-0000-000000000009
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -35,7 +35,7 @@ func (j *enrichBookFilesJob) Description() string {
 }
 func (j *enrichBookFilesJob) CanResume() bool { return false }
 func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err
 	}
@@ -46,11 +46,11 @@ func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, repo
 			return ctx.Err()
 		}
 		reporter.Increment()
-		bf := files[i]
-		if bf.TrackNumber != 0 {
+		c := files[i]
+		if c.TrackNumber != 0 {
 			continue
 		}
-		stem := strings.TrimSuffix(filepath.Base(bf.FilePath), filepath.Ext(bf.FilePath))
+		stem := strings.TrimSuffix(filepath.Base(c.FilePath), filepath.Ext(c.FilePath))
 		m := trackNumRe.FindStringSubmatch(stem)
 		if m == nil {
 			continue
@@ -60,8 +60,28 @@ func (j *enrichBookFilesJob) Run(ctx context.Context, store database.Store, repo
 			continue
 		}
 		if !dryRun {
-			bf.TrackNumber = n
-			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+			// Hydrate the full row and mutate/write THAT — never a
+			// hand-built BookFile{} from Core fields, which would wipe the
+			// stored fingerprint. See
+			// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
+			full, herr := store.GetBookFiles(c.BookID)
+			if herr != nil {
+				slog.Error("enrich-book-files hydrate failed", "details", herr.Error())
+				continue
+			}
+			var target *database.BookFile
+			for j := range full {
+				if full[j].ID == c.ID {
+					target = &full[j]
+					break
+				}
+			}
+			if target == nil {
+				slog.Warn("enrich-book-files: hydrate: row not found", "id", c.ID)
+				continue
+			}
+			target.TrackNumber = n
+			if uerr := store.UpdateBookFile(target.ID, target); uerr != nil {
 				msg := uerr.Error()
 				slog.Error("enrich-book-files UpdateBookFile failed", "details", msg)
 				continue

--- a/internal/maintenance/jobs/fix_book_file_paths.go
+++ b/internal/maintenance/jobs/fix_book_file_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_book_file_paths.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000011-0000-0000-0000-000000000011
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -30,7 +30,7 @@ func (j *fixBookFilePathsJob) Description() string {
 }
 func (j *fixBookFilePathsJob) CanResume() bool { return false }
 func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err
 	}
@@ -41,14 +41,34 @@ func (j *fixBookFilePathsJob) Run(ctx context.Context, store database.Store, rep
 			return ctx.Err()
 		}
 		reporter.Increment()
-		bf := files[i]
-		if bf.Missing {
+		c := files[i]
+		if c.Missing {
 			continue
 		}
-		if _, serr := os.Stat(bf.FilePath); os.IsNotExist(serr) {
+		if _, serr := os.Stat(c.FilePath); os.IsNotExist(serr) {
 			if !dryRun {
-				bf.Missing = true
-				if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+				// Hydrate the full row and mutate/write THAT — never a
+				// hand-built BookFile{} from Core fields, which would wipe
+				// the stored fingerprint. See
+				// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
+				full, herr := store.GetBookFiles(c.BookID)
+				if herr != nil {
+					slog.Error("fix-book-file-paths hydrate failed", "details", herr.Error())
+					continue
+				}
+				var target *database.BookFile
+				for j := range full {
+					if full[j].ID == c.ID {
+						target = &full[j]
+						break
+					}
+				}
+				if target == nil {
+					slog.Warn("fix-book-file-paths: hydrate: row not found", "id", c.ID)
+					continue
+				}
+				target.Missing = true
+				if uerr := store.UpdateBookFile(target.ID, target); uerr != nil {
 					msg := uerr.Error()
 					slog.Error("fix-book-file-paths UpdateBookFile failed", "details", msg)
 					continue

--- a/internal/maintenance/jobs/fix_book_file_paths_test.go
+++ b/internal/maintenance/jobs/fix_book_file_paths_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_book_file_paths_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b1c2d3e4-f5a6-7890-bcde-123456789456
-// last-edited: 2026-05-05
+// last-edited: 2026-07-06
 
 // Package jobs_test exercises the fix-book-file-paths maintenance job.
 package jobs_test
@@ -47,8 +47,8 @@ func TestFixBookFilePathsJob_DefaultParams_DryRunTrue(t *testing.T) {
 func TestFixBookFilePathsJob_EmptyStore_NoOp(t *testing.T) {
 	// No book_files → nothing to process, no error.
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
-			return []database.BookFile{}, nil
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
+			return []database.BookFileCore{}, nil
 		},
 	}
 	j, err := maintenance.Get("fix-book-file-paths")
@@ -60,13 +60,13 @@ func TestFixBookFilePathsJob_EmptyStore_NoOp(t *testing.T) {
 
 func TestFixBookFilePathsJob_DryRun_DoesNotUpdateDB(t *testing.T) {
 	// A book_file whose stored path doesn't exist on disk.
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "bf-1", BookID: "book-1", FilePath: "/nonexistent/path/chapter.mp3"},
 	}
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(id string, bf *database.BookFile) error {
@@ -91,13 +91,13 @@ func TestFixBookFilePathsJob_SkipsExistingPaths(t *testing.T) {
 	require.NoError(t, err)
 	f.Close()
 
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "bf-exists", BookID: "book-exists", FilePath: realFile},
 	}
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(id string, bf *database.BookFile) error {
@@ -116,15 +116,22 @@ func TestFixBookFilePathsJob_SkipsExistingPaths(t *testing.T) {
 
 func TestFixBookFilePathsJob_Apply_MarksAsMissing(t *testing.T) {
 	// A book_file whose path doesn't exist on disk → in apply mode it should be updated (marked missing).
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "bf-missing", BookID: "book-m", FilePath: "/no/such/file.mp3", Missing: false},
 	}
 
 	var updatedID string
 	var updatedMissing bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
+		},
+		// The job now hydrates the full row via GetBookFiles(bookID) before
+		// writing back (see docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md).
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return []database.BookFile{
+				{ID: "bf-missing", BookID: "book-m", FilePath: "/no/such/file.mp3", Missing: false},
+			}, nil
 		},
 		UpdateBookFileFunc: func(id string, bf *database.BookFile) error {
 			updatedID = id
@@ -144,9 +151,9 @@ func TestFixBookFilePathsJob_Apply_MarksAsMissing(t *testing.T) {
 
 func TestFixBookFilePathsJob_CancelRespected(t *testing.T) {
 	// Many files — cancellation should cause the job to return early.
-	files := make([]database.BookFile, 20)
+	files := make([]database.BookFileCore, 20)
 	for i := range files {
-		files[i] = database.BookFile{
+		files[i] = database.BookFileCore{
 			ID:       "bf-cancel-" + string(rune('0'+i%10)),
 			BookID:   "book-cancel",
 			FilePath: "/nonexistent/cancel-" + string(rune('0'+i%10)) + ".mp3",
@@ -154,7 +161,7 @@ func TestFixBookFilePathsJob_CancelRespected(t *testing.T) {
 	}
 
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(id string, bf *database.BookFile) error {

--- a/internal/maintenance/jobs/recompute_itunes_paths.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000013-0000-0000-0000-000000000013
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -30,7 +30,7 @@ func (j *recomputeITunesPathsJob) Description() string {
 }
 func (j *recomputeITunesPathsJob) CanResume() bool { return false }
 func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err
 	}
@@ -41,14 +41,34 @@ func (j *recomputeITunesPathsJob) Run(ctx context.Context, store database.Store,
 			return ctx.Err()
 		}
 		reporter.Increment()
-		bf := files[i]
-		want := metafetch.ComputeITunesPath(bf.FilePath)
-		if want == bf.ITunesPath {
+		c := files[i]
+		want := metafetch.ComputeITunesPath(c.FilePath)
+		if want == c.ITunesPath {
 			continue
 		}
 		if !dryRun {
-			bf.ITunesPath = want
-			if uerr := store.UpdateBookFile(bf.ID, &bf); uerr != nil {
+			// Hydrate the full row and mutate/write THAT — never a
+			// hand-built BookFile{} from Core fields, which would wipe the
+			// stored fingerprint. See
+			// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
+			full, herr := store.GetBookFiles(c.BookID)
+			if herr != nil {
+				slog.Error("recompute-itunes-paths hydrate failed", "details", herr.Error())
+				continue
+			}
+			var target *database.BookFile
+			for j := range full {
+				if full[j].ID == c.ID {
+					target = &full[j]
+					break
+				}
+			}
+			if target == nil {
+				slog.Warn("recompute-itunes-paths: hydrate: row not found", "id", c.ID)
+				continue
+			}
+			target.ITunesPath = want
+			if uerr := store.UpdateBookFile(target.ID, target); uerr != nil {
 				msg := uerr.Error()
 				slog.Error("recompute-itunes-paths UpdateBookFile failed", "details", msg)
 				continue

--- a/internal/maintenance/jobs/recompute_itunes_paths_test.go
+++ b/internal/maintenance/jobs/recompute_itunes_paths_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_itunes_paths_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b7c8d9e0-f1a2-3456-bcde-789012345012
-// last-edited: 2026-05-05
+// last-edited: 2026-07-06
 
 // Package jobs_test exercises the recompute-itunes-paths maintenance job.
 // noopReporter and the blank jobs import are provided by fix_read_by_narrator_test.go.
@@ -48,8 +48,8 @@ func TestRecomputeItunesPathsJob_DefaultParams(t *testing.T) {
 func TestRecomputeItunesPathsJob_EmptyStore(t *testing.T) {
 	// No book files → no-op, no error.
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
-			return []database.BookFile{}, nil
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
+			return []database.BookFileCore{}, nil
 		},
 	}
 
@@ -65,13 +65,13 @@ func TestRecomputeItunesPathsJob_EmptyStore(t *testing.T) {
 
 func TestRecomputeItunesPathsJob_DryRunDoesNotUpdate(t *testing.T) {
 	// File with a mismatched itunes_path; in dry-run no UpdateBookFile should be called.
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "bf-1", BookID: "book-1", FilePath: "/books/author/title/chapter.mp3", ITunesPath: "/old/path.mp3"},
 	}
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(id string, file *database.BookFile) error {
@@ -96,13 +96,13 @@ func TestRecomputeItunesPathsJob_DryRunDoesNotUpdate(t *testing.T) {
 func TestRecomputeItunesPathsJob_SkipsAlreadyCorrect(t *testing.T) {
 	// When computed path == stored path, UpdateBookFile must not be called.
 	// Use an empty ITunesPath so ComputeITunesPath returns "" and both sides match.
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "bf-2", BookID: "book-2", FilePath: "/books/author/title/chapter.mp3", ITunesPath: ""},
 	}
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(id string, file *database.BookFile) error {
@@ -125,16 +125,16 @@ func TestRecomputeItunesPathsJob_SkipsAlreadyCorrect(t *testing.T) {
 }
 
 func TestRecomputeItunesPathsJob_CancelRespected(t *testing.T) {
-	files := make([]database.BookFile, 5)
+	files := make([]database.BookFileCore, 5)
 	for i := range files {
-		files[i] = database.BookFile{ID: "bf-cancel-" + string(rune('0'+i)), FilePath: "/books/b/c.mp3"}
+		files[i] = database.BookFileCore{ID: "bf-cancel-" + string(rune('0'+i)), FilePath: "/books/b/c.mp3"}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 	}

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.0.2
+// version: 2.1.0
 // guid: a1000012-0000-0000-0000-000000000012
-// last-edited: 2026-07-03
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -53,11 +53,11 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 	slog.Info("refetch-missing-authors / books have no author", "opID", opID, "books_count", len(books), "allBooks_count", len(allBooks))
 
 	// Load all book files upfront to avoid N+1 queries.
-	allFiles, err := store.GetAllBookFiles()
+	allFiles, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return fmt.Errorf("GetAllBookFiles: %w", err)
+		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
-	filesByBook := make(map[string][]database.BookFile, len(allFiles))
+	filesByBook := make(map[string][]database.BookFileCore, len(allFiles))
 	for i := range allFiles {
 		f := &allFiles[i]
 		filesByBook[f.BookID] = append(filesByBook[f.BookID], *f)

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
-// last-edited: 2026-06-16
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -45,9 +45,9 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 
 	searchRoots := rmfr_searchRoots()
 
-	allFiles, err := store.GetAllBookFiles()
+	allFiles, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return fmt.Errorf("GetAllBookFiles: %w", err)
+		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
 	allBooks, err := store.GetAllBooks(0, 0)
 	if err != nil {
@@ -72,7 +72,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	}
 
 	// Collect candidates.
-	var candidates []database.BookFile
+	var candidates []database.BookFileCore
 	for i := range allFiles {
 		f := &allFiles[i]
 		if f.FilePath == "" || f.Missing {
@@ -93,7 +93,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	for _, r := range existingResults {
 		done[r.BookID] = true
 	}
-	var work []database.BookFile
+	var work []database.BookFileCore
 	for _, f := range candidates {
 		if !done[f.ID] {
 			work = append(work, f)
@@ -170,7 +170,7 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	var completed int64 = int64(alreadyDone)
 	var progressMu sync.Mutex
 
-	workCh := make(chan database.BookFile, len(work))
+	workCh := make(chan database.BookFileCore, len(work))
 	for _, f := range work {
 		workCh <- f
 	}
@@ -244,9 +244,13 @@ type rmfr_result struct {
 }
 
 // rmfr_repairOne tries four escalating strategies and returns a result.
-// Only calls UpdateBookFile — never creates new Book or BookFile rows.
+// Only calls UpdateBookFile — never creates new Book or BookFile rows. On a
+// successful match it hydrates the full row via GetBookFiles(f.BookID) and
+// writes THAT — never a hand-built BookFile{} from the Core candidate, which
+// would wipe the stored fingerprint. See
+// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
 func rmfr_repairOne(
-	f database.BookFile,
+	f database.BookFileCore,
 	metaByBook map[string]rmfr_bookMeta,
 	pidToLocation map[string]string,
 	itunesOpts itunes.ImportOptions,
@@ -530,16 +534,36 @@ func rmfr_repairOne(
 	}
 
 	fi, _ := os.Stat(candidate)
-	f.FilePath = candidate
-	f.OriginalFilename = filepath.Base(candidate)
-	f.Missing = false
+
+	// Hydrate the full row and mutate/write THAT — see the doc comment above.
+	full, herr := store.GetBookFiles(f.BookID)
+	if herr != nil {
+		res.Error = herr.Error()
+		slog.Warn("repair-missing-files hydrate failed", "opID", opID, "f", f.ID, "herr", herr)
+		return res
+	}
+	var target *database.BookFile
+	for j := range full {
+		if full[j].ID == f.ID {
+			target = &full[j]
+			break
+		}
+	}
+	if target == nil {
+		res.Error = "hydrate: row not found"
+		slog.Warn("repair-missing-files hydrate: row not found", "opID", opID, "f", f.ID)
+		return res
+	}
+	target.FilePath = candidate
+	target.OriginalFilename = filepath.Base(candidate)
+	target.Missing = false
 	if fi != nil {
-		f.FileSize = fi.Size()
+		target.FileSize = fi.Size()
 	}
 	if ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(candidate), ".")); ext != "" {
-		f.Format = ext
+		target.Format = ext
 	}
-	if upErr := store.UpdateBookFile(f.ID, &f); upErr != nil {
+	if upErr := store.UpdateBookFile(target.ID, target); upErr != nil {
 		res.Error = upErr.Error()
 		slog.Warn("repair-missing-files UpdateBookFile", "opID", opID, "f", f.ID, "upErr", upErr)
 	} else {

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -68,11 +68,11 @@ func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, rep
 	for _, a := range allAuthors {
 		authorByID[a.ID] = a.Name
 	}
-	allFiles, err := store.GetAllBookFiles()
+	allFiles, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return fmt.Errorf("GetAllBookFiles: %w", err)
+		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
-	filesByBook := make(map[string][]database.BookFile, len(allFiles))
+	filesByBook := make(map[string][]database.BookFileCore, len(allFiles))
 	for i := range allFiles {
 		f := &allFiles[i]
 		filesByBook[f.BookID] = append(filesByBook[f.BookID], *f)

--- a/internal/maintenance/jobs/scan_duplicate_files.go
+++ b/internal/maintenance/jobs/scan_duplicate_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duplicate_files.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000016-0000-0000-0000-000000000016
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -31,7 +31,7 @@ func (j *scanDuplicateFilesJob) Description() string {
 }
 func (j *scanDuplicateFilesJob) CanResume() bool { return false }
 func (j *scanDuplicateFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/acoustid/lsh_backfill.go
+++ b/internal/plugins/acoustid/lsh_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/lsh_backfill.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2c4d6e80-3b5a-4f9c-9b1d-7e8f0a2b4c6d
 // last-edited: 2026-07-06
 
@@ -36,16 +36,20 @@ type lshIndexChecker interface {
 // store implements it) or harmlessly rewritten (when it does not).
 //
 // Gate uses AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file fingerprint
-// exists) rather than len(AcoustIDFingerprint) == 0, because GetAllBookFiles
-// returns the memdb-slim projection in production (UseMemDB=true) where
-// stripBookFileForMemdb nils the raw AcoustIDFingerprint blob to save RAM —
-// the byte-length gate was always true under memdb, making this op a silent
-// no-op. The row we re-save still carries a nil AcoustIDFingerprint, but
-// PebbleStore.UpdateBookFile restores the stored blob from Pebble whenever
-// the incoming value is empty (the "preserve-on-empty" guard added for the
-// same memdb-slim-roundtrip class of bug) *before* writeBookFileSecondaryIndexes
-// runs, so writeFingerprintLSHIndexes still sees the real fingerprint bytes.
-// No hydrate call is needed here — UpdateBookFile does it for us.
+// exists) rather than len(AcoustIDFingerprint) == 0, because
+// GetAllBookFilesCore returns BookFileCore — the raw AcoustIDFingerprint blob
+// is a heavy field that never exists on Core. DurationSec is the KEPT proxy.
+//
+// The row we re-save is hydrated via GetBookFiles(bookID) first and the
+// UpdateBookFile call writes THAT full row — not the Core candidate (which
+// has no fingerprint bytes at all and can't be passed to UpdateBookFile
+// without either a compile error or a hand-built BookFile{} literal that
+// would wipe the stored fingerprint). This drops the prior reliance on
+// PebbleStore.UpdateBookFile's preserve-on-empty guard, which only restores
+// AcoustIDFingerprint — not the diagnostic fields
+// (FingerprintFailureReason/Detail/DiagnosticJSON) — so a hydrate-then-write
+// here also closes that residual gap for this op. See
+// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
 //
 // Use after deploying the LSH index code to populate the existing ~308K
 // fingerprinted rows without re-running fpcalc.
@@ -85,7 +89,7 @@ func (p *Plugin) runLSHBackfill(ctx context.Context, _ json.RawMessage, reporter
 	prog := sdk.NewProgress(reporter, 0)
 	prog.Start("Loading book files for LSH backfill…")
 
-	files, err := p.store.GetAllBookFiles()
+	files, err := p.store.GetAllBookFilesCore()
 	if err != nil {
 		return fmt.Errorf("load book files: %w", err)
 	}
@@ -101,20 +105,38 @@ func (p *Plugin) runLSHBackfill(ctx context.Context, _ json.RawMessage, reporter
 
 	var indexed, skippedNoFP, skippedAlreadyIndexed, failed int
 
-	if err := registry.RunItems(ctx, reporter, files, func(ctx context.Context, f database.BookFile) error {
+	if err := registry.RunItems(ctx, reporter, files, func(ctx context.Context, f database.BookFileCore) error {
 		// Proxy gate: AcoustIDFingerprintDurationSec > 0 means a whole-file
-		// fingerprint was computed, even when the memdb-slim row we're
-		// holding has AcoustIDFingerprint stripped to nil. See the doc
-		// comment above for why this is safe to re-save unmodified.
+		// fingerprint was computed, even though BookFileCore never carries
+		// the AcoustIDFingerprint bytes themselves. See the doc comment
+		// above for why this is safe.
 		if f.AcoustIDFingerprintDurationSec == 0 {
 			skippedNoFP++
 		} else if hasChecker && checker.HasLSHIndex(f.ID) {
 			skippedAlreadyIndexed++
 		} else {
-			// Re-save the row so PebbleStore.writeBookFileSecondaryIndexes writes
-			// the fpidx + fpidx_meta entries. Passed unmodified — just a hook trigger.
-			updated := f
-			if err := p.store.UpdateBookFile(f.ID, &updated); err != nil {
+			// Hydrate the full row and re-save THAT so
+			// PebbleStore.writeBookFileSecondaryIndexes writes the fpidx +
+			// fpidx_meta entries with the real fingerprint bytes intact.
+			full, herr := p.store.GetBookFiles(f.BookID)
+			if herr != nil {
+				log.Warn("acoustid lsh-backfill: hydrate failed", "id", f.ID, "err", herr)
+				failed++
+				return nil
+			}
+			var target *database.BookFile
+			for j := range full {
+				if full[j].ID == f.ID {
+					target = &full[j]
+					break
+				}
+			}
+			if target == nil {
+				log.Warn("acoustid lsh-backfill: hydrate: row not found", "id", f.ID)
+				failed++
+				return nil
+			}
+			if err := p.store.UpdateBookFile(target.ID, target); err != nil {
 				log.Warn("acoustid lsh-backfill: update failed", "id", f.ID, "err", err)
 				failed++
 			} else {

--- a/internal/plugins/acoustid/lsh_backfill_test.go
+++ b/internal/plugins/acoustid/lsh_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/lsh_backfill_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3d5e7f91-4c6b-5a0d-ac2e-8f9a1b3c5d7e
 // last-edited: 2026-07-06
 
@@ -64,21 +64,32 @@ func (i *indexableMockStore) HasLSHIndex(id string) bool {
 // three with fingerprints, two without — exactly three UpdateBookFile calls
 // should fire.
 func TestLSHBackfill_FiltersAndUpdates(t *testing.T) {
-	files := []database.BookFile{
-		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0xde, 0xad, 0xbe, 0xef}, AcoustIDFingerprintDurationSec: 1800},
+	files := []database.BookFileCore{
+		{ID: "f1", BookID: "b1", AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f2", BookID: "b2"}, // no fp
-		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0xfe, 0xed, 0xfa, 0xce}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f3", BookID: "b3", AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f4", BookID: "b4"}, // no fp
-		{ID: "f5", BookID: "b5", AcoustIDFingerprint: []byte{0xca, 0xfe, 0xba, 0xbe}, AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f5", BookID: "b5", AcoustIDFingerprintDurationSec: 1800},
+	}
+	// hydrateFiles simulates GetBookFiles(bookID) — the full-row read the op
+	// now hydrates from before writing back (see the writeback-wipe audit
+	// doc). Keyed by BookID.
+	hydrateFiles := map[string][]database.BookFile{
+		"b1": {{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0xde, 0xad, 0xbe, 0xef}}},
+		"b3": {{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0xfe, 0xed, 0xfa, 0xce}}},
+		"b5": {{ID: "f5", BookID: "b5", AcoustIDFingerprint: []byte{0xca, 0xfe, 0xba, 0xbe}}},
 	}
 
 	var (
-		mu       sync.Mutex
-		updates  []string
+		mu      sync.Mutex
+		updates []string
 	)
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
+		},
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return hydrateFiles[bookID], nil
 		},
 		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
 			mu.Lock()
@@ -125,15 +136,15 @@ func TestLSHBackfill_FiltersAndUpdates(t *testing.T) {
 // reports rows are already indexed, the op makes zero UpdateBookFile calls.
 // Models the second-run case after a previous successful backfill.
 func TestLSHBackfill_IdempotentWithHasLSHIndex(t *testing.T) {
-	files := []database.BookFile{
-		{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0x01, 0x02, 0x03, 0x04}, AcoustIDFingerprintDurationSec: 1800},
-		{ID: "f2", BookID: "b2", AcoustIDFingerprint: []byte{0x05, 0x06, 0x07, 0x08}, AcoustIDFingerprintDurationSec: 1800},
-		{ID: "f3", BookID: "b3", AcoustIDFingerprint: []byte{0x09, 0x0a, 0x0b, 0x0c}, AcoustIDFingerprintDurationSec: 1800},
+	files := []database.BookFileCore{
+		{ID: "f1", BookID: "b1", AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f2", BookID: "b2", AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f3", BookID: "b3", AcoustIDFingerprintDurationSec: 1800},
 	}
 
 	updateCalls := 0
 	mock := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		UpdateBookFileFunc: func(string, *database.BookFile) error {
@@ -169,15 +180,27 @@ func TestLSHBackfill_IdempotentWithHasLSHIndex(t *testing.T) {
 // for some rows and false for others, only the unindexed rows with a stored
 // fp are updated.
 func TestLSHBackfill_PartialIndex(t *testing.T) {
-	files := []database.BookFile{
-		{ID: "f1", AcoustIDFingerprint: []byte{1}, AcoustIDFingerprintDurationSec: 1800},
-		{ID: "f2", AcoustIDFingerprint: []byte{2}, AcoustIDFingerprintDurationSec: 1800},
-		{ID: "f3", AcoustIDFingerprint: []byte{3}, AcoustIDFingerprintDurationSec: 1800},
+	files := []database.BookFileCore{
+		{ID: "f1", AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f2", AcoustIDFingerprintDurationSec: 1800},
+		{ID: "f3", AcoustIDFingerprintDurationSec: 1800},
 		{ID: "f4"}, // no fp at all
+	}
+	// hydrateFiles simulates GetBookFiles(bookID="") — none of the files set
+	// BookID, so they all share the empty-string bucket; the op matches by
+	// file ID within the returned slice.
+	hydrateFiles := map[string][]database.BookFile{
+		"": {
+			{ID: "f2", AcoustIDFingerprint: []byte{2}},
+			{ID: "f3", AcoustIDFingerprint: []byte{3}},
+		},
 	}
 	var updates []string
 	mock := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return hydrateFiles[bookID], nil
+		},
 		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
 			updates = append(updates, id)
 			return nil
@@ -202,12 +225,17 @@ func TestLSHBackfill_PartialIndex(t *testing.T) {
 // TestLSHBackfill_CancelMidRun verifies that cancelling the context part-way
 // returns ctx.Err() and stops further updates.
 func TestLSHBackfill_CancelMidRun(t *testing.T) {
-	files := make([]database.BookFile, 100)
+	files := make([]database.BookFileCore, 100)
+	hydrateFiles := make([]database.BookFile, 100)
 	for i := range files {
-		files[i] = database.BookFile{
-			ID:                             string(rune('a'+i%26)) + "-" + string(rune('0'+i%10)),
-			AcoustIDFingerprint:            []byte{byte(i)},
+		id := string(rune('a'+i%26)) + "-" + string(rune('0'+i%10))
+		files[i] = database.BookFileCore{
+			ID:                             id,
 			AcoustIDFingerprintDurationSec: 1800,
+		}
+		hydrateFiles[i] = database.BookFile{
+			ID:                  id,
+			AcoustIDFingerprint: []byte{byte(i)},
 		}
 	}
 
@@ -215,7 +243,10 @@ func TestLSHBackfill_CancelMidRun(t *testing.T) {
 
 	var updates int
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		// None of the files set BookID, so every hydrate call shares the
+		// same full slice; the op matches by file ID within it.
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) { return hydrateFiles, nil },
 		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
 			updates++
 			if updates == 5 {
@@ -241,26 +272,31 @@ func TestLSHBackfill_CancelMidRun(t *testing.T) {
 }
 
 // TestLSHBackfill_MemdbSlimRowStillTriggersUpdate is the regression test for
-// the memdb-slim no-op bug: GetAllBookFiles returns the memdb-slim projection
-// in production (UseMemDB=true), where stripBookFileForMemdb nils the raw
-// AcoustIDFingerprint blob but preserves AcoustIDFingerprintDurationSec.
-// Before the fix, the gate was len(AcoustIDFingerprint)==0 — always true for
-// a memdb-slim row — so this op silently skipped every fingerprinted file in
-// prod. This test supplies exactly that shape (nil blob, DurationSec>0) and
-// asserts UpdateBookFile still fires; PebbleStore.UpdateBookFile's own
-// preserve-on-empty guard (merged separately) is what restores the real
-// bytes before the LSH secondary index is written.
+// the memdb-slim no-op bug: GetAllBookFilesCore returns BookFileCore, which
+// never carries the raw AcoustIDFingerprint bytes at all (heavy field,
+// stripped on both the memdb and Pebble-direct paths); DurationSec is the
+// KEPT proxy. Before the fix, the gate was len(AcoustIDFingerprint)==0 —
+// always true — so this op silently skipped every fingerprinted file in
+// prod. This test supplies exactly that shape (DurationSec>0, no blob to
+// even check) and asserts UpdateBookFile still fires against the row
+// hydrated via GetBookFiles.
 func TestLSHBackfill_MemdbSlimRowStillTriggersUpdate(t *testing.T) {
-	files := []database.BookFile{
-		// Memdb-slim shape: blob stripped, duration proxy survives.
-		{ID: "f1", BookID: "b1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
-		// Genuinely unfingerprinted: neither blob nor duration.
+	files := []database.BookFileCore{
+		// Memdb-slim shape: duration proxy survives.
+		{ID: "f1", BookID: "b1", AcoustIDFingerprintDurationSec: 1800},
+		// Genuinely unfingerprinted: no duration.
 		{ID: "f2", BookID: "b2"},
+	}
+	hydrateFiles := map[string][]database.BookFile{
+		"b1": {{ID: "f1", BookID: "b1", AcoustIDFingerprint: []byte{0xAA, 0xBB}}},
 	}
 
 	var updates []string
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return hydrateFiles[bookID], nil
+		},
 		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
 			updates = append(updates, id)
 			return nil
@@ -286,7 +322,7 @@ func TestLSHBackfill_MemdbSlimRowStillTriggersUpdate(t *testing.T) {
 // Done frames so the UI never sees a 0/0 bar.
 func TestLSHBackfill_EmptyStore(t *testing.T) {
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return nil, nil
 		},
 	}

--- a/internal/plugins/acoustid/online_lookup.go
+++ b/internal/plugins/acoustid/online_lookup.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/online_lookup.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 6e7f8091-a2b3-c4d5-e6f7-08192a3b4c5d
 // last-edited: 2026-07-06
 
@@ -15,6 +15,7 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/acoustid"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -94,7 +95,7 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 	prog := sdk.NewProgress(reporter, 0)
 	prog.Start("Loading book files for online lookup…")
 
-	files, err := p.store.GetAllBookFiles()
+	files, err := p.store.GetAllBookFilesCore()
 	if err != nil {
 		return fmt.Errorf("load book files: %w", err)
 	}
@@ -104,15 +105,13 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 	//
 	// The gate uses AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file
 	// fingerprint was computed) rather than len(AcoustIDFingerprint)==0,
-	// because GetAllBookFiles returns the memdb-slim projection in
-	// production (UseMemDB=true): stripBookFileForMemdb nils the raw
-	// AcoustIDFingerprint blob to save RAM but keeps DurationSec. The old
-	// byte-length gate was always true under memdb, so this op silently
-	// found zero candidates in prod. The raw bytes themselves are hydrated
-	// per-candidate at API-call time below (this loop is already
+	// because GetAllBookFilesCore returns BookFileCore — the raw
+	// AcoustIDFingerprint blob is a heavy field that never exists on Core
+	// (stripped under memdb, and not projected under Pebble-direct either).
+	// DurationSec is the KEPT proxy field. The raw bytes themselves are
+	// hydrated per-candidate at API-call time below (this loop is already
 	// network-bound and rate-limited, so a per-candidate Pebble read is
-	// negligible) — we deliberately do NOT stash `raw` from the slim struct
-	// here.
+	// negligible).
 	type candidate struct {
 		idx int // original index in files
 		dur int
@@ -170,29 +169,33 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 
 		f := &files[c.idx]
 
-		// Hydrate the raw whole-file fingerprint at API-call time.
-		// GetAllBookFiles strips AcoustIDFingerprint under memdb
-		// (stripBookFileForMemdb); the candidate filter above only checked
-		// the memdb-safe DurationSec proxy, so most candidates land here
-		// with a nil blob. GetBookFiles reads raw Pebble unconditionally
-		// (no UseMemDB check), so it always returns the real bytes.
-		raw := f.AcoustIDFingerprint
+		// Hydrate the full row (raw whole-file fingerprint + writeback
+		// target) at API-call time. BookFileCore never carries
+		// AcoustIDFingerprint (heavy field, not on Core at all); GetBookFiles
+		// reads raw Pebble unconditionally (no UseMemDB check), so it always
+		// returns the real bytes. The hydrated *BookFile is also reused below
+		// as the UpdateBookFile target — writing back the Core-derived
+		// candidate would compile-error (no such method) or, worse, wipe
+		// fingerprint fields if hand-reconstructed; see
+		// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
+		var raw []byte
+		var hydrated *database.BookFile
 		var hydrateErr error
-		if len(raw) == 0 {
-			if bookFiles, herr := p.store.GetBookFiles(f.BookID); herr != nil {
-				hydrateErr = fmt.Errorf("hydrate GetBookFiles: %w", herr)
-			} else {
-				for _, hf := range bookFiles {
-					if hf.ID == f.ID {
-						raw = hf.AcoustIDFingerprint
-						break
-					}
+		if bookFiles, herr := p.store.GetBookFiles(f.BookID); herr != nil {
+			hydrateErr = fmt.Errorf("hydrate GetBookFiles: %w", herr)
+		} else {
+			for j := range bookFiles {
+				if bookFiles[j].ID == f.ID {
+					hydrated = &bookFiles[j]
+					raw = hydrated.AcoustIDFingerprint
+					break
 				}
-				if len(raw) == 0 {
-					// Data drift: the DurationSec proxy claimed a fingerprint
-					// exists but the raw row has no blob either.
-					hydrateErr = fmt.Errorf("hydrate: no fingerprint bytes for file %s (data drift)", f.ID)
-				}
+			}
+			if hydrated == nil || len(raw) == 0 {
+				// Data drift: the DurationSec proxy claimed a fingerprint
+				// exists but the raw row has no blob either (or the row
+				// disappeared between the slim scan and this hydrate).
+				hydrateErr = fmt.Errorf("hydrate: no fingerprint bytes for file %s (data drift)", f.ID)
 			}
 		}
 
@@ -227,10 +230,13 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 			log.Warn("acoustid online lookup: request failed",
 				"file_id", f.ID, "err", lerr)
 		} else {
-			f.AcoustIDOnlineLookedUpAt = &now
+			// Mutate + write back the hydrated FULL row (not the Core
+			// candidate) so fingerprint fields already on the Pebble row
+			// survive the update. See the hydrate block above.
+			hydrated.AcoustIDOnlineLookedUpAt = &now
 			if res.Score >= AcoustIDOnlineMinScore && res.RecordingID != "" {
-				f.AcoustIDOnlineRecordingID = res.RecordingID
-				f.AcoustIDOnlineScore = res.Score
+				hydrated.AcoustIDOnlineRecordingID = res.RecordingID
+				hydrated.AcoustIDOnlineScore = res.Score
 				matched++
 				log.Info("acoustid online lookup: matched",
 					"file_id", f.ID,
@@ -240,11 +246,11 @@ func (p *Plugin) runOnlineLookup(ctx context.Context, params json.RawMessage, re
 			} else {
 				// Persist the looked-up timestamp so we don't re-query
 				// every run; clear any stale match below threshold.
-				f.AcoustIDOnlineRecordingID = ""
-				f.AcoustIDOnlineScore = 0
+				hydrated.AcoustIDOnlineRecordingID = ""
+				hydrated.AcoustIDOnlineScore = 0
 				noMatch++
 			}
-			if uerr := p.store.UpdateBookFile(f.ID, f); uerr != nil {
+			if uerr := p.store.UpdateBookFile(hydrated.ID, hydrated); uerr != nil {
 				log.Warn("acoustid online lookup: persist failed",
 					"file_id", f.ID, "err", uerr)
 			}

--- a/internal/plugins/acoustid/reset_all.go
+++ b/internal/plugins/acoustid/reset_all.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/reset_all.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: f3b1e8c4-2d7a-4d62-aabb-1f1d6e2c4a01
-// last-edited: 2026-07-01
+// last-edited: 2026-07-06
 
 package acoustid
 
@@ -84,8 +84,14 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 		cleared = c
 		log.Info("acoustid reset-all: bulk clear done", "cleared", c, "total", t, "elapsed", time.Since(startedAt).Round(time.Second))
 	} else {
-		// Per-row fallback (mock/sqlite tests).
-		files, err := p.store.GetAllBookFiles()
+		// Per-row fallback (mock/sqlite tests). AcoustIDSeg0..6 are stripped
+		// from BookFileCore entirely (heavy fingerprint-diagnostic fields),
+		// so this path must hydrate each candidate's full row via
+		// GetBookFiles just to read them, then clear + write back THAT full
+		// row — never a hand-built BookFile{} from Core fields. Only reached
+		// in mock/sqlite tests (prod uses the bulk-clear fast path above),
+		// so the extra per-row hydrate read is not a perf concern.
+		files, err := p.store.GetAllBookFilesCore()
 		if err != nil {
 			return fmt.Errorf("load book files: %w", err)
 		}
@@ -93,21 +99,36 @@ func (p *Plugin) runResetAll(ctx context.Context, _ json.RawMessage, reporter sd
 		log.Info("acoustid reset-all: clearing fingerprints (slow path)", "book_files", total)
 		prog = sdk.NewProgress(reporter, total)
 		prog.Start("Clearing fingerprints (slow path)…")
-		err = registry.RunItems(ctx, reporter, files, func(_ context.Context, f database.BookFile) error {
-			if f.AcoustIDSeg0 == "" && f.AcoustIDSeg1 == "" && f.AcoustIDSeg2 == "" &&
-				f.AcoustIDSeg3 == "" && f.AcoustIDSeg4 == "" && f.AcoustIDSeg5 == "" &&
-				f.AcoustIDSeg6 == "" {
+		err = registry.RunItems(ctx, reporter, files, func(_ context.Context, f database.BookFileCore) error {
+			full, herr := p.store.GetBookFiles(f.BookID)
+			if herr != nil {
+				log.Warn("acoustid reset-all: hydrate failed", "id", f.ID, "err", herr)
 				return nil
 			}
-			updated := f
-			updated.AcoustIDSeg0 = ""
-			updated.AcoustIDSeg1 = ""
-			updated.AcoustIDSeg2 = ""
-			updated.AcoustIDSeg3 = ""
-			updated.AcoustIDSeg4 = ""
-			updated.AcoustIDSeg5 = ""
-			updated.AcoustIDSeg6 = ""
-			if err := p.store.UpdateBookFile(f.ID, &updated); err != nil {
+			var target *database.BookFile
+			for j := range full {
+				if full[j].ID == f.ID {
+					target = &full[j]
+					break
+				}
+			}
+			if target == nil {
+				log.Warn("acoustid reset-all: hydrate: row not found", "id", f.ID)
+				return nil
+			}
+			if target.AcoustIDSeg0 == "" && target.AcoustIDSeg1 == "" && target.AcoustIDSeg2 == "" &&
+				target.AcoustIDSeg3 == "" && target.AcoustIDSeg4 == "" && target.AcoustIDSeg5 == "" &&
+				target.AcoustIDSeg6 == "" {
+				return nil
+			}
+			target.AcoustIDSeg0 = ""
+			target.AcoustIDSeg1 = ""
+			target.AcoustIDSeg2 = ""
+			target.AcoustIDSeg3 = ""
+			target.AcoustIDSeg4 = ""
+			target.AcoustIDSeg5 = ""
+			target.AcoustIDSeg6 = ""
+			if err := p.store.UpdateBookFile(target.ID, target); err != nil {
 				log.Warn("acoustid reset-all: update file failed", "id", f.ID, "err", err)
 				return nil
 			}

--- a/internal/plugins/acoustid/reset_all_test.go
+++ b/internal/plugins/acoustid/reset_all_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/reset_all_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8b2f4a6c-1d3e-4f5a-9c7b-0e1a2b3c4d5f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-06
 
 package acoustid
 
@@ -65,7 +65,15 @@ func newTestResetAllEmbeddingStore(t *testing.T) *database.EmbeddingStore {
 // on every file that has at least one non-empty segment, and leaves
 // already-clear files untouched while still counting only real clears.
 func TestResetAll_SlowPathClearsFingerprints(t *testing.T) {
-	files := []database.BookFile{
+	// AcoustIDSeg0..6 are stripped from BookFileCore entirely, so the
+	// candidate list carries only IDs and the real segment values live in
+	// the hydrated full row returned by GetBookFiles.
+	files := []database.BookFileCore{
+		{ID: "f1"},
+		{ID: "f2"}, // already clear
+		{ID: "f3"},
+	}
+	hydrateFiles := []database.BookFile{
 		{ID: "f1", AcoustIDSeg0: "AQADtAcSRY"},
 		{ID: "f2"}, // already clear
 		{ID: "f3", AcoustIDSeg3: "AQADtAcSRZ", AcoustIDSeg6: "AQADtAcSRA"},
@@ -74,8 +82,11 @@ func TestResetAll_SlowPathClearsFingerprints(t *testing.T) {
 	var mu sync.Mutex
 	var updates []string
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
+		},
+		GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
+			return hydrateFiles, nil
 		},
 		UpdateBookFileFunc: func(id string, updated *database.BookFile) error {
 			mu.Lock()
@@ -140,7 +151,7 @@ func TestResetAll_DeletesCandidatesAcrossPages(t *testing.T) {
 	}
 
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return nil, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return nil, nil },
 	}
 	p := &Plugin{store: store, embeddingStore: emb}
 	r := &resetAllTestReporter{}
@@ -170,12 +181,12 @@ func TestResetAll_DeletesCandidatesAcrossPages(t *testing.T) {
 // context causes runResetAll to return a non-nil error promptly, relying on
 // RunItems's built-in ctx.Done() polling in the slow-path loop.
 func TestResetAll_CancelledContextReturnsError(t *testing.T) {
-	files := []database.BookFile{
-		{ID: "f1", AcoustIDSeg0: "AQADtAcSRY"},
-		{ID: "f2", AcoustIDSeg0: "AQADtAcSRZ"},
+	files := []database.BookFileCore{
+		{ID: "f1"},
+		{ID: "f2"},
 	}
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		UpdateBookFileFunc: func(string, *database.BookFile) error {
 			t.Error("UpdateBookFile should not be called with a pre-cancelled context")
 			return nil

--- a/internal/plugins/dedup/lsh_index_build.go
+++ b/internal/plugins/dedup/lsh_index_build.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/lsh_index_build.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: e61b955e-93bf-4ea6-bb1f-7acd30491fdb
 // last-edited: 2026-07-06
 
@@ -27,9 +27,12 @@ import (
 // The *PebbleStore satisfies this interface; other store implementations
 // may return errors from the LSH methods (they carry no index).
 type LSHIndexStore interface {
-	// GetAllBookFiles returns every BookFile row. The op iterates all files
-	// and indexes only those with a non-empty AcoustIDFingerprint.
-	GetAllBookFiles() ([]database.BookFile, error)
+	// GetAllBookFilesCore returns the BookFileCore projection of every
+	// BookFile row. The op iterates all files and indexes only those with a
+	// whole-file fingerprint (AcoustIDFingerprintDurationSec > 0 — the KEPT
+	// proxy; the raw AcoustIDFingerprint bytes are a heavy field never
+	// present on Core and must be hydrated per-book via GetBookFiles).
+	GetAllBookFilesCore() ([]database.BookFileCore, error)
 
 	// HasLSHIndex reports whether a BookFile already has an fpidx_meta row.
 	// The op uses this to skip already-indexed files on incremental re-runs —
@@ -120,7 +123,7 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 	loadProg := sdk.NewProgress(reporter, 0)
 	loadProg.Start("Loading BookFiles for LSH indexing…")
 
-	files, err := lshStore.GetAllBookFiles()
+	files, err := lshStore.GetAllBookFilesCore()
 	if err != nil {
 		return fmt.Errorf("lsh-index-build: load files: %w", err)
 	}
@@ -174,14 +177,14 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 
 		idxs := groups[bookID] // indices into the read-only `files` slice
 
-		// Does any file in this book carry the proxy (DurationSec>0) but a
-		// memdb-stripped blob (AcoustIDFingerprint==nil)? Only then do we pay
-		// for a hydrate read — most files either have no fp at all (skip) or
-		// (in a cold-start / Pebble-direct run) already carry the real bytes.
+		// Does any file in this book carry the proxy (DurationSec>0)? Core
+		// never carries the raw AcoustIDFingerprint bytes at all (heavy
+		// field, stripped on both the memdb and Pebble-direct paths), so any
+		// file with a whole-file fp always needs the hydrate read now.
 		needsHydrate := false
 		for _, idx := range idxs {
 			f := &files[idx]
-			if f.AcoustIDFingerprintDurationSec > 0 && len(f.AcoustIDFingerprint) == 0 {
+			if f.AcoustIDFingerprintDurationSec > 0 {
 				needsHydrate = true
 				break
 			}
@@ -215,8 +218,9 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 			}
 
 			// AcoustIDFingerprintDurationSec > 0 is the memdb-safe proxy for
-			// "has whole-file fp" (the blob itself may be stripped to nil).
-			hasWholeFP := len(f.AcoustIDFingerprint) > 0 || f.AcoustIDFingerprintDurationSec > 0
+			// "has whole-file fp" — Core carries no AcoustIDFingerprint bytes
+			// to check directly.
+			hasWholeFP := f.AcoustIDFingerprintDurationSec > 0
 			if !hasWholeFP {
 				localNoFP++
 				if f.FingerprintFailedAt == nil {
@@ -235,27 +239,26 @@ func (p *Plugin) runLSHIndexBuild(ctx context.Context, _ json.RawMessage, report
 				continue
 			}
 
-			fp := f.AcoustIDFingerprint
-			if len(fp) == 0 {
-				// Memdb-stripped: hydrate from the raw-Pebble read above.
-				if hydrated != nil {
-					if hf, ok := hydrated[f.ID]; ok {
-						fp = hf.AcoustIDFingerprint
-					}
-					if len(fp) == 0 {
-						reporter.Logger().Warn("lsh-index-build: hydrate returned empty fingerprint (data drift)",
-							"file_id", f.ID, "book_id", f.BookID)
-					}
+			// Core never carries the raw bytes; the op always hydrates via
+			// the per-book GetBookFiles map built above.
+			var fp []byte
+			if hydrated != nil {
+				if hf, ok := hydrated[f.ID]; ok {
+					fp = hf.AcoustIDFingerprint
 				}
 				if len(fp) == 0 {
-					// Hydrate failed, or the raw row genuinely has no blob
-					// despite the DurationSec proxy claiming one exists.
-					// Count as an error (not noFP) so it isn't misrouted into
-					// the rescan-enqueue path — the file DOES have a
-					// fingerprint on record, we just couldn't read it this run.
-					localErrs++
-					continue
+					reporter.Logger().Warn("lsh-index-build: hydrate returned empty fingerprint (data drift)",
+						"file_id", f.ID, "book_id", f.BookID)
 				}
+			}
+			if len(fp) == 0 {
+				// Hydrate failed, or the raw row genuinely has no blob
+				// despite the DurationSec proxy claiming one exists.
+				// Count as an error (not noFP) so it isn't misrouted into
+				// the rescan-enqueue path — the file DOES have a
+				// fingerprint on record, we just couldn't read it this run.
+				localErrs++
+				continue
 			}
 
 			subs, bands, fpErr := fingerprint.Subprints(fp)

--- a/internal/plugins/dedup/lsh_index_build_test.go
+++ b/internal/plugins/dedup/lsh_index_build_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/lsh_index_build_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: c1cf5590-1bc1-4f88-9031-62333bcb593f
 // last-edited: 2026-07-06
 
@@ -38,26 +38,26 @@ func synthRawLSH(seed int64, frames int) []byte {
 // Note: mockLSHStore only needs to satisfy the LSHIndexStore interface
 // (used via type assertion inside runLSHIndexBuild), not database.Store.
 type mockLSHStore struct {
-	files        []database.BookFile
+	files        []database.BookFileCore
 	indexedFiles map[string]bool // HasLSHIndex returns true for these IDs
 	mu           sync.Mutex      // guards putCalls (written concurrently by RunItems workers)
 	putCalls     []string        // fileIDs passed to PutLSHEntries
 	flagSet      bool
 
 	// hydrateFiles simulates the raw-Pebble GetBookFiles(bookID) read that
-	// the hydrate path falls back to when a memdb-slim BookFile row (from
-	// GetAllBookFiles) has AcoustIDFingerprintDurationSec > 0 but a nil
-	// AcoustIDFingerprint blob. Keyed by BookID.
+	// the hydrate path uses to obtain the real AcoustIDFingerprint bytes —
+	// BookFileCore (from GetAllBookFilesCore) never carries that field at
+	// all. Keyed by BookID.
 	hydrateFiles map[string][]database.BookFile
 	// hydrateErr, when non-nil, makes GetBookFiles fail for every book —
 	// simulates a Pebble read error during hydrate.
 	hydrateErr error
 }
 
-// GetBookFiles simulates the raw-Pebble read used to hydrate a memdb-slim
-// BookFile's stripped AcoustIDFingerprint blob. Unlike GetAllBookFiles, a
-// real PebbleStore.GetBookFiles never goes through memdb, so it always
-// returns full rows — the mock mirrors that by returning hydrateFiles as-is.
+// GetBookFiles simulates the raw-Pebble read used to hydrate the real
+// AcoustIDFingerprint bytes for a BookFileCore candidate. A real
+// PebbleStore.GetBookFiles never goes through memdb, so it always returns
+// full rows — the mock mirrors that by returning hydrateFiles as-is.
 func (m *mockLSHStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
 	if m.hydrateErr != nil {
 		return nil, m.hydrateErr
@@ -68,7 +68,7 @@ func (m *mockLSHStore) GetBookFiles(bookID string) ([]database.BookFile, error) 
 // database.Store compliance: use nil for the plugin.store field — the
 // type assertion path in runLSHIndexBuild casts to LSHIndexStore directly.
 
-func (m *mockLSHStore) GetAllBookFiles() ([]database.BookFile, error) {
+func (m *mockLSHStore) GetAllBookFilesCore() ([]database.BookFileCore, error) {
 	return m.files, nil
 }
 func (m *mockLSHStore) HasLSHIndex(id string) bool {
@@ -134,8 +134,8 @@ type mockLSHStoreAdapter struct {
 // Override only the LSHIndexStore methods (plus GetBookFiles, used by the
 // hydrate path — it is part of database.BookFileStore/database.Store, not
 // LSHIndexStore, but runLSHIndexBuild calls it via p.store directly).
-func (a *mockLSHStoreAdapter) GetAllBookFiles() ([]database.BookFile, error) {
-	return a.inner.GetAllBookFiles()
+func (a *mockLSHStoreAdapter) GetAllBookFilesCore() ([]database.BookFileCore, error) {
+	return a.inner.GetAllBookFilesCore()
 }
 func (a *mockLSHStoreAdapter) GetBookFiles(bookID string) ([]database.BookFile, error) {
 	return a.inner.GetBookFiles(bookID)
@@ -168,14 +168,18 @@ func TestLSHIndexBuild_OpIndexesAllWithFingerprints(t *testing.T) {
 	fp := synthRawLSH(42, 57600)
 
 	ms := &mockLSHStore{
-		files: []database.BookFile{
-			{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: fp},
-			{ID: "file-2", BookID: "book-2", AcoustIDFingerprint: fp},
-			{ID: "file-3", BookID: "book-3", AcoustIDFingerprint: nil}, // no fp
-			{ID: "file-4", BookID: "book-4", AcoustIDFingerprint: fp},
+		files: []database.BookFileCore{
+			{ID: "file-1", BookID: "book-1", AcoustIDFingerprintDurationSec: 1800},
+			{ID: "file-2", BookID: "book-2", AcoustIDFingerprintDurationSec: 1800},
+			{ID: "file-3", BookID: "book-3"}, // no fp (DurationSec==0)
+			{ID: "file-4", BookID: "book-4", AcoustIDFingerprintDurationSec: 1800},
 		},
 		indexedFiles: map[string]bool{
 			"file-4": true, // already indexed — should be skipped
+		},
+		hydrateFiles: map[string][]database.BookFile{
+			"book-1": {{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: fp}},
+			"book-2": {{ID: "file-2", BookID: "book-2", AcoustIDFingerprint: fp}},
 		},
 	}
 
@@ -250,13 +254,16 @@ func TestLSHIndexBuild_EnqueuesFingerRescanForNoFPBooks(t *testing.T) {
 	fp := synthRawLSH(42, 57600)
 
 	ms := &mockLSHStore{
-		files: []database.BookFile{
-			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp},
-			{ID: "file-2", BookID: "book-nofp-a", AcoustIDFingerprint: nil},
-			{ID: "file-3", BookID: "book-nofp-a", AcoustIDFingerprint: nil}, // same book → deduplicated
-			{ID: "file-4", BookID: "book-nofp-b", AcoustIDFingerprint: nil},
+		files: []database.BookFileCore{
+			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprintDurationSec: 1800},
+			{ID: "file-2", BookID: "book-nofp-a"},
+			{ID: "file-3", BookID: "book-nofp-a"}, // same book → deduplicated
+			{ID: "file-4", BookID: "book-nofp-b"},
 		},
 		indexedFiles: map[string]bool{},
+		hydrateFiles: map[string][]database.BookFile{
+			"book-has-fp": {{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp}},
+		},
 	}
 
 	reg := &mockRegistry{}
@@ -303,11 +310,15 @@ func TestLSHIndexBuild_NoEnqueueWhenAllHaveFingerprints(t *testing.T) {
 	fp := synthRawLSH(7, 57600)
 
 	ms := &mockLSHStore{
-		files: []database.BookFile{
-			{ID: "f1", BookID: "b1", AcoustIDFingerprint: fp},
-			{ID: "f2", BookID: "b2", AcoustIDFingerprint: fp},
+		files: []database.BookFileCore{
+			{ID: "f1", BookID: "b1", AcoustIDFingerprintDurationSec: 1800},
+			{ID: "f2", BookID: "b2", AcoustIDFingerprintDurationSec: 1800},
 		},
 		indexedFiles: map[string]bool{},
+		hydrateFiles: map[string][]database.BookFile{
+			"b1": {{ID: "f1", BookID: "b1", AcoustIDFingerprint: fp}},
+			"b2": {{ID: "f2", BookID: "b2", AcoustIDFingerprint: fp}},
+		},
 	}
 
 	reg := &mockRegistry{}
@@ -337,9 +348,9 @@ func TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue(t *testing.T) {
 	now := time.Now()
 
 	ms := &mockLSHStore{
-		files: []database.BookFile{
+		files: []database.BookFileCore{
 			// book-has-fp: has fingerprint → indexed
-			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp},
+			{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprintDurationSec: 1800},
 			// book-perm-fail: noFP but ALL files permanently failed → no enqueue
 			{ID: "file-2", BookID: "book-perm-fail", FingerprintFailedAt: &now},
 			{ID: "file-3", BookID: "book-perm-fail", FingerprintFailedAt: &now},
@@ -347,6 +358,9 @@ func TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue(t *testing.T) {
 			{ID: "file-4", BookID: "book-never-tried"},
 		},
 		indexedFiles: map[string]bool{},
+		hydrateFiles: map[string][]database.BookFile{
+			"book-has-fp": {{ID: "file-1", BookID: "book-has-fp", AcoustIDFingerprint: fp}},
+		},
 	}
 
 	reg := &mockRegistry{}
@@ -387,26 +401,27 @@ func TestLSHIndexBuild_SkipsPermanentlyFailedBooksFromEnqueue(t *testing.T) {
 }
 
 // TestLSHIndexBuild_HydratesMemdbStrippedFingerprint is the regression test
-// for the memdb-slim no-op bug: GetAllBookFiles (the memdb-slim projection
-// under prod's UseMemDB=true) nils AcoustIDFingerprint while preserving
+// for the memdb-slim no-op bug: GetAllBookFilesCore (BookFileCore, which
+// never carries AcoustIDFingerprint at all) preserves
 // AcoustIDFingerprintDurationSec (>0 ⇒ a whole-file fingerprint exists on
 // the raw row). Before the fix, the gate was len(AcoustIDFingerprint)==0,
 // which is always true for a memdb-slim row, so every such file was silently
 // skipped and PutLSHEntries was never called — the op reported success but
 // indexed nothing.
 //
-// This test simulates that shape: file-1 arrives from GetAllBookFiles with a
-// nil blob + DurationSec>0, and GetBookFiles(bookID) — standing in for the
-// real PebbleStore.GetBookFiles, which always reads raw Pebble and is never
-// memdb-stripped — returns the same file WITH the real fingerprint bytes.
-// Asserts the hydrate path recovers the blob and the file gets indexed.
+// This test simulates that shape: file-1 arrives from GetAllBookFilesCore
+// with DurationSec>0 (and no fingerprint field to even check), and
+// GetBookFiles(bookID) — standing in for the real PebbleStore.GetBookFiles,
+// which always reads raw Pebble and is never memdb-stripped — returns the
+// same file WITH the real fingerprint bytes. Asserts the hydrate path
+// recovers the blob and the file gets indexed.
 func TestLSHIndexBuild_HydratesMemdbStrippedFingerprint(t *testing.T) {
 	fp := synthRawLSH(99, 57600)
 
 	ms := &mockLSHStore{
-		files: []database.BookFile{
+		files: []database.BookFileCore{
 			// Memdb-slim projection: DurationSec survives, blob is nil'd.
-			{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
+			{ID: "file-1", BookID: "book-1", AcoustIDFingerprintDurationSec: 1800},
 		},
 		indexedFiles: map[string]bool{},
 		hydrateFiles: map[string][]database.BookFile{
@@ -446,8 +461,8 @@ func TestLSHIndexBuild_HydratesMemdbStrippedFingerprint(t *testing.T) {
 // and no rescan enqueue.
 func TestLSHIndexBuild_HydrateDataDriftCountsAsErrorNotNoFP(t *testing.T) {
 	ms := &mockLSHStore{
-		files: []database.BookFile{
-			{ID: "file-1", BookID: "book-1", AcoustIDFingerprint: nil, AcoustIDFingerprintDurationSec: 1800},
+		files: []database.BookFileCore{
+			{ID: "file-1", BookID: "book-1", AcoustIDFingerprintDurationSec: 1800},
 		},
 		indexedFiles: map[string]bool{},
 		hydrateFiles: map[string][]database.BookFile{

--- a/internal/plugins/dedup/purge_legacy_fp.go
+++ b/internal/plugins/dedup/purge_legacy_fp.go
@@ -1,6 +1,7 @@
 // file: internal/plugins/dedup/purge_legacy_fp.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3b7a2e9f-c1d4-4f8b-a5e0-6d3c8b2f1e47
+// last-edited: 2026-07-06
 
 // Package dedup — op dedup.purge-legacy-fp-candidates (T015, SPEC 1 §8 step 2).
 //
@@ -260,7 +261,7 @@ func (p *Plugin) runPurgeLegacyFP(ctx context.Context, rawParams json.RawMessage
 // for all current BookFiles. This is used to re-verify whether a candidate pair
 // still has a genuine whole-file hash match before marking it stale.
 func (p *Plugin) buildFileHashIndex(_ context.Context) (map[string]map[string]struct{}, error) {
-	files, err := p.store.GetAllBookFiles()
+	files, err := p.store.GetAllBookFilesCore()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/dedup/purge_legacy_fp_test.go
+++ b/internal/plugins/dedup/purge_legacy_fp_test.go
@@ -1,6 +1,7 @@
 // file: internal/plugins/dedup/purge_legacy_fp_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9e4b7f3a-2c1d-4e8b-b6a5-0d7c9e2f5b8a
+// last-edited: 2026-07-06
 
 // Table-driven tests for the dedup.purge-legacy-fp-candidates op (T015).
 //
@@ -192,9 +193,9 @@ func TestPurgeLegacyFP(t *testing.T) {
 			es := newTestEmbeddingStorePurge(t)
 
 			// Build file-hash fixtures for the mock store.
-			var bookFiles []database.BookFile
+			var bookFiles []database.BookFileCore
 			if tc.fileHashA != "" {
-				bookFiles = append(bookFiles, database.BookFile{
+				bookFiles = append(bookFiles, database.BookFileCore{
 					ID:       "file-a",
 					BookID:   "book-a",
 					FileHash: tc.fileHashA,
@@ -207,7 +208,7 @@ func TestPurgeLegacyFP(t *testing.T) {
 				if tc.sharedHash {
 					bHash = tc.fileHashA // same hash → genuine dupe
 				}
-				bookFiles = append(bookFiles, database.BookFile{
+				bookFiles = append(bookFiles, database.BookFileCore{
 					ID:       "file-b",
 					BookID:   "book-b",
 					FileHash: bHash,
@@ -215,7 +216,7 @@ func TestPurgeLegacyFP(t *testing.T) {
 			}
 
 			ms := &database.MockStore{
-				GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+				GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 					return bookFiles, nil
 				},
 				GetSettingFunc: func(key string) (*database.Setting, error) {
@@ -265,7 +266,7 @@ func TestPurgeLegacyFP_FlagSkip(t *testing.T) {
 	es := newTestEmbeddingStorePurge(t)
 
 	ms := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return nil, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return nil, nil },
 		GetSettingFunc: func(key string) (*database.Setting, error) {
 			if key == purgeLegacyFPDoneFlag {
 				return &database.Setting{Key: key, Value: "true"}, nil // flag set

--- a/internal/plugins/maintenance/fs_regroup_xml.go
+++ b/internal/plugins/maintenance/fs_regroup_xml.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/fs_regroup_xml.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7d2a9c14-3e86-4b50-9f71-2c8e0a6d4b95
-// last-edited: 2026-06-21
+// last-edited: 2026-07-06
 
 // Package maintenance — op maintenance.fs-regroup-xml.
 //
@@ -124,9 +124,9 @@ func (p *Plugin) runFSRegroupXML(ctx context.Context, raw json.RawMessage, repor
 
 	// Pass 2: file counts so already-multi-file books are excluded.
 	_ = reporter.UpdateProgress(1, 3, "Phase 2/3: counting book files…")
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return fmt.Errorf("GetAllBookFiles: %w", err)
+		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
 	for i := range files {
 		if fsb := bookMeta[files[i].BookID]; fsb != nil {

--- a/internal/plugins/maintenance/integrity_check.go
+++ b/internal/plugins/maintenance/integrity_check.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/integrity_check.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7f4a2b3c-9d1e-4f6a-8b5c-2e0d1f3a4b5c
-// last-edited: 2026-07-01
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -73,15 +73,15 @@ func (p *Plugin) runIntegrityCheck(ctx context.Context, raw json.RawMessage, rep
 //
 // This is the testable core of runIntegrityCheck. It is purely a scan — it
 // never calls any store write or delete method.
-func findIntegrityMismatches(ctx context.Context, store database.Store) (flagged []database.BookFile, totalFiles int, err error) {
+func findIntegrityMismatches(ctx context.Context, store database.Store) (flagged []database.BookFileCore, totalFiles int, err error) {
 	if ctx.Err() != nil {
 		return nil, 0, ctx.Err()
 	}
-	files, ferr := store.GetAllBookFiles()
+	files, ferr := store.GetAllBookFilesCore()
 	if ferr != nil {
-		return nil, 0, fmt.Errorf("GetAllBookFiles: %w", ferr)
+		return nil, 0, fmt.Errorf("GetAllBookFilesCore: %w", ferr)
 	}
-	flagged = make([]database.BookFile, 0)
+	flagged = make([]database.BookFileCore, 0)
 	for _, f := range files {
 		if ctx.Err() != nil {
 			return nil, 0, ctx.Err()

--- a/internal/plugins/maintenance/integrity_check_test.go
+++ b/internal/plugins/maintenance/integrity_check_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/integrity_check_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a9d1e2f-4b5c-4d6e-8f7a-1b2c3d4e5f6a
-// last-edited: 2026-07-01
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -17,7 +17,7 @@ import (
 // record, mismatched hashes explained by an AO tag write, and rows with no
 // baseline hash, only the true mismatches (no AO write) are flagged.
 func TestFindIntegrityMismatches_ReportOnly(t *testing.T) {
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		// (a) matching hashes — not flagged.
 		{ID: "f1", FilePath: "/lib/a.m4b", FileHash: "hash-a", OriginalFileHash: "hash-a"},
 		// (b) mismatch with no AO write on record — flagged.
@@ -30,7 +30,7 @@ func TestFindIntegrityMismatches_ReportOnly(t *testing.T) {
 
 	var writeCalls, deleteCalls []string
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		DeleteBookFileFunc: func(id string) error {
@@ -64,12 +64,12 @@ func TestFindIntegrityMismatches_ReportOnly(t *testing.T) {
 // TestFindIntegrityMismatches_NoMismatches verifies the clean-library case
 // returns an empty slice with no error.
 func TestFindIntegrityMismatches_NoMismatches(t *testing.T) {
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "f1", FileHash: "h1", OriginalFileHash: "h1"},
 		{ID: "f2", FileHash: "h2", OriginalFileHash: "h2"},
 	}
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 	}
 	flagged, _, err := findIntegrityMismatches(context.Background(), store)
 	if err != nil {

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-06-20
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -179,9 +179,9 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 	}
 
 	// Pass 2: all book files → PID→location + per-book file counts.
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return snap, fmt.Errorf("GetAllBookFiles: %w", err)
+		return snap, fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
 	fileCount := make(map[string]int, len(meta))
 	for i := range files {

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
-// last-edited: 2026-05-29
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -125,19 +125,19 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 // findOrphanBookFiles returns every BookFile whose BookID does not match any
 // existing book ID. Returns the orphan slice, the total number of book_files
 // scanned, and the number of valid book IDs found. The scan uses the memdb
-// fastpath via Store.GetAllBookFiles / Store.GetAllBooks; both calls return
-// projections of the underlying tables without per-row decoding cost.
+// fastpath via Store.GetAllBookFilesCore / Store.GetAllBooks; both calls
+// return projections of the underlying tables without per-row decoding cost.
 //
 // This is the testable core of runOrphanBookFilesCleanup. It does not delete
 // anything — callers that want to delete iterate over the result and call
 // Store.DeleteBookFile themselves.
-func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFile, totalFiles int, totalBooks int, err error) {
+func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFileCore, totalFiles int, totalBooks int, err error) {
 	if ctx.Err() != nil {
 		return nil, 0, 0, ctx.Err()
 	}
-	files, ferr := store.GetAllBookFiles()
+	files, ferr := store.GetAllBookFilesCore()
 	if ferr != nil {
-		return nil, 0, 0, fmt.Errorf("GetAllBookFiles: %w", ferr)
+		return nil, 0, 0, fmt.Errorf("GetAllBookFilesCore: %w", ferr)
 	}
 	if ctx.Err() != nil {
 		return nil, 0, 0, ctx.Err()
@@ -152,7 +152,7 @@ func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []d
 	for _, b := range books {
 		valid[b.ID] = struct{}{}
 	}
-	orphans = make([]database.BookFile, 0)
+	orphans = make([]database.BookFileCore, 0)
 	for _, f := range files {
 		if ctx.Err() != nil {
 			return nil, 0, 0, ctx.Err()

--- a/internal/plugins/maintenance/orphan_book_files_test.go
+++ b/internal/plugins/maintenance/orphan_book_files_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 0bd4f9a2-1c3e-4f5a-8b6c-7d9e0f1a2b3c
-// last-edited: 2026-05-29
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -26,7 +26,7 @@ func TestFindOrphanBookFiles_ReportOnly(t *testing.T) {
 		{ID: "book-keep-2", Title: "Kept 2"},
 		{ID: "book-keep-3", Title: "Kept 3"},
 	}
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "f1", BookID: "book-keep-1", FilePath: "/lib/a.m4b"},
 		{ID: "f2", BookID: "book-keep-2", FilePath: "/lib/b.m4b"},
 		{ID: "f3", BookID: "book-ghost-9", FilePath: "/lib/orphan-1.m4b"}, // orphan
@@ -37,7 +37,7 @@ func TestFindOrphanBookFiles_ReportOnly(t *testing.T) {
 
 	var deleteCalls []string
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) {
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
 		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
@@ -86,14 +86,14 @@ func TestFindOrphanBookFiles_ReportOnly(t *testing.T) {
 // empty slice with no error.
 func TestFindOrphanBookFiles_NoOrphans(t *testing.T) {
 	books := []database.Book{{ID: "b1"}, {ID: "b2"}}
-	files := []database.BookFile{
+	files := []database.BookFileCore{
 		{ID: "f1", BookID: "b1"},
 		{ID: "f2", BookID: "b2"},
 		{ID: "f3", BookID: "b1"},
 	}
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
-		GetAllBooksFunc:     func(limit, offset int) ([]database.Book, error) { return books, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetAllBooksFunc:         func(limit, offset int) ([]database.Book, error) { return books, nil },
 	}
 	orphans, _, _, err := findOrphanBookFiles(context.Background(), store)
 	if err != nil {

--- a/internal/plugins/maintenance/tag_backfill.go
+++ b/internal/plugins/maintenance/tag_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/tag_backfill.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1f6b3d28-9a47-4c50-8e21-7b0c4a9d6e35
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // Package maintenance — op maintenance.tag-backfill.
 //
@@ -75,18 +75,18 @@ func (p *Plugin) runTagBackfill(ctx context.Context, raw json.RawMessage, report
 		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no changes will be written")
 	}
 
-	files, err := store.GetAllBookFiles()
+	files, err := store.GetAllBookFilesCore()
 	if err != nil {
-		return fmt.Errorf("GetAllBookFiles: %w", err)
+		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
 	total := len(files)
 	_ = reporter.UpdateProgress(0, total, fmt.Sprintf("Reading tags for %d files…", total))
 
 	// Limit caps how many files are EXAMINED (not just how many are backfilled),
 	// matching the original serial semantics: only the first Limit files (in
-	// GetAllBookFiles order) are looked at at all. Truncating the input slice up
-	// front makes this equivalent under registry.RunItems regardless of the
-	// order workers finish in.
+	// GetAllBookFilesCore order) are looked at at all. Truncating the input
+	// slice up front makes this equivalent under registry.RunItems regardless
+	// of the order workers finish in.
 	items := files
 	if params.Limit > 0 && params.Limit < total {
 		items = files[:params.Limit]
@@ -108,7 +108,7 @@ func (p *Plugin) runTagBackfill(ctx context.Context, raw json.RawMessage, report
 		examples                           = make([]string, 0, 5)
 	)
 
-	err = registry.RunItems(ctx, reporter, items, func(_ context.Context, f database.BookFile) error {
+	err = registry.RunItems(ctx, reporter, items, func(_ context.Context, f database.BookFileCore) error {
 		mu.Lock()
 		examined++
 		mu.Unlock()
@@ -137,7 +137,34 @@ func (p *Plugin) runTagBackfill(ctx context.Context, raw json.RawMessage, report
 			return nil // nothing capturable
 		}
 
-		updated := f // copy
+		// Hydrate the full row and mutate/write THAT — never a hand-built
+		// BookFile{} from Core fields, which would wipe the stored
+		// fingerprint. BatchUpsertBookFiles' preserve-on-empty guard also
+		// covers this, but hydrating here keeps the write self-contained
+		// rather than relying on that guard for correctness. See
+		// docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md.
+		full, herr := store.GetBookFiles(f.BookID)
+		if herr != nil {
+			mu.Lock()
+			readErr++
+			mu.Unlock()
+			return nil
+		}
+		var target *database.BookFile
+		for j := range full {
+			if full[j].ID == f.ID {
+				target = &full[j]
+				break
+			}
+		}
+		if target == nil {
+			mu.Lock()
+			readErr++
+			mu.Unlock()
+			return nil
+		}
+
+		updated := *target // copy of the full hydrated row
 		updated.RawTags = meta.AllTags
 		if meta.TrackNumber > 0 {
 			updated.TrackNumber = meta.TrackNumber

--- a/internal/plugins/maintenance/tag_backfill_test.go
+++ b/internal/plugins/maintenance/tag_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/tag_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5b6e7f4a-9c1d-4e0a-8f2b-3a6d1c9e5b70
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package maintenance
 
@@ -123,13 +123,23 @@ func TestTagBackfill_ParallelProducesSameResultAsSerial(t *testing.T) {
 		wantBackfilled[id] = true
 	}
 
+	// core is the BookFileCore projection of files — the op's
+	// GetAllBookFilesCore call. GetBookFiles (the hydrate path for each
+	// backfill candidate) returns the full rows directly since none of the
+	// fixtures set a BookID (all share the empty-string bucket).
+	core := make([]database.BookFileCore, len(files))
+	for i := range files {
+		core[i] = files[i].Core()
+	}
+
 	var (
 		upsertMu      sync.Mutex
 		upserted      []*database.BookFile
 		upsertBatches int
 	)
 	store := &database.MockStore{
-		GetAllBookFilesFunc: func() ([]database.BookFile, error) { return files, nil },
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return core, nil },
+		GetBookFilesFunc:        func(bookID string) ([]database.BookFile, error) { return files, nil },
 		BatchUpsertBookFilesFunc: func(batch []*database.BookFile) error {
 			upsertMu.Lock()
 			upserted = append(upserted, batch...)

--- a/internal/server/handlers/mocks/mock_reading_store.go
+++ b/internal/server/handlers/mocks/mock_reading_store.go
@@ -415,24 +415,24 @@ func (_c *MockReadingStore_GetAcoustIDStats_Call) RunAndReturn(run func() (*data
 	return _c
 }
 
-// GetAllBookFiles provides a mock function for the type MockReadingStore
-func (_mock *MockReadingStore) GetAllBookFiles() ([]database.BookFile, error) {
+// GetAllBookFilesCore provides a mock function for the type MockReadingStore
+func (_mock *MockReadingStore) GetAllBookFilesCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBookFiles")
+		panic("no return value specified for GetAllBookFilesCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -443,29 +443,29 @@ func (_mock *MockReadingStore) GetAllBookFiles() ([]database.BookFile, error) {
 	return r0, r1
 }
 
-// MockReadingStore_GetAllBookFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFiles'
-type MockReadingStore_GetAllBookFiles_Call struct {
+// MockReadingStore_GetAllBookFilesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBookFilesCore'
+type MockReadingStore_GetAllBookFilesCore_Call struct {
 	*mock.Call
 }
 
-// GetAllBookFiles is a helper method to define mock.On call
-func (_e *MockReadingStore_Expecter) GetAllBookFiles() *MockReadingStore_GetAllBookFiles_Call {
-	return &MockReadingStore_GetAllBookFiles_Call{Call: _e.mock.On("GetAllBookFiles")}
+// GetAllBookFilesCore is a helper method to define mock.On call
+func (_e *MockReadingStore_Expecter) GetAllBookFilesCore() *MockReadingStore_GetAllBookFilesCore_Call {
+	return &MockReadingStore_GetAllBookFilesCore_Call{Call: _e.mock.On("GetAllBookFilesCore")}
 }
 
-func (_c *MockReadingStore_GetAllBookFiles_Call) Run(run func()) *MockReadingStore_GetAllBookFiles_Call {
+func (_c *MockReadingStore_GetAllBookFilesCore_Call) Run(run func()) *MockReadingStore_GetAllBookFilesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockReadingStore_GetAllBookFiles_Call) Return(bookFiles []database.BookFile, err error) *MockReadingStore_GetAllBookFiles_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockReadingStore_GetAllBookFilesCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockReadingStore_GetAllBookFilesCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockReadingStore_GetAllBookFiles_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockReadingStore_GetAllBookFiles_Call {
+func (_c *MockReadingStore_GetAllBookFilesCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockReadingStore_GetAllBookFilesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## STOREFID W3 — slim book-file getter retype

Renames `GetAllBookFiles()` → `GetAllBookFilesCore()` returning `[]BookFileCore` so a caller reading a memdb-stripped fingerprint field becomes a **compile error** instead of a silent nil read. Atomic across the `Store` interface, `PebbleStore`, `MemStore`, the hand-written `MockStore`, and the mockery-generated mock (regenerated with pinned v3.7.1).

### Fingerprint-wipe closure (the point of this wave)
The retype compile-forced **8 whole-library writeback jobs** off the "read memdb-slim → write the whole struct back" anti-pattern (which wiped stored fingerprint diagnostics) and onto **hydrate-mutate-update** — `GetBookFiles(bookID)` → mutate the full row → `UpdateBookFile`:

`recompute_itunes_paths`, `enrich_book_files`, `fix_book_file_paths`, `repair_missing_files`, `tag_backfill`, `reset_all` (slow path), acoustid `online_lookup`, acoustid `lsh_backfill`.

No `BookFileCore.ToBookFile()` bridge and no hand-constructed `BookFile{}` writeback anywhere (both compile but wipe at runtime — all 8 sites hand-reviewed for the hydrate shape). The compile audit **corrected the caller census**: `tag_backfill` and `reset_all` were originally mis-classified as safe/test-only.

### Deferred (documented, not in this PR)
`GetBookFilesNeedingDelugeImport` is kept byte-identical (non-memdb branch re-points to the internal full `getAllBookFilesPebbleScan()`). The **3 indirect deluge import writeback vectors** it feeds (`internal/deluge/ImportToLibrary`, `bulk_deluge_import`, `deluge/centralization`) are a pre-existing wipe (blob guarded by PR-A #1839, diagnostics wiped) — documented in the audit doc + TODO, fixed in fast-follow **PR-D**.

### Verification
- `go build ./...` — pass (read-fidelity proof: no caller reads a stripped field)
- `go vet ./...` — pass
- `go test -race` pass: `internal/database/...`, `internal/plugins/acoustid/...`, `internal/plugins/dedup/...`, `internal/maintenance/...`, `internal/plugins/maintenance/...`

Follows PR-A #1839 / PR-B #1840. Part of the STOREFID initiative (docs/specs/2026-07-05-store-getter-fidelity-unification.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)