### PR TITLE
fix(database): preserve Author/Series in UpdateBook + hydrate author-split write-backs (data-loss)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,30 @@
   ratings/ISBN/etc. intact and the `book:path:` index still resolves; a missing-book write returns an
   error and creates no phantom row. Reverting a call site to the bare literal reintroduces the wipe
   inside the tested function and fails the test.
+#### July 13, 2026 - fix(database): preserve Author/Series in UpdateBook + hydrate author-split write-backs (data-loss)
+
+- **`database`** — **prod data-loss fix.** `PebbleStore.UpdateBook`'s preserve-on-nil guard restored
+  seven memdb-stripped heavy fields (Description/VersionNotes/BookSig*) but OMITTED the denormalized
+  `Author`/`Series`. Those fields carry `json:",omitempty"` and Pebble persists them (`db:"-"` only
+  suppresses SQLite), so any write sourced from a `BookCore`→`ToBook()` or memdb projection (both nil
+  Author/Series) silently erased them from the stored Pebble row. Added Author/Series to the guard,
+  mirroring the existing seven-field pattern. They are recomputed display objects, never user-cleared
+  to nil (no empty-string-style sentinel; verified 0 of 135 `UpdateBook` call sites intentionally
+  nil-clear them), so preserve-on-nil is the correct semantics — the same class as the CreateOrganizedVersion
+  fix (STOREFID W5d-1 / #1887).
+- **`maintenance` / `scheduler`** — the two duplicate composite-author-split ops wrote a
+  heavy-field-nil `ToBook()` projection AND changed the book's `AuthorID`, so a merely-preserved
+  Author would have been *stale* (naming the old composite). Both now hydrate the full row via
+  `GetBookByID` and write it with BOTH the new `AuthorID` and a fresh denormalized `Author`
+  (`Author.ID == AuthorID`), not preserved-stale. On hydrate failure they fall back to the projection
+  write so the AuthorID change still lands (guard preserves the rest). Deleted the false inline
+  comments that claimed the guard restored Author/Series.
+- **`organizer`** — `MoveBookFile`'s bare `{FilePath}` write (dead/latent — no live caller today)
+  would total-wipe the row under the full-fidelity backend; it now hydrates before setting FilePath.
+- Regression tests: a nil-Author/Series `UpdateBook` over a populated row keeps both (real
+  `PebbleStore`); the author-split op leaves `Author.ID == AuthorID` and preserves Series after an
+  AuthorID change (`TestAuthorSplit_WritesFreshAuthorNotStaleOrNil`). Targeted packages green under
+  `-race`; `go vet` + `gofmt` clean.
 
 #### July 13, 2026 - feat(dedup): keep labeled-example ScoreBreakdown fresh on dismiss/relabel
 

--- a/TODO.md
+++ b/TODO.md
@@ -359,6 +359,32 @@ Adjacent unguarded paths NOT covered (separate follow-up): `dedup.MergeBooks`
   confirmed, so an issue would have been opened and closed in the same breath; this TODO entry
   plus the PR that landed the fix are the durable record.
 
+## ✅ RESOLVED — root-cause guard + remaining Author/Series wipe call sites (follow-on to W5d-1, 2026-07-13)
+
+- The #1887/98c2a218 fix patched only the `CreateOrganizedVersion` call site; the **root-cause
+  gap in `PebbleStore.UpdateBook`'s preserve-on-nil guard** (no Author/Series case) and two other
+  slim-projection call sites remained. All fixed this session on sign-off:
+  - **Fix 1 (root, `internal/database/pebble_store.go`):** added `Author`/`Series` to the
+    preserve-on-nil guard, mirroring the seven-field pattern. A backstop for the whole
+    Core-projection write class. Justification for preserve-on-nil: Author/Series are denormalized
+    display objects derived from AuthorID/SeriesID, recomputed on read, never user-cleared to nil
+    (pointer structs, no empty-string sentinel) — verified 0 of 135 `UpdateBook` call sites
+    intentionally nil-clear them.
+  - **Fix 2 (`internal/plugins/maintenance/author.go`, `internal/scheduler/extra_ops.go`):** the
+    two duplicate composite-author-split ops wrote `book.ToBook()` (nil Author/Series) AND changed
+    `AuthorID`, so a merely-preserved Author would be *stale* (old composite). Both now hydrate via
+    `GetBookByID` and write the full row with the new `AuthorID` + a fresh `Author`
+    (`Author.ID == AuthorID`); on hydrate failure they fall back to the projection write (guard
+    preserves the rest) so the AuthorID change still lands. False "guard restores Author/Series"
+    comments deleted.
+  - **Fix 3 (`internal/organizer/move.go`):** `MoveBookFile`'s bare `{FilePath}` write (dead/latent,
+    no live caller) hydrates before the write; falls back to bare write on hydrate failure.
+- **Verified:** new `TestUpdateBook_PreservesAuthorSeriesOnNilIncoming` (real `PebbleStore`) and
+  `TestAuthorSplit_WritesFreshAuthorNotStaleOrNil` (op leaves `Author.ID == AuthorID`, Series
+  preserved) pass; `MoveBookFile` tests updated for the hydrate call; `internal/database`,
+  `internal/plugins/maintenance`, `internal/scheduler`, `internal/organizer` green under `-race`;
+  `go build ./...`, `go vet`, `gofmt -l` clean.
+
 ## ✅ PR-D: deluge import fingerprint-wipe (3 impls) — RESOLVED (STOREFID W6, 2026-07-07)
 
 - **Fixed as a side effect of STOREFID W6's `GetBookFilesNeedingDelugeImport` → Core retype**:

--- a/docs/executive-summaries/2026-07-13-author-series-data-loss-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-author-series-data-loss-executive-summary.md
@@ -1,0 +1,71 @@
+<!-- file: docs/executive-summaries/2026-07-13-author-series-data-loss-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7d2a9f31-6c48-4b0e-9a15-3e8b7c0f4d62 -->
+<!-- last-edited: 2026-07-13 -->
+
+# Executive Summary: Stopping Silent Author and Series Loss on Book Edits
+
+**Shipped:** follow-on to the July 11 organizer fix
+([#1887](https://github.com/falkcorp/audiobook-organizer/pull/1887) confirmed it,
+commit 98c2a218 patched the first spot). This change closes the underlying gap
+and the remaining places it could bite.
+
+## Executive Summary
+
+Some routine background operations could quietly erase a book's **Author** and
+**Series** from the saved record. Nothing was shown to be wrong at the time —
+the information just disappeared from storage on the next save.
+
+We found the single root cause behind it, fixed it in one central place so it
+can't recur across the whole class of operations, and then fixed the two
+remaining operations that were still tripping over it. We also fixed one more
+spot that wasn't in use yet but would have caused the same loss the moment it
+was turned on.
+
+## What was wrong, in plain terms
+
+When the app saves a book, it saves the full record. But several operations save
+a **lightweight copy** of a book that deliberately leaves out heavy fields to
+run fast. The save routine already knew to protect most of those heavy fields —
+if the lightweight copy left them blank, it kept the previously-stored values
+instead of wiping them.
+
+Author and Series were missing from that protected list. So any operation that
+saved a lightweight copy — for example, the maintenance job that splits a
+combined "Author A & Author B" entry into two separate authors — would blank out
+the stored Author and Series on that book.
+
+The author-splitting job had an extra wrinkle: it was also *changing* the
+author, so simply keeping the old value would have left the book labeled with the
+now-wrong combined author.
+
+## What we changed
+
+1. **Fixed the root cause once, centrally.** The save routine now protects Author
+   and Series the same way it already protects the other heavy fields: if a save
+   comes in without them, it keeps what was already stored rather than erasing it.
+   This is a backstop for every operation of this kind, not just the ones we knew
+   about. Author and Series are always re-derived from the book's author and
+   series IDs, so keeping them is always the right call — no operation ever
+   legitimately clears them.
+
+2. **Fixed the two author-splitting jobs properly.** Instead of saving a
+   lightweight copy, they now load the full stored record, set both the new author
+   *and* a correct, fresh author label, and save that — so the book ends up
+   correctly labeled, not just un-erased. If loading the full record ever fails,
+   they still complete the author change rather than skipping it.
+
+3. **Fixed a not-yet-used file-move step** that would have wiped the whole record
+   the moment it was wired up.
+
+## Why it matters
+
+Author and Series are core to how a library is organized and browsed. Losing them
+silently means books drift out of their series and away from their authors with
+no error and no obvious cause — the kind of corruption that is hard to notice and
+harder to trace back. This change stops it at the source and repairs every path
+that could trigger it, with regression tests that reproduce the loss and prove it
+no longer happens against the real production-style database.
+
+Every existing author and series decision is preserved; the fix only ever keeps
+or correctly refreshes this data, and it can be rolled back as a single change.

--- a/internal/database/pebble_book_preserve_test.go
+++ b/internal/database/pebble_book_preserve_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_book_preserve_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9a2f1c6e-4d3b-4a71-8e2c-6b7d8f9012ab
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package database
 
@@ -139,5 +139,76 @@ func TestUpdateBook_ExplicitClearStillOverwrites(t *testing.T) {
 	}
 	if *got.Description != "" {
 		t.Errorf("Description not cleared: got %q, want empty string", *got.Description)
+	}
+}
+
+// UpdateBook must NOT wipe the denormalized Author/Series when the incoming
+// row leaves them nil (STOREFID W5d-1 / #1887). Author/Series carry
+// json:",omitempty" and Pebble persists them (db:"-" only suppresses SQLite),
+// so a BookCore->ToBook or memdb-projection write-back with them nil erased
+// them from the stored Pebble row before this guard existed. They are
+// recomputed display objects, never user-cleared to nil, so preserve-on-nil is
+// correct — the same class of fix as the seven memdb-stripped fields above.
+func TestUpdateBook_PreservesAuthorSeriesOnNilIncoming(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	book, err := s.CreateBook(&Book{Title: "Denorm Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	authorID := 42
+	seriesID := 7
+	author := &Author{ID: authorID, Name: "Ursula K. Le Guin"}
+	series := &Series{ID: seriesID, Name: "Earthsea"}
+
+	// Seed the denormalized Author/Series (plus the identity IDs) via a full
+	// write, as a hydrated caller would.
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:       book.ID,
+		Title:    book.Title,
+		AuthorID: &authorID,
+		SeriesID: &seriesID,
+		Author:   author,
+		Series:   series,
+	}); err != nil {
+		t.Fatalf("UpdateBook (seed): %v", err)
+	}
+
+	// Simulate a BookCore->ToBook / memdb-projection round trip: incoming
+	// *Book has nil Author/Series (as ToBook leaves them) but changes an
+	// unrelated field.
+	newTitle := "Denorm Book Renamed"
+	if _, err := s.UpdateBook(book.ID, &Book{
+		ID:       book.ID,
+		Title:    newTitle,
+		AuthorID: &authorID,
+		SeriesID: &seriesID,
+	}); err != nil {
+		t.Fatalf("UpdateBook (projection round trip): %v", err)
+	}
+
+	got, err := s.GetBookByID(book.ID) // pebble-direct → the stored row
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID: err=%v got=%v", err, got)
+	}
+	if got.Title != newTitle {
+		t.Errorf("Title not updated: got %q, want %q", got.Title, newTitle)
+	}
+	if got.Author == nil {
+		t.Fatal("Author WIPED: got nil, want preserved denormalized author")
+	}
+	if got.Author.ID != authorID || got.Author.Name != author.Name {
+		t.Errorf("Author corrupted: got %+v, want %+v", got.Author, author)
+	}
+	if got.Series == nil {
+		t.Fatal("Series WIPED: got nil, want preserved denormalized series")
+	}
+	if got.Series.ID != seriesID || got.Series.Name != series.Name {
+		t.Errorf("Series corrupted: got %+v, want %+v", got.Series, series)
 	}
 }

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.113.1
+// version: 1.114.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
 package database
 
@@ -1797,11 +1797,13 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 
 	// Preserve fields stripped by stripBookForMemdb (STOR-1). Callers that
 	// sourced `book` from the memdb projection (GetAllBooks on the production
-	// UseMemDB path) carry nil Description/VersionNotes/BookSig* even though
-	// the stored row has real values. Restoring from oldBook — already fetched
-	// above via the Pebble-direct GetBookByID — costs zero extra reads.
-	// Mirrors the UpsertBookFile/BatchUpsertBookFiles fingerprint-preserve
-	// guard (PERF-7) — keep both in sync.
+	// UseMemDB path) or from a BookCore->ToBook projection carry nil
+	// Description/VersionNotes/BookSig*/Author/Series even though the stored
+	// row has real values. Restoring from oldBook — already fetched above via
+	// the Pebble-direct GetBookByID — costs zero extra reads. Mirrors the
+	// UpsertBookFile/BatchUpsertBookFiles fingerprint-preserve guard (PERF-7)
+	// — keep both in sync. stripBookForMemdb nils exactly these nine fields,
+	// so the guard restores exactly them.
 	if book.Description == nil {
 		book.Description = oldBook.Description
 	}
@@ -1822,6 +1824,21 @@ func (p *PebbleStore) UpdateBook(id string, book *Book) (*Book, error) {
 	}
 	if book.BookSigCoveragePct == nil {
 		book.BookSigCoveragePct = oldBook.BookSigCoveragePct
+	}
+	// Author/Series are denormalized display objects derived from
+	// AuthorID/SeriesID; they are recomputed on read, never user-cleared to
+	// nil (no empty-string-style sentinel exists for these pointer structs),
+	// so preserve-on-nil is correct — the same class of fix as the seven
+	// fields above (STOREFID W5d-1 / #1887; the CreateOrganizedVersion write
+	// wiped these before the call-site hydrate landed). A write that
+	// legitimately changes the author must set BOTH AuthorID and a fresh
+	// Author object (see the author-split ops); this guard only stops the
+	// nil-projection wipe, it does not re-derive.
+	if book.Author == nil {
+		book.Author = oldBook.Author
+	}
+	if book.Series == nil {
+		book.Series = oldBook.Series
 	}
 
 	data, err := json.Marshal(book)

--- a/internal/organizer/move.go
+++ b/internal/organizer/move.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/move.go
-// version: 1.0.1
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-13
 
 package organizer
 
@@ -55,14 +56,30 @@ func MoveBookFile(store database.Store, bookID, oldPath, newPath string, extraUp
 		return fmt.Errorf("failed to move file %s → %s: %w", oldPath, newPath, err)
 	}
 
-	// Step 5: Update database
-	update := &database.Book{
-		FilePath: newPath,
-	}
-	if extraUpdates != nil {
-		// Merge extra updates
+	// Step 5: Update database.
+	//
+	// A bare {FilePath} update is a full-replace under the full-fidelity
+	// PebbleStore backend, so writing it directly would total-wipe the row
+	// (Author/Series/Description/... all nil). Hydrate the stored row first and
+	// mutate only FilePath on it. Latent today (no live caller passes
+	// extraUpdates==nil through this path), but fixed before it is wired.
+	// If a caller supplied extraUpdates, honor those as-is; on hydrate failure
+	// fall back to the bare write so the path change still lands.
+	var update *database.Book
+	switch {
+	case extraUpdates != nil:
 		update = extraUpdates
 		update.FilePath = newPath
+	default:
+		if full, err := store.GetBookByID(bookID); err == nil && full != nil {
+			full.FilePath = newPath
+			update = full
+		} else {
+			if err != nil {
+				slog.Warn("file_move: hydrate failed, writing bare FilePath update", "bookID", bookID, "err", err)
+			}
+			update = &database.Book{FilePath: newPath}
+		}
 	}
 
 	if _, err := store.UpdateBook(bookID, update); err != nil {

--- a/internal/organizer/unit_test.go
+++ b/internal/organizer/unit_test.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/unit_test.go
-// version: 1.0.2
+// version: 1.0.3
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
+// last-edited: 2026-07-13
 
 package organizer
 
@@ -954,7 +955,22 @@ func TestMoveBookFile_Success(t *testing.T) {
 	os.WriteFile(src, []byte("content"), 0644)
 
 	mockStore := mocks.NewMockStore(t)
-	mockStore.On("UpdateBook", "book-1", mock.AnythingOfType("*database.Book")).Return(&database.Book{}, nil)
+	// With extraUpdates=nil, MoveBookFile hydrates the full row before the
+	// write so it never total-wipes the record (Author/Series/...). The write
+	// must carry the new FilePath on the hydrated row.
+	mockStore.On("GetBookByID", "book-1").
+		Return(&database.Book{ID: "book-1", Title: "Kept Title"}, nil)
+	mockStore.On("UpdateBook", "book-1", mock.AnythingOfType("*database.Book")).
+		Run(func(args mock.Arguments) {
+			book := args.Get(1).(*database.Book)
+			if book.FilePath != dst {
+				t.Errorf("expected FilePath = %q, got %q", dst, book.FilePath)
+			}
+			if book.Title != "Kept Title" {
+				t.Errorf("hydrated row not written: Title = %q, want %q", book.Title, "Kept Title")
+			}
+		}).
+		Return(&database.Book{}, nil)
 
 	err := MoveBookFile(mockStore, "book-1", src, dst, nil)
 	if err != nil {
@@ -973,6 +989,8 @@ func TestMoveBookFile_DBUpdateFails_Rollback(t *testing.T) {
 	os.WriteFile(src, []byte("content"), 0644)
 
 	mockStore := mocks.NewMockStore(t)
+	mockStore.On("GetBookByID", "book-1").
+		Return(&database.Book{ID: "book-1"}, nil)
 	mockStore.On("UpdateBook", "book-1", mock.AnythingOfType("*database.Book")).Return(nil, fmt.Errorf("db error"))
 
 	err := MoveBookFile(mockStore, "book-1", src, dst, nil)

--- a/internal/plugins/maintenance/author.go
+++ b/internal/plugins/maintenance/author.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/author.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1234-ef01-456789012345
-// last-edited: 2026-07-05
+// last-edited: 2026-07-13
 
 package maintenance
 
@@ -207,14 +207,29 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 			}
 			if book.AuthorID != nil && *book.AuthorID == author.ID && len(newAuthors) > 0 {
 				firstID := newAuthors[0].ID
-				book.AuthorID = &firstID
-				// book is BookCore (heavy fields nil) — bridge via .ToBook()
-				// so PebbleStore.UpdateBook sees the expected all-nil heavy
-				// fields and restores them from the stored row (STOR-1 guard
-				// in UpdateBook), rather than a type mismatch or an
-				// accidental heavy-field wipe.
-				full := book.ToBook()
-				_, _ = store.UpdateBook(book.ID, &full)
+				// `book` is a BookCore (heavy fields nil). Do NOT write its
+				// ToBook() projection: that carries nil Author/Series AND,
+				// because this op changes AuthorID, the guard-preserved Author
+				// would be STALE (it still names the composite author). Hydrate
+				// the full stored row and set BOTH the new AuthorID and a fresh
+				// denormalized Author so the row stays consistent
+				// (Author.ID == AuthorID), not preserved-stale (STOREFID
+				// W5d-1 / #1887).
+				if full, err := store.GetBookByID(book.ID); err == nil && full != nil {
+					newPrimary := newAuthors[0]
+					full.AuthorID = &firstID
+					full.Author = &newPrimary
+					_, _ = store.UpdateBook(book.ID, full)
+				} else {
+					// Hydration failed — fall back to the projection write so
+					// the AuthorID change still lands (UpdateBook's guard
+					// preserves the old Author/Series; the denormalized Author
+					// is re-derived from AuthorID on read). Never skip the split.
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("author split: hydrate book %s failed, writing projection: %v", book.ID, err))
+					book.AuthorID = &firstID
+					full := book.ToBook()
+					_, _ = store.UpdateBook(book.ID, &full)
+				}
 			}
 			booksUpdated++
 		}

--- a/internal/plugins/maintenance/author_split_writeback_test.go
+++ b/internal/plugins/maintenance/author_split_writeback_test.go
@@ -1,0 +1,113 @@
+// file: internal/plugins/maintenance/author_split_writeback_test.go
+// version: 1.0.0
+// guid: 4b7e1d92-8c6a-4f3b-9a02-1e5c7d8f0a3b
+// last-edited: 2026-07-13
+
+package maintenance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestAuthorSplit_WritesFreshAuthorNotStaleOrNil proves the composite-author
+// split write-back (STOREFID W5d-1 / #1887) hydrates the full stored row and
+// writes it with BOTH the new AuthorID AND a fresh denormalized Author — never
+// a BookCore->ToBook projection (which carries nil Author/Series) and never the
+// guard-preserved-but-stale composite Author.
+//
+// The op changes the book's primary AuthorID from the composite author to the
+// first split author, so a merely preserved Author would still name the
+// composite (Author.ID != AuthorID). This test fails on both the pre-fix wipe
+// (Author == nil) and on a preserve-only fix (Author.ID stale).
+func TestAuthorSplit_WritesFreshAuthorNotStaleOrNil(t *testing.T) {
+	const (
+		compositeID = 1
+		firstNewID  = 101
+		secondNewID = 102
+		seriesID    = 9
+	)
+
+	// The stored, hydrated row: has a STALE denormalized Author (the composite)
+	// plus a Series and Description that must survive the write.
+	desc := "back-cover blurb"
+	storedBook := database.Book{
+		ID:          "bk1",
+		Title:       "The Left Hand of Darkness",
+		AuthorID:    intPtr(compositeID),
+		SeriesID:    intPtr(seriesID),
+		Author:      &database.Author{ID: compositeID, Name: "Alice Smith / Bob Jones"},
+		Series:      &database.Series{ID: seriesID, Name: "Hainish Cycle"},
+		Description: &desc,
+	}
+
+	createCalls := 0
+	written := make([]database.Book, 0, 1)
+
+	store := &database.MockStore{
+		GetAllAuthorsFunc: func() ([]database.Author, error) {
+			return []database.Author{{ID: compositeID, Name: "Alice Smith / Bob Jones"}}, nil
+		},
+		// Force the create path so newAuthors is populated deterministically.
+		GetAuthorByNameFunc: func(_ string) (*database.Author, error) { return nil, nil },
+		CreateAuthorFunc: func(name string) (*database.Author, error) {
+			createCalls++
+			id := firstNewID
+			if createCalls == 2 {
+				id = secondNewID
+			}
+			return &database.Author{ID: id, Name: name}, nil
+		},
+		GetBooksByAuthorIDWithRoleFunc: func(authorID int) ([]database.BookCore, error) {
+			if authorID != compositeID {
+				return nil, nil
+			}
+			return []database.BookCore{{ID: "bk1", Title: storedBook.Title, AuthorID: intPtr(compositeID)}}, nil
+		},
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			if id == "bk1" {
+				b := storedBook // copy
+				return &b, nil
+			}
+			return nil, nil
+		},
+		UpdateBookFunc: func(_ string, b *database.Book) (*database.Book, error) {
+			written = append(written, *b)
+			return b, nil
+		},
+		DeleteAuthorFunc: func(_ int) error { return nil },
+	}
+
+	p := New(fakeDeps{store: store})
+	if err := p.runAuthorSplitScan(context.Background(), nil, &fakeReporter{}); err != nil {
+		t.Fatalf("runAuthorSplitScan: %v", err)
+	}
+
+	if len(written) != 1 {
+		t.Fatalf("expected exactly 1 UpdateBook write, got %d", len(written))
+	}
+	got := written[0]
+
+	// AuthorID must advance to the first split author.
+	if got.AuthorID == nil || *got.AuthorID != firstNewID {
+		t.Errorf("AuthorID: got %v, want %d", got.AuthorID, firstNewID)
+	}
+	// The denormalized Author must be FRESH (matches new AuthorID), not nil
+	// (pre-fix wipe) and not the stale composite (preserve-only).
+	if got.Author == nil {
+		t.Fatal("Author WIPED: got nil, want fresh denormalized author for the new AuthorID")
+	}
+	if got.Author.ID != firstNewID {
+		t.Errorf("Author STALE: got Author.ID=%d, want %d (must match new AuthorID)", got.Author.ID, firstNewID)
+	}
+	// Series (unchanged by an author split) must survive via hydration.
+	if got.Series == nil || got.Series.ID != seriesID {
+		t.Errorf("Series not preserved: got %+v, want ID=%d", got.Series, seriesID)
+	}
+	// Heavy fields carried by the hydrated row survive too (defense-in-depth).
+	if got.Description == nil || *got.Description != desc {
+		t.Errorf("Description not preserved: got %v, want %q", got.Description, desc)
+	}
+}

--- a/internal/scheduler/extra_ops.go
+++ b/internal/scheduler/extra_ops.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/extra_ops.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a9b8c7d6-e5f4-3210-fedc-ba9876543210
-// last-edited: 2026-07-07
+// last-edited: 2026-07-13
 
 // extra_ops registers OperationDefs for 13 scheduler tasks that previously
 // used the legacy triggerOperation / triggerOperationWithID helpers.  Each def
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
@@ -39,6 +38,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/sweep"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+	"github.com/gin-gonic/gin"
 )
 
 // ExtraOpsDeps holds the typed dependencies needed by ExtraOpsRegistrar.
@@ -331,18 +331,33 @@ func (r *ExtraOpsRegistrar) RegisterAuthorSplitScanOp(reg *opsregistry.Registry)
 						errCount++
 						continue
 					}
-					// Update primary AuthorID to first individual author
+					// Update primary AuthorID to first individual author.
 					if book.AuthorID != nil && *book.AuthorID == author.ID && len(newAuthors) > 0 {
 						firstID := newAuthors[0].ID
-						book.AuthorID = &firstID
-						// book is BookCore (heavy fields nil) — bridge via
-						// .ToBook() so PebbleStore.UpdateBook sees the
-						// expected all-nil heavy fields and restores them
-						// from the stored row (STOR-1 guard in UpdateBook),
-						// rather than a type mismatch or an accidental
-						// heavy-field wipe.
-						full := book.ToBook()
-						_, _ = store.UpdateBook(book.ID, &full)
+						// `book` is a BookCore (heavy fields nil). Do NOT write
+						// its ToBook() projection: it carries nil Author/Series
+						// AND, because this op changes AuthorID, the
+						// guard-preserved Author would be STALE (still the
+						// composite). Hydrate the full stored row and set BOTH
+						// the new AuthorID and a fresh denormalized Author so
+						// the row stays consistent (Author.ID == AuthorID), not
+						// preserved-stale (STOREFID W5d-1 / #1887). Duplicate of
+						// internal/plugins/maintenance/author.go — keep in sync.
+						if full, err := store.GetBookByID(book.ID); err == nil && full != nil {
+							newPrimary := newAuthors[0]
+							full.AuthorID = &firstID
+							full.Author = &newPrimary
+							_, _ = store.UpdateBook(book.ID, full)
+						} else {
+							// Hydration failed — fall back to the projection
+							// write so the AuthorID change still lands
+							// (UpdateBook's guard preserves the old
+							// Author/Series). Never skip the split.
+							_ = progress.Log("warning", fmt.Sprintf("author split: hydrate book %s failed, writing projection: %v", book.ID, err), nil)
+							book.AuthorID = &firstID
+							full := book.ToBook()
+							_, _ = store.UpdateBook(book.ID, &full)
+						}
 					}
 					booksUpdated++
 				}


### PR DESCRIPTION
## Summary

Confirmed prod **data-loss** (field-wipe) of denormalized `Author`/`Series`. The #1887 / 98c2a218 fix patched only the `CreateOrganizedVersion` call site; the **root-cause gap in `PebbleStore.UpdateBook`'s preserve-on-nil guard** (no Author/Series case) plus two other slim-projection call sites remained. This PR closes the class.

## Root cause

`Book.Author`/`Book.Series` carry `json:"...,omitempty"` and Pebble `json.Marshal` persists them (the `db:"-"` tag only suppresses SQLite). `UpdateBook`'s preserve-on-nil guard restored the seven memdb-stripped heavy fields (Description/VersionNotes/BookSig*) but **omitted Author/Series**, so any write sourced from a `BookCore`→`ToBook()` or memdb projection (both nil Author/Series) silently erased them from the stored Pebble row.

## The three fixes

**Fix 1 — root, `internal/database/pebble_store.go`.** Added `Author`/`Series` to the preserve-on-nil guard, mirroring the seven-field pattern exactly. Backstop for the whole Core-projection write class.

*Why preserve-on-nil is correct (no legitimate nil-clear):* Author/Series are denormalized display objects derived from AuthorID/SeriesID, recomputed on read, never user-cleared to nil — they are pointer structs with no empty-string-style sentinel (unlike Description's `&""` escape hatch). Verified: **0 of 135** `UpdateBook` call sites intentionally nil-clear them.

**Fix 2 — `internal/plugins/maintenance/author.go` + `internal/scheduler/extra_ops.go`.** The two duplicate composite-author-split ops wrote `book.ToBook()` (nil Author/Series) **and** changed `AuthorID`, so a merely-preserved Author would be *stale* (still naming the old composite). Both now hydrate the full row via `GetBookByID` and write it with the new `AuthorID` **and** a fresh denormalized `Author` (`Author.ID == AuthorID`) — correct-and-consistent, not preserved-stale. On hydrate failure they fall back to the projection write so the AuthorID change still lands (guard preserves the rest) — never skip the split. Deleted the false inline comments claiming the guard restored Author/Series. The scheduler op is a byte-identical twin of the maintenance op (only the logger call differs); fixed identically, covered by the maintenance test + build/vet.

**Fix 3 — `internal/organizer/move.go`.** `MoveBookFile`'s bare `{FilePath}` write (dead/latent — no live caller today) would total-wipe the row under the full-fidelity backend; it now hydrates before setting FilePath, falling back to the bare write on hydrate failure. The `extraUpdates` branch is unchanged.

## Tests / verification

- `TestUpdateBook_PreservesAuthorSeriesOnNilIncoming` (real `PebbleStore`, the #1887 harness) — a nil-Author/Series write over a populated row keeps both.
- `TestAuthorSplit_WritesFreshAuthorNotStaleOrNil` — drives `runAuthorSplitScan`; asserts the written row has `Author.ID == AuthorID` (fresh, not stale/nil) and Series preserved after an AuthorID change.
- `MoveBookFile` tests updated for the new hydrate call.
- `internal/database`, `internal/plugins/maintenance`, `internal/scheduler`, `internal/organizer` green under `-race`; `go build ./...`, `go vet`, `gofmt -l` clean.
- Whole-repo `go test ./... -short`: only `internal/server` fails, on a **pre-existing** package-level timeout stall in Pebble/registry teardown (documented flake) — reproduced identically on a checkout **without** these changes; unrelated to Author/Series.

Also updated CHANGELOG, TODO, and added a plain-language executive summary (`docs/executive-summaries/2026-07-13-author-series-data-loss-executive-summary.md`) per the data-loss criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv