### PR TITLE
fix(scanner): concurrent-run cache safety, store-error-aware dup detection, walk-error visibility

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.48.0
+// version: 1.49.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package scanner
 
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dhowden/tag"
@@ -42,6 +43,33 @@ var saveBook func(ctx context.Context, book *Book) error = saveBookToDatabase
 
 // defaultLog is a package-level logger for functions that cannot accept a logger parameter.
 var defaultLog = logger.New("scanner")
+
+// Counters for store failures that were previously swallowed silently
+// (audit 2026-07-17 H5). Package-level atomics because saveBookToDatabase is
+// reached through the saveBook variable, whose fixed signature cannot carry
+// per-run state; each ProcessBooksParallel run snapshots the totals at entry
+// and logs the delta in its completion summary. Concurrent runs may attribute
+// a few of each other's failures to their own summary — acceptable for logs.
+var (
+	dupLookupErrCount       atomic.Int64 // duplicate-detection hash lookup store errors
+	dupLookupSkipCount      atomic.Int64 // files skipped: duplicate status undeterminable
+	scanCacheUpdateErrCount atomic.Int64 // UpdateScanCache failures (file re-hashed every scan until it succeeds)
+	scanFailCountErrCount   atomic.Int64 // IncrScanFailCount failures
+)
+
+// warnSampled increments c and logs at Warn on the first occurrence and every
+// 1000th after — bounded noise on a mass store failure without ever being
+// fully silent. Returns the new count.
+func warnSampled(c *atomic.Int64, log logger.Logger, format string, args ...interface{}) int64 {
+	n := c.Add(1)
+	if n == 1 || n%1000 == 0 {
+		if log == nil {
+			log = defaultLog
+		}
+		log.Warn(format, args...)
+	}
+	return n
+}
 
 // Scanner defines the interface for scanning and processing audiobook files.
 // Tests can swap in a mock implementation via SetScanner.
@@ -166,8 +194,70 @@ func SetScanCache(cache map[string]database.ScanCacheEntry) {
 }
 
 // ClearScanCache removes the cached map after a scan completes.
+// Test/legacy direct-clear; production scan runs use AcquireScanCache's
+// release func so concurrent runs don't clear each other's cache.
 func ClearScanCache() {
 	SetScanCache(nil)
+}
+
+// scanCacheRefs / scanCacheFullRuns reference-count concurrent scan runs that
+// share globalScanCache (audit 2026-07-17 R-4): library.scan and
+// library.import have distinct ConcurrencyKeys and can run this code path
+// concurrently; without refcounting, the first finisher's deferred clear
+// nils the cache under the still-running op, silently disabling incremental
+// skip mid-run. Both guarded by globalScanCacheMu.
+var (
+	scanCacheRefs     int
+	scanCacheFullRuns int
+)
+
+// AcquireScanCache registers a scan run with the shared incremental-skip
+// cache and returns an idempotent release func the run must call (defer)
+// when it finishes.
+//
+// Design choice (R-4): a refcount around the existing package-level cache was
+// chosen over threading a per-run cache instance through the scan context
+// because ProcessBooksParallel sits behind the Scanner interface (mocked by
+// tests); changing its signature would ripple through every implementation
+// and mock, while the refcount confines the fix to this file.
+//
+// Rules:
+//   - The first acquirer installs its cache; later concurrent acquirers share
+//     it (all production callers load the same map from GetScanCacheMap, so
+//     sharing is safe).
+//   - A run that passes nil requested a FULL scan (incremental skip disabled).
+//     Any active full run disables the cache for every concurrent run:
+//     skipping unchanged files under a force-rescan would be a correctness
+//     bug, whereas re-processing unchanged files under an incremental run is
+//     only slower. The cache stays disabled until the last run releases.
+//   - The cache is cleared when the last active run releases.
+func AcquireScanCache(cache map[string]database.ScanCacheEntry) func() {
+	globalScanCacheMu.Lock()
+	defer globalScanCacheMu.Unlock()
+	scanCacheRefs++
+	isFull := cache == nil
+	if isFull {
+		scanCacheFullRuns++
+		globalScanCache = nil
+	} else if scanCacheFullRuns == 0 && globalScanCache == nil {
+		globalScanCache = cache
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			globalScanCacheMu.Lock()
+			defer globalScanCacheMu.Unlock()
+			scanCacheRefs--
+			if isFull {
+				scanCacheFullRuns--
+			}
+			if scanCacheRefs <= 0 {
+				scanCacheRefs = 0
+				scanCacheFullRuns = 0
+				globalScanCache = nil
+			}
+		})
+	}
 }
 
 // worksLookupCache caches a (normalizedTitle|authorID) → workID map for the
@@ -197,13 +287,21 @@ func worksLookupKey(normalizedTitle string, authorID *int) string {
 }
 
 // InitWorksLookupCache builds the (normalizedTitle|authorID) → workID map by
-// calling GetAllWorks once. Called by ScanService at the start of each scan.
+// calling GetAllWorks once. Test/legacy direct-init; production scan runs use
+// AcquireWorksLookupCache / ReleaseWorksLookupCache so concurrent runs don't
+// clear each other's cache (audit 2026-07-17 R-4).
 // If GetAllWorks fails, the cache is left empty but enabled — saveBookToDatabase
 // will fall through to a direct CreateWork (which is the same fallback path as
 // when nothing matched).
 func InitWorksLookupCache() {
 	worksLookupMu.Lock()
 	defer worksLookupMu.Unlock()
+	initWorksLookupCacheLocked()
+}
+
+// initWorksLookupCacheLocked is the body of InitWorksLookupCache; callers must
+// hold worksLookupMu.
+func initWorksLookupCacheLocked() {
 	worksLookupCache = make(map[string]string)
 	worksLookupReady = true
 	store := getStore()
@@ -221,13 +319,50 @@ func InitWorksLookupCache() {
 	defaultLog.Info("InitWorksLookupCache: loaded %d works", len(works))
 }
 
-// ClearWorksLookupCache drops the per-scan works lookup map. Called by
-// ScanService after the scan completes (deferred).
+// ClearWorksLookupCache drops the per-scan works lookup map. Test/legacy
+// direct-clear counterpart of InitWorksLookupCache; production scan runs use
+// ReleaseWorksLookupCache.
 func ClearWorksLookupCache() {
 	worksLookupMu.Lock()
 	defer worksLookupMu.Unlock()
 	worksLookupCache = nil
 	worksLookupReady = false
+}
+
+// worksLookupRefs reference-counts concurrent scan runs sharing the works
+// lookup cache (audit 2026-07-17 R-4). Guarded by worksLookupMu. Without it,
+// the first finishing run's deferred clear dropped the cache under a
+// still-running concurrent run, degrading every remaining saveBookToDatabase
+// call to an O(N) GetAllWorks scan per book.
+var worksLookupRefs int
+
+// AcquireWorksLookupCache registers a scan run with the shared works lookup
+// cache, populating it on first use (one GetAllWorks call). Later concurrent
+// acquirers share the same map — safe because all runs resolve works against
+// the same store and rememberCreatedWork keeps the map coherent under
+// worksLookupMu. Pair with a deferred ReleaseWorksLookupCache.
+func AcquireWorksLookupCache() {
+	worksLookupMu.Lock()
+	defer worksLookupMu.Unlock()
+	worksLookupRefs++
+	if worksLookupReady && worksLookupCache != nil {
+		return // already populated by a concurrent run
+	}
+	initWorksLookupCacheLocked()
+}
+
+// ReleaseWorksLookupCache decrements the refcount and drops the cache when the
+// last active scan run finishes.
+func ReleaseWorksLookupCache() {
+	worksLookupMu.Lock()
+	defer worksLookupMu.Unlock()
+	if worksLookupRefs > 0 {
+		worksLookupRefs--
+	}
+	if worksLookupRefs == 0 {
+		worksLookupCache = nil
+		worksLookupReady = false
+	}
 }
 
 // lookupWorkID returns the cached workID for (normalizedTitle, authorID), or
@@ -363,12 +498,22 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 	visitedInodes := make(map[uint64]struct{})
 	var visitedMu sync.Mutex
 
+	// walkErrCount tallies non-fatal walk/read/stat failures so dropped
+	// subtrees are visible in the scan summary instead of silent
+	// (audit 2026-07-17 R-5/M8). Atomic: ReadDir failures occur in workers.
+	var walkErrCount atomic.Int64
+
 	registerDirectory := func(path string, info os.FileInfo) bool {
 		if info == nil {
 			return false
 		}
 		statInfo, err := os.Stat(path)
-		if err != nil || !statInfo.IsDir() {
+		if err != nil {
+			walkErrCount.Add(1)
+			scanLog.Warn("scan walk: cannot stat %s: %v (subtree skipped)", path, err)
+			return false
+		}
+		if !statInfo.IsDir() {
 			return false
 		}
 		inode, ok := getInode(statInfo)
@@ -392,13 +537,20 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 			if path == rootDir {
 				return err
 			}
+			walkErrCount.Add(1)
+			scanLog.Warn("scan walk: error at %s: %v (subtree skipped)", path, err)
 			return nil
 		}
 		info, err := d.Info()
 		if err != nil {
+			walkErrCount.Add(1)
+			scanLog.Warn("scan walk: cannot read entry info for %s: %v (entry skipped)", path, err)
 			return nil
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
+			// Symlinked directories are registered for scanning. Non-directory
+			// symlinks return false and are intentionally ignored; stat
+			// failures are warn-logged + counted inside registerDirectory (M8).
 			_ = registerDirectory(path, info)
 			return nil
 		}
@@ -432,6 +584,8 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 			// Read directory entries
 			entries, err := os.ReadDir(scanDir)
 			if err != nil {
+				walkErrCount.Add(1)
+				scanLog.Warn("scan walk: cannot read directory %s: %v (directory skipped)", scanDir, err)
 				return
 			}
 
@@ -467,6 +621,12 @@ func ScanDirectoryParallel(ctx context.Context, rootDir string, workers int, sca
 	}
 
 	wg.Wait()
+
+	// Surface dropped-subtree count in the scan summary (R-5): each failure was
+	// warn-logged above, but a single aggregate makes a mass-failure obvious.
+	if n := walkErrCount.Load(); n > 0 {
+		scanLog.Warn("scan walk summary: walk_errors=%d (directories or entries skipped due to I/O errors; library may be undercounted)", n)
+	}
 
 	// Prevention post-pass: groupFilesIntoBooks runs per-leaf-dir, so a book laid
 	// out as one chapter per "<prefix> - N" subdir shatters into one book per
@@ -509,6 +669,13 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 
 	total := len(books)
 	scanLog.Info("scan started: %d total files", total)
+
+	// Snapshot swallowed-store-failure counters so the completion summary can
+	// report this run's delta (audit 2026-07-17 H5).
+	dupLookupErrStart := dupLookupErrCount.Load()
+	dupLookupSkipStart := dupLookupSkipCount.Load()
+	scanCacheErrStart := scanCacheUpdateErrCount.Load()
+	scanFailCountErrStart := scanFailCountErrCount.Load()
 
 	// progressCh serializes progress updates so callbacks and progress output
 	// are handled in a single goroutine.
@@ -611,7 +778,10 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 						defer func() { recover() }()
 						if store := getStore(); store != nil {
 							if dbBook, dbErr := store.GetBookByFilePath(filePath); dbErr == nil && dbBook != nil {
-								_ = store.UpdateScanCache(dbBook.ID, fi.ModTime().Unix(), fi.Size())
+								if uerr := store.UpdateScanCache(dbBook.ID, fi.ModTime().Unix(), fi.Size()); uerr != nil {
+									// Silent failure meant the file was re-hashed every scan forever (H5).
+									warnSampled(&scanCacheUpdateErrCount, scanLog, "UpdateScanCache failed for %s: %v (file will be re-hashed next scan)", filePath, uerr)
+								}
 							}
 						}
 					}()
@@ -730,7 +900,10 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 					fallbackUsed = true
 					if gs := getStore(); gs != nil {
 						sum := sha256.Sum256([]byte(filePath))
-						_, _ = gs.IncrScanFailCount(fmt.Sprintf("%x", sum[:8]))
+						if _, ierr := gs.IncrScanFailCount(fmt.Sprintf("%x", sum[:8])); ierr != nil {
+							// Silent failure disabled the auto-quarantine escalation path (H5).
+							warnSampled(&scanFailCountErrCount, scanLog, "IncrScanFailCount failed for %s: %v", filePath, ierr)
+						}
 					}
 				} else {
 					// Reset fail counter on successful parse so transient failures
@@ -864,7 +1037,10 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 					}
 					if fi, statErr := os.Stat(books[idx].FilePath); statErr == nil {
 						if dbBook, dbErr := store.GetBookByFilePath(books[idx].FilePath); dbErr == nil && dbBook != nil {
-							_ = store.UpdateScanCache(dbBook.ID, fi.ModTime().Unix(), fi.Size())
+							if uerr := store.UpdateScanCache(dbBook.ID, fi.ModTime().Unix(), fi.Size()); uerr != nil {
+								// Silent failure meant the file was re-hashed every scan forever (H5).
+								warnSampled(&scanCacheUpdateErrCount, scanLog, "UpdateScanCache failed for %s: %v (file will be re-hashed next scan)", books[idx].FilePath, uerr)
+							}
 						}
 					}
 				}()
@@ -885,6 +1061,20 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 
 	if len(errs) > 0 {
 		scanLog.Warn("%d books failed to save", len(errs))
+	}
+
+	// Per-run store-failure summary (H5): once per run, not per file.
+	if d := dupLookupErrCount.Load() - dupLookupErrStart; d > 0 {
+		scanLog.Warn("scan summary: %d duplicate-detection hash lookups failed (store errors)", d)
+	}
+	if d := dupLookupSkipCount.Load() - dupLookupSkipStart; d > 0 {
+		scanLog.Warn("scan summary: %d files skipped because duplicate status was undeterminable (store errors during hash lookup)", d)
+	}
+	if d := scanCacheUpdateErrCount.Load() - scanCacheErrStart; d > 0 {
+		scanLog.Warn("scan summary: %d scan-cache updates failed (affected files will be re-hashed next scan)", d)
+	}
+	if d := scanFailCountErrCount.Load() - scanFailCountErrStart; d > 0 {
+		scanLog.Warn("scan summary: %d scan-fail-count increments failed", d)
 	}
 
 	if ctxErr != nil {
@@ -1839,15 +2029,35 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 				getStore().GetBookByOriginalHash,
 				getStore().GetBookByOrganizedHash,
 			}
+			lookupErrs := 0
+			var firstLookupErr error
 			for _, lookup := range hashLookups {
-				candidate, err := lookup(*fileHash)
-				if err != nil {
+				candidate, lerr := lookup(*fileHash)
+				if lerr != nil {
+					// Not-found is (nil, nil) on every store; a non-nil error
+					// is a real store failure (audit 2026-07-17 H5).
+					lookupErrs++
+					if firstLookupErr == nil {
+						firstLookupErr = lerr
+					}
+					warnSampled(&dupLookupErrCount, defaultLog, "duplicate-detection hash lookup failed for %s: %v", book.FilePath, lerr)
 					continue
 				}
 				if candidate != nil {
 					existing = candidate
 					break
 				}
+			}
+
+			// A failing store must not silently re-import an existing book: if
+			// any lookup errored and none found a match, this file cannot be
+			// proven NOT to be a duplicate — skip importing it (conservative;
+			// H5). The file is untouched on disk and will import on the next
+			// scan once the store recovers.
+			if existing == nil && lookupErrs > 0 {
+				dupLookupSkipCount.Add(1)
+				return fmt.Errorf("skipping import of %s: duplicate status undeterminable (%d/%d hash lookups failed, first error: %w)",
+					book.FilePath, lookupErrs, len(hashLookups), firstLookupErr)
 			}
 
 			if existing != nil {
@@ -2099,7 +2309,12 @@ func ComputeFileHash(filePath string) (string, error) {
 
 		// Last chunk
 		if info.Size() > chunkSize {
-			file.Seek(-chunkSize, io.SeekEnd)
+			// A discarded Seek error would hash the wrong window and poison
+			// dedup (audit 2026-07-17 DL-4); matches the check in
+			// process_file.go computeHashFromReader.
+			if _, err := file.Seek(-chunkSize, io.SeekEnd); err != nil {
+				return "", err
+			}
 			last := make([]byte, chunkSize)
 			n, err := file.Read(last)
 			if err != nil && err != io.EOF {

--- a/internal/scanner/scanner_reliability_test.go
+++ b/internal/scanner/scanner_reliability_test.go
@@ -1,0 +1,272 @@
+// file: internal/scanner/scanner_reliability_test.go
+// version: 1.0.0
+// guid: 9f8e7d6c-5b4a-3921-8c7d-6e5f4a3b2c1d
+// last-edited: 2026-07-17
+
+// Tests for the 2026-07-17 multi-discipline-review scanner findings:
+// R-4 (refcounted scan/works caches surviving concurrent runs) and
+// H5 (duplicate-detection store errors must skip import, not re-import).
+
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// resetScanCacheRefsForTest forces the refcounted scan-cache globals back to a
+// clean state regardless of test outcome. Name is task-unique (relscn) to
+// avoid parallel-worker helper collisions.
+func resetScanCacheRefsForTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		globalScanCacheMu.Lock()
+		scanCacheRefs = 0
+		scanCacheFullRuns = 0
+		globalScanCache = nil
+		globalScanCacheMu.Unlock()
+		worksLookupMu.Lock()
+		worksLookupRefs = 0
+		worksLookupCache = nil
+		worksLookupReady = false
+		worksLookupMu.Unlock()
+	})
+}
+
+// peekGlobalScanCache reads the shared cache under its lock.
+func peekGlobalScanCache() map[string]database.ScanCacheEntry {
+	globalScanCacheMu.RLock()
+	defer globalScanCacheMu.RUnlock()
+	return globalScanCache
+}
+
+// TestRelScn_ScanCacheSurvivesFirstRelease reproduces R-4: a concurrent
+// library.scan and library.import each acquire the cache; the first finisher's
+// release must NOT clear it while the second run is still active.
+func TestRelScn_ScanCacheSurvivesFirstRelease(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+
+	cacheA := map[string]database.ScanCacheEntry{"/lib/a.m4b": {Mtime: 1, Size: 10}}
+	cacheB := map[string]database.ScanCacheEntry{"/import/b.m4b": {Mtime: 2, Size: 20}}
+
+	releaseA := AcquireScanCache(cacheA)
+	releaseB := AcquireScanCache(cacheB)
+
+	// First run finishes.
+	releaseA()
+
+	if got := peekGlobalScanCache(); got == nil {
+		t.Fatal("R-4 regression: scan cache cleared while a concurrent run was still active")
+	}
+
+	// Second (still-active) run must still be able to skip via the cache.
+	if !shouldSkipFile("/lib/a.m4b", 1, 10, peekGlobalScanCache()) {
+		t.Fatal("expected incremental skip to still work for the surviving run")
+	}
+
+	releaseB()
+	if got := peekGlobalScanCache(); got != nil {
+		t.Fatal("scan cache should be cleared after the last run releases")
+	}
+
+	// Release funcs must be idempotent.
+	releaseA()
+	releaseB()
+	globalScanCacheMu.RLock()
+	refs := scanCacheRefs
+	globalScanCacheMu.RUnlock()
+	if refs != 0 {
+		t.Fatalf("scanCacheRefs = %d after all releases, want 0", refs)
+	}
+}
+
+// TestRelScn_FullRunDisablesIncrementalSkip verifies the documented rule: any
+// active full (force) run disables the shared cache for every concurrent run —
+// skipping unchanged files under a force-rescan would be a correctness bug.
+func TestRelScn_FullRunDisablesIncrementalSkip(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+
+	releaseIncr := AcquireScanCache(map[string]database.ScanCacheEntry{"/lib/a.m4b": {Mtime: 1, Size: 10}})
+	releaseFull := AcquireScanCache(nil) // force/full run
+
+	if got := peekGlobalScanCache(); got != nil {
+		t.Fatal("an active full run must disable the shared incremental-skip cache")
+	}
+
+	releaseFull()
+	releaseIncr()
+	if got := peekGlobalScanCache(); got != nil {
+		t.Fatal("cache should be nil after all runs release")
+	}
+}
+
+// TestRelScn_ConcurrentAcquireReleaseRace hammers acquire/release from many
+// goroutines under -race; each incremental run asserts mid-run that the cache
+// it depends on is still installed.
+func TestRelScn_ConcurrentAcquireReleaseRace(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache := map[string]database.ScanCacheEntry{
+				fmt.Sprintf("/lib/f%d.m4b", i): {Mtime: int64(i), Size: int64(i)},
+			}
+			release := AcquireScanCache(cache)
+			defer release()
+			for j := 0; j < 200; j++ {
+				// Worker read path (mirrors ProcessBooksParallel).
+				globalScanCacheMu.RLock()
+				c := globalScanCache
+				globalScanCacheMu.RUnlock()
+				if c == nil {
+					t.Errorf("run %d: cache nil mid-run (iteration %d) with no full runs active", i, j)
+					return
+				}
+				_ = shouldSkipFile("/nope", 0, 0, c)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := peekGlobalScanCache(); got != nil {
+		t.Fatal("cache should be cleared after every concurrent run released")
+	}
+}
+
+// TestRelScn_WorksLookupCacheSurvivesFirstRelease covers the works-lookup half
+// of R-4: the first finisher's release must not drop the map (degrading the
+// still-running scan to O(N) GetAllWorks per book).
+func TestRelScn_WorksLookupCacheSurvivesFirstRelease(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+	prevStore := getStore()
+	SetStore(nil) // init path with no store: empty but ready cache
+	t.Cleanup(func() { SetStore(prevStore) })
+
+	AcquireWorksLookupCache()
+	AcquireWorksLookupCache()
+
+	ReleaseWorksLookupCache() // first run finishes
+
+	worksLookupMu.RLock()
+	ready := worksLookupReady
+	cache := worksLookupCache
+	worksLookupMu.RUnlock()
+	if !ready || cache == nil {
+		t.Fatal("R-4 regression: works lookup cache dropped while a concurrent run was still active")
+	}
+
+	ReleaseWorksLookupCache() // last run finishes
+
+	worksLookupMu.RLock()
+	ready = worksLookupReady
+	cache = worksLookupCache
+	worksLookupMu.RUnlock()
+	if ready || cache != nil {
+		t.Fatal("works lookup cache should be dropped after the last run releases")
+	}
+}
+
+// TestRelScn_HashLookupStoreErrorSkipsImport covers H5: when the store fails
+// during duplicate-detection hash lookups and no duplicate can be proven, the
+// file must be SKIPPED (error returned, no CreateBook), never re-imported.
+func TestRelScn_HashLookupStoreErrorSkipsImport(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+
+	storeErr := errors.New("pebble: injected I/O failure")
+	created := false
+	mock := &database.MockStore{
+		GetBookByFilePathFunc: func(path string) (*database.Book, error) { return nil, nil },
+		GetBookByFileHashFunc: func(hash string) (*database.Book, error) { return nil, storeErr },
+		GetBookByOriginalHashFunc: func(hash string) (*database.Book, error) {
+			return nil, storeErr
+		},
+		GetBookByOrganizedHashFunc: func(hash string) (*database.Book, error) {
+			return nil, storeErr
+		},
+		CreateBookFunc: func(book *database.Book) (*database.Book, error) {
+			created = true
+			return book, nil
+		},
+	}
+
+	prevStore := getStore()
+	SetStore(mock)
+	t.Cleanup(func() { SetStore(prevStore) })
+
+	skipsBefore := dupLookupSkipCount.Load()
+	errsBefore := dupLookupErrCount.Load()
+
+	book := &Book{
+		FilePath: "/import/new-file.m4b",
+		FileHash: "deadbeef", // pre-computed: skips on-disk hashing
+	}
+	err := saveBookToDatabase(context.Background(), book)
+	if err == nil {
+		t.Fatal("H5 regression: store failure during dup detection did not skip the import")
+	}
+	if !strings.Contains(err.Error(), "duplicate status undeterminable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("H5 regression: CreateBook was called despite undeterminable duplicate status")
+	}
+	if got := dupLookupSkipCount.Load() - skipsBefore; got != 1 {
+		t.Fatalf("dupLookupSkipCount delta = %d, want 1", got)
+	}
+	if got := dupLookupErrCount.Load() - errsBefore; got != 3 {
+		t.Fatalf("dupLookupErrCount delta = %d, want 3 (one per failing lookup)", got)
+	}
+}
+
+// TestRelScn_HashLookupPartialErrorStillFindsDuplicate verifies that a store
+// error on one index does not mask a duplicate found via another index: the
+// found duplicate wins and the file is handled by the normal dedup path.
+func TestRelScn_HashLookupPartialErrorStillFindsDuplicate(t *testing.T) {
+	resetScanCacheRefsForTest(t)
+
+	groupID := "vg-existing"
+	existing := &database.Book{
+		ID:             "01EXISTING",
+		Title:          "Already Imported",
+		FilePath:       "/library/already-imported.m4b",
+		VersionGroupID: &groupID, // already version-linked → dedup path returns nil
+	}
+	created := false
+	mock := &database.MockStore{
+		GetBookByFilePathFunc: func(path string) (*database.Book, error) { return nil, nil },
+		GetBookByFileHashFunc: func(hash string) (*database.Book, error) {
+			return nil, errors.New("pebble: injected I/O failure")
+		},
+		GetBookByOriginalHashFunc: func(hash string) (*database.Book, error) {
+			return existing, nil
+		},
+		CreateBookFunc: func(book *database.Book) (*database.Book, error) {
+			created = true
+			return book, nil
+		},
+	}
+
+	prevStore := getStore()
+	SetStore(mock)
+	t.Cleanup(func() { SetStore(prevStore) })
+
+	book := &Book{
+		FilePath: "/import/duplicate-copy.m4b",
+		FileHash: "deadbeef",
+	}
+	if err := saveBookToDatabase(context.Background(), book); err != nil {
+		t.Fatalf("duplicate found via a healthy index should not error, got: %v", err)
+	}
+	if created {
+		t.Fatal("already-version-linked duplicate must not be re-imported")
+	}
+}

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-01
+// last-edited: 2026-07-17
 package scanner
 
 import (
@@ -157,15 +157,20 @@ func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req
 		log.Info("Incremental scan: ~%d known files, checking for changes", totalFilesAcrossFolders)
 	}
 
-	// Install scan cache into the scanner package so workers can skip unchanged files.
-	SetScanCache(scanCache)
-	defer ClearScanCache()
+	// Install scan cache into the scanner package so workers can skip unchanged
+	// files. Reference-counted (audit 2026-07-17 R-4): library.scan and
+	// library.import have distinct ConcurrencyKeys and can run this path
+	// concurrently — with a plain deferred clear, the first finisher nilled the
+	// cache under the still-running run.
+	releaseScanCache := AcquireScanCache(scanCache)
+	defer releaseScanCache()
 
 	// Build the per-scan works lookup cache so saveBookToDatabase does not
 	// run GetAllWorks() once per book (MAYDEPLOY-H6: 50K books × 50K works
-	// = 2.5B lookups → single load + map access).
-	InitWorksLookupCache()
-	defer ClearWorksLookupCache()
+	// = 2.5B lookups → single load + map access). Reference-counted for the
+	// same R-4 concurrent-run reason as the scan cache above.
+	AcquireWorksLookupCache()
+	defer ReleaseWorksLookupCache()
 
 	// Scan each folder
 	stats := &ScanStats{}
@@ -239,8 +244,19 @@ func (ss *ScanService) countFilesAcrossFolders(foldersToScan []string, log logge
 			continue
 		}
 		fileCount := 0
-		_ = filepath.WalkDir(folderPath, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
+		walkErrLogged := false
+		walkErr := filepath.WalkDir(folderPath, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// Permission/I-O errors here undercount the progress
+				// denominator; log the first per folder so the undercount is
+				// not silent (audit 2026-07-17 H6), then keep counting.
+				if !walkErrLogged {
+					walkErrLogged = true
+					log.Warn("count phase: walk error under %s at %s: %v (progress total may undercount)", folderPath, path, err)
+				}
+				return nil
+			}
+			if d.IsDir() {
 				return nil
 			}
 			ext := strings.ToLower(filepath.Ext(path))
@@ -252,6 +268,10 @@ func (ss *ScanService) countFilesAcrossFolders(foldersToScan []string, log logge
 			}
 			return nil
 		})
+		if walkErr != nil && !walkErrLogged {
+			// Only reachable when the root itself fails to stat.
+			log.Warn("count phase: walk failed for %s: %v (progress total may undercount)", folderPath, walkErr)
+		}
 		log.Info("Folder %s: Found %d audiobook files", folderPath, fileCount)
 		totalFilesAcrossFolders += fileCount
 	}


### PR DESCRIPTION
## Summary
Scanner reliability fixes (R-4/H5/R-5/H6/DL-4/M8 from docs/audits/2026-07-17-multi-discipline-review.md):
- **R-4**: package-singleton scan/works caches are now refcounted (AcquireScanCache/AcquireWorksLookupCache) — concurrent library.scan + library.import no longer nil each other's caches mid-run; any active full/force run disables incremental skip for all concurrent runs (correctness over speed)
- **H5**: duplicate-detection hash-lookup store errors are counted, warn-sampled, and conservatively SKIP the file (duplicate status undeterminable) instead of silently re-importing; swallowed UpdateScanCache/IncrScanFailCount errors now counted + per-run summary
- **R-5/H6/M8**: WalkDir/ReadDir/stat/registerDirectory failures warn-logged + walk_errors counter in scan summary; count-phase walk errors logged (progress denominator honesty)
- **DL-4**: ComputeFileHash tail-window Seek errors now returned (matches process_file.go sibling) — no more silent wrong-window hashes poisoning dedup

## Tests
6 new tests incl. 8×200 concurrent acquire/release under -race and MockStore error-injection for the skip path; full scanner package green under -race; repo-wide -short suite 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65