### PR TITLE
fix(security): guard book user-tags writes + ai/scans/compare, stop internal-error leaks, clamp history limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,36 @@
 - Tests: shared-lock `-race` serialization tests in both packages (CombineBooks-vs-MergeBooks and
   dedup.MergeBooks-vs-merge.Service.MergeBooks, disjoint per-goroutine data), each verified to fail
   with its lock reverted (`maxActive=9` and `maxActive=2` respectively).
+#### July 13, 2026 - fix(security): guard book user-tags writes + ai/scans/compare, stop internal-error leaks, clamp history limit
+
+- **Authorization gap (primary fix)** — `PUT/POST /audiobooks/:id/user-tags` and
+  `DELETE /audiobooks/:id/user-tags/:tag` (`internal/server/user_tags.go`) were
+  registered with no `s.perm(...)` guard, so any authenticated principal — even
+  a view-only role or a zero-permission scoped API key — could rewrite or wipe a
+  book's global tags (`SetBookTags`/`AddBookTag`/`RemoveBookTag`). Added
+  `s.perm(auth.PermLibraryEditMetadata)` to all three routes, matching the
+  sibling `POST /audiobooks/batch-tags` write guard and the read side's
+  `PermLibraryView` requirement.
+- **`GET /ai/scans/compare`** (`internal/server/wire_media_routes.go`) was
+  missing the `PermLibraryView` guard every sibling `/ai/scans*` read route
+  requires. Added the guard without disturbing its route-ordering comment
+  (must stay registered before `/:id`).
+- **Internal-error info leaks** — 7 handlers across
+  `internal/server/deluge_integration.go`, `internal/server/deluge_discovery.go`,
+  `internal/server/handlers/cache.go`, and
+  `internal/server/handlers/audiobooks/handler_tags.go` called
+  `httputil.RespondWithInternalError(c, err.Error())`, serializing raw
+  internal error text (DB/driver detail, filesystem paths) to the client.
+  Swapped to `httputil.InternalError(c, "<static message>", err)`, which logs
+  the full error server-side but returns only a generic message.
+- **Unbounded metadata-history `?limit=`** — `GetBookMetadataHistory` and
+  `GetFieldMetadataHistory` (`internal/server/handlers/audiobooks/handler_metadata.go`)
+  only validated `limit > 0`, allowing an attacker-supplied huge value to force
+  an unbounded read. Clamped to 1000, matching the ceiling
+  `httputil.ParsePaginationParams` uses elsewhere.
+- Tests: new `internal/server/user_tags_authz_test.go` proves a viewer-role
+  session (library.view only) gets 403 on all three user-tags write routes and
+  an admin session succeeds.
 
 #### July 13, 2026 - fix(dedup): serialize MergeBooks + harden auto-merge journal/guards (data-loss risk)
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,19 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
+## ✅ RESOLVED — book user-tags write routes had no permission guard (2026-07-13)
+
+`PUT/POST /audiobooks/:id/user-tags` and `DELETE /audiobooks/:id/user-tags/:tag`
+(`internal/server/user_tags.go`) were registered with no `s.perm(...)` check, so
+any authenticated principal — even a view-only role or a zero-permission scoped
+API key — could rewrite or wipe a book's global tags. **Fixed** by adding
+`s.perm(auth.PermLibraryEditMetadata)` to all three routes. Same PR also closed
+a matching gap on `GET /ai/scans/compare` (missing `PermLibraryView`), swapped 7
+`err.Error()`-to-client info-leak sites for `httputil.InternalError` (logs the
+real error, returns a generic message), and clamped the metadata-history
+`?limit=` to 1000. Test: `internal/server/user_tags_authz_test.go` (viewer → 403,
+admin → 200 on all three write routes).
+
 ## 📦 2026-07-10 Remaining-Work Planning Packages — READY FOR EXECUTION
 
 Ten full planning packages (spec + plan + task briefs) covering INIT-1..10 of the

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -1,7 +1,7 @@
 // file: internal/server/deluge_discovery.go
-// version: 3.0.0
+// version: 3.1.0
 // guid: e6f7a8b9-c0d1-2e3f-4a5b-6c7d8e9f0a1b
-// last-edited: 2026-05-11
+// last-edited: 2026-07-13
 //
 // Deluge label-based audiobook discovery — HTTP handlers.
 //
@@ -97,7 +97,7 @@ func (s *Server) handleDelugeDiscoverImport(c *gin.Context) {
 		Organize: false,
 	})
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to import file", err)
 		return
 	}
 

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -1,7 +1,7 @@
 // file: internal/server/deluge_integration.go
-// version: 2.0.0
+// version: 2.1.0
 // guid: 1c9d0e8f-2a3b-4a70-b8c5-3d7e0f1b9a99
-// last-edited: 2026-05-11
+// last-edited: 2026-07-13
 //
 // Deluge integration — HTTP handlers and thin shims.
 //
@@ -77,7 +77,7 @@ func (s *Server) handleDelugeTestConnection(c *gin.Context) {
 	}
 	client, err := deluge.New(url, pass)
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to create deluge client", err)
 		return
 	}
 	if err := client.Login(); err != nil {

--- a/internal/server/handlers/audiobooks/handler_metadata.go
+++ b/internal/server/handlers/audiobooks/handler_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_metadata.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 591661c3-5e87-4559-9a08-3203eec4fb68
-// last-edited: 2026-06-23
+// last-edited: 2026-07-13
 
 // Metadata-history / undo / field-state / path-history / external-id /
 // changelog / changes endpoints for the audiobooks domain. Split out of
@@ -23,6 +23,12 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 )
 
+// maxHistoryLimit caps the ?limit= query param on the per-book metadata
+// history endpoints, matching the ceiling httputil.ParsePaginationParams
+// applies elsewhere. An attacker-supplied huge limit could otherwise force
+// an unbounded history read/allocation.
+const maxHistoryLimit = 1000
+
 // GetBookMetadataHistory handles GET /audiobooks/:id/metadata-history.
 func (h *Handler) GetBookMetadataHistory(c *gin.Context) {
 	id := c.Param("id")
@@ -35,6 +41,9 @@ func (h *Handler) GetBookMetadataHistory(c *gin.Context) {
 	if l := c.Query("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
 			limit = parsed
+			if limit > maxHistoryLimit {
+				limit = maxHistoryLimit
+			}
 		}
 	}
 	records, err := store.GetBookChangeHistory(id, limit)
@@ -74,6 +83,9 @@ func (h *Handler) GetFieldMetadataHistory(c *gin.Context) {
 	if l := c.Query("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
 			limit = parsed
+			if limit > maxHistoryLimit {
+				limit = maxHistoryLimit
+			}
 		}
 	}
 	records, err := store.GetMetadataChangeHistory(id, field, limit)

--- a/internal/server/handlers/audiobooks/handler_tags.go
+++ b/internal/server/handlers/audiobooks/handler_tags.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_tags.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: ff2e3609-5ce3-4414-a18b-976d21b929fb
-// last-edited: 2026-06-23
+// last-edited: 2026-07-13
 
 // Tag read/write, alternative-title CRUD, and batch tag-update endpoints for
 // the audiobooks domain. Split out of handler.go for readability; one Handler,
@@ -46,7 +46,7 @@ func (h *Handler) GetAudiobookTags(c *gin.Context) {
 func (h *Handler) ListAllUserTags(c *gin.Context) {
 	tags, err := h.audiobookService.ListAllUserTags()
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to list user tags", err)
 		return
 	}
 	if tags == nil {
@@ -60,7 +60,7 @@ func (h *Handler) GetBookUserTags(c *gin.Context) {
 	id := c.Param("id")
 	tags, err := h.audiobookService.GetBookUserTags(id)
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to get book user tags", err)
 		return
 	}
 	if tags == nil {
@@ -79,7 +79,7 @@ func (h *Handler) GetBookTagsDetailed(c *gin.Context) {
 	}
 	tags, err := h.store.GetBookTagsDetailed(id)
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to get detailed book tags", err)
 		return
 	}
 	if tags == nil {
@@ -194,7 +194,7 @@ func (h *Handler) BatchUpdateTags(c *gin.Context) {
 	body.RemoveTags = filterEmpty(body.RemoveTags)
 	updated, err := h.audiobookService.BatchUpdateUserTags(body.BookIDs, body.AddTags, body.RemoveTags)
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to batch update tags", err)
 		return
 	}
 	httputil.RespondWithOK(c, gin.H{"updated": updated})

--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/cache.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: c9d0e1f2-a3b4-5678-cdef-678901234567
-// last-edited: 2026-06-22
+// last-edited: 2026-07-13
 
 package handlers
 
@@ -169,7 +169,7 @@ func (h *CacheHandler) HandleCacheStatsHistory(c *gin.Context) {
 	}
 	snaps, err := h.metricsStore.GetCacheStatsHistory(cacheName, since, limit)
 	if err != nil {
-		httputil.RespondWithInternalError(c, err.Error())
+		httputil.InternalError(c, "failed to get cache stats history", err)
 		return
 	}
 	httputil.RespondWithOK(c, struct {

--- a/internal/server/user_tags.go
+++ b/internal/server/user_tags.go
@@ -1,7 +1,7 @@
 // file: internal/server/user_tags.go
-// version: 2.3.0
+// version: 2.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
-// last-edited: 2026-06-10
+// last-edited: 2026-07-13
 
 package server
 
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 )
 
@@ -20,10 +21,15 @@ func normalizeTag(t string) string {
 }
 
 // setupUserTagRoutes registers the user tag API routes on the given router group.
+//
+// These mutate global per-book tags (SetBookTags/AddBookTag/RemoveBookTag, not
+// user-scoped), so they require library.edit_metadata — the same guard used by
+// the sibling write POST /audiobooks/batch-tags, and consistent with the read
+// side (GET .../user-tags requiring library.view).
 func (s *Server) setupUserTagRoutes(protected *gin.RouterGroup) {
-	protected.PUT("/audiobooks/:id/user-tags", s.setBookUserTags)
-	protected.POST("/audiobooks/:id/user-tags", s.addBookUserTag)
-	protected.DELETE("/audiobooks/:id/user-tags/:tag", s.removeBookUserTag)
+	protected.PUT("/audiobooks/:id/user-tags", s.perm(auth.PermLibraryEditMetadata), s.setBookUserTags)
+	protected.POST("/audiobooks/:id/user-tags", s.perm(auth.PermLibraryEditMetadata), s.addBookUserTag)
+	protected.DELETE("/audiobooks/:id/user-tags/:tag", s.perm(auth.PermLibraryEditMetadata), s.removeBookUserTag)
 }
 
 // setBookUserTags replaces all user-defined tags on a book.

--- a/internal/server/user_tags_authz_test.go
+++ b/internal/server/user_tags_authz_test.go
@@ -1,0 +1,157 @@
+// file: internal/server/user_tags_authz_test.go
+// version: 1.0.0
+// guid: 7a4e9b3c-2f1d-4a6e-9c8b-5d3f0e1a2b4c
+// last-edited: 2026-07-13
+
+// Regression coverage for the book user-tags write routes' authorization
+// guard (fixed in this change). setupUserTagRoutes previously registered
+// PUT/POST/DELETE .../user-tags with no s.perm(...) check, so any
+// authenticated principal — including a view-only role — could mutate the
+// global per-book tag set. These tests build a server with auth enabled and
+// seeded admin/viewer roles, then assert the viewer session (library.view
+// only) gets 403 on all three write routes while the admin session
+// (library.edit_metadata included) succeeds.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// setupUserTagsAuthzTestServer creates a test server with authentication
+// enabled and seeded admin + viewer sessions. setupTestServer (used by most
+// of this package's tests) always runs with auth disabled, which would make
+// a 403 assertion meaningless here.
+func setupUserTagsAuthzTestServer(t *testing.T) (srv *Server, adminToken, viewerToken string, bookID string, cleanup func()) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	origCfg := config.AppConfig
+	tempDir, err := os.MkdirTemp("", "audiobook-authz-test-*")
+	require.NoError(t, err)
+
+	config.AppConfig = config.Config{
+		DatabaseType: "pebble",
+		DatabasePath: filepath.Join(tempDir, "test.pebble"),
+		RootDir:      tempDir,
+		EnableAuth:   true,
+	}
+
+	store, err := database.NewPebbleStore(config.AppConfig.DatabasePath)
+	require.NoError(t, err)
+	database.SetGlobalStore(store)
+
+	err = database.RunMigrations(store)
+	require.NoError(t, err)
+
+	_, _, err = auth.SeedRoles(store)
+	require.NoError(t, err)
+
+	admin, err := store.CreateUser("admin", "admin@x.test", "bcrypt", "hash", []string{auth.SeedRoleAdmin}, "active")
+	require.NoError(t, err)
+	viewer, err := store.CreateUser("viewer", "viewer@x.test", "bcrypt", "hash", []string{auth.SeedRoleViewer}, "active")
+	require.NoError(t, err)
+
+	adminSession, err := store.CreateSession(admin.ID, "127.0.0.1", "test", time.Hour)
+	require.NoError(t, err)
+	viewerSession, err := store.CreateSession(viewer.ID, "127.0.0.1", "test", time.Hour)
+	require.NoError(t, err)
+
+	book, err := store.CreateBook(&database.Book{
+		Title:    "Authz Test Book",
+		FilePath: "/tmp/authz-test.m4b",
+	})
+	require.NoError(t, err)
+
+	server := NewServer(store)
+	if server.opRegistry != nil {
+		server.opRegistry.Start(context.Background())
+	}
+
+	cleanup = func() {
+		if server.opRegistry != nil {
+			_ = server.opRegistry.Shutdown(context.Background())
+		}
+		if server.fileIOPool != nil {
+			server.fileIOPool.Stop()
+		}
+		if server.writeBackBatcher != nil {
+			_ = server.writeBackBatcher.Stop(context.Background())
+		}
+		database.SetGlobalStore(nil)
+		store.Close()
+		_ = os.RemoveAll(tempDir)
+		config.AppConfig = origCfg
+	}
+
+	return server, adminSession.ID, viewerSession.ID, book.ID, cleanup
+}
+
+func TestUserTagRoutes_ViewerForbidden(t *testing.T) {
+	server, _, viewerToken, bookID, cleanup := setupUserTagsAuthzTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   []byte
+	}{
+		{"PUT set tags", http.MethodPut, "/api/v1/audiobooks/" + bookID + "/user-tags", []byte(`{"tags":["scifi"]}`)},
+		{"POST add tag", http.MethodPost, "/api/v1/audiobooks/" + bookID + "/user-tags", []byte(`{"tag":"scifi"}`)},
+		{"DELETE remove tag", http.MethodDelete, "/api/v1/audiobooks/" + bookID + "/user-tags/scifi", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+viewerToken)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, req)
+			require.Equal(t, http.StatusForbidden, w.Code, "viewer (library.view only) should be forbidden; body=%s", w.Body.String())
+		})
+	}
+}
+
+func TestUserTagRoutes_AdminAllowed(t *testing.T) {
+	server, adminToken, _, bookID, cleanup := setupUserTagsAuthzTestServer(t)
+	defer cleanup()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   []byte
+	}{
+		{"PUT set tags", http.MethodPut, "/api/v1/audiobooks/" + bookID + "/user-tags", []byte(`{"tags":["scifi"]}`)},
+		{"POST add tag", http.MethodPost, "/api/v1/audiobooks/" + bookID + "/user-tags", []byte(`{"tag":"fantasy"}`)},
+		{"DELETE remove tag", http.MethodDelete, "/api/v1/audiobooks/" + bookID + "/user-tags/fantasy", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, bytes.NewReader(tc.body))
+			req.Header.Set("Authorization", "Bearer "+adminToken)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, req)
+			require.NotEqual(t, http.StatusForbidden, w.Code, "admin (library.edit_metadata) should not be forbidden; body=%s", w.Body.String())
+			require.NotEqual(t, http.StatusUnauthorized, w.Code, "admin session should authenticate; body=%s", w.Body.String())
+			require.Equal(t, http.StatusOK, w.Code, "admin write should succeed; body=%s", w.Body.String())
+		})
+	}
+}

--- a/internal/server/wire_media_routes.go
+++ b/internal/server/wire_media_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_media_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-5678-cdef-901234567890
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package server
 
@@ -53,7 +53,7 @@ func (s *Server) wireMediaRoutes(
 	{
 		aiScans.POST("", s.perm(auth.PermLibraryEditMetadata), aiH.StartScan)
 		aiScans.GET("", s.perm(auth.PermLibraryView), aiH.ListScans)
-		aiScans.GET("/compare", aiH.CompareScans) // Must be before /:id to avoid conflict
+		aiScans.GET("/compare", s.perm(auth.PermLibraryView), aiH.CompareScans) // Must be before /:id to avoid conflict
 		aiScans.GET("/:id", s.perm(auth.PermLibraryView), aiH.GetScan)
 		aiScans.GET("/:id/results", s.perm(auth.PermLibraryView), aiH.GetScanResults)
 		aiScans.POST("/:id/apply", s.perm(auth.PermLibraryEditMetadata), aiH.ApplyScanResults)


### PR DESCRIPTION
## Summary

### Fix 1 (PRIMARY — authorization gap)
`internal/server/user_tags.go` — the three mutating book user-tags routes were
registered on `protected` with **no permission guard**:
- `PUT /api/v1/audiobooks/:id/user-tags`
- `POST /api/v1/audiobooks/:id/user-tags`
- `DELETE /api/v1/audiobooks/:id/user-tags/:tag`

These mutate **global** per-book tags (`SetBookTags`/`AddBookTag`/`RemoveBookTag`,
not user-scoped), so any authenticated principal — even a view-only role or a
zero-permission scoped API key — could rewrite or wipe a book's tags.

**Fix:** added `s.perm(auth.PermLibraryEditMetadata)` to all three routes,
matching the sibling write `POST /audiobooks/batch-tags` and the read side
(`GET .../user-tags` already requires `PermLibraryView`).

**Test:** `internal/server/user_tags_authz_test.go` — a viewer-role session
(has `library.view` only) gets `403` on all three write routes; an
admin/editor-role session (`library.edit_metadata`) gets `200`.

```
--- PASS: TestUserTagRoutes_ViewerForbidden (3.24s)
    --- PASS: TestUserTagRoutes_ViewerForbidden/PUT_set_tags
    --- PASS: TestUserTagRoutes_ViewerForbidden/POST_add_tag
    --- PASS: TestUserTagRoutes_ViewerForbidden/DELETE_remove_tag
--- PASS: TestUserTagRoutes_AdminAllowed (3.29s)
    --- PASS: TestUserTagRoutes_AdminAllowed/PUT_set_tags
    --- PASS: TestUserTagRoutes_AdminAllowed/POST_add_tag
    --- PASS: TestUserTagRoutes_AdminAllowed/DELETE_remove_tag
```

### Fix 2 (authz gap, low) — `ai/scans/compare` missing guard
`internal/server/wire_media_routes.go:56` — `GET /api/v1/ai/scans/compare` had
no `s.perm(...)` while every sibling `/ai/scans*` read requires
`PermLibraryView`. Added the guard; route order preserved (`/compare` still
registered before `/:id`, comment intact).

### Fix 3 (info-leak, systemic low) — raw `err.Error()` returned to clients
7 call sites used `httputil.RespondWithInternalError(c, err.Error())`, which
serializes internal error text (DB/driver detail, filesystem paths) straight
to the HTTP response. Swapped each to `httputil.InternalError(c, "<static
message>", err)`, which **logs** the real error server-side (`slog.Error`) and
returns only a generic message to the client. Status code unchanged (500).

- `internal/server/deluge_integration.go:80`
- `internal/server/deluge_discovery.go:100`
- `internal/server/handlers/cache.go:172`
- `internal/server/handlers/audiobooks/handler_tags.go:49,63,82,197`

(Two nearby `deluge_integration.go` sites that route through
`RespondWithError(..., "BAD_GATEWAY")` were left alone — those intentionally
surface upstream-connectivity failures at a distinct status code, not an
internal-error leak, and were out of the requested scope.)

### Fix 4 (DoS, minor) — unbounded per-book history `?limit=`
`internal/server/handlers/audiobooks/handler_metadata.go:35,74` —
`GetBookMetadataHistory` / `GetFieldMetadataHistory` only checked `parsed > 0`
on `?limit=`, so an attacker-supplied huge value could force an unbounded
read/allocation. Clamped both to a new `maxHistoryLimit = 1000` constant,
matching the ceiling `httputil.ParsePaginationParams` uses elsewhere. The
existing `>0` behavior for valid values is unchanged.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` on the 8 changed/added Go files: flags the 6 pre-existing
      files + the new test file for import ordering (internal `falkcorp/`
      packages before third-party `gin-gonic`/`testify`). Verified via
      `git show HEAD:<file> | gofmt -l` that **all 6 pre-existing files
      already failed stock gofmt before this PR** — this is the repo's
      established (non-stock) import convention (confirmed against
      `internal/server/server_test.go` and other neighboring files), not a
      regression introduced here.
- [x] New authz test (`TestUserTagRoutes_ViewerForbidden`,
      `TestUserTagRoutes_AdminAllowed`) — pass under `-race`.
- [x] Scoped regression run (not the full `internal/server` package — it's
      known to exceed the 600s CI timeout):
      `go test ./internal/server/... ./internal/server/handlers/... -run
      'TestUserTagRoutes|TestMetadataStateService_*|TestUndoMetadataChange_*|
      TestGetBookMetadataHistory_Handler|TestGetFieldMetadataHistory_Handler|
      TestCoverageMetadataHistory|TestCoverageUserTags|TestGetAudiobookTags*|
      TestListAllUserTags|TestGetBookUserTags|TestGetBookTagsDetailed|
      TestBatchUpdateTags*|TestAIHandler_CompareScans_*|TestNotifyDeluge*|
      TestHandleDelugeStatus_*|TestIsPathTracked_*|TestNormalizeTitle|
      TestParseTorrentNameCandidates_*|TestIsTitleTracked_*|TestSha256File*|
      TestIsContentHashTracked_*' -race` — all pass.
- [x] Route-ordering regression: confirmed `aiScans.GET("/compare", ...)` is
      still registered immediately before `aiScans.GET("/:id", ...)`.
- [x] No handler business logic changed — only guards added, the error
      helper swapped, and the limit clamped.

## COMPLETED / REMAINING / BLOCKED

- **COMPLETED: 4** — Fix 1 (user-tags authz + test), Fix 2 (ai/scans/compare
  guard), Fix 3 (7 error-leak sites → `httputil.InternalError`), Fix 4
  (history-limit clamp, 2 sites).
- **REMAINING: 0**
- **BLOCKED: 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv