### PR TITLE
feat(database): implement GetFolderDuplicatesCore on Pebble + MemStore (INIT-2 T1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,27 @@
   anti-over-suppression case (a live `bgCtx` must still run every warmer), green under `-race`.
   TODO.md's WARMERS-NOT-IN-BGWG item checked off.
 
+#### July 10, 2026 - feat(database): implement GetFolderDuplicatesCore on Pebble + MemStore (INIT-2 T1)
+
+- **`database`** — replaced the known-unimplemented `GetFolderDuplicatesCore` stub (previously a
+  hard `return nil, nil` on both storage backends) with a real implementation: `PebbleStore`
+  delegates to a new `MemStore.GetFolderDuplicatesCore` twin when memdb is published, with a
+  Pebble-scan fallback (paged `GetAllBooksCore` + per-book `GetBookFiles`, never a per-book
+  title-query fan-out) for cold start/tests. Both backends bucket non-deleted, primary-version
+  books by `(util.NormalizeTitle(title), single-parent-dir)` through a shared
+  `bucketFolderDuplicates` helper so the two paths can never drift; a book with no files or files
+  spanning multiple dirs has an UNKNOWN parent dir and is silently skipped (never grouped, never
+  an error). Dedup tier 2 ("same title in same folder, e.g. M4B + MP3") in
+  `internal/dedup/book_dedup.go`'s `ScanBookDuplicates` and
+  `AudiobookService.GetDuplicateBooks` now returns real groups instead of an always-empty tier.
+  Added `MockStore.GetFolderDuplicatesCoreFunc` hook mirroring the existing
+  `GetDuplicateBooksByMetadataFunc` shape. `GetDuplicateBooksByMetadataCore` (the metadata-fuzzy
+  sibling) is untouched — deferred to a follow-up task.
+- Tests: `internal/database/pebble_store_folder_dups_test.go` runs a shared fixture through both
+  the memdb-delegation path and the Pebble scan-fallback path and asserts identical groups,
+  including an anti-over-suppression case where a multi-dir book is skipped but other valid
+  groups still return.
+
 #### July 10, 2026 - docs(plan): 10 remaining-work planning packages (INIT-1..10)
 
 - **`docs`** — full planning packages for the remaining-work catalog: 10 design specs,

--- a/TODO.md
+++ b/TODO.md
@@ -123,22 +123,30 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   regression tests — same shape, could be added as a follow-up if one of them regresses.
 - Root cause + census (historical): `docs/audits/2026-07-05-updatebookfile-memdb-writeback-fingerprint-wipe.md`.
 
-## 🟠 GetFolderDuplicates / GetDuplicateBooksByMetadata are no-op stubs in production (found 2026-07-07)
+## 🟠 GetDuplicateBooksByMetadata is still a no-op stub in production (found 2026-07-07, folder half fixed 2026-07-10)
 
 - **NEW finding** during STOREFID W6's Core retype of these 2 getters. `PebbleStore.GetFolderDuplicatesCore`
-  and `PebbleStore.GetDuplicateBooksByMetadataCore` (`internal/database/pebble_store.go`) are hard
-  `return nil, nil` stubs — **no `MemStore` implementation exists for either getter**, so unlike
-  every other slim getter in this codebase, these two ALWAYS return empty regardless of
+  and `PebbleStore.GetDuplicateBooksByMetadataCore` (`internal/database/pebble_store.go`) were both hard
+  `return nil, nil` stubs — **no `MemStore` implementation existed for either getter**, so unlike
+  every other slim getter in this codebase, these two ALWAYS returned empty regardless of
   `UseMemDB`. Folder-based duplicate detection (same title, same folder — e.g. M4B + MP3 pairs) and
-  metadata-based fuzzy duplicate detection are therefore non-functional in production today; only
-  hash-based duplicate detection (`GetDuplicateBooks`) actually works.
+  metadata-based fuzzy duplicate detection were therefore non-functional in production; only
+  hash-based duplicate detection (`GetDuplicateBooks`) actually worked.
   Callers: `internal/dedup/book_dedup.go` (`ScanBookDuplicates`, tiers 2 and 3 of the 3-tier scan),
   `internal/audiobooks/service_single.go` (`GetDuplicateBooks`).
-- **Not fixed as part of W6** — implementing real folder/metadata duplicate detection is a
-  materially different task than a type retype (the retype only made the existing no-op behavior
-  Core-typed; the STOREFID work does not change or fix this gap). Needs its own scoped design:
-  folder-based detection would need a folder→books index or a scan; metadata-based detection
-  already has full fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
+- **✅ Folder half FIXED 2026-07-10 (INIT-2 TASK-01)**: `PebbleStore.GetFolderDuplicatesCore` now
+  delegates to a real `MemStore.GetFolderDuplicatesCore` twin when memdb is published, with a
+  Pebble-scan fallback (paged `GetAllBooksCore` + per-book `GetBookFiles`) for cold start/tests.
+  Both backends bucket non-deleted, primary-version books by
+  `(util.NormalizeTitle(title), single-parent-dir)` via a shared `bucketFolderDuplicates` helper so
+  the two paths can't drift. A book with no files, or files spanning multiple dirs, has an
+  UNKNOWN parent dir and is silently skipped (never grouped, never an error). Dedup tier 2 in
+  `ScanBookDuplicates` / `AudiobookService.GetDuplicateBooks` now returns real folder-duplicate
+  groups. Tests: `internal/database/pebble_store_folder_dups_test.go` (both backends, incl. the
+  anti-over-suppression case where a multi-dir book is skipped but other groups still return).
+- **Metadata half still open (TASK-02, same files, later wave)** — implementing real
+  metadata-based fuzzy duplicate detection is a separate scoped task: it already has full
+  fuzzy-matching logic downstream (`applyTranscriptionMetadataTiebreaker`,
   `metadataPairSimilarity`) that's just never fed any candidates today.
 
 ## ✅ DurationSec invariant for the 3 PR-B fingerprint ops — RESOLVED + PROD-CONFIRMED (2026-07-06 → 08)

--- a/internal/database/memdb_reads.go
+++ b/internal/database/memdb_reads.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_reads.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000006
-// last-edited: 2026-07-07
+// last-edited: 2026-07-10
 
 package database
 
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
 
 // Read-side implementations for the queries previously handled by Chai SQL.
@@ -352,6 +353,63 @@ func (m *MemStore) GetAllAuthorFileCounts() (map[int]int, error) {
 		out[authorID] += n
 	}
 	return out, nil
+}
+
+// GetFolderDuplicatesCore is the MemStore twin of
+// PebbleStore.GetFolderDuplicatesCore's memdb-delegation branch
+// (pebble_store.go) — see that method's doc comment for full bucketing
+// semantics (normalizedTitle + single-parent-dir, >=2 members per group,
+// deleted/non-primary/empty-title/multi-dir books silently skipped). Walks
+// the memdb books table once via the ID index, resolving each qualifying
+// book's parent dir from the memdb book_files table (memIdxBookID) — a
+// pointer walk, no JSON unmarshal, no Pebble disk scan — then defers to the
+// shared bucketFolderDuplicates helper so the two backends can never drift
+// in bucketing behavior.
+func (m *MemStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
+	txn := m.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(memTableBooks, memIdxID)
+	if err != nil {
+		return nil, fmt.Errorf("memdb folder duplicates scan: %w", err)
+	}
+
+	var entries []folderDupEntry
+	for obj := iter.Next(); obj != nil; obj = iter.Next() {
+		b := obj.(*Book)
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			continue
+		}
+		if b.IsPrimaryVersion != nil && !*b.IsPrimaryVersion {
+			continue
+		}
+		if strings.TrimSpace(b.Title) == "" {
+			continue
+		}
+
+		fIter, ferr := txn.Get(memTableBookFiles, memIdxBookID, b.ID)
+		if ferr != nil {
+			return nil, fmt.Errorf("memdb book_files for %s: %w", b.ID, ferr)
+		}
+		var paths []string
+		for fo := fIter.Next(); fo != nil; fo = fIter.Next() {
+			if bf, ok := fo.(*BookFile); ok {
+				paths = append(paths, bf.FilePath)
+			}
+		}
+		dir, ok := singleParentDir(paths)
+		if !ok {
+			continue
+		}
+
+		entries = append(entries, folderDupEntry{
+			book:      b.Core(),
+			normTitle: util.NormalizeTitle(b.Title),
+			dir:       dir,
+		})
+	}
+
+	return bucketFolderDuplicates(entries), nil
 }
 
 // GetBooksBySeriesIDCore returns primary, not-deleted books for a series

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.78.0
+// version: 1.79.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-07
+// last-edited: 2026-07-10
 
 package database
 
@@ -58,6 +58,7 @@ type MockStore struct {
 	RevertBookToVersionFunc         func(id string, ts time.Time) (*Book, error)
 	PruneBookVersionsFunc           func(id string, keepCount int) (int, error)
 	GetDuplicateBooksFunc           func() ([][]Book, error)
+	GetFolderDuplicatesCoreFunc     func() ([][]BookCore, error)
 	GetDuplicateBooksByMetadataFunc func(threshold float64) ([][]BookCore, error)
 	CreateBookFunc                  func(book *Book) (*Book, error)
 	UpdateBookFunc                  func(id string, book *Book) (*Book, error)
@@ -760,6 +761,9 @@ func (m *MockStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]Boo
 }
 
 func (m *MockStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
+	if m.GetFolderDuplicatesCoreFunc != nil {
+		return m.GetFolderDuplicatesCoreFunc()
+	}
 	return nil, nil
 }
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.110.0
+// version: 1.111.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-07
+// last-edited: 2026-07-10
 
 package database
 
@@ -1040,12 +1040,123 @@ func (p *PebbleStore) GetBooksByTitleInDir(normalizedTitle, dirPath string) ([]B
 // GetFolderDuplicatesCore is Core-typed (STOREFID W6) — see the interface
 // doc comment.
 //
-// PebbleStore doesn't support folder-based duplicate detection efficiently
-// (no MemStore implementation exists for this getter either — it is a
-// known-unimplemented stub on both storage backends today, always returning
-// an empty result; see TODO.md for the tracked gap).
+// Groups books for dedup tier 2 ("same title in same folder, e.g. M4B +
+// MP3"): buckets non-deleted, primary-version books by
+// (util.NormalizeTitle(title), single-parent-dir) and emits every bucket
+// with >=2 members as one []BookCore group. A book with no files, or whose
+// files span more than one distinct parent directory, has an UNKNOWN parent
+// dir — it is silently skipped (never grouped, never an error); an
+// empty/whitespace title is skipped too (an empty-title bucket would glue
+// unrelated books together). Delegates to the memdb twin when published
+// (mirrors GetBooksBySeriesIDCore's delegation shape); otherwise pages
+// through GetAllBooksCore (bounded pages) and resolves each book's parent
+// dir via GetBookFiles — a single pass over books, never a per-book
+// title-query fan-out (that O(N^2) shape is what GetBooksByTitleInDir would
+// produce if called per book, so this method never calls it).
 func (p *PebbleStore) GetFolderDuplicatesCore() ([][]BookCore, error) {
-	return nil, nil
+	if p.UseMemDB && p.mem() != nil {
+		return p.mem().GetFolderDuplicatesCore()
+	}
+
+	var entries []folderDupEntry
+	const folderDupPageSize = 500
+	offset := 0
+	for {
+		page, err := p.GetAllBooksCore(folderDupPageSize, offset)
+		if err != nil {
+			return nil, err
+		}
+		for _, book := range page {
+			// GetAllBooksCore already excludes MarkedForDeletion rows; primary
+			// version is not one of its filters, so it's checked here to
+			// mirror GetBooksBySeriesIDCore's memdb-twin exclusions.
+			if book.IsPrimaryVersion != nil && !*book.IsPrimaryVersion {
+				continue
+			}
+			if strings.TrimSpace(book.Title) == "" {
+				continue
+			}
+
+			files, ferr := p.GetBookFiles(book.ID)
+			if ferr != nil {
+				return nil, ferr
+			}
+			paths := make([]string, len(files))
+			for i, f := range files {
+				paths[i] = f.FilePath
+			}
+			dir, ok := singleParentDir(paths)
+			if !ok {
+				continue
+			}
+
+			entries = append(entries, folderDupEntry{
+				book:      book,
+				normTitle: util.NormalizeTitle(book.Title),
+				dir:       dir,
+			})
+		}
+		if len(page) < folderDupPageSize {
+			break
+		}
+		offset += folderDupPageSize
+	}
+
+	return bucketFolderDuplicates(entries), nil
+}
+
+// folderDupEntry is one qualifying book (already filtered for
+// deleted/non-primary/empty-title/unknown-dir) awaiting bucketing by
+// GetFolderDuplicatesCore's bucketing pass. Shared between the PebbleStore
+// scan-fallback (above) and the MemStore twin (memdb_reads.go) so the two
+// backends can never drift in bucketing semantics.
+type folderDupEntry struct {
+	book      BookCore
+	normTitle string
+	dir       string
+}
+
+// bucketFolderDuplicates buckets entries by (normTitle, dir) and emits every
+// bucket with >=2 members as one group, preserving first-seen bucket order.
+func bucketFolderDuplicates(entries []folderDupEntry) [][]BookCore {
+	type bucketKey struct {
+		title string
+		dir   string
+	}
+	buckets := make(map[bucketKey][]BookCore)
+	order := make([]bucketKey, 0, len(entries))
+	for _, e := range entries {
+		key := bucketKey{title: e.normTitle, dir: e.dir}
+		if _, exists := buckets[key]; !exists {
+			order = append(order, key)
+		}
+		buckets[key] = append(buckets[key], e.book)
+	}
+
+	var groups [][]BookCore
+	for _, key := range order {
+		if len(buckets[key]) >= 2 {
+			groups = append(groups, buckets[key])
+		}
+	}
+	return groups
+}
+
+// singleParentDir returns the shared filepath.Dir of every path, or ("",
+// false) when there are no paths, or the paths span more than one distinct
+// directory — the "UNKNOWN parent dir" case documented on
+// GetFolderDuplicatesCore, a non-disqualifying skip.
+func singleParentDir(paths []string) (string, bool) {
+	if len(paths) == 0 {
+		return "", false
+	}
+	dir := filepath.Dir(paths[0])
+	for _, p := range paths[1:] {
+		if filepath.Dir(p) != dir {
+			return "", false
+		}
+	}
+	return dir, true
 }
 
 // GetDuplicateBooksByMetadataCore is Core-typed (STOREFID W6) — see the

--- a/internal/database/pebble_store_folder_dups_test.go
+++ b/internal/database/pebble_store_folder_dups_test.go
@@ -1,0 +1,175 @@
+// file: internal/database/pebble_store_folder_dups_test.go
+// version: 1.0.0
+// guid: 7b16b9f0-cdcf-4018-bd7a-f293247a9a91
+// last-edited: 2026-07-10
+
+package database
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// folderDupFixtureIDs names the book IDs created by buildFolderDupFixture,
+// keyed by mnemonic, so subtests can assert on specific books without
+// re-deriving IDs from titles.
+type folderDupFixtureIDs struct {
+	sameA, sameB             string // (a): same normalized title, same dir -> grouped
+	diffDirA, diffDirB       string // (b): same normalized title, different dirs -> not grouped
+	uniqueOnly               string // (c): single book, unique title -> not grouped
+	deletedKeep, deletedGone string // (d): marked-for-deletion excluded, leaving a singleton
+	multiDir                 string // (e): files span two dirs -> UNKNOWN dir, skipped
+}
+
+// buildFolderDupFixture populates store with the TASK-01 acceptance fixture
+// covering all five documented cases (a)-(e). Every created BookFile gets a
+// globally-unique file path (via the fileSeq counter) so the book:path and
+// book_file secondary indexes never silently collide across fixture books,
+// even when two books intentionally share the same parent directory.
+func buildFolderDupFixture(t *testing.T, store Store) folderDupFixtureIDs {
+	t.Helper()
+
+	fileSeq := 0
+	nextFilePath := func(dir string) string {
+		fileSeq++
+		return filepath.Join(dir, fmt.Sprintf("file%d.mp3", fileSeq))
+	}
+
+	create := func(title string, dirs []string, opts ...func(*Book)) string {
+		book := &Book{Title: title}
+		if len(dirs) > 0 {
+			book.FilePath = nextFilePath(dirs[0])
+		}
+		for _, o := range opts {
+			o(book)
+		}
+		created, err := store.CreateBook(book)
+		require.NoError(t, err)
+		for _, dir := range dirs {
+			bf := &BookFile{BookID: created.ID, FilePath: nextFilePath(dir)}
+			require.NoError(t, store.CreateBookFile(bf))
+		}
+		return created.ID
+	}
+
+	var ids folderDupFixtureIDs
+
+	// (a) two books, same normalized title (case/whitespace differ), files
+	// in the same dir -> one group of 2.
+	ids.sameA = create("Same Title", []string{"/library/AuthorA/BookX"})
+	ids.sameB = create("  SAME TITLE  ", []string{"/library/AuthorA/BookX"})
+
+	// (b) same normalized title, different dirs -> no group.
+	ids.diffDirA = create("Different Dir Title", []string{"/library/AuthorB/BookY"})
+	ids.diffDirB = create("different dir title", []string{"/library/AuthorB/BookZ"})
+
+	// (c) single book, unique title -> no group.
+	ids.uniqueOnly = create("Unique Title Only", []string{"/library/AuthorC/BookC"})
+
+	// (d) marked-for-deletion book excluded: only one non-deleted book
+	// remains sharing the title/dir, so no group forms.
+	ids.deletedKeep = create("Deleted Group Title", []string{"/library/AuthorD/BookD"})
+	ids.deletedGone = create("Deleted Group Title", []string{"/library/AuthorD/BookD"}, func(b *Book) {
+		deleted := true
+		b.MarkedForDeletion = &deleted
+	})
+
+	// (e) a book with files in two DIFFERENT dirs -> UNKNOWN parent dir,
+	// silently skipped (never grouped, never an error). Its title is
+	// unique so it wouldn't group with anything else anyway; the case of
+	// interest is that its presence must not suppress the valid (a) group
+	// (anti-over-suppression) — see the MultiDirSkippedOthersStillGrouped
+	// subtest below.
+	ids.multiDir = create("Multi Dir Skip Title", []string{
+		"/library/AuthorE/BookE1",
+		"/library/AuthorE/BookE2",
+	})
+
+	return ids
+}
+
+// groupIDs returns the sorted book IDs of a single group, for
+// order-independent comparison.
+func groupIDs(group []BookCore) []string {
+	ids := make([]string, len(group))
+	for i, b := range group {
+		ids[i] = b.ID
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// assertFolderDupGroups asserts that groups contains exactly one group,
+// containing exactly ids.sameA/ids.sameB (case a), and that none of the
+// deliberately-not-grouped fixture books (cases b/c/d/e) appear in any
+// group.
+func assertFolderDupGroups(t *testing.T, groups [][]BookCore, ids folderDupFixtureIDs) {
+	t.Helper()
+	require.Len(t, groups, 1, "expected exactly one folder-duplicate group")
+
+	want := []string{ids.sameA, ids.sameB}
+	sort.Strings(want)
+	require.Equal(t, want, groupIDs(groups[0]))
+
+	excluded := map[string]bool{
+		ids.diffDirA:    true,
+		ids.diffDirB:    true,
+		ids.uniqueOnly:  true,
+		ids.deletedKeep: true,
+		ids.deletedGone: true,
+		ids.multiDir:    true,
+	}
+	for _, g := range groups {
+		for _, b := range g {
+			require.False(t, excluded[b.ID], "book %s should not appear in any folder-duplicate group", b.ID)
+		}
+	}
+}
+
+// TestGetFolderDuplicatesCore runs the shared TASK-01 fixture through BOTH
+// the memdb-delegation path (PebbleStore.UseMemDB=true, the production
+// default) and the Pebble scan-fallback path (UseMemDB=false), asserting
+// identical groups on both, plus a dedicated anti-over-suppression subtest
+// for case (e).
+func TestGetFolderDuplicatesCore(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	ids := buildFolderDupFixture(t, store)
+
+	p, ok := store.(*PebbleStore)
+	require.True(t, ok, "expected *PebbleStore from setupPebbleTestDB")
+	p.WaitForWarmup()
+
+	t.Run("MemDBPath", func(t *testing.T) {
+		p.UseMemDB = true
+		groups, err := store.GetFolderDuplicatesCore()
+		require.NoError(t, err)
+		assertFolderDupGroups(t, groups, ids)
+	})
+
+	t.Run("ScanFallbackPath", func(t *testing.T) {
+		p.UseMemDB = false
+		groups, err := store.GetFolderDuplicatesCore()
+		require.NoError(t, err)
+		assertFolderDupGroups(t, groups, ids)
+	})
+
+	t.Run("MultiDirSkippedOthersStillGrouped", func(t *testing.T) {
+		// Case (e), anti-over-suppression: a book whose files span two
+		// distinct parent dirs is silently skipped (UNKNOWN dir) rather
+		// than erroring or suppressing the rest of the run — the valid
+		// case-(a) group must still come back, on BOTH backends.
+		for _, useMemDB := range []bool{true, false} {
+			p.UseMemDB = useMemDB
+			groups, err := store.GetFolderDuplicatesCore()
+			require.NoError(t, err)
+			require.Len(t, groups, 1)
+			require.NotContains(t, groupIDs(groups[0]), ids.multiDir)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Replaces the known-unimplemented `GetFolderDuplicatesCore` stub (previously a hard `return nil, nil` on both storage backends) with a real implementation, so dedup tier 2 ("same title in same folder, e.g. M4B + MP3") in `ScanBookDuplicates` and `AudiobookService.GetDuplicateBooks` starts returning groups.
- `PebbleStore.GetFolderDuplicatesCore` delegates to a new `MemStore.GetFolderDuplicatesCore` twin (`internal/database/memdb_reads.go`) when memdb is published (mirrors `GetBooksBySeriesIDCore`'s delegation shape); otherwise falls back to paging `GetAllBooksCore` + resolving each qualifying book's parent dir via `GetBookFiles` — one pass over books, never a per-book title-query fan-out.
- Both backends bucket non-deleted, primary-version books by `(util.NormalizeTitle(title), single-parent-dir)` through a new shared `bucketFolderDuplicates`/`singleParentDir` helper pair in `pebble_store.go`, so the two paths can never drift in bucketing semantics. A book with no files, or files spanning more than one parent dir, has an UNKNOWN parent dir and is silently skipped (never grouped, never an error); an empty/whitespace title is skipped too.
- Added `MockStore.GetFolderDuplicatesCoreFunc` hook mirroring the existing `GetDuplicateBooksByMetadataFunc` shape.
- `GetDuplicateBooksByMetadataCore` (the metadata-fuzzy sibling, TASK-02) is untouched — its stub, doc comment, and `return nil, nil` are left as-is.
- Updated `TODO.md`'s "GetFolderDuplicates / GetDuplicateBooksByMetadata are no-op stubs" entry to close out the folder half and `CHANGELOG.md` with a matching entry.

**Note for reviewers on the concurrency mandate:** the Pebble scan-fallback path calls `GetBookFiles(bookID)` once per qualifying book in a plain loop. This is intentional and matches the brief: it's a cold-start/tests-only fallback (production runs the memdb twin, a microsecond in-memory index walk), and each call is an O(1) bounded prefix scan, not the O(N²) per-book *title-query* fan-out the docstring explicitly calls out as forbidden (that shape would come from calling `GetBooksByTitleInDir` per book, which this method never does).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `staticcheck ./internal/database/...` — 1 pre-existing unrelated finding (`deleteFingerprintLSHIndexesByID is unused`, present on `origin/main` before this change); no new findings on touched files
- [x] `go test ./internal/database/... -short -race -run TestGetFolderDuplicatesCore -count=1 -v` — PASS (MemDBPath, ScanFallbackPath, MultiDirSkippedOthersStillGrouped subtests, both plain and `-race`)
- [x] `go test ./... -short -count=1` — full run hit 2 timeouts under heavy concurrent-session disk contention on the dev box (`internal/database`'s `TestCoverage_*` and `internal/server`'s `TestCoverageListActiveOperations`, both pre-existing tests with zero code path overlap with this change, stuck on Pebble `fsync`/`pebble.Open` per goroutine dumps — the documented "CI Go Tests intermittent stalls" flake). Isolated targeted reruns of the specific stuck tests pass in ~5s each; all dedup/duplicates-adjacent packages that DO exercise this getter (`internal/dedup`, `internal/audiobooks`, `internal/server/handlers/dedup`, `internal/server/handlers/duplicates`) passed cleanly in the full run.

New test file: `internal/database/pebble_store_folder_dups_test.go` — runs a single shared fixture (covering all 5 documented cases: same-title-same-dir grouped, same-title-different-dir not grouped, unique-title not grouped, marked-for-deletion excluded, multi-dir book skipped without suppressing other groups) through both the memdb-delegation path and the Pebble scan-fallback path on the same store instance (toggling `PebbleStore.UseMemDB`), asserting identical groups on both.

Co-Authored-By: Claude <noreply@anthropic.com>