### PR TITLE
docs(process): split status reports from executive summaries into separate folders

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.87.0 -->
+<!-- version: 9.88.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -42,11 +42,13 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
 ### ✅ Execution Wave 1 + Wave 2 + Wave 2b shipped (2026-07-10/11) — 15/50 tasks merged
 
 - **Wave 1 (5 PRs, #1871–#1875, merged 2026-07-10):** see
-  [`docs/status/2026-07-04-monthly-roundup-executive-summary.md`](docs/status/2026-07-04-monthly-roundup-executive-summary.md)
+  [`docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md`](docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md)
   (theme 16, "Remaining-work execution wave" — the three wave docs were folded into the monthly
-  roundup and removed).
+  roundup and removed) and
+  [`docs/status/2026-07-11-remaining-work-execution.md`](docs/status/2026-07-11-remaining-work-execution.md)
+  for the terse PR-by-PR status record.
 - **Wave 2 (6 PRs, #1878–#1883, merged 2026-07-11):** see
-  [`docs/status/2026-07-04-monthly-roundup-executive-summary.md`](docs/status/2026-07-04-monthly-roundup-executive-summary.md)
+  [`docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md`](docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md)
   (theme 16).
   - [x] INIT-2 T04 — dedup candidate status secondary index (#1878).
   - [x] INIT-3 T02 — extract metadata scoring literals into `MetadataScoringConfig` (#1879).
@@ -59,7 +61,7 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   - **INIT-2's `internal/dedup/engine.go` tasks (T03 + T05) are both merged**, which unblocks
     Phase B: INIT-1 TASK-08 and INIT-4 TASK-05 (both rebase on that file) can now start.
 - **Wave 2b (4 PRs, #1885–#1888, merged 2026-07-11):** see
-  [`docs/status/2026-07-04-monthly-roundup-executive-summary.md`](docs/status/2026-07-04-monthly-roundup-executive-summary.md)
+  [`docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md`](docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md)
   (theme 16, plus the #1887 prod data-loss confirmation in the "Highest-risk items" list).
   - [x] INIT-4 T05 — move boilerplate title blocklist to config-extendable module (#1885).
   - [x] INIT-9 T04 — quote mock-freshness pathspec so nested mocks dirs are checked (#1886) — see

--- a/docs/executive-summaries/2026-07-03-itl-hardening-executive-summary.md
+++ b/docs/executive-summaries/2026-07-03-itl-hardening-executive-summary.md
@@ -1,7 +1,7 @@
-<!-- file: docs/status/2026-07-03-itl-hardening-executive-summary.md -->
+<!-- file: docs/executive-summaries/2026-07-03-itl-hardening-executive-summary.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: d6272ad6-0339-46b6-af79-209576b0cf24 -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-11 -->
 
 # Executive Summary: iTunes Library (.itl) Write-Back Hardening
 

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -1,4 +1,4 @@
-<!-- file: docs/status/2026-07-04-monthly-roundup-executive-summary.md -->
+<!-- file: docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md -->
 <!-- version: 1.1.0 -->
 <!-- guid: 5b0ee171-8a4f-4669-a2dd-91ffeabaa486 -->
 <!-- last-edited: 2026-07-11 -->

--- a/docs/process/executive-summaries.md
+++ b/docs/process/executive-summaries.md
@@ -1,7 +1,7 @@
 <!-- file: docs/process/executive-summaries.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: b608794a-eac5-44bc-95b9-643872bd0ca8 -->
-<!-- last-edited: 2026-07-04 -->
+<!-- last-edited: 2026-07-11 -->
 
 # Executive Summary Convention
 
@@ -27,11 +27,19 @@ for.
 
 ## Where it goes
 
-`docs/status/YYYY-MM-DD-<short-topic>-executive-summary.md`, using the date
-the work shipped (merge date), not the date work started.
+`docs/executive-summaries/YYYY-MM-DD-<short-topic>-executive-summary.md`,
+using the date the work shipped (merge date), not the date work started.
 
 If the work also produced a formal spec (see `docs/specs/`), link to it and
 to the merged PR at the top of the summary.
+
+An executive summary is the polished, stakeholder-facing narrative for a
+body of work — distinct from a status report (see
+[`docs/process/status-reports.md`](status-reports.md)), which is a terse,
+internal/operational update (a TL;DR, a table of what shipped, and what's
+still in flight or blocked) aimed at the maintainer/engineer rather than a
+non-engineer stakeholder; the two are not mutually exclusive and a large
+execution wave often warrants both.
 
 ## Structure
 

--- a/docs/process/status-reports.md
+++ b/docs/process/status-reports.md
@@ -1,0 +1,78 @@
+<!-- file: docs/process/status-reports.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3cbd8de8-4d8e-442d-958e-fc04662bc325 -->
+<!-- last-edited: 2026-07-11 -->
+
+# Status Report Convention
+
+A status report is a terse, internal/operational record of a work session,
+sprint, or execution wave: what shipped, what's still in flight, and what's
+blocked or deferred. It is written for the maintainer/engineer, not for a
+non-engineer stakeholder — unlike an
+[executive summary](executive-summaries.md), a status report is allowed to
+use file:line references, PR numbers, and internal jargon freely.
+
+## When to produce one
+
+Produce a status report after a significant work session, sprint, or
+execution wave, when the maintainer needs a quick record of what shipped,
+what's in flight, and what's blocked or deferred — for example:
+
+- A multi-PR execution wave (planning → task briefs → several PRs merged in
+  one session).
+- A focused push on a specific track (e.g. a backend cutover, a calibration
+  pass) that produced several merged PRs plus some open follow-up items.
+- Handing off mid-task, so the next session (or a teammate) can pick up
+  without re-deriving state from `git log`.
+
+Do **not** produce one for a single small PR or a routine fix — that's what
+the commit message and CHANGELOG entry are for.
+
+## Where it goes
+
+`docs/status/YYYY-MM-DD-<short-topic>.md`, using the date the report was
+written (typically the date the session wrapped up).
+
+Note the naming difference from executive summaries: status reports do
+**not** use the `-executive-summary` suffix — that suffix is reserved for
+[`docs/executive-summaries/`](../executive-summaries/).
+
+## Structure
+
+Based on `docs/status/2026-07-02-local-cutover-and-matching.md` as the
+reference example:
+
+1. **Header block**: the standard 4-line file header.
+2. **`## TL;DR`**: a short paragraph covering what happened, why, and what's
+   left — enough for someone to understand the session's shape without
+   reading further.
+3. **`## Shipped this session`**: a table of what merged, with columns
+   `PR | Area | What`. Keep each "What" cell to one terse line.
+4. Any of the following sections that apply:
+   - **`## In flight`** — work started but not yet merged/complete.
+   - **`## Blocked / deferred`** — work explicitly paused, waiting on a
+     decision, sign-off, or external dependency.
+   - **`## Next steps`** — what should happen in the next session.
+
+Additional freeform sections (setup notes, config dumps, findings) are fine
+when they help a reader resume the work, following the shape of the
+reference example above.
+
+Write for the maintainer/engineer audience: technical detail, file:line
+references, and PR numbers are all appropriate here — the opposite of the
+"no jargon, no file paths" rule for executive summaries.
+
+## Status reports vs. executive summaries
+
+A status report and an executive summary **may both exist for the same body
+of work** — they are not mutually exclusive. A large execution wave often
+warrants both: a terse internal one in `docs/status/` for the maintainer,
+and a polished narrative one in `docs/executive-summaries/` for
+non-engineer stakeholders. When both exist, cross-link them.
+
+## Workflow
+
+1. Do the work, ship it (PRs merged).
+2. Draft the status report using the structure above.
+3. Commit it and open a normal PR like any other change.
+4. Mention the file path back to the user so they can find it.

--- a/docs/status/2026-07-11-remaining-work-execution.md
+++ b/docs/status/2026-07-11-remaining-work-execution.md
@@ -1,0 +1,74 @@
+<!-- file: docs/status/2026-07-11-remaining-work-execution.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8877ac6a-c413-408f-b4b3-fd48a6ece32a -->
+<!-- last-edited: 2026-07-11 -->
+
+# Status — Remaining-Work Execution Wave (2026-07-10 – 2026-07-11)
+
+## TL;DR
+
+Ran the planning→execution pipeline end to end: PR #1870 produced a 10-initiative
+catalog (INIT-1..10 — specs, plans, and 50 weak-model-proof task briefs) plus an
+execution manifest, then execution landed ~15 code PRs across dedup, search,
+metadata, and tech-debt, split into a wave-1 batch (#1871–#1875) and a longer
+wave-2 batch (#1878–#1888), with three docs-only follow-up PRs (#1884, #1890,
+#1891) recording progress along the way. One **confirmed prod data-loss bug**
+was surfaced and deliberately left unresolved for a human decision rather than
+auto-fixed — see #1887 (Author/Series wiped on `CreateOrganizedVersion`
+write-back). Phase B is partly unblocked: the INIT-2 `engine.go` dedup tasks
+landed (#1875, #1878, #1881, #1883). Remaining autonomous-lane work is still
+open: INIT-1, INIT-3 (T03–T08), INIT-4 (T06), INIT-9 (T01/T02), and INIT-10.
+
+This document itself is a further follow-up: it, and the folder split it
+belongs to (`docs/status/` vs `docs/executive-summaries/`), landed in a PR
+opened after #1891 — see that PR for the taxonomy change.
+
+For the polished, stakeholder-facing narrative version of this same body of
+work, see the "Remaining-work execution wave" theme in
+[`docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md`](../executive-summaries/2026-07-04-monthly-roundup-executive-summary.md).
+
+## Shipped this session
+
+| PR | Area | What |
+|----|------|------|
+| #1870 | planning | 10-initiative planning package (specs + plans + 50 task briefs, INIT-1..10) + execution manifest |
+| #1871 | search | Dead Bleve field-boost bug fixed (title/author/series ranking) |
+| #1872 | metadata | Duplicate duration-scoring functions unified behind one ratio-tier table (golden-fixture verified) |
+| #1873 | reliability | Cache warmers enrolled in shutdown WaitGroup (goroutine-leak-on-restart fix) |
+| #1874 | search | **Correctness bug**: per-user search filters (read_status etc.) were silently discarded — fixed |
+| #1875 | dedup | `GetFolderDuplicatesCore` implemented on Pebble + MemStore (dedup tier 2 now live) |
+| #1878 | dedup | Candidate status secondary index + backfill op |
+| #1879 | metadata | Scoring literals extracted to `MetadataScoringConfig` (behavior-preserving) |
+| #1880 | tech-debt | sdkguard dependency-guard fixed via decorator inversion + type move |
+| #1881 | dedup | Drain-gate parity with the emission chokepoint; drain flag v1→v2 |
+| #1882 | search | Bleve hit hydration batched via `GetBooksByIDs` (was per-hit) |
+| #1883 | dedup | Full-scan emit() mutex sharded 16-way (CONC-3); -race verified |
+| #1884 | docs | Executive summary + changelog for execution wave 2 |
+| #1885 | dedup | Boilerplate-title blocklist moved to a config-extendable module |
+| #1886 | ci | Mock-freshness CI glob fixed to cover nested mocks dirs |
+| #1887 | organizer | **Confirmed prod bug**: Author/Series wiped on `CreateOrganizedVersion` write-back (test documents it, fix deferred) |
+| #1888 | search | Bleve facet counts (genres/languages/tags), handler+warmer in lockstep |
+| #1890 | docs | Changelog + follow-ups for execution wave 2b |
+| #1891 | docs | Consolidated the wave-1/wave-2 executive summaries into the monthly roundup doc |
+
+## In flight
+
+- Phase B (dedup engine work) is partly unblocked — the INIT-2 `engine.go`
+  tasks that landed (#1875, #1878, #1881, #1883) clear the path for the
+  remaining INIT-2 items, but those have not started yet.
+
+## Blocked / deferred
+
+- **INIT-5 T2** — Deluge spike, needs sign-off before proceeding.
+- **INIT-9 REPO-SIZE-1** — history-rewrite plan needs review before execution
+  (destructive, one-way operation on repo history).
+- **INIT-7** — on hold.
+- **Author/Series prod-fix decision (#1887)** — the bug is confirmed and
+  documented by a test, but the fix itself is deliberately deferred pending a
+  human decision on rollout approach.
+
+## Next steps
+
+- Remaining autonomous-lane initiatives still open: **INIT-1**, **INIT-3**
+  (T03–T08), **INIT-4** (T06), **INIT-9** (T01/T02), **INIT-10**.
+- Resolve the blocked/deferred items above before resuming their initiatives.

--- a/docs/status/2026-07-11-remaining-work-execution.md
+++ b/docs/status/2026-07-11-remaining-work-execution.md
@@ -1,5 +1,5 @@
 <!-- file: docs/status/2026-07-11-remaining-work-execution.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.0.1 -->
 <!-- guid: 8877ac6a-c413-408f-b4b3-fd48a6ece32a -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -20,8 +20,8 @@ landed (#1875, #1878, #1881, #1883). Remaining autonomous-lane work is still
 open: INIT-1, INIT-3 (T03–T08), INIT-4 (T06), INIT-9 (T01/T02), and INIT-10.
 
 This document itself is a further follow-up: it, and the folder split it
-belongs to (`docs/status/` vs `docs/executive-summaries/`), landed in a PR
-opened after #1891 — see that PR for the taxonomy change.
+belongs to (`docs/status/` vs `docs/executive-summaries/`), landed in
+[PR #1892](https://github.com/falkcorp/audiobook-organizer/pull/1892).
 
 For the polished, stakeholder-facing narrative version of this same body of
 work, see the "Remaining-work execution wave" theme in


### PR DESCRIPTION
## Summary

- Formalizes status updates and executive summaries as two distinct document types, each in its own folder: polished, stakeholder-facing narratives move to `docs/executive-summaries/`; terse internal/operational status reports stay in `docs/status/`.
- Moves the two existing executive-summary docs (`2026-07-03-itl-hardening-executive-summary.md`, `2026-07-04-monthly-roundup-executive-summary.md`) via `git mv` — history preserved, content unchanged (only file-header path/date bumped).
- Updates `docs/process/executive-summaries.md` ("Where it goes" now points at `docs/executive-summaries/`) and adds a new `docs/process/status-reports.md` documenting the `docs/status/` convention.
- Backfills the missing status doc for the July 10-11 remaining-work execution wave: `docs/status/2026-07-11-remaining-work-execution.md` (TL;DR + PR table + in-flight/blocked/next-steps).
- Repoints TODO.md's three links to the monthly roundup at its new location; the roundup's own relative self-link to the itl-hardening doc was verified still-correct (both moved to the same new folder together).

Docs-only change — zero code files touched (6 files changed, all `.md`).

## Test plan

- [x] `git mv` used for both executive-summary moves (verified `git log --follow` shows pre-move commit history on both).
- [x] Repo-wide grep for old `docs/status/2026-07-03-itl-hardening...` / `docs/status/2026-07-04-monthly-roundup...` paths — zero remaining hits outside the two moved files' own self-referencing headers.
- [x] Broader basename-only grep (`2026-07-03-itl-hardening-executive-summary` / `2026-07-04-monthly-roundup-executive-summary`) confirms every remaining reference is either inside the two moved files (already-correct relative self-links) or repointed in TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv