### PR TITLE
feat(regroup): reconcile purge — self-heal superseded review holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.157.0 -->
+<!-- version: 3.157.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-14 -->
+<!-- last-edited: 2026-07-16 -->
 
 # Changelog
 
@@ -34,6 +34,28 @@ of unrelated audiobooks.
 - Test: `TestClassify_FlatNumberedDistinctBooks_NotMultidisc` reproduces the prod shape
   (numbered distinct books in an author folder → must not be confident multidisc). Still
   dry-run only; no book writes.
+#### July 14, 2026 - feat(regroup): reconcile purge — self-heal superseded review holds
+
+The regroup dry-run producer only ever UPSERTs the folders it emits — it never removed
+holds for folders it *stopped* emitting. So every classifier change left orphans in the
+review queue: a folder that flipped Kind kept its stale hold under the old Kind's dedup
+key (why the queue showed 458, not 435), and once the over-merge fix lands, the 24
+author/collection over-merge holds would linger as approvable "70 tracks → 1" rows.
+
+- **New `DeleteReviewItem(id)` on `ReviewStore`** (`internal/database/review_store.go`,
+  `iface_review.go`, mocks): removes the record + status-index + dedup-index rows;
+  idempotent. Tearing down the dedup index lets a later re-scan re-emit the folder fresh.
+- **Producer reconcile** (`internal/plugins/maintenance/regroup_shattered_ai.go`): after
+  writing holds, on a FULL run (`limit == 0`) it deletes any **pending** `regroup.*` hold
+  whose folder is not in this run's emitted set. Human-decided holds (approved/rejected/
+  applied) are always preserved; other producers' holds are never touched; a capped/canary
+  run skips reconcile (its emitted set is intentionally partial). Result line now reports
+  `stale-purged=N`.
+- Effect: after deploying the over-merge fix, one full dry-run self-heals the queue — the
+  24 stale over-merge holds and the Kind-flip orphans are removed automatically.
+- Tests: store delete round-trip (record + both indexes gone, re-upsert creates a fresh
+  row); reconcile purges superseded pending only, preserves decided/other-producer/emitted;
+  capped-run no-op.
 
 #### July 13, 2026 - fix(regroup): anthology counts distinct works + fold in original iTunes album path (B1 tuning)
 

--- a/internal/database/iface_review.go
+++ b/internal/database/iface_review.go
@@ -33,4 +33,10 @@ type ReviewStore interface {
 	// SetReviewItemStatus transitions an item to a new status, moving its
 	// status-index row. Returns (nil, nil) when the item does not exist.
 	SetReviewItemStatus(id, status string) (*ReviewItem, error)
+
+	// DeleteReviewItem removes an item and all its index rows (record, status,
+	// dedup). Idempotent — deleting a missing id is a no-op. Deleting the dedup
+	// index forgets a remembered decision, so producers must only delete PENDING
+	// items (the regroup reconcile relies on this to purge superseded holds).
+	DeleteReviewItem(id string) error
 }

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -2701,3 +2701,4 @@ func (m *MockStore) ListReviewItems(_ ReviewFilter) ([]ReviewItem, int, error) {
 func (m *MockStore) CountReviewItems(_ string) (int, error)               { return 0, nil }
 func (m *MockStore) ReviewStatsByKind() ([]ReviewKindStat, error)         { return nil, nil }
 func (m *MockStore) SetReviewItemStatus(_, _ string) (*ReviewItem, error) { return nil, nil }
+func (m *MockStore) DeleteReviewItem(_ string) error                      { return nil }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -33194,6 +33194,57 @@ func (_c *MockStore_DeleteRaw_Call) RunAndReturn(run func(key string) error) *Mo
 	return _c
 }
 
+// DeleteReviewItem provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteReviewItem(id string) error {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteReviewItem")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteReviewItem_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteReviewItem'
+type MockStore_DeleteReviewItem_Call struct {
+	*mock.Call
+}
+
+// DeleteReviewItem is a helper method to define mock.On call
+//   - id string
+func (_e *MockStore_Expecter) DeleteReviewItem(id any) *MockStore_DeleteReviewItem_Call {
+	return &MockStore_DeleteReviewItem_Call{Call: _e.mock.On("DeleteReviewItem", id)}
+}
+
+func (_c *MockStore_DeleteReviewItem_Call) Run(run func(id string)) *MockStore_DeleteReviewItem_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteReviewItem_Call) Return(err error) *MockStore_DeleteReviewItem_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteReviewItem_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteReviewItem_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteRole provides a mock function for the type MockStore
 func (_mock *MockStore) DeleteRole(id string) error {
 	ret := _mock.Called(id)

--- a/internal/database/review_store.go
+++ b/internal/database/review_store.go
@@ -457,3 +457,43 @@ func (p *PebbleStore) SetReviewItemStatus(id, status string) (*ReviewItem, error
 	}
 	return item, nil
 }
+
+// DeleteReviewItem removes a review item and ALL its index rows (record, status
+// index, dedup index). Idempotent: deleting a missing id is a no-op returning nil.
+//
+// Deleting the dedup index means a future producer re-scan of that folder can create
+// a FRESH hold — exactly what the regroup reconcile wants for a hold whose folder is
+// no longer a candidate. Because this forgets a remembered decision, callers that
+// must PRESERVE one (rejected-is-remembered) must only delete PENDING items; the
+// regroup reconcile enforces that.
+func (p *PebbleStore) DeleteReviewItem(id string) error {
+	// Serialize against UpsertReviewItem, which reads the dedup index to decide
+	// create-vs-update: deleting that index concurrently could let a duplicate slip
+	// in. Same mutex, same reason as Upsert.
+	p.reviewMu.Lock()
+	defer p.reviewMu.Unlock()
+
+	item, err := p.getReviewItem(id)
+	if err != nil {
+		return err
+	}
+	if item == nil {
+		return nil // idempotent no-op
+	}
+	b := p.db.NewBatch()
+	defer b.Close()
+	if err := b.Delete(reviewItemRecKey(id), nil); err != nil {
+		return err
+	}
+	if item.Status != "" {
+		if err := b.Delete(reviewItemStatusKey(item.Status, id), nil); err != nil {
+			return err
+		}
+	}
+	if item.DedupKey != "" {
+		if err := b.Delete(reviewItemDedupIdxKey(item.DedupKey), nil); err != nil {
+			return err
+		}
+	}
+	return b.Commit(pebble.Sync)
+}

--- a/internal/database/review_store_test.go
+++ b/internal/database/review_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/review_store_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9d3b7f21-4a58-4c69-b8e2-1f0a6c5d4e37
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 package database
 
@@ -27,6 +27,47 @@ func mkReviewItem(kind, dedupKey, folder, summary, payload string) ReviewItem {
 		FolderRef: folder,
 		Summary:   summary,
 		Payload:   payload,
+	}
+}
+
+func TestDeleteReviewItem_RemovesRecordAndAllIndexes(t *testing.T) {
+	s := newReviewTestStore(t)
+	it, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", "dk-del", "/books/a", "sum", `{}`))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := s.DeleteReviewItem(it.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Record gone.
+	if got, _ := s.GetReviewItem(it.ID); got != nil {
+		t.Fatalf("expected item gone after delete, got %+v", got)
+	}
+	// Status index gone → pending count is 0.
+	if n, _ := s.CountReviewItems(ReviewStatusPending); n != 0 {
+		t.Fatalf("expected 0 pending after delete, got %d", n)
+	}
+	// Dedup index gone → re-upserting the same DedupKey creates a FRESH row (a new
+	// ID), not an update of the deleted one. This is what lets the regroup reconcile
+	// safely purge-then-re-emit.
+	again, err := s.UpsertReviewItem(mkReviewItem("regroup.multidisc", "dk-del", "/books/a", "sum2", `{}`))
+	if err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	if again.ID == it.ID {
+		t.Fatal("expected a fresh ID after delete+re-upsert (dedup index must have been torn down)")
+	}
+	if again.Status != ReviewStatusPending {
+		t.Fatalf("re-upserted item should be pending, got %q", again.Status)
+	}
+}
+
+func TestDeleteReviewItem_MissingIsNoOp(t *testing.T) {
+	s := newReviewTestStore(t)
+	if err := s.DeleteReviewItem("does-not-exist"); err != nil {
+		t.Fatalf("deleting a missing id must be a no-op, got %v", err)
 	}
 }
 

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_shattered_ai.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8b3e6d21-4f97-4c05-a1d8-2e7b9c0f5a63
-// last-edited: 2026-07-13
+// last-edited: 2026-07-14
 
 // Package maintenance — op maintenance.regroup-shattered-ai (PR-B1).
 //
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -214,15 +215,74 @@ func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage,
 		}
 	}
 
+	// RECONCILE-PURGE: delete PENDING regroup holds whose folder is no longer a
+	// candidate this run — a folder that flipped Kind (leaving an orphan under the old
+	// Kind's DedupKey) or one the tuned classifier stopped emitting entirely (e.g. an
+	// author/collection folder that used to over-merge). UpsertReviewItem only ever
+	// UPSERTs folders it emits, so without this a superseded hold lingers in the queue
+	// forever. Only PENDING holds are purged — a human decision (approved/rejected/
+	// applied) is always preserved. Skipped on a capped/canary run (Limit > 0), where
+	// the emitted set is intentionally partial and would wrongly purge the remainder.
+	purged := reconcileStaleHolds(ctx, store, reporter, groups, params.Limit)
+
 	result := fmt.Sprintf(
-		"DRY RUN — review holds written=%d (already-decided=%d, write-errors=%d) from %d detected groups; library untouched. bykind=%v",
-		written, alreadyDecided, writeErrs, len(groups), st.ByKind)
+		"DRY RUN — review holds written=%d (already-decided=%d, write-errors=%d, stale-purged=%d) from %d detected groups; library untouched. bykind=%v",
+		written, alreadyDecided, writeErrs, purged, len(groups), st.ByKind)
 	_ = reporter.Log(slog.LevelInfo, result)
 	_ = reporter.UpdateProgress(len(ids)+1, len(ids)+1, result)
 	if writeErrs > 0 {
 		return fmt.Errorf("%d review-hold write errors during regroup dry-run (see op log)", writeErrs)
 	}
 	return nil
+}
+
+// reconcileScanLimit bounds the pending-holds fetch during reconcile. Comfortably
+// exceeds any realistic regroup hold population (intentional holds only).
+const reconcileScanLimit = 100_000
+
+// reconcileStaleHolds deletes PENDING regroup.* holds whose DedupKey is not in the set
+// this run emitted, returning the number purged. Returns 0 (a no-op) when limit > 0 (a
+// canary run emits only a subset, so purging the rest would be wrong). It never touches
+// non-regroup holds (another producer's rows) or human-decided holds. Sequential by
+// design: the pending-hold count is bounded (intentional holds only), each delete is a
+// cheap local Pebble write, and DeleteReviewItem/UpsertReviewItem share one mutex, so a
+// worker pool would only add contention.
+func reconcileStaleHolds(ctx context.Context, store database.Store, reporter sdk.Reporter, groups []itunesservice.RegroupGroup, limit int) int {
+	if limit > 0 {
+		return 0
+	}
+	emitted := make(map[string]struct{}, len(groups))
+	for i := range groups {
+		emitted[regroupDedupKey(groups[i].Kind, groups[i].FolderRef)] = struct{}{}
+	}
+	pending, _, err := store.ListReviewItems(database.ReviewFilter{
+		Status: database.ReviewStatusPending,
+		Limit:  reconcileScanLimit,
+	})
+	if err != nil {
+		_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("reconcile: list pending review items: %v", err))
+		return 0
+	}
+	purged := 0
+	for _, it := range pending {
+		if ctx.Err() != nil {
+			break
+		}
+		if !strings.HasPrefix(it.Kind, "regroup.") {
+			continue // never purge another producer's holds
+		}
+		if _, ok := emitted[it.DedupKey]; ok {
+			continue // still a candidate this run
+		}
+		if derr := store.DeleteReviewItem(it.ID); derr != nil {
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("reconcile: delete stale hold %s (%s): %v", it.ID, it.FolderRef, derr))
+			continue
+		}
+		purged++
+	}
+	_ = reporter.Log(slog.LevelInfo,
+		fmt.Sprintf("RECONCILE-PURGE: deleted %d superseded pending regroup holds (folder no longer emitted)", purged))
+	return purged
 }
 
 // regroupDedupKey is the STABLE upsert target: a hash of (Kind, FolderRef). Re-running

--- a/internal/plugins/maintenance/regroup_shattered_ai_test.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 )
 
 // seedShatterBook creates a single-file book at a chapter-shatter path so the dry-run
@@ -160,5 +161,93 @@ func TestRegroupShatteredAI_DryRun_PreservesDecision(t *testing.T) {
 	}
 	if after[0].Status != database.ReviewStatusRejected {
 		t.Errorf("re-scan resurfaced a rejected hold: status=%q", after[0].Status)
+	}
+}
+
+// seedHold writes one pending review hold directly (bypassing the scan) so reconcile
+// tests can set up a queue state precisely.
+func seedHold(t *testing.T, s *database.PebbleStore, kind, dedupKey, folder string) database.ReviewItem {
+	t.Helper()
+	it, err := s.UpsertReviewItem(database.ReviewItem{
+		Kind: kind, DedupKey: dedupKey, FolderRef: folder, Summary: "s", Payload: "{}",
+	})
+	if err != nil {
+		t.Fatalf("seedHold: %v", err)
+	}
+	return it
+}
+
+// remainingKeys returns the set of DedupKeys still present across all statuses.
+func remainingKeys(t *testing.T, s *database.PebbleStore) map[string]bool {
+	t.Helper()
+	items, _, err := s.ListReviewItems(database.ReviewFilter{Limit: 1000})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	keys := map[string]bool{}
+	for _, it := range items {
+		keys[it.DedupKey] = true
+	}
+	return keys
+}
+
+// TestReconcileStaleHolds_PurgesSupersededPendingOnly: a full run deletes PENDING
+// regroup holds whose folder is no longer emitted, while preserving emitted holds,
+// human-decided (rejected) holds, and another producer's (non-regroup) holds.
+func TestReconcileStaleHolds_PurgesSupersededPendingOnly(t *testing.T) {
+	s := regroupStore(t)
+
+	emittedKey := regroupDedupKey(itunesservice.KindMultidisc, "/books/keep")
+	seedHold(t, s, itunesservice.KindMultidisc, emittedKey, "/books/keep")
+
+	staleKey := regroupDedupKey(itunesservice.KindAnthology, "/books/stale")
+	seedHold(t, s, itunesservice.KindAnthology, staleKey, "/books/stale")
+
+	rejKey := regroupDedupKey(itunesservice.KindMultidisc, "/books/rej")
+	rej := seedHold(t, s, itunesservice.KindMultidisc, rejKey, "/books/rej")
+	if _, err := s.SetReviewItemStatus(rej.ID, database.ReviewStatusRejected); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	// A different producer's pending hold — must never be purged by the regroup reconcile.
+	seedHold(t, s, "dedup.candidate", "dedup-key-1", "/books/dedup")
+
+	// This run emits only the "keep" folder.
+	groups := []itunesservice.RegroupGroup{
+		{Kind: itunesservice.KindMultidisc, FolderRef: "/books/keep"},
+	}
+	purged := reconcileStaleHolds(context.Background(), s, &fakeReporter{}, groups, 0)
+	if purged != 1 {
+		t.Fatalf("expected exactly 1 stale hold purged, got %d", purged)
+	}
+
+	keys := remainingKeys(t, s)
+	if !keys[emittedKey] {
+		t.Error("emitted hold was wrongly purged")
+	}
+	if keys[staleKey] {
+		t.Error("stale pending regroup hold was NOT purged")
+	}
+	if !keys[rejKey] {
+		t.Error("human-decided (rejected) hold was wrongly purged — only PENDING may be purged")
+	}
+	if !keys["dedup-key-1"] {
+		t.Error("another producer's hold was wrongly purged — reconcile must only touch regroup.*")
+	}
+}
+
+// TestReconcileStaleHolds_SkippedOnCappedRun: a canary run (limit > 0) emits only a
+// subset, so reconcile must be a no-op rather than purging the un-emitted remainder.
+func TestReconcileStaleHolds_SkippedOnCappedRun(t *testing.T) {
+	s := regroupStore(t)
+	staleKey := regroupDedupKey(itunesservice.KindMultidisc, "/books/x")
+	seedHold(t, s, itunesservice.KindMultidisc, staleKey, "/books/x")
+
+	purged := reconcileStaleHolds(context.Background(), s, &fakeReporter{}, nil, 5) // limit > 0
+	if purged != 0 {
+		t.Fatalf("capped run must not purge, got %d", purged)
+	}
+	if n, _ := s.CountReviewItems(""); n != 1 {
+		t.Fatalf("hold must remain after a capped run, got %d", n)
 	}
 }


### PR DESCRIPTION
## Problem

The regroup dry-run producer only ever **UPSERTs** the folders it emits — it never removed holds for folders it *stopped* emitting. So every classifier change leaves orphans in the review queue:
- A folder that **flips Kind** keeps its stale hold under the old Kind's dedup key (this is why the prod queue showed **458**, not 435 — leftover anthology/Kind-flip orphans).
- Once the over-merge classifier fix (#1954) lands, the **24 author/collection over-merge holds** would linger as approvable "Multi-disc: 70 tracks → 1" rows.

The review queue had **no delete** — only status changes — so there was no way to clean them.

## Change

- **`DeleteReviewItem(id)` on `ReviewStore`** (`review_store.go`, `iface_review.go`, both mocks): removes the record + status-index + dedup-index rows; idempotent. Tearing down the dedup index lets a later re-scan re-emit the folder fresh. Mocks regenerated via the pinned **mockery v3.7.1** (`make mocks`), not hand-edited — `make mocks-check` is green.
- **Producer reconcile** (`regroup_shattered_ai.go`): after writing holds, on a **full run** (`limit == 0`) it deletes any **pending** `regroup.*` hold whose folder is not in this run's emitted set. Guarantees:
  - Human-decided holds (`approved`/`rejected`/`applied`) are **always preserved** — only pending is purged.
  - Other producers' holds are **never touched** (`regroup.` prefix guard).
  - A capped/canary run (`limit > 0`) **skips** reconcile — its emitted set is intentionally partial.
  - Result line now reports `stale-purged=N`.

**Effect:** after deploying the over-merge fix, **one full dry-run self-heals the queue** — the 24 stale over-merge holds and the Kind-flip orphans are removed automatically. No manual bulk-reject needed.

## Test

- `TestDeleteReviewItem_RemovesRecordAndAllIndexes` (record + status + dedup index gone; re-upsert makes a fresh row) + `_MissingIsNoOp`.
- `TestReconcileStaleHolds_PurgesSupersededPendingOnly` (purges stale pending; preserves emitted, rejected/decided, and another producer's holds) + `_SkippedOnCappedRun`.
- `go test ./internal/database/ ./internal/plugins/maintenance/` green; `go vet`, `gofmt`, `make mocks-check` clean.

Pairs with **#1954** (the over-merge classifier fix): deploy both, then re-run `maintenance.regroup-shattered-ai` once for a clean queue. Still dry-run only — no book writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)