### PR TITLE
fix(search): apply per-user DSL filters in searchWithBleve (INIT-4 T2)

### DIFF
--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-07
+// last-edited: 2026-07-10
 
 package audiobooks
 
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
 )
@@ -67,7 +68,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	// Apply filters in order of precedence
 	if search != "" {
 		if svc.searchIndex != nil {
-			books, err = svc.searchWithBleve(search, limit, offset)
+			books, err = svc.searchWithBleve(search, limit, offset, f.UserID)
 		} else {
 			books, err = svc.store.SearchBooks(search, limit, offset)
 		}
@@ -512,16 +513,29 @@ func (svc *AudiobookService) EnrichAudiobooksWithNamesAndFiles(books []database.
 	return enrichedBooks
 }
 
+// searchPostFilterWindow bounds the Bleve over-fetch used when
+// per-user DSL filters (read_status / progress_pct / last_played)
+// must be applied in Go after the index returns candidates. Mirrors
+// the playlist evaluator's defaultEvalPageSize precedent
+// (internal/playlist/evaluator.go) — kept as a private, package-local
+// constant rather than importing the playlist one.
+const searchPostFilterWindow = 10000
+
 // searchWithBleve parses the query via the DSL, translates to a
 // Bleve native query, and returns the matching books. Per-user
 // filters produced by the translator (read_status / progress_pct /
-// last_played) are currently dropped here — the library-list route
-// doesn't carry user state. Spec 3.6 will wire them back in at the
-// handler layer once the user context is plumbed.
+// last_played) are applied here (INIT-4 T2) via
+// search.MatchPerUserFilters: Bleve is over-fetched up to
+// searchPostFilterWindow, each hit's per-user state is read and
+// matched, then offset/limit slicing is applied to the filtered
+// slice. Requires userID (the authenticated caller, plumbed in by
+// GetAudiobooks via f.UserID); with no userID the filters are
+// skipped and a warning is logged rather than silently
+// over-suppressing results.
 //
 // Falls back to an empty slice (not nil) on zero matches so callers
 // get consistent JSON shape.
-func (svc *AudiobookService) searchWithBleve(query string, limit, offset int) ([]database.Book, error) {
+func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, userID string) ([]database.Book, error) {
 	ast, err := search.ParseQuery(query)
 	if err != nil {
 		// Parser failure: fall back to the substring search path so
@@ -529,10 +543,64 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int) ([
 		// rejects (e.g. punctuation-heavy book titles).
 		return svc.store.SearchBooks(query, limit, offset)
 	}
-	bleveQ, _, err := search.Translate(ast)
+	bleveQ, perUser, err := search.Translate(ast)
 	if err != nil {
 		return svc.store.SearchBooks(query, limit, offset)
 	}
+
+	if len(perUser) > 0 && userID != "" && !config.AppConfig.DisablePerUserSearchFilters {
+		hits, _, err := svc.searchIndex.SearchNative(bleveQ, 0, searchPostFilterWindow)
+		if err != nil {
+			return nil, fmt.Errorf("bleve search: %w", err)
+		}
+		if len(hits) >= searchPostFilterWindow {
+			slog.Warn("search: post-filter window exhausted; results beyond it are truncated",
+				"window", searchPostFilterWindow)
+		}
+		filtered := make([]database.Book, 0, len(hits))
+		for _, h := range hits {
+			b, _ := svc.store.GetBookByID(h.BookID)
+			if b == nil {
+				continue
+			}
+			state, stateErr := svc.store.GetUserBookState(userID, b.ID)
+			if stateErr != nil {
+				// FAIL-OPEN (Decision 5): evaluate the zero-value state, loudly.
+				slog.Warn("search: per-user state read failed; evaluating zero-value state",
+					"book_id", b.ID, "err", stateErr)
+				state = nil
+			}
+			if !search.MatchPerUserFilters(state, perUser) {
+				continue
+			}
+			filtered = append(filtered, *b)
+		}
+		// Apply pagination after filtering — offset beyond len yields an
+		// empty slice, not an error (mirrors GetAudiobooks' heavy
+		// post-filter slicing above).
+		if offset > 0 && offset < len(filtered) {
+			filtered = filtered[offset:]
+		} else if offset >= len(filtered) {
+			filtered = nil
+		}
+		if limit > 0 && limit < len(filtered) {
+			filtered = filtered[:limit]
+		}
+		if filtered == nil {
+			filtered = []database.Book{}
+		}
+		return filtered, nil
+	}
+
+	if len(perUser) > 0 {
+		reason := "no_user_context"
+		if config.AppConfig.DisablePerUserSearchFilters {
+			reason = "disabled_by_config"
+		}
+		slog.Warn("search: per-user filters dropped, no user context",
+			"filters", len(perUser), "reason", reason)
+	}
+
 	hits, _, err := svc.searchIndex.SearchNative(bleveQ, offset, limit)
 	if err != nil {
 		return nil, fmt.Errorf("bleve search: %w", err)

--- a/internal/audiobooks/service_query_search_per_user_test.go
+++ b/internal/audiobooks/service_query_search_per_user_test.go
@@ -1,0 +1,253 @@
+// file: internal/audiobooks/service_query_search_per_user_test.go
+// version: 1.0.0
+// guid: e3a7c1d9-4b2f-4a68-9c1e-5f8a2d3b7c40
+// last-edited: 2026-07-10
+
+// Tests for the searchWithBleve per-user DSL filter fix (INIT-4 T2).
+// read_status / progress_pct / last_played filters are peeled off by
+// search.Translate and were previously discarded with `_`; these
+// tests pin the restored behavior: over-fetch -> per-user match ->
+// offset/limit slicing, fail-open state-read errors, window-
+// exhaustion warning, and the DisablePerUserSearchFilters kill
+// switch.
+
+package audiobooks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// buildSearchTestIndex opens a throwaway on-disk Bleve index and seeds
+// it with docs all sharing Author "sanderson" so a single DSL clause
+// (author:sanderson) selects every seeded book, letting the per-user
+// clause do all the narrowing in each test below.
+func buildSearchTestIndex(t *testing.T, bookIDs ...string) *search.BleveIndex {
+	t.Helper()
+	idx, err := search.Open(filepath.Join(t.TempDir(), "bleve"))
+	if err != nil {
+		t.Fatalf("open bleve: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	docs := make([]search.BookDocument, 0, len(bookIDs))
+	for _, id := range bookIDs {
+		docs = append(docs, search.BookDocument{BookID: id, Title: id, Author: "sanderson"})
+	}
+	if err := idx.IndexBookBatch(docs); err != nil {
+		t.Fatalf("index batch: %v", err)
+	}
+	return idx
+}
+
+// captureWarnLog redirects the default slog logger to a buffer for
+// the duration of the test and restores it on cleanup.
+func captureWarnLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := slog.Default()
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestSearchWithBleveAppliesReadStatusFilter is acceptance case (a):
+// read_status:finished returns only the finished book.
+func TestSearchWithBleveAppliesReadStatusFilter(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	mockStore.EXPECT().GetUserBookState("alice", "b1").
+		Return(&database.UserBookState{Status: database.UserBookStatusInProgress}, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b2").
+		Return(&database.UserBookState{Status: database.UserBookStatusFinished}, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b3").Return(nil, nil)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson read_status:finished", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "b2", got[0].ID)
+	}
+}
+
+// TestSearchWithBleveNoFilterQueryUnchanged is the positive control for
+// (c): a plain query with no per-user DSL clause returns Bleve's hits
+// unchanged (fast path untouched).
+func TestSearchWithBleveNoFilterQueryUnchanged(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	assert.Len(t, got, 3, "no per-user clause -> all 3 Bleve matches returned")
+}
+
+// TestSearchWithBlevePaginationAfterFilter is acceptance case (b):
+// pagination must slice AFTER the per-user filter pass, not before.
+// Seeds 5 Bleve hits where 2 fail the per-user filter, leaving 3
+// post-filter matches; limit=2 offset=2 must yield exactly 1 book.
+// If pagination were (incorrectly) applied to the raw 5 pre-filter
+// hits instead, limit=2 offset=2 would select 2 raw hits BEFORE
+// filtering — which could yield 0, 1, or 2 books depending on which
+// 2 of the 5 landed in that window, so this only discriminates
+// correctly because the filter-passing books (b1, b3, b5) are
+// deliberately not contiguous in seed order.
+func TestSearchWithBlevePaginationAfterFilter(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3", "b4", "b5")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	inProgress := &database.UserBookState{Status: database.UserBookStatusInProgress}
+	finished := &database.UserBookState{Status: database.UserBookStatusFinished}
+	mockStore.EXPECT().GetUserBookState("alice", "b1").Return(inProgress, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b2").Return(finished, nil) // filtered out
+	mockStore.EXPECT().GetUserBookState("alice", "b3").Return(inProgress, nil)
+	mockStore.EXPECT().GetUserBookState("alice", "b4").Return(finished, nil) // filtered out
+	mockStore.EXPECT().GetUserBookState("alice", "b5").Return(inProgress, nil)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 2, 2, "author:sanderson read_status:in_progress", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	assert.Len(t, got, 1, "5 raw hits, 3 post-filter matches, limit=2 offset=2 -> 1 book")
+}
+
+// TestSearchWithBleveEmptyUserIDReturnsAllMatches is acceptance case
+// (c): anti-over-suppression. Without a userID, per-user filters are
+// skipped (not applied as an all-fail filter) so results aren't
+// silently emptied.
+func TestSearchWithBleveEmptyUserIDReturnsAllMatches(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	// No GetUserBookState expectation set — asserting the code path
+	// never calls it when userID == "".
+
+	buf := captureWarnLog(t)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson read_status:finished", nil, nil, ListFilters{})
+	assert.NoError(t, err)
+	assert.Len(t, got, 3, "empty userID must never produce an empty page when matches exist")
+	assert.Contains(t, buf.String(), "per-user filters dropped, no user context")
+}
+
+// TestSearchWithBleveStateErrorFailsOpen covers spec Decision 5 and
+// the Testing table: a GetUserBookState error on one hit must NOT
+// silently drop the row or fail the whole request. It's evaluated as
+// the zero-value state (loudly, via a warn) and the request keeps
+// serving. Uses a NEGATED filter so the zero-value evaluation is
+// directly observable: an erroring state read must still be treated
+// as unfinished, so `-read_status:finished` keeps it in the results.
+func TestSearchWithBleveStateErrorFailsOpen(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	mockStore.EXPECT().GetUserBookState("alice", "b1").
+		Return(nil, fmt.Errorf("pebble: i/o error"))
+	mockStore.EXPECT().GetUserBookState("alice", "b2").
+		Return(&database.UserBookState{Status: database.UserBookStatusFinished}, nil)
+
+	buf := captureWarnLog(t)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson -read_status:finished", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1, "erroring state read -> zero-value eval keeps b1 (not finished); b2 genuinely finished is excluded") {
+		assert.Equal(t, "b1", got[0].ID)
+	}
+	assert.Contains(t, buf.String(), "per-user state read failed; evaluating zero-value state")
+	assert.Contains(t, buf.String(), "b1")
+}
+
+// TestSearchWithBleveWindowExhaustionWarns covers the Testing-table
+// Decision 4 contract: when the pre-filter hit count reaches
+// searchPostFilterWindow, a truncation warning is logged.
+func TestSearchWithBleveWindowExhaustionWarns(t *testing.T) {
+	ids := make([]string, searchPostFilterWindow+5)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("book-%05d", i)
+	}
+	idx := buildSearchTestIndex(t, ids...)
+
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	// Every state read returns nil,nil (no record) -> zero-value state.
+	// Filter is negated read_status:finished so the zero-value state
+	// always passes, keeping the assembled slice large without needing
+	// per-ID stubbing.
+	mockStore.EXPECT().GetUserBookState(mock.Anything, mock.Anything).Return(nil, nil)
+
+	buf := captureWarnLog(t)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	_, err := svc.GetAudiobooks(context.Background(), 10, 0, "author:sanderson -read_status:finished", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "post-filter window exhausted; results beyond it are truncated")
+}
+
+// TestSearchWithBleveKillSwitchDrops covers spec Decision 11: with
+// DisablePerUserSearchFilters=true, per-user filters are skipped
+// (today's pre-fix drop-and-warn behavior) even though a userID is
+// present.
+func TestSearchWithBleveKillSwitchDrops(t *testing.T) {
+	config.Mutate(func(c *config.Config) { c.DisablePerUserSearchFilters = true })
+	t.Cleanup(func() {
+		config.Mutate(func(c *config.Config) { c.DisablePerUserSearchFilters = false })
+	})
+
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
+	mockStore := mocks.NewMockStore(t)
+	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
+		return &database.Book{ID: id}, nil
+	})
+	// No GetUserBookState expectation: the kill switch must prevent any
+	// state reads at all — an unexpected call here fails the test.
+
+	buf := captureWarnLog(t)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson read_status:finished", nil, nil, ListFilters{UserID: "alice"})
+	assert.NoError(t, err)
+	assert.Len(t, got, 3, "kill switch on -> today's unfiltered behavior restored")
+	assert.Contains(t, buf.String(), "per-user filters dropped, no user context")
+	assert.Contains(t, buf.String(), "disabled_by_config")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.64.0
+// version: 1.65.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-10
 
 package config
 
@@ -541,6 +541,13 @@ type Config struct {
 	// token (.bootstrap-token) is always generated — it is emergency access
 	// infrastructure and is not affected by this flag.
 	WriteStartupReadOnlyKey bool `json:"write_startup_readonly_key" mapstructure:"write_startup_readonly_key"`
+
+	// DisablePerUserSearchFilters, when true, makes searchWithBleve skip
+	// per-user DSL post-filtering (read_status/progress_pct/last_played)
+	// and warn — the pre-fix drop-and-warn behavior. Ops escape hatch for
+	// the up-to-10K sequential state reads per per-user-filtered request
+	// (spec Decision 11); NOT a feature flag. Default false = filters ON.
+	DisablePerUserSearchFilters bool `json:"disable_per_user_search_filters"`
 }
 
 // mu guards AppConfig against concurrent writes.

--- a/internal/playlist/evaluator.go
+++ b/internal/playlist/evaluator.go
@@ -1,6 +1,7 @@
 // file: internal/playlist/evaluator.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: 9c2d5f1e-6b4a-4a70-b8c5-3d7e0f1b9a68
+// last-edited: 2026-07-10
 //
 // Smart playlist query evaluator (spec 3.4 task 2).
 //
@@ -28,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -123,7 +123,9 @@ func EvaluateSmartPlaylist(
 // whose per-user state doesn't satisfy every filter. Filters for
 // fields the user never wrote are treated as "no match" (the user
 // hasn't engaged with the book, so e.g. `read_status:finished`
-// doesn't match an unstarted book).
+// doesn't match an unstarted book). Matching itself delegates to
+// search.MatchPerUserFilters — the single exported source of truth
+// shared with searchWithBleve (INIT-4 T2).
 func applyPerUserFilters(
 	store database.UserPositionStore,
 	ids []string,
@@ -136,116 +138,11 @@ func applyPerUserFilters(
 	kept := make([]string, 0, len(ids))
 	for _, id := range ids {
 		state, _ := store.GetUserBookState(userID, id)
-		match := true
-		for _, f := range filters {
-			ok := perUserFilterMatches(state, f.Node)
-			if f.Negated {
-				ok = !ok
-			}
-			if !ok {
-				match = false
-				break
-			}
-		}
-		if match {
+		if search.MatchPerUserFilters(state, filters) {
 			kept = append(kept, id)
 		}
 	}
 	return kept
-}
-
-// perUserFilterMatches evaluates a single FieldNode against a
-// UserBookState. A nil state means the user has no record — only
-// negated filters can succeed against nil.
-func perUserFilterMatches(state *database.UserBookState, node *search.FieldNode) bool {
-	if state == nil {
-		// Treat absence as a zero-value state: status="" + progress=0.
-		// That way `read_status:unstarted` (if the caller maps
-		// "unstarted"→"") matches and `read_status:finished` rejects.
-		state = &database.UserBookState{}
-	}
-	switch node.Field {
-	case "read_status":
-		return strings.EqualFold(state.Status, node.Value)
-	case "progress_pct":
-		return numericFieldMatches(float64(state.ProgressPct), node)
-	case "last_played":
-		if state.LastActivityAt.IsZero() {
-			return false
-		}
-		return timeFieldMatches(state.LastActivityAt, node)
-	default:
-		return false
-	}
-}
-
-func numericFieldMatches(got float64, node *search.FieldNode) bool {
-	switch node.Op {
-	case "range":
-		lo, err1 := strconv.ParseFloat(node.RangeMin, 64)
-		hi, err2 := strconv.ParseFloat(node.RangeMax, 64)
-		if err1 != nil || err2 != nil {
-			return false
-		}
-		return got >= lo && got <= hi
-	case ">", "<", ">=", "<=", "=", "":
-		want, err := strconv.ParseFloat(node.Value, 64)
-		if err != nil {
-			return false
-		}
-		switch node.Op {
-		case ">":
-			return got > want
-		case "<":
-			return got < want
-		case ">=":
-			return got >= want
-		case "<=":
-			return got <= want
-		default:
-			return got == want
-		}
-	}
-	return false
-}
-
-func timeFieldMatches(got time.Time, node *search.FieldNode) bool {
-	parse := func(s string) (time.Time, bool) {
-		// Accept RFC3339 + plain YYYY-MM-DD.
-		if t, err := time.Parse(time.RFC3339, s); err == nil {
-			return t, true
-		}
-		if t, err := time.Parse("2006-01-02", s); err == nil {
-			return t, true
-		}
-		return time.Time{}, false
-	}
-	switch node.Op {
-	case "range":
-		lo, ok1 := parse(node.RangeMin)
-		hi, ok2 := parse(node.RangeMax)
-		if !ok1 || !ok2 {
-			return false
-		}
-		return !got.Before(lo) && !got.After(hi)
-	default:
-		want, ok := parse(node.Value)
-		if !ok {
-			return false
-		}
-		switch node.Op {
-		case ">":
-			return got.After(want)
-		case "<":
-			return got.Before(want)
-		case ">=":
-			return got.After(want) || got.Equal(want)
-		case "<=":
-			return got.Before(want) || got.Equal(want)
-		default:
-			return got.Equal(want)
-		}
-	}
 }
 
 // sortBookIDs reorders ids per the playlist's SortJSON directives.

--- a/internal/search/per_user_match.go
+++ b/internal/search/per_user_match.go
@@ -1,0 +1,132 @@
+// file: internal/search/per_user_match.go
+// version: 1.0.0
+// guid: a82911d7-d9dc-4f47-9863-1a7638e47194
+// last-edited: 2026-07-10
+
+// Per-user DSL filter evaluation (INIT-4 T2). Moved here — verbatim —
+// from internal/playlist/evaluator.go so internal/search is the single
+// exported source of truth for matching a database.UserBookState
+// against the PerUserFilter slice Translate peels off the DSL AST.
+// Both the playlist evaluator and searchWithBleve delegate to
+// MatchPerUserFilters instead of each carrying their own copy.
+
+package search
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// MatchPerUserFilters reports whether state satisfies EVERY filter
+// (AND semantics; Negated inverts per filter). state==nil is evaluated
+// as the zero-value UserBookState — read_status:finished rejects an
+// unstarted book, negated filters can still succeed.
+func MatchPerUserFilters(state *database.UserBookState, filters []PerUserFilter) bool {
+	for _, f := range filters {
+		ok := perUserFilterMatches(state, f.Node)
+		if f.Negated {
+			ok = !ok
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// perUserFilterMatches evaluates a single FieldNode against a
+// UserBookState. A nil state means the user has no record — only
+// negated filters can succeed against nil.
+func perUserFilterMatches(state *database.UserBookState, node *FieldNode) bool {
+	if state == nil {
+		// Treat absence as a zero-value state: status="" + progress=0.
+		// That way `read_status:unstarted` (if the caller maps
+		// "unstarted"→"") matches and `read_status:finished` rejects.
+		state = &database.UserBookState{}
+	}
+	switch node.Field {
+	case "read_status":
+		return strings.EqualFold(state.Status, node.Value)
+	case "progress_pct":
+		return numericFieldMatches(float64(state.ProgressPct), node)
+	case "last_played":
+		if state.LastActivityAt.IsZero() {
+			return false
+		}
+		return timeFieldMatches(state.LastActivityAt, node)
+	default:
+		return false
+	}
+}
+
+func numericFieldMatches(got float64, node *FieldNode) bool {
+	switch node.Op {
+	case "range":
+		lo, err1 := strconv.ParseFloat(node.RangeMin, 64)
+		hi, err2 := strconv.ParseFloat(node.RangeMax, 64)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+		return got >= lo && got <= hi
+	case ">", "<", ">=", "<=", "=", "":
+		want, err := strconv.ParseFloat(node.Value, 64)
+		if err != nil {
+			return false
+		}
+		switch node.Op {
+		case ">":
+			return got > want
+		case "<":
+			return got < want
+		case ">=":
+			return got >= want
+		case "<=":
+			return got <= want
+		default:
+			return got == want
+		}
+	}
+	return false
+}
+
+func timeFieldMatches(got time.Time, node *FieldNode) bool {
+	parse := func(s string) (time.Time, bool) {
+		// Accept RFC3339 + plain YYYY-MM-DD.
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
+	}
+	switch node.Op {
+	case "range":
+		lo, ok1 := parse(node.RangeMin)
+		hi, ok2 := parse(node.RangeMax)
+		if !ok1 || !ok2 {
+			return false
+		}
+		return !got.Before(lo) && !got.After(hi)
+	default:
+		want, ok := parse(node.Value)
+		if !ok {
+			return false
+		}
+		switch node.Op {
+		case ">":
+			return got.After(want)
+		case "<":
+			return got.Before(want)
+		case ">=":
+			return got.After(want) || got.Equal(want)
+		case "<=":
+			return got.Before(want) || got.Equal(want)
+		default:
+			return got.Equal(want)
+		}
+	}
+}

--- a/internal/search/per_user_match_test.go
+++ b/internal/search/per_user_match_test.go
@@ -1,0 +1,127 @@
+// file: internal/search/per_user_match_test.go
+// version: 1.0.0
+// guid: 6f3d8b2a-1c4e-4a9f-9d2b-7e5a1f3c8b60
+// last-edited: 2026-07-10
+
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func filter(field, value string, negated bool) PerUserFilter {
+	return PerUserFilter{Node: &FieldNode{Field: field, Value: value}, Negated: negated}
+}
+
+func TestMatchPerUserFilters_NilStateZeroValue(t *testing.T) {
+	// nil state == zero-value UserBookState: Status == "".
+	filters := []PerUserFilter{filter("read_status", "finished", false)}
+	if MatchPerUserFilters(nil, filters) {
+		t.Error("nil state should NOT match read_status:finished")
+	}
+}
+
+func TestMatchPerUserFilters_NilStateNegatedMatches(t *testing.T) {
+	// A NEGATED filter (`NOT read_status:finished`) DOES match a book
+	// with no state.
+	filters := []PerUserFilter{filter("read_status", "finished", true)}
+	if !MatchPerUserFilters(nil, filters) {
+		t.Error("nil state should match NOT read_status:finished")
+	}
+}
+
+func TestMatchPerUserFilters_ReadStatusMatch(t *testing.T) {
+	state := &database.UserBookState{Status: database.UserBookStatusFinished}
+	filters := []PerUserFilter{filter("read_status", "finished", false)}
+	if !MatchPerUserFilters(state, filters) {
+		t.Error("expected finished state to match read_status:finished")
+	}
+}
+
+func TestMatchPerUserFilters_ReadStatusCaseInsensitive(t *testing.T) {
+	state := &database.UserBookState{Status: "Finished"}
+	filters := []PerUserFilter{filter("read_status", "finished", false)}
+	if !MatchPerUserFilters(state, filters) {
+		t.Error("expected read_status match to be case-insensitive")
+	}
+}
+
+func TestMatchPerUserFilters_Negation(t *testing.T) {
+	state := &database.UserBookState{Status: database.UserBookStatusInProgress}
+	filters := []PerUserFilter{filter("read_status", "finished", true)}
+	if !MatchPerUserFilters(state, filters) {
+		t.Error("in-progress state should match NOT read_status:finished")
+	}
+
+	finishedState := &database.UserBookState{Status: database.UserBookStatusFinished}
+	if MatchPerUserFilters(finishedState, filters) {
+		t.Error("finished state should NOT match NOT read_status:finished")
+	}
+}
+
+func TestMatchPerUserFilters_NumericRange(t *testing.T) {
+	filters := []PerUserFilter{
+		{Node: &FieldNode{Field: "progress_pct", Op: "range", RangeMin: "50", RangeMax: "100"}},
+	}
+	if !MatchPerUserFilters(&database.UserBookState{ProgressPct: 75}, filters) {
+		t.Error("progress_pct 75 should match progress_pct:50..100")
+	}
+	if MatchPerUserFilters(&database.UserBookState{ProgressPct: 10}, filters) {
+		t.Error("progress_pct 10 should NOT match progress_pct:50..100")
+	}
+	// Boundaries are inclusive.
+	if !MatchPerUserFilters(&database.UserBookState{ProgressPct: 50}, filters) {
+		t.Error("progress_pct 50 should match progress_pct:50..100 (inclusive lower bound)")
+	}
+	if !MatchPerUserFilters(&database.UserBookState{ProgressPct: 100}, filters) {
+		t.Error("progress_pct 100 should match progress_pct:50..100 (inclusive upper bound)")
+	}
+}
+
+func TestMatchPerUserFilters_LastPlayedZeroNeverMatches(t *testing.T) {
+	filters := []PerUserFilter{
+		{Node: &FieldNode{Field: "last_played", Op: ">", Value: "2020-01-01"}},
+	}
+	// Zero LastActivityAt (nil state, or a state that never played)
+	// never matches a last_played filter, negated or not being
+	// evaluated at the FieldNode layer (negation applied by caller).
+	if MatchPerUserFilters(nil, filters) {
+		t.Error("zero LastActivityAt should never match a last_played filter")
+	}
+	state := &database.UserBookState{LastActivityAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}
+	if !MatchPerUserFilters(state, filters) {
+		t.Error("2024 last_played should match last_played:>2020-01-01")
+	}
+}
+
+func TestMatchPerUserFilters_AndAcrossFilters(t *testing.T) {
+	state := &database.UserBookState{
+		Status:      database.UserBookStatusInProgress,
+		ProgressPct: 60,
+	}
+	filters := []PerUserFilter{
+		filter("read_status", "in_progress", false),
+		{Node: &FieldNode{Field: "progress_pct", Op: "range", RangeMin: "50", RangeMax: "100"}},
+	}
+	if !MatchPerUserFilters(state, filters) {
+		t.Error("state satisfying both filters should match (AND semantics)")
+	}
+
+	// Fail one of the two filters -> overall no match.
+	failFilters := []PerUserFilter{
+		filter("read_status", "finished", false),
+		{Node: &FieldNode{Field: "progress_pct", Op: "range", RangeMin: "50", RangeMax: "100"}},
+	}
+	if MatchPerUserFilters(state, failFilters) {
+		t.Error("state failing one of two AND'd filters should NOT match")
+	}
+}
+
+func TestMatchPerUserFilters_EmptyFiltersAlwaysMatch(t *testing.T) {
+	if !MatchPerUserFilters(nil, nil) {
+		t.Error("no filters should always match")
+	}
+}


### PR DESCRIPTION
## Summary

`read_status:` / `progress_pct:` / `last_played:` DSL filters were peeled off by the
translator (`search.Translate`) and then discarded with `_` in `searchWithBleve` —
`read_status:unread` returned **unfiltered** results. This wires them back in.

- Lifted the playlist package's per-user evaluator into `internal/search/per_user_match.go`
  as ONE exported source of truth (`MatchPerUserFilters` + the three moved-verbatim private
  helpers `perUserFilterMatches` / `numericFieldMatches` / `timeFieldMatches`).
- `internal/playlist/evaluator.go` now delegates its inner match loop to
  `search.MatchPerUserFilters` (the three private funcs deleted, not copied).
- `searchWithBleve` now captures the `perUser` slice and, when
  `len(perUser) > 0 && userID != "" && !DisablePerUserSearchFilters`, over-fetches Bleve to
  `searchPostFilterWindow` (10000), reads each hit's per-user state, matches, then applies
  `offset`/`limit` slicing AFTER filtering.
- State-read errors **fail open** (zero-value eval + `slog.Warn`, never a silent `_` discard,
  never a request failure) — spec Decision 5.
- Window-exhaustion warning when pre-filter hits reach the window — spec Decision 4.
- New config kill switch `disable_per_user_search_filters` (default false = filters ON) —
  spec Decision 11.
- Empty-userID / disabled paths keep today's drop-and-warn behavior (anti-over-suppression).

## Files changed

- `internal/search/per_user_match.go` (new) — moved evaluator + `MatchPerUserFilters`
- `internal/search/per_user_match_test.go` (new) — nil-state/negation/numeric-range/AND tests
- `internal/playlist/evaluator.go` — delegate to `search.MatchPerUserFilters`; drop `strconv` import
- `internal/audiobooks/service_query.go` — `searchWithBleve` signature + per-user filter application
- `internal/audiobooks/service_query_search_per_user_test.go` (new) — 7 search-path tests
- `internal/config/config.go` — `DisablePerUserSearchFilters` field

## Tests

- `internal/search`: `TestMatchPerUserFilters_*` (9) green
- `internal/audiobooks`: `TestSearchWithBleve{AppliesReadStatusFilter,NoFilterQueryUnchanged,PaginationAfterFilter,EmptyUserIDReturnsAllMatches,StateErrorFailsOpen,WindowExhaustionWarns,KillSwitchDrops}` green; full `go test ./internal/audiobooks/... -count=1` = ok (103s)
- `internal/playlist`: existing tests pass UNMODIFIED (incl. property-based `TestProp_PerUserFilterIsolation`) — pins the moved evaluator's behavior
- `go build ./...` clean; `go vet ./...` clean; `gofmt -l` clean; scoped `staticcheck` clean

## Notes for reviewer (deviations)

1. **Acceptance grep #5** (`state, _ := ...GetUserBookState`) returns **1 hit at
   `service_query.go:312`** — that is the pre-existing `ListFilters.PerUserFilters` path
   (`matchesAllPerUserFilters`), which the brief explicitly forbids touching. The NEW
   `searchWithBleve` code correctly uses `state, stateErr :=` + fail-open warn, so the
   criterion's intent ("no silent discard on the search path") is met. Left line 312 as-is
   per the brief's surgical-precision boundary.
2. The no-user-context / kill-switch warn adds a `"reason"` attribute
   (`no_user_context` vs `disabled_by_config`) to the single shared warn message, rather than
   the brief's exact `slog.Warn(..., "filters", len(perUser))` call — same skip-and-warn
   branch, differentiated by reason value.
3. Full-suite `go test ./... -short` returned exit 1 due to `internal/server`'s
   `TestCoverageUserTags` hitting the 10-min default timeout — an **unrelated package this diff
   does not touch** and a documented intermittent stall (`NewFileIOPool` goroutines parked on
   `chan receive`). Not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)