### PR TITLE
perf(reconcile): parallelize the last two serial whole-library loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.166.0 -->
+<!-- version: 3.167.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,27 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - perf(reconcile): parallelize the last two serial whole-library loops
+
+Follow-up to #1960 (`hashFilesConcurrent`). The two remaining single-core hotspots in
+`internal/reconcile/reconcile.go` now run across a bounded `errgroup` pool sized to
+`runtime.NumCPU()`:
+
+- **`BuildReconcilePreviewWithProgress` path-check** — the per-book `os.Stat` over the
+  whole library now runs concurrently; `knownPaths` is built in a cheap serial pre-pass,
+  and each stat records into its own index slot so the ordered `brokenBooks` /
+  `BrokenRecords` fold is byte-for-byte identical to the former sequential build.
+- **`FindBrokenSegmentBooks`** — the outer per-book loop (directory stat + `GetBookFiles`
+  + per-segment stat storm + non-dry-run hydrate/`UpdateBook`) is now sharded across
+  workers. Work partitions by book index, so each book's DB row is touched by exactly one
+  worker and the per-book `UpdateBook` writes never race (they only flip
+  `LibraryState`/`MarkedForDeletion`, no secondary-indexed field). `Details` lands in
+  per-index slots and folds in book order; counters are atomic.
+
+Output is unchanged — same broken records, same order, same counts. Adds the package's
+first behavioral tests (`reconcile_parallel_test.go`), run under `-race`, asserting
+order-preservation and exact counts for both loops. Closes `RECONCILE-SERIAL-LOOPS`.
 
 #### July 16, 2026 - fix(server): unify destructive-reset authz on RequireAdmin + require confirm token on /system/reset
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.8 -->
+<!-- version: 9.106.9 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -1760,16 +1760,17 @@ must sequence, but A and B are parallelizable. Spawn:
   `TestResetSystem_RequiresConfirm` asserts 400 + no `store.Reset()` call without the token; existing
   reset tests updated to send it. `wire_system_routes.go`, `handlers/system/handler.go`.
 
-- [ ] **RECONCILE-SERIAL-LOOPS** (2026-07-16, concurrency bug hunt) — two remaining serial
-  full-library loops in `internal/reconcile/reconcile.go` (the hashing loop was parallelized
-  2026-07-16 via `hashFilesConcurrent`, branch `perf/reconcile-parallel-loops`): (1)
-  `FindBrokenSegmentBooks` (~L750) does per-book `os.Stat` + `GetBookFiles` + `GetBookByID` +
-  `UpdateBook` over `GetAllBooksCore(100000,0)` fully serially — the per-book `UpdateBook` writes
-  are per-distinct-book so they parallelize safely; (2) the path-check loop (~L217) does serial
-  `os.Stat` over up to 100k books. Both are lower priority than the hash loop (I/O-bound; #2 also
-  mutates order-sensitive shared state — `knownPaths` map + ordered `brokenBooks`/`BrokenRecords`
-  slices — so needs partitioning/sharded-collect + a test, not a naive fan-out). No tests exist in
-  this package yet beyond `reconcile_hash_test.go`.
+- [x] **RECONCILE-SERIAL-LOOPS** (2026-07-16, concurrency bug hunt) — ✅ **FIXED 2026-07-16**
+  (branch `perf/reconcile-parallel-loops-2`). Both remaining serial full-library loops in
+  `internal/reconcile/reconcile.go` now run across an `errgroup` pool sized to `runtime.NumCPU()`:
+  (1) `FindBrokenSegmentBooks` — outer per-book loop (dir stat + `GetBookFiles` + per-segment stat +
+  non-dry-run hydrate/`UpdateBook`) sharded by book index (each row touched by one worker → writes
+  never race; only `LibraryState`/`MarkedForDeletion` flip, no secondary-indexed field), `Details`
+  collected in index slots + folded in book order, atomic counters; (2) the `BuildReconcilePreview`
+  path-check — per-book `os.Stat` parallelized, `knownPaths` built in a serial pre-pass, results in
+  index slots so the ordered `brokenBooks`/`BrokenRecords` fold is identical to the sequential build.
+  Output byte-for-byte unchanged. Added the package's first behavioral tests
+  (`reconcile_parallel_test.go`, run under `-race`) asserting order-preservation + exact counts.
 
 - [x] **UPDATEBOOK-STALE-DENORMALIZED-AUTHOR** (2026-07-16, write-path bug hunt) — ✅ **FIXED
   2026-07-16** (branch `fix/update-audiobook-stale-denormalized-author`). `UpdateAudiobook`

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,5 +1,5 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-07-16
 
@@ -256,22 +256,49 @@ func BuildReconcilePreviewWithProgress(store Store, log logger.Logger) (*Reconci
 		return result, nil
 	}
 	report(0, totalBooks, fmt.Sprintf("Checking file paths for %d books...", totalBooks))
-	for i, book := range books {
-		if book.FilePath == "" {
+	// knownPaths is a cheap in-memory set build with no I/O, so keep it serial.
+	for i := range books {
+		if books[i].FilePath != "" {
+			knownPaths[books[i].FilePath] = true
+		}
+	}
+	// The per-book os.Stat is the expensive part — on whole-library scans over
+	// network/ZFS storage a serial loop of tens of thousands of stat syscalls is
+	// a CLAUDE.md concurrency-mandate hotspot (twin of hashFilesConcurrent, added
+	// in #1960). Run the stats across a bounded worker pool, recording each
+	// result into its own index slot so the ordered brokenBooks / BrokenRecords
+	// fold below is byte-for-byte identical to the former sequential build. Books
+	// with an empty FilePath were skipped before (never broken); brokenFlag stays
+	// false for them.
+	brokenFlag := make([]bool, len(books))
+	var statDone int64
+	var g errgroup.Group
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	for i := range books {
+		if books[i].FilePath == "" {
 			continue
 		}
-		knownPaths[book.FilePath] = true
-		if _, err := os.Stat(book.FilePath); err != nil {
-			brokenBooks = append(brokenBooks, book)
+		g.Go(func() error {
+			if _, err := os.Stat(books[i].FilePath); err != nil {
+				brokenFlag[i] = true
+			}
+			if n := atomic.AddInt64(&statDone, 1); n%1000 == 0 {
+				report(int(n), totalBooks, fmt.Sprintf("Checked %d/%d book paths", n, totalBooks))
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // os.Stat errors are the signal (broken), never fatal here
+
+	for i := range books {
+		if brokenFlag[i] {
+			brokenBooks = append(brokenBooks, books[i])
 			result.BrokenRecords = append(result.BrokenRecords, ReconcileBrokenRecord{
-				BookID:   book.ID,
-				Title:    book.Title,
-				FilePath: book.FilePath,
-				FileHash: book.FileHash,
+				BookID:   books[i].ID,
+				Title:    books[i].Title,
+				FilePath: books[i].FilePath,
+				FileHash: books[i].FileHash,
 			})
-		}
-		if i%1000 == 0 && i > 0 {
-			report(i, totalBooks, fmt.Sprintf("Checked %d/%d book paths (%d broken so far)", i, totalBooks, len(brokenBooks)))
 		}
 	}
 	report(totalBooks, totalBooks, fmt.Sprintf("Checked %d/%d book paths (%d broken)", totalBooks, totalBooks, len(brokenBooks)))
@@ -773,67 +800,96 @@ func FindBrokenSegmentBooks(store Store, dryRun bool) (*BrokenSegmentResult, err
 	now := time.Now()
 	needsReview := "needs_review"
 
-	for _, book := range allBooks {
+	// Each book does a directory stat + GetBookFiles + a per-segment stat storm +
+	// (non-dry-run) a hydrate/UpdateBook — a whole-library-scale I/O-bound loop and
+	// a CLAUDE.md concurrency-mandate hotspot. Shard the OUTER loop across a bounded
+	// worker pool. Correctness under concurrency:
+	//   - Work partitions by book index, so each book (and its DB row) is touched
+	//     by exactly one worker; the per-book UpdateBook writes are to disjoint keys
+	//     and never race (they also only flip LibraryState/MarkedForDeletion, not
+	//     any secondary-indexed field, so no cross-book index contention).
+	//   - Per-book output lands in its own index slot (entries[i]); result.Details
+	//     is folded in book order afterwards, so it is identical to the former
+	//     sequential append order.
+	//   - Counters are atomic and assigned once at the end.
+	entries := make([]*BrokenSegmentEntry, len(allBooks))
+	var booksChecked, brokenBooks, markedForReview int64
+	var g errgroup.Group
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	for i := range allBooks {
+		book := allBooks[i]
 		// Only check directory-based books in import paths (not in library)
 		if config.AppConfig.RootDir != "" && strings.HasPrefix(book.FilePath, config.AppConfig.RootDir) {
 			continue
 		}
-		info, serr := os.Stat(book.FilePath)
-		if serr != nil || !info.IsDir() {
-			continue
-		}
-
-		files, segErr := store.GetBookFiles(book.ID)
-		if segErr != nil || len(files) == 0 {
-			continue
-		}
-
-		result.BooksChecked++
-		var missingPaths []string
-		activeCount := 0
-		for _, f := range files {
-			if f.Missing || f.FilePath == "" {
-				continue
+		g.Go(func() error {
+			info, serr := os.Stat(book.FilePath)
+			if serr != nil || !info.IsDir() {
+				return nil
 			}
-			activeCount++
-			if _, ferr := os.Stat(f.FilePath); os.IsNotExist(ferr) {
-				missingPaths = append(missingPaths, f.FilePath)
+
+			files, segErr := store.GetBookFiles(book.ID)
+			if segErr != nil || len(files) == 0 {
+				return nil
 			}
-		}
 
-		if len(missingPaths) == 0 {
-			continue
-		}
-
-		entry := BrokenSegmentEntry{
-			BookID:          book.ID,
-			Title:           book.Title,
-			FilePath:        book.FilePath,
-			TotalSegments:   activeCount,
-			MissingSegments: len(missingPaths),
-			MissingPaths:    missingPaths,
-		}
-		result.Details = append(result.Details, entry)
-		result.BrokenBooks++
-
-		if !dryRun {
-			// Hydrate before writeback — book is a Core (slim) value here, and
-			// writing it straight through UpdateBook would wipe Author/Series.
-			full, ferr := store.GetBookByID(book.ID)
-			if ferr != nil || full == nil {
-				slog.Warn("failed to hydrate broken book for update", "book", book.ID, "ferr", ferr)
-			} else {
-				full.LibraryState = &needsReview
-				full.MarkedForDeletion = boolPtr(true)
-				full.MarkedForDeletionAt = &now
-				if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
-					slog.Warn("failed to mark broken book", "book", full.ID, "uerr", uerr)
-				} else {
-					result.MarkedForReview++
+			atomic.AddInt64(&booksChecked, 1)
+			var missingPaths []string
+			activeCount := 0
+			for _, f := range files {
+				if f.Missing || f.FilePath == "" {
+					continue
+				}
+				activeCount++
+				if _, ferr := os.Stat(f.FilePath); os.IsNotExist(ferr) {
+					missingPaths = append(missingPaths, f.FilePath)
 				}
 			}
+
+			if len(missingPaths) == 0 {
+				return nil
+			}
+
+			entries[i] = &BrokenSegmentEntry{
+				BookID:          book.ID,
+				Title:           book.Title,
+				FilePath:        book.FilePath,
+				TotalSegments:   activeCount,
+				MissingSegments: len(missingPaths),
+				MissingPaths:    missingPaths,
+			}
+			atomic.AddInt64(&brokenBooks, 1)
+
+			if !dryRun {
+				// Hydrate before writeback — book is a Core (slim) value here, and
+				// writing it straight through UpdateBook would wipe Author/Series.
+				full, ferr := store.GetBookByID(book.ID)
+				if ferr != nil || full == nil {
+					slog.Warn("failed to hydrate broken book for update", "book", book.ID, "ferr", ferr)
+				} else {
+					full.LibraryState = &needsReview
+					full.MarkedForDeletion = boolPtr(true)
+					full.MarkedForDeletionAt = &now
+					if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+						slog.Warn("failed to mark broken book", "book", full.ID, "uerr", uerr)
+					} else {
+						atomic.AddInt64(&markedForReview, 1)
+					}
+				}
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // per-book errors are logged and skipped, never fatal
+
+	for _, e := range entries {
+		if e != nil {
+			result.Details = append(result.Details, *e)
 		}
 	}
+	result.BooksChecked = int(booksChecked)
+	result.BrokenBooks = int(brokenBooks)
+	result.MarkedForReview = int(markedForReview)
 
 	return result, nil
 }

--- a/internal/reconcile/reconcile_parallel_test.go
+++ b/internal/reconcile/reconcile_parallel_test.go
@@ -1,5 +1,5 @@
 // file: internal/reconcile/reconcile_parallel_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c7f1a94-3e60-4d18-9b5a-8f0c6d2e1a37
 // last-edited: 2026-07-16
 
@@ -212,6 +212,71 @@ func TestBuildReconcilePreview_ParallelBrokenOrder(t *testing.T) {
 	}
 	if !equalStrings(gotIDs, wantBrokenIDs) {
 		t.Errorf("BrokenRecords order = %v, want %v (book order, not pool order)", gotIDs, wantBrokenIDs)
+	}
+}
+
+// TestFindBrokenSegmentBooks_RealStoreConcurrent drives the non-dry-run write
+// path against a REAL PebbleStore (not the mutex-guarded fake) so `go test
+// -race` exercises concurrent GetBookByID / GetBookFiles / UpdateBook —
+// including the memdb write-through — across the worker pool. This is the
+// check that actually proves the production behavior change is safe: a
+// concurrent unlocked-map access in the store would surface here as a race or a
+// fatal panic. Every book is broken, so every worker performs a hydrate+update,
+// maximizing write concurrency.
+func TestFindBrokenSegmentBooks_RealStoreConcurrent(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new pebble store: %v", err)
+	}
+
+	prevRoot := config.AppConfig.RootDir
+	config.AppConfig.RootDir = "" // disable the library-prefix skip; check all books
+	defer func() { config.AppConfig.RootDir = prevRoot }()
+
+	base := t.TempDir()
+	const n = 40 // enough books to keep NumCPU workers genuinely contending
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		dir := filepath.Join(base, fmt.Sprintf("book-%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		seg0 := writeFile(t, dir, "seg0.m4b", "s0")             // present
+		seg1 := filepath.Join(dir, "seg1-missing.m4b")         // never written → missing
+		book, err := ps.CreateBook(&database.Book{Title: fmt.Sprintf("book %d", i), FilePath: dir})
+		if err != nil {
+			t.Fatalf("create book: %v", err)
+		}
+		ids = append(ids, book.ID)
+		for _, fp := range []string{seg0, seg1} {
+			if err := ps.CreateBookFile(&database.BookFile{BookID: book.ID, FilePath: fp}); err != nil {
+				t.Fatalf("create book file: %v", err)
+			}
+		}
+	}
+
+	res, err := FindBrokenSegmentBooks(ps, false)
+	if err != nil {
+		t.Fatalf("FindBrokenSegmentBooks: %v", err)
+	}
+	if res.BooksChecked != n {
+		t.Errorf("BooksChecked = %d, want %d", res.BooksChecked, n)
+	}
+	if res.BrokenBooks != n {
+		t.Errorf("BrokenBooks = %d, want %d", res.BrokenBooks, n)
+	}
+	if res.MarkedForReview != n {
+		t.Errorf("MarkedForReview = %d, want %d", res.MarkedForReview, n)
+	}
+	// Confirm the writes actually persisted through the store (not just counted).
+	for _, id := range ids {
+		b, err := ps.GetBookByID(id)
+		if err != nil || b == nil {
+			t.Fatalf("re-read %s: %v", id, err)
+		}
+		if b.LibraryState == nil || *b.LibraryState != "needs_review" {
+			t.Errorf("book %s LibraryState = %v, want needs_review", id, b.LibraryState)
+		}
 	}
 }
 

--- a/internal/reconcile/reconcile_parallel_test.go
+++ b/internal/reconcile/reconcile_parallel_test.go
@@ -1,0 +1,228 @@
+// file: internal/reconcile/reconcile_parallel_test.go
+// version: 1.0.0
+// guid: 2c7f1a94-3e60-4d18-9b5a-8f0c6d2e1a37
+// last-edited: 2026-07-16
+
+package reconcile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// fakeReconcileStore is a minimal, concurrency-safe Store double. It embeds the
+// full database.Store interface so it satisfies reconcile.Store (a subset);
+// only the handful of methods the parallelized loops touch are implemented, and
+// any other call would nil-panic (it never happens in these tests). The mutex
+// guards the maps against the worker pools so `go test -race` exercises the
+// concurrent access. `books` is read-only during a run.
+type fakeReconcileStore struct {
+	database.Store
+	books   []database.BookCore
+	files   map[string][]database.BookFile
+	byID    map[string]*database.Book
+	updated map[string]*database.Book
+	mu      chan struct{} // 1-slot semaphore used as a mutex
+}
+
+func newFakeStore() *fakeReconcileStore {
+	return &fakeReconcileStore{
+		files:   map[string][]database.BookFile{},
+		byID:    map[string]*database.Book{},
+		updated: map[string]*database.Book{},
+		mu:      make(chan struct{}, 1),
+	}
+}
+
+func (f *fakeReconcileStore) lock()   { f.mu <- struct{}{} }
+func (f *fakeReconcileStore) unlock() { <-f.mu }
+
+func (f *fakeReconcileStore) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
+	return f.books, nil
+}
+
+func (f *fakeReconcileStore) GetAllImportPaths() ([]database.ImportPath, error) {
+	return nil, nil
+}
+
+func (f *fakeReconcileStore) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	f.lock()
+	defer f.unlock()
+	return f.files[bookID], nil
+}
+
+func (f *fakeReconcileStore) GetBookByID(id string) (*database.Book, error) {
+	f.lock()
+	defer f.unlock()
+	return f.byID[id], nil
+}
+
+func (f *fakeReconcileStore) UpdateBook(id string, book *database.Book) (*database.Book, error) {
+	f.lock()
+	defer f.unlock()
+	f.updated[id] = book
+	return book, nil
+}
+
+// TestFindBrokenSegmentBooks_ParallelOrderAndCounts verifies the parallelized
+// FindBrokenSegmentBooks: Details must come out in book order (not scrambled by
+// the worker pool), the counters must be exact, and the non-dry-run write path
+// must mark exactly the broken books. Broken indices are deliberately
+// non-contiguous {1,3,4,6} so a concurrency-scrambled fold would be detected.
+// Run under -race to exercise the pool.
+func TestFindBrokenSegmentBooks_ParallelOrderAndCounts(t *testing.T) {
+	prevRoot := config.AppConfig.RootDir
+	config.AppConfig.RootDir = "" // disable the library-prefix skip; check all books
+	defer func() { config.AppConfig.RootDir = prevRoot }()
+
+	base := t.TempDir()
+	const n = 8
+	brokenSet := map[int]bool{1: true, 3: true, 4: true, 6: true}
+
+	store := newFakeStore()
+	var wantBrokenIDs []string
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("book-%02d", i)
+		dir := filepath.Join(base, id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		// Segment 0 always present on disk.
+		seg0 := writeFile(t, dir, "seg0.m4b", "s0")
+		var seg1 string
+		if brokenSet[i] {
+			seg1 = filepath.Join(dir, "seg1-missing.m4b") // never written → missing
+			wantBrokenIDs = append(wantBrokenIDs, id)
+		} else {
+			seg1 = writeFile(t, dir, "seg1.m4b", "s1")
+		}
+		store.books = append(store.books, database.BookCore{ID: id, Title: id, FilePath: dir})
+		store.files[id] = []database.BookFile{
+			{FilePath: seg0},
+			{FilePath: seg1},
+		}
+		store.byID[id] = &database.Book{ID: id, Title: id, FilePath: dir}
+	}
+
+	// --- dry run: no writes, but full detection + ordering + counts ---
+	res, err := FindBrokenSegmentBooks(store, true)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if res.BooksChecked != n {
+		t.Errorf("BooksChecked = %d, want %d", res.BooksChecked, n)
+	}
+	if res.BrokenBooks != len(wantBrokenIDs) {
+		t.Errorf("BrokenBooks = %d, want %d", res.BrokenBooks, len(wantBrokenIDs))
+	}
+	if res.MarkedForReview != 0 {
+		t.Errorf("MarkedForReview = %d, want 0 on dry run", res.MarkedForReview)
+	}
+	if len(store.updated) != 0 {
+		t.Errorf("dry run wrote %d books, want 0", len(store.updated))
+	}
+	gotIDs := make([]string, len(res.Details))
+	for i, d := range res.Details {
+		gotIDs[i] = d.BookID
+	}
+	if !equalStrings(gotIDs, wantBrokenIDs) {
+		t.Errorf("Details order = %v, want %v (must match book order, not pool order)", gotIDs, wantBrokenIDs)
+	}
+
+	// --- real run: same detection, plus each broken book marked needs_review ---
+	store2 := newFakeStore()
+	store2.books = store.books
+	store2.files = store.files
+	for _, b := range store.books {
+		bk := *store.byID[b.ID]
+		store2.byID[b.ID] = &bk
+	}
+	res2, err := FindBrokenSegmentBooks(store2, false)
+	if err != nil {
+		t.Fatalf("real run: %v", err)
+	}
+	if res2.MarkedForReview != len(wantBrokenIDs) {
+		t.Errorf("MarkedForReview = %d, want %d", res2.MarkedForReview, len(wantBrokenIDs))
+	}
+	if len(store2.updated) != len(wantBrokenIDs) {
+		t.Errorf("wrote %d books, want %d", len(store2.updated), len(wantBrokenIDs))
+	}
+	for _, id := range wantBrokenIDs {
+		b, ok := store2.updated[id]
+		if !ok {
+			t.Errorf("broken book %s was not marked", id)
+			continue
+		}
+		if b.LibraryState == nil || *b.LibraryState != "needs_review" {
+			t.Errorf("book %s LibraryState = %v, want needs_review", id, b.LibraryState)
+		}
+		if b.MarkedForDeletion == nil || !*b.MarkedForDeletion {
+			t.Errorf("book %s MarkedForDeletion not set", id)
+		}
+	}
+}
+
+// TestBuildReconcilePreview_ParallelBrokenOrder verifies the parallelized
+// path-check loop in BuildReconcilePreviewWithProgress: BrokenRecords must list
+// exactly the books whose FilePath is missing on disk, in book order, even
+// though the stats run concurrently. With no import paths/root/iTunes dirs,
+// FindUntrackedFiles returns nothing and the preview returns the broken records
+// as UnmatchedBooks — enough to assert on the parallel fold. Broken indices
+// {0,2,5} are non-contiguous.
+func TestBuildReconcilePreview_ParallelBrokenOrder(t *testing.T) {
+	prevRoot := config.AppConfig.RootDir
+	prevITunes := config.AppConfig.ITunes.LibraryReadPath
+	config.AppConfig.RootDir = ""
+	config.AppConfig.ITunes.LibraryReadPath = ""
+	defer func() {
+		config.AppConfig.RootDir = prevRoot
+		config.AppConfig.ITunes.LibraryReadPath = prevITunes
+	}()
+
+	base := t.TempDir()
+	const n = 7
+	brokenSet := map[int]bool{0: true, 2: true, 5: true}
+
+	store := newFakeStore()
+	var wantBrokenIDs []string
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("bk-%02d", i)
+		var path string
+		if brokenSet[i] {
+			path = filepath.Join(base, id+"-missing.m4b") // never created → broken
+			wantBrokenIDs = append(wantBrokenIDs, id)
+		} else {
+			path = writeFile(t, base, id+".m4b", "present")
+		}
+		store.books = append(store.books, database.BookCore{ID: id, Title: id, FilePath: path})
+	}
+
+	res, err := BuildReconcilePreview(store)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	gotIDs := make([]string, len(res.BrokenRecords))
+	for i, r := range res.BrokenRecords {
+		gotIDs[i] = r.BookID
+	}
+	if !equalStrings(gotIDs, wantBrokenIDs) {
+		t.Errorf("BrokenRecords order = %v, want %v (book order, not pool order)", gotIDs, wantBrokenIDs)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes the **RECONCILE-SERIAL-LOOPS** TODO item — the follow-up to #1960 (`hashFilesConcurrent`). The two remaining single-core hotspots in `internal/reconcile/reconcile.go` now run across a bounded `errgroup` pool sized to `runtime.NumCPU()`.

## What changed

**1. `BuildReconcilePreviewWithProgress` path-check** (the per-book `os.Stat` over the whole library):
- `knownPaths` is a cheap in-memory set with no I/O → built in a serial pre-pass.
- The expensive `os.Stat` calls run concurrently, each recording into its own index slot (`brokenFlag[i]`).
- The ordered `brokenBooks` / `BrokenRecords` fold runs serially afterward → **byte-for-byte identical** to the former sequential build.

**2. `FindBrokenSegmentBooks`** (directory stat + `GetBookFiles` + per-segment stat storm + non-dry-run hydrate/`UpdateBook`):
- The **outer** per-book loop is sharded across workers.
- **Write safety:** work partitions by book index, so each book's DB row is touched by exactly one worker; the per-book `UpdateBook` writes are to disjoint keys and never race. They only flip `LibraryState`/`MarkedForDeletion` — no secondary-indexed field — so there's no cross-book index contention either.
- `Details` lands in per-index slots and folds in book order; `BooksChecked`/`BrokenBooks`/`MarkedForReview` are atomic counters assigned once at the end.

Output is unchanged: same broken records, same order, same counts. Follows the `hashFilesConcurrent` pattern and the CLAUDE.md concurrency mandate (partition order-sensitive shared state, don't naive-fan-out).

## Tests

Adds the package's first behavioral tests (`reconcile_parallel_test.go`), run under `-race` via a small concurrency-safe fake `Store`:
- `TestFindBrokenSegmentBooks_ParallelOrderAndCounts` — non-contiguous broken indices `{1,3,4,6}`; asserts `Details` order matches book order (a scrambled fold would fail), exact counters, dry-run writes nothing, and the real run marks exactly the broken books `needs_review`.
- `TestBuildReconcilePreview_ParallelBrokenOrder` — non-contiguous broken `{0,2,5}`; asserts `BrokenRecords` order matches book order.

`go build ./...`, `go vet ./internal/reconcile/` clean; `go test ./internal/reconcile/ -race` green.

Docs: CHANGELOG + TODO updated. No executive summary — pure performance change with identical output (matching how the sibling #1960 was handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)