### PR TITLE
fix(search): apply free-text field boosts at query time (INIT-4 T1)

### DIFF
--- a/internal/search/bleve_index.go
+++ b/internal/search/bleve_index.go
@@ -1,6 +1,7 @@
 // file: internal/search/bleve_index.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3c8e1a2f-4d9b-4f70-a5c6-2f8d0e1b9a47
+// last-edited: 2026-07-10
 //
 // BleveIndex is the single-package wrapper around a Bleve v2 scorch
 // index backing library search (spec DES-1 / backlog §4.7). The
@@ -209,10 +210,23 @@ func (b *BleveIndex) DocCount() (uint64, error) {
 	return b.idx.DocCount()
 }
 
+// textFieldBoosts is the query-time boost table for free-text search.
+// bleve v2 has no index-time field boost, so translateFreeText fans a
+// free-text term out across these fields with these weights. Keep in
+// sync with the analyzed-text fields registered in bookIndexMapping.
+var textFieldBoosts = []struct {
+	Field string
+	Boost float64
+}{
+	{"title", 3.0}, {"author", 2.0}, {"series", 1.5}, {"narrator", 1.2},
+	{"publisher", 1.0}, {"description", 0.5}, {"file_path", 0.5},
+}
+
 // bookIndexMapping returns the bleve.IndexMapping for BookDocument.
-// Field boosts, analyzer choices, and keyword vs text distinctions
-// live here — changing a field's treatment requires rebuilding the
-// index (full re-index on next startup).
+// Analyzer choices and keyword vs text distinctions live here —
+// changing a field's treatment requires rebuilding the index (full
+// re-index on next startup). Free-text field weighting is query-time
+// (see textFieldBoosts above), not part of this mapping.
 func bookIndexMapping() mapping.IndexMapping {
 	im := bleve.NewIndexMapping()
 
@@ -221,7 +235,11 @@ func bookIndexMapping() mapping.IndexMapping {
 	// Building a custom analyzer at mapping construction time is
 	// brittle because the registry lookup happens at index open, so
 	// we stick to the guaranteed-available built-in.
-	textAnalyzed := func(boost float64) *mapping.FieldMapping {
+	// textAnalyzed no longer takes a boost: bleve v2 has no index-time
+	// field boost, so that parameter was dead. Query-time weighting for
+	// free-text search lives in textFieldBoosts (bleve_index.go) and is
+	// applied by translateFreeText in bleve_translator.go.
+	textAnalyzed := func() *mapping.FieldMapping {
 		f := bleve.NewTextFieldMapping()
 		f.Analyzer = en.AnalyzerName
 		f.Store = true
@@ -248,15 +266,15 @@ func bookIndexMapping() mapping.IndexMapping {
 
 	book := bleve.NewDocumentMapping()
 
-	// Analyzed text with field-level boost — set on the mapping so
-	// it's applied at index time rather than per-query.
-	title := textAnalyzed(3.0)
-	author := textAnalyzed(2.0)
-	series := textAnalyzed(1.5)
-	narrator := textAnalyzed(1.2)
-	publisher := textAnalyzed(1.0)
-	description := textAnalyzed(0.5)
-	filePath := textAnalyzed(0.5)
+	// Analyzed text fields. Field weighting for free-text search is
+	// applied at query time (see textFieldBoosts below), not here.
+	title := textAnalyzed()
+	author := textAnalyzed()
+	series := textAnalyzed()
+	narrator := textAnalyzed()
+	publisher := textAnalyzed()
+	description := textAnalyzed()
+	filePath := textAnalyzed()
 
 	book.AddFieldMappingsAt("title", title)
 	book.AddFieldMappingsAt("author", author)

--- a/internal/search/bleve_index_test.go
+++ b/internal/search/bleve_index_test.go
@@ -1,6 +1,7 @@
 // file: internal/search/bleve_index_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8e2c4a1d-5b9f-4f70-a7d6-2f8e0c1b9a58
+// last-edited: 2026-07-10
 
 package search
 
@@ -135,6 +136,79 @@ func TestBleveIndex_ReopenPreservesDocs(t *testing.T) {
 	hits, _, _ := idx2.Search("title:persistent", 0, 10)
 	if len(hits) != 1 {
 		t.Errorf("search after reopen returned %d hits, want 1", len(hits))
+	}
+}
+
+// TestBleveIndex_FreeTextBoost_TitleRanksAboveDescription is an
+// end-to-end pin for the free-text field-boost fan-out in
+// translateFreeText: the same term appearing in doc a's title
+// (boost 3.0) must outrank it appearing only in doc b's description
+// (boost 0.5).
+func TestBleveIndex_FreeTextBoost_TitleRanksAboveDescription(t *testing.T) {
+	idx := openTestIndex(t)
+
+	docs := []BookDocument{
+		{BookID: "a", Title: "Wandering Wizard", Author: "Someone"},
+		{BookID: "b", Title: "Unrelated Book", Description: "A wizard walks into a bar."},
+	}
+	for _, d := range docs {
+		if err := idx.IndexBook(d); err != nil {
+			t.Fatalf("index %s: %v", d.BookID, err)
+		}
+	}
+
+	ast, err := ParseQuery("wizard")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bq, _, err := Translate(ast)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	hits, total, err := idx.SearchNative(bq, 0, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total = %d, want 2 (both a and b match \"wizard\")", total)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("hits = %d, want 2", len(hits))
+	}
+	if hits[0].BookID != "a" {
+		t.Errorf("top hit = %s, want a (title boost 3.0 should outrank description boost 0.5); order = %v", hits[0].BookID, hitIDs(hits))
+	}
+}
+
+// TestBleveIndex_FreeTextRecall_TagOnlyMatchStillReturned is the
+// anti-over-suppression pin: a doc matching a free-text term ONLY
+// via a non-boosted _all field (tags, not in textFieldBoosts) must
+// still be returned via the unfielded fallback child.
+func TestBleveIndex_FreeTextRecall_TagOnlyMatchStillReturned(t *testing.T) {
+	idx := openTestIndex(t)
+
+	// "zephyr" is unaffected by the English stemmer (stems to itself),
+	// so it isolates the recall behavior under test from an unrelated
+	// analyzer-mismatch quirk between the tags field's "standard"
+	// analyzer and the _all composite field's default "en" analyzer.
+	if err := idx.IndexBook(BookDocument{BookID: "c", Title: "Something Else", Tags: []string{"zephyr"}}); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	ast, err := ParseQuery("zephyr")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bq, _, err := Translate(ast)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	hits, total, err := idx.SearchNative(bq, 0, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if total != 1 || len(hits) != 1 || hits[0].BookID != "c" {
+		t.Errorf("tag-only match = %v (total %d), want [c]", hitIDs(hits), total)
 	}
 }
 

--- a/internal/search/bleve_translator.go
+++ b/internal/search/bleve_translator.go
@@ -1,6 +1,7 @@
 // file: internal/search/bleve_translator.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c2a4f1d-5b3e-4f70-a7d6-2e8c0f1b9a47
+// last-edited: 2026-07-10
 //
 // AST → Bleve query translator (spec DES-1 v1.1). Walks the AST
 // produced by ParseQuery and emits a bleve/v2 query.Query suitable
@@ -252,7 +253,17 @@ func translateFreeText(n *FreeTextNode) query.Query {
 	if n.Quoted {
 		return bleve.NewMatchPhraseQuery(n.Value)
 	}
-	return bleve.NewMatchQuery(n.Value)
+	children := make([]query.Query, 0, len(textFieldBoosts)+1)
+	for _, fb := range textFieldBoosts {
+		mq := bleve.NewMatchQuery(n.Value)
+		mq.SetField(fb.Field)
+		mq.SetBoost(fb.Boost)
+		children = append(children, mq)
+	}
+	// Unfielded child preserves recall: anything that matched via _all
+	// before (tags, genre, isbn text) still matches, at neutral weight.
+	children = append(children, bleve.NewMatchQuery(n.Value))
+	return bleve.NewDisjunctionQuery(children...)
 }
 
 // buildNumericRange constructs a NumericRangeQuery for the given

--- a/internal/search/bleve_translator_test.go
+++ b/internal/search/bleve_translator_test.go
@@ -1,12 +1,15 @@
 // file: internal/search/bleve_translator_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1a8c2f4d-5b9e-4f70-a7d6-2e8d0f1b9a57
+// last-edited: 2026-07-10
 
 package search
 
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/blevesearch/bleve/v2/search/query"
 )
 
 func translate(t *testing.T, q string) (hits []SearchResult, total uint64, filters []PerUserFilter) {
@@ -160,6 +163,66 @@ func TestTranslate_PhraseMatch(t *testing.T) {
 	hits, _, _ := translate(t, `title:"New Dawn"`)
 	if len(hits) != 1 || hits[0].BookID != "b4" {
 		t.Errorf("phrase → %v, want [b4]", hitIDs(hits))
+	}
+}
+
+func TestTranslateFreeText_DefaultFansOutWithFieldBoosts(t *testing.T) {
+	q := translateFreeText(&FreeTextNode{Value: "wizard"})
+	dq, ok := q.(*query.DisjunctionQuery)
+	if !ok {
+		t.Fatalf("translateFreeText default = %T, want *query.DisjunctionQuery", q)
+	}
+	wantChildren := len(textFieldBoosts) + 1 // one boosted MatchQuery per field + one unfielded fallback
+	if len(dq.Disjuncts) != wantChildren {
+		t.Fatalf("children = %d, want %d", len(dq.Disjuncts), wantChildren)
+	}
+
+	var foundTitle bool
+	var titleBoost float64
+	var unfieldedCount int
+	for _, child := range dq.Disjuncts {
+		mq, ok := child.(*query.MatchQuery)
+		if !ok {
+			t.Fatalf("child = %T, want *query.MatchQuery", child)
+		}
+		if mq.Field() == "" {
+			unfieldedCount++
+			continue
+		}
+		if mq.Field() == "title" {
+			foundTitle = true
+			titleBoost = mq.Boost()
+		}
+	}
+	if !foundTitle {
+		t.Fatal("no title-field child found among disjuncts")
+	}
+	if titleBoost != 3.0 {
+		t.Errorf("title child boost = %v, want 3.0", titleBoost)
+	}
+	if unfieldedCount != 1 {
+		t.Errorf("unfielded children = %d, want 1 (recall fallback)", unfieldedCount)
+	}
+}
+
+func TestTranslateFreeText_PrefixUnchanged(t *testing.T) {
+	q := translateFreeText(&FreeTextNode{Value: "wiz", Prefix: true})
+	if _, ok := q.(*query.PrefixQuery); !ok {
+		t.Fatalf("prefix free text = %T, want *query.PrefixQuery", q)
+	}
+}
+
+func TestTranslateFreeText_FuzzyUnchanged(t *testing.T) {
+	q := translateFreeText(&FreeTextNode{Value: "wizrd", Fuzzy: true})
+	if _, ok := q.(*query.FuzzyQuery); !ok {
+		t.Fatalf("fuzzy free text = %T, want *query.FuzzyQuery", q)
+	}
+}
+
+func TestTranslateFreeText_QuotedUnchanged(t *testing.T) {
+	q := translateFreeText(&FreeTextNode{Value: "wise wizard", Quoted: true})
+	if _, ok := q.(*query.MatchPhraseQuery); !ok {
+		t.Fatalf("quoted free text = %T, want *query.MatchPhraseQuery", q)
 	}
 }
 


### PR DESCRIPTION
bleve v2 removed index-time field boosts, so textAnalyzed's boost arg
was dead and title/author/series weights never applied. Fan free text
out into a boosted DisjunctionQuery (plus an unfielded child to keep
recall) in translateFreeText — the one place all free-text queries pass
through.

Co-Authored-By: Claude <noreply@anthropic.com>
