### PR TITLE
fix(server): hydrate before write in entities_ops to stop full-record wipe (data-loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,32 @@
   the rescan call is gated, not unconditional), `TestDatasetBackfill_ApplyUpsertFailure_NotDismissed`,
   `TestRescoreLabeledExamples_ApplyUpsertFailure_CountsError`. `internal/organizer/...`,
   `internal/plugins/dedup/...`, `internal/itunes/...` all green under `-race`.
+#### July 13, 2026 - fix(server): hydrate before write in entities_ops to stop full-record wipe (DATA-LOSS)
+
+- **Catastrophic data-loss fix** (backend) — the `entities.resolve-production-author` op had two
+  write sites that passed a near-empty `database.Book{}` literal to the **full-replace** `UpdateBook`,
+  wiping the ENTIRE stored Pebble record for each processed book:
+  - Publisher-reclassify branch: `UpdateBook(id, &database.Book{Publisher: &pub})` — kept only
+    Publisher.
+  - AI-cover author-resolve branch: `UpdateBook(id, &database.Book{AuthorID: &aid})` — kept only
+    AuthorID.
+  Everything else was destroyed: `Title`, `FilePath` (which also **corrupts the `book:path:` index**),
+  `SeriesID`, `Author`/`Series`, `Narrator`, `Genre`, `ISBN`/`ASIN`, all ratings, media-info,
+  transcription, and metadata-review state. `UpdateBook`'s preserve-on-nil guard only restores 7 heavy
+  `Description`/`BookSig*` fields — the rest were gone permanently.
+- **Fix:** both sites now hydrate the full current row via `GetBookByID` immediately before the write
+  and mutate ONLY the intended field, matching the STOREFID W5d-1 pattern (PR #1888). The write logic
+  is extracted into `assignPublisherPreservingRecord` / `assignResolvedAuthorPreservingRecord`.
+- **Fail-closed:** if hydration fails, NOTHING is written (a skipped publisher/author tag is far better
+  than a wiped record). The op logs the skip, increments a new hydrate-skip counter (surfaced in the
+  result message), and continues to the next book — a hydrate error never wedges the run. The
+  author-resolve site skips both the Book row and the `book_authors` join on hydrate error, so the
+  book stays consistently attributed to the production company rather than half-applied.
+- **Regression test** (`internal/server/entities_ops_hydrate_test.go`, real PebbleStore, `-race`):
+  a fully-populated book run through each write path keeps Title/FilePath/AuthorID (or Publisher)/
+  ratings/ISBN/etc. intact and the `book:path:` index still resolves; a missing-book write returns an
+  error and creates no phantom row. Reverting a call site to the bare literal reintroduces the wipe
+  inside the tested function and fails the test.
 
 #### July 13, 2026 - feat(dedup): keep labeled-example ScoreBreakdown fresh on dismiss/relabel
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 <!-- version: 9.100.0 -->
 <!-- version: 9.99.2 -->
 <!-- version: 9.99.1 -->
+<!-- version: 9.99.2 -->
 <!-- version: 9.99.0 -->
 <!-- version: 9.98.0 -->
 <!-- version: 9.97.0 -->
@@ -298,6 +299,32 @@ Adjacent unguarded paths NOT covered (separate follow-up): `dedup.MergeBooks`
   `saveBookToDatabase` + `PebbleStore.UpdateBook` round-trip and asserts 20 previously-wiped fields
   survive a rescan; proven to FAIL against the old write path. `-race` clean; full scanner package
   green. CHANGELOG + July monthly executive summary (§4 data-integrity) updated.
+## ✅ RESOLVED — entities.resolve-production-author empty-literal UpdateBook wiped the WHOLE book record (2026-07-13)
+
+- **Root cause, exact locations:** `internal/server/entities_ops.go` — the
+  `entities.resolve-production-author` op had **two** write sites passing a near-empty
+  `database.Book{}` literal to the full-replace `UpdateBook`:
+  - publisher-reclassify branch: `UpdateBook(book.ID, &database.Book{Publisher: &pub})` (kept only Publisher);
+  - AI-cover author-resolve branch: `UpdateBook(book.ID, &database.Book{AuthorID: &aid})` (kept only AuthorID).
+  `book` came from `GetBooksByAuthorIDWithRoleCore` (a `BookCore` projection) but the writes ignored
+  it. Because `UpdateBook`'s STOR-1 preserve-on-nil guard only restores 7 heavy
+  `Description`/`BookSig*` fields, every other stored field — `Title`, `FilePath` (which also
+  **corrupts the `book:path:` index**), `SeriesID`, `Author`/`Series`, `Narrator`, `Genre`,
+  `ISBN`/`ASIN`, all ratings, media-info, transcription, metadata-review state — was permanently
+  wiped for every processed book. Same footgun family as W5d-1 (below) and the deluge
+  fingerprint-wipe.
+- **Fix (2026-07-13):** both sites hydrate the full current row via `GetBookByID` immediately before
+  the write and mutate ONLY the intended field (STOREFID W5d-1 idiom, PR #1888). Write logic
+  extracted into `assignPublisherPreservingRecord` / `assignResolvedAuthorPreservingRecord` so the
+  regression test binds to the real write path. **Fail-CLOSED** here (unlike W5d-1's fail-OPEN): on a
+  hydrate error nothing is written — a skipped publisher/author tag beats a wiped record — the op
+  logs the skip, bumps a new hydrate-skip counter (surfaced in the result message), and continues to
+  the next book. Only these two sites had the empty-literal footgun; the author-merge op in the same
+  file already hydrates via `GetBookByID` before its `UpdateBook`.
+- **Verified:** `internal/server/entities_ops_hydrate_test.go` (real `PebbleStore`, `-race`) — a
+  fully-populated book run through each path keeps every previously-wiped field and the `book:path:`
+  index intact; a missing-book write returns an error and writes no phantom row. `go build ./...`,
+  `go vet`, `gofmt -l` clean.
 
 ## ✅ RESOLVED — CreateOrganizedVersion original-book slim-writeback wiped Author/Series (STOREFID W5d-1, 2026-07-07; CONFIRMED 2026-07-11 by #1887; FIXED 2026-07-11)
 

--- a/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-04-monthly-roundup-executive-summary.md
@@ -277,6 +277,21 @@ present) — so nothing outside the scanner's remit can be lost, and any
 field added in the future is preserved automatically rather than having to
 be remembered. A regression test proves twenty previously-wiped fields now
 survive a rescan.
+**A worse variant of the same bug, caught and fixed (2026-07-13):** the
+"resolve production author" tool — which tries to find a real author for
+books credited only to a production company — had two save steps that were
+even more destructive than dropping a field or two. Each one saved the book
+back to the database carrying *only* the single value it had just worked out
+(the publisher in one step, the author in the other) and nothing else. Because
+the save is a full overwrite, that erased everything else on the record — the
+title, the file location, the series, narrator, genre, ISBN, every rating,
+and more — for every book the tool touched. Blanking the file location also
+broke the internal index the app uses to find a book by its path. The fix is
+the same principle as above: before writing, the tool now loads the book's
+complete current record, changes only the one intended value, and saves that
+whole record back. And it now fails safe — if it can't load the current
+record first, it skips that book's update entirely rather than risk wiping it,
+logs the skip, and moves on.
 
 ### 5. Whisper transcription pipeline and GPU infrastructure
 

--- a/internal/server/entities_ops.go
+++ b/internal/server/entities_ops.go
@@ -1,6 +1,7 @@
 // file: internal/server/entities_ops.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3f7e2a91-b4c6-4d85-9e13-7a2f10c84d32
+// last-edited: 2026-07-13
 
 // entities_ops registers the UOS-02 OperationDefs for author entity
 // operations: author-merge and resolve-production-author. Each def is
@@ -225,6 +226,7 @@ func (s *Server) RegisterResolveProductionAuthorOp(reg *opsregistry.Registry) er
 
 			resolved := 0
 			failed := 0
+			hydrateSkipped := 0
 			for i, book := range books {
 				if ctx.Err() != nil {
 					return ctx.Err()
@@ -238,11 +240,15 @@ func (s *Server) RegisterResolveProductionAuthorOp(reg *opsregistry.Registry) er
 					newAuthor, _ := store.GetAuthorByID(*resp.Book.AuthorID)
 					if newAuthor != nil && !dedup.IsProductionCompany(newAuthor.Name) {
 						_ = progress.Log("info", fmt.Sprintf("Resolved %q → author %q (source: %s)", book.Title, newAuthor.Name, resp.Source), nil)
-						// Reclassify production company as publisher
+						// Reclassify production company as publisher. Hydrate the
+						// full stored row before the write (see
+						// assignPublisherPreservingRecord) so the full-replace
+						// UpdateBook cannot wipe Title/FilePath/ratings/etc.
 						if book.Publisher == nil || *book.Publisher == "" {
-							pub := prodAuthorName
-							book.Publisher = &pub
-							store.UpdateBook(book.ID, &database.Book{Publisher: &pub})
+							if err := assignPublisherPreservingRecord(store, book.ID, prodAuthorName); err != nil {
+								_ = progress.Log("warn", fmt.Sprintf("Skipped publisher reclassify for %q (hydrate failed, record left intact): %v", book.Title, err), nil)
+								hydrateSkipped++
+							}
 						}
 						resolved++
 						continue
@@ -263,24 +269,20 @@ func (s *Server) RegisterResolveProductionAuthorOp(reg *opsregistry.Registry) er
 								existing, _ = store.CreateAuthor(parsed.Author)
 							}
 							if existing != nil {
-								aid := existing.ID
-								book.AuthorID = &aid
-								store.UpdateBook(book.ID, &database.Book{AuthorID: &aid})
-								// Update book_authors
-								bookAuthors, _ := store.GetBookAuthors(book.ID)
-								var updated []database.BookAuthor
-								for _, ba := range bookAuthors {
-									if ba.AuthorID != authorID {
-										updated = append(updated, ba)
-									}
+								// Assign the discovered author. Hydrate the full
+								// stored row before the AuthorID write (see
+								// assignResolvedAuthorPreservingRecord) so the
+								// full-replace UpdateBook cannot wipe the record.
+								// Fail-closed: on hydrate error nothing is written
+								// (neither the Book row nor the join), leaving the
+								// book consistently attributed to the production
+								// company rather than half-resolved or wiped.
+								if err := assignResolvedAuthorPreservingRecord(store, book.ID, existing.ID, authorID); err != nil {
+									_ = progress.Log("warn", fmt.Sprintf("Skipped author resolve for %q (hydrate failed, record left intact): %v", book.Title, err), nil)
+									hydrateSkipped++
+									failed++
+									continue
 								}
-								updated = append(updated, database.BookAuthor{
-									BookID:   book.ID,
-									AuthorID: existing.ID,
-									Role:     "author",
-									Position: 0,
-								})
-								store.SetBookAuthors(book.ID, updated)
 								resolved++
 								continue
 							}
@@ -297,12 +299,89 @@ func (s *Server) RegisterResolveProductionAuthorOp(reg *opsregistry.Registry) er
 			}
 			s.authorsCache.InvalidateAll()
 
-			resultMsg := fmt.Sprintf("Resolved %d/%d books for %q (%d unresolved)", resolved, len(books), prodAuthorName, failed)
+			resultMsg := fmt.Sprintf("Resolved %d/%d books for %q (%d unresolved, %d skipped on hydrate error)", resolved, len(books), prodAuthorName, failed, hydrateSkipped)
 			_ = progress.Log("info", resultMsg, nil)
 			_ = progress.UpdateProgress(len(books), len(books), resultMsg)
 			return nil
 		},
 	})
+}
+
+// assignPublisherPreservingRecord reclassifies a production company as the
+// book's Publisher WITHOUT wiping the rest of the stored record.
+//
+// database.Store.UpdateBook is a FULL-REPLACE write: it marshals the whole Book
+// passed to it (only seven heavy Description/BookSig* fields are restored from
+// the old row). Passing a near-empty literal such as &database.Book{Publisher:…}
+// therefore wipes Title, FilePath (which also corrupts the book:path: index),
+// AuthorID, ratings, media-info, and everything else. This helper instead
+// hydrates the current full row via GetBookByID and mutates only Publisher, so
+// every other field survives the write.
+//
+// Fail-closed: if hydration fails it returns the error and writes NOTHING. A
+// skipped publisher tag is far better than a wiped record; the caller counts the
+// skip and moves on to the next book.
+func assignPublisherPreservingRecord(store database.Store, bookID, publisher string) error {
+	full, err := store.GetBookByID(bookID)
+	if err != nil {
+		return fmt.Errorf("hydrate book %s before publisher write: %w", bookID, err)
+	}
+	if full == nil {
+		return fmt.Errorf("hydrate book %s before publisher write: not found", bookID)
+	}
+	pub := publisher
+	full.Publisher = &pub
+	if _, err := store.UpdateBook(bookID, full); err != nil {
+		return fmt.Errorf("update book %s publisher: %w", bookID, err)
+	}
+	return nil
+}
+
+// assignResolvedAuthorPreservingRecord points a book at a newly discovered
+// author: it sets the denormalized Book.AuthorID and rewrites the book_authors
+// join to drop the production-company author and add the resolved one — WITHOUT
+// wiping the rest of the stored record (see assignPublisherPreservingRecord for
+// why a bare UpdateBook literal is catastrophic).
+//
+// Fail-closed: if hydration fails it returns the error before touching anything,
+// so neither the Book row nor the join is written and the book stays consistently
+// attributed to the production company (unresolved) rather than half-applied or
+// wiped. The join rewrite itself is best-effort: an error there is logged by the
+// caller path but does not roll back the AuthorID write (matching prior behavior).
+func assignResolvedAuthorPreservingRecord(store database.Store, bookID string, resolvedAuthorID, prodAuthorID int) error {
+	full, err := store.GetBookByID(bookID)
+	if err != nil {
+		return fmt.Errorf("hydrate book %s before author write: %w", bookID, err)
+	}
+	if full == nil {
+		return fmt.Errorf("hydrate book %s before author write: not found", bookID)
+	}
+	aid := resolvedAuthorID
+	full.AuthorID = &aid
+	if _, err := store.UpdateBook(bookID, full); err != nil {
+		return fmt.Errorf("update book %s author: %w", bookID, err)
+	}
+
+	// Rewrite the book_authors join: drop the production-company author, add the
+	// resolved author. Best-effort, as before — a failure here is logged but does
+	// not fail the resolution (the denormalized AuthorID already points correctly).
+	bookAuthors, _ := store.GetBookAuthors(bookID)
+	var updated []database.BookAuthor
+	for _, ba := range bookAuthors {
+		if ba.AuthorID != prodAuthorID {
+			updated = append(updated, ba)
+		}
+	}
+	updated = append(updated, database.BookAuthor{
+		BookID:   bookID,
+		AuthorID: resolvedAuthorID,
+		Role:     "author",
+		Position: 0,
+	})
+	if err := store.SetBookAuthors(bookID, updated); err != nil {
+		slog.Warn("resolve-production-author: failed to rewrite book_authors join", "book", bookID, "err", err)
+	}
+	return nil
 }
 
 func init() {

--- a/internal/server/entities_ops_hydrate_test.go
+++ b/internal/server/entities_ops_hydrate_test.go
@@ -1,0 +1,184 @@
+// file: internal/server/entities_ops_hydrate_test.go
+// version: 1.0.0
+// guid: b9d41f27-8e6a-4c02-9f5b-2a7c14e630d8
+// last-edited: 2026-07-13
+
+package server
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fullyPopulatedBook builds a Book with every field the resolve-production-author
+// write path would otherwise wipe set to a non-zero value, so a regression can be
+// detected as any of them reverting to its zero value.
+func fullyPopulatedBook(t *testing.T, store *database.PebbleStore) *database.Book {
+	t.Helper()
+	sp := func(s string) *string { return &s }
+	ip := func(i int) *int { return &i }
+	fp := func(f float64) *float64 { return &f }
+
+	authorID := 42
+	seriesID := 7
+	book := &database.Book{
+		Title:                "The Well-Populated Book",
+		AuthorID:             ip(authorID),
+		SeriesID:             ip(seriesID),
+		FilePath:             "/library/audiobooks/well-populated-book.m4b",
+		Narrator:             sp("Jane Reader"),
+		Genre:                sp("Science Fiction"),
+		Publisher:            nil, // intentionally empty so the reclassify branch fires
+		ISBN10:               sp("0123456789"),
+		ISBN13:               sp("9780123456789"),
+		ASIN:                 sp("B0000000AB"),
+		Description:          sp("A long description that lives only in the full Pebble row."),
+		ITunesRating:         ip(80),
+		AudibleRatingOverall: fp(4.7),
+		AudibleRatingCount:   ip(1234),
+		GoogleRatingAverage:  fp(4.2),
+	}
+	created, err := store.CreateBook(book)
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	return created
+}
+
+// assertRecordIntact verifies every field that the full-replace UpdateBook wipe
+// would have destroyed is still present on the stored row.
+func assertRecordIntact(t *testing.T, store *database.PebbleStore, id string) *database.Book {
+	t.Helper()
+	got, err := store.GetBookByID(id)
+	if err != nil {
+		t.Fatalf("GetBookByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("book vanished from store after write")
+	}
+	if got.Title != "The Well-Populated Book" {
+		t.Errorf("Title wiped: got %q", got.Title)
+	}
+	if got.FilePath != "/library/audiobooks/well-populated-book.m4b" {
+		t.Errorf("FilePath wiped: got %q", got.FilePath)
+	}
+	if got.SeriesID == nil || *got.SeriesID != 7 {
+		t.Errorf("SeriesID wiped: got %v", got.SeriesID)
+	}
+	if got.Narrator == nil || *got.Narrator != "Jane Reader" {
+		t.Errorf("Narrator wiped: got %v", got.Narrator)
+	}
+	if got.Genre == nil || *got.Genre != "Science Fiction" {
+		t.Errorf("Genre wiped: got %v", got.Genre)
+	}
+	if got.ISBN13 == nil || *got.ISBN13 != "9780123456789" {
+		t.Errorf("ISBN13 wiped: got %v", got.ISBN13)
+	}
+	if got.ASIN == nil || *got.ASIN != "B0000000AB" {
+		t.Errorf("ASIN wiped: got %v", got.ASIN)
+	}
+	if got.Description == nil || *got.Description == "" {
+		t.Errorf("Description wiped: got %v", got.Description)
+	}
+	if got.ITunesRating == nil || *got.ITunesRating != 80 {
+		t.Errorf("ITunesRating wiped: got %v", got.ITunesRating)
+	}
+	if got.AudibleRatingOverall == nil || *got.AudibleRatingOverall != 4.7 {
+		t.Errorf("AudibleRatingOverall wiped: got %v", got.AudibleRatingOverall)
+	}
+	if got.GoogleRatingAverage == nil || *got.GoogleRatingAverage != 4.2 {
+		t.Errorf("GoogleRatingAverage wiped: got %v", got.GoogleRatingAverage)
+	}
+	return got
+}
+
+// TestAssignPublisherPreservingRecord proves the publisher-reclassify write path
+// (resolve-production-author site #1) sets ONLY Publisher and leaves every other
+// field — and the book:path: index — intact. This is the load-bearing regression
+// for the full-record wipe: reverting the call site to a bare UpdateBook literal
+// reintroduces the wipe inside the tested function and fails this test.
+func TestAssignPublisherPreservingRecord(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	book := fullyPopulatedBook(t, store)
+
+	if err := assignPublisherPreservingRecord(store, book.ID, "SomeProduction LLC"); err != nil {
+		t.Fatalf("assignPublisherPreservingRecord: %v", err)
+	}
+
+	got := assertRecordIntact(t, store, book.ID)
+	if got.Publisher == nil || *got.Publisher != "SomeProduction LLC" {
+		t.Errorf("Publisher not set: got %v", got.Publisher)
+	}
+	// AuthorID must survive the publisher write (only Publisher was intended).
+	if got.AuthorID == nil || *got.AuthorID != 42 {
+		t.Errorf("AuthorID wiped by publisher write: got %v", got.AuthorID)
+	}
+	// The book:path: index must still resolve — the wipe would have blanked
+	// FilePath and deleted/corrupted this index key.
+	byPath, err := store.GetBookByFilePath(book.FilePath)
+	if err != nil {
+		t.Fatalf("GetBookByFilePath: %v", err)
+	}
+	if byPath == nil || byPath.ID != book.ID {
+		t.Errorf("book:path: index corrupted: got %v", byPath)
+	}
+}
+
+// TestAssignResolvedAuthorPreservingRecord proves the AI-cover author-resolve
+// write path (resolve-production-author site #2) sets ONLY AuthorID (plus the
+// book_authors join) and leaves every other field intact.
+func TestAssignResolvedAuthorPreservingRecord(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	book := fullyPopulatedBook(t, store)
+	const prodAuthorID = 42
+	const resolvedAuthorID = 99
+
+	if err := assignResolvedAuthorPreservingRecord(store, book.ID, resolvedAuthorID, prodAuthorID); err != nil {
+		t.Fatalf("assignResolvedAuthorPreservingRecord: %v", err)
+	}
+
+	got := assertRecordIntact(t, store, book.ID)
+	if got.AuthorID == nil || *got.AuthorID != resolvedAuthorID {
+		t.Errorf("AuthorID not set to resolved author: got %v", got.AuthorID)
+	}
+	byPath, err := store.GetBookByFilePath(book.FilePath)
+	if err != nil {
+		t.Fatalf("GetBookByFilePath: %v", err)
+	}
+	if byPath == nil || byPath.ID != book.ID {
+		t.Errorf("book:path: index corrupted: got %v", byPath)
+	}
+}
+
+// TestAssignPreservingRecord_FailClosedOnMissing proves that when hydration finds
+// no row, NOTHING is written — the helper returns an error and does not create or
+// mutate any record (fail-closed).
+func TestAssignPreservingRecord_FailClosedOnMissing(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if err := assignPublisherPreservingRecord(store, "does-not-exist", "X"); err == nil {
+		t.Error("assignPublisherPreservingRecord: expected error on missing book, got nil")
+	}
+	if err := assignResolvedAuthorPreservingRecord(store, "does-not-exist", 1, 2); err == nil {
+		t.Error("assignResolvedAuthorPreservingRecord: expected error on missing book, got nil")
+	}
+	// No phantom row should have been created by the failed writes.
+	if got, _ := store.GetBookByID("does-not-exist"); got != nil {
+		t.Errorf("fail-closed violated: a row was written for a missing book: %v", got)
+	}
+}


### PR DESCRIPTION
## The catastrophic wipe (two live data-loss scenarios)

The `entities.resolve-production-author` op (`internal/server/entities_ops.go`) had **two** write sites that passed a near-empty `database.Book{}` literal to the **full-replace** `UpdateBook`, wiping the ENTIRE stored Pebble record for every book the op processed:

1. **Publisher-reclassify branch** (~L245): `store.UpdateBook(book.ID, &database.Book{Publisher: &pub})` — `book` came from `GetBooksByAuthorIDWithRoleCore` (a `BookCore` projection) but the write ignored it and passed a literal holding **only** Publisher. Result: `Title`→"", `FilePath`→"" (which also **corrupts the `book:path:` index**), `AuthorID`, `SeriesID`, `Author`/`Series`, `Narrator`, `Genre`, `ISBN`/`ASIN`, all ratings, media-info, transcription, metadata-review state — all wiped.
2. **AI-cover author-resolve branch** (~L268): `store.UpdateBook(book.ID, &database.Book{AuthorID: &aid})` — same op, same total wipe (only `AuthorID` survived).

`UpdateBook`'s STOR-1 preserve-on-nil guard only restores 7 heavy `Description`/`BookSig*` fields; everything else was gone permanently.

## The fix — hydrate then mutate

Both sites now hydrate the full current row via `GetBookByID` immediately before the write and mutate **only** the intended field, then write the full row back — the STOREFID W5d-1 idiom (PR #1888). The write logic is extracted into `assignPublisherPreservingRecord` / `assignResolvedAuthorPreservingRecord` so the regression test binds to the **real** write path (reverting a call site to the bare literal reintroduces the wipe inside the tested function and fails the test).

### Fail-closed choice
Unlike W5d-1 (which fails **open** because its state transition must always land), this op fails **closed**: if `GetBookByID` fails, **nothing** is written — a skipped publisher/author tag is far better than a wiped record. The op logs the skip, increments a new hydrate-skip counter (surfaced in the result message), and continues to the next book, so a hydrate error never wedges the run. The author-resolve site skips both the Book row and the `book_authors` join on hydrate error, leaving the book consistently attributed to the production company rather than half-applied.

**Only these two sites** had the empty-literal footgun in this file — the `author-merge` op already hydrates via `GetBookByID` before its `UpdateBook`.

## Test results
`internal/server/entities_ops_hydrate_test.go` (real `PebbleStore`, `-race`):
- Fully-populated book → each write path → asserts `Title`, `FilePath`, `AuthorID`/`Publisher`, `SeriesID`, `Narrator`, `Genre`, `ISBN13`, `ASIN`, `Description`, and all ratings **survive**, and the `book:path:` index still resolves.
- Missing-book write returns an error and creates **no** phantom row (fail-closed).

```
--- PASS: TestAssignPublisherPreservingRecord (0.17s)
--- PASS: TestAssignResolvedAuthorPreservingRecord (0.19s)
--- PASS: TestAssignPreservingRecord_FailClosedOnMissing (0.15s)
```

`go build ./...` (exit 0), `go vet`, `gofmt -l` clean. Entities/author test subset green under `-race` (67.9s). The full `internal/server` package exceeds the go-test 600s timeout under both `-race` and no-race — a pre-existing environmental limit from the package's size, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv