### PR TITLE
fix(dedup): stop rescans from resurrecting dismissed candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,45 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.168.0 -->
+<!-- version: 3.169.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-16 -->
+<!-- last-edited: 2026-07-17 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 17, 2026 - fix(dedup): a rescan silently resurrected dismissed candidates
+
+`UpsertCandidateNew` guarded `Layer`, `Similarity`, `ScoreBreakdown`, `Band` and
+`FormulaVersion` behind a `protected` check, then assigned `Status`
+**unconditionally**:
+
+```go
+oldStatus := existing.Status
+existing.Status = c.Status   // clobbered a human verdict
+```
+
+Every dedup scan re-upserts the same pairs with status `pending`, so any candidate
+a reviewer had `dismissed` returned to the review queue on the next run. Because
+dismissals never stuck, the queue could not converge: the same false positives came
+back after every scan, forever.
+
+Measured on a full-fidelity replica of production: a single `dedup.full-scan`
+flipped exactly **43** candidates `dismissed` -> `pending` (all `layer=exact`,
+`similarity=1`), while an untouched production control stayed at 1351 dismissed.
+The diff showed that transition and no other.
+
+The engine already assumed this stickiness elsewhere — the purge path is explicit
+about it ("CRITICAL: Only purge PENDING candidates. Merged and dismissed rows...",
+`internal/dedup/engine.go`) — so the upsert path was inconsistent with the rest of
+the engine rather than deliberately permissive.
+
+Status is now treated as a verdict: `dismissed`/`merged` survive a rescan and may
+only be replaced by another terminal verdict. Machine-derived statuses
+(`pending`, `stale-drain`, `stale-fp`) stay refreshable, so rescans can still
+reclassify freely.
+
 
 #### July 16, 2026 - fix(metadata): a per-chapter tag title could become the whole book's title (CONS-17b)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 9.106.10 -->
+<!-- version: 9.107.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-16 -->
+<!-- last-edited: 2026-07-17 -->
 
 # Project TODO
 
@@ -17,6 +17,24 @@ future agent) can scan the entire workspace in one page.
 - [`docs/implementation-guide.md`](docs/implementation-guide.md) — integration guide for open items
 - [`docs/codebase-evaluation.md`](docs/codebase-evaluation.md) — 2026-04-30 codebase audit (12 issue groups, 38 bot-tasks)
 - Claude project memory at `~/.claude/projects/-Users-jdfalk-repos-github-com-jdfalk-audiobook-organizer/memory/` — items still to graduate here
+
+---
+
+## ✅ FIXED (2026-07-17) — DEDUP-DISMISS-RESURRECT: rescans undid human dismissals
+
+`UpsertCandidateNew` protected Layer/Similarity/ScoreBreakdown/Band/FormulaVersion but
+assigned `Status` unconditionally. Every scan re-upserts pairs as `pending`, so
+`dismissed` candidates returned to the queue on each run — the review queue could never
+converge.
+
+Found on the dedup sandbox: one `dedup.full-scan` flipped exactly **43** candidates
+`dismissed`→`pending` (all layer=exact, sim=1); prod control unchanged at 1351 dismissed.
+Diff showed that transition and no other.
+
+Fixed by treating `dismissed`/`merged` as terminal verdicts (replaceable only by another
+terminal verdict); `pending`/`stale-drain`/`stale-fp` stay refreshable. Regression test
+`TestUpsertCandidate_TerminalStatusSurvivesRescan`
+(`internal/database/embedding_candidate_status_sticky_test.go`) fails without the fix.
 
 ---
 

--- a/docs/executive-summaries/2026-07-17-dismissed-duplicates-came-back-executive-summary.md
+++ b/docs/executive-summaries/2026-07-17-dismissed-duplicates-came-back-executive-summary.md
@@ -1,0 +1,66 @@
+<!-- file: docs/executive-summaries/2026-07-17-dismissed-duplicates-came-back-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2f7c1d4-96e3-4a58-8c02-1d7e4b93af65 -->
+<!-- last-edited: 2026-07-17 -->
+
+# Duplicates you dismissed kept coming back
+
+## What was wrong
+
+When the app thinks two books might be the same, it puts the pair in a review
+queue. You look at it and decide: yes, merge them, or no, these are different —
+dismiss it.
+
+Dismissing didn't stick. The next time the duplicate scan ran, pairs you had
+already rejected quietly returned to the queue as if you had never looked at
+them. Your decision was thrown away, and there was no message saying so.
+
+The effect compounds. Every scan handed back a batch of already-rejected pairs,
+so the queue never got smaller no matter how much reviewing was done. Work spent
+on the queue was being erased.
+
+## Why it happened
+
+Each scan re-records every pair it finds, and marks the ones it records as
+"needs review". That's correct for pairs it's seeing for the first time.
+
+The problem was that the code re-applied "needs review" to pairs that already
+had a decision on them. It had been written carefully to protect other
+information on the pair — how similar the books are, how that was calculated —
+but the *decision itself* was left unprotected and got overwritten by the
+incoming "needs review".
+
+The rest of the system already assumed decisions were permanent. The cleanup
+routine that removes old pairs explicitly refuses to touch dismissed or merged
+ones. So this wasn't a deliberate choice — one path protected your decisions and
+another quietly undid them.
+
+## What we changed
+
+A decision is now treated as a decision. Once a pair is dismissed or merged, a
+scan cannot revert it to "needs review". Only another decision can change it —
+for example, if you later decide a dismissed pair really should be merged.
+
+Everything the scan is *supposed* to keep updating still updates freely, so this
+doesn't make the system stubborn. It only stops it from forgetting.
+
+## How we found it
+
+We built a disposable copy of the live system — the real library, the real
+database — isolated so nothing we did could reach production. Then we ran the
+real duplicate scan on the copy and compared it against untouched production.
+
+The comparison was unambiguous: **43 pairs** changed from dismissed back to
+needs-review, and nothing else changed at all. Production, as a control, stayed
+where it was. That is the kind of result that is very hard to argue with, and it
+is not something we could have seen by reading the code alone — it took running
+the real thing on real data.
+
+## What this means going forward
+
+Reviewing the duplicate queue is now worth doing: the queue can actually shrink
+and stay shrunk.
+
+One caveat: this fixes the behaviour from here on. Dismissals that were already
+lost to previous scans are gone — those pairs are sitting in the queue again and
+will need dismissing one final time.

--- a/internal/database/embedding_candidate_status_sticky_test.go
+++ b/internal/database/embedding_candidate_status_sticky_test.go
@@ -1,0 +1,83 @@
+// file: internal/database/embedding_candidate_status_sticky_test.go
+// version: 1.0.0
+// guid: 8f61d0b3-45ac-4e29-91d7-6b2f83c0e5a4
+// last-edited: 2026-07-17
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpsertCandidate_TerminalStatusSurvivesRescan is a regression test for the
+// dismiss-resurrect bug.
+//
+// UpsertCandidateNew carefully protects Layer/Similarity/ScoreBreakdown/Band/
+// FormulaVersion behind a `protected` check, but assigned Status unconditionally:
+//
+//	oldStatus := existing.Status
+//	existing.Status = c.Status   // <- clobbered a human verdict
+//
+// Every dedup scan re-upserts the same pairs with Status "pending", so a
+// dismissed candidate silently returned to the review queue on each run.
+// Measured on a full-fidelity replica of production: a single dedup.full-scan
+// flipped exactly 43 candidates dismissed -> pending (all layer=exact,
+// similarity=1), while a prod control instance stayed at 1351 dismissed.
+//
+// This matters beyond annoyance: if dismissals do not survive a scan, the review
+// queue can never converge -- the same false positives come back forever.
+// The purge path already treats these as sticky ("CRITICAL: Only purge PENDING
+// candidates. Merged and dismissed rows..." in dedup/engine.go), so the engine
+// already assumed the behavior this test pins down.
+func TestUpsertCandidate_TerminalStatusSurvivesRescan(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		verdict  string // status a reviewer/auto-resolve recorded
+		incoming string // status the rescan re-upserts with
+		want     string
+	}{
+		{"dismissed survives a rescan", "dismissed", "pending", "dismissed"},
+		{"merged survives a rescan", "merged", "pending", "merged"},
+		{"dismissed may be upgraded to merged", "dismissed", "merged", "merged"},
+		{"pending is still updatable", "pending", "dismissed", "dismissed"},
+		{"stale-drain stays refreshable", "stale-drain", "pending", "pending"},
+		{"stale-fp stays refreshable", "stale-fp", "pending", "pending"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestEmbeddingStore(t)
+
+			base := DedupCandidate{
+				EntityType: "book",
+				EntityAID:  "01KNDBRDX5A7NPB408V2VTG9XY",
+				EntityBID:  "01KQAW4JMN3XXCB8HKD62F3K8W",
+				Layer:      "exact",
+				Similarity: floatPtr(1),
+				Status:     "pending",
+			}
+			id, isNew, err := store.UpsertCandidateNew(base)
+			require.NoError(t, err)
+			require.True(t, isNew)
+
+			// Record the verdict (what a reviewer or auto-resolve does).
+			verdict := base
+			verdict.Status = tc.verdict
+			_, _, err = store.UpsertCandidateNew(verdict)
+			require.NoError(t, err)
+
+			// A rescan re-upserts the identical pair.
+			rescan := base
+			rescan.Status = tc.incoming
+			gotID, gotNew, err := store.UpsertCandidateNew(rescan)
+			require.NoError(t, err)
+			require.False(t, gotNew, "rescan must update the existing row, not insert")
+			require.Equal(t, id, gotID)
+
+			cands, _, err := store.ListCandidates(CandidateFilter{Limit: 10})
+			require.NoError(t, err)
+			require.Len(t, cands, 1)
+			require.Equal(t, tc.want, cands[0].Status)
+		})
+	}
+}

--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,6 +1,6 @@
 // file: internal/database/embedding_store.go
-// version: 2.7.2
-// last-edited: 2026-07-11
+// version: 2.8.0
+// last-edited: 2026-07-17
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
 package database
@@ -427,6 +427,20 @@ func (s *EmbeddingStore) PutCachedEmbedding(textHash, model string, vector []flo
 
 // ─── Dedup candidate methods ──────────────────────────────────────────────────
 
+// isTerminalCandidateStatus reports whether a dedup candidate status records a
+// VERDICT rather than a machine-derived classification.
+//
+// "dismissed" and "merged" are decisions — a human reviewed the pair, or
+// auto-resolve acted on it. They must survive a rescan: every scan re-upserts
+// the same pairs with status "pending", so a resurrected dismissal puts a known
+// false positive back in the review queue after every run.
+//
+// "pending", "stale-drain" and "stale-fp" are deliberately NOT terminal: they
+// are reclassifications a rescan should be free to revise.
+func isTerminalCandidateStatus(status string) bool {
+	return status == "dismissed" || status == "merged"
+}
+
 func dedupRecKey(id int64) []byte {
 	return []byte(fmt.Sprintf("%s%016x", dedupRecPfx, id))
 }
@@ -632,7 +646,24 @@ func (s *EmbeddingStore) UpsertCandidateNew(c DedupCandidate) (id int64, isNew b
 		existing.LLMReason = c.LLMReason
 	}
 	oldStatus := existing.Status
-	existing.Status = c.Status
+	// Status is a VERDICT, not derived data: "dismissed" and "merged" record a
+	// decision (human review or auto-resolve), while every rescan re-upserts the
+	// same pair with Status "pending". Overwriting unconditionally therefore
+	// resurrected dismissals on every dedup.full-scan — measured on a
+	// full-fidelity replica of production: 43 candidates flipped
+	// dismissed -> pending in a single scan, so the same false positives return
+	// to the review queue after each run and the queue can never converge.
+	//
+	// The purge path already treats these as sticky ("CRITICAL: Only purge
+	// PENDING candidates. Merged and dismissed rows..." — dedup/engine.go), so
+	// this restores the intent the rest of the engine already assumes.
+	//
+	// Machine-derived statuses (stale-drain, stale-fp) stay refreshable: they are
+	// reclassifications a rescan SHOULD be able to revise. Only another terminal
+	// verdict may replace a terminal verdict (e.g. dismissed -> merged).
+	if !isTerminalCandidateStatus(existing.Status) || isTerminalCandidateStatus(c.Status) {
+		existing.Status = c.Status
+	}
 	existing.UpdatedAt = now
 
 	data, err := json.Marshal(existing)


### PR DESCRIPTION
## The bug

`UpsertCandidateNew` protects most fields behind a `protected` check — then assigns `Status` unconditionally, outside it:

```go
protected := existing.Layer == "exact" || ...
if !protected {
    existing.Layer = c.Layer
    existing.Similarity = c.Similarity
    ...
}
...
oldStatus := existing.Status
existing.Status = c.Status        // <- unconditional; clobbers a human verdict
```

Every dedup scan re-upserts the same pairs with `Status: "pending"`. So any candidate a reviewer had **dismissed** silently returned to the review queue on the next scan.

**The queue could never converge.** Dismiss a false positive, run a scan, it's back. Forever.

## Evidence — measured on real data

A full-fidelity replica of production (ZFS clone + copied Pebble DB) ran one `dedup.full-scan`. Diffing it against the untouched production instance as a control:

```
prod   : 15270 candidates
sandbox: 15270 candidates

common=15268   status-changed=43

=== STATUS TRANSITIONS (prod -> sandbox) ===
  dismissed    -> pending          43   <-- HUMAN DECISION LOST

by layer: {'exact': 43}
```

That transition and **no other**. Prod control stayed at 1351 dismissed; sandbox dropped to 1308.

## Why this is a bug, not a design choice

The engine already assumes these statuses are sticky — the purge path is explicit:

> `// CRITICAL: Only purge PENDING candidates. Merged and dismissed rows...` — `internal/dedup/engine.go:2887`

And `drain_stale` only ever reads `Status: "pending"`. So one path deliberately protects dismissals while the upsert path silently undid them. This restores the intent the rest of the engine already relies on.

## The fix

Status is a **verdict**, not derived data:

- `dismissed` / `merged` → terminal. Survive a rescan; replaceable only by another terminal verdict (so `dismissed → merged` still works).
- `pending` / `stale-drain` / `stale-fp` → machine-derived. Stay refreshable, so rescans can still reclassify freely.

## Testing

`TestUpsertCandidate_TerminalStatusSurvivesRescan` — table-driven, both directions:

| case | without fix |
|---|---|
| dismissed survives a rescan | **FAIL** — expected `dismissed`, actual `pending` |
| merged survives a rescan | **FAIL** — expected `merged`, actual `pending` |
| dismissed may be upgraded to merged | passes |
| pending is still updatable | passes |
| stale-drain stays refreshable | passes |
| stale-fp stays refreshable | passes |

The four "refreshable" cases pass **both** with and without the fix — they pin down that the fix doesn't over-protect.

`internal/database` + `internal/dedup` green under `-race` (259s / 30s).

## Note

This fixes behavior going forward. Dismissals already lost to prior scans are gone — those pairs are back in the queue and need dismissing once more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvpyZ1aPbPSyLioiiR4UVu