### PR TITLE
fix(dedup): drain-gate parity with upsertExactCandidate + drain flag v2 (INIT-2 T3, #1512)

### DIFF
--- a/internal/dedup/drain_stale.go
+++ b/internal/dedup/drain_stale.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/drain_stale.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 60d982e2-6836-4327-9ddf-9b55375f39ea
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // Package dedup — DrainStaleCandidates (DEDUP-1 / CONS-16 / CONS-17).
 //
@@ -55,6 +55,7 @@ const staleDrainStatus = "stale-drain"
 // Reason buckets — which gate first rejected a would-purge candidate.
 const (
 	drainReasonMissingBook        = "missing_book"
+	drainReasonNonPrimaryVersion  = "non_primary_version"
 	drainReasonIdentifierConflict = "identifier_conflict"
 	drainReasonBoilerplateTitle   = "boilerplate_title"
 	drainReasonShortDuration      = "short_duration"
@@ -277,21 +278,40 @@ func (de *Engine) DrainStaleCandidates(ctx context.Context, opID string, apply b
 	return result, nil
 }
 
-// classifyStaleCandidate re-runs upsertExactCandidate's guard chain (minus the
-// isNonPrimaryVersion gate, which PurgeStaleCandidates already drains separately)
-// against a pair's CURRENT data. It returns the first rejecting reason and true
-// if the candidate would no longer be emitted today, or ("", false) if it still
-// passes every gate and must be kept.
+// classifyStaleCandidate re-runs upsertExactCandidate's full guard chain —
+// isNonPrimaryVersion, identifiersConflict, isBoilerplateTitle,
+// hasKnownShortDuration, isPartVsWholeMismatch, in the SAME order the
+// chokepoint applies them — against a pair's CURRENT data. It returns the
+// first rejecting reason and true if the candidate would no longer be
+// emitted today, or ("", false) if it still passes every gate and must be
+// kept.
 //
-// This reuses the real predicate functions verbatim (identifiersConflict,
-// isBoilerplateTitle, hasKnownShortDuration, isPartVsWholeMismatch) rather than
-// reimplementing them, so the re-evaluation can never drift from what the live
-// emitter actually does.
+// This reuses the real predicate functions verbatim rather than
+// reimplementing them, so the re-evaluation can never drift from what the
+// live emitter actually does.
+//
+// non_primary_version (INIT-2 T3, drain-gate parity): originally omitted
+// here on the theory that PurgeStaleCandidates already handles non-primary
+// pairs — but PurgeStaleCandidates is a DIFFERENT op (hard-delete, all
+// layers, run at startup/rescan, not scoped to this drain's pending
+// exact-layer backlog). A pending exact candidate can still involve a
+// non-primary book between PurgeStaleCandidates runs, so the chokepoint's
+// first gate needs its own twin here for the drain's report/apply to be a
+// true preview of what upsertExactCandidate would (not) emit today. The
+// soft-reclassify (never delete) semantics keep this idempotent alongside
+// PurgeStaleCandidates' separate hard-delete sweep — a row either path
+// already removed simply never appears in this scan again.
 func (de *Engine) classifyStaleCandidate(a, b drainBookMeta) (string, bool) {
 	// A missing book on either side means the candidate can't be actioned — the
 	// same conservative treatment PurgeStaleCandidates gives missing books.
+	// This check has no chokepoint twin (upsertExactCandidate always receives
+	// live, already-loaded *database.Book pointers, never a dangling ID) — it
+	// exists only because the drain re-resolves books by ID.
 	if a.missing || b.missing {
 		return drainReasonMissingBook, true
+	}
+	if isNonPrimaryVersion(a.stub) || isNonPrimaryVersion(b.stub) {
+		return drainReasonNonPrimaryVersion, true
 	}
 	if identifiersConflict(a.stub, b.stub) {
 		return drainReasonIdentifierConflict, true

--- a/internal/dedup/drain_stale_test.go
+++ b/internal/dedup/drain_stale_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/drain_stale_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6b8c9a6c-b168-4fb9-ba23-99937427b562
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // Tests for Engine.DrainStaleCandidates (DEDUP-1 / CONS-16 / CONS-17).
 //
@@ -21,11 +21,12 @@ import (
 
 // drainBook is a compact spec for a book fixture in these tests.
 type drainBook struct {
-	id       string
-	title    string
-	duration *int
-	isbn13   *string
-	files    []database.BookFile
+	id               string
+	title            string
+	duration         *int
+	isbn13           *string
+	files            []database.BookFile
+	isPrimaryVersion *bool // nil = unknown/conservative (never non-primary)
 }
 
 // setupDrainTest wires an Engine whose GetBookByID / GetBookFiles resolve from
@@ -45,10 +46,11 @@ func setupDrainTest(t *testing.T, books []drainBook) (*Engine, *database.Embeddi
 			return nil, nil // since-deleted book
 		}
 		return &database.Book{
-			ID:       b.id,
-			Title:    b.title,
-			Duration: b.duration,
-			ISBN13:   b.isbn13,
+			ID:               b.id,
+			Title:            b.title,
+			Duration:         b.duration,
+			ISBN13:           b.isbn13,
+			IsPrimaryVersion: b.isPrimaryVersion,
 		}, nil
 	}
 	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
@@ -143,6 +145,52 @@ func TestDrainStale_PartVsWhole(t *testing.T) {
 	}
 	if res.WouldPurge != 1 || res.ReasonCounts[drainReasonPartVsWhole] != 1 {
 		t.Fatalf("part_vs_whole bucket wrong: wouldPurge %d, reasons %v", res.WouldPurge, res.ReasonCounts)
+	}
+}
+
+// TestDrainStale_NonPrimaryVersion is the INIT-2 T3 drain-gate-parity
+// regression: the chokepoint's FIRST gate (isNonPrimaryVersion) must have a
+// drain twin bucketed as non_primary_version, matching upsertExactCandidate's
+// behavior of never emitting a candidate involving a non-primary
+// version-group member.
+func TestDrainStale_NonPrimaryVersion(t *testing.T) {
+	primary := true
+	nonPrimary := false
+	engine, es := setupDrainTest(t, []drainBook{
+		{id: "BOOK_A", title: "A Real Book", duration: intPtr(3600), isPrimaryVersion: &primary},
+		{id: "BOOK_B", title: "A Real Book", duration: intPtr(3600), isPrimaryVersion: &nonPrimary},
+	})
+	seedDrainCandidate(t, es, "BOOK_A", "BOOK_B")
+
+	res, err := engine.DrainStaleCandidates(context.Background(), "", false)
+	if err != nil {
+		t.Fatalf("DrainStaleCandidates: %v", err)
+	}
+	if res.WouldPurge != 1 || res.ReasonCounts[drainReasonNonPrimaryVersion] != 1 {
+		t.Fatalf("non_primary_version bucket wrong: wouldPurge %d, reasons %v", res.WouldPurge, res.ReasonCounts)
+	}
+}
+
+// TestDrainStale_NonPrimaryVersion_ConservativeNilKept is the
+// anti-over-suppression proof for the new gate: a pair whose IsPrimaryVersion
+// is unknown (nil) on both sides — the common case for older rows and for
+// stores that never set the flag — must NOT be treated as non-primary.
+// isNonPrimaryVersion(nil-flag book) returns false, matching
+// upsertExactCandidate's own conservative default, so this pair must be KEPT
+// by the drain exactly like it would still be emitted by the chokepoint.
+func TestDrainStale_NonPrimaryVersion_ConservativeNilKept(t *testing.T) {
+	engine, es := setupDrainTest(t, []drainBook{
+		{id: "BOOK_A", title: "A Real Book", duration: intPtr(3600)}, // isPrimaryVersion left nil
+		{id: "BOOK_B", title: "A Real Book", duration: intPtr(3600)}, // isPrimaryVersion left nil
+	})
+	seedDrainCandidate(t, es, "BOOK_A", "BOOK_B")
+
+	res, err := engine.DrainStaleCandidates(context.Background(), "", false)
+	if err != nil {
+		t.Fatalf("DrainStaleCandidates: %v", err)
+	}
+	if res.Inspected != 1 || res.WouldPurge != 0 || res.Kept != 1 {
+		t.Fatalf("nil-primary-flag pair over-suppressed: inspected %d, wouldPurge %d, kept %d (want 1/0/1)", res.Inspected, res.WouldPurge, res.Kept)
 	}
 }
 

--- a/internal/dedup/engine_exact_guard_test.go
+++ b/internal/dedup/engine_exact_guard_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_exact_guard_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a1e6d3f-9c72-4a0b-8e35-1f6b2c7d9e40
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 // Regression guard for DEDUP-INTRO-1 (residual): upsertExactCandidate is the
 // shared chokepoint for every exact-family emitter. It must reject pairs
@@ -9,10 +9,24 @@
 // where either book has a known, positive Duration under
 // minFingerprintMatchSeconds — while still allowing genuine duplicates
 // (normal titles, durations well above the threshold) through.
+//
+// INIT-2 T3 (2026-07-11) added the gate-parity + anti-over-suppression tests
+// below: TestUpsertExactCandidateGateParityWithDrain proves
+// DrainStaleCandidates' guard chain mirrors upsertExactCandidate's
+// gate-for-gate (including the non_primary_version twin added by this task),
+// TestExactEmitHappyPathSurvives proves a known-good duplicate still emits
+// and is kept by both paths, TestUpsertExactCandidate_PairDedupeConfirmed
+// confirms (without rebuilding) UpsertCandidateNew's existing pair-level
+// dedupe, and TestUpsertExactCandidate_NilDurationConservativeBothGates
+// locks in nil/unknown-duration conservatism across both duration-sensitive
+// gates.
 package dedup
 
 import (
+	"context"
 	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
 func TestUpsertExactCandidate_BoilerplateTitleGuard(t *testing.T) {
@@ -104,5 +118,281 @@ func TestUpsertExactCandidate_ZeroDurationNotSuppressed(t *testing.T) {
 	cands := pendingCandidates(t, es)
 	if len(cands) != 1 {
 		t.Errorf("expected 1 candidate for zero-duration pair (treated as unknown), got %d: %+v", len(cands), cands)
+	}
+}
+
+// TestUpsertExactCandidateGateParityWithDrain is the INIT-2 T3 acceptance
+// test: for every gate in upsertExactCandidate's chain (non-primary-version
+// skip, identifiersConflict, isBoilerplateTitle, hasKnownShortDuration,
+// isPartVsWholeMismatch), a pair rejected by the chokepoint must be
+// classified would-purge by DrainStaleCandidates with the MATCHING reason
+// bucket, and a pair that passes every gate must be emitted by the
+// chokepoint AND kept by the drain. This proves DrainStaleCandidates' gate
+// chain mirrors upsertExactCandidate's gate-for-gate, in the same order.
+func TestUpsertExactCandidateGateParityWithDrain(t *testing.T) {
+	short := 30
+
+	type pairCase struct {
+		name       string
+		a, b       *database.Book
+		files      map[string][]database.BookFile // bookID -> files, for part-vs-whole only
+		wantReason string                          // "" = kept by both chokepoint and drain
+	}
+
+	isbnA, isbnB := "9781111111111", "9782222222222"
+
+	cases := []pairCase{
+		{
+			name:       "non_primary_version",
+			a:          primaryBook("A", "Real Title"),
+			b:          nonPrimaryBook("B", "Real Title"),
+			wantReason: drainReasonNonPrimaryVersion,
+		},
+		{
+			name: "identifier_conflict",
+			a: func() *database.Book {
+				b := primaryBook("A", "Real Title")
+				b.ISBN13 = &isbnA
+				return b
+			}(),
+			b: func() *database.Book {
+				b := primaryBook("B", "Real Title")
+				b.ISBN13 = &isbnB
+				return b
+			}(),
+			wantReason: drainReasonIdentifierConflict,
+		},
+		{
+			name:       "boilerplate_title",
+			a:          primaryBook("A", "This is Audible"),
+			b:          primaryBook("B", "This is Audible"),
+			wantReason: drainReasonBoilerplateTitle,
+		},
+		{
+			name: "short_duration",
+			a: func() *database.Book {
+				b := primaryBook("A", "Real Title")
+				b.Duration = &short
+				return b
+			}(),
+			b:          primaryBook("B", "Real Title"),
+			wantReason: drainReasonShortDuration,
+		},
+		{
+			name: "part_vs_whole",
+			a:    primaryBook("A", "Real Title"),
+			b:    primaryBook("B", "Real Title"),
+			files: map[string][]database.BookFile{
+				"A": {{ID: "FA1", BookID: "A", Duration: 100}},
+				"B": {
+					{ID: "FB1", BookID: "B", Duration: 500},
+					{ID: "FB2", BookID: "B", Duration: 500},
+				},
+			},
+			wantReason: drainReasonPartVsWhole,
+		},
+		{
+			name:       "kept_genuine_duplicate",
+			a:          primaryBook("A", "Genuine Duplicate Book"),
+			b:          primaryBook("B", "Genuine Duplicate Book"),
+			wantReason: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// --- Chokepoint side: call upsertExactCandidate directly. ---
+			engine, mock, es := setupTestEngine(t)
+			if tc.files != nil {
+				mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+					return tc.files[bookID], nil
+				}
+			}
+			if err := engine.upsertExactCandidate(tc.a, tc.b, "exact", 1.0); err != nil {
+				t.Fatalf("upsertExactCandidate: %v", err)
+			}
+			chokepointCands := pendingCandidates(t, es)
+			if tc.wantReason == "" {
+				if len(chokepointCands) != 1 {
+					t.Fatalf("chokepoint: expected 1 candidate (kept case), got %d: %+v", len(chokepointCands), chokepointCands)
+				}
+			} else if len(chokepointCands) != 0 {
+				t.Fatalf("chokepoint: expected 0 candidates (rejected by %s), got %d: %+v", tc.name, len(chokepointCands), chokepointCands)
+			}
+
+			// --- Drain side: fresh engine/store; seed the pending candidate
+			// directly since the chokepoint may have refused to create it in
+			// the reject cases. ---
+			dEngine, dMock, dEs := setupTestEngine(t)
+			books := map[string]*database.Book{tc.a.ID: tc.a, tc.b.ID: tc.b}
+			dMock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+			if tc.files != nil {
+				dMock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+					return tc.files[bookID], nil
+				}
+			}
+			if err := dEs.UpsertCandidate(database.DedupCandidate{
+				EntityType: "book",
+				EntityAID:  tc.a.ID,
+				EntityBID:  tc.b.ID,
+				Layer:      "exact",
+				Status:     "pending",
+			}); err != nil {
+				t.Fatalf("seed drain candidate: %v", err)
+			}
+
+			res, err := dEngine.DrainStaleCandidates(context.Background(), "", false)
+			if err != nil {
+				t.Fatalf("DrainStaleCandidates: %v", err)
+			}
+			if tc.wantReason == "" {
+				if res.WouldPurge != 0 || res.Kept != 1 {
+					t.Fatalf("drain: expected kept (0 would-purge), got wouldPurge=%d kept=%d reasons=%v", res.WouldPurge, res.Kept, res.ReasonCounts)
+				}
+			} else if res.WouldPurge != 1 || res.ReasonCounts[tc.wantReason] != 1 {
+				t.Fatalf("drain: expected would-purge with reason %s, got wouldPurge=%d reasons=%v", tc.wantReason, res.WouldPurge, res.ReasonCounts)
+			}
+		})
+	}
+}
+
+// TestExactEmitHappyPathSurvives is the anti-over-suppression proof required
+// by INIT-2 T3: a known-good duplicate pair (plausible audio on both sides —
+// real duration, distinct folders, no identifier conflict, no boilerplate
+// title, no part-vs-whole mismatch) must still emit a candidate through the
+// full exact-title emission path (CheckBook -> checkExactTitle ->
+// upsertExactCandidate, not just the chokepoint called in isolation), and
+// that candidate must be KEPT (not would-purge) by DrainStaleCandidates. If
+// the gate-parity fix in this task over-suppressed, this test would catch
+// it.
+func TestExactEmitHappyPathSurvives(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+	engine.AutoMergeEnabled = false
+
+	dur := 3600
+	authorID := 1
+	primary := true
+	a := &database.Book{
+		ID: "HAPPY_A", Title: "The Great Adventure", AuthorID: &authorID,
+		Duration: &dur, IsPrimaryVersion: &primary, FilePath: "/library/author/book-a/file.m4b",
+	}
+	b := &database.Book{
+		ID: "HAPPY_B", Title: "The Great Adventure", AuthorID: &authorID,
+		Duration: &dur, IsPrimaryVersion: &primary, FilePath: "/library/author/book-b/file.m4b",
+	}
+	byAuthor := []database.Book{*a, *b}
+	wireExactTitleOnly(mock, map[string]*database.Book{"HAPPY_A": a, "HAPPY_B": b}, byAuthor)
+
+	for _, id := range []string{"HAPPY_A", "HAPPY_B"} {
+		if _, err := engine.CheckBook(context.Background(), id); err != nil {
+			t.Fatalf("CheckBook(%s): %v", id, err)
+		}
+	}
+
+	cands := pendingCandidates(t, es)
+	found := false
+	for _, c := range cands {
+		if (c.EntityAID == "HAPPY_A" && c.EntityBID == "HAPPY_B") || (c.EntityAID == "HAPPY_B" && c.EntityBID == "HAPPY_A") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a known-good duplicate pair to still emit a candidate, got: %+v", cands)
+	}
+
+	// Feed the same pair through the drain and confirm it is KEPT, not
+	// would-purge — proves the gate-parity fix does not over-suppress a
+	// legitimate duplicate.
+	dEngine, dMock, dEs := setupTestEngine(t)
+	books := map[string]*database.Book{"HAPPY_A": a, "HAPPY_B": b}
+	dMock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+	dMock.GetBookFilesFunc = func(string) ([]database.BookFile, error) { return nil, nil }
+	if err := dEs.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "HAPPY_A", EntityBID: "HAPPY_B", Layer: "exact", Status: "pending",
+	}); err != nil {
+		t.Fatalf("seed drain candidate: %v", err)
+	}
+	res, err := dEngine.DrainStaleCandidates(context.Background(), "", false)
+	if err != nil {
+		t.Fatalf("DrainStaleCandidates: %v", err)
+	}
+	if res.WouldPurge != 0 || res.Kept != 1 {
+		t.Fatalf("drain over-suppressed a known-good duplicate: wouldPurge=%d kept=%d reasons=%v", res.WouldPurge, res.Kept, res.ReasonCounts)
+	}
+}
+
+// TestUpsertExactCandidate_PairDedupeConfirmed confirms (does not rebuild)
+// the pair-level dedupe already implemented in
+// EmbeddingStore.UpsertCandidateNew: two upsertExactCandidate calls for the
+// SAME pair — including with A/B swapped — must produce exactly one stored
+// candidate row, not two, because UpsertCandidateNew canonicalizes A/B order
+// and point-reads dedupPairKey before insert.
+func TestUpsertExactCandidate_PairDedupeConfirmed(t *testing.T) {
+	engine, _, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Genuine Duplicate Book")
+	b := primaryBook("B", "Genuine Duplicate Book")
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate(a,b): %v", err)
+	}
+	// Reversed argument order — UpsertCandidateNew canonicalizes A/B so this
+	// must still land on the SAME pair key, not a second row.
+	if err := engine.upsertExactCandidate(b, a, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate(b,a): %v", err)
+	}
+
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Fatalf("expected exactly 1 stored candidate for the same pair called twice, got %d: %+v", len(cands), cands)
+	}
+}
+
+// TestUpsertExactCandidate_NilDurationConservativeBothGates locks in nil/
+// unknown-duration conservatism across BOTH duration-sensitive gates
+// (hasKnownShortDuration and isPartVsWholeMismatch): a pair with unknown
+// Book.Duration on both sides, and a single BookFile each (so neither side
+// has the >=2-file "whole" shape isPartVsWholeMismatch looks for), must
+// still emit through the chokepoint AND be kept by the drain — proving
+// neither gate's nil-conservative default was flipped by this task's
+// changes.
+func TestUpsertExactCandidate_NilDurationConservativeBothGates(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	a.Duration = nil
+	b := primaryBook("B", "Real Book Title")
+	b.Duration = nil
+
+	files := map[string][]database.BookFile{
+		"A": {{ID: "FA1", BookID: "A", Duration: 100}},
+		"B": {{ID: "FB1", BookID: "B", Duration: 100}},
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return files[bookID], nil }
+
+	if err := engine.upsertExactCandidate(a, b, "exact", 1.0); err != nil {
+		t.Fatalf("upsertExactCandidate: %v", err)
+	}
+	cands := pendingCandidates(t, es)
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate for nil-duration pair (no over-suppression), got %d: %+v", len(cands), cands)
+	}
+
+	// Drain-side parity: the same pair, re-seeded, must be KEPT.
+	dEngine, dMock, dEs := setupTestEngine(t)
+	books := map[string]*database.Book{"A": a, "B": b}
+	dMock.GetBookByIDFunc = func(id string) (*database.Book, error) { return books[id], nil }
+	dMock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) { return files[bookID], nil }
+	if err := dEs.UpsertCandidate(database.DedupCandidate{
+		EntityType: "book", EntityAID: "A", EntityBID: "B", Layer: "exact", Status: "pending",
+	}); err != nil {
+		t.Fatalf("seed drain candidate: %v", err)
+	}
+	res, err := dEngine.DrainStaleCandidates(context.Background(), "", false)
+	if err != nil {
+		t.Fatalf("DrainStaleCandidates: %v", err)
+	}
+	if res.WouldPurge != 0 || res.Kept != 1 {
+		t.Fatalf("drain over-suppressed nil-duration pair: wouldPurge=%d kept=%d reasons=%v", res.WouldPurge, res.Kept, res.ReasonCounts)
 	}
 }

--- a/internal/plugins/dedup/drain_stale.go
+++ b/internal/plugins/dedup/drain_stale.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/drain_stale.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a6103a90-d68c-4db5-ace4-e2a9fb2a51e1
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // Package dedup — op dedup.drain-stale (DEDUP-1 / CONS-16 / CONS-17).
 //
@@ -13,8 +13,12 @@
 //
 // Dry-run by default. Pass {"apply":true} to soft-reclassify would-purge rows
 // to "stale-drain" (never a hard delete). The apply path is gated behind a
-// versioned Settings done-flag (dedup_stale_drain_v1_done) so a second apply
+// versioned Settings done-flag (dedup_stale_drain_v2_done) so a second apply
 // run after completion is a safe no-op — the M0 purge_legacy_fp precedent.
+// (v1 -> v2, INIT-2 T3: DrainStaleCandidates' gate chain gained a
+// non_primary_version twin so it now mirrors upsertExactCandidate
+// gate-for-gate; the flag bumped so a prior v1 "done" state never blocks the
+// re-run needed to apply the corrected criteria.)
 //
 // DATA-LOSS GATE: this op ships the tool only. Running apply=true against
 // production requires a separate, explicit owner greenlight after the dry-run
@@ -32,9 +36,14 @@ import (
 )
 
 // drainStaleDoneFlag is the versioned Settings key that prevents re-running the
-// apply path after it has completed once. Bump to v2 if the drain criteria ever
-// change and a re-run is required.
-const drainStaleDoneFlag = "dedup_stale_drain_v1_done"
+// apply path after it has completed once. Bump to v3 if the drain criteria ever
+// change again and a re-run is required.
+//
+// v1 -> v2 (INIT-2 T3, 2026-07-11): DrainStaleCandidates gained a
+// non_primary_version gate twin (drain-gate parity with upsertExactCandidate)
+// — bumped so a v1 "done" apply does not silently block the re-run needed to
+// apply the corrected criteria against the ~387k backlog.
+const drainStaleDoneFlag = "dedup_stale_drain_v2_done"
 
 // drainStaleCheckpointID is the stable checkpoint key for the op's resumable
 // scan. A constant is safe because ConcurrencyKey serialises runs, so no two


### PR DESCRIPTION
## INIT-2 TASK-03 — Exact-layer explosion (#1512): drain-gate parity + drain flag v2 [review-critical]

Bounds the exact-layer candidate explosion at the CODE level. **Review-critical**: an over-broad guard would silently suppress real duplicates, so every change is additive and anti-over-suppression tested.

### Chokepoint audit — no bypass emitters found
All six exact-family emitters route through the single chokepoint `upsertExactCandidate`:
- `handleFileHashMatch` (via `checkExactFileHash`), `checkExactISBNIndexed`, `checkExactISBNScan`, `checkExactMetadataSourceHash`, `checkExactTitle`, `checkDurationMatch`.

The chokepoint's five-gate chain (non-primary-version skip → `identifiersConflict` → `isBoilerplateTitle` → `hasKnownShortDuration` → `isPartVsWholeMismatch`) and the emission-time `hasPlausibleAudio` gates on `checkExactTitle`/`checkExactISBN*` are **intact**. `CollectExactAcoustID` and the `collectors_exact.go` scoring-path collectors are left intentionally ungated per their doc comments; the AcoustID-veto NOTE is untouched. **No emission-time gap; no chokepoint additions.**

`UpsertCandidateNew`'s pair-level dedupe (canonicalize + `dedupPairKey` point-read) already exists — **confirmed with a test, not rebuilt**. `internal/database/embedding_store.go` was NOT edited.

### Gap closed — drain parity only
`DrainStaleCandidates.classifyStaleCandidate` was missing the chokepoint's **first** gate, `isNonPrimaryVersion`. Its stale doc comment claimed `PurgeStaleCandidates` "drains it separately", but that is a **different op** (hard-delete, all layers, startup/rescan-timed) — not a drain twin with a reason bucket. A pending exact candidate can involve a non-primary book between `PurgeStaleCandidates` runs, so the drain's report/apply was not a true preview of what the chokepoint would emit today.

**Fix (additive):** added the `non_primary_version` gate + reason bucket, in chokepoint order (after the drain-only `missing_book` pre-check, before `identifier_conflict`).

### Drain-gate parity — before vs after
| Order | Chokepoint (`upsertExactCandidate`) | Drain BEFORE | Drain AFTER |
|--|--|--|--|
| pre | — | `missing_book` | `missing_book` |
| 1 | non-primary-version skip | *(missing)* | **`non_primary_version`** |
| 2 | `identifiersConflict` | `identifier_conflict` | `identifier_conflict` |
| 3 | `isBoilerplateTitle` | `boilerplate_title` | `boilerplate_title` |
| 4 | `hasKnownShortDuration` | `short_duration` | `short_duration` |
| 5 | `isPartVsWholeMismatch` | `part_vs_whole` | `part_vs_whole` |

Now gate-for-gate identical (drain adds only the emission-impossible `missing_book` pre-check for ID re-resolution).

### Done-flag bump
`drainStaleDoneFlag`: `dedup_stale_drain_v1_done` → `dedup_stale_drain_v2_done` so the T6 prod drain re-runs with the corrected criteria even if a v1 apply ever completed.

### Tests
- `TestUpsertExactCandidateGateParityWithDrain` — table-driven, all 5 gates: chokepoint rejection ⇔ drain would-purge with matching bucket; happy path emitted+kept.
- `TestExactEmitHappyPathSurvives` — anti-over-suppression: a known-good dup pair still emits through `CheckBook`→`checkExactTitle` and is kept by the drain.
- `TestDrainStale_NonPrimaryVersion` + `TestDrainStale_NonPrimaryVersion_ConservativeNilKept` — the new gate buckets correctly, and a nil `IsPrimaryVersion` pair is KEPT (conservative default unchanged).
- `TestUpsertExactCandidate_PairDedupeConfirmed` — two upserts (incl. A/B swapped) → one stored candidate.
- `TestUpsertExactCandidate_NilDurationConservativeBothGates` — nil-duration conservatism across both duration gates.

### Verification (foreground, this session)
- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `go test -race -count=1 ./internal/dedup/... ./internal/plugins/dedup/... -short` — exit 0
- `go test ./... -short` — only failure is `internal/server` at 600s (known load-induced stall flake: idle `FileIOPool`/Pebble goroutines on `chan receive`; zero `--- FAIL`, zero panics; unrelated to these changes). All 30 other packages `ok`.

### Gate
Code + tests only. **No prod drain/apply was run** — the drain RUN is the separately human-gated TASK-06.

Files: `internal/dedup/drain_stale.go`, `internal/dedup/drain_stale_test.go`, `internal/dedup/engine_exact_guard_test.go`, `internal/plugins/dedup/drain_stale.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv