### PR TITLE
fix(dedup): recover composite-calibration coverage via CandidateID join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,28 @@
   calls to distinct locals — same assertion, no permanent suppression.
 - No runtime behavior changed: everything deleted was statically unreachable or a
   deprecated-but-inert sentinel. staticcheck version: 2026.1 (v0.7.0).
+#### July 12, 2026 - fix(dedup): recover composite-calibration coverage via CandidateID join
+
+- **`dedup.calibrate-composite`** (backend) — the composite scorer calibrator was returning
+  `insufficient-coverage` even after a fresh `dedup.full-scan` (only ~234 of ~2,305 labeled
+  pairs carried a `ScoreBreakdown`; `skipped_no_breakdown` ≈ 2,069, below the 500-per-class
+  floor), so the multi-signal path meant to beat the embedding-cosine precision ceiling could
+  not be tuned at all. Root cause: a labeled example snapshots its `ScoreBreakdown` from the
+  candidate at label-write time (`dataset.BuildExample`), but a later full-scan updates the
+  *candidate* record's breakdown in-place without re-snapshotting the example for
+  already-existing pairs (`engine.upsertCandidateWithLiveLabel` re-captures only brand-new
+  pairs), and `dedup.dataset-backfill` re-snapshots only *pending* candidates — so a dismissed
+  `not_dup` example keeps a stale (nil) snapshot forever (the 226-true-dup / 8-not-dup
+  asymmetry seen in the calibrate report).
+- The calibrator now falls back to **joining each stale labeled pair to its candidate record's
+  persisted `ScoreBreakdown` by `CandidateID`** (`GetCandidateByID`) when the example's own
+  snapshot is nil/empty. The join reads data of the identical kind the collectors persisted —
+  no scorer fork, strictly read-only in the calibration path (the operator-gated band-apply is
+  unchanged). A new `joined_from_candidate` counter is reported/logged for observability.
+- Existing examples that already carry their own breakdown never consult the join, so the
+  INIT-1 T5 bit-for-bit scoring pin is preserved. Whether prod coverage now crosses the
+  500-per-class floor must be confirmed by an operator-gated `dedup.calibrate-composite` run
+  (the fix cannot be verified offline).
 
 #### July 12, 2026 - fix(dedup): same-title/high-similarity not_dup mining guard (INIT-1 adjacent)
 

--- a/internal/plugins/dedup/calibrate_composite.go
+++ b/internal/plugins/dedup/calibrate_composite.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/calibrate_composite.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4c2f7a91-8d3b-4e6a-9f10-5b7c2d1e8a34
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 // Package dedup — op dedup.calibrate-composite (INIT-1 T5).
 //
@@ -381,7 +381,7 @@ func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMe
 	pairsOut := len(deduped)
 
 	var pairs []compositePair
-	var scoredTrue, scoredNot, skippedNoBreakdown, skippedLabel int
+	var scoredTrue, scoredNot, skippedNoBreakdown, skippedLabel, joinedFromCandidate int
 	for i := range deduped {
 		ex := deduped[i]
 		switch ex.Label {
@@ -393,8 +393,27 @@ func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMe
 		}
 		sigs, ok := parseBreakdownSignals(ex.ScoreBreakdown)
 		if !ok {
-			// nil / unparseable / empty-signal breakdown — counted, NEVER scored
-			// as zero (a zero score would poison the not_dup precision math).
+			// The labeled example holds a stale nil/empty breakdown snapshot. The
+			// example's ScoreBreakdown is, by construction, a COPY taken from the
+			// candidate at label-write time (dataset.BuildExample), but a later
+			// full-scan updates the CANDIDATE record's breakdown in-place WITHOUT
+			// re-snapshotting the example for already-existing pairs
+			// (engine.upsertCandidateWithLiveLabel re-captures only brand-new pairs),
+			// and dataset-backfill re-snapshots only PENDING candidates — so a
+			// dismissed not_dup example keeps its stale snapshot forever. Recover the
+			// breakdown by JOINING to the candidate record by CandidateID. This reads
+			// data of the IDENTICAL kind as the examples that already parse (same
+			// *models.UnifiedDedupScore the collectors persisted), so it introduces no
+			// heterogeneity and no scorer fork — it is a pure read-mismatch repair.
+			sigs, ok = p.candidateBreakdownSignals(ex.CandidateID)
+			if ok {
+				joinedFromCandidate++
+			}
+		}
+		if !ok {
+			// nil / unparseable / empty-signal breakdown on BOTH the example and its
+			// candidate — counted, NEVER scored as zero (a zero score would poison
+			// the not_dup precision math).
 			skippedNoBreakdown++
 			continue
 		}
@@ -410,6 +429,7 @@ func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMe
 	log.Info("calibrate-composite coverage",
 		"rows_in", rowsIn, "pairs_out", pairsOut,
 		"scored_true_dup", scoredTrue, "scored_not_dup", scoredNot,
+		"joined_from_candidate", joinedFromCandidate,
 		"skipped_no_breakdown", skippedNoBreakdown, "skipped_label", skippedLabel)
 
 	// --- Fail-closed coverage floor ---
@@ -418,6 +438,7 @@ func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMe
 			"status", "insufficient-coverage",
 			"rows_in", rowsIn, "pairs_out", pairsOut,
 			"scored_true_dup", scoredTrue, "scored_not_dup", scoredNot,
+			"joined_from_candidate", joinedFromCandidate,
 			"skipped_no_breakdown", skippedNoBreakdown,
 			"min_scored_pairs", minScored)
 		_ = reporter.UpdateProgress(4, 4, fmt.Sprintf(
@@ -524,6 +545,7 @@ func (p *Plugin) runCalibrateComposite(ctx context.Context, rawParams json.RawMe
 		"pairs_out", pairsOut,
 		"scored_true_dup", scoredTrue,
 		"scored_not_dup", scoredNot,
+		"joined_from_candidate", joinedFromCandidate,
 		"skipped_no_breakdown", skippedNoBreakdown,
 		"target_precision_certain", targetCertain,
 		"target_precision_high", targetHigh,
@@ -649,6 +671,28 @@ func describeBandRec(r bandRec, orderingConflict bool) string {
 		return "target-not-met"
 	}
 	return fmt.Sprintf("min=%.2f(p=%.3f,r=%.3f)", r.Rec.Min, r.Rec.Precision, r.Rec.Recall)
+}
+
+// candidateBreakdownSignals recovers a labeled pair's signal set by JOINING to
+// its candidate record's persisted ScoreBreakdown. It is the fallback for a
+// labeled example whose own ScoreBreakdown snapshot is stale (nil/empty) while
+// the candidate — updated in-place by a later full-scan — carries a fresh one.
+// Strictly READ-ONLY: GetCandidateByID is a point read and this never writes.
+// Returns ok=false for a zero/missing CandidateID, a read/unmarshal error, an
+// absent candidate, or a candidate whose breakdown carries no signals — every
+// un-scorable case is skipped+counted upstream, never treated as a zero score.
+func (p *Plugin) candidateBreakdownSignals(candidateID int64) ([]models.Signal, bool) {
+	if candidateID == 0 || p.embeddingStore == nil {
+		return nil, false
+	}
+	cand, err := p.embeddingStore.GetCandidateByID(candidateID)
+	if err != nil || cand == nil || cand.ScoreBreakdown == nil {
+		return nil, false
+	}
+	if len(cand.ScoreBreakdown.Signals) == 0 {
+		return nil, false
+	}
+	return cand.ScoreBreakdown.Signals, true
 }
 
 // parseBreakdownSignals recovers the signal set from a stored ScoreBreakdown JSON

--- a/internal/plugins/dedup/calibrate_composite_test.go
+++ b/internal/plugins/dedup/calibrate_composite_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/dedup/calibrate_composite_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7e5a1c3b-9d2f-4a08-8b61-3c4d5e6f7a89
 // last-edited: 2026-07-12
 
@@ -294,5 +294,89 @@ func TestCalibrateCompositeParamsDefaultNoApply(t *testing.T) {
 	}
 	if p.Apply {
 		t.Fatal("empty params must default Apply=false (report only); scheduled label_refinement chain depends on this")
+	}
+}
+
+// upsertCandidateBreakdown writes a candidate record carrying a single-signal
+// ScoreBreakdown and returns its assigned ID, so a test can point a
+// stale-snapshot labeled example at it and exercise the CandidateID join.
+func upsertCandidateBreakdown(t *testing.T, es *database.EmbeddingStore, tag string, kind unified.SignalKind, conf float64) int64 {
+	t.Helper()
+	id, _, err := es.UpsertCandidateNew(database.DedupCandidate{
+		EntityType: "book",
+		EntityAID:  "ca-" + tag,
+		EntityBID:  "cb-" + tag,
+		Status:     "pending",
+		ScoreBreakdown: &models.UnifiedDedupScore{
+			Signals: []models.Signal{{Kind: kind, Confidence: conf, Raw: conf}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("upsert candidate %s: %v", tag, err)
+	}
+	return id
+}
+
+// upsertStaleLabel writes a labeled example with a NIL ScoreBreakdown (a stale
+// snapshot) pointing at candidateID — the exact shape the CandidateID join must
+// repair.
+func upsertStaleLabel(t *testing.T, es *database.EmbeddingStore, candidateID int64, label string) {
+	t.Helper()
+	ex := database.LabeledExample{
+		CandidateID: candidateID,
+		EntityAID:   fmt.Sprintf("la%08d", candidateID),
+		EntityBID:   fmt.Sprintf("lb%08d", candidateID),
+		Label:       label,
+		LabelSource: "rule",
+		DecidedAt:   "2026-07-01T00:00:00Z",
+		// ScoreBreakdown intentionally nil — the stale-snapshot condition.
+	}
+	if err := es.UpsertLabeledExample(ex); err != nil {
+		t.Fatalf("upsert stale label %d: %v", candidateID, err)
+	}
+}
+
+// TestCalibrateCompositeJoinsCandidateBreakdown proves the read-mismatch repair:
+// a labeled example whose own ScoreBreakdown is stale (nil) but whose CANDIDATE
+// record carries a fresh breakdown is recovered by the CandidateID join and
+// scored — while a stale example whose candidate is absent stays skipped, and
+// examples carrying their own breakdown never consult the join (pin preserved).
+func TestCalibrateCompositeJoinsCandidateBreakdown(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// A true_dup carrying its OWN breakdown — the join is never consulted for it.
+	upsertPairs(t, es, 500000, 1, "true_dup", breakdownWith(unified.SigEmbedHigh, 0.94))
+
+	// A not_dup with a stale (nil) snapshot whose candidate carries a fresh
+	// breakdown — this is the pair the join must recover.
+	notDupCandID := upsertCandidateBreakdown(t, es, "notdup", unified.SigMetaFuzzy, 0.80)
+	upsertStaleLabel(t, es, notDupCandID, "not_dup")
+
+	// A not_dup stale snapshot whose CandidateID references NO candidate record —
+	// nothing to join to, so it must stay skipped (never scored as zero).
+	upsertStaleLabel(t, es, 99999999, "not_dup")
+
+	p := &Plugin{store: pebble, embeddingStore: es}
+	rep := newCaptureReporter()
+	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":1}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	f := reportFields(t, rep.buf.String())
+
+	if f["status"] != "ok" {
+		t.Fatalf("status = %v, want ok (join lifts coverage over the floor)", f["status"])
+	}
+	if got := f["joined_from_candidate"].(float64); got != 1 {
+		t.Errorf("joined_from_candidate = %v, want 1", got)
+	}
+	if got := f["scored_not_dup"].(float64); got != 1 {
+		t.Errorf("scored_not_dup = %v, want 1 (recovered via join)", got)
+	}
+	if got := f["scored_true_dup"].(float64); got != 1 {
+		t.Errorf("scored_true_dup = %v, want 1", got)
+	}
+	if got := f["skipped_no_breakdown"].(float64); got != 1 {
+		t.Errorf("skipped_no_breakdown = %v, want 1 (orphan stale label, no candidate)", got)
 	}
 }


### PR DESCRIPTION
dedup.calibrate-composite returned insufficient-coverage even after a fresh
dedup.full-scan because a labeled example snapshots its ScoreBreakdown from the
candidate at label-write time, but a later full-scan updates the candidate's
breakdown in-place WITHOUT re-snapshotting the example for existing pairs
(engine.upsertCandidateWithLiveLabel re-captures only brand-new pairs), and
dataset-backfill re-snapshots only pending candidates. A dismissed not_dup
example therefore keeps a stale nil snapshot forever, producing the observed
226-true-dup / 8-not-dup coverage asymmetry.

The calibrator now falls back to joining each stale labeled pair to its
candidate record's persisted ScoreBreakdown by CandidateID (GetCandidateByID)
when the example's own snapshot is nil/empty. This recovers data of the
identical kind the collectors persisted, does not fork the scorer, and is
strictly read-only in the calibration path (the operator-gated band-apply is
unchanged). Adds a joined_from_candidate counter for observability.

Examples carrying their own breakdown never consult the join, so the INIT-1 T5
bit-for-bit scoring pin is preserved.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv
