### PR TITLE
fix(maintenance): whole-library ops silently processed only a fixed-limit subset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.162.0 -->
+<!-- version: 3.163.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,35 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(maintenance): whole-library ops silently processed only a fixed-limit subset
+
+Five maintenance/scan operations fetched "all books" with a **fixed positive page
+limit** and no pagination loop, so on the production library (~30K–44K books) they
+silently processed only the first N and skipped the rest. `GetAllBooksCore` treats
+`limit <= 0` as unbounded (verified against both the memdb `paginate` and the Pebble
+iterator paths), so each was one call away from correct.
+
+- **`OptimizeDatabase`** (`internal/server/handlers/operations/handler.go`) — split
+  compound `A & B` author/narrator names across the library; capped at 10,000 →
+  ~20K–34K books never split.
+- **`enrichImportedBooks`** (`internal/itunes/service/importer.go`) — post-import
+  metadata enrichment; capped at 10,000 while its sibling `organizeImportedBooks`
+  used 100,000. On a fresh 44K import only the first 10K got enriched.
+- **`runMetadataRefreshScan`** (both copies: `internal/scheduler/extra_ops.go` and
+  `internal/server/metadata_ops.go`) — the "incomplete metadata" report capped its
+  denominator at 10,000, silently under-reporting.
+- **`quarantineKnownBadFiles`** (`internal/server/quarantine_known_bad.go`) — a
+  one-time startup scan (guarded by a done-flag so it never re-runs) capped at 20,000
+  → the remaining books would *never* be scanned for permanently-unreadable files.
+
+All five now call `GetAllBooksCore(0, 0)`. A new getter-contract test
+(`TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded`) locks the `limit <= 0 ==
+unbounded` semantics so the cap can't silently return. Follow-ups tracked in TODO
+(`WHOLE-LIBRARY-FIXED-LIMIT-FRAGILE`): ~10 more sites use a 100K/1M limit that is
+safe today but will truncate as the library grows.
+
+Executive summary: `docs/executive-summaries/2026-07-16-whole-library-truncation-executive-summary.md`.
 
 #### July 16, 2026 - perf(reconcile): parallelize untracked-file hashing (concurrency-mandate hotspot)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.4 -->
+<!-- version: 9.106.5 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1736,6 +1736,27 @@ must sequence, but A and B are parallelizable. Spawn:
 ---
 
 ## 🐛 Open Bugs — May 17, 2026
+
+- [x] **WHOLE-LIBRARY-FIXED-LIMIT-LIVE** (2026-07-16, pagination bug hunt) — ✅ **FIXED 2026-07-16**
+  (branch `fix/whole-library-truncation`). Five whole-library ops fetched books with a fixed
+  positive limit and no loop, silently processing only the first N of ~30K–44K: `OptimizeDatabase`
+  (10K), `enrichImportedBooks` (10K), `runMetadataRefreshScan` ×2 (10K), `quarantineKnownBadFiles`
+  (20K, one-time+done-flag → rest never scanned). All → `GetAllBooksCore(0, 0)` (unbounded, verified
+  in both memdb `paginate` and Pebble iterator). Contract test `TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded`.
+- [ ] **WHOLE-LIBRARY-FIXED-LIMIT-FRAGILE** (2026-07-16, pagination bug hunt) — ~10 whole-library
+  sites use `GetAllBooksCore(100000, 0)` or `(1000000, 0)`: `cmd/seed.go:247`, `migrations.go:617`,
+  `reconcile.go:243/767`, `deluge/discovery.go:71`, `itunes/service/importer.go:539/798/1158`,
+  `itunes/service/path_reconcile.go:74`, `sweep/sweeper.go:85`, `maintenance/jobs/generate_itl_tests.go:44`,
+  `handlers/metadata/handler.go:1193`. Safe today (~30K < 100K) but will silently truncate as the
+  library grows. Switch each to `GetAllBooksCore(0, 0)` or a cursor loop. Verify each is whole-library
+  intent first (migrations.go is sensitive — check the migration semantics before changing).
+- [ ] **RESET-AUTHZ-CONSISTENCY** (2026-07-16, API authz bug hunt) — LOW: `/system/reset` &
+  `/system/factory-reset` (`wire_system_routes.go:31-32`) gate on `PermSettingsManage` while the
+  sibling `/maintenance/wipe` (`server_lifecycle.go:1284`) gates on `RequireAdmin()`. No live
+  escalation in default roles (only admin has settings.manage), but a custom non-admin role with
+  settings.manage could full-wipe via reset. Also `ResetSystem` (full DB wipe) lacks the
+  `{"confirm":"RESET"}` token that the *more* destructive `FactoryReset` requires. Fix: gate all
+  three destructive endpoints on one model (`RequireAdmin()`) + add confirm token to `ResetSystem`.
 
 - [ ] **RECONCILE-SERIAL-LOOPS** (2026-07-16, concurrency bug hunt) — two remaining serial
   full-library loops in `internal/reconcile/reconcile.go` (the hashing loop was parallelized

--- a/docs/executive-summaries/2026-07-16-whole-library-truncation-executive-summary.md
+++ b/docs/executive-summaries/2026-07-16-whole-library-truncation-executive-summary.md
@@ -1,0 +1,43 @@
+<!-- file: docs/executive-summaries/2026-07-16-whole-library-truncation-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6b3f9a41-2d78-4c05-9e16-8a4c0f7d2b39 -->
+<!-- last-edited: 2026-07-16 -->
+
+# Executive Summary: Maintenance Tasks Were Only Looking at Part of the Library
+
+## What changed
+
+Several "run across the whole library" maintenance tasks were quietly only looking at
+the first chunk of books and ignoring the rest. Each asked the database for "all
+books" but with a fixed ceiling — 10,000 or 20,000 — baked in. With roughly 30,000+
+books in the library, that meant the tasks stopped well short of the end and never
+touched the remaining two-thirds, with no error and nothing in the report to say so.
+
+The affected tasks:
+
+- **Tidy up combined author names** (splitting entries like "Author A & Author B" into
+  two) — only the first 10,000 books were ever cleaned up.
+- **Fill in metadata after an iTunes import** — on a large first import, only the first
+  10,000 imported books got enriched.
+- **The "which books have incomplete metadata?" report** — counted against only the
+  first 10,000, so it under-reported how much was missing.
+- **The one-time scan for permanently-unreadable files** — capped at 20,000, and because
+  it marks itself "done" and never runs again, the rest of the library would have stayed
+  unscanned forever.
+
+All five now ask for the entire library with no ceiling. A test locks in the "no
+ceiling" behavior so the cap can't quietly creep back.
+
+## Why it mattered
+
+Nothing was deleted or corrupted — but work the system reported as done was only
+partially done, invisibly. A book past the cutoff would never get its author name
+tidied, never get enriched after import, and never get checked for unreadable files.
+The report that tells you how healthy your metadata is was itself only counting part of
+the shelf.
+
+## Also noted (follow-ups, not fixed here)
+
+About ten other whole-library tasks use a much higher ceiling (100,000 or a million).
+Those are fine at today's size but would hit the same problem as the library grows;
+they're logged as a follow-up to switch to the same no-ceiling form.

--- a/internal/database/memdb_reads_test.go
+++ b/internal/database/memdb_reads_test.go
@@ -1,11 +1,12 @@
 // file: internal/database/memdb_reads_test.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000007
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 package database
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -225,6 +226,56 @@ func TestMemStore_GetAllBooksCore_Filters(t *testing.T) {
 			ids = append(ids, b.ID)
 		}
 		t.Errorf("expected [b1], got %v", ids)
+	}
+}
+
+// GetAllBooksCore must treat limit <= 0 as UNBOUNDED (return every row), while a
+// positive limit truncates. Whole-library maintenance ops rely on the limit==0
+// form to avoid silently processing only a subset (see the July-16 truncation
+// fixes: OptimizeDatabase, enrichImportedBooks, runMetadataRefreshScan,
+// quarantineKnownBadFiles). This test locks that contract so a future change to
+// the getter can't reintroduce a silent cap on limit==0.
+func TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded(t *testing.T) {
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	books := make([]Book, 0, 5)
+	for i := range 5 {
+		books = append(books, Book{
+			ID:                fmt.Sprintf("b%d", i),
+			Title:             fmt.Sprintf("Book %d", i),
+			IsPrimaryVersion:  ptrBool_mem(true),
+			MarkedForDeletion: ptrBool_mem(false),
+		})
+	}
+	seedMemStore(t, m, books, nil, nil, nil)
+
+	// Positive limit below the row count truncates.
+	got, err := m.GetAllBooksCore(3, 0, nil)
+	if err != nil {
+		t.Fatalf("GetAllBooksCore(3,0): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("limit=3 returned %d rows, want 3 (truncated)", len(got))
+	}
+
+	// limit == 0 returns everything.
+	all, err := m.GetAllBooksCore(0, 0, nil)
+	if err != nil {
+		t.Fatalf("GetAllBooksCore(0,0): %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("limit=0 returned %d rows, want all 5 (unbounded)", len(all))
+	}
+
+	// Negative limit is also unbounded.
+	allNeg, err := m.GetAllBooksCore(-1, 0, nil)
+	if err != nil {
+		t.Fatalf("GetAllBooksCore(-1,0): %v", err)
+	}
+	if len(allNeg) != 5 {
+		t.Fatalf("limit=-1 returned %d rows, want all 5 (unbounded)", len(allNeg))
 	}
 }
 

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.12.0
+// version: 1.12.1
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-13
+// last-edited: 2026-07-16
 
 package itunesservice
 
@@ -1035,7 +1035,7 @@ func (imp *Importer) enrichImportedBooks(ctx context.Context, status *itunesImpo
 		return
 	}
 
-	books, err := imp.store.GetAllBooksCore(10000, 0)
+	books, err := imp.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		log.Error("Failed to list books for enrichment: %v", err)
 		return

--- a/internal/scheduler/extra_ops.go
+++ b/internal/scheduler/extra_ops.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/extra_ops.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a9b8c7d6-e5f4-3210-fedc-ba9876543210
-// last-edited: 2026-07-13
+// last-edited: 2026-07-16
 
 // extra_ops registers OperationDefs for 13 scheduler tasks that previously
 // used the legacy triggerOperation / triggerOperationWithID helpers.  Each def
@@ -833,7 +833,7 @@ func (r *ExtraOpsRegistrar) runMetadataRefreshScan(ctx context.Context, progress
 		return fmt.Errorf("database not initialized")
 	}
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
-	books, err := store.GetAllBooksCore(10000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)
 	}

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/operations/handler.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: 1b7fbd86-cdda-4921-b2d0-786f5cadb438
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 // Package operations hosts the background-operation HTTP handlers extracted
 // from the server package: the long-running scan / organize / optimize /
@@ -306,7 +306,7 @@ func (h *Handler) OptimizeDatabase(c *gin.Context) {
 		return
 	}
 
-	books, err := h.store.GetAllBooksCore(10000, 0)
+	books, err := h.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		httputil.InternalError(c, "failed to get audiobooks", err)
 		return

--- a/internal/server/metadata_ops.go
+++ b/internal/server/metadata_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_ops.go
-// version: 1.5.0
+// version: 1.5.1
 // guid: fba55738-5898-4950-8e79-3ee008ad0c70
-// last-edited: 2026-07-11
+// last-edited: 2026-07-16
 //
 // Async-operation machinery for the metadata domain, relocated verbatim from
 // metadata_handlers.go (ADR-003 Phase 4) when the 19 metadata HTTP handlers
@@ -966,7 +966,7 @@ func (s *Server) runMetadataRefreshScan(ctx context.Context, progress operations
 	_ = progress.Log("info", "Starting metadata refresh scan", nil)
 	// Pre-load total is unknown; placeholder (0/1) avoids 0/0.
 	_ = progress.UpdateProgress(0, 1, "Scanning books for incomplete metadata... (0/1 0.00%)")
-	books, err := store.GetAllBooksCore(10000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get books: %w", err)
 	}

--- a/internal/server/quarantine_known_bad.go
+++ b/internal/server/quarantine_known_bad.go
@@ -1,7 +1,7 @@
 // file: internal/server/quarantine_known_bad.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 package server
 
@@ -26,7 +26,7 @@ func (s *Server) quarantineKnownBadFiles() {
 		return
 	}
 
-	books, err := store.GetAllBooksCore(20000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		slog.Warn("quarantineKnownBadFiles GetAllBooksCore", "err", err)
 		return


### PR DESCRIPTION
## Bug (silent incomplete processing)

Five "run across the whole library" operations fetched books with a **fixed positive page limit and no pagination loop**, so on the ~30K–44K-book production library they silently processed only the first N and skipped the rest — no error, nothing in the report.

`GetAllBooksCore` treats `limit <= 0` as **unbounded** — verified against **both** paths: the memdb `paginate()` (`limit > 0 &&` gates the cap) and the Pebble iterator (`if limit > 0 && count >= limit { break }`). So each op was one argument from correct.

| Op | File | Limit | Impact |
|----|------|-------|--------|
| `OptimizeDatabase` | `handlers/operations/handler.go` | 10000 | compound `A & B` name-split skipped ~20K–34K books |
| `enrichImportedBooks` | `itunes/service/importer.go` | 10000 | on a 44K import only first 10K enriched (sibling used 100000) |
| `runMetadataRefreshScan` ×2 | `scheduler/extra_ops.go`, `server/metadata_ops.go` | 10000 | incomplete-metadata report under-counted |
| `quarantineKnownBadFiles` | `server/quarantine_known_bad.go` | 20000 | one-time scan + done-flag → rest of library **never** scanned |

## Fix

All five now call `GetAllBooksCore(0, 0)`.

New getter-contract test `TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded` asserts `limit=3` truncates while `limit=0` and `limit=-1` return every row — locking the semantic the fix depends on so a future getter change can't silently reintroduce a cap.

Found via a read-only pagination bug hunt; the getter semantics and all five call sites were **verified against source** before fixing.

## Scope / follow-ups (TODO)

- `WHOLE-LIBRARY-FIXED-LIMIT-FRAGILE` — ~10 more sites use a 100K/1M limit: safe today (~30K books) but will truncate as the library grows. Deferred (some, e.g. `migrations.go`, need per-site care).
- `RESET-AUTHZ-CONSISTENCY` — LOW: `/system/reset` vs `/maintenance/wipe` use different authz models + `ResetSystem` lacks a confirm token (from the parallel API-authz hunt; no live escalation in default roles).

## Verification
`go build ./...`, `go vet` (database/server/scheduler/itunes), and the database suite green.

Executive summary: `docs/executive-summaries/2026-07-16-whole-library-truncation-executive-summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)