### PR TITLE
fix(scanner): stop wiping metadata/ratings/transcriptions on rescan (data-loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,37 @@
   loser, mirroring `autoMergeCertain`.
 - Tests: a load-bearing `-race` merge-serialization test (verified to fail with the lock reverted:
   `maxActive=16`), a journal-failure-skips-merge test, and an `ApplyVerdicts` batch skip/cleanup test.
+#### July 13, 2026 - fix(scanner): stop wiping metadata/ratings/transcriptions on rescan (data-loss)
+
+- **Rescan data-loss fixed** (backend, `internal/scanner/scanner.go`) — re-scanning an
+  already-imported file (matched by path, or an existing hash-duplicate whose organized path is
+  being promoted) used to write a partial scanner-built `database.Book` literal via a full-replace
+  `UpdateBook(existing.ID, dbBook)`. Only a hand-maintained subset of the existing row was copied
+  back via `preserveExistingFields`, so every omitted field was WIPED on every rescan: `AuthorID`
+  and `SeriesID` (whenever the file had no author/series tag → `resolveAuthorID`/`resolveSeriesID`
+  return nil), `Genre`, `MetadataReviewStatus`/`MetadataSource`/`MetadataSourceHash`, all
+  Audible/Google/User/iTunes rating fields, media-info (`Bitrate`/`Codec`/`SampleRate`/`Channels`/
+  `BitDepth`/`Quality`), `ITunesSyncStatus`, `AudibleRuntimeMin`, `DurationVerifiedAt`,
+  `MergedIntoBookID`, `QuarantineReason`/`QuarantinedAt`, and all transcription fields
+  (`IntroTranscription`, `Transcribed*`, `Transcribe*`).
+- **Fix — invert the write:** the rescan path now starts from the COMPLETE existing row
+  (`GetBookByFilePath` → `GetBookByID` is a full-fidelity Pebble point-get, verified) and overlays
+  ONLY the scanner-owned fields via a new `applyScannerFields` helper — file path/format/hashes/size,
+  duration, library-state, and the tag-derived title/author/series/narrator/publisher/language/
+  provider-IDs when present. Everything else survives by construction, so a newly-added Book field
+  can never silently regress (fails closed, not open). Reuses the already-loaded `existing`, no extra
+  DB read on the hot path.
+- **Field-ownership rule:** every overlaid field is "scanned value wins if present (non-nil /
+  non-zero), else keep existing" — reproducing prior behavior for the fields `preserveExistingFields`
+  already guarded, and adding that same guard to the fields the old code overwrote unconditionally
+  (Title/AuthorID/SeriesID/Format/hashes/Duration), which is precisely the wipe this fixes.
+  `SourceImportPath` is deliberately not overlaid ("set on CreateBook only, never mutated on
+  UpdateBook"). The org-ID re-link, hash-dup, sibling, and create branches are untouched.
+- **Load-bearing regression test** (`internal/scanner/rescan_preserve_test.go`) — drives the real
+  `saveBookToDatabase` + `PebbleStore.UpdateBook` round-trip (not the helper in isolation): imports a
+  book, enriches it with ratings/transcription/review-status/media-info, rescans the same path with
+  new tags and NO author/series, and asserts scanner-owned fields update while 20 previously-wiped
+  fields survive. Proven to FAIL against the old write path. `-race` clean.
 
 #### July 13, 2026 - feat(dedup): keep labeled-example ScoreBreakdown fresh on dismiss/relabel
 

--- a/TODO.md
+++ b/TODO.md
@@ -243,6 +243,31 @@ Adjacent unguarded paths NOT covered (separate follow-up): `dedup.MergeBooks`
   this change) green with zero FAIL/panic/DATA RACE. Frontend: `tsc --noEmit` clean, `eslint`
   clean, full vitest suite green (55/55 files, 351/351 tests after the loading-UX follow-up).
 
+## ✅ RESOLVED — library-scan RESCAN wiped metadata/ratings/transcriptions via full-replace UpdateBook (2026-07-13)
+
+- **Sibling to the W5d-1 write-back wipe below, but on the SCANNER hot path.** `saveBookToDatabase`
+  (`internal/scanner/scanner.go`) built a partial `&database.Book{...}` literal from freshly-scanned
+  tags and, on a path-match rescan (or organized-path promotion of an existing hash-duplicate), wrote
+  it via a full-replace `getStore().UpdateBook(existing.ID, dbBook)`. Only a subset was copied back
+  via `preserveExistingFields`, so every omitted field was WIPED on EVERY rescan: `AuthorID`/
+  `SeriesID` (whenever the file had no author/series tag — `resolveAuthorID`/`resolveSeriesID` return
+  nil), `Genre`, `MetadataReviewStatus`/`MetadataSource`/`MetadataSourceHash`, all Audible/Google/
+  User/iTunes rating fields, media-info (`Bitrate`/`Codec`/`SampleRate`/`Channels`/`BitDepth`/
+  `Quality`), `ITunesSyncStatus`, `AudibleRuntimeMin`, `DurationVerifiedAt`, `MergedIntoBookID`,
+  `Quarantine*`, and all transcription fields (`IntroTranscription`/`Transcribed*`/`Transcribe*`).
+- **Fix — invert the write** (chosen over extending `preserveExistingFields`, which fails OPEN — a
+  future field not added to the list is silently wiped). New `applyScannerFields(dst, scanned)`
+  overlays only the scanner-owned fields onto a copy of the COMPLETE existing row
+  (`GetBookByFilePath`→`GetBookByID` is a full-fidelity Pebble point-get, verified), then writes that
+  copy. Everything else survives by construction; fails CLOSED. Reuses the already-loaded `existing`,
+  no extra DB read. Rule: scanned-wins-if-present-else-keep-existing for every overlaid field;
+  `SourceImportPath` never overlaid (CreateBook-only). Org-ID re-link, hash-dup, sibling, and create
+  branches untouched.
+- **Load-bearing regression test:** `internal/scanner/rescan_preserve_test.go` drives the real
+  `saveBookToDatabase` + `PebbleStore.UpdateBook` round-trip and asserts 20 previously-wiped fields
+  survive a rescan; proven to FAIL against the old write path. `-race` clean; full scanner package
+  green. CHANGELOG + July monthly executive summary (§4 data-integrity) updated.
+
 ## ✅ RESOLVED — CreateOrganizedVersion original-book slim-writeback wiped Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887; FIXED 2026-07-11)
 
 - **Was CONFIRMED, not just suspected, as of 2026-07-11 (#1887, INIT-9 T07).** The executable

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -1,7 +1,7 @@
 <!-- file: docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md -->
-<!-- version: 1.4.0 -->
+<!-- version: 1.5.0 -->
 <!-- guid: 5b0ee171-8a4f-4669-a2dd-91ffeabaa486 -->
-<!-- last-edited: 2026-07-11 -->
+<!-- last-edited: 2026-07-13 -->
 
 # Executive Summary: June–July Monthly Roundup
 
@@ -260,6 +260,23 @@ database expects rather than only the ones the in-memory object happened
 to be carrying (#1552, #1747). Durations are now read from the real audio
 file via `ffprobe` (a standard audio-inspection tool) instead of estimated
 from bitrate (#1555), and stored consistently in seconds (#1523).
+
+**A third instance on the library-scan path (rescans):** the same
+full-replace-save-wipes-fields shape was found on the scanner's hot path.
+Every time an already-imported file was re-scanned (e.g. after being
+re-processed or moved), the scanner wrote back a record built only from the
+file's own audio tags — which meant it silently erased everything the tags
+don't carry: the book's author and series links (whenever the file had no
+author/series tag), all fetched ratings, the Whisper-generated
+transcriptions used to identify unlabeled books, the "metadata reviewed"
+status, genre, and the technical audio details (bitrate, codec, etc.). The
+fix inverts the save so it starts from the book's complete existing record
+and overlays only the handful of fields the scanner legitimately owns
+(file path, hashes, size, and the tag-derived title/author/narrator when
+present) — so nothing outside the scanner's remit can be lost, and any
+field added in the future is preserved automatically rather than having to
+be remembered. A regression test proves twenty previously-wiped fields now
+survive a rescan.
 
 ### 5. Whisper transcription pipeline and GPU infrastructure
 

--- a/internal/scanner/rescan_preserve_test.go
+++ b/internal/scanner/rescan_preserve_test.go
@@ -1,0 +1,195 @@
+// file: internal/scanner/rescan_preserve_test.go
+// version: 1.0.0
+// guid: b2f4c6a8-1d3e-4f50-9a7b-2c6e8d0f1a34
+// last-edited: 2026-07-13
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+func strPtr(s string) *string   { return &s }
+func intP(i int) *int           { return &i }
+func f64Ptr(f float64) *float64 { return &f }
+
+// TestSaveBookToDatabase_RescanPreservesEnrichedFields is the load-bearing
+// regression test for the rescan data-loss bug: re-scanning an already-imported
+// file (matched by path) used to write a partial scanner Book literal via a
+// full-replace UpdateBook, wiping every field the scanner does not populate —
+// Author/Series, ratings, Whisper transcriptions, MetadataReviewStatus, Genre,
+// media-info, etc. This test drives the REAL saveBookToDatabase +
+// PebbleStore.UpdateBook path (not applyScannerFields in isolation) so it also
+// proves the store getter returns a full-fidelity row.
+func TestSaveBookToDatabase_RescanPreservesEnrichedFields(t *testing.T) {
+	store, cleanup := setupPebbleStore(t)
+	defer cleanup()
+
+	prevStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	SetStore(store)
+	t.Cleanup(func() {
+		database.SetGlobalStore(prevStore)
+		SetStore(nil)
+	})
+
+	prevConfig := config.AppConfig
+	t.Cleanup(func() { config.AppConfig = prevConfig })
+
+	rootDir := t.TempDir()
+	config.AppConfig.RootDir = rootDir
+
+	filePath := filepath.Join(rootDir, "rich-book.m4b")
+	if err := os.WriteFile(filePath, []byte("rich book content"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	// 1) Initial import with author + series so the links exist.
+	orig := &Book{
+		FilePath: filePath,
+		Title:    "Original Title",
+		Author:   "Rich Author",
+		Series:   "Rich Series",
+		Position: 3,
+		Format:   ".m4b",
+		Duration: 100,
+		Narrator: "Original Narrator",
+	}
+	if err := saveBookToDatabase(context.Background(), orig); err != nil {
+		t.Fatalf("initial saveBookToDatabase failed: %v", err)
+	}
+
+	saved, err := store.GetBookByFilePath(filePath)
+	if err != nil || saved == nil {
+		t.Fatalf("expected saved book after import, err=%v", err)
+	}
+	if saved.AuthorID == nil || saved.SeriesID == nil {
+		t.Fatalf("expected author/series links after import, got author=%v series=%v", saved.AuthorID, saved.SeriesID)
+	}
+	origAuthorID := *saved.AuthorID
+	origSeriesID := *saved.SeriesID
+
+	// 2) Enrich the row with data no scanner tag carries — the exact set the
+	// old rescan wiped. Persisted via a full-replace UpdateBook, which the
+	// store does NOT protect for these fields.
+	saved.AudibleRatingOverall = f64Ptr(4.7)
+	saved.AudibleRatingCount = intP(1234)
+	saved.GoogleRatingAverage = f64Ptr(4.2)
+	saved.ITunesRating = intP(100)
+	saved.UserRatingOverall = f64Ptr(5.0)
+	saved.IntroTranscription = strPtr("This is Rich Title by Rich Author. Read by Original Narrator.")
+	saved.TranscribedTitle = strPtr("Rich Title")
+	saved.TranscribedAuthor = strPtr("Rich Author")
+	saved.TranscribeStatus = strPtr("ok")
+	saved.MetadataReviewStatus = strPtr("matched")
+	saved.MetadataSource = strPtr("audible")
+	saved.MetadataSourceHash = strPtr("sha256:deadbeef")
+	saved.Genre = strPtr("Fantasy")
+	saved.Bitrate = intP(128)
+	saved.Codec = strPtr("aac")
+	saved.SampleRate = intP(44100)
+	saved.Quality = strPtr("high")
+	saved.ITunesSyncStatus = strPtr("synced")
+	saved.AudibleRuntimeMin = intP(605)
+	if _, err := store.UpdateBook(saved.ID, saved); err != nil {
+		t.Fatalf("enrich UpdateBook failed: %v", err)
+	}
+
+	// 3) Rescan the SAME path with fresh tag data that changes scanner-owned
+	// fields (Title, Narrator) AND carries NO author/series tag — the case that
+	// previously produced nil AuthorID/SeriesID and wiped the links.
+	rescan := &Book{
+		FilePath: filePath,
+		Title:    "Rescanned Title",
+		Author:   "", // no author tag
+		Series:   "", // no series tag
+		Format:   ".m4b",
+		Duration: 100,
+		Narrator: "Rescanned Narrator",
+	}
+	if err := saveBookToDatabase(context.Background(), rescan); err != nil {
+		t.Fatalf("rescan saveBookToDatabase failed: %v", err)
+	}
+
+	// 4) Reload and assert: scanner-owned fields updated, everything else survived.
+	got, err := store.GetBookByFilePath(filePath)
+	if err != nil || got == nil {
+		t.Fatalf("expected book after rescan, err=%v", err)
+	}
+
+	// Scanner-owned fields DID update.
+	if got.Title != "Rescanned Title" {
+		t.Errorf("Title: want %q, got %q", "Rescanned Title", got.Title)
+	}
+	if got.Narrator == nil || *got.Narrator != "Rescanned Narrator" {
+		t.Errorf("Narrator: want %q, got %v", "Rescanned Narrator", got.Narrator)
+	}
+
+	// Author/Series links SURVIVED (the headline fix).
+	if got.AuthorID == nil || *got.AuthorID != origAuthorID {
+		t.Errorf("AuthorID wiped on rescan: want %d, got %v", origAuthorID, got.AuthorID)
+	}
+	if got.SeriesID == nil || *got.SeriesID != origSeriesID {
+		t.Errorf("SeriesID wiped on rescan: want %d, got %v", origSeriesID, got.SeriesID)
+	}
+
+	// Every previously-wiped enriched field SURVIVED.
+	assertF64(t, "AudibleRatingOverall", got.AudibleRatingOverall, 4.7)
+	assertInt(t, "AudibleRatingCount", got.AudibleRatingCount, 1234)
+	assertF64(t, "GoogleRatingAverage", got.GoogleRatingAverage, 4.2)
+	assertInt(t, "ITunesRating", got.ITunesRating, 100)
+	assertF64(t, "UserRatingOverall", got.UserRatingOverall, 5.0)
+	assertStr(t, "IntroTranscription", got.IntroTranscription, "This is Rich Title by Rich Author. Read by Original Narrator.")
+	assertStr(t, "TranscribedTitle", got.TranscribedTitle, "Rich Title")
+	assertStr(t, "TranscribedAuthor", got.TranscribedAuthor, "Rich Author")
+	assertStr(t, "TranscribeStatus", got.TranscribeStatus, "ok")
+	assertStr(t, "MetadataReviewStatus", got.MetadataReviewStatus, "matched")
+	assertStr(t, "MetadataSource", got.MetadataSource, "audible")
+	assertStr(t, "MetadataSourceHash", got.MetadataSourceHash, "sha256:deadbeef")
+	assertStr(t, "Genre", got.Genre, "Fantasy")
+	assertInt(t, "Bitrate", got.Bitrate, 128)
+	assertStr(t, "Codec", got.Codec, "aac")
+	assertInt(t, "SampleRate", got.SampleRate, 44100)
+	assertStr(t, "Quality", got.Quality, "high")
+	assertStr(t, "ITunesSyncStatus", got.ITunesSyncStatus, "synced")
+	assertInt(t, "AudibleRuntimeMin", got.AudibleRuntimeMin, 605)
+}
+
+func assertStr(t *testing.T, field string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s wiped on rescan: want %q, got nil", field, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s: want %q, got %q", field, want, *got)
+	}
+}
+
+func assertInt(t *testing.T, field string, got *int, want int) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s wiped on rescan: want %d, got nil", field, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s: want %d, got %d", field, want, *got)
+	}
+}
+
+func assertF64(t *testing.T, field string, got *float64, want float64) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s wiped on rescan: want %v, got nil", field, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s: want %v, got %v", field, want, *got)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.47.1
+// version: 1.48.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
 package scanner
 
@@ -2018,21 +2018,27 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 			return err
 		}
 
-		// Preserve original hash if already stored and we are rescanning a library file
-		if existing.OriginalFileHash != nil {
-			dbBook.OriginalFileHash = existing.OriginalFileHash
-		}
-		if dbBook.OrganizedFileHash == nil && existing.OrganizedFileHash != nil {
-			dbBook.OrganizedFileHash = existing.OrganizedFileHash
-		}
+		// Rescan of an already-imported file (matched by path, or an existing
+		// hash-duplicate whose organized path we are promoting above). Writing
+		// the partial dbBook literal via a full-replace UpdateBook wiped every
+		// Book field the scanner does not populate — fetched metadata, ratings,
+		// Whisper transcriptions, media-info, review status, quarantine state,
+		// lifecycle timestamps, etc. — because UpdateBook replaces the whole row
+		// (data-loss bug).
+		//
+		// Fix (INVERT): start from the COMPLETE existing row and overlay ONLY
+		// the fields the scanner is authoritative for. Everything else survives
+		// by construction, so a newly-added Book field can never silently
+		// regress. `existing` is already loaded (GetBookByFilePath ->
+		// GetBookByID is a full-fidelity point-get), so this adds no extra DB
+		// read. Copy it first so the getter's pointer is never mutated in place.
+		merged := *existing
+		applyScannerFields(&merged, dbBook)
 
-		// Preserve enriched fields that scanner doesn't extract (e.g. from metadata fetch or AI parse)
-		preserveExistingFields(dbBook, existing)
-
-		_, err = getStore().UpdateBook(existing.ID, dbBook)
+		_, err = getStore().UpdateBook(existing.ID, &merged)
 		if err == nil {
 			// Check for metadata hash duplicates after update
-			detectMetadataHashDuplicate(dbBook, defaultLog)
+			detectMetadataHashDuplicate(&merged, defaultLog)
 		}
 		return err
 	}
@@ -2341,6 +2347,101 @@ func preserveExistingFields(scanned *database.Book, existing *database.Book) {
 	if scanned.SourceImportPath == nil && existing.SourceImportPath != nil {
 		scanned.SourceImportPath = existing.SourceImportPath
 	}
+}
+
+// applyScannerFields overlays the fields the scanner freshly derives from the
+// file and its tags onto dst (a copy of the COMPLETE existing row), leaving
+// every other field untouched. It is the write-side of the rescan data-loss
+// fix: previously a rescan wrote a partial Book literal via a full-replace
+// UpdateBook, wiping fetched metadata, ratings, Whisper transcriptions,
+// media-info (Bitrate/Codec/…), MetadataReviewStatus/Source/Hash,
+// ITunesSyncStatus, quarantine state, version links, and lifecycle timestamps.
+// Starting from the full row and overlaying only scanner-owned fields makes
+// data loss impossible by construction — a future Book field is preserved
+// automatically rather than silently dropped.
+//
+// The rule for every overlaid field is "scanned value wins if present (non-nil
+// / non-zero), else keep existing." This reproduces the prior behavior for the
+// fields preserveExistingFields already guarded and for the always-set
+// LibraryState/Quantity, and adds the same guard to the fields the old code
+// overwrote unconditionally (Title/AuthorID/SeriesID/Format/hashes/Duration) —
+// which is precisely the wipe this fixes (an untagged file yields nil
+// AuthorID/SeriesID), applied consistently.
+func applyScannerFields(dst *database.Book, scanned *database.Book) {
+	// Identity / file-derived fields (freshly read from the file this scan).
+	if scanned.FilePath != "" {
+		dst.FilePath = scanned.FilePath
+	}
+	if scanned.Format != "" {
+		dst.Format = scanned.Format
+	}
+	if scanned.FileHash != nil {
+		dst.FileHash = scanned.FileHash
+	}
+	if scanned.FileSize != nil {
+		dst.FileSize = scanned.FileSize
+	}
+	// OriginalFileHash records the pre-organize hash; once stored it must be
+	// preserved, so only adopt the scanned value when none is stored yet.
+	if dst.OriginalFileHash == nil && scanned.OriginalFileHash != nil {
+		dst.OriginalFileHash = scanned.OriginalFileHash
+	}
+	// OrganizedFileHash: scanned value wins when the file is under RootDir.
+	if scanned.OrganizedFileHash != nil {
+		dst.OrganizedFileHash = scanned.OrganizedFileHash
+	}
+	if scanned.Duration != nil {
+		dst.Duration = scanned.Duration
+	}
+	if scanned.LibraryState != nil {
+		dst.LibraryState = scanned.LibraryState
+	}
+	if scanned.Quantity != nil {
+		dst.Quantity = scanned.Quantity
+	}
+
+	// Tag-derived identity fields.
+	if scanned.Title != "" {
+		dst.Title = scanned.Title
+	}
+	if scanned.AuthorID != nil {
+		dst.AuthorID = scanned.AuthorID
+	}
+	if scanned.SeriesID != nil {
+		dst.SeriesID = scanned.SeriesID
+	}
+	if scanned.SeriesSequence != nil && *scanned.SeriesSequence != 0 {
+		dst.SeriesSequence = scanned.SeriesSequence
+	}
+	if scanned.WorkID != nil {
+		dst.WorkID = scanned.WorkID
+	}
+
+	// Tag-derived enrichment fields.
+	if scanned.Narrator != nil {
+		dst.Narrator = scanned.Narrator
+	}
+	if scanned.Language != nil {
+		dst.Language = scanned.Language
+	}
+	if scanned.Publisher != nil {
+		dst.Publisher = scanned.Publisher
+	}
+	if scanned.ASIN != nil {
+		dst.ASIN = scanned.ASIN
+	}
+	if scanned.OpenLibraryID != nil {
+		dst.OpenLibraryID = scanned.OpenLibraryID
+	}
+	if scanned.HardcoverID != nil {
+		dst.HardcoverID = scanned.HardcoverID
+	}
+	if scanned.GoogleBooksID != nil {
+		dst.GoogleBooksID = scanned.GoogleBooksID
+	}
+
+	// SourceImportPath is set on CreateBook only and must never be mutated on
+	// UpdateBook, so it is deliberately NOT overlaid here (dst keeps existing's).
 }
 
 // identifySeriesUsingExternalAPIs tries to match books to series using external APIs


### PR DESCRIPTION
## The wipe scenario (data-loss, REVIEW-CRITICAL)

`saveBookToDatabase` (`internal/scanner/scanner.go`) builds a **partial** `&database.Book{...}` literal from freshly-scanned tags, then on a **rescan** of an already-imported file — matched by path, or an existing hash-duplicate whose organized path is being promoted — writes it with a **full-replace** `getStore().UpdateBook(existing.ID, dbBook)`. Only a hand-maintained subset of the existing row was copied back via `preserveExistingFields`, so **every omitted field was WIPED on every rescan**:

- `AuthorID` / `SeriesID` — whenever the file has no author/series tag, `resolveAuthorID`/`resolveSeriesID` return `nil`, and the full-replace writes `nil` (verified at `scanner.go:2160-2233`).
- `Genre`, `MetadataReviewStatus`, `MetadataSource`, `MetadataSourceHash`
- All rating fields (`Audible*`, `Google*`, `User*`, `ITunesRating`)
- Media-info (`Bitrate`, `Codec`, `SampleRate`, `Channels`, `BitDepth`, `Quality`)
- `ITunesSyncStatus`, `AudibleRuntimeMin`, `DurationVerifiedAt`, `MergedIntoBookID`, `QuarantineReason`/`QuarantinedAt`
- All transcription fields (`IntroTranscription`, `Transcribed*`, `Transcribe*`)

Consequence: rescanning a changed/re-processed file destroyed fetched metadata, ratings, and Whisper transcriptions. This is the scan-path sibling of the `CreateOrganizedVersion` write-back wipe (STOREFID W5d-1 / #1893).

## Approach chosen: INVERT the write (and why)

Instead of writing the partial `dbBook` and back-filling a subset, the rescan path now starts from the **COMPLETE existing row** and overlays **only** the fields the scanner legitimately owns (new `applyScannerFields` helper), then writes that.

- **Fails closed, not open.** Everything the scanner doesn't own survives by construction — a newly-added `Book` field is preserved automatically. The alternative (extend `preserveExistingFields`) fails *open*: any future field not added to the list is silently wiped. For a data-loss fix, fail-closed wins.
- **Fidelity precondition verified.** Invert only works if `existing` is complete. `GetBookByFilePath` → `GetBookByID` does a full `json.Unmarshal` of the stored value on the Pebble prod path (`pebble_store.go:746-819`) — full-fidelity, no memdb/summary projection.
- **No extra DB read on the hot path.** Reuses the already-loaded `existing`; works on a copy (`merged := *existing`) so the getter's pointer is never mutated in place.

## Field-ownership split

Overlaid (scanner-owned; rule = **scanned wins if present, else keep existing**): `FilePath`, `Format`, `FileHash`, `FileSize`, `OriginalFileHash` (existing wins if already set), `OrganizedFileHash`, `Duration`, `LibraryState`, `Quantity`, `Title`, `AuthorID`, `SeriesID`, `SeriesSequence`, `WorkID`, `Narrator`, `Language`, `Publisher`, `ASIN`, `OpenLibraryID`, `HardcoverID`, `GoogleBooksID`.

This reproduces prior behavior for the fields `preserveExistingFields` already guarded and for always-set `LibraryState`/`Quantity`, and **adds** the guard to the fields the old code overwrote unconditionally (`Title`/`AuthorID`/`SeriesID`/`Format`/hashes/`Duration`) — which is precisely the wipe being fixed.

NOT touched (survive by construction): `SourceImportPath` (CreateBook-only, never mutated on update), version fields, deletion state, all ratings, all transcription fields, media-info, metadata-review/source/hash, iTunes fields, `BookSig*`, scan-cache, quarantine, lifecycle timestamps, and every future field. The org-ID re-link, hash-dup, sibling, and create branches are untouched.

## Test results

Load-bearing regression test `internal/scanner/rescan_preserve_test.go` drives the **real** `saveBookToDatabase` + `PebbleStore.UpdateBook` round-trip (not the helper in isolation, so it also proves getter fidelity): import a book → enrich with ratings/transcription/review-status/media-info → rescan same path with new tags and **no author/series** → reload and assert.

- With the fix: full scanner package **green**, `-race` clean (`go test ./internal/scanner/... -race`).
- **Proven discriminating:** reverting to the old write path fails the test with **20 wiped fields** (AuthorID, SeriesID, all ratings, all transcription fields, MetadataReviewStatus/Source/Hash, Genre, Bitrate/Codec/SampleRate/Quality, ITunesSyncStatus, AudibleRuntimeMin).
- `go vet` clean, `gofmt -l` clean (on changed files), `go build ./...` clean.

## Docs

CHANGELOG, TODO (new ✅ RESOLVED section), and the July monthly executive summary (§4 Book/chapter data-integrity) updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv