### PR TITLE
fix(logging): H/M observability batch (T05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.177.0 -->
+<!-- version: 3.178.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - fix(logging): H/M observability batch (T05)
+
+- Added Warn/Error logs with context + summary counters to the swallowed-error
+  and no-progress sites from the 2026-07-17 review: H1 (dedup unified-scoring
+  book-lookup errors), H2 (author series-map), H3 (itunes_heal fpcalc/AcoustID/
+  Whisper failures now distinct from "no match"), H4 (itunes write-back
+  GetBookByID errors vs nil-book skips), H8 (author-merge GetBookAuthors), H9
+  (llm_review op progress on up-to-10K-pair builds), M1 (transcribe-stats put),
+  M2/M3 (swallowed EnsureSingletonBookTag / GetBookByID), M7 (MetadataUpgradeRun
+  now reports progress every 25 books — a 120-min network-bound op that was
+  previously silent between start and result). Behavior unchanged throughout;
+  this is observability only.
 
 #### July 18, 2026 - dedup: triage purge-apply path (T03-BUILD)
 

--- a/TODO.md
+++ b/TODO.md
@@ -206,7 +206,7 @@ external-ID reassignment + ITL removal, T10).
       purgeable stub/title_leak candidates — see Dedup item 2 above. Sandbox run itself
       still not executed.)
 - [ ] **T04** — prod deploy (nothing deployed 2026-07-17) + prod dry-runs + ⚠️ HUMAN-GATED apply
-- [ ] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (file:line anchors in the brief)
+- [x] **T05** — logging H/M batch: H1 H2 H3 H4 H8 H9 M1 M2 M3 M7 (#PR)
 - [x] **T06** — R-1: `op.terminal` SSE backend publisher added (see Fixed list, #2002)
 - [x] **T07** — R-6: AssignOrphanVGs worker pool + VG clobber guard (#2003)
 - [x] **T08** — R-3 (abandoned-reporter logBuf growth) · R-7 (dead scan checkpoint code) · P-2 (RunItems backwards progress) (see Fixed list, #2002)

--- a/internal/dedup/author.go
+++ b/internal/dedup/author.go
@@ -1,11 +1,13 @@
 // file: internal/dedup/author.go
-// version: 1.11.0
+// version: 1.11.1
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f90
+// last-edited: 2026-07-18
 
 package dedup
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"regexp"
 	"strings"
@@ -744,9 +746,19 @@ func BuildAuthorSeriesMap(store interface {
 	GetSeriesByID(id int) (*database.Series, error)
 }, authors []database.Author) map[int][]string {
 	result := make(map[int][]string, len(authors))
+	// H2 (2026-07 error-correction sweep): both store errors below used to be
+	// bare `continue`s. A failure here doesn't fail the map build — it just
+	// silently degrades author-dedup's series cross-referencing for the
+	// affected author (fewer/no series names → sharesSeries() never fires
+	// for them). Count both kinds and emit one summary Warn so a systemic
+	// store problem shows up instead of manifesting only as "series
+	// cross-referencing isn't catching duplicates".
+	booksLoadErrs := 0
+	seriesLoadErrs := 0
 	for _, a := range authors {
 		books, err := store.GetBooksByAuthorIDCore(a.ID)
 		if err != nil {
+			booksLoadErrs++
 			continue
 		}
 		seen := make(map[int]bool)
@@ -756,7 +768,11 @@ func BuildAuthorSeriesMap(store interface {
 			}
 			seen[*b.SeriesID] = true
 			series, err := store.GetSeriesByID(*b.SeriesID)
-			if err != nil || series == nil {
+			if err != nil {
+				seriesLoadErrs++
+				continue
+			}
+			if series == nil {
 				continue
 			}
 			normalized := strings.ToLower(strings.TrimSpace(series.Name))
@@ -764,6 +780,13 @@ func BuildAuthorSeriesMap(store interface {
 				result[a.ID] = append(result[a.ID], normalized)
 			}
 		}
+	}
+	if booksLoadErrs > 0 || seriesLoadErrs > 0 {
+		slog.Warn("dedup author-series map: store errors degraded series cross-referencing",
+			"authors", len(authors),
+			"books_load_errors", booksLoadErrs,
+			"series_load_errors", seriesLoadErrs,
+		)
 	}
 	return result
 }

--- a/internal/dedup/collectors_metadata.go
+++ b/internal/dedup/collectors_metadata.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/collectors_metadata.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: e1f2a3b4-c5d6-4e7f-8a0b-1c2d3e4f5a6b
-// last-edited: 2026-07-05
+// last-edited: 2026-07-18
 
 // Package dedup — metadata-based collector family (fable5 T014).
 //
@@ -173,6 +173,11 @@ func CollectDuration(
 	bookSeriesNum := seriesNumberOf(book)
 
 	var signals []unified.Signal
+	// M2 (2026-07 error-correction sweep): EnsureSingletonBookTag failures
+	// below used to be swallowed with `_ =`. Side-effect tags only — never
+	// gate signal emission — so behavior stays log-and-continue; just count
+	// and warn once per call instead of failing silently.
+	tagErrs := 0
 
 	for i := range others {
 		other := &others[i]
@@ -237,8 +242,12 @@ func CollectDuration(
 			// Preserved verbatim from checkDurationMatch side-effect
 			// (engine.go:655-658).
 			if tagStore != nil {
-				_ = database.EnsureSingletonBookTag(tagStore, book.ID, "dedup:duration-match", "dedup:duration-match", "system")
-				_ = database.EnsureSingletonBookTag(tagStore, other.ID, "dedup:duration-match", "dedup:duration-match", "system")
+				if err := database.EnsureSingletonBookTag(tagStore, book.ID, "dedup:duration-match", "dedup:duration-match", "system"); err != nil {
+					tagErrs++
+				}
+				if err := database.EnsureSingletonBookTag(tagStore, other.ID, "dedup:duration-match", "dedup:duration-match", "system"); err != nil {
+					tagErrs++
+				}
 			}
 			continue
 		}
@@ -249,10 +258,18 @@ func CollectDuration(
 		// (engine.go:672-675).
 		if pct >= 0.10 && titleDist <= cfg.LevenshteinMax {
 			if tagStore != nil {
-				_ = database.EnsureSingletonBookTag(tagStore, book.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system")
-				_ = database.EnsureSingletonBookTag(tagStore, other.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system")
+				if err := database.EnsureSingletonBookTag(tagStore, book.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system"); err != nil {
+					tagErrs++
+				}
+				if err := database.EnsureSingletonBookTag(tagStore, other.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system"); err != nil {
+					tagErrs++
+				}
 			}
 		}
+	}
+
+	if tagErrs > 0 {
+		slog.Warn("dedup/collectors_metadata: EnsureSingletonBookTag errors", "book", book.ID, "errors", tagErrs)
 	}
 
 	return signals, nil
@@ -391,6 +408,9 @@ func CollectMetaFuzzy(
 	bookTitleForms := allNormalizedTitleFormsForStore(store, book)
 
 	var signals []unified.Signal
+	// M2: GetBookByID errors here used to be a bare `continue` with no
+	// counter, indistinguishable from "candidate no longer exists".
+	lookupErrs := 0
 
 	for _, candID := range candidateIDs {
 		if candID == book.ID {
@@ -398,7 +418,11 @@ func CollectMetaFuzzy(
 		}
 
 		other, err := store.GetBookByID(candID)
-		if err != nil || other == nil {
+		if err != nil {
+			lookupErrs++
+			continue
+		}
+		if other == nil {
 			continue
 		}
 		if !hasUsableTitle(other.Title) {
@@ -433,6 +457,11 @@ func CollectMetaFuzzy(
 				sim, conf, book.ID, other.ID,
 			),
 		})
+	}
+
+	if lookupErrs > 0 {
+		slog.Warn("dedup/collectors_metadata: CollectMetaFuzzy candidate lookup errors",
+			"book", book.ID, "errors", lookupErrs, "total_candidates", len(candidateIDs))
 	}
 
 	return signals, nil

--- a/internal/dedup/engine.go
+++ b/internal/dedup/engine.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/engine.go
-// version: 1.62.0
+// version: 1.63.0
 // guid: 8f3a1c6e-d472-4b9a-a5e1-7c2d9f0b3e84
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package dedup
 
@@ -574,6 +574,14 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 	suppressedDeleted := 0
 	suppressedDeleteFailures := 0
 
+	// H1 (2026-07 error-correction sweep): GetBookByID errors for a candidate
+	// ref used to be a bare `continue` — indistinguishable from "candidate no
+	// longer exists" and invisible at any log level. Track how many candidate
+	// lookups fail for this book's scan and emit ONE summary Warn below so a
+	// store-level problem (e.g. transient Pebble read errors) shows up instead
+	// of silently shrinking the candidate set.
+	candidateLookupErrs := 0
+
 	for _, ref := range embeddingCandIDs {
 		// Cancellation check per-candidate, not just per-book: a single book
 		// with an unusually large pending-candidate set can otherwise run
@@ -587,6 +595,9 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 
 		candID := ref.otherID
 		otherBook, err := de.bookStore.GetBookByID(candID)
+		if err != nil {
+			candidateLookupErrs++
+		}
 		if err != nil || otherBook == nil {
 			continue
 		}
@@ -673,6 +684,18 @@ func (de *Engine) runUnifiedScoringForBook(ctx context.Context, book *database.B
 		logging.Warn(ctx, "dedup unified: suppressed candidate deletes failed",
 			"book", book.ID,
 			"failures", suppressedDeleteFailures,
+		)
+	}
+
+	// H1: surface candidate-book lookup errors that used to be a silent
+	// `continue` — a nonzero count here means some pairs were skipped for
+	// this book because the store couldn't read the OTHER side, not because
+	// the candidate is gone.
+	if candidateLookupErrs > 0 {
+		logging.Warn(ctx, "dedup unified: candidate book lookup errors",
+			"book", book.ID,
+			"errors", candidateLookupErrs,
+			"total_candidates", len(embeddingCandIDs),
 		)
 	}
 
@@ -840,12 +863,18 @@ func (de *Engine) checkExactFileHash(book *database.Book, authorName string) (bo
 	if err != nil {
 		return false, err
 	}
+	// H1: GetBookByFileHash errors here used to be a bare `continue` — a
+	// per-file hash lookup failure looked identical to "no match", silently
+	// dropping this file out of the exact-file-hash check. Track it and emit
+	// one summary Warn for this book so a store-level problem is visible.
+	fileHashLookupErrs := 0
 	for _, f := range files {
 		if f.FileHash == "" {
 			continue
 		}
 		other, err := de.bookStore.GetBookByFileHash(f.FileHash)
 		if err != nil {
+			fileHashLookupErrs++
 			continue
 		}
 		if other != nil && other.ID != book.ID {
@@ -857,6 +886,10 @@ func (de *Engine) checkExactFileHash(book *database.Book, authorName string) (bo
 				return true, nil
 			}
 		}
+	}
+	if fileHashLookupErrs > 0 {
+		slog.Warn("dedup exact-file-hash: file hash lookup errors",
+			"book", book.ID, "errors", fileHashLookupErrs, "total_files", len(files))
 	}
 	return false, nil
 }
@@ -1215,6 +1248,12 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 	}
 	others := booksFromCore(othersCore)
 
+	// M3: EnsureSingletonBookTag failures below used to be swallowed with
+	// `_ =`. These are side-effect tags only (never gate the merge/candidate
+	// decision), so behavior stays log-and-continue — just count and warn
+	// once per book instead of failing silently.
+	tagErrs := 0
+
 	bookDur := float64(*book.Duration)
 	bookNorm := normalizeTitle(book.Title)
 	bookForms := de.allNormalizedTitleForms(book)
@@ -1283,12 +1322,16 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 			}
 			// Tag both sides so users can filter "books the
 			// dedup engine matched on duration signal".
-			_ = database.EnsureSingletonBookTag(
+			if err := database.EnsureSingletonBookTag(
 				de.bookStore, book.ID, "dedup:duration-match", "dedup:duration-match", "system",
-			)
-			_ = database.EnsureSingletonBookTag(
+			); err != nil {
+				tagErrs++
+			}
+			if err := database.EnsureSingletonBookTag(
 				de.bookStore, other.ID, "dedup:duration-match", "dedup:duration-match", "system",
-			)
+			); err != nil {
+				tagErrs++
+			}
 			continue
 		}
 
@@ -1300,13 +1343,21 @@ func (de *Engine) checkDurationMatch(book *database.Book) error {
 		// 10% because normal transcoding noise ends around 2-5%
 		// and 10% is safely above that.
 		if pct >= 0.10 && titleDist <= durationLevenshteinMax {
-			_ = database.EnsureSingletonBookTag(
+			if err := database.EnsureSingletonBookTag(
 				de.bookStore, book.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system",
-			)
-			_ = database.EnsureSingletonBookTag(
+			); err != nil {
+				tagErrs++
+			}
+			if err := database.EnsureSingletonBookTag(
 				de.bookStore, other.ID, "dedup:duration-abridged", "dedup:duration-abridged", "system",
-			)
+			); err != nil {
+				tagErrs++
+			}
 		}
+	}
+	if tagErrs > 0 {
+		slog.Warn("dedup duration-match: EnsureSingletonBookTag errors",
+			"book", book.ID, "errors", tagErrs)
 	}
 	return nil
 }
@@ -3141,7 +3192,17 @@ func (de *Engine) getAllPrimaryBooksWithFullFields() ([]database.Book, error) {
 // Candidates that are already at layer='llm' are skipped — rerunning is cheap in
 // bookkeeping but expensive in API calls, so callers should use UpsertCandidate to
 // clear the layer back to 'embedding' if they want a re-review.
-func (de *Engine) RunLLMReview(ctx context.Context) error {
+// RunLLMReview scans pending ambiguous embedding-layer candidates (book and
+// author) and submits them as a batch to the configured LLM for review.
+//
+// progressFn is optional (H9, 2026-07 error-correction sweep): the
+// input-building loop below can iterate up to LLMMaxPairsPerRun (default
+// 10K) pairs, each doing a store read per side via buildPairInput, inside a
+// 120-minute op timeout. Before this, the op reported zero progress between
+// "starting" and "job submitted" — indistinguishable from a hang. When a
+// callback is supplied it is invoked every 100 pairs (and once at the end)
+// with (built-so-far, total-candidates).
+func (de *Engine) RunLLMReview(ctx context.Context, progressFn ...ProgressCallback) error {
 	if de.llmParser == nil || !de.llmParser.IsEnabled() {
 		logging.Info(ctx, "dedup LLM review skipped — llmParser not configured")
 		return nil
@@ -3169,17 +3230,26 @@ func (de *Engine) RunLLMReview(ctx context.Context) error {
 	}
 	logging.Info(ctx, "dedup LLM review starting — pair(s) queued", "allCandidates_count", len(allCandidates))
 
+	var reportProgress ProgressCallback
+	if len(progressFn) > 0 && progressFn[0] != nil {
+		reportProgress = progressFn[0]
+	}
+
 	// Build inputs alongside an index→candidate map for verdict routing.
-	inputs := make([]ai.DedupPairInput, 0, len(allCandidates))
-	byIndex := make(map[int]database.DedupCandidate, len(allCandidates))
+	total := len(allCandidates)
+	inputs := make([]ai.DedupPairInput, 0, total)
+	byIndex := make(map[int]database.DedupCandidate, total)
 	for i, c := range allCandidates {
 		input, ok := de.buildPairInput(i, c)
 		if !ok {
 			logging.Info(ctx, "dedup skipping candidate — could not load entities", "c", c.ID)
-			continue
+		} else {
+			inputs = append(inputs, input)
+			byIndex[i] = c
 		}
-		inputs = append(inputs, input)
-		byIndex[i] = c
+		if reportProgress != nil && ((i+1)%100 == 0 || i+1 == total) {
+			reportProgress(i+1, total, fmt.Sprintf("building LLM review inputs: %d/%d pairs", i+1, total))
+		}
 	}
 	if len(inputs) == 0 {
 		return nil

--- a/internal/itunes/service/importer.go
+++ b/internal/itunes/service/importer.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/importer.go
-// version: 1.13.0
+// version: 1.13.1
 // guid: 2b8e5f1a-4c7d-4e9f-b3a0-6d8c2e7a4f1b
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package itunesservice
 
@@ -421,6 +421,11 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 		hashLinked := 0
 		hashBlocked := 0
 		hashBlockFailed := 0
+		// H4 (2026-07 error-correction sweep): GetBookByID error vs. a benign
+		// nil-book skip (book removed between the quick-import phase and
+		// this pass) used to be one bare `continue`. Distinguish them so a
+		// store-level lookup problem is visible in the completion summary.
+		bookLookupErrs := 0
 		for hi, bookID := range newBookIDs {
 			if log.IsCanceled() {
 				log.Info("Hash validation canceled")
@@ -428,7 +433,12 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 			}
 
 			book, err := imp.store.GetBookByID(bookID)
-			if err != nil || book == nil {
+			if err != nil {
+				bookLookupErrs++
+				log.Warn("Hash validation: GetBookByID failed for %s: %v", bookID, err)
+				continue
+			}
+			if book == nil {
 				continue
 			}
 
@@ -479,7 +489,7 @@ func (imp *Importer) Execute(ctx context.Context, opID string, req ImportRequest
 				log.UpdateProgress(totalGroups, totalGroups, msg)
 			}
 		}
-		log.Info("Hash validation completed: %d linked, %d blocked, %d blocked-but-soft-delete-failed out of %d new books", hashLinked, hashBlocked, hashBlockFailed, len(newBookIDs))
+		log.Info("Hash validation completed: %d linked, %d blocked, %d blocked-but-soft-delete-failed, %d lookup errors out of %d new books", hashLinked, hashBlocked, hashBlockFailed, bookLookupErrs, len(newBookIDs))
 	}
 
 	// Phase 4: Metadata enrichment

--- a/internal/itunes/service/position_sync.go
+++ b/internal/itunes/service/position_sync.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/position_sync.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: 9f7a8b5c-0d6e-4a70-b8c5-3d7e0f1b9a99
-// last-edited: 2026-07-07
+// last-edited: 2026-07-18
 //
 // Bidirectional sync between the app's per-user position/state
 // tracking (spec 3.6) and the iTunes Bookmark / Play Count fields
@@ -151,6 +151,11 @@ func (p *PositionSync) pushPositions() int {
 	}
 
 	pushed := 0
+	// H4 (2026-07 error-correction sweep): GetBookByID error vs. a benign
+	// nil-book/no-PID skip used to be one bare `continue`. Distinguish them
+	// so a store-level lookup problem is visible instead of just quietly
+	// reducing how many positions get pushed.
+	lookupErrs := 0
 	seen := map[string]bool{}
 	for _, pos := range positions {
 		if seen[pos.BookID] {
@@ -159,7 +164,11 @@ func (p *PositionSync) pushPositions() int {
 		seen[pos.BookID] = true
 
 		book, err := p.store.GetBookByID(pos.BookID)
-		if err != nil || book == nil || book.ITunesPersistentID == nil {
+		if err != nil {
+			lookupErrs++
+			continue
+		}
+		if book == nil || book.ITunesPersistentID == nil {
 			continue
 		}
 
@@ -189,6 +198,10 @@ func (p *PositionSync) pushPositions() int {
 				slog.Warn("bump play count for", "book", book.ID, "err", err)
 			}
 		}
+	}
+
+	if lookupErrs > 0 {
+		slog.Warn("itunes position push: book lookup errors", "errors", lookupErrs, "total_positions", len(positions))
 	}
 
 	return pushed

--- a/internal/itunes/service/writeback_batcher.go
+++ b/internal/itunes/service/writeback_batcher.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/writeback_batcher.go
-// version: 5.4.0
+// version: 5.4.1
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e90
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 //
 // Combined write-back batcher: handles location updates, track additions,
 // and track removals in a single ITL read-modify-write cycle.
@@ -404,9 +404,19 @@ func (b *WriteBackBatcher) flush() {
 	var locationUpdates []itunes.ITLLocationUpdate
 	var metadataUpdates []itunes.ITLMetadataUpdate
 	var skippedMetadata, changedMetadata int
+	// H4 (2026-07 error-correction sweep): GetBookByID error and "book
+	// deleted between enqueue and flush" (nil, no error) used to be treated
+	// identically as a silent skip. Track them separately — a store error is
+	// worth investigating, a nil book is expected/benign churn.
+	var bookLookupErrs, bookNilSkips int
 	for _, id := range bookIDs {
 		book, err := store.GetBookByID(id)
-		if err != nil || book == nil {
+		if err != nil {
+			bookLookupErrs++
+			continue
+		}
+		if book == nil {
+			bookNilSkips++
 			continue
 		}
 		// Only primary versions are written to iTunes. A non-primary
@@ -538,6 +548,17 @@ func (b *WriteBackBatcher) flush() {
 				Genre:        genre,
 			})
 		}
+	}
+
+	// Emitted before the ops.IsEmpty() early return below so lookup errors
+	// are never lost even when every enqueued book ended up producing no
+	// update (e.g. all bookIDs errored or were skipped).
+	if bookLookupErrs > 0 || bookNilSkips > 0 {
+		slog.Warn("iTunes write-back: book lookups skipped",
+			"lookup_errors", bookLookupErrs,
+			"nil_book_skips", bookNilSkips,
+			"total_bookIDs", len(bookIDs),
+		)
 	}
 
 	ops := itunes.ITLOperationSet{

--- a/internal/metabatch/upgrade.go
+++ b/internal/metabatch/upgrade.go
@@ -1,7 +1,7 @@
 // file: internal/metabatch/upgrade.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-02
+// last-edited: 2026-07-18
 //
 // Background job that upgrades metadata from lower-quality sources
 // (primarily Google Books) to richer ones (Hardcover, Audible/Audnexus)
@@ -28,6 +28,7 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 )
 
@@ -75,7 +76,13 @@ const MinUpgradeConfidenceWithTranscription = 0.85
 // sources and attempts to find a better match from other sources.
 // Respects context cancellation so it can be run as a long-running
 // operation with a kill switch.
-func (s *MetadataUpgradeService) RunUpgrade(ctx context.Context, limit int) (*UpgradeResult, error) {
+//
+// progress may be nil (M7, 2026-07 error-correction sweep): before this, the
+// op reported nothing between "starting" and the final result while checking
+// up to `limit` books, each involving a network metadata search — a 30+
+// minute silent stretch indistinguishable from a hang. When non-nil,
+// progress is reported every 25 books checked (and once more at the end).
+func (s *MetadataUpgradeService) RunUpgrade(ctx context.Context, limit int, progress operations.ProgressReporter) (*UpgradeResult, error) {
 	if s.Fetcher == nil {
 		return nil, fmt.Errorf("metadata fetch service not configured")
 	}
@@ -113,6 +120,12 @@ func (s *MetadataUpgradeService) RunUpgrade(ctx context.Context, limit int) (*Up
 				result.Upgraded++
 			} else {
 				result.Skipped++
+			}
+
+			if progress != nil && (result.Checked%25 == 0 || result.Checked >= limit) {
+				_ = progress.UpdateProgress(result.Checked, limit, fmt.Sprintf(
+					"metadata upgrade: %d/%d books checked (%d upgraded, %d skipped, %d errors)",
+					result.Checked, limit, result.Upgraded, result.Skipped, result.Errors))
 			}
 		}
 	}

--- a/internal/plugins/dedup/llm_review.go
+++ b/internal/plugins/dedup/llm_review.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/llm_review.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-06
+// last-edited: 2026-07-18
 
 package dedup
 
@@ -37,13 +37,32 @@ func (p *Plugin) runLLMReview(ctx context.Context, _ json.RawMessage, reporter s
 		return fmt.Errorf("dedup engine not available")
 	}
 
-	prog := sdk.NewProgress(reporter, 0)
-	prog.Start("Starting LLM review of ambiguous candidates...")
-	if err := p.engine.RunLLMReview(ctx); err != nil {
+	_ = reporter.UpdateProgress(0, 1, "Starting LLM review of ambiguous candidates...")
+
+	// H9 (2026-07 error-correction sweep): the total pair count isn't known
+	// until RunLLMReview lists ambiguous candidates internally, so the
+	// sdk.Progress bar is constructed lazily on the first callback instead
+	// of up front with a placeholder n=0 (which made StepN a no-op). Without
+	// this, the op reported nothing between "starting" and "job submitted"
+	// while building up to 10K pair inputs — indistinguishable from a hang.
+	var prog *sdk.Progress
+	onProgress := func(current, total int, message string) {
+		if prog == nil {
+			prog = sdk.NewProgress(reporter, total)
+			prog.Start(message)
+		}
+		prog.StepN(current, message)
+	}
+
+	if err := p.engine.RunLLMReview(ctx, onProgress); err != nil {
 		reporter.Logger().Error("LLM review error", "error", err)
 		return fmt.Errorf("LLM review: %w", err)
 	}
-	prog.Finalize("writing results...")
-	prog.Done("LLM review complete")
+	if prog != nil {
+		prog.Finalize("writing results...")
+		prog.Done("LLM review complete")
+	} else {
+		_ = reporter.UpdateProgress(1, 1, "LLM review complete (no ambiguous candidates)")
+	}
 	return nil
 }

--- a/internal/plugins/maintenance/author.go
+++ b/internal/plugins/maintenance/author.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/author.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: e5f6a7b8-c9d0-1234-ef01-456789012345
-// last-edited: 2026-07-13
+// last-edited: 2026-07-18
 
 package maintenance
 
@@ -117,6 +117,13 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 	splitCount := 0
 	booksUpdated := 0
 	errCount := 0
+	// H8 (2026-07 error-correction sweep): GetBookAuthors errors below used to
+	// be a bare `continue` — the book is left un-relinked to the new
+	// individual authors, yet DeleteAuthor(author.ID) below still removes the
+	// composite author it pointed to, orphaning that book's author reference.
+	// This is a data-affecting miscount, not just a skip, so it gets its own
+	// counter and a per-occurrence Warn in addition to the run summary.
+	bookAuthorsLookupErrs := 0
 	total := len(authors)
 	prog := sdk.NewProgress(reporter, total)
 	prog.Start(fmt.Sprintf("Scanning %d authors for composite names...", total))
@@ -169,6 +176,10 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 		for _, book := range books {
 			bookAuthors, err := store.GetBookAuthors(book.ID)
 			if err != nil {
+				bookAuthorsLookupErrs++
+				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+					"author split: GetBookAuthors failed for book %s (author %q not relinked): %v",
+					book.ID, author.Name, err))
 				continue
 			}
 			role := "author"
@@ -251,8 +262,8 @@ func (p *Plugin) runAuthorSplitScan(ctx context.Context, _ json.RawMessage, repo
 	// Invalidate dedup cache since authors changed
 	p.deps.InvalidateDedupCache()
 
-	resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors)",
-		splitCount, booksUpdated, errCount)
+	resultMsg := fmt.Sprintf("Split %d composite authors, updated %d books (%d errors, %d books not relinked due to lookup errors)",
+		splitCount, booksUpdated, errCount, bookAuthorsLookupErrs)
 	_ = reporter.Log(slog.LevelInfo, resultMsg)
 	prog.Done(resultMsg)
 	return nil

--- a/internal/plugins/maintenance/deps.go
+++ b/internal/plugins/maintenance/deps.go
@@ -72,7 +72,11 @@ type ServerDeps interface {
 	// InvalidateDedupCache invalidates the author-duplicates dedup cache.
 	InvalidateDedupCache()
 	// MetadataUpgradeRun runs the metadata upgrade scan up to limit books.
-	MetadataUpgradeRun(ctx context.Context, limit int) (checked, upgraded, skipped, errs int, err error)
+	// progress may be nil; when non-nil it is updated every 25 books checked
+	// (M7, 2026-07 error-correction sweep — this is a 120-minute,
+	// network-bound op that previously reported nothing between start and
+	// result).
+	MetadataUpgradeRun(ctx context.Context, limit int, progress operations.ProgressReporter) (checked, upgraded, skipped, errs int, err error)
 	// SearchTranscriptionCandidate finds the top-scoring metadata candidate for
 	// bookID using transTitle as the query. The returned score may exceed 1.0
 	// (uncapped scale with transcription boosts applied). Returns found=false

--- a/internal/plugins/maintenance/metadata.go
+++ b/internal/plugins/maintenance/metadata.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/metadata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a7b8c9d0-e1f2-3456-0123-678901234567
-// last-edited: 2026-05-07
+// last-edited: 2026-07-18
 
 package maintenance
 
@@ -70,7 +70,11 @@ func (p *Plugin) runMetadataUpgrade(ctx context.Context, _ json.RawMessage, repo
 	prog := sdk.NewProgress(reporter, 0)
 	prog.Start("Scanning for books with upgradeable metadata sources...")
 	_ = reporter.Log(slog.LevelInfo, "Scanning for books with upgradeable metadata sources...")
-	checked, upgraded, skipped, errs, err := p.deps.MetadataUpgradeRun(ctx, 200)
+	// M7 (2026-07 error-correction sweep): thread the reporter through as a
+	// progress sink so the 120-minute network-bound scan reports books
+	// processed/total every 25 books instead of going silent between start
+	// and result.
+	checked, upgraded, skipped, errs, err := p.deps.MetadataUpgradeRun(ctx, 200, newOpsAdapter(reporter))
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/maintenance/title_backfill_test.go
+++ b/internal/plugins/maintenance/title_backfill_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/title_backfill_test.go
-// version: 1.4.1
+// version: 1.5.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
 // last-edited: 2026-07-18
 
@@ -77,7 +77,7 @@ func (d fakeDeps) DedupTriageExactPending(_ context.Context, _ bool) (*TriageRep
 	return &TriageReport{}, nil
 }
 func (d fakeDeps) InvalidateDedupCache() {}
-func (d fakeDeps) MetadataUpgradeRun(_ context.Context, _ int) (int, int, int, int, error) {
+func (d fakeDeps) MetadataUpgradeRun(_ context.Context, _ int, _ operations.ProgressReporter) (int, int, int, int, error) {
 	return 0, 0, 0, 0, nil
 }
 func (d fakeDeps) OptimizeAIScanStore() error { return nil }

--- a/internal/plugins/maintenance/transcribe_stats_accum.go
+++ b/internal/plugins/maintenance/transcribe_stats_accum.go
@@ -1,11 +1,12 @@
 // file: internal/plugins/maintenance/transcribe_stats_accum.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 9d3b1e57-6a02-4c8f-b14d-7e9a2f5c08b1
-// last-edited: 2026-07-01
+// last-edited: 2026-07-18
 
 package maintenance
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
@@ -109,7 +110,14 @@ func (a *transcribeStatsAccum) flush(markDone bool) {
 	}
 	snapshot := a.stats // copy under lock
 	a.mu.Unlock()
-	_ = a.sink.PutTranscribeStats(&snapshot)
+	// M1 (2026-07 error-correction sweep): a persist failure here used to be
+	// swallowed with `_ =`. flush is called after every page, so a
+	// transiently failing sink previously left the live-monitor aggregate
+	// silently stale with no signal that anything was wrong.
+	if err := a.sink.PutTranscribeStats(&snapshot); err != nil {
+		slog.Warn("transcribe stats: persist failed — live monitor may show stale counts",
+			"run_op_id", snapshot.RunOpID, "attempted", snapshot.Attempted, "err", err)
+	}
 }
 
 // snapshot returns a copy of the current counters for logging.

--- a/internal/reconcile/itunes_heal.go
+++ b/internal/reconcile/itunes_heal.go
@@ -1,7 +1,7 @@
 // file: internal/reconcile/itunes_heal.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 7f3a1b2c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
-// last-edited: 2026-06-26
+// last-edited: 2026-07-18
 
 package reconcile
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"os/exec"
@@ -27,6 +28,30 @@ import (
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 	"howett.net/plist"
 )
+
+// resolverFailureCounters (H3, 2026-07 error-correction sweep) tracks
+// per-resolver failures inside resolveAmbiguousByAcoustID and
+// resolveAmbiguousByTranscription that used to be bare `continue`s —
+// indistinguishable from "this candidate just isn't a match", silently
+// inflating the `ambiguous` bucket in RunITunesHeal's summary. Shared by
+// pointer across the RunItems worker pool (Concurrency: 16), so every field
+// is an atomic counter.
+type resolverFailureCounters struct {
+	fpcalcFailed         atomic.Int64 // FileWholeFingerprint error/nil result
+	acoustidLookupFailed atomic.Int64 // ac.Lookup error or empty title
+	whisperFailed        atomic.Int64 // TranscribeFirst30s error/empty text
+}
+
+// warnRateLimited logs msg at Warn on the first occurrence and every 100th
+// occurrence thereafter (n is the post-increment count), so a systemic
+// failure (fpcalc missing, AcoustID down, Whisper model unavailable) is
+// visible without spamming one line per track across a multi-thousand-track
+// heal run.
+func warnRateLimited(n int64, msg string, args ...any) {
+	if n == 1 || n%100 == 0 {
+		slog.Warn(msg, append(args, "occurrence", n)...)
+	}
+}
 
 // iTunesTrack is the minimal set of fields we need from an iTunes XML track entry.
 type iTunesTrack struct {
@@ -342,7 +367,12 @@ func resolveAmbiguousByBookMeta(store database.Store, track iTunesTrack, candida
 // fingerprint when available, falling back to fpcalc), submits to AcoustID,
 // and picks the candidate whose returned title/artist best matches the iTunes
 // track. Only invoked when layers 1–3 fail and an API key is configured.
-func resolveAmbiguousByAcoustID(ctx context.Context, store database.Store, ac *acoustid.Client, track iTunesTrack, candidates []string) string {
+//
+// failures may be nil (tests / call sites that don't care about the counters);
+// when non-nil, fpcalc failures and AcoustID lookup failures are tallied and
+// rate-limited-Warn logged instead of silently `continue`-ing — before H3
+// these were indistinguishable from "no match", inflating `ambiguous`.
+func resolveAmbiguousByAcoustID(ctx context.Context, store database.Store, ac *acoustid.Client, track iTunesTrack, candidates []string, failures *resolverFailureCounters) string {
 	albumWords := titleWords(track.Album)
 	artistWords := titleWords(track.Artist)
 
@@ -368,6 +398,10 @@ func resolveAmbiguousByAcoustID(ctx context.Context, store database.Store, ac *a
 		} else {
 			wf, err := fingerprint.FileWholeFingerprint(path)
 			if err != nil || wf == nil {
+				if failures != nil {
+					n := failures.fpcalcFailed.Add(1)
+					warnRateLimited(n, "itunes-heal: fpcalc fallback failed", "path", path, "err", err)
+				}
 				continue
 			}
 			rawFP = wf.Raw
@@ -377,6 +411,10 @@ func resolveAmbiguousByAcoustID(ctx context.Context, store database.Store, ac *a
 		encoded := fingerprint.EncodeWholeFingerprint(rawFP)
 		result, err := ac.Lookup(ctx, encoded, durationSec)
 		if err != nil || result.Title == "" {
+			if failures != nil {
+				n := failures.acoustidLookupFailed.Add(1)
+				warnRateLimited(n, "itunes-heal: AcoustID lookup failed", "path", path, "err", err)
+			}
 			continue
 		}
 
@@ -443,7 +481,11 @@ func resolveNotFoundByPID(store database.Store, pid string) string {
 // Only called when there are ≤5 candidates (cost: ~5–15 s per candidate with a
 // local Whisper model; more candidates indicate a structural problem better
 // handled by the triage op).
-func resolveAmbiguousByTranscription(ctx context.Context, store database.Store, track iTunesTrack, candidates []string) string {
+//
+// failures may be nil; when non-nil, Whisper transcription failures are
+// tallied and rate-limited-Warn logged instead of a silent `continue` — see
+// resolveAmbiguousByAcoustID's doc comment for why this matters (H3).
+func resolveAmbiguousByTranscription(ctx context.Context, store database.Store, track iTunesTrack, candidates []string, failures *resolverFailureCounters) string {
 	if len(candidates) == 0 || len(candidates) > 5 {
 		return ""
 	}
@@ -474,6 +516,10 @@ func resolveAmbiguousByTranscription(ctx context.Context, store database.Store, 
 
 		text, err := transcribe.TranscribeFirst30s(ctx, firstFile)
 		if err != nil || text == "" {
+			if failures != nil {
+				n := failures.whisperFailed.Add(1)
+				warnRateLimited(n, "itunes-heal: transcription failed", "path", firstFile, "err", err)
+			}
 			continue
 		}
 
@@ -727,6 +773,7 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 		merged    atomic.Int64
 		healErrs  atomic.Int64
 	)
+	var resolverFailures resolverFailureCounters
 
 	err = registry.RunItems(ctx, reporter, slice,
 		func(ctx context.Context, t iTunesTrack) error {
@@ -756,7 +803,7 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 
 			// Layer 4: AcoustID title lookup — only when API key is configured.
 			if src == "" && len(candidates) > 0 && ac != nil {
-				src = resolveAmbiguousByAcoustID(ctx, store, ac, t, candidates)
+				src = resolveAmbiguousByAcoustID(ctx, store, ac, t, candidates, &resolverFailures)
 			}
 
 			// Layer 5: PID lookup — authoritative for both ambiguous and not-found.
@@ -771,7 +818,7 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 			// candidate whose title/author best matches the iTunes track. Definitive
 			// but expensive; only runs for ≤5 still-ambiguous candidates.
 			if src == "" && len(candidates) > 0 && store != nil {
-				src = resolveAmbiguousByTranscription(ctx, store, t, candidates)
+				src = resolveAmbiguousByTranscription(ctx, store, t, candidates, &resolverFailures)
 			}
 
 			// Layer 7: fuzzy album/artist path scan for zero-candidate not-found tracks.
@@ -802,8 +849,9 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 			ProgressOffset: startIdx,
 			ProgressTotal:  len(missing),
 			Label: func(i, total int) string {
-				return fmt.Sprintf("Track %d/%d  healed=%d merged=%d ambig=%d missing=%d err=%d",
-					i+1, total, healed.Load(), merged.Load(), ambiguous.Load(), notFound.Load(), healErrs.Load())
+				return fmt.Sprintf("Track %d/%d  healed=%d merged=%d ambig=%d missing=%d err=%d  resolver_fails(fpcalc=%d acoustid=%d whisper=%d)",
+					i+1, total, healed.Load(), merged.Load(), ambiguous.Load(), notFound.Load(), healErrs.Load(),
+					resolverFailures.fpcalcFailed.Load(), resolverFailures.acoustidLookupFailed.Load(), resolverFailures.whisperFailed.Load())
 			},
 		},
 	)
@@ -822,7 +870,11 @@ func RunITunesHeal(ctx context.Context, store database.Store, reporter sdk.Repor
 		Errors:      int(healErrs.Load()),
 	}
 	resultJSON, _ := json.Marshal(result)
-	log.Info("itunes-heal: complete", "result", string(resultJSON))
+	log.Info("itunes-heal: complete", "result", string(resultJSON),
+		"resolver_fpcalc_failed", resolverFailures.fpcalcFailed.Load(),
+		"resolver_acoustid_failed", resolverFailures.acoustidLookupFailed.Load(),
+		"resolver_whisper_failed", resolverFailures.whisperFailed.Load(),
+	)
 	_ = reporter.UpdateProgress(len(missing), len(missing), fmt.Sprintf(
 		"Done: healed=%d  merged=%d  ambig=%d  not_found=%d  err=%d",
 		result.Healed, result.Merged, result.Ambiguous, result.NotFound, result.Errors,

--- a/internal/scheduler/extra_ops.go
+++ b/internal/scheduler/extra_ops.go
@@ -1,7 +1,7 @@
 // file: internal/scheduler/extra_ops.go
-// version: 1.2.1
+// version: 1.2.2
 // guid: a9b8c7d6-e5f4-3210-fedc-ba9876543210
-// last-edited: 2026-07-16
+// last-edited: 2026-07-18
 
 // extra_ops registers OperationDefs for 13 scheduler tasks that previously
 // used the legacy triggerOperation / triggerOperationWithID helpers.  Each def
@@ -197,7 +197,10 @@ func (r *ExtraOpsRegistrar) RegisterMetadataUpgradeOp(reg *opsregistry.Registry)
 			}
 			svc := metabatch.NewMetadataUpgradeService(r.Store, r.Deps.MetadataFetchService)
 			_ = progress.Log("info", "Scanning for books with upgradeable metadata sources...", nil)
-			result, err := svc.RunUpgrade(ctx, 200)
+			// M7 (2026-07 error-correction sweep): thread progress through so
+			// this 4-hour-timeout op reports books processed/total every 25
+			// books instead of going silent between start and result.
+			result, err := svc.RunUpgrade(ctx, 200, progress)
 			if err != nil {
 				return err
 			}

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -121,12 +121,12 @@ func (s *Server) InvalidateDedupCache() {
 	}
 }
 
-func (s *Server) MetadataUpgradeRun(ctx context.Context, limit int) (checked, upgraded, skipped, errs int, err error) {
+func (s *Server) MetadataUpgradeRun(ctx context.Context, limit int, progress operations.ProgressReporter) (checked, upgraded, skipped, errs int, err error) {
 	if s.metadataFetchService == nil {
 		return 0, 0, 0, 0, fmt.Errorf("metadata fetch service not initialized")
 	}
 	svc := NewMetadataUpgradeService(s.Store(), s.metadataFetchService)
-	result, err := svc.RunUpgrade(ctx, limit)
+	result, err := svc.RunUpgrade(ctx, limit, progress)
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}


### PR DESCRIPTION
Final task of the 2026-07-17 review fix wave. Adds Warn/Error logs + summary counters to the remaining swallowed-error/no-progress sites (H1–H4, H8, H9, M1–M3, M7 from docs/audits/2026-07-17-multi-discipline-review.md). Behavior unchanged — observability only. M7 threads a nil-safe progress param through MetadataUpgradeRun (was silent on a 120-min op). Completed by the coordinator after the T05 agent stalled mid-task; rebased onto merged T09/T03-BUILD interface changes (all three ServerDeps method updates coexist), test-compile verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65