### PR TITLE
fix(database): consistent work/version-group indexes + atomic narrator create (phantom-listing + id-race)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,39 @@
 - Tests: new `internal/server/user_tags_authz_test.go` proves a viewer-role
   session (library.view only) gets 403 on all three user-tags write routes and
   an admin session succeeds.
+#### July 13, 2026 - fix(database): consistent work/version-group indexes + atomic narrator create (phantom-listing + id-race)
+
+- **Phantom soft-deleted books in work & version-group listings** (backend, REVIEW-CRITICAL) — the
+  `book:work:<wid>:<id>` and `book:versiongroup:<vg>:<id>` secondary-index rows embed a full
+  serialized `Book` snapshot, but `UpdateBook` only rewrote that snapshot inside its
+  WorkID-changed / VersionGroupID-changed branches. Any edit that KEPT the same group left the
+  embedded copy stale forever — including `merge.SoftDeleteBook` / the audiobooks mutation service,
+  which set `MarkedForDeletion=true` via `UpdateBook` without touching WorkID. Result:
+  soft-deleted / merged-away books kept showing as live in `GetBooksByWorkID` /
+  `GetBooksByVersionGroup` (and stale title/author on any same-group metadata edit). Fixed by making
+  both readers treat the index as a **pointer**: the book ID is taken from the row KEY and
+  point-looked-up against the authoritative `book:<id>` row (skip if absent or `MarkedForDeletion`),
+  so the index can never desync from the source of truth again. The now-unused
+  `deserializeBookFromIndex` / `isValidULID` helpers were removed; the stale `serializeBookForIndex`
+  doc comment was corrected. (`GetBooksByAuthorIDCore` / `GetBooksBySeriesIDCore` were never
+  affected — they full-scan the authoritative `book:<id>` rows post "Task 3.4 index removal".)
+- **`DeleteBook` left dangling index rows → hard-deleted phantom** — `DeleteBook` never removed the
+  `book:work:<WorkID>:<id>` row (nor the three `book:hash` / `book:originalhash` /
+  `book:organizedhash` rows) that `CreateBook` writes, so a hard-deleted book still appeared in
+  `GetBooksByWorkID` and its hashes still resolved to a dead ID. Added the matching `batch.Delete`s
+  to the existing delete batch (the pointer-verify read above also neutralizes the work phantom, but
+  the dangling rows are now cleaned up).
+- **`CreateNarrator` id-race + non-atomic writes** — the narrator counter was a bare
+  `Get`→`++`→`Set` under NO lock (every other ID goes through `nextID` under `counterMu`) plus three
+  separate `pebble.Sync` `Set`s. Concurrent creates (reachable from import / metadata worker pools)
+  could allocate a duplicate/lost narrator ID; a crash between the writes could leave a record with
+  no name index. Fixed by re-checking existence and doing the counter read-modify-write + all three
+  writes under `counterMu` in a SINGLE atomic batch. Kept the legacy `narrator_counter` key
+  (switching to `nextID("narrator")` would use a different, uninitialized `counter:narrator` key and
+  collide with existing narrator numbering). Existing-narrator fast path preserved.
+- Tests: real-`PebbleStore` regression tests for soft-delete exclusion (work + version-group),
+  same-group metadata-edit reflection, `DeleteBook` dangling-row removal (raw key scan), and a
+  `-race` concurrent-`CreateNarrator` test asserting exactly one ID / one record.
 
 #### July 13, 2026 - fix(dedup): serialize MergeBooks + harden auto-merge journal/guards (data-loss risk)
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,26 @@ remaining-work catalog, produced, adversarially judged (3 lenses × 10), brief-v
 - Prod-data mutations (INIT-1 T7, INIT-2 T3/T6 drains, INIT-10 C8) are dry-run →
   AskUserQuestion gated in the briefs.
 
+## ✅ RESOLVED — stale work/version-group indexes showed soft/hard-deleted books as live; narrator-create id-race (2026-07-13)
+
+The `book:work:<wid>:<id>` and `book:versiongroup:<vg>:<id>` index rows embed a
+serialized `Book` snapshot that `UpdateBook` only refreshed on WorkID/VersionGroupID
+change, so a same-group edit (notably `merge.SoftDeleteBook` setting
+`MarkedForDeletion` via `UpdateBook`) left the snapshot stale — soft-deleted /
+merged-away books stayed live in `GetBooksByWorkID` / `GetBooksByVersionGroup`.
+**Fixed** by making both readers pointer-verify: take the book ID from the row KEY,
+point-look-up `book:<id>`, skip if absent / `MarkedForDeletion`. Removed the now-dead
+`deserializeBookFromIndex` / `isValidULID`; corrected the stale `serializeBookForIndex`
+doc comment. Also: `DeleteBook` now tears down the `book:work` row + the three
+`book:*hash` rows it previously leaked (dangling-row phantom); and `CreateNarrator`
+now does its existence re-check + counter read-modify-write + all three writes under
+`counterMu` in a single atomic batch (kept the legacy `narrator_counter` key — not
+`nextID("narrator")`, which uses a different uninitialized key). Author/Series `Core`
+readers were never affected (they full-scan authoritative `book:<id>` rows post
+"Task 3.4 index removal"). Tests: real-`PebbleStore` regressions + a `-race`
+concurrent-`CreateNarrator` test. See
+`docs/executive-summaries/2026-07-13-index-consistency-executive-summary.md`.
+
 ## ✅ RESOLVED — concurrent dedup merges could corrupt/vanish a version group (2026-07-13)
 
 `merge.Service.MergeBooks` (a process-wide singleton shared by `dedup.full-scan`

--- a/docs/executive-summaries/2026-07-13-index-consistency-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-index-consistency-executive-summary.md
@@ -1,0 +1,49 @@
+<!-- file: docs/executive-summaries/2026-07-13-index-consistency-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c2e5a41-9b83-4d0f-a6e1-2f4b8c9d0e1a -->
+<!-- last-edited: 2026-07-13 -->
+
+# Executive Summary: Deleted Books No Longer Haunt Work and Version Listings
+
+## What changed
+
+To open a book's "other versions" or "same work" list quickly, the app keeps a
+small shortcut index that remembers which books belong to each group. To make
+those lists load fast, the shortcut stored a little snapshot of each book right
+alongside it.
+
+The problem: that snapshot was only refreshed when a book moved to a *different*
+group. If a book was deleted, hidden, or merged away — but stayed in the same
+group — the snapshot kept the old "this book is here and active" information.
+So a book you deleted or merged could keep showing up as a live entry in its
+work list and its version list, and an edit to a book's title could fail to
+appear in those same lists.
+
+The fix stops trusting the stored snapshot. The lists now look up each book's
+real, current record before showing it, and skip anything that's been deleted or
+hidden. The shortcut is still used to find *which* books to check, so the lists
+stay fast — they just no longer show stale ghosts.
+
+We also found that permanently deleting a book left some of these shortcut
+entries behind, which is the same ghost problem from the other direction; those
+leftovers are now cleaned up when a book is deleted.
+
+## Why it mattered
+
+These are real lists people see in the app. A merged-away or deleted book
+appearing as if it were still live is confusing and makes the library look like
+it has duplicates or undead entries it doesn't actually have. No audio files
+were ever affected — this was purely about which entries the version and work
+lists displayed.
+
+## Also fixed
+
+- **Narrator creation race:** when several books were imported at once, two
+  imports could try to create the same narrator at the same moment and end up
+  with a duplicate or a half-written narrator record. Narrator creation is now
+  done as one locked, all-or-nothing step, so concurrent imports always converge
+  on a single clean record.
+
+All fixes ship together in the database layer and are covered by new tests,
+including one that deliberately creates the same narrator from many threads at
+once to prove the race is gone.

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.114.0
+// version: 1.115.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-07-13
 
@@ -39,48 +39,21 @@ func prefixEnd(prefix []byte) []byte {
 	return upper
 }
 
-// serializeBookForIndex marshals a Book to JSON for index storage.
-// This enables GetBooksBySeriesIDCore and GetBooksByAuthorIDCore to deserialize
-// directly from the index without secondary point lookups.
+// serializeBookForIndex marshals a Book to JSON for index storage in the
+// book:work:<wid>:<id> and book:versiongroup:<vg>:<id> rows.
+//
+// INDEX-CONSISTENCY: the embedded snapshot is a write-time convenience only. As
+// of the point-verify-on-read fix, GetBooksByWorkID and GetBooksByVersionGroup
+// no longer trust this value — they extract the book ID from the row KEY and
+// point-look-up the authoritative book:<id> row — so a snapshot that goes stale
+// (e.g. UpdateBook flipping MarkedForDeletion without changing WorkID) can no
+// longer surface a phantom live book. The value is retained for backward
+// compatibility with existing rows and any future value-consuming reader.
+// GetBooksBySeriesIDCore / GetBooksByAuthorIDCore do NOT use this index at all
+// (they full-scan the authoritative book:<id> rows post "Task 3.4 index
+// removal").
 func serializeBookForIndex(book *Book) ([]byte, error) {
 	return json.Marshal(book)
-}
-
-// deserializeBookFromIndex unmarshals a Book from index storage.
-// Handles both new format (full Book JSON) and old format (just book ID).
-// If the value looks like a ULID (32 chars, alphanumeric), treat it as a legacy format
-// that still needs a point lookup. Otherwise, unmarshal as Book JSON.
-func deserializeBookFromIndex(value []byte, fallbackLookup func(string) (*Book, error)) (*Book, error) {
-	if len(value) == 0 {
-		return nil, nil
-	}
-
-	// Check if this looks like a legacy format (just a ULID)
-	valueStr := string(value)
-	if len(valueStr) == 26 && isValidULID(valueStr) {
-		// Legacy format: just the book ID. Fall back to point lookup.
-		return fallbackLookup(valueStr)
-	}
-
-	// New format: full Book JSON
-	var book Book
-	if err := json.Unmarshal(value, &book); err != nil {
-		return nil, err
-	}
-	return &book, nil
-}
-
-// isValidULID checks if a string looks like a ULID (26 alphanumeric chars)
-func isValidULID(s string) bool {
-	if len(s) != 26 {
-		return false
-	}
-	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z')) {
-			return false
-		}
-	}
-	return true
 }
 
 // PebbleStore implements the Store interface using PebbleDB (LSM key-value store)
@@ -2242,6 +2215,41 @@ func (p *PebbleStore) DeleteBook(id string) error {
 		}
 	}
 
+	// Delete work-ID index (INDEX-CONSISTENCY). CreateBook writes
+	// book:work:<WorkID>:<id> but the original DeleteBook never tore it down,
+	// leaving a dangling index row that surfaced the hard-deleted book as a
+	// live phantom in GetBooksByWorkID. Mirror UpdateBook's teardown.
+	if book.WorkID != nil && *book.WorkID != "" {
+		workKey := []byte(fmt.Sprintf("book:work:%s:%s", *book.WorkID, id))
+		if err := batch.Delete(workKey, nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+
+	// Delete the three file-hash index rows CreateBook writes. Same dangling-row
+	// class as the work index above: without these, book:hash / book:originalhash
+	// / book:organizedhash lookups resolve to a hard-deleted book ID. Guards
+	// mirror CreateBook's (nil / empty-string skipped).
+	if book.FileHash != nil && *book.FileHash != "" {
+		if err := batch.Delete([]byte(fmt.Sprintf("book:hash:%s", *book.FileHash)), nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+	if book.OriginalFileHash != nil && *book.OriginalFileHash != "" {
+		if err := batch.Delete([]byte(fmt.Sprintf("book:originalhash:%s", *book.OriginalFileHash)), nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+	if book.OrganizedFileHash != nil && *book.OrganizedFileHash != "" {
+		if err := batch.Delete([]byte(fmt.Sprintf("book:organizedhash:%s", *book.OrganizedFileHash)), nil); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+
 	statePrefix := []byte(fmt.Sprintf("metadata_state:%s:", id))
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: statePrefix,
@@ -2580,6 +2588,15 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 	// Fast path: use the book:versiongroup:<gid>:<id> index added in
 	// PERF-VERSIONS so we touch O(|group|) keys instead of full-scanning
 	// the entire books table (was ~15s on 10K books).
+	//
+	// INDEX-CONSISTENCY: like GetBooksByWorkID, the index value embeds a
+	// serialized Book snapshot that UpdateBook only refreshes when the
+	// VersionGroupID changes, so a same-group edit (SoftDeleteBook sets
+	// MarkedForDeletion via UpdateBook without touching the group) leaves it
+	// stale. Treat the index as a POINTER: the trailing key segment is the book
+	// ID (a ULID, no nested colons); point-look-up the authoritative book:<id>
+	// row and skip anything absent (hard-deleted) or MarkedForDeletion
+	// (soft-deleted). This can never desync from the source of truth.
 	prefix := []byte(fmt.Sprintf("book:versiongroup:%s:", groupID))
 	upper := append([]byte(nil), prefix...)
 	upper[len(upper)-1] = ';' // ':' + 1
@@ -2589,9 +2606,11 @@ func (p *PebbleStore) GetBooksByVersionGroup(groupID string) ([]Book, error) {
 	}
 	var books []Book
 	for idxIter.First(); idxIter.Valid(); idxIter.Next() {
-		b, err := deserializeBookFromIndex(idxIter.Value(), func(id string) (*Book, error) {
-			return p.GetBookByID(id)
-		})
+		bookID := string(idxIter.Key()[len(prefix):])
+		if bookID == "" {
+			continue
+		}
+		b, err := p.GetBookByID(bookID)
 		if err != nil || b == nil {
 			continue
 		}

--- a/internal/database/pebble_store_authors.go
+++ b/internal/database/pebble_store_authors.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_authors.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1f8b9fd2-e424-4a09-9ee4-7b5b64660605
-// last-edited: 2026-07-05
+// last-edited: 2026-07-13
 
 package database
 
@@ -665,7 +665,7 @@ func (p *PebbleStore) GetAllAuthorFileCounts_Pebble() (map[int]int, error) {
 }
 
 func (p *PebbleStore) CreateNarrator(name string) (*Narrator, error) {
-	// Check if narrator already exists
+	// Fast path: return the existing narrator without taking the counter lock.
 	existing, err := p.GetNarratorByName(name)
 	if err != nil {
 		return nil, err
@@ -674,11 +674,31 @@ func (p *PebbleStore) CreateNarrator(name string) (*Narrator, error) {
 		return existing, nil
 	}
 
-	// Generate a new ID by incrementing a counter
+	// Allocation path. Serialize the counter read-modify-write plus all three
+	// writes under counterMu — the same mutex nextID uses for every other ID —
+	// so concurrent CreateNarrator calls can't allocate a duplicate/lost
+	// narrator ID, and commit record + name index + counter in a SINGLE batch so
+	// a crash can't leave a record with no name index (or an un-bumped counter).
+	// NOTE: we keep the legacy narrator_counter key rather than switching to
+	// nextID("narrator"), which uses a different (uninitialized) counter:narrator
+	// key that would collide with / orphan the existing narrator numbering. The
+	// lock is held across the pebble.Sync commit, which is acceptable on this
+	// cold create path.
+	p.counterMu.Lock()
+	defer p.counterMu.Unlock()
+
+	// Re-check under the lock: another goroutine may have created it between our
+	// fast-path check and acquiring the lock.
+	if existing, err := p.GetNarratorByName(name); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return existing, nil
+	}
+
 	counterKey := []byte("narrator_counter")
 	var nextID int
 	if val, closer, err := p.db.Get(counterKey); err == nil {
-		json.Unmarshal(val, &nextID)
+		_ = json.Unmarshal(val, &nextID)
 		closer.Close()
 	}
 	nextID++
@@ -688,23 +708,27 @@ func (p *PebbleStore) CreateNarrator(name string) (*Narrator, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	key := []byte(fmt.Sprintf("narrator:%d", nextID))
-	if err := p.db.Set(key, data, pebble.Sync); err != nil {
+	idData, err := json.Marshal(nextID)
+	if err != nil {
 		return nil, err
 	}
 
-	// Save name index
+	batch := p.db.NewBatch()
+	if err := batch.Set([]byte(fmt.Sprintf("narrator:%d", nextID)), data, nil); err != nil {
+		batch.Close()
+		return nil, err
+	}
 	nameKey := []byte(fmt.Sprintf("narrator_name:%s", util.NormalizeAuthor(name)))
-	idData, _ := json.Marshal(nextID)
-	if err := p.db.Set(nameKey, idData, pebble.Sync); err != nil {
+	if err := batch.Set(nameKey, idData, nil); err != nil {
+		batch.Close()
 		return nil, fmt.Errorf("pebble Set narrator name index: %w", err)
 	}
-
-	// Update counter
-	counterData, _ := json.Marshal(nextID)
-	if err := p.db.Set(counterKey, counterData, pebble.Sync); err != nil {
+	if err := batch.Set(counterKey, idData, nil); err != nil {
+		batch.Close()
 		return nil, fmt.Errorf("pebble Set narrator counter: %w", err)
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return nil, err
 	}
 
 	p.UpsertNarratorToMemDB(narrator)

--- a/internal/database/pebble_store_index_consistency_test.go
+++ b/internal/database/pebble_store_index_consistency_test.go
@@ -1,0 +1,250 @@
+// file: internal/database/pebble_store_index_consistency_test.go
+// version: 1.0.0
+// guid: 3f7a9c21-6b4d-4e8f-a1c2-5d6e7f8091ab
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestWorkIndexExcludesSoftDeleted covers Bug 1 for the work index: an
+// UpdateBook that sets MarkedForDeletion without changing WorkID must not leave
+// the book showing as live in GetBooksByWorkID (the index embeds a Book
+// snapshot that UpdateBook only refreshes on WorkID change).
+func TestWorkIndexExcludesSoftDeleted(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	workID := "WORK00000000000000000000AA"
+	book := &Book{
+		Title:    "Work Book",
+		FilePath: "/test/work/soft.mp3",
+		WorkID:   strPtr(workID),
+	}
+	created, err := store.CreateBook(book)
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	if got, err := store.GetBooksByWorkID(workID); err != nil || len(got) != 1 {
+		t.Fatalf("pre-delete GetBooksByWorkID = %d books, %v; want 1", len(got), err)
+	}
+
+	// Soft-delete via UpdateBook, same WorkID (mirrors SoftDeleteBook).
+	upd := *created
+	upd.MarkedForDeletion = boolPtr(true)
+	if _, err := store.UpdateBook(created.ID, &upd); err != nil {
+		t.Fatalf("UpdateBook soft-delete: %v", err)
+	}
+
+	got, err := store.GetBooksByWorkID(workID)
+	if err != nil {
+		t.Fatalf("post-delete GetBooksByWorkID: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("soft-deleted book still live in work listing: got %d books, want 0", len(got))
+	}
+}
+
+// TestVersionGroupIndexExcludesSoftDeleted covers Bug 1 for the version-group
+// index. Uses two books in the group so the fast-path (not the fallback scan)
+// is what filters out the soft-deleted one.
+func TestVersionGroupIndexExcludesSoftDeleted(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	vg := "VG0000000000000000000000BB"
+	live := &Book{Title: "Live", FilePath: "/test/vg/live.mp3", VersionGroupID: strPtr(vg)}
+	doomed := &Book{Title: "Doomed", FilePath: "/test/vg/doomed.mp3", VersionGroupID: strPtr(vg)}
+	if _, err := store.CreateBook(live); err != nil {
+		t.Fatalf("CreateBook live: %v", err)
+	}
+	createdDoomed, err := store.CreateBook(doomed)
+	if err != nil {
+		t.Fatalf("CreateBook doomed: %v", err)
+	}
+
+	if got, err := store.GetBooksByVersionGroup(vg); err != nil || len(got) != 2 {
+		t.Fatalf("pre-delete GetBooksByVersionGroup = %d, %v; want 2", len(got), err)
+	}
+
+	upd := *createdDoomed
+	upd.MarkedForDeletion = boolPtr(true)
+	if _, err := store.UpdateBook(createdDoomed.ID, &upd); err != nil {
+		t.Fatalf("UpdateBook soft-delete: %v", err)
+	}
+
+	got, err := store.GetBooksByVersionGroup(vg)
+	if err != nil {
+		t.Fatalf("post-delete GetBooksByVersionGroup: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "Live" {
+		t.Errorf("version-group listing = %d books %v; want [Live]", len(got), titles(got))
+	}
+}
+
+// TestWorkIndexReflectsMetadataEdit covers Bug 1's staleness for a benign edit:
+// a title change that keeps the same WorkID must be reflected in the listing
+// (the old embedded snapshot carried the previous title).
+func TestWorkIndexReflectsMetadataEdit(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	workID := "WORK00000000000000000000CC"
+	created, err := store.CreateBook(&Book{
+		Title:    "Old Title",
+		FilePath: "/test/work/edit.mp3",
+		WorkID:   strPtr(workID),
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	upd := *created
+	upd.Title = "New Title"
+	if _, err := store.UpdateBook(created.ID, &upd); err != nil {
+		t.Fatalf("UpdateBook title edit: %v", err)
+	}
+
+	got, err := store.GetBooksByWorkID(workID)
+	if err != nil {
+		t.Fatalf("GetBooksByWorkID: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "New Title" {
+		t.Errorf("work listing = %v; want [New Title]", titles(got))
+	}
+}
+
+// TestDeleteBookRemovesWorkIndexRow covers Bug 2: DeleteBook must remove the
+// dangling book:work index row (not just neutralize it on read).
+func TestDeleteBookRemovesWorkIndexRow(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	workID := "WORK00000000000000000000DD"
+	created, err := store.CreateBook(&Book{
+		Title:    "To Delete",
+		FilePath: "/test/work/delete.mp3",
+		WorkID:   strPtr(workID),
+	})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	if err := store.DeleteBook(created.ID); err != nil {
+		t.Fatalf("DeleteBook: %v", err)
+	}
+
+	got, err := store.GetBooksByWorkID(workID)
+	if err != nil {
+		t.Fatalf("GetBooksByWorkID: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("hard-deleted book still live in work listing: got %d, want 0", len(got))
+	}
+
+	// Raw check: no book:work:<workID>: row should remain.
+	ps, ok := store.(*PebbleStore)
+	if !ok {
+		t.Fatalf("store is not *PebbleStore: %T", store)
+	}
+	prefix := []byte(fmt.Sprintf("book:work:%s:", workID))
+	upper := append([]byte(nil), prefix...)
+	upper[len(upper)-1] = ';'
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+	if iter.First(); iter.Valid() {
+		t.Errorf("dangling book:work index row remains after DeleteBook: %q", string(iter.Key()))
+	}
+}
+
+// TestCreateNarratorConcurrent covers Bug 3: concurrent CreateNarrator("X") from
+// N goroutines must yield exactly one narrator ID and one record, with no
+// duplicate/lost writes. Run under -race.
+func TestCreateNarratorConcurrent(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	const n = 16
+	var wg sync.WaitGroup
+	ids := make([]int, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			nar, err := store.CreateNarrator("Contended Narrator")
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			ids[idx] = nar.ID
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("CreateNarrator goroutine %d: %v", i, err)
+		}
+	}
+
+	// Every call must observe the same single narrator ID.
+	first := ids[0]
+	for i, id := range ids {
+		if id != first {
+			t.Fatalf("goroutine %d got narrator ID %d, want %d (duplicate allocation)", i, id, first)
+		}
+	}
+
+	// And exactly one narrator record exists.
+	nar, err := store.GetNarratorByName("Contended Narrator")
+	if err != nil {
+		t.Fatalf("GetNarratorByName: %v", err)
+	}
+	if nar == nil || nar.ID != first {
+		t.Fatalf("GetNarratorByName = %+v; want ID %d", nar, first)
+	}
+
+	ps, ok := store.(*PebbleStore)
+	if !ok {
+		t.Fatalf("store is not *PebbleStore: %T", store)
+	}
+	iter, err := ps.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte("narrator:"),
+		UpperBound: []byte("narrator:\xff"),
+	})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+	count := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		count++
+	}
+	if count != 1 {
+		t.Errorf("narrator record count = %d; want 1", count)
+	}
+}
+
+func titles(books []Book) []string {
+	out := make([]string, len(books))
+	for i, b := range books {
+		out[i] = b.Title
+	}
+	return out
+}

--- a/internal/database/pebble_store_works.go
+++ b/internal/database/pebble_store_works.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_works.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d915e6f-133a-4fba-995b-8e4b26b04486
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package database
 
@@ -167,7 +167,17 @@ func (p *PebbleStore) DeleteWork(id string) error {
 }
 
 func (p *PebbleStore) GetBooksByWorkID(workID string) ([]Book, error) {
-	// Use book:work:<workID>:<bookID> index to avoid O(50K) full-scan
+	// Use book:work:<workID>:<bookID> index to avoid O(50K) full-scan.
+	//
+	// INDEX-CONSISTENCY: the index VALUE embeds a serialized Book snapshot, but
+	// UpdateBook only refreshes that snapshot when the WorkID itself changes — a
+	// same-work edit (notably SoftDeleteBook, which sets MarkedForDeletion via
+	// UpdateBook without touching WorkID) leaves the embedded copy stale, and a
+	// DeleteBook historically left the row dangling. So we treat the index as a
+	// POINTER: the trailing key segment is the book ID (a ULID, no nested
+	// colons), which we point-look-up against the authoritative book:<id> row.
+	// A book that is absent (hard-deleted) or MarkedForDeletion (soft-deleted)
+	// is skipped. This can never desync from the source of truth.
 	prefix := []byte(fmt.Sprintf("book:work:%s:", workID))
 	upper := append([]byte(nil), prefix...)
 	upper[len(upper)-1] = ';' // ':' + 1
@@ -179,9 +189,11 @@ func (p *PebbleStore) GetBooksByWorkID(workID string) ([]Book, error) {
 
 	var books []Book
 	for iter.First(); iter.Valid(); iter.Next() {
-		b, err := deserializeBookFromIndex(iter.Value(), func(id string) (*Book, error) {
-			return p.GetBookByID(id)
-		})
+		bookID := string(iter.Key()[len(prefix):])
+		if bookID == "" {
+			continue
+		}
+		b, err := p.GetBookByID(bookID)
 		if err != nil || b == nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

Three confirmed PebbleDB secondary-index consistency bugs in the database layer that surfaced deleted books as live phantoms in real UI listings, plus a narrator-ID race. All fixes stay entirely in `internal/database/**`.

### Bug 1 (HIGH) — stale embedded snapshot → phantom live books in work / version-group listings
- **Trigger:** `book:work:<wid>:<id>` and `book:versiongroup:<vg>:<id>` index rows embed a full serialized `Book`. `UpdateBook` only rewrote that embedded value inside its `WorkID`-changed / `VersionGroupID`-changed branches, so any edit that kept the same group left the snapshot stale forever. `merge.SoftDeleteBook` and the audiobooks mutation service set `MarkedForDeletion=true` via `UpdateBook` **without** changing WorkID.
- **Consequence:** soft-deleted / merged-away books kept showing as live in `GetBooksByWorkID` / `GetBooksByVersionGroup`; same-group metadata edits (title/author) never reflected.
- **Fix — approach (B), point-verify-on-read:** both readers now take the book ID from the row **KEY** (`...:<id>`, a ULID with no nested colons) and point-look-up the authoritative `book:<id>` row, skipping anything absent or `MarkedForDeletion`. The index is a pointer again and can never desync from the source of truth — this also neutralizes Bug 2's phantom. Removed the now-dead `deserializeBookFromIndex` / `isValidULID` and corrected the stale `serializeBookForIndex` doc comment.
- **Why (B) covers the whole class:** the only other readers named in that doc comment — `GetBooksByAuthorIDCore` / `GetBooksBySeriesIDCore` — no longer use an embedded-JSON index; post "Task 3.4 index removal" they full-scan the authoritative `book:<id>` rows, so they were never phantom-prone. `deserializeBookFromIndex` was used by ONLY these two readers (grep-verified).

### Bug 2 (HIGH) — DeleteBook left dangling index rows → hard-deleted phantom
- **Trigger:** `DeleteBook` never removed the `book:work:<WorkID>:<id>` row (nor the three `book:hash` / `book:originalhash` / `book:organizedhash` rows) that `CreateBook` writes.
- **Consequence:** a hard-deleted book still appeared live in `GetBooksByWorkID`, and its hashes still resolved to a dead ID.
- **Fix:** added the matching `batch.Delete`s (guards mirror `CreateBook`) to the existing delete batch.

### Bug 3 (MEDIUM) — CreateNarrator id-race + non-atomic 3-write
- **Trigger:** `narrator_counter` was a bare `Get`→`++`→`Set` under **no** lock, plus three separate `pebble.Sync` `Set`s. Reachable concurrently from import / metadata worker pools.
- **Consequence:** duplicate/lost narrator ID; a crash between writes could leave a record with no name index.
- **Fix:** existence re-check + counter read-modify-write + all three writes under `counterMu` in a **single** atomic batch. Kept the legacy `narrator_counter` key — `nextID("narrator")` uses a different, uninitialized `counter:narrator` key (grep-confirmed unused) that would collide with / orphan existing narrator numbering. Existing-narrator fast path preserved.

## Test results
- New real-`PebbleStore` regression tests: work + version-group soft-delete exclusion, same-group metadata-edit reflection, `DeleteBook` dangling-row removal (raw key scan), and a `-race` concurrent-`CreateNarrator` test (exactly one ID / one record).
- `go test ./internal/database/... -race -count=1` — **green** (314s full package).
- `go vet ./internal/database/...`, `gofmt -l`, `go build ./...` — all clean.

## Notes
Data-integrity fix (phantom listings from stale/dangling indexes). Executive summary added: `docs/executive-summaries/2026-07-13-index-consistency-executive-summary.md`. No key-format or schema change; no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv