### PR TITLE
perf(dedup): status secondary index over candidates; named both_unmatched ceiling (INIT-2 T4)

### DIFF
--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.6.0
-// last-edited: 2026-07-07
+// version: 2.7.1
+// last-edited: 2026-07-11
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -77,15 +77,17 @@ func init() {
 //	dedup:r:<id16hex>               → candRec JSON      (dedup candidate)
 //	dedup:p:<type>:<aID>:<bID>      → id16hex           (pair uniqueness index)
 //	dedup:e:<type>:<entityID>:<id16hex> → empty         (entity secondary index — both sides)
+//	dedup:s:<status>:<id16hex>      → empty             (status secondary index, INIT-2 T4)
 //	dedup:seq                       → [8]byte LE int64  (auto-increment counter)
 //	dedup:label:<id16hex>           → LabeledExample JSON   (dataset labels)
 const (
-	embVecPfx      = "emb:v:"
-	embCachePfx    = "emb:c:"
-	dedupRecPfx    = "dedup:r:"
-	dedupPairPfx   = "dedup:p:"
-	dedupEntityPfx = "dedup:e:"
-	dedupSeqKey    = "dedup:seq"
+	embVecPfx         = "emb:v:"
+	embCachePfx       = "emb:c:"
+	dedupRecPfx       = "dedup:r:"
+	dedupPairPfx      = "dedup:p:"
+	dedupEntityPfx    = "dedup:e:"
+	dedupStatusIdxPfx = "dedup:s:"
+	dedupSeqKey       = "dedup:seq"
 )
 
 // embRec is the stored value for a vector embedding.
@@ -440,6 +442,14 @@ func dedupEntityKey(entityType, entityID string, id int64) []byte {
 	return []byte(fmt.Sprintf("%s%s:%s:%016x", dedupEntityPfx, entityType, entityID, id))
 }
 
+// dedupStatusIdxKey builds a presence-only secondary-index key for a
+// candidate's status (INIT-2 T4), mirroring dedupEntityKey's %016x id
+// encoding. Prefix-scanning "dedup:s:<status>:" yields every candidate ID
+// with that status in O(k), instead of ListCandidates' full dedup:r: scan.
+func dedupStatusIdxKey(status string, id int64) []byte {
+	return []byte(fmt.Sprintf("%s%s:%016x", dedupStatusIdxPfx, status, id))
+}
+
 // nextID reads and increments the sequential counter. Must be called with s.mu held.
 // The new counter value is written into the supplied batch so counter + record land atomically.
 func (s *EmbeddingStore) nextID(b *pebble.Batch) (int64, error) {
@@ -560,6 +570,10 @@ func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew b
 		if err := b.Set(dedupEntityKey(c.EntityType, c.EntityBID, id), nil, nil); err != nil {
 			return 0, false, err
 		}
+		// Status secondary index (INIT-2 T4) — same batch, no new commit.
+		if err := b.Set(dedupStatusIdxKey(rec.Status, id), nil, nil); err != nil {
+			return 0, false, err
+		}
 		if err := b.Commit(candidateWriteOpts); err != nil { // NoSync — see candidateWriteOpts (#19)
 			return 0, false, err
 		}
@@ -617,6 +631,7 @@ func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew b
 	if c.LLMReason != "" {
 		existing.LLMReason = c.LLMReason
 	}
+	oldStatus := existing.Status
 	existing.Status = c.Status
 	existing.UpdatedAt = now
 
@@ -634,10 +649,93 @@ func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew b
 	if err := b.Set(dedupEntityKey(existing.EntityType, existing.EntityBID, id), nil, nil); err != nil {
 		return 0, false, err
 	}
+	// Status secondary index (INIT-2 T4) — this update branch can change
+	// Status, so drop the old-status row (when it actually changed) and
+	// ensure the current-status row exists. Same batch, no new commit.
+	if oldStatus != "" && oldStatus != existing.Status {
+		if err := b.Delete(dedupStatusIdxKey(oldStatus, id), nil); err != nil {
+			return 0, false, err
+		}
+	}
+	if err := b.Set(dedupStatusIdxKey(existing.Status, id), nil, nil); err != nil {
+		return 0, false, err
+	}
 	if err := b.Commit(candidateWriteOpts); err != nil { // NoSync — see candidateWriteOpts (#19)
 		return 0, false, err
 	}
 	return id, false, nil
+}
+
+// dedupCandidateStatusIndexBuiltFlagKey is stored in Settings when the
+// dedup.build-candidate-status-index backfill op completes (INIT-2 T4). The
+// v1 suffix lets us force a re-run by bumping to v2. Mirrors
+// isbnIndexBuiltFlagKey's naming convention (pebble_store_isbn_index.go).
+//
+// EmbeddingStore reads/writes this directly via the same "setting:" key
+// namespace + JSON Setting{} schema that PebbleStore.GetSetting/SetSetting
+// use (settings.go) — both structs wrap the SAME underlying *pebble.DB
+// (see NewEmbeddingStore), so this is not a second settings mechanism, just
+// a second Go-level accessor for the identical physical rows.
+const dedupCandidateStatusIndexBuiltFlagKey = "dedup_candidate_status_index_v1_done"
+
+// IsCandidateStatusIndexBuilt reports whether the
+// dedup.build-candidate-status-index backfill op has completed. ListCandidates
+// gates its indexed read path on this flag; an unbuilt index falls back to
+// today's full dedup:r: scan (fail-open — no candidate can ever be silently
+// dropped by an incomplete index).
+func (s *EmbeddingStore) IsCandidateStatusIndexBuilt() bool {
+	if err := s.checkClosed(); err != nil {
+		return false
+	}
+	data, closer, err := s.db.Get([]byte("setting:" + dedupCandidateStatusIndexBuiltFlagKey))
+	if err != nil {
+		return false // ErrNotFound or any other error — fail open to the full scan.
+	}
+	defer closer.Close()
+	var setting Setting
+	if err := json.Unmarshal(data, &setting); err != nil {
+		return false
+	}
+	return setting.Value == "true"
+}
+
+// SetCandidateStatusIndexBuilt marks the status-index backfill complete.
+// Called by the dedup.build-candidate-status-index op when its full scan
+// finishes.
+func (s *EmbeddingStore) SetCandidateStatusIndexBuilt() error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	setting := Setting{Key: dedupCandidateStatusIndexBuiltFlagKey, Value: "true", Type: "bool"}
+	data, err := json.Marshal(setting)
+	if err != nil {
+		return fmt.Errorf("marshal candidate status index flag: %w", err)
+	}
+	return s.db.Set([]byte("setting:"+dedupCandidateStatusIndexBuiltFlagKey), data, pebble.Sync)
+}
+
+// WriteCandidateStatusIndexRow writes a single "dedup:s:" presence-only
+// index row for a candidate (INIT-2 T4). Used only by the
+// dedup.build-candidate-status-index backfill op to populate the index for
+// rows that predate the write-path maintenance added to
+// UpsertCandidateNew/UpdateCandidateStatus/DeleteCandidate. Idempotent —
+// re-writing the same (status, id) pair is a harmless no-op set.
+//
+// Uses candidateWriteOpts (NoSync) rather than a shared batch — see its doc
+// comment (PR #1855 / issue #19): the backfill op fans this out over a
+// bounded worker pool (registry.RunItems), and each call here is an
+// independent single-key Pebble write, so there is no shared batch/lock to
+// serialize workers behind a per-row fsync. A blank status is a no-op
+// (a candidate can never legitimately have an empty status — UpsertCandidateNew
+// defaults it to "pending" — so this only guards against corrupt/legacy rows).
+func (s *EmbeddingStore) WriteCandidateStatusIndexRow(id int64, status string) error {
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	if status == "" {
+		return nil
+	}
+	return s.db.Set(dedupStatusIdxKey(status, id), nil, candidateWriteOpts)
 }
 
 // GetCandidateByID retrieves a single candidate by its ID.
@@ -662,10 +760,30 @@ func (s *EmbeddingStore) GetCandidateByID(id int64) (*DedupCandidate, error) {
 
 // ListCandidates returns a paginated list of dedup candidates matching the filter
 // along with the total count of matching rows.
+//
+// Fallback semantics (INIT-2 T4): when the "dedup:s:" status index has not
+// finished building (IsCandidateStatusIndexBuilt() == false) OR the caller
+// did not set a status filter, this is BYTE-FOR-BYTE today's full dedup:r:
+// scan — the flag/filter combination fails open, never closed, so no
+// candidate can ever be silently dropped by an incomplete index. Only when
+// the flag is set AND f.Status != "" does it switch to the indexed path:
+// prefix-scan "dedup:s:<status>:", point-read each dedup:r: record, apply
+// the REMAINING filters in Go, then the same sort + pagination tail. A
+// dangling index row (record missing) is skipped silently, never an error.
 func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, int, error) {
 	if err := s.checkClosed(); err != nil {
 		return nil, 0, err
 	}
+
+	if f.Status != "" && s.IsCandidateStatusIndexBuilt() {
+		all, err := s.listCandidatesByStatusIndex(f)
+		if err != nil {
+			return nil, 0, err
+		}
+		page, total := paginateCandidates(all, f)
+		return page, total, nil
+	}
+
 	prefix := []byte(dedupRecPfx)
 	upper := prefixUpperBound(prefix)
 
@@ -687,23 +805,7 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 			continue
 		}
 		c := candRecToCandidate(id, rec)
-
-		if f.EntityType != "" && c.EntityType != f.EntityType {
-			continue
-		}
-		if f.Status != "" && c.Status != f.Status {
-			continue
-		}
-		if f.Layer != "" && c.Layer != f.Layer {
-			continue
-		}
-		if f.MinSimilarity != nil && (c.Similarity == nil || *c.Similarity < *f.MinSimilarity) {
-			continue
-		}
-		if f.MaxSimilarity != nil && (c.Similarity == nil || *c.Similarity > *f.MaxSimilarity) {
-			continue
-		}
-		if f.Band != "" && c.Band != f.Band {
+		if !matchesCandidateFilter(c, f, true) {
 			continue
 		}
 		all = append(all, c)
@@ -712,7 +814,96 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 		return nil, 0, fmt.Errorf("list candidates scan: %w", err)
 	}
 
-	// Sort by similarity descending (mirrors SQL ORDER BY COALESCE(similarity,0) DESC).
+	page, total := paginateCandidates(all, f)
+	return page, total, nil
+}
+
+// listCandidatesByStatusIndex is the indexed read path: prefix-scan
+// "dedup:s:<f.Status>:" for candidate IDs, point-read each dedup:r: record,
+// and apply every filter EXCEPT Status (already satisfied by the index scan)
+// in Go. A dangling index row (dedup:r: record missing — e.g. a delete that
+// raced the read) is skipped silently rather than treated as an error.
+func (s *EmbeddingStore) listCandidatesByStatusIndex(f CandidateFilter) ([]DedupCandidate, error) {
+	prefix := dedupStatusIdxKey(f.Status, 0)
+	prefix = prefix[:len(prefix)-16] // strip the %016x id suffix, keep "dedup:s:<status>:"
+	upper := prefixUpperBound(prefix)
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, fmt.Errorf("list candidates by status index: %w", err)
+	}
+	defer iter.Close()
+
+	var all []DedupCandidate
+	for iter.First(); iter.Valid(); iter.Next() {
+		idHex := string(iter.Key()[len(prefix):])
+		id, err := strconv.ParseInt(idHex, 16, 64)
+		if err != nil {
+			continue
+		}
+		val, closer, err := s.db.Get(dedupRecKey(id))
+		if err == pebble.ErrNotFound {
+			continue // dangling index row — tolerated, never an error.
+		}
+		if err != nil {
+			return nil, fmt.Errorf("list candidates by status index fetch %d: %w", id, err)
+		}
+		var rec candRec
+		unmarshalErr := json.Unmarshal(val, &rec)
+		closer.Close()
+		if unmarshalErr != nil {
+			continue
+		}
+		c := candRecToCandidate(id, rec)
+		// Status is already guaranteed by the index scan; still re-check so a
+		// stale/dangling row pointing at a record whose status has since
+		// changed (write raced the read) cannot leak into the result.
+		if c.Status != f.Status {
+			continue
+		}
+		if !matchesCandidateFilter(c, f, false) {
+			continue
+		}
+		all = append(all, c)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, fmt.Errorf("list candidates by status index scan: %w", err)
+	}
+	return all, nil
+}
+
+// matchesCandidateFilter applies CandidateFilter's fields to c. When
+// checkStatus is false, the Status field is assumed already satisfied (the
+// indexed read path pre-filtered by status via the prefix scan) and is
+// skipped here.
+func matchesCandidateFilter(c DedupCandidate, f CandidateFilter, checkStatus bool) bool {
+	if f.EntityType != "" && c.EntityType != f.EntityType {
+		return false
+	}
+	if checkStatus && f.Status != "" && c.Status != f.Status {
+		return false
+	}
+	if f.Layer != "" && c.Layer != f.Layer {
+		return false
+	}
+	if f.MinSimilarity != nil && (c.Similarity == nil || *c.Similarity < *f.MinSimilarity) {
+		return false
+	}
+	if f.MaxSimilarity != nil && (c.Similarity == nil || *c.Similarity > *f.MaxSimilarity) {
+		return false
+	}
+	if f.Band != "" && c.Band != f.Band {
+		return false
+	}
+	return true
+}
+
+// paginateCandidates sorts by similarity descending (mirrors SQL ORDER BY
+// COALESCE(similarity,0) DESC) and applies f.Limit/f.Offset, returning the
+// page plus the total matching count. Shared by both the full-scan and
+// indexed ListCandidates read paths so pagination stays byte-for-byte
+// identical between them.
+func paginateCandidates(all []DedupCandidate, f CandidateFilter) ([]DedupCandidate, int) {
 	sort.Slice(all, func(i, j int) bool {
 		si, sj := 0.0, 0.0
 		if all[i].Similarity != nil {
@@ -737,7 +928,7 @@ func (s *EmbeddingStore) ListCandidates(f CandidateFilter) ([]DedupCandidate, in
 	if end > total {
 		end = total
 	}
-	return all[start:end], total, nil
+	return all[start:end], total
 }
 
 // ListCandidatesForEntity returns all dedup candidates that involve the given
@@ -832,11 +1023,54 @@ func (s *EmbeddingStore) BackfillEntityIndex() (int, error) {
 }
 
 // UpdateCandidateStatus updates the status of a single candidate by ID.
+//
+// Unlike updateCandidate (used by UpdateCandidateScore/UpdateCandidateLLM,
+// neither of which touches Status), this maintains the "dedup:s:" status
+// secondary index (INIT-2 T4): the old-status row is deleted and the
+// new-status row is set in the SAME pebble.Batch as the record write, using
+// candidateWriteOpts (NoSync — see PR #1855 / candidateWriteOpts doc). No new
+// lock, no new commit beyond the single write this function already made.
 func (s *EmbeddingStore) UpdateCandidateStatus(id int64, status string) error {
-	return s.updateCandidate(id, func(rec *candRec) {
-		rec.Status = status
-		rec.UpdatedAt = time.Now().UnixNano()
-	})
+	if err := s.checkClosed(); err != nil {
+		return err
+	}
+	val, closer, err := s.db.Get(dedupRecKey(id))
+	if err == pebble.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("update candidate status read %d: %w", id, err)
+	}
+	var rec candRec
+	if err := json.Unmarshal(val, &rec); err != nil {
+		closer.Close()
+		return fmt.Errorf("update candidate status unmarshal %d: %w", id, err)
+	}
+	closer.Close()
+
+	oldStatus := rec.Status
+	rec.Status = status
+	rec.UpdatedAt = time.Now().UnixNano()
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("update candidate status marshal %d: %w", id, err)
+	}
+
+	b := s.db.NewBatch()
+	defer b.Close()
+	if err := b.Set(dedupRecKey(id), data, nil); err != nil {
+		return err
+	}
+	if oldStatus != "" && oldStatus != status {
+		if err := b.Delete(dedupStatusIdxKey(oldStatus, id), nil); err != nil {
+			return err
+		}
+	}
+	if err := b.Set(dedupStatusIdxKey(status, id), nil, nil); err != nil {
+		return err
+	}
+	return b.Commit(candidateWriteOpts) // NoSync — see candidateWriteOpts (#19)
 }
 
 // UpdateCandidateScore persists a new ScoreBreakdown, Band, and
@@ -908,7 +1142,8 @@ func (s *EmbeddingStore) DeleteCandidate(id int64) error {
 	_ = b.Delete(dedupPairKey(rec.EntityType, rec.EntityAID, rec.EntityBID), nil)
 	_ = b.Delete(dedupEntityKey(rec.EntityType, rec.EntityAID, id), nil)
 	_ = b.Delete(dedupEntityKey(rec.EntityType, rec.EntityBID, id), nil)
-	return b.Commit(candidateWriteOpts) // NoSync — see candidateWriteOpts (#19)
+	_ = b.Delete(dedupStatusIdxKey(rec.Status, id), nil) // INIT-2 T4
+	return b.Commit(candidateWriteOpts)                  // NoSync — see candidateWriteOpts (#19)
 }
 
 // MarkCandidatesAsMergedForEntity sets status="merged" on every candidate row

--- a/internal/database/embedding_store_status_index_test.go
+++ b/internal/database/embedding_store_status_index_test.go
@@ -1,0 +1,273 @@
+// file: internal/database/embedding_store_status_index_test.go
+// version: 1.0.0
+// guid: 5a2c7e1f-9d3b-4a6e-8c1d-2f4b6a8e0c3d
+// last-edited: 2026-07-11
+
+package database
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusIndexRows returns every "dedup:s:" key currently stored, for direct
+// assertion on the secondary index contents (bypassing ListCandidates so the
+// maintenance tests can verify the index itself, not just its read path).
+func statusIndexRows(t *testing.T, s *EmbeddingStore) []string {
+	t.Helper()
+	prefix := []byte(dedupStatusIdxPfx)
+	upper := prefixUpperBound(prefix)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var rows []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		rows = append(rows, string(iter.Key()))
+	}
+	require.NoError(t, iter.Error())
+	return rows
+}
+
+// seedStatusIndexFixture writes a small, deterministic set of candidates
+// spanning multiple statuses/layers/similarities, shared by the parity and
+// fallback tests so both exercise the identical dataset.
+func seedStatusIndexFixture(t *testing.T, s *EmbeddingStore) {
+	t.Helper()
+	fixture := []DedupCandidate{
+		{EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Similarity: floatPtr(0.95), Status: "pending"},
+		{EntityType: "book", EntityAID: "b3", EntityBID: "b4", Layer: "embedding", Similarity: floatPtr(0.80), Status: "pending"},
+		{EntityType: "book", EntityAID: "b5", EntityBID: "b6", Layer: "exact", Similarity: floatPtr(0.99), Status: "pending"},
+		{EntityType: "book", EntityAID: "b7", EntityBID: "b8", Layer: "embedding", Similarity: floatPtr(0.70), Status: "merged"},
+		{EntityType: "author", EntityAID: "a1", EntityBID: "a2", Layer: "metadata", Similarity: floatPtr(0.60), Status: "pending"},
+		{EntityType: "book", EntityAID: "b9", EntityBID: "b10", Layer: "embedding", Similarity: floatPtr(0.85), Status: "dismissed"},
+	}
+	for _, c := range fixture {
+		require.NoError(t, s.UpsertCandidate(c))
+	}
+}
+
+// (a) Parity: on the same fixture, the indexed read path (flag set) and the
+// full-scan read path (flag unset) must return identical rows/totals/order
+// for a status-filtered query. This is the anti-over-suppression proof: no
+// row may silently disappear once the index is active.
+func TestCandidateStatusIndex_Parity(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+	seedStatusIndexFixture(t, store)
+
+	filter := CandidateFilter{Status: "pending"}
+
+	// Flag unset — full scan.
+	assert.False(t, store.IsCandidateStatusIndexBuilt())
+	fullScanResults, fullScanTotal, err := store.ListCandidates(filter)
+	require.NoError(t, err)
+
+	// Now flip the flag on (as the backfill op would after a clean run) and
+	// re-run the identical query — the index rows are already present
+	// because every write path (UpsertCandidate here) maintains them inline.
+	require.NoError(t, store.SetCandidateStatusIndexBuilt())
+	require.True(t, store.IsCandidateStatusIndexBuilt())
+	indexedResults, indexedTotal, err := store.ListCandidates(filter)
+	require.NoError(t, err)
+
+	require.Equal(t, fullScanTotal, indexedTotal, "totals must match between full-scan and indexed reads")
+	require.Len(t, indexedResults, len(fullScanResults))
+	for i := range fullScanResults {
+		assert.Equal(t, fullScanResults[i].ID, indexedResults[i].ID, "row order/identity must match at position %d", i)
+		assert.Equal(t, fullScanResults[i].EntityAID, indexedResults[i].EntityAID)
+		assert.Equal(t, fullScanResults[i].EntityBID, indexedResults[i].EntityBID)
+		assert.Equal(t, fullScanResults[i].Status, indexedResults[i].Status)
+	}
+
+	// Sanity: exactly the 4 "pending" rows from the fixture (3 book + 1 author).
+	assert.Equal(t, 4, fullScanTotal)
+}
+
+// (a-continued) Parity must also hold when additional filters (EntityType,
+// Layer, similarity range, Band) are combined with the status filter — the
+// indexed path applies these as a Go-side post-filter after the prefix scan,
+// exactly like the full-scan path does inline.
+func TestCandidateStatusIndex_Parity_WithAdditionalFilters(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+	seedStatusIndexFixture(t, store)
+
+	filter := CandidateFilter{Status: "pending", EntityType: "book", Layer: "embedding"}
+
+	fullScanResults, fullScanTotal, err := store.ListCandidates(filter)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetCandidateStatusIndexBuilt())
+	indexedResults, indexedTotal, err := store.ListCandidates(filter)
+	require.NoError(t, err)
+
+	assert.Equal(t, fullScanTotal, indexedTotal)
+	assert.Equal(t, len(fullScanResults), len(indexedResults))
+	// Expect exactly the 2 pending/book/embedding rows (b1/b2 and b3/b4) —
+	// the exact-layer pending row and the author row must be excluded.
+	assert.Equal(t, 2, indexedTotal)
+	for _, c := range indexedResults {
+		assert.Equal(t, "book", c.EntityType)
+		assert.Equal(t, "embedding", c.Layer)
+		assert.Equal(t, "pending", c.Status)
+	}
+}
+
+// (b) Maintenance: create → status change → delete leaves exactly the
+// expected "dedup:s:" rows at every step.
+func TestCandidateStatusIndex_Maintenance_CreateChangeDelete(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Create.
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2",
+		Layer: "embedding", Similarity: floatPtr(0.9), Status: "pending",
+	}))
+	results, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	id := results[0].ID
+
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 1, "exactly one status-index row after create")
+	assert.Equal(t, string(dedupStatusIdxKey("pending", id)), rows[0])
+
+	// Status change via UpdateCandidateStatus.
+	require.NoError(t, store.UpdateCandidateStatus(id, "merged"))
+	rows = statusIndexRows(t, store)
+	require.Len(t, rows, 1, "old-status row must be replaced, not accumulated")
+	assert.Equal(t, string(dedupStatusIdxKey("merged", id)), rows[0])
+
+	// Status change via UpsertCandidateNew's update branch (existing pair).
+	_, isNew, err := store.UpsertCandidateNew(DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2",
+		Layer: "embedding", Similarity: floatPtr(0.9), Status: "dismissed",
+	})
+	require.NoError(t, err)
+	assert.False(t, isNew, "same pair must update in place, not create a new row")
+	rows = statusIndexRows(t, store)
+	require.Len(t, rows, 1)
+	assert.Equal(t, string(dedupStatusIdxKey("dismissed", id)), rows[0])
+
+	// Delete.
+	require.NoError(t, store.DeleteCandidate(id))
+	rows = statusIndexRows(t, store)
+	assert.Empty(t, rows, "delete must remove the status-index row")
+}
+
+// (b-continued) A second candidate must not disturb the first's index row,
+// and updating one candidate's status must leave unrelated rows untouched.
+func TestCandidateStatusIndex_Maintenance_MultipleCandidatesIsolated(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending",
+	}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b3", EntityBID: "b4", Layer: "embedding", Status: "pending",
+	}))
+
+	results, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 2)
+
+	// Move the first to merged; the second must remain untouched.
+	var firstID int64
+	for _, c := range results {
+		if c.EntityAID == "b1" {
+			firstID = c.ID
+		}
+	}
+	require.NoError(t, store.UpdateCandidateStatus(firstID, "merged"))
+
+	rows = statusIndexRows(t, store)
+	require.Len(t, rows, 2, "total row count unchanged — one moved, one untouched")
+
+	pending, _, err := store.ListCandidates(CandidateFilter{Status: "pending"})
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "b3", pending[0].EntityAID)
+
+	merged, _, err := store.ListCandidates(CandidateFilter{Status: "merged"})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	assert.Equal(t, "b1", merged[0].EntityAID)
+}
+
+// (c) A dangling index row (dedup:s: entry whose dedup:r: record is missing —
+// e.g. a delete that raced the read, or a hand-corrupted store) is skipped
+// silently by the indexed read path, never surfaced as an error.
+func TestCandidateStatusIndex_DanglingRowSkippedSilently(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending",
+	}))
+	results, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Manually inject a dangling index row pointing at a non-existent candidate ID.
+	const danglingID = int64(999999)
+	require.NoError(t, store.db.Set(dedupStatusIdxKey("pending", danglingID), nil, pebble.Sync))
+
+	require.NoError(t, store.SetCandidateStatusIndexBuilt())
+
+	got, total, err := store.ListCandidates(CandidateFilter{Status: "pending"})
+	require.NoError(t, err, "a dangling index row must never surface as an error")
+	require.Len(t, got, 1, "only the real candidate should be returned")
+	assert.Equal(t, 1, total)
+	assert.Equal(t, "b1", got[0].EntityAID)
+}
+
+// (d) Flag-unset fallback: with the built-flag unset, ListCandidates must
+// still honor every CandidateFilter field exactly as it did before the
+// index existed — the fallback path is byte-for-byte the original full scan.
+func TestCandidateStatusIndex_FlagUnsetFallback_HonorsAllFilters(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+	seedStatusIndexFixture(t, store)
+	require.False(t, store.IsCandidateStatusIndexBuilt())
+
+	minSim := 0.75
+	maxSim := 0.90
+	results, total, err := store.ListCandidates(CandidateFilter{
+		Status:        "pending",
+		EntityType:    "book",
+		Layer:         "embedding",
+		MinSimilarity: &minSim,
+		MaxSimilarity: &maxSim,
+	})
+	require.NoError(t, err)
+	// Only b3/b4 (similarity 0.80, pending, book, embedding) satisfies every filter.
+	require.Equal(t, 1, total)
+	require.Len(t, results, 1)
+	assert.Equal(t, "b3", results[0].EntityAID)
+	assert.Equal(t, "b4", results[0].EntityBID)
+}
+
+// The backfill write path (WriteCandidateStatusIndexRow, used by the
+// dedup.build-candidate-status-index op) writes the same key shape as the
+// inline write-path maintenance and is idempotent.
+func TestCandidateStatusIndex_WriteCandidateStatusIndexRow(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	require.NoError(t, store.WriteCandidateStatusIndexRow(42, "pending"))
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 1)
+	assert.Equal(t, string(dedupStatusIdxKey("pending", 42)), rows[0])
+
+	// Idempotent re-write.
+	require.NoError(t, store.WriteCandidateStatusIndexRow(42, "pending"))
+	rows = statusIndexRows(t, store)
+	require.Len(t, rows, 1)
+
+	// Blank status is a no-op guard, not an error.
+	require.NoError(t, store.WriteCandidateStatusIndexRow(43, ""))
+	rows = statusIndexRows(t, store)
+	require.Len(t, rows, 1, "blank status must not write a row")
+}

--- a/internal/plugins/dedup/build_candidate_index.go
+++ b/internal/plugins/dedup/build_candidate_index.go
@@ -1,0 +1,197 @@
+// file: internal/plugins/dedup/build_candidate_index.go
+// version: 1.0.0
+// guid: 87487445-8923-477d-866c-b8153fd7755b
+// last-edited: 2026-07-11
+
+// Package dedup — op dedup.build-candidate-status-index (INIT-2 T4).
+//
+// Backfills the dedup:s: status secondary index for every existing dedup
+// candidate. New candidates (created/updated after the write-path
+// maintenance landed in embedding_store.go's UpsertCandidateNew /
+// UpdateCandidateStatus / DeleteCandidate) already get their index rows
+// maintained inline in the same batch as the record write; this op catches
+// rows written before that change shipped.
+//
+// Once this op completes, ListCandidates flips from the O(N) dedup:r: full
+// scan to the O(k) dedup:s:<status>: indexed read whenever a status filter
+// is set (see embedding_store.go ListCandidates's "Fallback semantics" doc
+// comment). Until it completes, ListCandidates always fails open to the full
+// scan — no candidate can ever be silently dropped by an incomplete index.
+//
+// Idempotent: re-running overwrites the same presence-only keys — safe to
+// re-run any number of times, including after a partial/cancelled run.
+//
+// Usage:
+//
+//	POST /api/v1/operations  {"op":"dedup.build-candidate-status-index"}
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// candidateStatusIndexScanLimit bounds the single ListCandidates call this op
+// uses to load every candidate for the full-table scan. Named (not a bare
+// literal) per the same discipline as handler.go's bothUnmatchedScanLimit:
+// this must stay >= the max candidate population (~387k pending pre-drain,
+// plus every other status combined) or the scan silently truncates and the
+// index would be built incomplete. 2_000_000 is a generous ceiling well
+// above any plausible population — never lower it without checking the
+// current candidate count first.
+const candidateStatusIndexScanLimit = 2_000_000
+
+// buildCandidateStatusIndexDef returns the OperationDef for the
+// dedup.build-candidate-status-index op (INIT-2 T4).
+func (p *Plugin) buildCandidateStatusIndexDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.build-candidate-status-index",
+		Plugin:      "dedup",
+		DisplayName: "Build candidate status secondary index",
+		Description: "Backfills the dedup:s: status secondary index over dedup candidates, " +
+			"enabling ListCandidates to serve status-filtered queries (e.g. the triage default " +
+			"pending) from an O(k) indexed scan instead of the O(N) dedup:r: full-table scan. " +
+			"Idempotent — safe to re-run.",
+		ResumePolicy:    sdk.ResumeRequeue,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "dedup.build-candidate-status-index",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         60 * time.Minute,
+		Capabilities: []sdk.Capability{
+			sdk.CapLibraryRead,
+			sdk.CapLibraryWrite,
+		},
+		Run: p.runBuildCandidateStatusIndex,
+	}
+}
+
+// runBuildCandidateStatusIndex implements dedup.build-candidate-status-index.
+//
+// Algorithm (mirrors lsh_index_build.go's shape — collect once, then fan the
+// per-item writes out over a bounded worker pool per the CLAUDE.md
+// whole-library-concurrency mandate; a plain for-range loop writing one
+// index row per candidate at ~387k rows is exactly the shape that caused the
+// 2026-07-05 single-core `dedup.full-scan` stall):
+//
+//  1. Load every candidate via ListCandidates with no status filter (always
+//     the full dedup:r: scan path — see embedding_store.go's Fallback
+//     semantics doc comment) up to candidateStatusIndexScanLimit.
+//  2. Fan the candidates out over registry.RunItems (Concurrency=runtime.NumCPU()).
+//     Each worker writes one dedup:s: row via WriteCandidateStatusIndexRow — a
+//     single-key Pebble Set using candidateWriteOpts (NoSync), never a shared
+//     batch or lock, so workers never serialize behind an fsync (PR #1855 /
+//     issue #19 lesson — see candidateWriteOpts's doc comment).
+//  3. On successful completion (no cancellation, no run error), set the
+//     dedup_candidate_status_index_v1_done flag so ListCandidates switches to
+//     the indexed read path. A partial/cancelled run leaves the flag unset,
+//     so the fail-open full-scan path stays authoritative until a clean
+//     re-run — re-running is always safe (idempotent presence-only writes).
+func (p *Plugin) runBuildCandidateStatusIndex(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+
+	slog.Info("build-candidate-status-index: starting")
+	loadProg := sdk.NewProgress(reporter, 0)
+	loadProg.Start("Loading dedup candidates…")
+
+	candidates, _, err := p.embeddingStore.ListCandidates(database.CandidateFilter{
+		Limit: candidateStatusIndexScanLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("build-candidate-status-index: list candidates: %w", err)
+	}
+	total := len(candidates)
+	if total == 0 {
+		loadProg.Done("No candidates found — nothing to index")
+		slog.Info("build-candidate-status-index: no candidates, exiting")
+		return nil
+	}
+	slog.Info("build-candidate-status-index: loaded candidates", "total", total)
+
+	prog := sdk.NewProgress(reporter, total)
+	prog.Start(fmt.Sprintf("Indexing candidate status: 0 / %d", total))
+
+	var mu sync.Mutex
+	var written, skipped, errs int
+	const logInterval = 15 * time.Second
+	lastLog := time.Now()
+
+	runErr := registry.RunItems(ctx, reporter, candidates, func(ctx context.Context, c database.DedupCandidate) error {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+		if c.Status == "" {
+			// A candidate can never legitimately have an empty status
+			// (UpsertCandidateNew defaults it to "pending"); this only
+			// guards against corrupt/legacy rows. Skip rather than error —
+			// one bad row must never abort an otherwise-clean backfill.
+			mu.Lock()
+			skipped++
+			mu.Unlock()
+			return nil
+		}
+		if err := p.embeddingStore.WriteCandidateStatusIndexRow(c.ID, c.Status); err != nil {
+			reporter.Logger().Error("build-candidate-status-index: write error",
+				"candidate_id", c.ID, "error", err)
+			mu.Lock()
+			errs++
+			mu.Unlock()
+			return nil // don't abort the whole run for one bad row — idempotent, re-runnable.
+		}
+
+		mu.Lock()
+		written++
+		curWritten, curSkipped, curErrs := written, skipped, errs
+		shouldLog := time.Since(lastLog) >= logInterval
+		if shouldLog {
+			lastLog = time.Now()
+		}
+		mu.Unlock()
+		if shouldLog {
+			slog.Info("build-candidate-status-index: progress",
+				"written", curWritten, "skipped", curSkipped, "errors", curErrs, "total", total)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, t int) string {
+			mu.Lock()
+			curWritten, curSkipped, curErrs := written, skipped, errs
+			mu.Unlock()
+			return fmt.Sprintf("Indexing candidate status: %d/%d (written=%d skipped=%d errors=%d)",
+				i+1, t, curWritten, curSkipped, curErrs)
+		},
+	})
+	if runErr != nil {
+		slog.Info("build-candidate-status-index: stopped", "written", written, "error", runErr)
+		return runErr
+	}
+
+	prog.Finalize("writing completion flag…")
+
+	if flagErr := p.embeddingStore.SetCandidateStatusIndexBuilt(); flagErr != nil {
+		reporter.Logger().Error("build-candidate-status-index: failed to set completion flag", "error", flagErr)
+		// Non-fatal: the index rows are written even if the flag write
+		// fails. ListCandidates simply keeps using the full scan until a
+		// subsequent run successfully sets the flag.
+	}
+
+	summary := fmt.Sprintf(
+		"Candidate status index build complete — %d written, %d skipped (empty status), %d errors (of %d candidates)",
+		written, skipped, errs, total)
+	prog.Done(summary)
+	slog.Info("build-candidate-status-index: complete",
+		"written", written, "skipped", skipped, "errors", errs, "total", total)
+	return nil
+}

--- a/internal/plugins/dedup/build_candidate_index_test.go
+++ b/internal/plugins/dedup/build_candidate_index_test.go
@@ -1,0 +1,144 @@
+// file: internal/plugins/dedup/build_candidate_index_test.go
+// version: 1.0.0
+// guid: 3d8f1c2a-6b4e-4a9d-9c7f-1e5a8b3d6f20
+// last-edited: 2026-07-11
+
+// Tests for the dedup.build-candidate-status-index op (INIT-2 T4).
+//
+// Wires a real EmbeddingStore backed by a temporary PebbleDB (no mock store
+// needed — the op only touches p.embeddingStore) and exercises the op
+// wrapper: it rebuilds dedup:s: rows for candidates whose index entries are
+// missing (simulating pre-index legacy rows), sets the completion flag on a
+// clean run, and is idempotent on re-run.
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildCandidateStatusIndexOp_Metadata asserts the OperationDef shape.
+func TestBuildCandidateStatusIndexOp_Metadata(t *testing.T) {
+	p := &Plugin{}
+	def := p.buildCandidateStatusIndexDef()
+	assert.Equal(t, "dedup.build-candidate-status-index", def.ID)
+	assert.True(t, def.Cancellable)
+}
+
+// TestBuildCandidateStatusIndexOp_RebuildsMissingRowsAndSetsFlag simulates
+// legacy pre-index candidates (dedup:s: rows deleted out from under otherwise
+// normal dedup:r: records — the state a real pre-INIT-2-T4 store would be in)
+// and asserts the op rebuilds every row and sets the completion flag on a
+// clean, uncancelled run.
+func TestBuildCandidateStatusIndexOp_RebuildsMissingRowsAndSetsFlag(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+
+	require.NoError(t, es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending",
+	}))
+	require.NoError(t, es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "b3", EntityBID: "b4", Layer: "embedding", Status: "merged",
+	}))
+	require.NoError(t, es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "author", EntityAID: "a1", EntityBID: "a2", Layer: "metadata", Status: "dismissed",
+	}))
+
+	results, _, err := es.ListCandidates(database.CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	// Simulate legacy rows: wipe every dedup:s: entry the inline write-path
+	// maintenance already wrote, as if these candidates predate INIT-2 T4.
+	wipeStatusIndex(t, es)
+	assert.Empty(t, statusIndexRowsPlugin(t, es), "precondition: index wiped")
+	assert.False(t, es.IsCandidateStatusIndexBuilt())
+
+	p := &Plugin{embeddingStore: es}
+	require.NoError(t, p.runBuildCandidateStatusIndex(context.Background(), nil, &mockReporter{}))
+
+	assert.True(t, es.IsCandidateStatusIndexBuilt(), "flag must be set after a clean run")
+
+	rows := statusIndexRowsPlugin(t, es)
+	require.Len(t, rows, 3, "one status-index row rebuilt per candidate")
+
+	for _, c := range results {
+		got, _, err := es.ListCandidates(database.CandidateFilter{Status: c.Status})
+		require.NoError(t, err)
+		found := false
+		for _, g := range got {
+			if g.ID == c.ID {
+				found = true
+			}
+		}
+		assert.True(t, found, "candidate %d (status=%s) must be findable via the now-built index", c.ID, c.Status)
+	}
+}
+
+// TestBuildCandidateStatusIndexOp_IdempotentReRun asserts a second run over
+// an already-indexed store neither duplicates rows nor errors.
+func TestBuildCandidateStatusIndexOp_IdempotentReRun(t *testing.T) {
+	es := newTestEmbeddingStorePurge(t)
+	require.NoError(t, es.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending",
+	}))
+
+	p := &Plugin{embeddingStore: es}
+	require.NoError(t, p.runBuildCandidateStatusIndex(context.Background(), nil, &mockReporter{}))
+	first := statusIndexRowsPlugin(t, es)
+	require.Len(t, first, 1)
+
+	require.NoError(t, p.runBuildCandidateStatusIndex(context.Background(), nil, &mockReporter{}))
+	second := statusIndexRowsPlugin(t, es)
+	assert.Equal(t, first, second, "re-running must not duplicate or otherwise change index rows")
+	assert.True(t, es.IsCandidateStatusIndexBuilt())
+}
+
+// TestBuildCandidateStatusIndexOp_NoEmbeddingStore asserts the op fails fast
+// with a clear error rather than a nil-pointer panic when wired without an
+// embedding store.
+func TestBuildCandidateStatusIndexOp_NoEmbeddingStore(t *testing.T) {
+	p := &Plugin{}
+	err := p.runBuildCandidateStatusIndex(context.Background(), nil, &mockReporter{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedding store not available")
+}
+
+// wipeStatusIndex deletes every "dedup:s:" row directly, bypassing the
+// write-path maintenance, to simulate a pre-INIT-2-T4 store for the op test.
+func wipeStatusIndex(t *testing.T, es *database.EmbeddingStore) {
+	t.Helper()
+	db := es.PebbleDB()
+	require.NotNil(t, db)
+	for _, key := range statusIndexRowsPlugin(t, es) {
+		require.NoError(t, db.Delete([]byte(key), pebble.Sync))
+	}
+}
+
+// statusIndexRowsPlugin returns every "dedup:s:" key currently stored, for
+// direct assertion from the plugin package (which cannot see the database
+// package's unexported dedupStatusIdxPfx constant, so it hardcodes the same
+// literal the embedding_store.go key-space doc comment documents).
+func statusIndexRowsPlugin(t *testing.T, es *database.EmbeddingStore) []string {
+	t.Helper()
+	db := es.PebbleDB()
+	require.NotNil(t, db)
+	prefix := []byte("dedup:s:")
+	upper := append([]byte{}, prefix...)
+	upper[len(upper)-1]++
+	iter, err := db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var rows []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		rows = append(rows, string(iter.Key()))
+	}
+	require.NoError(t, iter.Error())
+	return rows
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-07-08
+// last-edited: 2026-07-11
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -79,6 +79,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.autoResolveDef(),                   // TASK-17: Tier-1 CERTAIN auto-merge (dry-run default, kill-switch gated)
 		p.cleanupOrphanEmbeddingsDef(),       // retroactive counterpart to #1802: deletes emb:v:book:* rows whose book is gone
 		p.cleanupOrphanAuthorEmbeddingsDef(), // author-side counterpart: deletes emb:v:author:* rows orphaned by a merge/delete (#1866 follow-up)
+		p.buildCandidateStatusIndexDef(),     // INIT-2 T4: dedup:s: status secondary index backfill over dedup candidates
 	}
 
 	for _, op := range ops {

--- a/internal/server/handlers/dedup/handler.go
+++ b/internal/server/handlers/dedup/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/handler.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: d1b9e024-d28c-4d62-8f90-96d7064559c4
-// last-edited: 2026-07-02
+// last-edited: 2026-07-11
 
 // Package deduphandler hosts the dedup-domain HTTP handlers extracted from the
 // server package: dedup candidate / cluster / series listing, merge / dismiss /
@@ -44,6 +44,16 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/gin-gonic/gin"
 )
+
+// bothUnmatchedScanLimit is the ceiling ≥ the max candidate population;
+// ListCandidates treats limit <= 0 as 50, so this must never be removed or
+// set below the population — see spec §C4. The both_unmatched triage view
+// filters on the Book side (which book has matched metadata), a signal the
+// store cannot pre-filter on, so the handler must fetch the whole
+// status/layer-filtered candidate set and filter + paginate in-handler
+// (see the both_unmatched handling below); 1_000_000 comfortably exceeds
+// the ~387k pending pre-drain candidate population.
+const bothUnmatchedScanLimit = 1_000_000
 
 // Handler hosts the dedup-domain HTTP endpoints.
 type Handler struct {
@@ -172,7 +182,7 @@ func (h *Handler) ListDedupCandidates(c *gin.Context) {
 	if bothUnmatched {
 		// Fetch everything matching the base filter; the store scans the whole
 		// candidate table regardless, so this only widens the returned slice.
-		filter.Limit = 1_000_000
+		filter.Limit = bothUnmatchedScanLimit
 		filter.Offset = 0
 	} else {
 		filter.Limit = limit


### PR DESCRIPTION
dedup:s: presence rows maintained in the same NoSync batches as dedup:r:
records (PR #1855 lesson: no new fsync, no lock across commit); ListCandidates
uses the index when the built-flag is set, fail-open to the full scan
otherwise. New idempotent backfill op dedup.build-candidate-status-index
mirrors the isbn-index flag pattern, fans writes out over a bounded
registry.RunItems worker pool per the CLAUDE.md whole-library-concurrency
mandate, and is registered in plugin.go's ops slice. both_unmatched's
1_000_000 ceiling kept unconditionally, renamed to bothUnmatchedScanLimit
(limit<=0 means 50 in ListCandidates — never delete it).

Co-Authored-By: Claude <noreply@anthropic.com>
