### PR TITLE
docs(status): changelog + follow-ups for execution wave 2b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.136.0 -->
+<!-- version: 3.137.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -8,6 +8,51 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 11, 2026 - feat(search): Bleve facet counts for genres/languages/tags (INIT-4 T04, #1888)
+
+- **`search`** — added `*_counts` facet aggregations (genres/languages/tags) to Bleve search
+  responses via a single shared `buildFacetsResponse` builder that both the search handler and the
+  facets cache warmer now route through, so the two response shapes can never drift out of
+  lockstep with each other. Additive and fail-open: on any facet-building error the new
+  `*_counts` keys are simply omitted, leaving the response byte-identical to the pre-change shape
+  at HTTP 200. No frontend change required to adopt.
+
+#### July 11, 2026 - test(organizer): verify Author/Series fate in CreateOrganizedVersion write-back (STOREFID W5d-1, INIT-9 T07, #1887)
+
+- **`organizer`** — added regression coverage for the original-book slim write-back tracked in
+  TODO.md (`🟠 CreateOrganizedVersion original-book slim-writeback`). **Confirms a real prod
+  data-loss bug (Outcome B):** Author/Series do **not** survive the `CreateOrganizedVersion`
+  original-book write-back. `PebbleStore.UpdateBook`'s STOR-1 preserve-on-nil guard
+  (`internal/database/pebble_store.go:1571-1598`) restores Description/VersionNotes/BookSig* from
+  the old row when the incoming value is nil, but has no equivalent case for Author/Series — so
+  the page-derived, heavy-field-nil `book` written back at
+  `internal/organizer/service.go:927-941` silently wipes them on the original book. The new test
+  `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback`
+  (`internal/organizer/organized_version_writeback_test.go`) documents this executably via
+  `t.Skipf("W5d-1 KNOWN BUG CONFIRMED")` — it will flip to a real PASS once the fail-open hydrate
+  fix lands. The companion demotion-invariant test (VersionGroupID/IsPrimaryVersion/LibraryState)
+  passes today. **This PR is test-only and does not fix the bug** — the fix is a deliberately
+  deferred, decision-carrying follow-up (see TODO.md).
+
+#### July 11, 2026 - ci(mocks): quote mock-freshness pathspec so nested mocks dirs are checked (INIT-9 T04, #1797, #1886)
+
+- **`ci`** — fixed the Mock-Freshness CI check's glob: the unquoted shell pattern
+  `internal/*/mocks/` only ever matched one path segment, so nested mock directories such as
+  `internal/server/handlers/*/mocks/` were silently excluded from the staleness diff. Replaced
+  with the quoted git pathspec `:(glob)internal/**/mocks/**` in `.github/workflows/ci.yml`, which
+  recurses into nested `mocks/` dirs at any depth. This is the exact gap that let a stale nested
+  mock slip past CI earlier this session. `.github/workflows/ci.yml` only; all nested mocks were
+  already fresh, so this is a coverage fix with no behavior change today.
+
+#### July 11, 2026 - refactor(dedup): move boilerplate title blocklist to config-extendable module (INIT-4 T05, #1885)
+
+- **`dedup`** — moved the hardcoded boilerplate-title blocklist out of `internal/dedup/engine.go`
+  into a new self-initializing `internal/dedup/boilerplate.go` (`sync.Once`-guarded, defaults
+  byte-identical to the old inline lists), and added an extension-only `DedupBoilerplateConfig` to
+  config so operators can append additional boilerplate titles without a code change. Purely
+  behavior-preserving — the emit()-sharding from #1883 is untouched, and all 9 existing call sites
+  plus the 3 existing test files stayed green.
 
 #### July 11, 2026 - perf(search): batch-hydrate Bleve hits with GetBooksByIDs (INIT-4 T03, #1882)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.85.0 -->
+<!-- version: 9.86.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -39,7 +39,7 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
 - Prod-data mutations (INIT-1 T7, INIT-2 T3/T6 drains, INIT-10 C8) are dry-run →
   AskUserQuestion gated in the briefs.
 
-### ✅ Execution Wave 1 + Wave 2 shipped (2026-07-10/11) — 11/50 tasks merged
+### ✅ Execution Wave 1 + Wave 2 + Wave 2b shipped (2026-07-10/11) — 15/50 tasks merged
 
 - **Wave 1 (5 PRs, #1871–#1875, merged 2026-07-10):** see
   [`docs/status/2026-07-10-execution-wave1-executive-summary.md`](docs/status/2026-07-10-execution-wave1-executive-summary.md).
@@ -55,10 +55,29 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
     (#1883).
   - **INIT-2's `internal/dedup/engine.go` tasks (T03 + T05) are both merged**, which unblocks
     Phase B: INIT-1 TASK-08 and INIT-4 TASK-05 (both rebase on that file) can now start.
-- **REMAINING: 39** of the 50-brief catalog across INIT-1..10 (11 shipped across the two waves;
-  39 not started), plus Phase B/C follow-ups.
+- **Wave 2b (4 PRs, #1885–#1888, merged 2026-07-11):** see
+  [`docs/status/2026-07-11-execution-wave2b-executive-summary.md`](docs/status/2026-07-11-execution-wave2b-executive-summary.md).
+  - [x] INIT-4 T05 — move boilerplate title blocklist to config-extendable module (#1885).
+  - [x] INIT-9 T04 — quote mock-freshness pathspec so nested mocks dirs are checked (#1886) — see
+    follow-up B below (Makefile has the same unfixed bug).
+  - [x] INIT-9 T07 — verify Author/Series fate in `CreateOrganizedVersion` write-back (#1887) —
+    **test-only; confirmed a real HIGH prod-data-loss bug, see the "🔴 HIGH — PROD DATA-LOSS"
+    section above.** Does not fix it.
+  - [x] INIT-4 T04 — Bleve facet counts for genres/languages/tags (#1888).
+  - **INIT-4 is now 5/6** (T01–T05 shipped across Wave 1/Wave 2/Wave 2b; only T06 heavy-filter
+    perf-pushdown remains — review-critical since it touches search query construction).
+- **REMAINING: 35** of the 50-brief catalog across INIT-1..10 (15 shipped across the three
+  waves; 35 not started), plus Phase B/C follow-ups, plus the two Wave-2b follow-ups below.
 - **BLOCKED: 3** — INIT-5 T2 (needs Deluge-spike sign-off), INIT-9 REPO-SIZE-1
   (STOP-FOR-HUMAN plan review), INIT-7 (held on #1260–#1265).
+- **Wave 2b follow-ups (new, open, not yet fixed):**
+  - **A.** 🔴 HIGH prod data-loss — see the dedicated section above
+    ("CreateOrganizedVersion original-book slim-writeback wipes Author/Series").
+  - **B.** `Makefile` lines ~212/214 (`mocks-check` target) use the identical unquoted
+    `internal/*/mocks/` pathspec that #1886 just fixed in `.github/workflows/ci.yml` — it
+    currently passes only because all committed mocks happen to be fresh, not because the glob is
+    correct. Quote it the same way: `:(glob)internal/**/mocks/**`. Low-risk, mechanical,
+    good next-wave candidate.
 
 ---
 
@@ -101,31 +120,40 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
 
 ---
 
-## 🟠 CreateOrganizedVersion original-book slim-writeback (Author/Series) — follow-up (STOREFID W5d-1, 2026-07-07)
+## 🔴 HIGH — PROD DATA-LOSS: CreateOrganizedVersion original-book slim-writeback wipes Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887) — needs human decision
 
-- **Pre-existing latent bug** surfaced during STOREFID W5d-1 review.
-  `internal/organizer/service.go` `CreateOrganizedVersion` writes the page-sourced
-  *original* book back with the version-group / non-primary / `organized_source` stamp:
+- **⚠️ CONFIRMED, not just suspected, as of 2026-07-11 (#1887, INIT-9 T07).** The executable test
+  `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback`
+  (`internal/organizer/organized_version_writeback_test.go`) proves this against a real
+  `PebbleStore`, not just memdb: `t.Skipf("W5d-1 KNOWN BUG CONFIRMED")`. It will flip to a real
+  PASS once the fix below lands — use it as the acceptance test, don't write a new one.
+- **Root cause, exact locations:**
+  `PebbleStore.UpdateBook`'s STOR-1 preserve-on-nil guard
+  (`internal/database/pebble_store.go:1571-1598`) restores Description/VersionNotes/BookSig* from
+  the old row when the incoming value is nil, but has **no equivalent case for Author/Series**.
+  The call site at `internal/organizer/service.go:927-941` writes back a page-derived
+  (`GetAllBooksCore`→`ToBook`), heavy-field-nil `book` with the version-group / non-primary /
+  `organized_source` stamp:
   ```go
   book.VersionGroupID = &versionGroupID
   book.IsPrimaryVersion = &isNotPrimary
   book.LibraryState = &organizedSourceState
   orgSvc.db.UpdateBook(book.ID, book)   // book is GetAllBooksCore→ToBook, heavy-field-nil
   ```
-  Under prod's memdb default `book` has nil `Author`/`Series` (not STOR-1-guarded), so this
-  wipes the original's denormalized author/series. Prod behavior is unchanged by W5d-1
-  (memdb already stripped these); the `.ToBook()` in W5d-1 just makes it no longer
-  compile-visible — `GetAllBooks` was removed entirely in W5z (2026-07-07), so this is now
-  the only remaining route back to a full `Book` in this code path.
+  so the original book's denormalized Author/Series are silently wiped on every
+  `CreateOrganizedVersion` call, under the production PebbleStore backend, not just memdb.
 - **Fix must be careful:** hydrating via `GetBookByID` before the write (the usual pattern)
   preserves Author/Series BUT must NOT regress the version-group state transition to
   fail-closed — a `GetBookByID` error must still demote the original to non-primary, or the
   version group ends up with **two primaries**. So: hydrate-and-write on success, but fall
   back to the direct state write (accepting the rare Author/Series wipe) if hydrate fails —
-  i.e. fail-OPEN for the state transition, preserve-heavy-when-possible. Add a regression
-  test asserting Author survives AND the original is demoted even when GetBookByID errors.
+  i.e. fail-OPEN for the state transition, preserve-heavy-when-possible.
 - Same writeback shape as the W5d-1 organizer writebacks that DID get the `hydrateAndUpdateBook`
   helper; this one was deliberately left out pending the fail-open design above.
+- **DEFERRED TO A HUMAN.** Both the fail-open hydrate fix (a decision-carrying change to a
+  version-group state-transition invariant) and filing a tracking GitHub issue are intentionally
+  left undone by #1887 — that PR is test-only. Do not implement the fix or file the issue without
+  explicit sign-off; when approved, the fix should flip the #1887 test from SKIP to PASS.
 
 ## ✅ PR-D: deluge import fingerprint-wipe (3 impls) — RESOLVED (STOREFID W6, 2026-07-07)
 

--- a/docs/status/2026-07-11-execution-wave2b-executive-summary.md
+++ b/docs/status/2026-07-11-execution-wave2b-executive-summary.md
@@ -1,0 +1,106 @@
+<!-- file: docs/status/2026-07-11-execution-wave2b-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9d4e7f31-6b8c-4a2d-b5e9-1c3f8a7d6042 -->
+<!-- last-edited: 2026-07-11 -->
+
+# Executive Summary: Remaining-Work Execution, Wave 2b
+
+**Shipped:** PRs [#1885](https://github.com/falkcorp/audiobook-organizer/pull/1885), [#1886](https://github.com/falkcorp/audiobook-organizer/pull/1886), [#1887](https://github.com/falkcorp/audiobook-organizer/pull/1887), [#1888](https://github.com/falkcorp/audiobook-organizer/pull/1888), all merged into `main` on 2026-07-11.
+**Related plan:** [2026-07-10 remaining-work execution manifest](../plans/2026-07-10-execution-manifest.md), from the planning package merged in PR [#1870](https://github.com/falkcorp/audiobook-organizer/pull/1870).
+**Related summaries:** [Wave 1 executive summary](2026-07-10-execution-wave1-executive-summary.md), [Wave 2 executive summary](2026-07-11-execution-wave2-executive-summary.md) — the two earlier slices of the same plan.
+
+## The most important thing in this wave: a confirmed prod data-loss bug (not fixed yet — needs a human decision)
+
+One of these four changes is test-only and does not fix anything. It exists specifically to
+settle, with a real automated test against the real production database engine, whether a
+long-suspected bug is actually happening. **It is.**
+
+**What's broken:** When a user organizes a book into a new location and the system creates an
+"organized version," it also writes back a small update to the *original* book record — marking
+it as a non-primary version of the new one. That write-back silently erases the original book's
+**Author and Series** information, because the record being written was built from a data path
+that never carried Author/Series to begin with, and the database layer's "don't overwrite good
+data with a blank" safety net (which already protects several other fields) doesn't cover
+Author/Series. This is not a new bug — it was suspected and documented on 2026-07-07 — but this
+wave's test is the first proof that it happens against the actual production database engine, not
+just a in-memory approximation of it.
+
+**Why it wasn't fixed in this wave:** the correct fix is more delicate than "just re-fetch the
+record first," because that same write-back also has to demote the original book to non-primary
+so the system never ends up with two "primary" versions of the same book. If the re-fetch step
+itself fails, the fix has to decide which invariant to protect — never leave Author/Series wiped,
+or never leave two primary versions — and that's a real trade-off a human should sign off on, not
+something to silently pick during an autonomous pass. The new test is written to serve as the
+acceptance check for whichever fix gets approved: it currently skips itself with an explicit
+"KNOWN BUG CONFIRMED" message and will turn into a real pass once the fix lands.
+
+**What to do next:** this needs your decision on the trade-off above, and then a tracking GitHub
+issue and a follow-up fix PR — both intentionally left undone here. See the escalated entry in
+`TODO.md` ("🔴 HIGH — PROD DATA-LOSS: CreateOrganizedVersion original-book slim-writeback wipes
+Author/Series") for the exact file and line references.
+
+## The other three changes (low-risk, all shipped)
+
+### A CI safety check had a blind spot for nested folders
+
+**What it was:** The automated check that verifies generated mock code is up to date used a
+folder-matching pattern that only looked one level deep. Mock folders nested two or more levels
+down (which do exist in this project) were invisible to the check — they could go stale and CI
+would never notice.
+
+**Why it mattered:** This is the exact kind of gap that let a stale nested mock slip past review
+earlier in the same work session.
+
+**The fix:** Changed the pattern to explicitly match at any depth. No mocks were actually stale
+today — this closes the blind spot before it causes a real problem, not because it already had.
+**Note:** a second copy of the exact same broken pattern was found in the local `make
+mocks-check` target (`Makefile`) during this wave's review — it wasn't touched (out of scope for
+this PR) and is now a tracked open follow-up.
+
+### A hardcoded list moved to a place operators can extend
+
+**What it was:** The list of "boilerplate" audiobook titles the duplicate-detection system
+ignores (things like generic placeholder titles that aren't real book identifiers) was hardcoded
+directly inside a large, sensitive file that several other changes this session also had to
+modify.
+
+**Why it mattered:** Two problems at once: hardcoded lists can't be extended without a code
+change, and living inside a heavily-edited shared file made this list an unnecessary source of
+merge friction for unrelated work.
+
+**The fix:** Moved the list into its own small file with the exact same default values, and made
+it extensible through configuration. Nothing about which titles are treated as boilerplate changed
+today.
+
+### Search results can now show facet counts
+
+**What it was:** Search results already supported filtering by genre, language, and tag, but the
+response didn't tell the frontend how many results exist in each category — so a filter UI
+couldn't show "Fantasy (42)" without a separate query.
+
+**Why it mattered:** This is groundwork for a nicer filtering experience; without counts, any
+future genre/language/tag filter UI would need extra round-trips or would have to guess.
+
+**The fix:** Added the counts as new fields in the search response, computed by one shared
+function used both when a live search runs and when the results are pre-warmed into cache — so
+the two code paths can never disagree on the numbers. If anything goes wrong computing them, the
+new fields are just left out and the rest of the response is unaffected; no existing frontend code
+needs to change to keep working.
+
+## Verification approach
+
+All four changes passed the project's standard "Minimal CI" gate (build, short tests with the
+race detector, frontend lint/test, mock-freshness check) before merging. The data-loss-confirming
+test (#1887) is deliberately a `t.Skipf`, not a `t.Fatal` — it documents the bug without failing
+CI, since fixing it is out of scope for this PR.
+
+## What's next
+
+- **Human decision needed** on the Author/Series write-back fix trade-off (see above) before any
+  code changes there.
+- The Makefile mock-freshness follow-up (same bug #1886 fixed in CI, still present locally) is a
+  small, low-risk next-wave candidate.
+- INIT-4 (filtering-search) is now 5 of 6 tasks shipped — only T06 (heavy-filter perf pushdown)
+  remains, and it's flagged as review-critical since it touches search query construction.
+- The remaining ~35 tasks from the original 50-task catalog are tracked in the execution manifest
+  linked above.


### PR DESCRIPTION
## Summary
- Records the 4 execution-wave-2b PRs (#1885 INIT-4 T05, #1886 INIT-9 T04, #1887 INIT-9 T07, #1888 INIT-4 T04) in CHANGELOG.md and extends TODO.md's "Execution Wave 1 + Wave 2" section to "Wave 1 + Wave 2 + Wave 2b" (11/50 → 15/50 catalog tasks).
- **Escalates an existing TODO.md item to HIGH severity** (`🔴 HIGH — PROD DATA-LOSS: CreateOrganizedVersion original-book slim-writeback wipes Author/Series`): #1887's new test proves, against a real `PebbleStore`, that Author/Series are silently wiped on the original book's write-back during `CreateOrganizedVersion`. The fix itself is deliberately NOT included here — it needs a human decision on a fail-open-hydrate-vs-version-group-invariant trade-off.
- Adds a small open follow-up: `Makefile:212,214` has the same unquoted mock-freshness glob bug that #1886 just fixed in `.github/workflows/ci.yml`.
- New `docs/status/2026-07-11-execution-wave2b-executive-summary.md`, leading with the confirmed data-loss finding.

This is a **documentation-only PR** — zero product code touched. `CHANGELOG.md` and `TODO.md` are updated, one new file under `docs/status/` is added. (A gitignored session-status note at `.claude/notes/2026-07-10-execution-session-status.md` was also updated directly on `main`, outside this PR, since gitignored files cannot be part of a PR diff.)

## Test plan
- [x] Diff-only review: `git diff --stat origin/main` shows only `CHANGELOG.md`, `TODO.md`, and the new `docs/status/2026-07-11-execution-wave2b-executive-summary.md` — no code files.
- [x] Verified the cited file:line anchors (`internal/database/pebble_store.go:1571-1598`, `internal/organizer/service.go:927-941`) against current `main` before writing them into TODO.md.
- [x] Verified the Makefile follow-up's line numbers (`Makefile:212,214`) against current `main`.
- N/A — no code changes to build/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv