### PR TITLE
test(database): data-loss invariants + regression suite (round-trip fidelity, store invariants, key-encoding, concurrency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,8 @@
   - **T3 store-consistency invariants** — `dbtest.AssertStoreInvariants` (public, for the merge
     package) + a white-box `assertStoreInvariants` (raw index-row scan): no book both live-primary and
     soft-deleted, no index listing surfaces a deleted book, no dangling secondary-index row. Wired into
-    the existing merge/combine tests.
+    the existing merge/combine tests AND the concurrent-merge/-combine race tests (where merge bug
+    class #3 is actually triggered).
   - **T4 concurrency harness** (`-race`) — partitioned interleaved mutations then invariant check.
   - **T5 key-encoding property test** — delimiter/unicode-laden titles, paths, tags, work IDs, and
     author/series names resolve to exactly the right record (generalizes the tag-colon-parse fix).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,28 @@
 - Tests: year-routing + no-overwrite (`TestApplyMetadataToBook_YearRouting`), Open Library language
   ambiguity (`TestUnambiguousLanguage`, `TestSearchByTitle_AmbiguousLanguageSkipped`), and
   Audible/Audnexus flag assertions. `internal/metafetch` + `internal/metadata` green under `-race`.
+#### July 13, 2026 - test(database): data-loss invariants + regression suite
+
+- **Class-level regression coverage for the four data-loss bug classes** (test-only, no production
+  change). Complements the existing point regression tests with invariants that fail automatically
+  when a future change reintroduces a whole class of bug:
+  - **T1 reflective heavy-field preservation** (`dataloss_preserve_invariant_test.go`) — derives the
+    must-preserve field set by diffing a fully-populated `Book` against `stripBookForMemdb`, then
+    asserts each stripped field survives a memdb-round-trip `UpdateBook`. Adding a heavy field to
+    `stripBookForMemdb` without a matching `UpdateBook` preserve-on-nil guard now fails the build.
+  - **T2 round-trip fidelity** (`dataloss_roundtrip_test.go`) — writes a fully-populated record back
+    UNCHANGED via `UpdateBook`/`UpdateBookFile` and asserts field-by-field equality, with a documented
+    a-priori exclusion set (only derived/dropped fields). A generic wipe detector.
+  - **T3 store-consistency invariants** — `dbtest.AssertStoreInvariants` (public, for the merge
+    package) + a white-box `assertStoreInvariants` (raw index-row scan): no book both live-primary and
+    soft-deleted, no index listing surfaces a deleted book, no dangling secondary-index row. Wired into
+    the existing merge/combine tests.
+  - **T4 concurrency harness** (`-race`) — partitioned interleaved mutations then invariant check.
+  - **T5 key-encoding property test** — delimiter/unicode-laden titles, paths, tags, work IDs, and
+    author/series names resolve to exactly the right record (generalizes the tag-colon-parse fix).
+  - **T6** — added the missing path-rename stale-index-row regression; other scenarios already covered
+    were intentionally not duplicated.
+  - All green under `-race`; no NEW production bug was surfaced by the new invariants.
 
 #### July 13, 2026 - fix(dedup): serialize CombineBooks + dedup.MergeBooks (close merge-race follow-ups from #1930)
 

--- a/TODO.md
+++ b/TODO.md
@@ -81,6 +81,18 @@ real error, returns a generic message), and clamped the metadata-history
 `?limit=` to 1000. Test: `internal/server/user_tags_authz_test.go` (viewer → 403,
 admin → 200 on all three write routes).
 
+## ✅ DONE — data-loss invariants + regression test suite (test-only, 2026-07-13)
+
+Class-level regression coverage for the four recently-fixed data-loss bug classes
+(write-back wipe, stale embedded-copy/phantom, merge corruption, key-encoding),
+all real tests on a real `PebbleStore`. New: `internal/database/dataloss_*.go`
+(T1 reflective heavy-field preservation, T2 round-trip fidelity, T4 `-race`
+concurrency, T5 key-encoding property, T6 path-rename regression),
+`store_invariants_test.go` (white-box `assertStoreInvariants`), and
+`internal/database/dbtest/invariants.go` (public `AssertStoreInvariants`, wired
+into `internal/merge` combine/merge tests). All green under `-race`; no new
+production bug surfaced. No production code changed.
+
 ## 📦 2026-07-10 Remaining-Work Planning Packages — READY FOR EXECUTION
 
 Ten full planning packages (spec + plan + task briefs) covering INIT-1..10 of the

--- a/internal/database/dataloss_concurrency_test.go
+++ b/internal/database/dataloss_concurrency_test.go
@@ -1,0 +1,149 @@
+// file: internal/database/dataloss_concurrency_test.go
+// version: 1.0.0
+// guid: a6b7c8d9-0e1f-2a3b-4c5d-concurrency001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// T4 — concurrency invariant harness (run under -race).
+//
+// N workers run interleaved store mutations (UpdateBook metadata edits, soft
+// delete via MarkedForDeletion, and hard DeleteBook) over a SHARED store. Work
+// is PARTITIONED by book ID: each worker owns a disjoint set of books and never
+// touches another worker's row. This is deliberate (CLAUDE.md concurrency rule):
+// it keeps the test deterministic — no two workers can produce an
+// order-dependent lost update on the same row, so any invariant violation after
+// the join is a genuine store-level corruption, not a benign race between two
+// legitimate writers. Meanwhile the workers still hammer the store's SHARED
+// internals concurrently (memdb, secondary indexes, aggregate caches), which is
+// exactly what -race is here to vet.
+//
+// Randomness is seeded from a fixed arithmetic table (worker, step), never from
+// time or math/rand, so runs are reproducible.
+//
+// NOTE: merge.SoftDeleteBook / MergeBooks live in package merge and cannot be
+// called from a white-box database test without an import cycle. Merge/combine
+// concurrency is covered separately by internal/merge/service_concurrent_test.go
+// and by the dbtest.AssertStoreInvariants calls wired into the merge tests.
+func TestConcurrency_StoreInvariantsHold(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	workers := runtime.NumCPU()
+	if workers < 4 {
+		workers = 4
+	}
+	if workers > 16 {
+		workers = 16
+	}
+	const booksPerWorker = 3
+	const steps = 24
+
+	// Shared work IDs so the book:work index is contended across workers even
+	// though each row belongs to exactly one worker.
+	sharedWorks := []string{"WORKC0000000000000000000A", "WORKC0000000000000000000B"}
+
+	type owned struct{ ids []string }
+	all := make([]owned, workers)
+	for w := 0; w < workers; w++ {
+		for k := 0; k < booksPerWorker; k++ {
+			b, err := store.CreateBook(&Book{
+				Title:    fmt.Sprintf("w%d-b%d", w, k),
+				FilePath: fmt.Sprintf("/lib/conc/w%d-b%d.m4b", w, k),
+				WorkID:   strPtr(sharedWorks[(w+k)%len(sharedWorks)]),
+			})
+			if err != nil {
+				t.Fatalf("CreateBook w%d k%d: %v", w, k, err)
+			}
+			all[w].ids = append(all[w].ids, b.ID)
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make([][]error, workers)
+	start := make(chan struct{})
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			<-start
+			deleted := map[string]bool{}
+			for s := 0; s < steps; s++ {
+				id := all[w].ids[(w+s)%booksPerWorker]
+				if deleted[id] {
+					continue
+				}
+				// Deterministic op selection from a fixed table.
+				switch (w*7 + s*3) % 5 {
+				case 0, 1: // metadata edit (title)
+					if err := updateTitleConc(store, id, fmt.Sprintf("w%d-s%d", w, s)); err != nil {
+						errs[w] = append(errs[w], err)
+					}
+				case 2: // toggle work id (index churn)
+					if err := updateWorkConc(store, id, sharedWorks[s%len(sharedWorks)]); err != nil {
+						errs[w] = append(errs[w], err)
+					}
+				case 3: // soft delete via MarkedForDeletion
+					if err := softDeleteConc(store, id); err != nil {
+						errs[w] = append(errs[w], err)
+					}
+				case 4: // hard delete on the LAST touch of this book
+					if s >= steps-booksPerWorker {
+						if err := store.DeleteBook(id); err != nil {
+							errs[w] = append(errs[w], err)
+						}
+						deleted[id] = true
+					}
+				}
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+
+	for w := range errs {
+		for _, e := range errs[w] {
+			t.Errorf("worker %d op error: %v", w, e)
+		}
+	}
+
+	assertStoreInvariants(t, store)
+}
+
+func updateTitleConc(store Store, id, title string) error {
+	cur, err := store.GetBookByID(id)
+	if err != nil || cur == nil {
+		return err
+	}
+	cur.Title = title
+	_, err = store.UpdateBook(id, cur)
+	return err
+}
+
+func updateWorkConc(store Store, id, work string) error {
+	cur, err := store.GetBookByID(id)
+	if err != nil || cur == nil {
+		return err
+	}
+	cur.WorkID = &work
+	_, err = store.UpdateBook(id, cur)
+	return err
+}
+
+func softDeleteConc(store Store, id string) error {
+	cur, err := store.GetBookByID(id)
+	if err != nil || cur == nil {
+		return err
+	}
+	tru := true
+	cur.MarkedForDeletion = &tru
+	_, err = store.UpdateBook(id, cur)
+	return err
+}

--- a/internal/database/dataloss_key_encoding_test.go
+++ b/internal/database/dataloss_key_encoding_test.go
@@ -1,0 +1,190 @@
+// file: internal/database/dataloss_key_encoding_test.go
+// version: 1.0.0
+// guid: f5b6c7d8-9e0f-1a2b-3c4d-keyencoding001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"fmt"
+	"testing"
+)
+
+// T5 — key-encoding property test.
+//
+// Values that contain the index delimiters (':' and '/'), leading/trailing
+// delimiters, and unicode must not corrupt any secondary-index parse. This is
+// the generic form of the tag-colon-parse bug: a byte-prefix scan over
+// "tag_idx:<tag>:" also matches longer tags sharing that prefix, so every
+// lookup must return EXACTLY the right record and nothing that merely shares a
+// delimiter-bearing prefix.
+
+var nastyValues = []struct {
+	name string
+	val  string
+}{
+	{"internal_colon", "a:b:c"},
+	{"internal_slash", "a/b/c"},
+	{"leading_colon", ":leading"},
+	{"trailing_colon", "trailing:"},
+	{"colon_and_slash", "x:/y:z/"},
+	{"unicode", "café:naïve/日本語"},
+	{"unicode_colon_suffix", "日本語:"},
+}
+
+// TestKeyEncoding_PathIndex: a FilePath full of delimiters must resolve back to
+// exactly its own book, and its stored Title must be byte-identical.
+func TestKeyEncoding_PathIndex(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	ids := map[string]string{}
+	for i, nv := range nastyValues {
+		path := fmt.Sprintf("/lib/%s/%s.m4b", nv.val, nv.val)
+		title := "Title " + nv.val
+		created, err := store.CreateBook(&Book{Title: title, FilePath: path})
+		if err != nil {
+			t.Fatalf("CreateBook %q: %v", nv.name, err)
+		}
+		ids[path] = created.ID
+		_ = i
+	}
+
+	for path, wantID := range ids {
+		got, err := store.GetBookByFilePath(path)
+		if err != nil {
+			t.Fatalf("GetBookByFilePath %q: %v", path, err)
+		}
+		if got == nil || got.ID != wantID {
+			t.Errorf("path %q resolved to %v, want book %s", path, got, wantID)
+			continue
+		}
+		if got.FilePath != path {
+			t.Errorf("stored FilePath corrupted: got %q, want %q", got.FilePath, path)
+		}
+	}
+}
+
+// TestKeyEncoding_TagIndex is the crown-jewel colon-parse discrimination: a
+// lookup for tag "genre" must NOT return the book tagged "genre:fantasy" (which
+// shares the byte prefix), and vice-versa. Also covers arbitrary nasty tags.
+func TestKeyEncoding_TagIndex(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	// Prefix-sharing pair: the classic bug.
+	base, err := store.CreateBook(&Book{Title: "base", FilePath: "/lib/tag-base.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook base: %v", err)
+	}
+	long, err := store.CreateBook(&Book{Title: "long", FilePath: "/lib/tag-long.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook long: %v", err)
+	}
+	if err := store.SetBookTags(base.ID, []string{"genre"}); err != nil {
+		t.Fatalf("SetBookTags base: %v", err)
+	}
+	if err := store.SetBookTags(long.ID, []string{"genre:fantasy"}); err != nil {
+		t.Fatalf("SetBookTags long: %v", err)
+	}
+
+	assertTagExactly(t, store, "genre", base.ID)
+	assertTagExactly(t, store, "genre:fantasy", long.ID)
+
+	// Arbitrary nasty tags, each on its own book, must round-trip exactly.
+	for _, nv := range nastyValues {
+		b, err := store.CreateBook(&Book{Title: "tag-" + nv.name, FilePath: "/lib/tag-" + nv.name + ".m4b"})
+		if err != nil {
+			t.Fatalf("CreateBook %q: %v", nv.name, err)
+		}
+		if err := store.SetBookTags(b.ID, []string{nv.val}); err != nil {
+			t.Fatalf("SetBookTags %q: %v", nv.name, err)
+		}
+		assertTagExactly(t, store, nv.val, b.ID)
+	}
+}
+
+func assertTagExactly(t *testing.T, store Store, tag, wantID string) {
+	t.Helper()
+	ids, err := store.GetBooksByTag(tag)
+	if err != nil {
+		t.Fatalf("GetBooksByTag %q: %v", tag, err)
+	}
+	if len(ids) != 1 || ids[0] != wantID {
+		t.Errorf("GetBooksByTag(%q) = %v, want exactly [%s]", tag, ids, wantID)
+	}
+}
+
+// TestKeyEncoding_WorkIndex: a WorkID containing internal colons must not
+// mis-parse the book:work:<wid>:<bookID> key. Two books with delimiter-bearing
+// work IDs must each be listed under their own work and nothing else.
+func TestKeyEncoding_WorkIndex(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	widA := "WORK:A:1"
+	widB := "WORK:A:1:extra" // shares the byte prefix "WORK:A:1"
+	a, err := store.CreateBook(&Book{Title: "wa", FilePath: "/lib/wa.m4b", WorkID: strPtr(widA)})
+	if err != nil {
+		t.Fatalf("CreateBook a: %v", err)
+	}
+	b, err := store.CreateBook(&Book{Title: "wb", FilePath: "/lib/wb.m4b", WorkID: strPtr(widB)})
+	if err != nil {
+		t.Fatalf("CreateBook b: %v", err)
+	}
+
+	gotA, err := store.GetBooksByWorkID(widA)
+	if err != nil {
+		t.Fatalf("GetBooksByWorkID A: %v", err)
+	}
+	if !containsIDWB(gotA, a.ID) {
+		t.Errorf("work %q missing its own book %s (got %d)", widA, a.ID, len(gotA))
+	}
+	if containsIDWB(gotA, b.ID) {
+		t.Errorf("work %q leaked prefix-sharing book %s", widA, b.ID)
+	}
+
+	gotB, err := store.GetBooksByWorkID(widB)
+	if err != nil {
+		t.Fatalf("GetBooksByWorkID B: %v", err)
+	}
+	if !containsIDWB(gotB, b.ID) || containsIDWB(gotB, a.ID) {
+		t.Errorf("work %q listing wrong: got %d books, want exactly [%s]", widB, len(gotB), b.ID)
+	}
+}
+
+// TestKeyEncoding_AuthorSeriesNames: delimiter-bearing author/series names must
+// store losslessly and resolve to exactly the right record by name.
+func TestKeyEncoding_AuthorSeriesNames(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	for _, nv := range nastyValues {
+		aName := "Author " + nv.val
+		author, err := ps.CreateAuthor(aName)
+		if err != nil {
+			t.Fatalf("CreateAuthor %q: %v", nv.name, err)
+		}
+		gotA, err := ps.GetAuthorByName(aName)
+		if err != nil || gotA == nil || gotA.ID != author.ID {
+			t.Errorf("GetAuthorByName(%q) = %v (err %v), want id %d", aName, gotA, err, author.ID)
+		}
+		if gotA != nil && gotA.Name != aName {
+			t.Errorf("author name corrupted: got %q, want %q", gotA.Name, aName)
+		}
+
+		sName := "Series " + nv.val
+		series, err := ps.CreateSeries(sName, nil)
+		if err != nil {
+			t.Fatalf("CreateSeries %q: %v", nv.name, err)
+		}
+		gotS, err := ps.GetSeriesByName(sName, nil)
+		if err != nil || gotS == nil || gotS.ID != series.ID {
+			t.Errorf("GetSeriesByName(%q) = %v (err %v), want id %d", sName, gotS, err, series.ID)
+		}
+		if gotS != nil && gotS.Name != sName {
+			t.Errorf("series name corrupted: got %q, want %q", gotS.Name, sName)
+		}
+	}
+}

--- a/internal/database/dataloss_preserve_invariant_test.go
+++ b/internal/database/dataloss_preserve_invariant_test.go
@@ -1,0 +1,184 @@
+// file: internal/database/dataloss_preserve_invariant_test.go
+// version: 1.0.0
+// guid: d3f4a5b6-7c8d-9e0f-1a2b-preserveinv001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// wantStrippedCount is the number of Book fields stripBookForMemdb nils and
+// that UpdateBook's preserve-on-nil guard must therefore restore. This is a
+// deliberate tripwire: if you add a heavy field to stripBookForMemdb (raising
+// this count) you MUST also add its preserve-on-nil branch to UpdateBook, then
+// bump this constant. If the count changes and this test starts failing, that
+// is the signal — do not just bump the number without adding the guard branch.
+const wantStrippedCount = 9
+
+// dlFixedTime is a clean, monotonic-clock-free UTC instant so JSON round-trips
+// are byte-exact and reflect.DeepEqual on *time.Time fields is reliable.
+var dlFixedTime = time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+func dlIntPtr(i int) *int       { return &i }
+func dlInt64Ptr(i int64) *int64 { return &i }
+
+// dlPopulateNonZero recursively fills every settable field of v with a
+// distinctive non-zero sentinel. The whole point of T1 is that a NEW field
+// added to Book (and to stripBookForMemdb) is automatically covered — that only
+// works if the populator leaves NOTHING at its zero value, so a newly-added
+// pointer field is non-nil before the strip and the strip's nil-ing of it shows
+// up in the diff. The `default` branch fails loudly so an unhandled field type
+// forces this helper (and the test's coverage) to be updated rather than
+// silently skipped.
+func dlPopulateNonZero(t *testing.T, v reflect.Value, field string) {
+	t.Helper()
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("sentinel-" + field)
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(7)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(7)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(3.5)
+	case reflect.Interface:
+		// e.g. MetadataProvenanceEntry.Value (any). A concrete non-nil string
+		// is enough to make the field non-zero; strip doesn't touch these.
+		v.Set(reflect.ValueOf("sentinel-" + field))
+	case reflect.Ptr:
+		elem := reflect.New(v.Type().Elem())
+		dlPopulateNonZero(t, elem.Elem(), field)
+		v.Set(elem)
+	case reflect.Slice:
+		elem := reflect.New(v.Type().Elem())
+		dlPopulateNonZero(t, elem.Elem(), field)
+		v.Set(reflect.Append(reflect.MakeSlice(v.Type(), 0, 1), elem.Elem()))
+	case reflect.Map:
+		m := reflect.MakeMap(v.Type())
+		k := reflect.New(v.Type().Key())
+		dlPopulateNonZero(t, k.Elem(), field)
+		val := reflect.New(v.Type().Elem())
+		dlPopulateNonZero(t, val.Elem(), field)
+		m.SetMapIndex(k.Elem(), val.Elem())
+		v.Set(m)
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			v.Set(reflect.ValueOf(dlFixedTime))
+			return
+		}
+		for i := 0; i < v.NumField(); i++ {
+			if f := v.Field(i); f.CanSet() {
+				dlPopulateNonZero(t, f, v.Type().Field(i).Name)
+			}
+		}
+	default:
+		t.Fatalf("dlPopulateNonZero: unhandled kind %s for field %q — extend the populator so T1 stays drift-proof", v.Kind(), field)
+	}
+}
+
+// strippedBookFields returns the indices+names of Book fields that
+// stripBookForMemdb changes, derived by diffing a fully-populated Book against
+// its stripped copy. This is the SAME source of truth the guard must track —
+// the set can never drift from stripBookForMemdb because it is computed from it.
+func strippedBookFields(t *testing.T) (full *Book, indices []int, names []string) {
+	t.Helper()
+	full = &Book{}
+	dlPopulateNonZero(t, reflect.ValueOf(full).Elem(), "Book")
+
+	stripped := stripBookForMemdb(full)
+	fv, sv := reflect.ValueOf(full).Elem(), reflect.ValueOf(stripped).Elem()
+	for i := 0; i < fv.NumField(); i++ {
+		if !fv.Field(i).CanInterface() {
+			continue
+		}
+		if !reflect.DeepEqual(fv.Field(i).Interface(), sv.Field(i).Interface()) {
+			indices = append(indices, i)
+			names = append(names, fv.Type().Field(i).Name)
+		}
+	}
+	return full, indices, names
+}
+
+// TestStripBookForMemdb_StrippedSetMatchesGuardCount asserts the derived
+// stripped-field set has exactly wantStrippedCount members. A mismatch means
+// stripBookForMemdb changed and the UpdateBook guard + this constant need review.
+func TestStripBookForMemdb_StrippedSetMatchesGuardCount(t *testing.T) {
+	_, _, names := strippedBookFields(t)
+	if len(names) != wantStrippedCount {
+		t.Fatalf("stripBookForMemdb now strips %d fields %v; want %d. If you added a heavy field, add a preserve-on-nil branch to UpdateBook and bump wantStrippedCount.",
+			len(names), names, wantStrippedCount)
+	}
+}
+
+// TestUpdateBook_PreservesEveryStrippedFieldOnNilIncoming is the crown-jewel
+// invariant: for EACH field stripBookForMemdb nils, a memdb-round-trip
+// UpdateBook (that field nil, everything else intact) must NOT wipe the stored
+// value. Reflection-driven so a newly-stripped field is covered automatically —
+// if someone adds a field to stripBookForMemdb but forgets UpdateBook's guard,
+// the subtest for that field fails here.
+func TestUpdateBook_PreservesEveryStrippedFieldOnNilIncoming(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	full, indices, names := strippedBookFields(t)
+	if len(indices) == 0 {
+		t.Fatal("no stripped fields derived — populator or strip changed")
+	}
+
+	for k, idx := range indices {
+		name := names[k]
+		t.Run(name, func(t *testing.T) {
+			// Seed a book carrying real (non-nil) values in every heavy field.
+			created, err := store.CreateBook(&Book{Title: "seed-" + name, FilePath: "/lib/seed-" + name + ".m4b"})
+			if err != nil {
+				t.Fatalf("CreateBook: %v", err)
+			}
+			seed := *full
+			seed.ID = created.ID
+			seed.FilePath = "/lib/seed-" + name + ".m4b"
+			if _, err := store.UpdateBook(created.ID, &seed); err != nil {
+				t.Fatalf("UpdateBook (seed): %v", err)
+			}
+			seeded, err := store.GetBookByID(created.ID)
+			if err != nil || seeded == nil {
+				t.Fatalf("GetBookByID (seeded): err=%v got=%v", err, seeded)
+			}
+			want := reflect.ValueOf(seeded).Elem().Field(idx).Interface()
+			if isNilValue(reflect.ValueOf(want)) {
+				t.Fatalf("seed did not populate field %q (got nil) — cannot test preservation", name)
+			}
+
+			// Simulate the memdb/projection round trip: exactly this ONE field
+			// nil, everything else carried through unchanged.
+			proj := *seeded
+			reflect.ValueOf(&proj).Elem().Field(idx).Set(reflect.Zero(reflect.ValueOf(&proj).Elem().Field(idx).Type()))
+			if _, err := store.UpdateBook(created.ID, &proj); err != nil {
+				t.Fatalf("UpdateBook (projection): %v", err)
+			}
+
+			got, err := store.GetBookByID(created.ID)
+			if err != nil || got == nil {
+				t.Fatalf("GetBookByID (final): err=%v got=%v", err, got)
+			}
+			final := reflect.ValueOf(got).Elem().Field(idx).Interface()
+			if !reflect.DeepEqual(final, want) {
+				t.Errorf("field %q WIPED by memdb-round-trip UpdateBook: got %#v, want %#v (add a preserve-on-nil branch to UpdateBook)", name, final, want)
+			}
+		})
+	}
+}
+
+func isNilValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/database/dataloss_regression_test.go
+++ b/internal/database/dataloss_regression_test.go
@@ -1,0 +1,76 @@
+// file: internal/database/dataloss_regression_test.go
+// version: 1.0.0
+// guid: b7c8d9e0-1f2a-3b4c-5d6e-regression0001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"testing"
+)
+
+// T6 — explicit named regression tests for data-loss scenarios that did NOT
+// already have a dedicated test on main. Scenarios that ARE already covered
+// elsewhere are intentionally NOT duplicated here:
+//
+//	soft-delete work/version-group exclusion .... pebble_store_index_consistency_test.go
+//	DeleteBook dangling-row teardown ............ pebble_store_index_consistency_test.go
+//	concurrent CreateNarrator id race .......... pebble_store_index_consistency_test.go
+//	UpdateBook memdb-stripped/Author-Series wipe  pebble_book_preserve_test.go
+//	UpdateBookFile fingerprint wipe ............. pebble_bookfile_preserve_test.go
+//	tag/author/series colon collision .......... store_coverage_test.go
+//	author-split write-back .................... plugins/maintenance/author_split_writeback_test.go
+//	merge serialization ........................ merge/service_concurrent_test.go
+//
+// The gap filled below: a FilePath RENAME via UpdateBook must tear down the old
+// book:path index row, or the stale row becomes a phantom pointer to the (now
+// moved) book — a lookup by the old path would resolve to a book that no longer
+// lives there, and after that book is deleted the row dangles.
+
+// TestRegression_PathRenameLeavesNoStaleIndexRow reproduces the path-index
+// teardown scenario: after UpdateBook changes FilePath, the OLD path must no
+// longer resolve, the NEW path must resolve to the book, and no raw
+// book:path:<old> row may remain.
+func TestRegression_PathRenameLeavesNoStaleIndexRow(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	oldPath := "/lib/old/name.m4b"
+	newPath := "/lib/new/name.m4b"
+
+	created, err := store.CreateBook(&Book{Title: "Renamer", FilePath: oldPath})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	// Sanity: old path resolves before rename.
+	if got, _ := store.GetBookByFilePath(oldPath); got == nil || got.ID != created.ID {
+		t.Fatalf("pre-rename: old path did not resolve to the book")
+	}
+
+	upd := *created
+	upd.FilePath = newPath
+	if _, err := store.UpdateBook(created.ID, &upd); err != nil {
+		t.Fatalf("UpdateBook rename: %v", err)
+	}
+
+	// Old path must NOT resolve; new path must resolve to the same book.
+	if got, err := store.GetBookByFilePath(oldPath); err != nil {
+		t.Fatalf("GetBookByFilePath(old): %v", err)
+	} else if got != nil {
+		t.Errorf("stale path index: old path %q still resolves to book %s after rename", oldPath, got.ID)
+	}
+	if got, err := store.GetBookByFilePath(newPath); err != nil || got == nil || got.ID != created.ID {
+		t.Errorf("new path %q did not resolve to book %s: got=%v err=%v", newPath, created.ID, got, err)
+	}
+
+	// Raw: no book:path:<oldPath> row may remain.
+	ps := store.(*PebbleStore)
+	if _, closer, err := ps.db.Get([]byte("book:path:" + oldPath)); err == nil {
+		closer.Close()
+		t.Errorf("raw book:path:%s row still present after rename (dangling)", oldPath)
+	}
+
+	// The whole store must still satisfy every consistency invariant.
+	assertStoreInvariants(t, store)
+}

--- a/internal/database/dataloss_roundtrip_test.go
+++ b/internal/database/dataloss_roundtrip_test.go
@@ -1,0 +1,212 @@
+// file: internal/database/dataloss_roundtrip_test.go
+// version: 1.0.0
+// guid: e4a5b6c7-8d9e-0f1a-2b3c-roundtrip00001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// T2 — round-trip fidelity per full-replace setter.
+//
+// A generic wipe detector: build a fully-populated record (every field set to a
+// distinctive non-zero sentinel via the reflective populator from T1), snapshot
+// it, write it back UNCHANGED via the setter, re-read, and assert field-by-field
+// equality. Any field that fails to round-trip and is NOT in the a-priori,
+// struct-semantics-justified exclusion set is a data-loss wipe → the test fails
+// loudly rather than being papered over.
+//
+// The exclusion sets are decided from struct/setter SEMANTICS before running,
+// NOT grown to make the test green. If you see a NEW field fail here, do not add
+// it to the exclusion list reflexively — first determine whether the setter is
+// wiping something it should preserve (a real bug).
+
+// jsonClone deep-copies via marshal→unmarshal so the snapshot is independent of
+// the setter's in-place mutation of the input struct.
+func jsonClone(t *testing.T, src, dst any) {
+	t.Helper()
+	b, err := json.Marshal(src)
+	if err != nil {
+		t.Fatalf("jsonClone marshal: %v", err)
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		t.Fatalf("jsonClone unmarshal: %v", err)
+	}
+}
+
+// assertFieldsRoundTrip compares got vs want field-by-field, skipping the named
+// exclusions (with the reason baked into the failure message when something
+// unexpected drifts).
+func assertFieldsRoundTrip(t *testing.T, label string, got, want any, excluded map[string]string) {
+	t.Helper()
+	gv := reflect.ValueOf(got).Elem()
+	wv := reflect.ValueOf(want).Elem()
+	for i := 0; i < gv.NumField(); i++ {
+		name := gv.Type().Field(i).Name
+		if !gv.Field(i).CanInterface() {
+			continue
+		}
+		if reason, skip := excluded[name]; skip {
+			_ = reason
+			continue
+		}
+		if !reflect.DeepEqual(gv.Field(i).Interface(), wv.Field(i).Interface()) {
+			t.Errorf("%s: field %q did NOT round-trip: got %#v, want %#v. "+
+				"If this is a legitimately derived/dropped field, document it in the exclusion set with justification; "+
+				"otherwise the setter is WIPING data — treat as a real bug.",
+				label, name, gv.Field(i).Interface(), wv.Field(i).Interface())
+		}
+	}
+}
+
+// TestRoundTrip_UpdateBook writes a fully-populated Book back unchanged and
+// asserts nothing is dropped. Exclusions (a priori, by semantics):
+//
+//	CreatedAt — UpdateBook preserves the ORIGINAL row's created_at (from the
+//	            CreateBook seed), not the caller's value. By design.
+//	UpdatedAt — UpdateBook stamps time.Now() on every write. By design.
+func TestRoundTrip_UpdateBook(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	created, err := store.CreateBook(&Book{Title: "seed", FilePath: "/lib/rt-book.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	full := &Book{}
+	dlPopulateNonZero(t, reflect.ValueOf(full).Elem(), "Book")
+	full.ID = created.ID
+	full.FilePath = "/lib/rt-book.m4b"
+
+	want := &Book{}
+	jsonClone(t, full, want)
+
+	if _, err := store.UpdateBook(created.ID, full); err != nil {
+		t.Fatalf("UpdateBook: %v", err)
+	}
+	got, err := store.GetBookByID(created.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetBookByID: err=%v got=%v", err, got)
+	}
+
+	assertFieldsRoundTrip(t, "UpdateBook", got, want, map[string]string{
+		"CreatedAt": "preserved from the original row, not the caller",
+		"UpdatedAt": "stamped to now on every write",
+	})
+}
+
+// TestRoundTrip_UpdateBookFile writes a fully-populated BookFile back unchanged.
+// Exclusions (a priori, by semantics):
+//
+//	ID / CreatedAt / UpdatedAt — identity + timestamps managed by the setter.
+//	AcoustIDSeg0..6            — deliberately DROPPED on write by
+//	                             marshalBookFileDropSegs (T020); the stored row
+//	                             never carries them. Not a wipe of live data.
+func TestRoundTrip_UpdateBookFile(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	book, err := store.CreateBook(&Book{Title: "rt-file-book", FilePath: "/lib/rt-file-book.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	ps := store.(*PebbleStore)
+	seed := &BookFile{BookID: book.ID, FilePath: "/lib/rt-file-book/01.mp3"}
+	if err := ps.CreateBookFile(seed); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	full := &BookFile{}
+	dlPopulateNonZero(t, reflect.ValueOf(full).Elem(), "BookFile")
+	full.ID = seed.ID
+	full.BookID = book.ID
+
+	want := &BookFile{}
+	jsonClone(t, full, want)
+
+	if err := ps.UpdateBookFile(seed.ID, full); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+	files, err := ps.GetBookFiles(book.ID)
+	if err != nil {
+		t.Fatalf("GetBookFiles: %v", err)
+	}
+	var got *BookFile
+	for i := range files {
+		if files[i].ID == seed.ID {
+			got = &files[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("book file %s not found after update", seed.ID)
+	}
+
+	assertFieldsRoundTrip(t, "UpdateBookFile", got, want, map[string]string{
+		"ID":           "identity, set by the setter",
+		"CreatedAt":    "preserved from the original row",
+		"UpdatedAt":    "stamped to now on every write",
+		"AcoustIDSeg0": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg1": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg2": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg3": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg4": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg5": "deprecated 7-seg field intentionally dropped on write (T020)",
+		"AcoustIDSeg6": "deprecated 7-seg field intentionally dropped on write (T020)",
+	})
+}
+
+// TestRoundTrip_AuthorSeries covers the author/series setters that actually
+// exist. NOTE: there is no UpsertAuthor/UpsertSeries full-struct setter (the
+// task brief assumed one) — Author={ID,Name} and Series={ID,Name,AuthorID}
+// carry NO heavy/denormalized fields, so the write-back-wipe class does not
+// apply. These setters take individual fields, so round-trip fidelity is simply
+// create→read and rename→read.
+func TestRoundTrip_AuthorSeries(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	author, err := ps.CreateAuthor("Ursula K. Le Guin")
+	if err != nil {
+		t.Fatalf("CreateAuthor: %v", err)
+	}
+	gotA, err := ps.GetAuthorByID(author.ID)
+	if err != nil || gotA == nil {
+		t.Fatalf("GetAuthorByID: err=%v got=%v", err, gotA)
+	}
+	if gotA.Name != "Ursula K. Le Guin" || gotA.ID != author.ID {
+		t.Errorf("author round-trip: got %+v", gotA)
+	}
+	if err := ps.UpdateAuthorName(author.ID, "U. K. Le Guin"); err != nil {
+		t.Fatalf("UpdateAuthorName: %v", err)
+	}
+	if gotA, _ = ps.GetAuthorByID(author.ID); gotA == nil || gotA.Name != "U. K. Le Guin" {
+		t.Errorf("author rename not persisted: got %+v", gotA)
+	}
+
+	aid := author.ID
+	series, err := ps.CreateSeries("Earthsea", &aid)
+	if err != nil {
+		t.Fatalf("CreateSeries: %v", err)
+	}
+	gotS, err := ps.GetSeriesByID(series.ID)
+	if err != nil || gotS == nil {
+		t.Fatalf("GetSeriesByID: err=%v got=%v", err, gotS)
+	}
+	if gotS.Name != "Earthsea" || gotS.AuthorID == nil || *gotS.AuthorID != aid {
+		t.Errorf("series round-trip: got %+v", gotS)
+	}
+	if err := ps.UpdateSeriesName(series.ID, "Earthsea Cycle"); err != nil {
+		t.Fatalf("UpdateSeriesName: %v", err)
+	}
+	if gotS, _ = ps.GetSeriesByID(series.ID); gotS == nil || gotS.Name != "Earthsea Cycle" {
+		t.Errorf("series rename not persisted: got %+v", gotS)
+	}
+}

--- a/internal/database/dbtest/invariants.go
+++ b/internal/database/dbtest/invariants.go
@@ -1,0 +1,178 @@
+// file: internal/database/dbtest/invariants.go
+// version: 1.0.0
+// guid: b1d2f3a4-5c6e-7a8b-9c0d-invariantsdbt1
+// last-edited: 2026-07-13
+
+// Package dbtest holds cross-package TEST-ONLY helpers for asserting
+// data-loss / store-consistency invariants against a real database.Store.
+//
+// It lives in its own package (not a _test.go file) for exactly one reason:
+// the store-invariant assertion must be callable from BOTH the database
+// package's white-box tests and the merge package's tests. A white-box
+// (`package database`) test file cannot import a helper that imports
+// `database` without creating an import cycle, so the shared, PUBLIC-API-only
+// portion of the invariant check lives here where any test package can reach
+// it. Nothing in the production build imports this package.
+//
+// The checks here use ONLY the exported database.Store surface, so they are
+// portable but cannot see raw secondary-index rows. Two limitations follow from
+// the public surface and are covered instead by the database package's own
+// white-box helper (assertStoreInvariants in store_invariants_test.go):
+//   - ListBookIDs (memdb-backed) omits soft-deleted books, so invariant (a)
+//     ("live primary AND MarkedForDeletion") is effectively vacuous here — a
+//     book in that contradictory state would not be enumerated. The white-box
+//     helper scans raw primary rows and checks it properly.
+//   - The "no dangling index row" check needs the unexported *PebbleStore.db.
+//
+// What this helper DOES robustly verify (via GetBookByID, which returns
+// soft-deleted rows too): index listings never surface a soft-deleted or
+// non-existent book as live, and every live book is discoverable via its
+// own indexes.
+package dbtest
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// AssertStoreInvariants scans every book reachable via the public Store API
+// and asserts the store-consistency invariants that guard the data-loss bug
+// classes fixed on main:
+//
+//	(a) No book is BOTH a live primary version AND MarkedForDeletion — a merge
+//	    that half-applied could leave a row in this contradictory state.
+//	(b) Every secondary-index-backed listing (work, version-group, file-path,
+//	    iTunes persistent ID) resolves to books that actually exist and whose
+//	    soft/hard-delete state matches — i.e. a soft-deleted or hard-deleted
+//	    book must never surface as live in an index listing, and a live book
+//	    must be discoverable through its own indexes.
+//
+// It is intentionally cheap (a ListBookIDs + point reads) so it can run inline
+// at the end of merge/combine/delete tests without meaningfully slowing them.
+func AssertStoreInvariants(tb testing.TB, store database.Store) {
+	tb.Helper()
+
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		tb.Fatalf("invariant: ListBookIDs: %v", err)
+	}
+
+	live := map[string]*database.Book{}
+	all := map[string]*database.Book{}
+	for _, id := range ids {
+		b, err := store.GetBookByID(id)
+		if err != nil {
+			tb.Fatalf("invariant: GetBookByID(%s): %v", id, err)
+		}
+		if b == nil {
+			// ListBookIDs returned an ID that no longer resolves — a dangling
+			// primary listing. That is itself a consistency violation.
+			tb.Errorf("invariant (b): ListBookIDs returned %s but GetBookByID is nil (dangling primary)", id)
+			continue
+		}
+		all[id] = b
+		marked := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+
+		// (a) live-primary && marked-for-deletion is contradictory.
+		if marked && b.IsPrimaryVersion != nil && *b.IsPrimaryVersion {
+			tb.Errorf("invariant (a): book %s is a live primary version AND MarkedForDeletion", id)
+		}
+		if !marked {
+			live[id] = b
+		}
+	}
+
+	// (b) Nothing an index listing returns may be soft-deleted or non-existent,
+	// and any book it returns must resolve. Check the work + version-group
+	// listings, which historically embedded stale Book snapshots.
+	seenWork := map[string]bool{}
+	seenVG := map[string]bool{}
+	for _, b := range all {
+		if b.WorkID != nil && *b.WorkID != "" && !seenWork[*b.WorkID] {
+			seenWork[*b.WorkID] = true
+			got, err := store.GetBooksByWorkID(*b.WorkID)
+			if err != nil {
+				tb.Fatalf("invariant: GetBooksByWorkID(%s): %v", *b.WorkID, err)
+			}
+			assertListingLive(tb, store, "work "+*b.WorkID, got)
+		}
+		if b.VersionGroupID != nil && *b.VersionGroupID != "" && !seenVG[*b.VersionGroupID] {
+			seenVG[*b.VersionGroupID] = true
+			got, err := store.GetBooksByVersionGroup(*b.VersionGroupID)
+			if err != nil {
+				tb.Fatalf("invariant: GetBooksByVersionGroup(%s): %v", *b.VersionGroupID, err)
+			}
+			assertListingLive(tb, store, "versiongroup "+*b.VersionGroupID, got)
+		}
+	}
+
+	// (b) A LIVE book must be discoverable by its own work/version-group listing.
+	for id, b := range live {
+		if b.WorkID != nil && *b.WorkID != "" {
+			got, _ := store.GetBooksByWorkID(*b.WorkID)
+			if !containsID(got, id) {
+				tb.Errorf("invariant (b): live book %s absent from its own work listing %s", id, *b.WorkID)
+			}
+		}
+		if b.VersionGroupID != nil && *b.VersionGroupID != "" {
+			got, _ := store.GetBooksByVersionGroup(*b.VersionGroupID)
+			if !containsID(got, id) {
+				tb.Errorf("invariant (b): live book %s absent from its own version-group listing %s", id, *b.VersionGroupID)
+			}
+		}
+		// (b) The file-path index must resolve to a book carrying that exact path.
+		if b.FilePath != "" {
+			byPath, err := store.GetBookByFilePath(b.FilePath)
+			if err != nil {
+				tb.Fatalf("invariant: GetBookByFilePath(%s): %v", b.FilePath, err)
+			}
+			if byPath == nil {
+				tb.Errorf("invariant (b): live book %s path %q not resolvable via path index", id, b.FilePath)
+			} else if byPath.FilePath != b.FilePath {
+				tb.Errorf("invariant (b): path index for %q resolved to a book with path %q", b.FilePath, byPath.FilePath)
+			}
+		}
+		// (b) The iTunes-persistent-ID lookup must resolve to an existing book.
+		if b.ITunesPersistentID != nil && *b.ITunesPersistentID != "" {
+			byPID, err := store.GetBookByITunesPersistentID(*b.ITunesPersistentID)
+			if err != nil {
+				tb.Fatalf("invariant: GetBookByITunesPersistentID(%s): %v", *b.ITunesPersistentID, err)
+			}
+			if byPID == nil {
+				tb.Errorf("invariant (b): live book %s iTunes PID %q not resolvable", id, *b.ITunesPersistentID)
+			}
+		}
+	}
+}
+
+// assertListingLive asserts every book an index listing returned still exists
+// and is not soft-deleted. Existence is re-checked via GetBookByID (which
+// returns soft-deleted rows too) rather than the ListBookIDs-derived set, since
+// ListBookIDs omits soft-deleted books and would misclassify them.
+func assertListingLive(tb testing.TB, store database.Store, label string, got []database.Book) {
+	tb.Helper()
+	for i := range got {
+		b := &got[i]
+		stored, err := store.GetBookByID(b.ID)
+		if err != nil {
+			tb.Fatalf("invariant: GetBookByID(%s): %v", b.ID, err)
+		}
+		if stored == nil {
+			tb.Errorf("invariant (b): listing %s returned hard-deleted/nonexistent book %s as live", label, b.ID)
+			continue
+		}
+		if stored.MarkedForDeletion != nil && *stored.MarkedForDeletion {
+			tb.Errorf("invariant (b): listing %s returned soft-deleted book %s as live", label, b.ID)
+		}
+	}
+}
+
+func containsID(books []database.Book, id string) bool {
+	for i := range books {
+		if books[i].ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/database/store_invariants_test.go
+++ b/internal/database/store_invariants_test.go
@@ -1,0 +1,255 @@
+// file: internal/database/store_invariants_test.go
+// version: 1.1.0
+// guid: c2e3f4a5-6b7c-8d9e-0f1a-storeinvar0001
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// assertStoreInvariants is the white-box store-consistency checker. It lives in
+// `package database` (not internal/database/dbtest) so it can reach the
+// unexported *PebbleStore.db for the raw checks that the public helper cannot
+// do. It is deliberately NOT importing dbtest — a white-box test importing a
+// package that imports `database` would be an import cycle.
+//
+// Invariants:
+//
+//	(a) No book is both a live primary version AND MarkedForDeletion.
+//	(b) Every work/version-group/path listing resolves to existing, non-soft-
+//	    deleted books (a soft/hard-deleted book must never surface as live in a
+//	    listing), and every live book is discoverable via its own indexes.
+//	(c) No dangling index row: every book:path:, book:work:, book:versiongroup:,
+//	    book:isbn10:/isbn13:/asin:, and tag_idx: row references a book that
+//	    PHYSICALLY exists (a soft-deleted book still exists and legitimately
+//	    keeps its rows; only a HARD-deleted book must have none).
+//
+// Physical existence is taken from a raw scan of the primary book:<id> rows
+// (which includes soft-deleted books), NOT from ListBookIDs — the memdb-backed
+// ListBookIDs omits soft-deleted books, so using it here would false-positive a
+// soft-deleted book's still-valid index rows as "dangling".
+func assertStoreInvariants(t *testing.T, store Store) {
+	t.Helper()
+	ps, ok := store.(*PebbleStore)
+	if !ok {
+		t.Fatalf("invariant: store is not *PebbleStore: %T", store)
+	}
+
+	// Physical book set (includes soft-deleted) via raw primary-row scan.
+	all := map[string]*Book{}
+	{
+		iter := mustIter(t, ps, "book:0", "book:;")
+		defer iter.Close()
+		for iter.First(); iter.Valid(); iter.Next() {
+			key := string(iter.Key())
+			// Primary key form is exactly "book:<ulid>" — one colon, colon-free id.
+			rest := strings.TrimPrefix(key, "book:")
+			if strings.IndexByte(rest, ':') >= 0 {
+				continue // secondary-index key (book:path:, book:work:, …)
+			}
+			var b Book
+			if err := json.Unmarshal(iter.Value(), &b); err != nil {
+				t.Fatalf("invariant: unmarshal %q: %v", key, err)
+			}
+			all[rest] = &b
+		}
+	}
+
+	live := map[string]*Book{}
+	for id, b := range all {
+		marked := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+		if marked && b.IsPrimaryVersion != nil && *b.IsPrimaryVersion {
+			t.Errorf("invariant (a): book %s is a live primary version AND MarkedForDeletion", id)
+		}
+		if !marked {
+			live[id] = b
+		}
+	}
+
+	// (b) index listings return only existing, non-soft-deleted books; live
+	// books appear in their own listings.
+	seenWork, seenVG := map[string]bool{}, map[string]bool{}
+	for _, b := range all {
+		if b.WorkID != nil && *b.WorkID != "" && !seenWork[*b.WorkID] {
+			seenWork[*b.WorkID] = true
+			got, err := store.GetBooksByWorkID(*b.WorkID)
+			if err != nil {
+				t.Fatalf("invariant: GetBooksByWorkID: %v", err)
+			}
+			assertListingLiveWB(t, "work "+*b.WorkID, got, all)
+		}
+		if b.VersionGroupID != nil && *b.VersionGroupID != "" && !seenVG[*b.VersionGroupID] {
+			seenVG[*b.VersionGroupID] = true
+			got, err := store.GetBooksByVersionGroup(*b.VersionGroupID)
+			if err != nil {
+				t.Fatalf("invariant: GetBooksByVersionGroup: %v", err)
+			}
+			assertListingLiveWB(t, "versiongroup "+*b.VersionGroupID, got, all)
+		}
+	}
+	for id, b := range live {
+		if b.WorkID != nil && *b.WorkID != "" {
+			got, _ := store.GetBooksByWorkID(*b.WorkID)
+			if !containsIDWB(got, id) {
+				t.Errorf("invariant (b): live book %s absent from work listing %s", id, *b.WorkID)
+			}
+		}
+		if b.FilePath != "" {
+			byPath, err := store.GetBookByFilePath(b.FilePath)
+			if err != nil {
+				t.Fatalf("invariant: GetBookByFilePath: %v", err)
+			}
+			if byPath == nil || byPath.ID != id {
+				t.Errorf("invariant (b): path index for %q did not resolve back to book %s (got %v)", b.FilePath, id, byPath)
+			}
+		}
+	}
+
+	// (c) No dangling secondary-index rows. Book must physically exist in `all`.
+	exists := func(id string) bool { return all[id] != nil }
+	scanValueIsID(t, ps, "book:path:", exists)
+	for _, prefix := range []string{
+		"book:work:",
+		"book:versiongroup:",
+		"book:isbn10:",
+		"book:isbn13:",
+		"book:asin:",
+		"tag_idx:",
+	} {
+		scanTrailingKeyIsID(t, ps, prefix, exists)
+	}
+}
+
+func assertListingLiveWB(t *testing.T, label string, got []Book, all map[string]*Book) {
+	t.Helper()
+	for i := range got {
+		b := &got[i]
+		stored, ok := all[b.ID]
+		if !ok {
+			t.Errorf("invariant (b): listing %s returned unknown/hard-deleted book %s", label, b.ID)
+			continue
+		}
+		if stored.MarkedForDeletion != nil && *stored.MarkedForDeletion {
+			t.Errorf("invariant (b): listing %s returned soft-deleted book %s as live", label, b.ID)
+		}
+	}
+}
+
+func containsIDWB(books []Book, id string) bool {
+	for i := range books {
+		if books[i].ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func scanValueIsID(t *testing.T, ps *PebbleStore, prefix string, exists func(string) bool) {
+	t.Helper()
+	iter := mustIterPrefix(t, ps, prefix)
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		id := string(iter.Value())
+		if id != "" && !exists(id) {
+			t.Errorf("invariant (c): dangling %s row %q → nonexistent book %q", prefix, string(iter.Key()), id)
+		}
+	}
+}
+
+func scanTrailingKeyIsID(t *testing.T, ps *PebbleStore, prefix string, exists func(string) bool) {
+	t.Helper()
+	iter := mustIterPrefix(t, ps, prefix)
+	defer iter.Close()
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := string(iter.Key())
+		idx := strings.LastIndex(key, ":")
+		if idx < 0 || idx+1 >= len(key) {
+			continue
+		}
+		id := key[idx+1:]
+		if !exists(id) {
+			t.Errorf("invariant (c): dangling %s row %q → nonexistent book %q", prefix, key, id)
+		}
+	}
+}
+
+func mustIterPrefix(t *testing.T, ps *PebbleStore, prefix string) *pebble.Iterator {
+	t.Helper()
+	ub := append([]byte(nil), []byte(prefix)...)
+	ub[len(ub)-1]++ // prefix end
+	return mustIter(t, ps, prefix, string(ub))
+}
+
+func mustIter(t *testing.T, ps *PebbleStore, lower, upper string) *pebble.Iterator {
+	t.Helper()
+	iter, err := ps.db.NewIter(&pebble.IterOptions{LowerBound: []byte(lower), UpperBound: []byte(upper)})
+	if err != nil {
+		t.Fatalf("invariant: NewIter(%q,%q): %v", lower, upper, err)
+	}
+	return iter
+}
+
+// TestStoreInvariants_CleanStore proves the helper passes on a normal store
+// with live books, a shared work ID, and tags — a baseline so a later failure
+// means a real inconsistency, not a broken assertion.
+func TestStoreInvariants_CleanStore(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	wid := "WORK0000000000000000000AAA"
+	for _, title := range []string{"Alpha", "Beta", "Gamma"} {
+		created, err := store.CreateBook(&Book{Title: title, FilePath: "/lib/" + title + ".m4b", WorkID: strPtr(wid)})
+		if err != nil {
+			t.Fatalf("CreateBook: %v", err)
+		}
+		if err := store.SetBookTags(created.ID, []string{"genre:fantasy", "favorite"}); err != nil {
+			t.Fatalf("SetBookTags: %v", err)
+		}
+	}
+	assertStoreInvariants(t, store)
+}
+
+// TestStoreInvariants_SoftThenHardDelete exercises the delete/soft-delete paths.
+// A soft-deleted book still physically exists and keeps its index rows (must NOT
+// be flagged); a hard-deleted book must have its row + all index rows gone.
+func TestStoreInvariants_SoftThenHardDelete(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+
+	wid := "WORK0000000000000000000BBB"
+	a, err := store.CreateBook(&Book{Title: "Keeper", FilePath: "/lib/keeper.m4b", WorkID: strPtr(wid)})
+	if err != nil {
+		t.Fatalf("CreateBook a: %v", err)
+	}
+	b, err := store.CreateBook(&Book{Title: "Doomed", FilePath: "/lib/doomed.m4b", WorkID: strPtr(wid)})
+	if err != nil {
+		t.Fatalf("CreateBook b: %v", err)
+	}
+
+	// Soft-delete b via UpdateBook (mirrors merge.SoftDeleteBook). b still exists.
+	upd := *b
+	tru := true
+	upd.MarkedForDeletion = &tru
+	if _, err := store.UpdateBook(b.ID, &upd); err != nil {
+		t.Fatalf("soft-delete UpdateBook: %v", err)
+	}
+	assertStoreInvariants(t, store)
+	if got, _ := store.GetBooksByWorkID(wid); containsIDWB(got, b.ID) {
+		t.Errorf("soft-deleted book %s still live in work listing", b.ID)
+	}
+
+	// Hard-delete b: row + index rows must be gone (no dangling rows).
+	if err := store.DeleteBook(b.ID); err != nil {
+		t.Fatalf("DeleteBook: %v", err)
+	}
+	assertStoreInvariants(t, store)
+	if got, err := store.GetBookByID(a.ID); err != nil || got == nil {
+		t.Fatalf("survivor a lost: err=%v got=%v", err, got)
+	}
+}

--- a/internal/merge/combine_test.go
+++ b/internal/merge/combine_test.go
@@ -1,6 +1,7 @@
 // file: internal/merge/combine_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c8e4d1a-9f3b-4e6a-8b7c-1d2e3f4a5b6c
+// last-edited: 2026-07-13
 // last-edited: 2026-06-21
 
 package merge
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
 	ulid "github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,6 +106,11 @@ func TestService_CombineBooks(t *testing.T) {
 		assert.True(t, got["PID-1"], "PID-1 reassigned to survivor")
 		assert.True(t, got["PID-3"], "PID-3 reassigned to survivor")
 	}
+
+	// Data-loss invariant: after a combine (which deletes the absorbed books and
+	// materializes files on the survivor) the store must have no dangling index
+	// rows or contradictory book states.
+	dbtest.AssertStoreInvariants(t, store)
 }
 
 func TestService_CombineBooks_TooFew(t *testing.T) {

--- a/internal/merge/service_concurrent_test.go
+++ b/internal/merge/service_concurrent_test.go
@@ -1,5 +1,5 @@
 // file: internal/merge/service_concurrent_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5c8a1f42-9d6b-4e73-8a10-2b4c6d9e0f13
 // last-edited: 2026-07-13
 
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -136,6 +137,13 @@ func TestMergeBooks_ConcurrentSamePair_Serializes(t *testing.T) {
 	if a.MarkedForDeletion == nil || !*a.MarkedForDeletion {
 		t.Fatalf("loser A was not soft-deleted")
 	}
+
+	// Whole-store data-loss invariant, asserted AFTER the concurrent-merge race
+	// that actually produces bug class #3. This is the only place the merge-race
+	// corruption condition is triggered, so it is the meaningful place to assert
+	// no book is both live-primary and soft-deleted, no listing shows a deleted
+	// book, and no index row dangles.
+	dbtest.AssertStoreInvariants(t, real)
 }
 
 // TestMergeFamily_CombineAndMerge_ShareOneLock proves CombineBooks serializes on
@@ -206,4 +214,8 @@ func TestMergeFamily_CombineAndMerge_ShareOneLock(t *testing.T) {
 		*a1.VersionGroupID == "" || *a1.VersionGroupID != *b1.VersionGroupID {
 		t.Fatalf("merged pair not in one consistent version group: a=%+v b=%+v", a1, b1)
 	}
+
+	// Whole-store invariant after the concurrent Combine+Merge race across all
+	// pairs (combine hard-deletes an absorbed book; merge soft-deletes a loser).
+	dbtest.AssertStoreInvariants(t, real)
 }

--- a/internal/merge/service_test.go
+++ b/internal/merge/service_test.go
@@ -1,5 +1,6 @@
 // file: internal/merge/service_test.go
-// version: 1.0.0
+// version: 1.1.0
+// last-edited: 2026-07-13
 
 package merge
 
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
 	ulid "github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -74,6 +76,10 @@ func TestService_MergeBooks(t *testing.T) {
 	assert.Equal(t, result.VersionGroupID, *b2.VersionGroupID)
 	require.NotNil(t, b2.IsPrimaryVersion)
 	assert.True(t, *b2.IsPrimaryVersion)
+
+	// Data-loss invariant: a merge must never leave the store inconsistent
+	// (e.g. a book both live-primary and soft-deleted, or a survivor vanished).
+	dbtest.AssertStoreInvariants(t, store)
 }
 
 func TestService_MergeBooks_ExplicitPrimary(t *testing.T) {

--- a/internal/merge/service_test.go
+++ b/internal/merge/service_test.go
@@ -1,5 +1,6 @@
 // file: internal/merge/service_test.go
 // version: 1.1.0
+// guid: 9b3d7e21-4a6c-4f08-8e15-7c2a9d4b6e30
 // last-edited: 2026-07-13
 
 package merge


### PR DESCRIPTION
## What this adds

Class-level regression coverage for the four data-loss bug classes recently fixed on `main`, each a **real test on a real `PebbleStore`**. These complement the existing *point* regression tests with *invariants* that fail automatically when a future change reintroduces a whole class of bug. **TEST-ONLY — no production code changed.**

## ⚠ Did any new invariant surface a REAL bug?

**No.** Every invariant passes against current `main` under `-race`. (One failure appeared during development — it was a bug in *my own* T3 helper: it derived "does this book exist" from `ListBookIDs()`, which on the memdb path omits soft-deleted books, so a soft-deleted book's still-valid index rows looked "dangling." Soft-deleted books physically exist and correctly keep their rows; the helper now checks physical existence via a raw primary-row scan / `GetBookByID`. Not a production issue.)

## What each test class guards

- **T1 — reflective heavy-field preservation** (`dataloss_preserve_invariant_test.go`) — *the crown jewel.* Reflection derives the must-preserve set by diffing a fully-populated `Book` against `stripBookForMemdb`, then asserts each stripped field survives a memdb-round-trip `UpdateBook` (that one field nil, the rest intact). Adding a heavy field to `stripBookForMemdb` without a matching `UpdateBook` preserve-on-nil guard now fails the build. `wantStrippedCount = 9` tripwire + a populator that `t.Fatal`s on an unhandled field type keep it drift-proof.
- **T2 — round-trip fidelity** (`dataloss_roundtrip_test.go`) — writes a fully-populated record back UNCHANGED via `UpdateBook`/`UpdateBookFile`, asserts field-by-field equality. Exclusion set is decided a-priori from struct semantics and documented (UpdateBook: `CreatedAt`/`UpdatedAt`; UpdateBookFile: identity/timestamps + `AcoustIDSeg0..6` dropped by `marshalBookFileDropSegs`). A field outside that set failing = a real wipe.
- **T3 — store-consistency invariants** — `dbtest.AssertStoreInvariants` (public, interface-only, importable by `merge`) + white-box `assertStoreInvariants` (raw index-row scan). Checks: (a) no book both live-primary and `MarkedForDeletion`; (b) no index listing surfaces a soft/hard-deleted book; (c) no dangling `book:path`/`book:work`/`book:versiongroup`/`book:isbn*`/`book:asin`/`tag_idx` row. Wired into the existing `merge` combine/merge tests.
- **T4 — concurrency harness** (`-race`) — N partitioned workers run interleaved `UpdateBook`/soft-delete/`DeleteBook`, then invariant check. Deterministic seeds, no sleeps.
- **T5 — key-encoding property test** — delimiter/unicode-laden titles, paths, tags, work IDs, author/series names resolve to exactly the right record and nothing sharing a prefix (generalizes the tag-colon-parse fix; includes the classic `genre` vs `genre:fantasy` discrimination).
- **T6 — named regression (gaps only)** — added the missing **path-rename stale-index-row** regression. Scenarios already covered on `main` were intentionally **not** duplicated: soft-delete work/version-group exclusion, DeleteBook dangling-row, narrator id-race (`pebble_store_index_consistency_test.go`); UpdateBook/BookFile preserve (`pebble_book_preserve_test.go`, `pebble_bookfile_preserve_test.go`); tag/author/series colon collision (`store_coverage_test.go`); author-split write-back (`plugins/maintenance/`); merge serialization (`merge/service_concurrent_test.go`).

## Task-brief vs reality note

The brief listed `UpsertAuthor`/`UpsertSeries` as full-replace setters — **they do not exist.** Authors (`{ID,Name}`) and Series (`{ID,Name,AuthorID}`) carry no heavy/denormalized fields and use field-specific setters (`CreateAuthor`/`UpdateAuthorName`, `CreateSeries`/`UpdateSeriesName`), so the write-back-wipe class does not apply. Per the test-only rule, no production `Upsert*` helper was added; T2 covers the setters that exist.

## Verification

`go test ./internal/database/... ./internal/merge/... -race` — all green. `go build ./...`, `go vet`, `gofmt -l` clean. CHANGELOG + TODO updated. Executive summary intentionally skipped (test-only, no production/data-loss change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv