### PR TITLE
fix(dedup): bump BackfillVersionMarker to re-embed authors stranded on stale model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.128.0 -->
+<!-- version: 3.129.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -8,6 +8,31 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 8, 2026 - fix(dedup): bump BackfillVersionMarker to re-embed authors stranded on stale model
+
+- **`fix(dedup)`** — `internal/dedup/backfill_progress.go`: bumped `BackfillVersionMarker`
+  (`embedding_backfill_v5_done` → `embedding_backfill_v6_done`) to force one more run of
+  `runEmbeddingBackfill` on next startup.
+- **Root cause**: the Jul 2 2026 cutover from OpenAI `text-embedding-3-large` (3072-dim) to local
+  bge-m3 (1024-dim) was reconciled for books via the dedicated `dedup.reembed-embeddings` op, but
+  that op is explicitly books-only ("re-embedding authors is left to a follow-up" per its own doc
+  comment) — that follow-up was never built. `runEmbeddingBackfill`'s author loop
+  (`embedAuthorsConcurrent` → `EmbedAuthor`) is already model-aware (PR #1744,
+  `embeddingModelMatches`) and would have fixed this on its own, but it's gated by
+  `BackfillVersionMarker` and only runs once per marker generation — v5 predates the cutover, so it
+  never fired again.
+- **Observed symptom**: every server restart since Jul 2, `HydrateChromem` tried to mirror ~3,450
+  authors' stale 3072-dim vectors into the reconfigured 1024-dim chromem/HNSW ANN store, logging a
+  `dedup chromem upsert author ... vector dim 3072 != store dim 1024` warning per author (confirmed
+  via prod journalctl: 10,350 warnings / 3,450 unique author IDs in one startup burst, none since —
+  it's a one-time-per-restart burst, not an ongoing failure). Cosmetically noisy, but the real
+  defect is that those 3,450 authors had zero Layer 2 embedding-dedup coverage since the cutover.
+- **Fix scope**: one constant bump, zero new code — reuses the existing, tested, concurrent
+  author-embed path instead of building a new author-scoped reembed op. Next restart re-embeds the
+  affected authors via the model-aware path; books cache-hit immediately since they're already
+  reconciled. Also re-runs `PurgeStaleCandidates` + `FullScan`, both already hardened (see #19
+  closure, 2026-07-07).
 
 #### July 8, 2026 - docs: STOREFID DurationSec invariant RESOLVED + prod-confirmed
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.77.0 -->
+<!-- version: 9.78.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -17,6 +17,22 @@ future agent) can scan the entire workspace in one page.
 - [`docs/implementation-guide.md`](docs/implementation-guide.md) — integration guide for open items
 - [`docs/codebase-evaluation.md`](docs/codebase-evaluation.md) — 2026-04-30 codebase audit (12 issue groups, 38 bot-tasks)
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
+
+---
+
+## ✅ Author embeddings stranded on stale model (bge-m3 cutover follow-up) — RESOLVED (2026-07-08)
+
+- **Found via prod journalctl**: every restart since the Jul 2 2026 local-embeddings cutover
+  (OpenAI text-embedding-3-large 3072-dim → bge-m3 1024-dim), `HydrateChromem` logged
+  `dedup chromem upsert author ... vector dim 3072 != store dim 1024` for ~3,450 authors
+  (10,350 warnings in one startup burst; confirmed not ongoing — no recurrence since).
+- **Root cause**: `dedup.reembed-embeddings` (built for this exact cutover) is books-only by its
+  own doc comment ("re-embedding authors is left to a follow-up" — never built).
+  `runEmbeddingBackfill`'s author loop is already model-aware (PR #1744) but gated by
+  `BackfillVersionMarker`, which predates the cutover and was never bumped, so it never re-ran.
+- **Fix**: bumped `BackfillVersionMarker` v5 → v6 (`internal/dedup/backfill_progress.go`) — one
+  constant, zero new code, reuses the existing tested concurrent author-embed path. Takes effect
+  on next server restart/deploy.
 
 ---
 

--- a/internal/dedup/backfill_progress.go
+++ b/internal/dedup/backfill_progress.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/backfill_progress.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f6a7b8c9-d0e1-f2a3-b4c5-d6e7f8a9b0c1
-// last-edited: 2026-07-04
+// last-edited: 2026-07-08
 
 package dedup
 
@@ -18,8 +18,22 @@ package dedup
 //     "number", "no", "part", "pt", "episode", "ep", "#", and added a
 //     last-ditch digit-only-difference fallback to catch series volumes
 //     whose marker the regex doesn't recognize
-//   - v5: current version
-const BackfillVersionMarker = "embedding_backfill_v5_done"
+//   - v5: previous version
+//   - v6: re-run to pick up authors stranded on a stale embedding model.
+//     The Jul 2 2026 cutover from OpenAI text-embedding-3-large (3072-dim)
+//     to local bge-m3 (1024-dim) reconciled books via the dedicated
+//     dedup.reembed-embeddings op, but that op is books-only — author
+//     vectors were never re-embedded. Every restart since then,
+//     HydrateChromem tried to mirror ~3,450 authors' stale 3072-dim
+//     vectors into the 1024-dim ANN store and logged a dimension-mismatch
+//     warning per author (harmless spam, but those authors also had zero
+//     Layer 2 embedding-dedup coverage). runEmbeddingBackfill's author
+//     loop (embedAuthorsConcurrent -> EmbedAuthor) is already model-aware
+//     (PR #1744) and would have fixed this on its own, but it only runs
+//     once per marker generation — v5 predates the cutover, so it never
+//     fired again. Bumping to v6 triggers one more pass; books cache-hit
+//     immediately (already reconciled), authors get freshly embedded.
+const BackfillVersionMarker = "embedding_backfill_v6_done"
 
 // NewDedupScanProgressLogger returns a progress callback suitable for
 // Engine.FullScan that logs once every `interval` books processed (plus


### PR DESCRIPTION
## Summary
- 3,450 authors have been stuck on stale 3072-dim (OpenAI text-embedding-3-large) embeddings since the Jul 2 2026 local-embeddings cutover to bge-m3 (1024-dim). `dedup.reembed-embeddings` reconciled books but is explicitly books-only.
- `runEmbeddingBackfill`'s author loop is already model-aware (PR #1744) and would have fixed this on its own — it's just gated by `BackfillVersionMarker`, which predates the cutover (v5) and was never bumped, so it never ran again.
- Symptom: every restart since the cutover, `HydrateChromem` tried to mirror these authors' stale-dim vectors into the reconfigured 1024-dim chromem/HNSW store and logged a `vector dim 3072 != store dim 1024` warning per author (10,350 warnings / 3,450 unique author IDs confirmed via prod journalctl in one startup burst; none since — cosmetic, but those authors also had zero Layer 2 embedding-dedup coverage in the meantime).
- Fix: bump `BackfillVersionMarker` v5 → v6. One constant, zero new code — reuses the existing tested concurrent author-embed path (`embedAuthorsConcurrent` → `EmbedAuthor`) instead of building a new author-scoped reembed op. Takes effect on next server restart/deploy: books cache-hit immediately (already reconciled), authors get freshly embedded.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dedup/... ./internal/server/... -run 'Backfill|EmbedModel|Embed' -short` — all pass
- [x] `go test ./... -short` — pass except `internal/server` (`TestListActiveOperations` hangs to the 300s/600s default timeout); confirmed **identical hang reproduces on `main` with this change absent**, so it's a pre-existing local-environment issue unrelated to this fix, not something this PR introduces
- [ ] Confirm on real CI (Minimal CI / Go Tests short+race) that this pre-existing hang doesn't actually block — main passed this same job a few hours ago (PR #1861)
- [ ] After merge + deploy: watch the next restart's logs for `runEmbeddingBackfill`/author-embed progress, then re-check `journalctl` for the `dedup chromem upsert author` warning — should be zero on the following restart

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A8ggNEBJCA8PJnBdg7g2GF