### PR TITLE
refactor(dedup): move boilerplate title blocklist to config-extendable module (INIT-4 T5)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.66.0
+// version: 1.67.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-07-11
 
@@ -178,6 +178,24 @@ func (c DedupConfig) ThresholdsForModel(model string) (high, low float64) {
 		return t.High, t.Low
 	}
 	return c.BookHighThreshold, c.BookLowThreshold
+}
+
+// DedupBoilerplateConfig holds extension-only additions to the compiled-in
+// publisher-boilerplate title blocklist (internal/dedup/boilerplate.go,
+// INIT-4 T5). Config entries are ALWAYS additive to the built-in
+// Audible/publisher patterns — there is intentionally no replace/override
+// field: that would let a misconfigured deployment silently drop the entire
+// compiled-in list and re-open the dedup false-positive bug the list exists
+// to prevent (spec docs/specs/2026-07-10-filtering-search-design.md Decision
+// 8). Empty (the default) is byte-identical to the pre-config hardcoded
+// behavior.
+type DedupBoilerplateConfig struct {
+	// ExtraTitlePatterns are additional exact-match boilerplate titles,
+	// appended to (never replacing) the compiled-in defaults.
+	ExtraTitlePatterns []string `json:"extra_title_patterns" mapstructure:"extra_title_patterns"`
+	// ExtraPrefixPatterns are additional anchored-prefix boilerplate
+	// patterns, appended to (never replacing) the compiled-in defaults.
+	ExtraPrefixPatterns []string `json:"extra_prefix_patterns" mapstructure:"extra_prefix_patterns"`
 }
 
 // ITunesConfig holds all settings for the iTunes sync and write-back subsystem.
@@ -496,6 +514,12 @@ type Config struct {
 
 	// Dedup holds all deduplication settings (thresholds, auto-merge, LLM model, signal bands).
 	Dedup DedupConfig `json:"dedup" mapstructure:"dedup"`
+
+	// DedupBoilerplate holds extension-only additions to the compiled-in
+	// publisher-boilerplate title blocklist (internal/dedup/boilerplate.go,
+	// INIT-4 T5). Empty (default) is byte-identical to the pre-config
+	// hardcoded behavior.
+	DedupBoilerplate DedupBoilerplateConfig `json:"dedup_boilerplate" mapstructure:"dedup_boilerplate"`
 
 	// MetadataScoring holds all AI-assisted metadata candidate scoring settings
 	// (embedding scoring, LLM rerank tier, and tag-write backup policy).
@@ -901,6 +925,12 @@ func InitConfig() {
 	viper.SetDefault("dedup.llm_auto_merge_high_confidence", false) // opt-in
 	viper.SetDefault("dedup.on_import_via_scheduler", false)        // opt-in — keep eager path until M4 confirmed
 
+	// Dedup boilerplate-blocklist extras (nested under "dedup_boilerplate.*",
+	// INIT-4 T5). Empty by default — the compiled-in blocklist in
+	// internal/dedup/boilerplate.go is always active regardless.
+	viper.SetDefault("dedup_boilerplate.extra_title_patterns", []string{})
+	viper.SetDefault("dedup_boilerplate.extra_prefix_patterns", []string{})
+
 	// Metadata candidate scoring defaults (nested under "metadata_scoring.*").
 	// BindEnv maps env vars so METADATA_SCORING_* overrides even without AutomaticEnv.
 	viper.SetDefault("metadata_scoring.embedding_enabled", false)
@@ -1181,6 +1211,13 @@ func InitConfig() {
 					BandMediumMin:  viper.GetFloat64("dedup.signals.band_medium_min"),
 					BandReviewMin:  viper.GetFloat64("dedup.signals.band_review_min"),
 				},
+			},
+
+			// Dedup boilerplate-blocklist extras (nested sub-struct, INIT-4 T5).
+			// Empty by default — see DedupBoilerplateConfig.
+			DedupBoilerplate: DedupBoilerplateConfig{
+				ExtraTitlePatterns:  viper.GetStringSlice("dedup_boilerplate.extra_title_patterns"),
+				ExtraPrefixPatterns: viper.GetStringSlice("dedup_boilerplate.extra_prefix_patterns"),
 			},
 
 			// Metadata candidate scoring + tag-write backup policy (nested sub-struct)
@@ -1625,6 +1662,14 @@ func ResetToDefaults() {
 					BandMediumMin:  75.0,
 					BandReviewMin:  60.0,
 				},
+			},
+
+			// Dedup boilerplate-blocklist extras (nested sub-struct, INIT-4 T5).
+			// Empty by default — the compiled-in blocklist in
+			// internal/dedup/boilerplate.go is always active regardless.
+			DedupBoilerplate: DedupBoilerplateConfig{
+				ExtraTitlePatterns:  nil,
+				ExtraPrefixPatterns: nil,
 			},
 
 			// Metadata candidate scoring + tag-write backup policy (nested sub-struct)

--- a/internal/dedup/boilerplate.go
+++ b/internal/dedup/boilerplate.go
@@ -1,0 +1,128 @@
+// file: internal/dedup/boilerplate.go
+// version: 1.0.0
+// guid: 2349d60e-e5e8-4c03-b3a7-0123a0b0bf36
+// last-edited: 2026-07-11
+
+package dedup
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+)
+
+// boilerplateTitlePatterns are exact publisher intro/outro "titles" that are
+// not real books and must not seed dedup matches. Seeded from
+// docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md and safe to extend.
+//
+// This list is the compiled-in DEFAULT set and is ALWAYS active — config
+// extras (config.DedupBoilerplateConfig, INIT-4 T5) only APPEND to it, never
+// replace it (spec docs/specs/2026-07-10-filtering-search-design.md Decision
+// 8: a replace escape hatch would let a misconfigured deployment silently
+// drop all Audible/publisher suppression and re-open the dedup false-positive
+// bug this list exists to prevent).
+var boilerplateTitlePatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"end credits",
+	"credits",
+	"opening credits",
+	"closing credits",
+	"intro",
+	"introduction",
+	"outro",
+	"epilogue music",
+	"publisher introduction",
+	"publisher's note",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+}
+
+// boilerplateTitlePrefixPatterns are anchored boilerplate phrases that may carry
+// trailing publisher copy. Keep this list narrower than the exact-title list so
+// real books like "Introduction to Algorithms" still match normally.
+var boilerplateTitlePrefixPatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+}
+
+// boilerplateInit guards the one-time build of effectiveTitlePatterns /
+// effectivePrefixPatterns from the compiled-in defaults above plus any
+// config.AppConfig.DedupBoilerplate extras. Loading once (rather than on
+// every isBoilerplateTitle call) keeps the hot per-book scan path lock-free
+// after startup — isBoilerplateTitle is called from the AcoustIDScan
+// per-pair gates, which must stay a fast, deterministic, non-blocking
+// function (see the emitShards/bookCacheMu design notes in engine.go).
+var boilerplateInit sync.Once
+
+// effectiveTitlePatterns / effectivePrefixPatterns are the normalized
+// pattern sets isBoilerplateTitle actually matches against: the compiled-in
+// defaults ALWAYS present, plus normalized config extras appended (never
+// replacing). Populated once by loadBoilerplatePatterns.
+var effectiveTitlePatterns []string
+var effectivePrefixPatterns []string
+
+// loadBoilerplatePatterns builds effectiveTitlePatterns/effectivePrefixPatterns
+// from the compiled-in defaults plus normalized config extras (read from
+// config.Snapshot().DedupBoilerplate). Always starts from the full
+// compiled-in slices — config can only APPEND, never replace or remove a
+// default pattern (Decision 8). Empty/whitespace-only extras are dropped so
+// an empty config entry can never become a match-everything pattern. With no
+// configured extras (the default, empty DedupBoilerplateConfig), the
+// effective sets are byte-identical to the compiled-in defaults.
+func loadBoilerplatePatterns() {
+	effectiveTitlePatterns = append([]string(nil), boilerplateTitlePatterns...)
+	effectivePrefixPatterns = append([]string(nil), boilerplateTitlePrefixPatterns...)
+
+	cfg := config.Snapshot()
+	for _, p := range cfg.DedupBoilerplate.ExtraTitlePatterns {
+		normalized := util.NormalizeTitle(util.CollapseSpaces(p))
+		if normalized == "" {
+			continue
+		}
+		effectiveTitlePatterns = append(effectiveTitlePatterns, normalized)
+	}
+	for _, p := range cfg.DedupBoilerplate.ExtraPrefixPatterns {
+		normalized := util.NormalizeTitle(util.CollapseSpaces(p))
+		if normalized == "" {
+			continue
+		}
+		effectivePrefixPatterns = append(effectivePrefixPatterns, normalized)
+	}
+}
+
+func isBoilerplateTitle(title string) bool {
+	boilerplateInit.Do(loadBoilerplatePatterns)
+
+	normalized := util.NormalizeTitle(util.CollapseSpaces(title))
+	if normalized == "" {
+		return false
+	}
+	for _, pattern := range effectiveTitlePatterns {
+		if normalized == pattern {
+			return true
+		}
+	}
+	for _, pattern := range effectivePrefixPatterns {
+		if strings.HasPrefix(normalized, pattern+" ") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dedup/boilerplate_test.go
+++ b/internal/dedup/boilerplate_test.go
@@ -1,0 +1,178 @@
+// file: internal/dedup/boilerplate_test.go
+// version: 1.0.0
+// guid: 50999f4c-4d92-482f-8f6d-a637c6497352
+// last-edited: 2026-07-11
+
+// Tests for the boilerplate title blocklist moved out of engine.go into
+// boilerplate.go (INIT-4 T5): default-parity (every compiled-in pattern
+// still flags, exactly like the pre-move hardcoded lists), config-extension
+// (extras appended via config.DedupBoilerplateConfig get flagged, and never
+// replace the compiled-in defaults — Decision 8), and anti-over-suppression
+// (real titles that merely start with a boilerplate-adjacent word, e.g.
+// "Introduction to Algorithms", must never be flagged).
+package dedup
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+)
+
+// resetBoilerplatePatternsForTestOnly clears the cached effective pattern
+// set (populated once per process by boilerplateInit) so the next
+// isBoilerplateTitle call re-derives it from the compiled-in defaults plus
+// whatever config.AppConfig.DedupBoilerplate extras are set at that moment.
+// Test-only: production code never resets this cache.
+func resetBoilerplatePatternsForTestOnly() {
+	boilerplateInit = sync.Once{}
+	effectiveTitlePatterns = nil
+	effectivePrefixPatterns = nil
+}
+
+// withBoilerplateExtras sets config.AppConfig.DedupBoilerplate to the given
+// extras for the duration of the test, forces isBoilerplateTitle to
+// re-derive its pattern cache on next use, and restores/reset everything on
+// cleanup so no state leaks into other tests in this package.
+func withBoilerplateExtras(t *testing.T, titles, prefixes []string) {
+	t.Helper()
+	prev := config.Snapshot().DedupBoilerplate
+	config.Mutate(func(c *config.Config) {
+		c.DedupBoilerplate = config.DedupBoilerplateConfig{
+			ExtraTitlePatterns:  titles,
+			ExtraPrefixPatterns: prefixes,
+		}
+	})
+	resetBoilerplatePatternsForTestOnly()
+	t.Cleanup(func() {
+		config.Mutate(func(c *config.Config) {
+			c.DedupBoilerplate = prev
+		})
+		resetBoilerplatePatternsForTestOnly()
+	})
+}
+
+// TestIsBoilerplateTitle_DefaultPatternsAllFlagged proves every compiled-in
+// pattern (both the exact-title list and the anchored-prefix list) is still
+// flagged after the move to boilerplate.go — default-parity with the
+// pre-move hardcoded engine.go behavior.
+func TestIsBoilerplateTitle_DefaultPatternsAllFlagged(t *testing.T) {
+	resetBoilerplatePatternsForTestOnly()
+	t.Cleanup(resetBoilerplatePatternsForTestOnly)
+
+	for _, p := range boilerplateTitlePatterns {
+		if !isBoilerplateTitle(p) {
+			t.Errorf("exact pattern %q: expected isBoilerplateTitle=true, got false", p)
+		}
+	}
+	for _, p := range boilerplateTitlePrefixPatterns {
+		// Prefix patterns match when followed by a space and trailing text
+		// (strings.HasPrefix(normalized, pattern+" ")), so exercise the
+		// anchored form rather than the bare pattern.
+		title := p + " and some trailing publisher copy"
+		if !isBoilerplateTitle(title) {
+			t.Errorf("prefix pattern %q (as %q): expected isBoilerplateTitle=true, got false", p, title)
+		}
+	}
+}
+
+// TestIsBoilerplateTitle_AntiOverSuppression proves real book titles that
+// merely share a boilerplate-adjacent leading word survive (are NOT
+// flagged), with defaults alone and with a config extras list active.
+func TestIsBoilerplateTitle_AntiOverSuppression(t *testing.T) {
+	realTitles := []string{
+		"Introduction to Algorithms",
+		"The End Credits of a Life",
+	}
+
+	t.Run("defaults_only", func(t *testing.T) {
+		resetBoilerplatePatternsForTestOnly()
+		t.Cleanup(resetBoilerplatePatternsForTestOnly)
+
+		for _, title := range realTitles {
+			if isBoilerplateTitle(title) {
+				t.Errorf("real title %q: expected isBoilerplateTitle=false, got true", title)
+			}
+		}
+	})
+
+	t.Run("with_extras_active", func(t *testing.T) {
+		withBoilerplateExtras(t,
+			[]string{"a completely different exact boilerplate title"},
+			[]string{"totally unrelated prefix"},
+		)
+
+		for _, title := range realTitles {
+			if isBoilerplateTitle(title) {
+				t.Errorf("real title %q: expected isBoilerplateTitle=false even with extras active, got true", title)
+			}
+		}
+	})
+}
+
+// TestIsBoilerplateTitle_ConfigExtraPattern proves a title matching only a
+// config-supplied extra (not any compiled-in default) gets flagged once the
+// extras are active — the config-extension path works end to end.
+func TestIsBoilerplateTitle_ConfigExtraPattern(t *testing.T) {
+	withBoilerplateExtras(t,
+		[]string{"Ce Livre Est Termine"}, // exact extra (normalization-cased input)
+		[]string{"Bienvenue Chez"},       // prefix extra
+	)
+
+	if !isBoilerplateTitle("Ce Livre Est Termine") {
+		t.Error("exact config extra: expected isBoilerplateTitle=true, got false")
+	}
+	if !isBoilerplateTitle("Bienvenue Chez Audible France") {
+		t.Error("prefix config extra: expected isBoilerplateTitle=true, got false")
+	}
+	if isBoilerplateTitle("An Unrelated Real Book Title") {
+		t.Error("unrelated real title: expected isBoilerplateTitle=false, got true")
+	}
+
+	// Empty/whitespace-only extras must never become match-everything
+	// patterns.
+	withBoilerplateExtras(t, []string{"  ", ""}, []string{" "})
+	if isBoilerplateTitle("Any Title At All") {
+		t.Error("blank config extras: expected no match-everything behavior, got true")
+	}
+	if isBoilerplateTitle("") {
+		t.Error("empty title: expected isBoilerplateTitle=false, got true")
+	}
+}
+
+// TestBoilerplateConfigExtension proves that with config extras active, the
+// compiled-in defaults are ALWAYS retained (Decision 8: extension-only, no
+// replace escape hatch) — a compiled-in pattern still hits alongside the
+// extras.
+func TestBoilerplateConfigExtension(t *testing.T) {
+	withBoilerplateExtras(t,
+		[]string{"a brand new publisher boilerplate line"},
+		nil,
+	)
+
+	// Compiled-in default still flags.
+	if !isBoilerplateTitle("this is audible") {
+		t.Error("compiled-in default pattern must still flag with extras active, but did not")
+	}
+	// The new extra also flags.
+	if !isBoilerplateTitle("a brand new publisher boilerplate line") {
+		t.Error("config extra pattern must flag once active, but did not")
+	}
+}
+
+// TestIsBoilerplateTitle_EmptyConfigByteIdenticalToDefaults proves that with
+// an empty (zero-value) DedupBoilerplateConfig — the out-of-the-box state —
+// isBoilerplateTitle behaves exactly like the pre-move hardcoded lists: every
+// default pattern flags, no extra patterns exist to flag.
+func TestIsBoilerplateTitle_EmptyConfigByteIdenticalToDefaults(t *testing.T) {
+	withBoilerplateExtras(t, nil, nil)
+
+	for _, p := range boilerplateTitlePatterns {
+		if !isBoilerplateTitle(p) {
+			t.Errorf("empty-config default pattern %q: expected true, got false", p)
+		}
+	}
+	if isBoilerplateTitle("Introduction to Algorithms") {
+		t.Error("empty-config real title: expected false, got true")
+	}
+}

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.57.0
+// version: 1.58.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-11
 
@@ -27,73 +27,12 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
-	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var dedupTracer = otel.Tracer("audiobook-organizer/dedup")
-
-// boilerplateTitlePatterns are exact publisher intro/outro "titles" that are
-// not real books and must not seed dedup matches. Seeded from
-// docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md and safe to extend.
-var boilerplateTitlePatterns = []string{
-	"this is audible",
-	"audible hopes you have enjoyed this program",
-	"audible hopes you have enjoyed this book",
-	"audible studios presents",
-	"audible presents",
-	"this is an audible original",
-	"end credits",
-	"credits",
-	"opening credits",
-	"closing credits",
-	"intro",
-	"introduction",
-	"outro",
-	"epilogue music",
-	"publisher introduction",
-	"publisher's note",
-	"produced by audible studios",
-	"recorded books presents",
-	"graphic audio presents",
-	"brilliance audio presents",
-}
-
-// boilerplateTitlePrefixPatterns are anchored boilerplate phrases that may carry
-// trailing publisher copy. Keep this list narrower than the exact-title list so
-// real books like "Introduction to Algorithms" still match normally.
-var boilerplateTitlePrefixPatterns = []string{
-	"this is audible",
-	"audible hopes you have enjoyed this program",
-	"audible hopes you have enjoyed this book",
-	"audible studios presents",
-	"audible presents",
-	"this is an audible original",
-	"produced by audible studios",
-	"recorded books presents",
-	"graphic audio presents",
-	"brilliance audio presents",
-}
-
-func isBoilerplateTitle(title string) bool {
-	normalized := util.NormalizeTitle(util.CollapseSpaces(title))
-	if normalized == "" {
-		return false
-	}
-	for _, pattern := range boilerplateTitlePatterns {
-		if normalized == pattern {
-			return true
-		}
-	}
-	for _, pattern := range boilerplateTitlePrefixPatterns {
-		if strings.HasPrefix(normalized, pattern+" ") {
-			return true
-		}
-	}
-	return false
-}
 
 // minFingerprintMatchSeconds: files shorter than this are publisher
 // intro/outro clips, not book content — their fingerprints must not seed or


### PR DESCRIPTION
The publisher intro/outro blocklist was two hardcoded English-only
slices inside engine.go. Move them verbatim to boilerplate.go and layer
extension-only config (extra patterns APPEND to the compiled-in
defaults, which are always active) with behavior byte-identical when
config is empty — per-publisher and i18n lists no longer require a code
change.

Co-Authored-By: Claude <noreply@anthropic.com>
