### PR TITLE
perf(dedup): shard full-scan emit() mutex; move book lookups off the pair lock (INIT-2 T5, CONC-3)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.56.0
+// version: 1.57.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-08
+// last-edited: 2026-07-11
 
 package dedup
 
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/ai"
@@ -3633,6 +3634,93 @@ func minLevenshteinBetweenForms(a, b []string) int {
 	return minDist
 }
 
+// acoustidEmitShardCount is the number of independent mutex/map shards the
+// full-scan emit() uses to track which canonical pair keys it has already
+// handled. 16 keeps lock contention negligible under a runtime.NumCPU()
+// worker pool while staying small enough that the final count() scan is
+// trivial.
+const acoustidEmitShardCount = 16
+
+// acoustidEmitShard is one bucket of the sharded "already handled this pair"
+// set: a mutex guarding its own map. A canonical pair key always hashes to
+// the same shard, so all operations on a given pair serialize on one mutex.
+type acoustidEmitShard struct {
+	mu      sync.Mutex
+	handled map[string]struct{}
+}
+
+// acoustidEmitShards replaces the single global emit() mutex (CONC-3). It
+// shards the per-pair check-then-set across acoustidEmitShardCount mutexes so
+// the NumCPU worker pool no longer serializes behind one lock, while
+// preserving the invariant that matters: because the SAME canonical pair key
+// always hashes (FNV-1a) to the SAME shard, two workers can never both
+// observe a pair as unhandled and both emit it. Distinct pairs on different
+// shards proceed in parallel; distinct pairs that collide on a shard still
+// each get their own map entry, so no emission is ever lost.
+type acoustidEmitShards [acoustidEmitShardCount]acoustidEmitShard
+
+// newAcoustidEmitShards returns a ready-to-use shard set with every bucket's
+// map initialized.
+func newAcoustidEmitShards() *acoustidEmitShards {
+	s := &acoustidEmitShards{}
+	for i := range s {
+		s[i].handled = make(map[string]struct{})
+	}
+	return s
+}
+
+// fnv1aStr is an allocation-free FNV-1a hash of s, used to pick a pair's
+// shard. Same string always maps to the same shard.
+func fnv1aStr(s string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	h := uint32(offset32)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
+}
+
+// shardFor returns the shard that owns key. The same key always resolves to
+// the same shard, which is what makes mark()'s check-then-set atomic per pair.
+func (s *acoustidEmitShards) shardFor(key string) *acoustidEmitShard {
+	return &s[fnv1aStr(key)%acoustidEmitShardCount]
+}
+
+// mark records key as handled and returns true ONLY the first time it is
+// called for that key (across all goroutines). The check-then-insert runs
+// under the key's shard mutex, so two workers can never both see the key as
+// unhandled — this is the per-pair check-then-set atomicity the CONC-3
+// comment mandates, now scoped to one shard instead of a global lock. It
+// touches only in-memory map state (never a store write), so holding the
+// shard mutex across it is safe; callers perform any store write AFTER mark()
+// returns and the shard lock is released.
+func (s *acoustidEmitShards) mark(key string) bool {
+	sh := s.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if _, ok := sh.handled[key]; ok {
+		return false
+	}
+	sh.handled[key] = struct{}{}
+	return true
+}
+
+// count returns the total number of distinct handled pair keys across all
+// shards (for the completion log's emitted_count).
+func (s *acoustidEmitShards) count() int {
+	n := 0
+	for i := range s {
+		s[i].mu.Lock()
+		n += len(s[i].handled)
+		s[i].mu.Unlock()
+	}
+	return n
+}
+
 // AcoustIDScan walks all primary books, extracts their stored acoustic
 // fingerprint segments, and emits DedupCandidate rows (layer="acoustid")
 // for any two books whose audio content matches.
@@ -3670,36 +3758,77 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	// CONC-3 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md):
 	// This per-book loop is embarrassingly parallel — each book's LSH lookup
-	// + Tier-1 segment walk only reads that book's own files — but it shares
-	// FOUR maps + a counter across every book, all mutated inside emit()/the
-	// loop: booksByID, boilerplateBookCache, parentDirCache, emitted, and
-	// identifierGateDrops. mu guards all five. Following TASK-01's
-	// (BookSignatureScan) pattern, the ENTIRE emit() body runs under mu: the
-	// emitted-key check-then-set must be atomic across workers (splitting it
-	// into separate lock/unlock windows would let two workers both pass the
-	// "not already emitted" check for the same pair and double-upsert), and
-	// emits are rare relative to the LSH/segment-walk traffic that stays
-	// lock-free, so this keeps the parallelized work on the hot path.
-	var mu sync.Mutex
-	// isBoilerplateBook is only called from within the locked emit() body
-	// below — mu is already held, so no internal locking here.
+	// + Tier-1 segment walk only reads that book's own files — and runs on a
+	// runtime.NumCPU() worker pool via registry.RunItems below. It used to
+	// funnel every emit() through ONE global mutex (which also held that lock
+	// across the fallback GetBookByID/GetBookFiles store reads), so one
+	// straggling store read stalled every worker. That single lock is now
+	// split two ways:
+	//
+	//  1. Per-pair "already handled" state lives in emitShards: the canonical
+	//     pair key is hashed (FNV-1a) to one of acoustidEmitShardCount shard
+	//     mutexes, and emitShards.mark(key) does the check-then-set under that
+	//     one shard's lock. Because the SAME pair always hashes to the SAME
+	//     shard, the check-then-set stays atomic per pair — two workers can
+	//     never both see a pair as unhandled and both upsert it — which is the
+	//     exact invariant the old global lock guaranteed, now without
+	//     serializing unrelated pairs.
+	//  2. Per-book caches (booksByID, boilerplateBookCache, parentDirCache)
+	//     move behind bookCacheMu, a small dedicated mutex used only inside the
+	//     three gate helpers. Crucially their fallback store reads run OUTSIDE
+	//     any lock (double-checked: read cache under bookCacheMu, miss ⇒ unlock
+	//     ⇒ store read ⇒ relock ⇒ recheck-then-store), so no store read ever
+	//     executes under a pair-shard lock (PR #1855: never hold a lock across
+	//     a Pebble commit). A duplicate concurrent fetch of the same book is
+	//     acceptable — the reads are idempotent and the results deterministic.
+	//
+	// The three gates (boilerplate, identifier-conflict, same-directory) are
+	// deterministic pure functions of the two books' immutable-during-scan
+	// data, so emit() evaluates them BEFORE claiming the shard. Only the
+	// mark() check-then-set needs per-pair atomicity; evaluating the gates
+	// first changes nothing observable (a repeat emit of an already-handled
+	// pair just does a few extra cache-hit reads before mark() returns false).
+	// This is a deliberate deviation from a literal "gates inside the lock"
+	// reading: it is the only arrangement that keeps the lazy store fallbacks
+	// while honoring "no store read under a pair-shard lock".
+	//
+	// identifierGateDrops is an atomic counter (workers increment it
+	// concurrently from the conflict path).
+	var bookCacheMu sync.Mutex
+	// isBoilerplateBook reads/fills boilerplateBookCache under bookCacheMu; on
+	// a miss it does its GetBookByID fallback with NO lock held (the store read
+	// is only reachable for LSH-returned books outside the pre-seeded scan
+	// slice), then recheck-then-stores. Never called under a pair-shard lock.
 	isBoilerplateBook := func(bookID string) bool {
+		bookCacheMu.Lock()
 		if blocked, ok := boilerplateBookCache[bookID]; ok {
+			bookCacheMu.Unlock()
 			return blocked
 		}
+		bookCacheMu.Unlock()
+
 		book, err := de.bookStore.GetBookByID(bookID)
 		if err != nil {
 			slog.Warn("dedup: isBoilerplateBook fallback GetBookByID failed", "book_id", bookID, "err", err)
 		}
 		blocked := err == nil && book != nil && isBoilerplateTitle(book.Title)
+
+		bookCacheMu.Lock()
+		if existing, ok := boilerplateBookCache[bookID]; ok {
+			bookCacheMu.Unlock()
+			return existing
+		}
 		boilerplateBookCache[bookID] = blocked
+		bookCacheMu.Unlock()
 		return blocked
 	}
 
-	// emitted tracks canonical pair keys we've already inserted this run so we
-	// don't call UpsertCandidate multiple times for the same pair (can happen
-	// when two books share several segments). Guarded by mu.
-	emitted := make(map[string]struct{})
+	// emitShards tracks canonical pair keys we've already handled this run so
+	// we never call UpsertCandidate more than once for the same pair (can
+	// happen when two books share several segments, and — since A's worker
+	// emits (A,B) while B's worker emits (B,A) — from two workers at once).
+	// Sharded by pair-key hash; see the CONC-3 comment above.
+	emitShards := newAcoustidEmitShards()
 	pairKey := func(a, b string) string {
 		if a > b {
 			a, b = b, a
@@ -3709,61 +3838,86 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	// Per-book parent-directory cache so we don't fetch BookFiles twice per
 	// comparison. Empty string = unknown / no files / different parents.
-	// Guarded by mu: populated both by the per-book priming step in the
-	// RunItems callback below and lazily inside parentDirForBook (which, like
-	// isBoilerplateBook, is only called from within the locked emit() body).
+	// Guarded by bookCacheMu: populated both by the per-book priming step in
+	// the RunItems callback below and lazily inside parentDirForBook. Like the
+	// other two gate helpers, its GetBookFiles fallback runs with NO lock held.
 	parentDirCache := make(map[string]string)
 	parentDirForBook := func(bookID string) string {
+		bookCacheMu.Lock()
 		if v, ok := parentDirCache[bookID]; ok {
+			bookCacheMu.Unlock()
 			return v
 		}
+		bookCacheMu.Unlock()
+
 		bfs, err := de.bookStore.GetBookFiles(bookID)
-		if err != nil || len(bfs) == 0 {
-			parentDirCache[bookID] = ""
-			return ""
-		}
-		dir := filepath.Dir(bfs[0].FilePath)
-		for _, bf := range bfs[1:] {
-			if filepath.Dir(bf.FilePath) != dir {
-				parentDirCache[bookID] = ""
-				return ""
+		result := ""
+		if err == nil && len(bfs) > 0 {
+			dir := filepath.Dir(bfs[0].FilePath)
+			result = dir
+			for _, bf := range bfs[1:] {
+				if filepath.Dir(bf.FilePath) != dir {
+					result = ""
+					break
+				}
 			}
 		}
-		parentDirCache[bookID] = dir
-		return dir
+
+		bookCacheMu.Lock()
+		if v, ok := parentDirCache[bookID]; ok {
+			bookCacheMu.Unlock()
+			return v
+		}
+		parentDirCache[bookID] = result
+		bookCacheMu.Unlock()
+		return result
 	}
 
-	identifierGateDrops := 0
-	// bookForIdentifierGate is only called from within the locked emit()
-	// body below — mu is already held, so no internal locking here.
+	var identifierGateDrops atomic.Int64
+	// bookForIdentifierGate reads booksByID under bookCacheMu; on a miss it
+	// does its GetBookByID fallback with NO lock held. A book the fallback
+	// cannot fetch (err or nil) yields nil — and identifiersConflict(nil, x)
+	// is false, so an un-fetchable book never blocks emission (conservative,
+	// unchanged). Never called under a pair-shard lock.
 	bookForIdentifierGate := func(bookID string) *database.Book {
+		bookCacheMu.Lock()
 		if b := booksByID[bookID]; b != nil {
+			bookCacheMu.Unlock()
 			return b
 		}
+		bookCacheMu.Unlock()
+
 		b, err := de.bookStore.GetBookByID(bookID)
 		if err != nil || b == nil {
 			return nil
 		}
+
+		bookCacheMu.Lock()
+		if existing := booksByID[bookID]; existing != nil {
+			bookCacheMu.Unlock()
+			return existing
+		}
 		booksByID[bookID] = b
+		bookCacheMu.Unlock()
 		return b
 	}
-	// emit runs the full pair decision + all four-map/counter mutation under
-	// mu (see CONC-3 comment above), so concurrent workers can never
-	// interleave on the same pair key and the guarded state sees exactly the
-	// same sequence of updates the serial scan produced.
+	// emit evaluates the three deterministic gates first (their fallbacks are
+	// safe under bookCacheMu with store reads unlocked), then claims the pair
+	// once via emitShards.mark(). The store upsert runs AFTER mark() returns
+	// and its shard lock is released — mark-before-upsert means a claimed pair
+	// is never retried, so no lock is ever held across the candidate write.
 	emit := func(bookAID, bookBID string, sim float64) {
-		mu.Lock()
-		defer mu.Unlock()
 		if isBoilerplateBook(bookAID) || isBoilerplateBook(bookBID) {
 			return
 		}
 		key := pairKey(bookAID, bookBID)
-		if _, already := emitted[key]; already {
-			return
-		}
+
 		if identifiersConflict(bookForIdentifierGate(bookAID), bookForIdentifierGate(bookBID)) {
-			emitted[key] = struct{}{}
-			identifierGateDrops++
+			// Claim the pair once (so it is counted once and never retried),
+			// but never upsert a conflicting pair.
+			if emitShards.mark(key) {
+				identifierGateDrops.Add(1)
+			}
 			return
 		}
 		// Suppress when both books' files live in the same directory: those
@@ -3771,13 +3925,18 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 		// The scanner's split-book detection (PR #1167) prevents this for
 		// new imports, but the library has thousands of pre-PR splits that
 		// would otherwise be flagged as 100% AcoustID matches just because
-		// their fingerprint segments happen to overlap.
+		// their fingerprint segments happen to overlap. Deliberately NOT
+		// marked (matches the pre-sharding scan): parentDirForBook returns ""
+		// (unknown) on any fetch miss, and unknown never suppresses.
 		if dirA := parentDirForBook(bookAID); dirA != "" {
 			if dirB := parentDirForBook(bookBID); dirB == dirA {
 				return
 			}
 		}
-		emitted[key] = struct{}{}
+		// Real candidate: claim once, then upsert with no lock held.
+		if !emitShards.mark(key) {
+			return
+		}
 		if err := de.upsertCandidateWithLiveLabel(database.DedupCandidate{
 			EntityType: "book",
 			EntityAID:  bookAID,
@@ -3802,8 +3961,8 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 			// Prime cache for this book (avoids the duplicate GetBookFiles
 			// inside parentDirForBook when emit is called for this side).
 			// Pure in-memory (files already fetched above) — cheap even
-			// though every worker takes this lock once per book.
-			mu.Lock()
+			// though every worker takes bookCacheMu once per book.
+			bookCacheMu.Lock()
 			if _, cached := parentDirCache[book.ID]; !cached {
 				if len(files) == 0 {
 					parentDirCache[book.ID] = ""
@@ -3823,7 +3982,7 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 					}
 				}
 			}
-			mu.Unlock()
+			bookCacheMu.Unlock()
 
 			// LSH-backed candidate lookup is optional — only PebbleStore
 			// implements it. SQLite/mock stores skip this path and fall
@@ -3910,8 +4069,8 @@ func (de *Engine) AcoustIDScan(ctx context.Context, progress func(done, total in
 
 	slog.Info("[dedup] acoustid scan complete books scanned, candidate pair(s) emitted",
 		"total", total,
-		"emitted_count", len(emitted),
-		"identifier_gate_dropped_count", identifierGateDrops)
+		"emitted_count", emitShards.count(),
+		"identifier_gate_dropped_count", identifierGateDrops.Load())
 	return nil
 }
 

--- a/internal/dedup/engine_acoustid_parallel_test.go
+++ b/internal/dedup/engine_acoustid_parallel_test.go
@@ -1,17 +1,20 @@
 // file: internal/dedup/engine_acoustid_parallel_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d3b6f1a-2c47-4e8b-9a0d-5f61c8e0a3b2
-// last-edited: 2026-07-05
+// last-edited: 2026-07-11
 
-// Regression tests for CONC-3: AcoustIDScan's per-book loop is now sharded
-// across a bounded worker pool (registry.RunItems) instead of running
-// single-threaded. AcoustIDScan mutates FOUR shared maps + a counter inside
-// emit()/the loop (booksByID, boilerplateBookCache, parentDirCache, emitted,
-// identifierGateDrops) — this test proves the parallel pass emits the EXACT
-// same candidate set as an independent ground truth (no lost/duplicated
-// updates through the guarded state) and exercises every one of the four
-// gates (boilerplate book, conflicting identifiers, same-parent-dir
-// suppression, and a genuine match) concurrently under -race.
+// Regression tests for CONC-3: AcoustIDScan's per-book loop is sharded across
+// a bounded worker pool (registry.RunItems) instead of running
+// single-threaded. Its per-pair "already handled" state now lives in the
+// emitShards shard set (keyed by canonical pair-key hash) rather than one
+// global mutex, and the per-book caches (booksByID, boilerplateBookCache,
+// parentDirCache) sit behind bookCacheMu with store reads run unlocked; the
+// identifier-gate counter is atomic. This test proves the parallel pass emits
+// the EXACT same candidate set as an independent ground truth (no
+// lost/duplicated emissions) and exercises every one of the four gates
+// (boilerplate book, conflicting identifiers, same-parent-dir suppression,
+// and a genuine match) concurrently under -race. The per-pair single-emission
+// invariant is proven directly in engine_emit_shard_race_test.go.
 package dedup
 
 import (

--- a/internal/dedup/engine_emit_shard_race_test.go
+++ b/internal/dedup/engine_emit_shard_race_test.go
@@ -1,0 +1,260 @@
+// file: internal/dedup/engine_emit_shard_race_test.go
+// version: 1.0.0
+// guid: 7e1f2a93-4b6c-4d5e-8f01-2a3b4c5d6e7f
+// last-edited: 2026-07-11
+
+// Race/invariant tests for CONC-3 (INIT-2 T5): the full-scan emit() no longer
+// runs under one global mutex. Per-pair "already handled" state is sharded
+// across acoustidEmitShardCount mutexes keyed by the canonical pair-key hash,
+// so the runtime.NumCPU() RunItems worker pool no longer serializes behind a
+// single lock, while the check-then-set stays atomic PER PAIR.
+//
+// The two low-level tests exercise emitShards.mark() directly — that is the
+// EXACT check-then-set primitive emit() uses — so the 64-goroutine same-pair
+// proof and the shard-collision no-loss proof transfer to the real emit path.
+// The two scan-level tests confirm the wiring end to end: a mutual A<->B
+// fixture makes both books' workers emit the same canonical pair concurrently
+// (the maximum same-pair contention reachable through the scan, since only
+// A's worker emits (A,B) and only B's emits (B,A)), and a ghost-target
+// fixture pins the nil/unknown gate semantics under the new locking.
+//
+// TestParallelAcoustIDScan_SameCandidatesAsSerial (engine_acoustid_parallel_
+// test.go) already covers the distinct-pair no-loss / four-gate case at
+// 60-way parallelism; these tests add the per-pair single-emission proof.
+package dedup
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+)
+
+// makeUsefulFP builds a base64 chromaprint payload that
+// fingerprint.IsUsefulFingerprint accepts: a 4-byte header followed by
+// >= MinUsefulFingerprintFrames little-endian uint32 frames. Distinct seeds
+// yield distinct fingerprint strings so a mock's exact-match lookup can map
+// each book's segment to a different partner file.
+func makeUsefulFP(seed byte) string {
+	const frames = 96 // comfortably above MinUsefulFingerprintFrames (80)
+	buf := make([]byte, 4+frames*4)
+	for i := range buf {
+		buf[i] = seed + byte(i*7)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+// TestAcoustidEmitShards_MarkSamePairClaimedOnce hammers a SINGLE pair key
+// from 64 goroutines released simultaneously and asserts mark() returns true
+// exactly once. This is the per-pair check-then-set atomicity invariant: same
+// key -> same shard -> no two workers can both observe the pair as unhandled.
+// A regression (e.g. removing the shard lock, or splitting check and set)
+// would let mark() return true more than once, which in emit() is a
+// double-upsert / double-emit. Runs under -race.
+func TestAcoustidEmitShards_MarkSamePairClaimedOnce(t *testing.T) {
+	const goroutines = 64
+	shards := newAcoustidEmitShards()
+	const key = "BOOK_A:BOOK_B"
+
+	var trues atomic.Int64
+	var start sync.WaitGroup
+	start.Add(1) // gate so every goroutine contends at once
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start.Wait()
+			if shards.mark(key) {
+				trues.Add(1)
+			}
+		}()
+	}
+	start.Done()
+	wg.Wait()
+
+	if got := trues.Load(); got != 1 {
+		t.Fatalf("same pair key claimed %d times, want exactly 1 (double-emit under contention)", got)
+	}
+	if got := shards.count(); got != 1 {
+		t.Fatalf("count()=%d, want 1", got)
+	}
+}
+
+// TestAcoustidEmitShards_DistinctPairsNoLoss proves the anti-over-suppression
+// side: many DISTINCT keys (far more than acoustidEmitShardCount, so keys are
+// guaranteed to collide on shared shards) each claimed by several racing
+// goroutines. Every distinct key must be claimed exactly once (no lost
+// emission from a shard collision), and count() must equal the number of
+// distinct keys. Runs under -race.
+func TestAcoustidEmitShards_DistinctPairsNoLoss(t *testing.T) {
+	const numKeys = 200 // >> acoustidEmitShardCount (16): forces shard sharing
+	const perKey = 4    // goroutines racing to claim each key
+
+	shards := newAcoustidEmitShards()
+	keys := make([]string, numKeys)
+	trues := make([]atomic.Int64, numKeys)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numKeys; i++ {
+		keys[i] = fmt.Sprintf("A%04d:B%04d", i, i)
+		for g := 0; g < perKey; g++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				if shards.mark(keys[idx]) {
+					trues[idx].Add(1)
+				}
+			}(i)
+		}
+	}
+	wg.Wait()
+
+	for i := 0; i < numKeys; i++ {
+		if got := trues[i].Load(); got != 1 {
+			t.Fatalf("key %s claimed %d times, want exactly 1 (lost or duplicated emission)", keys[i], got)
+		}
+	}
+	if got := shards.count(); got != numKeys {
+		t.Fatalf("count()=%d, want %d (shard collision dropped distinct entries)", got, numKeys)
+	}
+}
+
+// TestAcoustidEmitShards_ShardForStable pins the property that makes the
+// invariant hold: the same key always resolves to the same shard.
+func TestAcoustidEmitShards_ShardForStable(t *testing.T) {
+	shards := newAcoustidEmitShards()
+	for _, k := range []string{"", "A:B", "BOOK_A:BOOK_B", "zzz:aaa"} {
+		if shards.shardFor(k) != shards.shardFor(k) {
+			t.Fatalf("shardFor(%q) is not stable across calls", k)
+		}
+	}
+}
+
+// TestAcoustIDScan_ConcurrentSamePair_SingleCandidate drives the real scan
+// with a mutual A<->B fixture: A's segment exact-matches B's file and B's
+// segment exact-matches A's file, so A's worker emits (A,B) while B's worker
+// emits (B,A) — the same canonical pair — concurrently through
+// registry.RunItems. Exactly one candidate must be stored. Runs under -race.
+func TestAcoustIDScan_ConcurrentSamePair_SingleCandidate(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	fpA := makeUsefulFP(1)
+	fpB := makeUsefulFP(2)
+	if fpA == fpB || !fingerprint.IsUsefulFingerprint(fpA) || !fingerprint.IsUsefulFingerprint(fpB) {
+		t.Fatalf("fixture fingerprints drifted: fpA==fpB=%v useful(A)=%v useful(B)=%v",
+			fpA == fpB, fingerprint.IsUsefulFingerprint(fpA), fingerprint.IsUsefulFingerprint(fpB))
+	}
+
+	bookA := database.Book{ID: "BOOK_A", Title: "Book A"}
+	bookB := database.Book{ID: "BOOK_B", Title: "Book B"}
+	fileA := database.BookFile{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/book.m4b", AcoustIDSeg0: fpA}
+	fileB := database.BookFile{ID: "FILE_B", BookID: "BOOK_B", FilePath: "/lib/b/book.m4b", AcoustIDSeg0: fpB}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		return []database.Book{bookA, bookB}, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "BOOK_A":
+			return []database.BookFile{fileA}, nil
+		case "BOOK_B":
+			return []database.BookFile{fileB}, nil
+		}
+		return nil, nil
+	}
+	// A's segment resolves to B's file and vice versa, so both workers emit
+	// the SAME canonical pair (BOOK_A, BOOK_B) at the same time.
+	mock.GetBookFileByAcoustIDFunc = func(fp string) (*database.BookFile, error) {
+		switch fp {
+		case fpA:
+			return &fileB, nil
+		case fpB:
+			return &fileA, nil
+		}
+		return nil, nil
+	}
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book", Layer: "acoustid", Status: "pending", Limit: 1_000_000,
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("same pair emitted concurrently from both workers produced %d candidates, want exactly 1: %+v", len(cands), cands)
+	}
+	if key := pairKeyFor(cands[0].EntityAID, cands[0].EntityBID); key != pairKeyFor("BOOK_A", "BOOK_B") {
+		t.Fatalf("candidate pair = %s, want BOOK_A:BOOK_B", key)
+	}
+}
+
+// TestAcoustIDScan_NilAndUnknownGatesDoNotSuppress pins the conservative
+// nil/unknown semantics under the new locking: when a match target is NOT in
+// the scanned book slice (a "ghost" reachable only via the exact-match index),
+// bookForIdentifierGate's fallback returns nil and identifiersConflict(book,
+// nil) is false (never blocks), and parentDirForBook returns "" (unknown) so
+// the same-directory suppression never fires. The pair must still be emitted.
+func TestAcoustIDScan_NilAndUnknownGatesDoNotSuppress(t *testing.T) {
+	engine, mock, es := setupTestEngine(t)
+
+	fpA := makeUsefulFP(3)
+	if !fingerprint.IsUsefulFingerprint(fpA) {
+		t.Fatalf("fixture fingerprint drifted: not useful")
+	}
+
+	bookA := database.Book{ID: "BOOK_A", Title: "Book A"}
+	fileA := database.BookFile{ID: "FILE_A", BookID: "BOOK_A", FilePath: "/lib/a/book.m4b", AcoustIDSeg0: fpA}
+	// GHOST is the match target but is NOT returned by GetAllBooks, so it is
+	// never pre-seeded into booksByID/parentDirCache — it forces the lazy
+	// store fallbacks that must return nil / "" without suppressing.
+	ghostFile := database.BookFile{ID: "FILE_GHOST", BookID: "GHOST", FilePath: "/lib/ghost/book.m4b", AcoustIDSeg0: fpA}
+
+	mock.GetAllBooksFunc = func(limit, offset int) ([]database.Book, error) {
+		return []database.Book{bookA}, nil
+	}
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "BOOK_A":
+			return []database.BookFile{fileA}, nil
+		case "GHOST":
+			return nil, nil // unknown parent dir -> "" -> must NOT suppress
+		}
+		return nil, nil
+	}
+	mock.GetBookByIDFunc = func(id string) (*database.Book, error) {
+		return nil, nil // GHOST un-fetchable -> nil gate book -> must NOT block
+	}
+	mock.GetBookFileByAcoustIDFunc = func(fp string) (*database.BookFile, error) {
+		if fp == fpA {
+			return &ghostFile, nil
+		}
+		return nil, nil
+	}
+
+	if err := engine.AcoustIDScan(context.Background(), nil); err != nil {
+		t.Fatalf("AcoustIDScan: %v", err)
+	}
+
+	cands, _, err := es.ListCandidates(database.CandidateFilter{
+		EntityType: "book", Layer: "acoustid", Status: "pending", Limit: 1_000_000,
+	})
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("nil-gate/unknown-dir pair should still emit: got %d candidates, want 1: %+v", len(cands), cands)
+	}
+	if key := pairKeyFor(cands[0].EntityAID, cands[0].EntityBID); key != pairKeyFor("BOOK_A", "GHOST") {
+		t.Fatalf("candidate pair = %s, want BOOK_A:GHOST", key)
+	}
+}


### PR DESCRIPTION
Per-pair check-then-set atomicity preserved by hashing the canonical pair
key to one of 16 shard mutexes (same pair -> same shard); per-book caches
get a dedicated mutex (bookCacheMu) with store reads outside all pair
locks; identifierGateDrops goes atomic. The three deterministic gates are
evaluated before the shard claim so no GetBookByID/GetBookFiles ever runs
under a pair-shard lock, and the candidate upsert runs after the shard
lock is released (mark-before-upsert). RunItems pool untouched. -race
tests prove no double-emit (same pair) and no lost emissions (distinct
pairs, shard collisions).

Co-Authored-By: Claude <noreply@anthropic.com>
