### PR TITLE
fix(dedup): dedupe labeled examples to one per book-pair at calibration/export (INIT-1 T3)

### DIFF
--- a/internal/dedup/dataset/pair_dedupe.go
+++ b/internal/dedup/dataset/pair_dedupe.go
@@ -1,0 +1,94 @@
+// file: internal/dedup/dataset/pair_dedupe.go
+// version: 1.0.0
+// guid: 3f8b1a90-2c47-4d1e-9a6b-7e0c5d84f2a1
+// last-edited: 2026-07-11
+
+// Package dataset — pair-level dedupe of labeled examples (INIT-1 T3).
+//
+// The dedup:label store keys rows by candidateID, and one book-pair produces
+// multiple candidates across layers, so a labeled dataset holds ~2.7× more rows
+// than unique pairs (6,926 rows for 2,564 pairs on 2026-07-08). Calibration and
+// export must collapse those to ONE row per book-pair so a pair is never
+// double-counted. This is a consumption-time collapse only — the store keyspace
+// is untouched.
+package dataset
+
+import (
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// sourceRank orders LabelSource by trust: human > llm_judge > itunes_attr >
+// rule. An unknown source ranks as rule (lowest) — non-disqualifying, but never
+// preferred over a recognized higher source.
+func sourceRank(src string) int {
+	switch src {
+	case "human":
+		return 3
+	case "llm_judge":
+		return 2
+	case "itunes_attr":
+		return 1
+	default: // "rule" and any unknown source
+		return 0
+	}
+}
+
+// PairKey returns the canonical identity of a labeled example's book pair:
+// the two entity IDs sorted lexicographically, joined with "|". A/B ordering
+// therefore never splits a pair.
+func PairKey(ex database.LabeledExample) string {
+	a, b := ex.EntityAID, ex.EntityBID
+	if a <= b {
+		return a + "|" + b
+	}
+	return b + "|" + a
+}
+
+// prefers reports whether candidate cand should displace the current best row
+// for a pair. Preference order:
+//  1. a labeled row (Label != "") always beats an unlabeled row;
+//  2. higher source rank (human > llm_judge > itunes_attr > rule);
+//  3. latest DecidedAt (RFC3339 strings compare lexicographically; "" loses);
+//  4. highest CandidateID.
+func prefers(cand, best database.LabeledExample) bool {
+	candLabeled := cand.Label != ""
+	bestLabeled := best.Label != ""
+	if candLabeled != bestLabeled {
+		return candLabeled // labeled beats unlabeled regardless of source
+	}
+	if cr, br := sourceRank(cand.LabelSource), sourceRank(best.LabelSource); cr != br {
+		return cr > br
+	}
+	if cand.DecidedAt != best.DecidedAt {
+		return cand.DecidedAt > best.DecidedAt
+	}
+	return cand.CandidateID > best.CandidateID
+}
+
+// DedupeByPair collapses examples to ONE per canonical pair.
+// Preference: human > llm_judge > itunes_attr > rule; ties by latest
+// DecidedAt (string compare), then highest CandidateID. Labeled rows
+// always beat unlabeled (Label == "") rows. Order of the result follows
+// first-seen pair order (stable for tests).
+func DedupeByPair(examples []database.LabeledExample) []database.LabeledExample {
+	if len(examples) == 0 {
+		return examples
+	}
+	// idx maps a pair key to the slot in out currently holding its best row, so
+	// first-seen pair order is preserved and a higher-preference row replaces in
+	// place rather than appending.
+	idx := make(map[string]int, len(examples))
+	out := make([]database.LabeledExample, 0, len(examples))
+	for _, ex := range examples {
+		key := PairKey(ex)
+		if slot, seen := idx[key]; seen {
+			if prefers(ex, out[slot]) {
+				out[slot] = ex
+			}
+			continue
+		}
+		idx[key] = len(out)
+		out = append(out, ex)
+	}
+	return out
+}

--- a/internal/dedup/dataset/pair_dedupe_test.go
+++ b/internal/dedup/dataset/pair_dedupe_test.go
@@ -1,0 +1,145 @@
+// file: internal/dedup/dataset/pair_dedupe_test.go
+// version: 1.0.0
+// guid: 8d2e6c14-95af-4b73-8f1c-6a0d3e29b7c4
+// last-edited: 2026-07-11
+
+package dataset
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestDedupeByPairPrefersHuman verifies a human-sourced row survives over a
+// rule-sourced row for the same pair.
+func TestDedupeByPairPrefersHuman(t *testing.T) {
+	in := []database.LabeledExample{
+		{CandidateID: 1, EntityAID: "a", EntityBID: "b", Label: "not_dup", LabelSource: "rule"},
+		{CandidateID: 2, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "human"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 1 {
+		t.Fatalf("want 1 row, got %d", len(out))
+	}
+	if out[0].LabelSource != "human" || out[0].CandidateID != 2 {
+		t.Fatalf("want human row (id 2), got source=%q id=%d", out[0].LabelSource, out[0].CandidateID)
+	}
+}
+
+// TestDedupeByPairCrossClass verifies dedup across both label classes: a pair
+// holding a rule not_dup and a human true_dup collapses to the single human
+// true_dup row (not one per class).
+func TestDedupeByPairCrossClass(t *testing.T) {
+	in := []database.LabeledExample{
+		{CandidateID: 10, EntityAID: "x", EntityBID: "y", Label: "not_dup", LabelSource: "rule"},
+		{CandidateID: 11, EntityAID: "x", EntityBID: "y", Label: "true_dup", LabelSource: "human"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 1 {
+		t.Fatalf("cross-class pair must yield exactly 1 row, got %d", len(out))
+	}
+	if out[0].Label != "true_dup" || out[0].LabelSource != "human" {
+		t.Fatalf("want human true_dup, got label=%q source=%q", out[0].Label, out[0].LabelSource)
+	}
+}
+
+// TestDedupeByPairLatestDecidedAt verifies that among same-source rows the
+// latest DecidedAt wins.
+func TestDedupeByPairLatestDecidedAt(t *testing.T) {
+	in := []database.LabeledExample{
+		{CandidateID: 1, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "human", DecidedAt: "2026-07-01T00:00:00Z"},
+		{CandidateID: 2, EntityAID: "a", EntityBID: "b", Label: "not_dup", LabelSource: "human", DecidedAt: "2026-07-05T00:00:00Z"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 1 {
+		t.Fatalf("want 1 row, got %d", len(out))
+	}
+	if out[0].CandidateID != 2 {
+		t.Fatalf("want latest-decided row (id 2), got id=%d", out[0].CandidateID)
+	}
+}
+
+// TestDedupeByPairHighestCandidateID verifies the final tie-break: same source,
+// same DecidedAt → highest CandidateID wins.
+func TestDedupeByPairHighestCandidateID(t *testing.T) {
+	in := []database.LabeledExample{
+		{CandidateID: 7, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "rule", DecidedAt: "2026-07-01T00:00:00Z"},
+		{CandidateID: 42, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "rule", DecidedAt: "2026-07-01T00:00:00Z"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 1 {
+		t.Fatalf("want 1 row, got %d", len(out))
+	}
+	if out[0].CandidateID != 42 {
+		t.Fatalf("want highest CandidateID (42), got %d", out[0].CandidateID)
+	}
+}
+
+// TestDedupeByPairKeepsSingletons verifies distinct pairs pass through
+// unchanged and in first-seen order (anti-over-suppression).
+func TestDedupeByPairKeepsSingletons(t *testing.T) {
+	in := []database.LabeledExample{
+		{CandidateID: 1, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "rule"},
+		{CandidateID: 2, EntityAID: "c", EntityBID: "d", Label: "not_dup", LabelSource: "rule"},
+		{CandidateID: 3, EntityAID: "e", EntityBID: "f", Label: "unsure", LabelSource: "human"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 3 {
+		t.Fatalf("distinct pairs must not be dropped: want 3, got %d", len(out))
+	}
+	for i, want := range []int64{1, 2, 3} {
+		if out[i].CandidateID != want {
+			t.Fatalf("first-seen order broken at %d: want id %d, got %d", i, want, out[i].CandidateID)
+		}
+	}
+}
+
+// TestDedupeByPairUnlabeledNeverDisplaces verifies a labeled row is never
+// displaced by an unlabeled (Label == "") row for the same pair — even when the
+// unlabeled row carries a higher-trust source — but a pair with ONLY unlabeled
+// rows keeps one of them.
+func TestDedupeByPairUnlabeledNeverDisplaces(t *testing.T) {
+	in := []database.LabeledExample{
+		// Labeled rule row must beat an unlabeled human row for the same pair.
+		{CandidateID: 1, EntityAID: "a", EntityBID: "b", Label: "true_dup", LabelSource: "rule"},
+		{CandidateID: 2, EntityAID: "a", EntityBID: "b", Label: "", LabelSource: "human"},
+		// Pair with only unlabeled rows keeps one.
+		{CandidateID: 3, EntityAID: "c", EntityBID: "d", Label: "", LabelSource: "rule"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 2 {
+		t.Fatalf("want 2 rows, got %d", len(out))
+	}
+	byKey := map[string]database.LabeledExample{}
+	for _, ex := range out {
+		byKey[PairKey(ex)] = ex
+	}
+	if got := byKey["a|b"]; got.CandidateID != 1 || got.Label != "true_dup" {
+		t.Fatalf("labeled row must survive unlabeled: got id=%d label=%q", got.CandidateID, got.Label)
+	}
+	if got := byKey["c|d"]; got.CandidateID != 3 {
+		t.Fatalf("only-unlabeled pair must keep its row, got id=%d", got.CandidateID)
+	}
+}
+
+// TestPairKeyOrderInsensitive verifies (A,B) and (B,A) collapse to one key.
+func TestPairKeyOrderInsensitive(t *testing.T) {
+	ab := PairKey(database.LabeledExample{EntityAID: "alpha", EntityBID: "beta"})
+	ba := PairKey(database.LabeledExample{EntityAID: "beta", EntityBID: "alpha"})
+	if ab != ba {
+		t.Fatalf("PairKey not order-insensitive: %q != %q", ab, ba)
+	}
+	if ab != "alpha|beta" {
+		t.Fatalf("want canonical key alpha|beta, got %q", ab)
+	}
+
+	in := []database.LabeledExample{
+		{CandidateID: 1, EntityAID: "alpha", EntityBID: "beta", Label: "true_dup", LabelSource: "rule"},
+		{CandidateID: 2, EntityAID: "beta", EntityBID: "alpha", Label: "true_dup", LabelSource: "human"},
+	}
+	out := DedupeByPair(in)
+	if len(out) != 1 {
+		t.Fatalf("A,B and B,A must collapse to one pair, got %d rows", len(out))
+	}
+}

--- a/internal/plugins/dedup/calibrate_embedding_thresholds.go
+++ b/internal/plugins/dedup/calibrate_embedding_thresholds.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/calibrate_embedding_thresholds.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6f1d2e3a-4b5c-4d6e-8f90-1a2b3c4d5e6f
-// last-edited: 2026-07-04
+// last-edited: 2026-07-11
 
 // Package dedup — op dedup.calibrate-embedding-thresholds (DEDUP-2/3).
 //
@@ -55,6 +55,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -145,6 +146,15 @@ type calibrationPair struct {
 // collectCalibrationPairs turns labeled examples into scored (label, cosine)
 // pairs using only same-model, same-dimension embeddings for the target model.
 //
+// Before scoring, examples are collapsed to ONE row per canonical book-pair via
+// dataset.DedupeByPair (INIT-1 T3): the dedup:label store keys rows by
+// candidateID, so a single book-pair produces multiple labeled rows across
+// layers that would otherwise be double-counted in the precision math. Dedup
+// runs across both label classes together, so a pair holding both a rule
+// not_dup and a human true_dup resolves to the human row rather than appearing
+// in both classes. rowsIn is the pre-dedup count and pairsOut the post-dedup
+// count (rowsIn >= pairsOut), reported so the collapse is observable.
+//
 // Skip rules (DEDUP-3 contamination guard) — a skipped pair is counted, never
 // scored:
 //   - either embedding missing (Get errors or returns nil) → skippedMissing
@@ -152,14 +162,17 @@ type calibrationPair struct {
 //     length → skippedMismatch
 //
 // It is a pure function of its inputs (the getter is the only side channel), so
-// the sweep and skip behaviour are unit-testable with synthetic data.
+// the dedupe, sweep, and skip behaviour are unit-testable with synthetic data.
 func collectCalibrationPairs(
 	examples []database.LabeledExample,
 	getter embeddingGetter,
 	model string,
-) (pairs []calibrationPair, skippedMissing, skippedMismatch int) {
-	for i := range examples {
-		ex := examples[i]
+) (pairs []calibrationPair, skippedMissing, skippedMismatch, rowsIn, pairsOut int) {
+	rowsIn = len(examples)
+	deduped := dataset.DedupeByPair(examples)
+	pairsOut = len(deduped)
+	for i := range deduped {
+		ex := deduped[i]
 		a, aErr := getter.Get("book", ex.EntityAID)
 		if aErr != nil || a == nil {
 			skippedMissing++
@@ -186,7 +199,7 @@ func collectCalibrationPairs(
 			entityBID: ex.EntityBID,
 		})
 	}
-	return pairs, skippedMissing, skippedMismatch
+	return pairs, skippedMissing, skippedMismatch, rowsIn, pairsOut
 }
 
 // bandRecommendation is the sweep result for one band.
@@ -372,7 +385,14 @@ func (p *Plugin) runCalibrateEmbeddingThresholds(ctx context.Context, rawParams 
 
 	// --- Score pairs (same-model, same-dim only) ---
 	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Scoring %d labeled pairs…", len(examples)))
-	pairs, skippedMissing, skippedMismatch := collectCalibrationPairs(examples, p.embeddingStore, model)
+	pairs, skippedMissing, skippedMismatch, rowsIn, pairsOut := collectCalibrationPairs(examples, p.embeddingStore, model)
+
+	// Observability for the INIT-1 T3 pair-collapse: rowsIn is the number of
+	// labeled rows loaded, pairsOut the count after collapsing to one per
+	// book-pair (rowsIn >= pairsOut). A large gap means the store held many
+	// per-layer duplicate rows for the same pair.
+	log.Info("calibrate-embedding-thresholds pair-dedupe",
+		"rows_in", rowsIn, "pairs_out", pairsOut)
 
 	var sampleTrue, sampleNot int
 	for _, pr := range pairs {
@@ -422,6 +442,8 @@ func (p *Plugin) runCalibrateEmbeddingThresholds(ctx context.Context, rawParams 
 	// --- Report (structured log fields — read-only, no result sink to write) ---
 	fields := []any{
 		"model", model,
+		"rows_in", rowsIn,
+		"pairs_out", pairsOut,
 		"sample_true_dup", sampleTrue,
 		"sample_not_dup", sampleNot,
 		"skipped_dimension_mismatch", skippedMismatch,

--- a/internal/plugins/dedup/calibrate_embedding_thresholds_test.go
+++ b/internal/plugins/dedup/calibrate_embedding_thresholds_test.go
@@ -1,15 +1,104 @@
 // file: internal/plugins/dedup/calibrate_embedding_thresholds_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8a7b6c5d-4e3f-4a2b-9c1d-0e9f8a7b6c5d
-// last-edited: 2026-07-04
+// last-edited: 2026-07-11
 
 package dedup
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
+
+// captureReporter is an sdk.Reporter whose Logger() writes JSON records to an
+// in-memory buffer, so a test can inspect the structured report fields emitted
+// by an op (here: rows_in / pairs_out on the "…report" line).
+type captureReporter struct {
+	buf    *bytes.Buffer
+	logger *slog.Logger
+}
+
+func newCaptureReporter() *captureReporter {
+	buf := &bytes.Buffer{}
+	return &captureReporter{buf: buf, logger: slog.New(slog.NewJSONHandler(buf, nil))}
+}
+
+func (r *captureReporter) UpdateProgress(_, _ int, _ string) error          { return nil }
+func (r *captureReporter) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
+func (r *captureReporter) Logger() *slog.Logger                             { return r.logger }
+func (r *captureReporter) Checkpoint(_ any) error                           { return nil }
+func (r *captureReporter) IsCanceled() bool                                 { return false }
+func (r *captureReporter) RunPhase(_ context.Context, _ string, fn func(context.Context, sdk.Reporter) error) error {
+	return fn(context.Background(), r)
+}
+func (r *captureReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }
+func (r *captureReporter) SetCurrentItem(_ string)                          {}
+
+// TestCalibrationReport_RowsInGePairsOut runs the calibration op against a real
+// EmbeddingStore holding two true_dup rows for the SAME book-pair plus one row
+// for a distinct pair, and asserts the structured report line carries rows_in
+// and pairs_out with rows_in >= pairs_out (the INIT-1 T3 pair-collapse is
+// observable). Embeddings are intentionally absent, so every pair is skipped as
+// missing — the report counts still emit.
+func TestCalibrationReport_RowsInGePairsOut(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	rows := []database.LabeledExample{
+		{CandidateID: 1, EntityAID: "book-a", EntityBID: "book-b", Label: "true_dup", LabelSource: "rule", DecidedAt: "2026-07-01T00:00:00Z"},
+		{CandidateID: 2, EntityAID: "book-a", EntityBID: "book-b", Label: "true_dup", LabelSource: "human", DecidedAt: "2026-07-05T00:00:00Z"},
+		{CandidateID: 3, EntityAID: "book-c", EntityBID: "book-d", Label: "true_dup", LabelSource: "rule", DecidedAt: "2026-07-01T00:00:00Z"},
+	}
+	for _, ex := range rows {
+		if err := es.UpsertLabeledExample(ex); err != nil {
+			t.Fatalf("upsert labeled example %d: %v", ex.CandidateID, err)
+		}
+	}
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateEmbeddingThresholds(context.Background(), json.RawMessage(`{"model":"bge-m3"}`), rep); err != nil {
+		t.Fatalf("runCalibrateEmbeddingThresholds: %v", err)
+	}
+
+	var rowsIn, pairsOut float64
+	found := false
+	for _, line := range strings.Split(strings.TrimSpace(rep.buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] != "calibrate-embedding-thresholds report" {
+			continue
+		}
+		ri, riOK := rec["rows_in"].(float64)
+		po, poOK := rec["pairs_out"].(float64)
+		if !riOK || !poOK {
+			t.Fatalf("report line missing rows_in/pairs_out: %s", line)
+		}
+		rowsIn, pairsOut, found = ri, po, true
+	}
+	if !found {
+		t.Fatalf("no calibration report line found in output:\n%s", rep.buf.String())
+	}
+	if rowsIn < pairsOut {
+		t.Fatalf("expected rows_in >= pairs_out, got rows_in=%v pairs_out=%v", rowsIn, pairsOut)
+	}
+	// The two same-pair rows must collapse: 3 rows in, 2 pairs out.
+	if rowsIn != 3 || pairsOut != 2 {
+		t.Fatalf("expected rows_in=3 pairs_out=2, got rows_in=%v pairs_out=%v", rowsIn, pairsOut)
+	}
+}
 
 // fakeEmbGetter is a map-backed embeddingGetter for the calibration tests.
 // A missing key returns (nil, nil), which the collector treats as a missing
@@ -199,7 +288,7 @@ func TestCollectCalibrationPairs_SkipsMismatchAndMissing(t *testing.T) {
 		{EntityAID: "missing_a", EntityBID: "missing_b", Label: "true_dup"},
 	}
 
-	pairs, skippedMissing, skippedMismatch := collectCalibrationPairs(examples, getter, model)
+	pairs, skippedMissing, skippedMismatch, _, _ := collectCalibrationPairs(examples, getter, model)
 
 	if len(pairs) != 1 {
 		t.Fatalf("expected exactly 1 scored pair, got %d", len(pairs))

--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 package deduphandler
 
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/gin-gonic/gin"
 )
@@ -158,7 +159,9 @@ func (h *Handler) OverrideDedupLabel(c *gin.Context) {
 // Query params (all optional, mirror LabeledExampleFilter — empty means "no
 // filter"): label, label_source, band, folder_relation, signature_relation.
 // Unlike ListDedupLabels this endpoint is unpaginated: it exports every row
-// matching the filter.
+// matching the filter. By default rows are collapsed to one per canonical
+// book-pair (INIT-1 T3); pass raw=true to skip the collapse and stream every
+// stored row.
 func (h *Handler) ExportLabeledExamples(c *gin.Context) {
 	es := h.embeddingStore
 	if es == nil {
@@ -178,6 +181,14 @@ func (h *Handler) ExportLabeledExamples(c *gin.Context) {
 	if err != nil {
 		httputil.InternalError(c, "failed to list labeled examples for export", err)
 		return
+	}
+
+	// Collapse to one row per canonical book-pair by default (INIT-1 T3): the
+	// dedup:label store keys by candidateID, so multi-layer pairs otherwise
+	// export ~2.7× duplicate rows. raw=true is a debugging escape hatch that
+	// streams every stored row without deduping.
+	if c.Query("raw") != "true" {
+		items = dataset.DedupeByPair(items)
 	}
 
 	filename := fmt.Sprintf("dedup-labels-%s.jsonl", time.Now().Format("20060102-150405"))

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/label_review_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8a3e1c46-9b20-4d75-8f31-2a6e0c9d5b39
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 package deduphandler_test
 
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,11 +18,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// seedLabel writes one labeled example. Each candidate gets its OWN distinct
+// book-pair (entity IDs derived from candID) so that export/calibration
+// pair-dedupe (INIT-1 T3) leaves distinct candidates intact — tests that want
+// same-pair collapse construct colliding pairs explicitly.
 func seedLabel(t *testing.T, d testDeps, candID int64, label, source string) {
 	t.Helper()
 	if err := d.es.UpsertLabeledExample(database.LabeledExample{
-		CandidateID: candID, EntityAID: "a", EntityBID: "b",
-		Layer: "exact", Label: label, LabelSource: source, LabelReason: "seed",
+		CandidateID: candID,
+		EntityAID:   fmt.Sprintf("a%d", candID),
+		EntityBID:   fmt.Sprintf("b%d", candID),
+		Layer:       "exact", Label: label, LabelSource: source, LabelReason: "seed",
 	}); err != nil {
 		t.Fatalf("UpsertLabeledExample: %v", err)
 	}
@@ -207,6 +214,68 @@ func TestExportLabeledExamples_FilterByLabelSource(t *testing.T) {
 	}
 	if lines != 1 {
 		t.Fatalf("expected 1 JSONL line for label_source=human filter, got %d; body=%s", lines, w.Body.String())
+	}
+}
+
+// countJSONLines counts the non-empty lines in a JSONL response body.
+func countJSONLines(t *testing.T, w *httptest.ResponseRecorder) int {
+	t.Helper()
+	scanner := bufio.NewScanner(bytes.NewReader(w.Body.Bytes()))
+	n := 0
+	for scanner.Scan() {
+		if len(scanner.Bytes()) > 0 {
+			n++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return n
+}
+
+// TestExportLabeledExamples_DedupesByPairDefaultAndRaw verifies the INIT-1 T3
+// pair-collapse on the export path: two labeled rows for the SAME book-pair
+// (a rule not_dup and a human true_dup) export as ONE row by default (the human
+// row wins), while raw=true streams both stored rows unchanged.
+func TestExportLabeledExamples_DedupesByPairDefaultAndRaw(t *testing.T) {
+	h, d := newHandler(t)
+	// Same pair (dup-pair-a / dup-pair-b), two candidate IDs across layers.
+	if err := d.es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: 100, EntityAID: "dup-pair-a", EntityBID: "dup-pair-b",
+		Layer: "exact", Label: "not_dup", LabelSource: "rule", DecidedAt: "2026-07-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertLabeledExample rule: %v", err)
+	}
+	if err := d.es.UpsertLabeledExample(database.LabeledExample{
+		CandidateID: 101, EntityAID: "dup-pair-a", EntityBID: "dup-pair-b",
+		Layer: "embedding", Label: "true_dup", LabelSource: "human", DecidedAt: "2026-07-05T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("UpsertLabeledExample human: %v", err)
+	}
+
+	// Default: deduped to one row, the human true_dup.
+	w := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+	if got := countJSONLines(t, w); got != 1 {
+		t.Fatalf("default export: expected 1 deduped line, got %d; body=%s", got, w.Body.String())
+	}
+	var ex database.LabeledExample
+	if err := json.Unmarshal(bytes.TrimSpace(w.Body.Bytes()), &ex); err != nil {
+		t.Fatalf("decode deduped row: %v", err)
+	}
+	if ex.LabelSource != "human" || ex.Label != "true_dup" {
+		t.Fatalf("deduped row should be human true_dup, got source=%q label=%q", ex.LabelSource, ex.Label)
+	}
+
+	// raw=true: escape hatch streams both stored rows.
+	wRaw := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export?raw=true", nil, nil)
+	if wRaw.Code != http.StatusOK {
+		t.Fatalf("raw status=%d want 200; body=%s", wRaw.Code, wRaw.Body.String())
+	}
+	if got := countJSONLines(t, wRaw); got != 2 {
+		t.Fatalf("raw=true export: expected 2 raw lines, got %d; body=%s", got, wRaw.Body.String())
 	}
 }
 


### PR DESCRIPTION
The dedup:label store keys by candidateID, so multi-layer pairs exported ~2.7x
duplicate rows (6,926 rows -> 2,564 pairs on 2026-07-08) and calibration
double-counted them. Adds dataset.DedupeByPair (human > llm_judge >
itunes_attr > rule, latest DecidedAt, highest CandidateID) and applies it in
collectCalibrationPairs and ExportLabeledExamples.

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
