### PR TITLE
refactor(store): 3 remaining getters → Core, closes STOREFID W6 + PR-D (fingerprint-wipe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.120.0 -->
+<!-- version: 3.121.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,64 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - refactor(store): 3 remaining getters → Core, closes STOREFID W6 + PR-D (fingerprint-wipe)
+
+- **`refactor(store)`** — STOREFID W6: the last 3 non-`GetAllBooks` slim getters retyped to Core,
+  following the same direct-rename pattern used for W1/W3/W4 (small caller counts, no interim
+  dual-existence period needed):
+  - `GetBookFilesNeedingDelugeImport` → `GetBookFilesNeedingDelugeImportCore` (`[]BookFileCore`).
+    The existing SLIM strip set documented on this getter was verified to match `BookFileCore`'s
+    strip set exactly (`FingerprintFailureReason/Detail/DiagnosticJSON`, `AcoustIDFingerprint`,
+    `AcoustIDSeg0..6`, retaining `FingerprintFailedAt`/`AcoustIDFingerprintDurationSec`) — a clean,
+    compile-certified fit. `PebbleStore`'s old body called `s.mem().GetBookFilesNeedingDelugeImport`
+    which itself now returns `BookFileCore` via `.Core()`.
+  - `GetFolderDuplicates`/`GetDuplicateBooksByMetadata` → `...Core` (`[][]BookCore`). **New finding
+    during this retype: neither getter has a `MemStore` implementation at all** — `PebbleStore`'s
+    versions are hard stub `return nil, nil` regardless of `UseMemDB`, meaning folder-based and
+    metadata-based duplicate-book detection are non-functional no-ops in production today. This is
+    a pre-existing gap unrelated to STOREFID (tracked as a new TODO item, not fixed here — fixing it
+    means implementing real detection logic, a materially different task than a type retype).
+    `internal/dedup/book_dedup.go` and `internal/audiobooks/service_single.go` convert the Core
+    result to `[]Book` immediately at the store boundary via a small `coreGroupsToBookGroups`
+    helper (one copy per package) — the shared merge/tiebreaker pipeline and the public
+    `BookDupGroup.Books []database.Book` JSON contract are untouched, and every function that
+    touches the merged groups was verified to read only Core-safe fields (Title, AuthorID via a
+    separate `GetAuthorByID` call — never `book.Author` — and `TranscribedTitle`).
+- **This retype also force-surfaced and closes PR-D** (the deluge import fingerprint-wipe
+  fast-follow tracked since STOREFID W3, 2026-07-06): `GetBookFilesNeedingDelugeImportCore`'s
+  narrower return type made the `UpdateBookFile(bf.ID, bf)` writeback in all 3 known impls a
+  compile error (a `*BookFileCore` can't stand in for the `*BookFile` those write paths need)
+  rather than a silent runtime wipe. Fixed all 3 with the standard hydrate-mutate-update pattern
+  (`GetBookFileByID(bookID, fileID)` before mutating `DelugeOriginalPath`/`FilePath`/
+  `ImportedFromDelugeAt` and writing back the full row):
+  `internal/plugins/deluge/centralization.go` (inline `RunItems` closure),
+  `internal/server/deluge_discovery.go` (`handleDelugeImport` before calling
+  `deluge.ImportToLibrary`), `internal/maintenance/jobs/bulk_deluge_import.go` (before calling the
+  package-local `bdi_importToLibrary`). Both `ImportToLibrary` and `bdi_importToLibrary` keep their
+  existing `*database.BookFile` signatures unchanged — the hydrate happens at each call site, not
+  inside the shared helpers, since `ImportToLibrary` is exported and used more widely.
+- **Regression test added** (`internal/plugins/deluge/centralization_test.go`,
+  `TestRunCentralization_HydratesBeforeWriteback`): seeds a `BookFile` with
+  `FingerprintDiagnosticJSON` set, runs it through `runCentralization`, and asserts the field
+  survives the `UpdateBookFile` writeback. Manually verified this test fails on the pre-fix
+  behavior (a naive Core→`UpdateBookFile` writeback with no hydrate) before confirming it passes
+  with the actual fix — the wipe was invisible to the existing suite precisely because nothing
+  asserted on it. Required adding `GetBookFilesNeedingDelugeImportCoreFunc` to `MockStore` (it was
+  previously a hard stub with no test seam).
+- `make mocks` regenerated 5 files (verified via `git diff --name-only`): `mock_store.go`
+  (MockBookFileStore/MockBookReader/MockBookStore/MockStore), `mock_reading_store.go`,
+  `mock_metadata_store.go`, `mock_playlist_store.go`, `mock_operations_store.go`.
+- 18 hand-edited files fixed by the resulting red build (interface, 2 storage-backend impls, 2
+  production writeback call sites, and 13 test/mock files), all confirmed Core-safe before
+  retyping. Full suite green: `internal/database`/`internal/dedup`/`internal/audiobooks` and 9
+  other directly-touched packages all `ok`; `internal/server` verified separately at 467.900s
+  (matches this session's established "300–520s but passes locally" pattern); remaining 74
+  packages `ok`, 0 FAIL.
+- This closes STOREFID W6 (the last 3 slim getters) and PR-D (deluge fingerprint-wipe) in the same
+  PR. Remaining STOREFID work: Phase-4 naming lint (no exported getter should return a full
+  `Book`/`BookFile` while delegating to memdb — spot-check every `p.mem()` call site's exported
+  wrapper return type).
 
 #### July 7, 2026 - refactor(store): remove GetAllBooks entirely (STOREFID W5z)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.69.0 -->
+<!-- version: 9.70.1 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -46,20 +46,40 @@ future agent) can scan the entire workspace in one page.
 - Same writeback shape as the W5d-1 organizer writebacks that DID get the `hydrateAndUpdateBook`
   helper; this one was deliberately left out pending the fail-open design above.
 
-## 🟠 PR-D: deluge import fingerprint-wipe (3 impls) — fast-follow after STOREFID W3 (2026-07-06)
+## ✅ PR-D: deluge import fingerprint-wipe (3 impls) — RESOLVED (STOREFID W6, 2026-07-07)
 
-- **NEW finding** during STOREFID W3 caller audit. Three deluge import paths read a
-  BookFile from `GetBookFilesNeedingDelugeImport` (memdb-slim in prod) and write it
-  back via `UpdateBookFile`, wiping fingerprint **diagnostic** fields (the
-  `AcoustIDFingerprint` blob is guarded by PR-A #1839):
-  - `internal/deluge/import.go` `ImportToLibrary` (~L68-72)
-  - `internal/maintenance/jobs/bulk_deluge_import.go` `bdi_importToLibrary` (~L200-202)
-  - `internal/plugins/deluge/centralization.go` (~L144-146)
-- **Fix:** hydrate the full row via `GetBookFiles(bookID)` at each writeback point
-  (same shape as the W3 jobs). Do NOT make the getter return full via bulk hydrate —
-  `maxBooks` defaults to 0 (uncapped) and caps AFTER the getter, so a full-blob slice
-  would reintroduce the memdb RAM anti-pattern.
-- Root cause + census: `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.
+- **Fixed as a side effect of STOREFID W6's `GetBookFilesNeedingDelugeImport` → Core retype**:
+  the narrower `BookFileCore` return type made the `UpdateBookFile(bf.ID, bf)` writeback in all 3
+  impls a compile error, forcing (not just documenting) the hydrate fix at the same time as the
+  retype. Fixed via `GetBookFileByID(bookID, fileID)` hydrate-mutate-update at each call site:
+  `internal/plugins/deluge/centralization.go`, `internal/server/deluge_discovery.go` (before
+  calling `deluge.ImportToLibrary`), `internal/maintenance/jobs/bulk_deluge_import.go` (before
+  calling `bdi_importToLibrary`). `ImportToLibrary`/`bdi_importToLibrary` signatures unchanged.
+- Regression test: `internal/plugins/deluge/centralization_test.go`
+  `TestRunCentralization_HydratesBeforeWriteback` covers the `centralization.go` path only
+  (seeds `FingerprintDiagnosticJSON`, asserts it survives `UpdateBookFile`; manually verified to
+  fail against the pre-fix naive writeback). The other 2 impls (`deluge_discovery.go`,
+  `bulk_deluge_import.go`) share the identical hydrate pattern but do not yet have their own
+  regression tests — same shape, could be added as a follow-up if one of them regresses.
+- Root cause + census (historical): `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.
+
+## 🟠 GetFolderDuplicates / GetDuplicateBooksByMetadata are no-op stubs in production (found 2026-07-07)
+
+- **NEW finding** during STOREFID W6's Core retype of these 2 getters. `PebbleStore.GetFolderDuplicatesCore`
+  and `PebbleStore.GetDuplicateBooksByMetadataCore` (`internal/database/pebble_store.go`) are hard
+  `return nil, nil` stubs — **no `MemStore` implementation exists for either getter**, so unlike
+  every other slim getter in this codebase, these two ALWAYS return empty regardless of
+  `UseMemDB`. Folder-based duplicate detection (same title, same folder — e.g. M4B + MP3 pairs) and
+  metadata-based fuzzy duplicate detection are therefore non-functional in production today; only
+  hash-based duplicate detection (`GetDuplicateBooks`) actually works.
+  Callers: `internal/dedup/book_dedup.go` (`ScanBookDuplicates`, tiers 2 and 3 of the 3-tier scan),
+  `internal/audiobooks/service_single.go` (`GetDuplicateBooks`).
+- **Not fixed as part of W6** — implementing real folder/metadata duplicate detection is a
+  materially different task than a type retype (the retype only made the existing no-op behavior
+  Core-typed; the STOREFID work does not change or fix this gap). Needs its own scoped design:
+  folder-based detection would need a folder→books index or a scan; metadata-based detection
+  already has full fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
+  `metadataPairSimilarity`) that's just never fed any candidates today.
 
 ## 🟡 Verify DurationSec invariant for the 3 PR-B fingerprint ops (2026-07-06)
 

--- a/internal/audiobooks/audiobook_service_unit_test.go
+++ b/internal/audiobooks/audiobook_service_unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/audiobook_service_unit_test.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package audiobooks
 
@@ -390,7 +390,7 @@ func TestAudiobookService_GetDuplicateBooks_NoDuplicates(t *testing.T) {
 	svc := NewAudiobookService(mockStore)
 
 	mockStore.EXPECT().GetDuplicateBooks().Return(nil, nil)
-	mockStore.EXPECT().GetFolderDuplicates().Return(nil, nil)
+	mockStore.EXPECT().GetFolderDuplicatesCore().Return(nil, nil)
 
 	result, err := svc.GetDuplicateBooks(context.Background())
 	assert.NoError(t, err)
@@ -409,7 +409,7 @@ func TestAudiobookService_GetDuplicateBooks_CountsCorrectly(t *testing.T) {
 		{{ID: "d"}, {ID: "e"}},            // 1 duplicate
 	}
 	mockStore.EXPECT().GetDuplicateBooks().Return(groups, nil)
-	mockStore.EXPECT().GetFolderDuplicates().Return(nil, nil)
+	mockStore.EXPECT().GetFolderDuplicatesCore().Return(nil, nil)
 
 	result, err := svc.GetDuplicateBooks(context.Background())
 	assert.NoError(t, err)

--- a/internal/audiobooks/service_single.go
+++ b/internal/audiobooks/service_single.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_single.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: d6a0e5f4-a7b8-9c01-bd2e-3f4a5b6c7d8e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package audiobooks
 
@@ -207,6 +207,27 @@ func (svc *AudiobookService) extractBookFileMetadata(book *database.Book, author
 	return m
 }
 
+// coreGroupsToBookGroups widens [][]database.BookCore to [][]database.Book
+// via .ToBook() (heavy fields left at their zero value — never populated by
+// GetFolderDuplicatesCore in the first place, so this is not a lossy
+// conversion). Used at the store boundary so the shared merge logic below
+// (which only reads b.ID and stays []Book to match GetDuplicateBooks)
+// doesn't need its own Core variant.
+func coreGroupsToBookGroups(groups [][]database.BookCore) [][]database.Book {
+	if groups == nil {
+		return nil
+	}
+	out := make([][]database.Book, len(groups))
+	for i, group := range groups {
+		converted := make([]database.Book, len(group))
+		for j, c := range group {
+			converted[j] = c.ToBook()
+		}
+		out[i] = converted
+	}
+	return out
+}
+
 // GetDuplicateBooks retrieves all duplicate book groups
 func (svc *AudiobookService) GetDuplicateBooks(ctx context.Context) (*DuplicatesResult, error) {
 	if svc.store == nil {
@@ -222,8 +243,13 @@ func (svc *AudiobookService) GetDuplicateBooks(ctx context.Context) (*Duplicates
 		duplicateGroups = [][]database.Book{}
 	}
 
-	// Get folder-based duplicates (same title in same folder, e.g. M4B + MP3)
-	folderGroups, err := svc.store.GetFolderDuplicates()
+	// Get folder-based duplicates (same title in same folder, e.g. M4B + MP3).
+	// Converted immediately at the store boundary — everything below only
+	// reads b.ID (Core-safe), so .ToBook() is a lossless widen, not the
+	// hydrate-before-writeback landmine (this path only reports duplicate
+	// groups; it never writes a book back).
+	folderGroupsCore, err := svc.store.GetFolderDuplicatesCore()
+	folderGroups := coreGroupsToBookGroups(folderGroupsCore)
 	if err != nil {
 		slog.Warn("folder duplicate detection failed", "err", err)
 	} else {

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,5 +1,5 @@
 // file: internal/batch/service_test.go
-// version: 1.0.8
+// version: 1.0.9
 // last-edited: 2026-07-07
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
@@ -104,8 +104,8 @@ func (m *MockBookStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]str
 func (m *MockBookStore) GetBookByOriginalHash(hash string) (*database.Book, error)  { return nil, nil }
 func (m *MockBookStore) GetBookByOrganizedHash(hash string) (*database.Book, error) { return nil, nil }
 func (m *MockBookStore) GetDuplicateBooks() ([][]database.Book, error)              { return nil, nil }
-func (m *MockBookStore) GetFolderDuplicates() ([][]database.Book, error)            { return nil, nil }
-func (m *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+func (m *MockBookStore) GetFolderDuplicatesCore() ([][]database.BookCore, error)    { return nil, nil }
+func (m *MockBookStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	return nil, nil
 }
 func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]database.Book, error) {

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_book.go
-// version: 2.9.0
+// version: 2.10.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
 // last-edited: 2026-07-07
 
@@ -51,12 +51,15 @@ type BookReader interface {
 	GetBookByOriginalHash(hash string) (*Book, error)
 	GetBookByOrganizedHash(hash string) (*Book, error)
 	GetDuplicateBooks() ([][]Book, error)
-	// GetFolderDuplicates is SLIM (memdb projection) — see
+	// GetFolderDuplicatesCore is Core-typed (STOREFID W6): the return type is
+	// BookCore, not Book, so the nine heavy fields being absent is
+	// compiler-enforced rather than silently nil'd. A caller that needs any
+	// of the heavy fields MUST fetch via GetBookByID (full Pebble). See
 	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetFolderDuplicates() ([][]Book, error)
-	// GetDuplicateBooksByMetadata is SLIM (memdb projection) — see
-	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error)
+	GetFolderDuplicatesCore() ([][]BookCore, error)
+	// GetDuplicateBooksByMetadataCore is Core-typed (STOREFID W6): see
+	// GetFolderDuplicatesCore's doc comment.
+	GetDuplicateBooksByMetadataCore(threshold float64) ([][]BookCore, error)
 	GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]Book, error)
 	// GetBooksBySeriesIDCore is Core-typed (STOREFID W4): the return type is
 	// BookCore, not Book, so the nine heavy fields (Description,

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -141,12 +141,17 @@ type BookFileStore interface {
 	// BookFileCore return type makes reading a stripped fingerprint field a
 	// compile error instead of a silent nil.
 	GetAllBookFilesCore() ([]BookFileCore, error)
-	// GetBookFilesNeedingDelugeImport returns book_files that have a deluge_hash
-	// but have not yet been copied into the library (imported_from_deluge_at IS NULL).
-	//
-	// SLIM (memdb projection) — see
-	// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-	GetBookFilesNeedingDelugeImport() ([]BookFile, error)
+	// GetBookFilesNeedingDelugeImportCore returns book_files that have a
+	// deluge_hash but have not yet been copied into the library
+	// (imported_from_deluge_at IS NULL). Core-typed (STOREFID W6): the return
+	// type is BookFileCore, not BookFile, so the heavy fingerprint-diagnostic
+	// fields (FingerprintFailureReason/Detail/DiagnosticJSON,
+	// AcoustIDFingerprint, AcoustIDSeg0..6) being absent is compiler-enforced
+	// rather than silently nil'd (FingerprintFailedAt and
+	// AcoustIDFingerprintDurationSec are retained on Core). A caller that
+	// needs any of the stripped fields MUST fetch via GetBookFiles(bookID)
+	// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
+	GetBookFilesNeedingDelugeImportCore() ([]BookFileCore, error)
 	GetBookFileByID(bookID, fileID string) (*BookFile, error)
 	GetBookFileByPID(itunesPID string) (*BookFile, error)
 	// ClearITunesPID surgically clears itunes_persistent_id and itunes_path

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
 // last-edited: 2026-07-07
 
@@ -866,8 +866,9 @@ func (m *MemStore) GetAllBookFilesCore() ([]BookFileCore, error) {
 	return files, nil
 }
 
-// GetBookFilesNeedingDelugeImport returns BookFiles that have a non-empty
-// DelugeHash AND have not yet been imported (ImportedFromDelugeAt is nil).
+// GetBookFilesNeedingDelugeImportCore returns BookFileCores that have a
+// non-empty DelugeHash AND have not yet been imported (ImportedFromDelugeAt
+// is nil). Core-typed (STOREFID W6) — see the interface doc comment.
 //
 // Walks the sparse memdb deluge_hash index — only rows with a non-empty
 // DelugeHash exist in that index — then post-filters on the
@@ -875,14 +876,14 @@ func (m *MemStore) GetAllBookFilesCore() ([]BookFileCore, error) {
 // O(308K), which mirrors the GetAllBookFiles fastpath from PR #1166 but
 // trims the working set to the deluge-relevant subset for the discovery
 // handler and centralization plugin (H2 + H8).
-func (m *MemStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+func (m *MemStore) GetBookFilesNeedingDelugeImportCore() ([]BookFileCore, error) {
 	txn := m.db.Txn(false)
 	defer txn.Abort()
 	iter, err := txn.Get(memTableBookFiles, memIdxDelugeHash)
 	if err != nil {
 		return nil, fmt.Errorf("memdb deluge_hash scan: %w", err)
 	}
-	var out []BookFile
+	var out []BookFileCore
 	for obj := iter.Next(); obj != nil; obj = iter.Next() {
 		bf, ok := obj.(*BookFile)
 		if !ok {
@@ -891,7 +892,7 @@ func (m *MemStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
 		if bf.ImportedFromDelugeAt != nil {
 			continue
 		}
-		out = append(out, *bf)
+		out = append(out, bf.Core())
 	}
 	return out, nil
 }

--- a/internal/database/memdb_reads_test.go
+++ b/internal/database/memdb_reads_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_reads_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000007
 // last-edited: 2026-07-07
 
@@ -253,7 +253,7 @@ func TestMemStore_CountFiles(t *testing.T) {
 	}
 }
 
-func TestMemStore_GetBookFilesNeedingDelugeImport(t *testing.T) {
+func TestMemStore_GetBookFilesNeedingDelugeImportCore(t *testing.T) {
 	m, err := NewMemStore()
 	if err != nil {
 		t.Fatalf("NewMemStore: %v", err)
@@ -274,9 +274,9 @@ func TestMemStore_GetBookFilesNeedingDelugeImport(t *testing.T) {
 	}
 	seedMemStore(t, m, nil, files, nil, nil)
 
-	got, err := m.GetBookFilesNeedingDelugeImport()
+	got, err := m.GetBookFilesNeedingDelugeImportCore()
 	if err != nil {
-		t.Fatalf("GetBookFilesNeedingDelugeImport: %v", err)
+		t.Fatalf("GetBookFilesNeedingDelugeImportCore: %v", err)
 	}
 	gotIDs := map[string]bool{}
 	for _, f := range got {

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.75.0
+// version: 1.77.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-07
 
@@ -32,7 +32,7 @@ var _ Store = (*MockStore)(nil)
 // MockStore is a simple mock implementation for testing services
 type MockStore struct {
 	// Book methods
-	GetBookByIDFunc                 func(id string) (*Book, error)
+	GetBookByIDFunc       func(id string) (*Book, error)
 	GetBookByFilePathFunc func(path string) (*Book, error)
 	// GetAllBooksFunc is test-only plumbing (NOT a Store interface method —
 	// GetAllBooks was removed from the interface in STOREFID W5z). Several
@@ -58,7 +58,7 @@ type MockStore struct {
 	RevertBookToVersionFunc         func(id string, ts time.Time) (*Book, error)
 	PruneBookVersionsFunc           func(id string, keepCount int) (int, error)
 	GetDuplicateBooksFunc           func() ([][]Book, error)
-	GetDuplicateBooksByMetadataFunc func(threshold float64) ([][]Book, error)
+	GetDuplicateBooksByMetadataFunc func(threshold float64) ([][]BookCore, error)
 	CreateBookFunc                  func(book *Book) (*Book, error)
 	UpdateBookFunc                  func(id string, book *Book) (*Book, error)
 	UpdateBookRatingError           error
@@ -345,30 +345,31 @@ type MockStore struct {
 	BulkCreateExternalIDMappingsFunc func(mappings []ExternalIDMapping) error
 
 	// BookFile methods
-	CreateBookFileFunc                  func(file *BookFile) error
-	GetAllBookFilesCoreFunc             func() ([]BookFileCore, error)
-	UpdateBookFileFunc                  func(id string, file *BookFile) error
-	UpdateBookFileHashesFunc            func(id, originalHash, postMetadataHash string) error
-	GetBookFilesFunc                    func(bookID string) ([]BookFile, error)
-	GetBookFileByIDFunc                 func(bookID, fileID string) (*BookFile, error)
-	GetBookFileByPIDFunc                func(itunesPID string) (*BookFile, error)
-	ClearITunesPIDFunc                  func(itunesPID string) (bool, error)
-	GetBookFileByPathFunc               func(filePath string) (*BookFile, error)
-	MarkFileImportedFromDelugeFunc      func(ctx context.Context, originalPath, libraryPath, torrentHash string) error
-	GetBookFileByAcoustIDFunc           func(fingerprint string) (*BookFile, error)
-	GetBookFileByAcoustIDFuzzyFunc      func(fingerprint string, minSimilarity float64) (*BookFile, error)
-	DeleteBookFileFunc                  func(id string) error
-	DeleteBookFilesForBookFunc          func(bookID string) error
-	UpsertBookFileFunc                  func(file *BookFile) error
-	BatchUpsertBookFilesFunc            func(files []*BookFile) error
-	MoveBookFilesToBookFunc             func(fileIDs []string, sourceBookID, targetBookID string) error
-	GetDuplicateFilesByHashFunc         func(limit int) ([]DuplicateFileGroup, error)
-	GetBookBySegmentFileHashFunc        func(hash string) (*Book, error)
-	SetBookFileHashFunc                 func(id, hash string) error
-	GetBookFileHashStatsFunc            func() (*BookFileHashStats, error)
-	GetBookMetadataHashStatsFunc        func() (*BookMetadataHashStats, error)
-	GetFilesWithFingerprintFailuresFunc func(reason string, limit, offset int) ([]BookFile, int64, error)
-	GetAcoustIDStatsFunc                func() (*AcoustIDStats, error)
+	CreateBookFileFunc                      func(file *BookFile) error
+	GetAllBookFilesCoreFunc                 func() ([]BookFileCore, error)
+	GetBookFilesNeedingDelugeImportCoreFunc func() ([]BookFileCore, error)
+	UpdateBookFileFunc                      func(id string, file *BookFile) error
+	UpdateBookFileHashesFunc                func(id, originalHash, postMetadataHash string) error
+	GetBookFilesFunc                        func(bookID string) ([]BookFile, error)
+	GetBookFileByIDFunc                     func(bookID, fileID string) (*BookFile, error)
+	GetBookFileByPIDFunc                    func(itunesPID string) (*BookFile, error)
+	ClearITunesPIDFunc                      func(itunesPID string) (bool, error)
+	GetBookFileByPathFunc                   func(filePath string) (*BookFile, error)
+	MarkFileImportedFromDelugeFunc          func(ctx context.Context, originalPath, libraryPath, torrentHash string) error
+	GetBookFileByAcoustIDFunc               func(fingerprint string) (*BookFile, error)
+	GetBookFileByAcoustIDFuzzyFunc          func(fingerprint string, minSimilarity float64) (*BookFile, error)
+	DeleteBookFileFunc                      func(id string) error
+	DeleteBookFilesForBookFunc              func(bookID string) error
+	UpsertBookFileFunc                      func(file *BookFile) error
+	BatchUpsertBookFilesFunc                func(files []*BookFile) error
+	MoveBookFilesToBookFunc                 func(fileIDs []string, sourceBookID, targetBookID string) error
+	GetDuplicateFilesByHashFunc             func(limit int) ([]DuplicateFileGroup, error)
+	GetBookBySegmentFileHashFunc            func(hash string) (*Book, error)
+	SetBookFileHashFunc                     func(id, hash string) error
+	GetBookFileHashStatsFunc                func() (*BookFileHashStats, error)
+	GetBookMetadataHashStatsFunc            func() (*BookMetadataHashStats, error)
+	GetFilesWithFingerprintFailuresFunc     func(reason string, limit, offset int) ([]BookFile, int64, error)
+	GetAcoustIDStatsFunc                    func() (*AcoustIDStats, error)
 
 	// Path history
 	RecordPathChangeFunc   func(change *BookPathChange) error
@@ -757,11 +758,11 @@ func (m *MockStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]Boo
 	return nil, nil
 }
 
-func (m *MockStore) GetFolderDuplicates() ([][]Book, error) {
+func (m *MockStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
 	return nil, nil
 }
 
-func (m *MockStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error) {
+func (m *MockStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]BookCore, error) {
 	if m.GetDuplicateBooksByMetadataFunc != nil {
 		return m.GetDuplicateBooksByMetadataFunc(threshold)
 	}
@@ -2400,7 +2401,12 @@ func (m *MockStore) GetAllBookFilesCore() ([]BookFileCore, error) {
 	}
 	return nil, nil
 }
-func (m *MockStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) { return nil, nil }
+func (m *MockStore) GetBookFilesNeedingDelugeImportCore() ([]BookFileCore, error) {
+	if m.GetBookFilesNeedingDelugeImportCoreFunc != nil {
+		return m.GetBookFilesNeedingDelugeImportCoreFunc()
+	}
+	return nil, nil
+}
 
 func (m *MockStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath, libraryPath, torrentHash string) error {
 	if m.MarkFileImportedFromDelugeFunc != nil {

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -4096,24 +4096,24 @@ func (_c *MockBookReader_GetDuplicateBooks_Call) RunAndReturn(run func() ([][]da
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -4124,18 +4124,18 @@ func (_mock *MockBookReader) GetDuplicateBooksByMetadata(threshold float64) ([][
 	return r0, r1
 }
 
-// MockBookReader_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockBookReader_GetDuplicateBooksByMetadata_Call struct {
+// MockBookReader_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockBookReader_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockBookReader_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockBookReader_GetDuplicateBooksByMetadata_Call {
-	return &MockBookReader_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockBookReader_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockBookReader_GetDuplicateBooksByMetadataCore_Call {
+	return &MockBookReader_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockBookReader_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockBookReader_GetDuplicateBooksByMetadata_Call {
+func (_c *MockBookReader_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockBookReader_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -4148,34 +4148,34 @@ func (_c *MockBookReader_GetDuplicateBooksByMetadata_Call) Run(run func(threshol
 	return _c
 }
 
-func (_c *MockBookReader_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockBookReader_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockBookReader_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockBookReader_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockBookReader_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockBookReader_GetDuplicateBooksByMetadata_Call {
+func (_c *MockBookReader_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockBookReader_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -4186,29 +4186,29 @@ func (_mock *MockBookReader) GetFolderDuplicates() ([][]database.Book, error) {
 	return r0, r1
 }
 
-// MockBookReader_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockBookReader_GetFolderDuplicates_Call struct {
+// MockBookReader_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockBookReader_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockBookReader_Expecter) GetFolderDuplicates() *MockBookReader_GetFolderDuplicates_Call {
-	return &MockBookReader_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockBookReader_Expecter) GetFolderDuplicatesCore() *MockBookReader_GetFolderDuplicatesCore_Call {
+	return &MockBookReader_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockBookReader_GetFolderDuplicates_Call) Run(run func()) *MockBookReader_GetFolderDuplicates_Call {
+func (_c *MockBookReader_GetFolderDuplicatesCore_Call) Run(run func()) *MockBookReader_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBookReader_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockBookReader_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockBookReader_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockBookReader_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockBookReader_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockBookReader_GetFolderDuplicates_Call {
+func (_c *MockBookReader_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockBookReader_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -7477,24 +7477,24 @@ func (_c *MockBookStore_GetDuplicateBooks_Call) RunAndReturn(run func() ([][]dat
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -7505,18 +7505,18 @@ func (_mock *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]
 	return r0, r1
 }
 
-// MockBookStore_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockBookStore_GetDuplicateBooksByMetadata_Call struct {
+// MockBookStore_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockBookStore_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockBookStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockBookStore_GetDuplicateBooksByMetadata_Call {
-	return &MockBookStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockBookStore_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockBookStore_GetDuplicateBooksByMetadataCore_Call {
+	return &MockBookStore_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockBookStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockBookStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockBookStore_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockBookStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -7529,34 +7529,34 @@ func (_c *MockBookStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold
 	return _c
 }
 
-func (_c *MockBookStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockBookStore_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockBookStore_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockBookStore_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockBookStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockBookStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockBookStore_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockBookStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -7567,29 +7567,29 @@ func (_mock *MockBookStore) GetFolderDuplicates() ([][]database.Book, error) {
 	return r0, r1
 }
 
-// MockBookStore_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockBookStore_GetFolderDuplicates_Call struct {
+// MockBookStore_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockBookStore_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockBookStore_Expecter) GetFolderDuplicates() *MockBookStore_GetFolderDuplicates_Call {
-	return &MockBookStore_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockBookStore_Expecter) GetFolderDuplicatesCore() *MockBookStore_GetFolderDuplicatesCore_Call {
+	return &MockBookStore_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockBookStore_GetFolderDuplicates_Call) Run(run func()) *MockBookStore_GetFolderDuplicates_Call {
+func (_c *MockBookStore_GetFolderDuplicatesCore_Call) Run(run func()) *MockBookStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBookStore_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockBookStore_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockBookStore_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockBookStore_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockBookStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockBookStore_GetFolderDuplicates_Call {
+func (_c *MockBookStore_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockBookStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -15015,24 +15015,24 @@ func (_c *MockBookFileStore_GetBookFiles_Call) RunAndReturn(run func(bookID stri
 	return _c
 }
 
-// GetBookFilesNeedingDelugeImport provides a mock function for the type MockBookFileStore
-func (_mock *MockBookFileStore) GetBookFilesNeedingDelugeImport() ([]database.BookFile, error) {
+// GetBookFilesNeedingDelugeImportCore provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) GetBookFilesNeedingDelugeImportCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBookFilesNeedingDelugeImport")
+		panic("no return value specified for GetBookFilesNeedingDelugeImportCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -15043,29 +15043,29 @@ func (_mock *MockBookFileStore) GetBookFilesNeedingDelugeImport() ([]database.Bo
 	return r0, r1
 }
 
-// MockBookFileStore_GetBookFilesNeedingDelugeImport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImport'
-type MockBookFileStore_GetBookFilesNeedingDelugeImport_Call struct {
+// MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImportCore'
+type MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call struct {
 	*mock.Call
 }
 
-// GetBookFilesNeedingDelugeImport is a helper method to define mock.On call
-func (_e *MockBookFileStore_Expecter) GetBookFilesNeedingDelugeImport() *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call {
-	return &MockBookFileStore_GetBookFilesNeedingDelugeImport_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImport")}
+// GetBookFilesNeedingDelugeImportCore is a helper method to define mock.On call
+func (_e *MockBookFileStore_Expecter) GetBookFilesNeedingDelugeImportCore() *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call {
+	return &MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImportCore")}
 }
 
-func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call) Run(run func()) *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call) Run(run func()) *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call) Return(bookFiles []database.BookFile, err error) *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockBookFileStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockBookFileStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -36720,24 +36720,24 @@ func (_c *MockStore_GetBookFiles_Call) RunAndReturn(run func(bookID string) ([]d
 	return _c
 }
 
-// GetBookFilesNeedingDelugeImport provides a mock function for the type MockStore
-func (_mock *MockStore) GetBookFilesNeedingDelugeImport() ([]database.BookFile, error) {
+// GetBookFilesNeedingDelugeImportCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetBookFilesNeedingDelugeImportCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBookFilesNeedingDelugeImport")
+		panic("no return value specified for GetBookFilesNeedingDelugeImportCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -36748,29 +36748,29 @@ func (_mock *MockStore) GetBookFilesNeedingDelugeImport() ([]database.BookFile, 
 	return r0, r1
 }
 
-// MockStore_GetBookFilesNeedingDelugeImport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImport'
-type MockStore_GetBookFilesNeedingDelugeImport_Call struct {
+// MockStore_GetBookFilesNeedingDelugeImportCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImportCore'
+type MockStore_GetBookFilesNeedingDelugeImportCore_Call struct {
 	*mock.Call
 }
 
-// GetBookFilesNeedingDelugeImport is a helper method to define mock.On call
-func (_e *MockStore_Expecter) GetBookFilesNeedingDelugeImport() *MockStore_GetBookFilesNeedingDelugeImport_Call {
-	return &MockStore_GetBookFilesNeedingDelugeImport_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImport")}
+// GetBookFilesNeedingDelugeImportCore is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetBookFilesNeedingDelugeImportCore() *MockStore_GetBookFilesNeedingDelugeImportCore_Call {
+	return &MockStore_GetBookFilesNeedingDelugeImportCore_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImportCore")}
 }
 
-func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) Run(run func()) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockStore_GetBookFilesNeedingDelugeImportCore_Call) Run(run func()) *MockStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) Return(bookFiles []database.BookFile, err error) *MockStore_GetBookFilesNeedingDelugeImport_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockStore_GetBookFilesNeedingDelugeImportCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockStore_GetBookFilesNeedingDelugeImportCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockStore_GetBookFilesNeedingDelugeImportCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -38619,24 +38619,24 @@ func (_c *MockStore_GetDuplicateBooks_Call) RunAndReturn(run func() ([][]databas
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockStore
-func (_mock *MockStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -38647,18 +38647,18 @@ func (_mock *MockStore) GetDuplicateBooksByMetadata(threshold float64) ([][]data
 	return r0, r1
 }
 
-// MockStore_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockStore_GetDuplicateBooksByMetadata_Call struct {
+// MockStore_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockStore_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockStore_GetDuplicateBooksByMetadata_Call {
-	return &MockStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockStore_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockStore_GetDuplicateBooksByMetadataCore_Call {
+	return &MockStore_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockStore_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -38671,12 +38671,12 @@ func (_c *MockStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold flo
 	return _c
 }
 
-func (_c *MockStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockStore_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockStore_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockStore_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockStore_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -38885,24 +38885,24 @@ func (_c *MockStore_GetFilesWithFingerprintFailures_Call) RunAndReturn(run func(
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockStore
-func (_mock *MockStore) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockStore
+func (_mock *MockStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -38913,29 +38913,29 @@ func (_mock *MockStore) GetFolderDuplicates() ([][]database.Book, error) {
 	return r0, r1
 }
 
-// MockStore_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockStore_GetFolderDuplicates_Call struct {
+// MockStore_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockStore_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockStore_Expecter) GetFolderDuplicates() *MockStore_GetFolderDuplicates_Call {
-	return &MockStore_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockStore_Expecter) GetFolderDuplicatesCore() *MockStore_GetFolderDuplicatesCore_Call {
+	return &MockStore_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockStore_GetFolderDuplicates_Call) Run(run func()) *MockStore_GetFolderDuplicates_Call {
+func (_c *MockStore_GetFolderDuplicatesCore_Call) Run(run func()) *MockStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockStore_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockStore_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockStore_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockStore_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockStore_GetFolderDuplicates_Call {
+func (_c *MockStore_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.109.0
+// version: 1.110.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-07-07
 
@@ -1037,25 +1037,21 @@ func (p *PebbleStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]B
 	return results, nil
 }
 
-// GetFolderDuplicates is SLIM (memdb projection): returns rows with heavy
-// fields nil'd — Description, VersionNotes, BookSigV1, BookSigV1Mask,
-// BookSigSegments, BookSigBuiltAt, BookSigCoveragePct, Author, Series. A
-// caller that needs any of those MUST fetch via GetBookByID /
-// GetAllBooksFullFrom (full Pebble). See
-// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (p *PebbleStore) GetFolderDuplicates() ([][]Book, error) {
-	// PebbleStore doesn't support folder-based duplicate detection efficiently.
+// GetFolderDuplicatesCore is Core-typed (STOREFID W6) — see the interface
+// doc comment.
+//
+// PebbleStore doesn't support folder-based duplicate detection efficiently
+// (no MemStore implementation exists for this getter either — it is a
+// known-unimplemented stub on both storage backends today, always returning
+// an empty result; see TODO.md for the tracked gap).
+func (p *PebbleStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
 	return nil, nil
 }
 
-// GetDuplicateBooksByMetadata is not efficiently supported in PebbleStore.
-//
-// SLIM (memdb projection): returns rows with heavy fields nil'd — Description,
-// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments, BookSigBuiltAt,
-// BookSigCoveragePct, Author, Series. A caller that needs any of those MUST
-// fetch via GetBookByID / GetAllBooksFullFrom (full Pebble). See
-// docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (p *PebbleStore) GetDuplicateBooksByMetadata(threshold float64) ([][]Book, error) {
+// GetDuplicateBooksByMetadataCore is Core-typed (STOREFID W6) — see the
+// interface doc comment. Not efficiently supported in PebbleStore (see
+// GetFolderDuplicatesCore's doc comment for the same known gap).
+func (p *PebbleStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]BookCore, error) {
 	return nil, nil
 }
 

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-07-06
+// last-edited: 2026-07-07
 
 package database
 
@@ -497,8 +497,10 @@ func (s *PebbleStore) getAllBooksPebbleScan() ([]Book, error) {
 	return books, nil
 }
 
-// GetBookFilesNeedingDelugeImport returns book_files that have a non-empty
-// deluge_hash but have not yet been imported (imported_from_deluge_at IS NULL).
+// GetBookFilesNeedingDelugeImportCore returns book_files that have a
+// non-empty deluge_hash but have not yet been imported
+// (imported_from_deluge_at IS NULL). Core-typed (STOREFID W6) — see the
+// interface doc comment.
 //
 // When memdb is published, walks the sparse deluge_hash index — only rows
 // where DelugeHash is non-empty are indexed — and post-filters on the
@@ -506,24 +508,18 @@ func (s *PebbleStore) getAllBooksPebbleScan() ([]Book, error) {
 // centralization plugin from a 308K full BookFile scan to walking just the
 // (much smaller) deluge-touched subset (H2 + H8). Pebble full-scan retained
 // as the cold-start fallback.
-//
-// SLIM (memdb projection): returns rows with heavy fields nil'd —
-// FingerprintFailureReason/Detail/DiagnosticJSON, AcoustIDFingerprint,
-// AcoustIDSeg0..6 (FingerprintFailedAt and AcoustIDFingerprintDurationSec are
-// kept). A caller that needs any of those MUST fetch via GetBookFiles(bookID)
-// (full Pebble). See docs/specs/2026-07-05-store-getter-fidelity-unification.md.
-func (s *PebbleStore) GetBookFilesNeedingDelugeImport() ([]BookFile, error) {
+func (s *PebbleStore) GetBookFilesNeedingDelugeImportCore() ([]BookFileCore, error) {
 	if s.UseMemDB && s.mem() != nil {
-		return s.mem().GetBookFilesNeedingDelugeImport()
+		return s.mem().GetBookFilesNeedingDelugeImportCore()
 	}
 	all, err := s.getAllBookFilesPebbleScan()
 	if err != nil {
 		return nil, err
 	}
-	var out []BookFile
+	var out []BookFileCore
 	for _, f := range all {
 		if f.DelugeHash != "" && f.ImportedFromDelugeAt == nil {
-			out = append(out, f)
+			out = append(out, f.Core())
 		}
 	}
 	return out, nil

--- a/internal/database/store_coverage_test.go
+++ b/internal/database/store_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_coverage_test.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
-// last-edited: 2026-06-10
+// last-edited: 2026-07-07
 
 // NOTE(fable5 T022): setupCoverageDB ported to PebbleStore; SQLiteStore
 // type assertions updated. Tests for SQLite-only methods (CountTableRows,
@@ -1129,7 +1129,7 @@ func TestCoverage_GetFolderDuplicates(t *testing.T) {
 	_ = createTestBook(t, store, "Duplicate", "/same/folder/dup1.m4b", nil, nil)
 	_ = createTestBook(t, store, "Duplicate", "/same/folder/dup2.m4b", nil, nil)
 
-	dupes, err := store.GetFolderDuplicates()
+	dupes, err := store.GetFolderDuplicatesCore()
 	require.NoError(t, err)
 	// May or may not find dupes depending on implementation (normalized title matching),
 	// but the function should not error
@@ -1147,7 +1147,7 @@ func TestCoverage_GetDuplicateBooksByMetadata(t *testing.T) {
 	_ = createBookWithDuration(t, store, "Almost Same Title", "/tmp/dupe1.m4b", &author.ID, &dur)
 	_ = createBookWithDuration(t, store, "Almost Same Title", "/tmp/dupe2.m4b", &author.ID, &dur)
 
-	dupes, err := store.GetDuplicateBooksByMetadata(0.8)
+	dupes, err := store.GetDuplicateBooksByMetadataCore(0.8)
 	require.NoError(t, err)
 	_ = dupes // just testing it doesn't error
 }

--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/book_dedup.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-06-28
+// last-edited: 2026-07-07
 
 // Package dedup: book_dedup.go contains the extracted execution logic for the
 // "dedup.book-scan" and "dedup.book-merge" async operations.  The *Server
@@ -38,6 +38,28 @@ type BookDupGroup struct {
 type BookScanResult struct {
 	Groups          []BookDupGroup
 	TotalDuplicates int
+}
+
+// coreGroupsToBookGroups widens [][]database.BookCore to [][]database.Book
+// via .ToBook() (heavy fields left at their zero value — never populated by
+// GetFolderDuplicatesCore/GetDuplicateBooksByMetadataCore in the first
+// place, so this is not a lossy conversion). Used at the ScanBookDuplicates
+// store boundary so the shared addGroups/tiebreaker pipeline (which stays
+// []Book to match hashGroups from GetDuplicateBooks and the public
+// BookDupGroup.Books JSON contract) doesn't need its own Core variant.
+func coreGroupsToBookGroups(groups [][]database.BookCore) [][]database.Book {
+	if groups == nil {
+		return nil
+	}
+	out := make([][]database.Book, len(groups))
+	for i, group := range groups {
+		converted := make([]database.Book, len(group))
+		for j, c := range group {
+			converted[j] = c.ToBook()
+		}
+		out[i] = converted
+	}
+	return out
 }
 
 // ScanBookDuplicates runs the three-tier duplicate-book scan (hash, folder,
@@ -77,19 +99,26 @@ func ScanBookDuplicates(
 
 	// Step 2: Folder duplicates (same title in same folder)
 	report(2, "Finding folder-based duplicates...")
-	folderGroups, err := store.GetFolderDuplicates()
+	folderGroupsCore, err := store.GetFolderDuplicatesCore()
 	if err != nil {
 		slog.Warn("folder dedup failed", "error", err)
-		folderGroups = nil
+		folderGroupsCore = nil
 	}
+	// Converted immediately at the store boundary — everything downstream
+	// (addGroups, dismissed-key lookups) only ever reads Core-safe fields
+	// (ID, Title), so .ToBook() here is a lossless widen, not the
+	// hydrate-before-writeback landmine (this pipeline never writes a book
+	// back; it only reports duplicate groups).
+	folderGroups := coreGroupsToBookGroups(folderGroupsCore)
 
 	// Step 3: Metadata-based fuzzy matching
 	report(3, "Finding metadata-based duplicates...")
-	metadataGroups, err := store.GetDuplicateBooksByMetadata(metadataBorderlineFloor)
+	metadataGroupsCore, err := store.GetDuplicateBooksByMetadataCore(metadataBorderlineFloor)
 	if err != nil {
 		slog.Warn("metadata dedup failed", "error", err)
-		metadataGroups = nil
+		metadataGroupsCore = nil
 	}
+	metadataGroups := coreGroupsToBookGroups(metadataGroupsCore)
 	metadataGroups, metadataConfidence, metadataReason := applyTranscriptionMetadataTiebreaker(store, metadataGroups)
 
 	report(4, "Merging results...")

--- a/internal/dedup/book_dedup_test.go
+++ b/internal/dedup/book_dedup_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/book_dedup_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1234-efab-345678901234
-// last-edited: 2026-06-28
+// last-edited: 2026-07-07
 
 package dedup
 
@@ -127,9 +127,9 @@ func TestScanBookDuplicates_TranscriptionPromotesBorderlineMetadataMatch(t *test
 
 	var metadataThreshold float64
 	mock := &database.MockStore{}
-	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.Book, error) {
+	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.BookCore, error) {
 		metadataThreshold = threshold
-		return [][]database.Book{{bookA, bookB}}, nil
+		return [][]database.BookCore{{bookA.Core(), bookB.Core()}}, nil
 	}
 	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
 		return &database.Author{ID: id, Name: "Shared Author"}, nil
@@ -162,8 +162,8 @@ func TestScanBookDuplicates_TranscriptionDemotesBorderlineMetadataMismatch(t *te
 	}
 
 	mock := &database.MockStore{}
-	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.Book, error) {
-		return [][]database.Book{{bookA, bookB}}, nil
+	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.BookCore, error) {
+		return [][]database.BookCore{{bookA.Core(), bookB.Core()}}, nil
 	}
 	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
 		return &database.Author{ID: id, Name: "Shared Author"}, nil
@@ -181,8 +181,8 @@ func TestScanBookDuplicates_TranscriptionMissingLeavesMetadataDecisionUnchanged(
 	bookB := database.Book{ID: "BBB", Title: "Kingdom of Glass", AuthorID: &authorID}
 
 	mock := &database.MockStore{}
-	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.Book, error) {
-		return [][]database.Book{{bookA, bookB}}, nil
+	mock.GetDuplicateBooksByMetadataFunc = func(threshold float64) ([][]database.BookCore, error) {
+		return [][]database.BookCore{{bookA.Core(), bookB.Core()}}, nil
 	}
 	mock.GetAuthorByIDFunc = func(id int) (*database.Author, error) {
 		return &database.Author{ID: id, Name: "Shared Author"}, nil

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.7
+// version: 1.0.8
 // last-edited: 2026-07-07
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
@@ -109,11 +109,11 @@ func (m *mockRebuildStore) GetDuplicateBooks() ([][]database.Book, error) {
 	return nil, nil
 }
 
-func (m *mockRebuildStore) GetFolderDuplicates() ([][]database.Book, error) {
+func (m *mockRebuildStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	return nil, nil
 }
 
-func (m *mockRebuildStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+func (m *mockRebuildStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	return nil, nil
 }
 

--- a/internal/maintenance/jobs/bulk_deluge_import.go
+++ b/internal/maintenance/jobs/bulk_deluge_import.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/bulk_deluge_import.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: a2b8c6d7-9e0f-1a2b-3c4d-5e6f7a8b9c0d
-// last-edited: 2026-05-01
+// last-edited: 2026-07-07
 
 package jobs
 
@@ -56,9 +56,9 @@ func (j *bulkDelugeImportJob) Run(ctx context.Context, store database.Store, rep
 
 	client := bdi_buildDelugeClient()
 
-	pending, err := store.GetBookFilesNeedingDelugeImport()
+	pending, err := store.GetBookFilesNeedingDelugeImportCore()
 	if err != nil {
-		return fmt.Errorf("GetBookFilesNeedingDelugeImport: %w", err)
+		return fmt.Errorf("GetBookFilesNeedingDelugeImportCore: %w", err)
 	}
 	if maxBooks > 0 && len(pending) > maxBooks {
 		pending = pending[:maxBooks]
@@ -88,7 +88,31 @@ func (j *bulkDelugeImportJob) Run(ctx context.Context, store database.Store, rep
 			}
 			imported++
 		} else {
-			newPath, importErr := bdi_importToLibrary(&config.AppConfig, client, store, f)
+			// Hydrate the full row before writing back — f is the Core
+			// (memdb-slim) projection, and passing it straight to
+			// bdi_importToLibrary would silently wipe the
+			// fingerprint-diagnostic fields on its UpdateBookFile call
+			// (STOREFID PR-D).
+			full, hydrateErr := store.GetBookFileByID(f.BookID, f.ID)
+			if hydrateErr != nil || full == nil {
+				errMsg := "book file not found"
+				if hydrateErr != nil {
+					errMsg = hydrateErr.Error()
+				}
+				slog.Warn("bulk-deluge-import hydrate failed", "opID", opID, "f", f.FilePath, "err", errMsg)
+				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "error": errMsg})
+				if opID != "" {
+					_ = store.CreateOperationResult(&database.OperationResult{
+						OperationID: opID,
+						BookID:      f.ID,
+						ResultJSON:  string(resultJSON),
+						Status:      "error",
+					})
+				}
+				failed++
+				continue
+			}
+			newPath, importErr := bdi_importToLibrary(&config.AppConfig, client, store, full)
 			if importErr != nil {
 				slog.Warn("bulk-deluge-import", "opID", opID, "f", f.FilePath, "importErr", importErr)
 				resultJSON, _ := json.Marshal(map[string]any{"path": f.FilePath, "error": importErr.Error()})

--- a/internal/plugins/deluge/centralization.go
+++ b/internal/plugins/deluge/centralization.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/deluge/centralization.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-06-23
+// last-edited: 2026-07-07
 
 package deluge
 
@@ -63,12 +63,12 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 
 	sdk.NewProgress(reporter, 0).Start("Loading Deluge-imported files...")
 
-	pending, err := p.store.GetBookFilesNeedingDelugeImport()
+	pending, err := p.store.GetBookFilesNeedingDelugeImportCore()
 	if err != nil {
 		return fmt.Errorf("load deluge-pending book files: %w", err)
 	}
 
-	toImport := make([]*database.BookFile, 0, len(pending))
+	toImport := make([]*database.BookFileCore, 0, len(pending))
 	for i := range pending {
 		toImport = append(toImport, &pending[i])
 	}
@@ -99,7 +99,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 	// atomic keeps the intent clear if concurrency is raised later.
 	var localCount atomic.Int64
 
-	runErr := registry.RunItems(ctx, reporter, resumeSlice, func(ctx context.Context, bf *database.BookFile) error {
+	runErr := registry.RunItems(ctx, reporter, resumeSlice, func(ctx context.Context, bf *database.BookFileCore) error {
 		globalIdx := baseIdx + int(localCount.Add(1)) - 1
 
 		srcPath := bf.FilePath
@@ -138,12 +138,23 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 			}
 		}
 
-		now := time.Now()
-		bf.DelugeOriginalPath = srcPath
-		bf.FilePath = dest
-		bf.ImportedFromDelugeAt = &now
+		// Hydrate the full row before writing back — bf is the Core (memdb-slim)
+		// projection, and a naive UpdateBookFile(bf.ID, bf) here would silently
+		// wipe the fingerprint-diagnostic fields (STOREFID PR-D).
+		full, hydrateErr := p.store.GetBookFileByID(bf.BookID, bf.ID)
+		if hydrateErr != nil || full == nil {
+			errCount.Add(1)
+			checkpoint.LastError = fmt.Sprintf("hydrate book file %s: %v", bf.ID, hydrateErr)
+			reporter.Logger().Error("hydrate book file failed", "id", bf.ID, "error", hydrateErr)
+			return nil // non-fatal
+		}
 
-		if err := p.store.UpdateBookFile(bf.ID, bf); err != nil {
+		now := time.Now()
+		full.DelugeOriginalPath = srcPath
+		full.FilePath = dest
+		full.ImportedFromDelugeAt = &now
+
+		if err := p.store.UpdateBookFile(full.ID, full); err != nil {
 			errCount.Add(1)
 			checkpoint.LastError = fmt.Sprintf("update book file: %v", err)
 			reporter.Logger().Error("update book file failed", "id", bf.ID, "error", err)

--- a/internal/plugins/deluge/centralization_test.go
+++ b/internal/plugins/deluge/centralization_test.go
@@ -1,0 +1,100 @@
+// file: internal/plugins/deluge/centralization_test.go
+// version: 1.0.0
+// guid: d4e5f6a7-b8c9-4d0e-9f1a-2b3c4d5e6f7a
+// last-edited: 2026-07-07
+
+package deluge
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// --- test reporter (mirrors internal/plugins/acoustid/lsh_backfill_test.go) --
+
+type centralizationTestReporter struct{}
+
+func (r *centralizationTestReporter) UpdateProgress(int, int, string) error { return nil }
+func (r *centralizationTestReporter) Log(slog.Level, string, ...slog.Attr) error {
+	return nil
+}
+func (r *centralizationTestReporter) Logger() *slog.Logger { return slog.Default() }
+func (r *centralizationTestReporter) Checkpoint(any) error { return nil }
+func (r *centralizationTestReporter) IsCanceled() bool     { return false }
+func (r *centralizationTestReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, sdk.Reporter) error) error {
+	return fn(ctx, r)
+}
+func (r *centralizationTestReporter) Trigger(context.Context, string, any) error { return nil }
+func (r *centralizationTestReporter) SetCurrentItem(string)                      {}
+
+// TestRunCentralization_HydratesBeforeWriteback is a regression test for
+// STOREFID PR-D: GetBookFilesNeedingDelugeImportCore returns a memdb-slim
+// BookFileCore, and centralization used to write that struct straight back
+// via UpdateBookFile, silently wiping the fingerprint diagnostic fields.
+// This asserts a pre-set FingerprintDiagnosticJSON survives the centralize
+// pass — it fails on the pre-fix code (bare Core-to-Book write) because the
+// value would arrive at UpdateBookFile as nil.
+func TestRunCentralization_HydratesBeforeWriteback(t *testing.T) {
+	root := t.TempDir()
+	// srcPath lives outside root so the centralize pass computes a distinct
+	// destDir (== root) instead of hitting the srcPath == dest skip path.
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "book.mp3")
+	if err := os.WriteFile(srcPath, []byte("test data"), 0o644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+
+	origRoot := config.AppConfig.RootDir
+	config.AppConfig.RootDir = root
+	defer func() { config.AppConfig.RootDir = origRoot }()
+
+	diagJSON := `{"reason":"low_confidence"}`
+
+	fullFile := &database.BookFile{
+		ID:                        "f1",
+		BookID:                    "b1",
+		FilePath:                  srcPath,
+		FingerprintDiagnosticJSON: &diagJSON,
+	}
+
+	var updated *database.BookFile
+	store := &database.MockStore{
+		GetBookFilesNeedingDelugeImportCoreFunc: func() ([]database.BookFileCore, error) {
+			return []database.BookFileCore{fullFile.Core()}, nil
+		},
+		GetBookFileByIDFunc: func(bookID, fileID string) (*database.BookFile, error) {
+			if bookID == fullFile.BookID && fileID == fullFile.ID {
+				return fullFile, nil
+			}
+			return nil, nil
+		},
+		UpdateBookFileFunc: func(id string, file *database.BookFile) error {
+			updated = file
+			return nil
+		},
+	}
+
+	p := &Plugin{store: store}
+	r := &centralizationTestReporter{}
+
+	if err := p.runCentralization(context.Background(), nil, r); err != nil {
+		t.Fatalf("runCentralization returned error: %v", err)
+	}
+
+	if updated == nil {
+		t.Fatal("UpdateBookFile was never called")
+	}
+	if updated.FingerprintDiagnosticJSON == nil {
+		t.Fatal("FingerprintDiagnosticJSON was wiped on writeback (PR-D regression)")
+	}
+	if *updated.FingerprintDiagnosticJSON != diagJSON {
+		t.Errorf("FingerprintDiagnosticJSON = %q, want %q", *updated.FingerprintDiagnosticJSON, diagJSON)
+	}
+}

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -133,7 +133,7 @@ func (s *Server) handleDiscoveryImport(c *gin.Context) {
 	// Centralized store method — uses the memdb deluge_hash fastpath
 	// when published (avoids loading all 308K BookFiles just to filter
 	// to the small Deluge-touched subset).
-	pending, err := store.GetBookFilesNeedingDelugeImport()
+	pending, err := store.GetBookFilesNeedingDelugeImportCore()
 	if err != nil {
 		httputil.InternalError(c, "failed to load book files", err)
 		return
@@ -160,7 +160,21 @@ func (s *Server) handleDiscoveryImport(c *gin.Context) {
 			skipped++
 			continue
 		}
-		newPath, importErr := delugeclient.ImportToLibrary(&config.AppConfig, client, store, f)
+		// Hydrate the full row before writing back — f is the Core (memdb-slim)
+		// projection, and passing it straight to ImportToLibrary would silently
+		// wipe the fingerprint-diagnostic fields on its UpdateBookFile call
+		// (STOREFID PR-D).
+		full, hydrateErr := store.GetBookFileByID(f.BookID, f.ID)
+		if hydrateErr != nil || full == nil {
+			errMsg := "book file not found"
+			if hydrateErr != nil {
+				errMsg = hydrateErr.Error()
+			}
+			results = append(results, result{FileID: f.ID, Path: f.FilePath, Error: errMsg})
+			failed++
+			continue
+		}
+		newPath, importErr := delugeclient.ImportToLibrary(&config.AppConfig, client, store, full)
 		if importErr != nil {
 			results = append(results, result{FileID: f.ID, Path: f.FilePath, Error: importErr.Error()})
 			failed++

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -2047,24 +2047,24 @@ func (_c *MockMetadataStore_GetDuplicateBooks_Call) RunAndReturn(run func() ([][
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -2075,18 +2075,18 @@ func (_mock *MockMetadataStore) GetDuplicateBooksByMetadata(threshold float64) (
 	return r0, r1
 }
 
-// MockMetadataStore_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockMetadataStore_GetDuplicateBooksByMetadata_Call struct {
+// MockMetadataStore_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockMetadataStore_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockMetadataStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
-	return &MockMetadataStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockMetadataStore_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call {
+	return &MockMetadataStore_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockMetadataStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -2099,34 +2099,34 @@ func (_c *MockMetadataStore_GetDuplicateBooksByMetadata_Call) Run(run func(thres
 	return _c
 }
 
-func (_c *MockMetadataStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockMetadataStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockMetadataStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -2137,29 +2137,29 @@ func (_mock *MockMetadataStore) GetFolderDuplicates() ([][]database.Book, error)
 	return r0, r1
 }
 
-// MockMetadataStore_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockMetadataStore_GetFolderDuplicates_Call struct {
+// MockMetadataStore_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockMetadataStore_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockMetadataStore_Expecter) GetFolderDuplicates() *MockMetadataStore_GetFolderDuplicates_Call {
-	return &MockMetadataStore_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockMetadataStore_Expecter) GetFolderDuplicatesCore() *MockMetadataStore_GetFolderDuplicatesCore_Call {
+	return &MockMetadataStore_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockMetadataStore_GetFolderDuplicates_Call) Run(run func()) *MockMetadataStore_GetFolderDuplicates_Call {
+func (_c *MockMetadataStore_GetFolderDuplicatesCore_Call) Run(run func()) *MockMetadataStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockMetadataStore_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockMetadataStore_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockMetadataStore_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockMetadataStore_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockMetadataStore_GetFolderDuplicates_Call {
+func (_c *MockMetadataStore_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockMetadataStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -1696,24 +1696,24 @@ func (_c *MockPlaylistStore_GetDuplicateBooks_Call) RunAndReturn(run func() ([][
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -1724,18 +1724,18 @@ func (_mock *MockPlaylistStore) GetDuplicateBooksByMetadata(threshold float64) (
 	return r0, r1
 }
 
-// MockPlaylistStore_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockPlaylistStore_GetDuplicateBooksByMetadata_Call struct {
+// MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockPlaylistStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
-	return &MockPlaylistStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockPlaylistStore_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call {
+	return &MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockPlaylistStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -1748,34 +1748,34 @@ func (_c *MockPlaylistStore_GetDuplicateBooksByMetadata_Call) Run(run func(thres
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockPlaylistStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockPlaylistStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -1786,29 +1786,29 @@ func (_mock *MockPlaylistStore) GetFolderDuplicates() ([][]database.Book, error)
 	return r0, r1
 }
 
-// MockPlaylistStore_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockPlaylistStore_GetFolderDuplicates_Call struct {
+// MockPlaylistStore_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockPlaylistStore_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockPlaylistStore_Expecter) GetFolderDuplicates() *MockPlaylistStore_GetFolderDuplicates_Call {
-	return &MockPlaylistStore_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockPlaylistStore_Expecter) GetFolderDuplicatesCore() *MockPlaylistStore_GetFolderDuplicatesCore_Call {
+	return &MockPlaylistStore_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockPlaylistStore_GetFolderDuplicates_Call) Run(run func()) *MockPlaylistStore_GetFolderDuplicates_Call {
+func (_c *MockPlaylistStore_GetFolderDuplicatesCore_Call) Run(run func()) *MockPlaylistStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockPlaylistStore_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockPlaylistStore_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockPlaylistStore_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockPlaylistStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockPlaylistStore_GetFolderDuplicates_Call {
+func (_c *MockPlaylistStore_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockPlaylistStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/mocks/mock_reading_store.go
+++ b/internal/server/handlers/mocks/mock_reading_store.go
@@ -971,24 +971,24 @@ func (_c *MockReadingStore_GetBookFiles_Call) RunAndReturn(run func(bookID strin
 	return _c
 }
 
-// GetBookFilesNeedingDelugeImport provides a mock function for the type MockReadingStore
-func (_mock *MockReadingStore) GetBookFilesNeedingDelugeImport() ([]database.BookFile, error) {
+// GetBookFilesNeedingDelugeImportCore provides a mock function for the type MockReadingStore
+func (_mock *MockReadingStore) GetBookFilesNeedingDelugeImportCore() ([]database.BookFileCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetBookFilesNeedingDelugeImport")
+		panic("no return value specified for GetBookFilesNeedingDelugeImportCore")
 	}
 
-	var r0 []database.BookFile
+	var r0 []database.BookFileCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFile, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([]database.BookFileCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() []database.BookFile); ok {
+	if returnFunc, ok := ret.Get(0).(func() []database.BookFileCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.BookFile)
+			r0 = ret.Get(0).([]database.BookFileCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -999,29 +999,29 @@ func (_mock *MockReadingStore) GetBookFilesNeedingDelugeImport() ([]database.Boo
 	return r0, r1
 }
 
-// MockReadingStore_GetBookFilesNeedingDelugeImport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImport'
-type MockReadingStore_GetBookFilesNeedingDelugeImport_Call struct {
+// MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBookFilesNeedingDelugeImportCore'
+type MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call struct {
 	*mock.Call
 }
 
-// GetBookFilesNeedingDelugeImport is a helper method to define mock.On call
-func (_e *MockReadingStore_Expecter) GetBookFilesNeedingDelugeImport() *MockReadingStore_GetBookFilesNeedingDelugeImport_Call {
-	return &MockReadingStore_GetBookFilesNeedingDelugeImport_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImport")}
+// GetBookFilesNeedingDelugeImportCore is a helper method to define mock.On call
+func (_e *MockReadingStore_Expecter) GetBookFilesNeedingDelugeImportCore() *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call {
+	return &MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call{Call: _e.mock.On("GetBookFilesNeedingDelugeImportCore")}
 }
 
-func (_c *MockReadingStore_GetBookFilesNeedingDelugeImport_Call) Run(run func()) *MockReadingStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call) Run(run func()) *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockReadingStore_GetBookFilesNeedingDelugeImport_Call) Return(bookFiles []database.BookFile, err error) *MockReadingStore_GetBookFilesNeedingDelugeImport_Call {
-	_c.Call.Return(bookFiles, err)
+func (_c *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call) Return(bookFileCores []database.BookFileCore, err error) *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call {
+	_c.Call.Return(bookFileCores, err)
 	return _c
 }
 
-func (_c *MockReadingStore_GetBookFilesNeedingDelugeImport_Call) RunAndReturn(run func() ([]database.BookFile, error)) *MockReadingStore_GetBookFilesNeedingDelugeImport_Call {
+func (_c *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call) RunAndReturn(run func() ([]database.BookFileCore, error)) *MockReadingStore_GetBookFilesNeedingDelugeImportCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -3575,24 +3575,24 @@ func (_c *MockOperationsStore_GetDuplicateBooks_Call) RunAndReturn(run func() ([
 	return _c
 }
 
-// GetDuplicateBooksByMetadata provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+// GetDuplicateBooksByMetadataCore provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	ret := _mock.Called(threshold)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDuplicateBooksByMetadata")
+		panic("no return value specified for GetDuplicateBooksByMetadataCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) ([][]database.BookCore, error)); ok {
 		return returnFunc(threshold)
 	}
-	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func(float64) [][]database.BookCore); ok {
 		r0 = returnFunc(threshold)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(float64) error); ok {
@@ -3603,18 +3603,18 @@ func (_mock *MockOperationsStore) GetDuplicateBooksByMetadata(threshold float64)
 	return r0, r1
 }
 
-// MockOperationsStore_GetDuplicateBooksByMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadata'
-type MockOperationsStore_GetDuplicateBooksByMetadata_Call struct {
+// MockOperationsStore_GetDuplicateBooksByMetadataCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuplicateBooksByMetadataCore'
+type MockOperationsStore_GetDuplicateBooksByMetadataCore_Call struct {
 	*mock.Call
 }
 
-// GetDuplicateBooksByMetadata is a helper method to define mock.On call
+// GetDuplicateBooksByMetadataCore is a helper method to define mock.On call
 //   - threshold float64
-func (_e *MockOperationsStore_Expecter) GetDuplicateBooksByMetadata(threshold any) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
-	return &MockOperationsStore_GetDuplicateBooksByMetadata_Call{Call: _e.mock.On("GetDuplicateBooksByMetadata", threshold)}
+func (_e *MockOperationsStore_Expecter) GetDuplicateBooksByMetadataCore(threshold any) *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call {
+	return &MockOperationsStore_GetDuplicateBooksByMetadataCore_Call{Call: _e.mock.On("GetDuplicateBooksByMetadataCore", threshold)}
 }
 
-func (_c *MockOperationsStore_GetDuplicateBooksByMetadata_Call) Run(run func(threshold float64)) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call) Run(run func(threshold float64)) *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 float64
 		if args[0] != nil {
@@ -3627,34 +3627,34 @@ func (_c *MockOperationsStore_GetDuplicateBooksByMetadata_Call) Run(run func(thr
 	return _c
 }
 
-func (_c *MockOperationsStore_GetDuplicateBooksByMetadata_Call) Return(bookss [][]database.Book, err error) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_GetDuplicateBooksByMetadata_Call) RunAndReturn(run func(threshold float64) ([][]database.Book, error)) *MockOperationsStore_GetDuplicateBooksByMetadata_Call {
+func (_c *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call) RunAndReturn(run func(threshold float64) ([][]database.BookCore, error)) *MockOperationsStore_GetDuplicateBooksByMetadataCore_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetFolderDuplicates provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetFolderDuplicates() ([][]database.Book, error) {
+// GetFolderDuplicatesCore provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetFolderDuplicatesCore() ([][]database.BookCore, error) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFolderDuplicates")
+		panic("no return value specified for GetFolderDuplicatesCore")
 	}
 
-	var r0 [][]database.Book
+	var r0 [][]database.BookCore
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() ([][]database.Book, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func() ([][]database.BookCore, error)); ok {
 		return returnFunc()
 	}
-	if returnFunc, ok := ret.Get(0).(func() [][]database.Book); ok {
+	if returnFunc, ok := ret.Get(0).(func() [][]database.BookCore); ok {
 		r0 = returnFunc()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([][]database.Book)
+			r0 = ret.Get(0).([][]database.BookCore)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func() error); ok {
@@ -3665,29 +3665,29 @@ func (_mock *MockOperationsStore) GetFolderDuplicates() ([][]database.Book, erro
 	return r0, r1
 }
 
-// MockOperationsStore_GetFolderDuplicates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicates'
-type MockOperationsStore_GetFolderDuplicates_Call struct {
+// MockOperationsStore_GetFolderDuplicatesCore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFolderDuplicatesCore'
+type MockOperationsStore_GetFolderDuplicatesCore_Call struct {
 	*mock.Call
 }
 
-// GetFolderDuplicates is a helper method to define mock.On call
-func (_e *MockOperationsStore_Expecter) GetFolderDuplicates() *MockOperationsStore_GetFolderDuplicates_Call {
-	return &MockOperationsStore_GetFolderDuplicates_Call{Call: _e.mock.On("GetFolderDuplicates")}
+// GetFolderDuplicatesCore is a helper method to define mock.On call
+func (_e *MockOperationsStore_Expecter) GetFolderDuplicatesCore() *MockOperationsStore_GetFolderDuplicatesCore_Call {
+	return &MockOperationsStore_GetFolderDuplicatesCore_Call{Call: _e.mock.On("GetFolderDuplicatesCore")}
 }
 
-func (_c *MockOperationsStore_GetFolderDuplicates_Call) Run(run func()) *MockOperationsStore_GetFolderDuplicates_Call {
+func (_c *MockOperationsStore_GetFolderDuplicatesCore_Call) Run(run func()) *MockOperationsStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockOperationsStore_GetFolderDuplicates_Call) Return(bookss [][]database.Book, err error) *MockOperationsStore_GetFolderDuplicates_Call {
-	_c.Call.Return(bookss, err)
+func (_c *MockOperationsStore_GetFolderDuplicatesCore_Call) Return(bookCoress [][]database.BookCore, err error) *MockOperationsStore_GetFolderDuplicatesCore_Call {
+	_c.Call.Return(bookCoress, err)
 	return _c
 }
 
-func (_c *MockOperationsStore_GetFolderDuplicates_Call) RunAndReturn(run func() ([][]database.Book, error)) *MockOperationsStore_GetFolderDuplicates_Call {
+func (_c *MockOperationsStore_GetFolderDuplicatesCore_Call) RunAndReturn(run func() ([][]database.BookCore, error)) *MockOperationsStore_GetFolderDuplicatesCore_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,5 +1,5 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
 // last-edited: 2026-07-07
 
@@ -109,8 +109,8 @@ func (m *MockBookStore) GetBookIDsByISBNASIN(isbn10, isbn13, asin string) ([]str
 func (m *MockBookStore) GetBookByOriginalHash(hash string) (*database.Book, error)  { return nil, nil }
 func (m *MockBookStore) GetBookByOrganizedHash(hash string) (*database.Book, error) { return nil, nil }
 func (m *MockBookStore) GetDuplicateBooks() ([][]database.Book, error)              { return nil, nil }
-func (m *MockBookStore) GetFolderDuplicates() ([][]database.Book, error)            { return nil, nil }
-func (m *MockBookStore) GetDuplicateBooksByMetadata(threshold float64) ([][]database.Book, error) {
+func (m *MockBookStore) GetFolderDuplicatesCore() ([][]database.BookCore, error)    { return nil, nil }
+func (m *MockBookStore) GetDuplicateBooksByMetadataCore(threshold float64) ([][]database.BookCore, error) {
 	return nil, nil
 }
 func (m *MockBookStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]database.Book, error) {


### PR DESCRIPTION
## Summary

- STOREFID W6: retype the last 3 non-`GetAllBooks` slim getters to return `*Core` projection types (`GetBookFilesNeedingDelugeImportCore`, `GetFolderDuplicatesCore`, `GetDuplicateBooksByMetadataCore`), matching the pattern established by W1/W3/W4/W5.
- This retype force-surfaced and closes **PR-D** (deluge import fingerprint-wipe, tracked since W3): the narrower `BookFileCore` return type made the naive `UpdateBookFile(bf.ID, bf)` writeback in all 3 deluge-import call sites a compile error instead of a silent prod data-loss bug. Fixed all 3 with hydrate-mutate-update via `GetBookFileByID`.
- New finding (documented, not fixed): `GetFolderDuplicates`/`GetDuplicateBooksByMetadata` have no `MemStore` implementation at all — `PebbleStore`'s versions are hard `return nil, nil` stubs regardless of `UseMemDB`. Folder- and metadata-based duplicate detection are non-functional no-ops in production today. Tracked as a new TODO item; implementing real detection logic is out of scope for this retype.
- Added a regression test (`internal/plugins/deluge/centralization_test.go`) that seeds a `FingerprintDiagnosticJSON` value and asserts it survives the deluge-centralize writeback — manually verified it fails against the pre-fix naive writeback.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` full suite green (see CI)
- [x] New regression test manually verified to fail pre-fix, pass post-fix
- [x] `make mocks` diff scoped to expected 5 files
