### PR TITLE
fix(registry): watchdog birth-hang detection, zombie-op terminal status, queued-op cancel, strike/timeout hygiene

### DIFF
--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.6.1
+// version: 3.7.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-11
+// last-edited: 2026-07-17
 
 package registry
 
@@ -551,11 +551,23 @@ func (r *Registry) EnqueueOp(ctx context.Context, defID string, params any, opts
 	if def.ConcurrencyKey != "" {
 		if active, listErr := r.store.ListActiveOperationsV2(); listErr == nil {
 			for _, op := range active {
-				if op.DefID == defID {
-					r.logger.Info("registry: enqueue deduped — active op exists",
-						"op_id", op.ID, "def_id", defID, "status", op.Status)
-					return op.ID, nil
+				if op.DefID != defID {
+					continue
 				}
+				// C-3: skip zombie rows — a row can be left "running" with no
+				// live run handle (crash windows, historical abandonment bugs).
+				// Deduping against such a row returns a dead op's ID for every
+				// future enqueue of this def until restart, silently disabling
+				// the op type. Only "running" rows are checked: "queued" rows
+				// legitimately have no handle until dispatched.
+				if op.Status == "running" && !r.hasLiveHandle(op.ID) {
+					r.logger.Warn("registry: enqueue dedupe skipping zombie running row (no live handle)",
+						"op_id", op.ID, "def_id", defID)
+					continue
+				}
+				r.logger.Info("registry: enqueue deduped — active op exists",
+					"op_id", op.ID, "def_id", defID, "status", op.Status)
+				return op.ID, nil
 			}
 		}
 	}
@@ -770,14 +782,36 @@ func (r *Registry) publishOpCreated(row database.OperationV2Row, resumed bool) {
 // Cancel cancels an operation by id.
 // If the op is queued, it is marked canceled in the DB.
 // If the op is running, its context is canceled.
+// If the op has been claimed by the dispatcher but not yet picked up by a
+// worker (a stub handle with nil cancel, the op sitting in the buffered
+// nextRun channel), it is flagged so the worker drops it before Run and its
+// DB row is marked canceled (C-1 — this case used to be a silent no-op and
+// the op ran anyway).
 func (r *Registry) Cancel(opID string) error {
 	r.mu.Lock()
 	h, running := r.running[opID]
+	if running && h.cancel == nil {
+		// Stub handle: no context to cancel yet. Flag it under the same lock
+		// the worker uses when overwriting the stub (see executeRun), so the
+		// worker is guaranteed to observe the flag and skip the run.
+		h.queuedCancel = true
+	}
 	r.mu.Unlock()
 
 	if running {
-		r.logger.Info("registry: canceling running op", "op_id", opID)
-		h.cancelIfActive()
+		if h.cancel != nil {
+			r.logger.Info("registry: canceling running op", "op_id", opID)
+			h.cancelIfActive()
+			return nil
+		}
+		// Stub path: the DB row is still "queued" (the worker only marks it
+		// running on pickup) — mark it canceled now so the UI reflects the
+		// cancel immediately instead of after worker pickup.
+		updated, err := r.store.SetOperationV2StatusIfQueued(opID, "canceled")
+		if err != nil {
+			return fmt.Errorf("registry: cancel op %s: %w", opID, err)
+		}
+		r.logger.Info("registry: canceled op awaiting worker pickup", "op_id", opID, "db_updated", updated)
 		return nil
 	}
 
@@ -790,6 +824,16 @@ func (r *Registry) Cancel(opID string) error {
 		r.logger.Info("registry: canceled queued op", "op_id", opID)
 	}
 	return nil
+}
+
+// hasLiveHandle reports whether opID currently has an in-memory run handle
+// (stub or full). Used by EnqueueOp's ConcurrencyKey dedupe to distinguish a
+// genuinely running op from a zombie "running" DB row.
+func (r *Registry) hasLiveHandle(opID string) bool {
+	r.mu.RLock()
+	_, ok := r.running[opID]
+	r.mu.RUnlock()
+	return ok
 }
 
 // AbandonedCount returns the current number of abandoned goroutines for a

--- a/internal/operations/registry/reliability_fixes_test.go
+++ b/internal/operations/registry/reliability_fixes_test.go
@@ -1,0 +1,206 @@
+// file: internal/operations/registry/reliability_fixes_test.go
+// version: 1.0.0
+// guid: 8f1c2a3b-4d5e-6f70-8192-a3b4c5d6e7f8
+// last-edited: 2026-07-17
+
+package registry_test
+
+// Regression tests for the 2026-07-17 registry reliability cluster:
+//
+//   R-2: watchdog detects an op that hangs BEFORE its first UpdateProgress
+//        (marking an op running never stamps last_progress_at, so the old
+//        !IsZero() guard made hang-from-birth ops undetectable).
+//   C-3: a genuinely abandoned op gets a terminal status so its row leaves
+//        the active index, and the ConcurrencyKey enqueue-dedupe no longer
+//        returns the zombie's ID for every future enqueue of the def.
+//   C-1: Cancel of an op sitting in the buffered nextRun channel (stub
+//        handle, nil cancel func) is no longer a silent no-op — the op is
+//        marked canceled and never runs.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// TestWatchdog_StuckBeforeFirstProgress verifies that an op that hangs before
+// ever calling UpdateProgress is still detected as stuck: the watchdog falls
+// back to the row's StartedAt when both the in-memory atomic clock and the DB
+// last_progress_at are unset (R-2).
+func TestWatchdog_StuckBeforeFirstProgress(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 50 * time.Millisecond,
+	})
+
+	canceled := make(chan struct{})
+	def := makeValidDef("test.wdog-stuck-from-birth")
+	def.ResumePolicy = registry.ResumeDrop
+	def.ProgressTimeout = 100 * time.Millisecond
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		// Hang immediately — never call UpdateProgress. Before the fix this op
+		// was invisible to the watchdog forever ("silent for hours" class).
+		<-runCtx.Done()
+		close(canceled)
+		return runCtx.Err()
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.wdog-stuck-from-birth", nil)
+	awaitStatus(t, store, opID, "running", 3*time.Second)
+
+	// No backdating: StartedAt is stamped by the worker; after ProgressTimeout
+	// (100ms) elapses the watchdog (50ms cycle) must cancel the run.
+	select {
+	case <-canceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("hang-from-birth op was not canceled within 3s")
+	}
+	awaitStatus(t, store, opID, "canceled", 3*time.Second)
+
+	if n := len(store.strikesOfKind(opID, "stuck")); n == 0 {
+		t.Error("expected at least 1 stuck strike, got 0")
+	}
+}
+
+// TestAbandoned_TerminalStatusAllowsReenqueue verifies that a genuinely
+// abandoned op (ctx-canceled, goroutine doesn't return within grace) gets a
+// terminal status — so its row leaves the active index — and that a
+// subsequent enqueue of the same ConcurrencyKey'd def creates a NEW op that
+// runs to completion instead of returning the zombie's ID forever (C-3).
+func TestAbandoned_TerminalStatusAllowsReenqueue(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 30 * time.Second, // keep the watchdog out of the way
+		AbandonedCap:     10,
+		AbandonGrace:     100 * time.Millisecond,
+	})
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var calls atomic.Int32
+
+	def := makeValidDef("test.abandoned-reenqueue")
+	def.Plugin = "reenqueue-plugin"
+	def.ConcurrencyKey = "reenqueue.key"
+	def.ResumePolicy = registry.ResumeDrop
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-release // ignore ctx — simulate a goroutine that won't die
+			return nil
+		}
+		return nil
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+	defer close(release) // let the runaway goroutine drain at test end
+
+	op1, _ := r.EnqueueOp(ctx, "test.abandoned-reenqueue", nil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op1 did not start within 5s")
+	}
+
+	// Cancel op1; after AbandonGrace it is classified abandoned and must get a
+	// terminal status (interrupted_dropped for ResumeDrop) so it leaves the
+	// active index.
+	_ = r.Cancel(op1)
+	awaitStatus(t, store, op1, "interrupted_dropped", 5*time.Second)
+
+	// Re-enqueue: the ConcurrencyKey dedupe must NOT return the zombie's ID.
+	op2, err := r.EnqueueOp(ctx, "test.abandoned-reenqueue", nil)
+	if err != nil {
+		t.Fatalf("re-enqueue after abandonment failed: %v", err)
+	}
+	if op2 == op1 {
+		t.Fatalf("re-enqueue returned the abandoned zombie's ID %s — op type silently disabled", op1)
+	}
+	// And the new op must actually run to completion.
+	awaitStatus(t, store, op2, "completed", 5*time.Second)
+}
+
+// TestCancel_OpQueuedInWorkerChannelNeverRuns verifies that canceling an op
+// that has been claimed by the dispatcher but is still sitting in the buffered
+// nextRun channel (workers saturated) marks it canceled and prevents its Run
+// from ever being invoked (C-1 — previously a silent no-op: the stub handle
+// has a nil cancel func and the queued-path DB cancel was never attempted).
+func TestCancel_OpQueuedInWorkerChannelNeverRuns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	// Single worker so a long-running op saturates the pool.
+	r := registry.NewWithOptions(store, slog.Default(), 1, registry.Options{
+		WatchdogInterval: 30 * time.Second,
+	})
+
+	blockerStarted := make(chan struct{})
+	releaseBlocker := make(chan struct{})
+	blocker := makeValidDef("test.cancel-chan-blocker")
+	blocker.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(blockerStarted)
+		select {
+		case <-releaseBlocker:
+		case <-runCtx.Done():
+		}
+		return nil
+	}
+	_ = r.RegisterOp(blocker)
+
+	var targetRan atomic.Bool
+	target := makeValidDef("test.cancel-chan-target")
+	target.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		targetRan.Store(true)
+		return nil
+	}
+	_ = r.RegisterOp(target)
+	r.Start(ctx)
+
+	// Saturate the sole worker.
+	blockerID, _ := r.EnqueueOp(ctx, "test.cancel-chan-blocker", nil)
+	select {
+	case <-blockerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocker op did not start within 5s")
+	}
+
+	// Enqueue the target; the dispatcher (100ms ticker) claims it and parks it
+	// in the nextRun channel behind the busy worker. Give it a few cycles.
+	targetID, _ := r.EnqueueOp(ctx, "test.cancel-chan-target", nil)
+	time.Sleep(400 * time.Millisecond)
+
+	// Cancel while it sits in the channel.
+	if err := r.Cancel(targetID); err != nil {
+		t.Fatalf("Cancel returned error: %v", err)
+	}
+	awaitStatus(t, store, targetID, "canceled", 3*time.Second)
+
+	// Free the worker; it will pick the target from the channel and must drop
+	// it without invoking Run.
+	close(releaseBlocker)
+	awaitStatus(t, store, blockerID, "completed", 5*time.Second)
+
+	// Give the worker time to (incorrectly) start the target if the fix were
+	// absent, then assert it never ran and stayed canceled.
+	time.Sleep(500 * time.Millisecond)
+	if targetRan.Load() {
+		t.Error("canceled-in-channel op's Run was invoked; cancel must prevent the run")
+	}
+	if got := store.statusOf(targetID); got != "canceled" {
+		t.Errorf("expected target status to remain canceled, got %q", got)
+	}
+}

--- a/internal/operations/registry/shutdown_stub_handle_test.go
+++ b/internal/operations/registry/shutdown_stub_handle_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/shutdown_stub_handle_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7b3c9d1e-4a52-4c8f-9e0a-2f6b1d8c4a37
-// last-edited: 2026-06-03
+// last-edited: 2026-07-17
 
 // White-box regression tests for the "stub handle" nil-cancel race.
 //
@@ -61,9 +61,15 @@ func TestShutdown_StubHandleNilCancel_NoPanic(t *testing.T) {
 }
 
 // TestCancel_StubHandleNilCancel_NoPanic verifies Cancel does not panic when
-// the targeted op is a stub handle (nil cancel).
+// the targeted op is a stub handle (nil cancel), and that it flags the stub +
+// attempts the DB cancel (C-1: canceling a channel-queued op used to be a
+// silent no-op — the op ran anyway).
 func TestCancel_StubHandleNilCancel_NoPanic(t *testing.T) {
 	store := databasemocks.NewMockOpsV2Store(t)
+	// The stub path now marks the still-'queued' row canceled in the DB.
+	store.EXPECT().
+		SetOperationV2StatusIfQueued("stub-op", "canceled").
+		Return(true, nil).Once()
 
 	r := New(store, slog.Default(), 1, nil)
 	insertStubHandle(r, "stub-op")
@@ -72,4 +78,10 @@ func TestCancel_StubHandleNilCancel_NoPanic(t *testing.T) {
 		err := r.Cancel("stub-op")
 		require.NoError(t, err)
 	})
+
+	// The stub must be flagged so the worker drops the run before invoking it.
+	r.mu.Lock()
+	flagged := r.running["stub-op"].queuedCancel
+	r.mu.Unlock()
+	require.True(t, flagged, "Cancel must set queuedCancel on the stub handle")
 }

--- a/internal/operations/registry/watchdog.go
+++ b/internal/operations/registry/watchdog.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/watchdog.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2b3c4d5e-6f7a-8901-bcde-f01234567890
-// last-edited: 2026-06-22
+// last-edited: 2026-07-17
 
 package registry
 
@@ -75,6 +75,17 @@ func (r *Registry) watchdogCycle() {
 			continue
 		}
 
+		// Skip rows that are not actually running yet. A handle can exist for a
+		// row still marked "queued": the dispatcher inserts a stub handle the
+		// instant an op is claimed, but the worker only marks the row "running"
+		// on pickup from the nextRun channel. While an op sits in that channel
+		// (e.g. saturated workers), its row may carry stale StartedAt /
+		// LastProgressAt values from a previous resumed run — inspecting those
+		// here would write spurious stuck strikes.
+		if row.Status != "running" {
+			continue
+		}
+
 		// --- Strike: stuck ---
 		// Cancel the op's context. The worker detects cancellation and sets
 		// terminal status when Run returns; we do NOT set status here.
@@ -91,6 +102,14 @@ func (r *Registry) watchdogCycle() {
 			lastProgress = time.Unix(0, ts).UTC()
 		} else if row.LastProgressAt != nil {
 			lastProgress = *row.LastProgressAt
+		} else if row.StartedAt != nil {
+			// R-2: no progress has EVER been reported (atomic unset, DB row nil).
+			// Marking an op running stamps StartedAt but never LastProgressAt, so
+			// without this fallback an op that hangs BEFORE its first
+			// UpdateProgress call was undetectable — the exact "silent for hours"
+			// incident class. Fall back to StartedAt so a hang-from-birth op
+			// accrues stuck time from the moment it started.
+			lastProgress = *row.StartedAt
 		}
 		if !lastProgress.IsZero() && now.Sub(lastProgress) > progressTimeout {
 			r.writeStrike(h.id, def.ID, def.Plugin, "stuck",
@@ -111,6 +130,13 @@ func (r *Registry) watchdogCycle() {
 		if minInterval == 0 {
 			minInterval = defaultMinCheckpointInterval
 		}
+		// C-4: the strike threshold honors the def's own MinCheckpointInterval,
+		// with defaultMinCheckpointTimeout as the floor. The old code compared
+		// against the 5m constant alone, striking long-interval defs spuriously.
+		threshold := minInterval
+		if threshold < defaultMinCheckpointTimeout {
+			threshold = defaultMinCheckpointTimeout
+		}
 
 		// Reference time: last_checkpoint_at if set, else started_at.
 		var refTime *time.Time
@@ -124,9 +150,17 @@ func (r *Registry) watchdogCycle() {
 		}
 
 		elapsed := now.Sub(*refTime)
-		if elapsed >= defaultMinCheckpointTimeout {
-			r.writeStrike(h.id, def.ID, def.Plugin, "uncheckpointed",
-				fmt.Sprintf("no checkpoint for %s (min_interval=%s)", elapsed.Round(time.Second), minInterval))
+		if elapsed < threshold {
+			continue
 		}
+		// C-4: dedupe. The watchdog cycles every ~30s; without this gate a
+		// persistently uncheckpointed op re-inserted a strike row every cycle.
+		// Write at most one strike per threshold interval per op.
+		if last := h.lastUncheckpointedStrike.Load(); last != 0 && now.Sub(time.Unix(0, last).UTC()) < threshold {
+			continue
+		}
+		h.lastUncheckpointedStrike.Store(now.UnixNano())
+		r.writeStrike(h.id, def.ID, def.Plugin, "uncheckpointed",
+			fmt.Sprintf("no checkpoint for %s (threshold=%s, min_interval=%s)", elapsed.Round(time.Second), threshold, minInterval))
 	}
 }

--- a/internal/operations/registry/watchdog_test.go
+++ b/internal/operations/registry/watchdog_test.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/watchdog_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4d5e6f7a-8b9c-0123-def0-1234567890ab
-// last-edited: 2026-06-22
+// last-edited: 2026-07-17
 
 package registry_test
 
@@ -79,6 +79,10 @@ func TestWatchdog_UncheckpointedOpGetsStrike(t *testing.T) {
 	def := makeValidDef("test.wdog-uncheckpointed")
 	def.ResumePolicy = registry.ResumeRestart
 	def.MinCheckpointInterval = 100 * time.Millisecond
+	// Backdating started_at (below) would otherwise also trip the stuck check's
+	// StartedAt fallback (R-2) and cancel the op before the uncheckpointed
+	// branch is reached; a large ProgressTimeout keeps the stuck path quiet.
+	def.ProgressTimeout = 30 * time.Minute
 	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
 		close(started)
 		<-runCtx.Done()

--- a/internal/operations/registry/watchdog_test.go
+++ b/internal/operations/registry/watchdog_test.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/watchdog_test.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 4d5e6f7a-8b9c-0123-def0-1234567890ab
 // last-edited: 2026-07-17
 
@@ -194,14 +194,15 @@ func TestWatchdog_InfiniteRestartForceDrop(t *testing.T) {
 		return nil
 	}
 	_ = r.RegisterOp(def)
-	r.Start(ctx)
 
-	// Enqueue an op and pre-set resume_count=3 (no high_water_progress).
+	// Enqueue and set resume_count=3 BEFORE starting the registry: enqueueing
+	// after Start races the dispatcher — on a loaded runner the worker can pick
+	// the op up and complete it before setResumeCount lands (observed in CI).
+	// With the registry not yet started, the row is queued and the state is in
+	// place before the first dispatch tick can reach checkInfiniteRestart.
 	opID, _ := r.EnqueueOp(ctx, "test.wdog-infinite-restart", nil)
-	// Wait for it to be picked up (queued), then set resume_count before dispatch.
-	// We need to set it before the worker calls checkInfiniteRestart.
-	// Insert directly with resume_count=3.
 	store.setResumeCount(opID, 3)
+	r.Start(ctx)
 
 	// Wait for the op to be force-dropped (executeRun calls checkInfiniteRestart).
 	awaitStatus(t, store, opID, "interrupted_dropped", 5*time.Second)

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.10.1
+// version: 2.11.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-07-11
+// last-edited: 2026-07-17
 
 package registry
 
@@ -54,6 +54,16 @@ type runHandle struct {
 	// Stored as Unix nanoseconds; zero means progress has never been reported.
 	// The watchdog reads this first (lock-free) before falling back to the DB row.
 	lastProgressAt atomic.Int64
+	// lastUncheckpointedStrike (Unix nanoseconds) dedupes the watchdog's
+	// uncheckpointed strikes: at most one strike per threshold interval per op
+	// (C-4). Only the watchdog goroutine touches it; atomic for -race hygiene.
+	lastUncheckpointedStrike atomic.Int64
+	// queuedCancel is set by Registry.Cancel on a dispatcher STUB handle (nil
+	// cancel func) when the op is canceled while sitting in the buffered
+	// nextRun channel. The worker checks it — under Registry.mu, the same lock
+	// that guards the write — before registering the full handle, and drops
+	// the run without ever invoking Run (C-1). Guarded by Registry.mu.
+	queuedCancel bool
 }
 
 // cancelIfActive cancels the run's context if it has been wired up.
@@ -131,6 +141,9 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	r.mu.RUnlock()
 	if !ok {
 		r.logger.Warn("registry: worker got run for unknown def; skipping", "def_id", qr.defID)
+		// Release the dispatcher's stub handle so its plugin slot and
+		// ConcurrencyKey don't leak (same leak shape as the force-drop path, C-2).
+		r.releaseRunHandle(qr.opID)
 		return false
 	}
 
@@ -161,7 +174,12 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	}
 	defer cancel()
 
-	// Register the handle.
+	// Register the handle. Before overwriting the dispatcher's stub, honor a
+	// cancel that arrived while the run sat in the buffered nextRun channel
+	// (C-1): the stub has a nil cancel func, so Registry.Cancel flags it with
+	// queuedCancel instead. The flag is written and read under r.mu, so this
+	// check races with nothing — if Cancel got the lock first, we see the flag
+	// and drop the run without ever invoking Run.
 	h := &runHandle{
 		id:             qr.opID,
 		defID:          qr.defID,
@@ -171,6 +189,17 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		cancel:         cancel,
 	}
 	r.mu.Lock()
+	if prev, exists := r.running[qr.opID]; exists && prev.queuedCancel {
+		r.mu.Unlock()
+		r.releaseRunHandle(qr.opID)
+		now := time.Now().UTC()
+		msg := "canceled before start (canceled while queued for a worker)"
+		if err := r.store.UpdateOperationV2Status(qr.opID, "canceled", nil, &now, &msg); err != nil {
+			r.logger.Warn("registry: failed to mark channel-canceled op canceled", "op_id", qr.opID, "error", err)
+		}
+		r.logger.Info("registry: dropped run canceled while queued in worker channel", "op_id", qr.opID, "def_id", qr.defID)
+		return false
+	}
 	r.running[qr.opID] = h
 	r.mu.Unlock()
 
@@ -220,6 +249,12 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		completedAt := time.Now().UTC()
 		if runCtx.Err() != nil {
 			finalStatus = "canceled"
+			// C-5: distinguish def.Timeout expiry from a user/watchdog cancel.
+			if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+				msg := fmt.Sprintf("timeout: run exceeded %s", timeout)
+				errMsg = &msg
+				r.logger.Warn("registry: subprocess run timed out", "op_id", qr.opID, "def_id", qr.defID, "timeout", timeout)
+			}
 		} else if runErr != nil {
 			finalStatus = "failed"
 			msg := runErr.Error()
@@ -230,6 +265,9 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		if err := r.store.UpdateOperationV2Status(qr.opID, finalStatus, nil, &completedAt, errMsg); err != nil {
 			r.logger.Warn("registry: failed to update subprocess op terminal status", "op_id", qr.opID, "error", err)
 		}
+		// C-5: notify the dep scheduler on ALL terminal transitions (the
+		// subprocess path previously notified on none of them).
+		r.notifyDepTerminal(finalStatus, qr)
 		emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, true)
 		r.logger.Info("registry: subprocess run finished", "op_id", qr.opID, "status", finalStatus)
 		return false
@@ -301,6 +339,24 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 			// goroutine is monitored so the abandoned counter drains when it
 			// eventually returns.
 			r.releaseRunHandle(qr.opID)
+			// C-3: write a terminal status so the row leaves the opv2 active
+			// index. Without this the row stayed "running" forever, and the
+			// ConcurrencyKey enqueue-dedupe in EnqueueOp kept returning this
+			// zombie op's ID for every future enqueue of the def — silently
+			// disabling the op type until restart. Mirror Shutdown's semantics:
+			// interrupted_* per the def's ResumePolicy. Nothing else writes this
+			// row's status afterwards: the runaway goroutine's eventual return
+			// only decrements the abandoned counter (below).
+			abandonedAt := time.Now().UTC()
+			abandonMsg := "abandoned: op goroutine did not exit within grace after context cancellation"
+			if err := r.store.UpdateOperationV2Status(qr.opID, interruptedStatus(qr.resumePolicy), nil, &abandonedAt, &abandonMsg); err != nil {
+				r.logger.Warn("registry: failed to mark abandoned op interrupted", "op_id", qr.opID, "error", err)
+			}
+			// Terminal transition: resolve dep-waiting subjects now rather than
+			// leaving them to the 5m sweep (C-5).
+			for _, sub := range subjectsFromParams(qr.params) {
+				r.notifyDepFailed(sub, qr.defID)
+			}
 			r.logger.Warn("registry: op goroutine abandoned; spawning replacement worker",
 				"op_id", qr.opID, "plugin", qr.plugin)
 			r.goroutineWG.Add(1)
@@ -325,6 +381,17 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	switch {
 	case ctxCanceled:
 		finalStatus = "canceled"
+		// C-5: def.Timeout expiry used to be recorded as a bare "canceled" —
+		// indistinguishable from a user cancel. The run context carries the
+		// timeout deadline, so DeadlineExceeded means the run timed out (user/
+		// watchdog cancels yield context.Canceled). Status stays "canceled"
+		// (no new schema/UI status value) but the reason is persisted in
+		// error_message and logged distinctly.
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			msg := fmt.Sprintf("timeout: run exceeded %s", timeout)
+			errMsg = &msg
+			r.logger.Warn("registry: run timed out", "op_id", qr.opID, "def_id", qr.defID, "timeout", timeout)
+		}
 	case runErr != nil:
 		finalStatus = "failed"
 		msg := runErr.Error()
@@ -339,21 +406,28 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 
 	// Notify the dependency scheduler (async; non-blocking) so waiting_deps ops
 	// for the same subject can be re-evaluated or failed as appropriate.
-	// subjectsFromParams handles both single-subject {"book_id":"..."} params
-	// and batched {"subjects":[...]} params so every subject in a batch op
-	// receives its completion/failure notification.
-	for _, sub := range subjectsFromParams(qr.params) {
-		switch finalStatus {
-		case "completed":
-			r.notifyDepCompletion(sub, qr.defID)
-		case "failed":
-			r.notifyDepFailed(sub, qr.defID)
-		}
-	}
+	r.notifyDepTerminal(finalStatus, qr)
 
 	emitOpFinishedLog(runCtx, reporter, runStartedAt, finalStatus, runErr, false)
 	r.logger.Info("registry: run finished", "op_id", qr.opID, "status", finalStatus)
 	return false
+}
+
+// notifyDepTerminal notifies the dependency scheduler for every subject of a
+// run that reached a terminal status. C-5: ALL terminal transitions notify —
+// "completed" as a completion, everything else (failed, canceled, timeout,
+// interrupted_*) as a failure — so dep-waiting subjects are resolved
+// immediately instead of falling back to the 5m sweep. subjectsFromParams
+// handles both single-subject {"book_id":"..."} params and batched
+// {"subjects":[...]} params so every subject in a batch op is notified.
+func (r *Registry) notifyDepTerminal(finalStatus string, qr *queuedRun) {
+	for _, sub := range subjectsFromParams(qr.params) {
+		if finalStatus == "completed" {
+			r.notifyDepCompletion(sub, qr.defID)
+		} else {
+			r.notifyDepFailed(sub, qr.defID)
+		}
+	}
 }
 
 // emitOpFinishedLog emits the canonical "operation finished" line through
@@ -408,6 +482,15 @@ func (r *Registry) checkInfiniteRestart(qr *queuedRun, def OperationDef) bool {
 	completed := time.Now().UTC()
 	msg := "force-dropped: infinite restart without progress"
 	_ = r.store.UpdateOperationV2Status(qr.opID, "interrupted_dropped", nil, &completed, &msg)
+	// C-2: release the dispatcher's stub handle. The force-drop path returned
+	// before executeRun ever registered/released the run, leaking the
+	// ConcurrencyKey and the pluginRunning slot until restart — which blocked
+	// every def sharing that key (e.g. "acoustid.fingerprint").
+	r.releaseRunHandle(qr.opID)
+	// Terminal transition: notify dep-waiting subjects (C-5).
+	for _, sub := range subjectsFromParams(qr.params) {
+		r.notifyDepFailed(sub, qr.defID)
+	}
 	r.logger.Warn("registry: force-dropping op due to infinite restart",
 		"op_id", qr.opID, "def_id", qr.defID, "resume_count", row.ResumeCount)
 	return true


### PR DESCRIPTION
## Summary
Six confirmed reliability fixes in internal/operations/registry (pipeline findings R-2/C-3/C-2/C-4/C-5/C-1, docs/audits/2026-07-17-multi-discipline-review.md):
- Watchdog now detects ops that hang before their FIRST progress report (StartedAt fallback) — the 'silent for hours' incident class; plus a status guard against spurious strikes on parked rows
- Abandoned ops get a terminal interrupted_* status and the enqueue-dedupe skips zombie rows — an abandoned op no longer silently disables its op type until restart
- checkInfiniteRestart force-drop + unknown-def early return now release the ConcurrencyKey/plugin slot (doc comment claimed it; code didn't)
- Uncheckpointed strike uses max(def.MinCheckpointInterval, 5m) and dedupes to one strike per interval (was: strike row every 30s)
- Timeout expiry persists a distinct error_message + warn log; dep scheduler notified on ALL terminal transitions (was: completed/failed only)
- Cancel now works for ops queued in the worker channel (stub-handle flag + DB cancel under the same lock; run never starts)

## Tests
3 new behavioral tests + 2 updated; full package -race green twice (59s); dependent packages (scheduler, plugins/maintenance, plugins/dedup) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65