### PR TITLE
feat(maintenance): title-repair op — re-derive CONS-17b agreed chapter titles over stored books

### DIFF
--- a/internal/metadata/assemble.go
+++ b/internal/metadata/assemble.go
@@ -1,6 +1,7 @@
 // file: internal/metadata/assemble.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
+// last-edited: 2026-07-17
 
 package metadata
 
@@ -135,6 +136,14 @@ func agreedChapterTitle(dirPath string, supportedExts []string) (agreed string, 
 		}
 	}
 	return agreed, true
+}
+
+// AgreedChapterTitle exposes the CONS-17b agree-title discriminator for callers
+// outside this package (e.g. the maintenance.title-repair op, which re-derives
+// titles for books stored before CONS-17b shipped). It is a thin wrapper over
+// the unexported agreedChapterTitle — the logic stays in one place.
+func AgreedChapterTitle(dirPath string, supportedExts []string) (agreed string, multi bool) {
+	return agreedChapterTitle(dirPath, supportedExts)
 }
 
 // resolveTitle picks the book title. dirPath + supportedExts enable the CONS-17b

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package maintenance
 
@@ -78,6 +78,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 
 		// --- title cleanup ---
 		p.titleBackfillDef(),
+		p.titleRepairDef(),
 
 		// --- duration repair ---
 		p.durationBackfillDef(),

--- a/internal/plugins/maintenance/title_repair.go
+++ b/internal/plugins/maintenance/title_repair.go
@@ -1,0 +1,357 @@
+// file: internal/plugins/maintenance/title_repair.go
+// version: 1.0.0
+// guid: 13bedd46-9b61-41a2-b791-36813d7ffcb9
+// last-edited: 2026-07-17
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metadata"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// titleRepairParams controls maintenance.title-repair. Dry-run is the default:
+// nothing is written unless apply=true.
+type titleRepairParams struct {
+	Apply bool `json:"apply"`
+}
+
+// repairAction is the per-book outcome of the title-repair decision.
+type repairAction int
+
+const (
+	// actionRetitle: the CONS-17b agreed chapter title differs from the stored
+	// title — retitle (or report in dry-run).
+	actionRetitle repairAction = iota
+	// actionSkipDeleted: book is soft-deleted (MarkedForDeletion).
+	actionSkipDeleted
+	// actionSkipSingleFile: <2 files — a single-file book cannot have the
+	// chapter-title leak (CONS-17b definition).
+	actionSkipSingleFile
+	// actionSkipProvenance: title has an override / override-lock / fetched
+	// value, or the book's metadata came from a fetched provider — never
+	// clobber curated or provider-supplied titles.
+	actionSkipProvenance
+	// actionSkipNoAgreement: chapters do not agree on a stripped title (or the
+	// directory holds <2 audio files on disk).
+	actionSkipNoAgreement
+	// actionSkipTitleOK: the agreed title already equals the stored title —
+	// idempotent no-op.
+	actionSkipTitleOK
+)
+
+// titleRepairBook carries everything the pure decision function needs about
+// one book, pre-gathered by the runner so the decision itself does no IO.
+type titleRepairBook struct {
+	Title             string
+	MarkedForDeletion bool
+	// MetadataSource is Book.MetadataSource ("" when nil) — a non-empty value
+	// means a provider supplied the last applied metadata.
+	MetadataSource string
+	// TitleState is the metadata_state:<ulid>:title row, nil when absent.
+	TitleState *database.MetadataFieldState
+	FilePaths  []string
+}
+
+// titleRepairDecision is the outcome of decideTitleRepair.
+type titleRepairDecision struct {
+	Action repairAction
+	// Reason is a short human-readable skip reason for Debug logging.
+	Reason string
+	// DirPath is the (majority) directory the agreement check ran against.
+	DirPath string
+	// MixedDir reports that the book's files span more than one directory
+	// (counted separately; the majority directory is still used).
+	MixedDir bool
+	// NewTitle is set only when Action == actionRetitle.
+	NewTitle string
+}
+
+// majorityDir returns the directory shared by most of paths, and whether the
+// paths span more than one distinct directory. Ties break lexicographically
+// (smallest dir wins) so the result is deterministic.
+func majorityDir(paths []string) (dir string, mixed bool) {
+	counts := make(map[string]int, 1)
+	for _, p := range paths {
+		counts[filepath.Dir(p)]++
+	}
+	best, bestN := "", 0
+	for d, n := range counts {
+		if n > bestN || (n == bestN && (best == "" || d < best)) {
+			best, bestN = d, n
+		}
+	}
+	return best, len(counts) > 1
+}
+
+// decideTitleRepair is the pure per-book decision for maintenance.title-repair.
+// agreedFn abstracts metadata.AgreedChapterTitle so tests can stub the on-disk
+// tag reads; it is only invoked after all cheap gates pass. Check order is
+// deliberately cheapest-first: soft-delete → file count → provenance →
+// agreement (the only gate that reads audio tags off disk).
+func decideTitleRepair(in titleRepairBook, agreedFn func(dirPath string) (agreed string, multi bool)) titleRepairDecision {
+	if in.MarkedForDeletion {
+		return titleRepairDecision{Action: actionSkipDeleted, Reason: "soft-deleted"}
+	}
+	if len(in.FilePaths) < 2 {
+		return titleRepairDecision{Action: actionSkipSingleFile, Reason: "single-file book"}
+	}
+	dir, mixed := majorityDir(in.FilePaths)
+
+	// Provenance guard: only proceed when the stored title is file/filename
+	// derived or has no field state at all.
+	if st := in.TitleState; st != nil {
+		if st.OverrideLocked || st.OverrideValue != nil {
+			return titleRepairDecision{Action: actionSkipProvenance, Reason: "title has user override", DirPath: dir, MixedDir: mixed}
+		}
+		if st.FetchedValue != nil {
+			return titleRepairDecision{Action: actionSkipProvenance, Reason: "title has fetched value", DirPath: dir, MixedDir: mixed}
+		}
+	}
+	if in.MetadataSource != "" {
+		return titleRepairDecision{
+			Action:   actionSkipProvenance,
+			Reason:   "book metadata applied from provider " + in.MetadataSource,
+			DirPath:  dir,
+			MixedDir: mixed,
+		}
+	}
+
+	agreed, multi := agreedFn(dir)
+	if !multi || agreed == "" {
+		return titleRepairDecision{Action: actionSkipNoAgreement, Reason: "chapters do not agree on a title", DirPath: dir, MixedDir: mixed}
+	}
+	if strings.EqualFold(agreed, in.Title) {
+		return titleRepairDecision{Action: actionSkipTitleOK, Reason: "stored title already matches agreed title", DirPath: dir, MixedDir: mixed}
+	}
+	return titleRepairDecision{Action: actionRetitle, DirPath: dir, MixedDir: mixed, NewTitle: agreed}
+}
+
+func (p *Plugin) titleRepairDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.title-repair",
+		Plugin:          "maintenance",
+		DisplayName:     "Repair leaked chapter-tag titles (CONS-17b)",
+		Description:     "Re-derives each multi-file book's title via the CONS-17b all-chapters-agree check and repairs stored titles that are per-chapter tag residue (e.g. 'Big Finish Ident'). Skips single-file books and any title with override/fetched provenance. Default dry-run previews old→new; set apply=true to write.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.title-repair",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         4 * time.Hour,
+		Schedule:        nil,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runTitleRepair,
+	}
+}
+
+// titleRepairWorkers caps the RunItems pool: the per-book work is disk-IO +
+// tag-read bound, so more than 8 workers just thrashes the disk.
+func titleRepairWorkers() int {
+	n := runtime.NumCPU()
+	if n > 8 {
+		n = 8
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+func (p *Plugin) runTitleRepair(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params titleRepairParams // Apply=false → dry-run (safe default)
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	if !params.Apply {
+		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no changes will be written (set apply=true to write)")
+	}
+
+	// Load the full book list up front (Core rows are slim). Paged — no
+	// silent cap: the loop runs until a short page.
+	const pageSize = 500
+	var books []database.BookCore
+	for offset := 0; ; {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		page, err := store.GetAllBooksCore(pageSize, offset)
+		if err != nil {
+			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
+		}
+		books = append(books, page...)
+		offset += len(page)
+		if len(page) < pageSize {
+			break
+		}
+	}
+
+	total := len(books)
+	exts := config.AppConfig.SupportedExtensions
+	workers := titleRepairWorkers()
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"title-repair starting: %d books, %d workers, apply=%v", total, workers, params.Apply))
+	if total == 0 {
+		_ = reporter.UpdateProgress(1, 1, "title-repair: 0 books — nothing to do")
+		return nil
+	}
+
+	// Counters are atomics — the RunItems pool below is concurrent. Each
+	// worker touches a disjoint book, so writes never collide on a row, but
+	// counters are shared.
+	var examined, retitled, skipSingle, skipNoAgree, skipProv, skipTitleOK, skipDeleted, mixedDir, errs atomic.Int64
+
+	verb := "would retitle"
+	if params.Apply {
+		verb = "retitled"
+	}
+
+	err := registry.RunItems(ctx, reporter, books, func(ctx context.Context, b database.BookCore) error {
+		n := examined.Add(1)
+		if n%500 == 0 {
+			_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+				"title-repair progress: %d/%d examined, %d %s, %d errors", n, total, retitled.Load(), verb, errs.Load()))
+		}
+
+		// Cheap pre-gate before any per-book DB reads.
+		if b.MarkedForDeletion != nil && *b.MarkedForDeletion {
+			skipDeleted.Add(1)
+			return nil
+		}
+
+		files, ferr := store.GetBookFiles(b.ID)
+		if ferr != nil {
+			errs.Add(1)
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("book %s: GetBookFiles failed: %v", b.ID, ferr))
+			return nil // non-fatal: keep sweeping
+		}
+		paths := make([]string, 0, len(files))
+		for _, f := range files {
+			if f.FilePath != "" {
+				paths = append(paths, f.FilePath)
+			}
+		}
+
+		var titleState *database.MetadataFieldState
+		states, serr := store.GetMetadataFieldStates(b.ID)
+		if serr != nil {
+			errs.Add(1)
+			_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("book %s: GetMetadataFieldStates failed: %v", b.ID, serr))
+			return nil
+		}
+		for i := range states {
+			if states[i].Field == "title" {
+				titleState = &states[i]
+				break
+			}
+		}
+
+		metaSource := ""
+		if b.MetadataSource != nil {
+			metaSource = *b.MetadataSource
+		}
+		deleted := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+
+		d := decideTitleRepair(titleRepairBook{
+			Title:             b.Title,
+			MarkedForDeletion: deleted,
+			MetadataSource:    metaSource,
+			TitleState:        titleState,
+			FilePaths:         paths,
+		}, func(dir string) (string, bool) {
+			return metadata.AgreedChapterTitle(dir, exts)
+		})
+
+		if d.MixedDir {
+			mixedDir.Add(1)
+			_ = reporter.Log(slog.LevelDebug, fmt.Sprintf(
+				"book %s: files span multiple directories; using majority dir %s", b.ID, d.DirPath))
+		}
+
+		switch d.Action {
+		case actionSkipDeleted:
+			skipDeleted.Add(1)
+		case actionSkipSingleFile:
+			skipSingle.Add(1)
+		case actionSkipNoAgreement:
+			skipNoAgree.Add(1)
+		case actionSkipTitleOK:
+			skipTitleOK.Add(1)
+		case actionSkipProvenance:
+			skipProv.Add(1)
+		case actionRetitle:
+			_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+				"book %s: %s %q → %q", b.ID, verb, b.Title, d.NewTitle))
+			if params.Apply {
+				// UpdateBook is a FULL replacement — hydrate the full row and
+				// patch ONLY Title so denormalized Author/Series/fingerprints
+				// survive. Provenance note: the persisted field-state store
+				// only holds fetched/override values; the file-level value IS
+				// Book.Title, and the provenance map is recomputed at read
+				// time, so no separate provenance write is needed.
+				full, herr := store.GetBookByID(b.ID)
+				if herr != nil || full == nil {
+					errs.Add(1)
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("book %s: hydrate failed: %v", b.ID, herr))
+					return nil
+				}
+				full.Title = d.NewTitle
+				if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+					errs.Add(1)
+					_ = reporter.Log(slog.LevelWarn, fmt.Sprintf("book %s: UpdateBook failed: %v", b.ID, uerr))
+					return nil
+				}
+			}
+			retitled.Add(1)
+		}
+		if d.Action != actionRetitle && d.Reason != "" {
+			_ = reporter.Log(slog.LevelDebug, fmt.Sprintf("book %s: skip — %s", b.ID, d.Reason))
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: workers,
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Books %d/%d (%s=%d err=%d)", i+1, t, verb, retitled.Load(), errs.Load())
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	suffix := ""
+	if !params.Apply {
+		suffix = " (dry run — no writes)"
+	}
+	result := fmt.Sprintf(
+		"title-repair complete: examined=%d %s=%d skipped_single_file=%d skipped_no_agreement=%d skipped_provenance=%d skipped_title_ok=%d skipped_deleted=%d mixed_dir=%d errors=%d%s",
+		examined.Load(), strings.ReplaceAll(verb, " ", "_"), retitled.Load(), skipSingle.Load(), skipNoAgree.Load(),
+		skipProv.Load(), skipTitleOK.Load(), skipDeleted.Load(), mixedDir.Load(), errs.Load(), suffix)
+	_ = reporter.Log(slog.LevelInfo, result)
+	_ = reporter.UpdateProgress(total, total, result)
+
+	if errs.Load() > 0 {
+		return fmt.Errorf("%d per-book errors (see op log for details)", errs.Load())
+	}
+	return nil
+}

--- a/internal/plugins/maintenance/title_repair_test.go
+++ b/internal/plugins/maintenance/title_repair_test.go
@@ -1,0 +1,188 @@
+// file: internal/plugins/maintenance/title_repair_test.go
+// version: 1.0.0
+// guid: 1ca153f8-f8b3-40d5-871c-7959e39314ea
+// last-edited: 2026-07-17
+
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// agreedStub returns a fixed AgreedChapterTitle result and records whether it
+// was called — provenance/single-file gates must skip the (expensive) tag read.
+func agreedStub(agreed string, multi bool, called *bool) func(string) (string, bool) {
+	return func(string) (string, bool) {
+		if called != nil {
+			*called = true
+		}
+		return agreed, multi
+	}
+}
+
+// trStrPtr is a task-unique string-pointer helper (strPtr already exists in
+// auto_match_transcribed_test.go in this package).
+func trStrPtr(s string) *string { return &s }
+
+func TestDecideTitleRepair_RetitleCase(t *testing.T) {
+	in := titleRepairBook{
+		Title:     "nobody103 (Jack Voraces)", // per-chapter tag residue
+		FilePaths: []string{"/lib/mother-of-learning/ch1.mp3", "/lib/mother-of-learning/ch2.mp3"},
+	}
+	d := decideTitleRepair(in, agreedStub("Mother of Learning", true, nil))
+	if d.Action != actionRetitle {
+		t.Fatalf("Action = %v, want actionRetitle", d.Action)
+	}
+	if d.NewTitle != "Mother of Learning" {
+		t.Fatalf("NewTitle = %q, want %q", d.NewTitle, "Mother of Learning")
+	}
+	if d.MixedDir {
+		t.Fatalf("MixedDir = true for same-dir files")
+	}
+	if d.DirPath != "/lib/mother-of-learning" {
+		t.Fatalf("DirPath = %q", d.DirPath)
+	}
+}
+
+func TestDecideTitleRepair_SingleFileSkip(t *testing.T) {
+	called := false
+	in := titleRepairBook{
+		Title:     "Some Book",
+		FilePaths: []string{"/lib/book/book.m4b"},
+	}
+	d := decideTitleRepair(in, agreedStub("Other", true, &called))
+	if d.Action != actionSkipSingleFile {
+		t.Fatalf("Action = %v, want actionSkipSingleFile", d.Action)
+	}
+	if called {
+		t.Fatalf("agreedFn called for single-file book — must be gated before tag reads")
+	}
+}
+
+func TestDecideTitleRepair_SoftDeleteSkip(t *testing.T) {
+	called := false
+	in := titleRepairBook{
+		Title:             "Some Book",
+		MarkedForDeletion: true,
+		FilePaths:         []string{"/lib/b/1.mp3", "/lib/b/2.mp3"},
+	}
+	d := decideTitleRepair(in, agreedStub("Other", true, &called))
+	if d.Action != actionSkipDeleted {
+		t.Fatalf("Action = %v, want actionSkipDeleted", d.Action)
+	}
+	if called {
+		t.Fatalf("agreedFn called for soft-deleted book")
+	}
+}
+
+func TestDecideTitleRepair_ProvenanceSkips(t *testing.T) {
+	paths := []string{"/lib/b/1.mp3", "/lib/b/2.mp3"}
+	cases := []struct {
+		name string
+		in   titleRepairBook
+	}{
+		{"override value", titleRepairBook{Title: "T", FilePaths: paths,
+			TitleState: &database.MetadataFieldState{Field: "title", OverrideValue: trStrPtr(`"Custom"`)}}},
+		{"override locked", titleRepairBook{Title: "T", FilePaths: paths,
+			TitleState: &database.MetadataFieldState{Field: "title", OverrideLocked: true}}},
+		{"fetched value", titleRepairBook{Title: "T", FilePaths: paths,
+			TitleState: &database.MetadataFieldState{Field: "title", FetchedValue: trStrPtr(`"Fetched"`)}}},
+		{"book metadata source", titleRepairBook{Title: "T", FilePaths: paths,
+			MetadataSource: "audible"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			d := decideTitleRepair(tc.in, agreedStub("Other", true, &called))
+			if d.Action != actionSkipProvenance {
+				t.Fatalf("Action = %v, want actionSkipProvenance", d.Action)
+			}
+			if called {
+				t.Fatalf("agreedFn called despite provenance guard")
+			}
+			if d.Reason == "" {
+				t.Fatalf("Reason empty — skip reasons must be loggable")
+			}
+		})
+	}
+}
+
+func TestDecideTitleRepair_NoAgreementSkip(t *testing.T) {
+	in := titleRepairBook{
+		Title:     "Some Book",
+		FilePaths: []string{"/lib/b/1.mp3", "/lib/b/2.mp3"},
+	}
+	// Chapters disagree → agreed == "".
+	if d := decideTitleRepair(in, agreedStub("", true, nil)); d.Action != actionSkipNoAgreement {
+		t.Fatalf("disagreeing chapters: Action = %v, want actionSkipNoAgreement", d.Action)
+	}
+	// Directory holds <2 audio files on disk → multi == false.
+	if d := decideTitleRepair(in, agreedStub("X", false, nil)); d.Action != actionSkipNoAgreement {
+		t.Fatalf("!multi: Action = %v, want actionSkipNoAgreement", d.Action)
+	}
+}
+
+// TestDecideTitleRepair_Idempotent proves the second run is a no-op: after a
+// retitle, agreed == stored (case-insensitively) → actionSkipTitleOK.
+func TestDecideTitleRepair_Idempotent(t *testing.T) {
+	in := titleRepairBook{
+		Title:     "Mother of Learning",
+		FilePaths: []string{"/lib/b/1.mp3", "/lib/b/2.mp3"},
+	}
+	if d := decideTitleRepair(in, agreedStub("Mother of Learning", true, nil)); d.Action != actionSkipTitleOK {
+		t.Fatalf("exact match: Action = %v, want actionSkipTitleOK", d.Action)
+	}
+	if d := decideTitleRepair(in, agreedStub("MOTHER OF LEARNING", true, nil)); d.Action != actionSkipTitleOK {
+		t.Fatalf("case-insensitive match: Action = %v, want actionSkipTitleOK", d.Action)
+	}
+}
+
+func TestDecideTitleRepair_MixedDirUsesMajority(t *testing.T) {
+	in := titleRepairBook{
+		Title: "wrong",
+		FilePaths: []string{
+			"/lib/majority/1.mp3",
+			"/lib/majority/2.mp3",
+			"/lib/stray/3.mp3",
+		},
+	}
+	var gotDir string
+	d := decideTitleRepair(in, func(dir string) (string, bool) {
+		gotDir = dir
+		return "Right Title", true
+	})
+	if !d.MixedDir {
+		t.Fatalf("MixedDir = false for files spanning two dirs")
+	}
+	if gotDir != "/lib/majority" {
+		t.Fatalf("agreement checked against %q, want majority dir /lib/majority", gotDir)
+	}
+	if d.Action != actionRetitle || d.NewTitle != "Right Title" {
+		t.Fatalf("Action=%v NewTitle=%q", d.Action, d.NewTitle)
+	}
+}
+
+func TestMajorityDir(t *testing.T) {
+	dir, mixed := majorityDir([]string{"/a/1.mp3", "/a/2.mp3", "/b/3.mp3"})
+	if dir != "/a" || !mixed {
+		t.Fatalf("majorityDir = (%q, %v), want (/a, true)", dir, mixed)
+	}
+	dir, mixed = majorityDir([]string{"/a/1.mp3", "/a/2.mp3"})
+	if dir != "/a" || mixed {
+		t.Fatalf("majorityDir = (%q, %v), want (/a, false)", dir, mixed)
+	}
+	// Deterministic tie-break: lexicographically smallest dir wins.
+	dir, mixed = majorityDir([]string{"/b/1.mp3", "/a/2.mp3"})
+	if dir != "/a" || !mixed {
+		t.Fatalf("tie: majorityDir = (%q, %v), want (/a, true)", dir, mixed)
+	}
+}
+
+func TestTitleRepairWorkers_Cap(t *testing.T) {
+	n := titleRepairWorkers()
+	if n < 1 || n > 8 {
+		t.Fatalf("titleRepairWorkers() = %d, want 1..8", n)
+	}
+}


### PR DESCRIPTION
## Summary
New op `maintenance.title-repair` (dry-run by default, `{"apply": true}` to write): re-runs the CONS-17b agreed-chapter-title derivation over stored books and repairs title-leak residue — the root cause of 76% of the 9,074 exact-pending dedup backlog (measured on the dedup sandbox; see docs/dedup/STATUS.md remediation path, step 1).

- registry.RunItems pool, min(NumCPU,8) workers; pure decision function gates cheapest-first: soft-delete → single-file → provenance (override/locked/fetched/MetadataSource skipped) → tag agreement
- metadata.AgreedChapterTitle exported as a thin wrapper; derivation logic untouched
- Full counter set (examined, retitled/would_retitle, per-reason skips, errors); progress every 500; uncapped paged listing
- Idempotent; UpdateBook via fetch-mutate-write (Title only)

## Verification plan
Sandbox first: dry-run on the dedup sandbox, expect ~thousands of would_retitle in the known title-leak cliques; then apply + dedup.full-scan there to measure exact-layer collapse before any prod run (prod apply stays human-gated).

## Tests
9 decision-function tests + workers-cap test; maintenance + metadata short suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65