### PR TITLE
feat(review): universal review-queue backend (store + API + apply registry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.153.0 -->
+<!-- version: 3.154.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - feat(review): universal review-queue backend (store + API + apply registry)
+
+Adds the backend for a universal review queue — a single home for items the system
+flags for human review (PR-A1 of the review-queue + shattered-book-regroup plan). No
+user-facing behavior yet; the banner/panel is PR-A2 and the first producer (the regroup
+op) is PR-B1.
+
+- New Pebble-backed `ReviewItem` store (`internal/database/review_store.go`) with a
+  `review_item:*` keyspace and a status secondary index (mirroring the dedup
+  candidate-status index). **Idempotent upsert keyed by `DedupKey` (Kind+FolderRef):**
+  re-running a producer scan never duplicates rows and never un-rejects a
+  human-decided item.
+- `ReviewStore` interface + `PebbleStore` impl + store-mock methods.
+- HTTP API (`/review/count`, `/review/items`, `/review/items/:id/approve|reject`,
+  `/review/bulk`): reads gated on `library.view`, mutations on `library.edit-metadata`
+  (matching dedup). Bulk action refuses a request with neither `kind` nor `ids` to
+  prevent an accidental approve/reject-all.
+- Apply-handler registry keyed by `Kind`: `approve` runs the registered producer
+  handler (then marks `applied`) or, when none is registered yet, marks `approved`
+  without erroring — the regroup apply handler plugs in at PR-B2.
 
 #### July 13, 2026 - fix(activity): label imports correctly in change log (+ import-provenance path capture)
 

--- a/internal/database/iface_review.go
+++ b/internal/database/iface_review.go
@@ -1,0 +1,36 @@
+// file: internal/database/iface_review.go
+// version: 1.0.0
+// guid: 7a1e4d63-2c9f-48b5-b0a7-6e3d51f8c294
+// last-edited: 2026-07-13
+
+package database
+
+// ReviewStore is the universal review-queue surface (PR-A1). It backs a generic,
+// producer-agnostic queue of items flagged for a human decision. Producers
+// UPSERT by DedupKey (idempotent, decision-preserving); the HTTP layer lists,
+// counts, and transitions items. Implemented on *PebbleStore (review_store.go).
+type ReviewStore interface {
+	// UpsertReviewItem inserts or idempotently updates a review item keyed by
+	// its stable DedupKey. A re-scan never duplicates a row and never resurfaces
+	// an already-decided (non-pending) item. See the implementation for the full
+	// idempotency contract.
+	UpsertReviewItem(item ReviewItem) (ReviewItem, error)
+
+	// GetReviewItem returns a single item by ID, or (nil, nil) when absent.
+	GetReviewItem(id string) (*ReviewItem, error)
+
+	// ListReviewItems returns a paginated, newest-first slice of items matching
+	// the filter plus the total match count (before pagination).
+	ListReviewItems(filter ReviewFilter) ([]ReviewItem, int, error)
+
+	// CountReviewItems returns the number of items with the given status; a blank
+	// status counts every item.
+	CountReviewItems(status string) (int, error)
+
+	// ReviewStatsByKind returns a per-(Kind, Status) count breakdown.
+	ReviewStatsByKind() ([]ReviewKindStat, error)
+
+	// SetReviewItemStatus transitions an item to a new status, moving its
+	// status-index row. Returns (nil, nil) when the item does not exist.
+	SetReviewItemStatus(id, status string) (*ReviewItem, error)
+}

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.80.0
+// version: 1.81.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 package database
 
@@ -2690,3 +2690,14 @@ func (m *MockStore) PromoteToQueued(_ string) error                { return nil 
 func (m *MockStore) AddToBatchBucket(_ string, _ OpSubject) error         { return nil }
 func (m *MockStore) ListBatchBucket(_ string) ([]BatchBucketEntry, error) { return nil, nil }
 func (m *MockStore) ClearBatchBucket(_ string, _ []OpSubject) error       { return nil }
+
+// ReviewStore stubs (PR-A1) — permissive no-ops for tests that don't exercise
+// the review queue. Handler/store tests use a real *PebbleStore, not this mock.
+func (m *MockStore) UpsertReviewItem(item ReviewItem) (ReviewItem, error) { return item, nil }
+func (m *MockStore) GetReviewItem(_ string) (*ReviewItem, error)          { return nil, nil }
+func (m *MockStore) ListReviewItems(_ ReviewFilter) ([]ReviewItem, int, error) {
+	return nil, 0, nil
+}
+func (m *MockStore) CountReviewItems(_ string) (int, error)               { return 0, nil }
+func (m *MockStore) ReviewStatsByKind() ([]ReviewKindStat, error)         { return nil, nil }
+func (m *MockStore) SetReviewItemStatus(_, _ string) (*ReviewItem, error) { return nil, nil }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -51371,3 +51371,374 @@ func (_c *MockStore_UpsertOpStateV2_Call) RunAndReturn(run func(row database.OpS
 	_c.Call.Return(run)
 	return _c
 }
+
+// ReviewStore methods (PR-A1). Hand-added: local mockery version drifts from the
+// pinned one, so regenerating would rewrite every mock in the repo. These mirror
+// the testify template the generator emits.
+
+func (_mock *MockStore) UpsertReviewItem(item database.ReviewItem) (database.ReviewItem, error) {
+	ret := _mock.Called(item)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertReviewItem")
+	}
+
+	var r0 database.ReviewItem
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(database.ReviewItem) (database.ReviewItem, error)); ok {
+		return returnFunc(item)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.ReviewItem) database.ReviewItem); ok {
+		r0 = returnFunc(item)
+	} else {
+		r0 = ret.Get(0).(database.ReviewItem)
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.ReviewItem) error); ok {
+		r1 = returnFunc(item)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+func (_mock *MockStore) GetReviewItem(id string) (*database.ReviewItem, error) {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReviewItem")
+	}
+
+	var r0 *database.ReviewItem
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (*database.ReviewItem, error)); ok {
+		return returnFunc(id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) *database.ReviewItem); ok {
+		r0 = returnFunc(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.ReviewItem)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+func (_mock *MockStore) ListReviewItems(filter database.ReviewFilter) ([]database.ReviewItem, int, error) {
+	ret := _mock.Called(filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListReviewItems")
+	}
+
+	var r0 []database.ReviewItem
+	var r1 int
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(database.ReviewFilter) ([]database.ReviewItem, int, error)); ok {
+		return returnFunc(filter)
+	}
+	if returnFunc, ok := ret.Get(0).(func(database.ReviewFilter) []database.ReviewItem); ok {
+		r0 = returnFunc(filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.ReviewItem)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(database.ReviewFilter) int); ok {
+		r1 = returnFunc(filter)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+	if returnFunc, ok := ret.Get(2).(func(database.ReviewFilter) error); ok {
+		r2 = returnFunc(filter)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+func (_mock *MockStore) CountReviewItems(status string) (int, error) {
+	ret := _mock.Called(status)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountReviewItems")
+	}
+
+	var r0 int
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (int, error)); ok {
+		return returnFunc(status)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) int); ok {
+		r0 = returnFunc(status)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(status)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+func (_mock *MockStore) ReviewStatsByKind() ([]database.ReviewKindStat, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReviewStatsByKind")
+	}
+
+	var r0 []database.ReviewKindStat
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() ([]database.ReviewKindStat, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() []database.ReviewKindStat); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]database.ReviewKindStat)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+func (_mock *MockStore) SetReviewItemStatus(id string, status string) (*database.ReviewItem, error) {
+	ret := _mock.Called(id, status)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetReviewItemStatus")
+	}
+
+	var r0 *database.ReviewItem
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string) (*database.ReviewItem, error)); ok {
+		return returnFunc(id, status)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string) *database.ReviewItem); ok {
+		r0 = returnFunc(id, status)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.ReviewItem)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = returnFunc(id, status)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_UpsertReviewItem_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertReviewItem'
+type MockStore_UpsertReviewItem_Call struct {
+	*mock.Call
+}
+
+// UpsertReviewItem is a helper method to define mock.On call
+//   - item database.ReviewItem
+func (_e *MockStore_Expecter) UpsertReviewItem(item any) *MockStore_UpsertReviewItem_Call {
+	return &MockStore_UpsertReviewItem_Call{Call: _e.mock.On("UpsertReviewItem", item)}
+}
+
+func (_c *MockStore_UpsertReviewItem_Call) Run(run func(item database.ReviewItem)) *MockStore_UpsertReviewItem_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.ReviewItem
+		if args[0] != nil {
+			arg0 = args[0].(database.ReviewItem)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_UpsertReviewItem_Call) Return(reviewItem database.ReviewItem, err error) *MockStore_UpsertReviewItem_Call {
+	_c.Call.Return(reviewItem, err)
+	return _c
+}
+
+func (_c *MockStore_UpsertReviewItem_Call) RunAndReturn(run func(item database.ReviewItem) (database.ReviewItem, error)) *MockStore_UpsertReviewItem_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_GetReviewItem_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReviewItem'
+type MockStore_GetReviewItem_Call struct {
+	*mock.Call
+}
+
+// GetReviewItem is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) GetReviewItem(id any) *MockStore_GetReviewItem_Call {
+	return &MockStore_GetReviewItem_Call{Call: _e.mock.On("GetReviewItem", id)}
+}
+
+func (_c *MockStore_GetReviewItem_Call) Run(run func(id string)) *MockStore_GetReviewItem_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_GetReviewItem_Call) Return(reviewItem *database.ReviewItem, err error) *MockStore_GetReviewItem_Call {
+	_c.Call.Return(reviewItem, err)
+	return _c
+}
+
+func (_c *MockStore_GetReviewItem_Call) RunAndReturn(run func(id string) (*database.ReviewItem, error)) *MockStore_GetReviewItem_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_ListReviewItems_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListReviewItems'
+type MockStore_ListReviewItems_Call struct {
+	*mock.Call
+}
+
+// ListReviewItems is a helper method to define mock.On call
+//   - filter database.ReviewFilter
+func (_e *MockStore_Expecter) ListReviewItems(filter any) *MockStore_ListReviewItems_Call {
+	return &MockStore_ListReviewItems_Call{Call: _e.mock.On("ListReviewItems", filter)}
+}
+
+func (_c *MockStore_ListReviewItems_Call) Run(run func(filter database.ReviewFilter)) *MockStore_ListReviewItems_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 database.ReviewFilter
+		if args[0] != nil {
+			arg0 = args[0].(database.ReviewFilter)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_ListReviewItems_Call) Return(reviewItems []database.ReviewItem, n int, err error) *MockStore_ListReviewItems_Call {
+	_c.Call.Return(reviewItems, n, err)
+	return _c
+}
+
+func (_c *MockStore_ListReviewItems_Call) RunAndReturn(run func(filter database.ReviewFilter) ([]database.ReviewItem, int, error)) *MockStore_ListReviewItems_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_CountReviewItems_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountReviewItems'
+type MockStore_CountReviewItems_Call struct {
+	*mock.Call
+}
+
+// CountReviewItems is a helper method to define mock.On call
+//   - status string
+func (_e *MockStore_Expecter) CountReviewItems(status any) *MockStore_CountReviewItems_Call {
+	return &MockStore_CountReviewItems_Call{Call: _e.mock.On("CountReviewItems", status)}
+}
+
+func (_c *MockStore_CountReviewItems_Call) Run(run func(status string)) *MockStore_CountReviewItems_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_CountReviewItems_Call) Return(n int, err error) *MockStore_CountReviewItems_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockStore_CountReviewItems_Call) RunAndReturn(run func(status string) (int, error)) *MockStore_CountReviewItems_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_ReviewStatsByKind_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReviewStatsByKind'
+type MockStore_ReviewStatsByKind_Call struct {
+	*mock.Call
+}
+
+// ReviewStatsByKind is a helper method to define mock.On call
+func (_e *MockStore_Expecter) ReviewStatsByKind() *MockStore_ReviewStatsByKind_Call {
+	return &MockStore_ReviewStatsByKind_Call{Call: _e.mock.On("ReviewStatsByKind")}
+}
+
+func (_c *MockStore_ReviewStatsByKind_Call) Run(run func()) *MockStore_ReviewStatsByKind_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStore_ReviewStatsByKind_Call) Return(reviewKindStats []database.ReviewKindStat, err error) *MockStore_ReviewStatsByKind_Call {
+	_c.Call.Return(reviewKindStats, err)
+	return _c
+}
+
+func (_c *MockStore_ReviewStatsByKind_Call) RunAndReturn(run func() ([]database.ReviewKindStat, error)) *MockStore_ReviewStatsByKind_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockStore_SetReviewItemStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReviewItemStatus'
+type MockStore_SetReviewItemStatus_Call struct {
+	*mock.Call
+}
+
+// SetReviewItemStatus is a helper method to define mock.On call
+//   - id string
+//   - status string
+func (_e *MockStore_Expecter) SetReviewItemStatus(id any, status any) *MockStore_SetReviewItemStatus_Call {
+	return &MockStore_SetReviewItemStatus_Call{Call: _e.mock.On("SetReviewItemStatus", id, status)}
+}
+
+func (_c *MockStore_SetReviewItemStatus_Call) Run(run func(id string, status string)) *MockStore_SetReviewItemStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetReviewItemStatus_Call) Return(reviewItem *database.ReviewItem, err error) *MockStore_SetReviewItemStatus_Call {
+	_c.Call.Return(reviewItem, err)
+	return _c
+}
+
+func (_c *MockStore_SetReviewItemStatus_Call) RunAndReturn(run func(id string, status string) (*database.ReviewItem, error)) *MockStore_SetReviewItemStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store.go
-// version: 1.115.0
+// version: 1.116.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
 // last-edited: 2026-07-13
 
@@ -99,6 +99,7 @@ type PebbleStore struct {
 	memPtr                   atomic.Pointer[MemStore]
 	counterMu                sync.Mutex // protects nextID read-modify-write
 	opsMu                    sync.Mutex // serializes v2 op CAS operations (SetOperationV2StatusIfQueued)
+	reviewMu                 sync.Mutex // serializes review-item upserts so concurrent same-DedupKey writes can't duplicate rows (review_store.go)
 	opsLogSeq                int64      // monotonic counter for log key uniqueness; accessed via atomic
 	rootDir                  string     // organized library root; set via SetRootDir after config load
 	libraryCountsRecomputeMu sync.Mutex // gates recompute to prevent stampede when N callers see dirty cache

--- a/internal/database/review_store.go
+++ b/internal/database/review_store.go
@@ -1,0 +1,459 @@
+// file: internal/database/review_store.go
+// version: 1.0.0
+// guid: 4f2c8a91-6b3d-4e57-9a02-8d1f5c7e3b40
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// ─── Review-queue store (PR-A1) ──────────────────────────────────────────────
+//
+// A generic, producer-agnostic queue of items flagged for a human decision. v1
+// producer is the regroup op (Track B); A1 is pure infra. The design mirrors the
+// dedup candidate store's Status/secondary-index pattern (embedding_store.go) but
+// lives in its own keyspace so the two never overload each other.
+//
+// Key-space layout (PebbleDB):
+//
+//	review_item:r:<id>                     → ReviewItem JSON  (the record)
+//	review_item:status:<status>:<id>       → empty            (status secondary index)
+//	review_item:dedupkey:<dedupKey>        → <id>             (idempotency index)
+//
+// Records live under the "r:" sub-prefix so a full-record scan (prefix
+// "review_item:r:") never collides with the "status:" / "dedupkey:" indexes —
+// exactly the dedup:r: / dedup:s: split.
+//
+// Unlike the dedup status index, this keyspace is greenfield: the status index
+// is authoritative from the very first row, so there is no build-flag /
+// fail-open-to-full-scan machinery. A status-filtered list/count trusts the
+// index directly (still re-checking the record's status on point-read to guard
+// against a concurrent status change racing the scan).
+const (
+	reviewItemRecPfx    = "review_item:r:"
+	reviewItemStatusPfx = "review_item:status:"
+	reviewItemDedupPfx  = "review_item:dedupkey:"
+)
+
+// Review item status values (stringly-typed, matching dedup/house style).
+const (
+	ReviewStatusPending  = "pending"
+	ReviewStatusApproved = "approved"
+	ReviewStatusRejected = "rejected"
+	ReviewStatusApplied  = "applied"
+)
+
+// ReviewItem is one thing the system has flagged for a human decision.
+//
+// DedupKey is the STABLE upsert target — a normalized hash of (Kind, FolderRef)
+// computed by the producer. Re-running a producer's scan UPSERTs by DedupKey so
+// the same folder never piles up duplicate rows and a prior human decision
+// (rejected) is never resurfaced. See UpsertReviewItem for the exact idempotency
+// contract.
+type ReviewItem struct {
+	ID        string    `json:"id"`         // ULID
+	Kind      string    `json:"kind"`       // e.g. "regroup.multidisc", "regroup.anthology"
+	DedupKey  string    `json:"dedup_key"`  // STABLE: hash(Kind + FolderRef) — upsert target
+	FolderRef string    `json:"folder_ref"` // grandparent folder path this hold is about
+	Status    string    `json:"status"`     // pending | approved | rejected | applied
+	Summary   string    `json:"summary"`    // one-line human label
+	Payload   string    `json:"payload"`    // JSON blob: folder, listing, proposed action, member IDs, ...
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ReviewFilter controls ListReviewItems / list-by-status queries.
+type ReviewFilter struct {
+	Status string
+	Kind   string
+	Limit  int
+	Offset int
+}
+
+// ReviewKindStat holds a count for one (Kind, Status) grouping.
+type ReviewKindStat struct {
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+func reviewItemRecKey(id string) []byte { return []byte(reviewItemRecPfx + id) }
+
+func reviewItemStatusKey(status, id string) []byte {
+	return []byte(reviewItemStatusPfx + status + ":" + id)
+}
+
+func reviewItemDedupIdxKey(dedupKey string) []byte {
+	return []byte(reviewItemDedupPfx + dedupKey)
+}
+
+// getReviewItem is the internal point-read; returns (nil, nil) when not found.
+func (p *PebbleStore) getReviewItem(id string) (*ReviewItem, error) {
+	val, closer, err := p.db.Get(reviewItemRecKey(id))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get review item %s: %w", id, err)
+	}
+	var item ReviewItem
+	unmarshalErr := json.Unmarshal(val, &item)
+	closer.Close()
+	if unmarshalErr != nil {
+		return nil, fmt.Errorf("unmarshal review item %s: %w", id, unmarshalErr)
+	}
+	return &item, nil
+}
+
+// UpsertReviewItem inserts or idempotently updates a review item keyed by its
+// stable DedupKey. It is the producer entry point.
+//
+// Idempotency contract (the critical invariant — a re-scan must be a no-op for
+// already-decided items):
+//
+//   - New DedupKey → create a fresh row (ULID assigned if item.ID is empty),
+//     Status defaulted to "pending" when empty, CreatedAt = UpdatedAt = now.
+//   - Existing DedupKey, current Status == "pending" → update Summary, Payload,
+//     and UpdatedAt only. Kind/FolderRef/CreatedAt/Status are preserved (Kind and
+//     FolderRef are what DedupKey hashes, so they cannot legitimately change).
+//   - Existing DedupKey, current Status != "pending" (approved/rejected/applied)
+//     → FULL no-op: the stored row (including UpdatedAt) is returned untouched, so
+//     a re-scan never un-rejects a rejected hold or re-summarizes a decided one.
+//
+// The dedupkey → id index is written once on create and never deleted in A1, so
+// "rejected is remembered": a rejected folder stays rejected across re-scans.
+func (p *PebbleStore) UpsertReviewItem(item ReviewItem) (ReviewItem, error) {
+	if item.DedupKey == "" {
+		return ReviewItem{}, fmt.Errorf("review item: DedupKey is required for upsert")
+	}
+	if item.Kind == "" {
+		return ReviewItem{}, fmt.Errorf("review item: Kind is required")
+	}
+
+	// Serialize upserts so two producers writing the same DedupKey concurrently
+	// cannot both miss the index and create duplicate rows.
+	p.reviewMu.Lock()
+	defer p.reviewMu.Unlock()
+
+	// Look up the existing row by DedupKey.
+	idxVal, idxCloser, err := p.db.Get(reviewItemDedupIdxKey(item.DedupKey))
+	if err != nil && err != pebble.ErrNotFound {
+		return ReviewItem{}, fmt.Errorf("review item dedupkey lookup: %w", err)
+	}
+	now := time.Now().UTC()
+
+	if err == pebble.ErrNotFound {
+		// New row.
+		id := item.ID
+		if id == "" {
+			id, err = newULID()
+			if err != nil {
+				return ReviewItem{}, fmt.Errorf("review item: generate id: %w", err)
+			}
+		}
+		status := item.Status
+		if status == "" {
+			status = ReviewStatusPending
+		}
+		rec := ReviewItem{
+			ID:        id,
+			Kind:      item.Kind,
+			DedupKey:  item.DedupKey,
+			FolderRef: item.FolderRef,
+			Status:    status,
+			Summary:   item.Summary,
+			Payload:   item.Payload,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		data, err := json.Marshal(rec)
+		if err != nil {
+			return ReviewItem{}, fmt.Errorf("marshal review item: %w", err)
+		}
+		b := p.db.NewBatch()
+		defer b.Close()
+		if err := b.Set(reviewItemRecKey(id), data, nil); err != nil {
+			return ReviewItem{}, err
+		}
+		if err := b.Set(reviewItemDedupIdxKey(rec.DedupKey), []byte(id), nil); err != nil {
+			return ReviewItem{}, err
+		}
+		if err := b.Set(reviewItemStatusKey(rec.Status, id), nil, nil); err != nil {
+			return ReviewItem{}, err
+		}
+		if err := b.Commit(pebble.Sync); err != nil {
+			return ReviewItem{}, err
+		}
+		return rec, nil
+	}
+
+	// Existing row.
+	existingID := string(idxVal)
+	idxCloser.Close()
+	existing, err := p.getReviewItem(existingID)
+	if err != nil {
+		return ReviewItem{}, err
+	}
+	if existing == nil {
+		// Dangling dedupkey index (record gone). Treat as a fresh insert reusing
+		// the mapped ID so the index and record reconverge.
+		status := item.Status
+		if status == "" {
+			status = ReviewStatusPending
+		}
+		rec := ReviewItem{
+			ID:        existingID,
+			Kind:      item.Kind,
+			DedupKey:  item.DedupKey,
+			FolderRef: item.FolderRef,
+			Status:    status,
+			Summary:   item.Summary,
+			Payload:   item.Payload,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		data, err := json.Marshal(rec)
+		if err != nil {
+			return ReviewItem{}, fmt.Errorf("marshal review item: %w", err)
+		}
+		b := p.db.NewBatch()
+		defer b.Close()
+		if err := b.Set(reviewItemRecKey(existingID), data, nil); err != nil {
+			return ReviewItem{}, err
+		}
+		if err := b.Set(reviewItemStatusKey(rec.Status, existingID), nil, nil); err != nil {
+			return ReviewItem{}, err
+		}
+		if err := b.Commit(pebble.Sync); err != nil {
+			return ReviewItem{}, err
+		}
+		return rec, nil
+	}
+
+	// A decided item is never touched by a re-scan — full no-op.
+	if existing.Status != ReviewStatusPending {
+		return *existing, nil
+	}
+
+	// Pending item: refresh only the mutable presentation fields.
+	existing.Summary = item.Summary
+	existing.Payload = item.Payload
+	existing.UpdatedAt = now
+	data, err := json.Marshal(existing)
+	if err != nil {
+		return ReviewItem{}, fmt.Errorf("marshal review item: %w", err)
+	}
+	// Status is unchanged (still pending) so the status index needs no update.
+	if err := p.db.Set(reviewItemRecKey(existing.ID), data, pebble.Sync); err != nil {
+		return ReviewItem{}, err
+	}
+	return *existing, nil
+}
+
+// GetReviewItem retrieves a single review item by ID. Returns (nil, nil) when
+// not found.
+func (p *PebbleStore) GetReviewItem(id string) (*ReviewItem, error) {
+	return p.getReviewItem(id)
+}
+
+// ListReviewItems returns a paginated slice of review items matching the filter,
+// plus the total count of matches (before pagination). Results are ordered
+// newest-first (CreatedAt desc, ID desc tie-break) so the freshest holds surface
+// at the top of the queue.
+//
+// When f.Status != "" the status secondary index drives the scan; otherwise a
+// full record scan is used. The Kind filter is always applied in Go.
+func (p *PebbleStore) ListReviewItems(f ReviewFilter) ([]ReviewItem, int, error) {
+	var all []ReviewItem
+	var err error
+	if f.Status != "" {
+		all, err = p.listReviewItemsByStatusIndex(f.Status)
+	} else {
+		all, err = p.listAllReviewItems()
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Apply the Kind filter (status is already satisfied by the chosen scan).
+	if f.Kind != "" {
+		filtered := all[:0:0]
+		for _, it := range all {
+			if it.Kind == f.Kind {
+				filtered = append(filtered, it)
+			}
+		}
+		all = filtered
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		if !all[i].CreatedAt.Equal(all[j].CreatedAt) {
+			return all[i].CreatedAt.After(all[j].CreatedAt)
+		}
+		return all[i].ID > all[j].ID
+	})
+
+	total := len(all)
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	start := f.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+	return all[start:end], total, nil
+}
+
+func (p *PebbleStore) listAllReviewItems() ([]ReviewItem, error) {
+	prefix := []byte(reviewItemRecPfx)
+	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: prefixUpperBound(prefix)})
+	if err != nil {
+		return nil, fmt.Errorf("list review items: %w", err)
+	}
+	defer iter.Close()
+
+	var out []ReviewItem
+	for iter.First(); iter.Valid(); iter.Next() {
+		var item ReviewItem
+		if err := json.Unmarshal(iter.Value(), &item); err != nil {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, iter.Error()
+}
+
+func (p *PebbleStore) listReviewItemsByStatusIndex(status string) ([]ReviewItem, error) {
+	prefix := []byte(reviewItemStatusPfx + status + ":")
+	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: prefixUpperBound(prefix)})
+	if err != nil {
+		return nil, fmt.Errorf("list review items by status: %w", err)
+	}
+	defer iter.Close()
+
+	pfxLen := len(prefix)
+	var out []ReviewItem
+	for iter.First(); iter.Valid(); iter.Next() {
+		id := string(iter.Key()[pfxLen:])
+		item, err := p.getReviewItem(id)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			continue // dangling index row — tolerated, never an error.
+		}
+		// Re-check status: a status change that raced this scan could leave a
+		// stale index row pointing at a now-different record.
+		if item.Status != status {
+			continue
+		}
+		out = append(out, *item)
+	}
+	return out, iter.Error()
+}
+
+// CountReviewItems returns the number of review items with the given status.
+// A blank status counts every review item. The status index makes the common
+// pending-count an O(k) index scan with no record reads.
+func (p *PebbleStore) CountReviewItems(status string) (int, error) {
+	var prefix []byte
+	if status == "" {
+		prefix = []byte(reviewItemRecPfx)
+	} else {
+		prefix = []byte(reviewItemStatusPfx + status + ":")
+	}
+	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: prefixUpperBound(prefix)})
+	if err != nil {
+		return 0, fmt.Errorf("count review items: %w", err)
+	}
+	defer iter.Close()
+
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+	return n, iter.Error()
+}
+
+// ReviewStatsByKind returns a per-(Kind, Status) breakdown of every review item,
+// sorted by Kind then Status. Callers that want only the pending breakdown
+// filter on Status == ReviewStatusPending.
+func (p *PebbleStore) ReviewStatsByKind() ([]ReviewKindStat, error) {
+	items, err := p.listAllReviewItems()
+	if err != nil {
+		return nil, err
+	}
+	type key struct{ kind, status string }
+	counts := map[key]int{}
+	for _, it := range items {
+		counts[key{it.Kind, it.Status}]++
+	}
+	stats := make([]ReviewKindStat, 0, len(counts))
+	for k, c := range counts {
+		stats = append(stats, ReviewKindStat{Kind: k.kind, Status: k.status, Count: c})
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].Kind != stats[j].Kind {
+			return stats[i].Kind < stats[j].Kind
+		}
+		return stats[i].Status < stats[j].Status
+	})
+	return stats, nil
+}
+
+// SetReviewItemStatus transitions a review item to a new status and moves its
+// status-index row accordingly. Returns (nil, nil) when the item does not exist
+// so callers can respond 404. The dedupkey index is never touched (DedupKey is
+// stable), so a rejected item stays remembered across future producer re-scans.
+func (p *PebbleStore) SetReviewItemStatus(id, status string) (*ReviewItem, error) {
+	if status == "" {
+		return nil, fmt.Errorf("review item: status is required")
+	}
+	item, err := p.getReviewItem(id)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		return nil, nil
+	}
+	oldStatus := item.Status
+	item.Status = status
+	item.UpdatedAt = time.Now().UTC()
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		return nil, fmt.Errorf("marshal review item: %w", err)
+	}
+	b := p.db.NewBatch()
+	defer b.Close()
+	if err := b.Set(reviewItemRecKey(id), data, nil); err != nil {
+		return nil, err
+	}
+	if oldStatus != "" && oldStatus != status {
+		if err := b.Delete(reviewItemStatusKey(oldStatus, id), nil); err != nil {
+			return nil, err
+		}
+	}
+	if err := b.Set(reviewItemStatusKey(status, id), nil, nil); err != nil {
+		return nil, err
+	}
+	if err := b.Commit(pebble.Sync); err != nil {
+		return nil, err
+	}
+	return item, nil
+}

--- a/internal/database/review_store_test.go
+++ b/internal/database/review_store_test.go
@@ -1,0 +1,300 @@
+// file: internal/database/review_store_test.go
+// version: 1.0.0
+// guid: 9d3b7f21-4a58-4c69-b8e2-1f0a6c5d4e37
+// last-edited: 2026-07-13
+
+package database
+
+import (
+	"testing"
+)
+
+func newReviewTestStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	s.WaitForWarmup()
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func mkReviewItem(kind, dedupKey, folder, summary, payload string) ReviewItem {
+	return ReviewItem{
+		Kind:      kind,
+		DedupKey:  dedupKey,
+		FolderRef: folder,
+		Summary:   summary,
+		Payload:   payload,
+	}
+}
+
+func TestUpsertReviewItem_NewAssignsIDAndPending(t *testing.T) {
+	s := newReviewTestStore(t)
+	got, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", "dk1", "/books/a", "sum", `{"x":1}`))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if got.ID == "" {
+		t.Fatal("expected an ID to be assigned")
+	}
+	if got.Status != ReviewStatusPending {
+		t.Fatalf("expected status pending, got %q", got.Status)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Fatal("expected CreatedAt/UpdatedAt to be set")
+	}
+
+	// Round-trip.
+	fetched, err := s.GetReviewItem(got.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fetched == nil || fetched.DedupKey != "dk1" || fetched.Summary != "sum" {
+		t.Fatalf("round-trip mismatch: %+v", fetched)
+	}
+}
+
+func TestUpsertReviewItem_IdempotentOnDedupKey(t *testing.T) {
+	s := newReviewTestStore(t)
+	first, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", "dk1", "/books/a", "sum1", `{"v":1}`))
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+
+	// Re-upsert same DedupKey with new Summary/Payload — must update in place, not duplicate.
+	second, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", "dk1", "/books/a", "sum2", `{"v":2}`))
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected same ID on re-upsert, got %q vs %q", second.ID, first.ID)
+	}
+	if second.Summary != "sum2" || second.Payload != `{"v":2}` {
+		t.Fatalf("expected Summary/Payload updated on pending re-upsert, got %+v", second)
+	}
+
+	// Exactly one row must exist.
+	count, err := s.CountReviewItems("")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 row after idempotent re-upsert, got %d", count)
+	}
+}
+
+func TestUpsertReviewItem_PreservesRejectedStatus(t *testing.T) {
+	s := newReviewTestStore(t)
+	first, err := s.UpsertReviewItem(mkReviewItem("regroup.anthology", "dk2", "/books/b", "sum1", `{"v":1}`))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// Human rejects it.
+	if _, err := s.SetReviewItemStatus(first.ID, ReviewStatusRejected); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// A re-scan re-upserts the same DedupKey with a fresh summary/payload.
+	reupsert, err := s.UpsertReviewItem(mkReviewItem("regroup.anthology", "dk2", "/books/b", "NEW-sum", `{"v":9}`))
+	if err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	if reupsert.Status != ReviewStatusRejected {
+		t.Fatalf("re-scan must NOT un-reject: got status %q", reupsert.Status)
+	}
+	// Full no-op for a decided item: summary/payload preserved, not overwritten.
+	if reupsert.Summary != "sum1" || reupsert.Payload != `{"v":1}` {
+		t.Fatalf("decided item must be untouched by re-upsert, got %+v", reupsert)
+	}
+
+	// Still rejected on disk, still exactly one row.
+	fetched, err := s.GetReviewItem(first.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fetched.Status != ReviewStatusRejected {
+		t.Fatalf("expected persisted rejected status, got %q", fetched.Status)
+	}
+	if c, _ := s.CountReviewItems(""); c != 1 {
+		t.Fatalf("expected 1 row, got %d", c)
+	}
+}
+
+func TestCountReviewItems_ByStatusIndex(t *testing.T) {
+	s := newReviewTestStore(t)
+	// 3 pending, then reject one.
+	var ids []string
+	for i, dk := range []string{"a", "b", "c"} {
+		it, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", dk, "/books/"+dk, "s", ""))
+		if err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+		ids = append(ids, it.ID)
+	}
+	if _, err := s.SetReviewItemStatus(ids[0], ReviewStatusRejected); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	if got, _ := s.CountReviewItems(ReviewStatusPending); got != 2 {
+		t.Fatalf("expected 2 pending, got %d", got)
+	}
+	if got, _ := s.CountReviewItems(ReviewStatusRejected); got != 1 {
+		t.Fatalf("expected 1 rejected, got %d", got)
+	}
+	if got, _ := s.CountReviewItems(""); got != 3 {
+		t.Fatalf("expected 3 total, got %d", got)
+	}
+}
+
+func TestListReviewItems_FilterByStatusAndKind(t *testing.T) {
+	s := newReviewTestStore(t)
+	seed := []struct{ kind, dk string }{
+		{"regroup.multidisc", "m1"},
+		{"regroup.multidisc", "m2"},
+		{"regroup.anthology", "a1"},
+	}
+	for _, sd := range seed {
+		if _, err := s.UpsertReviewItem(mkReviewItem(sd.kind, sd.dk, "/f/"+sd.dk, "s", "")); err != nil {
+			t.Fatalf("seed %s: %v", sd.dk, err)
+		}
+	}
+
+	// Status pending + kind filter.
+	items, total, err := s.ListReviewItems(ReviewFilter{Status: ReviewStatusPending, Kind: "regroup.multidisc"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Fatalf("expected 2 multidisc pending, got total=%d len=%d", total, len(items))
+	}
+	for _, it := range items {
+		if it.Kind != "regroup.multidisc" {
+			t.Fatalf("unexpected kind in filtered result: %q", it.Kind)
+		}
+	}
+
+	// No status filter → all 3.
+	_, total, err = s.ListReviewItems(ReviewFilter{})
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("expected 3 total, got %d", total)
+	}
+}
+
+func TestListReviewItems_Pagination(t *testing.T) {
+	s := newReviewTestStore(t)
+	for i := 0; i < 5; i++ {
+		dk := string(rune('a' + i))
+		if _, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", dk, "/f/"+dk, "s", "")); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	page, total, err := s.ListReviewItems(ReviewFilter{Status: ReviewStatusPending, Limit: 2, Offset: 0})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if total != 5 {
+		t.Fatalf("expected total 5, got %d", total)
+	}
+	if len(page) != 2 {
+		t.Fatalf("expected page size 2, got %d", len(page))
+	}
+}
+
+func TestSetReviewItemStatus_MovesIndexRow(t *testing.T) {
+	s := newReviewTestStore(t)
+	it, err := s.UpsertReviewItem(mkReviewItem("regroup.version-group", "vg1", "/f/vg1", "s", ""))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Move pending → approved.
+	updated, err := s.SetReviewItemStatus(it.ID, ReviewStatusApproved)
+	if err != nil {
+		t.Fatalf("set status: %v", err)
+	}
+	if updated == nil || updated.Status != ReviewStatusApproved {
+		t.Fatalf("expected approved, got %+v", updated)
+	}
+
+	// The pending index row must be gone; the approved one present.
+	if got, _ := s.CountReviewItems(ReviewStatusPending); got != 0 {
+		t.Fatalf("expected 0 pending after move, got %d", got)
+	}
+	if got, _ := s.CountReviewItems(ReviewStatusApproved); got != 1 {
+		t.Fatalf("expected 1 approved after move, got %d", got)
+	}
+
+	// The old-status index scan must not resurface it (stale-row guard).
+	pendingList, _, err := s.ListReviewItems(ReviewFilter{Status: ReviewStatusPending})
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pendingList) != 0 {
+		t.Fatalf("expected no pending items, got %d", len(pendingList))
+	}
+}
+
+func TestSetReviewItemStatus_NotFound(t *testing.T) {
+	s := newReviewTestStore(t)
+	got, err := s.SetReviewItemStatus("nonexistent", ReviewStatusApproved)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing item, got %+v", got)
+	}
+}
+
+func TestReviewStatsByKind(t *testing.T) {
+	s := newReviewTestStore(t)
+	items := []struct{ kind, dk string }{
+		{"regroup.multidisc", "m1"},
+		{"regroup.multidisc", "m2"},
+		{"regroup.anthology", "a1"},
+	}
+	var anthologyID string
+	for _, sd := range items {
+		it, err := s.UpsertReviewItem(mkReviewItem(sd.kind, sd.dk, "/f/"+sd.dk, "s", ""))
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if sd.kind == "regroup.anthology" {
+			anthologyID = it.ID
+		}
+	}
+	if _, err := s.SetReviewItemStatus(anthologyID, ReviewStatusRejected); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	stats, err := s.ReviewStatsByKind()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	pendingByKind := map[string]int{}
+	for _, st := range stats {
+		if st.Status == ReviewStatusPending {
+			pendingByKind[st.Kind] = st.Count
+		}
+	}
+	if pendingByKind["regroup.multidisc"] != 2 {
+		t.Fatalf("expected 2 pending multidisc, got %d", pendingByKind["regroup.multidisc"])
+	}
+	if _, ok := pendingByKind["regroup.anthology"]; ok {
+		t.Fatalf("expected no pending anthology (it was rejected), got %d", pendingByKind["regroup.anthology"])
+	}
+}
+
+func TestUpsertReviewItem_RequiresDedupKeyAndKind(t *testing.T) {
+	s := newReviewTestStore(t)
+	if _, err := s.UpsertReviewItem(ReviewItem{Kind: "regroup.multidisc"}); err == nil {
+		t.Fatal("expected error for empty DedupKey")
+	}
+	if _, err := s.UpsertReviewItem(ReviewItem{DedupKey: "dk"}); err == nil {
+		t.Fatal("expected error for empty Kind")
+	}
+}

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.84.0
+// version: 2.85.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-07-07
+// last-edited: 2026-07-13
 
 package database
 
@@ -53,6 +53,7 @@ type Store interface {
 	RejectedMetadataStore
 	OpsV2Store
 	MetadataCacheStore
+	ReviewStore
 }
 
 // BookAlternativeTitle represents a variant name for a book — romaji

--- a/internal/server/handlers/review/handler.go
+++ b/internal/server/handlers/review/handler.go
@@ -1,0 +1,312 @@
+// file: internal/server/handlers/review/handler.go
+// version: 1.0.0
+// guid: 2b6f9c14-8e37-4a5d-91c6-0f4a7d2e8b53
+// last-edited: 2026-07-13
+
+// Package reviewhandler hosts the universal review-queue HTTP handlers (PR-A1).
+//
+// The review queue is a generic, producer-agnostic home for everything the
+// system has flagged for a human decision. A1 is pure infrastructure: the store
+// (database.ReviewStore) plus this HTTP surface plus an apply-handler registry
+// that future producers register into. v1's producer is the regroup op (Track
+// B, not built yet), so at A1 the queue starts empty and no apply handlers are
+// registered.
+//
+// Apply-handler registry: because producers don't exist yet, approving an item
+// dispatches on its Kind to a registered ApplyFunc. When a Kind has a handler,
+// approve runs it and then sets the item to "applied". When it does NOT (the A1
+// state for every Kind), approve simply sets "approved" and returns OK with a
+// note — it never errors. Track B's B2 registers the regroup apply handler.
+package reviewhandler
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
+)
+
+// ApplyFunc executes the real-world action an approved review item represents
+// (e.g. the regroup op collapsing shattered books). Registered per Kind.
+type ApplyFunc func(ctx context.Context, item database.ReviewItem) error
+
+// Handler hosts the review-queue HTTP endpoints.
+type Handler struct {
+	// store is the wire-time snapshot of the review-queue store.
+	store database.ReviewStore
+
+	// applyHandlers maps a review item's Kind to the action that applies it.
+	// Empty in A1; populated by producers (e.g. B2's regroup) via
+	// RegisterApplyHandler. Guarded by mu because registration may happen during
+	// wiring while requests could already be arriving.
+	mu            sync.RWMutex
+	applyHandlers map[string]ApplyFunc
+}
+
+// New constructs a review Handler from its store dependency.
+func New(store database.ReviewStore) *Handler {
+	return &Handler{
+		store:         store,
+		applyHandlers: make(map[string]ApplyFunc),
+	}
+}
+
+// RegisterApplyHandler registers the apply action for a given review Kind.
+// Producers call this at wire time (B2 registers the regroup apply path).
+func (h *Handler) RegisterApplyHandler(kind string, fn ApplyFunc) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.applyHandlers[kind] = fn
+}
+
+func (h *Handler) applyHandlerFor(kind string) (ApplyFunc, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	fn, ok := h.applyHandlers[kind]
+	return fn, ok
+}
+
+// GetReviewCount handles GET /api/v1/review/count.
+//
+// Response: { "count": N, "byKind": { "<kind>": n, ... } } where count and the
+// byKind breakdown both cover PENDING items only (decision #1: the badge counts
+// intentional holds awaiting a decision, never decided items).
+func (h *Handler) GetReviewCount(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	count, err := h.store.CountReviewItems(database.ReviewStatusPending)
+	if err != nil {
+		httputil.InternalError(c, "failed to count review items", err)
+		return
+	}
+	stats, err := h.store.ReviewStatsByKind()
+	if err != nil {
+		httputil.InternalError(c, "failed to compute review stats", err)
+		return
+	}
+	byKind := gin.H{}
+	for _, s := range stats {
+		if s.Status == database.ReviewStatusPending {
+			byKind[s.Kind] = s.Count
+		}
+	}
+	httputil.RespondWithOK(c, gin.H{"count": count, "byKind": byKind})
+}
+
+// ListReviewItems handles GET /api/v1/review/items.
+//
+// Query params: status (default "pending"), kind, limit (default 50), offset.
+func (h *Handler) ListReviewItems(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	status := c.DefaultQuery("status", database.ReviewStatusPending)
+	// "all" is an explicit escape hatch for "every status".
+	if status == "all" {
+		status = ""
+	}
+	filter := database.ReviewFilter{
+		Status: status,
+		Kind:   c.Query("kind"),
+		Limit:  atoiDefault(c.Query("limit"), 50),
+		Offset: atoiDefault(c.Query("offset"), 0),
+	}
+	items, total, err := h.store.ListReviewItems(filter)
+	if err != nil {
+		httputil.InternalError(c, "failed to list review items", err)
+		return
+	}
+	if items == nil {
+		items = []database.ReviewItem{}
+	}
+	httputil.RespondWithList(c, items, total, filter.Limit, filter.Offset)
+}
+
+// ApproveReviewItem handles POST /api/v1/review/items/:id/approve.
+//
+// If a Kind has a registered apply handler, it runs then the item is set
+// "applied". Otherwise (A1 for every Kind) the item is set "approved" and a note
+// is returned — approving without a handler is never an error.
+func (h *Handler) ApproveReviewItem(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	id := c.Param("id")
+	updated, note, err := h.approveOne(c.Request.Context(), id)
+	if err != nil {
+		httputil.InternalError(c, "failed to approve review item", err)
+		return
+	}
+	if updated == nil {
+		httputil.RespondWithNotFound(c, "review item", id)
+		return
+	}
+	resp := gin.H{"item": updated}
+	if note != "" {
+		resp["note"] = note
+	}
+	httputil.RespondWithOK(c, resp)
+}
+
+// approveOne applies + transitions a single item. Returns (nil, "", nil) when
+// the item does not exist. note is set when the item was approved without a
+// registered apply handler.
+func (h *Handler) approveOne(ctx context.Context, id string) (*database.ReviewItem, string, error) {
+	item, err := h.store.GetReviewItem(id)
+	if err != nil {
+		return nil, "", err
+	}
+	if item == nil {
+		return nil, "", nil
+	}
+	if fn, ok := h.applyHandlerFor(item.Kind); ok {
+		if err := fn(ctx, *item); err != nil {
+			return nil, "", err
+		}
+		updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApplied)
+		return updated, "", err
+	}
+	updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
+	if err != nil {
+		return nil, "", err
+	}
+	return updated, "no apply handler registered for kind " + item.Kind + "; marked approved", nil
+}
+
+// RejectReviewItem handles POST /api/v1/review/items/:id/reject.
+func (h *Handler) RejectReviewItem(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	id := c.Param("id")
+	updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusRejected)
+	if err != nil {
+		httputil.InternalError(c, "failed to reject review item", err)
+		return
+	}
+	if updated == nil {
+		httputil.RespondWithNotFound(c, "review item", id)
+		return
+	}
+	httputil.RespondWithOK(c, gin.H{"item": updated})
+}
+
+// bulkRequest is the POST /api/v1/review/bulk body (decision #4: grouped bulk
+// actions). One of Kind or IDs must be set — an unscoped bulk over the whole
+// queue is rejected to avoid an accidental approve/reject-all.
+type bulkRequest struct {
+	Action string   `json:"action"` // "approve" | "reject"
+	Kind   string   `json:"kind,omitempty"`
+	IDs    []string `json:"ids,omitempty"`
+}
+
+// bulkResult reports the outcome of a bulk action.
+type bulkResult struct {
+	Action    string   `json:"action"`
+	Approved  []string `json:"approved,omitempty"`
+	Applied   []string `json:"applied,omitempty"`
+	Rejected  []string `json:"rejected,omitempty"`
+	NotFound  []string `json:"not_found,omitempty"`
+	Processed int      `json:"processed"`
+}
+
+// BulkReviewAction handles POST /api/v1/review/bulk.
+//
+// Targets are the explicit IDs when provided, otherwise every PENDING item of
+// the given Kind. Volume is bounded (v1 producer holds only), so this runs
+// sequentially; a worker pool would be premature until real apply handlers land.
+func (h *Handler) BulkReviewAction(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	var req bulkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.RespondWithBadRequest(c, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Action != "approve" && req.Action != "reject" {
+		httputil.RespondWithBadRequest(c, "action must be 'approve' or 'reject'")
+		return
+	}
+	if req.Kind == "" && len(req.IDs) == 0 {
+		httputil.RespondWithBadRequest(c, "bulk action requires 'kind' or 'ids' — refusing to act on the entire queue")
+		return
+	}
+
+	ids := req.IDs
+	if len(ids) == 0 {
+		// Kind-scoped: act on every pending item of that Kind.
+		items, _, err := h.store.ListReviewItems(database.ReviewFilter{
+			Status: database.ReviewStatusPending,
+			Kind:   req.Kind,
+			Limit:  bulkScanLimit,
+		})
+		if err != nil {
+			httputil.InternalError(c, "failed to list review items for bulk action", err)
+			return
+		}
+		ids = make([]string, 0, len(items))
+		for _, it := range items {
+			ids = append(ids, it.ID)
+		}
+	}
+
+	result := bulkResult{Action: req.Action}
+	for _, id := range ids {
+		switch req.Action {
+		case "approve":
+			updated, _, err := h.approveOne(c.Request.Context(), id)
+			if err != nil {
+				httputil.InternalError(c, "failed to approve review item "+id, err)
+				return
+			}
+			if updated == nil {
+				result.NotFound = append(result.NotFound, id)
+				continue
+			}
+			if updated.Status == database.ReviewStatusApplied {
+				result.Applied = append(result.Applied, id)
+			} else {
+				result.Approved = append(result.Approved, id)
+			}
+			result.Processed++
+		case "reject":
+			updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusRejected)
+			if err != nil {
+				httputil.InternalError(c, "failed to reject review item "+id, err)
+				return
+			}
+			if updated == nil {
+				result.NotFound = append(result.NotFound, id)
+				continue
+			}
+			result.Rejected = append(result.Rejected, id)
+			result.Processed++
+		}
+	}
+	httputil.RespondWithOK(c, result)
+}
+
+// bulkScanLimit caps the kind-scoped pending fetch. Comfortably exceeds any
+// realistic v1 hold population (intentional holds only, never raw backlogs).
+const bulkScanLimit = 100_000
+
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/server/handlers/review/handler_test.go
+++ b/internal/server/handlers/review/handler_test.go
@@ -1,0 +1,295 @@
+// file: internal/server/handlers/review/handler_test.go
+// version: 1.0.0
+// guid: 8e4a1c72-3d95-4b60-a7f1-9c2e6b0d5f83
+// last-edited: 2026-07-13
+
+// Tests for the universal review-queue handlers. The store is exercised through
+// a REAL pebble-backed *database.PebbleStore (which implements the ReviewStore
+// interface), matching the dedup handler tests' real-store approach. There is at
+// least one test per public endpoint plus the apply-registry and bulk-guard
+// paths.
+
+package reviewhandler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+func newTestStore(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	s.WaitForWarmup()
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func seed(t *testing.T, s *database.PebbleStore, kind, dedupKey string) database.ReviewItem {
+	t.Helper()
+	it, err := s.UpsertReviewItem(database.ReviewItem{
+		Kind:      kind,
+		DedupKey:  dedupKey,
+		FolderRef: "/f/" + dedupKey,
+		Summary:   "s",
+		Payload:   "{}",
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return it
+}
+
+func doReq(t *testing.T, fn gin.HandlerFunc, method, url string, body any, params gin.Params) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	var reader *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, url, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	c.Request = req
+	c.Params = params
+	fn(c)
+	return w
+}
+
+func decodeBody(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode body %q: %v", w.Body.String(), err)
+	}
+	return m
+}
+
+func TestGetReviewCount(t *testing.T) {
+	s := newTestStore(t)
+	seed(t, s, "regroup.multidisc", "m1")
+	seed(t, s, "regroup.multidisc", "m2")
+	seed(t, s, "regroup.anthology", "a1")
+	h := reviewhandler.New(s)
+
+	w := doReq(t, h.GetReviewCount, http.MethodGet, "/review/count", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w)
+	data := body["data"].(map[string]any)
+	if data["count"].(float64) != 3 {
+		t.Fatalf("expected count 3, got %v", data["count"])
+	}
+	byKind := data["byKind"].(map[string]any)
+	if byKind["regroup.multidisc"].(float64) != 2 {
+		t.Fatalf("expected 2 multidisc, got %v", byKind["regroup.multidisc"])
+	}
+}
+
+func TestListReviewItems(t *testing.T) {
+	s := newTestStore(t)
+	seed(t, s, "regroup.multidisc", "m1")
+	seed(t, s, "regroup.anthology", "a1")
+	h := reviewhandler.New(s)
+
+	// Default (pending) + kind filter.
+	w := doReq(t, h.ListReviewItems, http.MethodGet, "/review/items?kind=regroup.multidisc", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w)
+	if body["count"].(float64) != 1 {
+		t.Fatalf("expected count 1 for multidisc, got %v", body["count"])
+	}
+	items := body["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+}
+
+func TestApproveReviewItem_NoHandler_MarksApproved(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s) // no apply handlers registered (A1 state)
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w)
+	data := body["data"].(map[string]any)
+	if data["note"] == nil {
+		t.Fatal("expected a note when no apply handler is registered")
+	}
+	item := data["item"].(map[string]any)
+	if item["status"] != database.ReviewStatusApproved {
+		t.Fatalf("expected status approved, got %v", item["status"])
+	}
+}
+
+func TestApproveReviewItem_WithHandler_MarksApplied(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s)
+
+	var applied bool
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, item database.ReviewItem) error {
+		applied = true
+		if item.ID != it.ID {
+			t.Errorf("apply handler got wrong item: %s", item.ID)
+		}
+		return nil
+	})
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !applied {
+		t.Fatal("expected apply handler to be invoked")
+	}
+	item := decodeBody(t, w)["data"].(map[string]any)["item"].(map[string]any)
+	if item["status"] != database.ReviewStatusApplied {
+		t.Fatalf("expected status applied, got %v", item["status"])
+	}
+}
+
+func TestApproveReviewItem_HandlerError_StaysPending(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s)
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		return context.DeadlineExceeded // any apply failure
+	})
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when apply handler fails, got %d: %s", w.Code, w.Body.String())
+	}
+	// The item must NOT have advanced past pending — approve is not idempotent
+	// over a failed apply (B2 relies on this: a failed collapse leaves the hold
+	// re-approvable rather than stranded as "applied").
+	fetched, _ := s.GetReviewItem(it.ID)
+	if fetched.Status != database.ReviewStatusPending {
+		t.Fatalf("expected status to stay pending after apply failure, got %q", fetched.Status)
+	}
+}
+
+func TestApproveReviewItem_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	h := reviewhandler.New(s)
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/missing/approve", nil,
+		gin.Params{{Key: "id", Value: "missing"}})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRejectReviewItem(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.anthology", "a1")
+	h := reviewhandler.New(s)
+
+	w := doReq(t, h.RejectReviewItem, http.MethodPost, "/review/items/"+it.ID+"/reject", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	fetched, _ := s.GetReviewItem(it.ID)
+	if fetched.Status != database.ReviewStatusRejected {
+		t.Fatalf("expected persisted rejected status, got %q", fetched.Status)
+	}
+}
+
+func TestBulkReviewAction_RejectByKind(t *testing.T) {
+	s := newTestStore(t)
+	seed(t, s, "regroup.multidisc", "m1")
+	seed(t, s, "regroup.multidisc", "m2")
+	seed(t, s, "regroup.anthology", "a1")
+	h := reviewhandler.New(s)
+
+	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
+		map[string]any{"action": "reject", "kind": "regroup.multidisc"}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeBody(t, w)["data"].(map[string]any)
+	if data["processed"].(float64) != 2 {
+		t.Fatalf("expected 2 processed, got %v", data["processed"])
+	}
+	// The anthology item must be untouched.
+	if got, _ := s.CountReviewItems(database.ReviewStatusPending); got != 1 {
+		t.Fatalf("expected 1 pending remaining, got %d", got)
+	}
+	if got, _ := s.CountReviewItems(database.ReviewStatusRejected); got != 2 {
+		t.Fatalf("expected 2 rejected, got %d", got)
+	}
+}
+
+func TestBulkReviewAction_ByIDs(t *testing.T) {
+	s := newTestStore(t)
+	a := seed(t, s, "regroup.multidisc", "m1")
+	b := seed(t, s, "regroup.multidisc", "m2")
+	h := reviewhandler.New(s)
+
+	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
+		map[string]any{"action": "approve", "ids": []string{a.ID, b.ID}}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	data := decodeBody(t, w)["data"].(map[string]any)
+	if data["processed"].(float64) != 2 {
+		t.Fatalf("expected 2 processed, got %v", data["processed"])
+	}
+}
+
+func TestBulkReviewAction_RejectsUnscoped(t *testing.T) {
+	s := newTestStore(t)
+	seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s)
+
+	// Neither kind nor ids → must be refused, and nothing changed.
+	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
+		map[string]any{"action": "reject"}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unscoped bulk, got %d: %s", w.Code, w.Body.String())
+	}
+	if got, _ := s.CountReviewItems(database.ReviewStatusPending); got != 1 {
+		t.Fatalf("unscoped bulk must not mutate; expected 1 pending, got %d", got)
+	}
+}
+
+func TestBulkReviewAction_InvalidAction(t *testing.T) {
+	s := newTestStore(t)
+	h := reviewhandler.New(s)
+	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
+		map[string]any{"action": "delete", "kind": "regroup.multidisc"}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid action, got %d", w.Code)
+	}
+}

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.17.0
+// version: 2.18.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 package server
 
@@ -19,6 +19,7 @@ import (
 	entities "github.com/falkcorp/audiobook-organizer/internal/server/handlers/entities"
 	metadatahandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/metadata"
 	operations "github.com/falkcorp/audiobook-organizer/internal/server/handlers/operations"
+	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
 	system "github.com/falkcorp/audiobook-organizer/internal/server/handlers/system"
 	toolshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/tools"
 	"github.com/falkcorp/audiobook-organizer/internal/undo"
@@ -574,6 +575,12 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// lifecycle as the tools handler above.
 	aiBackendsH := aibackendshandler.New(s.toolRegistry, s.ollamaDaemon)
 
+	// Review-queue handler (PR-A1). The store is the wide database.Store, which
+	// embeds database.ReviewStore. s.Store() returns the interface so a nil store
+	// stays a nil interface (the handler guards on store == nil). Apply handlers
+	// are registered later by producers (Track B2); none exist at A1.
+	reviewH := reviewhandler.New(s.Store())
+
 	// ── Register protected routes via per-domain methods ─────────────────────
 	s.wireLibraryRoutes(protected, cacheH, activityH, splitBookH, filesystemH, organizeH, metaCacheH, readingH, playlistH, userH, versionsH)
 	s.wireMediaRoutes(protected, itunesH, aiH, diagH, toolsH, aiBackendsH, pluginsH)
@@ -581,6 +588,7 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	s.wireOperationsRoutes(protected, opsV2H, operationsH)
 	s.wireSystemRoutes(protected, systemH)
 	s.wireDedupRoutes(protected, dedupH, duplicatesH)
+	s.wireReviewRoutes(protected, reviewH)
 	s.wireAudiobooksRoutes(protected, audiobooksH)
 	s.wireMetadataRoutes(protected, metadataH)
 }

--- a/internal/server/wire_review_routes.go
+++ b/internal/server/wire_review_routes.go
@@ -1,0 +1,26 @@
+// file: internal/server/wire_review_routes.go
+// version: 1.1.0
+// guid: 5c8e1a37-9b24-4f60-83d1-7e2a9c4b6f18
+// last-edited: 2026-07-13
+
+package server
+
+import (
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
+	"github.com/gin-gonic/gin"
+)
+
+// wireReviewRoutes registers the universal review-queue domain routes (PR-A1) on
+// the protected group. Handler instantiation stays in wireHandlers.
+//
+// Reads (count/list) require library.view. Mutations (approve/reject/bulk) apply
+// real library changes via producer apply-handlers, so they require the stricter
+// library.edit-metadata guard, matching dedup's merge/dismiss mutations.
+func (s *Server) wireReviewRoutes(protected *gin.RouterGroup, reviewH *reviewhandler.Handler) {
+	protected.GET("/review/count", s.perm(auth.PermLibraryView), reviewH.GetReviewCount)
+	protected.GET("/review/items", s.perm(auth.PermLibraryView), reviewH.ListReviewItems)
+	protected.POST("/review/items/:id/approve", s.perm(auth.PermLibraryEditMetadata), reviewH.ApproveReviewItem)
+	protected.POST("/review/items/:id/reject", s.perm(auth.PermLibraryEditMetadata), reviewH.RejectReviewItem)
+	protected.POST("/review/bulk", s.perm(auth.PermLibraryEditMetadata), reviewH.BulkReviewAction)
+}


### PR DESCRIPTION
**PR-A1** of the review-queue + shattered-book-regroup plan (`docs/plans/2026-07-13-review-queue-and-regroup.md`).

Backend only — no user-facing behavior yet (banner/panel = PR-A2; first producer = regroup op, PR-B1).

## What
- New Pebble-backed `ReviewItem` store (`internal/database/review_store.go`), `review_item:*` keyspace + status secondary index (mirrors the dedup candidate-status index).
- **Idempotent upsert keyed by `DedupKey` (Kind+FolderRef):** re-running a producer scan never duplicates rows and never un-rejects a human-decided item — the count stays meaningful across re-scans.
- `ReviewStore` interface + `PebbleStore` impl + store-mock methods (hand-added to the mockery mock, no unscoped regen).
- HTTP API: `/review/count`, `/review/items`, `/review/items/:id/approve|reject`, `/review/bulk`. Reads → `library.view`; **mutations → `library.edit-metadata`** (matches dedup merge/dismiss). Bulk refuses a request with neither `kind` nor `ids` (no accidental approve-all).
- Apply-handler registry keyed by `Kind`: approve runs the registered producer handler then marks `applied`; with none registered (the A1 state) it marks `approved` without erroring. The regroup apply handler registers at PR-B2.

## Verification
- `go build ./...` clean; `go vet ./...` clean across the whole tree (confirms every `Store` implementer satisfies the new interface).
- `go test ./... -short`: 101/101 packages pass. New: `review_store_test.go` (9 tests), `review/handler_test.go` (11 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)