### PR TITLE
fix(web): stop BookDetail load race + orphaned SSE EventSource leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- file: CHANGELOG.md -->
+<!-- version: 3.150.0 -->
 <!-- version: 3.149.0 -->
 <!-- version: 3.148.0 -->
 <!-- version: 3.147.0 -->
@@ -13,6 +14,42 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - fix(web): stop BookDetail load race + orphaned SSE EventSource leak
+
+- **BookDetail load race (frontend, wrong book shown)** — `BookDetail.tsx`'s
+  id-keyed load effect (`loadBook`, `loadVersions`, `getBookExternalIDs`,
+  the `metadata-rejections` fetch, and the detailed-tags effect) had no
+  request-sequence guard. Navigating book A -> book B quickly (or A's
+  `getBook` simply resolving after B's) let A's stale response overwrite
+  B's already-rendered state, showing the wrong book under the current URL.
+  Fixed with the same `cancelled`-flag idiom already used elsewhere in the
+  file: `loadBook`/`loadVersions` take an optional `isStale` check, and the
+  id-keyed effects skip every `setState` once their run has been
+  superseded by a newer navigation.
+- **Orphaned SSE EventSource on error (frontend, leaked API calls after
+  logout)** — `useOperationsStore.openSSE()`'s `onError` unconditionally
+  cleared `_sseSource` without ever closing the underlying `EventSource`.
+  Since `openSSE()` is only invoked once per login (`App.tsx`, no retry
+  call site), on a *terminal* error (browser gave up, `readyState ===
+  CLOSED`) the orphaned source stayed referenced by nothing — `closeSSE()`
+  (e.g. on logout) could no longer reach it, so it kept firing `onEvent` /
+  `loadFromServer()` forever, and a later `openSSE()` could spawn a second
+  live source past the `_sseSource !== null` guard. Fixed by closing +
+  nulling the ref only when `es.readyState === EventSource.CLOSED`; on a
+  *transient* drop (network blip, sleep/wake, server restart) the ref is
+  left intact so the browser's own auto-reconnect keeps working and
+  `closeSSE()` can still reach the same live source — closing
+  unconditionally here would have killed reconnect on the first blip.
+- Tests: `BookDetail.race.test.tsx` (out-of-order `getBook` resolution,
+  asserts the last-navigated book wins — verified to fail against the
+  pre-fix code) and 3 new `useOperationsStore.test.ts` cases (transient
+  error leaves the source open; terminal error closes + nulls it; a
+  subsequent `openSSE()` after a terminal error creates exactly one new
+  source). `web/src/test/setup.ts`'s mock `EventSource` gained the
+  standard `CONNECTING`/`OPEN`/`CLOSED` static constants so tests (and the
+  store) can reference `EventSource.CLOSED` the same way the real browser
+  API does.
 
 #### July 13, 2026 - fix(dedup): serialize CombineBooks + dedup.MergeBooks (close merge-race follow-ups from #1930)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 <!-- file: TODO.md -->
+<!-- version: 9.102.0 -->
 <!-- version: 9.101.0 -->
 <!-- version: 9.100.0 -->
 <!-- version: 9.99.2 -->
@@ -26,6 +27,29 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## ✅ RESOLVED — BookDetail load race + orphaned SSE EventSource leak (2026-07-13)
+
+Two confirmed frontend correctness bugs. (1) `BookDetail.tsx`'s id-keyed load
+effect had no request-sequence guard, so navigating between books quickly (or
+a slow response for the previously-viewed book) could let a stale `getBook`
+response overwrite the currently-displayed book. **Fixed** by adding a
+`cancelled`-flag guard (the idiom already used elsewhere in the file) to
+`loadBook`/`loadVersions` and the id-keyed effects (external IDs, rejection
+history, detailed tags). (2) `useOperationsStore.openSSE()`'s `onError`
+unconditionally nulled `_sseSource` without closing the underlying
+`EventSource`; since `openSSE()` is only called once per login with no retry
+site, a *terminal* error left the source orphaned — unreachable by
+`closeSSE()` (e.g. on logout), so it kept firing `loadFromServer()` forever,
+and a later `openSSE()` could open a second live source. **Fixed** by
+closing + nulling the ref only when `es.readyState === EventSource.CLOSED`;
+a *transient* drop (network blip, server restart) leaves the ref intact so
+the browser's own reconnect keeps working (closing unconditionally would
+have killed reconnect on the first blip — caught in review before merge).
+Tests: `web/src/pages/BookDetail.race.test.tsx` (out-of-order resolution,
+last navigation wins — verified to fail against the pre-fix code) and 3
+cases in `web/src/stores/useOperationsStore.test.ts` covering the
+transient/terminal split plus the exactly-one-new-source guarantee.
 
 ## ✅ RESOLVED — book user-tags write routes had no permission guard (2026-07-13)
 

--- a/web/src/pages/BookDetail.race.test.tsx
+++ b/web/src/pages/BookDetail.race.test.tsx
@@ -1,0 +1,94 @@
+// file: web/src/pages/BookDetail.race.test.tsx
+// version: 1.0.0
+// guid: 7c1d9e2a-4f5b-4a6c-9d3e-2b8f7a1c0e6d
+// last-edited: 2026-07-13
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { BookDetail } from './BookDetail';
+import * as api from '../services/api';
+
+vi.mock('../services/api', async () => {
+  const actual = await vi.importActual<typeof import('../services/api')>(
+    '../services/api'
+  );
+  return {
+    ...actual,
+    getBook: vi.fn(),
+    getBookVersions: vi.fn().mockResolvedValue([]),
+    getBookExternalIDs: vi.fn().mockResolvedValue({
+      itunes_linked: false,
+      total: 0,
+      external_ids: [],
+    }),
+    getBookFiles: vi.fn().mockResolvedValue({ files: [], count: 0 }),
+    getBookSegments: vi.fn().mockResolvedValue([]),
+    getBookTags: vi.fn().mockResolvedValue({ tags: {} }),
+    getBookTagsDetailed: vi.fn().mockResolvedValue([]),
+  };
+});
+
+function makeBook(id: string, title: string): api.Book {
+  return {
+    id,
+    title,
+    file_path: `/library/${id}/${id}.m4b`,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+// Exposes react-router's navigate function to the test so it can drive an
+// in-app navigation imperatively (simulating a user clicking to a different
+// book quickly) without needing a visible link in the rendered tree.
+let capturedNavigate: ((path: string) => void) | null = null;
+function NavCapture() {
+  capturedNavigate = useNavigate();
+  return null;
+}
+
+describe('BookDetail load race (BOOKDETAIL-RACE)', () => {
+  it('shows the last-navigated book even when its getBook response arrives before the earlier one', async () => {
+    const bookA = makeBook('book-a', 'Book A Title');
+    const bookB = makeBook('book-b', 'Book B Title');
+
+    let resolveA: ((book: api.Book) => void) | null = null;
+    let resolveB: ((book: api.Book) => void) | null = null;
+    vi.mocked(api.getBook).mockImplementation((id: string) => {
+      if (id === 'book-a') return new Promise((resolve) => { resolveA = resolve; });
+      if (id === 'book-b') return new Promise((resolve) => { resolveB = resolve; });
+      return Promise.reject(new Error(`unexpected id ${id}`));
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={['/library/book-a']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <NavCapture />
+        <Routes>
+          <Route path="/library/:id" element={<BookDetail />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Wait until the effect for book-a has kicked off its getBook call.
+    await waitFor(() => expect(resolveA).not.toBeNull());
+
+    // Navigate to book-b BEFORE book-a's request resolves. This is the
+    // "navigate quickly between books" trigger for BOOKDETAIL-RACE.
+    act(() => { capturedNavigate!('/library/book-b'); });
+    await waitFor(() => expect(resolveB).not.toBeNull());
+
+    // Resolve book-b FIRST, then book-a: the out-of-order arrival that used
+    // to let book-a's stale setBook overwrite book-b's already-rendered data.
+    await act(async () => { resolveB!(bookB); });
+    await act(async () => { resolveA!(bookA); });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Book B Title').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText('Book A Title')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDetail.tsx
-// version: 1.51.0
+// version: 1.52.0
 // guid: 4d2f7c6a-1b3e-4c5d-8f7a-9b0c1d2e3f4a
-// last-edited: 2026-06-22
+// last-edited: 2026-07-13
 
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -115,18 +115,29 @@ export const BookDetail = () => {
   // Load detailed tags for source attribution (CAT-1 / PR #548)
   useEffect(() => {
     if (!id) return;
+    let cancelled = false;
     api.getBookTagsDetailed(id)
-      .then(setDetailedTags)
-      .catch(() => setDetailedTags([]));
+      .then((data) => { if (!cancelled) setDetailedTags(data); })
+      .catch(() => { if (!cancelled) setDetailedTags([]); });
+    return () => { cancelled = true; };
   }, [id, filesRefreshKey]);
 
-  const loadBook = useCallback(async () => {
+  // loadBook/loadVersions accept an optional `isStale` check so the
+  // id-keyed load effect below can detect when its `id` has been
+  // superseded by a faster navigation and skip applying a stale response
+  // (BOOKDETAIL-RACE: navigating book A -> book B quickly, or A's response
+  // simply arriving after B's, used to let A's setBook overwrite B's).
+  // Callers outside that effect (button handlers, onRefresh, etc.) call
+  // these with no argument, which is unconditional/unchanged behavior.
+  const loadBook = useCallback(async (isStale?: () => boolean) => {
     if (!id) return;
     setLoading(true);
     try {
       const data = await api.getBook(id);
+      if (isStale?.()) return;
       setBook(data);
     } catch (error) {
+      if (isStale?.()) return;
       if (error instanceof api.ApiError) {
         if (error.status === 404) {
           setBook(null);
@@ -141,7 +152,9 @@ export const BookDetail = () => {
       console.error('Failed to load book', error);
       toast('Failed to load audiobook details.', 'error');
     } finally {
-      setLoading(false);
+      // Don't clear loading for a stale request — a newer request for a
+      // different id may still be in flight and already owns `loading`.
+      if (!isStale?.()) setLoading(false);
     }
   }, [id, navigate, toast]);
 
@@ -156,22 +169,32 @@ export const BookDetail = () => {
     }
   }, [id]);
 
-  const loadVersions = useCallback(async () => {
+  const loadVersions = useCallback(async (isStale?: () => boolean) => {
     if (!id) return;
     try {
       const data = await api.getBookVersions(id);
+      if (isStale?.()) return;
       setVersions(data);
     } catch (error) {
+      if (isStale?.()) return;
       console.error('Failed to load versions', error);
     }
   }, [id]);
 
 
+  // Primary id-keyed load. A `cancelled` flag (same idiom used elsewhere in
+  // this file, e.g. the linkSearch and tag-preload effects) guards every
+  // setState below so a slow/out-of-order response for a book we've already
+  // navigated away from can't overwrite state for the book now on screen
+  // (BOOKDETAIL-RACE).
   useEffect(() => {
-    loadBook();
-    loadVersions();
+    let cancelled = false;
+    const isStale = () => cancelled;
+    loadBook(isStale);
+    loadVersions(isStale);
     // Load external ID info (iTunes linkage)
     api.getBookExternalIDs(id!).then((data) => {
+      if (cancelled) return;
       setItunesLinked(data.itunes_linked);
       setItunesPidCount(data.total);
       setItunesExternalIDs(data.external_ids.filter((e) => e.source === 'itunes' && !e.tombstoned));
@@ -179,8 +202,9 @@ export const BookDetail = () => {
     // Load rejection history (META-REJ-1)
     fetch(`/api/v1/audiobooks/${id}/metadata-rejections`, { credentials: 'include' })
       .then((r) => r.ok ? r.json() : Promise.reject(r))
-      .then((data) => setRejections(data.rejections ?? []))
+      .then((data) => { if (!cancelled) setRejections(data.rejections ?? []); })
       .catch(() => {});
+    return () => { cancelled = true; };
   }, [id, loadBook, loadVersions]);
 
   // Inline version link search

--- a/web/src/stores/useOperationsStore.test.ts
+++ b/web/src/stores/useOperationsStore.test.ts
@@ -1,7 +1,7 @@
 // file: web/src/stores/useOperationsStore.test.ts
-// version: 2.3.0
+// version: 2.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-05-08
+// last-edited: 2026-07-13
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useOperationsStore } from './useOperationsStore';
@@ -195,5 +195,86 @@ describe('useOperationsStore', () => {
     });
 
     expect(useOperationsStore.getState().latestLogEvent).toBeNull();
+  });
+
+  it('onError leaves a transiently-erroring (still auto-reconnecting) EventSource alone', () => {
+    vi.useFakeTimers();
+    useOperationsStore.setState({ _sseSource: null } as Parameters<typeof useOperationsStore.setState>[0]);
+    vi.mocked(api.getOperationTimeline).mockResolvedValue([]);
+
+    const closeSpy = vi.fn();
+    // readyState CONNECTING (0): the browser is auto-reconnecting this exact
+    // source on its own — matches a transient drop / server restart.
+    const fakeSource = { close: closeSpy, readyState: EventSource.CONNECTING } as unknown as EventSource;
+    let capturedOnError: ((err: Event) => void) | null = null;
+    vi.mocked(api.openOperationsSSE).mockImplementation(({ onError }) => {
+      capturedOnError = onError ?? null;
+      return fakeSource;
+    });
+
+    useOperationsStore.getState().openSSE();
+    expect(useOperationsStore.getState()._sseSource).toBe(fakeSource);
+
+    capturedOnError!(new Event('error'));
+
+    // Must NOT close or null the ref — openSSE() is only ever called once
+    // per login (see App.tsx), so nulling here with nothing to re-open it
+    // would kill live reconnect on the first blip. Leaving the ref intact
+    // also means closeSSE() (e.g. on logout) can still reach and close this
+    // same source, so there's no orphan.
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(useOperationsStore.getState()._sseSource).toBe(fakeSource);
+
+    vi.useRealTimers();
+  });
+
+  it('onError closes and clears _sseSource once the EventSource has permanently given up (no orphaned reconnecting source)', () => {
+    vi.useFakeTimers();
+    useOperationsStore.setState({ _sseSource: null } as Parameters<typeof useOperationsStore.setState>[0]);
+    vi.mocked(api.getOperationTimeline).mockResolvedValue([]);
+
+    const closeSpy = vi.fn();
+    // readyState CLOSED (2): the browser has given up for good — this is the
+    // only case that should tear down and null the ref.
+    const fakeSource = { close: closeSpy, readyState: EventSource.CLOSED } as unknown as EventSource;
+    let capturedOnError: ((err: Event) => void) | null = null;
+    vi.mocked(api.openOperationsSSE).mockImplementation(({ onError }) => {
+      capturedOnError = onError ?? null;
+      return fakeSource;
+    });
+
+    useOperationsStore.getState().openSSE();
+    expect(useOperationsStore.getState()._sseSource).toBe(fakeSource);
+    expect(capturedOnError).not.toBeNull();
+
+    capturedOnError!(new Event('error'));
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(useOperationsStore.getState()._sseSource).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('a subsequent openSSE after a terminal error creates exactly one new EventSource', () => {
+    useOperationsStore.setState({ _sseSource: null } as Parameters<typeof useOperationsStore.setState>[0]);
+    vi.mocked(api.getOperationTimeline).mockResolvedValue([]);
+    vi.mocked(api.openOperationsSSE).mockClear();
+
+    let capturedOnError: ((err: Event) => void) | null = null;
+    const firstSource = { close: vi.fn(), readyState: EventSource.CLOSED } as unknown as EventSource;
+    const secondSource = { close: vi.fn(), readyState: EventSource.OPEN } as unknown as EventSource;
+    vi.mocked(api.openOperationsSSE)
+      .mockImplementationOnce(({ onError }) => {
+        capturedOnError = onError ?? null;
+        return firstSource;
+      })
+      .mockImplementationOnce(() => secondSource);
+
+    useOperationsStore.getState().openSSE();
+    capturedOnError!(new Event('error'));
+    useOperationsStore.getState().openSSE();
+
+    expect(api.openOperationsSSE).toHaveBeenCalledTimes(2);
+    expect(useOperationsStore.getState()._sseSource).toBe(secondSource);
   });
 });

--- a/web/src/stores/useOperationsStore.ts
+++ b/web/src/stores/useOperationsStore.ts
@@ -1,6 +1,7 @@
 // file: web/src/stores/useOperationsStore.ts
-// version: 3.6.0
+// version: 3.6.2
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
+// last-edited: 2026-07-13
 
 import { create } from 'zustand';
 import * as api from '../services/api';
@@ -377,10 +378,25 @@ export const useOperationsStore = create<OperationsState>()((set, get) => ({
         }
       },
       onError: () => {
-        // On error, clear the source so the next openSSE() call reconnects.
-        // The browser EventSource already retries automatically, but if the
-        // connection is truly closed we want the next call to re-open it.
-        set({ _sseSource: null });
+        // The native EventSource auto-reconnects on TRANSIENT drops (network
+        // blip, laptop sleep/wake, a server restart) — on those it sets
+        // readyState back to CONNECTING and keeps this exact `es` alive with
+        // no action needed from us. It only reaches CLOSED when it has
+        // permanently given up (e.g. a fatal HTTP status). openSSE() is only
+        // ever called once per login (App.tsx effect keyed on auth state),
+        // with nothing that re-invokes it on error, so unconditionally
+        // closing `es` here would kill live reconnect on the first blip.
+        //
+        // So: only tear down + clear the ref once the browser has truly
+        // given up (readyState === CLOSED). That still fixes the leak this
+        // guard exists for — on a transient drop the ref stays valid so
+        // closeSSE() (e.g. on logout) can still reach and close this same
+        // `es`, and the `_sseSource !== null` guard keeps blocking a second
+        // openSSE() from spawning a duplicate live source.
+        if (es.readyState === EventSource.CLOSED) {
+          es.close();
+          set({ _sseSource: null });
+        }
         // Reconcile after a likely server restart: pull the timeline so any
         // ops the server auto-resumed (which won't emit op.created) show up
         // in the bell again. Delay so we don't fire during transient blips.

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,7 @@
 // file: web/src/test/setup.ts
-// version: 1.0.5
+// version: 1.0.6
 // guid: 8f9a0b1c-2d3e-4f5a-6b7c-8d9e0f1a2b3c
+// last-edited: 2026-07-13
 
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
@@ -61,12 +62,20 @@ Object.defineProperty(global, 'localStorage', {
   },
 });
 
-// Mock EventSource (SSE) for tests
+// Mock EventSource (SSE) for tests. Mirrors the native readyState numbering
+// (0 CONNECTING / 1 OPEN / 2 CLOSED) and exposes the same static constants,
+// since store code (useOperationsStore's openSSE) branches on
+// `es.readyState === EventSource.CLOSED` to distinguish a transient,
+// auto-reconnecting drop from a terminal one.
 class MockEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
   url: string;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
-  readyState = 1;
+  readyState = MockEventSource.OPEN;
 
   constructor(url: string) {
     this.url = url;
@@ -75,7 +84,7 @@ class MockEventSource {
   addEventListener() {}
   removeEventListener() {}
   close() {
-    this.readyState = 2;
+    this.readyState = MockEventSource.CLOSED;
   }
 }
 


### PR DESCRIPTION
## Summary

Two confirmed frontend correctness bugs, fixed surgically in the two files identified.

### Bug 1 — BookDetail load race (shows the wrong book)

**Trigger:** navigating book A → book B quickly, or A's `getBook` response simply arriving after B's.

**Consequence:** `BookDetail.tsx`'s id-keyed load effect (`loadBook`, `loadVersions`, `getBookExternalIDs`, the `metadata-rejections` fetch, and the detailed-tags effect) had no request-sequence guard, so the stale A response could overwrite B's already-rendered state — the page shows book A while the URL/rest of the UI is on book B.

**Fix:** the same `cancelled`-flag idiom already used elsewhere in this file (linkSearch effect, tag-preload effect). `loadBook`/`loadVersions` take an optional `isStale` check (default `undefined` — every other call site, e.g. button handlers and `onRefresh`, is unaffected); the id-keyed effect and the detailed-tags effect each get a `cancelled` flag + cleanup, skipping every `setState` (`setBook`, `setVersions`, `setItunesLinked`/`setItunesPidCount`/`setItunesExternalIDs`, `setRejections`, `setDetailedTags`) once superseded.

### Bug 2 — orphaned EventSource on SSE error (leaked API calls after logout)

**Trigger:** any SSE error on the operations stream. Native `EventSource` fires `onerror` on both transient drops (network blip, sleep/wake, server restart — where the browser auto-reconnects on its own) and terminal ones (`readyState === CLOSED`, browser has given up for good).

**Consequence found:** `openSSE`'s `onError` unconditionally cleared `_sseSource` without calling `es.close()`. Since `openSSE()` is only ever invoked once per login (`App.tsx`, effect keyed on auth state, no retry call site), a *terminal* error left the source orphaned — `closeSSE()` (called from `App.tsx` on logout/unmount) could no longer reach it via the store, so its `onEvent` handlers kept calling `loadFromServer()` forever, and a later `openSSE()` could spawn a second live source past the `_sseSource !== null` guard.

**First-pass fix rejected in review:** unconditionally calling `es.close()` in `onError` (as initially drafted) would have fixed the leak but broken live reconnect on the very first transient network blip or server restart, since nothing re-invokes `openSSE()` afterward. Caught before merge via a second pass with an independent reviewer.

**Fix shipped:** close + null the ref only when `es.readyState === EventSource.CLOSED`. On a transient drop the ref is left intact, so the browser's own reconnect keeps working *and* `closeSSE()` can still reach the same live source (no orphan). `web/src/test/setup.ts`'s mock `EventSource` gained the standard `CONNECTING`/`OPEN`/`CLOSED` static constants so this can be exercised in tests the same way the real browser API works.

## Test results

- `npx tsc --noEmit -p .` — clean, no errors.
- `make web-lint` (full `eslint .`) — 0 errors, 24 pre-existing warnings in untouched files.
- `make web-test` (full vitest suite) — **368/368 passed**, 57 test files.
- `npm run build` (production Vite build) — succeeds.
- New/extended tests, all passing:
  - `web/src/pages/BookDetail.race.test.tsx` — mocks `getBook` so book-A's promise resolves *after* book-B's; navigates A→B mid-flight; asserts the final rendered title is B, not A. **Verified this test fails against the pre-fix code** (temporarily stashed the `BookDetail.tsx` fix and re-ran — red as expected, then restored).
  - `web/src/stores/useOperationsStore.test.ts` — 3 new cases: (1) a transient error (`readyState: CONNECTING`) does not close the source or null the ref, (2) a terminal error (`readyState: CLOSED`) closes and nulls it, (3) a subsequent `openSSE()` after a terminal error creates exactly one new `EventSource`. **Verified case (1) fails against an unconditional-close version** of the fix (temporarily patched, re-ran — red as expected, then restored).

## Test plan

- [x] Typecheck clean
- [x] Lint clean on changed files (and full `eslint .`)
- [x] Full frontend test suite green (368/368)
- [x] Production build succeeds
- [x] New regression tests independently verified to fail against the un-fixed code for both bugs
- [x] CHANGELOG.md / TODO.md updated in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv