### PR TITLE
fix(activity): label imports correctly in change log (+ import-provenance path capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.152.0 -->
+<!-- version: 3.153.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -8,6 +8,41 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - fix(activity): label imports correctly in change log (+ import-provenance path capture)
+
+Fixes a change-log entry that showed `📁 Rename — Renamed — → /mnt/.../book.mp3` (an
+empty "from" path, mislabeled as a rename) for what was actually an import, plus the
+underlying provenance gap that discarded the real source path when organize renamed a
+file.
+
+- **Bug 1 (display).** `internal/activity/changelog.go` hardcoded `Type:"rename"` and
+  `"Renamed — <old> → <new>"` for EVERY `book_path_history` row, including import
+  records that `PebbleStore.CreateBook` writes with an empty `OldPath` and
+  `ChangeType:"import"`. The `—` in that summary is the "label — detail" separator
+  (matching the sibling "Metadata applied — …" summaries), NOT the old path, so an
+  empty `OldPath` rendered as `Renamed — → /newpath`. Now branches on
+  `ChangeType`/`OldPath`: import (empty `OldPath`) → `Type:"import"` +
+  `"Imported — <path>"` (no phantom `→`); real moves keep `Type:"rename"` with a
+  ChangeType-specific verb (Renamed / Organized / Copied to library / Version swapped /
+  Quarantined / Restored from quarantine / Path repaired; unknown+from → "Moved"). The
+  operation-changes loop also gained `organize_rename` and `book_create` cases so an
+  organized book's change log no longer shows raw "Operation change — …" junk. The
+  frontend already maps `import`→📦/"Import" and `rename`→📁/"Rename", so no frontend
+  change was needed.
+- **Bug 2 (provenance).** `internal/organizer/service.go` `CreateOrganizedVersion`
+  renames/moves the file from `book.FilePath` → `newPath` but only recorded
+  CreateBook's empty-from "import" marker, dropping the known source path. It now
+  records a second `organize` path-change carrying the real old → new (mirroring the
+  `library_copy` convention in `metafetch/service_apply.go`), so the change log shows
+  where a file was organized FROM. `organizer.Store` gained `database.PathHistoryStore`
+  (already satisfied by `PebbleStore` and the full `database` mock — no regen).
+  Forward-only: existing rows are immutable, so a book organized before this deploy
+  cannot regain its never-stored old path — its entry simply relabels to "Imported".
+- **Investigation finding.** The iTunes importers and the scanner ingest **in place**
+  (`FilePath` = the on-disk location, no rename), so their empty `OldPath` is correct
+  and "Imported" is the right label — no lost path there. The organize→new-version path
+  was the sole place a real source path was being discarded.
 
 #### July 13, 2026 - fix(metafetch): thread context through FetchMetadataForBook + self-correct stale year-kind cache entries
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.104.0 -->
+<!-- version: 9.105.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -19,6 +19,23 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## ✅ RESOLVED — change-log mislabeled imports as renames + organize dropped source path (2026-07-13)
+
+Change-log entry showed `📁 Rename — Renamed — → /mnt/.../book.mp3` (empty "from") for
+an import. Root cause: `internal/activity/changelog.go` hardcoded `Type:"rename"` +
+`"Renamed — <old> → <new>"` for every `book_path_history` row, so the empty-`OldPath`
+import record CreateBook writes rendered as a phantom rename. **Fixed:** branch on
+`ChangeType`/`OldPath` — empty-from → `import` + "Imported — <path>"; real moves keep
+`rename` with a ChangeType-specific verb; op-changes loop gained `organize_rename` /
+`book_create` cases. Underlying provenance gap: `CreateOrganizedVersion` renamed the
+file but only recorded CreateBook's empty-from import marker — it now records a second
+`organize` path-change with the real old → new (`library_copy` convention). iTunes/
+scanner imports are in-place, so their empty `OldPath` is legitimate. Forward-only fix
+(immutable rows). Files: `internal/activity/changelog.go`,
+`internal/organizer/service.go` (Store += `PathHistoryStore`). Tests:
+`internal/activity/service_unit_test.go`,
+`internal/organizer/organized_version_writeback_test.go`.
 
 ## ✅ RESOLVED — Metadata rate-limit sharing + per-request throttle + cancellable Audnexus (2026-07-13)
 

--- a/internal/activity/changelog.go
+++ b/internal/activity/changelog.go
@@ -1,6 +1,7 @@
 // file: internal/activity/changelog.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 93167949-a587-41e9-8ef9-92d03f86aea6
+// last-edited: 2026-07-13
 
 package activity
 
@@ -57,10 +58,11 @@ func (svc *ChangelogService) GetBookChangelog(bookID string) ([]ChangeLogEntry, 
 		slog.Warn("changelog GetBookPathHistory", "bookID", bookID, "err", err)
 	} else {
 		for _, ph := range pathHistory {
+			entryType, summary := pathChangeEntry(ph)
 			entries = append(entries, ChangeLogEntry{
 				Timestamp: ph.CreatedAt,
-				Type:      "rename",
-				Summary:   fmt.Sprintf("Renamed — %s → %s", ph.OldPath, ph.NewPath),
+				Type:      entryType,
+				Summary:   summary,
 				Details: map[string]any{
 					"old_path":    ph.OldPath,
 					"new_path":    ph.NewPath,
@@ -118,6 +120,12 @@ func (svc *ChangelogService) GetBookChangelog(bookID string) ([]ChangeLogEntry, 
 			case "file_move":
 				entryType = "rename"
 				summary = fmt.Sprintf("File moved — %s → %s", oc.OldValue, oc.NewValue)
+			case "organize_rename":
+				entryType = "rename"
+				summary = fmt.Sprintf("Organized — %s → %s", oc.OldValue, oc.NewValue)
+			case "book_create":
+				entryType = "import"
+				summary = "Organized version created"
 			case "tag_write":
 				entryType = "tag_write"
 				summary = fmt.Sprintf("Tags written — %s: %s → %s", oc.FieldName, oc.OldValue, oc.NewValue)
@@ -157,6 +165,46 @@ func (svc *ChangelogService) GetBookChangelog(bookID string) ([]ChangeLogEntry, 
 	}
 
 	return entries, nil
+}
+
+// pathChangeEntry maps a BookPathChange to a changelog (type, summary) pair.
+//
+// The change-log frontend (web/src/components/ChangeLog.tsx) only has icons/labels
+// for a fixed set of types — rename (📁), import (📦), metadata_apply, tag_write,
+// transcode — so this deliberately emits only "import" or "rename" and encodes the
+// specific verb in the summary. A "label — detail" em-dash separator matches the
+// sibling summaries ("Metadata applied — …").
+//
+// The historical bug: this loop hardcoded Type "rename" and "Renamed — <old> → <new>"
+// for EVERY record, so an import record (OldPath == "", ChangeType "import" written by
+// PebbleStore.CreateBook) rendered as "Renamed — → /newpath" — a phantom rename with
+// an empty "from". Import records now render as "Imported — /newpath".
+func pathChangeEntry(ph database.BookPathChange) (entryType, summary string) {
+	// Import records legitimately have no source path (the file was ingested in
+	// place, e.g. by the scanner or iTunes importer). Treat any empty-OldPath row
+	// as an import regardless of the stored ChangeType.
+	if ph.ChangeType == "import" || ph.OldPath == "" {
+		return "import", fmt.Sprintf("Imported — %s", ph.NewPath)
+	}
+
+	verb := "Moved"
+	switch ph.ChangeType {
+	case "organize":
+		verb = "Organized"
+	case "rename":
+		verb = "Renamed"
+	case "library_copy":
+		verb = "Copied to library"
+	case "version_swap":
+		verb = "Version swapped"
+	case "quarantine":
+		verb = "Quarantined"
+	case "unquarantine":
+		verb = "Restored from quarantine"
+	case "itunes_path_repair":
+		verb = "Path repaired"
+	}
+	return "rename", fmt.Sprintf("%s — %s → %s", verb, ph.OldPath, ph.NewPath)
 }
 
 // DerefStrDisplay safely dereferences a *string, returning "<nil>" for nil pointers (display-oriented).

--- a/internal/activity/service_unit_test.go
+++ b/internal/activity/service_unit_test.go
@@ -1,5 +1,5 @@
 // file: internal/activity/service_unit_test.go
-// version: 1.0.0
+// version: 1.1.0
 
 package activity
 
@@ -160,6 +160,77 @@ func TestChangelogService_OperationChangeTypes(t *testing.T) {
 	metaEntry, ok := byType["metadata_apply"]
 	require.True(t, ok)
 	assert.Contains(t, metaEntry.Summary, "Metadata updated")
+}
+
+// --------------------------------------------------------------------------
+// Path-history entry labeling (import vs rename vs organize)
+// --------------------------------------------------------------------------
+
+// TestChangelogService_ImportPathChangeLabeledImport is the regression for the
+// reported bug: an import path-change (OldPath == "", ChangeType "import", written
+// by PebbleStore.CreateBook) was mislabeled as a rename and rendered
+// "Renamed — → /newpath" with an empty "from". It must now be an "import" entry
+// with "Imported — <path>" and NO phantom "→".
+func TestChangelogService_ImportPathChangeLabeledImport(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	ts := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	mockStore.EXPECT().GetBookPathHistory("book-1").Return([]database.BookPathChange{
+		{BookID: "book-1", OldPath: "", NewPath: "/mnt/lib/book.mp3", ChangeType: "import", CreatedAt: ts},
+	}, nil)
+	mockStore.EXPECT().GetBookChangeHistory("book-1", 100).Return(nil, nil)
+	mockStore.EXPECT().GetBookChanges("book-1").Return(nil, nil)
+
+	svc := NewChangelogService(mockStore)
+	entries, err := svc.GetBookChangelog("book-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "import", entries[0].Type)
+	assert.Equal(t, "Imported — /mnt/lib/book.mp3", entries[0].Summary)
+	assert.NotContains(t, entries[0].Summary, "→")
+	assert.NotContains(t, entries[0].Summary, "Renamed")
+}
+
+// TestChangelogService_RealRenameStillLabeledRename guards that a genuine rename
+// (non-empty OldPath) keeps the rename type and the old → new summary.
+func TestChangelogService_RealRenameStillLabeledRename(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	ts := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	mockStore.EXPECT().GetBookPathHistory("book-1").Return([]database.BookPathChange{
+		{BookID: "book-1", OldPath: "/old/name.mp3", NewPath: "/new/name.mp3", ChangeType: "rename", CreatedAt: ts},
+	}, nil)
+	mockStore.EXPECT().GetBookChangeHistory("book-1", 100).Return(nil, nil)
+	mockStore.EXPECT().GetBookChanges("book-1").Return(nil, nil)
+
+	svc := NewChangelogService(mockStore)
+	entries, err := svc.GetBookChangelog("book-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "rename", entries[0].Type)
+	assert.Equal(t, "Renamed — /old/name.mp3 → /new/name.mp3", entries[0].Summary)
+}
+
+// TestChangelogService_OrganizePathChangeLabeledOrganize covers the Bug-2
+// provenance record: CreateOrganizedVersion now writes an "organize" path-change
+// carrying the real source path, which must render as a rename-type "Organized —
+// <old> → <new>" entry so the change log shows where the file was organized FROM.
+func TestChangelogService_OrganizePathChangeLabeledOrganize(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	ts := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	mockStore.EXPECT().GetBookPathHistory("book-1").Return([]database.BookPathChange{
+		{BookID: "book-1", OldPath: "/staging/Star Wars: The Force Unleashed.mp3", NewPath: "/mnt/lib/2-03 (SW-022) Star Wars_ The Force U.mp3", ChangeType: "organize", CreatedAt: ts},
+	}, nil)
+	mockStore.EXPECT().GetBookChangeHistory("book-1", 100).Return(nil, nil)
+	mockStore.EXPECT().GetBookChanges("book-1").Return(nil, nil)
+
+	svc := NewChangelogService(mockStore)
+	entries, err := svc.GetBookChangelog("book-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "rename", entries[0].Type)
+	assert.Contains(t, entries[0].Summary, "Organized — /staging/Star Wars: The Force Unleashed.mp3 →")
 }
 
 // --------------------------------------------------------------------------

--- a/internal/organizer/organized_version_writeback_test.go
+++ b/internal/organizer/organized_version_writeback_test.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/organized_version_writeback_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8eea5b3c-7be2-4f84-a629-aca6c5044dbb
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 package organizer
 
@@ -105,6 +105,60 @@ func TestCreateOrganizedVersion_OriginalDemotedToNonPrimary(t *testing.T) {
 	}
 	if *got.LibraryState != "organized_source" {
 		t.Errorf("LibraryState = %q, want %q", *got.LibraryState, "organized_source")
+	}
+}
+
+// TestCreateOrganizedVersion_RecordsOrganizeProvenance proves the Bug-2
+// import-provenance fix: CreateOrganizedVersion moves the file from the original
+// path to newPath, and that source path is known here, so it must record an
+// "organize" path-change on the new book carrying the real old → new. Without it
+// the change log only shows CreateBook's empty-from "import" marker and drops
+// where the file was organized FROM.
+func TestCreateOrganizedVersion_RecordsOrganizeProvenance(t *testing.T) {
+	store, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	store.WaitForWarmup()
+	t.Cleanup(func() { _ = store.Close() })
+
+	svc := NewService(store)
+	org := &Organizer{config: &config.Config{}}
+
+	seeded := newWritebackTestBook(t, store)
+	oldPath := seeded.FilePath
+
+	newPath := filepath.Join(t.TempDir(), "organized.m4b")
+	created, err := svc.CreateOrganizedVersion(org, seeded, newPath, false, "", &noopLogger{})
+	if err != nil {
+		t.Fatalf("CreateOrganizedVersion: %v", err)
+	}
+
+	history, err := store.GetBookPathHistory(created.ID)
+	if err != nil {
+		t.Fatalf("GetBookPathHistory: %v", err)
+	}
+
+	var foundOrganize, foundImport bool
+	for _, ph := range history {
+		switch ph.ChangeType {
+		case "organize":
+			foundOrganize = true
+			if ph.OldPath != oldPath {
+				t.Errorf("organize OldPath = %q, want %q (the real source path)", ph.OldPath, oldPath)
+			}
+			if ph.NewPath != newPath {
+				t.Errorf("organize NewPath = %q, want %q", ph.NewPath, newPath)
+			}
+		case "import":
+			foundImport = true
+		}
+	}
+	if !foundOrganize {
+		t.Errorf("no organize path-change recorded for organized book %q; history=%+v", created.ID, history)
+	}
+	if !foundImport {
+		t.Errorf("expected CreateBook import path-change to still be present; history=%+v", history)
 	}
 }
 

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,5 +1,5 @@
 // file: internal/organizer/service.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
 // last-edited: 2026-07-13
 
@@ -35,6 +35,7 @@ type Store interface {
 	database.NarratorStore
 	database.MaintenanceStore
 	database.TagStore
+	database.PathHistoryStore
 }
 
 // Compile-time proof that PebbleStore satisfies organizer.Store.
@@ -911,6 +912,24 @@ func (orgSvc *Service) CreateOrganizedVersion(org *Organizer, book *database.Boo
 		}
 		return nil, err
 	}
+	// Import-provenance: CreateBook records an "import" path-change with an empty
+	// OldPath for the new organized book. But organize RENAMED/MOVED the file from
+	// book.FilePath → newPath, and that source path is known here, so record a
+	// second "organize" path-change carrying the real old→new. Without this the
+	// change log would only show "Imported — <newPath>" and drop where the file was
+	// organized FROM. Mirrors the library_copy convention in
+	// metafetch/service_apply.go (CreateBook import marker + explicit old→new).
+	if book.FilePath != "" && book.FilePath != newPath {
+		if err := orgSvc.db.RecordPathChange(&database.BookPathChange{
+			BookID:     createdBook.ID,
+			OldPath:    book.FilePath,
+			NewPath:    newPath,
+			ChangeType: "organize",
+		}); err != nil {
+			log.Warn("organize: failed to record organize path change for %s: %v", createdBook.ID, err)
+		}
+	}
+
 	// Mark both the organized copy and the original for rescan
 	_ = orgSvc.db.MarkNeedsRescan(createdBook.ID)
 	_ = orgSvc.db.MarkNeedsRescan(book.ID)


### PR DESCRIPTION
## The report

On a book's Change Log tab an entry showed:

> 📁 Rename — Renamed — → /mnt/.../2-03 (SW-022) Star Wars_ The Force U.mp3

The "from" path is empty (renders as an em-dash) and it is labeled **Rename** for what was actually an **import** of an organized file. Two problems: a display mislabel, and an underlying provenance gap.

## Bug 1 (display) — fixed

`internal/activity/changelog.go` hardcoded `Type:"rename"` + `"Renamed — <old> → <new>"` for **every** `book_path_history` row, including the empty-`OldPath` `import` record that `PebbleStore.CreateBook` writes (`pebble_store.go` ~1734). The `—` in that summary is the "label — detail" separator (matching the sibling `"Metadata applied — …"`), **not** the old path — so an empty `OldPath` rendered as `Renamed — → /newpath`.

Now `pathChangeEntry(ph)` branches on `ChangeType`/`OldPath`:
- empty-from → `Type:"import"`, `"Imported — <path>"` (no phantom `→`)
- real move → `Type:"rename"` with a ChangeType-specific verb: Renamed / Organized / Copied to library / Version swapped / Quarantined / Restored from quarantine / Path repaired; unknown-with-from → "Moved"

The operation-changes loop (section 3) also gained `organize_rename` and `book_create` cases so an organized book's change log no longer shows raw `"Operation change — …"` junk next to the fixed section-1 line.

The frontend (`web/src/components/ChangeLog.tsx`) already maps `import`→📦/"Import" and `rename`→📁/"Rename" and renders `summary`, so **no frontend change was needed** — fixing the backend `Type`+`Summary` is sufficient.

## Bug 2 (provenance) — investigated, fixed

**Finding:** Traced every `RecordPathChange`/`CreateBook` import site.
- iTunes importers (`importer.go` 296/714/1515) and the scanner (`scanner.go:2009`) ingest **in place** — `FilePath` = the on-disk location, no rename — so their empty `OldPath` is legitimate and "Imported" is the correct label. No lost path there.
- `CreateOrganizedVersion` (`organizer/service.go:840`) is the **sole** path that renames/moves the file (source `book.FilePath` → sanitized `newPath`) while recording only CreateBook's empty-from import marker. That is the user's scenario (the sanitized filename comes from the organize template). The real source path was in scope but dropped.

**Fix:** after CreateBook succeeds, `CreateOrganizedVersion` now records a second `organize` path-change carrying the real `old → new` (mirroring the `library_copy` convention in `metafetch/service_apply.go:378` — CreateBook writes the import origin marker, the mover writes an explicit old→new). Guarded by `book.FilePath != "" && book.FilePath != newPath`. `organizer.Store` gained `database.PathHistoryStore` (already satisfied by `PebbleStore` and the full `database` mock — no regen).

**Verdict on Bug 2: real lost path plumbed** for the organize path; in-place imports legitimately had none. The fix is **forward-only** — path-history rows are immutable, so a book organized before this deploy cannot retroactively regain its never-stored old path; its entry simply relabels from the phantom "Renamed — →" to "Imported — <path>". Only future organizes get full provenance.

## Tests
- `internal/activity/service_unit_test.go`: import record → `import` + "Imported — <path>" (no `→`, not "Renamed"); real rename → `rename` + "Renamed — <old> → <new>"; organize record → `rename` + "Organized — <old> → <new>".
- `internal/organizer/organized_version_writeback_test.go`: `CreateOrganizedVersion` records an `organize` path-change with the real source path (and the import marker remains).
- `go test ./internal/activity/... ./internal/organizer/... ./internal/database/... -race` green; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT4Dmnqaq2E7CCmQk2VuGv