### PR TITLE
refactor(store): route GetAllBooks heavy-field readers to GetAllBooksFullFrom cursor (STOREFID W5c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.115.0 -->
+<!-- version: 3.116.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,26 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): route GetAllBooks heavy-field readers to GetAllBooksFullFrom cursor (STOREFID W5c)
+
+- **`refactor(store)` + latent-bug fix** — migrated the **9 `GetAllBooks` call sites (7 files)** that
+  read a memdb-stripped HEAVY field (`Author`/`Series`/`Description`/`BookSigV1`) off every iterated
+  book. Under prod `UseMemDB=true` these loops were silently reading `nil`/empty heavy fields (same
+  latent class as the BookSignatureScan no-op fixed earlier) — the memdb projection strips those
+  fields and `GetAllBooks` returned the slim copies. Each now uses `GetAllBooksFullFrom(afterID,
+  limit)`, which fetches every book via `GetBookByID` (full Pebble JSON, memdb-bypassed), so the
+  heavy reads return real data AND any writeback writes a full, write-safe struct (the old slim
+  writeback would have wiped `Author`/`Series`).
+- **Files:** `itunes/rebuild.go` (3 paged loops → `afterID` cursor: ComputeITLDiff / RebuildITLFromDB
+  / BuildExportITL), `maintenance/jobs/{relink_report,dedup_books}.go`,
+  `plugins/acoustid/{backfill,fingerprint_rescan}.go` (backfill keeps its `registry.RunItems` pool),
+  `plugins/maintenance/{fs_regroup_xml,itunes_regroup}.go`. Slurp sites (`GetAllBooks(0,0)`) →
+  `GetAllBooksFullFrom("", 0)`; paged sites → the server-search-style `afterID` cursor loop.
+- Unlike the Core waves this is **not** compiler-certified (the return type stays `[]Book`), so every
+  site was reviewed to confirm it genuinely reads a heavy field. `mockRebuildStore.GetAllBooksFullFrom`
+  in the itunes test was upgraded from an empty stub to real sorted-ID cursor semantics.
+  `go build` / `go vet` / package tests green.
 
 #### July 7, 2026 - refactor(store): migrate GetAllBooks writeback/DUAL callers to hydrate (STOREFID W5b)
 

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/rebuild.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: 3f2e1d0c-9b8a-7c6d-5e4f-3a2b1c0d9e8f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package itunes
 
@@ -46,8 +46,9 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 	// all primary-version books that have an iTunes PID.
 	dbPIDs := make(map[string]*database.Book)
 	const pageSize = 500
-	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+	afterID := ""
+	for {
+		books, err := store.GetAllBooksFullFrom(afterID, pageSize)
 		if err != nil {
 			return nil, nil, fmt.Errorf("get books: %w", err)
 		}
@@ -69,6 +70,10 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 			if b.ITunesPersistentID != nil && *b.ITunesPersistentID != "" {
 				dbPIDs[strings.ToUpper(*b.ITunesPersistentID)] = b
 			}
+		}
+		afterID = books[len(books)-1].ID
+		if len(books) < pageSize {
+			break
 		}
 	}
 
@@ -270,10 +275,11 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledg
 	// Collect all DB books to add back.
 	var adds []ITLNewTrack
 	const pageSize = 500
-	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+	afterID := ""
+	for {
+		books, err := store.GetAllBooksFullFrom(afterID, pageSize)
 		if err != nil {
-			return nil, fmt.Errorf("get books page %d: %w", offset/pageSize, err)
+			return nil, fmt.Errorf("get books page after %q: %w", afterID, err)
 		}
 		if len(books) == 0 {
 			break
@@ -290,6 +296,10 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledg
 				continue
 			}
 			adds = append(adds, buildNewTrackFromBook(store, b))
+		}
+		afterID = books[len(books)-1].ID
+		if len(books) < pageSize {
+			break
 		}
 	}
 
@@ -341,10 +351,11 @@ func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) (
 
 	var adds []ITLNewTrack
 	const pageSize = 500
-	for offset := 0; ; offset += pageSize {
-		books, err := store.GetAllBooks(pageSize, offset)
+	afterID := ""
+	for {
+		books, err := store.GetAllBooksFullFrom(afterID, pageSize)
 		if err != nil {
-			return nil, fmt.Errorf("get books page %d: %w", offset/pageSize, err)
+			return nil, fmt.Errorf("get books page after %q: %w", afterID, err)
 		}
 		if len(books) == 0 {
 			break
@@ -364,6 +375,10 @@ func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) (
 				continue
 			}
 			adds = append(adds, buildNewTrackFromBook(store, b))
+		}
+		afterID = books[len(books)-1].ID
+		if len(books) < pageSize {
+			break
 		}
 	}
 

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,11 +1,12 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.6
+// version: 1.0.7
 // last-edited: 2026-07-07
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -19,7 +20,26 @@ type mockRebuildStore struct {
 }
 
 func (m *mockRebuildStore) GetAllBooksFullFrom(afterID string, limit int) ([]database.Book, error) {
-	return nil, nil
+	// Cursor semantics matching PebbleStore.GetAllBooksFullFrom: walk books in
+	// sorted-ID order, skip everything up to and including afterID, return the
+	// next `limit` (0 = all). Returns full books (the map holds full structs),
+	// so ComputeITLDiff/RebuildITLFromDB/BuildExportITL exercise real data.
+	ids := make([]string, 0, len(m.books))
+	for id := range m.books {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	var result []database.Book
+	for _, id := range ids {
+		if id <= afterID {
+			continue
+		}
+		result = append(result, *m.books[id])
+		if limit > 0 && len(result) >= limit {
+			break
+		}
+	}
+	return result, nil
 }
 func (m *mockRebuildStore) GetAllBooks(pageSize, offset int) ([]database.Book, error) {
 	var result []database.Book

--- a/internal/maintenance/jobs/dedup_books.go
+++ b/internal/maintenance/jobs/dedup_books.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/dedup_books.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1000010-0000-0000-0000-000000000010
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -237,9 +237,9 @@ func (j *dedupBooksJob) Run(ctx context.Context, store database.Store, reporter 
 func ddFetchAllBooksPaginated(store database.Store) ([]database.Book, error) {
 	const pageSize = 500
 	var all []database.Book
-	offset := 0
+	afterID := ""
 	for {
-		page, err := store.GetAllBooks(pageSize, offset)
+		page, err := store.GetAllBooksFullFrom(afterID, pageSize)
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func ddFetchAllBooksPaginated(store database.Store) ([]database.Book, error) {
 		if len(page) < pageSize {
 			break
 		}
-		offset += pageSize
+		afterID = page[len(page)-1].ID
 	}
 	return all, nil
 }

--- a/internal/maintenance/jobs/relink_report.go
+++ b/internal/maintenance/jobs/relink_report.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/relink_report.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1000022-0000-0000-0000-000000000022
-// last-edited: 2026-06-16
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -49,7 +49,7 @@ func (j *relinkReportJob) Run(ctx context.Context, store database.Store, reporte
 		return fmt.Errorf("root_dir not configured")
 	}
 
-	allBooks, err := store.GetAllBooks(0, 0)
+	allBooks, err := store.GetAllBooksFullFrom("", 0)
 	if err != nil {
 		return fmt.Errorf("failed to list books: %w", err)
 	}

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-06-25
+// last-edited: 2026-07-07
 
 package acoustid
 
@@ -79,7 +79,7 @@ func (p *Plugin) runBackfill(ctx context.Context, params json.RawMessage, report
 	prog := sdk.NewProgress(reporter, 0)
 	prog.Start("Loading books for fingerprint backfill...")
 
-	books, err := p.store.GetAllBooks(100000, 0)
+	books, err := p.store.GetAllBooksFullFrom("", 0)
 	if err != nil {
 		reporter.Logger().Error("load books", "error", err)
 		return fmt.Errorf("load books: %w", err)

--- a/internal/plugins/acoustid/fingerprint_rescan.go
+++ b/internal/plugins/acoustid/fingerprint_rescan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/fingerprint_rescan.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a7b8c9d0-e1f2-3456-def0-123456789abc
-// last-edited: 2026-05-31
+// last-edited: 2026-07-07
 
 package acoustid
 
@@ -306,7 +306,11 @@ func fpRescanWorkers() int {
 func loadBooksForRescan(store database.Store, scope string, bookIDs []string) ([]database.Book, error) {
 	switch scope {
 	case scopeAll, scopeMissing:
-		return store.GetAllBooks(0, 0)
+		// GetAllBooksFullFrom returns FULL (GetBookByID-sourced) books, matching
+		// the scopeBooks branch below. loadBooksForRescan's contract is full
+		// books — the rescan reads/writes heavy fingerprint fields — so the
+		// memdb-slim GetAllBooks projection would have silently stripped them.
+		return store.GetAllBooksFullFrom("", 0)
 	case scopeBooks:
 		out := make([]database.Book, 0, len(bookIDs))
 		for _, id := range bookIDs {

--- a/internal/plugins/maintenance/fs_regroup_xml.go
+++ b/internal/plugins/maintenance/fs_regroup_xml.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/fs_regroup_xml.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 7d2a9c14-3e86-4b50-9f71-2c8e0a6d4b95
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 // Package maintenance — op maintenance.fs-regroup-xml.
 //
@@ -83,14 +83,15 @@ func (p *Plugin) runFSRegroupXML(ctx context.Context, raw json.RawMessage, repor
 	// Pass 1: all books → slim FSBook view (id, title, authorID, asin, path, primary, duration).
 	bookMeta := make(map[string]*itunesservice.FSBook)
 	const page = 1000
-	off := 0
+	afterID := ""
+	scanned := 0
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		books, err := store.GetAllBooks(page, off)
+		books, err := store.GetAllBooksFullFrom(afterID, page)
 		if err != nil {
-			return fmt.Errorf("GetAllBooks offset=%d: %w", off, err)
+			return fmt.Errorf("GetAllBooksFullFrom afterID=%q: %w", afterID, err)
 		}
 		if len(books) == 0 {
 			break
@@ -115,8 +116,9 @@ func (p *Plugin) runFSRegroupXML(ctx context.Context, raw json.RawMessage, repor
 			fsb.EnrichScore = enrichScore(b)
 			bookMeta[b.ID] = &fsb
 		}
-		off += len(books)
-		_ = reporter.UpdateProgress(0, 3, fmt.Sprintf("Phase 1/3: scanned %d books…", off))
+		scanned += len(books)
+		afterID = books[len(books)-1].ID
+		_ = reporter.UpdateProgress(0, 3, fmt.Sprintf("Phase 1/3: scanned %d books…", scanned))
 		if len(books) < page {
 			break
 		}

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package maintenance
 
@@ -143,14 +143,15 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 	meta := make(map[string]partialMeta)
 	vgNonPrimary := make(map[string]bool) // version-group id -> has a non-primary member
 	const page = 1000
-	off := 0
+	afterID := ""
+	scanned := 0
 	for {
 		if ctx.Err() != nil {
 			return snap, ctx.Err()
 		}
-		books, err := store.GetAllBooks(page, off)
+		books, err := store.GetAllBooksFullFrom(afterID, page)
 		if err != nil {
-			return snap, fmt.Errorf("GetAllBooks offset=%d: %w", off, err)
+			return snap, fmt.Errorf("GetAllBooksFullFrom afterID=%q: %w", afterID, err)
 		}
 		if len(books) == 0 {
 			break
@@ -171,8 +172,9 @@ func (p *Plugin) buildRegroupSnapshot(ctx context.Context, store database.Store,
 				vgNonPrimary[vg] = true
 			}
 		}
-		off += len(books)
-		_ = reporter.UpdateProgress(1, 4, fmt.Sprintf("Phase 2/4: scanned %d books…", off))
+		scanned += len(books)
+		afterID = books[len(books)-1].ID
+		_ = reporter.UpdateProgress(1, 4, fmt.Sprintf("Phase 2/4: scanned %d books…", scanned))
 		if len(books) < page {
 			break
 		}


### PR DESCRIPTION
## STOREFID W5c — heavy-field readers → GetAllBooksFullFrom cursor

Third W5 batch (after W5a #1846, W5b #1847). Migrates the **9 `GetAllBooks` call sites across 7 files** that read a memdb-stripped HEAVY field (`Author`/`Series`/`Description`/`BookSigV1`) off every iterated book.

### Latent bug this fixes
Under prod `UseMemDB=true`, `GetAllBooks` returns the **memdb-slim projection** — heavy fields nil'd. These loops were silently reading `nil`/empty heavy fields (same class as the BookSignatureScan no-op). Each now uses `GetAllBooksFullFrom(afterID, limit)`, which fetches every book via `GetBookByID` (full Pebble JSON, memdb-bypassed). Result: heavy reads return **real data**, and any writeback writes a **full, write-safe** struct (the old slim writeback would have wiped `Author`/`Series`).

### Not compiler-certified — every site hand-reviewed
Unlike the Core waves (W5a/b), the return type stays `[]Book`, so `go build` can't prove correctness. Each site was reviewed to confirm it genuinely reads a heavy field and that pagination shape is preserved.

| File | Sites | Shape | Notes |
|---|---|---|---|
| `itunes/rebuild.go` | 3 | paged → cursor | ComputeITLDiff / RebuildITLFromDB / BuildExportITL |
| `maintenance/jobs/relink_report.go` | 1 | slurp | reads `book.Author` |
| `maintenance/jobs/dedup_books.go` | 1 | paged → cursor | `ddFetchAllBooksPaginated`; 3 writebacks now full |
| `plugins/acoustid/backfill.go` | 1 | slurp | keeps `registry.RunItems` pool |
| `plugins/acoustid/fingerprint_rescan.go` | 1 | slurp | `loadBooksForRescan` full contract |
| `plugins/maintenance/fs_regroup_xml.go` | 1 | paged → cursor | `enrichScore` reads Description |
| `plugins/maintenance/itunes_regroup.go` | 1 | paged → cursor | `enrichScore` reads Description |

Slurp sites (`GetAllBooks(0,0)`) → `GetAllBooksFullFrom("", 0)`; paged loops → server-search-style `afterID` cursor. Concurrency (RunItems), ctx-cancel, filters, progress reporting preserved byte-for-byte.

### Test hardening
`mockRebuildStore.GetAllBooksFullFrom` was an empty `return nil, nil` stub — upgraded to real sorted-ID cursor semantics so any test exercising the rebuild fetch loops uses real data (no vacuous pass).

### Verification
`go build ./...` ✅  `go vet ./...` ✅  `-race`/package tests green for itunes, maintenance/jobs, plugins/acoustid, plugins/maintenance.

`GetAllBooks` still exists; removed atomically in W5z after W5d. Rollback: revert the merge commit (package-local).

> Coordinator note: original W5c worker died mid-stream (API error) after migrating 6/7 files; coordinator finished `fingerprint_rescan.go`, caught + fixed the vacuous test-mock stub, and verified every site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)