### PR TITLE
feat(dedup): breakdown-backfill op for pre-T015 candidates + relax title-leak triage precondition

### DIFF
--- a/internal/plugins/dedup/breakdown_backfill.go
+++ b/internal/plugins/dedup/breakdown_backfill.go
@@ -1,0 +1,417 @@
+// file: internal/plugins/dedup/breakdown_backfill.go
+// version: 1.0.0
+// guid: ec0f5e9d-2f6d-485d-9f24-ad3d917d1834
+// last-edited: 2026-07-17
+
+// Package dedup — op dedup.breakdown-backfill.
+//
+// # Why this op exists
+//
+// 9,950 of ~10,362 exact-layer pending candidates on prod are pre-T015 rows
+// with NO ScoreBreakdown. One data gap disables two tools at once:
+//   - Engine.Rescore ("stored signal sets only") explicitly skips
+//     nil-breakdown rows, so they can never be re-banded, and
+//   - maintenance.dedup-exact-triage classifies every nil-breakdown row as
+//     TriageClassUnknown, so the whole backlog lands in the manual-review
+//     bucket.
+//
+// This op recomputes each nil-breakdown PENDING candidate's unified signal set
+// and composed score with the engine's EXISTING scorer
+// (Engine.ScorePairsForBook → the same collectors + unified.ComposeScore the
+// operational scan uses via the shared collectPairSignals helper — no scorer
+// fork) and persists it onto the candidate via UpdateCandidateScore.
+//
+// # Deliberate divergences from the operational scan
+//
+//  1. The work list is the existing pending candidates themselves — no new
+//     pairs are ever created, and no lifecycle work (eligibility delete,
+//     status change) is performed. Only ScoreBreakdown/Band/FormulaVersion
+//     are written; Layer/Similarity/Status are untouched.
+//  2. The `Band == ""` below-band skip is BYPASSED: a below-band breakdown is
+//     still a breakdown — ANY breakdown beats none for triage/calibration.
+//  3. The embedding cosine is NOT recomputable offline (it comes from the
+//     stored candidate Similarity, mirroring the scan's embeddingMap). An
+//     embedding-layer candidate with a nil Similarity is scored with the
+//     remaining signals and the unavailable cosine is recorded in
+//     missing_signal_counts.
+//
+// Pairs that produce zero signals stay reported-but-unscorable — never
+// persisted, since an empty breakdown would be indistinguishable from
+// "scored, no evidence".
+//
+// Dry-run (report only, 10 sample pairs logged) is the default.
+// {"apply":true} writes.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// breakdownBackfillCandidateLimit mirrors internal/dedup's (unexported)
+// wholeBacklogCandidateLimit: every whole-backlog op lists with the same 1M
+// cap and WARNS when the listing hits it exactly (no silent caps).
+const breakdownBackfillCandidateLimit = 1_000_000
+
+// breakdownBackfillProgressEvery controls the "progress every N processed
+// pairs" Info log.
+const breakdownBackfillProgressEvery = 1000
+
+// breakdownBackfillSampleLimit caps the sample pairs logged for a dry-run.
+const breakdownBackfillSampleLimit = 10
+
+// breakdownBackfillParams are the JSON parameters accepted by the op.
+type breakdownBackfillParams struct {
+	// Apply, if true, persists each recomputed breakdown via
+	// UpdateCandidateScore. Default false (dry-run) — reports counts and 10
+	// sample pairs, writes nothing.
+	Apply bool `json:"apply"`
+}
+
+// candidateBackfillStore is the narrow store surface the op needs
+// (database.EmbeddingStore satisfies it).
+type candidateBackfillStore interface {
+	ListCandidates(f database.CandidateFilter) ([]database.DedupCandidate, int, error)
+	UpdateCandidateScore(id int64, score *models.UnifiedDedupScore, band, formulaVersion string) error
+}
+
+// breakdownBackfillReport is the op's result payload, logged as JSON at the
+// end of the run so a sandbox run can be measured mechanically.
+type breakdownBackfillReport struct {
+	Apply               bool           `json:"apply"`
+	TotalPending        int            `json:"total_pending"`
+	SkippedHasBreakdown int            `json:"skipped_has_breakdown"`
+	Targets             int            `json:"targets"`
+	Processed           int            `json:"processed"`
+	Backfilled          int            `json:"backfilled"`
+	WouldBackfill       int            `json:"would_backfill"`
+	ZeroSignal          int            `json:"zero_signal"`
+	SkippedNoBook       int            `json:"skipped_no_book"`
+	ScoreErrs           int            `json:"score_errs"`
+	UpdateErrs          int            `json:"update_errs"`
+	MissingSignalCounts map[string]int `json:"missing_signal_counts"`
+	SignalKindCounts    map[string]int `json:"signal_kind_counts"`
+}
+
+// breakdownBackfillDef returns the OperationDef for dedup.breakdown-backfill.
+func (p *Plugin) breakdownBackfillDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "dedup.breakdown-backfill",
+		Plugin:      "dedup",
+		DisplayName: "Backfill ScoreBreakdowns onto pre-T015 pending candidates",
+		Description: "Recomputes the unified signal set + composed score for every pending dedup " +
+			"candidate with no ScoreBreakdown (pre-T015 rows) using the engine's existing scorer, " +
+			"and persists it via UpdateCandidateScore so Engine.Rescore and " +
+			"maintenance.dedup-exact-triage can act on the whole backlog. Writes ONLY " +
+			"ScoreBreakdown/Band/FormulaVersion — never status, layer, or similarity. " +
+			"Dry-run by default; apply=true writes.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		ConcurrencyKey:  "dedup.breakdown-backfill",
+		Cancellable:     true,
+		Timeout:         60 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runBreakdownBackfill,
+	}
+}
+
+// runBreakdownBackfill wires the plugin's engine + store into the testable
+// runner.
+func (p *Plugin) runBreakdownBackfill(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	if p.engine == nil {
+		return fmt.Errorf("dedup engine not available")
+	}
+	if p.embeddingStore == nil {
+		return fmt.Errorf("embedding store not available")
+	}
+	return runBreakdownBackfillWith(ctx, p.engine, p.embeddingStore, rawParams, reporter)
+}
+
+// backfillRef is one nil-breakdown candidate to score, grouped under its
+// EntityAID.
+type backfillRef struct {
+	candID       int64
+	otherID      string // EntityBID (the pair's B side)
+	embeddingCos *float64
+	missingCos   bool // embedding-layer row whose stored cosine is gone
+}
+
+// backfillGroup bundles all target candidates sharing an A book so book A's
+// per-book precompute (inside ScorePairsForBook) runs once per group. Groups
+// are disjoint by A; each candidate row is keyed by a distinct candID, so
+// parallel UpdateCandidateScore writes never collide.
+type backfillGroup struct {
+	aID  string
+	refs []backfillRef
+}
+
+// runBreakdownBackfillWith is the testable core: it lists pending candidates,
+// keeps the nil/empty-breakdown ones, groups them by EntityAID, scores each
+// group through the engine's real scorer in a bounded worker pool
+// (registry.RunItems, NumCPU workers — DB-read + CPU scoring over ~10K+
+// pairs), and (apply=true) persists each recomputed breakdown via
+// UpdateCandidateScore.
+func runBreakdownBackfillWith(
+	ctx context.Context,
+	scorer pairScorer,
+	store candidateBackfillStore,
+	rawParams json.RawMessage,
+	reporter sdk.Reporter,
+) error {
+	var params breakdownBackfillParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	log := reporter.Logger()
+
+	// --- Load the whole pending backlog (book pairs only — author-pair
+	// candidates have no Book rows for the scorer to load) ---
+	_ = reporter.UpdateProgress(0, 3, "Loading pending candidates…")
+	cands, _, err := store.ListCandidates(database.CandidateFilter{
+		EntityType: "book",
+		Status:     "pending",
+		Limit:      breakdownBackfillCandidateLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("list pending candidates: %w", err)
+	}
+	// No silent caps: hitting the limit exactly means an unknown tail of
+	// pending candidates was NOT listed — say so.
+	if len(cands) == breakdownBackfillCandidateLimit {
+		log.Warn("breakdown-backfill: candidate list truncated at limit — some pending candidates were not inspected",
+			"limit", breakdownBackfillCandidateLimit)
+	}
+	if reporter.IsCanceled() {
+		return context.Canceled
+	}
+
+	// --- Partition: already-scored rows are skipped, the rest are targets ---
+	skippedHasBreakdown := 0
+	groupByA := make(map[string]*backfillGroup)
+	targets := 0
+	missingSignalCounts := map[string]int{}
+	for i := range cands {
+		c := &cands[i]
+		if c.ScoreBreakdown != nil && len(c.ScoreBreakdown.Signals) > 0 {
+			skippedHasBreakdown++
+			continue
+		}
+		ref := backfillRef{candID: c.ID, otherID: c.EntityBID}
+		// Mirror the operational scan's embeddingMap: only an embedding-layer
+		// row contributes a stored cosine. The cosine is the ONE signal input
+		// that cannot be recomputed offline; when an embedding-layer row has
+		// lost it, score with the remaining signals and record the gap.
+		if c.Layer == "embedding" {
+			if c.Similarity != nil {
+				cos := *c.Similarity
+				ref.embeddingCos = &cos
+			} else {
+				ref.missingCos = true
+				missingSignalCounts["embedding_cosine"]++
+			}
+		}
+		g, ok := groupByA[c.EntityAID]
+		if !ok {
+			g = &backfillGroup{aID: c.EntityAID}
+			groupByA[c.EntityAID] = g
+		}
+		g.refs = append(g.refs, ref)
+		targets++
+	}
+	groups := make([]backfillGroup, 0, len(groupByA))
+	for _, g := range groupByA {
+		groups = append(groups, *g)
+	}
+
+	log.Info("breakdown-backfill start",
+		"apply", params.Apply,
+		"total_pending", len(cands),
+		"skipped_has_breakdown", skippedHasBreakdown,
+		"targets", targets,
+		"a_groups", len(groups),
+		"workers", runtime.NumCPU(),
+	)
+
+	// --- Score + (apply) persist, sharded across disjoint A-groups ---
+	_ = reporter.UpdateProgress(1, 3, fmt.Sprintf("Scoring %d nil-breakdown candidates across %d A-groups…", targets, len(groups)))
+
+	var (
+		mu               sync.Mutex
+		processed        int
+		backfilled       int
+		wouldBackfill    int
+		zeroSignal       int
+		skippedNoBook    int
+		scoreErrs        int
+		updateErrs       int
+		signalKindCounts = map[string]int{}
+		samples          []string
+	)
+
+	err = registry.RunItems(ctx, reporter, groups, func(ctx context.Context, g backfillGroup) error {
+		if reporter.IsCanceled() {
+			return context.Canceled
+		}
+
+		inputs := make([]dedupengine.RescorePairInput, len(g.refs))
+		for i, r := range g.refs {
+			inputs[i] = dedupengine.RescorePairInput{OtherID: r.otherID, EmbeddingCos: r.embeddingCos}
+		}
+
+		results, sErr := scorer.ScorePairsForBook(ctx, g.aID, inputs)
+		if sErr != nil {
+			mu.Lock()
+			scoreErrs += len(g.refs)
+			processed += len(g.refs)
+			mu.Unlock()
+			log.Warn("breakdown-backfill: score error", "a_id", g.aID, "error", sErr)
+			return nil // partial progress beats aborting the whole op
+		}
+
+		// Zip results back to refs by INDEX (ScorePairsForBook returns one
+		// result per input, in order). A short return (nil A-book, mid-flight
+		// cancellation) leaves the trailing refs unscored → skipped_no_book,
+		// so the counts still reconcile against targets.
+		if len(results) < len(g.refs) {
+			mu.Lock()
+			skippedNoBook += len(g.refs) - len(results)
+			processed += len(g.refs) - len(results)
+			mu.Unlock()
+		}
+
+		for i := 0; i < len(results); i++ {
+			res := results[i]
+			ref := g.refs[i]
+
+			mu.Lock()
+			processed++
+			if processed%breakdownBackfillProgressEvery == 0 {
+				log.Info("breakdown-backfill progress",
+					"processed", processed,
+					"targets", targets,
+					"backfilled", backfilled,
+					"would_backfill", wouldBackfill,
+					"zero_signal", zeroSignal,
+					"errors", scoreErrs+updateErrs,
+				)
+			}
+			mu.Unlock()
+
+			// Zero-signal pairs are unscorable — counted, never persisted.
+			if res.NumSignals == 0 || res.Score == nil {
+				mu.Lock()
+				zeroSignal++
+				mu.Unlock()
+				continue
+			}
+
+			mu.Lock()
+			for _, s := range res.Score.Signals {
+				signalKindCounts[string(s.Kind)]++
+			}
+			if len(samples) < breakdownBackfillSampleLimit {
+				samples = append(samples, fmt.Sprintf(
+					"cand=%d pair=%s↔%s score=%.2f band=%q signals=%d",
+					ref.candID, g.aID, ref.otherID, res.Score.Score, res.Score.Band, res.NumSignals))
+			}
+			mu.Unlock()
+
+			if !params.Apply {
+				mu.Lock()
+				wouldBackfill++
+				mu.Unlock()
+				continue
+			}
+
+			// Persist ONLY ScoreBreakdown/Band/FormulaVersion (below-band
+			// breakdowns included — the band gate is deliberately bypassed).
+			if uErr := store.UpdateCandidateScore(ref.candID, res.Score, res.Score.Band, res.Score.Formula); uErr != nil {
+				mu.Lock()
+				updateErrs++
+				mu.Unlock()
+				log.Error("breakdown-backfill: update candidate score error",
+					"candidate_id", ref.candID, "error", uErr)
+				continue
+			}
+			mu.Lock()
+			backfilled++
+			mu.Unlock()
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: runtime.NumCPU(),
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Scored %d/%d A-groups…", i+1, total)
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// --- Report ---
+	_ = reporter.UpdateProgress(2, 3, "Summarizing…")
+	for _, s := range samples {
+		log.Info("breakdown-backfill sample", "pair", s)
+	}
+
+	report := breakdownBackfillReport{
+		Apply:               params.Apply,
+		TotalPending:        len(cands),
+		SkippedHasBreakdown: skippedHasBreakdown,
+		Targets:             targets,
+		Processed:           processed,
+		Backfilled:          backfilled,
+		WouldBackfill:       wouldBackfill,
+		ZeroSignal:          zeroSignal,
+		SkippedNoBook:       skippedNoBook,
+		ScoreErrs:           scoreErrs,
+		UpdateErrs:          updateErrs,
+		MissingSignalCounts: missingSignalCounts,
+		SignalKindCounts:    signalKindCounts,
+	}
+	reportJSON, _ := json.Marshal(report)
+	_ = reporter.Log(slog.LevelInfo, "Breakdown-backfill report (JSON)", slog.String("report", string(reportJSON)))
+	log.Info("breakdown-backfill complete",
+		"apply", params.Apply,
+		"total_pending", len(cands),
+		"skipped_has_breakdown", skippedHasBreakdown,
+		"targets", targets,
+		"processed", processed,
+		"backfilled", backfilled,
+		"would_backfill", wouldBackfill,
+		"zero_signal", zeroSignal,
+		"skipped_no_book", skippedNoBook,
+		"score_errs", scoreErrs,
+		"update_errs", updateErrs,
+		"missing_signal_counts", missingSignalCounts,
+		"signal_kind_counts", signalKindCounts,
+	)
+
+	summary := fmt.Sprintf(
+		"targets=%d processed=%d backfilled=%d would_backfill=%d skipped_has_breakdown=%d zero_signal=%d skipped_no_book=%d score_errs=%d update_errs=%d",
+		targets, processed, backfilled, wouldBackfill, skippedHasBreakdown, zeroSignal, skippedNoBook, scoreErrs, updateErrs)
+	for k, v := range missingSignalCounts {
+		summary += fmt.Sprintf(" missing[%s]=%d", k, v)
+	}
+
+	if !params.Apply {
+		_ = reporter.UpdateProgress(3, 3, "Dry-run — "+summary+". Pass apply=true to persist ScoreBreakdowns.")
+	} else {
+		_ = reporter.UpdateProgress(3, 3, "Complete — "+summary+".")
+	}
+	return nil
+}

--- a/internal/plugins/dedup/breakdown_backfill_test.go
+++ b/internal/plugins/dedup/breakdown_backfill_test.go
@@ -1,0 +1,299 @@
+// file: internal/plugins/dedup/breakdown_backfill_test.go
+// version: 1.0.0
+// guid: db53792e-6046-4acd-ba6c-1857084924cc
+// last-edited: 2026-07-17
+
+// Tests for dedup.breakdown-backfill. A fake pairScorer (shared with the
+// rescore-labeled-examples tests) stands in for the real Engine so the op's
+// decision/skip logic — has-breakdown skip, dry-run no-write, apply persist,
+// zero-signal skip, update-error counting, missing-embedding-cosine
+// accounting — is exercised deterministically against a real EmbeddingStore.
+package dedup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	"github.com/falkcorp/audiobook-organizer/internal/models"
+)
+
+// seedCandidate upserts a pending dedup candidate and returns its store ID.
+func seedCandidate(t *testing.T, es *database.EmbeddingStore, c database.DedupCandidate) int64 {
+	t.Helper()
+	if c.EntityType == "" {
+		c.EntityType = "book"
+	}
+	if c.Status == "" {
+		c.Status = "pending"
+	}
+	id, _, err := es.UpsertCandidateNew(c)
+	if err != nil {
+		t.Fatalf("seed candidate %s/%s: %v", c.EntityAID, c.EntityBID, err)
+	}
+	return id
+}
+
+// failingUpdateScoreStore wraps a real *database.EmbeddingStore but forces
+// UpdateCandidateScore to fail for a chosen set of candidate IDs, so the test
+// can assert the op counts (rather than swallows) persist failures.
+type failingUpdateScoreStore struct {
+	*database.EmbeddingStore
+	failIDs map[int64]bool
+}
+
+func (f *failingUpdateScoreStore) UpdateCandidateScore(id int64, score *models.UnifiedDedupScore, band, formulaVersion string) error {
+	if f.failIDs[id] {
+		return fmt.Errorf("simulated update failure")
+	}
+	return f.EmbeddingStore.UpdateCandidateScore(id, score, band, formulaVersion)
+}
+
+// TestBreakdownBackfill_SkipsHasBreakdown proves a candidate that already has a
+// non-empty ScoreBreakdown is never rescored or rewritten — it is counted as
+// skipped_has_breakdown and its stored breakdown is byte-identical afterwards.
+func TestBreakdownBackfill_SkipsHasBreakdown(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	existing := &unified.UnifiedDedupScore{
+		Pair:    [2]string{"hasA", "hasB"},
+		Score:   88.0,
+		Band:    "HIGH",
+		Formula: "noisy_or_v1",
+		Signals: []models.Signal{{Kind: unified.SigExactFile, Confidence: 0.99}},
+	}
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "hasA", EntityBID: "hasB", Layer: "exact",
+		ScoreBreakdown: existing, Band: "HIGH", FormulaVersion: "noisy_or_v1",
+	})
+
+	// The fake scorer would produce a DIFFERENT score — if the op rescored the
+	// row, the stored breakdown would change.
+	rep := &capturingReporter{}
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil || got.ScoreBreakdown == nil {
+		t.Fatal("candidate with existing breakdown vanished or lost its breakdown")
+	}
+	if got.ScoreBreakdown.Score != 88.0 || got.Band != "HIGH" {
+		t.Fatalf("existing breakdown was rewritten: score=%.1f band=%q", got.ScoreBreakdown.Score, got.Band)
+	}
+	if !strings.Contains(rep.lastMsg, "skipped_has_breakdown=1") {
+		t.Fatalf("summary should report skipped_has_breakdown=1, got %q", rep.lastMsg)
+	}
+}
+
+// TestBreakdownBackfill_DryRunWritesNothing proves the default (apply=false)
+// computes and counts but persists nothing.
+func TestBreakdownBackfill_DryRunWritesNothing(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "dryA", EntityBID: "dryB", Layer: "exact",
+	})
+
+	rep := &capturingReporter{}
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("dry-run must not delete the candidate")
+	}
+	if got.ScoreBreakdown != nil {
+		t.Fatalf("dry-run wrote a ScoreBreakdown: %+v", got.ScoreBreakdown)
+	}
+	if !strings.Contains(rep.lastMsg, "would_backfill=1") {
+		t.Fatalf("summary should report would_backfill=1, got %q", rep.lastMsg)
+	}
+}
+
+// TestBreakdownBackfill_ApplyWritesBreakdown proves apply=true persists the
+// recomputed breakdown (even a below-band one — ANY breakdown beats none for
+// triage/calibration) while leaving Status/Layer/Similarity untouched.
+func TestBreakdownBackfill_ApplyWritesBreakdown(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	sim := 0.42
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "appA", EntityBID: "appB", Layer: "exact", Similarity: &sim,
+	})
+
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("candidate vanished")
+	}
+	if got.ScoreBreakdown == nil || len(got.ScoreBreakdown.Signals) < 1 {
+		t.Fatalf("apply=true did not persist a breakdown with >=1 signal: %+v", got.ScoreBreakdown)
+	}
+	if got.ScoreBreakdown.Score != 4.0 {
+		t.Fatalf("persisted score: want 4.0, got %.4f", got.ScoreBreakdown.Score)
+	}
+	if got.FormulaVersion != "test" {
+		t.Fatalf("FormulaVersion not persisted: got %q", got.FormulaVersion)
+	}
+	// Below-band composed score → empty band mirrored onto the candidate.
+	if got.Band != "" {
+		t.Fatalf("Band should mirror the composed (empty) band, got %q", got.Band)
+	}
+	// Lifecycle fields must be untouched.
+	if got.Status != "pending" {
+		t.Fatalf("Status changed: got %q", got.Status)
+	}
+	if got.Layer != "exact" {
+		t.Fatalf("Layer changed: got %q", got.Layer)
+	}
+	if got.Similarity == nil || *got.Similarity != 0.42 {
+		t.Fatalf("Similarity changed: got %v", got.Similarity)
+	}
+}
+
+// TestBreakdownBackfill_ZeroSignalNotPersisted proves a pair the scorer cannot
+// produce any signal for is counted (zero_signal) and never written — an empty
+// breakdown would be indistinguishable from "scored, no evidence".
+func TestBreakdownBackfill_ZeroSignalNotPersisted(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "zeroA", EntityBID: "zeroB", Layer: "exact",
+	})
+
+	rep := &capturingReporter{}
+	zeroScorer := &fakePairScorer{} // no signals → unscorable
+	if err := runBreakdownBackfillWith(context.Background(), zeroScorer, es,
+		json.RawMessage(`{"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil || got.ScoreBreakdown != nil {
+		t.Fatalf("zero-signal pair must not get a breakdown, got %+v", got)
+	}
+	if !strings.Contains(rep.lastMsg, "zero_signal=1") {
+		t.Fatalf("summary should report zero_signal=1, got %q", rep.lastMsg)
+	}
+}
+
+// TestBreakdownBackfill_UpdateFailure_CountsError proves a persist failure is
+// counted in the summary (update_errs) instead of being silently swallowed.
+func TestBreakdownBackfill_UpdateFailure_CountsError(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "failA", EntityBID: "failB", Layer: "exact",
+	})
+
+	wrapped := &failingUpdateScoreStore{EmbeddingStore: es, failIDs: map[int64]bool{id: true}}
+	rep := &capturingReporter{}
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), wrapped,
+		json.RawMessage(`{"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil || got.ScoreBreakdown != nil {
+		t.Fatalf("failed update must leave the candidate breakdown-less, got %+v", got)
+	}
+	if !strings.Contains(rep.lastMsg, "update_errs=1") {
+		t.Fatalf("summary should report update_errs=1, got %q", rep.lastMsg)
+	}
+}
+
+// TestBreakdownBackfill_MissingEmbeddingCosineCounted proves an embedding-layer
+// candidate with no stored cosine is still scored with the remaining signals and
+// the unavailable embedding signal is recorded in missing_signal_counts.
+func TestBreakdownBackfill_MissingEmbeddingCosineCounted(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	id := seedCandidate(t, es, database.DedupCandidate{
+		EntityAID: "embA", EntityBID: "embB", Layer: "embedding", // Similarity nil → cosine unrecoverable
+	})
+
+	rep := &capturingReporter{}
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), rep); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Still backfilled from the remaining (duration) signal.
+	got, err := es.GetCandidateByID(id)
+	if err != nil {
+		t.Fatalf("GetCandidateByID: %v", err)
+	}
+	if got == nil || got.ScoreBreakdown == nil {
+		t.Fatal("pair with missing cosine should still be backfilled from remaining signals")
+	}
+	if !strings.Contains(rep.lastMsg, "missing[embedding_cosine]=1") {
+		t.Fatalf("summary should report missing[embedding_cosine]=1, got %q", rep.lastMsg)
+	}
+}
+
+// TestBreakdownBackfill_ParallelManyGroups spreads many nil-breakdown candidates
+// across many A-groups so the registry.RunItems pool is genuinely contended; run
+// under -race to catch unguarded shared state. Every candidate must end up with
+// a persisted breakdown.
+func TestBreakdownBackfill_ParallelManyGroups(t *testing.T) {
+	pebble := newPebbleForISBNIndexTest(t)
+	es := database.NewEmbeddingStore(pebble.DB())
+
+	const n = 200
+	ids := make([]int64, n)
+	for i := 0; i < n; i++ {
+		ids[i] = seedCandidate(t, es, database.DedupCandidate{
+			EntityAID: fmt.Sprintf("pA%03d", i), // distinct A per pair → many groups
+			EntityBID: fmt.Sprintf("pB%03d", i),
+			Layer:     "exact",
+		})
+	}
+
+	if err := runBreakdownBackfillWith(context.Background(), belowBandScorer(), es,
+		json.RawMessage(`{"apply":true}`), &fakeReporter{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	for i, id := range ids {
+		got, err := es.GetCandidateByID(id)
+		if err != nil {
+			t.Fatalf("GetCandidateByID(%d): %v", id, err)
+		}
+		if got == nil || got.ScoreBreakdown == nil {
+			t.Fatalf("candidate %d (pair %d): breakdown not persisted", id, i)
+		}
+	}
+}

--- a/internal/plugins/dedup/plugin.go
+++ b/internal/plugins/dedup/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/plugin.go
-// version: 1.17.0
+// version: 1.18.0
 // guid: d1e2f3a4-b5c6-7890-abcd-ef1234567890
-// last-edited: 2026-07-12
+// last-edited: 2026-07-17
 
 // Package dedup is the UOS plugin for deduplication operations.
 // It wraps the internal dedup.Engine and registers OperationDefs through
@@ -82,6 +82,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.cleanupOrphanAuthorEmbeddingsDef(), // author-side counterpart: deletes emb:v:author:* rows orphaned by a merge/delete (#1866 follow-up)
 		p.buildCandidateStatusIndexDef(),     // INIT-2 T4: dedup:s: status secondary index backfill over dedup candidates
 		p.rescoreLabeledExamplesDef(),        // recompute ScoreBreakdowns onto labeled examples (incl. below-band/dismissed) for calibration coverage
+		p.breakdownBackfillDef(),             // backfill ScoreBreakdowns onto pre-T015 nil-breakdown pending candidates (unblocks Rescore + exact-triage)
 	}
 
 	for _, op := range ops {

--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedup_triage.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
-// last-edited: 2026-06-24
+// last-edited: 2026-07-17
 
 package maintenance
 
@@ -39,11 +39,18 @@ const (
 	// DurationVerifiedAt stamp) — otherwise falls through to unknown.
 	TriageClassFragment TriageClass = "fragment"
 
-	// TriageClassTitleLeak — both books are iTunes imports, the candidate layer is
-	// "exact" (title match), and no hard signal (file-hash / ISBN / meta-hash) is
-	// present in the ScoreBreakdown. These are CONS-17 artifacts: the iTunes
-	// importer set every track's title to the first track's title, causing
-	// spurious title-identity matches across unrelated chapters.
+	// TriageClassTitleLeak — an exact-layer candidate with no hard signal
+	// (file-hash / ISBN / meta-hash) in the ScoreBreakdown, where EITHER
+	//   (a) both books are iTunes imports (the original CONS-17 signature), OR
+	//   (b) the two books carry an identical normalized title (the leak's own
+	//       evidence, provenance-independent).
+	// These are CONS-17 artifacts: the iTunes importer set every track's title
+	// to the first track's title, causing spurious title-identity matches
+	// across unrelated chapters. Branch (b) exists because proven title-leak
+	// books live under the organized library path after being moved out of the
+	// iTunes tree — the both-iTunes precondition alone classified 0 of 6,921
+	// proven title-leak pairs. Books under ANY library path qualify when the
+	// title-identity evidence fires.
 	TriageClassTitleLeak TriageClass = "title_leak"
 
 	// TriageClassUnknown — pre-T015 candidate with no ScoreBreakdown, or a
@@ -128,9 +135,24 @@ func ClassifyCandidate(c database.DedupCandidate, a, b *database.Book) (TriageCl
 		return cls, reason
 	}
 
-	// 4. Title-leak: both books are iTunes imports, layer = exact, no hard signal.
-	if a.ITunesPersistentID != nil && b.ITunesPersistentID != nil && c.Layer == "exact" {
-		return TriageClassTitleLeak, "both books are iTunes imports with exact-layer title match and no hard signal"
+	// 4. Title-leak: exact-layer candidate, no hard signal (step 2 already
+	// returned genuine for any hard-signal breakdown), and EITHER both books
+	// are iTunes imports (original CONS-17 signature) OR the two books share
+	// an identical normalized title (the leak's own evidence). The identical-
+	// title branch is deliberately stricter than the engine's Levenshtein<=2
+	// exact-title matcher: title-leak classification feeds a purge decision,
+	// so only verified title identity qualifies a non-iTunes pair. Note the
+	// "exact" layer also covers ISBN / file-hash / duration emitters — for a
+	// pre-T015 nil-breakdown row that provenance is unknowable, which is why
+	// the title-identity evidence is required rather than layer alone.
+	if c.Layer == "exact" {
+		if a.ITunesPersistentID != nil && b.ITunesPersistentID != nil {
+			return TriageClassTitleLeak, "both books are iTunes imports with exact-layer title match and no hard signal"
+		}
+		if t := normalizedLeakTitle(a.Title); t != "" && t == normalizedLeakTitle(b.Title) {
+			return TriageClassTitleLeak, fmt.Sprintf(
+				"identical normalized title %q with exact-layer match and no hard signal (CONS-17 title leak)", t)
+		}
 	}
 
 	// 5. Pre-T015 (no ScoreBreakdown) or unclassifiable mixed signals.
@@ -138,6 +160,14 @@ func ClassifyCandidate(c database.DedupCandidate, a, b *database.Book) (TriageCl
 		return TriageClassUnknown, "pre-T015 candidate, no ScoreBreakdown"
 	}
 	return TriageClassUnknown, fmt.Sprintf("layer=%s, no hard signal, signals=%s", c.Layer, signalList(c))
+}
+
+// normalizedLeakTitle canonicalizes a title for the title-leak identity check:
+// lowercase with whitespace runs collapsed. Deliberately conservative — no
+// punctuation stripping, no fuzzy distance — because a title_leak verdict is
+// purgeable and must only fire on verified title identity.
+func normalizedLeakTitle(t string) string {
+	return strings.Join(strings.Fields(strings.ToLower(t)), " ")
 }
 
 func isTriageStub(b *database.Book) bool {

--- a/internal/plugins/maintenance/dedup_triage_test.go
+++ b/internal/plugins/maintenance/dedup_triage_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedup_triage_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8f9a0b1c-2d3e-4f50-a6b7-c8d9e0f12345
-// last-edited: 2026-06-24
+// last-edited: 2026-07-17
 
 package maintenance
 
@@ -141,6 +141,88 @@ func TestClassifyCandidate_TitleLeak(t *testing.T) {
 	cls, reason := ClassifyCandidate(c, a, b)
 	if cls != TriageClassTitleLeak {
 		t.Errorf("got %s (%s), want title_leak", cls, reason)
+	}
+}
+
+// TestClassifyCandidate_TitleLeak_NonITunes_SameTitle proves the relaxed
+// precondition: a pair with NO iTunes provenance (e.g. books moved under the
+// organized library path) classifies as title_leak when the title-identity
+// evidence fires — identical normalized title, exact layer, no hard signal.
+func TestClassifyCandidate_TitleLeak_NonITunes_SameTitle(t *testing.T) {
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	b := makeBook("b", 5*1024*1024, 3500, "")
+	a.Title = "The Leaked Title"
+	b.Title = "The Leaked Title"
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassTitleLeak {
+		t.Errorf("got %s (%s), want title_leak for non-iTunes identical-title pair", cls, reason)
+	}
+}
+
+// TestClassifyCandidate_TitleLeak_NonITunes_SameTitle_NilBreakdown covers the
+// pre-T015 shape of the same leak: no ScoreBreakdown at all, identical titles,
+// exact layer, no iTunes IDs — previously fell through to unknown.
+func TestClassifyCandidate_TitleLeak_NonITunes_SameTitle_NilBreakdown(t *testing.T) {
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	b := makeBook("b", 5*1024*1024, 3500, "")
+	a.Title = "Chapter Leak Book"
+	b.Title = "chapter  leak BOOK" // normalization: case + whitespace runs
+	c := database.DedupCandidate{Layer: "exact"} // pre-T015, nil breakdown
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassTitleLeak {
+		t.Errorf("got %s (%s), want title_leak for pre-T015 identical-title pair", cls, reason)
+	}
+}
+
+// TestClassifyCandidate_NonITunes_DifferentTitles_NotLeak guards the
+// conservative side of the relaxation: without iTunes provenance AND without
+// title identity, an exact-layer soft-signal pair must NOT be purgeable.
+func TestClassifyCandidate_NonITunes_DifferentTitles_NotLeak(t *testing.T) {
+	a := makeBook("a", 5*1024*1024, 3600, "") // titles "Book a" vs "Book b"
+	b := makeBook("b", 5*1024*1024, 3500, "")
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigMetaFuzzy))
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls == TriageClassTitleLeak {
+		t.Errorf("different-title non-iTunes pair must not be title_leak (%s)", reason)
+	}
+	if cls != TriageClassUnknown {
+		t.Errorf("got %s (%s), want unknown", cls, reason)
+	}
+}
+
+// TestClassifyCandidate_SameTitle_HardSignal_StaysGenuine proves purge safety
+// of the relaxation ordering: an identical-title pair whose breakdown carries a
+// hard signal (ISBN) is classified genuine at step 2 and never reaches the
+// title-leak branch.
+func TestClassifyCandidate_SameTitle_HardSignal_StaysGenuine(t *testing.T) {
+	a := makeBook("a", 10*1024*1024, 3600, "")
+	b := makeBook("b", 10*1024*1024, 3600, "")
+	a.Title = "Same Real Book"
+	b.Title = "Same Real Book"
+	c := withBreakdown(database.DedupCandidate{Layer: "exact"}, sig(unified.SigISBNASIN))
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls != TriageClassGenuine {
+		t.Errorf("got %s (%s), want genuine — hard signal must outrank title-leak", cls, reason)
+	}
+}
+
+// TestClassifyCandidate_EmptyTitles_NotLeak guards against two empty/blank
+// titles counting as "identical".
+func TestClassifyCandidate_EmptyTitles_NotLeak(t *testing.T) {
+	a := makeBook("a", 5*1024*1024, 3600, "")
+	b := makeBook("b", 5*1024*1024, 3500, "")
+	a.Title = "   "
+	b.Title = ""
+	c := database.DedupCandidate{Layer: "exact"}
+
+	cls, reason := ClassifyCandidate(c, a, b)
+	if cls == TriageClassTitleLeak {
+		t.Errorf("blank titles must not classify as title_leak (%s)", reason)
 	}
 }
 


### PR DESCRIPTION
## Summary
Steps 2+3 of the dedup remediation path (docs/dedup/STATUS.md): ~9,950 pending candidates predate T015 and have no ScoreBreakdown — one data gap that disables BOTH `maintenance.dedup-exact-triage` (everything classifies unknown) and composite calibration.

- New op `dedup.breakdown-backfill` (dry-run default, `{"apply": true}`): recomputes each nil-breakdown pending candidate's unified signal set via the exact scan-path surface (`ScorePairsForBook` → `collectPairSignals` → `unified.ComposeScore` — bit-identical scoring, no fork) and persists via UpdateCandidateScore only (Status/Layer/Similarity untouched). Sharded by EntityAID via registry.RunItems at NumCPU; embedding cosine reused from stored Similarity; zero-signal pairs counted, never persisted; full structured counter report.
- TriageClassTitleLeak no longer requires both books be iTunes imports (0 of 6,921 proven title-leak pairs matched that precondition): within the exact layer it now also fires on identical normalized titles (strict equality, no fuzzy) — deliberately conservative since title_leak is purgeable; hard-signal pairs still classify genuine first.

## Verification plan
Sandbox: dry-run → apply → rerun dedup-exact-triage, expect unknown≈9,950 to collapse into real classes before any prod run.

## Tests
7 op tests (real PebbleStore, -race) + 5 triage tests; dedup/maintenance suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65