### PR TITLE
fix(metafetch): share rate-limiter/breaker across batch + per-request throttle + cancellable Audnexus lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.150.0 -->
+<!-- version: 3.151.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -8,6 +8,51 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - fix(metafetch): share rate-limiter/breaker across batch + per-request throttle + cancellable Audnexus lookup
+
+Three confirmed reliability bugs in the external-metadata layer:
+
+- **Hardcover limiter + circuit breaker recreated per book (rate limit never
+  enforced across a batch)** — `Service.BuildSourceChain()`
+  (`internal/metafetch/service_search.go`) built fresh source clients and
+  `ProtectedSource` circuit breakers on every call, and it is called once per
+  book by `FetchMetadataForBook`, `SearchMetadataForBookWithOptions`,
+  `FetchMetadataForBookByTitle`, and the metadata-upgrade op. Hardcover's 60-rpm
+  limiter (its `requestLog`) and each source's breaker state therefore reset
+  every book, so across a batch they never accumulated: a thundering herd got
+  through and the breaker could never trip for a down source. **Fixed** by
+  memoizing the chain on the `Service`, keyed on a fingerprint of the
+  metadata-source config — the same `*ProtectedSource`/client instances are reused
+  across every per-book fetch (limiter + breaker persist), and the chain rebuilds
+  only when the source config changes at runtime. The shared chain is
+  goroutine-safe: all source clients are stateless (`http.Client` + immutable
+  config) and the Hardcover limiter and `CircuitBreaker` each carry their own mutex.
+- **Global 10 req/s limiter consumed once per book, not per HTTP call** — the
+  candidate-fetch op (`internal/server/metadata_batch_candidates.go`) called
+  `limiter.Wait(ctx)` ONCE per book, then issued many HTTP calls (up to 5 sources ×
+  several title attempts). With `rate.NewLimiter(10, 1)` and 8 workers, "10/sec"
+  actually permitted ~10 *books*/sec = a large multiple in outbound requests.
+  **Fixed** by threading the limiter into the search core
+  (`searchMetadataForBook` + new `FetchAndCacheLimited`) so each LIVE source call
+  acquires one token (cache hits consume none) — the 10/s ceiling now governs
+  actual requests. The interactive search-dialog and bulk-fetch paths pass a nil
+  limiter and are unchanged.
+- **Audnexus ASIN lookup ignored context (up to 270s uninterruptible)** —
+  `AudnexusClient.LookupByASIN` (`internal/metadata/audnexus.go`) looped 9 regions
+  with `httpClient.Get` and no context, so a missing/unreachable record burned up
+  to 9×30s and could not be cancelled by a batch cancel. **Fixed** by threading a
+  `context.Context` into the region loop (`http.NewRequestWithContext`), bailing on
+  `ctx.Done()`, and bounding each region request with a 10s per-request timeout
+  (worst case ~90s). The candidate op's direct-ASIN path now passes a real
+  cancellable ctx; the auto-fetch `SearchByContext` caller has no ctx to thread
+  yet (its `FetchMetadataForBook` entry point is context-free) so it is bounded to
+  ~90s but not promptly cancellable — full cancellation there is a follow-up that
+  needs a ctx on `FetchMetadataForBook`.
+- Tests: `BuildSourceChain` memoization + breaker-persistence-across-calls
+  (`internal/metafetch/reliability_test.go`), per-request limiter granularity
+  (timing), and cancelled-context / already-cancelled Audnexus region-loop abort
+  (`internal/metadata/audnexus_test.go`).
 
 #### July 13, 2026 - fix(web): stop BookDetail load race + orphaned SSE EventSource leak
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.102.0 -->
+<!-- version: 9.103.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -17,6 +17,32 @@ future agent) can scan the entire workspace in one page.
 - [`docs/implementation-guide.md`](docs/implementation-guide.md) — integration guide for open items
 - [`docs/codebase-evaluation.md`](docs/codebase-evaluation.md) — 2026-04-30 codebase audit (12 issue groups, 38 bot-tasks)
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
+
+---
+
+## ✅ RESOLVED — Metadata rate-limit sharing + per-request throttle + cancellable Audnexus (2026-07-13)
+
+Three confirmed reliability bugs in the external-metadata layer. (1) `BuildSourceChain`
+rebuilt the source clients + circuit breakers on every per-book call, so Hardcover's
+60-rpm limiter and each source's breaker never accumulated across a batch (thundering
+herd; breaker could never trip). **Fixed** by memoizing the chain on the `Service`
+(fingerprinted on source config), so limiter + breaker persist. (2) The candidate-fetch
+op consumed the 10 req/s limiter once per book while issuing many HTTP calls per book —
+"10/s" meant ~10 books/s. **Fixed** by threading the limiter into the search core
+(`FetchAndCacheLimited`) so it gates each live source call. (3) Audnexus `LookupByASIN`
+looped 9 regions with no context (up to 270s, uncancellable). **Fixed** with
+`http.NewRequestWithContext` per region + `ctx.Done()` bail + 10s per-request timeout.
+
+**Follow-up (open):** the auto-fetch/importer path (`FetchMetadataForBook` →
+`SearchByContext` → `LookupByASIN`) is now bounded to ~90s but not promptly cancellable,
+because `FetchMetadataForBook` has no `context.Context`. Threading a ctx through
+`FetchMetadataForBook` (+ its interface, mock, and the itunes-importer/organizer/handler
+call sites) would make that path fully cancellable.
+
+Files: `internal/metafetch/service.go`, `internal/metafetch/service_search.go`,
+`internal/metafetch/cache.go`, `internal/metadata/audnexus.go`,
+`internal/server/metadata_batch_candidates.go`. Tests in
+`internal/metafetch/reliability_test.go` + `internal/metadata/audnexus_test.go`.
 
 ---
 

--- a/docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md
@@ -1,0 +1,52 @@
+<!-- file: docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9d2f6b41-8c37-4e5a-b0d9-1a2c3e4f5b6a -->
+<!-- last-edited: 2026-07-13 -->
+
+# Executive Summary: Metadata Lookups That No Longer Hammer or Hang
+
+## What changed
+
+When the app looks up book information (cover, author, series, narrator) from
+outside services like Audible, Open Library, and Hardcover, it is supposed to be
+polite: only so many requests per second, back off automatically when a service
+is having problems, and never get stuck for minutes on a single book. Three bugs
+meant it was doing none of those reliably during large batch runs.
+
+- **It ignored its own speed limit.** The part that decides "only 10 requests a
+  second" was checking the limit once per *book*, but each book fans out into
+  many actual requests across several services. In a batch with several workers,
+  that let it fire far more than 10 requests a second at the outside services —
+  a stampede that can get us throttled or temporarily blocked. It now counts the
+  real requests, so the limit means what it says.
+
+- **It kept forgetting a service was down.** The app has a "circuit breaker"
+  that stops calling a service after it fails repeatedly, plus a per-service rate
+  limiter — but both were being thrown away and rebuilt for *every single book*.
+  So across a batch they never added up: the breaker could never actually trip,
+  and the rate limiter never accumulated. These are now shared across the whole
+  run, so a failing service is skipped instead of retried thousands of times.
+
+- **One missing book could freeze a lookup for over four minutes.** Looking up a
+  book by its Audible ID tried nine regional stores one after another, each
+  waiting up to 30 seconds, with no way to interrupt it — up to 270 seconds
+  stuck on a single unfound book, and a "cancel" on the batch couldn't stop it.
+  Each regional attempt is now capped at 10 seconds (worst case ~90 seconds
+  instead of 270), and the loop stops immediately when the work is cancelled.
+
+## Why it mattered
+
+These only bit during bulk metadata runs, which is exactly when they hurt most:
+a full-library fetch could stampede external services (risking rate-limit
+blocks), keep pounding a service that was already down, and stall for minutes on
+individual problem books — with a "cancel" that didn't fully work. No book data
+was lost or corrupted; this is about the app being well-behaved and responsive
+when talking to the outside world.
+
+## Known limitation
+
+The everyday auto-fetch path (used when importing) is now *bounded* — it can no
+longer hang for 270 seconds — but it can't yet be *instantly* cancelled mid-book,
+because that entry point doesn't carry a cancellation signal. Worst case there is
+about 90 seconds per stuck book. Making it instantly cancellable is a tracked
+follow-up.

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audnexus.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
 // last-edited: 2026-07-13
 
@@ -142,8 +142,13 @@ func (c *AudnexusClient) SearchByContext(ctx *SearchContext) ([]BookMetadata, er
 		return nil, nil
 	}
 
-	// Look up the book by ASIN
-	metadata, err := c.LookupByASIN(ctx.ASIN)
+	// Look up the book by ASIN. This ContextualSearch entry point carries no
+	// Go context.Context (its caller, FetchMetadataForBook, has none to thread),
+	// so we use context.Background(); LookupByASIN still bounds each region
+	// request with a per-request timeout so a missing/unreachable ASIN can't burn
+	// the full 9×30s. Callers that DO hold a cancellable ctx (the candidate op's
+	// direct-ASIN path) call LookupByASIN directly with it.
+	metadata, err := c.LookupByASIN(context.Background(), ctx.ASIN)
 	if err != nil {
 		return nil, err
 	}
@@ -157,36 +162,80 @@ func (c *AudnexusClient) SearchByContext(ctx *SearchContext) ([]BookMetadata, er
 // Some books are only available in certain regional Audible stores.
 var audnexusRegions = []string{"", "us", "uk", "au", "ca", "in", "de", "fr", "jp"}
 
+// audnexusPerRegionTimeout bounds a single region request so one slow/unreachable
+// regional Audible store can't consume the whole lookup budget. Nine regions ×
+// this cap is the worst case for a missing ASIN (was 9×30s = 270s uninterruptible
+// before contexts were threaded).
+const audnexusPerRegionTimeout = 10 * time.Second
+
 // LookupByASIN fetches a book directly by its Audible ASIN.
 // Tries multiple regions since books may only be indexed in certain Audible stores.
-func (c *AudnexusClient) LookupByASIN(asin string) (*BookMetadata, error) {
+//
+// The region loop honors ctx: it bails immediately when ctx is cancelled/expired
+// (so a batch cancel aborts promptly instead of grinding through all 9 regions),
+// and each region request is additionally bounded by audnexusPerRegionTimeout via
+// http.NewRequestWithContext so a single hung region can't stall the lookup.
+func (c *AudnexusClient) LookupByASIN(ctx context.Context, asin string) (*BookMetadata, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
 	for _, region := range audnexusRegions {
-		bookURL := fmt.Sprintf("%s/books/%s", c.baseURL, url.PathEscape(asin))
-		if region != "" {
-			bookURL += "?region=" + region
-		}
-		resp, err := c.httpClient.Get(bookURL)
-		if err != nil {
-			lastErr = fmt.Errorf("failed to lookup Audnexus book: %w", err)
-			continue
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			var book audnexusBook
-			if err := json.UnmarshalRead(resp.Body, &book); err != nil {
-				resp.Body.Close()
-				lastErr = fmt.Errorf("failed to decode Audnexus book: %w", err)
-				continue
+		// Bail promptly on cancellation rather than starting another region.
+		if err := ctx.Err(); err != nil {
+			if lastErr == nil {
+				lastErr = err
 			}
-			resp.Body.Close()
-			slog.Debug("Audnexus found ASIN in region", "asin", asin, "region", region)
-			return c.bookToMetadata(&book), nil
+			return nil, lastErr
 		}
-		resp.Body.Close()
-		lastErr = fmt.Errorf("audnexus book lookup returned status %d (region=%s)", resp.StatusCode, region)
+		meta, done, err := c.lookupRegion(ctx, asin, region)
+		if done {
+			return meta, nil
+		}
+		if err != nil {
+			// Propagate a context error immediately — no other region will
+			// fare better once the caller has cancelled/timed out.
+			if ctx.Err() != nil {
+				return nil, err
+			}
+			lastErr = err
+		}
 	}
 	return nil, lastErr
+}
+
+// lookupRegion issues a single-region ASIN lookup bounded by
+// audnexusPerRegionTimeout. Returns done=true with the metadata on a hit;
+// done=false with an error to try the next region. Kept as its own function so
+// the per-request context cancel is deferred cleanly (vet-safe) rather than
+// juggling cancel() across the loop's multiple continue paths.
+func (c *AudnexusClient) lookupRegion(ctx context.Context, asin, region string) (*BookMetadata, bool, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, audnexusPerRegionTimeout)
+	defer cancel()
+
+	bookURL := fmt.Sprintf("%s/books/%s", c.baseURL, url.PathEscape(asin))
+	if region != "" {
+		bookURL += "?region=" + region
+	}
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, bookURL, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create Audnexus request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to lookup Audnexus book: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var book audnexusBook
+		if err := json.UnmarshalRead(resp.Body, &book); err != nil {
+			return nil, false, fmt.Errorf("failed to decode Audnexus book: %w", err)
+		}
+		slog.Debug("Audnexus found ASIN in region", "asin", asin, "region", region)
+		return c.bookToMetadata(&book), true, nil
+	}
+	return nil, false, fmt.Errorf("audnexus book lookup returned status %d (region=%s)", resp.StatusCode, region)
 }
 
 func (c *AudnexusClient) bookToMetadata(book *audnexusBook) *BookMetadata {

--- a/internal/metadata/audnexus_test.go
+++ b/internal/metadata/audnexus_test.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audnexus_test.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-c5d6e7f8a9b0
 // last-edited: 2026-07-13
 
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestAudnexusClient_Name(t *testing.T) {
@@ -54,7 +55,7 @@ func TestAudnexusClient_LookupByASIN(t *testing.T) {
 	defer server.Close()
 
 	client := NewAudnexusClientWithBaseURL(server.URL)
-	meta, err := client.LookupByASIN("B003JVHRU0")
+	meta, err := client.LookupByASIN(context.Background(), "B003JVHRU0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,9 +120,76 @@ func TestAudnexusClient_LookupByASIN_NotFound(t *testing.T) {
 	defer server.Close()
 
 	client := NewAudnexusClientWithBaseURL(server.URL)
-	_, err := client.LookupByASIN("BADASIN")
+	_, err := client.LookupByASIN(context.Background(), "BADASIN")
 	if err == nil {
 		t.Error("expected error on 404 response")
+	}
+}
+
+// TestAudnexusClient_LookupByASIN_CancelledContext verifies that a cancelled
+// context aborts the multi-region ASIN loop PROMPTLY rather than grinding
+// through all 9 regions (which previously burned up to 9×30s = 270s and could
+// not be cancelled by a batch cancel). The server hangs on every request, so
+// without context honoring, this test would time out.
+func TestAudnexusClient_LookupByASIN_CancelledContext(t *testing.T) {
+	blocked := make(chan struct{})
+	defer close(blocked)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hang until the request's context is cancelled (or the test ends).
+		select {
+		case <-r.Context().Done():
+		case <-blocked:
+		}
+	}))
+	defer server.Close()
+
+	client := NewAudnexusClientWithBaseURL(server.URL)
+
+	// Cancel shortly after starting so the FIRST region request is in-flight.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := client.LookupByASIN(ctx, "B0HANGHANG")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a cancelled lookup")
+	}
+	// Must return in well under the 270s (or even the 9×10s bounded) worst case.
+	if elapsed > 5*time.Second {
+		t.Fatalf("cancelled lookup took %v; expected prompt abort (< 5s)", elapsed)
+	}
+}
+
+// TestAudnexusClient_LookupByASIN_AlreadyCancelled verifies the loop bails on
+// the very first iteration when handed an already-cancelled context, without
+// issuing any HTTP request.
+func TestAudnexusClient_LookupByASIN_AlreadyCancelled(t *testing.T) {
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	client := NewAudnexusClientWithBaseURL(server.URL)
+	start := time.Now()
+	_, err := client.LookupByASIN(ctx, "B0CANCELED")
+	if err == nil {
+		t.Fatal("expected an error from an already-cancelled lookup")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatalf("already-cancelled lookup was not prompt: %v", time.Since(start))
+	}
+	if hits != 0 {
+		t.Fatalf("expected 0 HTTP requests for an already-cancelled ctx, got %d", hits)
 	}
 }
 

--- a/internal/metafetch/cache.go
+++ b/internal/metafetch/cache.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/cache.go
-// version: 1.2.0
+// version: 1.3.0
 //
 // Cache-layer on top of metafetch.Service. The persisted record type
 // lives in internal/database (MetadataCandidateCache) — re-exported
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"golang.org/x/time/rate"
 )
 
 // ErrStaleMetadataCache is returned by ValidateCachedIdentity when the cache
@@ -112,6 +113,29 @@ func (mfs *Service) FetchAndCache(ctx context.Context, bookID, query, author, na
 	if err != nil {
 		return nil, err
 	}
+	return mfs.cacheSearchResponse(bookID, query, author, narrator, series, resp), nil
+}
+
+// FetchAndCacheLimited is FetchAndCache for batch callers that must throttle
+// ACTUAL outbound requests: the limiter is threaded into the search core so each
+// live source call (not each book) acquires a token, and ctx is propagated so a
+// batch cancel aborts in-flight requests. Cache hits consume no tokens. A nil
+// limiter behaves exactly like FetchAndCache.
+func (mfs *Service) FetchAndCacheLimited(ctx context.Context, limiter *rate.Limiter, bookID, query, author, narrator, series string, opts SearchOptions) (*MetadataCandidateCache, error) {
+	if mfs == nil {
+		return nil, fmt.Errorf("FetchAndCacheLimited: nil Service")
+	}
+	resp, err := mfs.searchMetadataForBook(ctx, limiter, bookID, query, author, narrator, series, opts)
+	if err != nil {
+		return nil, err
+	}
+	return mfs.cacheSearchResponse(bookID, query, author, narrator, series, resp), nil
+}
+
+// cacheSearchResponse writes the top-N candidates from a search response to the
+// candidate cache (always replaces) and returns the resulting entry. Shared by
+// FetchAndCache and FetchAndCacheLimited so both persist results identically.
+func (mfs *Service) cacheSearchResponse(bookID, query, author, narrator, series string, resp *SearchMetadataResponse) *MetadataCandidateCache {
 	candidates := resp.Results
 	if len(candidates) > metadataCacheTopN {
 		candidates = candidates[:metadataCacheTopN]
@@ -136,11 +160,11 @@ func (mfs *Service) FetchAndCache(ctx context.Context, bookID, query, author, na
 		if err := mfs.db.PutMetadataCache(entry); err != nil {
 			// Cache failure should not break the user's fetch; log and
 			// continue (callers can still consume the in-memory entry).
-						slog.Warn("metafetch FetchAndCache write", "id", bookID, "error", err)
-			return entry, nil
+			slog.Warn("metafetch FetchAndCache write", "id", bookID, "error", err)
+			return entry
 		}
 	}
-	return entry, nil
+	return entry
 }
 
 // ListCachedSummaries returns one summary per cached entry, ordered

--- a/internal/metafetch/reliability_test.go
+++ b/internal/metafetch/reliability_test.go
@@ -1,0 +1,181 @@
+// file: internal/metafetch/reliability_test.go
+// version: 1.0.0
+// guid: 4b8c1d2e-3f5a-4c6b-8d7e-9a0b1c2d3e4f
+// last-edited: 2026-07-13
+//
+// Regression tests for the metadata-reliability fixes:
+//   - Bug 3: BuildSourceChain memoizes the chain so the per-source circuit
+//     breaker (and Hardcover's rate limiter) persist ACROSS per-book fetches
+//     instead of being recreated fresh each book.
+//   - Bug 4: the candidate-op search path throttles ACTUAL outbound requests
+//     (one limiter token per live source call), not once per book.
+
+package metafetch
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+)
+
+// withMetadataSourceConfig temporarily swaps the global metadata-source config
+// and restores it on cleanup. Not parallel-safe (mutates a process global), so
+// callers must NOT t.Parallel().
+func withMetadataSourceConfig(t *testing.T, sources []config.MetadataSource) {
+	t.Helper()
+	savedSources := config.AppConfig.MetadataSources
+	savedHC := config.AppConfig.HardcoverAPIToken
+	savedG := config.AppConfig.GoogleBooksAPIKey
+	t.Cleanup(func() {
+		config.AppConfig.MetadataSources = savedSources
+		config.AppConfig.HardcoverAPIToken = savedHC
+		config.AppConfig.GoogleBooksAPIKey = savedG
+	})
+	config.AppConfig.MetadataSources = sources
+}
+
+// TestBuildSourceChain_MemoizedAndBreakerPersists proves Bug 3's fix: repeated
+// BuildSourceChain calls (one per book in a batch) return the SAME
+// *ProtectedSource instances, so a circuit breaker tripped while processing one
+// book is still open for the next — the breaker can actually trip for a down
+// source, and Hardcover's limiter accumulates rather than resetting per book.
+func TestBuildSourceChain_MemoizedAndBreakerPersists(t *testing.T) {
+	withMetadataSourceConfig(t, []config.MetadataSource{
+		{ID: "openlibrary", Enabled: true, Priority: 1},
+		{ID: "audnexus", Enabled: true, Priority: 2},
+	})
+
+	mfs := NewService(&database.MockStore{})
+
+	c1 := mfs.BuildSourceChain()
+	c2 := mfs.BuildSourceChain()
+	if len(c1) != 2 || len(c2) != 2 {
+		t.Fatalf("expected 2 sources per chain, got %d and %d", len(c1), len(c2))
+	}
+	// Interface equality on *ProtectedSource compares pointers: memoization
+	// returns the identical instances across calls.
+	for i := range c1 {
+		if c1[i] != c2[i] {
+			t.Fatalf("chain element %d not memoized: %p vs %p", i, c1[i], c2[i])
+		}
+	}
+
+	// Trip the first source's breaker (5 consecutive failures = threshold).
+	ps, ok := c1[0].(*metadata.ProtectedSource)
+	if !ok {
+		t.Fatalf("expected *metadata.ProtectedSource, got %T", c1[0])
+	}
+	for i := 0; i < 5; i++ {
+		ps.Breaker().RecordFailure()
+	}
+	if got := ps.Breaker().StateName(); got != "open" {
+		t.Fatalf("breaker should be open after 5 failures, got %q", got)
+	}
+
+	// The NEXT book's chain sees the SAME breaker, still open — this is the
+	// property that was broken before (fresh breaker per book never tripped).
+	c3 := mfs.BuildSourceChain()
+	ps3, ok := c3[0].(*metadata.ProtectedSource)
+	if !ok {
+		t.Fatalf("expected *metadata.ProtectedSource, got %T", c3[0])
+	}
+	if got := ps3.Breaker().StateName(); got != "open" {
+		t.Fatalf("breaker state did not persist across BuildSourceChain calls, got %q", got)
+	}
+
+	// A config change (settings edit) must rebuild the chain with fresh instances
+	// so runtime config changes are honored.
+	config.AppConfig.MetadataSources = []config.MetadataSource{
+		{ID: "openlibrary", Enabled: true, Priority: 1},
+	}
+	c4 := mfs.BuildSourceChain()
+	if len(c4) != 1 {
+		t.Fatalf("expected 1 source after config change, got %d", len(c4))
+	}
+	if c4[0] == c1[0] {
+		t.Fatal("chain should rebuild (new instances) after a config change")
+	}
+}
+
+// countingSource records how many live source calls it received. Every method
+// returns empty results so the search short-circuits into "no candidates".
+type countingSource struct {
+	name  string
+	calls *int64
+}
+
+func (c *countingSource) Name() string { return c.name }
+func (c *countingSource) SearchByTitle(_ context.Context, _ string) ([]metadata.BookMetadata, error) {
+	atomic.AddInt64(c.calls, 1)
+	return nil, nil
+}
+func (c *countingSource) SearchByTitleAndAuthor(_ context.Context, _, _ string) ([]metadata.BookMetadata, error) {
+	atomic.AddInt64(c.calls, 1)
+	return nil, nil
+}
+
+// TestSearchMetadataForBook_LimiterGatesPerRequest proves Bug 4's fix: the
+// limiter is consumed per LIVE source call, not once per book. With N sources
+// each issuing one SearchByTitle, a limiter permitting one call per interval
+// forces total elapsed ≈ (N-1)*interval. Under the old per-book behavior the
+// whole search consumed a single token and returned effectively instantly
+// regardless of how many outbound requests it made.
+func TestSearchMetadataForBook_LimiterGatesPerRequest(t *testing.T) {
+	const nSources = 4
+	const interval = 40 * time.Millisecond
+
+	var calls int64
+	sources := make([]metadata.MetadataSource, 0, nSources)
+	for i := 0; i < nSources; i++ {
+		sources = append(sources, &countingSource{name: "src", calls: &calls})
+	}
+
+	// book.Title has no chapter markers and no author/narrator, so each source
+	// issues exactly ONE SearchByTitle call (searchTitle == book.Title).
+	book := &database.Book{ID: "b1", Title: "A Plain Title"}
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(string) (*database.Book, error) { return book, nil },
+	}
+	svc := NewService(mock)
+	svc.SetOverrideSources(sources)
+
+	// Baseline: nil limiter → no throttling → fast, and N live calls.
+	atomic.StoreInt64(&calls, 0)
+	startNoLimit := time.Now()
+	if _, err := svc.searchMetadataForBook(context.Background(), nil, "b1", "", "", "", "", SearchOptions{}); err != nil {
+		t.Fatalf("unlimited search error: %v", err)
+	}
+	elapsedNoLimit := time.Since(startNoLimit)
+	if got := atomic.LoadInt64(&calls); got != nSources {
+		t.Fatalf("expected %d live source calls, got %d", nSources, got)
+	}
+	if elapsedNoLimit > interval {
+		t.Fatalf("unlimited search should be fast, took %v", elapsedNoLimit)
+	}
+
+	// Rate-limited: one call per interval, burst 1. N calls ⇒ ≈ (N-1)*interval.
+	atomic.StoreInt64(&calls, 0)
+	limiter := rate.NewLimiter(rate.Every(interval), 1)
+	startLimited := time.Now()
+	if _, err := svc.searchMetadataForBook(context.Background(), limiter, "b1", "", "", "", "", SearchOptions{}); err != nil {
+		t.Fatalf("limited search error: %v", err)
+	}
+	elapsedLimited := time.Since(startLimited)
+	if got := atomic.LoadInt64(&calls); got != nSources {
+		t.Fatalf("expected %d live source calls under limiter, got %d", nSources, got)
+	}
+	// (N-1) waits of `interval` each; allow slack for scheduler jitter but require
+	// clearly more than a single per-book token would have cost (~0).
+	minExpected := time.Duration(nSources-2) * interval
+	if elapsedLimited < minExpected {
+		t.Fatalf("limiter did not gate per request: %d calls took only %v (want ≥ %v)",
+			nSources, elapsedLimited, minExpected)
+	}
+}

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 5.2.0
+// version: 5.3.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
-// last-edited: 2026-07-01
+// last-edited: 2026-07-13
 
 package metafetch
 
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
@@ -44,6 +45,20 @@ type Service struct {
 	// safeWriteDeps guards tag/cover writes against Deluge-protected paths.
 	// Zero-value = no guard (writes proceed in-place). Set via SetSafeWriteDeps.
 	safeWriteDeps tagger.SafeWriteDeps
+
+	// Memoized metadata-source chain. BuildSourceChain builds the client chain
+	// (each source wrapped in a circuit breaker) ONCE and reuses it across every
+	// per-book fetch so the Hardcover 60-rpm limiter (its requestLog) and the
+	// per-source circuit breakers accumulate/persist across a whole batch instead
+	// of being recreated per book. cachedChainFP is a fingerprint of the metadata
+	// source config; the chain is rebuilt only when that changes (settings edit),
+	// so runtime config changes are still honored. Guarded by chainMu. The chain
+	// itself is safe for concurrent use by the worker pools that share it: every
+	// source client is stateless (http.Client + immutable config), and the
+	// Hardcover limiter and CircuitBreaker each carry their own mutex.
+	chainMu       sync.Mutex
+	cachedChain   []metadata.MetadataSource
+	cachedChainFP string
 }
 
 type FetchMetadataResponse struct {
@@ -146,7 +161,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	if mfs.isProtectedPath(book.FilePath) {
 		libCopy := mfs.ensureLibraryCopy(book)
 		if libCopy == nil {
-						slog.Warn("cannot embed cover no library copy for protected book", "id", book.ID)
+			slog.Warn("cannot embed cover no library copy for protected book", "id", book.ID)
 			return
 		}
 		book = libCopy
@@ -161,7 +176,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		// Multi-file book
 		bookFiles, err := mfs.db.GetBookFiles(book.ID)
 		if err != nil {
-						slog.Warn("failed to list book files for cover embedding on book", "id", book.ID, "error", err)
+			slog.Warn("failed to list book files for cover embedding on book", "id", book.ID, "error", err)
 			return
 		}
 		for _, bf := range bookFiles {
@@ -191,7 +206,7 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 		if len(existingData) > 0 {
 			existingHash := fmt.Sprintf("%x", sha256.Sum256(existingData))[:12]
 			if newHash == existingHash {
-								slog.Debug("cover art unchanged for book , skipping embed", "id", book.ID)
+				slog.Debug("cover art unchanged for book , skipping embed", "id", book.ID)
 				return
 			}
 		}
@@ -206,13 +221,13 @@ func (mfs *Service) embedCoverInBookFiles(book *database.Book, coverPath string)
 	embedded := 0
 	for _, f := range files {
 		if err := tagger.EmbedCoverArtSafe(context.Background(), f, coverPath, mfs.safeWriteDeps); err != nil {
-						slog.Warn("cover art embedding failed for", "value", f, "error", err)
+			slog.Warn("cover art embedding failed for", "value", f, "error", err)
 		} else {
 			embedded++
 		}
 	}
 	if embedded > 0 {
-				slog.Info("cover art embedded into file(s) for book", "count", embedded, "id", book.ID)
+		slog.Info("cover art embedded into file(s) for book", "count", embedded, "id", book.ID)
 	}
 }
 
@@ -242,7 +257,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	// Check if we already have this exact image archived (by hash)
 	dedupDir := filepath.Join(config.AppConfig.RootDir, "covers", "dedup")
 	if err := os.MkdirAll(dedupDir, 0775); err != nil {
-				slog.Warn("failed to create cover dedup dir", "error", err)
+		slog.Warn("failed to create cover dedup dir", "error", err)
 		return
 	}
 
@@ -250,7 +265,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	if _, err := os.Stat(dedupPath); err != nil {
 		// New unique image — save to dedup store
 		if err := os.WriteFile(dedupPath, data, 0664); err != nil {
-						slog.Warn("failed to write dedup cover for", "id", bookID, "error", err)
+			slog.Warn("failed to write dedup cover for", "id", bookID, "error", err)
 			return
 		}
 	}
@@ -258,7 +273,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 	// Create a history entry that references the dedup hash instead of storing a copy
 	historyDir := filepath.Join(config.AppConfig.RootDir, "covers", "history", bookID)
 	if err := os.MkdirAll(historyDir, 0775); err != nil {
-				slog.Warn("failed to create cover history dir", "error", err)
+		slog.Warn("failed to create cover history dir", "error", err)
 		return
 	}
 
@@ -270,12 +285,12 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 		if err := os.Link(dedupPath, archivePath); err != nil {
 			// Hardlink also failed — just copy
 			if err := os.WriteFile(archivePath, data, 0664); err != nil {
-								slog.Warn("failed to archive old cover for", "id", bookID, "error", err)
+				slog.Warn("failed to archive old cover for", "id", bookID, "error", err)
 				return
 			}
 		}
 	}
-		slog.Info("archived old cover art (hash)", "path", archivePath, "hash", coverHash[:12])
+	slog.Info("archived old cover art (hash)", "path", archivePath, "hash", coverHash[:12])
 
 	// Record in metadata change history so it appears in the changelog
 	now := time.Now()
@@ -289,7 +304,7 @@ func (mfs *Service) archiveExistingCover(bookID string, audioFilePath string) {
 		ChangedAt:  now,
 	}
 	if err := mfs.db.RecordMetadataChange(record); err != nil {
-				slog.Warn("failed to record cover archive history for", "id", bookID, "error", err)
+		slog.Warn("failed to record cover archive history for", "id", bookID, "error", err)
 	}
 	// Dual-write to unified activity log
 	if mfs.activityService != nil {
@@ -445,15 +460,15 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 				bookFiles[0].FilePath = entry.TargetPath
 			}
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-								slog.Warn("failed to update book path for", "id", id, "error", err)
+				slog.Warn("failed to update book path for", "id", id, "error", err)
 			} else {
-								slog.Info("renamed single-file book", "id", id, "path", entry.TargetPath)
+				slog.Info("renamed single-file book", "id", id, "path", entry.TargetPath)
 			}
 		} else if bf, ok := bfMap[entry.SegmentID]; ok {
 			bf.FilePath = entry.TargetPath
 			bf.ITunesPath = ComputeITunesPath(entry.TargetPath)
 			if err := mfs.db.UpdateBookFile(bf.ID, bf); err != nil {
-								slog.Warn("failed to update book_file path for", "id", bf.ID, "error", err)
+				slog.Warn("failed to update book_file path for", "id", bf.ID, "error", err)
 			}
 		}
 		// Record path change for each successful rename
@@ -485,9 +500,9 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		if newBookPath != book.FilePath {
 			book.FilePath = newBookPath
 			if _, err := mfs.db.UpdateBook(id, book); err != nil {
-								slog.Warn("failed to update book path for", "id", id, "error", err)
+				slog.Warn("failed to update book path for", "id", id, "error", err)
 			} else {
-								slog.Info("renamed book files for", "id", id, "path", newBookPath)
+				slog.Info("renamed book files for", "id", id, "path", newBookPath)
 			}
 		}
 	}
@@ -499,7 +514,7 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 				bookFiles[i].ITunesPath = itunesPath
 				if !strings.HasPrefix(bookFiles[i].ID, "virtual-") {
 					if err := mfs.db.UpdateBookFile(bookFiles[i].ID, &bookFiles[i]); err != nil {
-												slog.Warn("failed to update itunes_path for book file", "id", bookFiles[i].ID, "error", err)
+						slog.Warn("failed to update itunes_path for book file", "id", bookFiles[i].ID, "error", err)
 					}
 				}
 			}
@@ -518,7 +533,7 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 	if mfs.dedupEngine != nil {
 		go func() {
 			if _, err := mfs.dedupEngine.CheckBook(context.Background(), id); err != nil {
-								slog.Warn("dedup re-check failed for book after metadata apply", "id", id, "error", err)
+				slog.Warn("dedup re-check failed for book after metadata apply", "id", id, "error", err)
 			}
 		}()
 	}

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_search.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 package metafetch
 
@@ -12,6 +12,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/falkcorp/audiobook-organizer/internal/openlibrary"
+	"golang.org/x/time/rate"
 	"log/slog"
 	"sort"
 	"strings"
@@ -52,7 +54,70 @@ func (mfs *Service) buildSearchContext(book *database.Book, searchTitle, author,
 	}
 	return ctx
 }
+
+// BuildSourceChain returns the metadata-source chain, MEMOIZED on the Service so
+// the same *ProtectedSource (and the underlying source clients) are reused across
+// every per-book fetch in a batch. This is what makes the Hardcover 60-rpm limiter
+// and the per-source circuit breakers accumulate across a batch instead of being
+// recreated fresh on each book (which let a thundering herd through and prevented
+// the breaker from ever tripping for a down source).
+//
+// The memo is keyed on a fingerprint of the metadata-source config, so a runtime
+// settings change (enabling/disabling a source, editing a token/priority) rebuilds
+// the chain; an unchanged config returns the identical chain instances. The
+// returned slice must be treated as read-only (callers append to NEW slices, never
+// mutate in place) — the underlying clients are shared and concurrency-safe.
 func (mfs *Service) BuildSourceChain() []metadata.MetadataSource {
+	fp := sourceChainFingerprint()
+	mfs.chainMu.Lock()
+	defer mfs.chainMu.Unlock()
+	if mfs.cachedChain != nil && mfs.cachedChainFP == fp {
+		return mfs.cachedChain
+	}
+	chain := buildSourceChainFromConfig(mfs.olStore)
+	mfs.cachedChain = chain
+	mfs.cachedChainFP = fp
+	return chain
+}
+
+// waitForLimiter acquires one token from limiter, blocking until a token is
+// available or ctx is cancelled. A nil limiter is a no-op (returns nil), so the
+// non-batch search paths (interactive dialog, bulk fetch) are unthrottled exactly
+// as before. Returns ctx's error if the wait is cancelled.
+func waitForLimiter(ctx context.Context, limiter *rate.Limiter) error {
+	if limiter == nil {
+		return nil
+	}
+	return limiter.Wait(ctx)
+}
+
+// sourceChainFingerprint is a deterministic digest of the config that
+// BuildSourceChain reads, so the memoized chain is rebuilt exactly when that
+// config changes. encoding/json sorts map keys (the per-source Credentials map),
+// so the marshaled form is stable for equal configs.
+func sourceChainFingerprint() string {
+	payload := struct {
+		Sources   []config.MetadataSource
+		Hardcover string
+		Google    string
+	}{
+		Sources:   config.AppConfig.MetadataSources,
+		Hardcover: config.AppConfig.HardcoverAPIToken,
+		Google:    config.AppConfig.GoogleBooksAPIKey,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		// Marshal of plain config structs shouldn't fail; on the off chance it
+		// does, return a unique-ish value so we rebuild rather than serve stale.
+		return fmt.Sprintf("fp-error-%d", time.Now().UnixNano())
+	}
+	return string(b)
+}
+
+// buildSourceChainFromConfig constructs a fresh source chain from the current
+// config. Extracted from BuildSourceChain so the memoization wrapper stays small;
+// olStore is passed explicitly (rather than reading mfs) to keep it a pure builder.
+func buildSourceChainFromConfig(olStore *openlibrary.OLStore) []metadata.MetadataSource {
 	// Copy and sort by priority
 	sources := make([]config.MetadataSource, len(config.AppConfig.MetadataSources))
 	copy(sources, config.AppConfig.MetadataSources)
@@ -69,8 +134,8 @@ func (mfs *Service) BuildSourceChain() []metadata.MetadataSource {
 		switch src.ID {
 		case "openlibrary":
 			client := metadata.NewOpenLibraryClient()
-			if mfs.olStore != nil {
-				client.SetOLStore(mfs.olStore)
+			if olStore != nil {
+				client.SetOLStore(olStore)
 			}
 			rawSource = client
 		case "google-books":
@@ -135,7 +200,28 @@ func (mfs *Service) SearchMetadataForBook(id string, query string, authorHint ..
 // old variadic signature wraps this and passes default options. All new call
 // sites should use this method directly so they can pass SearchOptions fields
 // (UseRerank etc.) explicitly.
+//
+// This is a thin wrapper over searchMetadataForBook with no rate limiter
+// (nil) and a background context — behavior is identical to the historical
+// method, so the interactive search-dialog path and the bulk-fetch path are
+// unchanged. Batch callers that need per-request rate limiting or cancellation
+// (the candidate-fetch op) go through FetchAndCacheLimited instead.
 func (mfs *Service) SearchMetadataForBookWithOptions(
+	id, query, author, narrator, series string,
+	opts SearchOptions,
+) (*SearchMetadataResponse, error) {
+	return mfs.searchMetadataForBook(context.Background(), nil, id, query, author, narrator, series, opts)
+}
+
+// searchMetadataForBook is the core search pipeline. When limiter != nil, every
+// LIVE outbound source call (each SearchByTitle/SearchByTitleAndAuthor attempt and
+// each direct ASIN lookup) first acquires one limiter token, so the configured
+// rate governs ACTUAL requests rather than books. Cache hits skip the source calls
+// entirely and therefore consume no tokens. ctx is threaded to every source call
+// (and to the Audnexus ASIN lookup) so a batch cancel aborts in-flight requests.
+func (mfs *Service) searchMetadataForBook(
+	ctx context.Context,
+	limiter *rate.Limiter,
 	id, query, author, narrator, series string,
 	opts SearchOptions,
 ) (*SearchMetadataResponse, error) {
@@ -217,7 +303,22 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 	var sourcesTried []string
 	sourcesFailed := map[string]string{}
 
+	// gatedSearch runs one LIVE source call after acquiring a limiter token
+	// (when a limiter is set) and threads ctx through. Cache hits never call this,
+	// so they consume no tokens — the limiter therefore governs actual outbound
+	// requests, not books. A cancelled/expired ctx short-circuits without a call.
+	gatedSearch := func(fn func(context.Context) ([]metadata.BookMetadata, error)) ([]metadata.BookMetadata, error) {
+		if err := waitForLimiter(ctx, limiter); err != nil {
+			return nil, err
+		}
+		return fn(ctx)
+	}
+
 	for _, src := range sources {
+		// Stop promptly if the caller cancelled — don't start another source.
+		if err := ctx.Err(); err != nil {
+			break
+		}
 		var allResults []metadata.BookMetadata
 		var lastErr error
 		sourcesTried = append(sourcesTried, src.Name())
@@ -247,7 +348,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		if !cacheHit {
 			// If author hint provided, use title+author search for better results
 			if searchAuthor != "" {
-				if results, serr := src.SearchByTitleAndAuthor(context.Background(), searchTitle, searchAuthor); serr == nil {
+				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+					return src.SearchByTitleAndAuthor(c, searchTitle, searchAuthor)
+				}); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
 					lastErr = serr
@@ -259,7 +362,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			// swapped in audiobook metadata. Try searching with the narrator as
 			// author to catch these cases.
 			if bookNarrator != "" && bookNarrator != searchAuthor {
-				if results, serr := src.SearchByTitleAndAuthor(context.Background(), searchTitle, bookNarrator); serr == nil {
+				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+					return src.SearchByTitleAndAuthor(c, searchTitle, bookNarrator)
+				}); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
 					slog.Debug("metadata-search narrator-as-author fallback( ) error", "name", src.Name(), "searchTitle", searchTitle, "narrator", bookNarrator, "error", serr)
@@ -267,7 +372,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			}
 
 			// Always also search by title only to get broader results
-			if results, serr := src.SearchByTitle(context.Background(), searchTitle); serr == nil {
+			if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+				return src.SearchByTitle(c, searchTitle)
+			}); serr == nil {
 				allResults = append(allResults, results...)
 			} else {
 				lastErr = serr
@@ -275,7 +382,9 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			}
 			// SearchByTitle with original title if different
 			if searchTitle != book.Title {
-				if results, serr := src.SearchByTitle(context.Background(), book.Title); serr == nil {
+				if results, serr := gatedSearch(func(c context.Context) ([]metadata.BookMetadata, error) {
+					return src.SearchByTitle(c, book.Title)
+				}); serr == nil {
 					allResults = append(allResults, results...)
 				} else {
 					lastErr = serr
@@ -302,7 +411,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 			}
 		}
 
-		baseScores, baseTier := mfs.ScoreBaseCandidates(context.Background(), book, allResults, searchWords)
+		baseScores, baseTier := mfs.ScoreBaseCandidates(ctx, book, allResults, searchWords)
 		slog.Debug("metadata-search scored results from with tier", "count", len(allResults), "name", src.Name(), "baseTier", baseTier)
 
 		for i, r := range allResults {
@@ -430,13 +539,25 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 		asinToLookup = extractASIN(searchTitle)
 	}
 	if asinToLookup != "" {
-		// Try Audible API first (more complete), fall back to Audnexus
+		// Try Audible API first (more complete), fall back to Audnexus. Each is a
+		// live request, so acquire a limiter token before it (when limiter != nil)
+		// to keep the per-request rate ceiling honest. The Audnexus lookup is now
+		// ctx-aware — a batch cancel aborts its 9-region loop promptly instead of
+		// burning up to 9×30s.
 		audibleClient := metadata.NewAudibleClient()
-		result, err := audibleClient.LookupByASIN(asinToLookup)
+		var result *metadata.BookMetadata
+		err := waitForLimiter(ctx, limiter)
+		if err == nil {
+			result, err = audibleClient.LookupByASIN(asinToLookup)
+		}
 		if err != nil || result == nil {
 			slog.Debug("metadata-search Audible API lookup for failed, trying Audnexus", "value", asinToLookup, "error", err)
 			audnexus := metadata.NewAudnexusClient()
-			result, err = audnexus.LookupByASIN(asinToLookup)
+			if werr := waitForLimiter(ctx, limiter); werr != nil {
+				err = werr
+			} else {
+				result, err = audnexus.LookupByASIN(ctx, asinToLookup)
+			}
 		}
 		if err == nil && result != nil {
 			key := strings.ToLower(result.Title + "|" + result.Author)
@@ -529,7 +650,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 
 	// Optional LLM rerank pass on the top ambiguous candidates.
 	if opts.UseRerank && mfs.llmScorer != nil && config.AppConfig.MetadataScoring.LLMEnabled {
-		candidates = mfs.RerankTopK(context.Background(), book, candidates)
+		candidates = mfs.RerankTopK(ctx, book, candidates)
 	}
 
 	slog.Debug("metadata-search returning candidates for (search words )", "candidateCount", len(candidates), "searchTitle", searchTitle, "searchWords", searchWords)
@@ -546,6 +667,7 @@ func (mfs *Service) SearchMetadataForBookWithOptions(
 //   - the direct ASIN-lookup candidate (Source == "Audnexus (Audible)"),
 //   - any TranscriptionBoosted candidate,
 //   - the single highest-scored candidate in the input slice.
+//
 // If every candidate lacks a cover, the input is returned unchanged.
 func filterCoverlessCandidates(candidates []MetadataCandidate) []MetadataCandidate {
 	if len(candidates) == 0 {

--- a/internal/server/metadata_batch_candidates.go
+++ b/internal/server/metadata_batch_candidates.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_batch_candidates.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
-// last-edited: 2026-06-21
+// last-edited: 2026-07-13
 //
 // HTTP handlers for the metadata candidate batch fetch / apply pipeline.
 // Pure service types and logic live in internal/metabatch.
@@ -210,29 +210,25 @@ func (s *Server) fetchCandidateForBook(
 		}
 	}
 
-	// Wait for rate limiter before making external requests.
-	if err := limiter.Wait(ctx); err != nil {
-		return CandidateResult{
-			Book:   bookInfo,
-			Status: "error",
-			Error:  fmt.Sprintf("rate limiter cancelled: %v", err),
-		}
-	}
-
 	var authorHint []string
 	if book.Author != nil && book.Author.Name != "" {
 		authorHint = append(authorHint, book.Author.Name)
 	}
 
 	// METADATA-CACHED-MATCHER: batch fetch always invalidates + writes
-	// the persistent cache for each book. FetchAndCache runs the same
+	// the persistent cache for each book. FetchAndCacheLimited runs the same
 	// search chain and replaces the cache row in one call, so the
 	// per-book Review UI hits a fresh top-10 next render.
+	//
+	// The shared limiter is threaded into the search core so it throttles ACTUAL
+	// outbound requests (one token per live source call), not books — previously a
+	// single limiter.Wait per book let each book fan out to many HTTP calls, so
+	// "10/s" permitted 10 books/s = a large multiple of the intended request rate.
 	authorForHash := ""
 	if len(authorHint) > 0 {
 		authorForHash = authorHint[0]
 	}
-	entry, err := mfs.FetchAndCache(ctx, bookID, book.Title, authorForHash, "", "", metafetch.SearchOptions{})
+	entry, err := mfs.FetchAndCacheLimited(ctx, limiter, bookID, book.Title, authorForHash, "", "", metafetch.SearchOptions{})
 	if err != nil {
 		return CandidateResult{
 			Book:   bookInfo,


### PR DESCRIPTION
Fixes three confirmed reliability bugs in the external-metadata layer. No change to which sources are queried, result ranking, or applied fields — only rate-limiter sharing, token granularity, and context/cancellation.

## Bug 3 — Hardcover limiter + circuit breaker recreated per book
**Scenario:** `Service.BuildSourceChain()` builds fresh source clients + `ProtectedSource` circuit breakers on every call, and it's invoked once per book by `FetchMetadataForBook`, `SearchMetadataForBookWithOptions`, `FetchMetadataForBookByTitle`, and the metadata-upgrade op.
**Consequence:** Hardcover's 60-rpm limiter (its `requestLog`) and each source's breaker state reset every book, so across a batch they never accumulate — a thundering herd gets through and the breaker can never trip for a down source.
**Fix:** memoize the chain on the `Service`, keyed on a fingerprint of the metadata-source config. The same `*ProtectedSource`/client instances are reused across every per-book fetch (limiter + breaker persist), and the chain rebuilds only when the source config changes at runtime (settings edit), so runtime config changes are still honored. Mirrors the already-correct bulk-op pattern in `metadata_ops.go` (which builds the chain once); that path is untouched.

**Goroutine-safety:** the memoized chain is shared by the worker pools that call it. All source clients are stateless (`http.Client` + immutable config); Hardcover's `waitForRateLimit` (its own `mu`) and `CircuitBreaker` (its own `mu`) are already safe for concurrent use; `BuildSourceChain` guards the memo with a new `sync.Mutex`. No caller mutates the returned slice in place.

## Bug 4 — global 10 req/s limiter consumed once per book, not per HTTP call
**Scenario:** the candidate-fetch op (`metadata_batch_candidates.go`) called `limiter.Wait(ctx)` ONCE per book, then `FetchAndCache` issued many HTTP calls (up to 5 sources × several title attempts).
**Consequence:** with `rate.NewLimiter(10, 1)` and 8 workers, "10/sec" actually permitted ~10 *books*/sec = a large multiple in outbound requests.
**Fix:** thread the limiter into the search core (`searchMetadataForBook` + new `FetchAndCacheLimited`) so each LIVE source call acquires one token; cache hits skip the source calls and consume none, so the 10/s ceiling governs actual requests. The interactive search-dialog and bulk-fetch paths pass a `nil` limiter and are byte-for-byte unchanged.

## Bug 5 — Audnexus ASIN lookup ignored context (up to 270s uninterruptible)
**Scenario:** `AudnexusClient.LookupByASIN` looped 9 regions with `httpClient.Get` and no context.
**Consequence:** a missing/unreachable record burned up to 9×30s = 270s and couldn't be cancelled by a batch cancel.
**Fix:** thread `context.Context` into the region loop (`http.NewRequestWithContext`, extracted `lookupRegion` helper for vet-safe per-request `defer cancel()`), bail on `ctx.Done()`, and bound each region request with a 10s per-request timeout (worst case ~90s). Multi-region fallback preserved.

### ⚠️ Bounded vs. promptly-cancellable (explicit)
The candidate op's direct-ASIN path now passes a real cancellable ctx. The **auto-fetch/importer path** (`FetchMetadataForBook` → `SearchByContext` → `LookupByASIN`) — the common 270s hang — is now **bounded to ~90s but NOT promptly cancellable**, because `FetchMetadataForBook` has no `context.Context` to thread. The ~90s bound is the honest production win here. Full prompt cancellation needs a follow-up that adds a ctx to `FetchMetadataForBook` (its interface + mock + the itunes-importer/organizer/handler call sites) — scoped out to keep this PR surgical (only `audnexus.go` was named for Bug 5). Tracked in TODO.

## Tests
- `internal/metafetch/reliability_test.go`: `BuildSourceChain` returns identical `*ProtectedSource` instances across calls and a breaker tripped on one call stays open on the next (breaker persistence); per-request limiter granularity via timing (N source calls behind a slow limiter take ≈(N-1)×interval, vs. ~0 for a per-book token).
- `internal/metadata/audnexus_test.go`: a cancelled context aborts the region loop in <5s (vs. 270s), and an already-cancelled ctx issues 0 HTTP requests.

**Verification:** `go build ./...`, `go vet`, `gofmt -l` all clean. `go test -race` green on `internal/metafetch`, `internal/metadata`, `internal/metabatch`, `internal/itunes/...`, and the metadata/candidate/bulk-fetch tests in `internal/server` (run via `-run` to stay under the 600s CI timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv