### PR TITLE
fix(dedup): serialize CombineBooks + dedup.MergeBooks (close merge-race follow-ups from #1930)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- file: CHANGELOG.md -->
+<!-- version: 3.149.0 -->
 <!-- version: 3.148.0 -->
 <!-- version: 3.147.0 -->
 <!-- version: 3.146.0 -->
@@ -12,6 +13,31 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - fix(dedup): serialize CombineBooks + dedup.MergeBooks (close merge-race follow-ups from #1930)
+
+- **Two adjacent concurrent-merge corruption paths closed** (backend, REVIEW-CRITICAL) — the #1930
+  fix serialized `merge.Service.MergeBooks` but explicitly left two sibling read-modify-writes of the
+  same data-corruption class unguarded. Both are now serialized on the SAME process-wide lock so any
+  two merge-family operations are mutually exclusive on a shared book row:
+  - `merge.Service.CombineBooks` — the manual "combine into one multi-file book" path. It is a
+    synchronous HTTP handler (no ConcurrencyKey), so two combines, or a combine racing a `MergeBooks`,
+    could interleave `GetBookByID` → `MoveBookFilesToBook` → `ReassignExternalIDs` → `DeleteBook` →
+    `UpdateBook` and corrupt the same way (orphaned files, a book both survivor and deleted).
+  - `dedup.MergeBooks` — a package-level function (NOT `merge.Service`) with its own read-modify-write
+    (iTunes-metadata transfer + hard-delete, no version group), reachable from two async ops with
+    DIFFERENT ConcurrencyKeys (`dedup.book-merge` and the iTunes-heal op), so it could race itself AND
+    `merge.Service.MergeBooks`/`CombineBooks`. Its distinct semantics mean it is intentionally NOT
+    routed through the Service — it only shares the lock.
+- **Implementation** — #1930's per-instance `merge.Service.mergeMu` was promoted to a package-level
+  `mergeSerializeMu` in `internal/merge/serialize.go` with exported `LockMergeRMW`/`UnlockMergeRMW`
+  helpers, so `dedup.MergeBooks` (which cannot reach a `*merge.Service` from the reconcile op path)
+  shares the exact same lock. Single lock, three acquirers; non-reentrant and deadlock-free (none of
+  the three calls another, and no store method calls back up). Scoped to the read-modify-write only —
+  local Pebble/in-memory work, no network/large-scan under the lock.
+- Tests: shared-lock `-race` serialization tests in both packages (CombineBooks-vs-MergeBooks and
+  dedup.MergeBooks-vs-merge.Service.MergeBooks, disjoint per-goroutine data), each verified to fail
+  with its lock reverted (`maxActive=9` and `maxActive=2` respectively).
 
 #### July 13, 2026 - fix(dedup): serialize MergeBooks + harden auto-merge journal/guards (data-loss risk)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 <!-- file: TODO.md -->
+<!-- version: 9.101.0 -->
 <!-- version: 9.100.0 -->
 <!-- version: 9.99.2 -->
 <!-- version: 9.99.1 -->
@@ -56,8 +57,12 @@ redundant Engine-level `mergeMu`). Also: `autoMergeCertain` now writes a provisi
 reversal-journal entry *before* the merge (hard error → skip if it fails) and patches it
 after; `ApplyVerdicts` gained the soft-deleted pre-check + loser candidate cleanup.
 See `docs/executive-summaries/2026-07-13-merge-serialization-executive-summary.md`.
-Adjacent unguarded paths NOT covered (separate follow-up): `dedup.MergeBooks`
-(book_dedup.go, its own store read-modify-write) and `merge.Service.CombineBooks`.
+**Follow-up (2026-07-13, RESOLVED):** the two adjacent unguarded paths flagged here —
+`dedup.MergeBooks` (book_dedup.go) and `merge.Service.CombineBooks` — are now serialized
+on the SAME lock. #1930's per-instance `mergeMu` was promoted to a package-level
+`mergeSerializeMu` (`internal/merge/serialize.go`, exported `LockMergeRMW`/`UnlockMergeRMW`)
+so all three merge-family read-modify-writes are mutually exclusive on a shared book row.
+Shared-lock `-race` tests in both packages, each verified to fail with its lock reverted.
 
 ### ✅ Execution Wave 1 + Wave 2 + Wave 2b shipped (2026-07-10/11) — 15/50 tasks merged
 

--- a/docs/executive-summaries/2026-07-13-merge-serialization-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-merge-serialization-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-07-13-merge-serialization-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 3b7f0c92-6a41-4d58-8e12-9c05a2f7e6d4 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -45,3 +45,18 @@ but the library's record of which copy is the "real" one could be scrambled.
 
 All three fixes ship together and are covered by new tests, including one that
 deliberately runs many merges at once and confirms they no longer collide.
+
+## Follow-up: two more merge paths closed (same day)
+
+The original fix protected the main merge path but deliberately left two related
+paths for a follow-up: **"combine"** (the manual action that folds several
+separate entries into one multi-file book) and the **duplicate-cleanup merge**
+used by the iTunes reconcile and the book-merge cleanup job. Both did the same
+kind of unprotected update and could run at the same time as a regular merge —
+so the exact collision above was still possible through them.
+
+Both are now protected by the *same* lock as the main merge path, so no two
+book-merging actions of any kind can ever overlap on the same book. This closes
+the whole class of problem, not just the one path. New tests run the combine and
+the cleanup-merge concurrently against a regular merge and confirm they take
+turns; each test was checked to genuinely fail if the protection is removed.

--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/book_dedup.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-07
+// last-edited: 2026-07-13
 
 // Package dedup: book_dedup.go contains the extracted execution logic for the
 // "dedup.book-scan" and "dedup.book-merge" async operations.  The *Server
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 	ulid "github.com/oklog/ulid/v2"
 )
@@ -335,6 +336,20 @@ type BookMergeResult struct {
 //
 // opID is the legacy operation ID written into OperationChange records.
 // keepID is the ID of the book to keep; every ID in mergeIDs is deleted.
+//
+// Concurrency: this is a package-level function (NOT merge.Service.MergeBooks)
+// with its own unguarded read-modify-write, reached from two async ops with
+// DIFFERENT ConcurrencyKeys (dedup.book-merge and the iTunes-heal op), so it can
+// race itself AND merge.Service.MergeBooks/CombineBooks on a shared book row. It
+// therefore acquires the SAME process-wide lock those Service methods use
+// (merge.LockMergeRMW, see internal/merge/serialize.go) for the whole
+// read-modify-write, making every merge atomic w.r.t. every other merge. The
+// per-book loop is bounded by one request's merge set and does only local DB /
+// in-memory progress work under the lock — nothing network/large-scan. Semantics
+// differ from merge.Service.MergeBooks (hard-delete + iTunes-metadata transfer,
+// no version group), so it is intentionally NOT routed through the Service; it
+// only shares the lock. Non-reentrant: this never calls the Service merge paths,
+// so the lock is taken exactly once.
 func MergeBooks(
 	_ context.Context,
 	store database.Store,
@@ -342,6 +357,9 @@ func MergeBooks(
 	mergeIDs []string,
 	progress ProgressReporter,
 ) (BookMergeResult, error) {
+	merge.LockMergeRMW()
+	defer merge.UnlockMergeRMW()
+
 	keepBook, err := store.GetBookByID(keepID)
 	if err != nil || keepBook == nil {
 		return BookMergeResult{}, fmt.Errorf("keep book %s not found", keepID)

--- a/internal/dedup/book_dedup_concurrent_test.go
+++ b/internal/dedup/book_dedup_concurrent_test.go
@@ -1,0 +1,138 @@
+// file: internal/dedup/book_dedup_concurrent_test.go
+// version: 1.0.0
+// guid: 9f2c7b41-6d38-4e05-a1b9-3c7e0d2f5a64
+// last-edited: 2026-07-13
+
+package dedup
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+// dedupSerializeProbe wraps a real database.Store and counts the maximum number
+// of goroutines simultaneously inside the merge read-modify-write. It overrides
+// the two methods BOTH dedup.MergeBooks and merge.Service.MergeBooks drive
+// (GetBookByID / UpdateBook) and delegates the rest. A tiny sleep on entry widens
+// the interleave window so that, if the two paths did NOT share one lock, their
+// bodies would overlap and push maxActive to 2+. Sharing merge's package-level
+// lock keeps at most one goroutine inside at a time -> maxActive == 1.
+type dedupSerializeProbe struct {
+	database.Store
+	active    int32
+	maxActive int32
+}
+
+func (p *dedupSerializeProbe) enter() {
+	n := atomic.AddInt32(&p.active, 1)
+	for {
+		m := atomic.LoadInt32(&p.maxActive)
+		if n <= m || atomic.CompareAndSwapInt32(&p.maxActive, m, n) {
+			break
+		}
+	}
+	time.Sleep(500 * time.Microsecond)
+}
+
+func (p *dedupSerializeProbe) leave() { atomic.AddInt32(&p.active, -1) }
+
+func (p *dedupSerializeProbe) GetBookByID(id string) (*database.Book, error) {
+	p.enter()
+	defer p.leave()
+	return p.Store.GetBookByID(id)
+}
+
+func (p *dedupSerializeProbe) UpdateBook(id string, b *database.Book) (*database.Book, error) {
+	p.enter()
+	defer p.leave()
+	return p.Store.UpdateBook(id, b)
+}
+
+func newConcurrentTestStore(t *testing.T) database.Store {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	orig := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	t.Cleanup(func() {
+		database.SetGlobalStore(orig)
+		_ = store.Close()
+	})
+	return store
+}
+
+// TestDedupMergeBooks_SharesLockWithMergeService is the load-bearing regression
+// test for Path 2 of the #1930 follow-up. dedup.MergeBooks is a package-level
+// function (NOT merge.Service.MergeBooks) with its own read-modify-write, and it
+// can run concurrently with merge.Service.MergeBooks on a shared book row. It
+// must therefore take the SAME process-wide lock those Service methods use.
+//
+// Each goroutine gets its OWN disjoint pair, so maxActive>1 can only mean two
+// read-modify-writes overlapped — i.e. the lock was NOT shared. Even goroutines
+// run dedup.MergeBooks, odd goroutines run merge.Service.MergeBooks, all through
+// one shared probe store. WITH the shared lock (merge.LockMergeRMW) maxActive
+// stays 1. Discriminates: giving dedup.MergeBooks its own separate mutex lets a
+// dedup merge overlap a Service merge and maxActive reaches 2 (verified during
+// development). The even goroutines also exercise dedup-vs-dedup serialization.
+func TestDedupMergeBooks_SharesLockWithMergeService(t *testing.T) {
+	real := newConcurrentTestStore(t)
+	probe := &dedupSerializeProbe{Store: real}
+	ms := merge.NewService(probe)
+
+	const goroutines = 16
+	type pair struct{ keep, drop string }
+	pairs := make([]pair, goroutines)
+	for i := range pairs {
+		keep := ulid.Make().String()
+		drop := ulid.Make().String()
+		if _, err := real.CreateBook(&database.Book{ID: keep, Title: "Keep", Format: "m4b", FilePath: "/tmp/" + keep + ".m4b"}); err != nil {
+			t.Fatalf("CreateBook keep: %v", err)
+		}
+		if _, err := real.CreateBook(&database.Book{ID: drop, Title: "Drop", Format: "mp3", FilePath: "/tmp/" + drop + ".mp3"}); err != nil {
+			t.Fatalf("CreateBook drop: %v", err)
+		}
+		pairs[i] = pair{keep, drop}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			p := pairs[i]
+			if i%2 == 0 {
+				// dedup.MergeBooks: hard-delete drop, transfer metadata into keep.
+				_, _ = MergeBooks(context.Background(), probe, "", p.keep, []string{p.drop}, nil)
+			} else {
+				// merge.Service.MergeBooks: version-group merge (keep is m4b winner).
+				_, _ = ms.MergeBooks([]string{p.keep, p.drop}, "")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&probe.maxActive); got != 1 {
+		t.Fatalf("dedup.MergeBooks did NOT share the merge lock: maxActive=%d, want 1 "+
+			"(a dedup merge overlapped a merge.Service merge on the shared probe)", got)
+	}
+
+	// Consistency spot-check: pair[0] went through dedup.MergeBooks -> keep alive,
+	// drop hard-deleted.
+	if k0, err := real.GetBookByID(pairs[0].keep); err != nil || k0 == nil {
+		t.Fatalf("dedup keep book missing: %v", err)
+	}
+	if d0, _ := real.GetBookByID(pairs[0].drop); d0 != nil {
+		t.Fatalf("dedup drop book was not deleted")
+	}
+}

--- a/internal/merge/serialize.go
+++ b/internal/merge/serialize.go
@@ -1,0 +1,48 @@
+// file: internal/merge/serialize.go
+// version: 1.0.0
+// guid: b1e7d4a9-2c63-4f81-9a05-6d3e2f0c7b48
+// last-edited: 2026-07-13
+
+package merge
+
+import "sync"
+
+// mergeSerializeMu serializes EVERY merge-family read-modify-write across the
+// whole process. All three unguarded paths in the codebase acquire this one
+// lock so any two of them are mutually exclusive on a shared book row:
+//
+//   - merge.Service.MergeBooks   (version-group merge; soft-deletes losers)
+//   - merge.Service.CombineBooks (multi-file combine; hard-deletes shells)
+//   - dedup.MergeBooks           (iTunes-metadata transfer + hard-delete;
+//     a SEPARATE package function, not on Service,
+//     which reaches this lock via LockMergeRMW)
+//
+// Why one shared lock, not one per path: each does an unguarded
+// GetBookByID -> mutate -> UpdateBook / DeleteBook / SoftDeleteBook / external-ID
+// reassignment with no transaction. They run concurrently — CombineBooks is a
+// synchronous HTTP handler with no concurrency key, and dedup.MergeBooks is
+// reachable from two async ops with DIFFERENT ConcurrencyKeys — so two of them
+// (or one racing MergeBooks) can interleave writes to the same book and leave it
+// both primary AND soft-deleted, strand a version group across two ulids,
+// hard-delete a book another path just promoted, or soft-delete the winner.
+// Separate locks would leave the cross-path races open; only a single shared
+// lock makes every merge atomic w.r.t. every other merge. (Originally #1930 put
+// this mutex on merge.Service; it moved to package level so dedup.MergeBooks —
+// which cannot reach a *merge.Service instance from the reconcile op path — can
+// share the exact same lock. merge.Service is a process singleton, so this is
+// behaviorally identical for the Service methods and strictly safer.)
+//
+// Scope: hold it only around the read-modify-write itself; nothing
+// slow/blocking (network, large scan) runs while it is held.
+var mergeSerializeMu sync.Mutex
+
+// LockMergeRMW acquires the shared merge serialization lock for a caller OUTSIDE
+// this package (specifically dedup.MergeBooks, whose read-modify-write must be
+// mutually exclusive with merge.Service.MergeBooks / CombineBooks on shared
+// book rows). Pair it with a deferred UnlockMergeRMW. Non-reentrant: a caller
+// must not already hold this lock and must not call another merge-family path
+// while holding it.
+func LockMergeRMW() { mergeSerializeMu.Lock() }
+
+// UnlockMergeRMW releases the lock taken by LockMergeRMW.
+func UnlockMergeRMW() { mergeSerializeMu.Unlock() }

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,5 +1,5 @@
 // file: internal/merge/service.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
 // last-edited: 2026-07-13
 
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -43,27 +42,14 @@ func AsExternalIDReassigner(s any) ExternalIDReassigner {
 }
 
 // Service handles merging duplicate books into version groups.
+//
+// MergeBooks and CombineBooks serialize their read-modify-writes on the
+// package-level mergeSerializeMu (see serialize.go), shared with the sibling
+// dedup.MergeBooks path so any two merges are mutually exclusive on a shared
+// book row.
 type Service struct {
 	db               database.Store
 	writeBackBatcher WriteBackEnqueuer
-
-	// mergeMu serializes MergeBooks across ALL callers of this Service.
-	//
-	// merge.Service is a process-wide singleton (serviceregistry KeyMerge):
-	// the same instance is shared by the dedup Engine (full-scan auto-merge,
-	// auto-resolve, and LLM ApplyVerdicts) and by the HTTP merge handlers.
-	// Those dedup ops have distinct ConcurrencyKeys and run in an 8-worker
-	// pool, so two of them (or a manual HTTP merge racing an auto-merge) can
-	// call MergeBooks at the same time. MergeBooks does an unguarded
-	// read-modify-write per book (GetBookByID -> mutate -> full-column
-	// UpdateBook -> soft-delete losers) with no transaction, so interleaved
-	// writes to a shared book could leave it both primary AND soft-deleted,
-	// strand a version group across two ulids, or soft-delete the winner.
-	// Holding this lock for the whole read-modify-write makes every merge
-	// atomic w.r.t. every other merge. It lives on the Service (not on the
-	// Engine) so the guard cannot be forgotten by a future caller, and the
-	// scope is only the merge itself — nothing slow/blocking runs under it.
-	mergeMu sync.Mutex
 }
 
 // SetWriteBackBatcher sets the iTunes write-back batcher.
@@ -115,11 +101,12 @@ func (ms *Service) MergeBooks(bookIDs []string, primaryID string) (*Result, erro
 		return nil, fmt.Errorf("need at least 2 book IDs to merge")
 	}
 
-	// Serialize the entire read-modify-write against every other merge on this
-	// (singleton) Service — see the mergeMu doc comment. Scoped to the merge
-	// itself; nothing slow/blocking runs while it is held.
-	ms.mergeMu.Lock()
-	defer ms.mergeMu.Unlock()
+	// Serialize the entire read-modify-write against every other merge-family
+	// path (MergeBooks / CombineBooks / dedup.MergeBooks) — see the
+	// mergeSerializeMu doc comment. Scoped to the merge itself; nothing
+	// slow/blocking runs while it is held.
+	mergeSerializeMu.Lock()
+	defer mergeSerializeMu.Unlock()
 
 	// Fetch all books
 	var books []*database.Book
@@ -278,6 +265,19 @@ func (ms *Service) CombineBooks(bookIDs []string, primaryID string, override *Co
 	if primaryID == "" {
 		return nil, fmt.Errorf("primary_id is required for combine")
 	}
+
+	// Serialize the entire read-modify-write against every other merge-family
+	// path (MergeBooks / CombineBooks / dedup.MergeBooks). CombineBooks is a
+	// synchronous HTTP handler with no concurrency key, so two combines — or a
+	// combine racing a MergeBooks on a shared book — can otherwise interleave
+	// GetBookByID -> MoveBookFilesToBook -> ReassignExternalIDs -> DeleteBook
+	// -> UpdateBook and corrupt the same way #1930 fixed for MergeBooks. Scoped
+	// to the combine itself; only local DB work runs while it is held.
+	// (CombineBooks never calls MergeBooks or dedup.MergeBooks, so the
+	// non-reentrant mutex is taken exactly once.)
+	mergeSerializeMu.Lock()
+	defer mergeSerializeMu.Unlock()
+
 	survivor, err := ms.db.GetBookByID(primaryID)
 	if err != nil || survivor == nil {
 		return nil, fmt.Errorf("primary book %s not found", primaryID)

--- a/internal/merge/service_concurrent_test.go
+++ b/internal/merge/service_concurrent_test.go
@@ -1,5 +1,5 @@
 // file: internal/merge/service_concurrent_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c8a1f42-9d6b-4e73-8a10-2b4c6d9e0f13
 // last-edited: 2026-07-13
 
@@ -135,5 +135,75 @@ func TestMergeBooks_ConcurrentSamePair_Serializes(t *testing.T) {
 	}
 	if a.MarkedForDeletion == nil || !*a.MarkedForDeletion {
 		t.Fatalf("loser A was not soft-deleted")
+	}
+}
+
+// TestMergeFamily_CombineAndMerge_ShareOneLock proves CombineBooks serializes on
+// the SAME lock as MergeBooks (the package-level mergeSerializeMu). Each
+// goroutine operates on its OWN disjoint pair, so a maxActive>1 can only mean two
+// read-modify-writes overlapped — i.e. the lock was NOT shared — not a data
+// conflict. Even goroutines Combine, odd goroutines Merge; all go through one
+// shared Service+probe. WITH the shared lock maxActive stays 1. Discriminates:
+// reverting CombineBooks' mergeSerializeMu.Lock() lets a Combine overlap a Merge
+// and maxActive reaches 2 (verified during development).
+func TestMergeFamily_CombineAndMerge_ShareOneLock(t *testing.T) {
+	real := setupTestStore(t)
+	probe := &serializeProbe{Store: real}
+	ms := NewService(probe)
+
+	const goroutines = 16
+	type pair struct{ a, b string }
+	pairs := make([]pair, goroutines)
+	for i := range pairs {
+		a := ulid.Make().String()
+		b := ulid.Make().String()
+		// Unique file paths so combine's per-book file materialization never
+		// collides across goroutines.
+		if _, err := real.CreateBook(&database.Book{ID: a, Title: "A", Format: "mp3", FilePath: "/tmp/" + a + ".mp3"}); err != nil {
+			t.Fatalf("CreateBook A: %v", err)
+		}
+		if _, err := real.CreateBook(&database.Book{ID: b, Title: "B", Format: "m4b", FilePath: "/tmp/" + b + ".m4b"}); err != nil {
+			t.Fatalf("CreateBook B: %v", err)
+		}
+		pairs[i] = pair{a, b}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			p := pairs[i]
+			if i%2 == 0 {
+				// Combine b into a (a survives, b absorbed + hard-deleted).
+				_, _ = ms.CombineBooks([]string{p.a, p.b}, p.a, nil)
+			} else {
+				// Merge auto-picks the m4b winner (b); a is soft-deleted.
+				_, _ = ms.MergeBooks([]string{p.a, p.b}, "")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&probe.maxActive); got != 1 {
+		t.Fatalf("Combine and Merge did NOT share one lock: maxActive=%d, want 1 "+
+			"(a CombineBooks read-modify-write overlapped a MergeBooks)", got)
+	}
+
+	// Spot-check consistency of one pair of each kind.
+	// pair[0] was combined: survivor a alive, absorbed b hard-deleted (gone).
+	if a0, err := real.GetBookByID(pairs[0].a); err != nil || a0 == nil {
+		t.Fatalf("combine survivor A missing: %v", err)
+	}
+	if b0, _ := real.GetBookByID(pairs[0].b); b0 != nil {
+		t.Fatalf("combine absorbed B was not deleted")
+	}
+	// pair[1] was merged: both books share one non-empty version group.
+	a1, _ := real.GetBookByID(pairs[1].a)
+	b1, _ := real.GetBookByID(pairs[1].b)
+	if a1 == nil || b1 == nil || a1.VersionGroupID == nil || b1.VersionGroupID == nil ||
+		*a1.VersionGroupID == "" || *a1.VersionGroupID != *b1.VersionGroupID {
+		t.Fatalf("merged pair not in one consistent version group: a=%+v b=%+v", a1, b1)
 	}
 }


### PR DESCRIPTION
## Summary

PR #1930 serialized `merge.Service.MergeBooks` against concurrent-merge corruption but explicitly flagged **two adjacent read-modify-writes of the same data-corruption class** as out-of-scope follow-ups. This closes both by making all three merge-family paths share **one** process-wide lock, so any two merges are mutually exclusive on a shared book row.

REVIEW-CRITICAL. No merge/combine **semantics** change — serialization only.

## Path 1 — `merge.Service.CombineBooks` — NEEDED serialization

- Sibling of `MergeBooks` on the same `merge.Service` singleton; a **synchronous HTTP handler** (`internal/server/handlers/duplicates/handler.go:351`) with **no ConcurrencyKey**.
- Does its own read-modify-write: `GetBookByID` → `MoveBookFilesToBook` → `ReassignExternalIDs` → `DeleteBook` → `UpdateBook`. Two concurrent combines, or a combine racing a `MergeBooks`, could interleave and corrupt the shared book (orphaned files, a book both survivor and deleted).
- **Reentrancy proof:** CombineBooks never calls `MergeBooks` or `dedup.MergeBooks` (verified its full outgoing-call set) → the non-reentrant mutex is taken exactly once.
- **Fix:** takes the shared lock around its read-modify-write.

## Path 2 — `dedup.MergeBooks` — NEEDED serialization, shares the SAME lock

- A **package-level function** (NOT `merge.Service`) with its own read-modify-write (iTunes-metadata transfer + **hard-delete**, no version group).
- Reachable from **two async ops with DIFFERENT ConcurrencyKeys** — `dedup.book-merge` (`duplicates_ops.go:151`) and the iTunes-heal op (`reconcile/itunes_heal.go:274`). The op dispatcher (`operations/registry/dispatcher.go` Gate 3) only serializes **same-key** ops, so `dedup.MergeBooks` can race **itself** AND `merge.Service.MergeBooks`/`CombineBooks` on a shared book.
- Semantics differ from `merge.Service.MergeBooks`, so it is **intentionally NOT routed through the Service** (per the task constraint not to change merge behavior) — it only shares the lock.
- **Reentrancy proof:** never calls the Service merge paths → lock taken exactly once.

## Implementation

- #1930's per-instance `merge.Service.mergeMu` is promoted to a package-level `mergeSerializeMu` in `internal/merge/serialize.go`, with exported `LockMergeRMW`/`UnlockMergeRMW` so `dedup.MergeBooks` — which cannot reach a `*merge.Service` from the reconcile op path — shares the **exact same** lock. Single lock, three acquirers.
- `merge.Service` is a process singleton, so package-level == instance-level for the Service methods, and strictly safer for cross-package sharing. `dedup` already imports `merge` (no import cycle; `merge` does not import `dedup`); `reconcile` needs no change.
- **No slow work under the lock:** verified `dedup.MergeBooks`'s progress reporter does only a local Pebble write + in-process event bus + slog (`reporter_db.go`); the loop is bounded by one request's merge set; the itunes-heal caller passes `nil` progress. Consistent with #1930's scope.
- **Deadlock:** single lock, no path calls another lock-taker while held, no store method calls back up → deadlock-free.

## Tests

Shared-lock `-race` serialization tests in **both** packages, using disjoint per-goroutine data so `maxActive` isolates lock-sharing (not data conflict):
- `internal/merge`: `TestMergeFamily_CombineAndMerge_ShareOneLock` — even goroutines Combine, odd Merge, one shared Service/probe → `maxActive == 1`. **Verified fails with the CombineBooks lock reverted: `maxActive=9`.**
- `internal/dedup`: `TestDedupMergeBooks_SharesLockWithMergeService` — even goroutines `dedup.MergeBooks`, odd `merge.Service.MergeBooks`, shared probe → `maxActive == 1`. **Verified fails with a separate lock: `maxActive=2`.**

Results: `go test ./internal/merge/... ./internal/dedup/... ./internal/reconcile/... -race` green; `go build ./...`, `go vet ./internal/merge/... ./internal/dedup/...`, `gofmt -l` (my files) clean.

> Note: the full `go test ./... -short` run hit the pre-existing intermittent `internal/server` timeout at `Registry.Shutdown` (Pebble WAL flush — PEBBLE-CLOSED-SHUTDOWN-RACE), with **no** merge/dedup/combine symbols anywhere in the hang stack. The merge/combine/dedup handler tests pass in isolation. Re-running to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv