### PR TITLE
fix(ai): author merge/alias no longer deletes an author whose books failed to reassign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.160.0 -->
+<!-- version: 3.161.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,26 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(ai): author merge/alias no longer deletes an author whose books failed to reassign
+
+Completes the apply-path guard hardening. The AI author-review apply
+(`internal/server/ai_ops.go`, `RegisterAIAuthorMergeApplyOp`) — both the `merge`
+and `alias` actions — re-points every book crediting a variant author onto the
+canonical author, then deletes the variant. The delete ran **unconditionally**:
+a book whose `SetBookAuthors` reassignment failed (or whose `GetBookAuthors` read
+failed and was silently `continue`d) still credited the variant, which was then
+deleted anyway → a **dangling `BookAuthor` row** / lost author attribution.
+
+- **Fix:** the per-book reassignment loop (duplicated in both actions) is extracted
+  into a testable `reassignBooksFromAuthor` helper that returns per-book errors. The
+  variant author is deleted **only** when that result is empty (every book re-pointed);
+  otherwise the delete is skipped and the failure is reported. A previously-silent
+  `GetBookAuthors` read error now also blocks the delete.
+- Tests (`ai_author_reassign_test.go`): all-succeed re-points both books; a
+  `SetBookAuthors` failure, a `GetBookAuthors` read failure, and a book-list failure
+  each block the delete; a book already crediting the canonical author has the variant
+  credit de-duplicated (remap logic preserved).
 
 #### July 16, 2026 - fix(apply-paths): harden two silent-failure guards against data loss
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.2 -->
+<!-- version: 9.106.3 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1744,12 +1744,13 @@ must sequence, but A and B are parallelizable. Spawn:
 - [x] **APPLY-GUARD-COMBINE-AUTHOR-OVERRIDE** (2026-07-16, silent-failure hunt) — ✅ **FIXED
   2026-07-16** (same branch). `merge/service.go` Combine dropped the user's author override via
   `_ = SetBookAuthors`/`_,_ = UpdateBook`; now `slog.Warn`s on error like the sibling title path.
-- [ ] **APPLY-GUARD-AI-AUTHOR-MERGE-DELETE** (2026-07-16, silent-failure hunt) — the AI author
-  merge/alias apply (`internal/server/ai_ops.go` `RegisterAIAuthorMergeApplyOp`) calls
-  `DeleteAuthor(mergeID)` unconditionally even when a book's `SetBookAuthors` reassignment failed
-  → dangling author reference / lost attribution. FIX (follow-up PR): track per-mergeID reassign
-  success (incl. the `GetBookAuthors` continue), skip `DeleteAuthor` if any book failed. Needs a
-  test seam — the apply is an inline op closure; extract a testable `reassignBooksAuthor` helper.
+- [x] **APPLY-GUARD-AI-AUTHOR-MERGE-DELETE** (2026-07-16, silent-failure hunt) — ✅ **FIXED
+  2026-07-16** (branch `fix/ai-author-merge-delete-guard`). Extracted the duplicated per-book
+  reassignment loop (merge + alias cases in `internal/server/ai_ops.go`) into a testable
+  `reassignBooksFromAuthor` helper (`ai_author_reassign.go`) returning per-book errors; the variant
+  `DeleteAuthor` now runs only when that result is empty. A previously-silent `GetBookAuthors` read
+  error now also blocks the delete. Tests in `ai_author_reassign_test.go` cover all-succeed, set
+  failure, authors-read failure, book-list failure, and the already-credits-keep dedup path.
 
 - [x] **SPLITBOOK-MERGE-ORPHAN** (2026-07-16, found via silent-failure bug hunt) — ✅ **FIXED
   2026-07-16** (branch `fix/splitbook-merge-orphan`). `MergeSplitBookCluster`

--- a/internal/server/ai_author_reassign.go
+++ b/internal/server/ai_author_reassign.go
@@ -1,0 +1,72 @@
+// file: internal/server/ai_author_reassign.go
+// version: 1.0.0
+// guid: 4e8c1b53-9a27-4d60-bf14-7c9e0a35d2f1
+// last-edited: 2026-07-16
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// authorReassignStore is the minimal store surface reassignBooksFromAuthor needs.
+// *database.PebbleStore (and the full database.Store) satisfy it.
+type authorReassignStore interface {
+	GetBooksByAuthorIDWithRoleCore(authorID int) ([]database.BookCore, error)
+	GetBookAuthors(bookID string) ([]database.BookAuthor, error)
+	SetBookAuthors(bookID string, authors []database.BookAuthor) error
+}
+
+// reassignBooksFromAuthor re-points every book currently crediting mergeID so it
+// credits keepID instead (de-duplicating when a book already credits keepID).
+//
+// It returns a slice of per-book error strings. An EMPTY slice means every book
+// that credited mergeID was successfully reassigned, so mergeID is safe to delete.
+// A NON-EMPTY slice means at least one book still credits mergeID — deleting
+// mergeID would leave a dangling BookAuthor row (lost author attribution), so the
+// caller MUST skip the delete. This is the fix for the prior code, which deleted
+// mergeID unconditionally even when a book's reassignment (or its author read)
+// had failed.
+func reassignBooksFromAuthor(store authorReassignStore, mergeID, keepID int) []string {
+	books, err := store.GetBooksByAuthorIDWithRoleCore(mergeID)
+	if err != nil {
+		return []string{fmt.Sprintf("get books for author %d: %v", mergeID, err)}
+	}
+
+	var errs []string
+	for _, book := range books {
+		bookAuthors, err := store.GetBookAuthors(book.ID)
+		if err != nil {
+			// Could not read this book's authors → we cannot safely strip mergeID
+			// from it, so record the failure (blocks the delete) instead of the
+			// prior silent `continue`.
+			errs = append(errs, fmt.Sprintf("get authors for book %s: %v", book.ID, err))
+			continue
+		}
+		hasKeep := false
+		for _, ba := range bookAuthors {
+			if ba.AuthorID == keepID {
+				hasKeep = true
+				break
+			}
+		}
+		var newAuthors []database.BookAuthor
+		for _, ba := range bookAuthors {
+			if ba.AuthorID == mergeID {
+				if !hasKeep {
+					ba.AuthorID = keepID
+					newAuthors = append(newAuthors, ba)
+					hasKeep = true
+				}
+			} else {
+				newAuthors = append(newAuthors, ba)
+			}
+		}
+		if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
+			errs = append(errs, fmt.Sprintf("update book %s: %v", book.ID, err))
+		}
+	}
+	return errs
+}

--- a/internal/server/ai_author_reassign_test.go
+++ b/internal/server/ai_author_reassign_test.go
@@ -1,0 +1,131 @@
+// file: internal/server/ai_author_reassign_test.go
+// version: 1.0.0
+// guid: 8b1d3f27-6c94-4a05-9e21-3d7f0a58c4b6
+// last-edited: 2026-07-16
+
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeReassignStore implements the narrow authorReassignStore surface so the
+// test can inject read/write failures per book.
+type fakeReassignStore struct {
+	books      []database.BookCore
+	booksErr   error
+	authors    map[string][]database.BookAuthor
+	authorsErr map[string]error
+	setErr     map[string]error
+	setCalls   map[string][]database.BookAuthor
+}
+
+func (f *fakeReassignStore) GetBooksByAuthorIDWithRoleCore(int) ([]database.BookCore, error) {
+	return f.books, f.booksErr
+}
+
+func (f *fakeReassignStore) GetBookAuthors(bookID string) ([]database.BookAuthor, error) {
+	if e := f.authorsErr[bookID]; e != nil {
+		return nil, e
+	}
+	return f.authors[bookID], nil
+}
+
+func (f *fakeReassignStore) SetBookAuthors(bookID string, a []database.BookAuthor) error {
+	if e := f.setErr[bookID]; e != nil {
+		return e
+	}
+	if f.setCalls == nil {
+		f.setCalls = map[string][]database.BookAuthor{}
+	}
+	f.setCalls[bookID] = a
+	return nil
+}
+
+const mergeID, keepID = 2, 1
+
+// Happy path: every book crediting mergeID is re-pointed to keepID; no errors,
+// so the caller may delete mergeID.
+func TestReassignBooksFromAuthor_AllSucceed(t *testing.T) {
+	f := &fakeReassignStore{
+		books: []database.BookCore{{ID: "b1"}, {ID: "b2"}},
+		authors: map[string][]database.BookAuthor{
+			"b1": {{BookID: "b1", AuthorID: mergeID, Role: "author"}},
+			"b2": {{BookID: "b2", AuthorID: mergeID, Role: "author"}},
+		},
+	}
+	errs := reassignBooksFromAuthor(f, mergeID, keepID)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	for _, id := range []string{"b1", "b2"} {
+		got := f.setCalls[id]
+		if len(got) != 1 || got[0].AuthorID != keepID {
+			t.Errorf("book %s: expected single author re-pointed to keepID %d, got %+v", id, keepID, got)
+		}
+	}
+}
+
+// A failed SetBookAuthors must surface as an error so the caller skips the
+// author delete (prevents a dangling BookAuthor row).
+func TestReassignBooksFromAuthor_SetFailureBlocksDelete(t *testing.T) {
+	f := &fakeReassignStore{
+		books: []database.BookCore{{ID: "b1"}, {ID: "b2"}},
+		authors: map[string][]database.BookAuthor{
+			"b1": {{BookID: "b1", AuthorID: mergeID}},
+			"b2": {{BookID: "b2", AuthorID: mergeID}},
+		},
+		setErr: map[string]error{"b2": errors.New("write failed")},
+	}
+	errs := reassignBooksFromAuthor(f, mergeID, keepID)
+	if len(errs) == 0 {
+		t.Fatal("expected a non-empty error slice (must block author delete), got none")
+	}
+}
+
+// A failed GetBookAuthors read must also block the delete — the prior code
+// silently `continue`d, leaving the book crediting mergeID while deleting it.
+func TestReassignBooksFromAuthor_AuthorsReadFailureBlocksDelete(t *testing.T) {
+	f := &fakeReassignStore{
+		books:      []database.BookCore{{ID: "b1"}},
+		authorsErr: map[string]error{"b1": errors.New("read failed")},
+	}
+	errs := reassignBooksFromAuthor(f, mergeID, keepID)
+	if len(errs) == 0 {
+		t.Fatal("expected an error when a book's authors can't be read")
+	}
+}
+
+// A failed book-list read blocks the delete too.
+func TestReassignBooksFromAuthor_BookListFailureBlocksDelete(t *testing.T) {
+	f := &fakeReassignStore{booksErr: errors.New("list failed")}
+	errs := reassignBooksFromAuthor(f, mergeID, keepID)
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly one error for a failed book list, got %v", errs)
+	}
+}
+
+// A book already crediting keepID has the mergeID credit dropped (dedup), not
+// duplicated — and this counts as success.
+func TestReassignBooksFromAuthor_DedupWhenAlreadyCreditsKeep(t *testing.T) {
+	f := &fakeReassignStore{
+		books: []database.BookCore{{ID: "b1"}},
+		authors: map[string][]database.BookAuthor{
+			"b1": {
+				{BookID: "b1", AuthorID: keepID, Role: "author"},
+				{BookID: "b1", AuthorID: mergeID, Role: "co-author"},
+			},
+		},
+	}
+	errs := reassignBooksFromAuthor(f, mergeID, keepID)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+	got := f.setCalls["b1"]
+	if len(got) != 1 || got[0].AuthorID != keepID {
+		t.Errorf("expected the mergeID credit dropped, leaving only keepID, got %+v", got)
+	}
+}

--- a/internal/server/ai_ops.go
+++ b/internal/server/ai_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/ai_ops.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-05
+// last-edited: 2026-07-16
 
 // ai_ops registers the ai.author-review and ai.author-merge-apply
 // OperationDefs that previously went through the legacy BridgeQueue.
@@ -17,7 +17,6 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
-	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
@@ -164,41 +163,14 @@ func (s *Server) RegisterAIAuthorMergeApplyOp(reg *opsregistry.Registry) error {
 						if mergeID == sug.KeepID {
 							continue
 						}
-						books, err := store.GetBooksByAuthorIDWithRoleCore(mergeID)
-						if err != nil {
-							applyErrors = append(applyErrors, fmt.Sprintf("get books for author %d: %v", mergeID, err))
+						reassignErrs := reassignBooksFromAuthor(store, mergeID, sug.KeepID)
+						applyErrors = append(applyErrors, reassignErrs...)
+						// Only delete the merged-away author once EVERY book that
+						// credited it has been re-pointed. Deleting while a book still
+						// credits mergeID would leave a dangling author reference.
+						if len(reassignErrs) > 0 {
+							applyErrors = append(applyErrors, fmt.Sprintf("author %d NOT deleted: %d book(s) could not be reassigned", mergeID, len(reassignErrs)))
 							continue
-						}
-
-						_ = progress.Log("info", fmt.Sprintf("Snapshotting %d books before merge of author %d", len(books), mergeID), nil)
-
-						for _, book := range books {
-							bookAuthors, err := store.GetBookAuthors(book.ID)
-							if err != nil {
-								continue
-							}
-							hasKeep := false
-							for _, ba := range bookAuthors {
-								if ba.AuthorID == sug.KeepID {
-									hasKeep = true
-									break
-								}
-							}
-							var newAuthors []database.BookAuthor
-							for _, ba := range bookAuthors {
-								if ba.AuthorID == mergeID {
-									if !hasKeep {
-										ba.AuthorID = sug.KeepID
-										newAuthors = append(newAuthors, ba)
-										hasKeep = true
-									}
-								} else {
-									newAuthors = append(newAuthors, ba)
-								}
-							}
-							if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
-								applyErrors = append(applyErrors, fmt.Sprintf("update book %s: %v", book.ID, err))
-							}
 						}
 
 						if err := store.DeleteAuthor(mergeID); err != nil {
@@ -229,38 +201,15 @@ func (s *Server) RegisterAIAuthorMergeApplyOp(reg *opsregistry.Registry) error {
 							if _, err := store.CreateAuthorAlias(sug.KeepID, variant.Name, "pen_name"); err != nil {
 								applyErrors = append(applyErrors, fmt.Sprintf("create alias for author %d: %v", sug.KeepID, err))
 							}
-							// Re-link books and delete the variant author
-							books, err := store.GetBooksByAuthorIDWithRoleCore(mergeID)
-							if err != nil {
-								continue
+							// Re-link books and delete the variant author only if every
+							// book was successfully re-pointed (see reassignBooksFromAuthor).
+							reassignErrs := reassignBooksFromAuthor(store, mergeID, sug.KeepID)
+							for _, e := range reassignErrs {
+								applyErrors = append(applyErrors, e+" (alias)")
 							}
-							for _, book := range books {
-								bookAuthors, err := store.GetBookAuthors(book.ID)
-								if err != nil {
-									continue
-								}
-								hasKeep := false
-								for _, ba := range bookAuthors {
-									if ba.AuthorID == sug.KeepID {
-										hasKeep = true
-										break
-									}
-								}
-								var newAuthors []database.BookAuthor
-								for _, ba := range bookAuthors {
-									if ba.AuthorID == mergeID {
-										if !hasKeep {
-											ba.AuthorID = sug.KeepID
-											newAuthors = append(newAuthors, ba)
-											hasKeep = true
-										}
-									} else {
-										newAuthors = append(newAuthors, ba)
-									}
-								}
-								if err := store.SetBookAuthors(book.ID, newAuthors); err != nil {
-									applyErrors = append(applyErrors, fmt.Sprintf("update book %s for alias: %v", book.ID, err))
-								}
+							if len(reassignErrs) > 0 {
+								applyErrors = append(applyErrors, fmt.Sprintf("aliased author %d NOT deleted: %d book(s) could not be reassigned", mergeID, len(reassignErrs)))
+								continue
 							}
 							if err := store.DeleteAuthor(mergeID); err != nil {
 								applyErrors = append(applyErrors, fmt.Sprintf("delete aliased author %d: %v", mergeID, err))


### PR DESCRIPTION
Completes the apply-path guard hardening (the third finding from the silent-failure bug hunt).

## Bug (silent data corruption)

`RegisterAIAuthorMergeApplyOp` (`internal/server/ai_ops.go`), in **both** the `merge` and `alias` actions, re-points every book crediting a variant author onto the canonical author, then deletes the variant.

The delete ran **unconditionally**. A book whose `SetBookAuthors` reassignment failed — or whose `GetBookAuthors` read failed and was silently `continue`d — still credited the variant, which was then deleted anyway → a **dangling `BookAuthor` row** (the book loses its author attribution).

## Fix

Extract the per-book reassignment loop (previously duplicated in both actions) into a testable `reassignBooksFromAuthor` helper (`ai_author_reassign.go`) that returns per-book error strings. The variant `DeleteAuthor` now runs **only** when that result is empty (every book re-pointed); otherwise the delete is skipped and the failure reported. A previously-silent `GetBookAuthors` read error now also blocks the delete.

The helper takes a narrow 3-method interface, so it's unit-tested directly against a purpose-built fake.

## Tests (`ai_author_reassign_test.go`)
- all-succeed → both books re-pointed to keepID, no errors
- `SetBookAuthors` failure → non-empty errors (blocks delete)
- `GetBookAuthors` read failure → blocks delete
- book-list failure → blocks delete
- book already crediting the canonical author → variant credit de-duplicated (remap logic preserved)

`go build ./...`, `go vet ./internal/server`, and the helper suite green.

Closes `APPLY-GUARD-AI-AUTHOR-MERGE-DELETE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)