### PR TITLE
refactor(sdk): break sdkguard violations via decorator inversion + type move (#1795)

### DIFF
--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 2.7.1
+// version: 2.7.2
 // last-edited: 2026-07-11
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/pebble/v2"
-	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
 	"github.com/falkcorp/audiobook-organizer/internal/metrics"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
 	"github.com/klauspost/compress/zstd"
 )
 
@@ -119,9 +119,9 @@ type candRec struct {
 
 	// Unified scoring fields (T015, SPEC 1 §3). All omitempty so pre-T015
 	// rows round-trip without growing their stored size.
-	ScoreBreakdown *unified.UnifiedDedupScore `json:"sb,omitempty"`
-	Band           string                     `json:"band,omitempty"`
-	FormulaVersion string                     `json:"fv,omitempty"`
+	ScoreBreakdown *models.UnifiedDedupScore `json:"sb,omitempty"`
+	Band           string                    `json:"band,omitempty"`
+	FormulaVersion string                    `json:"fv,omitempty"`
 }
 
 // Embedding holds a vector embedding for a single entity.
@@ -160,9 +160,9 @@ type DedupCandidate struct {
 	UpdatedAt  time.Time `json:"updated_at"`
 
 	// Unified scoring fields (T015, SPEC 1 §3). Nil/empty on pre-T015 rows.
-	ScoreBreakdown *unified.UnifiedDedupScore `json:"score_breakdown,omitempty"`
-	Band           string                     `json:"band,omitempty"`
-	FormulaVersion string                     `json:"formula_version,omitempty"`
+	ScoreBreakdown *models.UnifiedDedupScore `json:"score_breakdown,omitempty"`
+	Band           string                    `json:"band,omitempty"`
+	FormulaVersion string                    `json:"formula_version,omitempty"`
 }
 
 // CandidateFilter controls ListCandidates queries.
@@ -1076,7 +1076,7 @@ func (s *EmbeddingStore) UpdateCandidateStatus(id int64, status string) error {
 // UpdateCandidateScore persists a new ScoreBreakdown, Band, and
 // FormulaVersion onto an existing candidate. Called by Engine.Rescore
 // when apply=true to commit re-computed scores without re-collecting signals.
-func (s *EmbeddingStore) UpdateCandidateScore(id int64, score *unified.UnifiedDedupScore, band, formulaVersion string) error {
+func (s *EmbeddingStore) UpdateCandidateScore(id int64, score *models.UnifiedDedupScore, band, formulaVersion string) error {
 	return s.updateCandidate(id, func(rec *candRec) {
 		rec.ScoreBreakdown = score
 		rec.Band = band

--- a/internal/dedup/unified/score.go
+++ b/internal/dedup/unified/score.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/unified/score.go
-// version: 1.0.0
+// version: 1.1.1
 // guid: e12361d1-96ea-4301-919d-3fdb51e12f8f
+// last-edited: 2026-07-11
 
 // Package unified provides the scoring core for the unified deduplication
 // pipeline (SPEC 1, fable5). It is intentionally pure: no I/O, no storage
@@ -9,13 +10,17 @@
 // after calibration changes.
 package unified
 
-import "time"
+import "github.com/falkcorp/audiobook-organizer/internal/models"
 
 // SignalKind is the identifier for a single evidence signal in the dedup
 // pipeline. Kinds are categorised as PRIMARY (contribute to the noisy-OR
 // product) or SUPPORTING (add bounded boosts after the product is computed).
 // See SPEC 1 §3 and ComposeScore for the exact categorisation logic.
-type SignalKind string
+//
+// Moved to internal/models/dedup_score.go (TASK-03, SDKGUARD-VIOLATION #1795)
+// so pkg/plugin/sdk's dependency tree no longer has to pull in this package;
+// aliased here so all existing unified.SignalKind call sites keep compiling.
+type SignalKind = models.SignalKind
 
 const (
 	// Primary signals — these are independent evidence sources that feed
@@ -67,66 +72,19 @@ const (
 
 // Signal is a single piece of evidence from one collector for one candidate
 // pair. Signals from all collectors are passed to ComposeScore together.
-type Signal struct {
-	// Kind identifies which collector produced this signal.
-	Kind SignalKind `json:"kind"`
-
-	// Raw is the unscaled measurement (e.g. cosine similarity 0.961,
-	// Hamming similarity 0.93, absolute duration delta as a fraction 0.004).
-	Raw float64 `json:"raw"`
-
-	// Confidence is the calibrated probability (0..1) that this signal
-	// alone indicates a duplicate. ComposeScore reads this field; Raw is
-	// stored for human auditing and re-calibration.
-	Confidence float64 `json:"confidence"`
-
-	// Evidence is a human-readable description for UI display and audit
-	// logs (e.g. "whole-file hash 9af3… both sides",
-	// "cosine 0.961 via embedding_high collector").
-	Evidence string `json:"evidence"`
-
-	// FPVersion is the fingerprint-algorithm version that produced the
-	// underlying acoustic data, stored for provenance and invalidation.
-	// Empty for non-acoustic signals.
-	FPVersion string `json:"fp_version,omitempty"`
-}
+//
+// Moved to internal/models/dedup_score.go (TASK-03, SDKGUARD-VIOLATION #1795);
+// aliased here so all existing unified.Signal call sites keep compiling.
+type Signal = models.Signal
 
 // UnifiedDedupScore is the composite output of ComposeScore for one candidate
 // pair. It is stored as DedupCandidate.ScoreBreakdown (JSON).
-type UnifiedDedupScore struct {
-	// Pair holds the two book IDs in canonical order (aID < bID).
-	Pair [2]string `json:"pair"`
-
-	// Score is the noisy-OR composite score on a 0–100 scale, capped at 100.
-	// Consumers should use Band for thresholding rather than raw Score,
-	// since calibration changes the meaning of any absolute number.
-	Score float64 `json:"score"`
-
-	// Band is the persistence band derived from Score:
-	//   CERTAIN ≥ 97   — auto-merge eligible
-	//   HIGH    90–96.99 — suggest-merge
-	//   MEDIUM  75–89.99 — review queue
-	//   REVIEW  60–74.99 — LLM phase / manual
-	//   (below 60 is not persisted)
-	Band string `json:"band"`
-
-	// Signals is the full per-signal breakdown, always stored.
-	// Supports re-scoring without re-collection when calibration changes.
-	Signals []Signal `json:"signals"`
-
-	// Suppressors lists the negative-guard identifiers that were fired
-	// before scoring (e.g. "series_volume_differs", "same_dir_multi_file").
-	// Non-empty means the pair was dropped before ComposeScore was called;
-	// the score will be 0 if this ever reaches persistence.
-	Suppressors []string `json:"suppressors"`
-
-	// Formula is the scoring algorithm version tag used to compute this
-	// score. Enables corpus-wide re-score detection after formula upgrades.
-	Formula string `json:"formula"`
-
-	// ComputedAt is the wall-clock time when this score was computed.
-	ComputedAt time.Time `json:"computed_at"`
-}
+//
+// Moved to internal/models/dedup_score.go (TASK-03, SDKGUARD-VIOLATION #1795)
+// so internal/database can reference it without pulling in this whole
+// package (and, transitively, pkg/plugin/sdk with it); aliased here so all
+// existing unified.UnifiedDedupScore call sites keep compiling.
+type UnifiedDedupScore = models.UnifiedDedupScore
 
 // Band constants — match exactly the thresholds in ComposeScore.
 const (

--- a/internal/models/dedup_score.go
+++ b/internal/models/dedup_score.go
@@ -1,0 +1,77 @@
+// file: internal/models/dedup_score.go
+// version: 1.0.0
+// guid: 59926af2-f1cb-4823-bbfd-65a11750bce6
+// last-edited: 2026-07-11
+
+package models
+
+import "time"
+
+// SignalKind is the identifier for a single evidence signal in the dedup
+// pipeline. Kinds are categorised as PRIMARY (contribute to the noisy-OR
+// product) or SUPPORTING (add bounded boosts after the product is computed).
+// See SPEC 1 §3 and ComposeScore for the exact categorisation logic.
+type SignalKind string
+
+// Signal is a single piece of evidence from one collector for one candidate
+// pair. Signals from all collectors are passed to ComposeScore together.
+type Signal struct {
+	// Kind identifies which collector produced this signal.
+	Kind SignalKind `json:"kind"`
+
+	// Raw is the unscaled measurement (e.g. cosine similarity 0.961,
+	// Hamming similarity 0.93, absolute duration delta as a fraction 0.004).
+	Raw float64 `json:"raw"`
+
+	// Confidence is the calibrated probability (0..1) that this signal
+	// alone indicates a duplicate. ComposeScore reads this field; Raw is
+	// stored for human auditing and re-calibration.
+	Confidence float64 `json:"confidence"`
+
+	// Evidence is a human-readable description for UI display and audit
+	// logs (e.g. "whole-file hash 9af3… both sides",
+	// "cosine 0.961 via embedding_high collector").
+	Evidence string `json:"evidence"`
+
+	// FPVersion is the fingerprint-algorithm version that produced the
+	// underlying acoustic data, stored for provenance and invalidation.
+	// Empty for non-acoustic signals.
+	FPVersion string `json:"fp_version,omitempty"`
+}
+
+// UnifiedDedupScore is the composite output of ComposeScore for one candidate
+// pair. It is stored as DedupCandidate.ScoreBreakdown (JSON).
+type UnifiedDedupScore struct {
+	// Pair holds the two book IDs in canonical order (aID < bID).
+	Pair [2]string `json:"pair"`
+
+	// Score is the noisy-OR composite score on a 0–100 scale, capped at 100.
+	// Consumers should use Band for thresholding rather than raw Score,
+	// since calibration changes the meaning of any absolute number.
+	Score float64 `json:"score"`
+
+	// Band is the persistence band derived from Score:
+	//   CERTAIN ≥ 97   — auto-merge eligible
+	//   HIGH    90–96.99 — suggest-merge
+	//   MEDIUM  75–89.99 — review queue
+	//   REVIEW  60–74.99 — LLM phase / manual
+	//   (below 60 is not persisted)
+	Band string `json:"band"`
+
+	// Signals is the full per-signal breakdown, always stored.
+	// Supports re-scoring without re-collection when calibration changes.
+	Signals []Signal `json:"signals"`
+
+	// Suppressors lists the negative-guard identifiers that were fired
+	// before scoring (e.g. "series_volume_differs", "same_dir_multi_file").
+	// Non-empty means the pair was dropped before ComposeScore was called;
+	// the score will be 0 if this ever reaches persistence.
+	Suppressors []string `json:"suppressors"`
+
+	// Formula is the scoring algorithm version tag used to compute this
+	// score. Enables corpus-wide re-score detection after formula upgrades.
+	Formula string `json:"formula"`
+
+	// ComputedAt is the wall-clock time when this score was computed.
+	ComputedAt time.Time `json:"computed_at"`
+}

--- a/internal/operations/registry/context_decorator_test.go
+++ b/internal/operations/registry/context_decorator_test.go
@@ -1,0 +1,129 @@
+// file: internal/operations/registry/context_decorator_test.go
+// version: 1.0.1
+// guid: 3d9f9e02-6b41-4a6b-9a2a-0e6a1b7f2c5d
+// last-edited: 2026-07-11
+
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// sdkGuardDecoratorProbeKey is a task-unique context key type (TASK-03,
+// SDKGUARD-VIOLATION #1795) used only by the tests in this file to detect
+// whether Registry.SetRunContextDecorator's decorator ran before the op's
+// Run func was invoked. Named distinctly from any other test-helper key in
+// this package to avoid the parallel-test-helper-collision failure mode.
+type sdkGuardDecoratorProbeKey struct{}
+
+// TestRunContextDecorator_DecoratesRunContext verifies that a decorator
+// wired via SetRunContextDecorator runs before the dispatched op's Run func
+// is invoked, and that its return value (a modified context) is the one the
+// op actually observes. This is the behavior registry_wire.go depends on to
+// preserve SLOG op-ID correlation (logger.WithOperation) now that the
+// registry package no longer imports the internal logging package directly.
+func TestRunContextDecorator_DecoratesRunContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{})
+
+	var gotOpIDInDecorator string
+	var gotValueInRun any
+	seenInRun := make(chan struct{})
+
+	r.SetRunContextDecorator(func(ctx context.Context, opID string) context.Context {
+		gotOpIDInDecorator = opID
+		return context.WithValue(ctx, sdkGuardDecoratorProbeKey{}, "decorated-"+opID)
+	})
+
+	def := makeValidDef("test.rundecorator-set")
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		gotValueInRun = runCtx.Value(sdkGuardDecoratorProbeKey{})
+		close(seenInRun)
+		return nil
+	}
+	if err := r.RegisterOp(def); err != nil {
+		t.Fatalf("RegisterOp: %v", err)
+	}
+	r.Start(ctx)
+
+	opID, err := r.EnqueueOp(ctx, "test.rundecorator-set", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+
+	select {
+	case <-seenInRun:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op's Run func was not invoked within 5s")
+	}
+	awaitStatus(t, store, opID, "completed", 5*time.Second)
+
+	if gotOpIDInDecorator != opID {
+		t.Errorf("decorator saw opID=%q, want %q", gotOpIDInDecorator, opID)
+	}
+	want := "decorated-" + opID
+	if gotValueInRun != want {
+		t.Errorf("Run observed ctx value %v, want %q — decorator's returned context was not the one passed to Run", gotValueInRun, want)
+	}
+}
+
+// TestRunContextDecorator_NilDecoratorRunsUndecorated verifies that a
+// Registry with no decorator wired (the default — SetRunContextDecorator was
+// never called) dispatches runs normally: no panic, and the run context
+// carries no decoration.
+func TestRunContextDecorator_NilDecoratorRunsUndecorated(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{})
+
+	var gotValueInRun any
+	var runErr error
+	seenInRun := make(chan struct{})
+
+	def := makeValidDef("test.rundecorator-nil")
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) (err error) {
+		defer func() {
+			if p := recover(); p != nil {
+				err = context.DeadlineExceeded // sentinel: any panic fails the test below
+				runErr = err
+			}
+		}()
+		gotValueInRun = runCtx.Value(sdkGuardDecoratorProbeKey{})
+		close(seenInRun)
+		return nil
+	}
+	if err := r.RegisterOp(def); err != nil {
+		t.Fatalf("RegisterOp: %v", err)
+	}
+	r.Start(ctx)
+
+	opID, err := r.EnqueueOp(ctx, "test.rundecorator-nil", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+
+	select {
+	case <-seenInRun:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op's Run func was not invoked within 5s (nil decorator should not block dispatch)")
+	}
+	awaitStatus(t, store, opID, "completed", 5*time.Second)
+
+	if runErr != nil {
+		t.Fatalf("Run func panicked with nil decorator wired: %v", runErr)
+	}
+	if gotValueInRun != nil {
+		t.Errorf("Run observed ctx value %v, want nil (no decorator was wired)", gotValueInRun)
+	}
+}

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.5.0
+// version: 3.6.1
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 package registry
 
@@ -54,6 +54,18 @@ type Registry struct {
 	// Set via SetDepBookStore before Start(). Nil is safe: combinedDepStore()
 	// falls back to OpsV2DepAdapter (conservative: field_set always unmet).
 	depBookStore DepBookStore
+
+	// runContextDecorator optionally decorates each run's context before the
+	// op's Run func is invoked (e.g. to stamp SLOG operation-id correlation).
+	// Set via SetRunContextDecorator before Start(). Nil is safe: the worker
+	// skips decoration and runs with the plain per-run context.
+	//
+	// This indirection exists so this package never imports the internal
+	// logging package directly — that import would leak into
+	// pkg/plugin/sdk's dependency tree via this package
+	// (SDKGUARD-VIOLATION #1795). Production wiring happens
+	// post-construction in internal/server/registry_wire.go.
+	runContextDecorator func(ctx context.Context, opID string) context.Context
 
 	// batch manages the M3 per-op-type debounce buckets for Batchable ops.
 	batch *batchManager
@@ -175,6 +187,27 @@ type DepBookStore interface {
 func (r *Registry) SetDepBookStore(bs DepBookStore) {
 	r.mu.Lock()
 	r.depBookStore = bs
+	r.mu.Unlock()
+}
+
+// SetRunContextDecorator wires a function that decorates each run's context
+// immediately before Run is invoked (e.g. logger.WithOperation, which stamps
+// a context-bound *slog.Logger tagged with the operation id for SLOG
+// correlation). Must be called BEFORE Start(), mirroring SetDepBookStore:
+// the worker reads r.runContextDecorator without locking (see
+// combinedDepStore's identical precedent), so it is only safe to set once
+// at startup. Nil is safe and simply disables decoration — runs then
+// execute with the plain per-run context.
+//
+// This setter exists so the registry package never has to import the
+// internal logging package (or any other decorator source) directly:
+// importing it here would leak into pkg/plugin/sdk's allowed-dependency
+// tree, since the SDK's public surface is built on type aliases into this
+// package (SDKGUARD-VIOLATION #1795). Callers wire the concrete decorator
+// post-construction — see internal/server/registry_wire.go.
+func (r *Registry) SetRunContextDecorator(fn func(ctx context.Context, opID string) context.Context) {
+	r.mu.Lock()
+	r.runContextDecorator = fn
 	r.mu.Unlock()
 }
 

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.9.0
+// version: 2.10.1
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 package registry
 
@@ -15,7 +15,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -153,8 +152,13 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		}
 	}
 	runCtx, cancel := context.WithTimeout(parentCtx, timeout)
-	// Install a context-bound slog.Logger that tags every line with the operation id.
-	runCtx = logger.WithOperation(runCtx, qr.opID)
+	// Decorate the run context (e.g. install a context-bound slog.Logger that
+	// tags every line with the operation id) via the optional decorator hook.
+	// Nil is the default when no decorator was wired via
+	// SetRunContextDecorator — runs proceed undecorated.
+	if r.runContextDecorator != nil {
+		runCtx = r.runContextDecorator(runCtx, qr.opID)
+	}
 	defer cancel()
 
 	// Register the handle.

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,6 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.18.0
-// last-edited: 2026-07-03
+// version: 1.19.1
+// last-edited: 2026-07-11
 
 package server
 
@@ -20,6 +20,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/importer"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
@@ -336,6 +337,10 @@ func wireServerFromContainer(s *Server, c *serviceregistry.Container) {
 		if s.activityService != nil {
 			s.opRegistry.SetActivityRecorder(s.activityService)
 		}
+		// Wires SLOG op-ID correlation (logger.WithOperation) into every run's
+		// context without the registry package importing internal/logger
+		// directly — see Registry.SetRunContextDecorator (SDKGUARD-VIOLATION #1795).
+		s.opRegistry.SetRunContextDecorator(logger.WithOperation)
 	}
 	if hub, ok := serviceregistry.TryGet[*opsregistry.EventHub](c, serviceregistry.KeyOpHub); ok {
 		s.opHub = hub


### PR DESCRIPTION
pkg/plugin/sdk's dep tree pulled internal/logger (registry worker's single
logger.WithOperation call) and internal/dedup/unified (UnifiedDedupScore in
embedding_store). Inverts the first behind Registry.SetRunContextDecorator
(wired to logger.WithOperation in registry_wire.go, preserving SLOG op-ID
correlation) and moves UnifiedDedupScore/Signal/SignalKind to internal/models
with aliases left in unified. make sdkguard green; allowlist untouched.

Co-Authored-By: Claude <noreply@anthropic.com>
