### PR TITLE
fix(metafetch): route print vs audiobook-release year correctly + stop OpenLibrary language mislabel (data-corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.150.0 -->
-<!-- version: 3.149.0 -->
-<!-- version: 3.148.0 -->
-<!-- version: 3.147.0 -->
-<!-- version: 3.146.0 -->
-<!-- version: 3.145.0 -->
-<!-- version: 3.142.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -50,6 +44,36 @@
   standard `CONNECTING`/`OPEN`/`CLOSED` static constants so tests (and the
   store) can reference `EventSource.CLOSED` the same way the real browser
   API does.
+#### July 13, 2026 - fix(metafetch): route print vs audiobook-release year + stop OpenLibrary language mislabel (data-corruption)
+
+- **Print year no longer clobbers a correct audiobook release year** (backend, data-integrity) —
+  `meta.PublishYear` was OVERLOADED: Audible/Audnexus report the audiobook's release year, while Open
+  Library/Google Books/Hardcover/Wikipedia report the work's original PRINT year (often decades
+  earlier). `ApplyMetadataToBook` wrote `PublishYear` into `book.AudiobookReleaseYear`
+  unconditionally and never set `book.PrintYear`, so a Google/Open Library candidate overwrote a
+  correct Audible release year — which then propagated to the file `year` tag via
+  `service_writeback.go`. Fixed with a `PublishYearIsAudiobookRelease` year-kind flag on
+  `BookMetadata` (default = print; only Audible/Audnexus set it true). Apply now routes release →
+  `AudiobookReleaseYear` (unchanged behavior) and print → `PrintYear`, gated so a present year is
+  never overwritten with 0 and the two fields never cross-contaminate. The candidate-apply path
+  derives the kind from `candidate.Source` via `metadata.SourceProducesAudiobookReleaseYear`.
+  `RecordChangeHistory` and `persistFetchedMetadata` provenance now key off the routed field too.
+- **Open Library no longer mislabels language from an unordered array** (backend, data-integrity) —
+  the search-doc `Language`/`Publisher`/`ISBN` arrays are UNORDERED aggregates across editions;
+  `Language[0]` picked an arbitrary edition. Because language is persisted as a
+  `metadata:language:<code>` system tag that drives the review language filter, a book whose
+  first-listed edition was a translation got mislabeled and mis-filtered. `SearchByTitle` /
+  `SearchByTitleAndAuthor` now set language only when the editions agree (new `unambiguousLanguage`
+  helper); when ambiguous, no tag is set — no value beats a wrong one. `Publisher`/`ISBN` `[0]` are
+  intentionally left (not filter-driving tags; skipping would broadly regress publisher population,
+  and any ISBN is a valid identifier).
+- Note: the metadata fetch cache stores parsed `[]BookMetadata`; pre-deploy Audible/Audnexus cache
+  entries deserialize with the new flag `false` and transiently route their release year to
+  `PrintYear` until the cache TTL (`MetadataFetchCacheTTLDays`) expires. This is bounded and
+  non-clobbering (it fails to populate `AudiobookReleaseYear`; it never overwrites a good one).
+- Tests: year-routing + no-overwrite (`TestApplyMetadataToBook_YearRouting`), Open Library language
+  ambiguity (`TestUnambiguousLanguage`, `TestSearchByTitle_AmbiguousLanguageSkipped`), and
+  Audible/Audnexus flag assertions. `internal/metafetch` + `internal/metadata` green under `-race`.
 
 #### July 13, 2026 - fix(dedup): serialize CombineBooks + dedup.MergeBooks (close merge-race follow-ups from #1930)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,5 @@
 <!-- file: TODO.md -->
 <!-- version: 9.102.0 -->
-<!-- version: 9.101.0 -->
-<!-- version: 9.100.0 -->
-<!-- version: 9.99.2 -->
-<!-- version: 9.99.1 -->
-<!-- version: 9.99.2 -->
-<!-- version: 9.99.0 -->
-<!-- version: 9.98.0 -->
-<!-- version: 9.97.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -50,6 +42,31 @@ Tests: `web/src/pages/BookDetail.race.test.tsx` (out-of-order resolution,
 last navigation wins — verified to fail against the pre-fix code) and 3
 cases in `web/src/stores/useOperationsStore.test.ts` covering the
 transient/terminal split plus the exactly-one-new-source guarantee.
+## ✅ RESOLVED — metadata print-year clobbered audiobook release year; Open Library language mislabel (2026-07-13)
+
+`meta.PublishYear` was OVERLOADED: Audible/Audnexus = audiobook release year,
+Open Library/Google Books/Hardcover/Wikipedia = original print year (often
+decades earlier). `ApplyMetadataToBook` wrote it into `AudiobookReleaseYear`
+unconditionally and never set `PrintYear`, so a print-year candidate overwrote a
+correct release year and reached the file `year` tag via `service_writeback.go`.
+**Fixed** with a `PublishYearIsAudiobookRelease` year-kind flag on `BookMetadata`
+(default print; only Audible/Audnexus set true); apply routes release →
+`AudiobookReleaseYear`, print → `PrintYear`, never cross-contaminating. Candidate
+path derives the kind from `candidate.Source` via
+`metadata.SourceProducesAudiobookReleaseYear`. Also **fixed** Open Library
+`Language[0]` picking an arbitrary edition from an unordered array (persisted as a
+`metadata:language:<code>` filter-driving tag) — `SearchByTitle`/
+`SearchByTitleAndAuthor` now set language only when editions agree
+(`unambiguousLanguage`). Tests: `TestApplyMetadataToBook_YearRouting`,
+`TestUnambiguousLanguage`, `TestSearchByTitle_AmbiguousLanguageSkipped`, plus
+Audible/Audnexus flag assertions.
+
+- **Optional follow-up (deferred, low priority):** the fetch cache stores parsed
+  `[]BookMetadata`; pre-deploy Audible/Audnexus entries deserialize with the flag
+  `false` and transiently route release year to `PrintYear` until TTL expiry
+  (bounded, non-clobbering). Could be hardened by re-deriving the flag from
+  `src.Name()` at the two cache-hit replay sites (`service_fetch.go`,
+  `service_search.go`) — left out to keep this PR off `service_search.go`.
 
 ## ✅ RESOLVED — book user-tags write routes had no permission guard (2026-07-13)
 

--- a/docs/executive-summaries/2026-07-13-metadata-year-language-corruption-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-metadata-year-language-corruption-executive-summary.md
@@ -1,0 +1,64 @@
+<!-- file: docs/executive-summaries/2026-07-13-metadata-year-language-corruption-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4a1f8e2c-9b73-4d16-8e05-2c7a6f9b1d38 -->
+<!-- last-edited: 2026-07-13 -->
+
+# Executive Summary: Stopping Wrong Publication Year and Language on Books
+
+## Executive Summary
+
+When the app pulled book details from an outside catalog, two kinds of wrong
+information could quietly replace correct information — and, in the case of the
+year, get written into the audio files themselves. We fixed both so the correct
+value is kept and the wrong value never overwrites it.
+
+## What was wrong, in plain terms
+
+**1. The wrong year could overwrite the right year.**
+
+There are two different "years" for an audiobook: the year the *audiobook* was
+released (from Audible), and the year the *original book* was first printed
+(from book catalogs like Open Library and Google Books). For a classic, these
+can be decades apart — a 1937 novel with a 2010 audiobook edition.
+
+The app treated them as one field. Whenever it matched a book against a book
+catalog, it copied that catalog's *print* year into the *audiobook release year*
+slot, painting over a correct Audible release year. Worse, that value then got
+stamped into the audio file's own `year` tag — so the mistake spread from our
+records into the files on disk.
+
+**2. The wrong language could get attached.**
+
+Open Library returns a book's languages as an unordered jumble across every
+edition ever published. The app just took the first one in the list. If the
+first listed edition happened to be a translation, the book got tagged with that
+language — and because that tag drives the "filter by language" feature in
+review, an English book could quietly disappear from the English view.
+
+## What we changed
+
+1. **We taught the app which kind of year it's looking at.** Audible and its
+   sister source now mark their year as an *audiobook release* year; every book
+   catalog's year is treated as an *original print* year. Release years go to the
+   release-year field, print years go to a separate print-year field, and neither
+   can overwrite the other. A print-year match can no longer touch a correct
+   audiobook release year.
+
+2. **We stopped guessing the language.** When Open Library's editions disagree on
+   language, the app now attaches no language at all — because no label is better
+   than a wrong one that hides the book from its own language filter. When the
+   editions agree, it still sets the language as before.
+
+## Why it matters
+
+Both bugs silently replaced correct data with wrong data, and the year bug
+reached all the way into the audio files' embedded tags — the hardest kind of
+error to notice or trace. Publication year and language are also core to how a
+library is browsed and filtered, so a wrong value doesn't just look bad, it makes
+books hard to find.
+
+The fix only ever keeps or correctly routes this data; it never erases a good
+value, and it ships with tests that reproduce each corruption and prove it no
+longer happens. It can be rolled back as a single change. One bounded, harmless
+after-effect: for a short while, previously-cached Audible results may leave the
+audiobook release year unfilled (never wrong) until the cache naturally refreshes.

--- a/internal/metadata/audible.go
+++ b/internal/metadata/audible.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/audible.go
-// version: 1.5.3
+// version: 1.6.0
 // guid: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -280,7 +281,9 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 		meta.Narrator = strings.Join(narratorNames, ", ")
 	}
 
-	// Year from issue_date or release_date
+	// Year from issue_date or release_date — this is the AUDIOBOOK release year,
+	// not the work's original print year. Flag it so apply routes it to
+	// Book.AudiobookReleaseYear (never PrintYear).
 	dateStr := p.IssueDate
 	if dateStr == "" {
 		dateStr = p.ReleaseDate
@@ -288,6 +291,7 @@ func (c *AudibleClient) productToMetadata(p *audibleProduct) BookMetadata {
 	if len(dateStr) >= 4 {
 		fmt.Sscanf(dateStr[:4], "%d", &meta.PublishYear)
 	}
+	meta.PublishYearIsAudiobookRelease = true
 
 	// Cover image — prefer largest available
 	for _, size := range []string{"500", "252", "128"} {

--- a/internal/metadata/audible_test.go
+++ b/internal/metadata/audible_test.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/audible_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b8c7d6e5-f4a3-2b1c-0d9e-8f7a6b5c4d3e
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -84,6 +85,9 @@ func TestAudibleClient_SearchByTitle(t *testing.T) {
 	}
 	if r.PublishYear != 2024 {
 		t.Errorf("year: got %d", r.PublishYear)
+	}
+	if !r.PublishYearIsAudiobookRelease {
+		t.Error("Audible PublishYear must be flagged as an audiobook release year")
 	}
 	if r.CoverURL != "https://example.com/cover.jpg" {
 		t.Errorf("cover: got %q", r.CoverURL)

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/audnexus.go
-// version: 2.3.2
+// version: 2.4.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -223,12 +224,15 @@ func (c *AudnexusClient) bookToMetadata(book *audnexusBook) *BookMetadata {
 		meta.Narrator = strings.Join(narratorNames, ", ")
 	}
 
-	// Year from releaseDate or copyright
+	// Year from releaseDate or copyright — this is the AUDIOBOOK release year,
+	// not the work's original print year. Flag it so apply routes it to
+	// Book.AudiobookReleaseYear (never PrintYear).
 	if len(book.ReleaseDate) >= 4 {
 		fmt.Sscanf(book.ReleaseDate[:4], "%d", &meta.PublishYear)
 	} else if book.Copyright > 0 {
 		meta.PublishYear = book.Copyright
 	}
+	meta.PublishYearIsAudiobookRelease = true
 
 	// Series
 	if book.SeriesPrimary != nil {

--- a/internal/metadata/audnexus_test.go
+++ b/internal/metadata/audnexus_test.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/audnexus_test.go
-// version: 2.1.0
+// version: 2.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-c5d6e7f8a9b0
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -71,6 +72,9 @@ func TestAudnexusClient_LookupByASIN(t *testing.T) {
 	}
 	if meta.PublishYear != 2012 {
 		t.Errorf("expected year 2012, got %d", meta.PublishYear)
+	}
+	if !meta.PublishYearIsAudiobookRelease {
+		t.Error("Audnexus PublishYear must be flagged as an audiobook release year")
 	}
 	if meta.ISBN != "9780007489943" {
 		t.Errorf("expected ISBN, got %q", meta.ISBN)

--- a/internal/metadata/openlibrary.go
+++ b/internal/metadata/openlibrary.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/openlibrary.go
-// version: 1.8.2
+// version: 1.9.0
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -119,6 +120,17 @@ type BookMetadata struct {
 	SeriesPosition string
 	DurationSec    int // audio runtime in seconds (Audible: runtime_length_min × 60)
 
+	// PublishYearIsAudiobookRelease disambiguates the OVERLOADED PublishYear.
+	// When true, PublishYear is the audiobook's release/issue year (Audible,
+	// Audnexus). When false (the default), it is the work's original PRINT /
+	// first-publication year (Open Library, Google Books, Hardcover, Wikipedia),
+	// which is often decades earlier. ApplyMetadataToBook routes the year to the
+	// correct Book field by this flag: a print/work year must NEVER be written to
+	// AudiobookReleaseYear (it clobbers a correct release year and reaches the
+	// file `year` tag via writeback), and a release year must never land in
+	// PrintYear.
+	PublishYearIsAudiobookRelease bool
+
 	// Audible-specific ratings (1–5 scale). Performance and Story are
 	// audiobook-specific dimensions not available from other sources.
 	AudibleRatingOverall     float64
@@ -135,6 +147,30 @@ type BookMetadata struct {
 	// response group. Each element is a ladder node name (e.g. "Science Fiction",
 	// "Space Opera"). Applied as book_tags with source="audible_category".
 	CategoryTags []string
+}
+
+// unambiguousLanguage returns the single distinct (case-insensitive) value in
+// vals, or "" when vals is empty or holds differing values. Open Library search
+// docs return Language as an UNORDERED aggregate across every edition, so
+// Language[0] is not "most relevant" — a book whose first-listed edition is a
+// translation would be mislabeled. That value is persisted as a
+// metadata:language:<code> system tag driving the review language filter, so a
+// guessed language is actively harmful: when ambiguous we set none, because no
+// tag beats a wrong one.
+func unambiguousLanguage(vals []string) string {
+	first := ""
+	for _, v := range vals {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if first == "" {
+			first = v
+		} else if !strings.EqualFold(v, first) {
+			return "" // ambiguous — differing languages across editions
+		}
+	}
+	return first
 }
 
 // SearchByTitle searches for books by title. Checks local dump store first if available.
@@ -197,8 +233,9 @@ func (c *OpenLibraryClient) SearchByTitle(ctx context.Context, title string) ([]
 			metadata.ISBN = doc.ISBN[0]
 		}
 
-		if len(doc.Language) > 0 {
-			metadata.Language = doc.Language[0]
+		// Only set language when the editions agree — see unambiguousLanguage.
+		if lang := unambiguousLanguage(doc.Language); lang != "" {
+			metadata.Language = lang
 		}
 
 		if doc.CoverI > 0 {
@@ -260,8 +297,9 @@ func (c *OpenLibraryClient) SearchByTitleAndAuthor(ctx context.Context, title, a
 			metadata.ISBN = doc.ISBN[0]
 		}
 
-		if len(doc.Language) > 0 {
-			metadata.Language = doc.Language[0]
+		// Only set language when the editions agree — see unambiguousLanguage.
+		if lang := unambiguousLanguage(doc.Language); lang != "" {
+			metadata.Language = lang
 		}
 
 		if doc.CoverI > 0 {

--- a/internal/metadata/openlibrary_test.go
+++ b/internal/metadata/openlibrary_test.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/openlibrary_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -419,5 +420,61 @@ func TestNewOpenLibraryClientWithBaseURL_TrailingSlash(t *testing.T) {
 
 	if client.baseURL != "https://example.com" {
 		t.Errorf("Expected trailing slash to be trimmed, got %q", client.baseURL)
+	}
+}
+
+// TestUnambiguousLanguage covers the helper directly.
+func TestUnambiguousLanguage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"eng"}, "eng"},
+		{"duplicate_same", []string{"eng", "eng"}, "eng"},
+		{"case_insensitive_same", []string{"eng", "ENG"}, "eng"},
+		{"ambiguous_differ", []string{"spa", "eng"}, ""},
+		{"blank_then_single", []string{"", "spa"}, "spa"},
+	}
+	for _, c := range cases {
+		if got := unambiguousLanguage(c.in); got != c.want {
+			t.Errorf("%s: unambiguousLanguage(%v) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+// TestSearchByTitle_AmbiguousLanguageSkipped proves an Open Library search doc
+// whose editions list differing languages does NOT persist a guessed language,
+// while a single-language doc still does. Guessing Language[0] on an unordered
+// array mislabels a book whose first-listed edition is a translation, because
+// the value becomes a metadata:language:<code> system tag driving the review
+// language filter.
+func TestSearchByTitle_AmbiguousLanguageSkipped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"numFound":2,
+			"start":0,
+			"docs":[
+				{"title":"Translated First","language":["spa","eng"]},
+				{"title":"English Only","language":["eng"]}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewOpenLibraryClientWithBaseURL(server.URL)
+	results, err := client.SearchByTitle(context.Background(), "anything")
+	if err != nil {
+		t.Fatalf("SearchByTitle failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Language != "" {
+		t.Errorf("ambiguous language should be skipped, got %q", results[0].Language)
+	}
+	if results[1].Language != "eng" {
+		t.Errorf("single-language doc should set language 'eng', got %q", results[1].Language)
 	}
 }

--- a/internal/metadata/source.go
+++ b/internal/metadata/source.go
@@ -1,10 +1,26 @@
 // file: internal/metadata/source.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
 
 package metadata
 
 import "context"
+
+// SourceProducesAudiobookReleaseYear reports whether the named metadata source
+// populates PublishYear with an audiobook RELEASE/issue year (Audible,
+// Audnexus) rather than a print/work publication year. The candidate-apply path
+// no longer has the source's BookMetadata (and its PublishYearIsAudiobookRelease
+// flag) in scope — only the candidate's Source name survives — so it derives the
+// year kind from the source name here. Uses the clients' own Name() values so it
+// can never drift from what search stores in MetadataCandidate.Source.
+func SourceProducesAudiobookReleaseYear(sourceName string) bool {
+	switch sourceName {
+	case (&AudibleClient{}).Name(), (&AudnexusClient{}).Name():
+		return true
+	default:
+		return false
+	}
+}
 
 // MetadataSource is a pluggable metadata provider.
 type MetadataSource interface {

--- a/internal/metafetch/service_apply.go
+++ b/internal/metafetch/service_apply.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_apply.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: 6ca469ca-7d2e-4738-b6f1-ae09449ed9e4
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package metafetch
 
@@ -44,8 +44,22 @@ func (mfs *Service) ApplyMetadataToBook(book *database.Book, meta metadata.BookM
 	if meta.Language != "" && IsBetterStringPtr(book.Language, meta.Language) {
 		book.Language = stringPtr(meta.Language)
 	}
+	// Route the year by its source KIND. meta.PublishYear is OVERLOADED:
+	// Audible/Audnexus report the audiobook RELEASE year, while Open Library /
+	// Google Books / Hardcover / Wikipedia report the original PRINT/work year
+	// (often decades earlier). This used to write PublishYear into
+	// AudiobookReleaseYear unconditionally, so a print-year candidate clobbered a
+	// correct Audible release year — which then propagated to the file `year` tag
+	// via service_writeback.go. Now: release → AudiobookReleaseYear (unchanged
+	// behavior), print → PrintYear (only when empty). The `!= 0` gate means a
+	// present year is never overwritten with 0, and the two fields never
+	// cross-contaminate.
 	if meta.PublishYear != 0 {
-		book.AudiobookReleaseYear = intPtrHelper(meta.PublishYear)
+		if meta.PublishYearIsAudiobookRelease {
+			book.AudiobookReleaseYear = intPtrHelper(meta.PublishYear)
+		} else if book.PrintYear == nil || *book.PrintYear == 0 {
+			book.PrintYear = intPtrHelper(meta.PublishYear)
+		}
 	}
 	if meta.CoverURL != "" {
 		book.CoverURL = stringPtr(meta.CoverURL)
@@ -163,11 +177,20 @@ func (mfs *Service) RecordChangeHistory(book *database.Book, meta metadata.BookM
 	}
 
 	if meta.PublishYear != 0 {
+		// Record against the field the year actually routes to (see
+		// ApplyMetadataToBook): release-kind → audiobook_release_year,
+		// print-kind → print_year.
+		yearField := "print_year"
+		yearOld := derefIntAsString(book.PrintYear)
+		if meta.PublishYearIsAudiobookRelease {
+			yearField = "audiobook_release_year"
+			yearOld = derefIntAsString(book.AudiobookReleaseYear)
+		}
 		changes = append(changes, struct {
 			field  string
 			oldVal string
 			newVal string
-		}{"audiobook_release_year", derefIntAsString(book.AudiobookReleaseYear), strconv.Itoa(meta.PublishYear)})
+		}{yearField, yearOld, strconv.Itoa(meta.PublishYear)})
 	}
 
 	for _, c := range changes {
@@ -406,7 +429,12 @@ func (mfs *Service) persistFetchedMetadata(bookID string, meta metadata.BookMeta
 		fetchedValues["language"] = meta.Language
 	}
 	if meta.PublishYear != 0 {
-		fetchedValues["audiobook_release_year"] = meta.PublishYear
+		// Provenance key mirrors the routed field (see ApplyMetadataToBook).
+		if meta.PublishYearIsAudiobookRelease {
+			fetchedValues["audiobook_release_year"] = meta.PublishYear
+		} else {
+			fetchedValues["print_year"] = meta.PublishYear
+		}
 	}
 	if meta.CoverURL != "" {
 		fetchedValues["cover_url"] = meta.CoverURL
@@ -470,6 +498,10 @@ func (mfs *Service) ApplyMetadataCandidate(id string, candidate MetadataCandidat
 		Description:    candidate.Description,
 		Language:       candidate.Language,
 		DurationSec:    candidate.DurationSec,
+		// candidate.Year is a bare int with no kind attached; derive whether it
+		// is an audiobook release year (Audible/Audnexus) from the source name so
+		// ApplyMetadataToBook routes it to the same field as the auto-fetch path.
+		PublishYearIsAudiobookRelease: metadata.SourceProducesAudiobookReleaseYear(candidate.Source),
 	}
 
 	// If fields list is non-empty, zero out fields NOT in the list

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_mock_test.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-9012-cdef-012345678901
-// last-edited: 2026-07-10
+// last-edited: 2026-07-13
 
 package metafetch
 
@@ -974,7 +974,12 @@ func TestApplyMetadataToBook(t *testing.T) {
 		assert.Equal(t, "The Way of Kings", book.Title)
 		assert.Equal(t, "Tor Books", *book.Publisher)
 		assert.Equal(t, "en", *book.Language)
-		assert.Equal(t, 2010, *book.AudiobookReleaseYear)
+		// A source-less meta defaults to print-kind, so the year routes to
+		// PrintYear (not AudiobookReleaseYear). See TestApplyMetadataToBook_YearRouting.
+		assert.Nil(t, book.AudiobookReleaseYear)
+		if assert.NotNil(t, book.PrintYear) {
+			assert.Equal(t, 2010, *book.PrintYear)
+		}
 		assert.Equal(t, "http://cover.jpg", *book.CoverURL)
 		assert.Equal(t, "Michael Kramer", *book.Narrator)
 		assert.Equal(t, 10, *book.AuthorID)
@@ -1072,6 +1077,50 @@ func TestApplyMetadataToBook(t *testing.T) {
 		assert.True(t, seriesCreated, "should create new series")
 		assert.Equal(t, 77, *book.SeriesID)
 		assert.Equal(t, 3, *book.SeriesSequence)
+	})
+}
+
+// TestApplyMetadataToBook_YearRouting proves the print-vs-audiobook-release
+// year routing that fixes the data-corruption bug: a print/work year (Open
+// Library, Google Books) must land in PrintYear, an audiobook release year
+// (Audible, Audnexus) in AudiobookReleaseYear, and applying a print-year
+// candidate must NEVER overwrite an existing correct AudiobookReleaseYear.
+func TestApplyMetadataToBook_YearRouting(t *testing.T) {
+	svc := NewService(&database.MockStore{})
+
+	t.Run("print_year_routes_to_PrintYear", func(t *testing.T) {
+		book := &database.Book{ID: "b1", Title: "T"}
+		// Default flag (false) == print/work year (OpenLibrary/GoogleBooks).
+		meta := metadata.BookMetadata{Title: "T", PublishYear: 1937}
+		svc.ApplyMetadataToBook(book, meta)
+		assert.Nil(t, book.AudiobookReleaseYear, "print year must not touch AudiobookReleaseYear")
+		if assert.NotNil(t, book.PrintYear) {
+			assert.Equal(t, 1937, *book.PrintYear)
+		}
+	})
+
+	t.Run("release_year_routes_to_AudiobookReleaseYear", func(t *testing.T) {
+		book := &database.Book{ID: "b1", Title: "T"}
+		meta := metadata.BookMetadata{Title: "T", PublishYear: 2010, PublishYearIsAudiobookRelease: true}
+		svc.ApplyMetadataToBook(book, meta)
+		assert.Nil(t, book.PrintYear, "release year must not touch PrintYear")
+		if assert.NotNil(t, book.AudiobookReleaseYear) {
+			assert.Equal(t, 2010, *book.AudiobookReleaseYear)
+		}
+	})
+
+	t.Run("print_candidate_does_not_overwrite_release_year", func(t *testing.T) {
+		existing := 2010
+		book := &database.Book{ID: "b1", Title: "T", AudiobookReleaseYear: &existing}
+		// A Google Books / Open Library candidate with a print year decades earlier.
+		meta := metadata.BookMetadata{Title: "T", PublishYear: 1985}
+		svc.ApplyMetadataToBook(book, meta)
+		if assert.NotNil(t, book.AudiobookReleaseYear) {
+			assert.Equal(t, 2010, *book.AudiobookReleaseYear, "correct release year must survive a print-year apply")
+		}
+		if assert.NotNil(t, book.PrintYear) {
+			assert.Equal(t, 1985, *book.PrintYear, "print year lands in PrintYear")
+		}
 	})
 }
 

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/metadata_fetch_service_test.go
-// version: 4.4.0
+// version: 4.4.1
 // guid: f6a7b8c9-d0e1-f2a3-b4c5-d6e7f8a9b0c1
+// last-edited: 2026-07-13
 
 package server
 
@@ -288,7 +289,11 @@ func TestMetadataFetchService_ApplyMetadata_AllFields(t *testing.T) {
 		Publisher:   "Acme Press",
 		Language:    "en",
 		PublishYear: 2023,
-		CoverURL:    "https://example.com/cover.jpg",
+		// PublishYear is an audiobook release year (Audible/Audnexus-style source),
+		// so it routes to AudiobookReleaseYear; without this flag it would route to
+		// PrintYear (see fix/metadata-year-and-language-corruption).
+		PublishYearIsAudiobookRelease: true,
+		CoverURL:                      "https://example.com/cover.jpg",
 	}
 
 	mfs.ApplyMetadataToBook(book, meta)


### PR DESCRIPTION
## Two confirmed metadata-application data-corruption bugs

Both bugs persist WRONG data over correct data, and the year bug reaches the file `year` tag via `service_writeback.go` -- treated as data-integrity.

### Bug 1 -- print year clobbered audiobook release year
**Scenario:** `meta.PublishYear` is OVERLOADED by source. Audible/Audnexus report the audiobook's release/issue year; Open Library, Google Books, Hardcover, and Wikipedia report the work's original PRINT/first-publication year (often decades earlier). `ApplyMetadataToBook` wrote `PublishYear` into `book.AudiobookReleaseYear` **unconditionally** and **never** set `book.PrintYear`.

**Consequence:** a Google Books / Open Library candidate overwrote a correct Audible release year (e.g. a 2010 audiobook of a 1937 novel became 1937), and that value then propagated into the audio file's embedded `year` tag.

### Bug 2 -- OpenLibrary took arbitrary [0] of an unordered array
**Scenario:** Open Library search docs return `Language`/`Publisher`/`ISBN` as UNORDERED aggregates across every edition. The code used `Language[0]`.

**Consequence:** `Language` is persisted as a `metadata:language:<code>` system tag that drives the review language filter, so a book whose first-listed edition is a translation got mislabeled -- an English book could vanish from the English filter.

## Design -- year-kind flag

Added `PublishYearIsAudiobookRelease bool` to `BookMetadata` (default `false` = print/work year; only Audible + Audnexus set it `true`). This is the "year-kind enum" alternative the brief sanctioned, chosen because it is strictly more surgical than adding a second int field:

- `PublishYear` stays populated by every source, so **`service_search.go` is untouched** (candidate `.Year` still fed from it) and existing source unit tests stay green.
- `ApplyMetadataToBook` routes by the flag: release -> `AudiobookReleaseYear` (unchanged behavior, no regression), print -> `PrintYear`. Gated on `PublishYear != 0`; the two fields never cross-contaminate.
- The candidate-apply path has no `BookMetadata` in scope, so it derives the kind from `candidate.Source` via the new `metadata.SourceProducesAudiobookReleaseYear` helper (uses the clients' own `Name()` so it can't drift).
- `RecordChangeHistory` + `persistFetchedMetadata` provenance now key off the routed field (`print_year` vs `audiobook_release_year`).

## Language policy

New `unambiguousLanguage` helper: set language only when the editions agree (single distinct, case-insensitive value); when ambiguous, set none -- no tag beats a wrong one. `Publisher`/`ISBN` `[0]` left as-is: they are NOT filter-driving system tags, skipping `Publisher` would broadly regress publisher population on multi-edition books, and any `ISBN` in the list is a valid identifier. `editionToMetadata`'s per-single-edition `[0]` picks are correct and untouched.

## Known transient after-effect (non-blocking)
The fetch cache stores parsed `[]BookMetadata`. Pre-deploy Audible/Audnexus cache entries deserialize with the new flag `false` and transiently route their release year to `PrintYear` until the cache TTL (`MetadataFetchCacheTTLDays`) expires. Bounded and **non-clobbering** -- it fails to populate `AudiobookReleaseYear`, it never overwrites a good one. Optional hardening (re-derive the flag at the cache-replay sites) is noted in TODO; left out to keep this PR off `service_search.go`.

## Test results
- `TestApplyMetadataToBook_YearRouting` -- print -> `PrintYear`; release -> `AudiobookReleaseYear`; a print-year candidate does NOT overwrite an existing correct `AudiobookReleaseYear`. PASS.
- `TestUnambiguousLanguage` + `TestSearchByTitle_AmbiguousLanguageSkipped` -- `["spa","eng"]` sets no language; `["eng"]` sets `eng`. PASS.
- Audible/Audnexus flag assertions added. PASS.
- `go test ./internal/metafetch/... ./internal/metadata/... -race` green; `go vet` clean; `gofmt` clean on changed files; `go build ./...` clean.

CHANGELOG + TODO updated; executive summary added (`docs/executive-summaries/2026-07-13-metadata-year-language-corruption-executive-summary.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv