### PR TITLE
fix(registry): publish op.terminal SSE + reporter/scanner hygiene (T06+T08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,42 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.174.0 -->
+<!-- version: 3.175.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # Changelog
 
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - registry SSE + reporter/scanner hygiene (T06 + T08)
+
+- **R-1 (op.terminal SSE, T06):** the backend now publishes an `op.terminal`
+  event on every terminal transition — completed, failed, canceled, timeout,
+  abandonment (`interrupted_*`), force-drop, canceled-before-start, and
+  canceled-while-queued. Previously the event contract existed only on the
+  frontend, so finished operations lingered as phantom "running" entries in the
+  operations bell until a manual refresh. New helper
+  `Registry.publishOpTerminal` fans out `{op_id, def_id, status}` via the
+  existing bus (nil-safe; no direct SSE-hub import). Covered by
+  `terminal_events_test.go`.
+- **R-3 (abandoned-reporter log buffer, T08):** after a run is abandoned its
+  reporter's flush goroutine has already exited, but the wedged goroutine kept
+  calling `Log`, growing `logBuf` without bound and losing every line anyway.
+  The buffer is now capped at 1,000 entries (drop-oldest with a dropped-counter)
+  and the worker flips a terminal flag (`markTerminal`) on the abandonment paths
+  so subsequent `Log` calls are cheap no-ops. Covered by
+  `reporter_terminal_test.go`.
+- **R-7 (dead scan-checkpoint code, T08):** removed the unused
+  `ScanService.PerformScanWithID` (zero callers) and its
+  `operations.SaveParams(ScanParams)`/`ClearState` calls — `LoadParams[ScanParams]`
+  had zero callers and `library.scan` uses `ResumePolicy=ResumeDrop`, so an
+  interrupted scan restarts from scratch (idempotent re-walk) rather than
+  resuming from a checkpoint that was never read.
+- **P-2 (parallel progress counter, T08):** `RunItems` now reports an atomic
+  completion count instead of the item index, so parallel progress no longer
+  jumps backwards when items finish out of order. Covered by
+  `run_items_p2_test.go`.
 
 #### July 17, 2026 - error-correction fix wave (15 PRs) + sandbox verification
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.4.0 -->
+<!-- version: 10.4.1 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -175,7 +175,7 @@ R-2/C-3/C-2/C-4/C-5/C-1 (#1980) · C1/C6/C4/C5/C3 (#1981) ·
 breakdown-backfill op + title-leak relax (#1982) · devops 1(code)/2(template)/
 3/4/5/9 (#1983) · DL-5/C-6/C-7/M5/M6 (#1984) · R-4/H5/R-5/H6/DL-4/M8 (#1985) ·
 DL-1/DL-2/DL-3/M4 (#1986 — OPEN in CI at time of writing, see brief T01) ·
-R-1 (T06) + R-3/R-7/P-2 (T08) (#PR_PLACEHOLDER).
+R-1 (T06) + R-3/R-7/P-2 (T08) (#2002).
 
 ### Remaining — execution state (briefs)
 
@@ -184,9 +184,9 @@ R-1 (T06) + R-3/R-7/P-2 (T08) (#PR_PLACEHOLDER).
 - [ ] **T03** — sandbox: triage purge wave → purge-stale → full-scan → final backlog measurement vs 9,074 baseline
 - [ ] **T04** — prod deploy (nothing deployed 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
 - [ ] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (file:line anchors in the brief)
-- [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #PR_PLACEHOLDER)
+- [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #2002)
 - [ ] **T07** — R-6: AssignOrphanVGs serial loop + VersionGroupID clobber guard (`internal/reconcile/reconcile.go:1270-1327`)
-- [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #PR_PLACEHOLDER)
+- [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #2002)
 - [ ] **T09** — C2: remux/transcode 6-h ops have no reporter threading + can't fail · H7 (external-id backfill, same shape)
 - [ ] **T10** — F6: legacy dedup.MergeBooks hard-deletes losers without external-ID reassignment/ITL removal — VERIFY then reroute
 - [ ] **T11** — F7 (quarantine serial loops → RunItems) · R-9 (path_repair serial loop) · R-8 (all-unreadable-durations group misclassified "short")

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 <!-- file: TODO.md -->
-<!-- version: 10.3.0 -->
+<!-- version: 10.4.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # Project TODO — live items only
 
@@ -174,7 +174,8 @@ F1 (#1973) · F2 (#1976) · F3/F4/F5/C7 (#1977) · title-repair op (#1978) ·
 R-2/C-3/C-2/C-4/C-5/C-1 (#1980) · C1/C6/C4/C5/C3 (#1981) ·
 breakdown-backfill op + title-leak relax (#1982) · devops 1(code)/2(template)/
 3/4/5/9 (#1983) · DL-5/C-6/C-7/M5/M6 (#1984) · R-4/H5/R-5/H6/DL-4/M8 (#1985) ·
-DL-1/DL-2/DL-3/M4 (#1986 — OPEN in CI at time of writing, see brief T01).
+DL-1/DL-2/DL-3/M4 (#1986 — OPEN in CI at time of writing, see brief T01) ·
+R-1 (T06) + R-3/R-7/P-2 (T08) (#PR_PLACEHOLDER).
 
 ### Remaining — execution state (briefs)
 
@@ -183,9 +184,9 @@ DL-1/DL-2/DL-3/M4 (#1986 — OPEN in CI at time of writing, see brief T01).
 - [ ] **T03** — sandbox: triage purge wave → purge-stale → full-scan → final backlog measurement vs 9,074 baseline
 - [ ] **T04** — prod deploy (nothing deployed 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
 - [ ] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (file:line anchors in the brief)
-- [ ] **T06** — R-1: `op.terminal` SSE has zero backend publishers (phantom "running" ops in UI)
+- [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #PR_PLACEHOLDER)
 - [ ] **T07** — R-6: AssignOrphanVGs serial loop + VersionGroupID clobber guard (`internal/reconcile/reconcile.go:1270-1327`)
-- [ ] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress)
+- [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #PR_PLACEHOLDER)
 - [ ] **T09** — C2: remux/transcode 6-h ops have no reporter threading + can't fail · H7 (external-id backfill, same shape)
 - [ ] **T10** — F6: legacy dedup.MergeBooks hard-deletes losers without external-ID reassignment/ITL removal — VERIFY then reroute
 - [ ] **T11** — F7 (quarantine serial loops → RunItems) · R-9 (path_repair serial loop) · R-8 (all-unreadable-durations group misclassified "short")

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.7.0
+// version: 3.8.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package registry
 
@@ -779,6 +779,30 @@ func (r *Registry) publishOpCreated(row database.OperationV2Row, resumed bool) {
 	})
 }
 
+// publishOpTerminal fans out an op.terminal SSE event (R-1) whenever an
+// operation reaches a terminal status (completed, failed, canceled, timeout,
+// interrupted_*, or force-dropped). Without it, the UI's operations bell keeps
+// rendering a finished op as "running" until the next manual refresh — the
+// backend never told it the op ended. The frontend
+// (web/src/stores/useOperationsStore.ts) responds to this event by reloading
+// operation state from the server.
+//
+// context.Background() is used deliberately (not the run's context): every
+// terminal call site reaches here AFTER the run context has been canceled
+// (canceled/timeout/abandon paths) or is about to be, so passing runCtx would
+// make the publish a no-op on exactly the paths that most need it. The bus is
+// nil-safe; publishOpTerminal is a no-op when no bus is wired.
+func (r *Registry) publishOpTerminal(opID, defID, status string) {
+	if r.bus == nil {
+		return
+	}
+	_ = r.bus.Publish(context.Background(), "op.terminal", map[string]any{
+		"op_id":  opID,
+		"def_id": defID,
+		"status": status,
+	})
+}
+
 // Cancel cancels an operation by id.
 // If the op is queued, it is marked canceled in the DB.
 // If the op is running, its context is canceled.
@@ -822,6 +846,15 @@ func (r *Registry) Cancel(opID string) error {
 	}
 	if updated {
 		r.logger.Info("registry: canceled queued op", "op_id", opID)
+		// R-1: a purely-queued op is never picked up by a worker once canceled,
+		// so no worker-path op.terminal fires — publish it here or the UI bell
+		// leaves the op phantom-"running". def_id is best-effort (the FE only
+		// needs op_id); an empty def_id on a lookup miss is harmless.
+		defID := ""
+		if row, gerr := r.store.GetOperationV2(opID); gerr == nil && row != nil {
+			defID = row.DefID
+		}
+		r.publishOpTerminal(opID, defID, "canceled")
 	}
 	return nil
 }

--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
-// last-edited: 2026-06-24
+// last-edited: 2026-07-18
 
 package registry
 
@@ -54,9 +54,16 @@ type dbReporter struct {
 	activityRecorder ActivityRecorder
 	logger           *slog.Logger
 
-	logMu   sync.Mutex
-	logBuf  []logEntry
-	flushCh chan struct{}
+	logMu       sync.Mutex
+	logBuf      []logEntry
+	droppedLogs uint64 // count of oldest entries dropped after logBuf hit the cap (guarded by logMu)
+	flushCh     chan struct{}
+
+	// terminated is flipped by markTerminal() when the owning run is abandoned:
+	// its flushLoop has already exited (runCtx canceled) so any further buffered
+	// log lines are unrecoverable. Once set, Log() is a cheap no-op. Atomic so
+	// the wedged Run goroutine can read it without taking logMu. (R-3)
+	terminated atomic.Bool
 
 	progressMu          sync.Mutex
 	progressCurrent     int
@@ -341,8 +348,22 @@ func (r *dbReporter) UpdateProgress(current, total int, message string) error {
 	return nil
 }
 
+// maxBufferedLogEntries caps logBuf. When a run is abandoned its flushLoop has
+// exited but the wedged goroutine may keep calling Log; without a cap logBuf
+// would grow without bound. Beyond the cap the oldest entries are dropped and
+// counted (see droppedLogs). 1,000 entries is far more than any healthy flush
+// interval (250ms) ever leaves unflushed. (R-3)
+const maxBufferedLogEntries = 1000
+
 // Log implements Reporter.
 func (r *dbReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	// R-3: after abandonment the reporter is terminal — its flushLoop is gone,
+	// so buffered lines can never be persisted. Drop the line cheaply rather
+	// than growing logBuf forever behind a monitored-but-wedged goroutine.
+	if r.terminated.Load() {
+		return nil
+	}
+
 	entry := logEntry{
 		level:     level,
 		message:   message,
@@ -352,6 +373,12 @@ func (r *dbReporter) Log(level slog.Level, message string, attrs ...slog.Attr) e
 
 	r.logMu.Lock()
 	r.logBuf = append(r.logBuf, entry)
+	// R-3: bound the buffer, dropping oldest-first so the most recent lines
+	// survive. Counts the drops for observability.
+	if over := len(r.logBuf) - maxBufferedLogEntries; over > 0 {
+		r.logBuf = r.logBuf[over:]
+		r.droppedLogs += uint64(over)
+	}
 	shouldFlush := len(r.logBuf) >= 100
 	r.logMu.Unlock()
 
@@ -392,6 +419,34 @@ func (r *dbReporter) Log(level slog.Level, message string, attrs ...slog.Attr) e
 // Logger implements Reporter.
 func (r *dbReporter) Logger() *slog.Logger {
 	return r.logger
+}
+
+// markTerminal flags the reporter as terminal so subsequent Log calls become
+// cheap no-ops (R-3). Called by the worker on the abandonment paths, where the
+// run's flushLoop has already exited (runCtx canceled) and any further log
+// lines are unrecoverable by design. If any lines were already dropped by the
+// buffer cap it records that fact once, on the process logger (r.Log would
+// no-op now, and recursing into it would be pointless).
+func (r *dbReporter) markTerminal() {
+	if r.terminated.Swap(true) {
+		return // already terminal — don't double-log
+	}
+	r.logMu.Lock()
+	dropped := r.droppedLogs
+	buffered := len(r.logBuf)
+	r.logMu.Unlock()
+	if dropped > 0 || buffered > 0 {
+		slog.Default().Warn("dbReporter: reporter marked terminal after abandonment; buffered op logs discarded",
+			"op_id", r.opID, "dropped_over_cap", dropped, "buffered_unflushed", buffered)
+	}
+}
+
+// droppedLogCount returns the number of log entries dropped after the buffer
+// hit its cap. Used by tests. (R-3)
+func (r *dbReporter) droppedLogCount() uint64 {
+	r.logMu.Lock()
+	defer r.logMu.Unlock()
+	return r.droppedLogs
 }
 
 // Checkpoint implements Reporter.

--- a/internal/operations/registry/reporter_terminal_test.go
+++ b/internal/operations/registry/reporter_terminal_test.go
@@ -1,0 +1,99 @@
+// file: internal/operations/registry/reporter_terminal_test.go
+// version: 1.0.0
+// guid: 9b1c4e7a-3d52-4a68-b0f1-6c2d3e4f5a6b
+// last-edited: 2026-07-18
+
+package registry
+
+// White-box tests for R-3: the abandoned-reporter log-buffer guards. Kept in
+// package registry (not registry_test) so they can construct a bare dbReporter
+// and reach the unexported markTerminal / droppedLogCount without a store or
+// flush goroutine.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// newBareReporter builds a dbReporter with no store, bus, activity recorder, or
+// flushLoop goroutine — Log on it touches only in-memory state at info level.
+func newBareReporter() *dbReporter {
+	return &dbReporter{
+		opID:    "op-r3",
+		defID:   "test.r3",
+		flushCh: make(chan struct{}, 1),
+		runCtx:  context.Background(),
+	}
+}
+
+// TestReporterR3_LogNoOpAfterTerminal verifies that once markTerminal is called
+// (the abandonment path) Log stops buffering — the fix that stops logBuf from
+// growing unbounded behind a wedged goroutine.
+func TestReporterR3_LogNoOpAfterTerminal(t *testing.T) {
+	r := newBareReporter()
+
+	// A few pre-terminal lines buffer normally.
+	for i := 0; i < 5; i++ {
+		_ = r.Log(slog.LevelInfo, "pre-terminal")
+	}
+	r.logMu.Lock()
+	before := len(r.logBuf)
+	r.logMu.Unlock()
+	if before != 5 {
+		t.Fatalf("expected 5 buffered entries pre-terminal, got %d", before)
+	}
+
+	r.markTerminal()
+
+	// Post-terminal lines must be dropped without touching the buffer.
+	for i := 0; i < 10_000; i++ {
+		_ = r.Log(slog.LevelInfo, "post-terminal — wedged goroutine still logging")
+	}
+	r.logMu.Lock()
+	after := len(r.logBuf)
+	r.logMu.Unlock()
+	if after != before {
+		t.Errorf("logBuf grew after markTerminal: before=%d after=%d (want no growth)", before, after)
+	}
+	if !r.terminated.Load() {
+		t.Error("terminated flag not set after markTerminal")
+	}
+}
+
+// TestReporterR3_BufferCapDropsOldest verifies that even before termination the
+// buffer is bounded: past the cap, oldest entries are dropped and counted, so a
+// run whose flushLoop has stalled cannot grow logBuf without limit.
+func TestReporterR3_BufferCapDropsOldest(t *testing.T) {
+	r := newBareReporter()
+
+	const extra = 500
+	total := maxBufferedLogEntries + extra
+	for i := 0; i < total; i++ {
+		_ = r.Log(slog.LevelInfo, "line")
+	}
+
+	r.logMu.Lock()
+	got := len(r.logBuf)
+	r.logMu.Unlock()
+	if got != maxBufferedLogEntries {
+		t.Errorf("logBuf len: got %d want cap %d", got, maxBufferedLogEntries)
+	}
+	if dropped := r.droppedLogCount(); dropped != extra {
+		t.Errorf("droppedLogCount: got %d want %d", dropped, extra)
+	}
+}
+
+// TestReporterR3_MarkTerminalIdempotent verifies markTerminal is safe to call
+// more than once (both shutdown-abandon and genuine-abandon paths may hit it).
+func TestReporterR3_MarkTerminalIdempotent(t *testing.T) {
+	r := newBareReporter()
+	r.markTerminal()
+	r.markTerminal() // must not panic or flip anything back
+	if !r.terminated.Load() {
+		t.Error("terminated flag cleared by second markTerminal")
+	}
+	if err := r.Log(slog.LevelInfo, "x"); err != nil {
+		t.Errorf("Log after terminal returned error: %v", err)
+	}
+}

--- a/internal/operations/registry/run_items.go
+++ b/internal/operations/registry/run_items.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/run_items.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: a2b3c4d5-e6f7-8901-abcd-ef2345678901
-// last-edited: 2026-06-25
+// last-edited: 2026-07-18
 
 package registry
 
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -101,6 +102,13 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 		lbl = func(i, total int) string { return fmt.Sprintf("item %d/%d", opt.ProgressOffset+i+1, total) }
 	}
 
+	// P-2: report a monotonic completion count, not the item index. In parallel
+	// mode items finish out of order, so reporting ProgressOffset+i+1 made the
+	// progress bar jump backwards (item 5 finishing before item 2 reported 6
+	// then 3). An atomic counter incremented as each item completes is monotonic
+	// in both sequential and parallel modes. The label still carries the item's
+	// own index for identity.
+	var completed atomic.Int64
 	runOne := func(ctx context.Context, i int, item T) error {
 		itemCtx := ctx
 		if opt.PerItemTimeout > 0 {
@@ -111,7 +119,8 @@ func RunItems[T any](ctx context.Context, r Reporter, items []T, fn func(ctx con
 		l := lbl(i, progTotal)
 		r.SetCurrentItem(l)
 		err := fn(itemCtx, item)
-		_ = r.UpdateProgress(opt.ProgressOffset+i+1, progTotal, l)
+		done := int(completed.Add(1))
+		_ = r.UpdateProgress(opt.ProgressOffset+done, progTotal, l)
 		return err
 	}
 

--- a/internal/operations/registry/run_items_p2_test.go
+++ b/internal/operations/registry/run_items_p2_test.go
@@ -1,0 +1,118 @@
+// file: internal/operations/registry/run_items_p2_test.go
+// version: 1.0.0
+// guid: 4f8a2c6e-1b93-4d57-8e0a-2c9b1d3e4f60
+// last-edited: 2026-07-18
+
+package registry_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// p2ProgReporter records every UpdateProgress current value thread-safely so a
+// parallel RunItems test can assert on the reported progression. Task-unique
+// name per the parallel-test-helper-collision rule.
+type p2ProgReporter struct {
+	mu       sync.Mutex
+	currents []int
+}
+
+func (r *p2ProgReporter) UpdateProgress(current, _ int, _ string) error {
+	r.mu.Lock()
+	r.currents = append(r.currents, current)
+	r.mu.Unlock()
+	return nil
+}
+func (r *p2ProgReporter) SetCurrentItem(string)                         {}
+func (r *p2ProgReporter) Log(slog.Level, string, ...slog.Attr) error    { return nil }
+func (r *p2ProgReporter) Logger() *slog.Logger                          { return slog.Default() }
+func (r *p2ProgReporter) Checkpoint(any) error                          { return nil }
+func (r *p2ProgReporter) IsCanceled() bool                              { return false }
+func (r *p2ProgReporter) Trigger(context.Context, string, any) error    { return nil }
+func (r *p2ProgReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, r)
+}
+
+func (r *p2ProgReporter) snapshot() (count, max int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, c := range r.currents {
+		if c > max {
+			max = c
+		}
+	}
+	return len(r.currents), max
+}
+
+// TestRunItems_ParallelProgressIsCompletionCount is the P-2 regression test.
+//
+// The bug: parallel RunItems reported the item INDEX (i+1), not a completion
+// count — so a high-index item finishing early reported a high progress value
+// while few items had actually completed, and the bar jumped backwards.
+//
+// Setup: N items at full concurrency. Item 0 blocks until released; items
+// 1..N-1 all complete first. Once those N-1 completions are reported, the max
+// reported value must be <= N-1 (fix) — under the index-based bug it would
+// already be N (item N-1 reported N while item 0 was still running).
+func TestRunItems_ParallelProgressIsCompletionCount(t *testing.T) {
+	const n = 20
+	rep := &p2ProgReporter{}
+	items := make([]int, n)
+	for i := range items {
+		items[i] = i
+	}
+
+	release := make(chan struct{})
+	fn := func(_ context.Context, item int) error {
+		if item == 0 {
+			<-release // finishes last
+		}
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- registry.RunItems(context.Background(), rep, items, fn,
+			registry.RunItemsOptions{Concurrency: n})
+	}()
+
+	// Wait until the N-1 non-blocking items have all reported completion.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		count, _ := rep.snapshot()
+		if count >= n-1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d progress reports after 5s, wanted %d", count, n-1)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// With item 0 still blocked, at most n-1 items have completed, so the
+	// highest progress value reported so far must not exceed n-1.
+	if _, max := rep.snapshot(); max > n-1 {
+		t.Errorf("progress reported %d with item 0 still running (only %d completed) — "+
+			"progress is tracking item index, not completion count", max, n-1)
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("RunItems returned error: %v", err)
+	}
+
+	// Final report must reach n and never exceed it.
+	count, max := rep.snapshot()
+	if count != n {
+		t.Errorf("expected %d progress reports total, got %d", n, count)
+	}
+	if max != n {
+		t.Errorf("final max progress: got %d want %d", max, n)
+	}
+}

--- a/internal/operations/registry/terminal_events_test.go
+++ b/internal/operations/registry/terminal_events_test.go
@@ -1,0 +1,234 @@
+// file: internal/operations/registry/terminal_events_test.go
+// version: 1.0.0
+// guid: 7e3d9c1a-2b46-4f80-9c5e-1a7f2b3c4d5e
+// last-edited: 2026-07-18
+
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// t06TermBus is a mutex-protected recording Bus for the R-1 op.terminal tests.
+// Terminal events are published from worker goroutines, so a plain slice append
+// (like the existing recordingBus) would race under -race. Task-unique name per
+// the parallel-test-helper-collision rule.
+type t06TermBus struct {
+	mu     sync.Mutex
+	events []t06TermEvent
+}
+
+type t06TermEvent struct {
+	name    string
+	payload map[string]any
+}
+
+func (b *t06TermBus) Publish(_ context.Context, name string, payload any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	m, _ := payload.(map[string]any)
+	b.events = append(b.events, t06TermEvent{name: name, payload: m})
+	return nil
+}
+
+// waitTerminal polls for an op.terminal event for opID and returns its status,
+// or fails the test after timeout. The event is published immediately AFTER the
+// terminal DB write in the worker, so a store-status check can win the race by
+// a hair — polling the bus closes that window.
+func (b *t06TermBus) waitTerminal(t *testing.T, opID string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		b.mu.Lock()
+		for _, ev := range b.events {
+			if ev.name == "op.terminal" && ev.payload["op_id"] == opID {
+				status, _ := ev.payload["status"].(string)
+				b.mu.Unlock()
+				return status
+			}
+		}
+		b.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no op.terminal event for op %s within %v", opID, timeout)
+	return ""
+}
+
+// TestTerminalEvent_Completed asserts op.terminal fires with status=completed.
+func TestTerminalEvent_Completed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	def := makeValidDef("test.term-completed")
+	def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error { return nil }
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.term-completed", nil)
+	awaitStatus(t, store, opID, "completed", 5*time.Second)
+	if got := bus.waitTerminal(t, opID, 5*time.Second); got != "completed" {
+		t.Errorf("op.terminal status: got %q want completed", got)
+	}
+}
+
+// TestTerminalEvent_Failed asserts op.terminal fires with status=failed.
+func TestTerminalEvent_Failed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	def := makeValidDef("test.term-failed")
+	def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		return errors.New("boom")
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.term-failed", nil)
+	awaitStatus(t, store, opID, "failed", 5*time.Second)
+	if got := bus.waitTerminal(t, opID, 5*time.Second); got != "failed" {
+		t.Errorf("op.terminal status: got %q want failed", got)
+	}
+}
+
+// TestTerminalEvent_CanceledRunning asserts op.terminal fires with
+// status=canceled when a running op's context is canceled (in-process path).
+func TestTerminalEvent_CanceledRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	started := make(chan struct{})
+	def := makeValidDef("test.term-canceled")
+	def.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(started)
+		<-runCtx.Done() // honor cancellation promptly (not abandoned)
+		return runCtx.Err()
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.term-canceled", nil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op did not start")
+	}
+	_ = r.Cancel(opID)
+
+	awaitStatus(t, store, opID, "canceled", 5*time.Second)
+	if got := bus.waitTerminal(t, opID, 5*time.Second); got != "canceled" {
+		t.Errorf("op.terminal status: got %q want canceled", got)
+	}
+}
+
+// TestTerminalEvent_Abandoned asserts op.terminal fires with an interrupted_*
+// status when a run ignores cancellation and is classified as abandoned.
+func TestTerminalEvent_Abandoned(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.NewWithOptions(store, slog.Default(), 2, registry.Options{
+		WatchdogInterval: 30 * time.Second,
+		AbandonedCap:     10,
+		AbandonGrace:     100 * time.Millisecond,
+		Bus:              bus,
+	})
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	def := makeValidDef("test.term-abandoned") // ResumeDrop → interrupted_dropped
+	def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(started)
+		<-release // ignore ctx: forces the abandonment path
+		return nil
+	}
+	_ = r.RegisterOp(def)
+	r.Start(ctx)
+
+	opID, _ := r.EnqueueOp(ctx, "test.term-abandoned", nil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op did not start")
+	}
+	_ = r.Cancel(opID)
+
+	awaitStatus(t, store, opID, "interrupted_dropped", 5*time.Second)
+	if got := bus.waitTerminal(t, opID, 5*time.Second); got != "interrupted_dropped" {
+		t.Errorf("op.terminal status: got %q want interrupted_dropped", got)
+	}
+	close(release)
+}
+
+// TestTerminalEvent_ForceDropped asserts op.terminal fires with
+// status=interrupted_dropped on the infinite-restart force-drop path. The
+// resume_count is set BEFORE Start so it can never race the worker pickup.
+func TestTerminalEvent_ForceDropped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	def := makeValidDef("test.term-forcedrop")
+	def.ResumePolicy = registry.ResumeRestart // required for checkInfiniteRestart
+	def.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error { return nil }
+	_ = r.RegisterOp(def)
+
+	// Enqueue before Start so the dispatcher can't pick it up until resume_count
+	// is staged (guards the enqueue-vs-setup race).
+	opID, _ := r.EnqueueOp(ctx, "test.term-forcedrop", nil)
+	store.setResumeCount(opID, 3) // >= 3 with high_water=0 → force drop
+	r.Start(ctx)
+
+	awaitStatus(t, store, opID, "interrupted_dropped", 5*time.Second)
+	if got := bus.waitTerminal(t, opID, 5*time.Second); got != "interrupted_dropped" {
+		t.Errorf("op.terminal status: got %q want interrupted_dropped", got)
+	}
+}
+
+// TestTerminalEvent_CanceledQueued asserts op.terminal fires with
+// status=canceled when a purely-queued op (never picked up) is canceled — the
+// path with no worker to publish the event on the op's behalf.
+func TestTerminalEvent_CanceledQueued(t *testing.T) {
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	def := makeValidDef("test.term-queued-cancel")
+	_ = r.RegisterOp(def)
+
+	// Do NOT Start — the op stays queued, never dispatched.
+	opID, err := r.EnqueueOp(context.Background(), "test.term-queued-cancel", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+	if err := r.Cancel(opID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if got := bus.waitTerminal(t, opID, 2*time.Second); got != "canceled" {
+		t.Errorf("op.terminal status: got %q want canceled", got)
+	}
+}

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.11.0
+// version: 2.12.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package registry
 
@@ -197,6 +197,9 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		if err := r.store.UpdateOperationV2Status(qr.opID, "canceled", nil, &now, &msg); err != nil {
 			r.logger.Warn("registry: failed to mark channel-canceled op canceled", "op_id", qr.opID, "error", err)
 		}
+		// R-1: this is a terminal transition too — publish op.terminal so the UI
+		// bell drops the op instead of leaving it phantom-"running".
+		r.publishOpTerminal(qr.opID, qr.defID, "canceled")
 		r.logger.Info("registry: dropped run canceled while queued in worker channel", "op_id", qr.opID, "def_id", qr.defID)
 		return false
 	}
@@ -265,6 +268,8 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		if err := r.store.UpdateOperationV2Status(qr.opID, finalStatus, nil, &completedAt, errMsg); err != nil {
 			r.logger.Warn("registry: failed to update subprocess op terminal status", "op_id", qr.opID, "error", err)
 		}
+		// R-1: fan out op.terminal so the UI bell stops showing this op as running.
+		r.publishOpTerminal(qr.opID, qr.defID, finalStatus)
 		// C-5: notify the dep scheduler on ALL terminal transitions (the
 		// subprocess path previously notified on none of them).
 		r.notifyDepTerminal(finalStatus, qr)
@@ -327,6 +332,11 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 				// so Shutdown (bounded by its own context) genuinely drains.
 				r.logger.Info("registry: op goroutine abandoned during shutdown; waiting for it to exit before freeing slot",
 					"op_id", qr.opID, "plugin", qr.plugin)
+				// R-3: same rationale as the genuine-abandonment path — the
+				// wedged goroutine's flushLoop is gone, so no-op its Log calls.
+				if dbr, ok := reporter.(*dbReporter); ok {
+					dbr.markTerminal()
+				}
 				go func() {
 					<-done
 					r.releaseRunHandle(qr.opID)
@@ -348,10 +358,20 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 			// row's status afterwards: the runaway goroutine's eventual return
 			// only decrements the abandoned counter (below).
 			abandonedAt := time.Now().UTC()
+			abandonStatus := interruptedStatus(qr.resumePolicy)
 			abandonMsg := "abandoned: op goroutine did not exit within grace after context cancellation"
-			if err := r.store.UpdateOperationV2Status(qr.opID, interruptedStatus(qr.resumePolicy), nil, &abandonedAt, &abandonMsg); err != nil {
+			if err := r.store.UpdateOperationV2Status(qr.opID, abandonStatus, nil, &abandonedAt, &abandonMsg); err != nil {
 				r.logger.Warn("registry: failed to mark abandoned op interrupted", "op_id", qr.opID, "error", err)
 			}
+			// R-3: the runaway goroutine keeps calling reporter.Log even though
+			// its flushLoop has exited (runCtx canceled) — the buffered lines are
+			// unrecoverable by design, so flip the reporter's terminal flag to make
+			// those Log calls cheap no-ops and stop logBuf from growing unbounded.
+			if dbr, ok := reporter.(*dbReporter); ok {
+				dbr.markTerminal()
+			}
+			// R-1: fan out op.terminal for the abandonment transition.
+			r.publishOpTerminal(qr.opID, qr.defID, abandonStatus)
 			// Terminal transition: resolve dep-waiting subjects now rather than
 			// leaving them to the 5m sweep (C-5).
 			for _, sub := range subjectsFromParams(qr.params) {
@@ -403,6 +423,9 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 	if err := r.store.UpdateOperationV2Status(qr.opID, finalStatus, nil, &completedAt, errMsg); err != nil {
 		r.logger.Warn("registry: failed to update op terminal status", "op_id", qr.opID, "error", err)
 	}
+
+	// R-1: fan out op.terminal so the UI bell stops showing this op as running.
+	r.publishOpTerminal(qr.opID, qr.defID, finalStatus)
 
 	// Notify the dependency scheduler (async; non-blocking) so waiting_deps ops
 	// for the same subject can be re-evaluated or failed as appropriate.
@@ -482,6 +505,8 @@ func (r *Registry) checkInfiniteRestart(qr *queuedRun, def OperationDef) bool {
 	completed := time.Now().UTC()
 	msg := "force-dropped: infinite restart without progress"
 	_ = r.store.UpdateOperationV2Status(qr.opID, "interrupted_dropped", nil, &completed, &msg)
+	// R-1: fan out op.terminal for the force-drop transition.
+	r.publishOpTerminal(qr.opID, def.ID, "interrupted_dropped")
 	// C-2: release the dispatcher's stub handle. The force-drop path returned
 	// before executeRun ever registered/released the run, leaking the
 	// ConcurrencyKey and the pluginRunning slot until restart — which blocked

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/service.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 package scanner
 
 import (
@@ -17,7 +17,6 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
-	"github.com/falkcorp/audiobook-organizer/internal/operations"
 )
 
 // scanServiceStore is the narrow slice of database.Store this service uses.
@@ -70,20 +69,18 @@ type ScanStats struct {
 	ImportBooks  int
 }
 
-// PerformScanWithID executes the multi-folder scan operation with checkpoint support.
-func (ss *ScanService) PerformScanWithID(ctx context.Context, opID string, req *ScanRequest, log logger.Logger) error {
-	// Save params for resume
-	_ = operations.SaveParams(ss.db, opID, operations.ScanParams{
-		FolderPath:  req.FolderPath,
-		ForceUpdate: req.ForceUpdate != nil && *req.ForceUpdate,
-	})
-	err := ss.performScanInternal(ctx, opID, req, log)
-	_ = operations.ClearState(ss.db, opID)
-	return err
-}
-
 // PerformScan executes the multi-folder scan operation.
 // Accepts a logger.Logger for unified logging, progress, and change tracking.
+//
+// R-7: there is intentionally no checkpoint/resume plumbing here. The old
+// PerformScanWithID saved operations.ScanParams via operations.SaveParams for a
+// resume path that never existed — LoadParams[ScanParams] had zero callers and
+// the method itself had zero callers. The v2 "library.scan" OperationDef uses
+// ResumePolicy=ResumeDrop (see internal/server/library_core_ops.go), so an
+// interrupted scan is dropped and simply restarts from scratch on the next run;
+// a full re-walk is idempotent (the scan cache skips unchanged files). The dead
+// save/clear calls were removed to stop implying a resume contract that isn't
+// honored.
 func (ss *ScanService) PerformScan(ctx context.Context, req *ScanRequest, log logger.Logger) error {
 	return ss.performScanInternal(ctx, "", req, log)
 }


### PR DESCRIPTION
Combined T06 + T08 from `docs/agent-tasks/error-correction-2026-07/TASKS.md` (both edit `internal/operations/registry/worker.go`, so they cannot be split across branches).

## R-1 (T06) — `op.terminal` SSE publisher
The event contract existed only on the frontend (`web/src/stores/useOperationsStore.ts`, `web/src/services/api.ts`) — **no backend code published it**, so completed ops lingered as phantom "running" in the operations bell until a manual refresh. Added `Registry.publishOpTerminal` (fans out `{op_id, def_id, status}` via the existing bus; nil-safe; no direct SSE-hub import) and call it on every terminal transition:
- completed / failed / canceled / timeout (in-process + subprocess paths)
- abandonment (`interrupted_*`)
- force-drop (infinite-restart)
- canceled-before-start (queued-in-worker-channel)
- canceled-while-queued (`Cancel()` of a purely-queued op — the path with no worker to publish on its behalf)

## R-3 (T08) — abandoned-reporter log buffer
After a run is abandoned its reporter's `flushLoop` has already exited (runCtx canceled) but the wedged goroutine kept calling `Log`, growing `logBuf` without bound while every line was unrecoverable anyway. Now: buffer capped at 1,000 entries (drop-oldest + dropped-counter) **and** the worker flips a terminal flag (`markTerminal`) on the abandonment paths so subsequent `Log` calls are cheap no-ops.

## R-7 (T08) — dead scan-checkpoint code
Deleted `ScanService.PerformScanWithID` (zero callers) and its `operations.SaveParams(ScanParams)`/`ClearState` calls. `LoadParams[ScanParams]` had zero callers and `library.scan` uses `ResumePolicy=ResumeDrop`, so an interrupted scan restarts from scratch (idempotent re-walk) — it never resumed from the checkpoint that was being written. Comment left on `PerformScan` explaining why. (Unused `internal/operations` import removed.)

## P-2 (T08) — RunItems backwards progress
Parallel `RunItems` reported the item **index** (`i+1`), so a high-index item finishing early reported a high value while few items had completed — the bar jumped backwards. Now reports an atomic completion counter (monotonic in both sequential and parallel modes).

## Tests
- `terminal_events_test.go` — all terminal paths fire `op.terminal` via a mutex-protected recording bus (completed, failed, canceled-running, abandoned, force-dropped, canceled-queued). State set before `Start` to avoid enqueue-vs-setup races.
- `reporter_terminal_test.go` — white-box (internal package): buffer cap drops oldest + counts, `Log` no-ops after `markTerminal`, idempotent.
- `run_items_p2_test.go` — deterministic order test: with item 0 blocked, max reported progress stays ≤ N-1 (fails under the index-based bug), final == N.

## Verification
- `go test ./internal/operations/registry/... -race -count=3` → ok (196.9s)
- `go test ./internal/scanner/... -race -count=1` → ok
- `go build ./...` → clean

Live SSE curl verification: see PR comment (attempted per T06 acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65