### PR TITLE
feat(config): extract metadata scoring literals into MetadataScoringConfig (INIT-3-T1)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.65.0
+// version: 1.66.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package config
 
@@ -224,6 +224,70 @@ type MetadataScoringConfig struct {
 	LLMRerankEpsilon   float64 `json:"llm_rerank_epsilon"   mapstructure:"llm_rerank_epsilon"`
 	LLMRerankTopK      int     `json:"llm_rerank_top_k"     mapstructure:"llm_rerank_top_k"`
 	WriteBackupBefore  bool    `json:"write_backup_before"  mapstructure:"write_backup_before"`
+
+	// --- new: transcription boosts (defaults 2.0 / 1.4 / 1.6 / 1.4) ---
+	TranscriptionTitleExactBoost  float64 `json:"transcription_title_exact_boost"  mapstructure:"transcription_title_exact_boost"`
+	TranscriptionTitleSubstrBoost float64 `json:"transcription_title_substr_boost" mapstructure:"transcription_title_substr_boost"`
+	TranscriptionAuthorBoost      float64 `json:"transcription_author_boost"       mapstructure:"transcription_author_boost"`
+	TranscriptionNarratorBoost    float64 `json:"transcription_narrator_boost"     mapstructure:"transcription_narrator_boost"`
+
+	// --- new: base-score adjustments (defaults 0.15 / 0.05 / 0.15 / 0.35).
+	// POINTER knobs: 0 is a legitimate operator value for CompilationPenalty,
+	// RichMetadataBonusCap, and F1MinScore, so "unset" is nil, NOT 0. ---
+	CompilationPenalty     *float64 `json:"compilation_penalty"       mapstructure:"compilation_penalty"`
+	RichMetadataFieldBonus float64  `json:"rich_metadata_field_bonus" mapstructure:"rich_metadata_field_bonus"`
+	RichMetadataBonusCap   *float64 `json:"rich_metadata_bonus_cap"   mapstructure:"rich_metadata_bonus_cap"`
+	F1MinScore             *float64 `json:"f1_min_score"              mapstructure:"f1_min_score"`
+
+	// --- new: series boosts (defaults 1.4 / 2.0 / 0.5) ---
+	SeriesNameMatchBoost     float64 `json:"series_name_match_boost"     mapstructure:"series_name_match_boost"`
+	SeriesNumberExactBoost   float64 `json:"series_number_exact_boost"   mapstructure:"series_number_exact_boost"`
+	SeriesNumberWrongPenalty float64 `json:"series_number_wrong_penalty" mapstructure:"series_number_wrong_penalty"`
+
+	// --- new: duration tier VALUES (defaults = the multiplier/score columns of
+	// the durationTiers table in internal/metafetch/service_scoring.go). Tier
+	// STRUCTURE (edges + count) stays fixed in code. ---
+	DurationTierMultipliers []float64 `json:"duration_tier_multipliers" mapstructure:"duration_tier_multipliers"`
+	DurationTierScores      []float64 `json:"duration_tier_scores"      mapstructure:"duration_tier_scores"`
+
+	// --- new: bulk-fetch concurrency (default 4; consumed by TASK-05) ---
+	BulkFetchWorkers int `json:"bulk_fetch_workers" mapstructure:"bulk_fetch_workers"`
+}
+
+// f64Ptr returns a pointer to v. Used to populate the pointer-typed scoring
+// knobs (CompilationPenalty, RichMetadataBonusCap, F1MinScore) from a
+// viper.GetFloat64 result, which can't have its address taken inline.
+func f64Ptr(v float64) *float64 {
+	return &v
+}
+
+// getFloat64Slice reads a []float64 out of viper. Viper has no
+// GetFloat64Slice; SetDefault stores our []float64 default verbatim, but a
+// value loaded from YAML/JSON typically comes back as []any with each
+// element as float64 (or int for whole numbers), so this normalizes both
+// shapes defensively. Any other shape (missing key, wrong type) returns nil
+// — the metafetch-side resolver treats nil/mismatched-length as "unset" and
+// falls back to the built-in duration tier table.
+func getFloat64Slice(key string) []float64 {
+	switch v := viper.Get(key).(type) {
+	case []float64:
+		return v
+	case []any:
+		out := make([]float64, 0, len(v))
+		for _, item := range v {
+			switch n := item.(type) {
+			case float64:
+				out = append(out, n)
+			case int:
+				out = append(out, float64(n))
+			default:
+				return nil
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // AIBackend mode constants. They control, independently for embeddings and
@@ -846,6 +910,23 @@ func InitConfig() {
 	viper.SetDefault("metadata_scoring.llm_rerank_epsilon", 0.05)
 	viper.SetDefault("metadata_scoring.llm_rerank_top_k", 5)
 	viper.SetDefault("metadata_scoring.write_backup_before", true)
+	// Scoring literals extracted into config (INIT-3-T1) — defaults equal
+	// today's hardcoded literals so behavior is bit-identical until an
+	// operator tunes a knob. See MetadataScoringConfig for field docs.
+	viper.SetDefault("metadata_scoring.transcription_title_exact_boost", 2.0)
+	viper.SetDefault("metadata_scoring.transcription_title_substr_boost", 1.4)
+	viper.SetDefault("metadata_scoring.transcription_author_boost", 1.6)
+	viper.SetDefault("metadata_scoring.transcription_narrator_boost", 1.4)
+	viper.SetDefault("metadata_scoring.compilation_penalty", 0.15)
+	viper.SetDefault("metadata_scoring.rich_metadata_field_bonus", 0.05)
+	viper.SetDefault("metadata_scoring.rich_metadata_bonus_cap", 0.15)
+	viper.SetDefault("metadata_scoring.f1_min_score", 0.35)
+	viper.SetDefault("metadata_scoring.series_name_match_boost", 1.4)
+	viper.SetDefault("metadata_scoring.series_number_exact_boost", 2.0)
+	viper.SetDefault("metadata_scoring.series_number_wrong_penalty", 0.5)
+	viper.SetDefault("metadata_scoring.duration_tier_multipliers", []float64{1.30, 1.20, 1.10, 1.00, 0.75, 0.50})
+	viper.SetDefault("metadata_scoring.duration_tier_scores", []float64{20, 15, 10, 0, -10, -20})
+	viper.SetDefault("metadata_scoring.bulk_fetch_workers", 4)
 
 	// AI backend-mode toggle. Modes default empty (resolved from legacy fields
 	// by EffectiveEmbeddingMode / EffectiveLLMMode). LocalBaseURL uses a
@@ -868,6 +949,18 @@ func InitConfig() {
 	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")     //nolint:errcheck
 	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")         //nolint:errcheck
 	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE")   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.transcription_title_exact_boost", "METADATA_SCORING_TRANSCRIPTION_TITLE_EXACT_BOOST")   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.transcription_title_substr_boost", "METADATA_SCORING_TRANSCRIPTION_TITLE_SUBSTR_BOOST") //nolint:errcheck
+	viper.BindEnv("metadata_scoring.transcription_author_boost", "METADATA_SCORING_TRANSCRIPTION_AUTHOR_BOOST")             //nolint:errcheck
+	viper.BindEnv("metadata_scoring.transcription_narrator_boost", "METADATA_SCORING_TRANSCRIPTION_NARRATOR_BOOST")         //nolint:errcheck
+	viper.BindEnv("metadata_scoring.compilation_penalty", "METADATA_SCORING_COMPILATION_PENALTY")                           //nolint:errcheck
+	viper.BindEnv("metadata_scoring.rich_metadata_field_bonus", "METADATA_SCORING_RICH_METADATA_FIELD_BONUS")               //nolint:errcheck
+	viper.BindEnv("metadata_scoring.rich_metadata_bonus_cap", "METADATA_SCORING_RICH_METADATA_BONUS_CAP")                   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.f1_min_score", "METADATA_SCORING_F1_MIN_SCORE")                                         //nolint:errcheck
+	viper.BindEnv("metadata_scoring.series_name_match_boost", "METADATA_SCORING_SERIES_NAME_MATCH_BOOST")                   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.series_number_exact_boost", "METADATA_SCORING_SERIES_NUMBER_EXACT_BOOST")               //nolint:errcheck
+	viper.BindEnv("metadata_scoring.series_number_wrong_penalty", "METADATA_SCORING_SERIES_NUMBER_WRONG_PENALTY")           //nolint:errcheck
+	viper.BindEnv("metadata_scoring.bulk_fetch_workers", "METADATA_SCORING_BULK_FETCH_WORKERS")                             //nolint:errcheck
 
 	// Unified dedup scoring defaults (SPEC 1 §3–4, T011).
 	// These are consumed by internal/dedup/unified.LoadScoreConfig via Viper.
@@ -1099,6 +1192,25 @@ func InitConfig() {
 				LLMRerankEpsilon:   viper.GetFloat64("metadata_scoring.llm_rerank_epsilon"),
 				LLMRerankTopK:      viper.GetInt("metadata_scoring.llm_rerank_top_k"),
 				WriteBackupBefore:  viper.GetBool("metadata_scoring.write_backup_before"),
+
+				TranscriptionTitleExactBoost:  viper.GetFloat64("metadata_scoring.transcription_title_exact_boost"),
+				TranscriptionTitleSubstrBoost: viper.GetFloat64("metadata_scoring.transcription_title_substr_boost"),
+				TranscriptionAuthorBoost:      viper.GetFloat64("metadata_scoring.transcription_author_boost"),
+				TranscriptionNarratorBoost:    viper.GetFloat64("metadata_scoring.transcription_narrator_boost"),
+
+				CompilationPenalty:     f64Ptr(viper.GetFloat64("metadata_scoring.compilation_penalty")),
+				RichMetadataFieldBonus: viper.GetFloat64("metadata_scoring.rich_metadata_field_bonus"),
+				RichMetadataBonusCap:   f64Ptr(viper.GetFloat64("metadata_scoring.rich_metadata_bonus_cap")),
+				F1MinScore:             f64Ptr(viper.GetFloat64("metadata_scoring.f1_min_score")),
+
+				SeriesNameMatchBoost:     viper.GetFloat64("metadata_scoring.series_name_match_boost"),
+				SeriesNumberExactBoost:   viper.GetFloat64("metadata_scoring.series_number_exact_boost"),
+				SeriesNumberWrongPenalty: viper.GetFloat64("metadata_scoring.series_number_wrong_penalty"),
+
+				DurationTierMultipliers: getFloat64Slice("metadata_scoring.duration_tier_multipliers"),
+				DurationTierScores:      getFloat64Slice("metadata_scoring.duration_tier_scores"),
+
+				BulkFetchWorkers: viper.GetInt("metadata_scoring.bulk_fetch_workers"),
 			},
 
 			// AI backend-mode toggle (nested sub-struct). Modes default empty
@@ -1524,6 +1636,25 @@ func ResetToDefaults() {
 				LLMRerankEpsilon:   0.05,
 				LLMRerankTopK:      5,
 				WriteBackupBefore:  true,
+
+				TranscriptionTitleExactBoost:  2.0,
+				TranscriptionTitleSubstrBoost: 1.4,
+				TranscriptionAuthorBoost:      1.6,
+				TranscriptionNarratorBoost:    1.4,
+
+				CompilationPenalty:     f64Ptr(0.15),
+				RichMetadataFieldBonus: 0.05,
+				RichMetadataBonusCap:   f64Ptr(0.15),
+				F1MinScore:             f64Ptr(0.35),
+
+				SeriesNameMatchBoost:     1.4,
+				SeriesNumberExactBoost:   2.0,
+				SeriesNumberWrongPenalty: 0.5,
+
+				DurationTierMultipliers: []float64{1.30, 1.20, 1.10, 1.00, 0.75, 0.50},
+				DurationTierScores:      []float64{20, 15, 10, 0, -10, -20},
+
+				BulkFetchWorkers: 4,
 			},
 
 			// AI backend-mode toggle. Modes empty at rest (derived from legacy

--- a/internal/metafetch/service_scoring.go
+++ b/internal/metafetch/service_scoring.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: d2226468-bed1-4989-93f3-b0bc3a344424
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package metafetch
 
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // isGarbageValue returns true if a string value is effectively useless metadata.
@@ -112,11 +113,12 @@ func computeF1Base(r metadata.BookMetadata, searchWords map[string]bool) float64
 // ApplyNonBaseAdjustments applies bonuses/penalties to a base similarity score
 // based on metadata heuristics (series, narrator, language, etc.).
 func ApplyNonBaseAdjustments(baseScore float64, r metadata.BookMetadata, baseWordCount int) float64 {
+	k := scoringKnobs()
 	score := baseScore
 
 	// Compilation penalty
 	if isCompilation(r.Title) {
-		score *= 0.15
+		score *= k.CompilationPenalty
 	}
 
 	// Length penalty: penalise results that are much longer than the search.
@@ -130,22 +132,22 @@ func ApplyNonBaseAdjustments(baseScore float64, r metadata.BookMetadata, baseWor
 		}
 	}
 
-	// Rich-metadata bonus (capped at +0.15, additive)
+	// Rich-metadata bonus (capped at +RichMetadataBonusCap, additive)
 	bonus := 0.0
 	if r.Description != "" {
-		bonus += 0.05
+		bonus += k.RichMetadataFieldBonus
 	}
 	if r.CoverURL != "" {
-		bonus += 0.05
+		bonus += k.RichMetadataFieldBonus
 	}
 	if r.Narrator != "" {
-		bonus += 0.05
+		bonus += k.RichMetadataFieldBonus
 	}
 	if r.ISBN != "" {
-		bonus += 0.05
+		bonus += k.RichMetadataFieldBonus
 	}
-	if bonus > 0.15 {
-		bonus = 0.15
+	if bonus > k.RichMetadataBonusCap {
+		bonus = k.RichMetadataBonusCap
 	}
 
 	return score + bonus
@@ -190,22 +192,174 @@ var durationTiers = []struct {
 
 // durationTier looks up the canonical (multiplier, score) pair for a
 // duration-match ratio. See durationTiers for the boundary-inclusivity
-// contract this switch implements.
+// contract this switch implements. The tier EDGES (MaxRatio, from
+// durationTiers) stay fixed in code; the Multiplier/Score VALUES are
+// resolved through scoringKnobs so an operator can retune them (INIT-3-T1)
+// without touching the boundary structure.
 func durationTier(ratio float64) (multiplier, score float64) {
+	k := scoringKnobs()
 	switch {
 	case ratio < durationTiers[0].MaxRatio:
-		return durationTiers[0].Multiplier, durationTiers[0].Score
+		return k.DurationTierMultipliers[0], k.DurationTierScores[0]
 	case ratio < durationTiers[1].MaxRatio:
-		return durationTiers[1].Multiplier, durationTiers[1].Score
+		return k.DurationTierMultipliers[1], k.DurationTierScores[1]
 	case ratio < durationTiers[2].MaxRatio:
-		return durationTiers[2].Multiplier, durationTiers[2].Score
+		return k.DurationTierMultipliers[2], k.DurationTierScores[2]
 	case ratio <= durationTiers[3].MaxRatio:
-		return durationTiers[3].Multiplier, durationTiers[3].Score
+		return k.DurationTierMultipliers[3], k.DurationTierScores[3]
 	case ratio <= durationTiers[4].MaxRatio:
-		return durationTiers[4].Multiplier, durationTiers[4].Score
+		return k.DurationTierMultipliers[4], k.DurationTierScores[4]
 	default:
-		return durationTiers[5].Multiplier, durationTiers[5].Score
+		return k.DurationTierMultipliers[5], k.DurationTierScores[5]
 	}
+}
+
+// resolvedScoringKnobs holds the metadata-scoring literals extracted into
+// config (INIT-3-T1), resolved from config.AppConfig.MetadataScoring with
+// legacy-literal fallback. Every field here corresponds 1:1 to a hardcoded
+// literal that existed before this task; see scoringKnobs for the per-knob
+// fail-open semantics.
+type resolvedScoringKnobs struct {
+	TranscriptionTitleExactBoost  float64
+	TranscriptionTitleSubstrBoost float64
+	TranscriptionAuthorBoost      float64
+	TranscriptionNarratorBoost    float64
+
+	CompilationPenalty     float64
+	RichMetadataFieldBonus float64
+	RichMetadataBonusCap   float64
+	F1MinScore             float64
+
+	SeriesNameMatchBoost     float64
+	SeriesNumberExactBoost   float64
+	SeriesNumberWrongPenalty float64
+
+	// DurationTierMultipliers/DurationTierScores are the Multiplier/Score
+	// columns durationTier looks up by tier index; always the same length as
+	// the built-in durationTiers table (a mismatched-length config falls
+	// back to the built-in columns — see resolveDurationTierValues).
+	DurationTierMultipliers []float64
+	DurationTierScores      []float64
+}
+
+// defaultDurationTierMultipliers/defaultDurationTierScores are the
+// Multiplier/Score columns of durationTiers, precomputed once so the
+// duration-tier fail-open path (resolveDurationTierValues) never allocates
+// on the common case of "operator hasn't overridden this knob".
+var defaultDurationTierMultipliers, defaultDurationTierScores = func() ([]float64, []float64) {
+	multipliers := make([]float64, len(durationTiers))
+	scores := make([]float64, len(durationTiers))
+	for i, t := range durationTiers {
+		multipliers[i] = t.Multiplier
+		scores[i] = t.Score
+	}
+	return multipliers, scores
+}()
+
+// durationTierMismatchWarnOnce ensures a misconfigured (non-empty but wrong
+// length) duration-tier override is logged once, not once per scored
+// candidate.
+var durationTierMismatchWarnOnce sync.Once
+
+// scoringKnobs resolves every extracted scoring literal (INIT-3-T1) from
+// config.AppConfig.MetadataScoring, with defaults exactly equal to the
+// pre-extraction hardcoded literals — so a zero-value MetadataScoringConfig
+// (e.g. a test that never calls config.InitConfig) reproduces today's scores
+// bit-for-bit.
+//
+// Per-knob fail-open semantics (spec C2, normative — a blanket
+// zero-as-unset rule would make 0 unreachable for knobs where 0 is a
+// legitimate operator value):
+//
+//   - Multiplicative boosts (the four transcription boosts, the three
+//     series boosts, RichMetadataFieldBonus) are plain float64 in the
+//     config struct: a zero/missing value falls back to the legacy
+//     literal — NEVER "multiply by zero", since 0 would silently zero out
+//     every score on that path.
+//   - F1MinScore / CompilationPenalty / RichMetadataBonusCap are *float64
+//     in the config struct: nil (unset) falls back to the legacy literal,
+//     but an EXPLICIT 0 is honored — 0 is a real operator value (e.g.
+//     F1MinScore=0 disables the reject floor; CompilationPenalty=0
+//     disables the compilation penalty entirely).
+//   - Duration tier value arrays: config must supply BOTH arrays at the
+//     same length as the built-in durationTiers table, or the whole
+//     built-in table is used (fail-open); a non-empty-but-mismatched-length
+//     override is logged once so a misconfiguration stays visible without
+//     spamming logs per candidate.
+func scoringKnobs() resolvedScoringKnobs {
+	cfg := config.AppConfig.MetadataScoring
+
+	k := resolvedScoringKnobs{
+		TranscriptionTitleExactBoost:  cfg.TranscriptionTitleExactBoost,
+		TranscriptionTitleSubstrBoost: cfg.TranscriptionTitleSubstrBoost,
+		TranscriptionAuthorBoost:      cfg.TranscriptionAuthorBoost,
+		TranscriptionNarratorBoost:    cfg.TranscriptionNarratorBoost,
+		RichMetadataFieldBonus:        cfg.RichMetadataFieldBonus,
+		SeriesNameMatchBoost:          cfg.SeriesNameMatchBoost,
+		SeriesNumberExactBoost:        cfg.SeriesNumberExactBoost,
+		SeriesNumberWrongPenalty:      cfg.SeriesNumberWrongPenalty,
+	}
+	if k.TranscriptionTitleExactBoost == 0 {
+		k.TranscriptionTitleExactBoost = 2.0
+	}
+	if k.TranscriptionTitleSubstrBoost == 0 {
+		k.TranscriptionTitleSubstrBoost = 1.4
+	}
+	if k.TranscriptionAuthorBoost == 0 {
+		k.TranscriptionAuthorBoost = 1.6
+	}
+	if k.TranscriptionNarratorBoost == 0 {
+		k.TranscriptionNarratorBoost = 1.4
+	}
+	if k.RichMetadataFieldBonus == 0 {
+		k.RichMetadataFieldBonus = 0.05
+	}
+	if k.SeriesNameMatchBoost == 0 {
+		k.SeriesNameMatchBoost = 1.4
+	}
+	if k.SeriesNumberExactBoost == 0 {
+		k.SeriesNumberExactBoost = 2.0
+	}
+	if k.SeriesNumberWrongPenalty == 0 {
+		k.SeriesNumberWrongPenalty = 0.5
+	}
+
+	if cfg.CompilationPenalty != nil {
+		k.CompilationPenalty = *cfg.CompilationPenalty
+	} else {
+		k.CompilationPenalty = 0.15
+	}
+	if cfg.RichMetadataBonusCap != nil {
+		k.RichMetadataBonusCap = *cfg.RichMetadataBonusCap
+	} else {
+		k.RichMetadataBonusCap = 0.15
+	}
+	if cfg.F1MinScore != nil {
+		k.F1MinScore = *cfg.F1MinScore
+	} else {
+		k.F1MinScore = 0.35
+	}
+
+	k.DurationTierMultipliers, k.DurationTierScores = resolveDurationTierValues(cfg.DurationTierMultipliers, cfg.DurationTierScores)
+
+	return k
+}
+
+// resolveDurationTierValues applies the duration-tier fail-open rule
+// documented on scoringKnobs: config must supply both arrays at exactly
+// len(durationTiers), or the built-in Multiplier/Score columns are used
+// unmodified.
+func resolveDurationTierValues(multipliers, scores []float64) ([]float64, []float64) {
+	if len(multipliers) == len(durationTiers) && len(scores) == len(durationTiers) {
+		return multipliers, scores
+	}
+	if len(multipliers) != 0 || len(scores) != 0 {
+		durationTierMismatchWarnOnce.Do(func() {
+			slog.Warn("metadata-scoring duration tier config length mismatch, falling back to built-in table",
+				"wantLen", len(durationTiers), "gotMultipliers", len(multipliers), "gotScores", len(scores))
+		})
+	}
+	return defaultDurationTierMultipliers, defaultDurationTierScores
 }
 
 // durationDeltaRatio computes the symmetric duration-match ratio shared by
@@ -325,6 +479,7 @@ func containsCI(a, b string) bool {
 // is read aloud verbatim in the intro.
 // Returns (adjusted score, true) when any boost was applied; (score, false) otherwise.
 func transcriptionBoost(score float64, r metadata.BookMetadata, th transcriptionHints) (float64, bool) {
+	k := scoringKnobs()
 	// The transcribed TITLE is the anchor — it is read aloud verbatim in the
 	// intro. The author/narrator boosts only apply when the title ALSO agrees;
 	// otherwise a same-author, wrong-title candidate gets multiplied to the top
@@ -335,10 +490,10 @@ func transcriptionBoost(score float64, r metadata.BookMetadata, th transcription
 	titleMatched := false
 	if titleHintPresent && r.Title != "" {
 		if util.NormalizeTitle(r.Title) == util.NormalizeTitle(th.title) {
-			score *= 2.0
+			score *= k.TranscriptionTitleExactBoost
 			titleMatched = true
 		} else if containsCI(r.Title, th.title) {
-			score *= 1.4
+			score *= k.TranscriptionTitleSubstrBoost
 			titleMatched = true
 		}
 	}
@@ -353,11 +508,11 @@ func transcriptionBoost(score float64, r metadata.BookMetadata, th transcription
 	}
 	boosted := titleMatched
 	if th.author != "" && containsCI(r.Author, th.author) {
-		score *= 1.6
+		score *= k.TranscriptionAuthorBoost
 		boosted = true
 	}
 	if th.narrator != "" && containsCI(r.Narrator, th.narrator) {
-		score *= 1.4
+		score *= k.TranscriptionNarratorBoost
 		boosted = true
 	}
 	return score, boosted
@@ -387,7 +542,7 @@ func pickBestMatchFromScored(
 	bookDurationSec int,
 	hints ...transcriptionHints,
 ) []metadata.BookMetadata {
-	const f1MinScore = 0.35
+	f1MinScore := scoringKnobs().F1MinScore
 
 	var th transcriptionHints
 	if len(hints) > 0 {

--- a/internal/metafetch/service_scoring_test.go
+++ b/internal/metafetch/service_scoring_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_scoring_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7e3f6a1c-9b4d-4e2a-8c1f-6d5b3a2e9f70
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package metafetch
 
@@ -341,4 +341,185 @@ func TestDurationScoringGolden(t *testing.T) {
 			assert.InDelta(t, c.wantScore, gotScore, 1e-9, "computeDurationScore(%d, %d)", c.book, c.cand)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// INIT-3-T1 — MetadataScoringConfig extraction equivalence proof.
+//
+// These tests prove the gate's zero-behavior-change requirement
+// mechanically: scoringKnobs() must resolve every extracted literal to
+// today's hardcoded value whenever config.AppConfig.MetadataScoring is a
+// zero-value struct (no operator tuning, or a context — like most of this
+// package's tests — that never called config.InitConfig), and must honor an
+// EXPLICIT zero on the three pointer knobs where zero is a legitimate
+// operator value.
+// ---------------------------------------------------------------------------
+
+// withMetadataScoringConfig sets config.AppConfig.MetadataScoring for the
+// duration of the test and restores the prior value on cleanup, so these
+// knob mutations can never leak into another test sharing the same
+// config.AppConfig global.
+func withMetadataScoringConfig(t *testing.T, cfg config.MetadataScoringConfig) {
+	t.Helper()
+	prev := config.AppConfig.MetadataScoring
+	config.AppConfig.MetadataScoring = cfg
+	t.Cleanup(func() {
+		config.AppConfig.MetadataScoring = prev
+	})
+}
+
+// TestScoringConfigDefaultsMatchLegacyLiterals is the acceptance-criteria
+// gate test: a zero-value MetadataScoringConfig must reproduce every
+// pre-extraction literal exactly, across transcriptionBoost,
+// ApplyNonBaseAdjustments, and the duration-tier/series knobs.
+func TestScoringConfigDefaultsMatchLegacyLiterals(t *testing.T) {
+	withMetadataScoringConfig(t, config.MetadataScoringConfig{})
+
+	t.Run("transcriptionBoost", func(t *testing.T) {
+		const base = 1.0
+		cand := metadata.BookMetadata{Title: "The Way of Kings", Author: "Brandon Sanderson", Narrator: "Michael Kramer"}
+
+		gotExact, boosted := transcriptionBoost(base, cand, transcriptionHints{title: "The Way of Kings"})
+		require.True(t, boosted)
+		assert.InDelta(t, base*2.0, gotExact, 1e-9, "legacy exact-title boost was score *= 2.0")
+
+		gotSubstr, boosted := transcriptionBoost(base, metadata.BookMetadata{Title: "The Way of Kings (Stormlight 1)"}, transcriptionHints{title: "The Way of Kings"})
+		require.True(t, boosted)
+		assert.InDelta(t, base*1.4, gotSubstr, 1e-9, "legacy substring-title boost was score *= 1.4")
+
+		gotAuthor, boosted := transcriptionBoost(base, cand, transcriptionHints{author: "Brandon Sanderson"})
+		require.True(t, boosted)
+		assert.InDelta(t, base*1.6, gotAuthor, 1e-9, "legacy author boost was score *= 1.6")
+
+		gotNarrator, boosted := transcriptionBoost(base, cand, transcriptionHints{narrator: "Michael Kramer"})
+		require.True(t, boosted)
+		assert.InDelta(t, base*1.4, gotNarrator, 1e-9, "legacy narrator boost was score *= 1.4")
+	})
+
+	t.Run("compilationPenalty", func(t *testing.T) {
+		got := ApplyNonBaseAdjustments(1.0, metadata.BookMetadata{Title: "The Best of Everything: Omnibus"}, 0)
+		assert.InDelta(t, 0.15, got, 1e-9, "legacy compilation penalty was score *= 0.15")
+	})
+
+	t.Run("richMetadataBonusSingleField", func(t *testing.T) {
+		got := ApplyNonBaseAdjustments(0.0, metadata.BookMetadata{Title: "Single Field Book", ISBN: "123"}, 0)
+		assert.InDelta(t, 0.05, got, 1e-9, "legacy rich-metadata bonus per field was +0.05")
+	})
+
+	t.Run("richMetadataBonusCapped", func(t *testing.T) {
+		r := metadata.BookMetadata{
+			Title: "Uncapped Bonus Book", Description: "d", CoverURL: "c", Narrator: "n", ISBN: "i",
+		}
+		// legacy: 4 fields * 0.05 = 0.20, capped at 0.15.
+		got := ApplyNonBaseAdjustments(0.0, r, 0)
+		assert.InDelta(t, 0.15, got, 1e-9, "legacy rich-metadata bonus was capped at 0.15")
+	})
+
+	t.Run("f1MinScore", func(t *testing.T) {
+		assert.InDelta(t, 0.35, scoringKnobs().F1MinScore, 1e-9, "legacy F1 min score was const f1MinScore = 0.35")
+	})
+
+	t.Run("seriesBoosts", func(t *testing.T) {
+		k := scoringKnobs()
+		assert.InDelta(t, 1.4, k.SeriesNameMatchBoost, 1e-9, "legacy series-name boost was score *= 1.4")
+		assert.InDelta(t, 2.0, k.SeriesNumberExactBoost, 1e-9, "legacy series-number exact boost was c.Score *= 2.0")
+		assert.InDelta(t, 0.5, k.SeriesNumberWrongPenalty, 1e-9, "legacy series-number wrong-number penalty was c.Score *= 0.5")
+	})
+
+	t.Run("durationTierDefaults", func(t *testing.T) {
+		k := scoringKnobs()
+		assert.Equal(t, []float64{1.30, 1.20, 1.10, 1.00, 0.75, 0.50}, k.DurationTierMultipliers, "legacy durationTiers Multiplier column")
+		assert.Equal(t, []float64{20, 15, 10, 0, -10, -20}, k.DurationTierScores, "legacy durationTiers Score column")
+	})
+}
+
+// TestScoringConfigZeroMultiplicativeKnobFallsBackToLegacy proves the
+// multiplicative-knob fail-open rule: an explicit (or missing) 0 on a
+// plain-float64 knob is treated as "unset" and falls back to the legacy
+// literal — it must NEVER multiply a score by zero, which would silently
+// zero out every candidate on that scoring path.
+func TestScoringConfigZeroMultiplicativeKnobFallsBackToLegacy(t *testing.T) {
+	withMetadataScoringConfig(t, config.MetadataScoringConfig{
+		TranscriptionTitleExactBoost: 0, // explicit zero, indistinguishable from unset for a plain float64
+	})
+
+	got, boosted := transcriptionBoost(1.0, metadata.BookMetadata{Title: "The Way of Kings"}, transcriptionHints{title: "The Way of Kings"})
+	require.True(t, boosted)
+	assert.InDelta(t, 2.0, got, 1e-9, "a zero/missing multiplicative knob must fall back to the legacy literal, never multiply by zero")
+}
+
+// TestScoringConfigExplicitZeroHonored proves the pointer-knob fail-open
+// rule: nil (unset) falls back to the legacy literal, but an EXPLICIT 0 is
+// honored — 0 is a real operator value for F1MinScore (disables the reject
+// floor), CompilationPenalty (disables the penalty), and RichMetadataBonusCap
+// (suppresses the bonus).
+func TestScoringConfigExplicitZeroHonored(t *testing.T) {
+	zero := 0.0
+
+	t.Run("F1MinScore explicit zero disables the reject floor", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{F1MinScore: &zero})
+		assert.InDelta(t, 0.0, scoringKnobs().F1MinScore, 1e-9)
+	})
+
+	t.Run("F1MinScore nil falls back to legacy default", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{F1MinScore: nil})
+		assert.InDelta(t, 0.35, scoringKnobs().F1MinScore, 1e-9)
+	})
+
+	t.Run("CompilationPenalty explicit zero disables the penalty", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{CompilationPenalty: &zero})
+		got := ApplyNonBaseAdjustments(1.0, metadata.BookMetadata{Title: "Omnibus Collection"}, 0)
+		assert.InDelta(t, 0.0, got, 1e-9, "explicit CompilationPenalty=0 must zero the score for a compilation, not fall back to 0.15")
+	})
+
+	t.Run("CompilationPenalty nil falls back to legacy default", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{CompilationPenalty: nil})
+		got := ApplyNonBaseAdjustments(1.0, metadata.BookMetadata{Title: "Omnibus Collection"}, 0)
+		assert.InDelta(t, 0.15, got, 1e-9)
+	})
+
+	t.Run("RichMetadataBonusCap explicit zero suppresses the bonus", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{RichMetadataBonusCap: &zero})
+		got := ApplyNonBaseAdjustments(0.0, metadata.BookMetadata{Title: "Bonus Book", ISBN: "i"}, 0)
+		assert.InDelta(t, 0.0, got, 1e-9, "explicit RichMetadataBonusCap=0 must suppress the bonus entirely")
+	})
+
+	t.Run("RichMetadataBonusCap nil falls back to legacy default", func(t *testing.T) {
+		withMetadataScoringConfig(t, config.MetadataScoringConfig{RichMetadataBonusCap: nil})
+		got := ApplyNonBaseAdjustments(0.0, metadata.BookMetadata{Title: "Bonus Book", ISBN: "i"}, 0)
+		assert.InDelta(t, 0.05, got, 1e-9)
+	})
+}
+
+// TestScoringConfigDurationTierMismatchedLengthFallsBackToBuiltinTable
+// proves the duration-tier array fail-open rule: config must supply BOTH
+// arrays at exactly len(durationTiers), or the built-in Multiplier/Score
+// columns are used unmodified — a non-empty-but-wrong-length override must
+// never be truncated, padded, or partially applied.
+func TestScoringConfigDurationTierMismatchedLengthFallsBackToBuiltinTable(t *testing.T) {
+	withMetadataScoringConfig(t, config.MetadataScoringConfig{
+		DurationTierMultipliers: []float64{9.9, 9.9, 9.9}, // wrong length: built-in table has 6 tiers
+		DurationTierScores:      []float64{99, 99, 99},
+	})
+
+	k := scoringKnobs()
+	assert.Equal(t, []float64{1.30, 1.20, 1.10, 1.00, 0.75, 0.50}, k.DurationTierMultipliers)
+	assert.Equal(t, []float64{20, 15, 10, 0, -10, -20}, k.DurationTierScores)
+
+	// End-to-end: durationScoreMultiplier/computeDurationScore must also see
+	// the built-in table, not the mismatched override.
+	assert.InDelta(t, 1.30, durationScoreMultiplier(7200, 7200+59), 1e-9)
+	assert.InDelta(t, float64(20), computeDurationScore(7200, 7200+59), 1e-9)
+}
+
+// TestScoringConfigDurationTierMatchedLengthOverrideApplied proves the
+// positive case: a correctly-sized override IS honored end-to-end.
+func TestScoringConfigDurationTierMatchedLengthOverrideApplied(t *testing.T) {
+	withMetadataScoringConfig(t, config.MetadataScoringConfig{
+		DurationTierMultipliers: []float64{5, 4, 3, 2, 1, 0},
+		DurationTierScores:      []float64{50, 40, 30, 20, 10, 0},
+	})
+
+	assert.InDelta(t, 5.0, durationScoreMultiplier(7200, 7200+59), 1e-9)
+	assert.InDelta(t, float64(50), computeDurationScore(7200, 7200+59), 1e-9)
 }

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_search.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 package metafetch
 
@@ -365,7 +365,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				rSeriesLower := strings.ToLower(r.Series)
 				sSeriesLower := strings.ToLower(searchSeries)
 				if strings.Contains(rSeriesLower, sSeriesLower) || strings.Contains(sSeriesLower, rSeriesLower) {
-					score *= 1.4 // Boost for series match
+					score *= scoringKnobs().SeriesNameMatchBoost // Boost for series match
 				}
 			}
 
@@ -497,6 +497,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		originalTitle = book.Title
 	}
 	if expectedNum := extractTrailingNumber(originalTitle); expectedNum != "" {
+		k := scoringKnobs()
 		for i := range candidates {
 			c := &candidates[i]
 			candidateNum := ""
@@ -509,9 +510,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 				candidateNum = extractTrailingNumber(c.Title)
 			}
 			if candidateNum == expectedNum {
-				c.Score *= 2.0 // Strong boost for exact number match
+				c.Score *= k.SeriesNumberExactBoost // Strong boost for exact number match
 			} else if candidateNum != "" && candidateNum != expectedNum {
-				c.Score *= 0.5 // Penalize wrong number in same series
+				c.Score *= k.SeriesNumberWrongPenalty // Penalize wrong number in same series
 			}
 		}
 	}


### PR DESCRIPTION
All scoring weights (transcription boosts, compilation penalty, rich-metadata
bonus, F1 floor, duration tiers, series boosts) become tunable config with
defaults equal to today's literals — bit-identical scoring until an operator
tunes them (equivalence fixture-proven). Per-knob fail-open resolver:
missing multiplicative knobs fall back to legacy literals; pointer knobs
(F1 floor, compilation penalty, bonus cap) keep an explicit 0 reachable
(nil = unset). Duration tier structure stays in code; only tier values are
config.

Co-Authored-By: Claude <noreply@anthropic.com>
