### PR TITLE
fix(reconcile): parallelize AssignOrphanVGs + add VG clobber guard (T07/R-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.175.0 -->
+<!-- version: 3.176.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,17 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - fix(reconcile): AssignOrphanVGs worker pool + VG clobber guard (T07/R-6)
+
+- `AssignOrphanVGs` (`internal/reconcile/reconcile.go`) was a serial whole-library
+  loop doing two DB calls per orphan — a concurrency-mandate hotspot — and
+  unconditionally overwrote `VersionGroupID` on the re-hydrated book, clobbering a
+  VG assigned concurrently by a sibling worker, regroup apply, or merge.
+- Parallelized the per-candidate hydrate+write across a bounded `errgroup.Group`
+  pool (`runtime.NumCPU()`), sharded so no two workers touch the same book row;
+  added a clobber guard (skip + `skipped_concurrent_assignment` counter) and
+  progress/summary logging.
 
 #### July 18, 2026 - devops follow-ups (T12, 5 independent items)
 

--- a/TODO.md
+++ b/TODO.md
@@ -197,7 +197,7 @@ F7/R-9/R-8 (#2004 — T11).
 - [ ] **T04** — prod deploy (nothing deployed 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
 - [ ] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (file:line anchors in the brief)
 - [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #2002)
-- [ ] **T07** — R-6: AssignOrphanVGs serial loop + VersionGroupID clobber guard (`internal/reconcile/reconcile.go:1270-1327`)
+- [x] **T07** — R-6: AssignOrphanVGs worker pool + VG clobber guard (#2003)
 - [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #2002)
 - [ ] **T09** — C2: remux/transcode 6-h ops have no reporter threading + can't fail · H7 (external-id backfill, same shape)
 - [ ] **T10** — F6: legacy dedup.MergeBooks hard-deletes losers without external-ID reassignment/ITL removal — VERIFY then reroute

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/reconcile.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-16
+// last-edited: 2026-07-18
 
 package reconcile
 
@@ -134,6 +134,12 @@ type AssignVGResult struct {
 	AlreadyHasVG int `json:"already_has_vg"`
 	NotInLibrary int `json:"not_in_library"`
 	Errors       int `json:"errors"`
+	// SkippedConcurrentAssignment counts books that already had a
+	// VersionGroupID by the time this worker re-fetched the full record —
+	// i.e. another concurrent process (a sibling worker, a regroup apply, or
+	// a merge) assigned one between the initial orphan scan and the
+	// fetch-full/write-back. These are intentionally left untouched.
+	SkippedConcurrentAssignment int `json:"skipped_concurrent_assignment"`
 }
 
 // RunReconcileScan executes the reconcile preview build and persists results.
@@ -1267,6 +1273,22 @@ func MergeBookMetadata(dst, src *database.Book) []string {
 
 // AssignOrphanVGs finds books in the library directory that have no version group,
 // creates a VG for each, and marks them as primary.
+// AssignOrphanVGs assigns a fresh VersionGroupID to every library book that
+// doesn't have one yet. The candidate scan is serial (cheap, no I/O beyond
+// the initial paginated load), but the per-candidate work — a GetBookByID
+// hydrate plus an UpdateBook write-back — is two DB calls per book, which on
+// a whole-library scale collection is a CLAUDE.md concurrency-mandate
+// hotspot if left serial. It is parallelized across a bounded worker pool
+// (runtime.NumCPU()) below, sharded over the candidates slice so each worker
+// only ever touches its own disjoint book row — no two workers can race on
+// the same book.
+//
+// Clobber guard: because the initial scan and the per-book hydrate/write are
+// not atomic, another process (a sibling worker in this same pool, a
+// concurrent regroup apply, or a merge) can assign a VersionGroupID to a book
+// in between. After re-fetching the full record, if VersionGroupID is now
+// non-empty and doesn't match the ID this worker planned to assign, the
+// worker skips the write rather than clobbering the concurrent assignment.
 func AssignOrphanVGs(store Store, rootDir string) (*AssignVGResult, error) {
 	result := &AssignVGResult{}
 
@@ -1283,6 +1305,8 @@ func AssignOrphanVGs(store Store, rootDir string) (*AssignVGResult, error) {
 		}
 	}
 
+	// Serial pre-filter: no I/O, just in-memory field checks.
+	var candidates []database.BookCore
 	for i := range allBooks {
 		c := &allBooks[i]
 		result.TotalChecked++
@@ -1299,29 +1323,72 @@ func AssignOrphanVGs(store Store, rootDir string) (*AssignVGResult, error) {
 			continue
 		}
 
-		// Hydrate before writeback — c is a Core (slim) value here, and writing
-		// it straight through UpdateBook would wipe Author/Series.
-		b, herr := store.GetBookByID(c.ID)
-		if herr != nil || b == nil {
-			slog.Warn("assign-orphan-vgs failed to hydrate book", "book", c.ID, "herr", herr)
-			result.Errors++
-			continue
-		}
-
-		// Create a version group and mark as primary
-		vgID := fmt.Sprintf("vg-%s", ulid.Make().String())
-		b.VersionGroupID = &vgID
-		isPrimary := true
-		b.IsPrimaryVersion = &isPrimary
-		organizedState := "organized"
-		b.LibraryState = &organizedState
-
-		if _, err := store.UpdateBook(b.ID, b); err != nil {
-			result.Errors++
-			continue
-		}
-		result.Assigned++
+		candidates = append(candidates, *c)
 	}
+
+	total := len(candidates)
+	if total == 0 {
+		return result, nil
+	}
+
+	var assigned, skippedConcurrent, errCount, processed int64
+	logProgress := func() {
+		if n := atomic.AddInt64(&processed, 1); n%500 == 0 {
+			slog.Info("assign-orphan-vgs progress", "processed", n, "total", total)
+		}
+	}
+
+	var g errgroup.Group
+	g.SetLimit(max(runtime.NumCPU(), 1))
+	for i := range candidates {
+		c := &candidates[i]
+		g.Go(func() error {
+			defer logProgress()
+
+			// Hydrate before writeback — c is a Core (slim) value here, and
+			// writing it straight through UpdateBook would wipe Author/Series.
+			b, herr := store.GetBookByID(c.ID)
+			if herr != nil || b == nil {
+				slog.Warn("assign-orphan-vgs failed to hydrate book", "book", c.ID, "herr", herr)
+				atomic.AddInt64(&errCount, 1)
+				return nil
+			}
+
+			// Clobber guard — see doc comment above.
+			plannedVGID := fmt.Sprintf("vg-%s", ulid.Make().String())
+			if b.VersionGroupID != nil && *b.VersionGroupID != "" && *b.VersionGroupID != plannedVGID {
+				atomic.AddInt64(&skippedConcurrent, 1)
+				return nil
+			}
+
+			// Create a version group and mark as primary
+			b.VersionGroupID = &plannedVGID
+			isPrimary := true
+			b.IsPrimaryVersion = &isPrimary
+			organizedState := "organized"
+			b.LibraryState = &organizedState
+
+			if _, err := store.UpdateBook(b.ID, b); err != nil {
+				atomic.AddInt64(&errCount, 1)
+				return nil
+			}
+			atomic.AddInt64(&assigned, 1)
+			return nil
+		})
+	}
+	_ = g.Wait() // per-book errors are counted, not fatal to the whole run
+
+	result.Assigned = int(assigned)
+	result.SkippedConcurrentAssignment = int(skippedConcurrent)
+	result.Errors += int(errCount)
+
+	slog.Info("assign-orphan-vgs summary",
+		"total_checked", result.TotalChecked,
+		"assigned", result.Assigned,
+		"skipped_already_grouped", result.AlreadyHasVG,
+		"skipped_concurrent_assignment", result.SkippedConcurrentAssignment,
+		"errors", result.Errors,
+	)
 
 	return result, nil
 }

--- a/internal/reconcile/reconcile_orphanvg_test.go
+++ b/internal/reconcile/reconcile_orphanvg_test.go
@@ -1,0 +1,237 @@
+// file: internal/reconcile/reconcile_orphanvg_test.go
+// version: 1.0.0
+// guid: 7a1c9e2d-4f6b-4a3e-9d0c-5b8e2f1a6c3d
+// last-edited: 2026-07-18
+
+package reconcile
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestAssignOrphanVGs_PoolCorrectness drives AssignOrphanVGs across a worker
+// pool of orphan books (no VersionGroupID, in the library dir) plus a
+// not-in-library book and an already-grouped book, and verifies: every orphan
+// gets a unique VersionGroupID + IsPrimaryVersion=true + LibraryState set,
+// the counters are exact, and nothing outside the intended candidate set was
+// touched. Run with -race to exercise the pool.
+func TestAssignOrphanVGs_PoolCorrectness(t *testing.T) {
+	prevRoot := config.AppConfig.RootDir
+	defer func() { config.AppConfig.RootDir = prevRoot }()
+
+	const libRoot = "/lib"
+	const n = 40 // enough to keep NumCPU workers genuinely contending
+
+	store := newFakeStore()
+	var orphanIDs []string
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("orphan-%02d", i)
+		orphanIDs = append(orphanIDs, id)
+		path := fmt.Sprintf("%s/%s.m4b", libRoot, id)
+		store.books = append(store.books, database.BookCore{ID: id, Title: id, FilePath: path})
+		store.byID[id] = &database.Book{ID: id, Title: id, FilePath: path}
+	}
+
+	// Already-grouped book: caught by the serial pre-filter, never hydrated.
+	grouped := "grouped-book"
+	existingVG := "vg-existing"
+	store.books = append(store.books, database.BookCore{ID: grouped, Title: grouped, FilePath: libRoot + "/grouped.m4b", VersionGroupID: &existingVG})
+	store.byID[grouped] = &database.Book{ID: grouped, Title: grouped, FilePath: libRoot + "/grouped.m4b", VersionGroupID: &existingVG}
+
+	// Outside the library root entirely.
+	outside := "outside-book"
+	store.books = append(store.books, database.BookCore{ID: outside, Title: outside, FilePath: "/other/outside.m4b"})
+	store.byID[outside] = &database.Book{ID: outside, Title: outside, FilePath: "/other/outside.m4b"}
+
+	config.AppConfig.RootDir = libRoot
+
+	res, err := AssignOrphanVGs(store, libRoot)
+	if err != nil {
+		t.Fatalf("AssignOrphanVGs: %v", err)
+	}
+
+	wantTotal := n + 2
+	if res.TotalChecked != wantTotal {
+		t.Errorf("TotalChecked = %d, want %d", res.TotalChecked, wantTotal)
+	}
+	if res.Assigned != n {
+		t.Errorf("Assigned = %d, want %d", res.Assigned, n)
+	}
+	if res.AlreadyHasVG != 1 {
+		t.Errorf("AlreadyHasVG = %d, want 1", res.AlreadyHasVG)
+	}
+	if res.NotInLibrary != 1 {
+		t.Errorf("NotInLibrary = %d, want 1", res.NotInLibrary)
+	}
+	if res.Errors != 0 {
+		t.Errorf("Errors = %d, want 0", res.Errors)
+	}
+	if res.SkippedConcurrentAssignment != 0 {
+		t.Errorf("SkippedConcurrentAssignment = %d, want 0", res.SkippedConcurrentAssignment)
+	}
+
+	// Every orphan must have been written exactly once with a unique VG.
+	seenVG := make(map[string]bool, n)
+	if len(store.updated) != n {
+		t.Fatalf("wrote %d books, want %d", len(store.updated), n)
+	}
+	for _, id := range orphanIDs {
+		b, ok := store.updated[id]
+		if !ok {
+			t.Errorf("orphan %s was not written", id)
+			continue
+		}
+		if b.VersionGroupID == nil || *b.VersionGroupID == "" {
+			t.Errorf("orphan %s VersionGroupID not set", id)
+			continue
+		}
+		if seenVG[*b.VersionGroupID] {
+			t.Errorf("orphan %s VersionGroupID %s collides with another book", id, *b.VersionGroupID)
+		}
+		seenVG[*b.VersionGroupID] = true
+		if b.IsPrimaryVersion == nil || !*b.IsPrimaryVersion {
+			t.Errorf("orphan %s IsPrimaryVersion not set true", id)
+		}
+		if b.LibraryState == nil || *b.LibraryState != "organized" {
+			t.Errorf("orphan %s LibraryState = %v, want organized", id, b.LibraryState)
+		}
+	}
+
+	// The already-grouped and outside-library books must never be written.
+	if _, ok := store.updated[grouped]; ok {
+		t.Errorf("already-grouped book %s was written, want untouched", grouped)
+	}
+	if _, ok := store.updated[outside]; ok {
+		t.Errorf("outside-library book %s was written, want untouched", outside)
+	}
+}
+
+// TestAssignOrphanVGs_ConcurrentAssignmentSkip proves the clobber guard: a
+// book that looked like an orphan at the initial Core scan (GetAllBooksCore)
+// but has since had a VersionGroupID assigned by someone else (a sibling
+// worker, a concurrent regroup apply, or a merge) — visible only once this
+// worker re-fetches the full record via GetBookByID — must be skipped, not
+// overwritten. Before this fix AssignOrphanVGs used the Core snapshot's
+// VersionGroupID check as the only guard and would clobber this race.
+func TestAssignOrphanVGs_ConcurrentAssignmentSkip(t *testing.T) {
+	prevRoot := config.AppConfig.RootDir
+	defer func() { config.AppConfig.RootDir = prevRoot }()
+
+	const libRoot = "/lib"
+	config.AppConfig.RootDir = libRoot
+
+	store := newFakeStore()
+
+	// The Core snapshot (what the initial scan sees) has no VG — it looks
+	// like a legitimate orphan and passes the pre-filter.
+	raced := "raced-book"
+	path := libRoot + "/raced.m4b"
+	store.books = append(store.books, database.BookCore{ID: raced, Title: raced, FilePath: path})
+
+	// But the full record (what GetBookByID returns, simulating a concurrent
+	// writer that landed between the scan and this hydrate) already has one.
+	concurrentVG := "vg-assigned-by-someone-else"
+	concurrentIsPrimary := true
+	store.byID[raced] = &database.Book{
+		ID: raced, Title: raced, FilePath: path,
+		VersionGroupID:   &concurrentVG,
+		IsPrimaryVersion: &concurrentIsPrimary,
+	}
+
+	// A genuine orphan alongside it so the run does real work too.
+	clean := "clean-book"
+	cleanPath := libRoot + "/clean.m4b"
+	store.books = append(store.books, database.BookCore{ID: clean, Title: clean, FilePath: cleanPath})
+	store.byID[clean] = &database.Book{ID: clean, Title: clean, FilePath: cleanPath}
+
+	res, err := AssignOrphanVGs(store, libRoot)
+	if err != nil {
+		t.Fatalf("AssignOrphanVGs: %v", err)
+	}
+
+	if res.SkippedConcurrentAssignment != 1 {
+		t.Errorf("SkippedConcurrentAssignment = %d, want 1", res.SkippedConcurrentAssignment)
+	}
+	if res.Assigned != 1 {
+		t.Errorf("Assigned = %d, want 1", res.Assigned)
+	}
+	if res.Errors != 0 {
+		t.Errorf("Errors = %d, want 0", res.Errors)
+	}
+
+	// The raced book must never have been written, and its VG must be
+	// unchanged from the concurrent assignment.
+	if _, ok := store.updated[raced]; ok {
+		t.Errorf("raced book %s was written, want left untouched by the clobber guard", raced)
+	}
+	if got := store.byID[raced].VersionGroupID; got == nil || *got != concurrentVG {
+		t.Errorf("raced book VersionGroupID = %v, want unchanged %q", got, concurrentVG)
+	}
+
+	// The clean book must have been assigned normally.
+	b, ok := store.updated[clean]
+	if !ok {
+		t.Fatalf("clean book %s was not written", clean)
+	}
+	if b.VersionGroupID == nil || *b.VersionGroupID == "" {
+		t.Errorf("clean book VersionGroupID not set")
+	}
+}
+
+// TestAssignOrphanVGs_RealStoreConcurrent drives AssignOrphanVGs against a
+// real PebbleStore (not the mutex-guarded fake) so `go test -race` exercises
+// concurrent GetBookByID / UpdateBook — including the memdb write-through —
+// across the worker pool, and confirms the writes persisted.
+func TestAssignOrphanVGs_RealStoreConcurrent(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new pebble store: %v", err)
+	}
+
+	const libRoot = "/lib"
+	const n = 40
+
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		path := fmt.Sprintf("%s/book-%02d.m4b", libRoot, i)
+		book, err := ps.CreateBook(&database.Book{Title: fmt.Sprintf("book %d", i), FilePath: path})
+		if err != nil {
+			t.Fatalf("create book: %v", err)
+		}
+		ids = append(ids, book.ID)
+	}
+
+	res, err := AssignOrphanVGs(ps, libRoot)
+	if err != nil {
+		t.Fatalf("AssignOrphanVGs: %v", err)
+	}
+	if res.Assigned != n {
+		t.Errorf("Assigned = %d, want %d", res.Assigned, n)
+	}
+	if res.Errors != 0 {
+		t.Errorf("Errors = %d, want 0", res.Errors)
+	}
+
+	seenVG := make(map[string]bool, n)
+	for _, id := range ids {
+		b, err := ps.GetBookByID(id)
+		if err != nil || b == nil {
+			t.Fatalf("re-read %s: %v", id, err)
+		}
+		if b.VersionGroupID == nil || *b.VersionGroupID == "" {
+			t.Errorf("book %s VersionGroupID not set", id)
+			continue
+		}
+		if seenVG[*b.VersionGroupID] {
+			t.Errorf("book %s VersionGroupID %s collides", id, *b.VersionGroupID)
+		}
+		seenVG[*b.VersionGroupID] = true
+		if b.IsPrimaryVersion == nil || !*b.IsPrimaryVersion {
+			t.Errorf("book %s IsPrimaryVersion not set true", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `AssignOrphanVGs` (`internal/reconcile/reconcile.go`) was a serial whole-library loop doing two DB calls (`GetBookByID` + `UpdateBook`) per orphan book — a CLAUDE.md concurrency-mandate hotspot — and it unconditionally overwrote `VersionGroupID` on the re-hydrated book, which could clobber a version group assigned concurrently (by a sibling worker, a regroup apply, or a merge).
- Parallelized the per-candidate hydrate+write across a bounded worker pool (`errgroup.Group` sized to `runtime.NumCPU()`), matching the existing in-file pattern used by `hashFilesConcurrent`/`FindBrokenSegmentBooks` in the same file. `AssignOrphanVGs` runs from a synchronous HTTP handler (`internal/server/reconcile.go`) with no `operations.Reporter`, so the `registry.RunItems` exemplar (which requires one) isn't directly callable here — this applies the same bounded-pool shape without a reporter.
- Sharded over a pre-filtered candidates slice so no two workers ever touch the same book row (disjoint partitioning by book ID).
- Added a clobber guard: after the per-book `GetBookByID` re-fetch, if `VersionGroupID` is already non-empty and differs from this worker's planned assignment, the write is skipped and counted under the new `skipped_concurrent_assignment` result field instead of overwriting.
- Added progress logging every 500 books plus a structured summary log (assigned, skipped_already_grouped, skipped_concurrent_assignment, errors).

Implements brief T07 (`docs/agent-tasks/error-correction-2026-07/TASKS.md`), closing finding R-6.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/reconcile/... -race -count=1` — clean locally (3 new tests: pool-correctness, concurrent-assignment skip, real-PebbleStore concurrent write)
- [x] `Minimal CI / Go Tests (short, race)` — pass in CI. (A local full `go test ./internal/server/... -race -count=1` run was slow/inconclusive — three concurrent `-race` suites from sibling task worktrees were contending on this machine and it hit the 10-minute default timeout on cumulative suite time, not a stuck test; no test there exercises `AssignOrphanVGs` directly. CI's own race job is the authoritative signal and it's green.)
- [x] File headers bumped (reconcile.go 1.5.0 → 1.6.0)
- [x] CHANGELOG.md + TODO.md updated in this PR (T07 line ticked/moved to Fixed list with this PR number)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>