### PR TITLE
perf(search): batch-hydrate Bleve hits with GetBooksByIDs (INIT-4 T3)

### DIFF
--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.7.0
+// version: 1.7.1
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package audiobooks
 

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
 // last-edited: 2026-07-10
 
@@ -557,12 +557,22 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 			slog.Warn("search: post-filter window exhausted; results beyond it are truncated",
 				"window", searchPostFilterWindow)
 		}
-		filtered := make([]database.Book, 0, len(hits))
+		ids := make([]string, 0, len(hits))
 		for _, h := range hits {
-			b, _ := svc.store.GetBookByID(h.BookID)
-			if b == nil {
-				continue
-			}
+			ids = append(ids, h.BookID)
+		}
+		// Batch-hydrate (INIT-4 T3): one store call instead of one per hit.
+		// FAIL-OPEN at the call site (spec §C3): a non-nil error from
+		// GetBooksByIDs must not fail the whole search page — warn and
+		// keep serving the rows hydrated so far, mirroring the old
+		// per-hit loop's silent-skip-on-error semantics.
+		hydrated, hydrateErr := svc.store.GetBooksByIDs(ids)
+		if hydrateErr != nil {
+			slog.Warn("search: batch hydrate failed; serving partial page",
+				"err", hydrateErr, "hydrated", len(hydrated))
+		}
+		filtered := make([]database.Book, 0, len(hydrated))
+		for _, b := range hydrated {
 			state, stateErr := svc.store.GetUserBookState(userID, b.ID)
 			if stateErr != nil {
 				// FAIL-OPEN (Decision 5): evaluate the zero-value state, loudly.
@@ -573,7 +583,7 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 			if !search.MatchPerUserFilters(state, perUser) {
 				continue
 			}
-			filtered = append(filtered, *b)
+			filtered = append(filtered, b)
 		}
 		// Apply pagination after filtering — offset beyond len yields an
 		// empty slice, not an error (mirrors GetAudiobooks' heavy
@@ -605,12 +615,22 @@ func (svc *AudiobookService) searchWithBleve(query string, limit, offset int, us
 	if err != nil {
 		return nil, fmt.Errorf("bleve search: %w", err)
 	}
-	books := make([]database.Book, 0, len(hits))
+	ids := make([]string, 0, len(hits))
 	for _, h := range hits {
-		b, _ := svc.store.GetBookByID(h.BookID)
-		if b != nil {
-			books = append(books, *b)
-		}
+		ids = append(ids, h.BookID)
+	}
+	// Batch-hydrate (INIT-4 T3): one store call instead of one per hit.
+	// FAIL-OPEN at the call site (spec §C3): a non-nil error from
+	// GetBooksByIDs must not fail the whole search page — warn and keep
+	// serving the rows hydrated so far, mirroring the old per-hit loop's
+	// silent-skip-on-error semantics.
+	books, hydrateErr := svc.store.GetBooksByIDs(ids)
+	if hydrateErr != nil {
+		slog.Warn("search: batch hydrate failed; serving partial page",
+			"err", hydrateErr, "hydrated", len(books))
+	}
+	if books == nil {
+		books = []database.Book{}
 	}
 	return books, nil
 }

--- a/internal/audiobooks/service_query_search_hydration_test.go
+++ b/internal/audiobooks/service_query_search_hydration_test.go
@@ -1,0 +1,69 @@
+// file: internal/audiobooks/service_query_search_hydration_test.go
+// version: 1.0.0
+// guid: 9f0a1b2c-3d4e-5f60-7182-93a4b5c6d7e8
+// last-edited: 2026-07-11
+
+// Tests for the searchWithBleve batch-hydration fail-open path (INIT-4 T3).
+// GetBookByID's per-hit loop was replaced with a single GetBooksByIDs call
+// (see pebble_store_books_by_ids_test.go for the store-level getter
+// contract); this file pins the service-level fail-open contract: a
+// non-nil error from GetBooksByIDs must never fail the whole search
+// request, only shrink the page to whatever rows were hydrated.
+
+package audiobooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestSearchWithBleveHydrationErrorPartialPage covers spec §C3 parity: when
+// GetBooksByIDs returns (partial rows, error) — e.g. a corrupt row mid-batch
+// per pebble_store_books_by_ids_test.go's ErrorAlongsideRows contract — the
+// service must serve the partial page and log a warning, never propagate
+// the error to the caller (fail-open, mirroring the old per-hit loop's
+// silent-skip-on-error semantics).
+func TestSearchWithBleveHydrationErrorPartialPage(t *testing.T) {
+	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
+	mockStore := mocks.NewMockStore(t)
+
+	hydrateErr := errors.New("unmarshal book \"b3\": unexpected end of JSON input")
+	// Bleve's hit order for equally-scored docs isn't guaranteed to match
+	// seed order, so the "corrupt row" position is determined at call time
+	// from whatever order GetBooksByIDs actually receives — the assertions
+	// below key off that same position rather than assuming b3 is 3rd.
+	var wantHydrated int
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		// Simulate a corrupt row for "b3": return rows read so far
+		// (everything before it) alongside the error, per the getter's
+		// error-alongside-rows contract.
+		partial := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			if id == "b3" {
+				wantHydrated = len(partial)
+				return partial, hydrateErr
+			}
+			partial = append(partial, database.Book{ID: id})
+		}
+		t.Fatal("test setup error: \"b3\" not present in hydration ids")
+		return partial, nil
+	})
+
+	buf := captureWarnLog(t)
+
+	svc := NewAudiobookService(mockStore)
+	svc.SetSearchIndex(idx)
+
+	got, err := svc.GetAudiobooks(context.Background(), 50, 0, "author:sanderson", nil, nil, ListFilters{})
+	assert.NoError(t, err, "hydration error must never fail the whole search request")
+	assert.Len(t, got, wantHydrated, "partial page: only rows hydrated before the corrupt row are served")
+	assert.Contains(t, buf.String(), "search: batch hydrate failed; serving partial page")
+	assert.Contains(t, buf.String(), fmt.Sprintf("hydrated=%d", wantHydrated))
+}

--- a/internal/audiobooks/service_query_search_per_user_test.go
+++ b/internal/audiobooks/service_query_search_per_user_test.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query_search_per_user_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e3a7c1d9-4b2f-4a68-9c1e-5f8a2d3b7c40
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 // Tests for the searchWithBleve per-user DSL filter fix (INIT-4 T2).
 // read_status / progress_pct / last_played filters are peeled off by
@@ -67,8 +67,12 @@ func captureWarnLog(t *testing.T) *bytes.Buffer {
 func TestSearchWithBleveAppliesReadStatusFilter(t *testing.T) {
 	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	mockStore.EXPECT().GetUserBookState("alice", "b1").
 		Return(&database.UserBookState{Status: database.UserBookStatusInProgress}, nil)
@@ -92,8 +96,12 @@ func TestSearchWithBleveAppliesReadStatusFilter(t *testing.T) {
 func TestSearchWithBleveNoFilterQueryUnchanged(t *testing.T) {
 	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 
 	svc := NewAudiobookService(mockStore)
@@ -117,8 +125,12 @@ func TestSearchWithBleveNoFilterQueryUnchanged(t *testing.T) {
 func TestSearchWithBlevePaginationAfterFilter(t *testing.T) {
 	idx := buildSearchTestIndex(t, "b1", "b2", "b3", "b4", "b5")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	inProgress := &database.UserBookState{Status: database.UserBookStatusInProgress}
 	finished := &database.UserBookState{Status: database.UserBookStatusFinished}
@@ -143,8 +155,12 @@ func TestSearchWithBlevePaginationAfterFilter(t *testing.T) {
 func TestSearchWithBleveEmptyUserIDReturnsAllMatches(t *testing.T) {
 	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	// No GetUserBookState expectation set — asserting the code path
 	// never calls it when userID == "".
@@ -170,8 +186,12 @@ func TestSearchWithBleveEmptyUserIDReturnsAllMatches(t *testing.T) {
 func TestSearchWithBleveStateErrorFailsOpen(t *testing.T) {
 	idx := buildSearchTestIndex(t, "b1", "b2")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	mockStore.EXPECT().GetUserBookState("alice", "b1").
 		Return(nil, fmt.Errorf("pebble: i/o error"))
@@ -203,8 +223,12 @@ func TestSearchWithBleveWindowExhaustionWarns(t *testing.T) {
 	idx := buildSearchTestIndex(t, ids...)
 
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	// Every state read returns nil,nil (no record) -> zero-value state.
 	// Filter is negated read_status:finished so the zero-value state
@@ -234,8 +258,12 @@ func TestSearchWithBleveKillSwitchDrops(t *testing.T) {
 
 	idx := buildSearchTestIndex(t, "b1", "b2", "b3")
 	mockStore := mocks.NewMockStore(t)
-	mockStore.EXPECT().GetBookByID(mock.Anything).RunAndReturn(func(id string) (*database.Book, error) {
-		return &database.Book{ID: id}, nil
+	mockStore.EXPECT().GetBooksByIDs(mock.Anything).RunAndReturn(func(ids []string) ([]database.Book, error) {
+		books := make([]database.Book, 0, len(ids))
+		for _, id := range ids {
+			books = append(books, database.Book{ID: id})
+		}
+		return books, nil
 	})
 	// No GetUserBookState expectation: the kill switch must prevent any
 	// state reads at all — an unexpected call here fails the test.

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,6 +1,6 @@
 // file: internal/batch/service_test.go
-// version: 1.0.9
-// last-edited: 2026-07-07
+// version: 1.1.0
+// last-edited: 2026-07-11
 // guid: b2c3d4e5-f6a7-b8c9-0d1e-2f3a4b5c6d7e
 
 package batch
@@ -59,6 +59,23 @@ func (m *MockBookStore) GetBookByID(id string) (*database.Book, error) {
 		FilePath:             book.FilePath,
 		LibraryState:         book.LibraryState,
 	}, nil
+}
+
+// GetBooksByIDs is a test double for the interface-ripple from INIT-4 T3:
+// order-preserving, skip-missing, built on top of GetBookByID so it stays
+// consistent with the existing deep-copy semantics above.
+func (m *MockBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	books := make([]database.Book, 0, len(ids))
+	for _, id := range ids {
+		b, err := m.GetBookByID(id)
+		if err != nil {
+			return books, err
+		}
+		if b != nil {
+			books = append(books, *b)
+		}
+	}
+	return books, nil
 }
 
 func (m *MockBookStore) UpdateBook(id string, book *database.Book) (*database.Book, error) {

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.10.0
+// version: 2.11.0
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-07-07
+// last-edited: 2026-07-10
 
 package database
 
@@ -26,6 +26,11 @@ type UpdateBookRatingRequest struct {
 // read books. See spec 2026-04-17-store-interface-segregation-design.md.
 type BookReader interface {
 	GetBookByID(id string) (*Book, error)
+	// GetBooksByIDs returns the full Book rows for ids, preserving input
+	// order and silently skipping IDs that do not resolve (mirrors
+	// GetBookByID's nil-on-not-found). Full fidelity: reads the complete
+	// book:<id> row — heavy fields (AcoustIDFingerprint etc.) intact.
+	GetBooksByIDs(ids []string) ([]Book, error)
 	// GetAllBooksCore is Core-typed (STOREFID W5a/W5z): the return type is
 	// BookCore, not Book, so the nine heavy fields (Description,
 	// VersionNotes, BookSigV1, BookSigV1Mask, BookSigSegments,

--- a/internal/database/iface_book.go
+++ b/internal/database/iface_book.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_book.go
-// version: 2.11.0
+// version: 2.11.1
 // guid: 668ec5a2-f8d9-4fdb-b0d5-09937b5d83ea
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package database
 

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -33,6 +33,7 @@ var _ Store = (*MockStore)(nil)
 type MockStore struct {
 	// Book methods
 	GetBookByIDFunc       func(id string) (*Book, error)
+	GetBooksByIDsFunc     func(ids []string) ([]Book, error)
 	GetBookByFilePathFunc func(path string) (*Book, error)
 	// GetAllBooksFunc is test-only plumbing (NOT a Store interface method —
 	// GetAllBooks was removed from the interface in STOREFID W5z). Several
@@ -703,6 +704,13 @@ func (m *MockStore) GetAllBookSummaries(limit, offset int) ([]BookSummary, error
 func (m *MockStore) GetBookByID(id string) (*Book, error) {
 	if m.GetBookByIDFunc != nil {
 		return m.GetBookByIDFunc(id)
+	}
+	return nil, nil
+}
+
+func (m *MockStore) GetBooksByIDs(ids []string) ([]Book, error) {
+	if m.GetBooksByIDsFunc != nil {
+		return m.GetBooksByIDsFunc(ids)
 	}
 	return nil, nil
 }

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.79.0
+// version: 1.80.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package database
 

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3225,68 +3225,6 @@ func (_c *MockBookReader_GetBookByID_Call) RunAndReturn(run func(id string) (*da
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockBookReader
-func (_mock *MockBookReader) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockBookReader_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockBookReader_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockBookReader_Expecter) GetBooksByIDs(ids any) *MockBookReader_GetBooksByIDs_Call {
-	return &MockBookReader_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockBookReader_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookReader_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockBookReader_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockBookReader_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookReader_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -3735,6 +3673,68 @@ func (_c *MockBookReader_GetBooksByAuthorIDCore_Call) Return(bookCores []databas
 }
 
 func (_c *MockBookReader_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockBookReader_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockBookReader_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockBookReader_Expecter) GetBooksByIDs(ids any) *MockBookReader_GetBooksByIDs_Call {
+	return &MockBookReader_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookReader_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookReader_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6668,68 +6668,6 @@ func (_c *MockBookStore_GetBookByID_Call) RunAndReturn(run func(id string) (*dat
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockBookStore
-func (_mock *MockBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockBookStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockBookStore_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockBookStore_Expecter) GetBooksByIDs(ids any) *MockBookStore_GetBooksByIDs_Call {
-	return &MockBookStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockBookStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookStore_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockBookStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockBookStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookStore_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockBookStore
 func (_mock *MockBookStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -7178,6 +7116,68 @@ func (_c *MockBookStore_GetBooksByAuthorIDCore_Call) Return(bookCores []database
 }
 
 func (_c *MockBookStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockBookStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockBookStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockBookStore_Expecter) GetBooksByIDs(ids any) *MockBookStore_GetBooksByIDs_Call {
+	return &MockBookStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -36035,68 +36035,6 @@ func (_c *MockStore_GetBookByID_Call) RunAndReturn(run func(id string) (*databas
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockStore
-func (_mock *MockStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockStore_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockStore_Expecter) GetBooksByIDs(ids any) *MockStore_GetBooksByIDs_Call {
-	return &MockStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockStore_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockStore_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockStore_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockStore
 func (_mock *MockStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -38100,6 +38038,68 @@ func (_c *MockStore_GetBooksByAuthorIDWithRoleCore_Call) Return(bookCores []data
 }
 
 func (_c *MockStore_GetBooksByAuthorIDWithRoleCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockStore_GetBooksByAuthorIDWithRoleCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockStore_Expecter) GetBooksByIDs(ids any) *MockStore_GetBooksByIDs_Call {
+	return &MockStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -3225,6 +3225,68 @@ func (_c *MockBookReader_GetBookByID_Call) RunAndReturn(run func(id string) (*da
 	return _c
 }
 
+// GetBooksByIDs provides a mock function for the type MockBookReader
+func (_mock *MockBookReader) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookReader_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockBookReader_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockBookReader_Expecter) GetBooksByIDs(ids any) *MockBookReader_GetBooksByIDs_Call {
+	return &MockBookReader_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookReader_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookReader_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookReader_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookReader_GetBooksByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookByITunesPersistentID provides a mock function for the type MockBookReader
 func (_mock *MockBookReader) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -6602,6 +6664,68 @@ func (_c *MockBookStore_GetBookByID_Call) Return(book *database.Book, err error)
 }
 
 func (_c *MockBookStore_GetBookByID_Call) RunAndReturn(run func(id string) (*database.Book, error)) *MockBookStore_GetBookByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockBookStore
+func (_mock *MockBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBookStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockBookStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockBookStore_Expecter) GetBooksByIDs(ids any) *MockBookStore_GetBooksByIDs_Call {
+	return &MockBookStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockBookStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockBookStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockBookStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockBookStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -35907,6 +36031,68 @@ func (_c *MockStore_GetBookByID_Call) Return(book *database.Book, err error) *Mo
 }
 
 func (_c *MockStore_GetBookByID_Call) RunAndReturn(run func(id string) (*database.Book, error)) *MockStore_GetBookByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockStore
+func (_mock *MockStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockStore_Expecter) GetBooksByIDs(ids any) *MockStore_GetBooksByIDs_Call {
+	return &MockStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.111.0
+// version: 1.112.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package database
 

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -760,6 +760,47 @@ func (p *PebbleStore) GetBookByID(id string) (*Book, error) {
 	return &book, nil
 }
 
+// GetBooksByIDs returns the full Book rows for ids, preserving input order
+// and silently skipping IDs that do not resolve (mirrors GetBookByID's
+// nil-on-not-found). It reuses GetBookByID's exact read pattern per item —
+// the same book:<id> point-get + json.Unmarshal — so it is full-fidelity,
+// never a memdb-slim projection; heavy fields (AcoustIDFingerprint etc.)
+// survive.
+//
+// Concurrency: this is a plain sequential loop, not a worker pool. Per
+// CLAUDE.md's concurrency rule, that's correct here because callers bound
+// ids to a single request page (searchWithBleve caps at
+// searchPostFilterWindow = 10000 hits), not whole-library scale, and each
+// item is a cheap local Pebble point-get.
+//
+// Error semantics (spec §C3, verbatim contract): a per-item not-found is
+// skipped silently, matching GetBookByID. On the FIRST non-not-found
+// read/unmarshal error, the loop stops and returns the rows read so far
+// ALONGSIDE the error (not a bare nil, err) so the caller can still serve a
+// partial page instead of failing the whole request.
+func (p *PebbleStore) GetBooksByIDs(ids []string) ([]Book, error) {
+	books := make([]Book, 0, len(ids))
+	for _, id := range ids {
+		key := []byte(fmt.Sprintf("book:%s", id))
+		value, closer, err := p.db.Get(key)
+		if err == pebble.ErrNotFound {
+			continue
+		}
+		if err != nil {
+			return books, fmt.Errorf("get book %q: %w", id, err)
+		}
+
+		var book Book
+		unmarshalErr := json.Unmarshal(value, &book)
+		closer.Close()
+		if unmarshalErr != nil {
+			return books, fmt.Errorf("unmarshal book %q: %w", id, unmarshalErr)
+		}
+		books = append(books, book)
+	}
+	return books, nil
+}
+
 func (p *PebbleStore) GetBookByFilePath(path string) (*Book, error) {
 	indexKey := []byte(fmt.Sprintf("book:path:%s", path))
 	value, closer, err := p.db.Get(indexKey)

--- a/internal/database/pebble_store_books_by_ids_test.go
+++ b/internal/database/pebble_store_books_by_ids_test.go
@@ -1,0 +1,186 @@
+// file: internal/database/pebble_store_books_by_ids_test.go
+// version: 1.0.0
+// guid: 7e5d4c3b-2a19-4f8e-9d0c-1b2a3c4d5e6f
+// last-edited: 2026-07-11
+
+package database
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newPebbleStoreForBooksByIDs mirrors newPebbleStoreForLSH's setup pattern
+// (see pebble_store_lsh_test.go) for a fresh, isolated PebbleStore per test.
+func newPebbleStoreForBooksByIDs(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "books-by-ids-db"))
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func mustCreateBookForBatch(t *testing.T, store *PebbleStore, id, title string) *Book {
+	t.Helper()
+	book := &Book{
+		ID:       id,
+		Title:    title,
+		FilePath: "/tmp/" + id + "-" + title + ".mp3",
+	}
+	created, err := store.CreateBook(book)
+	if err != nil {
+		t.Fatalf("CreateBook %s: %v", id, err)
+	}
+	return created
+}
+
+// TestGetBooksByIDs_OrderPreserved asserts the batch getter returns rows in
+// the same order as the requested ids, not storage/insertion order.
+func TestGetBooksByIDs_OrderPreserved(t *testing.T) {
+	store := newPebbleStoreForBooksByIDs(t)
+	a := mustCreateBookForBatch(t, store, "book-a", "Alpha")
+	b := mustCreateBookForBatch(t, store, "book-b", "Bravo")
+	c := mustCreateBookForBatch(t, store, "book-c", "Charlie")
+
+	got, err := store.GetBooksByIDs([]string{c.ID, a.ID, b.ID})
+	if err != nil {
+		t.Fatalf("GetBooksByIDs: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 books, got %d", len(got))
+	}
+	wantOrder := []string{c.ID, a.ID, b.ID}
+	for i, id := range wantOrder {
+		if got[i].ID != id {
+			t.Errorf("index %d: got ID %q, want %q (order not preserved)", i, got[i].ID, id)
+		}
+	}
+}
+
+// TestGetBooksByIDs_UnknownIDSkipped asserts an ID that does not resolve is
+// silently skipped, matching GetBookByID's nil-on-not-found semantics —
+// no error, and the result simply omits that row.
+func TestGetBooksByIDs_UnknownIDSkipped(t *testing.T) {
+	store := newPebbleStoreForBooksByIDs(t)
+	a := mustCreateBookForBatch(t, store, "book-a", "Alpha")
+
+	got, err := store.GetBooksByIDs([]string{a.ID, "does-not-exist"})
+	if err != nil {
+		t.Fatalf("GetBooksByIDs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 book (unknown ID skipped), got %d", len(got))
+	}
+	if got[0].ID != a.ID {
+		t.Errorf("got ID %q, want %q", got[0].ID, a.ID)
+	}
+}
+
+// TestGetBooksByIDs_EmptyInput asserts empty ids returns a non-nil empty
+// slice (never nil) and a nil error.
+func TestGetBooksByIDs_EmptyInput(t *testing.T) {
+	store := newPebbleStoreForBooksByIDs(t)
+
+	got, err := store.GetBooksByIDs([]string{})
+	if err != nil {
+		t.Fatalf("GetBooksByIDs: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d entries", len(got))
+	}
+}
+
+// TestGetBooksByIDs_Fidelity asserts the batch getter is full-fidelity — it
+// reuses GetBookByID's exact book:<id> point-get + json.Unmarshal, so heavy
+// fields (Description, VersionNotes, BookSigV1 family) survive the round
+// trip rather than being dropped by a memdb-slim projection.
+func TestGetBooksByIDs_Fidelity(t *testing.T) {
+	store := newPebbleStoreForBooksByIDs(t)
+
+	desc := "a long description with plot details"
+	versionNotes := "remastered edition notes"
+	bookSigV1 := "b64-signature-payload"
+	bookSigMask := "b64-coverage-mask"
+	bookSigSegments := 4096
+	bookSigCoveragePct := 87
+	bookSigBuiltAt := time.Now().UTC().Truncate(time.Second)
+
+	book := &Book{
+		ID:                 "book-heavy",
+		Title:              "Heavy Fields",
+		FilePath:           "/tmp/book-heavy.mp3",
+		Description:        &desc,
+		VersionNotes:       &versionNotes,
+		BookSigV1:          &bookSigV1,
+		BookSigV1Mask:      &bookSigMask,
+		BookSigSegments:    &bookSigSegments,
+		BookSigCoveragePct: &bookSigCoveragePct,
+		BookSigBuiltAt:     &bookSigBuiltAt,
+	}
+	created, err := store.CreateBook(book)
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	got, err := store.GetBooksByIDs([]string{created.ID})
+	if err != nil {
+		t.Fatalf("GetBooksByIDs: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(got))
+	}
+	row := got[0]
+	if row.Description == nil || *row.Description != desc {
+		t.Errorf("Description not full-fidelity: got %v, want %q", row.Description, desc)
+	}
+	if row.VersionNotes == nil || *row.VersionNotes != versionNotes {
+		t.Errorf("VersionNotes not full-fidelity: got %v, want %q", row.VersionNotes, versionNotes)
+	}
+	if row.BookSigV1 == nil || *row.BookSigV1 != bookSigV1 {
+		t.Errorf("BookSigV1 not full-fidelity: got %v, want %q", row.BookSigV1, bookSigV1)
+	}
+	if row.BookSigV1Mask == nil || *row.BookSigV1Mask != bookSigMask {
+		t.Errorf("BookSigV1Mask not full-fidelity: got %v, want %q", row.BookSigV1Mask, bookSigMask)
+	}
+	if row.BookSigSegments == nil || *row.BookSigSegments != bookSigSegments {
+		t.Errorf("BookSigSegments not full-fidelity: got %v, want %d", row.BookSigSegments, bookSigSegments)
+	}
+	if row.BookSigCoveragePct == nil || *row.BookSigCoveragePct != bookSigCoveragePct {
+		t.Errorf("BookSigCoveragePct not full-fidelity: got %v, want %d", row.BookSigCoveragePct, bookSigCoveragePct)
+	}
+	if row.BookSigBuiltAt == nil || !row.BookSigBuiltAt.Equal(bookSigBuiltAt) {
+		t.Errorf("BookSigBuiltAt not full-fidelity: got %v, want %v", row.BookSigBuiltAt, bookSigBuiltAt)
+	}
+}
+
+// TestGetBooksByIDs_ErrorAlongsideRows asserts the spec §C3 contract: on the
+// first non-not-found error (here, a corrupt/unmarshalable row mid-batch),
+// the getter returns the rows read so far ALONGSIDE the error — never a
+// bare (nil, err) — so the caller can still serve a partial page.
+func TestGetBooksByIDs_ErrorAlongsideRows(t *testing.T) {
+	store := newPebbleStoreForBooksByIDs(t)
+	a := mustCreateBookForBatch(t, store, "book-a", "Alpha")
+	b := mustCreateBookForBatch(t, store, "book-b", "Bravo")
+
+	// Directly write an unparsable value under a book:<id> key, bypassing
+	// CreateBook, to simulate a corrupt row mid-batch.
+	corruptID := "book-corrupt"
+	if err := store.db.Set([]byte(fmt.Sprintf("book:%s", corruptID)), []byte("{not valid json"), nil); err != nil {
+		t.Fatalf("seed corrupt row: %v", err)
+	}
+
+	got, err := store.GetBooksByIDs([]string{a.ID, corruptID, b.ID})
+	if err == nil {
+		t.Fatal("expected a non-nil error for the corrupt row")
+	}
+	if len(got) != 1 || got[0].ID != a.ID {
+		t.Fatalf("expected rows-read-so-far [%s], got %+v", a.ID, got)
+	}
+}

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -1,6 +1,6 @@
 // file: internal/itunes/rebuild_test.go
-// version: 1.0.8
-// last-edited: 2026-07-07
+// version: 1.0.9
+// last-edited: 2026-07-11
 // guid: 1c2d3e4f-5a6b-7c8d-9e0f-1a2b3c4d5e6f
 
 package itunes
@@ -70,6 +70,23 @@ func (m *mockRebuildStore) GetBookByID(id string) (*database.Book, error) {
 		return book, nil
 	}
 	return nil, nil
+}
+
+// GetBooksByIDs is a test double for the interface-ripple from INIT-4 T3:
+// order-preserving, skip-missing, built on top of GetBookByID so it stays
+// consistent with the existing lookup-by-ID semantics above.
+func (m *mockRebuildStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	books := make([]database.Book, 0, len(ids))
+	for _, id := range ids {
+		b, err := m.GetBookByID(id)
+		if err != nil {
+			return books, err
+		}
+		if b != nil {
+			books = append(books, *b)
+		}
+	}
+	return books, nil
 }
 
 func (m *mockRebuildStore) CountAllBooks() (int, error)     { return 0, nil }

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -1176,68 +1176,6 @@ func (_c *MockMetadataStore_GetBookByID_Call) RunAndReturn(run func(id string) (
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockMetadataStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockMetadataStore_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockMetadataStore_Expecter) GetBooksByIDs(ids any) *MockMetadataStore_GetBooksByIDs_Call {
-	return &MockMetadataStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockMetadataStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockMetadataStore_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockMetadataStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockMetadataStore_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockMetadataStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockMetadataStore_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -1686,6 +1624,68 @@ func (_c *MockMetadataStore_GetBooksByAuthorIDCore_Call) Return(bookCores []data
 }
 
 func (_c *MockMetadataStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockMetadataStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockMetadataStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockMetadataStore_Expecter) GetBooksByIDs(ids any) *MockMetadataStore_GetBooksByIDs_Call {
+	return &MockMetadataStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockMetadataStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockMetadataStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockMetadataStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -1176,6 +1176,68 @@ func (_c *MockMetadataStore_GetBookByID_Call) RunAndReturn(run func(id string) (
 	return _c
 }
 
+// GetBooksByIDs provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockMetadataStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockMetadataStore_Expecter) GetBooksByIDs(ids any) *MockMetadataStore_GetBooksByIDs_Call {
+	return &MockMetadataStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockMetadataStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockMetadataStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockMetadataStore_GetBooksByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookByITunesPersistentID provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -825,6 +825,68 @@ func (_c *MockPlaylistStore_GetBookByID_Call) RunAndReturn(run func(id string) (
 	return _c
 }
 
+// GetBooksByIDs provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlaylistStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockPlaylistStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockPlaylistStore_Expecter) GetBooksByIDs(ids any) *MockPlaylistStore_GetBooksByIDs_Call {
+	return &MockPlaylistStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockPlaylistStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockPlaylistStore_GetBooksByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookByITunesPersistentID provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)

--- a/internal/server/handlers/mocks/mock_playlist_store.go
+++ b/internal/server/handlers/mocks/mock_playlist_store.go
@@ -825,68 +825,6 @@ func (_c *MockPlaylistStore_GetBookByID_Call) RunAndReturn(run func(id string) (
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockPlaylistStore
-func (_mock *MockPlaylistStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockPlaylistStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockPlaylistStore_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockPlaylistStore_Expecter) GetBooksByIDs(ids any) *MockPlaylistStore_GetBooksByIDs_Call {
-	return &MockPlaylistStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockPlaylistStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockPlaylistStore_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockPlaylistStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockPlaylistStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockPlaylistStore_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockPlaylistStore
 func (_mock *MockPlaylistStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -1335,6 +1273,68 @@ func (_c *MockPlaylistStore_GetBooksByAuthorIDCore_Call) Return(bookCores []data
 }
 
 func (_c *MockPlaylistStore_GetBooksByAuthorIDCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockPlaylistStore_GetBooksByAuthorIDCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockPlaylistStore
+func (_mock *MockPlaylistStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPlaylistStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockPlaylistStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockPlaylistStore_Expecter) GetBooksByIDs(ids any) *MockPlaylistStore_GetBooksByIDs_Call {
+	return &MockPlaylistStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockPlaylistStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockPlaylistStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockPlaylistStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockPlaylistStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -2518,68 +2518,6 @@ func (_c *MockOperationsStore_GetBookByID_Call) RunAndReturn(run func(id string)
 	return _c
 }
 
-// GetBooksByIDs provides a mock function for the type MockOperationsStore
-func (_mock *MockOperationsStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
-	ret := _mock.Called(ids)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBooksByIDs")
-	}
-
-	var r0 []database.Book
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
-		return returnFunc(ids)
-	}
-	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
-		r0 = returnFunc(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.Book)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = returnFunc(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockOperationsStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
-type MockOperationsStore_GetBooksByIDs_Call struct {
-	*mock.Call
-}
-
-// GetBooksByIDs is a helper method to define mock.On call
-//   - ids []string
-func (_e *MockOperationsStore_Expecter) GetBooksByIDs(ids any) *MockOperationsStore_GetBooksByIDs_Call {
-	return &MockOperationsStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
-}
-
-func (_c *MockOperationsStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockOperationsStore_GetBooksByIDs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []string
-		if args[0] != nil {
-			arg0 = args[0].([]string)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockOperationsStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockOperationsStore_GetBooksByIDs_Call {
-	_c.Call.Return(books, err)
-	return _c
-}
-
-func (_c *MockOperationsStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockOperationsStore_GetBooksByIDs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetBookByITunesPersistentID provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)
@@ -3214,6 +3152,68 @@ func (_c *MockOperationsStore_GetBooksByAuthorIDWithRoleCore_Call) Return(bookCo
 }
 
 func (_c *MockOperationsStore_GetBooksByAuthorIDWithRoleCore_Call) RunAndReturn(run func(authorID int) ([]database.BookCore, error)) *MockOperationsStore_GetBooksByAuthorIDWithRoleCore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetBooksByIDs provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperationsStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockOperationsStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockOperationsStore_Expecter) GetBooksByIDs(ids any) *MockOperationsStore_GetBooksByIDs_Call {
+	return &MockOperationsStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockOperationsStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockOperationsStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockOperationsStore_GetBooksByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/handlers/operations/mocks/mock_operations_store.go
+++ b/internal/server/handlers/operations/mocks/mock_operations_store.go
@@ -2518,6 +2518,68 @@ func (_c *MockOperationsStore_GetBookByID_Call) RunAndReturn(run func(id string)
 	return _c
 }
 
+// GetBooksByIDs provides a mock function for the type MockOperationsStore
+func (_mock *MockOperationsStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBooksByIDs")
+	}
+
+	var r0 []database.Book
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func([]string) ([]database.Book, error)); ok {
+		return returnFunc(ids)
+	}
+	if returnFunc, ok := ret.Get(0).(func([]string) []database.Book); ok {
+		r0 = returnFunc(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.Book)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = returnFunc(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockOperationsStore_GetBooksByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBooksByIDs'
+type MockOperationsStore_GetBooksByIDs_Call struct {
+	*mock.Call
+}
+
+// GetBooksByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockOperationsStore_Expecter) GetBooksByIDs(ids any) *MockOperationsStore_GetBooksByIDs_Call {
+	return &MockOperationsStore_GetBooksByIDs_Call{Call: _e.mock.On("GetBooksByIDs", ids)}
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) Run(run func(ids []string)) *MockOperationsStore_GetBooksByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) Return(books []database.Book, err error) *MockOperationsStore_GetBooksByIDs_Call {
+	_c.Call.Return(books, err)
+	return _c
+}
+
+func (_c *MockOperationsStore_GetBooksByIDs_Call) RunAndReturn(run func(ids []string) ([]database.Book, error)) *MockOperationsStore_GetBooksByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBookByITunesPersistentID provides a mock function for the type MockOperationsStore
 func (_mock *MockOperationsStore) GetBookByITunesPersistentID(persistentID string) (*database.Book, error) {
 	ret := _mock.Called(persistentID)

--- a/internal/sweep/sweeper_test.go
+++ b/internal/sweep/sweeper_test.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8910-abcd-ef2345678902
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 
 package sweep
 
@@ -41,6 +41,23 @@ func (m *MockBookStore) GetBookByID(id string) (*database.Book, error) {
 		}
 	}
 	return nil, nil
+}
+
+// GetBooksByIDs is a test double for the interface-ripple from INIT-4 T3:
+// order-preserving, skip-missing, built on top of GetBookByID so it stays
+// consistent with the existing lookup-by-ID semantics above.
+func (m *MockBookStore) GetBooksByIDs(ids []string) ([]database.Book, error) {
+	books := make([]database.Book, 0, len(ids))
+	for _, id := range ids {
+		b, err := m.GetBookByID(id)
+		if err != nil {
+			return books, err
+		}
+		if b != nil {
+			books = append(books, *b)
+		}
+	}
+	return books, nil
 }
 
 func (m *MockBookStore) DeleteBookTombstone(id string) error {


### PR DESCRIPTION
## Summary

- `searchWithBleve` fetched every hit one-by-one via `GetBookByID`. Adds an order-preserving, skip-missing, full-fidelity batch getter `GetBooksByIDs(ids []string) ([]Book, error)` to `BookReader` (PebbleStore impl mirrors the single-get's `book:<id>` point read, sequential loop — bounded by the request page size, not whole-library scale) and uses it for both hydration sites in `searchWithBleve`. Behavior invariant; one store call per page instead of N.
- Error semantics (spec §C3): the getter returns rows-read-so-far **alongside** a non-not-found error (never a bare `nil, err`); the call site fails OPEN — `slog.Warn`s and serves the partial page, never fails the whole search request on one bad row.
- **Interface-ripple fix**: this WIP branch had a killed prior session that added the interface method but did not fix consumers. This PR hand-fixes every mock/fake that implements `BookReader`/`BookStore` and broke as a result: `internal/batch` and `internal/sweep`'s hand-written `MockBookStore` fakes, `internal/itunes`'s `mockRebuildStore` fake, and three mockery-generated store mocks (`handlers.MockPlaylistStore`, `metadata.MockMetadataStore`, `operations.MockOperationsStore`) that transitively embed `BookReader`/`BookStore`. No mockery regeneration was run (version-drift footgun) — all hand-edited, mirroring each file's existing `GetBookByID` method style.
- Fixes the existing `searchWithBleve` per-user-filter test suite, which stubbed `GetBookByID` and broke once the hydration sites switched to `GetBooksByIDs`.

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `go test ./... -short` — full repo green. `internal/server` alone hit the documented load-induced 10-minute stall flake when run concurrently with another agent's `-race` suite on the same machine (goroutine dump shows only idle `FileIOPool`/`nutsdb` worker goroutines and an unrelated `TestListAudiobookVersions`, zero references to `GetBooksByIDs`/`searchWithBleve`); re-ran `internal/server` alone and it passed in 490s.
- [x] New tests: `internal/database/pebble_store_books_by_ids_test.go` (order preservation, unknown-ID skip, empty-input, full-fidelity round trip, error-alongside-rows) and `TestSearchWithBleveHydrationErrorPartialPage` (fail-open partial-page serving on hydration error).
- [x] `git diff --stat` — 14 files; 3 mockery-generated mock files touched beyond the brief's single-mock acceptance line are a required ripple fix (documented in PR description above), not scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv