### PR TITLE
docs: correct #19 NoSync load-test characterization (mutex-waiter nuance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.125.0 -->
+<!-- version: 3.126.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -18,9 +18,12 @@
   clean completion since the 2026-07-06 incident. Backlog cleared/rescored: **10869 pending
   candidates**. The score phase reached **606 books/sec** (vs ~0.8/sec while broken), and the
   `pebble.NoSync` write-stall fix (commit `087d0dbe`) was finally load-tested under a *fast*
-  write rate — candidate writes flowing, mutex waiters cycling to single digits, **zero swap**,
-  no L0 write-stall. Prod reverted to the pprof-off build afterward. TODO.md #19 section flipped
-  🟡 → ✅.
+  write rate: `s.mu` is still a serialization point — waiters oscillate up to ~NumCPU (observed
+  44–46 in the write-heavy tail) — but with the fsync gone from the critical section each hold is
+  microseconds, so the queue **drains rather than accumulating into a write-stall** (hence 606
+  books/sec sustained, clean 11-min finish, **zero swap**). Per-pair striped locks remain a live
+  *throughput* optimization, never needed for correctness/stall. Prod reverted to the pprof-off
+  build afterward. TODO.md #19 section flipped 🟡 → ✅.
 
 #### July 7, 2026 - perf(dedup): index the scoring-path ISBN/ASIN collector (O(N²) → O(matches)) (#19 follow-up)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.74.0 -->
+<!-- version: 9.75.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-07 -->
 
@@ -138,8 +138,10 @@ future agent) can scan the entire workspace in one page.
   (`44329/44329`, `duration_ms=675848` ≈ 11 min) — first clean completion since the
   incident. **Backlog cleared/rescored: 10869 pending candidates.** The score phase hit
   **606 books/sec** (was ~0.8/sec broken), and NoSync was finally load-tested under a
-  *fast* write rate: candidate writes flowing (`UpsertCandidate` active) with mutex
-  waiters cycling to single digits and **zero swap** — no write-stall. pprof build then
+  *fast* write rate: `s.mu` stays a serialization point (waiters oscillate up to ~NumCPU,
+  observed 44–46 in the write-heavy tail) but with the fsync gone each hold is microseconds,
+  so the queue **drains rather than stalling** — **zero swap**, clean finish. Striped locks
+  remain a live *throughput* optimization, never needed for correctness. pprof build then
   reverted to the normal prod build (`make deploy`, pprof off). **#19 CLOSED.**
 - Downstream (separate, owner-gated): `dedup.calibrate-embedding-thresholds`
   (precision-target-not-met) can now be re-run against the freshly-scored 10869 backlog.


### PR DESCRIPTION
Docs-only honesty correction to the merged #19 closure notes (PR #1859).

The closure docs said "mutex waiters cycling to single digits." The actual pprof trace (run2.log) shows `SemacquireMutex` spiking to **44–46** (~NumCPU) in the write-heavy tail, with `runUnifiedScoring` down to 1–2 there. Accurate framing: `s.mu` **remains a serialization point** for candidate writes, but with the fsync gone from the critical section each hold is microseconds, so the queue **drains rather than accumulating into a write-stall** — hence 606 books/sec sustained, clean 11-min finish, zero swap. Per-pair striped locks remain a live *throughput* optimization, never needed for correctness/stall.

Conclusion (#19 resolved + prod-confirmed) is unchanged; only the mechanism wording is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)