### PR TITLE
feat(dedup): dedup.calibrate-composite op — tune noisy-OR bands + signal confidences (INIT-1 T5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.142.0 -->
+<!-- version: 3.143.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -25,6 +25,23 @@
   `slog.Warn`s before the full-corpus fetch instead of silently scanning the whole library.
 - Documented a confirmed pre-existing bug found while authoring the tests (non-title sort +
   a filter on a non-projected field → zero books) in TODO.md; out of scope to fix here.
+
+#### July 11, 2026 - feat(dedup): dedup.calibrate-composite op — tune noisy-OR bands (INIT-1 T5)
+
+- **`dedup`** (backend) — new op `dedup.calibrate-composite`
+  (`internal/plugins/dedup/calibrate_composite.go`) that calibrates the noisy-OR composite
+  scorer against the pair-deduped gold-label set, replaying each labeled pair's stored
+  `ScoreBreakdown` signals through `unified.ComposeScore` under coordinate-wise config
+  variants. The existing `dedup.calibrate-embedding-thresholds` sweeps only a single
+  embedding cosine cut-point; ~47% of true_dup pairs score below cosine 0.98, so the
+  composite is the right calibration surface. Fail-closed coverage floor (skips + counts
+  nil-breakdown rows), bounded `errgroup` sweep pool sized to `runtime.NumCPU()`. Dry-run by
+  default. **Applicability finding:** only the four band thresholds have a config-blob
+  persistence surface (`config.DedupSignalConfig`); per-signal confidence bounds do not, so
+  the op splits into an APPLICABLE band recommendation (round 1, under baseline confidences,
+  operator-gated apply that survives restart) and ADVISORY-only confidence suggestions
+  (round 2, reported for a manual config.yaml edit, never persisted, never gates the apply).
+  Apply is refused unless every tunable band met its target. Registered in `plugin.go`.
 
 #### July 11, 2026 - docs(system): comprehensive system documentation set (DOCS-1, #1276)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.92.1 -->
-<!-- version: 9.93.0 -->
+<!-- version: 9.94.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-11 -->
 
@@ -59,6 +58,13 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
   - [x] INIT-4 T03 — batch-hydrate Bleve hits with `GetBooksByIDs` (#1882).
   - [x] INIT-2 T05 — shard full-scan `emit()` mutex; move book lookups off the pair lock, CONC-3
     (#1883).
+  - [x] INIT-1 T05 — `dedup.calibrate-composite` op: coordinate-wise noisy-OR band calibration
+    over the pair-deduped gold set (`internal/plugins/dedup/calibrate_composite.go`), dry-run
+    by default, operator-gated band apply. **Follow-up (potential future work):** per-signal
+    `MinConfidence`/`MaxConfidence` recommendations are ADVISORY-only because
+    `config.DedupSignalConfig` persists band thresholds but has no per-kind confidence field —
+    adding one (a `map[string]KindConfig` under `dedup.signals`) would let the confidence round
+    become applyable instead of a manual config.yaml edit.
   - **INIT-2's `internal/dedup/engine.go` tasks (T03 + T05) are both merged**, which unblocks
     Phase B: INIT-1 TASK-08 and INIT-4 TASK-05 (both rebase on that file) can now start.
 - **Wave 2b (4 PRs, #1885–#1888, merged 2026-07-11):** see

--- a/internal/plugins/dedup/calibrate_composite.go
+++ b/internal/plugins/dedup/calibrate_composite.go
@@ -1,0 +1,828 @@
+// file: internal/plugins/dedup/calibrate_composite.go
+// version: 1.1.0
+// guid: 4c2f7a91-8d3b-4e6a-9f10-5b7c2d1e8a34
+// last-edited: 2026-07-11
+
+// Package dedup — op dedup.calibrate-composite (INIT-1 T5).
+//
+// # Why this op exists
+//
+// The sibling op dedup.calibrate-embedding-thresholds sweeps a SINGLE embedding
+// cosine cut-point. Per the 2026-07-08 findings, ~47% of true_dup pairs score
+// below cosine 0.98, so no single embedding cut-point can serve the
+// high-confidence tier. The composite noisy-OR scorer (unified.ComposeScore) is
+// the right calibration surface because it fuses every signal a pair carries.
+// This op replays each labeled pair's stored ScoreBreakdown signal set through
+// unified.ComposeScore under candidate configs and reports the band thresholds
+// (and, advisory-only, per-signal confidence bounds) that hit a target precision.
+//
+// # Two calibration surfaces, only one of them persistable
+//
+// unified.ComposeScore reads Signal.Confidence DIRECTLY and ignores the cfg's
+// per-kind Min/MaxConfidence. So a config's confidence bounds only affect scoring
+// via collector-side CLAMPING. To make a confidence-bound sweep meaningful this op
+// re-clamps each primary signal's Confidence to the candidate [Min,Max] before
+// composing — faithful to reusing ComposeScore, but note it can only explore the
+// clamping regime (tighten a stored confidence, or raise one below a new floor);
+// it cannot widen a value the collector already clamped away.
+//
+// CRITICAL persistence gap (found during implementation): the ONLY config-blob
+// surface for dedup.signals.* is the four band thresholds (config.DedupSignalConfig).
+// Per-kind confidences have NO field in the Config struct and would be silently
+// dropped by UpdateConfig's JSON round-trip (same failure class as the retired
+// flat keys). Adding a field is out of scope ("do NOT invent a new persistence
+// path / no config.go changes"). Therefore:
+//
+//   - Round 1 — band thresholds under BASELINE (production) confidences — is the
+//     APPLICABLE recommendation. Its target-met flags accurately predict prod
+//     because prod runs baseline confidences + these bands. The apply path uses
+//     ONLY these, and the apply gate is computed from the EXACT config being
+//     persisted (baseline confidences + recommended bands).
+//   - Round 2 — per-signal confidence bounds — is ADVISORY only. It is reported so
+//     an operator can hand-edit config.yaml, but it is NEVER routed through
+//     UpdateConfig, NEVER gates the band apply, and NEVER contributes to the
+//     precision attributed to an applied band.
+//
+// # Discipline
+//
+// Dry-run (report only) is the default and only autonomous mode. {"apply":true}
+// persists band thresholds via the existing config update service and echoes the
+// previous values as the rollback record. Apply fires ONLY when every tunable band
+// (CERTAIN, HIGH) met its target under baseline confidences — never partial,
+// never target-not-met. Only CERTAIN and HIGH are tunable; MEDIUM/REVIEW are held
+// at baseline and only reported.
+//
+// Usage:
+//
+//	POST /api/v1/operations/v2  {"def_id":"dedup.calibrate-composite"}
+//	POST /api/v1/operations/v2  {"def_id":"dedup.calibrate-composite",
+//	                             "params":{"target_precision_certain":0.98,"apply":true}}
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+const (
+	// defaultTargetPrecisionCertain is the precision floor for the CERTAIN band
+	// (auto-merge eligible), matching the embedding op's high default.
+	defaultTargetPrecisionCertain = 0.98
+	// defaultTargetPrecisionCompositeHigh is the precision floor for the HIGH band.
+	defaultTargetPrecisionCompositeHigh = 0.90
+	// defaultMinScoredPairs is the per-class fail-closed coverage floor. Below
+	// this many scored pairs for EITHER class the op refuses to recommend.
+	defaultMinScoredPairs = 500
+
+	// bandSweepSpan / bandSweepStep define the ±span grid (score axis, 0..100)
+	// swept coordinate-wise around each band's baseline minimum.
+	bandSweepSpan = 10.0
+	bandSweepStep = 0.5
+
+	// confSweepSpan / confSweepStep define the ±span grid swept around each
+	// per-kind confidence bound in the advisory round.
+	confSweepSpan = 0.05
+	confSweepStep = 0.01
+
+	// minBandSampleSize is the minimum (true_dup+not_dup) count at/above a band
+	// cut-point for that cut-point's precision to be trusted (mirrors the
+	// embedding op's minSampleSizeForBestPrecision).
+	minBandSampleSize = 5
+)
+
+// calibrateCompositeParams are the JSON parameters accepted by the op.
+type calibrateCompositeParams struct {
+	// TargetPrecisionCertain is the precision floor for the CERTAIN band. Default 0.98.
+	TargetPrecisionCertain float64 `json:"target_precision_certain"`
+	// TargetPrecisionHigh is the precision floor for the HIGH band. Default 0.90.
+	TargetPrecisionHigh float64 `json:"target_precision_high"`
+	// MinScoredPairs is the per-class fail-closed coverage floor. Default 500.
+	MinScoredPairs int `json:"min_scored_pairs"`
+	// Apply, when true AND every tunable band met its target under baseline
+	// confidences, persists the recommended BAND thresholds. Default false
+	// (report only). Operator-gated — never sent autonomously.
+	Apply bool `json:"apply"`
+}
+
+// calibrateCompositeDef returns the OperationDef for dedup.calibrate-composite.
+func (p *Plugin) calibrateCompositeDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.calibrate-composite",
+		Plugin:      "dedup",
+		DisplayName: "Calibrate composite scorer (report; apply gated)",
+		Description: "Replays each labeled pair's stored ScoreBreakdown signals through " +
+			"unified.ComposeScore under coordinate-wise config variants against the " +
+			"pair-deduped gold set, and recommends noisy-OR band thresholds hitting a target " +
+			"precision. Per-signal confidence bounds are swept ADVISORY-only (no config-blob " +
+			"surface). Dry-run by default; apply=true writes dedup.signals.* band thresholds — " +
+			"operator-gated, refuses partial/target-not-met recommendations.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.calibrate-composite",
+		Cancellable:     true,
+		Timeout:         30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runCalibrateComposite,
+	}
+}
+
+// compositePair is one labeled pair plus the primary+supporting signal set
+// recovered from its stored ScoreBreakdown. It is scored under candidate configs.
+type compositePair struct {
+	trueDup bool // true = true_dup, false = not_dup
+	signals []models.Signal
+}
+
+// primaryKinds are the signal kinds that feed the noisy-OR product and whose
+// confidence bounds are meaningful to sweep (supporting kinds use boosts only).
+var primaryKinds = []unified.SignalKind{
+	unified.SigExactFile, unified.SigExactAcoustID, unified.SigISBNASIN,
+	unified.SigLSHAcoustID, unified.SigEmbedHigh, unified.SigMetaSrcHash,
+	unified.SigMetaFuzzy, unified.SigEmbedMedium,
+}
+
+func isPrimaryKind(k unified.SignalKind) bool {
+	for _, pk := range primaryKinds {
+		if pk == k {
+			return true
+		}
+	}
+	return false
+}
+
+// cloneScoreConfig deep-copies a ScoreConfig, including its Signals map, so a
+// candidate variant never aliases the baseline's per-kind entries.
+func cloneScoreConfig(cfg unified.ScoreConfig) unified.ScoreConfig {
+	out := cfg
+	out.Signals = make(map[string]unified.KindConfig, len(cfg.Signals))
+	for k, v := range cfg.Signals {
+		out.Signals[k] = v
+	}
+	return out
+}
+
+// scoreWithClamp composes a pair's signals under cfg, re-clamping each primary
+// signal's Confidence to that kind's [MinConfidence, MaxConfidence] first. This
+// replays collector-side clamping so a confidence-bound change actually moves the
+// composite score (ComposeScore itself reads Confidence verbatim). Supporting
+// signals are passed through unchanged (they contribute boosts, not confidence).
+func scoreWithClamp(signals []models.Signal, cfg unified.ScoreConfig) float64 {
+	clamped := make([]models.Signal, len(signals))
+	for i, s := range signals {
+		cs := s
+		if isPrimaryKind(s.Kind) {
+			if kc, ok := cfg.Signals[string(s.Kind)]; ok {
+				if cs.Confidence < kc.MinConfidence {
+					cs.Confidence = kc.MinConfidence
+				}
+				if cs.Confidence > kc.MaxConfidence {
+					cs.Confidence = kc.MaxConfidence
+				}
+			}
+		}
+		clamped[i] = cs
+	}
+	return unified.ComposeScore(clamped, nil, cfg, [2]string{}).Score
+}
+
+// scoreAll returns each pair's composite score under cfg (with clamping).
+func scoreAll(pairs []compositePair, cfg unified.ScoreConfig) []float64 {
+	scores := make([]float64, len(pairs))
+	for i := range pairs {
+		scores[i] = scoreWithClamp(pairs[i].signals, cfg)
+	}
+	return scores
+}
+
+// bandStat is the cumulative classifier stat at one band cut-point: everything
+// scoring >= Min is treated as a duplicate at that band or higher.
+type bandStat struct {
+	Min       float64 `json:"min"`
+	Precision float64 `json:"precision"`
+	Recall    float64 `json:"recall"`
+	TP        int     `json:"tp"`
+	FP        int     `json:"fp"`
+	N         int     `json:"n"` // TP+FP at/above the cut-point
+}
+
+// cumulativeBandStat computes precision/recall for the cut-point cutMin over the
+// fixed score/label arrays. precision = TP/(TP+FP); recall = TP/totalTrue. A
+// cut-point with no pairs at/above it has undefined precision (N==0).
+func cumulativeBandStat(scores []float64, pairs []compositePair, cutMin float64, totalTrue int) bandStat {
+	tp, fp := 0, 0
+	for i := range pairs {
+		if scores[i] < cutMin {
+			continue
+		}
+		if pairs[i].trueDup {
+			tp++
+		} else {
+			fp++
+		}
+	}
+	st := bandStat{Min: cutMin, TP: tp, FP: fp, N: tp + fp}
+	if tp+fp > 0 {
+		st.Precision = float64(tp) / float64(tp+fp)
+	}
+	if totalTrue > 0 {
+		st.Recall = float64(tp) / float64(totalTrue)
+	}
+	return st
+}
+
+// bandRec is the sweep result for one tunable band.
+type bandRec struct {
+	Met      bool     `json:"met"`
+	Baseline bandStat `json:"baseline"`      // stat at the baseline band minimum
+	Rec      bandStat `json:"rec,omitempty"` // stat at the recommended minimum (valid only when Met)
+}
+
+// sweepBandParallel evaluates every candidate cut-point in
+// [gridLo, gridHi] (step bandSweepStep) IN PARALLEL — each candidate config
+// variant is scored on its own goroutine from a bounded pool sized to
+// runtime.NumCPU() — and returns the LOWEST cut-point whose precision >=
+// targetPrecision (max recall subject to the precision floor) with a trustworthy
+// sample size. scores are precomputed once under baseline confidences and shared
+// read-only; ComposeScore is pure so the workers share nothing mutable. Each
+// worker writes only its own pre-indexed result slot, so the pass is race-clean.
+func sweepBandParallel(
+	ctx context.Context,
+	scores []float64,
+	pairs []compositePair,
+	totalTrue int,
+	gridLo, gridHi, targetPrecision float64,
+) (bandRec, error) {
+	// Build the ascending candidate grid (lowest first = max recall). Integer
+	// stepping (gridLo + i*step) keeps values exact — 0.5 is a power of two, so
+	// a recommended min lands precisely on a grid boundary, never 91.4999…
+	var cands []float64
+	if gridHi >= gridLo {
+		steps := int((gridHi-gridLo)/bandSweepStep + 0.5)
+		for i := 0; i <= steps; i++ {
+			t := gridLo + float64(i)*bandSweepStep
+			if t > gridHi+1e-9 {
+				break
+			}
+			cands = append(cands, t)
+		}
+	}
+	stats := make([]bandStat, len(cands))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.NumCPU())
+	for i := range cands {
+		i := i
+		g.Go(func() error {
+			select {
+			case <-gctx.Done():
+				return gctx.Err()
+			default:
+			}
+			stats[i] = cumulativeBandStat(scores, pairs, cands[i], totalTrue)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return bandRec{}, err
+	}
+
+	// First (lowest) candidate meeting the precision floor with enough samples.
+	for _, st := range stats {
+		if st.N >= minBandSampleSize && st.Precision >= targetPrecision {
+			return bandRec{Met: true, Rec: st}, nil
+		}
+	}
+	return bandRec{Met: false}, nil
+}
+
+// confSuggestion is one advisory per-kind confidence-bound recommendation.
+type confSuggestion struct {
+	Kind          string  `json:"kind"`
+	Bound         string  `json:"bound"` // "min_confidence" | "max_confidence"
+	From          float64 `json:"from"`
+	To            float64 `json:"to"`
+	CertainRecall float64 `json:"certain_recall_after"`
+	HighRecall    float64 `json:"high_recall_after"`
+}
+
+// runCalibrateComposite implements the op. Dry-run reports; apply (operator-gated,
+// all tunable bands met) persists band thresholds only.
+func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+
+	var params calibrateCompositeParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+	targetCertain := params.TargetPrecisionCertain
+	if targetCertain <= 0 {
+		targetCertain = defaultTargetPrecisionCertain
+	}
+	targetHigh := params.TargetPrecisionHigh
+	if targetHigh <= 0 {
+		targetHigh = defaultTargetPrecisionCompositeHigh
+	}
+	minScored := params.MinScoredPairs
+	if minScored <= 0 {
+		minScored = defaultMinScoredPairs
+	}
+
+	log := reporter.Logger()
+	log.Info("calibrate-composite start",
+		"apply", params.Apply,
+		"target_precision_certain", targetCertain,
+		"target_precision_high", targetHigh,
+		"min_scored_pairs", minScored)
+
+	// --- Load labeled examples (both classes) ---
+	_ = reporter.UpdateProgress(0, 4, "Loading labeled examples…")
+	trueDup, err := p.embeddingStore.ListLabeledExamples(database.LabeledExampleFilter{Label: "true_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list true_dup examples: %w", err)
+	}
+	notDup, err := p.embeddingStore.ListLabeledExamples(database.LabeledExampleFilter{Label: "not_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list not_dup examples: %w", err)
+	}
+	if reporter.IsCanceled() {
+		return context.Canceled
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	examples := make([]database.LabeledExample, 0, len(trueDup)+len(notDup))
+	examples = append(examples, trueDup...)
+	examples = append(examples, notDup...)
+
+	// --- Collapse to one row per canonical pair, then recover signals ---
+	_ = reporter.UpdateProgress(1, 4, "Collapsing to unique pairs + parsing breakdowns…")
+	rowsIn := len(examples)
+	deduped := dataset.DedupeByPair(examples)
+	pairsOut := len(deduped)
+
+	var pairs []compositePair
+	var scoredTrue, scoredNot, skippedNoBreakdown, skippedLabel int
+	for i := range deduped {
+		ex := deduped[i]
+		switch ex.Label {
+		case "true_dup", "not_dup":
+			// keep
+		default:
+			skippedLabel++ // unsure / unlabeled / unknown
+			continue
+		}
+		sigs, ok := parseBreakdownSignals(ex.ScoreBreakdown)
+		if !ok {
+			// nil / unparseable / empty-signal breakdown — counted, NEVER scored
+			// as zero (a zero score would poison the not_dup precision math).
+			skippedNoBreakdown++
+			continue
+		}
+		cp := compositePair{trueDup: ex.Label == "true_dup", signals: sigs}
+		pairs = append(pairs, cp)
+		if cp.trueDup {
+			scoredTrue++
+		} else {
+			scoredNot++
+		}
+	}
+
+	log.Info("calibrate-composite coverage",
+		"rows_in", rowsIn, "pairs_out", pairsOut,
+		"scored_true_dup", scoredTrue, "scored_not_dup", scoredNot,
+		"skipped_no_breakdown", skippedNoBreakdown, "skipped_label", skippedLabel)
+
+	// --- Fail-closed coverage floor ---
+	if scoredTrue < minScored || scoredNot < minScored {
+		log.Info("calibrate-composite report",
+			"status", "insufficient-coverage",
+			"rows_in", rowsIn, "pairs_out", pairsOut,
+			"scored_true_dup", scoredTrue, "scored_not_dup", scoredNot,
+			"skipped_no_breakdown", skippedNoBreakdown,
+			"min_scored_pairs", minScored)
+		_ = reporter.UpdateProgress(4, 4, fmt.Sprintf(
+			"insufficient-coverage — scored true_dup=%d not_dup=%d < min %d; recommending nothing.",
+			scoredTrue, scoredNot, minScored))
+		return nil
+	}
+
+	// --- Baseline config (production load; fall back to defaults) ---
+	baseCfg, lerr := unified.LoadScoreConfig()
+	if lerr != nil {
+		log.Warn("calibrate-composite: LoadScoreConfig failed, using DefaultScoreConfig", "error", lerr)
+		baseCfg = unified.DefaultScoreConfig()
+	}
+	totalTrue := scoredTrue
+
+	// Baseline scores under production confidences — computed ONCE and shared
+	// read-only across the parallel band sweep.
+	_ = reporter.UpdateProgress(2, 4, "Scoring pairs at baseline + sweeping bands…")
+	baseScores := scoreAll(pairs, baseCfg)
+
+	baselineCertain := cumulativeBandStat(baseScores, pairs, baseCfg.BandCertainMin, totalTrue)
+	baselineHigh := cumulativeBandStat(baseScores, pairs, baseCfg.BandHighMin, totalTrue)
+	baselineMedium := cumulativeBandStat(baseScores, pairs, baseCfg.BandMediumMin, totalTrue)
+	baselineReview := cumulativeBandStat(baseScores, pairs, baseCfg.BandReviewMin, totalTrue)
+
+	// --- Round 1: band-threshold sweep (APPLICABLE) ---
+	// Sweep HIGH first, then constrain CERTAIN's grid to sit STRICTLY above the
+	// recommended HIGH min. This bakes strict CERTAIN > HIGH > MEDIUM > REVIEW
+	// ordering into the search space rather than dropping a valid recommendation
+	// after the fact, so a cleanly separable set (both bands want the same cut)
+	// yields certain = high + one step, not a suppressed pair.
+	highLo := maxf(0, baseCfg.BandHighMin-bandSweepSpan)
+	if lo := baseCfg.BandMediumMin + bandSweepStep; lo > highLo {
+		highLo = lo
+	}
+	highHi := minf(baseCfg.BandCertainMin-bandSweepStep, baseCfg.BandHighMin+bandSweepSpan)
+	highRec, err := sweepBandParallel(ctx, baseScores, pairs, totalTrue, highLo, highHi, targetHigh)
+	if err != nil {
+		return err
+	}
+	highRec.Baseline = baselineHigh
+
+	certainLo := maxf(0, baseCfg.BandCertainMin-bandSweepSpan)
+	if lo := baseCfg.BandHighMin + bandSweepStep; lo > certainLo {
+		certainLo = lo
+	}
+	// If HIGH moved, CERTAIN must clear the NEW high min, not just the baseline.
+	if highRec.Met {
+		if lo := highRec.Rec.Min + bandSweepStep; lo > certainLo {
+			certainLo = lo
+		}
+	}
+	certainHi := minf(100, baseCfg.BandCertainMin+bandSweepSpan)
+	certainRec, err := sweepBandParallel(ctx, baseScores, pairs, totalTrue, certainLo, certainHi, targetCertain)
+	if err != nil {
+		return err
+	}
+	certainRec.Baseline = baselineCertain
+
+	// Defensive final ordering assertion — the constrained grid above makes this
+	// unreachable, but never emit a non-monotonic band config.
+	orderingConflict := false
+	if certainRec.Met && highRec.Met && certainRec.Rec.Min <= highRec.Rec.Min {
+		orderingConflict = true
+		log.Warn("calibrate-composite: band ordering conflict — certain<=high recommendation, not applicable",
+			"certain_min", certainRec.Rec.Min, "high_min", highRec.Rec.Min)
+	}
+
+	// --- Round 2: per-kind confidence-bound sweep (ADVISORY only) ---
+	// Evaluated against the round-1 recommended band thresholds (or baseline when
+	// a band was not met). Never persisted; never gates the band apply.
+	certainBandForConf := recOrBaselineMin(certainRec, baseCfg.BandCertainMin)
+	highBandForConf := recOrBaselineMin(highRec, baseCfg.BandHighMin)
+	_ = reporter.UpdateProgress(3, 4, "Sweeping per-kind confidence bounds (advisory)…")
+	confSuggestions, err := sweepConfidenceAdvisory(
+		ctx, pairs, baseCfg, totalTrue,
+		certainBandForConf, targetCertain, highBandForConf, targetHigh)
+	if err != nil {
+		return err
+	}
+
+	// --- Recommended config being considered for APPLY: baseline confidences +
+	// recommended bands (this is exactly what prod would run) ---
+	recCfg := cloneScoreConfig(baseCfg)
+	if certainRec.Met && !orderingConflict {
+		recCfg.BandCertainMin = certainRec.Rec.Min
+	}
+	if highRec.Met && !orderingConflict {
+		recCfg.BandHighMin = highRec.Rec.Min
+	}
+
+	// The apply gate: every TUNABLE band met its target under baseline confidences,
+	// and no ordering conflict. Computed from the exact config being persisted.
+	allTargetsMet := certainRec.Met && highRec.Met && !orderingConflict
+
+	baselineJSON, _ := json.Marshal(baseCfg)
+	recJSON, _ := json.Marshal(recCfg)
+
+	// --- Report ---
+	fields := []any{
+		"status", "ok",
+		"rows_in", rowsIn,
+		"pairs_out", pairsOut,
+		"scored_true_dup", scoredTrue,
+		"scored_not_dup", scoredNot,
+		"skipped_no_breakdown", skippedNoBreakdown,
+		"target_precision_certain", targetCertain,
+		"target_precision_high", targetHigh,
+		"baseline_certain_min", baseCfg.BandCertainMin,
+		"baseline_certain_precision", baselineCertain.Precision,
+		"baseline_certain_recall", baselineCertain.Recall,
+		"baseline_certain_n", baselineCertain.N,
+		"baseline_high_min", baseCfg.BandHighMin,
+		"baseline_high_precision", baselineHigh.Precision,
+		"baseline_high_recall", baselineHigh.Recall,
+		"baseline_high_n", baselineHigh.N,
+		"baseline_medium_precision", baselineMedium.Precision,
+		"baseline_medium_recall", baselineMedium.Recall,
+		"baseline_medium_n", baselineMedium.N,
+		"baseline_review_precision", baselineReview.Precision,
+		"baseline_review_recall", baselineReview.Recall,
+		"baseline_review_n", baselineReview.N,
+		"certain_target_met", certainRec.Met && !orderingConflict,
+		"high_target_met", highRec.Met && !orderingConflict,
+		"band_ordering_conflict", orderingConflict,
+		"all_targets_met", allTargetsMet,
+		"baseline_config_json", string(baselineJSON),
+		"recommended_config_json", string(recJSON),
+		"advisory_confidence_suggestions", len(confSuggestions),
+	}
+	if certainRec.Met && !orderingConflict {
+		fields = append(fields,
+			"recommended_certain_min", certainRec.Rec.Min,
+			"recommended_certain_precision", certainRec.Rec.Precision,
+			"recommended_certain_recall", certainRec.Rec.Recall,
+			"recommended_certain_n", certainRec.Rec.N)
+	} else {
+		fields = append(fields, "certain_target_not_met", true)
+	}
+	if highRec.Met && !orderingConflict {
+		fields = append(fields,
+			"recommended_high_min", highRec.Rec.Min,
+			"recommended_high_precision", highRec.Rec.Precision,
+			"recommended_high_recall", highRec.Rec.Recall,
+			"recommended_high_n", highRec.Rec.N)
+	} else {
+		fields = append(fields, "high_target_not_met", true)
+	}
+	log.Info("calibrate-composite report", fields...)
+	for _, s := range confSuggestions {
+		log.Info("calibrate-composite advisory confidence suggestion (config.yaml edit only, NOT applied)",
+			"kind", s.Kind, "bound", s.Bound, "from", s.From, "to", s.To,
+			"certain_recall_after", s.CertainRecall, "high_recall_after", s.HighRecall)
+	}
+
+	summary := fmt.Sprintf(
+		"scored_true=%d scored_not=%d skipped_no_breakdown=%d certain=%s high=%s advisory_conf=%d",
+		scoredTrue, scoredNot, skippedNoBreakdown,
+		describeBandRec(certainRec, orderingConflict), describeBandRec(highRec, orderingConflict), len(confSuggestions))
+
+	// --- Apply path (operator-gated; bands only; all tunable targets met) ---
+	if !params.Apply {
+		_ = reporter.UpdateProgress(4, 4, "Dry-run — "+summary+
+			". Bands are report-only until apply=true (operator-gated); confidence suggestions require a config.yaml edit.")
+		log.Info("calibrate-composite: dry-run only; nothing written")
+		return nil
+	}
+	if !allTargetsMet {
+		log.Warn("calibrate-composite: apply requested but not every tunable band met its target — writing nothing",
+			"certain_met", certainRec.Met, "high_met", highRec.Met, "ordering_conflict", orderingConflict)
+		_ = reporter.UpdateProgress(4, 4, "Apply requested but target(s) not met — refused, nothing written. "+summary)
+		return nil
+	}
+
+	if err := p.applyBandThresholds(recCfg, baseCfg, log); err != nil {
+		return err
+	}
+	_ = reporter.UpdateProgress(4, 4, fmt.Sprintf(
+		"Applied band thresholds certain=%.2f high=%.2f (previous certain=%.2f high=%.2f — rollback record). %s",
+		recCfg.BandCertainMin, recCfg.BandHighMin, baseCfg.BandCertainMin, baseCfg.BandHighMin, summary))
+	return nil
+}
+
+// applyBandThresholds persists the recommended band thresholds via the existing
+// config update service (the ONLY dedup.signals.* blob surface). It writes all
+// four band mins — recommended for tunable bands, baseline for held ones — so the
+// persisted config stays internally ordered, and loudly logs the previous values
+// as the rollback record.
+func (p *Plugin) applyBandThresholds(recCfg, prevCfg unified.ScoreConfig, log *slog.Logger) error {
+	if p.store == nil {
+		return fmt.Errorf("main store not available; cannot persist config")
+	}
+	log.Info("calibrate-composite APPLY: persisting band thresholds",
+		"new_certain_min", recCfg.BandCertainMin, "new_high_min", recCfg.BandHighMin,
+		"new_medium_min", recCfg.BandMediumMin, "new_review_min", recCfg.BandReviewMin,
+		"previous_certain_min", prevCfg.BandCertainMin, "previous_high_min", prevCfg.BandHighMin,
+		"previous_medium_min", prevCfg.BandMediumMin, "previous_review_min", prevCfg.BandReviewMin,
+		"rollback", "re-run apply with the previous_* values to restore")
+
+	payload := map[string]any{
+		"dedup": map[string]any{
+			"signals": map[string]any{
+				"band_certain_min": recCfg.BandCertainMin,
+				"band_high_min":    recCfg.BandHighMin,
+				"band_medium_min":  recCfg.BandMediumMin,
+				"band_review_min":  recCfg.BandReviewMin,
+			},
+		},
+	}
+	svc := config.NewUpdateService(p.store)
+	if err := svc.ApplyUpdates(payload); err != nil {
+		return fmt.Errorf("persist band thresholds: %w", err)
+	}
+	log.Info("calibrate-composite APPLY: band thresholds persisted (survives restart via config blob)")
+	return nil
+}
+
+// recOrBaselineMin returns the recommended band minimum when met, else the baseline.
+func recOrBaselineMin(r bandRec, baseline float64) float64 {
+	if r.Met {
+		return r.Rec.Min
+	}
+	return baseline
+}
+
+func describeBandRec(r bandRec, orderingConflict bool) string {
+	if !r.Met || orderingConflict {
+		return "target-not-met"
+	}
+	return fmt.Sprintf("min=%.2f(p=%.3f,r=%.3f)", r.Rec.Min, r.Rec.Precision, r.Rec.Recall)
+}
+
+// parseBreakdownSignals recovers the signal set from a stored ScoreBreakdown JSON
+// snapshot. Returns ok=false for nil/empty/unparseable payloads OR a parsed
+// breakdown carrying no signals (both are un-scorable and must be skipped+counted,
+// never treated as a zero score).
+func parseBreakdownSignals(raw json.RawMessage) ([]models.Signal, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var uds models.UnifiedDedupScore
+	if err := json.Unmarshal(raw, &uds); err != nil {
+		return nil, false
+	}
+	if len(uds.Signals) == 0 {
+		return nil, false
+	}
+	return uds.Signals, true
+}
+
+// sweepConfidenceAdvisory sweeps each primary kind's MinConfidence and
+// MaxConfidence over a ±confSweepSpan grid (coordinate-wise, one bound at a time)
+// and records any change that IMPROVES total target-band recall without dropping
+// either met target below its precision floor. Advisory only — the returned
+// suggestions are reported for a manual config.yaml edit and are never persisted.
+//
+// Each candidate config variant re-scores the whole pair slice, so the OUTER
+// variant loop is sharded across a bounded pool sized to runtime.NumCPU(); every
+// worker writes only its own pre-indexed slot (race-clean) and ComposeScore is
+// pure so nothing mutable is shared.
+func sweepConfidenceAdvisory(
+	ctx context.Context,
+	pairs []compositePair,
+	baseCfg unified.ScoreConfig,
+	totalTrue int,
+	certainMin, targetCertain, highMin, targetHigh float64,
+) ([]confSuggestion, error) {
+	// Which targets are met at baseline confidences — a suggestion must not break these.
+	baseScores := scoreAll(pairs, baseCfg)
+	baseCertain := cumulativeBandStat(baseScores, pairs, certainMin, totalTrue)
+	baseHigh := cumulativeBandStat(baseScores, pairs, highMin, totalTrue)
+	certainMetBase := baseCertain.N >= minBandSampleSize && baseCertain.Precision >= targetCertain
+	highMetBase := baseHigh.N >= minBandSampleSize && baseHigh.Precision >= targetHigh
+	baseObjective := baseCertain.Recall + baseHigh.Recall
+
+	working := cloneScoreConfig(baseCfg)
+	var suggestions []confSuggestion
+
+	type variant struct {
+		kind  unified.SignalKind
+		bound string
+		value float64
+	}
+
+	for _, kind := range primaryKinds {
+		kc, ok := working.Signals[string(kind)]
+		if !ok {
+			continue
+		}
+		for _, bound := range []string{"min_confidence", "max_confidence"} {
+			base := kc.MinConfidence
+			if bound == "max_confidence" {
+				base = kc.MaxConfidence
+			}
+			// Build candidate values around the current bound value.
+			var variants []variant
+			for d := -confSweepSpan; d <= confSweepSpan+1e-9; d += confSweepStep {
+				v := clampUnit(base + d)
+				variants = append(variants, variant{kind: kind, bound: bound, value: v})
+			}
+
+			results := make([]struct {
+				certain, high bandStat
+				valid         bool
+				value         float64
+			}, len(variants))
+
+			g, gctx := errgroup.WithContext(ctx)
+			g.SetLimit(runtime.NumCPU())
+			for i := range variants {
+				i := i
+				g.Go(func() error {
+					select {
+					case <-gctx.Done():
+						return gctx.Err()
+					default:
+					}
+					cand := cloneScoreConfig(working)
+					ck := cand.Signals[string(kind)]
+					if variants[i].bound == "min_confidence" {
+						ck.MinConfidence = variants[i].value
+					} else {
+						ck.MaxConfidence = variants[i].value
+					}
+					// Keep min<=max; an invalid combination is skipped, not scored.
+					if ck.MinConfidence > ck.MaxConfidence {
+						results[i].valid = false
+						return nil
+					}
+					cand.Signals[string(kind)] = ck
+					sc := scoreAll(pairs, cand)
+					results[i].certain = cumulativeBandStat(sc, pairs, certainMin, totalTrue)
+					results[i].high = cumulativeBandStat(sc, pairs, highMin, totalTrue)
+					results[i].valid = true
+					results[i].value = variants[i].value
+					return nil
+				})
+			}
+			if err := g.Wait(); err != nil {
+				return nil, err
+			}
+
+			// Pick the variant maximizing total target-band recall subject to
+			// every baseline-met target staying met (anti-over-suppression).
+			bestObjective := baseObjective
+			bestIdx := -1
+			for i, r := range results {
+				if !r.valid {
+					continue
+				}
+				if certainMetBase && !(r.certain.N >= minBandSampleSize && r.certain.Precision >= targetCertain) {
+					continue
+				}
+				if highMetBase && !(r.high.N >= minBandSampleSize && r.high.Precision >= targetHigh) {
+					continue
+				}
+				obj := r.certain.Recall + r.high.Recall
+				if obj > bestObjective+1e-9 {
+					bestObjective = obj
+					bestIdx = i
+				}
+			}
+			if bestIdx >= 0 {
+				chosen := results[bestIdx]
+				suggestions = append(suggestions, confSuggestion{
+					Kind: string(kind), Bound: bound, From: base, To: chosen.value,
+					CertainRecall: chosen.certain.Recall, HighRecall: chosen.high.Recall,
+				})
+				// Adopt into the working cfg so later coordinates compound (advisory only).
+				wk := working.Signals[string(kind)]
+				if bound == "min_confidence" {
+					wk.MinConfidence = chosen.value
+				} else {
+					wk.MaxConfidence = chosen.value
+				}
+				working.Signals[string(kind)] = wk
+				kc = wk
+				baseObjective = bestObjective
+			}
+		}
+	}
+	return suggestions, nil
+}
+
+func clampUnit(v float64) float64 {
+	if v < 0.0001 {
+		return 0.0001
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func maxf(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minf(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/plugins/dedup/calibrate_composite_test.go
+++ b/internal/plugins/dedup/calibrate_composite_test.go
@@ -1,0 +1,283 @@
+// file: internal/plugins/dedup/calibrate_composite_test.go
+// version: 1.0.0
+// guid: 7e5a1c3b-9d2f-4a08-8b61-3c4d5e6f7a89
+// last-edited: 2026-07-11
+
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
+)
+
+// breakdownWith builds a ScoreBreakdown JSON snapshot carrying a single primary
+// signal of the given kind + confidence, so a test can dial a pair's composite
+// score deterministically (single-signal noisy-OR → score = 100*confidence,
+// after cfg clamping).
+func breakdownWith(kind unified.SignalKind, conf float64) json.RawMessage {
+	uds := models.UnifiedDedupScore{
+		Signals: []models.Signal{{Kind: kind, Confidence: conf, Raw: conf}},
+	}
+	b, _ := json.Marshal(uds)
+	return b
+}
+
+// upsertPairs writes n labeled examples of the given label, each a DISTINCT
+// canonical pair (so DedupeByPair never collapses them), each carrying the given
+// single-signal breakdown. idBase offsets candidate/entity IDs across calls.
+func upsertPairs(t *testing.T, es *database.EmbeddingStore, idBase, n int, label string, bd json.RawMessage) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		id := idBase + i
+		ex := database.LabeledExample{
+			CandidateID:    int64(id),
+			EntityAID:      fmt.Sprintf("a%06d", id),
+			EntityBID:      fmt.Sprintf("b%06d", id),
+			Label:          label,
+			LabelSource:    "rule",
+			DecidedAt:      "2026-07-01T00:00:00Z",
+			ScoreBreakdown: bd,
+		}
+		if err := es.UpsertLabeledExample(ex); err != nil {
+			t.Fatalf("upsert %d: %v", id, err)
+		}
+	}
+}
+
+// reportFields parses the single "calibrate-composite report" JSON log line the
+// op emits and returns its fields for assertion.
+func reportFields(t *testing.T, buf string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(buf), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == "calibrate-composite report" {
+			return rec
+		}
+	}
+	t.Fatalf("no 'calibrate-composite report' line found in:\n%s", buf)
+	return nil
+}
+
+// TestCalibrateCompositeInsufficientCoverage: a below-floor input reports
+// insufficient-coverage and recommends nothing; nil-breakdown rows are skipped
+// and counted (never scored as zero).
+func TestCalibrateCompositeInsufficientCoverage(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	upsertPairs(t, es, 1000, 3, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.94))
+	upsertPairs(t, es, 2000, 3, "not_dup", breakdownWith(unified.SigMetaFuzzy, 0.80))
+	// Two nil-breakdown rows that must be skipped + counted, not scored as zero.
+	upsertPairs(t, es, 3000, 2, "true_dup", nil)
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+
+	if f["status"] != "insufficient-coverage" {
+		t.Fatalf("status = %v, want insufficient-coverage", f["status"])
+	}
+	if got := f["scored_true_dup"].(float64); got != 3 {
+		t.Errorf("scored_true_dup = %v, want 3", got)
+	}
+	if got := f["skipped_no_breakdown"].(float64); got != 2 {
+		t.Errorf("skipped_no_breakdown = %v, want 2 (nil breakdowns skipped, not scored)", got)
+	}
+	if _, ok := f["recommended_high_min"]; ok {
+		t.Error("insufficient-coverage must recommend nothing, got recommended_high_min")
+	}
+}
+
+// TestCalibrateCompositeDryRunWritesNothing: default params, a well-separated
+// set → recommendations appear in the report, and the config store is untouched.
+func TestCalibrateCompositeDryRunWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// 600 per class clears the default 500 floor.
+	upsertPairs(t, es, 100000, 600, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.94))
+	upsertPairs(t, es, 200000, 600, "not_dup", breakdownWith(unified.SigEmbedHigh, 0.915))
+
+	before := config.Snapshot().Dedup.Signals
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+
+	if f["status"] != "ok" {
+		t.Fatalf("status = %v, want ok", f["status"])
+	}
+	if _, ok := f["recommended_high_min"]; !ok {
+		t.Error("expected a recommended_high_min in the dry-run report")
+	}
+	after := config.Snapshot().Dedup.Signals
+	if before != after {
+		t.Errorf("dry-run mutated config store: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestCalibrateCompositeFindsSeparation: a set where the HIGH band must shift
+// from 90→92 to reach target precision → the recommendation contains 92.
+func TestCalibrateCompositeFindsSeparation(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// true_dup score 94, not_dup score 91.5 (both inside SigEmbedHigh's [0.88,0.95]
+	// clamp so no clamping distorts). At min=90 precision is 0.5; at 92 the
+	// not_dup pairs drop out → precision 1.0.
+	upsertPairs(t, es, 100000, 30, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.94))
+	upsertPairs(t, es, 200000, 30, "not_dup", breakdownWith(unified.SigEmbedHigh, 0.915))
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+
+	got, ok := f["recommended_high_min"].(float64)
+	if !ok {
+		t.Fatalf("expected recommended_high_min, report: %v", f)
+	}
+	if got != 92.0 {
+		t.Errorf("recommended_high_min = %v, want 92.0", got)
+	}
+	if f["high_target_met"] != true {
+		t.Errorf("high_target_met = %v, want true", f["high_target_met"])
+	}
+}
+
+// TestCalibrateCompositeTargetNotMet: inseparable classes → target-not-met,
+// nothing recommended (the recommender must never force a bad threshold).
+func TestCalibrateCompositeTargetNotMet(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// Both classes at the SAME score 92 — no cut-point can separate them.
+	upsertPairs(t, es, 100000, 30, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.92))
+	upsertPairs(t, es, 200000, 30, "not_dup", breakdownWith(unified.SigEmbedHigh, 0.92))
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+
+	if _, ok := f["recommended_high_min"]; ok {
+		t.Error("inseparable classes must recommend nothing for HIGH")
+	}
+	if _, ok := f["recommended_certain_min"]; ok {
+		t.Error("inseparable classes must recommend nothing for CERTAIN")
+	}
+	if f["high_target_met"] != false || f["certain_target_met"] != false {
+		t.Errorf("expected both targets unmet, got high=%v certain=%v", f["high_target_met"], f["certain_target_met"])
+	}
+	if f["all_targets_met"] != false {
+		t.Errorf("all_targets_met = %v, want false", f["all_targets_met"])
+	}
+}
+
+// TestCalibrateCompositeTargetNotMetApplyWritesNothing: apply=true on an
+// inseparable set is refused — the config store stays untouched.
+func TestCalibrateCompositeTargetNotMetApplyWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+	upsertPairs(t, es, 100000, 30, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.92))
+	upsertPairs(t, es, 200000, 30, "not_dup", breakdownWith(unified.SigEmbedHigh, 0.92))
+
+	before := config.Snapshot().Dedup.Signals
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10,"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if after := config.Snapshot().Dedup.Signals; before != after {
+		t.Errorf("apply on target-not-met mutated config: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestCalibrateCompositeSweepParallel exercises the errgroup band-sweep pool
+// (run the package with -race). A moderate well-separated set is enough to fan
+// out multiple candidate variants across workers.
+func TestCalibrateCompositeSweepParallel(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+	upsertPairs(t, es, 100000, 40, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.94))
+	upsertPairs(t, es, 200000, 40, "not_dup", breakdownWith(unified.SigEmbedHigh, 0.915))
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if f := reportFields(t, rep.buf.String()); f["status"] != "ok" {
+		t.Fatalf("status = %v, want ok", f["status"])
+	}
+}
+
+// TestCalibrateCompositeApplyPersistsBands: with apply=true and both tunable
+// bands meeting target, the recommended BAND thresholds survive a
+// SaveConfigToDatabase → LoadConfigFromDatabase round-trip. (Per-signal
+// confidences are advisory-only and intentionally do NOT round-trip — no config
+// blob surface exists for them.)
+func TestCalibrateCompositeApplyPersistsBands(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// true_dup score 99 (SigExactAcoustID, clamped to 0.99); not_dup score 80
+	// (SigMetaFuzzy, clamped to [0.70,0.85]). Both CERTAIN(97) and HIGH(90) meet
+	// target at baseline, so the sweep recommends and apply fires.
+	upsertPairs(t, es, 100000, 30, "true_dup", breakdownWith(unified.SigExactAcoustID, 0.99))
+	upsertPairs(t, es, 200000, 30, "not_dup", breakdownWith(unified.SigMetaFuzzy, 0.80))
+
+	// Restore global config after the test (UpdateConfig/LoadConfigFromDatabase
+	// mutate the process-wide AppConfig).
+	orig := config.Snapshot()
+	t.Cleanup(func() { config.Mutate(func(c *config.Config) { *c = orig }) })
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10,"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+	if f["all_targets_met"] != true {
+		t.Fatalf("all_targets_met = %v, want true (report: %v)", f["all_targets_met"], f)
+	}
+	recCertain := f["recommended_certain_min"].(float64)
+	recHigh := f["recommended_high_min"].(float64)
+
+	// Reload from the persisted config blob and assert the bands round-tripped.
+	if err := config.LoadConfigFromDatabase(pebble); err != nil {
+		t.Fatalf("LoadConfigFromDatabase: %v", err)
+	}
+	sig := config.Snapshot().Dedup.Signals
+	if sig.BandCertainMin != recCertain {
+		t.Errorf("persisted band_certain_min = %v, want %v", sig.BandCertainMin, recCertain)
+	}
+	if sig.BandHighMin != recHigh {
+		t.Errorf("persisted band_high_min = %v, want %v", sig.BandHighMin, recHigh)
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.15.0
+// version: 1.16.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
 // last-edited: 2026-07-11
 
@@ -69,6 +69,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.bookfileSegDropDef(),               // T020: drop AcoustID segment fields from stored values
 		p.datasetBackfillDef(),               // C4: label + suppress residual pending candidates
 		p.calibrateEmbeddingThresholdsDef(),  // DEDUP-2/3: bge-m3 threshold calibration report (dry-run only)
+		p.calibrateCompositeDef(),            // INIT-1 T5: noisy-OR composite band calibration (dry-run; band apply operator-gated)
 		p.mineGoldLabelsDef(),                // gold miner: auto-label high-confidence true_dup positives
 		p.rebuildGoldLabelsDef(),             // rebuild rule/auto_high_conf gold labels against current state
 		p.quarantineChapterArtifactsDef(),    // drain chapter-file-as-book artifacts (candidate explosion)


### PR DESCRIPTION
## dedup.calibrate-composite (INIT-1 T5)

Adds op `dedup.calibrate-composite` that calibrates the noisy-OR composite scorer
(`unified.ComposeScore`) against the pair-deduped gold-label set, filling the gap
left by `dedup.calibrate-embedding-thresholds` (which sweeps only a single embedding
cosine cut-point — ~47% of true_dup pairs score below cosine 0.98).

### What it does
- Loads labeled examples (both classes), `dataset.DedupeByPair`, parses each row's
  stored `ScoreBreakdown` into `unified.UnifiedDedupScore` to recover its signal set.
- **Fail-closed coverage floor**: nil/empty/unparseable breakdowns are skipped and
  counted (`skipped_no_breakdown`), never scored as zero; `< min_scored_pairs` per
  class → `insufficient-coverage`, recommends nothing.
- **Round 1 (bands)**: coordinate-wise sweep of CERTAIN/HIGH band thresholds over a
  ±10 grid (step 0.5), each candidate scored on a bounded `errgroup` pool sized to
  `runtime.NumCPU()`. HIGH swept first, then CERTAIN constrained strictly above it, so
  a recommendation is always monotonic (CERTAIN > HIGH > MEDIUM > REVIEW).
- **Round 2 (confidences)**: sweeps each primary kind's `MinConfidence`/`MaxConfidence`
  (±0.05, step 0.01), re-clamping stored signal confidences before composing (because
  `ComposeScore` reads `Signal.Confidence` verbatim and ignores the cfg bounds).
- Dry-run by default. `apply=true` is operator-gated and refuses partial/target-not-met
  recommendations.

### ⚠️ Applicability finding — surfaced deliberately
The brief assumed both bands *and* per-signal confidences are applyable to
`dedup.signals.*`. In the codebase only the **four band thresholds** have a config-blob
persistence surface (`config.DedupSignalConfig`); **per-kind confidences have no field**
and would be silently dropped by `UpdateConfig`'s JSON round-trip (same failure class as
the retired flat keys). Adding a field is out of scope ("do NOT invent a new persistence
path / no config.go changes"). Resolution:
- **Round-1 band recommendations are APPLICABLE** — persisted via the existing
  `config.UpdateService` (survives restart via the PebbleDB config blob). The apply gate
  and the precision attributed to applied bands are computed under **baseline (production)
  confidences**, exactly the config prod will run — never under the swept confidences.
- **Round-2 confidence recommendations are ADVISORY-only** — reported for a manual
  config.yaml edit, never persisted, never gate the band apply.
This split is called out so it reads as a faithful resolution of a real gap, not a miss.
Follow-up logged in TODO.md: add a `map[string]KindConfig` under `dedup.signals` to make
the confidence round applyable.

### Tests (`-race`)
`TestCalibrateCompositeInsufficientCoverage`, `...DryRunWritesNothing`,
`...FindsSeparation` (90→92 band shift), `...TargetNotMet`,
`...TargetNotMetApplyWritesNothing`, `...SweepParallel`, `...ApplyPersistsBands`
(band values round-trip through `SaveConfigToDatabase`→`LoadConfigFromDatabase`).

### CI note
`internal/plugins/dedup/... -race` green; full short suite **excluding** `internal/server`
green; vet/staticcheck(scoped)/sdkguard/mocks-check/check-mock-fresh green. The
`internal/server` package hits the documented load-sensitive integration-test stall
(`TestITunesImport_NonexistentFile`'s `SetupIntegration` — passes in isolation); this PR
touches no server code. staticcheck is pre-existing red on main (#1796).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv