### PR TITLE
perf(reconcile): parallelize untracked-file hashing (concurrency-mandate hotspot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.161.0 -->
+<!-- version: 3.162.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,29 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - perf(reconcile): parallelize untracked-file hashing (concurrency-mandate hotspot)
+
+The reconcile preview builder (`internal/reconcile/reconcile.go`,
+`BuildReconcilePreviewWithProgress`) hashed every untracked on-disk file in a plain
+single-core `for range` loop — the exact anti-pattern called out by the CLAUDE.md
+concurrency mandate and the 2026-07-05 hotspot audit (hashing is explicitly named as
+work that must use a bounded pool). On a large library with thousands of untracked
+files this pinned one core while the rest sat idle.
+
+- **Fix:** extracted the hashing into `hashFilesConcurrent`, a bounded
+  `errgroup.Group` pool sized to `runtime.NumCPU()`. Each file hashes into its own
+  index-ordered slot and the hash→path map is folded serially afterwards, so the
+  former "highest-indexed file wins on a hash collision" behavior is preserved
+  **exactly**. `scanner.ComputeSegmentFileHash` opens its own file and shares no
+  state, so it is safe to call concurrently.
+- Tests (`reconcile_hash_test.go`, first tests in this package): correct indexing,
+  collision last-wins, skip-on-hash-error, empty input, and progress reporting — all
+  run under `-race`.
+- Follow-ups tracked in TODO (`RECONCILE-SERIAL-LOOPS`): the two remaining serial
+  full-library loops in this file (`FindBrokenSegmentBooks` per-book stat+DB, and the
+  path-check `os.Stat` loop) are lower priority (I/O-bound, order-sensitive shared
+  state) and deferred to a follow-up with proper partitioning + tests.
 
 #### July 16, 2026 - fix(ai): author merge/alias no longer deletes an author whose books failed to reassign
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.3 -->
+<!-- version: 9.106.4 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1736,6 +1736,17 @@ must sequence, but A and B are parallelizable. Spawn:
 ---
 
 ## 🐛 Open Bugs — May 17, 2026
+
+- [ ] **RECONCILE-SERIAL-LOOPS** (2026-07-16, concurrency bug hunt) — two remaining serial
+  full-library loops in `internal/reconcile/reconcile.go` (the hashing loop was parallelized
+  2026-07-16 via `hashFilesConcurrent`, branch `perf/reconcile-parallel-loops`): (1)
+  `FindBrokenSegmentBooks` (~L750) does per-book `os.Stat` + `GetBookFiles` + `GetBookByID` +
+  `UpdateBook` over `GetAllBooksCore(100000,0)` fully serially — the per-book `UpdateBook` writes
+  are per-distinct-book so they parallelize safely; (2) the path-check loop (~L217) does serial
+  `os.Stat` over up to 100k books. Both are lower priority than the hash loop (I/O-bound; #2 also
+  mutates order-sensitive shared state — `knownPaths` map + ordered `brokenBooks`/`BrokenRecords`
+  slices — so needs partitioning/sharded-collect + a test, not a naive fan-out). No tests exist in
+  this package yet beyond `reconcile_hash_test.go`.
 
 - [x] **APPLY-GUARD-ITUNES-REGROUP-FAILOPEN** (2026-07-16, silent-failure hunt) — ✅ **FIXED
   2026-07-16** (branch `fix/harden-apply-path-guards`). `itunes_regroup.go` delete guard read

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-13
+// last-edited: 2026-07-16
 
 package reconcile
 
@@ -12,7 +12,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -22,6 +24,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
 	"github.com/falkcorp/audiobook-organizer/internal/security/safepath"
 	"github.com/oklog/ulid/v2"
+	"golang.org/x/sync/errgroup"
 )
 
 // Store is the database dependency for reconcile operations.
@@ -157,6 +160,44 @@ func BuildReconcilePreview(store Store) (*ReconcilePreviewResult, error) {
 	return BuildReconcilePreviewWithProgress(store, nil)
 }
 
+// hashFilesConcurrent computes a segment hash for every file across a bounded
+// worker pool (runtime.NumCPU()) and returns a hash→path index. This replaces a
+// former single-core loop that hashed potentially thousands of on-disk files
+// serially (a CLAUDE.md concurrency-mandate hotspot). ComputeSegmentFileHash
+// opens its own file and shares no state, so it is safe to call concurrently.
+//
+// Behaviour is preserved exactly: each file hashes into its own index-ordered
+// slot and the map is folded serially afterwards, so on a hash collision the
+// highest-indexed file still wins (as the sequential map-build did). Files that
+// fail to hash are skipped. report, if non-nil, is called ~every 100 files with
+// the running completed count.
+func hashFilesConcurrent(files []string, report func(done int)) map[string]string {
+	hashes := make([]string, len(files))
+	var done int64
+	var g errgroup.Group
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	for i, fp := range files {
+		g.Go(func() error {
+			if h, err := scanner.ComputeSegmentFileHash(fp); err == nil {
+				hashes[i] = h // sha256 hex is never empty; "" == unhashed
+			}
+			if n := atomic.AddInt64(&done, 1); report != nil && n%100 == 0 {
+				report(int(n))
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // per-file hash errors are skipped, matching prior behaviour
+
+	idx := make(map[string]string, len(files))
+	for i, h := range hashes {
+		if h != "" {
+			idx[h] = files[i]
+		}
+	}
+	return idx
+}
+
 // BuildReconcilePreviewWithProgress builds the full reconciliation preview with
 // progress reporting for background operations. log may be nil.
 func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*ReconcilePreviewResult, error) {
@@ -261,17 +302,9 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 	// Step 3: Hash untracked files for matching
 	totalUntracked := len(untrackedFiles)
 	report(0, totalUntracked, fmt.Sprintf("Hashing %d untracked files...", totalUntracked))
-	hashIndex := make(map[string]string)
-	for i, fp := range untrackedFiles {
-		h, err := scanner.ComputeSegmentFileHash(fp)
-		if err != nil {
-			continue
-		}
-		hashIndex[h] = fp
-		if i%100 == 0 && i > 0 {
-			report(i, totalUntracked, fmt.Sprintf("Hashed %d/%d untracked files", i, totalUntracked))
-		}
-	}
+	hashIndex := hashFilesConcurrent(untrackedFiles, func(done int) {
+		report(done, totalUntracked, fmt.Sprintf("Hashed %d/%d untracked files", done, totalUntracked))
+	})
 	report(totalUntracked, totalUntracked, fmt.Sprintf("Hashed %d/%d untracked files", totalUntracked, totalUntracked))
 	logMsg("info", fmt.Sprintf("Computed hashes for %d untracked files", len(hashIndex)))
 

--- a/internal/reconcile/reconcile_hash_test.go
+++ b/internal/reconcile/reconcile_hash_test.go
@@ -1,0 +1,91 @@
+// file: internal/reconcile/reconcile_hash_test.go
+// version: 1.0.0
+// guid: 5a9c2e74-8b13-4d6f-9027-1e4c8a35d9b2
+// last-edited: 2026-07-16
+
+package reconcile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/scanner"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// hashFilesConcurrent must index each hashable file, drop the highest-indexed
+// file on a content collision (preserving the old sequential last-wins map
+// build), and skip files that fail to hash. Run with -race to exercise the pool.
+func TestHashFilesConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a.m4b", "content-A")
+	b := writeFile(t, dir, "b.m4b", "content-B")
+	// Two files with identical content hash to the same value → collision.
+	c1 := writeFile(t, dir, "c1.m4b", "same-content")
+	c2 := writeFile(t, dir, "c2.m4b", "same-content")
+	missing := filepath.Join(dir, "does-not-exist.m4b") // hash error → skipped
+
+	files := []string{a, b, c1, c2, missing}
+	idx := hashFilesConcurrent(files, nil)
+
+	ha, _ := scanner.ComputeSegmentFileHash(a)
+	hb, _ := scanner.ComputeSegmentFileHash(b)
+	hc, _ := scanner.ComputeSegmentFileHash(c1)
+
+	if idx[ha] != a {
+		t.Errorf("hash of a → %q, want %q", idx[ha], a)
+	}
+	if idx[hb] != b {
+		t.Errorf("hash of b → %q, want %q", idx[hb], b)
+	}
+	// Collision: c1 and c2 share a hash; the higher index (c2) must win, matching
+	// the former sequential `hashIndex[h] = fp` in index order.
+	if idx[hc] != c2 {
+		t.Errorf("collision winner = %q, want highest-index %q", idx[hc], c2)
+	}
+	// Three distinct hashes (a, b, shared-c); the missing file contributed none.
+	if len(idx) != 3 {
+		t.Errorf("index size = %d, want 3 (missing file skipped)", len(idx))
+	}
+}
+
+func TestHashFilesConcurrent_Empty(t *testing.T) {
+	if idx := hashFilesConcurrent(nil, nil); len(idx) != 0 {
+		t.Fatalf("empty input → %d entries, want 0", len(idx))
+	}
+}
+
+// The progress callback fires (at the ~every-100 cadence) and never races.
+func TestHashFilesConcurrent_ProgressReported(t *testing.T) {
+	dir := t.TempDir()
+	files := make([]string, 0, 250)
+	for i := range 250 {
+		files = append(files, writeFile(t, dir, fmt.Sprintf("f%03d.m4b", i), fmt.Sprintf("content-%d", i)))
+	}
+	var maxDone int64
+	idx := hashFilesConcurrent(files, func(done int) {
+		for {
+			cur := atomic.LoadInt64(&maxDone)
+			if int64(done) <= cur || atomic.CompareAndSwapInt64(&maxDone, cur, int64(done)) {
+				break
+			}
+		}
+	})
+	if len(idx) != 250 {
+		t.Errorf("index size = %d, want 250", len(idx))
+	}
+	if atomic.LoadInt64(&maxDone) < 100 {
+		t.Errorf("progress high-water = %d, want >= 100", maxDone)
+	}
+}


### PR DESCRIPTION
## Problem

`BuildReconcilePreviewWithProgress` (`internal/reconcile/reconcile.go`) hashed every untracked on-disk file in a plain single-core loop:
```go
for i, fp := range untrackedFiles {
    h, err := scanner.ComputeSegmentFileHash(fp)
    ...
    hashIndex[h] = fp
}
```
This is the exact anti-pattern the **CLAUDE.md concurrency mandate** and the [2026-07-05 hotspot audit](docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md) call out — hashing is explicitly named as work that must use a bounded pool. On a large library with thousands of untracked files it pinned one core while the rest sat idle. Found via a read-only concurrency bug hunt.

## Fix

Extracted the hashing into `hashFilesConcurrent`, a bounded `errgroup.Group` pool sized to `runtime.NumCPU()`.

**Behavior is preserved exactly:** each file hashes into its own index-ordered slot; the `hash→path` map is folded serially afterwards, so on a hash collision the highest-indexed file still wins (as the sequential `hashIndex[h] = fp` did). `scanner.ComputeSegmentFileHash` opens its own file and shares no state, so concurrent calls are safe.

## Tests

`reconcile_hash_test.go` (first tests in this package), all run under `-race`:
- correct hash→path indexing
- **collision → highest-index wins** (proves behavior preservation)
- skip-on-hash-error (missing file contributes nothing)
- empty input
- progress callback fires at the ~every-100 cadence

## Scope / follow-ups

Deliberately scoped to the **hash loop** (CPU-bound, clean behavior-preservation). The two other serial loops in this file — `FindBrokenSegmentBooks` (per-book stat+DB) and the path-check `os.Stat` loop — are I/O-bound and touch order-sensitive shared state (`knownPaths` map + ordered slices), so they need partitioning + tests and are tracked in TODO as `RECONCILE-SERIAL-LOOPS` rather than risked here.

`go build ./...`, `go vet`, and the package suite (with `-race`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)