### PR TITLE
fix(registry): publish op.terminal on dep-scheduler fail-propagation (T06 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,12 @@
   frontend, so finished operations lingered as phantom "running" entries in the
   operations bell until a manual refresh. New helper
   `Registry.publishOpTerminal` fans out `{op_id, def_id, status}` via the
-  existing bus (nil-safe; no direct SSE-hub import). Covered by
+  existing bus (nil-safe; no direct SSE-hub import), called at every worker
+  terminal-write site plus the dependency-scheduler fail-propagation path
+  (`DepsScheduler.OnOpFailed`, which fails a waiting_deps op when its
+  prerequisite fails — a live transition with no worker to publish it).
+  Startup-resume and shutdown-drain terminal writes are intentionally not
+  published (no SSE client is connected at those points). Covered by
   `terminal_events_test.go`.
 - **R-3 (abandoned-reporter log buffer, T08):** after a run is abandoned its
   reporter's flush goroutine has already exited, but the wedged goroutine kept

--- a/internal/operations/registry/deps_scheduler.go
+++ b/internal/operations/registry/deps_scheduler.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/deps_scheduler.go
-// version: 1.1.2
+// version: 1.2.0
 // guid: a3b4c5d6-e7f8-9a0b-1c2d-3e4f5a6b7c8d
-// last-edited: 2026-07-12
+// last-edited: 2026-07-18
 
 // deps_scheduler.go implements the event-driven + sweep re-evaluation loop for
 // waiting_deps operations. It is the bridge between op lifecycle events
@@ -149,6 +149,10 @@ func (s *DepsScheduler) OnOpFailed(ctx context.Context, sub Subject, opType stri
 				"op_id", op.ID, "error", failErr)
 			continue
 		}
+		// R-1: this is a terminal transition on a LIVE op (a waiting_deps op
+		// failed because its prerequisite failed) — publish op.terminal so the
+		// UI bell drops it instead of leaving it phantom-"running".
+		s.reg.publishOpTerminal(op.ID, op.DefID, "failed")
 		s.mu.Lock()
 		s.removeFromIndex(op.SubjectType, op.SubjectID, op.ID)
 		s.mu.Unlock()

--- a/internal/operations/registry/terminal_events_test.go
+++ b/internal/operations/registry/terminal_events_test.go
@@ -209,6 +209,55 @@ func TestTerminalEvent_ForceDropped(t *testing.T) {
 	}
 }
 
+// TestTerminalEvent_DepFailPropagation asserts op.terminal fires with
+// status=failed when a waiting_deps op is failed because its prerequisite
+// failed (DepsScheduler.OnOpFailed) — a live-operation terminal transition
+// with no worker to publish it, so the scheduler must.
+func TestTerminalEvent_DepFailPropagation(t *testing.T) {
+	store := newSmartFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 4, bus)
+
+	prereq := makeValidDef("test.term-prereq-fail")
+	if err := r.RegisterOp(prereq); err != nil {
+		t.Fatalf("RegisterOp prereq: %v", err)
+	}
+	dep := makeValidDef("test.term-dep-fail")
+	dep.Requires = []registry.Requirement{{Kind: registry.ReqOpCompleted, OpType: "test.term-prereq-fail"}}
+	if err := r.RegisterOp(dep); err != nil {
+		t.Fatalf("RegisterOp dep: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.Start(ctx)
+
+	params := map[string]string{"book_id": "b-term-fail"}
+	depOpID, err := r.EnqueueOp(ctx, "test.term-dep-fail", params)
+	if err != nil {
+		t.Fatalf("EnqueueOp dep: %v", err)
+	}
+	if store.statusOf(depOpID) != "waiting_deps" {
+		t.Fatalf("expected dep parked, got %q", store.statusOf(depOpID))
+	}
+
+	sched := registry.NewDepsScheduler(r, store)
+	if err := sched.OnOpFailed(ctx, registry.Subject{Type: "book", ID: "b-term-fail"}, "test.term-prereq-fail"); err != nil {
+		t.Fatalf("OnOpFailed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && store.statusOf(depOpID) != "failed" {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := store.statusOf(depOpID); got != "failed" {
+		t.Fatalf("expected dep failed, got %q", got)
+	}
+	if got := bus.waitTerminal(t, depOpID, 2*time.Second); got != "failed" {
+		t.Errorf("op.terminal status: got %q want failed", got)
+	}
+}
+
 // TestTerminalEvent_CanceledQueued asserts op.terminal fires with
 // status=canceled when a purely-queued op (never picked up) is canceled — the
 // path with no worker to publish the event on the op's behalf.

--- a/internal/scanner/service.go
+++ b/internal/scanner/service.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/service.go
-// version: 1.10.0
+// version: 1.10.1
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-07-18
 package scanner
@@ -85,7 +85,7 @@ func (ss *ScanService) PerformScan(ctx context.Context, req *ScanRequest, log lo
 	return ss.performScanInternal(ctx, "", req, log)
 }
 
-// performScanInternal is the shared implementation used by PerformScan and PerformScanWithID.
+// performScanInternal is the shared implementation behind PerformScan.
 // opID may be empty when called without a tracked operation (activity batching is skipped).
 func (ss *ScanService) performScanInternal(ctx context.Context, opID string, req *ScanRequest, log logger.Logger) error {
 	// Set the active embedding store for dedup detection during this scan


### PR DESCRIPTION
Follow-up to #2002 (T06 R-1). #2002 was merged by the coordinator before this final commit landed, so this completeness fix needs its own PR.

## What
`DepsScheduler.OnOpFailed` marks a `waiting_deps` op **failed** when its prerequisite op fails. That is a terminal transition on a **live** operation, but it happens in the scheduler (not the worker), so no `op.terminal` SSE event was published — leaving the op phantom-"running" in the operations bell, the exact symptom #2002 set out to kill. Found by mechanically enumerating every `UpdateOperationV2Status`/`SetOperationV2StatusIfQueued` call in the package and classifying each by the status literal it writes.

Fix: publish `op.terminal` via the `*Registry` the scheduler already holds (`s.reg.publishOpTerminal`). The bus is nil-safe.

Deliberately **not** published (documented in the comment + CHANGELOG): the startup-resume terminal writes in `resume.go` (`resumeDrop`/`resumeAsk`/requeue) and the Shutdown drain-timeout write — no SSE client is connected at process startup or exit.

## Test
`TestTerminalEvent_DepFailPropagation` — parks a dep op, fails its prerequisite via `OnOpFailed`, asserts both the DB status and the published `op.terminal` reach `failed`.

- `go test ./internal/operations/registry/... -run TestTerminalEvent_DepFailPropagation -race` → ok
- Full package `go test ./internal/operations/registry/... -race -count=3` → ok (197.6s, run before split)
- `go build ./internal/operations/registry/...` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65