### PR TITLE
fix(ci): bump stale github-common pin causing Nightly Full CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.5
+# version: 3.0.6
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-07-03
+# last-edited: 2026-07-08
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -28,7 +28,7 @@ jobs:
   # Parallel fast jobs via reusable minimal workflow
   ci:
     name: Minimal CI
-    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-ci-minimal.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # main 2026-07-05 (fixes jdfalk/ghcommon -> falkcorp/github-common stale-ref 400 error)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/frontend-ci.yml
-# version: 2.9.4
+# version: 2.9.5
 # guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
-# last-edited: 2026-07-03
+# last-edited: 2026-07-08
 
 name: Frontend CI
 
@@ -51,7 +51,7 @@ jobs:
     name: Frontend Build and Test
     needs: frontend-config
     if: needs.frontend-config.outputs.has-frontend == 'true'
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # main 2026-07-05 (fixes jdfalk/ghcommon -> falkcorp/github-common stale-ref 400 error)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/nightly.yml
-# version: 1.0.3
+# version: 1.0.4
 # guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-# last-edited: 2026-07-03
+# last-edited: 2026-07-08
 
 # Nightly full CI: property tests, coverage check, E2E, staticcheck.
 # Runs the complete reusable-ci.yml suite on a schedule.
@@ -28,7 +28,7 @@ permissions:
 jobs:
   full-ci:
     name: Full CI Suite
-    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main 2026-07-03 (go test -timeout 30m fix)
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # main 2026-07-05 (fixes jdfalk/ghcommon -> falkcorp/github-common stale-ref 400 error)
     with:
       go-version: '1.26'
       go-experiment: 'jsonv2'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/security.yml
-# version: 2.4.0
+# version: 2.4.1
 # guid: 7f2a3c1d-4e5f-6g7h-8i9j-0k1l2m3n4o5p
-# last-edited: 2026-07-03
+# last-edited: 2026-07-08
 #
 # Security scanning: advanced CodeQL, dependency review, language audits, and
 # Go/NPM dependency submission for supply chain security. Third-party filesystem
@@ -27,7 +27,7 @@ permissions:
 jobs:
   advanced-security:
     name: Advanced CodeQL Security
-    uses: falkcorp/github-common/.github/workflows/reusable-security.yml@1dec34cd8d8e2504d9be8298b522eff11448a401 # main @ 2026-07-03, no tagged release yet
+    uses: falkcorp/github-common/.github/workflows/reusable-security.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # main 2026-07-05 (fixes jdfalk/ghcommon -> falkcorp/github-common stale-ref 400 error)
     with:
       languages: '["go", "javascript", "actions"]'
       skip-codeql: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@
 
 ### Features & Fixes
 
+#### July 8, 2026 - fix(ci): bump stale github-common pin causing Nightly Full CI failure
+
+- **`fix(ci)`** — `Nightly Full CI` (and `Security`/`Frontend CI` which share the same reusable
+  workflows) was pinned to `falkcorp/github-common@1dec34c`, a commit that predates
+  `github-common`'s own `a575899` fix ("update remaining jdfalk/ghcommon references to
+  falkcorp/github-common"). `reusable-ci.yml` at that stale pin still had 5 occurrences of the
+  pre-org-migration `jdfalk/ghcommon` submodule path, causing
+  `fatal: unable to access 'https://github.com/jdfalk/ghcommon/': ... 400` on every nightly run.
+- Bumped all 4 `falkcorp/github-common` pins in this repo (`ci.yml`, `nightly.yml`, `security.yml`,
+  `frontend-ci.yml`) to `github-common`'s current main (`7ff6ed8`), which includes the fix plus
+  subsequent accumulated improvements (release cleanup-guard, gha-release-go/gha-docs-generator pin
+  bumps). Verified zero remaining `1dec34c` references and valid YAML on all 4 files.
+- Found while investigating a general CI-health check; `ci.yml`'s `reusable-ci-minimal.yml` was not
+  itself in the buggy-file list (Minimal CI/PR checks were unaffected), bumped anyway for
+  consistency and to track the same current pin across all 4 callers.
+
 #### July 8, 2026 - fix(dedup): bump BackfillVersionMarker to re-embed authors stranded on stale model
 
 - **`fix(dedup)`** — `internal/dedup/backfill_progress.go`: bumped `BackfillVersionMarker`


### PR DESCRIPTION
## Summary

- `Nightly Full CI` was failing with `fatal: unable to access 'https://github.com/jdfalk/ghcommon/': ... 400` on every scheduled run — a stale pre-org-migration submodule path.
- Root cause: the reusable workflow pin (`falkcorp/github-common@1dec34c`) predates `github-common`'s own fix for this exact issue (commit `a575899`, "update remaining jdfalk/ghcommon references to falkcorp/github-common"), which touched `reusable-ci.yml` (5 occurrences).
- Bumped all 4 `falkcorp/github-common` pins in this repo (`ci.yml`, `nightly.yml`, `security.yml`, `frontend-ci.yml`) to current main (`7ff6ed8`).

## Test plan

- [x] `grep` confirms zero remaining references to the stale pin
- [x] All 4 edited YAML files parse cleanly
- [x] No Go code touched, `go build ./...` unaffected
- [ ] Post-merge: confirm next `Nightly Full CI` run passes