### PR TITLE
refactor(store): migrate GetAllBooks writeback/DUAL callers to hydrate (STOREFID W5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.114.0 -->
+<!-- version: 3.115.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): migrate GetAllBooks writeback/DUAL callers to hydrate (STOREFID W5b)
+
+- **`refactor(store)`** — migrated the **12 remaining `GetAllBooks` writeback/DUAL call sites**
+  (across 8 files) to `GetAllBooksCore` + hydrate-on-writeback, the second W5 batch after W5a's
+  45 mechanically-safe sites. Files: `database/migrations.go`, `reconcile/reconcile.go` (4 sites),
+  `itunes/service/importer.go` (2), and `maintenance/jobs/{backfill_metadata_source_hash,
+  fix_library_states,refetch_missing_authors,relink_missing_to_itunes}.go` +
+  `plugins/maintenance/title_backfill.go` (1 each). Package-local only — no interface / mock
+  signature change (`GetAllBooksCore` and `GetBookByID` already exist from prior waves).
+- **Data-loss vector closed (bounded).** Each of these loops iterated the whole library from the
+  memdb-slim `GetAllBooks` projection and wrote a page-sourced struct straight back through
+  `UpdateBook`, wiping the denormalized `Author`/`Series` (`db:"-"`, the 2 heavy Book fields NOT
+  covered by `UpdateBook`'s STOR-1 preserve-on-empty guard; the other 7 —
+  Description/VersionNotes/BookSig* — were already guarded). Every site now hydrates the full row
+  via `GetBookByID`, mutates only its target field, and writes the hydrated struct — never a
+  `BookCore`-derived or hand-built `Book{}` (both would compile and both would wipe). Severity is
+  bounded to Author/Series, but those are persisted and read elsewhere, so it was a real wipe.
+- **`reconcile.MergeNoVGDuplicates`** additionally routed `MergeBookMetadata` (which reads/writes
+  the heavy `Description` field) and `softDelete` (a full-struct writeback) through an ID-keyed
+  `hydrate()` cache, preserving the pre-refactor in-memory accumulation semantics (repeated merges
+  into the same primary/keeper still see earlier merges) while guaranteeing every write targets a
+  hydrated full row. `go build`, `go vet`, and the `-race` suite for all five affected packages
+  pass; test mocks migrated to `GetAllBooksCoreFunc` + `GetBookByIDFunc` stubs.
 
 #### July 7, 2026 - refactor(store): add GetAllBooksCore, migrate safe callers (STOREFID W5a)
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1,7 +1,7 @@
 // file: internal/database/migrations.go
-// version: 1.40.0
+// version: 1.41.0
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
-// last-edited: 2026-06-10
+// last-edited: 2026-07-07
 
 package database
 
@@ -612,20 +612,27 @@ func migration014Up(store Store) error {
 
 // migration014UpPebble handles the corrupted-path check for PebbleDB stores.
 func migration014UpPebble(store Store) error {
-	books, err := store.GetAllBooks(1000000, 0)
+	books, err := store.GetAllBooksCore(1000000, 0)
 	if err != nil {
 		return fmt.Errorf("migration 14: failed to list books: %w", err)
 	}
 
 	flagged := 0
-	for _, book := range books {
-		if !strings.Contains(book.FilePath, "{") {
+	for _, core := range books {
+		if !strings.Contains(core.FilePath, "{") {
 			continue
 		}
-		// FilePath contains a literal brace — flag for review
+		// FilePath contains a literal brace — flag for review. Hydrate before
+		// writeback: core is Core (slim); writing it straight through
+		// UpdateBook would wipe the denormalized Author/Series on Pebble.
+		book, hydrateErr := store.GetBookByID(core.ID)
+		if hydrateErr != nil || book == nil {
+			slog.Info("- Warning could not hydrate book", "value", core.ID, "path", core.FilePath, "error", hydrateErr)
+			continue
+		}
 		state := "needs_review"
 		book.LibraryState = &state
-		if _, updateErr := store.UpdateBook(book.ID, &book); updateErr != nil {
+		if _, updateErr := store.UpdateBook(book.ID, book); updateErr != nil {
 			slog.Info("- Warning could not flag book", "value", book.ID, "path", book.FilePath, "error", updateErr)
 			continue
 		}

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 // last-edited: 2026-07-07
 
@@ -532,13 +532,17 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 	}
 
 	log.UpdateProgress(0, 0, "Building persistent ID index...")
-	allBooks, err := imp.store.GetAllBooks(100000, 0)
+	// Core-typed: the matching indices below only ever read/write Core-safe
+	// fields (ITunesPersistentID, FilePath, Title, ITunesPlayCount,
+	// ITunesRating, ITunesBookmark, ITunesLastPlayed). The actual writeback
+	// hydrates a full row (see below) so it never wipes Author/Series.
+	allBooks, err := imp.store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return fmt.Errorf("failed to load books for index: %w", err)
 	}
-	pidIndex := make(map[string]*database.Book, len(allBooks))
-	pathIndex := make(map[string]*database.Book, len(allBooks))
-	titleIndex := make(map[string]*database.Book, len(allBooks))
+	pidIndex := make(map[string]*database.BookCore, len(allBooks))
+	pathIndex := make(map[string]*database.BookCore, len(allBooks))
+	titleIndex := make(map[string]*database.BookCore, len(allBooks))
 	for i := range allBooks {
 		if allBooks[i].ITunesPersistentID != nil && *allBooks[i].ITunesPersistentID != "" {
 			pidIndex[*allBooks[i].ITunesPersistentID] = &allBooks[i]
@@ -636,20 +640,32 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 			}
 
 			if changed {
-				if _, err := imp.store.UpdateBook(existing.ID, existing); err != nil {
-					log.Error("Failed to update '%s': %v", existing.Title, err)
+				// Hydrate full row before writeback — existing is Core (slim);
+				// writing it straight through UpdateBook would wipe Author/Series.
+				full, hydrateErr := imp.store.GetBookByID(existing.ID)
+				if hydrateErr != nil || full == nil {
+					log.Error("Failed to hydrate '%s' for update: %v", existing.Title, hydrateErr)
 				} else {
-					updated++
-					if activityFn != nil {
-						activityFn(database.ActivityEntry{
-							Tier:    "change",
-							Type:    "itunes_sync",
-							Level:   "info",
-							Source:  "scheduler",
-							BookID:  existing.ID,
-							Summary: fmt.Sprintf("iTunes sync updated: %s", existing.Title),
-							Tags:    []string{"itunes"},
-						})
+					full.ITunesPersistentID = existing.ITunesPersistentID
+					full.ITunesPlayCount = existing.ITunesPlayCount
+					full.ITunesRating = existing.ITunesRating
+					full.ITunesBookmark = existing.ITunesBookmark
+					full.ITunesLastPlayed = existing.ITunesLastPlayed
+					if _, err := imp.store.UpdateBook(full.ID, full); err != nil {
+						log.Error("Failed to update '%s': %v", full.Title, err)
+					} else {
+						updated++
+						if activityFn != nil {
+							activityFn(database.ActivityEntry{
+								Tier:    "change",
+								Type:    "itunes_sync",
+								Level:   "info",
+								Source:  "scheduler",
+								BookID:  full.ID,
+								Summary: fmt.Sprintf("iTunes sync updated: %s", full.Title),
+								Tags:    []string{"itunes"},
+							})
+						}
 					}
 				}
 			} else {
@@ -1213,7 +1229,7 @@ func (imp *Importer) enrichConcurrency() int {
 //     colliding case gets the same one-wins/one-fails outcome the serial
 //     loop always produced (order-independent, same result set).
 func (imp *Importer) organizeImportedBooks(ctx context.Context, status *itunesImportStatus, log logger.Logger) {
-	books, err := imp.store.GetAllBooks(100000, 0)
+	core, err := imp.store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		log.Error("Failed to list books for organize: %v", err)
 		return
@@ -1222,17 +1238,26 @@ func (imp *Importer) organizeImportedBooks(ctx context.Context, status *itunesIm
 	// Pre-filter to the books this phase actually organizes, same filter
 	// the original sequential loop applied inline per iteration. Keeps
 	// RunItems' Concurrency fan-out and progress denominator scoped to
-	// real work only.
-	toOrganize := make([]*database.Book, 0, len(books))
-	for i := range books {
-		book := &books[i]
-		if book.LibraryState == nil || *book.LibraryState != "imported" {
+	// real work only. The filter itself only needs Core-safe fields
+	// (LibraryState, ITunesImportSource), but organizeOneBook/organizeDestKey
+	// generate the destination path from Author/Series (heavy fields), and
+	// the writeback below must never persist a slim struct — so every
+	// surviving candidate is hydrated via GetBookByID before being queued.
+	toOrganize := make([]*database.Book, 0, len(core))
+	for i := range core {
+		c := &core[i]
+		if c.LibraryState == nil || *c.LibraryState != "imported" {
 			continue
 		}
-		if book.ITunesImportSource == nil {
+		if c.ITunesImportSource == nil {
 			continue
 		}
-		toOrganize = append(toOrganize, book)
+		full, hydrateErr := imp.store.GetBookByID(c.ID)
+		if hydrateErr != nil || full == nil {
+			log.Warn("Failed to hydrate book %s for organize: %v", c.ID, hydrateErr)
+			continue
+		}
+		toOrganize = append(toOrganize, full)
 	}
 
 	var mu sync.Mutex

--- a/internal/itunes/service/importer_error_paths_test.go
+++ b/internal/itunes/service/importer_error_paths_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer_error_paths_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a7c3f2e1-4d8b-4e6a-9f0c-2b5d7e3a8c1f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-07
 
 // Package itunesservice - error and edge-case tests for importer.go (TODO 4.13d).
 //
@@ -366,8 +366,8 @@ func TestSync_GetAllBooksFails_ReturnsError(t *testing.T) {
 	xmlPath := writeXMLWithAudiobook(t, dir, "Sync Book", "Sync Author", pid, trackPath)
 
 	m := dbmocks.NewMockStore(t)
-	// After parsing and grouping, Sync calls GetAllBooks for the PID index.
-	m.EXPECT().GetAllBooks(100000, 0).Return(nil, fmt.Errorf("database connection lost")).Once()
+	// After parsing and grouping, Sync calls GetAllBooksCore for the PID index.
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(nil, fmt.Errorf("database connection lost")).Once()
 	// No deferred iTunes updates (ITLWriteBackEnabled = false).
 
 	imp := newImporter(Deps{Store: m, Config: Config{ITLWriteBackEnabled: false}})

--- a/internal/itunes/service/importer_organize_parallel_test.go
+++ b/internal/itunes/service/importer_organize_parallel_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer_organize_parallel_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: 3f9a1c7e-2b6d-4a58-9e0f-7c1d5b8a4e2f
-// last-edited: 2026-07-05
+// last-edited: 2026-07-07
 
 package itunesservice
 
@@ -110,10 +110,21 @@ func buildOrganizeFixture(t *testing.T, n, distinctTitles int) ([]database.Book,
 		}
 	}
 
+	core := make([]database.BookCore, len(books))
+	for i := range books {
+		core[i] = books[i].Core()
+	}
+
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return(books, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(core, nil)
 	for i := range books {
 		id := books[i].ID
+		b := books[i]
+		// organizeImportedBooks hydrates each Core-filtered candidate via
+		// GetBookByID before organizing/writing back (DUAL-adjacent: the
+		// destination path is derived from Author/Series, heavy fields not
+		// present on BookCore).
+		m.EXPECT().GetBookByID(id).Return(&b, nil)
 		// organizeDestKey and organizeOneBook each call GetBookFiles once
 		// per book (two calls total) — the mock permits unlimited calls
 		// by default (no .Once()), matching that.
@@ -196,7 +207,7 @@ func TestOrganizeImportedBooks_ParallelMatchesSerial_NoDestinationRace(t *testin
 // no-op and must not panic on an empty slice.
 func TestOrganizeImportedBooks_EmptyList(t *testing.T) {
 	m := dbmocks.NewMockStore(t)
-	m.EXPECT().GetAllBooks(100000, 0).Return(nil, nil)
+	m.EXPECT().GetAllBooksCore(100000, 0).Return(nil, nil)
 
 	imp := &Importer{store: m, organizeConcurrencyOverride: 4}
 	status := &itunesImportStatus{}

--- a/internal/maintenance/jobs/backfill_metadata_source_hash.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000015-0000-0000-0000-000000000015
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -31,7 +31,7 @@ func (j *backfillMetadataSourceHashJob) Description() string {
 }
 func (j *backfillMetadataSourceHashJob) CanResume() bool { return false }
 func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err
 	}
@@ -54,9 +54,15 @@ func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.
 		sum := sha256.Sum256([]byte(raw))
 		hash := fmt.Sprintf("%x", sum)
 		if !dryRun {
-			updBook := *book
-			updBook.MetadataSourceHash = &hash
-			if _, uerr := store.UpdateBook(book.ID, &updBook); uerr != nil {
+			// Hydrate before writeback — book is Core (slim); writing it
+			// straight through UpdateBook would wipe Author/Series.
+			full, herr := store.GetBookByID(book.ID)
+			if herr != nil || full == nil {
+				slog.Error("backfill-metadata-source-hash hydrate failed", "id", book.ID, "err", herr)
+				continue
+			}
+			full.MetadataSourceHash = &hash
+			if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
 				msg := uerr.Error()
 				slog.Error("backfill-metadata-source-hash UpdateBook failed", "details", msg)
 				continue
@@ -69,7 +75,7 @@ func (j *backfillMetadataSourceHashJob) Run(ctx context.Context, store database.
 	return nil
 }
 
-func bookMetadataSourceAndID(book *database.Book) (string, string) {
+func bookMetadataSourceAndID(book *database.BookCore) (string, string) {
 	if book.MetadataSource == nil {
 		return "", ""
 	}

--- a/internal/maintenance/jobs/backfill_metadata_source_hash_test.go
+++ b/internal/maintenance/jobs/backfill_metadata_source_hash_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_metadata_source_hash_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-05-16
+// last-edited: 2026-07-07
 
 package jobs_test
 
@@ -42,11 +42,11 @@ func TestBackfillMetadataSourceHashJob_SkipsAlreadyHashed(t *testing.T) {
 	}
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -64,11 +64,11 @@ func TestBackfillMetadataSourceHashJob_SkipsNilSourceAndID(t *testing.T) {
 	book := database.Book{ID: "book-noid", Title: "No Source"}
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -93,11 +93,15 @@ func TestBackfillMetadataSourceHashJob_HashesAudibleBook(t *testing.T) {
 	}
 	var writtenHash string
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b := book
+			return &b, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			if b.MetadataSourceHash != nil {
@@ -126,11 +130,11 @@ func TestBackfillMetadataSourceHashJob_DryRun(t *testing.T) {
 	}
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -147,9 +151,9 @@ func TestBackfillMetadataSourceHashJob_DryRun(t *testing.T) {
 func TestBackfillMetadataSourceHashJob_Cancellation(t *testing.T) {
 	src := "audible"
 	asin := "B000000001"
-	books := make([]database.Book, 5)
+	books := make([]database.BookCore, 5)
 	for i := range books {
-		books[i] = database.Book{
+		books[i] = database.BookCore{
 			ID:             fmt.Sprintf("b%d", i),
 			Title:          "Book",
 			MetadataSource: &src,
@@ -157,7 +161,7 @@ func TestBackfillMetadataSourceHashJob_Cancellation(t *testing.T) {
 		}
 	}
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}

--- a/internal/maintenance/jobs/fix_library_states.go
+++ b/internal/maintenance/jobs/fix_library_states.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_library_states.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1000008-0000-0000-0000-000000000008
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -30,7 +30,7 @@ func (j *fixLibraryStatesJob) Description() string {
 }
 func (j *fixLibraryStatesJob) CanResume() bool { return false }
 func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
-	books, err := store.GetAllBooks(0, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return err
 	}
@@ -55,9 +55,15 @@ func (j *fixLibraryStatesJob) Run(ctx context.Context, store database.Store, rep
 			continue
 		}
 		if !dryRun {
-			updated := *book
-			updated.LibraryState = &wantState
-			if _, uerr := store.UpdateBook(book.ID, &updated); uerr != nil {
+			// Hydrate before writeback — book is Core (slim); writing it
+			// straight through UpdateBook would wipe Author/Series.
+			full, herr := store.GetBookByID(book.ID)
+			if herr != nil || full == nil {
+				slog.Error("fix-library-states hydrate failed", "id", book.ID, "err", herr)
+				continue
+			}
+			full.LibraryState = &wantState
+			if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
 				msg := uerr.Error()
 				slog.Error("fix-library-states UpdateBook failed", "details", msg)
 			} else {

--- a/internal/maintenance/jobs/fix_library_states_test.go
+++ b/internal/maintenance/jobs/fix_library_states_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/fix_library_states_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: e2f3a4b5-c6d7-8901-efab-234567890567
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 // Package jobs_test exercises the fix-library-states maintenance job.
 package jobs_test
@@ -44,11 +44,15 @@ func TestFixLibraryStatesJob_DryRun_NoUpdate(t *testing.T) {
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b := book
+			return &b, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -75,11 +79,15 @@ func TestFixLibraryStatesJob_Apply_UpdatesBook(t *testing.T) {
 
 	var updatedState string
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b := book
+			return &b, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			if b.LibraryState != nil {
@@ -108,11 +116,15 @@ func TestFixLibraryStatesJob_NoChanges_WhenStateCorrect(t *testing.T) {
 
 	var updateCalled bool
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return []database.Book{book}, nil
+			return []database.BookCore{book.Core()}, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b := book
+			return &b, nil
 		},
 		UpdateBookFunc: func(id string, b *database.Book) (*database.Book, error) {
 			updateCalled = true
@@ -142,12 +154,16 @@ func TestFixLibraryStatesJob_Cancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
+	core := make([]database.BookCore, len(books))
+	for i := range books {
+		core[i] = books[i].Core()
+	}
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset > 0 {
 				return nil, nil
 			}
-			return books, nil
+			return core, nil
 		},
 	}
 

--- a/internal/maintenance/jobs/refetch_missing_authors.go
+++ b/internal/maintenance/jobs/refetch_missing_authors.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1000012-0000-0000-0000-000000000012
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -36,14 +36,16 @@ func (j *refetchMissingAuthorsJob) CanResume() bool    { return true }
 func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
 	opID := maintenance.OperationIDFromCtx(ctx)
 
-	// Load all books without an author.
-	allBooks, err := store.GetAllBooks(0, 0)
+	// Load all books without an author. Core-typed: the filter/lookup below
+	// only needs AuthorID/ID/Title/FilePath, all Core-safe fields; the actual
+	// writeback hydrates a full row (see below) so it never wipes Author/Series.
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	// Filter to only books with no author.
-	var books []database.Book
+	var books []database.BookCore
 	for i := range allBooks {
 		if allBooks[i].AuthorID == nil {
 			books = append(books, allBooks[i])
@@ -164,9 +166,17 @@ func (j *refetchMissingAuthorsJob) Run(ctx context.Context, store database.Store
 			slog.Info("refetch-missing-authors created author", "opID", opID, "authorName", authorName, "authorID", author.ID)
 		}
 
-		b.AuthorID = &author.ID
-		if _, err := store.UpdateBook(b.ID, b); err != nil {
-			slog.Error("failed to update book", "b", b.ID, "err", err)
+		// Hydrate before writeback — b is Core (slim); writing it straight
+		// through UpdateBook would wipe the denormalized Author/Series.
+		full, herr := store.GetBookByID(b.ID)
+		if herr != nil || full == nil {
+			slog.Error("failed to hydrate book for update", "b", b.ID, "err", herr)
+			errors++
+			continue
+		}
+		full.AuthorID = &author.ID
+		if _, err := store.UpdateBook(full.ID, full); err != nil {
+			slog.Error("failed to update book", "b", full.ID, "err", err)
 			errors++
 			continue
 		}

--- a/internal/maintenance/jobs/refetch_missing_authors_test.go
+++ b/internal/maintenance/jobs/refetch_missing_authors_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/refetch_missing_authors_test.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: e4f5a6b7-c8d9-0123-efab-456789012789
-// last-edited: 2026-05-05
+// last-edited: 2026-07-07
 
 package jobs_test
 
@@ -47,7 +47,7 @@ func TestRefetchMissingAuthorsJob_DefaultParamsDryRunTrue(t *testing.T) {
 func TestRefetchMissingAuthorsJob_NoBooksReturned(t *testing.T) {
 	// No books at all — job should complete cleanly.
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			return nil, nil
 		},
 	}
@@ -63,8 +63,8 @@ func TestRefetchMissingAuthorsJob_AllBooksHaveAuthor(t *testing.T) {
 	// No books without author — nothing to update.
 	authorID := 1
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{
 				{ID: "b1", Title: "Book One", AuthorID: &authorID},
 			}, nil
 		},
@@ -87,8 +87,8 @@ func TestRefetchMissingAuthorsJob_AllBooksHaveAuthor(t *testing.T) {
 func TestRefetchMissingAuthorsJob_SkipsBookWithNoFiles(t *testing.T) {
 	// Book with no author and no files — should be skipped without error.
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
-			return []database.Book{
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{
 				{ID: "b-nofile", Title: "Orphan Book", AuthorID: nil, FilePath: ""},
 			}, nil
 		},
@@ -109,13 +109,13 @@ func TestRefetchMissingAuthorsJob_SkipsBookWithNoFiles(t *testing.T) {
 }
 
 func TestRefetchMissingAuthorsJob_CancelationRespected(t *testing.T) {
-	books := make([]database.Book, 5)
+	books := make([]database.BookCore, 5)
 	for i := range books {
-		books[i] = database.Book{ID: "b-cancel-" + string(rune('0'+i)), Title: "T"}
+		books[i] = database.BookCore{ID: "b-cancel-" + string(rune('0'+i)), Title: "T"}
 	}
 
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			return books, nil
 		},
 	}

--- a/internal/maintenance/jobs/relink_missing_to_itunes.go
+++ b/internal/maintenance/jobs/relink_missing_to_itunes.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_missing_to_itunes.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: e0f6a4d5-7b8c-9d0e-1f2a-3b4c5d6e7f80
-// last-edited: 2026-06-16
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -54,9 +54,9 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		return fmt.Errorf("root_dir is not configured")
 	}
 
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
-		return fmt.Errorf("GetAllBooks: %w", err)
+		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}
 
 	reporter.SetTotal(len(allBooks))
@@ -71,14 +71,25 @@ func (j *relinkMissingToITunesJob) Run(ctx context.Context, store database.Store
 		}
 		reporter.Increment()
 
-		book := &allBooks[i]
-		fp := book.FilePath
+		core := &allBooks[i]
+		fp := core.FilePath
 		if !strings.HasPrefix(fp, organizerRoot) {
 			skipped++
 			continue
 		}
 		if _, err := os.Stat(fp); err == nil {
 			skipped++
+			continue
+		}
+
+		// Hydrate before further processing — DUAL site: Author (a heavy
+		// field) is read below AND the eventual writeback must never persist
+		// a slim struct (that would wipe Author/Series on Pebble). A single
+		// hydrate serves both needs.
+		book, herr := store.GetBookByID(core.ID)
+		if herr != nil || book == nil {
+			slog.Warn("relink-missing-to-itunes failed to hydrate book", "book", core.ID, "herr", herr)
+			unresolved++
 			continue
 		}
 

--- a/internal/plugins/maintenance/title_backfill.go
+++ b/internal/plugins/maintenance/title_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-23
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -21,9 +21,12 @@ type titleBackfillParams struct {
 	DryRun bool `json:"dryRun"`
 }
 
-// pendingUpdate holds a book whose title needs stripping.
+// pendingUpdate holds a book whose title needs stripping. book is Core (slim)
+// — Title/ID are Core-safe fields, and the actual writeback in phase 2
+// hydrates a full row via GetBookByID before applying newTitle, so it never
+// wipes the denormalized Author/Series on Pebble.
 type pendingUpdate struct {
-	book     database.Book
+	book     database.BookCore
 	newTitle string
 }
 
@@ -80,9 +83,9 @@ func (p *Plugin) runTitleBackfill(ctx context.Context, raw json.RawMessage, repo
 			return ctx.Err()
 		}
 
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
-			return fmt.Errorf("GetAllBooks offset=%d: %w", offset, err)
+			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
 		}
 		if len(books) == 0 {
 			break
@@ -149,8 +152,17 @@ func (p *Plugin) runTitleBackfill(ctx context.Context, raw json.RawMessage, repo
 			"book %s: %q → %q", u.book.ID, u.book.Title, u.newTitle))
 
 		if !params.DryRun {
-			u.book.Title = u.newTitle
-			if _, err := store.UpdateBook(u.book.ID, &u.book); err != nil {
+			// Hydrate before writeback — u.book is Core (slim); writing it
+			// straight through UpdateBook would wipe Author/Series.
+			full, herr := store.GetBookByID(u.book.ID)
+			if herr != nil || full == nil {
+				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+					"book %s: hydrate failed: %v", u.book.ID, herr))
+				errCount++
+				continue
+			}
+			full.Title = u.newTitle
+			if _, err := store.UpdateBook(full.ID, full); err != nil {
 				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
 					"book %s: UpdateBook failed: %v", u.book.ID, err))
 				errCount++

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -110,7 +110,7 @@ var _ ServerDeps = fakeDeps{}
 func newTestPlugin(books []database.Book) (*Plugin, *[]database.Book) {
 	written := make([]database.Book, 0)
 	store := &database.MockStore{
-		GetAllBooksFunc: func(limit, offset int) ([]database.Book, error) {
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			if offset >= len(books) {
 				return nil, nil
 			}
@@ -118,7 +118,20 @@ func newTestPlugin(books []database.Book) (*Plugin, *[]database.Book) {
 			if end > len(books) {
 				end = len(books)
 			}
-			return books[offset:end], nil
+			core := make([]database.BookCore, end-offset)
+			for i, b := range books[offset:end] {
+				core[i] = b.Core()
+			}
+			return core, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			for i := range books {
+				if books[i].ID == id {
+					b := books[i]
+					return &b, nil
+				}
+			}
+			return nil, nil
 		},
 		UpdateBookFunc: func(_ string, b *database.Book) (*database.Book, error) {
 			written = append(written, *b)

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,5 +1,5 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-07-07
 
@@ -624,11 +624,12 @@ func CountMatchType(matches []ReconcileMatch, matchType string) int {
 func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*VersionGroupCleanupResult, error) {
 	result := &VersionGroupCleanupResult{}
 
-	// Fetch all books and group by version_group_id
-	versionGroups := make(map[string][]database.Book)
+	// Fetch all books and group by version_group_id. Core-typed: grouping and
+	// dup-selection only need ID/FilePath/VersionGroupID, all Core-safe fields.
+	versionGroups := make(map[string][]database.BookCore)
 	const pageSize = 1000
 	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch books: %w", err)
 		}
@@ -649,7 +650,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 		}
 
 		// Separate into originals (non-primary, outside library) and organized copies (in library)
-		var originals, libraryCopies []database.Book
+		var originals, libraryCopies []database.BookCore
 		for _, m := range members {
 			if rootDir != "" && strings.HasPrefix(m.FilePath, rootDir) {
 				libraryCopies = append(libraryCopies, m)
@@ -698,16 +699,28 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 			result.DuplicatesRemoved++
 		}
 
-		// Ensure the kept library copy is primary and the original(s) are non-primary
+		// Ensure the kept library copy is primary and the original(s) are non-primary.
+		// Hydrate each target via GetBookByID before writing back — kept/orig are
+		// Core (slim) values here, and writing a slim struct through UpdateBook
+		// would wipe the denormalized Author/Series on Pebble.
 		if !dryRun {
 			isPrimary := true
 			isNotPrimary := false
-			kept := libraryCopies[keepIdx]
-			kept.IsPrimaryVersion = &isPrimary
-			store.UpdateBook(kept.ID, &kept)
-			for _, orig := range originals {
+			keptCore := libraryCopies[keepIdx]
+			if kept, err := store.GetBookByID(keptCore.ID); err != nil || kept == nil {
+				slog.Warn("version-group cleanup failed to hydrate kept book", "kept", keptCore.ID, "err", err)
+			} else {
+				kept.IsPrimaryVersion = &isPrimary
+				store.UpdateBook(kept.ID, kept)
+			}
+			for _, origCore := range originals {
+				orig, err := store.GetBookByID(origCore.ID)
+				if err != nil || orig == nil {
+					slog.Warn("version-group cleanup failed to hydrate original book", "orig", origCore.ID, "err", err)
+					continue
+				}
 				orig.IsPrimaryVersion = &isNotPrimary
-				store.UpdateBook(orig.ID, &orig)
+				store.UpdateBook(orig.ID, orig)
 			}
 		}
 	}
@@ -718,7 +731,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 // FindBrokenSegmentBooks finds books whose segment files don't exist on disk
 // and optionally marks them as needs_review.
 func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, error) {
-	allBooks, err := store.GetAllBooks(100000, 0)
+	allBooks, err := store.GetAllBooksCore(100000, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get books: %w", err)
 	}
@@ -771,13 +784,20 @@ func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, err
 		result.BrokenBooks++
 
 		if !dryRun {
-			book.LibraryState = &needsReview
-			book.MarkedForDeletion = boolPtr(true)
-			book.MarkedForDeletionAt = &now
-			if _, uerr := store.UpdateBook(book.ID, &book); uerr != nil {
-				slog.Warn("failed to mark broken book", "book", book.ID, "uerr", uerr)
+			// Hydrate before writeback — book is a Core (slim) value here, and
+			// writing it straight through UpdateBook would wipe Author/Series.
+			full, ferr := store.GetBookByID(book.ID)
+			if ferr != nil || full == nil {
+				slog.Warn("failed to hydrate broken book for update", "book", book.ID, "ferr", ferr)
 			} else {
-				result.MarkedForReview++
+				full.LibraryState = &needsReview
+				full.MarkedForDeletion = boolPtr(true)
+				full.MarkedForDeletionAt = &now
+				if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+					slog.Warn("failed to mark broken book", "book", full.ID, "uerr", uerr)
+				} else {
+					result.MarkedForReview++
+				}
 			}
 		}
 	}
@@ -790,11 +810,12 @@ func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, err
 func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplicatesResult, error) {
 	result := &MergeDuplicatesResult{}
 
-	// Load all books in pages
-	var allBooks []database.Book
+	// Load all books in pages. Core-typed: grouping/keeper-selection only needs
+	// ID/Title/FilePath/VersionGroupID/IsPrimaryVersion, all Core-safe fields.
+	var allBooks []database.BookCore
 	pageSize := 5000
 	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get books: %w", err)
 		}
@@ -805,8 +826,8 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 	}
 
 	// Index VG primary books by normalized title
-	vgPrimaryByTitle := make(map[string]*database.Book)
-	var noVGBooks []database.Book
+	vgPrimaryByTitle := make(map[string]*database.BookCore)
+	var noVGBooks []database.BookCore
 
 	for i := range allBooks {
 		b := &allBooks[i]
@@ -835,23 +856,60 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 		return err
 	}
 
+	// hydrated caches full (heavy-field) Book rows fetched via GetBookByID, keyed
+	// by ID. MergeBookMetadata reads/writes heavy fields (e.g. Description) that
+	// BookCore does not carry, and every writeback below MUST target a hydrated
+	// full row, never a Core value, or Author/Series would be wiped on Pebble.
+	// The shared cache also preserves the original in-memory-accumulation
+	// semantics: when several dupes merge into the same primary/keeper, later
+	// merges see the earlier ones' effects (matches pre-refactor pointer reuse).
+	hydrated := make(map[string]*database.Book)
+	hydrate := func(id string) (*database.Book, error) {
+		if b, ok := hydrated[id]; ok {
+			return b, nil
+		}
+		full, err := store.GetBookByID(id)
+		if err != nil || full == nil {
+			return nil, err
+		}
+		hydrated[id] = full
+		return full, nil
+	}
+
 	// Phase 1: Match no-VG books against existing VG primaries
 	handled := make(map[string]bool)
 
 	for i := range noVGBooks {
-		dupe := &noVGBooks[i]
-		normTitle := strings.TrimSpace(strings.ToLower(dupe.Title))
-		primary, found := vgPrimaryByTitle[normTitle]
+		dupeCore := &noVGBooks[i]
+		normTitle := strings.TrimSpace(strings.ToLower(dupeCore.Title))
+		primaryCore, found := vgPrimaryByTitle[normTitle]
 		if !found {
 			continue
 		}
 
-		handled[dupe.ID] = true
+		handled[dupeCore.ID] = true
 		result.MatchedToVG++
 		entry := MergeDuplicateEntry{
-			DuplicateID: dupe.ID,
-			PrimaryID:   primary.ID,
-			Title:       dupe.Title,
+			DuplicateID: dupeCore.ID,
+			PrimaryID:   primaryCore.ID,
+			Title:       dupeCore.Title,
+		}
+
+		primary, perr := hydrate(primaryCore.ID)
+		if perr != nil || primary == nil {
+			slog.Warn("merge-dupes failed to hydrate primary", "primary", primaryCore.ID, "err", perr)
+			entry.Action = "error"
+			result.Errors++
+			result.Details = append(result.Details, entry)
+			continue
+		}
+		dupe, derr := hydrate(dupeCore.ID)
+		if derr != nil || dupe == nil {
+			slog.Warn("merge-dupes failed to hydrate dupe", "dupe", dupeCore.ID, "err", derr)
+			entry.Action = "error"
+			result.Errors++
+			result.Details = append(result.Details, entry)
+			continue
 		}
 
 		merged := MergeBookMetadata(primary, dupe)
@@ -893,7 +951,7 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 	}
 
 	// Phase 2: Deduplicate among remaining no-VG orphans (same title → keep one, delete rest)
-	orphansByTitle := make(map[string][]*database.Book)
+	orphansByTitle := make(map[string][]*database.BookCore)
 	for i := range noVGBooks {
 		b := &noVGBooks[i]
 		if handled[b.ID] {
@@ -922,17 +980,31 @@ func MergeNoVGDuplicates(store Store, rootDir string, dryRun bool) (*MergeDuplic
 			}
 		}
 
-		keeper := group[bestIdx]
-		for i, dupe := range group {
+		keeperCore := group[bestIdx]
+		keeper, kerr := hydrate(keeperCore.ID)
+		if kerr != nil || keeper == nil {
+			slog.Warn("merge-self-dupes failed to hydrate keeper", "keeper", keeperCore.ID, "err", kerr)
+			continue
+		}
+		for i, dupeCore := range group {
 			if i == bestIdx {
 				continue
 			}
 
 			result.SelfDuplicates++
 			entry := MergeDuplicateEntry{
-				DuplicateID: dupe.ID,
+				DuplicateID: dupeCore.ID,
 				PrimaryID:   keeper.ID,
-				Title:       dupe.Title,
+				Title:       dupeCore.Title,
+			}
+
+			dupe, derr := hydrate(dupeCore.ID)
+			if derr != nil || dupe == nil {
+				slog.Warn("merge-self-dupes failed to hydrate dupe", "dupe", dupeCore.ID, "err", derr)
+				entry.Action = "error"
+				result.Errors++
+				result.Details = append(result.Details, entry)
+				continue
 			}
 
 			merged := MergeBookMetadata(keeper, dupe)
@@ -1109,10 +1181,10 @@ func MergeBookMetadata(dst, src *database.Book) []string {
 func AssignOrphanVGs(store Store, rootDir string) (*AssignVGResult, error) {
 	result := &AssignVGResult{}
 
-	var allBooks []database.Book
+	var allBooks []database.BookCore
 	pageSize := 5000
 	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+		books, err := store.GetAllBooksCore(pageSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get books: %w", err)
 		}
@@ -1123,18 +1195,27 @@ func AssignOrphanVGs(store Store, rootDir string) (*AssignVGResult, error) {
 	}
 
 	for i := range allBooks {
-		b := &allBooks[i]
+		c := &allBooks[i]
 		result.TotalChecked++
 
 		// Skip books that already have a VG
-		if b.VersionGroupID != nil && *b.VersionGroupID != "" {
+		if c.VersionGroupID != nil && *c.VersionGroupID != "" {
 			result.AlreadyHasVG++
 			continue
 		}
 
 		// Only process books in the library directory
-		if rootDir == "" || !strings.HasPrefix(b.FilePath, rootDir) {
+		if rootDir == "" || !strings.HasPrefix(c.FilePath, rootDir) {
 			result.NotInLibrary++
+			continue
+		}
+
+		// Hydrate before writeback — c is a Core (slim) value here, and writing
+		// it straight through UpdateBook would wipe Author/Series.
+		b, herr := store.GetBookByID(c.ID)
+		if herr != nil || b == nil {
+			slog.Warn("assign-orphan-vgs failed to hydrate book", "book", c.ID, "herr", herr)
+			result.Errors++
 			continue
 		}
 


### PR DESCRIPTION
## STOREFID W5b — GetAllBooks writeback/DUAL callers → hydrate

Second W5 batch after W5a (#1846, 45 mechanically-safe sites). Migrates the **12 remaining `GetAllBooks` writeback/DUAL call sites** across **8 files** to `GetAllBooksCore` + hydrate-on-writeback. Package-local — no interface / mock signature change (`GetAllBooksCore` and `GetBookByID` already exist from prior waves).

### The vector closed (bounded)
Each loop iterated the whole library from the memdb-slim `GetAllBooks` projection and wrote a page-sourced struct straight back through `UpdateBook`, wiping the denormalized `Author`/`Series` (`db:"-"` — the 2 heavy `Book` fields **not** covered by `UpdateBook`'s STOR-1 preserve-on-empty guard; the other 7 — Description/VersionNotes/BookSig\* — were already guarded). Every site now hydrates the full row via `GetBookByID`, mutates only its target field, and writes the hydrated struct — never a `BookCore`-derived or hand-built `Book{}` (both compile, both wipe). Severity is bounded to Author/Series, but those are persisted and read elsewhere, so it was a real wipe.

### Per-site classification (all 12 were slim-writeback — none retype-only)
| File | Sites | Notes |
|---|---|---|
| `database/migrations.go` | 1 | `migration014UpPebble` — hydrate before `LibraryState` set |
| `reconcile/reconcile.go` | 4 | Cleanup VG groups, FindBrokenSegmentBooks, MergeNoVGDuplicates (ID-keyed `hydrate()` cache), AssignOrphanVGs |
| `itunes/service/importer.go` | 2 | Sync PID-index (copies 5 iTunes fields onto hydrated `full`), organizeImportedBooks (DUAL — dest path derived from Author/Series) |
| `maintenance/jobs/backfill_metadata_source_hash.go` | 1 | + helper retyped to `*BookCore` |
| `maintenance/jobs/fix_library_states.go` | 1 | |
| `maintenance/jobs/refetch_missing_authors.go` | 1 | |
| `maintenance/jobs/relink_missing_to_itunes.go` | 1 | DUAL — single hydrate serves `Author` read + `FilePath` writeback |
| `plugins/maintenance/title_backfill.go` | 1 | `pendingUpdate.book` retyped to `BookCore`, hydrate at apply |

`reconcile.MergeNoVGDuplicates` additionally routes `MergeBookMetadata` (reads the heavy `Description` field) and `softDelete` (a full-struct writeback) through an **ID-keyed `hydrate()` cache**, preserving the pre-refactor in-memory accumulation semantics (repeated merges into the same primary/keeper see earlier merges) while guaranteeing every write targets a hydrated full row.

### Verification
- `go build ./...` ✅  `go vet ./...` ✅
- `go test -race` green for all 5 affected packages
- Coordinator diffed **every** writeback site — all confirmed to write a `GetBookByID`-hydrated `full`, never a Core-derived struct
- Test mocks migrated to `GetAllBooksCoreFunc` + `GetBookByIDFunc` stubs; no generated-mock regeneration

`GetAllBooks` still exists; removed atomically in W5z once W5c/W5d also migrate. Rollback: revert the merge commit (package-local, nothing depends on these edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)