### PR TITLE
fix(database): skip all book: secondary index keys in unbounded scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.169.0 -->
+<!-- version: 3.170.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-17 -->
 
@@ -8,6 +8,36 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 17, 2026 - fix(database): secondary index keys aborted every unbounded book scan
+
+`GetAllBooksFullFrom` iterates the Pebble range `book:0`..`book:~`, which holds book
+records *and* ten secondary indexes that share the `book:` prefix (`asin`, `author`,
+`hash`, `isbn13`, `organizedhash`, `originalhash`, `path`, `series`, `versiongroup`,
+`work`). Only `:path:` was skipped, so every other index key was handed to
+`json.Unmarshal` as if it were a `Book`. Several index families store an **empty**
+value — the data lives entirely in the key — and unmarshalling zero bytes returns
+`unexpected end of JSON input`, which aborted the whole scan at the first
+`book:asin:` key.
+
+It only reproduced with `limit=0` (unbounded): any caller passing a limit below the
+book count stopped iterating before reaching the index keys, so the bug stayed latent.
+It also needed the raw Pebble path — the memdb path swallows per-record errors with
+`continue` — which is why it surfaced on **startup tasks**, before memdb warm-up.
+
+On production this made `acoustid.backfill` fail on **every restart** with
+`load books: unexpected end of JSON input`, silently stalling fingerprint coverage —
+the acknowledged bottleneck for dedup quality. Verified against a full-fidelity copy
+of the production database: 48,369 real book records, and 6,685 `book:asin:` +
+2,400 `book:isbn13:` keys with empty values sitting directly after them in key order.
+
+Affected unbounded callers: `plugins/acoustid/backfill.go`,
+`plugins/acoustid/fingerprint_rescan.go`, `dedup/engine.go`,
+`maintenance/jobs/relink_report.go`.
+
+The predicate now keys off structure rather than a hardcoded list: record IDs
+(ULID/UUID) never contain `:`, so a colon after the `book:` prefix marks an index
+key. New indexes cannot silently outgrow it.
 
 #### July 17, 2026 - fix(dedup): a rescan silently resurrected dismissed candidates
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 9.107.0 -->
+<!-- version: 9.108.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-17 -->
 
@@ -19,6 +19,30 @@ future agent) can scan the entire workspace in one page.
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
 
 ---
+
+## ✅ FIXED (2026-07-17) — GETALLBOOKS-INDEX-KEYS: unbounded book scans died on index keys
+
+`GetAllBooksFullFrom` iterated `book:0`..`book:~` and skipped only `:path:`, then
+`json.Unmarshal`'d the other nine `book:`-prefixed secondary indexes as Books. The
+`book:asin:` / `book:isbn13:` families store empty values, so unmarshal returned
+`unexpected end of JSON input` and killed the scan.
+
+Only reproduced with `limit=0` **and** the raw Pebble path (memdb swallows per-record
+errors), i.e. **startup tasks before warm-up**. Prod effect: `acoustid.backfill` failed
+on every restart → fingerprint coverage silently stalled.
+
+Fixed by matching on structure (a `:` after the `book:` prefix ⇒ index key) instead of
+a hardcoded prefix list. Regression test `TestGetAllBooksFullFrom_SkipsSecondaryIndexKeys`
+(`internal/database/pebble_books_index_keys_test.go`) reproduces the exact prod error and
+fails without the fix.
+
+**Follow-up found while verifying on the dedup sandbox — still open:**
+- **DEDUP-DURATION-NOT-THE-CAUSE:** applying `maintenance.duration-backfill` (7,845 file
+  durations across 719 books) changed candidate counts by **zero** — `exact` stayed at
+  13,008. The long-held premise that the exact-layer backlog is driven by the duration-ms
+  bug does not hold for the current data; `dedup.full-scan` is embedding-only and does not
+  recompute the `exact` layer. Identify what actually generates `exact` candidates.
+  (The other follow-up, DEDUP-DISMISS-RESURRECT, is now fixed — see the entry below.)
 
 ## ✅ FIXED (2026-07-17) — DEDUP-DISMISS-RESURRECT: rescans undid human dismissals
 

--- a/docs/executive-summaries/2026-07-17-fingerprint-backfill-silently-failing-executive-summary.md
+++ b/docs/executive-summaries/2026-07-17-fingerprint-backfill-silently-failing-executive-summary.md
@@ -1,0 +1,79 @@
+<!-- file: docs/executive-summaries/2026-07-17-fingerprint-backfill-silently-failing-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5e8b3a91-2c47-4d6f-b083-9a1c5e7d40f2 -->
+<!-- last-edited: 2026-07-17 -->
+
+# The audio-fingerprinting job had been quietly failing every single restart
+
+## What was wrong
+
+The app keeps a job that listens to your audiobooks and computes an audio
+"fingerprint" for each one — a compact signature of how the audio actually sounds.
+Fingerprints are the most reliable way to tell whether two books are genuinely the
+same recording, as opposed to two books that merely share a title.
+
+That job never ran. Every time the server restarted, it started up, tried to load
+the list of books, immediately hit an error, and gave up. It then reported itself as
+failed in a log file and nothing else happened. No alert, no retry, nothing visible
+in the interface. As far as anyone using the app could tell, fingerprinting was
+simply on.
+
+The practical cost: roughly two-thirds of the library has no fingerprint. That is
+the single biggest reason duplicate detection has to fall back on comparing titles
+and durations, which is fuzzier and produces more false matches for a human to sort
+through.
+
+## What was actually happening
+
+The database stores books in a list, and stores a set of lookup shortcuts — "find
+the book with this ISBN", "find the book at this file path" — right alongside them.
+The code that reads "every book" walked past the end of the real books and started
+reading the shortcuts, trying to interpret each one as if it were a book.
+
+Most of those shortcuts have nothing stored in them; the useful information is in
+the label, not the contents. So the code opened an empty one, tried to read a book
+out of it, found nothing, and treated that as a fatal error rather than skipping it.
+
+There was already a rule to skip one specific kind of shortcut — the file-path one.
+But nine other kinds had been added over time and nobody extended the rule. The
+first one the code reached happened to be the ISBN-style shortcut, and that is
+exactly where it died.
+
+Two things kept this hidden for a long time:
+
+- It only breaks when something asks for *all* the books at once. Anything asking
+  for a page at a time stops before reaching the shortcuts and works perfectly.
+- The app normally serves reads from a fast in-memory copy, which quietly skips
+  unreadable entries instead of failing. Only jobs that run at startup — before that
+  in-memory copy is ready — read the database directly and hit the error.
+
+So it needed both conditions at once. The fingerprint job happened to be the one job
+that met both, on every startup.
+
+## What we changed
+
+The code now recognises a shortcut by its shape rather than by a hand-maintained
+list of names. Book identifiers never contain a colon; every shortcut label does.
+That single distinction is enough, and it means future shortcuts cannot silently
+break this again — which is the failure that actually happened here.
+
+We also added a test that reproduces the original error exactly, and confirmed it
+fails without the fix. It cannot regress unnoticed.
+
+## How we found it
+
+We built a disposable, full-fidelity copy of the production system — real library,
+real database, isolated so that even a genuine delete cannot touch production media.
+The bug announced itself in the first twenty seconds of running it, in the startup
+log. It had been sitting in production logs for months, doing so silently that
+nobody had cause to read them.
+
+Three other jobs read the book list the same unbounded way and were exposed to the
+identical failure: the fingerprint rescan, the duplicate-detection engine, and the
+relink report. All four are fixed by this one change.
+
+## What this does not fix
+
+Fingerprint coverage does not repair itself. The job can now run, but the roughly
+two-thirds of the library that was never fingerprinted still needs a backfill pass
+to catch up. That is a separate, deliberate step.

--- a/internal/database/pebble_books_index_keys_test.go
+++ b/internal/database/pebble_books_index_keys_test.go
@@ -1,0 +1,77 @@
+// file: internal/database/pebble_books_index_keys_test.go
+// version: 1.0.0
+// guid: 3d9c1f47-8a2e-4b06-9d51-7c4e2a8f60b3
+// last-edited: 2026-07-17
+
+package database
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAllBooksFullFrom_SkipsSecondaryIndexKeys is a regression test for the
+// Pebble-path bug where GetAllBooksFullFrom iterated "book:0".."book:~" and
+// skipped only ":path:" keys, then json.Unmarshal'd every other key in range as
+// if it were a Book.
+//
+// The "book:" prefix is shared by ten secondary indexes (asin, author, hash,
+// isbn13, organizedhash, originalhash, path, series, versiongroup, work).
+// Several of them store an EMPTY value because the data lives entirely in the
+// key; json.Unmarshal of zero bytes returns "unexpected end of JSON input", so
+// the scan died at the first book:asin: key it reached.
+//
+// It only reproduces with limit=0 (unbounded): any caller passing a limit under
+// the book count stops iterating before reaching the index keys. On production
+// this made acoustid.backfill fail on every startup with
+// "load books: unexpected end of JSON input", which in turn stalled fingerprint
+// coverage. Affected unbounded callers: acoustid/backfill.go,
+// acoustid/fingerprint_rescan.go, dedup/engine.go, maintenance/jobs/relink_report.go.
+func TestGetAllBooksFullFrom_SkipsSecondaryIndexKeys(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+
+	const total = 5
+	for i := 0; i < total; i++ {
+		_, err := store.CreateBook(&Book{
+			Title:    fmt.Sprintf("Book %03d", i),
+			FilePath: fmt.Sprintf("/tmp/book_%03d.m4b", i),
+		})
+		require.NoError(t, err)
+	}
+
+	// Write the secondary-index keys exactly as production stores them: the data
+	// is encoded in the key and the value is empty (asin/isbn13) or a bare book
+	// ID that is not valid JSON (author/hash/series).
+	emptyValued := []string{
+		"book:asin:0062688650:01KNDB93H0EVZXKMTEMS4T017V",
+		"book:isbn13:9780002246828:01KNDB9CP8H7M17DBCS83TV6HR",
+	}
+	for _, k := range emptyValued {
+		require.NoError(t, store.db.Set([]byte(k), []byte{}, pebble.Sync))
+	}
+	nonJSONValued := map[string]string{
+		"book:hash:000063743d8365eb2af105df0589d90357fbdb0d5bdbcdafa13f29a8d0bd8f64": "01KNDBK4FYRWSAZW6PBG9947T8",
+		"book:author:38541:01KNDBK4FYRWSAZW6PBG9947T8":                               "01KNDBK4FYRWSAZW6PBG9947T8",
+		"book:series:144944:01KNDBK4FYRWSAZW6PBG9947T8":                              "01KNDBK4FYRWSAZW6PBG9947T8",
+	}
+	for k, v := range nonJSONValued {
+		require.NoError(t, store.db.Set([]byte(k), []byte(v), pebble.Sync))
+	}
+
+	// Force the raw Pebble path. This is what production hits when an unbounded
+	// scan runs as a startup task, before memdb warm-up publishes the index --
+	// the memdb path swallows per-record errors with `continue` and so hides this.
+	store.UseMemDB = false
+
+	// limit=0 => unbounded: iterate past the last record and into the index keys.
+	books, err := store.GetAllBooksFullFrom("", 0)
+	require.NoError(t, err, "secondary index keys must not abort the scan")
+	require.Len(t, books, total, "must return every book and no index keys")
+	for _, b := range books {
+		require.NotEmpty(t, b.ID, "an index key was decoded as a Book")
+	}
+}

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.116.0
+// version: 1.117.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package database
 
@@ -533,7 +533,20 @@ func (p *PebbleStore) GetAllBooksFullFrom(afterID string, limit int) ([]Book, er
 	count := 0
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := string(iter.Key())
-		if strings.Contains(key, ":path:") {
+		// The "book:0".."book:~" range holds record keys ("book:<id>") AND every
+		// secondary index that shares the prefix: book:asin:, book:author:,
+		// book:hash:, book:isbn13:, book:organizedhash:, book:originalhash:,
+		// book:path:, book:series:, book:versiongroup:, book:work:. Only ":path:"
+		// used to be skipped, so the others were unmarshalled as Books. Several
+		// index families store an empty value (the data lives in the key), and
+		// json.Unmarshal of zero bytes returns "unexpected end of JSON input",
+		// which aborted the entire scan at the first book:asin: key.
+		//
+		// Record IDs (ULID/UUID) never contain ':', so a colon in the remainder
+		// is what distinguishes an index key from a record. Match on that rather
+		// than maintaining a list of index prefixes that new indexes can outgrow.
+		rest, ok := strings.CutPrefix(key, "book:")
+		if !ok || strings.Contains(rest, ":") {
 			continue
 		}
 		var book Book


### PR DESCRIPTION
## The bug

`GetAllBooksFullFrom` iterates the Pebble range `book:0`..`book:~`. That range holds book records **and** ten secondary indexes sharing the `book:` prefix. Only `:path:` was skipped:

```go
if strings.Contains(key, ":path:") { continue }
var book Book
if err := json.Unmarshal(iter.Value(), &book); err != nil {
    return nil, err        // one index key kills the whole scan
}
```

The `asin`/`isbn13` index families store an **empty** value (the data lives in the key). `json.Unmarshal` of zero bytes returns `unexpected end of JSON input`, aborting the scan at the first `book:asin:` key.

## Why it stayed hidden

It needs **both**:
1. `limit=0` (unbounded) — any caller passing a limit below the book count stops before reaching index keys.
2. The raw Pebble path — the memdb path swallows per-record errors with `continue`.

Both hold for **startup tasks**, which run before memdb warm-up.

## Production impact

`acoustid.backfill` failed on **every restart**:

```
2026-07-16T18:48:38 ERROR def_id=acoustid.backfill error="load books: unexpected end of JSON input"
2026-07-16T19:45:16 ERROR def_id=acoustid.backfill error="load books: unexpected end of JSON input"
```

Fingerprint coverage — the acknowledged bottleneck for dedup quality (~65% unfingerprinted) — has been silently stalled.

## Evidence

Scanned a full-fidelity copy of the production DB with the exact iterator bounds:

```
PREFIX                        TOTAL     okBook      EMPTY    badJSON
book:<record>                 48369      48369          0          0
book:asin:                     6685          0       6685          0   <-- first key after records
book:author:                  67621          0          0      67621
book:hash:                    48340          0          0      48340
book:isbn13:                   2400          0       2400          0
book:organizedhash:           37301          0          0      37301
book:originalhash:            48302          0          0      48302
book:path:                    45558          0          0          0   <-- the only one skipped
book:series:                  57105          0          0      57105
book:versiongroup:             1746       1745          0          1
book:work:                      710        710          0          0
```

`book:<record> = 48369` matches `maintenance.duration-backfill`'s independent "Scanned 48369 books".

## Affected unbounded callers

- `internal/plugins/acoustid/backfill.go:82`
- `internal/plugins/acoustid/fingerprint_rescan.go:313`
- `internal/dedup/engine.go:3062`
- `internal/maintenance/jobs/relink_report.go:52`

## The fix

Match on structure, not a hardcoded prefix list. Record IDs (ULID/UUID) never contain `:`, so a colon after the `book:` prefix marks an index key — new indexes cannot silently outgrow it.

## Testing

- `TestGetAllBooksFullFrom_SkipsSecondaryIndexKeys` reproduces the exact prod error; **fails without the fix** (`Received unexpected error: unexpected end of JSON input`), passes with it.
- Full `internal/database` package green under `-race` (165s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvpyZ1aPbPSyLioiiR4UVu