### PR TITLE
fix(dedup): bump BackfillVersionMarker v6 -> v7 to close 3-author gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.129.0 -->
+<!-- version: 3.130.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 8, 2026 - fix(dedup): bump BackfillVersionMarker v6 -> v7 to close 3-author gap
+
+- **`fix(dedup)`** — `internal/dedup/backfill_progress.go`: bumped `BackfillVersionMarker`
+  (`embedding_backfill_v6_done` → `embedding_backfill_v7_done`).
+- **Follow-up to v6** (below): deploying v6 re-embedded 9,080/9,083 authors cleanly, but 3
+  (authorIDs 39755, 40861, 42076) were touched after `runEmbeddingBackfill`'s `GetAllAuthors()`
+  snapshot was taken and missed that pass — confirmed via prod journalctl, still logging the
+  `vector dim 3072 != store dim 1024` warning after a fresh restart post-v6.
+- **Cost**: since everything except these 3 stragglers is already reconciled at bge-m3, this re-run
+  should be fast — books and the other 9,080 authors cache-hit immediately (TextHash + model match),
+  only the 3 do real embedding work. Still re-runs the full `PurgeStaleCandidates` + `FullScan` pass
+  as a side effect of the shared `runEmbeddingBackfill` pipeline.
 
 #### July 8, 2026 - fix(ci): bump stale github-common pin causing Nightly Full CI failure
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.78.0 -->
+<!-- version: 9.79.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -31,8 +31,11 @@ future agent) can scan the entire workspace in one page.
   `runEmbeddingBackfill`'s author loop is already model-aware (PR #1744) but gated by
   `BackfillVersionMarker`, which predates the cutover and was never bumped, so it never re-ran.
 - **Fix**: bumped `BackfillVersionMarker` v5 → v6 (`internal/dedup/backfill_progress.go`) — one
-  constant, zero new code, reuses the existing tested concurrent author-embed path. Takes effect
-  on next server restart/deploy.
+  constant, zero new code, reuses the existing tested concurrent author-embed path. Deployed and
+  verified on prod: 9,080/9,083 authors reconciled, warning count dropped from 10,350/restart to 0.
+- **Residual**: 3 authors (39755, 40861, 42076) were touched after the v6 run's `GetAllAuthors()`
+  snapshot and missed the pass — still warning post-v6. Bumped v6 → v7 to close the gap; cheap
+  re-run since everything else already cache-hits at bge-m3.
 
 ---
 

--- a/internal/dedup/backfill_progress.go
+++ b/internal/dedup/backfill_progress.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/backfill_progress.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f6a7b8c9-d0e1-f2a3-b4c5-d6e7f8a9b0c1
 // last-edited: 2026-07-08
 
@@ -19,21 +19,15 @@ package dedup
 //     last-ditch digit-only-difference fallback to catch series volumes
 //     whose marker the regex doesn't recognize
 //   - v5: previous version
-//   - v6: re-run to pick up authors stranded on a stale embedding model.
-//     The Jul 2 2026 cutover from OpenAI text-embedding-3-large (3072-dim)
-//     to local bge-m3 (1024-dim) reconciled books via the dedicated
-//     dedup.reembed-embeddings op, but that op is books-only — author
-//     vectors were never re-embedded. Every restart since then,
-//     HydrateChromem tried to mirror ~3,450 authors' stale 3072-dim
-//     vectors into the 1024-dim ANN store and logged a dimension-mismatch
-//     warning per author (harmless spam, but those authors also had zero
-//     Layer 2 embedding-dedup coverage). runEmbeddingBackfill's author
-//     loop (embedAuthorsConcurrent -> EmbedAuthor) is already model-aware
-//     (PR #1744) and would have fixed this on its own, but it only runs
-//     once per marker generation — v5 predates the cutover, so it never
-//     fired again. Bumping to v6 triggers one more pass; books cache-hit
-//     immediately (already reconciled), authors get freshly embedded.
-const BackfillVersionMarker = "embedding_backfill_v6_done"
+//   - v6: re-run to pick up authors stranded on a stale embedding model
+//     (Jul 2 2026 OpenAI-to-bge-m3 cutover; see git history for detail).
+//     Deployed 2026-07-08: reconciled 9,080/9,083 authors. 3 authors
+//     (39755, 40861, 42076) were touched after the run's GetAllAuthors()
+//     snapshot was taken and missed the pass.
+//   - v7: re-run once more to close the 3-author gap left by v6. Cheap:
+//     books and the other 9,080 authors cache-hit immediately (already
+//     reconciled at bge-m3), only the 3 stragglers do real embedding work.
+const BackfillVersionMarker = "embedding_backfill_v7_done"
 
 // NewDedupScanProgressLogger returns a progress callback suitable for
 // Engine.FullScan that logs once every `interval` books processed (plus


### PR DESCRIPTION
## Summary
- Follow-up to #1862 (v6). Deploying v6 re-embedded 9,080/9,083 authors cleanly (10,350 warnings/restart -> 0), but 3 authors (39755, 40861, 42076) were touched after `runEmbeddingBackfill`'s `GetAllAuthors()` snapshot and missed that pass — confirmed via prod journalctl, still logging `vector dim 3072 != store dim 1024` after a fresh post-v6 restart.
- Bumps `BackfillVersionMarker` v6 → v7 to trigger one more pass. Should be cheap: books and the other 9,080 authors cache-hit immediately (already reconciled), only the 3 stragglers do real embedding work. Still re-runs `PurgeStaleCandidates` + `FullScan` as a side effect of the shared pipeline.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dedup/... ./internal/server/... -run 'Backfill|EmbedModel|Embed' -short` — pass
- [ ] Deploy + confirm on prod: the 3 remaining authors get embedded, warning count drops to 0 with no residual

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A8ggNEBJCA8PJnBdg7g2GF