### PR TITLE
fix(maintenance): future-proof remaining whole-library ops against fixed-limit truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.163.0 -->
+<!-- version: 3.164.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(maintenance): future-proof remaining whole-library ops against fixed-limit truncation
+
+Follow-up to the same-day truncation fix. Eleven more whole-library operations fetched
+books with a fixed `GetAllBooksCore(100000, 0)` / `(1_000_000, 0)` limit — safe at the
+current ~30K-book library but silently truncating once it grows past the cap. All now
+use the unbounded `GetAllBooksCore(0, 0)` form (semantics locked by the contract test
+added in the prior fix):
+
+- `cmd/seed.go` (purgeSeedBooks), `internal/database/migrations.go` (migration014UpPebble,
+  currently unwired), `internal/reconcile/reconcile.go` (×2: preview builder +
+  FindBrokenSegmentBooks), `internal/deluge/discovery.go` (BuildLibraryIndex),
+  `internal/itunes/service/importer.go` (×3: ITL-update collection + organizeImportedBooks),
+  `internal/itunes/service/path_reconcile.go`, `internal/sweep/sweeper.go`,
+  `internal/maintenance/jobs/generate_itl_tests.go`,
+  `internal/server/handlers/metadata/handler.go` (library-state filter).
+- The two `internal/itunes/backfill.go` sites were left as-is — they are correct
+  offset-cursor loops (`GetAllBooksCore(10000, offset)` terminating on a short/empty page),
+  not single-call truncations.
+
+This closes the `WHOLE-LIBRARY-FIXED-LIMIT` class entirely (live + fragile).
 
 #### July 16, 2026 - fix(maintenance): whole-library ops silently processed only a fixed-limit subset
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.5 -->
+<!-- version: 9.106.6 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1743,13 +1743,14 @@ must sequence, but A and B are parallelizable. Spawn:
   (10K), `enrichImportedBooks` (10K), `runMetadataRefreshScan` ×2 (10K), `quarantineKnownBadFiles`
   (20K, one-time+done-flag → rest never scanned). All → `GetAllBooksCore(0, 0)` (unbounded, verified
   in both memdb `paginate` and Pebble iterator). Contract test `TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded`.
-- [ ] **WHOLE-LIBRARY-FIXED-LIMIT-FRAGILE** (2026-07-16, pagination bug hunt) — ~10 whole-library
+- [x] **WHOLE-LIBRARY-FIXED-LIMIT-FRAGILE** (2026-07-16, pagination bug hunt) — ~10 whole-library
   sites use `GetAllBooksCore(100000, 0)` or `(1000000, 0)`: `cmd/seed.go:247`, `migrations.go:617`,
   `reconcile.go:243/767`, `deluge/discovery.go:71`, `itunes/service/importer.go:539/798/1158`,
   `itunes/service/path_reconcile.go:74`, `sweep/sweeper.go:85`, `maintenance/jobs/generate_itl_tests.go:44`,
   `handlers/metadata/handler.go:1193`. Safe today (~30K < 100K) but will silently truncate as the
-  library grows. Switch each to `GetAllBooksCore(0, 0)` or a cursor loop. Verify each is whole-library
-  intent first (migrations.go is sensitive — check the migration semantics before changing).
+  library grows. ✅ **FIXED 2026-07-16** (branch `fix/whole-library-fragile-limits`): all 11 switched
+  to `GetAllBooksCore(0, 0)` after verifying each is whole-library intent. The two `itunes/backfill.go`
+  sites were correctly left as-is (proper offset-cursor loops, not truncations). Closes the class.
 - [ ] **RESET-AUTHZ-CONSISTENCY** (2026-07-16, API authz bug hunt) — LOW: `/system/reset` &
   `/system/factory-reset` (`wire_system_routes.go:31-32`) gate on `PermSettingsManage` while the
   sibling `/maintenance/wipe` (`server_lifecycle.go:1284`) gates on `RequireAdmin()`. No live

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -1,7 +1,7 @@
 // file: cmd/seed.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: 7d2e9a4f-1b85-4c63-9f0a-3e8d7b2c1f56
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 //
 // `seed` populates a fresh database with synthetic books for local
 // development. Use it after `make build` so a dev can hit `make run`
@@ -244,7 +244,7 @@ func upsertSeries(store database.SeriesStore, name string, authorID *int) (*data
 }
 
 func purgeSeedBooks(store database.BookStore) (int, error) {
-	books, err := store.GetAllBooksCore(100000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1,7 +1,7 @@
 // file: internal/database/migrations.go
-// version: 1.41.1
+// version: 1.41.2
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
-// last-edited: 2026-07-12
+// last-edited: 2026-07-16
 
 package database
 
@@ -614,7 +614,7 @@ func migration014Up(store Store) error {
 //
 //lint:ignore U1000 kept: real Pebble corrupted-path migration logic not yet dispatched from the migration014Up no-op stub (follow-up wire-up, 2026-07-12)
 func migration014UpPebble(store Store) error {
-	books, err := store.GetAllBooksCore(1000000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("migration 14: failed to list books: %w", err)
 	}

--- a/internal/deluge/discovery.go
+++ b/internal/deluge/discovery.go
@@ -1,7 +1,7 @@
 // file: internal/deluge/discovery.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 //
 // Four-tier matching to decide if a labeled Deluge torrent is already in
 // the library — run in order, stop on first hit:
@@ -68,7 +68,7 @@ func BuildLibraryIndex(store BookLister) LibraryIndex {
 		Paths:  make(map[string]struct{}),
 		Titles: make(map[string]struct{}),
 	}
-	books, err := store.GetAllBooksCore(100000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		slog.Warn("deluge discovery failed to load books", "err", err)
 		return idx

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/service/importer.go
-// version: 1.12.1
+// version: 1.12.2
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
 // last-edited: 2026-07-16
 
@@ -536,7 +536,7 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 	// fields (ITunesPersistentID, FilePath, Title, ITunesPlayCount,
 	// ITunesRating, ITunesBookmark, ITunesLastPlayed). The actual writeback
 	// hydrates a full row (see below) so it never wipes Author/Series.
-	allBooks, err := imp.store.GetAllBooksCore(100000, 0)
+	allBooks, err := imp.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("failed to load books for index: %w", err)
 	}
@@ -795,7 +795,7 @@ func (imp *Importer) DiscoverLibraryPath() string {
 
 // CollectITLUpdatesWithBookIDs returns updates and the book IDs that contributed them.
 func (imp *Importer) CollectITLUpdatesWithBookIDs() ([]itunes.ITLLocationUpdate, []string) {
-	allBooks, err := imp.store.GetAllBooksCore(100000, 0)
+	allBooks, err := imp.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return nil, nil
 	}
@@ -1155,7 +1155,7 @@ func (imp *Importer) enrichConcurrency() int {
 //     colliding case gets the same one-wins/one-fails outcome the serial
 //     loop always produced (order-independent, same result set).
 func (imp *Importer) organizeImportedBooks(ctx context.Context, status *itunesImportStatus, log logger.Logger) {
-	core, err := imp.store.GetAllBooksCore(100000, 0)
+	core, err := imp.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		log.Error("Failed to list books for organize: %v", err)
 		return

--- a/internal/itunes/service/path_reconcile.go
+++ b/internal/itunes/service/path_reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/path_reconcile.go
-// version: 2.4.0
+// version: 2.4.1
 // guid: 9e3b7a1d-4c2f-4a60-b8d5-2f1e8c0d9a47
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 //
 // One-time (repeatable) backfill that walks every book with an
 // iTunes persistent ID, recomputes book_files.ITunesPath from the
@@ -71,7 +71,7 @@ func (r *PathReconciler) Reconcile(ctx context.Context, opID string, progress op
 	_ = progress.Log("info", "Starting iTunes path reconcile", nil)
 
 	// Load all books — 100k is the same cap other maintenance ops use.
-	books, err := r.store.GetAllBooksCore(100000, 0)
+	books, err := r.store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("load books: %w", err)
 	}

--- a/internal/maintenance/jobs/generate_itl_tests.go
+++ b/internal/maintenance/jobs/generate_itl_tests.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/generate_itl_tests.go
-// version: 1.3.0
+// version: 1.3.1
 // guid: b7e3f1a2-4c5d-6e7f-8a9b-0c1d2e3f4a5b
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 package jobs
 
@@ -41,7 +41,7 @@ func (j *generateITLTestsJob) Run(ctx context.Context, store database.Store, rep
 		return fmt.Errorf("unsafe output dir path: %w", err)
 	}
 
-	allBooks, err := store.GetAllBooksCore(100000, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return fmt.Errorf("GetAllBooksCore: %w", err)
 	}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,5 +1,5 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-07-16
 
@@ -240,7 +240,7 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 
 	// Step 1: Find broken DB records
 	report(0, 1, "Loading all books from database...")
-	books, err := store.GetAllBooksCore(100000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list books: %w", err)
 	}
@@ -764,7 +764,7 @@ func CleanupDuplicateVersionGroups(store Store, rootDir string, dryRun bool) (*V
 // FindBrokenSegmentBooks finds books whose segment files don't exist on disk
 // and optionally marks them as needs_review.
 func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, error) {
-	allBooks, err := store.GetAllBooksCore(100000, 0)
+	allBooks, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get books: %w", err)
 	}

--- a/internal/server/handlers/metadata/handler.go
+++ b/internal/server/handlers/metadata/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/metadata/handler.go
-// version: 1.6.1
+// version: 1.6.2
 // guid: 54bb4ad0-cab0-41fc-b9cb-557c96beee44
-// last-edited: 2026-07-13
+// last-edited: 2026-07-16
 
 // Package metadatahandler hosts the metadata-domain HTTP handlers extracted
 // from the server package's metadata_handlers.go: batch-update / validate /
@@ -1190,7 +1190,7 @@ func (h *Handler) handleBulkWriteBackImpl(c *gin.Context) {
 		books, err = store.GetBooksBySeriesIDCore(*req.Filter.SeriesID)
 	} else {
 		// Get all books, then filter by library_state
-		books, err = store.GetAllBooksCore(1_000_000, 0)
+		books, err = store.GetAllBooksCore(0, 0)
 	}
 	if err != nil {
 		httputil.InternalError(c, "failed to query books", err)

--- a/internal/sweep/sweeper.go
+++ b/internal/sweep/sweeper.go
@@ -1,7 +1,7 @@
 // file: internal/sweep/sweeper.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a1b2c3d4-e5f6-4789-abcd-ef2345678901
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 package sweep
 
@@ -82,7 +82,7 @@ func AuditFileConsistency(store database.BookStore) (*SweeperResult, error) {
 		Errors:       []string{},
 	}
 
-	books, err := store.GetAllBooksCore(100000, 0)
+	books, err := store.GetAllBooksCore(0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list books: %w", err)
 	}


### PR DESCRIPTION
Follow-up to #1961. Eleven more whole-library operations fetched books with a fixed `GetAllBooksCore(100000, 0)` / `(1_000_000, 0)` limit — **safe at today's ~30K library but will silently truncate** once it grows past the cap (the exact class #1961 fixed for the sub-44K cases).

All switched to the unbounded `GetAllBooksCore(0, 0)` form. The `limit <= 0 == unbounded` semantic is locked by `TestMemStore_GetAllBooksCore_LimitZeroIsUnbounded` (added in #1961).

Each site was verified whole-library intent:

| File | Function |
|------|----------|
| `cmd/seed.go` | purgeSeedBooks |
| `internal/database/migrations.go` | migration014UpPebble (currently unwired) |
| `internal/reconcile/reconcile.go` ×2 | preview builder + FindBrokenSegmentBooks |
| `internal/deluge/discovery.go` | BuildLibraryIndex |
| `internal/itunes/service/importer.go` ×3 | ITL-update collection + organizeImportedBooks |
| `internal/itunes/service/path_reconcile.go` | path reconcile |
| `internal/sweep/sweeper.go` | missing-file sweep |
| `internal/maintenance/jobs/generate_itl_tests.go` | ITL test generation |
| `internal/server/handlers/metadata/handler.go` | library-state filter |

**Deliberately left as-is:** the two `internal/itunes/backfill.go` sites use `GetAllBooksCore(10000, offset)` inside proper offset-cursor loops that terminate on a short/empty page — correct pagination, not truncation.

Closes the `WHOLE-LIBRARY-FIXED-LIMIT` class (live in #1961 + fragile here).

`go build ./...` and `go vet` (all 9 changed packages) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)