### PR TITLE
perf(dedup): index scoring-path CollectISBNASIN, O(N²)→O(matches) (#19 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.123.0 -->
+<!-- version: 3.124.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,28 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - perf(dedup): index the scoring-path ISBN/ASIN collector (O(N²) → O(matches)) (#19 follow-up)
+
+- **`perf(dedup)`** — `CollectISBNASIN` (the ISBN/ASIN collector on the unified *scoring* path)
+  previously did a full ~48K-book `GetAllBooksCore` scan **per book that has an external ID**,
+  making `dedup.full-scan`'s "Composing scores" phase O(N²) (~50 books/min → ~16 h projected on
+  prod). PR #1451 fixed this same O(N²) on the *emission* path (`checkExactISBN`) via an ISBN index,
+  but the scoring-path collector was a copy of the pre-#1451 logic and never got it. This grafts the
+  emission path's indexed fast path onto the collector: `GetBookIDsByISBNASIN` + per-match
+  `GetBookByID` when `IsISBNIndexBuilt()`, with the O(N) scan kept as the fallback when the index
+  isn't built. Behavior-preserving: same field precedence (isbn10 → isbn13 → asin), same evidence
+  strings, same `MarkedForDeletion` filtering (deletion parity with the scan).
+- `CollectISBNASIN` now takes a `context.Context` and checks `ctx.Err()` between units of work on
+  both paths, so cancellation is prompt — the previous ~1m48s cancel latency observed on prod came
+  from this loop having no ctx check (`registry.RunItems` only polls ctx between books).
+- Unblocks the #19 prod-confirmation gate: only after this can `dedup.full-scan` reach a clean
+  completion (clearing the ~10,114 "unknown" candidate backlog) *and* drive candidate writes fast
+  enough to actually load-test the `pebble.NoSync` write-stall fix (commit `087d0dbe`). #19 stays
+  open until that clean run is observed.
+- Tests (`internal/dedup/collectors_isbn_test.go`): indexed-vs-scan **signal-set equivalence**,
+  ctx-cancel promptness on both paths, empty-ISBN early return, index-not-built fallback. Whole
+  `internal/dedup/...` package passes under `-race`.
 
 #### July 7, 2026 - feat(database): expose DurationSec-invariant fingerprint count (STOREFID follow-up)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.72.0 -->
+<!-- version: 9.73.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -121,6 +121,20 @@ future agent) can scan the entire workspace in one page.
   → capture periodic goroutine+heap dumps → require a **clean full completion** (also
   clears the ~10,114 backlog). Escalation held in reserve if any residual stall:
   per-pair striped locks for truly-concurrent commits (WAL group-commit coalesces).
+- **✅ Prod run 2026-07-07 (pprof build):** the NoSync write-stall did **not** recur —
+  during the score phase pprof showed 0 mutex waiters, 0 goroutines parked on `s.mu`,
+  48 workers runnable in compute, 0 swap; graceful cancel **worked** this time
+  (`context canceled` propagated, worker pool drained, no restart, ~1m48s). BUT the
+  run could not reach clean completion: it exposed a **separate O(N²)** in the
+  scoring-path `CollectISBNASIN` (full `GetAllBooksCore` scan per ISBN-bearing book,
+  ~50 books/min → ~16 h), previously *masked* by the write-stall. Caveat: because the
+  O(N²) throttled candidate writes to a trickle, this run proved *mechanism + cancel*,
+  **not** stall-cured-under-load — the real load test needs the fast pass below.
+- **⏳ Now blocked on the O(N²) fix** (PR `fix/dedup-scoring-isbn-index`): grafts the
+  emission path's ISBN index onto `CollectISBNASIN` (O(matches)) + adds a `ctx.Err()`
+  check. After it deploys: confirm `IsISBNIndexBuilt()` on prod (run
+  `dedup.isbn-index-build` if not), then re-run `dedup.full-scan` to the clean
+  completion that finally closes #19 and load-tests NoSync.
 
 ### Original incident notes (2026-07-06, pre-root-cause — kept for history)
 

--- a/internal/dedup/collectors_exact.go
+++ b/internal/dedup/collectors_exact.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/collectors_exact.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-4c5d-8e6f-7a8b9c0d1e2f
 // last-edited: 2026-07-07
 
@@ -31,6 +31,7 @@
 package dedup
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -47,8 +48,11 @@ type ExactFileHashStore interface {
 }
 
 // ISBNASINStore is the subset of database.Store required by CollectISBNASIN.
+// GetAllBooksCore drives the O(N) scan fallback; GetBookByID hydrates the
+// indexed fast path (one point-read per index match).
 type ISBNASINStore interface {
 	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
+	GetBookByID(id string) (*database.Book, error)
 }
 
 // MetaSrcHashStore is the subset of database.Store required by
@@ -131,12 +135,16 @@ func CollectExactFileHash(
 
 // ─── ISBN/ASIN collector ──────────────────────────────────────────────────────
 
-// CollectISBNASIN scans all books for matching ISBN10, ISBN13, or ASIN and
-// emits a SigISBNASIN signal (confidence 0.98) per unique matching book.
+// CollectISBNASIN finds books that share an ISBN10, ISBN13, or ASIN with book
+// and emits a SigISBNASIN signal (confidence 0.98) per unique matching book.
 //
-// The scan is O(N) over all books.  This is acceptable because it only runs
-// when the query book has at least one ISBN/ASIN value — books without external
-// IDs are skipped immediately.
+// Two paths, mirroring checkExactISBN (engine.go): when a built ISBN index is
+// wired, the indexed fast path resolves matches in O(matches) via
+// GetBookIDsByISBNASIN + per-match GetBookByID; otherwise it falls back to the
+// O(N) GetAllBooksCore scan (the original behavior). Both paths are exercised
+// only when the query book has at least one external ID. Prior to this the
+// scoring path always took the O(N) scan — an O(N²) hotspot over the full score
+// pass (#19). Both paths honor ctx cancellation between units of work.
 //
 // Logic unchanged from checkExactISBN (engine.go:350-426); emission shape only.
 //
@@ -144,9 +152,12 @@ func CollectExactFileHash(
 // (re-scoring pre-existing candidates), NOT the emission path. The
 // hasPlausibleAudio gate — which lives on checkExactISBN in engine.go — is
 // intentionally not applied here; it is an emission-time guard and does not
-// belong on a scoring-only collector.
+// belong on a scoring-only collector. MarkedForDeletion IS filtered, so the
+// indexed set equals what the scan (via GetAllBooksCore's deletion filter) sees.
 func CollectISBNASIN(
+	ctx context.Context,
 	store ISBNASINStore,
+	index ISBNIndexStore,
 	book *database.Book,
 ) ([]unified.Signal, error) {
 	if book == nil {
@@ -160,13 +171,77 @@ func CollectISBNASIN(
 	if bookISBN10 == "" && bookISBN13 == "" && bookASIN == "" {
 		return nil, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// matchFieldFor derives the evidence field with the same precedence the scan
+	// used (isbn10 > isbn13 > asin); "" means no shared external ID.
+	matchFieldFor := func(oISBN10, oISBN13, oASIN string) string {
+		switch {
+		case bookISBN10 != "" && oISBN10 == bookISBN10:
+			return "isbn10:" + bookISBN10
+		case bookISBN13 != "" && oISBN13 == bookISBN13:
+			return "isbn13:" + bookISBN13
+		case bookASIN != "" && oASIN == bookASIN:
+			return "asin:" + bookASIN
+		}
+		return ""
+	}
+	emit := func(sigs []unified.Signal, otherID, matchField string) []unified.Signal {
+		return append(sigs, unified.Signal{
+			Kind:       unified.SigISBNASIN,
+			Raw:        1.0,
+			Confidence: 0.98,
+			Evidence:   fmt.Sprintf("isbn/asin match %s: book %s ↔ %s", matchField, book.ID, otherID),
+		})
+	}
 
 	seen := make(map[string]bool)
 	var signals []unified.Signal
 
+	// Fast path: indexed lookup, O(matches). Mirrors checkExactISBNIndexed.
+	if index != nil && index.IsISBNIndexBuilt() {
+		ids, err := index.GetBookIDsByISBNASIN(bookISBN10, bookISBN13, bookASIN)
+		if err != nil {
+			return nil, fmt.Errorf("CollectISBNASIN index lookup: %w", err)
+		}
+		for _, otherID := range ids {
+			if otherID == book.ID || seen[otherID] {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			other, err := store.GetBookByID(otherID)
+			if err != nil {
+				return nil, fmt.Errorf("CollectISBNASIN hydrate %s: %w", otherID, err)
+			}
+			if other == nil {
+				continue // deleted between index scan and point lookup
+			}
+			// Deletion parity: GetAllBooksCore excludes MarkedForDeletion books,
+			// so the scan path never sees them; match that here.
+			if other.MarkedForDeletion != nil && *other.MarkedForDeletion {
+				continue
+			}
+			matchField := matchFieldFor(derefStr(other.ISBN10), derefStr(other.ISBN13), derefStr(other.ASIN))
+			if matchField == "" {
+				continue // index over-returned (normalization); re-check keeps parity
+			}
+			seen[otherID] = true
+			signals = emit(signals, otherID, matchField)
+		}
+		return signals, nil
+	}
+
+	// Fallback: O(N) GetAllBooksCore scan (original behavior).
 	const batchSize = 500
 	offset := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		batch, err := store.GetAllBooksCore(batchSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("CollectISBNASIN get all books at offset %d: %w", offset, err)
@@ -180,24 +255,12 @@ func CollectISBNASIN(
 			if other.ID == book.ID || seen[other.ID] {
 				continue
 			}
-			var matchField string
-			if bookISBN10 != "" && derefStr(other.ISBN10) == bookISBN10 {
-				matchField = "isbn10:" + bookISBN10
-			} else if bookISBN13 != "" && derefStr(other.ISBN13) == bookISBN13 {
-				matchField = "isbn13:" + bookISBN13
-			} else if bookASIN != "" && derefStr(other.ASIN) == bookASIN {
-				matchField = "asin:" + bookASIN
-			}
+			matchField := matchFieldFor(derefStr(other.ISBN10), derefStr(other.ISBN13), derefStr(other.ASIN))
 			if matchField == "" {
 				continue
 			}
 			seen[other.ID] = true
-			signals = append(signals, unified.Signal{
-				Kind:       unified.SigISBNASIN,
-				Raw:        1.0,
-				Confidence: 0.98,
-				Evidence:   fmt.Sprintf("isbn/asin match %s: book %s ↔ %s", matchField, book.ID, other.ID),
-			})
+			signals = emit(signals, other.ID, matchField)
 		}
 
 		if len(batch) < batchSize {

--- a/internal/dedup/collectors_isbn_test.go
+++ b/internal/dedup/collectors_isbn_test.go
@@ -1,0 +1,178 @@
+// file: internal/dedup/collectors_isbn_test.go
+// version: 1.0.0
+// guid: 5a1f7c92-6d84-4e3b-9f21-8c0a4b6e2d75
+// last-edited: 2026-07-07
+
+// Tests for CollectISBNASIN (scoring-path ISBN/ASIN collector): the indexed fast
+// path must emit a signal set identical to the O(N) GetAllBooksCore scan, and
+// both paths must honor context cancellation promptly. See PLAN.md / #19.
+
+package dedup
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeISBNASINStore implements ISBNASINStore for collector tests: a fixed book
+// list for the O(N) scan path plus an ID→Book map for indexed hydration.
+type fakeISBNASINStore struct {
+	all           []database.BookCore // returned by GetAllBooksCore (already deletion-filtered)
+	byID          map[string]*database.Book
+	getAllCalls   int
+	getByIDCalls  int
+}
+
+func (f *fakeISBNASINStore) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
+	f.getAllCalls++
+	if offset >= len(f.all) {
+		return nil, nil
+	}
+	end := offset + limit
+	if limit <= 0 || end > len(f.all) {
+		end = len(f.all)
+	}
+	return f.all[offset:end], nil
+}
+
+func (f *fakeISBNASINStore) GetBookByID(id string) (*database.Book, error) {
+	f.getByIDCalls++
+	return f.byID[id], nil
+}
+
+// isbnBook builds a Book + matching BookCore fixture pair sharing the given IDs.
+func isbnCore(id, isbn10, isbn13, asin string) database.BookCore {
+	var i10, i13, a *string
+	if isbn10 != "" {
+		i10 = strPtr(isbn10)
+	}
+	if isbn13 != "" {
+		i13 = strPtr(isbn13)
+	}
+	if asin != "" {
+		a = strPtr(asin)
+	}
+	return database.BookCore{ID: id, ISBN10: i10, ISBN13: i13, ASIN: a}
+}
+
+func isbnFull(id, isbn10, isbn13, asin string) *database.Book {
+	b := &database.Book{ID: id}
+	if isbn10 != "" {
+		b.ISBN10 = strPtr(isbn10)
+	}
+	if isbn13 != "" {
+		b.ISBN13 = strPtr(isbn13)
+	}
+	if asin != "" {
+		b.ASIN = strPtr(asin)
+	}
+	return b
+}
+
+// sigKeys returns a comparable, order-independent view of a signal set:
+// "kind|confidence|evidence" per signal, sorted.
+func sigKeys(sigs []unified.Signal) []string {
+	keys := make([]string, 0, len(sigs))
+	for _, s := range sigs {
+		keys = append(keys, string(s.Kind)+"|"+s.Evidence)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// buildISBNFixture returns a store where BOOK_A shares ISBN13 with B, ISBN10 with
+// C, and ASIN with D; E matches nothing. All non-A books are the "others".
+func buildISBNFixture() (*fakeISBNASINStore, *database.Book, []string) {
+	others := []database.BookCore{
+		isbnCore("BOOK_B", "", "9780000000001", ""),      // ISBN13 match
+		isbnCore("BOOK_C", "0000000010", "", ""),         // ISBN10 match
+		isbnCore("BOOK_D", "", "", "B00ASIN0001"),        // ASIN match
+		isbnCore("BOOK_E", "9999999999", "9789999999999", "B00NOPE0000"), // no match
+	}
+	bookA := isbnFull("BOOK_A", "0000000010", "9780000000001", "B00ASIN0001")
+	store := &fakeISBNASINStore{
+		all:  append([]database.BookCore{isbnCore("BOOK_A", "0000000010", "9780000000001", "B00ASIN0001")}, others...),
+		byID: map[string]*database.Book{},
+	}
+	for _, c := range others {
+		store.byID[c.ID] = isbnFull(c.ID, derefStr(c.ISBN10), derefStr(c.ISBN13), derefStr(c.ASIN))
+	}
+	// Matching IDs the index would return (B, C, D — not E, not self A).
+	return store, bookA, []string{"BOOK_B", "BOOK_C", "BOOK_D"}
+}
+
+// TestCollectISBNASIN_IndexedMatchesScan is the core equivalence property: for the
+// same fixture, the indexed fast path and the O(N) scan path emit an identical
+// signal set, and each path touches only its own store method.
+func TestCollectISBNASIN_IndexedMatchesScan(t *testing.T) {
+	ctx := context.Background()
+
+	// Scan path: index nil.
+	scanStore, bookA, matchIDs := buildISBNFixture()
+	scanSigs, err := CollectISBNASIN(ctx, scanStore, nil, bookA)
+	require.NoError(t, err)
+	assert.Positive(t, scanStore.getAllCalls, "scan path must call GetAllBooksCore")
+	assert.Zero(t, scanStore.getByIDCalls, "scan path must not hydrate by ID")
+
+	// Indexed path: index built, returns the matching IDs.
+	idxStore, _, _ := buildISBNFixture()
+	idx := &fakeISBNIndexStore{built: true, returnIDs: matchIDs}
+	idxSigs, err := CollectISBNASIN(ctx, idxStore, idx, bookA)
+	require.NoError(t, err)
+	assert.Equal(t, 1, idx.getCallCount, "indexed path must query the index exactly once")
+	assert.Zero(t, idxStore.getAllCalls, "indexed path must NOT full-scan")
+	assert.Positive(t, idxStore.getByIDCalls, "indexed path must hydrate matches by ID")
+
+	// Both paths must find exactly the 3 matches (B, C, D).
+	assert.Len(t, scanSigs, 3, "scan path should find 3 ISBN/ASIN matches")
+	assert.Equal(t, sigKeys(scanSigs), sigKeys(idxSigs), "indexed and scan signal sets must be identical")
+	for _, s := range idxSigs {
+		assert.Equal(t, unified.SigISBNASIN, s.Kind)
+		assert.InDelta(t, 0.98, s.Confidence, 1e-9)
+	}
+}
+
+// TestCollectISBNASIN_CtxCancel verifies prompt cancellation on both paths.
+func TestCollectISBNASIN_CtxCancel(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanStore, bookA, matchIDs := buildISBNFixture()
+	_, err := CollectISBNASIN(cancelled, scanStore, nil, bookA)
+	require.ErrorIs(t, err, context.Canceled, "scan path must return promptly on cancelled ctx")
+
+	idxStore, _, _ := buildISBNFixture()
+	idx := &fakeISBNIndexStore{built: true, returnIDs: matchIDs}
+	_, err = CollectISBNASIN(cancelled, idxStore, idx, bookA)
+	require.ErrorIs(t, err, context.Canceled, "indexed path must return promptly on cancelled ctx")
+}
+
+// TestCollectISBNASIN_EmptyISBNEarlyReturn: a book with no ISBN/ASIN does no work.
+func TestCollectISBNASIN_EmptyISBNEarlyReturn(t *testing.T) {
+	store, _, _ := buildISBNFixture()
+	idx := &fakeISBNIndexStore{built: true}
+	sigs, err := CollectISBNASIN(context.Background(), store, idx, isbnFull("BOOK_X", "", "", ""))
+	require.NoError(t, err)
+	assert.Empty(t, sigs)
+	assert.Zero(t, store.getAllCalls)
+	assert.Zero(t, store.getByIDCalls)
+	assert.Zero(t, idx.getCallCount)
+}
+
+// TestCollectISBNASIN_FallbackWhenIndexNotBuilt: index present but not built →
+// scan path, index not queried.
+func TestCollectISBNASIN_FallbackWhenIndexNotBuilt(t *testing.T) {
+	store, bookA, _ := buildISBNFixture()
+	idx := &fakeISBNIndexStore{built: false}
+	sigs, err := CollectISBNASIN(context.Background(), store, idx, bookA)
+	require.NoError(t, err)
+	assert.Len(t, sigs, 3)
+	assert.Positive(t, store.getAllCalls, "must fall back to scan when index not built")
+	assert.Zero(t, idx.getCallCount, "index must not be queried when not built")
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.54.0
+// version: 1.55.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-07
 
@@ -541,7 +541,9 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	// of its pending candidates; we filter per candidate inside the loop below.
 	// Running these N times (once per candidate) multiplied DB reads by N.
 	allExactHashSigs, _ := CollectExactFileHash(de.bookStore, book)
-	allISBNSigs, _ := CollectISBNASIN(de.bookStore, book)
+	// Indexed ISBN/ASIN when the index is built (O(matches)); O(N) scan fallback
+	// otherwise. Passing ctx makes the scan cancellable mid-flight (#19).
+	allISBNSigs, _ := CollectISBNASIN(ctx, de.bookStore, de.isbnIndexStore, book)
 	allMetaSrcSigs, _ := CollectMetaSrcHash(de.bookStore, book)
 	allDurationSigs, _ := CollectDuration(de.bookStore, de.bookStore, book, durCfg)
 


### PR DESCRIPTION
## Why

Prod confirmation of the #19 `pebble.NoSync` write-stall fix (commit `087d0dbe`) this session showed the write-stall is gone (0 mutex waiters, workers runnable in compute, cancel works in ~1m48s) — but the `dedup.full-scan` "Composing scores" phase still could not reach a clean completion. pprof exposed a **separate O(N²)**: `CollectISBNASIN` (ISBN/ASIN collector on the unified *scoring* path) does a full ~48K-book `GetAllBooksCore` scan **per book that has an external ID** (~50 books/min → ~16h projected). It was previously *masked* by the write-stall.

PR #1451 already fixed this exact O(N²) on the *emission* path (`checkExactISBN`) with an ISBN index — but the scoring-path collector is a copy of the pre-#1451 logic and never got it.

## What

- Graft the emission path's indexed fast path onto `CollectISBNASIN`: `GetBookIDsByISBNASIN` + per-match `GetBookByID` when `IsISBNIndexBuilt()`, O(N) scan kept as the fallback when the index isn't built.
- **Behavior-preserving:** same field precedence (isbn10 → isbn13 → asin), same evidence strings, same `MarkedForDeletion` filtering (deletion parity with what `GetAllBooksCore`'s deletion filter lets the scan see). `hasPlausibleAudio` deliberately still omitted (scoring path, not emission).
- Add `context.Context` + `ctx.Err()` checks between units of work on both paths → prompt cancellation (kills the ~1m48s latency; `registry.RunItems` only polls ctx between books).

## Tests

`internal/dedup/collectors_isbn_test.go`:
- **indexed-vs-scan signal-set equivalence** (the core correctness property)
- ctx-cancel promptness on both paths
- empty-ISBN early return
- index-not-built fallback

Whole `internal/dedup/...` package passes under `-race`. `go build ./...`, `go vet` clean. (Local `make ci` staticcheck failures are all pre-existing U1000/SA1019 noise on main — none in the changed files.)

## Follow-up (not in this PR)

After merge + `make deploy-debug`: confirm `IsISBNIndexBuilt()` on prod (run `dedup.isbn-index-build` if needed), then re-run `dedup.full-scan` to the **clean completion** that closes #19 and load-tests NoSync under representative write rate. #19 stays open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)