### PR TITLE
feat(dedup): suspicious-label review queue with one-click human override (INIT-1 T4)

### DIFF
--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
 // last-edited: 2026-07-11
 
@@ -58,6 +58,107 @@ func (h *Handler) ListDedupLabels(c *gin.Context) {
 		"total":  total,
 		"limit":  filter.Limit,
 		"offset": filter.Offset,
+	})
+}
+
+// suspiciousRow is a labeled example plus the reasons it was flagged as
+// suspicious, so the review UI can show WHY a rule-sourced not_dup is being
+// surfaced for human confirmation. LabeledExample is embedded so its fields
+// promote to the top level of the JSON object (mirroring ListDedupLabels rows).
+type suspiciousRow struct {
+	database.LabeledExample
+	SuspicionReasons []string `json:"suspicion_reasons"`
+}
+
+// isSuspiciousLabel: rule-sourced not_dup with duplicate-shaped evidence.
+func isSuspiciousLabel(ex database.LabeledExample) bool {
+	return len(suspicionReasons(ex)) > 0
+}
+
+// suspicionReasons returns the human-readable evidence that makes a rule-sourced
+// not_dup label suspicious, or nil when the row is not suspicious. Only
+// rule-sourced rows can fire (human/auto rows are never second-guessed here).
+// Empty/unknown fields never fire an arm — they are non-disqualifying, the row
+// simply isn't suspicious on that evidence.
+func suspicionReasons(ex database.LabeledExample) []string {
+	if ex.LabelSource != "rule" {
+		return nil
+	}
+	var reasons []string
+	// Arm (a) — TRANSITIONAL: reuses the exported dataset.SharesIdentity helper
+	// (same ASIN / same version-group / identical primary path). After TASK-07
+	// re-mines with TASK-01's guard, identity-sharing pairs are emitted as
+	// "unsure" (not rule not_dup), so this arm can only surface the historical
+	// pre-re-mine backlog and then goes quiet. The queue's durable value is arms
+	// (b)/(c)/(d). One identity implementation, two consumers — do NOT
+	// re-implement identity comparisons here.
+	if dataset.SharesIdentity(ex) {
+		reasons = append(reasons, "shares hard identity (ASIN / version-group / path)")
+	}
+	// Arm (b) — landed in a duplicate-likely band.
+	if ex.Band == "CERTAIN" || ex.Band == "HIGH" {
+		reasons = append(reasons, "duplicate-likely band ("+ex.Band+")")
+	}
+	// Arm (c) — near-identical embedding cosine.
+	if ex.Similarity != nil && *ex.Similarity >= 0.95 {
+		reasons = append(reasons, "cosine similarity >= 0.95")
+	}
+	// Arm (d) — same title with the ms/sec duration-ratio signature (~0.001).
+	if ex.A.Title != "" && ex.A.Title == ex.B.Title && ex.DurationRatio > 0 && ex.DurationRatio < 0.01 {
+		reasons = append(reasons, "ms/sec duration-ratio signature (identical title)")
+	}
+	return reasons
+}
+
+// ListSuspiciousDedupLabels handles GET /api/v1/dedup/labels/suspicious — the
+// suspicious-label review queue. It loads every rule-sourced not_dup label and
+// surfaces only those carrying duplicate-shaped evidence (see suspicionReasons),
+// so a reviewer can one-click override them via the existing
+// POST /dedup/labels/:id/override route. Read-only: it never mutates a label.
+//
+// The suspicion predicate is an in-handler filter (not a store index) over the
+// not_dup rows — trivial per-row string compares at ~7k-row dataset scale.
+// Pagination mirrors ListDedupLabels (limit/offset), applied to the filtered
+// set; total is the count of suspicious rows for the same predicate.
+func (h *Handler) ListSuspiciousDedupLabels(c *gin.Context) {
+	es := h.embeddingStore
+	if es == nil {
+		httputil.RespondWithServiceUnavailable(c, "embedding store not available")
+		return
+	}
+
+	// Limit:0 = load all not_dup rows; the suspicion predicate + pagination are
+	// applied in-handler below.
+	all, err := es.ListLabeledExamples(database.LabeledExampleFilter{Label: labelNotDup, Limit: 0})
+	if err != nil {
+		httputil.InternalError(c, "failed to list labeled examples", err)
+		return
+	}
+
+	suspicious := make([]suspiciousRow, 0)
+	for _, ex := range all {
+		if !isSuspiciousLabel(ex) {
+			continue
+		}
+		suspicious = append(suspicious, suspiciousRow{LabeledExample: ex, SuspicionReasons: suspicionReasons(ex)})
+	}
+
+	total := len(suspicious)
+	limit := clampAtoi(c.Query("limit"), 50, 1, 500)
+	offset := clampAtoi(c.Query("offset"), 0, 0, 1<<31)
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"labels": suspicious[offset:end],
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
 	})
 }
 

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/dedup/label_review_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8a3e1c46-9b20-4d75-8f31-2a6e0c9d5b39
 // last-edited: 2026-07-11
 
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	deduphandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/dedup"
 	"github.com/gin-gonic/gin"
 )
 
@@ -284,6 +285,181 @@ func TestExportLabeledExamples_DedupesByPairDefaultAndRaw(t *testing.T) {
 func TestExportLabeledExamples_NoEmbedStore(t *testing.T) {
 	h, _ := newHandler(t, noEmbed)
 	w := doReq(t, h.ExportLabeledExamples, http.MethodGet, "/api/v1/dedup/labels/export", nil, nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ───────────────────────── suspicious-label review queue (T4) ────────────────
+
+// upsertEx writes an arbitrary LabeledExample with a distinct book-pair derived
+// from candID (so no pair collides), applying opt to shape the evidence fields.
+func upsertEx(t *testing.T, d testDeps, candID int64, label, source string, opt func(*database.LabeledExample)) {
+	t.Helper()
+	ex := database.LabeledExample{
+		CandidateID: candID,
+		EntityAID:   fmt.Sprintf("a%d", candID),
+		EntityBID:   fmt.Sprintf("b%d", candID),
+		Layer:       "exact",
+		Label:       label,
+		LabelSource: source,
+		LabelReason: "seed",
+	}
+	if opt != nil {
+		opt(&ex)
+	}
+	if err := d.es.UpsertLabeledExample(ex); err != nil {
+		t.Fatalf("UpsertLabeledExample: %v", err)
+	}
+}
+
+// getSuspicious drives ListSuspiciousDedupLabels and returns total + rows.
+func getSuspicious(t *testing.T, h *deduphandler.Handler) (int, []map[string]any) {
+	t.Helper()
+	w := doReq(t, h.ListSuspiciousDedupLabels, http.MethodGet, "/api/v1/dedup/labels/suspicious", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	return decodeLabels(t, w)
+}
+
+func fptr(v float64) *float64 { return &v }
+
+// TestSuspiciousPredicateIdentity covers arm (a): a rule not_dup that shares hard
+// identity (ASIN, version group, or identical primary path) is flagged, and the
+// flag routes through the exported dataset.SharesIdentity helper.
+func TestSuspiciousPredicateIdentity(t *testing.T) {
+	cases := []struct {
+		name string
+		opt  func(*database.LabeledExample)
+	}{
+		{"asin", func(ex *database.LabeledExample) { ex.A.ASIN, ex.B.ASIN = "B00SAME", "B00SAME" }},
+		{"version_group", func(ex *database.LabeledExample) { ex.A.VersionGroupID, ex.B.VersionGroupID = "vg-1", "vg-1" }},
+		{"path", func(ex *database.LabeledExample) { ex.A.PrimaryPath, ex.B.PrimaryPath = "/lib/x.m4b", "/lib/x.m4b" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, d := newHandler(t)
+			upsertEx(t, d, 1, "not_dup", "rule", tc.opt)
+			total, rows := getSuspicious(t, h)
+			if total != 1 || len(rows) != 1 {
+				t.Fatalf("expected 1 suspicious row, got total=%d len=%d", total, len(rows))
+			}
+			reasons, _ := rows[0]["suspicion_reasons"].([]any)
+			if len(reasons) == 0 {
+				t.Fatalf("expected a suspicion reason; row=%v", rows[0])
+			}
+		})
+	}
+}
+
+// TestSuspiciousPredicateBand covers arm (b): a rule not_dup in a CERTAIN/HIGH
+// band is flagged; a LOW-band one (all else disjoint) is not.
+func TestSuspiciousPredicateBand(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "rule", func(ex *database.LabeledExample) { ex.Band = "CERTAIN" })
+	upsertEx(t, d, 2, "not_dup", "rule", func(ex *database.LabeledExample) { ex.Band = "HIGH" })
+	upsertEx(t, d, 3, "not_dup", "rule", func(ex *database.LabeledExample) { ex.Band = "LOW" })
+	total, _ := getSuspicious(t, h)
+	if total != 2 {
+		t.Fatalf("expected 2 suspicious (CERTAIN,HIGH), got %d", total)
+	}
+}
+
+// TestSuspiciousPredicateSimilarity covers arm (c): cosine >= 0.95 flags; below
+// does not.
+func TestSuspiciousPredicateSimilarity(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "rule", func(ex *database.LabeledExample) { ex.Similarity = fptr(0.96) })
+	upsertEx(t, d, 2, "not_dup", "rule", func(ex *database.LabeledExample) { ex.Similarity = fptr(0.80) })
+	total, _ := getSuspicious(t, h)
+	if total != 1 {
+		t.Fatalf("expected 1 suspicious (sim>=0.95), got %d", total)
+	}
+}
+
+// TestSuspiciousPredicateMsSecSignature covers arm (d): identical title with a
+// ms/sec duration-ratio (~0.001) flags; a sane ratio does not.
+func TestSuspiciousPredicateMsSecSignature(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "rule", func(ex *database.LabeledExample) {
+		ex.A.Title, ex.B.Title = "Same Book", "Same Book"
+		ex.DurationRatio = 0.001
+	})
+	upsertEx(t, d, 2, "not_dup", "rule", func(ex *database.LabeledExample) {
+		ex.A.Title, ex.B.Title = "Same Book", "Same Book"
+		ex.DurationRatio = 0.30
+	})
+	total, _ := getSuspicious(t, h)
+	if total != 1 {
+		t.Fatalf("expected 1 suspicious (ms/sec signature), got %d", total)
+	}
+}
+
+// TestSuspiciousPredicateCleanRuleLabelNotFlagged is the anti-over-suppression
+// case: a rule not_dup with disjoint ASINs/paths, LOW band, similarity 0.5, and
+// a sane ratio 0.3 carries NO duplicate-shaped evidence and must NOT be flagged.
+func TestSuspiciousPredicateCleanRuleLabelNotFlagged(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "rule", func(ex *database.LabeledExample) {
+		ex.A.ASIN, ex.B.ASIN = "B00AAA", "B00BBB"
+		ex.A.PrimaryPath, ex.B.PrimaryPath = "/lib/a.m4b", "/lib/b.m4b"
+		ex.A.Title, ex.B.Title = "Book A", "Book B"
+		ex.Band = "LOW"
+		ex.Similarity = fptr(0.5)
+		ex.DurationRatio = 0.3
+	})
+	total, _ := getSuspicious(t, h)
+	if total != 0 {
+		t.Fatalf("clean rule label must not be flagged; got total=%d", total)
+	}
+}
+
+// TestSuspiciousPredicateEmptyFieldsNotFlagged asserts a rule not_dup with
+// all-empty identity, no band, no similarity, and zero ratio is not suspicious
+// (unknown fields are non-disqualifying, never firing an arm).
+func TestSuspiciousPredicateEmptyFieldsNotFlagged(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "rule", nil) // no evidence set at all
+	total, _ := getSuspicious(t, h)
+	if total != 0 {
+		t.Fatalf("empty-evidence rule label must not be flagged; got total=%d", total)
+	}
+}
+
+// TestSuspiciousPredicateHumanLabelNeverFlagged asserts human-sourced rows are
+// excluded regardless of evidence — even a shared ASIN plus CERTAIN band does
+// not surface a human label into the queue (only rule rows are second-guessed).
+func TestSuspiciousPredicateHumanLabelNeverFlagged(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "not_dup", "human", func(ex *database.LabeledExample) {
+		ex.A.ASIN, ex.B.ASIN = "B00SAME", "B00SAME"
+		ex.Band = "CERTAIN"
+		ex.Similarity = fptr(0.99)
+	})
+	total, _ := getSuspicious(t, h)
+	if total != 0 {
+		t.Fatalf("human label must never be flagged; got total=%d", total)
+	}
+}
+
+// TestSuspiciousExcludesNonNotDupAndNonRule confirms the queue only ever
+// contains rule-sourced not_dup rows: a true_dup rule row and an auto_high_conf
+// not_dup row (both with strong evidence) are excluded.
+func TestSuspiciousExcludesNonNotDupAndNonRule(t *testing.T) {
+	h, d := newHandler(t)
+	upsertEx(t, d, 1, "true_dup", "rule", func(ex *database.LabeledExample) { ex.Band = "CERTAIN" })
+	upsertEx(t, d, 2, "not_dup", "auto_high_conf", func(ex *database.LabeledExample) { ex.Band = "CERTAIN" })
+	total, _ := getSuspicious(t, h)
+	if total != 0 {
+		t.Fatalf("non-not_dup/non-rule rows must be excluded; got total=%d", total)
+	}
+}
+
+// TestSuspiciousNoEmbedStore mirrors the 503 nil-store guard.
+func TestSuspiciousNoEmbedStore(t *testing.T) {
+	h, _ := newHandler(t, noEmbed)
+	w := doReq(t, h.ListSuspiciousDedupLabels, http.MethodGet, "/api/v1/dedup/labels/suspicious", nil, nil)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d want 503; body=%s", w.Code, w.Body.String())
 	}

--- a/internal/server/wire_dedup_routes.go
+++ b/internal/server/wire_dedup_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_dedup_routes.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b8c9d0e1-f2a3-4567-bcde-890123456789
-// last-edited: 2026-07-02
+// last-edited: 2026-07-11
 
 package server
 
@@ -40,7 +40,8 @@ func (s *Server) wireDedupRoutes(
 	// C6 — gold-dataset review (the dedup feedback-loop labels).
 	protected.GET("/dedup/labels", s.perm(auth.PermLibraryView), dedupH.ListDedupLabels)
 	protected.GET("/dedup/labels/stats", s.perm(auth.PermLibraryView), dedupH.GetDedupLabelStats)
-	protected.GET("/dedup/labels/export", s.perm(auth.PermLibraryView), dedupH.ExportLabeledExamples) // C7 — JSONL export of the labeled dataset.
+	protected.GET("/dedup/labels/export", s.perm(auth.PermLibraryView), dedupH.ExportLabeledExamples)         // C7 — JSONL export of the labeled dataset.
+	protected.GET("/dedup/labels/suspicious", s.perm(auth.PermLibraryView), dedupH.ListSuspiciousDedupLabels) // INIT-1 T4 — read-only suspicious-label review queue.
 	protected.POST("/dedup/labels/:id/override", s.perm(auth.PermLibraryEditMetadata), dedupH.OverrideDedupLabel)
 	protected.POST("/dedup/candidates/merge-series", s.perm(auth.PermLibraryEditMetadata), dedupH.MergeDedupCandidateSeries)
 	protected.POST("/dedup/scan", s.perm(auth.PermScanTrigger), dedupH.TriggerDedupScan)

--- a/web/src/pages/DedupLabels.tsx
+++ b/web/src/pages/DedupLabels.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/DedupLabels.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 7e3a1c92-4b60-4d85-9f21-6a5e0c9d3f58
-// last-edited: 2026-06-28
+// last-edited: 2026-07-11
 
 // DedupLabels — the C6 gold-dataset review page for the dedup feedback loop.
 // Lists labeled dedup examples (the dedup:label: keyspace), filterable by label
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Box, Typography, Paper, Table, TableBody, TableCell, TableContainer, TableHead,
   TableRow, Chip, Select, MenuItem, FormControl, InputLabel, Button, Stack,
-  CircularProgress, Alert, Tooltip, Link as MuiLink, TextField,
+  CircularProgress, Alert, Tooltip, Link as MuiLink, TextField, Tabs, Tab,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { LabelToggle } from '../components/dedup/LabelToggle';
@@ -46,6 +46,13 @@ interface LabeledExample {
   decided_at?: string;
   a?: BookFeatures;
   b?: BookFeatures;
+}
+
+// SuspiciousExample extends a labeled row with the reasons the backend flagged
+// it (rule-sourced not_dup carrying duplicate-shaped evidence). Rendered on the
+// "Suspicious" tab where each row can be one-click overridden to a human label.
+interface SuspiciousExample extends LabeledExample {
+  suspicion_reasons?: string[];
 }
 
 interface LabelStats {
@@ -105,6 +112,94 @@ function BookCell({
   );
 }
 
+// fmtDuration renders seconds as a compact h:mm label ("—" when unknown).
+function fmtDuration(sec?: number): string {
+  if (!sec || sec <= 0) return '—';
+  const h = Math.floor(sec / 3600);
+  const m = Math.round((sec % 3600) / 60);
+  return `${h}h${m.toString().padStart(2, '0')}m`;
+}
+
+// SuspiciousQueue renders the rule-sourced not_dup labels that carry
+// duplicate-shaped evidence, with per-row one-click overrides. Each button
+// POSTs the EXISTING /dedup/labels/:id/override route (source→human) and, on
+// success, the row is removed from the queue by the parent.
+function SuspiciousQueue({
+  rows,
+  loading,
+  error,
+  pathVars,
+  onOpen,
+  onOverride,
+}: {
+  rows: SuspiciousExample[];
+  loading: boolean;
+  error: string | null;
+  pathVars: PathVar[];
+  onOpen: (id: string) => void;
+  onOverride: (candidateId: number, label: string) => void;
+}) {
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Rule-sourced <code>not_dup</code> labels carrying duplicate-shaped evidence
+        (shared ASIN/path, CERTAIN/HIGH band, cosine&nbsp;≥&nbsp;0.95, or the ms/sec
+        duration-ratio signature). Each override becomes a permanent human gold label.
+      </Typography>
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      <TableContainer component={Paper}>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell>Book A</TableCell>
+              <TableCell>Book B</TableCell>
+              <TableCell>Duration A / B</TableCell>
+              <TableCell>Why suspicious</TableCell>
+              <TableCell align="center">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <TableRow><TableCell colSpan={5} align="center"><CircularProgress size={24} sx={{ my: 2 }} /></TableCell></TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow><TableCell colSpan={5} align="center"><Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>No suspicious labels in the queue.</Typography></TableCell></TableRow>
+            ) : rows.map((r) => (
+              <TableRow key={r.candidate_id} hover>
+                <TableCell>
+                  <BookCell bookId={r.entity_a_id} title={r.a?.title} path={r.a?.primary_path} pathVars={pathVars} onOpen={onOpen} />
+                </TableCell>
+                <TableCell>
+                  <BookCell bookId={r.entity_b_id} title={r.b?.title} path={r.b?.primary_path} pathVars={pathVars} onOpen={onOpen} />
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption">{fmtDuration(r.a?.total_duration_sec)} / {fmtDuration(r.b?.total_duration_sec)}</Typography>
+                </TableCell>
+                <TableCell>
+                  <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+                    {(r.suspicion_reasons || []).map((reason) => (
+                      <Chip key={reason} size="small" color="warning" variant="outlined" label={reason} />
+                    ))}
+                  </Stack>
+                </TableCell>
+                <TableCell align="center">
+                  <Stack direction="row" spacing={1} justifyContent="center">
+                    <Button size="small" color="success" variant="outlined" onClick={() => onOverride(r.candidate_id, 'true_dup')}>
+                      Mark true_dup
+                    </Button>
+                    <Button size="small" color="error" variant="outlined" onClick={() => onOverride(r.candidate_id, 'not_dup')}>
+                      Confirm not_dup
+                    </Button>
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}
+
 export default function DedupLabels() {
   const navigate = useNavigate();
   const pathVars = usePathVars();
@@ -119,6 +214,11 @@ export default function DedupLabels() {
   const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // tab 0 = all labels (existing view), tab 1 = suspicious review queue.
+  const [tab, setTab] = useState(0);
+  const [suspRows, setSuspRows] = useState<SuspiciousExample[]>([]);
+  const [suspLoading, setSuspLoading] = useState(false);
+  const [suspError, setSuspError] = useState<string | null>(null);
   const openBook = useCallback((bookId: string) => navigate(`/library/${bookId}`), [navigate]);
 
   const loadStats = useCallback(async () => {
@@ -146,6 +246,37 @@ export default function DedupLabels() {
       await loadStats();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Override failed');
+    }
+  }, [loadStats]);
+
+  const loadSuspicious = useCallback(async () => {
+    setSuspLoading(true);
+    setSuspError(null);
+    try {
+      const r = await apiFetch(`${API_BASE}/dedup/labels/suspicious?limit=${PAGE}`);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const d = (await r.json()).data;
+      setSuspRows(d.labels || []);
+    } catch (e) {
+      setSuspError(e instanceof Error ? e.message : 'Failed to load suspicious labels');
+    } finally {
+      setSuspLoading(false);
+    }
+  }, []);
+
+  // overrideSuspicious POSTs the EXISTING override route (stamping
+  // label_source=human) and drops the row from the queue on success.
+  const overrideSuspicious = useCallback(async (candidateId: number, label: string) => {
+    try {
+      const r = await apiFetch(`${API_BASE}/dedup/labels/${candidateId}/override`, {
+        method: 'POST',
+        body: JSON.stringify({ label, reason: 'ui_override' }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      setSuspRows((current) => current.filter((row) => row.candidate_id !== candidateId));
+      await loadStats();
+    } catch (e) {
+      setSuspError(e instanceof Error ? e.message : 'Override failed');
     }
   }, [loadStats]);
 
@@ -264,6 +395,7 @@ export default function DedupLabels() {
 
   useEffect(() => { void loadStats(); }, [loadStats]);
   useEffect(() => { void load(); }, [load]);
+  useEffect(() => { if (tab === 1) void loadSuspicious(); }, [tab, loadSuspicious]);
   useEffect(() => () => { if (bandDebounceRef.current) clearTimeout(bandDebounceRef.current); }, []);
 
   return (
@@ -286,6 +418,13 @@ export default function DedupLabels() {
         </Stack>
       )}
 
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="All Labels" />
+        <Tab label="Suspicious" />
+      </Tabs>
+
+      {tab === 0 && (
+      <>
       <Stack direction="row" spacing={2} sx={{ mb: 2 }}>
         <FormControl size="small" sx={{ minWidth: 160 }}>
           <InputLabel id="dedup-label-filter-label">Label</InputLabel>
@@ -393,6 +532,19 @@ export default function DedupLabels() {
         </Typography>
         <Button disabled={offset + PAGE >= total} onClick={() => setOffset(offset + PAGE)}>Next</Button>
       </Stack>
+      </>
+      )}
+
+      {tab === 1 && (
+        <SuspiciousQueue
+          rows={suspRows}
+          loading={suspLoading}
+          error={suspError}
+          pathVars={pathVars}
+          onOpen={openBook}
+          onOverride={overrideSuspicious}
+        />
+      )}
 
       <PathVarsLegend />
     </Box>

--- a/web/src/pages/__tests__/DedupLabels.test.tsx
+++ b/web/src/pages/__tests__/DedupLabels.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/__tests__/DedupLabels.test.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4e0c7a92-8b15-4d63-9f20-3a6e1c8d5b09
-// last-edited: 2026-06-28
+// last-edited: 2026-07-11
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -27,6 +27,20 @@ const sampleRow = {
   b: { title: 'Mistborn (CD)', primary_path: `${LIBROOT}/Sanderson/Mistborn-CD/01.m4b` },
 };
 
+const suspiciousRow = {
+  candidate_id: 77,
+  entity_a_id: 'SUSA',
+  entity_b_id: 'SUSB',
+  layer: 'embedding',
+  band: 'CERTAIN',
+  label: 'not_dup',
+  label_source: 'rule',
+  label_reason: 'part_vs_whole',
+  suspicion_reasons: ['duplicate-likely band (CERTAIN)', 'cosine similarity >= 0.95'],
+  a: { title: 'The Way of Kings', primary_path: `${LIBROOT}/Sanderson/WoK/01.m4b`, total_duration_sec: 3000 },
+  b: { title: 'The Way of Kings', primary_path: `${LIBROOT}/Sanderson/WoK-dup/01.m4b`, total_duration_sec: 3010 },
+};
+
 describe('DedupLabels page', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -39,6 +53,7 @@ describe('DedupLabels page', () => {
         return jsonResponse({ data: { total: 1, by_label: { unsure: 1 }, by_source: { rule: 1 } } });
       }
       if (url.includes('/override')) return jsonResponse({ data: { status: 'updated', label: 'not_dup', label_source: 'human' } });
+      if (url.includes('/dedup/labels/suspicious')) return jsonResponse({ data: { labels: [suspiciousRow], total: 1 } });
       if (url.includes('/dedup/labels')) return jsonResponse({ data: { labels: [sampleRow], total: 1 } });
       return jsonResponse({ data: {} });
     });
@@ -100,5 +115,51 @@ describe('DedupLabels page', () => {
       expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({ label: 'not_dup' });
     });
     expect(await screen.findByText('human')).toBeInTheDocument();
+  });
+
+  it('renders suspicious rows and reasons when the Suspicious tab is opened', async () => {
+    render(
+      <MemoryRouter>
+        <DedupLabels />
+      </MemoryRouter>
+    );
+    await screen.findByText('Mistborn');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Suspicious' }));
+
+    // The suspicious pair renders with its reason chips (the pair title appears
+    // for both Book A and Book B, so assert on the unique reason text).
+    expect(await screen.findByText('cosine similarity >= 0.95')).toBeInTheDocument();
+    expect(screen.getByText('duplicate-likely band (CERTAIN)')).toBeInTheDocument();
+    expect(screen.getAllByText('The Way of Kings').length).toBeGreaterThan(0);
+
+    // The queue was fetched from the suspicious endpoint.
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => String(u).includes('/dedup/labels/suspicious'));
+      expect(call).toBeTruthy();
+    });
+  });
+
+  it('posts an override to the existing route when "Mark true_dup" is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <DedupLabels />
+      </MemoryRouter>
+    );
+    await screen.findByText('Mistborn');
+    fireEvent.click(screen.getByRole('tab', { name: 'Suspicious' }));
+    await screen.findByText('cosine similarity >= 0.95');
+
+    fireEvent.click(screen.getByRole('button', { name: /Mark true_dup/i }));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => String(u).includes('/dedup/labels/77/override'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({ label: 'true_dup' });
+    });
+    // On success the row leaves the queue (its reason chip is gone).
+    await waitFor(() => {
+      expect(screen.queryByText('cosine similarity >= 0.95')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Surfaces rule-sourced not_dup labels carrying duplicate-shaped evidence
(shared ASIN/path, CERTAIN/HIGH band, cosine >= 0.95, ms/sec ratio signature)
in the Gold Labels UI. One-click override reuses POST /dedup/labels/:id/override,
which stamps label_source=human — rows the re-mine permanently preserves.

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
