### PR TITLE
fix(ci): widen local mocks-check glob to catch nested mocks dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.158.0 -->
+<!-- version: 3.158.1 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(ci): widen local mocks-check glob to catch nested mocks dirs (MOCK-FRESHNESS-GLOB-GAP)
+
+The Makefile `mocks-check` target diffed only `internal/*/mocks/` — a shell glob that
+matches exactly one directory level. It silently **missed all 8 nested mocks dirs** under
+`internal/server/handlers/**/mocks/` (audiobooks, dedup, duplicates, entities, metadata,
+operations, system, and the handlers-root mocks). A stale mock in any of those — e.g. the
+dir holding `mock_dedup_engine.go`, stale from #1736 until hand-regenerated in #1757 —
+passed `make mocks-check` locally while the real CI gate (`ci.yml`, which already used
+`:(glob)internal/**/mocks/**`) failed. Devs got a false green.
+
+- **Fix:** the Makefile target now uses the same recursive git pathspec as CI,
+  `:(glob)internal/**/mocks/**`, restoring local/CI parity.
+- Verified empirically: with the old glob a modified `internal/server/handlers/mocks/…`
+  file left `mocks-check` reporting clean (false pass); with the new glob the same change
+  is caught. `make mocks-check` still passes clean on fresh mocks.
 
 #### July 14, 2026 - fix(regroup): multidisc classifier over-merged author/collection folders
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.15.2
+# version: 2.15.3
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-07-03
+# last-edited: 2026-07-16
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -209,9 +209,9 @@ mocks:
 mocks-check:
 	@echo "🎭 Checking that committed mocks are up to date..."
 	@mockery --log-level warn
-	@if ! git diff --quiet -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; then \
+	@if ! git diff --quiet -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; then \
 		echo "❌ Committed mocks are stale. Run 'make mocks' and commit the result."; \
-		git diff --stat -- internal/*/mocks/ internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; \
+		git diff --stat -- ':(glob)internal/**/mocks/**' internal/ai/mock_*_test.go internal/metadata/mock_*_test.go; \
 		exit 1; \
 	fi
 	@echo "✅ Mocks are up to date"

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.0 -->
+<!-- version: 9.106.1 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-14 -->
+<!-- last-edited: 2026-07-16 -->
 
 # Project TODO
 
@@ -1803,9 +1803,12 @@ must sequence, but A and B are parallelizable. Spawn:
   review — migration014UpPebble (Pebble corrupted-path migration not dispatched), deluge
   importToLibrary (server shim points at a non-existent `deluge.ImportToLibrary`), rewriteChunksBE
   (BE ITL write-back not hooked into the write path).
-- [ ] **MOCK-FRESHNESS-GLOB-GAP** (2026-07-03) — the Mock Freshness CI gate's `internal/*/mocks/`
-  glob misses nested mocks dirs (e.g. the dir holding `mock_dedup_engine.go`, stale since #1736
-  until hand-regenerated in #1757). Widen the glob to `internal/**/mocks/`.
+- [x] **MOCK-FRESHNESS-GLOB-GAP** (2026-07-03) — ✅ **FIXED 2026-07-16** (branch
+  `fix/mock-freshness-glob-gap`). CI's `ci.yml` gate already used the recursive
+  `:(glob)internal/**/mocks/**` pathspec; only the local Makefile `mocks-check` target
+  still used the one-level `internal/*/mocks/` glob, missing all 8
+  `internal/server/handlers/**/mocks/` dirs. Brought the Makefile to parity with CI.
+  Verified: old glob false-passes a modified nested mock, new glob catches it.
 - [x] **PEBBLE-CLOSED-SHUTDOWN-RACE** (2026-07-01, found during the agent-task sweep) — ✅ **FIXED
   2026-07-02** (branch `fix/pebble-shutdown-race`). **Root cause was NOT `SweepTick`** as the
   original entry guessed — that path was already enrolled in `goroutineWG` and drained by


### PR DESCRIPTION
## Problem

The Makefile `mocks-check` target diffed only `internal/*/mocks/` — a shell glob matching exactly **one** directory level. It silently missed all **8 nested mocks dirs** under `internal/server/handlers/**/mocks/` (audiobooks, dedup, duplicates, entities, metadata, operations, system, and the handlers-root mocks).

Result: a stale mock in any of those dirs — e.g. the one holding `mock_dedup_engine.go`, stale from #1736 until hand-regenerated in #1757 — **passed `make mocks-check` locally** while the real CI gate (`ci.yml`, which already used `:(glob)internal/**/mocks/**`) failed. Devs got a false green from the local gate.

## Fix

The Makefile target now uses the same recursive git pathspec as CI: `:(glob)internal/**/mocks/**`. Local `make ci` / `make mocks-check` is now at parity with the CI gate.

## Verification

Empirically proven (not just syntax-checked):
- With the **old** glob, modifying `internal/server/handlers/mocks/mock_plugin_registrar.go` left `mocks-check` reporting clean → **false pass**.
- With the **new** pathspec, the same change is **caught**.
- `make mocks-check` still passes clean on the current (fresh) mocks.

Closes #1797 (MOCK-FRESHNESS-GLOB-GAP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)