### PR TITLE
fix(maintenance): thread reporter progress + error return through remux/transcode/external-ID backfill (C2/H7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.176.0 -->
+<!-- version: 3.175.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -112,6 +113,30 @@
   operator can see unreadable groups accumulating.
 - All three packages (`internal/plugins/dedup`, `internal/itunes/...`,
   `internal/scanner`) pass `go test ./... -race -count=1`.
+#### July 18, 2026 - T09: remux/transcode/external-ID-backfill reporter threading (C2/H7)
+
+- **fix(maintenance):** the malformed-M4B remux op, its transcode twin, and the
+  external-ID backfill op each logged one "starting" line, called into a void
+  dependency method that could run for hours, then unconditionally logged
+  "complete" — a multi-hour ffmpeg walk gave no progress and could never fail
+  the op, even on a fatal setup problem (no RootDir configured, ffmpeg
+  missing) or a real persistence error.
+- Reworked the dependency chain
+  (`internal/plugins/maintenance/backfill.go` → `ServerDeps` →
+  `internal/server/malformed_m4b_wrappers.go` / `external_id_backfill.go` →
+  `internal/remux/remux.go` + `transcode.go` / `internal/itunes/backfill.go`)
+  so each now takes a `func(processed, total int, msg string)` progress
+  callback and returns `error`. The plugin wires the callback to
+  `reporter.UpdateProgress` and fails the op on a non-nil error.
+- Remux/transcode report an accurate "X/Y" (a cheap pre-count walk over the
+  same candidate predicate) every 25 files; external-ID backfill reports
+  after every page of book pagination and every 10,000 iTunes-XML tracks.
+  Per-file remux/transcode failures stay non-fatal (expected — transcode is
+  the designed fallback for files remux can't fix); a track-PID bulk-write
+  failure that was previously logged and discarded now fails the op.
+- No behavior change for the startup goroutines in `server_lifecycle.go`
+  that call these directly (outside the UOS op registry) — they now surface
+  the returned error via a Warn log instead of it being silently unreachable.
 
 #### July 17, 2026 - error-correction fix wave (15 PRs) + sandbox verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.176.0 -->
-<!-- version: 3.175.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -114,6 +113,7 @@
 - All three packages (`internal/plugins/dedup`, `internal/itunes/...`,
   `internal/scanner`) pass `go test ./... -race -count=1`.
 #### July 18, 2026 - T09: remux/transcode/external-ID-backfill reporter threading (C2/H7)
+#### July 18, 2026 - T09: remux/transcode/external-ID-backfill reporter threading (C2/H7) — PR #2006
 
 - **fix(maintenance):** the malformed-M4B remux op, its transcode twin, and the
   external-ID backfill op each logged one "starting" line, called into a void
@@ -127,16 +127,26 @@
   `internal/remux/remux.go` + `transcode.go` / `internal/itunes/backfill.go`)
   so each now takes a `func(processed, total int, msg string)` progress
   callback and returns `error`. The plugin wires the callback to
-  `reporter.UpdateProgress` and fails the op on a non-nil error.
+  `reporter.UpdateProgress` and fails the op on a non-nil error. Added an
+  explicit 30m `ProgressTimeout` to the transcode `OperationDef` — a full
+  AAC re-encode can exceed the registry's 5m default gap between progress
+  stamps at the "every 25 files" cadence.
 - Remux/transcode report an accurate "X/Y" (a cheap pre-count walk over the
   same candidate predicate) every 25 files; external-ID backfill reports
   after every page of book pagination and every 10,000 iTunes-XML tracks.
   Per-file remux/transcode failures stay non-fatal (expected — transcode is
   the designed fallback for files remux can't fix); a track-PID bulk-write
-  failure that was previously logged and discarded now fails the op.
-- No behavior change for the startup goroutines in `server_lifecycle.go`
-  that call these directly (outside the UOS op registry) — they now surface
-  the returned error via a Warn log instead of it being silently unreachable.
+  failure and a book-pagination read failure, both previously
+  logged-and-discarded (or silently `break`), now fail the op instead of
+  letting it mark itself "done" after skipping part of the library.
+- The `startBackfills()` goroutines in `server_lifecycle.go` run these same
+  ops directly at every boot, **outside** the UOS op registry (no reporter
+  available there) — grepping found no enqueue site for the UOS ops
+  themselves, so this goroutine path is likely the only one that's actually
+  live in prod. Added `startupProgressLogger`, a small slog-based progress
+  callback, so this path also gets more than one log line across a
+  multi-hour run, and now surfaces the previously-unreachable error via
+  `slog.Warn`.
 
 #### July 17, 2026 - error-correction fix wave (15 PRs) + sandbox verification
 

--- a/TODO.md
+++ b/TODO.md
@@ -188,6 +188,7 @@ DL-1/DL-2/DL-3/M4 (#1986 — OPEN in CI at time of writing, see brief T01) ·
 R-1 (T06) + R-3/R-7/P-2 (T08) (#2002).
 F7/R-9/R-8 (#PENDING — T11, see CHANGELOG July 18, 2026).
 F7/R-9/R-8 (#2004 — T11).
+C2/H7 remux/transcode/external-ID-backfill reporter threading (#2006).
 
 ### Remaining — execution state (briefs)
 
@@ -200,6 +201,9 @@ F7/R-9/R-8 (#2004 — T11).
 - [x] **T07** — R-6: AssignOrphanVGs worker pool + VG clobber guard (#2003)
 - [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #2002)
 - [ ] **T09** — C2: remux/transcode 6-h ops have no reporter threading + can't fail · H7 (external-id backfill, same shape)
+- [ ] **T06** — R-1: `op.terminal` SSE has zero backend publishers (phantom "running" ops in UI)
+- [ ] **T07** — R-6: AssignOrphanVGs serial loop + VersionGroupID clobber guard (`internal/reconcile/reconcile.go:1270-1327`)
+- [ ] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress)
 - [ ] **T10** — F6: legacy dedup.MergeBooks hard-deletes losers without external-ID reassignment/ITL removal — VERIFY then reroute
 - [ ] **T11** — F7 (quarantine serial loops → RunItems) · R-9 (path_repair serial loop) · R-8 (all-unreadable-durations group misclassified "short")
 - [x] **T12** — devops: 8 remaining scripts with internal IPs · op-stall alert (commented, metric doesn't exist yet — see Infra #36) · coverage floor on PR gate · systemd unit dedupe · credential entropy — #2001

--- a/internal/itunes/backfill.go
+++ b/internal/itunes/backfill.go
@@ -1,12 +1,13 @@
 // file: internal/itunes/backfill.go
-// version: 1.5.0
+// version: 1.7.0
 // guid: b8c9d0e1-f2a3-b4c5-d6e7-f8a9b0c1d2e3
-// last-edited: 2026-07-07
+// last-edited: 2026-07-18
 
 package itunes
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -34,7 +35,17 @@ type ExternalIDBackfillStore interface {
 // loop runs to completion (potentially minutes on a large library) and
 // crashes with "pebble: closed" if the store closes mid-iteration. The
 // caller (Server.Start's background goroutine) passes s.bgCtx.
-func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) error {
+//
+// progress is called after every page of the book-pagination pass (total is
+// unknown ahead of a pass over a paginated store, so 0 is reported for it —
+// the message still conveys real counts) and every 10000 tracks during the
+// iTunes-XML streaming pass, so a whole-library run surfaces progress instead
+// of one log line at the end (H7). progress may be nil.
+//
+// Persistence errors (bulk-write failures, the track-PID pass) are now
+// returned instead of silently discarded — previously the op always reported
+// success even when nothing was actually written (H7).
+func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore, progress func(processed, total int, msg string)) error {
 	if store == nil {
 		return nil
 	}
@@ -48,13 +59,20 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 
 	offset := 0
 	backfilled := 0
+	booksScanned := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			slog.Info("external ID backfill canceled at offset after mappings", "offset", offset, "backfilled", backfilled, "err", err)
 			return nil
 		}
 		books, err := store.GetAllBooksCore(10000, offset)
-		if err != nil || len(books) == 0 {
+		if err != nil {
+			// H7: a read failure here used to `break` silently, letting the
+			// loop fall through to the track-PID pass and mark the whole
+			// backfill "done" despite skipping the rest of the library.
+			return fmt.Errorf("external ID backfill: read books at offset %d: %w", offset, err)
+		}
+		if len(books) == 0 {
 			break
 		}
 
@@ -95,10 +113,16 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 			}
 		}
 		if len(batch) > 0 {
-			_ = store.BulkCreateExternalIDMappings(batch)
+			if err := store.BulkCreateExternalIDMappings(batch); err != nil {
+				return fmt.Errorf("external ID backfill: bulk write at offset %d: %w", offset, err)
+			}
 			backfilled += len(batch)
 		}
+		booksScanned += len(books)
 		offset += 10000
+		if progress != nil {
+			progress(booksScanned, 0, fmt.Sprintf("Backfilling external IDs: %d books scanned (%d mappings written)", booksScanned, backfilled))
+		}
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -108,7 +132,10 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 	slog.Info("Backfilled external ID mappings from book + file records", "backfilled", backfilled)
 
 	// Backfill ALL track-level PIDs from the iTunes XML
-	itunesBackfilled, _ := BackfillITunesTrackPIDs(ctx, store)
+	itunesBackfilled, err := BackfillITunesTrackPIDs(ctx, store, progress)
+	if err != nil {
+		return fmt.Errorf("external ID backfill: track-PID pass: %w", err)
+	}
 	if itunesBackfilled > 0 {
 		slog.Info("Backfilled track-level PIDs from iTunes XML", "itunesBackfilled", itunesBackfilled)
 	}
@@ -127,7 +154,11 @@ func BackfillExternalIDs(ctx context.Context, store ExternalIDBackfillStore) err
 //
 // Uses streaming XML parser to avoid loading the entire library into memory.
 // ctx aborts the stream and book index operations; passing context.Background is safe.
-func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore) (int, error) {
+// progress is called every 10000 tracks streamed (may be nil). Bulk-write
+// failures now abort the stream and return an error instead of being logged
+// and discarded (H7) — a caller relying on the returned count/error to decide
+// whether the backfill "done" flag can be set needs it to be accurate.
+func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore, progress func(processed, total int, msg string)) (int, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -151,7 +182,12 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 			return 0, nil
 		}
 		books, err := store.GetAllBooksCore(10000, offset)
-		if err != nil || len(books) == 0 {
+		if err != nil {
+			// H7: a read failure here used to `break` silently and fall through
+			// to a stream parse over a partial (or empty) PID/title index.
+			return 0, fmt.Errorf("BackfillITunesTrackPIDs: read books at offset %d: %w", offset, err)
+		}
+		if len(books) == 0 {
 			break
 		}
 		for _, book := range books {
@@ -176,6 +212,9 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 		trackedCount++
 		if trackedCount%10000 == 0 {
 			slog.Info("BackfillITunesTrackPIDs streaming progress", "tracks_processed", trackedCount)
+			if progress != nil {
+				progress(trackedCount, 0, fmt.Sprintf("Backfilling iTunes track PIDs: %d tracks scanned (%d registered)", trackedCount, registered))
+			}
 		}
 
 		// Group tracks by album as we stream them
@@ -209,7 +248,7 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 					// Flush in batches of 5000
 					if len(batch) >= 5000 {
 						if batchErr := store.BulkCreateExternalIDMappings(batch); batchErr != nil {
-							slog.Warn("BackfillITunesTrackPIDs failed to write batch", "err", batchErr)
+							return fmt.Errorf("BackfillITunesTrackPIDs: bulk write mid-stream: %w", batchErr)
 						}
 						batch = batch[:0]
 					}
@@ -254,7 +293,7 @@ func BackfillITunesTrackPIDs(ctx context.Context, store ExternalIDBackfillStore)
 	// Flush remaining batch
 	if len(batch) > 0 {
 		if batchErr := store.BulkCreateExternalIDMappings(batch); batchErr != nil {
-			slog.Warn("BackfillITunesTrackPIDs failed to write final batch", "err", batchErr)
+			return registered, fmt.Errorf("BackfillITunesTrackPIDs: bulk write final batch: %w", batchErr)
 		}
 	}
 

--- a/internal/itunes/backfill_test.go
+++ b/internal/itunes/backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/backfill_test.go
-// version: 1.0.2
+// version: 1.2.0
 // guid: c9d0e1f2-a3b4-c5d6-e7f8-a9b0c1d2e3f4
-// last-edited: 2026-07-07
+// last-edited: 2026-07-18
 
 package itunes
 
@@ -23,6 +23,11 @@ type MockBackfillStore struct {
 	books          map[string]database.Book
 	externalIDMaps []database.ExternalIDMapping
 	hasError       bool
+	// failBulkCreate fails only BulkCreateExternalIDMappings, leaving reads
+	// (GetAllBooksCore/GetBookFiles) working so the H7 bulk-write-error
+	// propagation test can exercise the write failure without the
+	// pagination loop breaking out before it ever reaches a write.
+	failBulkCreate bool
 }
 
 func NewMockBackfillStore() *MockBackfillStore {
@@ -66,7 +71,7 @@ func (m *MockBackfillStore) CreateExternalIDMapping(mapping *database.ExternalID
 }
 
 func (m *MockBackfillStore) BulkCreateExternalIDMappings(mappings []database.ExternalIDMapping) error {
-	if m.hasError {
+	if m.hasError || m.failBulkCreate {
 		return errMockFailure
 	}
 	m.externalIDMaps = append(m.externalIDMaps, mappings...)
@@ -81,7 +86,7 @@ func (m *MockBackfillStore) SetSetting(key, value, dataType string, internal boo
 }
 
 func TestBackfillExternalIDsWithNilStore(t *testing.T) {
-	err := BackfillExternalIDs(context.Background(), nil)
+	err := BackfillExternalIDs(context.Background(), nil, nil)
 	if err != nil {
 		t.Errorf("expected nil error for nil store, got %v", err)
 	}
@@ -96,7 +101,10 @@ func TestBackfillExternalIDsCollectsBookPIDs(t *testing.T) {
 		ITunesPersistentID: &pidValue,
 	}
 
-	err := BackfillExternalIDs(context.Background(), mockStore)
+	var progressCalls int
+	err := BackfillExternalIDs(context.Background(), mockStore, func(_, _ int, _ string) {
+		progressCalls++
+	})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -105,13 +113,52 @@ func TestBackfillExternalIDsCollectsBookPIDs(t *testing.T) {
 	if len(mockStore.externalIDMaps) < 1 {
 		t.Errorf("expected at least 1 mapping, got %d", len(mockStore.externalIDMaps))
 	}
+
+	// H7: pagination must report progress at least once per page scanned.
+	if progressCalls == 0 {
+		t.Error("expected progress callback to be invoked at least once, got 0 calls")
+	}
+}
+
+// TestBackfillExternalIDsPropagatesBulkWriteError proves the H7 fix: a
+// persistence failure during the book-pagination pass is returned to the
+// caller instead of being silently discarded (previously `_ =
+// store.BulkCreateExternalIDMappings(batch)`), so the op can actually fail.
+func TestBackfillExternalIDsPropagatesBulkWriteError(t *testing.T) {
+	mockStore := NewMockBackfillStore()
+	pidValue := "test-pid-456"
+	mockStore.books["book1"] = database.Book{
+		ID:                 "book1",
+		Title:              "Test Book",
+		ITunesPersistentID: &pidValue,
+	}
+	mockStore.failBulkCreate = true
+
+	err := BackfillExternalIDs(context.Background(), mockStore, nil)
+	if err == nil {
+		t.Fatal("expected error when BulkCreateExternalIDMappings fails, got nil")
+	}
+}
+
+// TestBackfillExternalIDsPropagatesReadError proves the H7 fix: a
+// GetAllBooksCore read failure during pagination is returned instead of
+// silently `break`-ing out of the loop and falling through to mark the
+// whole backfill "done" despite skipping the rest of the library.
+func TestBackfillExternalIDsPropagatesReadError(t *testing.T) {
+	mockStore := NewMockBackfillStore()
+	mockStore.hasError = true
+
+	err := BackfillExternalIDs(context.Background(), mockStore, nil)
+	if err == nil {
+		t.Fatal("expected error when GetAllBooksCore fails, got nil")
+	}
 }
 
 func TestBackfillITunesTrackPIDsWithNoConfiguredPath(t *testing.T) {
 	mockStore := NewMockBackfillStore()
 
 	// With no configured path, should return 0 gracefully
-	count, err := BackfillITunesTrackPIDs(context.Background(), mockStore)
+	count, err := BackfillITunesTrackPIDs(context.Background(), mockStore, nil)
 	if count != 0 {
 		t.Errorf("expected 0 registered PIDs with no configured path, got %d", count)
 	}

--- a/internal/plugins/maintenance/backfill.go
+++ b/internal/plugins/maintenance/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/backfill.go
-// version: 1.1.0
+// version: 1.3.0
 // guid: f2a3b4c5-d6e7-8901-5678-123456789012
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package maintenance
 
@@ -39,7 +39,13 @@ func (p *Plugin) externalIDBackfillDef() sdk.OperationDef {
 
 func (p *Plugin) runExternalIDBackfill(_ context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting external ID backfill")
-	p.deps.BackfillExternalIDs()
+	err := p.deps.BackfillExternalIDs(func(processed, total int, msg string) {
+		_ = reporter.UpdateProgress(processed, total, msg)
+	})
+	if err != nil {
+		_ = reporter.Log(slog.LevelError, "External ID backfill failed", slog.String("error", err.Error()))
+		return err
+	}
 	_ = reporter.Log(slog.LevelInfo, "External ID backfill complete")
 	return nil
 }
@@ -89,7 +95,13 @@ func (p *Plugin) malformedM4BRemuxDef() sdk.OperationDef {
 
 func (p *Plugin) runMalformedM4BRemux(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting malformed M4B remux")
-	p.deps.RemuxMalformedM4BFiles(ctx)
+	err := p.deps.RemuxMalformedM4BFiles(ctx, func(processed, total int, msg string) {
+		_ = reporter.UpdateProgress(processed, total, msg)
+	})
+	if err != nil {
+		_ = reporter.Log(slog.LevelError, "Malformed M4B remux failed", slog.String("error", err.Error()))
+		return err
+	}
 	_ = reporter.Log(slog.LevelInfo, "Malformed M4B remux complete")
 	return nil
 }
@@ -108,6 +120,14 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 		Cancellable:     true,
 		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
 		Timeout:         6 * time.Hour,
+		// C2: a full AAC re-encode can take minutes per file, so the every-25
+		// -files progress cadence can leave a long gap between UpdateProgress
+		// stamps. The registry watchdog's default ProgressTimeout is 5 minutes
+		// (see internal/operations/registry/watchdog.go) — without an explicit
+		// override here a slow but healthy transcode run risks being killed as
+		// "stuck". 30m matches the precedent in intro_transcribe.go for a
+		// similarly slow per-item op.
+		ProgressTimeout: 30 * time.Minute,
 		Schedule:        nil,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapFilesWrite, sdk.CapSubprocessSpawn},
 		Run:             p.runMalformedM4BTranscode,
@@ -116,7 +136,13 @@ func (p *Plugin) malformedM4BTranscodeDef() sdk.OperationDef {
 
 func (p *Plugin) runMalformedM4BTranscode(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
 	_ = reporter.Log(slog.LevelInfo, "Starting malformed M4B transcode")
-	p.deps.TranscodeMalformedM4BFiles(ctx)
+	err := p.deps.TranscodeMalformedM4BFiles(ctx, func(processed, total int, msg string) {
+		_ = reporter.UpdateProgress(processed, total, msg)
+	})
+	if err != nil {
+		_ = reporter.Log(slog.LevelError, "Malformed M4B transcode failed", slog.String("error", err.Error()))
+		return err
+	}
 	_ = reporter.Log(slog.LevelInfo, "Malformed M4B transcode complete")
 	return nil
 }

--- a/internal/plugins/maintenance/backfill_ops_test.go
+++ b/internal/plugins/maintenance/backfill_ops_test.go
@@ -1,0 +1,140 @@
+// file: internal/plugins/maintenance/backfill_ops_test.go
+// version: 1.0.0
+// guid: 7d8e9f0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a
+// last-edited: 2026-07-18
+
+// Package maintenance tests for T09 (C2/H7): proves runExternalIDBackfill,
+// runMalformedM4BRemux, and runMalformedM4BTranscode thread the op reporter's
+// progress and error through to the underlying deps calls instead of
+// swallowing them — the bug that let a multi-hour ffmpeg walk show a single
+// "starting"/"complete" log line and never fail the op.
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// t09OpsFakeDeps wraps fakeDeps (from title_backfill_test.go) and overrides
+// the three C2/H7 methods with configurable error + progress-invocation
+// behavior, so tests can assert the Run functions propagate both correctly.
+// Named with a t09 prefix per RULE 9 (task-unique test helper names — a
+// same-named helper in this package has broken main before).
+type t09OpsFakeDeps struct {
+	fakeDeps
+	backfillErr  error
+	remuxErr     error
+	transcodeErr error
+}
+
+func (d t09OpsFakeDeps) BackfillExternalIDs(progress func(processed, total int, msg string)) error {
+	if progress != nil {
+		progress(1, 2, "half done")
+	}
+	return d.backfillErr
+}
+
+func (d t09OpsFakeDeps) RemuxMalformedM4BFiles(_ context.Context, progress func(processed, total int, msg string)) error {
+	if progress != nil {
+		progress(5, 10, "remuxing")
+	}
+	return d.remuxErr
+}
+
+func (d t09OpsFakeDeps) TranscodeMalformedM4BFiles(_ context.Context, progress func(processed, total int, msg string)) error {
+	if progress != nil {
+		progress(3, 7, "transcoding")
+	}
+	return d.transcodeErr
+}
+
+var _ ServerDeps = t09OpsFakeDeps{}
+
+// t09ProgressReporter is a minimal fakeReporter wrapper that records every
+// UpdateProgress call so tests can assert the callback threaded through.
+type t09ProgressReporter struct {
+	fakeReporter
+	progressCalls []string
+}
+
+func (r *t09ProgressReporter) UpdateProgress(current, total int, msg string) error {
+	r.progressCalls = append(r.progressCalls, msg)
+	return r.fakeReporter.UpdateProgress(current, total, msg)
+}
+
+func TestRunExternalIDBackfill_ThreadsProgressAndSucceeds(t *testing.T) {
+	p := New(t09OpsFakeDeps{})
+	reporter := &t09ProgressReporter{}
+
+	if err := p.runExternalIDBackfill(context.Background(), nil, reporter); err != nil {
+		t.Fatalf("runExternalIDBackfill() unexpected error: %v", err)
+	}
+	if len(reporter.progressCalls) != 1 || reporter.progressCalls[0] != "half done" {
+		t.Errorf("runExternalIDBackfill() progress calls = %v, want [\"half done\"]", reporter.progressCalls)
+	}
+}
+
+// TestRunExternalIDBackfill_PropagatesError proves the H7 fix: a non-nil
+// error from BackfillExternalIDs now fails the op instead of being demoted
+// to a Warn log while the Run function unconditionally reports "complete".
+func TestRunExternalIDBackfill_PropagatesError(t *testing.T) {
+	wantErr := errors.New("backfill boom")
+	p := New(t09OpsFakeDeps{backfillErr: wantErr})
+	reporter := &t09ProgressReporter{}
+
+	err := p.runExternalIDBackfill(context.Background(), nil, reporter)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runExternalIDBackfill() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunMalformedM4BRemux_ThreadsProgressAndSucceeds(t *testing.T) {
+	p := New(t09OpsFakeDeps{})
+	reporter := &t09ProgressReporter{}
+
+	if err := p.runMalformedM4BRemux(context.Background(), nil, reporter); err != nil {
+		t.Fatalf("runMalformedM4BRemux() unexpected error: %v", err)
+	}
+	if len(reporter.progressCalls) != 1 || reporter.progressCalls[0] != "remuxing" {
+		t.Errorf("runMalformedM4BRemux() progress calls = %v, want [\"remuxing\"]", reporter.progressCalls)
+	}
+}
+
+// TestRunMalformedM4BRemux_PropagatesError proves the C2 fix: a fatal setup
+// failure from RemuxMalformedM4BFiles now fails the op.
+func TestRunMalformedM4BRemux_PropagatesError(t *testing.T) {
+	wantErr := errors.New("remux boom")
+	p := New(t09OpsFakeDeps{remuxErr: wantErr})
+	reporter := &t09ProgressReporter{}
+
+	err := p.runMalformedM4BRemux(context.Background(), nil, reporter)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runMalformedM4BRemux() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunMalformedM4BTranscode_ThreadsProgressAndSucceeds(t *testing.T) {
+	p := New(t09OpsFakeDeps{})
+	reporter := &t09ProgressReporter{}
+
+	if err := p.runMalformedM4BTranscode(context.Background(), nil, reporter); err != nil {
+		t.Fatalf("runMalformedM4BTranscode() unexpected error: %v", err)
+	}
+	if len(reporter.progressCalls) != 1 || reporter.progressCalls[0] != "transcoding" {
+		t.Errorf("runMalformedM4BTranscode() progress calls = %v, want [\"transcoding\"]", reporter.progressCalls)
+	}
+}
+
+// TestRunMalformedM4BTranscode_PropagatesError proves the C2 fix: a fatal
+// setup failure from TranscodeMalformedM4BFiles now fails the op.
+func TestRunMalformedM4BTranscode_PropagatesError(t *testing.T) {
+	wantErr := errors.New("transcode boom")
+	p := New(t09OpsFakeDeps{transcodeErr: wantErr})
+	reporter := &t09ProgressReporter{}
+
+	err := p.runMalformedM4BTranscode(context.Background(), nil, reporter)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runMalformedM4BTranscode() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/deps.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567891
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 // Package maintenance is the UOS plugin for all maintenance/janitor operations.
 // It holds 26 OperationDefs migrated from the legacy scheduler_tasks.go.
@@ -40,13 +40,18 @@ type ServerDeps interface {
 
 	// ----- one-shot startup ops -----
 
-	BackfillExternalIDs()
+	// BackfillExternalIDs, RemuxMalformedM4BFiles, and TranscodeMalformedM4BFiles
+	// take a progress callback (processed, total int, msg string) — total may
+	// be 0 when unknown ahead of a paginated pass — and return the impl's
+	// error so a fatal setup failure or persistence error can fail the op
+	// instead of being silently swallowed (C2/H7). progress may be nil.
+	BackfillExternalIDs(progress func(processed, total int, msg string)) error
 	// StripMovementAtoms, RemuxMalformedM4BFiles, and TranscodeMalformedM4BFiles
 	// take ctx so their per-file library walks stop early on cancellation
 	// (SYS-1); pass the op's run context.
 	StripMovementAtoms(ctx context.Context)
-	RemuxMalformedM4BFiles(ctx context.Context)
-	TranscodeMalformedM4BFiles(ctx context.Context)
+	RemuxMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error
+	TranscodeMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error
 
 	// ----- store helpers called by ops -----
 

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-07-07
+// last-edited: 2026-07-18
 
 package maintenance
 
@@ -58,10 +58,14 @@ func (d fakeDeps) ExecuteSeriesPrune(_ context.Context, _ database.Store, _ oper
 func (d fakeDeps) ExecuteSeriesNormalizeCore(_ context.Context, _ database.Store, _ func(string)) ([]string, error) {
 	return nil, nil
 }
-func (d fakeDeps) BackfillExternalIDs()                            {}
-func (d fakeDeps) StripMovementAtoms(_ context.Context)            {}
-func (d fakeDeps) RemuxMalformedM4BFiles(_ context.Context)        {}
-func (d fakeDeps) TranscodeMalformedM4BFiles(_ context.Context)    {}
+func (d fakeDeps) BackfillExternalIDs(_ func(int, int, string)) error { return nil }
+func (d fakeDeps) StripMovementAtoms(_ context.Context)               {}
+func (d fakeDeps) RemuxMalformedM4BFiles(_ context.Context, _ func(int, int, string)) error {
+	return nil
+}
+func (d fakeDeps) TranscodeMalformedM4BFiles(_ context.Context, _ func(int, int, string)) error {
+	return nil
+}
 func (d fakeDeps) CleanupOrphanedTempFiles(_ string, _ string) int { return 0 }
 func (d fakeDeps) CleanupTrashedVersions() int                     { return 0 }
 func (d fakeDeps) SweepArchivedBooks() int                         { return 0 }

--- a/internal/remux/remux.go
+++ b/internal/remux/remux.go
@@ -1,7 +1,7 @@
 // file: internal/remux/remux.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package remux
 
@@ -38,6 +38,21 @@ func New(store Store) *Remuxer {
 	return &Remuxer{store: store}
 }
 
+// isRemuxCandidate reports whether path is an M4B/M4A file this pass should
+// consider (used identically by the pre-count pass and the work pass so the
+// reported "total" never drifts from what actually gets processed).
+func isRemuxCandidate(path string, d fs.DirEntry) bool {
+	if d.IsDir() {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".m4b" && ext != ".m4a" {
+		return false
+	}
+	// Skip orphaned temp files — those are handled by cleanupOrphanedTempFiles.
+	return !strings.Contains(filepath.Base(path), ".tmp.")
+}
+
 // RemuxMalformedFiles walks the library once and re-muxes any M4B/M4A
 // file that taglib cannot parse (malformed atom structure). Re-muxing with
 // ffmpeg -c copy rewrites the atom layout without re-encoding audio, making
@@ -45,29 +60,58 @@ func New(store Store) *Remuxer {
 // is verified before replacing the original. Runs once at startup. The walk
 // checks ctx per file and stops early via fs.SkipAll when canceled (SYS-1);
 // a canceled run does not write the done flag, so the next startup resumes.
-func (r *Remuxer) RemuxMalformedFiles(ctx context.Context) {
+//
+// progress is called every 25 processed files (and once more at the end)
+// with the running counts, so a caller wired to an op reporter's
+// UpdateProgress can surface a live "X/Y" during a multi-hour run instead of
+// a single log line at completion (C2). progress may be nil.
+//
+// A non-nil error is returned only for fatal setup problems (RootDir not
+// configured, ffmpeg missing) — those used to be swallowed as a Warn log,
+// letting the op report success while doing nothing. Per-file remux
+// failures are expected in normal operation (the transcode op is the
+// designed fallback for files that can't be remuxed) and are counted in the
+// progress message rather than failing the whole run.
+func (r *Remuxer) RemuxMalformedFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
 	if r.store == nil {
-		return
+		return nil
 	}
 
 	if setting, err := r.store.GetSetting(RemuxKey); err == nil && setting != nil && setting.Value == "true" {
 		slog.Info("Malformed M4B remux already completed, skipping")
-		return
+		return nil
 	}
 
 	root := config.AppConfig.RootDir
 	if root == "" {
-		slog.Warn("RemuxMalformedFiles RootDir not configured, skipping")
-		return
+		return fmt.Errorf("RemuxMalformedFiles: RootDir not configured")
 	}
 
 	if _, err := exec.LookPath("ffmpeg"); err != nil {
-		slog.Warn("RemuxMalformedFiles ffmpeg not found, skipping")
-		return
+		return fmt.Errorf("RemuxMalformedFiles: ffmpeg not found: %w", err)
 	}
 
-	slog.Info("Starting malformed M4B remux scan under", "root", root)
-	remuxed, clean, failed := 0, 0, 0
+	// Pre-count candidates so progress can report an accurate "X/Y" instead
+	// of an unbounded counter. Cheap relative to the ffmpeg work itself —
+	// this pass does no file content reads, just a directory walk.
+	total := 0
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		select {
+		case <-ctx.Done():
+			return fs.SkipAll
+		default:
+		}
+		if walkErr != nil {
+			return nil
+		}
+		if isRemuxCandidate(path, d) {
+			total++
+		}
+		return nil
+	})
+
+	slog.Info("Starting malformed M4B remux scan under", "root", root, "candidates", total)
+	remuxed, clean, failed, processed := 0, 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
@@ -80,14 +124,13 @@ func (r *Remuxer) RemuxMalformedFiles(ctx context.Context) {
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".m4b" && ext != ".m4a" {
+		if !isRemuxCandidate(path, d) {
 			return nil
 		}
 
-		// Skip orphaned temp files — those are handled by cleanupOrphanedTempFiles.
-		if strings.Contains(filepath.Base(path), ".tmp.") {
-			return nil
+		processed++
+		if progress != nil && processed%25 == 0 {
+			progress(processed, total, fmt.Sprintf("Probing M4B: %d/%d (remuxed=%d failed=%d)", processed, total, remuxed, failed))
 		}
 
 		if _, err := taglib.ReadTags(path); err == nil {
@@ -114,8 +157,13 @@ func (r *Remuxer) RemuxMalformedFiles(ctx context.Context) {
 		return nil
 	})
 
+	if progress != nil {
+		progress(processed, total, fmt.Sprintf("Probing M4B: %d/%d (remuxed=%d failed=%d)", processed, total, remuxed, failed))
+	}
+
 	slog.Info("Malformed M4B remux complete", "remuxed", remuxed, "clean", clean, "failed", failed)
 	_ = r.store.SetSetting(RemuxKey, "true", "bool", false)
+	return nil
 }
 
 // RemuxFile re-muxes an M4B/M4A file in-place using ffmpeg -c copy.

--- a/internal/remux/remux_test.go
+++ b/internal/remux/remux_test.go
@@ -1,16 +1,20 @@
 // file: internal/remux/remux_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package remux
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
@@ -55,7 +59,9 @@ func TestRemuxerNew(t *testing.T) {
 
 func TestRemuxMalformedFilesWithoutStore(t *testing.T) {
 	remuxer := &Remuxer{store: nil}
-	remuxer.RemuxMalformedFiles(context.Background()) // Should not panic
+	if err := remuxer.RemuxMalformedFiles(context.Background(), nil); err != nil {
+		t.Errorf("RemuxMalformedFiles() with nil store should return nil, got %v", err)
+	}
 }
 
 func TestRemuxMalformedFilesAlreadyCompleted(t *testing.T) {
@@ -69,7 +75,76 @@ func TestRemuxMalformedFilesAlreadyCompleted(t *testing.T) {
 		},
 	}
 	remuxer := New(store)
-	remuxer.RemuxMalformedFiles(context.Background()) // Should skip due to already completed
+	if err := remuxer.RemuxMalformedFiles(context.Background(), nil); err != nil {
+		t.Errorf("RemuxMalformedFiles() already-completed should return nil, got %v", err)
+	}
+}
+
+// TestRemuxMalformedFilesRootDirNotConfigured proves the C2 fix: a fatal
+// setup failure (no RootDir configured) now returns an error instead of
+// being swallowed as a Warn log, so the op can actually fail.
+func TestRemuxMalformedFilesRootDirNotConfigured(t *testing.T) {
+	origRoot := config.AppConfig.RootDir
+	config.AppConfig.RootDir = ""
+	defer func() { config.AppConfig.RootDir = origRoot }()
+
+	store := &MockStore{}
+	remuxer := New(store)
+	err := remuxer.RemuxMalformedFiles(context.Background(), nil)
+	if err == nil {
+		t.Fatal("RemuxMalformedFiles() expected error when RootDir is not configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "RootDir") {
+		t.Errorf("RemuxMalformedFiles() error = %q, want it to mention RootDir", err.Error())
+	}
+}
+
+// TestRemuxMalformedFilesProgressCallback proves the C2 fix: progress is
+// threaded through and called every 25 files (and once more at the end),
+// with an accurate total from the pre-count pass.
+func TestRemuxMalformedFilesProgressCallback(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available, skipping")
+	}
+
+	origRoot := config.AppConfig.RootDir
+	tmpDir := t.TempDir()
+	config.AppConfig.RootDir = tmpDir
+	defer func() { config.AppConfig.RootDir = origRoot }()
+
+	// Files that taglib can't parse are "malformed" candidates; plain text
+	// content is enough to exercise the walk + progress path (ffmpeg will
+	// fail to remux them, which is fine — we're only proving progress fires
+	// with an accurate total, not that remux succeeds).
+	for i := 0; i < 3; i++ {
+		p := filepath.Join(tmpDir, fmt.Sprintf("test%d.m4b", i))
+		if err := os.WriteFile(p, []byte("not a real m4b"), 0o644); err != nil {
+			t.Fatalf("write test file: %v", err)
+		}
+	}
+
+	store := &MockStore{}
+	remuxer := New(store)
+
+	var calls int
+	var lastProcessed, lastTotal int
+	err := remuxer.RemuxMalformedFiles(context.Background(), func(processed, total int, _ string) {
+		calls++
+		lastProcessed = processed
+		lastTotal = total
+	})
+	if err != nil {
+		t.Fatalf("RemuxMalformedFiles() unexpected error: %v", err)
+	}
+	if calls == 0 {
+		t.Fatal("RemuxMalformedFiles() progress callback was never called")
+	}
+	if lastTotal != 3 {
+		t.Errorf("RemuxMalformedFiles() final total = %d, want 3", lastTotal)
+	}
+	if lastProcessed != 3 {
+		t.Errorf("RemuxMalformedFiles() final processed = %d, want 3", lastProcessed)
+	}
 }
 
 func TestRemuxFileErrorsOnNonexistentFile(t *testing.T) {

--- a/internal/remux/transcode.go
+++ b/internal/remux/transcode.go
@@ -1,7 +1,7 @@
 // file: internal/remux/transcode.go
-// version: 1.1.1
+// version: 1.2.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package remux
 
@@ -39,31 +39,54 @@ func TranscodeSkipKey(path string) string {
 	return fmt.Sprintf("transcode_skip_%x", h[:8])
 }
 
+// isTranscodeCandidate reports whether path is an M4B/M4A file this pass
+// should consider (used identically by the pre-count pass and the work pass
+// so the reported "total" never drifts from what actually gets processed).
+func isTranscodeCandidate(path string, d fs.DirEntry) bool {
+	if d.IsDir() {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext != ".m4b" && ext != ".m4a" {
+		return false
+	}
+	return !strings.Contains(filepath.Base(path), ".tmp.")
+}
+
 // TranscodeMalformedFiles walks the library and re-encodes any M4B/M4A
 // file that taglib cannot parse even after the remux pass. Full AAC transcode
 // at 64 kbps rebuilds the file from scratch, which fixes corruption that a
 // stream copy cannot repair. Runs once at startup. The walk checks ctx per
 // file and stops early via fs.SkipAll when canceled (SYS-1); a canceled run
 // does not write the done flag, so the next startup resumes.
-func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
+//
+// progress is called every 25 processed files (and once more at the end)
+// with the running counts, so a caller wired to an op reporter's
+// UpdateProgress can surface a live "X/Y" during a multi-hour ffmpeg walk
+// instead of a single log line at completion (C2). progress may be nil.
+//
+// A non-nil error is returned only for fatal setup problems (RootDir not
+// configured, ffmpeg missing) — those used to be swallowed as a Warn log,
+// letting the op report success while doing nothing. Per-file transcode
+// failures are expected (files get marked permanently-unfixable and are
+// counted in the progress message) rather than failing the whole run.
+func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
 	if t.store == nil {
-		return
+		return nil
 	}
 
 	if setting, err := t.store.GetSetting(TranscodeKey); err == nil && setting != nil && setting.Value == "true" {
 		slog.Info("Malformed M4B transcode already completed, skipping")
-		return
+		return nil
 	}
 
 	root := config.AppConfig.RootDir
 	if root == "" {
-		slog.Warn("TranscodeMalformedFiles RootDir not configured, skipping")
-		return
+		return fmt.Errorf("TranscodeMalformedFiles: RootDir not configured")
 	}
 
 	if _, err := exec.LookPath("ffmpeg"); err != nil {
-		slog.Warn("TranscodeMalformedFiles ffmpeg not found, skipping")
-		return
+		return fmt.Errorf("TranscodeMalformedFiles: ffmpeg not found: %w", err)
 	}
 
 	// Pre-mark files confirmed permanently unfixable by full transcode.
@@ -80,8 +103,27 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 		}
 	}
 
-	slog.Info("Starting malformed M4B transcode scan under", "root", root)
-	transcoded, clean, failed, skipped := 0, 0, 0, 0
+	// Pre-count candidates so progress can report an accurate "X/Y" instead
+	// of an unbounded counter. Cheap relative to the ffmpeg work itself —
+	// this pass does no file content reads, just a directory walk.
+	total := 0
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		select {
+		case <-ctx.Done():
+			return fs.SkipAll
+		default:
+		}
+		if walkErr != nil {
+			return nil
+		}
+		if isTranscodeCandidate(path, d) {
+			total++
+		}
+		return nil
+	})
+
+	slog.Info("Starting malformed M4B transcode scan under", "root", root, "candidates", total)
+	transcoded, clean, failed, skipped, processed := 0, 0, 0, 0, 0
 
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		// Stop the walk cleanly on shutdown (SYS-1). fs.SkipAll ends WalkDir
@@ -94,13 +136,13 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if ext != ".m4b" && ext != ".m4a" {
+		if !isTranscodeCandidate(path, d) {
 			return nil
 		}
 
-		if strings.Contains(filepath.Base(path), ".tmp.") {
-			return nil
+		processed++
+		if progress != nil && processed%25 == 0 {
+			progress(processed, total, fmt.Sprintf("Transcoding M4B: %d/%d (transcoded=%d failed=%d skipped=%d)", processed, total, transcoded, failed, skipped))
 		}
 
 		if _, err := taglib.ReadTags(path); err == nil {
@@ -137,8 +179,13 @@ func (t *Transcoder) TranscodeMalformedFiles(ctx context.Context) {
 		return nil
 	})
 
+	if progress != nil {
+		progress(processed, total, fmt.Sprintf("Transcoding M4B: %d/%d (transcoded=%d failed=%d skipped=%d)", processed, total, transcoded, failed, skipped))
+	}
+
 	slog.Info("Malformed M4B transcode transcoded, already readable, failed, permanently skipped", "transcoded", transcoded, "clean", clean, "failed", failed, "skipped", skipped)
 	_ = t.store.SetSetting(TranscodeKey, "true", "bool", false)
+	return nil
 }
 
 // TranscodeFile re-encodes an M4B/M4A file to 64 kbps AAC in-place.

--- a/internal/remux/transcode_test.go
+++ b/internal/remux/transcode_test.go
@@ -1,7 +1,7 @@
 // file: internal/remux/transcode_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package remux
 
@@ -10,9 +10,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
@@ -30,7 +33,9 @@ func TestTranscoderNew(t *testing.T) {
 
 func TestTranscodeMalformedFilesWithoutStore(t *testing.T) {
 	transcoder := &Transcoder{store: nil}
-	transcoder.TranscodeMalformedFiles(context.Background()) // Should not panic
+	if err := transcoder.TranscodeMalformedFiles(context.Background(), nil); err != nil {
+		t.Errorf("TranscodeMalformedFiles() with nil store should return nil, got %v", err)
+	}
 }
 
 func TestTranscodeMalformedFilesAlreadyCompleted(t *testing.T) {
@@ -44,7 +49,71 @@ func TestTranscodeMalformedFilesAlreadyCompleted(t *testing.T) {
 		},
 	}
 	transcoder := NewTranscoder(store)
-	transcoder.TranscodeMalformedFiles(context.Background()) // Should skip due to already completed
+	if err := transcoder.TranscodeMalformedFiles(context.Background(), nil); err != nil {
+		t.Errorf("TranscodeMalformedFiles() already-completed should return nil, got %v", err)
+	}
+}
+
+// TestTranscodeMalformedFilesRootDirNotConfigured proves the C2 fix: a fatal
+// setup failure (no RootDir configured) now returns an error instead of
+// being swallowed as a Warn log, so the op can actually fail.
+func TestTranscodeMalformedFilesRootDirNotConfigured(t *testing.T) {
+	origRoot := config.AppConfig.RootDir
+	config.AppConfig.RootDir = ""
+	defer func() { config.AppConfig.RootDir = origRoot }()
+
+	store := &MockStore{}
+	transcoder := NewTranscoder(store)
+	err := transcoder.TranscodeMalformedFiles(context.Background(), nil)
+	if err == nil {
+		t.Fatal("TranscodeMalformedFiles() expected error when RootDir is not configured, got nil")
+	}
+	if !strings.Contains(err.Error(), "RootDir") {
+		t.Errorf("TranscodeMalformedFiles() error = %q, want it to mention RootDir", err.Error())
+	}
+}
+
+// TestTranscodeMalformedFilesProgressCallback proves the C2 fix: progress is
+// threaded through with an accurate total from the pre-count pass.
+func TestTranscodeMalformedFilesProgressCallback(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available, skipping")
+	}
+
+	origRoot := config.AppConfig.RootDir
+	tmpDir := t.TempDir()
+	config.AppConfig.RootDir = tmpDir
+	defer func() { config.AppConfig.RootDir = origRoot }()
+
+	for i := 0; i < 3; i++ {
+		p := filepath.Join(tmpDir, fmt.Sprintf("test%d.m4b", i))
+		if err := os.WriteFile(p, []byte("not a real m4b"), 0o644); err != nil {
+			t.Fatalf("write test file: %v", err)
+		}
+	}
+
+	store := &MockStore{}
+	transcoder := NewTranscoder(store)
+
+	var calls int
+	var lastProcessed, lastTotal int
+	err := transcoder.TranscodeMalformedFiles(context.Background(), func(processed, total int, _ string) {
+		calls++
+		lastProcessed = processed
+		lastTotal = total
+	})
+	if err != nil {
+		t.Fatalf("TranscodeMalformedFiles() unexpected error: %v", err)
+	}
+	if calls == 0 {
+		t.Fatal("TranscodeMalformedFiles() progress callback was never called")
+	}
+	if lastTotal != 3 {
+		t.Errorf("TranscodeMalformedFiles() final total = %d, want 3", lastTotal)
+	}
+	if lastProcessed != 3 {
+		t.Errorf("TranscodeMalformedFiles() final processed = %d, want 3", lastProcessed)
+	}
 }
 
 func TestTranscodeSkipKey(t *testing.T) {

--- a/internal/server/external_id_backfill.go
+++ b/internal/server/external_id_backfill.go
@@ -1,7 +1,7 @@
 // file: internal/server/external_id_backfill.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: a3b4c5d6-e7f8-4a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-07-07
+// last-edited: 2026-07-18
 
 package server
 
@@ -44,24 +44,32 @@ func asExternalIDStore(s any) ExternalIDStore {
 // backfillExternalIDs delegates to itunes.BackfillExternalIDs.
 // The domain package handles idempotency checks and coordinates book-level,
 // file-level, and track-level PID registration.
-func (s *Server) backfillExternalIDs() {
+//
+// progress is forwarded straight to itunes.BackfillExternalIDs so the
+// whole-library pagination reports live progress (H7). The domain error is
+// now returned to the caller instead of being demoted to a Warn log — a
+// failure here (e.g. a write error mid-backfill) used to leave the op
+// reporting success unconditionally.
+func (s *Server) backfillExternalIDs(progress func(processed, total int, msg string)) error {
 	store := s.Store()
 	if store == nil {
-		return
+		return nil
 	}
 
 	eidStore := asExternalIDStore(store)
 	if eidStore == nil {
 		slog.Debug("backfillExternalIDs store does not implement ExternalIDStore, skipping")
-		return
+		return nil
 	}
 
 	// Delegate to the itunes domain package. s.bgCtx aborts the backfill
 	// on shutdown so it can't outlive the store and crash on
 	// "pebble: closed" in CreateExternalIDMapping.
-	if err := itunes.BackfillExternalIDs(s.bgCtx, &externalIDStoreAdapter{eidStore: eidStore, store: store}); err != nil {
+	if err := itunes.BackfillExternalIDs(s.bgCtx, &externalIDStoreAdapter{eidStore: eidStore, store: store}, progress); err != nil {
 		slog.Warn("backfillExternalIDs", "err", err)
+		return err
 	}
+	return nil
 }
 
 // externalIDStoreAdapter adapts ExternalIDStore and database.Store to

--- a/internal/server/malformed_m4b_wrappers.go
+++ b/internal/server/malformed_m4b_wrappers.go
@@ -1,7 +1,7 @@
 // file: internal/server/malformed_m4b_wrappers.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package server
 
@@ -12,15 +12,19 @@ import (
 )
 
 // remuxMalformedM4BFiles is a thin wrapper that delegates to the remux package.
-// ctx lets the library walk stop early on shutdown (SYS-1).
-func (s *Server) remuxMalformedM4BFiles(ctx context.Context) {
+// ctx lets the library walk stop early on shutdown (SYS-1). progress and the
+// error return are threaded straight through to the op reporter (C2) so a
+// multi-hour ffmpeg walk surfaces live progress and can fail the op on a
+// fatal setup problem instead of silently completing.
+func (s *Server) remuxMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
 	remuxer := remux.New(s.store)
-	remuxer.RemuxMalformedFiles(ctx)
+	return remuxer.RemuxMalformedFiles(ctx, progress)
 }
 
 // transcodeMalformedM4BFiles is a thin wrapper that delegates to the remux package.
-// ctx lets the library walk stop early on shutdown (SYS-1).
-func (s *Server) transcodeMalformedM4BFiles(ctx context.Context) {
+// ctx lets the library walk stop early on shutdown (SYS-1). See
+// remuxMalformedM4BFiles for the progress/error threading rationale (C2).
+func (s *Server) transcodeMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
 	transcoder := remux.NewTranscoder(s.store)
-	transcoder.TranscodeMalformedFiles(ctx)
+	return transcoder.TranscodeMalformedFiles(ctx, progress)
 }

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.44.0
+// version: 1.46.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-07-10
+// last-edited: 2026-07-18
 
 package server
 
@@ -933,7 +933,16 @@ func (s *Server) startBackfills() {
 	s.bgWG.Add("external-id-backfill")
 	go func() {
 		defer s.bgWG.Done("external-id-backfill")
-		s.backfillExternalIDs()
+		// This startup-goroutine path has no op reporter (only the UOS plugin
+		// op maintenance.external-id-backfill does), so progress is surfaced
+		// via a plain slog.Info instead of reporter.UpdateProgress — this is
+		// the path that actually runs at every boot, so it's the one that
+		// needs the "more than one log line" fix (H7), not just the UOS
+		// plugin op (unclear whether that path is ever enqueued). The error
+		// is no longer silently swallowed either.
+		if err := s.backfillExternalIDs(startupProgressLogger("external-id-backfill")); err != nil {
+			slog.Warn("startup external-id-backfill failed", "err", err)
+		}
 	}()
 
 	// AcoustID fingerprint backfill. CONC-9 removed the serial server-side
@@ -992,7 +1001,11 @@ func (s *Server) startBackfills() {
 	s.bgWG.Add("remux-malformed-m4b")
 	go func() {
 		defer s.bgWG.Done("remux-malformed-m4b")
-		s.remuxMalformedM4BFiles(s.bgCtx)
+		// See the external-id-backfill goroutine above for why this logs
+		// progress via slog rather than a reporter (C2).
+		if err := s.remuxMalformedM4BFiles(s.bgCtx, startupProgressLogger("remux-malformed-m4b")); err != nil {
+			slog.Warn("startup remux-malformed-m4b failed", "err", err)
+		}
 	}()
 
 	// Build the search index on first startup (or if it got wiped).
@@ -1014,9 +1027,26 @@ func (s *Server) startBackfills() {
 	s.bgWG.Add("transcode+quarantine")
 	go func() {
 		defer s.bgWG.Done("transcode+quarantine")
-		s.transcodeMalformedM4BFiles(s.bgCtx)
+		// See the external-id-backfill goroutine above for why this logs
+		// progress via slog rather than a reporter (C2).
+		if err := s.transcodeMalformedM4BFiles(s.bgCtx, startupProgressLogger("transcode-malformed-m4b")); err != nil {
+			slog.Warn("startup transcode-malformed-m4b failed", "err", err)
+		}
 		s.quarantineKnownBadFiles()
 	}()
+}
+
+// startupProgressLogger returns a C2/H7 progress callback that logs via slog,
+// for use by the raw startBackfills goroutines above, which run outside the
+// UOS op registry and so have no reporter.UpdateProgress to call. Without
+// this, these ops — which run unconditionally at every boot — would still
+// show only a single "starting"/"complete" log line across a multi-hour run,
+// even after threading progress through the dep layer, because nil progress
+// is a no-op.
+func startupProgressLogger(op string) func(processed, total int, msg string) {
+	return func(processed, total int, msg string) {
+		slog.Info("startup progress", "op", op, "processed", processed, "total", total, "msg", msg)
+	}
 }
 
 func (s *Server) perm(p auth.Permission) gin.HandlerFunc {

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_maintenance_deps.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: b4c5d6e7-f8a9-0123-7890-345678901234
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 // This file implements the maintenance.ServerDeps interface on *Server, giving
 // the maintenance plugin access to server internals without creating an import
@@ -59,20 +59,20 @@ func (s *Server) ExecuteSeriesNormalizeCore(ctx context.Context, store database.
 
 // ---- one-shot startup ops ----
 
-func (s *Server) BackfillExternalIDs() {
-	s.backfillExternalIDs()
+func (s *Server) BackfillExternalIDs(progress func(processed, total int, msg string)) error {
+	return s.backfillExternalIDs(progress)
 }
 
 func (s *Server) StripMovementAtoms(ctx context.Context) {
 	s.stripMovementAtoms(ctx)
 }
 
-func (s *Server) RemuxMalformedM4BFiles(ctx context.Context) {
-	s.remuxMalformedM4BFiles(ctx)
+func (s *Server) RemuxMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
+	return s.remuxMalformedM4BFiles(ctx, progress)
 }
 
-func (s *Server) TranscodeMalformedM4BFiles(ctx context.Context) {
-	s.transcodeMalformedM4BFiles(ctx)
+func (s *Server) TranscodeMalformedM4BFiles(ctx context.Context, progress func(processed, total int, msg string)) error {
+	return s.transcodeMalformedM4BFiles(ctx, progress)
 }
 
 // ---- store helpers ----


### PR DESCRIPTION
## Summary

T09 from `docs/agent-tasks/error-correction-2026-07/TASKS.md`: closes C2 and H7.

- **C2**: `internal/plugins/maintenance/backfill.go`'s remux and transcode ops
  logged one line, called a void dep method (`RemuxMalformedM4BFiles`/
  `TranscodeMalformedM4BFiles`) that could run for hours, then unconditionally
  logged "complete" — a 6-hour ffmpeg walk showed exactly one op-log line and
  failures couldn't fail the op.
- **H7**: same shape for the external-ID backfill
  (`internal/server/external_id_backfill.go` → `internal/itunes/backfill.go`)
  — the domain error was demoted to a Warn log, the op completed
  unconditionally, and the whole-library pagination reported no progress.

### What changed

- `internal/remux/remux.go` + `transcode.go`: `RemuxMalformedFiles`/
  `TranscodeMalformedFiles` now take a `func(processed, total int, msg string)`
  progress callback and return `error`. A cheap pre-count pass (same
  candidate predicate as the work pass) gives an accurate "X/Y"; progress
  fires every 25 files. A non-nil error is returned only for fatal setup
  failures (RootDir not configured, ffmpeg missing) — per-file failures stay
  non-fatal since transcode is the designed fallback for files remux can't
  fix. Added an explicit 30m `ProgressTimeout` to the transcode
  `OperationDef` since a full re-encode can exceed the registry's 5m default
  gap between progress stamps (remux doesn't need it — it advances on every
  candidate file, well inside 5 minutes).
- `internal/itunes/backfill.go`: `BackfillExternalIDs`/
  `BackfillITunesTrackPIDs` take the same callback and now propagate
  `GetAllBooksCore` read errors and `BulkCreateExternalIDMappings` write
  errors instead of silently `break`-ing the pagination loop or
  logging-and-discarding — both of those previously let the op mark itself
  "done" despite skipping part of the library.
- Dependency chain updated end to end: `maintenance.ServerDeps` →
  `internal/server/server_maintenance_deps.go` →
  `malformed_m4b_wrappers.go` / `external_id_backfill.go`. The UOS plugin Run
  functions in `internal/plugins/maintenance/backfill.go` wire the callback to
  `reporter.UpdateProgress` and fail the op on a non-nil error.
- The `startBackfills()` goroutines in `internal/server/server_lifecycle.go`
  run these same ops directly at every boot, **outside** the UOS op
  registry (no reporter available there). Added a small `startupProgressLogger`
  helper so this path — which is the one that's actually live at every
  startup — also surfaces more than a single log line across a multi-hour
  run, and now logs the previously-swallowed error via `slog.Warn` instead of
  it being unreachable.

### Flags for the reviewer / coordinator

- **Coordination**: this PR edits `internal/server/server_maintenance_deps.go`,
  which the T05 brief also owns. Unavoidable — changing the `ServerDeps`
  interface signature forces changing `*Server`'s implementation of those
  three methods, and they live in that file. The edit here is confined to
  the three one-shot-op methods (`BackfillExternalIDs`,
  `RemuxMalformedM4BFiles`, `TranscodeMalformedM4BFiles`), a different region
  from T05's author/metadata/transcribe edits, so the rebase should
  auto-resolve — but please sequence it.
- **Scope caveat**: I could not find where the UOS ops
  `maintenance.malformed-m4b-remux`, `maintenance.malformed-m4b-transcode`,
  or `maintenance.external-id-backfill` actually get enqueued (no
  `EnqueueOp` call site for any of the three). It's possible that path is
  dormant and these ops only ever run via the direct `startBackfills()`
  goroutines — that's why the `startupProgressLogger` fix to the goroutine
  path matters as the actual live-in-prod win, not just the UOS plugin
  wiring.
- **Left out of scope**: `remux.go`'s (and `transcode.go`'s) done-flag write
  happens unconditionally even when the walk was canceled mid-run,
  contradicting its own doc comment ("a canceled run does not write the done
  flag"). Real bug, not part of C2/H7 — flagging for a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/remux/... -race -count=1` — pass (new tests for
      RootDir-not-configured error, progress-callback cadence/accuracy)
- [x] `go test ./internal/itunes/... -race -count=1` — pass (new tests for
      progress callback, bulk-write error propagation, read error propagation)
- [x] `go test ./internal/plugins/maintenance/... -race -count=1` — pass (new
      `backfill_ops_test.go` proving the Run functions thread progress to
      `reporter.UpdateProgress` and fail the op on a non-nil dep error)
- [x] `gofmt -l` clean on all 14 touched Go files
- [~] `go test ./internal/server/... -race -count=1` — timed out locally
      under heavy contention from ~6 sibling agents concurrently running
      their own `-race ./internal/server/...` suites on this machine (a
      dumped test, `TestDeleteBackup_Success`, was stuck on Pebble fsync
      disk I/O, unrelated to any code touched here — it passes in <5s in
      isolation). No `internal/server` test references any of the changed
      symbols. Deferring to CI for a clean-environment full run.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65