### PR TITLE
fix(dedup): same-title/high-sim not_dup mining guard (INIT-1 adjacent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,33 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.143.0 -->
+<!-- version: 3.144.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-11 -->
+<!-- last-edited: 2026-07-12 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 12, 2026 - fix(dedup): same-title/high-similarity not_dup mining guard (INIT-1 adjacent)
+
+- **`dedup`** (backend) — the deterministic mining rule `partVsWhole`
+  (`internal/dedup/dataset/rules.go`) no longer emits `not_dup` for a pair whose only
+  negative evidence is a duration ratio when the two books share an identical normalized
+  title AND carry high candidate similarity (≥0.95) AND the title is not a compiled-in
+  boilerplate ident — such pairs now go `unsure` (queued for review) instead. Prod evidence
+  (`/dedup/labels/export`, 2026-07-12): 565 of 1332 `not_dup` were same-title part-vs-whole,
+  of which ~267 are real books (e.g. "Foundation", "The Last Hunter") split by corrupt/part
+  durations (durations of 154h/4147h) at cosine ~1.0 — real duplicates that
+  `dedup.dataset-backfill` was then *dismissing* out of the review queue.
+- Boilerplate idents are carved out: "Big Finish Ident" (298 of the 565 pairs — a recurring
+  publisher jingle, legitimately not a book duplicate) is added to the shared boilerplate
+  blocklist and keeps its `not_dup` label. The compiled-in default patterns + a pure matcher
+  moved to a new leaf package `internal/boilerplate` so the offline mining rules can reuse the
+  exact same list the live engine gate uses (the two previously could not share it — an import
+  cycle). The engine gate now also drops future "Big Finish Ident" candidates.
+- Rule change affects only future `Classify` runs; the ~267 already-mislabeled rows require an
+  operator `dedup.dataset-backfill` (apply) re-run to be relabeled.
 
 #### July 11, 2026 - test(audiobooks): parity-lock the shipped heavy-filter pushdown (INIT-4 T6)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.95.1 -->
+<!-- version: 9.96.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-12 -->
 
@@ -65,6 +65,13 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
     `config.DedupSignalConfig` persists band thresholds but has no per-kind confidence field —
     adding one (a `map[string]KindConfig` under `dedup.signals`) would let the confidence round
     become applyable instead of a manual config.yaml edit.
+  - [x] INIT-1 T07 follow-up — same-title / high-similarity `not_dup` mining guard: `partVsWhole`
+    routes same-title + sim≥0.95 + non-boilerplate pairs to `unsure` instead of `not_dup`
+    (`internal/dedup/dataset/rules.go`); "Big Finish Ident" added to a shared leaf blocklist
+    (`internal/boilerplate`) and kept `not_dup`. Fixes the residual cosine-1.0 `not_dup`
+    contamination class the re-mine (T07) surfaced. **Follow-up (operator):** re-run
+    `dedup.dataset-backfill` (apply) to relabel the ~267 already-mislabeled prod rows, then
+    `dedup.calibrate-composite` / embedding-threshold calibration to realize the precision gain.
   - **INIT-2's `internal/dedup/engine.go` tasks (T03 + T05) are both merged**, which unblocks
     Phase B: INIT-1 TASK-08 and INIT-4 TASK-05 (both rebase on that file) can now start.
 - **Wave 2b (4 PRs, #1885–#1888, merged 2026-07-11):** see

--- a/internal/boilerplate/patterns.go
+++ b/internal/boilerplate/patterns.go
@@ -1,0 +1,96 @@
+// file: internal/boilerplate/patterns.go
+// version: 1.0.0
+// guid: e8d1c3a7-4b62-4f90-9a15-2c7e6b0d4f38
+// last-edited: 2026-07-12
+
+// Package boilerplate holds the compiled-in list of publisher intro/outro
+// "titles" that are not real books, plus a pure matcher over that list. It is a
+// leaf package (imports only internal/util) so it can be shared by both the
+// live dedup engine (internal/dedup) and the offline mining rules
+// (internal/dedup/dataset) — which cannot import internal/dedup because
+// internal/dedup already imports internal/dedup/dataset (an import cycle).
+//
+// This package is the SINGLE SOURCE OF TRUTH for the default patterns. The
+// engine's config-extra append path (internal/dedup/boilerplate.go) layers
+// deployment-specific extras ON TOP of these defaults; the matcher here is
+// deliberately defaults-only so deterministic mining does not depend on
+// per-deployment config.
+package boilerplate
+
+import (
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/util"
+)
+
+// DefaultTitlePatterns are exact publisher intro/outro "titles" that are not
+// real books and must not seed dedup matches. Seeded from
+// docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md and safe to extend.
+var DefaultTitlePatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"end credits",
+	"credits",
+	"opening credits",
+	"closing credits",
+	"intro",
+	"introduction",
+	"outro",
+	"epilogue music",
+	"publisher introduction",
+	"publisher's note",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+	// "big finish ident" is the recurring Big Finish audio-drama publisher jingle
+	// extracted as a standalone track across hundreds of releases. It is
+	// embedding-identical (cosine ~1.0) to every other copy of itself but is not
+	// a book, so pairs of it are legitimately not_dup — this entry keeps the
+	// same-title/high-similarity mining guard from wrongly downgrading those
+	// correct not_dup labels to unsure (298 such pairs on prod, 2026-07-12).
+	"big finish ident",
+}
+
+// DefaultPrefixPatterns are anchored boilerplate phrases that may carry trailing
+// publisher copy. Kept narrower than DefaultTitlePatterns so real books like
+// "Introduction to Algorithms" still match normally.
+var DefaultPrefixPatterns = []string{
+	"this is audible",
+	"audible hopes you have enjoyed this program",
+	"audible hopes you have enjoyed this book",
+	"audible studios presents",
+	"audible presents",
+	"this is an audible original",
+	"produced by audible studios",
+	"recorded books presents",
+	"graphic audio presents",
+	"brilliance audio presents",
+}
+
+// IsBoilerplateTitle reports whether title matches one of the compiled-in
+// default patterns after normalization (lowercase, collapsed whitespace). It
+// mirrors the normalization used by internal/dedup's isBoilerplateTitle so the
+// two agree on the default set. Config extras are intentionally NOT consulted
+// here (see package doc).
+func IsBoilerplateTitle(title string) bool {
+	normalized := util.NormalizeTitle(util.CollapseSpaces(title))
+	if normalized == "" {
+		return false
+	}
+	for _, pattern := range DefaultTitlePatterns {
+		if normalized == pattern {
+			return true
+		}
+	}
+	for _, pattern := range DefaultPrefixPatterns {
+		if strings.HasPrefix(normalized, pattern+" ") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/boilerplate/patterns_test.go
+++ b/internal/boilerplate/patterns_test.go
@@ -1,0 +1,31 @@
+// file: internal/boilerplate/patterns_test.go
+// version: 1.0.0
+// guid: b2f4a6d8-1c30-4e75-9f82-6a3d5c7e0b41
+// last-edited: 2026-07-12
+
+package boilerplate
+
+import "testing"
+
+func TestIsBoilerplateTitle(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+	}{
+		{"Intro", true},
+		{"intro", true},
+		{"  Big Finish Ident  ", true}, // whitespace-normalized default
+		{"BIG FINISH IDENT", true},
+		{"Credits", true},
+		{"This Is Audible presenting the show", true}, // prefix pattern
+		{"Introduction to Algorithms", false},         // real book, prefix must not over-match
+		{"Foundation", false},
+		{"The Last Hunter", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsBoilerplateTitle(c.title); got != c.want {
+			t.Errorf("IsBoilerplateTitle(%q) = %v, want %v", c.title, got, c.want)
+		}
+	}
+}

--- a/internal/dedup/boilerplate.go
+++ b/internal/dedup/boilerplate.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/boilerplate.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2349d60e-e5e8-4c03-b3a7-0123a0b0bf36
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 package dedup
 
@@ -9,58 +9,24 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/falkcorp/audiobook-organizer/internal/boilerplate"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
 
-// boilerplateTitlePatterns are exact publisher intro/outro "titles" that are
-// not real books and must not seed dedup matches. Seeded from
-// docs/agent-tasks/dedup-intro-falsepositive/FINDINGS.md and safe to extend.
-//
-// This list is the compiled-in DEFAULT set and is ALWAYS active — config
-// extras (config.DedupBoilerplateConfig, INIT-4 T5) only APPEND to it, never
-// replace it (spec docs/specs/2026-07-10-filtering-search-design.md Decision
-// 8: a replace escape hatch would let a misconfigured deployment silently
-// drop all Audible/publisher suppression and re-open the dedup false-positive
-// bug this list exists to prevent).
-var boilerplateTitlePatterns = []string{
-	"this is audible",
-	"audible hopes you have enjoyed this program",
-	"audible hopes you have enjoyed this book",
-	"audible studios presents",
-	"audible presents",
-	"this is an audible original",
-	"end credits",
-	"credits",
-	"opening credits",
-	"closing credits",
-	"intro",
-	"introduction",
-	"outro",
-	"epilogue music",
-	"publisher introduction",
-	"publisher's note",
-	"produced by audible studios",
-	"recorded books presents",
-	"graphic audio presents",
-	"brilliance audio presents",
-}
+// boilerplateTitlePatterns / boilerplateTitlePrefixPatterns are the compiled-in
+// DEFAULT sets, now owned by the shared leaf package internal/boilerplate so the
+// offline mining rules (internal/dedup/dataset, which cannot import this package
+// without an import cycle) can reuse the exact same list. These defaults are
+// ALWAYS active — config extras (config.DedupBoilerplateConfig, INIT-4 T5) only
+// APPEND to them, never replace them (spec
+// docs/specs/2026-07-10-filtering-search-design.md Decision 8: a replace escape
+// hatch would let a misconfigured deployment silently drop all Audible/publisher
+// suppression and re-open the dedup false-positive bug this list exists to
+// prevent).
+var boilerplateTitlePatterns = boilerplate.DefaultTitlePatterns
 
-// boilerplateTitlePrefixPatterns are anchored boilerplate phrases that may carry
-// trailing publisher copy. Keep this list narrower than the exact-title list so
-// real books like "Introduction to Algorithms" still match normally.
-var boilerplateTitlePrefixPatterns = []string{
-	"this is audible",
-	"audible hopes you have enjoyed this program",
-	"audible hopes you have enjoyed this book",
-	"audible studios presents",
-	"audible presents",
-	"this is an audible original",
-	"produced by audible studios",
-	"recorded books presents",
-	"graphic audio presents",
-	"brilliance audio presents",
-}
+var boilerplateTitlePrefixPatterns = boilerplate.DefaultPrefixPatterns
 
 // boilerplateInit guards the one-time build of effectiveTitlePatterns /
 // effectivePrefixPatterns from the compiled-in defaults above plus any

--- a/internal/dedup/dataset/rules.go
+++ b/internal/dedup/dataset/rules.go
@@ -1,15 +1,31 @@
 // file: internal/dedup/dataset/rules.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9e2b4c71-3a85-4d60-8f29-1b7c6a4e5d02
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 package dataset
 
 import (
 	"fmt"
 
+	"github.com/falkcorp/audiobook-organizer/internal/boilerplate"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
+
+// sameTitleHighSimThreshold is the candidate-similarity floor at/above which a
+// same-title pair is treated as "suspected same work" by the partVsWhole guard.
+// Set to the whole-book signature match threshold (0.95) for consistency.
+//
+// Caveat: for the dominant "exact" candidate layer, LabeledExample.Similarity is
+// an exact-title-match score (≈1.0 whenever titles match), NOT the author-aware
+// embedding cosine — so on that layer this gate does NOT separate same-work from
+// a genuine same-title/different-work collision. The guard's safety does not
+// rest on the gate: it routes to unsure (a review-queue holding state that never
+// merges), so even a genuine collision landing in unsure cannot cause a wrong
+// merge. The threshold is kept as a conservative filter for the non-exact layers
+// (embedding/acoustid/llm) and to require *some* positive similarity evidence.
+const sameTitleHighSimThreshold = 0.95
 
 // partVsWholeRatioMax is the duration-ratio ceiling below which a pair is
 // classified as a part matched against a whole book (not a duplicate).
@@ -30,7 +46,7 @@ const minPlausibleAudioBytes = 256 * 1024 // 256 KiB
 //  1. wholeBookSignatureMatch → true_dup  (strong positive oracle)
 //  2. missingFile             → unsure   (file absence is evidence-free for dup-ness)
 //  3. implausibleAudio        → not_dup  (hard negative: stub/placeholder side)
-//  4. partVsWhole             → not_dup  (hard negative: duration mismatch; unsure when the pair shares identity — unit corruption)
+//  4. partVsWhole             → not_dup  (hard negative: duration mismatch; unsure when the pair shares identity — unit corruption — OR shares a non-boilerplate title at high similarity — suspected same work)
 func Classify(ex database.LabeledExample) (label, reason string, fires bool) {
 	if l, r, ok := wholeBookSignatureMatch(ex); ok {
 		return l, r, true
@@ -134,7 +150,38 @@ func partVsWhole(ex database.LabeledExample) (string, string, bool) {
 		if SharesIdentity(ex) {
 			return "unsure", fmt.Sprintf("duration ratio %.3f but pair shares identity — suspected unit corruption", ex.DurationRatio), true
 		}
+		// A same-title, high-similarity pair whose only negative evidence is the
+		// duration ratio is far more likely a same-work mismatch (a partial/sample
+		// file, an abridged edition, or — very commonly on prod — a corrupt
+		// duration inflating the ratio) than a genuine part-vs-whole. Rather than
+		// poison the gold set with a false not_dup (which dataset-backfill would
+		// then *dismiss*, pulling a real duplicate out of review), route to unsure.
+		// Boilerplate idents (e.g. "Big Finish Ident") are excluded: they are
+		// embedding-identical to every copy of themselves but are legitimately
+		// not_dup at the book level, so they keep the not_dup label.
+		if sharesNonBoilerplateTitleAtHighSim(ex) {
+			return "unsure", fmt.Sprintf("duration ratio %.3f but same title at high similarity — suspected same work", ex.DurationRatio), true
+		}
 		return "not_dup", fmt.Sprintf("duration ratio %.3f — part vs whole", ex.DurationRatio), true
 	}
 	return "", "", false
+}
+
+// sharesNonBoilerplateTitleAtHighSim reports whether the pair has identical
+// normalized (non-empty) titles, a candidate similarity at/above
+// sameTitleHighSimThreshold, and a title that is NOT a compiled-in boilerplate
+// ident. It is the predicate for partVsWhole's same-work guard. Similarity is
+// unknown (nil) on some rows; treat unknown as "not high" so the guard stays
+// conservative and only fires on positive similarity evidence.
+func sharesNonBoilerplateTitleAtHighSim(ex database.LabeledExample) bool {
+	ta := util.NormalizeTitle(util.CollapseSpaces(ex.A.Title))
+	tb := util.NormalizeTitle(util.CollapseSpaces(ex.B.Title))
+	if ta == "" || ta != tb {
+		return false
+	}
+	if ex.Similarity == nil || *ex.Similarity < sameTitleHighSimThreshold {
+		return false
+	}
+	// Both titles are equal here, so checking either side is sufficient.
+	return !boilerplate.IsBoilerplateTitle(ex.A.Title)
 }

--- a/internal/dedup/dataset/rules_test.go
+++ b/internal/dedup/dataset/rules_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/dataset/rules_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c1d4e8b5-7f23-4a90-9b01-6e2c5d8f3a47
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 package dataset
 
@@ -257,5 +257,109 @@ func TestPartVsWholeGenuineStillNotDup(t *testing.T) {
 	}
 	if SharesIdentity(bothEmpty) {
 		t.Fatal("all-empty identity must not report SharesIdentity")
+	}
+}
+
+// simPtr is a test helper for the *float64 LabeledExample.Similarity field.
+func simPtr(v float64) *float64 { return &v }
+
+// The following tests pin the same-title / high-similarity partVsWhole guard
+// (2026-07-12). Each fixture is anchored on a real row pulled from the prod
+// labeled-example export (/dedup/labels/export). The guard converts a same-title
+// pair whose only negative evidence is a duration ratio into unsure — but only
+// when it is NOT a compiled-in boilerplate ident and carries high candidate
+// similarity, so it never over-suppresses the legitimate not_dup classes.
+
+// TestPartVsWholeSameTitleHighSimGoesUnsure mirrors the real-book mislabels:
+// e.g. "Foundation" (Asimov) at similarity 1.0 with a corrupt/part duration
+// ratio (0.268) — same author, same work, but split into not_dup by the ratio.
+// These must go unsure so dataset-backfill stops dismissing real duplicates.
+func TestPartVsWholeSameTitleHighSimGoesUnsure(t *testing.T) {
+	ex := database.LabeledExample{
+		Layer:         "exact",
+		Similarity:    simPtr(1.0),
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 82569, Title: "Foundation"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 22130, Title: "Foundation"},
+		DurationRatio: 22130.0 / 82569.0,
+	}
+	label, reason, fires := partVsWhole(ex)
+	if !fires || label != "unsure" {
+		t.Fatalf("partVsWhole = (%q, fires=%v), want unsure/true; reason=%q", label, fires, reason)
+	}
+	if !strings.Contains(reason, "same title at high similarity") {
+		t.Fatalf("reason should flag the same-work guard; got %q", reason)
+	}
+	// Full Classify path must also surface unsure (no earlier catcher steals it).
+	if l, _, f := Classify(ex); !f || l != "unsure" {
+		t.Fatalf("Classify = (%q, fires=%v), want unsure/true", l, f)
+	}
+}
+
+// TestPartVsWholeBoilerplateIdentStaysNotDup is the anti-over-suppression carve-
+// out: "Big Finish Ident" is embedding-identical to every copy of itself (sim
+// 1.0) and hits the duration-ratio rule (0.483), but is a legitimate not_dup at
+// the book level — the boilerplate exclusion must keep it not_dup (298 such
+// pairs on prod, 2026-07-12).
+func TestPartVsWholeBoilerplateIdentStaysNotDup(t *testing.T) {
+	ex := database.LabeledExample{
+		Layer:         "exact",
+		Similarity:    simPtr(1.0),
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 8293, Title: "Big Finish Ident"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 4008, Title: "Big Finish Ident"},
+		DurationRatio: 4008.0 / 8293.0,
+	}
+	label, reason, fires := partVsWhole(ex)
+	if !fires || label != "not_dup" {
+		t.Fatalf("boilerplate ident: partVsWhole = (%q, fires=%v), want not_dup/true; reason=%q", label, fires, reason)
+	}
+	if !strings.Contains(reason, "part vs whole") {
+		t.Fatalf("reason should be the plain part-vs-whole not_dup; got %q", reason)
+	}
+}
+
+// TestPartVsWholeSameTitleLowSimStaysNotDup pins the low-similarity path: a
+// same-title pair whose candidate similarity is below the high-sim floor (e.g.
+// the "The Improbable Adventures of Sherlock Holmes" anthology collision at
+// 0.859) is a plausible genuine title collision and keeps not_dup — the guard
+// requires positive high-similarity evidence before downgrading.
+func TestPartVsWholeSameTitleLowSimStaysNotDup(t *testing.T) {
+	ex := database.LabeledExample{
+		Layer:         "embedding",
+		Similarity:    simPtr(0.859),
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 40000, Title: "The Improbable Adventures of Sherlock Holmes"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 12000, Title: "The Improbable Adventures of Sherlock Holmes"},
+		DurationRatio: 12000.0 / 40000.0,
+	}
+	if label, _, fires := partVsWhole(ex); !fires || label != "not_dup" {
+		t.Fatalf("same-title low-sim: partVsWhole = (%q, fires=%v), want not_dup/true", label, fires)
+	}
+}
+
+// TestPartVsWholeSameTitleUnknownSimStaysNotDup covers rows where Similarity is
+// nil (unknown): the guard treats unknown as "not high" and stays not_dup.
+func TestPartVsWholeSameTitleUnknownSimStaysNotDup(t *testing.T) {
+	ex := database.LabeledExample{
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000, Title: "Foundation"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 10800, Title: "Foundation"},
+		DurationRatio: 10800.0 / 36000.0,
+	}
+	if label, _, fires := partVsWhole(ex); !fires || label != "not_dup" {
+		t.Fatalf("same-title unknown-sim: partVsWhole = (%q, fires=%v), want not_dup/true", label, fires)
+	}
+}
+
+// TestPartVsWholeDifferentTitleHighSimStaysNotDup pins that the guard keys on
+// TITLE identity, not similarity alone: a genuine part-vs-whole with DIFFERENT
+// titles but high similarity remains not_dup.
+func TestPartVsWholeDifferentTitleHighSimStaysNotDup(t *testing.T) {
+	ex := database.LabeledExample{
+		Layer:         "embedding",
+		Similarity:    simPtr(0.97),
+		A:             database.BookFeatures{FilesExist: true, TotalDurationSec: 36000, Title: "Foundation"},
+		B:             database.BookFeatures{FilesExist: true, TotalDurationSec: 10800, Title: "Foundation and Empire"},
+		DurationRatio: 10800.0 / 36000.0,
+	}
+	if label, _, fires := partVsWhole(ex); !fires || label != "not_dup" {
+		t.Fatalf("different-title high-sim: partVsWhole = (%q, fires=%v), want not_dup/true", label, fires)
 	}
 }


### PR DESCRIPTION
The partVsWhole mining rule emitted not_dup for pairs whose only negative
evidence was a duration ratio, even when the two books shared an identical
normalized title at high similarity (cosine ~1.0). On prod, 565 of 1332
not_dup labels were same-title part-vs-whole; ~267 are real books split by
corrupt/part durations (durations of 154h/4147h) — real duplicates that
dedup.dataset-backfill then *dismissed* out of the review queue.

partVsWhole now routes same-title + Similarity>=0.95 + non-boilerplate pairs
to unsure instead of not_dup. Boilerplate idents are carved out: "Big Finish
Ident" (298 of the 565 pairs, a recurring publisher jingle that is legitimately
not a book duplicate) is added to the blocklist and keeps its not_dup label.

To share the blocklist with the offline mining rules (internal/dedup/dataset
cannot import internal/dedup — import cycle), the compiled-in default patterns
plus a pure matcher move to a new leaf package internal/boilerplate that both
the live engine gate and the mining rules import. The engine gate now also
drops future "Big Finish Ident" candidates.

Safety: the guard only ever downgrades not_dup -> unsure (a review-queue
holding state that never merges), so even a genuine same-title collision
landing in unsure cannot cause a wrong merge. Rule change affects only future
Classify runs; the ~267 already-mislabeled rows need an operator
dedup.dataset-backfill (apply) re-run to be relabeled.

Fixture-locked tests anchor all branches on real pulled prod rows.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
