### PR TITLE
feat(download): add UpdateStoragePath re-point semantics to TorrentClient (INIT-5 T1)

### DIFF
--- a/internal/download/client.go
+++ b/internal/download/client.go
@@ -1,14 +1,22 @@
 // file: internal/download/client.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 404055b4-a238-453f-80a7-f6303ab23ec1
+// last-edited: 2026-07-12
 
 // Package download provides torrent and Usenet client integrations.
 package download
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrRePointUnsupported is returned by TorrentClient.UpdateStoragePath
+// implementations that have not yet implemented re-point-only relocation.
+// It is fail-closed: callers must treat it as "the old path is still the one
+// registered with the client" and must NOT assume the storage path changed.
+var ErrRePointUnsupported = errors.New("re-point-only relocation not supported by this client")
 
 // TorrentInfo is the read-only view of a single torrent that the organizer
 // needs. Fields map directly to the native API responses of each client; the
@@ -64,8 +72,23 @@ type TorrentClient interface {
 	// It returns only the fields the cleanup loop needs.
 	GetUploadStats(ctx context.Context, id string) (*UploadStats, error)
 
-	// SetDownloadPath relocates a torrent to a new directory on disk.
+	// SetDownloadPath performs a PHYSICAL relocation of a torrent: it asks the
+	// client to move the data to a new directory on disk (Deluge
+	// core.move_storage / qBittorrent setLocation). Use UpdateStoragePath
+	// instead when the caller has ALREADY moved the data and only needs the
+	// client's registered path re-pointed.
 	SetDownloadPath(ctx context.Context, id, newPath string) error
+
+	// UpdateStoragePath is a RE-POINT-ONLY relocation: the caller has already
+	// moved the data on disk and only needs the client's registered storage
+	// path updated to match. Implementations MUST be fail-closed on RPC errors
+	// — on any RPC failure the OLD path must stay registered (return the error;
+	// never leave the client pointed at a path whose move was not confirmed).
+	// A process crash inside a remove-before-re-add window (mechanism-A
+	// residual) is documented in the spec's T2 spike protocol and is not
+	// promisable away here. Implementors that have not yet landed a real
+	// mechanism MUST return ErrRePointUnsupported (fail-closed).
+	UpdateStoragePath(ctx context.Context, id, newPath string) error
 
 	// RemoveTorrent removes the torrent from the client.
 	RemoveTorrent(ctx context.Context, id string, deleteFiles bool) error

--- a/internal/download/deluge.go
+++ b/internal/download/deluge.go
@@ -1,6 +1,7 @@
 // file: internal/download/deluge.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 466129e8-037a-4da5-a961-078808151e0e
+// last-edited: 2026-07-12
 
 package download
 
@@ -189,7 +190,9 @@ func (d *DelugeClient) GetUploadStats(ctx context.Context, id string) (*UploadSt
 	}, nil
 }
 
-// SetDownloadPath moves a torrent to a new download directory.
+// SetDownloadPath performs a PHYSICAL move of a torrent's data to a new
+// download directory (Deluge core.move_storage). For re-point-only relocation
+// where the caller has already moved the data, use UpdateStoragePath instead.
 func (d *DelugeClient) SetDownloadPath(ctx context.Context, id, newPath string) error {
 	_, err := d.call(ctx, "core.set_torrent_move_completed_path", id, newPath)
 	if err != nil {
@@ -197,6 +200,14 @@ func (d *DelugeClient) SetDownloadPath(ctx context.Context, id, newPath string) 
 	}
 	_, err = d.call(ctx, "core.move_storage", []string{id}, newPath)
 	return err
+}
+
+// UpdateStoragePath is the re-point-only relocation stub. It is fail-closed:
+// until the real-Deluge spike (TASK-02) lands a confirmed mechanism, it returns
+// ErrRePointUnsupported so callers never assume a path change that did not
+// happen.
+func (d *DelugeClient) UpdateStoragePath(ctx context.Context, id, newPath string) error {
+	return ErrRePointUnsupported
 }
 
 // RemoveTorrent removes a torrent from the client.

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,5 +1,6 @@
 // file: internal/download/download_test.go
-// version: 1.1.0
+// version: 1.2.0
+// last-edited: 2026-07-12
 
 package download
 
@@ -58,6 +59,31 @@ func TestUsenetClientInterface(t *testing.T) {
 			// Just checking that the type assertions work
 			if tt.client == nil {
 				t.Error("client should not be nil")
+			}
+		})
+	}
+}
+
+// TestUpdateStoragePathFailClosed verifies that the re-point-only relocation
+// stubs on both torrent clients are fail-closed: they return
+// ErrRePointUnsupported until TASK-02 (Deluge) / TASK-05 (qBittorrent) land a
+// real mechanism.
+func TestUpdateStoragePathFailClosed(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		client TorrentClient
+	}{
+		{name: "DelugeClient", client: &DelugeClient{}},
+		{name: "QBittorrentClient", client: &QBittorrentClient{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.client.UpdateStoragePath(ctx, "test-id", "/new/path")
+			if !errors.Is(err, ErrRePointUnsupported) {
+				t.Errorf("expected ErrRePointUnsupported, got %v", err)
 			}
 		})
 	}

--- a/internal/download/qbittorrent.go
+++ b/internal/download/qbittorrent.go
@@ -1,6 +1,7 @@
 // file: internal/download/qbittorrent.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: b1275f4a-b460-48d6-9a95-ac95ac9056fb
+// last-edited: 2026-07-12
 
 package download
 
@@ -177,7 +178,9 @@ func (q *QBittorrentClient) GetUploadStats(ctx context.Context, id string) (*Upl
 	}, nil
 }
 
-// SetDownloadPath moves a torrent to a new download directory.
+// SetDownloadPath performs a PHYSICAL move of a torrent's data to a new
+// download directory (qBittorrent setLocation). For re-point-only relocation
+// where the caller has already moved the data, use UpdateStoragePath instead.
 func (q *QBittorrentClient) SetDownloadPath(ctx context.Context, id, newPath string) error {
 	data := url.Values{"hashes": {id}, "location": {newPath}}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, q.baseURL+"/api/v2/torrents/setLocation", strings.NewReader(data.Encode()))
@@ -194,6 +197,14 @@ func (q *QBittorrentClient) SetDownloadPath(ctx context.Context, id, newPath str
 		return fmt.Errorf("qbittorrent: setLocation returned status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// UpdateStoragePath is the re-point-only relocation stub. It is fail-closed:
+// until the guarded qBittorrent re-point work (TASK-05) lands a confirmed
+// mechanism, it returns ErrRePointUnsupported so callers never assume a path
+// change that did not happen.
+func (q *QBittorrentClient) UpdateStoragePath(ctx context.Context, id, newPath string) error {
+	return ErrRePointUnsupported
 }
 
 // RemoveTorrent removes a torrent from the client.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,5 +1,6 @@
 // file: internal/plugin/plugin.go
-// version: 1.1.0
+// version: 1.1.1
+// last-edited: 2026-07-12
 
 package plugin
 
@@ -43,7 +44,14 @@ type Deps struct {
 	Router PluginRouter
 }
 
-// DownloadClient is implemented by plugins that manage a download client.
+// DownloadClient is VESTIGIAL — it has zero implementors and is NOT the seam
+// for torrent-client work. It embeds this package's Plugin base
+// (Capabilities/Init/Shutdown/HealthCheck), but the real download plugin
+// (internal/plugins/deluge) implements a DIFFERENT base — pkg/plugin/sdk.Plugin
+// — so a compile-assert against this interface can never hold without bridging
+// two plugin frameworks. New torrent-client work extends
+// internal/download.TorrentClient (which has real implementors and a config
+// factory) instead of this interface.
 type DownloadClient interface {
 	Plugin
 	TestConnection() error


### PR DESCRIPTION
Extends the existing internal/download.TorrentClient interface with a
re-point-only relocation method distinct from the physical SetDownloadPath,
with fail-closed ErrRePointUnsupported stubs on the Deluge and qBittorrent
clients until the real-Deluge spike (TASK-02) lands the mechanism. Marks the
vestigial internal/plugin.DownloadClient as not-the-seam (doc-comment only).

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
