### PR TITLE
fix(organizer): stop wiping Author/Series on CreateOrganizedVersion write-back (STOREFID W5d-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.137.0 -->
+<!-- version: 3.138.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 11, 2026 - fix(organizer): stop wiping Author/Series on CreateOrganizedVersion write-back (STOREFID W5d-1)
+
+- **`organizer`** — **prod data-loss fix.** Creating an organized version of a book was silently
+  wiping that book's Author and Series on the original record, because the write-back that
+  demotes the original to a non-primary version wrote a lightweight, heavy-field-nil projection
+  of the book instead of the full record. Confirmed by an executable test against a real
+  PebbleStore (#1887) before this fix landed. Fixed by hydrating the full book record
+  immediately before that write and mutating/persisting it instead of the slim projection; if
+  hydration fails, the code still falls back to the old direct write so the version-group state
+  transition always completes (a missed demotion — two primary versions in one group — would be
+  worse than the rare Author/Series loss on that fallback path). The regression test added in
+  #1887 now passes instead of skipping.
 
 #### July 11, 2026 - feat(search): Bleve facet counts for genres/languages/tags (INIT-4 T04, #1888)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.88.0 -->
+<!-- version: 9.89.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -67,8 +67,8 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   - [x] INIT-9 T04 — quote mock-freshness pathspec so nested mocks dirs are checked (#1886) — see
     follow-up B below (Makefile has the same unfixed bug).
   - [x] INIT-9 T07 — verify Author/Series fate in `CreateOrganizedVersion` write-back (#1887) —
-    **test-only; confirmed a real HIGH prod-data-loss bug, see the "🔴 HIGH — PROD DATA-LOSS"
-    section above.** Does not fix it.
+    test-only; confirmed a real HIGH prod-data-loss bug. **Now fixed** — see the "✅ RESOLVED"
+    section above (fixed same-session, 2026-07-11, on user sign-off).
   - [x] INIT-4 T04 — Bleve facet counts for genres/languages/tags (#1888).
   - **INIT-4 is now 5/6** (T01–T05 shipped across Wave 1/Wave 2/Wave 2b; only T06 heavy-filter
     perf-pushdown remains — review-critical since it touches search query construction).
@@ -76,10 +76,10 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   waves; 35 not started), plus Phase B/C follow-ups, plus the two Wave-2b follow-ups below.
 - **BLOCKED: 3** — INIT-5 T2 (needs Deluge-spike sign-off), INIT-9 REPO-SIZE-1
   (STOP-FOR-HUMAN plan review), INIT-7 (held on #1260–#1265).
-- **Wave 2b follow-ups (new, open, not yet fixed):**
-  - **A.** 🔴 HIGH prod data-loss — see the dedicated section above
-    ("CreateOrganizedVersion original-book slim-writeback wipes Author/Series").
-  - **B.** `Makefile` lines ~212/214 (`mocks-check` target) use the identical unquoted
+- **Wave 2b follow-ups:**
+  - **A.** ✅ RESOLVED 2026-07-11 — the 🔴 HIGH prod data-loss bug (Author/Series wiped on
+    `CreateOrganizedVersion` write-back) is fixed; see the dedicated section above.
+  - **B.** (still open) `Makefile` lines ~212/214 (`mocks-check` target) use the identical unquoted
     `internal/*/mocks/` pathspec that #1886 just fixed in `.github/workflows/ci.yml` — it
     currently passes only because all committed mocks happen to be fresh, not because the glob is
     correct. Quote it the same way: `:(glob)internal/**/mocks/**`. Low-risk, mechanical,
@@ -126,40 +126,38 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
 
 ---
 
-## 🔴 HIGH — PROD DATA-LOSS: CreateOrganizedVersion original-book slim-writeback wipes Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887) — needs human decision
+## ✅ RESOLVED — CreateOrganizedVersion original-book slim-writeback wiped Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887; FIXED 2026-07-11)
 
-- **⚠️ CONFIRMED, not just suspected, as of 2026-07-11 (#1887, INIT-9 T07).** The executable test
-  `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback`
-  (`internal/organizer/organized_version_writeback_test.go`) proves this against a real
-  `PebbleStore`, not just memdb: `t.Skipf("W5d-1 KNOWN BUG CONFIRMED")`. It will flip to a real
-  PASS once the fix below lands — use it as the acceptance test, don't write a new one.
+- **Was CONFIRMED, not just suspected, as of 2026-07-11 (#1887, INIT-9 T07).** The executable
+  test `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback`
+  (`internal/organizer/organized_version_writeback_test.go`) proved this against a real
+  `PebbleStore`, not just memdb, via a guarded `t.Skipf("W5d-1 KNOWN BUG CONFIRMED")`.
 - **Root cause, exact locations:**
   `PebbleStore.UpdateBook`'s STOR-1 preserve-on-nil guard
   (`internal/database/pebble_store.go:1571-1598`) restores Description/VersionNotes/BookSig* from
-  the old row when the incoming value is nil, but has **no equivalent case for Author/Series**.
-  The call site at `internal/organizer/service.go:927-941` writes back a page-derived
-  (`GetAllBooksCore`→`ToBook`), heavy-field-nil `book` with the version-group / non-primary /
-  `organized_source` stamp:
-  ```go
-  book.VersionGroupID = &versionGroupID
-  book.IsPrimaryVersion = &isNotPrimary
-  book.LibraryState = &organizedSourceState
-  orgSvc.db.UpdateBook(book.ID, book)   // book is GetAllBooksCore→ToBook, heavy-field-nil
-  ```
-  so the original book's denormalized Author/Series are silently wiped on every
-  `CreateOrganizedVersion` call, under the production PebbleStore backend, not just memdb.
-- **Fix must be careful:** hydrating via `GetBookByID` before the write (the usual pattern)
-  preserves Author/Series BUT must NOT regress the version-group state transition to
-  fail-closed — a `GetBookByID` error must still demote the original to non-primary, or the
-  version group ends up with **two primaries**. So: hydrate-and-write on success, but fall
-  back to the direct state write (accepting the rare Author/Series wipe) if hydrate fails —
-  i.e. fail-OPEN for the state transition, preserve-heavy-when-possible.
-- Same writeback shape as the W5d-1 organizer writebacks that DID get the `hydrateAndUpdateBook`
-  helper; this one was deliberately left out pending the fail-open design above.
-- **DEFERRED TO A HUMAN.** Both the fail-open hydrate fix (a decision-carrying change to a
-  version-group state-transition invariant) and filing a tracking GitHub issue are intentionally
-  left undone by #1887 — that PR is test-only. Do not implement the fix or file the issue without
-  explicit sign-off; when approved, the fix should flip the #1887 test from SKIP to PASS.
+  the old row when the incoming value is nil, but had **no equivalent case for Author/Series**.
+  The call site at `internal/organizer/service.go` (the version-group demotion write in
+  `CreateOrganizedVersion`) wrote back a page-derived (`GetAllBooksCore`→`ToBook`),
+  heavy-field-nil `book`, so the original book's denormalized Author/Series were silently wiped
+  on every `CreateOrganizedVersion` call under the production PebbleStore backend, not just
+  memdb.
+- **Fix (approved by user 2026-07-11, implemented same session):** hydrate the original book via
+  `GetBookByID` immediately before the version-group write and mutate/persist that full row
+  instead of the slim projection. Deliberately did NOT reuse the existing `hydrateAndUpdateBook`
+  helper, because that helper fails **closed** on a hydrate error (skips the write entirely) —
+  here that would leave the version group with **two primaries**, worse than the rare Author/Series
+  wipe being fixed. Instead: hydrate-and-write the full row on success; if hydration fails, fall
+  back to the direct state-only write (today's pre-fix behavior, accepting the rare wipe) so the
+  state transition always lands — fail-OPEN for the state transition,
+  preserve-heavy-when-possible.
+- **Verified:** `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback` flips from SKIP
+  to PASS; the sibling invariant test `TestCreateOrganizedVersion_OriginalDemotedToNonPrimary`
+  (proves the version-group demotion still holds) stays green; full `internal/organizer` package
+  green under `-race`; whole-repo `go build ./... && go vet ./...` and `go test ./... -short`
+  green (98/98 packages, zero failures).
+- No separate tracking GitHub issue filed — the bug was fixed in the same session it was
+  confirmed, so an issue would have been opened and closed in the same breath; this TODO entry
+  plus the PR that landed the fix are the durable record.
 
 ## ✅ PR-D: deluge import fingerprint-wipe (3 impls) — RESOLVED (STOREFID W6, 2026-07-07)
 

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/service.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 
 package organizer
 
@@ -925,19 +925,34 @@ func (orgSvc *Service) CreateOrganizedVersion(org *Organizer, book *database.Boo
 	}
 
 	// Update original book: set version group, mark as non-primary, update state.
-	// NOTE: `book` here is a page-derived (GetAllBooksCore→ToBook, heavy-field-nil)
-	// projection, so this direct write wipes the original's denormalized
-	// Author/Series under a full-fidelity backend — a PRE-EXISTING latent bug
-	// (memdb already stripped these in prod before STOREFID). Deliberately NOT
-	// fixed here: a correct fix must hydrate to preserve Author/Series WITHOUT
-	// regressing the version-group state transition to fail-closed (a GetBookByID
-	// error must not leave two primaries in the group). Tracked as a follow-up.
+	// `book` here is a page-derived (GetAllBooksCore→ToBook, heavy-field-nil)
+	// projection, so writing it directly would wipe the original's denormalized
+	// Author/Series under a full-fidelity backend (STOREFID W5d-1, #1887).
+	// Fixed via hydrate-before-write, matching hydrateAndUpdateBook's pattern —
+	// but NOT that helper itself: its fail-closed skip-on-hydrate-error would
+	// leave the version group with two primaries, which is worse than the rare
+	// Author/Series wipe this fallback accepts. So: hydrate and write the full
+	// row on success; if hydration fails, fall back to the direct state-only
+	// write (today's pre-fix behavior) so the state transition always lands —
+	// fail-OPEN for the state transition, preserve-heavy-when-possible.
 	organizedSourceState := "organized_source"
 	book.VersionGroupID = &versionGroupID
 	book.IsPrimaryVersion = &isNotPrimary
 	book.LibraryState = &organizedSourceState
-	if _, err := orgSvc.db.UpdateBook(book.ID, book); err != nil {
-		log.Warn("Failed to update original book %s version group: %v", book.ID, err)
+	if hydrated, hydrateErr := orgSvc.db.GetBookByID(book.ID); hydrateErr == nil && hydrated != nil {
+		hydrated.VersionGroupID = &versionGroupID
+		hydrated.IsPrimaryVersion = &isNotPrimary
+		hydrated.LibraryState = &organizedSourceState
+		if _, err := orgSvc.db.UpdateBook(book.ID, hydrated); err != nil {
+			log.Warn("Failed to update original book %s version group: %v", book.ID, err)
+		}
+	} else {
+		if hydrateErr != nil {
+			log.Warn("organize: hydrate-before-write failed for original book %s, falling back to state-only write (Author/Series may be wiped): %v", book.ID, hydrateErr)
+		}
+		if _, err := orgSvc.db.UpdateBook(book.ID, book); err != nil {
+			log.Warn("Failed to update original book %s version group: %v", book.ID, err)
+		}
 	}
 
 	// Record operation changes for undo


### PR DESCRIPTION
## Summary
- **Confirmed prod data-loss bug (#1887), fixed same-session on explicit user sign-off.** `CreateOrganizedVersion`'s version-group demotion write on the original book used a page-derived, heavy-field-nil projection (`GetAllBooksCore`→`ToBook`) instead of the full record, silently wiping the original's denormalized Author/Series on every call under the production PebbleStore backend.
- Fix: hydrate the full book via `GetBookByID` immediately before the write and mutate/persist that full row. Deliberately does **not** reuse the existing `hydrateAndUpdateBook` helper — that helper fails *closed* on a hydrate error (skips the write entirely), which here would leave the version group with two primaries. Instead: hydrate-and-write on success; fall back to the direct state-only write (today's pre-fix behavior) if hydration fails, so the version-group state transition always lands (fail-open for the state transition, preserve-heavy-when-possible).
- `internal/organizer/organized_version_writeback_test.go`'s `TestCreateOrganizedVersion_AuthorSeriesSurviveOriginalWriteback` (added by #1887, previously `t.Skipf`'d as a confirmed bug) now **passes** instead of skipping. The sibling invariant test `TestCreateOrganizedVersion_OriginalDemotedToNonPrimary` stays green.

## Test plan
- [x] `go build ./internal/organizer/...` — exit 0
- [x] `go test ./internal/organizer/ -run TestCreateOrganizedVersion -v -race` — both tests PASS (the target test flips SKIP→PASS)
- [x] `go test ./internal/organizer/... -race -short` — full package green
- [x] `go build ./... && go vet ./...` — whole repo, exit 0
- [x] `go test ./... -short` — whole repo, 98/98 packages ok, zero failures
- [x] TODO.md's "PROD DATA-LOSS" section updated to RESOLVED; CHANGELOG.md entry added

No tracking GitHub issue filed separately — the bug was confirmed and fixed in the same session, so an issue would have opened and closed in the same breath.

Co-Authored-By: Claude <noreply@anthropic.com>