### PR TITLE
fix(database): correct Pebble tag-index colon parsing for namespaced tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.138.0 -->
+<!-- version: 3.139.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -8,6 +8,39 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 11, 2026 - fix(database): correct Pebble tag-index colon parsing for namespaced tags; fix(library): true reset on "All Books"
+
+- **`database`** — **prod correctness fix.** Every colon-namespaced tag (the auto-applied
+  `metadata:*`, `dedup:*`, `import:*`, `organize:*` system tags — see `internal/database/migrations.go:935-965`)
+  was mishandled by the Pebble tag index's read path in four functions in
+  `internal/database/pebble_store_tags.go`: `ListAllTags` and the shared `pebbleListAllTags`
+  helper (used by author/series tags too) truncated any tag at its first colon, collapsing every
+  `metadata:*` variant into one bogus "metadata" bucket and every `dedup:*` variant into "dedup";
+  `GetBooksByTag` and the shared `pebbleEntitiesByTag` helper prefix-scanned `tag_idx:<tag>:`,
+  which Pebble also matches against any longer tag sharing that byte prefix, then mis-parsed the
+  match into a garbage ID — for books this always returned zero results, for author/series tags
+  it would have silently returned wrong entity IDs. Confirmed against production (44,325 books):
+  the bogus "metadata"/"dedup" buckets showed 30,372/28,177 books each, but filtering by
+  `tag=metadata`, `tag=dedup`, or even the fully-correct `tag=metadata:source:audible` all
+  returned 0 results. Fixed by parsing on the *last* colon (the tag/entityID boundary, since
+  entity IDs are guaranteed colon-free) instead of a fixed split arity, and by re-validating
+  every prefix-scan match against the requested tag before including it. Pure read-path fix — the
+  write path was already correct, so no backfill or data migration is needed. New regression
+  tests (`TestCoverage_BookTagsColonCollision`, `TestCoverage_AuthorSeriesTagsColonCollision` in
+  `internal/database/store_coverage_test.go`) cover a bare tag and its colon-suffixed namespaced
+  sibling coexisting across all three tag keyspaces (book/author/series); both fail against the
+  pre-fix code and pass against the fix.
+- **`library`** (frontend) — clicking "All Books" in the left nav (or the collapsed-sidebar
+  Library icon, or the Library group header — all three navigate to the same route) previously
+  left the tag filter "stuck": a plain `navigate('/library')` could be swallowed by the
+  page's internal echo-suppression guard (`isInternalUpdate`, used to stop a read-from-URL effect
+  from re-triggering its own write-back), so `selectedTags` (and therefore the actual book query)
+  sometimes never cleared even though the URL looked reset. The sidebar's Library-root links now
+  navigate to `/library?reset=1`; `Library.tsx` checks for that marker *before* the echo-guard so
+  it can never be swallowed, explicitly clears page/search/sort/filters/tags, then strips the
+  marker from the URL. New tests in `web/src/pages/Library.resetNavigation.test.tsx` cover both
+  the tag-filter and search-box cases; both fail against the pre-fix code and pass against the fix.
 
 #### July 11, 2026 - fix(organizer): stop wiping Author/Series on CreateOrganizedVersion write-back (STOREFID W5d-1)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.89.0 -->
+<!-- version: 9.90.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -125,6 +125,42 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   (orphan-cleanup op).
 
 ---
+
+## ✅ RESOLVED — library "Metadata"/"Dedup" tag bubbles miscounted + zero-result on click; "All Books" left tag filters stuck (2026-07-11)
+
+- **User report:** the library's browsable tag cloud showed "Metadata" and "Dedup" bubbles with
+  huge counts that failed to load ("too many books") when clicked; separately, clicking "All
+  Books" in the left nav never actually cleared an active tag filter.
+- **Initial hypothesis (source-based system-tag filtering + missing pagination/cancel UX) was
+  wrong** — advisor-requested empirical verification against production (44,325 books) found the
+  real root cause: a byte-prefix/fixed-split-arity parsing bug in the Pebble tag index's read
+  path, in **4 functions**, not 2 — `ListAllTags`/`GetBooksByTag` (books) and the shared
+  `pebbleListAllTags`/`pebbleEntitiesByTag` helpers (author/series tags, same file, same bug
+  class, not part of the original report but caught alongside). Any colon-namespaced tag
+  (`metadata:*`, `dedup:*`, `import:*`, `organize:*` — see `internal/database/migrations.go:935-965`)
+  was either truncated to its first segment (collapsing all variants into one bogus bucket) or
+  mis-parsed after a prefix-scan collision (returning 0 results, or for author/series, would have
+  returned garbage entity IDs). Confirmed: `tag=metadata`, `tag=dedup`, and even the fully-correct
+  `tag=metadata:source:audible` all returned `count: 0` in prod; ordinary tags like "fantasy"
+  filtered correctly.
+- **Fix:** parse on the *last* colon (bookID/entityID are guaranteed colon-free) instead of a
+  fixed split arity, and re-validate every prefix-scan match against the requested tag before
+  including it. Pure read-path fix, no backfill needed. Separately, `Sidebar.tsx`'s Library-root
+  links now navigate to `/library?reset=1`, and `Library.tsx` handles that marker *before* its
+  `isInternalUpdate` echo-suppression guard so a reset request can never be silently swallowed —
+  that swallow (not a missing clear-tags call) was the actual cause of "stuck" filters.
+- **Deferred, not in this fix (open follow-ups):** cancel/timeout-aware loading UX for tag
+  filters — needs re-measuring which corrected system tags are actually large enough to warrant
+  it, now that the fake giant buckets are gone; and whether system-sourced tags should still be
+  hidden from the general "Browse by Tag" cloud, now a genuine UX preference rather than a
+  required bug fix.
+- **Verified:** new regression tests (`TestCoverage_BookTagsColonCollision`,
+  `TestCoverage_AuthorSeriesTagsColonCollision` in `internal/database/store_coverage_test.go`;
+  `Library.resetNavigation.test.tsx`) all fail against the pre-fix code and pass against the fix.
+  Backend: `go build ./...`, `go vet ./...` clean; `internal/database` green under `-race`;
+  97-package suite (excluding the pre-existing `internal/server` stall, unrelated to this change)
+  green with zero FAIL/panic/DATA RACE. Frontend: `tsc --noEmit` clean, `eslint` clean, full
+  vitest suite 54/54 files, 345/345 tests green.
 
 ## ✅ RESOLVED — CreateOrganizedVersion original-book slim-writeback wiped Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887; FIXED 2026-07-11)
 

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -1,11 +1,11 @@
 <!-- file: docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: 5b0ee171-8a4f-4669-a2dd-91ffeabaa486 -->
 <!-- last-edited: 2026-07-11 -->
 
 # Executive Summary: June–July Monthly Roundup
 
-**Shipped:** PRs [#1240–#1893](https://github.com/falkcorp/audiobook-organizer/pulls?q=is%3Apr+is%3Amerged+merged%3A2026-06-05..2026-07-11), covering 2026-06-05 through 2026-07-11 (~430 merged PRs total; the July 5–11 remaining-work execution added 12 code/CI PRs (#1878–#1888) plus the same-day Author/Series data-loss fix, #1893)
+**Shipped:** PRs [#1240–#1893+](https://github.com/falkcorp/audiobook-organizer/pulls?q=is%3Apr+is%3Amerged+merged%3A2026-06-05..2026-07-11), covering 2026-06-05 through 2026-07-11 (~430 merged PRs total; the July 5–11 remaining-work execution added 12 code/CI PRs (#1878–#1888) plus the same-day Author/Series data-loss fix (#1893) and the library tag-browsing fix that follows)
 **Related doc:** [2026-07-03-itl-hardening-executive-summary.md](2026-07-03-itl-hardening-executive-summary.md) — full write-up of this month's iTunes library (`.itl`) write-back hardening (K13–K17), linked rather than repeated below.
 
 This is a monthly roundup rather than a single-change summary: instead of one
@@ -558,6 +558,41 @@ erased that book's Author and Series information (#1887) — a genuine
 production data-loss bug. It was fixed the same day (#1893): see the
 highest-risk list above for the plain-language write-up of the bug and the
 fix.
+
+### 17. Library tag-browsing bug fix
+
+**What it was:** A user reported that the "Metadata" and "Dedup" bubbles in
+the library's browsable tag list showed suspiciously large counts, and
+clicking either one failed to load any books at all. Separately, clicking
+"All Books" in the left-hand navigation didn't reliably clear an active tag
+filter, so the library could stay stuck showing a filtered view even after
+asking for the unfiltered one.
+
+**Why it mattered:** The initial theory — that these were two separate,
+mostly cosmetic problems (some internal bookkeeping tags leaking into a
+user-facing list, and a missing loading indicator) — turned out to be
+wrong. Verifying the theory against real production data before writing any
+fix found the actual cause: a text-parsing bug in how the database reads
+back tag names that contain colons, which is how the system labels
+auto-applied tags internally (for example, "which online catalog this
+book's metadata came from"). Any tag with a colon in its name was either
+being mislabeled and miscounted, or made completely unsearchable — the
+"Metadata" and "Dedup" bubbles were a visible symptom of a bug that
+affected every auto-applied tag in the system, not just those two.
+
+**The fix:** The database's tag-lookup logic was corrected to read colon-
+containing tag names properly instead of truncating or misreading them —
+a read-only fix with no changes needed to any tag data already stored,
+so nothing had to be migrated or backfilled. The "All Books" link was also
+changed to explicitly request a full reset, closing a timing gap where a
+plain "go to this page" navigation could be silently ignored by an internal
+safeguard meant to prevent an unrelated update loop. Two further
+improvements the user asked about — a "still loading, want to cancel?"
+affordance for large tag filters, and whether internal bookkeeping tags
+should be hidden from the browsable list at all — were deliberately held
+back pending a second look at real tag sizes now that the miscounting bug
+is fixed, rather than building them against numbers that were never
+accurate to begin with.
 
 Dependency updates this month (7 pull requests, entirely automated version
 bumps) had no behavior changes worth a full write-up and are noted here for

--- a/internal/database/pebble_store_tags.go
+++ b/internal/database/pebble_store_tags.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_tags.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c2ad6d2b-75c3-446d-9f67-08cc517050e2
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 package database
 
@@ -232,11 +232,15 @@ func (p *PebbleStore) ListAllTags() ([]TagWithCount, error) {
 
 	counts := make(map[string]int)
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Key format: tag_idx:<tag>:<bookID>
+		// Key format: tag_idx:<tag>:<bookID>. Tags may themselves contain
+		// colons (e.g. "metadata:source:audible"), so the tag/bookID
+		// boundary is the LAST colon, not a fixed split arity — bookIDs
+		// (ULIDs) are guaranteed colon-free, which is what makes this
+		// unambiguous.
 		key := string(iter.Key())
-		parts := strings.SplitN(key, ":", 3)
-		if len(parts) >= 2 {
-			counts[parts[1]]++
+		rest := strings.TrimPrefix(key, "tag_idx:")
+		if idx := strings.LastIndex(rest, ":"); idx > 0 {
+			counts[rest[:idx]]++
 		}
 	}
 
@@ -269,12 +273,21 @@ func (p *PebbleStore) GetBooksByTag(tag string) ([]string, error) {
 
 	var bookIDs []string
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Key format: tag_idx:<tag>:<bookID>
+		// Key format: tag_idx:<tag>:<bookID>. A byte-prefix scan for
+		// "tag_idx:<tag>:" also matches longer tags sharing that prefix
+		// (e.g. tag="metadata" matches keys belonging to
+		// "metadata:source:audible" too), so every match must be
+		// re-validated: the segment before the LAST colon must equal the
+		// requested tag exactly, or the key belongs to a different
+		// (longer) tag and is skipped rather than mis-parsed into a fake
+		// bookID.
 		key := string(iter.Key())
-		parts := strings.SplitN(key, ":", 3)
-		if len(parts) == 3 {
-			bookIDs = append(bookIDs, parts[2])
+		rest := strings.TrimPrefix(key, "tag_idx:")
+		idx := strings.LastIndex(rest, ":")
+		if idx <= 0 || rest[:idx] != tag {
+			continue
 		}
+		bookIDs = append(bookIDs, rest[idx+1:])
 	}
 	return bookIDs, nil
 }
@@ -448,12 +461,14 @@ func (p *PebbleStore) pebbleListAllTags(ks pebbleTagKeyspace) ([]TagWithCount, e
 
 	counts := make(map[string]int)
 	for iter.First(); iter.Valid(); iter.Next() {
-		// Key format: <indexPrefix><tag>:<entityID>
+		// Key format: <indexPrefix><tag>:<entityID>. Tags may themselves
+		// contain colons, so the tag/entityID boundary is the LAST colon —
+		// entityIDs (strconv.Itoa'd author/series IDs) are guaranteed
+		// colon-free.
 		key := string(iter.Key())
 		rest := strings.TrimPrefix(key, ks.indexPrefix)
-		parts := strings.SplitN(rest, ":", 2)
-		if len(parts) >= 1 {
-			counts[parts[0]]++
+		if idx := strings.LastIndex(rest, ":"); idx > 0 {
+			counts[rest[:idx]]++
 		}
 	}
 
@@ -484,10 +499,20 @@ func (p *PebbleStore) pebbleEntitiesByTag(ks pebbleTagKeyspace, tag string) ([]s
 
 	var ids []string
 	for iter.First(); iter.Valid(); iter.Next() {
+		// A byte-prefix scan for "<indexPrefix><tag>:" also matches longer
+		// tags sharing that prefix (e.g. tag="metadata" matches keys
+		// belonging to "metadata:source:audible" too). Re-validate via the
+		// LAST colon: the segment before it must equal the requested tag
+		// exactly, or the key belongs to a different (longer) tag and must
+		// be skipped rather than returned as a garbage entity ID.
 		key := string(iter.Key())
-		rest := strings.TrimPrefix(key, fmt.Sprintf("%s%s:", ks.indexPrefix, tag))
-		if rest != "" {
-			ids = append(ids, rest)
+		rest := strings.TrimPrefix(key, ks.indexPrefix)
+		idx := strings.LastIndex(rest, ":")
+		if idx <= 0 || rest[:idx] != tag {
+			continue
+		}
+		if id := rest[idx+1:]; id != "" {
+			ids = append(ids, id)
 		}
 	}
 	return ids, nil

--- a/internal/database/store_coverage_test.go
+++ b/internal/database/store_coverage_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_coverage_test.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 
 // NOTE(fable5 T022): setupCoverageDB ported to PebbleStore; SQLiteStore
 // type assertions updated. Tests for SQLite-only methods (CountTableRows,
@@ -816,6 +816,90 @@ func TestCoverage_BookTags(t *testing.T) {
 	tags, err = store.GetBookTags(bookID)
 	require.NoError(t, err)
 	assert.Len(t, tags, 1)
+}
+
+// TestCoverage_BookTagsColonCollision regression-tests a bug where a
+// colon-containing tag (e.g. a system tag like "metadata:source:audible")
+// and a bare tag that is its prefix (e.g. "metadata") coexisted in the tag
+// index. ListAllTags/GetBooksByTag used to truncate or byte-prefix-collide
+// on the colon, collapsing counts and returning zero (or garbage) results
+// for the namespaced tag. See internal/database/pebble_store_tags.go.
+func TestCoverage_BookTagsColonCollision(t *testing.T) {
+	store := setupCoverageDB(t)
+
+	bareBook := createTestBook(t, store, "Bare Tag Book", "/tmp/bare.m4b", nil, nil)
+	nsBook := createTestBook(t, store, "Namespaced Tag Book", "/tmp/ns.m4b", nil, nil)
+	bothBook := createTestBook(t, store, "Both Tags Book", "/tmp/both.m4b", nil, nil)
+
+	require.NoError(t, store.AddBookTagWithSource(bareBook, "metadata", "system"))
+	require.NoError(t, store.AddBookTagWithSource(nsBook, "metadata:source:audible", "system"))
+	require.NoError(t, store.AddBookTagWithSource(bothBook, "metadata", "system"))
+	require.NoError(t, store.AddBookTagWithSource(bothBook, "metadata:source:audible", "system"))
+
+	allTags, err := store.ListAllTags()
+	require.NoError(t, err)
+	counts := make(map[string]int)
+	for _, tc := range allTags {
+		counts[tc.Tag] = tc.Count
+	}
+	assert.Equal(t, 2, counts["metadata"], "bare tag count must not include namespaced-tag rows")
+	assert.Equal(t, 2, counts["metadata:source:audible"], "namespaced tag must be preserved whole, not truncated")
+
+	bareResults, err := store.GetBooksByTag("metadata")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{bareBook, bothBook}, bareResults, "bare-tag lookup must not match the namespaced tag's rows")
+
+	nsResults, err := store.GetBooksByTag("metadata:source:audible")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{nsBook, bothBook}, nsResults, "namespaced-tag lookup must resolve to real book IDs, not zero results")
+}
+
+// TestCoverage_AuthorSeriesTagsColonCollision is the author/series
+// counterpart of TestCoverage_BookTagsColonCollision, covering the shared
+// pebbleListAllTags/pebbleEntitiesByTag helpers.
+func TestCoverage_AuthorSeriesTagsColonCollision(t *testing.T) {
+	store := setupCoverageDB(t)
+
+	bareAuthor, err := store.CreateAuthor("Bare Tag Author")
+	require.NoError(t, err)
+	nsAuthor, err := store.CreateAuthor("Namespaced Tag Author")
+	require.NoError(t, err)
+
+	require.NoError(t, store.AddAuthorTagWithSource(bareAuthor.ID, "metadata", "system"))
+	require.NoError(t, store.AddAuthorTagWithSource(nsAuthor.ID, "metadata:source:audible", "system"))
+
+	allAuthorTags, err := store.ListAllAuthorTags()
+	require.NoError(t, err)
+	authorCounts := make(map[string]int)
+	for _, tc := range allAuthorTags {
+		authorCounts[tc.Tag] = tc.Count
+	}
+	assert.Equal(t, 1, authorCounts["metadata"])
+	assert.Equal(t, 1, authorCounts["metadata:source:audible"])
+
+	bareAuthorIDs, err := store.GetAuthorsByTag("metadata")
+	require.NoError(t, err)
+	assert.Equal(t, []int{bareAuthor.ID}, bareAuthorIDs, "bare-tag lookup must not pull in the namespaced tag's author, and must not return a garbage ID")
+
+	nsAuthorIDs, err := store.GetAuthorsByTag("metadata:source:audible")
+	require.NoError(t, err)
+	assert.Equal(t, []int{nsAuthor.ID}, nsAuthorIDs)
+
+	bareSeries, err := store.CreateSeries("Bare Tag Series", nil)
+	require.NoError(t, err)
+	nsSeries, err := store.CreateSeries("Namespaced Tag Series", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, store.AddSeriesTagWithSource(bareSeries.ID, "dedup", "system"))
+	require.NoError(t, store.AddSeriesTagWithSource(nsSeries.ID, "dedup:merge-survivor:auto-hash", "system"))
+
+	bareSeriesIDs, err := store.GetSeriesByTag("dedup")
+	require.NoError(t, err)
+	assert.Equal(t, []int{bareSeries.ID}, bareSeriesIDs)
+
+	nsSeriesIDs, err := store.GetSeriesByTag("dedup:merge-survivor:auto-hash")
+	require.NoError(t, err)
+	assert.Equal(t, []int{nsSeries.ID}, nsSeriesIDs)
 }
 
 // --- User Tags (on book_tags via BookUserTag interface) ---

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -45,7 +45,11 @@ interface SidebarProps {
 }
 
 const librarySubItems = [
-  { text: 'All Books', icon: <LibraryBooksIcon />, path: '/library' },
+  // path carries ?reset=1 so Library.tsx does a true full reset (page,
+  // search, sort, filters, tags) instead of the state-preserving nav most
+  // other sidebar links use; matchPath (query-free) drives the selected
+  // highlight so it still lights up on a plain /library visit.
+  { text: 'All Books', icon: <LibraryBooksIcon />, path: '/library?reset=1', matchPath: '/library' },
   { text: 'In Progress', icon: <MenuBookIcon />, path: '/library?search=read_status:in_progress' },
   { text: 'Finished', icon: <LibraryBooksIcon />, path: '/library?search=read_status:finished' },
   { text: 'Fingerprints', icon: <WavesIcon />, path: '/fingerprints' },
@@ -135,7 +139,7 @@ export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggl
                   <ListItem key={item.text} disablePadding>
                     <ListItemButton
                       sx={{ pl: 4 }}
-                      selected={location.pathname === item.path}
+                      selected={location.pathname === (item.matchPath ?? item.path)}
                       onClick={() => handleNavigation(item.path)}
                     >
                       <ListItemIcon>{item.icon}</ListItemIcon>

--- a/web/src/pages/Library.resetNavigation.test.tsx
+++ b/web/src/pages/Library.resetNavigation.test.tsx
@@ -1,0 +1,135 @@
+// file: web/src/pages/Library.resetNavigation.test.tsx
+// version: 1.0.0
+// guid: 4c8b1a2d-9e3f-4a7b-8c1d-2e3f4a5b6c7d
+// last-edited: 2026-07-11
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { Library } from './Library';
+import * as api from '../services/api';
+
+vi.mock('../services/api', () => {
+  class ApiError extends Error {
+    status: number;
+    data?: unknown;
+    constructor(message: string, status: number, data?: unknown) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.data = data;
+    }
+  }
+  return {
+    ApiError,
+    getOperationLogsTail: vi.fn().mockResolvedValue([]),
+    getOperationTimeline: vi.fn().mockResolvedValue([]),
+    getActiveOperations: vi.fn().mockResolvedValue([]),
+    getBooks: vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: 'id-1',
+          title: 'Test Book',
+          file_path: '/tmp/book.m4b',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+          author_name: 'Author',
+        },
+      ],
+      count: 1,
+    }),
+    searchBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    searchBooksPage: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getImportPaths: vi.fn().mockResolvedValue([]),
+    countBooks: vi.fn().mockResolvedValue(1),
+    getBookFacets: vi.fn().mockResolvedValue({ genres: [], languages: [] }),
+    getAuthors: vi.fn().mockResolvedValue([]),
+    getSeries: vi.fn().mockResolvedValue([]),
+    getSystemStatus: vi.fn().mockResolvedValue({
+      status: 'ok',
+      library: { path: '/tmp', book_count: 1, total_size: 0 },
+      import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
+      memory: {},
+      runtime: {},
+      operations: { recent: [] },
+    }),
+    getHomeDirectory: vi.fn().mockResolvedValue('/tmp'),
+    getSoftDeletedBooks: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    getUserColumnConfig: vi.fn().mockResolvedValue(null),
+    saveUserColumnConfig: vi.fn().mockResolvedValue(undefined),
+    listAllUserTags: vi.fn().mockResolvedValue([{ tag: 'metadata', count: 3 }]),
+    getSavedFilterPresets: vi.fn().mockResolvedValue([]),
+    saveSavedFilterPresets: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Mirrors what Sidebar.tsx's "All Books" link does (navigate to
+// /library?reset=1) without needing to render the full Sidebar/layout.
+function ResetNavButton() {
+  const navigate = useNavigate();
+  return (
+    <button onClick={() => navigate('/library?reset=1')}>trigger-reset-nav</button>
+  );
+}
+
+describe('Library reset navigation (/library?reset=1)', () => {
+  it('clears the tag filter left over from a prior filtered view', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={['/library?tag=metadata']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <ResetNavButton />
+        <Library />
+      </MemoryRouter>
+    );
+
+    // Sanity: the stale filtered state actually took effect before reset —
+    // no free-text search here, so loadAudiobooks always goes through
+    // api.getBooks (not the api.searchBooksPage branch), keeping the
+    // assertion below deterministic.
+    await waitFor(() => {
+      const lastCall = vi.mocked(api.getBooks).mock.calls.at(-1);
+      expect(lastCall?.[2]?.tags).toEqual(['metadata']);
+    });
+
+    await user.click(screen.getByText('trigger-reset-nav'));
+
+    // The actual data query — not just the visible chip — drops the tag
+    // filter. This is the part that was previously "stuck": a plain
+    // navigate('/library') left selectedTags (and therefore this query)
+    // unchanged.
+    await waitFor(
+      () => {
+        const lastCall = vi.mocked(api.getBooks).mock.calls.at(-1);
+        expect(lastCall?.[2]?.tags).toBeUndefined();
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it('clears the search box left over from a prior filtered view', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={['/library?search=foo']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <ResetNavButton />
+        <Library />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('trigger-reset-nav'));
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue('foo')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -550,6 +550,24 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
   // Sync state FROM URL when user navigates (back/forward) or edits URL directly
   const isInternalUpdate = useRef(false);
   useEffect(() => {
+    // Explicit full-reset request (Sidebar's "All Books" link uses
+    // /library?reset=1). Checked BEFORE the isInternalUpdate guard below
+    // so a reset request can never be swallowed as an internal echo of a
+    // prior filter/search/sort change — that swallow is what previously
+    // left tag (and other) filters "stuck" after clicking All Books.
+    if (searchParams.get('reset') === '1') {
+      setPage(1);
+      setSearchQuery('');
+      setSortBy(SortField.Title);
+      setSortOrder(SortOrder.Ascending);
+      setViewMode('grid');
+      setItemsPerPage(20);
+      setSelectedTags([]);
+      baseHandleFiltersChange({});
+      isInternalUpdate.current = true;
+      setSearchParams(new URLSearchParams(), { replace: true });
+      return;
+    }
     if (isInternalUpdate.current) {
       isInternalUpdate.current = false;
       return;


### PR DESCRIPTION
## Summary

Fixes the reported library UI bug (the "Metadata"/"Dedup" tag bubbles showing bogus counts and failing to load on click) and the "All Books" nav leaving tag filters stuck.

The originally-approved plan assumed a UX-layer fix (hide system tags from the browse cloud, add pagination/cancel UX). Advisor-requested empirical verification against production data found the *actual* root cause is different: a byte-prefix/fixed-split-arity parsing bug in the Pebble tag index's read path.

- **`internal/database/pebble_store_tags.go`** — 4 functions (`ListAllTags`, `GetBooksByTag`, and the shared `pebbleListAllTags`/`pebbleEntitiesByTag` helpers used by author/series tags too) mishandled any tag containing a colon (all auto-applied `metadata:*`/`dedup:*`/`import:*`/`organize:*` system tags). Confirmed against prod (44,325 books): `tag=metadata`, `tag=dedup`, and even the fully-correct `tag=metadata:source:audible` all returned `count: 0`. Fixed by parsing on the *last* colon (entity IDs are guaranteed colon-free) and re-validating every prefix-scan match against the requested tag. Pure read-path fix — write path was already correct, no backfill needed.
- **`web/src/components/layout/Sidebar.tsx` + `web/src/pages/Library.tsx`** — "All Books" now navigates to `/library?reset=1`; `Library.tsx` handles that marker *before* its `isInternalUpdate` echo-suppression guard, so a reset request can no longer be silently swallowed by that guard (the actual cause of "stuck" filters, not a missing clear-tags call).

Deferred (not in this PR, per advisor sequencing guidance): cancel/timeout-aware loading UX for tag filters (needs re-measuring realistic tag sizes now that the fake giant buckets are gone), and whether system-sourced tags should be hidden from the general browse cloud (now a genuine UX preference, not a required bug fix).

## Test plan

- [x] New regression tests fail against pre-fix code, pass against the fix (verified via `git stash`):
  - `TestCoverage_BookTagsColonCollision`, `TestCoverage_AuthorSeriesTagsColonCollision` (`internal/database/store_coverage_test.go`)
  - `Library.resetNavigation.test.tsx` (tag-filter case + search-box case)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `internal/database` (changed package) green under `-race -short`
- [x] 97-package suite green (`go build`/`go vet`/`go test -race -short`, excluding the pre-existing `internal/server` intermittent stall, unrelated to this change) — zero FAIL/panic/DATA RACE
- [x] Frontend: `tsc --noEmit` clean, `eslint` clean, full vitest suite 54/54 files, 345/345 tests

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv