### PR TITLE
refactor(store): ExternalIDBackfillStore.GetAllBooks → GetAllBooksCore (STOREFID W5d-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.117.0 -->
+<!-- version: 3.118.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,18 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): ExternalIDBackfillStore.GetAllBooks → GetAllBooksCore (STOREFID W5d-2)
+
+- **`refactor(store)`** — second W5d batch (Batch C). Atomically renamed the
+  `itunes.ExternalIDBackfillStore` interface method `GetAllBooks(limit,offset) []Book` →
+  `GetAllBooksCore(limit,offset) []BookCore`, across all three coupled sites in one commit: the
+  interface (`internal/itunes/backfill.go`), its sole real implementer — the
+  `externalIDStoreAdapter` in `internal/server/external_id_backfill.go` (delegates to
+  `database.Store.GetAllBooksCore`) — and the hand-rolled `MockBackfillStore`
+  (`internal/itunes/backfill_test.go`). The two callers (`BackfillExternalIDs`,
+  `BackfillITunesTrackPIDs`) read only Core-safe fields (`ITunesPersistentID`, `ID`), so the
+  retype is compile-certified. Package-local to itunes+server; no mockery mock involved.
 
 #### July 7, 2026 - refactor(store): migrate package-local GetAllBooks callers (STOREFID W5d-1)
 

--- a/internal/itunes/backfill.go
+++ b/internal/itunes/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/backfill.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b8c9d0e1-f2a3-b4c5-d6e7-f8a9b0c1d2e3
-// last-edited: 2026-06-23
+// last-edited: 2026-07-07
 
 package itunes
 
@@ -16,7 +16,9 @@ import (
 
 // ExternalIDBackfillStore defines the store interface needed for external ID backfill.
 type ExternalIDBackfillStore interface {
-	GetAllBooks(limit, offset int) ([]database.Book, error)
+	// GetAllBooksCore returns the memdb-slim projection — the backfill loops
+	// only read Core-safe fields (ITunesPersistentID, ID) off each book.
+	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
 	GetBookFiles(bookID string) ([]database.BookFile, error)
 	CreateExternalIDMapping(mapping *database.ExternalIDMapping) error
 	BulkCreateExternalIDMappings(mappings []database.ExternalIDMapping) error
@@ -51,7 +53,7 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 			slog.Info("external ID backfill canceled at offset after mappings", "offset", offset, "backfilled", backfilled, "err", err)
 			return nil
 		}
-		books, err := store.GetAllBooks(10000, offset)
+		books, err := store.GetAllBooksCore(10000, offset)
 		if err != nil || len(books) == 0 {
 			break
 		}
@@ -148,7 +150,7 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 			slog.Info("BackfillITunesTrackPIDs canceled mid-index at offset", "offset", offset)
 			return 0, nil
 		}
-		books, err := store.GetAllBooks(10000, offset)
+		books, err := store.GetAllBooksCore(10000, offset)
 		if err != nil || len(books) == 0 {
 			break
 		}

--- a/internal/itunes/backfill_test.go
+++ b/internal/itunes/backfill_test.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/backfill_test.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: c9d0e1f2-a3b4-c5d6-e7f8-a9b0c1d2e3f4
+// last-edited: 2026-07-07
 
 package itunes
 
@@ -30,17 +31,17 @@ func NewMockBackfillStore() *MockBackfillStore {
 	}
 }
 
-func (m *MockBackfillStore) GetAllBooks(limit, offset int) ([]database.Book, error) {
+func (m *MockBackfillStore) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
 	if m.hasError {
 		return nil, errMockFailure
 	}
-	var all []database.Book
+	var all []database.BookCore
 	for _, b := range m.books {
-		all = append(all, b)
+		all = append(all, b.Core())
 	}
 	// Simulate pagination via limit/offset to allow backfill loop to terminate.
 	if offset >= len(all) {
-		return []database.Book{}, nil
+		return []database.BookCore{}, nil
 	}
 	end := offset + limit
 	if end > len(all) {

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/server/external_id_backfill.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-05-11
+// last-edited: 2026-07-07
 
 package server
 
@@ -71,8 +71,8 @@ type externalIDStoreAdapter struct {
 	store    database.Store
 }
 
-func (a *externalIDStoreAdapter) GetAllBooks(limit, offset int) ([]database.Book, error) {
-	return a.store.GetAllBooks(limit, offset)
+func (a *externalIDStoreAdapter) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
+	return a.store.GetAllBooksCore(limit, offset)
 }
 
 func (a *externalIDStoreAdapter) GetBookFiles(bookID string) ([]database.BookFile, error) {


### PR DESCRIPTION
## STOREFID W5d-2 — ExternalIDBackfillStore (Batch C)

Second of three W5d batches. **Atomically** renames the `itunes.ExternalIDBackfillStore` interface method `GetAllBooks(limit,offset) []Book` → `GetAllBooksCore(limit,offset) []BookCore` across all three coupled sites in one commit (a partial rename breaks structural interface satisfaction silently):

- **Interface** — `internal/itunes/backfill.go`
- **Sole implementer** — `externalIDStoreAdapter` in `internal/server/external_id_backfill.go` (delegates to `database.Store.GetAllBooksCore`, which exists from W5a)
- **Hand-rolled mock** — `MockBackfillStore` in `internal/itunes/backfill_test.go` (fixture `.Core()`'d)

The two callers (`BackfillExternalIDs`, `BackfillITunesTrackPIDs`) read only Core-safe fields (`ITunesPersistentID`, `ID`), so the retype is **compile-certified**. Package-local to itunes + server; **no mockery-generated mock** touched (that's W5d-3).

### Verification
`go build ./...` ✅  `go vet ./...` ✅  itunes + server backfill/external-ID tests green (the mock exercises `GetAllBooksCore` and asserts mappings are created — not vacuous).

`GetAllBooks` on `database.Store` still exists; removed in W5z after W5d-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)