### PR TITLE
fix(regroup): multidisc classifier over-merged author/collection folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,39 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.156.0 -->
+<!-- version: 3.157.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-13 -->
+<!-- last-edited: 2026-07-14 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 14, 2026 - fix(regroup): multidisc classifier over-merged author/collection folders
+
+A prod dry-run (op `01KXGZG8…`) surfaced that **24 of 196** confident `regroup.multidisc`
+holds were over-merges: a plain **author or collection folder** of *distinct* single-file
+books was being collapsed into ONE book — e.g. `.../Terry Pratchett Discworld` (70 different
+novels → 1), `.../Clive Barker` (19), `iTunes Media/Audiobooks/<Author>` folders, and a flat
+`.../unsorted/books` dump (103 unrelated titles → 1). Approving one would have merged dozens
+of unrelated audiobooks.
+
+- **Root cause:** the flat-multitrack branch in `ClassifyShatteredFolders`
+  (`internal/itunes/service/fs_regroup_shape.go`) fired on `structure=="flat" &&
+  numberedCount*2>=n`. Most audiobook filenames carry *some* number (series #, year,
+  bitrate), so `numberedCount` alone couldn't tell 70 chapters of one book from 70 different
+  books. The existing `FlatDumpDistinctBooks_Skipped` test only used *un-numbered* files
+  (`The Hobbit.m4b`), so it never exercised this path.
+- **Fix:** the flat-multitrack branch now also requires `!manyDistinctTitles` — the same
+  distinct-title-stems signal already used as the anthology discriminator now also **vetoes**
+  a confident collapse. Author/collection folders drop to no-hold (they aren't single-book
+  candidates). Errs toward NOT grouping: a real book with per-chapter descriptive titles is
+  left shattered (recoverable) rather than distinct books merged (corruption).
+- Legit collapses are unaffected: numbered same-stem chapters (`01 - Chapter`, `Chapter NNN`,
+  disc sets) still collapse — verified incl. the 133-sequential-chapter case.
+- Test: `TestClassify_FlatNumberedDistinctBooks_NotMultidisc` reproduces the prod shape
+  (numbered distinct books in an author folder → must not be confident multidisc). Still
+  dry-run only; no book writes.
 
 #### July 13, 2026 - fix(regroup): anthology counts distinct works + fold in original iTunes album path (B1 tuning)
 

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1e7d4a92-3c85-4b60-9f21-6a8c0d5e2b47
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 // Package service — deterministic (regex-only) shape classifier for the
 // shattered-book REGROUP review producer (PR-B1).
@@ -43,6 +43,15 @@
 // N chapter files) collapse to multidisc; a marked-but-sequential folder is held as
 // ambiguous. This fixes a prod false positive that counted 133 chapter FILES of one
 // novel as 133 distinct WORKS.
+//
+// Over-merge guard (v1.2): the flat-multitrack branch now also requires
+// !manyDistinctTitles. A plain AUTHOR/COLLECTION folder of distinct single-file books
+// (e.g. `.../Terry Pratchett Discworld` = 70 different novels, or a flat
+// `.../unsorted/books` dump) is flat-and-numbered too — most audiobook filenames carry
+// SOME number — so numberedCount alone mistook 70 different books for 70 chapters of
+// one. The distinct-title-stems signal (already the anthology discriminator) now also
+// VETOES a confident collapse, dropping such folders to no-hold. A prod dry-run on
+// 2026-07-14 flagged 24 of 196 confident-multidisc holds as this over-merge shape.
 //
 // Pure function over DB-derived metadata: no I/O, fully unit-testable.
 
@@ -557,9 +566,23 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 		return build(KindMultidisc, true,
 			"collapse disc set into 1 multi-file audiobook", 0), true
 
-	case structure == "flat" && numberedCount*2 >= n && n >= flatMultitrackMin:
+	case structure == "flat" && numberedCount*2 >= n && n >= flatMultitrackMin && !manyDistinctTitles:
 		// Many members sit directly in ONE book folder and are sequentially numbered →
 		// flat multi-track collapse. The shared parent folder IS the book identity.
+		//
+		// OVER-MERGE GUARD (!manyDistinctTitles): a plain AUTHOR or COLLECTION folder
+		// holding N *distinct* single-file books (e.g. `.../Audiobooks/Terry Pratchett
+		// Discworld` = 70 different novels, or a flat `.../unsorted/books` dump) also
+		// looks flat-and-numbered — most audiobook filenames carry SOME number (series
+		// #, year, bitrate), so numberedCount alone can't tell 70 chapters of one book
+		// from 70 different books. `manyDistinctTitles` (a strong majority of members
+		// carry their OWN distinct title stem) is exactly that discriminator, and it
+		// was already the anthology signal — here we also use it to REFUSE a confident
+		// collapse. Such folders fall through to the flat-ambiguous / default cases
+		// (no confident merge). This errs toward NOT grouping: a real book with
+		// per-chapter descriptive titles is left shattered (recoverable later) rather
+		// than N distinct books being wrongly merged into one (corruption). A dry-run
+		// on 2026-07-14 flagged 24/196 confident-multidisc holds as this shape.
 		return build(KindMultidisc, true,
 			"collapse flat multi-track folder into 1 multi-file audiobook", 0), true
 

--- a/internal/itunes/service/fs_regroup_shape_test.go
+++ b/internal/itunes/service/fs_regroup_shape_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4d2a7f81-6c93-4e50-b8a1-0f5e2c9d3b76
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 package itunesservice
 
@@ -309,6 +309,32 @@ func TestClassify_FlatDumpDistinctBooks_Skipped(t *testing.T) {
 	}
 	if st.DistinctSkip != 1 {
 		t.Errorf("DistinctSkip=%d, want 1 (stats %+v)", st.DistinctSkip, st)
+	}
+}
+
+// Real prod over-merge (2026-07-14): an AUTHOR/COLLECTION folder of distinct,
+// individually-numbered single-file books looked flat-and-numbered and was wrongly
+// collapsed into ONE confident multidisc book (e.g. `.../Terry Pratchett Discworld`
+// = 70 different novels → 1). The earlier FlatDump test only used UN-numbered files
+// (numberedCount=0), so it never exercised the flat-multitrack branch; real filenames
+// carry series #/year/bitrate numbers that trip it. The distinct-title-stems guard
+// must veto the confident collapse for these.
+func TestClassify_FlatNumberedDistinctBooks_NotMultidisc(t *testing.T) {
+	base := shatterRoot + "/Terry Pratchett Discworld"
+	books := []ShatterBook{
+		sb("d1", base+"/01 - The Colour of Magic.mp3"),
+		sb("d2", base+"/02 - The Light Fantastic.mp3"),
+		sb("d3", base+"/03 - Equal Rites.mp3"),
+		sb("d4", base+"/04 - Mort.mp3"),
+		sb("d5", base+"/05 - Sourcery.mp3"),
+		sb("d6", base+"/06 - Wyrd Sisters.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	for _, g := range groups {
+		if g.Kind == KindMultidisc && g.Confident {
+			t.Fatalf("author folder of distinct numbered books must NOT be a confident "+
+				"multidisc collapse; got %+v", g)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem (found in the prod dry-run)

Inspecting the 196 `regroup.multidisc` holds the dry-run wrote, **24 were over-merges** — a plain **author/collection folder** of *distinct* single-file books collapsed into ONE:

| Distinct titles / files | Folder |
|---|---|
| 70 / 70 | `Terry Pratchett Discworld` (70 different novels) |
| 27 / 32 | `Michael Swanwick` |
| 21 / 22 | `iTunes Media/Audiobooks/Joshua Dalzelle` |
| 19 / 19 | `Clive Barker` |
| — | `.../unsorted/books` flat dump (103 unrelated titles → 1) |

Approving one of these would merge dozens of unrelated audiobooks into a single book.

## Root cause

The flat-multitrack branch in `ClassifyShatteredFolders` fired on `structure=="flat" && numberedCount*2>=n && n>=4`. Most audiobook filenames carry *some* number (series #, year, bitrate), so `numberedCount` alone can't distinguish 70 chapters of one book from 70 different books. The existing `FlatDumpDistinctBooks_Skipped` test only used **un-numbered** files, so it never caught this.

## Fix

The flat-multitrack branch now also requires **`!manyDistinctTitles`** — the distinct-title-stems signal already used to discriminate anthologies now also *vetoes* a confident collapse. Author/collection folders drop to no-hold (they aren't single-book candidates).

Errs toward **not grouping**: a real book with per-chapter descriptive titles is left harmlessly shattered (recoverable later) rather than distinct books being merged (corruption).

**Legit collapses unaffected** — numbered same-stem chapters (`01 - Chapter`, `Chapter NNN`), disc sets, and the 133-sequential-chapter case still collapse (verified).

## Test / scope

- New `TestClassify_FlatNumberedDistinctBooks_NotMultidisc` reproduces the exact prod shape.
- `go test ./internal/itunes/service/ ./internal/plugins/maintenance/` — green; gofmt/build clean.
- **Still dry-run only** — no book writes. Safe to merge + deploy; re-running `maintenance.regroup-shattered-ai` afterward stops emitting the over-merge holds.
- ⚠️ **Does NOT clean the existing queue.** The op only upserts folders it emits; it never deletes holds for folders it stops emitting. So the 24 stale over-merge holds already written (plus earlier stale-Kind-flip orphans) **remain pending** until purged. `ReviewStore` has no Delete today — purge needs either a new `DeleteReviewItem`/reconcile method or a bulk-reject pass. Tracked as a follow-up; not in this PR.

Lands **before** the B2 apply path (#1953) so the queue is clean before any approve can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
