### PR TITLE
feat(metrics): per-operation progress exporter + op-stall alert (TODO #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.178.0 -->
+<!-- version: 3.179.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - feat(metrics): per-operation progress exporter + op-stall alert (TODO #36)
+
+- **`audiobook_organizer_op_items_processed{op_id,op_type}`** and a companion
+  **`audiobook_organizer_op_items_total{op_id,op_type}`** gauge were added
+  (`internal/metrics/metrics.go`, `SetOpProgress`/`ClearOpProgress`) —
+  previously `internal/metrics/metrics.go` only counted ops
+  started/completed/failed/canceled by type; nothing exported a running op's
+  items-processed progress, so a wedged-but-"running" op (the 2026-07-05
+  `dedup.full-scan` 3+ hour hang, the 9hr Pebble write-stall freeze) was only
+  ever noticed by a human watching the UI.
+- Wired from the registry's DB-backed progress reporter
+  (`internal/operations/registry/reporter_db.go`, `dbReporter.UpdateProgress`)
+  on every `ProgressReporter.UpdateProgress` call, and cleared via
+  `registry.publishOpTerminal` (`internal/operations/registry/registry.go`) —
+  the single choke point every terminal transition (completed/failed/
+  canceled/interrupted/dep-failure-propagated) already routes through — so
+  stale op_ids never accumulate as unbounded label-series cardinality.
+- Uncommented + finalized the "op stalled" alert left by PR #2001/T12 in
+  `deploy/prometheus/alert-rules.yml`: `AudiobookOrganizerOpStalled` fires on
+  `rate(audiobook_organizer_op_items_processed[30m]) == 0` for 30m. No
+  separate `op_active` gauge was needed — the series' own existence (created
+  at op start, deleted at terminal) already proxies "is this op still
+  running". Validated with `promtool check rules`.
 
 #### July 18, 2026 - fix(logging): H/M observability batch (T05)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.5.0 -->
+<!-- version: 10.6.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -129,16 +129,22 @@ Companion docs:
     review, REPO-SIZE-1.
 35. **Consultancy wave 4+ residuals** ([roadmap](docs/consultancy/00-ROADMAP.md)) —
     unverified; needs a close-out sweep against shipped work.
-36. **Op-progress Prometheus metric (T12 follow-up)** — no metric today exports
-    per-operation item-processed progress; `internal/metrics/metrics.go` only
-    has started/completed/failed/canceled counts by type, not progress within
-    a running op. Build an exporter (e.g. a gauge
-    `audiobook_organizer_op_items_processed{op_id,op_type}`, updated from
-    `internal/operations/progress.go`'s `ProgressReporter.UpdateProgress`) so
-    the commented-out "op stalled" alert in `deploy/prometheus/alert-rules.yml`
-    can be uncommented and wired up. This closes the observability gap behind
-    the 3+ hour `dedup.full-scan` hang and the 9hr Pebble write-stall freeze —
-    both were only noticed by a human watching the UI.
+36. **Op-progress Prometheus metric (T12 follow-up)** — ✅ DONE (PR #2014,
+    2026-07-18): added `audiobook_organizer_op_items_processed{op_id,op_type}`
+    + companion `audiobook_organizer_op_items_total{op_id,op_type}` gauges
+    (`internal/metrics/metrics.go`, `SetOpProgress`/`ClearOpProgress`), set on
+    every `dbReporter.UpdateProgress` call
+    (`internal/operations/registry/reporter_db.go`) and deleted on every
+    terminal transition via `registry.publishOpTerminal`
+    (`internal/operations/registry/registry.go`) so stale op_ids never
+    accumulate. Uncommented + finalized the "op stalled" alert in
+    `deploy/prometheus/alert-rules.yml` (`AudiobookOrganizerOpStalled`,
+    `rate(audiobook_organizer_op_items_processed[30m]) == 0` for 30m —
+    existence of the series itself proxies "op is active" since it's deleted
+    at terminal, so no separate `op_active` gauge was needed). Closes the
+    observability gap behind the 3+ hour `dedup.full-scan` hang and the 9hr
+    Pebble write-stall freeze — both were only noticed by a human watching
+    the UI.
 
 ## UX (4)
 

--- a/deploy/prometheus/alert-rules.yml
+++ b/deploy/prometheus/alert-rules.yml
@@ -1,5 +1,5 @@
 # file: deploy/prometheus/alert-rules.yml
-# version: 1.1.0
+# version: 1.2.0
 # guid: d2e3f4a5-b6c7-4d8e-9f0a-1b2c3d4e5f6a
 # last-edited: 2026-07-18
 #
@@ -116,43 +116,44 @@ groups:
             /var/lib/audiobook-organizer for at least 10 minutes. Requires
             node_exporter scraping the host (see prerequisite note above).
 
-      # OP-STALL (2026-07-17 devops follow-up, T12 item 2): "op active but
-      # making no progress" — the class of incident behind the 3+ hour
-      # dedup.full-scan hang (docs/audits/2026-07-05-concurrency-single-
-      # threaded-hotspots.md) and the 9hr Pebble write-stall freeze
+      # OP-STALL (2026-07-17 devops follow-up, T12 item 2; finalized TODO #36):
+      # "op active but making no progress" — the class of incident behind the
+      # 3+ hour dedup.full-scan hang (docs/audits/2026-07-05-concurrency-
+      # single-threaded-hotspots.md) and the 9hr Pebble write-stall freeze
       # (project_concurrency_followups_jul5). Both were only noticed by a
       # human watching the UI, not by an alert.
       #
-      # BLOCKED: there is currently NO Prometheus metric that exports
-      # per-operation item-processed progress. internal/metrics/metrics.go
-      # only has operations_started/completed/failed/canceled_total (count
-      # by type, not progress within a still-running op) and
-      # operation_duration_seconds (only observed once an op finishes, so it
-      # cannot detect a wedged/still-running op). The actual progress signal
-      # today is internal/operations/progress.go's ProgressReporter.
-      # UpdateProgress(current, total, message) — purely in-process, stored
-      # on the op record and returned via GET
-      # /api/v1/operations/v2/<op_id>, never exported to Prometheus.
+      # The exporter now exists: internal/metrics/metrics.go's
+      # audiobook_organizer_op_items_processed{op_id,op_type} gauge is set on
+      # every ProgressReporter.UpdateProgress call (internal/operations/
+      # registry/reporter_db.go, dbReporter.UpdateProgress ->
+      # metrics.SetOpProgress) and deleted the instant the op reaches a
+      # terminal state (registry.publishOpTerminal -> metrics.ClearOpProgress
+      # — the single choke point every terminal transition already routes
+      # through). Because the series only exists while an op is in flight, no
+      # separate "op_active" gauge is needed: the expr below implicitly
+      # requires the op to still be running simply by referencing a series
+      # that stops existing the moment it isn't. A companion
+      # audiobook_organizer_op_items_total{op_id,op_type} gauge is also
+      # exported (same lifecycle) so percent-complete is computable
+      # (op_items_processed / op_items_total) even though it isn't needed by
+      # this rule.
       #
-      # A TODO.md line has been added for building the exporter (a gauge
-      # such as audiobook_organizer_op_items_processed{op_id,op_type} updated
-      # from UpdateProgress, likely via a small adapter around ProgressReporter
-      # in internal/operations). Once that metric exists, uncomment and wire
-      # up a rule of this shape:
-      #
-      # - alert: AudiobookOrganizerOpStalled
-      #   expr: >-
-      #     (audiobook_organizer_op_active == 1)
-      #     and
-      #     (rate(audiobook_organizer_op_items_processed_total[30m]) == 0)
-      #   for: 30m
-      #   labels:
-      #     severity: warning
-      #   annotations:
-      #     summary: "audiobook-organizer operation appears stalled"
-      #     description: >-
-      #       An operation ({{ $labels.op_type }}, {{ $labels.op_id }}) has
-      #       been active for at least 30 minutes with zero items processed
-      #       in that window — likely wedged rather than merely slow. Check
-      #       `journalctl -u audiobook-organizer` and GET
-      #       /api/v1/operations/v2/{{ $labels.op_id }} for the last log line.
+      # rate() over a gauge is valid here because, within one op_id's
+      # lifetime, "current" is monotonically non-decreasing (a real progress
+      # counter) and the series is deleted rather than reset to 0 on
+      # completion — so there is never an in-series counter-reset for rate()
+      # to misinterpret.
+      - alert: AudiobookOrganizerOpStalled
+        expr: rate(audiobook_organizer_op_items_processed[30m]) == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "audiobook-organizer operation appears stalled"
+          description: >-
+            An operation ({{ $labels.op_type }}, {{ $labels.op_id }}) has
+            been active for at least 30 minutes with zero items processed
+            in that window — likely wedged rather than merely slow. Check
+            `journalctl -u audiobook-organizer` and GET
+            /api/v1/operations/v2/{{ $labels.op_id }} for the last log line.

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/minio/minlz v1.1.1 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,7 +1,7 @@
 // file: internal/metrics/metrics.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9f8e7d6c-5b4a-3210-9fed-cba876543210
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package metrics
 
@@ -123,6 +123,32 @@ var (
 		Name:      "ai_backend_available",
 		Help:      "1 if the named AI backend was reachable/available at last check, else 0",
 	}, []string{"backend"})
+
+	// opItemsProcessed/opItemsTotal export per-operation *progress* while an op
+	// is still running (OPS-5 op-stall detection). Unlike the started/completed/
+	// failed/canceled counters above (count of ops by type, only incremented at
+	// lifecycle edges), these gauges reflect the in-flight ProgressReporter.
+	// UpdateProgress(current, total, ...) state so a wedged-but-still-"running"
+	// op (e.g. the 2026-07-05 dedup.full-scan 3hr hang, or the 9hr Pebble
+	// write-stall freeze — both only noticed by a human watching the UI) can be
+	// alerted on via rate(op_items_processed) == 0 for a sustained window.
+	//
+	// Labeled by {op_id, op_type} rather than just {op_type} because the alert
+	// needs to identify the *specific* wedged run, not just its type. This is
+	// bounded cardinality in practice: only currently in-flight ops have a
+	// series at all — ClearOpProgress deletes both series the instant an op
+	// reaches a terminal state (see registry.publishOpTerminal), so historical
+	// op_ids never accumulate.
+	opItemsProcessed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "audiobook_organizer",
+		Name:      "op_items_processed",
+		Help:      "Current items-processed count for an in-flight operation, by op_id and op_type. Deleted once the op reaches a terminal state.",
+	}, []string{"op_id", "op_type"})
+	opItemsTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "audiobook_organizer",
+		Name:      "op_items_total",
+		Help:      "Total items expected for an in-flight operation (0 if not yet known), by op_id and op_type. Deleted once the op reaches a terminal state.",
+	}, []string{"op_id", "op_type"})
 )
 
 // Register initializes metrics with the global Prometheus registry (idempotent)
@@ -131,7 +157,8 @@ func Register() {
 		prometheus.MustRegister(operationStarted, operationCompleted, operationFailed, operationCanceled, operationDuration,
 			booksGauge, foldersGauge, memoryAllocGauge, goroutinesGauge,
 			cacheHits, cacheMisses, cacheSets, cacheInvalidations, cacheEvictions, cacheSize, cacheGetDuration,
-			itunesLocationUnmappable, aiBackendAvailable)
+			itunesLocationUnmappable, aiBackendAvailable,
+			opItemsProcessed, opItemsTotal)
 	})
 }
 
@@ -167,6 +194,26 @@ func SetBooks(n int)          { booksGauge.Set(float64(n)) }
 func SetFolders(n int)        { foldersGauge.Set(float64(n)) }
 func SetMemoryAlloc(b uint64) { memoryAllocGauge.Set(float64(b)) }
 func SetGoroutines(n int)     { goroutinesGauge.Set(float64(n)) }
+
+// SetOpProgress records the current/total items-processed progress for an
+// in-flight operation (OPS-5 op-stall detection). Call on every
+// ProgressReporter.UpdateProgress. opType should be the op's def_id (stable
+// type identifier), not a free-form message, to keep cardinality bounded.
+func SetOpProgress(opID, opType string, current, total int) {
+	opItemsProcessed.WithLabelValues(opID, opType).Set(float64(current))
+	opItemsTotal.WithLabelValues(opID, opType).Set(float64(total))
+}
+
+// ClearOpProgress deletes the per-op progress gauge series for opID/opType.
+// Call exactly once when an operation reaches a terminal state (completed,
+// failed, canceled, or interrupted) — without this, op_items_processed and
+// op_items_total would accumulate one label-series per historical op_id
+// forever (unbounded cardinality growth). Safe to call even if no series was
+// ever set for this opID (no-op).
+func ClearOpProgress(opID, opType string) {
+	opItemsProcessed.DeleteLabelValues(opID, opType)
+	opItemsTotal.DeleteLabelValues(opID, opType)
+}
 
 // Cache helpers
 func RecordCacheHit(cache string)          { cacheHits.WithLabelValues(cache).Inc() }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,12 +1,15 @@
 // file: internal/metrics/metrics_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b
+// last-edited: 2026-07-18
 
 package metrics
 
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestRegister(t *testing.T) {
@@ -234,4 +237,72 @@ func TestOperationLifecycle_Canceled(t *testing.T) {
 	IncOperationCanceled(opType)
 
 	t.Log("Successfully recorded canceled operation")
+}
+
+// b2uniqueOpLabels returns an op_id/op_type label pair unique to this test
+// run, so parallel/table-driven tests never collide on the same GaugeVec
+// label series (task-unique per B2 op-progress-metric work item).
+func b2uniqueOpLabels(t *testing.T, suffix string) (opID, opType string) {
+	t.Helper()
+	return "b2-op-" + suffix, "b2.op_type." + suffix
+}
+
+// TestSetOpProgress_SetsGauges verifies UpdateProgress-style calls (via
+// SetOpProgress) set both the items-processed and items-total gauges for the
+// given op_id/op_type label pair (OPS-5 op-stall exporter, TODO #36).
+func TestSetOpProgress_SetsGauges(t *testing.T) {
+	Register()
+	opID, opType := b2uniqueOpLabels(t, "setprogress")
+	defer ClearOpProgress(opID, opType)
+
+	SetOpProgress(opID, opType, 42, 100)
+
+	if got := testutil.ToFloat64(opItemsProcessed.WithLabelValues(opID, opType)); got != 42 {
+		t.Errorf("opItemsProcessed = %v, want 42", got)
+	}
+	if got := testutil.ToFloat64(opItemsTotal.WithLabelValues(opID, opType)); got != 100 {
+		t.Errorf("opItemsTotal = %v, want 100", got)
+	}
+
+	// A subsequent call (simulating the next UpdateProgress tick) overwrites
+	// rather than accumulates — these are gauges, not counters.
+	SetOpProgress(opID, opType, 75, 100)
+	if got := testutil.ToFloat64(opItemsProcessed.WithLabelValues(opID, opType)); got != 75 {
+		t.Errorf("opItemsProcessed after second update = %v, want 75", got)
+	}
+}
+
+// TestClearOpProgress_DeletesGaugeSeries verifies that ClearOpProgress —
+// called by registry.publishOpTerminal on every terminal transition — removes
+// the per-op label series entirely (not just zeroes it), so stale op_ids
+// don't accumulate as unbounded cardinality once an op completes/fails/
+// cancels (OPS-5, TODO #36).
+func TestClearOpProgress_DeletesGaugeSeries(t *testing.T) {
+	Register()
+	opID, opType := b2uniqueOpLabels(t, "clearprogress")
+
+	SetOpProgress(opID, opType, 10, 20)
+	if got := testutil.ToFloat64(opItemsProcessed.WithLabelValues(opID, opType)); got != 10 {
+		t.Fatalf("precondition: opItemsProcessed = %v, want 10", got)
+	}
+
+	ClearOpProgress(opID, opType)
+
+	deletedProcessed := opItemsProcessed.DeleteLabelValues(opID, opType)
+	deletedTotal := opItemsTotal.DeleteLabelValues(opID, opType)
+	if deletedProcessed {
+		t.Error("opItemsProcessed series still present after ClearOpProgress (Delete should have been a no-op on an already-deleted series)")
+	}
+	if deletedTotal {
+		t.Error("opItemsTotal series still present after ClearOpProgress (Delete should have been a no-op on an already-deleted series)")
+	}
+
+	// A freshly re-observed value after clearing must start from the new
+	// current/total, not any stale prior state (there should be none, since
+	// the series was deleted rather than merely reset to 0).
+	SetOpProgress(opID, opType, 1, 5)
+	defer ClearOpProgress(opID, opType)
+	if got := testutil.ToFloat64(opItemsProcessed.WithLabelValues(opID, opType)); got != 1 {
+		t.Errorf("opItemsProcessed after re-observe = %v, want 1", got)
+	}
 }

--- a/internal/operations/registry/progress_metric_test.go
+++ b/internal/operations/registry/progress_metric_test.go
@@ -1,0 +1,187 @@
+// file: internal/operations/registry/progress_metric_test.go
+// version: 1.0.0
+// guid: 3c1d9e7a-4b6f-4a2c-8e0d-5f9a1b2c3d4e
+// last-edited: 2026-07-18
+
+package registry_test
+
+// Tests for the OPS-5 op-progress Prometheus exporter (TODO #36):
+// dbReporter.UpdateProgress sets audiobook_organizer_op_items_processed/
+// _total (internal/metrics.SetOpProgress), and registry.publishOpTerminal
+// clears both series on every terminal transition (internal/metrics.
+// ClearOpProgress) so stale op_ids don't accumulate as label series. These
+// tests exercise the real dbReporter/worker path end-to-end (not the metrics
+// package in isolation — that's covered by internal/metrics/metrics_test.go)
+// by reading back the global Prometheus registry, since the underlying
+// gauges are unexported and this test lives in the external registry_test
+// package.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/falkcorp/audiobook-organizer/internal/metrics"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// b2gaugeValue polls the global Prometheus DefaultGatherer for a gauge metric
+// family named `name` carrying label op_id=opID, returning (value, found).
+// Reading via Gather (rather than a package-level accessor) avoids the need
+// for any test-only export on the metrics package and — critically — never
+// creates a series as a side effect the way GaugeVec.WithLabelValues would,
+// so it can truthfully assert a series is ABSENT after ClearOpProgress.
+// Task-unique name (b2xxx) per the parallel-test-helper-collision rule.
+func b2gaugeValue(t *testing.T, name, opID string) (value float64, found bool) {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if b2metricHasLabel(m, "op_id", opID) {
+				return m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return 0, false
+}
+
+func b2metricHasLabel(m *dto.Metric, key, want string) bool {
+	for _, lp := range m.GetLabel() {
+		if lp.GetName() == key && lp.GetValue() == want {
+			return true
+		}
+	}
+	return false
+}
+
+// b2waitGaugeAbsent polls until the named gauge series for opID is gone (or
+// fails the test after timeout). Used to assert ClearOpProgress ran — the
+// deletion happens synchronously inside registry.publishOpTerminal, but that
+// call itself happens on the worker goroutine racing this test goroutine.
+func b2waitGaugeAbsent(t *testing.T, name, opID string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, found := b2gaugeValue(t, name, opID); !found {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("gauge %s{op_id=%q} still present after %v", name, opID, timeout)
+}
+
+// TestProgressMetric_SetOnUpdateAndClearedOnTerminal is the end-to-end proof
+// for TODO #36: a running op's UpdateProgress call is visible as
+// audiobook_organizer_op_items_processed/_total, and once the op reaches a
+// terminal state ("completed") both series are gone.
+func TestProgressMetric_SetOnUpdateAndClearedOnTerminal(t *testing.T) {
+	metrics.Register()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	release := make(chan struct{})
+	reported := make(chan struct{})
+
+	def := makeValidDef("test.progress-metric-lifecycle")
+	def.Run = func(_ context.Context, _ json.RawMessage, rep registry.Reporter) error {
+		if err := rep.UpdateProgress(3, 10, "a third of the way"); err != nil {
+			return err
+		}
+		close(reported)
+		<-release // hold the op "running" until the test has observed the gauge
+		return nil
+	}
+	if err := r.RegisterOp(def); err != nil {
+		t.Fatalf("RegisterOp: %v", err)
+	}
+	r.Start(context.Background())
+
+	opID, err := r.EnqueueOp(context.Background(), "test.progress-metric-lifecycle", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+
+	select {
+	case <-reported:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op never reported progress")
+	}
+
+	if got, found := b2gaugeValue(t, "audiobook_organizer_op_items_processed", opID); !found || got != 3 {
+		t.Fatalf("op_items_processed{op_id=%q} = %v, found=%v; want 3, true", opID, got, found)
+	}
+	if got, found := b2gaugeValue(t, "audiobook_organizer_op_items_total", opID); !found || got != 10 {
+		t.Fatalf("op_items_total{op_id=%q} = %v, found=%v; want 10, true", opID, got, found)
+	}
+
+	close(release)
+	awaitStatus(t, store, opID, "completed", 5*time.Second)
+	bus.waitTerminal(t, opID, 5*time.Second)
+
+	b2waitGaugeAbsent(t, "audiobook_organizer_op_items_processed", opID, 2*time.Second)
+	b2waitGaugeAbsent(t, "audiobook_organizer_op_items_total", opID, 2*time.Second)
+}
+
+// TestProgressMetric_ClearedOnCancel proves the cleanup path also fires on a
+// cancel-while-running terminal transition, not just normal completion.
+func TestProgressMetric_ClearedOnCancel(t *testing.T) {
+	metrics.Register()
+
+	store := newFakeStore()
+	bus := &t06TermBus{}
+	r := registry.New(store, slog.Default(), 1, bus)
+
+	started := make(chan struct{})
+
+	def := makeValidDef("test.progress-metric-cancel")
+	def.Run = func(runCtx context.Context, _ json.RawMessage, rep registry.Reporter) error {
+		if err := rep.UpdateProgress(1, 0, "started"); err != nil {
+			return err
+		}
+		close(started)
+		<-runCtx.Done() // honor cancellation promptly (not abandoned)
+		return runCtx.Err()
+	}
+	if err := r.RegisterOp(def); err != nil {
+		t.Fatalf("RegisterOp: %v", err)
+	}
+	r.Start(context.Background())
+
+	opID, err := r.EnqueueOp(context.Background(), "test.progress-metric-cancel", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("op did not start")
+	}
+
+	if _, found := b2gaugeValue(t, "audiobook_organizer_op_items_processed", opID); !found {
+		t.Fatalf("op_items_processed{op_id=%q} not set before cancel", opID)
+	}
+
+	if err := r.Cancel(opID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	awaitStatus(t, store, opID, "canceled", 5*time.Second)
+	bus.waitTerminal(t, opID, 5*time.Second)
+
+	b2waitGaugeAbsent(t, "audiobook_organizer_op_items_processed", opID, 2*time.Second)
+	b2waitGaugeAbsent(t, "audiobook_organizer_op_items_total", opID, 2*time.Second)
+}

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/registry.go
-// version: 3.8.0
+// version: 3.9.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
 // last-edited: 2026-07-18
 
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metrics"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -792,7 +793,17 @@ func (r *Registry) publishOpCreated(row database.OperationV2Row, resumed bool) {
 // (canceled/timeout/abandon paths) or is about to be, so passing runCtx would
 // make the publish a no-op on exactly the paths that most need it. The bus is
 // nil-safe; publishOpTerminal is a no-op when no bus is wired.
+//
+// This is also the single choke point every terminal-transition call site
+// (worker.go's canceled/subprocess/abandoned/normal paths, deps_scheduler.go,
+// and Cancel below) already routes through, so it doubles as the cleanup
+// point for the OPS-5 per-op progress gauges (metrics.SetOpProgress): without
+// deleting them here, audiobook_organizer_op_items_processed/_total would
+// accumulate one label-series per historical op_id forever. This runs
+// regardless of whether a bus is wired.
 func (r *Registry) publishOpTerminal(opID, defID, status string) {
+	metrics.ClearOpProgress(opID, defID)
+
 	if r.bus == nil {
 		return
 	}

--- a/internal/operations/registry/reporter_db.go
+++ b/internal/operations/registry/reporter_db.go
@@ -1,5 +1,5 @@
 // file: internal/operations/registry/reporter_db.go
-// version: 1.6.0
+// version: 1.7.0
 // guid: 1a2b3c4d-5e6f-7890-abcd-ef0123456789
 // last-edited: 2026-07-18
 
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metrics"
 )
 
 // Bus is satisfied by the EventHub in UOS-06. A nil Bus is safe; all
@@ -322,6 +323,12 @@ func (r *dbReporter) UpdateProgress(current, total int, message string) error {
 	r.lastProgressMessage = message
 	r.progressMu.Unlock()
 	r.progressGen.Add(1)
+
+	// OPS-5: export current/total to Prometheus on every progress update so a
+	// wedged-but-"running" op is detectable via rate(op_items_processed) == 0
+	// rather than only by a human watching the UI. Cleared on terminal
+	// transition by registry.publishOpTerminal -> metrics.ClearOpProgress.
+	metrics.SetOpProgress(r.opID, r.defID, current, total)
 
 	if r.synchronous {
 		if err := r.store.UpdateOpProgressV2(r.opID, current, total, message); err != nil {


### PR DESCRIPTION
## Summary

- Adds `audiobook_organizer_op_items_processed{op_id,op_type}` and a companion `audiobook_organizer_op_items_total{op_id,op_type}` Prometheus gauge (`internal/metrics/metrics.go`: `SetOpProgress`/`ClearOpProgress`). Previously `internal/metrics/metrics.go` only counted ops started/completed/failed/canceled by type — nothing exported a running op's items-processed progress.
- Wired from `dbReporter.UpdateProgress` (`internal/operations/registry/reporter_db.go`) on every progress update, and cleared from `registry.publishOpTerminal` (`internal/operations/registry/registry.go`) — the single choke point every terminal transition (completed/failed/canceled/interrupted/dep-failure-propagated) already routes through — so stale op_ids never accumulate as unbounded label-series cardinality.
- Uncomments + finalizes the "op stalled" alert left by PR #2001/T12 in `deploy/prometheus/alert-rules.yml`: `AudiobookOrganizerOpStalled` fires on `rate(audiobook_organizer_op_items_processed[30m]) == 0` for 30m. No separate `op_active` gauge needed — the series' own existence (created at op start, deleted at terminal) already proxies "is this op still running".
- This closes the observability gap behind the 3+ hour `dedup.full-scan` hang and the 9hr Pebble write-stall freeze, both previously only noticed by a human watching the UI.

Ticks TODO.md item 36 and adds a CHANGELOG entry.

## Test plan

- [x] `internal/metrics/metrics_test.go`: `TestSetOpProgress_SetsGauges`, `TestClearOpProgress_DeletesGaugeSeries` (in-package, direct gauge assertions via `testutil.ToFloat64`)
- [x] `internal/operations/registry/progress_metric_test.go` (new): `TestProgressMetric_SetOnUpdateAndClearedOnTerminal`, `TestProgressMetric_ClearedOnCancel` — end-to-end through the real worker/reporter path, reading back the global Prometheus registry
- [x] `go test ./internal/metrics/... ./internal/operations/... -race -count=1` — all green
- [x] `go build ./...` clean
- [x] `promtool check rules deploy/prometheus/alert-rules.yml` — `SUCCESS: 6 rules found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65