### PR TITLE
feat(web): render metadata:language as language name, hide metadata:source chips (filter-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.156.0 -->
+<!-- version: 3.157.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-13 -->
+<!-- last-edited: 2026-07-14 -->
 
 # Changelog
 
@@ -204,6 +204,32 @@ pre-#1940 cached Audible entry is corrected on read so its year routes to
 every caller was updated); `internal/metafetch` + `internal/metadata` +
 `internal/metabatch` green under `-race`; targeted `internal/server` metadata/import
 tests green; `go vet` + `gofmt` clean.
+#### July 13, 2026 - feat(web): render metadata:language as language name, hide metadata:source chips (filter-only)
+
+Display-only cleanup of `metadata:*` system tags in the React frontend — storage and
+the API are unchanged; raw tags like `metadata:language:en` and
+`metadata:source:audible` are still stored and filtered on exactly as before. New
+shared helper `web/src/utils/tagDisplay.ts` (`formatTagLabel`, `isSourceTag`,
+`shouldRenderTagChip`):
+
+- **`metadata:language:<code>`** now renders as the language name (e.g. "English",
+  "Spanish") via `Intl.DisplayNames`, falling back to the code uppercased if the
+  runtime can't resolve it.
+- **`metadata:source:<name>`** (audible, openlibrary, googlebooks, audnexus, etc.)
+  no longer renders as a chip on book cards or in `TagEditor`'s system-tag row — it
+  remains a filter-only option in `FilterSidebar`, shown there with a clean label
+  ("Audible", "Open Library", "Google Books").
+- Any other `metadata:*` tag has the `metadata:` prefix stripped for display; plain
+  user tags are unaffected.
+- `AudiobookCard.tsx` filters out source tags before slicing to the visible 3, so the
+  "+N more" overflow count reflects only the chips actually shown.
+
+Changed: `web/src/utils/tagDisplay.ts` (new), `web/src/components/audiobooks/AudiobookCard.tsx`,
+`web/src/components/audiobooks/FilterSidebar.tsx`, `web/src/components/audiobooks/TagEditor.tsx`.
+New tests: `web/src/utils/__tests__/tagDisplay.test.ts` (18 cases),
+`web/src/components/audiobooks/AudiobookCard.test.tsx` (2 cases). Full frontend suite:
+388/388 passing across 59 files; `tsc && vite build` and `eslint .` both clean on the
+changed files.
 
 #### July 13, 2026 - fix(metafetch): share rate-limiter/breaker across batch + per-request throttle + cancellable Audnexus lookup
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.105.0 -->
+<!-- version: 9.106.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-13 -->
+<!-- last-edited: 2026-07-14 -->
 
 # Project TODO
 
@@ -36,6 +36,18 @@ scanner imports are in-place, so their empty `OldPath` is legitimate. Forward-on
 `internal/organizer/service.go` (Store += `PathHistoryStore`). Tests:
 `internal/activity/service_unit_test.go`,
 `internal/organizer/organized_version_writeback_test.go`.
+## ✅ RESOLVED — Display-only cleanup of metadata:* system tags (2026-07-13)
+
+`metadata:language:<code>` and `metadata:source:<name>` tags rendered as raw
+namespaced strings in chips (`metadata:language:en`, `metadata:source:audible`).
+**Fixed**, display-only — storage/API/filter payloads unchanged. New shared helper
+`web/src/utils/tagDisplay.ts` (`formatTagLabel`, `isSourceTag`,
+`shouldRenderTagChip`): language tags now show the language name
+(`Intl.DisplayNames`, uppercased-code fallback); source tags no longer render as
+chips on book cards or in `TagEditor` (filter-only, still listed with a clean
+label in `FilterSidebar`); other `metadata:*` tags have the prefix stripped.
+Changed `AudiobookCard.tsx`, `FilterSidebar.tsx`, `TagEditor.tsx`. 20 new unit/
+component tests; full frontend suite 388/388 passing.
 
 ## ✅ RESOLVED — Metadata rate-limit sharing + per-request throttle + cancellable Audnexus (2026-07-13)
 

--- a/web/src/components/audiobooks/AudiobookCard.test.tsx
+++ b/web/src/components/audiobooks/AudiobookCard.test.tsx
@@ -1,0 +1,60 @@
+// file: web/src/components/audiobooks/AudiobookCard.test.tsx
+// version: 1.0.0
+// guid: e1027ee2-8526-4e0c-a5ef-9e75e8a362b0
+// last-edited: 2026-07-13
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AudiobookCard } from './AudiobookCard';
+import type { Audiobook } from '../../types';
+
+function makeAudiobook(overrides: Partial<Audiobook> = {}): Audiobook {
+  return {
+    id: 'book-1',
+    title: 'A Test Book',
+    file_path: '/books/a-test-book.m4b',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('AudiobookCard tag display', () => {
+  it('does not render a chip for a metadata:source:* tag but does render "English" for metadata:language:en', () => {
+    const audiobook = makeAudiobook({
+      tags: ['metadata:source:audible', 'metadata:language:en', 'favorite'],
+    });
+
+    render(<AudiobookCard audiobook={audiobook} />);
+
+    // The source tag's raw form must never appear as a chip.
+    expect(screen.queryByText('metadata:source:audible')).not.toBeInTheDocument();
+    expect(screen.queryByText(/audible/i)).not.toBeInTheDocument();
+
+    // The language tag renders as its display name.
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.queryByText('metadata:language:en')).not.toBeInTheDocument();
+
+    // Plain user tags are unaffected.
+    expect(screen.getByText('favorite')).toBeInTheDocument();
+  });
+
+  it('excludes source tags from the "+N more" overflow count', () => {
+    const audiobook = makeAudiobook({
+      tags: [
+        'metadata:source:audible',
+        'metadata:language:en',
+        'one',
+        'two',
+        'three',
+      ],
+    });
+
+    render(<AudiobookCard audiobook={audiobook} />);
+
+    // 4 visible (non-source) tags total: language + one/two/three -> first 3
+    // shown, "+1" overflow for the remainder. If the source tag were
+    // counted, this would incorrectly read "+2".
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/audiobooks/AudiobookCard.tsx
+++ b/web/src/components/audiobooks/AudiobookCard.tsx
@@ -1,6 +1,7 @@
 // file: web/src/components/audiobooks/AudiobookCard.tsx
-// version: 1.12.0
+// version: 1.13.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
+// last-edited: 2026-07-13
 
 import React from 'react';
 import {
@@ -27,6 +28,7 @@ import {
 } from '@mui/icons-material';
 import type { Audiobook } from '../../types';
 import type { ColumnDefinition } from '../../config/columnDefinitions';
+import { formatTagLabel, shouldRenderTagChip } from '../../utils/tagDisplay';
 
 interface AudiobookCardProps {
   audiobook: Audiobook;
@@ -112,6 +114,11 @@ export const AudiobookCard: React.FC<AudiobookCardProps> = ({
   const getCoverPlaceholder = () => {
     return audiobook.title?.charAt(0).toUpperCase() || '?';
   };
+
+  // metadata:source:* tags never render as chips here — they stay
+  // filter-only (see FilterSidebar). Filter BEFORE slicing to 3 so the
+  // "+N more" overflow count below reflects the actually-visible set.
+  const visibleTags = (audiobook.tags ?? []).filter(shouldRenderTagChip);
 
   return (
     <Card
@@ -295,19 +302,19 @@ export const AudiobookCard: React.FC<AudiobookCardProps> = ({
           {audiobook.language && (
             <Chip label={audiobook.language} size="small" variant="outlined" />
           )}
-          {audiobook.tags && audiobook.tags.length > 0 && audiobook.tags.slice(0, 3).map((tag) => (
+          {visibleTags.slice(0, 3).map((tag) => (
             <Chip
               key={tag}
-              label={tag}
+              label={formatTagLabel(tag)}
               size="small"
               variant="outlined"
               color="secondary"
               icon={<LocalOfferIcon />}
             />
           ))}
-          {audiobook.tags && audiobook.tags.length > 3 && (
+          {visibleTags.length > 3 && (
             <Chip
-              label={`+${audiobook.tags.length - 3}`}
+              label={`+${visibleTags.length - 3}`}
               size="small"
               variant="outlined"
               color="secondary"

--- a/web/src/components/audiobooks/FilterSidebar.tsx
+++ b/web/src/components/audiobooks/FilterSidebar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/FilterSidebar.tsx
-// version: 1.6.0
+// version: 1.7.0
 // guid: 2e3f4a5b-6c7d-8e9f-0a1b-2c3d4e5f6a7b
 
 import React from 'react';
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import { FilterList as FilterListIcon } from '@mui/icons-material';
 import type { FilterOptions } from '../../types';
+import { formatTagLabel } from '../../utils/tagDisplay';
 
 interface FilterSidebarProps {
   open: boolean;
@@ -204,7 +205,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                 {availableTags.map((t) => (
                   <Chip
                     key={t.tag}
-                    label={`${t.tag} (${t.count})`}
+                    label={`${formatTagLabel(t.tag)} (${t.count})`}
                     size="small"
                     onClick={() => {
                       const exists = selectedTags.includes(t.tag);
@@ -229,7 +230,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                     return (
                       <Chip
                         key={key}
-                        label={tag}
+                        label={formatTagLabel(tag)}
                         size="small"
                         variant="outlined"
                         {...rest}
@@ -249,7 +250,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                           width: '100%',
                         }}
                       >
-                        <span>{option}</span>
+                        <span>{formatTagLabel(option)}</span>
                         {tagInfo && (
                           <Typography
                             variant="caption"

--- a/web/src/components/audiobooks/TagEditor.tsx
+++ b/web/src/components/audiobooks/TagEditor.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/audiobooks/TagEditor.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: b3c4d5e6-f7a8-4b9c-0d1e-2f3a4b5c6d7e
 
 import React, { useState, useRef } from 'react';
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import * as api from '../../services/api';
+import { formatTagLabel, shouldRenderTagChip } from '../../utils/tagDisplay';
 
 interface TagEditorProps {
   bookId: string;
@@ -87,7 +88,11 @@ export const TagEditor: React.FC<TagEditorProps> = ({
     : tags.map((t) => ({ tag: t, source: 'user', created_at: '' }));
 
   const userTags = effectiveTags.filter((t) => !isSystemTag(t.source));
-  const systemTags = effectiveTags.filter((t) => isSystemTag(t.source));
+  // metadata:source:* tags are filter-only (see FilterSidebar) — they never
+  // render as chips here, same as on the book cards.
+  const systemTags = effectiveTags.filter(
+    (t) => isSystemTag(t.source) && shouldRenderTagChip(t.tag)
+  );
 
   const availableSuggestions = allTags.filter(
     (t) => !tags.includes(t.toLowerCase())
@@ -124,7 +129,7 @@ export const TagEditor: React.FC<TagEditorProps> = ({
       title={`System tag (${bt.source}) — applied automatically by the server`}
     >
       <Chip
-        label={bt.tag}
+        label={formatTagLabel(bt.tag)}
         size="small"
         variant="outlined"
         color={systemTagColor(bt.tag)}

--- a/web/src/utils/__tests__/tagDisplay.test.ts
+++ b/web/src/utils/__tests__/tagDisplay.test.ts
@@ -1,0 +1,102 @@
+// file: web/src/utils/__tests__/tagDisplay.test.ts
+// version: 1.0.0
+// guid: dfcc4114-190c-4ee9-9383-8a5f614ef889
+// last-edited: 2026-07-13
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatTagLabel,
+  isSourceTag,
+  shouldRenderTagChip,
+  languageNameFor,
+  sourceNameFor,
+} from '../tagDisplay';
+
+describe('languageNameFor', () => {
+  it('resolves an ISO 639-1 code', () => {
+    expect(languageNameFor('en')).toBe('English');
+  });
+
+  it('resolves an ISO 639-2 code', () => {
+    expect(languageNameFor('spa')).toBe('Spanish');
+  });
+
+  it('falls back to the uppercased code for an unknown code', () => {
+    expect(languageNameFor('zzzz')).toBe('ZZZZ');
+  });
+});
+
+describe('sourceNameFor', () => {
+  it('title-cases a simple source name', () => {
+    expect(sourceNameFor('audible')).toBe('Audible');
+  });
+
+  it('special-cases openlibrary', () => {
+    expect(sourceNameFor('openlibrary')).toBe('Open Library');
+  });
+
+  it('special-cases googlebooks', () => {
+    expect(sourceNameFor('googlebooks')).toBe('Google Books');
+  });
+
+  it('title-cases an unmapped source with separators', () => {
+    expect(sourceNameFor('some_new-source')).toBe('Some New Source');
+  });
+});
+
+describe('isSourceTag', () => {
+  it('is true for metadata:source:* tags', () => {
+    expect(isSourceTag('metadata:source:audible')).toBe(true);
+    expect(isSourceTag('metadata:source:openlibrary')).toBe(true);
+  });
+
+  it('is false for other metadata tags and plain tags', () => {
+    expect(isSourceTag('metadata:language:en')).toBe(false);
+    expect(isSourceTag('metadata:other')).toBe(false);
+    expect(isSourceTag('favorite')).toBe(false);
+    expect(isSourceTag('metadata:source:')).toBe(false);
+  });
+});
+
+describe('shouldRenderTagChip', () => {
+  it('is the inverse of isSourceTag', () => {
+    expect(shouldRenderTagChip('metadata:source:audible')).toBe(false);
+    expect(shouldRenderTagChip('metadata:language:en')).toBe(true);
+    expect(shouldRenderTagChip('favorite')).toBe(true);
+  });
+});
+
+describe('formatTagLabel', () => {
+  it('formats metadata:language:en as English', () => {
+    expect(formatTagLabel('metadata:language:en')).toBe('English');
+  });
+
+  it('formats metadata:language:spa as Spanish', () => {
+    expect(formatTagLabel('metadata:language:spa')).toBe('Spanish');
+  });
+
+  it('formats metadata:language:de as German', () => {
+    expect(formatTagLabel('metadata:language:de')).toBe('German');
+  });
+
+  it('formats an unknown language code as the uppercased code', () => {
+    expect(formatTagLabel('metadata:language:zzzz')).toBe('ZZZZ');
+  });
+
+  it('formats metadata:source:openlibrary as Open Library', () => {
+    expect(formatTagLabel('metadata:source:openlibrary')).toBe('Open Library');
+  });
+
+  it('formats metadata:source:audible as Audible', () => {
+    expect(formatTagLabel('metadata:source:audible')).toBe('Audible');
+  });
+
+  it('strips the metadata: prefix for other metadata tags', () => {
+    expect(formatTagLabel('metadata:something:else')).toBe('something:else');
+  });
+
+  it('leaves a plain user tag unchanged', () => {
+    expect(formatTagLabel('favorite')).toBe('favorite');
+    expect(formatTagLabel('to-listen')).toBe('to-listen');
+  });
+});

--- a/web/src/utils/tagDisplay.ts
+++ b/web/src/utils/tagDisplay.ts
@@ -1,0 +1,127 @@
+// file: web/src/utils/tagDisplay.ts
+// version: 1.0.0
+// guid: d638b9b0-4403-4fe1-acdd-05cc951128d0
+// last-edited: 2026-07-13
+
+// Display-only formatting for `metadata:*` system tags. Storage and the API
+// keep the raw namespaced tag strings (e.g. `metadata:language:en`,
+// `metadata:source:audible`) exactly as-is — these helpers only change what
+// the UI shows. Never feed the *output* of formatTagLabel back into a filter
+// value or API call; always use the original tag string for that.
+
+const METADATA_PREFIX = 'metadata:';
+const LANGUAGE_PREFIX = 'metadata:language:';
+const SOURCE_PREFIX = 'metadata:source:';
+
+// languageDisplayNames lazily resolves ISO 639-1/639-2 codes to English
+// language names. Constructed once and reused; Intl.DisplayNames throws in
+// environments without full ICU data, so callers must still guard with
+// try/catch (see languageNameFor).
+let languageDisplayNames: Intl.DisplayNames | null | undefined;
+
+function getLanguageDisplayNames(): Intl.DisplayNames | null {
+  if (languageDisplayNames === undefined) {
+    try {
+      languageDisplayNames = new Intl.DisplayNames(['en'], { type: 'language' });
+    } catch {
+      languageDisplayNames = null;
+    }
+  }
+  return languageDisplayNames;
+}
+
+/**
+ * languageNameFor resolves a language code (e.g. "en", "spa") to its English
+ * display name (e.g. "English", "Spanish"). Falls back to the code
+ * uppercased if `Intl.DisplayNames` is unavailable, throws, or returns the
+ * code unchanged (its own "I don't recognize this" signal).
+ */
+export function languageNameFor(code: string): string {
+  const trimmed = code.trim();
+  if (!trimmed) return trimmed;
+  const displayNames = getLanguageDisplayNames();
+  if (displayNames) {
+    try {
+      const name = displayNames.of(trimmed);
+      if (name && name.toLowerCase() !== trimmed.toLowerCase()) {
+        return name;
+      }
+    } catch {
+      // fall through to the uppercase fallback below
+    }
+  }
+  return trimmed.toUpperCase();
+}
+
+// SOURCE_LABEL_OVERRIDES covers source names whose title-cased form isn't
+// the natural display name (multi-word product names, acronyms, etc.).
+const SOURCE_LABEL_OVERRIDES: Record<string, string> = {
+  openlibrary: 'Open Library',
+  googlebooks: 'Google Books',
+  audnexus: 'Audnexus',
+};
+
+function titleCase(value: string): string {
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * sourceNameFor resolves a `metadata:source:<name>` suffix to a clean
+ * display label, e.g. "audible" -> "Audible", "openlibrary" -> "Open
+ * Library". Falls back to a generic title-case for unmapped sources.
+ */
+export function sourceNameFor(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return trimmed;
+  const override = SOURCE_LABEL_OVERRIDES[trimmed.toLowerCase()];
+  if (override) return override;
+  return titleCase(trimmed);
+}
+
+/**
+ * isSourceTag reports whether `tag` is a `metadata:source:*` system tag.
+ * These are hidden from chip rendering on book cards / book detail — they
+ * remain filter-only (see FilterSidebar).
+ */
+export function isSourceTag(tag: string): boolean {
+  return tag.startsWith(SOURCE_PREFIX) && tag.length > SOURCE_PREFIX.length;
+}
+
+/**
+ * shouldRenderTagChip reports whether `tag` should render as a chip on
+ * book cards / book detail. Source tags are filter-only and never render
+ * as chips there.
+ */
+export function shouldRenderTagChip(tag: string): boolean {
+  return !isSourceTag(tag);
+}
+
+/**
+ * formatTagLabel returns the display label for `tag`:
+ *  - `metadata:language:<code>` -> the language name (e.g. "English").
+ *  - `metadata:source:<name>` -> a clean source label (e.g. "Audible"),
+ *    used only for the FilterSidebar facet — callers that render chips on
+ *    book cards/detail should skip these via `shouldRenderTagChip` first.
+ *  - any other `metadata:*` tag -> the tag with the `metadata:` prefix
+ *    stripped.
+ *  - any non-`metadata:` tag -> returned unchanged.
+ *
+ * The raw tag string is always what's sent to the API/filters — this
+ * function is display-only.
+ */
+export function formatTagLabel(tag: string): string {
+  if (tag.startsWith(LANGUAGE_PREFIX)) {
+    return languageNameFor(tag.slice(LANGUAGE_PREFIX.length));
+  }
+  if (tag.startsWith(SOURCE_PREFIX)) {
+    return sourceNameFor(tag.slice(SOURCE_PREFIX.length));
+  }
+  if (tag.startsWith(METADATA_PREFIX)) {
+    return tag.slice(METADATA_PREFIX.length);
+  }
+  return tag;
+}


### PR DESCRIPTION
## Summary

Display-only cleanup of `metadata:*` system tags in the frontend. **Storage and the API are unchanged** — `metadata:language:en` and `metadata:source:audible` etc. are still stored, filtered on, and sent to the API exactly as before. Only how they're rendered changes.

### Display rules

1. **`metadata:language:<code>`** → chip labeled with the language name (e.g. `en` → "English", `spa`/`de` → "Spanish"/"German") via `Intl.DisplayNames(['en'], { type: 'language' })`. Falls back to the code uppercased if resolution fails or returns the code unchanged.
2. **`metadata:source:<name>`** (audible, openlibrary, googlebooks, audnexus, etc.) → never rendered as a chip on book cards or in `TagEditor`'s system-tag row. Stays **filter-only** in `FilterSidebar`, shown there with a clean label ("Audible", "Open Library", "Google Books", or generic title-case for anything unmapped). The filter *value* sent to the API is still the raw tag — only the visible label changes.
3. Any other `metadata:*` tag → `metadata:` prefix stripped for display.
4. Non-`metadata:` user tags → unchanged.

### What changed

- **New:** `web/src/utils/tagDisplay.ts` — shared `formatTagLabel`, `isSourceTag`, `shouldRenderTagChip` helpers, used everywhere so the three rules above can't drift.
- `web/src/components/audiobooks/AudiobookCard.tsx` — filters out source tags *before* slicing to the visible 3 chips (so "+N more" reflects the actually-visible set), formats the rest with `formatTagLabel`.
- `web/src/components/audiobooks/FilterSidebar.tsx` — the tag facet still lists ALL tags (including source — still filterable), but the three label-render sites (facet chip row, autocomplete selected-tag chips, autocomplete dropdown option) now use `formatTagLabel`. The underlying filter value is untouched.
- `web/src/components/audiobooks/TagEditor.tsx` — `renderSystemChip` gets the same treatment (format + hide source tags) for consistency. This component isn't currently imported anywhere else in the tree, but it's the other spot that renders raw `metadata:*` chips.
- Checked `BookDetailVersionGroup.tsx`, `bookDetailUtils.ts`, `BookDetailInfoTab.tsx`, `BookDetailDialogs.tsx`, `TagComparison.tsx` — none of them render the audiobook's user/system `tags` array as chips (their `.tags` usages are unrelated ID3/audio-file tag maps), so no changes needed there.

## Test plan

- [x] `tagDisplay.ts` unit tests (18 cases): `metadata:language:en` → "English", `metadata:language:spa` → "Spanish", `metadata:language:de` → "German", unknown code → uppercased fallback, `isSourceTag('metadata:source:audible')` → true, `formatTagLabel('metadata:source:openlibrary')` → "Open Library", plain user tag → unchanged.
- [x] `AudiobookCard.test.tsx` component tests (2 cases): no chip rendered for `metadata:source:*`, "English" chip rendered for `metadata:language:en`, and the "+N more" overflow count excludes hidden source tags.
- [x] `npm --prefix web run build` (`tsc && vite build`) — clean.
- [x] `make web-lint` — 0 errors (24 pre-existing warnings, unrelated to changed files).
- [x] `make web-test` — **388/388 passing across 59 files**.

CHANGELOG.md and TODO.md updated in this PR. Executive-summary criteria not met (single small, display-only, non-data-affecting change) — skipped per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv