### PR TITLE
feat(search): Bleve facet counts for genres/languages/tags (INIT-4 T4)

### DIFF
--- a/internal/audiobooks/service_facets.go
+++ b/internal/audiobooks/service_facets.go
@@ -1,0 +1,34 @@
+// file: internal/audiobooks/service_facets.go
+// version: 1.0.0
+// guid: 7d2b1c4e-8f3a-4b6d-9e0c-1a2b3c4d5e6f
+// last-edited: 2026-07-11
+
+// AudiobookService.FacetCounts (INIT-4 T4) — a thin wrapper around
+// BleveIndex.FacetCounts giving the /audiobooks/facets response optional
+// genre/language/tag value->count maps. Deliberately its own file (not
+// service_query.go, which owns searchWithBleve) per the task-04 brief: this
+// surface is additive and independently owned so sibling tasks touching
+// service_query.go don't collide with it.
+
+package audiobooks
+
+import "errors"
+
+// ErrSearchIndexUnavailable indicates the Bleve index is not open yet (e.g.
+// early startup, before Server.Start finishes opening it). Mirrors
+// internal/playlist/evaluator.go's sentinel of the same name; defined
+// locally rather than imported so this package doesn't take a dependency on
+// internal/playlist for a single error value. Callers fail open to a
+// DB-distinct-only response rather than surfacing a 500.
+var ErrSearchIndexUnavailable = errors.New("search index not yet available")
+
+// FacetCounts returns value->count maps for the genre, language, and tags
+// keyword fields via the Bleve index. Returns ErrSearchIndexUnavailable
+// when the index hasn't been wired in yet (SetSearchIndex not called, or
+// called with nil) — never a panic, never a partial/inconsistent result.
+func (svc *AudiobookService) FacetCounts() (genres, languages, tags map[string]int, err error) {
+	if svc.searchIndex == nil {
+		return nil, nil, nil, ErrSearchIndexUnavailable
+	}
+	return svc.searchIndex.FacetCounts(0)
+}

--- a/internal/audiobooks/service_facets_test.go
+++ b/internal/audiobooks/service_facets_test.go
@@ -1,0 +1,92 @@
+// file: internal/audiobooks/service_facets_test.go
+// version: 1.0.0
+// guid: 3a5e9c1b-6d2f-4a80-9b1c-7e4f0a2d5c6b
+// last-edited: 2026-07-11
+
+// Tests for AudiobookService.FacetCounts (INIT-4 T4): the nil-index
+// sentinel path and the pass-through-to-BleveIndex.FacetCounts path.
+
+package audiobooks
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/search"
+)
+
+// TestAudiobookService_FacetCounts_NilIndex pins the fail-open sentinel:
+// a service with no wired search index returns ErrSearchIndexUnavailable
+// and nil maps, never a panic.
+func TestAudiobookService_FacetCounts_NilIndex(t *testing.T) {
+	svc := &AudiobookService{}
+
+	genres, languages, tags, err := svc.FacetCounts()
+	if !errors.Is(err, ErrSearchIndexUnavailable) {
+		t.Fatalf("err = %v, want ErrSearchIndexUnavailable", err)
+	}
+	if genres != nil || languages != nil || tags != nil {
+		t.Errorf("expected nil maps on nil-index error, got genres=%v languages=%v tags=%v", genres, languages, tags)
+	}
+}
+
+// TestAudiobookService_FacetCounts_WithIndex pins the pass-through path:
+// once SetSearchIndex wires a real (non-nil) index, FacetCounts returns
+// the same value->count maps BleveIndex.FacetCounts would.
+func TestAudiobookService_FacetCounts_WithIndex(t *testing.T) {
+	idx, err := search.Open(filepath.Join(t.TempDir(), "bleve"))
+	if err != nil {
+		t.Fatalf("open bleve: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	docs := []search.BookDocument{
+		{BookID: "b1", Title: "One", Genre: "Fantasy", Language: "en", Tags: []string{"epic"}},
+		{BookID: "b2", Title: "Two", Genre: "Fantasy", Language: "en", Tags: []string{"epic"}},
+	}
+	if err := idx.IndexBookBatch(docs); err != nil {
+		t.Fatalf("index batch: %v", err)
+	}
+
+	svc := &AudiobookService{}
+	svc.SetSearchIndex(idx)
+
+	genres, languages, tags, err := svc.FacetCounts()
+	if err != nil {
+		t.Fatalf("FacetCounts: %v", err)
+	}
+	wantGenres := map[string]int{"fantasy": 2}
+	if !reflect.DeepEqual(genres, wantGenres) {
+		t.Errorf("genres = %v, want %v", genres, wantGenres)
+	}
+	wantLanguages := map[string]int{"en": 2}
+	if !reflect.DeepEqual(languages, wantLanguages) {
+		t.Errorf("languages = %v, want %v", languages, wantLanguages)
+	}
+	wantTags := map[string]int{"epic": 2}
+	if !reflect.DeepEqual(tags, wantTags) {
+		t.Errorf("tags = %v, want %v", tags, wantTags)
+	}
+}
+
+// TestAudiobookService_FacetCounts_SetNilRevertsToSentinel pins
+// SetSearchIndex(nil) reverting the service back to the sentinel path, per
+// its own doc comment ("Calling with nil reverts to the Store.SearchBooks
+// fallback").
+func TestAudiobookService_FacetCounts_SetNilRevertsToSentinel(t *testing.T) {
+	idx, err := search.Open(filepath.Join(t.TempDir(), "bleve"))
+	if err != nil {
+		t.Fatalf("open bleve: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+
+	svc := &AudiobookService{}
+	svc.SetSearchIndex(idx)
+	svc.SetSearchIndex(nil)
+
+	if _, _, _, err := svc.FacetCounts(); !errors.Is(err, ErrSearchIndexUnavailable) {
+		t.Fatalf("err = %v, want ErrSearchIndexUnavailable", err)
+	}
+}

--- a/internal/search/bleve_index.go
+++ b/internal/search/bleve_index.go
@@ -1,7 +1,7 @@
 // file: internal/search/bleve_index.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3c8e1a2f-4d9b-4f70-a5c6-2f8d0e1b9a47
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 //
 // BleveIndex is the single-package wrapper around a Bleve v2 scorch
 // index backing library search (spec DES-1 / backlog §4.7). The
@@ -197,6 +197,45 @@ func (b *BleveIndex) SearchNative(q query.Query, from, size int) ([]SearchResult
 		})
 	}
 	return out, res.Total, nil
+}
+
+// FacetCounts returns value->count maps for the genre, language, and
+// tags keyword fields via a MatchAll facet search. size caps distinct
+// values per facet; <=0 defaults to 200. A facet with no matching
+// documents yields an empty map, never nil (e.g. an empty index).
+func (b *BleveIndex) FacetCounts(size int) (genres, languages, tags map[string]int, err error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.idx == nil {
+		return nil, nil, nil, fmt.Errorf("bleve index not open")
+	}
+	if size <= 0 {
+		size = 200
+	}
+	req := bleve.NewSearchRequestOptions(bleve.NewMatchAllQuery(), 0, 0, false)
+	req.AddFacet("genres", bleve.NewFacetRequest("genre", size))
+	req.AddFacet("languages", bleve.NewFacetRequest("language", size))
+	req.AddFacet("tags", bleve.NewFacetRequest("tags", size))
+	res, err := b.idx.Search(req)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return facetTermCounts(res, "genres"), facetTermCounts(res, "languages"), facetTermCounts(res, "tags"), nil
+}
+
+// facetTermCounts extracts one named term-facet's value->count map from a
+// Bleve search result. A missing facet (e.g. zero indexed documents) yields
+// an empty map, never nil.
+func facetTermCounts(res *bleve.SearchResult, facetName string) map[string]int {
+	out := map[string]int{}
+	fr := res.Facets[facetName]
+	if fr == nil || fr.Terms == nil {
+		return out
+	}
+	for _, t := range fr.Terms.Terms() {
+		out[t.Term] = t.Count
+	}
+	return out
 }
 
 // DocCount returns the number of documents currently indexed. Useful

--- a/internal/search/bleve_index_test.go
+++ b/internal/search/bleve_index_test.go
@@ -1,12 +1,13 @@
 // file: internal/search/bleve_index_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8e2c4a1d-5b9f-4f70-a7d6-2f8e0c1b9a58
-// last-edited: 2026-07-10
+// last-edited: 2026-07-11
 
 package search
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -218,4 +219,78 @@ func hitIDs(hits []SearchResult) []string {
 		out[i] = h.BookID
 	}
 	return out
+}
+
+// TestBleveIndex_FacetCounts_KnownDocs indexes fixture docs with known
+// genres/languages/tags and asserts the exact count maps FacetCounts
+// returns (INIT-4 T4).
+func TestBleveIndex_FacetCounts_KnownDocs(t *testing.T) {
+	idx := openTestIndex(t)
+
+	docs := []BookDocument{
+		{BookID: "a", Title: "A", Genre: "Fantasy", Language: "en", Tags: []string{"epic", "series"}},
+		{BookID: "b", Title: "B", Genre: "Fantasy", Language: "en", Tags: []string{"epic"}},
+		// Genre uses a single-word value (no hyphen/space) because the
+		// genre field's "standard" analyzer tokenizes on punctuation, so a
+		// hyphenated value like "Sci-Fi" would fragment into two facet
+		// terms ("sci", "fi") rather than staying one term — orthogonal to
+		// what FacetCounts itself needs to prove here.
+		{BookID: "c", Title: "C", Genre: "Mystery", Language: "fr", Tags: []string{"series"}},
+	}
+	for _, d := range docs {
+		if err := idx.IndexBook(d); err != nil {
+			t.Fatalf("index %s: %v", d.BookID, err)
+		}
+	}
+
+	genres, languages, tags, err := idx.FacetCounts(0)
+	if err != nil {
+		t.Fatalf("FacetCounts: %v", err)
+	}
+
+	wantGenres := map[string]int{"fantasy": 2, "mystery": 1}
+	if !reflect.DeepEqual(genres, wantGenres) {
+		t.Errorf("genres = %v, want %v", genres, wantGenres)
+	}
+	wantLanguages := map[string]int{"en": 2, "fr": 1}
+	if !reflect.DeepEqual(languages, wantLanguages) {
+		t.Errorf("languages = %v, want %v", languages, wantLanguages)
+	}
+	wantTags := map[string]int{"epic": 2, "series": 2}
+	if !reflect.DeepEqual(tags, wantTags) {
+		t.Errorf("tags = %v, want %v", tags, wantTags)
+	}
+}
+
+// TestBleveIndex_FacetCounts_EmptyIndex pins the empty-library edge case:
+// an open index with zero documents returns empty (never nil) maps and no
+// error.
+func TestBleveIndex_FacetCounts_EmptyIndex(t *testing.T) {
+	idx := openTestIndex(t)
+
+	genres, languages, tags, err := idx.FacetCounts(0)
+	if err != nil {
+		t.Fatalf("FacetCounts: %v", err)
+	}
+	if genres == nil || len(genres) != 0 {
+		t.Errorf("genres = %v, want empty non-nil map", genres)
+	}
+	if languages == nil || len(languages) != 0 {
+		t.Errorf("languages = %v, want empty non-nil map", languages)
+	}
+	if tags == nil || len(tags) != 0 {
+		t.Errorf("tags = %v, want empty non-nil map", tags)
+	}
+}
+
+// TestBleveIndex_FacetCounts_NotOpen pins the not-open-index error path
+// (mirrors Search/SearchNative's own nil-idx guard).
+func TestBleveIndex_FacetCounts_NotOpen(t *testing.T) {
+	idx := openTestIndex(t)
+	_ = idx.Close()
+
+	_, _, _, err := idx.FacetCounts(0)
+	if err == nil {
+		t.Error("FacetCounts on a closed index should error")
+	}
 }

--- a/internal/server/audiobooks_helpers.go
+++ b/internal/server/audiobooks_helpers.go
@@ -1,11 +1,11 @@
 // file: internal/server/audiobooks_helpers.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 439aa827-edea-481d-8918-ddacd2c140b7
-// last-edited: 2026-07-05
+// last-edited: 2026-07-11
 
 // Server-package helpers relocated out of audiobooks_handlers.go when the
 // audiobooks HTTP handlers were extracted into the handlers/audiobooks
-// sub-package (ADR-003 Phase 4). These three helpers STAY in package server
+// sub-package (ADR-003 Phase 4). These helpers STAY in package server
 // because they are shared with files that did NOT move:
 //
 //   - buildAudiobookListResponse — the list-pipeline builder, called by both the
@@ -13,6 +13,15 @@
 //     closure) and the library list cache warmer (library_list_warmer.go). Its
 //     signature + *Server-method form are preserved EXACTLY so existing callers
 //     compile unchanged.
+//   - buildFacetsResponse (INIT-4 T4) — the facets response builder, called by
+//     both the relocated AudiobookFacets handler (via the injected
+//     buildFacetsResponse closure, mirroring buildListResponse above) and
+//     warmFacetsCache below, so the handler and the startup warmer can never
+//     drift into different response shapes. DB-distinct genre/language lists
+//     are unconditional; AudiobookService.FacetCounts() (internal/audiobooks/
+//     service_facets.go) adds genre_counts/language_counts/tag_counts on
+//     success and is skipped (not a 500) on any error, including the
+//     nil-index ErrSearchIndexUnavailable sentinel.
 //   - warmFacetsCache — the startup facets cache pre-warmer, launched as a
 //     goroutine from server_lifecycle.go. facetsCacheKey is shared with the
 //     audiobookFacets handler in the sub-package; the string value MUST match
@@ -28,10 +37,10 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
+	"github.com/gin-gonic/gin"
 )
 
 // buildAudiobookListResponse runs the full /api/v1/audiobooks list pipeline
@@ -107,23 +116,33 @@ func (s *Server) buildAudiobookListResponse(ctx context.Context, limit, offset i
 
 const facetsCacheKey = "all"
 
-// warmFacetsCache pre-computes genres and languages at startup.
-// Called as a goroutine from Server.Start so the first Library page load
-// hits the cache instead of triggering a full PebbleDB scan.
-func (s *Server) warmFacetsCache() {
+// buildFacetsResponse composes the /audiobooks/facets response body: the
+// DB-distinct genre/language lists (unconditional, byte-identical to the
+// pre-INIT-4-T4 shape) plus best-effort Bleve facet counts. Shared between
+// the relocated AudiobookFacets handler (via the injected buildFacetsResponse
+// closure passed into audiobookshandler.New, see wire_handlers.go) and
+// warmFacetsCache below so both produce the identical shape — see this
+// file's package doc comment for why the shared builder lives here rather
+// than in the handler sub-package.
+//
+// Any AudiobookService.FacetCounts() error (including the nil-index
+// ErrSearchIndexUnavailable sentinel) fails OPEN: the genre_counts /
+// language_counts / tag_counts keys are simply omitted and the DB-distinct
+// response is returned unchanged. Only a DB-distinct fetch failure (store
+// nil, GetDistinctGenres/Languages erroring) returns a non-nil error here —
+// that is the pre-existing 500 path, unaffected by this task.
+func (s *Server) buildFacetsResponse(ctx context.Context) (gin.H, error) {
+	_ = ctx // reserved for parity with buildAudiobookListResponse; no context-aware call in this path yet.
 	if s.Store() == nil {
-		return
+		return nil, fmt.Errorf("database not initialized")
 	}
-	slog.Info("facets pre-warming genres/languages cache")
 	genres, err := s.Store().GetDistinctGenres()
 	if err != nil {
-		slog.Info("facets genre warm-up failed", "err", err)
-		return
+		return nil, fmt.Errorf("failed to fetch genres: %w", err)
 	}
 	languages, err := s.Store().GetDistinctLanguages()
 	if err != nil {
-		slog.Info("facets language warm-up failed", "err", err)
-		return
+		return nil, fmt.Errorf("failed to fetch languages: %w", err)
 	}
 	if genres == nil {
 		genres = []string{}
@@ -131,8 +150,46 @@ func (s *Server) warmFacetsCache() {
 	if languages == nil {
 		languages = []string{}
 	}
-	s.facetsCache.Set(facetsCacheKey, gin.H{"genres": genres, "languages": languages})
-	slog.Info("facets cache warm genres, languages", "genres_count", len(genres), "languages_count", len(languages))
+	result := gin.H{"genres": genres, "languages": languages}
+
+	if s.audiobookService != nil {
+		genreCounts, languageCounts, tagCounts, fcErr := s.audiobookService.FacetCounts()
+		if fcErr != nil {
+			slog.Debug("facets: Bleve FacetCounts unavailable, serving DB-distinct only", "err", fcErr)
+		} else {
+			result["genre_counts"] = genreCounts
+			result["language_counts"] = languageCounts
+			result["tag_counts"] = tagCounts
+		}
+	}
+
+	return result, nil
+}
+
+// warmFacetsCache pre-computes the facets response at startup via
+// buildFacetsResponse (shared with the AudiobookFacets handler — see that
+// method's doc comment). Called as a goroutine from Server.Start so the
+// first Library page load hits the cache instead of triggering a full
+// PebbleDB scan.
+func (s *Server) warmFacetsCache() {
+	if s.Store() == nil {
+		return
+	}
+	slog.Info("facets pre-warming genres/languages cache")
+	result, err := s.buildFacetsResponse(context.Background())
+	if err != nil {
+		slog.Info("facets warm-up failed", "err", err)
+		return
+	}
+	s.facetsCache.Set(facetsCacheKey, result)
+	genreCount, langCount := 0, 0
+	if g, ok := result["genres"].([]string); ok {
+		genreCount = len(g)
+	}
+	if l, ok := result["languages"].([]string); ok {
+		langCount = len(l)
+	}
+	slog.Info("facets cache warm genres, languages", "genres_count", genreCount, "languages_count", langCount)
 }
 
 // runAutoPurgeSoftDeleted purges soft-deleted books older than the configured

--- a/internal/server/handlers/audiobooks/handler.go
+++ b/internal/server/handlers/audiobooks/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 51fac747-9478-4075-8621-9da4bbdedc37
-// last-edited: 2026-07-05
+// last-edited: 2026-07-11
 
 // Package audiobookshandler hosts the main library list / CRUD HTTP handlers
 // extracted from the server package's audiobooks_handlers.go: book listing
@@ -54,7 +54,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -65,6 +64,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
 )
 
 // facetsCacheKey is the single cache key under which audiobookFacets stores /
@@ -117,6 +117,16 @@ type Handler struct {
 	// byte-for-byte identical.
 	buildListResponse func(ctx context.Context, limit, offset int, search string, authorID, seriesID *int, filters audiobookspkg.ListFilters, showQuarantined bool) (gin.H, error)
 
+	// buildFacetsResponse wraps *Server.buildFacetsResponse (audiobooks_helpers.go),
+	// shared with the startup facets cache warmer (warmFacetsCache) so both
+	// produce the identical {"genres":[...],"languages":[...]} shape, plus the
+	// additive genre_counts/language_counts/tag_counts keys (INIT-4 T4). The
+	// wrapped method folds in AudiobookService.FacetCounts() (internal/audiobooks/
+	// service_facets.go) for those additive keys, failing open to the
+	// DB-distinct-only shape on any FacetCounts error (including the nil-index
+	// ErrSearchIndexUnavailable sentinel) — never a 500 from this handler.
+	buildFacetsResponse func(ctx context.Context) (gin.H, error)
+
 	// isProtectedPath wraps *Server.isProtectedPath (server_middleware.go), used
 	// by updateAudiobook to skip write-back for protected paths.
 	isProtectedPath func(filePath string) bool
@@ -153,6 +163,7 @@ func New(
 	authorsCache *cache.Cache[*audiobookspkg.AuthorWithCountListResponse],
 	seriesCache *cache.Cache[*audiobookspkg.SeriesWithCountsResponse],
 	buildListResponse func(ctx context.Context, limit, offset int, search string, authorID, seriesID *int, filters audiobookspkg.ListFilters, showQuarantined bool) (gin.H, error),
+	buildFacetsResponse func(ctx context.Context) (gin.H, error),
 	isProtectedPath func(filePath string) bool,
 	enrichBook func(book *database.Book) any,
 	getFieldStates func(id string) (any, error),
@@ -173,6 +184,7 @@ func New(
 		authorsCache:         authorsCache,
 		seriesCache:          seriesCache,
 		buildListResponse:    buildListResponse,
+		buildFacetsResponse:  buildFacetsResponse,
 		isProtectedPath:      isProtectedPath,
 		enrichBook:           enrichBook,
 		getFieldStates:       getFieldStates,
@@ -634,11 +646,15 @@ func (h *Handler) CountAudiobooks(c *gin.Context) {
 }
 
 // AudiobookFacets handles GET /audiobooks/facets. Returns lightweight lists of
-// distinct genres and languages for filter dropdowns. Results are cached for 5
-// minutes and pre-warmed at startup (warmFacetsCache stays in package server).
+// distinct genres and languages for filter dropdowns, plus (INIT-4 T4)
+// additive genre_counts/language_counts/tag_counts maps when the Bleve index
+// is available. Results are cached for 5 minutes and pre-warmed at startup
+// (warmFacetsCache stays in package server); both the cache-miss path here
+// and the warmer build the response through the shared buildFacetsResponse
+// closure (see its doc comment on the Handler struct) so they can never
+// drift into different shapes.
 func (h *Handler) AudiobookFacets(c *gin.Context) {
-	store := h.store
-	if store == nil {
+	if h.store == nil {
 		httputil.RespondWithInternalError(c, "database not initialized")
 		return
 	}
@@ -647,23 +663,11 @@ func (h *Handler) AudiobookFacets(c *gin.Context) {
 		return
 	}
 	// Cache miss (e.g. first request before warm-up goroutine completes, or after TTL expiry).
-	genres, err := store.GetDistinctGenres()
+	result, err := h.buildFacetsResponse(c.Request.Context())
 	if err != nil {
-		httputil.InternalError(c, "failed to fetch genres", err)
+		httputil.InternalError(c, "failed to fetch facets", err)
 		return
 	}
-	languages, err := store.GetDistinctLanguages()
-	if err != nil {
-		httputil.InternalError(c, "failed to fetch languages", err)
-		return
-	}
-	if genres == nil {
-		genres = []string{}
-	}
-	if languages == nil {
-		languages = []string{}
-	}
-	result := gin.H{"genres": genres, "languages": languages}
 	h.facetsCache.Set(facetsCacheKey, result)
 	httputil.RespondWithOK(c, result)
 }

--- a/internal/server/handlers/audiobooks/handler_test.go
+++ b/internal/server/handlers/audiobooks/handler_test.go
@@ -1,15 +1,15 @@
 // file: internal/server/handlers/audiobooks/handler_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5cd764d5-8036-425c-842e-c49d0d44acec
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 // Tests for the audiobooks-domain handlers (main library list / CRUD). The
 // store / audiobook-service / updater / write-back / metadata-state /
 // metadata-fetch / batch / changelog / external-id deps are generated mocks; the
-// injected helper funcs (buildListResponse, isProtectedPath, enrichBook,
-// getFieldStates, getExternalIDStore, publishEvent) are stub closures returning
-// canned payloads or recording invocations. There is at least one test per
-// public method (36 methods) plus key branches.
+// injected helper funcs (buildListResponse, buildFacetsResponse, isProtectedPath,
+// enrichBook, getFieldStates, getExternalIDStore, publishEvent) are stub closures
+// returning canned payloads or recording invocations. There is at least one test
+// per public method (36 methods) plus key branches.
 
 package audiobookshandler_test
 
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/mock"
@@ -48,6 +50,9 @@ type recorders struct {
 	publishedEvents  []plugin.Event
 	listResp         gin.H
 	listErr          error
+	facetsResp       gin.H
+	facetsErr        error
+	facetsCalls      int
 	extIDStore       audiobookshandler.ExternalIDStore
 }
 
@@ -101,6 +106,13 @@ func newHandler(t *testing.T) (*audiobookshandler.Handler, testDeps) {
 				rec.listResp = gin.H{"items": []any{}, "count": 0, "limit": limit, "offset": offset}
 			}
 			return rec.listResp, rec.listErr
+		},
+		func(ctx context.Context) (gin.H, error) {
+			rec.facetsCalls++
+			if rec.facetsResp == nil && rec.facetsErr == nil {
+				rec.facetsResp = gin.H{"genres": []string{}, "languages": []string{}}
+			}
+			return rec.facetsResp, rec.facetsErr
 		},
 		func(filePath string) bool {
 			rec.protectedPaths = append(rec.protectedPaths, filePath)
@@ -189,14 +201,92 @@ func TestCountAudiobooks(t *testing.T) {
 	}
 }
 
-func TestAudiobookFacets(t *testing.T) {
+// TestAudiobookFacets_NilIndexFallbackShape pins the INIT-4 T4 nil-index
+// fallback contract: when buildFacetsResponse (the shared handler+warmer
+// builder in package server) can't reach the Bleve index, the response
+// deep-equals the pre-task shape exactly — the genre_counts/language_counts/
+// tag_counts keys are OMITTED, not present-but-empty.
+func TestAudiobookFacets_NilIndexFallbackShape(t *testing.T) {
 	h, d := newHandler(t)
-	d.store.EXPECT().GetDistinctGenres().Return([]string{"Fantasy"}, nil)
-	d.store.EXPECT().GetDistinctLanguages().Return([]string{"en"}, nil)
+	d.rec.facetsResp = gin.H{"genres": []string{"Fantasy"}, "languages": []string{"en"}}
 	c, w := newCtx("GET", "/audiobooks/facets", nil, nil)
 	h.AudiobookFacets(c)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
+	}
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := map[string]any{
+		"genres":    []any{"Fantasy"},
+		"languages": []any{"en"},
+	}
+	if !reflect.DeepEqual(resp.Data, want) {
+		t.Errorf("body = %#v, want %#v (no *_counts keys)", resp.Data, want)
+	}
+	if d.rec.facetsCalls != 1 {
+		t.Errorf("facetsCalls = %d, want 1", d.rec.facetsCalls)
+	}
+}
+
+// TestAudiobookFacets_WithIndexShape pins the with-index shape: the
+// additive genre_counts/language_counts/tag_counts keys are present
+// alongside the unchanged genres/languages lists.
+func TestAudiobookFacets_WithIndexShape(t *testing.T) {
+	h, d := newHandler(t)
+	d.rec.facetsResp = gin.H{
+		"genres":          []string{"Fantasy"},
+		"languages":       []string{"en"},
+		"genre_counts":    map[string]int{"Fantasy": 3},
+		"language_counts": map[string]int{"en": 3},
+		"tag_counts":      map[string]int{},
+	}
+	c, w := newCtx("GET", "/audiobooks/facets", nil, nil)
+	h.AudiobookFacets(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, key := range []string{"genre_counts", "language_counts", "tag_counts"} {
+		if !strings.Contains(body, key) {
+			t.Errorf("body missing %q: %s", key, body)
+		}
+	}
+}
+
+// TestAudiobookFacets_CacheHitSkipsBuilder confirms a warm cache entry is
+// served without invoking buildFacetsResponse again.
+func TestAudiobookFacets_CacheHitSkipsBuilder(t *testing.T) {
+	h, d := newHandler(t)
+	// newHandler's caches use a 0 default TTL (always-expired, so every other
+	// test here forces a cache miss on purpose) — this test needs an entry
+	// that is still live when AudiobookFacets reads it, hence SetWithTTL.
+	d.facetCache.SetWithTTL("all", gin.H{"genres": []string{"Fantasy"}, "languages": []string{"en"}}, time.Minute)
+	c, w := newCtx("GET", "/audiobooks/facets", nil, nil)
+	h.AudiobookFacets(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	if d.rec.facetsCalls != 0 {
+		t.Errorf("facetsCalls = %d, want 0 (cache hit should skip the builder)", d.rec.facetsCalls)
+	}
+}
+
+// TestAudiobookFacets_BuilderError covers the pre-existing (unrelated to
+// INIT-4 T4) DB-fetch-failure path: buildFacetsResponse returning an error
+// (e.g. store not initialized, GetDistinctGenres/Languages erroring) is
+// still a 500 — only a FacetCounts-specific error fails open, per the
+// builder's own doc comment (audiobooks_helpers.go).
+func TestAudiobookFacets_BuilderError(t *testing.T) {
+	h, d := newHandler(t)
+	d.rec.facetsErr = errString("database not initialized")
+	c, w := newCtx("GET", "/audiobooks/facets", nil, nil)
+	h.AudiobookFacets(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", w.Code)
 	}
 }
 

--- a/internal/server/handlers_integration_test.go
+++ b/internal/server/handlers_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers_integration_test.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-06-23
+// last-edited: 2026-07-11
 
 package server
 
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/batch"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
@@ -26,6 +25,7 @@ import (
 	system "github.com/falkcorp/audiobook-organizer/internal/server/handlers/system"
 	"github.com/falkcorp/audiobook-organizer/internal/undo"
 	"github.com/falkcorp/audiobook-organizer/internal/work"
+	"github.com/gin-gonic/gin"
 )
 
 // newOperationsHandler constructs an operations.Handler from the test server's
@@ -171,6 +171,7 @@ func newAudiobooksHandler(s *Server) *audiobookshandler.Handler {
 		s.authorsCache,
 		s.seriesCache,
 		s.buildAudiobookListResponse,
+		s.buildFacetsResponse,
 		s.isProtectedPath,
 		func(b *database.Book) any { return s.enrichBookForResponseSingle(b) },
 		func(id string) (any, error) { return s.metadataStateService.LoadMetadataState(id) },

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.16.0
+// version: 2.17.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-05
+// last-edited: 2026-07-11
 
 package server
 
@@ -504,6 +504,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		s.authorsCache,
 		s.seriesCache,
 		s.buildAudiobookListResponse,
+		s.buildFacetsResponse,
 		s.isProtectedPath,
 		func(b *database.Book) any { return s.enrichBookForResponseSingle(b) },
 		func(id string) (any, error) { return s.metadataStateService.LoadMetadataState(id) },


### PR DESCRIPTION
The facets endpoint returned only DB-distinct string lists. Add
BleveIndex.FacetCounts over the already-indexed keyword fields, a
service wrapper with a nil-index sentinel, and additive *_counts
response keys — existing keys and the startup warmer stay in lockstep,
DB-distinct remains the fallback on any index error.

Co-Authored-By: Claude <noreply@anthropic.com>
