### PR TITLE
docs(dedup): T13 truth-up — sandbox-proven 85.5% dedup backlog collapse

### DIFF
--- a/docs/dedup/STATUS.md
+++ b/docs/dedup/STATUS.md
@@ -1,7 +1,7 @@
 <!-- file: docs/dedup/STATUS.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 09dc17af-0c96-4f15-bc27-e5f48edb9e74 -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # Dedup — Status & Architecture (single source of truth)
 
@@ -37,26 +37,50 @@ genuine-duplicate review signal:
 4. **Stub/empty records** — 11–91-byte files paired with real books. Cleanup;
    never had real audio.
 
-## Remediation path (in order)
+## Remediation path (in order) — PROVEN END-TO-END ON SANDBOX 2026-07-18
 
-1. **Title repair** — fix leaked/junk titles on affected books so exact-title
-   cliques dissolve instead of being purged blind. (Code merged; prod run
-   pending.)
-2. **ScoreBreakdown backfill** — populate ScoreBreakdowns on labeled/pending
-   pairs so composite calibration has real inputs (this was the "calibration
-   blocked" gap, resolved by the #1926/#1927 chain: recall 0.33 → ~0.70 at
-   96.7% precision, auto-merge tier 98.3%).
-3. **Triage** — `maintenance.dedup-exact-triage` classifies the backlog into the
-   four populations above (read-only); review the report.
-4. **Rescan** — full-scan/rescore on the cleaned corpus; then PH-2b runs the
-   per-population purge wave and the review UI drains what remains.
+1. **Title repair** — `maintenance.title-repair` (op built, PR #1978) re-derives
+   CONS-17b agreed chapter titles over stored books so exact-title cliques
+   dissolve. Measured: 556 books retitled, 0 errors.
+2. **ScoreBreakdown backfill** — `dedup.breakdown-backfill` (op built, PR #1982)
+   populates ScoreBreakdowns on pre-T015 pending candidates so triage and
+   composite calibration have real inputs (this was the "calibration blocked"
+   gap; the #1926/#1927 chain took recall 0.33 → ~0.70 at 96.7% precision).
+   Measured: ~9,419 candidates backfilled, 0 errors.
+3. **Triage classify + purge-apply** — `maintenance.dedup-exact-triage` classifies
+   the backlog into the four populations above; with **`{"apply":true}`** (op
+   built, PR #2008) it **dismisses** (never hard-deletes — reversible, and the
+   #1973 terminal-status guard stops resurrection) the purgeable stub/title-leak
+   populations. The relaxed title-leak precondition (PR #1982) recognizes
+   non-iTunes title-leak by identical normalized title.
+4. **Rescan** — `dedup.purge-stale` + `dedup.full-scan` on the cleaned corpus;
+   the review UI drains what genuinely remains.
+
+### Sandbox validation results (2026-07-18, full-fidelity prod replica, 0 errors)
+
+Ran the full chain on a fresh ZFS clone + copy of the production Pebble DB
+(baseline identical to prod: **9,074 exact-pending / 10,319 total-pending**):
+
+| Stage | exact-pending | total-pending | dismissed |
+|---|---|---|---|
+| baseline | 9,074 | 10,319 | 1,351 |
+| after title-repair + breakdown-backfill | 9,074 | 10,319 | 1,351 |
+| **after triage purge-apply** (classified purgeable=**7,891**, keep=278, review=2,150 → dismissed 7,891) | **1,183** | 2,428 | 9,242 |
+| after purge-stale | 1,181 | 2,426 | 9,242 |
+| **final** after full-scan (embedding re-emission) | **1,311** | 2,554 | 9,242 |
+
+**Net: exact-pending 9,074 → 1,311 (−85.5%); total-pending 10,319 → 2,554 (−75%);
+7,891 title-leak/stub junk candidates dismissed, 0 errors.** The remaining ~1,300
+are genuine plausible duplicates + review-band + a small full-scan embedding
+re-emission — the real review backlog that *should* remain. This validates the
+whole title-repair → backfill → relaxed-triage → purge design predicted at 76%.
 
 Prod execution of this path is tracked in
 [`docs/operations/pending-prod-actions.md`](../operations/pending-prod-actions.md)
-(rows 1–2). High-risk steps validate on **the dedup sandbox** first — a
-disposable replica of prod; isolation is proven (a destructive test at the prod
-path left prod byte-identical). Mechanics are deliberately not documented here:
-**private runbook in falkcorp/infra-docs**.
+(rows 1–2) and is **human-gated** (not yet run on prod). High-risk steps validate
+on **the dedup sandbox** first — a disposable replica of prod; isolation is proven
+(a destructive test at the prod path left prod byte-identical). Mechanics are
+deliberately not documented here: **private runbook in falkcorp/infra-docs**.
 
 ## What's fixed (recent)
 
@@ -85,12 +109,16 @@ path left prod byte-identical). Mechanics are deliberately not documented here:
   **cover recovery** fast-follows (TODO #3, #11, #12).
 - **`review_apply_enabled` flip** — human decision
   ([DECISIONS-PENDING](../plans/DECISIONS-PENDING.md)).
-- **2026-07-17 review findings F2–F7** (ApplyVersionGroup group-integrity bugs,
-  status-index bypass, Rescore 100K truncation, legacy MergeBooks op gaps) — see
+- **2026-07-17 review findings F2–F7 are now FIXED** (F2 ApplyVersionGroup
+  integrity #1976, F3/F4/F5 index/Rescore-cap #1977, F6 legacy MergeBooks
+  rerouted off hard-delete #2007, F7 quarantine RunItems #2004) — full map in
   [`docs/audits/2026-07-17-multi-discipline-review.md`](../audits/2026-07-17-multi-discipline-review.md).
-- Audit-carryover code items still relevant: differentiated residual-disposition
-  op (fragment-floor; purge title-leak/stub) and raising the purge-stale 100K
-  cap to 1M with chunked deletes.
+- The differentiated residual-disposition op is now **built** (`dedup-exact-triage`
+  `{"apply":true}` dismisses title-leak/stub, PR #2008) and **validated on the
+  sandbox** (see the validation table above). The Rescore/purge whole-backlog caps
+  were raised to 1M (#1977).
+- **Only prod execution remains** (human-gated) — the sandbox run proved the
+  full chain; the equivalent prod run is TODO #2 / pending-prod-actions rows 1–2.
 
 ## Architecture — the feedback loop
 

--- a/docs/operations/pending-prod-actions.md
+++ b/docs/operations/pending-prod-actions.md
@@ -1,7 +1,7 @@
 <!-- file: docs/operations/pending-prod-actions.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.0.1 -->
 <!-- guid: 84079e70-633b-4bf5-849a-7b6671f6de61 -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # Pending Prod Actions — the run-on-prod queue
 
@@ -22,8 +22,8 @@ validated on the dedup sandbox first (private runbook in falkcorp/infra-docs).
 
 | # | Action | What / why | Op / command shape | Gating | Source |
 |---|--------|------------|--------------------|--------|--------|
-| 1 | **PH-2 exact-triage** | Run the triage op that classifies the exact-pending dedup backlog into its four populations, then review the population report before any purge | def-id `maintenance.dedup-exact-triage` (read-only classify) → review report → PH-2b per-population purge wave (**never blanket-purge**) | operator-run (triage) → human-decision (PH-2b purge) | [`docs/dedup/STATUS.md`](../dedup/STATUS.md); TODO #2 |
-| 2 | **CONS-10 / INIT-2 T6 backlog drain** | Drain/triage the ~15,269-pending candidate backlog now that title-repair + rescore code is merged; run was never executed | ops per [`docs/plans/2026-07-10-dedup-pipeline-hardening.md`](../plans/2026-07-10-dedup-pipeline-hardening.md) (dry-run → apply); sandbox-first | human-decision (prod apply) | TODO #1 |
+| 1 | **PH-2 exact-triage** | Run the triage op that classifies the exact-pending dedup backlog into its four populations, then review the population report before any purge | def-id `maintenance.dedup-exact-triage` (read-only classify) → review report → PH-2b per-population purge wave (**never blanket-purge**) | operator-run (triage) → human-decision (PH-2b purge) | **Sandbox-validated 2026-07-18: purgeable=7,891, exact-pending 9,074→1,311 (−85.5%), 0 errors** — [`docs/dedup/STATUS.md`](../dedup/STATUS.md); TODO #2 |
+| 2 | **CONS-10 / INIT-2 T6 backlog drain** | Drain/triage the ~15,269-pending candidate backlog now that title-repair + rescore code is merged; run was never executed | chain PROVEN on sandbox 2026-07-18 (title-repair→breakdown-backfill→triage `apply=true`→purge-stale→full-scan; ops #1978/#1982/#2008); prod = same sequence, human-gated | human-decision (prod apply) | TODO #1 |
 | 3 | **Duration-reextract tail** | Re-enqueue the duration-reextract apply for the ~721-book tail that the v3 run left behind | duration-reextract op re-enqueue (see archived design [`2026-06-21-duration-reextract-v3-design.md`](../archive/2026-07-consolidation/specs/2026-06-21-duration-reextract-v3-design.md)); dry-run supported | operator-run | TODO #19 |
 | 4 | **iTunes heal Layer-6 re-trigger** | Re-run the iTunes path-heal op so Layer-6 (the last-resort matching layer) reprocesses the residuals (3,720 ambiguous / 5,349 not-found / 4,734 doubled-path) | re-enqueue the iTunes path-heal op after the residual pools shrink | operator-run | TODO #17, #49 |
 | 5 | **SLOG-PROD-VERIFY** | Live smoke test that the op-activity logging chain (start/progress/complete + activity tags) actually lands in prod journald/op-log | runbook: [`docs/operations/slog-prod-verify.md`](slog-prod-verify.md) | operator-run | TODO #28 |

--- a/docs/status/2026-07-17-error-correction-session.md
+++ b/docs/status/2026-07-17-error-correction-session.md
@@ -1,7 +1,7 @@
 <!-- file: docs/status/2026-07-17-error-correction-session.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 3f8a1c62-9b4e-4d17-a2c5-7e0d94f6b813 -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # 2026-07-17 error-correction session — status record
 
@@ -52,7 +52,9 @@ Measured results:
 | `dedup.purge-stale` after retitle | only **15** candidates removed → 9,059 exact-pending. **Key learning:** the shattered single-file chapter-books (the 76 % clique residue) each live in their **own directory**, so the same-dir stale rule cannot catch them, and title-repair correctly skips single-file books. The designed lever for that population is triage (with the #1982 relaxed title_leak class) → per-population purge — NOT retitle, NOT purge-stale. |
 | `dedup.breakdown-backfill` dry-run | targets=10,062 · would_backfill=9,419 · skipped_has_breakdown=242 · zero_signal=643 · errors=0 |
 | `dedup.breakdown-backfill` apply | was RUNNING at session stop (op `01KXSJHBDDP17AMR8WYKSTQH30`); completes server-side harmlessly (sandbox only). Verify + continue per task brief T02. |
-| `maintenance.dedup-exact-triage` | NOT yet run — next step (T02). Expect the former `unknown=9,950` to collapse into real classes, with `title_leak` >> 0. |
+| `maintenance.dedup-exact-triage` (classify) | purgeable=**7,891** (title_leak+stub) · keep=278 (genuine) · review=2,150 — the former `unknown=9,950` collapsed into real classes, exactly as predicted. |
+| `maintenance.dedup-exact-triage {"apply":true}` (purge-apply, NEW op #2008) | dismissed 7,891 → exact-pending **9,074 → 1,183**; total-pending 10,319 → 2,428; 0 errors. |
+| `dedup.purge-stale` + `dedup.full-scan` (final) | exact-pending **1,311** · total-pending 2,554 (full-scan embedding re-emission). **Net −85.5% exact-pending; the whole title-repair → backfill → relaxed-triage → purge chain is proven end-to-end, 0 errors.** Full 2026-07-18 re-run recorded in `docs/dedup/STATUS.md`. |
 
 Sandbox operational notes (for the next operator):
 - Instance may or may not still be running on :8485 (plain HTTP, NOT https).
@@ -66,16 +68,22 @@ Sandbox operational notes (for the next operator):
   build — poll `GET /api/v1/operations/v2/<op_id>` yourself instead.
 - Full runbook: falkcorp/infra-docs `docs/runbooks/dedup-sandbox.md` (private).
 
-## Remaining work
+## Status (updated 2026-07-18)
 
-All remaining work is specified in
-[`docs/agent-tasks/error-correction-2026-07/TASKS.md`](../agent-tasks/error-correction-2026-07/TASKS.md)
-(13 briefs T01–T13, dependency-ordered). Summary: land #1986; finish the sandbox
-sequence (backfill-apply verify → triage → purge wave → full-scan → measure);
-prod deploy + human-gated prod apply; SSE terminal publisher (R-1); orphan-VG
-pool (R-6); logging H/M batch; remux/transcode reporter threading (C2);
-legacy-MergeBooks verify (F6); concurrency hygiene (F7, R-9); chapter-duration
-guard (R-8); registry/scanner hygiene (R-3, R-7, P-2); devops follow-ups
-(8 scripts with internal IPs, op-stall alert, coverage floor on PR gate,
-systemd unit dedupe, credential entropy, op_verify.py); docs refresh with
-measured numbers.
+The follow-on briefs T01–T13 ([`docs/agent-tasks/error-correction-2026-07/TASKS.md`](../agent-tasks/error-correction-2026-07/TASKS.md))
+are **complete except the human-gated prod step**:
+
+- **T01–T02, T05–T13 DONE.** The 2026-07-18 coordination wave merged all nine
+  code fixes across PRs **#2001–#2010** (SSE terminal publisher R-1; registry
+  hygiene R-3/R-7/P-2; orphan-VG pool R-6; logging H/M batch; remux/transcode +
+  external-ID-backfill reporter threading C2/H7; legacy MergeBooks rerouted off
+  hard-delete F6; concurrency + duration hygiene F7/R-9/R-8; devops follow-ups;
+  the triage purge-apply op) plus docs cleanup #2011. Main builds + `go vet`
+  clean.
+- **T03 DONE** — the full remediation chain is proven end-to-end on the sandbox
+  (see the table above and `docs/dedup/STATUS.md`): exact-pending **9,074 → 1,311
+  (−85.5%)**, 7,891 junk candidates dismissed, 0 errors.
+- **T04 — the only thing left — is HUMAN-GATED.** Nothing has been deployed to or
+  run on production. Prod deploy + prod dry-runs + the apply decision await an
+  explicit human go-ahead ([`docs/plans/DECISIONS-PENDING.md`](../plans/DECISIONS-PENDING.md);
+  pending-prod-actions rows 1–2).


### PR DESCRIPTION
Records the 2026-07-18 end-to-end sandbox validation of the dedup remediation chain: exact-pending **9,074 → 1,311 (−85.5%)**, 7,891 title-leak/stub junk candidates dismissed, 0 errors. Updates docs/dedup/STATUS.md (validation table, F2–F7 marked fixed), the session status doc, and pending-prod-actions rows 1–2. Prod execution remains human-gated (T04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65