### PR TITLE
feat(dedup): add dedup.cleanup-orphan-author-embeddings op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.131.0 -->
+<!-- version: 3.132.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -8,6 +8,29 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 8, 2026 - feat(dedup): add dedup.cleanup-orphan-author-embeddings op
+
+- **`feat(dedup)`** — new op `internal/plugins/dedup/cleanup_orphan_author_embeddings.go`, the
+  author-side counterpart to `dedup.cleanup-orphan-embeddings` (books, PR #1802 follow-up).
+  Finds `emb:v:author:*` rows whose author ID no longer exists as a live author (merged into
+  another author, or hard-deleted) and reports/deletes them. Dry-run by default; `apply=true`
+  deletes only confirmed-orphaned rows; idempotent.
+- **Why a separate implementation, not a shared helper with the book op**: the book op's orphan
+  check (`GetBookByID(id) == nil`) is unsound for authors. `PebbleStore.GetAuthorByID` follows a
+  tombstone redirect for merged authors — `GetAuthorByID(mergedID)` returns the CANONICAL author's
+  data (non-nil), not nil — so a merged-away ID would look "live" and never get flagged. This op
+  instead builds its live-ID set from `GetAllAuthors()` (literal `author:N` key enumeration, no
+  tombstone-following), the same definition that let the 3 orphaned rows (authorIDs 39755, 40861,
+  42076) survive HydrateChromem's model-mismatch guard (#1866) indefinitely — confirmed via prod
+  journalctl during the #1862/#1865/#1866 investigation.
+- **Test coverage** includes a regression test
+  (`TestCleanupOrphanAuthorEmbeddingsOp_ScanFlagsMergedAuthorAsOrphan`) that wires a mock
+  reproducing the real tombstone-redirect behavior, to prove the op doesn't fall into the same trap.
+- **Follow-up, not urgent**: #1866's hydrate guard already makes these rows harmless (skipped, not
+  spammed); this op is for actually deleting the dead rows from Pebble. Not yet run on prod —
+  dry-run first to confirm the expected 3-author (plus the 18 stale-book rows #1866 also surfaced,
+  out of scope for this author-only op) count before applying.
 
 #### July 8, 2026 - fix(dedup): HydrateChromem skips stale-model embedding rows instead of spamming warnings
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.80.0 -->
+<!-- version: 9.81.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-08 -->
 
@@ -44,9 +44,12 @@ future agent) can scan the entire workspace in one page.
   doesn't match the current embed client, instead of attempting a doomed mirror + warning. Logs one
   summary line per hydrate (`stale_books`/`stale_authors` counts) so orphaned/stale rows stay
   visible instead of silently vanishing. No marker bump needed — deploy + restart only.
-- **Optional future work (not blocking)**: an author-side `cleanup-orphan-embeddings` (the book-side
-  one already exists) to actually delete these dead rows from Pebble, for clean data. The hydrate
-  guard already makes them harmless, so this is cosmetic/hygiene only.
+- **Follow-up shipped**: `dedup.cleanup-orphan-author-embeddings` op built (author-side counterpart
+  to the existing book op) to actually delete these dead rows from Pebble. Had to diverge from the
+  book op's `GetBookByID(id) == nil` pattern — `GetAuthorByID` follows the same tombstone redirect
+  that caused the original bug, so the op checks existence against `GetAllAuthors()` instead.
+  Covered by a regression test that reproduces the redirect. Not yet run on prod (dry-run first);
+  the hydrate guard already makes the rows harmless, so this is cleanup/hygiene, not urgent.
 
 ---
 

--- a/internal/plugins/dedup/cleanup_orphan_author_embeddings.go
+++ b/internal/plugins/dedup/cleanup_orphan_author_embeddings.go
@@ -1,0 +1,216 @@
+// file: internal/plugins/dedup/cleanup_orphan_author_embeddings.go
+// version: 1.0.0
+// guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-07-08
+
+// Package dedup — op dedup.cleanup-orphan-author-embeddings.
+//
+// Author-side counterpart to dedup.cleanup-orphan-embeddings (books, PR #1802
+// follow-up). PR #1866's HydrateChromem model-mismatch guard stopped these
+// rows from spamming a dimension-mismatch warning on every restart, but it
+// only skips them — the dead rows stay in the embedding table forever. This
+// op is the retroactive cleanup: it finds emb:v:author:* rows whose author ID
+// no longer exists as a live author (merged into another author, or hard
+// deleted) and reports/deletes them.
+//
+// # Why this can't reuse the book op's GetBookByID pattern
+//
+// The book op treats "GetBookByID returns nil" as the orphan signal. For
+// authors that check is unsound: PebbleStore.GetAuthorByID follows a
+// tombstone redirect for merged authors — GetAuthorByID(oldID) returns the
+// CANONICAL author's data (non-nil), not nil, so a merged-away ID would look
+// "live" and never get flagged. That silent redirect is exactly what let 3
+// orphaned rows (authorIDs 39755, 40861, 42076) survive indefinitely: they
+// were excluded from GetAllAuthors() (which iterates literal author:N Pebble
+// keys, no tombstone-following) yet still had an embedding row, discovered
+// while chasing a residual `dedup chromem upsert author` warning through
+// PRs #1862/#1865/#1866.
+//
+// This op instead builds its "is this ID live" set directly from
+// GetAllAuthors() — the same literal-key enumeration that HydrateChromem's
+// author loop and the embedding backfill's author loop both rely on — so an
+// ID is orphaned here if and only if it's exactly the condition that makes it
+// unreachable by every other author-embedding code path in the system.
+//
+//   - Dry-run (default): reports orphaned vs. live counts and a bounded
+//     sample of orphaned entity IDs + their stored .Model.
+//   - Apply (apply=true): deletes ONLY the rows confirmed orphaned. A row
+//     whose author still exists (by literal ID) is never touched, regardless
+//     of that embedding's model/dimension — a live author's stale-model
+//     embedding is in scope for a future author-side re-embed, not this op.
+//
+// Idempotent: apply only ever deletes rows it can currently prove orphaned,
+// so a second apply run finds nothing left to delete.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// cleanupOrphanAuthorSampleLimit bounds how many orphaned entity IDs are
+// captured for the report sample, mirroring the book-side op's sample limit.
+const cleanupOrphanAuthorSampleLimit = 10
+
+// cleanupOrphanAuthorEmbeddingsParams are the JSON parameters accepted by the op.
+type cleanupOrphanAuthorEmbeddingsParams struct {
+	// Apply, if true, deletes rows confirmed orphaned (author no longer
+	// exists). Default false (dry-run/report only).
+	Apply bool `json:"apply"`
+}
+
+// cleanupOrphanAuthorSample is one orphaned row surfaced in the report
+// sample, so a reviewer can spot-check specific entity IDs before applying.
+type cleanupOrphanAuthorSample struct {
+	EntityID string
+	Model    string
+}
+
+// cleanupOrphanAuthorReport is the full result of scanning emb:v:author:*
+// rows against the live-author-ID set: total/orphaned/live counts and a
+// bounded sample of orphaned rows. OrphanIDs holds every orphaned entity ID
+// found (not just the sample) so apply can delete them without a second scan.
+type cleanupOrphanAuthorReport struct {
+	Total     int
+	Orphaned  int
+	Live      int
+	Sample    []cleanupOrphanAuthorSample
+	OrphanIDs []string
+}
+
+func (r cleanupOrphanAuthorReport) summary() string {
+	return fmt.Sprintf("total=%d orphaned=%d live=%d", r.Total, r.Orphaned, r.Live)
+}
+
+// cleanupOrphanAuthorEmbeddingsDef returns the OperationDef for
+// dedup.cleanup-orphan-author-embeddings.
+func (p *Plugin) cleanupOrphanAuthorEmbeddingsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.cleanup-orphan-author-embeddings",
+		Plugin:      "dedup",
+		DisplayName: "Clean up orphaned author embeddings",
+		Description: "Author-side counterpart to dedup.cleanup-orphan-embeddings (books): finds " +
+			"emb:v:author:* rows whose author ID no longer exists as a live author (merged into " +
+			"another author or hard-deleted) and reports them. Existence is checked against " +
+			"GetAllAuthors(), not GetAuthorByID, because GetAuthorByID follows tombstone redirects " +
+			"for merged authors and would misreport a merged-away ID as live. Dry-run by default; " +
+			"pass apply=true to delete only the confirmed-orphaned rows. Idempotent: re-running " +
+			"apply after a clean pass finds nothing left to delete.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.cleanup-orphan-author-embeddings",
+		Cancellable:     true,
+		Timeout:         10 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runCleanupOrphanAuthorEmbeddings,
+	}
+}
+
+// runCleanupOrphanAuthorEmbeddings implements the
+// cleanup-orphan-author-embeddings op.
+func (p *Plugin) runCleanupOrphanAuthorEmbeddings(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	if p.store == nil {
+		return fmt.Errorf("main store not available")
+	}
+
+	var params cleanupOrphanAuthorEmbeddingsParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	reporter.Logger().Info("cleanup-orphan-author-embeddings start", "apply", params.Apply)
+
+	_ = reporter.UpdateProgress(0, 3, "Listing author embeddings…")
+	embeddings, err := p.embeddingStore.ListByType("author")
+	if err != nil {
+		return fmt.Errorf("list author embeddings: %w", err)
+	}
+
+	_ = reporter.UpdateProgress(1, 3, "Loading live author IDs…")
+	authors, err := p.store.GetAllAuthors()
+	if err != nil {
+		return fmt.Errorf("get all authors: %w", err)
+	}
+	liveIDs := make(map[string]struct{}, len(authors))
+	for _, a := range authors {
+		liveIDs[strconv.Itoa(a.ID)] = struct{}{}
+	}
+
+	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf(
+		"Checking %d embeddings against %d live authors…", len(embeddings), len(liveIDs)))
+	report := scanOrphanAuthorEmbeddings(embeddings, liveIDs)
+
+	reporter.Logger().Info("cleanup-orphan-author-embeddings: scan complete", "stats", report.summary())
+	for _, s := range report.Sample {
+		reporter.Logger().Info("cleanup-orphan-author-embeddings: sample orphan", "entity_id", s.EntityID, "model", s.Model)
+	}
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
+			"Dry-run — %d orphaned author embeddings found (%d live, %d total). Pass apply=true to delete.",
+			report.Orphaned, report.Live, report.Total))
+		reporter.Logger().Info("cleanup-orphan-author-embeddings: dry-run only; nothing deleted")
+		return nil
+	}
+
+	_ = reporter.UpdateProgress(2, 3, fmt.Sprintf("Applying — deleting %d orphaned embeddings…", len(report.OrphanIDs)))
+	var deleted, deleteErrs int
+	for _, id := range report.OrphanIDs {
+		if reporter.IsCanceled() {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if err := p.embeddingStore.Delete("author", id); err != nil {
+			deleteErrs++
+			reporter.Logger().Error("cleanup-orphan-author-embeddings: delete error", "entity_id", id, "error", err)
+			continue
+		}
+		deleted++
+	}
+
+	_ = reporter.UpdateProgress(3, 3, fmt.Sprintf(
+		"Complete — deleted %d/%d orphaned embeddings (%d errors). %s",
+		deleted, len(report.OrphanIDs), deleteErrs, report.summary()))
+	reporter.Logger().Info("cleanup-orphan-author-embeddings complete",
+		"deleted", deleted, "delete_errs", deleteErrs, "summary", report.summary())
+	return nil
+}
+
+// scanOrphanAuthorEmbeddings is the pure core of the op: for every given
+// embedding it checks whether the entity ID is present in liveIDs (built
+// from GetAllAuthors(), the literal-key enumeration every other author-
+// embedding code path relies on), and returns the full report — counts, a
+// bounded sample, and the complete list of orphaned entity IDs ready for
+// apply to delete. Pure/no I/O (liveIDs is precomputed), so no context or
+// cancellation plumbing is needed here, unlike the book op's per-row
+// GetBookByID lookups.
+func scanOrphanAuthorEmbeddings(embeddings []database.Embedding, liveIDs map[string]struct{}) cleanupOrphanAuthorReport {
+	var report cleanupOrphanAuthorReport
+	for _, e := range embeddings {
+		report.Total++
+		if _, ok := liveIDs[e.EntityID]; ok {
+			report.Live++
+			continue
+		}
+		report.Orphaned++
+		report.OrphanIDs = append(report.OrphanIDs, e.EntityID)
+		if len(report.Sample) < cleanupOrphanAuthorSampleLimit {
+			report.Sample = append(report.Sample, cleanupOrphanAuthorSample{EntityID: e.EntityID, Model: e.Model})
+		}
+	}
+	return report
+}

--- a/internal/plugins/dedup/cleanup_orphan_author_embeddings_test.go
+++ b/internal/plugins/dedup/cleanup_orphan_author_embeddings_test.go
@@ -1,0 +1,203 @@
+// file: internal/plugins/dedup/cleanup_orphan_author_embeddings_test.go
+// version: 1.0.0
+// guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
+// last-edited: 2026-07-08
+
+// Tests for the dedup.cleanup-orphan-author-embeddings op (author-side
+// counterpart to dedup.cleanup-orphan-embeddings).
+//
+// The key thing under test is the existence check: it must go through
+// GetAllAuthors() (literal author:N key enumeration), NOT GetAuthorByID
+// (which follows tombstone redirects for merged authors and would report a
+// merged-away ID as "live"). cleanupOrphanAuthorMockStore deliberately wires
+// GetAuthorByIDFunc to return a REDIRECTED canonical author for a merged ID,
+// so a test that accidentally used GetAuthorByID for the existence check
+// would wrongly classify it as live and fail to catch the regression.
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupOrphanAuthorMockStore returns a MockStore whose GetAllAuthors
+// resolves only the given live author IDs. GetAuthorByID is wired to follow
+// a tombstone-style redirect for mergedID -> canonicalID, mirroring
+// PebbleStore.GetAuthorByID's real behavior: it returns the CANONICAL
+// author's data for a merged-away ID rather than nil. Any op that used
+// GetAuthorByID for the orphan check would therefore see mergedID as "live"
+// and fail to flag it — exactly the bug this op exists to avoid.
+func cleanupOrphanAuthorMockStore(liveIDs []int, mergedID, canonicalID int) *database.MockStore {
+	authors := make([]database.Author, 0, len(liveIDs))
+	byID := make(map[int]*database.Author, len(liveIDs))
+	for _, id := range liveIDs {
+		a := database.Author{ID: id, Name: "Live Author"}
+		authors = append(authors, a)
+		byID[id] = &a
+	}
+	return &database.MockStore{
+		GetAllAuthorsFunc: func() ([]database.Author, error) {
+			return authors, nil
+		},
+		GetAuthorByIDFunc: func(id int) (*database.Author, error) {
+			if id == mergedID {
+				// Tombstone redirect: returns the canonical author, non-nil.
+				return byID[canonicalID], nil
+			}
+			return byID[id], nil
+		},
+	}
+}
+
+// seedAuthorEmbedding upserts an author embedding with the given entity ID and model.
+func seedAuthorEmbedding(t *testing.T, es *database.EmbeddingStore, entityID, model string) {
+	t.Helper()
+	require.NoError(t, es.Upsert(database.Embedding{
+		EntityType: "author",
+		EntityID:   entityID,
+		Model:      model,
+		Vector:     []float32{0.1, 0.2, 0.3},
+	}))
+}
+
+// TestCleanupOrphanAuthorEmbeddingsOp_Metadata asserts the OperationDef shape.
+func TestCleanupOrphanAuthorEmbeddingsOp_Metadata(t *testing.T) {
+	p := &Plugin{}
+	def := p.cleanupOrphanAuthorEmbeddingsDef()
+	assert.Equal(t, "dedup.cleanup-orphan-author-embeddings", def.ID)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryRead)
+	assert.Contains(t, def.Capabilities, sdk.CapLibraryWrite)
+
+	var params cleanupOrphanAuthorEmbeddingsParams
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &params))
+	assert.False(t, params.Apply, "apply must default to false")
+}
+
+// TestCleanupOrphanAuthorEmbeddingsOp_DryRunReportsCountsWithoutMutating
+// asserts dry-run correctly classifies orphaned vs. live embeddings and
+// writes nothing to the store.
+func TestCleanupOrphanAuthorEmbeddingsOp_DryRunReportsCountsWithoutMutating(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanAuthorMockStore([]int{1, 2}, 39755, 1)
+
+	seedAuthorEmbedding(t, es, "1", "bge-m3")
+	seedAuthorEmbedding(t, es, "2", "text-embedding-3-large") // "wrong" model, but author is live
+	seedAuthorEmbedding(t, es, "39755", "text-embedding-3-large")
+	seedAuthorEmbedding(t, es, "40861", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanAuthorEmbeddingsParams{Apply: false})
+	require.NoError(t, err)
+	require.NoError(t, p.runCleanupOrphanAuthorEmbeddings(context.Background(), params, &mockReporter{}))
+
+	all, err := es.ListByType("author")
+	require.NoError(t, err)
+	assert.Len(t, all, 4, "dry-run must not delete any embedding")
+}
+
+// TestCleanupOrphanAuthorEmbeddingsOp_ScanFlagsMergedAuthorAsOrphan is the
+// regression test for the exact bug this op exists to avoid: a merged
+// author's ID must be flagged orphaned even though GetAuthorByID(mergedID)
+// would return the canonical author (non-nil) via tombstone redirect.
+func TestCleanupOrphanAuthorEmbeddingsOp_ScanFlagsMergedAuthorAsOrphan(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanAuthorMockStore([]int{1}, 39755, 1)
+
+	seedAuthorEmbedding(t, es, "1", "bge-m3")
+	seedAuthorEmbedding(t, es, "39755", "text-embedding-3-large") // merged into author 1
+
+	// Sanity-check the mock actually reproduces the redirect: GetAuthorByID
+	// on the merged ID returns the canonical author, non-nil.
+	canonical, err := ms.GetAuthorByID(39755)
+	require.NoError(t, err)
+	require.NotNil(t, canonical, "mock must reproduce GetAuthorByID's tombstone redirect")
+
+	embeddings, err := es.ListByType("author")
+	require.NoError(t, err)
+	authors, err := ms.GetAllAuthors()
+	require.NoError(t, err)
+	liveIDs := map[string]struct{}{}
+	for _, a := range authors {
+		liveIDs[strconv.Itoa(a.ID)] = struct{}{}
+	}
+
+	report := scanOrphanAuthorEmbeddings(embeddings, liveIDs)
+	assert.Equal(t, 2, report.Total)
+	assert.Equal(t, 1, report.Orphaned)
+	assert.Equal(t, 1, report.Live)
+	assert.ElementsMatch(t, []string{"39755"}, report.OrphanIDs)
+}
+
+// TestCleanupOrphanAuthorEmbeddingsOp_ApplyDeletesOnlyOrphans asserts
+// apply=true deletes only the rows whose author is confirmed gone, leaving
+// live-author embeddings — including one with a "wrong" model — untouched.
+func TestCleanupOrphanAuthorEmbeddingsOp_ApplyDeletesOnlyOrphans(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanAuthorMockStore([]int{1, 2}, 39755, 1)
+
+	seedAuthorEmbedding(t, es, "1", "bge-m3")
+	seedAuthorEmbedding(t, es, "2", "text-embedding-3-large") // stale model, but out of scope: author is live
+	seedAuthorEmbedding(t, es, "39755", "text-embedding-3-large")
+	seedAuthorEmbedding(t, es, "40861", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanAuthorEmbeddingsParams{Apply: true})
+	require.NoError(t, err)
+	require.NoError(t, p.runCleanupOrphanAuthorEmbeddings(context.Background(), params, &mockReporter{}))
+
+	remaining, err := es.ListByType("author")
+	require.NoError(t, err)
+	require.Len(t, remaining, 2, "only the two orphaned rows should be deleted")
+
+	ids := make([]string, 0, len(remaining))
+	for _, e := range remaining {
+		ids = append(ids, e.EntityID)
+	}
+	assert.ElementsMatch(t, []string{"1", "2"}, ids)
+
+	live2, err := es.Get("author", "2")
+	require.NoError(t, err)
+	require.NotNil(t, live2)
+	assert.Equal(t, "text-embedding-3-large", live2.Model)
+
+	gone1, err := es.Get("author", "39755")
+	require.NoError(t, err)
+	assert.Nil(t, gone1)
+	gone2, err := es.Get("author", "40861")
+	require.NoError(t, err)
+	assert.Nil(t, gone2)
+}
+
+// TestCleanupOrphanAuthorEmbeddingsOp_ApplyTwiceIsIdempotent asserts a second
+// apply run after a clean pass finds nothing left to delete.
+func TestCleanupOrphanAuthorEmbeddingsOp_ApplyTwiceIsIdempotent(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	ms := cleanupOrphanAuthorMockStore([]int{1}, 39755, 1)
+
+	seedAuthorEmbedding(t, es, "1", "bge-m3")
+	seedAuthorEmbedding(t, es, "39755", "text-embedding-3-large")
+
+	p := buildPlugin(t, es, ms)
+	params, err := json.Marshal(cleanupOrphanAuthorEmbeddingsParams{Apply: true})
+	require.NoError(t, err)
+
+	require.NoError(t, p.runCleanupOrphanAuthorEmbeddings(context.Background(), params, &mockReporter{}))
+	remaining, err := es.ListByType("author")
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "1", remaining[0].EntityID)
+
+	require.NoError(t, p.runCleanupOrphanAuthorEmbeddings(context.Background(), params, &mockReporter{}))
+	remaining, err = es.ListByType("author")
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "1", remaining[0].EntityID)
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-07-04
+// last-edited: 2026-07-08
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -64,20 +64,21 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.splitBookScanDef(),
 		p.purgeStaleDef(),
 		p.lshIndexBuildDef(),
-		p.purgeLegacyFPDef(),                // T015: legacy fingerprint purge op
-		p.embReencodeDef(),                  // T021: float16+zstd re-encode op
-		p.bookfileSegDropDef(),              // T020: drop AcoustID segment fields from stored values
-		p.datasetBackfillDef(),              // C4: label + suppress residual pending candidates
-		p.calibrateEmbeddingThresholdsDef(), // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)
-		p.mineGoldLabelsDef(),               // gold miner: auto-label high-confidence true_dup positives
-		p.rebuildGoldLabelsDef(),            // rebuild rule/auto_high_conf gold labels against current state
-		p.quarantineChapterArtifactsDef(),   // drain chapter-file-as-book artifacts (candidate explosion)
-		p.drainStaleDef(),                   // DEDUP-1: drain CONS-16/17-era stale exact candidates (dry-run gated)
-		p.checkBookDef(),                    // M4: per-book dedup check via dependency scheduler
-		p.buildISBNIndexDef(),               // T022: ISBN/ASIN secondary index backfill
-		p.reembedEmbeddingsDef(),            // Part B: re-embed corpus when the embedding model changes
-		p.autoResolveDef(),                  // TASK-17: Tier-1 CERTAIN auto-merge (dry-run default, kill-switch gated)
-		p.cleanupOrphanEmbeddingsDef(),      // retroactive counterpart to #1802: deletes emb:v:book:* rows whose book is gone
+		p.purgeLegacyFPDef(),                 // T015: legacy fingerprint purge op
+		p.embReencodeDef(),                   // T021: float16+zstd re-encode op
+		p.bookfileSegDropDef(),               // T020: drop AcoustID segment fields from stored values
+		p.datasetBackfillDef(),               // C4: label + suppress residual pending candidates
+		p.calibrateEmbeddingThresholdsDef(),  // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)
+		p.mineGoldLabelsDef(),                // gold miner: auto-label high-confidence true_dup positives
+		p.rebuildGoldLabelsDef(),             // rebuild rule/auto_high_conf gold labels against current state
+		p.quarantineChapterArtifactsDef(),    // drain chapter-file-as-book artifacts (candidate explosion)
+		p.drainStaleDef(),                    // DEDUP-1: drain CONS-16/17-era stale exact candidates (dry-run gated)
+		p.checkBookDef(),                     // M4: per-book dedup check via dependency scheduler
+		p.buildISBNIndexDef(),                // T022: ISBN/ASIN secondary index backfill
+		p.reembedEmbeddingsDef(),             // Part B: re-embed corpus when the embedding model changes
+		p.autoResolveDef(),                   // TASK-17: Tier-1 CERTAIN auto-merge (dry-run default, kill-switch gated)
+		p.cleanupOrphanEmbeddingsDef(),       // retroactive counterpart to #1802: deletes emb:v:book:* rows whose book is gone
+		p.cleanupOrphanAuthorEmbeddingsDef(), // author-side counterpart: deletes emb:v:author:* rows orphaned by a merge/delete (#1866 follow-up)
 	}
 
 	for _, op := range ops {


### PR DESCRIPTION
## Summary
- Author-side counterpart to the existing `dedup.cleanup-orphan-embeddings` (books, PR #1802 follow-up). Finds `emb:v:author:*` rows whose author ID no longer exists as a live author (merged into another author, or hard-deleted) and reports/deletes them. Dry-run by default; `apply=true` deletes only confirmed-orphaned rows; idempotent.
- **Can't reuse the book op's pattern**: the book op treats `GetBookByID(id) == nil` as the orphan signal. For authors that's unsound — `PebbleStore.GetAuthorByID` follows a tombstone redirect for merged authors, returning the CANONICAL author's data (non-nil) rather than nil. That's exactly the gap that let 3 orphaned rows (authorIDs 39755, 40861, 42076) survive `HydrateChromem`'s model-mismatch guard (#1866) indefinitely — discovered while chasing a residual warning through #1862/#1865/#1866. This op instead checks existence against `GetAllAuthors()` (literal `author:N` key enumeration, no tombstone-following), the same definition every other author-embedding code path in the system relies on.
- Includes a regression test (`TestCleanupOrphanAuthorEmbeddingsOp_ScanFlagsMergedAuthorAsOrphan`) that wires a mock reproducing the real tombstone-redirect behavior, to prove the op doesn't fall into the same trap.
- #1866's hydrate guard already makes these rows harmless (skipped, not spammed); this op is for actually deleting the dead rows from Pebble — not urgent, cleanup/hygiene only. Not run on prod yet.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/plugins/dedup/...`
- [x] `go test ./internal/plugins/dedup/... -short` — all pass, including 5 new tests for this op
- [ ] After merge: run `dedup.cleanup-orphan-author-embeddings` dry-run on prod, confirm it reports exactly 3 orphaned authors (39755, 40861, 42076), then apply

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A8ggNEBJCA8PJnBdg7g2GF