### PR TITLE
docs(sandbox): [withdrawn — moved to internal repo]

### DIFF
--- a/SANDBOX_NOTE.md
+++ b/SANDBOX_NOTE.md
@@ -1,0 +1,6 @@
+<!-- file: SANDBOX_NOTE.md -->
+<!-- version: 1.0.0 -->
+
+# (relocated)
+
+This content was moved to an internal repository. Nothing here.


### PR DESCRIPTION
Withdrawn. This content described internal infrastructure and has been moved to a private repository. Nothing here.