### PR TITLE
fix(metafetch): thread context through FetchMetadataForBook + self-correct stale year-kind cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.151.0 -->
+<!-- version: 3.152.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -8,6 +8,47 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - fix(metafetch): thread context through FetchMetadataForBook + self-correct stale year-kind cache entries
+
+Resolves the two documented follow-ups left by PRs #1940/#1942 in the metadata layer:
+
+- **Auto-fetch/importer path was not promptly cancellable (follow-up from #1942).**
+  #1942 made the Audnexus multi-region ASIN lookup cancellable and ~90s-bounded,
+  but `FetchMetadataForBook` (and the interface + search/fetch chain it drives)
+  carried no `context.Context`, so a batch/import cancel could not interrupt an
+  in-flight external fetch until the ~90s bound elapsed. **Fixed** by threading a
+  real `context.Context` (as the first parameter, Go convention) from every caller
+  through `FetchMetadataForBook` → the source loop → each `SearchByTitle` /
+  `SearchByTitleAndAuthor` / `SearchByContext` call, and wiring it into the
+  already-ctx-aware Audnexus `LookupByASIN`. `ContextualSearch.SearchByContext` now
+  takes a `context.Context` (Audnexus/Hardcover/ProtectedSource + mock updated), so
+  the placeholder `context.Background()` those paths used is gone. Callers updated:
+  itunes importer (uses the RunItems per-item ctx), the metadata HTTP handler
+  (`c.Request.Context()`), and the organizer's injected fetch closure (threads
+  `PerformOrganize`'s ctx). A cancelled context now aborts an in-flight
+  `FetchMetadataForBook` promptly, well under the ~90s bound. `FetchMetadataForBookByTitle`
+  is intentionally left as-is (it never calls `SearchByContext`/`LookupByASIN`, so
+  it is not the ~90s hotspot); its scheduler/entities-ops callers are unchanged.
+- **Stale fetch-cache entries routed an Audible/Audnexus release year to PrintYear
+  (follow-up from #1940).** #1940 added `PublishYearIsAudiobookRelease` to
+  `BookMetadata`; the fetch cache stores parsed `[]BookMetadata`, so entries cached
+  BEFORE the deploy deserialize with the new bool defaulting to `false` and, on
+  replay, routed an Audible/Audnexus RELEASE year to `PrintYear` for one cache-TTL
+  window. **Fixed** on cache READ by re-deriving `PublishYearIsAudiobookRelease`
+  from the entry's stored source (the cache key includes `src.Name()`) via
+  `metadata.SourceProducesAudiobookReleaseYear` — cheaper than a schema bump and
+  self-healing with no re-fetch. Applied at the load-bearing fetch-path replay site
+  (`service_fetch.go`, which feeds `ApplyMetadataToBook`) and mirrored on the
+  search-path replay site (`service_search.go`) for consistency.
+
+Tests: cancelled-context aborts an in-flight `FetchMetadataForBook` promptly, and a
+pre-#1940 cached Audible entry is corrected on read so its year routes to
+`AudiobookReleaseYear` (not `PrintYear`) — both in
+`internal/metafetch/service_fetch_followups_test.go`. `go build ./...` clean (proves
+every caller was updated); `internal/metafetch` + `internal/metadata` +
+`internal/metabatch` green under `-race`; targeted `internal/server` metadata/import
+tests green; `go vet` + `gofmt` clean.
 
 #### July 13, 2026 - fix(metafetch): share rate-limiter/breaker across batch + per-request throttle + cancellable Audnexus lookup
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.103.0 -->
+<!-- version: 9.104.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -33,11 +33,15 @@ op consumed the 10 req/s limiter once per book while issuing many HTTP calls per
 looped 9 regions with no context (up to 270s, uncancellable). **Fixed** with
 `http.NewRequestWithContext` per region + `ctx.Done()` bail + 10s per-request timeout.
 
-**Follow-up (open):** the auto-fetch/importer path (`FetchMetadataForBook` →
-`SearchByContext` → `LookupByASIN`) is now bounded to ~90s but not promptly cancellable,
-because `FetchMetadataForBook` has no `context.Context`. Threading a ctx through
-`FetchMetadataForBook` (+ its interface, mock, and the itunes-importer/organizer/handler
-call sites) would make that path fully cancellable.
+**Follow-up (RESOLVED 2026-07-13):** the auto-fetch/importer path
+(`FetchMetadataForBook` → `SearchByContext` → `LookupByASIN`) is now fully
+cancellable. A real `context.Context` is threaded (first param) from every caller
+through `FetchMetadataForBook` → the source loop → each `Search*` call and the
+Audnexus `LookupByASIN`; `ContextualSearch.SearchByContext` now takes a ctx too.
+A cancelled context aborts an in-flight fetch promptly, well under the ~90s bound.
+(`FetchMetadataForBookByTitle` left as-is — it never touches SearchByContext/
+LookupByASIN, so it is not the ~90s hotspot.) Test:
+`internal/metafetch/service_fetch_followups_test.go`.
 
 Files: `internal/metafetch/service.go`, `internal/metafetch/service_search.go`,
 `internal/metafetch/cache.go`, `internal/metadata/audnexus.go`,
@@ -87,12 +91,15 @@ path derives the kind from `candidate.Source` via
 `TestUnambiguousLanguage`, `TestSearchByTitle_AmbiguousLanguageSkipped`, plus
 Audible/Audnexus flag assertions.
 
-- **Optional follow-up (deferred, low priority):** the fetch cache stores parsed
-  `[]BookMetadata`; pre-deploy Audible/Audnexus entries deserialize with the flag
-  `false` and transiently route release year to `PrintYear` until TTL expiry
-  (bounded, non-clobbering). Could be hardened by re-deriving the flag from
-  `src.Name()` at the two cache-hit replay sites (`service_fetch.go`,
-  `service_search.go`) — left out to keep this PR off `service_search.go`.
+- **Optional follow-up (RESOLVED 2026-07-13):** the fetch cache stores parsed
+  `[]BookMetadata`; pre-deploy Audible/Audnexus entries deserialized with the flag
+  `false` and transiently routed release year to `PrintYear` until TTL expiry.
+  **Fixed** by re-deriving `PublishYearIsAudiobookRelease` from `src.Name()` (via
+  `metadata.SourceProducesAudiobookReleaseYear`) on cache READ at both replay sites
+  (`service_fetch.go` — load-bearing, feeds `ApplyMetadataToBook`; `service_search.go`
+  — mirrored for consistency). Cheap, self-healing, no re-fetch. Test:
+  `internal/metafetch/service_fetch_followups_test.go`
+  (`TestFetchMetadataForBook_StaleCacheYearKindSelfCorrected`).
 
 ## ✅ RESOLVED — book user-tags write routes had no permission guard (2026-07-13)
 

--- a/docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md
+++ b/docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-07-13-metadata-reliability-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 9d2f6b41-8c37-4e5a-b0d9-1a2c3e4f5b6a -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -43,10 +43,19 @@ individual problem books — with a "cancel" that didn't fully work. No book dat
 was lost or corrupted; this is about the app being well-behaved and responsive
 when talking to the outside world.
 
-## Known limitation
+## Known limitation (now resolved — 2026-07-13)
 
-The everyday auto-fetch path (used when importing) is now *bounded* — it can no
-longer hang for 270 seconds — but it can't yet be *instantly* cancelled mid-book,
-because that entry point doesn't carry a cancellation signal. Worst case there is
-about 90 seconds per stuck book. Making it instantly cancellable is a tracked
-follow-up.
+The everyday auto-fetch path (used when importing) was *bounded* — it could no
+longer hang for 270 seconds — but it could not yet be *instantly* cancelled
+mid-book, because that entry point did not carry a cancellation signal (worst case
+~90 seconds per stuck book). **This is now fixed:** the cancellation signal is
+threaded all the way from the caller (import, organize, or a web request) down
+through the lookup and into the regional-store loop, so pressing "cancel" on a
+batch or import stops an in-flight lookup right away instead of waiting out the
+~90-second bound.
+
+Shipped alongside it: a small cache-correctness fix. When the app remembers a
+previous Audible/Audnexus lookup, older remembered entries (saved before a recent
+release-vs-print-year fix) could briefly file the audiobook's *release* year in the
+*print* year slot until that memory expired. Those entries now correct themselves
+the moment they're re-read, so the year lands in the right place with no re-fetch.

--- a/internal/audiobooks/organize.go
+++ b/internal/audiobooks/organize.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/organize.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-05-05
+// last-edited: 2026-07-13
 //
 // Thin forwarding layer — the real implementation now lives in
 // internal/organizer/service.go. This file provides type aliases and
@@ -11,6 +11,8 @@
 package audiobooks
 
 import (
+	"context"
+
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/falkcorp/audiobook-organizer/internal/organizer"
@@ -33,9 +35,9 @@ func NewOrganizeService(db database.Store) *OrganizeService {
 		scanner.ApplyOrganizedFileMetadata(book, newPath)
 	}
 	svc.ComputeITunesPath = metafetch.ComputeITunesPath
-	svc.FetchMetadataForBook = func(bookID string) (interface{}, error) {
+	svc.FetchMetadataForBook = func(ctx context.Context, bookID string) (interface{}, error) {
 		mfs := metafetch.NewService(db)
-		return mfs.FetchMetadataForBook(bookID)
+		return mfs.FetchMetadataForBook(ctx, bookID)
 	}
 
 	return svc

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 // last-edited: 2026-07-13
 
@@ -115,7 +115,7 @@ type Importer struct {
 // database.Store pair through a live metafetch.Service. *metafetch.Service
 // satisfies this interface unmodified — newImporter's wiring is unaffected.
 type metadataFetcher interface {
-	FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error)
+	FetchMetadataForBook(ctx context.Context, id string) (*metafetch.FetchMetadataResponse, error)
 }
 
 func newImporter(deps Deps) *Importer {
@@ -1070,8 +1070,8 @@ func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImpo
 
 	reporter := &loggerReporterAdapter{log: log}
 
-	runErr := registry.RunItems(enrichCtx, reporter, toEnrich, func(_ context.Context, book *database.BookCore) error {
-		resp, err := imp.mfs.FetchMetadataForBook(book.ID)
+	runErr := registry.RunItems(enrichCtx, reporter, toEnrich, func(itemCtx context.Context, book *database.BookCore) error {
+		resp, err := imp.mfs.FetchMetadataForBook(itemCtx, book.ID)
 		if err != nil {
 			log.Debug("No metadata found for '%s': %v", book.Title, err)
 			if atomic.AddInt32(&breakerFails, 1) >= enrichBreakerThreshold {

--- a/internal/itunes/service/importer_enrich_parallel_test.go
+++ b/internal/itunes/service/importer_enrich_parallel_test.go
@@ -40,7 +40,7 @@ func newFakeMetadataFetcher(fails func(id string) bool) *fakeMetadataFetcher {
 	return &fakeMetadataFetcher{fails: fails, seen: map[string]int{}}
 }
 
-func (f *fakeMetadataFetcher) FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error) {
+func (f *fakeMetadataFetcher) FetchMetadataForBook(_ context.Context, id string) (*metafetch.FetchMetadataResponse, error) {
 	f.mu.Lock()
 	f.calls++
 	f.inFlight++

--- a/internal/metadata/audnexus.go
+++ b/internal/metadata/audnexus.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/audnexus.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-a3b4c5d6e7f8
 // last-edited: 2026-07-13
 
@@ -137,18 +137,17 @@ func (c *AudnexusClient) SearchByTitleAndAuthor(ctx context.Context, title, auth
 // SearchByContext implements ContextualSearch interface.
 // Audnexus prefers ASIN-based lookups. If an ASIN is available, we look it up.
 // Otherwise, return nil to let the chain fall through to the next source.
-func (c *AudnexusClient) SearchByContext(ctx *SearchContext) ([]BookMetadata, error) {
-	if ctx == nil || ctx.ASIN == "" {
+func (c *AudnexusClient) SearchByContext(ctx context.Context, sc *SearchContext) ([]BookMetadata, error) {
+	if sc == nil || sc.ASIN == "" {
 		return nil, nil
 	}
 
-	// Look up the book by ASIN. This ContextualSearch entry point carries no
-	// Go context.Context (its caller, FetchMetadataForBook, has none to thread),
-	// so we use context.Background(); LookupByASIN still bounds each region
-	// request with a per-request timeout so a missing/unreachable ASIN can't burn
-	// the full 9×30s. Callers that DO hold a cancellable ctx (the candidate op's
-	// direct-ASIN path) call LookupByASIN directly with it.
-	metadata, err := c.LookupByASIN(context.Background(), ctx.ASIN)
+	// Look up the book by ASIN, threading the caller's real context so a
+	// batch/import cancel aborts the 9-region loop promptly (LookupByASIN also
+	// bounds each region request with a per-request timeout). This entry point
+	// used to get context.Background() because FetchMetadataForBook had no ctx to
+	// thread — that ctx is now plumbed end-to-end.
+	metadata, err := c.LookupByASIN(ctx, sc.ASIN)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metadata/audnexus_test.go
+++ b/internal/metadata/audnexus_test.go
@@ -214,7 +214,7 @@ func TestAudnexusClient_SearchByContext_UsesASIN(t *testing.T) {
 	client := NewAudnexusClientWithBaseURL(server.URL)
 
 	// With ASIN: should hit LookupByASIN and return one result.
-	results, err := client.SearchByContext(&SearchContext{
+	results, err := client.SearchByContext(context.Background(), &SearchContext{
 		Title:  "The Hobbit",
 		Author: "Tolkien",
 		ASIN:   "B003JVHRU0",
@@ -230,7 +230,7 @@ func TestAudnexusClient_SearchByContext_UsesASIN(t *testing.T) {
 	}
 
 	// Without ASIN: should return (nil, nil) so the chain falls through.
-	results, err = client.SearchByContext(&SearchContext{
+	results, err = client.SearchByContext(context.Background(), &SearchContext{
 		Title:  "The Hobbit",
 		Author: "Tolkien",
 	})
@@ -242,7 +242,7 @@ func TestAudnexusClient_SearchByContext_UsesASIN(t *testing.T) {
 	}
 
 	// Nil context: same — return (nil, nil) cleanly, not a panic.
-	results, err = client.SearchByContext(nil)
+	results, err = client.SearchByContext(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/metadata/circuitbreaker.go
+++ b/internal/metadata/circuitbreaker.go
@@ -1,7 +1,7 @@
 // file: internal/metadata/circuitbreaker.go
-// version: 1.2.2
+// version: 1.3.0
 // guid: e2f3a4b5-c6d7-8901-ef23-456789abcdef
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -186,7 +186,7 @@ func (ps *ProtectedSource) Breaker() *CircuitBreaker {
 // method, wrapping an Audnexus or Hardcover client in a
 // ProtectedSource would strip the optional interface and the
 // contextual fast-path would silently never run.
-func (ps *ProtectedSource) SearchByContext(ctx *SearchContext) ([]BookMetadata, error) {
+func (ps *ProtectedSource) SearchByContext(ctx context.Context, sc *SearchContext) ([]BookMetadata, error) {
 	inner, ok := ps.source.(ContextualSearch)
 	if !ok {
 		return nil, nil
@@ -194,7 +194,7 @@ func (ps *ProtectedSource) SearchByContext(ctx *SearchContext) ([]BookMetadata, 
 	if err := ps.breaker.AllowRequest(); err != nil {
 		return nil, err
 	}
-	results, err := inner.SearchByContext(ctx)
+	results, err := inner.SearchByContext(ctx, sc)
 	if err != nil {
 		ps.breaker.RecordFailure()
 		return nil, err

--- a/internal/metadata/hardcover.go
+++ b/internal/metadata/hardcover.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/hardcover.go
-// version: 1.2.2
+// version: 1.3.0
 // guid: e7e02554-8931-49ba-9528-d3d51279da1d
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -209,23 +210,24 @@ language`
 // precise than the fuzzy search_books endpoint), falling back to a
 // title+author query. ASIN isn't something Hardcover indexes directly
 // so we ignore that field.
-func (c *HardcoverClient) SearchByContext(ctx *SearchContext) ([]BookMetadata, error) {
+func (c *HardcoverClient) SearchByContext(ctx context.Context, sc *SearchContext) ([]BookMetadata, error) {
 	if c.apiToken == "" {
 		return nil, nil
 	}
-	if ctx == nil {
+	if sc == nil {
 		return nil, nil
 	}
-	// Prefer ISBN-13 → ISBN-10 → title+author.
+	// Prefer ISBN-13 → ISBN-10 → title+author. ctx is the caller's real context
+	// so a batch/import cancel aborts the GraphQL request promptly.
 	switch {
-	case ctx.ISBN13 != "":
-		return c.search(context.Background(), ctx.ISBN13)
-	case ctx.ISBN10 != "":
-		return c.search(context.Background(), ctx.ISBN10)
-	case ctx.Title != "" && ctx.Author != "":
-		return c.search(context.Background(), ctx.Title+" "+ctx.Author)
-	case ctx.Title != "":
-		return c.search(context.Background(), ctx.Title)
+	case sc.ISBN13 != "":
+		return c.search(ctx, sc.ISBN13)
+	case sc.ISBN10 != "":
+		return c.search(ctx, sc.ISBN10)
+	case sc.Title != "" && sc.Author != "":
+		return c.search(ctx, sc.Title+" "+sc.Author)
+	case sc.Title != "":
+		return c.search(ctx, sc.Title)
 	}
 	return nil, nil
 }

--- a/internal/metadata/hardcover_test.go
+++ b/internal/metadata/hardcover_test.go
@@ -136,7 +136,7 @@ func TestHardcoverClient_SearchByContext_PrefersISBN(t *testing.T) {
 	client := NewHardcoverClientWithBaseURL(server.URL, "test-token")
 
 	// ISBN-13 path: query text must contain the ISBN, not the title.
-	_, _ = client.SearchByContext(&SearchContext{
+	_, _ = client.SearchByContext(context.Background(), &SearchContext{
 		Title:  "Foundation and Empire",
 		Author: "Isaac Asimov",
 		ISBN13: "9780553293371",
@@ -146,7 +146,7 @@ func TestHardcoverClient_SearchByContext_PrefersISBN(t *testing.T) {
 	}
 
 	// Fall-through: no ISBN → use title+author.
-	_, _ = client.SearchByContext(&SearchContext{
+	_, _ = client.SearchByContext(context.Background(), &SearchContext{
 		Title:  "Foundation and Empire",
 		Author: "Isaac Asimov",
 	})
@@ -171,7 +171,7 @@ func TestHardcoverClient_NoToken_NoOps(t *testing.T) {
 		t.Errorf("expected 0 results with no token, got %d", len(results))
 	}
 
-	results, err = client.SearchByContext(&SearchContext{
+	results, err = client.SearchByContext(context.Background(), &SearchContext{
 		Title:  "anything",
 		ISBN13: "9780553293371",
 	})

--- a/internal/metadata/mocks/mock_contextual_search.go
+++ b/internal/metadata/mocks/mock_contextual_search.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,8 +39,8 @@ func (_m *MockContextualSearch) EXPECT() *MockContextualSearch_Expecter {
 }
 
 // SearchByContext provides a mock function for the type MockContextualSearch
-func (_mock *MockContextualSearch) SearchByContext(ctx *metadata.SearchContext) ([]metadata.BookMetadata, error) {
-	ret := _mock.Called(ctx)
+func (_mock *MockContextualSearch) SearchByContext(ctx context.Context, sc *metadata.SearchContext) ([]metadata.BookMetadata, error) {
+	ret := _mock.Called(ctx, sc)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SearchByContext")
@@ -46,18 +48,18 @@ func (_mock *MockContextualSearch) SearchByContext(ctx *metadata.SearchContext) 
 
 	var r0 []metadata.BookMetadata
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*metadata.SearchContext) ([]metadata.BookMetadata, error)); ok {
-		return returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *metadata.SearchContext) ([]metadata.BookMetadata, error)); ok {
+		return returnFunc(ctx, sc)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*metadata.SearchContext) []metadata.BookMetadata); ok {
-		r0 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *metadata.SearchContext) []metadata.BookMetadata); ok {
+		r0 = returnFunc(ctx, sc)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]metadata.BookMetadata)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(*metadata.SearchContext) error); ok {
-		r1 = returnFunc(ctx)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *metadata.SearchContext) error); ok {
+		r1 = returnFunc(ctx, sc)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -70,19 +72,25 @@ type MockContextualSearch_SearchByContext_Call struct {
 }
 
 // SearchByContext is a helper method to define mock.On call
-//   - ctx *metadata.SearchContext
-func (_e *MockContextualSearch_Expecter) SearchByContext(ctx any) *MockContextualSearch_SearchByContext_Call {
-	return &MockContextualSearch_SearchByContext_Call{Call: _e.mock.On("SearchByContext", ctx)}
+//   - ctx context.Context
+//   - sc *metadata.SearchContext
+func (_e *MockContextualSearch_Expecter) SearchByContext(ctx any, sc any) *MockContextualSearch_SearchByContext_Call {
+	return &MockContextualSearch_SearchByContext_Call{Call: _e.mock.On("SearchByContext", ctx, sc)}
 }
 
-func (_c *MockContextualSearch_SearchByContext_Call) Run(run func(ctx *metadata.SearchContext)) *MockContextualSearch_SearchByContext_Call {
+func (_c *MockContextualSearch_SearchByContext_Call) Run(run func(ctx context.Context, sc *metadata.SearchContext)) *MockContextualSearch_SearchByContext_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *metadata.SearchContext
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*metadata.SearchContext)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *metadata.SearchContext
+		if args[1] != nil {
+			arg1 = args[1].(*metadata.SearchContext)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -93,7 +101,7 @@ func (_c *MockContextualSearch_SearchByContext_Call) Return(bookMetadatas []meta
 	return _c
 }
 
-func (_c *MockContextualSearch_SearchByContext_Call) RunAndReturn(run func(ctx *metadata.SearchContext) ([]metadata.BookMetadata, error)) *MockContextualSearch_SearchByContext_Call {
+func (_c *MockContextualSearch_SearchByContext_Call) RunAndReturn(run func(ctx context.Context, sc *metadata.SearchContext) ([]metadata.BookMetadata, error)) *MockContextualSearch_SearchByContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/metadata/source.go
+++ b/internal/metadata/source.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/source.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
+// last-edited: 2026-07-13
 
 package metadata
 
@@ -59,6 +60,10 @@ type SearchContext struct {
 // methods if SearchByContext returns no results. This lets Audnexus
 // skip straight to LookupByASIN when we already have an ASIN, and
 // lets Hardcover do a cleaner GraphQL search when we have an ISBN.
+//
+// ctx is a real Go context.Context threaded from the caller so a batch/import
+// cancel aborts an in-flight lookup promptly (Audnexus's 9-region ASIN loop in
+// particular). sc carries the richer search fields.
 type ContextualSearch interface {
-	SearchByContext(ctx *SearchContext) ([]BookMetadata, error)
+	SearchByContext(ctx context.Context, sc *SearchContext) ([]BookMetadata, error)
 }

--- a/internal/metafetch/service_fetch.go
+++ b/internal/metafetch/service_fetch.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_fetch.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: b24c7a25-2efa-4b85-adb0-2d591218eff2
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package metafetch
 
@@ -32,16 +32,25 @@ func (mfs *Service) queueISBNEnrichment(id string, book *database.Book) {
 	go func(bid string) {
 		found, err := mfs.isbnEnrichment.EnrichBookISBN(context.Background(), bid)
 		if err != nil {
-						slog.Warn("ISBN enrichment failed for", "id", bid, "error", err)
+			slog.Warn("ISBN enrichment failed for", "id", bid, "error", err)
 		} else if found {
-						slog.Info("ISBN enrichment succeeded for", "id", bid)
+			slog.Info("ISBN enrichment succeeded for", "id", bid)
 		}
 	}(id)
 }
 
 // FetchMetadataForBook fetches and applies metadata for a single audiobook,
 // trying each configured source in priority order until one succeeds.
-func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, error) {
+//
+// ctx is threaded end-to-end into every source Search* call and the Audnexus
+// ASIN lookup, so a batch/import cancel (or timeout) aborts an in-flight
+// external fetch promptly instead of waiting out the ~90s Audnexus region-loop
+// bound. Callers with no natural context may pass context.Background().
+func (mfs *Service) FetchMetadataForBook(ctx context.Context, id string) (*FetchMetadataResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	book, err := mfs.db.GetBookByID(id)
 	if err != nil || book == nil {
 		return nil, fmt.Errorf("audiobook not found")
@@ -100,6 +109,11 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 
 	var lastErr error
 	for _, src := range sources {
+		// Stop promptly if the caller cancelled — don't start another source.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		var results []metadata.BookMetadata
 		var searchErr error
 
@@ -111,8 +125,21 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 		if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
 			var cachedResults []metadata.BookMetadata
 			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil && len(cachedResults) > 0 {
+				// Self-correct stale entries: the fetch cache stores parsed
+				// []BookMetadata, and entries cached BEFORE the year-kind flag
+				// (PublishYearIsAudiobookRelease, #1940) shipped deserialize with
+				// it defaulting to false — so an Audible/Audnexus RELEASE year
+				// would wrongly route to PrintYear on replay for one TTL window.
+				// The cache key includes src.Name(), so we re-derive the flag from
+				// the source here (cheap, self-healing, no re-fetch). This is the
+				// load-bearing site — results below feed ApplyMetadataToBook, which
+				// reads meta.PublishYearIsAudiobookRelease directly.
+				isRelease := metadata.SourceProducesAudiobookReleaseYear(src.Name())
+				for i := range cachedResults {
+					cachedResults[i].PublishYearIsAudiobookRelease = isRelease
+				}
 				results = cachedResults
-								slog.Debug("metadata-fetch cache HIT for ( ) — results, age", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
+				slog.Debug("metadata-fetch cache HIT for ( ) — results, age", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))
 			}
 		}
 
@@ -125,10 +152,10 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			// search. Sources that don't implement the interface just
 			// fall through to the title/author path below.
 			if ctxSearch, ok := src.(metadata.ContextualSearch); ok {
-				ctx := mfs.buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
-				results, searchErr = ctxSearch.SearchByContext(ctx)
+				sctx := mfs.buildSearchContext(book, searchTitle, currentAuthor, currentNarrator)
+				results, searchErr = ctxSearch.SearchByContext(ctx, sctx)
 				if searchErr != nil {
-										slog.Warn("context search failed for", "name", src.Name(), "value", book.Title, "error", searchErr)
+					slog.Warn("context search failed for", "name", src.Name(), "value", book.Title, "error", searchErr)
 					// Context search failure is non-fatal — fall through
 					// to the regular title/author path in case that works.
 				}
@@ -136,24 +163,24 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 
 			// Try title+author search first for better match quality
 			if len(results) == 0 && currentAuthor != "" {
-				results, searchErr = src.SearchByTitleAndAuthor(context.Background(), searchTitle, currentAuthor)
+				results, searchErr = src.SearchByTitleAndAuthor(ctx, searchTitle, currentAuthor)
 				if searchErr != nil {
-										slog.Warn("title+author search failed for by", "name", src.Name(), "searchTitle", searchTitle, "currentAuthor", currentAuthor, "error", searchErr)
+					slog.Warn("title+author search failed for by", "name", src.Name(), "searchTitle", searchTitle, "currentAuthor", currentAuthor, "error", searchErr)
 				}
 			}
 
 			// Fall back to title-only search
 			if len(results) == 0 {
-				results, searchErr = src.SearchByTitle(context.Background(), searchTitle)
+				results, searchErr = src.SearchByTitle(ctx, searchTitle)
 				if searchErr != nil {
-										slog.Warn("failed for", "name", src.Name(), "value", searchTitle, "error", searchErr)
+					slog.Warn("failed for", "name", src.Name(), "value", searchTitle, "error", searchErr)
 					lastErr = searchErr
 				}
 			}
 
 			// Try original title if cleaned title returned nothing
 			if len(results) == 0 && searchTitle != book.Title {
-				results, searchErr = src.SearchByTitle(context.Background(), book.Title)
+				results, searchErr = src.SearchByTitle(ctx, book.Title)
 				if searchErr != nil {
 					lastErr = searchErr
 					continue
@@ -164,7 +191,7 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) == 0 {
 				strippedTitle := stripSubtitle(searchTitle)
 				if strippedTitle != searchTitle && strippedTitle != book.Title {
-					results, searchErr = src.SearchByTitle(context.Background(), strippedTitle)
+					results, searchErr = src.SearchByTitle(ctx, strippedTitle)
 					if searchErr != nil {
 						lastErr = searchErr
 						continue
@@ -179,10 +206,10 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			// have one for a tighter match.
 			if len(results) == 0 && th.title != "" && th.title != searchTitle && th.title != book.Title {
 				if th.author != "" {
-					results, searchErr = src.SearchByTitleAndAuthor(context.Background(), th.title, th.author)
+					results, searchErr = src.SearchByTitleAndAuthor(ctx, th.title, th.author)
 				}
 				if len(results) == 0 {
-					results, searchErr = src.SearchByTitle(context.Background(), th.title)
+					results, searchErr = src.SearchByTitle(ctx, th.title)
 				}
 				if searchErr != nil {
 					lastErr = searchErr
@@ -194,14 +221,14 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if len(results) > 0 {
 				if blob, merr := json.Marshal(results); merr == nil {
 					if perr := database.PutCachedMetadataFetch(mfs.db, id, src.Name(), blob, 0); perr != nil {
-												slog.Warn("metadata-fetch cache put failed for ( )", "id", id, "name", src.Name(), "error", perr)
+						slog.Warn("metadata-fetch cache put failed for ( )", "id", id, "name", src.Name(), "error", perr)
 					}
 				}
 			}
 		}
 
 		if len(results) == 0 {
-						slog.Debug("returned 0 results for", "name", src.Name(), "value", searchTitle)
+			slog.Debug("returned 0 results for", "name", src.Name(), "value", searchTitle)
 		}
 		if len(results) > 0 {
 			// Score all results and pick the best; reject if below quality threshold.
@@ -213,14 +240,14 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			}
 			scored := mfs.bestTitleMatchForBook(book, results, currentAuthor, currentNarrator, scoreTitles...)
 			if len(scored) == 0 {
-								slog.Debug("all results rejected by quality scorer for", "name", src.Name(), "count", len(results), "value", searchTitle)
+				slog.Debug("all results rejected by quality scorer for", "name", src.Name(), "count", len(results), "value", searchTitle)
 				continue // try next source
 			}
 			// Apply series position filter if the book's position is already known.
 			if book.SeriesSequence != nil {
 				scored = ApplySeriesPositionFilter(scored, *book.SeriesSequence)
 				if len(scored) == 0 {
-										slog.Debug("best result rejected by series position filter for", "name", src.Name(), "value", searchTitle)
+					slog.Debug("best result rejected by series position filter for", "name", src.Name(), "value", searchTitle)
 					continue
 				}
 			}
@@ -260,9 +287,9 @@ func (mfs *Service) FetchMetadataForBook(id string) (*FetchMetadataResponse, err
 			if meta.CoverURL != "" && config.AppConfig.RootDir != "" {
 				coverPath, coverErr := metadata.DownloadCoverArt(meta.CoverURL, config.AppConfig.RootDir, id)
 				if coverErr != nil {
-										slog.Warn("cover art download failed for", "id", id, "error", coverErr)
+					slog.Warn("cover art download failed for", "id", id, "error", coverErr)
 				} else {
-										slog.Info("cover art saved to", "path", coverPath)
+					slog.Info("cover art saved to", "path", coverPath)
 					// Update book's cover_url to the local path for serving
 					localCoverURL := "/api/v1/covers/local/" + filepath.Base(coverPath)
 					if updatedBook != nil {

--- a/internal/metafetch/service_fetch_followups_test.go
+++ b/internal/metafetch/service_fetch_followups_test.go
@@ -1,0 +1,153 @@
+// file: internal/metafetch/service_fetch_followups_test.go
+// version: 1.0.0
+// guid: 4d9a2f6b-1c83-4e57-9b0a-7f2e6c1d8a34
+// last-edited: 2026-07-13
+
+package metafetch
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingSource is a metadata source whose Search* calls block until the
+// caller's context is cancelled, then return ctx.Err(). It is used to prove
+// that FetchMetadataForBook honors context cancellation end-to-end (TODO 1):
+// before ctx was threaded, an in-flight external fetch could not be interrupted
+// until the ~90s Audnexus region-loop bound elapsed.
+type blockingSource struct {
+	name    string
+	started chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingSource) Name() string { return b.name }
+
+func (b *blockingSource) signalStarted() { b.once.Do(func() { close(b.started) }) }
+
+func (b *blockingSource) SearchByTitle(ctx context.Context, _ string) ([]metadata.BookMetadata, error) {
+	b.signalStarted()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (b *blockingSource) SearchByTitleAndAuthor(ctx context.Context, _, _ string) ([]metadata.BookMetadata, error) {
+	b.signalStarted()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestFetchMetadataForBook_CancelledContextAborts verifies that cancelling the
+// context aborts an in-flight FetchMetadataForBook promptly (well under the ~90s
+// Audnexus bound) rather than blocking indefinitely on the source call.
+func TestFetchMetadataForBook_CancelledContextAborts(t *testing.T) {
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			// No author → the fetch flow lands directly on SearchByTitle.
+			return &database.Book{ID: id, Title: "Some Searchable Title"}, nil
+		},
+	}
+	svc := NewService(mock)
+
+	// Same instance listed twice: the first source blocks (and we cancel while
+	// it's blocked); the loop's top-of-iteration ctx.Err() check then returns
+	// context.Canceled directly before the second iteration issues any call.
+	bs := &blockingSource{name: "blocking", started: make(chan struct{})}
+	svc.SetOverrideSources([]metadata.MetadataSource{bs, bs})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := svc.FetchMetadataForBook(ctx, "b1")
+		errCh <- err
+	}()
+
+	// Wait until we're actually inside the blocking source call, then cancel.
+	select {
+	case <-bs.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocking source was never entered")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("FetchMetadataForBook did not abort promptly after context cancel")
+	}
+}
+
+// TestFetchMetadataForBook_StaleCacheYearKindSelfCorrected verifies TODO 2: an
+// Audible/Audnexus fetch-cache entry that was serialized BEFORE the
+// PublishYearIsAudiobookRelease flag shipped (#1940) — so the flag deserializes
+// as false — is self-corrected on cache READ by re-deriving the flag from the
+// entry's source, routing the year to AudiobookReleaseYear (release) rather than
+// PrintYear (print).
+func TestFetchMetadataForBook_StaleCacheYearKindSelfCorrected(t *testing.T) {
+	raw := map[string][]byte{}
+	var updatedBook *database.Book
+	mock := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			return &database.Book{ID: id, Title: "Mistborn"}, nil
+		},
+		GetAuthorByNameFunc: func(name string) (*database.Author, error) {
+			return &database.Author{ID: 1, Name: name}, nil
+		},
+		UpdateBookFunc: func(_ string, book *database.Book) (*database.Book, error) {
+			updatedBook = book
+			return book, nil
+		},
+		RecordMetadataChangeFunc: func(_ *database.MetadataChangeRecord) error { return nil },
+		GetSeriesByNameFunc: func(name string, _ *int) (*database.Series, error) {
+			return &database.Series{ID: 1, Name: name}, nil
+		},
+		GetRawFunc:    func(k string) ([]byte, error) { return raw[k], nil },
+		SetRawFunc:    func(k string, v []byte) error { raw[k] = v; return nil },
+		DeleteRawFunc: func(k string) error { delete(raw, k); return nil },
+	}
+
+	// The source name MUST match a real release-year source so
+	// SourceProducesAudiobookReleaseYear returns true — reference the client's
+	// own Name() rather than hardcoding a string.
+	audibleName := (&metadata.AudibleClient{}).Name()
+
+	// A pre-#1940 cached entry: flag defaults to false even though the source
+	// (Audible) reports an audiobook RELEASE year.
+	blob, err := json.Marshal([]metadata.BookMetadata{{
+		Title:                         "Mistborn",
+		Author:                        "Brandon Sanderson",
+		PublishYear:                   2015,
+		PublishYearIsAudiobookRelease: false,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, database.PutCachedMetadataFetch(mock, "b1", audibleName, blob, 1.0))
+
+	svc := NewService(mock)
+	svc.SetOverrideSources([]metadata.MetadataSource{
+		&mockMetadataSource{name: audibleName},
+	})
+
+	resp, err := svc.FetchMetadataForBook(context.Background(), "b1")
+	require.NoError(t, err)
+	assert.Equal(t, audibleName, resp.Source)
+	require.NotNil(t, updatedBook)
+
+	// The corrected flag routes 2015 to the audiobook release year, NOT PrintYear.
+	require.NotNil(t, updatedBook.AudiobookReleaseYear, "release year should be set from the cached Audible entry")
+	assert.Equal(t, 2015, *updatedBook.AudiobookReleaseYear)
+	if updatedBook.PrintYear != nil {
+		assert.Equal(t, 0, *updatedBook.PrintYear, "print year must not receive the release year")
+	}
+}

--- a/internal/metafetch/service_mock_test.go
+++ b/internal/metafetch/service_mock_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	tmock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/falkcorp/audiobook-organizer/internal/ai/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -1979,7 +1979,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 			},
 		}
 		svc := NewService(mock)
-		_, err := svc.FetchMetadataForBook("nonexistent")
+		_, err := svc.FetchMetadataForBook(context.Background(), "nonexistent")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
@@ -1992,7 +1992,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 			},
 		}
 		svc := NewService(mock)
-		_, err := svc.FetchMetadataForBook("b1")
+		_, err := svc.FetchMetadataForBook(context.Background(), "b1")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no-match")
 	})
@@ -2005,7 +2005,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 		}
 		svc := NewService(mock)
 		svc.SetOverrideSources([]metadata.MetadataSource{})
-		_, err := svc.FetchMetadataForBook("b1")
+		_, err := svc.FetchMetadataForBook(context.Background(), "b1")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no metadata sources")
 	})
@@ -2020,7 +2020,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 		svc.SetOverrideSources([]metadata.MetadataSource{
 			&mockMetadataSource{name: "test", results: nil},
 		})
-		_, err := svc.FetchMetadataForBook("b1")
+		_, err := svc.FetchMetadataForBook(context.Background(), "b1")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no metadata found")
 	})
@@ -2058,7 +2058,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 			},
 		})
 
-		resp, err := svc.FetchMetadataForBook("b1")
+		resp, err := svc.FetchMetadataForBook(context.Background(), "b1")
 		require.NoError(t, err)
 		assert.Equal(t, "test-source", resp.Source)
 		assert.Equal(t, "metadata fetched and applied", resp.Message)
@@ -2082,7 +2082,7 @@ func TestFetchMetadataForBook(t *testing.T) {
 			},
 		})
 
-		_, err := svc.FetchMetadataForBook("b1")
+		_, err := svc.FetchMetadataForBook(context.Background(), "b1")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no metadata found")
 	})

--- a/internal/metafetch/service_search.go
+++ b/internal/metafetch/service_search.go
@@ -1,5 +1,5 @@
 // file: internal/metafetch/service_search.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: bcba782a-8ed4-4285-be91-2af3eddc90e3
 // last-edited: 2026-07-13
 
@@ -339,6 +339,17 @@ func (mfs *Service) searchMetadataForBook(
 		if cached, _, cerr := database.GetCachedMetadataFetchWithMaxAge(mfs.db, id, src.Name(), maxAge); cerr == nil && cached != nil {
 			var cachedResults []metadata.BookMetadata
 			if jerr := json.Unmarshal(cached.Results, &cachedResults); jerr == nil {
+				// Keep the in-memory []BookMetadata internally consistent with the
+				// year-kind flag (#1940): entries cached before it shipped
+				// deserialize with PublishYearIsAudiobookRelease=false, so re-derive
+				// it from the source (cache key includes src.Name()). NOTE: on the
+				// search path this is defensive-only — candidates carry Source and
+				// re-derive the flag at apply time (service_apply.go) — but it keeps
+				// the two cache-replay sites symmetric.
+				isRelease := metadata.SourceProducesAudiobookReleaseYear(src.Name())
+				for i := range cachedResults {
+					cachedResults[i].PublishYearIsAudiobookRelease = isRelease
+				}
 				allResults = cachedResults
 				cacheHit = true
 				slog.Debug("metadata-search cache HIT for ( ) — results, age", "id", id, "name", src.Name(), "count", len(cachedResults), "value", time.Since(cached.CachedAt).Round(time.Second))

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.7.1
+// version: 1.8.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-07-13
 
@@ -73,7 +73,9 @@ type Service struct {
 
 	// FetchMetadataForBook fetches metadata for a book by ID.
 	// Returns (result, error). Breaks the metafetch import cycle.
-	FetchMetadataForBook func(bookID string) (interface{}, error)
+	// ctx is threaded so a cancelled organize op aborts an in-flight external
+	// metadata fetch promptly.
+	FetchMetadataForBook func(ctx context.Context, bookID string) (interface{}, error)
 }
 
 // SetWriteBackBatcher sets the iTunes write-back batcher.
@@ -107,7 +109,7 @@ func NewService(db Store) *Service {
 		},
 		ApplyOrganizedFileMetadata: func(book *database.Book, newPath string) {},
 		ComputeITunesPath:          func(_ string) string { return "" },
-		FetchMetadataForBook:       func(_ string) (interface{}, error) { return nil, nil },
+		FetchMetadataForBook:       func(_ context.Context, _ string) (interface{}, error) { return nil, nil },
 	}
 }
 
@@ -199,7 +201,7 @@ func (orgSvc *Service) PerformOrganize(ctx context.Context, req *Request, log lo
 			if book.CoverURL != nil {
 				continue // already enriched
 			}
-			if _, err := orgSvc.FetchMetadataForBook(book.ID); err == nil {
+			if _, err := orgSvc.FetchMetadataForBook(ctx, book.ID); err == nil {
 				enriched++
 			}
 		}

--- a/internal/organizer/unit_test.go
+++ b/internal/organizer/unit_test.go
@@ -6,6 +6,7 @@
 package organizer
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1192,7 +1193,7 @@ func TestNewService(t *testing.T) {
 	if p := svc.ComputeITunesPath("/file"); p != "" {
 		t.Errorf("default ComputeITunesPath should return empty, got %q", p)
 	}
-	r, err := svc.FetchMetadataForBook("any")
+	r, err := svc.FetchMetadataForBook(context.Background(), "any")
 	if r != nil || err != nil {
 		t.Errorf("default FetchMetadataForBook should return nil/nil, got %v/%v", r, err)
 	}

--- a/internal/server/e2e_workflow_test.go
+++ b/internal/server/e2e_workflow_test.go
@@ -163,7 +163,7 @@ func TestE2E_ScanAndFetchMetadata(t *testing.T) {
 
 	// Step 2: Fetch metadata
 	metaSvc := metafetch.NewService(env.Store)
-	resp, err := metaSvc.FetchMetadataForBook(bookID)
+	resp, err := metaSvc.FetchMetadataForBook(context.Background(), bookID)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.6.0
+// version: 1.6.1
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-07-07
+// last-edited: 2026-07-13
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -57,7 +57,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -67,6 +66,7 @@ import (
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -427,7 +427,7 @@ func (h *Handler) fetchAudiobookMetadataImpl(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.metadataFetchService.FetchMetadataForBook(id)
+	resp, err := h.metadataFetchService.FetchMetadataForBook(c.Request.Context(), id)
 	if err != nil {
 		httputil.RespondWithError(c, 404, err.Error(), "NOT_FOUND")
 		return

--- a/internal/server/handlers/metadata/handler_test.go
+++ b/internal/server/handlers/metadata/handler_test.go
@@ -223,7 +223,7 @@ func TestGetMetadataFields(t *testing.T) {
 
 func TestFetchAudiobookMetadata(t *testing.T) {
 	h, d := newHandler(t)
-	d.mfs.EXPECT().FetchMetadataForBook("b1").Return(&metafetch.FetchMetadataResponse{
+	d.mfs.EXPECT().FetchMetadataForBook(mock.Anything, "b1").Return(&metafetch.FetchMetadataResponse{
 		Message: "ok", Source: "audible", Book: &database.Book{ID: "b1", Title: "T"},
 	}, nil)
 	d.mfs.EXPECT().InvalidateCachedCandidates("b1").Return(nil)
@@ -240,7 +240,7 @@ func TestFetchAudiobookMetadata(t *testing.T) {
 
 func TestFetchAudiobookMetadata_NotFound(t *testing.T) {
 	h, d := newHandler(t)
-	d.mfs.EXPECT().FetchMetadataForBook("bx").Return(nil, assertErr("nope"))
+	d.mfs.EXPECT().FetchMetadataForBook(mock.Anything, "bx").Return(nil, assertErr("nope"))
 	w := doReq(h.FetchAudiobookMetadata, http.MethodPost, "/audiobooks/bx/fetch-metadata", nil, idParam("bx"))
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", w.Code)

--- a/internal/server/handlers/metadata/interfaces.go
+++ b/internal/server/handlers/metadata/interfaces.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/interfaces.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b1ab2e4a-1f73-42f2-955d-c4a30f0fbaac
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 // Narrow dependency interfaces for the metadata-domain HTTP handlers (the 19
 // per-book + library metadata endpoints extracted from the server package's
@@ -99,7 +99,7 @@ type MetadataStore interface {
 // (writeBackAudiobookMetadata) can invoke it both with and without a segment
 // list, matching the original.
 type MetadataFetchService interface {
-	FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error)
+	FetchMetadataForBook(ctx context.Context, id string) (*metafetch.FetchMetadataResponse, error)
 	InvalidateCachedCandidates(bookID string) error
 	GetCachedCandidates(bookID string) (*metafetch.MetadataCandidateCache, bool, error)
 	FetchAndCache(ctx context.Context, bookID, query, author, narrator, series string, opts metafetch.SearchOptions) (*metafetch.MetadataCandidateCache, error)

--- a/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
+++ b/internal/server/handlers/metadata/mocks/mock_metadata_fetch_service.go
@@ -305,8 +305,8 @@ func (_c *MockMetadataFetchService_FetchAndCache_Call) RunAndReturn(run func(ctx
 }
 
 // FetchMetadataForBook provides a mock function for the type MockMetadataFetchService
-func (_mock *MockMetadataFetchService) FetchMetadataForBook(id string) (*metafetch.FetchMetadataResponse, error) {
-	ret := _mock.Called(id)
+func (_mock *MockMetadataFetchService) FetchMetadataForBook(ctx context.Context, id string) (*metafetch.FetchMetadataResponse, error) {
+	ret := _mock.Called(ctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FetchMetadataForBook")
@@ -314,18 +314,18 @@ func (_mock *MockMetadataFetchService) FetchMetadataForBook(id string) (*metafet
 
 	var r0 *metafetch.FetchMetadataResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*metafetch.FetchMetadataResponse, error)); ok {
-		return returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*metafetch.FetchMetadataResponse, error)); ok {
+		return returnFunc(ctx, id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *metafetch.FetchMetadataResponse); ok {
-		r0 = returnFunc(id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *metafetch.FetchMetadataResponse); ok {
+		r0 = returnFunc(ctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*metafetch.FetchMetadataResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -338,19 +338,25 @@ type MockMetadataFetchService_FetchMetadataForBook_Call struct {
 }
 
 // FetchMetadataForBook is a helper method to define mock.On call
+//   - ctx context.Context
 //   - id string
-func (_e *MockMetadataFetchService_Expecter) FetchMetadataForBook(id any) *MockMetadataFetchService_FetchMetadataForBook_Call {
-	return &MockMetadataFetchService_FetchMetadataForBook_Call{Call: _e.mock.On("FetchMetadataForBook", id)}
+func (_e *MockMetadataFetchService_Expecter) FetchMetadataForBook(ctx any, id any) *MockMetadataFetchService_FetchMetadataForBook_Call {
+	return &MockMetadataFetchService_FetchMetadataForBook_Call{Call: _e.mock.On("FetchMetadataForBook", ctx, id)}
 }
 
-func (_c *MockMetadataFetchService_FetchMetadataForBook_Call) Run(run func(id string)) *MockMetadataFetchService_FetchMetadataForBook_Call {
+func (_c *MockMetadataFetchService_FetchMetadataForBook_Call) Run(run func(ctx context.Context, id string)) *MockMetadataFetchService_FetchMetadataForBook_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -361,7 +367,7 @@ func (_c *MockMetadataFetchService_FetchMetadataForBook_Call) Return(fetchMetada
 	return _c
 }
 
-func (_c *MockMetadataFetchService_FetchMetadataForBook_Call) RunAndReturn(run func(id string) (*metafetch.FetchMetadataResponse, error)) *MockMetadataFetchService_FetchMetadataForBook_Call {
+func (_c *MockMetadataFetchService_FetchMetadataForBook_Call) RunAndReturn(run func(ctx context.Context, id string) (*metafetch.FetchMetadataResponse, error)) *MockMetadataFetchService_FetchMetadataForBook_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/metadata_fetch_service_test.go
+++ b/internal/server/metadata_fetch_service_test.go
@@ -67,7 +67,7 @@ func TestMetadataFetchService_FetchMetadataForBook_NotFound(t *testing.T) {
 	}
 	mfs := metafetch.NewService(mockDB)
 
-	_, err := mfs.FetchMetadataForBook("nonexistent")
+	_, err := mfs.FetchMetadataForBook(context.Background(), "nonexistent")
 
 	if err == nil {
 		t.Error("expected error for nonexistent book")
@@ -136,7 +136,7 @@ func TestMetadataFetchService_NoSourcesEnabled(t *testing.T) {
 	}
 	mfs := metafetch.NewService(mockDB)
 
-	_, err := mfs.FetchMetadataForBook("book1")
+	_, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err == nil {
 		t.Error("expected error when no sources enabled")
 	}
@@ -171,7 +171,7 @@ func TestMetadataFetchService_Source1Fails_Source2Succeeds(t *testing.T) {
 	}
 	mfs.SetOverrideSources([]metadata.MetadataSource{source1, source2})
 
-	resp, err := mfs.FetchMetadataForBook("book1")
+	resp, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestMetadataFetchService_TitleStrippingFallback(t *testing.T) {
 	}
 	mfs.SetOverrideSources([]metadata.MetadataSource{src})
 
-	resp, err := mfs.FetchMetadataForBook("book1")
+	resp, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestMetadataFetchService_AllSourcesNoResults(t *testing.T) {
 	}
 	mfs.SetOverrideSources([]metadata.MetadataSource{emptySrc("A"), emptySrc("B"), emptySrc("C")})
 
-	_, err := mfs.FetchMetadataForBook("book1")
+	_, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err == nil {
 		t.Fatal("expected error when all sources return no results")
 	}
@@ -270,7 +270,7 @@ func TestMetadataFetchService_AllSourcesError(t *testing.T) {
 	}
 	mfs.SetOverrideSources([]metadata.MetadataSource{errSrc("SourceA"), errSrc("SourceB")})
 
-	_, err := mfs.FetchMetadataForBook("book1")
+	_, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err == nil {
 		t.Fatal("expected error when all sources return errors")
 	}
@@ -378,7 +378,7 @@ func TestMetadataFetchService_AuthorLookupFails(t *testing.T) {
 	}
 	mfs.SetOverrideSources([]metadata.MetadataSource{src})
 
-	resp, err := mfs.FetchMetadataForBook("book1")
+	resp, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err != nil {
 		t.Fatalf("search should proceed despite author lookup failure: %v", err)
 	}
@@ -895,7 +895,7 @@ func TestFetchMetadataForBook_BoxSetRejected_IndividualBookApplied(t *testing.T)
 	mfs := metafetch.NewService(mockDB)
 	mfs.SetOverrideSources([]metadata.MetadataSource{src})
 
-	resp, err := mfs.FetchMetadataForBook("book1")
+	resp, err := mfs.FetchMetadataForBook(context.Background(), "book1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/server/metadata_integration_test.go
+++ b/internal/server/metadata_integration_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,7 +54,7 @@ func TestMetadataFetch_WithMockAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(created.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), created.ID)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 
@@ -99,7 +100,7 @@ func TestMetadataFetch_FallbackToAuthorSearch(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(created.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), created.ID)
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 
@@ -129,7 +130,7 @@ func TestMetadataFetch_NotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	svc := metafetch.NewService(env.Store)
-	_, err = svc.FetchMetadataForBook(created.ID)
+	_, err = svc.FetchMetadataForBook(context.Background(), created.ID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no metadata found")
 }

--- a/internal/server/pipeline_integration_test.go
+++ b/internal/server/pipeline_integration_test.go
@@ -5,6 +5,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,7 +75,7 @@ func TestPipeline_ImportThenFetchMetadata(t *testing.T) {
 
 	// 6. Call FetchMetadataForBook
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(book.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -141,7 +142,7 @@ func TestPipeline_FetchMetadata_MultiSourceFallback(t *testing.T) {
 
 	// 5. Call FetchMetadataForBook
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(book.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -204,7 +205,7 @@ func TestPipeline_ChapterTitle_StillFindsBook(t *testing.T) {
 
 	// 4. Call FetchMetadataForBook
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(book.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), book.ID)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -254,7 +255,7 @@ func TestPipeline_FetchMetadata_NoResults_AllSources(t *testing.T) {
 
 	// 4. Call FetchMetadataForBook
 	svc := metafetch.NewService(env.Store)
-	resp, err := svc.FetchMetadataForBook(book.ID)
+	resp, err := svc.FetchMetadataForBook(context.Background(), book.ID)
 
 	// 5. Assert: error contains "no metadata found"
 	require.Error(t, err)


### PR DESCRIPTION
Resolves the two documented follow-ups from PRs #1940/#1942 in the metadata layer.

## TODO 1 — prompt cancellation (follow-up from #1942)
#1942 bounded the Audnexus multi-region ASIN lookup to ~90s, but the auto-fetch/importer path could not be *promptly* cancelled because `FetchMetadataForBook` (and its interface + the search/fetch chain it drives) carried no `context.Context`.

Threaded a real `context.Context` as the **first** param from every caller down through `FetchMetadataForBook` → the source loop → each `SearchByTitle` / `SearchByTitleAndAuthor` / `SearchByContext` call, and wired it into the already-ctx-aware Audnexus `LookupByASIN`. `ContextualSearch.SearchByContext` now takes a `context.Context` (Audnexus / Hardcover / ProtectedSource + mock updated), so the placeholder `context.Background()` those paths used is gone.

**Blast radius** — 3 production entry points (itunes importer via the RunItems per-item ctx; the metadata HTTP handler via `c.Request.Context()`; the organizer via `PerformOrganize`'s ctx) plus the `internal/audiobooks` wiring closure; 2 interface definitions (`metadataFetcher`, `MetadataFetchService`); 2 hand-edited mocks (`MockMetadataFetchService`, `MockContextualSearch`); 1 test fake (`fakeMetadataFetcher`).

`FetchMetadataForBookByTitle` is **intentionally** left context-free — it never calls `SearchByContext`/`LookupByASIN`, so it is not the ~90s hotspot; its scheduler / entities-ops callers are unchanged. (Leaves the interfaces briefly asymmetric.)

## TODO 2 — stale fetch-cache routes release year to PrintYear (follow-up from #1940)
The fetch cache stores parsed `[]BookMetadata`; entries cached BEFORE #1940 deserialize with `PublishYearIsAudiobookRelease` defaulting to `false`, so on replay an Audible/Audnexus RELEASE year routed to `PrintYear` for one cache-TTL window (bounded, non-clobbering, but wrong).

**Approach (b)** — on cache READ, re-derive the flag from the entry's stored source (the cache key includes `src.Name()`) via `metadata.SourceProducesAudiobookReleaseYear`. Cheaper than a schema/key bump and self-healing with no re-fetch. Applied at the load-bearing fetch-path replay site (`service_fetch.go`, feeds `ApplyMetadataToBook`) and mirrored on the search-path replay site (`service_search.go`) for consistency — the search-path edit is documented as inert (candidates re-derive from `Source` at apply time), so only the fetch-path test is load-bearing.

No change to fetch/search results, ranking, or the #1940 year-routing semantics — only ctx plumbing + cancellation and stale-entry self-correction.

## Tests / verification
- New `internal/metafetch/service_fetch_followups_test.go`:
  - `TestFetchMetadataForBook_CancelledContextAborts` — a source that blocks on `ctx.Done()`; a cancelled context aborts an in-flight fetch promptly (guarded by a 5s `time.After`, asserts `context.Canceled`), well under the ~90s bound.
  - `TestFetchMetadataForBook_StaleCacheYearKindSelfCorrected` — a pre-#1940 cached Audible entry (flag false, `PublishYear` set) is corrected on read so the year routes to `AudiobookReleaseYear`, not `PrintYear`. Uses the real `AudibleClient{}.Name()` so `SourceProducesAudiobookReleaseYear` is non-vacuous.
- `go build ./...` clean (proves every non-test caller updated); `go test ./... -run zzzNoSuchTest` clean (proves every **test** package compiles under the broad signature change).
- `internal/metafetch` + `internal/metadata` + `internal/metabatch` green under `-race`; `internal/organizer` / `internal/itunes` / `internal/audiobooks` green under `-race`; targeted `internal/server` metadata/import tests green via `-run` (full package exceeds the 600s CI timeout).
- `go vet` + `gofmt -l` clean on changed files.

CHANGELOG + TODO updated (both follow-ups marked resolved); the existing metadata-reliability executive summary's "Known limitation" section updated to reflect resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv