### PR TITLE
fix(server): enroll all four cache warmers in bgWG with shutdown skip (#1794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.134.0 -->
+<!-- version: 3.135.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-10 -->
 
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 10, 2026 - fix(server): enroll all four cache warmers in bgWG with shutdown skip (#1794)
+
+- **`fix(server)`** — `warmFacetsCache`/`warmLibrarySizes`/`warmAuthorsCache`/`warmSeriesCache`
+  were fire-and-forget and could outlive `Close()` (PEBBLE-CLOSED family lifecycle gap;
+  follow-up to #1781, which enrolled the sibling `library-list-warmer` +
+  `apikey-expiry-sweep`). Each launch in `startCacheWarmers`
+  (`internal/server/server_lifecycle.go`) now registers a named `s.bgWG` entry
+  (`facets-warmer`/`library-sizes-warmer`/`authors-warmer`/`series-warmer`) and skips on an
+  already-canceled `s.bgCtx` before touching the store, mirroring the enrolled sibling. The
+  stale "remain intentionally untracked" doc comment above `startCacheWarmers` is rewritten to
+  match. No warmer function signature changed. New tests
+  `TestStartCacheWarmers_SkipOnCanceledCtx` / `TestStartCacheWarmers_EnrolledInBgWG`
+  (`internal/server/cache_warmers_bgwg_test.go`) cover both the shutdown-skip path and the
+  anti-over-suppression case (a live `bgCtx` must still run every warmer), green under `-race`.
+  TODO.md's WARMERS-NOT-IN-BGWG item checked off.
 
 #### July 10, 2026 - docs(plan): 10 remaining-work planning packages (INIT-1..10)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.83.0 -->
+<!-- version: 9.84.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-10 -->
 
@@ -1281,10 +1281,15 @@ must sequence, but A and B are parallelizable. Spawn:
   finds fixed in #1781: latent prod nil-deref in `ProtectedPathCache.refresh()` with Deluge
   unconfigured (tag-write pre-flights would 500), deluge singleton test leak, RootDir test
   pollution. Proof: `internal/server -short -race -count=2` green (952s).
-- [ ] **WARMERS-NOT-IN-BGWG** (2026-07-03, follow-up from #1781) — sibling fire-and-forget cache
-  warmers (`warmFacetsCache`/`warmLibrarySizes`/`warmAuthorsCache`/`warmSeriesCache`) are
-  short-lived and haven't struck, but share the trickle-warmer's lifecycle gap. Enroll in
-  bgWG/bgCtx like `runTrickleWarmer` (server_lifecycle.go / library_list_warmer.go pattern).
+- [x] **WARMERS-NOT-IN-BGWG** (2026-07-03, follow-up from #1781) — ✅ **FIXED 2026-07-10 (#1794,
+  TASK-05).** Sibling fire-and-forget cache warmers (`warmFacetsCache`/`warmLibrarySizes`/
+  `warmAuthorsCache`/`warmSeriesCache`) were short-lived and hadn't struck, but shared the
+  trickle-warmer's lifecycle gap. Enrolled in bgWG/bgCtx exactly like `runTrickleWarmer`
+  (server_lifecycle.go `startCacheWarmers`): each launch now does
+  `bgWG.Add(name)`/`defer bgWG.Done(name)` plus a `bgCtx.Err()` shutdown-skip check. New tests
+  `TestStartCacheWarmers_SkipOnCanceledCtx` / `TestStartCacheWarmers_EnrolledInBgWG` in
+  `internal/server/cache_warmers_bgwg_test.go` cover both the skip-on-shutdown and
+  anti-over-suppression (live ctx still runs warmers) cases under `-race`.
 - [x] **INGEST-VERSION-FLAKE** (2026-07-03) — ✅ **FIXED #1777.** Root cause was NOT ordering:
   PebbleStore async memdb-warmup race — `CreateImportPath`'s memdb write no-ops before warmup
   publishes, so `GetAllImportPaths` (memdb-backed) missed the test's temp dir →

--- a/internal/server/cache_warmers_bgwg_test.go
+++ b/internal/server/cache_warmers_bgwg_test.go
@@ -1,0 +1,107 @@
+// file: internal/server/cache_warmers_bgwg_test.go
+// version: 1.1.0
+// guid: 8f2b6f2a-9e1c-4d3a-8b7e-0c6f5a1d2e3b
+// last-edited: 2026-07-10
+
+// cache_warmers_bgwg_test verifies TASK-05 (#1794): all four fire-and-forget
+// cache warmers (warmFacetsCache/warmLibrarySizes/warmAuthorsCache/
+// warmSeriesCache) are enrolled in s.bgWG and skip when s.bgCtx is already
+// canceled, mirroring the library-list-warmer sibling enrolled by #1781.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitCacheWarmersBgWG runs wg.Wait() in a goroutine and fails the test
+// instead of hanging forever if a warmer leaks past its bgCtx-canceled skip
+// check (task-unique name to avoid the parallel-test-helper-collision
+// footgun — internal/server already has other _test.go files in flight).
+func waitCacheWarmersBgWG(t *testing.T, wg *namedWaitGroup, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("bgWG.Wait() did not return within %s — still running: %v", timeout, wg.Running())
+	}
+}
+
+// TestStartCacheWarmers_SkipOnCanceledCtx verifies that when the server's
+// bgCtx is already canceled (shutdown in progress), all four warmers skip
+// their store access instead of racing a possibly-closed Pebble store, and
+// bgWG.Wait() still returns promptly with no panic. A canceled bgCtx also
+// lets the long-lived siblings sharing bgWG (apikey-expiry-sweep,
+// library-list-trickle-warmer) exit immediately via their own bgCtx.Done()
+// checks, so Wait() returning here is not warmer-specific — it is the
+// no-goroutine-leak assertion.
+func TestStartCacheWarmers_SkipOnCanceledCtx(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// Simulate a server already tearing down.
+	server.bgCancel()
+
+	server.startCacheWarmers()
+	waitCacheWarmersBgWG(t, &server.bgWG, 5*time.Second)
+
+	_, facetsOK := server.facetsCache.Get(facetsCacheKey)
+	assert.False(t, facetsOK, "facets warmer should have skipped on canceled bgCtx")
+
+	_, authorsOK := server.authorsCache.Get("all")
+	assert.False(t, authorsOK, "authors warmer should have skipped on canceled bgCtx")
+
+	_, seriesOK := server.seriesCache.Get("all")
+	assert.False(t, seriesOK, "series warmer should have skipped on canceled bgCtx")
+}
+
+// TestStartCacheWarmers_EnrolledInBgWG is the anti-over-suppression
+// counterpart: with a live (non-canceled) bgCtx every warmer must still run
+// to completion and populate its cache — the skip check must never fire
+// while the server is healthy.
+//
+// bgWG also carries two intentionally long-lived siblings that only exit on
+// bgCtx cancellation (apikey-expiry-sweep ticks every 6h;
+// library-list-trickle-warmer runs until shutdown), so this test cannot call
+// bgWG.Wait() while bgCtx is still live — that would hang the whole suite.
+// Instead: assert the four target warmers ran (their caches populated)
+// while bgCtx is live, THEN cancel bgCtx so every enrolled goroutine
+// (targets + siblings) can exit, THEN Wait() with a timeout to confirm no
+// goroutine leaked past shutdown.
+func TestStartCacheWarmers_EnrolledInBgWG(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	require.NoError(t, server.bgCtx.Err(), "bgCtx must be live for this test")
+
+	server.startCacheWarmers()
+
+	assert.Eventually(t, func() bool {
+		_, ok := server.facetsCache.Get(facetsCacheKey)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "facets warmer should have executed and populated the cache with a live bgCtx")
+
+	assert.Eventually(t, func() bool {
+		_, ok := server.authorsCache.Get("all")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "authors warmer should have executed and populated the cache with a live bgCtx")
+
+	assert.Eventually(t, func() bool {
+		_, ok := server.seriesCache.Get("all")
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "series warmer should have executed and populated the cache with a live bgCtx")
+
+	// Let the long-lived siblings (and the trickle warmer) observe shutdown
+	// so bgWG.Wait() below can return.
+	server.bgCancel()
+	waitCacheWarmersBgWG(t, &server.bgWG, 10*time.Second)
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.43.0
+// version: 1.44.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-10
 
 package server
 
@@ -695,18 +695,36 @@ func (s *Server) Start(cfg ServerConfig) error {
 
 // startCacheWarmers launches the fire-and-forget cache pre-warmers plus the
 // API-key expiry sweep. Extracted verbatim from Start as part of the SYS-2
-// decomposition; goroutine-tracking is unchanged — warmFacetsCache /
-// warmLibrarySizes / warmAuthorsCache / warmSeriesCache remain intentionally
-// untracked, while library-list-warmer and apikey-expiry-sweep stay enrolled
-// in bgWG (PR #1781 lifecycle work). Do not "promote" the untracked ones here.
+// decomposition; all four cache warmers (warmFacetsCache / warmLibrarySizes /
+// warmAuthorsCache / warmSeriesCache) are now bgWG-enrolled per #1794 (the
+// follow-up to #1781, which enrolled library-list-warmer + apikey-expiry-sweep
+// first) so a Shutdown drains every warmer before the store closes instead of
+// letting it outlive Close() and hit a closed Pebble store
+// (PEBBLE-CLOSED family). Each launch also skips on an already-canceled
+// bgCtx — a SKIP-on-shutdown guard, not a startup gate: a live bgCtx must
+// still run every warmer.
 func (s *Server) startCacheWarmers() {
 	// Pre-warm facets cache (genres/languages) - lightweight, <1 second
-	go s.warmFacetsCache()
+	s.bgWG.Add("facets-warmer")
+	go func() {
+		defer s.bgWG.Done("facets-warmer")
+		if s.bgCtx.Err() != nil {
+			return // server already shutting down — skip, never warm a closing store
+		}
+		s.warmFacetsCache()
+	}()
 	// Pre-warm library size cache via filesystem walk so any later refresh
 	// path (nightly maintenance, manual rescan) starts with current data.
 	// The hot path of /system/status reads DB stats (PR #1137); this just
 	// keeps the FS-based numbers fresh in the 24h-TTL package cache.
-	go s.warmLibrarySizes()
+	s.bgWG.Add("library-sizes-warmer")
+	go func() {
+		defer s.bgWG.Done("library-sizes-warmer")
+		if s.bgCtx.Err() != nil {
+			return // server already shutting down — skip, never warm a closing store
+		}
+		s.warmLibrarySizes()
+	}()
 	// Pre-warm the audiobook list cache after memdb is published. Fires
 	// the most common library-page queries (title asc/desc, -review:matched,
 	// library_state filter) so the user's first load doesn't pay the full
@@ -721,8 +739,22 @@ func (s *Server) startCacheWarmers() {
 		defer s.bgWG.Done("library-list-warmer")
 		s.warmAudiobookListCache()
 	}()
-	go s.warmAuthorsCache()
-	go s.warmSeriesCache()
+	s.bgWG.Add("authors-warmer")
+	go func() {
+		defer s.bgWG.Done("authors-warmer")
+		if s.bgCtx.Err() != nil {
+			return // server already shutting down — skip, never warm a closing store
+		}
+		s.warmAuthorsCache()
+	}()
+	s.bgWG.Add("series-warmer")
+	go func() {
+		defer s.bgWG.Done("series-warmer")
+		if s.bgCtx.Err() != nil {
+			return // server already shutting down — skip, never warm a closing store
+		}
+		s.warmSeriesCache()
+	}()
 
 	// Low-frequency background sweep that WARN-logs API keys approaching
 	// expiry or lacking one entirely (legacy keys) — observability only,


### PR DESCRIPTION
warmFacetsCache/warmLibrarySizes/warmAuthorsCache/warmSeriesCache were
fire-and-forget and could outlive Close() (PEBBLE-CLOSED family lifecycle gap;
follow-up to #1781). Each launch now registers a named bgWG entry and skips on
an already-canceled bgCtx, mirroring the enrolled library-list-warmer sibling.

Co-Authored-By: Claude <noreply@anthropic.com>
