### PR TITLE
docs(process): require executive-summary check alongside CHANGELOG/TODO; add #1893 fix to roundup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,5 +219,20 @@ the entire sequence:
 
 ## Post-Task Hygiene
 
-- After completing any feature/fix: update CHANGELOG, update TODO, and commit before moving on.
+- After completing any feature/fix: update CHANGELOG, update TODO, **and check the
+  executive-summary criteria** (`docs/process/executive-summaries.md`), then commit before
+  moving on. Do all three together — don't treat the executive summary as a separate,
+  deferrable step.
+- **Why a third check, not just two:** CHANGELOG and TODO are written for engineers — file
+  paths, function names, PR numbers. Most users find that gibberish. The executive summary
+  (`docs/executive-summaries/`) is the one written for them: plain language, no jargon, what
+  changed and why it mattered. A data-loss fix isn't done, from a user's point of view, until
+  that's updated too.
+- The criteria (full list in `docs/process/executive-summaries.md`): it fixes something that
+  could have silently caused data loss or corruption; it spans multiple files/PRs or one PR
+  with a wide blast radius; it closes out a tracked set of issues; or the user signed off on a
+  multi-step plan that got executed to completion. If it qualifies, update the **current
+  month's** summary in `docs/executive-summaries/` in the SAME PR as the CHANGELOG/TODO edit —
+  not a follow-up PR, not "later." If it doesn't qualify (a typo fix, a single small change),
+  skip it — that's what CHANGELOG/TODO are for.
 - When editing release notes, PREPEND to existing auto-generated content; never replace the body wholesale.

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -1,11 +1,11 @@
 <!-- file: docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 5b0ee171-8a4f-4669-a2dd-91ffeabaa486 -->
 <!-- last-edited: 2026-07-11 -->
 
 # Executive Summary: June–July Monthly Roundup
 
-**Shipped:** PRs [#1240–#1890](https://github.com/falkcorp/audiobook-organizer/pulls?q=is%3Apr+is%3Amerged+merged%3A2026-06-05..2026-07-11), covering 2026-06-05 through 2026-07-11 (~430 merged PRs total; the July 5–11 remaining-work execution added 12: #1878–#1890)
+**Shipped:** PRs [#1240–#1893](https://github.com/falkcorp/audiobook-organizer/pulls?q=is%3Apr+is%3Amerged+merged%3A2026-06-05..2026-07-11), covering 2026-06-05 through 2026-07-11 (~430 merged PRs total; the July 5–11 remaining-work execution added 12 code/CI PRs (#1878–#1888) plus the same-day Author/Series data-loss fix, #1893)
 **Related doc:** [2026-07-03-itl-hardening-executive-summary.md](2026-07-03-itl-hardening-executive-summary.md) — full write-up of this month's iTunes library (`.itl`) write-back hardening (K13–K17), linked rather than repeated below.
 
 This is a monthly roundup rather than a single-change summary: instead of one
@@ -149,13 +149,14 @@ data before it was caught:
 - **#1431** — a routine dependency bump (a JavaScript build tool, Vite,
   version 7 to 8) crashed the entire frontend in production; reverted the
   same day it was noticed.
-- **#1887** — a confirmed production data-loss bug: creating an "organized
-  version" of a book silently erases that book's Author and Series
-  information. A test now proves this happens against the real production
-  storage engine, not just an in-memory approximation of it. The fix is
-  deliberately deferred pending a human decision on a trade-off it
-  involves; the test will flip from confirming the bug to passing once that
-  fix lands.
+- **#1887 / #1893** — a production data-loss bug: creating an "organized
+  version" of a book silently erased that book's Author and Series
+  information. A test proved this happened against the real production
+  storage engine, not just an in-memory approximation of it (#1887); the
+  fix landed the same day on explicit sign-off (#1893), fetching the full
+  book record before the write instead of a stripped-down copy, with a
+  safe fallback so a book is never left in a broken half-organized state
+  if that fetch fails.
 
 Verification note: each item above shipped with its own fix verified in
 context (tests, code review, or direct reproduction of the original bug);
@@ -553,10 +554,10 @@ noticing (#1886).
 One more result from this wave belongs in the highest-risk list above
 rather than here: a test written to settle whether a long-suspected bug was
 real confirmed that creating an "organized version" of a book silently
-erases that book's Author and Series information (#1887) — a genuine
-production data-loss bug, deliberately left unfixed pending a human
-decision on a trade-off in the correct fix, and tracked as the newest entry
-in the highest-risk list above.
+erased that book's Author and Series information (#1887) — a genuine
+production data-loss bug. It was fixed the same day (#1893): see the
+highest-risk list above for the plain-language write-up of the bug and the
+fix.
 
 Dependency updates this month (7 pull requests, entirely automated version
 bumps) had no behavior changes worth a full write-up and are noted here for

--- a/docs/process/executive-summaries.md
+++ b/docs/process/executive-summaries.md
@@ -1,5 +1,5 @@
 <!-- file: docs/process/executive-summaries.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: b608794a-eac5-44bc-95b9-643872bd0ca8 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -27,7 +27,22 @@ for.
 
 ## Where it goes
 
-`docs/executive-summaries/YYYY-MM-DD-<short-topic>-executive-summary.md`,
+**Check for an existing rolling summary for the current month first**
+(`docs/executive-summaries/YYYY-MM-*-executive-summary.md`). If one exists,
+ADD a new Executive Summary bullet + a new numbered section to it — do not
+create a second file for the same month. One doc per month is the goal;
+several small dated files fragmenting the same month is exactly the sprawl
+this convention exists to prevent (it happened once, in three separate
+files, and had to be manually consolidated back into one roundup).
+
+Only create a new file when either no summary exists yet for the current
+month (first qualifying change of the month), or the work is big/
+self-contained enough to warrant its own deep-dive report that the monthly
+roundup then links to instead of repeating (see the iTunes-hardening report
+linked at the top of the current roundup for the pattern) — that's the
+exception, not the default.
+
+New-file naming: `docs/executive-summaries/YYYY-MM-DD-<short-topic>-executive-summary.md`,
 using the date the work shipped (merge date), not the date work started.
 
 If the work also produced a formal spec (see `docs/specs/`), link to it and
@@ -66,10 +81,13 @@ summary) — describe behavior and mechanism in prose instead.
 
 ## Workflow
 
-1. Do the work, ship it (PR merged).
-2. Draft the summary using the structure above, reusing language from any
-   spec/CHANGELOG entries already written during the work — don't
-   re-derive from scratch.
+1. Do the work, ship it (PR merged) — update CHANGELOG.md and TODO.md as
+   normal (see CLAUDE.md's Post-Task Hygiene section).
+2. **Same PR, not a follow-up:** check the "When to produce one" criteria
+   above. If it qualifies, draft the summary using the structure above,
+   reusing language from any spec/CHANGELOG entries already written during
+   the work — don't re-derive from scratch. Bundling it with the
+   CHANGELOG/TODO edit is what keeps this from being skipped.
 3. Commit it and open a normal PR like any other change (same review/merge
    flow as the rest of the repo — this doc does not grant an exception to
    branch protection or bypass review).


### PR DESCRIPTION
Post-Task Hygiene only mentioned CHANGELOG + TODO, so the executive-summary
convention doc's own "update proactively" instruction got missed for #1893
(a confirmed prod data-loss fix that squarely meets the doc's own
data-loss/corruption criterion). Fix the process, not just the instance:

- CLAUDE.md Post-Task Hygiene now names the executive-summary check as a
  third mandatory step alongside CHANGELOG/TODO, explains why (CHANGELOG/TODO
  are for engineers; the executive summary is what an average user can
  actually read), and says to do it in the SAME PR, not a follow-up.
- docs/process/executive-summaries.md's Workflow section cross-references
  the same same-PR expectation from the other direction, and "Where it
  goes" now says to extend the CURRENT MONTH's existing rolling roundup
  file instead of creating a new dated file per qualifying change --
  the fragmentation this was meant to prevent already happened once
  tonight (three separate wave files, manually consolidated back into one).
- Updated the June-July monthly roundup itself: #1887's "deliberately
  deferred pending a human decision" language is now "fixed the same day
  on explicit sign-off (#1893)", in both the highest-risk list and the
  wave-16 cross-reference. PR range widened to #1893.

Co-Authored-By: Claude <noreply@anthropic.com>
