### PR TITLE
fix(devops): IP scrub in shipped code/scripts, worktree-proof pre-commit hook + secret scan, deploy template, embed-frontend smoke

### DIFF
--- a/.github/workflows/binary-smoke.yml
+++ b/.github/workflows/binary-smoke.yml
@@ -1,6 +1,7 @@
 # file: .github/workflows/binary-smoke.yml
-# version: 1.3.0
+# version: 1.4.0
 # guid: 8dad4b58-c626-48e4-9adc-2696ddd2e864
+# last-edited: 2026-07-17
 
 name: Binary Smoke
 
@@ -31,6 +32,13 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libtag1-dev
 
@@ -45,12 +53,20 @@ jobs:
           ./audiobook-organizer serve --help >/dev/null
           ./audiobook-organizer inspect-metadata --help >/dev/null
 
-      - name: Start Server And Probe Health Endpoint
+      - name: Build Frontend
+        run: cd web && npm ci && npm run build
+
+      - name: Build Embedded Binary (embed_frontend)
+        run: go build -tags embed_frontend -o audiobook-organizer-embedded .
+        env:
+          GOEXPERIMENT: jsonv2
+
+      - name: Start Embedded Server And Probe Health + SPA
         run: |
           set -euo pipefail
           tmpdir="$(mktemp -d)"
           mkdir -p "${tmpdir}/library" "${tmpdir}/playlists"
-          ./audiobook-organizer \
+          ./audiobook-organizer-embedded \
             --dir "${tmpdir}/library" \
             --db "${tmpdir}/audiobooks.pebble" \
             --playlists "${tmpdir}/playlists" \
@@ -84,5 +100,15 @@ jobs:
           fi
 
           echo "Health check passed"
+
+          # Verify the embedded SPA is actually served at / (catches builds
+          # where web/dist was stale or missing at embed time).
+          if ! curl -fsS "http://127.0.0.1:18080/" | grep -qi "<html"; then
+            echo "Embedded SPA probe failed: / did not serve HTML"
+            cat "${tmpdir}/server.log"
+            exit 1
+          fi
+          echo "Embedded SPA probe passed"
+
           kill "${pid}" >/dev/null 2>&1 || true
           wait "${pid}" >/dev/null 2>&1 || true

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,13 +1,13 @@
 # file: Makefile.local.example
-# version: 1.0.1
+# version: 1.1.0
 # guid: a2b4c6d8-e0f2-4a6b-8c0d-2e4f6a8b0c2d
-# last-edited: 2026-07-03
+# last-edited: 2026-07-17
 #
 # TEMPLATE — copy to Makefile.local (gitignored) and fill in your own values.
 # Makefile.local is included by the committed Makefile via `-include
 # Makefile.local` and supplies the machine-local deployment variables
-# (DEPLOY_HOST, DEPLOY_BIN) plus the `deploy`/`deploy-debug` targets. None of
-# this is committed — only this sanitized example is.
+# (DEPLOY_HOST, DEPLOY_BIN, DEPLOY_URL) plus the `deploy`/`deploy-debug`
+# targets. None of this is committed — only this sanitized example is.
 #
 # Usage:
 #   cp Makefile.local.example Makefile.local
@@ -25,28 +25,73 @@ DEPLOY_HOST := 192.168.0.10
 # committed `make rollback` target as well as this file's `deploy:` recipe.
 DEPLOY_BIN := /usr/local/bin/audiobook-organizer
 
-## deploy: Cross-compile, ship the binary, preserve a .prev copy, and restart
+# Base URL of the deployed server, used by the post-deploy version check.
+DEPLOY_URL := https://$(DEPLOY_HOST):8484
+
+## deploy: Build frontend + cross-compile embedded binary, ship it, preserve a
+## .prev copy, restart, and verify the deployed version.
+#
+# Mirrors the committed `build-linux` target's build chain: web-build first
+# (so web/dist is fresh — embed_frontend embeds whatever is on disk, stale or
+# absent), then cross-compile with the SAME tag set the real build uses
+# (embed_frontend fts5 native_taglib). Cross-compiling CGO (fts5/native_taglib)
+# from macOS requires: brew install filosottile/musl-cross/musl-cross
 .PHONY: deploy
-deploy: build-api
+deploy: web-build
+	@echo "→ Pre-flight: checking local branch is not behind origin/main..."
+	@git fetch origin main
+	@git merge-base --is-ancestor origin/main HEAD || (echo "❌ local main behind origin — pull first"; exit 1)
 	@echo "→ Cross-compiling linux/amd64 binary..."
-	GOOS=linux GOARCH=amd64 go build -tags embed_frontend -o dist/$(BINARY)-linux-amd64 .
+	@mkdir -p dist
+	CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
+		-tags "embed_frontend fts5 native_taglib" \
+		-ldflags="-s -w -linkmode external -extldflags '-static' -X main.version=$$(git describe --tags --always)" \
+		-o dist/$(BINARY)-linux-amd64 .
 	@echo "→ Copying binary to $(DEPLOY_HOST)..."
 	scp dist/$(BINARY)-linux-amd64 $(DEPLOY_HOST):/home/USER/audiobook-organizer
 	@echo "→ Preserving previous binary as .prev, installing new binary, restarting service..."
 	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
 	  sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && \
 	  sudo systemctl restart audiobook-organizer.service'
+	@echo "→ Post-deploy: verifying deployed version matches git describe..."
+	@sleep 3; \
+	  expected=$$(git describe --tags --always); \
+	  deployed=$$(curl -ksf $(DEPLOY_URL)/api/v1/system/version || echo "UNREACHABLE"); \
+	  echo "   expected: $$expected"; \
+	  echo "   deployed: $$deployed"; \
+	  case "$$deployed" in \
+	    *"$$expected"*) echo "✅ Deployed version matches." ;; \
+	    *) echo "❌ Deployed version does NOT match git describe — stale binary shipped?"; exit 1 ;; \
+	  esac
 	@echo "✅ Deployed to $(DEPLOY_HOST). Roll back with: make rollback DEPLOY_HOST=$(DEPLOY_HOST) DEPLOY_BIN=$(DEPLOY_BIN)"
 
 ## deploy-debug: Same as deploy, but ships a debug (non-stripped) build
 .PHONY: deploy-debug
-deploy-debug: build-api
+deploy-debug: web-build
+	@echo "→ Pre-flight: checking local branch is not behind origin/main..."
+	@git fetch origin main
+	@git merge-base --is-ancestor origin/main HEAD || (echo "❌ local main behind origin — pull first"; exit 1)
 	@echo "→ Cross-compiling linux/amd64 debug binary..."
-	GOOS=linux GOARCH=amd64 go build -gcflags="all=-N -l" -tags embed_frontend -o dist/$(BINARY)-linux-amd64-debug .
+	@mkdir -p dist
+	CC=x86_64-linux-musl-gcc GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
+		-gcflags="all=-N -l" \
+		-tags "embed_frontend fts5 native_taglib" \
+		-ldflags="-linkmode external -extldflags '-static' -X main.version=$$(git describe --tags --always)" \
+		-o dist/$(BINARY)-linux-amd64-debug .
 	@echo "→ Copying debug binary to $(DEPLOY_HOST)..."
 	scp dist/$(BINARY)-linux-amd64-debug $(DEPLOY_HOST):/home/USER/audiobook-organizer
 	@echo "→ Preserving previous binary as .prev, installing new binary, restarting service..."
 	ssh $(DEPLOY_HOST) 'sudo cp $(DEPLOY_BIN) $(DEPLOY_BIN).prev 2>/dev/null; \
 	  sudo mv /home/USER/audiobook-organizer $(DEPLOY_BIN) && \
 	  sudo systemctl restart audiobook-organizer.service'
+	@echo "→ Post-deploy: verifying deployed version matches git describe..."
+	@sleep 3; \
+	  expected=$$(git describe --tags --always); \
+	  deployed=$$(curl -ksf $(DEPLOY_URL)/api/v1/system/version || echo "UNREACHABLE"); \
+	  echo "   expected: $$expected"; \
+	  echo "   deployed: $$deployed"; \
+	  case "$$deployed" in \
+	    *"$$expected"*) echo "✅ Deployed version matches." ;; \
+	    *) echo "❌ Deployed version does NOT match git describe — stale binary shipped?"; exit 1 ;; \
+	  esac
 	@echo "✅ Debug build deployed to $(DEPLOY_HOST)."

--- a/cmd/dedup_bench.go
+++ b/cmd/dedup_bench.go
@@ -1,6 +1,7 @@
 // file: cmd/dedup_bench.go
-// version: 1.3.1
+// version: 1.3.2
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-17
 
 //go:build bench
 
@@ -71,7 +72,7 @@ func init() {
 	}, "Models to test")
 	dedupBenchCmd.Flags().StringVar(&benchMode, "mode", "both", "Mode: groups, full, or both")
 	dedupBenchCmd.Flags().BoolVar(&benchDryRun, "dry-run", false, "Extract data only, don't call API")
-	dedupBenchCmd.Flags().StringVar(&benchServerURL, "server", "", "Remote server URL to fetch authors (e.g., https://172.16.2.30:8484)")
+	dedupBenchCmd.Flags().StringVar(&benchServerURL, "server", "", "Remote server URL to fetch authors (e.g., https://<server>:8484)")
 	dedupBenchCmd.Flags().IntVar(&benchChunkSize, "chunk-size", 500, "Max authors per AI request chunk")
 	dedupBenchCmd.Flags().BoolVar(&benchBatch, "batch", false, "Submit as async batch jobs (50% cheaper, ~24h completion)")
 }

--- a/scripts/dedup_bench_submit.py
+++ b/scripts/dedup_bench_submit.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
+# file: scripts/dedup_bench_submit.py
+# version: 1.1.0
+# guid: 3b9e1c5a-7d2f-4e8b-a6c1-9f4d0e2b8a53
+# last-edited: 2026-07-17
 """Submit dedup benchmark batch jobs to OpenAI.
 
 Fetches author data from a remote server, builds test configurations,
 and submits them as batch API jobs (50% cheaper than real-time).
 
 Usage:
-    python3 scripts/dedup_bench_submit.py --server https://172.16.2.30:8484
+    python3 scripts/dedup_bench_submit.py --server https://<server>:8484
 
-Loads API keys from scripts/.env automatically.
+The server URL may also be supplied via the ABK_API_URL environment
+variable; one of the two is required. Loads API keys from scripts/.env
+automatically.
 """
 
 import argparse
@@ -350,7 +356,9 @@ def submit_batch(
 def main():
     parser = argparse.ArgumentParser(description="Submit dedup benchmark batch jobs")
     parser.add_argument(
-        "--server", required=True, help="Server URL (e.g., https://172.16.2.30:8484)"
+        "--server",
+        default=os.environ.get("ABK_API_URL"),
+        help="Server URL (e.g., https://<server>:8484); defaults to $ABK_API_URL",
     )
     parser.add_argument(
         "--output", default="testdata/dedup-bench", help="Output directory"
@@ -367,6 +375,12 @@ def main():
         "--groups-json", help="Path to pre-computed groups.json (from Go binary)"
     )
     args = parser.parse_args()
+
+    if not args.server:
+        parser.error(
+            "--server is required (or set the ABK_API_URL environment variable "
+            "to your server URL, e.g. https://<server>:8484)"
+        )
 
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if not api_key and not args.dry_run:

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # file: scripts/setup-git-hooks.sh
-# version: 1.1.0
+# version: 1.2.0
 # guid: e8c4b7a2-1f3d-44e7-9c5e-8f2d1b4a9e3c
-# last-edited: 2026-07-03
+# last-edited: 2026-07-17
 # Set up git pre-commit hook to prevent accidentally committing .api-token
+#
+# Uses --git-common-dir (NOT --git-dir): in a linked worktree, --git-dir
+# resolves to .git/worktrees/<name>, whose hooks/ directory git never
+# consults — a hook installed there silently never fires. The common dir's
+# hooks/ applies to the main checkout AND every worktree.
 
-HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+HOOK_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/hooks"
 HOOK_FILE="$HOOK_DIR/pre-commit"
 
 # Create hooks directory if it doesn't exist
@@ -14,7 +19,7 @@ mkdir -p "$HOOK_DIR"
 # Create pre-commit hook
 cat > "$HOOK_FILE" <<'EOF'
 #!/bin/bash
-# Pre-commit hook: prevent .api-token from being committed
+# Pre-commit hook: prevent credentials/secrets from being committed
 
 PROTECTED_FILES=(
     ".api-token"
@@ -47,6 +52,28 @@ for FILE in "${PROTECTED_FILES[@]}"; do
     fi
 done
 
+# Content scan: block staged diffs that ADD API tokens or internal IPs.
+# Patterns: abk_ API keys, and 172.16.x.x internal-network addresses.
+# NOTE: all greps use -E (ERE) — in BRE, '\+' is a repetition operator and
+# '^\+\+\+ ' errors out ("repetition-operator operand invalid").
+SECRET_RE='abk_[A-Za-z0-9]{16,}|172\.16\.[0-9]{1,3}\.[0-9]{1,3}'
+ADDED_SECRETS=$(git diff --cached --unified=0 --no-color \
+    | grep -E '^\+' | grep -Ev '^\+\+\+ ' | grep -E "$SECRET_RE")
+if [[ -n "$ADDED_SECRETS" ]]; then
+    echo "❌ Error: staged changes add content matching a secret/internal-IP pattern:"
+    echo ""
+    echo "$ADDED_SECRETS" | head -10
+    echo ""
+    echo "This is a public repo — API tokens (abk_...) and internal network"
+    echo "addresses (172.16.x.x) must never be committed. Replace with an env"
+    echo "variable or a placeholder like https://<server>:8484."
+    echo ""
+    echo "If this is a deliberate false positive, bypass once with:"
+    echo "  git commit --no-verify"
+    echo ""
+    exit 1
+fi
+
 exit 0
 EOF
 
@@ -62,8 +89,13 @@ echo "  - .bootstrap-token (temporary bootstrap auth token)"
 echo "  - .readonly-key (startup read-only API key)"
 echo "  - .claude/.credentials/ (per-worktree username/password)"
 echo ""
-echo "The hook will prevent these from being committed."
-echo "If you accidentally stage one, you'll get an error message."
+echo "Staged-content scan also blocks diffs that ADD:"
+echo "  - API tokens matching abk_<16+ alphanumerics>"
+echo "  - internal IPs matching 172.16.x.x"
+echo "(bypass a false positive with: git commit --no-verify)"
+echo ""
+echo "The hook is installed in the COMMON git dir, so it fires for the main"
+echo "checkout and every linked worktree."
 echo ""
 echo "To manage worktree credentials, use:"
 echo "  ./scripts/manage-credentials.sh --help"

--- a/scripts/setup-winrm-windows.ps1
+++ b/scripts/setup-winrm-windows.ps1
@@ -1,26 +1,48 @@
 # file: scripts/setup-winrm-windows.ps1
-# version: 1.0.0
+# version: 1.1.0
 # guid: d5e6f7a8-b9c0-1234-defa-456789012345
-# last-edited: 2026-06-27
+# last-edited: 2026-07-17
 #
-# Run ONCE as Administrator on the Windows GPU machine (172.16.3.22).
+# Run ONCE as Administrator on the Windows GPU machine (<windows-gpu-host>).
 # Enables PowerShell Remoting (WinRM) so the Mac and Linux server can
 # deploy and control this machine via Invoke-Command / Copy-Item.
 #
 # No OpenSSH required — WinRM is built into Windows.
 #
+# Your LAN subnet is REQUIRED (no default) — pass it as parameters or set
+# the environment variables before running:
+#   .\setup-winrm-windows.ps1 -LanSubnetWildcard "10.0.*" -LanSubnetCidr "10.0.0.0/16"
+# or:
+#   $env:ABK_LAN_SUBNET_WILDCARD = "10.0.*"
+#   $env:ABK_LAN_SUBNET_CIDR    = "10.0.0.0/16"
+#
 # After running: test from Mac with:
-#   pwsh -Command "Invoke-Command -ComputerName 172.16.3.22 -Credential (Get-Credential) -ScriptBlock { hostname }"
+#   pwsh -Command "Invoke-Command -ComputerName <windows-gpu-host> -Credential (Get-Credential) -ScriptBlock { hostname }"
 #
 # Or save credentials once:
 #   $cred = Get-Credential
 #   $cred | Export-Clixml ~/windows-gpu.cred   # stored encrypted, current user only
-#   Invoke-Command -ComputerName 172.16.3.22 -Credential (Import-Clixml ~/windows-gpu.cred) -ScriptBlock { hostname }
+#   Invoke-Command -ComputerName <windows-gpu-host> -Credential (Import-Clixml ~/windows-gpu.cred) -ScriptBlock { hostname }
 
 #Requires -RunAsAdministrator
 
+param(
+    # Wildcard form of your LAN subnet for WinRM TrustedHosts (e.g. "10.0.*").
+    [string]$LanSubnetWildcard = $env:ABK_LAN_SUBNET_WILDCARD,
+    # CIDR form of your LAN subnet for firewall scoping (e.g. "10.0.0.0/16").
+    [string]$LanSubnetCidr = $env:ABK_LAN_SUBNET_CIDR
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
+
+if (-not $LanSubnetWildcard -or -not $LanSubnetCidr) {
+    Write-Host "ERROR: LAN subnet not specified — refusing to guess." -ForegroundColor Red
+    Write-Host "Pass -LanSubnetWildcard/-LanSubnetCidr or set ABK_LAN_SUBNET_WILDCARD /"
+    Write-Host "ABK_LAN_SUBNET_CIDR, e.g.:"
+    Write-Host '  .\setup-winrm-windows.ps1 -LanSubnetWildcard "10.0.*" -LanSubnetCidr "10.0.0.0/16"'
+    exit 1
+}
 
 function Write-Step($msg) { Write-Host "`n==> $msg" -ForegroundColor Cyan }
 function Write-Ok($msg)   { Write-Host "    OK: $msg" -ForegroundColor Green }
@@ -31,10 +53,10 @@ Enable-PSRemoting -Force -SkipNetworkProfileCheck
 Write-Ok "PSRemoting enabled"
 
 # ── 2. Allow connections from the LAN (trusted hosts) ────────────────────────
-# Restrict to the 172.16.x.x subnet; adjust if your LAN differs.
-Write-Step "Setting trusted hosts to 172.16.*"
+# Restrict to your LAN subnet (from -LanSubnetWildcard / ABK_LAN_SUBNET_WILDCARD).
+Write-Step "Setting trusted hosts to $LanSubnetWildcard"
 $current = (Get-Item WSMan:\localhost\Client\TrustedHosts).Value
-$lanSubnet = "172.16.*"
+$lanSubnet = $LanSubnetWildcard
 if ($current -notlike "*$lanSubnet*") {
     $newValue = if ($current) { "$current,$lanSubnet" } else { $lanSubnet }
     Set-Item WSMan:\localhost\Client\TrustedHosts -Value $newValue -Force
@@ -55,9 +77,9 @@ if (-not $existing) {
         -Direction     Inbound `
         -Protocol      TCP `
         -LocalPort     5985 `
-        -RemoteAddress "172.16.0.0/16" `
+        -RemoteAddress $LanSubnetCidr `
         -Action        Allow | Out-Null
-    Write-Ok "Firewall rule created (172.16.0.0/16 → TCP 5985)"
+    Write-Ok "Firewall rule created ($LanSubnetCidr → TCP 5985)"
 } else {
     Enable-NetFirewallRule -Name $ruleName
     Write-Ok "Firewall rule already exists (enabled)"
@@ -74,9 +96,9 @@ if (-not $w8000) {
         -Direction     Inbound `
         -Protocol      TCP `
         -LocalPort     8000 `
-        -RemoteAddress "172.16.0.0/16" `
+        -RemoteAddress $LanSubnetCidr `
         -Action        Allow | Out-Null
-    Write-Ok "Firewall rule created (172.16.0.0/16 → TCP 8000)"
+    Write-Ok "Firewall rule created ($LanSubnetCidr → TCP 8000)"
 } else {
     Write-Ok "Whisper Server firewall rule already exists"
 }
@@ -91,4 +113,4 @@ Write-Host "Then deploy whisper_server.py and restart:"
 Write-Host "  pwsh scripts/manage-whisper-server.ps1 -Deploy -Restart"
 Write-Host ""
 Write-Host "Or just run a quick command:"
-Write-Host '  pwsh -Command "Invoke-Command -ComputerName 172.16.3.22 -Credential (Get-Credential) -ScriptBlock { whoami }"'
+Write-Host '  pwsh -Command "Invoke-Command -ComputerName <windows-gpu-host> -Credential (Get-Credential) -ScriptBlock { whoami }"'

--- a/scripts/transcribe_monitor.py
+++ b/scripts/transcribe_monitor.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # file: scripts/transcribe_monitor.py
-# version: 1.0.1
+# version: 1.1.0
 # guid: 2f7c4a91-8b03-4d6e-9a52-1c6e8f0b3d47
-# last-edited: 2026-06-30
+# last-edited: 2026-07-17
 """Transcription progress monitor + alerter.
 
 Polls the audiobook-organizer transcribe-stats aggregate
@@ -34,8 +34,11 @@ Examples:
   # continuous, poll every 30s, alert + auto-relaunch when idle
   python3 transcribe_monitor.py --interval 30 --relaunch
 
-  # against prod explicitly
-  python3 transcribe_monitor.py --base https://172.16.2.30:8484 --insecure
+  # against a specific server explicitly
+  python3 transcribe_monitor.py --base https://<server>:8484 --insecure
+
+The API base URL is required: pass --base or set the ABK_API_URL environment
+variable (ABK_BASE is also honored for backward compatibility).
 """
 
 import argparse
@@ -262,12 +265,16 @@ def _try_relaunch(args, token, state, record):
 
 def main():
     ap = argparse.ArgumentParser(description="Transcription progress monitor + alerter")
-    ap.add_argument("--base", default=os.environ.get("ABK_BASE", "https://172.16.2.30:8484"),
-                    help="API base URL (default https://172.16.2.30:8484)")
+    ap.add_argument("--base",
+                    default=os.environ.get("ABK_API_URL", os.environ.get("ABK_BASE")),
+                    help="API base URL, e.g. https://<server>:8484 "
+                         "(required; defaults to $ABK_API_URL, then $ABK_BASE)")
     ap.add_argument("--token-file", default=os.environ.get("ABK_TOKEN_FILE", ".api-token"),
                     help="file with 'api_key=abk_...' (default ./.api-token)")
-    ap.add_argument("--whisper-url", default=os.environ.get("WHISPER_URL", "http://172.16.3.22:19847"),
-                    help="Whisper server base for /health check ('' to skip)")
+    ap.add_argument("--whisper-url", default=os.environ.get("WHISPER_URL", ""),
+                    help="Whisper server base for /health check, e.g. "
+                         "http://<whisper-host>:19847 (defaults to $WHISPER_URL; "
+                         "'' skips the check)")
     ap.add_argument("--interval", type=int, default=30, help="poll interval seconds (default 30)")
     ap.add_argument("--stall-secs", type=int, default=300,
                     help="alert if in-flight counters unchanged this long (default 300)")
@@ -285,6 +292,10 @@ def main():
                          "Off by default to avoid silently disabling verification.")
     ap.add_argument("--once", action="store_true", help="run a single poll and exit")
     args = ap.parse_args()
+
+    if not args.base:
+        ap.error("--base is required (or set the ABK_API_URL environment variable "
+                 "to your server URL, e.g. https://<server>:8484)")
 
     token = read_token(args.token_file)
     state = {}


### PR DESCRIPTION
## Summary
DevOps hygiene fixes (devops findings 1-5,8,9 from docs/audits/2026-07-17-multi-discipline-review.md):
- Internal IPs removed from shipped CLI help (cmd/dedup_bench.go) and 3 scripts — all now require ABK_API_URL/params with clear errors, no internal defaults (self-check: 0 added IP lines, 15 removed)
- Pre-commit hook: --git-common-dir fix (hook installed from a linked worktree previously NEVER fired — live-proven), plus staged-content scan blocking added API tokens and internal-IP literals (live-tested: fake token/IP/credential-file commits all blocked)
- Makefile.local.example deploy now mirrors the real build chain (web-build + fts5/native_taglib/musl tags), adds origin-freshness pre-flight and post-deploy version verification
- binary-smoke.yml now builds and boots the embed_frontend binary pre-merge (SPA probe on /), SHA-pinned

Known follow-up (documented in PR, not in scope): 8 additional scripts still contain internal IPs; the new hook blocks new additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65