### PR TITLE
feat(dedup): keep labeled-example ScoreBreakdown fresh on dismiss/relabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,39 @@
 <!-- file: CHANGELOG.md -->
+<!-- version: 3.147.0 -->
 <!-- version: 3.146.0 -->
 <!-- version: 3.145.0 -->
 <!-- version: 3.142.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-12 -->
+<!-- last-edited: 2026-07-13 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - feat(dedup): keep labeled-example ScoreBreakdown fresh on dismiss/relabel
+
+- **Label-write freshness** (backend) — when a human (re)writes a dedup label (dismiss, bulk/cluster
+  dismiss, merge, or a review override/relabel), the pair's current `ScoreBreakdown` is now
+  (re)snapshotted onto its `LabeledExample` at write time. Previously only *brand-new* candidate
+  pairs got a snapshot (`engine.upsertCandidateWithLiveLabel` returns early on `!isNew`), so a
+  dismissed/relabeled pair's breakdown was never refreshed and the calibration gold set slowly rotted
+  back to no-coverage as new labels accrued — making `dedup.rescore-labeled-examples` (the one-shot
+  backfill) a forever-rerun chore. This closes that gap going forward.
+- **No scorer drift:** the refresh calls the SAME shared `Engine.ScorePairsForBook`
+  (`collectPairSignals` + `unified.ComposeScore`) that PR #1926 introduced — no fork, no weight
+  changes. Embedding cosine is sourced from the example's stored `Similarity` gated on
+  `Layer=="embedding"`, identical to the backfill. Below-band pairs are **persisted** (no band-skip
+  on the snapshot) — those low-scoring negatives are the calibration signal.
+- **Best-effort, never blocks the user:** a scoring/persist failure is logged at debug and swallowed
+  — a dismiss always succeeds even if rescoring hiccups. Zero-signal and merge-deleted-book pairs
+  no-op cleanly (no bogus breakdown written).
+- **Data safety:** the refresh narrow-writes ONLY `Score`/`ScoreBreakdown`/`Band` in place before the
+  existing single upsert; `Label`, `LabelSource` (esp. `human`), `LabelReason`, `DecidedAt` are never
+  touched. Tests prove: a below-band dismiss persists a non-nil breakdown; a human override keeps its
+  `human` source + label + reason through the refresh; a scoring failure still writes the label and
+  persists no bogus breakdown. `-race` clean.
 
 #### July 12, 2026 - feat(dedup): rescore-labeled-examples op to populate ScoreBreakdowns for calibration
 
@@ -41,7 +65,7 @@
 - **`lint`** (backend) — `staticcheck ./...` now exits 0 for the first time since #1767, so the
   local `make ci` staticcheck step is honest again (the per-PR merge gate, Minimal CI, never ran
   staticcheck). 42 findings drained: 37 U1000 (unused), 4 SA1019 (deprecated), 1 SA4000.
-- 31 grep-verified-dead U1000 symbols removed (dead-duplicate handlers/aliases/helpers, superseded
+- 33 grep-verified-dead U1000 symbols removed (dead-duplicate handlers/aliases/helpers, superseded
   wrappers, redundant `maxInt`, unused test helpers, write-only `worksLookupDisabled`, unused
   struct fields). Every deletion was confirmed dead across all build configs by a repo-wide grep
   before removal; the whole dead-duplicate file `internal/server/metadata_cached_handlers.go` was

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,10 @@
 <!-- file: TODO.md -->
+<!-- version: 9.99.0 -->
 <!-- version: 9.98.0 -->
 <!-- version: 9.97.0 -->
 <!-- version: 9.93.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-12 -->
+<!-- last-edited: 2026-07-13 -->
 
 # Project TODO
 
@@ -1463,6 +1464,19 @@ must sequence, but A and B are parallelizable. Spawn:
   `TestStartCacheWarmers_SkipOnCanceledCtx` / `TestStartCacheWarmers_EnrolledInBgWG` in
   `internal/server/cache_warmers_bgwg_test.go` cover both the skip-on-shutdown and
   anti-over-suppression (live ctx still runs warmers) cases under `-race`.
+- [x] **DEDUP-EXAMPLE-FRESHNESS** (2026-07-13) — ✅ **DONE.** Root cause of the calibration
+  coverage rot: `engine.upsertCandidateWithLiveLabel` snapshots a pair's `ScoreBreakdown` onto its
+  `LabeledExample` only when the pair is brand-new (`if !isNew { return nil }`); dismiss/relabel
+  never re-snapshots, so the gold set decays back to no-coverage as new labels accrue and
+  `dedup.rescore-labeled-examples` would have to be re-run forever. Fix: the two human-label write
+  chokepoints (`recordHumanLabel` for dismiss/merge/bulk; `OverrideDedupLabel` for relabel) now
+  best-effort call a shared `refreshExampleBreakdown` that recomputes via the SAME
+  `Engine.ScorePairsForBook` scorer (no fork) and narrow-writes only `Score`/`ScoreBreakdown`/`Band`
+  before the existing upsert — below-band persisted, human label fields preserved, failures
+  swallowed. `ScorePairsForBook` added to the handler's `DedupEngine` seam (mock hand-edited, no
+  mockery regen). NOTE (latency, for follow-up): the cluster/bulk dismiss loops call the refresh
+  per-pair synchronously inside one request — an async best-effort variant may be warranted at
+  scale.
 - [x] **INGEST-VERSION-FLAKE** (2026-07-03) — ✅ **FIXED #1777.** Root cause was NOT ordering:
   PebbleStore async memdb-warmup race — `CreateImportPath`'s memdb write no-ops before warmup
   publishes, so `GetAllImportPaths` (memdb-backed) missed the test's temp dir →
@@ -1485,7 +1499,7 @@ must sequence, but A and B are parallelizable. Spawn:
   `UnifiedDedupScore`/`Signal`/`SignalKind` to a new neutral `internal/models` package with type
   aliases left in `internal/dedup/unified`. `make sdkguard` is green on main.
 - [x] **STATICCHECK-BURNDOWN** (2026-07-03) — ✅ done 2026-07-12 (TASK-02, 42 findings drained):
-  37 U1000 + 4 SA1019 + 1 SA4000. 31 grep-verified-dead U1000 symbols deleted; 4 U1000 kept with
+  37 U1000 + 4 SA1019 + 1 SA4000. 33 grep-verified-dead U1000 symbols deleted; 4 U1000 kept with
   `//lint:ignore` + reason (migration014UpPebble, deleteFingerprintLSHIndexesByID placeholder,
   rewriteChunksBE BE-write subsystem, deluge importToLibrary — each a documented placeholder or
   dropped wire-up worth surfacing, see follow-up note below); 3 SA1019 SQLite-RBAC sentinel

--- a/internal/server/handlers/dedup/interfaces.go
+++ b/internal/server/handlers/dedup/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/interfaces.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e84f746d-28e9-4c8a-9520-66191e582881
-// last-edited: 2026-07-02
+// last-edited: 2026-07-13
 
 // Narrow dependency interfaces for the dedup-domain HTTP handlers (candidate /
 // cluster / series listing, merge / dismiss / remove, bulk merge, stats,
@@ -73,6 +73,15 @@ type MergeService interface {
 // The concrete *dedup.Engine satisfies it.
 type DedupEngine interface {
 	CleanupCandidatesAfterMerge(mergedAwayBookIDs []string) int
+	// ScorePairsForBook recomputes the ScoreBreakdown for a work list of pairs
+	// sharing book A, using the SAME collectors + unified.ComposeScore as the
+	// operational scan (via the shared collectPairSignals helper — no scorer
+	// fork). Below-band pairs are NOT dropped. Used by the label-write path to
+	// re-snapshot a dismissed/relabeled pair's breakdown onto its LabeledExample
+	// so the calibration gold set doesn't rot back to no-coverage as new labels
+	// accrue (the ongoing counterpart to the one-shot dedup.rescore-labeled-examples
+	// backfill).
+	ScorePairsForBook(ctx context.Context, aID string, inputs []dedup.RescorePairInput) ([]dedup.RescorePairResult, error)
 	// Rescore re-runs unified.ComposeScore over stored signal sets for every
 	// pending candidate. When apply=false this is a dry-run (no writes);
 	// apply=true persists new bands and scores. Returns a delta summary

--- a/internal/server/handlers/dedup/label_capture.go
+++ b/internal/server/handlers/dedup/label_capture.go
@@ -1,15 +1,18 @@
 // file: internal/server/handlers/dedup/label_capture.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 7c1d9e42-3a8b-4f60-9c21-5e0a7b2d6f48
-// last-edited: 2026-06-23
+// last-edited: 2026-07-13
 
 package deduphandler
 
 import (
+	"context"
+	"encoding/json"
 	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup/dataset"
 )
 
@@ -81,6 +84,12 @@ func (h *Handler) recordHumanLabel(ex *database.LabeledExample, label, reason st
 	ex.LabelSource = labelSourceHuman
 	ex.LabelReason = reason
 	ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	// (Re)snapshot the pair's current ScoreBreakdown onto this example BEFORE the
+	// single upsert, so a dismissed/below-band pair still carries a persisted
+	// breakdown for calibration coverage. Best-effort: touches only the score
+	// fields and never blocks the label write. Background context — this gold
+	// capture should complete regardless of the request's own cancellation.
+	h.refreshExampleBreakdown(context.Background(), ex)
 	if err := es.UpsertLabeledExample(*ex); err != nil {
 		slog.Warn("dedup label capture: upsert failed", "candidate_id", ex.CandidateID, "error", err)
 		return
@@ -104,4 +113,67 @@ func (h *Handler) captureHumanLabelByID(candidateID int64, label, reason string)
 		return
 	}
 	h.recordHumanLabel(h.snapshotCandidateExample(cand), label, reason)
+}
+
+// refreshExampleBreakdown recomputes the pair's current ScoreBreakdown with the
+// engine's shared scorer (Engine.ScorePairsForBook — the same collectors +
+// unified.ComposeScore the operational scan uses, no fork) and narrow-writes ONLY
+// ex.Score / ex.ScoreBreakdown / ex.Band in place. It is the ongoing counterpart
+// to the one-shot dedup.rescore-labeled-examples backfill: without it, dismissing
+// or relabeling a pair rewrites the label but never re-snapshots its breakdown
+// (engine.upsertCandidateWithLiveLabel captures only brand-new pairs), so the
+// calibration gold set slowly rots back to no-coverage as new labels accrue.
+//
+// Contract:
+//   - Best-effort: any failure (nil engine, nil book, score error, marshal error)
+//     is logged at debug and swallowed — the caller's label write MUST still
+//     proceed. A user dismissing a pair always succeeds even if rescoring hiccups.
+//   - Below-band pairs are persisted: ScorePairsForBook does NOT drop below-band
+//     scores, and this method persists whenever a score with >=1 signal is
+//     produced — those low-scoring negatives ARE the calibration signal.
+//   - Zero-signal / merge-deleted-book pairs no-op cleanly (nil result or
+//     NumSignals==0), so no bogus breakdown is ever written.
+//   - Data safety: it touches ONLY the three score fields. Label, LabelSource
+//     (esp. "human"), LabelReason, DecidedAt and every other field the caller
+//     just set are left exactly as they are.
+//
+// EmbeddingCos is sourced from the example's stored Similarity ONLY when its Layer
+// is "embedding" — identical to dedup.rescore-labeled-examples, so the two paths
+// reconstruct the embedding signal the same way and stay bit-consistent.
+func (h *Handler) refreshExampleBreakdown(ctx context.Context, ex *database.LabeledExample) {
+	if ex == nil || h.dedupEngine == nil {
+		return
+	}
+	if ex.EntityAID == "" || ex.EntityBID == "" {
+		return
+	}
+
+	in := dedup.RescorePairInput{OtherID: ex.EntityBID}
+	if ex.Layer == "embedding" && ex.Similarity != nil {
+		cos := *ex.Similarity
+		in.EmbeddingCos = &cos
+	}
+
+	results, err := h.dedupEngine.ScorePairsForBook(ctx, ex.EntityAID, []dedup.RescorePairInput{in})
+	if err != nil {
+		slog.Debug("dedup label capture: rescore failed",
+			"candidate_id", ex.CandidateID, "entity_a", ex.EntityAID, "entity_b", ex.EntityBID, "error", err)
+		return
+	}
+	if len(results) == 0 || results[0].Score == nil || results[0].NumSignals == 0 {
+		// Zero-signal / unscorable / merge-deleted-book pair — never persist a
+		// bogus (empty) breakdown; leave whatever the example already carried.
+		return
+	}
+
+	sc := results[0].Score
+	raw, mErr := json.Marshal(sc)
+	if mErr != nil {
+		slog.Debug("dedup label capture: marshal score failed", "candidate_id", ex.CandidateID, "error", mErr)
+		return
+	}
+	// Narrow write: ONLY the score fields.
+	ex.Score = sc.Score
+	ex.ScoreBreakdown = raw
+	ex.Band = sc.Band
 }

--- a/internal/server/handlers/dedup/label_capture_test.go
+++ b/internal/server/handlers/dedup/label_capture_test.go
@@ -25,6 +25,12 @@ func allowLabelCaptureReads(d testDeps) {
 		Return(&database.Book{ID: "x", Title: "T"}, nil).Maybe()
 	d.store.EXPECT().GetBookFiles(mock.Anything).
 		Return([]database.BookFile{{FilePath: "/lib/a.m4b", FileSize: 5 << 20, Duration: 3600}}, nil).Maybe()
+	// The label-write path now (re)snapshots the pair's ScoreBreakdown via the
+	// engine's shared scorer. It is best-effort; allow it any number of times
+	// (incl. zero) and return an empty (zero-signal) result so nothing is
+	// persisted onto the example unless a test wires a richer return.
+	d.engine.EXPECT().ScorePairsForBook(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
 }
 
 func TestDismissDedupCandidate_RecordsHumanNotDupLabel(t *testing.T) {

--- a/internal/server/handlers/dedup/label_freshness_test.go
+++ b/internal/server/handlers/dedup/label_freshness_test.go
@@ -1,0 +1,154 @@
+// file: internal/server/handlers/dedup/label_freshness_test.go
+// version: 1.0.0
+// guid: 4d7a2c81-6e39-4b05-9f28-1a3c7e0d5b62
+// last-edited: 2026-07-13
+
+// Tests for the label-write freshness refresh: dismissing / relabeling a pair
+// (re)snapshots its ScoreBreakdown onto the LabeledExample via the engine's
+// shared scorer, INCLUDING below-band pairs, without ever clobbering the human
+// label fields or failing the primary label write.
+
+package deduphandler_test
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	unifiedpkg "github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+)
+
+// allowFreshnessStoreReads permits (but does not require) the best-effort
+// snapshot's book reads, returning books with a file so BuildExample populates
+// an example. Unlike allowLabelCaptureReads it does NOT wire the engine — each
+// test below sets its own ScorePairsForBook return.
+func allowFreshnessStoreReads(d testDeps) {
+	d.store.EXPECT().GetBookByID(mock.Anything).
+		Return(&database.Book{ID: "x", Title: "T"}, nil).Maybe()
+	d.store.EXPECT().GetBookFiles(mock.Anything).
+		Return([]database.BookFile{{FilePath: "/lib/a.m4b", FileSize: 5 << 20, Duration: 3600}}, nil).Maybe()
+}
+
+// TestDismiss_PersistsBelowBandBreakdown proves that dismissing a pair to not_dup
+// persists a non-nil ScoreBreakdown on its LabeledExample EVEN when the composed
+// score is below the review band (Band == "") — the snapshot must not re-apply
+// the operational scan's band-skip. It also proves the narrow write leaves the
+// human label fields intact.
+func TestDismiss_PersistsBelowBandBreakdown(t *testing.T) {
+	h, d := newHandler(t)
+	allowFreshnessStoreReads(d)
+	id, aID, bID := insertCandidate(t, d.es, "book-aaa", "book-bbb")
+
+	// A below-band score (Band == "") with real signals — the calibration
+	// negative the operational scan would have discarded.
+	belowBand := &unifiedpkg.UnifiedDedupScore{
+		Score:   12.5,
+		Band:    "", // below every review band
+		Pair:    [2]string{aID, bID},
+		Formula: unifiedpkg.FormulaVersion,
+		Signals: []unifiedpkg.Signal{{Kind: unifiedpkg.SigDuration, Raw: 0.5, Confidence: 0.4, Evidence: "dur"}},
+	}
+	d.engine.EXPECT().ScorePairsForBook(mock.Anything, aID, mock.Anything).
+		Return([]dedupengine.RescorePairResult{{OtherID: bID, Score: belowBand, NumSignals: 1}}, nil).Once()
+
+	w := doReq(t, h.DismissDedupCandidate, http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/dismiss", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(id)
+	if err != nil || ex == nil {
+		t.Fatalf("GetLabeledExample: %v (ex=%v)", err, ex)
+	}
+	// Breakdown persisted despite being below-band.
+	if len(ex.ScoreBreakdown) == 0 {
+		t.Fatalf("expected a persisted ScoreBreakdown for a below-band dismiss, got empty")
+	}
+	if ex.Band != "" {
+		t.Fatalf("Band=%q want empty (below-band snapshot preserved)", ex.Band)
+	}
+	if ex.Score != 12.5 {
+		t.Fatalf("Score=%v want 12.5", ex.Score)
+	}
+	// Human label fields untouched by the narrow write.
+	if ex.Label != "not_dup" || ex.LabelSource != "human" || ex.LabelReason != "user_dismiss" {
+		t.Fatalf("label=%q source=%q reason=%q; want not_dup/human/user_dismiss", ex.Label, ex.LabelSource, ex.LabelReason)
+	}
+}
+
+// TestOverrideRelabel_PreservesHumanLabelFields proves the refresh on the
+// relabel/override path narrow-writes ONLY the score fields: after the refresh
+// the row is still LabelSource=="human" with the reviewer's Label + LabelReason,
+// and the breakdown was populated.
+func TestOverrideRelabel_PreservesHumanLabelFields(t *testing.T) {
+	h, d := newHandler(t)
+	seedLabel(t, d, 42, "true_dup", "auto_high_conf") // Layer "exact" → no embedding cosine
+
+	score := &unifiedpkg.UnifiedDedupScore{
+		Score:   77.0,
+		Band:    "HIGH",
+		Pair:    [2]string{"a42", "b42"},
+		Formula: unifiedpkg.FormulaVersion,
+		Signals: []unifiedpkg.Signal{{Kind: unifiedpkg.SigMetaFuzzy, Raw: 0.9, Confidence: 0.8, Evidence: "meta"}},
+	}
+	d.engine.EXPECT().ScorePairsForBook(mock.Anything, "a42", mock.Anything).
+		Return([]dedupengine.RescorePairResult{{OtherID: "b42", Score: score, NumSignals: 1}}, nil).Once()
+
+	w := doReq(t, h.OverrideDedupLabel, http.MethodPost, "/api/v1/dedup/labels/42/override",
+		map[string]string{"label": "not_dup", "reason": "reviewer says different book"},
+		gin.Params{{Key: "id", Value: "42"}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(42)
+	if err != nil || ex == nil {
+		t.Fatalf("GetLabeledExample: %v (ex=%v)", err, ex)
+	}
+	if ex.Label != "not_dup" || ex.LabelSource != "human" || ex.LabelReason != "reviewer says different book" {
+		t.Fatalf("label=%q source=%q reason=%q; human label fields not preserved through refresh",
+			ex.Label, ex.LabelSource, ex.LabelReason)
+	}
+	if len(ex.ScoreBreakdown) == 0 || ex.Band != "HIGH" || ex.Score != 77.0 {
+		t.Fatalf("score fields not refreshed: breakdown_len=%d band=%q score=%v", len(ex.ScoreBreakdown), ex.Band, ex.Score)
+	}
+}
+
+// TestDismiss_ScoringFailureIsBestEffort proves a scoring failure in the refresh
+// path NEVER fails the primary label write: the dismiss still returns 200, the
+// human label is still written, and no bogus breakdown is persisted.
+func TestDismiss_ScoringFailureIsBestEffort(t *testing.T) {
+	h, d := newHandler(t)
+	allowFreshnessStoreReads(d)
+	id, aID, _ := insertCandidate(t, d.es, "book-aaa", "book-bbb")
+
+	d.engine.EXPECT().ScorePairsForBook(mock.Anything, aID, mock.Anything).
+		Return(nil, assertErr{}).Once()
+
+	w := doReq(t, h.DismissDedupCandidate, http.MethodPost,
+		"/api/v1/dedup/candidates/"+strconv.FormatInt(id, 10)+"/dismiss", nil,
+		gin.Params{{Key: "id", Value: strconv.FormatInt(id, 10)}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d want 200 even when rescoring fails; body=%s", w.Code, w.Body.String())
+	}
+
+	ex, err := d.es.GetLabeledExample(id)
+	if err != nil || ex == nil {
+		t.Fatalf("GetLabeledExample: %v (ex=%v)", err, ex)
+	}
+	// The label was written despite the scoring failure.
+	if ex.Label != "not_dup" || ex.LabelSource != "human" {
+		t.Fatalf("label=%q source=%q; want not_dup/human written despite rescore failure", ex.Label, ex.LabelSource)
+	}
+	// No bogus breakdown persisted from the failed rescore.
+	if len(ex.ScoreBreakdown) != 0 {
+		t.Fatalf("expected no ScoreBreakdown after a rescore failure, got %d bytes", len(ex.ScoreBreakdown))
+	}
+}

--- a/internal/server/handlers/dedup/label_review.go
+++ b/internal/server/handlers/dedup/label_review.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/dedup/label_review.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 5e2a9c41-7b30-4d68-8f12-3a6e0c9d5b27
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 package deduphandler
 
@@ -243,6 +243,11 @@ func (h *Handler) OverrideDedupLabel(c *gin.Context) {
 		ex.LabelReason = "ui_override"
 	}
 	ex.DecidedAt = time.Now().UTC().Format(time.RFC3339)
+	// (Re)snapshot the pair's current ScoreBreakdown onto the example BEFORE the
+	// single upsert, so a relabeled (incl. below-band) pair keeps a fresh,
+	// calibratable breakdown. Best-effort: touches only the score fields and
+	// never blocks the override.
+	h.refreshExampleBreakdown(c.Request.Context(), ex)
 	if err := es.UpsertLabeledExample(*ex); err != nil {
 		httputil.InternalError(c, "failed to save label override", err)
 		return

--- a/internal/server/handlers/dedup/label_review_test.go
+++ b/internal/server/handlers/dedup/label_review_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	deduphandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/dedup"
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/mock"
 )
 
 // seedLabel writes one labeled example. Each candidate gets its OWN distinct
@@ -105,6 +106,9 @@ func TestGetDedupLabelStats_UnlabeledDerived(t *testing.T) {
 func TestOverrideDedupLabel_SetsHuman(t *testing.T) {
 	h, d := newHandler(t)
 	seedLabel(t, d, 7, "true_dup", "auto_high_conf")
+	// The override path now best-effort re-snapshots the breakdown; allow it.
+	d.engine.EXPECT().ScorePairsForBook(mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
 
 	w := doReq(t, h.OverrideDedupLabel, http.MethodPost, "/api/v1/dedup/labels/7/override",
 		map[string]string{"label": "not_dup", "reason": "reviewer says different book"},

--- a/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
+++ b/internal/server/handlers/dedup/mocks/mock_dedup_engine.go
@@ -222,3 +222,77 @@ func (_c *MockDedupEngine_Rescore_Call) RunAndReturn(run func(ctx context.Contex
 	_c.Call.Return(run)
 	return _c
 }
+
+// ScorePairsForBook provides a mock function for the type MockDedupEngine
+func (_mock *MockDedupEngine) ScorePairsForBook(ctx context.Context, aID string, inputs []dedup.RescorePairInput) ([]dedup.RescorePairResult, error) {
+	ret := _mock.Called(ctx, aID, inputs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ScorePairsForBook")
+	}
+
+	var r0 []dedup.RescorePairResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []dedup.RescorePairInput) ([]dedup.RescorePairResult, error)); ok {
+		return returnFunc(ctx, aID, inputs)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []dedup.RescorePairInput) []dedup.RescorePairResult); ok {
+		r0 = returnFunc(ctx, aID, inputs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]dedup.RescorePairResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, []dedup.RescorePairInput) error); ok {
+		r1 = returnFunc(ctx, aID, inputs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDedupEngine_ScorePairsForBook_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ScorePairsForBook'
+type MockDedupEngine_ScorePairsForBook_Call struct {
+	*mock.Call
+}
+
+// ScorePairsForBook is a helper method to define mock.On call
+//   - ctx context.Context
+//   - aID string
+//   - inputs []dedup.RescorePairInput
+func (_e *MockDedupEngine_Expecter) ScorePairsForBook(ctx any, aID any, inputs any) *MockDedupEngine_ScorePairsForBook_Call {
+	return &MockDedupEngine_ScorePairsForBook_Call{Call: _e.mock.On("ScorePairsForBook", ctx, aID, inputs)}
+}
+
+func (_c *MockDedupEngine_ScorePairsForBook_Call) Run(run func(ctx context.Context, aID string, inputs []dedup.RescorePairInput)) *MockDedupEngine_ScorePairsForBook_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []dedup.RescorePairInput
+		if args[2] != nil {
+			arg2 = args[2].([]dedup.RescorePairInput)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDedupEngine_ScorePairsForBook_Call) Return(rescorePairResults []dedup.RescorePairResult, err error) *MockDedupEngine_ScorePairsForBook_Call {
+	_c.Call.Return(rescorePairResults, err)
+	return _c
+}
+
+func (_c *MockDedupEngine_ScorePairsForBook_Call) RunAndReturn(run func(ctx context.Context, aID string, inputs []dedup.RescorePairInput) ([]dedup.RescorePairResult, error)) *MockDedupEngine_ScorePairsForBook_Call {
+	_c.Call.Return(run)
+	return _c
+}


### PR DESCRIPTION
## The rot mechanism
The operational unified scan snapshots a pair's `ScoreBreakdown` onto its `LabeledExample` **only when the candidate pair is brand-new** (`engine.upsertCandidateWithLiveLabel` returns early on `!isNew`); a later dismiss (`not_dup`) or relabel never re-snapshots, so the calibration gold set slowly rots back to no-coverage as new labels accrue — making PR #1926's one-shot `dedup.rescore-labeled-examples` backfill a forever-rerun chore.

## Insertion point chosen (and why)
A `UpsertLabeledExample` grep proves the human-label write path is exactly **two chokepoints**, so no logic scattering was needed (the "spread across many handlers" STOP condition does not apply):
- `label_capture.go recordHumanLabel` — the funnel for **all** merge/dismiss captures (single dismiss via `captureHumanLabelByID`, `DismissDedupCluster`, single merge, `BulkMergeDedupCandidates`).
- `label_review.go OverrideDedupLabel` — the relabel/override path.

Both already do `set label fields → UpsertLabeledExample(*ex)`. A new shared helper `refreshExampleBreakdown(ctx, ex)` mutates **only** `ex.Score`/`ex.ScoreBreakdown`/`ex.Band` in place **before** that existing single upsert. One write, no double-RMW, data-safe by construction (the caller owns the label fields; the helper touches only the three score fields). The helper reuses the SAME shared `Engine.ScorePairsForBook` (`collectPairSignals` + `unified.ComposeScore`) PR #1926 introduced — no scorer fork, no weight changes; embedding cosine sourced from the example's stored `Similarity` gated on `Layer=="embedding"`, identical to the backfill. **No band-skip on the snapshot** — below-band negatives (the calibration signal) are persisted.

`ScorePairsForBook` was added to the handler's `DedupEngine` interface seam; the concrete `*dedup.Engine` already satisfies it. The generated mock was **hand-edited** (no mockery regen, per the v3.7.1-vs-v2.53.6 drift gotcha).

## Best-effort guarantee
Any scoring/persist failure (nil engine, nil book, score error, marshal error) is logged at debug and **swallowed** — the primary label write always succeeds, exactly like `captureLiveLabel`. A user dismissing a pair always succeeds even if rescoring hiccups. Zero-signal and merge-deleted-book pairs no-op cleanly (nil result / `NumSignals==0`), so no bogus breakdown is ever written.

## Data-safety proof
The refresh narrow-writes only the three score fields; `Label`, `LabelSource` (esp. `human`), `LabelReason`, `DecidedAt` are never touched. New tests (`internal/server/handlers/dedup`, `-race`):
- `TestDismiss_PersistsBelowBandBreakdown` — dismissing to `not_dup` persists a **non-nil** breakdown even with `Band==""` (proves no band-skip), and preserves `not_dup`/`human`/`user_dismiss`.
- `TestOverrideRelabel_PreservesHumanLabelFields` — a human override keeps `human` source + label + reason through the refresh, with score fields updated.
- `TestDismiss_ScoringFailureIsBestEffort` — a scoring failure still returns 200, still writes the human label, and persists **no** bogus breakdown.

## Test results
- `go test ./internal/dedup/... ./internal/plugins/dedup/... -race` — **ok**
- `go test ./internal/server/handlers/dedup/ -race` — **ok** (all new + existing label tests pass)
- `go test ./internal/server/ -race -timeout 30m` — **ok (556.5s)** _(the default 10-min `go test` timeout is too tight for this race-instrumented package — a known env issue; CI uses `-timeout 30m`. This package is not touched by the PR.)_
- `go build ./...`, `go vet`, `gofmt -l` on changed files — **clean**

## Also folded in
Corrects PR #1924's dead-symbol count in `CHANGELOG.md` + `TODO.md`: **33** grep-verified-dead U1000 symbols removed, not 31 (37 U1000 total − 4 kept = 33). Doc-only.

## ⚠️ Latency trade-off (surface, don't force)
Single dismiss/override is one pair — synchronous is fine. But `DismissDedupCluster` and `BulkMergeDedupCandidates` call `recordHumanLabel` **per pair in a loop**, so the refresh becomes N sequential per-book precomputes inside one HTTP request. Implemented synchronously + best-effort as instructed; flagging for the orchestrator to decide whether an async best-effort goroutine is warranted for the bulk paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv