### PR TITLE
feat(dedup): rescore-labeled-examples op to populate ScoreBreakdowns for calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- file: CHANGELOG.md -->
+<!-- version: 3.146.0 -->
 <!-- version: 3.145.0 -->
 <!-- version: 3.142.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
@@ -9,6 +10,31 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 12, 2026 - feat(dedup): rescore-labeled-examples op to populate ScoreBreakdowns for calibration
+
+- **`dedup.rescore-labeled-examples`** (backend, NEW op) — recomputes each labeled dedup pair's
+  `ScoreBreakdown` with the engine's existing scorer and narrow-writes it onto the
+  `LabeledExample`, so `dedup.calibrate-composite` can meet its ≥500-scored-pairs-per-class floor.
+  The prior CandidateID-join fix (same day) recovered zero because dismissed pairs' candidate
+  records are pruned/breakdown-less; this op instead manufactures the breakdowns on the labeled set
+  where the calibrator's primary read looks.
+- Two deliberate divergences from the operational unified scan: (1) the labeled pairs — including
+  **dismissed** ones that are in no candidate list — are injected as an explicit work list; (2) the
+  `if composed.Band == "" { continue }` below-band skip is **bypassed**, so the low-scoring
+  negatives the scan discards (the calibration signal) get persisted. Zero-signal pairs stay
+  reported-but-unscorable (never written as a poisoning zero).
+- **Bit-identical scoring, no scorer fork:** the scan loop's per-pair signal gather was extracted
+  into a shared `collectPairSignals` helper (`internal/dedup/rescore.go`); both
+  `runUnifiedScoringForBook` and the new `Engine.ScorePairsForBook` call it. The embedding cosine is
+  sourced from each labeled example's stored `Similarity` gated on `Layer=="embedding"`, mirroring
+  the scan's `embeddingMap` exactly — never recomputed. Existing unified-scan tests pass unchanged.
+- **Data safety:** persistence is a narrow read-modify-write (`GetLabeledExample` → set only
+  `Score`/`ScoreBreakdown`/`Band` → `UpsertLabeledExample`); `Label`, `LabelSource` (esp. `human`),
+  `LabelReason`, `DecidedAt` are never touched, and a row deleted between list and write is skipped
+  (never re-created). A test asserts a `human`-sourced example survives rescore with its label
+  intact. Concurrency via `registry.RunItems` sharded across A-groups (disjoint by candidateID);
+  `-race` clean. Dry-run by default; `apply=true` writes.
 
 #### July 12, 2026 - chore(lint): drain staticcheck backlog to zero findings (#1796, TASK-02)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 <!-- file: TODO.md -->
+<!-- version: 9.98.0 -->
 <!-- version: 9.97.0 -->
 <!-- version: 9.93.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
@@ -73,6 +74,15 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
     contamination class the re-mine (T07) surfaced. **Follow-up (operator):** re-run
     `dedup.dataset-backfill` (apply) to relabel the ~267 already-mislabeled prod rows, then
     `dedup.calibrate-composite` / embedding-threshold calibration to realize the precision gain.
+  - [x] `dedup.rescore-labeled-examples` op (`internal/plugins/dedup/rescore_labeled_examples.go`,
+    `internal/dedup/rescore.go`) — recomputes each labeled pair's `ScoreBreakdown` with the engine's
+    existing scorer (shared `collectPairSignals` helper, bit-identical) and narrow-writes it onto the
+    `LabeledExample`, INCLUDING below-band + dismissed pairs, so `dedup.calibrate-composite` can meet
+    its ≥500-per-class coverage floor. Dry-run default; `apply=true` writes only Score/ScoreBreakdown/Band.
+    **Follow-up (operator):** run `dedup.rescore-labeled-examples` (apply) on prod, then re-run
+    `dedup.calibrate-composite` — check the reported `zero_signal_*_by_class` counts to decide whether
+    the remaining unscorable negatives warrant a separate "score-missing-as-zero" policy change (a
+    decision deliberately left to the operator; the op never scores a zero-signal pair as zero).
   - **INIT-2's `internal/dedup/engine.go` tasks (T03 + T05) are both merged**, which unblocks
     Phase B: INIT-1 TASK-08 and INIT-4 TASK-05 (both rebase on that file) can now start.
 - **Wave 2b (4 PRs, #1885–#1888, merged 2026-07-11):** see

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,5 +1,5 @@
 // file: internal/dedup/engine.go
-// version: 1.59.2
+// version: 1.60.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
 // last-edited: 2026-07-12
 
@@ -537,13 +537,29 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	// PH-3b: build O(1) embedding map so the per-candidate inner scan
 	// (previously O(k)) becomes a single map lookup.
 	// Index both directions so lookup works regardless of which side is EntityA.
-	type pairKey = [2]string
 	embeddingMap := make(map[pairKey]float64, len(bookCandidates))
 	for _, c := range bookCandidates {
 		if c.Layer == "embedding" && c.Similarity != nil {
 			embeddingMap[pairKey{c.EntityAID, c.EntityBID}] = *c.Similarity
 			embeddingMap[pairKey{c.EntityBID, c.EntityAID}] = *c.Similarity
 		}
+	}
+
+	// Bundle the per-book precomputed signal batches so the per-pair gather can be
+	// shared verbatim with dedup.rescore-labeled-examples (ScorePairsForBook).
+	// Reusing the SAME collectPairSignals helper is what keeps the two scoring
+	// paths bit-identical — there is no second copy of the collection logic.
+	batches := pairSignalBatches{
+		exactHashSigs:   allExactHashSigs,
+		isbnSigs:        allISBNSigs,
+		metaSrcSigs:     allMetaSrcSigs,
+		durationSigs:    allDurationSigs,
+		exactAcoustSigs: allExactAcoustSigs,
+		lshAcoustSigs:   allLSHAcoustSigs,
+		embeddingMap:    embeddingMap,
+		embCfg:          embCfg,
+		fuzCfg:          fuzCfg,
+		authorName:      authorName,
 	}
 
 	for _, ref := range embeddingCandIDs {
@@ -588,77 +604,10 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 			continue
 		}
 
-		// 2. Collect signals from all available collectors.
-		var signals []unified.Signal
-
-		// Exact-file hash signals (pre-computed above).
-		for _, s := range allExactHashSigs {
-			if isSigForPair(s, book.ID, candID) {
-				signals = append(signals, s)
-			}
-		}
-
-		// ISBN/ASIN (pre-computed above).
-		for _, s := range allISBNSigs {
-			if isSigForPair(s, book.ID, candID) {
-				signals = append(signals, s)
-			}
-		}
-
-		// Metadata source hash (pre-computed above).
-		for _, s := range allMetaSrcSigs {
-			if isSigForPair(s, book.ID, candID) {
-				signals = append(signals, s)
-			}
-		}
-
-		// Embedding signal — O(1) map lookup (PH-3b).
-		if cos, ok := embeddingMap[pairKey{book.ID, candID}]; ok {
-			cos32 := float32(cos)
-			if cos >= embCfg.HighThreshold {
-				signals = append(signals, unified.Signal{
-					Kind:       unified.SigEmbedHigh,
-					Raw:        cos,
-					Confidence: embedHighConfidence(cos32, embCfg.HighThreshold),
-					Evidence: fmt.Sprintf(
-						"embedding cosine %.4f (high tier): book %s ↔ %s",
-						cos32, book.ID, candID),
-				})
-			} else if cos >= embCfg.LowThreshold {
-				signals = append(signals, unified.Signal{
-					Kind:       unified.SigEmbedMedium,
-					Raw:        cos,
-					Confidence: embedMediumConfidence(cos32, embCfg.LowThreshold, embCfg.HighThreshold),
-					Evidence: fmt.Sprintf(
-						"embedding cosine %.4f (medium tier): book %s ↔ %s",
-						cos32, book.ID, candID),
-				})
-			}
-		}
-
-		// Duration signal (pre-computed above).
-		for _, s := range allDurationSigs {
-			if isDurationSigFor(s.Evidence, book.ID, candID) {
-				signals = append(signals, s)
-			}
-		}
-
-		// Metadata-fuzzy (per-candidate by design — takes candIDs param).
-		if sigs, err := CollectMetaFuzzy(de.bookStore, book, authorName, []string{candID}, fuzCfg); err == nil {
-			signals = append(signals, sigs...)
-		}
-
-		// AcoustID signals (pre-computed above).
-		for _, s := range allExactAcoustSigs {
-			if isSigForBookID(s.Evidence, candID) {
-				signals = append(signals, s)
-			}
-		}
-		for _, s := range allLSHAcoustSigs {
-			if isSigForBookID(s.Evidence, candID) {
-				signals = append(signals, s)
-			}
-		}
+		// 2. Collect signals from all available collectors. Shared verbatim with
+		// dedup.rescore-labeled-examples (ScorePairsForBook) via collectPairSignals
+		// so both scoring paths gather identical evidence for a pair.
+		signals := de.collectPairSignals(book, candID, batches)
 
 		if len(signals) == 0 {
 			continue

--- a/internal/dedup/rescore.go
+++ b/internal/dedup/rescore.go
@@ -1,0 +1,282 @@
+// file: internal/dedup/rescore.go
+// version: 1.0.0
+// guid: 8b1d4f27-6a90-4c3e-9d21-0f5a7c2e8b64
+// last-edited: 2026-07-12
+
+// Package dedup — per-pair signal gather shared by the operational unified scan
+// and the dedup.rescore-labeled-examples op (ScorePairsForBook).
+//
+// # Why this file exists
+//
+// The operational unified scan (runUnifiedScoringForBook) drops every pair whose
+// composite score falls below the review band (`if composed.Band == "" { continue }`)
+// and never re-snapshots a dismissed pair's LabeledExample. As a result the
+// calibration gold set (dedup.calibrate-composite) has almost no scored not_dup
+// pairs — the below-band negatives the scan discards ARE the calibration signal.
+//
+// ScorePairsForBook recomputes each labeled pair's ScoreBreakdown using the SAME
+// collectors + unified.ComposeScore as the operational scan (via the shared
+// collectPairSignals helper — there is NO second copy of the scoring math), with
+// two deliberate divergences:
+//
+//  1. It scores an explicitly injected work list of (A, B) pairs — dismissed
+//     pairs are in no book's candidate list, so they must be fed in by ID.
+//  2. It does NOT drop below-band pairs — the caller persists the breakdown for
+//     every pair that produced at least one signal.
+//
+// The embedding cosine is sourced from the labeled example's stored Similarity
+// (passed in via RescorePairInput.EmbeddingCos, gated by the caller on
+// Layer=="embedding"), mirroring the scan's embeddingMap construction exactly —
+// it is NOT recomputed, so no signal is injected that the deployed scorer would
+// not have produced.
+
+package dedup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+)
+
+// pairKey indexes the embedding cosine map in both pair directions.
+type pairKey = [2]string
+
+// pairSignalBatches holds the per-book precomputed signal batches (and the
+// per-book configs) that collectPairSignals filters per candidate. Bundling
+// them lets runUnifiedScoringForBook and ScorePairsForBook share ONE copy of the
+// gather logic, which is what keeps their scoring bit-identical.
+type pairSignalBatches struct {
+	exactHashSigs   []unified.Signal
+	isbnSigs        []unified.Signal
+	metaSrcSigs     []unified.Signal
+	durationSigs    []unified.Signal
+	exactAcoustSigs []unified.Signal
+	lshAcoustSigs   []unified.Signal
+	// embeddingMap holds the pair's embedding cosine indexed in both directions.
+	embeddingMap map[pairKey]float64
+	embCfg       EmbeddingCollectorConfig
+	fuzCfg       MetaFuzzyConfig
+	authorName   string
+}
+
+// collectPairSignals gathers every evidence signal for the (book, candID) pair
+// from the precomputed per-book batches. Extracted verbatim from
+// runUnifiedScoringForBook's inner loop so the operational scan and
+// dedup.rescore-labeled-examples score pairs through the identical code path.
+func (de *Engine) collectPairSignals(book *database.Book, candID string, b pairSignalBatches) []unified.Signal {
+	var signals []unified.Signal
+
+	// Exact-file hash signals (pre-computed).
+	for _, s := range b.exactHashSigs {
+		if isSigForPair(s, book.ID, candID) {
+			signals = append(signals, s)
+		}
+	}
+
+	// ISBN/ASIN (pre-computed).
+	for _, s := range b.isbnSigs {
+		if isSigForPair(s, book.ID, candID) {
+			signals = append(signals, s)
+		}
+	}
+
+	// Metadata source hash (pre-computed).
+	for _, s := range b.metaSrcSigs {
+		if isSigForPair(s, book.ID, candID) {
+			signals = append(signals, s)
+		}
+	}
+
+	// Embedding signal — O(1) map lookup (PH-3b).
+	if cos, ok := b.embeddingMap[pairKey{book.ID, candID}]; ok {
+		cos32 := float32(cos)
+		if cos >= b.embCfg.HighThreshold {
+			signals = append(signals, unified.Signal{
+				Kind:       unified.SigEmbedHigh,
+				Raw:        cos,
+				Confidence: embedHighConfidence(cos32, b.embCfg.HighThreshold),
+				Evidence: fmt.Sprintf(
+					"embedding cosine %.4f (high tier): book %s ↔ %s",
+					cos32, book.ID, candID),
+			})
+		} else if cos >= b.embCfg.LowThreshold {
+			signals = append(signals, unified.Signal{
+				Kind:       unified.SigEmbedMedium,
+				Raw:        cos,
+				Confidence: embedMediumConfidence(cos32, b.embCfg.LowThreshold, b.embCfg.HighThreshold),
+				Evidence: fmt.Sprintf(
+					"embedding cosine %.4f (medium tier): book %s ↔ %s",
+					cos32, book.ID, candID),
+			})
+		}
+	}
+
+	// Duration signal (pre-computed).
+	for _, s := range b.durationSigs {
+		if isDurationSigFor(s.Evidence, book.ID, candID) {
+			signals = append(signals, s)
+		}
+	}
+
+	// Metadata-fuzzy (per-candidate by design — takes candIDs param).
+	if sigs, err := CollectMetaFuzzy(de.bookStore, book, b.authorName, []string{candID}, b.fuzCfg); err == nil {
+		signals = append(signals, sigs...)
+	}
+
+	// AcoustID signals (pre-computed).
+	for _, s := range b.exactAcoustSigs {
+		if isSigForBookID(s.Evidence, candID) {
+			signals = append(signals, s)
+		}
+	}
+	for _, s := range b.lshAcoustSigs {
+		if isSigForBookID(s.Evidence, candID) {
+			signals = append(signals, s)
+		}
+	}
+
+	return signals
+}
+
+// RescorePairInput identifies one pair to rescore against book A. OtherID is the
+// B-side book ID. EmbeddingCos carries the labeled example's stored embedding
+// cosine ONLY when the pair's stored layer is "embedding" (nil otherwise), so the
+// embedding signal is reconstructed exactly as the operational scan would have
+// produced it — never recomputed for a non-embedding-layer pair.
+type RescorePairInput struct {
+	OtherID      string
+	EmbeddingCos *float64
+}
+
+// RescorePairResult is one scored pair. Score is nil when the pair produced no
+// signals (unscorable — the caller reports it but never persists a zero-signal
+// breakdown, which would poison the calibrator's not_dup precision math).
+type RescorePairResult struct {
+	OtherID    string
+	Score      *unified.UnifiedDedupScore
+	NumSignals int
+}
+
+// ScorePairsForBook recomputes the ScoreBreakdown for a work list of pairs that
+// all share book A (aID), using the SAME collectors + unified.ComposeScore as the
+// operational unified scan (via collectPairSignals). It runs book A's per-book
+// precompute ONCE and scores every B against it.
+//
+// Two deliberate divergences from runUnifiedScoringForBook:
+//   - the work list is injected explicitly (dismissed pairs are in no candidate
+//     list), and
+//   - the below-band skip (`if composed.Band == "" { continue }`) is BYPASSED —
+//     every pair with >=1 signal gets a composed score returned regardless of band.
+//
+// It performs NO candidate lifecycle work (no eligibility delete, no upsert): its
+// sole job is to manufacture breakdowns for an already-labeled calibration set.
+// Eligibility filtering would drop the very below-band negatives we need. Signal
+// gathering is symmetric, so scoring from the canonical-A side matches what the
+// operational scan produces from whichever endpoint owned the candidate.
+//
+// CONTRACT: on success it returns exactly ONE result per input, in the SAME order
+// as inputs. Callers rely on positional (index) zipping to map results back to
+// their labeled example — two inputs with the same OtherID (a pair re-created
+// under a new candidateID while the old label row persists) are distinct entries
+// and MUST NOT be de-duplicated by OtherID. A short/empty return (nil book,
+// mid-flight cancellation) means the trailing inputs were not scored.
+func (de *Engine) ScorePairsForBook(ctx context.Context, aID string, inputs []RescorePairInput) ([]RescorePairResult, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	book, err := de.bookStore.GetBookByID(aID)
+	if err != nil {
+		return nil, fmt.Errorf("ScorePairsForBook: get book %s: %w", aID, err)
+	}
+	if book == nil {
+		return nil, nil
+	}
+
+	// Resolve author name (identical to CheckBook / the operational scan).
+	authorName := ""
+	if book.AuthorID != nil {
+		if author, aErr := de.bookStore.GetAuthorByID(*book.AuthorID); aErr == nil && author != nil {
+			authorName = author.Name
+		}
+	}
+
+	// Per-book configs — identical to runUnifiedScoringForBook.
+	cfg := de.getScoreConfig()
+	embCfg := DefaultEmbeddingCollectorConfig()
+	embHigh, embLow := de.resolvedBookThresholds()
+	embCfg.HighThreshold = embHigh
+	embCfg.LowThreshold = embLow
+	durCfg := DefaultDurationCollectorConfig()
+	fuzCfg := DefaultMetaFuzzyConfig()
+	lshCfg := DefaultLSHAcoustIDConfig()
+
+	bookFiles, _ := de.bookStore.GetBookFiles(book.ID)
+
+	// Per-book precompute — identical collectors to the operational scan. The
+	// duration collector's tagStore is nil here: tags are a pure side effect that
+	// does NOT affect the emitted signals, so skipping them keeps scoring
+	// bit-identical while avoiding surprise writes during a rescore.
+	allExactHashSigs, _ := CollectExactFileHash(de.bookStore, book)
+	allISBNSigs, _ := CollectISBNASIN(ctx, de.bookStore, de.isbnIndexStore, book)
+	allMetaSrcSigs, _ := CollectMetaSrcHash(de.bookStore, book)
+	allDurationSigs, _ := CollectDuration(de.bookStore, nil, book, durCfg)
+
+	var allExactAcoustSigs, allLSHAcoustSigs []unified.Signal
+	if de.acoustidBookFileStore != nil {
+		for _, bf := range bookFiles {
+			sigs, _ := CollectExactAcoustID(de.acoustidBookFileStore, &bf, book.ID)
+			allExactAcoustSigs = append(allExactAcoustSigs, sigs...)
+		}
+	}
+	if de.lshAcoustIDStore != nil {
+		for _, bf := range bookFiles {
+			sigs, _ := CollectLSHAcoustID(de.lshAcoustIDStore, &bf, book.ID, lshCfg)
+			allLSHAcoustSigs = append(allLSHAcoustSigs, sigs...)
+		}
+	}
+
+	// Embedding map from the caller-supplied stored cosines (mirrors the scan's
+	// embeddingMap, which reads candidate.Similarity gated on Layer=="embedding").
+	embeddingMap := make(map[pairKey]float64, len(inputs))
+	for _, in := range inputs {
+		if in.EmbeddingCos != nil {
+			embeddingMap[pairKey{aID, in.OtherID}] = *in.EmbeddingCos
+			embeddingMap[pairKey{in.OtherID, aID}] = *in.EmbeddingCos
+		}
+	}
+
+	batches := pairSignalBatches{
+		exactHashSigs:   allExactHashSigs,
+		isbnSigs:        allISBNSigs,
+		metaSrcSigs:     allMetaSrcSigs,
+		durationSigs:    allDurationSigs,
+		exactAcoustSigs: allExactAcoustSigs,
+		lshAcoustSigs:   allLSHAcoustSigs,
+		embeddingMap:    embeddingMap,
+		embCfg:          embCfg,
+		fuzCfg:          fuzCfg,
+		authorName:      authorName,
+	}
+
+	results := make([]RescorePairResult, 0, len(inputs))
+	for _, in := range inputs {
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+		signals := de.collectPairSignals(book, in.OtherID, batches)
+		res := RescorePairResult{OtherID: in.OtherID, NumSignals: len(signals)}
+		if len(signals) > 0 {
+			// BYPASS the band gate: compose and return the score regardless of band.
+			composed := unified.ComposeScore(signals, nil, cfg, canonicalPairIDs(aID, in.OtherID))
+			res.Score = &composed
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}

--- a/internal/dedup/rescore_test.go
+++ b/internal/dedup/rescore_test.go
@@ -1,0 +1,153 @@
+// file: internal/dedup/rescore_test.go
+// version: 1.0.0
+// guid: c4a70f81-92db-4e35-8a16-0d5f7c2e9b41
+// last-edited: 2026-07-12
+
+package dedup
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// newRescoreTestEngine builds an Engine backed by a real PebbleStore so the
+// collectors run their real store queries.
+func newRescoreTestEngine(t *testing.T) (*Engine, *database.PebbleStore) {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "rescore-test"))
+	if err != nil {
+		t.Fatalf("open PebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	es := database.NewEmbeddingStore(store.DB())
+	return NewEngine(es, store, nil, nil, nil), store
+}
+
+func mkBookWithHash(t *testing.T, store *database.PebbleStore, title, hash string, authorID *int, durationSec int) string {
+	t.Helper()
+	dur := durationSec
+	b := &database.Book{Title: title, AuthorID: authorID, Duration: &dur, FilePath: "/audio/" + title + ".m4b"}
+	created, err := store.CreateBook(b)
+	if err != nil {
+		t.Fatalf("CreateBook %q: %v", title, err)
+	}
+	if err := store.CreateBookFile(&database.BookFile{
+		BookID:   created.ID,
+		FilePath: "/audio/" + title + ".m4b",
+		FileHash: hash,
+		FileSize: 5 << 20,
+		Duration: durationSec,
+	}); err != nil {
+		t.Fatalf("CreateBookFile %q: %v", title, err)
+	}
+	return created.ID
+}
+
+// TestScorePairsForBook_InjectsAndSkipsZeroSignal proves the injected-work-list
+// path: a signal-bearing pair (near-identical titles → SigMetaFuzzy) returns a
+// non-nil composed score, while a pair sharing no evidence returns a nil Score
+// (unscorable — never persisted as a zero, which would poison calibration math).
+func TestScorePairsForBook_InjectsAndSkipsZeroSignal(t *testing.T) {
+	eng, store := newRescoreTestEngine(t)
+
+	author, err := store.CreateAuthor("Melville")
+	if err != nil {
+		t.Fatalf("CreateAuthor: %v", err)
+	}
+	// Near-identical titles + same author → a primary SigMetaFuzzy signal fires.
+	aID := mkBookWithHash(t, store, "Moby Dick Unabridged", "aaaa000000000001", &author.ID, 3600)
+	bID := mkBookWithHash(t, store, "Moby Dick Unabridgd", "bbbb000000000002", &author.ID, 3600)
+	// A book with nothing in common (different author, title, hash, duration).
+	other, err := store.CreateAuthor("Nobody")
+	if err != nil {
+		t.Fatalf("CreateAuthor: %v", err)
+	}
+	cID := mkBookWithHash(t, store, "Zxqw Vfpl Ktrn", "cccc000000000003", &other.ID, 1234)
+
+	// canonical A must be the smaller ID for a stable pair identity.
+	lo, hi := aID, bID
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+
+	res, err := eng.ScorePairsForBook(context.Background(), lo, []RescorePairInput{
+		{OtherID: hi},
+		{OtherID: cID},
+	})
+	if err != nil {
+		t.Fatalf("ScorePairsForBook: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("want 2 results, got %d", len(res))
+	}
+
+	byOther := map[string]RescorePairResult{}
+	for _, r := range res {
+		byOther[r.OtherID] = r
+	}
+
+	scored := byOther[hi]
+	if scored.NumSignals < 1 || scored.Score == nil {
+		t.Fatalf("metadata pair: want >=1 signal + non-nil score, got n=%d score=%v", scored.NumSignals, scored.Score)
+	}
+	if scored.Score.Score <= 0 {
+		t.Fatalf("metadata pair: want composite > 0, got %.4f", scored.Score.Score)
+	}
+
+	none := byOther[cID]
+	if none.NumSignals != 0 || none.Score != nil {
+		t.Fatalf("no-signal pair: want 0 signals + nil score, got n=%d score=%v", none.NumSignals, none.Score)
+	}
+}
+
+// TestScorePairsForBook_BelowBandNotDropped is the core-behavior proof: a pair
+// whose ONLY signal is a supporting duration match composes to a below-band score
+// (band==""), which the operational scan DROPS. ScorePairsForBook must instead
+// return that composed score (non-nil) so the caller can persist it — the whole
+// point of the op. The two books share an author + duration (duration fires) but
+// have titles far enough apart that no primary metadata-fuzzy signal fires.
+func TestScorePairsForBook_BelowBandNotDropped(t *testing.T) {
+	eng, store := newRescoreTestEngine(t)
+
+	author, err := store.CreateAuthor("Shared Author")
+	if err != nil {
+		t.Fatalf("CreateAuthor: %v", err)
+	}
+
+	// Short, dissimilar titles: absolute Levenshtein distance 6 (<= duration's
+	// LevenshteinMax=6, so SigDuration fires) but normalized similarity 0.25, so
+	// metaTitleAuthorSimilarity = 0.70*0.25 + 0.30*1.0 = 0.475 < 0.50 → no
+	// SigMetaFuzzy. Distinct file hashes → no exact-file signal; no embedding
+	// cosine supplied → no embedding signal. Result: duration-only, below band.
+	aID := mkBookWithHash(t, store, "aardvark", "1111111111111111", &author.ID, 3600)
+	bID := mkBookWithHash(t, store, "zzzzzzrk", "2222222222222222", &author.ID, 3600)
+
+	lo, hi := aID, bID
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+
+	res, err := eng.ScorePairsForBook(context.Background(), lo, []RescorePairInput{{OtherID: hi}})
+	if err != nil {
+		t.Fatalf("ScorePairsForBook: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("want 1 result, got %d", len(res))
+	}
+	r := res[0]
+	if r.NumSignals < 1 || r.Score == nil {
+		t.Fatalf("below-band pair: want >=1 signal + non-nil score (NOT dropped), got n=%d score=%v", r.NumSignals, r.Score)
+	}
+	if r.Score.Band != "" {
+		t.Fatalf("below-band pair: expected empty band (score %.4f), got band=%q — fixture no longer below-band", r.Score.Score, r.Score.Band)
+	}
+	// Precise bit-identical math: with no primary signal the noisy-OR product is
+	// 0 and the only contribution is the SigDuration supporting boost (4.0 in
+	// DefaultScoreConfig), well under the 60.0 review floor.
+	if r.Score.Score != 4.0 {
+		t.Fatalf("below-band pair: expected composite == duration boost 4.0, got %.4f", r.Score.Score)
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.16.0
+// version: 1.17.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-07-11
+// last-edited: 2026-07-12
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -81,6 +81,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.cleanupOrphanEmbeddingsDef(),       // retroactive counterpart to #1802: deletes emb:v:book:* rows whose book is gone
 		p.cleanupOrphanAuthorEmbeddingsDef(), // author-side counterpart: deletes emb:v:author:* rows orphaned by a merge/delete (#1866 follow-up)
 		p.buildCandidateStatusIndexDef(),     // INIT-2 T4: dedup:s: status secondary index backfill over dedup candidates
+		p.rescoreLabeledExamplesDef(),        // recompute ScoreBreakdowns onto labeled examples (incl. below-band/dismissed) for calibration coverage
 	}
 
 	for _, op := range ops {

--- a/internal/plugins/dedup/rescore_labeled_examples.go
+++ b/internal/plugins/dedup/rescore_labeled_examples.go
@@ -1,0 +1,364 @@
+// file: internal/plugins/dedup/rescore_labeled_examples.go
+// version: 1.0.0
+// guid: 3e9c1a70-5d84-4b62-8f01-6a2d7c0e9b53
+// last-edited: 2026-07-12
+
+// Package dedup — op dedup.rescore-labeled-examples.
+//
+// # Why this op exists
+//
+// dedup.calibrate-composite needs >=500 SCORED pairs per class, where a pair is
+// "scored" only if its LabeledExample carries a parseable ScoreBreakdown with
+// >=1 signal. On prod, 2,069 of 2,303 labeled pairs have no usable breakdown
+// anywhere, because:
+//   - the operational unified scan drops below-band pairs before persisting
+//     (`if composed.Band == "" { continue }`), and not_dup pairs are
+//     disproportionately low-scoring, and
+//   - labeling a pair not_dup DISMISSES its candidate, so it leaves the pending
+//     set and is never re-scored; its LabeledExample keeps a stale/nil
+//     ScoreBreakdown forever. Joining back to the candidate recovers nothing
+//     because the dismissed candidate is pruned/breakdown-less.
+//
+// This op recomputes each labeled pair's ScoreBreakdown with the engine's EXISTING
+// scorer (Engine.ScorePairsForBook → the same collectors + unified.ComposeScore
+// the operational scan uses — no scorer fork) and persists it onto the
+// LabeledExample, where calibrate-composite's PRIMARY read looks.
+//
+// # Two deliberate divergences from the operational scan
+//
+//  1. The labeled pairs (including dismissed ones, which are in no candidate list)
+//     are INJECTED as the work list.
+//  2. The `Band == ""` skip is BYPASSED — below-band labeled pairs get their
+//     breakdown persisted. Those negatives ARE the calibration signal.
+//
+// (Pairs that produce zero signals stay reported-but-unscorable — never persisted,
+// since a zero-signal breakdown is what the calibrator already treats as missing.)
+//
+// # Data safety
+//
+// Persistence is a NARROW read-modify-write: GetLabeledExample → set ONLY Score,
+// ScoreBreakdown, Band → UpsertLabeledExample. Label, LabelSource (esp. "human"),
+// LabelReason, DecidedAt and every other field are left untouched. If the example
+// vanished between listing and writing, the op SKIPS it — it never creates a row.
+//
+// Dry-run (report only) is the default. {"apply":true} writes.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// rescoreLabeledExamplesParams are the JSON parameters accepted by the op.
+type rescoreLabeledExamplesParams struct {
+	// Apply, if true, narrow-writes each recomputed ScoreBreakdown onto its
+	// LabeledExample. Default false (dry-run) — reports counts, writes nothing.
+	Apply bool `json:"apply"`
+}
+
+// pairScorer is the narrow engine surface the op depends on. Abstracted so the
+// runner can be unit-tested with a deterministic fake in place of a real Engine.
+type pairScorer interface {
+	ScorePairsForBook(ctx context.Context, aID string, inputs []dedupengine.RescorePairInput) ([]dedupengine.RescorePairResult, error)
+}
+
+// labeledExampleStore is the narrow store surface the op needs for the
+// read-modify-write persist (database.EmbeddingStore satisfies it).
+type labeledExampleStore interface {
+	ListLabeledExamples(f database.LabeledExampleFilter) ([]database.LabeledExample, error)
+	GetLabeledExample(candidateID int64) (*database.LabeledExample, error)
+	UpsertLabeledExample(ex database.LabeledExample) error
+}
+
+// rescoreLabeledExamplesDef returns the OperationDef for
+// dedup.rescore-labeled-examples.
+func (p *Plugin) rescoreLabeledExamplesDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.rescore-labeled-examples",
+		Plugin:      "dedup",
+		DisplayName: "Rescore labeled examples (populate ScoreBreakdowns for calibration)",
+		Description: "Recomputes each labeled dedup pair's ScoreBreakdown with the engine's " +
+			"existing scorer and narrow-writes it onto the LabeledExample, INCLUDING below-band " +
+			"and dismissed pairs, so dedup.calibrate-composite can meet its per-class coverage " +
+			"floor. Dry-run by default; apply=true writes only Score/ScoreBreakdown/Band, never " +
+			"the label fields.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.rescore-labeled-examples",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runRescoreLabeledExamples,
+	}
+}
+
+// runRescoreLabeledExamples wires the plugin's engine + store into the testable
+// runner.
+func (p *Plugin) runRescoreLabeledExamples(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return fmt.Errorf("dedup engine not available")
+	}
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	return runRescoreLabeledExamplesWith(ctx, p.engine, p.embeddingStore, rawParams, reporter)
+}
+
+// labeledRef is one labeled pair to rescore, grouped under its EntityAID.
+type labeledRef struct {
+	candidateID  int64
+	otherID      string // EntityBID (the pair's B side)
+	trueDup      bool   // true = true_dup, false = not_dup
+	embeddingCos *float64
+}
+
+// aGroup bundles all labeled pairs sharing a canonical A book so book A's per-book
+// precompute runs once per group. Groups are disjoint by A; each pair's own
+// LabeledExample is keyed by a distinct candidateID, so parallel writes never
+// collide.
+type aGroup struct {
+	aID  string
+	refs []labeledRef
+}
+
+// runRescoreLabeledExamplesWith is the testable core: it lists labeled examples,
+// groups them by canonical A, scores each group through the engine's real scorer
+// in a bounded worker pool, and (apply=true) narrow-writes the recomputed
+// breakdown onto each LabeledExample.
+func runRescoreLabeledExamplesWith(
+	ctx context.Context,
+	scorer pairScorer,
+	store labeledExampleStore,
+	rawParams json.RawMessage,
+	reporter sdk.Reporter,
+) error {
+	var params rescoreLabeledExamplesParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	log := reporter.Logger()
+	log.Info("rescore-labeled-examples start", "apply", params.Apply)
+
+	// --- Load the calibration classes (true_dup + not_dup, incl. dismissed) ---
+	_ = reporter.UpdateProgress(0, 3, "Loading labeled examples…")
+	trueDup, err := store.ListLabeledExamples(database.LabeledExampleFilter{Label: "true_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list true_dup examples: %w", err)
+	}
+	notDup, err := store.ListLabeledExamples(database.LabeledExampleFilter{Label: "not_dup", Limit: 1_000_000})
+	if err != nil {
+		return fmt.Errorf("list not_dup examples: %w", err)
+	}
+	if reporter.IsCanceled() {
+		return context.Canceled
+	}
+
+	// --- Group by canonical A book ---
+	groupByA := make(map[string]*aGroup)
+	addRef := func(ex database.LabeledExample, trueDupClass bool) {
+		ref := labeledRef{candidateID: ex.CandidateID, otherID: ex.EntityBID, trueDup: trueDupClass}
+		// Mirror the operational scan's embeddingMap: only an embedding-layer pair
+		// contributes a stored cosine; every other layer has its own signal.
+		if ex.Layer == "embedding" && ex.Similarity != nil {
+			cos := *ex.Similarity
+			ref.embeddingCos = &cos
+		}
+		g, ok := groupByA[ex.EntityAID]
+		if !ok {
+			g = &aGroup{aID: ex.EntityAID}
+			groupByA[ex.EntityAID] = g
+		}
+		g.refs = append(g.refs, ref)
+	}
+	for i := range trueDup {
+		addRef(trueDup[i], true)
+	}
+	for i := range notDup {
+		addRef(notDup[i], false)
+	}
+
+	groups := make([]aGroup, 0, len(groupByA))
+	for _, g := range groupByA {
+		groups = append(groups, *g)
+	}
+
+	totalLabeled := len(trueDup) + len(notDup)
+	log.Info("rescore-labeled-examples: loaded",
+		"total_labeled", totalLabeled, "true_dup", len(trueDup), "not_dup", len(notDup),
+		"a_groups", len(groups))
+
+	// --- Score + (apply) persist, sharded across A-groups ---
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Scoring %d labeled pairs across %d A-groups…", totalLabeled, len(groups)))
+
+	var (
+		mu             sync.Mutex
+		scoredTrue     int
+		scoredNot      int
+		zeroSignalTrue int
+		zeroSignalNot  int
+		wouldWrite     int
+		wrote          int
+		humanPreserved int
+		scoreErrs      int
+		getErrs        int
+		missingAtWrite int
+		skippedNoBook  int
+	)
+
+	err = registry.RunItems(ctx, reporter, groups, func(ctx context.Context, g aGroup) error {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+
+		inputs := make([]dedupengine.RescorePairInput, len(g.refs))
+		for i, r := range g.refs {
+			inputs[i] = dedupengine.RescorePairInput{OtherID: r.otherID, EmbeddingCos: r.embeddingCos}
+		}
+
+		results, sErr := scorer.ScorePairsForBook(ctx, g.aID, inputs)
+		if sErr != nil {
+			mu.Lock()
+			scoreErrs += len(g.refs)
+			mu.Unlock()
+			log.Warn("rescore-labeled-examples: score error", "a_id", g.aID, "error", sErr)
+			return nil // partial progress beats aborting the whole op
+		}
+
+		// Zip results back to refs by INDEX (ScorePairsForBook returns one result
+		// per input, in order). Keying by OtherID would silently collapse two
+		// labeled rows for the same (A,B) pair — a candidate re-created under a new
+		// candidateID leaves the old label row behind — dropping one and
+		// double-counting the other. A short return (nil A-book, cancellation)
+		// leaves the trailing refs unscored → skipped_no_book, so the counts still
+		// reconcile against total_labeled.
+		if len(results) < len(g.refs) {
+			mu.Lock()
+			skippedNoBook += len(g.refs) - len(results)
+			mu.Unlock()
+		}
+
+		for i := 0; i < len(results); i++ {
+			res := results[i]
+			ref := g.refs[i]
+
+			// Zero-signal pairs are unscorable — reported by class, never persisted.
+			if res.NumSignals == 0 || res.Score == nil {
+				mu.Lock()
+				if ref.trueDup {
+					zeroSignalTrue++
+				} else {
+					zeroSignalNot++
+				}
+				mu.Unlock()
+				continue
+			}
+
+			mu.Lock()
+			if ref.trueDup {
+				scoredTrue++
+			} else {
+				scoredNot++
+			}
+			wouldWrite++
+			mu.Unlock()
+
+			if !params.Apply {
+				continue
+			}
+
+			// --- NARROW read-modify-write (data safety) ---
+			cur, gErr := store.GetLabeledExample(ref.candidateID)
+			if gErr != nil {
+				mu.Lock()
+				getErrs++
+				mu.Unlock()
+				log.Warn("rescore-labeled-examples: get error", "candidate_id", ref.candidateID, "error", gErr)
+				continue
+			}
+			if cur == nil {
+				// Deleted between listing and writing — never re-create it.
+				mu.Lock()
+				missingAtWrite++
+				mu.Unlock()
+				continue
+			}
+
+			raw, mErr := json.Marshal(res.Score)
+			if mErr != nil {
+				mu.Lock()
+				scoreErrs++
+				mu.Unlock()
+				log.Warn("rescore-labeled-examples: marshal error", "candidate_id", ref.candidateID, "error", mErr)
+				continue
+			}
+
+			isHuman := cur.LabelSource == "human"
+			// Set ONLY the score fields; leave Label/LabelSource/LabelReason/
+			// DecidedAt and every other field exactly as they were.
+			cur.Score = res.Score.Score
+			cur.ScoreBreakdown = raw
+			cur.Band = res.Score.Band
+
+			if uErr := store.UpsertLabeledExample(*cur); uErr != nil {
+				log.Error("rescore-labeled-examples: upsert error", "candidate_id", ref.candidateID, "error", uErr)
+				continue
+			}
+			mu.Lock()
+			wrote++
+			if isHuman {
+				humanPreserved++
+			}
+			mu.Unlock()
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Scored %d/%d A-groups…", i+1, total)
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// --- Report (zero_signal-by-class is the decision input for a follow-up) ---
+	_ = reporter.UpdateProgress(2, 3, "Summarizing…")
+	log.Info("rescore-labeled-examples report",
+		"apply", params.Apply,
+		"total_labeled", totalLabeled,
+		"scored_true_dup", scoredTrue,
+		"scored_not_dup", scoredNot,
+		"zero_signal_true_dup", zeroSignalTrue,
+		"zero_signal_not_dup", zeroSignalNot,
+		"would_write", wouldWrite,
+		"wrote", wrote,
+		"human_labels_preserved", humanPreserved,
+		"score_errs", scoreErrs,
+		"get_errs", getErrs,
+		"missing_at_write", missingAtWrite,
+		"skipped_no_book", skippedNoBook,
+	)
+
+	summary := fmt.Sprintf(
+		"scored true_dup=%d not_dup=%d; zero_signal true_dup=%d not_dup=%d; would_write=%d wrote=%d human_preserved=%d",
+		scoredTrue, scoredNot, zeroSignalTrue, zeroSignalNot, wouldWrite, wrote, humanPreserved)
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3, "Dry-run — "+summary+". Pass apply=true to persist ScoreBreakdowns.")
+	} else {
+		_ = reporter.UpdateProgress(3, 3, "Complete — "+summary+".")
+	}
+	return nil
+}

--- a/internal/plugins/dedup/rescore_labeled_examples_test.go
+++ b/internal/plugins/dedup/rescore_labeled_examples_test.go
@@ -1,0 +1,260 @@
+// file: internal/plugins/dedup/rescore_labeled_examples_test.go
+// version: 1.0.0
+// guid: 6d2b8f14-3a97-4e05-9c81-7f0a5d3e2c68
+// last-edited: 2026-07-12
+
+// Tests for dedup.rescore-labeled-examples. A fake pairScorer stands in for the
+// real Engine so the persistence contract (below-band write, narrow write that
+// preserves human labels, dry-run no-op, parallel safety) is exercised
+// deterministically against a real EmbeddingStore.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
+)
+
+// fakePairScorer returns a canned UnifiedDedupScore for every injected pair. When
+// signals is empty the pair is reported unscorable (nil Score, NumSignals 0),
+// matching the real engine's zero-signal contract.
+type fakePairScorer struct {
+	score   float64
+	band    string
+	signals []models.Signal
+}
+
+func (f *fakePairScorer) ScorePairsForBook(_ context.Context, aID string, inputs []dedupengine.RescorePairInput) ([]dedupengine.RescorePairResult, error) {
+	out := make([]dedupengine.RescorePairResult, 0, len(inputs))
+	for _, in := range inputs {
+		res := dedupengine.RescorePairResult{OtherID: in.OtherID, NumSignals: len(f.signals)}
+		if len(f.signals) > 0 {
+			res.Score = &unified.UnifiedDedupScore{
+				Pair:    [2]string{aID, in.OtherID},
+				Score:   f.score,
+				Band:    f.band,
+				Signals: f.signals,
+				Formula: "test",
+			}
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// belowBandScorer emits a single below-band (band=="") duration signal — exactly
+// the negative the operational scan discards and this op must persist.
+func belowBandScorer() *fakePairScorer {
+	return &fakePairScorer{
+		score: 4.0,
+		band:  "", // below the review floor — the scan would drop this pair
+		signals: []models.Signal{
+			{Kind: unified.SigDuration, Raw: 1.0, Confidence: 0, Evidence: "duration match"},
+		},
+	}
+}
+
+func seedLabeled(t *testing.T, es *database.EmbeddingStore, ex database.LabeledExample) {
+	t.Helper()
+	if err := es.UpsertLabeledExample(ex); err != nil {
+		t.Fatalf("seed labeled example %d: %v", ex.CandidateID, err)
+	}
+}
+
+// TestRescoreLabeledExamples_BelowBandPersisted proves the band-skip bypass: a
+// below-band (band=="") labeled pair, which the operational scan never persists,
+// gets a parseable ScoreBreakdown written onto its LabeledExample.
+func TestRescoreLabeledExamples_BelowBandPersisted(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	seedLabeled(t, es, database.LabeledExample{
+		CandidateID: 101, EntityAID: "bookA", EntityBID: "bookB",
+		Label: "not_dup", LabelSource: "rule", // dismissed-style negative, no breakdown
+	})
+
+	if err := runRescoreLabeledExamplesWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetLabeledExample(101)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if got == nil {
+		t.Fatal("labeled example vanished")
+	}
+	if len(got.ScoreBreakdown) == 0 {
+		t.Fatal("below-band pair: ScoreBreakdown was not persisted (band-skip bypass failed)")
+	}
+	// It must be parseable with >=1 signal — the property calibrate-composite needs.
+	var uds models.UnifiedDedupScore
+	if err := json.Unmarshal(got.ScoreBreakdown, &uds); err != nil {
+		t.Fatalf("persisted ScoreBreakdown does not parse: %v", err)
+	}
+	if len(uds.Signals) < 1 {
+		t.Fatalf("persisted ScoreBreakdown has no signals (unscorable): %+v", uds)
+	}
+	if got.Score != 4.0 {
+		t.Fatalf("Score not persisted: want 4.0, got %.4f", got.Score)
+	}
+	if got.Band != "" {
+		t.Fatalf("Band should mirror the composed (empty) band, got %q", got.Band)
+	}
+}
+
+// TestRescoreLabeledExamples_HumanLabelPreserved proves the narrow write: a
+// human-sourced labeled example keeps LabelSource=="human", its Label, and its
+// DecidedAt after rescore — only Score/ScoreBreakdown/Band change.
+func TestRescoreLabeledExamples_HumanLabelPreserved(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	seedLabeled(t, es, database.LabeledExample{
+		CandidateID: 202, EntityAID: "humA", EntityBID: "humB",
+		Label: "not_dup", LabelSource: "human",
+		LabelReason: "reviewer said different book", DecidedAt: "2026-07-01T00:00:00Z",
+	})
+
+	if err := runRescoreLabeledExamplesWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetLabeledExample(202)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if got == nil {
+		t.Fatal("labeled example vanished")
+	}
+	// Label provenance MUST survive untouched.
+	if got.LabelSource != "human" {
+		t.Fatalf("human LabelSource clobbered: got %q", got.LabelSource)
+	}
+	if got.Label != "not_dup" {
+		t.Fatalf("human Label clobbered: got %q", got.Label)
+	}
+	if got.LabelReason != "reviewer said different book" {
+		t.Fatalf("LabelReason clobbered: got %q", got.LabelReason)
+	}
+	if got.DecidedAt != "2026-07-01T00:00:00Z" {
+		t.Fatalf("DecidedAt clobbered: got %q", got.DecidedAt)
+	}
+	// But the ScoreBreakdown must now be populated.
+	if len(got.ScoreBreakdown) == 0 {
+		t.Fatal("ScoreBreakdown not written onto human-labeled example")
+	}
+}
+
+// TestRescoreLabeledExamples_DryRunWritesNothing proves apply=false persists nothing.
+func TestRescoreLabeledExamples_DryRunWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	seedLabeled(t, es, database.LabeledExample{
+		CandidateID: 303, EntityAID: "dryA", EntityBID: "dryB",
+		Label: "true_dup", LabelSource: "rule",
+	})
+
+	if err := runRescoreLabeledExamplesWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetLabeledExample(303)
+	if err != nil {
+		t.Fatalf("GetLabeledExample: %v", err)
+	}
+	if got == nil {
+		t.Fatal("dry-run must not delete the example")
+	}
+	if len(got.ScoreBreakdown) != 0 || got.Score != 0 {
+		t.Fatalf("dry-run wrote something: breakdown_len=%d score=%.4f", len(got.ScoreBreakdown), got.Score)
+	}
+}
+
+// TestRescoreLabeledExamples_DuplicatePairRowsBothRescored proves that two labeled
+// examples for the SAME canonical (A,B) pair but with DIFFERENT candidateIDs — the
+// candidate-recreated-after-dismiss case — BOTH get their breakdown persisted.
+// Regression guard for keying results by OtherID (which would collapse them,
+// dropping one and double-writing the other).
+func TestRescoreLabeledExamples_DuplicatePairRowsBothRescored(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	// Same (A,B), two candidateIDs (old dismissed row + new recreated row).
+	seedLabeled(t, es, database.LabeledExample{
+		CandidateID: 401, EntityAID: "dupA", EntityBID: "dupB",
+		Label: "not_dup", LabelSource: "rule",
+	})
+	seedLabeled(t, es, database.LabeledExample{
+		CandidateID: 402, EntityAID: "dupA", EntityBID: "dupB",
+		Label: "not_dup", LabelSource: "human",
+	})
+
+	if err := runRescoreLabeledExamplesWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for _, id := range []int64{401, 402} {
+		got, err := es.GetLabeledExample(id)
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", id, err)
+		}
+		if got == nil || len(got.ScoreBreakdown) == 0 {
+			t.Fatalf("duplicate-pair row %d: breakdown not persisted (results keyed by OtherID?)", id)
+		}
+	}
+	// The human-sourced duplicate row must still have its label intact.
+	human, _ := es.GetLabeledExample(402)
+	if human.LabelSource != "human" || human.Label != "not_dup" {
+		t.Fatalf("row 402: label provenance clobbered: source=%q label=%q", human.LabelSource, human.Label)
+	}
+}
+
+// TestRescoreLabeledExamples_ParallelManyGroups spreads many labeled pairs across
+// many A-groups so the registry.RunItems pool is genuinely contended; run under
+// -race to catch unguarded shared state. Every example must end up with a
+// persisted breakdown.
+func TestRescoreLabeledExamples_ParallelManyGroups(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	const n = 200
+	for i := 0; i < n; i++ {
+		class := "true_dup"
+		if i%2 == 0 {
+			class = "not_dup"
+		}
+		seedLabeled(t, es, database.LabeledExample{
+			CandidateID: int64(1000 + i),
+			EntityAID:   fmt.Sprintf("A%03d", i), // distinct A per pair → many groups
+			EntityBID:   fmt.Sprintf("B%03d", i),
+			Label:       class, LabelSource: "rule",
+		})
+	}
+
+	if err := runRescoreLabeledExamplesWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for i := 0; i < n; i++ {
+		got, err := es.GetLabeledExample(int64(1000 + i))
+		if err != nil {
+			t.Fatalf("GetLabeledExample(%d): %v", 1000+i, err)
+		}
+		if got == nil || len(got.ScoreBreakdown) == 0 {
+			t.Fatalf("example %d: breakdown not persisted", 1000+i)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause (one sentence)
`dedup.calibrate-composite` returns `insufficient-coverage` because 2,069/2,303 labeled pairs carry no parseable `ScoreBreakdown` — the operational unified scan drops below-band pairs (`if composed.Band == "" { continue }`) and never re-snapshots a *dismissed* pair's `LabeledExample`, and the prior same-day CandidateID-join fix recovered **zero** because dismissed candidates are pruned/breakdown-less.

## What the op does
New op **`dedup.rescore-labeled-examples`** recomputes each labeled dedup pair's `ScoreBreakdown` with the engine's existing scorer and narrow-writes it onto the `LabeledExample`, where the calibrator's primary read looks. Dry-run by default; `apply=true` writes.

## The two deliberate divergences from the operational scan
1. **Injected work list** — the labeled pairs (including *dismissed* ones, absent from any book's candidate list) are fed in explicitly by (EntityAID, EntityBID). Grouped by canonical A so book-A precompute runs once per group.
2. **Band-skip bypass** — the `Band == ""` skip is bypassed; below-band labeled pairs get their breakdown persisted, because those low-scoring negatives ARE the calibration signal. Zero-signal pairs stay reported-but-unscorable (never written as a poisoning zero).

## Bit-identical scoring (no scorer fork)
The scan loop's per-pair signal gather is extracted verbatim into a shared `collectPairSignals` helper (`internal/dedup/rescore.go`); both `runUnifiedScoringForBook` and the new `Engine.ScorePairsForBook` call it. The embedding cosine is sourced from each labeled example's stored `Similarity` gated on `Layer=="embedding"`, mirroring the scan's `embeddingMap` construction exactly — never recomputed. `unified.ComposeScore` and all scorer weights are untouched. **The existing unified-scan tests pass unchanged = no-drift proof.**

## Narrow-write safety proof
Persistence is a read-modify-write: `GetLabeledExample(candidateID)` → set **only** `Score`/`ScoreBreakdown`/`Band` → `UpsertLabeledExample`. `Label`, `LabelSource` (esp. `human`), `LabelReason`, `DecidedAt` are never touched; a row deleted between list and write is skipped, never re-created. Results are zipped to labeled rows **by index** (not by `OtherID`), so two label rows for the same (A,B) pair under different candidateIDs — the dismiss-then-recreate case — both get rescored instead of one being dropped and the other double-counted. Sharded across A-groups via `registry.RunItems` (disjoint by candidateID) sized to `runtime.NumCPU()`.

## Test results (all pass)
`go test ./internal/plugins/dedup/... ./internal/dedup/... -race` — all ok; `go vet` + `gofmt -l` clean.

- **Below-band persisted (engine):** `TestScorePairsForBook_BelowBandNotDropped` — a duration-only pair composes to exactly `4.0` (the supporting boost, no primary signal), `Band==""`; `ScorePairsForBook` returns it non-nil instead of dropping it (the operational scan's `Band==""` behavior).
- **Below-band persisted (op):** `TestRescoreLabeledExamples_BelowBandPersisted` — a below-band (`band==""`) labeled pair gets a parseable ScoreBreakdown (≥1 signal, `Score==4.0`) written onto its `LabeledExample`.
- **Human preserved:** `TestRescoreLabeledExamples_HumanLabelPreserved` — a `LabelSource=="human"` / `Label=="not_dup"` example keeps its `LabelSource`, `Label`, `LabelReason`, `DecidedAt` after rescore, while `ScoreBreakdown` becomes non-empty.
- **Dry-run writes nothing:** `TestRescoreLabeledExamples_DryRunWritesNothing`.
- **Duplicate-pair rows:** `TestRescoreLabeledExamples_DuplicatePairRowsBothRescored` — two candidateIDs for one (A,B) pair both persisted; index-zip regression guard.
- **Concurrency:** `TestRescoreLabeledExamples_ParallelManyGroups` (200 pairs across 200 A-groups) under `-race`.
- **Injection + zero-signal:** `TestScorePairsForBook_InjectsAndSkipsZeroSignal`.

## zero_signal-by-class projection
The op emits `zero_signal_true_dup` / `zero_signal_not_dup` prominently in its report. These are the pairs that produce no signal at all (below `LowThreshold` cosine + no other collector) and remain unscorable even after rescore — the decision input for a possible follow-up "score-missing-as-zero" policy, which is left to the operator (this PR does NOT touch `calibrate_composite.go`'s "never score missing as zero" guard). Exact prod counts require a run; from the coverage numbers, the bulk of the 2,069 currently-unscored pairs should become scorable (they were dropped for `Band==""`, not for zero signals), with the residual zero-signal negatives surfaced by class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv