### PR TITLE
fix(dedup): normalize ms/sec durations per-file at the mining boundary (INIT-1 T2)

### DIFF
--- a/internal/database/duration_sanity.go
+++ b/internal/database/duration_sanity.go
@@ -1,7 +1,7 @@
 // file: internal/database/duration_sanity.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8b1f4d2c-5e69-4a30-9c71-2f8a6b0d4e95
-// last-edited: 2026-06-19
+// last-edited: 2026-07-11
 
 package database
 
@@ -50,6 +50,19 @@ func DurationLooksLikeMillis(fileSize int64, durationSec int) bool {
 	correctedBitsPerSec := fileSize * 8 / int64(correctedSec)
 	return correctedBitsPerSec >= minPlausibleBitsPerSec &&
 		correctedBitsPerSec <= maxPlausibleBitsPerSec
+}
+
+// NormalizeDurationSec returns durationSec/1000 when DurationLooksLikeMillis
+// reports the value is milliseconds, else durationSec unchanged. Inputs
+// <= 0 (unknown) are returned unchanged. Pure read-time twin of
+// normalizeBookFileDuration (which repairs at the write chokepoint); used by
+// the dedup dataset builder to normalize historical pre-CONS-18 rows at
+// read time.
+func NormalizeDurationSec(fileSizeBytes int64, durationSec int) int {
+	if DurationLooksLikeMillis(fileSizeBytes, durationSec) {
+		return durationSec / 1000
+	}
+	return durationSec
 }
 
 // normalizeBookFileDuration repairs a millisecond-valued Duration in place at the

--- a/internal/database/duration_sanity_test.go
+++ b/internal/database/duration_sanity_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/duration_sanity_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4e7a1b9-3d62-4f08-8a15-6b9e2c0f7d43
-// last-edited: 2026-06-19
+// last-edited: 2026-07-11
 
 package database
 
@@ -76,4 +76,29 @@ func TestNormalizeBookFileDuration(t *testing.T) {
 			t.Fatal("nil must return false")
 		}
 	})
+}
+
+func TestNormalizeDurationSecMillisDetected(t *testing.T) {
+	size := bytesForKbps(3600, 64)
+	if got := NormalizeDurationSec(size, 3600*1000); got != 3600 {
+		t.Errorf("NormalizeDurationSec(%d, %d)=%d want 3600", size, 3600*1000, got)
+	}
+}
+
+func TestNormalizeDurationSecPlausibleUnchanged(t *testing.T) {
+	size := bytesForKbps(3600, 64)
+	if got := NormalizeDurationSec(size, 3600); got != 3600 {
+		t.Errorf("NormalizeDurationSec(%d, %d)=%d want 3600 (unchanged)", size, 3600, got)
+	}
+}
+
+func TestNormalizeDurationSecUnknownUnchanged(t *testing.T) {
+	// fileSize <= 0 → unknown, return unchanged even if the value looks ms-scale.
+	if got := NormalizeDurationSec(0, 3600*1000); got != 3600*1000 {
+		t.Errorf("NormalizeDurationSec(0, %d)=%d want %d (unchanged)", 3600*1000, got, 3600*1000)
+	}
+	// duration <= 0 → unknown, return unchanged.
+	if got := NormalizeDurationSec(bytesForKbps(3600, 64), 0); got != 0 {
+		t.Errorf("NormalizeDurationSec(size, 0)=%d want 0 (unchanged)", got)
+	}
 }

--- a/internal/dedup/dataset/builder.go
+++ b/internal/dedup/dataset/builder.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 4a91c7e0-6d83-4b25-9f10-2c5a8e7d4b31
 // last-edited: 2026-07-11
 
@@ -164,7 +164,11 @@ func buildFeatures(bk *database.Book, files []database.BookFile) database.BookFe
 		if fl.AcoustIDFingerprintDurationSec > 0 {
 			total += fl.AcoustIDFingerprintDurationSec
 		} else if fl.Duration > 0 {
-			total += float64(fl.Duration)
+			// Normalize per file BEFORE summing: historical rows written before the
+			// CONS-18 write chokepoint may hold ms-scale durations. The bitrate test
+			// is a per-file contract (this file's size vs its duration), so an
+			// aggregate-level check would miss one corrupt file among clean ones.
+			total += float64(database.NormalizeDurationSec(fl.FileSize, fl.Duration))
 		}
 		if fl.AcoustIDOnlineRecordingID != "" {
 			f.RecordingIDs = append(f.RecordingIDs, fl.AcoustIDOnlineRecordingID)

--- a/internal/dedup/dataset/builder_test.go
+++ b/internal/dedup/dataset/builder_test.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/dataset/builder_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b3e7f2a1-9c45-4d80-8e62-5f1a3d6c7b90
 // last-edited: 2026-07-11
 
@@ -58,6 +58,94 @@ type fakeStore struct {
 
 func (f *fakeStore) GetBook(id string) (*database.Book, error)           { return f.books[id], nil }
 func (f *fakeStore) GetBookFiles(id string) ([]database.BookFile, error) { return f.files[id], nil }
+
+// sizeForKbps returns the byte size of a file of durationSec seconds at kbps
+// kilobits/sec, so per-file bitrate lands inside the plausible band and the
+// ms/sec heuristic behaves as it would on real rows.
+func sizeForKbps(durationSec, kbps int) int64 {
+	return int64(durationSec) * int64(kbps) * 1000 / 8
+}
+
+// TestBuildExampleNormalizesDurationRatio proves the mining boundary normalizes
+// a historical ms-scale row at read time, so an ms-vs-sec pair of the same book
+// yields a ratio ≈ 1.0 rather than ≈ 0.001. The anti-over-suppression subtest
+// proves a genuinely short part is NOT normalized and still scores low.
+func TestBuildExampleNormalizesDurationRatio(t *testing.T) {
+	t.Run("ms_vs_sec_pair_normalizes_to_1", func(t *testing.T) {
+		// Same ~5.8h audiobook at 64 kbps: A holds the corrupt ms-scale duration
+		// (20810840), B holds the correct seconds value (20810).
+		size := sizeForKbps(20810, 64) // 166_480_000 bytes
+		bkA := &database.Book{ID: "a", Title: "Same Book"}
+		bkB := &database.Book{ID: "b", Title: "Same Book"}
+		fs := &fakeStore{
+			books: map[string]*database.Book{"a": bkA, "b": bkB},
+			files: map[string][]database.BookFile{
+				"a": {{BookID: "a", FilePath: "/lib/x/a.m4b", FileSize: size, Duration: 20810840}},
+				"b": {{BookID: "b", FilePath: "/lib/x/b.m4b", FileSize: size, Duration: 20810}},
+			},
+		}
+		cand := database.DedupCandidate{ID: 30, EntityAID: "a", EntityBID: "b", Layer: "exact"}
+		ex, err := BuildExample(fs, cand)
+		if err != nil {
+			t.Fatalf("BuildExample: %v", err)
+		}
+		if ex.A.TotalDurationSec != 20810 {
+			t.Fatalf("A.TotalDurationSec = %v, want 20810 (ms-scale normalized at read time)", ex.A.TotalDurationSec)
+		}
+		if ex.B.TotalDurationSec != 20810 {
+			t.Fatalf("B.TotalDurationSec = %v, want 20810 (plausible, untouched)", ex.B.TotalDurationSec)
+		}
+		if ex.DurationRatio < 1.0-1e-9 || ex.DurationRatio > 1.0+1e-9 {
+			t.Fatalf("DurationRatio = %v, want ≈ 1.0 (not the ≈ 0.001 raw ms/sec mismatch)", ex.DurationRatio)
+		}
+	})
+
+	t.Run("genuine_short_part_still_low_ratio", func(t *testing.T) {
+		// Both durations are plausible seconds → neither is normalized. A real
+		// 300s part vs a 20000s whole must still yield a low ratio.
+		sizeA := sizeForKbps(300, 64)
+		sizeB := sizeForKbps(20000, 64)
+		bkA := &database.Book{ID: "a", Title: "Part"}
+		bkB := &database.Book{ID: "b", Title: "Whole"}
+		fs := &fakeStore{
+			books: map[string]*database.Book{"a": bkA, "b": bkB},
+			files: map[string][]database.BookFile{
+				"a": {{BookID: "a", FilePath: "/lib/x/part.m4b", FileSize: sizeA, Duration: 300}},
+				"b": {{BookID: "b", FilePath: "/lib/x/whole.m4b", FileSize: sizeB, Duration: 20000}},
+			},
+		}
+		cand := database.DedupCandidate{ID: 31, EntityAID: "a", EntityBID: "b", Layer: "exact"}
+		ex, err := BuildExample(fs, cand)
+		if err != nil {
+			t.Fatalf("BuildExample: %v", err)
+		}
+		if ex.A.TotalDurationSec != 300 || ex.B.TotalDurationSec != 20000 {
+			t.Fatalf("durations must be untouched: a=%v b=%v", ex.A.TotalDurationSec, ex.B.TotalDurationSec)
+		}
+		wantRatio := 300.0 / 20000.0
+		if ex.DurationRatio < wantRatio-1e-9 || ex.DurationRatio > wantRatio+1e-9 {
+			t.Fatalf("DurationRatio = %v, want %v (genuine short part not over-suppressed)", ex.DurationRatio, wantRatio)
+		}
+	})
+}
+
+// TestBuildFeaturesMixedCorruptFiles is the proof that normalization is per file,
+// not on the aggregate: one ms-corrupted file among clean seconds-files must sum
+// to the correct per-file-normalized total. An aggregate-level implementation
+// (normalizing the raw sum) fails this fixture.
+func TestBuildFeaturesMixedCorruptFiles(t *testing.T) {
+	// Three files, each a 1h/64 kbps part; the middle one holds an ms-scale value.
+	size := sizeForKbps(3600, 64) // 28_800_000 bytes
+	files := []database.BookFile{
+		{BookID: "x", FilePath: "/lib/x/p1.m4b", FileSize: size, Duration: 3600},
+		{BookID: "x", FilePath: "/lib/x/p2.m4b", FileSize: size, Duration: 3600000}, // ms-scale
+		{BookID: "x", FilePath: "/lib/x/p3.m4b", FileSize: size, Duration: 3600},
+	}
+	f := buildFeatures(&database.Book{ID: "x", Title: "Mixed"}, files)
+	if f.TotalDurationSec != 3*3600 {
+		t.Fatalf("TotalDurationSec = %v, want %d (per-file normalized 3×3600)", f.TotalDurationSec, 3*3600)
+	}
+}
 
 func TestBuildExample_PartVsWholeFeatures(t *testing.T) {
 	whole := &database.Book{ID: "whole", Title: "The Crafter's Defense"}


### PR DESCRIPTION
Historical BookFile rows written before the CONS-18 write-chokepoint repair
still hold millisecond-scale durations, and the dataset builder summed them
raw into TotalDurationSec, so durationRatio saw 1000x unit mismatches. Adds
database.NormalizeDurationSec (pure read-time twin of the shipped
normalizeBookFileDuration repair, same DurationLooksLikeMillis heuristic) and
applies it per file, before summing, in buildFeatures. The shipped chokepoint
repair, backfill wrapper, and importer conversion are verified untouched.

Co-Authored-By: Claude <noreply@anthropic.com>
