### PR TITLE
test(organizer): verify Author/Series fate in CreateOrganizedVersion write-back (STOREFID W5d-1)

### DIFF
--- a/internal/organizer/organized_version_writeback_test.go
+++ b/internal/organizer/organized_version_writeback_test.go
@@ -1,0 +1,168 @@
+// file: internal/organizer/organized_version_writeback_test.go
+// version: 1.0.0
+// guid: 8eea5b3c-7be2-4f84-a629-aca6c5044dbb
+// last-edited: 2026-07-11
+
+package organizer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// newWritebackTestBook seeds one book in store with denormalized Author and
+// Series populated, mirroring the shape a full-fidelity Pebble row has in
+// production before it is ever passed through the memdb-slim projection.
+//
+// It then immediately re-reads the row via GetBookByID and hard-fails if
+// Author/Series did not persist. Without this check, a later nil Author on
+// the original book after CreateOrganizedVersion would be ambiguous: did
+// the write-back wipe it, or did CreateBook/Pebble simply never persist a
+// denormalized Author in the first place? Asserting the baseline here makes
+// the later Outcome-A/B read unambiguous — a post-write-back nil can only
+// be the write-back's doing.
+func newWritebackTestBook(t *testing.T, store *database.PebbleStore) *database.Book {
+	t.Helper()
+
+	created, err := store.CreateBook(&database.Book{
+		Title:    "Writeback Probe",
+		FilePath: filepath.Join(t.TempDir(), "original.m4b"),
+		Author:   &database.Author{ID: 1, Name: "Original Author"},
+		Series:   &database.Series{ID: 1, Name: "Original Series"},
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	seeded, err := store.GetBookByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID (post-seed baseline): %v", err)
+	}
+	if seeded == nil {
+		t.Fatalf("GetBookByID (post-seed baseline) returned nil for %q", created.ID)
+	}
+	if seeded.Author == nil || seeded.Series == nil {
+		t.Fatalf("fixture bug: seeded book has nil Author/Series before any write-back — Author=%v Series=%v", seeded.Author, seeded.Series)
+	}
+
+	return seeded
+}
+
+// TestCreateOrganizedVersion_OriginalDemotedToNonPrimary proves the
+// version-group demotion invariant holds against a real PebbleStore:
+// after CreateOrganizedVersion runs, the original book must end up with
+// VersionGroupID set, IsPrimaryVersion=false, and LibraryState=
+// "organized_source". This must hold regardless of the Author/Series
+// outcome verified below (TODO.md: CreateOrganizedVersion original-book
+// slim-writeback, STOREFID W5d-1).
+func TestCreateOrganizedVersion_OriginalDemotedToNonPrimary(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	store.WaitForWarmup()
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewService(store)
+	org := &Organizer{config: &config.Config{}}
+
+	seeded := newWritebackTestBook(t, store)
+
+	// Build the SLIM projection the production write-back path sends:
+	// GetAllBooksCore -> ToBook nils the heavy/denormalized fields.
+	slim := *seeded
+	slim.Author = nil
+	slim.Series = nil
+	slim.Description = nil
+
+	newPath := filepath.Join(t.TempDir(), "organized.m4b")
+	if _, err := svc.CreateOrganizedVersion(org, &slim, newPath, false, "", &noopLogger{}); err != nil {
+		t.Fatalf("CreateOrganizedVersion: %v", err)
+	}
+
+	got, err := store.GetBookByID(seeded.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetBookByID returned nil for original book %q", seeded.ID)
+	}
+
+	if got.VersionGroupID == nil || *got.VersionGroupID == "" {
+		t.Errorf("VersionGroupID not set on original: got %v", got.VersionGroupID)
+	}
+	if got.IsPrimaryVersion == nil {
+		t.Fatalf("IsPrimaryVersion is nil on original")
+	}
+	if *got.IsPrimaryVersion != false {
+		t.Errorf("IsPrimaryVersion = %v, want false", *got.IsPrimaryVersion)
+	}
+	if got.LibraryState == nil {
+		t.Fatalf("LibraryState is nil on original")
+	}
+	if *got.LibraryState != "organized_source" {
+		t.Errorf("LibraryState = %q, want %q", *got.LibraryState, "organized_source")
+	}
+}
+
+// TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback probes
+// whether the original book's denormalized Author/Series survive the
+// slim write-back in CreateOrganizedVersion (internal/organizer/service.go,
+// comment: "Deliberately NOT fixed here ... Tracked as a follow-up").
+// Locked two-outcome protocol (TASK-07, STOREFID W5d-1):
+//
+//   - Outcome A (PASS): Author/Series survive -> the TODO concern is
+//     disproven at the store layer; assertions below stay live.
+//   - Outcome B (wipe confirmed): the guarded block below detects the wipe
+//     and skips with a message identifying the known bug, rather than
+//     failing silently or asserting a broken invariant as green. This is
+//     the ONLY permitted skip in this file — any other GetBookByID error or
+//     nil result is a hard test failure (fixture bug), not a skip.
+func TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	store.WaitForWarmup()
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewService(store)
+	org := &Organizer{config: &config.Config{}}
+
+	seeded := newWritebackTestBook(t, store)
+
+	slim := *seeded
+	slim.Author = nil
+	slim.Series = nil
+	slim.Description = nil
+
+	newPath := filepath.Join(t.TempDir(), "organized.m4b")
+	if _, err := svc.CreateOrganizedVersion(org, &slim, newPath, false, "", &noopLogger{}); err != nil {
+		t.Fatalf("CreateOrganizedVersion: %v", err)
+	}
+
+	got, err := store.GetBookByID(seeded.ID)
+	if err != nil {
+		t.Fatalf("GetBookByID: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetBookByID returned nil for original book %q", seeded.ID)
+	}
+
+	// Guarded wipe-detection block: this is the ONLY permitted skip path in
+	// this file. It runs before any hard assertion so a confirmed wipe
+	// documents the bug executably instead of failing the suite.
+	if got.Author == nil || got.Series == nil {
+		t.Skipf("W5d-1 KNOWN BUG CONFIRMED: Author/Series wiped by slim write-back (STOR-1 guard lacks Author/Series) — unskip when the fail-open hydrate fix (TODO.md:75-83) lands")
+	}
+
+	if got.Author.Name != seeded.Author.Name {
+		t.Errorf("Author.Name = %q, want %q (survived write-back)", got.Author.Name, seeded.Author.Name)
+	}
+	if got.Series.Name != seeded.Series.Name {
+		t.Errorf("Series.Name = %q, want %q (survived write-back)", got.Series.Name, seeded.Series.Name)
+	}
+}


### PR DESCRIPTION
## Summary

INIT-9 TASK-07 (STOREFID W5d-1): test-only regression coverage for the
`CreateOrganizedVersion` original-book slim write-back (TODO.md's
"CreateOrganizedVersion original-book slim-writeback (Author/Series)"
follow-up item). No product code changed — the fail-open hydrate fix
(TODO.md:75-83) remains a separate, decision-carrying task.

Adds `internal/organizer/organized_version_writeback_test.go` with two
tests against a **real `database.PebbleStore`** (not MemStore/mocks — the
whole point is fidelity through an actual Pebble write-back), with
`store.WaitForWarmup()` called immediately after `NewPebbleStore` per the
documented warmup race.

## Outcome (two-outcome protocol, locked)

**Outcome B — the wipe is CONFIRMED.** `PebbleStore.UpdateBook`'s STOR-1
preserve-on-nil guard (`internal/database/pebble_store.go`, ~1571-1598)
covers `Description`/`VersionNotes`/`BookSig*` but **not** `Author`/`Series`.
When `CreateOrganizedVersion` writes the page-derived slim original back via
`orgSvc.db.UpdateBook(book.ID, book)`, the original book's denormalized
`Author`/`Series` are wiped.

- `TestCreateOrganizedVersion_OriginalDemotedToNonPrimary` — **PASSES**.
  Proves the demotion invariant holds regardless of the Author/Series
  outcome: `VersionGroupID` set, `IsPrimaryVersion=false`,
  `LibraryState="organized_source"`.
- `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback` — the
  test seeds a book, re-reads it via `GetBookByID` immediately after
  seeding to hard-assert the fixture baseline (Author/Series non-nil
  *before* any write-back — this rules out "CreateBook never persisted
  them" as an alternate explanation), then runs
  `CreateOrganizedVersion` and re-reads again. The post-write-back read
  has nil Author/Series, so the test **SKIPs** via the single sanctioned
  guarded skip:
  `t.Skipf("W5d-1 KNOWN BUG CONFIRMED: Author/Series wiped by slim write-back (STOR-1 guard lacks Author/Series) — unskip when the fail-open hydrate fix (TODO.md:75-83) lands")`

Test output:
```
--- PASS: TestCreateOrganizedVersion_OriginalDemotedToNonPrimary (0.22s)
--- SKIP: TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback (0.23s)
    organized_version_writeback_test.go:159: W5d-1 KNOWN BUG CONFIRMED: Author/Series wiped by slim write-back (STOR-1 guard lacks Author/Series) — unskip when the fail-open hydrate fix (TODO.md:75-83) lands
PASS
```

## Deviation from the brief (scope carve-out from the dispatching orchestrator)

The task brief's step 5/acceptance criteria call for, on Outcome B: updating
TODO.md's item annotation, and filing a severity-tagged GitHub issue for the
fail-open hydrate fix, with the issue number referenced in both TODO.md and
this PR's BLOCKED line.

**This run's dispatch instructions explicitly said "Do NOT edit
CHANGELOG.md/TODO.md"** (tracking centralized elsewhere by the coordinator
across a batch of parallel tasks), so TODO.md was left untouched and no
GitHub issue was filed by this task. Evidence for whoever files that
follow-up:

- Confirmed-wipe test: `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback`
  in `internal/organizer/organized_version_writeback_test.go`
- Root cause: `internal/database/pebble_store.go` `PebbleStore.UpdateBook`
  STOR-1 preserve-on-nil guard (~line 1571) lists
  `Description`/`VersionNotes`/`BookSig*` but not `Author`/`Series`
- Write-back call site: `internal/organizer/service.go`
  `CreateOrganizedVersion`, comment starting "Deliberately NOT fixed here"
  (~line 931)
- Fix design already sketched in TODO.md:120-126 (fail-open hydrate:
  hydrate-and-write on success, fall back to direct state write, accepting
  the rare wipe, if hydrate fails — so the version-group demotion never
  regresses to fail-closed)

**BLOCKED: 1 — file a severity-tagged (prod data-loss) GitHub issue for the
fail-open hydrate fix described above and annotate TODO.md's
"CreateOrganizedVersion original-book slim-writeback" item with the issue
number; deferred to the coordinator per this task's do-not-edit-TODO
instruction.**

## Test plan

- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `go test -race -short ./internal/organizer/... -run TestCreateOrganizedVersion -v` — exit 0 (1 PASS, 1 documented SKIP)
- [x] `go test ./internal/organizer/... ./internal/database/... -short -race` — exit 0
- [x] `go test ./... -short` — exit 1, but the only failure is the pre-existing documented flake: `internal/server` `panic: test timed out after 10m0s` (`TestServerStartGracefulShutdown`), zero `--- FAIL` lines anywhere in the run. Every other package is `ok`.
- [x] `git diff --stat origin/main -- internal/organizer/ | grep -v _test.go` — no output (test-only, mechanically proven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)