### PR TITLE
fix(logging): critical observability gaps — iTunes stub crons, AI retry, triage/split-scan/cleanup progress

### DIFF
--- a/internal/ai/retry.go
+++ b/internal/ai/retry.go
@@ -1,7 +1,7 @@
 // file: internal/ai/retry.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: f6a7b8c9-d0e1-2345-fabc-678901234567
-// last-edited: 2026-07-03
+// last-edited: 2026-07-17
 
 // Package ai — shared retry helper for OpenAI / Ollama API calls.
 package ai
@@ -9,6 +9,7 @@ package ai
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/openai/openai-go/v3"
@@ -71,6 +72,8 @@ func DoWithRetry(ctx context.Context, maxAttempts int, base time.Duration, fn fu
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			backoff := time.Duration(attempt*attempt) * base
+			slog.Warn("ai call failed, retrying after backoff",
+				"attempt", attempt, "max_attempts", maxAttempts, "backoff", backoff, "err", lastErr)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -86,5 +89,6 @@ func DoWithRetry(ctx context.Context, maxAttempts int, base time.Duration, fn fu
 		}
 		return nil
 	}
+	slog.Error("ai call retries exhausted", "max_attempts", maxAttempts, "err", lastErr)
 	return lastErr
 }

--- a/internal/ai/retry_test.go
+++ b/internal/ai/retry_test.go
@@ -1,13 +1,15 @@
 // file: internal/ai/retry_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-234567890123
-// last-edited: 2026-07-03
+// last-edited: 2026-07-17
 
 package ai
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -80,4 +82,38 @@ func TestDoWithRetry_TransientErrorStillRetries(t *testing.T) {
 
 	var pe *PermanentError
 	assert.False(t, errors.As(err, &pe), "transient error must not be wrapped as PermanentError")
+}
+
+// TestDoWithRetry_LogsRetriesAndExhaustion proves C6 observability: each
+// retry emits a Warn with attempt/backoff/err, and exhausting all attempts
+// emits an Error. Uses a buffer-backed default slog handler.
+func TestDoWithRetry_LogsRetriesAndExhaustion(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	transientErr := &openai.Error{StatusCode: 500}
+	err := DoWithRetry(context.Background(), 3, time.Millisecond, func() error {
+		return transientErr
+	})
+	require.Error(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ai call failed, retrying after backoff", "each retry must be logged at Warn")
+	assert.Contains(t, out, "max_attempts=3")
+	assert.Contains(t, out, "ai call retries exhausted", "exhaustion must be logged at Error")
+}
+
+// TestDoWithRetry_SuccessLogsNothing proves the happy path stays silent —
+// no retry Warn and no exhaustion Error when fn succeeds first try.
+func TestDoWithRetry_SuccessLogsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	err := DoWithRetry(context.Background(), 3, time.Millisecond, func() error { return nil })
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "successful first attempt must not log retry noise")
 }

--- a/internal/dedup/split_book_detector.go
+++ b/internal/dedup/split_book_detector.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/split_book_detector.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9c1f0a3e-b7d2-4e84-8c12-3fa8e1d6b9c0
-// last-edited: 2026-07-07
+// last-edited: 2026-07-17
 
 // Package dedup — split-book backfill detector.
 //
@@ -89,8 +89,10 @@ type splitBookSlim struct {
 
 // DetectSplitBookCandidates walks every book in the store and returns the
 // list of split-book clusters. No DB writes — purely analytical.
-func DetectSplitBookCandidates(ctx context.Context, store database.Store) ([]SplitBookCandidate, error) {
-	all, err := loadSlimBooks(ctx, store)
+// progress, if non-nil, is invoked with the running count of books loaded
+// (every page of 1000) so long scans stay observable up to the op timeout.
+func DetectSplitBookCandidates(ctx context.Context, store database.Store, progress func(loaded int)) ([]SplitBookCandidate, error) {
+	all, err := loadSlimBooks(ctx, store, progress)
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +105,13 @@ func DetectSplitBookCandidates(ctx context.Context, store database.Store) ([]Spl
 }
 
 // loadSlimBooks paginates through every book and projects to splitBookSlim.
-func loadSlimBooks(ctx context.Context, store database.Store) ([]splitBookSlim, error) {
+// progress, if non-nil, is called once per page with the total books loaded
+// so far (pages are 1000 books).
+func loadSlimBooks(ctx context.Context, store database.Store, progress func(loaded int)) ([]splitBookSlim, error) {
 	const pageSize = 1000
 	var all []splitBookSlim
 	offset := 0
+	loaded := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -133,6 +138,10 @@ func loadSlimBooks(ctx context.Context, store database.Store) ([]splitBookSlim, 
 				AuthorID: b.AuthorID,
 				SeriesID: b.SeriesID,
 			})
+		}
+		loaded += len(batch)
+		if progress != nil {
+			progress(loaded)
 		}
 		if len(batch) < pageSize {
 			break

--- a/internal/plugins/dedup/split_book_scan.go
+++ b/internal/plugins/dedup/split_book_scan.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/split_book_scan.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c6e8f0b-3a5b-7c9d-1e2f-4a6b8c0d2e3f
-// last-edited: 2026-05-29
+// last-edited: 2026-07-17
 
 package dedup
 
@@ -49,7 +49,15 @@ func (p *Plugin) runSplitBookScan(ctx context.Context, _ json.RawMessage, report
 
 	scanProg := sdk.NewProgress(reporter, 0)
 	scanProg.Start("Scanning library for split-book clusters...")
-	cands, err := dedupengine.DetectSplitBookCandidates(ctx, p.store)
+	// Book-loading progress: total is unknown up front, so the callback
+	// updates the indeterminate frame's message (and the op log) every
+	// 1000 books instead of a percentage.
+	cands, err := dedupengine.DetectSplitBookCandidates(ctx, p.store, func(loaded int) {
+		scanProg.StepN(0, fmt.Sprintf("Loading books: %d loaded...", loaded))
+		if loaded%10000 == 0 {
+			reporter.Logger().Info("split-book scan: loading books", "loaded", loaded)
+		}
+	})
 	if err != nil {
 		reporter.Logger().Error("split-book detector error", "error", err)
 		return fmt.Errorf("split-book scan: %w", err)

--- a/internal/plugins/itunes/import.go
+++ b/internal/plugins/itunes/import.go
@@ -1,13 +1,14 @@
 // file: internal/plugins/itunes/import.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-05-15
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -35,6 +36,10 @@ func (p *Plugin) importDef() sdk.OperationDef {
 func (p *Plugin) runImport(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes import operation.
 	// This should handle parameterized imports (genre, selection, etc.).
+	// NOTE: the canonical itunes.import op is registered by
+	// server.RegisterITunesImportOp (itunes_ops.go); this stub is
+	// intentionally unregistered (see Register in plugin.go).
+	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.import"))
 	return nil
 }
 

--- a/internal/plugins/itunes/path_reconcile.go
+++ b/internal/plugins/itunes/path_reconcile.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/itunes/path_reconcile.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: d4e5f6a7-b8c9-0123-defg-234567890123
 // last-edited: 2026-07-17
 
@@ -15,13 +15,14 @@ import (
 )
 
 func (p *Plugin) pathReconciledDef() sdk.OperationDef {
-	sched := "0 4 * * *"
+	// No Schedule: the Run below is an unimplemented stub (C1). The former
+	// daily "0 4 * * *" cron burned an op-history row every night doing
+	// nothing. Restore a schedule only together with a real implementation.
 	return sdk.OperationDef{
 		ID:                    "itunes.path-reconcile",
 		Plugin:                "itunes",
 		DisplayName:           "iTunes Path Reconcile",
 		Description:           "Reconcile iTunes track paths after library reorganizations.",
-		Schedule:              &sched,
 		Isolate:               false,
 		ResumePolicy:          sdk.ResumeDrop,
 		DefaultPriority:       sdk.PriorityLow,

--- a/internal/plugins/itunes/path_reconcile.go
+++ b/internal/plugins/itunes/path_reconcile.go
@@ -1,13 +1,14 @@
 // file: internal/plugins/itunes/path_reconcile.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: d4e5f6a7-b8c9-0123-defg-234567890123
-// last-edited: 2026-05-07
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -35,5 +36,6 @@ func (p *Plugin) pathReconciledDef() sdk.OperationDef {
 func (p *Plugin) runPathReconcile(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes path reconciliation operation.
 	// This should call p.svc.Paths.Reconcile(ctx, opID, progress).
+	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.path-reconcile"))
 	return nil
 }

--- a/internal/plugins/itunes/path_repair.go
+++ b/internal/plugins/itunes/path_repair.go
@@ -1,13 +1,14 @@
 // file: internal/plugins/itunes/path_repair.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e5f6a7b8-c9d0-1234-efgh-345678901234
-// last-edited: 2026-05-07
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
@@ -33,5 +34,6 @@ func (p *Plugin) pathRepairDef() sdk.OperationDef {
 func (p *Plugin) runPathRepair(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes path repair operation.
 	// This should call p.svc.Repair.Repair(ctx, opID, dryRun, progress).
+	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.path-repair"))
 	return nil
 }

--- a/internal/plugins/itunes/plugin_test.go
+++ b/internal/plugins/itunes/plugin_test.go
@@ -1,12 +1,18 @@
 // file: internal/plugins/itunes/plugin_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b8c9d0-e1f2-3456-ghij-567890123456
-// last-edited: 2026-05-07
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
 	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
 // TestPlugin_NilGuard tests that the plugin handles nil service gracefully.
@@ -15,5 +21,74 @@ func TestPlugin_NilGuard(t *testing.T) {
 	p := New(nil, nil)
 	if err := p.Register(nil); err != nil {
 		t.Fatalf("nil guard: %v", err)
+	}
+}
+
+// TestStubOps_NoCronSchedule locks in the C1 fix: unimplemented stub ops
+// must NOT carry a cron schedule (they were burning a green no-op
+// op-history row every 10/30 minutes). Restore schedules only alongside a
+// real implementation.
+func TestStubOps_NoCronSchedule(t *testing.T) {
+	p := New(nil, nil)
+	if s := p.syncDef().Schedule; s != nil {
+		t.Errorf("itunes.sync is a stub but has schedule %q — remove it or implement the op", *s)
+	}
+	if s := p.positionSyncDef().Schedule; s != nil {
+		t.Errorf("itunes.position-sync is a stub but has schedule %q — remove it or implement the op", *s)
+	}
+}
+
+// stubWarnReporter captures Log calls so the not-implemented warning can be
+// asserted. Other Reporter methods are no-ops.
+type stubWarnReporter struct {
+	logged bytes.Buffer
+}
+
+var _ sdk.Reporter = (*stubWarnReporter)(nil)
+
+func (r *stubWarnReporter) UpdateProgress(current, total int, message string) error { return nil }
+func (r *stubWarnReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	r.logged.WriteString(level.String() + " " + message)
+	for _, a := range attrs {
+		r.logged.WriteString(" " + a.String())
+	}
+	r.logged.WriteString("\n")
+	return nil
+}
+func (r *stubWarnReporter) Logger() *slog.Logger       { return slog.Default() }
+func (r *stubWarnReporter) Checkpoint(state any) error { return nil }
+func (r *stubWarnReporter) IsCanceled() bool           { return false }
+func (r *stubWarnReporter) RunPhase(ctx context.Context, name string, fn func(context.Context, sdk.Reporter) error) error {
+	return fn(ctx, r)
+}
+func (r *stubWarnReporter) Trigger(ctx context.Context, eventName string, payload any) error {
+	return nil
+}
+func (r *stubWarnReporter) SetCurrentItem(label string) {}
+
+// TestStubRuns_LogNotImplementedWarn proves every stub Run emits an honest
+// "op not implemented" warning instead of silently returning nil.
+func TestStubRuns_LogNotImplementedWarn(t *testing.T) {
+	p := New(nil, nil)
+	runs := map[string]func(context.Context) error{}
+	rep := &stubWarnReporter{}
+	runs["itunes.sync"] = func(ctx context.Context) error { return p.runSync(ctx, nil, rep) }
+	runs["itunes.position-sync"] = func(ctx context.Context) error { return p.runPositionSync(ctx, nil, rep) }
+	runs["itunes.import"] = func(ctx context.Context) error { return p.runImport(ctx, nil, rep) }
+	runs["itunes.path-reconcile"] = func(ctx context.Context) error { return p.runPathReconcile(ctx, nil, rep) }
+	runs["itunes.path-repair"] = func(ctx context.Context) error { return p.runPathRepair(ctx, nil, rep) }
+
+	for id, run := range runs {
+		rep.logged.Reset()
+		if err := run(context.Background()); err != nil {
+			t.Fatalf("%s: stub run returned error: %v", id, err)
+		}
+		out := rep.logged.String()
+		if !strings.Contains(out, "op not implemented") {
+			t.Errorf("%s: stub run did not log a not-implemented warning; got %q", id, out)
+		}
+		if !strings.Contains(out, id) {
+			t.Errorf("%s: warning does not name the def id; got %q", id, out)
+		}
 	}
 }

--- a/internal/plugins/itunes/plugin_test.go
+++ b/internal/plugins/itunes/plugin_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/itunes/plugin_test.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: a7b8c9d0-e1f2-3456-ghij-567890123456
 // last-edited: 2026-07-17
 
@@ -35,6 +35,9 @@ func TestStubOps_NoCronSchedule(t *testing.T) {
 	}
 	if s := p.positionSyncDef().Schedule; s != nil {
 		t.Errorf("itunes.position-sync is a stub but has schedule %q — remove it or implement the op", *s)
+	}
+	if s := p.pathReconciledDef().Schedule; s != nil {
+		t.Errorf("itunes.path-reconcile is a stub but has schedule %q — remove it or implement the op", *s)
 	}
 }
 

--- a/internal/plugins/itunes/position_sync.go
+++ b/internal/plugins/itunes/position_sync.go
@@ -1,26 +1,28 @@
 // file: internal/plugins/itunes/position_sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: f6a7b8c9-d0e1-2345-fghi-456789012345
-// last-edited: 2026-05-07
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
 func (p *Plugin) positionSyncDef() sdk.OperationDef {
-	sched := "*/10 * * * *"
 	return sdk.OperationDef{
-		ID:                    "itunes.position-sync",
-		Plugin:                "itunes",
-		DisplayName:           "iTunes Position Sync",
-		Description:           "Sync reading positions between iTunes bookmarks and the app.",
-		Schedule:              &sched,
+		ID:          "itunes.position-sync",
+		Plugin:      "itunes",
+		DisplayName: "iTunes Position Sync",
+		Description: "Sync reading positions between iTunes bookmarks and the app.",
+		// Schedule removed 2026-07-17: Run is an unimplemented stub, so the
+		// "*/10 * * * *" cron burned a green no-op op-history row every 10
+		// minutes. Restore the schedule when position sync is implemented.
 		Isolate:               false,
 		ResumePolicy:          sdk.ResumeRequeue,
 		DefaultPriority:       sdk.PriorityNormal,
@@ -35,5 +37,6 @@ func (p *Plugin) positionSyncDef() sdk.OperationDef {
 func (p *Plugin) runPositionSync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes position sync operation.
 	// This should call p.svc.Positions.Sync().
+	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.position-sync"))
 	return nil
 }

--- a/internal/plugins/itunes/sync.go
+++ b/internal/plugins/itunes/sync.go
@@ -1,26 +1,28 @@
 // file: internal/plugins/itunes/sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-07
+// last-edited: 2026-07-17
 
 package itunes
 
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
 func (p *Plugin) syncDef() sdk.OperationDef {
-	sched := "*/30 * * * *"
 	return sdk.OperationDef{
-		ID:                    "itunes.sync",
-		Plugin:                "itunes",
-		DisplayName:           "iTunes Library Sync",
-		Description:           "Sync audiobook metadata with the iTunes/Music library.",
-		Schedule:              &sched,
+		ID:          "itunes.sync",
+		Plugin:      "itunes",
+		DisplayName: "iTunes Library Sync",
+		Description: "Sync audiobook metadata with the iTunes/Music library.",
+		// Schedule removed 2026-07-17: Run is an unimplemented stub, so the
+		// "*/30 * * * *" cron burned a green no-op op-history row every 30
+		// minutes. Restore the schedule when the sync is actually implemented.
 		Isolate:               false,
 		ResumePolicy:          sdk.ResumeRestart,
 		DefaultPriority:       sdk.PriorityNormal,
@@ -35,5 +37,6 @@ func (p *Plugin) syncDef() sdk.OperationDef {
 func (p *Plugin) runSync(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	// TODO: Implement iTunes sync operation.
 	// This should call p.svc.Importer.Sync with appropriate path mappings.
+	_ = reporter.Log(slog.LevelWarn, "op not implemented — no-op", slog.String("def_id", "itunes.sync"))
 	return nil
 }

--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedup_triage.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
-// last-edited: 2026-06-24
+// last-edited: 2026-07-17
 
 package maintenance
 
@@ -54,31 +54,35 @@ const (
 
 // TriageExample records minimal context on a sampled candidate for the report.
 type TriageExample struct {
-	CandidateID int64       `json:"candidate_id"`
-	BookAID     string      `json:"book_a_id"`
-	BookBID     string      `json:"book_b_id"`
-	BookATitle  string      `json:"book_a_title"`
-	BookBTitle  string      `json:"book_b_title"`
-	Layer       string      `json:"layer"`
-	Reason      string      `json:"reason"`
+	CandidateID int64  `json:"candidate_id"`
+	BookAID     string `json:"book_a_id"`
+	BookBID     string `json:"book_b_id"`
+	BookATitle  string `json:"book_a_title"`
+	BookBTitle  string `json:"book_b_title"`
+	Layer       string `json:"layer"`
+	Reason      string `json:"reason"`
 }
 
 // TriagePopulation holds the count and up to 5 examples for one class.
 type TriagePopulation struct {
-	Class    TriageClass    `json:"class"`
-	Count    int            `json:"count"`
+	Class    TriageClass     `json:"class"`
+	Count    int             `json:"count"`
 	Examples []TriageExample `json:"examples,omitempty"`
 }
 
 // TriageReport is the output of the dry-run triage op.
 // It is logged as JSON at the end of the run and returned as op result data.
 type TriageReport struct {
-	ScannedAt      time.Time                    `json:"scanned_at"`
-	TotalScanned   int                          `json:"total_scanned"`
+	ScannedAt      time.Time                        `json:"scanned_at"`
+	TotalScanned   int                              `json:"total_scanned"`
 	Populations    map[TriageClass]TriagePopulation `json:"populations"`
-	PurgeableCount int                          `json:"purgeable_count"`
-	KeepCount      int                          `json:"keep_count"`
-	ReviewCount    int                          `json:"review_count"`
+	PurgeableCount int                              `json:"purgeable_count"`
+	KeepCount      int                              `json:"keep_count"`
+	ReviewCount    int                              `json:"review_count"`
+	// BookLookupErrors counts GetBookByID failures during triage. Failed
+	// lookups classify with a nil book, so a nonzero value means the
+	// population counts may be skewed toward stub/unknown.
+	BookLookupErrors int `json:"book_lookup_errors,omitempty"`
 }
 
 // purgeableClasses are the populations safe to delete without human review.

--- a/internal/server/movement_atom_cleanup.go
+++ b/internal/server/movement_atom_cleanup.go
@@ -1,7 +1,7 @@
 // file: internal/server/movement_atom_cleanup.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c2d3e4f5-a6b7-8c9d-0e1f-2a3b4c5d6e7f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-17
 
 package server
 
@@ -51,17 +51,24 @@ func (s *Server) stripMovementAtoms(ctx context.Context) {
 	deps := s.safeWriteDeps()
 
 	slog.Info("Starting movement atom cleanup under …", "root", root)
-	stripped, clean, failed := 0, 0, 0
+	stripped, clean, failed, walkErrs := 0, 0, 0, 0
 
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
-		// without an error; WalkDir's return is discarded above by design.
+		// without an error, so completion is detected via ctx.Err() below.
 		select {
 		case <-ctx.Done():
 			return fs.SkipAll
 		default:
 		}
-		if walkErr != nil || d.IsDir() {
+		if walkErr != nil {
+			// Previously swallowed: an unreadable dir/file silently shrank
+			// the walk. Log it so partial coverage is visible.
+			slog.Warn("movement atom cleanup: walk error", "path", path, "err", walkErr)
+			walkErrs++
+			return nil
+		}
+		if d.IsDir() {
 			return nil
 		}
 		ext := strings.ToLower(filepath.Ext(path))
@@ -79,11 +86,35 @@ func (s *Server) stripMovementAtoms(ctx context.Context) {
 		default:
 			clean++
 		}
+		if processed := stripped + clean + failed; processed%500 == 0 {
+			slog.Info("movement atom cleanup: progress",
+				"processed", processed, "stripped", stripped, "clean", clean, "failed", failed)
+		}
 		return nil
 	})
+	if err != nil {
+		slog.Warn("movement atom cleanup: walk aborted", "root", root, "err", err)
+	}
 
-	slog.Info("Movement atom cleanup stripped, already clean, errors", "stripped", stripped, "clean", clean, "failed", failed)
-	_ = store.SetSetting(movementAtomCleanupKey, "true", "bool", false)
+	slog.Info("Movement atom cleanup stripped, already clean, errors",
+		"stripped", stripped, "clean", clean, "failed", failed, "walk_errors", walkErrs)
+
+	if ctx.Err() != nil {
+		slog.Info("movement atom cleanup canceled before completion — done flag not written, will resume next startup")
+		return
+	}
+	if err != nil {
+		slog.Warn("movement atom cleanup: walk did not complete — done flag not written, will re-run next startup")
+		return
+	}
+	if serr := store.SetSetting(movementAtomCleanupKey, "true", "bool", false); serr != nil {
+		// Previously swallowed: a failed write meant a silent full re-walk
+		// on every boot. Do not claim completion.
+		slog.Error("movement atom cleanup: failed to persist done flag — cleanup will re-run on next startup",
+			"key", movementAtomCleanupKey, "err", serr)
+		return
+	}
+	slog.Info("Movement atom cleanup complete — done flag persisted", "key", movementAtomCleanupKey)
 }
 
 // removeMovementAtomsFromFile reads the file's tags, removes the three

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-07-11
+// last-edited: 2026-07-17
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -270,14 +270,25 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 	if err != nil {
 		return nil, fmt.Errorf("list candidates: %w", err)
 	}
+	slog.Info("dedup triage: starting", "candidates", len(candidates))
 
 	// Memoize book lookups — a book may appear in many candidate pairs.
+	// Failed lookups are counted (not swallowed) — a nil book skews the
+	// classification toward stub/unknown, so the report must disclose them.
+	var lookupErrs int
+	var firstLookupErr error
 	bookCache := make(map[string]*database.Book, len(candidates))
 	getBook := func(id string) *database.Book {
 		if b, ok := bookCache[id]; ok {
 			return b
 		}
-		b, _ := s.Store().GetBookByID(id)
+		b, gerr := s.Store().GetBookByID(id)
+		if gerr != nil {
+			lookupErrs++
+			if firstLookupErr == nil {
+				firstLookupErr = fmt.Errorf("get book %s: %w", id, gerr)
+			}
+		}
 		bookCache[id] = b
 		return b
 	}
@@ -299,6 +310,10 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
+		}
+		if i > 0 && i%5000 == 0 {
+			slog.Info("dedup triage: progress",
+				"processed", i, "total", len(candidates), "lookup_errors", lookupErrs)
 		}
 		c := candidates[i]
 		a := getBook(c.EntityAID)
@@ -328,9 +343,10 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 	}
 
 	report := &maintenanceplugin.TriageReport{
-		ScannedAt:    time.Now(),
-		TotalScanned: len(candidates),
-		Populations:  make(map[maintenanceplugin.TriageClass]maintenanceplugin.TriagePopulation, len(pops)),
+		ScannedAt:        time.Now(),
+		TotalScanned:     len(candidates),
+		Populations:      make(map[maintenanceplugin.TriageClass]maintenanceplugin.TriagePopulation, len(pops)),
+		BookLookupErrors: lookupErrs,
 	}
 	for cls, ps := range pops {
 		report.Populations[cls] = maintenanceplugin.TriagePopulation{
@@ -347,6 +363,16 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 			report.ReviewCount += ps.count
 		}
 	}
+	if lookupErrs > 0 {
+		slog.Warn("dedup triage: book lookups failed — population counts may be skewed",
+			"lookup_errors", lookupErrs, "first_error", firstLookupErr)
+	}
+	slog.Info("dedup triage: complete",
+		"scanned", report.TotalScanned,
+		"purgeable", report.PurgeableCount,
+		"keep", report.KeepCount,
+		"review", report.ReviewCount,
+		"lookup_errors", lookupErrs)
 	return report, nil
 }
 


### PR DESCRIPTION
## Summary
Five critical logging/observability fixes (C1/C6/C4/C5/C3 from docs/audits/2026-07-17-multi-discipline-review.md):
- **iTunes stub ops**: removed cron schedules from the three scheduled no-op stubs (itunes.sync every 30m, itunes.position-sync every 10m, itunes.path-reconcile daily) — each burned green op-history rows doing nothing; all five stub Runs now log a not-implemented Warn; schedule-lock test prevents regression
- **AI retry (internal/ai/retry.go)**: every retry now logs attempt/backoff/err at Warn, exhaustion at Error (was: minutes of silent quadratic backoff on every OpenAI/Ollama outage)
- **Dedup exact triage**: start/progress-per-5000/summary logs; GetBookByID errors now counted + surfaced in a new TriageReport.BookLookupErrors field (was: silently skewed report)
- **Split-book scan**: progress callback per 1000-book page wired to the op reporter (was: silent up to its 60-min timeout)
- **movement-atom cleanup**: walk errors counted + logged, progress every 500 files, SetSetting failure no longer claims completion; bonus fix — done flag no longer written after ctx cancellation (contradicted its own doc)

## Tests
Schedule-lock + stub-warn + retry-logging tests added; itunes/ai/dedup/maintenance/server suites green (server suite rerun isolated per the known contention pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65