### PR TITLE
fix(metafetch): validate cache SourceHash at apply time to close TOCTOU window (INIT-3-T5)

### DIFF
--- a/internal/metafetch/cache.go
+++ b/internal/metafetch/cache.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/cache.go
-// version: 1.1.0
+// version: 1.2.0
 //
 // Cache-layer on top of metafetch.Service. The persisted record type
 // lives in internal/database (MetadataCandidateCache) — re-exported
@@ -14,12 +14,19 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
+
+// ErrStaleMetadataCache is returned by ValidateCachedIdentity when the cache
+// entry's stored SourceHash does not match a hash recomputed over the book's
+// CURRENT search inputs — i.e. the book's identity drifted since the cache was
+// written. Callers treat a non-nil error as "skip + log" (fail-closed).
+var ErrStaleMetadataCache = errors.New("metadata cache stale: source hash mismatch")
 
 // MetadataCandidateCache is a re-export of the persistence type so
 // metafetch callers don't need to know about internal/database.
@@ -50,6 +57,45 @@ func (mfs *Service) GetCachedCandidates(bookID string) (*MetadataCandidateCache,
 		return nil, false, nil
 	}
 	return entry, entry.IsFresh(), nil
+}
+
+// ValidateCachedIdentity closes the metadata-cache TOCTOU window (INIT-3-T5):
+// the cache is keyed only by book ID, so an entry can be refreshed between the
+// gate read and the apply. This recomputes the existing hashSearchInputs over
+// the book's CURRENT fields and compares it to the SourceHash stored at write
+// time. It reuses hashSearchInputs exactly — no second hashing scheme — and
+// does not touch mfs.db, so it is safe on a minimal Service.
+//
+// Three-case semantics (mirrored in the tests):
+//   - stored hash EMPTY (legacy row predating the field being load-bearing) →
+//     fail-OPEN: slog.Warn + nil, so an UNCHANGED book still applies via the
+//     existing slot-0 identity guard;
+//   - hash MISMATCH → fail-CLOSED: ErrStaleMetadataCache (wrapped with book ID);
+//   - hash MATCH → nil.
+//
+// Note: the two production cache writers hash different input shapes — the batch
+// path (metadata_batch_candidates.go) passes narrator/series as empty strings;
+// the UI handler path passes user-typed values. Recomputing over the book's
+// current fields therefore fails CLOSED for a row whose stored hash came from
+// inputs that differ from the book's fields (e.g. a book with a narrator cached
+// via the batch path). That is intentional and conservative: refusing an apply
+// never mutates data — it only declines to reuse a cache row whose provenance
+// no longer matches the book.
+func (mfs *Service) ValidateCachedIdentity(entry *MetadataCandidateCache, bookID, query, author, narrator, series string) error {
+	if entry == nil {
+		return nil
+	}
+	if entry.SourceHash == "" {
+		// Legacy row written before SourceHash was load-bearing. Fail open so
+		// an unchanged book still applies; the slot-0 identity guard remains.
+		slog.Warn("metafetch ValidateCachedIdentity: legacy cache row has empty SourceHash, applying (fail-open)", "id", bookID)
+		return nil
+	}
+	want := hashSearchInputs(bookID, query, author, narrator, series)
+	if entry.SourceHash != want {
+		return fmt.Errorf("%w: book %s (stored %s, current %s)", ErrStaleMetadataCache, bookID, entry.SourceHash, want)
+	}
+	return nil
 }
 
 // FetchAndCache runs the existing search pipeline, writes top-N to

--- a/internal/metafetch/cache_test.go
+++ b/internal/metafetch/cache_test.go
@@ -1,0 +1,61 @@
+// file: internal/metafetch/cache_test.go
+// version: 1.0.0
+// guid: 7f2a1c4e-9b3d-4e6a-8c1f-2d5b8a0e3f61
+// last-edited: 2026-07-11
+
+// Package metafetch tests for INIT-3-T5: ValidateCachedIdentity makes the
+// cache's existing SourceHash load-bearing at apply time, closing the TOCTOU
+// window where the book's search inputs drift between the cache write and the
+// apply. The three-case fail-open/fail-closed semantics are exercised here,
+// where the unexported hashSearchInputs is reachable to build matching hashes.
+package metafetch
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateCachedIdentity(t *testing.T) {
+	var mfs *Service // nil Service is fine — ValidateCachedIdentity never touches mfs.db.
+
+	const (
+		bookID   = "book-1"
+		query    = "The Stable Book"
+		author   = "Stable Author"
+		narrator = "Sam Narrator"
+		series   = "Stable Series"
+	)
+
+	t.Run("match returns nil", func(t *testing.T) {
+		entry := &MetadataCandidateCache{
+			BookID:     bookID,
+			SourceHash: hashSearchInputs(bookID, query, author, narrator, series),
+		}
+		if err := mfs.ValidateCachedIdentity(entry, bookID, query, author, narrator, series); err != nil {
+			t.Fatalf("ValidateCachedIdentity() = %v, want nil on matching hash", err)
+		}
+	})
+
+	t.Run("mismatch fails closed with ErrStaleMetadataCache", func(t *testing.T) {
+		entry := &MetadataCandidateCache{
+			BookID:     bookID,
+			SourceHash: hashSearchInputs(bookID, query, author, narrator, series),
+		}
+		// The book's author drifted since the cache write.
+		err := mfs.ValidateCachedIdentity(entry, bookID, query, "A Different Author", narrator, series)
+		if err == nil {
+			t.Fatal("ValidateCachedIdentity() = nil, want ErrStaleMetadataCache on drifted inputs")
+		}
+		if !errors.Is(err, ErrStaleMetadataCache) {
+			t.Fatalf("ValidateCachedIdentity() error = %v, want errors.Is ErrStaleMetadataCache", err)
+		}
+	})
+
+	t.Run("legacy empty hash fails open", func(t *testing.T) {
+		entry := &MetadataCandidateCache{BookID: bookID, SourceHash: ""}
+		// Inputs are arbitrary — an empty stored hash must always apply (nil).
+		if err := mfs.ValidateCachedIdentity(entry, bookID, query, author, narrator, series); err != nil {
+			t.Fatalf("ValidateCachedIdentity() = %v, want nil (fail-open) on empty legacy hash", err)
+		}
+	})
+}

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -390,6 +390,14 @@ func (s *Server) SearchTranscriptionCandidate(_ context.Context, bookID, _, _ st
 // close that window, verify the re-read cache slot 0 still matches the gated
 // identity before applying, and error out on mismatch — the caller already
 // treats a non-nil error as "skip + log".
+//
+// SourceHash layer (INIT-3-T5): the slot-0 identity re-check catches a cache
+// row whose top candidate was swapped, but NOT a row whose search INPUTS
+// drifted (the book's title/author/narrator/series was edited) while the top
+// candidate happened to stay put. ValidateCachedIdentity recomputes the stored
+// SourceHash over the book's CURRENT fields and refuses on mismatch (fail
+// closed); legacy rows with an empty hash fail open with a warning. This runs
+// BEFORE the slot-0 check as a first, independent layer — both guards are kept.
 func (s *Server) ApplyTranscriptionCandidate(_ context.Context, bookID, gatedTitle, gatedAuthor string) error {
 	if s.metadataFetchService == nil {
 		return fmt.Errorf("metadata fetch service not initialized")
@@ -401,6 +409,39 @@ func (s *Server) ApplyTranscriptionCandidate(_ context.Context, bookID, gatedTit
 	if entry == nil || len(entry.Candidates) == 0 {
 		return fmt.Errorf("no cached candidates for book %s", bookID)
 	}
+
+	// SourceHash guard: recompute the cache row's search-input hash over the
+	// book's CURRENT fields and refuse if it drifted since the write. A missing
+	// store or book is anomalous at apply time — fail closed (skip + log).
+	store := s.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	book, err := store.GetBookByID(bookID)
+	if err != nil {
+		return fmt.Errorf("get book %s for cache-identity check: %w", bookID, err)
+	}
+	if book == nil {
+		return fmt.Errorf("book %s not found for cache-identity check", bookID)
+	}
+	curAuthor := ""
+	if book.Author != nil && book.Author.Name != "" {
+		curAuthor = book.Author.Name
+	}
+	curNarrator := ""
+	if book.Narrator != nil {
+		curNarrator = *book.Narrator
+	}
+	curSeries := ""
+	if book.Series != nil && book.Series.Name != "" {
+		curSeries = book.Series.Name
+	}
+	if verr := s.metadataFetchService.ValidateCachedIdentity(entry, bookID, book.Title, curAuthor, curNarrator, curSeries); verr != nil {
+		slog.Warn("apply-transcription-candidate: cache source-hash drift since write",
+			"book_id", bookID, "error", verr)
+		return verr
+	}
+
 	var cand metafetch.MetadataCandidate
 	if err := json.Unmarshal(entry.Candidates[0], &cand); err != nil {
 		return fmt.Errorf("decode cached candidate for book %s: %w", bookID, err)

--- a/internal/server/server_maintenance_deps_test.go
+++ b/internal/server/server_maintenance_deps_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c1e4f6a-2b7d-4a3e-8f5c-6d1a9b2e4c7f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // Package server tests for TASK-23 (MATCH-6/BUG-3/QUAL-3): ApplyTranscriptionCandidate
 // must verify the identity of the re-read cached candidate against the
@@ -14,6 +14,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -131,5 +132,76 @@ func TestApplyTranscriptionCandidate_NoRegression_SameCandidateBothReads(t *test
 	}
 	if len(*updateCalls) != 1 {
 		t.Fatalf("UpdateBook was called %d times, want 1 — the matching candidate must still be applied", len(*updateCalls))
+	}
+}
+
+// TestApplyTranscriptionCandidateSourceHashDriftRefused proves the INIT-3-T5
+// SourceHash layer catches a drift the slot-0 identity check cannot: the top
+// candidate is unchanged between the gate and apply reads (so the slot-0 guard
+// would pass), but the cache row's stored SourceHash no longer matches a hash
+// recomputed over the book's current fields. The apply must fail closed and
+// never reach the write path.
+func TestApplyTranscriptionCandidateSourceHashDriftRefused(t *testing.T) {
+	bookID := "book-3"
+	book := &database.Book{ID: bookID, Title: "Current Title"}
+
+	cand := metafetch.MetadataCandidate{Title: "The Stable Book", Author: "Stable Author", Score: 0.9, Source: "test"}
+	entry := mustCandidateCache(t, bookID, cand)
+	// Non-empty hash that cannot match a recompute over the book's real fields:
+	// simulates a row whose search inputs drifted since the cache write.
+	entry.SourceHash = "deadbeefdeadbeef"
+
+	store, updateCalls := newTOCTOUCacheStore(t, book, entry, entry)
+	s := &Server{store: store, metadataFetchService: metafetch.NewService(store)}
+	ctx := context.Background()
+
+	candTitle, candAuthor, _, found, err := s.SearchTranscriptionCandidate(ctx, bookID, "irrelevant", "irrelevant")
+	if err != nil || !found {
+		t.Fatalf("SearchTranscriptionCandidate() = (found=%v, err=%v), want found=true, err=nil", found, err)
+	}
+
+	applyErr := s.ApplyTranscriptionCandidate(ctx, bookID, candTitle, candAuthor)
+	if applyErr == nil {
+		t.Fatal("ApplyTranscriptionCandidate() = nil error, want non-nil on SourceHash drift")
+	}
+	if !errors.Is(applyErr, metafetch.ErrStaleMetadataCache) {
+		t.Fatalf("ApplyTranscriptionCandidate() error = %v, want errors.Is ErrStaleMetadataCache", applyErr)
+	}
+	if len(*updateCalls) != 0 {
+		t.Fatalf("UpdateBook was called %d times, want 0 — a drifted cache row must never be applied", len(*updateCalls))
+	}
+}
+
+// TestApplyTranscriptionCandidateUnchangedStillApplies is the anti-over-
+// suppression check for the INIT-3-T5 guard: a legacy cache row with an empty
+// SourceHash (predating the field being load-bearing) must fail OPEN so an
+// UNCHANGED, known-good book still applies with the new guard active. This is
+// the mustCandidateCache shape (SourceHash == ""), so it exercises the
+// fail-open branch of ValidateCachedIdentity end-to-end through the apply path.
+func TestApplyTranscriptionCandidateUnchangedStillApplies(t *testing.T) {
+	bookID := "book-4"
+	book := &database.Book{ID: bookID, Title: "Old Title"}
+
+	cand := metafetch.MetadataCandidate{Title: "The Stable Book", Author: "Stable Author", Score: 0.9, Source: "test"}
+	entry := mustCandidateCache(t, bookID, cand) // SourceHash == "" → fail-open
+	if entry.SourceHash != "" {
+		t.Fatalf("precondition: expected empty SourceHash, got %q", entry.SourceHash)
+	}
+
+	store, updateCalls := newTOCTOUCacheStore(t, book, entry, entry)
+	s := &Server{store: store, metadataFetchService: metafetch.NewService(store)}
+	ctx := context.Background()
+
+	candTitle, candAuthor, _, found, err := s.SearchTranscriptionCandidate(ctx, bookID, "irrelevant", "irrelevant")
+	if err != nil || !found {
+		t.Fatalf("SearchTranscriptionCandidate() = (found=%v, err=%v), want found=true, err=nil", found, err)
+	}
+
+	applyErr := s.ApplyTranscriptionCandidate(ctx, bookID, candTitle, candAuthor)
+	if applyErr != nil {
+		t.Fatalf("ApplyTranscriptionCandidate() = %v, want nil — an unchanged book must still apply with the new guard active", applyErr)
+	}
+	if len(*updateCalls) != 1 {
+		t.Fatalf("UpdateBook was called %d times, want 1 — the legit apply must not be over-suppressed", len(*updateCalls))
 	}
 }


### PR DESCRIPTION
The metadata cache is keyed only by book ID; the apply-time guard in
ApplyTranscriptionCandidate re-checked candidate identity but not whether
the book's search inputs had drifted since the cache write. SourceHash
(stored since v1, diagnostic-only) is now recomputed and compared before
apply: mismatch fails closed, legacy empty-hash rows fail open with a
warning. The existing identity re-check is kept as a second layer.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
