### PR TITLE
feat(maintenance): shattered-book regroup dry-run op (first review-queue producer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.154.0 -->
+<!-- version: 3.155.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-13 -->
 
@@ -8,6 +8,41 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 13, 2026 - feat(maintenance): shattered-book regroup dry-run op (first review-queue producer, PR-B1)
+
+Adds `maintenance.regroup-shattered-ai`, the FIRST producer into the universal
+review queue (PR-A1). It re-derives real audiobooks from the thousands of single-file
+"books" the broken iTunes import left behind (one track = one book), using the library
+**folder** as the identity signal (tags are unreliable). **Dry-run only:** it writes
+ZERO book/file changes — the only writes are review-queue holds via `UpsertReviewItem`.
+The apply path (CombineBooks / version-group writes) is a later PR.
+
+- New pure, no-I/O regex classifier `ClassifyShatteredFolders`
+  (`internal/itunes/service/fs_regroup_shape.go`). It groups single-file books by their
+  **book folder** — the file's grandparent when its parent is a chapter (`<prefix> - N`),
+  disc (`Disc N`), or edition (`... (Unabridged)`) sub-dir, else the parent (flat
+  multi-track) — and classifies each folder into one of four load-bearing Kind strings
+  the A1 frontend maps: `regroup.multidisc` (confident collapse: flat numbered tracks,
+  disc sets, or chapter shells matching the folder name), `regroup.version-group`
+  (Abridged + Unabridged editions), `regroup.anthology` (anthology/trilogy/omnibus
+  markers), and `regroup.ambiguous` (book-like but mixed/weak identity). Folders that are
+  clearly collections of distinct books (author dirs, correctly-stored series volumes,
+  flat dumps) are skipped so the queue is not flooded; genuine single-file books are left
+  alone. Table-tested (no DB).
+- The op (`internal/plugins/maintenance/regroup_shattered_ai.go`, registered in
+  `plugin.go`) enumerates the full library with the memdb-cap-safe `ListBookIDs` +
+  `registry.RunItems` bounded worker pool (`Concurrency: runtime.NumCPU()`) — never a
+  serial full-library `for range` (cites the 2026-07-05 3-hr single-core incident).
+  Grouping and the idempotent review-row writes run single-threaded after the read-only
+  scan (no write races). Emits a `RECONCILE:` line accounting for every book.
+- Each detected group becomes one `pending` hold keyed by a stable
+  `DedupKey = hash(Kind + FolderRef)`, so re-running the dry-run never duplicates a row
+  or resurfaces a human-decided (rejected/applied) one. Payload carries the folder, file
+  list, proposed action, member book IDs, derived survivor title, and confidence.
+- Tests: pure detector table tests + a dry-run op test over a temp Pebble store asserting
+  ZERO book/file mutation, correct hold count, upsert idempotency, and decision
+  preservation (`-race`).
 
 #### July 13, 2026 - feat(review): universal review-queue frontend (PR-A2)
 

--- a/docs/plans/2026-07-13-review-queue-and-regroup.md
+++ b/docs/plans/2026-07-13-review-queue-and-regroup.md
@@ -1,0 +1,232 @@
+<!-- file: docs/plans/2026-07-13-review-queue-and-regroup.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d9f2a6c-7e14-4b8a-9c2d-5f1e6a3b7c40 -->
+<!-- last-edited: 2026-07-13 -->
+
+# PLAN — Universal Review Queue + Shattered-Book Regroup Op
+
+**Status:** Awaiting approval. NO feature code written until the user signs off.
+**Author decisions captured:** 2026-07-13 (see "Locked decisions" — all via AskUserQuestion).
+
+---
+
+## Goal
+
+Two independently-shippable tracks, sequenced so the review queue ships already
+populated with real data from the regroup op:
+
+- **Track A — Universal Review Queue.** A single, glanceable home for everything the
+  system has flagged for a human decision. A global banner ("You have N items to
+  review") + a left-nav `/review` panel. v1 producer = the regroup op only, so the
+  count is meaningful from day one (starts at 0, grows only with intentional holds).
+- **Track B — Regroup Shattered Books.** A new maintenance op
+  `maintenance.regroup-shattered-ai` that groups the thousands of single-file "books"
+  (one track = one book, from the broken iTunes import) back into real multi-file
+  audiobooks, using the **folder path as the identity signal**. v1 is **regex-only**
+  (no GPU dependency); ambiguous folders are *held for review* rather than
+  AI-classified. AI enrichment is a fast-follow once the GPU box serves Ollama.
+
+The regroup op is the first *producer* into the review queue — it does not invent its
+own private "held" list.
+
+---
+
+## Locked decisions (from the user, 2026-07-13)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Review count semantics | **Regroup holds only, v1.** Count starts at 0; dedup/metadata opt in later. Never raw backlogs. |
+| 2 | Banner style | **Single aggregate** — "You have N items to review" (breakdown lives inside the panel). |
+| 3 | Approve action | **Apply immediately** (individual) + **grouped bulk actions**. |
+| 4 | Hold volume handling | **Grouped bulk actions** — bucket holds by shape; approve/reject a whole class or filtered subset in one click. |
+| 5 | Rollout | **Whole-library dry-run first.** Run #1 writes **zero** book/file changes; auto-apply-confident is a *separate later toggle*, off in run #1. |
+| 6 | AI tier | **Regex-only v1**; ambiguous → held (no AI). AI enrichment = fast-follow when Ollama is serving. |
+| 7 | Cover recovery (folder.jpg→cover) | **Separate later phase/PR.** Not in the grouping op. |
+| 8 | Abridged + Unabridged in one folder | **2-book version group**, both visible (primary = Unabridged). Via `UpdateBook`, NOT `MergeBooks`. |
+| 9 | Anthology / trilogy | **N separate books** (one per distinct work). In v1 (regex), these are *held for review* — regex can't reliably split them; AI does that later. |
+
+---
+
+## Infra reality (verified this session — informs Track B)
+
+- **Whisper** runs on the GPU box (172.16.3.22) via `WHISPER_REMOTE_URL=http://172.16.3.22:19847` — healthy, resident ~6 GB on the 8 GB RTX 2070 SUPER.
+- **Ollama** is installed on the box (v0.31.1) but **not running / fails to start headless**
+  (`Unable to init instance … timed out`), and prod sets **no** `ai_backend.local_base_url`
+  (falls back to the checked-in placeholder `192.168.0.20:11434`, which is dead from the server).
+- ⇒ The LLM→GPU path is **non-functional today**. This is *why* v1 is regex-only and the AI
+  tier is deferred. No code in v1 depends on the box. When the AI tier lands, it will
+  `ProbeOllamaAvailable` and **degrade gracefully to regex-only** if the endpoint is down.
+
+---
+
+## Track A — Universal Review Queue
+
+### A1. Backend: generic review-item store (greenfield)
+
+New store (mirror the dedup `Status`/secondary-index pattern; do **not** overload the dedup store).
+
+`ReviewItem` (Pebble-backed, new keyspace `review_item:*`):
+```
+ID          string     // ULID
+Kind        string     // "regroup.multidisc" | "regroup.anthology" | "regroup.version-group" | "regroup.ambiguous"
+DedupKey    string     // STABLE: sha/normalized (Kind + folder-ref) — upsert target
+FolderRef   string     // grandparent folder path this hold is about
+Status      string     // "pending" | "approved" | "rejected" | "applied"  (stringly-typed, matches house style)
+Summary     string     // one-line human label
+Payload     string     // JSON: folder path, file listing, proposed action, member book IDs, confidence, derived title, (AI reasoning later)
+CreatedAt   time.Time
+UpdatedAt   time.Time
+```
+- **Idempotency (advisor-flagged):** producers UPSERT keyed by `DedupKey = (Kind, FolderRef)`.
+  Re-running the dry-run must not pile up duplicates. Status is preserved on upsert (a
+  re-scan does not un-reject a rejected item).
+- **Dismiss persistence:** `rejected` is remembered (keyed by folder) so re-scans don't resurface it.
+- Secondary index `review_item:status:<status>:<id>` for fast pending-count + list-by-status
+  (mirror `dedupStatusIdxKey` / `WriteCandidateStatusIndexRow` at `internal/database/embedding_store.go:449,731`).
+- Count = number of `pending` items (index scan / maintained counter).
+
+Files: `internal/database/review_store.go` (new), `internal/database/iface_review.go` (new
+interface), wire into PebbleStore + the store mock (`mock_store.go`).
+
+### A2. Backend: HTTP API
+
+Register on the protected group (`s.perm(auth.PermLibraryView)`), house envelopes from `internal/httputil`:
+- `GET /api/v1/review/count` → `RespondWithOK(gin.H{"count": N, "byKind": {...}})`.
+- `GET /api/v1/review/items?status=pending&kind=&limit=&offset=` → `RespondWithList(items, count, limit, offset)`.
+- `POST /api/v1/review/items/:id/approve` → applies immediately (calls the regroup apply-one path), sets `applied`.
+- `POST /api/v1/review/items/:id/reject` → sets `rejected`.
+- `POST /api/v1/review/bulk` → `{action: approve|reject, filter: {kind, ids?}}` → grouped bulk action (decision #4).
+
+Files: `internal/server/handlers/review/handler.go` (new), `internal/server/wire_review_routes.go` (new),
+registered in the router setup alongside `wire_dedup_routes.go`.
+
+### A3. Frontend
+
+- **Global banner** (single aggregate, decision #2): new `ReviewBanner.tsx` rendered in
+  `MainLayout.tsx` above `{children}` (so it shows on every route, unlike the Dashboard-only
+  AnnouncementBanner). Hidden when count == 0. Clicking → `/review`.
+- **Live count**: new `useReviewStore` (zustand), mirroring `useOperationsStore` — initial REST
+  fetch + refresh. v1 = poll `/review/count` on mount + interval (SSE event optional fast-follow).
+- **Left-nav entry**: add `{ text: 'Review', icon, path: '/review' }` to `Sidebar.tsx` (after Dedup),
+  with a `<Badge>` count copied from `OperationsIndicator`.
+- **`/review` page** (`web/src/pages/ReviewQueue.tsx`, lazy-imported + routed in `App.tsx`):
+  holds grouped by `Kind` (decision #4) with per-group counts, filters, and
+  approve/reject on individual items **and** whole buckets/filtered subsets.
+
+### A4. Track A test strategy
+- Go: store round-trip + upsert-idempotency (same DedupKey twice → 1 row, status preserved);
+  status-index count correctness; handler tests for count/list/approve/reject/bulk with the store mock.
+- Frontend: Vitest for the store (count refresh) + banner visibility (0 → hidden, N → shown) + bulk action wiring.
+
+---
+
+## Track B — Regroup Shattered Books (`maintenance.regroup-shattered-ai`)
+
+### B0. Op registration
+Add `p.regroupShatteredAIDef()` to the `defs` slice in
+`internal/plugins/maintenance/plugin.go` (~line 95); it's registered by the existing
+`r.RegisterOp(d)` loop. Copy the shape of `fs_regroup_xml.go`:
+`sdk.OperationDef{ID:"maintenance.regroup-shattered-ai", Capabilities:[CapLibraryRead(,CapLibraryWrite when apply)], ResumePolicy:ResumeDrop, ConcurrencyKey:..., Timeout:120m, Run:p.runRegroup}`.
+Params struct `regroupParams{ Apply bool json:"apply" }` — **default false = dry-run** (safe).
+(Note: run #1 = dry-run regardless; apply is a later toggle per decision #5.)
+
+### B1. Detection (read-only) — the regex/deterministic tier
+- Enumerate the full library with `ListBookIDs()` → `registry.RunItems(Concurrency: NumCPU())`
+  → `GetBookByID` + `GetBookFiles` per item (the memdb-cap-safe pattern). CPU-bound fan-out.
+- Group single-file books by **grandparent folder** (the identity signal). Reuse/extend the pure
+  `GroupShatteredBooks` model in `internal/itunes/service/fs_regroup.go` — but broaden the shape
+  detector beyond the current `^(.*) - (\d+)$` (which heals 0/44,327) to recognize:
+  - **A. flat multi-track** (many audio files, one folder) → 1 book, N files — **confident**.
+  - **B. multi-disc** (`Disc N/` subfolders) → 1 book, N files — **confident**.
+  - **C. version-group** (Abridged + Unabridged markers) → **hold** (`regroup.version-group`).
+  - **D. anthology / trilogy** (multiple distinct-title markers) → **hold** (`regroup.anthology`).
+  - **F. genuine single file** → leave alone (no action).
+  - anything unclassifiable → **hold** (`regroup.ambiguous`).
+- Title derivation for the survivor: strip `NN - ` prefix and `(era/year)` suffix; author from
+  tags/metadata, never the path.
+
+### B2. Dry-run output (run #1 — writes ZERO book/file changes)
+**Read-only w.r.t. books/files; DOES write review-queue rows — that is the point.**
+- Confident A/B groups → written to the review queue too in run #1 (as `pending`), *not*
+  auto-applied. (Auto-apply-confident is a separate toggle, off in run #1 — resolves the
+  decision-5-vs-"auto-apply-confident" tension the advisor flagged.)
+- C/D/ambiguous → `pending` holds with full payload (folder, listing, proposed action, member IDs, confidence).
+- A `RECONCILE:` log line accounting for every book (mirror fs_regroup_xml.go), + reporter progress.
+- Net effect of run #1: the review queue fills with real, deduped holds; the library is untouched.
+
+### B3. Apply path (later toggle / driven by review approvals — decision #3 "apply immediately")
+Approving an item in the panel (or enabling the confident-auto-apply toggle) executes the write
+**for that group**, taking the shared lock and using the safe primitives:
+- **Collapse N single-file books → 1 multi-file** (shapes A/B): `merge.CombineBooks(memberIDs, survivorID, override)`.
+  Materializes virtual `Book.FilePath` into real BookFiles, moves files via `MoveBookFilesToBook`,
+  **hard-deletes** absorbed shells (files stay on disk → rescan-recoverable — this is what makes
+  it safe enough to auto-apply), then `RecomputeBookAggregates(survivorID)`.
+- **Version group** (shape C, decision #8): set `VersionGroupID` + `IsPrimaryVersion` (Unabridged=primary)
+  on **both** books via `UpdateBook`. **Do NOT** call `MergeBooks` (it soft-deletes the loser). Reuse
+  the group-ID-reuse logic from `merge/service.go:144-154`.
+- **Anthology** (shape D): split into N books — v1 holds these for review; the actual split write
+  lands with the AI tier (which identifies sub-work boundaries). Until then, approving an anthology
+  hold is a no-op-with-note or deferred.
+- **Concurrency/ordering:** partition apply by `FolderRef`/survivor so two workers never heal the
+  same group; take `mergeSerializeMu` (shared with `dedup.MergeBooks`) on every merge-family write.
+
+### B4. Data-loss safety rules (from the store audit — carry verbatim into the apply path)
+1. **Source every book/file to be written from FULL getters** — `GetBookByID` / `GetBooksByIDs` /
+   `GetBookFiles`. **Never** write back from `GetAllBooks`(memdb) or `GetAllBookFilesCore` (they
+   strip Author/Series/Description/BookSig* and AcoustIDFingerprint/segments respectively).
+2. Move files with `MoveBookFilesToBook`, not reconstructed BookFile writes (the BookFile PK
+   embeds bookID; re-keying is what that function does).
+3. `UpdateBook` has the nil-preserve guard for the 9 stripped fields; still re-fetch survivor via
+   `GetBookByID` before applying overrides (as CombineBooks does at service.go:357).
+4. `RecomputeBookAggregates(survivorID)` after any file move to fix Duration/FileSize sums.
+5. **Cover orphaning:** covers are keyed by `covers/{bookID}.*`. When a shell is deleted/absorbed,
+   its cover orphans. v1 does not touch covers (decision #7); the cover-recovery phase will handle
+   copy-to-survivor.
+
+### B5. Track B test strategy
+- Pure grouping: table tests over the broadened shape detector (flat / multi-disc / version-group /
+  anthology / single) — no DB.
+- Dry-run: asserts ZERO book/file mutations, N review rows created, upsert idempotent on re-run.
+- Apply (`-race`): CombineBooks collapse invariants (survivor file count, shells gone, aggregates
+  recomputed, fingerprints intact); version-group both-visible + primary correct; partition/lock
+  race test (two workers, disjoint folders, no double-heal). Extend the existing data-loss
+  invariant suite (#1941) rather than a parallel one.
+
+---
+
+## PR sequence (each independently green + mergeable)
+
+1. **PR-A1** Review-queue backend (store + interface + mock + API + wire routes) — additive, no behavior change.
+2. **PR-A2** Review-queue frontend (banner + store + sidebar + /review page + grouped bulk actions).
+3. **PR-B1** Regroup op: registration + broadened shape detector (pure, unit-tested) + **dry-run only**,
+   producing review-queue holds. No apply path. (This is what populates the queue with real data.)
+4. **PR-B2** Regroup apply path (CombineBooks collapse + version-group) wired to review-approve +
+   the confident-auto-apply toggle (default off). `-race` invariant tests.
+5. **Fast-follow (separate PRs, not in this plan's critical path):**
+   - AI enrichment tier (`OpenAIParser.ClassifyFolderShape`, batched, small model, `ProbeOllamaAvailable`
+     graceful-degrade) — **blocked on Ollama serving on the box.**
+   - Cover recovery (folder.jpg/cover.jpg → `covers/{bookID}`, priority rules) — own PR.
+   - Dedup REVIEW-band as a second review-queue producer (opt-in).
+
+---
+
+## Test / verification strategy (overall)
+- `make ci` gate per PR; `-race` on all apply/merge tests.
+- Dry-run verified against prod (read-only) before any apply toggle is enabled.
+- Follow the STOREFID lesson: after any store-getter touch, run the **full** `go test ./... -short`,
+  not a subset (old-func mocks vacuous-pass elsewhere).
+
+## Rollback
+- Track A: additive (new store keyspace, new routes, new UI). Rollback = revert PRs; no data migration.
+  Review rows are advisory; deleting the keyspace loses only the queue, not library data.
+- Track B dry-run: read-only on books; rollback = revert + delete `review_item:*` rows.
+- Track B apply: CombineBooks hard-deletes shells but **leaves files on disk** → a rescan re-imports
+  them (the pre-regroup shattered state is reconstructable). Version-group writes are reversible by
+  clearing `VersionGroupID`. No apply runs until dry-run numbers are reviewed and the toggle is
+  explicitly enabled.
+
+## Out of scope / explicitly deferred
+- AI classification tier (needs Ollama serving — infra gap above).
+- Cover-art recovery (own phase).
+- Dedup/metadata as review-queue producers (opt-in later; keeps the v1 count meaningful).
+- INIT-7, INIT-8 (parked).

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -1,0 +1,485 @@
+// file: internal/itunes/service/fs_regroup_shape.go
+// version: 1.0.0
+// guid: 1e7d4a92-3c85-4b60-9f21-6a8c0d5e2b47
+// last-edited: 2026-07-13
+
+// Package service — deterministic (regex-only) shape classifier for the
+// shattered-book REGROUP review producer (PR-B1).
+//
+// The broken iTunes import created one standalone single-file "book" per track
+// (~44K records), each living under a per-book folder. This classifier re-derives
+// candidate real audiobooks WITHOUT the iTunes XML, fingerprinting, or any AI: it
+// groups single-file books by their **book folder** and classifies each folder's
+// shape from the folder/track NAMES alone. The library folder is the only reliable
+// identity signal here — the per-track tags are unreliable (see the plan
+// docs/plans/2026-07-13-review-queue-and-regroup.md, decision #6: regex-only v1).
+//
+// This is a companion to GroupShatteredBooks (fs_regroup.go). That function is a
+// high-precision auto-heal planner (prefix ⊆ parent, ASIN/author consensus) that
+// only ever emits confident collapses; this one is BROADER — it recognizes disc
+// sets, version groups (Abridged + Unabridged), anthologies, and ambiguous folders,
+// and emits every candidate as a review HOLD (never an auto-apply). All four Kind
+// strings are load-bearing: the A1 review-queue frontend maps them verbatim.
+//
+// Grouping key (deviation from a literal "grandparent folder"): a literal
+// always-grandparent key over-merges flat multi-track (`<Book>/01.mp3` → grandparent
+// is `<Author>`, collapsing the whole author). Instead we group by the BOOK FOLDER:
+// the file's grandparent when its parent dir is a chapter (`<prefix> - N`) or disc
+// (`Disc N`) subdir, else the file's parent dir. This is the correct generalization
+// of "the book folder" and matches docs/dedup-import-pipeline-audit.md's
+// (grandparent_dir, normalized-album) recommendation.
+//
+// Pure function over DB-derived metadata: no I/O, fully unit-testable.
+
+package itunesservice
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Regroup Kind strings — LOAD-BEARING. The A1 review-queue frontend maps these
+// verbatim; do not rename without updating the frontend map.
+const (
+	KindMultidisc    = "regroup.multidisc"     // confident collapse: N single-file books = 1 audiobook
+	KindVersionGroup = "regroup.version-group" // Abridged + Unabridged editions in one folder
+	KindAnthology    = "regroup.anthology"     // multiple distinct works (anthology/trilogy/omnibus)
+	KindAmbiguous    = "regroup.ambiguous"     // book-like folder, cannot confidently classify
+)
+
+// ShatterBook is the slim per-book view the classifier reasons over. Build it from
+// a Book plus its BookFiles: FileCount comes from the BookFile rows, FilePath is the
+// real BookFile path when the book owns exactly one file, else the virtual
+// Book.FilePath.
+type ShatterBook struct {
+	BookID    string
+	FilePath  string // real BookFile path (preferred) or virtual Book.FilePath
+	FileCount int    // BookFiles owned; > 1 means already a real multi-file book
+	IsPrimary bool   // non-primary version members are ignored
+	Title     string // scanner-derived title (album tag); may be empty
+	Author    string // display author when known; never used for the FOLDER key
+}
+
+// RegroupGroup is one book folder the classifier flagged for a review hold.
+type RegroupGroup struct {
+	FolderRef      string        // the book folder (grandparent for chapter/disc; parent for flat)
+	Kind           string        // one of the Kind* constants
+	Confident      bool          // true only for confident multidisc collapses
+	SurvivorTitle  string        // derived: strip "NN - " prefix and "(era/year)" / " - N" suffix
+	ProposedAction string        // human-readable proposed action
+	Members        []ShatterBook // ordered by chapter/track number then BookID
+}
+
+// ShapeStats reconciles every input book so the record count ties out (no silent
+// filtering), mirroring fs_regroup.go's GroupStats.
+type ShapeStats struct {
+	TotalBooks   int            // all books seen
+	NonPrimary   int            // skipped: non-primary version member
+	MultiFile    int            // skipped: already a real multi-file book
+	NoPath       int            // skipped: no usable file path
+	Singletons   int            // book folders with a single member (genuine single file)
+	DistinctSkip int            // book folders skipped as distinct-book collections (no hold)
+	Groups       int            // emitted review groups (== len(returned groups))
+	ByKind       map[string]int // emitted-group count per Kind
+}
+
+// ─── shape regexes ───────────────────────────────────────────────────────────
+
+// discDirRe matches a disc subfolder basename: "Disc 1", "CD03", "disc_2".
+var discDirRe = regexp.MustCompile(`(?i)^(?:disc|cd)\s*_?\s*0*(\d+)$`)
+
+// chapterSubdirRe matches a chapter subfolder basename "<prefix> - N" (the shatter
+// shape): a title, a dash separator, then a number. Requiring the dash separates it
+// from disc dirs and bare numbers. "Cage of Souls - 15" → ("Cage of Souls", 15).
+var chapterSubdirRe = regexp.MustCompile(`^(.+?)\s*-\s*(\d{1,4})$`)
+
+// editionMarkerRe detects an Abridged/Unabridged edition marker anywhere in a name.
+var editionMarkerRe = regexp.MustCompile(`(?i)\b(?:un)?abridged\b`)
+
+// leadNumRe / trailNumRe extract a track ordinal from a bare filename. A leading
+// number ("01 - Chapter One" → 1) is preferred; else a trailing number ("Chapter 3"
+// → 3, "05" → 5).
+var (
+	leadNumRe  = regexp.MustCompile(`^\s*(\d{1,4})\b`)
+	trailNumRe = regexp.MustCompile(`(\d{1,4})\s*$`)
+)
+
+// flatMultitrackMin is the minimum member count for a FLAT numbered folder to be a
+// CONFIDENT multi-disc collapse. Below it, a numbered flat folder is only ambiguous
+// (2-3 loose numbered files could be distinct works stored under a shared dir).
+const flatMultitrackMin = 4
+
+// unabridgedRe / abridgedRe detect edition markers. Order matters: "unabridged"
+// contains "abridged", so hasAbridged is only asserted after stripping every
+// "unabridged" occurrence from the text.
+var (
+	unabridgedRe = regexp.MustCompile(`(?i)unabridged`)
+	abridgedRe   = regexp.MustCompile(`(?i)abridged`)
+)
+
+// anthologyRe detects STRONG markers that a folder holds "multiple distinct works"
+// — which regex cannot reliably split, so these are held for review. Deliberately
+// excludes weak terms like "collection"/"complete" that appear on legitimate single
+// audiobooks ("The Complete Collection", unabridged) to avoid mislabeling them.
+var anthologyRe = regexp.MustCompile(`(?i)\b(antholog(?:y|ies)|omnibus|trilog(?:y|ies)|tetralog(?:y|ies)|quartet|boxed?\s*set)\b`)
+
+// leadingNumRe / trailingParenRe / trailingNumSuffixRe clean a derived survivor title.
+var (
+	leadingNumRe        = regexp.MustCompile(`^\s*\d+\s*[-.]\s*`)
+	trailingParenRe     = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
+	trailingNumSuffixRe = regexp.MustCompile(`\s*[-]\s*\d+\s*$`)
+)
+
+// normTitle lowercases and strips non-alphanumerics for substring/identity checks.
+// (Shares the fs_regroup.go definition — declared there, reused here.)
+
+// memberInfo is the per-member derived layout used during classification.
+type memberInfo struct {
+	book       ShatterBook
+	structure  string // "disc" | "chapter" | "flat"
+	parentBase string // basename of the file's immediate parent dir
+	fileBase   string // filename without extension
+	prefix     string // original-case title prefix (chapter prefix, or track prefix)
+	normPrefix string // normalized prefix for consensus voting
+	num        int    // chapter/track/disc number (0 when none)
+	hasNum     bool
+}
+
+// folderKeyOf computes the BOOK FOLDER key and per-member layout for one file path.
+// The key is the file's grandparent when its parent dir is a sub-container of the
+// book folder (a chapter `<prefix> - N` dir, a `Disc N` dir, or an edition
+// `... (Unabridged)` dir), and the parent dir itself otherwise (flat multi-track).
+// See the package doc for why this generalizes "the book folder".
+func folderKeyOf(fp string) (key string, mi memberInfo) {
+	parent := filepath.Dir(fp)
+	pbase := filepath.Base(parent)
+	fileBase := strings.TrimSuffix(filepath.Base(fp), filepath.Ext(filepath.Base(fp)))
+	mi.parentBase = pbase
+	mi.fileBase = fileBase
+
+	switch {
+	case discDirRe.MatchString(pbase):
+		m := discDirRe.FindStringSubmatch(pbase)
+		mi.structure = "disc"
+		mi.num, _ = strconv.Atoi(m[1])
+		mi.hasNum = true
+		return filepath.Dir(parent), mi
+
+	case chapterSubdirRe.MatchString(pbase):
+		// Parent dir is a "<prefix> - N" chapter dir (the shatter shape). Group by the
+		// grandparent (the book folder that holds all the chapter dirs); the prefix is
+		// the per-member identity vote.
+		m := chapterSubdirRe.FindStringSubmatch(pbase)
+		mi.structure = "chapter"
+		mi.prefix = strings.TrimSpace(m[1])
+		mi.normPrefix = normTitle(mi.prefix)
+		mi.num, _ = strconv.Atoi(m[2])
+		mi.hasNum = true
+		return filepath.Dir(parent), mi
+
+	case editionMarkerRe.MatchString(pbase):
+		// Parent dir is an edition sub-folder ("<Book> (Unabridged)"). Group by the
+		// grandparent book folder; identity vote = the edition name minus its markers.
+		mi.structure = "edition"
+		mi.prefix = stripEditionMarkers(pbase)
+		mi.normPrefix = normTitle(mi.prefix)
+		mi.num, mi.hasNum = trackNum(fileBase)
+		return filepath.Dir(parent), mi
+
+	default:
+		// Flat multi-track: the file sits directly in the book folder. Numbering comes
+		// from the filename; the identity vote is the filename's title remainder (weak).
+		mi.structure = "flat"
+		mi.num, mi.hasNum = trackNum(fileBase)
+		mi.prefix = titleRemainder(fileBase)
+		mi.normPrefix = normTitle(mi.prefix)
+		return parent, mi
+	}
+}
+
+// trackNum extracts a track ordinal from a bare filename: a leading number is
+// preferred ("01 - Chapter One" → 1), else a trailing number ("Chapter 3" → 3).
+func trackNum(fileBase string) (int, bool) {
+	if m := leadNumRe.FindStringSubmatch(fileBase); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return n, true
+	}
+	if m := trailNumRe.FindStringSubmatch(fileBase); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return n, true
+	}
+	return 0, false
+}
+
+// titleRemainder strips a leading "NN[ -._]" ordinal and a trailing number from a
+// filename, leaving the title-ish remainder used as a weak flat-folder identity vote.
+func titleRemainder(fileBase string) string {
+	t := leadNumRe.ReplaceAllString(fileBase, "")
+	t = strings.TrimLeft(t, " -_.")
+	t = trailNumRe.ReplaceAllString(t, "")
+	return strings.TrimRight(strings.TrimSpace(t), " -_.")
+}
+
+// stripEditionMarkers removes Abridged/Unabridged markers and any parenthetical
+// groups from an edition folder name, leaving the book title ("Dune (Unabridged)" →
+// "Dune").
+func stripEditionMarkers(name string) string {
+	t := editionMarkerRe.ReplaceAllString(name, " ")
+	for {
+		stripped := trailingParenRe.ReplaceAllString(t, "")
+		if stripped == t {
+			break
+		}
+		t = stripped
+	}
+	// Drop any now-empty "()" left behind and collapse whitespace.
+	t = strings.ReplaceAll(t, "()", " ")
+	return strings.TrimSpace(strings.Join(strings.Fields(t), " "))
+}
+
+// ClassifyShatteredFolders groups single-file books by their book folder and
+// classifies each folder's shape. It emits ONE RegroupGroup per candidate folder
+// that plausibly represents a single book needing review; folders that are clearly
+// collections of DISTINCT books (author dirs, correctly-stored series volumes, flat
+// dumps) are skipped (DistinctSkip) so the review queue is not flooded, and genuine
+// single-file books (group size 1) are left alone (Singletons).
+//
+// It performs NO writes and NO I/O — the caller (the dry-run op) turns each group
+// into a review-queue hold.
+func ClassifyShatteredFolders(books []ShatterBook) ([]RegroupGroup, ShapeStats) {
+	st := ShapeStats{TotalBooks: len(books), ByKind: map[string]int{}}
+
+	byKey := make(map[string][]memberInfo)
+	for _, b := range books {
+		if !b.IsPrimary {
+			st.NonPrimary++
+			continue
+		}
+		if b.FileCount > 1 {
+			st.MultiFile++
+			continue
+		}
+		if strings.TrimSpace(b.FilePath) == "" {
+			st.NoPath++
+			continue
+		}
+		key, mi := folderKeyOf(b.FilePath)
+		mi.book = b
+		byKey[key] = append(byKey[key], mi)
+	}
+
+	groups := make([]RegroupGroup, 0, len(byKey))
+	for key, members := range byKey {
+		if len(members) < 2 {
+			st.Singletons++ // genuine single-file book — leave alone
+			continue
+		}
+		g, emit := classifyGroup(key, members)
+		if !emit {
+			st.DistinctSkip++
+			continue
+		}
+		st.ByKind[g.Kind]++
+		groups = append(groups, g)
+	}
+	st.Groups = len(groups)
+
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].Kind != groups[j].Kind {
+			return groups[i].Kind < groups[j].Kind
+		}
+		return groups[i].FolderRef < groups[j].FolderRef
+	})
+	return groups, st
+}
+
+// versionMarkers reports whether text carries both an Unabridged and an Abridged
+// marker (case-insensitive). Because "unabridged" contains "abridged", the abridged
+// check runs against text with every "unabridged" occurrence removed.
+func versionMarkers(text string) (hasUnabridged, hasAbridged bool) {
+	hasUnabridged = unabridgedRe.MatchString(text)
+	stripped := unabridgedRe.ReplaceAllString(text, " ")
+	hasAbridged = abridgedRe.MatchString(stripped)
+	return hasUnabridged, hasAbridged
+}
+
+// classifyGroup assigns a shape Kind to one book-folder group. emit=false means the
+// folder is not a single-book candidate (a collection of distinct books) and gets no
+// review hold. Thresholds are documented inline; the classifier biases conservative
+// (ambiguous, not confident) whenever the evidence is weak — every group is a
+// human-reviewed hold, so the human is the backstop.
+func classifyGroup(key string, members []memberInfo) (RegroupGroup, bool) {
+	n := len(members)
+	folderName := filepath.Base(key)
+	normFolder := normTitle(folderName)
+
+	// Marker text = the folder name + every member's parent-dir basename, filename,
+	// and title. Editions/anthology markers can live on any of them.
+	var sb strings.Builder
+	sb.WriteString(folderName)
+	for _, m := range members {
+		sb.WriteByte(' ')
+		sb.WriteString(m.parentBase)
+		sb.WriteByte(' ')
+		sb.WriteString(m.fileBase)
+		sb.WriteByte(' ')
+		sb.WriteString(m.book.Title)
+	}
+	text := sb.String()
+	hasUnab, hasAb := versionMarkers(text)
+	hasAnthology := anthologyRe.MatchString(text)
+
+	// Structural tallies.
+	var discCount, chapterCount, flatCount, numberedCount int
+	prefixVotes := map[string]int{}
+	for _, m := range members {
+		switch m.structure {
+		case "disc":
+			discCount++
+		case "chapter":
+			chapterCount++
+		default:
+			flatCount++
+		}
+		if m.hasNum {
+			numberedCount++
+		}
+		if m.normPrefix != "" {
+			prefixVotes[m.normPrefix]++
+		}
+	}
+	dominantPrefix, dominantCount := topStr(prefixVotes)
+	distinctPrefixes := len(prefixVotes)
+	structure := majorityStructure(discCount, chapterCount, flatCount)
+
+	// folderNamedAfterBook: the members' dominant title prefix is a majority AND is a
+	// substring of the book-folder name. This is the high-precision "these chapters
+	// belong to THIS book" guard (mirrors fs_regroup.go's prefix ⊆ parent). It is
+	// FALSE for correctly-stored series volumes (`Author/Series - N/file`: grandparent
+	// = author, not named after the series), which keeps them out of the queue.
+	folderNamedAfterBook := dominantPrefix != "" &&
+		strings.Contains(normFolder, dominantPrefix) &&
+		dominantCount*2 >= n
+
+	sortMembers(members)
+	build := func(kind string, confident bool, action string) RegroupGroup {
+		out := make([]ShatterBook, 0, n)
+		for _, m := range members {
+			out = append(out, m.book)
+		}
+		return RegroupGroup{
+			FolderRef:      key,
+			Kind:           kind,
+			Confident:      confident,
+			SurvivorTitle:  deriveSurvivorTitle(folderName),
+			ProposedAction: action,
+			Members:        out,
+		}
+	}
+
+	switch {
+	case hasUnab && hasAb && dominantCount*2 >= n:
+		// Abridged + Unabridged editions of the SAME book share a folder → 2-book
+		// version group (decision #8). The dominant-prefix guard (a majority of members
+		// share one book title after markers are stripped) prevents a false positive on
+		// an AUTHOR folder that merely happens to hold one abridged + one unabridged of
+		// two DIFFERENT books. Held for review; the human confirms the primary edition.
+		return build(KindVersionGroup, false,
+			"create a version group (Abridged + Unabridged), Unabridged primary"), true
+
+	case hasAnthology:
+		// Anthology/trilogy/omnibus → multiple distinct works; regex cannot split
+		// them (decision #9), so hold for review.
+		return build(KindAnthology, false,
+			"split into separate works (held — needs review to identify boundaries)"), true
+
+	case structure == "disc" && discCount*2 > n:
+		// Majority of members live in Disc N / CD N subfolders → one multi-disc book.
+		return build(KindMultidisc, true,
+			"collapse disc set into 1 multi-file audiobook"), true
+
+	case structure == "flat" && numberedCount*2 >= n && n >= flatMultitrackMin:
+		// Many members sit directly in ONE book folder and are sequentially numbered →
+		// flat multi-track collapse. The shared parent folder IS the book identity.
+		return build(KindMultidisc, true,
+			"collapse flat multi-track folder into 1 multi-file audiobook"), true
+
+	case (structure == "chapter" || structure == "edition") && folderNamedAfterBook && distinctPrefixes <= 1:
+		// Classic shatter (`<Book>/<Book> - N/file`) or a single edition folder
+		// (`<Book>/<Book> (Unabridged)/file`), one consistent identity matching the
+		// book folder → confident collapse.
+		return build(KindMultidisc, true,
+			"collapse chapter/edition shells into 1 multi-file audiobook"), true
+
+	case (structure == "chapter" || structure == "edition") && folderNamedAfterBook && distinctPrefixes >= 2:
+		// Book folder, but the sub-dirs carry ≥2 distinct title prefixes — mixed
+		// identity. Confident collapse is unsafe; hold for review.
+		return build(KindAmbiguous, false,
+			"review: folder with mixed identities"), true
+
+	case structure == "flat" && dominantPrefix != "" && dominantCount*2 >= n:
+		// Flat folder whose members share a dominant title but are NOT cleanly
+		// numbered (or too few to be confident) — book-like but uncertain. Hold.
+		return build(KindAmbiguous, false,
+			"review: flat folder shares a title but ordering is unclear"), true
+
+	default:
+		// No positive single-book evidence: an author folder, correctly-stored series
+		// volumes, or a flat dump of distinct files. Emit no hold (avoids flooding).
+		return RegroupGroup{}, false
+	}
+}
+
+// majorityStructure returns the dominant structure among the three tallies. Ties
+// break disc > chapter > flat (disc/chapter carry stronger single-book signal).
+func majorityStructure(disc, chapter, flat int) string {
+	if disc >= chapter && disc >= flat && disc > 0 {
+		return "disc"
+	}
+	if chapter >= flat && chapter > 0 {
+		return "chapter"
+	}
+	return "flat"
+}
+
+// topStr returns the most-voted key and its count.
+func topStr(votes map[string]int) (string, int) {
+	bestKey, best := "", 0
+	for k, v := range votes {
+		if v > best {
+			bestKey, best = k, v
+		}
+	}
+	return bestKey, best
+}
+
+// sortMembers orders members by chapter/track number, then BookID for stability.
+func sortMembers(members []memberInfo) {
+	sort.SliceStable(members, func(i, j int) bool {
+		if members[i].num != members[j].num {
+			return members[i].num < members[j].num
+		}
+		return members[i].book.BookID < members[j].book.BookID
+	})
+}
+
+// deriveSurvivorTitle turns a book-folder name into a clean survivor title: strip a
+// leading "NN - " track prefix, a trailing "(era/year)" parenthetical, and a trailing
+// " - N" number. Author is intentionally NOT derived from the path.
+func deriveSurvivorTitle(folderName string) string {
+	t := folderName
+	t = leadingNumRe.ReplaceAllString(t, "")
+	// Strip trailing parentheticals repeatedly, e.g. "Book (Unabridged) (2019)".
+	for {
+		stripped := trailingParenRe.ReplaceAllString(t, "")
+		if stripped == t {
+			break
+		}
+		t = stripped
+	}
+	t = trailingNumSuffixRe.ReplaceAllString(t, "")
+	return strings.TrimSpace(t)
+}

--- a/internal/itunes/service/fs_regroup_shape_test.go
+++ b/internal/itunes/service/fs_regroup_shape_test.go
@@ -1,0 +1,227 @@
+// file: internal/itunes/service/fs_regroup_shape_test.go
+// version: 1.0.0
+// guid: 4d2a7f81-6c93-4e50-b8a1-0f5e2c9d3b76
+// last-edited: 2026-07-13
+
+package itunesservice
+
+import (
+	"fmt"
+	"testing"
+)
+
+const shatterRoot = "/mnt/bigdata/books/audiobook-organizer"
+
+// sb builds a primary single-file ShatterBook at a path.
+func sb(id, path string) ShatterBook {
+	return ShatterBook{BookID: id, FilePath: path, FileCount: 1, IsPrimary: true}
+}
+
+// findGroup returns the group whose FolderRef ends with the given suffix.
+func findGroup(t *testing.T, groups []RegroupGroup, folderSuffix string) RegroupGroup {
+	t.Helper()
+	for _, g := range groups {
+		if len(g.FolderRef) >= len(folderSuffix) && g.FolderRef[len(g.FolderRef)-len(folderSuffix):] == folderSuffix {
+			return g
+		}
+	}
+	t.Fatalf("no group with folder ending %q in %+v", folderSuffix, groups)
+	return RegroupGroup{}
+}
+
+// Classic chapter shatter: `<Book>/<Book> - N/file` → confident multidisc collapse.
+func TestClassify_ChapterShatter_Multidisc(t *testing.T) {
+	base := shatterRoot + "/Adrian Tchaikovsky/Cage of Souls"
+	var books []ShatterBook
+	for i := 1; i <= 12; i++ {
+		books = append(books, sb(fmt.Sprintf("c%02d", i),
+			fmt.Sprintf("%s/Cage of Souls - %d/01.mp3", base, i)))
+	}
+	groups, st := ClassifyShatteredFolders(books)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 group, got %d (stats %+v)", len(groups), st)
+	}
+	g := groups[0]
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Errorf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	if g.FolderRef != base {
+		t.Errorf("FolderRef=%q, want %q", g.FolderRef, base)
+	}
+	if len(g.Members) != 12 {
+		t.Errorf("members=%d, want 12", len(g.Members))
+	}
+	if g.SurvivorTitle != "Cage of Souls" {
+		t.Errorf("survivorTitle=%q, want 'Cage of Souls'", g.SurvivorTitle)
+	}
+	// Members ordered by chapter number.
+	for i, m := range g.Members {
+		want := fmt.Sprintf("c%02d", i+1)
+		if m.BookID != want {
+			t.Errorf("member %d = %q, want %q (ordering)", i, m.BookID, want)
+		}
+	}
+}
+
+// Flat multi-track: many numbered tracks directly in one book folder → confident multidisc.
+func TestClassify_FlatMultitrack_Multidisc(t *testing.T) {
+	base := shatterRoot + "/Neil Gaiman/Coraline"
+	var books []ShatterBook
+	for i := 1; i <= 8; i++ {
+		books = append(books, sb(fmt.Sprintf("f%02d", i),
+			fmt.Sprintf("%s/%02d - Chapter.mp3", base, i)))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Coraline")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Errorf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	if len(g.Members) != 8 {
+		t.Errorf("members=%d, want 8", len(g.Members))
+	}
+}
+
+// Disc subfolders: `<Book>/Disc N/file` → confident multidisc.
+func TestClassify_DiscSubfolders_Multidisc(t *testing.T) {
+	base := shatterRoot + "/Patrick Rothfuss/The Name of the Wind"
+	books := []ShatterBook{
+		sb("d1", base+"/Disc 1/track.mp3"),
+		sb("d2", base+"/Disc 2/track.mp3"),
+		sb("d3", base+"/Disc 3/track.mp3"),
+		sb("d4", base+"/CD 4/track.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Name of the Wind")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Errorf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+}
+
+// Abridged + Unabridged editions in one folder → version-group hold (not confident).
+func TestClassify_VersionGroup(t *testing.T) {
+	base := shatterRoot + "/Frank Herbert/Dune"
+	books := []ShatterBook{
+		sb("v1", base+"/Dune (Unabridged)/01.mp3"),
+		sb("v2", base+"/Dune (Abridged)/01.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Dune")
+	if g.Kind != KindVersionGroup {
+		t.Fatalf("kind=%q, want version-group", g.Kind)
+	}
+	if g.Confident {
+		t.Errorf("version-group must not be confident (needs human primary pick)")
+	}
+}
+
+// Anthology/omnibus marker → anthology hold.
+func TestClassify_Anthology(t *testing.T) {
+	base := shatterRoot + "/Isaac Asimov/Foundation Trilogy"
+	books := []ShatterBook{
+		sb("a1", base+"/Foundation Trilogy - 1/01.mp3"),
+		sb("a2", base+"/Foundation Trilogy - 2/01.mp3"),
+		sb("a3", base+"/Foundation Trilogy - 3/01.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Foundation Trilogy")
+	if g.Kind != KindAnthology {
+		t.Fatalf("kind=%q, want anthology", g.Kind)
+	}
+	if g.Confident {
+		t.Errorf("anthology must not be confident")
+	}
+}
+
+// A genuine single-file book (group of 1) gets NO hold.
+func TestClassify_GenuineSingle_NoHold(t *testing.T) {
+	books := []ShatterBook{sb("s1", shatterRoot+"/Andy Weir/The Martian/The Martian.m4b")}
+	groups, st := ClassifyShatteredFolders(books)
+	if len(groups) != 0 {
+		t.Fatalf("want 0 groups for a lone single file, got %d", len(groups))
+	}
+	if st.Singletons != 1 {
+		t.Errorf("Singletons=%d, want 1 (stats %+v)", st.Singletons, st)
+	}
+}
+
+// Correctly-stored series volumes under the author dir must NOT be held: grandparent
+// is the author, not named after the series (mirrors fs_regroup's prefix ⊆ parent).
+func TestClassify_SeriesVolumes_Skipped(t *testing.T) {
+	author := shatterRoot + "/Brandon Sanderson"
+	books := []ShatterBook{
+		sb("m1", author+"/Mistborn - 1/book.m4b"),
+		sb("m2", author+"/Mistborn - 2/book.m4b"),
+		sb("m3", author+"/Mistborn - 3/book.m4b"),
+	}
+	groups, st := ClassifyShatteredFolders(books)
+	if len(groups) != 0 {
+		t.Fatalf("series volumes must not be held, got %d groups: %+v", len(groups), groups)
+	}
+	if st.DistinctSkip != 1 {
+		t.Errorf("DistinctSkip=%d, want 1 (stats %+v)", st.DistinctSkip, st)
+	}
+}
+
+// A flat dump of DISTINCT books under one non-book folder must NOT be held.
+func TestClassify_FlatDumpDistinctBooks_Skipped(t *testing.T) {
+	dump := shatterRoot + "/abooks"
+	books := []ShatterBook{
+		sb("x1", dump+"/The Hobbit.m4b"),
+		sb("x2", dump+"/Neuromancer.m4b"),
+		sb("x3", dump+"/Snow Crash.m4b"),
+	}
+	groups, st := ClassifyShatteredFolders(books)
+	if len(groups) != 0 {
+		t.Fatalf("flat dump of distinct books must not be held, got %d: %+v", len(groups), groups)
+	}
+	if st.DistinctSkip != 1 {
+		t.Errorf("DistinctSkip=%d, want 1 (stats %+v)", st.DistinctSkip, st)
+	}
+}
+
+// A book folder whose chapter dirs carry two distinct titles → ambiguous hold.
+func TestClassify_MixedIdentityChapters_Ambiguous(t *testing.T) {
+	base := shatterRoot + "/Various/Split Decision"
+	books := []ShatterBook{
+		sb("i1", base+"/Split Decision - 1/01.mp3"),
+		sb("i2", base+"/Split Decision - 2/01.mp3"),
+		sb("i3", base+"/Split Decision - 3/01.mp3"),
+		sb("i4", base+"/Other Work - 1/01.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Split Decision")
+	if g.Kind != KindAmbiguous {
+		t.Errorf("kind=%q, want ambiguous", g.Kind)
+	}
+	if g.Confident {
+		t.Errorf("ambiguous must not be confident")
+	}
+}
+
+// deriveSurvivorTitle strips a leading "NN - " track prefix, trailing parentheticals,
+// and a trailing " - N" number.
+func TestDeriveSurvivorTitle(t *testing.T) {
+	cases := map[string]string{
+		"Cage of Souls":            "Cage of Souls",
+		"01 - The Fellowship":      "The Fellowship",
+		"Dune (Unabridged)":        "Dune",
+		"Dune (Unabridged) (2019)": "Dune",
+		"The Name of the Wind - 2": "The Name of the Wind",
+	}
+	for in, want := range cases {
+		if got := deriveSurvivorTitle(in); got != want {
+			t.Errorf("deriveSurvivorTitle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// versionMarkers must not false-positive "abridged" inside "unabridged".
+func TestVersionMarkers_UnabridgedOnly(t *testing.T) {
+	if _, hasAb := versionMarkers("The Book (Unabridged)"); hasAb {
+		t.Errorf("unabridged-only text wrongly flagged abridged")
+	}
+	hasUn, hasAb := versionMarkers("Dune Unabridged / Dune Abridged")
+	if !hasUn || !hasAb {
+		t.Errorf("want both markers, got unabridged=%v abridged=%v", hasUn, hasAb)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.9.2
+// version: 1.10.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-07-03
+// last-edited: 2026-07-13
 
 package maintenance
 
@@ -93,6 +93,9 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 		// --- filesystem shattered-book heal (tag-anchored) ---
 		p.fsRegroupXMLDef(),
+
+		// --- shattered-book regroup (dry-run, review-queue producer; PR-B1) ---
+		p.regroupShatteredAIDef(),
 
 		// --- lossless tag backfill for existing rows ---
 		p.tagBackfillDef(),

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -1,0 +1,270 @@
+// file: internal/plugins/maintenance/regroup_shattered_ai.go
+// version: 1.0.0
+// guid: 8b3e6d21-4f97-4c05-a1d8-2e7b9c0f5a63
+// last-edited: 2026-07-13
+
+// Package maintenance — op maintenance.regroup-shattered-ai (PR-B1).
+//
+// The FIRST producer into the universal review queue (PR-A1). It enumerates the
+// whole library, groups the thousands of single-file "books" left by the broken
+// iTunes import (one track = one book) by their book folder, classifies each
+// folder's shape with a deterministic regex tier (NO AI — that's a deferred
+// fast-follow), and writes ONE review-queue HOLD per candidate folder.
+//
+// This is DRY-RUN ONLY (locked decision #5): run #1 writes ZERO book/file changes.
+// Even confident multi-disc collapses are written as `pending` holds, never
+// auto-applied — the apply path (CombineBooks/version-group writes) is PR-B2. The
+// only writes this op makes are review-queue rows via UpsertReviewItem, which is
+// idempotent on its stable DedupKey so re-running never duplicates a hold or
+// resurfaces a human-decided one.
+//
+// REAL-WORLD YIELD IS UNVERIFIED. The prior tag-anchored heal (fs_regroup_xml.go)
+// healed 0 of the ~44,327 shattered records that remain, which means those records
+// likely do NOT have the classic `<prefix> - N` chapter shape this classifier's
+// chapter branch (and the old regex) recognizes. The broadened branches (flat
+// multi-track, disc sets, edition folders) target the other shapes and group on the
+// REAL BookFile path rather than the virtual Book.FilePath, but they have only been
+// validated against synthetic fixtures. The op is itself the intended acceptance
+// gate: a read-only whole-library dry-run on prod is required to confirm the queue
+// fills with real holds and the classification kinds are sane before any apply
+// toggle is enabled (see docs/plans/2026-07-13-review-queue-and-regroup.md).
+
+package maintenance
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// regroupParams configures the dry-run regroup scan. There is no apply flag in B1 —
+// this op is always a dry-run review-queue producer (decision #5).
+type regroupParams struct {
+	// Limit caps how many detected groups get a review hold this run (0 = no cap).
+	// Useful for a first canary run before writing the full queue.
+	Limit int `json:"limit"`
+}
+
+// regroupPayload is the JSON stored on each review-queue hold. The A1 frontend
+// renders it; keep the field names stable.
+type regroupPayload struct {
+	Folder         string   `json:"folder"`
+	Files          []string `json:"files"`
+	ProposedAction string   `json:"proposedAction"`
+	MemberBookIDs  []string `json:"memberBookIDs"`
+	SurvivorTitle  string   `json:"survivorTitle"`
+	Confidence     string   `json:"confidence"` // "high" (confident) | "review"
+}
+
+func (p *Plugin) regroupShatteredAIDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.regroup-shattered-ai",
+		Plugin:      "maintenance",
+		DisplayName: "Regroup shattered books (dry-run · review-queue producer)",
+		Description: "Scans the whole library, groups the single-file books left by the broken iTunes import " +
+			"(one track = one book) by their book folder, classifies each folder's shape with a deterministic " +
+			"regex tier (multi-disc, version group, anthology, or ambiguous — NO AI), and writes one review-queue " +
+			"HOLD per candidate folder. DRY-RUN ONLY: writes ZERO book/file changes; the only writes are review " +
+			"rows (idempotent). The apply path is a later PR.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.regroup-shattered-ai",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         120 * time.Minute,
+		// Read-only w.r.t. books/files in B1 (writes ONLY review-queue rows). No
+		// CapLibraryWrite until the apply path lands (PR-B2).
+		Capabilities: []sdk.Capability{sdk.CapLibraryRead},
+		Run:          p.runRegroupShatteredAI,
+	}
+}
+
+func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := regroupParams{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	_ = reporter.UpdateProgress(0, 0, "Phase 1/2: enumerating library…")
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("ListBookIDs: %w", err)
+	}
+
+	// CONCURRENCY (CLAUDE.md mandate): a plain `for range books` full-library scan is
+	// forbidden — a serial dedup.full-scan went silent for 3+ hours at 100% CPU on a
+	// single core on 2026-07-05 (docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md).
+	// Fan the read-only per-book scan out across NumCPU workers via registry.RunItems
+	// (the memdb-cap-safe ListBookIDs + RunItems pattern). Grouping, classification, and
+	// the review-row writes run single-threaded AFTER the scan, so there are no write
+	// races — the only shared state here is the slim-view slice, guarded by mu.
+	var mu sync.Mutex
+	views := make([]itunesservice.ShatterBook, 0, len(ids))
+	scanErr := registry.RunItems(ctx, reporter, ids, func(ctx context.Context, id string) error {
+		b, err := store.GetBookByID(id)
+		if err != nil || b == nil {
+			return nil // non-fatal: skip a book that vanished mid-scan
+		}
+		files, ferr := store.GetBookFiles(id)
+		if ferr != nil {
+			return nil // non-fatal: skip on read error
+		}
+		v := itunesservice.ShatterBook{
+			BookID:    b.ID,
+			Title:     b.Title,
+			FileCount: len(files),
+			IsPrimary: b.IsPrimaryVersion == nil || *b.IsPrimaryVersion,
+		}
+		// Prefer the real BookFile path (more reliable than the virtual Book.FilePath);
+		// fall back to Book.FilePath for zero-file virtual shells.
+		if len(files) >= 1 && files[0].FilePath != "" {
+			v.FilePath = files[0].FilePath
+		} else {
+			v.FilePath = b.FilePath
+		}
+		mu.Lock()
+		views = append(views, v)
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   runtime.NumCPU(),
+		ProgressTotal: len(ids),
+		ErrMode:       registry.ErrModeCollect,
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Phase 1/2: scanning book %d/%d…", i+1, total)
+		},
+	})
+	if scanErr != nil {
+		return fmt.Errorf("library scan: %w", scanErr)
+	}
+
+	_ = reporter.UpdateProgress(len(ids), len(ids)+1, "Phase 2/2: classifying folders + writing review holds…")
+	groups, st := itunesservice.ClassifyShatteredFolders(views)
+
+	// RECONCILE: account for EVERY book so the record count ties out vs the library
+	// (mirror fs_regroup_xml.go — no silent filtering). scan-skipped = books whose
+	// GetBookByID/GetBookFiles read failed or that vanished mid-scan; surfacing it
+	// makes st.TotalBooks + scan-skipped tie back to len(ids).
+	scanSkipped := len(ids) - len(views)
+	recon := fmt.Sprintf(
+		"RECONCILE: library=%d scan-skipped=%d total=%d non-primary=%d multi-file=%d no-path=%d singletons=%d distinct-skipped=%d groups=%d bykind=%v",
+		len(ids), scanSkipped, st.TotalBooks, st.NonPrimary, st.MultiFile, st.NoPath, st.Singletons, st.DistinctSkip, st.Groups, st.ByKind)
+	_ = reporter.Log(slog.LevelInfo, recon)
+
+	// Write one idempotent review hold per detected group. ZERO book/file writes.
+	written, alreadyDecided, writeErrs := 0, 0, 0
+	for i := range groups {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if params.Limit > 0 && i >= params.Limit {
+			break
+		}
+		g := groups[i]
+		payload, perr := buildRegroupPayload(g)
+		if perr != nil {
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("marshal payload for %q: %v", g.FolderRef, perr))
+			writeErrs++
+			continue
+		}
+		item := database.ReviewItem{
+			Kind:      g.Kind,
+			DedupKey:  regroupDedupKey(g.Kind, g.FolderRef),
+			FolderRef: g.FolderRef,
+			Summary:   regroupSummary(g),
+			Payload:   payload,
+		}
+		res, uerr := store.UpsertReviewItem(item)
+		if uerr != nil {
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("UpsertReviewItem %q: %v", g.FolderRef, uerr))
+			writeErrs++
+			continue
+		}
+		written++
+		if res.Status != database.ReviewStatusPending {
+			alreadyDecided++
+		}
+		if written%200 == 0 {
+			_ = reporter.UpdateProgress(len(ids), len(ids)+1,
+				fmt.Sprintf("Phase 2/2: wrote %d/%d review holds…", written, len(groups)))
+		}
+	}
+
+	result := fmt.Sprintf(
+		"DRY RUN — review holds written=%d (already-decided=%d, write-errors=%d) from %d detected groups; library untouched. bykind=%v",
+		written, alreadyDecided, writeErrs, len(groups), st.ByKind)
+	_ = reporter.Log(slog.LevelInfo, result)
+	_ = reporter.UpdateProgress(len(ids)+1, len(ids)+1, result)
+	if writeErrs > 0 {
+		return fmt.Errorf("%d review-hold write errors during regroup dry-run (see op log)", writeErrs)
+	}
+	return nil
+}
+
+// regroupDedupKey is the STABLE upsert target: a hash of (Kind, FolderRef). Re-running
+// the scan on unchanged data produces the same key, so UpsertReviewItem updates in
+// place instead of duplicating. Known limitation: if a folder's Kind flips between
+// runs (as data changes), the key changes and the old row is orphaned — acceptable for
+// a dry-run producer; the frontend surfaces the current classification.
+func regroupDedupKey(kind, folderRef string) string {
+	sum := sha256.Sum256([]byte(kind + "\x00" + folderRef))
+	return "regroup:" + hex.EncodeToString(sum[:16])
+}
+
+// regroupSummary renders the one-line human label for a hold.
+func regroupSummary(g itunesservice.RegroupGroup) string {
+	n := len(g.Members)
+	switch g.Kind {
+	case itunesservice.KindMultidisc:
+		return fmt.Sprintf("Multi-disc: %d tracks → 1 book — %s", n, g.FolderRef)
+	case itunesservice.KindVersionGroup:
+		return fmt.Sprintf("Version group (Abridged + Unabridged): %d files — %s", n, g.FolderRef)
+	case itunesservice.KindAnthology:
+		return fmt.Sprintf("Anthology/collection: %d works — %s", n, g.FolderRef)
+	default:
+		return fmt.Sprintf("Ambiguous folder (%d files) — needs review — %s", n, g.FolderRef)
+	}
+}
+
+// buildRegroupPayload serializes a group into the review-hold JSON payload.
+func buildRegroupPayload(g itunesservice.RegroupGroup) (string, error) {
+	files := make([]string, 0, len(g.Members))
+	ids := make([]string, 0, len(g.Members))
+	for _, m := range g.Members {
+		files = append(files, m.FilePath)
+		ids = append(ids, m.BookID)
+	}
+	confidence := "review"
+	if g.Confident {
+		confidence = "high"
+	}
+	data, err := json.Marshal(regroupPayload{
+		Folder:         g.FolderRef,
+		Files:          files,
+		ProposedAction: g.ProposedAction,
+		MemberBookIDs:  ids,
+		SurvivorTitle:  g.SurvivorTitle,
+		Confidence:     confidence,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/internal/plugins/maintenance/regroup_shattered_ai_test.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai_test.go
@@ -1,0 +1,164 @@
+// file: internal/plugins/maintenance/regroup_shattered_ai_test.go
+// version: 1.0.0
+// guid: 3a9f6c04-8e21-4b57-9d0a-6f2e7c1b5a48
+// last-edited: 2026-07-13
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// seedShatterBook creates a single-file book at a chapter-shatter path so the dry-run
+// op's scan groups it into a review hold.
+func seedShatterBook(t *testing.T, s *database.PebbleStore, path string) string {
+	t.Helper()
+	b, err := s.CreateBook(&database.Book{})
+	if err != nil || b == nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	if err := s.CreateBookFile(&database.BookFile{BookID: b.ID, FilePath: path}); err != nil {
+		t.Fatalf("CreateBookFile(%s): %v", path, err)
+	}
+	return b.ID
+}
+
+// countBooksAndFiles returns the TOTAL live book and book-file counts across the
+// whole store (not just a seeded subset), so the zero-mutation assertion proves the
+// dry-run neither deleted nor CREATED any book/file rows.
+func countBooksAndFiles(t *testing.T, s *database.PebbleStore) (books, files int) {
+	t.Helper()
+	ids, err := s.ListBookIDs()
+	if err != nil {
+		t.Fatalf("ListBookIDs: %v", err)
+	}
+	for _, id := range ids {
+		books++
+		bf, _ := s.GetBookFiles(id)
+		files += len(bf)
+	}
+	return books, files
+}
+
+// The dry-run op must write review-queue rows and make ZERO book/file mutations, and
+// re-running it must be idempotent (same review-row count, not doubled).
+func TestRegroupShatteredAI_DryRun_WritesHolds_ZeroMutations_Idempotent(t *testing.T) {
+	s := regroupStore(t)
+
+	// A chapter-shatter book folder: 6 single-file chapter shells under one book folder.
+	base := "/lib/Adrian Tchaikovsky/Cage of Souls"
+	var ids []string
+	for i := 1; i <= 6; i++ {
+		ids = append(ids, seedShatterBook(t, s, base+"/Cage of Souls - "+itoa(i)+"/01.mp3"))
+	}
+	// A lone genuine single-file book that must NOT produce a hold.
+	ids = append(ids, seedShatterBook(t, s, "/lib/Andy Weir/The Martian/The Martian.m4b"))
+
+	beforeBooks, beforeFiles := countBooksAndFiles(t, s)
+
+	p := &Plugin{deps: fakeDeps{store: s}}
+	rep := &fakeReporter{}
+
+	// Run #1.
+	if err := p.runRegroupShatteredAI(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run #1: %v", err)
+	}
+
+	// ZERO book/file mutations.
+	afterBooks, afterFiles := countBooksAndFiles(t, s)
+	if afterBooks != beforeBooks || afterFiles != beforeFiles {
+		t.Fatalf("dry-run mutated books/files: books %d→%d, files %d→%d",
+			beforeBooks, afterBooks, beforeFiles, afterFiles)
+	}
+
+	// Exactly one review hold (the chapter-shatter folder; the lone single is skipped).
+	items1, total1, err := s.ListReviewItems(database.ReviewFilter{})
+	if err != nil {
+		t.Fatalf("ListReviewItems: %v", err)
+	}
+	if total1 != 1 {
+		t.Fatalf("run #1 wrote %d review items, want 1: %+v", total1, items1)
+	}
+	hold := items1[0]
+	if hold.Kind != "regroup.multidisc" {
+		t.Errorf("hold kind = %q, want regroup.multidisc", hold.Kind)
+	}
+	if hold.FolderRef != base {
+		t.Errorf("hold folderRef = %q, want %q", hold.FolderRef, base)
+	}
+	if hold.Status != database.ReviewStatusPending {
+		t.Errorf("hold status = %q, want pending", hold.Status)
+	}
+	// Payload carries the 6 member book IDs and the derived survivor title.
+	var payload regroupPayload
+	if err := json.Unmarshal([]byte(hold.Payload), &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if len(payload.MemberBookIDs) != 6 || len(payload.Files) != 6 {
+		t.Errorf("payload members=%d files=%d, want 6/6", len(payload.MemberBookIDs), len(payload.Files))
+	}
+	if payload.SurvivorTitle != "Cage of Souls" {
+		t.Errorf("payload survivorTitle = %q, want 'Cage of Souls'", payload.SurvivorTitle)
+	}
+	if payload.Confidence != "high" {
+		t.Errorf("payload confidence = %q, want high", payload.Confidence)
+	}
+
+	// Run #2 — UPSERT idempotency: the same folder must NOT create a second row.
+	if err := p.runRegroupShatteredAI(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run #2: %v", err)
+	}
+	_, total2, err := s.ListReviewItems(database.ReviewFilter{})
+	if err != nil {
+		t.Fatalf("ListReviewItems #2: %v", err)
+	}
+	if total2 != 1 {
+		t.Fatalf("run #2 review items = %d, want 1 (upsert must not duplicate)", total2)
+	}
+
+	// Books/files still untouched after the second run.
+	after2Books, after2Files := countBooksAndFiles(t, s)
+	if after2Books != beforeBooks || after2Files != beforeFiles {
+		t.Fatalf("run #2 mutated books/files: books %d→%d, files %d→%d",
+			beforeBooks, after2Books, beforeFiles, after2Files)
+	}
+}
+
+// A human-rejected hold must not be resurfaced (status preserved) on a re-scan.
+func TestRegroupShatteredAI_DryRun_PreservesDecision(t *testing.T) {
+	s := regroupStore(t)
+	base := "/lib/Brandon Sanderson/Elantris"
+	for i := 1; i <= 5; i++ {
+		seedShatterBook(t, s, base+"/Elantris - "+itoa(i)+"/01.mp3")
+	}
+
+	p := &Plugin{deps: fakeDeps{store: s}}
+	rep := &fakeReporter{}
+	if err := p.runRegroupShatteredAI(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run #1: %v", err)
+	}
+	items, _, _ := s.ListReviewItems(database.ReviewFilter{})
+	if len(items) != 1 {
+		t.Fatalf("want 1 hold, got %d", len(items))
+	}
+	// Human rejects it.
+	if _, err := s.SetReviewItemStatus(items[0].ID, database.ReviewStatusRejected); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// Re-scan must leave the rejected item rejected (no resurfacing).
+	if err := p.runRegroupShatteredAI(context.Background(), nil, rep); err != nil {
+		t.Fatalf("run #2: %v", err)
+	}
+	after, total, _ := s.ListReviewItems(database.ReviewFilter{})
+	if total != 1 {
+		t.Fatalf("re-scan changed item count to %d, want 1", total)
+	}
+	if after[0].Status != database.ReviewStatusRejected {
+		t.Errorf("re-scan resurfaced a rejected hold: status=%q", after[0].Status)
+	}
+}


### PR DESCRIPTION
**PR-B1** of the review-queue + shattered-book-regroup plan. First **producer** into the review queue (PR-A1/#1947). Builds on A1+A2 (both merged).

Re-derives real audiobooks from the ~44K single-file "books" the broken iTunes import left behind (one track = one book), using the library **folder** as the identity signal (tags are unreliable).

## Dry-run only — ZERO book/file writes
The only writes are review-queue holds via `UpsertReviewItem`. The apply path (CombineBooks / version-group writes) is PR-B2. `Capabilities: [CapLibraryRead]`.

## What
- Pure regex classifier `ClassifyShatteredFolders` (`internal/itunes/service/fs_regroup_shape.go`): groups single-file books by their **book folder** (grandparent when the parent is a chapter/`Disc N`/edition subdir, else parent — avoids over-merging flat multitrack to the author dir), classifies into the 4 A1 frontend kinds: `regroup.multidisc` (confident), `regroup.version-group`, `regroup.anthology`, `regroup.ambiguous`. Collections of distinct books (author dirs, series volumes, flat dumps) and genuine single-file books are skipped so the queue isn't flooded.
- The op (`regroup_shattered_ai.go`): `ListBookIDs` + `registry.RunItems(Concurrency: NumCPU())` read-only scan (cites the 2026-07-05 3-hr single-core incident); idempotent holds keyed by `DedupKey = hash(Kind + FolderRef)` so re-runs never duplicate or resurface human-decided items. Emits a `RECONCILE:` line.

## Verification
- build/vet/gofmt clean; `-race` tests pass (11 detector cases + 2 op tests: zero-mutation, correct hold count, upsert idempotency, decision preservation).

## ⚠️ Real-world yield unverified (acceptance gate)
The detector's branches have only run against synthetic fixtures. The prior heal fixed 0/44,327, so real folder shapes need sampling before trusting the numbers — a read-only whole-library dry-run + `RECONCILE:` inspection is the gate before enabling any apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)