### PR TITLE
feat(acoustid): add duration-backfill op for legacy zero-DurationSec fingerprints (STOREFID follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.126.0 -->
+<!-- version: 3.127.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,42 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - feat(acoustid): add duration-backfill op for legacy zero-DurationSec fingerprints (STOREFID follow-up)
+
+- **`feat(acoustid)`** — new manual-trigger operation `acoustid.duration-backfill`
+  (`internal/plugins/acoustid/duration_backfill.go`) that fixes the 2,781 prod `book_file` rows
+  found via the newly-deployed `with_fingerprint_zero_duration` counter: rows with an
+  `AcoustIDFingerprint` blob but `AcoustIDFingerprintDurationSec == 0`. These rows are invisible to
+  the 3 PR-B fingerprint ops (which gate on `DurationSec > 0`) and to the daily `acoustid.backfill`
+  cron op (which always skips rows that already have a blob, `force` is never set).
+- **Root cause**: `AcoustIDFingerprintDurationSec` is only ever set together with the fingerprint
+  blob, both from a single `fingerprint.FileWholeFingerprint()` call — there's no code path that
+  sets one without the other today. These rows are historical/legacy data (predate that invariant),
+  not an active bug in current write paths.
+- **Scoping**: added `Store.GetFilesWithZeroDurationFingerprint(limit, offset)` (`internal/database/
+  iface_misc.go` + `pebble_store_stats.go`), a Pebble-direct scan+filter mirroring the existing
+  sibling `GetFilesWithFingerprintFailures`. The new op scopes to exactly the violating rows via
+  this getter — not a full-library force-rescan (which would redundantly re-process ~293K already-
+  correct rows).
+- **Safety**: `DurationBackfillParams.Live` defaults to `false` (the Go zero value), so triggering
+  the op with no params — or any params JSON that omits the field — is always a read-only dry run
+  that reports the affected count + a capped sample of paths. Explicit `{"live": true}` required to
+  write. Re-running fpcalc is idempotent (same input file → same output), so there's no "wrong data
+  written" risk beyond what the existing `acoustid.backfill`/`acoustid.fingerprint-rescan` ops
+  already carry. **A top-level `fingerprint.Available()` gate was removed after CI caught it blocking
+  even the dry-run path** (which never calls fpcalc); the live path already handles backend
+  unavailability per-file via `doFingerprintFile`'s existing fallback chain.
+- **Concurrency**: bounded worker pool (`fpRescanWorkers()`, same tunable as `fingerprint_rescan.go`)
+  — the correctly-parallel sibling for this exact fpcalc-subprocess workload, per this repo's
+  concurrency-first convention. Not a book-level loop like `acoustid.backfill`; operates directly on
+  the scoped file list.
+- Regression test `TestGetFilesWithZeroDurationFingerprint_ScopesToViolatingRows`
+  (`internal/database/pebble_acoustid_stats_test.go`) plus 3 op-level tests
+  (`internal/plugins/acoustid/duration_backfill_test.go`): dry-run never writes, zero-affected-rows
+  is a clean no-op, live run correctly counts ineligible (missing-file) rows without erroring out.
+- `make mocks` regenerated 2 files (verified via `git diff --name-only`): `internal/database/mocks/
+  mock_store.go`, `internal/server/handlers/mocks/mock_reading_store.go`.
 
 #### July 7, 2026 - docs: #19 dedup.full-scan freeze RESOLVED + prod-confirmed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.75.0 -->
+<!-- version: 9.76.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -81,20 +81,26 @@ future agent) can scan the entire workspace in one page.
   already has full fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
   `metadataPairSimilarity`) that's just never fed any candidates today.
 
-## 🟡 Verify DurationSec invariant for the 3 PR-B fingerprint ops (2026-07-06, diagnostic added 2026-07-07)
+## 🟠 DurationSec invariant for the 3 PR-B fingerprint ops — CONFIRMED VIOLATED, fix built (2026-07-06 → 07)
 
 - The 3 rerouted ops (lsh_backfill / lsh_index_build / online_lookup) gate on
   `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has a whole-file
-  fingerprint". This assumes `AcoustIDFingerprint set ⇒ DurationSec > 0`. **Run a prod
-  query** for `book_file` rows with a non-empty fingerprint blob but `DurationSec == 0`;
-  if any exist they are silently skipped — backfill `DurationSec` or broaden the gate.
+  fingerprint". This assumes `AcoustIDFingerprint set ⇒ DurationSec > 0`.
   Code comment in `internal/plugins/acoustid/online_lookup.go`.
 - **Diagnostic added (2026-07-07):** `AcoustIDStats.WithFingerprintZeroDuration`, surfaced on the
-  existing `GET /maintenance/acoustid-stats` endpoint, now answers this directly — no new op or
-  prod DB access needed. **Still needs one prod query run post-deploy to actually close this item**:
-  hit the endpoint and check `with_fingerprint_zero_duration`. If 0, the invariant holds and this
-  item is fully resolved. If nonzero, that count identifies exactly how many rows need a
-  `DurationSec` backfill.
+  existing `GET /maintenance/acoustid-stats` endpoint.
+- **Prod query run (2026-07-07, post-deploy of `b28e9d9e`): 2,781 of 296,010 fingerprinted rows
+  (0.94%) violate the invariant.** These rows are permanently invisible to the 3 PR-B ops, and to
+  the daily `acoustid.backfill` cron (which also always skips rows with an existing blob).
+- **Fix built (2026-07-07):** new manual-trigger op `acoustid.duration-backfill`
+  (`internal/plugins/acoustid/duration_backfill.go`) scoped to exactly these rows via the new
+  `Store.GetFilesWithZeroDurationFingerprint` getter. Dry-run by default (`live` param must be
+  explicitly `true` to write); bounded worker pool matching `fingerprint_rescan.go`. See the
+  CHANGELOG entry for full detail.
+- **Still open:** the op is built and merged but has not yet been triggered against prod. Once run
+  with `live=true`, re-query `/maintenance/acoustid-stats` and confirm
+  `with_fingerprint_zero_duration` drops to (near) 0 — some rows may legitimately fail if the
+  source audio file no longer exists on disk (counted as `ineligible`, not silently dropped).
 
 ---
 

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,5 +1,5 @@
 // file: internal/database/iface_misc.go
-// version: 1.19.0
+// version: 1.20.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
 // last-edited: 2026-07-07
 
@@ -199,6 +199,11 @@ type BookFileStore interface {
 	// GetFilesWithFingerprintFailures returns book_files where FingerprintFailedAt is set,
 	// optionally filtered by reason. Returns the filtered page plus total matching count.
 	GetFilesWithFingerprintFailures(reason string, limit, offset int) ([]BookFile, int64, error)
+	// GetFilesWithZeroDurationFingerprint returns book_files where AcoustIDFingerprint is
+	// set but AcoustIDFingerprintDurationSec==0 (STOREFID DurationSec invariant violation
+	// — legacy rows the memdb-proxy-based fingerprint ops silently skip). Returns the
+	// filtered page plus total matching count.
+	GetFilesWithZeroDurationFingerprint(limit, offset int) ([]BookFile, int64, error)
 	// GetAcoustIDStats returns AcoustID fingerprint coverage across all book files,
 	// including a per-library-root breakdown.
 	GetAcoustIDStats() (*AcoustIDStats, error)

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/mock_store.go
-// version: 1.77.0
+// version: 1.78.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-07-07
 
@@ -369,6 +369,7 @@ type MockStore struct {
 	GetBookFileHashStatsFunc                func() (*BookFileHashStats, error)
 	GetBookMetadataHashStatsFunc            func() (*BookMetadataHashStats, error)
 	GetFilesWithFingerprintFailuresFunc     func(reason string, limit, offset int) ([]BookFile, int64, error)
+	GetFilesWithZeroDurationFingerprintFunc func(limit, offset int) ([]BookFile, int64, error)
 	GetAcoustIDStatsFunc                    func() (*AcoustIDStats, error)
 
 	// Path history
@@ -2513,6 +2514,13 @@ func (m *MockStore) GetBookMetadataHashStats() (*BookMetadataHashStats, error) {
 func (m *MockStore) GetFilesWithFingerprintFailures(reason string, limit, offset int) ([]BookFile, int64, error) {
 	if m.GetFilesWithFingerprintFailuresFunc != nil {
 		return m.GetFilesWithFingerprintFailuresFunc(reason, limit, offset)
+	}
+	return nil, 0, nil
+}
+
+func (m *MockStore) GetFilesWithZeroDurationFingerprint(limit, offset int) ([]BookFile, int64, error) {
+	if m.GetFilesWithZeroDurationFingerprintFunc != nil {
+		return m.GetFilesWithZeroDurationFingerprintFunc(limit, offset)
 	}
 	return nil, 0, nil
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -15267,6 +15267,80 @@ func (_c *MockBookFileStore_GetFilesWithFingerprintFailures_Call) RunAndReturn(r
 	return _c
 }
 
+// GetFilesWithZeroDurationFingerprint provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) GetFilesWithZeroDurationFingerprint(limit int, offset int) ([]database.BookFile, int64, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFilesWithZeroDurationFingerprint")
+	}
+
+	var r0 []database.BookFile
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookFile, int64, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookFile); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) int64); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(int, int) error); ok {
+		r2 = returnFunc(limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFilesWithZeroDurationFingerprint'
+type MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call struct {
+	*mock.Call
+}
+
+// GetFilesWithZeroDurationFingerprint is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockBookFileStore_Expecter) GetFilesWithZeroDurationFingerprint(limit any, offset any) *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call {
+	return &MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call{Call: _e.mock.On("GetFilesWithZeroDurationFingerprint", limit, offset)}
+}
+
+func (_c *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call) Run(run func(limit int, offset int)) *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call) Return(bookFiles []database.BookFile, n int64, err error) *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Return(bookFiles, n, err)
+	return _c
+}
+
+func (_c *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookFile, int64, error)) *MockBookFileStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarkFileImportedFromDeluge provides a mock function for the type MockBookFileStore
 func (_mock *MockBookFileStore) MarkFileImportedFromDeluge(ctx context.Context, originalPath string, libraryPath string, torrentHash string) error {
 	ret := _mock.Called(ctx, originalPath, libraryPath, torrentHash)
@@ -38881,6 +38955,80 @@ func (_c *MockStore_GetFilesWithFingerprintFailures_Call) Return(bookFiles []dat
 }
 
 func (_c *MockStore_GetFilesWithFingerprintFailures_Call) RunAndReturn(run func(reason string, limit int, offset int) ([]database.BookFile, int64, error)) *MockStore_GetFilesWithFingerprintFailures_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetFilesWithZeroDurationFingerprint provides a mock function for the type MockStore
+func (_mock *MockStore) GetFilesWithZeroDurationFingerprint(limit int, offset int) ([]database.BookFile, int64, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFilesWithZeroDurationFingerprint")
+	}
+
+	var r0 []database.BookFile
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookFile, int64, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookFile); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) int64); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(int, int) error); ok {
+		r2 = returnFunc(limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockStore_GetFilesWithZeroDurationFingerprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFilesWithZeroDurationFingerprint'
+type MockStore_GetFilesWithZeroDurationFingerprint_Call struct {
+	*mock.Call
+}
+
+// GetFilesWithZeroDurationFingerprint is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockStore_Expecter) GetFilesWithZeroDurationFingerprint(limit any, offset any) *MockStore_GetFilesWithZeroDurationFingerprint_Call {
+	return &MockStore_GetFilesWithZeroDurationFingerprint_Call{Call: _e.mock.On("GetFilesWithZeroDurationFingerprint", limit, offset)}
+}
+
+func (_c *MockStore_GetFilesWithZeroDurationFingerprint_Call) Run(run func(limit int, offset int)) *MockStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetFilesWithZeroDurationFingerprint_Call) Return(bookFiles []database.BookFile, n int64, err error) *MockStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Return(bookFiles, n, err)
+	return _c
+}
+
+func (_c *MockStore_GetFilesWithZeroDurationFingerprint_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookFile, int64, error)) *MockStore_GetFilesWithZeroDurationFingerprint_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_acoustid_stats_test.go
+++ b/internal/database/pebble_acoustid_stats_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_acoustid_stats_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: e5f6a7b8-c9d0-1234-efab-234567890123
 // last-edited: 2026-07-07
 
@@ -157,6 +157,49 @@ func TestGetAcoustIDStats_ZeroDurationInvariant(t *testing.T) {
 	assert.Equal(t, 3, stats.TotalFiles)
 	assert.Equal(t, 2, stats.WithFingerprint, "2 rows have a fingerprint blob")
 	assert.Equal(t, 1, stats.WithFingerprintZeroDuration, "exactly 1 fingerprinted row has DurationSec==0")
+}
+
+// TestGetFilesWithZeroDurationFingerprint_ScopesToViolatingRows verifies the
+// row-level getter that backs the acoustid.duration-backfill op: it must
+// return exactly the rows with a fingerprint blob but DurationSec==0, and
+// nothing else (not normal fingerprinted rows, not fingerprint-less rows).
+func TestGetFilesWithZeroDurationFingerprint_ScopesToViolatingRows(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	importPath := "/lib"
+	src := "audible"
+	asin1, asin2, asin3 := "B020", "B021", "B022"
+	books := []Book{
+		{Title: "Normal FP", MetadataSource: &src, ASIN: &asin1, SourceImportPath: &importPath},
+		{Title: "Zero Duration FP", MetadataSource: &src, ASIN: &asin2, SourceImportPath: &importPath},
+		{Title: "No FP", MetadataSource: &src, ASIN: &asin3, SourceImportPath: &importPath},
+	}
+	for i := range books {
+		created, err := store.CreateBook(&books[i])
+		require.NoError(t, err)
+		books[i].ID = created.ID
+	}
+
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[0].ID, FilePath: "/lib/normal.m4b",
+		AcoustIDFingerprint: []byte{1, 2, 3, 4}, AcoustIDFingerprintDurationSec: 1800,
+	}))
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[1].ID, FilePath: "/lib/zero-duration.m4b",
+		AcoustIDFingerprint: []byte{5, 6, 7, 8}, AcoustIDFingerprintDurationSec: 0,
+	}))
+	require.NoError(t, store.CreateBookFile(&BookFile{
+		BookID: books[2].ID, FilePath: "/lib/no-fp.m4b",
+	}))
+
+	ps := store.(*PebbleStore)
+	matched, total, err := ps.GetFilesWithZeroDurationFingerprint(0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, matched, 1)
+	assert.Equal(t, "/lib/zero-duration.m4b", matched[0].FilePath)
+	assert.Equal(t, books[1].ID, matched[0].BookID)
 }
 
 func TestGetAcoustIDStats_AllSegmentsChecked(t *testing.T) {

--- a/internal/database/pebble_store_stats.go
+++ b/internal/database/pebble_store_stats.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_stats.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 8643a893-1898-4098-8e69-c312531d962c
 // last-edited: 2026-07-07
 
@@ -739,6 +739,37 @@ func (p *PebbleStore) GetFilesWithFingerprintFailures(reason string, limit, offs
 			continue
 		}
 		if reason != "" && (f.FingerprintFailureReason == nil || *f.FingerprintFailureReason != reason) {
+			continue
+		}
+		matched = append(matched, f)
+	}
+	total := int64(len(matched))
+	if offset >= len(matched) {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if limit <= 0 || end > len(matched) {
+		end = len(matched)
+	}
+	return matched[offset:end], total, nil
+}
+
+// GetFilesWithZeroDurationFingerprint scans all book_files and returns those
+// where AcoustIDFingerprint is set but AcoustIDFingerprintDurationSec==0
+// (STOREFID DurationSec invariant violation). Same Pebble-direct scan as
+// GetFilesWithFingerprintFailures for the same reason: the fingerprint blob
+// is stripped from memdb-resident rows.
+func (p *PebbleStore) GetFilesWithZeroDurationFingerprint(limit, offset int) ([]BookFile, int64, error) {
+	allFiles, err := p.getAllBookFilesPebbleScan()
+	if err != nil {
+		return nil, 0, fmt.Errorf("GetFilesWithZeroDurationFingerprint: %w", err)
+	}
+	var matched []BookFile
+	for _, f := range allFiles {
+		if len(f.AcoustIDFingerprint) == 0 {
+			continue
+		}
+		if f.AcoustIDFingerprintDurationSec != 0 {
 			continue
 		}
 		matched = append(matched, f)

--- a/internal/plugins/acoustid/duration_backfill.go
+++ b/internal/plugins/acoustid/duration_backfill.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/acoustid/duration_backfill.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b
 // last-edited: 2026-07-07
 
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
-	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -57,9 +56,11 @@ func (p *Plugin) runDurationBackfill(ctx context.Context, params json.RawMessage
 	if p.store == nil {
 		return fmt.Errorf("database store not available")
 	}
-	if !fingerprint.Available() {
-		return fmt.Errorf("no fingerprint backend (fpcalc / ffmpeg) found")
-	}
+	// No top-level fingerprint.Available() gate: dry-run mode never calls
+	// fpcalc, and the live path already handles backend unavailability
+	// per-file via doFingerprintFile's fpcalc→ffmpeg→fail fallback chain
+	// (markFingerprintFailure), so a hard stop here would only abort the
+	// whole batch unnecessarily.
 
 	var req DurationBackfillParams
 	if len(params) > 0 {

--- a/internal/plugins/acoustid/duration_backfill.go
+++ b/internal/plugins/acoustid/duration_backfill.go
@@ -1,0 +1,146 @@
+// file: internal/plugins/acoustid/duration_backfill.go
+// version: 1.0.0
+// guid: e5f6a7b8-c9d0-4e1f-9a2b-3c4d5e6f7a8b
+// last-edited: 2026-07-07
+
+package acoustid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// DurationBackfillParams controls the acoustid.duration-backfill operation.
+// Live defaults to false (the Go zero value), so triggering the op with no
+// params — or any params JSON that omits the field — is always a safe,
+// read-only dry run. Callers must explicitly pass {"live": true} to write.
+type DurationBackfillParams struct {
+	Live bool `json:"live,omitempty"`
+}
+
+func (p *Plugin) durationBackfillDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "acoustid.duration-backfill",
+		Plugin:          "acoustid",
+		DisplayName:     "AcoustID DurationSec repair",
+		Description:     "Re-derives AcoustIDFingerprintDurationSec for book_files that have a fingerprint but DurationSec==0 (STOREFID follow-up). Dry-run by default; pass live=true to write.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "acoustid.fingerprint",
+		Isolate:         false,
+		Timeout:         6 * time.Hour,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+			sdk.CapFilesRead,
+			sdk.CapFilesExecute,
+			sdk.CapSubprocessSpawn,
+		},
+		Run: p.runDurationBackfill,
+	}
+}
+
+// runDurationBackfill scopes to exactly the rows where AcoustIDFingerprint is
+// set but AcoustIDFingerprintDurationSec==0 (via GetFilesWithZeroDurationFingerprint)
+// and re-runs fpcalc (force=true) on each. Uses the same bounded worker-pool
+// shape as fingerprint_rescan.go's runFingerprintRescan — the correctly-
+// parallel sibling for this exact fpcalc-subprocess workload.
+func (p *Plugin) runDurationBackfill(ctx context.Context, params json.RawMessage, reporter sdk.Reporter) error {
+	if p.store == nil {
+		return fmt.Errorf("database store not available")
+	}
+	if !fingerprint.Available() {
+		return fmt.Errorf("no fingerprint backend (fpcalc / ffmpeg) found")
+	}
+
+	var req DurationBackfillParams
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &req); err != nil {
+			reporter.Logger().Error("failed to unmarshal params", "error", err)
+			req = DurationBackfillParams{}
+		}
+	}
+
+	_ = reporter.UpdateProgress(0, 1, "Scanning for zero-duration fingerprinted files...")
+
+	files, _, err := p.store.GetFilesWithZeroDurationFingerprint(0, 0)
+	if err != nil {
+		return fmt.Errorf("scan zero-duration fingerprints: %w", err)
+	}
+
+	total := len(files)
+	if total == 0 {
+		_ = reporter.UpdateProgress(1, 1, "No zero-duration fingerprinted files found")
+		return nil
+	}
+
+	if !req.Live {
+		sample := make([]string, 0, 10)
+		for i, f := range files {
+			if i >= 10 {
+				break
+			}
+			sample = append(sample, f.FilePath)
+		}
+		reporter.Logger().Info("duration-backfill dry run", "affected_count", total, "sample", sample)
+		_ = reporter.UpdateProgress(1, 1, fmt.Sprintf("Dry run: %d files affected (pass live=true to fix)", total))
+		return nil
+	}
+
+	workers := fpRescanWorkers()
+
+	var (
+		fixed      atomic.Int64
+		failed     atomic.Int64
+		ineligible atomic.Int64
+	)
+	startedAt := time.Now()
+
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+
+	for _, f := range files {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return ctx.Err()
+		default:
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(bf database.BookFile) {
+			defer func() { <-sem; wg.Done() }()
+
+			if ctx.Err() != nil {
+				return
+			}
+
+			switch fingerprintBookFile(p.store, bf, true) {
+			case fingerprintOutcomeFingerprinted:
+				fixed.Add(1)
+			case fingerprintOutcomeFailed:
+				failed.Add(1)
+			case fingerprintOutcomeIneligible:
+				ineligible.Add(1)
+			}
+			done := fixed.Load() + failed.Load() + ineligible.Load()
+			_ = reporter.UpdateProgress(int(done), total,
+				fmt.Sprintf("fixed=%d failed=%d ineligible=%d / %d", fixed.Load(), failed.Load(), ineligible.Load(), total))
+		}(f)
+	}
+	wg.Wait()
+
+	_ = reporter.UpdateProgress(total, total,
+		fmt.Sprintf("Duration backfill complete in %s — fixed=%d failed=%d ineligible=%d (of %d)",
+			time.Since(startedAt).Round(time.Second), fixed.Load(), failed.Load(), ineligible.Load(), total))
+	return nil
+}

--- a/internal/plugins/acoustid/duration_backfill_test.go
+++ b/internal/plugins/acoustid/duration_backfill_test.go
@@ -1,0 +1,112 @@
+// file: internal/plugins/acoustid/duration_backfill_test.go
+// version: 1.0.0
+// guid: f6a7b8c9-d0e1-4f2a-9b3c-4d5e6f7a8b9c
+// last-edited: 2026-07-07
+
+package acoustid
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestDurationBackfill_DryRunDoesNotWrite verifies that omitting "live" (or
+// explicitly passing live=false) never calls UpdateBookFile — the op only
+// reports the affected count and a sample of paths.
+func TestDurationBackfill_DryRunDoesNotWrite(t *testing.T) {
+	files := []database.BookFile{
+		{ID: "f1", BookID: "b1", FilePath: "/lib/a.m4b", AcoustIDFingerprint: []byte{1, 2}},
+		{ID: "f2", BookID: "b2", FilePath: "/lib/b.m4b", AcoustIDFingerprint: []byte{3, 4}},
+	}
+
+	scanCalled := false
+	updateCalled := false
+	store := &database.MockStore{
+		GetFilesWithZeroDurationFingerprintFunc: func(limit, offset int) ([]database.BookFile, int64, error) {
+			scanCalled = true
+			return files, int64(len(files)), nil
+		},
+		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	p := &Plugin{store: store}
+	r := &lshTestReporter{}
+
+	if err := p.runDurationBackfill(context.Background(), nil, r); err != nil {
+		t.Fatalf("runDurationBackfill returned error: %v", err)
+	}
+	if !scanCalled {
+		t.Error("expected GetFilesWithZeroDurationFingerprint to be called")
+	}
+	if updateCalled {
+		t.Error("dry run must never call UpdateBookFile")
+	}
+}
+
+// TestDurationBackfill_NoAffectedFiles verifies the zero-rows path is a
+// clean no-op (matches the "no work to do" shape of the sibling ops).
+func TestDurationBackfill_NoAffectedFiles(t *testing.T) {
+	updateCalled := false
+	store := &database.MockStore{
+		GetFilesWithZeroDurationFingerprintFunc: func(limit, offset int) ([]database.BookFile, int64, error) {
+			return nil, 0, nil
+		},
+		UpdateBookFileFunc: func(id string, _ *database.BookFile) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	p := &Plugin{store: store}
+	r := &lshTestReporter{}
+
+	if err := p.runDurationBackfill(context.Background(), nil, r); err != nil {
+		t.Fatalf("runDurationBackfill returned error: %v", err)
+	}
+	if updateCalled {
+		t.Error("no affected files means UpdateBookFile must never be called")
+	}
+}
+
+// TestDurationBackfill_LiveRunSkipsMissingFiles verifies live=true actually
+// attempts a fix, and that files whose path no longer exists on disk are
+// counted as ineligible (via fingerprintEligibility's file_not_found guard)
+// rather than erroring the whole op out.
+func TestDurationBackfill_LiveRunSkipsMissingFiles(t *testing.T) {
+	files := []database.BookFile{
+		{ID: "f1", BookID: "b1", FilePath: "/does/not/exist/a.m4b", AcoustIDFingerprint: []byte{1, 2}},
+		{ID: "f2", BookID: "b2", FilePath: "/does/not/exist/b.m4b", AcoustIDFingerprint: []byte{3, 4}},
+	}
+
+	store := &database.MockStore{
+		GetFilesWithZeroDurationFingerprintFunc: func(limit, offset int) ([]database.BookFile, int64, error) {
+			return files, int64(len(files)), nil
+		},
+	}
+
+	p := &Plugin{store: store}
+	r := &lshTestReporter{}
+
+	params, err := json.Marshal(DurationBackfillParams{Live: true})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	if err := p.runDurationBackfill(context.Background(), params, r); err != nil {
+		t.Fatalf("runDurationBackfill returned error: %v", err)
+	}
+
+	if len(r.frames) < 2 {
+		t.Fatalf("expected at least 2 progress frames, got %d", len(r.frames))
+	}
+	last := r.frames[len(r.frames)-1]
+	if last.total != 2 || last.current != 2 {
+		t.Errorf("expected final frame 2/2, got %d/%d", last.current, last.total)
+	}
+}

--- a/internal/plugins/acoustid/plugin.go
+++ b/internal/plugins/acoustid/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/plugin.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789abc
-// last-edited: 2026-05-06
+// last-edited: 2026-07-07
 
 // Package acoustid is the UOS plugin for AcoustID fingerprinting operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -50,6 +50,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.resetAllDef(),
 		p.lshBackfillDef(),
 		p.onlineLookupDef(),
+		p.durationBackfillDef(),
 	}
 
 	for _, op := range ops {

--- a/internal/server/handlers/mocks/mock_reading_store.go
+++ b/internal/server/handlers/mocks/mock_reading_store.go
@@ -1223,6 +1223,80 @@ func (_c *MockReadingStore_GetFilesWithFingerprintFailures_Call) RunAndReturn(ru
 	return _c
 }
 
+// GetFilesWithZeroDurationFingerprint provides a mock function for the type MockReadingStore
+func (_mock *MockReadingStore) GetFilesWithZeroDurationFingerprint(limit int, offset int) ([]database.BookFile, int64, error) {
+	ret := _mock.Called(limit, offset)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFilesWithZeroDurationFingerprint")
+	}
+
+	var r0 []database.BookFile
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(int, int) ([]database.BookFile, int64, error)); ok {
+		return returnFunc(limit, offset)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int, int) []database.BookFile); ok {
+		r0 = returnFunc(limit, offset)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.BookFile)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int, int) int64); ok {
+		r1 = returnFunc(limit, offset)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(int, int) error); ok {
+		r2 = returnFunc(limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockReadingStore_GetFilesWithZeroDurationFingerprint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFilesWithZeroDurationFingerprint'
+type MockReadingStore_GetFilesWithZeroDurationFingerprint_Call struct {
+	*mock.Call
+}
+
+// GetFilesWithZeroDurationFingerprint is a helper method to define mock.On call
+//   - limit int
+//   - offset int
+func (_e *MockReadingStore_Expecter) GetFilesWithZeroDurationFingerprint(limit any, offset any) *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call {
+	return &MockReadingStore_GetFilesWithZeroDurationFingerprint_Call{Call: _e.mock.On("GetFilesWithZeroDurationFingerprint", limit, offset)}
+}
+
+func (_c *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call) Run(run func(limit int, offset int)) *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 int
+		if args[1] != nil {
+			arg1 = args[1].(int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call) Return(bookFiles []database.BookFile, n int64, err error) *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Return(bookFiles, n, err)
+	return _c
+}
+
+func (_c *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call) RunAndReturn(run func(limit int, offset int) ([]database.BookFile, int64, error)) *MockReadingStore_GetFilesWithZeroDurationFingerprint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetUserBookState provides a mock function for the type MockReadingStore
 func (_mock *MockReadingStore) GetUserBookState(userID string, bookID string) (*database.UserBookState, error) {
 	ret := _mock.Called(userID, bookID)


### PR DESCRIPTION
## Summary

- New manual-trigger operation `acoustid.duration-backfill` that fixes the 2,781 prod `book_file` rows found via the newly-deployed `with_fingerprint_zero_duration` counter: rows with an `AcoustIDFingerprint` blob but `AcoustIDFingerprintDurationSec==0`. These rows are invisible to the 3 PR-B fingerprint ops (gate on `DurationSec>0`) and to the daily `acoustid.backfill` cron (always skips rows with an existing blob).
- Root cause: `AcoustIDFingerprintDurationSec` is only ever set together with the fingerprint blob from a single `fingerprint.FileWholeFingerprint()` call — these rows are historical/legacy data, not an active write-path bug.
- Added `Store.GetFilesWithZeroDurationFingerprint` (mirrors the existing sibling `GetFilesWithFingerprintFailures`) to scope the new op to exactly the violating rows, not a full-library force-rescan.
- `Live` defaults to `false` (Go zero value) so the op is a safe read-only dry run unless `{"live": true}` is explicitly passed. Bounded worker pool matching `fingerprint_rescan.go`'s already-correctly-parallel shape for this exact fpcalc-subprocess workload.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short` full suite green (96 packages ok, 0 FAIL)
- [x] New tests: `TestGetFilesWithZeroDurationFingerprint_ScopesToViolatingRows`, `TestDurationBackfill_DryRunDoesNotWrite`, `TestDurationBackfill_NoAffectedFiles`, `TestDurationBackfill_LiveRunSkipsMissingFiles`
- [x] `make mocks` diff scoped to expected 2 files
- [ ] Post-deploy: trigger `acoustid.duration-backfill` dry-run, review sample/count, then live run with explicit confirmation