### PR TITLE
feat(library): cancelable, timeout-aware loading for the book list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.139.0 -->
+<!-- version: 3.140.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -8,6 +8,23 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 11, 2026 - feat(library): cancelable, timeout-aware loading for the book list
+
+- **`library`** (frontend) — the book grid/list previously showed a bare, indefinite spinner
+  with no way out while a query was in flight, including for tag filters. `AudiobookGrid` and
+  `AudiobookList` now render a shared `LoadingWithCancel` component: after ~3s it grows a "Still
+  loading… Cancel" button. Cancelling aborts the in-flight request via a new `AbortController` in
+  `useLibraryQuery.ts` (same pattern already used in `UnifiedDedupTab.tsx`/
+  `CandidateCompareDrawer.tsx`) and, per the original bug report, also clears the active tag
+  filter so the same slow query doesn't immediately re-fire. `getBooks`, `searchBooksPage`, and
+  `getImportPaths` in `api.ts` now accept an optional `signal`. A cancelled/aborted request is
+  treated as a no-op, not a failure — no error toast, and it doesn't clobber a newer in-flight
+  request's result.
+- Known limitation, not addressed here: whether large, slow-to-filter tags still exist in
+  practice can only be re-measured once the tag-index parsing fix (see above) has been deployed
+  to production — this change builds the general-purpose cancel mechanism the original report
+  asked for regardless of that measurement.
 
 #### July 11, 2026 - fix(database): correct Pebble tag-index colon parsing for namespaced tags; fix(library): true reset on "All Books"
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.90.0 -->
+<!-- version: 9.91.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -149,18 +149,25 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   links now navigate to `/library?reset=1`, and `Library.tsx` handles that marker *before* its
   `isInternalUpdate` echo-suppression guard so a reset request can never be silently swallowed —
   that swallow (not a missing clear-tags call) was the actual cause of "stuck" filters.
-- **Deferred, not in this fix (open follow-ups):** cancel/timeout-aware loading UX for tag
-  filters — needs re-measuring which corrected system tags are actually large enough to warrant
-  it, now that the fake giant buckets are gone; and whether system-sourced tags should still be
-  hidden from the general "Browse by Tag" cloud, now a genuine UX preference rather than a
-  required bug fix.
+- **Follow-up shipped same day:** cancel/timeout-aware loading UX for tag filters —
+  `AudiobookGrid`/`AudiobookList` now render a shared `LoadingWithCancel` component (grows a
+  "Still loading… Cancel" affordance after ~3s); `useLibraryQuery.ts` gained an `AbortController`
+  + `cancelLoad()` (`getBooks`/`searchBooksPage`/`getImportPaths` now accept a `signal`); cancel
+  also clears the active tag filter, per the original ask. Built as a general-purpose mechanism
+  independent of tag size, since real post-deploy tag-size numbers weren't available yet to
+  re-validate the original "is this still needed" question at build time.
+- **Still deferred (open follow-up):** whether system-sourced tags should be hidden from the
+  general "Browse by Tag" cloud — now a genuine UX preference rather than a required bug fix,
+  since correctly-parsed system tags render as many small correct bubbles instead of two broken
+  giant ones.
 - **Verified:** new regression tests (`TestCoverage_BookTagsColonCollision`,
   `TestCoverage_AuthorSeriesTagsColonCollision` in `internal/database/store_coverage_test.go`;
-  `Library.resetNavigation.test.tsx`) all fail against the pre-fix code and pass against the fix.
-  Backend: `go build ./...`, `go vet ./...` clean; `internal/database` green under `-race`;
-  97-package suite (excluding the pre-existing `internal/server` stall, unrelated to this change)
-  green with zero FAIL/panic/DATA RACE. Frontend: `tsc --noEmit` clean, `eslint` clean, full
-  vitest suite 54/54 files, 345/345 tests green.
+  `Library.resetNavigation.test.tsx`; `useLibraryQuery.test.ts`'s `cancelLoad` suite;
+  `LoadingWithCancel.test.tsx`) all fail against their respective pre-fix code and pass against
+  the fix. Backend: `go build ./...`, `go vet ./...` clean; `internal/database` green under
+  `-race`; 97-package suite (excluding the pre-existing `internal/server` stall, unrelated to
+  this change) green with zero FAIL/panic/DATA RACE. Frontend: `tsc --noEmit` clean, `eslint`
+  clean, full vitest suite green (55/55 files, 351/351 tests after the loading-UX follow-up).
 
 ## ✅ RESOLVED — CreateOrganizedVersion original-book slim-writeback wiped Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887; FIXED 2026-07-11)
 

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md -->
-<!-- version: 1.3.0 -->
+<!-- version: 1.4.0 -->
 <!-- guid: 5b0ee171-8a4f-4669-a2dd-91ffeabaa486 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -586,13 +586,14 @@ a read-only fix with no changes needed to any tag data already stored,
 so nothing had to be migrated or backfilled. The "All Books" link was also
 changed to explicitly request a full reset, closing a timing gap where a
 plain "go to this page" navigation could be silently ignored by an internal
-safeguard meant to prevent an unrelated update loop. Two further
-improvements the user asked about — a "still loading, want to cancel?"
-affordance for large tag filters, and whether internal bookkeeping tags
-should be hidden from the browsable list at all — were deliberately held
-back pending a second look at real tag sizes now that the miscounting bug
-is fixed, rather than building them against numbers that were never
-accurate to begin with.
+safeguard meant to prevent an unrelated update loop. A same-day follow-up
+then added the "still loading, want to cancel?" affordance the user asked
+for: after a few seconds, any slow book-list load now offers a cancel
+button, and cancelling also clears the active tag filter so the same slow
+search doesn't just fire again immediately. One remaining question — whether
+internal bookkeeping tags should be hidden from the browsable tag list at
+all — was deliberately left open as a preference for a human to decide,
+rather than a bug for us to silently fix one way or the other.
 
 Dependency updates this month (7 pull requests, entirely automated version
 bumps) had no behavior changes worth a full write-up and are noted here for

--- a/web/src/components/BookGrid.tsx
+++ b/web/src/components/BookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/BookGrid.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 6e7f8a9b-0c1d-2e3f-4a5b-6c7d8e9f0a1b
-// last-edited: 2026-05-20
+// last-edited: 2026-07-11
 
 import React from 'react';
 import {
@@ -18,6 +18,7 @@ import type { ColumnDefinition } from '../config/columnDefinitions';
 interface BookGridProps {
   audiobooks: Audiobook[];
   loading: boolean;
+  onCancelLoad?: () => void;
   viewMode: ViewMode;
   page: number;
   totalPages: number;
@@ -46,6 +47,7 @@ interface BookGridProps {
 export const BookGrid: React.FC<BookGridProps> = ({
   audiobooks,
   loading,
+  onCancelLoad,
   viewMode,
   page,
   totalPages,
@@ -88,6 +90,7 @@ export const BookGrid: React.FC<BookGridProps> = ({
         <AudiobookGrid
           audiobooks={audiobooks}
           loading={loading}
+          onCancelLoad={onCancelLoad}
           onEdit={onEdit}
           onDelete={onDelete}
           onClick={onClick}
@@ -103,6 +106,7 @@ export const BookGrid: React.FC<BookGridProps> = ({
         <AudiobookList
           audiobooks={audiobooks}
           loading={loading}
+          onCancelLoad={onCancelLoad}
           onEdit={onEdit}
           onDelete={onDelete}
           onClick={onClick}

--- a/web/src/components/audiobooks/AudiobookGrid.tsx
+++ b/web/src/components/audiobooks/AudiobookGrid.tsx
@@ -1,16 +1,19 @@
 // file: web/src/components/audiobooks/AudiobookGrid.tsx
-// version: 1.7.0
+// version: 1.8.0
 // guid: 9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e
+// last-edited: 2026-07-11
 
 import React from 'react';
-import { Grid, Box, Typography, CircularProgress } from '@mui/material';
+import { Grid, Box, Typography } from '@mui/material';
 import { AudiobookCard } from './AudiobookCard';
+import { LoadingWithCancel } from './LoadingWithCancel';
 import type { Audiobook } from '../../types';
 import type { ColumnDefinition } from '../../config/columnDefinitions';
 
 interface AudiobookGridProps {
   audiobooks: Audiobook[];
   loading?: boolean;
+  onCancelLoad?: () => void;
   onEdit?: (audiobook: Audiobook) => void;
   onDelete?: (audiobook: Audiobook) => void;
   onClick?: (audiobook: Audiobook) => void;
@@ -26,6 +29,7 @@ interface AudiobookGridProps {
 export const AudiobookGrid: React.FC<AudiobookGridProps> = ({
   audiobooks,
   loading = false,
+  onCancelLoad,
   onEdit,
   onDelete,
   onClick,
@@ -38,16 +42,7 @@ export const AudiobookGrid: React.FC<AudiobookGridProps> = ({
   visibleColumnIds,
 }) => {
   if (loading) {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="400px"
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingWithCancel onCancel={onCancelLoad} />;
   }
 
   if (audiobooks.length === 0) {

--- a/web/src/components/audiobooks/AudiobookList.tsx
+++ b/web/src/components/audiobooks/AudiobookList.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/audiobooks/AudiobookList.tsx
-// version: 2.7.1
+// version: 2.8.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-05-20
+// last-edited: 2026-07-11
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -41,10 +41,12 @@ import type { Audiobook, BookFile, FilterOptions } from '../../types';
 import { type ColumnDefinition, getDefaultVisibleColumns } from '../../config/columnDefinitions';
 import * as api from '../../services/api';
 import type { QuickQueryItem } from '../../services/api';
+import { LoadingWithCancel } from './LoadingWithCancel';
 
 interface AudiobookListProps {
   audiobooks: Audiobook[];
   loading?: boolean;
+  onCancelLoad?: () => void;
   onEdit?: (audiobook: Audiobook) => void;
   onDelete?: (audiobook: Audiobook) => void;
   onClick?: (audiobook: Audiobook) => void;
@@ -68,6 +70,7 @@ const fallbackColumns = getDefaultVisibleColumns();
 export const AudiobookList: React.FC<AudiobookListProps> = ({
   audiobooks,
   loading = false,
+  onCancelLoad,
   onEdit,
   onDelete,
   onClick,
@@ -314,11 +317,7 @@ export const AudiobookList: React.FC<AudiobookListProps> = ({
   };
 
   if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingWithCancel onCancel={onCancelLoad} />;
   }
 
   if (audiobooks.length === 0) {

--- a/web/src/components/audiobooks/LoadingWithCancel.test.tsx
+++ b/web/src/components/audiobooks/LoadingWithCancel.test.tsx
@@ -1,0 +1,46 @@
+// file: web/src/components/audiobooks/LoadingWithCancel.test.tsx
+// version: 1.0.0
+// guid: 7a1e3c5b-9d2f-4a6c-8b1e-3d5f7a9c1b3e
+// last-edited: 2026-07-11
+
+import { render, screen, act } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LoadingWithCancel } from './LoadingWithCancel';
+
+describe('LoadingWithCancel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('does not show a cancel button before the slow threshold', () => {
+    render(<LoadingWithCancel onCancel={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  test('shows a cancel button after the slow threshold and calls onCancel when clicked', () => {
+    const onCancel = vi.fn();
+    render(<LoadingWithCancel onCancel={onCancel} />);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    const button = screen.getByRole('button', { name: /cancel/i });
+    button.click();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('never shows a cancel button when onCancel is not provided', () => {
+    render(<LoadingWithCancel />);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/audiobooks/LoadingWithCancel.tsx
+++ b/web/src/components/audiobooks/LoadingWithCancel.tsx
@@ -1,0 +1,49 @@
+// file: web/src/components/audiobooks/LoadingWithCancel.tsx
+// version: 1.0.0
+// guid: 2f8c4a1d-6b3e-4d7a-9c5f-8e1b3a6d2f4c
+// last-edited: 2026-07-11
+
+import { useEffect, useState } from 'react';
+import { Box, CircularProgress, Button, Typography } from '@mui/material';
+
+const SLOW_THRESHOLD_MS = 3000;
+
+interface LoadingWithCancelProps {
+  /** Omit to show a plain indefinite spinner with no cancel affordance. */
+  onCancel?: () => void;
+}
+
+// Remounts (and so resets its own elapsed timer) whenever the parent's
+// `loading` branch flips false -> true, since the parent conditionally
+// renders this component only while loading is true.
+export function LoadingWithCancel({ onCancel }: LoadingWithCancelProps) {
+  const [slow, setSlow] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setSlow(true), SLOW_THRESHOLD_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="400px"
+      gap={2}
+    >
+      <CircularProgress />
+      {slow && onCancel && (
+        <>
+          <Typography variant="body2" color="text.secondary">
+            Still loading&hellip;
+          </Typography>
+          <Button variant="outlined" size="small" onClick={onCancel}>
+            Cancel
+          </Button>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/layout/Sidebar.tsx
-// version: 1.13.0
+// version: 1.14.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
+// last-edited: 2026-07-11
 
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.6.0
+// version: 1.7.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 import {
   Typography,
@@ -41,6 +41,7 @@ import { STORAGE_KEYS } from '../../lib/storageKeys';
 interface LibraryBookGridProps {
   audiobooks: Audiobook[];
   loading: boolean;
+  onCancelLoad?: () => void;
   searchQuery: string;
   setSearchQuery: (q: string) => void;
   setParsedSearch: (p: ParsedSearch) => void;
@@ -111,6 +112,7 @@ interface LibraryBookGridProps {
 export const LibraryBookGrid = ({
   audiobooks,
   loading,
+  onCancelLoad,
   searchQuery,
   setSearchQuery,
   setParsedSearch,
@@ -346,6 +348,7 @@ export const LibraryBookGrid = ({
           <BookGrid
             audiobooks={audiobooks}
             loading={loading}
+            onCancelLoad={onCancelLoad}
             viewMode={viewMode}
             page={page}
             totalPages={totalPages}

--- a/web/src/hooks/useLibraryQuery.test.ts
+++ b/web/src/hooks/useLibraryQuery.test.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.test.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7c8d9e0f-1a2b-4c5d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
@@ -92,5 +92,131 @@ describe('useLibraryQuery out-of-order response guard', () => {
 
     expect(result.current.audiobooks).toHaveLength(1);
     expect(result.current.audiobooks[0].id).toBe('!fresh');
+  });
+});
+
+// baseProps mirrors the fixture in the describe block above — duplicated
+// rather than shared across describe blocks so each suite's mock wiring
+// stays self-contained and easy to read in isolation.
+function makeBaseProps(overrides: Partial<Parameters<typeof useLibraryQuery>[0]> = {}) {
+  return {
+    page: 1,
+    itemsPerPage: 20,
+    debouncedSearch: '',
+    parsedSearch: null,
+    filters: {},
+    selectedTags: [] as string[],
+    sortBy: SortField.Title,
+    sortOrder: SortOrder.Ascending,
+    activeScanOp: null,
+    activeOrganizeOp: null,
+    setImportPaths: vi.fn(),
+    navigate: vi.fn() as unknown as ReturnType<typeof import('react-router-dom').useNavigate>,
+    toast: vi.fn(),
+    buildFieldFilters: () => [],
+    convertBook,
+    ...overrides,
+  };
+}
+
+// abortableGetBooks returns a getBooks mock whose promise only settles when
+// the AbortSignal passed by loadAudiobooks() fires — modeling a real fetch()
+// cancellation instead of a fake timer or a manually-resolved promise.
+function abortableGetBooks() {
+  let capturedSignal: AbortSignal | undefined;
+  const impl: typeof api.getBooks = (_limit, _offset, options) => {
+    capturedSignal = options?.signal;
+    return new Promise((_resolve, reject) => {
+      options?.signal?.addEventListener('abort', () => {
+        const err = new Error('The operation was aborted.');
+        err.name = 'AbortError';
+        reject(err);
+      });
+    });
+  };
+  return { impl, getSignal: () => capturedSignal };
+}
+
+describe('useLibraryQuery cancelLoad', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    useLibraryCache.getState().clear();
+    vi.mocked(api.getImportPaths).mockResolvedValue([]);
+  });
+
+  test('cancelLoad aborts the in-flight fetch and flips loading off immediately', async () => {
+    const { impl, getSignal } = abortableGetBooks();
+    vi.mocked(api.getBooks).mockImplementation(impl);
+
+    const { result } = renderHook(() => useLibraryQuery(makeBaseProps()));
+
+    act(() => {
+      result.current.loadAudiobooks();
+    });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(getSignal()?.aborted).toBe(false);
+
+    act(() => {
+      result.current.cancelLoad();
+    });
+
+    // loading flips synchronously — cancelLoad does not wait for the
+    // aborted fetch promise to reject and run through its own finally.
+    expect(result.current.loading).toBe(false);
+    expect(getSignal()?.aborted).toBe(true);
+  });
+
+  test('an aborted request does not surface an error toast or clear the book list', async () => {
+    const { impl } = abortableGetBooks();
+    vi.mocked(api.getBooks).mockImplementation(impl);
+    const toast = vi.fn();
+
+    const { result } = renderHook(() => useLibraryQuery(makeBaseProps({ toast })));
+
+    act(() => {
+      result.current.loadAudiobooks();
+    });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    act(() => {
+      result.current.cancelLoad();
+    });
+
+    // Let the now-rejected fetch promise's .catch() handler run.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(toast).not.toHaveBeenCalled();
+    // The abort branch returns before the `setAudiobooks([])` fallback that
+    // a genuine failure would hit, so a cancel is not indistinguishable
+    // from a server error in the UI.
+    expect(result.current.audiobooks).toEqual([]);
+  });
+
+  test('loadAudiobooks aborts a still-in-flight prior call before issuing a new one', async () => {
+    const { impl, getSignal: getFirstSignal } = abortableGetBooks();
+    vi.mocked(api.getBooks).mockImplementationOnce(impl);
+    vi.mocked(api.getBooks).mockResolvedValueOnce({
+      items: [makeBook('second', 'Second Book')],
+      count: 1,
+    });
+
+    const { result } = renderHook(() => useLibraryQuery(makeBaseProps()));
+
+    act(() => {
+      result.current.loadAudiobooks();
+    });
+    await waitFor(() => expect(getFirstSignal()).toBeDefined());
+    expect(getFirstSignal()?.aborted).toBe(false);
+
+    act(() => {
+      result.current.loadAudiobooks();
+    });
+
+    await waitFor(() => expect(getFirstSignal()?.aborted).toBe(true));
+    await waitFor(() => expect(result.current.audiobooks).toHaveLength(1));
+    expect(result.current.audiobooks[0].id).toBe('second');
   });
 });

--- a/web/src/hooks/useLibraryQuery.ts
+++ b/web/src/hooks/useLibraryQuery.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789003
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -75,6 +75,11 @@ export function useLibraryQuery({
   // overwrite good data with stale data.
   const latestRequestIdRef = useRef(0);
 
+  // AbortController for the in-flight loadAudiobooks fetch, so a slow tag
+  // filter (or any slow query) can be cancelled from the UI. Same pattern as
+  // UnifiedDedupTab.tsx / CandidateCompareDrawer.tsx.
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   const loadSoftDeleted = useCallback(async () => {
     setSoftDeletedLoading(true);
     try {
@@ -92,6 +97,9 @@ export function useLibraryQuery({
 
   const loadAudiobooks = useCallback(async () => {
     const requestId = ++latestRequestIdRef.current;
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
     setLoading(true);
     try {
       const offset = (page - 1) * itemsPerPage;
@@ -123,7 +131,7 @@ export function useLibraryQuery({
 
       const [page_, folders] = await Promise.all([
         searchText
-          ? api.searchBooksPage(searchText, itemsPerPage, offset, filters.showFailed)
+          ? api.searchBooksPage(searchText, itemsPerPage, offset, filters.showFailed, controller.signal)
           : api.getBooks(itemsPerPage, offset, {
               sortBy,
               sortOrder,
@@ -135,8 +143,9 @@ export function useLibraryQuery({
               fingerprintStatus: filters.fingerprintStatus,
               coveragePercentMin: filters.coveragePercentMin,
               coveragePercentMax: filters.coveragePercentMax,
+              signal: controller.signal,
             }),
-        api.getImportPaths(),
+        api.getImportPaths(controller.signal),
       ]);
 
       // A newer loadAudiobooks call has since been issued (e.g. page size or
@@ -178,6 +187,13 @@ export function useLibraryQuery({
       setTotalPages(totalPages);
       setImportPaths(importPathsData);
     } catch (error) {
+      // A cancelled fetch (user clicked Cancel, or a newer request superseded
+      // this one and aborted it) is not a failure — skip the error toast/
+      // empty-state handling entirely. loading/audiobooks state is already
+      // whatever cancelLoad() or the newer request set it to.
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
       if (error instanceof api.ApiError && error.status === 401) {
         navigate('/login');
         return;
@@ -242,6 +258,15 @@ export function useLibraryQuery({
     useLibraryCache.getState().clear();
   }, []);
 
+  // cancelLoad aborts the in-flight loadAudiobooks fetch and flips loading
+  // off immediately — don't wait for the aborted promise to reject and run
+  // through its own finally block, since that adds a round trip's worth of
+  // latency to what should feel instant.
+  const cancelLoad = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setLoading(false);
+  }, []);
+
   return {
     audiobooks,
     setAudiobooks,
@@ -255,5 +280,6 @@ export function useLibraryQuery({
     loadAudiobooks,
     loadSoftDeleted,
     clearLibraryCache,
+    cancelLoad,
   };
 }

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.tsx
-// version: 1.77.0
+// version: 1.78.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -652,6 +652,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     loadAudiobooks,
     loadSoftDeleted,
     clearLibraryCache,
+    cancelLoad,
   } = useLibraryQuery({
     page,
     itemsPerPage,
@@ -669,6 +670,15 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     buildFieldFilters,
     convertBook: convertApiBook,
   });
+
+  // Cancelling a slow load also clears the active tag filter — a slow tag
+  // filter is exactly the case a user is likely cancelling out of, and
+  // leaving it selected would just re-trigger the same slow query on the
+  // next render.
+  const handleCancelLoad = useCallback(() => {
+    cancelLoad();
+    handleTagFilterChange([]);
+  }, [cancelLoad, handleTagFilterChange]);
 
   const {
     selectedAudiobooks,
@@ -1874,6 +1884,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         <LibraryBookGrid
           audiobooks={audiobooks}
           loading={loading}
+          onCancelLoad={handleCancelLoad}
           searchQuery={searchQuery}
           setSearchQuery={setSearchQuery}
           setParsedSearch={setParsedSearch}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -897,6 +897,7 @@ export async function getBooks(
     fingerprintStatus?: 'complete' | 'partial' | 'none';
     coveragePercentMin?: number;
     coveragePercentMax?: number;
+    signal?: AbortSignal;
   }
 ): Promise<BooksPage> {
   const params = new URLSearchParams();
@@ -922,7 +923,7 @@ export async function getBooks(
     params.set('coverage_percent_max', String(options.coveragePercentMax));
   params.set('is_primary_version', 'true');
 
-  const response = await apiFetch(`${API_BASE}/audiobooks?${params}`);
+  const response = await apiFetch(`${API_BASE}/audiobooks?${params}`, { signal: options?.signal });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch books');
   }
@@ -975,7 +976,8 @@ export async function searchBooksPage(
   query: string,
   limit = 50,
   offset = 0,
-  showFailed = false
+  showFailed = false,
+  signal?: AbortSignal
 ): Promise<BooksPage> {
   const params = new URLSearchParams({
     search: query,
@@ -984,7 +986,7 @@ export async function searchBooksPage(
     is_primary_version: 'true',
   });
   if (showFailed) params.set('show_quarantined', 'true');
-  const response = await apiFetch(`${API_BASE}/audiobooks?${params}`);
+  const response = await apiFetch(`${API_BASE}/audiobooks?${params}`, { signal });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to search books');
   }
@@ -1705,8 +1707,8 @@ export async function getWorks(): Promise<Work[]> {
 }
 
 // Import Paths
-export async function getImportPaths(): Promise<ImportPath[]> {
-  const response = await apiFetch(`${API_BASE}/import-paths`);
+export async function getImportPaths(signal?: AbortSignal): Promise<ImportPath[]> {
+  const response = await apiFetch(`${API_BASE}/import-paths`, { signal });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to fetch import paths');
   }


### PR DESCRIPTION
## Summary

Third part of the reported library UI bug (#1895 covered the first two: the tag-index parsing bug and the "All Books" reset). This adds the cancel/timeout-aware loading UX the user originally asked for: "show some indication that it's loading, even if it's like a loading model that allowed the user to cancel if it was taking too long. It also has to clear the tag in a cancel situation."

**Known limitation, flagged before building:** whether large, slow-to-filter tags still exist in practice can only be re-measured once #1895 is deployed to production. This PR builds the general-purpose cancel mechanism regardless of that measurement, since it's independently useful and was explicitly requested.

- **`web/src/services/api.ts`** — `getBooks`, `searchBooksPage`, `getImportPaths` now accept an optional `signal?: AbortSignal`, matching the existing `getDedupCandidateBreakdown(id, signal?)` convention.
- **`web/src/hooks/useLibraryQuery.ts`** — new `AbortController` ref (same pattern as `UnifiedDedupTab.tsx`/`CandidateCompareDrawer.tsx`): aborts the previous in-flight request at the start of every `loadAudiobooks()` call, and exposes `cancelLoad()`. A cancelled/aborted fetch is treated as a no-op in the catch block — no error toast, no clobbering a newer request's result.
- **`web/src/components/audiobooks/LoadingWithCancel.tsx`** (new) — shared component: plain spinner for the first ~3s, then grows a "Still loading… Cancel" button. Used by both `AudiobookGrid` (grid view) and `AudiobookList` (list view), threaded through `BookGrid.tsx` → `LibraryBookGrid.tsx` → `Library.tsx`.
- **`web/src/pages/Library.tsx`** — the cancel callback calls both `cancelLoad()` and `handleTagFilterChange([])`, per the original ask that cancelling must also clear the tag filter.
- Also fixes two missed file-header version bumps from #1895 (`Sidebar.tsx`, `Library.tsx`).

Deferred (still open, not in this PR): whether system-sourced tags should be hidden from the general browse cloud at all — a UX preference, not a bug.

## Test plan

- [x] New tests fail against pre-fix code, pass against the fix (verified via `git stash`): `useLibraryQuery.test.ts`'s `cancelLoad` describe block (3 tests: abort flips loading off immediately, aborted request doesn't toast/clobber state, a new load aborts a still-in-flight prior one)
- [x] `LoadingWithCancel.test.tsx` (3 tests: no cancel button before threshold, button appears + fires `onCancel` after threshold, never shown without an `onCancel` handler)
- [x] `tsc --noEmit` clean, `eslint` clean on all changed files
- [x] Full vitest suite green: 55/55 files, 351/351 tests

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv