### PR TITLE
feat(metadata): author/series ID resolution + legacy history-stub retirement (INIT-3-T4)

### DIFF
--- a/internal/metadata/enhanced.go
+++ b/internal/metadata/enhanced.go
@@ -1,12 +1,13 @@
 // file: internal/metadata/enhanced.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 7e8d9c0b-1a2f-3e4d-5c6b-7a8d9c0b1a2f
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 
 package metadata
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -58,17 +59,6 @@ type MetadataUpdate struct {
 	BookID   string                 `json:"book_id" binding:"required"`
 	Updates  map[string]interface{} `json:"updates" binding:"required"`
 	Validate bool                   `json:"validate"`
-}
-
-// MetadataHistory represents a historical metadata change
-type MetadataHistory struct {
-	ID        int       `json:"id"`
-	BookID    string    `json:"book_id"`
-	Field     string    `json:"field"`
-	OldValue  string    `json:"old_value"`
-	NewValue  string    `json:"new_value"`
-	UpdatedAt time.Time `json:"updated_at"`
-	UpdatedBy string    `json:"updated_by,omitempty"`
 }
 
 // ValidationRule defines a validation constraint
@@ -192,6 +182,24 @@ func ValidateMetadata(updates map[string]interface{}, rules map[string]Validatio
 	return errors
 }
 
+// batchUpdateStore is the store surface BatchUpdateMetadata needs (INIT-3-T4):
+// the book reader/writer (embedded database.BookStore, as the parameter was
+// before) plus the author/series lookup-or-create helpers and the
+// metadata-change recorder used for author/series name → ID resolution.
+// Widening the parameter from database.BookStore leaves ImportMetadata (still
+// database.BookStore) untouched; the sole production caller passes
+// handlers/metadata's MetadataStore, which already embeds database.BookStore
+// and declares these methods. No internal/database interface, mock, or
+// generated file changes — this is a call-signature widening only.
+type batchUpdateStore interface {
+	database.BookStore
+	GetAuthorByName(name string) (*database.Author, error)
+	CreateAuthor(name string) (*database.Author, error)
+	GetSeriesByName(name string, authorID *int) (*database.Series, error)
+	CreateSeries(name string, authorID *int) (*database.Series, error)
+	RecordMetadataChange(record *database.MetadataChangeRecord) error
+}
+
 // BatchUpdateMetadata applies metadata updates to multiple books with validation.
 //
 // Parallelized via registry.RunItems (CONC-13): each worker processes one
@@ -208,10 +216,22 @@ func ValidateMetadata(updates map[string]interface{}, rules map[string]Validatio
 // concurrent UpdateBook calls cannot race or corrupt state at this
 // concurrency. rules is read-only after construction, so sharing it across
 // workers needs no lock.
-func BatchUpdateMetadata(updates []MetadataUpdate, store database.BookStore, validate bool) ([]error, int) {
+//
+// Author/series resolution (INIT-3-T4) is guarded by resolveMu: GetAuthorByName
+// → CreateAuthor (and the series equivalent) is a check-then-create that the
+// store does NOT make atomic (nextID is locked, but the existence check and the
+// name-index write are not), so two workers resolving the SAME new name at this
+// concurrency could otherwise create duplicate author/series rows whose
+// name-index points at only one — a data-integrity bug on a prod write path
+// (CLAUDE.md concurrency rule: exclusive access where parallel workers must
+// never double-create the same row). Serializing only the lookup-or-create
+// section is cheap (local Pebble point-gets) and correctness outranks the small
+// throughput hit here.
+func BatchUpdateMetadata(updates []MetadataUpdate, store batchUpdateStore, validate bool) ([]error, int) {
 	rules := DefaultValidationRules()
 
 	var mu sync.Mutex
+	var resolveMu sync.Mutex
 	var errs []error
 	successCount := 0
 
@@ -247,14 +267,57 @@ func BatchUpdateMetadata(updates []MetadataUpdate, store database.BookStore, val
 			return nil
 		}
 
-		// Apply updates
+		// Apply updates. book is the FULL hydrated row from GetBookByID (a
+		// direct book:<id> point-get + unmarshal, not a memdb-slim projection),
+		// so mutating and writing it back cannot wipe heavy fields.
 		if title, ok := update.Updates["title"].(string); ok {
 			book.Title = title
 		}
-		// TODO: Resolve author name to ID and update book.AuthorID
-		// For now, skip author updates pending author resolution implementation
-		// TODO: Resolve series name to ID and update book.SeriesID
-		// For now, skip series updates pending series resolution implementation
+		// Resolve author name → book.AuthorID (INIT-3-T4). Edge semantics:
+		//   - empty/absent name → no change (skip; never clear an existing ID)
+		//   - lookup MISS → CreateAuthor, then assign
+		//   - store ERROR on lookup/create → FAIL-OPEN: log, leave AuthorID
+		//     unset, and still persist the other applied fields (a store hiccup
+		//     never aborts the whole apply; only UpdateBook stays fatal-to-item).
+		// resolveMu makes the check-then-create atomic across workers.
+		if name, ok := update.Updates["author"].(string); ok && name != "" {
+			resolveMu.Lock()
+			author, aerr := store.GetAuthorByName(name)
+			if aerr == nil && author == nil {
+				author, aerr = store.CreateAuthor(name)
+			}
+			resolveMu.Unlock()
+			switch {
+			case aerr != nil:
+				slog.Warn("BatchUpdateMetadata: author resolution failed; leaving AuthorID unset (fail-open)",
+					"book", update.BookID, "author", name, "error", aerr)
+			case author != nil && (book.AuthorID == nil || *book.AuthorID != author.ID):
+				oldID := book.AuthorID
+				newID := author.ID
+				book.AuthorID = &newID
+				recordIDChange(store, update.BookID, "author_id", oldID, newID)
+			}
+		}
+		// Resolve series name → book.SeriesID, scoped to the (possibly
+		// just-resolved) author. Same edge semantics + fail-open posture.
+		if name, ok := update.Updates["series"].(string); ok && name != "" {
+			resolveMu.Lock()
+			series, serr := store.GetSeriesByName(name, book.AuthorID)
+			if serr == nil && series == nil {
+				series, serr = store.CreateSeries(name, book.AuthorID)
+			}
+			resolveMu.Unlock()
+			switch {
+			case serr != nil:
+				slog.Warn("BatchUpdateMetadata: series resolution failed; leaving SeriesID unset (fail-open)",
+					"book", update.BookID, "series", name, "error", serr)
+			case series != nil && (book.SeriesID == nil || *book.SeriesID != series.ID):
+				oldID := book.SeriesID
+				newID := series.ID
+				book.SeriesID = &newID
+				recordIDChange(store, update.BookID, "series_id", oldID, newID)
+			}
+		}
 		if format, ok := update.Updates["format"].(string); ok {
 			book.Format = format
 		}
@@ -648,24 +711,44 @@ func writeFLACMetadata(filePath string, metadata map[string]interface{}, config 
 	return nil
 }
 
-// RecordMetadataChange records a metadata change in history
-// This would typically be stored in the database
-func RecordMetadataChange(bookID string, field, oldValue, newValue, updatedBy string) *MetadataHistory {
-	return &MetadataHistory{
-		BookID:    bookID,
-		Field:     field,
-		OldValue:  oldValue,
-		NewValue:  newValue,
-		UpdatedAt: time.Now(),
-		UpdatedBy: updatedBy,
+// recordIDChange records a successful author/series ID resolution as a
+// MetadataChangeRecord (old → new) through the shipped metadata-history store,
+// so a mis-resolution (name collision → wrong existing author) is auditable and
+// reversible. Fail-open: a recording error is logged, never fatal. Previous/new
+// values are JSON-encoded to match the existing history writers in
+// internal/metafetch (nil previous → "null").
+//
+// The legacy enhanced.go history stub (MetadataHistory / RecordMetadataChange /
+// GetMetadataHistory) that used to live here was dead code shadowing this
+// already-shipped subsystem (database.MetadataChangeRecord + PebbleStore impl +
+// live /metadata-history routes + MetadataHistory.tsx) and has been retired
+// (INIT-3-T4, spec Decision 6 — no new history storage).
+func recordIDChange(store batchUpdateStore, bookID, field string, oldID *int, newID int) {
+	prev := jsonEncodeIDPtr(oldID)
+	next := jsonEncodeIDPtr(&newID)
+	rec := &database.MetadataChangeRecord{
+		BookID:        bookID,
+		Field:         field,
+		PreviousValue: &prev,
+		NewValue:      &next,
+		ChangeType:    "bulk_update",
+		Source:        "manual",
+		ChangedAt:     time.Now(),
+	}
+	if err := store.RecordMetadataChange(rec); err != nil {
+		slog.Warn("BatchUpdateMetadata: failed to record ID change history (non-fatal)",
+			"book", bookID, "field", field, "error", err)
 	}
 }
 
-// GetMetadataHistory retrieves metadata change history for a book
-// This is a placeholder for future database implementation
-func GetMetadataHistory(bookID string, store database.BookStore) ([]MetadataHistory, error) {
-	// TODO: Implement metadata history storage and retrieval in database
-	return nil, fmt.Errorf("metadata history not yet implemented in database")
+// jsonEncodeIDPtr JSON-encodes a nullable int ID (nil → "null") to match the
+// JSON-encoded PreviousValue/NewValue convention of the metadata-history store.
+func jsonEncodeIDPtr(id *int) string {
+	b, err := json.Marshal(id)
+	if err != nil {
+		return "null"
+	}
+	return string(b)
 }
 
 // ExportMetadata exports book metadata to a structured format

--- a/internal/metadata/enhanced_test.go
+++ b/internal/metadata/enhanced_test.go
@@ -1,7 +1,7 @@
 // file: internal/metadata/enhanced_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 
 package metadata
 
@@ -373,43 +373,135 @@ func TestBatchUpdateMetadata_UpdateError(t *testing.T) {
 	}
 }
 
-func TestRecordMetadataChange(t *testing.T) {
-	history := RecordMetadataChange("book123", "title", "Old Title", "New Title", "user123")
+// TestAuthorSeriesResolution proves the INIT-3-T4 author/series name → ID
+// resolution edge semantics: reuse (no duplicate created), create-once,
+// empty-name skip (never clears an ID), store-error fail-open (other fields
+// still applied, ID left unset), and a MetadataChangeRecord per ID change.
+func TestAuthorSeriesResolution(t *testing.T) {
+	t.Run("existing author reused, no duplicate created", func(t *testing.T) {
+		store := newMockStore(t)
+		existingID := 5
+		book := &database.Book{ID: "b1", Title: "T"}
+		store.EXPECT().GetBookByID("b1").Return(book, nil).Once()
+		store.EXPECT().GetAuthorByName("Ursula Le Guin").
+			Return(&database.Author{ID: existingID, Name: "Ursula Le Guin"}, nil).Once()
+		// CreateAuthor must NOT be called (no expectation set → call would fail).
+		store.EXPECT().RecordMetadataChange(mock.MatchedBy(func(r *database.MetadataChangeRecord) bool {
+			return r.Field == "author_id" && r.BookID == "b1"
+		})).Return(nil).Once()
+		store.EXPECT().UpdateBook("b1", mock.MatchedBy(func(b *database.Book) bool {
+			return b.AuthorID != nil && *b.AuthorID == existingID
+		})).Return(book, nil).Once()
 
-	if history == nil {
-		t.Fatal("Expected non-nil history record")
-	}
-	if history.BookID != "book123" {
-		t.Errorf("Expected BookID=book123, got %s", history.BookID)
-	}
-	if history.Field != "title" {
-		t.Errorf("Expected Field=title, got %s", history.Field)
-	}
-	if history.OldValue != "Old Title" {
-		t.Errorf("Expected OldValue=Old Title, got %s", history.OldValue)
-	}
-	if history.NewValue != "New Title" {
-		t.Errorf("Expected NewValue=New Title, got %s", history.NewValue)
-	}
-	if history.UpdatedBy != "user123" {
-		t.Errorf("Expected UpdatedBy=user123, got %s", history.UpdatedBy)
-	}
-	if history.UpdatedAt.IsZero() {
-		t.Error("Expected UpdatedAt to be set")
-	}
+		errs, ok := BatchUpdateMetadata([]MetadataUpdate{{
+			BookID:  "b1",
+			Updates: map[string]interface{}{"author": "Ursula Le Guin"},
+		}}, store, false)
+		if len(errs) != 0 || ok != 1 {
+			t.Fatalf("expected 0 errors / 1 success, got %d errors / %d success: %v", len(errs), ok, errs)
+		}
+	})
+
+	t.Run("unknown author created once, series created scoped to author", func(t *testing.T) {
+		store := newMockStore(t)
+		newAuthorID := 7
+		newSeriesID := 3
+		book := &database.Book{ID: "b2", Title: "T"}
+		store.EXPECT().GetBookByID("b2").Return(book, nil).Once()
+		store.EXPECT().GetAuthorByName("New Author").Return(nil, nil).Once()
+		store.EXPECT().CreateAuthor("New Author").
+			Return(&database.Author{ID: newAuthorID, Name: "New Author"}, nil).Once()
+		// Series lookup must be scoped to the just-resolved author ID.
+		store.EXPECT().GetSeriesByName("New Series", mock.MatchedBy(func(a *int) bool {
+			return a != nil && *a == newAuthorID
+		})).Return(nil, nil).Once()
+		store.EXPECT().CreateSeries("New Series", mock.MatchedBy(func(a *int) bool {
+			return a != nil && *a == newAuthorID
+		})).Return(&database.Series{ID: newSeriesID, Name: "New Series"}, nil).Once()
+		store.EXPECT().RecordMetadataChange(mock.MatchedBy(func(r *database.MetadataChangeRecord) bool {
+			return r.Field == "author_id"
+		})).Return(nil).Once()
+		store.EXPECT().RecordMetadataChange(mock.MatchedBy(func(r *database.MetadataChangeRecord) bool {
+			return r.Field == "series_id"
+		})).Return(nil).Once()
+		store.EXPECT().UpdateBook("b2", mock.MatchedBy(func(b *database.Book) bool {
+			return b.AuthorID != nil && *b.AuthorID == newAuthorID &&
+				b.SeriesID != nil && *b.SeriesID == newSeriesID
+		})).Return(book, nil).Once()
+
+		errs, ok := BatchUpdateMetadata([]MetadataUpdate{{
+			BookID:  "b2",
+			Updates: map[string]interface{}{"author": "New Author", "series": "New Series"},
+		}}, store, false)
+		if len(errs) != 0 || ok != 1 {
+			t.Fatalf("expected 0 errors / 1 success, got %d errors / %d success: %v", len(errs), ok, errs)
+		}
+	})
+
+	t.Run("empty author name skipped, existing ID preserved", func(t *testing.T) {
+		store := newMockStore(t)
+		existingID := 9
+		book := &database.Book{ID: "b3", Title: "Old", AuthorID: &existingID}
+		store.EXPECT().GetBookByID("b3").Return(book, nil).Once()
+		// No GetAuthorByName/CreateAuthor/RecordMetadataChange expectations:
+		// an empty name is a no-op that must not clear the existing ID.
+		store.EXPECT().UpdateBook("b3", mock.MatchedBy(func(b *database.Book) bool {
+			return b.AuthorID != nil && *b.AuthorID == existingID && b.Title == "New"
+		})).Return(book, nil).Once()
+
+		errs, ok := BatchUpdateMetadata([]MetadataUpdate{{
+			BookID:  "b3",
+			Updates: map[string]interface{}{"author": "", "title": "New"},
+		}}, store, false)
+		if len(errs) != 0 || ok != 1 {
+			t.Fatalf("expected 0 errors / 1 success, got %d errors / %d success: %v", len(errs), ok, errs)
+		}
+	})
+
+	t.Run("resolution store error is fail-open: other fields still applied, ID left unset", func(t *testing.T) {
+		store := newMockStore(t)
+		book := &database.Book{ID: "b4", Title: "Old"}
+		store.EXPECT().GetBookByID("b4").Return(book, nil).Once()
+		store.EXPECT().GetAuthorByName("Boom").Return(nil, errors.New("store down")).Once()
+		// No RecordMetadataChange (no successful ID change). Title still applied,
+		// AuthorID left unset.
+		store.EXPECT().UpdateBook("b4", mock.MatchedBy(func(b *database.Book) bool {
+			return b.AuthorID == nil && b.Title == "New"
+		})).Return(book, nil).Once()
+
+		errs, ok := BatchUpdateMetadata([]MetadataUpdate{{
+			BookID:  "b4",
+			Updates: map[string]interface{}{"author": "Boom", "title": "New"},
+		}}, store, false)
+		if len(errs) != 0 || ok != 1 {
+			t.Fatalf("fail-open expected 0 errors / 1 success, got %d errors / %d success: %v", len(errs), ok, errs)
+		}
+	})
 }
 
-func TestGetMetadataHistory(t *testing.T) {
+// TestLegacyHistoryStubRetired asserts the dead enhanced.go history stub
+// (MetadataHistory / RecordMetadataChange-free-func / GetMetadataHistory) is
+// retired: this file compiles without referencing any of those symbols
+// (compile-level absence), and author/series ID changes are now recorded
+// through the shipped store-backed metadata-history subsystem
+// (store.RecordMetadataChange), not a local stub.
+func TestLegacyHistoryStubRetired(t *testing.T) {
 	store := newMockStore(t)
+	book := &database.Book{ID: "b5", Title: "T"}
+	recorded := false
+	store.EXPECT().GetBookByID("b5").Return(book, nil).Once()
+	store.EXPECT().GetAuthorByName("A").Return(&database.Author{ID: 1, Name: "A"}, nil).Once()
+	store.EXPECT().RecordMetadataChange(mock.Anything).
+		Run(func(r *database.MetadataChangeRecord) { recorded = true }).Return(nil).Once()
+	store.EXPECT().UpdateBook("b5", mock.Anything).Return(book, nil).Once()
 
-	history, err := GetMetadataHistory("book123", store)
+	BatchUpdateMetadata([]MetadataUpdate{{
+		BookID:  "b5",
+		Updates: map[string]interface{}{"author": "A"},
+	}}, store, false)
 
-	// Function is not yet implemented, should return error
-	if err == nil {
-		t.Error("Expected error for unimplemented function")
-	}
-	if history != nil {
-		t.Error("Expected nil history for unimplemented function")
+	if !recorded {
+		t.Fatal("expected ID change recorded via shipped store.RecordMetadataChange subsystem")
 	}
 }
 

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-07-06
+// last-edited: 2026-07-11
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -55,9 +55,15 @@ import (
 type MetadataStore interface {
 	database.BookStore
 
-	// Author resolution (bulkFetchMetadata).
+	// Author/series resolution (bulkFetchMetadata + metadata.BatchUpdateMetadata's
+	// author/series name → ID resolution, INIT-3-T4). The series/history methods
+	// were added so this type satisfies metadata.BatchUpdateMetadata's widened
+	// store parameter without a cast (the doc above notes it is passed straight in).
 	GetAuthorByName(name string) (*database.Author, error)
 	CreateAuthor(name string) (*database.Author, error)
+	GetSeriesByName(name string, authorID *int) (*database.Series, error)
+	CreateSeries(name string, authorID *int) (*database.Series, error)
+	RecordMetadataChange(record *database.MetadataChangeRecord) error
 
 	// Metadata rejections (markAudiobookNoMatch / handleGetMetadataRejections).
 	AddMetadataRejection(r database.MetadataRejection) error

--- a/internal/server/handlers/metadata/mocks/mock_metadata_store.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_store.go
@@ -497,6 +497,74 @@ func (_c *MockMetadataStore_CreateOperation_Call) RunAndReturn(run func(id strin
 	return _c
 }
 
+// CreateSeries provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) CreateSeries(name string, authorID *int) (*database.Series, error) {
+	ret := _mock.Called(name, authorID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateSeries")
+	}
+
+	var r0 *database.Series
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, *int) (*database.Series, error)); ok {
+		return returnFunc(name, authorID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, *int) *database.Series); ok {
+		r0 = returnFunc(name, authorID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.Series)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, *int) error); ok {
+		r1 = returnFunc(name, authorID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_CreateSeries_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateSeries'
+type MockMetadataStore_CreateSeries_Call struct {
+	*mock.Call
+}
+
+// CreateSeries is a helper method to define mock.On call
+//   - name string
+//   - authorID *int
+func (_e *MockMetadataStore_Expecter) CreateSeries(name any, authorID any) *MockMetadataStore_CreateSeries_Call {
+	return &MockMetadataStore_CreateSeries_Call{Call: _e.mock.On("CreateSeries", name, authorID)}
+}
+
+func (_c *MockMetadataStore_CreateSeries_Call) Run(run func(name string, authorID *int)) *MockMetadataStore_CreateSeries_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 *int
+		if args[1] != nil {
+			arg1 = args[1].(*int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_CreateSeries_Call) Return(series *database.Series, err error) *MockMetadataStore_CreateSeries_Call {
+	_c.Call.Return(series, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_CreateSeries_Call) RunAndReturn(run func(name string, authorID *int) (*database.Series, error)) *MockMetadataStore_CreateSeries_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteBook provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) DeleteBook(id string) error {
 	ret := _mock.Called(id)
@@ -2526,6 +2594,74 @@ func (_c *MockMetadataStore_GetScanFailCount_Call) RunAndReturn(run func(pathHas
 	return _c
 }
 
+// GetSeriesByName provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) GetSeriesByName(name string, authorID *int) (*database.Series, error) {
+	ret := _mock.Called(name, authorID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSeriesByName")
+	}
+
+	var r0 *database.Series
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, *int) (*database.Series, error)); ok {
+		return returnFunc(name, authorID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, *int) *database.Series); ok {
+		r0 = returnFunc(name, authorID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.Series)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, *int) error); ok {
+		r1 = returnFunc(name, authorID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockMetadataStore_GetSeriesByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSeriesByName'
+type MockMetadataStore_GetSeriesByName_Call struct {
+	*mock.Call
+}
+
+// GetSeriesByName is a helper method to define mock.On call
+//   - name string
+//   - authorID *int
+func (_e *MockMetadataStore_Expecter) GetSeriesByName(name any, authorID any) *MockMetadataStore_GetSeriesByName_Call {
+	return &MockMetadataStore_GetSeriesByName_Call{Call: _e.mock.On("GetSeriesByName", name, authorID)}
+}
+
+func (_c *MockMetadataStore_GetSeriesByName_Call) Run(run func(name string, authorID *int)) *MockMetadataStore_GetSeriesByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 *int
+		if args[1] != nil {
+			arg1 = args[1].(*int)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_GetSeriesByName_Call) Return(series *database.Series, err error) *MockMetadataStore_GetSeriesByName_Call {
+	_c.Call.Return(series, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_GetSeriesByName_Call) RunAndReturn(run func(name string, authorID *int) (*database.Series, error)) *MockMetadataStore_GetSeriesByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IncrScanFailCount provides a mock function for the type MockMetadataStore
 func (_mock *MockMetadataStore) IncrScanFailCount(pathHash string) (int, error) {
 	ret := _mock.Called(pathHash)
@@ -3087,6 +3223,57 @@ func (_c *MockMetadataStore_RecomputeBookAggregates_Call) Return(err error) *Moc
 }
 
 func (_c *MockMetadataStore_RecomputeBookAggregates_Call) RunAndReturn(run func(bookID string) error) *MockMetadataStore_RecomputeBookAggregates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RecordMetadataChange provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) RecordMetadataChange(record *database.MetadataChangeRecord) error {
+	ret := _mock.Called(record)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecordMetadataChange")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*database.MetadataChangeRecord) error); ok {
+		r0 = returnFunc(record)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockMetadataStore_RecordMetadataChange_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordMetadataChange'
+type MockMetadataStore_RecordMetadataChange_Call struct {
+	*mock.Call
+}
+
+// RecordMetadataChange is a helper method to define mock.On call
+//   - record *database.MetadataChangeRecord
+func (_e *MockMetadataStore_Expecter) RecordMetadataChange(record any) *MockMetadataStore_RecordMetadataChange_Call {
+	return &MockMetadataStore_RecordMetadataChange_Call{Call: _e.mock.On("RecordMetadataChange", record)}
+}
+
+func (_c *MockMetadataStore_RecordMetadataChange_Call) Run(run func(record *database.MetadataChangeRecord)) *MockMetadataStore_RecordMetadataChange_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *database.MetadataChangeRecord
+		if args[0] != nil {
+			arg0 = args[0].(*database.MetadataChangeRecord)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_RecordMetadataChange_Call) Return(err error) *MockMetadataStore_RecordMetadataChange_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockMetadataStore_RecordMetadataChange_Call) RunAndReturn(run func(record *database.MetadataChangeRecord) error) *MockMetadataStore_RecordMetadataChange_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary (⚠ review-critical — prod write path: creates author/series rows, writes book IDs)

Implements the two author/series TODOs in `internal/metadata/enhanced.go`'s `BatchUpdateMetadata` bulk-update path and retires the dead legacy metadata-history stub in the same file.

- **Author/series resolution:** `update.Updates["author"]`/`["series"]` (non-empty string) → `GetAuthorByName`/`GetSeriesByName(name, book.AuthorID)`; on miss → `CreateAuthor`/`CreateSeries`; assign `book.AuthorID`/`SeriesID`. Series is scoped to the (possibly just-resolved) author.
- **Edge semantics** (in code comments + tests): empty/absent name → skip (never clears an ID); lookup miss → create; **store error → fail-open** (log, leave ID unset, still persist other applied fields — only `UpdateBook` stays fatal-to-item, as today).
- **Concurrency guard (added):** `CreateAuthor`/`CreateSeries` are check-then-create and NOT atomic (`nextID` is locked, but the existence check + name-index write are not). Under the `registry.RunItems` worker pool (Concurrency 4), two workers resolving the same new name could create duplicate rows whose name-index points at only one. The resolve-or-create section is serialized with `resolveMu` per CLAUDE.md's concurrency rule.
- **Hydrated write-back:** `book` comes from `GetBookByID` (a direct `book:<id>` point-get + unmarshal — full-fidelity, not memdb-slim), so mutate + `UpdateBook` cannot wipe heavy fields. No re-fetch needed.
- **History via existing subsystem:** each successful ID change records a `database.MetadataChangeRecord` (`author_id`/`series_id`, old → new, JSON-encoded, `ChangeType: bulk_update`) through the shipped store method (fail-open on recording error). **No new history storage** (spec Decision 6).
- **Stub retirement:** deletes the dead `MetadataHistory` type, the `RecordMetadataChange` free function, and `GetMetadataHistory` (returned "not yet implemented") plus their tests. Grep-confirmed no external consumers, so deleted (not delegated).
- **Interface widening only:** `BatchUpdateMetadata`'s param widened from `database.BookStore` to a local composed `batchUpdateStore` interface; the handler's `MetadataStore` (interfaces.go) extended with `GetSeriesByName`/`CreateSeries`/`RecordMetadataChange`; its mockery mock regenerated (v3.7.1). **No `internal/database` interface/mock/generated file changed.**

## Acceptance criteria
- [x] `grep 'TODO' enhanced.go` no longer shows the author/series TODOs
- [x] `grep "metadata history not yet implemented" enhanced.go` → 0 hits
- [x] `git diff origin/main --stat -- internal/database/` shows NO changes
- [x] `TestAuthorSeriesResolution`: reuse (no dup), create-once, empty-name skip preserves ID, store-error fail-open (other fields applied), `MetadataChangeRecord` per ID change
- [x] `TestLegacyHistoryStubRetired` green
- [x] Touched packages green: `internal/metadata`, `internal/server/handlers/metadata`
- [x] mocks-check + check-mock-fresh (DB) fresh; staticcheck scoped to changed non-test files clean
- [x] File headers bumped on the 3 hand-edited files (mock is generated)

## Full-suite note
`go test ./... -short`: only `internal/server` fails, via a **pre-existing intermittent stall** (`TestE2E_ScanAndFetchMetadata` hangs → 10-min timeout; FileIOPool/pebble resource pressure across the huge suite). Verified NOT caused by this change: the full `internal/server` suite times out identically on **clean origin/main**, and the test passes in **2s in isolation** on this branch. Documented in project memory as the "CI Go Tests intermittent stalls" flake. My change touches only a handler-interface widening + regenerated mock + `internal/metadata` (not exercised by that E2E).

## Rollback
Roll-FORWARD for data: reverting stops future resolution but does not undo already-written `AuthorID`/`SeriesID` links or created author/series rows; the per-change `MetadataChangeRecord` rows are the audit trail. Stub retirement is pure code deletion (revert restores it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv