### PR TITLE
feat(ui): show file hash chain in book-file detail view (HASH-CHAIN-2, #1270)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 <!-- file: TODO.md -->
 <!-- version: 9.92.1 -->
+<!-- version: 9.93.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -2198,7 +2199,7 @@ Track the full lifecycle of a file's hash so we can answer "has this file change
 Proposed chain: **DownloadHash** (as-downloaded) → **OriginalFileHash** (after iTunes/external tagger) → **FileHash** (current, after AO).
 
 - [x] **HASH-CHAIN-1** Add `download_hash` column to `book_files` (SQLite migration + PebbleDB field). Populate it from Deluge import data (already have `deluge_hash`) and allow manual set via API.  ✅ shipped #1722 (agent-task sweep 2026-07-01)
-- [ ] **HASH-CHAIN-2** [hold] UI: show hash chain in book file detail view so users can see when/where a file changed.
+- [x] **HASH-CHAIN-2** [hold] UI: show hash chain in book file detail view so users can see when/where a file changed. — shipped, see #1270 / this PR
 - [x] **HASH-CHAIN-3** Integrity alert: flag files where `file_hash != original_file_hash` and no AO tag-write is on record (possible external modification / bit-rot).  ✅ shipped #1726 (agent-task sweep 2026-07-01)
 
 *Low priority — AcoustID fingerprinting covers the identity-across-re-encode case better. Useful mainly for strict download-integrity auditing.*

--- a/web/src/components/bookdetail/BookDetailVersionGroup.tsx
+++ b/web/src/components/bookdetail/BookDetailVersionGroup.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/bookdetail/BookDetailVersionGroup.tsx
-// version: 1.0.2
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-fabc-456789012345
-// last-edited: 2026-05-31
+// last-edited: 2026-07-11
 
 import {
   Alert,
@@ -36,6 +36,38 @@ import { formatDuration, formatBytes, formatTagValue } from './bookDetailUtils';
 import { useNavigate } from 'react-router-dom';
 
 const SEGMENT_PREVIEW_COUNT = 5;
+
+// Hash chain (HASH-CHAIN-2, #1270): Download -> Original -> Post-metadata -> Current.
+// Sourced PER FILE from the BookFile prop — never from Book (which lacks these fields).
+const HASH_CHAIN_LINKS: ReadonlyArray<{
+  key: 'download_hash' | 'original_file_hash' | 'post_metadata_hash' | 'file_hash';
+  label: string;
+}> = [
+  { key: 'download_hash', label: 'Download' },
+  { key: 'original_file_hash', label: 'Original' },
+  { key: 'post_metadata_hash', label: 'Post-metadata' },
+  { key: 'file_hash', label: 'Current' },
+];
+
+const HashChainLink = ({ label, value }: { label: string; value?: string }) => {
+  const hasValue = typeof value === 'string' && value.length > 0;
+  // Missing/absent hashes render as an em dash (never hidden, never an error).
+  const shown = hasValue ? value.slice(0, 12) : '—';
+  const content = (
+    <Box component="span" sx={{ display: 'inline-flex', flexDirection: 'column', minWidth: 0 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.2 }}>
+        {label}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{ fontFamily: 'monospace', wordBreak: 'break-all', lineHeight: 1.2 }}
+      >
+        {shown}
+      </Typography>
+    </Box>
+  );
+  return hasValue ? <Tooltip title={value}>{content}</Tooltip> : content;
+};
 const OVERALL_METADATA_FIELDS = [
   { key: 'title', label: 'Title' },
   { key: 'author_name', label: 'Author' },
@@ -533,6 +565,54 @@ export const BookDetailVersionGroup = ({
                   </Box>
                 );
               })()}
+
+              {/* Hash chain per file (HASH-CHAIN-2, #1270). Only the current
+                  version carries per-file hash data (bookFiles); non-current
+                  versions have no hash data and are out of scope. */}
+              {isCurrent && bookFiles.length > 0 && (
+                <Box sx={{ mt: 2 }} data-testid="hash-chain-section">
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                    Hash Chain
+                  </Typography>
+                  <Stack spacing={1}>
+                    {bookFiles.map((f) => (
+                      <Box
+                        key={f.id}
+                        sx={{
+                          p: 1,
+                          border: '1px solid',
+                          borderColor: 'divider',
+                          borderRadius: 1,
+                          bgcolor: 'background.default',
+                        }}
+                      >
+                        <Typography
+                          variant="caption"
+                          sx={{ display: 'block', wordBreak: 'break-all', mb: 0.5 }}
+                        >
+                          {f.file_path}
+                        </Typography>
+                        <Stack
+                          direction="row"
+                          spacing={1.5}
+                          alignItems="flex-start"
+                          flexWrap="wrap"
+                          useFlexGap
+                          divider={
+                            <Box component="span" sx={{ alignSelf: 'center', color: 'text.disabled' }}>
+                              →
+                            </Box>
+                          }
+                        >
+                          {HASH_CHAIN_LINKS.map((link) => (
+                            <HashChainLink key={link.key} label={link.label} value={f[link.key]} />
+                          ))}
+                        </Stack>
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
             </Box>
           );
         })}

--- a/web/src/pages/BookDetail.hash-chain.test.tsx
+++ b/web/src/pages/BookDetail.hash-chain.test.tsx
@@ -1,0 +1,153 @@
+// file: web/src/pages/BookDetail.hash-chain.test.tsx
+// version: 1.0.0
+// guid: 4b2d9f7e-1c3a-4e5b-8a6d-9f0e1c2d3b4a
+// last-edited: 2026-07-11
+
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookDetail } from './BookDetail';
+import * as api from '../services/api';
+
+vi.mock('../components/TagComparison', () => ({
+  TagComparison: () => <div data-testid="tag-comparison" />,
+}));
+
+vi.mock('../components/ChangeLog', () => ({
+  ChangeLog: () => <div data-testid="change-log" />,
+}));
+
+vi.mock('../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../services/api')>(
+    '../services/api'
+  );
+  return {
+    ...actual,
+    getBook: vi.fn(),
+    getBookVersions: vi.fn(),
+    getBookExternalIDs: vi.fn(),
+    getBookSegments: vi.fn(),
+    getBookFiles: vi.fn(),
+    getBookTags: vi.fn(),
+  };
+});
+
+const mockBook: api.Book = {
+  id: 'book-1',
+  title: 'The Great Book',
+  author_name: 'A. Writer',
+  narrator: 'N. Reader',
+  file_path: '/library/the-great-book/the-great-book.m4b',
+  format: 'mp3',
+  codec: 'mp3',
+  duration: 7500,
+  file_size: 2147483648,
+  is_primary_version: true,
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-01T00:00:00Z',
+};
+
+// A file with the full hash chain present. Distinct 20-char values so the
+// 12-char truncation is unambiguous to assert on.
+const fileWithHashes: api.BookFile = {
+  id: 'file-1',
+  book_id: 'book-1',
+  file_path: '/library/the-great-book/file-1.mp3',
+  format: 'mp3',
+  file_size: 10485760,
+  duration: 600,
+  track_number: 1,
+  track_count: 1,
+  missing: false,
+  file_exists: true,
+  download_hash: 'dddddddddddd0000download',
+  original_file_hash: 'oooooooooooo1111original',
+  post_metadata_hash: 'pppppppppppp2222postmeta',
+  file_hash: 'cccccccccccc3333current',
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-01T00:00:00Z',
+};
+
+// A file with NO hash values at all (the anti-over-suppression case).
+const fileWithoutHashes: api.BookFile = {
+  id: 'file-2',
+  book_id: 'book-1',
+  file_path: '/library/the-great-book/file-2.mp3',
+  format: 'mp3',
+  file_size: 10485760,
+  duration: 600,
+  track_number: 1,
+  track_count: 1,
+  missing: false,
+  file_exists: true,
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-01T00:00:00Z',
+};
+
+function setup(files: api.BookFile[]) {
+  vi.mocked(api.getBook).mockResolvedValue(mockBook);
+  vi.mocked(api.getBookVersions).mockResolvedValue([mockBook]);
+  vi.mocked(api.getBookExternalIDs).mockResolvedValue({
+    itunes_linked: false,
+    total: 0,
+    external_ids: [],
+  });
+  vi.mocked(api.getBookSegments).mockResolvedValue([]);
+  vi.mocked(api.getBookFiles).mockResolvedValue({ files, count: files.length });
+  vi.mocked(api.getBookTags).mockResolvedValue({ tags: {} });
+
+  return render(
+    <MemoryRouter
+      initialEntries={['/library/book-1?tab=files']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/library/:id" element={<BookDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('BookDetail hash chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the four truncated hash values for a file with a full chain', async () => {
+    setup([fileWithHashes]);
+
+    const section = await screen.findByTestId('hash-chain-section');
+
+    // Labels in chain order.
+    expect(screen.getByText('Download')).toBeInTheDocument();
+    expect(screen.getByText('Original')).toBeInTheDocument();
+    expect(screen.getByText('Post-metadata')).toBeInTheDocument();
+    expect(screen.getByText('Current')).toBeInTheDocument();
+
+    // The truncated (12-char) VALUES must actually render. This is the check
+    // that fails if the chain is wired to `version` (a Book) instead of `f`.
+    expect(screen.getByText('dddddddddddd')).toBeInTheDocument();
+    expect(screen.getByText('oooooooooooo')).toBeInTheDocument();
+    expect(screen.getByText('pppppppppppp')).toBeInTheDocument();
+    expect(screen.getByText('cccccccccccc')).toBeInTheDocument();
+
+    // Values are truncated, not full-length.
+    expect(section).not.toHaveTextContent('dddddddddddd0000download');
+  });
+
+  it('renders the chain with dashes and does not crash when a file has no hashes', async () => {
+    setup([fileWithoutHashes]);
+
+    const section = await screen.findByTestId('hash-chain-section');
+
+    // Row still renders all four labels.
+    expect(screen.getByText('Download')).toBeInTheDocument();
+    expect(screen.getByText('Original')).toBeInTheDocument();
+    expect(screen.getByText('Post-metadata')).toBeInTheDocument();
+    expect(screen.getByText('Current')).toBeInTheDocument();
+
+    // Four em dashes for the four missing links.
+    const dashes = within(section).getAllByText('—');
+    expect(dashes.length).toBe(4);
+  });
+});

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.51.0
+// version: 2.52.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-07-11
 
@@ -267,7 +267,11 @@ export interface BookFile {
   sample_rate_hz?: number;
   channels?: number;
   bit_depth?: number;
+  // Hash chain (HASH-CHAIN-2, #1270): download -> original -> post-metadata -> current.
   file_hash?: string;
+  download_hash?: string;
+  original_file_hash?: string;
+  post_metadata_hash?: string;
   missing: boolean;
   file_exists?: boolean;
   // Deluge import fields (DELUGE-1, PR #540)

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,7 +1,7 @@
 // file: web/src/types/index.ts
-// version: 1.17.0
+// version: 1.18.0
 // guid: 0d1e2f3a-4b5c-6d7e-8f9a-0b1c2d3e4f5a
-// last-edited: 2026-05-20
+// last-edited: 2026-07-11
 
 // Audiobook (Book) type
 export interface Audiobook {
@@ -226,6 +226,7 @@ export interface BookFile {
   channels?: number;
   bit_depth?: number;
   file_hash?: string;
+  download_hash?: string;
   original_file_hash?: string;
   post_metadata_hash?: string;
   // Acoustic fingerprint segments (0=intro, 1-5=body, 6=outro)


### PR DESCRIPTION
Closes #1270

Renders each book file's hash chain — **Download → Original → Post-metadata → Current** — in the expanded per-file rows of the book detail Files tab (TODO item HASH-CHAIN-2). The backend has stored all four hashes since HASH-CHAIN-1 (#1722) but no UI surfaced them.

## What changed (frontend-only)
- `web/src/components/bookdetail/BookDetailVersionGroup.tsx` — a compact per-file "Hash Chain" section, sourced from each `BookFile` in the `bookFiles` prop (never `Book`, which lacks `download_hash`/`post_metadata_hash`). Values truncated to 12 chars, each wrapped in the existing MUI `Tooltip` showing the full hash. Missing/empty values render an em dash `—`; the row always renders when expanded. Gated on `isCurrent && bookFiles.length > 0` (non-current versions carry no hash data — out of scope).
- `web/src/types/index.ts` — added `download_hash?: string` to `interface BookFile`.
- `web/src/services/api.ts` — the component's `BookFile` actually comes from here (not `types/index.ts` as the brief assumed); it was missing three of the four hash fields, so added `download_hash`, `original_file_hash`, `post_metadata_hash`. Purely additive.
- `web/src/pages/BookDetail.hash-chain.test.tsx` — new tests: (a) positive — a file with all four hashes renders four truncated values; (b) anti-over-suppression — a file with no hashes still renders the row with four dashes, no crash.
- `TODO.md` — HASH-CHAIN-2 ticked.

## Verification
- New tests green (2/2); BookDetail suite green (files-history + unlock + hash-chain).
- `npm run build` (vite) green — type additions compile.
- `tsc --noEmit` → 0 errors.
- `make ci` stops only at `staticcheck`, all failures pre-existing #1796 in `internal/*` Go files (this PR touches no Go). Merge gate is Minimal CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv