### PR TITLE
fix(audiobooks): editing a book's author by ID persisted a stale author name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.164.0 -->
+<!-- version: 3.165.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,21 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(audiobooks): editing a book's author by ID persisted a stale author name
+
+`UpdateAudiobook` changed a book's `AuthorID` (and `SeriesID`) but left the embedded,
+denormalized `Author`/`Series` display object pointing at the *old* record. `UpdateBook`'s
+preserve-on-nil guard could not correct it — the stale struct is non-nil — so the wrong
+name was written to the stored row. Every read path
+(`resolveAuthorAndSeriesNames`, `EnrichAudiobooksWithNames`) prefers the embedded object
+when present, so the book displayed the previous author/series indefinitely — the FK said
+one author, the visible name said another. Reachable through the `author_id` / `series_id`
+API fields (`update_service.go:86`). The fix syncs the embedded object to the resolved ID
+**before** persisting (the write side now honors `UpdateBook`'s documented "set BOTH the ID
+and a fresh object" contract). Every subsequent edit also self-heals any pre-existing
+mismatch. Regression test re-reads the row straight from the store to assert on what was
+actually written. `internal/audiobooks/service_mutation.go`.
 
 #### July 16, 2026 - fix(maintenance): future-proof remaining whole-library ops against fixed-limit truncation
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.6 -->
+<!-- version: 9.106.7 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1770,6 +1770,17 @@ must sequence, but A and B are parallelizable. Spawn:
   slices — so needs partitioning/sharded-collect + a test, not a naive fan-out). No tests exist in
   this package yet beyond `reconcile_hash_test.go`.
 
+- [x] **UPDATEBOOK-STALE-DENORMALIZED-AUTHOR** (2026-07-16, write-path bug hunt) — ✅ **FIXED
+  2026-07-16** (branch `fix/update-audiobook-stale-denormalized-author`). `UpdateAudiobook`
+  (`service_mutation.go`) changed `AuthorID`/`SeriesID` (reachable via the `author_id`/`series_id`
+  API fields, `update_service.go:86`) but left the embedded denormalized `Author`/`Series` display
+  struct pointing at the OLD record. `UpdateBook`'s preserve-on-nil guard can't fix a stale *non-nil*
+  struct, so the stale name was persisted; read paths (`resolveAuthorAndSeriesNames`,
+  `EnrichAudiobooksWithNames`) prefer the embedded object when present → wrong author/series shown
+  indefinitely. Inverse of the July 13 blank-on-nil fix. Fix syncs the embedded object to the resolved
+  ID BEFORE persist (honors `UpdateBook`'s "set BOTH ID and fresh object" contract); self-heals prior
+  mismatches on any edit. Regression test re-reads from the store to assert what was written. Exec
+  summary: `docs/executive-summaries/2026-07-16-stale-author-on-id-edit-executive-summary.md`.
 - [x] **APPLY-GUARD-ITUNES-REGROUP-FAILOPEN** (2026-07-16, silent-failure hunt) — ✅ **FIXED
   2026-07-16** (branch `fix/harden-apply-path-guards`). `itunes_regroup.go` delete guard read
   `files, _ :=`/`exts, _ :=` and fell open on a read error (nil→len 0→delete a possibly-non-empty

--- a/docs/executive-summaries/2026-07-16-stale-author-on-id-edit-executive-summary.md
+++ b/docs/executive-summaries/2026-07-16-stale-author-on-id-edit-executive-summary.md
@@ -1,0 +1,54 @@
+<!-- file: docs/executive-summaries/2026-07-16-stale-author-on-id-edit-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4b1e7c92-8a53-4f06-b2d9-6e0a1f3c7d84 -->
+<!-- last-edited: 2026-07-16 -->
+
+# Executive Summary: Editing a Book's Author by ID Left the Old Author Name Showing
+
+**Shipped:** July 16, 2026. A follow-on to the July 13 author/series data-loss
+fix — the same part of the code, but the opposite failure.
+
+## Executive Summary
+
+When you changed a book's author (or series) by picking a different one, the
+book's record kept the change to *which* author it pointed at — but the **name it
+displayed stayed the old one**. So a book could point at "New Author" internally
+while every screen still showed "Old Author," with no error and no sign anything
+was off. We fixed it at the point of the edit and added a test that reproduces the
+old wrong behavior and proves it's gone.
+
+## What was wrong, in plain terms
+
+Every book stores two things about its author: an internal reference (which author
+it belongs to) and a saved copy of the author's name, kept alongside the book so
+the library can list thousands of books quickly without looking each author up one
+by one. Those two are supposed to always agree.
+
+When an edit changed the author by its internal reference, the code updated the
+reference but forgot to refresh the saved name next to it. The save routine has a
+safety rule that protects the saved name from being *accidentally blanked out*
+(that was the July 13 fix) — but that rule only kicks in when the name is missing
+entirely. Here the name wasn't missing; it was simply *the old one*, so the safety
+rule left it alone and the stale name was written to storage.
+
+Because the app trusts that saved-alongside name whenever it's present, the book
+then showed the previous author everywhere until something else happened to rewrite
+it. The same problem applied to a book's series.
+
+## What we changed
+
+The edit now refreshes the saved author and series names to match whichever author
+and series were chosen, and it does so **before** the record is written — so the
+stored copy is correct, not just the reply the screen happens to show right after
+saving. As a bonus, because this runs on every edit, any book that already had a
+mismatched name quietly corrects itself the next time it's touched.
+
+## Why it matters
+
+Author and series names are how a library is browsed and searched. A book that
+internally belongs to one author but visibly shows another is confusing, looks like
+lost data, and is hard to trace — the internal reference and the visible label
+disagree with no error to point at the cause. This change keeps the two in step at
+the moment of the edit, is covered by a regression test that checks what was
+actually saved to the real database (not just what the screen showed), and can be
+rolled back as a single change.

--- a/internal/audiobooks/service_mutation.go
+++ b/internal/audiobooks/service_mutation.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_mutation.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e7b1f6a5-b8c9-0d12-ce3f-4a5b6c7d8e9f
-// last-edited: 2026-06-23
+// last-edited: 2026-07-16
 
 package audiobooks
 
@@ -349,6 +349,26 @@ func (svc *AudiobookService) UpdateAudiobook(ctx context.Context, id string, req
 		entry.OverrideLocked = false
 		entry.UpdatedAt = now
 		state[field] = entry
+	}
+
+	// Sync the denormalized Author/Series display objects to the resolved IDs
+	// BEFORE persisting. Read paths prefer the embedded object when non-nil and
+	// only fall back to a GetAuthorByID/GetSeriesByID lookup when it is nil
+	// (see resolveAuthorAndSeriesNames in helpers.go and
+	// EnrichAudiobooksWithNames in service_query.go). currentBook — and thus
+	// payload.Book — carries the *old* Author/Series struct loaded by
+	// GetBookByID above; changing AuthorID/SeriesID here (via the direct
+	// author_id/series_id fields at the top, or the name-resolution branches)
+	// without refreshing the embedded object would persist a stale name.
+	// UpdateBook's preserve-on-nil guard cannot fix this (the stale object is
+	// non-nil), so the write side must honor its documented contract of setting
+	// BOTH the ID and a fresh object. This mirrors the response-enrichment block
+	// below, but must run before UpdateBook so the stored blob is correct too.
+	if payload.AuthorID != nil && resolvedAuthorName != "" {
+		payload.Book.Author = &database.Author{ID: *payload.AuthorID, Name: resolvedAuthorName}
+	}
+	if payload.SeriesID != nil && resolvedSeriesName != "" {
+		payload.Book.Series = &database.Series{ID: *payload.SeriesID, Name: resolvedSeriesName, AuthorID: payload.AuthorID}
 	}
 
 	// Save to database

--- a/internal/audiobooks/service_mutation_author_sync_test.go
+++ b/internal/audiobooks/service_mutation_author_sync_test.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_mutation_author_sync_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3f9a0c71-6d24-4e83-b1a7-5c8e9f0a2d13
 // last-edited: 2026-07-16
 
@@ -67,4 +67,47 @@ func TestUpdateAudiobook_SyncsDenormalizedAuthorOnIDChange(t *testing.T) {
 		"persisted Author.ID is stale — still points at the old author")
 	require.Equal(t, "New Author", reread.Author.Name,
 		"persisted Author.Name is stale — read paths would display the old author name")
+}
+
+// TestUpdateAudiobook_SyncsDenormalizedSeriesOnIDChange is the Series twin of
+// the author regression above — changing a book's series by series_id must keep
+// the embedded Series display object in sync with the FK, not persist the old
+// series' name.
+func TestUpdateAudiobook_SyncsDenormalizedSeriesOnIDChange(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+
+	oldSeries, err := ps.CreateSeries("Old Series", nil)
+	require.NoError(t, err)
+	newSeries, err := ps.CreateSeries("New Series", nil)
+	require.NoError(t, err)
+
+	book, err := ps.CreateBook(&database.Book{
+		Title:    "Test Book",
+		SeriesID: &oldSeries.ID,
+		Series:   &database.Series{ID: oldSeries.ID, Name: "Old Series"},
+	})
+	require.NoError(t, err)
+
+	svc := NewAudiobookService(ps)
+
+	_, err = svc.UpdateAudiobook(context.Background(), book.ID, &UpdateAudiobookRequest{
+		Updates: &AudiobookUpdate{
+			Book: &database.Book{SeriesID: &newSeries.ID},
+		},
+	})
+	require.NoError(t, err)
+
+	reread, err := ps.GetBookByID(book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reread)
+
+	require.NotNil(t, reread.SeriesID)
+	require.Equal(t, newSeries.ID, *reread.SeriesID, "SeriesID should be updated to the new series")
+
+	require.NotNil(t, reread.Series, "embedded Series should be populated")
+	require.Equal(t, newSeries.ID, reread.Series.ID,
+		"persisted Series.ID is stale — still points at the old series")
+	require.Equal(t, "New Series", reread.Series.Name,
+		"persisted Series.Name is stale — read paths would display the old series name")
 }

--- a/internal/audiobooks/service_mutation_author_sync_test.go
+++ b/internal/audiobooks/service_mutation_author_sync_test.go
@@ -1,0 +1,70 @@
+// file: internal/audiobooks/service_mutation_author_sync_test.go
+// version: 1.0.0
+// guid: 3f9a0c71-6d24-4e83-b1a7-5c8e9f0a2d13
+// last-edited: 2026-07-16
+
+package audiobooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateAudiobook_SyncsDenormalizedAuthorOnIDChange is a regression guard
+// for the stale denormalized-author write-back bug: changing a book's author by
+// author_id (not author_name) updated Book.AuthorID but left the embedded
+// Book.Author display struct pointing at the OLD author. UpdateBook's
+// preserve-on-nil guard could not fix it (the stale struct is non-nil), so the
+// stale name was persisted, and every read path
+// (resolveAuthorAndSeriesNames / EnrichAudiobooksWithNames) prefers the
+// embedded object when non-nil — so the wrong author name was displayed
+// indefinitely. The fix syncs the embedded object to the resolved ID BEFORE
+// persisting. This test re-reads the row straight from the store (not the
+// returned pointer, which the response-enrichment block fixes regardless) so it
+// asserts on what was actually written.
+func TestUpdateAudiobook_SyncsDenormalizedAuthorOnIDChange(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+
+	oldAuthor, err := ps.CreateAuthor("Old Author")
+	require.NoError(t, err)
+	newAuthor, err := ps.CreateAuthor("New Author")
+	require.NoError(t, err)
+
+	// Seed a book whose embedded Author matches its AuthorID (the correct
+	// starting state produced by any normal write).
+	book, err := ps.CreateBook(&database.Book{
+		Title:    "Test Book",
+		AuthorID: &oldAuthor.ID,
+		Author:   &database.Author{ID: oldAuthor.ID, Name: "Old Author"},
+	})
+	require.NoError(t, err)
+
+	svc := NewAudiobookService(ps)
+
+	// Change the author via author_id only — the exact reported path.
+	_, err = svc.UpdateAudiobook(context.Background(), book.ID, &UpdateAudiobookRequest{
+		Updates: &AudiobookUpdate{
+			Book: &database.Book{AuthorID: &newAuthor.ID},
+		},
+	})
+	require.NoError(t, err)
+
+	// Re-read from the store to inspect what was actually persisted.
+	reread, err := ps.GetBookByID(book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reread)
+
+	require.NotNil(t, reread.AuthorID)
+	require.Equal(t, newAuthor.ID, *reread.AuthorID, "AuthorID should be updated to the new author")
+
+	// The denormalized display object must track the FK, not lag behind it.
+	require.NotNil(t, reread.Author, "embedded Author should be populated")
+	require.Equal(t, newAuthor.ID, reread.Author.ID,
+		"persisted Author.ID is stale — still points at the old author")
+	require.Equal(t, "New Author", reread.Author.Name,
+		"persisted Author.Name is stale — read paths would display the old author name")
+}


### PR DESCRIPTION
## Problem

`UpdateAudiobook` (`internal/audiobooks/service_mutation.go`) changes a book's `AuthorID`/`SeriesID` — reachable via the `author_id`/`series_id` API fields (`update_service.go:86`) — but left the **embedded, denormalized `Author`/`Series` display object** pointing at the *old* record.

- `GetBookByID` loads the book with its old embedded `Author`.
- Setting `currentBook.AuthorID` changes the FK but not `currentBook.Author`.
- `UpdateBook`'s preserve-on-nil guard (`if book.Author == nil`) can't fix a **stale non-nil** struct, so the stale name is marshaled into the stored blob.
- The response-enrichment block (L369-374) runs *after* `UpdateBook` returns the same pointer, so it fixes only the in-memory reply — not the persisted row.
- Every read path — `resolveAuthorAndSeriesNames` (helpers.go) and `EnrichAudiobooksWithNames` (service_query.go) — **prefers the embedded object when non-nil**, only falling back to `GetAuthorByID` when it's `nil`.

Net effect: after changing a book's author (or series) by ID, the book's FK points at the new author while every screen displays the **old** author name — indefinitely, with no error. This is the inverse of the 2026-07-13 blank-on-nil author/series data-loss fix (that one handled nil; this one handles stale-non-nil).

## Fix

Sync the embedded `Author`/`Series` display object to the resolved ID **before** persisting, honoring `UpdateBook`'s documented "a write that changes the author must set BOTH the ID and a fresh object" contract. Reuses the exact construction from the existing post-persist enrichment (so the multi-author "A & B" combined-display case is preserved). Because it runs on every edit, it also self-heals any pre-existing mismatch.

## Test

`TestUpdateAudiobook_SyncsDenormalizedAuthorOnIDChange` seeds a book via a real `PebbleStore`, changes the author via `author_id` only, then **re-reads the row straight from the store** (not the returned pointer, which the response-enrichment fixes regardless) and asserts the persisted `Author.ID` **and** `Author.Name` track the new author. Verified it FAILS without the fix (persisted `Author.ID` stays the old author = 1) and passes with it.

- `go build ./...` clean
- `go vet ./internal/audiobooks/` clean
- `go test ./internal/audiobooks/ -race` green (48.9s)

Docs: CHANGELOG + TODO (`UPDATEBOOK-STALE-DENORMALIZED-AUTHOR`) + executive summary (`docs/executive-summaries/2026-07-16-stale-author-on-id-edit-executive-summary.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)