### PR TITLE
fix(dedup): HydrateChromem skips stale-model embedding rows instead of spamming warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.130.0 -->
+<!-- version: 3.131.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 8, 2026 - fix(dedup): HydrateChromem skips stale-model embedding rows instead of spamming warnings
+
+- **`fix(dedup)`** — `internal/dedup/engine.go` `HydrateChromem`: both the book and author loops now
+  skip any stored embedding row whose model doesn't match the currently-wired embed client
+  (`embeddingModelMatches`), instead of attempting to mirror it into the ANN store where it fails
+  the dimension check and logs a per-row warning.
+- **Root cause of the v6/v7 residual**: 3 author IDs (39755, 40861, 42076) kept logging
+  `dedup chromem upsert author ... vector dim 3072 != store dim 1024` on every restart even after
+  the v7 backfill (#1862, #1865). Root-caused via `GetAllAuthors()` returning `total=9080` in both
+  backfill runs while `ListByType("author")` returns `9083` rows — an exact, reproducible 3-row gap,
+  not a race. `GetAuthorByID` has explicit tombstone-redirect logic for merged authors that
+  `GetAllAuthors()` doesn't apply (it iterates literal `author:N` keys), so these 3 are embedding
+  rows orphaned by an author merge/delete — the entity is gone, so no amount of re-running the
+  backfill (`GetAllAuthors()`-driven) can ever reach them.
+- **Fix**: rather than another marker bump (which cannot work — confirmed dead-end), add the guard
+  HydrateChromem should have had from the start. Also adds a single summary `slog.Warn` per hydrate
+  run (`stale_books`, `stale_authors` counts) when any are skipped, so these rows stay visible as
+  candidates for re-embed or a future orphan-cleanup pass instead of silently vanishing from the
+  logs. Covered by new test `TestHydrateChromem_SkipsStaleModelRows` (both the "still-resolvable but
+  stale" and "orphaned, doesn't resolve at all" cases, for both books and authors).
 
 #### July 8, 2026 - fix(dedup): bump BackfillVersionMarker v6 -> v7 to close 3-author gap
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.79.0 -->
+<!-- version: 9.80.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -33,9 +33,20 @@ future agent) can scan the entire workspace in one page.
 - **Fix**: bumped `BackfillVersionMarker` v5 → v6 (`internal/dedup/backfill_progress.go`) — one
   constant, zero new code, reuses the existing tested concurrent author-embed path. Deployed and
   verified on prod: 9,080/9,083 authors reconciled, warning count dropped from 10,350/restart to 0.
-- **Residual**: 3 authors (39755, 40861, 42076) were touched after the v6 run's `GetAllAuthors()`
-  snapshot and missed the pass — still warning post-v6. Bumped v6 → v7 to close the gap; cheap
-  re-run since everything else already cache-hits at bge-m3.
+- **Residual (corrected)**: 3 authors (39755, 40861, 42076) still warned post-v6. Initially assumed
+  a `GetAllAuthors()` snapshot race and bumped v6 → v7 to retry — but the same 3 IDs recurred
+  identically after v7, proving it wasn't a race. Root cause: `GetAllAuthors()` iterates literal
+  `author:N` Pebble keys and returned `total=9080` both times, while the embedding store has 9083
+  rows — these 3 are orphaned rows left by an author merge/delete (`GetAuthorByID` has
+  tombstone-redirect logic for merged authors that `GetAllAuthors()` doesn't apply). No backfill
+  re-run can ever reach them, since the entity is gone.
+- **Final fix**: `HydrateChromem` (both book and author loops) now skips any row whose stored model
+  doesn't match the current embed client, instead of attempting a doomed mirror + warning. Logs one
+  summary line per hydrate (`stale_books`/`stale_authors` counts) so orphaned/stale rows stay
+  visible instead of silently vanishing. No marker bump needed — deploy + restart only.
+- **Optional future work (not blocking)**: an author-side `cleanup-orphan-embeddings` (the book-side
+  one already exists) to actually delete these dead rows from Pebble, for clean data. The hydrate
+  guard already makes them harmless, so this is cosmetic/hygiene only.
 
 ---
 

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.55.0
+// version: 1.56.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-07
+// last-edited: 2026-07-08
 
 package dedup
 
@@ -323,7 +323,14 @@ func (de *Engine) getScoreConfig() unified.ScoreConfig {
 //
 // Books that no longer exist or are non-primary version-group members are
 // skipped; the embedding table may contain stale rows that EmbedBook would
-// have cleaned up on its next visit.
+// have cleaned up on its next visit. Rows stamped with a different model
+// than the currently-wired embed client are also skipped — mirroring one
+// would only fail the ANN store's dimension check (e.g. after a model
+// cutover) and log a warning for no benefit. Orphaned rows left behind by a
+// merge/delete (the entity no longer exists to re-embed) hit this same
+// guard, since a re-embed can never reach them either; the mismatched
+// vector just sits inert in the embedding table instead of spamming logs
+// every restart.
 //
 // Returns counts so the caller can log progress. Errors on individual rows
 // are logged but never abort the hydrate — partial coverage is better than
@@ -332,6 +339,8 @@ func (de *Engine) HydrateChromem(ctx context.Context) (booksHydrated, authorsHyd
 	if de.chromemStore == nil || de.embedStore == nil {
 		return 0, 0, nil
 	}
+
+	var staleBooks, staleAuthors int
 
 	bookEmbeds, err := de.embedStore.ListByType("book")
 	if err != nil {
@@ -342,6 +351,10 @@ func (de *Engine) HydrateChromem(ctx context.Context) (booksHydrated, authorsHyd
 			return booksHydrated, authorsHydrated, err
 		}
 		if len(e.Vector) == 0 {
+			continue
+		}
+		if !de.embeddingModelMatches(e.Model) {
+			staleBooks++
 			continue
 		}
 		book, _ := de.bookStore.GetBookByID(e.EntityID)
@@ -368,9 +381,26 @@ func (de *Engine) HydrateChromem(ctx context.Context) (booksHydrated, authorsHyd
 		if len(e.Vector) == 0 {
 			continue
 		}
+		if !de.embeddingModelMatches(e.Model) {
+			staleAuthors++
+			continue
+		}
 		de.mirrorAuthorToChromem(ctx, e.EntityID, e.Vector)
 		authorsHydrated++
 	}
+
+	// Surface stale-model rows once, as a single summary, instead of either
+	// spamming a warning per row (the old behavior this guard replaces) or
+	// silently dropping them where nobody would ever notice they exist.
+	// These rows are candidates for a re-embed (if the entity is real and
+	// just missed a backfill pass) or a future orphan-embedding cleanup (if
+	// the entity was merged/deleted and the row is dead weight) — either way
+	// this line is the trigger to go look, not a fire-and-forget skip.
+	if staleBooks > 0 || staleAuthors > 0 {
+		slog.Warn("chromem hydrate: skipped stale-model embedding rows (candidates for re-embed or orphan cleanup)",
+			"stale_books", staleBooks, "stale_authors", staleAuthors)
+	}
+
 	return booksHydrated, authorsHydrated, nil
 }
 

--- a/internal/dedup/hydrate_chromem_test.go
+++ b/internal/dedup/hydrate_chromem_test.go
@@ -1,0 +1,108 @@
+// file: internal/dedup/hydrate_chromem_test.go
+// version: 1.0.0
+// guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-07-08
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/ai"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeVectorANNStore is a minimal in-memory database.VectorANNStore double
+// that records every Upsert call so tests can assert which entities were (or
+// were not) mirrored during HydrateChromem.
+type fakeVectorANNStore struct {
+	upserted map[string]bool // "entityType/entityID" -> seen
+}
+
+func newFakeVectorANNStore() *fakeVectorANNStore {
+	return &fakeVectorANNStore{upserted: map[string]bool{}}
+}
+
+func (f *fakeVectorANNStore) Upsert(_ context.Context, entityType, entityID string, _ []float32, _ map[string]string) error {
+	f.upserted[entityType+"/"+entityID] = true
+	return nil
+}
+func (f *fakeVectorANNStore) Get(_ context.Context, _, _ string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeVectorANNStore) Delete(_ context.Context, _, _ string) error { return nil }
+func (f *fakeVectorANNStore) FindSimilar(_ context.Context, _ string, _ []float32, _ int, _ map[string]string) ([]database.ChromemSimilarityResult, error) {
+	return nil, nil
+}
+func (f *fakeVectorANNStore) CountByType(_ context.Context, _ string) (int, error) { return 0, nil }
+func (f *fakeVectorANNStore) Close() error                                        { return nil }
+
+// TestHydrateChromem_SkipsStaleModelRows verifies the guard added after the
+// bge-m3 cutover: a row stamped with a different model than the currently
+// wired embed client is skipped instead of being mirrored into the ANN
+// store, where it would only fail the store's dimension check and log a
+// warning. Covers both the book and author loops, and both the "stale but
+// re-embeddable" case (a book/author that still exists) and the "orphaned"
+// case (an author ID that no longer resolves via GetAuthorByID, e.g. after a
+// merge) — HydrateChromem should skip the stale row before ever needing to
+// look the entity up.
+func TestHydrateChromem_SkipsStaleModelRows(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	fake := newFakeVectorANNStore()
+	engine.SetChromemStore(fake)
+	engine.embedClient = ai.NewEmbeddingClientWithOptions("k", "bge-m3", "")
+
+	primary := true
+	currentBook := &database.Book{ID: "BOOK_CURRENT", Title: "Current Model Book", IsPrimaryVersion: &primary}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		if id == "BOOK_CURRENT" {
+			return currentBook, nil
+		}
+		// BOOK_STALE deliberately still resolves — the row must be skipped
+		// on the model check alone, without ever reaching the book lookup.
+		return &database.Book{ID: id, Title: "Stale Model Book", IsPrimaryVersion: &primary}, nil
+	}
+
+	if err := es.Upsert(database.Embedding{EntityType: "book", EntityID: "BOOK_CURRENT", Vector: []float32{1, 2, 3, 4}, Model: "bge-m3"}); err != nil {
+		t.Fatalf("seed current-model book: %v", err)
+	}
+	if err := es.Upsert(database.Embedding{EntityType: "book", EntityID: "BOOK_STALE", Vector: []float32{1, 2, 3}, Model: "text-embedding-3-large"}); err != nil {
+		t.Fatalf("seed stale-model book: %v", err)
+	}
+
+	// AUTHOR_ORPHAN mimics the real prod scenario: an embedding row exists
+	// for an author ID that no longer exists (merged/deleted), so it isn't
+	// in the entity table at all. The guard must skip it purely on model
+	// mismatch, never needing to resolve the author.
+	if err := es.Upsert(database.Embedding{EntityType: "author", EntityID: "9999", Vector: []float32{5, 6, 7, 8}, Model: "bge-m3"}); err != nil {
+		t.Fatalf("seed current-model author: %v", err)
+	}
+	if err := es.Upsert(database.Embedding{EntityType: "author", EntityID: "AUTHOR_ORPHAN", Vector: []float32{5, 6, 7}, Model: "text-embedding-3-large"}); err != nil {
+		t.Fatalf("seed orphaned stale-model author: %v", err)
+	}
+
+	booksHydrated, authorsHydrated, err := engine.HydrateChromem(context.Background())
+	if err != nil {
+		t.Fatalf("HydrateChromem: %v", err)
+	}
+
+	if booksHydrated != 1 {
+		t.Errorf("booksHydrated = %d, want 1", booksHydrated)
+	}
+	if authorsHydrated != 1 {
+		t.Errorf("authorsHydrated = %d, want 1", authorsHydrated)
+	}
+	if !fake.upserted["book/BOOK_CURRENT"] {
+		t.Error("expected current-model book to be mirrored into the ANN store")
+	}
+	if fake.upserted["book/BOOK_STALE"] {
+		t.Error("stale-model book should NOT have been mirrored into the ANN store")
+	}
+	if !fake.upserted["author/9999"] {
+		t.Error("expected current-model author to be mirrored into the ANN store")
+	}
+	if fake.upserted["author/AUTHOR_ORPHAN"] {
+		t.Error("orphaned stale-model author should NOT have been mirrored into the ANN store")
+	}
+}


### PR DESCRIPTION
## Summary
- Root-caused the residual 3-author warning left after #1862/#1865 (v6/v7 `BackfillVersionMarker` bumps): `GetAllAuthors()` returned `total=9080` in both backfill runs while `ListByType("author")` has 9083 rows — an exact, reproducible 3-row gap, not a race (the same 3 IDs recurred identically after both runs).
- `GetAuthorByID` has tombstone-redirect logic for merged authors that `GetAllAuthors()` doesn't apply (it iterates literal `author:N` keys) — these 3 rows are embedding leftovers from an author merge/delete. No backfill re-run can ever reach them since the entity is gone; bumping the marker further would be a dead end.
- Adds the guard `HydrateChromem` should have had from the start: skip any row whose stored model doesn't match the currently-wired embed client, for both the book and author loops, instead of attempting a doomed mirror into the ANN store (dimension-check failure + per-row warning). Also logs one summary line per hydrate run (`stale_books`/`stale_authors` counts) when any are skipped, so these stay visible as re-embed/cleanup candidates instead of silently vanishing.
- No marker bump needed this time — deploy + restart only.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/dedup/...`
- [x] New test `TestHydrateChromem_SkipsStaleModelRows` — covers both "stale but resolvable" and "orphaned, doesn't resolve" cases for books and authors
- [x] `go test ./internal/dedup/... ./internal/server/... -short` — all pass (`internal/server` 479s, no failures; a known-slow-but-not-failing test there is unrelated to this change)
- [ ] Deploy + confirm on prod: the 3 previously-orphaned author warnings (39755, 40861, 42076) no longer appear, replaced by a single summary line

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A8ggNEBJCA8PJnBdg7g2GF