### PR TITLE
refactor(logging): wire op-context slog call sites to logging.* — shard 1/1 (SLOG-W13, #1254)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.94.0 -->
+<!-- version: 9.95.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-11 -->
+<!-- last-edited: 2026-07-12 -->
 
 # Project TODO
 
@@ -1589,7 +1589,7 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ### Remaining slog / logging work
 
-- [ ] **SLOG-W13** [hold] Wire `logging.Info(ctx, ...)` into long-tail async ops that currently use raw `slog.Info`: `runBulkWriteBack`, ISBN enrichment goroutine, iTunes sync ops, batch poller, scanner deep paths. ~1363 raw `slog.Info/Warn/Error/Debug` calls across 193 files remain. Priority: any code inside an op-context flow (where `logging.WithOp` has been called upstream). Code outside ops (startup, background goroutines) can stay as raw slog.  <!-- 2026-07-01: ◑ PARTIAL: batch_poller + isbn flows wired (commit 7f5c28f1); runBulkWriteBack, iTunes sync, scanner deep paths remain (~1363 raw slog calls). Re-held per db977ae3 (context overflow). -->  <!-- 2026-07-01: further progress — writeback+ISBN #1715, scanner deep paths #1724 done; iTunes sync n/a (ops are stubs); broad ~1363-call residual remains open -->
+- [ ] **SLOG-W13** [hold] Wire `logging.Info(ctx, ...)` into long-tail async ops that currently use raw `slog.Info`: `runBulkWriteBack`, ISBN enrichment goroutine, iTunes sync ops, batch poller, scanner deep paths. ~1363 raw `slog.Info/Warn/Error/Debug` calls across 193 files remain. Priority: any code inside an op-context flow (where `logging.WithOp` has been called upstream). Code outside ops (startup, background goroutines) can stay as raw slog.  <!-- 2026-07-01: ◑ PARTIAL: batch_poller + isbn flows wired (commit 7f5c28f1); runBulkWriteBack, iTunes sync, scanner deep paths remain (~1363 raw slog calls). Re-held per db977ae3 (context overflow). -->  <!-- 2026-07-01: further progress — writeback+ISBN #1715, scanner deep paths #1724 done; iTunes sync n/a (ops are stubs); broad ~1363-call residual remains open -->  <!-- 2026-07-12: SLOG-W13 sweep shard (ux-small-items TASK-07): wired 14 op-flow sites across 4 op-plugin files — deluge import.go(2)+centralization.go(1), maintenance optimize.go(8)+cleanup.go(3). Residual = 1422 raw slog.Info/Warn/Error/Debug (non-test) across internal/. Out-of-scope (staying raw, per in/out test): no-ctx-in-scope funcs (itunes/adapter.go, acoustid/backfill.go fingerprint helpers, internal/organizer/*), startup/lifecycle (plugin PostInit hooks, plugin/registry.go Register/InitAll/ShutdownAll), and background goroutines (plugin/events.go EventBus.Publish). Deferred-contested (NOT swept — dispatch trailing shard only AFTER sibling branches merge): internal/dedup/** (116), internal/plugins/dedup/** (19) — actively edited by agent/dedup-label-quality-* and agent/metadata-matching-* branches at sweep time; internal/database/embedding_store.go and internal/server/metadata_ops.go currently have 0 raw slog. -->
 - [ ] **SLOG-PROD-VERIFY** Smoke-test metadata-fetch on prod to verify the full chain (opID in logs, `/api/v1/operations/:id/activity` returns rows).  <!-- 2026-07-01: ⏳ code/endpoint exist (docs/slog-prod-verify.md); remaining is a live-prod smoke-test run. -->
 - [x] **CACHE-WARMUP-ROOT-CAUSE** Investigate root cause of cache warm-up OOM. Likely issue: `List*WithCounts()` allocates unboundedly during scan, or the `Server` struct cache fields retain full API response objects. Once fixed, re-enable startup preload. — ✅ verified done 2026-07-01: startup preload re-enabled (server_lifecycle.go:277); warmers rewritten to typed counts, no gin.H (entity_cache_warmers.go, commit 4515cb2c). Live OOM re-confirmation is operational.
 

--- a/internal/plugins/deluge/centralization.go
+++ b/internal/plugins/deluge/centralization.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/deluge/centralization.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-07
+// last-edited: 2026-07-12
 
 package deluge
 
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
@@ -165,7 +165,7 @@ func (p *Plugin) runCentralization(ctx context.Context, params json.RawMessage, 
 			if moveErr := p.client.MoveStorage([]string{bf.DelugeHash}, filepath.Dir(dest)); moveErr != nil {
 				reporter.Logger().Warn("deluge move_storage failed", "hash", bf.DelugeHash, "error", moveErr)
 			} else {
-				slog.Info("deluge move_storage succeeded", "hash", bf.DelugeHash, "dir", filepath.Dir(dest))
+				logging.Info(ctx, "deluge move_storage succeeded", "hash", bf.DelugeHash, "dir", filepath.Dir(dest))
 			}
 		}
 

--- a/internal/plugins/deluge/import.go
+++ b/internal/plugins/deluge/import.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/deluge/import.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: f1e2d3c4-b5a6-7890-cdef-0123456789ab
-// last-edited: 2026-05-15
+// last-edited: 2026-07-12
 
 package deluge
 
@@ -11,9 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"log/slog"
-
 	delugeclient "github.com/falkcorp/audiobook-organizer/internal/deluge"
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 )
 
 // importToLibrary reflinks src into dst (falls back to copy), updates the DB,
@@ -41,7 +40,7 @@ func (p *Plugin) importToLibrary(ctx context.Context, torrentHash, srcPath, dstP
 	// 4. Update DB: set imported_from_deluge_at, deluge_original_path
 	if p.store != nil {
 		if err := p.store.MarkFileImportedFromDeluge(ctx, srcPath, dstPath, torrentHash); err != nil {
-			slog.Warn("failed to update deluge import record", "err", err)
+			logging.Warn(ctx, "failed to update deluge import record", "err", err)
 			// non-fatal: file is already copied
 		}
 	}
@@ -49,7 +48,7 @@ func (p *Plugin) importToLibrary(ctx context.Context, torrentHash, srcPath, dstP
 	// 5. Call core.move_storage (best-effort)
 	if p.client != nil && torrentHash != "" {
 		if err := p.client.MoveStorage([]string{torrentHash}, filepath.Dir(dstPath)); err != nil {
-			slog.Warn("core.move_storage failed; Deluge will seed from original path", "err", err, "torrent", torrentHash)
+			logging.Warn(ctx, "core.move_storage failed; Deluge will seed from original path", "err", err, "torrent", torrentHash)
 			// non-fatal: the import succeeded even if seeding location doesn't update
 		}
 	}

--- a/internal/plugins/maintenance/cleanup.go
+++ b/internal/plugins/maintenance/cleanup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/cleanup.go
-// version: 1.0.1
+// version: 1.0.2
 // guid: c3d4e5f6-a7b8-9012-cdef-234567890123
-// last-edited: 2026-05-07
+// last-edited: 2026-07-12
 
 package maintenance
 
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -153,7 +154,7 @@ func (p *Plugin) runCleanupActivityLog(ctx context.Context, _ json.RawMessage, r
 	}
 	msg := fmt.Sprintf("Activity log cleanup: compacted %d, summarized %d, pruned %d",
 		compacted, summarized, pruned)
-	slog.Info(msg)
+	logging.Info(ctx, msg)
 	_ = reporter.Log(slog.LevelInfo, msg)
 	return nil
 }
@@ -238,10 +239,10 @@ func (p *Plugin) runCleanupOldBackups(ctx context.Context, _ json.RawMessage, re
 			age := time.Since(info.ModTime())
 			if age > maxAge {
 				if rmErr := os.Remove(path); rmErr != nil {
-					slog.Warn("failed to remove old backup", "path", path, "err", rmErr)
+					logging.Warn(ctx, "failed to remove old backup", "path", path, "err", rmErr)
 				} else {
 					removed++
-					slog.Info("cleaned up old backup", "path", path, "age", age.Round(time.Hour))
+					logging.Info(ctx, "cleaned up old backup", "path", path, "age", age.Round(time.Hour))
 				}
 			}
 		}

--- a/internal/plugins/maintenance/optimize.go
+++ b/internal/plugins/maintenance/optimize.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/optimize.go
-// version: 1.0.0
+// version: 1.0.1
 // guid: d4e5f6a7-b8c9-0123-4567-890123456789
-// last-edited: 2026-05-19
+// last-edited: 2026-07-12
 
 package maintenance
 
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -51,7 +52,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 	opID := ctxOpID(ctx)
 	start := time.Now()
 
-	slog.Info("library.optimize: sweep started",
+	logging.Info(ctx, "library.optimize: sweep started",
 		"operation_id", opID,
 	)
 	_ = reporter.Log(slog.LevelInfo, "Library optimize sweep started")
@@ -90,7 +91,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 
 	for i, ch := range children {
 		if reporter.IsCanceled() {
-			slog.Info("library.optimize: sweep canceled",
+			logging.Info(ctx, "library.optimize: sweep canceled",
 				"operation_id", opID,
 				"completed", completed,
 				"failed", failed,
@@ -108,7 +109,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		prog.StepN(i, fmt.Sprintf("Running child op %d/%d: %s", i+1, total, ch.name))
 
 		childStart := time.Now()
-		slog.Info("library.optimize: child started",
+		logging.Info(ctx, "library.optimize: child started",
 			"operation_id", opID,
 			"child", ch.name,
 			"def_id", ch.defID,
@@ -120,7 +121,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		childID, err := p.deps.EnqueueOp(ctx, ch.defID, ch.params)
 		if err != nil {
 			elapsed := time.Since(childStart)
-			slog.Warn("library.optimize: child enqueue failed",
+			logging.Warn(ctx, "library.optimize: child enqueue failed",
 				"operation_id", opID,
 				"child", ch.name,
 				"def_id", ch.defID,
@@ -133,7 +134,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 			continue
 		}
 
-		slog.Info("library.optimize: child enqueued",
+		logging.Info(ctx, "library.optimize: child enqueued",
 			"operation_id", opID,
 			"child", ch.name,
 			"child_id", childID,
@@ -142,7 +143,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		// Wait for the child to reach a terminal state.
 		if waitErr := p.deps.WaitForOp(ctx, childID); waitErr != nil {
 			elapsed := time.Since(childStart)
-			slog.Warn("library.optimize: child failed or timed out",
+			logging.Warn(ctx, "library.optimize: child failed or timed out",
 				"operation_id", opID,
 				"child", ch.name,
 				"child_id", childID,
@@ -156,7 +157,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 		}
 
 		elapsed := time.Since(childStart)
-		slog.Info("library.optimize: child completed",
+		logging.Info(ctx, "library.optimize: child completed",
 			"operation_id", opID,
 			"child", ch.name,
 			"child_id", childID,
@@ -168,7 +169,7 @@ func (p *Plugin) runOptimize(ctx context.Context, _ json.RawMessage, reporter sd
 	}
 
 	totalElapsed := time.Since(start)
-	slog.Info("library.optimize: sweep complete",
+	logging.Info(ctx, "library.optimize: sweep complete",
 		"operation_id", opID,
 		"children_completed", completed,
 		"children_failed", failed,


### PR DESCRIPTION
Mechanical reroute so op-flow log lines carry the op-ID chain; call sites
without ctx in scope are left raw and recorded in the residual note. No
signatures changed.

Scope: 14 op-flow sites across 4 op-plugin files (deluge import.go,
centralization.go; maintenance optimize.go, cleanup.go). Contested paths
(internal/dedup/**, internal/plugins/dedup/**, metadata_ops.go) EXCLUDED —
they are actively edited by unmerged sibling branches; deferred to a
trailing shard per the brief's dedup-partition rule. Residual count and
category breakdown recorded in TODO.md SLOG-W13.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
