### PR TITLE
fix(server): unify destructive-reset authz on RequireAdmin + confirm token on /system/reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.165.0 -->
+<!-- version: 3.166.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,21 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(server): unify destructive-reset authz on RequireAdmin + require confirm token on /system/reset
+
+Two consistency gaps on the full-wipe endpoints:
+
+- `/system/reset` and `/system/factory-reset` gated on `PermSettingsManage` while the
+  sibling `/maintenance/wipe` uses `RequireAdmin()`. No live escalation in the default
+  roles (only admin has `settings.manage`), but a custom non-admin role granted
+  `settings.manage` could wipe the whole library via reset. Both now go through the same
+  admin-only subgroup (`RequireAdmin()`) as `/maintenance/wipe` and `/admin/*`.
+- `ResetSystem` (a full DB wipe) accepted a bare POST, while the *more* destructive
+  `FactoryReset` already required `{"confirm":"RESET"}`. `ResetSystem` now requires the
+  same token, so a mis-fired request can't silently erase the database.
+
+`internal/server/wire_system_routes.go`, `internal/server/handlers/system/handler.go`.
 
 #### July 16, 2026 - fix(audiobooks): editing a book's author by ID persisted a stale author name
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.7 -->
+<!-- version: 9.106.8 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1751,13 +1751,14 @@ must sequence, but A and B are parallelizable. Spawn:
   library grows. ✅ **FIXED 2026-07-16** (branch `fix/whole-library-fragile-limits`): all 11 switched
   to `GetAllBooksCore(0, 0)` after verifying each is whole-library intent. The two `itunes/backfill.go`
   sites were correctly left as-is (proper offset-cursor loops, not truncations). Closes the class.
-- [ ] **RESET-AUTHZ-CONSISTENCY** (2026-07-16, API authz bug hunt) — LOW: `/system/reset` &
-  `/system/factory-reset` (`wire_system_routes.go:31-32`) gate on `PermSettingsManage` while the
-  sibling `/maintenance/wipe` (`server_lifecycle.go:1284`) gates on `RequireAdmin()`. No live
-  escalation in default roles (only admin has settings.manage), but a custom non-admin role with
-  settings.manage could full-wipe via reset. Also `ResetSystem` (full DB wipe) lacks the
-  `{"confirm":"RESET"}` token that the *more* destructive `FactoryReset` requires. Fix: gate all
-  three destructive endpoints on one model (`RequireAdmin()`) + add confirm token to `ResetSystem`.
+- [x] **RESET-AUTHZ-CONSISTENCY** (2026-07-16, API authz bug hunt) — ✅ **FIXED 2026-07-16**
+  (branch `fix/reset-authz-consistency`). `/system/reset` & `/system/factory-reset` now go through
+  the same admin-only subgroup (`RequireAdmin()`) as `/maintenance/wipe` and `/admin/*`, instead of
+  the weaker `PermSettingsManage` — a custom non-admin role granted `settings.manage` can no longer
+  full-wipe via reset. `ResetSystem` now requires the same `{"confirm":"RESET"}` token as the more
+  destructive `FactoryReset`, so a bare/mis-fired POST can't silently wipe the DB. Regression test
+  `TestResetSystem_RequiresConfirm` asserts 400 + no `store.Reset()` call without the token; existing
+  reset tests updated to send it. `wire_system_routes.go`, `handlers/system/handler.go`.
 
 - [ ] **RECONCILE-SERIAL-LOOPS** (2026-07-16, concurrency bug hunt) — two remaining serial
   full-library loops in `internal/reconcile/reconcile.go` (the hashing loop was parallelized

--- a/internal/server/handlers/system/handler.go
+++ b/internal/server/handlers/system/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 8475f406-df31-4286-95b0-30787397603e
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 // Package system hosts the system-level HTTP handlers extracted from the server
 // package: health, status, announcements, storage, logs, activity-log,
@@ -368,6 +368,19 @@ func (h *Handler) GetSystemActivityLog(c *gin.Context) {
 
 // ResetSystem implements POST /system/reset.
 func (h *Handler) ResetSystem(c *gin.Context) {
+	// Require the same explicit {"confirm":"RESET"} token that the more
+	// destructive FactoryReset requires — ResetSystem also wipes the entire
+	// database (books, authors, series, settings), so a bare POST must not be
+	// enough to trigger it. Keep the token string identical to FactoryReset so
+	// callers use one confirmation contract for both.
+	var req struct {
+		Confirm string `json:"confirm"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil || req.Confirm != "RESET" {
+		httputil.RespondWithBadRequest(c, "request body must contain {\"confirm\": \"RESET\"}")
+		return
+	}
+
 	store := h.resolveStore()
 	// Reset database
 	if err := store.Reset(); err != nil {

--- a/internal/server/handlers/system/handler_test.go
+++ b/internal/server/handlers/system/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/system/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: af6670e5-d640-4339-b0b2-3b0cf1596ce7
-// last-edited: 2026-07-07
+// last-edited: 2026-07-16
 
 // Unit tests for the system-domain HTTP handlers. Each public method has at
 // least one test; happy paths plus key branches (config mask-secrets path,
@@ -274,7 +274,7 @@ func TestResetSystem_OK(t *testing.T) {
 	d.store.EXPECT().Reset().Return(nil)
 	d.store.EXPECT().InvalidateLibraryStats().Return()
 
-	w := run(http.MethodPost, "/system/reset", "/system/reset", nil, func(r *gin.Engine) {
+	w := run(http.MethodPost, "/system/reset", "/system/reset", []byte(`{"confirm":"RESET"}`), func(r *gin.Engine) {
 		r.POST("/system/reset", h.ResetSystem)
 	})
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -284,10 +284,23 @@ func TestResetSystem_DBError(t *testing.T) {
 	h, d := newTestHandler(t)
 	d.store.EXPECT().Reset().Return(errors.New("reset failed"))
 
-	w := run(http.MethodPost, "/system/reset", "/system/reset", nil, func(r *gin.Engine) {
+	w := run(http.MethodPost, "/system/reset", "/system/reset", []byte(`{"confirm":"RESET"}`), func(r *gin.Engine) {
 		r.POST("/system/reset", h.ResetSystem)
 	})
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestResetSystem_RequiresConfirm is a regression guard: ResetSystem wipes the
+// whole database, so a bare POST (or a wrong token) must be rejected with 400
+// before store.Reset() is ever called — matching FactoryReset. Without the
+// confirm gate this returned 200 and wiped the DB. The mock store asserts no
+// Reset() call (unexpected calls fail the test).
+func TestResetSystem_RequiresConfirm(t *testing.T) {
+	h, _ := newTestHandler(t)
+	w := run(http.MethodPost, "/system/reset", "/system/reset", []byte(`{"confirm":"nope"}`), func(r *gin.Engine) {
+		r.POST("/system/reset", h.ResetSystem)
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // --- FactoryReset ---

--- a/internal/server/handlers_unit_test.go
+++ b/internal/server/handlers_unit_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers_unit_test.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: f8a2d1c3-4b5e-6789-abcd-ef0123456789
-// last-edited: 2026-07-06
+// last-edited: 2026-07-16
 //
 // Unit tests for HTTP handlers using MockStore + httptest.
 // Focuses on handlers that directly call s.Store() without
@@ -762,7 +762,7 @@ func TestHandler_ResetSystem_Success(t *testing.T) {
 
 	router.POST("/system/reset", newSystemHandler(srv).ResetSystem)
 
-	req := httptest.NewRequest("POST", "/system/reset", nil)
+	req := httptest.NewRequest("POST", "/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
@@ -776,7 +776,7 @@ func TestHandler_ResetSystem_StoreError(t *testing.T) {
 
 	router.POST("/system/reset", newSystemHandler(srv).ResetSystem)
 
-	req := httptest.NewRequest("POST", "/system/reset", nil)
+	req := httptest.NewRequest("POST", "/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 

--- a/internal/server/reset_handler_test.go
+++ b/internal/server/reset_handler_test.go
@@ -1,6 +1,7 @@
 // file: internal/server/reset_handler_test.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
+// last-edited: 2026-07-16
 
 package server
 
@@ -38,7 +39,7 @@ func TestResetSystem_Success(t *testing.T) {
 	config.AppConfig.AutoOrganize = false
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte("{}")))
+	req := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -87,7 +88,7 @@ func TestResetSystem_Error(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte("{}")))
+	req := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	c, _ := gin.CreateTestContext(w)
 	c.Request = req
@@ -118,7 +119,7 @@ func TestResetSystem_MultipleResets(t *testing.T) {
 	config.AppConfig.LogLevel = "debug"
 
 	w1 := httptest.NewRecorder()
-	req1 := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte("{}")))
+	req1 := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	req1.Header.Set("Content-Type", "application/json")
 	c1, _ := gin.CreateTestContext(w1)
 	c1.Request = req1
@@ -137,7 +138,7 @@ func TestResetSystem_MultipleResets(t *testing.T) {
 	config.AppConfig.LogLevel = "debug"
 
 	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte("{}")))
+	req2 := httptest.NewRequest("POST", "/api/v1/system/reset", bytes.NewReader([]byte(`{"confirm":"RESET"}`)))
 	req2.Header.Set("Content-Type", "application/json")
 	c2, _ := gin.CreateTestContext(w2)
 	c2.Request = req2

--- a/internal/server/wire_system_routes.go
+++ b/internal/server/wire_system_routes.go
@@ -1,13 +1,14 @@
 // file: internal/server/wire_system_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a7b8c9d0-e1f2-3456-abcd-789012345678
-// last-edited: 2026-06-30
+// last-edited: 2026-07-16
 
 package server
 
 import (
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	system "github.com/falkcorp/audiobook-organizer/internal/server/handlers/system"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
 	"github.com/gin-gonic/gin"
 )
 
@@ -28,8 +29,17 @@ func (s *Server) wireSystemRoutes(
 	protected.GET("/system/storage", s.perm(auth.PermSettingsManage), systemH.GetSystemStorage)
 	protected.GET("/system/logs", s.perm(auth.PermSettingsManage), systemH.GetSystemLogs)
 	protected.GET("/system/activity-log", s.perm(auth.PermSettingsManage), systemH.GetSystemActivityLog)
-	protected.POST("/system/reset", s.perm(auth.PermSettingsManage), systemH.ResetSystem)
-	protected.POST("/system/factory-reset", s.perm(auth.PermSettingsManage), systemH.FactoryReset)
+	// Destructive full-wipe endpoints: gate on RequireAdmin() to match the
+	// sibling /maintenance/wipe (server_lifecycle.go) rather than the weaker
+	// PermSettingsManage — a custom non-admin role granted settings.manage must
+	// not be able to wipe the whole library via reset. Same admin-only subgroup
+	// pattern used in server_lifecycle.go and wire_library_routes.go.
+	adminOnly := protected.Group("")
+	adminOnly.Use(servermiddleware.RequireAdmin())
+	{
+		adminOnly.POST("/system/reset", systemH.ResetSystem)
+		adminOnly.POST("/system/factory-reset", systemH.FactoryReset)
+	}
 	protected.GET("/config", s.perm(auth.PermSettingsManage), systemH.GetConfig)
 	protected.PUT("/config", s.perm(auth.PermSettingsManage), systemH.UpdateConfig)
 	protected.GET("/dashboard", s.perm(auth.PermLibraryView), systemH.GetDashboard)

--- a/web/tests/e2e/utils/setup-modes.ts
+++ b/web/tests/e2e/utils/setup-modes.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/utils/setup-modes.ts
-// version: 3.0.0
+// version: 3.0.1
 // guid: f1e2d3c4-b5a6-7890-cdef-a1b2c3d4e5f6
-// last-edited: 2026-02-07
+// last-edited: 2026-07-16
 
 import { Page } from '@playwright/test';
 import type { MockApiOptions } from './test-helpers';
@@ -30,7 +30,9 @@ export async function resetToFactoryDefaults(
           const res = await fetch(`${baseURL}/api/v1/system/reset`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({}),
+            // /system/reset now requires the same {"confirm":"RESET"} token as
+            // /system/factory-reset (a bare POST is rejected with 400).
+            body: JSON.stringify({ confirm: 'RESET' }),
           });
           return { success: res.ok, status: res.status };
         } catch (error) {


### PR DESCRIPTION
Closes the **RESET-AUTHZ-CONSISTENCY** TODO item (API authz bug hunt, 2026-07-16, LOW).

## Two gaps on the full-wipe endpoints

**1. Inconsistent authz.** `/system/reset` and `/system/factory-reset` gated on `PermSettingsManage`, while the sibling destructive endpoint `/maintenance/wipe` (and `/admin/*`, `/cache/stats/keys`) gate on `RequireAdmin()`. In the default roles only admin has `settings.manage`, so there's no live escalation — but a **custom non-admin role granted `settings.manage`** could wipe the entire library via reset. Both reset endpoints now go through the same admin-only subgroup as `/maintenance/wipe`, using the established pattern:

```go
adminOnly := protected.Group("")
adminOnly.Use(servermiddleware.RequireAdmin())
{
    adminOnly.POST("/system/reset", systemH.ResetSystem)
    adminOnly.POST("/system/factory-reset", systemH.FactoryReset)
}
```

**2. Missing confirm token.** `ResetSystem` performs a full DB wipe (books, authors, series, settings) but accepted a **bare POST**, while the *more* destructive `FactoryReset` already required `{"confirm":"RESET"}`. `ResetSystem` now requires the same token — a mis-fired or accidental request can't silently erase the database.

## Behavior note

When `EnableAuth=false` the `authMiddleware` is a passthrough that injects no user, so `RequireAdmin()` 401s — meaning these two endpoints become unreachable in auth-disabled dev mode, exactly like `/maintenance/wipe` already is. That's the intended, safer posture for a destructive full-wipe op and the point of unifying on one model.

## Test

- `TestResetSystem_RequiresConfirm` (new): a wrong/absent token → **400**, and the mock store asserts `Reset()` is **never called**. Fails without the confirm gate (previously 200 + DB wiped).
- `TestResetSystem_OK` / `TestResetSystem_DBError` updated to send the token.
- `go build ./...`, `go vet ./internal/server/...` clean; `go test ./internal/server/handlers/system/` green.

Docs: CHANGELOG + TODO updated. No executive summary — LOW-severity defense-in-depth hardening, single-PR, no observed data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)