### PR TITLE
feat(dedup): scheduled label-refinement loop (dry-run chain, built-in-disabled) (INIT-1 T6)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.67.0
+// version: 1.68.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 package config
 
@@ -409,6 +409,7 @@ type AutoUpdateConfig struct {
 // ScheduledTasksConfig holds settings for all background scheduled tasks.
 type ScheduledTasksConfig struct {
 	DedupRefresh             ScheduledTaskConfig `json:"dedup_refresh"               mapstructure:"dedup_refresh"`
+	LabelRefinement          ScheduledTaskConfig `json:"label_refinement"            mapstructure:"label_refinement"`
 	AuthorSplit              ScheduledTaskConfig `json:"author_split"                mapstructure:"author_split"`
 	DbOptimize               ScheduledTaskConfig `json:"db_optimize"                 mapstructure:"db_optimize"`
 	MetadataRefresh          ScheduledTaskConfig `json:"metadata_refresh"            mapstructure:"metadata_refresh"`
@@ -773,6 +774,12 @@ func InitConfig() {
 	viper.SetDefault("scheduled.dedup_refresh.enabled", false)
 	viper.SetDefault("scheduled.dedup_refresh.interval", 360)
 	viper.SetDefault("scheduled.dedup_refresh.on_startup", false)
+	// label_refinement ships DISABLED (INIT-1 T6): the scheduled dry-run chain
+	// (dedup.rebuild-gold-labels → dedup.calibrate-composite) only runs when an
+	// owner flips enabled=true. Interval is weekly (10080 min).
+	viper.SetDefault("scheduled.label_refinement.enabled", false)
+	viper.SetDefault("scheduled.label_refinement.interval", 10080)
+	viper.SetDefault("scheduled.label_refinement.on_startup", false)
 	viper.SetDefault("scheduled.author_split.enabled", false)
 	viper.SetDefault("scheduled.author_split.interval", 0)
 	viper.SetDefault("scheduled.author_split.on_startup", false)
@@ -797,6 +804,9 @@ func InitConfig() {
 	viper.BindEnv("scheduled.dedup_refresh.enabled", "SCHEDULED_DEDUP_REFRESH_ENABLED")                             //nolint:errcheck
 	viper.BindEnv("scheduled.dedup_refresh.interval", "SCHEDULED_DEDUP_REFRESH_INTERVAL")                           //nolint:errcheck
 	viper.BindEnv("scheduled.dedup_refresh.on_startup", "SCHEDULED_DEDUP_REFRESH_ON_STARTUP")                       //nolint:errcheck
+	viper.BindEnv("scheduled.label_refinement.enabled", "SCHEDULED_LABEL_REFINEMENT_ENABLED")                       //nolint:errcheck
+	viper.BindEnv("scheduled.label_refinement.interval", "SCHEDULED_LABEL_REFINEMENT_INTERVAL")                     //nolint:errcheck
+	viper.BindEnv("scheduled.label_refinement.on_startup", "SCHEDULED_LABEL_REFINEMENT_ON_STARTUP")                 //nolint:errcheck
 	viper.BindEnv("scheduled.author_split.enabled", "SCHEDULED_AUTHOR_SPLIT_ENABLED")                               //nolint:errcheck
 	viper.BindEnv("scheduled.author_split.interval", "SCHEDULED_AUTHOR_SPLIT_INTERVAL")                             //nolint:errcheck
 	viper.BindEnv("scheduled.author_split.on_startup", "SCHEDULED_AUTHOR_SPLIT_ON_STARTUP")                         //nolint:errcheck
@@ -1267,6 +1277,11 @@ func InitConfig() {
 					Enabled:   viper.GetBool("scheduled.dedup_refresh.enabled"),
 					Interval:  viper.GetInt("scheduled.dedup_refresh.interval"),
 					OnStartup: viper.GetBool("scheduled.dedup_refresh.on_startup"),
+				},
+				LabelRefinement: ScheduledTaskConfig{
+					Enabled:   viper.GetBool("scheduled.label_refinement.enabled"),
+					Interval:  viper.GetInt("scheduled.label_refinement.interval"),
+					OnStartup: viper.GetBool("scheduled.label_refinement.on_startup"),
 				},
 				AuthorSplit: ScheduledTaskConfig{
 					Enabled:   viper.GetBool("scheduled.author_split.enabled"),

--- a/internal/plugins/dedup/calibrate_composite_test.go
+++ b/internal/plugins/dedup/calibrate_composite_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/calibrate_composite_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e5a1c3b-9d2f-4a08-8b61-3c4d5e6f7a89
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 package dedup
 
@@ -279,5 +279,20 @@ func TestCalibrateCompositeApplyPersistsBands(t *testing.T) {
 	}
 	if sig.BandHighMin != recHigh {
 		t.Errorf("persisted band_high_min = %v, want %v", sig.BandHighMin, recHigh)
+	}
+}
+
+// TestCalibrateCompositeParamsDefaultNoApply is the canary the scheduler's
+// label_refinement chain (internal/scheduler/tasks.go, TestLabelRefinementChainPassesNoApply)
+// relies on: empty params must default Apply=false so calibrate-composite reports
+// without persisting band thresholds. If this default ever flips, the scheduled
+// chain's empty-params call would silently become a timed prod mutation.
+func TestCalibrateCompositeParamsDefaultNoApply(t *testing.T) {
+	var p calibrateCompositeParams
+	if err := json.Unmarshal([]byte(`{}`), &p); err != nil {
+		t.Fatalf("unmarshal empty params: %v", err)
+	}
+	if p.Apply {
+		t.Fatal("empty params must default Apply=false (report only); scheduled label_refinement chain depends on this")
 	}
 }

--- a/internal/plugins/dedup/rebuild_gold_labels_test.go
+++ b/internal/plugins/dedup/rebuild_gold_labels_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/rebuild_gold_labels_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2b8e5f14-6a37-4c92-9d05-3f7a8b1c6e40
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 // Tests for the dedup.rebuild-gold-labels op against a real PebbleStore +
 // EmbeddingStore: dry-run diff reporting (changed/unchanged/unlabelable),
@@ -402,5 +402,20 @@ func TestRebuildGoldLabels_Apply_Idempotent(t *testing.T) {
 		if got != want {
 			t.Fatalf("candidate %d: first=%v second=%v — apply is not idempotent", id, want, got)
 		}
+	}
+}
+
+// TestRebuildGoldLabelsParamsDefaultNoApply is the canary the scheduler's
+// label_refinement chain (internal/scheduler/tasks.go, TestLabelRefinementChainPassesNoApply)
+// relies on: empty params must default Apply=false so the op takes its guarded
+// dry-run no-write return. If this default ever flips, the scheduled chain's
+// empty-params call would silently become a timed prod mutation.
+func TestRebuildGoldLabelsParamsDefaultNoApply(t *testing.T) {
+	var p rebuildGoldLabelsParams
+	if err := json.Unmarshal([]byte(`{}`), &p); err != nil {
+		t.Fatalf("unmarshal empty params: %v", err)
+	}
+	if p.Apply {
+		t.Fatal("empty params must default Apply=false (dry-run); scheduled label_refinement chain depends on this")
 	}
 }

--- a/internal/scheduler/tasks.go
+++ b/internal/scheduler/tasks.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/tasks.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9b4c7e21-a5f3-4d08-b2e6-3c8d1f7a0e54
-// last-edited: 2026-06-16
+// last-edited: 2026-07-12
 
 // Package scheduler — task registrations.
 // All 22 registered tasks are defined here. Each task's TriggerFn and
@@ -47,6 +47,19 @@ type seriesNormalizeOpParams struct {
 type schedulerExtraOpParams struct {
 	LegacyOpID string `json:"legacy_op_id"`
 }
+
+// labelRefinementRebuildParams / labelRefinementCalibrateParams are the params
+// the label_refinement scheduled chain passes to dedup.rebuild-gold-labels and
+// dedup.calibrate-composite. They are EMPTY ON PURPOSE: with no apply key,
+// both ops fall back to their built-in dry-run/report default (Apply=false) —
+// rebuild_gold_labels.go takes the guarded `if !params.Apply` no-write return,
+// calibrate_composite.go reports without persisting bands. The scheduled path
+// has NO way to set apply=true; enabling an apply is an operator AskUserQuestion
+// decision only. The Apply==false-on-empty-params guarantee is pinned by
+// canaries in internal/plugins/dedup/{rebuild_gold_labels,calibrate_composite}_test.go.
+type labelRefinementRebuildParams struct{}
+
+type labelRefinementCalibrateParams struct{}
 
 // ---- registration -------------------------------------------------------
 
@@ -189,6 +202,42 @@ func (ts *TaskScheduler) registerAllTasks() {
 		},
 		RunOnStart:             func() bool { return config.AppConfig.Scheduled.DedupRefresh.OnStartup },
 		RunInMaintenanceWindow: func() bool { return config.AppConfig.Maintenance.DedupRefresh },
+	})
+
+	// label_refinement (INIT-1 T6): built-in-DISABLED scheduled chain that, only
+	// when an owner sets scheduled.label_refinement.enabled=true, periodically
+	// runs dedup.rebuild-gold-labels then dedup.calibrate-composite in DRY-RUN
+	// mode and logs a summary. It writes NOTHING — there is no apply on this path.
+	// Deliberately minimal; INIT-6 WF-3 is expected to subsume scheduled.* keys.
+	ts.registerTask(TaskDefinition{
+		Name:        "label_refinement",
+		Description: "Dry-run gold-label refinement chain: rebuild-gold-labels → calibrate-composite (report only; applies are operator-gated)",
+		Category:    "maintenance",
+		TriggerFn: func(source string) (*database.Operation, error) {
+			if ts.deps.Store() == nil {
+				return nil, fmt.Errorf("database not initialized")
+			}
+			if ts.deps.OpRegistry == nil {
+				return nil, fmt.Errorf("operations registry not initialized")
+			}
+			// Run the two-op chain detached so the scheduler tick / manual
+			// Run-Now returns promptly (each op can run for tens of minutes).
+			// No legacy op row is created, so TriggerFn returns a nil op.
+			go ts.runLabelRefinementChain()
+			return nil, nil
+		},
+		IsEnabled: func() bool { return config.AppConfig.Scheduled.LabelRefinement.Enabled },
+		GetInterval: func() time.Duration {
+			mins := config.AppConfig.Scheduled.LabelRefinement.Interval
+			if mins <= 0 {
+				return 0
+			}
+			return time.Duration(mins) * time.Minute
+		},
+		RunOnStart: func() bool { return config.AppConfig.Scheduled.LabelRefinement.OnStartup },
+		// Intentionally NOT part of the maintenance window (also absent from
+		// maintenanceOrder): keeps the task fully inert under default config.
+		RunInMaintenanceWindow: func() bool { return false },
 	})
 
 	ts.registerTask(TaskDefinition{
@@ -793,4 +842,85 @@ func (ts *TaskScheduler) registerAllTasks() {
 		RunOnStart:             func() bool { return false },
 		RunInMaintenanceWindow: func() bool { return true },
 	})
+}
+
+// labelRefinementChainTimeout bounds the whole dry-run chain so a hung op can
+// never leak the detached goroutine forever. It exceeds the sum of the two ops'
+// own timeouts (rebuild-gold-labels 60m + calibrate-composite 30m) plus slack.
+const labelRefinementChainTimeout = 2 * time.Hour
+
+// runLabelRefinementChain enqueues dedup.rebuild-gold-labels then
+// dedup.calibrate-composite, both in DRY-RUN mode (empty params ⇒ Apply=false),
+// waiting for each to reach a terminal state before starting the next, and logs
+// one summary line. It runs detached from TriggerFn and writes NOTHING: neither
+// op mutates state without apply=true, which is never sent on this path.
+func (ts *TaskScheduler) runLabelRefinementChain() {
+	ctx, cancel := context.WithTimeout(context.Background(), labelRefinementChainTimeout)
+	defer cancel()
+	// Cancel promptly on scheduler shutdown so we don't outlive the process.
+	if ts.shutdown != nil {
+		go func() {
+			select {
+			case <-ts.shutdown:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	rebuildID, err := ts.deps.OpRegistry.EnqueueOp(ctx, "dedup.rebuild-gold-labels", labelRefinementRebuildParams{})
+	if err != nil {
+		slog.Warn("label_refinement: failed to enqueue dedup.rebuild-gold-labels", "err", err)
+		return
+	}
+	if !ts.waitForOpV2(ctx, rebuildID) {
+		slog.Warn("label_refinement: rebuild-gold-labels did not complete cleanly; aborting chain", "op", rebuildID)
+		return
+	}
+
+	calibrateID, err := ts.deps.OpRegistry.EnqueueOp(ctx, "dedup.calibrate-composite", labelRefinementCalibrateParams{})
+	if err != nil {
+		slog.Warn("label_refinement: failed to enqueue dedup.calibrate-composite", "err", err)
+		return
+	}
+	if !ts.waitForOpV2(ctx, calibrateID) {
+		slog.Warn("label_refinement: calibrate-composite did not complete cleanly", "op", calibrateID)
+		return
+	}
+
+	slog.Info("label_refinement: dry-run chain complete (report only, nothing written)",
+		"rebuild_op", rebuildID, "calibrate_op", calibrateID)
+}
+
+// waitForOpV2 polls the v2 operation store until opID reaches a terminal state
+// or ctx is canceled; it returns true only on "completed". NOTE: the scheduler's
+// WaitForOperation reads the LEGACY operation:<id> table and would nil-deref on
+// a v2 registry op id (GetOperationByID returns (nil,nil) on not-found), so this
+// polls GetOperationV2 instead — mirroring Server.WaitForOp's terminal set.
+func (ts *TaskScheduler) waitForOpV2(ctx context.Context, opID string) bool {
+	store := ts.deps.Store()
+	if store == nil {
+		return false
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+			row, err := store.GetOperationV2(opID)
+			if err != nil || row == nil {
+				// DB error or not-yet-visible — keep polling until ctx expires.
+				continue
+			}
+			switch row.Status {
+			case "completed":
+				return true
+			case "failed", "canceled", "interrupted_dropped", "interrupted_quiesced":
+				return false
+			}
+			// queued or running — keep polling.
+		}
+	}
 }

--- a/internal/scheduler/tasks_label_refinement_test.go
+++ b/internal/scheduler/tasks_label_refinement_test.go
@@ -1,0 +1,87 @@
+// file: internal/scheduler/tasks_label_refinement_test.go
+// version: 1.0.0
+// guid: 3f1a6c92-8d47-4b0e-9a25-1c7e6b4d0f83
+// last-edited: 2026-07-12
+
+package scheduler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLabelRefinementRegistered verifies the built-in-disabled scheduled chain
+// is registered (INIT-1 T6).
+func TestLabelRefinementRegistered(t *testing.T) {
+	ts := NewTaskScheduler(testDeps())
+	def, ok := ts.GetTask("label_refinement")
+	assert.True(t, ok, "label_refinement task should be registered")
+	assert.Equal(t, "label_refinement", def.Name)
+	assert.Equal(t, "maintenance", def.Category)
+}
+
+// TestLabelRefinementDisabledByDefault verifies the task is inert under the
+// shipped default (scheduled.label_refinement.enabled=false). Provably-inert is
+// the CRITICAL requirement for this task: it must never schedule or run on
+// startup unless an owner opts in.
+func TestLabelRefinementDisabledByDefault(t *testing.T) {
+	// Default/zero-value config ⇒ Enabled=false, OnStartup=false, Interval=0.
+	config.AppConfig.Scheduled.LabelRefinement = config.ScheduledTaskConfig{}
+
+	ts := NewTaskScheduler(testDeps())
+	def, ok := ts.GetTask("label_refinement")
+	assert.True(t, ok)
+	assert.False(t, def.IsEnabled(), "label_refinement must be disabled by default")
+	assert.False(t, def.RunOnStart(), "label_refinement must not run on startup by default")
+	assert.Zero(t, def.GetInterval(), "disabled task must have zero interval (never scheduled)")
+	// Not part of the maintenance window, and absent from maintenanceOrder — the
+	// only two paths that could otherwise run it despite IsEnabled()==false.
+	assert.False(t, def.RunInMaintenanceWindow(), "label_refinement must not run in the maintenance window")
+	assert.NotContains(t, ts.maintenanceOrder, "label_refinement",
+		"label_refinement must not be in maintenanceOrder (keeps it inert on the maintenance path)")
+}
+
+// TestLabelRefinementIntervalGuard verifies a zero/negative interval never
+// yields a positive duration (so an enabled task with Interval<=0 cannot
+// busy-loop the ticker), and that a positive interval maps to minutes.
+func TestLabelRefinementIntervalGuard(t *testing.T) {
+	ts := NewTaskScheduler(testDeps())
+	def, ok := ts.GetTask("label_refinement")
+	assert.True(t, ok)
+
+	config.AppConfig.Scheduled.LabelRefinement.Interval = 0
+	assert.Zero(t, def.GetInterval(), "interval 0 ⇒ manual only, never scheduled")
+	config.AppConfig.Scheduled.LabelRefinement.Interval = -5
+	assert.Zero(t, def.GetInterval(), "negative interval ⇒ zero duration (no busy-loop)")
+	config.AppConfig.Scheduled.LabelRefinement.Interval = 10080
+	assert.Equal(t, int64(10080*60), int64(def.GetInterval().Seconds()), "positive interval maps to minutes")
+
+	config.AppConfig.Scheduled.LabelRefinement = config.ScheduledTaskConfig{} // reset
+}
+
+// TestLabelRefinementChainPassesNoApply asserts the params the scheduled chain
+// passes to BOTH dedup ops carry no "apply" key — the entire "the scheduled
+// loop never applies" guarantee.
+//
+// "No apply key" equals "dry-run" ONLY because both ops default Apply=false when
+// the key is absent. That default is pinned by the companion canaries
+// TestRebuildGoldLabelsParamsDefaultNoApply (rebuild_gold_labels_test.go) and
+// TestCalibrateCompositeParamsDefaultNoApply (calibrate_composite_test.go): if a
+// future edit flips either default, those canaries fail and this empty-params
+// chain is caught before it silently becomes a timed prod mutation.
+//
+// These are the exact param values runLabelRefinementChain passes to EnqueueOp.
+func TestLabelRefinementChainPassesNoApply(t *testing.T) {
+	rebuild, err := json.Marshal(labelRefinementRebuildParams{})
+	assert.NoError(t, err)
+	assert.JSONEq(t, "{}", string(rebuild), "rebuild params must be empty (no apply key)")
+	assert.NotContains(t, string(rebuild), "apply")
+
+	calibrate, err := json.Marshal(labelRefinementCalibrateParams{})
+	assert.NoError(t, err)
+	assert.JSONEq(t, "{}", string(calibrate), "calibrate params must be empty (no apply key)")
+	assert.NotContains(t, string(calibrate), "apply")
+}


### PR DESCRIPTION
Adds scheduled.label_refinement (default enabled=false) chaining
dedup.rebuild-gold-labels and dedup.calibrate-composite in dry-run/report
mode only — applies remain operator AskUserQuestion decisions. Kept minimal
by design: INIT-6 WF-3 is expected to subsume these scheduled.* keys.

The chain polls GetOperationV2 (not the scheduler's legacy WaitForOperation,
which would nil-deref on a v2 registry op id) and runs detached so the tick
returns promptly. Provably inert by default: disabled, not on startup, not in
the maintenance window, and absent from maintenanceOrder. Empty-params →
Apply=false is pinned by canaries in the two dedup plugin test files.

Co-Authored-By: Claude <noreply@anthropic.com>
