### PR TITLE
fix(apply-paths): harden two silent-failure guards against data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.159.0 -->
+<!-- version: 3.160.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(apply-paths): harden two silent-failure guards against data loss
+
+Two error-swallowing sites in destructive apply paths, found via a read-only
+silent-failure bug hunt and verified against source:
+
+- **iTunes regroup delete guard now fails CLOSED** (`internal/plugins/maintenance/itunes_regroup.go`).
+  The projected-empty-book delete guard read `files, _ := store.GetBookFiles(id)` and
+  `exts, _ := store.GetExternalIDsForBook(id)`, discarding both errors. On a transient
+  read error the slices were a misleading `nil` (len 0), so the guard `len(files)!=0 ||
+  len(exts)!=0` passed and `DeleteBook` ran on a book whose emptiness was never proven —
+  potentially deleting one that still owned files or iTunes PID ext-ids. The guard now
+  captures both errors and skips the delete (counts it as skipped) when either read fails.
+  Regression test drives the read-error branch and asserts the book survives.
+- **Combine author override no longer silently dropped** (`internal/merge/service.go`).
+  The user-supplied author override wrote via `_ = SetBookAuthors(...)` / `_, _ =
+  UpdateBook(...)`, so a failed write discarded the user's explicit choice while Combine
+  still reported success. Both now `slog.Warn` on error, matching the sibling title/narrator
+  override path. Behavior on the success path is unchanged.
+
+Executive summary: `docs/executive-summaries/2026-07-16-apply-path-guard-hardening-executive-summary.md`.
 
 #### July 16, 2026 - fix(ci): widen local mocks-check glob to catch nested mocks dirs (MOCK-FRESHNESS-GLOB-GAP)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1737,6 +1737,20 @@ must sequence, but A and B are parallelizable. Spawn:
 
 ## 🐛 Open Bugs — May 17, 2026
 
+- [x] **APPLY-GUARD-ITUNES-REGROUP-FAILOPEN** (2026-07-16, silent-failure hunt) — ✅ **FIXED
+  2026-07-16** (branch `fix/harden-apply-path-guards`). `itunes_regroup.go` delete guard read
+  `files, _ :=`/`exts, _ :=` and fell open on a read error (nil→len 0→delete a possibly-non-empty
+  book). Now fails closed: any read error → skip delete. Regression test drives the error branch.
+- [x] **APPLY-GUARD-COMBINE-AUTHOR-OVERRIDE** (2026-07-16, silent-failure hunt) — ✅ **FIXED
+  2026-07-16** (same branch). `merge/service.go` Combine dropped the user's author override via
+  `_ = SetBookAuthors`/`_,_ = UpdateBook`; now `slog.Warn`s on error like the sibling title path.
+- [ ] **APPLY-GUARD-AI-AUTHOR-MERGE-DELETE** (2026-07-16, silent-failure hunt) — the AI author
+  merge/alias apply (`internal/server/ai_ops.go` `RegisterAIAuthorMergeApplyOp`) calls
+  `DeleteAuthor(mergeID)` unconditionally even when a book's `SetBookAuthors` reassignment failed
+  → dangling author reference / lost attribution. FIX (follow-up PR): track per-mergeID reassign
+  success (incl. the `GetBookAuthors` continue), skip `DeleteAuthor` if any book failed. Needs a
+  test seam — the apply is an inline op closure; extract a testable `reassignBooksAuthor` helper.
+
 - [x] **SPLITBOOK-MERGE-ORPHAN** (2026-07-16, found via silent-failure bug hunt) — ✅ **FIXED
   2026-07-16** (branch `fix/splitbook-merge-orphan`). `MergeSplitBookCluster`
   (`internal/dedup/split_book_merge.go`) soft-deleted **every** source book in Step 4, including

--- a/docs/executive-summaries/2026-07-16-apply-path-guard-hardening-executive-summary.md
+++ b/docs/executive-summaries/2026-07-16-apply-path-guard-hardening-executive-summary.md
@@ -1,0 +1,33 @@
+<!-- file: docs/executive-summaries/2026-07-16-apply-path-guard-hardening-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2a8f1e64-5c37-4b90-a1d6-9e30f7b5c8a4 -->
+<!-- last-edited: 2026-07-16 -->
+
+# Executive Summary: Closing Two Quiet Failure Gaps in Cleanup Actions
+
+## What changed
+
+When the app tidies up the library — merging duplicate iTunes entries, or combining
+several entries into one — it sometimes deletes an entry or writes new information. We
+found two places where, if a small internal read or write failed at the wrong moment,
+the app carried on as if nothing had gone wrong.
+
+- **Deleting a "now-empty" entry.** Before removing an entry the iTunes cleanup checks
+  that it truly has no files and no leftover iTunes links. If that check itself failed to
+  read — a momentary storage hiccup — the app treated the missing answer as "nothing
+  there" and deleted the entry anyway. It could have removed an entry that still had
+  audio or links attached. The check now treats an unreadable answer as "don't delete,"
+  so it errs on the side of keeping things.
+- **Losing a chosen author.** When you combine entries and type in the correct author,
+  that choice is saved. If saving it failed, the app said "combined" anyway and the
+  author you picked quietly vanished. It now records a warning when that save fails, so
+  the loss is visible instead of silent.
+
+## Why it mattered
+
+Both are quiet-failure paths: no error was shown, so a rare storage or write hiccup could
+have deleted an entry that wasn't really empty, or discarded a metadata choice, with
+nothing in the interface to signal it. Neither erases audio from disk. The fixes make the
+delete refuse to run when it can't confirm the entry is safe to remove, and make the
+dropped-author case log a warning instead of passing silently. The delete-guard fix ships
+with a test that simulates the failed check and confirms the entry is kept.

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,7 +1,7 @@
 // file: internal/merge/service.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
-// last-edited: 2026-07-13
+// last-edited: 2026-07-16
 
 package merge
 
@@ -377,13 +377,20 @@ func (ms *Service) CombineBooks(bookIDs []string, primaryID string, override *Co
 				author, err = ms.db.CreateAuthor(override.Author)
 			}
 			if err == nil && author != nil {
-				_ = ms.db.SetBookAuthors(primaryID, []database.BookAuthor{
+				// Surface failures instead of swallowing them: a dropped write here
+				// silently discards the user's explicit author choice while Combine
+				// still reports success (matches the sibling title/narrator path above).
+				if saErr := ms.db.SetBookAuthors(primaryID, []database.BookAuthor{
 					{BookID: primaryID, AuthorID: author.ID, Role: "author", Position: 0},
-				})
+				}); saErr != nil {
+					slog.Warn("combine override SetBookAuthors", "id", primaryID, "author", override.Author, "err", saErr)
+				}
 				// Also set AuthorID on the book row for backward compat.
 				if b, err2 := ms.db.GetBookByID(primaryID); err2 == nil && b != nil {
 					b.AuthorID = &author.ID
-					_, _ = ms.db.UpdateBook(b.ID, b)
+					if _, ubErr := ms.db.UpdateBook(b.ID, b); ubErr != nil {
+						slog.Warn("combine override author UpdateBook", "id", b.ID, "err", ubErr)
+					}
 				}
 			}
 			if err != nil {

--- a/internal/plugins/maintenance/itunes_regroup.go
+++ b/internal/plugins/maintenance/itunes_regroup.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/itunes_regroup.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 package maintenance
 
@@ -298,8 +298,17 @@ func (p *Plugin) applyRegroupPlan(ctx context.Context, store database.Store, pla
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		files, _ := store.GetBookFiles(id)
-		exts, _ := store.GetExternalIDsForBook(id)
+		files, ferr := store.GetBookFiles(id)
+		exts, eerr := store.GetExternalIDsForBook(id)
+		// Fail CLOSED: if either read errored we cannot prove the book is empty,
+		// so both slices may be a misleading nil (len 0). Skip the delete rather
+		// than risk removing a book that still owns files or iTunes PID ext-ids —
+		// the exact canary this guard exists to prevent.
+		if ferr != nil || eerr != nil {
+			deleteSkipped++
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("skip delete %s: could not verify empty (files err=%v, ext-ids err=%v)", id, ferr, eerr))
+			continue
+		}
 		if len(files) != 0 || len(exts) != 0 {
 			deleteSkipped++
 			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("skip delete %s: %d files, %d ext-ids remain", id, len(files), len(exts)))

--- a/internal/plugins/maintenance/itunes_regroup_test.go
+++ b/internal/plugins/maintenance/itunes_regroup_test.go
@@ -1,17 +1,32 @@
 // file: internal/plugins/maintenance/itunes_regroup_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-03
+// last-edited: 2026-07-16
 
 package maintenance
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 )
+
+// errExtIDStore wraps a Store and makes GetExternalIDsForBook error for one book
+// ID, so a test can drive the delete guard's "read failed" branch.
+type errExtIDStore struct {
+	database.Store
+	failID string
+}
+
+func (e *errExtIDStore) GetExternalIDsForBook(bookID string) ([]database.ExternalIDMapping, error) {
+	if bookID == e.failID {
+		return nil, fmt.Errorf("simulated ext-id read error")
+	}
+	return e.Store.GetExternalIDsForBook(bookID)
+}
 
 func regroupStore(t *testing.T) *database.PebbleStore {
 	t.Helper()
@@ -125,5 +140,41 @@ func TestITunesRegroupApply_DeleteGuardSkipsResidualExtID(t *testing.T) {
 	// b2 still has the residual mapping → must NOT have been deleted.
 	if b, _ := s.GetBookByID(b2); b == nil {
 		t.Fatalf("b2 deleted despite residual ext-id (guard failed)")
+	}
+}
+
+// The delete guard must fail CLOSED: if the ext-id (or file) read errors, the
+// book's emptiness can't be proven, so it must be skipped rather than deleted.
+// Without the fix, `exts, _ :=` swallowed the error → nil slice (len 0) → the
+// guard passed and DeleteBook ran on an unverifiable book.
+func TestITunesRegroupApply_DeleteGuardFailsClosedOnReadError(t *testing.T) {
+	s := regroupStore(t)
+	b1 := seedBook(t, s, "Frag A")
+	b2 := seedBook(t, s, "Frag B")
+	seedFilePID(t, s, b1, "p1")
+	seedFilePID(t, s, b2, "p2")
+
+	p := &Plugin{}
+	rep := &fakeReporter{}
+	groups := []itunesservice.HealGroup{{Title: "Merged Book", PIDs: []string{"p1", "p2"}}}
+	snap, _ := p.buildRegroupSnapshot(context.Background(), s, rep)
+	plan := itunesservice.PlanRegroup(groups, snap)
+
+	survivor := plan.Groups[0].Target
+	loser := b1
+	if survivor == b1 {
+		loser = b2
+	}
+
+	// Wrap so the delete-guard's ext-id read for the loser errors. The merge
+	// phase does not call GetExternalIDsForBook, so only the guard is affected.
+	wrapped := &errExtIDStore{Store: s, failID: loser}
+	if err := p.applyRegroupPlan(context.Background(), wrapped, plan, rep); err != nil {
+		t.Fatalf("applyRegroupPlan: %v", err)
+	}
+
+	// Fail-closed: the loser must survive because its emptiness could not be verified.
+	if b, _ := s.GetBookByID(loser); b == nil {
+		t.Fatalf("loser %s deleted despite ext-id read error (guard failed open)", loser)
 	}
 }


### PR DESCRIPTION
Two error-swallowing sites in destructive apply paths, found via a read-only silent-failure bug hunt and **verified against source** before fixing.

## 1. iTunes regroup delete guard — now fails CLOSED

`internal/plugins/maintenance/itunes_regroup.go`. The projected-empty-book delete guard read:
```go
files, _ := store.GetBookFiles(id)
exts, _  := store.GetExternalIDsForBook(id)
if len(files) != 0 || len(exts) != 0 { skip }
```
On a transient read error the discarded error left a `nil` (len 0) slice, so the guard passed and `DeleteBook` ran on a book whose emptiness was never proven — potentially deleting one that still owned files or iTunes PID ext-ids (the exact canary this guard exists to prevent).

**Fix:** capture both errors; if either read fails, treat the book as not-provably-empty and skip the delete (counted as skipped).

**Test:** `TestITunesRegroupApply_DeleteGuardFailsClosedOnReadError` wraps the store so the delete-target's ext-id read errors and asserts the book is **not** deleted. Fails without the fix.

## 2. Combine author override — no longer silently dropped

`internal/merge/service.go`. The user-supplied author override wrote via `_ = SetBookAuthors(...)` / `_, _ = UpdateBook(...)`, so a failed write discarded the user's explicit author choice while `Combine` still reported success.

**Fix:** both now `slog.Warn` on error, matching the sibling title/narrator override path. **Success-path behavior is byte-identical** (logging-only change on the error branch), so existing combine tests cover it.

## Follow-up (logged in TODO, not in this PR)

`ai_ops.go` `RegisterAIAuthorMergeApplyOp` calls `DeleteAuthor(mergeID)` even when a book's reassignment failed → dangling author reference. It's an inline op closure with no test seam; the fix needs a small helper extraction, so it's tracked as `APPLY-GUARD-AI-AUTHOR-MERGE-DELETE` for a focused follow-up PR.

## Verification
`go build ./...`, `go vet`, and full `internal/merge` + `internal/plugins/maintenance` suites green.

Executive summary: `docs/executive-summaries/2026-07-16-apply-path-guard-hardening-executive-summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)