### PR TITLE
fix(dedup): maintain status/entity indexes in bulk candidate ops; 1M whole-backlog cap; suppression summary

### DIFF
--- a/internal/database/embedding_store.go
+++ b/internal/database/embedding_store.go
@@ -1,5 +1,5 @@
 // file: internal/database/embedding_store.go
-// version: 2.8.0
+// version: 2.9.0
 // last-edited: 2026-07-17
 // guid: 7c4a9b2e-d831-4f5c-a07e-3b8d6e1f9c42
 
@@ -1239,6 +1239,7 @@ func (s *EmbeddingStore) MarkCandidatesAsMergedForEntity(entityType, entityID st
 	b := s.db.NewBatch()
 	defer b.Close()
 	for _, t := range targets {
+		oldStatus := t.rec.Status
 		t.rec.Status = "merged"
 		t.rec.UpdatedAt = now
 		data, err := json.Marshal(t.rec)
@@ -1247,6 +1248,21 @@ func (s *EmbeddingStore) MarkCandidatesAsMergedForEntity(entityType, entityID st
 		}
 		if err := b.Set(dedupRecKey(t.id), data, nil); err != nil {
 			return 0, fmt.Errorf("mark candidates merged set %d: %w", t.id, err)
+		}
+		// Maintain the "dedup:s:" status secondary index in the SAME batch,
+		// mirroring UpdateCandidateStatus: delete the old-status row, set the
+		// new one. Without this, bulk merges left stale dedup:s:pending: rows
+		// behind (and never wrote dedup:s:merged:), so the indexed read path
+		// kept surfacing merged candidates as pending. The "dedup:e:" entity
+		// rows are intentionally untouched — the candidate still exists and
+		// references the same entities; only its status changed.
+		if oldStatus != "" && oldStatus != "merged" {
+			if err := b.Delete(dedupStatusIdxKey(oldStatus, t.id), nil); err != nil {
+				return 0, fmt.Errorf("mark candidates merged status-index delete %d: %w", t.id, err)
+			}
+		}
+		if err := b.Set(dedupStatusIdxKey("merged", t.id), nil, nil); err != nil {
+			return 0, fmt.Errorf("mark candidates merged status-index set %d: %w", t.id, err)
 		}
 	}
 	if err := b.Commit(pebble.Sync); err != nil {
@@ -1293,8 +1309,14 @@ func (s *EmbeddingStore) RemoveCandidatesForEntity(entityType, entityID string) 
 	b := s.db.NewBatch()
 	defer b.Close()
 	for _, t := range targets {
+		// Mirror DeleteCandidate: clean ALL four key classes, not just the
+		// record + pair keys — otherwise every removal leaked two "dedup:e:"
+		// entity rows and one "dedup:s:" status row forever.
 		_ = b.Delete(dedupRecKey(t.id), nil)
 		_ = b.Delete(dedupPairKey(t.rec.EntityType, t.rec.EntityAID, t.rec.EntityBID), nil)
+		_ = b.Delete(dedupEntityKey(t.rec.EntityType, t.rec.EntityAID, t.id), nil)
+		_ = b.Delete(dedupEntityKey(t.rec.EntityType, t.rec.EntityBID, t.id), nil)
+		_ = b.Delete(dedupStatusIdxKey(t.rec.Status, t.id), nil)
 	}
 	if err := b.Commit(pebble.Sync); err != nil {
 		return 0, err
@@ -1365,10 +1387,18 @@ func (s *EmbeddingStore) CanonicalizeCandidates() (rewritten, deleted int, err e
 			rewritten++
 		} else if existingErr == nil {
 			// Canonical row already exists — delete the non-canonical duplicate.
+			// Mirror DeleteCandidate: clean ALL four key classes (record, pair,
+			// entity both sides, status), not just record + pair — otherwise
+			// each canonicalized duplicate leaked its "dedup:e:" and "dedup:s:"
+			// secondary-index rows forever. The entity keys are symmetric in
+			// (A,B), so the swapped duplicate's rows are addressable directly.
 			existingCloser.Close()
 			b := s.db.NewBatch()
 			_ = b.Delete(dedupRecKey(t.id), nil)
 			_ = b.Delete(oldPairKey, nil)
+			_ = b.Delete(dedupEntityKey(t.rec.EntityType, t.rec.EntityAID, t.id), nil)
+			_ = b.Delete(dedupEntityKey(t.rec.EntityType, t.rec.EntityBID, t.id), nil)
+			_ = b.Delete(dedupStatusIdxKey(t.rec.Status, t.id), nil)
 			if err := b.Commit(pebble.Sync); err != nil {
 				b.Close()
 				return rewritten, deleted, fmt.Errorf("canonicalize delete: %w", err)

--- a/internal/database/embedding_store_status_index_test.go
+++ b/internal/database/embedding_store_status_index_test.go
@@ -1,12 +1,15 @@
 // file: internal/database/embedding_store_status_index_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5a2c7e1f-9d3b-4a6e-8c1d-2f4b6a8e0c3d
-// last-edited: 2026-07-11
+// last-edited: 2026-07-17
 
 package database
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/assert"
@@ -248,6 +251,161 @@ func TestCandidateStatusIndex_FlagUnsetFallback_HonorsAllFilters(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, "b3", results[0].EntityAID)
 	assert.Equal(t, "b4", results[0].EntityBID)
+}
+
+// entityIndexRows returns every "dedup:e:" key currently stored, for direct
+// assertion on the entity secondary-index contents.
+func entityIndexRows(t *testing.T, s *EmbeddingStore) []string {
+	t.Helper()
+	prefix := []byte(dedupEntityPfx)
+	upper := prefixUpperBound(prefix)
+	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var rows []string
+	for iter.First(); iter.Valid(); iter.Next() {
+		rows = append(rows, string(iter.Key()))
+	}
+	require.NoError(t, iter.Error())
+	return rows
+}
+
+// (F3) MarkCandidatesAsMergedForEntity must move each affected candidate's
+// "dedup:s:" row from its old status to "merged" in the same batch as the
+// record rewrite — and must leave the "dedup:e:" entity rows intact (the
+// candidate still references both entities; only its status changed).
+func TestCandidateStatusIndex_MarkCandidatesAsMergedForEntity_MaintainsIndex(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Two pending candidates referencing bX (one on each side), plus one
+	// unrelated pending pair that must not be touched.
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "bX", EntityBID: "bY", Layer: "embedding", Status: "pending",
+	}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "bW", EntityBID: "bX", Layer: "embedding", Status: "pending",
+	}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "p1", EntityBID: "p2", Layer: "embedding", Status: "pending",
+	}))
+
+	all, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	idsByPair := map[string]int64{}
+	for _, c := range all {
+		idsByPair[c.EntityAID+":"+c.EntityBID] = c.ID
+	}
+	entityRowsBefore := entityIndexRows(t, store)
+	require.Len(t, entityRowsBefore, 6, "2 entity rows per candidate")
+
+	n, err := store.MarkCandidatesAsMergedForEntity("book", "bX")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 3, "one status row per candidate — old rows replaced, not accumulated")
+	assert.Contains(t, rows, string(dedupStatusIdxKey("merged", idsByPair["bX:bY"])))
+	assert.Contains(t, rows, string(dedupStatusIdxKey("merged", idsByPair["bW:bX"])))
+	assert.Contains(t, rows, string(dedupStatusIdxKey("pending", idsByPair["p1:p2"])))
+	assert.NotContains(t, rows, string(dedupStatusIdxKey("pending", idsByPair["bX:bY"])))
+	assert.NotContains(t, rows, string(dedupStatusIdxKey("pending", idsByPair["bW:bX"])))
+
+	// Entity index untouched — the candidates still exist and reference the
+	// same entities.
+	assert.ElementsMatch(t, entityRowsBefore, entityIndexRows(t, store))
+
+	// The indexed read path must now see the transition too.
+	require.NoError(t, store.SetCandidateStatusIndexBuilt())
+	pending, _, err := store.ListCandidates(CandidateFilter{Status: "pending"})
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "p1", pending[0].EntityAID)
+	merged, _, err := store.ListCandidates(CandidateFilter{Status: "merged"})
+	require.NoError(t, err)
+	assert.Len(t, merged, 2)
+}
+
+// (F4a) RemoveCandidatesForEntity must clean ALL four key classes for each
+// deleted candidate (dedup:r:, dedup:p:, dedup:e: both sides, dedup:s:),
+// mirroring DeleteCandidate — not just the record + pair keys.
+func TestCandidateIndexes_RemoveCandidatesForEntity_CleansAllIndexRows(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b1", EntityBID: "b2", Layer: "embedding", Status: "pending",
+	}))
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "b3", EntityBID: "b4", Layer: "embedding", Status: "merged",
+	}))
+
+	n, err := store.RemoveCandidatesForEntity("book", "b1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	// Status index: only the survivor's row remains.
+	survivors, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, survivors, 1)
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 1, "deleted candidate's status-index row must be removed")
+	assert.Equal(t, string(dedupStatusIdxKey("merged", survivors[0].ID)), rows[0])
+
+	// Entity index: b1/b2 rows gone, b3/b4 rows intact.
+	entityRows := entityIndexRows(t, store)
+	require.Len(t, entityRows, 2, "deleted candidate's entity-index rows must be removed")
+	gone, err := store.ListCandidatesForEntity("book", "b2", "")
+	require.NoError(t, err)
+	assert.Empty(t, gone, "entity index must not point at the deleted candidate")
+}
+
+// (F4b) CanonicalizeCandidates' duplicate-delete branch must clean the
+// non-canonical row's dedup:e: and dedup:s: rows too, not just dedup:r: +
+// dedup:p: — otherwise every canonicalized duplicate leaks two entity rows
+// and one status row forever.
+func TestCandidateIndexes_CanonicalizeDuplicateDelete_CleansAllIndexRows(t *testing.T) {
+	store := newTestEmbeddingStore(t)
+
+	// Canonical row via the normal path (h < w).
+	require.NoError(t, store.UpsertCandidate(DedupCandidate{
+		EntityType: "book", EntityAID: "hello", EntityBID: "world", Layer: "embedding", Status: "pending",
+	}))
+	all, _, err := store.ListCandidates(CandidateFilter{})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	canonID := all[0].ID
+
+	// Non-canonical duplicate written raw (bypasses upsert canonicalization),
+	// WITH its secondary-index rows present — simulating a fully indexed
+	// pre-canonicalization row.
+	const dupID = int64(7777)
+	rec := candRec{
+		EntityType: "book", EntityAID: "world", EntityBID: "hello",
+		Layer: "exact", Status: "pending",
+		CreatedAt: time.Now().UnixNano(), UpdatedAt: time.Now().UnixNano(),
+	}
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(dedupRecKey(dupID), data, pebble.Sync))
+	require.NoError(t, store.db.Set(dedupPairKey("book", "world", "hello"), []byte(fmt.Sprintf("%016x", dupID)), pebble.Sync))
+	require.NoError(t, store.db.Set(dedupEntityKey("book", "world", dupID), nil, pebble.Sync))
+	require.NoError(t, store.db.Set(dedupEntityKey("book", "hello", dupID), nil, pebble.Sync))
+	require.NoError(t, store.db.Set(dedupStatusIdxKey("pending", dupID), nil, pebble.Sync))
+
+	rewritten, deleted, err := store.CanonicalizeCandidates()
+	require.NoError(t, err)
+	assert.Equal(t, 0, rewritten)
+	assert.Equal(t, 1, deleted)
+
+	rows := statusIndexRows(t, store)
+	require.Len(t, rows, 1, "duplicate's status-index row must be removed")
+	assert.Equal(t, string(dedupStatusIdxKey("pending", canonID)), rows[0])
+
+	entityRows := entityIndexRows(t, store)
+	require.Len(t, entityRows, 2, "duplicate's entity-index rows must be removed")
+	assert.Contains(t, entityRows, string(dedupEntityKey("book", "hello", canonID)))
+	assert.Contains(t, entityRows, string(dedupEntityKey("book", "world", canonID)))
 }
 
 // The backfill write path (WriteCandidateStatusIndexRow, used by the

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.61.0
+// version: 1.62.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package dedup
 
@@ -47,6 +47,14 @@ const minFingerprintMatchSeconds = 60
 // pairs where the single-file side is clearly a small slice of the whole.
 // aligned with dataset/rules.go partVsWholeRatioMax (INIT-1 T8)
 const partVsWholeDurationRatioMax = 0.5
+
+// wholeBacklogCandidateLimit is the ListCandidates limit shared by every
+// whole-backlog pass (Rescore, PurgeStaleCandidates,
+// ReevaluateAcoustIDConflicts). paginateCandidates hard-slices AFTER the
+// similarity-desc sort, so a limit smaller than the pending backlog silently
+// processes only the top-similarity subset — any op meaning "all pending
+// candidates" must use this shared value and warn when it is hit exactly.
+const wholeBacklogCandidateLimit = 1_000_000
 
 // Engine orchestrates a 3-layer dedup system:
 //   - Layer 1: Exact matching (free, instant) — same file hash, ISBN/ASIN, or near-identical titles
@@ -558,6 +566,14 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		authorName:      authorName,
 	}
 
+	// C7: accumulate suppression outcomes across the whole per-book scan so ONE
+	// Info summary (with per-reason counts) survives at the end, instead of the
+	// suppression reasons from PairEligibility being discarded into per-pair
+	// Debug lines that are invisible at default log level.
+	suppressedByReason := map[string]int{}
+	suppressedDeleted := 0
+	suppressedDeleteFailures := 0
+
 	for _, ref := range embeddingCandIDs {
 		// Cancellation check per-candidate, not just per-book: a single book
 		// with an unusually large pending-candidate set can otherwise run
@@ -590,12 +606,18 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		// for any emitter (incl. LSH/AcoustID) that lacks the emit-time guard.
 		ok, suppressors := PairEligibility(book, otherBook)
 		if !ok {
+			for _, reason := range suppressors {
+				suppressedByReason[reason]++
+			}
 			logging.Debug(ctx, "dedup unified: suppressed pair → delete",
 				"book", book.ID, "other", candID,
 				"cand", ref.candID, "suppressors", suppressors)
 			if err := de.embedStore.DeleteCandidate(ref.candID); err != nil {
+				suppressedDeleteFailures++
 				logging.Debug(ctx, "dedup unified: delete suppressed candidate failed",
 					"cand", ref.candID, "err", err)
+			} else {
+				suppressedDeleted++
 			}
 			continue
 		}
@@ -635,6 +657,23 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 			logging.Debug(ctx, "dedup unified: upsert error",
 				"book", book.ID, "other", candID, "err", err)
 		}
+	}
+
+	// C7: one Info summary per scan with the per-reason suppression breakdown
+	// (the per-pair Debug lines above are invisible at default log level, so
+	// without this the DELETE of suppressed candidates was effectively silent).
+	if suppressedDeleted > 0 || suppressedDeleteFailures > 0 {
+		logging.Info(ctx, "dedup unified: suppressed candidates deleted",
+			"book", book.ID,
+			"deleted", suppressedDeleted,
+			"by_reason", suppressedByReason,
+		)
+	}
+	if suppressedDeleteFailures > 0 {
+		logging.Warn(ctx, "dedup unified: suppressed candidate deletes failed",
+			"book", book.ID,
+			"failures", suppressedDeleteFailures,
+		)
 	}
 
 	return nil
@@ -1552,10 +1591,15 @@ func (de *Engine) ReevaluateAcoustIDConflicts(ctx context.Context, dryRun bool) 
 	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
 		EntityType: "book",
 		Status:     "pending",
-		Limit:      1000000,
+		Limit:      wholeBacklogCandidateLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list candidates: %w", err)
+	}
+	if len(candidates) == wholeBacklogCandidateLimit {
+		logging.Warn(ctx, "dedup acoustid-conflict reevaluate: candidate list truncated at limit — some pending candidates were not examined",
+			"limit", wholeBacklogCandidateLimit,
+		)
 	}
 
 	res := &AcoustIDConflictResult{DryRun: dryRun}
@@ -2815,10 +2859,20 @@ func (de *Engine) Rescore(ctx context.Context, apply bool) (RescoreResult, error
 
 	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
 		Status: "pending",
-		Limit:  100000,
+		Limit:  wholeBacklogCandidateLimit,
 	})
 	if err != nil {
 		return RescoreResult{}, fmt.Errorf("rescore: list candidates: %w", err)
+	}
+	// "No silent caps": paginateCandidates hard-slices after the
+	// similarity-desc sort, so hitting the limit exactly means an unknown tail
+	// of pending candidates was NOT rescored — say so instead of silently
+	// processing only the top-similarity subset (the old 100K limit did
+	// exactly that on >100K-pending backlogs).
+	if len(candidates) == wholeBacklogCandidateLimit {
+		logging.Warn(ctx, "dedup rescore: candidate list truncated at limit — some pending candidates were not rescored",
+			"limit", wholeBacklogCandidateLimit,
+		)
 	}
 
 	cfg := de.getScoreConfig()
@@ -2896,13 +2950,18 @@ func (de *Engine) PurgeStaleCandidates(ctx context.Context) (int, error) {
 	candidates, _, err := de.embedStore.ListCandidates(database.CandidateFilter{
 		EntityType: "book",
 		Status:     "pending",
-		Limit:      1000000,
+		Limit:      wholeBacklogCandidateLimit,
 	})
 	if err != nil {
 		err := fmt.Errorf("list candidates: %w", err)
 		span.RecordError(err)
 		span.SetAttributes(attribute.Bool("error", true))
 		return 0, err
+	}
+	if len(candidates) == wholeBacklogCandidateLimit {
+		logging.Warn(ctx, "dedup purge stale: candidate list truncated at limit — some pending candidates were not examined",
+			"limit", wholeBacklogCandidateLimit,
+		)
 	}
 
 	// Memoise book lookups so a book referenced by many candidates is only
@@ -3162,7 +3221,11 @@ func (de *Engine) listAmbiguousCandidates(entityType string, low, high float64) 
 		Layer:         "embedding",
 		MinSimilarity: &low,
 		MaxSimilarity: &high,
-		Limit:         10000,
+		// Intentionally bounded (NOT wholeBacklogCandidateLimit): this feeds
+		// RunLLMReview, a paid per-pair external LLM batch that is further
+		// capped by LLMMaxPairsPerRun. Each run consumes from the top of the
+		// similarity-sorted ambiguous window; subsequent runs drain the rest.
+		Limit: 10000,
 	}
 	candidates, _, err := de.embedStore.ListCandidates(filter)
 	return candidates, err

--- a/internal/dedup/rescore_test.go
+++ b/internal/dedup/rescore_test.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/rescore_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c4a70f81-92db-4e35-8a16-0d5f7c2e9b41
-// last-edited: 2026-07-12
+// last-edited: 2026-07-17
 
 package dedup
 
@@ -149,5 +149,17 @@ func TestScorePairsForBook_BelowBandNotDropped(t *testing.T) {
 	// DefaultScoreConfig), well under the 60.0 review floor.
 	if r.Score.Score != 4.0 {
 		t.Fatalf("below-band pair: expected composite == duration boost 4.0, got %.4f", r.Score.Score)
+	}
+}
+
+// TestWholeBacklogCandidateLimit_NoSilentCaps pins the shared whole-backlog
+// ListCandidates limit used by Rescore / PurgeStaleCandidates /
+// ReevaluateAcoustIDConflicts at 1M. Rescore previously used a private 100K
+// limit: paginateCandidates hard-slices after the similarity-desc sort, so a
+// >100K pending backlog silently rescored only the top-similarity subset.
+// Any future lowering of this constant must be a deliberate, reviewed change.
+func TestWholeBacklogCandidateLimit_NoSilentCaps(t *testing.T) {
+	if wholeBacklogCandidateLimit != 1_000_000 {
+		t.Fatalf("wholeBacklogCandidateLimit = %d, want 1_000_000 (matches every whole-backlog sibling op; lowering it reintroduces the silent Rescore cap)", wholeBacklogCandidateLimit)
 	}
 }


### PR DESCRIPTION
## Summary
Four dedup store/engine fixes (F3/F4/F5 + logging C7 from docs/audits/2026-07-17-multi-discipline-review.md):
- MarkCandidatesAsMergedForEntity (runs after every merge) now maintains the dedup:s: status index (was: merged rows invisible to indexed listings, stale pending index rows grew forever)
- RemoveCandidatesForEntity + CanonicalizeCandidates duplicate-delete now clean all four key families like DeleteCandidate (was: dedup:e:/dedup:s: leaks)
- Engine.Rescore raised from a silent 100K cap to the shared 1M wholeBacklogCandidateLimit constant; all three whole-backlog call sites now warn on truncation (no silent caps)
- Unified-scoring suppression deletes now emit a per-scan Info summary with per-reason counts + delete-failure Warn (was: Debug-only destructive deletes)

## Tests
3 new index-maintenance tests (red against unfixed code) + limit pin test; internal/database + internal/dedup full short suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65