### PR TITLE
refactor(store): add GetAllBooksCore, migrate 45 safe callers (STOREFID W5a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.113.0 -->
+<!-- version: 3.114.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,18 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): add GetAllBooksCore, migrate safe callers (STOREFID W5a)
+
+- **`refactor(store)`** — added `GetAllBooksCore(limit, offset) []BookCore` alongside the
+  existing `GetAllBooks` (interface + `PebbleStore` + `MemStore` + mocks). W5 is staged as an
+  ADD-then-migrate-then-remove sequence rather than an atomic rename, because `GetAllBooks` has
+  ~60 callers. This first step migrates the **45 mechanically-safe call sites** (39 files) that
+  read only Core-safe fields and do not write a page-sourced struct back. No behavior change:
+  purely additive interface + type-narrowing retypes, fully certified by `go build` (a migrated
+  caller reading a stripped heavy field, or writing its `BookCore` page-struct back, cannot
+  compile). Writeback and heavy-field-reader call sites remain on `GetAllBooks` and are migrated
+  in follow-up batches (W5b…) before `GetAllBooks` is removed (W5z).
 
 #### July 7, 2026 - refactor(store): GetBooksBySeriesID → GetBooksBySeriesIDCore ([]BookCore) (STOREFID W4)
 

--- a/cmd/diagnostics.go
+++ b/cmd/diagnostics.go
@@ -1,6 +1,7 @@
 // file: cmd/diagnostics.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c8f6a0d4-2a8b-48cf-9d08-02cc9915d9fc
+// last-edited: 2026-07-07
 
 package cmd
 
@@ -85,11 +86,11 @@ func runCleanupInvalidBooks(force, dryRun bool) error {
 
 	const batchSize = 5000
 	offset := 0
-	invalid := make([]database.Book, 0)
+	invalid := make([]database.BookCore, 0)
 	placeholders := []string{"{series}", "{narrator}", "{author}", "{title}"}
 
 	for {
-		books, err := store.GetAllBooks(batchSize, offset)
+		books, err := store.GetAllBooksCore(batchSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed to fetch books: %w", err)
 		}
@@ -166,7 +167,7 @@ func runDiagnosticsQuery(limit int, prefix string, raw bool) error {
 	}
 	defer closer()
 
-	books, err := store.GetAllBooks(limit, 0)
+	books, err := store.GetAllBooksCore(limit, 0)
 	if err != nil {
 		return fmt.Errorf("failed to fetch books: %w", err)
 	}

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,6 +1,7 @@
 // file: cmd/seed.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7d2e9a4f-1b85-4c63-9f0a-3e8d7b2c1f56
+// last-edited: 2026-07-07
 //
 // `seed` populates a fresh database with synthetic books for local
 // development. Use it after `make build` so a dev can hit `make run`
@@ -243,7 +244,7 @@ func upsertSeries(store database.SeriesStore, name string, authorID *int) (*data
 }
 
 func purgeSeedBooks(store database.BookStore) (int, error) {
-	books, err := store.GetAllBooks(100000, 0)
+	books, err := store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package audiobooks
 
@@ -362,7 +362,7 @@ func (svc *AudiobookService) CountAudiobooksFiltered(ctx context.Context, filter
 	// Unreachable in practice — buildBookSummaryFilter now returns pushdownOK=true
 	// for fingerprint filters (FingerprintStatus/CoveragePercent are denormalized
 	// on Book). Kept as a defensive fallback.
-	books, err := svc.store.GetAllBooks(0, 0)
+	books, err := svc.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,6 +1,6 @@
 // file: internal/batch/service_test.go
-// version: 1.0.7
-// last-edited: 2026-07-06
+// version: 1.0.8
+// last-edited: 2026-07-07
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -84,6 +84,9 @@ func (m *MockBookStore) DeleteBook(id string) error {
 
 // Stub implementations for other BookStore methods not used by BatchService
 func (m *MockBookStore) GetAllBooks(limit, offset int) ([]database.Book, error) { return nil, nil }
+func (m *MockBookStore) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
+	return nil, nil
+}
 func (m *MockBookStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	return nil, nil
 }

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -29,6 +29,15 @@ type BookReader interface {
 	// GetAllBooks is SLIM (memdb projection) — see
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetAllBooks(limit, offset int) ([]Book, error)
+	// GetAllBooksCore is Core-typed (STOREFID W5a): the return type is
+	// BookCore, not Book, so the nine heavy fields (Description,
+	// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,
+	// BookSigBuiltAt, BookSigCoveragePct, Author, Series) being absent is
+	// compiler-enforced rather than silently nil'd. This coexists with
+	// GetAllBooks during the W5 migration; a caller that needs any of the
+	// heavy fields MUST fetch via GetBookByID / GetAllBooksFullFrom (full
+	// Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+	GetAllBooksCore(limit, offset int) ([]BookCore, error)
 	// GetAllBooksFullFrom returns up to limit non-deleted books whose PebbleDB key
 	// sorts after "book:<afterID>". Pass afterID="" to start from the beginning.
 	// This is an O(1) seek vs GetAllBooks's O(offset) skip — use for search

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -561,6 +561,92 @@ func (m *MemStore) GetAllBooks(limit, offset int, filters map[string]interface{}
 		all = append(all, *b)
 	}
 	return paginate(all, limit, offset), nil
+}
+
+// GetAllBooksCore is Core-typed (STOREFID W5a): the return type is BookCore,
+// not Book — memdb rows never carry the nine heavy fields (Description,
+// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
+// BookSigCoveragePct, Author, Series) in the first place, so projecting via
+// .Core() here just makes that guarantee visible in the type system. Mirrors
+// GetAllBooks exactly (same filters, same no-default-sort behavior), just
+// Core-typed; coexists with it during the W5 migration. See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (m *MemStore) GetAllBooksCore(limit, offset int, filters map[string]interface{}) ([]BookCore, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	var (
+		iter interface {
+			Next() interface{}
+		}
+		err error
+	)
+
+	switch {
+	case filters["series_id"] != nil:
+		iter, err = txn.Get(memTableBooks, memIdxSeriesID, filters["series_id"])
+	case filters["author_id"] != nil:
+		iter, err = txn.Get(memTableBooks, memIdxAuthorID, filters["author_id"])
+	case filters["version_group_id"] != nil:
+		iter, err = txn.Get(memTableBooks, memIdxVersionGroupID, filters["version_group_id"])
+	case filters["is_primary_version"] != nil:
+		iter, err = txn.Get(memTableBooks, memIdxIsPrimaryVersion, filters["is_primary_version"])
+	default:
+		iter, err = txn.Get(memTableBooks, memIdxID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("memdb books scan: %w", err)
+	}
+
+	cap0 := limit
+	if cap0 <= 0 || cap0 > 100_000 {
+		cap0 = 1024
+	}
+	all := make([]Book, 0, cap0)
+
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		b := obj.(*Book)
+		if v, ok := filters["is_primary_version"].(bool); ok {
+			eff := true
+			if b.IsPrimaryVersion != nil {
+				eff = *b.IsPrimaryVersion
+			}
+			if eff != v {
+				continue
+			}
+		}
+		if v, ok := filters["marked_for_deletion"].(bool); ok {
+			eff := false
+			if b.MarkedForDeletion != nil {
+				eff = *b.MarkedForDeletion
+			}
+			if eff != v {
+				continue
+			}
+		}
+		if v, ok := filters["series_id"].(int); ok {
+			if b.SeriesID == nil || *b.SeriesID != v {
+				continue
+			}
+		}
+		if v, ok := filters["author_id"].(int); ok {
+			if b.AuthorID == nil || *b.AuthorID != v {
+				continue
+			}
+		}
+		if v, ok := filters["version_group_id"].(string); ok {
+			if b.VersionGroupID == nil || *b.VersionGroupID != v {
+				continue
+			}
+		}
+		all = append(all, *b)
+	}
+	paged := paginate(all, limit, offset)
+	cores := make([]BookCore, len(paged))
+	for i := range paged {
+		cores[i] = paged[i].Core()
+	}
+	return cores, nil
 }
 
 // ListBookIDs returns the IDs of all non-deleted books. Walks the memdb

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.73.0
+// version: 1.74.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -35,6 +35,7 @@ type MockStore struct {
 	GetBookByIDFunc                 func(id string) (*Book, error)
 	GetBookByFilePathFunc           func(path string) (*Book, error)
 	GetAllBooksFunc                 func(limit, offset int) ([]Book, error)
+	GetAllBooksCoreFunc             func(limit, offset int) ([]BookCore, error)
 	GetAllBooksFullFromFunc         func(afterID string, limit int) ([]Book, error)
 	ListBookIDsFunc                 func() ([]string, error)
 	GetAllBookSummariesFunc         func(limit, offset int) ([]BookSummary, error)
@@ -666,6 +667,13 @@ func (m *MockStore) GetBooksByWorkID(workID string) ([]Book, error) {
 func (m *MockStore) GetAllBooks(limit, offset int) ([]Book, error) {
 	if m.GetAllBooksFunc != nil {
 		return m.GetAllBooksFunc(limit, offset)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetAllBooksCore(limit, offset int) ([]BookCore, error) {
+	if m.GetAllBooksCoreFunc != nil {
+		return m.GetAllBooksCoreFunc(limit, offset)
 	}
 	return nil, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -2903,6 +2903,74 @@ func (_c *MockBookReader_GetAllBooks_Call) RunAndReturn(run func(limit int, offs
 	return _c
 }
 
+// GetAllBooksCore provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockBookReader_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockBookReader_Expecter) GetAllBooksCore(limit any, offset any) *MockBookReader_GetAllBooksCore_Call {
+	return &MockBookReader_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockBookReader_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockBookReader_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockBookReader_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockBookReader_GetAllBooksCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllBooksFullFrom provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)
@@ -6280,6 +6348,74 @@ func (_c *MockBookStore_GetAllBooks_Call) Return(books []database.Book, err erro
 }
 
 func (_c *MockBookStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockBookStore_GetAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllBooksCore provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockBookStore_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockBookStore_Expecter) GetAllBooksCore(limit any, offset any) *MockBookStore_GetAllBooksCore_Call {
+	return &MockBookStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockBookStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockBookStore_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockBookStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockBookStore_GetAllBooksCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -34195,6 +34331,74 @@ func (_c *MockStore_GetAllBooks_Call) Return(books []database.Book, err error) *
 }
 
 func (_c *MockStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockStore_GetAllBooks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllBooksCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockStore_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockStore_Expecter) GetAllBooksCore(limit any, offset any) *MockStore_GetAllBooksCore_Call {
+	return &MockStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockStore_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockStore_GetAllBooksCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.107.0
+// version: 1.108.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -479,6 +479,59 @@ func (p *PebbleStore) GetAllBooks(limit, offset int) ([]Book, error) {
 			break
 		}
 		books = append(books, book)
+		count++
+	}
+
+	return books, nil
+}
+
+// GetAllBooksCore is Core-typed (STOREFID W5a): the return type is BookCore,
+// not Book, so the nine heavy fields (Description, VersionNotes, BookSigV1,
+// BookSigV1Mask, BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author,
+// Series) being absent is compiler-enforced rather than silently nil'd. Mirrors
+// GetAllBooks exactly, just Core-typed; coexists with it during the W5
+// migration. A caller that needs any of the heavy fields MUST fetch via
+// GetBookByID / GetAllBooksFullFrom (full Pebble). See
+// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+func (p *PebbleStore) GetAllBooksCore(limit, offset int) ([]BookCore, error) {
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().GetAllBooksCore(limit, offset, nil)
+	}
+	var books []BookCore
+	iter, err := p.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("book:0"),
+		UpperBound: []byte("book:;"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	skipped := 0
+	count := 0
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		// Skip path index keys (book:series and book:author indexes removed in Task 3.4)
+		key := string(iter.Key())
+		if strings.Contains(key, ":path:") {
+			continue
+		}
+
+		var book Book
+		if err := json.Unmarshal(iter.Value(), &book); err != nil {
+			return nil, err
+		}
+		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		if limit > 0 && count >= limit {
+			break
+		}
+		books = append(books, book.Core())
 		count++
 	}
 

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -137,7 +137,7 @@ func (p *PebbleStore) CountSeries() (int, error) {
 // starts with rootDir (organized) vs. those that don't (import/unorganized).
 // When rootDir is empty, all books are counted as unorganized.
 func (p *PebbleStore) GetBookCountsByLocation(rootDir string) (library, import_ int, err error) {
-	books, err := p.GetAllBooks(0, 0)
+	books, err := p.GetAllBooksCore(0, 0)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -154,7 +154,7 @@ func (p *PebbleStore) GetBookCountsByLocation(rootDir string) (library, import_ 
 // GetBookSizesByLocation sums file sizes for books in the library root vs. outside.
 // When rootDir is empty, all sizes go to the import (unorganized) bucket.
 func (p *PebbleStore) GetBookSizesByLocation(rootDir string) (librarySize, importSize int64, err error) {
-	books, err := p.GetAllBooks(0, 0)
+	books, err := p.GetAllBooksCore(0, 0)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -468,7 +468,7 @@ func (p *PebbleStore) GetDuplicateFilesByHash(limit int) ([]DuplicateFileGroup, 
 	}
 
 	// Build book title map for annotating results.
-	books, _ := p.GetAllBooks(0, 0)
+	books, _ := p.GetAllBooksCore(0, 0)
 	bookTitles := make(map[string]string, len(books))
 	bookPaths := make(map[string]string, len(books))
 	for _, b := range books {
@@ -551,7 +551,7 @@ func (p *PebbleStore) GetBookFileHashStats() (*BookFileHashStats, error) {
 
 	// Gather per-library stats by grouping files under their parent book's source_import_path.
 	// Build a bookID → source_import_path map first.
-	allBooks, berr := p.GetAllBooks(0, 0)
+	allBooks, berr := p.GetAllBooksCore(0, 0)
 	if berr == nil {
 		bookPaths := make(map[string]string, len(allBooks))
 		stats.TotalBooks = len(allBooks)
@@ -597,7 +597,7 @@ func (p *PebbleStore) GetBookFileHashStats() (*BookFileHashStats, error) {
 
 // GetBookMetadataHashStats returns metadata_source_hash coverage across all books.
 func (p *PebbleStore) GetBookMetadataHashStats() (*BookMetadataHashStats, error) {
-	allBooks, err := p.GetAllBooks(0, 0)
+	allBooks, err := p.GetAllBooksCore(0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("GetBookMetadataHashStats: %w", err)
 	}

--- a/internal/dedup/collectors_exact.go
+++ b/internal/dedup/collectors_exact.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_exact.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: c9d0e1f2-a3b4-4c5d-8e6f-7a8b9c0d1e2f
-// last-edited: 2026-06-13
+// last-edited: 2026-07-07
 
 // Package dedup — exact-tier collector family (fable5 T014).
 //
@@ -48,7 +48,7 @@ type ExactFileHashStore interface {
 
 // ISBNASINStore is the subset of database.Store required by CollectISBNASIN.
 type ISBNASINStore interface {
-	GetAllBooks(limit, offset int) ([]database.Book, error)
+	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
 }
 
 // MetaSrcHashStore is the subset of database.Store required by
@@ -167,7 +167,7 @@ func CollectISBNASIN(
 	const batchSize = 500
 	offset := 0
 	for {
-		batch, err := store.GetAllBooks(batchSize, offset)
+		batch, err := store.GetAllBooksCore(batchSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("CollectISBNASIN get all books at offset %d: %w", offset, err)
 		}

--- a/internal/dedup/split_book_detector.go
+++ b/internal/dedup/split_book_detector.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/split_book_detector.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c1f0a3e-b7d2-4e84-8c12-3fa8e1d6b9c0
-// last-edited: 2026-05-29
+// last-edited: 2026-07-07
 
 // Package dedup — split-book backfill detector.
 //
@@ -111,9 +111,9 @@ func loadSlimBooks(ctx context.Context, store database.Store) ([]splitBookSlim, 
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		batch, err := store.GetAllBooks(pageSize, offset)
+		batch, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
-			return nil, fmt.Errorf("split-book detector: GetAllBooks offset=%d: %w", offset, err)
+			return nil, fmt.Errorf("split-book detector: GetAllBooksCore offset=%d: %w", offset, err)
 		}
 		if len(batch) == 0 {
 			break

--- a/internal/deluge/discovery.go
+++ b/internal/deluge/discovery.go
@@ -1,7 +1,7 @@
 // file: internal/deluge/discovery.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-11
+// last-edited: 2026-07-07
 //
 // Four-tier matching to decide if a labeled Deluge torrent is already in
 // the library — run in order, stop on first hit:
@@ -59,7 +59,7 @@ type LibraryIndex struct {
 
 // BookLister is the narrow interface needed to build a library index.
 type BookLister interface {
-	GetAllBooks(limit, offset int) ([]database.Book, error)
+	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
 }
 
 // BuildLibraryIndex builds a LibraryIndex from all books in the store.
@@ -68,7 +68,7 @@ func BuildLibraryIndex(store BookLister) LibraryIndex {
 		Paths:  make(map[string]struct{}),
 		Titles: make(map[string]struct{}),
 	}
-	books, err := store.GetAllBooks(100000, 0)
+	books, err := store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		slog.Warn("deluge discovery failed to load books", "err", err)
 		return idx

--- a/internal/importer/collision.go
+++ b/internal/importer/collision.go
@@ -1,7 +1,7 @@
 // file: internal/importer/collision.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: 5c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
-// last-edited: 2026-06-17
+// last-edited: 2026-07-07
 //
 // Import-time collision preview. Before importing a file, check whether
 // it collides with an existing book (by title match, file hash, or fingerprint)
@@ -90,7 +90,7 @@ func CheckImportCollisions(store database.Store, req *CollisionPreviewRequest) *
 	}
 	if err == nil && meta.Title != "" {
 		titleLower := strings.ToLower(strings.TrimSpace(meta.Title))
-		books, _ := store.GetAllBooks(0, 0)
+		books, _ := store.GetAllBooksCore(0, 0)
 		for _, b := range books {
 			if strings.ToLower(strings.TrimSpace(b.Title)) == titleLower {
 				alreadyListed := false

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,6 +1,6 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.5
-// last-edited: 2026-07-06
+// version: 1.0.6
+// last-edited: 2026-07-07
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -31,6 +31,18 @@ func (m *mockRebuildStore) GetAllBooks(pageSize, offset int) ([]database.Book, e
 		idx++
 	}
 	return result, nil
+}
+
+func (m *mockRebuildStore) GetAllBooksCore(pageSize, offset int) ([]database.BookCore, error) {
+	books, err := m.GetAllBooks(pageSize, offset)
+	if err != nil {
+		return nil, err
+	}
+	cores := make([]database.BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+	return cores, nil
 }
 
 func (m *mockRebuildStore) GetBookByID(id string) (*database.Book, error) {

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -765,7 +765,7 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 
 // DiscoverLibraryPath finds the library path from the most recently imported book.
 func (imp *Importer) DiscoverLibraryPath() string {
-	books, err := imp.store.GetAllBooks(100, 0)
+	books, err := imp.store.GetAllBooksCore(100, 0)
 	if err != nil {
 		return ""
 	}
@@ -807,7 +807,7 @@ func (imp *Importer) CollectITLUpdates() []itunes.ITLLocationUpdate {
 			defer wg.Done()
 			var local []itunes.ITLLocationUpdate
 			for offset := range pageCh {
-				books, err := imp.store.GetAllBooks(pageSize, offset)
+				books, err := imp.store.GetAllBooksCore(pageSize, offset)
 				if err != nil || len(books) == 0 {
 					break
 				}
@@ -853,7 +853,7 @@ func (imp *Importer) CollectITLUpdates() []itunes.ITLLocationUpdate {
 
 // CollectITLUpdatesWithBookIDs returns updates and the book IDs that contributed them.
 func (imp *Importer) CollectITLUpdatesWithBookIDs() ([]itunes.ITLLocationUpdate, []string) {
-	allBooks, err := imp.store.GetAllBooks(100000, 0)
+	allBooks, err := imp.store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return nil, nil
 	}
@@ -1093,7 +1093,7 @@ func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImpo
 		return
 	}
 
-	books, err := imp.store.GetAllBooks(10000, 0)
+	books, err := imp.store.GetAllBooksCore(10000, 0)
 	if err != nil {
 		log.Error("Failed to list books for enrichment: %v", err)
 		return
@@ -1103,7 +1103,7 @@ func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImpo
 	// original sequential loop applied inline per iteration. Keeps
 	// RunItems' Concurrency fan-out and progress denominator scoped to real
 	// work only (mirrors organizeImportedBooks' toOrganize pre-filter).
-	toEnrich := make([]*database.Book, 0, len(books))
+	toEnrich := make([]*database.BookCore, 0, len(books))
 	for i := range books {
 		book := &books[i]
 		if book.LibraryState == nil || *book.LibraryState != "imported" {
@@ -1128,7 +1128,7 @@ func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImpo
 
 	reporter := &loggerReporterAdapter{log: log}
 
-	runErr := registry.RunItems(enrichCtx, reporter, toEnrich, func(_ context.Context, book *database.Book) error {
+	runErr := registry.RunItems(enrichCtx, reporter, toEnrich, func(_ context.Context, book *database.BookCore) error {
 		resp, err := imp.mfs.FetchMetadataForBook(book.ID)
 		if err != nil {
 			log.Debug("No metadata found for '%s': %v", book.Title, err)

--- a/internal/itunes/service/importer_enrich_parallel_test.go
+++ b/internal/itunes/service/importer_enrich_parallel_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer_enrich_parallel_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8d3a5b1e-6f2c-4a97-9e1d-3c7b8f4a2d6e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -96,8 +96,13 @@ func buildEnrichFixture(t *testing.T, n int) ([]database.Book, *dbmocks.MockStor
 		}
 	}
 
+	cores := make([]database.BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(10000, 0).Return(books, nil)
+	m.EXPECT().GetAllBooksCore(10000, 0).Return(cores, nil)
 	for i := range books {
 		id := books[i].ID
 		m.EXPECT().GetBookAuthors(id).Return(nil, nil).Maybe()
@@ -164,7 +169,7 @@ func TestEnrichImportedBooks_ParallelMatchesSerial(t *testing.T) {
 // imported books) — RunItems must be a no-op and must not panic.
 func TestEnrichImportedBooks_EmptyList(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(10000, 0).Return(nil, nil)
+	m.EXPECT().GetAllBooksCore(10000, 0).Return(nil, nil)
 
 	fetcher := newFakeMetadataFetcher(nil)
 	imp := &Importer{store: m, mfs: fetcher, enrichConcurrencyOverride: 4}

--- a/internal/itunes/service/importer_execute_test.go
+++ b/internal/itunes/service/importer_execute_test.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/importer_execute_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -242,7 +243,7 @@ func TestCollectITLUpdates_Empty(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
 	// CollectITLUpdates paginates via 4 workers; each worker gets offset 0
 	// and breaks on empty result.
-	m.EXPECT().GetAllBooks(10000, mock.Anything).Return(nil, nil).Maybe()
+	m.EXPECT().GetAllBooksCore(10000, mock.Anything).Return(nil, nil).Maybe()
 
 	imp := newImporter(Deps{Store: m, Config: Config{}})
 	updates := imp.CollectITLUpdates()

--- a/internal/itunes/service/importer_mock_test.go
+++ b/internal/itunes/service/importer_mock_test.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/importer_mock_test.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: e7f1a2b3-4c5d-6e7f-8a9b-0c1d2e3f4a5b
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -104,7 +105,7 @@ func TestGetStatusBulk_Mixed(t *testing.T) {
 
 func TestCollectITLUpdatesWithBookIDs_Empty(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{}, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{}, nil)
 
 	imp := newMockImporter(m)
 	updates, bookIDs := imp.CollectITLUpdatesWithBookIDs()
@@ -127,7 +128,7 @@ func TestCollectITLUpdatesWithBookIDs_SkipsNonPrimary(t *testing.T) {
 	}
 
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{book}, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{book.Core()}, nil)
 
 	imp := newMockImporter(m)
 	updates, bookIDs := imp.CollectITLUpdatesWithBookIDs()
@@ -152,7 +153,7 @@ func TestCollectITLUpdatesWithBookIDs_BookLevel(t *testing.T) {
 	}
 
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{book}, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{book.Core()}, nil)
 	m.EXPECT().GetBookFiles("book-2").Return(nil, nil)
 
 	imp := newMockImporter(m)
@@ -200,7 +201,7 @@ func TestCollectITLUpdatesWithBookIDs_FileLevel(t *testing.T) {
 	}
 
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{book}, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{book.Core()}, nil)
 	m.EXPECT().GetBookFiles("book-3").Return(files, nil)
 
 	imp := newMockImporter(m)
@@ -231,7 +232,7 @@ func TestDiscoverLibraryPath_FromConfig(t *testing.T) {
 	}
 
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100, 0).Return([]database.Book{book}, nil)
+	m.EXPECT().GetAllBooksCore(100, 0).Return([]database.BookCore{book.Core()}, nil)
 
 	imp := newMockImporter(m)
 	result := imp.DiscoverLibraryPath()
@@ -241,7 +242,7 @@ func TestDiscoverLibraryPath_FromConfig(t *testing.T) {
 
 func TestDiscoverLibraryPath_Empty(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100, 0).Return([]database.Book{}, nil)
+	m.EXPECT().GetAllBooksCore(100, 0).Return([]database.BookCore{}, nil)
 
 	imp := newMockImporter(m)
 	result := imp.DiscoverLibraryPath()

--- a/internal/itunes/service/path_reconcile.go
+++ b/internal/itunes/service/path_reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/path_reconcile.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: 9e3b7a1d-4c2f-4a60-b8d5-2f1e8c0d9a47
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 //
 // One-time (repeatable) backfill that walks every book with an
 // iTunes persistent ID, recomputes book_files.ITunesPath from the
@@ -71,7 +71,7 @@ func (r *PathReconciler) Reconcile(ctx context.Context, opID string, progress op
 	_ = progress.Log("info", "Starting iTunes path reconcile", nil)
 
 	// Load all books — 100k is the same cap other maintenance ops use.
-	books, err := r.store.GetAllBooks(100000, 0)
+	books, err := r.store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return fmt.Errorf("load books: %w", err)
 	}
@@ -88,7 +88,7 @@ func (r *PathReconciler) Reconcile(ctx context.Context, opID string, progress op
 
 	// Use RunItems to parallelize per-book processing.
 	// Concurrency defaults to runtime.NumCPU() for DB-read-bound work.
-	err = registry.RunItems(ctx, reporterAdapter, books, func(ctx context.Context, b database.Book) error {
+	err = registry.RunItems(ctx, reporterAdapter, books, func(ctx context.Context, b database.BookCore) error {
 		hasITunesBook := b.ITunesPersistentID != nil && *b.ITunesPersistentID != ""
 
 		bookFiles, _ := r.store.GetBookFiles(b.ID)

--- a/internal/itunes/service/path_reconcile_test.go
+++ b/internal/itunes/service/path_reconcile_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/path_reconcile_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -52,7 +52,7 @@ func TestPathReconcilerReconcile_NilStore(t *testing.T) {
 
 func TestPathReconcilerReconcile_EmptyLibrary(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{}, nil).Once()
+	m.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{}, nil).Once()
 	m.EXPECT().DeleteOperationState("op-2").Return(nil).Once()
 
 	r := newPathReconciler(m, nil)
@@ -69,7 +69,11 @@ func TestPathReconcilerReconcile_SkipsNonITunesBooks(t *testing.T) {
 	books := []database.Book{
 		{ID: "b1", Title: "No iTunes", FilePath: "/mnt/books/b1.m4b"},
 	}
-	m.EXPECT().GetAllBooks(100000, 0).Return(books, nil).Once()
+	cores := make([]database.BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(cores, nil).Once()
 	m.EXPECT().GetBookFiles("b1").Return([]database.BookFile{}, nil).Once()
 	m.EXPECT().DeleteOperationState("op-3").Return(nil).Once()
 
@@ -84,7 +88,7 @@ func TestPathReconcilerReconcile_SkipsNonITunesBooks(t *testing.T) {
 
 func TestPathReconcilerReconcile_LoadBooksError(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return(nil, assert.AnError).Once()
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(nil, assert.AnError).Once()
 
 	r := newPathReconciler(m, nil)
 	err := r.Reconcile(context.Background(), "op-4", noopProgress{})
@@ -131,7 +135,11 @@ func TestPathReconcilerReconcile_ParallelOutputMatchesSerial(t *testing.T) {
 
 	// Set up mock store to return test data and accept updates.
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return(books, nil).Once()
+	prCores := make([]database.BookCore, len(books))
+	for i := range books {
+		prCores[i] = books[i].Core()
+	}
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(prCores, nil).Once()
 
 	// Expect GetBookFiles calls for each book.
 	// With parallelization, the order is non-deterministic, so use RunFn for dynamic matching.

--- a/internal/itunes/service/position_sync.go
+++ b/internal/itunes/service/position_sync.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/position_sync.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 9f7a8b5c-0d6e-4a70-b8c5-3d7e0f1b9a99
+// last-edited: 2026-07-07
 //
 // Bidirectional sync between the app's per-user position/state
 // tracking (spec 3.6) and the iTunes Bookmark / Play Count fields
@@ -69,7 +70,7 @@ func (p *PositionSync) Sync() (pulled, pushed int) {
 // Iterates books with an iTunes Bookmark value and creates a position
 // row if none exists yet.
 func (p *PositionSync) pullBookmarks() int {
-	books, err := p.store.GetAllBooks(0, 0)
+	books, err := p.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		slog.Warn("itunes position sync list books", "err", err)
 		return 0

--- a/internal/maintenance/jobs/backfill_book_files.go
+++ b/internal/maintenance/jobs/backfill_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_book_files.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000005-0000-0000-0000-000000000005
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -32,7 +32,7 @@ func (j *backfillBookFilesJob) Description() string {
 }
 func (j *backfillBookFilesJob) CanResume() bool { return false }
 func (j *backfillBookFilesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/maintenance/jobs/bulk_fetch_metadata.go
+++ b/internal/maintenance/jobs/bulk_fetch_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_fetch_metadata.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: b3c9d7e8-0f1a-2b3c-4d5e-6f7a8b9c0d1e
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -57,9 +57,9 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 		}
 	}
 
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	ttlDays := config.AppConfig.MetadataFetchCacheTTLDays
@@ -98,7 +98,7 @@ func (j *bulkFetchMetadataJob) Run(ctx context.Context, store database.Store, re
 	}
 
 	type bookWork struct {
-		book       database.Book
+		book       database.BookCore
 		authorName string
 	}
 	var work []bookWork

--- a/internal/maintenance/jobs/fix_author_narrator_swap.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000003-0000-0000-0000-000000000003
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -38,7 +38,7 @@ func (j *fixAuthorNarratorSwapJob) Run(ctx context.Context, store database.Store
 	var found, applied int
 
 	for {
-		batch, err := store.GetAllBooks(batchSize, offset)
+		batch, err := store.GetAllBooksCore(batchSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed to list books: %w", err)
 		}

--- a/internal/maintenance/jobs/fix_author_narrator_swap_test.go
+++ b/internal/maintenance/jobs/fix_author_narrator_swap_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_author_narrator_swap_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a7b8c9d0-e1f2-3456-abcd-789012345678
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 package jobs_test
 
@@ -39,11 +39,15 @@ func TestFixAuthorNarratorSwapJob_DryRun_NoChanges(t *testing.T) {
 		{ID: "book-1", Title: "Normal Book", AuthorID: &authorID, Narrator: &narratorName},
 	}
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return books, nil
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			return &database.Author{ID: id, Name: "Real Author"}, nil
@@ -64,11 +68,15 @@ func TestFixAuthorNarratorSwapJob_DryRun_DetectsSwap(t *testing.T) {
 		{ID: "book-swap", Title: "Swapped Book", AuthorID: &authorID, Narrator: &swappedName},
 	}
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return books, nil
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			return &database.Author{ID: id, Name: "Stephen King"}, nil
@@ -101,11 +109,15 @@ func TestFixAuthorNarratorSwapJob_CancelRespected(t *testing.T) {
 	}
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return books, nil
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			return &database.Author{ID: id, Name: "Same Name"}, nil

--- a/internal/maintenance/jobs/fix_read_by_narrator.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000001-0000-0000-0000-000000000001
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -34,7 +34,7 @@ func (j *fixReadByNarratorJob) Description() string {
 func (j *fixReadByNarratorJob) CanResume() bool { return false }
 
 func (j *fixReadByNarratorJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)
 	}
@@ -102,7 +102,7 @@ type rbnrFixResult struct {
 	FilePath    string
 }
 
-func rbnrPattern1(book *database.Book, authorName string) *rbnrFixResult {
+func rbnrPattern1(book *database.BookCore, authorName string) *rbnrFixResult {
 	narrator := strings.TrimSpace(book.Title[len("read by "):])
 	if narrator == "" {
 		return nil
@@ -124,7 +124,7 @@ func rbnrPattern1(book *database.Book, authorName string) *rbnrFixResult {
 	}
 }
 
-func rbnrPattern2(book *database.Book, authorName string) *rbnrFixResult {
+func rbnrPattern2(book *database.BookCore, authorName string) *rbnrFixResult {
 	idx := rbnrCaseInsensitiveIndex(book.Title, " - read by ")
 	if idx < 0 {
 		return nil
@@ -154,7 +154,7 @@ func rbnrPattern2(book *database.Book, authorName string) *rbnrFixResult {
 	}
 }
 
-func rbnrPattern3(book *database.Book, authorName string) *rbnrFixResult {
+func rbnrPattern3(book *database.BookCore, authorName string) *rbnrFixResult {
 	narrator := strings.TrimSpace(book.Title[len("read by "):])
 	newTitle := rbnrTitleFromFilePath(book.FilePath)
 	if newTitle == "" {
@@ -189,7 +189,7 @@ func rbnrTitleFromFilePath(fp string) string {
 	return title
 }
 
-func rbnrApplyFix(store database.Store, book *database.Book, fix *rbnrFixResult) error {
+func rbnrApplyFix(store database.Store, book *database.BookCore, fix *rbnrFixResult) error {
 	current, err := store.GetBookByID(book.ID)
 	if err != nil {
 		return fmt.Errorf("GetBookByID: %w", err)

--- a/internal/maintenance/jobs/fix_read_by_narrator_test.go
+++ b/internal/maintenance/jobs/fix_read_by_narrator_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_read_by_narrator_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a3b4c5d6-e7f8-9012-abcd-345678901234
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 // Package jobs_test exercises the fix-read-by-narrator maintenance job.
 // Importing the jobs package (via the blank import below) triggers all
@@ -62,8 +62,8 @@ func TestFixReadByNarratorJob_DryRun(t *testing.T) {
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{book}, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{book.Core()}, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			if id == authorID {
@@ -103,8 +103,8 @@ func TestFixReadByNarratorJob_Apply(t *testing.T) {
 	updated := book
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{book}, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{book.Core()}, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			if id == authorID {
@@ -144,8 +144,8 @@ func TestFixReadByNarratorJob_NoMatchBooks(t *testing.T) {
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{book}, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{book.Core()}, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -176,8 +176,8 @@ func TestFixReadByNarratorJob_TitleDashReadBy(t *testing.T) {
 	var updatedTitle string
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{book}, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{book.Core()}, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			return nil, nil
@@ -223,8 +223,12 @@ func TestFixReadByNarratorJob_Cancellation(t *testing.T) {
 	cancel() // cancel immediately
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
 			return nil, nil

--- a/internal/maintenance/jobs/fix_version_groups.go
+++ b/internal/maintenance/jobs/fix_version_groups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_version_groups.go
-// version: 2.1.1
+// version: 2.2.0
 // guid: a1000004-0000-0000-0000-000000000004
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -36,14 +36,14 @@ func (j *fixVersionGroupsJob) Description() string { return "Fix and normalize v
 func (j *fixVersionGroupsJob) CanResume() bool     { return false }
 
 func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)
 	}
 	reporter.SetTotal(len(allBooks))
 
 	// Phase 1: title mismatch within version groups
-	groupMap := make(map[string][]database.Book)
+	groupMap := make(map[string][]database.BookCore)
 	for i := range allBooks {
 		b := &allBooks[i]
 		if b.VersionGroupID == nil || *b.VersionGroupID == "" {
@@ -70,7 +70,7 @@ func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, rep
 		}
 		majorityCore := vgFindMajorityCore(cores)
 
-		var outliers []database.Book
+		var outliers []database.BookCore
 		for _, bc := range cores {
 			if !vgCoreTitlesMatch(bc.core, majorityCore) {
 				outliers = append(outliers, bc.book)
@@ -134,7 +134,7 @@ func (j *fixVersionGroupsJob) Run(ctx context.Context, store database.Store, rep
 }
 
 type vgBookCore struct {
-	book database.Book
+	book database.BookCore
 	core string
 }
 
@@ -200,7 +200,7 @@ func vgLongWords(s string) map[string]bool {
 	return set
 }
 
-func vgUnlinkOutliers(store database.Store, outliers []database.Book) error {
+func vgUnlinkOutliers(store database.Store, outliers []database.BookCore) error {
 	for _, ob := range outliers {
 		current, err := store.GetBookByID(ob.ID)
 		if err != nil {
@@ -273,7 +273,7 @@ func vgBestMatchSubdir(parent, title string) string {
 	return bestPath
 }
 
-func vgFixAuthorDirPath(store database.Store, book *database.Book, subdir string) error {
+func vgFixAuthorDirPath(store database.Store, book *database.BookCore, subdir string) error {
 	current, err := store.GetBookByID(book.ID)
 	if err != nil {
 		return fmt.Errorf("GetBookByID: %w", err)

--- a/internal/maintenance/jobs/fix_version_groups_test.go
+++ b/internal/maintenance/jobs/fix_version_groups_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_version_groups_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d0e1f2a3-b4c5-6789-defa-012345678901
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 // Package jobs_test exercises the fix-version-groups maintenance job.
 // The blank import in fix_read_by_narrator_test.go already registers all
@@ -49,8 +49,8 @@ func TestFixVersionGroupsJob_DefaultParams(t *testing.T) {
 func TestFixVersionGroupsJob_DryRunNoGroups(t *testing.T) {
 	// No books → no-op, no error.
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{}, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{}, nil
 		},
 	}
 
@@ -75,8 +75,12 @@ func TestFixVersionGroupsJob_DryRunDoesNotUpdate(t *testing.T) {
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -115,8 +119,12 @@ func TestFixVersionGroupsJob_ApplyUnlinksOutlier(t *testing.T) {
 
 	var updatedIDs []string
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetBookByIDFunc: func(id string) (*database.Book, error) {
 			b := bookMap[id]
@@ -169,8 +177,12 @@ func TestFixVersionGroupsJob_Cancellation(t *testing.T) {
 	cancel() // pre-cancel
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 	}
 

--- a/internal/maintenance/jobs/repair_missing_files.go
+++ b/internal/maintenance/jobs/repair_missing_files.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/repair_missing_files.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f1a7b5e6-8c9d-0e1f-2a3b-4c5d6e7f8a90
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -49,9 +49,9 @@ func (j *repairMissingFilesJob) Run(ctx context.Context, store database.Store, r
 	if err != nil {
 		return fmt.Errorf("GetAllBookFilesCore: %w", err)
 	}
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 	allAuthors, err := store.GetAllAuthors()
 	if err != nil {

--- a/internal/maintenance/jobs/scan_composer_tags.go
+++ b/internal/maintenance/jobs/scan_composer_tags.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_composer_tags.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d9e5f3c4-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -56,9 +56,9 @@ func (j *scanComposerTagsJob) Run(ctx context.Context, store database.Store, rep
 		}
 	}
 
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 	allAuthors, err := store.GetAllAuthors()
 	if err != nil {

--- a/internal/maintenance/jobs/scan_duration_mismatch.go
+++ b/internal/maintenance/jobs/scan_duration_mismatch.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_duration_mismatch.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000018-0000-0000-0000-000000000018
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -31,7 +31,7 @@ func (j *scanDurationMismatchJob) Description() string {
 }
 func (j *scanDurationMismatchJob) CanResume() bool { return false }
 func (j *scanDurationMismatchJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/maintenance/jobs/scan_metadata_hash_dups.go
+++ b/internal/maintenance/jobs/scan_metadata_hash_dups.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/scan_metadata_hash_dups.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000017-0000-0000-0000-000000000017
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -31,7 +31,7 @@ func (j *scanMetadataHashDupsJob) Description() string {
 }
 func (j *scanMetadataHashDupsJob) CanResume() bool { return false }
 func (j *scanMetadataHashDupsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, _ bool) error {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err
 	}

--- a/internal/metafetch/isbn.go
+++ b/internal/metafetch/isbn.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/isbn.go
-// version: 1.4.2
+// version: 1.5.0
 // guid: 34290bd0-745e-4509-ad2d-e237785bb7ef
-// last-edited: 2026-07-01
+// last-edited: 2026-07-07
 
 package metafetch
 
@@ -113,7 +113,7 @@ func (s *ISBNService) EnrichMissingISBNs(ctx context.Context, limit int, w *acti
 			return checked, updated, ctx.Err()
 		}
 
-		books, err := s.db.GetAllBooks(pageSize, offset)
+		books, err := s.db.GetAllBooksCore(pageSize, offset)
 		if err != nil {
 			return checked, updated, err
 		}
@@ -163,7 +163,7 @@ func (s *ISBNService) resolveAuthor(book *database.Book) string {
 	return a.Name
 }
 
-func needsIdentifierEnrichment(book *database.Book) bool {
+func needsIdentifierEnrichment(book *database.BookCore) bool {
 	if book == nil {
 		return false
 	}

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -169,16 +169,16 @@ func TestNeedsIdentifierEnrichment(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		book   *database.Book
+		book   *database.BookCore
 		expect bool
 	}{
 		{"nil_book", nil, false},
-		{"no_isbn_fields", &database.Book{}, true},
-		{"has_isbn10", &database.Book{ISBN10: &isbn10}, false},
-		{"has_isbn13", &database.Book{ISBN13: &isbn13}, false},
-		{"empty_isbn10", &database.Book{ISBN10: &empty}, true},
-		{"whitespace_isbn10", &database.Book{ISBN10: &whitespace}, true},
-		{"has_both", &database.Book{ISBN10: &isbn10, ISBN13: &isbn13}, false},
+		{"no_isbn_fields", &database.BookCore{}, true},
+		{"has_isbn10", &database.BookCore{ISBN10: &isbn10}, false},
+		{"has_isbn13", &database.BookCore{ISBN13: &isbn13}, false},
+		{"empty_isbn10", &database.BookCore{ISBN10: &empty}, true},
+		{"whitespace_isbn10", &database.BookCore{ISBN10: &whitespace}, true},
+		{"has_both", &database.BookCore{ISBN10: &isbn10, ISBN13: &isbn13}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/plugins/dedup/build_isbn_index.go
+++ b/internal/plugins/dedup/build_isbn_index.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/build_isbn_index.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
-// last-edited: 2026-06-14
+// last-edited: 2026-07-07
 
 // Package dedup — op dedup.build-isbn-index.
 //
@@ -125,7 +125,7 @@ func (p *Plugin) runBuildISBNIndex(ctx context.Context, rawParams json.RawMessag
 		default:
 		}
 
-		batch, err := p.store.GetAllBooks(batchSize, offset)
+		batch, err := p.store.GetAllBooksCore(batchSize, offset)
 		if err != nil {
 			return fmt.Errorf("get all books at offset %d: %w", offset, err)
 		}

--- a/internal/plugins/dedup/embed_scan.go
+++ b/internal/plugins/dedup/embed_scan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/embed_scan.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: e2f3a4b5-c6d7-8901-bcde-f12345678901
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 // T018: embed_scan.go is the canonical implementation for both
 // dedup.embed-scan (sync) and dedup.embed-async (async/batch API).
@@ -119,7 +119,7 @@ func (p *Plugin) runEmbedScanMode(ctx context.Context, async bool, reporter sdk.
 	loadProg := sdk.NewProgress(reporter, 0)
 	loadProg.Start("Loading books for embedding...")
 
-	books, err := p.store.GetAllBooks(0, 0)
+	books, err := p.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("load books: %w", err)
 	}
@@ -137,7 +137,7 @@ func (p *Plugin) runEmbedScanMode(ctx context.Context, async bool, reporter sdk.
 	// so they must be atomic rather than plain ints.
 	var embedded, cached, skipped, errs atomic.Int64
 
-	runErr := registry.RunItems(ctx, reporter, books, func(ctx context.Context, book database.Book) error {
+	runErr := registry.RunItems(ctx, reporter, books, func(ctx context.Context, book database.BookCore) error {
 		status, embedErr := p.engine.EmbedBook(ctx, book.ID)
 		if embedErr != nil {
 			reporter.Logger().Error("embed error", "book_id", book.ID, "error", embedErr)

--- a/internal/plugins/dedup/embed_scan_test.go
+++ b/internal/plugins/dedup/embed_scan_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/embed_scan_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6a1d9c3e-4b7f-4a2d-9e6c-8f1b2c3d4e5f
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 // Tests for CONC-5: parallelizing the dedup.embed-scan synchronous per-book
 // EmbedBook loop with registry.RunItems.
@@ -61,8 +61,12 @@ func newEmbedScanFixture(t *testing.T, n int) (*Plugin, *database.MockStore, *da
 	}
 
 	mock := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetBookByIDFunc: func(id string) (*database.Book, error) {
 			return byID[id], nil

--- a/internal/plugins/dedup/quarantine_chapter_artifacts.go
+++ b/internal/plugins/dedup/quarantine_chapter_artifacts.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/quarantine_chapter_artifacts.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1d7a4f92-3c60-4e85-9b21-6a5e8c0d3f47
-// last-edited: 2026-06-19
+// last-edited: 2026-07-07
 
 // Package dedup — op dedup.quarantine-chapter-artifacts.
 //
@@ -89,7 +89,7 @@ func (p *Plugin) runQuarantineChapterArtifacts(ctx context.Context, rawParams js
 		"apply", params.Apply, "min_collisions", params.MinTitleCollisions, "max_duration_sec", params.MaxDurationSec)
 
 	_ = reporter.UpdateProgress(0, 3, "Loading library…")
-	books, err := p.store.GetAllBooks(0, 0)
+	books, err := p.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("get all books: %w", err)
 	}

--- a/internal/plugins/dedup/reembed_embeddings.go
+++ b/internal/plugins/dedup/reembed_embeddings.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/reembed_embeddings.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9d8c7b6a-5e4f-3a2b-1c0d-9e8f7a6b5c4d
-// last-edited: 2026-06-16
+// last-edited: 2026-07-07
 
 // Package dedup — op dedup.reembed-embeddings.
 //
@@ -171,7 +171,7 @@ func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMes
 		default:
 		}
 
-		batch, err := p.store.GetAllBooks(scanBatch, offset)
+		batch, err := p.store.GetAllBooksCore(scanBatch, offset)
 		if err != nil {
 			return fmt.Errorf("get all books at offset %d: %w", offset, err)
 		}
@@ -304,7 +304,7 @@ func (p *Plugin) runReembedEmbeddings(ctx context.Context, rawParams json.RawMes
 // instead of re-selecting un-embeddable books on every run. Books that already
 // carry a stale-model vector are handled separately (they must be deleted
 // regardless of embeddability) and do not go through this check.
-func embeddableForReembed(b *database.Book) bool {
+func embeddableForReembed(b *database.BookCore) bool {
 	if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
 		return false
 	}

--- a/internal/plugins/dedup/reembed_embeddings_test.go
+++ b/internal/plugins/dedup/reembed_embeddings_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/reembed_embeddings_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a2b1c0d-9e8f-7a6b-5c4d-3e2f1a0b9c8d
-// last-edited: 2026-06-14
+// last-edited: 2026-07-07
 
 // Unit tests for the reembed-embeddings op's scan-partition helper.
 
@@ -19,16 +19,16 @@ func TestEmbeddableForReembed(t *testing.T) {
 
 	cases := []struct {
 		name string
-		book database.Book
+		book database.BookCore
 		want bool
 	}{
-		{"primary nil + good title", database.Book{Title: "A Real Book"}, true},
-		{"primary true + good title", database.Book{Title: "Another Book", IsPrimaryVersion: &primaryTrue}, true},
-		{"non-primary excluded", database.Book{Title: "A Real Book", IsPrimaryVersion: &primaryFalse}, false},
-		{"empty title excluded", database.Book{Title: ""}, false},
-		{"whitespace title excluded", database.Book{Title: "   "}, false},
-		{"2-rune title excluded (matches hasUsableTitle >2)", database.Book{Title: "ab"}, false},
-		{"3-rune title included", database.Book{Title: "abc"}, true},
+		{"primary nil + good title", database.BookCore{Title: "A Real Book"}, true},
+		{"primary true + good title", database.BookCore{Title: "Another Book", IsPrimaryVersion: &primaryTrue}, true},
+		{"non-primary excluded", database.BookCore{Title: "A Real Book", IsPrimaryVersion: &primaryFalse}, false},
+		{"empty title excluded", database.BookCore{Title: ""}, false},
+		{"whitespace title excluded", database.BookCore{Title: "   "}, false},
+		{"2-rune title excluded (matches hasUsableTitle >2)", database.BookCore{Title: "ab"}, false},
+		{"3-rune title included", database.BookCore{Title: "abc"}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/plugins/maintenance/duration_backfill.go
+++ b/internal/plugins/maintenance/duration_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_backfill.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 7e4b2a90-3c61-4d58-8f29-6a1c0e5b9d83
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -88,15 +88,15 @@ func (p *Plugin) runDurationBackfill(ctx context.Context, raw json.RawMessage, r
 	const pageSize = 500
 	offset := 0
 	// Gather all books first via pagination.
-	var allBooks []database.Book
+	var allBooks []database.BookCore
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
-			return fmt.Errorf("GetAllBooks offset=%d: %w", offset, err)
+			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
 		}
 		if len(books) == 0 {
 			break
@@ -119,7 +119,7 @@ func (p *Plugin) runDurationBackfill(ctx context.Context, raw json.RawMessage, r
 	// Each worker independently checks a book's files and accumulates fixes; the shared
 	// maps are guarded by mu so the parallel version produces identical output to serial.
 	scanned := 0
-	err := registry.RunItems(ctx, reporter, allBooks, func(ctx context.Context, book database.Book) error {
+	err := registry.RunItems(ctx, reporter, allBooks, func(ctx context.Context, book database.BookCore) error {
 		files, ferr := store.GetBookFiles(book.ID)
 		if ferr != nil {
 			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(

--- a/internal/plugins/maintenance/duration_backfill_test.go
+++ b/internal/plugins/maintenance/duration_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/duration_backfill_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2c9f5a1b-4d83-4e07-9f6a-1b8e3c0d7a52
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -148,7 +148,7 @@ func TestDurationBackfill_ParallelProducesCorrectResults(t *testing.T) {
 			CountPrimaryBooksFunc: func() (int, error) {
 				return len(books), nil
 			},
-			GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+			GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 				if offset >= len(books) {
 					return nil, nil
 				}
@@ -156,7 +156,12 @@ func TestDurationBackfill_ParallelProducesCorrectResults(t *testing.T) {
 				if end > len(books) {
 					end = len(books)
 				}
-				return books[offset:end], nil
+				page := books[offset:end]
+				cores := make([]database.BookCore, len(page))
+				for i := range page {
+					cores[i] = page[i].Core()
+				}
+				return cores, nil
 			},
 			GetBookFilesFunc: func(bookID string) ([]database.BookFile, error) {
 				return filesByID[bookID], nil

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -142,11 +142,11 @@ func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []d
 	if ctx.Err() != nil {
 		return nil, 0, 0, ctx.Err()
 	}
-	// GetAllBooks(0, 0) is the unbounded form across the existing maintenance
+	// GetAllBooksCore(0, 0) is the unbounded form across the existing maintenance
 	// plugin (see pebble_store.go:9210, 9256, 9318) — limit=0 means "all".
-	books, berr := store.GetAllBooks(0, 0)
+	books, berr := store.GetAllBooksCore(0, 0)
 	if berr != nil {
-		return nil, 0, 0, fmt.Errorf("GetAllBooks: %w", berr)
+		return nil, 0, 0, fmt.Errorf("GetAllBooksCore: %w", berr)
 	}
 	valid := make(map[string]struct{}, len(books))
 	for _, b := range books {

--- a/internal/plugins/maintenance/orphan_book_files_test.go
+++ b/internal/plugins/maintenance/orphan_book_files_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 0bd4f9a2-1c3e-4f5a-8b6c-7d9e0f1a2b3c
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -40,8 +40,12 @@ func TestFindOrphanBookFiles_ReportOnly(t *testing.T) {
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) {
 			return files, nil
 		},
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return books, nil
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		DeleteBookFileFunc: func(id string) error {
 			deleteCalls = append(deleteCalls, id)
@@ -93,7 +97,13 @@ func TestFindOrphanBookFiles_NoOrphans(t *testing.T) {
 	}
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
-		GetAllBooksFunc:         func(limit, offset int) ([]database.Book, error) { return books, nil },
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
+		},
 	}
 	orphans, _, _, err := findOrphanBookFiles(context.Background(), store)
 	if err != nil {

--- a/internal/quarantine/service.go
+++ b/internal/quarantine/service.go
@@ -1,7 +1,7 @@
 // file: internal/quarantine/service.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package quarantine
 
@@ -27,7 +27,7 @@ type Store interface {
 	UpdateBook(id string, book *database.Book) (*database.Book, error)
 	RecordPathChange(change *database.BookPathChange) error
 	GetBookPathHistory(bookID string) ([]database.BookPathChange, error)
-	GetAllBooks(limit, offset int) ([]database.Book, error)
+	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
 	GetScanFailCount(pathHash string) (int, error)
 	GetITunesPurgePendingBooks() ([]database.Book, error)
 }
@@ -229,7 +229,7 @@ func (qs *QuarantineService) AutoQuarantineFailedScans() {
 	const pageSize = 1000
 	var offset int
 	for {
-		page, err := qs.store.GetAllBooks(pageSize, offset)
+		page, err := qs.store.GetAllBooksCore(pageSize, offset)
 		if err != nil || len(page) == 0 {
 			break
 		}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package reconcile
 
@@ -199,7 +199,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 
 	// Step 1: Find broken DB records
 	report(0, 1, "Loading all books from database...")
-	books, err := store.GetAllBooks(100000, 0)
+	books, err := store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list books: %w", err)
 	}
@@ -207,7 +207,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 
 	// Build set of all known file paths for quick lookup
 	knownPaths := make(map[string]bool, len(books))
-	var brokenBooks []database.Book
+	var brokenBooks []database.BookCore
 
 	totalBooks := len(books)
 	if totalBooks == 0 {

--- a/internal/scheduler/extra_ops.go
+++ b/internal/scheduler/extra_ops.go
@@ -1,6 +1,7 @@
 // file: internal/scheduler/extra_ops.go
-// version: 1.0.3
+// version: 1.1.0
 // guid: a9b8c7d6-e5f4-3210-fedc-ba9876543210
+// last-edited: 2026-07-07
 
 // extra_ops registers OperationDefs for 13 scheduler tasks that previously
 // used the legacy triggerOperation / triggerOperationWithID helpers.  Each def
@@ -817,7 +818,7 @@ func (r *ExtraOpsRegistrar) runMetadataRefreshScan(ctx context.Context, progress
 		return fmt.Errorf("database not initialized")
 	}
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
-	books, err := store.GetAllBooks(10000, 0)
+	books, err := store.GetAllBooksCore(10000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)
 	}

--- a/internal/server/embedding_backfill.go
+++ b/internal/server/embedding_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/server/embedding_backfill.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package server
 
@@ -104,14 +104,14 @@ type embeddingBackfillStats struct {
 // Extracted from runEmbeddingBackfill so the concurrency behavior (parallel
 // output identical to serial output, order-independent) can be exercised in
 // a unit test with a fake embedFn instead of a live dedup.Engine.
-func embedBooksConcurrent(ctx context.Context, books []database.Book, concurrency int, embedFn func(ctx context.Context, bookID string) (dedup.EmbedStatus, error)) (embeddingBackfillStats, error) {
+func embedBooksConcurrent(ctx context.Context, books []database.BookCore, concurrency int, embedFn func(ctx context.Context, bookID string) (dedup.EmbedStatus, error)) (embeddingBackfillStats, error) {
 	var (
 		mu    sync.Mutex
 		stats embeddingBackfillStats
 	)
 	reporter := &embeddingBackfillReporter{ctx: ctx, logEvery: 500}
 
-	err := registry.RunItems(ctx, reporter, books, func(ctx context.Context, book database.Book) error {
+	err := registry.RunItems(ctx, reporter, books, func(ctx context.Context, book database.BookCore) error {
 		status, embedErr := embedFn(ctx, book.ID)
 
 		mu.Lock()
@@ -215,7 +215,7 @@ func (s *Server) runEmbeddingBackfill() {
 	// call rather than a nested per-page loop. Swallow the error exactly as
 	// the previous pagination loop did (it only used the error to stop
 	// fetching, never logged it).
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		books = nil
 	}

--- a/internal/server/embedding_backfill_test.go
+++ b/internal/server/embedding_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/embedding_backfill_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4f81c2ae-6b39-47d5-9ae1-3c5d8b12f7a4
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package server
 
@@ -149,9 +149,9 @@ func fakeEmbedBookStatus(id string) (dedup.EmbedStatus, error) {
 // counters mutex actually prevents a data race under concurrency>1.
 func TestEmbedBooksConcurrent_ParallelMatchesSerial(t *testing.T) {
 	const n = 500
-	books := make([]database.Book, n)
+	books := make([]database.BookCore, n)
 	for i := 0; i < n; i++ {
-		books[i] = database.Book{ID: strconv.Itoa(i)}
+		books[i] = database.BookCore{ID: strconv.Itoa(i)}
 	}
 
 	serial, err := embedBooksConcurrent(context.Background(), books, 1, func(_ context.Context, id string) (dedup.EmbedStatus, error) {
@@ -188,9 +188,9 @@ func TestEmbedBooksConcurrent_ParallelMatchesSerial(t *testing.T) {
 // interleavings to catch if the mutex were ever removed.
 func TestEmbedBooksConcurrent_ConcurrentCallsAreSerialized(t *testing.T) {
 	const n = 2000
-	books := make([]database.Book, n)
+	books := make([]database.BookCore, n)
 	for i := 0; i < n; i++ {
-		books[i] = database.Book{ID: strconv.Itoa(i)}
+		books[i] = database.BookCore{ID: strconv.Itoa(i)}
 	}
 
 	var calls sync.Map // set of visited IDs, to also confirm no double-processing

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -1175,37 +1175,22 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 	}
 	_ = c.ShouldBindJSON(&req)
 
-	// Gather matching books based on filters
-	var books []database.Book
+	// Gather matching books based on filters. store.GetBooksByAuthorIDCore /
+	// GetBooksBySeriesIDCore / GetAllBooksCore are all Core-typed (STOREFID
+	// P3-W2 / W4 / W5a), so `books` is uniformly []database.BookCore now — no
+	// ToBook() round-trip needed. Only book.ID, MarkedForDeletion, FilePath,
+	// and LibraryState (all Core-safe, no heavy fields) are read from
+	// `books`/`filtered` below.
+	var books []database.BookCore
 	var err error
 
 	if req.Filter.AuthorID != nil {
-		// store.GetBooksByAuthorIDCore / GetBooksBySeriesIDCore are Core-typed
-		// (STOREFID P3-W2 / W4); the GetAllBooks branch below is not yet
-		// migrated and still returns []database.Book, so `books` stays
-		// []database.Book here too — convert back via BookCore.ToBook(). Only
-		// book.ID, MarkedForDeletion, FilePath, and LibraryState (all
-		// Core-safe, no heavy fields) are read from `books`/`filtered` below.
-		var booksCore []database.BookCore
-		booksCore, err = store.GetBooksByAuthorIDCore(*req.Filter.AuthorID)
-		if err == nil {
-			books = make([]database.Book, len(booksCore))
-			for i := range booksCore {
-				books[i] = booksCore[i].ToBook()
-			}
-		}
+		books, err = store.GetBooksByAuthorIDCore(*req.Filter.AuthorID)
 	} else if req.Filter.SeriesID != nil {
-		var booksCore []database.BookCore
-		booksCore, err = store.GetBooksBySeriesIDCore(*req.Filter.SeriesID)
-		if err == nil {
-			books = make([]database.Book, len(booksCore))
-			for i := range booksCore {
-				books[i] = booksCore[i].ToBook()
-			}
-		}
+		books, err = store.GetBooksBySeriesIDCore(*req.Filter.SeriesID)
 	} else {
 		// Get all books, then filter by library_state
-		books, err = store.GetAllBooks(1_000_000, 0)
+		books, err = store.GetAllBooksCore(1_000_000, 0)
 	}
 	if err != nil {
 		httputil.InternalError(c, "failed to query books", err)
@@ -1218,7 +1203,7 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 		targetStates = map[string]bool{*req.Filter.LibraryState: true}
 	}
 
-	var filtered []database.Book
+	var filtered []database.BookCore
 	for _, book := range books {
 		// Skip soft-deleted books
 		if book.MarkedForDeletion != nil && *book.MarkedForDeletion {

--- a/internal/server/handlers/metadata/handler_test.go
+++ b/internal/server/handlers/metadata/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1d31ef73-7c7a-4c3b-a840-01b0865023d7
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 // Tests for the metadata-domain handlers. The store / metadata-fetch-service /
 // write-back-enqueuer / operations-registry / file-io-pool deps are generated
@@ -559,7 +559,7 @@ func TestBulkFetchMetadata_ParallelPreservesOrderAndCounts(t *testing.T) {
 
 func TestHandleBulkWriteBack_DryRun(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetAllBooks(1_000_000, 0).Return([]database.Book{
+	d.store.EXPECT().GetAllBooksCore(1_000_000, 0).Return([]database.BookCore{
 		{ID: "b1", FilePath: "/x/a.m4b", LibraryState: strptr("organized")},
 	}, nil)
 	w := doReq(h.HandleBulkWriteBack, http.MethodPost, "/audiobooks/bulk-write-back",
@@ -571,7 +571,7 @@ func TestHandleBulkWriteBack_DryRun(t *testing.T) {
 
 func TestHandleBulkWriteBack_Enqueue202(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetAllBooks(1_000_000, 0).Return([]database.Book{
+	d.store.EXPECT().GetAllBooksCore(1_000_000, 0).Return([]database.BookCore{
 		{ID: "b1", FilePath: "/x/a.m4b", LibraryState: strptr("organized")},
 	}, nil)
 	d.reg.EXPECT().EnqueueOp(mock.Anything, "library.bulk-write-back", mock.Anything).Return("op-123", nil)

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -792,6 +792,74 @@ func (_c *MockMetadataStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
+// GetAllBooksCore provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockMetadataStore_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockMetadataStore_Expecter) GetAllBooksCore(limit any, offset any) *MockMetadataStore_GetAllBooksCore_Call {
+	return &MockMetadataStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockMetadataStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockMetadataStore_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockMetadataStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockMetadataStore_GetAllBooksCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllBooksFullFrom provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -503,6 +503,74 @@ func (_c *MockPlaylistStore_GetAllBooks_Call) RunAndReturn(run func(limit int, o
 	return _c
 }
 
+// GetAllBooksCore provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlaylistStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockPlaylistStore_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockPlaylistStore_Expecter) GetAllBooksCore(limit any, offset any) *MockPlaylistStore_GetAllBooksCore_Call {
+	return &MockPlaylistStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockPlaylistStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockPlaylistStore_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockPlaylistStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockPlaylistStore_GetAllBooksCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllBooksFullFrom provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/operations/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 1b7fbd86-cdda-4921-b2d0-786f5cadb438
-// last-edited: 2026-06-22
+// last-edited: 2026-07-07
 
 // Package operations hosts the background-operation HTTP handlers extracted
 // from the server package: the long-running scan / organize / optimize /
@@ -306,7 +306,7 @@ func (h *Handler) OptimizeDatabase(c *gin.Context) {
 		return
 	}
 
-	books, err := h.store.GetAllBooks(10000, 0)
+	books, err := h.store.GetAllBooksCore(10000, 0)
 	if err != nil {
 		httputil.InternalError(c, "failed to get audiobooks", err)
 		return

--- a/internal/server/handlers/operations/handler_test.go
+++ b/internal/server/handlers/operations/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/operations/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 36cf7fbb-8b23-4edb-ad4b-079ab2bd6cf1
-// last-edited: 2026-06-03
+// last-edited: 2026-07-07
 
 // Unit tests for the operations-domain HTTP handlers. Each public method has at
 // least one test; happy paths plus key branches (cancel not-found fallback,
@@ -266,7 +266,7 @@ func TestDeleteOperationHistory_Deletes(t *testing.T) {
 
 func TestOptimizeDatabase_NoBooks(t *testing.T) {
 	h, store, _, _, _, _ := newTestHandler(t)
-	store.EXPECT().GetAllBooks(10000, 0).Return([]database.Book{}, nil)
+	store.EXPECT().GetAllBooksCore(10000, 0).Return([]database.BookCore{}, nil)
 	w := run(http.MethodPost, "/operations/optimize-database", "/operations/optimize-database", nil, func(r *gin.Engine) {
 		r.POST("/operations/optimize-database", h.OptimizeDatabase)
 	})
@@ -307,7 +307,7 @@ func TestSetInternalFlag_RequiresKey(t *testing.T) {
 
 func TestAuditFileConsistency_Empty(t *testing.T) {
 	h, store, _, _, _, _ := newTestHandler(t)
-	store.EXPECT().GetAllBooks(100000, 0).Return([]database.Book{}, nil)
+	store.EXPECT().GetAllBooksCore(100000, 0).Return([]database.BookCore{}, nil)
 	w := run(http.MethodGet, "/operations/audit-files", "/operations/audit-files", nil, func(r *gin.Engine) {
 		r.GET("/operations/audit-files", h.AuditFileConsistency)
 	})

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -1703,6 +1703,74 @@ func (_c *MockOperationsStore_GetAllBooks_Call) RunAndReturn(run func(limit int,
 	return _c
 }
 
+// GetAllBooksCore provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllBooksCore")
+	}
+
+	var r0 []database.BookCore
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookCore)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperationsStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockOperationsStore_GetAllBooksCore_Call struct {
+	*mock.Call
+}
+
+// GetAllBooksCore is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockOperationsStore_Expecter) GetAllBooksCore(limit any, offset any) *MockOperationsStore_GetAllBooksCore_Call {
+	return &MockOperationsStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
+}
+
+func (_c *MockOperationsStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockOperationsStore_GetAllBooksCore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockOperationsStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockOperationsStore_GetAllBooksCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAllBooksFullFrom provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
 	ret := _mock.Called(afterID, limit)

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 8475f406-df31-4286-95b0-30787397603e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 // Package system hosts the system-level HTTP handlers extracted from the server
 // package: health, status, announcements, storage, logs, activity-log,
@@ -271,7 +271,7 @@ func (h *Handler) GetSystemAnnouncements(c *gin.Context) {
 	}
 
 	// Check for missing files (sample first 100 books)
-	books, err := store.GetAllBooks(100, 0)
+	books, err := store.GetAllBooksCore(100, 0)
 	if err == nil {
 		missingCount := 0
 		for _, book := range books {

--- a/internal/server/handlers/system/handler_test.go
+++ b/internal/server/handlers/system/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler_test.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: af6670e5-d640-4339-b0b2-3b0cf1596ce7
-// last-edited: 2026-06-16
+// last-edited: 2026-07-07
 
 // Unit tests for the system-domain HTTP handlers. Each public method has at
 // least one test; happy paths plus key branches (config mask-secrets path,
@@ -172,7 +172,7 @@ func TestGetSystemAnnouncements_DuplicateAuthors(t *testing.T) {
 		{ID: 2, Name: "Brandon Sanderson"},
 	}, nil)
 	d.store.EXPECT().GetBooksByAuthorIDWithRoleCore(mock.AnythingOfType("int")).Return([]database.BookCore{{ID: "b1"}}, nil).Maybe()
-	d.store.EXPECT().GetAllBooks(100, 0).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetAllBooksCore(100, 0).Return([]database.BookCore{}, nil)
 
 	w := run(http.MethodGet, "/system/announcements", "/system/announcements", nil, func(r *gin.Engine) {
 		r.GET("/system/announcements", h.GetSystemAnnouncements)
@@ -187,7 +187,7 @@ func TestGetSystemAnnouncements_DuplicateAuthors(t *testing.T) {
 func TestGetSystemAnnouncements_Empty(t *testing.T) {
 	h, d := newTestHandler(t)
 	d.store.EXPECT().GetAllAuthors().Return([]database.Author{}, nil)
-	d.store.EXPECT().GetAllBooks(100, 0).Return([]database.Book{}, nil)
+	d.store.EXPECT().GetAllBooksCore(100, 0).Return([]database.BookCore{}, nil)
 
 	w := run(http.MethodGet, "/system/announcements", "/system/announcements", nil, func(r *gin.Engine) {
 		r.GET("/system/announcements", h.GetSystemAnnouncements)

--- a/internal/server/handlers/system/interfaces.go
+++ b/internal/server/handlers/system/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/interfaces.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7a91ad40-5c96-4423-ad24-715acb791cf8
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 // Narrow dependency interfaces for the system domain handlers (health, status,
 // announcements, storage, logs, activity-log, reset/factory-reset, config
@@ -49,7 +49,7 @@ type SystemStore interface {
 	// GetBooksByAuthorIDWithRoleCore is Core-typed (STOREFID P3-W2b) — see
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
 	GetBooksByAuthorIDWithRoleCore(authorID int) ([]database.BookCore, error) // AuthorStore
-	GetAllBooks(limit, offset int) ([]database.Book, error)                  // BookStore
+	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)           // BookStore
 
 	// activity log
 	GetSystemActivityLogs(source string, limit int) ([]database.SystemActivityLog, error) // SystemActivityStore

--- a/internal/server/handlers/system/mocks/mock_system_store.go
+++ b/internal/server/handlers/system/mocks/mock_system_store.go
@@ -413,24 +413,24 @@ func (_c *MockSystemStore_GetAllBlockedHashes_Call) RunAndReturn(run func() ([]d
 	return _c
 }
 
-// GetAllBooks provides a mock function for the type MockSystemStore
-func (_mock *MockSystemStore) GetAllBooks(limit int, offset int) ([]database.Book, error) {
+// GetAllBooksCore provides a mock function for the type MockSystemStore
+func (_mock *MockSystemStore) GetAllBooksCore(limit int, offset int) ([]database.BookCore, error) {
 	ret := _mock.Called(limit, offset)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetAllBooks")
+		panic("no return value specified for GetAllBooksCore")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookCore, error)); ok {
 		return returnFunc(limit, offset)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookCore); ok {
 		r0 = returnFunc(limit, offset)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
@@ -441,19 +441,19 @@ func (_mock *MockSystemStore) GetAllBooks(limit int, offset int) ([]database.Boo
 	return r0, r1
 }
 
-// MockSystemStore_GetAllBooks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooks'
-type MockSystemStore_GetAllBooks_Call struct {
+// MockSystemStore_GetAllBooksCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllBooksCore'
+type MockSystemStore_GetAllBooksCore_Call struct {
 	*mock.Call
 }
 
-// GetAllBooks is a helper method to define mock.On call
+// GetAllBooksCore is a helper method to define mock.On call
 //   - limit int
 //   - offset int
-func (_e *MockSystemStore_Expecter) GetAllBooks(limit any, offset any) *MockSystemStore_GetAllBooks_Call {
-	return &MockSystemStore_GetAllBooks_Call{Call: _e.mock.On("GetAllBooks", limit, offset)}
+func (_e *MockSystemStore_Expecter) GetAllBooksCore(limit any, offset any) *MockSystemStore_GetAllBooksCore_Call {
+	return &MockSystemStore_GetAllBooksCore_Call{Call: _e.mock.On("GetAllBooksCore", limit, offset)}
 }
 
-func (_c *MockSystemStore_GetAllBooks_Call) Run(run func(limit int, offset int)) *MockSystemStore_GetAllBooks_Call {
+func (_c *MockSystemStore_GetAllBooksCore_Call) Run(run func(limit int, offset int)) *MockSystemStore_GetAllBooksCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 int
 		if args[0] != nil {
@@ -471,12 +471,12 @@ func (_c *MockSystemStore_GetAllBooks_Call) Run(run func(limit int, offset int))
 	return _c
 }
 
-func (_c *MockSystemStore_GetAllBooks_Call) Return(books []database.Book, err error) *MockSystemStore_GetAllBooks_Call {
-	_c.Call.Return(books, err)
+func (_c *MockSystemStore_GetAllBooksCore_Call) Return(bookCores []database.BookCore, err error) *MockSystemStore_GetAllBooksCore_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockSystemStore_GetAllBooks_Call) RunAndReturn(run func(limit int, offset int) ([]database.Book, error)) *MockSystemStore_GetAllBooks_Call {
+func (_c *MockSystemStore_GetAllBooksCore_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookCore, error)) *MockSystemStore_GetAllBooksCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/isbn_enrichment_test.go
+++ b/internal/server/isbn_enrichment_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/isbn_enrichment_test.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: 5b7766bc-1f00-4f32-b8ca-8cb0e815c9a1
-// last-edited: 2026-07-01
+// last-edited: 2026-07-07
 
 package server
 
@@ -207,11 +207,15 @@ func TestEnrichMissingISBNs_RespectsLimit(t *testing.T) {
 		{ID: "book-3", Title: "Three"},
 	}
 	mock := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return books, nil
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
 		},
 		GetBookByIDFunc: func(id string) (*database.Book, error) {
 			for i := range books {

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_fixups.go
-// version: 2.6.0
+// version: 2.7.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-06-23
+// last-edited: 2026-07-07
 
 package server
 
@@ -116,9 +116,9 @@ func (s *Server) handleWipe(c *gin.Context) {
 		offset := 0
 		batchSize := 500
 		for {
-			books, err := store.GetAllBooks(batchSize, offset)
+			books, err := store.GetAllBooksCore(batchSize, offset)
 			if err != nil {
-				slog.Warn("wipe files GetAllBooks failed", "error", err)
+				slog.Warn("wipe files GetAllBooksCore failed", "error", err)
 				break
 			}
 			for _, book := range books {
@@ -251,7 +251,7 @@ func wipeBookFiles(store maintenanceStore, dryRun bool) (int64, error) {
 	var count int64
 	offset := 0
 	for {
-		books, err := store.GetAllBooks(500, offset)
+		books, err := store.GetAllBooksCore(500, offset)
 		if err != nil {
 			return count, err
 		}

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-07-01
+// last-edited: 2026-07-07
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -70,11 +70,11 @@ func (s *Server) runBulkMetadataFetchAll(
 	// Total unknown until books load; use placeholder (0/1) to avoid 0/0.
 	_ = progress.UpdateProgress(0, 1, "loading books (0/1 0.00%)")
 
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		op.SetStatus("failed")
 		logging.Error(ctx, "failed to load all books", "err", err)
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	maxAge := time.Duration(config.AppConfig.MetadataFetchCacheTTLDays) * 24 * time.Hour
@@ -95,7 +95,7 @@ func (s *Server) runBulkMetadataFetchAll(
 	}
 
 	type bookWork struct {
-		book       database.Book
+		book       database.BookCore
 		authorName string
 	}
 	var work []bookWork
@@ -788,7 +788,7 @@ func (s *Server) runMetadataRefreshScan(ctx context.Context, progress operations
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
 	// Pre-load total is unknown; placeholder (0/1) avoids 0/0.
 	_ = progress.UpdateProgress(0, 1, "Scanning books for incomplete metadata... (0/1 0.00%)")
-	books, err := store.GetAllBooks(10000, 0)
+	books, err := store.GetAllBooksCore(10000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)
 	}

--- a/internal/server/quarantine_known_bad.go
+++ b/internal/server/quarantine_known_bad.go
@@ -1,6 +1,7 @@
 // file: internal/server/quarantine_known_bad.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
+// last-edited: 2026-07-07
 
 package server
 
@@ -25,9 +26,9 @@ func (s *Server) quarantineKnownBadFiles() {
 		return
 	}
 
-	books, err := store.GetAllBooks(20000, 0)
+	books, err := store.GetAllBooksCore(20000, 0)
 	if err != nil {
-		slog.Warn("quarantineKnownBadFiles GetAllBooks", "err", err)
+		slog.Warn("quarantineKnownBadFiles GetAllBooksCore", "err", err)
 		return
 	}
 

--- a/internal/sweep/archive_sweep.go
+++ b/internal/sweep/archive_sweep.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/archive_sweep.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: a9f8e7d6-c5b4-3a21-9087-654321fedcba
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 //
 // Archive sweep for soft-deleted books (backlog 7.10).
 //
@@ -28,7 +28,7 @@ func SweepArchivedBooks(store interface {
 	database.BookStore
 	database.BookFileStore
 }) int {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		slog.Warn("archive sweep list books", "err", err)
 		return 0

--- a/internal/sweep/sweeper.go
+++ b/internal/sweep/sweeper.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper.go
-// version: 1.0.2
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-4789-abcd-ef2345678901
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package sweep
 
@@ -82,7 +82,7 @@ func AuditFileConsistency(store database.BookStore) (*SweeperResult, error) {
 		Errors:       []string{},
 	}
 
-	books, err := store.GetAllBooks(100000, 0)
+	books, err := store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list books: %w", err)
 	}

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.0.6
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package sweep
 
@@ -68,6 +68,18 @@ func (m *MockBookStore) GetAllBooks(limit, offset int) ([]database.Book, error) 
 		end = len(m.books)
 	}
 	return m.books[offset:end], nil
+}
+
+func (m *MockBookStore) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
+	books, err := m.GetAllBooks(limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	cores := make([]database.BookCore, len(books))
+	for i := range books {
+		cores[i] = books[i].Core()
+	}
+	return cores, nil
 }
 
 // Stub out other required BookStore methods

--- a/internal/writeback/outbox.go
+++ b/internal/writeback/outbox.go
@@ -1,7 +1,7 @@
 // file: internal/writeback/outbox.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: 5c3d4e2f-6a7b-4a70-b8c5-3d7e0f1b9a99
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 //
 // Durable outbox for the ITL write-back queue (backlog 4.3).
 //
@@ -80,7 +80,7 @@ func (o *WriteBackOutbox) ReplayOrphans(batcher Enqueuer) int {
 	// Scan all _system preferences for outbox keys.
 	// This is a linear scan — acceptable at startup since the outbox
 	// should be small (< 100 items typically).
-	books, err := o.store.GetAllBooks(0, 0)
+	books, err := o.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
## STOREFID W5a — add `GetAllBooksCore` + migrate the mechanically-safe callers

`GetAllBooks(limit, offset) []Book` returns the memdb-slim projection under prod — a fidelity lie. With ~60 callers, W5 is staged **ADD → migrate-in-batches → remove**, not an atomic rename.

### This PR (additive, no behavior change)
- Adds `GetAllBooksCore(limit, offset) ([]BookCore, error)` to the `Store` interface, `PebbleStore`, `MemStore`, hand-written `MockStore`, and the mockery-generated mock. `GetAllBooks` stays — both coexist through W5.
- Migrates the **45 mechanically-safe call sites (39 files)**: read only Core-safe fields, no page-struct writeback.

**A green `go build` is the safety proof** — a migrated caller that read a stripped heavy field, or wrote its `BookCore` page-struct back via `UpdateBook`, could not compile. No writeback semantics change in this PR (verified: zero new `.ToBook()`).

### Deferred to follow-up batches (still on `GetAllBooks`)
- **~11 slim-struct-writeback** sites (Author/Series wipe vectors under memdb; the other 7 heavy fields are covered by `UpdateBook`'s STOR-1 guard) → W5b, hydrate fix.
- **~7 heavy-field readers** → route to the `GetAllBooksFullFrom` cursor.
- **~8 cross-package/exported-signature** sites → dedicated batches.
- `GetAllBooks` removed in **W5z** (red build then = completeness guarantee).

### Verification
- `go build ./...`, `go vet ./...` — pass
- `go test -race ./...` (incl. `internal/server`, 522s) — pass

Follows W4 #1845. Part of STOREFID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)