### PR TITLE
ci(mocks): quote mock-freshness pathspec so nested mocks dirs are checked (#1797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # file: .github/workflows/ci.yml
-# version: 3.0.6
+# version: 3.0.7
 # guid: f1a2b3c4-d5e6-f7a8-b9c0-d1e2f3a4b5c6
-# last-edited: 2026-07-08
+# last-edited: 2026-07-11
 
 # Fast parallel CI for PRs and pushes.
 # Runs go vet/build, short tests, frontend lint/build, and frontend unit tests
@@ -86,9 +86,9 @@ jobs:
         run: |
           set -e
           mockery
-          if ! git diff --quiet -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; then
+          if ! git diff --quiet -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; then
             echo "❌ Committed mocks are stale. Run 'make mocks' and commit."
-            git diff --stat -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go
+            git diff --stat -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go
             exit 1
           fi
           echo "✅ Mocks are up to date"


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml`'s "Check mockery mocks are fresh" step used the
unquoted pathspec `internal/*/mocks/`. Because it was unquoted, the runner's
shell expanded the `*` before `git diff` ever saw it — and shell globs never
cross `/`, so only the 6 one-level-deep `internal/<pkg>/mocks/` dirs were
covered. The 8 nested `internal/server/handlers/*/mocks/` dirs were invisible
to the gate. This is the exact gap that let `mock_dedup_engine.go` go stale
from #1736 until it was hand-regenerated in #1757.

Fix: replace `internal/*/mocks/` with the quoted git pathspec
`':(glob)internal/**/mocks/**'` on both lines that use it (the `git diff
--quiet` check and the `git diff --stat` diagnostic). The other two
pathspecs on those lines (`internal/ai/mock_*_test.go`,
`internal/metadata/mock_*_test.go`) are untouched — they were already
correct.

## Local verification (per task brief)

**Step 3 — nested-mock probe** (append a byte to
`internal/server/handlers/mocks/mock_activity_ops_store.go`, then run the
new pathspec):
```
$ git diff --quiet -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; echo "exit=$?"
step3_nested_exit=1
```
Detected dirty (the OLD unquoted pattern would have reported `exit=0` here —
this is the bug being fixed). Probe reverted; `git status --porcelain`
returned empty afterward.

**Step 4 — top-level-mock probe** (append a byte to
`internal/database/mocks/mock_store_coverage_test.go`):
```
$ git diff --quiet -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go 2>/dev/null; echo "exit=$?"
step4_toplevel_exit=1
```
Still detected — the widened pattern loses no coverage the old one had.
Probe reverted.

**Step 5 — mandatory pre-merge freshness check** (mockery v3.7.1, the
CI-pinned version; confirmed via `mockery version` before running):
```
$ mockery
(regenerated in place, exit 0)
$ git status --porcelain -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go
(empty)
```
All mocks — including the 8 newly-covered nested
`internal/server/handlers/*/mocks/` dirs — are already fresh on
`origin/main` (`1d0c7b23`). No mock regeneration was needed or committed in
this PR; the diff is limited to the 2-line pathspec fix + file-header bump.

## Other gates run locally

- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"` → `yaml ok`
- `make check-mock-fresh` → exit 0
- `make mocks-check` → exit 0
- `go build ./...` → exit 0
- `make sdkguard` → exit 0 (TASK-03's fix for #1795 is already on main)
- `make ci` → exits 2 at the `staticcheck` step. This is the pre-existing
  backlog (#1796) documented in the task brief — none of the flagged files
  are `ci.yml`, and staticcheck isn't part of Minimal CI (the actual merge
  gate). `test-all-short`/`coverage-check-short` were never reached because
  `make ci` is a sequential chain that stops at the first failing target.

## Follow-up (not fixed here, out of this task's scope)

`Makefile`'s `mocks-check` target (lines 212/214) has the **identical**
unquoted `internal/*/mocks/` bug as a latent twin of the CI workflow check.
It currently "works" only because all mocks happen to be fresh right now —
it would silently miss a stale nested mock the same way the CI step used to.
The task brief scopes this PR to `.github/workflows/ci.yml` only (see
file-ownership note), so this is left as a follow-up rather than fixed here.

## Acceptance criteria

- [x] `grep -n 'internal/\*/mocks/' .github/workflows/ci.yml` → 0 hits
- [x] `grep -c ":(glob)internal/\*\*/mocks/\*\*" .github/workflows/ci.yml` → 2
- [x] Step-3 probe `exit=1`, step-4 probe `exit=1` (pasted above)
- [x] Step-5 freshness check ran with mockery v3.7.1, `git status --porcelain` empty (pasted above)
- [ ] Minimal CI green on this PR (pending — will confirm after push)
- [x] Anti-over-suppression N/A — step 4 is the no-narrowing proof
- [x] File header bumped (`version: 3.0.6` → `3.0.7`, `last-edited: 2026-07-11`)

Co-Authored-By: Claude <noreply@anthropic.com>