### PR TITLE
docs: close #19 — dedup.full-scan freeze resolved + prod-confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.124.0 -->
+<!-- version: 3.125.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 7, 2026 - docs: #19 dedup.full-scan freeze RESOLVED + prod-confirmed
+
+- **`docs`** — closes the #19 investigation. After the O(N²) collector fix (PR #1857, commit
+  `c36c05f4`) deployed with pprof, `dedup.build-isbn-index` set `IsISBNIndexBuilt()=true`
+  (7524/7524 books indexed, 0 failed) and `dedup.full-scan` ran **end-to-end to 100%**
+  (`44329/44329`, `duration_ms=675848` ≈ 11 min, op `01KWZQPTFYZY64AD1YB16A433D`) — the first
+  clean completion since the 2026-07-06 incident. Backlog cleared/rescored: **10869 pending
+  candidates**. The score phase reached **606 books/sec** (vs ~0.8/sec while broken), and the
+  `pebble.NoSync` write-stall fix (commit `087d0dbe`) was finally load-tested under a *fast*
+  write rate — candidate writes flowing, mutex waiters cycling to single digits, **zero swap**,
+  no L0 write-stall. Prod reverted to the pprof-off build afterward. TODO.md #19 section flipped
+  🟡 → ✅.
 
 #### July 7, 2026 - perf(dedup): index the scoring-path ISBN/ASIN collector (O(N²) → O(matches)) (#19 follow-up)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.73.0 -->
+<!-- version: 9.74.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -98,7 +98,7 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
-## 🟡 dedup.full-scan freezes in composing-scores phase even after CONC-2/PR #1809 (2026-07-06) — ROOT-CAUSED + FIX SHIPPED, prod confirmation pending
+## ✅ dedup.full-scan freezes in composing-scores phase even after CONC-2/PR #1809 (2026-07-06) — RESOLVED + PROD-CONFIRMED 2026-07-07
 
 - **✅ ROOT CAUSE (2026-07-07, static trace):** per-candidate `EmbeddingStore.UpsertCandidate`
   (`UpsertCandidateNew`) took the store-wide `s.mu` **and held it across
@@ -130,11 +130,19 @@ future agent) can scan the entire workspace in one page.
   ~50 books/min → ~16 h), previously *masked* by the write-stall. Caveat: because the
   O(N²) throttled candidate writes to a trickle, this run proved *mechanism + cancel*,
   **not** stall-cured-under-load — the real load test needs the fast pass below.
-- **⏳ Now blocked on the O(N²) fix** (PR `fix/dedup-scoring-isbn-index`): grafts the
-  emission path's ISBN index onto `CollectISBNASIN` (O(matches)) + adds a `ctx.Err()`
-  check. After it deploys: confirm `IsISBNIndexBuilt()` on prod (run
-  `dedup.isbn-index-build` if not), then re-run `dedup.full-scan` to the clean
-  completion that finally closes #19 and load-tests NoSync.
+- **✅ O(N²) fix MERGED** (PR #1857 / commit `c36c05f4`): grafts the emission path's
+  ISBN index onto `CollectISBNASIN` (O(matches)) + a `ctx.Err()` check on both paths.
+- **✅ CLEAN COMPLETION PROD-CONFIRMED 2026-07-07 22:19** (op `01KWZQPTFYZY64AD1YB16A433D`,
+  build `gc36c05f4-debug`): after `dedup.build-isbn-index` (7524/7524 indexed, 0 failed)
+  set `IsISBNIndexBuilt()=true`, `dedup.full-scan` ran **end-to-end to 100%**
+  (`44329/44329`, `duration_ms=675848` ≈ 11 min) — first clean completion since the
+  incident. **Backlog cleared/rescored: 10869 pending candidates.** The score phase hit
+  **606 books/sec** (was ~0.8/sec broken), and NoSync was finally load-tested under a
+  *fast* write rate: candidate writes flowing (`UpsertCandidate` active) with mutex
+  waiters cycling to single digits and **zero swap** — no write-stall. pprof build then
+  reverted to the normal prod build (`make deploy`, pprof off). **#19 CLOSED.**
+- Downstream (separate, owner-gated): `dedup.calibrate-embedding-thresholds`
+  (precision-target-not-met) can now be re-run against the freshly-scored 10869 backlog.
 
 ### Original incident notes (2026-07-06, pre-root-cause — kept for history)
 


### PR DESCRIPTION
Closes the #19 investigation. Docs-only.

After PR #1857 (O(N²) `CollectISBNASIN` fix, `c36c05f4`) deployed with pprof and `dedup.build-isbn-index` set `IsISBNIndexBuilt()=true` (7524/7524 indexed, 0 failed), `dedup.full-scan` ran **end-to-end to 100%** (`44329/44329`, `duration_ms=675848` ≈ 11 min, op `01KWZQPTFYZY64AD1YB16A433D`) — first clean completion since the 2026-07-06 incident.

- **Backlog cleared/rescored:** 10869 pending candidates.
- **Score phase 606 books/sec** (was ~0.8/sec while O(N²)-broken).
- **`pebble.NoSync` (`087d0dbe`) load-tested** under a fast write rate: candidate writes flowing, mutex waiters cycling to single digits, **zero swap**, no L0 write-stall.
- Prod reverted to the pprof-off build (`make deploy`).

Flips TODO.md #19 section 🟡 → ✅ and records the confirmation in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)