### PR TITLE
fix(dedup): reroute book-merge off hard-delete to soft-delete path (F6/T10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.176.0 -->
+<!-- version: 3.175.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -147,6 +148,24 @@
   callback, so this path also gets more than one log line across a
   multi-hour run, and now surfaces the previously-unreachable error via
   `slog.Warn`.
+#### July 18, 2026 - F6: reroute dedup book-merge off the hard-delete path
+
+- **Data-loss fix (T10 / F6):** the `POST /audiobooks/merge` endpoint
+  (`dedup.book-merge` op) was hard-deleting merged-away books via
+  `store.DeleteBook`, which does **not** tombstone external-ID (`ext_id:*`)
+  mappings and does **not** enqueue iTunes ITL removals. Every merge therefore
+  orphaned the losers' PID/ASIN lookups (leaving them resolving to a deleted
+  book) and stranded their iTunes tracks in the library forever. The op now
+  routes through `merge.Service.MergeBooks`, which reassigns external IDs to the
+  winner, enqueues ITL removals, and **soft-deletes** losers (recoverable) — the
+  same single merge path the UI/version-group merge uses. The legacy first-win
+  iTunes-stat copy (rating/play-count/etc.) is preserved onto the winner so the
+  reroute is strictly-better than the old path on every axis. The legacy
+  `dedup.MergeBooks` function is retained only for
+  `internal/reconcile/itunes_heal.go` (which intentionally hard-collapses
+  organize-bug duplicate rows and still carries the same ext-ID/ITL gap — tracked
+  as a follow-up). Regression test drives the reroute on a real PebbleStore and
+  asserts soft-delete + external-ID reassignment + first-win copy.
 
 #### July 17, 2026 - error-correction fix wave (15 PRs) + sandbox verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 <!-- file: CHANGELOG.md -->
 <!-- version: 3.176.0 -->
-<!-- version: 3.175.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 <!-- file: TODO.md -->
 <!-- version: 10.4.1 -->
-<!-- version: 10.4.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 <!-- file: TODO.md -->
 <!-- version: 10.4.1 -->
+<!-- version: 10.4.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -189,6 +190,8 @@ R-1 (T06) + R-3/R-7/P-2 (T08) (#2002).
 F7/R-9/R-8 (#PENDING — T11, see CHANGELOG July 18, 2026).
 F7/R-9/R-8 (#2004 — T11).
 C2/H7 remux/transcode/external-ID-backfill reporter threading (#2006).
+F6 (#PR_PLACEHOLDER — book-merge rerouted off hard-delete to soft-delete +
+external-ID reassignment + ITL removal, T10).
 
 ### Remaining — execution state (briefs)
 
@@ -205,6 +208,7 @@ C2/H7 remux/transcode/external-ID-backfill reporter threading (#2006).
 - [ ] **T07** — R-6: AssignOrphanVGs serial loop + VersionGroupID clobber guard (`internal/reconcile/reconcile.go:1270-1327`)
 - [ ] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress)
 - [ ] **T10** — F6: legacy dedup.MergeBooks hard-deletes losers without external-ID reassignment/ITL removal — VERIFY then reroute
+- [ ] **T09** — C2: remux/transcode 6-h ops have no reporter threading + can't fail · H7 (external-id backfill, same shape)
 - [ ] **T11** — F7 (quarantine serial loops → RunItems) · R-9 (path_repair serial loop) · R-8 (all-unreadable-durations group misclassified "short")
 - [x] **T12** — devops: 8 remaining scripts with internal IPs · op-stall alert (commented, metric doesn't exist yet — see Infra #36) · coverage floor on PR gate · systemd unit dedupe · credential entropy — #2001
 - [ ] **T12** — devops: 8 remaining scripts with internal IPs · op-stall alert · coverage floor on PR gate · systemd unit dedupe · credential entropy

--- a/TODO.md
+++ b/TODO.md
@@ -191,6 +191,7 @@ F7/R-9/R-8 (#PENDING — T11, see CHANGELOG July 18, 2026).
 F7/R-9/R-8 (#2004 — T11).
 C2/H7 remux/transcode/external-ID-backfill reporter threading (#2006).
 F6 (#PR_PLACEHOLDER — book-merge rerouted off hard-delete to soft-delete +
+F6 (#2007 — book-merge rerouted off hard-delete to soft-delete +
 external-ID reassignment + ITL removal, T10).
 
 ### Remaining — execution state (briefs)

--- a/docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md
+++ b/docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md
@@ -1,0 +1,44 @@
+<!-- file: docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2f8a6c34-9b71-4d02-8e15-3a7c0d5e9b46 -->
+<!-- last-edited: 2026-07-18 -->
+
+# Executive Summary: Fixing How Merging Duplicate Books Handled iTunes Links
+
+## What changed
+
+When the library finds two entries that are really the same audiobook, you can
+merge them: keep one, drop the other. The older "duplicate merge" button did the
+drop by **permanently deleting** the extra entry outright.
+
+The problem was what that deletion left behind. Each book can carry links to
+iTunes — the identifiers iTunes uses to recognize a track. Permanently deleting
+the extra entry did **not** clean up those links, so:
+
+- the iTunes identifiers kept pointing at an entry that no longer existed, and
+- the extra entry's tracks were never removed from iTunes, so iTunes kept
+  showing the duplicate forever.
+
+A later iTunes import could then follow one of those stale links straight to a
+deleted entry.
+
+The fix routes the duplicate-merge button through the app's newer, safer merge
+path — the same one the rest of the app already uses. That path moves the iTunes
+links over to the kept entry, tells iTunes to remove the duplicate's tracks, and
+**retires the extra entry instead of erasing it**, so it can still be recovered.
+It also carries the extra entry's iTunes listening stats (rating, play count,
+etc.) onto the kept entry so nothing visible is lost in the switch, and it now
+correctly refuses to delete the very entry you asked to keep even if it was
+listed on both sides of the merge.
+
+## Why it mattered
+
+This is a quiet data-integrity path: no audio file was erased, but the library's
+iTunes links were left dangling and duplicate tracks were stranded in iTunes,
+with no error shown. Because the old button deleted entries outright, a merge
+that hit this bug could not be undone.
+
+The fix ships with tests that merge books on a real database and confirm the
+dropped entry is retired (not erased), its iTunes link now resolves to the kept
+entry, its listening stats moved across, and the kept entry can never be
+accidentally deleted or demoted when it appears on both sides of a merge.

--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/book_dedup.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-13
+// last-edited: 2026-07-18
 
 // Package dedup: book_dedup.go contains the extracted execution logic for the
 // "dedup.book-scan" and "dedup.book-merge" async operations.  The *Server
@@ -337,6 +337,40 @@ type BookMergeResult struct {
 // opID is the legacy operation ID written into OperationChange records.
 // keepID is the ID of the book to keep; every ID in mergeIDs is deleted.
 //
+// TransferITunesMetadataFirstWin copies the six iTunes-provenance Book fields
+// (persistent ID, play count, rating, date added, last played, bookmark) from a
+// merged-away loser onto the surviving keep book, first-win: a field is only
+// filled if the keep book does not already have it. These are Book-level fields,
+// NOT external-ID mappings, so merge.Service.ReassignExternalIDs does not carry
+// them — any merge path that soft-deletes/hard-deletes a loser must call this
+// first or the loser's iTunes stats are stranded on the removed row. Shared by
+// the legacy dedup.MergeBooks hard-delete path AND the rerouted book-merge op
+// (internal/server/duplicates_ops.go), so the copy semantics live in one place.
+func TransferITunesMetadataFirstWin(keep, from *database.Book) {
+	if keep == nil || from == nil {
+		return
+	}
+	if (keep.ITunesPersistentID == nil || *keep.ITunesPersistentID == "") &&
+		from.ITunesPersistentID != nil && *from.ITunesPersistentID != "" {
+		keep.ITunesPersistentID = from.ITunesPersistentID
+	}
+	if keep.ITunesPlayCount == nil && from.ITunesPlayCount != nil {
+		keep.ITunesPlayCount = from.ITunesPlayCount
+	}
+	if keep.ITunesRating == nil && from.ITunesRating != nil {
+		keep.ITunesRating = from.ITunesRating
+	}
+	if keep.ITunesDateAdded == nil && from.ITunesDateAdded != nil {
+		keep.ITunesDateAdded = from.ITunesDateAdded
+	}
+	if keep.ITunesLastPlayed == nil && from.ITunesLastPlayed != nil {
+		keep.ITunesLastPlayed = from.ITunesLastPlayed
+	}
+	if keep.ITunesBookmark == nil && from.ITunesBookmark != nil {
+		keep.ITunesBookmark = from.ITunesBookmark
+	}
+}
+
 // Concurrency: this is a package-level function (NOT merge.Service.MergeBooks)
 // with its own unguarded read-modify-write, reached from two async ops with
 // DIFFERENT ConcurrencyKeys (dedup.book-merge and the iTunes-heal op), so it can
@@ -347,9 +381,17 @@ type BookMergeResult struct {
 // per-book loop is bounded by one request's merge set and does only local DB /
 // in-memory progress work under the lock — nothing network/large-scan. Semantics
 // differ from merge.Service.MergeBooks (hard-delete + iTunes-metadata transfer,
-// no version group), so it is intentionally NOT routed through the Service; it
-// only shares the lock. Non-reentrant: this never calls the Service merge paths,
-// so the lock is taken exactly once.
+// no version group), so it only shares the lock. Non-reentrant: this never calls
+// the Service merge paths, so the lock is taken exactly once.
+//
+// F6 (2026-07-18): the POST /audiobooks/merge endpoint (dedup.book-merge op) no
+// longer uses this function — it was rerouted to merge.Service.MergeBooks
+// because this legacy path hard-deletes losers via store.DeleteBook, which does
+// NOT tombstone external-ID (ext_id:*) mappings and does NOT enqueue iTunes ITL
+// removals, orphaning both. See internal/server/duplicates_ops.go. This function
+// is retained solely for internal/reconcile/itunes_heal.go, which intentionally
+// hard-collapses organize-bug duplicate rows; that caller still carries the same
+// ext-ID/ITL gap and is tracked as a follow-up.
 func MergeBooks(
 	_ context.Context,
 	store database.Store,
@@ -397,25 +439,7 @@ func MergeBooks(
 		}
 
 		// Transfer useful iTunes metadata from merge book to keep book (first-win).
-		if (kBook.ITunesPersistentID == nil || *kBook.ITunesPersistentID == "") &&
-			mergeBook.ITunesPersistentID != nil && *mergeBook.ITunesPersistentID != "" {
-			kBook.ITunesPersistentID = mergeBook.ITunesPersistentID
-		}
-		if kBook.ITunesPlayCount == nil && mergeBook.ITunesPlayCount != nil {
-			kBook.ITunesPlayCount = mergeBook.ITunesPlayCount
-		}
-		if kBook.ITunesRating == nil && mergeBook.ITunesRating != nil {
-			kBook.ITunesRating = mergeBook.ITunesRating
-		}
-		if kBook.ITunesDateAdded == nil && mergeBook.ITunesDateAdded != nil {
-			kBook.ITunesDateAdded = mergeBook.ITunesDateAdded
-		}
-		if kBook.ITunesLastPlayed == nil && mergeBook.ITunesLastPlayed != nil {
-			kBook.ITunesLastPlayed = mergeBook.ITunesLastPlayed
-		}
-		if kBook.ITunesBookmark == nil && mergeBook.ITunesBookmark != nil {
-			kBook.ITunesBookmark = mergeBook.ITunesBookmark
-		}
+		TransferITunesMetadataFirstWin(kBook, mergeBook)
 
 		if err := store.DeleteBook(mergeID); err != nil {
 			result.Errors = append(result.Errors,

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,7 +1,7 @@
 // file: internal/server/duplicates_ops.go
-// version: 2.4.1
+// version: 2.5.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
-// last-edited: 2026-07-12
+// last-edited: 2026-07-18
 
 // duplicates_ops registers v2 OperationDefs for the 8 async dedup operations
 // that previously used s.queue.Enqueue.  HTTP handlers in duplicates_handlers.go
@@ -33,9 +33,11 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/logging"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 	"github.com/gin-gonic/gin"
@@ -148,12 +150,31 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 			op.AddEntity("books", p.MergeIDs...)
 			logging.Info(ctx, "book merge starting", "keep_id", p.KeepID, "merge_count", len(p.MergeIDs))
 
-			_, err := dedup.MergeBooks(ctx, store, p.LegacyOpID, p.KeepID, p.MergeIDs, progress)
-			if err != nil {
+			// F6 REROUTE: this op previously called dedup.MergeBooks, which
+			// hard-deleted losers via store.DeleteBook. DeleteBook does NOT
+			// tombstone external-ID (ext_id:*) mappings and does NOT enqueue
+			// iTunes ITL removals, so every legacy merge orphaned the losers'
+			// PID/ASIN lookups (leaving them resolving to a hard-deleted book)
+			// and stranded their iTunes tracks in the library forever. Route
+			// through merge.Service.MergeBooks instead (via applyBookMergeReroute),
+			// which reassigns external IDs to the winner, enqueues ITL removals,
+			// and soft-deletes losers (recoverable) — one merge path shared with
+			// the UI/version-group merge.
+			ms := s.mergeService
+			if ms == nil {
+				// Fallback matches wire_handlers.go's getMergeService nil-path.
+				// Note: a fresh Service has no write-back batcher, so ITL removals
+				// are skipped in that mode (tests / iTunes write-back disabled).
+				ms = merge.NewService(store)
+			}
+			if err := applyBookMergeReroute(ctx, store, ms, p.KeepID, p.MergeIDs); err != nil {
 				op.SetStatus("failed")
 				logging.Error(ctx, "book merge failed", "err", err)
 				return err
 			}
+			// Service takes no ProgressReporter; emit a final 100% so the op UI
+			// completes cleanly.
+			_ = progress.UpdateProgress(len(p.MergeIDs), len(p.MergeIDs), "Book merge complete")
 
 			s.dedupCache.InvalidateAll()
 			if s.dedupEngine != nil {
@@ -171,6 +192,40 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 			return nil
 		},
 	})
+}
+
+// applyBookMergeReroute performs the F6-rerouted book merge for the
+// dedup.book-merge op. It (1) copies the losers' iTunes stats onto the keep book
+// first-win (merge.Service.MergeBooks reassigns external-ID mappings but does
+// NOT carry these Book-level iTunes fields, and after soft-delete they would
+// otherwise survive only on the loser row and vanish on a later purge/archive
+// sweep), persisting the copy BEFORE the merge — Service re-reads books fresh
+// and writes the full keep object back, so the copy survives its own
+// version-group UpdateBook — then (2) merges via merge.Service.MergeBooks, which
+// reassigns external IDs to the winner, enqueues ITL removals, and soft-deletes
+// losers. Extracted from the op Run body so the reroute (soft-delete +
+// external-ID reassignment, NOT hard delete) is unit-testable on a real store.
+func applyBookMergeReroute(ctx context.Context, store database.Store, ms *merge.Service, keepID string, mergeIDs []string) error {
+	if keepBook, err := store.GetBookByID(keepID); err == nil && keepBook != nil {
+		changed := false
+		for _, mid := range mergeIDs {
+			if mid == keepID {
+				continue
+			}
+			if mb, mErr := store.GetBookByID(mid); mErr == nil && mb != nil {
+				dedup.TransferITunesMetadataFirstWin(keepBook, mb)
+				changed = true
+			}
+		}
+		if changed {
+			if _, uErr := store.UpdateBook(keepBook.ID, keepBook); uErr != nil {
+				logging.Warn(ctx, "book merge: iTunes-field transfer write failed", "err", uErr)
+			}
+		}
+	}
+	// Service takes ALL ids (losers + winner) and the winner id.
+	_, err := ms.MergeBooks(append(append([]string{}, mergeIDs...), keepID), keepID)
+	return err
 }
 
 // RegisterAuthorDedupScanOp registers the "dedup.author-scan" v2 OperationDef.

--- a/internal/server/duplicates_ops.go
+++ b/internal/server/duplicates_ops.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_ops.go
-// version: 2.5.0
+// version: 2.6.0
 // guid: 8b3e1f92-d4c7-4a6e-b5f0-2a7c9d1e3f45
 // last-edited: 2026-07-18
 
@@ -206,12 +206,30 @@ func (s *Server) RegisterBookMergeOp(reg *opsregistry.Registry) error {
 // losers. Extracted from the op Run body so the reroute (soft-delete +
 // external-ID reassignment, NOT hard delete) is unit-testable on a real store.
 func applyBookMergeReroute(ctx context.Context, store database.Store, ms *merge.Service, keepID string, mergeIDs []string) error {
+	// Build the loser set once, excluding the keep book and de-duping. Callers
+	// (the handler binds keep_id/merge_ids without validation) may include the
+	// keep book in mergeIDs; legacy dedup.MergeBooks guarded this with a
+	// `mergeID == keepID { continue }` skip. Without it, passing keepID into
+	// merge.Service.MergeBooks makes the version-group loop write the keep book
+	// twice and demote it to non-primary — leaving the group with NO primary and
+	// the keep book neither primary nor soft-deleted. Excluding it here (for BOTH
+	// the transfer and the Service call) preserves that integrity guarantee.
+	losers := make([]string, 0, len(mergeIDs))
+	seen := map[string]bool{keepID: true}
+	for _, mid := range mergeIDs {
+		if seen[mid] {
+			continue
+		}
+		seen[mid] = true
+		losers = append(losers, mid)
+	}
+	if len(losers) == 0 {
+		return nil // nothing to merge (every id was the keep book / duplicate)
+	}
+
 	if keepBook, err := store.GetBookByID(keepID); err == nil && keepBook != nil {
 		changed := false
-		for _, mid := range mergeIDs {
-			if mid == keepID {
-				continue
-			}
+		for _, mid := range losers {
 			if mb, mErr := store.GetBookByID(mid); mErr == nil && mb != nil {
 				dedup.TransferITunesMetadataFirstWin(keepBook, mb)
 				changed = true
@@ -224,7 +242,7 @@ func applyBookMergeReroute(ctx context.Context, store database.Store, ms *merge.
 		}
 	}
 	// Service takes ALL ids (losers + winner) and the winner id.
-	_, err := ms.MergeBooks(append(append([]string{}, mergeIDs...), keepID), keepID)
+	_, err := ms.MergeBooks(append(append([]string{}, losers...), keepID), keepID)
 	return err
 }
 

--- a/internal/server/duplicates_ops_reroute_test.go
+++ b/internal/server/duplicates_ops_reroute_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/duplicates_ops_reroute_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a9c1f27-8b3e-4d05-9a61-2f7c0d3e6b58
 // last-edited: 2026-07-18
 
@@ -97,5 +97,62 @@ func TestApplyBookMergeReroute_SoftDeletesAndReassignsExternalIDs(t *testing.T) 
 	}
 	if keep.ITunesRating == nil || *keep.ITunesRating != 80 {
 		t.Fatalf("keep iTunes rating = %v, want 80 (first-win copy from loser)", keep.ITunesRating)
+	}
+}
+
+// TestApplyBookMergeReroute_KeepIDInMergeIDs guards the version-group integrity
+// hole: the handler binds keep_id/merge_ids without validation, so the keep book
+// can appear in mergeIDs. If it were passed through to merge.Service.MergeBooks
+// the version-group loop would write the keep book twice and demote it to
+// non-primary, leaving the group with NO primary and the keep book neither
+// primary nor soft-deleted. The reroute must exclude keepID from the loser set.
+func TestApplyBookMergeReroute_KeepIDInMergeIDs(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	keepID := ulid.Make().String()
+	loserID := ulid.Make().String()
+	if _, err := store.CreateBook(&database.Book{
+		ID: keepID, Title: "Keep", Format: "m4b", FilePath: "/tmp/" + keepID + ".m4b",
+	}); err != nil {
+		t.Fatalf("CreateBook keep: %v", err)
+	}
+	if _, err := store.CreateBook(&database.Book{
+		ID: loserID, Title: "Loser", Format: "mp3", FilePath: "/tmp/" + loserID + ".mp3",
+	}); err != nil {
+		t.Fatalf("CreateBook loser: %v", err)
+	}
+
+	ms := merge.NewService(store)
+	// keepID deliberately included in mergeIDs (and duplicated).
+	if err := applyBookMergeReroute(context.Background(), store, ms, keepID, []string{keepID, loserID, loserID}); err != nil {
+		t.Fatalf("applyBookMergeReroute: %v", err)
+	}
+
+	// Keep book survives as the primary version, NOT soft-deleted.
+	keep, err := store.GetBookByID(keepID)
+	if err != nil {
+		t.Fatalf("GetBookByID keep: %v", err)
+	}
+	if keep == nil {
+		t.Fatal("keep book was deleted — keepID-in-mergeIDs must not remove the winner")
+	}
+	if keep.MarkedForDeletion != nil && *keep.MarkedForDeletion {
+		t.Fatal("keep book was soft-deleted — keepID must be excluded from the loser set")
+	}
+	if keep.IsPrimaryVersion == nil || !*keep.IsPrimaryVersion {
+		t.Fatalf("keep book is not the primary version (%v) — version group left with no primary", keep.IsPrimaryVersion)
+	}
+
+	// Loser is soft-deleted as expected.
+	loser, err := store.GetBookByID(loserID)
+	if err != nil {
+		t.Fatalf("GetBookByID loser: %v", err)
+	}
+	if loser == nil || loser.MarkedForDeletion == nil || !*loser.MarkedForDeletion {
+		t.Fatalf("loser not soft-deleted: %+v", loser)
 	}
 }

--- a/internal/server/duplicates_ops_reroute_test.go
+++ b/internal/server/duplicates_ops_reroute_test.go
@@ -1,0 +1,101 @@
+// file: internal/server/duplicates_ops_reroute_test.go
+// version: 1.0.0
+// guid: 4a9c1f27-8b3e-4d05-9a61-2f7c0d3e6b58
+// last-edited: 2026-07-18
+
+// F6 regression test: the dedup.book-merge op (POST /audiobooks/merge) was
+// rerouted from the legacy dedup.MergeBooks hard-delete path to
+// merge.Service.MergeBooks via applyBookMergeReroute. The legacy path hard-
+// deleted losers with store.DeleteBook, which does NOT tombstone external-ID
+// (ext_id:*) mappings and does NOT enqueue ITL removals — orphaning the losers'
+// PID/ASIN lookups and stranding their iTunes tracks. This test drives the
+// actual reroute helper on a real PebbleStore and asserts the loser is
+// SOFT-deleted (not hard-deleted), its external ID is reassigned to the winner,
+// and the winner inherits the loser's iTunes stats first-win. It fails against
+// the old hard-delete code (loser gone, external ID left dangling).
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	ulid "github.com/oklog/ulid/v2"
+)
+
+func t10IntPtr(v int) *int { return &v }
+
+func TestApplyBookMergeReroute_SoftDeletesAndReassignsExternalIDs(t *testing.T) {
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "pebble"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	keepID := ulid.Make().String()
+	loserID := ulid.Make().String()
+
+	// Winner (M4B) with NO iTunes rating; loser (mp3) carries a rating so we can
+	// prove the first-win copy runs.
+	if _, err := store.CreateBook(&database.Book{
+		ID: keepID, Title: "Keep", Format: "m4b", FilePath: "/tmp/" + keepID + ".m4b",
+	}); err != nil {
+		t.Fatalf("CreateBook keep: %v", err)
+	}
+	if _, err := store.CreateBook(&database.Book{
+		ID: loserID, Title: "Loser", Format: "mp3", FilePath: "/tmp/" + loserID + ".mp3",
+		ITunesRating: t10IntPtr(80), ITunesPlayCount: t10IntPtr(5),
+	}); err != nil {
+		t.Fatalf("CreateBook loser: %v", err)
+	}
+
+	// Give the loser an iTunes external-ID mapping. Under the legacy hard-delete
+	// path this row would be left dangling, resolving to a deleted book.
+	const loserPID = "PID-LOSER-T10"
+	if err := store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: loserPID, BookID: loserID, Provenance: "itunes",
+	}); err != nil {
+		t.Fatalf("CreateExternalIDMapping: %v", err)
+	}
+
+	ms := merge.NewService(store)
+	if err := applyBookMergeReroute(context.Background(), store, ms, keepID, []string{loserID}); err != nil {
+		t.Fatalf("applyBookMergeReroute: %v", err)
+	}
+
+	// (1) Loser is SOFT-deleted, not hard-deleted: the row still exists and is
+	// flagged MarkedForDeletion. Under legacy hard-delete GetBookByID returns nil.
+	loser, err := store.GetBookByID(loserID)
+	if err != nil {
+		t.Fatalf("GetBookByID loser: %v", err)
+	}
+	if loser == nil {
+		t.Fatal("loser was HARD-deleted (nil) — reroute must soft-delete so it stays recoverable")
+	}
+	if loser.MarkedForDeletion == nil || !*loser.MarkedForDeletion {
+		t.Fatal("loser not marked for deletion — expected soft-delete")
+	}
+
+	// (2) External ID reassigned to the winner (not dangling on the loser).
+	resolved, err := store.GetBookByExternalID("itunes", loserPID)
+	if err != nil {
+		t.Fatalf("GetBookByExternalID: %v", err)
+	}
+	if resolved != keepID {
+		t.Fatalf("external ID %s resolves to %q, want winner %q (legacy path left it dangling on the deleted loser)", loserPID, resolved, keepID)
+	}
+
+	// (3) First-win iTunes copy: winner inherited the loser's rating.
+	keep, err := store.GetBookByID(keepID)
+	if err != nil {
+		t.Fatalf("GetBookByID keep: %v", err)
+	}
+	if keep == nil {
+		t.Fatal("keep book missing after merge")
+	}
+	if keep.ITunesRating == nil || *keep.ITunesRating != 80 {
+		t.Fatalf("keep iTunes rating = %v, want 80 (first-win copy from loser)", keep.ITunesRating)
+	}
+}


### PR DESCRIPTION
## T10 / F6 — legacy dedup book-merge hard-deletes losers without external-ID reassignment or ITL removal

### STEP 1 — VERIFICATION (recorded per brief)

**Question:** Does PebbleStore's `DeleteBook` tombstone external-ID (`ext_id:*`) mappings or enqueue iTunes ITL removals?

**Answer: NO — it does neither.** Traced `internal/database/pebble_store.go:2198 DeleteBook`. It deletes `book:*`, `book:path:*`, `book:versiongroup:*`, `book:work:*`, the three `book:hash|originalhash|organizedhash:*` rows, `metadata_state:*`, ISBN/ASIN index rows, and the `emb:v:book:*` embedding row. It **never** touches the `ext_id:*` keyspace (external-ID mappings live in `internal/database/pebble_store_externalids.go`, keys `ext_id:<source>:<id>` + `ext_id:book:<book>:<source>:<id>`) and **never** calls any write-back/EnqueueRemove path.

**Consequence of the legacy path** (`internal/dedup/book_dedup.go MergeBooks`, reached from `POST /audiobooks/merge` → `internal/server/handlers/duplicates/handler.go MergeBooks` → `internal/server/duplicates_ops.go` `RegisterBookMergeOp`): each merged-away loser is hard-deleted, so
- its `ext_id:<source>:<id>` primary mapping is left dangling, still resolving (via `GetBookByExternalID`) to a book row that no longer exists; a later iTunes/ASIN import resolving that PID lands on a deleted ID, and
- its iTunes tracks are never enqueued for ITL removal, so they live in the iTunes library forever.

The modern path (`internal/merge/service.go MergeBooks`) instead collects PIDs → `ReassignExternalIDs` (loser→winner) → `EnqueueRemove` (ITL) → `SoftDeleteBook` (recoverable). So reroute is required.

### STEP 2 — FIX: reroute (not documented-safe)

The `dedup.book-merge` op now routes through `merge.Service.MergeBooks` via a new extracted `applyBookMergeReroute` helper (`internal/server/duplicates_ops.go`). This reassigns external IDs to the winner, enqueues ITL removals, and soft-deletes losers — one merge path shared with the UI/version-group merge. Endpoint response shape is unchanged (the handler still returns an op-ID; only the call *inside* the op body changed).

**iTunes first-win copy preserved.** The 6 iTunes Book-level fields (persistent ID, play count, rating, date added, last played, bookmark) are NOT carried by `ReassignExternalIDs`; after soft-delete they would survive only on the loser row and vanish on a later purge/archive sweep. The wrapper copies them first-win onto the winner and persists BEFORE the merge (Service re-reads books fresh and writes the full keep object back, so the copy survives its version-group `UpdateBook`). The copy logic is extracted into a shared `dedup.TransferITunesMetadataFirstWin` helper so legacy and the reroute share one source of truth.

**Serialization preserved.** `itunes_heal` stays on legacy `dedup.MergeBooks` (via `merge.LockMergeRMW`), and the endpoint now uses `Service.MergeBooks` (`mergeSerializeMu.Lock`). Confirmed `LockMergeRMW()` locks the *same* `mergeSerializeMu` (`internal/merge/serialize.go`), so the two paths remain mutually exclusive on a shared row.

### STEP 3 — TEST

`internal/server/duplicates_ops_reroute_test.go` drives `applyBookMergeReroute` on a real `PebbleStore` and asserts: (1) loser is **soft-deleted** (`GetBookByID` non-nil, `MarkedForDeletion=true`) not hard-deleted; (2) `GetBookByExternalID` for the loser's PID now resolves to the **winner**; (3) winner inherited the loser's iTunes rating (first-win). Verified to **fail** against the legacy hard-delete behavior (loser goes nil, external ID left dangling).

### Behavior-change flags for the reviewer (non-blocking)

- **Hard-delete → version-group soft-delete.** Merged duplicates become soft-deleted version-group members (recoverable) instead of being deleted. Intentional per the T10 brief ("one merge path"), but a real product-behavior change for this endpoint.
- **Error semantics flip.** Legacy accumulated per-book errors and returned success (partial merge); `Service.MergeBooks` returns on the first bad ID, so one missing book now fails the whole op instead of merging the rest.
- **`itunes_heal` has the identical ext-ID/ITL gap** (hard-delete, no reassign, no ITL). Out of T10 scope — retained deliberately (it hard-collapses organize-bug rows) and flagged as a tracked follow-up in a code comment at the legacy call site.

### Tests
- `go build ./...` clean.
- `go test ./internal/dedup/... ./internal/merge/... -race -count=1` → all `ok`.
- `go test ./internal/server/ -race -run 'Merge|Dedup|Duplicat|Combine|Reroute|ExternalID' -count=1` → `ok 58s` (new test included, no races).
- Full `internal/server` package exceeds the 10-min default `go test` timeout under **and without** `-race` on this machine (documented pre-existing slowness; timeout lands inside unrelated E2E tests — my test and all tests up to it pass steadily). A long-timeout full `-race` run is in progress; CI runs the authoritative suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65