### PR TITLE
docs(system): comprehensive system documentation set (DOCS-1, #1276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.140.0 -->
+<!-- version: 3.141.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 11, 2026 - docs(system): comprehensive system documentation set (DOCS-1, #1276)
+
+- **`docs/system`** — audited the existing 9-page system-documentation set against issue
+  #1276's six-item scope (process graphs/data flow, architecture diagrams, component
+  inventory, operations runbooks, incident history, API/storage) and gap-filled. Added the
+  missing `deploy-and-gpu-ops.md` link to `docs/system/README.md` (index table + site-map
+  diagram). Refreshed `docs/system/incidents.md` (stale at 2026-06-29) with post-June work:
+  INC-07 (`dedup.full-scan` single-core/write-stall/O(N²) freeze, #19), INC-08 (Author/Series
+  write-back wipe on `organizer.CreateOrganizedVersion`, PR #1888), INC-09 (Pebble tag-index
+  colon-parse bug, #1893), decision DEC-04 (STOREFID Core-vs-Full getter fidelity), a July
+  timeline section, and matching diagnostic-entry rows. Added a cross-link from
+  `docs/architecture.md` to `docs/system/README.md`. Docs-only; grounded in code symbols at HEAD.
 
 #### July 11, 2026 - feat(library): cancelable, timeout-aware loading for the book list
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,13 @@
 <!-- file: docs/architecture.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.0.1 -->
 <!-- guid: 1a9b8c7d-6e5f-4a3b-92c1-d0e9f8a7b6c5 -->
+<!-- last-edited: 2026-07-11 -->
 
 # Architecture
+
+> **See also:** the deeper, per-subsystem system-documentation set lives in
+> [`docs/system/`](system/README.md) — architecture, pipelines, storage, API,
+> runbooks, components, incidents, and deploy/GPU ops, with process/data-flow diagrams.
 
 ## Overview
 

--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -1,11 +1,15 @@
 <!-- file: docs/system/README.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: 42030117-6ba8-4f26-a2c6-9b5f9014ef88 -->
-<!-- last-edited: 2026-06-29 -->
+<!-- last-edited: 2026-07-11 -->
 
 # System Documentation
 
-> **Status:** DOCS-1 workstream complete. All 6 area documents are written and cross-linked below.
+> **Status:** DOCS-1 workstream complete (#1276). All eight area documents below are
+> written and cross-linked, covering the issue's six-item scope (process graphs/data
+> flow, architecture diagrams, component inventory, operations runbooks, incident
+> history, and API/storage detail). No scope item is deferred. Incident history was
+> last refreshed 2026-07-11 with the July STOREFID/concurrency work.
 
 Audiobook Organizer is a single-binary server (Go backend, React frontend) for scanning,
 normalizing, enriching, deduplicating, organizing, and serving audiobook
@@ -25,6 +29,7 @@ changes, metadata fetches, AI-assisted parsing, and operational workflows.
 | [Runbooks](runbooks.md) | Operational procedures for local builds, production service care, deployments, backups, and recovery. |
 | [Components](components.md) | Backend packages, frontend surfaces, integrations, and their primary ownership areas. |
 | [Incidents](incidents.md) | Known failure modes, historical incident notes, diagnostic entry points, and prevention follow-ups. |
+| [Deploy & GPU Ops](deploy-and-gpu-ops.md) | Deploy rollback flow, local-config templates, and Windows GPU (Ollama) keepalive. |
 
 ## Site Map
 
@@ -38,6 +43,7 @@ flowchart TD
     Runbooks["runbooks.md<br/>Operations and recovery"]
     Components["components.md<br/>Implementation inventory"]
     Incidents["incidents.md<br/>Failures and follow-ups"]
+    DeployGPU["deploy-and-gpu-ops.md<br/>Rollback and GPU keepalive"]
 
     Index --> Architecture
     Index --> Pipelines
@@ -46,6 +52,7 @@ flowchart TD
     Index --> Runbooks
     Index --> Components
     Index --> Incidents
+    Index --> DeployGPU
 
     Architecture --> Components
     Architecture --> API
@@ -54,6 +61,7 @@ flowchart TD
     Pipelines --> API
     Runbooks --> Pipelines
     Runbooks --> Storage
+    Runbooks --> DeployGPU
     Incidents --> Runbooks
     Incidents --> Components
 ```

--- a/docs/system/incidents.md
+++ b/docs/system/incidents.md
@@ -1,7 +1,7 @@
 <!-- file: docs/system/incidents.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: a7b8c9d0-e1f2-3456-0123-456789012345 -->
-<!-- last-edited: 2026-06-29 -->
+<!-- last-edited: 2026-07-11 -->
 
 # Incidents and Decisions
 
@@ -72,6 +72,39 @@ This document records known failure modes, historical incidents, architectural d
 
 ---
 
+### INC-07: `dedup.full-scan` freeze — single-core scoring, Pebble write-stall, O(N²) ISBN collector (#19)
+
+**Date:** 2026-07-05 (root-caused and fixed 2026-07-05 to 2026-07-08)
+**Component:** `internal/dedup` — full-scan scoring path; `internal/plugins/dedup`
+**Root cause:** A `dedup.full-scan` run went silent for hours at 100% CPU on a single core. Three distinct causes compounded, discovered across the concurrency audit and issue #19:
+- **Single-threaded scoring (concurrency audit, CONC-2):** the "unified scoring" pass was a plain `for range books` loop with no worker pool, so a whole-library-scale scan ran on one core. See [`docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`](../audits/2026-07-05-concurrency-single-threaded-hotspots.md) for the full hotspot inventory and per-shape fix patterns.
+- **Pebble write-stall:** synchronous candidate writes during the compose-scores phase stalled behind PebbleDB fsync, so the scan appeared frozen mid-run.
+- **O(N²) ISBN/ASIN collection:** `dedup.CollectISBNASIN` (`internal/dedup/collectors_exact.go`) compared every book against every other book pairwise instead of indexing matches.
+**Fix:** NoSync candidate writes during full-scan compose-scores (commit `087d0dbe`); `CollectISBNASIN` re-indexed O(N²)→O(matches) (commit `c36c05f4`); the `emit()` mutex was sharded and per-pair book lookups moved off the pair lock (commit `dd5aa9c7`, CONC-3). Prod-confirmed clean completion at ~606 books/sec (commit `b4058e10`).
+**Prevention:** Any full-library loop doing per-item DB/hash/fuzzy-compare work must ship with a bounded worker pool from the start (see the Concurrency section of `CLAUDE.md`). Pairwise/O(n²) collectors must index, not double-loop. Prefer `NoSync` for bulk intermediate writes that are recomputable on restart.
+
+---
+
+### INC-08: Author/Series wiped on organized-version write-back (STOREFID W5d-1, PR #1888)
+
+**Date:** 2026-07-08 (fix committed `98c2a218`)
+**Component:** `internal/organizer` — `CreateOrganizedVersion` (`internal/organizer/service.go`)
+**Root cause:** `CreateOrganizedVersion` read books via a memdb-slim getter (which strips heavy fields) and then wrote the whole book back. Because `UpdateBook` does a full column replacement, the slimmed round-trip wrote empty `Author`/`Series` over the curated values — a silent data-loss on every organized-version creation. Same footgun class as the earlier `AcoustIDFingerprint` wipe (see DEC-04).
+**Fix:** Stopped the write-back from clobbering `Author`/`Series` on `CreateOrganizedVersion`; regression test added (`internal/organizer/organized_version_writeback_test.go`).
+**Prevention:** Never full-replace a book/book-file that was read through a memdb-slim getter. Read via a `*Full`/hydrate getter, or preserve the stripped fields explicitly. See the memdb round-trip write footgun.
+
+---
+
+### INC-09: Namespaced tag bubbles return 0 books / bogus counts (#1893)
+
+**Date:** 2026-07-11 (fix committed `c6d1ccbc`)
+**Component:** `internal/database` — Pebble tag index (`ListAllTags`, `GetBooksByTag`, and the shared `pebbleListAllTags`/`pebbleEntitiesByTag` helpers)
+**Root cause:** The `tag_idx` key was parsed on a fixed split arity / unvalidated byte-prefix scan, so any colon-containing tag (all auto-applied `metadata:*`, `dedup:*`, `import:*`, `organize:*` system tags) was truncated or matched against the wrong entity. Prod-confirmed: `tag=metadata`, `tag=dedup`, and the fully-qualified `tag=metadata:source:audible` all returned 0 results, and the library-sidebar tag bubbles showed miscounted totals.
+**Fix:** Parse the index key on the **last** colon and re-validate every prefix-scan match (entity IDs are guaranteed colon-free). Also fixed the sidebar "All Books" navigation that left tag filters stuck.
+**Prevention:** Index keys that embed a variable-length, colon-containing value must split on the last delimiter and re-validate the scanned prefix — never assume a fixed field count.
+
+---
+
 ## Architectural Decisions
 
 ### DEC-01: PebbleDB as sole durable store
@@ -91,6 +124,12 @@ This document records known failure modes, historical incidents, architectural d
 **Date:** 2026-05
 **Decision:** All long-running jobs are implemented as `OperationDef` entries registered with the v2 operations registry. HTTP API provides launch + poll. State persists to PebbleDB (`opv2:*` keys). Checkpoint support allows resume after server restart.
 **Rationale:** Replaces a tangled mix of goroutines, channels, and ad-hoc HTTP endpoints. Provides uniform progress reporting, cancellation, and history.
+
+### DEC-04: Store-getter Core-vs-Full fidelity encoded in the type (STOREFID)
+
+**Date:** 2026-07 (waves W3–W6, PRs #1837–#1888)
+**Decision:** Store getters now return an explicit fidelity in their type. "Core" getters (`GetAllBooksCore`, `GetAllBookFilesCore`, `GetBooksBySeriesIDCore`) return slim `BookCore`/`BookFileCore` values (`internal/database/bookcore.go`) that intentionally omit heavy/strippable fields; callers that need every field must use a `*Full`/hydrate variant (`GetAllBooksFullFrom`, proxy-then-hydrate). The catch-all `GetAllBooks` was removed entirely (commit `3266f6d7`).
+**Rationale:** The `AcoustIDFingerprint` wipe and the Author/Series wipe (INC-08) were both the same footgun — a memdb-slim read followed by a full-column write-back. Making the slimness visible in the return type (`BookCore` vs full `Book`) turns a silent runtime data-loss into a compile-time-obvious choice at every call site. After a getter change, run `go test ./... -short` (not a subset) so old-signature mocks don't vacuous-pass.
 
 ---
 
@@ -126,6 +165,13 @@ gantt
     section Pagination
     Library double-pagination fix (PR #1660) :done, 2026-06-28, 2026-06-28
     memdb pagination cap fix (PR #1647)  :done, 2026-06-20, 2026-06-21
+
+    section STOREFID + Concurrency (July)
+    Concurrency single-core hotspot sweep :done, 2026-07-05, 2026-07-05
+    dedup.full-scan freeze resolved (#19) :done, 2026-07-05, 2026-07-08
+    STOREFID Core/Full getter fidelity   :done, 2026-07-05, 2026-07-08
+    Author/Series write-back wipe fix (PR #1888) :done, 2026-07-08, 2026-07-08
+    Pebble tag-index colon parse fix (#1893) :done, 2026-07-11, 2026-07-11
 ```
 
 ## Diagnostic Entry Points
@@ -142,6 +188,9 @@ When investigating an issue, start here:
 | Fingerprinting not progressing | Check `FingerprintFailedAt` on `BookFile`; fpcalc may need reinstall |
 | memdb shows stale counts | `InvalidateLibraryStats` should have been called; check for missed `UpdateBook` callers |
 | Operation stuck in "running" | Check `opv2:act:<id>` key exists; if server restarted mid-op, op may need manual cancel |
+| `dedup.full-scan` frozen at 100% CPU on one core | Confirm it is running on a worker pool, not a serial `for range books`; check for O(N²) collectors and synchronous Pebble writes (INC-07) |
+| Author/Series (or fingerprint) blank after organize/write-back | A memdb-slim getter was full-replaced; audit for `Core` getters feeding a full `UpdateBook`/`UpdateBookFile` (INC-08, DEC-04) |
+| Tag bubble shows wrong count or 0 books on click | Namespaced (`metadata:*`/`dedup:*`) tag-index parse; verify last-colon split in `pebbleEntitiesByTag` (INC-09) |
 
 ## Cross-references
 


### PR DESCRIPTION
Closes #1276

## Summary
Audit-and-gap-fill of the existing 9-page `docs/system/` set against issue #1276's six-item scope (not fresh authoring). Docs-only; no code touched.

## Gap audit (6 coverage items)
| Coverage item | Page(s) | Status |
|---|---|---|
| process graphs / data flow | pipelines.md | covered, current |
| architecture diagrams | architecture.md | covered, current |
| component inventory | components.md | covered, current |
| operations runbooks | runbooks.md + deploy-and-gpu-ops.md | covered, current |
| incident history | incidents.md | covered but was stale (fixed) |
| API / storage detail | api.md + storage.md | covered, current |

No scope item deferred.

## Changes
- `docs/system/README.md` — added the missing `deploy-and-gpu-ops.md` link (index table + site-map diagram); status line now reflects 8 pages / 6-item scope. Version bump.
- `docs/system/incidents.md` — refreshed from 2026-06-29 with July work, grounded in commits/symbols at HEAD: INC-07 (`dedup.full-scan` single-core/write-stall/O(N²) freeze, #19), INC-08 (Author/Series write-back wipe on `organizer.CreateOrganizedVersion`, PR #1888), INC-09 (Pebble tag-index colon-parse bug, #1893), DEC-04 (STOREFID Core-vs-Full getter fidelity), July gantt section, diagnostic-entry rows. Version bump.
- `docs/architecture.md` — cross-link to `docs/system/README.md`; header version bump.
- `CHANGELOG.md` — entry.

## Verification
- `ls docs/system/*.md | wc -l` = 9; ` ```mermaid ` fences = 12 (floor >=7).
- Every non-README page linked from README.
- Every new/edited file has the 4-line header; no bare `file:line` citations (symbol-based only).
- staticcheck is red on main (pre-existing #1796); this PR is docs-only, merge gate is Minimal CI green.