### PR TITLE
refactor(metafetch): unify duration scoring behind one ratio tier table (INIT-3-T2)

### DIFF
--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-07-03
+// last-edited: 2026-07-10
 
 package metafetch
 
@@ -1201,6 +1201,16 @@ func TestPickBestMatchFromScored(t *testing.T) {
 // durationScoreMultiplier
 // ---------------------------------------------------------------------------
 
+// TestDurationScoreMultiplier's expectations below were rewritten for
+// INIT-3-T2 (unify duration scoring): durationScoreMultiplier used to bucket
+// on the ABSOLUTE delta in seconds, independent of the book's own duration;
+// it now looks up the shared ratio-based durationTiers table (ratio =
+// |Δ|/bookDurationSec), the same table computeDurationScore uses, so the
+// two functions can never disagree on the same pair again. Every case below
+// with a book duration of 36000s (10h) is re-derived from the new ratio —
+// see the golden fixtures in service_scoring_test.go
+// (TestDurationScoringGolden) for the full old-value/new-value/why diff
+// across a wider grid including a very-long (40h) book.
 func TestDurationScoreMultiplier(t *testing.T) {
 	cases := []struct {
 		bookSec, candSec int
@@ -1210,14 +1220,29 @@ func TestDurationScoreMultiplier(t *testing.T) {
 		{0, 36000, 1.0, "unknown book duration → no adjustment"},
 		{36000, 0, 1.0, "unknown candidate duration → no adjustment"},
 		{36000, 36000, 1.30, "exact match → huge bonus"},
-		{36000, 36030, 1.30, "30s delta → huge bonus"},
-		{36000, 36300, 1.20, "5 min delta → strong bonus"},
-		{36000, 36600, 1.10, "10 min delta → good bonus"},
-		{36000, 37200, 1.05, "20 min delta → small bonus"},
-		{36000, 37800, 1.00, "30 min delta → no adjustment"},
-		{36000, 39600, 0.90, "60 min delta → minor penalty"},
-		{36000, 43200, 0.75, "120 min delta → significant penalty"},
-		{36000, 50400, 0.50, ">120 min delta → strong penalty (wrong edition)"},
+		{36000, 36030, 1.30, "30s delta, ratio 0.08% → huge bonus"},
+		// 300s delta, ratio 0.83%: was ×1.20 under the old 300s bucket;
+		// still deep in the new <5% ratio tier → ×1.30.
+		{36000, 36300, 1.30, "5 min delta, ratio 0.83% → huge bonus"},
+		// 600s delta, ratio 1.67%: was ×1.10 under the old 600s bucket;
+		// still <5% ratio → ×1.30.
+		{36000, 36600, 1.30, "10 min delta, ratio 1.67% → huge bonus"},
+		// 1200s delta, ratio 3.33%: was ×1.05 under the old 1200s bucket;
+		// still <5% ratio → ×1.30.
+		{36000, 37200, 1.30, "20 min delta, ratio 3.33% → huge bonus"},
+		// 1800s delta, ratio exactly 5%: was ×1.00 under the old 1800s
+		// bucket; 5% ratio lands in the new 5-10% tier → ×1.20.
+		{36000, 37800, 1.20, "30 min delta, ratio 5.00% → strong bonus"},
+		// 3600s delta, ratio exactly 10%: was ×0.90 under the old 3600s
+		// bucket; 10% ratio lands in the new 10-20% tier → ×1.10.
+		{36000, 39600, 1.10, "60 min delta, ratio 10.00% → good bonus"},
+		// 7200s delta, ratio exactly 20%: was ×0.75 under the old 7200s
+		// bucket; 20% ratio lands in the new 20-50% "acceptable range" tier
+		// → ×1.00.
+		{36000, 43200, 1.00, "120 min delta, ratio 20.00% → no adjustment"},
+		// 14400s delta, ratio 40%: was ×0.50 under the old >7200s
+		// catch-all; 40% ratio is still within the new 20-50% tier → ×1.00.
+		{36000, 50400, 1.00, ">120 min delta, ratio 40.00% → no adjustment"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.5.4
+// version: 1.6.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
-// last-edited: 2026-07-03
+// last-edited: 2026-07-10
 
 package metafetch
 
@@ -151,59 +151,111 @@ func ApplyNonBaseAdjustments(baseScore float64, r metadata.BookMetadata, baseWor
 	return score + bonus
 }
 
-// durationScoreMultiplier returns a score multiplier based on how closely the
-// candidate's runtime matches the book's known duration.
+// durationTiers is the ONE canonical, ratio-based classification of how
+// closely a candidate's runtime matches a book's known duration. Both
+// durationScoreMultiplier and computeDurationScore look up the same tier by
+// ratio = |candidateDurationSec-bookDurationSec| / bookDurationSec, so they
+// can never disagree about how close a duration match is (INIT-3-T2 —
+// before this table existed the two functions used independent bucket
+// systems — absolute-delta-seconds vs delta-ratio — that could and did
+// disagree on the same pair; see golden fixtures in
+// service_scoring_test.go for the divergent pre-unification behavior).
 //
-// Both values are in seconds. If either is zero (unknown), the multiplier is
-// 1.0 (no adjustment). The multiplier is symmetric — only the absolute delta
-// matters, not the direction (candidate longer vs shorter).
+// Unknown semantics (handled by the callers below, NOT a table row): if
+// either duration is <= 0, the comparison is UNKNOWN, never disqualifying —
+// durationScoreMultiplier returns 1.0 (no adjustment) and
+// computeDurationScore returns 0 (neutral).
 //
-// Scale (chosen so a near-identical runtime is a meaningful tiebreaker but
-// a huge mismatch is a strong rejection signal):
-//
-//	Δ ≤  1 min  → ×1.30  (essentially identical — almost certainly the same edition)
-//	Δ ≤  5 min  → ×1.20  (very close — same edition, minor encoding difference)
-//	Δ ≤ 10 min  → ×1.10  (close — probably correct)
-//	Δ ≤ 20 min  → ×1.05  (within margin)
-//	Δ ≤ 30 min  → ×1.00  (no adjustment — acceptable range)
-//	Δ ≤ 60 min  → ×0.90  (possible different edition or trim)
-//	Δ ≤ 120 min → ×0.75  (likely different edition, apply cautiously)
-//	Δ > 120 min → ×0.50  (almost certainly wrong edition or different book)
-func durationScoreMultiplier(bookDurationSec, candidateDurationSec int) float64 {
-	if bookDurationSec <= 0 || candidateDurationSec <= 0 {
-		return 1.0
+// Tier boundaries are looked up by durationTier, which mirrors the historical
+// computeDurationScore boundary semantics exactly: the first three tiers are
+// upper-bound-EXCLUSIVE (ratio strictly less than MaxRatio) and the next two
+// are upper-bound-INCLUSIVE (ratio <= MaxRatio), so a ratio landing exactly
+// on 0.05/0.10/0.20 falls into the NEXT tier while one landing exactly on
+// 0.50/1.00 stays in the CURRENT tier. This asymmetry is preserved on
+// purpose: computeDurationScore's Score column must reproduce bit-for-bit
+// what it already returned in production before this unification (see
+// acceptance criteria — zero additive-score cells may change).
+var durationTiers = []struct {
+	MaxRatio   float64 // upper bound of |Δ|/bookDurationSec for this tier
+	Multiplier float64 // durationScoreMultiplier result for this tier
+	Score      float64 // computeDurationScore result for this tier
+}{
+	{MaxRatio: 0.05, Multiplier: 1.30, Score: 20},  // essentially identical — same edition
+	{MaxRatio: 0.10, Multiplier: 1.20, Score: 15},  // very close — minor encoding difference
+	{MaxRatio: 0.20, Multiplier: 1.10, Score: 10},  // close — probably correct
+	{MaxRatio: 0.50, Multiplier: 1.00, Score: 0},   // acceptable range — no adjustment
+	{MaxRatio: 1.00, Multiplier: 0.75, Score: -10}, // likely different edition, apply cautiously
+	{MaxRatio: 0, Multiplier: 0.50, Score: -20},    // catch-all: ratio > 1.00 — almost certainly wrong book
+}
+
+// durationTier looks up the canonical (multiplier, score) pair for a
+// duration-match ratio. See durationTiers for the boundary-inclusivity
+// contract this switch implements.
+func durationTier(ratio float64) (multiplier, score float64) {
+	switch {
+	case ratio < durationTiers[0].MaxRatio:
+		return durationTiers[0].Multiplier, durationTiers[0].Score
+	case ratio < durationTiers[1].MaxRatio:
+		return durationTiers[1].Multiplier, durationTiers[1].Score
+	case ratio < durationTiers[2].MaxRatio:
+		return durationTiers[2].Multiplier, durationTiers[2].Score
+	case ratio <= durationTiers[3].MaxRatio:
+		return durationTiers[3].Multiplier, durationTiers[3].Score
+	case ratio <= durationTiers[4].MaxRatio:
+		return durationTiers[4].Multiplier, durationTiers[4].Score
+	default:
+		return durationTiers[5].Multiplier, durationTiers[5].Score
 	}
+}
+
+// durationDeltaRatio computes the symmetric duration-match ratio shared by
+// durationScoreMultiplier and computeDurationScore: |candidateDurationSec -
+// bookDurationSec| / bookDurationSec. Callers must have already verified
+// bookDurationSec > 0.
+func durationDeltaRatio(bookDurationSec, candidateDurationSec int) float64 {
 	delta := bookDurationSec - candidateDurationSec
 	if delta < 0 {
 		delta = -delta
 	}
-	switch {
-	case delta <= 60:
-		return 1.30
-	case delta <= 300:
-		return 1.20
-	case delta <= 600:
-		return 1.10
-	case delta <= 1200:
-		return 1.05
-	case delta <= 1800:
-		return 1.00
-	case delta <= 3600:
-		return 0.90
-	case delta <= 7200:
-		return 0.75
-	default:
-		return 0.50
+	return float64(delta) / float64(bookDurationSec)
+}
+
+// durationScoreMultiplier returns a score multiplier based on how closely the
+// candidate's runtime matches the book's known duration, via a lookup into
+// the canonical durationTiers table (shared with computeDurationScore).
+//
+// Both values are in seconds. If either is <= 0 (unknown), the multiplier is
+// 1.0 (no adjustment) — UNKNOWN, never disqualifying. The multiplier is
+// symmetric — only the ratio of the absolute delta to the book's duration
+// matters, not the direction (candidate longer vs shorter).
+//
+// Ratio-based scale (monotonic in the match ratio; replaces the former
+// absolute-delta-second buckets so the multiplier can never disagree with
+// computeDurationScore's ratio-based additive score on the same pair):
+//
+//	ratio <  5%       → ×1.30  (essentially identical — almost certainly the same edition)
+//	ratio <  5–10%     → ×1.20  (very close — same edition, minor encoding difference)
+//	ratio < 10–20%     → ×1.10  (close — probably correct)
+//	ratio ≤ 20–50%     → ×1.00  (acceptable range — no adjustment)
+//	ratio ≤ 50–100%    → ×0.75  (likely different edition, apply cautiously)
+//	ratio  > 100%      → ×0.50  (almost certainly wrong edition or different book)
+func durationScoreMultiplier(bookDurationSec, candidateDurationSec int) float64 {
+	if bookDurationSec <= 0 || candidateDurationSec <= 0 {
+		return 1.0
 	}
+	multiplier, _ := durationTier(durationDeltaRatio(bookDurationSec, candidateDurationSec))
+	return multiplier
 }
 
 // computeDurationScore returns an additive score component (in points) based on
 // how closely a candidate's runtime matches the book's known duration. Unlike
 // durationScoreMultiplier (which scales the overall score multiplicatively),
 // this function produces a human-readable breakdown value that surfaces in the
-// MetadataCandidate.DurationScore field.
+// MetadataCandidate.DurationScore field. Both functions share the same
+// canonical durationTiers lookup (see durationTier), so this Score column is
+// unchanged from the pre-unification implementation.
 //
-// Both values are in seconds. If either is zero (unknown), the result is 0.
+// Both values are in seconds. If either is <= 0 (unknown), the result is 0.
 // The delta ratio = |candidate_dur - book_dur| / book_dur:
 //
 //	ratio < 0.05  → +20  (within 5% — essentially the same edition)
@@ -216,25 +268,8 @@ func computeDurationScore(bookDurationSec, candidateDurationSec int) float64 {
 	if bookDurationSec <= 0 || candidateDurationSec <= 0 {
 		return 0
 	}
-	delta := bookDurationSec - candidateDurationSec
-	if delta < 0 {
-		delta = -delta
-	}
-	ratio := float64(delta) / float64(bookDurationSec)
-	switch {
-	case ratio < 0.05:
-		return 20
-	case ratio < 0.10:
-		return 15
-	case ratio < 0.20:
-		return 10
-	case ratio > 1.00:
-		return -20
-	case ratio > 0.50:
-		return -10
-	default:
-		return 0
-	}
+	_, score := durationTier(durationDeltaRatio(bookDurationSec, candidateDurationSec))
+	return score
 }
 
 // pickBestMatchFromScored takes pre-computed base scores from any tier and

--- a/internal/metafetch/service_scoring_test.go
+++ b/internal/metafetch/service_scoring_test.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_scoring_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7e3f6a1c-9b4d-4e2a-8c1f-6d5b3a2e9f70
 // last-edited: 2026-07-10
 
@@ -7,7 +7,6 @@ package metafetch
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,27 +145,29 @@ func TestSearchMetadataForBookWithOptions_DegenerateEmbeddingFallsBackToF1Result
 // scoring). durationScoreMultiplier (absolute-delta-second buckets) and
 // computeDurationScore (delta-ratio buckets) used to be two independent
 // bucket systems that could disagree on the same pair. This table locks in
-// their CURRENT, pre-unification outputs across a grid straddling every
-// bucket edge of BOTH systems, on both a short (2h) and a very long (40h)
-// book, so the post-unification rewrite (single ratio-based durationTiers
-// table) is provably behavior-preserving where required and every
-// intentional change is called out inline.
+// their outputs across a grid straddling every bucket edge of BOTH systems,
+// on both a short (2h) and a very long (40h) book.
 //
-// Additive computeDurationScore is already ratio-based, so its bucket edges
-// (0.05/0.10/0.20/0.50/1.00 delta-ratio) are independent of book length and
-// its outputs here define the tier table's Score column bit-for-bit — those
-// cells must NOT change after unification.
+// Post-unification (both functions now look up the shared ratio-based
+// durationTiers table via durationTier), EVERY multiplier cell that changed
+// carries an inline comment with the OLD value, the NEW value, and WHY —
+// this enumerated diff is the review artifact for INIT-3-T2. Every additive
+// Score value below is UNCHANGED from the pre-unification implementation
+// (computeDurationScore was already ratio-based, so its bucket edges
+// 0.05/0.10/0.20/0.50/1.00 are independent of book length and untouched by
+// the unification) — this file's git history (commit
+// "test(metafetch): golden fixtures for duration scoring pre-unification")
+// is the proof: the Score column here is identical to that commit's.
 //
-// durationScoreMultiplier is absolute-delta-second-based today (buckets at
-// 60/300/600/1200/1800/3600/7200s), so it responds identically to a given
-// delta regardless of book length; once unified onto the ratio table the
-// SAME delta produces a different multiplier depending on book length
-// (e.g. a 61s delta is a rounding error on a 40h book but a real signal on a
-// 2h book). Nearly every multiplier cell below is therefore EXPECTED to
-// change post-unification — see the inline comments added in the second
-// (post-swap) revision of this table for the old value / new value / why.
+// durationScoreMultiplier was absolute-delta-second-based before this change
+// (buckets at 60/300/600/1200/1800/3600/7200s), so it used to respond
+// identically to a given delta regardless of book length. Now unified onto
+// the ratio table, the SAME delta produces a different multiplier depending
+// on book length (e.g. a 61s delta is a rounding error on a 40h book but a
+// real ~0.85% signal on a 2h book) — this is the intended fix: the two
+// functions can no longer disagree about the same (book, candidate) pair.
 func TestDurationScoringGolden(t *testing.T) {
-	const short2h = 2 * 3600     // 7200s
+	const short2h = 2 * 3600      // 7200s
 	const veryLong40h = 40 * 3600 // 144000s
 
 	type tc struct {
@@ -176,75 +177,161 @@ func TestDurationScoringGolden(t *testing.T) {
 		wantScore      float64
 	}
 
-	// deltaCases straddles every bucket edge of BOTH the old absolute-delta
-	// multiplier (60/300/600/1200/1800/3600/7200s) and the old delta-ratio
-	// additive score (0.05/0.10/0.20/0.50/1.00 ratio) buckets, one tick below
-	// and one tick above each edge.
-	deltaCases := []int{59, 61, 299, 301, 599, 601, 1199, 1201, 1799, 1801, 3599, 3601, 7199, 7201}
+	cases := []tc{
+		// ---------------------------------------------------------------
+		// short2h (book=7200s): delta straddles every OLD absolute-delta-
+		// second edge (60/300/600/1200/1800/3600/7200s); ratio column shows
+		// what the new table actually keys off.
+		// ---------------------------------------------------------------
 
-	var cases []tc
-	for _, book := range []int{short2h, veryLong40h} {
-		bookName := "short2h"
-		if book == veryLong40h {
-			bookName = "verylong40h"
-		}
-		for _, d := range deltaCases {
-			cases = append(cases, tc{
-				name: fmt.Sprintf("%s/delta=%d", bookName, d),
-				book: book, cand: book + d,
-			})
-		}
-	}
+		// delta=59 ratio=0.0082 (<5%): UNCHANGED — both old systems already
+		// agreed here (×1.30/+20), and 0.82% is still deep in the new <5% tier.
+		{name: "short2h/delta=59", book: short2h, cand: short2h + 59, wantMultiplier: 1.30, wantScore: 20},
 
-	// wantMultiplier/wantScore captured from the CURRENT (pre-unification)
-	// implementation on 2026-07-10, via a throwaway probe test run against
-	// this exact grid — see PR description for the raw probe output.
-	current := map[string][2]float64{
-		"short2h/delta=59":        {1.30, 20},
-		"short2h/delta=61":        {1.20, 20},
-		"short2h/delta=299":       {1.20, 20},
-		"short2h/delta=301":       {1.10, 20},
-		"short2h/delta=599":       {1.10, 15},
-		"short2h/delta=601":       {1.05, 15},
-		"short2h/delta=1199":      {1.05, 10},
-		"short2h/delta=1201":      {1.00, 10},
-		"short2h/delta=1799":      {1.00, 0},
-		"short2h/delta=1801":      {0.90, 0},
-		"short2h/delta=3599":      {0.90, 0},
-		"short2h/delta=3601":      {0.75, -10},
-		"short2h/delta=7199":      {0.75, -10},
-		"short2h/delta=7201":      {0.50, -20},
-		"verylong40h/delta=59":    {1.30, 20},
-		"verylong40h/delta=61":    {1.20, 20},
-		"verylong40h/delta=299":   {1.20, 20},
-		"verylong40h/delta=301":   {1.10, 20},
-		"verylong40h/delta=599":   {1.10, 20},
-		"verylong40h/delta=601":   {1.05, 20},
-		"verylong40h/delta=1199":  {1.05, 20},
-		"verylong40h/delta=1201":  {1.00, 20},
-		"verylong40h/delta=1799":  {1.00, 20},
-		"verylong40h/delta=1801":  {0.90, 20},
-		"verylong40h/delta=3599":  {0.90, 20},
-		"verylong40h/delta=3601":  {0.75, 20},
-		"verylong40h/delta=7199":  {0.75, 20},
-		"verylong40h/delta=7201":  {0.50, 15},
-	}
-	for i, c := range cases {
-		want := current[c.name]
-		cases[i].wantMultiplier = want[0]
-		cases[i].wantScore = want[1]
-	}
+		// delta=61 ratio=0.0085 (<5%): CHANGED ×1.20→×1.30. The old absolute-
+		// second bucket crossed its 60s edge and dropped a tier even though
+		// 0.85% is still deep in the <5% ratio tier — the new table correctly
+		// keeps ×1.30.
+		{name: "short2h/delta=61", book: short2h, cand: short2h + 61, wantMultiplier: 1.30, wantScore: 20},
 
-	// Unknown-duration cases: either side <= 0 must be non-disqualifying
-	// (multiplier ×1.0, score +0), never a rejection signal, on both sides
-	// and for negative values too.
-	cases = append(cases,
-		tc{name: "unknown/book=0", book: 0, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
-		tc{name: "unknown/cand=0", book: 5000, cand: 0, wantMultiplier: 1.0, wantScore: 0},
-		tc{name: "unknown/both=0", book: 0, cand: 0, wantMultiplier: 1.0, wantScore: 0},
-		tc{name: "unknown/book=negative", book: -100, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
-		tc{name: "unknown/cand=negative", book: 5000, cand: -100, wantMultiplier: 1.0, wantScore: 0},
-	)
+		// delta=299 ratio=0.0415 (<5%): CHANGED ×1.20→×1.30, same reason as
+		// delta=61 — 4.15% is still under the 5% ratio edge.
+		{name: "short2h/delta=299", book: short2h, cand: short2h + 299, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=301 ratio=0.0418 (<5%): CHANGED ×1.10→×1.30. The old system
+		// crossed its 300s edge into the "close" tier; the ratio is still
+		// under 5%, so the new table keeps the top tier.
+		{name: "short2h/delta=301", book: short2h, cand: short2h + 301, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=599 ratio=0.0832 (5-10%): CHANGED ×1.10→×1.20. Old bucket was
+		// still in its 600s tier (×1.10); ratio-wise 8.3% belongs one tier
+		// higher (×1.20).
+		{name: "short2h/delta=599", book: short2h, cand: short2h + 599, wantMultiplier: 1.20, wantScore: 15},
+
+		// delta=601 ratio=0.0835 (5-10%): CHANGED ×1.05→×1.20. Old bucket
+		// crossed its 600s edge into ×1.05; ratio 8.35% is squarely in the
+		// new 5-10% tier (×1.20).
+		{name: "short2h/delta=601", book: short2h, cand: short2h + 601, wantMultiplier: 1.20, wantScore: 15},
+
+		// delta=1199 ratio=0.1665 (10-20%): CHANGED ×1.05→×1.10. Old bucket
+		// was still in its 1200s tier (×1.05); ratio 16.65% belongs in the
+		// new 10-20% tier (×1.10).
+		{name: "short2h/delta=1199", book: short2h, cand: short2h + 1199, wantMultiplier: 1.10, wantScore: 10},
+
+		// delta=1201 ratio=0.1668 (10-20%): CHANGED ×1.00→×1.10. Old bucket
+		// crossed its 1200s edge into ×1.00; ratio 16.68% is in the new
+		// 10-20% tier (×1.10).
+		{name: "short2h/delta=1201", book: short2h, cand: short2h + 1201, wantMultiplier: 1.10, wantScore: 10},
+
+		// delta=1799 ratio=0.2499 (20-50%): UNCHANGED — old bucket (×1.00,
+		// still within its 1800s tier) happens to match the new 20-50% tier
+		// (×1.00) exactly.
+		{name: "short2h/delta=1799", book: short2h, cand: short2h + 1799, wantMultiplier: 1.00, wantScore: 0},
+
+		// delta=1801 ratio=0.2501 (20-50%): CHANGED ×0.90→×1.00. Old bucket
+		// crossed its 1800s edge into ×0.90; ratio 25.01% is still well
+		// inside the new 20-50% "acceptable range" tier (×1.00).
+		{name: "short2h/delta=1801", book: short2h, cand: short2h + 1801, wantMultiplier: 1.00, wantScore: 0},
+
+		// delta=3599 ratio=0.4999 (20-50%): CHANGED ×0.90→×1.00. Old bucket
+		// was still in its 3600s tier (×0.90); ratio 49.99% is just inside
+		// the new 20-50% tier (×1.00).
+		{name: "short2h/delta=3599", book: short2h, cand: short2h + 3599, wantMultiplier: 1.00, wantScore: 0},
+
+		// delta=3601 ratio=0.5001 (50-100%): UNCHANGED — old bucket (×0.75,
+		// crossing into its 7200s tier) happens to match the new 50-100%
+		// tier (×0.75) exactly.
+		{name: "short2h/delta=3601", book: short2h, cand: short2h + 3601, wantMultiplier: 0.75, wantScore: -10},
+
+		// delta=7199 ratio=0.9999 (50-100%): UNCHANGED — old bucket (×0.75,
+		// still within its 7200s tier) matches the new 50-100% tier (×0.75).
+		{name: "short2h/delta=7199", book: short2h, cand: short2h + 7199, wantMultiplier: 0.75, wantScore: -10},
+
+		// delta=7201 ratio=1.0001 (>100%): UNCHANGED — old bucket (×0.50,
+		// past its 7200s edge) matches the new >100% catch-all tier (×0.50).
+		{name: "short2h/delta=7201", book: short2h, cand: short2h + 7201, wantMultiplier: 0.50, wantScore: -20},
+
+		// ---------------------------------------------------------------
+		// verylong40h (book=144000s): the SAME absolute deltas as above are
+		// now a tiny fraction of a 40h book, so nearly every multiplier cell
+		// changes — this is the core bug INIT-3-T2 fixes: the old
+		// absolute-second multiplier treated a 61s delta on a 40h book as a
+		// meaningful mismatch (×1.20) when it is really a 0.04% rounding
+		// error; the new ratio table correctly keeps it in the top tier.
+		// ---------------------------------------------------------------
+
+		// delta=59 ratio=0.00041 (<5%): UNCHANGED — both old systems already
+		// agreed (×1.30/+20).
+		{name: "verylong40h/delta=59", book: veryLong40h, cand: veryLong40h + 59, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=61 ratio=0.00042 (<5%): CHANGED ×1.20→×1.30. Old bucket
+		// crossed its 60s edge; ratio is a rounding error, stays top tier.
+		{name: "verylong40h/delta=61", book: veryLong40h, cand: veryLong40h + 61, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=299 ratio=0.00208 (<5%): CHANGED ×1.20→×1.30, same reason.
+		{name: "verylong40h/delta=299", book: veryLong40h, cand: veryLong40h + 299, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=301 ratio=0.00209 (<5%): CHANGED ×1.10→×1.30, same reason.
+		{name: "verylong40h/delta=301", book: veryLong40h, cand: veryLong40h + 301, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=599 ratio=0.00416 (<5%): CHANGED ×1.10→×1.30. Old bucket
+		// crossed its 600s edge; ratio is still under 0.5%, top tier.
+		{name: "verylong40h/delta=599", book: veryLong40h, cand: veryLong40h + 599, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=601 ratio=0.00417 (<5%): CHANGED ×1.05→×1.30, same reason.
+		{name: "verylong40h/delta=601", book: veryLong40h, cand: veryLong40h + 601, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=1199 ratio=0.00833 (<5%): CHANGED ×1.05→×1.30. Old bucket was
+		// in its 1200s tier; ratio is under 1%, top tier.
+		{name: "verylong40h/delta=1199", book: veryLong40h, cand: veryLong40h + 1199, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=1201 ratio=0.00834 (<5%): CHANGED ×1.00→×1.30, same reason.
+		{name: "verylong40h/delta=1201", book: veryLong40h, cand: veryLong40h + 1201, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=1799 ratio=0.01249 (<5%): CHANGED ×1.00→×1.30. Old bucket was
+		// in its 1800s "no adjustment" tier; ratio is ~1.25%, top tier.
+		{name: "verylong40h/delta=1799", book: veryLong40h, cand: veryLong40h + 1799, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=1801 ratio=0.01251 (<5%): CHANGED ×0.90→×1.30. Old bucket
+		// crossed its 1800s edge into a penalty tier; ratio is still ~1.25%,
+		// top tier — this is the sharpest illustration of the old bug: a
+		// 30-minute delta on a 40h book was penalized as if it were a
+		// meaningful mismatch.
+		{name: "verylong40h/delta=1801", book: veryLong40h, cand: veryLong40h + 1801, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=3599 ratio=0.02499 (<5%): CHANGED ×0.90→×1.30. Old bucket was
+		// in its 3600s tier; ratio is ~2.5%, top tier.
+		{name: "verylong40h/delta=3599", book: veryLong40h, cand: veryLong40h + 3599, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=3601 ratio=0.02501 (<5%): CHANGED ×0.75→×1.30. Old bucket
+		// crossed its 3600s edge into a heavier penalty; ratio is still
+		// ~2.5%, top tier.
+		{name: "verylong40h/delta=3601", book: veryLong40h, cand: veryLong40h + 3601, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=7199 ratio=0.04999 (<5%): CHANGED ×0.75→×1.30. Old bucket was
+		// in its 7200s tier (the old system's worst-but-one tier); ratio is
+		// just under 5%, still top tier.
+		{name: "verylong40h/delta=7199", book: veryLong40h, cand: veryLong40h + 7199, wantMultiplier: 1.30, wantScore: 20},
+
+		// delta=7201 ratio=0.05001 (5-10%): CHANGED ×0.50→×1.20. Old bucket
+		// crossed its final 7200s edge into the worst tier (×0.50, "almost
+		// certainly wrong edition"); ratio is barely over 5%, landing in the
+		// new 5-10% "very close" tier (×1.20) — the clearest example of the
+		// old function disagreeing with computeDurationScore's ratio-based
+		// +20 ("essentially the same edition") on the identical pair.
+		{name: "verylong40h/delta=7201", book: veryLong40h, cand: veryLong40h + 7201, wantMultiplier: 1.20, wantScore: 15},
+
+		// ---------------------------------------------------------------
+		// Unknown-duration cases: either side <= 0 must be non-disqualifying
+		// (multiplier ×1.0, score +0), never a rejection signal, on both
+		// sides and for negative values too. UNCHANGED by the unification.
+		// ---------------------------------------------------------------
+		{name: "unknown/book=0", book: 0, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
+		{name: "unknown/cand=0", book: 5000, cand: 0, wantMultiplier: 1.0, wantScore: 0},
+		{name: "unknown/both=0", book: 0, cand: 0, wantMultiplier: 1.0, wantScore: 0},
+		{name: "unknown/book=negative", book: -100, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
+		{name: "unknown/cand=negative", book: 5000, cand: -100, wantMultiplier: 1.0, wantScore: 0},
+	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/metafetch/service_scoring_test.go
+++ b/internal/metafetch/service_scoring_test.go
@@ -1,12 +1,13 @@
 // file: internal/metafetch/service_scoring_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e3f6a1c-9b4d-4e2a-8c1f-6d5b3a2e9f70
-// last-edited: 2026-07-03
+// last-edited: 2026-07-10
 
 package metafetch
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,4 +139,119 @@ func TestSearchMetadataForBookWithOptions_DegenerateEmbeddingFallsBackToF1Result
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Results, "F1 fallback should surface non-empty results even though the embedding tier degenerated to all-zero scores")
+}
+
+// ---------------------------------------------------------------------------
+// TestDurationScoringGolden — golden fixtures for INIT-3-T2 (unify duration
+// scoring). durationScoreMultiplier (absolute-delta-second buckets) and
+// computeDurationScore (delta-ratio buckets) used to be two independent
+// bucket systems that could disagree on the same pair. This table locks in
+// their CURRENT, pre-unification outputs across a grid straddling every
+// bucket edge of BOTH systems, on both a short (2h) and a very long (40h)
+// book, so the post-unification rewrite (single ratio-based durationTiers
+// table) is provably behavior-preserving where required and every
+// intentional change is called out inline.
+//
+// Additive computeDurationScore is already ratio-based, so its bucket edges
+// (0.05/0.10/0.20/0.50/1.00 delta-ratio) are independent of book length and
+// its outputs here define the tier table's Score column bit-for-bit — those
+// cells must NOT change after unification.
+//
+// durationScoreMultiplier is absolute-delta-second-based today (buckets at
+// 60/300/600/1200/1800/3600/7200s), so it responds identically to a given
+// delta regardless of book length; once unified onto the ratio table the
+// SAME delta produces a different multiplier depending on book length
+// (e.g. a 61s delta is a rounding error on a 40h book but a real signal on a
+// 2h book). Nearly every multiplier cell below is therefore EXPECTED to
+// change post-unification — see the inline comments added in the second
+// (post-swap) revision of this table for the old value / new value / why.
+func TestDurationScoringGolden(t *testing.T) {
+	const short2h = 2 * 3600     // 7200s
+	const veryLong40h = 40 * 3600 // 144000s
+
+	type tc struct {
+		name           string
+		book, cand     int
+		wantMultiplier float64
+		wantScore      float64
+	}
+
+	// deltaCases straddles every bucket edge of BOTH the old absolute-delta
+	// multiplier (60/300/600/1200/1800/3600/7200s) and the old delta-ratio
+	// additive score (0.05/0.10/0.20/0.50/1.00 ratio) buckets, one tick below
+	// and one tick above each edge.
+	deltaCases := []int{59, 61, 299, 301, 599, 601, 1199, 1201, 1799, 1801, 3599, 3601, 7199, 7201}
+
+	var cases []tc
+	for _, book := range []int{short2h, veryLong40h} {
+		bookName := "short2h"
+		if book == veryLong40h {
+			bookName = "verylong40h"
+		}
+		for _, d := range deltaCases {
+			cases = append(cases, tc{
+				name: fmt.Sprintf("%s/delta=%d", bookName, d),
+				book: book, cand: book + d,
+			})
+		}
+	}
+
+	// wantMultiplier/wantScore captured from the CURRENT (pre-unification)
+	// implementation on 2026-07-10, via a throwaway probe test run against
+	// this exact grid — see PR description for the raw probe output.
+	current := map[string][2]float64{
+		"short2h/delta=59":        {1.30, 20},
+		"short2h/delta=61":        {1.20, 20},
+		"short2h/delta=299":       {1.20, 20},
+		"short2h/delta=301":       {1.10, 20},
+		"short2h/delta=599":       {1.10, 15},
+		"short2h/delta=601":       {1.05, 15},
+		"short2h/delta=1199":      {1.05, 10},
+		"short2h/delta=1201":      {1.00, 10},
+		"short2h/delta=1799":      {1.00, 0},
+		"short2h/delta=1801":      {0.90, 0},
+		"short2h/delta=3599":      {0.90, 0},
+		"short2h/delta=3601":      {0.75, -10},
+		"short2h/delta=7199":      {0.75, -10},
+		"short2h/delta=7201":      {0.50, -20},
+		"verylong40h/delta=59":    {1.30, 20},
+		"verylong40h/delta=61":    {1.20, 20},
+		"verylong40h/delta=299":   {1.20, 20},
+		"verylong40h/delta=301":   {1.10, 20},
+		"verylong40h/delta=599":   {1.10, 20},
+		"verylong40h/delta=601":   {1.05, 20},
+		"verylong40h/delta=1199":  {1.05, 20},
+		"verylong40h/delta=1201":  {1.00, 20},
+		"verylong40h/delta=1799":  {1.00, 20},
+		"verylong40h/delta=1801":  {0.90, 20},
+		"verylong40h/delta=3599":  {0.90, 20},
+		"verylong40h/delta=3601":  {0.75, 20},
+		"verylong40h/delta=7199":  {0.75, 20},
+		"verylong40h/delta=7201":  {0.50, 15},
+	}
+	for i, c := range cases {
+		want := current[c.name]
+		cases[i].wantMultiplier = want[0]
+		cases[i].wantScore = want[1]
+	}
+
+	// Unknown-duration cases: either side <= 0 must be non-disqualifying
+	// (multiplier ×1.0, score +0), never a rejection signal, on both sides
+	// and for negative values too.
+	cases = append(cases,
+		tc{name: "unknown/book=0", book: 0, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
+		tc{name: "unknown/cand=0", book: 5000, cand: 0, wantMultiplier: 1.0, wantScore: 0},
+		tc{name: "unknown/both=0", book: 0, cand: 0, wantMultiplier: 1.0, wantScore: 0},
+		tc{name: "unknown/book=negative", book: -100, cand: 5000, wantMultiplier: 1.0, wantScore: 0},
+		tc{name: "unknown/cand=negative", book: 5000, cand: -100, wantMultiplier: 1.0, wantScore: 0},
+	)
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotMultiplier := durationScoreMultiplier(c.book, c.cand)
+			gotScore := computeDurationScore(c.book, c.cand)
+			assert.InDelta(t, c.wantMultiplier, gotMultiplier, 1e-9, "durationScoreMultiplier(%d, %d)", c.book, c.cand)
+			assert.InDelta(t, c.wantScore, gotScore, 1e-9, "computeDurationScore(%d, %d)", c.book, c.cand)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Unifies `durationScoreMultiplier` (previously absolute-delta-second buckets)
and `computeDurationScore` (previously delta-ratio buckets) behind ONE
canonical `durationTiers` table, keyed by ratio =
`|candidateDurationSec-bookDurationSec| / bookDurationSec`. Both functions
now do a lookup into the shared table via `durationTier`, so they can never
disagree about the same (book, candidate) pair again — both function names
and signatures are unchanged, all call sites in `service_search.go` are
untouched (`git diff origin/main --stat -- internal/metafetch/service_search.go`
is empty).

**Additive score column is provably unchanged for ALL inputs, not just the
test grid.** The new `durationTier` switch (`r<0.05→20; r<0.10→15;
r<0.20→10; r<=0.50→0; r<=1.00→-10; default→-20`) is the old
`computeDurationScore` switch verbatim, including the exact-boundary cases
(r=0.05→15, r=0.50→0, r=1.00→-10) via the same asymmetric `<`/`<=`
operators — a uniform `<=` loop would have broken this at r=0.05, so the
comparators were kept intentionally mismatched per tier.

**Multiplier cells are intentionally changed** wherever the old
absolute-delta-second bucket disagreed with what the ratio actually implies
— e.g. a 61s delta on a 40h book used to be penalized to ×1.20 (crossing the
old 60s edge) even though 61s is a 0.04% rounding error; it's now correctly
×1.30. Every changed cell is called out inline in
`TestDurationScoringGolden` (`internal/metafetch/service_scoring_test.go`)
with the old value, new value, and why — that table is the review artifact.
One behavioral note for reviewers: the ratio table also softens the
worst-tier penalty for shorter candidates (e.g. a 6h-off candidate on a 10h
book was ×0.50, is now ×0.75 since ratio 0.6 falls in the 50–100% tier);
`×0.50` is now only reachable when the candidate is >2x the book's known
duration. `TestPickBestMatchFromScored_WrongEditionRejected` still passes
since the base-score margin still resolves the winner correctly.

Golden fixtures were committed FIRST (capturing the pre-unification
independent outputs), then the swap landed in a second commit that updates
only the cells whose real behavior changed.

## Files changed

- `internal/metafetch/service_scoring.go` — the `durationTiers` table +
  `durationTier` lookup + rewritten `durationScoreMultiplier` /
  `computeDurationScore` (same names/signatures).
- `internal/metafetch/service_scoring_test.go` — `TestDurationScoringGolden`
  golden fixtures, with per-cell change justification comments.
- `internal/metafetch/service_mock_test.go` — pre-existing
  `TestDurationScoreMultiplier` updated to the new ratio-based expectations
  (was locking in the old absolute-second-bucket behavior on a 10h book).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/metafetch/...` — clean
- [x] scoped `staticcheck ./internal/metafetch/...` — clean (repo-wide
      `make ci` staticcheck step aborts on the pre-existing backlog #1796,
      none of it in `internal/metafetch`)
- [x] `go test ./internal/metafetch/... -count=1` — all green
- [x] `go test ./internal/metafetch/ -run TestDurationScoringGolden -v` — all
      green (28 grid cases + 5 unknown-duration cases)
- [x] Acceptance greps: `durationTiers` present, `case delta <=` count is 0,
      `service_search.go` diff empty

Co-Authored-By: Claude <noreply@anthropic.com>