### PR TITLE
docs: STOREFID DurationSec invariant RESOLVED + prod-confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.127.0 -->
+<!-- version: 3.128.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-07 -->
+<!-- last-edited: 2026-07-08 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 8, 2026 - docs: STOREFID DurationSec invariant RESOLVED + prod-confirmed
+
+- **`docs`** — closes out the STOREFID DurationSec invariant follow-up. `acoustid.duration-backfill`
+  (merged as commit `1194c726`) was deployed to prod, dry-run triggered first (confirmed 2,781
+  affected rows, reviewed a sample), then run live (op `01KWZW9ZGB5EP537643BAESPXR`):
+  **2781/2781 fixed, 0 failed, 0 ineligible, 1m9s.** Re-queried `GET /maintenance/acoustid-stats`:
+  `with_fingerprint_zero_duration` **2781 → 0**. The invariant the 3 PR-B fingerprint ops depend on
+  (`AcoustIDFingerprint set ⇒ DurationSec > 0`) now holds across the full library — this was the
+  last open item from STOREFID (all other waves closed 2026-07-07, see PR #1854/#1856/#1858).
+  TODO.md's DurationSec section flipped 🟠 → ✅.
 
 #### July 7, 2026 - feat(acoustid): add duration-backfill op for legacy zero-DurationSec fingerprints (STOREFID follow-up)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.76.0 -->
+<!-- version: 9.77.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-07 -->
+<!-- last-edited: 2026-07-08 -->
 
 # Project TODO
 
@@ -81,26 +81,26 @@ future agent) can scan the entire workspace in one page.
   already has full fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
   `metadataPairSimilarity`) that's just never fed any candidates today.
 
-## 🟠 DurationSec invariant for the 3 PR-B fingerprint ops — CONFIRMED VIOLATED, fix built (2026-07-06 → 07)
+## ✅ DurationSec invariant for the 3 PR-B fingerprint ops — RESOLVED + PROD-CONFIRMED (2026-07-06 → 08)
 
 - The 3 rerouted ops (lsh_backfill / lsh_index_build / online_lookup) gate on
   `AcoustIDFingerprintDurationSec > 0` as the memdb-safe proxy for "has a whole-file
-  fingerprint". This assumes `AcoustIDFingerprint set ⇒ DurationSec > 0`.
+  fingerprint". This assumed `AcoustIDFingerprint set ⇒ DurationSec > 0`.
   Code comment in `internal/plugins/acoustid/online_lookup.go`.
 - **Diagnostic added (2026-07-07):** `AcoustIDStats.WithFingerprintZeroDuration`, surfaced on the
   existing `GET /maintenance/acoustid-stats` endpoint.
 - **Prod query run (2026-07-07, post-deploy of `b28e9d9e`): 2,781 of 296,010 fingerprinted rows
-  (0.94%) violate the invariant.** These rows are permanently invisible to the 3 PR-B ops, and to
-  the daily `acoustid.backfill` cron (which also always skips rows with an existing blob).
+  (0.94%) violated the invariant.**
 - **Fix built (2026-07-07):** new manual-trigger op `acoustid.duration-backfill`
   (`internal/plugins/acoustid/duration_backfill.go`) scoped to exactly these rows via the new
   `Store.GetFilesWithZeroDurationFingerprint` getter. Dry-run by default (`live` param must be
-  explicitly `true` to write); bounded worker pool matching `fingerprint_rescan.go`. See the
-  CHANGELOG entry for full detail.
-- **Still open:** the op is built and merged but has not yet been triggered against prod. Once run
-  with `live=true`, re-query `/maintenance/acoustid-stats` and confirm
-  `with_fingerprint_zero_duration` drops to (near) 0 — some rows may legitimately fail if the
-  source audio file no longer exists on disk (counted as `ineligible`, not silently dropped).
+  explicitly `true` to write); bounded worker pool matching `fingerprint_rescan.go`.
+- **✅ RESOLVED (2026-07-08):** deployed (commit `1194c726`), dry-run triggered on prod first
+  (confirmed 2,781 affected, sample reviewed), then run live
+  (op `01KWZW9ZGB5EP537643BAESPXR`): **2781/2781 fixed, 0 failed, 0 ineligible, 1m9s.** Re-queried
+  `/maintenance/acoustid-stats`: **`with_fingerprint_zero_duration` dropped from 2781 → 0.**
+  Invariant now holds across the full library. The 3 PR-B ops and `acoustid.backfill` can now see
+  every fingerprinted row via the `DurationSec` proxy.
 
 ---
 


### PR DESCRIPTION
## Summary

- Closes out the STOREFID DurationSec invariant follow-up. \`acoustid.duration-backfill\` (merged as commit 1194c726) was deployed to prod, dry-run triggered first (confirmed 2,781 affected rows), then run live: **2781/2781 fixed, 0 failed, 0 ineligible, 1m9s**.
- Re-queried \`GET /maintenance/acoustid-stats\`: \`with_fingerprint_zero_duration\` **2781 → 0**. Invariant now holds across the full library.
- This was the last open item from STOREFID (all other waves closed 2026-07-07).

Docs-only change (TODO.md + CHANGELOG.md).