### PR TITLE
fix(dedup): align engine part-vs-whole veto ratio 0.6 -> 0.5 with dataset rule (INIT-1 T8)

### DIFF
--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.58.0
+// version: 1.59.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-11
 
@@ -44,7 +44,8 @@ const minFingerprintMatchSeconds = 60
 // it is being compared against (CONS-15). Conservative on purpose: genuine
 // single-file duplicates of comparable length must never be suppressed, only
 // pairs where the single-file side is clearly a small slice of the whole.
-const partVsWholeDurationRatioMax = 0.6
+// aligned with dataset/rules.go partVsWholeRatioMax (INIT-1 T8)
+const partVsWholeDurationRatioMax = 0.5
 
 // Engine orchestrates a 3-layer dedup system:
 //   - Layer 1: Exact matching (free, instant) — same file hash, ISBN/ASIN, or near-identical titles

--- a/internal/dedup/engine_part_vs_whole_test.go
+++ b/internal/dedup/engine_part_vs_whole_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine_part_vs_whole_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6d3a9f21-4b7c-4e58-9a01-2f5c8d6e7b34
-// last-edited: 2026-07-01
+// last-edited: 2026-07-11
 
 // Regression guard for CONS-15: upsertExactCandidate must reject a pair where
 // one side is a single-file book whose duration is a small fraction of the
@@ -73,5 +73,87 @@ func TestUpsertExactCandidate_ComparableSingleFilesStillPersisted(t *testing.T) 
 	cands := pendingCandidates(t, es)
 	if len(cands) != 1 {
 		t.Errorf("expected 1 candidate for comparable single-file pair, got %d: %+v", len(cands), cands)
+	}
+}
+
+// TestIsPartVsWholeMismatchAlignedRatio pins the veto boundary after aligning
+// partVsWholeDurationRatioMax from 0.6 to 0.5 (INIT-1 T8), matching the
+// dataset miner's partVsWholeRatioMax. The whole side is a two-file book
+// totalling 1000; the part side is a single file whose duration sets the ratio.
+//   - ratio 0.49 (<0.5): still vetoed as a mismatch.
+//   - ratio 0.55 ([0.5,0.6)): NO LONGER vetoed — anti-over-suppression proof
+//     that the veto narrowed rather than widened (was suppressed at 0.6).
+//   - ratio 0.70 (>0.6): unchanged, never vetoed.
+//
+// Zero/unknown-duration handling (non-positive part or whole → false) is left
+// exactly as-is and asserted below.
+func TestIsPartVsWholeMismatchAlignedRatio(t *testing.T) {
+	const wholeTotal = 1000 // two files of 500 each
+
+	cases := []struct {
+		name         string
+		partDuration int
+		wantMismatch bool
+	}{
+		{"ratio_0.49_vetoed", 490, true},
+		{"ratio_0.55_not_vetoed_narrowed_band", 550, false},
+		{"ratio_0.70_not_vetoed_unchanged", 700, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, mock, _ := setupTestEngine(t)
+
+			a := primaryBook("A", "Real Book Title")
+			b := primaryBook("B", "Real Book Title")
+
+			mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+				switch bookID {
+				case "A":
+					// Single-file "part" side.
+					return []database.BookFile{{ID: "FA1", BookID: "A", Duration: tc.partDuration}}, nil
+				case "B":
+					// Two-file "whole" side totalling wholeTotal.
+					return []database.BookFile{
+						{ID: "FB1", BookID: "B", Duration: wholeTotal / 2},
+						{ID: "FB2", BookID: "B", Duration: wholeTotal / 2},
+					}, nil
+				}
+				return nil, nil
+			}
+
+			if got := engine.isPartVsWholeMismatch(a, b); got != tc.wantMismatch {
+				t.Errorf("isPartVsWholeMismatch(part=%d, whole=%d) = %v, want %v",
+					tc.partDuration, wholeTotal, got, tc.wantMismatch)
+			}
+		})
+	}
+}
+
+// TestIsPartVsWholeMismatchNonPositiveDurations asserts the zero/unknown
+// duration guard is unchanged: a non-positive part or whole total is never a
+// mismatch, regardless of the ratio constant.
+func TestIsPartVsWholeMismatchNonPositiveDurations(t *testing.T) {
+	engine, mock, _ := setupTestEngine(t)
+
+	a := primaryBook("A", "Real Book Title")
+	b := primaryBook("B", "Real Book Title")
+
+	mock.GetBookFilesFunc = func(bookID string) ([]database.BookFile, error) {
+		switch bookID {
+		case "A":
+			// Zero-duration single file (unknown duration).
+			return []database.BookFile{{ID: "FA1", BookID: "A", Duration: 0}}, nil
+		case "B":
+			return []database.BookFile{
+				{ID: "FB1", BookID: "B", Duration: 500},
+				{ID: "FB2", BookID: "B", Duration: 500},
+			}, nil
+		}
+		return nil, nil
+	}
+
+	if engine.isPartVsWholeMismatch(a, b) {
+		t.Error("isPartVsWholeMismatch with zero part duration = true, want false (guard must stay)")
 	}
 }


### PR DESCRIPTION
The engine vetoed candidate emission at duration ratio < 0.6 while the
gold-label miner labels part-vs-whole at < 0.5, so the [0.5, 0.6) band was
suppressed before it could ever be labeled. Single-const alignment; lands
after INIT-2's engine.go waves per the file-ownership partition.

Added TestIsPartVsWholeMismatchAlignedRatio (0.49 vetoed, 0.55 now NOT
vetoed proving the veto narrowed, 0.70 unchanged) and
TestIsPartVsWholeMismatchNonPositiveDurations pinning the zero-duration
guard. No existing 0.6-era assertions required updating.

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
