### PR TITLE
fix(itunes): deferred ITL fixes marked applied only when actually written; blocked-hash delete verified; multi-file rollback fails loud

### DIFF
--- a/internal/itunes/itl.go
+++ b/internal/itunes/itl.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/itl.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 7f2a8b3c-4d5e-6f01-a2b3-c4d5e6f7a8b9
-// last-edited: 2026-06-10
+// last-edited: 2026-07-17
 
 package itunes
 
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	osexec "os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -95,6 +96,12 @@ type ITLWriteBackResult struct {
 	UpdatedCount int
 	BackupPath   string
 	OutputPath   string
+	// UpdatedPersistentIDs lists the (lowercased hex) persistent IDs whose
+	// location blocks were actually rewritten. Populated by
+	// UpdateITLLocations only; callers use it to mark per-row bookkeeping
+	// (e.g. deferred-update rows) applied ONLY for rows really written
+	// (DL-5) — a requested PID absent from the ITL never appears here.
+	UpdatedPersistentIDs []string
 }
 
 // ITLNewTrack describes a track to insert into an ITL file.
@@ -554,7 +561,15 @@ func walkChunksLE(data []byte, lib *ITLLibrary) {
 
 // rewriteChunksLE dispatches to the LE implementation in itl_le.go.
 func rewriteChunksLE(data []byte, updateMap map[string]string) ([]byte, int) {
-	return rewriteChunksLEImpl(data, updateMap)
+	return rewriteChunksLEMatched(data, updateMap, nil)
+}
+
+// rewriteChunksLEMatched is rewriteChunksLE plus per-PID accounting: when
+// matched is non-nil, every persistent ID (lowercased hex) whose location
+// block was actually rewritten is recorded into it. Lets callers
+// distinguish "requested" from "actually written" PIDs (DL-5).
+func rewriteChunksLEMatched(data []byte, updateMap map[string]string, matched map[string]bool) ([]byte, int) {
+	return rewriteChunksLEImpl(data, updateMap, matched)
 }
 
 // ---------------------------------------------------------------------------
@@ -696,12 +711,25 @@ func UpdateITLLocations(inputPath, outputPath string, updates []ITLLocationUpdat
 	// regeneration (CRIT-3) + the full ITLSafetyContract + BE refusal all happen
 	// inside the SafeWriteITL chokepoint (TASK-004) — no direct writeITLFile here.
 	updatedCount := 0
+	matched := make(map[string]bool, len(updates))
 	mutate := func(decompressed []byte) ([]byte, error) {
 		var newData []byte
-		newData, updatedCount = rewriteChunksLE(decompressed, updateMap)
+		newData, updatedCount = rewriteChunksLEMatched(decompressed, updateMap, matched)
 		return newData, nil
 	}
-	return safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &updatedCount)
+	result, err := safeWriteOrEncodeToFile(inputPath, outputPath, mutate, &updatedCount)
+	if err != nil {
+		return nil, err
+	}
+	// Surface which requested PIDs were actually rewritten (DL-5): callers
+	// must not mark bookkeeping applied for PIDs that never matched a
+	// location block in this ITL.
+	result.UpdatedPersistentIDs = make([]string, 0, len(matched))
+	for pid := range matched {
+		result.UpdatedPersistentIDs = append(result.UpdatedPersistentIDs, pid)
+	}
+	sort.Strings(result.UpdatedPersistentIDs)
+	return result, nil
 }
 
 // safeWriteOrEncodeToFile routes an itl.go writeback entry point through the

--- a/internal/itunes/itl_le.go
+++ b/internal/itunes/itl_le.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/itl_le.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: b4e8d927-6c3f-4a81-9e02-f7b3c8d4e56a
+// last-edited: 2026-07-17
 
 package itunes
 
@@ -448,7 +449,9 @@ func parsePlaylistMhohLE(data []byte, offset, length int, playlist *ITLPlaylist)
 // ---------------------------------------------------------------------------
 
 // rewriteChunksLEImpl walks msdh containers and rewrites location mhoh blocks.
-func rewriteChunksLEImpl(data []byte, updateMap map[string]string) ([]byte, int) {
+// matched, when non-nil, receives the lowercased persistent ID of every track
+// whose location block was actually rewritten (DL-5 per-row accounting).
+func rewriteChunksLEImpl(data []byte, updateMap map[string]string, matched map[string]bool) ([]byte, int) {
 	var out bytes.Buffer
 	offset := 0
 	updatedCount := 0
@@ -474,7 +477,7 @@ func rewriteChunksLEImpl(data []byte, updateMap map[string]string) ([]byte, int)
 			// Track-list container: rewrite sub-chunks
 			msdh := data[offset : offset+totalLen]
 			var currentPID string
-			rewritten, cnt := rewriteMsdhContentLE(msdh, updateMap, &currentPID)
+			rewritten, cnt := rewriteMsdhContentLE(msdh, updateMap, &currentPID, matched)
 			out.Write(rewritten)
 			updatedCount += cnt
 		} else {
@@ -488,8 +491,16 @@ func rewriteChunksLEImpl(data []byte, updateMap map[string]string) ([]byte, int)
 	return out.Bytes(), updatedCount
 }
 
+// recordMatchedPID marks pid (already lowercased) as actually rewritten in
+// matched, when the caller asked for per-PID accounting (DL-5).
+func recordMatchedPID(matched map[string]bool, pid string) {
+	if matched != nil && pid != "" {
+		matched[pid] = true
+	}
+}
+
 // rewriteMsdhContentLE rewrites mith/mhoh content inside an msdh container.
-func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *string) ([]byte, int) {
+func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *string, matched map[string]bool) ([]byte, int) {
 	if len(msdh) < 16 {
 		return msdh, 0
 	}
@@ -532,7 +543,7 @@ func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *
 			// Track item array wrapper — contains mith + mhoh sub-blocks
 			// We need to descend into it and rewrite its content
 			miahData := msdh[subOffset : subOffset+chunkLen]
-			rewritten, cnt := rewriteMiahContentLE(miahData, updateMap, currentPID)
+			rewritten, cnt := rewriteMiahContentLE(miahData, updateMap, currentPID, matched)
 			out.Write(rewritten)
 			updatedCount += cnt
 			trackCount++
@@ -546,7 +557,7 @@ func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *
 			}
 			// Walk mhoh sub-blocks inside this mith
 			mithData := msdh[subOffset : subOffset+chunkLen]
-			rewritten, cnt := rewriteMithContentLE(mithData, updateMap, *currentPID)
+			rewritten, cnt := rewriteMithContentLE(mithData, updateMap, *currentPID, matched)
 			out.Write(rewritten)
 			updatedCount += cnt
 
@@ -555,6 +566,7 @@ func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *
 				rewritten := rewriteHohmLocationLE(msdh, subOffset, chunkLen, newLoc)
 				out.Write(rewritten)
 				updatedCount++
+				recordMatchedPID(matched, *currentPID)
 			} else {
 				out.Write(msdh[subOffset : subOffset+chunkLen])
 			}
@@ -581,7 +593,7 @@ func rewriteMsdhContentLE(msdh []byte, updateMap map[string]string, currentPID *
 
 // rewriteMiahContentLE walks mith + mhoh blocks inside a miah (track item array) wrapper.
 // miah layout: tag(4) + headerLen(4) + totalLen(4) + ... then sub-blocks
-func rewriteMiahContentLE(miah []byte, updateMap map[string]string, currentPID *string) ([]byte, int) {
+func rewriteMiahContentLE(miah []byte, updateMap map[string]string, currentPID *string, matched map[string]bool) ([]byte, int) {
 	if len(miah) < 12 {
 		return miah, 0
 	}
@@ -624,6 +636,7 @@ func rewriteMiahContentLE(miah []byte, updateMap map[string]string, currentPID *
 				rewritten := rewriteHohmLocationLE(miah, subOffset, chunkLen, newLoc)
 				out.Write(rewritten)
 				updatedCount++
+				recordMatchedPID(matched, *currentPID)
 			} else {
 				out.Write(miah[subOffset : subOffset+chunkLen])
 			}
@@ -650,7 +663,7 @@ func rewriteMiahContentLE(miah []byte, updateMap map[string]string, currentPID *
 }
 
 // rewriteMithContentLE walks mhoh sub-blocks inside a mith container and rewrites locations.
-func rewriteMithContentLE(mith []byte, updateMap map[string]string, currentPID string) ([]byte, int) {
+func rewriteMithContentLE(mith []byte, updateMap map[string]string, currentPID string, matched map[string]bool) ([]byte, int) {
 	if len(mith) < 12 {
 		return mith, 0
 	}
@@ -685,6 +698,7 @@ func rewriteMithContentLE(mith []byte, updateMap map[string]string, currentPID s
 				rewritten := rewriteHohmLocationLE(mith, subOffset, chunkLen, newLoc)
 				out.Write(rewritten)
 				updatedCount++
+				recordMatchedPID(matched, currentPID)
 			} else {
 				out.Write(mith[subOffset : subOffset+chunkLen])
 			}

--- a/internal/itunes/itl_le_test.go
+++ b/internal/itunes/itl_le_test.go
@@ -219,9 +219,14 @@ func TestRewriteChunksLE_UpdatesLocation(t *testing.T) {
 		"aabbccddeeff1122": newLocation,
 	}
 
-	rewritten, count := rewriteChunksLEImpl(data, updateMap)
+	matched := map[string]bool{}
+	rewritten, count := rewriteChunksLEImpl(data, updateMap, matched)
 	if count != 1 {
 		t.Fatalf("expected 1 update, got %d", count)
+	}
+	// DL-5: the per-PID accounting must record exactly the rewritten PID.
+	if len(matched) != 1 || !matched["aabbccddeeff1122"] {
+		t.Fatalf("expected matched map to record aabbccddeeff1122, got %v", matched)
 	}
 
 	// Parse the rewritten data to verify
@@ -342,9 +347,14 @@ func TestRewriteChunksLE_NoMatchReturnsUnchanged(t *testing.T) {
 		"0000000000000000": "/new/path.m4b",
 	}
 
-	rewritten, count := rewriteChunksLEImpl(data, updateMap)
+	matched := map[string]bool{}
+	rewritten, count := rewriteChunksLEImpl(data, updateMap, matched)
 	if count != 0 {
 		t.Fatalf("expected 0 updates, got %d", count)
+	}
+	// DL-5: no rewrite → no PID recorded.
+	if len(matched) != 0 {
+		t.Fatalf("expected empty matched map, got %v", matched)
 	}
 
 	// Parse and verify location unchanged
@@ -374,7 +384,7 @@ func TestRewriteChunksLE_LocalURLUpdate(t *testing.T) {
 		"aabbccddeeff1122": `W:\new\path.m4b`,
 	}
 
-	rewritten, count := rewriteChunksLEImpl(data, updateMap)
+	rewritten, count := rewriteChunksLEImpl(data, updateMap, nil)
 	if count != 1 {
 		t.Fatalf("expected 1 update, got %d", count)
 	}
@@ -711,7 +721,7 @@ func TestRewriteMithContentLE(t *testing.T) {
 	}
 
 	// Invoke the function under test.
-	rewritten, count := rewriteMithContentLE(mithContainer, updateMap, currentPID)
+	rewritten, count := rewriteMithContentLE(mithContainer, updateMap, currentPID, nil)
 	if count != 1 {
 		t.Fatalf("expected 1 rewrite, got %d", count)
 	}

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.12.2
+// version: 1.13.0
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-16
+// last-edited: 2026-07-17
 
 package itunesservice
 
@@ -104,6 +104,15 @@ type Importer struct {
 	// seam purpose as organizeConcurrencyOverride: lets a test force the
 	// sequential path (1) and diff it against a parallel path.
 	enrichConcurrencyOverride int
+
+	// itlUpdateFn / itlRenameFn are test seams for the deferred ITL
+	// location-fix application (applyDeferredITunesUpdates, DL-5). Nil —
+	// the default for every real Importer — means the real
+	// itunes.UpdateITLLocations / itunes.RenameITLFile. Tests inject
+	// fakes so the applied-vs-pending bookkeeping can be exercised
+	// without a real binary ITL fixture.
+	itlUpdateFn func(inputPath, outputPath string, updates []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error)
+	itlRenameFn func(oldPath, newPath string) error
 }
 
 // metadataFetcher is the narrow, single-method subset of *metafetch.Service
@@ -312,14 +321,25 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 			}
 			trackNum := albumTrack.TrackNumber
 			trackLoc := importOpts.RemapPath(albumTrack.Location)
-			trackPath, _ := itunes.DecodeLocation(trackLoc)
-			_ = imp.store.CreateExternalIDMapping(&database.ExternalIDMapping{
+			trackPath, decErr := itunes.DecodeLocation(trackLoc)
+			if decErr != nil {
+				// M5: still create the mapping (PID linkage matters even
+				// without a path), but count + surface the malformed location.
+				incImportMalformedLocation(status)
+				log.Warn("Malformed iTunes location for track %d of '%s' (pid=%s): %v", trackNum, book.Title, albumTrack.PersistentID, decErr)
+			}
+			if mapErr := imp.store.CreateExternalIDMapping(&database.ExternalIDMapping{
 				Source:      "itunes",
 				ExternalID:  albumTrack.PersistentID,
 				BookID:      created.ID,
 				TrackNumber: &trackNum,
 				FilePath:    trackPath,
-			})
+			}); mapErr != nil {
+				// M5: a silently dropped mapping means the next sync can't
+				// match this track by PID — count it and say so.
+				incImportMappingError(status)
+				log.Warn("Failed to create iTunes external-ID mapping for '%s' (pid=%s, track %d): %v", book.Title, albumTrack.PersistentID, trackNum, mapErr)
+			}
 		}
 
 		if len(group.tracks) > 1 {
@@ -328,6 +348,10 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 				trackLoc := importOpts.RemapPath(track.Location)
 				trackPath, decErr := itunes.DecodeLocation(trackLoc)
 				if decErr != nil {
+					// M5: a skipped segment here silently loses a book_files
+					// row for a multi-file book — count + log it.
+					incImportMalformedLocation(status)
+					log.Warn("Skipping book file for track %d of '%s': undecodable iTunes location: %v", track.TrackNumber, book.Title, decErr)
 					continue
 				}
 				trackFormat := strings.TrimPrefix(strings.ToLower(filepath.Ext(trackPath)), ".")
@@ -355,11 +379,19 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 			for i := range book.Authors {
 				book.Authors[i].BookID = created.ID
 			}
-			_ = imp.store.SetBookAuthors(created.ID, book.Authors)
+			if saErr := imp.store.SetBookAuthors(created.ID, book.Authors); saErr != nil {
+				// M5: a dropped author link leaves the book unattributed —
+				// count + log instead of swallowing.
+				incImportAuthorSetError(status)
+				log.Warn("Failed to set %d author(s) on '%s' (%s): %v", len(book.Authors), book.Title, created.ID, saErr)
+			}
 		} else if created.AuthorID != nil {
-			_ = imp.store.SetBookAuthors(created.ID, []database.BookAuthor{
+			if saErr := imp.store.SetBookAuthors(created.ID, []database.BookAuthor{
 				{BookID: created.ID, AuthorID: *created.AuthorID, Role: "author", Position: 0},
-			})
+			}); saErr != nil {
+				incImportAuthorSetError(status)
+				log.Warn("Failed to set primary author on '%s' (%s): %v", book.Title, created.ID, saErr)
+			}
 		}
 
 		if req.ImportPlaylists {
@@ -388,6 +420,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 
 		hashLinked := 0
 		hashBlocked := 0
+		hashBlockFailed := 0
 		for hi, bookID := range newBookIDs {
 			if log.IsCanceled() {
 				log.Info("Hash validation canceled")
@@ -415,13 +448,14 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 			}
 
 			if blocked, err := imp.store.IsHashBlocked(hash); err == nil && blocked {
-				log.Warn("Hash validation: blocked hash for %s, soft-deleting", book.Title)
-				marked := true
-				now := time.Now()
-				book.MarkedForDeletion = &marked
-				book.MarkedForDeletionAt = &now
-				imp.store.UpdateBook(book.ID, book)
-				hashBlocked++
+				// C-6: only count (and claim) the soft-delete if the write
+				// actually landed — the sibling UpdateBook at the end of this
+				// loop checks its returns; this one must too.
+				if imp.softDeleteBlockedBook(book, log) {
+					hashBlocked++
+				} else {
+					hashBlockFailed++
+				}
 				continue
 			}
 
@@ -445,7 +479,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 				log.UpdateProgress(totalGroups, totalGroups, msg)
 			}
 		}
-		log.Info("Hash validation completed: %d linked, %d blocked out of %d new books", hashLinked, hashBlocked, len(newBookIDs))
+		log.Info("Hash validation completed: %d linked, %d blocked, %d blocked-but-soft-delete-failed out of %d new books", hashLinked, hashBlocked, hashBlockFailed, len(newBookIDs))
 	}
 
 	// Phase 4: Metadata enrichment
@@ -475,6 +509,125 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 	return nil
 }
 
+// softDeleteBlockedBook marks a blocked-hash book as MarkedForDeletion and
+// persists it, returning true only if the write actually landed (C-6). book
+// must be a full-fidelity row (Execute's hash-validation loop hydrates via
+// GetBookByID) so the write-back never persists a slim struct.
+func (imp *Importer) softDeleteBlockedBook(book *database.Book, log logger.Logger) bool {
+	marked := true
+	now := time.Now()
+	book.MarkedForDeletion = &marked
+	book.MarkedForDeletionAt = &now
+	if _, err := imp.store.UpdateBook(book.ID, book); err != nil {
+		log.Warn("Hash validation: blocked hash for '%s' (%s) but soft-delete write FAILED — book stays live: %v", book.Title, book.ID, err)
+		return false
+	}
+	log.Warn("Hash validation: blocked hash for '%s', soft-deleted", book.Title)
+	return true
+}
+
+// applyDeferredITunesUpdates applies pending deferred ITL location fixes
+// (accumulated while write-back was disabled) to the ITL file, then marks
+// applied ONLY the rows whose persistent IDs were actually rewritten in
+// the file (DL-5). Every other row stays pending and retries on the next
+// sync:
+//   - rows whose NewPath fails normalizeITunesLocation (WARN + metric
+//     logged there — CRIT-2) are never sent to the writer;
+//   - rows whose PID matched no location block in the ITL are reported
+//     via ITLWriteBackResult.UpdatedPersistentIDs and left pending;
+//   - a write error or a RenameITLFile failure commits nothing, so the
+//     whole batch stays pending (the .tmp is kept on rename failure per
+//     RenameITLFile's contract, for manual recovery).
+//
+// "Pending" = DeferredITunesUpdate.AppliedAt == nil (see
+// GetPendingDeferredITunesUpdates); MarkDeferredITunesUpdateApplied stamps
+// AppliedAt, permanently retiring the row — which is exactly why it must
+// only ever be called for rows really written to the ITL.
+func (imp *Importer) applyDeferredITunesUpdates(log logger.Logger) {
+	if !imp.cfg.ITLWriteBackEnabled || imp.cfg.LibraryWritePath == "" {
+		return
+	}
+	pending, pendErr := imp.store.GetPendingDeferredITunesUpdates()
+	if pendErr != nil {
+		log.Warn("Failed to load pending deferred iTunes updates: %v", pendErr)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	// TASK-006: normalize each deferred NewPath into the canonical WinPath
+	// (the LE writer derives the 0x0B URL). Unmappable values are skipped
+	// with a WARN + metric, never written raw (CRIT-2) — and stay pending
+	// rather than being falsely marked applied (DL-5).
+	updates := make([]itunes.ITLLocationUpdate, 0, len(pending))
+	included := make([]database.DeferredITunesUpdate, 0, len(pending))
+	for _, p := range pending {
+		if winPath, ok := normalizeITunesLocation(p.PersistentID, p.NewPath); ok {
+			updates = append(updates, itunes.ITLLocationUpdate{PersistentID: p.PersistentID, NewLocation: winPath})
+			included = append(included, p)
+		}
+	}
+	if len(updates) == 0 {
+		log.Warn("Deferred iTunes updates: 0 of %d pending rows normalized to a writable location; all stay pending", len(pending))
+		return
+	}
+
+	updateFn := imp.itlUpdateFn
+	if updateFn == nil {
+		updateFn = itunes.UpdateITLLocations
+	}
+	renameFn := imp.itlRenameFn
+	if renameFn == nil {
+		renameFn = itunes.RenameITLFile
+	}
+
+	itlPath := imp.cfg.LibraryWritePath
+	tmpPath := itlPath + ".deferred-update.tmp"
+	result, itlErr := updateFn(itlPath, tmpPath, updates)
+	if itlErr != nil {
+		log.Warn("Failed to apply deferred iTunes updates: %v — all %d rows stay pending", itlErr, len(pending))
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if result.UpdatedCount == 0 {
+		log.Warn("Deferred iTunes updates: none of %d normalized PIDs matched a track location in the ITL; all %d rows stay pending", len(updates), len(pending))
+		_ = os.Remove(tmpPath)
+		return
+	}
+	if renameErr := renameFn(tmpPath, itlPath); renameErr != nil {
+		// The real ITL was never replaced — nothing committed. Keep the .tmp
+		// (RenameITLFile's contract: left for manual recovery/retry) and keep
+		// every row pending for the next sync (DL-5).
+		log.Error("Deferred iTunes updates: wrote %d location fixes to %s but rename into place failed: %v — all %d rows stay pending", result.UpdatedCount, tmpPath, renameErr, len(pending))
+		return
+	}
+
+	written := make(map[string]bool, len(result.UpdatedPersistentIDs))
+	for _, pid := range result.UpdatedPersistentIDs {
+		written[strings.ToLower(pid)] = true
+	}
+	applied, markFailed, notInITL := 0, 0, 0
+	for _, p := range included {
+		if !written[strings.ToLower(p.PersistentID)] {
+			// PID absent from the ITL (track removed / never present):
+			// stays pending so a future ITL that contains it gets fixed.
+			notInITL++
+			continue
+		}
+		if markErr := imp.store.MarkDeferredITunesUpdateApplied(p.ID); markErr != nil {
+			// Row WAS written to the ITL; a failed mark means it will be
+			// re-applied (idempotently) next sync — safe, but log it.
+			markFailed++
+			log.Warn("Deferred iTunes update %d (pid=%s) written to ITL but failed to mark applied (will re-apply next sync): %v", p.ID, p.PersistentID, markErr)
+			continue
+		}
+		applied++
+	}
+	log.Info("Applied %d deferred iTunes updates: %d rows marked applied, %d mark failures, %d PIDs not in ITL, %d unmappable (unmarked rows stay pending)",
+		result.UpdatedCount, applied, markFailed, notInITL, len(pending)-len(included))
+}
+
 // Sync performs an incremental sync from the iTunes library XML.
 func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings []itunes.PathMapping, activityFn func(database.ActivityEntry), log logger.Logger) error {
 	log.UpdateProgress(0, 0, "Parsing iTunes library XML...")
@@ -498,33 +651,7 @@ func (imp *Importer) Sync(ctx context.Context, libraryPath string, pathMappings 
 	}
 
 	// Apply deferred iTunes updates before sync
-	if imp.cfg.ITLWriteBackEnabled && imp.cfg.LibraryWritePath != "" {
-		pending, _ := imp.store.GetPendingDeferredITunesUpdates()
-		if len(pending) > 0 {
-			// TASK-006: normalize each deferred NewPath into the canonical WinPath
-			// (the LE writer derives the 0x0B URL). Unmappable values are skipped
-			// with a WARN + metric, never written raw (CRIT-2).
-			updates := make([]itunes.ITLLocationUpdate, 0, len(pending))
-			for _, p := range pending {
-				if winPath, ok := normalizeITunesLocation(p.PersistentID, p.NewPath); ok {
-					updates = append(updates, itunes.ITLLocationUpdate{PersistentID: p.PersistentID, NewLocation: winPath})
-				}
-			}
-			itlPath := imp.cfg.LibraryWritePath
-			tmpPath := itlPath + ".deferred-update.tmp"
-			result, itlErr := itunes.UpdateITLLocations(itlPath, tmpPath, updates)
-			if itlErr == nil && result.UpdatedCount > 0 {
-				_ = itunes.RenameITLFile(tmpPath, itlPath)
-				for _, p := range pending {
-					_ = imp.store.MarkDeferredITunesUpdateApplied(p.ID)
-				}
-				log.Info("Applied %d deferred iTunes updates", result.UpdatedCount)
-			} else if itlErr != nil {
-				log.Warn("Failed to apply deferred iTunes updates: %v", itlErr)
-				_ = os.Remove(tmpPath)
-			}
-		}
-	}
+	imp.applyDeferredITunesUpdates(log)
 
 	importOpts := itunes.ImportOptions{
 		LibraryPath:  libraryPath,
@@ -1217,6 +1344,29 @@ func (imp *Importer) organizeImportedBooks(ctx context.Context, status *itunesIm
 
 		book.LibraryState = strPtr("organized")
 		if _, err := imp.store.UpdateBook(book.ID, book); err != nil {
+			if len(files) > 1 {
+				// C-7: a multi-file book got here via organizeMultiFileBook,
+				// which already MOVED each segment on disk and COMMITTED the
+				// matching per-file UpdateBookFile writes. Renaming the target
+				// directory back (the old single-file rollback) would strand
+				// those committed book_files rows pointing at paths that no
+				// longer exist — the segments were moved (and possibly
+				// renamed) individually, so a directory rename cannot restore
+				// them. The organized state on disk + book_files rows is
+				// self-consistent; only THIS Book row (FilePath/LibraryState)
+				// is stale. Don't touch the disk — fail loudly with a
+				// reconcile hint instead.
+				ids := make([]string, 0, len(files))
+				for _, f := range files {
+					ids = append(ids, f.ID)
+				}
+				msg := fmt.Sprintf(
+					"CRITICAL: UpdateBook failed after multi-file organize for '%s' (%s): %v — book row still points at %s but the segments and %d book_files rows moved to %s; reconcile book_file IDs: %s",
+					book.Title, book.ID, err, oldPath, len(files), book.FilePath, strings.Join(ids, ","))
+				log.Error("%s", msg)
+				recordImportFailure(status, msg)
+				return nil
+			}
 			log.Error("Failed to update organized path for '%s': %v — rolling back", book.Title, err)
 			if book.FilePath != oldPath {
 				if rbErr := os.Rename(book.FilePath, oldPath); rbErr != nil {
@@ -1646,6 +1796,10 @@ func (imp *Importer) commonParentDir(tracks []*itunes.Track, opts itunes.ImportO
 		location := opts.RemapPath(t.Location)
 		p, err := itunes.DecodeLocation(location)
 		if err != nil {
+			// M5: an undecodable location silently narrows the common-parent
+			// computation (and can mistitle/misplace the book) — say so.
+			slog.Warn("iTunes import: undecodable track location excluded from common-parent-dir computation",
+				"track", t.Name, "pid", t.PersistentID, "error", err)
 			continue
 		}
 		paths = append(paths, filepath.Dir(p))

--- a/internal/itunes/service/importer_integrity_test.go
+++ b/internal/itunes/service/importer_integrity_test.go
@@ -1,0 +1,253 @@
+// file: internal/itunes/service/importer_integrity_test.go
+// version: 1.0.0
+// guid: 9c1d7e2f-3a4b-4c5d-8e6f-0a1b2c3d4e5f
+// last-edited: 2026-07-17
+//
+// Integrity-finding regression tests from the 2026-07-17 multi-discipline
+// review:
+//   - DL-5: deferred ITL location-fix application must mark applied ONLY
+//     the rows actually written to the ITL, and a RenameITLFile failure
+//     must leave every row pending.
+//   - C-6: a blocked-hash soft-delete whose UpdateBook write fails must
+//     not be counted (or logged) as a successful deletion.
+//   - C-7: a failed UpdateBook after a multi-file organize must NOT rename
+//     the target directory back (the per-file rows are already committed);
+//     it must fail loudly with a reconcile hint listing the file IDs.
+
+package itunesservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// DL-5 — applyDeferredITunesUpdates applied-vs-pending bookkeeping
+// ---------------------------------------------------------------------------
+
+// w8DeferredFixture builds an Importer wired with fake ITL write/rename
+// seams and a mock store answering GetPendingDeferredITunesUpdates.
+// (w8 prefix: task-unique helper name per parallel-worker discipline.)
+func w8DeferredFixture(t *testing.T, m *dbmocks.MockStore, updateFn func(string, string, []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error), renameFn func(string, string) error) *Importer {
+	t.Helper()
+	return &Importer{
+		store: m,
+		cfg: Config{
+			ITLWriteBackEnabled: true,
+			LibraryWritePath:    filepath.Join(t.TempDir(), "iTunes Library.itl"),
+		},
+		itlUpdateFn: updateFn,
+		itlRenameFn: renameFn,
+	}
+}
+
+// w8PendingRows: row 1 normalizes and IS written; row 2 normalizes but its
+// PID never matches a location block in the ITL; row 3 fails normalization
+// (relative path — CRIT-2 unmappable).
+func w8PendingRows() []database.DeferredITunesUpdate {
+	return []database.DeferredITunesUpdate{
+		{ID: 1, BookID: "b1", PersistentID: "AABBCCDDEEFF0011", OldPath: `W:\Old\One.m4b`, NewPath: `W:\Audiobooks\One.m4b`, UpdateType: "location"},
+		{ID: 2, BookID: "b2", PersistentID: "1122334455667788", OldPath: `W:\Old\Two.m4b`, NewPath: `W:\Audiobooks\Two.m4b`, UpdateType: "location"},
+		{ID: 3, BookID: "b3", PersistentID: "99AABBCCDDEEFF00", OldPath: `W:\Old\Three.m4b`, NewPath: `relative-not-absolute.m4b`, UpdateType: "location"},
+	}
+}
+
+func TestApplyDeferredITunesUpdates_MarksOnlyRowsActuallyWritten(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetPendingDeferredITunesUpdates().Return(w8PendingRows(), nil)
+	// ONLY row 1 (the PID actually rewritten in the ITL) may be marked
+	// applied. Rows 2 (PID not in ITL) and 3 (unmappable) must stay
+	// pending — mockery fails the test on any unexpected Mark call.
+	m.EXPECT().MarkDeferredITunesUpdateApplied(1).Return(nil).Once()
+
+	var gotUpdates []itunes.ITLLocationUpdate
+	updateFn := func(_, _ string, updates []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error) {
+		gotUpdates = updates
+		return &itunes.ITLWriteBackResult{
+			UpdatedCount:         1,
+			UpdatedPersistentIDs: []string{"aabbccddeeff0011"},
+		}, nil
+	}
+	renamed := false
+	renameFn := func(_, _ string) error { renamed = true; return nil }
+
+	imp := w8DeferredFixture(t, m, updateFn, renameFn)
+	imp.applyDeferredITunesUpdates(logger.New("test-dl5-subset"))
+
+	require.True(t, renamed, "successful write must be renamed into place")
+	// The unmappable row 3 must never reach the ITL writer (CRIT-2).
+	require.Len(t, gotUpdates, 2, "only normalizable rows may be sent to the ITL writer")
+	pids := []string{gotUpdates[0].PersistentID, gotUpdates[1].PersistentID}
+	assert.ElementsMatch(t, []string{"AABBCCDDEEFF0011", "1122334455667788"}, pids)
+}
+
+func TestApplyDeferredITunesUpdates_RenameFailureKeepsAllRowsPending(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetPendingDeferredITunesUpdates().Return(w8PendingRows(), nil)
+	// No MarkDeferredITunesUpdateApplied expectation: ANY mark call after a
+	// rename failure is the DL-5 divergence bug and fails the test.
+
+	updateFn := func(_, _ string, updates []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error) {
+		return &itunes.ITLWriteBackResult{
+			UpdatedCount:         2,
+			UpdatedPersistentIDs: []string{"aabbccddeeff0011", "1122334455667788"},
+		}, nil
+	}
+	renameFn := func(_, _ string) error { return errors.New("target locked by iTunes") }
+
+	imp := w8DeferredFixture(t, m, updateFn, renameFn)
+	imp.applyDeferredITunesUpdates(logger.New("test-dl5-rename"))
+}
+
+func TestApplyDeferredITunesUpdates_WriteErrorKeepsAllRowsPending(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetPendingDeferredITunesUpdates().Return(w8PendingRows(), nil)
+	// No mark calls allowed on a write error either.
+
+	updateFn := func(_, _ string, _ []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error) {
+		return nil, errors.New("ITL corrupt")
+	}
+	renameFn := func(_, _ string) error {
+		t.Fatal("rename must not be attempted after a write error")
+		return nil
+	}
+
+	imp := w8DeferredFixture(t, m, updateFn, renameFn)
+	imp.applyDeferredITunesUpdates(logger.New("test-dl5-writeerr"))
+}
+
+func TestApplyDeferredITunesUpdates_MarkErrorIsLoggedNotFatal(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetPendingDeferredITunesUpdates().Return(w8PendingRows()[:1], nil)
+	m.EXPECT().MarkDeferredITunesUpdateApplied(1).Return(errors.New("pebble closed")).Once()
+
+	updateFn := func(_, _ string, _ []itunes.ITLLocationUpdate) (*itunes.ITLWriteBackResult, error) {
+		return &itunes.ITLWriteBackResult{
+			UpdatedCount:         1,
+			UpdatedPersistentIDs: []string{"aabbccddeeff0011"},
+		}, nil
+	}
+	renameFn := func(_, _ string) error { return nil }
+
+	imp := w8DeferredFixture(t, m, updateFn, renameFn)
+	// Must not panic; the row simply stays pending and re-applies next sync.
+	imp.applyDeferredITunesUpdates(logger.New("test-dl5-markerr"))
+}
+
+// ---------------------------------------------------------------------------
+// C-6 — blocked-hash soft-delete must check UpdateBook's returns
+// ---------------------------------------------------------------------------
+
+func TestSoftDeleteBlockedBook_WriteLands_ReturnsTrue(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().UpdateBook("blk-1", mock.Anything).Run(func(_ string, book *database.Book) {
+		require.NotNil(t, book.MarkedForDeletion)
+		assert.True(t, *book.MarkedForDeletion)
+		assert.NotNil(t, book.MarkedForDeletionAt)
+	}).Return(&database.Book{}, nil).Once()
+
+	imp := &Importer{store: m}
+	book := &database.Book{ID: "blk-1", Title: "Blocked Book"}
+	assert.True(t, imp.softDeleteBlockedBook(book, logger.New("test-c6-ok")))
+}
+
+func TestSoftDeleteBlockedBook_WriteFails_ReturnsFalse(t *testing.T) {
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().UpdateBook("blk-2", mock.Anything).Return(nil, errors.New("write failed")).Once()
+
+	imp := &Importer{store: m}
+	book := &database.Book{ID: "blk-2", Title: "Blocked Book Two"}
+	// C-6: the caller must NOT count this as a successful soft-delete.
+	assert.False(t, imp.softDeleteBlockedBook(book, logger.New("test-c6-fail")))
+}
+
+// ---------------------------------------------------------------------------
+// C-7 — multi-file organize + failed UpdateBook → loud reconcile, no dir rename
+// ---------------------------------------------------------------------------
+
+// w8MultiFileOrganizer is a BookOrganizer double whose directory organize
+// succeeds with a fixed path map. OrganizeBook must never be called for a
+// multi-file book.
+type w8MultiFileOrganizer struct {
+	mu       sync.Mutex
+	dirCalls int
+}
+
+func (o *w8MultiFileOrganizer) OrganizeBook(book *database.Book) (string, string, error) {
+	return "", "", fmt.Errorf("OrganizeBook must not be called for a multi-file book")
+}
+
+func (o *w8MultiFileOrganizer) OrganizeBookDirectory(book *database.Book, segmentPaths []string) (string, map[string]string, error) {
+	o.mu.Lock()
+	o.dirCalls++
+	o.mu.Unlock()
+	pathMap := make(map[string]string, len(segmentPaths))
+	for _, p := range segmentPaths {
+		pathMap[p] = "/organized/Multi Book/" + filepath.Base(p)
+	}
+	return "/organized/Multi Book", pathMap, nil
+}
+
+var _ BookOrganizer = (*w8MultiFileOrganizer)(nil)
+
+func TestOrganizeImportedBooks_MultiFileUpdateBookFailure_ReconcileHintNoDirRollback(t *testing.T) {
+	imported := "imported"
+	src := "/mnt/itunes/Library.xml"
+	book := database.Book{
+		ID:                 "mfb-1",
+		Title:              "Multi Book",
+		FilePath:           "/old/common",
+		LibraryState:       &imported,
+		ITunesImportSource: &src,
+	}
+	files := []database.BookFile{
+		{ID: "bf-1", BookID: "mfb-1", FilePath: "/old/common/a.m4b"},
+		{ID: "bf-2", BookID: "mfb-1", FilePath: "/old/common/b.m4b"},
+	}
+
+	m := dbmocks.NewMockStore(t)
+	m.EXPECT().GetAllBooksCore(0, 0).Return([]database.BookCore{book.Core()}, nil)
+	b := book
+	m.EXPECT().GetBookByID("mfb-1").Return(&b, nil)
+	m.EXPECT().GetBookFiles("mfb-1").Return(files, nil)
+	// organizeMultiFileBook commits the per-file rows BEFORE the Book write.
+	m.EXPECT().UpdateBookFile("bf-1", mock.Anything).Return(nil).Once()
+	m.EXPECT().UpdateBookFile("bf-2", mock.Anything).Return(nil).Once()
+	// The Book write fails → the C-7 branch under test.
+	m.EXPECT().UpdateBook("mfb-1", mock.Anything).Return(nil, errors.New("pebble write stall")).Once()
+
+	org := &w8MultiFileOrganizer{}
+	imp := &Importer{
+		store:                       m,
+		organizerFactory:            func() BookOrganizer { return org },
+		organizeConcurrencyOverride: 1,
+	}
+	status := &itunesImportStatus{}
+	imp.organizeImportedBooks(context.Background(), status, logger.New("test-c7"))
+
+	require.Equal(t, 1, org.dirCalls, "multi-file book must route through OrganizeBookDirectory")
+	require.Equal(t, 1, status.Failed, "the UpdateBook failure must be recorded as a failure")
+	require.NotEmpty(t, status.Errors)
+	msg := status.Errors[0]
+	// The reconcile hint must name every committed book_file row and both
+	// path sides of the divergence.
+	assert.Contains(t, msg, "reconcile", "must carry a reconcile hint")
+	assert.Contains(t, msg, "bf-1")
+	assert.Contains(t, msg, "bf-2")
+	assert.Contains(t, msg, "/old/common", "must name the stale book-row path")
+	assert.Contains(t, msg, "/organized/Multi Book", "must name the committed organized path")
+	assert.True(t, strings.Contains(msg, "CRITICAL"), "must be loud: %s", msg)
+}

--- a/internal/itunes/service/path_repair.go
+++ b/internal/itunes/service/path_repair.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/path_repair.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 01ad6c79-5f3f-4ee1-a07a-1f4b3a8c0d12
-// last-edited: 2026-05-01
+// last-edited: 2026-07-17
 //
 // PathRepairer dumps the iTunes XML, finds tracks whose Location no
 // longer exists on disk, re-discovers the correct path via three tiers
@@ -95,12 +95,17 @@ func extractBookOrganizerID(audioFilePath string) (string, error) {
 // logs and the operation result. Field names mirror the dry-run JSON
 // payload that callers consume.
 type iTunesPathRepairResult struct {
-	XMLTracks        int               `json:"xml_tracks"`
-	Missing          int               `json:"missing"`
-	AutoResolved     int               `json:"auto_resolved"`
-	NeedsReview      int               `json:"needs_review"`
-	Unresolved       int               `json:"unresolved"`
-	Enqueued         int               `json:"enqueued"`
+	XMLTracks    int `json:"xml_tracks"`
+	Missing      int `json:"missing"`
+	AutoResolved int `json:"auto_resolved"`
+	NeedsReview  int `json:"needs_review"`
+	Unresolved   int `json:"unresolved"`
+	Enqueued     int `json:"enqueued"`
+	// Undecodable counts audiobook tracks whose iTunes Location could not
+	// be decoded at all (M6) — these are skipped before the missing-file
+	// check, so without this counter they'd vanish from the report even
+	// though their on-disk state is unknown.
+	Undecodable      int               `json:"undecodable"`
 	DryRun           bool              `json:"dry_run"`
 	ReportPath       string            `json:"report_path,omitempty"`
 	Resolutions      []resolvedTrack   `json:"resolutions,omitempty"`
@@ -242,6 +247,9 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 		}
 		decoded, derr := itunes.DecodeLocation(track.Location)
 		if derr != nil || decoded == "" {
+			// M6: count skipped-undecodable locations so the repair summary
+			// reflects them instead of silently dropping them.
+			result.Undecodable++
 			continue
 		}
 		if pathExists(decoded) {
@@ -325,8 +333,8 @@ func (r *PathRepairer) repairWithResult(ctx context.Context, opID string, dryRun
 	_ = operations.ClearState(r.store, opID)
 
 	summary := fmt.Sprintf(
-		"iTunes path repair complete: tracks=%d missing=%d auto=%d review=%d unresolved=%d enqueued=%d dry_run=%t",
-		result.XMLTracks, result.Missing, result.AutoResolved, result.NeedsReview, result.Unresolved, result.Enqueued, result.DryRun,
+		"iTunes path repair complete: tracks=%d missing=%d auto=%d review=%d unresolved=%d undecodable=%d enqueued=%d dry_run=%t",
+		result.XMLTracks, result.Missing, result.AutoResolved, result.NeedsReview, result.Unresolved, result.Undecodable, result.Enqueued, result.DryRun,
 	)
 	_ = progress.Log("info", summary, nil)
 	_ = progress.UpdateProgress(scanned, scanned, summary)

--- a/internal/itunes/service/status.go
+++ b/internal/itunes/service/status.go
@@ -1,6 +1,7 @@
 // file: internal/itunes/service/status.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a4f1e3c-9b2d-4e8f-a0c1-5d7e9f3b6a2c
+// last-edited: 2026-07-17
 
 package itunesservice
 
@@ -23,7 +24,14 @@ type itunesImportStatus struct {
 	Skipped   int
 	Linked    int
 	Failed    int
-	Errors    []string
+	// M5 soft-failure counters: previously-swallowed per-track errors that
+	// don't fail the book but do lose data (external-ID mapping writes,
+	// author links, undecodable iTunes locations). Surfaced in the import
+	// summary so drops are visible instead of silent.
+	MappingErrors      int
+	AuthorSetErrors    int
+	MalformedLocations int
+	Errors             []string
 }
 
 // importStatusMap is a concurrent map from opID → *itunesImportStatus,
@@ -48,13 +56,16 @@ func (sm *importStatusMap) snapshot(opID string) *itunesImportStatus {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return &itunesImportStatus{
-		Total:     s.Total,
-		Processed: s.Processed,
-		Imported:  s.Imported,
-		Skipped:   s.Skipped,
-		Linked:    s.Linked,
-		Failed:    s.Failed,
-		Errors:    append([]string(nil), s.Errors...),
+		Total:              s.Total,
+		Processed:          s.Processed,
+		Imported:           s.Imported,
+		Skipped:            s.Skipped,
+		Linked:             s.Linked,
+		Failed:             s.Failed,
+		MappingErrors:      s.MappingErrors,
+		AuthorSetErrors:    s.AuthorSetErrors,
+		MalformedLocations: s.MalformedLocations,
+		Errors:             append([]string(nil), s.Errors...),
 	}
 }
 
@@ -85,6 +96,27 @@ func incImportSkipped(s *itunesImportStatus) {
 func incImportLinked(s *itunesImportStatus) {
 	s.mu.Lock()
 	s.Linked++
+	s.mu.Unlock()
+}
+
+// incImportMappingError counts a failed CreateExternalIDMapping write (M5).
+func incImportMappingError(s *itunesImportStatus) {
+	s.mu.Lock()
+	s.MappingErrors++
+	s.mu.Unlock()
+}
+
+// incImportAuthorSetError counts a failed SetBookAuthors write (M5).
+func incImportAuthorSetError(s *itunesImportStatus) {
+	s.mu.Lock()
+	s.AuthorSetErrors++
+	s.mu.Unlock()
+}
+
+// incImportMalformedLocation counts an undecodable iTunes track location (M5).
+func incImportMalformedLocation(s *itunesImportStatus) {
+	s.mu.Lock()
+	s.MalformedLocations++
 	s.mu.Unlock()
 }
 
@@ -131,8 +163,15 @@ func updateImportProgress(log logger.Logger, s *itunesImportStatus, processed, t
 func buildImportSummary(s *itunesImportStatus) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return fmt.Sprintf(
+	summary := fmt.Sprintf(
 		"Import completed: %d new, %d linked, %d skipped, %d failed",
 		s.Imported, s.Linked, s.Skipped, s.Failed,
 	)
+	// M5: surface soft-failure counters so silently-dropped writes are
+	// visible in the summary instead of hidden behind a clean-looking line.
+	if s.MappingErrors > 0 || s.AuthorSetErrors > 0 || s.MalformedLocations > 0 {
+		summary += fmt.Sprintf(" (%d mapping errors, %d author-set errors, %d malformed locations)",
+			s.MappingErrors, s.AuthorSetErrors, s.MalformedLocations)
+	}
+	return summary
 }


### PR DESCRIPTION
## Summary
iTunes importer integrity fixes (DL-5/C-6/C-7/M5/M6 from docs/audits/2026-07-17-multi-discipline-review.md):
- **DL-5**: the ITL rewriter now reports which persistent-IDs were actually rewritten (ITLWriteBackResult.UpdatedPersistentIDs); deferred location-fix rows are marked applied ONLY when their PID was written — normalization skips, missing PIDs, write errors, and RenameITLFile failures (now checked) all stay pending for retry. Bonus: orphaned .tmp on zero-update runs now cleaned.
- **C-6**: blocked-hash soft-delete verifies UpdateBook's returns; failures counted (hashBlockFailed) + logged, no longer claimed as deletions.
- **C-7**: multi-file import rollback verified unsound (per-file rows committed before Book write; dir rename can't restore per-segment paths) — replaced with a CRITICAL reconcile hint naming book, paths, and every committed file row, recorded to import status.
- **M5/M6**: mapping/author-set/malformed-location failures now counted + in import summary; path-repair reports undecodable locations.

## Tests
7 new integrity tests + matched-PID assertions in the LE rewriter suite; internal/itunes + service packages green under -race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65