### PR TITLE
refactor(store): GetBooksBySeriesID → GetBooksBySeriesIDCore ([]BookCore) (STOREFID W4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,30 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.112.0 -->
+<!-- version: 3.113.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-06 -->
+<!-- last-edited: 2026-07-07 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): GetBooksBySeriesID → GetBooksBySeriesIDCore ([]BookCore) (STOREFID W4)
+
+- **`refactor(store)`** — renamed the slim series getter `GetBooksBySeriesID()` →
+  `GetBooksBySeriesIDCore()` returning `[]BookCore` (same pattern as W2's
+  `GetBooksByAuthorIDCore`), atomic across the `Store` interface, `PebbleStore`,
+  `MemStore`, the hand-written `MockStore`, and the mockery-generated mock. A caller
+  reading a memdb-stripped heavy Book field is now a compile error.
+- **3 writeback call sites hardened** — the retype compile-surfaced three loops
+  (`duplicates_helpers.executeSeriesPrune`, `series_dedup.DedupSeries`,
+  `series_dedup.MergeSeries`) that set `SeriesID` on a memdb-slim book and wrote the
+  whole struct back via `UpdateBook`. `UpdateBook`'s STOR-1 preserve-on-empty guard
+  already restored the 7 persisted heavy fields (Description/VersionNotes/BookSig*),
+  but the denormalized `Author`/`Series` (`db:"-"`) were not guard-covered. All three
+  now hydrate the full row via `GetBookByID` and mutate only `SeriesID` — matching the
+  existing `cleanup_series.go` pattern — removing the guard reliance entirely.
+  Regression assertions confirm the heavy `Description` field survives a series reassign.
 
 #### July 6, 2026 - refactor(store): GetAllBookFiles → GetAllBookFilesCore ([]BookFileCore) (STOREFID W3)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.66.0 -->
+<!-- version: 9.67.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-06 -->
 

--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/audiobook_service_unit_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package audiobooks
 
@@ -177,8 +177,8 @@ func TestAudiobookService_GetAudiobooks_BySeriesID(t *testing.T) {
 	svc := NewAudiobookService(mockStore)
 
 	seriesID := 7
-	expected := []database.Book{{ID: "s1"}}
-	mockStore.EXPECT().GetBooksBySeriesID(7).Return(expected, nil)
+	expected := []database.BookCore{{ID: "s1"}}
+	mockStore.EXPECT().GetBooksBySeriesIDCore(7).Return(expected, nil)
 
 	books, err := svc.GetAudiobooks(context.Background(), 10, 0, "", nil, &seriesID)
 	assert.NoError(t, err)

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package audiobooks
 
@@ -74,7 +74,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	} else if authorID != nil {
 		// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2); GetAudiobooks'
 		// public signature ([]database.Book, shared with SearchBooks/
-		// GetBooksBySeriesID below and the caller's downstream filtering) is
+		// GetBooksBySeriesIDCore below and the caller's downstream filtering) is
 		// out of scope to retype here, so convert back via BookCore.ToBook().
 		var booksCore []database.BookCore
 		booksCore, err = svc.store.GetBooksByAuthorIDCore(*authorID)
@@ -85,7 +85,16 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			}
 		}
 	} else if seriesID != nil {
-		books, err = svc.store.GetBooksBySeriesID(*seriesID)
+		// GetBooksBySeriesIDCore is Core-typed (STOREFID W4); same rationale
+		// as the authorID branch above.
+		var booksCore []database.BookCore
+		booksCore, err = svc.store.GetBooksBySeriesIDCore(*seriesID)
+		if err == nil {
+			books = make([]database.Book, len(booksCore))
+			for i := range booksCore {
+				books[i] = booksCore[i].ToBook()
+			}
+		}
 	}
 
 	// Fall back to generic list only when no filter was applied

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,6 +1,6 @@
 // file: internal/batch/service_test.go
-// version: 1.0.6
-// last-edited: 2026-07-05
+// version: 1.0.7
+// last-edited: 2026-07-06
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -108,7 +108,9 @@ func (m *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]data
 func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]database.Book, error) {
 	return nil, nil
 }
-func (m *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	return nil, nil
 }

--- a/internal/database/coverage_test.go
+++ b/internal/database/coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/coverage_test.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 3b82b22e-cd28-49b8-8b9c-e0a34b18e631
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // NOTE(fable5 T022): TestInitializeStoreAndClose, TestDBInterfaceWrapper,
 // and TestWebHelpers removed — they tested SQLite initialisation and global
@@ -213,8 +213,8 @@ func TestMockStore_AllMethods(t *testing.T) {
 	if duplicates, err := mock.GetDuplicateBooks(); err != nil || duplicates != nil {
 		t.Errorf("GetDuplicateBooks() = %v, %v; want nil, nil", duplicates, err)
 	}
-	if books, err := mock.GetBooksBySeriesID(1); err != nil || books != nil {
-		t.Errorf("GetBooksBySeriesID() = %v, %v; want nil, nil", books, err)
+	if books, err := mock.GetBooksBySeriesIDCore(1); err != nil || books != nil {
+		t.Errorf("GetBooksBySeriesIDCore() = %v, %v; want nil, nil", books, err)
 	}
 	if books, err := mock.GetBooksByAuthorIDCore(1); err != nil || books != nil {
 		t.Errorf("GetBooksByAuthorIDCore() = %v, %v; want nil, nil", books, err)

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -53,9 +53,14 @@ type BookReader interface {
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error)
 	GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]Book, error)
-	// GetBooksBySeriesID is SLIM (memdb projection) — see
-	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetBooksBySeriesID(seriesID int) ([]Book, error)
+	// GetBooksBySeriesIDCore is Core-typed (STOREFID W4): the return type is
+	// BookCore, not Book, so the nine heavy fields (Description,
+	// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,
+	// BookSigBuiltAt, BookSigCoveragePct, Author, Series) being absent is
+	// compiler-enforced rather than silently nil'd. A caller that needs any
+	// of those MUST fetch via GetBookByID / GetAllBooksFullFrom (full
+	// Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+	GetBooksBySeriesIDCore(seriesID int) ([]BookCore, error)
 	// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2): the memdb
 	// projection is stripped of the nine heavy fields (Description,
 	// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-07-06
 
@@ -354,11 +354,21 @@ func (m *MemStore) GetAllAuthorFileCounts() (map[int]int, error) {
 	return out, nil
 }
 
-// GetBooksBySeriesID returns primary, not-deleted books for a series with
-// pagination. Sort order is series_sequence (nulls last) then title, but
-// the comparator pre-lowercases titles ONCE per row instead of on every
+// GetBooksBySeriesIDCore returns primary, not-deleted books for a series
+// with pagination. Sort order is series_sequence (nulls last) then title,
+// but the comparator pre-lowercases titles ONCE per row instead of on every
 // compare to avoid O(n log n) string allocations.
-func (m *MemStore) GetBooksBySeriesID(seriesID int, limit, offset int) ([]Book, error) {
+//
+// Core-typed (STOREFID W4): the return type is BookCore, not Book — memdb
+// rows never carry the nine heavy fields (Description, VersionNotes,
+// BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series) in the first place, so projecting via
+// .Core() here just makes that guarantee visible in the type system. Unlike
+// GetBooksByAuthorID (kept []Book because it is shared by two PebbleStore
+// callers), this method has exactly one caller
+// (PebbleStore.GetBooksBySeriesIDCore), so retyping it directly is the
+// smaller change. See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (m *MemStore) GetBooksBySeriesIDCore(seriesID int, limit, offset int) ([]BookCore, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
 
@@ -399,7 +409,12 @@ func (m *MemStore) GetBooksBySeriesID(seriesID int, limit, offset int) ([]Book, 
 			}
 		})
 	}
-	return paginate(all, limit, offset), nil
+	paged := paginate(all, limit, offset)
+	cores := make([]BookCore, len(paged))
+	for i := range paged {
+		cores[i] = paged[i].Core()
+	}
+	return cores, nil
 }
 
 // GetBooksByAuthorID returns primary, not-deleted books for an author with

--- a/internal/database/memdb_reads_test.go
+++ b/internal/database/memdb_reads_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000007
-// last-edited: 2026-07-03
+// last-edited: 2026-07-06
 
 package database
 
@@ -139,7 +139,7 @@ func TestMemStore_GetAllSeriesFileCounts(t *testing.T) {
 	}
 }
 
-func TestMemStore_GetBooksBySeriesID(t *testing.T) {
+func TestMemStore_GetBooksBySeriesIDCore(t *testing.T) {
 	m, err := NewMemStore()
 	if err != nil {
 		t.Fatalf("NewMemStore: %v", err)
@@ -152,9 +152,9 @@ func TestMemStore_GetBooksBySeriesID(t *testing.T) {
 	}
 	seedMemStore(t, m, books, nil, nil, nil)
 
-	got, err := m.GetBooksBySeriesID(10, 10, 0)
+	got, err := m.GetBooksBySeriesIDCore(10, 10, 0)
 	if err != nil {
-		t.Fatalf("GetBooksBySeriesID: %v", err)
+		t.Fatalf("GetBooksBySeriesIDCore: %v", err)
 	}
 	if len(got) != 3 {
 		t.Fatalf("expected 3 books, got %d", len(got))

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.72.0
+// version: 1.73.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-06
 
@@ -39,7 +39,7 @@ type MockStore struct {
 	ListBookIDsFunc                 func() ([]string, error)
 	GetAllBookSummariesFunc         func(limit, offset int) ([]BookSummary, error)
 	GetBooksByWorkIDFunc            func(workID string) ([]Book, error)
-	GetBooksBySeriesIDFunc          func(seriesID int) ([]Book, error)
+	GetBooksBySeriesIDCoreFunc      func(seriesID int) ([]BookCore, error)
 	GetBooksByAuthorIDCoreFunc      func(authorID int) ([]BookCore, error)
 	GetBooksByAuthorIDWithRoleFunc  func(authorID int) ([]BookCore, error)
 	GetBookByITunesPersistentIDFunc func(persistentID string) (*Book, error)
@@ -762,9 +762,9 @@ func (m *MockStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, er
 	return nil, nil
 }
 
-func (m *MockStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
-	if m.GetBooksBySeriesIDFunc != nil {
-		return m.GetBooksBySeriesIDFunc(seriesID)
+func (m *MockStore) GetBooksBySeriesIDCore(seriesID int) ([]BookCore, error) {
+	if m.GetBooksBySeriesIDCoreFunc != nil {
+		return m.GetBooksBySeriesIDCoreFunc(seriesID)
 	}
 	return nil, nil
 }

--- a/internal/database/mock_store_coverage_test.go
+++ b/internal/database/mock_store_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store_coverage_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9f8e7d6c-5b4a-3c2d-1e0f-a9b8c7d6e5f4
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -53,7 +53,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	mock.GetBookByOriginalHashFunc = func(string) (*Book, error) { return nil, nil }
 	mock.GetBookByOrganizedHashFunc = func(string) (*Book, error) { return nil, nil }
 	mock.GetDuplicateBooksFunc = func() ([][]Book, error) { return nil, nil }
-	mock.GetBooksBySeriesIDFunc = func(int) ([]Book, error) { return nil, nil }
+	mock.GetBooksBySeriesIDCoreFunc = func(int) ([]BookCore, error) { return nil, nil }
 	mock.GetBooksByAuthorIDCoreFunc = func(int) ([]BookCore, error) { return nil, nil }
 	mock.CreateBookFunc = func(*Book) (*Book, error) { return nil, nil }
 	mock.UpdateBookFunc = func(string, *Book) (*Book, error) { return nil, nil }
@@ -172,7 +172,7 @@ func TestMockStore_CustomFuncPaths(t *testing.T) {
 	_, _ = mock.GetBookByOriginalHash("hash")
 	_, _ = mock.GetBookByOrganizedHash("hash")
 	_, _ = mock.GetDuplicateBooks()
-	_, _ = mock.GetBooksBySeriesID(1)
+	_, _ = mock.GetBooksBySeriesIDCore(1)
 	_, _ = mock.GetBooksByAuthorIDCore(1)
 	_, _ = mock.CreateBook(&Book{})
 	_, _ = mock.UpdateBook("book-1", &Book{})

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3739,24 +3739,24 @@ func (_c *MockBookReader_GetBooksByMetadataSourceHash_Call) RunAndReturn(run fun
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -3767,18 +3767,18 @@ func (_mock *MockBookReader) GetBooksBySeriesID(seriesID int) ([]database.Book, 
 	return r0, r1
 }
 
-// MockBookReader_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockBookReader_GetBooksBySeriesID_Call struct {
+// MockBookReader_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockBookReader_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockBookReader_Expecter) GetBooksBySeriesID(seriesID any) *MockBookReader_GetBooksBySeriesID_Call {
-	return &MockBookReader_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockBookReader_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockBookReader_GetBooksBySeriesIDCore_Call {
+	return &MockBookReader_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockBookReader_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockBookReader_GetBooksBySeriesID_Call {
+func (_c *MockBookReader_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockBookReader_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -3791,12 +3791,12 @@ func (_c *MockBookReader_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *M
 	return _c
 }
 
-func (_c *MockBookReader_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockBookReader_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockBookReader_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockBookReader_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockBookReader_GetBooksBySeriesID_Call {
+func (_c *MockBookReader_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockBookReader_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7120,24 +7120,24 @@ func (_c *MockBookStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -7148,18 +7148,18 @@ func (_mock *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, e
 	return r0, r1
 }
 
-// MockBookStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockBookStore_GetBooksBySeriesID_Call struct {
+// MockBookStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockBookStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockBookStore_Expecter) GetBooksBySeriesID(seriesID any) *MockBookStore_GetBooksBySeriesID_Call {
-	return &MockBookStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockBookStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockBookStore_GetBooksBySeriesIDCore_Call {
+	return &MockBookStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockBookStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockBookStore_GetBooksBySeriesID_Call {
+func (_c *MockBookStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockBookStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -7172,12 +7172,12 @@ func (_c *MockBookStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *Mo
 	return _c
 }
 
-func (_c *MockBookStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockBookStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockBookStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockBookStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockBookStore_GetBooksBySeriesID_Call {
+func (_c *MockBookStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockBookStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -37906,24 +37906,24 @@ func (_c *MockStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run func(has
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockStore
-func (_mock *MockStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -37934,18 +37934,18 @@ func (_mock *MockStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error
 	return r0, r1
 }
 
-// MockStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockStore_GetBooksBySeriesID_Call struct {
+// MockStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockStore_Expecter) GetBooksBySeriesID(seriesID any) *MockStore_GetBooksBySeriesID_Call {
-	return &MockStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockStore_GetBooksBySeriesIDCore_Call {
+	return &MockStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockStore_GetBooksBySeriesID_Call {
+func (_c *MockStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -37958,12 +37958,12 @@ func (_c *MockStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockSt
 	return _c
 }
 
-func (_c *MockStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockStore_GetBooksBySeriesID_Call {
+func (_c *MockStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.106.0
+// version: 1.107.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -39,7 +39,7 @@ func prefixEnd(prefix []byte) []byte {
 }
 
 // serializeBookForIndex marshals a Book to JSON for index storage.
-// This enables GetBooksBySeriesID and GetBooksByAuthorIDCore to deserialize
+// This enables GetBooksBySeriesIDCore and GetBooksByAuthorIDCore to deserialize
 // directly from the index without secondary point lookups.
 func serializeBookForIndex(book *Book) ([]byte, error) {
 	return json.Marshal(book)
@@ -92,7 +92,7 @@ func isValidULID(s string) bool {
 // - book:<id>                  -> Book JSON
 // - book:path:<path>           -> book_id (for lookups)
 // NOTE: book:series and book:author prefix indexes were removed in Task 3.4.
-//       GetBooksBySeriesID and GetBooksByAuthorIDCore fall back to a full Pebble scan
+//       GetBooksBySeriesIDCore and GetBooksByAuthorIDCore fall back to a full Pebble scan
 //       (the in-memory query layer covers the hot paths).
 // - import_path:<id>           -> ImportPath JSON
 // - import_path:path:<path>    -> import_path_id (for lookups)
@@ -1057,17 +1057,29 @@ func (p *PebbleStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, 
 	return nil, nil
 }
 
-// GetBooksBySeriesID is SLIM (memdb projection): returns rows with heavy
-// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
-// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
-// caller that needs any of those MUST fetch via GetBookByID /
-// GetAllBooksFullFrom (full Pebble). See
-// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (p *PebbleStore) GetBooksBySeriesID(seriesID int) ([]Book, error) {
+// GetBooksBySeriesIDCore is Core-typed (STOREFID W4): the return type is
+// BookCore, not Book, so the nine heavy fields (Description, VersionNotes,
+// BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series) being absent is compiler-enforced
+// rather than silently nil'd. Both the memdb-fast-path rows (already
+// stripped at the source) and the getBooksBySeriesIDFull scan fallback
+// (full Book, projected via .Core() here) are covered — mapping via .Core()
+// just makes that guarantee visible in the type system. A caller that needs
+// any of the heavy fields MUST fetch via GetBookByID / GetAllBooksFullFrom
+// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (p *PebbleStore) GetBooksBySeriesIDCore(seriesID int) ([]BookCore, error) {
 	if p.UseMemDB && p.mem() != nil {
-		return p.mem().GetBooksBySeriesID(seriesID, 0, 0)
+		return p.mem().GetBooksBySeriesIDCore(seriesID, 0, 0)
 	}
-	return p.getBooksBySeriesIDFull(seriesID)
+	books, err := p.getBooksBySeriesIDFull(seriesID)
+	if err != nil {
+		return nil, err
+	}
+	cores := make([]BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+	return cores, nil
 }
 
 // getBooksBySeriesIDFull performs a full Pebble book scan filtered by series ID.

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_test.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package database
 
@@ -278,8 +278,8 @@ func TestPebbleGetAllBooks(t *testing.T) {
 	}
 }
 
-// TestPebbleGetBooksBySeriesID tests filtering books by series
-func TestPebbleGetBooksBySeriesID(t *testing.T) {
+// TestPebbleGetBooksBySeriesIDCore tests filtering books by series
+func TestPebbleGetBooksBySeriesIDCore(t *testing.T) {
 	// Arrange
 	store, cleanup := setupPebbleTestDB(t)
 	defer cleanup()
@@ -312,7 +312,7 @@ func TestPebbleGetBooksBySeriesID(t *testing.T) {
 	}
 
 	// Act - Get books by series
-	seriesBooks, err := store.GetBooksBySeriesID(series.ID)
+	seriesBooks, err := store.GetBooksBySeriesIDCore(series.ID)
 	if err != nil {
 		t.Fatalf("Failed to get books by series: %v", err)
 	}

--- a/internal/database/store_extra_test.go
+++ b/internal/database/store_extra_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_extra_test.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 68b2b2f9-2b8f-4f7f-9d8f-26e6306a3c8e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // NOTE(fable5 T022): SQLiteStore type assertions replaced with PebbleStore;
 // TestSQLiteExtendedFeatures renamed to TestPebbleExtendedFeatures.
@@ -341,8 +341,8 @@ func exerciseStoreCommon(t *testing.T, store Store) {
 	if count, err := store.CountPrimaryBooks(); err != nil || count < 1 {
 		t.Fatalf("CountPrimaryBooks failed: %v", err)
 	}
-	if _, err := store.GetBooksBySeriesID(series.ID); err != nil {
-		t.Fatalf("GetBooksBySeriesID failed: %v", err)
+	if _, err := store.GetBooksBySeriesIDCore(series.ID); err != nil {
+		t.Fatalf("GetBooksBySeriesIDCore failed: %v", err)
 	}
 	if _, err := store.GetBooksByAuthorIDCore(author.ID); err != nil {
 		t.Fatalf("GetBooksByAuthorIDCore failed: %v", err)

--- a/internal/dedup/series_dedup.go
+++ b/internal/dedup/series_dedup.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/series_dedup.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
+// last-edited: 2026-07-07
 
 // Package dedup: series_dedup.go contains the extracted execution logic for the
 // "dedup.series-scan", "dedup.series-dedup", and "dedup.series-merge" async
@@ -101,7 +102,7 @@ func enrichSeries(store database.Store, seriesList []database.Series, authorName
 			authorName = authorNameMap[*s.AuthorID]
 		}
 		sw := SeriesWithBooks{Series: s, AuthorName: authorName}
-		if books, err := store.GetBooksBySeriesID(s.ID); err == nil {
+		if books, err := store.GetBooksBySeriesIDCore(s.ID); err == nil {
 			limit := 5
 			if len(books) < limit {
 				limit = len(books)
@@ -333,17 +334,33 @@ func DedupSeries(
 			if i == keepIdx {
 				continue
 			}
-			books, err := store.GetBooksBySeriesID(s.ID)
+			// Hydrate the full row via GetBookByID and mutate/write THAT. The
+			// tempting shortcut — bookCore.ToBook() then UpdateBook — would drop
+			// the denormalized Author/Series (db:"-"): they are NOT covered by
+			// UpdateBook's STOR-1 preserve-on-empty guard (which only restores
+			// Description/VersionNotes/BookSig*). Hydrating keeps the write
+			// correct and self-contained.
+			// See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+			books, err := store.GetBooksBySeriesIDCore(s.ID)
 			if err != nil {
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("failed to get books for series %d: %v", s.ID, err))
 				continue
 			}
-			for _, book := range books {
-				book.SeriesID = &keepID
-				if _, err := store.UpdateBook(book.ID, &book); err != nil {
+			for _, bookCore := range books {
+				full, herr := store.GetBookByID(bookCore.ID)
+				if herr != nil {
 					result.Errors = append(result.Errors,
-						fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
+						fmt.Sprintf("failed to hydrate book %s: %v", bookCore.ID, herr))
+					continue
+				}
+				if full == nil {
+					continue
+				}
+				full.SeriesID = &keepID
+				if _, err := store.UpdateBook(full.ID, full); err != nil {
+					result.Errors = append(result.Errors,
+						fmt.Sprintf("failed to reassign book %s: %v", bookCore.ID, err))
 				}
 			}
 			if err := store.DeleteSeries(s.ID); err != nil {
@@ -465,27 +482,43 @@ func MergeSeries(
 		if mergeID == keepID {
 			continue
 		}
-		books, err := store.GetBooksBySeriesID(mergeID)
+		// Hydrate the full row via GetBookByID and mutate/write THAT. The
+		// tempting shortcut — bookCore.ToBook() then UpdateBook — would drop
+		// the denormalized Author/Series (db:"-"): they are NOT covered by
+		// UpdateBook's STOR-1 preserve-on-empty guard (which only restores
+		// Description/VersionNotes/BookSig*). Hydrating keeps the write
+		// correct and self-contained.
+		// See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+		books, err := store.GetBooksBySeriesIDCore(mergeID)
 		if err != nil {
 			result.Errors = append(result.Errors,
 				fmt.Sprintf("failed to get books for series %d: %v", mergeID, err))
 			continue
 		}
 
-		for _, book := range books {
+		for _, bookCore := range books {
 			oldSeriesID := ""
-			if book.SeriesID != nil {
-				oldSeriesID = fmt.Sprintf("%d", *book.SeriesID)
+			if bookCore.SeriesID != nil {
+				oldSeriesID = fmt.Sprintf("%d", *bookCore.SeriesID)
 			}
-			book.SeriesID = &keepID
-			if _, err := store.UpdateBook(book.ID, &book); err != nil {
+			full, herr := store.GetBookByID(bookCore.ID)
+			if herr != nil {
 				result.Errors = append(result.Errors,
-					fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
+					fmt.Sprintf("failed to hydrate book %s: %v", bookCore.ID, herr))
+				continue
+			}
+			if full == nil {
+				continue
+			}
+			full.SeriesID = &keepID
+			if _, err := store.UpdateBook(full.ID, full); err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("failed to reassign book %s: %v", bookCore.ID, err))
 			} else {
 				_ = store.CreateOperationChange(&database.OperationChange{
 					ID:          ulid.Make().String(),
 					OperationID: opID,
-					BookID:      book.ID,
+					BookID:      bookCore.ID,
 					ChangeType:  "metadata_update",
 					FieldName:   "series_id",
 					OldValue:    oldSeriesID,
@@ -529,7 +562,7 @@ func MergeSeries(
 			_ = progress.Log("info",
 				fmt.Sprintf("Linking books to %d authors", len(allAuthorIDs)), nil)
 		}
-		allBooks, err := store.GetBooksBySeriesID(keepID)
+		allBooks, err := store.GetBooksBySeriesIDCore(keepID)
 		if err == nil {
 			for _, book := range allBooks {
 				existing, _ := store.GetBookAuthors(book.ID)

--- a/internal/dedup/series_dedup_test.go
+++ b/internal/dedup/series_dedup_test.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/series_dedup_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-fabc-456789012345
+// last-edited: 2026-07-07
 
 package dedup
 
@@ -125,15 +126,23 @@ func TestDedupSeries_MergesDuplicates(t *testing.T) {
 	var deletedIDs []int
 	var updatedBooks []database.Book
 
+	heavyDesc := "heavy description that must survive the series reassign"
+
 	mock := &database.MockStore{}
 	mock.GetAllSeriesFunc = func() ([]database.Series, error) {
 		return []database.Series{seriesA, seriesB}, nil
 	}
-	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
+	mock.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) {
 		if id == 2 {
-			return []database.Book{{ID: "BOOK1", SeriesID: &id}}, nil
+			return []database.BookCore{{ID: "BOOK1", SeriesID: &id}}, nil
 		}
 		return nil, nil
+	}
+	// DedupSeries hydrates the full row via GetBookByID before writing, so the
+	// heavy Description field is present at write time and must be preserved.
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		sid := 2
+		return &database.Book{ID: id, SeriesID: &sid, Description: strPtr(heavyDesc)}, nil
 	}
 	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
 		updatedBooks = append(updatedBooks, *book)
@@ -153,6 +162,9 @@ func TestDedupSeries_MergesDuplicates(t *testing.T) {
 	require.Len(t, updatedBooks, 1)
 	require.NotNil(t, updatedBooks[0].SeriesID)
 	assert.Equal(t, 1, *updatedBooks[0].SeriesID)
+	// Regression: the hydrate-mutate-update path must NOT wipe heavy fields.
+	require.NotNil(t, updatedBooks[0].Description)
+	assert.Equal(t, heavyDesc, *updatedBooks[0].Description)
 }
 
 func TestDedupSeries_NoDuplicates(t *testing.T) {
@@ -191,11 +203,18 @@ func TestMergeSeries_BasicMerge(t *testing.T) {
 		}
 		return nil, nil
 	}
-	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
+	mock.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) {
 		if id == mergeID {
-			return []database.Book{{ID: "BOOK_X", SeriesID: &id}}, nil
+			return []database.BookCore{{ID: "BOOK_X", SeriesID: &id}}, nil
 		}
 		return nil, nil
+	}
+	// MergeSeries hydrates the full row via GetBookByID before writing, so the
+	// heavy Description field is present at write time and must be preserved.
+	heavyDesc := "heavy description that must survive the merge"
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		sid := mergeID
+		return &database.Book{ID: id, SeriesID: &sid, Description: strPtr(heavyDesc)}, nil
 	}
 	mock.UpdateBookFunc = func(id string, book *database.Book) (*database.Book, error) {
 		updatedBooks = append(updatedBooks, *book)
@@ -213,6 +232,9 @@ func TestMergeSeries_BasicMerge(t *testing.T) {
 	assert.Contains(t, deletedIDs, mergeID)
 	require.Len(t, updatedBooks, 1)
 	assert.Equal(t, keepID, *updatedBooks[0].SeriesID)
+	// Regression: the hydrate-mutate-update path must NOT wipe heavy fields.
+	require.NotNil(t, updatedBooks[0].Description)
+	assert.Equal(t, heavyDesc, *updatedBooks[0].Description)
 }
 
 func TestMergeSeries_CustomRename(t *testing.T) {
@@ -228,7 +250,7 @@ func TestMergeSeries_CustomRename(t *testing.T) {
 		renamedTo = name
 		return nil
 	}
-	mock.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) { return nil, nil }
+	mock.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) { return nil, nil }
 	mock.DeleteSeriesFunc = func(id int) error { return nil }
 
 	result, err := MergeSeries(context.Background(), mock, "op2", keepID, []int{}, "New Name", nil)

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,6 +1,6 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.4
-// last-edited: 2026-07-05
+// version: 1.0.5
+// last-edited: 2026-07-06
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -89,7 +89,7 @@ func (m *mockRebuildStore) GetBooksByTitleInDir(normalizedTitle, dirPath string)
 	return nil, nil
 }
 
-func (m *mockRebuildStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+func (m *mockRebuildStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	return nil, nil
 }
 

--- a/internal/maintenance/jobs/cleanup_series.go
+++ b/internal/maintenance/jobs/cleanup_series.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/cleanup_series.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000002-0000-0000-0000-000000000002
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package jobs
 
@@ -64,7 +64,7 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 			continue
 		}
 
-		books, bErr := store.GetBooksBySeriesID(ser.ID)
+		books, bErr := store.GetBooksBySeriesIDCore(ser.ID)
 		if bErr != nil || len(books) == 0 {
 			reporter.Increment()
 			continue
@@ -132,7 +132,10 @@ func (j *cleanupSeriesJob) Run(ctx context.Context, store database.Store, report
 	return nil
 }
 
-func csUnlinkAndDeleteSeries(store database.Store, book *database.Book, seriesID int) error {
+// csUnlinkAndDeleteSeries only reads book.ID from the passed-in row (BookCore
+// is sufficient — see caller) and hydrates the real writeback target via
+// GetBookByID below, so no heavy-field fidelity is lost.
+func csUnlinkAndDeleteSeries(store database.Store, book *database.BookCore, seriesID int) error {
 	current, err := store.GetBookByID(book.ID)
 	if err != nil {
 		return fmt.Errorf("GetBookByID: %w", err)
@@ -153,9 +156,9 @@ func csUnlinkAndDeleteSeries(store database.Store, book *database.Book, seriesID
 
 func csMergeSeriesGroup(store database.Store, keepID int, mergeIDs []int) error {
 	for _, fromID := range mergeIDs {
-		books, err := store.GetBooksBySeriesID(fromID)
+		books, err := store.GetBooksBySeriesIDCore(fromID)
 		if err != nil {
-			return fmt.Errorf("GetBooksBySeriesID(%d): %w", fromID, err)
+			return fmt.Errorf("GetBooksBySeriesIDCore(%d): %w", fromID, err)
 		}
 		for _, book := range books {
 			current, err := store.GetBookByID(book.ID)

--- a/internal/server/duplicates_handlers_test.go
+++ b/internal/server/duplicates_handlers_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/duplicates_handlers_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9c1e2f3a-4b5d-6e7f-8a9b-0c1d2e3f4a5b
+// last-edited: 2026-07-06
 
 package server
 
@@ -22,8 +23,8 @@ func TestComputeSeriesNormalizeActions_Basic(t *testing.T) {
 			{ID: 3, Name: "Discworld", AuthorID: &authorID},
 		}, nil
 	}
-	store.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
-		return []database.Book{{ID: fmt.Sprintf("book-%d", id)}}, nil
+	store.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) {
+		return []database.BookCore{{ID: fmt.Sprintf("book-%d", id)}}, nil
 	}
 
 	actions := computeSeriesNormalizeActions(store)
@@ -76,8 +77,8 @@ func TestComputeSeriesNormalizeActions_FlaggedCase(t *testing.T) {
 			{ID: 10, Name: "Clean Series Name", AuthorID: &authorID},
 		}, nil
 	}
-	store.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
-		return []database.Book{{ID: "book-10"}}, nil
+	store.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) {
+		return []database.BookCore{{ID: "book-10"}}, nil
 	}
 
 	actions := computeSeriesNormalizeActions(store)
@@ -95,12 +96,12 @@ func TestExecuteSeriesNormalizeCore_RenamesAndEnqueues(t *testing.T) {
 			{ID: 2, Name: "The Long Earth Two", AuthorID: &authorID},
 		}, nil
 	}
-	store.GetBooksBySeriesIDFunc = func(id int) ([]database.Book, error) {
+	store.GetBooksBySeriesIDCoreFunc = func(id int) ([]database.BookCore, error) {
 		switch id {
 		case 1:
-			return []database.Book{{ID: "book-1"}}, nil
+			return []database.BookCore{{ID: "book-1"}}, nil
 		case 2:
-			return []database.Book{{ID: "book-2"}}, nil
+			return []database.BookCore{{ID: "book-2"}}, nil
 		}
 		return nil, nil
 	}

--- a/internal/server/duplicates_helpers.go
+++ b/internal/server/duplicates_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/duplicates_helpers.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: 550a807d-8c00-4e34-9a8c-52a80710a0b9
-// last-edited: 2026-06-03
+// last-edited: 2026-07-07
 //
 // Shared, non-HTTP helpers that were extracted from duplicates_handlers.go when
 // the 17 duplicates HTTP handlers moved to internal/server/handlers/duplicates.
@@ -144,7 +144,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 		canonicalIdx := 0
 		canonicalBookCount := 0
 		for i, s := range group {
-			books, err := store.GetBooksBySeriesID(s.ID)
+			books, err := store.GetBooksBySeriesIDCore(s.ID)
 			if err != nil {
 				continue
 			}
@@ -160,21 +160,36 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 			if i == canonicalIdx {
 				continue
 			}
-			books, err := store.GetBooksBySeriesID(ser.ID)
+			// Hydrate the full row via GetBookByID and mutate/write THAT. The
+			// tempting shortcut — bookCore.ToBook() then UpdateBook — would drop
+			// the denormalized Author/Series (db:"-"): they are NOT covered by
+			// UpdateBook's STOR-1 preserve-on-empty guard (which only restores
+			// Description/VersionNotes/BookSig*). Hydrating keeps the write
+			// correct and self-contained.
+			// See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+			books, err := store.GetBooksBySeriesIDCore(ser.ID)
 			if err != nil {
 				mergeErrors = append(mergeErrors, fmt.Sprintf("failed to get books for series %d: %v", ser.ID, err))
 				continue
 			}
-			for _, book := range books {
+			for _, bookCore := range books {
 				oldSeriesID := ser.ID
-				book.SeriesID = &keepID
-				if _, err := store.UpdateBook(book.ID, &book); err != nil {
-					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to reassign book %s: %v", book.ID, err))
+				full, herr := store.GetBookByID(bookCore.ID)
+				if herr != nil {
+					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to hydrate book %s: %v", bookCore.ID, herr))
+					continue
+				}
+				if full == nil {
+					continue
+				}
+				full.SeriesID = &keepID
+				if _, err := store.UpdateBook(full.ID, full); err != nil {
+					mergeErrors = append(mergeErrors, fmt.Sprintf("failed to reassign book %s: %v", bookCore.ID, err))
 				} else if operationID != "" {
 					_ = store.CreateOperationChange(&database.OperationChange{
 						ID:          ulid.Make().String(),
 						OperationID: operationID,
-						BookID:      book.ID,
+						BookID:      bookCore.ID,
 						ChangeType:  "series_merge",
 						FieldName:   "series_id",
 						OldValue:    fmt.Sprintf("%d (%s)", oldSeriesID, ser.Name),
@@ -215,7 +230,7 @@ func (s *Server) executeSeriesPrune(ctx context.Context, store interface {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			books, err := store.GetBooksBySeriesID(ser.ID)
+			books, err := store.GetBooksBySeriesIDCore(ser.ID)
 			if err != nil {
 				continue
 			}
@@ -310,7 +325,7 @@ func computeSeriesNormalizeActions(store interface {
 		cleaned, pos, flagged := metadata.StripSeriesContamination(s.Name, "")
 
 		if flagged {
-			books, _ := store.GetBooksBySeriesID(s.ID)
+			books, _ := store.GetBooksBySeriesIDCore(s.ID)
 			actions = append(actions, seriesNormalizeAction{
 				SeriesID:  s.ID,
 				OldName:   s.Name,
@@ -330,7 +345,7 @@ func computeSeriesNormalizeActions(store interface {
 			aid = *s.AuthorID
 		}
 		key := groupKey{name: strings.ToLower(cleaned), authorID: aid}
-		books, _ := store.GetBooksBySeriesID(s.ID)
+		books, _ := store.GetBooksBySeriesIDCore(s.ID)
 
 		if existingID, ok := canonical[key]; ok {
 			actions = append(actions, seriesNormalizeAction{
@@ -393,9 +408,9 @@ func buildSeriesNormalizePreview(store interface {
 // collision with the duplicates handler MergeSeriesGroup.
 func mergeSeriesGroupHelper(store maintenanceStore, keepID int, mergeIDs []int) error {
 	for _, fromID := range mergeIDs {
-		books, err := store.GetBooksBySeriesID(fromID)
+		books, err := store.GetBooksBySeriesIDCore(fromID)
 		if err != nil {
-			return fmt.Errorf("GetBooksBySeriesID(%d): %w", fromID, err)
+			return fmt.Errorf("GetBooksBySeriesIDCore(%d): %w", fromID, err)
 		}
 
 		for _, book := range books {
@@ -438,7 +453,7 @@ func executeSeriesNormalizeCore(
 		if a.Action == "flag" {
 			continue
 		}
-		books, bErr := store.GetBooksBySeriesID(a.SeriesID)
+		books, bErr := store.GetBooksBySeriesIDCore(a.SeriesID)
 		if bErr != nil {
 			continue
 		}

--- a/internal/server/handlers/entities/handler.go
+++ b/internal/server/handlers/entities/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b02a07d8-1806-4c86-bb72-f0688d6caff3
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // Package entities hosts the entity-domain HTTP handlers extracted from the
 // server package: works, authors, series, and narrators — CRUD plus merges,
@@ -820,10 +820,21 @@ func (h *Handler) GetSeriesBooks(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "invalid series ID")
 		return
 	}
-	books, err := h.store.GetBooksBySeriesID(seriesID)
+	booksCore, err := h.store.GetBooksBySeriesIDCore(seriesID)
 	if err != nil {
 		httputil.InternalError(c, "failed to get series books", err)
 		return
+	}
+	// h.enrichBooks (injected from package server, see wire_handlers.go) is
+	// shared with full-fidelity Book sources elsewhere, so its signature
+	// stays []database.Book — convert back via BookCore.ToBook() rather than
+	// widening that shared response-building code (out of scope for
+	// STOREFID W4, matching the GetAuthorBooks convention above). The heavy
+	// fields it would enrich with were already absent from this SLIM getter
+	// before this change; no behavior change.
+	books := make([]database.Book, len(booksCore))
+	for i := range booksCore {
+		books[i] = booksCore[i].ToBook()
 	}
 
 	enriched := h.enrichBooks(books)
@@ -918,7 +929,7 @@ func (h *Handler) DeleteEmptySeries(c *gin.Context) {
 		httputil.RespondWithBadRequest(c, "invalid series ID")
 		return
 	}
-	books, err := h.store.GetBooksBySeriesID(seriesID)
+	books, err := h.store.GetBooksBySeriesIDCore(seriesID)
 	if err != nil {
 		httputil.InternalError(c, "failed to get series books", err)
 		return
@@ -949,7 +960,7 @@ func (h *Handler) BulkDeleteSeries(c *gin.Context) {
 	skipped := 0
 	var errors []string
 	for _, id := range req.IDs {
-		books, err := h.store.GetBooksBySeriesID(id)
+		books, err := h.store.GetBooksBySeriesIDCore(id)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("series %d: %v", id, err))
 			continue

--- a/internal/server/handlers/entities/handler_test.go
+++ b/internal/server/handlers/entities/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 163bc668-0761-43eb-9d85-f4983e8b014b
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package entities_test
 
@@ -416,7 +416,7 @@ func TestListSeries_Cached(t *testing.T) {
 
 func TestGetSeriesBooks(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesID(5).Return([]database.Book{{ID: "b1"}}, nil)
+	d.store.EXPECT().GetBooksBySeriesIDCore(5).Return([]database.BookCore{{ID: "b1"}}, nil)
 	c, w := newCtx(http.MethodGet, "/series/5/books", "", idParam("5"))
 	h.GetSeriesBooks(c)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -459,7 +459,7 @@ func TestSplitSeries_EmptyBookIDs(t *testing.T) {
 
 func TestDeleteEmptySeries(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesID(5).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetBooksBySeriesIDCore(5).Return([]database.BookCore{}, nil)
 	d.store.EXPECT().DeleteSeries(5).Return(nil)
 	c, w := newCtx(http.MethodDelete, "/series/5", "", idParam("5"))
 	h.DeleteEmptySeries(c)
@@ -468,7 +468,7 @@ func TestDeleteEmptySeries(t *testing.T) {
 
 func TestDeleteEmptySeries_HasBooks(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesID(5).Return([]database.Book{{ID: "b"}}, nil)
+	d.store.EXPECT().GetBooksBySeriesIDCore(5).Return([]database.BookCore{{ID: "b"}}, nil)
 	c, w := newCtx(http.MethodDelete, "/series/5", "", idParam("5"))
 	h.DeleteEmptySeries(c)
 	assert.Equal(t, http.StatusConflict, w.Code)
@@ -476,7 +476,7 @@ func TestDeleteEmptySeries_HasBooks(t *testing.T) {
 
 func TestBulkDeleteSeries(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetBooksBySeriesID(1).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetBooksBySeriesIDCore(1).Return([]database.BookCore{}, nil)
 	d.store.EXPECT().DeleteSeries(1).Return(nil)
 	c, w := newCtx(http.MethodPost, "/series/bulk-delete", `{"ids":[1]}`, nil)
 	h.BulkDeleteSeries(c)

--- a/internal/server/handlers/entities/interfaces.go
+++ b/internal/server/handlers/entities/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/entities/interfaces.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 43710377-fdb3-490c-872e-fd03309163be
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // Narrow dependency interfaces for the entities domain handlers (authors,
 // series, narrators, works). Each interface lists only the methods the
@@ -57,7 +57,9 @@ type EntitiesStore interface {
 	CountSeries() (int, error)
 	CreateSeries(name string, authorID *int) (*database.Series, error)
 	GetSeriesByID(id int) (*database.Series, error)
-	GetBooksBySeriesID(seriesID int) ([]database.Book, error)
+	// GetBooksBySeriesIDCore is Core-typed (STOREFID W4) — see
+	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+	GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error)
 	UpdateSeriesName(id int, name string) error
 	DeleteSeries(id int) error
 

--- a/internal/server/handlers/entities/mocks/mock_entities_store.go
+++ b/internal/server/handlers/entities/mocks/mock_entities_store.go
@@ -1241,24 +1241,24 @@ func (_c *MockEntitiesStore_GetBooksByAuthorIDWithRoleCore_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockEntitiesStore
-func (_mock *MockEntitiesStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockEntitiesStore
+func (_mock *MockEntitiesStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1269,18 +1269,18 @@ func (_mock *MockEntitiesStore) GetBooksBySeriesID(seriesID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockEntitiesStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockEntitiesStore_GetBooksBySeriesID_Call struct {
+// MockEntitiesStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockEntitiesStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockEntitiesStore_Expecter) GetBooksBySeriesID(seriesID any) *MockEntitiesStore_GetBooksBySeriesID_Call {
-	return &MockEntitiesStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockEntitiesStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockEntitiesStore_GetBooksBySeriesIDCore_Call {
+	return &MockEntitiesStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockEntitiesStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockEntitiesStore_GetBooksBySeriesID_Call {
+func (_c *MockEntitiesStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockEntitiesStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1293,12 +1293,12 @@ func (_c *MockEntitiesStore_GetBooksBySeriesID_Call) Run(run func(seriesID int))
 	return _c
 }
 
-func (_c *MockEntitiesStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockEntitiesStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockEntitiesStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockEntitiesStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockEntitiesStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockEntitiesStore_GetBooksBySeriesID_Call {
+func (_c *MockEntitiesStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockEntitiesStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -1180,12 +1180,12 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 	var err error
 
 	if req.Filter.AuthorID != nil {
-		// store.GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2); the
-		// GetBooksBySeriesID/GetAllBooks branches below are not yet migrated
-		// and still return []database.Book, so `books` stays []database.Book
-		// here too — convert back via BookCore.ToBook(). Only book.ID,
-		// MarkedForDeletion, FilePath, and LibraryState (all Core-safe, no
-		// heavy fields) are read from `books`/`filtered` below.
+		// store.GetBooksByAuthorIDCore / GetBooksBySeriesIDCore are Core-typed
+		// (STOREFID P3-W2 / W4); the GetAllBooks branch below is not yet
+		// migrated and still returns []database.Book, so `books` stays
+		// []database.Book here too — convert back via BookCore.ToBook(). Only
+		// book.ID, MarkedForDeletion, FilePath, and LibraryState (all
+		// Core-safe, no heavy fields) are read from `books`/`filtered` below.
 		var booksCore []database.BookCore
 		booksCore, err = store.GetBooksByAuthorIDCore(*req.Filter.AuthorID)
 		if err == nil {
@@ -1195,7 +1195,14 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 			}
 		}
 	} else if req.Filter.SeriesID != nil {
-		books, err = store.GetBooksBySeriesID(*req.Filter.SeriesID)
+		var booksCore []database.BookCore
+		booksCore, err = store.GetBooksBySeriesIDCore(*req.Filter.SeriesID)
+		if err == nil {
+			books = make([]database.Book, len(booksCore))
+			for i := range booksCore {
+				books[i] = booksCore[i].ToBook()
+			}
+		}
 	} else {
 		// Get all books, then filter by library_state
 		books, err = store.GetAllBooks(1_000_000, 0)

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -69,12 +69,12 @@ type MetadataStore interface {
 	PruneBookSnapshots(id string, keepCount int) (int, error)
 
 	// Filtered book queries (handleBulkWriteBack).
-	// GetBooksByAuthorIDCore is Core-typed (STOREFID P3-W2) — already
-	// required via the embedded database.BookStore above; redeclared here
-	// (matching the GetBooksBySeriesID convention below) purely for the
-	// "what this handler touches" documentation grouping.
+	// GetBooksByAuthorIDCore / GetBooksBySeriesIDCore are Core-typed
+	// (STOREFID P3-W2 / W4) — already required via the embedded
+	// database.BookStore above; redeclared here purely for the "what this
+	// handler touches" documentation grouping.
 	GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error)
-	GetBooksBySeriesID(seriesID int) ([]database.Book, error)
+	GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error)
 
 	// Legacy supervisor op row (batchWriteBackAudiobooks).
 	CreateOperation(id, opType string, folderPath *string) (*database.Operation, error)

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -1690,24 +1690,24 @@ func (_c *MockMetadataStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run 
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1718,18 +1718,18 @@ func (_mock *MockMetadataStore) GetBooksBySeriesID(seriesID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockMetadataStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockMetadataStore_GetBooksBySeriesID_Call struct {
+// MockMetadataStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockMetadataStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockMetadataStore_Expecter) GetBooksBySeriesID(seriesID any) *MockMetadataStore_GetBooksBySeriesID_Call {
-	return &MockMetadataStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockMetadataStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockMetadataStore_GetBooksBySeriesIDCore_Call {
+	return &MockMetadataStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockMetadataStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockMetadataStore_GetBooksBySeriesID_Call {
+func (_c *MockMetadataStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockMetadataStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1742,12 +1742,12 @@ func (_c *MockMetadataStore_GetBooksBySeriesID_Call) Run(run func(seriesID int))
 	return _c
 }
 
-func (_c *MockMetadataStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockMetadataStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockMetadataStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockMetadataStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockMetadataStore_GetBooksBySeriesID_Call {
+func (_c *MockMetadataStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockMetadataStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -1339,24 +1339,24 @@ func (_c *MockPlaylistStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(run 
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -1367,18 +1367,18 @@ func (_mock *MockPlaylistStore) GetBooksBySeriesID(seriesID int) ([]database.Boo
 	return r0, r1
 }
 
-// MockPlaylistStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockPlaylistStore_GetBooksBySeriesID_Call struct {
+// MockPlaylistStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockPlaylistStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockPlaylistStore_Expecter) GetBooksBySeriesID(seriesID any) *MockPlaylistStore_GetBooksBySeriesID_Call {
-	return &MockPlaylistStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockPlaylistStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockPlaylistStore_GetBooksBySeriesIDCore_Call {
+	return &MockPlaylistStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockPlaylistStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockPlaylistStore_GetBooksBySeriesID_Call {
+func (_c *MockPlaylistStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockPlaylistStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -1391,12 +1391,12 @@ func (_c *MockPlaylistStore_GetBooksBySeriesID_Call) Run(run func(seriesID int))
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockPlaylistStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockPlaylistStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockPlaylistStore_GetBooksBySeriesID_Call {
+func (_c *MockPlaylistStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockPlaylistStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -3218,24 +3218,24 @@ func (_c *MockOperationsStore_GetBooksByMetadataSourceHash_Call) RunAndReturn(ru
 	return _c
 }
 
-// GetBooksBySeriesID provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) {
+// GetBooksBySeriesIDCore provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
 	ret := _mock.Called(seriesID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBooksBySeriesID")
+		panic("no return value specified for GetBooksBySeriesIDCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) ([]database.BookCore, error)); ok {
 		return returnFunc(seriesID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int) []database.BookCore); ok {
 		r0 = returnFunc(seriesID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
@@ -3246,18 +3246,18 @@ func (_mock *MockOperationsStore) GetBooksBySeriesID(seriesID int) ([]database.B
 	return r0, r1
 }
 
-// MockOperationsStore_GetBooksBySeriesID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesID'
-type MockOperationsStore_GetBooksBySeriesID_Call struct {
+// MockOperationsStore_GetBooksBySeriesIDCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksBySeriesIDCore'
+type MockOperationsStore_GetBooksBySeriesIDCore_Call struct {
 	*mock.Call
 }
 
-// GetBooksBySeriesID is a helper method to define mock.On call
+// GetBooksBySeriesIDCore is a helper method to define mock.On call
 //   - seriesID int
-func (_e *MockOperationsStore_Expecter) GetBooksBySeriesID(seriesID any) *MockOperationsStore_GetBooksBySeriesID_Call {
-	return &MockOperationsStore_GetBooksBySeriesID_Call{Call: _e.mock.On("GetBooksBySeriesID", seriesID)}
+func (_e *MockOperationsStore_Expecter) GetBooksBySeriesIDCore(seriesID any) *MockOperationsStore_GetBooksBySeriesIDCore_Call {
+	return &MockOperationsStore_GetBooksBySeriesIDCore_Call{Call: _e.mock.On("GetBooksBySeriesIDCore", seriesID)}
 }
 
-func (_c *MockOperationsStore_GetBooksBySeriesID_Call) Run(run func(seriesID int)) *MockOperationsStore_GetBooksBySeriesID_Call {
+func (_c *MockOperationsStore_GetBooksBySeriesIDCore_Call) Run(run func(seriesID int)) *MockOperationsStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -3270,12 +3270,12 @@ func (_c *MockOperationsStore_GetBooksBySeriesID_Call) Run(run func(seriesID int
 	return _c
 }
 
-func (_c *MockOperationsStore_GetBooksBySeriesID_Call) Return(books []database.Book, err error) *MockOperationsStore_GetBooksBySeriesID_Call {
-	_c.Call.Return(books, err)
+func (_c *MockOperationsStore_GetBooksBySeriesIDCore_Call) Return(bookCores []database.BookCore, err error) *MockOperationsStore_GetBooksBySeriesIDCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_GetBooksBySeriesID_Call) RunAndReturn(run func(seriesID int) ([]database.Book, error)) *MockOperationsStore_GetBooksBySeriesID_Call {
+func (_c *MockOperationsStore_GetBooksBySeriesIDCore_Call) RunAndReturn(run func(seriesID int) ([]database.BookCore, error)) *MockOperationsStore_GetBooksBySeriesIDCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
+// last-edited: 2026-07-06
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
 // Focuses on handlers that directly call s.Store() without
@@ -1271,7 +1272,7 @@ func TestHandler_UpdateSeriesName_InvalidID(t *testing.T) {
 func TestHandler_DeleteEmptySeries_Success(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksBySeriesID(10).Return([]database.Book{}, nil)
+	mockStore.EXPECT().GetBooksBySeriesIDCore(10).Return([]database.BookCore{}, nil)
 	mockStore.EXPECT().DeleteSeries(10).Return(nil)
 
 	router.DELETE("/series/:id", newEntitiesHandler(srv).DeleteEmptySeries)
@@ -1286,7 +1287,7 @@ func TestHandler_DeleteEmptySeries_Success(t *testing.T) {
 func TestHandler_DeleteEmptySeries_HasBooks(t *testing.T) {
 	srv, mockStore, router := setupHandlerTest(t)
 
-	mockStore.EXPECT().GetBooksBySeriesID(10).Return([]database.Book{{ID: "b1"}}, nil)
+	mockStore.EXPECT().GetBooksBySeriesIDCore(10).Return([]database.BookCore{{ID: "b1"}}, nil)
 
 	router.DELETE("/series/:id", newEntitiesHandler(srv).DeleteEmptySeries)
 

--- a/internal/server/server_bulk_delete_test.go
+++ b/internal/server/server_bulk_delete_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_bulk_delete_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package server
 
@@ -431,7 +431,7 @@ func TestBulkDeleteSeries_MixedResults(t *testing.T) {
 
 func TestBulkDeleteSeries_StoreError(t *testing.T) {
 	mock := &database.MockStore{
-		GetBooksBySeriesIDFunc: func(seriesID int) ([]database.Book, error) {
+		GetBooksBySeriesIDCoreFunc: func(seriesID int) ([]database.BookCore, error) {
 			if seriesID == 1 {
 				return nil, fmt.Errorf("db read error")
 			}
@@ -464,7 +464,7 @@ func TestBulkDeleteSeries_StoreError(t *testing.T) {
 
 func TestBulkDeleteSeries_DeleteError(t *testing.T) {
 	mock := &database.MockStore{
-		GetBooksBySeriesIDFunc: func(seriesID int) ([]database.Book, error) {
+		GetBooksBySeriesIDCoreFunc: func(seriesID int) ([]database.BookCore, error) {
 			return nil, nil
 		},
 		DeleteSeriesFunc: func(id int) error {

--- a/internal/server/server_title_helpers.go
+++ b/internal/server/server_title_helpers.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_title_helpers.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: b4b0048c-d778-43c9-871e-21f9a9b6705d
-// last-edited: 2026-05-01
+// last-edited: 2026-07-06
 
 package server
 
@@ -46,7 +46,7 @@ func computeSeriesPrunePreview(store database.Store) (*seriesPrunePreviewResult,
 		canonicalIdx := 0
 		canonicalBookCount := 0
 		for i, s := range group {
-			books, err := store.GetBooksBySeriesID(s.ID)
+			books, err := store.GetBooksBySeriesIDCore(s.ID)
 			if err != nil {
 				continue
 			}
@@ -64,10 +64,10 @@ func computeSeriesPrunePreview(store database.Store) (*seriesPrunePreviewResult,
 				continue
 			}
 			mergeIDs = append(mergeIDs, s.ID)
-			books, _ := store.GetBooksBySeriesID(s.ID)
+			books, _ := store.GetBooksBySeriesIDCore(s.ID)
 			totalBooks += len(books)
 		}
-		books, _ := store.GetBooksBySeriesID(group[canonicalIdx].ID)
+		books, _ := store.GetBooksBySeriesIDCore(group[canonicalIdx].ID)
 		totalBooks += len(books)
 
 		result.Groups = append(result.Groups, seriesPrunePreviewGroup{
@@ -82,7 +82,7 @@ func computeSeriesPrunePreview(store database.Store) (*seriesPrunePreviewResult,
 
 	// Find orphan series with 0 books
 	for _, s := range allSeries {
-		books, err := store.GetBooksBySeriesID(s.ID)
+		books, err := store.GetBooksBySeriesIDCore(s.ID)
 		if err != nil {
 			continue
 		}

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.0.5
+// version: 1.0.6
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
-// last-edited: 2026-07-05
+// last-edited: 2026-07-06
 
 package sweep
 
@@ -104,7 +104,9 @@ func (m *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]data
 func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]database.Book, error) {
 	return nil, nil
 }
-func (m *MockBookStore) GetBooksBySeriesID(seriesID int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetBooksBySeriesIDCore(seriesID int) ([]database.BookCore, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetBooksByAuthorIDCore(authorID int) ([]database.BookCore, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## STOREFID W4 — slim series getter retype

Renames `GetBooksBySeriesID()` → `GetBooksBySeriesIDCore()` returning `[]BookCore` so a caller reading a memdb-stripped heavy Book field is a **compile error**. Atomic across the `Store` interface, `PebbleStore`, `MemStore`, hand-written `MockStore`, and mockery-generated mock. Same shape as the merged W2 (`GetBooksByAuthorIDCore`).

### 3 writeback loops hardened (compile-surfaced)
The retype exposed three loops that set `SeriesID` on a memdb-slim book and wrote the whole struct back via `UpdateBook`: `duplicates_helpers.executeSeriesPrune`, `series_dedup.DedupSeries`, `series_dedup.MergeSeries`.

`UpdateBook`'s **STOR-1 preserve-on-empty guard** already restored the 7 persisted heavy fields (Description/VersionNotes/BookSig*); the denormalized `Author`/`Series` (`db:"-"`) were the residual gap. All three now **hydrate the full row via `GetBookByID`** and mutate only `SeriesID` — matching the existing `cleanup_series.go` pattern — removing the guard reliance. Regression assertions confirm `Description` survives a series reassign.

### Read-only callers
`metadata/handler`, `entities/handler` (mirror W2's read-path `.ToBook()` bridge), `service_query`, `server_title_helpers`, `cleanup_series` — retyped to `[]BookCore`.

### Verification
- `go build ./...` / `go vet ./...` — pass
- `go test -race` pass: `internal/database/...`, `internal/dedup/...`, `internal/maintenance/...`, `internal/audiobooks/...`

Follows W3 #1844. Part of the STOREFID initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)