### PR TITLE
refactor(config): retire CFG-2 Phase D flat-key compat shim (#1536, CONS-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@
   timeline section, and matching diagnostic-entry rows. Added a cross-link from
   `docs/architecture.md` to `docs/system/README.md`. Docs-only; grounded in code symbols at HEAD.
 
+#### July 10, 2026 - refactor(config): retire CFG-2 Phase D flat-key compat shim (#1536, CONS-13)
+
+- **`config`** (backend) — removed the flat→nested config migration shim
+  (`legacyRemapGroup` type, `configRemapGroups` var, `applyLegacyRemaps` func) from
+  `internal/config/update_service.go`. Phases B+C (PR #1514, stable in prod since
+  2026-06-19) mean the frontend sends nested keys, so config updates now accept nested
+  keys only. `remapScheduledKeys` (INIT-6/WF-3) and the JSON round-trip apply path are
+  untouched.
+- To keep any regression observable rather than silent, added a one-release
+  detection-only warn-log (`retiredLegacyFlatKeys`): a flat-only POST that would have
+  been remapped is now dropped by the JSON round-trip, but each such key is warn-logged
+  (`legacy flat config key ... no longer remapped, dropped`). Removal follow-up filed as
+  CFG-2-D-LOG in TODO.md. Also fixed TODO.md's stale `internal/server/update_service.go`
+  path claim (that file does not exist).
+
 #### July 11, 2026 - feat(library): cancelable, timeout-aware loading for the book list
 
 - **`library`** (frontend) — the book grid/list previously showed a bare, indefinite spinner

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.91.0 -->
+<!-- version: 9.92.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -613,7 +613,8 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 - [ ] **CONS-10** **Track D3** — drain stale exact candidates. **Code fixes CONS-16 + CONS-17 now MERGED**; remaining blocker is the **backfill/re-scan** on prod (run `maintenance.duration-backfill` dry-run → apply; re-scan affected filesystem books so corrected titles land) so candidates self-resolve, THEN re-scope. ⚠️ Prod investigation (candidate 211) proved the 380K exact candidates are a MIX: some real dups + many real multi-file books mislabeled by the duration-ms + title-leak bugs. Quarantining before backfill = **DATA LOSS**. **Re-run `dedup.quarantine-chapter-artifacts` dry-run AFTER backfill, show the list, get explicit user OK before any apply.**  <!-- 2026-07-01: ⏳ code fixes (CONS-16/17) merged; blocked on prod duration-backfill + re-scan (DATA-LOSS gate — dry-run + user OK). -->
 - [x] **CONS-11** **Track D4** — manual-import UI button (op `library.import` already merged/deployed; no frontend yet). Add a button/dialog on the Library page that POSTs `{def_id:"library.import", params:{path}}` to `/api/v1/operations/v2` and polls. ~Lowest-effort remaining UI task. — ✅ verified done 2026-07-01: Library.tsx manualImport dialog + api.startLibraryImport
 - [x] **CONS-12** = **DEDUP-INTRO-1** (see Dedup UX section) — Audible intro/outro false-positive dedup candidates. — ✅ verified done 2026-07-01: = DEDUP-INTRO-1 (done)
-- [ ] **CONS-13** = **CFG-2 Phase D** — retire flat-key compat shim in `internal/server/update_service.go` (low priority; after 1+ wk prod stability).
+- [x] **CONS-13** = **CFG-2 Phase D** — retire flat-key compat shim in `internal/config/update_service.go` (low priority; after 1+ wk prod stability). — ✅ done 2026-07-10 (TASK-01): removed legacyRemapGroup/configRemapGroups/applyLegacyRemaps + their tests; kept remapScheduledKeys + JSON round-trip; added a one-release detection warn-log (retiredLegacyFlatKeys).
+- [ ] **CFG-2-D-LOG** — remove the `retiredLegacyFlatKeys` detection warn-log from `internal/config/update_service.go` after one stable release with zero flat-only-key warnings in prod logs (added by TASK-01).
 
 ### Metadata-repair track (root causes of the dedup candidate explosion) — investigated 2026-06-19
 
@@ -674,7 +675,7 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 - [x] **CFG-2 Phase A** — 11 nested TS interfaces added to `api.ts`. PR #1514.
 - [x] **CFG-2 Phase B** — `loadConfig`/`handleSave` wired to nested keys; Dedup tab at index 3. PR #1514.
 - [x] **CFG-2 Phase C** — Settings.tsx 3,077 → 1,395 lines; 9 section components + `useSettingsHandlers`. PR #1514.
-- [ ] **CFG-2 Phase D — Retire the flat-key compat shim.** Remove flat→nested remap in `update_service.go`; keep blob migration. Gate on Phase B+C proven stable. (open — future PR)
+- [x] **CFG-2 Phase D — Retire the flat-key compat shim.** Remove flat→nested remap in `update_service.go`; keep blob migration. Gate on Phase B+C proven stable. — ✅ done 2026-07-10 (TASK-01)
 - [x] **CFG-2 Phase E** — 5 Vitest unit tests + 1 E2E spec. 280 tests pass. PR #1514.
 
 ---

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1,7 +1,7 @@
 // file: internal/config/persistence_test.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-03
+// last-edited: 2026-07-10
 
 package config
 
@@ -856,43 +856,6 @@ func TestMigrateEmbeddingFields_EmptyBlob(t *testing.T) {
 	assert.False(t, changed, "empty blob should be a no-op")
 }
 
-func TestRemapEmbeddingKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"embedding_enabled":    true,
-		"embedding_model":      "bge-m3",
-		"embedding_dimensions": float64(1024),
-		"root_dir":             "/data",
-	}
-	result := applyLegacyRemaps(payload)
-
-	emb, ok := result["embedding"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, true, emb["enabled"])
-	assert.Equal(t, "bge-m3", emb["model"])
-	assert.Equal(t, float64(1024), emb["dimensions"])
-	assert.Equal(t, "/data", result["root_dir"]) // untouched
-	assert.NotContains(t, result, "embedding_enabled")
-	assert.NotContains(t, result, "embedding_model")
-}
-
-func TestRemapEmbeddingKeys_MixedKeys(t *testing.T) {
-	// Client sends both flat legacy key AND new nested key — merge, don't overwrite
-	payload := map[string]any{
-		"embedding_enabled": false,
-		"embedding":         map[string]any{"model": "bge-m3"},
-	}
-	result := applyLegacyRemaps(payload)
-	emb := result["embedding"].(map[string]any)
-	assert.Equal(t, false, emb["enabled"])
-	assert.Equal(t, "bge-m3", emb["model"])
-}
-
-func TestRemapEmbeddingKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
-}
-
 func TestMigrateDedupFields_FlatBlob(t *testing.T) {
 	flatBlob := `{
 		"dedup_book_high_threshold": 0.95,
@@ -928,27 +891,6 @@ func TestMigrateDedupFields_AlreadyNested(t *testing.T) {
 func TestMigrateDedupFields_EmptyBlob(t *testing.T) {
 	_, changed := migrateDedupBlob(`{}`)
 	assert.False(t, changed)
-}
-
-func TestRemapDedupKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"dedup_book_high_threshold": float64(0.95),
-		"dedup_review_model":        "gpt-5-mini",
-		"root_dir":                  "/data",
-	}
-	result := applyLegacyRemaps(payload)
-	d, ok := result["dedup"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, float64(0.95), d["book_high_threshold"])
-	assert.Equal(t, "gpt-5-mini", d["review_model"])
-	assert.Equal(t, "/data", result["root_dir"])
-	assert.NotContains(t, result, "dedup_book_high_threshold")
-}
-
-func TestRemapDedupKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
 func TestMigrateMetadataScoringFields_FlatBlob(t *testing.T) {
@@ -987,27 +929,6 @@ func TestMigrateMetadataScoringFields_AlreadyNested(t *testing.T) {
 func TestMigrateMetadataScoringFields_EmptyBlob(t *testing.T) {
 	_, changed := migrateMetadataScoringBlob(`{}`)
 	assert.False(t, changed)
-}
-
-func TestRemapMetadataScoringKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"metadata_embedding_scoring_enabled": true,
-		"write_backup_before_tag_write":      false,
-		"root_dir":                           "/data",
-	}
-	result := applyLegacyRemaps(payload)
-	ms, ok := result["metadata_scoring"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, true, ms["embedding_enabled"])
-	assert.Equal(t, false, ms["write_backup_before"])
-	assert.Equal(t, "/data", result["root_dir"])
-	assert.NotContains(t, result, "metadata_embedding_scoring_enabled")
-}
-
-func TestRemapMetadataScoringKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
 func TestMigrateITunesFields_FlatBlob(t *testing.T) {
@@ -1049,27 +970,6 @@ func TestMigrateITunesFields_EmptyBlob(t *testing.T) {
 	assert.False(t, changed)
 }
 
-func TestRemapITunesKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"itunes_sync_enabled":    true,
-		"itl_write_back_enabled": false,
-		"root_dir":               "/data",
-	}
-	result := applyLegacyRemaps(payload)
-	it, ok := result["itunes"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, true, it["sync_enabled"])
-	assert.Equal(t, false, it["write_back_enabled"])
-	assert.Equal(t, "/data", result["root_dir"])
-	assert.NotContains(t, result, "itunes_sync_enabled")
-}
-
-func TestRemapITunesKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
-}
-
 func TestMigrateMaintenanceFields_FlatBlob(t *testing.T) {
 	flatBlob := `{
 		"maintenance_window_enabled": false,
@@ -1105,27 +1005,6 @@ func TestMigrateMaintenanceFields_AlreadyNested(t *testing.T) {
 func TestMigrateMaintenanceFields_EmptyBlob(t *testing.T) {
 	_, changed := migrateMaintenanceBlob(`{}`)
 	assert.False(t, changed)
-}
-
-func TestRemapMaintenanceKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"maintenance_window_enabled":           false,
-		"acoustid_online_lookup_nightly_limit": float64(500),
-		"root_dir":                             "/data",
-	}
-	result := applyLegacyRemaps(payload)
-	m, ok := result["maintenance"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, false, m["enabled"])
-	assert.Equal(t, float64(500), m["acoustid_nightly_limit"])
-	assert.Equal(t, "/data", result["root_dir"])
-	assert.NotContains(t, result, "maintenance_window_enabled")
-}
-
-func TestRemapMaintenanceKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
 func TestMigrateScheduledFields_FlatBlob(t *testing.T) {
@@ -1225,27 +1104,6 @@ func TestMigrateAutoUpdateFields_AlreadyNested(t *testing.T) {
 func TestMigrateAutoUpdateFields_EmptyBlob(t *testing.T) {
 	_, changed := migrateAutoUpdateBlob(`{}`)
 	assert.False(t, changed)
-}
-
-func TestRemapAutoUpdateKeys_FlatKeys(t *testing.T) {
-	payload := map[string]any{
-		"auto_update_enabled": false,
-		"auto_update_channel": "beta",
-		"root_dir":            "/data",
-	}
-	result := applyLegacyRemaps(payload)
-	au, ok := result["auto_update"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, false, au["enabled"])
-	assert.Equal(t, "beta", au["channel"])
-	assert.Equal(t, "/data", result["root_dir"])
-	assert.NotContains(t, result, "auto_update_enabled")
-}
-
-func TestRemapAutoUpdateKeys_NoFlatKeys(t *testing.T) {
-	payload := map[string]any{"root_dir": "/data"}
-	result := applyLegacyRemaps(payload)
-	assert.Equal(t, map[string]any{"root_dir": "/data"}, result)
 }
 
 // TestMigrateAIBackend_LocalFromBaseURL: a nested embedding.base_url signals a

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,7 +1,7 @@
 // file: internal/config/update_service.go
-// version: 3.9.0
+// version: 3.10.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
-// last-edited: 2026-06-23
+// last-edited: 2026-07-10
 
 package config
 
@@ -67,107 +67,66 @@ var secretFieldKeys = []string{
 // immutableFieldKeys cannot be changed at runtime and are rejected if present.
 var immutableFieldKeys = []string{"database_type", "enable_sqlite"}
 
-// legacyRemapGroup defines a single flat→nested config migration shim.
-// Remove entries (and their keys) once the frontend sends nested keys directly.
-type legacyRemapGroup struct {
-	groupKey     string
-	flatToNested map[string]string
-}
-
-// configRemapGroups is the single source of truth for all flat→nested config
-// key translations in UpdateConfig. Adding a new group here is sufficient —
-// no per-group function required.
-var configRemapGroups = []legacyRemapGroup{
-	{groupKey: "embedding", flatToNested: map[string]string{
-		"embedding_enabled":    "enabled",
-		"embedding_model":      "model",
-		"embedding_dimensions": "dimensions",
-		"embedding_base_url":   "base_url",
-		"vector_index_backend": "vector_backend",
-	}},
-	{groupKey: "dedup", flatToNested: map[string]string{
-		"dedup_book_high_threshold":             "book_high_threshold",
-		"dedup_book_low_threshold":              "book_low_threshold",
-		"dedup_author_high_threshold":           "author_high_threshold",
-		"dedup_author_low_threshold":            "author_low_threshold",
-		"dedup_auto_merge_enabled":              "auto_merge_enabled",
-		"dedup_embeddings_enabled":              "embeddings_enabled",
-		"dedup_llm_auto_merge_high_confidence": "llm_auto_merge_high_confidence",
-		"dedup_on_import_via_scheduler":         "on_import_via_scheduler",
-		"dedup_review_model":                    "review_model",
-	}},
-	{groupKey: "metadata_scoring", flatToNested: map[string]string{
-		"metadata_embedding_scoring_enabled": "embedding_enabled",
-		"metadata_embedding_min_score":       "embedding_min_score",
-		"metadata_embedding_best_match_min":  "embedding_best_match",
-		"metadata_llm_scoring_enabled":       "llm_enabled",
-		"metadata_llm_rerank_epsilon":        "llm_rerank_epsilon",
-		"metadata_llm_rerank_top_k":          "llm_rerank_top_k",
-		"write_backup_before_tag_write":      "write_backup_before",
-	}},
-	{groupKey: "itunes", flatToNested: map[string]string{
-		"itunes_sync_enabled":       "sync_enabled",
-		"itunes_sync_interval":      "sync_interval",
-		"itl_write_back_enabled":    "write_back_enabled",
-		"itunes_library_write_path": "library_write_path",
-		"itunes_library_read_path":  "library_read_path",
-		"itunes_auto_write_back":    "auto_write_back",
-		"itunes_path_trim_enabled":  "path_trim_enabled",
-		"itunes_windows_root_path":  "windows_root_path",
-		"itunes_media_root":         "media_root",
-	}},
-	{groupKey: "maintenance", flatToNested: map[string]string{
-		"maintenance_window_enabled":                "enabled",
-		"maintenance_window_start":                  "window_start",
-		"maintenance_window_end":                    "window_end",
-		"maintenance_window_dedup_refresh":          "dedup_refresh",
-		"maintenance_window_series_prune":           "series_prune",
-		"maintenance_window_author_split":           "author_split",
-		"maintenance_window_tombstone_cleanup":      "tombstone_cleanup",
-		"maintenance_window_reconcile":              "reconcile",
-		"maintenance_window_purge_deleted":          "purge_deleted",
-		"maintenance_window_purge_old_logs":         "purge_old_logs",
-		"maintenance_window_db_optimize":            "db_optimize",
-		"maintenance_window_library_scan":           "library_scan",
-		"maintenance_window_library_organize":       "library_organize",
-		"maintenance_window_metadata_refresh":       "metadata_refresh",
-		"maintenance_window_library_size_refresh":   "library_size_refresh",
-		"maintenance_window_acoustid_online_lookup": "acoustid_online_lookup",
-		"acoustid_online_lookup_nightly_limit":      "acoustid_nightly_limit",
-	}},
-	{groupKey: "auto_update", flatToNested: map[string]string{
-		"auto_update_enabled":       "enabled",
-		"auto_update_channel":       "channel",
-		"auto_update_check_minutes": "check_minutes",
-		"auto_update_window_start":  "window_start",
-		"auto_update_window_end":    "window_end",
-	}},
-}
-
-// applyLegacyRemaps applies all configRemapGroups to payload, translating any
-// legacy flat keys to their nested equivalents. Existing sub-objects are merged
-// rather than replaced, so partial payloads don't zero sibling fields.
-func applyLegacyRemaps(payload map[string]any) map[string]any {
-	for _, g := range configRemapGroups {
-		nested := make(map[string]any)
-		for flat, short := range g.flatToNested {
-			if v, ok := payload[flat]; ok {
-				nested[short] = v
-				delete(payload, flat)
-			}
-		}
-		if len(nested) == 0 {
-			continue
-		}
-		if existing, ok := payload[g.groupKey].(map[string]any); ok {
-			for k, v := range nested {
-				existing[k] = v
-			}
-		} else {
-			payload[g.groupKey] = nested
-		}
-	}
-	return payload
+// retiredLegacyFlatKeys lists the flat config keys whose flat→nested remapping
+// shim was retired in CFG-2 Phase D (#1536, CONS-13). The frontend has sent nested
+// keys since PR #1514; these flat forms are no longer remapped and are dropped by
+// the JSON round-trip (no matching top-level json tag). UpdateConfig warn-logs any
+// that still arrive so a lost write is observable rather than silent. This list —
+// and its warn-log — should be removed after one stable release with zero warnings
+// in prod (follow-up CFG-2-D-LOG in TODO.md).
+var retiredLegacyFlatKeys = []string{
+	"embedding_enabled",
+	"embedding_model",
+	"embedding_dimensions",
+	"embedding_base_url",
+	"vector_index_backend",
+	"dedup_book_high_threshold",
+	"dedup_book_low_threshold",
+	"dedup_author_high_threshold",
+	"dedup_author_low_threshold",
+	"dedup_auto_merge_enabled",
+	"dedup_embeddings_enabled",
+	"dedup_llm_auto_merge_high_confidence",
+	"dedup_on_import_via_scheduler",
+	"dedup_review_model",
+	"metadata_embedding_scoring_enabled",
+	"metadata_embedding_min_score",
+	"metadata_embedding_best_match_min",
+	"metadata_llm_scoring_enabled",
+	"metadata_llm_rerank_epsilon",
+	"metadata_llm_rerank_top_k",
+	"write_backup_before_tag_write",
+	"itunes_sync_enabled",
+	"itunes_sync_interval",
+	"itl_write_back_enabled",
+	"itunes_library_write_path",
+	"itunes_library_read_path",
+	"itunes_auto_write_back",
+	"itunes_path_trim_enabled",
+	"itunes_windows_root_path",
+	"itunes_media_root",
+	"maintenance_window_enabled",
+	"maintenance_window_start",
+	"maintenance_window_end",
+	"maintenance_window_dedup_refresh",
+	"maintenance_window_series_prune",
+	"maintenance_window_author_split",
+	"maintenance_window_tombstone_cleanup",
+	"maintenance_window_reconcile",
+	"maintenance_window_purge_deleted",
+	"maintenance_window_purge_old_logs",
+	"maintenance_window_db_optimize",
+	"maintenance_window_library_scan",
+	"maintenance_window_library_organize",
+	"maintenance_window_metadata_refresh",
+	"maintenance_window_library_size_refresh",
+	"maintenance_window_acoustid_online_lookup",
+	"acoustid_online_lookup_nightly_limit",
+	"auto_update_enabled",
+	"auto_update_channel",
+	"auto_update_check_minutes",
+	"auto_update_window_start",
+	"auto_update_window_end",
 }
 
 // UpdateConfig applies a config update payload to AppConfig and persists it.
@@ -222,10 +181,18 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 		delete(filtered, k)
 	}
 
-	// Translate all legacy flat keys to their nested group equivalents.
-	// configRemapGroups is the single source of truth; remapScheduledKeys handles
-	// the deeper two-level nesting that the generic helper doesn't cover.
-	filtered = applyLegacyRemaps(filtered)
+	// Detection-only (CFG-2 Phase D, #1536/CONS-13): the flat→nested remap shim was
+	// retired — the frontend sends nested keys. Any flat-only key that still arrives
+	// is dropped by the JSON round-trip below (no matching top-level json tag); warn
+	// so a lost write is observable rather than silent. Log only — no remapping.
+	for _, k := range retiredLegacyFlatKeys {
+		if _, ok := filtered[k]; ok {
+			slog.Warn("legacy flat config key received; no longer remapped, dropped", "key", k)
+		}
+	}
+
+	// remapScheduledKeys handles the deeper two-level scheduled_* nesting that the
+	// retired generic shim never covered (owned by INIT-6/WF-3); it stays.
 	filtered = remapScheduledKeys(filtered)
 
 	// Apply all remaining fields via JSON round-trip.

--- a/internal/config/update_service_test.go
+++ b/internal/config/update_service_test.go
@@ -1,6 +1,7 @@
 // file: internal/config/update_service_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e5f6g7h8-i9j0-k1l2-m3n4-o5p6q7r8s9t0
+// last-edited: 2026-07-10
 
 package config
 
@@ -81,5 +82,51 @@ func TestUpdateService_ApplyUpdates_Success(t *testing.T) {
 
 	if AppConfig.RootDir != "/new/library" {
 		t.Errorf("expected '/new/library', got %q", AppConfig.RootDir)
+	}
+}
+
+// TestUpdateService_FlatKeysDropped proves the retired CFG-2 Phase D shim
+// (#1536/CONS-13) is gone: a payload carrying ONLY a formerly-remapped flat key
+// (dedup_embeddings_enabled) no longer touches the nested Dedup.EmbeddingsEnabled
+// field — it is dropped by the JSON round-trip (no top-level json tag).
+func TestUpdateService_FlatKeysDropped(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
+	service := NewUpdateService(mockStore)
+
+	original := AppConfig.Dedup.EmbeddingsEnabled
+	defer func() { AppConfig.Dedup.EmbeddingsEnabled = original }()
+
+	// Seed a known value, then send the flat key with the OPPOSITE value.
+	Mutate(func(c *Config) { c.Dedup.EmbeddingsEnabled = true })
+	if err := service.ApplyUpdates(map[string]any{"dedup_embeddings_enabled": false}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !AppConfig.Dedup.EmbeddingsEnabled {
+		t.Error("flat key dedup_embeddings_enabled should be dropped, leaving nested field unchanged (true)")
+	}
+}
+
+// TestUpdateService_NestedKeysStillApply is the anti-regression proof that the
+// kept JSON round-trip path still applies the nested form of the same key.
+func TestUpdateService_NestedKeysStillApply(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	mockStore.On("SetSetting", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.On("GetSetting", mock.Anything).Return((*database.Setting)(nil), nil).Maybe()
+	service := NewUpdateService(mockStore)
+
+	original := AppConfig.Dedup.EmbeddingsEnabled
+	defer func() { AppConfig.Dedup.EmbeddingsEnabled = original }()
+
+	Mutate(func(c *Config) { c.Dedup.EmbeddingsEnabled = true })
+	updates := map[string]any{"dedup": map[string]any{"embeddings_enabled": false}}
+	if err := service.ApplyUpdates(updates); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if AppConfig.Dedup.EmbeddingsEnabled {
+		t.Error("nested key dedup.embeddings_enabled should apply, setting field to false")
 	}
 }


### PR DESCRIPTION
Phases B+C (PR #1514) have been stable in prod since 2026-06-19; the frontend
sends nested keys. Removes legacyRemapGroup/configRemapGroups/applyLegacyRemaps;
keeps remapScheduledKeys (INIT-6/WF-3) and the JSON round-trip apply path. Adds
a one-release detection-only warn-log (retiredLegacyFlatKeys) so any flat-only
POST is observable rather than silently dropped. Also fixes TODO.md's stale
internal/server/update_service.go path claim.

Co-Authored-By: Claude <noreply@anthropic.com>
