### PR TITLE
feat(review): universal review-queue frontend (banner + /review panel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@
 
 ### Features & Fixes
 
+#### July 13, 2026 - feat(review): universal review-queue frontend (PR-A2)
+
+Adds the React/TypeScript frontend for the universal review queue (backend =
+PR-A1), the single glanceable home for everything the system flags for a human
+decision. v1 producer is the regroup op (Track B), so the count starts at 0 and
+grows only with intentional holds.
+
+- **API client** (`web/src/services/api.ts`): `getReviewCount`, `getReviewItems`,
+  `approveReviewItem`, `rejectReviewItem`, `bulkReviewAction` over the protected
+  `/api/v1/review` endpoints via the existing `apiFetch`. Types mirror the exact
+  wire shapes (snake_case item fields, camelCase `byKind`, flat `RespondWithList`
+  list, `data.item` unwrap, bulk `processed`).
+- **Store** (`web/src/stores/useReviewStore.ts`): `count`/`byKind`/`items` with
+  `loadCount`/`loadItems`, plus a self-owned count poller
+  (`startPolling`/`stopPolling`, double-start guarded), mirroring
+  `useOperationsStore`'s SSE lifecycle. App.tsx starts it on auth-ready.
+- **Banner** (`web/src/components/ReviewBanner.tsx`): single aggregate "You have
+  N items to review" in `MainLayout` above every route; hidden at 0; click →
+  `/review`.
+- **Sidebar**: Review nav entry after Dedup with a live count `Badge` read from
+  the store in render.
+- **Page** (`web/src/pages/ReviewQueue.tsx`, lazy-routed `/review`): pending
+  items bucketed by kind (human labels in `web/src/lib/reviewKinds.ts`) with
+  Approve/Reject-all per bucket and per item, defensive payload rendering, and an
+  empty state. Refreshes count + items after any action.
+- Tests: `useReviewStore` (count refresh/error/items) + `ReviewBanner` (hidden at
+  0, shows N, singular form, click navigates). Additive UI only — rollback is a
+  revert.
+
 #### July 13, 2026 - feat(review): universal review-queue backend (store + API + apply registry)
 
 Adds the backend for a universal review queue — a single home for items the system

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 // file: web/src/App.tsx
-// version: 1.21.1
+// version: 1.22.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
+// last-edited: 2026-07-13
 
 import { useState, useEffect, useCallback, lazy, Suspense, useRef } from 'react';
 import { STORAGE_KEYS } from './lib/storageKeys';
@@ -22,6 +23,7 @@ import { eventSourceManager } from './services/eventSourceManager';
 import * as api from './services/api';
 import { useAuth } from './contexts/AuthContext';
 import { useOperationsStore } from './stores/useOperationsStore';
+import { useReviewStore } from './stores/useReviewStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 
 // Lazy-loaded pages (code-split for smaller initial bundle)
@@ -62,6 +64,9 @@ const PlaylistDetail = lazy(() => import('./pages/PlaylistDetail'));
 const Setup = lazy(() => import('./pages/Setup'));
 const Users = lazy(() => import('./pages/Users'));
 const TrashedVersions = lazy(() => import('./pages/TrashedVersions'));
+const ReviewQueue = lazy(() =>
+  import('./pages/ReviewQueue').then((m) => ({ default: m.ReviewQueue }))
+);
 
 function App() {
   const auth = useAuth();
@@ -126,6 +131,16 @@ function App() {
     store.openSSE();
     void store.loadFromServer();
     return () => store.closeSSE();
+  }, [auth.initialized, auth.isAuthenticated, auth.requiresAuth]);
+
+  // Poll the review-queue count once the user is authenticated so the banner +
+  // sidebar badge stay live. The interval lifecycle lives in the store (guarded
+  // against double-start), mirroring the ops SSE effect above.
+  useEffect(() => {
+    if (!auth.initialized || (auth.requiresAuth && !auth.isAuthenticated)) return;
+    const review = useReviewStore.getState();
+    review.startPolling();
+    return () => review.stopPolling();
   }, [auth.initialized, auth.isAuthenticated, auth.requiresAuth]);
 
   // Listen for server shutdown events and handle reconnection
@@ -247,6 +262,7 @@ function App() {
               <Route path="/setup" element={<ErrorBoundary><Setup /></ErrorBoundary>} />
               <Route path="/users" element={<ErrorBoundary><Users /></ErrorBoundary>} />
               <Route path="/versions" element={<ErrorBoundary><TrashedVersions /></ErrorBoundary>} />
+              <Route path="/review" element={<ErrorBoundary><ReviewQueue /></ErrorBoundary>} />
             </Routes>
           </Suspense>
         </MainLayout>

--- a/web/src/components/ReviewBanner.test.tsx
+++ b/web/src/components/ReviewBanner.test.tsx
@@ -1,0 +1,50 @@
+// file: web/src/components/ReviewBanner.test.tsx
+// version: 1.0.0
+// guid: 3a7e2c81-9d46-4b50-8f13-6c0a5d9e2b47
+// last-edited: 2026-07-13
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { ReviewBanner } from './ReviewBanner';
+import { useReviewStore } from '../stores/useReviewStore';
+
+// Spy on useNavigate so the click-navigates assertion is a direct call check
+// rather than route introspection.
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+describe('ReviewBanner', () => {
+  beforeEach(() => {
+    navigateSpy.mockReset();
+    useReviewStore.setState({ count: 0, byKind: {}, items: [], itemsLoading: false, _pollTimer: null });
+  });
+
+  it('renders nothing when the count is 0', () => {
+    useReviewStore.setState({ count: 0 });
+    const { container } = renderWithProviders(<ReviewBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the aggregate count when there are pending items', () => {
+    useReviewStore.setState({ count: 5 });
+    renderWithProviders(<ReviewBanner />);
+    expect(screen.getByText(/You have 5 items to review/)).toBeInTheDocument();
+  });
+
+  it('uses the singular form for a single item', () => {
+    useReviewStore.setState({ count: 1 });
+    renderWithProviders(<ReviewBanner />);
+    expect(screen.getByText(/You have 1 item to review/)).toBeInTheDocument();
+  });
+
+  it('navigates to /review when clicked', () => {
+    useReviewStore.setState({ count: 3 });
+    renderWithProviders(<ReviewBanner />);
+    fireEvent.click(screen.getByText(/You have 3 items to review/));
+    expect(navigateSpy).toHaveBeenCalledWith('/review');
+  });
+});

--- a/web/src/components/ReviewBanner.tsx
+++ b/web/src/components/ReviewBanner.tsx
@@ -1,0 +1,38 @@
+// file: web/src/components/ReviewBanner.tsx
+// version: 1.0.0
+// guid: 9b2e7d41-6c30-4a58-8f19-2d7a5e0c3b64
+// last-edited: 2026-07-13
+
+import { useNavigate } from 'react-router-dom';
+import { Alert, Box } from '@mui/material';
+import FactCheckIcon from '@mui/icons-material/FactCheck.js';
+import { useReviewStore } from '../stores/useReviewStore';
+
+/**
+ * ReviewBanner is the single, glanceable "You have N items to review" banner
+ * (decision #2 — one aggregate number, breakdown lives inside the /review page).
+ *
+ * Rendered in MainLayout above every route's content, so it shows everywhere
+ * (unlike the Dashboard-only AnnouncementBanner). Hidden when the count is 0;
+ * clicking navigates to /review. The count is polled by useReviewStore, which
+ * App.tsx starts on auth-ready.
+ */
+export function ReviewBanner() {
+  const navigate = useNavigate();
+  const count = useReviewStore((s) => s.count);
+
+  if (count <= 0) return null;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Alert
+        severity="info"
+        icon={<FactCheckIcon fontSize="inherit" />}
+        sx={{ cursor: 'pointer' }}
+        onClick={() => navigate('/review')}
+      >
+        You have {count} item{count === 1 ? '' : 's'} to review
+      </Alert>
+    </Box>
+  );
+}

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -1,12 +1,13 @@
 // file: web/src/components/layout/MainLayout.tsx
-// version: 1.3.0
+// version: 1.4.0
 // guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-04-30
+// last-edited: 2026-07-13
 
 import { useState, ReactNode } from 'react';
 import { Box } from '@mui/material';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
+import { ReviewBanner } from '../ReviewBanner';
 import { usePendingFileOps } from '../../hooks/usePendingFileOps';
 
 interface MainLayoutProps {
@@ -58,6 +59,7 @@ export function MainLayout({ children }: MainLayoutProps) {
             }),
         }}
       >
+        <ReviewBanner />
         {children}
         <Box aria-hidden="true" sx={{ height: 56 }} />
       </Box>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,11 +1,12 @@
 // file: web/src/components/layout/Sidebar.tsx
-// version: 1.14.0
+// version: 1.15.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
+  Badge,
   Box,
   Collapse,
   Drawer,
@@ -34,6 +35,8 @@ import CollectionsBookmarkIcon from '@mui/icons-material/CollectionsBookmark.js'
 import PeopleIcon from '@mui/icons-material/People.js';
 import TimelineIcon from '@mui/icons-material/Timeline.js';
 import WavesIcon from '@mui/icons-material/Waves.js';
+import FactCheckIcon from '@mui/icons-material/FactCheck.js';
+import { useReviewStore } from '../../stores/useReviewStore';
 
 const MOBILE_DRAWER_WIDTH = 240;
 
@@ -65,6 +68,7 @@ const menuItems = [
   { text: 'Playlists', icon: <MenuBookIcon />, path: '/playlists' },
   { text: 'Activity', icon: <TimelineIcon />, path: '/activity' },
   { text: 'Dedup', icon: <MergeTypeIcon />, path: '/dedup' },
+  { text: 'Review', icon: <FactCheckIcon />, path: '/review' },
   { text: 'Gold Labels', icon: <LibraryBooksIcon />, path: '/dedup/labels' },
   { text: 'Diagnostics', icon: <BugReportIcon />, path: '/diagnostics' },
   { text: 'System', icon: <MonitorIcon />, path: '/system' },
@@ -75,8 +79,24 @@ const menuItems = [
 export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggleCollapse }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  // Live pending-review count → a Badge on the Review nav icon. Read from the
+  // store in render (NOT baked into the static menuItems array, whose icons are
+  // built once at module load and would freeze the count at 0).
+  const reviewCount = useReviewStore((s) => s.count);
 
   const [libraryOpen, setLibraryOpen] = useState(true);
+
+  // Wrap a menu item's icon in a count Badge for the Review entry.
+  const renderMenuIcon = (item: (typeof menuItems)[number]) => {
+    if (item.path === '/review') {
+      return (
+        <Badge badgeContent={reviewCount || undefined} color="warning">
+          {item.icon}
+        </Badge>
+      );
+    }
+    return item.icon;
+  };
 
   const handleNavigation = (path: string) => {
     navigate(path);
@@ -163,7 +183,7 @@ export function Sidebar({ open, onClose, drawerWidth, collapsed = false, onToggl
                 sx={{ justifyContent: isCollapsed ? 'center' : 'flex-start' }}
               >
                 <ListItemIcon sx={{ minWidth: isCollapsed ? 0 : undefined }}>
-                  {item.icon}
+                  {renderMenuIcon(item)}
                 </ListItemIcon>
                 {!isCollapsed && <ListItemText primary={item.text} />}
               </ListItemButton>

--- a/web/src/lib/reviewKinds.ts
+++ b/web/src/lib/reviewKinds.ts
@@ -1,0 +1,27 @@
+// file: web/src/lib/reviewKinds.ts
+// version: 1.0.0
+// guid: 7f3a1c9e-2d84-4b16-9a5f-6c0e8d2b4a71
+// last-edited: 2026-07-13
+
+// Human-readable labels for review-queue item Kinds. Single source of truth so
+// the queue page, banners, and any future producer UI stay in sync. Kinds not
+// listed fall back to a title-cased version of the raw kind string.
+
+export const REVIEW_KIND_LABELS: Record<string, string> = {
+  'regroup.multidisc': 'Multi-disc groups',
+  'regroup.version-group': 'Abridged / Unabridged editions',
+  'regroup.anthology': 'Anthologies / collections',
+  'regroup.ambiguous': 'Ambiguous folders',
+};
+
+/** labelForKind returns the human label for a review Kind, falling back to a
+ *  readable title-cased rendering of the raw kind ("regroup.foo-bar" → "Foo Bar")
+ *  so an unknown producer never shows a blank bucket header. */
+export function labelForKind(kind: string): string {
+  const known = REVIEW_KIND_LABELS[kind];
+  if (known) return known;
+  const tail = kind.includes('.') ? kind.slice(kind.indexOf('.') + 1) : kind;
+  return tail
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/web/src/pages/ReviewQueue.tsx
+++ b/web/src/pages/ReviewQueue.tsx
@@ -1,0 +1,325 @@
+// file: web/src/pages/ReviewQueue.tsx
+// version: 1.0.0
+// guid: 4c8f2a17-5e93-4d60-a1b8-7f3c6d9e0a52
+// last-edited: 2026-07-13
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  List,
+  ListItem,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
+import CheckIcon from '@mui/icons-material/Check.js';
+import CloseIcon from '@mui/icons-material/Close.js';
+import * as api from '../services/api';
+import { type ReviewItem } from '../services/api';
+import { useReviewStore } from '../stores/useReviewStore';
+import { useAppStore } from '../stores/useAppStore';
+import { labelForKind } from '../lib/reviewKinds';
+
+// A defensively-typed view of a review item's JSON payload. The producer op
+// (Track B) is not built yet, so NOTHING writes this shape in the current repo
+// state — every field is optional and parsing is wrapped in try/catch. Render
+// only what is present; never assume a key exists.
+interface ReviewPayload {
+  folder?: string;
+  proposed_action?: string;
+  action?: string;
+  derived_title?: string;
+  title?: string;
+  member_ids?: string[];
+  member_count?: number;
+  confidence?: number;
+  files?: string[];
+  [k: string]: unknown;
+}
+
+function parsePayload(raw: string): ReviewPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as ReviewPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function memberCount(payload: ReviewPayload | null): number | undefined {
+  if (!payload) return undefined;
+  if (typeof payload.member_count === 'number') return payload.member_count;
+  if (Array.isArray(payload.member_ids)) return payload.member_ids.length;
+  if (Array.isArray(payload.files)) return payload.files.length;
+  return undefined;
+}
+
+function PayloadDetails({ item }: { item: ReviewItem }) {
+  const payload = parsePayload(item.payload);
+  const folder = payload?.folder ?? item.folder_ref;
+  const proposed = payload?.proposed_action ?? payload?.action;
+  const title = payload?.derived_title ?? payload?.title;
+  const members = memberCount(payload);
+  const confidence = typeof payload?.confidence === 'number' ? payload.confidence : undefined;
+  const files = Array.isArray(payload?.files) ? payload!.files! : undefined;
+
+  return (
+    <Box sx={{ pl: 1 }}>
+      <Stack spacing={0.5} sx={{ mb: files ? 1 : 0 }}>
+        {folder && (
+          <Typography variant="body2">
+            <strong>Folder:</strong> <code>{folder}</code>
+          </Typography>
+        )}
+        {title && (
+          <Typography variant="body2">
+            <strong>Derived title:</strong> {title}
+          </Typography>
+        )}
+        {proposed && (
+          <Typography variant="body2">
+            <strong>Proposed action:</strong> {proposed}
+          </Typography>
+        )}
+        {members !== undefined && (
+          <Typography variant="body2">
+            <strong>Members:</strong> {members} file{members === 1 ? '' : 's'}
+          </Typography>
+        )}
+        {confidence !== undefined && (
+          <Typography variant="body2">
+            <strong>Confidence:</strong> {confidence.toFixed(2)}
+          </Typography>
+        )}
+      </Stack>
+      {files && files.length > 0 && (
+        <Box>
+          <Typography variant="caption" color="text.secondary">
+            Files
+          </Typography>
+          <List dense disablePadding sx={{ pl: 1 }}>
+            {files.slice(0, 25).map((f, i) => (
+              <ListItem key={i} disableGutters sx={{ py: 0 }}>
+                <Typography variant="caption" sx={{ wordBreak: 'break-all' }}>
+                  {f}
+                </Typography>
+              </ListItem>
+            ))}
+            {files.length > 25 && (
+              <ListItem disableGutters sx={{ py: 0 }}>
+                <Typography variant="caption" color="text.secondary">
+                  …and {files.length - 25} more
+                </Typography>
+              </ListItem>
+            )}
+          </List>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function ReviewQueue() {
+  const items = useReviewStore((s) => s.items);
+  const itemsLoading = useReviewStore((s) => s.itemsLoading);
+  const loadItems = useReviewStore((s) => s.loadItems);
+  const loadCount = useReviewStore((s) => s.loadCount);
+  const addNotification = useAppStore((s) => s.addNotification);
+
+  // Track in-flight action ids/kinds so buttons disable while their request runs.
+  const [busyItems, setBusyItems] = useState<Set<string>>(new Set());
+  const [busyKinds, setBusyKinds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    void loadItems({ status: 'pending' });
+  }, [loadItems]);
+
+  // Refresh both the queue and the badge count after any action.
+  const refresh = async () => {
+    await Promise.all([loadItems({ status: 'pending' }), loadCount()]);
+  };
+
+  // Bucket pending items by Kind, preserving a stable label + count per bucket.
+  const buckets = useMemo(() => {
+    const map = new Map<string, ReviewItem[]>();
+    for (const item of items) {
+      const list = map.get(item.kind) ?? [];
+      list.push(item);
+      map.set(item.kind, list);
+    }
+    return Array.from(map.entries())
+      .map(([kind, kindItems]) => ({ kind, label: labelForKind(kind), items: kindItems }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [items]);
+
+  const handleItemAction = async (item: ReviewItem, action: 'approve' | 'reject') => {
+    setBusyItems((prev) => new Set(prev).add(item.id));
+    try {
+      if (action === 'approve') {
+        await api.approveReviewItem(item.id);
+      } else {
+        await api.rejectReviewItem(item.id);
+      }
+      await refresh();
+    } catch (err) {
+      addNotification(
+        `Failed to ${action} item: ${err instanceof Error ? err.message : 'unknown error'}`,
+        'error'
+      );
+    } finally {
+      setBusyItems((prev) => {
+        const next = new Set(prev);
+        next.delete(item.id);
+        return next;
+      });
+    }
+  };
+
+  const handleBulkAction = async (kind: string, action: 'approve' | 'reject') => {
+    setBusyKinds((prev) => new Set(prev).add(kind));
+    try {
+      const result = await api.bulkReviewAction({ action, kind });
+      addNotification(
+        `${action === 'approve' ? 'Approved' : 'Rejected'} ${result.processed} item${
+          result.processed === 1 ? '' : 's'
+        }`,
+        'success'
+      );
+      await refresh();
+    } catch (err) {
+      addNotification(
+        `Bulk ${action} failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+        'error'
+      );
+    } finally {
+      setBusyKinds((prev) => {
+        const next = new Set(prev);
+        next.delete(kind);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Review Queue
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Items the system has flagged for a human decision, grouped by type. Approve or reject a
+        whole group, or expand a group to act on individual items.
+      </Typography>
+
+      {itemsLoading && items.length === 0 ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : buckets.length === 0 ? (
+        <Paper sx={{ p: 6, textAlign: 'center' }}>
+          <Typography variant="h6" gutterBottom>
+            Nothing to review 🎉
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            When the system flags something for a decision, it will show up here.
+          </Typography>
+        </Paper>
+      ) : (
+        <Stack spacing={2}>
+          {buckets.map((bucket) => {
+            const kindBusy = busyKinds.has(bucket.kind);
+            return (
+              <Paper key={bucket.kind} sx={{ p: 2 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    mb: 1,
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="h6">{bucket.label}</Typography>
+                    <Chip size="small" label={bucket.items.length} />
+                  </Box>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      size="small"
+                      variant="contained"
+                      color="success"
+                      startIcon={<CheckIcon />}
+                      disabled={kindBusy}
+                      onClick={() => handleBulkAction(bucket.kind, 'approve')}
+                    >
+                      Approve all
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="error"
+                      startIcon={<CloseIcon />}
+                      disabled={kindBusy}
+                      onClick={() => handleBulkAction(bucket.kind, 'reject')}
+                    >
+                      Reject all
+                    </Button>
+                  </Stack>
+                </Box>
+                <Divider sx={{ mb: 1 }} />
+                {bucket.items.map((item) => {
+                  const itemBusy = busyItems.has(item.id);
+                  return (
+                    <Accordion key={item.id} disableGutters>
+                      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                        <Typography variant="body2" sx={{ flexGrow: 1 }}>
+                          {item.summary || item.folder_ref || item.id}
+                        </Typography>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <PayloadDetails item={item} />
+                        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="success"
+                            startIcon={<CheckIcon />}
+                            disabled={itemBusy}
+                            onClick={() => handleItemAction(item, 'approve')}
+                          >
+                            Approve
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            startIcon={<CloseIcon />}
+                            disabled={itemBusy}
+                            onClick={() => handleItemAction(item, 'reject')}
+                          >
+                            Reject
+                          </Button>
+                        </Stack>
+                      </AccordionDetails>
+                    </Accordion>
+                  );
+                })}
+              </Paper>
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+export default ReviewQueue;

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.52.0
+// version: 2.53.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-07-11
+// last-edited: 2026-07-13
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -5796,6 +5796,136 @@ export async function pullAIBackendModel(model: string): Promise<{ model: string
   });
   if (!response.ok) {
     throw await buildApiError(response, `Failed to pull model ${model}`);
+  }
+  const body = await response.json();
+  return body.data;
+}
+
+// =====================================================================
+// Universal Review Queue (PR-A2 frontend for the PR-A1 backend).
+//
+// Field-name note: the backend serialises ReviewItem with snake_case struct
+// tags (dedup_key, folder_ref, created_at, updated_at) but the count endpoint's
+// byKind map is a camelCase gin.H literal key — so this contract is genuinely
+// mixed-case. Types below mirror the wire shapes exactly; do not normalise.
+// =====================================================================
+
+/** A single review-queue hold. `payload` is a JSON STRING (opaque here — the
+ *  producer op decides its shape); callers JSON.parse it defensively. */
+export interface ReviewItem {
+  id: string;
+  kind: string;
+  dedup_key: string;
+  folder_ref: string;
+  status: string;
+  summary: string;
+  payload: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** GET /review/count → data.{count, byKind}. Both cover PENDING items only. */
+export interface ReviewCount {
+  count: number;
+  byKind: Record<string, number>;
+}
+
+/** GET /review/items → flat {items, count, limit, offset, total} (RespondWithList,
+ *  no `data` wrapper). */
+export interface ReviewItemsPage {
+  items: ReviewItem[];
+  count: number;
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface ReviewItemsFilter {
+  status?: string;
+  kind?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/** POST /review/bulk → data.{action, processed, ...id buckets}. Note: the
+ *  backend reports `processed`, NOT an `affected` count. */
+export interface ReviewBulkResult {
+  action: string;
+  approved?: string[];
+  applied?: string[];
+  rejected?: string[];
+  not_found?: string[];
+  processed: number;
+}
+
+export interface ReviewBulkRequest {
+  action: 'approve' | 'reject';
+  /** At least one of kind / ids must be set — the backend refuses an unscoped
+   *  bulk over the entire queue. */
+  kind?: string;
+  ids?: string[];
+}
+
+export async function getReviewCount(): Promise<ReviewCount> {
+  const response = await apiFetch(`${API_BASE}/review/count`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to fetch review count');
+  }
+  const body = await response.json();
+  const data = body.data ?? {};
+  return { count: data.count ?? 0, byKind: data.byKind ?? {} };
+}
+
+export async function getReviewItems(filter: ReviewItemsFilter = {}): Promise<ReviewItemsPage> {
+  const params = new URLSearchParams();
+  params.set('status', filter.status ?? 'pending');
+  if (filter.kind) params.set('kind', filter.kind);
+  if (filter.limit !== undefined) params.set('limit', String(filter.limit));
+  if (filter.offset !== undefined) params.set('offset', String(filter.offset));
+  const response = await apiFetch(`${API_BASE}/review/items?${params.toString()}`);
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to fetch review items');
+  }
+  const body = await response.json();
+  return {
+    items: body.items ?? [],
+    count: body.count ?? 0,
+    limit: body.limit ?? 0,
+    offset: body.offset ?? 0,
+    total: body.total ?? 0,
+  };
+}
+
+export async function approveReviewItem(id: string): Promise<ReviewItem> {
+  const response = await apiFetch(`${API_BASE}/review/items/${encodeURIComponent(id)}/approve`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to approve review item');
+  }
+  const body = await response.json();
+  return body.data?.item;
+}
+
+export async function rejectReviewItem(id: string): Promise<ReviewItem> {
+  const response = await apiFetch(`${API_BASE}/review/items/${encodeURIComponent(id)}/reject`, {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to reject review item');
+  }
+  const body = await response.json();
+  return body.data?.item;
+}
+
+export async function bulkReviewAction(req: ReviewBulkRequest): Promise<ReviewBulkResult> {
+  const response = await apiFetch(`${API_BASE}/review/bulk`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    throw await buildApiError(response, 'Failed to run bulk review action');
   }
   const body = await response.json();
   return body.data;

--- a/web/src/stores/useReviewStore.test.ts
+++ b/web/src/stores/useReviewStore.test.ts
@@ -1,0 +1,79 @@
+// file: web/src/stores/useReviewStore.test.ts
+// version: 1.0.0
+// guid: 8d1f6b93-4a27-4c50-9e83-2b7c5d0a6f14
+// last-edited: 2026-07-13
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useReviewStore } from './useReviewStore';
+import * as api from '../services/api';
+
+vi.mock('../services/api');
+
+describe('useReviewStore', () => {
+  beforeEach(() => {
+    useReviewStore.setState({
+      count: 0,
+      byKind: {},
+      items: [],
+      itemsLoading: false,
+      _pollTimer: null,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('loadCount refreshes count + byKind from the count endpoint', async () => {
+    vi.mocked(api.getReviewCount).mockResolvedValue({
+      count: 7,
+      byKind: { 'regroup.multidisc': 5, 'regroup.ambiguous': 2 },
+    });
+
+    await useReviewStore.getState().loadCount();
+
+    expect(api.getReviewCount).toHaveBeenCalledTimes(1);
+    expect(useReviewStore.getState().count).toBe(7);
+    expect(useReviewStore.getState().byKind).toEqual({
+      'regroup.multidisc': 5,
+      'regroup.ambiguous': 2,
+    });
+  });
+
+  it('loadCount keeps the last value on error (non-critical)', async () => {
+    useReviewStore.setState({ count: 3 });
+    vi.mocked(api.getReviewCount).mockRejectedValue(new Error('boom'));
+
+    await useReviewStore.getState().loadCount();
+
+    // Failure must not zero the badge — it stays at the last known value.
+    expect(useReviewStore.getState().count).toBe(3);
+  });
+
+  it('loadItems populates items and toggles the loading flag', async () => {
+    vi.mocked(api.getReviewItems).mockResolvedValue({
+      items: [
+        {
+          id: 'r1',
+          kind: 'regroup.multidisc',
+          dedup_key: 'k1',
+          folder_ref: '/a/b',
+          status: 'pending',
+          summary: 'Disc 1/2',
+          payload: '{}',
+          created_at: '2026-07-13T00:00:00Z',
+          updated_at: '2026-07-13T00:00:00Z',
+        },
+      ],
+      count: 1,
+      limit: 500,
+      offset: 0,
+      total: 1,
+    });
+
+    await useReviewStore.getState().loadItems({ status: 'pending' });
+
+    expect(api.getReviewItems).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending' })
+    );
+    expect(useReviewStore.getState().items).toHaveLength(1);
+    expect(useReviewStore.getState().itemsLoading).toBe(false);
+  });
+});

--- a/web/src/stores/useReviewStore.ts
+++ b/web/src/stores/useReviewStore.ts
@@ -1,0 +1,87 @@
+// file: web/src/stores/useReviewStore.ts
+// version: 1.0.0
+// guid: 1e9d4c72-8a36-4f50-b1c7-3d2e6a9b7c81
+// last-edited: 2026-07-13
+
+import { create } from 'zustand';
+import * as api from '../services/api';
+import { type ReviewItem, type ReviewItemsFilter } from '../services/api';
+
+// Default poll cadence for the review count. The review queue is low-volume
+// (intentional holds only, never raw backlogs — decision #1), so a slow poll is
+// plenty; SSE is an optional fast-follow.
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+interface ReviewState {
+  /** Number of PENDING items — drives the banner + sidebar badge. */
+  count: number;
+  /** Pending count broken down by Kind (regroup.multidisc → 12, ...). */
+  byKind: Record<string, number>;
+  /** Items loaded for the /review page. */
+  items: ReviewItem[];
+  /** True while loadItems is in flight (for the page's loading state). */
+  itemsLoading: boolean;
+  /** setInterval handle for the count poller — kept here so it can be cleared
+   *  on stopPolling, mirroring useOperationsStore's _sseSource. */
+  _pollTimer: ReturnType<typeof setInterval> | null;
+
+  /** loadCount fetches the pending count + byKind breakdown (REST). */
+  loadCount: () => Promise<void>;
+  /** loadItems fetches items for the given filter (default: pending). */
+  loadItems: (filter?: ReviewItemsFilter) => Promise<void>;
+  /** startPolling begins the count poller. Calling it again while a poller is
+   *  already running is a no-op (guards against double-start across auth
+   *  transitions), mirroring useOperationsStore.openSSE's guard. */
+  startPolling: (intervalMs?: number) => void;
+  /** stopPolling tears down the count poller. */
+  stopPolling: () => void;
+}
+
+export const useReviewStore = create<ReviewState>()((set, get) => ({
+  count: 0,
+  byKind: {},
+  items: [],
+  itemsLoading: false,
+  _pollTimer: null,
+
+  loadCount: async () => {
+    try {
+      const { count, byKind } = await api.getReviewCount();
+      set({ count, byKind });
+    } catch (err) {
+      // Non-critical — the badge/banner just stays at its last value.
+      console.error('Failed to load review count', err);
+    }
+  },
+
+  loadItems: async (filter: ReviewItemsFilter = {}) => {
+    set({ itemsLoading: true });
+    try {
+      const page = await api.getReviewItems({ status: 'pending', limit: 500, ...filter });
+      set({ items: page.items });
+    } catch (err) {
+      console.error('Failed to load review items', err);
+      set({ items: [] });
+    } finally {
+      set({ itemsLoading: false });
+    }
+  },
+
+  startPolling: (intervalMs = DEFAULT_POLL_INTERVAL_MS) => {
+    // Guard: don't spin up a second interval if one is already running.
+    if (get()._pollTimer !== null) return;
+    // Fire once immediately so the badge reflects reality without waiting a
+    // full interval.
+    void get().loadCount();
+    const timer = setInterval(() => void get().loadCount(), intervalMs);
+    set({ _pollTimer: timer });
+  },
+
+  stopPolling: () => {
+    const timer = get()._pollTimer;
+    if (timer !== null) {
+      clearInterval(timer);
+      set({ _pollTimer: null });
+    }
+  },
+}));


### PR DESCRIPTION
**PR-A2** of the review-queue + shattered-book-regroup plan. Builds on PR-A1 (#1947, merged).

The user-facing half of the universal review queue: one glanceable "You have N items to review" banner + a `/review` panel that groups holds by kind with bulk actions.

## What
- **API client** (`web/src/services/api.ts`): the 5 `/review` calls via existing `apiFetch`; types match the real wire shapes (snake_case item fields, `byKind`, flat list, `data.item` unwrap, bulk `processed`).
- **Store** (`useReviewStore.ts`): `count`/`byKind`/`items` + a self-owned count poller (30s), mirroring `useOperationsStore`; started on auth-ready in `App.tsx`.
- **Banner** (`ReviewBanner.tsx`): single aggregate count in `MainLayout` above every route; hidden at 0; click → `/review`.
- **Sidebar**: Review entry after Dedup with a live count `Badge`.
- **Page** (`ReviewQueue.tsx`, lazy `/review`): pending items bucketed by kind with **Approve/Reject-all per bucket** and per item, defensive payload rendering, empty state.

## Verification
- `npx tsc --noEmit`: 0 errors. `npm run lint`: 0 errors (pre-existing warnings only).
- Vitest: 7 new tests; full suite 375/375 pass.

Additive UI only — rollback is a revert. No producer writes holds yet (that's PR-B1), so the queue renders empty until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)