### PR TITLE
perf(server): parallelize bulk metadata fetch with provider-respecting bounds (INIT-3-T3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.senan.xyz/taglib v0.13.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-07-07
+// last-edited: 2026-07-11
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -45,7 +45,100 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/policy"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	ulid "github.com/oklog/ulid/v2"
+	"golang.org/x/sync/errgroup"
 )
+
+// perProviderFetchCap bounds the number of concurrent live search calls issued
+// to any single metadata provider during a bulk fetch. It is a FIXED internal
+// constant (INIT-3-T3, reviewed): the ProtectedSource circuit breaker and the
+// per-provider limiters (e.g. Hardcover's 60-rpm limiter) sit beneath it, so no
+// per-deployment tuning is needed. Deliberately NOT config.
+const perProviderFetchCap = 2
+
+// defaultBulkFetchWorkers is the fallback outer-loop pool size when
+// config.AppConfig.MetadataScoring.BulkFetchWorkers is unset (<=0). Network-bound,
+// deliberately smaller than NumCPU per the CLAUDE.md concurrency mandate.
+const defaultBulkFetchWorkers = 4
+
+// bulkFetchWorkers resolves the configured outer-loop worker count, falling back
+// to defaultBulkFetchWorkers when unset. Kept trivially greppable so TASK-02 can
+// promote the value cleanly.
+func bulkFetchWorkers() int {
+	if w := config.AppConfig.MetadataScoring.BulkFetchWorkers; w > 0 {
+		return w
+	}
+	return defaultBulkFetchWorkers
+}
+
+// providerSemaphore bounds in-flight live search calls per source name. The map
+// is built ONCE before dispatch and is read-only thereafter, so concurrent
+// workers only ever touch a per-name buffered channel — never the map itself.
+type providerSemaphore struct{ byName map[string]chan struct{} }
+
+// newProviderSemaphore builds a per-source-name semaphore (capacity cap per name)
+// from a source chain. Duplicate names share one channel.
+func newProviderSemaphore(chain []metadata.MetadataSource, cap int) *providerSemaphore {
+	m := make(map[string]chan struct{}, len(chain))
+	for _, src := range chain {
+		n := src.Name()
+		if _, ok := m[n]; !ok {
+			m[n] = make(chan struct{}, cap)
+		}
+	}
+	return &providerSemaphore{byName: m}
+}
+
+// acquire blocks until a slot for name is free or ctx is done. An unknown name
+// (no channel) is treated as unbounded and acquire is a no-op — release then
+// matches. Returns ctx.Err() when the context is canceled while waiting.
+func (p *providerSemaphore) acquire(ctx context.Context, name string) error {
+	if p == nil {
+		return nil
+	}
+	ch := p.byName[name]
+	if ch == nil {
+		return nil
+	}
+	select {
+	case ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release returns a slot previously taken by acquire. Paired with acquire via
+// defer, so the channel always holds a token to drain; a no-op for unknown names.
+func (p *providerSemaphore) release(name string) {
+	if p == nil {
+		return
+	}
+	if ch := p.byName[name]; ch != nil {
+		<-ch
+	}
+}
+
+// runBookFetchPool runs processOne over indices [0,n) on a bounded errgroup pool
+// (the CLAUDE.md-sanctioned worker pool — errgroup.Group + SetLimit). Dispatch
+// stops promptly when ctx is canceled, and the first non-nil processOne error is
+// returned. Per-book fetch errors must be handled INSIDE processOne (record a
+// result row, return nil) so a single book never fails the whole op; processOne
+// should return an error only for genuine context cancellation.
+func runBookFetchPool(ctx context.Context, workers, n int, processOne func(context.Context, int) error) error {
+	if workers <= 0 {
+		workers = defaultBulkFetchWorkers
+	}
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
+	for i := 0; i < n; i++ {
+		if gctx.Err() != nil {
+			break // stop dispatching promptly on cancellation
+		}
+		i := i
+		g.Go(func() error { return processOne(gctx, i) })
+	}
+	return g.Wait()
+}
 
 // runBulkMetadataFetchAll is the resumable core of the full-library metadata
 // fetch. It ONLY fetches and caches — it never writes to book records.
@@ -157,15 +250,35 @@ func (s *Server) runBulkMetadataFetchAll(
 		sourceChain = append([]metadata.MetadataSource{audible}, rest...)
 	}
 
+	// Counters shared across the worker pool: completed (running total, seeded
+	// with the already-cached count) plus found/notFound as atomics. The `done`
+	// resume map above is fully built before dispatch and read-only inside workers.
 	completed := int64(alreadyDone)
-	found := 0
-	notFound := 0
+	var found, notFound atomic.Int64
 
-	for i, w := range work {
-		if ctx.Err() != nil {
-			return ctx.Err()
+	// Per-provider semaphore (fixed cap 2) shared by all workers so N pool workers
+	// can never stampede a single provider. Built from the read-only sourceChain.
+	sem := newProviderSemaphore(sourceChain, perProviderFetchCap)
+
+	// progressMu serializes ProgressReporter calls — the reporter is not assumed
+	// concurrency-safe (see runBulkWriteBack for the same precaution).
+	var progressMu sync.Mutex
+	reportProgress := func(current, total int, message string) {
+		progressMu.Lock()
+		_ = progress.UpdateProgress(current, total, message)
+		progressMu.Unlock()
+	}
+
+	// processOne handles a single book. Its body is the former serial loop body,
+	// unchanged except: counters use atomics, the live source calls are wrapped in
+	// the per-provider semaphore (cache reads / result writes stay outside), and it
+	// returns an error ONLY for genuine context cancellation. A per-book fetch
+	// error records a not_found row and returns nil so it never fails the op.
+	processOne := func(gctx context.Context, i int) error {
+		if gctx.Err() != nil {
+			return gctx.Err()
 		}
-
+		w := work[i]
 		bookID := w.book.ID
 		currentAuthor := w.authorName
 
@@ -180,13 +293,13 @@ func (s *Server) runBulkMetadataFetchAll(
 				ResultJSON:  `{"status":"skipped_fragment","source":""}`,
 				Status:      "skipped_fragment",
 			})
-			notFound++
+			notFound.Add(1)
 			n := atomic.AddInt64(&completed, 1)
-			if i%50 == 0 || int(n) == totalBooks {
-				_ = progress.UpdateProgress(int(n), totalBooks,
-					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+			if n%50 == 0 || int(n) == totalBooks {
+				reportProgress(int(n), totalBooks,
+					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found.Load(), notFound.Load()))
 			}
-			continue
+			return nil
 		}
 
 		searchTitle := stripChapterFromTitle(w.book.Title)
@@ -195,42 +308,58 @@ func (s *Server) runBulkMetadataFetchAll(
 		var sourceName string
 		cacheHit := false
 
+		// Per-book source chain stays SEQUENTIAL (priority-ordered, early-exit on
+		// first success, each source behind its ProtectedSource breaker). Only the
+		// OUTER book loop is parallel.
 		for _, src := range sourceChain {
-			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, src.Name(), maxAge); cerr == nil && cached != nil {
+			name := src.Name()
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, name, maxAge); cerr == nil && cached != nil {
 				var cachedResults []metadata.BookMetadata
 				if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
 					metaResults = cachedResults
-					sourceName = src.Name()
+					sourceName = name
 					cacheHit = true
 					break
 				}
 			}
-			var fetchErr error
-			if currentAuthor != "" {
-				metaResults, fetchErr = src.SearchByTitleAndAuthor(ctx, searchTitle, currentAuthor)
-				if fetchErr == nil && len(metaResults) > 0 {
-					sourceName = src.Name()
-					break
-				}
+			// Live calls only: bound concurrency per provider. ctx cancel while
+			// waiting on the semaphore aborts the book with ctx.Err().
+			if err := sem.acquire(gctx, name); err != nil {
+				return err
 			}
-			metaResults, fetchErr = src.SearchByTitle(ctx, searchTitle)
-			if fetchErr == nil && len(metaResults) > 0 {
-				sourceName = src.Name()
-				break
-			}
-			if searchTitle != w.book.Title {
+			ok := func() bool {
+				defer sem.release(name)
+				var fetchErr error
 				if currentAuthor != "" {
-					metaResults, fetchErr = src.SearchByTitleAndAuthor(ctx, w.book.Title, currentAuthor)
+					metaResults, fetchErr = src.SearchByTitleAndAuthor(gctx, searchTitle, currentAuthor)
 					if fetchErr == nil && len(metaResults) > 0 {
-						sourceName = src.Name()
-						break
+						sourceName = name
+						return true
 					}
 				}
-				metaResults, fetchErr = src.SearchByTitle(ctx, w.book.Title)
+				metaResults, fetchErr = src.SearchByTitle(gctx, searchTitle)
 				if fetchErr == nil && len(metaResults) > 0 {
-					sourceName = src.Name()
-					break
+					sourceName = name
+					return true
 				}
+				if searchTitle != w.book.Title {
+					if currentAuthor != "" {
+						metaResults, fetchErr = src.SearchByTitleAndAuthor(gctx, w.book.Title, currentAuthor)
+						if fetchErr == nil && len(metaResults) > 0 {
+							sourceName = name
+							return true
+						}
+					}
+					metaResults, fetchErr = src.SearchByTitle(gctx, w.book.Title)
+					if fetchErr == nil && len(metaResults) > 0 {
+						sourceName = name
+						return true
+					}
+				}
+				return false
+			}()
+			if ok {
+				break
 			}
 		}
 
@@ -241,10 +370,10 @@ func (s *Server) runBulkMetadataFetchAll(
 					_ = database.PutCachedMetadataFetch(store, bookID, sourceName, blob, 0)
 				}
 			}
-			found++
+			found.Add(1)
 			resultStatus = "cached"
 		} else {
-			notFound++
+			notFound.Add(1)
 		}
 
 		_ = store.CreateOperationResult(&database.OperationResult{
@@ -255,26 +384,34 @@ func (s *Server) runBulkMetadataFetchAll(
 		})
 
 		n := atomic.AddInt64(&completed, 1)
-		if i%50 == 0 || int(n) == totalBooks {
-			_ = progress.UpdateProgress(int(n), totalBooks,
-				fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+		if n%50 == 0 || int(n) == totalBooks {
+			reportProgress(int(n), totalBooks,
+				fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found.Load(), notFound.Load()))
 		}
 
 		// Rate-limit live API calls; cache hits are instant so skip the delay.
 		if !cacheHit && sourceName != "" && i < len(work)-1 {
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-gctx.Done():
+				return gctx.Err()
 			case <-time.After(200 * time.Millisecond):
 			}
 		}
+		return nil
+	}
+
+	if err := runBookFetchPool(ctx, bulkFetchWorkers(), len(work), processOne); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	finalCount := atomic.LoadInt64(&completed)
 	_ = progress.UpdateProgress(int(finalCount), totalBooks,
-		fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound))
+		fmt.Sprintf("complete — cached:%d not_found:%d", found.Load(), notFound.Load()))
 	op.SetStatus("success")
-	logging.Info(ctx, "bulk-metadata-fetch complete", "finalCount", finalCount, "found", found, "notFound", notFound)
+	logging.Info(ctx, "bulk-metadata-fetch complete", "finalCount", finalCount, "found", found.Load(), "notFound", notFound.Load())
 	return nil
 }
 
@@ -527,12 +664,33 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 		sourceChain = append([]metadata.MetadataSource{audible}, rest...)
 	}
 
+	// Counters shared across the worker pool: completed (running total, seeded with
+	// the already-done count) plus found/notFound as atomics. The `done` resume map
+	// above is fully built before dispatch and read-only inside workers.
 	completed := int64(alreadyDone)
-	found, notFound := 0, 0
-	for i, w := range work {
-		if ctx.Err() != nil {
-			return ctx.Err()
+	var found, notFound atomic.Int64
+
+	// Per-provider semaphore (fixed cap 2) shared by all workers, built from the
+	// read-only sourceChain — see runBulkMetadataFetchAll.
+	sem := newProviderSemaphore(sourceChain, perProviderFetchCap)
+
+	var progressMu sync.Mutex
+	reportProgress := func(current, total int, message string) {
+		progressMu.Lock()
+		_ = progress.UpdateProgress(current, total, message)
+		progressMu.Unlock()
+	}
+
+	// processOne handles one book; body is the former serial loop body, unchanged
+	// except counters are atomics and the live source calls are wrapped in the
+	// per-provider semaphore (cache reads / result writes stay outside). Returns an
+	// error only for genuine context cancellation; per-book fetch errors record a
+	// not_found row and return nil.
+	processOne := func(gctx context.Context, i int) error {
+		if gctx.Err() != nil {
+			return gctx.Err()
 		}
+		w := work[i]
 		bookID := w.book.ID
 
 		// Skip obvious chapter fragments of shattered audiobooks (see
@@ -545,13 +703,13 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 				ResultJSON:  `{"status":"skipped_fragment","source":""}`,
 				Status:      "skipped_fragment",
 			})
-			notFound++
+			notFound.Add(1)
 			n := atomic.AddInt64(&completed, 1)
-			if i%50 == 0 || int(n) == totalBooks {
-				_ = progress.UpdateProgress(int(n), totalBooks,
-					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+			if n%50 == 0 || int(n) == totalBooks {
+				reportProgress(int(n), totalBooks,
+					fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found.Load(), notFound.Load()))
 			}
-			continue
+			return nil
 		}
 
 		searchTitle := stripChapterFromTitle(w.book.Title)
@@ -559,25 +717,37 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 		var metaResults []metadata.BookMetadata
 		var sourceName string
 		cacheHit := false
+		// Per-book source chain stays SEQUENTIAL (priority early-exit + breakers).
 		for _, src := range sourceChain {
-			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, src.Name(), maxAge); cerr == nil && cached != nil {
+			name := src.Name()
+			if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(store, bookID, name, maxAge); cerr == nil && cached != nil {
 				var cr []metadata.BookMetadata
 				if jerr := json.Unmarshal(cached.Results, &cr); jerr == nil && len(cr) > 0 {
-					metaResults, sourceName, cacheHit = cr, src.Name(), true
+					metaResults, sourceName, cacheHit = cr, name, true
 					break
 				}
 			}
-			var ferr error
-			if w.authorName != "" {
-				metaResults, ferr = src.SearchByTitleAndAuthor(ctx, searchTitle, w.authorName)
+			if err := sem.acquire(gctx, name); err != nil {
+				return err
+			}
+			ok := func() bool {
+				defer sem.release(name)
+				var ferr error
+				if w.authorName != "" {
+					metaResults, ferr = src.SearchByTitleAndAuthor(gctx, searchTitle, w.authorName)
+					if ferr == nil && len(metaResults) > 0 {
+						sourceName = name
+						return true
+					}
+				}
+				metaResults, ferr = src.SearchByTitle(gctx, searchTitle)
 				if ferr == nil && len(metaResults) > 0 {
-					sourceName = src.Name()
-					break
+					sourceName = name
+					return true
 				}
-			}
-			metaResults, ferr = src.SearchByTitle(ctx, searchTitle)
-			if ferr == nil && len(metaResults) > 0 {
-				sourceName = src.Name()
+				return false
+			}()
+			if ok {
 				break
 			}
 		}
@@ -589,10 +759,10 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 					_ = database.PutCachedMetadataFetch(store, bookID, sourceName, blob, 0)
 				}
 			}
-			found++
+			found.Add(1)
 			resultStatus = "cached"
 		} else {
-			notFound++
+			notFound.Add(1)
 		}
 		_ = store.CreateOperationResult(&database.OperationResult{
 			OperationID: opID,
@@ -602,24 +772,32 @@ func (s *Server) runBulkMetadataFetchForBookIDs(
 		})
 
 		n := atomic.AddInt64(&completed, 1)
-		if i%50 == 0 || int(n) == totalBooks {
-			_ = progress.UpdateProgress(int(n), totalBooks,
-				fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found, notFound))
+		if n%50 == 0 || int(n) == totalBooks {
+			reportProgress(int(n), totalBooks,
+				fmt.Sprintf("fetched %d/%d — cached:%d not_found:%d", n, totalBooks, found.Load(), notFound.Load()))
 		}
 		if !cacheHit && sourceName != "" && i < len(work)-1 {
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-gctx.Done():
+				return gctx.Err()
 			case <-time.After(200 * time.Millisecond):
 			}
 		}
+		return nil
+	}
+
+	if err := runBookFetchPool(ctx, bulkFetchWorkers(), len(work), processOne); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	finalCount := atomic.LoadInt64(&completed)
 	_ = progress.UpdateProgress(int(finalCount), totalBooks,
-		fmt.Sprintf("complete — cached:%d not_found:%d", found, notFound))
+		fmt.Sprintf("complete — cached:%d not_found:%d", found.Load(), notFound.Load()))
 	op.SetStatus("success")
-	logging.Info(ctx, "bulk-metadata-fetch-ids complete", "finalCount", finalCount, "found", found, "notFound", notFound)
+	logging.Info(ctx, "bulk-metadata-fetch-ids complete", "finalCount", finalCount, "found", found.Load(), "notFound", notFound.Load())
 	return nil
 }
 

--- a/internal/server/metadata_ops_test.go
+++ b/internal/server/metadata_ops_test.go
@@ -1,0 +1,326 @@
+// file: internal/server/metadata_ops_test.go
+// version: 1.1.0
+// guid: 9c1e4a77-5b2d-4f83-9a10-2e7c6b8d4f01
+// last-edited: 2026-07-11
+
+// Package server tests for TASK-05 (INIT-3-T3): the bulk metadata fetch outer
+// loop now runs on a bounded errgroup pool with a per-provider semaphore. These
+// tests pin the concurrency contract that is otherwise invisible to CI:
+//
+//   - the worker pool never exceeds its configured limit (and actually reaches it);
+//   - the per-provider semaphore never allows more than perProviderFetchCap
+//     in-flight calls to one source (and actually reaches it);
+//   - two concurrent calls through a ProtectedSource are race-free;
+//   - resume-skip, counter-exactness, and context cancellation still hold when
+//     the outer loop is parallel.
+//
+// Metadata sources are disabled (config.AppConfig.MetadataSources = nil) for the
+// end-to-end run so BuildSourceChain() is empty and no book makes a real network
+// call — every book deterministically resolves to "not_found", which lets us
+// assert exact counter/row behavior under concurrency.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	"github.com/falkcorp/audiobook-organizer/internal/operations"
+)
+
+// concurrentFakeSource records the maximum number of overlapping search calls it
+// ever saw, so a test can assert a concurrency cap was respected AND reached.
+type concurrentFakeSource struct {
+	name     string
+	delay    time.Duration
+	inFlight atomic.Int32
+	maxSeen  atomic.Int32
+}
+
+func (f *concurrentFakeSource) Name() string { return f.name }
+
+func (f *concurrentFakeSource) observe() {
+	cur := f.inFlight.Add(1)
+	for {
+		m := f.maxSeen.Load()
+		if cur <= m || f.maxSeen.CompareAndSwap(m, cur) {
+			break
+		}
+	}
+	time.Sleep(f.delay)
+	f.inFlight.Add(-1)
+}
+
+func (f *concurrentFakeSource) SearchByTitle(_ context.Context, _ string) ([]metadata.BookMetadata, error) {
+	f.observe()
+	return nil, nil
+}
+
+func (f *concurrentFakeSource) SearchByTitleAndAuthor(_ context.Context, _, _ string) ([]metadata.BookMetadata, error) {
+	f.observe()
+	return nil, nil
+}
+
+// TestProviderSemaphore_CapRespectedAndReached drives many goroutines through the
+// real acquire/release around one source and asserts in-flight never exceeds the
+// cap but does reach it (so an accidentally-serialized path can't vacuously pass).
+func TestProviderSemaphore_CapRespectedAndReached(t *testing.T) {
+	src := &concurrentFakeSource{name: "fake", delay: 15 * time.Millisecond}
+	chain := []metadata.MetadataSource{src}
+	sem := newProviderSemaphore(chain, perProviderFetchCap)
+
+	const goroutines = 24
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := sem.acquire(ctx, src.name); err != nil {
+				return
+			}
+			defer sem.release(src.name)
+			_, _ = src.SearchByTitle(ctx, "t")
+		}()
+	}
+	wg.Wait()
+
+	if got := src.maxSeen.Load(); int(got) > perProviderFetchCap {
+		t.Fatalf("per-provider cap exceeded: max in-flight %d > cap %d", got, perProviderFetchCap)
+	}
+	if got := src.maxSeen.Load(); int(got) < perProviderFetchCap {
+		t.Fatalf("per-provider cap never reached: max in-flight %d < cap %d (pool may be serialized)", got, perProviderFetchCap)
+	}
+}
+
+// TestRunBookFetchPool_WorkerCapRespectedAndReached asserts the errgroup pool
+// honors its worker limit and actually saturates it.
+func TestRunBookFetchPool_WorkerCapRespectedAndReached(t *testing.T) {
+	const workers = 4
+	var inFlight, maxSeen atomic.Int32
+	err := runBookFetchPool(context.Background(), workers, 64, func(_ context.Context, _ int) error {
+		cur := inFlight.Add(1)
+		for {
+			m := maxSeen.Load()
+			if cur <= m || maxSeen.CompareAndSwap(m, cur) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		inFlight.Add(-1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := maxSeen.Load(); int(got) > workers {
+		t.Fatalf("worker cap exceeded: max in-flight %d > workers %d", got, workers)
+	}
+	if got := maxSeen.Load(); int(got) < workers {
+		t.Fatalf("worker cap never reached: max in-flight %d < workers %d (pool may be serialized)", got, workers)
+	}
+}
+
+// TestRunBookFetchPool_CtxCancelStopsPromptly asserts a mid-run cancellation
+// propagates as ctx.Err() from g.Wait and stops processing further items.
+func TestRunBookFetchPool_CtxCancelStopsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var processed atomic.Int32
+	const total = 200
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	err := runBookFetchPool(ctx, 4, total, func(gctx context.Context, _ int) error {
+		select {
+		case <-gctx.Done():
+			return gctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			processed.Add(1)
+			return nil
+		}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := processed.Load(); int(got) >= total {
+		t.Fatalf("expected cancellation to stop processing early, but processed all %d items", got)
+	}
+}
+
+// TestProtectedSource_ConcurrentCallsRaceFree wraps a fake in the real
+// ProtectedSource breaker and hits it with cap-many concurrent goroutines. Run
+// under -race, this proves the breaker's mutable counters are safe at cap 2.
+func TestProtectedSource_ConcurrentCallsRaceFree(t *testing.T) {
+	ps := metadata.NewProtectedSource(&concurrentFakeSource{name: "fake", delay: 2 * time.Millisecond}, 5, 30*time.Second)
+	var wg sync.WaitGroup
+	for i := 0; i < perProviderFetchCap*8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = ps.SearchByTitle(context.Background(), "t")
+			_, _ = ps.SearchByTitleAndAuthor(context.Background(), "t", "a")
+		}()
+	}
+	wg.Wait()
+}
+
+// recordingStore embeds MockStore and captures CreateOperationResult rows plus a
+// seedable GetOperationResults response so resume/counter behavior is observable.
+type recordingStore struct {
+	*database.MockStore
+	mu       sync.Mutex
+	created  []*database.OperationResult
+	existing []database.OperationResult
+}
+
+func (r *recordingStore) CreateOperationResult(res *database.OperationResult) error {
+	r.mu.Lock()
+	r.created = append(r.created, res)
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingStore) GetOperationResults(_ string) ([]database.OperationResult, error) {
+	return r.existing, nil
+}
+
+func (r *recordingStore) createdCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.created)
+}
+
+func newRecordingStore(books map[string]*database.Book) *recordingStore {
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b, ok := books[id]
+			if !ok {
+				return nil, nil
+			}
+			return b, nil
+		},
+	}
+	return &recordingStore{MockStore: mock}
+}
+
+func makeBooks(n int) (map[string]*database.Book, []string) {
+	books := make(map[string]*database.Book, n)
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("book-%03d", i)
+		books[id] = &database.Book{ID: id, Title: fmt.Sprintf("Title %03d", i)}
+		ids = append(ids, id)
+	}
+	return books, ids
+}
+
+// TestRunBulkMetadataFetchForBookIDs_CountersExactUnderConcurrency runs the real
+// parallel op with sources disabled: every book resolves to not_found and writes
+// exactly one result row. Asserts the row count is exact (no double/under count).
+func TestRunBulkMetadataFetchForBookIDs_CountersExactUnderConcurrency(t *testing.T) {
+	disableMetadataSourcesForTest(t)
+
+	const n = 250
+	books, ids := makeBooks(n)
+	store := newRecordingStore(books)
+	srv := &Server{store: store.MockStore, metadataFetchService: metafetch.NewService(store)}
+
+	err := srv.runBulkMetadataFetchForBookIDs(
+		context.Background(), "op-counters", ids,
+		operations.BulkMetadataFetchParams{}, store, fastpathNoopProgress{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := store.createdCount(); got != n {
+		t.Fatalf("expected exactly %d result rows, got %d", n, got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, r := range store.created {
+		if r.Status != "not_found" {
+			t.Fatalf("expected not_found (sources disabled), got %q for %s", r.Status, r.BookID)
+		}
+	}
+}
+
+// TestRunBulkMetadataFetchForBookIDs_ResumeSkipExact seeds existing result rows
+// and asserts those books are skipped (no new row) while the rest are processed.
+func TestRunBulkMetadataFetchForBookIDs_ResumeSkipExact(t *testing.T) {
+	disableMetadataSourcesForTest(t)
+
+	const n = 120
+	books, ids := makeBooks(n)
+	store := newRecordingStore(books)
+	// Mark the first 30 as already done.
+	const alreadyDone = 30
+	for i := 0; i < alreadyDone; i++ {
+		store.existing = append(store.existing, database.OperationResult{OperationID: "op-resume", BookID: ids[i], Status: "cached"})
+	}
+	srv := &Server{store: store.MockStore, metadataFetchService: metafetch.NewService(store)}
+
+	err := srv.runBulkMetadataFetchForBookIDs(
+		context.Background(), "op-resume", ids,
+		operations.BulkMetadataFetchParams{}, store, fastpathNoopProgress{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := store.createdCount(), n-alreadyDone; got != want {
+		t.Fatalf("resume-skip wrong: expected %d new rows, got %d", want, got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	seen := make(map[string]bool)
+	for _, r := range store.created {
+		seen[r.BookID] = true
+	}
+	for i := 0; i < alreadyDone; i++ {
+		if seen[ids[i]] {
+			t.Fatalf("book %s was already done but got re-processed", ids[i])
+		}
+	}
+}
+
+// TestRunBulkMetadataFetchForBookIDs_CtxCanceledReturnsErr asserts that a
+// pre-canceled context makes the op return context.Canceled (exercising the
+// post-Wait ctx check) without processing all books.
+func TestRunBulkMetadataFetchForBookIDs_CtxCanceledReturnsErr(t *testing.T) {
+	disableMetadataSourcesForTest(t)
+
+	const n = 500
+	books, ids := makeBooks(n)
+	store := newRecordingStore(books)
+	srv := &Server{store: store.MockStore, metadataFetchService: metafetch.NewService(store)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := srv.runBulkMetadataFetchForBookIDs(
+		ctx, "op-cancel", ids,
+		operations.BulkMetadataFetchParams{}, store, fastpathNoopProgress{},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := store.createdCount(); got >= n {
+		t.Fatalf("expected cancellation to stop processing early, processed %d/%d", got, n)
+	}
+}
+
+// NOTE: runBulkMetadataFetchAll is intentionally NOT covered by an end-to-end test
+// here. Unlike the by-ID variant, when the source chain is empty it falls back to a
+// real metadata.NewAudibleClient() (metadata_ops.go ~L239), so disabling sources
+// does not make it hermetic — a naive end-to-end test issues live Audible calls
+// (slow and flaky). The All rewrite reuses the SAME directly-tested primitives
+// (runBookFetchPool, providerSemaphore) and the same processOne shape as the by-ID
+// path (covered above); reviewers should line-check the All variant's work-building
+// and source-chain wrapping against those tested paths.


### PR DESCRIPTION
## Summary (TASK-05 / INIT-3-T3) — ⚠ review-critical, NO self-merge

Replaces the serial per-book loops in `runBulkMetadataFetchForBookIDs` and `runBulkMetadataFetchAll` (`internal/server/metadata_ops.go`) with a bounded `errgroup.Group` + `SetLimit` worker pool (default **4 workers**, from `config.AppConfig.MetadataScoring.BulkFetchWorkers`, TASK-02 merged) plus a per-source-name semaphore (**fixed cap 2 in-flight per provider**). The per-book source chain stays **sequential** (priority early-exit, `ProtectedSource` circuit breakers, Hardcover 60-rpm limiter untouched). Op contract, resume-via-`OperationResult` rows, and every-50 progress cadence are unchanged; `found`/`notFound` are now `atomic.Int64`, progress calls are mutex-serialized.

### Extracted primitives (directly unit-tested)
- `runBookFetchPool(ctx, workers, n, processOne)` — the bounded errgroup pool; correctness of cancellation is the **post-`Wait()` `ctx.Err()` check** (not just the dispatch-loop break).
- `providerSemaphore` — per-name buffered-channel semaphore, ctx-aware acquire/release, wraps live search calls only (cache reads / result writes stay outside).

### Acceptance criteria
- [x] `grep SetLimit internal/server/metadata_ops.go` hits (bounded errgroup pool present)
- [x] `grep 'for i, w := range work'` returns 0 hits (serial loop gone)
- [x] Per-provider semaphore exists and is tested (max in-flight per source ≤ 2 **and reached**)
- [x] Resume, counter-exactness, and ctx-cancel tests green under `-race`
- [x] Op registration untouched: `git diff origin/main -- metadata_ops.go` shows 0 changed `def_id`/`RegisterBulkMetadataFetchOp`/contract lines
- [x] Anti-over-suppression: N/A (no filter/guard/veto/skip/dedupe path added; fragment-skip preserved)
- [x] Tests green; `go vet` clean; scoped staticcheck on changed files = 0 findings (repo-wide staticcheck red is pre-existing #1796)
- [x] File headers bumped on every changed file

### Testing
- `go test ./internal/server/ -run 'BulkMetadataFetch|BulkFetch|ProviderSemaphore|ProtectedSource_Concurrent|RunBookFetchPool' -race` — 13 pass (10 new/relevant + 3 pre-existing bulk-fetch).
- Full `internal/server` package: `ok … 1136s` (package is legitimately slow — Makefile notes ~421s; gate uses `-timeout 25m`).

### ⚠ Reviewer note — line-check the `runBulkMetadataFetchAll` rewrite
`runBulkMetadataFetchAll` has **no end-to-end test**: unlike the by-ID variant it falls back to a real `metadata.NewAudibleClient()` when the source chain is empty (~L239), so "disable sources" is not hermetic and a naive test would make live Audible calls. It reuses the same directly-tested primitives and the same `processOne` shape as the by-ID path (which IS end-to-end tested for counters/resume/cancel). Please line-review the All variant's work-building (`GetAllBooksCore`/`BookCore`/`SkipCached`/orig-title retry) and its semaphore wrapping against those tested paths.

**Do NOT self-merge — coordinator/human line review of the concurrency diff is a hard precondition (races/resume regressions are partially invisible to CI).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv