### PR TITLE
refactor(store): diagnostics CollectAllBooks → GetAllBooksCore (STOREFID W5d-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.118.0 -->
+<!-- version: 3.119.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,29 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): diagnostics CollectAllBooks → GetAllBooksCore (STOREFID W5d-3, final GetAllBooks batch)
+
+- **`refactor(store)`** — last of the three W5d batches (Batch D). Retyped
+  `internal/diagnostics.Service.CollectAllBooks() []Book` → `[]BookCore`, with its internal paged loop
+  now calling `GetAllBooksCore` instead of `GetAllBooks`. `ToSlimBook`, `writeBooks`, `writeBatchJSONL`,
+  `writeVersionGroups`, and `writeMissingFields` all retyped their `[]database.Book` params to
+  `[]database.BookCore`. `ToSlimBook` was pre-verified to read only Core-safe fields (ID, Title,
+  AuthorID, Narrator, SeriesID, Format, Duration, FilePath, FileSize, VersionGroupID,
+  IsPrimaryVersion, WorkID, ITunesPersistentID, AudiobookReleaseYear, Publisher, LibraryState,
+  MarkedForDeletion) — a clean compile-certified retype, no hydrate needed (read-only export path,
+  no writeback).
+- **Shared-interface + mockery ripple:** `DiagnosticsService` in
+  `internal/server/handlers/diagnostics.go` retyped to `CollectAllBooks() ([]database.BookCore,
+  error)`; `make mocks` regenerated only `internal/server/handlers/mocks/mock_diagnostics_service.go`
+  (verified via `git diff --name-only`). Updated the hand-written test literal in
+  `diagnostics_test.go` and the `GetAllBooks`→`GetAllBooksCore` mock expectations in
+  `internal/diagnostics/service_test.go`.
+- **This closes W5 caller migration:** all `GetAllBooks` callers identified in the original 60-site
+  audit are now migrated (W5a add + 45 safe callers, W5b 12 writeback/DUAL sites, W5c 9 heavy-field
+  readers via `GetAllBooksFullFrom` cursor, W5d-1/2/3 the remaining cross-package/exported-signature
+  sites). `GetAllBooks` itself still exists on the interface — removing it is W5z, whose red
+  `go build` at removal is the actual completeness proof that no caller was missed.
 
 #### July 7, 2026 - refactor(store): ExternalIDBackfillStore.GetAllBooks → GetAllBooksCore (STOREFID W5d-2)
 

--- a/internal/diagnostics/service.go
+++ b/internal/diagnostics/service.go
@@ -1,6 +1,7 @@
 // file: internal/diagnostics/service.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: d1a9n0st-1cs0-s3rv-1c3z-1pexp0rt001
+// last-edited: 2026-07-07
 
 package diagnostics
 
@@ -52,8 +53,8 @@ type SlimBook struct {
 	MarkedForDeletion    *bool   `json:"marked_for_deletion,omitempty"`
 }
 
-// ToSlimBook converts a database.Book to a SlimBook.
-func ToSlimBook(b database.Book) SlimBook {
+// ToSlimBook converts a database.BookCore to a SlimBook.
+func ToSlimBook(b database.BookCore) SlimBook {
 	return SlimBook{
 		ID:                   b.ID,
 		Title:                b.Title,
@@ -235,13 +236,13 @@ func (ds *Service) GenerateExport(category, description string) (string, error) 
 	return zipPath, nil
 }
 
-// CollectAllBooks paginates through GetAllBooks until no more results.
-func (ds *Service) CollectAllBooks() ([]database.Book, error) {
+// CollectAllBooks paginates through GetAllBooksCore until no more results.
+func (ds *Service) CollectAllBooks() ([]database.BookCore, error) {
 	const pageSize = 10000
-	var allBooks []database.Book
+	var allBooks []database.BookCore
 	offset := 0
 	for {
-		books, err := ds.db.GetAllBooks(pageSize, offset)
+		books, err := ds.db.GetAllBooksCore(pageSize, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -293,7 +294,7 @@ func (ds *Service) writeSystemInfo(zw *zip.Writer, category, description string)
 	return WriteJSON(zw, "system_info.json", info)
 }
 
-func (ds *Service) writeBooks(zw *zip.Writer, allBooks []database.Book) error {
+func (ds *Service) writeBooks(zw *zip.Writer, allBooks []database.BookCore) error {
 	slim := make([]SlimBook, len(allBooks))
 	for i, b := range allBooks {
 		slim[i] = ToSlimBook(b)
@@ -356,7 +357,7 @@ func (ds *Service) writeSeries(zw *zip.Writer) error {
 }
 
 // writeBatchJSONL writes a batch.jsonl file based on current category and books.
-func (ds *Service) writeBatchJSONL(zw *zip.Writer, category, description string, allBooks []database.Book) error {
+func (ds *Service) writeBatchJSONL(zw *zip.Writer, category, description string, allBooks []database.BookCore) error {
 	slimBooks := make([]SlimBook, len(allBooks))
 	for i, b := range allBooks {
 		slimBooks[i] = ToSlimBook(b)
@@ -395,7 +396,7 @@ func (ds *Service) writeOperations(zw *zip.Writer) error {
 	return WriteJSON(zw, "operations.json", ops)
 }
 
-func (ds *Service) writeVersionGroups(zw *zip.Writer, allBooks []database.Book) error {
+func (ds *Service) writeVersionGroups(zw *zip.Writer, allBooks []database.BookCore) error {
 	groups := map[string][]SlimBook{}
 	for _, b := range allBooks {
 		if b.VersionGroupID != nil && *b.VersionGroupID != "" {
@@ -445,7 +446,7 @@ func (ds *Service) writeITunesAlbums(zw *zip.Writer) error {
 	return WriteJSON(zw, "itunes_albums.json", result)
 }
 
-func (ds *Service) writeMissingFields(zw *zip.Writer, allBooks []database.Book) error {
+func (ds *Service) writeMissingFields(zw *zip.Writer, allBooks []database.BookCore) error {
 	var missing []missingFieldEntry
 	for _, b := range allBooks {
 		var fields []string

--- a/internal/diagnostics/service_test.go
+++ b/internal/diagnostics/service_test.go
@@ -1,6 +1,7 @@
 // file: internal/diagnostics/service_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: d1a9n0st-1cs0-t3st-s3rv-1c3t3st0001
+// last-edited: 2026-07-07
 
 package diagnostics
 
@@ -22,10 +23,10 @@ import (
 
 func setupDiagnosticsMocks(t *testing.T) *dbmocks.MockStore {
 	store := dbmocks.NewMockStore(t)
-	store.EXPECT().GetAllBooks(10000, 0).Return([]database.Book{
+	store.EXPECT().GetAllBooksCore(10000, 0).Return([]database.BookCore{
 		{ID: "book1", Title: "Test Book"},
 	}, nil).Maybe()
-	store.EXPECT().GetAllBooks(10000, 10000).Return([]database.Book{}, nil).Maybe()
+	store.EXPECT().GetAllBooksCore(10000, 10000).Return([]database.BookCore{}, nil).Maybe()
 	store.EXPECT().GetAllAuthors().Return([]database.Author{}, nil).Maybe()
 	store.EXPECT().GetAllSeries().Return([]database.Series{}, nil).Maybe()
 	store.EXPECT().GetAllAuthorBookCounts().Return(map[int]int{}, nil).Maybe()
@@ -150,14 +151,14 @@ func TestService_GenerateExport_MetadataQuality(t *testing.T) {
 
 	authorID := 1
 	seriesID := 1
-	store.EXPECT().GetAllBooks(10000, 0).Unset()
-	store.EXPECT().GetAllBooks(10000, 0).Return([]database.Book{
+	store.EXPECT().GetAllBooksCore(10000, 0).Unset()
+	store.EXPECT().GetAllBooksCore(10000, 0).Return([]database.BookCore{
 		{ID: "book1", Title: "Complete Book", AuthorID: &authorID, SeriesID: &seriesID},
 		{ID: "book2", Title: "", AuthorID: nil},          // missing title, author, series
 		{ID: "book3", Title: "No Author", AuthorID: nil}, // missing author, series
 	}, nil).Maybe()
-	store.EXPECT().GetAllBooks(10000, 10000).Unset()
-	store.EXPECT().GetAllBooks(10000, 10000).Return([]database.Book{}, nil).Maybe()
+	store.EXPECT().GetAllBooksCore(10000, 10000).Unset()
+	store.EXPECT().GetAllBooksCore(10000, 10000).Return([]database.BookCore{}, nil).Maybe()
 	store.EXPECT().CountPrimaryBooks().Unset()
 	store.EXPECT().CountPrimaryBooks().Return(3, nil).Maybe()
 

--- a/internal/server/handlers/diagnostics.go
+++ b/internal/server/handlers/diagnostics.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/diagnostics.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 14e70c44-73ca-456a-bc67-8dc6ba6e5736
-// last-edited: 2026-06-16
+// last-edited: 2026-07-07
 
 // DiagnosticsHandler hosts the diagnostics HTTP endpoints extracted from the
 // server package: ZIP export start/download, AI batch submit + results, applying
@@ -37,7 +37,7 @@ import (
 // the diagnostics service. Only CollectAllBooks is called by the handlers; the
 // concrete *diagnostics.Service satisfies it.
 type DiagnosticsService interface {
-	CollectAllBooks() ([]database.Book, error)
+	CollectAllBooks() ([]database.BookCore, error)
 }
 
 // MergeService is the narrow interface DiagnosticsHandler requires from the

--- a/internal/server/handlers/diagnostics_test.go
+++ b/internal/server/handlers/diagnostics_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/diagnostics_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8ab4b825-05c3-4569-b450-0dca6b872771
-// last-edited: 2026-06-03
+// last-edited: 2026-07-07
 
 package handlers_test
 
@@ -139,7 +139,7 @@ func TestDiagnosticsHandler_SubmitAI_NilParserFallback(t *testing.T) {
 		Run(func(_ string, _ string, _ int, _ int, _ string) { close(done) }).
 		Return(nil)
 
-	diagSvc.EXPECT().CollectAllBooks().Return([]database.Book{{ID: "b1", Title: "X"}}, nil)
+	diagSvc.EXPECT().CollectAllBooks().Return([]database.BookCore{{ID: "b1", Title: "X"}}, nil)
 
 	// batchParser is nil → the no-parser fallback path.
 	h := handlers.NewDiagnosticsHandler(store, diagSvc, nil, nil, nil, nil, nil)

--- a/internal/server/handlers/mocks/mock_diagnostics_service.go
+++ b/internal/server/handlers/mocks/mock_diagnostics_service.go
@@ -37,23 +37,23 @@ func (_m *MockDiagnosticsService) EXPECT() *MockDiagnosticsService_Expecter {
 }
 
 // CollectAllBooks provides a mock function for the type MockDiagnosticsService
-func (_mock *MockDiagnosticsService) CollectAllBooks() ([]database.Book, error) {
+func (_mock *MockDiagnosticsService) CollectAllBooks() ([]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for CollectAllBooks")
 	}
 
-	var r0 []database.Book
+	var r0 []database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
+			r0 = ret.Get(0).([]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -81,12 +81,12 @@ func (_c *MockDiagnosticsService_CollectAllBooks_Call) Run(run func()) *MockDiag
 	return _c
 }
 
-func (_c *MockDiagnosticsService_CollectAllBooks_Call) Return(books []database.Book, err error) *MockDiagnosticsService_CollectAllBooks_Call {
-	_c.Call.Return(books, err)
+func (_c *MockDiagnosticsService_CollectAllBooks_Call) Return(bookCores []database.BookCore, err error) *MockDiagnosticsService_CollectAllBooks_Call {
+	_c.Call.Return(bookCores, err)
 	return _c
 }
 
-func (_c *MockDiagnosticsService_CollectAllBooks_Call) RunAndReturn(run func() ([]database.Book, error)) *MockDiagnosticsService_CollectAllBooks_Call {
+func (_c *MockDiagnosticsService_CollectAllBooks_Call) RunAndReturn(run func() ([]database.BookCore, error)) *MockDiagnosticsService_CollectAllBooks_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Last of the three W5d batches (Batch D), and the final `GetAllBooks` caller migration for STOREFID W5.
- `internal/diagnostics.Service.CollectAllBooks` and its consumers (`ToSlimBook`, `writeBooks`, `writeBatchJSONL`, `writeVersionGroups`, `writeMissingFields`) retype `[]database.Book` → `[]database.BookCore`; internal paged loop now calls `GetAllBooksCore`.
- `ToSlimBook` was pre-verified (this session's resume note) to read only Core-safe fields — clean compile-certified retype, no writeback, no hydrate needed.
- `DiagnosticsService` interface in `internal/server/handlers/diagnostics.go` retyped accordingly; `make mocks` regenerated only `mock_diagnostics_service.go` (verified via `git diff --name-only`).
- Test literal in `diagnostics_test.go` and `GetAllBooks` mock expectations in `internal/diagnostics/service_test.go` updated to `BookCore`.

This closes W5 caller migration — all known `GetAllBooks` callers from the original 60-site audit are migrated (W5a add + 45 safe, W5b 12 writeback/DUAL, W5c 9 heavy-field readers via cursor, W5d-1/2/3 remaining cross-package/exported-signature sites). `GetAllBooks` itself still exists on the interface; removing it is W5z, whose red `go build` at removal is the actual completeness proof.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/diagnostics/... ./internal/server/handlers/...` — all pass
- [x] `go test ./... -short` full suite — 97 packages ok; `internal/server` alone hit the known local 10m timeout (matches session resume note: "300–520s but passes locally, rely on CI's race job"), re-ran `internal/server` standalone with `-timeout=900s` → passes in 520.497s, confirming pre-existing slowness unrelated to this change, not a regression
- [ ] GitHub Minimal CI + Mock Freshness (gating below)

https://claude.ai/code/session_01RNwRWHnTvMYr34mpJGxPAe