### PR TITLE
feat(dedup): triage purge-apply — dismiss purgeable exact candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.176.0 -->
+<!-- version: 3.177.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,31 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - dedup: triage purge-apply path (T03-BUILD)
+
+- **`maintenance.dedup-exact-triage` gains an apply path**: the op accepted
+  `{"apply": bool}` params (previously ignored — hardwired report-only). With
+  `apply=true` (default remains `false`, preserving the original report-only
+  contract), every candidate classified `stub` or `title_leak`
+  (`maintenanceplugin.IsPurgeable`) is DISMISSED via
+  `EmbeddingStore.UpdateCandidateStatus(id, "dismissed")` — never
+  `DeleteCandidate`. Dismiss keeps the historical record, maintains the
+  `dedup:s:` status index, is reversible, and (per PR #1973's terminal-status
+  guard) a dismissed candidate never resurrects as pending on a later rescan.
+  `genuine`/`fragment`/`unknown` candidates are never touched. Individual
+  dismiss failures are counted (`dismiss_errors`), not fatal — the pass
+  continues past a single bad row. The `TriageReport` gained
+  `DismissedCount` (0 in dry-run; the number actually flipped when
+  `apply=true`), logged in both the per-run completion `slog` line and the
+  op's summary log line.
+- Unblocks brief T03 (`docs/agent-tasks/error-correction-2026-07/TASKS.md`) —
+  the sandbox purge wave for the 7,878 `title_leak` candidates found by T02's
+  triage run now has an apply mechanism to act on.
+- `internal/plugins/maintenance/deps.go`: `ServerDeps.DedupTriageExactPending`
+  signature changed to `(ctx, apply bool)`; `internal/server/server_maintenance_deps.go`
+  implements the dismiss loop; the `fakeDeps` test double in
+  `title_backfill_test.go` updated to match.
 
 #### July 18, 2026 - fix(reconcile): AssignOrphanVGs worker pool + VG clobber guard (T07/R-6)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.4.1 -->
+<!-- version: 10.4.2 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -34,7 +34,11 @@ Companion docs:
    falkcorp/infra-docs). Real backlog ~15,269 pending.
 2. **PH-2 — run `maintenance.dedup-exact-triage` on prod + review populations; PH-2b
    per-population purge wave** (H1:916) — never blanket-purge; four residual
-   populations (see `docs/dedup/STATUS.md`).
+   populations (see `docs/dedup/STATUS.md`). **Apply path now exists** (T03-BUILD):
+   `maintenance.dedup-exact-triage {"apply":true}` dismisses purgeable classes
+   (stub/title_leak) via `UpdateCandidateStatus(id, "dismissed")` — dry-run
+   (`apply=false`, the default) is unchanged report-only. Unblocks brief T03's
+   sandbox purge wave.
 3. **REVIEW-band candidate producer for the review queue** (H1:35) — B2 fast-follow;
    no commit yet.
 4. **Flip `review_apply_enabled` ON in prod** — apply path merged (#1953) but default
@@ -198,6 +202,9 @@ external-ID reassignment + ITL removal, T10).
 - [ ] **T01** — land PR #1986 (organizer data-loss fixes; CI was running)
 - [ ] **T02** — sandbox: verify breakdown-backfill apply, run dedup-exact-triage, record populations (backfill apply op `01KXSJHBDDP17AMR8WYKSTQH30` was in flight at stop)
 - [ ] **T03** — sandbox: triage purge wave → purge-stale → full-scan → final backlog measurement vs 9,074 baseline
+      (T03-BUILD landed: `maintenance.dedup-exact-triage {"apply":true}` now dismisses
+      purgeable stub/title_leak candidates — see Dedup item 2 above. Sandbox run itself
+      still not executed.)
 - [ ] **T04** — prod deploy (nothing deployed 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
 - [ ] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (file:line anchors in the brief)
 - [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #2002)

--- a/internal/plugins/maintenance/dedup_triage.go
+++ b/internal/plugins/maintenance/dedup_triage.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedup_triage.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 3a4b5c6d-7e8f-9012-abcd-ef1234567890
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package maintenance
 
@@ -90,6 +90,11 @@ type TriageReport struct {
 	// lookups classify with a nil book, so a nonzero value means the
 	// population counts may be skewed toward stub/unknown.
 	BookLookupErrors int `json:"book_lookup_errors,omitempty"`
+	// DismissedCount is the number of purgeable candidates (stub/title_leak)
+	// actually dismissed via UpdateCandidateStatus. Only populated when the op
+	// ran with apply=true; stays 0 in dry-run mode, where PurgeableCount above
+	// already communicates "would dismiss this many".
+	DismissedCount int `json:"dismissed_count,omitempty"`
 }
 
 // purgeableClasses are the populations safe to delete without human review.
@@ -278,14 +283,25 @@ func signalList(c database.DedupCandidate) string {
 	return strings.Join(kinds, ",")
 }
 
+// dedupExactTriageParams are the JSON parameters accepted by
+// maintenance.dedup-exact-triage.
+type dedupExactTriageParams struct {
+	// Apply, if true, dismisses every purgeable candidate (stub/title_leak)
+	// via UpdateCandidateStatus(id, "dismissed"). Default false — the
+	// original report-only contract is preserved: no candidates are
+	// modified, and the report's PurgeableCount communicates what WOULD be
+	// dismissed.
+	Apply bool `json:"apply"`
+}
+
 // --- op definition ---
 
 func (p *Plugin) dedupExactTriageDef() sdk.OperationDef {
 	return sdk.OperationDef{
 		ID:              "maintenance.dedup-exact-triage",
 		Plugin:          "maintenance",
-		DisplayName:     "Dedup exact-pending triage (dry-run)",
-		Description:     "Classifies all pending exact-layer dedup candidates into 4 populations (genuine/stub/fragment/title_leak) and reports counts. Dry-run only — no candidates are deleted.",
+		DisplayName:     "Dedup exact-pending triage (dry-run / apply)",
+		Description:     "Classifies all pending exact-layer dedup candidates into 5 populations (genuine/stub/fragment/title_leak/unknown) and reports counts. Dry-run by default — no candidates are deleted. With apply=true, dismisses every purgeable candidate (stub/title_leak) via a status update; genuine/fragment/unknown candidates are never touched.",
 		ResumePolicy:    sdk.ResumeDrop,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.dedup-exact-triage",
@@ -293,21 +309,32 @@ func (p *Plugin) dedupExactTriageDef() sdk.OperationDef {
 		Isolate:         false,
 		Timeout:         30 * time.Minute,
 		Schedule:        nil,
-		Capabilities:    []sdk.Capability{sdk.CapLibraryRead},
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
 		Run:             p.runDedupExactTriage,
 	}
 }
 
-func (p *Plugin) runDedupExactTriage(ctx context.Context, _ json.RawMessage, reporter sdk.Reporter) error {
+func (p *Plugin) runDedupExactTriage(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
 	if !p.deps.HasDedupEngine() {
 		_ = reporter.Log(slog.LevelInfo, "Dedup engine not initialized, skipping exact triage")
 		return nil
 	}
 
-	_ = reporter.Log(slog.LevelInfo, "Starting exact-pending dedup triage (dry-run — no deletes)")
+	var params dedupExactTriageParams
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return fmt.Errorf("parse params: %w", err)
+		}
+	}
+
+	if params.Apply {
+		_ = reporter.Log(slog.LevelInfo, "Starting exact-pending dedup triage (apply=true — purgeable candidates will be dismissed)")
+	} else {
+		_ = reporter.Log(slog.LevelInfo, "Starting exact-pending dedup triage (dry-run — no deletes)")
+	}
 	_ = reporter.UpdateProgress(0, 0, "Scanning candidates…")
 
-	report, err := p.deps.DedupTriageExactPending(ctx)
+	report, err := p.deps.DedupTriageExactPending(ctx, params.Apply)
 	if err != nil {
 		return fmt.Errorf("triage scan: %w", err)
 	}
@@ -329,8 +356,8 @@ func (p *Plugin) runDedupExactTriage(ctx context.Context, _ json.RawMessage, rep
 	}
 
 	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
-		"Summary: total=%d  purgeable=%d  keep=%d  review=%d",
-		report.TotalScanned, report.PurgeableCount, report.KeepCount, report.ReviewCount,
+		"Summary: total=%d  purgeable=%d  keep=%d  review=%d  dismissed=%d",
+		report.TotalScanned, report.PurgeableCount, report.KeepCount, report.ReviewCount, report.DismissedCount,
 	))
 
 	// Emit the full report as a structured log entry so the UI can surface it.

--- a/internal/plugins/maintenance/dedup_triage_apply_test.go
+++ b/internal/plugins/maintenance/dedup_triage_apply_test.go
@@ -1,0 +1,178 @@
+// file: internal/plugins/maintenance/dedup_triage_apply_test.go
+// version: 1.0.0
+// guid: a05e1939-0f66-42d7-9393-97dffc9064bd
+// last-edited: 2026-07-18
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// triageDeps wraps fakeDeps and overrides HasDedupEngine (true, so
+// runDedupExactTriage doesn't short-circuit) and DedupTriageExactPending, so
+// tests can capture the apply argument the op actually passed through from
+// its JSON params and control the returned TriageReport.
+type triageDeps struct {
+	fakeDeps
+	report      *TriageReport
+	err         error
+	gotApply    bool
+	applyCalled bool
+}
+
+func (d *triageDeps) HasDedupEngine() bool { return true }
+
+func (d *triageDeps) DedupTriageExactPending(_ context.Context, apply bool) (*TriageReport, error) {
+	d.applyCalled = true
+	d.gotApply = apply
+	if d.err != nil {
+		return nil, d.err
+	}
+	if d.report != nil {
+		return d.report, nil
+	}
+	return &TriageReport{Populations: map[TriageClass]TriagePopulation{}}, nil
+}
+
+func newTriagePlugin(deps *triageDeps) *Plugin {
+	deps.fakeDeps = fakeDeps{}
+	return &Plugin{deps: deps}
+}
+
+// TestRunDedupExactTriage_NilParams_DefaultsApplyFalse proves the preserved
+// contract: no params (nil rawParams, the shape every existing scheduled/
+// manual enqueue of this op already uses) must default to apply=false —
+// report-only, same as before this op grew an apply path.
+func TestRunDedupExactTriage_NilParams_DefaultsApplyFalse(t *testing.T) {
+	deps := &triageDeps{}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	err := p.runDedupExactTriage(context.Background(), nil, reporter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deps.applyCalled {
+		t.Fatal("DedupTriageExactPending was never called")
+	}
+	if deps.gotApply {
+		t.Error("nil params must default apply=false")
+	}
+}
+
+// TestRunDedupExactTriage_EmptyObjectParams_DefaultsApplyFalse covers the
+// `{}` params shape (as opposed to nil) — same default-false contract.
+func TestRunDedupExactTriage_EmptyObjectParams_DefaultsApplyFalse(t *testing.T) {
+	deps := &triageDeps{}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	err := p.runDedupExactTriage(context.Background(), json.RawMessage(`{}`), reporter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.gotApply {
+		t.Error("{} params must default apply=false")
+	}
+}
+
+// TestRunDedupExactTriage_ApplyTrueParam_PassedThrough proves {"apply":true}
+// reaches DedupTriageExactPending unchanged.
+func TestRunDedupExactTriage_ApplyTrueParam_PassedThrough(t *testing.T) {
+	deps := &triageDeps{}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	err := p.runDedupExactTriage(context.Background(), json.RawMessage(`{"apply":true}`), reporter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deps.gotApply {
+		t.Error(`{"apply":true} must pass apply=true through to DedupTriageExactPending`)
+	}
+}
+
+// TestRunDedupExactTriage_ApplyFalseParam_Explicit proves an explicit
+// {"apply":false} behaves identically to the default (belt-and-suspenders on
+// the report-only contract).
+func TestRunDedupExactTriage_ApplyFalseParam_Explicit(t *testing.T) {
+	deps := &triageDeps{}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	err := p.runDedupExactTriage(context.Background(), json.RawMessage(`{"apply":false}`), reporter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps.gotApply {
+		t.Error(`{"apply":false} must pass apply=false through`)
+	}
+}
+
+// TestRunDedupExactTriage_InvalidParamsJSON_ReturnsError proves malformed
+// params fail loudly instead of silently defaulting.
+func TestRunDedupExactTriage_InvalidParamsJSON_ReturnsError(t *testing.T) {
+	deps := &triageDeps{}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	err := p.runDedupExactTriage(context.Background(), json.RawMessage(`not json`), reporter)
+	if err == nil {
+		t.Fatal("expected an error for malformed params JSON")
+	}
+	if deps.applyCalled {
+		t.Error("DedupTriageExactPending must not be called when param parsing fails")
+	}
+}
+
+// TestRunDedupExactTriage_LogsDismissedCountInSummary proves the completion
+// summary line surfaces DismissedCount so an operator watching op logs (e.g.
+// the sandbox purge-wave run) can see how many candidates were actually
+// dismissed, not just how many were purgeable.
+func TestRunDedupExactTriage_LogsDismissedCountInSummary(t *testing.T) {
+	deps := &triageDeps{
+		report: &TriageReport{
+			TotalScanned:   9,
+			PurgeableCount: 7,
+			KeepCount:      1,
+			ReviewCount:    1,
+			DismissedCount: 7,
+			Populations:    map[TriageClass]TriagePopulation{},
+		},
+	}
+	p := newTriagePlugin(deps)
+	reporter := &fakeReporter{}
+
+	if err := p.runDedupExactTriage(context.Background(), json.RawMessage(`{"apply":true}`), reporter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var found bool
+	for _, line := range reporter.logs {
+		if strings.Contains(line, "dismissed=7") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a summary log line containing 'dismissed=7', got: %v", reporter.logs)
+	}
+}
+
+// TestDedupExactTriageDef_DescriptionMentionsApply locks in that the op's
+// self-description tells operators about the apply=true purge path, not just
+// the original dry-run-only text.
+func TestDedupExactTriageDef_DescriptionMentionsApply(t *testing.T) {
+	p := &Plugin{}
+	def := p.dedupExactTriageDef()
+	if !strings.Contains(def.Description, "apply=true") {
+		t.Errorf("Description must mention apply=true, got: %q", def.Description)
+	}
+	if !strings.Contains(def.Description, "dismiss") {
+		t.Errorf("Description must mention dismissing purgeable candidates, got: %q", def.Description)
+	}
+}

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -107,10 +107,14 @@ type ServerDeps interface {
 	) (compacted int, summarized int, pruned int, err error)
 
 	// DedupTriageExactPending scans all pending book dedup candidates,
-	// classifies each into one of four populations (genuine / stub / fragment /
-	// title_leak), and returns a TriageReport. No candidates are deleted.
-	// Returns an error if the embedding store is not initialised.
-	DedupTriageExactPending(ctx context.Context) (*TriageReport, error)
+	// classifies each into one of five populations (genuine / stub / fragment /
+	// title_leak / unknown), and returns a TriageReport. When apply is false
+	// (dry-run, the default), no candidates are modified. When apply is true,
+	// every candidate whose class is IsPurgeable (stub, title_leak) is
+	// dismissed via UpdateCandidateStatus(id, "dismissed") — genuine, fragment,
+	// and unknown candidates are never touched. Returns an error if the
+	// embedding store is not initialised.
+	DedupTriageExactPending(ctx context.Context, apply bool) (*TriageReport, error)
 
 	// ----- feature flags -----
 

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.4.0
+// version: 1.4.1
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
 // last-edited: 2026-07-18
 
@@ -73,7 +73,7 @@ func (d fakeDeps) ActivityFlushOp(_ string)                        {}
 func (d fakeDeps) EnqueueWriteBack(_ string)                       {}
 func (d fakeDeps) PollBatch(_ context.Context) (int, error)        { return 0, nil }
 func (d fakeDeps) DedupLLMReview(_ context.Context) error          { return nil }
-func (d fakeDeps) DedupTriageExactPending(_ context.Context) (*TriageReport, error) {
+func (d fakeDeps) DedupTriageExactPending(_ context.Context, _ bool) (*TriageReport, error) {
 	return &TriageReport{}, nil
 }
 func (d fakeDeps) InvalidateDedupCache() {}

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -256,8 +256,17 @@ func (s *Server) EnqueueOp(ctx context.Context, defID string, params any) (strin
 // DedupTriageExactPending implements maintenance.ServerDeps. It pages all
 // pending book dedup candidates, classifies each via ClassifyCandidate, and
 // returns a TriageReport with per-population counts and up to 5 examples each.
-// No candidates are deleted regardless of their class.
-func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugin.TriageReport, error) {
+// When apply is false (dry-run), no candidates are modified — PurgeableCount
+// communicates what WOULD be dismissed. When apply is true, every candidate
+// whose class is maintenanceplugin.IsPurgeable (stub/title_leak) is dismissed
+// via s.embeddingStore.UpdateCandidateStatus(id, "dismissed") — never
+// DeleteCandidate: dismiss keeps the historical record, maintains the
+// "dedup:s:" status secondary index, is reversible, and (per PR #1973's
+// terminal-status guard) prevents a dismissed candidate from resurrecting on
+// a later rescan. genuine/fragment/unknown candidates are never touched.
+// Individual dismiss failures are counted, not fatal — the first error is
+// logged and the pass continues so one bad row can't abort the whole apply.
+func (s *Server) DedupTriageExactPending(ctx context.Context, apply bool) (*maintenanceplugin.TriageReport, error) {
 	if s.embeddingStore == nil {
 		return nil, fmt.Errorf("embedding store not initialized")
 	}
@@ -305,6 +314,13 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		maintenanceplugin.TriageClassUnknown:   {},
 	}
 
+	// dismissedCount / dismissErrs / firstDismissErr only accumulate when
+	// apply=true; dismiss failures are logged (first one) but do not abort
+	// the pass — one bad row must not stop the rest of the purge.
+	var dismissedCount int
+	var dismissErrs int
+	var firstDismissErr error
+
 	for i := range candidates {
 		select {
 		case <-ctx.Done():
@@ -322,6 +338,20 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		cls, reason := maintenanceplugin.ClassifyCandidate(c, a, b)
 		ps := pops[cls]
 		ps.count++
+
+		if apply && maintenanceplugin.IsPurgeable(cls) {
+			if derr := s.embeddingStore.UpdateCandidateStatus(c.ID, "dismissed"); derr != nil {
+				dismissErrs++
+				if firstDismissErr == nil {
+					firstDismissErr = fmt.Errorf("dismiss candidate %d: %w", c.ID, derr)
+					slog.Error("dedup triage: dismiss failed, continuing pass",
+						"candidate_id", c.ID, "class", string(cls), "error", derr)
+				}
+			} else {
+				dismissedCount++
+			}
+		}
+
 		if len(ps.examples) < 5 {
 			titleA, titleB := "", ""
 			if a != nil {
@@ -347,6 +377,7 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		TotalScanned:     len(candidates),
 		Populations:      make(map[maintenanceplugin.TriageClass]maintenanceplugin.TriagePopulation, len(pops)),
 		BookLookupErrors: lookupErrs,
+		DismissedCount:   dismissedCount,
 	}
 	for cls, ps := range pops {
 		report.Populations[cls] = maintenanceplugin.TriagePopulation{
@@ -367,12 +398,19 @@ func (s *Server) DedupTriageExactPending(ctx context.Context) (*maintenanceplugi
 		slog.Warn("dedup triage: book lookups failed — population counts may be skewed",
 			"lookup_errors", lookupErrs, "first_error", firstLookupErr)
 	}
+	if dismissErrs > 0 {
+		slog.Warn("dedup triage: some dismiss writes failed — DismissedCount is a lower bound",
+			"dismiss_errors", dismissErrs, "first_error", firstDismissErr)
+	}
 	slog.Info("dedup triage: complete",
 		"scanned", report.TotalScanned,
 		"purgeable", report.PurgeableCount,
 		"keep", report.KeepCount,
 		"review", report.ReviewCount,
-		"lookup_errors", lookupErrs)
+		"lookup_errors", lookupErrs,
+		"apply", apply,
+		"dismissed", dismissedCount,
+		"dismiss_errors", dismissErrs)
 	return report, nil
 }
 

--- a/internal/server/server_maintenance_deps_triage_test.go
+++ b/internal/server/server_maintenance_deps_triage_test.go
@@ -1,0 +1,206 @@
+// file: internal/server/server_maintenance_deps_triage_test.go
+// version: 1.0.0
+// guid: 858930a2-ded4-48a8-9404-abc75c5bd103
+// last-edited: 2026-07-18
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/dedup/unified"
+	maintenanceplugin "github.com/falkcorp/audiobook-organizer/internal/plugins/maintenance"
+)
+
+// newTriageTestEmbeddingStore creates a temp-dir-backed EmbeddingStore for
+// server-level DedupTriageExactPending tests. Unlike internal/database's
+// unexported newTestEmbeddingStore helper, this uses the exported
+// database.NewEmbeddingStore constructor since this test lives outside the
+// database package.
+func newTriageTestEmbeddingStore(t *testing.T) *database.EmbeddingStore {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := pebble.Open(dir, &pebble.Options{})
+	require.NoError(t, err)
+	store := database.NewEmbeddingStore(db)
+	t.Cleanup(func() { _ = db.Close() })
+	return store
+}
+
+// t03TriageBook builds a *database.Book with the fields ClassifyCandidate
+// inspects. fileSize < 0 or duration < 0 leaves the corresponding pointer nil.
+func t03TriageBook(id, title string, fileSize int64, duration int, itunesPID string) database.Book {
+	b := database.Book{ID: id, Title: title}
+	if fileSize >= 0 {
+		b.FileSize = &fileSize
+	}
+	if duration >= 0 {
+		b.Duration = &duration
+	}
+	if itunesPID != "" {
+		b.ITunesPersistentID = &itunesPID
+	}
+	return b
+}
+
+// t03HardSignalBreakdown returns a ScoreBreakdown carrying a hard signal
+// (ISBN/ASIN), which ClassifyCandidate treats as TriageClassGenuine.
+func t03HardSignalBreakdown() *unified.UnifiedDedupScore {
+	return &unified.UnifiedDedupScore{Signals: []unified.Signal{{Kind: unified.SigISBNASIN, Confidence: 0.99}}}
+}
+
+// t03SoftSignalBreakdown returns a ScoreBreakdown with only a soft signal —
+// insufficient on its own to classify genuine.
+func t03SoftSignalBreakdown() *unified.UnifiedDedupScore {
+	return &unified.UnifiedDedupScore{Signals: []unified.Signal{{Kind: unified.SigMetaFuzzy, Confidence: 0.5}}}
+}
+
+// t03TriageFixture wires an embeddingStore + MockStore with one candidate of
+// each of the five triage classes, and returns the *Server plus the
+// candidate IDs keyed by class for post-run status assertions.
+func t03TriageFixture(t *testing.T) (srv *Server, ids map[maintenanceplugin.TriageClass]int64) {
+	t.Helper()
+	embStore := newTriageTestEmbeddingStore(t)
+
+	books := map[string]database.Book{
+		// genuine: hard ISBN signal, both real audio.
+		"genuine-a": t03TriageBook("genuine-a", "Genuine Book", 10*1024*1024, 3600, ""),
+		"genuine-b": t03TriageBook("genuine-b", "Genuine Book", 10*1024*1024, 3600, ""),
+		// stub: book B is a byte-empty stub.
+		"stub-a": t03TriageBook("stub-a", "Stub Pair A", 10*1024*1024, 3600, ""),
+		"stub-b": t03TriageBook("stub-b", "Stub Pair B", 100, 1, ""),
+		// fragment: duration ratio well under 5%.
+		"frag-a": t03TriageBook("frag-a", "Fragment Chapter", 5*1024*1024, 120, ""),
+		"frag-b": t03TriageBook("frag-b", "Fragment Full Book", 100*1024*1024, 5400, ""),
+		// title_leak: both iTunes imports, exact layer, only a soft signal.
+		"leak-a": t03TriageBook("leak-a", "Leaked Title", 5*1024*1024, 3600, "itunes-a"),
+		"leak-b": t03TriageBook("leak-b", "Leaked Title", 5*1024*1024, 3500, "itunes-b"),
+		// unknown: exact layer, soft signal only, non-iTunes, different titles.
+		"unk-a": t03TriageBook("unk-a", "Unknown Book A", 5*1024*1024, 3600, ""),
+		"unk-b": t03TriageBook("unk-b", "Unknown Book B", 5*1024*1024, 3600, ""),
+	}
+
+	store := &database.MockStore{
+		GetBookByIDFunc: func(id string) (*database.Book, error) {
+			b, ok := books[id]
+			if !ok {
+				return nil, nil
+			}
+			return &b, nil
+		},
+	}
+
+	candidates := map[maintenanceplugin.TriageClass]database.DedupCandidate{
+		maintenanceplugin.TriageClassGenuine: {
+			EntityType: "book", EntityAID: "genuine-a", EntityBID: "genuine-b",
+			Layer: "exact", ScoreBreakdown: t03HardSignalBreakdown(),
+		},
+		maintenanceplugin.TriageClassStub: {
+			EntityType: "book", EntityAID: "stub-a", EntityBID: "stub-b",
+			Layer: "exact", ScoreBreakdown: t03SoftSignalBreakdown(),
+		},
+		maintenanceplugin.TriageClassFragment: {
+			EntityType: "book", EntityAID: "frag-a", EntityBID: "frag-b",
+			Layer: "exact",
+		},
+		maintenanceplugin.TriageClassTitleLeak: {
+			EntityType: "book", EntityAID: "leak-a", EntityBID: "leak-b",
+			Layer: "exact", ScoreBreakdown: t03SoftSignalBreakdown(),
+		},
+		maintenanceplugin.TriageClassUnknown: {
+			EntityType: "book", EntityAID: "unk-a", EntityBID: "unk-b",
+			Layer: "exact", ScoreBreakdown: t03SoftSignalBreakdown(),
+		},
+	}
+
+	ids = make(map[maintenanceplugin.TriageClass]int64, len(candidates))
+	for cls, c := range candidates {
+		id, _, err := embStore.UpsertCandidateNew(c)
+		require.NoError(t, err)
+		ids[cls] = id
+	}
+
+	srv = &Server{store: store, embeddingStore: embStore}
+	return srv, ids
+}
+
+// TestDedupTriageExactPending_DryRun_DismissesNothing proves the preserved
+// report-only contract: apply=false must classify candidates but leave every
+// status at "pending" and DismissedCount at 0.
+func TestDedupTriageExactPending_DryRun_DismissesNothing(t *testing.T) {
+	srv, ids := t03TriageFixture(t)
+
+	report, err := srv.DedupTriageExactPending(context.Background(), false)
+	require.NoError(t, err)
+	require.Equal(t, 5, report.TotalScanned)
+	require.Equal(t, 0, report.DismissedCount)
+
+	// Purgeable classes (stub, title_leak) show up as purgeable, not dismissed.
+	require.Equal(t, 2, report.PurgeableCount)
+
+	for cls, id := range ids {
+		got, err := srv.embeddingStore.GetCandidateByID(id)
+		require.NoError(t, err)
+		require.Equalf(t, "pending", got.Status, "class %s must remain pending on dry-run", cls)
+	}
+}
+
+// TestDedupTriageExactPending_Apply_DismissesOnlyPurgeable proves apply=true
+// dismisses stub + title_leak candidates only, leaves genuine/fragment/unknown
+// pending, and DismissedCount matches the number of statuses actually flipped.
+func TestDedupTriageExactPending_Apply_DismissesOnlyPurgeable(t *testing.T) {
+	srv, ids := t03TriageFixture(t)
+
+	report, err := srv.DedupTriageExactPending(context.Background(), true)
+	require.NoError(t, err)
+	require.Equal(t, 5, report.TotalScanned)
+	require.Equal(t, 2, report.DismissedCount, "stub + title_leak = 2 purgeable candidates")
+	require.Equal(t, 2, report.PurgeableCount)
+
+	wantStatus := map[maintenanceplugin.TriageClass]string{
+		maintenanceplugin.TriageClassGenuine:   "pending",
+		maintenanceplugin.TriageClassStub:      "dismissed",
+		maintenanceplugin.TriageClassFragment:  "pending",
+		maintenanceplugin.TriageClassTitleLeak: "dismissed",
+		maintenanceplugin.TriageClassUnknown:   "pending",
+	}
+	for cls, id := range ids {
+		got, err := srv.embeddingStore.GetCandidateByID(id)
+		require.NoError(t, err)
+		require.Equalf(t, wantStatus[cls], got.Status, "class %s status after apply=true", cls)
+	}
+}
+
+// TestDedupTriageExactPending_Apply_SecondRunDoesNotRecountDismissed proves a
+// dismissed candidate does not resurrect as pending on a later run: the
+// second pass (regardless of apply) must scan strictly fewer candidates and
+// must not double-count the already-dismissed pair.
+func TestDedupTriageExactPending_Apply_SecondRunDoesNotRecountDismissed(t *testing.T) {
+	srv, ids := t03TriageFixture(t)
+
+	first, err := srv.DedupTriageExactPending(context.Background(), true)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.DismissedCount)
+
+	second, err := srv.DedupTriageExactPending(context.Background(), true)
+	require.NoError(t, err)
+	require.Equal(t, 3, second.TotalScanned, "the 2 dismissed candidates must not reappear as pending")
+	require.Equal(t, 0, second.DismissedCount, "nothing new to dismiss — already-dismissed rows are excluded from the pending scan")
+
+	// Statuses from the first run remain untouched (dismissed stays dismissed,
+	// pending classes stay pending — no reclassification flip on rescan).
+	for cls, id := range ids {
+		got, err := srv.embeddingStore.GetCandidateByID(id)
+		require.NoError(t, err)
+		if cls == maintenanceplugin.TriageClassStub || cls == maintenanceplugin.TriageClassTitleLeak {
+			require.Equal(t, "dismissed", got.Status)
+		} else {
+			require.Equal(t, "pending", got.Status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `maintenance.dedup-exact-triage` was hardwired report-only (classifies exact-layer dedup candidates into genuine/stub/fragment/title_leak/unknown, but never acts). This adds an apply path so the sandbox's ~7,878 `title_leak` candidates found in T02's triage run can actually be purged, not just measured.
- Op now accepts `{"apply": bool}` (default `false` — the original report-only contract is preserved unchanged).
- With `apply=true`, every candidate classified `stub` or `title_leak` (`maintenanceplugin.IsPurgeable`) is **dismissed** via `EmbeddingStore.UpdateCandidateStatus(id, "dismissed")` — never `DeleteCandidate`. Dismiss keeps the historical record, maintains the `dedup:s:` status index, is reversible, and (per PR #1973's terminal-status guard) a dismissed candidate never resurrects as pending on a later rescan. `genuine`/`fragment`/`unknown` candidates are never touched.
- Individual dismiss failures are counted (`dismiss_errors`), not fatal — the pass continues past a single bad row; the first error is logged.
- `TriageReport` gains `DismissedCount` (0 in dry-run; the number actually flipped when `apply=true`), logged in both the per-run completion `slog` line and the op's summary log line.
- `ServerDeps.DedupTriageExactPending` signature changed to `(ctx, apply bool)`; updated the `fakeDeps` test double in `title_backfill_test.go`.

Unblocks brief T03 (`docs/agent-tasks/error-correction-2026-07/TASKS.md`) — the sandbox purge wave itself has not been run yet, this PR only builds the mechanism.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/plugins/maintenance/... ./internal/server/... ./internal/database/... -short` (all pass; `internal/database` and `internal/server` needed `-timeout 20m` due to unrelated system contention from other concurrently-running agents on this box — confirmed unrelated by isolating the stalled test, `TestCoverage_AuthorTombstoneStubs` / `TestCoverageListAudiobooksWithFilters`, neither touched by this PR)
- [x] New tests in `internal/plugins/maintenance/dedup_triage_apply_test.go`: op param parsing (nil/`{}`/`{"apply":true}`/`{"apply":false}` all resolve correctly), malformed-JSON params error out before calling deps, summary log line surfaces `dismissed=N`, op `Description` mentions `apply=true`/dismiss.
- [x] New tests in `internal/server/server_maintenance_deps_triage_test.go` against a real `*database.EmbeddingStore` fixture (one candidate per class): `apply=false` dismisses nothing (all 5 stay `pending`); `apply=true` dismisses only `stub`+`title_leak` (`DismissedCount=2`), leaves `genuine`/`fragment`/`unknown` `pending`; a second `apply=true` run does not recount the already-dismissed pair (`TotalScanned` drops from 5→3, `DismissedCount=0` on the second pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65