### PR TITLE
chore: backlog sweep — CONS-17b fix, CFG-2-D-LOG removal, stall root-cause, TODO triage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.167.0 -->
+<!-- version: 3.168.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -8,6 +8,40 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 16, 2026 - fix(metadata): a per-chapter tag title could become the whole book's title (CONS-17b)
+
+The filesystem scanner now has the same all-chapters-agree discriminator the iTunes path
+got in CONS-FRAG. `resolveTitle` trusted any first-chapter tag title that wasn't obviously
+generic, so a chapter-level name that dodged `isGenericTitle` — e.g. a studio ident like
+"Big Finish Ident" — was adopted as the book's title, leaking into `Book.Title` and
+colliding across every book carrying that ident.
+
+`agreedChapterTitle` now reads the chapters' tag titles: if they all strip to the same
+non-empty title that IS the book title (`tag.Title(agreed)`, e.g. "Aces Abroad - Part 1…3"
+→ "Aces Abroad"); if they disagree, the title falls back to the folder. Single-file books
+keep trusting their tag outright. Cost is bounded — unlike the iTunes twin, which reads
+track names for free from the library XML, each check here is a real tag read, so it is
+capped at a 5-file sample with early-exit on the first disagreement and is only entered for
+multi-file books whose first tag is non-generic (the exact bug case). Album-preference
+stays rejected: album frequently equals the *series* name. No caller signature churn —
+`AssembleBookMetadata` already had `dirPath`. Two regression tests, both verified to fail
+without the fix. `internal/metadata/assemble.go`.
+
+#### July 16, 2026 - chore: backlog sweep — retire the CFG-2 flat-key shim, fix a test goroutine leak
+
+- **CFG-2-D-LOG**: removed the 54-entry `retiredLegacyFlatKeys` list and its detection
+  warn-log from `internal/config/update_service.go`. Its gate was "one stable release with
+  zero flat-only-key warnings in prod" — verified before removal: **0** occurrences in 30
+  days of prod logs across multiple releases. `remapScheduledKeys` intentionally stays.
+- **INTERNAL-SERVER-PKG-STALL**: root-caused. It is **not** a deadlock — the timeout dump's
+  only running test was 2s in; the package had simply spent its budget (measured: **664
+  tests, 357s cumulative** at `GOMAXPROCS=2 -race`, no pathological test), so a CPU-starved
+  CI runner can't fit it in 10m. The "parked in FileIOPool" hint was a red herring. Fixed
+  the real defect the dump exposed: a goroutine leak of **352 parked `FileIOPool.worker`s**
+  (≈88 servers × 4) — `setupHandlerTestServer` built a server and never stopped its pool.
+  The structural residual (package too big for the CI budget) is written up in TODO.md with
+  options rather than papered over.
 
 #### July 16, 2026 - perf(reconcile): parallelize the last two serial whole-library loops
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.9 -->
+<!-- version: 9.106.10 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-16 -->
 
@@ -846,7 +846,26 @@ SLOG-PROD-VERIFY, DEDUP-CANDIDATE-EXPLOSION).
 
 - 🟢 **Mock Freshness** ✅ FIXED (#1718, 2026-07-01) — pinned mockery to v3.7.1 (CI + Makefile + setup script); v2 could not generate the merged-file `.mockery.yaml`. `make mocks-check` green.
 - 🟢 `TestBackupEndpointsErrors` ✅ FIXED (#1711 — dead `os.Chdir` race removed, 20/20) · `TestScanService_MultiChapterAudiobook` ✅ FIXED (#1713 — missing `WaitForWarmup` in `SetupIntegration`, 20/20). NOTE: a *separate* pre-existing `pebble: closed` shutdown race remains under package-wide `-race` — see `PEBBLE-CLOSED-SHUTDOWN-RACE` in Open Bugs.
-- [ ] **INTERNAL-SERVER-PKG-STALL** (found 2026-07-11, during execution wave 2) — the
+- [~] **INTERNAL-SERVER-PKG-STALL** — ◑ **ROOT-CAUSED 2026-07-16 + leak fixed; structural residual open**
+  (branch `chore/backlog-sweep-jul16`). **It is NOT a deadlock.** Reproduced deterministically with
+  `GOMAXPROCS=2 go test ./internal/server/ -short -race`. The timeout dump shows the *only* running test at
+  the moment of the panic was `TestServerStartGracefulShutdown` at **2s** in — nothing was hung; the package
+  had simply burned the whole budget on the tests before it. Measured: **664 tests, 357s cumulative** at
+  `GOMAXPROCS=2 -race`, with **no pathological test** (slowest = `TestServerStartGracefulShutdown` 13.9s,
+  `TestValidateITunesLibrary` 8.5s, `TestSetupTestServerCleanup_…` 8.5s). Against CI's 600s budget, a
+  CPU-starved runner simply doesn't finish. The "parked on a channel receive in FileIOPool" hint in the
+  original note was a **red herring** — those goroutines are parked (cheap), not deadlocked.
+  **Fixed here:** a real goroutine leak the dump exposed — 414 goroutines at timeout, **352 of them
+  `FileIOPool.worker`** (= ~88 leaked Servers × 4 workers). `NewServer` starts a 4-worker pool and
+  `setupHandlerTestServer` never stopped it; now `t.Cleanup(srv.fileIOPool.Stop)`. (`setupTestServer` /
+  `setupTestServerWithStore` already stopped theirs.)
+  **Residual (structural, needs a decision, NOT a bug):** ~60 direct `NewServer(` calls in the package's tests
+  still leak their pool, and more importantly the package is simply too big to fit CI's 10m under contention.
+  Real options: (a) raise the per-package timeout, (b) split `internal/server` tests into sub-packages, or
+  (c) add a `newTestServer(t, store)` helper and migrate the 60 call sites. Not doing any of the three
+  unilaterally — (a) papers over it, (b)/(c) are wide refactors that want owner buy-in.
+  <!-- original note: -->
+  (found 2026-07-11, during execution wave 2) — the
   `internal/server` top-level test package intermittently stalls to the CI's 10-minute
   `go test -short -race` timeout under concurrent CPU load, with zero `--- FAIL` lines (the run
   just times out, it doesn't fail a specific test). Root-cause hint from observed goroutine dumps:
@@ -965,7 +984,11 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 - [x] **CONS-11** **Track D4** — manual-import UI button (op `library.import` already merged/deployed; no frontend yet). Add a button/dialog on the Library page that POSTs `{def_id:"library.import", params:{path}}` to `/api/v1/operations/v2` and polls. ~Lowest-effort remaining UI task. — ✅ verified done 2026-07-01: Library.tsx manualImport dialog + api.startLibraryImport
 - [x] **CONS-12** = **DEDUP-INTRO-1** (see Dedup UX section) — Audible intro/outro false-positive dedup candidates. — ✅ verified done 2026-07-01: = DEDUP-INTRO-1 (done)
 - [x] **CONS-13** = **CFG-2 Phase D** — retire flat-key compat shim in `internal/config/update_service.go` (low priority; after 1+ wk prod stability). — ✅ done 2026-07-10 (TASK-01): removed legacyRemapGroup/configRemapGroups/applyLegacyRemaps + their tests; kept remapScheduledKeys + JSON round-trip; added a one-release detection warn-log (retiredLegacyFlatKeys).
-- [ ] **CFG-2-D-LOG** — remove the `retiredLegacyFlatKeys` detection warn-log from `internal/config/update_service.go` after one stable release with zero flat-only-key warnings in prod logs (added by TASK-01).
+- [x] **CFG-2-D-LOG** — ✅ **DONE 2026-07-16** (branch `chore/backlog-sweep-jul16`). Gate verified before
+  removing: `journalctl -u audiobook-organizer --since '30 days ago' | grep -c 'legacy flat config key'` → **0**
+  across multiple stable releases, so no client has sent a retired flat key. Removed the 54-entry
+  `retiredLegacyFlatKeys` var + its detection loop from `internal/config/update_service.go`.
+  `remapScheduledKeys` (the deeper two-level `scheduled_*` nesting, owned by INIT-6/WF-3) intentionally stays.
 
 ### Metadata-repair track (root causes of the dedup candidate explosion) — investigated 2026-06-19
 
@@ -978,7 +1001,18 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 - [x] **CONS-15** **(D3-emitter)** part-vs-whole guard in the exact dedup emitter — defense-in-depth so a part can't pair 100% against a whole even if metadata is wrong. **Deprioritized** (fixing CONS-16/17 removes most of the cause).  ✅ shipped #1712 (agent-task sweep 2026-07-01)
 - [x] **CONS-16** ✅ **Duration-unit bug** — FIXED. (a) Extracted `trackDurationSeconds()` in `internal/itunes/service/importer.go`; routed all 3 write sites (now lines ~311/655/703) through it with `/1000`; added `trackDurationSeconds` unit test + a seconds assertion in the integration test (which previously mirrored the bug). (b) New dry-run-gated maintenance op `maintenance.duration-backfill` heals existing inflated rows. **Detection changed from the planned filesize/bitrate formula** — the iTunes importer never populates `BitrateKbps` (the `itunes.Track` struct has no BitRate field), so those rows have `BitrateKbps=0`. Replaced with an **implied-bitrate** test (millis if duration-as-seconds implies <4 kbps, with a 3 Mbps upper sanity bound) that needs only `FileSize` and never flags genuine low-bitrate audiobooks (advisor-reviewed: a 16 kbps floor would have corrupted 12 kbps spoken-word books). Per book: corrects each file then re-runs `RecomputeBookAggregates`. Dry-run default — no prod data touched until run with `dryRun=false`. Shipped in PR (branch `fix/cons16-duration-units`).
 - [x] **CONS-17** ✅ **Multi-file title leak** — FIXED, both paths. (1) **iTunes** `buildBookFromAlbumGroup`: empty album on a multi-file group now derives the title from the common parent **folder** before falling to the per-chapter track Name (scoped to multi-file; single-file keeps stripped track Name). (2) **Filesystem scanner**: sequential multi-file groups (`SegmentFiles>1`, `FilePath=segs[0]`) are now routed through `AssembleBookMetadata` via a condition change at `scanner.go:670` (`IsGenericPartFilename(filePath) || len(SegmentFiles)>1`) — NOT by setting `FilePath=dir` (which would drop the detected `SegmentFiles` subset and rescan the whole dir). Segments still created at the saveBook step. Tests: `TestBuildBookFromAlbumGroup_EmptyAlbumUsesFolder`, `TestAssembleBookMetadata_GenericChapterUsesFolder`. Shipped in PR (branch `fix/cons17-title-leak`).
-- [ ] **CONS-17b** **(follow-up, residual)** Multi-file group whose first chapter has a *non-generic* tag title (e.g. "Big Finish Ident") still prefers that tag over the folder, because `resolveTitle` (`assemble.go:88`) trusts non-generic tag titles. Robust fix needs a **"do all chapters agree on their `tag.Title`?"** discriminator (agree → it's the book title; disagree → fall to folder). ⚠️ Album-preference was **rejected**: album frequently equals the *series* name (`assemble.go:139` already notes this), so preferring album would replace correct titles with series names. Needs a small design before code. **Partially done (CONS-FRAG):** the iTunes importer path now implements exactly this all-chapters-agree discriminator (`agreedStrippedTitle`); the residual is the **filesystem scanner** `resolveTitle` path.
+- [x] **CONS-17b** ✅ **DONE 2026-07-16** (branch `chore/backlog-sweep-jul16`). The filesystem scanner now
+  has the same all-chapters-agree discriminator the iTunes path got in CONS-FRAG. `resolveTitle` takes
+  `dirPath` + supported exts (no caller signature churn — `AssembleBookMetadata` already had `dirPath`), and
+  `agreedChapterTitle` reads the chapters' tag titles: all strip to the same non-empty title → that's the book
+  title (`tag.Title(agreed)`, e.g. "Aces Abroad - Part 1…3" → "Aces Abroad"); they disagree → fall to the
+  folder. Single-file books keep trusting their tag outright. **Cost bounded** (the iTunes twin checks every
+  track for free off the XML; here each check is a real tag read): capped at a 5-file sample with early-exit on
+  the first disagreement, and only entered for multi-file books whose first tag is non-generic — the exact bug
+  case. Album-preference stayed rejected (album ≈ series name). 2 regression tests, both verified to FAIL
+  without the fix (pre-fix title = "Big Finish Ident"). Mirrors `agreedStrippedTitle` — keep the two in sync.
+  <!-- original: -->
+  Multi-file group whose first chapter has a *non-generic* tag title (e.g. "Big Finish Ident") still prefers that tag over the folder, because `resolveTitle` (`assemble.go:88`) trusts non-generic tag titles. Robust fix needs a **"do all chapters agree on their `tag.Title`?"** discriminator (agree → it's the book title; disagree → fall to folder). ⚠️ Album-preference was **rejected**: album frequently equals the *series* name (`assemble.go:139` already notes this), so preferring album would replace correct titles with series names. Needs a small design before code. **Partially done (CONS-FRAG):** the iTunes importer path now implements exactly this all-chapters-agree discriminator (`agreedStrippedTitle`); the residual is the **filesystem scanner** `resolveTitle` path.
 - [x] **CONS-FRAG** ✅ **iTunes book fragmentation** — FIXED. `groupTracksByAlbum` keyed `artist+"|"+album`, fragmenting (1) multi-author anthologies (constant album, per-story Artist → one book per author, e.g. "Wild Cards I") and (2) empty-album chapter files whose " - Part NN" suffix wouldn't strip ("Aces Abroad - Part 19"). Verified against prod via `/external-ids` (both iTunes-PID-linked) + ffprobe. Now keys on **album alone** when present, `name:<artist>|<stripped>` when empty, with a track-number-repeat **over-merge guard** (`splitOverMergedGroup`) protecting series-as-album. `titleutil.StripChapterSuffix` strips bare `- Part NN`/`- Chapter N`/`- CD N` (excludes `Book N`/`Volume N`). CONS-17b agree-title discriminator applied to the iTunes path. Forward-only; tests in `grouping_test.go` + `strip_test.go`. ⚠️ Existing fragmented+organized books need a **separate dry-run-gated re-group op** (un-organize = destructive; surface before applying — see CONS-10).
 - [x] **CONS-FRAG-HEAL** ✅ **built + dry-run → library already correctly grouped (no mass heal needed).** Dry-run-gated `maintenance.itunes-regroup` op (PRs #1542–#1546): in-place re-group via per-PID `ReassignExternalID` + `MoveBookFilesToBook` (NOT delete+reimport — canary proved purge tombstones PIDs; `.claude/notes/itunes-heal-canary-findings.md`); frozen deterministic exclusive-claim plan. **Prod dry-run: consolidate=0, fresh=0 → ZERO fragmentation/over-merge remain.** Completeness: complete-groups≈11,000, partial≈712, single-file-in-album=554. **Duration-backfill applied (17,684 files / 1,210 books ms→s)** then duration-bucketed the 554: <15min=7 (anthology pieces, correct), 15-90min=181 (short books), ≥90min=366 (complete books, false alarm). ⇒ **No orphaned-chapter problem; grouping healthy.** `dryRun:false` would change ~nothing (only 173 entangled groups, skipped). Residual (separate, NOT auto-run as unsafe/unclear): 173 entangled-would-move (task: manual/v2); 10,374 unresolved PIDs = import gap (benign, complete books present); **~383,902 stale dedup candidates** computed pre-fix — next workstream is dedup re-detection/purge to clear the original 6/47 false-match backlog.
 - [x] **CONS-FRAG-2** **(follow-up)** A newly-merged multi-file iTunes book whose chapter files are scattered across folders gets `Book.FilePath` = their common parent dir. `organizeOneBook` calls only the single-file `OrganizeBook`, which **safely refuses a directory `FilePath`** (early return at `organizer.go:98`, no file move) — so the book stays `imported` instead of organizing. Non-destructive but incomplete: route multi-file books (BookFiles>1) to `OrganizeBookDirectory(book, segmentPaths)` in `organizeOneBook`. BookFiles already carry correct per-track paths.  ✅ shipped #1709 (agent-task sweep 2026-07-01)
@@ -1097,7 +1131,8 @@ for untagged tracks. Scanner uses folder name as book title for no-tag groups.
 - [ ] **WF-3** Introduce a persisted **`Workflow`** object = enable/disable/schedule-able composition (DAG/ordered) of registered ops. Seed built-in workflows from today's scheduled ops. Collapse `scheduled_*` + `dedup_embeddings_enabled` flags into workflow state. Built-in workflows auto-enabled; user-added start **disabled** until explicitly enabled.
 - [ ] **WF-4** Registration-time dependency checks: refuse to register an action that invokes another plugin's actions without declaring the dependency (best-effort runtime check — true static isolation isn't feasible with Go compile-time plugin registration).
 - [ ] **WF-5** **UI workflow builder** — LAST, once the backend model is proven (smart-home / CI-CD-style composition). Biggest single cost; treat as its own product surface.
-- [ ] **WF-6** (Re-evaluate only) adopt `go-workflows` *iff* durable mid-run crash recovery becomes a hard requirement; (re-evaluate only) extract to a standalone Go package *iff* the model stabilizes and a second consumer wants it.
+- [-] **WF-6** — ⛔ **NOT DOING (2026-07-16): this is a trigger condition, not work.** Both halves are self-declared "(re-evaluate only) *iff*" — adopt `go-workflows` iff durable mid-run crash recovery becomes a hard requirement; extract a standalone package iff a second consumer appears. Neither condition holds, so there is nothing to build. Re-open only when a condition actually fires. Original text:
+  (Re-evaluate only) adopt `go-workflows` *iff* durable mid-run crash recovery becomes a hard requirement; (re-evaluate only) extract to a standalone Go package *iff* the model stabilizes and a second consumer wants it.
 
 ---
 
@@ -1319,7 +1354,8 @@ Plan: [`docs/plans/2026-06-13-dedup-exact-gate-and-dataset.md`](docs/plans/2026-
 
 ## 📚 Project Documentation (TODO — not yet done)
 
-- [ ] **DOCS-1** [hold] Write comprehensive system documentation for `falkcorp/audiobook-organizer` into `docs/` — full process graphs, architecture diagrams, data flow, component inventory, operations runbooks, incident history. Target: ≥9 files, ≥7 Mermaid diagrams (flowchart, sequence, state machine, Gantt). Model after `falkcorp/burndown-tasks/docs/` (PR #73, 2216 lines). Invoke as a dedicated documentation subagent: "write full process graphs, literally all the documentation you can write. The more graphs and charts the better."  <!-- 2026-07-01: ℹ️ quantitative bar already exceeded (418 md files, 59 mermaid); a single cohesive burndown-style deliverable is the only residual. -->
+- [-] **DOCS-1** — ⛔ **NOT DOING (2026-07-16): the bar it sets is already met.** The item's own 2026-07-01 note concedes it: the repo has **418 markdown files and 59 mermaid diagrams**, well past the "≥9 files, ≥7 diagrams" target modelled on burndown-tasks. The only residual was "one cohesive burndown-style deliverable" — a re-packaging of docs that already exist, with no consumer asking for it. Writing hundreds more pages of agent-generated prose has a real maintenance cost (doc rot) against no demand. Re-open if a specific audience needs a specific document. Original text:
+  [hold] Write comprehensive system documentation for `falkcorp/audiobook-organizer` into `docs/` — full process graphs, architecture diagrams, data flow, component inventory, operations runbooks, incident history. Target: ≥9 files, ≥7 Mermaid diagrams (flowchart, sequence, state machine, Gantt). Model after `falkcorp/burndown-tasks/docs/` (PR #73, 2216 lines). Invoke as a dedicated documentation subagent: "write full process graphs, literally all the documentation you can write. The more graphs and charts the better."  <!-- 2026-07-01: ℹ️ quantitative bar already exceeded (418 md files, 59 mermaid); a single cohesive burndown-style deliverable is the only residual. -->
 
 ---
 
@@ -1551,10 +1587,12 @@ Copy + pause-on-hover in #1182.
   Low priority; defer until profiler shows actual cost.
 - [x] **MAYDEPLOY-H7** [hold] — Cache `isProtectedPath` / `GetAllImportPaths`  ✅ shipped #1725 (agent-task sweep 2026-07-01)
   with TTL or mutation invalidation. Low priority (~10 rows).
-- [ ] **MAYDEPLOY-I1** [hold] — Verify D1 (`DEDUP_CHROMEM_LAZY`) and D2  <!-- 2026-07-01: ⏳ duplicate of I1 — code shipped; prod verification remains. -->
+- [x] **MAYDEPLOY-I1** — ✅ **CLOSED 2026-07-16 as a DUPLICATE of I1** (same D1/`DEDUP_CHROMEM_LAZY` + D2 prod-pprof verification, tracked twice). Track it under **I1** only. Original text:
+  [hold] — Verify D1 (`DEDUP_CHROMEM_LAZY`) and D2  <!-- 2026-07-01: ⏳ duplicate of I1 — code shipped; prod verification remains. -->
   (`NewDB()`) shipped behaviour matches design. Needs live prod
   observation (`/system/status`, heap dump).
-- [ ] **MAYDEPLOY-I6** [hold] — Re-run heap audit with live pprof from prod  <!-- 2026-07-01: ⏳ duplicate of I6 — prod pprof measurement. -->
+- [x] **MAYDEPLOY-I6** — ✅ **CLOSED 2026-07-16 as a DUPLICATE of I6** (same heap-audit-rerun, tracked twice). Track it under **I6** only. Original text:
+  [hold] — Re-run heap audit with live pprof from prod  <!-- 2026-07-01: ⏳ duplicate of I6 — prod pprof measurement. -->
   via `pprof_endpoint`. Replace structural estimates in
   `docs/perf-audit-2026-05-29-heap-breakdown.md` with measured bytes.
   Target: baseline ~18 GB → ~10 GB.
@@ -2557,8 +2595,10 @@ next picks up. Full plan in
 
 - [ ] **AI-RESP-A** [hold] Migrate `metadata_llm_review.go` (single call) — design spec linked above
 - [ ] **AI-RESP-B** [hold] Migrate `openai_parser.go` single-shot calls (6 sites) — depends on A clean
-- [ ] **AI-RESP-C** [hold] **DO NOT MIGRATE EMBEDDINGS** — `/v1/embeddings` stays as-is. This entry is here only to make the bot aware not to touch `embedding_client.go`.
-- [ ] **AI-RESP-D** [hold] Migrate Batches API (`openai_batch.go`) once OpenAI supports `/v1/responses` URLs in batch lines — verify endpoint allowlist before pickup
+- [x] **AI-RESP-C** — ✅ **CLOSED 2026-07-16: NOT A TASK.** This entry is a standing *guardrail note* ("don't touch `embedding_client.go`"), not work to be done, so it should never have sat in the open-item count. The instruction still stands and is preserved below; the checkbox is closed so the backlog reflects real work. Original text:
+  [hold] **DO NOT MIGRATE EMBEDDINGS** — `/v1/embeddings` stays as-is. This entry is here only to make the bot aware not to touch `embedding_client.go`.
+- [-] **AI-RESP-D** — ⛔ **NOT DOING (2026-07-16): externally blocked, not schedulable.** Its own precondition is "*once* OpenAI supports `/v1/responses` URLs in batch lines" — that's a vendor dependency we don't control, so it can't be planned or estimated. Re-open when OpenAI ships it. Original text:
+  [hold] Migrate Batches API (`openai_batch.go`) once OpenAI supports `/v1/responses` URLs in batch lines — verify endpoint allowlist before pickup
 - [ ] **AI-RESP-E** [hold] Migrate `aijobs/aijobs.go` multi-turn flows — adds `last_response_id` to job state; biggest token win
 - [ ] **AI-RESP-F** [hold] Cleanup: delete remaining Chat Completions call sites in `internal/ai/`
 
@@ -2735,13 +2775,15 @@ since it was last edited on 2026-04-11).
 
 ### 4. Architecture / Future-Proofing — [section](docs/backlog-2026-04-10.md#4-architecture--future-proofing)
 
-- [ ] **4.1** [hold] PostgreSQL research track (**XL**)
+- [-] **4.1** — ⛔ **NOT DOING (2026-07-16): settled architecture.** PebbleDB is the committed production store ("PebbleDB is the only production DB"); a Postgres migration is an **XL** research track with no driver — no capability gap, scale wall, or incident points at the store. Re-open only if a concrete requirement Pebble can't meet appears. Original text:
+  [hold] PostgreSQL research track (**XL**)
 - [x] **4.2** Split the monolithic `server.go` (commit `c858ceb`)
 - [x] **4.3** Move write-back queue to a durable outbox (**M**) — #344
 - [x] **4.4** Replace `database.GlobalStore` package var with DI (**L**) — complete (#280-#291)
 - [x] **4.5** Property-based tests for dedup engine (expanded to full codebase) (**M**) — complete (#357, #359, #361, #362, #363, #365, #366, #367, #368 — ~57 property tests across database / search / server / auth)
 - [x] **4.6** Chaos tests for the embedding store under shutdown (**M**) — 7 tests: double-close, ops-after-close, concurrent write/read during close, mixed access, durability, WAL checkpoint
-- [ ] **4.7** [hold] Per-workload store evaluation: Pebble vs SQLite vs PostgreSQL vs Go-native NoSQL (**L** research)
+- [-] **4.7** — ⛔ **NOT DOING (2026-07-16): same reason as 4.1, and it presupposes it.** Re-evaluating the store per workload is **L** research whose realistic outcome is "keep Pebble" — the store isn't a bottleneck; the measured problems this month were fixed-limit truncation, stale mocks, and single-core loops, none of them storage-engine choices. Original text:
+  [hold] Per-workload store evaluation: Pebble vs SQLite vs PostgreSQL vs Go-native NoSQL (**L** research)
 - [~] **4.8** Split the `database.Store` interface (ISP refactor) (**L**) — foundation + 3 proof-points shipped (#372, #376, #379, #380, #381, #382); ~38-file sweep + 18-file noop cleanup remain per [`docs/superpowers/plans/2026-04-17-store-iface-sweep.md`](docs/superpowers/plans/2026-04-17-store-iface-sweep.md)
 - [x] **4.9** Eliminate remaining package globals (DI Phase 2) (**M**) — 10 globals replaced with interface injection + Server fields (#386)
 - [ ] **4.10** [hold] Service-layer unit tests with mock stores (**L**) — leverage DI + ISP to unit-test AudiobookService, OrganizeService, MetadataFetchService, MergeService with MockStore; test error paths, edge cases, and business logic in isolation without HTTP or real DB  <!-- 2026-07-01: ◑ PARTIAL: unit tests exist for AudiobookService/OrganizeService/MetadataFetchService; MergeService lacks a dedicated mock-store unit-test file. -->
@@ -3053,7 +3095,8 @@ Activity page mobile layout, adaptive refresh, version vs snapshot UI polish, co
 
 ## ⚠️ Automated Findings
 
-- [ ] **DEDUP-CANDIDATE-EXPLOSION-2026-06-18** The `exact` dedup layer has **387,597 pending**  <!-- 2026-07-01: ⏳ = CONS-10 — prod backfill/investigation of the exact-candidate backlog; not a code deliverable. -->
+- [x] **DEDUP-CANDIDATE-EXPLOSION-2026-06-18** — ✅ **CLOSED 2026-07-16 as a DUPLICATE of CONS-10** (the 2026-07-01 note already said "= CONS-10"). The exact-candidate backlog is one workstream, gated on the prod duration-backfill + re-scan and an explicit apply decision — tracked under **CONS-10** only. Original text:
+  The `exact` dedup layer has **387,597 pending**  <!-- 2026-07-01: ⏳ = CONS-10 — prod backfill/investigation of the exact-candidate backlog; not a code deliverable. -->
   candidates (of 388,998 total; acoustid 1,028 / embedding 164 / llm 209 are sane) against only
   **49,573 final books** (`GET /api/v1/audiobooks` count) — yet memdb holds **401,968 raw `books`
   rows**. The exact emitters (`checkExactTitle` / `checkExactMetadataSourceHash` /

--- a/internal/config/update_service.go
+++ b/internal/config/update_service.go
@@ -1,7 +1,7 @@
 // file: internal/config/update_service.go
-// version: 3.10.0
+// version: 3.11.0
 // guid: f6g7h8i9-j0k1-l2m3-n4o5-p6q7r8s9t0u1
-// last-edited: 2026-07-10
+// last-edited: 2026-07-16
 
 package config
 
@@ -67,68 +67,6 @@ var secretFieldKeys = []string{
 // immutableFieldKeys cannot be changed at runtime and are rejected if present.
 var immutableFieldKeys = []string{"database_type", "enable_sqlite"}
 
-// retiredLegacyFlatKeys lists the flat config keys whose flat→nested remapping
-// shim was retired in CFG-2 Phase D (#1536, CONS-13). The frontend has sent nested
-// keys since PR #1514; these flat forms are no longer remapped and are dropped by
-// the JSON round-trip (no matching top-level json tag). UpdateConfig warn-logs any
-// that still arrive so a lost write is observable rather than silent. This list —
-// and its warn-log — should be removed after one stable release with zero warnings
-// in prod (follow-up CFG-2-D-LOG in TODO.md).
-var retiredLegacyFlatKeys = []string{
-	"embedding_enabled",
-	"embedding_model",
-	"embedding_dimensions",
-	"embedding_base_url",
-	"vector_index_backend",
-	"dedup_book_high_threshold",
-	"dedup_book_low_threshold",
-	"dedup_author_high_threshold",
-	"dedup_author_low_threshold",
-	"dedup_auto_merge_enabled",
-	"dedup_embeddings_enabled",
-	"dedup_llm_auto_merge_high_confidence",
-	"dedup_on_import_via_scheduler",
-	"dedup_review_model",
-	"metadata_embedding_scoring_enabled",
-	"metadata_embedding_min_score",
-	"metadata_embedding_best_match_min",
-	"metadata_llm_scoring_enabled",
-	"metadata_llm_rerank_epsilon",
-	"metadata_llm_rerank_top_k",
-	"write_backup_before_tag_write",
-	"itunes_sync_enabled",
-	"itunes_sync_interval",
-	"itl_write_back_enabled",
-	"itunes_library_write_path",
-	"itunes_library_read_path",
-	"itunes_auto_write_back",
-	"itunes_path_trim_enabled",
-	"itunes_windows_root_path",
-	"itunes_media_root",
-	"maintenance_window_enabled",
-	"maintenance_window_start",
-	"maintenance_window_end",
-	"maintenance_window_dedup_refresh",
-	"maintenance_window_series_prune",
-	"maintenance_window_author_split",
-	"maintenance_window_tombstone_cleanup",
-	"maintenance_window_reconcile",
-	"maintenance_window_purge_deleted",
-	"maintenance_window_purge_old_logs",
-	"maintenance_window_db_optimize",
-	"maintenance_window_library_scan",
-	"maintenance_window_library_organize",
-	"maintenance_window_metadata_refresh",
-	"maintenance_window_library_size_refresh",
-	"maintenance_window_acoustid_online_lookup",
-	"acoustid_online_lookup_nightly_limit",
-	"auto_update_enabled",
-	"auto_update_channel",
-	"auto_update_check_minutes",
-	"auto_update_window_start",
-	"auto_update_window_end",
-}
-
 // UpdateConfig applies a config update payload to AppConfig and persists it.
 //
 // Architecture: non-secret fields are applied via JSON round-trip onto AppConfig.
@@ -179,16 +117,6 @@ func (us *UpdateService) UpdateConfig(payload map[string]any) (int, map[string]a
 	}
 	for _, k := range secretFieldKeys {
 		delete(filtered, k)
-	}
-
-	// Detection-only (CFG-2 Phase D, #1536/CONS-13): the flat→nested remap shim was
-	// retired — the frontend sends nested keys. Any flat-only key that still arrives
-	// is dropped by the JSON round-trip below (no matching top-level json tag); warn
-	// so a lost write is observable rather than silent. Log only — no remapping.
-	for _, k := range retiredLegacyFlatKeys {
-		if _, ok := filtered[k]; ok {
-			slog.Warn("legacy flat config key received; no longer remapped, dropped", "key", k)
-		}
 	}
 
 	// remapScheduledKeys handles the deeper two-level scheduled_* nesting that the

--- a/internal/metadata/assemble.go
+++ b/internal/metadata/assemble.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/assemble.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
 
 package metadata
@@ -10,7 +10,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	"github.com/falkcorp/audiobook-organizer/internal/titleutil"
 )
 
 // AssembledMetadata is the combined, priority-resolved metadata for an audiobook.
@@ -62,7 +64,7 @@ func AssembleBookMetadata(dirPath, firstFilePath string, fileCount int, totalDur
 		}
 	}
 
-	bm.Title, bm.TitleSource = resolveTitle(tagMeta, fm, firstFilePath)
+	bm.Title, bm.TitleSource = resolveTitle(tagMeta, fm, firstFilePath, dirPath, config.AppConfig.SupportedExtensions)
 	bm.Authors, bm.AuthorSource = resolveAuthors(tagMeta, fm)
 	bm.SeriesName, bm.SeriesPosition, bm.SeriesSource = resolveSeries(tagMeta, fm)
 	bm.Narrator, bm.NarratorSource = resolveNarrator(tagMeta, fm)
@@ -85,12 +87,81 @@ func AssembleBookMetadata(dirPath, firstFilePath string, fileCount int, totalDur
 	return bm, nil
 }
 
-func resolveTitle(tag *Metadata, fm *FolderMetadata, firstFilePath string) (string, string) {
+// agreedTagTitleSample bounds how many chapter files the CONS-17b agree-title
+// discriminator reads. The iTunes twin (agreedStrippedTitle) can check every
+// track for free — track names come from the library XML — but here each check
+// is a real tag read off disk, so cap it. A disagreement almost always shows on
+// the second file (chapter titles differ per chapter), and the loop early-exits
+// the moment two disagree, so the common cost is 2 reads; only a genuinely
+// agreeing multi-chapter book pays the full sample.
+const agreedTagTitleSample = 5
+
+// agreedChapterTitle implements the CONS-17b discriminator for the filesystem
+// scanner: it returns the chapter-stripped tag title when EVERY sampled chapter
+// in dirPath strips to the same non-empty title (e.g. "Aces Abroad - Part 1" …
+// "- Part 14" all → "Aces Abroad"), and "" when they disagree (per-chapter names
+// like "Big Finish Ident" / "Opening Credits"), letting the caller fall back to
+// the folder name.
+//
+// multi reports whether dirPath actually holds more than one audio file; a
+// single-file book has nothing to agree with, so the caller keeps trusting its
+// tag title outright.
+//
+// This mirrors agreedStrippedTitle in internal/itunes/service/importer.go —
+// keep the two in sync. Album-preference was rejected for this decision: album
+// frequently equals the *series* name (see resolveSeries below), so preferring
+// it would replace correct titles with series names.
+func agreedChapterTitle(dirPath string, supportedExts []string) (agreed string, multi bool) {
+	files := listAudioFiles(dirPath, supportedExts)
+	if len(files) < 2 {
+		return "", false
+	}
+	if len(files) > agreedTagTitleSample {
+		files = files[:agreedTagTitleSample]
+	}
+	for _, fp := range files {
+		m, err := ExtractMetadata(fp, nil)
+		if err != nil {
+			return "", true // unreadable tag → can't establish agreement
+		}
+		s := titleutil.StripChapterSuffix(titleutil.StripChapterPrefix(strings.TrimSpace(m.Title)))
+		if s == "" {
+			return "", true
+		}
+		if agreed == "" {
+			agreed = s
+		} else if !strings.EqualFold(agreed, s) {
+			return "", true // chapters disagree → not a book title
+		}
+	}
+	return agreed, true
+}
+
+// resolveTitle picks the book title. dirPath + supportedExts enable the CONS-17b
+// all-chapters-agree check; pass an empty dirPath (or no exts) to skip it and
+// trust a non-generic tag title outright (the pre-CONS-17b behaviour).
+func resolveTitle(tag *Metadata, fm *FolderMetadata, firstFilePath, dirPath string, supportedExts []string) (string, string) {
 	if tag != nil && tag.Title != "" {
 		if !isGenericTitle(tag.Title) {
-			return tag.Title, "tag.Title"
+			// CONS-17b: a non-generic tag title on the FIRST chapter is only the
+			// book's title if every chapter agrees on it. A per-chapter name that
+			// merely dodges isGenericTitle (e.g. "Big Finish Ident") would
+			// otherwise be adopted as the whole book's title.
+			if dirPath == "" || len(supportedExts) == 0 {
+				return tag.Title, "tag.Title"
+			}
+			agreed, multi := agreedChapterTitle(dirPath, supportedExts)
+			switch {
+			case !multi:
+				return tag.Title, "tag.Title" // single-file book — nothing to disagree
+			case agreed != "":
+				return agreed, "tag.Title(agreed)"
+			}
+			logger.New("assemble").Debug(
+				"tag title %q not shared by all chapters; trying folder parser", tag.Title)
+		} else {
+			logger.New("assemble").Debug("tag title %q looks generic; trying folder parser", tag.Title)
 		}
-		logger.New("assemble").Debug("tag title %q looks generic; trying folder parser", tag.Title)
 	}
 	if fm.Title != "" {
 		return fm.Title, "folder.Title"
@@ -185,11 +256,13 @@ func (bm *AssembledMetadata) PrimaryAuthor() string {
 	return bm.Authors[0]
 }
 
-// FindFirstAudioFile returns the alphabetically first audio file in dirPath.
-func FindFirstAudioFile(dirPath string, supportedExts []string) string {
+// listAudioFiles returns dirPath's audio files in stable alphabetical order
+// (non-recursive). Shared by FindFirstAudioFile and the CONS-17b agree-title
+// check so both see the same file set in the same order.
+func listAudioFiles(dirPath string, supportedExts []string) []string {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
-		return ""
+		return nil
 	}
 
 	extSet := make(map[string]bool, len(supportedExts))
@@ -208,9 +281,15 @@ func FindFirstAudioFile(dirPath string, supportedExts []string) string {
 		}
 	}
 
+	sort.Strings(audioFiles)
+	return audioFiles
+}
+
+// FindFirstAudioFile returns the alphabetically first audio file in dirPath.
+func FindFirstAudioFile(dirPath string, supportedExts []string) string {
+	audioFiles := listAudioFiles(dirPath, supportedExts)
 	if len(audioFiles) == 0 {
 		return ""
 	}
-	sort.Strings(audioFiles)
 	return audioFiles[0]
 }

--- a/internal/metadata/assemble_test.go
+++ b/internal/metadata/assemble_test.go
@@ -1,5 +1,5 @@
 // file: internal/metadata/assemble_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
 
 package metadata
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -28,7 +29,7 @@ func newAssembleExtractorStub(t *testing.T, meta Metadata, err error) *mockMetad
 func TestResolveTitlePrefersTag(t *testing.T) {
 	tag := &Metadata{Title: "The Great Book"}
 	fm := &FolderMetadata{Title: "Folder Title"}
-	title, source := resolveTitle(tag, fm, "/some/path")
+	title, source := resolveTitle(tag, fm, "/some/path", "", nil)
 	if title != "The Great Book" || source != "tag.Title" {
 		t.Errorf("got title=%q source=%q, want 'The Great Book' / 'tag.Title'", title, source)
 	}
@@ -37,7 +38,7 @@ func TestResolveTitlePrefersTag(t *testing.T) {
 func TestResolveTitleSkipsGenericTag(t *testing.T) {
 	tag := &Metadata{Title: "Part 1"}
 	fm := &FolderMetadata{Title: "Real Book Title"}
-	title, source := resolveTitle(tag, fm, "/some/path")
+	title, source := resolveTitle(tag, fm, "/some/path", "", nil)
 	if title != "Real Book Title" || source != "folder.Title" {
 		t.Errorf("got title=%q source=%q, want 'Real Book Title' / 'folder.Title'", title, source)
 	}
@@ -78,10 +79,91 @@ func TestAssembleBookMetadata_GenericChapterUsesFolder(t *testing.T) {
 	}
 }
 
+// newPerFileExtractorStub returns a MetadataExtractor whose result depends on
+// the file's base name, so a test can give each chapter its own tag title.
+func newPerFileExtractorStub(t *testing.T, byBase map[string]Metadata) *mockMetadataExtractorInternal {
+	t.Helper()
+	m := newMockMetadataExtractorInternal(t)
+	m.EXPECT().ExtractMetadata(mock.Anything).RunAndReturn(func(path string) (Metadata, error) {
+		return byBase[filepath.Base(path)], nil
+	}).Maybe()
+	return m
+}
+
+// withChapterFiles builds <base>/<author>/<book>/ containing the named files and
+// points config at .mp3 so the CONS-17b agree-check can enumerate them.
+func withChapterFiles(t *testing.T, names ...string) (bookDir, firstChapter string) {
+	t.Helper()
+	prevExts := config.AppConfig.SupportedExtensions
+	config.AppConfig.SupportedExtensions = []string{".mp3"}
+	t.Cleanup(func() { config.AppConfig.SupportedExtensions = prevExts })
+
+	bookDir = filepath.Join(t.TempDir(), "Douglas Adams", "The Hitchhikers Guide")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(bookDir, n), []byte("not a real mp3"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return bookDir, filepath.Join(bookDir, names[0])
+}
+
+// TestAssembleBookMetadata_DisagreeingChapterTagsUseFolder is the CONS-17b
+// regression guard. The first chapter's tag title ("Big Finish Ident") is NOT
+// generic, so isGenericTitle doesn't catch it and the pre-fix resolveTitle
+// adopted it as the whole book's title — leaking a per-chapter ident into
+// Book.Title and colliding across every book with that ident. Because the
+// chapters disagree on their stripped tag titles, the title must come from the
+// folder instead.
+func TestAssembleBookMetadata_DisagreeingChapterTagsUseFolder(t *testing.T) {
+	bookDir, firstChapter := withChapterFiles(t, "chapter01.mp3", "chapter02.mp3")
+
+	SetMetadataExtractor(newPerFileExtractorStub(t, map[string]Metadata{
+		"chapter01.mp3": {Title: "Big Finish Ident", Artist: "Douglas Adams"},
+		"chapter02.mp3": {Title: "The Hitchhikers Guide - Part 2", Artist: "Douglas Adams"},
+	}))
+	defer func() { SetMetadataExtractor(nil) }()
+
+	bm, err := AssembleBookMetadata(bookDir, firstChapter, 2, 0)
+	if err != nil {
+		t.Fatalf("AssembleBookMetadata error: %v", err)
+	}
+	if bm.Title != "The Hitchhikers Guide" || bm.TitleSource != "folder.Title" {
+		t.Errorf("Title = %q (source %q), want 'The Hitchhikers Guide' / 'folder.Title' — "+
+			"a per-chapter ident must not become the book title", bm.Title, bm.TitleSource)
+	}
+}
+
+// TestAssembleBookMetadata_AgreeingChapterTagsWin is the positive half of
+// CONS-17b: when every chapter strips to the SAME title, that IS the book title
+// and must beat the folder name (mirrors the iTunes agreedStrippedTitle case,
+// e.g. "Aces Abroad - Part 1…14" → "Aces Abroad").
+func TestAssembleBookMetadata_AgreeingChapterTagsWin(t *testing.T) {
+	bookDir, firstChapter := withChapterFiles(t, "chapter01.mp3", "chapter02.mp3", "chapter03.mp3")
+
+	SetMetadataExtractor(newPerFileExtractorStub(t, map[string]Metadata{
+		"chapter01.mp3": {Title: "Aces Abroad - Part 1", Artist: "George R. R. Martin"},
+		"chapter02.mp3": {Title: "Aces Abroad - Part 2", Artist: "George R. R. Martin"},
+		"chapter03.mp3": {Title: "Aces Abroad - Part 3", Artist: "George R. R. Martin"},
+	}))
+	defer func() { SetMetadataExtractor(nil) }()
+
+	bm, err := AssembleBookMetadata(bookDir, firstChapter, 3, 0)
+	if err != nil {
+		t.Fatalf("AssembleBookMetadata error: %v", err)
+	}
+	if bm.Title != "Aces Abroad" || bm.TitleSource != "tag.Title(agreed)" {
+		t.Errorf("Title = %q (source %q), want 'Aces Abroad' / 'tag.Title(agreed)'",
+			bm.Title, bm.TitleSource)
+	}
+}
+
 func TestResolveTitleFallsBackToFilename(t *testing.T) {
 	tag := &Metadata{Title: "Chapter 3"}
 	fm := &FolderMetadata{}
-	title, source := resolveTitle(tag, fm, "/audiobooks/My Novel.mp3")
+	title, source := resolveTitle(tag, fm, "/audiobooks/My Novel.mp3", "", nil)
 	if title != "My Novel" || source != "filename" {
 		t.Errorf("got title=%q source=%q, want 'My Novel' / 'filename'", title, source)
 	}
@@ -89,7 +171,7 @@ func TestResolveTitleFallsBackToFilename(t *testing.T) {
 
 func TestResolveTitleNoSources(t *testing.T) {
 	fm := &FolderMetadata{}
-	title, source := resolveTitle(nil, fm, "")
+	title, source := resolveTitle(nil, fm, "", "", nil)
 	if title != "" || source != "unknown" {
 		t.Errorf("got title=%q source=%q, want '' / 'unknown'", title, source)
 	}

--- a/internal/server/handlers_integration_test.go
+++ b/internal/server/handlers_integration_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers_integration_test.go
-// version: 1.8.0
+// version: 1.8.1
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
-// last-edited: 2026-07-11
+// last-edited: 2026-07-16
 
 package server
 
@@ -217,7 +217,14 @@ func setupHandlerTestServer(t *testing.T) *Server {
 		database.SetGlobalStore(oldStore)
 	})
 
-	return NewServer(mockDB)
+	srv := NewServer(mockDB)
+	// INTERNAL-SERVER-PKG-STALL: NewServer starts a 4-worker FileIOPool. Without
+	// this cleanup every test that builds a server leaks those workers for the
+	// rest of the binary's life — a timed-out run's dump showed 352 parked
+	// FileIOPool.worker goroutines (≈88 leaked servers), which is pure race-
+	// detector and scheduler overhead piled onto an already-slow package.
+	t.Cleanup(srv.fileIOPool.Stop)
+	return srv
 }
 
 // TestListWorks_Success tests the listWorks handler with successful response


### PR DESCRIPTION
Clears **12 open backlog items** (40 open → 28), per the "implement where we should, say not-doing where we shouldn't" pass.

## Implemented (3)

**CONS-17b — a per-chapter tag title could become the whole book's title.** `resolveTitle` trusted any first-chapter tag title that wasn't obviously generic, so a studio ident like `"Big Finish Ident"` was adopted as the book's title — leaking into `Book.Title` and colliding across every book carrying that ident. The filesystem scanner now has the same all-chapters-agree discriminator the iTunes path got in CONS-FRAG:

- all chapters strip to the same title → that IS the book title (`tag.Title(agreed)`, e.g. `"Aces Abroad - Part 1…3"` → `"Aces Abroad"`)
- they disagree → fall back to the folder
- single-file books keep trusting their tag outright

**No caller signature churn** — `AssembleBookMetadata` already had `dirPath`. **Cost bounded**: unlike the iTunes twin (track names are free from the library XML), each check here is a real tag read, so it's capped at a 5-file sample with early-exit on first disagreement, and only entered for multi-file books whose first tag is non-generic — the exact bug case. Album-preference stays rejected (album ≈ series name). 2 regression tests, **both verified to FAIL without the fix** (pre-fix title = `"Big Finish Ident"`).

**CFG-2-D-LOG — retired the CFG-2 flat-key shim.** Its gate was "one stable release with zero flat-only-key warnings in prod." Verified *before* removing: `journalctl --since '30 days ago' | grep -c 'legacy flat config key'` → **0**, across multiple releases. Removed the 54-entry list + detection loop. `remapScheduledKeys` intentionally stays.

**INTERNAL-SERVER-PKG-STALL — root-caused (partial fix).** It is **not** a deadlock. Reproduced deterministically with `GOMAXPROCS=2 -race`; the timeout dump's only running test was **2s** in — nothing hung, the package had simply spent its budget. Measured: **664 tests, 357s cumulative**, **no pathological test** (slowest 13.9s). Against CI's 600s, a CPU-starved runner just doesn't finish. The original note's "parked on a channel receive in FileIOPool" hint was a **red herring** (parked ≠ deadlocked). Fixed the real defect the dump exposed: **352 leaked `FileIOPool.worker` goroutines** (≈88 servers × 4) — `setupHandlerTestServer` built a server and never stopped its pool.

> Structural residual documented in TODO.md rather than papered over: ~60 direct `NewServer(` calls still leak their pool, and the package is too big for the 10m budget. Options are (a) raise the timeout, (b) split the package, (c) add a `newTestServer(t, …)` helper + migrate 60 sites — all want owner buy-in, so none taken unilaterally.

## Closed as duplicate / not-a-task (4)

`MAYDEPLOY-I1` (= I1) · `MAYDEPLOY-I6` (= I6) · `DEDUP-CANDIDATE-EXPLOSION-2026-06-18` (= CONS-10, its own note already said so) · `AI-RESP-C` (a standing "don't touch `embedding_client.go`" guardrail note — never work; instruction preserved, checkbox closed).

## Not doing — recorded with reasons (5)

- **WF-6** — a trigger condition, not work: both halves are self-declared *"(re-evaluate only) iff…"*. Neither condition holds.
- **DOCS-1** — its own bar is already exceeded (418 md files / 59 mermaid vs a "≥9 files / ≥7 diagrams" target). Residual was re-packaging existing docs with no consumer; hundreds of pages of generated prose carry doc-rot cost against no demand.
- **4.1** (PostgreSQL research, XL) and **4.7** (per-workload store eval, L) — settled architecture. Pebble is the committed production store and isn't a bottleneck; this month's real problems were fixed-limit truncation, stale mocks, and single-core loops — none of them storage-engine choices.
- **AI-RESP-D** — externally blocked; its precondition is OpenAI shipping `/v1/responses` in batch lines.

## Verification

`go build ./...` clean; `go test -short` green on `internal/metadata`, `internal/config`, `internal/scanner`, `internal/importer`, plus the touched `internal/server` tests. Version headers bumped on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)