### PR TITLE
fix(dedup): guard not_dup mining rules — identity-sharing pairs go unsure (INIT-1 T1)

### DIFF
--- a/internal/database/dedup_label.go
+++ b/internal/database/dedup_label.go
@@ -1,7 +1,7 @@
 // file: internal/database/dedup_label.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5a0319bd-8bc4-4135-91e6-dfd43628dcc5
-// last-edited: 2026-07-04
+// last-edited: 2026-07-11
 
 package database
 
@@ -40,6 +40,10 @@ type BookFeatures struct {
 	// hasPlausibleAudio signal so the dataset can tell a genuine but unscanned
 	// copy (large file, zero duration) from a stub/placeholder (tiny file).
 	FileSizeBytes int64 `json:"file_size_bytes"`
+	// ASIN is the book's Amazon/Audible ID ("" when the book has none).
+	ASIN string `json:"asin,omitempty"`
+	// VersionGroupID links books that are versions of the same work ("" when ungrouped).
+	VersionGroupID string `json:"version_group_id,omitempty"`
 }
 
 // LabeledExample is one labeled dedup candidate pair plus the features behind

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 // Package dataset builds labeled dedup examples and runs deterministic catchers
 // over them. Pure: a store interface in, a database.LabeledExample out, no
@@ -134,6 +134,13 @@ func buildFeatures(bk *database.Book, files []database.BookFile) database.BookFe
 	if bk != nil {
 		f.Title = bk.Title
 		f.WholeBookSigPresent = bk.BookSigV1 != nil && *bk.BookSigV1 != ""
+		// Snapshot hard-identity fields; nil pointer → "" (unknown, non-disqualifying).
+		if bk.ASIN != nil {
+			f.ASIN = *bk.ASIN
+		}
+		if bk.VersionGroupID != nil {
+			f.VersionGroupID = *bk.VersionGroupID
+		}
 		if bk.CoverURL != nil && *bk.CoverURL != "" {
 			f.HasCover = true
 		}

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 package dataset
 
@@ -402,5 +402,25 @@ func TestBuildExample_FileSizeBytes(t *testing.T) {
 	}
 	if ex.B.FileSizeBytes != 32 {
 		t.Fatalf("B.FileSizeBytes = %d, want 32 (stub)", ex.B.FileSizeBytes)
+	}
+}
+
+// TestBuildFeatures_IdentityFields verifies buildFeatures snapshots the book's
+// ASIN and VersionGroupID pointers, and that a nil pointer becomes "" (the
+// intended "unknown" value the SharesIdentity guard treats as non-disqualifying).
+func TestBuildFeatures_IdentityFields(t *testing.T) {
+	asin := "B002V8MAAM"
+	vg := "vg-123"
+	set := buildFeatures(&database.Book{ID: "x", Title: "Set", ASIN: &asin, VersionGroupID: &vg}, nil)
+	if set.ASIN != asin {
+		t.Fatalf("ASIN = %q, want %q", set.ASIN, asin)
+	}
+	if set.VersionGroupID != vg {
+		t.Fatalf("VersionGroupID = %q, want %q", set.VersionGroupID, vg)
+	}
+
+	bare := buildFeatures(&database.Book{ID: "y", Title: "Bare"}, nil)
+	if bare.ASIN != "" || bare.VersionGroupID != "" {
+		t.Fatalf("nil identity pointers must snapshot as empty; got ASIN=%q VG=%q", bare.ASIN, bare.VersionGroupID)
 	}
 }

--- a/internal/dedup/dataset/rules.go
+++ b/internal/dedup/dataset/rules.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/rules.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
-// last-edited: 2026-06-13
+// last-edited: 2026-07-11
 
 package dataset
 
@@ -28,9 +28,9 @@ const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
 //
 // Priority order (highest first):
 //  1. wholeBookSignatureMatch → true_dup  (strong positive oracle)
-//  2. missingFile             → not_dup  (hard negative: never merge a ghost)
+//  2. missingFile             → unsure   (file absence is evidence-free for dup-ness)
 //  3. implausibleAudio        → not_dup  (hard negative: stub/placeholder side)
-//  4. partVsWhole             → not_dup  (hard negative: duration mismatch)
+//  4. partVsWhole             → not_dup  (hard negative: duration mismatch; unsure when the pair shares identity — unit corruption)
 func Classify(ex database.LabeledExample) (label, reason string, fires bool) {
 	if l, r, ok := wholeBookSignatureMatch(ex); ok {
 		return l, r, true
@@ -57,14 +57,34 @@ func wholeBookSignatureMatch(ex database.LabeledExample) (string, string, bool) 
 	return "", "", false
 }
 
-// missingFile fires when either side has no resolvable files. We must never
-// merge a book whose files are gone — there is nothing to consolidate into.
+// SharesIdentity reports whether the pair carries matching hard-identity
+// evidence (same ASIN, same version group, or identical primary path).
+// Empty values are UNKNOWN and never match — unknown is non-disqualifying.
+// Consumers: partVsWhole's unit-corruption guard (this file) and the
+// suspicious-label queue predicate (TASK-04).
+func SharesIdentity(ex database.LabeledExample) bool {
+	if ex.A.ASIN != "" && ex.A.ASIN == ex.B.ASIN {
+		return true
+	}
+	if ex.A.VersionGroupID != "" && ex.A.VersionGroupID == ex.B.VersionGroupID {
+		return true
+	}
+	if ex.A.PrimaryPath != "" && ex.A.PrimaryPath == ex.B.PrimaryPath {
+		return true
+	}
+	return false
+}
+
+// missingFile fires when either side has no resolvable files. File absence is
+// evidence-free for dup-ness (a book whose files are currently unresolvable may
+// still be a real duplicate), so this rule emits unsure — never not_dup — and
+// leaves the pair unlabeled rather than poisoning the gold set.
 func missingFile(ex database.LabeledExample) (string, string, bool) {
 	if !ex.A.FilesExist {
-		return "not_dup", "side A has no resolvable files", true
+		return "unsure", "side A has no resolvable files", true
 	}
 	if !ex.B.FilesExist {
-		return "not_dup", "side B has no resolvable files", true
+		return "unsure", "side B has no resolvable files", true
 	}
 	return "", "", false
 }
@@ -106,6 +126,14 @@ func sideImplausibleAudio(f database.BookFeatures) bool {
 func partVsWhole(ex database.LabeledExample) (string, string, bool) {
 	if ex.A.TotalDurationSec > 0 && ex.B.TotalDurationSec > 0 &&
 		ex.DurationRatio > 0 && ex.DurationRatio < partVsWholeRatioMax {
+		// A pair that shares hard identity (ASIN / version group / primary path)
+		// but shows an extreme ratio is almost always a ms/sec duration-unit
+		// corruption, not a genuine part-vs-whole — the 2026-07-08 calibration
+		// hand-verified every such flagged pair was a real duplicate. Emit unsure
+		// rather than poisoning the gold set with a false not_dup.
+		if SharesIdentity(ex) {
+			return "unsure", fmt.Sprintf("duration ratio %.3f but pair shares identity — suspected unit corruption", ex.DurationRatio), true
+		}
 		return "not_dup", fmt.Sprintf("duration ratio %.3f — part vs whole", ex.DurationRatio), true
 	}
 	return "", "", false

--- a/internal/dedup/dataset/rules_test.go
+++ b/internal/dedup/dataset/rules_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/rules_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c1d4e8b5-7f23-4a90-9b01-6e2c5d8f3a47
-// last-edited: 2026-06-13
+// last-edited: 2026-07-11
 
 package dataset
 
@@ -29,12 +29,14 @@ func TestCatchers(t *testing.T) {
 			wantFires: true, wantLabel: "not_dup",
 		},
 		{
-			name: "missing file one side",
+			// missingFile now emits unsure — file absence is evidence-free for
+			// dup-ness, so it must never poison the gold set with a not_dup.
+			name: "missing file one side => unsure",
 			ex: database.LabeledExample{
 				A: database.BookFeatures{FilesExist: true, TotalDurationSec: 100},
 				B: database.BookFeatures{FilesExist: false},
 			},
-			wantFires: true, wantLabel: "not_dup",
+			wantFires: true, wantLabel: "unsure",
 		},
 		{
 			name: "whole-book signature match => true_dup",
@@ -68,14 +70,15 @@ func TestCatchers(t *testing.T) {
 			wantFires: true, wantLabel: "true_dup",
 		},
 		{
-			// missing-file fires before part-vs-whole
+			// missing-file fires before part-vs-whole (priority preserved); it now
+			// yields unsure rather than not_dup.
 			name: "missing file beats part-vs-whole (priority check)",
 			ex: database.LabeledExample{
 				A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000},
 				B:             database.BookFeatures{FilesExist: false, TotalDurationSec: 100},
 				DurationRatio: 100.0 / 36000.0,
 			},
-			wantFires: true, wantLabel: "not_dup",
+			wantFires: true, wantLabel: "unsure",
 		},
 		{
 			// disjoint signature should not trigger signature-match catcher
@@ -151,5 +154,108 @@ func TestClassify_ReasonContainsRatio(t *testing.T) {
 	// Reason assertion: must describe the rule, not just echo the label.
 	if !strings.Contains(reason, "part vs whole") {
 		t.Fatalf("reason should describe the rule (want substring %q); got %q", "part vs whole", reason)
+	}
+}
+
+// The following regression tests pin the not_dup-mining guards added to stop
+// contaminated gold labels. Each part-vs-whole case is shaped like one of the
+// 2026-07-08 hand-verified prod mislabels (a ms/sec duration-unit corruption on
+// a pair that is really a duplicate), and must go unsure — never not_dup —
+// because the pair shares hard identity.
+
+// TestPartVsWholeSharedASINGoesUnsure mirrors "Way of the Wolf" (ASIN
+// B002V8MAAM): same ASIN, same primary path, durations 21171 vs 20810840
+// ("sec") — a ratio ≈ 0.001 that misfired the part-vs-whole rule.
+func TestPartVsWholeSharedASINGoesUnsure(t *testing.T) {
+	ex := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 21171, ASIN: "B002V8MAAM", PrimaryPath: "/lib/wolf/wolf.m4b"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 20810840, ASIN: "B002V8MAAM", PrimaryPath: "/lib/wolf/wolf.m4b"},
+		DurationRatio: 21171.0 / 20810840.0,
+	}
+	label, reason, fires := partVsWhole(ex)
+	if !fires || label != "unsure" {
+		t.Fatalf("partVsWhole = (%q, fires=%v), want unsure/true; reason=%q", label, fires, reason)
+	}
+	if !strings.Contains(reason, "shares identity") {
+		t.Fatalf("reason should flag the identity guard; got %q", reason)
+	}
+}
+
+// TestPartVsWholeSharedVersionGroupGoesUnsure exercises the version-group arm of
+// SharesIdentity: no ASIN, disjoint paths, but a shared VersionGroupID.
+func TestPartVsWholeSharedVersionGroupGoesUnsure(t *testing.T) {
+	ex := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 34535, VersionGroupID: "vg-empire", PrimaryPath: "/lib/foundation/a.m4b"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 57989869, VersionGroupID: "vg-empire", PrimaryPath: "/lib/foundation/b.m4b"},
+		DurationRatio: 34535.0 / 57989869.0,
+	}
+	label, _, fires := partVsWhole(ex)
+	if !fires || label != "unsure" {
+		t.Fatalf("partVsWhole = (%q, fires=%v), want unsure/true", label, fires)
+	}
+}
+
+// TestPartVsWholeSharedPathGoesUnsure mirrors "Alcatraz vs the Evil Librarians"
+// (ASIN B005GGGC3M, same path): the path arm alone must trigger the guard even
+// when ASIN and version group carry no matching evidence.
+func TestPartVsWholeSharedPathGoesUnsure(t *testing.T) {
+	ex := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 18000, PrimaryPath: "/lib/alcatraz/alcatraz.m4b"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 18000000, PrimaryPath: "/lib/alcatraz/alcatraz.m4b"},
+		DurationRatio: 18000.0 / 18000000.0,
+	}
+	label, _, fires := partVsWhole(ex)
+	if !fires || label != "unsure" {
+		t.Fatalf("partVsWhole = (%q, fires=%v), want unsure/true", label, fires)
+	}
+}
+
+// TestMissingFileGoesUnsure pins the missingFile rule to unsure on either side —
+// file absence is evidence-free for dup-ness and can no longer emit not_dup.
+func TestMissingFileGoesUnsure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ex   database.LabeledExample
+	}{
+		{"side A missing", database.LabeledExample{A: database.BookFeatures{FilesExist: false}, B: database.BookFeatures{FilesExist: true}}},
+		{"side B missing", database.LabeledExample{A: database.BookFeatures{FilesExist: true}, B: database.BookFeatures{FilesExist: false}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			label, _, fires := missingFile(tc.ex)
+			if !fires || label != "unsure" {
+				t.Fatalf("missingFile = (%q, fires=%v), want unsure/true", label, fires)
+			}
+		})
+	}
+}
+
+// TestPartVsWholeGenuineStillNotDup is the anti-over-suppression guard: a genuine
+// part-vs-whole pair with disjoint identity (different ASINs, different paths, no
+// version group, sane durations, ratio 0.3) is STILL not_dup — and a pair whose
+// identity fields are all empty (unknown is non-disqualifying) likewise stays
+// not_dup rather than being forced unsure.
+func TestPartVsWholeGenuineStillNotDup(t *testing.T) {
+	disjoint := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000, ASIN: "AAAAAAAAAA", PrimaryPath: "/lib/x/whole.m4b"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 10800, ASIN: "BBBBBBBBBB", PrimaryPath: "/lib/y/part.m4b"},
+		DurationRatio: 10800.0 / 36000.0,
+	}
+	if label, _, fires := partVsWhole(disjoint); !fires || label != "not_dup" {
+		t.Fatalf("disjoint identity: partVsWhole = (%q, fires=%v), want not_dup/true", label, fires)
+	}
+	if SharesIdentity(disjoint) {
+		t.Fatal("disjoint identity must not report SharesIdentity")
+	}
+
+	bothEmpty := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 10800},
+		DurationRatio: 10800.0 / 36000.0,
+	}
+	if label, _, fires := partVsWhole(bothEmpty); !fires || label != "not_dup" {
+		t.Fatalf("both-identity-empty: partVsWhole = (%q, fires=%v), want not_dup/true (unknown is non-disqualifying)", label, fires)
+	}
+	if SharesIdentity(bothEmpty) {
+		t.Fatal("all-empty identity must not report SharesIdentity")
 	}
 }

--- a/internal/plugins/dedup/dataset_backfill_test.go
+++ b/internal/plugins/dedup/dataset_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/dataset_backfill_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f8ff156-b5ec-4480-ac97-27acc54fd013
-// last-edited: 2026-07-05
+// last-edited: 2026-07-11
 
 // End-to-end test for the dedup.dataset-backfill op against a real PebbleStore
 // + EmbeddingStore, added alongside the CONC-8 memoize-then-parallelize change
@@ -18,9 +18,11 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
-// createBookNoFiles (a book with zero BookFile rows, so BookFeatures.FilesExist
-// is false and dataset.Classify's missingFile rule fires "not_dup") is defined
-// once in rebuild_gold_labels_test.go and reused here.
+// createBookStubAudio (a book whose only file is a sub-256 KiB, zero-duration
+// stub, so dataset.Classify's implausibleAudio rule fires "not_dup") is defined
+// once in rebuild_gold_labels_test.go and reused here. (missingFile no longer
+// emits not_dup — file absence is evidence-free for dup-ness — so a stub side
+// is used to exercise the not_dup dismiss path.)
 
 // TestDatasetBackfill_ParallelMatchesSerialOutput exercises the RunItems-backed
 // parallel path (CONC-8) with enough candidates to spread across every
@@ -28,8 +30,8 @@ import (
 // candidate so the mutex-guarded book-lookup cache in
 // memoizedBuilderAdapter.GetBook is actually contended across goroutines.
 // Every candidate's classification is deterministic given the fixture
-// (missingFile fires not_dup; a normal-duration/size pair with no shared
-// signature is left unlabeled), independent of item order or worker count —
+// (implausibleAudio fires not_dup on the stub side; a normal-duration/size pair
+// with no shared signature is left unlabeled), independent of item order or worker count —
 // that determinism is the "parallel == serial" guarantee, since
 // registry.RunItems with Concurrency==1 and Concurrency>1 both drive the same
 // per-item function. Run with -race to catch any unguarded shared state.
@@ -42,17 +44,17 @@ func TestDatasetBackfill_ParallelMatchesSerialOutput(t *testing.T) {
 
 	var wantNotDup, wantUnlabeled []int64
 	for i := 0; i < numLeaves; i++ {
-		missingFiles := i%2 == 0
+		stubSide := i%2 == 0
 		var leaf string
-		if missingFiles {
-			leaf = createBookNoFiles(t, pebble, fmt.Sprintf("NoFileLeaf%03d", i))
+		if stubSide {
+			leaf = createBookStubAudio(t, pebble, fmt.Sprintf("StubLeaf%03d", i))
 		} else {
 			// Same duration/size as the hub -> duration ratio 1.0, no
 			// part-vs-whole or stub signal, and no shared hash -> unlabeled.
 			leaf = createBookWithHashedFile(t, pebble, fmt.Sprintf("NormalLeaf%03d", i), fmt.Sprintf("distincthash%04d", i))
 		}
 		cand := candidateID(t, es, hub, leaf)
-		if missingFiles {
+		if stubSide {
 			wantNotDup = append(wantNotDup, cand)
 		} else {
 			wantUnlabeled = append(wantUnlabeled, cand)
@@ -75,7 +77,7 @@ func TestDatasetBackfill_ParallelMatchesSerialOutput(t *testing.T) {
 		if ex.Label != "not_dup" || ex.LabelSource != "rule" {
 			t.Fatalf("candidate %d: label=%q source=%q; want not_dup/rule", cand, ex.Label, ex.LabelSource)
 		}
-		// missingFile candidates must be suppressed (status -> dismissed).
+		// not_dup (stub-side) candidates must be suppressed (status -> dismissed).
 		cands, _, err := es.ListCandidates(database.CandidateFilter{Status: "dismissed", Limit: 1_000_000})
 		if err != nil {
 			t.Fatalf("ListCandidates(dismissed): %v", err)
@@ -111,7 +113,7 @@ func TestDatasetBackfill_DryRunWritesNothing(t *testing.T) {
 	es := database.NewEmbeddingStore(pebble.DB())
 
 	hub := createBookWithHashedFile(t, pebble, "DryHub", "dryhubhash0001")
-	leaf := createBookNoFiles(t, pebble, "DryLeafNoFiles")
+	leaf := createBookStubAudio(t, pebble, "DryLeafStub")
 	cand := candidateID(t, es, hub, leaf)
 
 	p := &Plugin{store: pebble, embeddingStore: es}

--- a/internal/plugins/dedup/rebuild_gold_labels_test.go
+++ b/internal/plugins/dedup/rebuild_gold_labels_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/rebuild_gold_labels_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b8e5f14-6a37-4c92-9d05-3f7a8b1c6e40
-// last-edited: 2026-07-04
+// last-edited: 2026-07-11
 
 // Tests for the dedup.rebuild-gold-labels op against a real PebbleStore +
 // EmbeddingStore: dry-run diff reporting (changed/unchanged/unlabelable),
@@ -17,14 +17,25 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
-// createBookNoFiles creates a book with no BookFile records, so
-// dataset.Classify's missingFile catcher fires not_dup for any pair
-// involving it.
-func createBookNoFiles(t *testing.T, pebble *database.PebbleStore, title string) string {
+// createBookStubAudio creates a book whose only file is a stub/placeholder
+// (sub-256 KiB, zero duration), so dataset.Classify's implausibleAudio catcher
+// fires not_dup for any pair involving it. (missingFile no longer emits not_dup
+// as of the not_dup-mining-guard change — file absence is evidence-free for
+// dup-ness — so these rebuild/backfill tests use a stub side, which is still a
+// hard not_dup, to exercise the not_dup recompute/dismiss paths.)
+func createBookStubAudio(t *testing.T, pebble *database.PebbleStore, title string) string {
 	t.Helper()
 	created, err := pebble.CreateBook(&database.Book{Title: title, FilePath: "/audio/" + title + ".m4b"})
 	if err != nil {
 		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	if err := pebble.CreateBookFile(&database.BookFile{
+		BookID:   created.ID,
+		FilePath: "/audio/" + title + ".m4b",
+		FileSize: 32, // < 256 KiB stub floor
+		Duration: 0,  // no positive duration
+	}); err != nil {
+		t.Fatalf("CreateBookFile %q: %v", title, err)
 	}
 	return created.ID
 }
@@ -44,8 +55,8 @@ func rebuildFixture(t *testing.T) (*database.PebbleStore, *database.EmbeddingSto
 func TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged(t *testing.T) {
 	pebble, es, p := rebuildFixture(t)
 
-	// missingFile fires not_dup for any pair where one side has no files.
-	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	// implausibleAudio fires not_dup for any pair with a stub/placeholder side.
+	noFiles := createBookStubAudio(t, pebble, "Ghost")
 	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-0001")
 	changedCand := candidateID(t, es, noFiles, hasFiles)
 
@@ -58,7 +69,7 @@ func TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged(t *testing.T) {
 	}
 
 	// Unchanged: another no-files pair, already stored as not_dup.
-	noFiles2 := createBookNoFiles(t, pebble, "Ghost2")
+	noFiles2 := createBookStubAudio(t, pebble, "Ghost2")
 	hasFiles2 := createBookWithHashedFile(t, pebble, "Real2", "hash-real-0002")
 	unchangedCand := candidateID(t, es, noFiles2, hasFiles2)
 	if err := es.UpsertLabeledExample(database.LabeledExample{
@@ -115,8 +126,8 @@ func TestRebuildGoldLabels_DryRun_RuleChangedAndUnchanged(t *testing.T) {
 func TestRebuildGoldLabels_ComputeRebuildDiff_ReportCorrectness(t *testing.T) {
 	pebble, es, p := rebuildFixture(t)
 
-	// Changed: stored true_dup, but missingFile fires not_dup today.
-	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	// Changed: stored true_dup, but implausibleAudio fires not_dup today.
+	noFiles := createBookStubAudio(t, pebble, "Ghost")
 	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-report-1")
 	changedCand := candidateID(t, es, noFiles, hasFiles)
 	if err := es.UpsertLabeledExample(database.LabeledExample{
@@ -127,7 +138,7 @@ func TestRebuildGoldLabels_ComputeRebuildDiff_ReportCorrectness(t *testing.T) {
 	}
 
 	// Unchanged: already stored as the not_dup missingFile would produce today.
-	noFiles2 := createBookNoFiles(t, pebble, "Ghost2")
+	noFiles2 := createBookStubAudio(t, pebble, "Ghost2")
 	hasFiles2 := createBookWithHashedFile(t, pebble, "Real2", "hash-real-report-2")
 	unchangedCand := candidateID(t, es, noFiles2, hasFiles2)
 	if err := es.UpsertLabeledExample(database.LabeledExample{
@@ -228,7 +239,7 @@ func TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther
 	pebble, es, p := rebuildFixture(t)
 
 	// Rule bucket: stale true_dup that should become not_dup.
-	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	noFiles := createBookStubAudio(t, pebble, "Ghost")
 	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-1111")
 	ruleCand := candidateID(t, es, noFiles, hasFiles)
 	if err := es.UpsertLabeledExample(database.LabeledExample{
@@ -342,7 +353,7 @@ func TestRebuildGoldLabels_Apply_WipesRuleAndAutoHighConf_PreservesHumanAndOther
 func TestRebuildGoldLabels_Apply_Idempotent(t *testing.T) {
 	pebble, es, p := rebuildFixture(t)
 
-	noFiles := createBookNoFiles(t, pebble, "Ghost")
+	noFiles := createBookStubAudio(t, pebble, "Ghost")
 	hasFiles := createBookWithHashedFile(t, pebble, "Real", "hash-real-2222")
 	ruleCand := candidateID(t, es, noFiles, hasFiles)
 	if err := es.UpsertLabeledExample(database.LabeledExample{


### PR DESCRIPTION
partVsWhole misfired on ms/sec-corrupted durations and labeled verified real
duplicates (shared ASIN/version-group/path) as not_dup; missingFile labeled
pairs not_dup on file absence alone. Both now emit unsure in those cases, so
the gold-label set stops poisoning calibration at the mining source.

Adds ASIN/VersionGroupID snapshot fields to database.BookFeatures (populated by
the dataset builder) and an exported SharesIdentity helper (reused by TASK-04).
Downstream rebuild/backfill tests switch their not_dup fixture from a no-files
book (now unsure) to a stub-audio book (implausibleAudio, still not_dup).

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
