### PR TITLE
feat(database): expose DurationSec-invariant fingerprint count (STOREFID follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.122.0 -->
+<!-- version: 3.123.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,26 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - feat(database): expose DurationSec-invariant fingerprint count (STOREFID follow-up)
+
+- **`feat(database)`** — added `AcoustIDStats.WithFingerprintZeroDuration`, surfaced on the existing
+  `GET /maintenance/acoustid-stats` endpoint. Counts rows where an `AcoustIDFingerprint` blob is
+  present but `AcoustIDFingerprintDurationSec == 0`. This matters because the 3 PR-B fingerprint ops
+  (`lsh_backfill`, `lsh_index_build`, `online_lookup`) gate on `DurationSec > 0` as a memdb-surviving
+  proxy for "has a fingerprint" (the blob itself is stripped from memdb) — a nonzero count here means
+  that proxy is unsound for those rows, and they're being silently skipped.
+- Purely additive: new JSON field on an existing authenticated read-only endpoint, zero behavior
+  change to any existing field or caller. Computed in the same full-Pebble-scan pass
+  `GetAcoustIDStats` already does (`getAllBookFilesPebbleScan`), no new scan added.
+- Regression test `TestGetAcoustIDStats_ZeroDurationInvariant` added
+  (`internal/database/pebble_acoustid_stats_test.go`): seeds a normal fingerprinted row, an
+  invariant-violating (blob-but-zero-duration) row, and a no-fingerprint row; asserts the new counter
+  isolates exactly the violating row.
+- Closes the STOREFID "DurationSec invariant" BLOCKED item's *build* half — after this deploys, the
+  endpoint will be queried once against prod to determine the actual count and close the item fully.
+  Background: `.claude/notes/2026-07-07-storefid-session-resume.md`,
+  `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.
 
 #### July 7, 2026 - fix(dedup): stop dedup.full-scan freezing in the composing-scores phase (#19)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.71.0 -->
+<!-- version: 9.72.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -81,7 +81,7 @@ future agent) can scan the entire workspace in one page.
   already has full fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
   `metadataPairSimilarity`) that's just never fed any candidates today.
 
-## 🟡 Verify DurationSec invariant for the 3 PR-B fingerprint ops (2026-07-06)
+## 🟡 Verify DurationSec invariant for the 3 PR-B fingerprint ops (2026-07-06, diagnostic added 2026-07-07)
 
 - The 3 rerouted ops (lsh_backfill / lsh_index_build / online_lookup) gate on
   `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has a whole-file
@@ -89,6 +89,12 @@ future agent) can scan the entire workspace in one page.
   query** for `book_file` rows with a non-empty fingerprint blob but `DurationSec == 0`;
   if any exist they are silently skipped — backfill `DurationSec` or broaden the gate.
   Code comment in `internal/plugins/acoustid/online_lookup.go`.
+- **Diagnostic added (2026-07-07):** `AcoustIDStats.WithFingerprintZeroDuration`, surfaced on the
+  existing `GET /maintenance/acoustid-stats` endpoint, now answers this directly — no new op or
+  prod DB access needed. **Still needs one prod query run post-deploy to actually close this item**:
+  hit the endpoint and check `with_fingerprint_zero_duration`. If 0, the invariant holds and this
+  item is fully resolved. If nonzero, that count identifies exactly how many rows need a
+  `DurationSec` backfill.
 
 ---
 

--- a/internal/database/pebble_acoustid_stats_test.go
+++ b/internal/database/pebble_acoustid_stats_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_acoustid_stats_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e5f6a7b8-c9d0-1234-efab-234567890123
-// last-edited: 2026-06-17
+// last-edited: 2026-07-07
 
 package database
 
@@ -110,6 +110,53 @@ func TestGetAcoustIDStats_StaleMemDBDoesNotBreakLibraryGrouping(t *testing.T) {
 	assert.Equal(t, "/lib/audiobooks", stats.ByLibrary[0].LibraryRoot)
 	assert.Equal(t, 2, stats.ByLibrary[0].TotalFiles)
 	assert.Equal(t, 1, stats.ByLibrary[0].WithFingerprint)
+}
+
+// TestGetAcoustIDStats_ZeroDurationInvariant is the regression test for the
+// STOREFID DurationSec invariant check: PR-B ops gate on
+// AcoustIDFingerprintDurationSec>0 as a memdb-surviving proxy for "has a
+// fingerprint." A row with a fingerprint blob but DurationSec==0 breaks that
+// proxy and is silently skipped by those ops. WithFingerprintZeroDuration
+// exists so this can be verified against production data.
+func TestGetAcoustIDStats_ZeroDurationInvariant(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	importPath := "/lib"
+	src := "audible"
+	asin1, asin2, asin3 := "B010", "B011", "B012"
+	books := []Book{
+		{Title: "Normal FP", MetadataSource: &src, ASIN: &asin1, SourceImportPath: &importPath},
+		{Title: "Zero Duration FP", MetadataSource: &src, ASIN: &asin2, SourceImportPath: &importPath},
+		{Title: "No FP", MetadataSource: &src, ASIN: &asin3, SourceImportPath: &importPath},
+	}
+	for i := range books {
+		created, err := store.CreateBook(&books[i])
+		require.NoError(t, err)
+		books[i].ID = created.ID
+	}
+
+	// Normal row: fingerprint + a real duration.
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[0].ID, FilePath: "/lib/normal.m4b",
+		AcoustIDFingerprint: []byte{1, 2, 3, 4}, AcoustIDFingerprintDurationSec: 1800,
+	}))
+	// Invariant-violating row: fingerprint present, but DurationSec==0.
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[1].ID, FilePath: "/lib/zero-duration.m4b",
+		AcoustIDFingerprint: []byte{5, 6, 7, 8}, AcoustIDFingerprintDurationSec: 0,
+	}))
+	// No fingerprint at all: must not count either way.
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[2].ID, FilePath: "/lib/no-fp.m4b",
+	}))
+
+	ps := store.(*PebbleStore)
+	stats, err := ps.GetAcoustIDStats()
+	require.NoError(t, err)
+	assert.Equal(t, 3, stats.TotalFiles)
+	assert.Equal(t, 2, stats.WithFingerprint, "2 rows have a fingerprint blob")
+	assert.Equal(t, 1, stats.WithFingerprintZeroDuration, "exactly 1 fingerprinted row has DurationSec==0")
 }
 
 func TestGetAcoustIDStats_AllSegmentsChecked(t *testing.T) {

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
 // last-edited: 2026-07-07
 
@@ -693,6 +693,9 @@ func (p *PebbleStore) GetAcoustIDStats() (*AcoustIDStats, error) {
 			f.AcoustIDSeg3 != "" || f.AcoustIDSeg4 != "" || f.AcoustIDSeg5 != "" || f.AcoustIDSeg6 != ""
 		if hasFP {
 			stats.WithFingerprint++
+			if f.AcoustIDFingerprintDurationSec == 0 {
+				stats.WithFingerprintZeroDuration++
+			}
 		}
 
 		root := bookLib[f.BookID]

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.83.0
+// version: 2.84.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-07-03
+// last-edited: 2026-07-07
 
 package database
 
@@ -305,24 +305,24 @@ type Book struct {
 // by avoiding unnecessary data transfer. Companion field to Book for read-only
 // projection use cases (PROJ-2 SQL query optimization).
 type BookSummary struct {
-	ID                   string     `json:"id"`
-	Title                string     `json:"title"`
-	AuthorID             *int       `json:"author_id,omitempty"`
-	SeriesID             *int       `json:"series_id,omitempty"`
-	SeriesSequence       *int       `json:"series_sequence,omitempty"`
-	FilePath             string     `json:"file_path"`
-	Format               string     `json:"format,omitempty"`
-	Duration             *int       `json:"duration,omitempty"`
-	OriginalFilename     *string    `json:"original_filename,omitempty"`
-	FileSize             *int64     `json:"file_size,omitempty"`
-	FileHash             *string    `json:"file_hash,omitempty"`
-	OriginalFileHash     *string    `json:"original_file_hash,omitempty"`
-	OrganizedFileHash    *string    `json:"organized_file_hash,omitempty"`
-	LibraryState         *string    `json:"library_state,omitempty"`
-	QuarantinedAt        *time.Time `json:"quarantined_at,omitempty"`
-	QuarantineReason     *string    `json:"quarantine_reason,omitempty"`
-	CoverURL             *string    `json:"cover_url,omitempty"`
-	Narrator             *string    `json:"narrator,omitempty"`
+	ID                string     `json:"id"`
+	Title             string     `json:"title"`
+	AuthorID          *int       `json:"author_id,omitempty"`
+	SeriesID          *int       `json:"series_id,omitempty"`
+	SeriesSequence    *int       `json:"series_sequence,omitempty"`
+	FilePath          string     `json:"file_path"`
+	Format            string     `json:"format,omitempty"`
+	Duration          *int       `json:"duration,omitempty"`
+	OriginalFilename  *string    `json:"original_filename,omitempty"`
+	FileSize          *int64     `json:"file_size,omitempty"`
+	FileHash          *string    `json:"file_hash,omitempty"`
+	OriginalFileHash  *string    `json:"original_file_hash,omitempty"`
+	OrganizedFileHash *string    `json:"organized_file_hash,omitempty"`
+	LibraryState      *string    `json:"library_state,omitempty"`
+	QuarantinedAt     *time.Time `json:"quarantined_at,omitempty"`
+	QuarantineReason  *string    `json:"quarantine_reason,omitempty"`
+	CoverURL          *string    `json:"cover_url,omitempty"`
+	Narrator          *string    `json:"narrator,omitempty"`
 	// TranscribedTitle is the Whisper-parsed intro title, carried in the
 	// summary projection so filter-pushdown callers (e.g.
 	// FilterSpec.OnlyParsedTranscription) can distinguish parsed from
@@ -981,7 +981,7 @@ type LibraryStats struct {
 	// file error (from the book_file_errors_by_book: index). Populated alongside
 	// TotalBooks/TotalFiles in computeLibraryStats so all three counts share a
 	// single cache entry and invalidation path.
-	BrokenFiles int       `json:"broken_files"`
+	BrokenFiles int `json:"broken_files"`
 	// FingerprintedBooks/PartiallyFingerprintedBooks/UnfingerprintedBooks
 	// classify every non-deleted book by whether its active book_files have
 	// any/all/none of them fingerprinted (BookFile.GetAcoustIDSeg0() != "",
@@ -1081,6 +1081,12 @@ type AcoustIDStats struct {
 	TotalFiles      int                      `json:"total_files"`
 	WithFingerprint int                      `json:"with_fingerprint"` // ≥1 segment populated
 	ByLibrary       []AcoustIDStatsByLibrary `json:"by_library"`
+	// WithFingerprintZeroDuration counts fingerprinted rows where
+	// AcoustIDFingerprintDurationSec==0 (STOREFID DurationSec invariant check).
+	// The PR-B ops gate on this field surviving the memdb strip as a proxy for
+	// "has a fingerprint" — a nonzero count here means that proxy is unsound
+	// for those rows and they're being silently skipped by those ops.
+	WithFingerprintZeroDuration int `json:"with_fingerprint_zero_duration"`
 }
 
 // AcoustIDStatsByLibrary breaks down fingerprint coverage for one library root.


### PR DESCRIPTION
## Summary

- Add `AcoustIDStats.WithFingerprintZeroDuration`, surfaced on the existing `GET /maintenance/acoustid-stats` endpoint. Counts `book_file` rows where an `AcoustIDFingerprint` blob is present but `AcoustIDFingerprintDurationSec==0`.
- The 3 PR-B fingerprint ops (`lsh_backfill`, `lsh_index_build`, `online_lookup`) gate on `DurationSec>0` as a memdb-surviving proxy for "has a fingerprint" (the blob itself is stripped from memdb). A nonzero count here means that proxy is unsound for those rows and they're being silently skipped.
- Purely additive: new JSON field on an existing authenticated read-only endpoint, computed in the same full-Pebble-scan pass `GetAcoustIDStats` already does. Zero behavior change to any existing field or caller.
- Closes the build half of the STOREFID "DurationSec invariant" item (user chose "build a read-only diagnostic" over direct prod DB inspection). Needs one prod query run post-deploy to close the item fully.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/database/...` full package green (217.893s), including new `TestGetAcoustIDStats_ZeroDurationInvariant`
- [ ] Post-deploy: `curl` `/maintenance/acoustid-stats` on prod and confirm `with_fingerprint_zero_duration`