### PR TITLE
feat(regroup): review-queue APPLY path for confident holds (PR-B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.157.2 -->
+<!-- version: 3.158.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -82,8 +82,13 @@ success the item transitions to `applied`.
   `internal/server/wire_handlers.go`. Tests assert the data-loss invariants (survivor
   keeps fingerprint + author; version-group members keep theirs) via
   `dbtest.AssertStoreInvariants` — the same drift-proof guard as the Jul-13 fixes.
-- **Not auto-applied.** This PR only *arms* the button; every collapse remains a
-  human-approved hold. Merging + deploying is the gated prod-apply decision.
+- **Global apply "off switch" (`config.review_apply_enabled`, default OFF).** Even with
+  this code deployed, approving a hold records the decision but NEVER runs the merge
+  while the switch is off — everything stays visible in the review pane. The gate lives
+  in the review handler (producer-agnostic) and is read at approve time. Flip to `true`
+  only when you want approvals to actually apply. New tests cover both switch states.
+- **Not auto-applied.** This PR only *arms* the button, and even then only when the
+  switch is on; every collapse remains a human-approved hold.
 
 #### July 13, 2026 - fix(regroup): anthology counts distinct works + fold in original iTunes album path (B1 tuning)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.157.1 -->
+<!-- version: 3.157.2 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -56,6 +56,34 @@ author/collection over-merge holds would linger as approvable "70 tracks → 1" 
 - Tests: store delete round-trip (record + both indexes gone, re-upsert creates a fresh
   row); reconcile purges superseded pending only, preserves decided/other-producer/emitted;
   capped-run no-op.
+#### July 14, 2026 - feat(regroup): review-queue APPLY path for confident holds (PR-B2)
+
+Turns the review queue's "Approve" from a status label-flip into a real merge for the
+two *confident* regroup kinds, closing the loop opened by B1 (the dry-run producer).
+Approving a hold now dispatches on its `Kind` to a registered apply function; on
+success the item transitions to `applied`.
+
+- **`regroup.multidisc`** (196 prod holds) → collapses the folder's single-file books
+  into ONE multi-file book via `merge.Service.CombineBooks(members, primary, nil)`. The
+  **nil override** is load-bearing: the only `UpdateBook`-on-survivor path in the merge
+  service is gated behind a non-nil override, so with nil the survivor row is never
+  rewritten and its `AcoustIDFingerprint` / Author / Series survive. Absorbed books'
+  files move by file ID (fingerprints ride along); absorbed rows are hard-deleted.
+- **`regroup.version-group`** (1 prod hold) → links the folder's editions into one
+  version group via **re-fetch-and-patch**: `GetBookByID` (full-fidelity row) → set only
+  `VersionGroupID` → `UpdateBook`. Never writes a fresh/partial `Book` back (UpdateBook
+  is a full-column replace — the historic Author/Series wipe class).
+- `regroup.anthology` and `regroup.ambiguous` are deliberately **handler-less** — they
+  need human sub-decisions, so approving one only marks it `approved`, never `applied`.
+- Survivor selection is deterministic (smallest ULID = earliest-created), and apply is
+  **retry-tolerant**: fewer than two surviving members is an idempotent no-op, so a
+  double-approve or a re-approve after a partial failure never errors.
+- New: `internal/plugins/maintenance/regroup_apply.go` (+ tests); registration wired in
+  `internal/server/wire_handlers.go`. Tests assert the data-loss invariants (survivor
+  keeps fingerprint + author; version-group members keep theirs) via
+  `dbtest.AssertStoreInvariants` — the same drift-proof guard as the Jul-13 fixes.
+- **Not auto-applied.** This PR only *arms* the button; every collapse remains a
+  human-approved hold. Merging + deploying is the gated prod-apply decision.
 
 #### July 13, 2026 - fix(regroup): anthology counts distinct works + fold in original iTunes album path (B1 tuning)
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,21 @@ future agent) can scan the entire workspace in one page.
 
 ---
 
+## 🔨 PR OPEN (unmerged) — review-queue APPLY path, PR-B2 (2026-07-14)
+
+Branch `feat/regroup-apply-path-b2`. Makes the review queue's "Approve" perform the
+real merge for the two confident regroup kinds: `regroup.multidisc` →
+`CombineBooks(members, primary, nil)` (nil override = survivor row never rewritten),
+`regroup.version-group` → shared `VersionGroupID` + one primary via re-fetch-and-patch
+`UpdateBook` (NOT MergeBooks — both editions stay visible, locked #8). Anthology/
+ambiguous stay handler-less. Deterministic smallest-ULID survivor; retry-tolerant
+(<2 present members = no-op). Files: `internal/plugins/maintenance/regroup_apply.go`
+(+ `_test.go` with data-loss invariants), `internal/server/wire_handlers.go`. **Not
+merged/deployed** — merging is the gated prod-apply decision. See
+[`docs/plans/2026-07-13-review-queue-and-regroup.md`](docs/plans/2026-07-13-review-queue-and-regroup.md).
+Follow-ups still open: AI enrichment tier (adjudicates the ambiguous pile), cover
+recovery, dedup REVIEW-band producer.
+
 ## ✅ RESOLVED — change-log mislabeled imports as renames + organize dropped source path (2026-07-13)
 
 Change-log entry showed `📁 Rename — Renamed — → /mnt/.../book.mp3` (empty "from") for

--- a/docs/plans/2026-07-13-review-queue-and-regroup.md
+++ b/docs/plans/2026-07-13-review-queue-and-regroup.md
@@ -1,7 +1,7 @@
 <!-- file: docs/plans/2026-07-13-review-queue-and-regroup.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 3d9f2a6c-7e14-4b8a-9c2d-5f1e6a3b7c40 -->
-<!-- last-edited: 2026-07-13 -->
+<!-- last-edited: 2026-07-14 -->
 
 # PLAN — Universal Review Queue + Shattered-Book Regroup Op
 
@@ -200,8 +200,13 @@ Approving an item in the panel (or enabling the confident-auto-apply toggle) exe
 2. **PR-A2** Review-queue frontend (banner + store + sidebar + /review page + grouped bulk actions).
 3. **PR-B1** Regroup op: registration + broadened shape detector (pure, unit-tested) + **dry-run only**,
    producing review-queue holds. No apply path. (This is what populates the queue with real data.)
-4. **PR-B2** Regroup apply path (CombineBooks collapse + version-group) wired to review-approve +
-   the confident-auto-apply toggle (default off). `-race` invariant tests.
+4. **PR-B2** Regroup apply path (CombineBooks collapse + version-group) wired to review-approve.
+   `-race` invariant tests. **✅ BUILT — branch `feat/regroup-apply-path-b2` (PR open, UNMERGED).**
+   Deviation from plan: dropped the `confident-auto-apply` toggle. The human review-approve *is*
+   the gate — nothing auto-applies, so a toggle would only re-introduce the auto-apply risk the
+   review queue exists to remove. Multidisc uses a **nil** CombineBooks override (survivor row
+   never rewritten); version-group uses re-fetch-and-patch UpdateBook. Anthology/ambiguous stay
+   handler-less. Merging+deploying is the gated prod-apply decision.
 5. **Fast-follow (separate PRs, not in this plan's critical path):**
    - AI enrichment tier (`OpenAIParser.ClassifyFolderShape`, batched, small model, `ProbeOllamaAvailable`
      graceful-degrade) — **blocked on Ollama serving on the box.**

--- a/docs/plans/2026-07-13-review-queue-and-regroup.md
+++ b/docs/plans/2026-07-13-review-queue-and-regroup.md
@@ -1,5 +1,5 @@
 <!-- file: docs/plans/2026-07-13-review-queue-and-regroup.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 3d9f2a6c-7e14-4b8a-9c2d-5f1e6a3b7c40 -->
 <!-- last-edited: 2026-07-14 -->
 
@@ -202,11 +202,13 @@ Approving an item in the panel (or enabling the confident-auto-apply toggle) exe
    producing review-queue holds. No apply path. (This is what populates the queue with real data.)
 4. **PR-B2** Regroup apply path (CombineBooks collapse + version-group) wired to review-approve.
    `-race` invariant tests. **✅ BUILT — branch `feat/regroup-apply-path-b2` (PR open, UNMERGED).**
-   Deviation from plan: dropped the `confident-auto-apply` toggle. The human review-approve *is*
-   the gate — nothing auto-applies, so a toggle would only re-introduce the auto-apply risk the
-   review queue exists to remove. Multidisc uses a **nil** CombineBooks override (survivor row
-   never rewritten); version-group uses re-fetch-and-patch UpdateBook. Anthology/ambiguous stay
-   handler-less. Merging+deploying is the gated prod-apply decision.
+   Kept the global apply switch as `config.review_apply_enabled` (**default OFF**): even with the
+   code deployed, approving a hold records the decision but NEVER merges while the switch is off —
+   everything stays visible in the review pane (per the user's explicit "no auto-merge until the
+   big switch" requirement). The gate lives in the review handler (producer-agnostic), read at
+   approve time. Multidisc uses a **nil** CombineBooks override (survivor row never rewritten);
+   version-group uses re-fetch-and-patch UpdateBook. Anthology/ambiguous stay handler-less.
+   Merging+deploying + flipping the switch is the gated prod-apply decision.
 5. **Fast-follow (separate PRs, not in this plan's critical path):**
    - AI enrichment tier (`OpenAIParser.ClassifyFolderShape`, batched, small model, `ProbeOllamaAvailable`
      graceful-degrade) — **blocked on Ollama serving on the box.**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.69.0
+// version: 1.70.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 package config
 
@@ -539,6 +539,14 @@ type Config struct {
 	UploadBodyLimitMB      int  `json:"upload_body_limit_mb"`
 	EnableAuth             bool `json:"enable_auth"`
 	EnableRateLimit        bool `json:"enable_rate_limit"`
+
+	// ReviewApplyEnabled is the GLOBAL "big switch" for the review-queue apply path.
+	// When false (the default), approving a review hold records the decision but NEVER
+	// executes the real-world action (e.g. a regroup CombineBooks merge) — every hold
+	// stays visible in the review pane for human eyes. Flip to true only when you want
+	// approvals to actually apply. Producer-agnostic: gates ALL registered apply
+	// handlers, not just regroup.
+	ReviewApplyEnabled bool `json:"review_apply_enabled"`
 
 	// Basic HTTP auth (lightweight single-user alternative)
 	BasicAuthEnabled  bool   `json:"basic_auth_enabled"`
@@ -1091,6 +1099,7 @@ func InitConfig() {
 			UploadBodyLimitMB:                viper.GetInt("upload_body_limit_mb"),
 			EnableAuth:                       viper.GetBool("enable_auth"),
 			EnableRateLimit:                  viper.GetBool("enable_rate_limit"),
+			ReviewApplyEnabled:               viper.GetBool("review_apply_enabled"),
 			BasicAuthEnabled:                 viper.GetBool("basic_auth_enabled"),
 			BasicAuthUsername:                viper.GetString("basic_auth_username"),
 			BasicAuthPassword:                viper.GetString("basic_auth_password"),
@@ -1635,6 +1644,7 @@ func ResetToDefaults() {
 			UploadBodyLimitMB:       10,
 			EnableAuth:              true,
 			EnableRateLimit:         true,
+			ReviewApplyEnabled:      false, // OFF by default — review-only until explicitly enabled
 			BasicAuthEnabled:        false,
 			BasicAuthUsername:       "",
 			BasicAuthPassword:       "",

--- a/internal/plugins/maintenance/regroup_apply.go
+++ b/internal/plugins/maintenance/regroup_apply.go
@@ -1,0 +1,211 @@
+// file: internal/plugins/maintenance/regroup_apply.go
+// version: 1.0.0
+// guid: e2a7c9d4-1f68-4b03-9c5e-7a0d3f814b62
+// last-edited: 2026-07-14
+
+// Package maintenance — the APPLY path for the regroup review queue (PR-B2).
+//
+// B1 (regroup_shattered_ai.go) is a dry-run producer: it writes one review-queue
+// HOLD per candidate folder and touches ZERO books. B2 is what makes the "Approve"
+// button in the review UI actually merge. It supplies one apply function per
+// CONFIDENT regroup Kind; the review handler dispatches on ReviewItem.Kind and, on
+// a nil error, transitions the item to "applied" (handler.go:approveOne).
+//
+// Only the two confident kinds get an apply function:
+//   - regroup.multidisc     → collapse N single-file books into 1 (CombineBooks).
+//   - regroup.version-group → share a VersionGroupID + designate one primary, via
+//     UpdateBook (NOT MergeBooks — both editions must stay visible; locked #8).
+//
+// regroup.anthology and regroup.ambiguous are deliberately handler-less: they need
+// human sub-decisions (which files are distinct works, how to split) that a single
+// apply function cannot make, so approving one only marks it "approved".
+//
+// DATA-LOSS SAFETY (this repo's dominant incident class is write-back wipes):
+//   - Multidisc uses CombineBooks(ids, primary, nil) — a NIL override. The only
+//     UpdateBook-on-survivor in merge.Service is gated behind a non-nil override, so
+//     with nil the survivor row is never rewritten and its AcoustIDFingerprint /
+//     Author / Series survive. Absorbed books' FILES move by file ID (fingerprints
+//     ride along); absorbed ROWS are hard-deleted intentionally.
+//   - Version-group uses re-fetch-and-patch: GetBookByID returns the FULL row, we
+//     mutate ONLY VersionGroupID, then UpdateBook. Never construct a fresh/partial
+//     Book and write it back — UpdateBook is a full-column replace.
+// Both paths are covered by regroup_apply_test.go's invariant assertions.
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	ulid "github.com/oklog/ulid/v2"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+)
+
+// bookCombiner is the slim slice of merge.Service the multidisc apply path needs.
+// Narrowing to an interface keeps the apply function unit-testable without a full
+// merge service while the real wiring passes *merge.Service.
+type bookCombiner interface {
+	CombineBooks(bookIDs []string, primaryID string, override *merge.CombineOverride) (*merge.CombineResult, error)
+}
+
+// ApplyMultidisc builds the apply function for regroup.multidisc holds: it collapses
+// the folder's single-file books into ONE multi-file book via CombineBooks.
+//
+// The returned func matches reviewhandler.ApplyFunc structurally (an unnamed func
+// type is assignable to the named type), so the wiring registers it directly without
+// this package importing the server handler.
+func ApplyMultidisc(store database.Store, combiner bookCombiner) func(context.Context, database.ReviewItem) error {
+	return func(ctx context.Context, item database.ReviewItem) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		p, err := decodeRegroupPayload(item)
+		if err != nil {
+			return err
+		}
+		// Retry tolerance: only combine members that still resolve. A double-approve,
+		// or a re-approve after a partial failure, must not error on already-absorbed
+		// (hard-deleted) rows.
+		present, err := presentMembers(store, p.MemberBookIDs)
+		if err != nil {
+			return err
+		}
+		if len(present) < 2 {
+			slog.Info("regroup multidisc apply: <2 members remain — already applied, no-op",
+				"item", item.ID, "folder", p.Folder, "present", len(present))
+			return nil
+		}
+		primaryID := pickPrimary(present)
+		res, err := combiner.CombineBooks(present, primaryID, nil) // nil override = survivor metadata untouched
+		if err != nil {
+			return fmt.Errorf("regroup multidisc apply: combine %q (%d books): %w", p.Folder, len(present), err)
+		}
+		slog.Info("regroup multidisc apply: collapsed folder",
+			"item", item.ID, "folder", p.Folder, "survivor", res.PrimaryID,
+			"files_moved", res.FilesMoved, "books_deleted", res.BooksDeleted)
+		return nil
+	}
+}
+
+// ApplyVersionGroup builds the apply function for regroup.version-group holds: it
+// links the folder's members (e.g. an Abridged + an Unabridged edition) into one
+// version group by giving them a shared VersionGroupID and designating one primary.
+//
+// LOCKED decision #8 (plan §B3): this uses UpdateBook, NOT merge.MergeBooks —
+// MergeBooks soft-deletes the loser, but a version group must keep BOTH editions
+// visible (the user picks which to play). The group-ID-reuse mirrors
+// merge/service.go: reuse an existing VersionGroupID if any member already has one.
+func ApplyVersionGroup(store database.Store) func(context.Context, database.ReviewItem) error {
+	return func(ctx context.Context, item database.ReviewItem) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		p, err := decodeRegroupPayload(item)
+		if err != nil {
+			return err
+		}
+		// Resolve all members up front (atomic-validate-then-write). Prefer an
+		// existing VersionGroupID for idempotency — a re-approve then re-links to the
+		// same group instead of minting a fresh one every time.
+		books := make([]*database.Book, 0, len(p.MemberBookIDs))
+		target := ""
+		for _, id := range p.MemberBookIDs {
+			b, err := store.GetBookByID(id)
+			if err != nil {
+				return fmt.Errorf("regroup version-group apply: lookup %s: %w", id, err)
+			}
+			if b == nil {
+				continue // tolerate a vanished member
+			}
+			books = append(books, b)
+			if b.VersionGroupID != nil && *b.VersionGroupID != "" {
+				if target == "" || *b.VersionGroupID < target {
+					target = *b.VersionGroupID
+				}
+			}
+		}
+		if len(books) < 2 {
+			slog.Info("regroup version-group apply: <2 members remain — nothing to group",
+				"item", item.ID, "folder", p.Folder, "present", len(books))
+			return nil
+		}
+		if target == "" {
+			target = ulid.Make().String()
+		}
+		// Designate a single primary deterministically: the smallest ULID (earliest-
+		// created), consistent with pickPrimary and stable across retries. The plan
+		// prefers the Unabridged edition, but that signal is not in the payload; a
+		// deterministic primary is the safe fallback. BOTH editions stay visible — we
+		// never soft-delete here.
+		primaryID := books[0].ID
+		for _, b := range books[1:] {
+			if b.ID < primaryID {
+				primaryID = b.ID
+			}
+		}
+		// Re-fetch-and-patch: mutate ONLY VersionGroupID + IsPrimaryVersion on the
+		// full fetched row (UpdateBook is a full-column replace — never write back a
+		// fresh/partial Book). Skip a write only when both already match (idempotent).
+		for _, b := range books {
+			vg := target
+			isPrimary := b.ID == primaryID
+			if b.VersionGroupID != nil && *b.VersionGroupID == target &&
+				b.IsPrimaryVersion != nil && *b.IsPrimaryVersion == isPrimary {
+				continue
+			}
+			b.VersionGroupID = &vg
+			b.IsPrimaryVersion = &isPrimary
+			if _, err := store.UpdateBook(b.ID, b); err != nil {
+				return fmt.Errorf("regroup version-group apply: set version group on %s: %w", b.ID, err)
+			}
+		}
+		slog.Info("regroup version-group apply: linked members",
+			"item", item.ID, "folder", p.Folder, "version_group", target,
+			"primary", primaryID, "members", len(books))
+		return nil
+	}
+}
+
+// decodeRegroupPayload unmarshals the hold's JSON payload (the shape the producer
+// wrote in buildRegroupPayload).
+func decodeRegroupPayload(item database.ReviewItem) (regroupPayload, error) {
+	var p regroupPayload
+	if err := json.Unmarshal([]byte(item.Payload), &p); err != nil {
+		return regroupPayload{}, fmt.Errorf("regroup apply: decode payload for item %s: %w", item.ID, err)
+	}
+	return p, nil
+}
+
+// presentMembers returns the subset of ids whose Book rows still resolve, preserving
+// order. A read error is fatal (aborts before any mutation); a not-found is skipped.
+func presentMembers(store database.Store, ids []string) ([]string, error) {
+	present := make([]string, 0, len(ids))
+	for _, id := range ids {
+		b, err := store.GetBookByID(id)
+		if err != nil {
+			return nil, fmt.Errorf("regroup apply: lookup %s: %w", id, err)
+		}
+		if b != nil {
+			present = append(present, id)
+		}
+	}
+	return present, nil
+}
+
+// pickPrimary chooses the survivor deterministically: the lexicographically smallest
+// member ID. Member IDs are ULIDs (time-sortable), so the smallest is the earliest-
+// created book — a stable, sensible canonical survivor that is identical across
+// retries (which the idempotency/partial-failure story relies on).
+func pickPrimary(ids []string) string {
+	primary := ids[0]
+	for _, id := range ids[1:] {
+		if id < primary {
+			primary = id
+		}
+	}
+	return primary
+}

--- a/internal/plugins/maintenance/regroup_apply_test.go
+++ b/internal/plugins/maintenance/regroup_apply_test.go
@@ -1,0 +1,283 @@
+// file: internal/plugins/maintenance/regroup_apply_test.go
+// version: 1.0.0
+// guid: a9d3f1c7-6b40-4e28-8f95-2c1e7b0a4d63
+// last-edited: 2026-07-14
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newApplyTestStore(t *testing.T) database.Store {
+	t.Helper()
+	s, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// minID mirrors pickPrimary — the smallest ID is the survivor CombineBooks keeps.
+func minID(ids ...string) string {
+	m := ids[0]
+	for _, id := range ids[1:] {
+		if id < m {
+			m = id
+		}
+	}
+	return m
+}
+
+func multidiscItem(t *testing.T, folder string, memberIDs []string) database.ReviewItem {
+	t.Helper()
+	payload, err := json.Marshal(regroupPayload{
+		Folder:         folder,
+		MemberBookIDs:  memberIDs,
+		ProposedAction: "collapse single-file books into one",
+		SurvivorTitle:  "Survivor",
+		Confidence:     "high",
+	})
+	require.NoError(t, err)
+	return database.ReviewItem{
+		ID:        ulid.Make().String(),
+		Kind:      "regroup.multidisc",
+		FolderRef: folder,
+		Payload:   string(payload),
+	}
+}
+
+func versionGroupItem(t *testing.T, folder string, memberIDs []string) database.ReviewItem {
+	t.Helper()
+	payload, err := json.Marshal(regroupPayload{
+		Folder:         folder,
+		MemberBookIDs:  memberIDs,
+		ProposedAction: "link editions as a version group",
+		SurvivorTitle:  "Survivor",
+		Confidence:     "high",
+	})
+	require.NoError(t, err)
+	return database.ReviewItem{
+		ID:        ulid.Make().String(),
+		Kind:      "regroup.version-group",
+		FolderRef: folder,
+		Payload:   string(payload),
+	}
+}
+
+// TestApplyMultidisc_CollapsesAndPreservesData is the core B2 invariant: collapsing
+// a multidisc folder must (a) leave exactly ONE book owning all files, (b) preserve
+// every file's AcoustIDFingerprint through the move (the memdb-roundtrip wipe class),
+// and (c) leave the survivor's author link intact (CombineBooks with a nil override
+// must never rewrite the survivor row).
+func TestApplyMultidisc_CollapsesAndPreservesData(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	// Three single-file books, each with a real fingerprinted BookFile.
+	ids := []string{ulid.Make().String(), ulid.Make().String(), ulid.Make().String()}
+	fpByPath := map[string][]byte{}
+	for i, id := range ids {
+		path := "/lib/folder/ch0" + string(rune('1'+i)) + ".mp3"
+		_, err := store.CreateBook(&database.Book{ID: id, Title: "Chapter", Format: "mp3", FilePath: path})
+		require.NoError(t, err)
+		fp := []byte("fp-" + id)
+		fpByPath[path] = fp
+		require.NoError(t, store.CreateBookFile(&database.BookFile{
+			ID: ulid.Make().String(), BookID: id, FilePath: path, Format: "mp3",
+			AcoustIDFingerprint: fp,
+		}))
+	}
+
+	// The survivor (smallest ULID) gets an author link AND a series link, both of
+	// which must survive the combine (Author/Series is the plan's named wipe class).
+	primaryID := minID(ids...)
+	author, err := store.CreateAuthor("Test Author")
+	require.NoError(t, err)
+	require.NoError(t, store.SetBookAuthors(primaryID, []database.BookAuthor{
+		{BookID: primaryID, AuthorID: author.ID, Role: "author", Position: 0},
+	}))
+	series, err := store.CreateSeries("Test Series", &author.ID)
+	require.NoError(t, err)
+	primaryBook, err := store.GetBookByID(primaryID)
+	require.NoError(t, err)
+	primaryBook.SeriesID = &series.ID
+	_, err = store.UpdateBook(primaryID, primaryBook)
+	require.NoError(t, err)
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	require.NoError(t, apply(context.Background(), multidiscItem(t, "/lib/folder", ids)))
+
+	// Exactly one book survives, and it is the deterministic primary.
+	for _, id := range ids {
+		b, _ := store.GetBookByID(id)
+		if id == primaryID {
+			require.NotNil(t, b, "survivor must remain")
+		} else {
+			assert.Nil(t, b, "absorbed book %s must be hard-deleted", id)
+		}
+	}
+
+	// Survivor owns all three files, and EVERY fingerprint survived the move.
+	files, err := store.GetBookFiles(primaryID)
+	require.NoError(t, err)
+	require.Len(t, files, 3, "survivor owns all files")
+	for _, f := range files {
+		want, ok := fpByPath[f.FilePath]
+		require.True(t, ok, "unexpected file path %s", f.FilePath)
+		assert.Equal(t, want, f.AcoustIDFingerprint,
+			"AcoustIDFingerprint must survive the file move (memdb-wipe guard)")
+	}
+
+	// Survivor's author link is intact (nil override never rewrote the row).
+	authors, err := store.GetBookAuthors(primaryID)
+	require.NoError(t, err)
+	require.Len(t, authors, 1)
+	assert.Equal(t, author.ID, authors[0].AuthorID)
+
+	// Survivor's SeriesID (a Book-row field) is intact — the other half of the
+	// plan's Author/Series wipe class.
+	survivorBook, err := store.GetBookByID(primaryID)
+	require.NoError(t, err)
+	require.NotNil(t, survivorBook.SeriesID, "survivor SeriesID must survive the combine")
+	assert.Equal(t, series.ID, *survivorBook.SeriesID)
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestApplyMultidisc_AlreadyApplied_NoOp verifies a re-approve (or an approve after
+// the group was already collapsed) is an idempotent no-op, never an error, when
+// fewer than two members still resolve.
+func TestApplyMultidisc_AlreadyApplied_NoOp(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	// Only one of the two referenced members actually exists.
+	survivor := ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{ID: survivor, Title: "Only", Format: "mp3", FilePath: "/lib/x/a.mp3"})
+	require.NoError(t, err)
+	missing := ulid.Make().String()
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	require.NoError(t, apply(context.Background(), multidiscItem(t, "/lib/x", []string{survivor, missing})),
+		"fewer than 2 present members must be a no-op success")
+
+	b, _ := store.GetBookByID(survivor)
+	assert.NotNil(t, b, "the lone survivor must be untouched")
+}
+
+// TestApplyVersionGroup_LinksAndPreservesData verifies the members end up sharing one
+// VersionGroupID while keeping their own files/fingerprints/authors (the re-fetch-
+// and-patch UpdateBook must not wipe other fields).
+func TestApplyVersionGroup_LinksAndPreservesData(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	ids := []string{ulid.Make().String(), ulid.Make().String()}
+	author, err := store.CreateAuthor("VG Author")
+	require.NoError(t, err)
+	for i, id := range ids {
+		path := "/lib/vg/ed" + string(rune('1'+i)) + ".mp3"
+		_, err := store.CreateBook(&database.Book{ID: id, Title: "Edition", Format: "mp3", FilePath: path})
+		require.NoError(t, err)
+		require.NoError(t, store.CreateBookFile(&database.BookFile{
+			ID: ulid.Make().String(), BookID: id, FilePath: path, Format: "mp3",
+			AcoustIDFingerprint: []byte("fp-" + id),
+		}))
+		require.NoError(t, store.SetBookAuthors(id, []database.BookAuthor{
+			{BookID: id, AuthorID: author.ID, Role: "author", Position: 0},
+		}))
+	}
+
+	apply := ApplyVersionGroup(store)
+	require.NoError(t, apply(context.Background(), versionGroupItem(t, "/lib/vg", ids)))
+
+	// Both members now share one non-empty VersionGroupID, stay VISIBLE (not
+	// soft-deleted — locked #8), and exactly ONE is primary.
+	var vg string
+	primaries := 0
+	for _, id := range ids {
+		b, err := store.GetBookByID(id)
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		require.NotNil(t, b.VersionGroupID, "member %s must have a VersionGroupID", id)
+		require.NotEmpty(t, *b.VersionGroupID)
+		if vg == "" {
+			vg = *b.VersionGroupID
+		} else {
+			assert.Equal(t, vg, *b.VersionGroupID, "members must share the same group")
+		}
+		require.NotNil(t, b.IsPrimaryVersion, "member %s must have IsPrimaryVersion set", id)
+		if *b.IsPrimaryVersion {
+			primaries++
+		}
+		assert.True(t, b.MarkedForDeletion == nil || !*b.MarkedForDeletion,
+			"version-group members must stay visible, never soft-deleted")
+
+		// Files/fingerprints preserved.
+		files, err := store.GetBookFiles(id)
+		require.NoError(t, err)
+		require.Len(t, files, 1)
+		assert.Equal(t, []byte("fp-"+id), files[0].AcoustIDFingerprint)
+
+		// Author link preserved through the UpdateBook patch.
+		authors, err := store.GetBookAuthors(id)
+		require.NoError(t, err)
+		require.Len(t, authors, 1)
+		assert.Equal(t, author.ID, authors[0].AuthorID)
+	}
+	assert.Equal(t, 1, primaries, "exactly one member must be the primary version")
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestApplyVersionGroup_Idempotent verifies a second apply keeps the same group
+// (does not mint a new VersionGroupID) and stays a no-op.
+func TestApplyVersionGroup_Idempotent(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	ids := []string{ulid.Make().String(), ulid.Make().String()}
+	for i, id := range ids {
+		_, err := store.CreateBook(&database.Book{
+			ID: id, Title: "Edition", Format: "mp3",
+			FilePath: "/lib/vg2/ed" + string(rune('1'+i)) + ".mp3",
+		})
+		require.NoError(t, err)
+	}
+
+	apply := ApplyVersionGroup(store)
+	item := versionGroupItem(t, "/lib/vg2", ids)
+	require.NoError(t, apply(context.Background(), item))
+
+	first, err := store.GetBookByID(ids[0])
+	require.NoError(t, err)
+	require.NotNil(t, first.VersionGroupID)
+	vg1 := *first.VersionGroupID
+
+	require.NoError(t, apply(context.Background(), item)) // re-apply
+	second, err := store.GetBookByID(ids[0])
+	require.NoError(t, err)
+	require.NotNil(t, second.VersionGroupID)
+	assert.Equal(t, vg1, *second.VersionGroupID, "re-apply must reuse the existing group")
+}
+
+func TestPickPrimary_SmallestID(t *testing.T) {
+	assert.Equal(t, "01AAAA", pickPrimary([]string{"01ZZZZ", "01AAAA", "01MMMM"}))
+	assert.Equal(t, "solo", pickPrimary([]string{"solo"}))
+}
+
+// TestApplyMultidisc_BadPayload surfaces a decode error rather than silently
+// swallowing it (so the item is NOT marked "applied").
+func TestApplyMultidisc_BadPayload(t *testing.T) {
+	store := newApplyTestStore(t)
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	err := apply(context.Background(), database.ReviewItem{
+		ID: ulid.Make().String(), Kind: "regroup.multidisc", Payload: "{not json",
+	})
+	require.Error(t, err)
+}

--- a/internal/server/handlers/review/handler.go
+++ b/internal/server/handlers/review/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/review/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2b6f9c14-8e37-4a5d-91c6-0f4a7d2e8b53
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 // Package reviewhandler hosts the universal review-queue HTTP handlers (PR-A1).
 //
@@ -12,11 +12,14 @@
 // B, not built yet), so at A1 the queue starts empty and no apply handlers are
 // registered.
 //
-// Apply-handler registry: because producers don't exist yet, approving an item
-// dispatches on its Kind to a registered ApplyFunc. When a Kind has a handler,
-// approve runs it and then sets the item to "applied". When it does NOT (the A1
-// state for every Kind), approve simply sets "approved" and returns OK with a
-// note — it never errors. Track B's B2 registers the regroup apply handler.
+// Apply-handler registry + global switch: approving an item dispatches on its Kind
+// to a registered ApplyFunc, BUT only when the global apply "big switch"
+// (applyEnabled) is on. When a Kind has a handler AND the switch is on, approve runs
+// it and sets the item to "applied". Otherwise — no handler, OR the switch is off
+// (review-only mode, the default) — approve just sets "approved" and returns OK with
+// a note, never executing anything. This makes "see everything in the review pane,
+// nothing auto-merges" the default until the switch is deliberately flipped. Track
+// B's B2 registers the regroup apply handlers; config.ReviewApplyEnabled is the switch.
 package reviewhandler
 
 import (
@@ -38,6 +41,12 @@ type Handler struct {
 	// store is the wire-time snapshot of the review-queue store.
 	store database.ReviewStore
 
+	// applyEnabled is the GLOBAL "big switch" gate, read at approve time. When it
+	// returns false (the default), approving a hold records the decision but NEVER
+	// executes its apply handler — every hold stays visible/reviewable. A nil gate is
+	// treated as disabled (fail-safe: never auto-apply unless explicitly turned on).
+	applyEnabled func() bool
+
 	// applyHandlers maps a review item's Kind to the action that applies it.
 	// Empty in A1; populated by producers (e.g. B2's regroup) via
 	// RegisterApplyHandler. Guarded by mu because registration may happen during
@@ -46,12 +55,21 @@ type Handler struct {
 	applyHandlers map[string]ApplyFunc
 }
 
-// New constructs a review Handler from its store dependency.
-func New(store database.ReviewStore) *Handler {
+// New constructs a review Handler. applyEnabled is the global apply gate (see the
+// field doc); pass nil to keep the queue review-only (apply handlers registered but
+// never executed).
+func New(store database.ReviewStore, applyEnabled func() bool) *Handler {
 	return &Handler{
 		store:         store,
+		applyEnabled:  applyEnabled,
 		applyHandlers: make(map[string]ApplyFunc),
 	}
+}
+
+// applyGloballyEnabled reports whether the apply "big switch" is on. A nil gate is
+// fail-safe OFF.
+func (h *Handler) applyGloballyEnabled() bool {
+	return h.applyEnabled != nil && h.applyEnabled()
 }
 
 // RegisterApplyHandler registers the apply action for a given review Kind.
@@ -166,18 +184,27 @@ func (h *Handler) approveOne(ctx context.Context, id string) (*database.ReviewIt
 	if item == nil {
 		return nil, "", nil
 	}
-	if fn, ok := h.applyHandlerFor(item.Kind); ok {
+	fn, hasHandler := h.applyHandlerFor(item.Kind)
+	if hasHandler && h.applyGloballyEnabled() {
 		if err := fn(ctx, *item); err != nil {
 			return nil, "", err
 		}
 		updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApplied)
 		return updated, "", err
 	}
+	// Either no apply handler for this Kind, OR the global apply switch is OFF
+	// (review-only mode). Record the decision as "approved" but do NOT execute — the
+	// item stays visible/reviewable and nothing is merged.
 	updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
 	if err != nil {
 		return nil, "", err
 	}
-	return updated, "no apply handler registered for kind " + item.Kind + "; marked approved", nil
+	note := "no apply handler registered for kind " + item.Kind + "; marked approved"
+	if hasHandler {
+		note = "apply is disabled (review-only mode): item approved but NOT applied — " +
+			"enable review_apply_enabled to perform the merge"
+	}
+	return updated, note, nil
 }
 
 // RejectReviewItem handles POST /api/v1/review/items/:id/reject.

--- a/internal/server/handlers/review/handler_test.go
+++ b/internal/server/handlers/review/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/review/handler_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8e4a1c72-3d95-4b60-a7f1-9c2e6b0d5f83
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 // Tests for the universal review-queue handlers. The store is exercised through
 // a REAL pebble-backed *database.PebbleStore (which implements the ReviewStore
@@ -91,7 +91,7 @@ func TestGetReviewCount(t *testing.T) {
 	seed(t, s, "regroup.multidisc", "m1")
 	seed(t, s, "regroup.multidisc", "m2")
 	seed(t, s, "regroup.anthology", "a1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	w := doReq(t, h.GetReviewCount, http.MethodGet, "/review/count", nil, nil)
 	if w.Code != http.StatusOK {
@@ -112,7 +112,7 @@ func TestListReviewItems(t *testing.T) {
 	s := newTestStore(t)
 	seed(t, s, "regroup.multidisc", "m1")
 	seed(t, s, "regroup.anthology", "a1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	// Default (pending) + kind filter.
 	w := doReq(t, h.ListReviewItems, http.MethodGet, "/review/items?kind=regroup.multidisc", nil, nil)
@@ -132,7 +132,7 @@ func TestListReviewItems(t *testing.T) {
 func TestApproveReviewItem_NoHandler_MarksApproved(t *testing.T) {
 	s := newTestStore(t)
 	it := seed(t, s, "regroup.multidisc", "m1")
-	h := reviewhandler.New(s) // no apply handlers registered (A1 state)
+	h := reviewhandler.New(s, func() bool { return true }) // no apply handlers registered (A1 state)
 
 	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
 		gin.Params{{Key: "id", Value: it.ID}})
@@ -153,7 +153,7 @@ func TestApproveReviewItem_NoHandler_MarksApproved(t *testing.T) {
 func TestApproveReviewItem_WithHandler_MarksApplied(t *testing.T) {
 	s := newTestStore(t)
 	it := seed(t, s, "regroup.multidisc", "m1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	var applied bool
 	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, item database.ReviewItem) error {
@@ -181,7 +181,7 @@ func TestApproveReviewItem_WithHandler_MarksApplied(t *testing.T) {
 func TestApproveReviewItem_HandlerError_StaysPending(t *testing.T) {
 	s := newTestStore(t)
 	it := seed(t, s, "regroup.multidisc", "m1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
 		return context.DeadlineExceeded // any apply failure
 	})
@@ -200,9 +200,63 @@ func TestApproveReviewItem_HandlerError_StaysPending(t *testing.T) {
 	}
 }
 
+// TestApproveReviewItem_ApplyGateOff_ApprovesNotApplies is the core safety test for
+// the global "big switch": with the gate OFF, approving a hold that HAS a registered
+// apply handler must record the decision as "approved" WITHOUT executing the handler
+// (nothing merges), and stay visible/reviewable.
+func TestApproveReviewItem_ApplyGateOff_ApprovesNotApplies(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	applied := false
+	h := reviewhandler.New(s, func() bool { return false }) // switch OFF
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		applied = true
+		return nil
+	})
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if applied {
+		t.Fatal("apply handler MUST NOT run while the global apply switch is off")
+	}
+	fetched, _ := s.GetReviewItem(it.ID)
+	if fetched.Status != database.ReviewStatusApproved {
+		t.Fatalf("expected status 'approved' (not applied) with switch off, got %q", fetched.Status)
+	}
+}
+
+// TestApproveReviewItem_ApplyGateOn_Applies verifies that flipping the switch ON makes
+// approve execute the registered handler and mark the item "applied".
+func TestApproveReviewItem_ApplyGateOn_Applies(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	applied := false
+	h := reviewhandler.New(s, func() bool { return true }) // switch ON
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		applied = true
+		return nil
+	})
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
+		gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !applied {
+		t.Fatal("apply handler must run when the global apply switch is on")
+	}
+	fetched, _ := s.GetReviewItem(it.ID)
+	if fetched.Status != database.ReviewStatusApplied {
+		t.Fatalf("expected status 'applied' with switch on, got %q", fetched.Status)
+	}
+}
+
 func TestApproveReviewItem_NotFound(t *testing.T) {
 	s := newTestStore(t)
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/missing/approve", nil,
 		gin.Params{{Key: "id", Value: "missing"}})
 	if w.Code != http.StatusNotFound {
@@ -213,7 +267,7 @@ func TestApproveReviewItem_NotFound(t *testing.T) {
 func TestRejectReviewItem(t *testing.T) {
 	s := newTestStore(t)
 	it := seed(t, s, "regroup.anthology", "a1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	w := doReq(t, h.RejectReviewItem, http.MethodPost, "/review/items/"+it.ID+"/reject", nil,
 		gin.Params{{Key: "id", Value: it.ID}})
@@ -231,7 +285,7 @@ func TestBulkReviewAction_RejectByKind(t *testing.T) {
 	seed(t, s, "regroup.multidisc", "m1")
 	seed(t, s, "regroup.multidisc", "m2")
 	seed(t, s, "regroup.anthology", "a1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
 		map[string]any{"action": "reject", "kind": "regroup.multidisc"}, nil)
@@ -255,7 +309,7 @@ func TestBulkReviewAction_ByIDs(t *testing.T) {
 	s := newTestStore(t)
 	a := seed(t, s, "regroup.multidisc", "m1")
 	b := seed(t, s, "regroup.multidisc", "m2")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
 		map[string]any{"action": "approve", "ids": []string{a.ID, b.ID}}, nil)
@@ -271,7 +325,7 @@ func TestBulkReviewAction_ByIDs(t *testing.T) {
 func TestBulkReviewAction_RejectsUnscoped(t *testing.T) {
 	s := newTestStore(t)
 	seed(t, s, "regroup.multidisc", "m1")
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 
 	// Neither kind nor ids → must be refused, and nothing changed.
 	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
@@ -286,7 +340,7 @@ func TestBulkReviewAction_RejectsUnscoped(t *testing.T) {
 
 func TestBulkReviewAction_InvalidAction(t *testing.T) {
 	s := newTestStore(t)
-	h := reviewhandler.New(s)
+	h := reviewhandler.New(s, func() bool { return true })
 	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
 		map[string]any{"action": "delete", "kind": "regroup.multidisc"}, nil)
 	if w.Code != http.StatusBadRequest {

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -581,7 +581,11 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// embeds database.ReviewStore. s.Store() returns the interface so a nil store
 	// stays a nil interface (the handler guards on store == nil). Apply handlers
 	// are registered later by producers (Track B2); none exist at A1.
-	reviewH := reviewhandler.New(s.Store())
+	// The global apply "big switch" (default OFF): when disabled, approving a hold
+	// records the decision but never executes its apply handler — everything stays
+	// visible in the review pane. Read at approve time so a config change takes effect
+	// without re-wiring.
+	reviewH := reviewhandler.New(s.Store(), func() bool { return config.AppConfig.ReviewApplyEnabled })
 
 	// Register the regroup APPLY handlers (PR-B2) so approving a confident hold in
 	// the review UI performs the real merge. Only the two confident kinds get a

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.18.0
+// version: 2.19.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 package server
 
@@ -10,7 +10,9 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	maintenanceplugin "github.com/falkcorp/audiobook-organizer/internal/plugins/maintenance"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	aibackendshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/aibackends"
 	audiobookshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/audiobooks"
@@ -580,6 +582,22 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// stays a nil interface (the handler guards on store == nil). Apply handlers
 	// are registered later by producers (Track B2); none exist at A1.
 	reviewH := reviewhandler.New(s.Store())
+
+	// Register the regroup APPLY handlers (PR-B2) so approving a confident hold in
+	// the review UI performs the real merge. Only the two confident kinds get a
+	// handler; anthology/ambiguous stay handler-less (approve → "approved", never
+	// auto-applied). Guarded on a real store — with a nil store the review handler
+	// short-circuits before dispatch, so the closures would never run anyway.
+	if s.Store() != nil {
+		mergeSvc := s.mergeService
+		if mergeSvc == nil {
+			mergeSvc = merge.NewService(s.Store())
+		}
+		reviewH.RegisterApplyHandler(itunesservice.KindMultidisc,
+			maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc))
+		reviewH.RegisterApplyHandler(itunesservice.KindVersionGroup,
+			maintenanceplugin.ApplyVersionGroup(s.Store()))
+	}
 
 	// ── Register protected routes via per-domain methods ─────────────────────
 	s.wireLibraryRoutes(protected, cacheH, activityH, splitBookH, filesystemH, organizeH, metaCacheH, readingH, playlistH, userH, versionsH)


### PR DESCRIPTION
## What

Turns the review queue's **Approve** from a status label-flip into a **real merge** for the two *confident* regroup kinds — closing the loop opened by B1 (the dry-run producer, #1949). Approving a hold dispatches on its `Kind` to a registered `ApplyFunc`; on a nil error the handler transitions the item to `applied`.

| Kind | Prod holds | Apply action |
|------|-----------:|--------------|
| `regroup.multidisc` | 196 | `CombineBooks(members, primary, nil)` — collapse N single-file books into 1 |
| `regroup.version-group` | 1 | shared `VersionGroupID` + one primary via re-fetch-and-patch `UpdateBook` |
| `regroup.anthology` | 8 | **handler-less** — approve → `approved`, never `applied` |
| `regroup.ambiguous` | 230 | **handler-less** — needs human sub-decisions |

## Data-loss safety (this repo's dominant incident class)

- **multidisc**: the **nil override** is load-bearing — the only `UpdateBook`-on-survivor path in `merge.Service` is gated behind a non-nil override, so with nil the survivor row is never rewritten and its `AcoustIDFingerprint` / Author / Series survive. Absorbed files move by file ID (fingerprints ride along); absorbed rows are hard-deleted (files preserved on survivor → no audio loss).
- **version-group**: re-fetch-and-patch (`GetBookByID` full row → set only `VersionGroupID`+`IsPrimaryVersion` → `UpdateBook`). **NOT `MergeBooks`** — that soft-deletes the loser, but a version group must keep **both** editions visible (locked decision #8).
- Tests assert these invariants via `dbtest.AssertStoreInvariants` — the same drift-proof guard as the Jul-13 data-loss fixes.

## Design notes

- Survivor selection is deterministic (smallest ULID = earliest-created), so retries are stable.
- Apply is **retry-tolerant**: fewer than two surviving members is an idempotent no-op, so a double-approve or re-approve after a partial failure never errors.
- Apply closures are built at wire time (where the merge service + store are in scope) and registered via `reviewH.RegisterApplyHandler`, keeping the `reviewhandler` package generic.

## ⚠️ Not auto-applied — gated

This PR only **arms** the button. Every collapse remains a **human-approved hold**; nothing auto-applies. **Merging + deploying is the gated prod-apply decision** — hold until explicitly approved.

## Test

- `go test ./internal/plugins/maintenance/ -run 'TestApply|TestPickPrimary' -race` — green (collapse + preserve-data invariants, version-group primary/both-visible, already-applied no-op, bad-payload error).
- Full touched-package suites (`maintenance`, `server`, `merge`, `review` handler) — green. gofmt/vet/staticcheck clean.

Plan: `docs/plans/2026-07-13-review-queue-and-regroup.md` (PR-B2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)