### PR TITLE
docs(plugin): refresh context skill, agents, and AI reference docs to 2026-07-17 reality

### DIFF
--- a/agents/db-design.md
+++ b/agents/db-design.md
@@ -1,7 +1,12 @@
 ---
 name: db-design
-description: Database design advisor for the audiobook-organizer codebase. Answers "how should I store X?" questions in a way that is consistent with existing schema decisions (PebbleDB key conventions, NutsDB activity log patterns, SQLite opt-in tier). Works generically on other projects when context docs are absent.
+description: Database design advisor for the audiobook-organizer codebase. Answers "how should I store X?" questions in a way that is consistent with existing schema decisions (PebbleDB key conventions, NutsDB activity/metrics patterns). Works generically on other projects when context docs are absent.
 ---
+
+<!-- file: agents/db-design.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 3d9c5b21-8e47-4f0a-b6d2-1c8e5a7f9b04 -->
+<!-- last-edited: 2026-07-17 -->
 
 # Database Design Advisor
 
@@ -16,7 +21,7 @@ Before proposing any new storage, answer:
 1. **Is this a single k:v value or a keyed collection?** Single values go as a top-level PebbleDB key. Collections need a key-prefix scheme.
 2. **Does it need to be queried by secondary keys?** PebbleDB is key-prefix only — if you need "find by author" you need either a secondary index (separate key) or an in-memory index.
 3. **Is it append-only / time-series?** NutsDB (`activity.nutsdb`) is for the activity log — don't put operational data there.
-4. **Is it relational with many joins?** SQLite is the opt-in alternative — but default to PebbleDB first and only escalate if needed.
+4. **Is it relational with many joins?** PebbleDB is the SOLE production store — the SQLite backend was removed (`InitializeStore` errors on `dbType: sqlite`). Model relational access as secondary-index keys (`<prefix>:<secondary>:<primary>`) or an in-memory index; do not propose a SQL tier.
 
 ## PebbleDB key conventions
 
@@ -36,5 +41,5 @@ For slow aggregate queries (counts, sums over large collections):
 ## What NOT to do
 
 - Do not add a new top-level table or collection without reading existing schema first
-- Do not use PebbleDB for relational data that needs multi-column queries — use SQLite
+- Do not propose SQLite (or any SQL store) — it was removed; multi-column query needs are met with secondary-index keys or in-memory indexes
 - Do not store full API response objects in cache (root cause of the 69GB memory bloat incident)

--- a/agents/pii-scanner.md
+++ b/agents/pii-scanner.md
@@ -35,17 +35,17 @@ When invoked with a path or "staged changes":
 2. If given "staged": run `git diff --cached --name-only` and read those files
 3. If given no argument: scan `docs/` and `.claude-plugin/` as the highest-risk areas
 
-For each file, reason about whether values are real vs placeholders. A value like `172.16.2.30` in a curl example is real PII. A value like `<your-server-ip>` is a safe placeholder.
+For each file, reason about whether values are real vs placeholders. A value like `172.16.99.99` in a curl example is real PII. A value like `<your-server-ip>` is a safe placeholder.
 
 ## Output format
 
 ```
 FILE: docs/AI-REFERENCE.md
-  LINE 19: 172.16.2.30 — private IP address [BLOCKER]
+  LINE 19: 172.16.99.99 — private IP address [BLOCKER]
   LINE 19: unimatrixzero — internal hostname [BLOCKER]
 
 FILE: docs/implementation-guide.md
-  LINE 4: 172.16.2.30 — private IP address (appears in curl examples) [BLOCKER]
+  LINE 4: 172.16.99.99 — private IP address (appears in curl examples) [BLOCKER]
 
 SUMMARY: 2 files, 3 blockers, 0 warnings
 ACTION: Replace with <your-server-ip> and <your-hostname> before public release

--- a/agents/schema-auditor.md
+++ b/agents/schema-auditor.md
@@ -3,6 +3,11 @@ name: schema-auditor
 description: Reviews existing database queries, migrations, and index choices. Catches N+1 query patterns, missing indexes, and unsafe live-data migrations. Point it at a file, a PR diff, or a migration to get a focused audit report.
 ---
 
+<!-- file: agents/schema-auditor.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 7a4e2f90-5c1b-4d83-a6e7-2b9d0c4f8e15 -->
+<!-- last-edited: 2026-07-17 -->
+
 # Schema Auditor
 
 ## Setup
@@ -22,17 +27,14 @@ Fix: use the batch fetch APIs (`GetBooksByIDs`, `GetAuthorsByIDs`, etc.) or add 
 
 ### Missing indexes
 
-For PebbleDB: check that any field used for prefix-scan has a corresponding secondary index key written on insert/update.
+PebbleDB is the sole production store (the SQLite backend was removed). Check that any field used for prefix-scan has a corresponding secondary index key written on insert/update — and that EVERY write path (insert, update, delete, bulk ops) maintains ALL of an entity's index families, not just the primary row. Reference: the dedup candidate store keeps four families in sync (`dedup:r:` / `dedup:p:` / `dedup:e:` / `dedup:s:`) — `docs/database-pebble-schema.md` documents the invariant.
 
-For SQLite: check that any column in a WHERE clause has an index, especially on large tables (books, book_files).
+### Migration / backfill safety on live data
 
-### Migration safety on live data
-
-Check migrations for:
-- Column additions without a DEFAULT value on large tables (will lock)
-- NOT NULL additions to populated columns without a backfill step first
-- Index creation without CONCURRENT (SQLite doesn't support this, but flag for awareness)
+Check migrations and backfill ops for:
 - Missing version-suffix on backfill flag keys (e.g., `backfill_done` instead of `backfill_v2_done`)
+- Full-replace write-backs on hydrated-from-memdb rows (wipes fields like `AcoustIDFingerprint` — fetch the FULL row, patch, then write)
+- Whole-library loops without a bounded worker pool (`registry.RunItems`) and without explicit list limits (silent default caps truncate results)
 
 ### PebbleDB key-scan performance
 

--- a/docs/AI-REFERENCE.md
+++ b/docs/AI-REFERENCE.md
@@ -1,14 +1,21 @@
 <!-- file: docs/AI-REFERENCE.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: e5f4g3h2-i1j0-k9l8-m7n6-o5p4q3r2s1t0 -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-17 -->
 
 # AI Reference Guide — Audiobook Organizer
 
 > **Purpose**: Complete project reference for AI agents. Read this before making any changes.
 > Keep this file updated with every architectural change.
 
-**Last updated**: 2026-07-01 | **Server version**: 1.117.0 | **Total API routes**: see `grep -rn '\.GET(\|\.POST(\|\.PUT(\|\.DELETE(\|\.PATCH(' --include='*.go' internal/server | grep -v _test.go | wc -l` for current count (~395 as of 2026-07-03)
+**Last updated**: 2026-07-17 | **Server version**: `v0.217.x` (ldflags-injected from the git tag into `main.version` → `server.SetVersion()`; defaults to `dev` in local builds — latest stable release `v0.217.7`) | **Total API routes**: see `grep -rn '\.GET(\|\.POST(\|\.PUT(\|\.DELETE(\|\.PATCH(' --include='*.go' internal/server | grep -v _test.go | wc -l` for current count (~608 as of 2026-07-17)
+
+**Live status docs** (read these for current numbers — this file documents structure, not state):
+
+- [`docs/dedup/STATUS.md`](dedup/STATUS.md) — dedup single source of truth (candidate counts, backlog composition; "if a number conflicts with an older doc, this doc wins")
+- [`docs/operations/pending-prod-actions.md`](operations/pending-prod-actions.md) — queued prod actions awaiting execution/human decision
+- [`docs/plans/DECISIONS-PENDING.md`](plans/DECISIONS-PENDING.md) — open decisions awaiting the owner
+- [`docs/audits/2026-07-17-multi-discipline-review.md`](audits/2026-07-17-multi-discipline-review.md) — latest cross-cutting code review findings
 
 ## Quick Facts
 
@@ -55,7 +62,10 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 ### `internal/database` — Data layer
 - **store.go** — `Store` interface (composite of ~36 role interfaces: `BookStore`, `AuthorStore`, `MetadataCacheStore`, …; PebbleStore is the ONLY implementation), ALL entity struct definitions (Book, Author, Series, Work, Narrator, BookSegment, Operation, etc.)
 - **pebble_store.go** — Primary implementation. Key schema: `book:<ulid>`, `book:path:<filepath>`, `book:hash:<hash>`, `author:<id>`, `series:<id>`, etc.
-- **embedding_store.go** — `EmbeddingStore` wrapping the main audiobooks.pebble DB for embeddings + dedup candidates + labeled dataset. Key-space: `emb:v:*`, `emb:c:*`, `dedup:r:*`, `dedup:p:*`, `dedup:seq`, `dedup:label:*`.
+- **embedding_store.go** — `EmbeddingStore` wrapping the main audiobooks.pebble DB for embeddings + dedup candidates + labeled dataset. Key-space: `emb:v:*`, `emb:c:*`, `dedup:r:*`, `dedup:p:*`, `dedup:e:*` (entity index), `dedup:s:*` (status index), `dedup:seq`, `dedup:label:*`.
+- **dedup_automerge_journal.go** — `dedup:automerge:<unixNano16hex>` journal entries written by the `dedup.auto-resolve` apply path; each merge records the book_ver snapshot timestamps so `Engine.UnmergeAuto` can reverse it.
+- **review_store.go** — generic human-review queue on `*PebbleStore` (`review_item:r:*` records, `review_item:status:*` index, `review_item:dedupkey:*` idempotency index). v1 producer is the regroup op; `UpsertReviewItem` upserts by stable DedupKey and never resurfaces an already-decided (approved/rejected/applied) item.
+- **pebble_store_ops_v2.go** — operations-registry-v2 persistence (`opv2:*` keyspace, see below).
 - **dedup_label.go** — Labeled dedup training dataset keyspace (`dedup:label:<candidateID,16hex>`). Types: `LabeledExample` (candidate pair + feature snapshot + label fields), `BookFeatures` (per-book evidence: title, author, path, durations, file count, has_cover, files_exist, recording_ids, itunes_pid_present, whole_book_sig_present), `LabeledExampleFilter`. Methods on `*EmbeddingStore`: `UpsertLabeledExample`, `GetLabeledExample`, `ListLabeledExamples`, `CountLabeledExamples`.
 - **ai_scan_store.go** — Separate PebbleDB (`ai_scans.db`) for AI dedup pipeline
 - **mock_store.go** — Test mock (generated with mockery patterns)
@@ -90,9 +100,35 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 - **openai_parser.go** — `OpenAIParser` with methods: `ParseFilename()`, `ParseAudiobook()`, `ParseCoverArt()`, `ReviewAuthorDuplicates()`, `DiscoverAuthorDuplicates()`, `CreateBatchAuthorDedup()`, `CheckBatchStatus()`, `DownloadBatchResults()`
 - **embedding_client.go** — Local embedding/LLM backend via Ollama: `bge-m3` (1024-dim vectors) for embeddings; `qwen2.5:7b-instruct` for LLM tasks. Primary backend for dedup/candidate ranking. See `internal/database/hnsw_embedding_store.go`, `internal/dedup/engine.go`, `internal/server/registry_wire.go` for integration points. OpenAI backend (`openai_parser.go`) remains in use for specific flows already documented above.
 
-### `internal/operations` — Background job queue
+### `internal/operations` — Background job queue (legacy v1)
 - **queue.go** — `OperationQueue` with timeout (configurable, default 30min), checkpoint/resume support, cancellation
 - Key: `Enqueue(id, type, folderPath, fn)`, `SetOperationTimeout()`, `SaveCheckpoint()`, `LoadCheckpoint()`
+
+### `internal/operations/registry` — Operations registry v2 (UOS)
+The plugin-op execution system. All `<plugin>.<op-name>` ops (dedup.*, maintenance.*, acoustid.*, …) run through this, persisted in the `opv2:` keyspace via `database.OpsV2Store` (`internal/database/pebble_store_ops_v2.go`).
+
+- **registry.go** — central `Registry`: owns every `OperationDef`, run handles, per-plugin `max_concurrent` caps, the ConcurrencyKey holder map, enqueue/cancel entry points
+- **dispatcher.go** — `runDispatcher`: 100ms-tick dispatch loop; walks queued ops in priority DESC / queued_at ASC order and promotes eligible ones to the worker pool (gates: plugin cap, ConcurrencyKey, deps)
+- **worker.go** — worker goroutines that execute op handlers with panic recovery, OTel tracing, abandoned-goroutine tracking (grace period before freeing the slot), infinite-restart detection
+- **watchdog.go** — periodic (30s) inspection of in-flight ops; writes `opv2:strike:` rows for uncheckpointed `ResumeRestart` ops and cancels ops stuck past `def.ProgressTimeout`
+- **resume.go** — `resumeAfterStartup`: walks `queued|running` rows on start and applies the def's `ResumePolicy` (`ResumeRestart` = re-dispatch with saved state, `ResumeRequeue` = fresh queued op, drop = discard)
+- **batch.go** — coalesces burst enqueues of a `Batchable` op type into ONE operation row via a debounce timer
+- **run_items.go** — `RunItems[T]`: generic bounded worker-pool helper (Concurrency, PerItemTimeout, ErrModeFail/ErrModeCollect). **The mandated pattern for any whole-library per-item loop** (see CLAUDE.md concurrency rules); never write a plain `for range books` loop with per-item DB/network/subprocess work
+
+`opv2:` key families (from the `pebble_store_ops_v2.go` header comment):
+
+```text
+opv2:def:{def_id}                                → OpDefinitionV2Row JSON
+opv2:op:{op_id}                                  → OperationV2Row JSON
+opv2:q:{999-priority:03d}:{ts_nano:020d}:{op_id} → op_id   (queue index; low byte-order = high priority, FIFO within priority)
+opv2:act:{op_id}                                 → ""      (active index: present while queued|running)
+opv2:state:{op_id}                               → OpStateV2Row JSON (checkpoint state)
+opv2:log:{op_id}:{ts_nano:020d}:{seq:010d}       → OpLogV2Row JSON
+opv2:err:{op_id}:{ts_nano:020d}                  → OpErrorV2Row JSON
+opv2:strike:{def_id}:{ts_nano:020d}:{op_id}      → OpStrikeV2Row JSON (watchdog strikes)
+```
+
+**ConcurrencyKey dedupe semantics**: an `OperationDef` may declare a `ConcurrencyKey` string; the dispatcher never runs two ops holding the same key simultaneously (the holder map in `Registry` maps key → running op ID; a queued op whose key is held stays queued). Use it to serialize op families that would corrupt shared state if overlapped.
 
 ### `internal/config` — Configuration
 - **config.go** — `Config` struct with 100+ fields. Global: `config.AppConfig`
@@ -113,6 +149,9 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 
 ### `internal/dedup` — Book deduplication engine
 - **engine.go** — `Engine` type; per-layer candidate emitters (`checkExactTitle`, `checkExactISBN`, `checkExactFileHash`, `checkExactMetadataSourceHash`, `checkDurationMatch`; the AcoustID/LSH/embedding/metadata-fuzzy collectors live in `collectors_*.go`); `PairEligibility` pre-filter; `hasPlausibleAudio(book) bool` gate (returns true when `Duration > 0` OR `FileSize >= 256 KiB`). The exact-title and exact-ISBN emitters call this gate for both sides before emitting a candidate — prevents stub/unscanned books from creating false-positive pairs.
+- **Candidate `Status` is a VERDICT, not derived data** (PR #1973): `dismissed` and `merged` record a decision (human review or auto-resolve). `EmbeddingStore.UpsertCandidateNew` never lets a rescan's `pending` overwrite a terminal status (`isTerminalCandidateStatus`) — before the fix, every `dedup.full-scan` resurrected dismissals (43 flips measured on a prod replica), so the review queue could never converge. Layer precedence on re-upsert: `exact` never overwritten; `llm` protected except by `exact`; a row with a non-empty `FormulaVersion` is never downgraded by a legacy writer without one (T015).
+- **No-silent-caps pattern**: whole-backlog list calls pass an explicit `Limit: 1_000_000` (e.g. `auto_resolve.go`, `engine.go`) instead of relying on a default page size that silently truncates; `drain_stale.go` deliberately streams with real Limit/Offset paging instead of materializing the backlog. Never add a whole-library read that inherits a silent default cap (see `feedback_getallbooksfrom_memdb_cap`).
+- **auto_resolve.go** — `Engine.AutoResolveCertain`: Tier-1 auto-merge of Band-CERTAIN candidates (≥2 primary signals or a whole-book-signature `true_dup` label). Dry-run by default; `apply=true` is refused unless the `dedup.auto_resolve_enabled` kill switch is on (owner greenlight) and respects a `max_merges` cap. Every applied merge writes a `dedup:automerge:` journal entry so `UnmergeAuto` can reverse it via book_ver snapshots.
 - **dataset/** (sub-package) — Pure builder + deterministic catchers for the labeled training dataset. No side effects.
   - `BuilderStore` interface: `GetBook(id string)`, `GetBookFiles(id string)`
   - `BuildExample(BuilderStore, DedupCandidate) (LabeledExample, error)` — loads both books, computes `DurationRatio`, `FolderRelation`, `SharesRecordingID`, `SignatureRelation`. Label fields left empty; caller must run `Classify`.
@@ -123,6 +162,14 @@ The Go binary embeds the compiled React app. A single process serves both the AP
 - **dataset_backfill.go** — `dedup.dataset-backfill` UOS op. Iterates all pending candidates, calls `dataset.BuildExample` + `dataset.Classify`, writes `LabeledExample` to `dedup:label:` keyspace. With `apply=true`, dismisses candidates labeled `not_dup` by a catcher. Dry-run by default. Idempotent.
   - `builderAdapter` bridges `database.Store.GetBookByID` → `BuilderStore.GetBook` (name mismatch bridged without touching either interface).
   - Known limitation: pairs where one side has `Duration=0` but file records exist are NOT caught by the current catchers — they are left unlabeled for human/ML review. The engine gate stops NEW such pairs from being created; existing residual pairs need a future FileSize-aware catcher.
+- **auto_resolve.go** — `dedup.auto-resolve` op wrapping `Engine.AutoResolveCertain` (dry-run default; apply gated by the `dedup.auto_resolve_enabled` kill switch + `max_merges` cap — see engine section above).
+- **rescore_labeled_examples.go** — `dedup.rescore-labeled-examples` op: recomputes each labeled pair's `ScoreBreakdown` with the engine's existing scorer (calibration was blocked because labeled examples captured before T015 carry no breakdowns). A sibling backfill for pre-T015 CANDIDATE rows (`dedup:r:` records lacking `ScoreBreakdown`) is in progress on a feature branch, not yet in this tree.
+- **drain_stale.go** — `dedup.drain-stale` op: pages the pending-exact backlog with real Limit/Offset (never a one-shot 1M materialization), checkpoint/resume via `SaveCheckpoint`, capped per-bucket samples in the dry-run report.
+
+### `internal/plugins/maintenance` — Maintenance ops (selected)
+- **regroup_shattered_ai.go** (PR-B1) — dry-run producer: writes one review-queue HOLD per candidate regroup folder; touches ZERO books.
+- **regroup_apply.go** (PR-B2) — the APPLY path for the regroup review queue. One apply function per CONFIDENT kind: `regroup.multidisc` → `CombineBooks(ids, primary, nil)` (nil override so the survivor row is never rewritten — no write-back wipe), `regroup.version-group` → re-fetch-and-patch `UpdateBook` mutating ONLY `VersionGroupID`. `regroup.anthology`/`regroup.ambiguous` are deliberately handler-less (need human sub-decisions). Prod apply is gated by config `review_apply_enabled` (`internal/config/config.go`, **default OFF** — plain `viper.GetBool`, no default set); the review handler refuses the merge and says so when the flag is off.
+- **title_backfill.go** — `maintenance.title-backfill` ("Strip chapter prefixes from book titles", the CONS-17b title-leak repair — called "title-repair" in `docs/operations/pending-prod-actions.md`). Two-phase: slim `BookCore` scan, then per-book hydrate-full-row-then-write so denormalized Author/Series are never wiped.
 
 ---
 
@@ -363,15 +410,20 @@ sess:<session_ulid>            → Session JSON
 ### Dedup / Embedding keyspace (within the main audiobooks.pebble DB)
 
 ```
-emb:v:<entityType>:<entityID>  → embRec JSON          (embedding vector record)
-emb:c:<model>:<textHash>       → raw float32 blob      (embedding cache)
-dedup:r:<id16hex>              → DedupCandidate JSON   (candidate record)
-dedup:p:<type>:<aID>:<bID>     → id16hex               (pair uniqueness index)
-dedup:seq                      → [8]byte LE int64      (auto-increment counter)
-dedup:label:<id16hex>          → LabeledExample JSON   (labeled training dataset)
+emb:v:<entityType>:<entityID>            → embRec JSON          (embedding vector record)
+emb:c:<model>:<textHash>                 → raw float32 blob      (embedding cache)
+dedup:r:<id16hex>                        → DedupCandidate JSON   (candidate record)
+dedup:p:<type>:<aID>:<bID>               → id16hex               (pair uniqueness index; A/B canonicalized aID < bID)
+dedup:e:<entityType>:<entityID>:<id16hex>→ (empty)               (entity index — BOTH sides written, so "all candidates for entity X" is O(k))
+dedup:s:<status>:<id16hex>               → (empty)               (status index, INIT-2 T4 — "all pending" without a full dedup:r: scan)
+dedup:seq                                → [8]byte LE int64      (auto-increment counter)
+dedup:label:<id16hex>                    → LabeledExample JSON   (labeled training dataset)
+dedup:automerge:<unixNano16hex>          → AutoMergeJournalEntry JSON (auto-resolve merge journal; UnmergeAuto reversal)
 ```
 
 Key format note: `<id16hex>` is a 16-character lowercase hex string encoding a signed int64 as uint64 (e.g., `fmt.Sprintf("%016x", uint64(candidateID))`). This zero-pads the key so prefix scans return rows in stable order.
+
+**Index-maintenance invariant** (fixed 2026-07-17): `DeleteCandidate` deletes all four candidate key families in one batch — `dedup:r:`, `dedup:p:`, both `dedup:e:` entries, and `dedup:s:`. Any bulk delete/purge path MUST do the same; deleting only `dedup:r:` leaves orphaned pair/entity/status index rows that block re-emission and corrupt status-filtered counts. Status changes must move the `dedup:s:` row (delete old-status key, write new-status key) — see `UpdateCandidateStatus` / `WriteCandidateStatusIndexRow` in `embedding_store.go`.
 
 ---
 

--- a/docs/database-pebble-schema.md
+++ b/docs/database-pebble-schema.md
@@ -1,7 +1,7 @@
 <!-- file: docs/database-pebble-schema.md -->
-<!-- version: 1.3.0 -->
+<!-- version: 1.4.0 -->
 <!-- guid: 8f6e2c1b-7d4a-4f86-9f2a-5a6b7c8d9e0f -->
-<!-- last-edited: 2026-07-03 -->
+<!-- last-edited: 2026-07-17 -->
 
 # PebbleDB Keyspace Schema and Data Model
 
@@ -275,8 +275,26 @@ prefix: `emb:` for embeddings, `dedup:` for candidates and labels.
 | Key pattern | Value | Notes |
 |-------------|-------|-------|
 | `dedup:r:<id16hex>` | `DedupCandidate` JSON | Candidate record; primary row |
-| `dedup:p:<type>:<aID>:<bID>` | `<id16hex>` | Pair uniqueness index (prevents re-emission) |
-| `dedup:seq` | `[8]byte` little-endian int64 | Auto-increment counter for candidate IDs |
+| `dedup:p:<type>:<aID>:<bID>` | `<id16hex>` | Pair uniqueness index (prevents re-emission); entity IDs canonicalized so `aID < bID` before write |
+| `dedup:e:<entityType>:<entityID>:<id16hex>` | empty | Entity secondary index. Written for BOTH sides of the pair, so "all candidates touching entity X" is an O(k) prefix scan (`dedupEntityKey`, used by `ListCandidatesForEntity`; backfillable via `BackfillEntityIndex`) |
+| `dedup:s:<status>:<id16hex>` | empty | Status secondary index (INIT-2 T4, `dedupStatusIdxKey`). Presence-only: prefix-scan `dedup:s:pending:` yields every pending candidate ID without a full `dedup:r:` scan. Falls back to a full scan when the index has not been built; status-filtered reads re-check the record's status on point-read |
+| `dedup:seq` | `[8]byte` little-endian int64 | Auto-increment counter for candidate IDs; incremented in the same batch as the new record so counter + row land atomically |
+| `dedup:automerge:<unixNano16hex>` | `AutoMergeJournalEntry` JSON | Auto-merge journal written by the `dedup.auto-resolve` apply path (one entry per merge). Records winner/loser IDs + their pre-merge `book_ver` snapshot timestamps so `Engine.UnmergeAuto` can reverse the merge. Fixed-width hex nano timestamp keeps scans chronological |
+
+**Index maintenance (invariant, fixed 2026-07-17):** every write path must keep
+all four candidate families consistent. `UpsertCandidateNew` writes `dedup:r:` +
+`dedup:p:` + both `dedup:e:` rows + `dedup:s:` in one batch; `DeleteCandidate`
+deletes all of them in one batch; `UpdateCandidateStatus` moves the `dedup:s:`
+row (delete old-status key, write new-status key). Bulk delete/purge code MUST
+mirror `DeleteCandidate` — deleting only the `dedup:r:` row orphans the pair
+index (blocking re-emission) and corrupts status-filtered counts. Candidate
+batches commit with `pebble.NoSync` (`candidateWriteOpts`) to avoid write
+stalls (#19).
+
+Status semantics: `Status` is a verdict (`pending` → `dismissed` | `merged`),
+not derived data. `UpsertCandidateNew` never overwrites a terminal status
+(`dismissed`/`merged`) with a rescan's `pending` (`isTerminalCandidateStatus`,
+PR #1973).
 
 ### Labeled dataset keyspace
 
@@ -295,6 +313,50 @@ files_exist, recording_ids, itunes_pid_present, whole_book_sig_present);
 `duration_ratio`, `folder_relation`, `shares_recording_id`,
 `signature_relation`; `label`, `label_source`, `label_reason`, `decided_at`,
 `formula_version`. Empty `label` = unlabeled, features only.
+
+## Review-queue keyspace (`internal/database/review_store.go`, PR-A1)
+
+A generic, producer-agnostic queue of items flagged for a human decision,
+implemented on `*PebbleStore` (main DB). v1 producer is the regroup op
+(`internal/plugins/maintenance/regroup_shattered_ai.go`); the apply path is
+`regroup_apply.go`, gated by config `review_apply_enabled` (default OFF).
+Mirrors the dedup store's record/status-index split but in its own keyspace.
+
+| Key pattern | Value | Notes |
+|-------------|-------|-------|
+| `review_item:r:<id>` | `ReviewItem` JSON | Primary record. `id` is a ULID. Fields: `id`, `kind` (e.g. `regroup.multidisc`, `regroup.anthology`), `dedup_key`, `folder_ref`, `status` (`pending` \| `approved` \| `rejected` \| `applied`), `summary`, `payload` (producer JSON blob), `created_at`, `updated_at` |
+| `review_item:status:<status>:<id>` | empty | Status secondary index. Greenfield keyspace, so the index is authoritative from row one — no build-flag/fallback machinery; status-filtered reads still re-check the record's status on point-read |
+| `review_item:dedupkey:<dedupKey>` | `<id>` | Idempotency index. `DedupKey` = producer-computed stable hash of (Kind, FolderRef) — the upsert target |
+
+Index maintenance / idempotency contract (`UpsertReviewItem`): new DedupKey →
+create row + status index + dedupkey index; existing DedupKey with status
+`pending` → update Summary/Payload/UpdatedAt only; existing DedupKey with a
+DECIDED status (approved/rejected/applied) → **full no-op**, so a producer
+re-scan never resurrects a rejected hold. Status transitions must move the
+`review_item:status:` row (delete old, write new). The dedupkey index is
+written once on create and never deleted in A1.
+
+## Operations registry v2 keyspace (`internal/database/pebble_store_ops_v2.go`)
+
+Persistence for `internal/operations/registry` (the UOS plugin-op system).
+All keys share the `opv2:` prefix; numeric key segments are fixed-width
+zero-padded so prefix scans return rows in stable order.
+
+| Key pattern | Value | Notes |
+|-------------|-------|-------|
+| `opv2:def:<def_id>` | `OpDefinitionV2Row` JSON | Registered operation definition (one per `<plugin>.<op-name>`) |
+| `opv2:op:<op_id>` | `OperationV2Row` JSON | One operation run. No status index exists — status-filtered queries (e.g. `waiting_deps`) scan all `opv2:op:` rows |
+| `opv2:q:<999-priority:03d>:<ts_nano:020d>:<op_id>` | `<op_id>` | Queue index. Priority is stored as `999-priority` so higher priority sorts FIRST in byte order; timestamp gives FIFO within a priority. Deleted when the op leaves `queued` |
+| `opv2:act:<op_id>` | empty | Active index: present while the op is `queued` or `running`; removed on terminal status. Startup resume scans this instead of all rows |
+| `opv2:state:<op_id>` | `OpStateV2Row` JSON | Checkpoint state for resume (`ResumePolicy`: restart with saved state vs requeue fresh) |
+| `opv2:log:<op_id>:<ts_nano:020d>:<seq:010d>` | `OpLogV2Row` JSON | Per-op log lines; ts+seq keeps same-nanosecond lines ordered |
+| `opv2:err:<op_id>:<ts_nano:020d>` | `OpErrorV2Row` JSON | Per-op error records |
+| `opv2:strike:<def_id>:<ts_nano:020d>:<op_id>` | `OpStrikeV2Row` JSON | Watchdog strikes (uncheckpointed / stuck-progress detections), keyed by DEF so repeat offenders cluster |
+
+Index maintenance: enqueue writes the row JSON + `opv2:q:` + `opv2:act:` keys
+together; dispatch deletes the `opv2:q:` entry; terminal status deletes
+`opv2:act:`. Anything that flips a row's status by hand must mirror those
+index writes or startup resume / the dispatcher will see phantom ops.
 
 ## Write patterns & atomicity
 

--- a/skills/project-context/SKILL.md
+++ b/skills/project-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: project-context
 description: Load project context for the audiobook-organizer codebase. Invoke this skill at the start of any agent that needs project knowledge. Reads live docs files — no hardcoded values. Falls back to generic behavior on non-audiobook-organizer projects.
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Project Context Loader
@@ -18,10 +18,15 @@ Check if `docs/AI-REFERENCE.md` exists in the current working directory.
 Read each file below in order. Stop if the context window is getting full (skip later files).
 
 1. `docs/AI-REFERENCE.md` — architecture overview, package map, API surface, critical gotchas
-2. `docs/database-architecture.md` — DB design decisions, rationale, schema overview
-3. `docs/database-pebble-schema.md` — PebbleDB key format reference
-4. `CLAUDE.md` — workflow rules, constraints, build commands
-5. The 3 most recently dated files in `docs/specs/` (by filename prefix YYYY-MM-DD) — recent architectural decisions
+2. `TODO.md` — live work items ONLY (the 2026-H1 history is frozen in `docs/archive/todo-2026-H1.md`; do not load it unless researching history)
+3. `docs/dedup/STATUS.md` — single source of truth on dedup state: real backlog numbers, remediation path, what is and is not safe to merge/purge
+4. `docs/database-architecture.md` — DB design decisions, rationale, schema overview
+5. `docs/database-pebble-schema.md` — PebbleDB key format reference
+6. `CLAUDE.md` — workflow rules, constraints, build commands
+7. `docs/operations/pending-prod-actions.md` — queued run-on-prod actions and their gating
+8. `docs/plans/DECISIONS-PENDING.md` — STOP-FOR-HUMAN decision queue (never resolve these autonomously)
+9. The 3 most recently dated files in `docs/specs/` (by filename prefix YYYY-MM-DD) — recent architectural decisions
+10. The most recent file in `docs/audits/` — latest review findings (as of 2026-07-17: the multi-discipline review)
 
 Use `ls docs/specs/ | sort -r | head -3` to identify the newest spec files.
 
@@ -33,24 +38,28 @@ After reading, emit this block (fill in from what you read):
 === PROJECT CONTEXT ===
 Language/Framework: Go 1.24 backend + React 18/TypeScript frontend (Gin, Material UI)
 Build: make build (full) | make build-api (backend only) | make deploy (prod)
-Test:  make test | make test-all | make test-e2e
-DB:    PebbleDB (primary) | NutsDB (activity log) | SQLite (opt-in)
+Test:  make test | make test-all | make test-e2e | make ci (fast gate)
+DB:    PebbleDB (sole production store) | NutsDB (activity/metrics) — SQLite backend REMOVED
 
 Key constraints:
-- UpdateBook does FULL column replacement — always supply all fields
-- ensureLibraryCopy returns stale data — follow with syncMetadataToLibraryCopy
-- runApplyPipeline must check isProtectedPath
-- Purge skips books with iTunes PIDs
+- UpdateBook / UpdateBookFile do FULL column replacement — always fetch-mutate-write, never write a partial struct
+- memdb-tier getters strip heavy fields (e.g. AcoustIDFingerprint) — never round-trip a memdb read into a write
+- Dedup candidate Status is a VERDICT: never let "pending" overwrite dismissed/merged (terminal-status guard in UpsertCandidateNew)
+- Whole-library loops MUST use bounded worker pools (registry.RunItems pattern) and MUST log start/progress/complete/skip
+- Whole-backlog candidate listings use the 1M limit + truncation warning — no silent caps
+- runApplyPipeline must check isProtectedPath; Purge skips books with iTunes PIDs
 - Use LSP (gopls hover/goToDefinition/findReferences) instead of grep for Go symbols
+- NEVER commit internal IPs/hostnames to this public repo — hosts are "the prod server" / "the GPU box"; fleet detail lives in falkcorp/infra-docs (private)
 
 Path mapping (CRITICAL — never forget this):
-- W:\ on the Windows iTunes machine maps to /mnt/bigdata/books/ on the server (172.16.2.30)
-- iTunes XML at /mnt/bigdata/books/itunes/iTunes Library.xml contains file://localhost/W:/itunes/... URLs
+- W:\ on the Windows iTunes machine maps to the books tree on the prod server
 - BookFile stores TWO paths: FilePath (translated Linux path) and ITunesPath (original Windows path)
-- ALL files are on the NAS (172.16.2.30) — there are ZERO Windows-local-only files. NEVER dismiss iTunes file_not_found as "Windows-only expected"
+- ALL files are on the prod server — there are ZERO Windows-local-only files. NEVER dismiss iTunes file_not_found as "Windows-only expected"
 - When FilePath doesn't resolve for an iTunes file, the file was MOVED on the server (organize bug) — find it on disk by filename/hash
 
+Dedup state: [fill from docs/dedup/STATUS.md — real backlog counts, remediation stage]
 Recent decisions: [list 1-3 key points from the newest spec files]
+Pending human decisions: [count from DECISIONS-PENDING.md]
 === END CONTEXT ===
 ```
 


### PR DESCRIPTION
## Summary
Task 4 of the error-correction session — bring the context plugin/skill and AI knowledge docs current:
- **project-context SKILL.md v1.1.0**: corpus now loads live TODO, docs/dedup/STATUS.md, pending-prod-actions, DECISIONS-PENDING, latest audit; context block updated (SQLite removed, status-is-a-verdict guard, no-silent-caps, IP-hygiene rule); internal IPs scrubbed
- **AI-REFERENCE.md v1.1.0**: adds dedup:e:/dedup:s:/dedup:automerge: key families + four-family maintenance invariant, full Operations-registry-v2 section (all 8 opv2: families, ConcurrencyKey semantics), status-verdict guard (#1973), AutoResolveCertain kill-switch, review-queue apply path, corrected version/route-count markers (~608 routes)
- **database-pebble-schema.md v1.4.0**: complete review-queue and opv2: keyspace sections, dedup index invariants
- **agents**: db-design + schema-auditor de-SQLite'd (PebbleDB sole store) + PebbleDB-specific audit checks; pii-scanner example IP replaced with dummy address

All claims code-verified; zero internal IPs/sandbox references (grep-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65