### PR TITLE
fix(organizer): rename rollback + stranded-temp resume, overwrite refusal, O_EXCL reflink

### DIFF
--- a/internal/metafetch/file_pipeline.go
+++ b/internal/metafetch/file_pipeline.go
@@ -1,11 +1,14 @@
 // file: internal/metafetch/file_pipeline.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
+// last-edited: 2026-07-17
 
 package metafetch
 
 import (
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,6 +16,27 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
+
+// tmpRenameSuffix is appended to the target path to form the intermediate
+// temp path used by RenameFiles' two-phase rename.
+const tmpRenameSuffix = ".tmp-rename"
+
+// safeRename renames src to dst, refusing to overwrite an existing dst.
+// POSIX rename(2) silently REPLACES an existing destination file; on a path
+// collision that would destroy another book's bytes. The collision error is an
+// *os.LinkError wrapping fs.ErrExist so os.IsExist(err) recognizes it.
+// (Duplicate of internal/organizer's helper — this whole file is a package
+// twin of internal/organizer/pipeline.go.)
+func safeRename(src, dst string) error {
+	if _, err := os.Lstat(dst); err == nil {
+		slog.Warn("safeRename refusing to overwrite existing destination",
+			"src", src, "dst", dst)
+		return &os.LinkError{Op: "rename", Old: src, New: dst, Err: fs.ErrExist}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat rename destination %s: %w", dst, err)
+	}
+	return os.Rename(src, dst)
+}
 
 // FileRenameEntry represents a planned file rename operation.
 type FileRenameEntry struct {
@@ -143,57 +167,102 @@ type RenameResult struct {
 	Errors    []string          `json:"errors,omitempty"`
 }
 
+// renameTemp tracks a file parked at its intermediate temp path during a
+// two-phase rename.
+type renameTemp struct {
+	TempPath string
+	Entry    FileRenameEntry
+}
+
+// rollbackRenameTemps returns files parked at their temp paths back to their
+// original source paths. A rollback failure is loud: a file left at a
+// .tmp-rename path is invisible to the library (its DB row points at the old
+// source path), so each failure is logged as an Error with both paths and
+// recorded in result.Errors — never silently dropped.
+func rollbackRenameTemps(temps []renameTemp, result *RenameResult) {
+	for _, t := range temps {
+		if err := os.Rename(t.TempPath, t.Entry.SourcePath); err != nil {
+			slog.Error("RenameFiles rollback failed — file stranded at temp path",
+				"temp_path", t.TempPath,
+				"source_path", t.Entry.SourcePath,
+				"target_path", t.Entry.TargetPath,
+				"error", err)
+			result.Errors = append(result.Errors, fmt.Sprintf(
+				"rollback failed, file stranded at %s (source %s): %v",
+				t.TempPath, t.Entry.SourcePath, err))
+		}
+	}
+}
+
 // RenameFiles performs atomic file renames using a temp intermediate step
 // to avoid conflicts when source and target overlap.
 // Missing source files are skipped (not fatal) and reported in the result.
+//
+// Failure semantics:
+//   - A file stranded at its temp path by a previously interrupted run (temp
+//     exists, source doesn't) is picked up and resumed through phase 2 instead
+//     of being skipped forever.
+//   - On any phase failure, every file still parked at a temp path is rolled
+//     back to its source path; rollback failures are logged and recorded in
+//     result.Errors.
+//   - Entries that already reached their final path before the failure remain
+//     in result.Succeeded — callers must persist DB path updates for them even
+//     when an error is returned.
+//   - Both phases refuse to overwrite an existing destination (safeRename);
+//     a collision fails the batch instead of silently destroying bytes.
 func RenameFiles(entries []FileRenameEntry) (*RenameResult, error) {
 	result := &RenameResult{}
 	if len(entries) == 0 {
 		return result, nil
 	}
 
-	// Pre-filter: skip entries where source doesn't exist
+	// Pre-filter: skip entries where source doesn't exist — unless the file
+	// was stranded at its temp path by an interrupted phase 2, in which case
+	// it re-enters phase 2 below so the rename completes.
 	var valid []FileRenameEntry
+	var temps []renameTemp
 	for _, entry := range entries {
 		if _, err := os.Stat(entry.SourcePath); os.IsNotExist(err) {
+			tempPath := entry.TargetPath + tmpRenameSuffix
+			if _, terr := os.Stat(tempPath); terr == nil {
+				slog.Warn("RenameFiles resuming stranded temp file from interrupted rename",
+					"temp_path", tempPath, "target_path", entry.TargetPath)
+				temps = append(temps, renameTemp{TempPath: tempPath, Entry: entry})
+				continue
+			}
 			result.Skipped = append(result.Skipped, entry)
 			continue
 		}
 		valid = append(valid, entry)
 	}
 
-	if len(valid) == 0 {
+	if len(valid) == 0 && len(temps) == 0 {
 		return result, nil
 	}
 
 	// Phase 1: rename source -> temp
-	type tempEntry struct {
-		TempPath string
-		Entry    FileRenameEntry
-	}
-	var temps []tempEntry
-
 	for _, entry := range valid {
 		// Ensure target directory exists
 		targetDir := filepath.Dir(entry.TargetPath)
 		if err := os.MkdirAll(targetDir, 0o775); err != nil {
+			rollbackRenameTemps(temps, result)
 			return result, fmt.Errorf("create target dir %s: %w", targetDir, err)
 		}
 
-		tempPath := entry.TargetPath + ".tmp-rename"
-		if err := os.Rename(entry.SourcePath, tempPath); err != nil {
+		tempPath := entry.TargetPath + tmpRenameSuffix
+		if err := safeRename(entry.SourcePath, tempPath); err != nil {
 			// Rollback temps already moved
-			for _, t := range temps {
-				_ = os.Rename(t.TempPath, t.Entry.SourcePath)
-			}
+			rollbackRenameTemps(temps, result)
 			return result, fmt.Errorf("rename %s -> temp: %w", entry.SourcePath, err)
 		}
-		temps = append(temps, tempEntry{TempPath: tempPath, Entry: entry})
+		temps = append(temps, renameTemp{TempPath: tempPath, Entry: entry})
 	}
 
-	// Phase 2: rename temp -> final
-	for _, t := range temps {
-		if err := os.Rename(t.TempPath, t.Entry.TargetPath); err != nil {
+	// Phase 2: rename temp -> final. On failure, roll back this and every
+	// remaining temp so no file is left stranded at a .tmp-rename path.
+	for i, t := range temps {
+		if err := safeRename(t.TempPath, t.Entry.TargetPath); err != nil {
+			rollbackRenameTemps(temps[i:], result)
 			return result, fmt.Errorf("rename temp -> %s: %w", t.Entry.TargetPath, err)
 		}
 		result.Succeeded = append(result.Succeeded, t.Entry)

--- a/internal/metafetch/file_pipeline_dataloss_test.go
+++ b/internal/metafetch/file_pipeline_dataloss_test.go
@@ -1,0 +1,85 @@
+// file: internal/metafetch/file_pipeline_dataloss_test.go
+// version: 1.0.0
+// guid: 6f1ed9f6-e6b5-47cb-9843-94343fe2e7eb
+// last-edited: 2026-07-17
+
+package metafetch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Mirrors internal/organizer/dataloss_fix_test.go for this package's twin
+// RenameFiles implementation (the one actually wired into the apply /
+// write-back paths).
+
+func TestMetafetchRenameFilesPhase2CollisionRollsBack(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "old", "book.m4b")
+	dst := filepath.Join(tmpDir, "new", "book.m4b")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("mover"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("occupant"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RenameFiles([]FileRenameEntry{
+		{SegmentID: "s1", SourcePath: src, TargetPath: dst},
+	})
+	if err == nil {
+		t.Fatal("expected error for phase-2 collision, got nil")
+	}
+	if len(result.Succeeded) != 0 {
+		t.Errorf("expected 0 succeeded, got %d", len(result.Succeeded))
+	}
+	if data, rerr := os.ReadFile(dst); rerr != nil || string(data) != "occupant" {
+		t.Errorf("occupant destroyed: %q err=%v", data, rerr)
+	}
+	if data, rerr := os.ReadFile(src); rerr != nil || string(data) != "mover" {
+		t.Errorf("source not rolled back: %q err=%v", data, rerr)
+	}
+	if _, terr := os.Stat(dst + tmpRenameSuffix); !os.IsNotExist(terr) {
+		t.Error("temp file left behind after rollback")
+	}
+}
+
+func TestMetafetchRenameFilesResumesStrandedTemp(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "old", "book.m4b") // does NOT exist
+	dst := filepath.Join(tmpDir, "new", "book.m4b")
+	tempPath := dst + tmpRenameSuffix
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tempPath, []byte("stranded"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RenameFiles([]FileRenameEntry{
+		{SegmentID: "s1", SourcePath: src, TargetPath: dst},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Skipped) != 0 {
+		t.Error("stranded entry bucketed into Skipped (the old lost-forever bug)")
+	}
+	if len(result.Succeeded) != 1 {
+		t.Fatalf("expected 1 succeeded (resumed), got %d", len(result.Succeeded))
+	}
+	if data, rerr := os.ReadFile(dst); rerr != nil || string(data) != "stranded" {
+		t.Errorf("resumed file wrong: %q err=%v", data, rerr)
+	}
+	if _, terr := os.Stat(tempPath); !os.IsNotExist(terr) {
+		t.Error("temp file still present after resume")
+	}
+}

--- a/internal/metafetch/service.go
+++ b/internal/metafetch/service.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service.go
-// version: 5.3.0
+// version: 5.4.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package metafetch
 
@@ -441,10 +441,11 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 
 	entries := ComputeTargetPaths(config.AppConfig.RootDir, pathFormat, segTitleFormat, book, bookFiles, vars)
 
-	renameResult, err := RenameFiles(entries)
-	if err != nil {
-		return fmt.Errorf("rename files: %w", err)
-	}
+	renameResult, renameErr := RenameFiles(entries)
+	// Even when RenameFiles returns an error, entries in renameResult.Succeeded
+	// have physically moved on disk — their DB paths MUST still be updated
+	// below, or the library loses track of files that did move. The error is
+	// returned after the DB sync + empty-dir cleanup.
 
 	// Update book file records with new paths
 	bfMap := make(map[string]*database.BookFile, len(bookFiles))
@@ -527,6 +528,12 @@ func (mfs *Service) RunApplyPipelineRenameOnly(id string, book *database.Book) e
 		if oldDir != filepath.Dir(entry.TargetPath) {
 			removeEmptyDirs(oldDir, config.AppConfig.RootDir)
 		}
+	}
+
+	// Now that DB paths for every succeeded rename are persisted, surface the
+	// rename failure (skipping dedup/writeback follow-ups for the failed run).
+	if renameErr != nil {
+		return fmt.Errorf("rename files: %w", renameErr)
 	}
 
 	// Trigger dedup check after metadata apply

--- a/internal/metafetch/service_writeback.go
+++ b/internal/metafetch/service_writeback.go
@@ -1,7 +1,7 @@
 // file: internal/metafetch/service_writeback.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: fad73c11-30c2-4fdc-addd-45afef25d792
-// last-edited: 2026-07-03
+// last-edited: 2026-07-17
 
 package metafetch
 
@@ -560,10 +560,12 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 	entries := ComputeTargetPaths(config.AppConfig.RootDir, pathFormat, segTitleFormat, book, bookFiles, vars)
 
 	if config.AppConfig.AutoRenameOnApply && !hasCheckpoint(mfs.db, id, phaseRename) {
-		renameResult, err := RenameFiles(entries)
-		if err != nil {
-			return fmt.Errorf("rename files: %w", err)
-		}
+		renameResult, renameErr := RenameFiles(entries)
+		// Even when RenameFiles returns an error, entries in
+		// renameResult.Succeeded have physically moved on disk — their DB
+		// paths MUST still be updated below, or the library loses track of
+		// files that did move. The error is returned after the DB sync,
+		// before the rename checkpoint is set.
 		if len(renameResult.Skipped) > 0 {
 						slog.Warn("files skipped (source missing) during rename", "count", len(renameResult.Skipped))
 		}
@@ -616,6 +618,13 @@ func (mfs *Service) runApplyPipeline(id string, book *database.Book) error {
 										slog.Info("updated book path for", "id", id, "path", newBookPath)
 				}
 			}
+		}
+
+		// DB paths for every succeeded rename are persisted; now surface the
+		// rename failure. The checkpoint is NOT set, so the next apply run
+		// retries the rename (including any stranded-temp resume).
+		if renameErr != nil {
+			return fmt.Errorf("rename files: %w", renameErr)
 		}
 		setCheckpoint(mfs.db, id, phaseRename)
 	}

--- a/internal/organizer/dataloss_fix_test.go
+++ b/internal/organizer/dataloss_fix_test.go
@@ -1,0 +1,284 @@
+// file: internal/organizer/dataloss_fix_test.go
+// version: 1.0.0
+// guid: ff38c140-155a-4c69-b3ea-b350a8503066
+// last-edited: 2026-07-17
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+)
+
+// Tests for the 2026-07-17 organizer data-loss fixes (DL-1/DL-2/DL-3):
+// two-phase rename rollback + stranded-temp resume, destination-collision
+// refusal on every wired move path, and reflink O_EXCL destination creation.
+
+// ---------------------------------------------------------------------------
+// safeRename (DL-2)
+// ---------------------------------------------------------------------------
+
+func TestSafeRenameDataloss(t *testing.T) {
+	t.Run("renames when destination missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		src := filepath.Join(tmpDir, "src.m4b")
+		dst := filepath.Join(tmpDir, "dst.m4b")
+		if err := os.WriteFile(src, []byte("bytes"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := safeRename(src, dst); err != nil {
+			t.Fatalf("safeRename: %v", err)
+		}
+		if _, err := os.Stat(dst); err != nil {
+			t.Errorf("destination missing after rename: %v", err)
+		}
+		if _, err := os.Stat(src); !os.IsNotExist(err) {
+			t.Error("source still exists after rename")
+		}
+	})
+
+	t.Run("refuses to overwrite existing destination", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		src := filepath.Join(tmpDir, "src.m4b")
+		dst := filepath.Join(tmpDir, "dst.m4b")
+		if err := os.WriteFile(src, []byte("new bytes"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, []byte("existing book"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := safeRename(src, dst)
+		if err == nil {
+			t.Fatal("expected collision error, got nil")
+		}
+		if !os.IsExist(err) {
+			t.Errorf("expected os.IsExist(err), got: %v", err)
+		}
+		// Destination bytes must be intact
+		data, rerr := os.ReadFile(dst)
+		if rerr != nil || string(data) != "existing book" {
+			t.Errorf("destination corrupted: %q err=%v", data, rerr)
+		}
+		// Source must be untouched
+		if _, serr := os.Stat(src); serr != nil {
+			t.Errorf("source lost: %v", serr)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RenameFiles rollback + stranded-temp resume (DL-1)
+// ---------------------------------------------------------------------------
+
+func TestRenameFilesPhase2CollisionRollsBack(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "old", "book.m4b")
+	dst := filepath.Join(tmpDir, "new", "book.m4b")
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("mover"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Occupy the final target so phase 2 collides.
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("occupant"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RenameFiles([]FileRenameEntry{
+		{SegmentID: "s1", SourcePath: src, TargetPath: dst},
+	})
+	if err == nil {
+		t.Fatal("expected error for phase-2 collision, got nil")
+	}
+	if len(result.Succeeded) != 0 {
+		t.Errorf("expected 0 succeeded, got %d", len(result.Succeeded))
+	}
+	// Occupant must be intact — never overwritten.
+	data, rerr := os.ReadFile(dst)
+	if rerr != nil || string(data) != "occupant" {
+		t.Errorf("occupant destroyed: %q err=%v", data, rerr)
+	}
+	// Source must be rolled back from the temp path — not stranded.
+	data, rerr = os.ReadFile(src)
+	if rerr != nil || string(data) != "mover" {
+		t.Errorf("source not rolled back: %q err=%v", data, rerr)
+	}
+	if _, terr := os.Stat(dst + tmpRenameSuffix); !os.IsNotExist(terr) {
+		t.Error("temp file left behind after rollback")
+	}
+}
+
+func TestRenameFilesResumesStrandedTemp(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "old", "book.m4b") // does NOT exist
+	dst := filepath.Join(tmpDir, "new", "book.m4b")
+	tempPath := dst + tmpRenameSuffix
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a previous run that failed after phase 1: file parked at temp.
+	if err := os.WriteFile(tempPath, []byte("stranded"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RenameFiles([]FileRenameEntry{
+		{SegmentID: "s1", SourcePath: src, TargetPath: dst},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Skipped) != 0 {
+		t.Errorf("stranded entry bucketed into Skipped (the old lost-forever bug)")
+	}
+	if len(result.Succeeded) != 1 {
+		t.Fatalf("expected 1 succeeded (resumed), got %d", len(result.Succeeded))
+	}
+	data, rerr := os.ReadFile(dst)
+	if rerr != nil || string(data) != "stranded" {
+		t.Errorf("resumed file wrong: %q err=%v", data, rerr)
+	}
+	if _, terr := os.Stat(tempPath); !os.IsNotExist(terr) {
+		t.Error("temp file still present after resume")
+	}
+}
+
+func TestRenameFilesPartialSucceededReportedOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	src1 := filepath.Join(tmpDir, "old", "a.m4b")
+	dst1 := filepath.Join(tmpDir, "new", "a.m4b")
+	src2 := filepath.Join(tmpDir, "old", "b.m4b")
+	dst2 := filepath.Join(tmpDir, "new", "b.m4b")
+	if err := os.MkdirAll(filepath.Dir(src1), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for p, c := range map[string]string{src1: "aaa", src2: "bbb"} {
+		if err := os.WriteFile(p, []byte(c), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Occupy only the second target: entry 1 completes, entry 2 collides.
+	if err := os.MkdirAll(filepath.Dir(dst2), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst2, []byte("occupant"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RenameFiles([]FileRenameEntry{
+		{SegmentID: "s1", SourcePath: src1, TargetPath: dst1},
+		{SegmentID: "s2", SourcePath: src2, TargetPath: dst2},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Entry 1 physically moved and must be reported so callers persist its DB path.
+	if len(result.Succeeded) != 1 || result.Succeeded[0].SegmentID != "s1" {
+		t.Fatalf("expected Succeeded=[s1], got %+v", result.Succeeded)
+	}
+	if data, rerr := os.ReadFile(dst1); rerr != nil || string(data) != "aaa" {
+		t.Errorf("entry 1 not at final path: %q err=%v", data, rerr)
+	}
+	// Entry 2 rolled back to source; occupant intact.
+	if data, rerr := os.ReadFile(src2); rerr != nil || string(data) != "bbb" {
+		t.Errorf("entry 2 not rolled back: %q err=%v", data, rerr)
+	}
+	if data, rerr := os.ReadFile(dst2); rerr != nil || string(data) != "occupant" {
+		t.Errorf("occupant destroyed: %q err=%v", data, rerr)
+	}
+	if _, terr := os.Stat(dst2 + tmpRenameSuffix); !os.IsNotExist(terr) {
+		t.Error("temp file left behind after rollback")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RenameService.moveFile / hardlinkOrCopy collision refusal (DL-2)
+// ---------------------------------------------------------------------------
+
+func TestMoveFileRefusesOverwrite(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewRenameService(mockStore)
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src.m4b")
+	dst := filepath.Join(tmpDir, "dst.m4b")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("existing book"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := svc.moveFile(src, dst)
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if data, rerr := os.ReadFile(dst); rerr != nil || string(data) != "existing book" {
+		t.Errorf("destination corrupted: %q err=%v", data, rerr)
+	}
+	if _, serr := os.Stat(src); serr != nil {
+		t.Errorf("source lost: %v", serr)
+	}
+}
+
+func TestHardlinkOrCopyRefusesOverwrite(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+	svc := NewRenameService(mockStore)
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src.m4b")
+	dst := filepath.Join(tmpDir, "dst.m4b")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("existing book"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := svc.hardlinkOrCopy(src, dst)
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if data, rerr := os.ReadFile(dst); rerr != nil || string(data) != "existing book" {
+		t.Errorf("destination corrupted: %q err=%v", data, rerr)
+	}
+	// No leftover temp file from the copy fallback.
+	if _, terr := os.Stat(dst + ".tmp"); !os.IsNotExist(terr) {
+		t.Error("copy temp file left behind")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Organizer.copyFile finalize collision refusal (DL-3 companion)
+// ---------------------------------------------------------------------------
+
+func TestCopyFileRefusesOverwrite(t *testing.T) {
+	o := &Organizer{}
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src.m4b")
+	dst := filepath.Join(tmpDir, "dst.m4b")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("existing book"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := o.copyFile(src, dst)
+	if err == nil {
+		t.Fatal("expected collision error, got nil")
+	}
+	if !os.IsExist(err) {
+		t.Errorf("expected os.IsExist(err) for organize-pool race recovery, got: %v", err)
+	}
+	if data, rerr := os.ReadFile(dst); rerr != nil || string(data) != "existing book" {
+		t.Errorf("destination corrupted: %q err=%v", data, rerr)
+	}
+}

--- a/internal/organizer/organizer.go
+++ b/internal/organizer/organizer.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/organizer.go
-// version: 1.18.0
+// version: 1.19.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-07-17
 
 package organizer
 
@@ -493,8 +494,15 @@ func (o *Organizer) copyFile(src, dst string) error {
 		_ = os.Remove(tempPath)
 		return fmt.Errorf("failed to close destination file: %w", err)
 	}
-	if err := os.Rename(tempPath, dst); err != nil {
+	// safeRename: a bare os.Rename would silently replace a destination that
+	// appeared between the caller's exists-check and now (concurrent organize
+	// workers) — refuse instead. The wrapped error still satisfies
+	// os.IsExist, so organizeFile callers' race recovery keeps working.
+	if err := safeRename(tempPath, dst); err != nil {
 		_ = os.Remove(tempPath)
+		if os.IsExist(err) {
+			return err
+		}
 		return fmt.Errorf("failed to finalize destination file: %w", err)
 	}
 

--- a/internal/organizer/pipeline.go
+++ b/internal/organizer/pipeline.go
@@ -1,11 +1,13 @@
 // file: internal/organizer/pipeline.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f01234567890
+// last-edited: 2026-07-17
 
 package organizer
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,6 +15,10 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
+
+// tmpRenameSuffix is appended to the target path to form the intermediate
+// temp path used by RenameFiles' two-phase rename.
+const tmpRenameSuffix = ".tmp-rename"
 
 // FileRenameEntry represents a planned file rename operation.
 type FileRenameEntry struct {
@@ -143,57 +149,102 @@ type RenameFilesResult struct {
 	Errors    []string          `json:"errors,omitempty"`
 }
 
+// renameTemp tracks a file parked at its intermediate temp path during a
+// two-phase rename.
+type renameTemp struct {
+	TempPath string
+	Entry    FileRenameEntry
+}
+
+// rollbackRenameTemps returns files parked at their temp paths back to their
+// original source paths. A rollback failure is loud: a file left at a
+// .tmp-rename path is invisible to the library (its DB row points at the old
+// source path), so each failure is logged as an Error with both paths and
+// recorded in result.Errors — never silently dropped.
+func rollbackRenameTemps(temps []renameTemp, result *RenameFilesResult) {
+	for _, t := range temps {
+		if err := os.Rename(t.TempPath, t.Entry.SourcePath); err != nil {
+			slog.Error("RenameFiles rollback failed — file stranded at temp path",
+				"temp_path", t.TempPath,
+				"source_path", t.Entry.SourcePath,
+				"target_path", t.Entry.TargetPath,
+				"error", err)
+			result.Errors = append(result.Errors, fmt.Sprintf(
+				"rollback failed, file stranded at %s (source %s): %v",
+				t.TempPath, t.Entry.SourcePath, err))
+		}
+	}
+}
+
 // RenameFiles performs atomic file renames using a temp intermediate step
 // to avoid conflicts when source and target overlap.
 // Missing source files are skipped (not fatal) and reported in the result.
+//
+// Failure semantics:
+//   - A file stranded at its temp path by a previously interrupted run (temp
+//     exists, source doesn't) is picked up and resumed through phase 2 instead
+//     of being skipped forever.
+//   - On any phase failure, every file still parked at a temp path is rolled
+//     back to its source path; rollback failures are logged and recorded in
+//     result.Errors.
+//   - Entries that already reached their final path before the failure remain
+//     in result.Succeeded — callers must persist DB path updates for them even
+//     when an error is returned.
+//   - Both phases refuse to overwrite an existing destination (safeRename);
+//     a collision fails the batch instead of silently destroying bytes.
 func RenameFiles(entries []FileRenameEntry) (*RenameFilesResult, error) {
 	result := &RenameFilesResult{}
 	if len(entries) == 0 {
 		return result, nil
 	}
 
-	// Pre-filter: skip entries where source doesn't exist
+	// Pre-filter: skip entries where source doesn't exist — unless the file
+	// was stranded at its temp path by an interrupted phase 2, in which case
+	// it re-enters phase 2 below so the rename completes.
 	var valid []FileRenameEntry
+	var temps []renameTemp
 	for _, entry := range entries {
 		if _, err := os.Stat(entry.SourcePath); os.IsNotExist(err) {
+			tempPath := entry.TargetPath + tmpRenameSuffix
+			if _, terr := os.Stat(tempPath); terr == nil {
+				slog.Warn("RenameFiles resuming stranded temp file from interrupted rename",
+					"temp_path", tempPath, "target_path", entry.TargetPath)
+				temps = append(temps, renameTemp{TempPath: tempPath, Entry: entry})
+				continue
+			}
 			result.Skipped = append(result.Skipped, entry)
 			continue
 		}
 		valid = append(valid, entry)
 	}
 
-	if len(valid) == 0 {
+	if len(valid) == 0 && len(temps) == 0 {
 		return result, nil
 	}
 
 	// Phase 1: rename source -> temp
-	type tempEntry struct {
-		TempPath string
-		Entry    FileRenameEntry
-	}
-	var temps []tempEntry
-
 	for _, entry := range valid {
 		// Ensure target directory exists
 		targetDir := filepath.Dir(entry.TargetPath)
 		if err := os.MkdirAll(targetDir, 0o775); err != nil {
+			rollbackRenameTemps(temps, result)
 			return result, fmt.Errorf("create target dir %s: %w", targetDir, err)
 		}
 
-		tempPath := entry.TargetPath + ".tmp-rename"
-		if err := os.Rename(entry.SourcePath, tempPath); err != nil {
+		tempPath := entry.TargetPath + tmpRenameSuffix
+		if err := safeRename(entry.SourcePath, tempPath); err != nil {
 			// Rollback temps already moved
-			for _, t := range temps {
-				_ = os.Rename(t.TempPath, t.Entry.SourcePath)
-			}
+			rollbackRenameTemps(temps, result)
 			return result, fmt.Errorf("rename %s -> temp: %w", entry.SourcePath, err)
 		}
-		temps = append(temps, tempEntry{TempPath: tempPath, Entry: entry})
+		temps = append(temps, renameTemp{TempPath: tempPath, Entry: entry})
 	}
 
-	// Phase 2: rename temp -> final
-	for _, t := range temps {
-		if err := os.Rename(t.TempPath, t.Entry.TargetPath); err != nil {
+	// Phase 2: rename temp -> final. On failure, roll back this and every
+	// remaining temp so no file is left stranded at a .tmp-rename path.
+	for i, t := range temps {
+		if err := safeRename(t.TempPath, t.Entry.TargetPath); err != nil {
+			rollbackRenameTemps(temps[i:], result)
 			return result, fmt.Errorf("rename temp -> %s: %w", t.Entry.TargetPath, err)
 		}
 		result.Succeeded = append(result.Succeeded, t.Entry)

--- a/internal/organizer/reflink_unix.go
+++ b/internal/organizer/reflink_unix.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/reflink_unix.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
+// last-edited: 2026-07-17
 
 //go:build darwin || linux
 
@@ -22,9 +23,18 @@ func (o *Organizer) reflinkFilePlatform(sourcePath, targetPath string) error {
 	}
 	defer srcFile.Close()
 
-	// Create destination file
-	dstFile, err := os.Create(targetPath)
+	// Create destination file. O_EXCL: os.Create would TRUNCATE an existing
+	// destination — under the concurrent organize worker pool a stat→create
+	// TOCTOU race could zero out a file another worker just finished (unlike
+	// os.Link, which fails with EEXIST). With O_EXCL an existing destination
+	// errors instead; the raw error is returned un-wrapped when it is an
+	// exists-error so callers' os.IsExist recovery works, mirroring the
+	// hardlink fallback.
+	dstFile, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o664)
 	if err != nil {
+		if os.IsExist(err) {
+			return err
+		}
 		return fmt.Errorf("failed to create destination file: %w", err)
 	}
 	defer dstFile.Close()

--- a/internal/organizer/reflink_unix_dataloss_test.go
+++ b/internal/organizer/reflink_unix_dataloss_test.go
@@ -1,0 +1,48 @@
+// file: internal/organizer/reflink_unix_dataloss_test.go
+// version: 1.0.0
+// guid: 5c6177ff-1c47-4386-ab1e-8bef9b9faf05
+// last-edited: 2026-07-17
+
+//go:build darwin || linux
+
+package organizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReflinkRefusesExistingDestination proves DL-3: reflinkFilePlatform must
+// NOT truncate an existing destination (os.Create did — a stat→create TOCTOU
+// under the concurrent organize pool could zero a file another worker just
+// wrote). With O_EXCL the open fails with an exists-error that callers'
+// os.IsExist recovery understands, matching the os.Link fallback.
+func TestReflinkRefusesExistingDestination(t *testing.T) {
+	o := &Organizer{}
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src.m4b")
+	dst := filepath.Join(tmpDir, "dst.m4b")
+	if err := os.WriteFile(src, []byte("source bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("existing book"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := o.reflinkFilePlatform(src, dst)
+	if err == nil {
+		t.Fatal("expected error for existing destination, got nil")
+	}
+	if !os.IsExist(err) {
+		t.Errorf("expected os.IsExist(err) so the organize pool's race recovery fires, got: %v", err)
+	}
+	// The destination must NOT have been truncated.
+	data, rerr := os.ReadFile(dst)
+	if rerr != nil {
+		t.Fatalf("read dst: %v", rerr)
+	}
+	if string(data) != "existing book" {
+		t.Errorf("destination truncated/overwritten: %q", data)
+	}
+}

--- a/internal/organizer/rename.go
+++ b/internal/organizer/rename.go
@@ -1,6 +1,7 @@
 // file: internal/organizer/rename.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-e1f2-a3b4-c5d6e7f8a9b0
+// last-edited: 2026-07-17
 
 package organizer
 
@@ -388,9 +389,15 @@ func (rs *RenameService) moveFile(src, dst string) error {
 		}
 	}
 
-	// Try os.Rename first (same filesystem)
-	if err := os.Rename(src, dst); err == nil {
+	// Try rename first (same filesystem). safeRename refuses to overwrite an
+	// existing destination — a bare os.Rename would silently REPLACE it,
+	// destroying another book's bytes on a path collision.
+	err := safeRename(src, dst)
+	if err == nil {
 		return nil
+	}
+	if os.IsExist(err) {
+		return fmt.Errorf("destination already exists, refusing to overwrite: %s", dst)
 	}
 
 	// Fallback: copy + delete for cross-filesystem moves
@@ -424,7 +431,9 @@ func (rs *RenameService) copyAndDelete(src, dst string) error {
 		_ = os.Remove(tmpDst)
 		return fmt.Errorf("failed to close: %w", err)
 	}
-	if err := os.Rename(tmpDst, dst); err != nil {
+	// safeRename: refuse to overwrite a destination that appeared during the
+	// copy (bare os.Rename would silently replace it).
+	if err := safeRename(tmpDst, dst); err != nil {
 		_ = os.Remove(tmpDst)
 		return fmt.Errorf("failed to finalize: %w", err)
 	}
@@ -446,9 +455,13 @@ func (rs *RenameService) hardlinkOrCopy(src, dst string) error {
 		}
 	}
 
-	// Try hardlink first
+	// Try hardlink first. os.Link fails with EEXIST if dst exists — treat
+	// that as a terminal collision instead of falling through to the copy
+	// path, whose finalize rename would silently overwrite the existing file.
 	if err := os.Link(src, dst); err == nil {
 		return nil
+	} else if os.IsExist(err) {
+		return fmt.Errorf("destination already exists, refusing to overwrite: %s", dst)
 	}
 
 	// Fallback: copy (never deletes source)
@@ -477,7 +490,13 @@ func (rs *RenameService) hardlinkOrCopy(src, dst string) error {
 		_ = os.Remove(tmpDst)
 		return fmt.Errorf("failed to close: %w", err)
 	}
-	return os.Rename(tmpDst, dst)
+	// safeRename: refuse to overwrite a destination that appeared during the
+	// copy (bare os.Rename would silently replace it).
+	if err := safeRename(tmpDst, dst); err != nil {
+		_ = os.Remove(tmpDst)
+		return fmt.Errorf("failed to finalize: %w", err)
+	}
+	return nil
 }
 
 // stringPtr returns a pointer to the given string.

--- a/internal/organizer/saferename.go
+++ b/internal/organizer/saferename.go
@@ -1,0 +1,39 @@
+// file: internal/organizer/saferename.go
+// version: 1.0.0
+// guid: 2df18e44-98f0-407e-ab5f-daf158f22554
+// last-edited: 2026-07-17
+
+package organizer
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+)
+
+// safeRename renames src to dst, refusing to overwrite an existing dst.
+//
+// POSIX rename(2) silently REPLACES an existing destination file, so a bare
+// os.Rename on a path collision destroys another book's bytes. Every wired
+// move/rename in this package must go through this helper (or perform its own
+// explicit destination check, like MoveBookFile). Callers that intend to
+// overwrite must delete dst explicitly first.
+//
+// The collision error is an *os.LinkError wrapping fs.ErrExist, so both
+// os.IsExist(err) and errors.Is(err, fs.ErrExist) recognize it — matching the
+// os.Link EEXIST behavior the organize worker pool already recovers from.
+//
+// There is an unavoidable TOCTOU window between the Lstat and the rename; the
+// guard converts a silent overwrite into an explicit error in all but a
+// sub-millisecond race, matching MoveBookFile's existing posture.
+func safeRename(src, dst string) error {
+	if _, err := os.Lstat(dst); err == nil {
+		slog.Warn("safeRename refusing to overwrite existing destination",
+			"src", src, "dst", dst)
+		return &os.LinkError{Op: "rename", Old: src, New: dst, Err: fs.ErrExist}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat rename destination %s: %w", dst, err)
+	}
+	return os.Rename(src, dst)
+}

--- a/internal/organizer/service.go
+++ b/internal/organizer/service.go
@@ -1,7 +1,7 @@
 // file: internal/organizer/service.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: c3d4e5f6-a7b8-c9d0-e1f2-a3b4c5d6e7f8
-// last-edited: 2026-07-13
+// last-edited: 2026-07-17
 
 package organizer
 
@@ -450,8 +450,13 @@ func (orgSvc *Service) ReOrganizeInPlace(book *database.Book, log logger.Logger)
 		return "", fmt.Errorf("cannot create target directory %s: %w (check parent permissions and disk space)", parentDir, err)
 	}
 
-	// Rename (move) the file or directory
-	if err := os.Rename(oldPath, targetPath); err != nil {
+	// Rename (move) the file or directory. safeRename refuses to overwrite an
+	// existing destination — a bare os.Rename would silently REPLACE it,
+	// destroying whichever book already lives at the target path.
+	if err := safeRename(oldPath, targetPath); err != nil {
+		if os.IsExist(err) {
+			return "", fmt.Errorf("cannot move %s -> %s: destination already exists — refusing to overwrite; resolve the collision first", oldPath, targetPath)
+		}
 		return "", fmt.Errorf("cannot move %s -> %s: %w (verify both paths exist, target not in use, same filesystem, write permission)", oldPath, targetPath, err)
 	}
 


### PR DESCRIPTION
## Summary
Organizer data-loss fixes (DL-1/DL-2/DL-3 from docs/audits/2026-07-17-multi-discipline-review.md):
- DL-1: two-phase RenameFiles now rolls back temp→source on phase-2 failure (Error-logged if rollback fails), and retries recognize a stranded .tmp-rename file (resume phase 2 or roll back) instead of Skipped-forever
- DL-2: wired move paths refuse to overwrite an existing destination (path collision no longer destroys another book's bytes)
- DL-3: reflink destination opened O_CREATE|O_EXCL; copyFile finalize refuses overwrite — closes the truncate TOCTOU under the 8-worker pool

## Tests
Regression tests for all three; organizer package green under -race (16.6s).

Written by worker W7 (verified + shipped by coordinator after the worker hit the session limit post-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65