### PR TITLE
feat(web): settings UI for metadata scoring knobs (INIT-3-T1)

### DIFF
--- a/web/src/components/settings/MetadataScoringSection.test.tsx
+++ b/web/src/components/settings/MetadataScoringSection.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/MetadataScoringSection.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c7d6e5f4-a3b2-1098-cdef-a98765432109
-// last-edited: 2026-06-19
+// last-edited: 2026-07-11
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
@@ -16,6 +16,21 @@ const defaultConfig: MetadataScoringConfig = {
   llm_rerank_epsilon: 0.05,
   llm_rerank_top_k: 5,
   write_backup_before: true,
+  // new scoring knobs, populated so every field renders with a value
+  transcription_title_exact_boost: 2.0,
+  transcription_title_substr_boost: 1.4,
+  transcription_author_boost: 1.6,
+  transcription_narrator_boost: 1.4,
+  compilation_penalty: 0.15,
+  rich_metadata_field_bonus: 0.05,
+  rich_metadata_bonus_cap: 0.15,
+  f1_min_score: 0.35,
+  series_name_match_boost: 1.4,
+  series_number_exact_boost: 2.0,
+  series_number_wrong_penalty: 0.5,
+  duration_tier_multipliers: [1.3, 1.2, 1.1, 1.0, 0.75, 0.5],
+  duration_tier_scores: [20, 15, 10, 0, -10, -20],
+  bulk_fetch_workers: 4,
 };
 
 describe('MetadataScoringSection', () => {
@@ -77,5 +92,96 @@ describe('MetadataScoringSection', () => {
     expect(onChange).toHaveBeenCalledWith({ embedding_best_match: 0.9 });
     const callArg = onChange.mock.calls[0][0] as { embedding_best_match: unknown };
     expect(typeof callArg.embedding_best_match).toBe('number');
+  });
+
+  // --- new scoring knobs ---
+
+  it('renders the four transcription boost inputs', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    expect(screen.getByLabelText('Title exact-match boost')).toBeInTheDocument();
+    expect(screen.getByLabelText('Title substring boost')).toBeInTheDocument();
+    expect(screen.getByLabelText('Author boost')).toBeInTheDocument();
+    expect(screen.getByLabelText('Narrator boost')).toBeInTheDocument();
+  });
+
+  it('round-trips a numeric transcription boost edit', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Title exact-match boost'), {
+      target: { value: '2.5' },
+    });
+    expect(onChange).toHaveBeenCalledWith({ transcription_title_exact_boost: 2.5 });
+    const arg = onChange.mock.calls[0][0] as { transcription_title_exact_boost: unknown };
+    expect(typeof arg.transcription_title_exact_boost).toBe('number');
+  });
+
+  it('round-trips a numeric series boost edit', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Series name match boost'), {
+      target: { value: '1.8' },
+    });
+    expect(onChange).toHaveBeenCalledWith({ series_name_match_boost: 1.8 });
+  });
+
+  it('round-trips a numeric bulk-fetch workers edit', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Bulk fetch workers'), {
+      target: { value: '8' },
+    });
+    expect(onChange).toHaveBeenCalledWith({ bulk_fetch_workers: 8 });
+  });
+
+  it('rebuilds the duration multiplier array when one tier is edited', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    // First "Tier 1" input belongs to the Multipliers group.
+    const tier1 = screen.getAllByLabelText('Tier 1')[0];
+    fireEvent.change(tier1, { target: { value: '1.5' } });
+    const arg = onChange.mock.calls[0][0] as { duration_tier_multipliers?: number[] };
+    expect(arg.duration_tier_multipliers).toEqual([1.5, 1.2, 1.1, 1.0, 0.75, 0.5]);
+  });
+
+  it('does not emit NaN when a numeric field is cleared', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Author boost'), { target: { value: '' } });
+    const arg = onChange.mock.calls[0][0] as { transcription_author_boost: unknown };
+    expect(arg.transcription_author_boost).toBeUndefined();
+    // Sanity: not NaN.
+    expect(Number.isNaN(arg.transcription_author_boost as number)).toBe(false);
+  });
+
+  // Pointer-knob semantics (spec C2): empty → absent (undefined), explicit 0 → 0.
+  it('sends an empty pointer knob (f1_min_score) as absent, never 0', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('F1 minimum score'), { target: { value: '' } });
+    const arg = onChange.mock.calls[0][0] as { f1_min_score?: number };
+    expect(arg.f1_min_score).toBeUndefined();
+    expect(arg.f1_min_score).not.toBe(0);
+  });
+
+  it('sends an explicit 0 for a pointer knob (compilation_penalty) as 0', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Compilation penalty'), { target: { value: '0' } });
+    expect(onChange).toHaveBeenCalledWith({ compilation_penalty: 0 });
+    const arg = onChange.mock.calls[0][0] as { compilation_penalty: unknown };
+    expect(arg.compilation_penalty).toBe(0);
+  });
+
+  it('resets transcription boosts to defaults', () => {
+    const onChange = vi.fn();
+    render(<MetadataScoringSection config={defaultConfig} onChange={onChange} />);
+    fireEvent.click(screen.getByText('Reset transcription boosts to defaults'));
+    expect(onChange).toHaveBeenCalledWith({
+      transcription_title_exact_boost: 2.0,
+      transcription_title_substr_boost: 1.4,
+      transcription_author_boost: 1.6,
+      transcription_narrator_boost: 1.4,
+    });
   });
 });

--- a/web/src/components/settings/MetadataScoringSection.tsx
+++ b/web/src/components/settings/MetadataScoringSection.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/settings/MetadataScoringSection.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-06-19
+// last-edited: 2026-07-11
 
 import {
   Box,
@@ -10,6 +10,8 @@ import {
   FormControlLabel,
   Switch,
   Grid,
+  Button,
+  Divider,
 } from '@mui/material';
 import * as api from '../../services/api';
 
@@ -18,7 +20,109 @@ interface MetadataScoringProps {
   onChange: (patch: Partial<api.MetadataScoringConfig>) => void;
 }
 
+// SCORING_DEFAULTS mirrors the Go legacy literals TASK-02 preserves (the
+// literal-defaults block in internal/config/config.go, ~1685). Used by the
+// per-group "Reset to defaults" buttons. Duration tier VALUE arrays are the
+// Multiplier/Score columns of durationTiers in
+// internal/metafetch/service_scoring.go (edges stay fixed in code).
+const SCORING_DEFAULTS = {
+  transcription_title_exact_boost: 2.0,
+  transcription_title_substr_boost: 1.4,
+  transcription_author_boost: 1.6,
+  transcription_narrator_boost: 1.4,
+  compilation_penalty: 0.15,
+  rich_metadata_field_bonus: 0.05,
+  rich_metadata_bonus_cap: 0.15,
+  f1_min_score: 0.35,
+  series_name_match_boost: 1.4,
+  series_number_exact_boost: 2.0,
+  series_number_wrong_penalty: 0.5,
+  bulk_fetch_workers: 4,
+  duration_tier_multipliers: [1.3, 1.2, 1.1, 1.0, 0.75, 0.5],
+  duration_tier_scores: [20, 15, 10, 0, -10, -20],
+} satisfies Partial<api.MetadataScoringConfig>;
+
+// numPatch parses a numeric input value into a scoring patch value. An
+// empty/blank input becomes `undefined` so the key is ABSENT in the saved
+// payload (JSON.stringify drops undefined) and the backend fail-open default
+// applies — never NaN. An explicit "0" stays 0, which the pointer knobs
+// (compilation_penalty, rich_metadata_bonus_cap, f1_min_score) honor as a real
+// operator value.
+function numPatch(value: string): number | undefined {
+  return value.trim() === '' ? undefined : Number(value);
+}
+
 export function MetadataScoringSection({ config, onChange }: MetadataScoringProps) {
+  // Numeric field bound to a single scoring key. Displays '' when unset so an
+  // empty input round-trips as absent rather than NaN.
+  const numField = (
+    key: keyof api.MetadataScoringConfig,
+    label: string,
+    helperText: string,
+    step = 0.05,
+    min?: number,
+  ) => (
+    <Grid item xs={12} sm={6} key={key}>
+      <TextField
+        fullWidth
+        type="number"
+        label={label}
+        value={(config[key] as number | undefined) ?? ''}
+        onChange={(e) =>
+          onChange({ [key]: numPatch(e.target.value) } as Partial<api.MetadataScoringConfig>)
+        }
+        helperText={helperText}
+        size="small"
+        inputProps={min !== undefined ? { min, step } : { step }}
+      />
+    </Grid>
+  );
+
+  const resetButton = (label: string, patch: Partial<api.MetadataScoringConfig>) => (
+    <Grid item xs={12}>
+      <Button size="small" variant="outlined" onClick={() => onChange(patch)}>
+        {label}
+      </Button>
+    </Grid>
+  );
+
+  // Duration tier VALUE array (multipliers or scores). Each element is a numeric
+  // input; editing one rebuilds the array so the whole array round-trips. Tier
+  // EDGES are fixed in code and are NOT rendered as inputs.
+  const durationArray = (
+    key: 'duration_tier_multipliers' | 'duration_tier_scores',
+    label: string,
+    step: number,
+  ) => {
+    const values = config[key] ?? SCORING_DEFAULTS[key];
+    return (
+      <Grid item xs={12}>
+        <Typography variant="body2" gutterBottom>
+          {label}
+        </Typography>
+        <Grid container spacing={1}>
+          {values.map((v, i) => (
+            <Grid item xs={4} sm={2} key={`${key}-${i}`}>
+              <TextField
+                fullWidth
+                type="number"
+                label={`Tier ${i + 1}`}
+                value={v}
+                onChange={(e) => {
+                  const next = [...values];
+                  next[i] = Number(e.target.value);
+                  onChange({ [key]: next } as Partial<api.MetadataScoringConfig>);
+                }}
+                size="small"
+                inputProps={{ step }}
+              />
+            </Grid>
+          ))}
+        </Grid>
+      </Grid>
+    );
+  };
+
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
@@ -113,6 +217,142 @@ export function MetadataScoringSection({ config, onChange }: MetadataScoringProp
             label="Write tag backup before applying metadata"
           />
         </Grid>
+      </Grid>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Transcription boosts */}
+      <Typography variant="subtitle1" gutterBottom>
+        Transcription boosts
+      </Typography>
+      <Grid container spacing={2}>
+        {numField(
+          'transcription_title_exact_boost',
+          'Title exact-match boost',
+          'Multiplier when the transcription title matches exactly',
+        )}
+        {numField(
+          'transcription_title_substr_boost',
+          'Title substring boost',
+          'Multiplier when the transcription title matches as a substring',
+        )}
+        {numField(
+          'transcription_author_boost',
+          'Author boost',
+          'Multiplier when the transcription author matches',
+        )}
+        {numField(
+          'transcription_narrator_boost',
+          'Narrator boost',
+          'Multiplier when the transcription narrator matches',
+        )}
+        {resetButton('Reset transcription boosts to defaults', {
+          transcription_title_exact_boost: SCORING_DEFAULTS.transcription_title_exact_boost,
+          transcription_title_substr_boost: SCORING_DEFAULTS.transcription_title_substr_boost,
+          transcription_author_boost: SCORING_DEFAULTS.transcription_author_boost,
+          transcription_narrator_boost: SCORING_DEFAULTS.transcription_narrator_boost,
+        })}
+      </Grid>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Score adjustments */}
+      <Typography variant="subtitle1" gutterBottom>
+        Score adjustments
+      </Typography>
+      <Grid container spacing={2}>
+        {numField(
+          'compilation_penalty',
+          'Compilation penalty',
+          'Penalty for compilation candidates (0 is a real value; leave empty for default)',
+        )}
+        {numField(
+          'rich_metadata_field_bonus',
+          'Rich-metadata field bonus',
+          'Per-field bonus for candidates with rich metadata',
+        )}
+        {numField(
+          'rich_metadata_bonus_cap',
+          'Rich-metadata bonus cap',
+          'Cap on total rich-metadata bonus (0 is a real value; leave empty for default)',
+        )}
+        {numField(
+          'f1_min_score',
+          'F1 minimum score',
+          'Minimum score floor (0 is a real value; leave empty for default)',
+        )}
+        {resetButton('Reset score adjustments to defaults', {
+          compilation_penalty: SCORING_DEFAULTS.compilation_penalty,
+          rich_metadata_field_bonus: SCORING_DEFAULTS.rich_metadata_field_bonus,
+          rich_metadata_bonus_cap: SCORING_DEFAULTS.rich_metadata_bonus_cap,
+          f1_min_score: SCORING_DEFAULTS.f1_min_score,
+        })}
+      </Grid>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Series boosts */}
+      <Typography variant="subtitle1" gutterBottom>
+        Series boosts
+      </Typography>
+      <Grid container spacing={2}>
+        {numField(
+          'series_name_match_boost',
+          'Series name match boost',
+          'Multiplier when the series name matches',
+        )}
+        {numField(
+          'series_number_exact_boost',
+          'Series number exact boost',
+          'Multiplier when the series number matches exactly',
+        )}
+        {numField(
+          'series_number_wrong_penalty',
+          'Series number wrong penalty',
+          'Penalty when the series number is wrong',
+        )}
+        {resetButton('Reset series boosts to defaults', {
+          series_name_match_boost: SCORING_DEFAULTS.series_name_match_boost,
+          series_number_exact_boost: SCORING_DEFAULTS.series_number_exact_boost,
+          series_number_wrong_penalty: SCORING_DEFAULTS.series_number_wrong_penalty,
+        })}
+      </Grid>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Duration tiers */}
+      <Typography variant="subtitle1" gutterBottom>
+        Duration tier values
+      </Typography>
+      <Typography variant="body2" color="text.secondary" gutterBottom>
+        Tier edges are fixed in code; only the multiplier and score values are editable.
+      </Typography>
+      <Grid container spacing={2}>
+        {durationArray('duration_tier_multipliers', 'Multipliers', 0.05)}
+        {durationArray('duration_tier_scores', 'Scores', 1)}
+        {resetButton('Reset duration tiers to defaults', {
+          duration_tier_multipliers: [...SCORING_DEFAULTS.duration_tier_multipliers],
+          duration_tier_scores: [...SCORING_DEFAULTS.duration_tier_scores],
+        })}
+      </Grid>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Bulk fetch */}
+      <Typography variant="subtitle1" gutterBottom>
+        Bulk fetch
+      </Typography>
+      <Grid container spacing={2}>
+        {numField(
+          'bulk_fetch_workers',
+          'Bulk fetch workers',
+          'Concurrent workers for bulk metadata fetch',
+          1,
+          1,
+        )}
+        {resetButton('Reset bulk fetch to defaults', {
+          bulk_fetch_workers: SCORING_DEFAULTS.bulk_fetch_workers,
+        })}
       </Grid>
     </Box>
   );

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.50.0
+// version: 2.51.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-07-03
+// last-edited: 2026-07-11
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -674,6 +674,36 @@ export interface MetadataScoringConfig {
   llm_rerank_epsilon: number;
   llm_rerank_top_k: number;
   write_backup_before: boolean;
+
+  // --- new scoring knobs (TASK-02). All optional; the backend fail-open
+  // defaults apply when a field is absent. Names mirror the Go json tags.
+  //
+  // Transcription boosts (legacy defaults 2.0 / 1.4 / 1.6 / 1.4):
+  transcription_title_exact_boost?: number;
+  transcription_title_substr_boost?: number;
+  transcription_author_boost?: number;
+  transcription_narrator_boost?: number;
+
+  // Base-score adjustments. compilation_penalty, rich_metadata_bonus_cap, and
+  // f1_min_score are POINTER knobs on the Go side: 0 is a real operator value,
+  // so send an empty input as absent (never 0) and an explicit 0 as 0.
+  compilation_penalty?: number;
+  rich_metadata_field_bonus?: number;
+  rich_metadata_bonus_cap?: number;
+  f1_min_score?: number;
+
+  // Series boosts (legacy defaults 1.4 / 2.0 / 0.5):
+  series_name_match_boost?: number;
+  series_number_exact_boost?: number;
+  series_number_wrong_penalty?: number;
+
+  // Duration tier VALUE arrays (multiplier/score columns). Tier edges + count
+  // stay fixed in code; a mismatched-length array is ignored by the backend.
+  duration_tier_multipliers?: number[];
+  duration_tier_scores?: number[];
+
+  // Bulk-fetch concurrency (legacy default 4):
+  bulk_fetch_workers?: number;
 }
 
 export interface ITunesPathMap {


### PR DESCRIPTION
Exposes the TASK-02 scoring config (transcription boosts, adjustments,
series boosts, duration tiers, bulk-fetch concurrency) in the existing
MetadataScoringSection with per-group reset-to-default. Field names mirror
the Go json tags; empty inputs stay absent so the backend fail-open
defaults apply.

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
