### PR TITLE
feat(config): recognize more audio formats (opus, wav, aiff, mka, aax, oga)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.68.0
+// version: 1.69.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-12
+// last-edited: 2026-07-13
 
 package config
 
@@ -982,13 +982,13 @@ func InitConfig() {
 	viper.BindEnv("ai_backend.local_embedding_model", "AI_BACKEND_LOCAL_EMBEDDING_MODEL") //nolint:errcheck
 	viper.BindEnv("ai_backend.local_llm_model", "AI_BACKEND_LOCAL_LLM_MODEL")             //nolint:errcheck
 
-	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")       //nolint:errcheck
-	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE")   //nolint:errcheck
-	viper.BindEnv("metadata_scoring.embedding_best_match", "METADATA_SCORING_EMBEDDING_BEST_MATCH") //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_enabled", "METADATA_SCORING_LLM_ENABLED")                   //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")     //nolint:errcheck
-	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")         //nolint:errcheck
-	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE")   //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_enabled", "METADATA_SCORING_EMBEDDING_ENABLED")                               //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_min_score", "METADATA_SCORING_EMBEDDING_MIN_SCORE")                           //nolint:errcheck
+	viper.BindEnv("metadata_scoring.embedding_best_match", "METADATA_SCORING_EMBEDDING_BEST_MATCH")                         //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_enabled", "METADATA_SCORING_LLM_ENABLED")                                           //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_epsilon", "METADATA_SCORING_LLM_RERANK_EPSILON")                             //nolint:errcheck
+	viper.BindEnv("metadata_scoring.llm_rerank_top_k", "METADATA_SCORING_LLM_RERANK_TOP_K")                                 //nolint:errcheck
+	viper.BindEnv("metadata_scoring.write_backup_before", "METADATA_SCORING_WRITE_BACKUP_BEFORE")                           //nolint:errcheck
 	viper.BindEnv("metadata_scoring.transcription_title_exact_boost", "METADATA_SCORING_TRANSCRIPTION_TITLE_EXACT_BOOST")   //nolint:errcheck
 	viper.BindEnv("metadata_scoring.transcription_title_substr_boost", "METADATA_SCORING_TRANSCRIPTION_TITLE_SUBSTR_BOOST") //nolint:errcheck
 	viper.BindEnv("metadata_scoring.transcription_author_boost", "METADATA_SCORING_TRANSCRIPTION_AUTHOR_BOOST")             //nolint:errcheck
@@ -1015,11 +1015,13 @@ func InitConfig() {
 
 	viper.SetDefault("supported_extensions", []string{
 		".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",
+		".opus", ".oga", ".wav", ".aiff", ".aif", ".mka", ".aax", ".aaxc",
 	})
 	viper.SetDefault("exclude_patterns", []string{})
 
 	supportedExtensions := []string{
 		".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",
+		".opus", ".oga", ".wav", ".aiff", ".aif", ".mka", ".aax", ".aaxc",
 	}
 	if viper.IsSet("supported_extensions") {
 		supportedExtensions = viper.GetStringSlice("supported_extensions")
@@ -1812,6 +1814,7 @@ func ResetToDefaults() {
 
 			SupportedExtensions: []string{
 				".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",
+				".opus", ".oga", ".wav", ".aiff", ".aif", ".mka", ".aax", ".aaxc",
 			},
 			ExcludePatterns: []string{},
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,7 @@
 // file: internal/config/config_test.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-06-16
+// last-edited: 2026-07-13
 
 package config
 
@@ -274,7 +274,10 @@ func TestSupportedExtensionsDefaults(t *testing.T) {
 
 	// Assert
 	extensions := AppConfig.SupportedExtensions
-	expectedExtensions := []string{".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma"}
+	expectedExtensions := []string{
+		".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",
+		".opus", ".oga", ".wav", ".aiff", ".aif", ".mka", ".aax", ".aaxc",
+	}
 
 	if len(extensions) != len(expectedExtensions) {
 		t.Errorf("Expected %d extensions, got %d", len(expectedExtensions), len(extensions))

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-07
+// last-edited: 2026-07-13
 
 package reconcile
 
@@ -460,7 +460,7 @@ func FindUntrackedFiles(store Store, knownPaths map[string]bool) ([]string, erro
 	}
 	// Fallback if no extensions configured
 	if len(extSet) == 0 {
-		for _, ext := range []string{".m4b", ".mp3", ".m4a", ".flac", ".aac", ".ogg", ".wma"} {
+		for _, ext := range []string{".m4b", ".mp3", ".m4a", ".flac", ".aac", ".ogg", ".wma", ".opus", ".oga", ".wav", ".aiff", ".aif", ".mka", ".aax", ".aaxc"} {
 			extSet[ext] = true
 		}
 	}


### PR DESCRIPTION
Adds `.opus .oga .wav .aiff .aif .mka .aax .aaxc` to the default supported-audio extensions (was `.m4b .mp3 .m4a .aac .ogg .flac .wma`) across all 3 config default sites + the reconcile scan fallback.

**Purely additive** — more file types are recognized as audio on scan/import; no existing behavior changes. Covers modern (opus), uncompressed (wav/aiff), matroska audio (mka), ogg-audio (oga), and Audible native (aax/aaxc). `go build` clean.

Note: existing libraries won't retroactively pick these up until a rescan of the relevant folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)