### PR TITLE
refactor(audio): consolidate the 3 duration extractors into one (AP-3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,34 @@
   separate `op_active` gauge was needed — the series' own existence (created
   at op start, deleted at terminal) already proxies "is this op still
   running". Validated with `promtool check rules`.
+#### July 18, 2026 - refactor(audio): consolidate the 3 duration extractors (AP-3b)
+
+- **New `internal/audioutil.ProbeDurationSeconds`** is now the single ffprobe
+  subprocess implementation shared by `internal/mediainfo` (`realDurationSec`,
+  the scanner's canonical duration source), `internal/fingerprint`
+  (`probeDuration`, used to place the 7 acoustic-fingerprint segment offsets),
+  and `internal/transcode` (`probeDuration` for chapter-metadata timestamps,
+  `probeFileDuration` for transcode progress reporting). All three had
+  independently reimplemented "shell out to ffprobe and parse the container
+  duration" — one via plain-text output, two via JSON — with small drift
+  between them (different `-v` verbosity, presence/absence of a timeout,
+  int/float64/int64-microseconds return types). This class of duplication is
+  exactly what produced past duration bugs (CONS-16/17/18, the ms-vs-seconds
+  confusion documented in `internal/database/duration_sanity.go`).
+- Each call site keeps its own return type, error contract, and validity
+  rules (mediainfo still rounds to `int` seconds and returns `ok=false` for
+  `<=0`; fingerprint and transcode still use raw `float64` seconds;
+  transcode's `probeFileDuration` still converts to microseconds and swallows
+  errors as `0`, matching its original best-effort contract) — this is a
+  consolidation of the ffprobe-invocation mechanism, not a change to any
+  caller's observed duration values or units.
+- Added `internal/audioutil/duration_test.go` (6 tests, generates real silent
+  audio via `ffmpeg -f lavfi anullsrc` and probes it, so no LFS fixture
+  dependency) plus a regression test per rerouted call site
+  (`internal/mediainfo/duration_unify_test.go`,
+  `internal/fingerprint/duration_unify_test.go`,
+  `internal/transcode/duration_unify_test.go`) proving each still returns the
+  correct value/unit after the reroute.
 
 #### July 18, 2026 - fix(logging): H/M observability batch (T05)
 

--- a/TODO.md
+++ b/TODO.md
@@ -79,7 +79,10 @@ Companion docs:
     RootDir only.
 19. **AP-3 duration-reextract ~721-book tail** (H1:949) — re-enqueue apply
     (see pending-prod-actions).
-20. **AP-3b — consolidate the 3 duration extractors into one** (H1:954).
+20. ~~**AP-3b — consolidate the 3 duration extractors into one** (H1:954).~~ DONE —
+    `internal/audioutil.ProbeDurationSeconds` is now the single ffprobe
+    implementation shared by `internal/mediainfo`, `internal/fingerprint`, and
+    `internal/transcode`; each call site keeps its own unit/error contract.
 21. **CONS-18 Part 2 — file-tag duration write-back** (H1:1019; spec 2026-06-19 DRAFT)
     — config-gated; deferred until dedup re-scope settles.
 22. **Torrent relocation INIT-5 T2–T7** ([plan](docs/plans/2026-07-10-torrent-relocation.md))

--- a/internal/audioutil/duration.go
+++ b/internal/audioutil/duration.go
@@ -1,0 +1,65 @@
+// file: internal/audioutil/duration.go
+// version: 1.0.0
+// guid: 03399668-0f87-4d27-b118-8315b574ef23
+// last-edited: 2026-07-18
+
+// Package audioutil holds small, dependency-free helpers shared by the audio
+// processing packages (internal/mediainfo, internal/fingerprint,
+// internal/transcode). It exists to stop those packages from independently
+// reimplementing the same ffprobe subprocess call — see ProbeDurationSeconds.
+package audioutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// ProbeDurationSeconds shells out to ffprobe and returns the container's
+// reported duration in seconds, as a float64 with no rounding applied.
+//
+// This consolidates what were previously three independent ffprobe-shelling
+// implementations (internal/mediainfo.realDurationSec, internal/fingerprint's
+// unexported probeDuration, and internal/transcode's unexported probeDuration /
+// probeFileDuration) that had drifted in small ways (JSON vs plain-text
+// ffprobe output, int vs float64 vs microsecond-int64 return types, presence
+// or absence of a timeout) and were the kind of thing behind past duration
+// bugs (see TODO item 20 / AP-3b). All three now call this function and
+// convert/validate at their own boundary instead of reimplementing the probe.
+//
+// ffprobePath selects which ffprobe binary to invoke; pass "" to resolve
+// "ffprobe" from PATH. ctx bounds the subprocess — pass context.Background()
+// for no timeout, or a context.WithTimeout for a bounded call (mediainfo does
+// this since a stuck ffprobe invocation must not hang the scanner).
+//
+// The returned value is NOT validated against zero/negative and callers apply
+// their own validity rules: mediainfo treats <=0 as "unknown" and falls back
+// to a flagged filesize/bitrate estimate, while transcode's chapter builder
+// has historically accepted whatever ffprobe reports. Preserving that
+// difference at the call site (rather than baking a single policy into this
+// helper) is intentional — this is a consolidation of the probe mechanism,
+// not a change to each caller's duration semantics.
+func ProbeDurationSeconds(ctx context.Context, ffprobePath, filePath string) (float64, error) {
+	bin := ffprobePath
+	if bin == "" {
+		bin = "ffprobe"
+	}
+	cmd := exec.CommandContext(ctx, bin,
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		filePath)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("ffprobe %s: %w", filePath, err)
+	}
+	secs, err := strconv.ParseFloat(strings.TrimSpace(stdout.String()), 64)
+	if err != nil {
+		return 0, fmt.Errorf("ffprobe duration parse %s: %w", filePath, err)
+	}
+	return secs, nil
+}

--- a/internal/audioutil/duration_test.go
+++ b/internal/audioutil/duration_test.go
@@ -1,0 +1,126 @@
+// file: internal/audioutil/duration_test.go
+// version: 1.0.0
+// guid: 4b0e6d3a-7c1f-4a52-9d8e-2f6a1c9b0d47
+// last-edited: 2026-07-18
+
+package audioutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// b4RequireFFmpeg skips the test when ffmpeg/ffprobe are not on PATH — these
+// tests generate a real audio fixture and probe it, rather than relying on
+// LFS-gated testdata fixtures that may not be checked out.
+func b4RequireFFmpeg(t *testing.T) (ffmpegPath, ffprobePath string) {
+	t.Helper()
+	fp, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not on PATH — skipping real-audio duration test")
+	}
+	pp, err := exec.LookPath("ffprobe")
+	if err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+	return fp, pp
+}
+
+// b4GenerateSilentAudio writes a silent audio file of the given duration
+// (seconds) to dir/name using ffmpeg's lavfi anullsrc source, and returns the
+// full path. Fails the test on any ffmpeg error.
+func b4GenerateSilentAudio(t *testing.T, ffmpegPath, dir, name string, seconds int) string {
+	t.Helper()
+	out := filepath.Join(dir, name)
+	cmd := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+		"-t", fmt.Sprintf("%d", seconds),
+		"-c:a", "libmp3lame",
+		out,
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffmpeg generate fixture: %v", err)
+	}
+	return out
+}
+
+func TestProbeDurationSeconds_RealFixture(t *testing.T) {
+	ffmpegPath, _ := b4RequireFFmpeg(t)
+	dir := t.TempDir()
+	path := b4GenerateSilentAudio(t, ffmpegPath, dir, "b4-3s.mp3", 3)
+
+	secs, err := ProbeDurationSeconds(context.Background(), "", path)
+	if err != nil {
+		t.Fatalf("ProbeDurationSeconds: %v", err)
+	}
+	// mp3 encoders pad slightly; allow generous tolerance.
+	if secs < 2.5 || secs > 3.5 {
+		t.Errorf("expected duration near 3s, got %.3f", secs)
+	}
+}
+
+func TestProbeDurationSeconds_ExplicitFFprobePath(t *testing.T) {
+	ffmpegPath, ffprobePath := b4RequireFFmpeg(t)
+	dir := t.TempDir()
+	path := b4GenerateSilentAudio(t, ffmpegPath, dir, "b4-2s.mp3", 2)
+
+	secs, err := ProbeDurationSeconds(context.Background(), ffprobePath, path)
+	if err != nil {
+		t.Fatalf("ProbeDurationSeconds: %v", err)
+	}
+	if secs < 1.5 || secs > 2.5 {
+		t.Errorf("expected duration near 2s, got %.3f", secs)
+	}
+}
+
+func TestProbeDurationSeconds_MissingFile(t *testing.T) {
+	b4RequireFFmpeg(t)
+	_, err := ProbeDurationSeconds(context.Background(), "", filepath.Join(t.TempDir(), "does-not-exist.mp3"))
+	if err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestProbeDurationSeconds_MissingFFprobeBinary(t *testing.T) {
+	_, err := ProbeDurationSeconds(context.Background(), filepath.Join(t.TempDir(), "no-such-ffprobe-binary"), "irrelevant.mp3")
+	if err == nil {
+		t.Error("expected an error when the ffprobe binary path does not exist")
+	}
+}
+
+func TestProbeDurationSeconds_UnparseableOutput(t *testing.T) {
+	// Use `true`-like binary substitute: a tiny shell script that prints
+	// non-numeric stdout, to exercise the ParseFloat failure branch without
+	// depending on a real ffprobe build.
+	dir := t.TempDir()
+	fakeProbe := filepath.Join(dir, "fake-ffprobe.sh")
+	script := "#!/bin/sh\necho not-a-number\n"
+	if err := os.WriteFile(fakeProbe, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake probe script: %v", err)
+	}
+	_, err := ProbeDurationSeconds(context.Background(), fakeProbe, filepath.Join(dir, "whatever.mp3"))
+	if err == nil {
+		t.Error("expected a parse error for non-numeric ffprobe output")
+	}
+}
+
+func TestProbeDurationSeconds_ContextTimeout(t *testing.T) {
+	dir := t.TempDir()
+	slowProbe := filepath.Join(dir, "slow-ffprobe.sh")
+	script := "#!/bin/sh\nsleep 5\necho 1.0\n"
+	if err := os.WriteFile(slowProbe, []byte(script), 0o755); err != nil {
+		t.Fatalf("write slow probe script: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := ProbeDurationSeconds(ctx, slowProbe, filepath.Join(dir, "whatever.mp3"))
+	if err == nil {
+		t.Error("expected an error when ctx times out before ffprobe finishes")
+	}
+}

--- a/internal/fingerprint/duration_unify_test.go
+++ b/internal/fingerprint/duration_unify_test.go
@@ -1,0 +1,51 @@
+// file: internal/fingerprint/duration_unify_test.go
+// version: 1.0.0
+// guid: 2d9f6b1c-8a3e-4c7d-b0f5-6e1a9c4d7b28
+// last-edited: 2026-07-18
+
+package fingerprint
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestProbeDuration_UnifiedProbe_RealFixture is a regression test for TODO
+// item 20 / AP-3b (duration-extractor consolidation): fpcalc.go's unexported
+// probeDuration now wraps the shared internal/audioutil.ProbeDurationSeconds
+// (previously it parsed ffprobe's JSON output independently). This proves the
+// reroute still returns the correct float64 seconds for a real audio file —
+// FileSegments relies on this value being seconds (not ms, not rounded) to
+// compute the 7 fingerprint segment offsets.
+func TestProbeDuration_UnifiedProbe_RealFixture(t *testing.T) {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not on PATH — skipping real-audio duration test")
+	}
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "b4-probe-duration.mp3")
+	cmd := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+		"-t", fmt.Sprintf("%d", 6),
+		"-c:a", "libmp3lame",
+		path,
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffmpeg generate fixture: %v", err)
+	}
+
+	dur, err := probeDuration(path)
+	if err != nil {
+		t.Fatalf("probeDuration: %v", err)
+	}
+	if dur < 5.0 || dur > 7.0 {
+		t.Errorf("expected duration near 6.0s (float64 seconds), got %.3f", dur)
+	}
+}

--- a/internal/fingerprint/fpcalc.go
+++ b/internal/fingerprint/fpcalc.go
@@ -1,7 +1,7 @@
 // file: internal/fingerprint/fpcalc.go
-// version: 3.3.0
+// version: 3.4.0
 // guid: b1c2d3e4-f5a6-7b8c-9d0e-1f2a3b4c5d6e
-// last-edited: 2026-06-15
+// last-edited: 2026-07-18
 
 // Package fingerprint generates AcoustID-compatible acoustic fingerprints for
 // audio files. It supports two backends:
@@ -28,6 +28,7 @@ package fingerprint
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -36,6 +37,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
 )
 
 // ErrNotAvailable is returned when neither fpcalc nor ffmpeg is on PATH.
@@ -337,37 +340,15 @@ func ffmpegChromaprintAt(path string, offset float64) (string, error) {
 	return fp, nil
 }
 
-// ffprobeResult is the subset of ffprobe JSON output we need.
-type ffprobeResult struct {
-	Format struct {
-		Duration string `json:"duration"`
-	} `json:"format"`
-}
-
-// probeDuration uses ffprobe to return the audio duration in seconds.
+// probeDuration uses ffprobe to return the audio duration in seconds. This is
+// a thin wrapper over the shared audioutil.ProbeDurationSeconds (also used by
+// internal/mediainfo and internal/transcode — see TODO item 20 / AP-3b); it
+// used to shell out to ffprobe independently via a JSON-parsing path, but that
+// produced the same duration value as the shared plain-text probe, so the
+// duplicate implementation was removed rather than kept as a second source of
+// drift.
 func probeDuration(path string) (float64, error) {
-	var stdout bytes.Buffer
-	cmd := exec.Command("ffprobe",
-		"-v", "error",
-		"-print_format", "json",
-		"-show_format",
-		path,
-	)
-	cmd.Stdout = &stdout
-	cmd.Stderr = nil
-	if err := cmd.Run(); err != nil {
-		return 0, fmt.Errorf("ffprobe %s: %w", path, err)
-	}
-	var r ffprobeResult
-	if err := json.NewDecoder(&stdout).Decode(&r); err != nil {
-		return 0, fmt.Errorf("ffprobe parse %s: %w", path, err)
-	}
-	var dur float64
-	_, err := fmt.Sscanf(r.Format.Duration, "%f", &dur)
-	if err != nil {
-		return 0, fmt.Errorf("ffprobe duration parse %s: %w", path, err)
-	}
-	return dur, nil
+	return audioutil.ProbeDurationSeconds(context.Background(), "", path)
 }
 
 // HammingSimilarity returns the fraction of bits that agree between two

--- a/internal/mediainfo/duration_unify_test.go
+++ b/internal/mediainfo/duration_unify_test.go
@@ -1,0 +1,49 @@
+// file: internal/mediainfo/duration_unify_test.go
+// version: 1.0.0
+// guid: 8c7d1a2e-4f9b-4d6a-9e2c-1a5b7d3e9f04
+// last-edited: 2026-07-18
+
+package mediainfo
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestRealDurationSec_UnifiedProbe_RealFixture is a regression test for TODO
+// item 20 / AP-3b (duration-extractor consolidation): realDurationSec now
+// routes through the shared internal/audioutil.ProbeDurationSeconds instead
+// of shelling out to ffprobe directly. This proves the reroute still returns
+// the correct rounded integer seconds for a real audio file.
+func TestRealDurationSec_UnifiedProbe_RealFixture(t *testing.T) {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not on PATH — skipping real-audio duration test")
+	}
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "b4-real-duration.mp3")
+	cmd := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+		"-t", fmt.Sprintf("%d", 4),
+		"-c:a", "libmp3lame",
+		path,
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffmpeg generate fixture: %v", err)
+	}
+
+	secs, ok := realDurationSec(path)
+	if !ok {
+		t.Fatal("expected ok=true for a real audio fixture")
+	}
+	if secs < 3 || secs > 5 {
+		t.Errorf("expected duration near 4s (int, rounded), got %d", secs)
+	}
+}

--- a/internal/mediainfo/mediainfo.go
+++ b/internal/mediainfo/mediainfo.go
@@ -1,21 +1,21 @@
 // file: internal/mediainfo/mediainfo.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: f1e2d3c4-b5a6-7c8d-9e0f-1a2b3c4d5e6f
+// last-edited: 2026-07-18
 
 package mediainfo
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dhowden/tag"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
 )
 
 // MediaInfo holds technical audio file information
@@ -42,23 +42,14 @@ const ffprobeDurationTimeout = 20 * time.Second
 // realDurationSec reads the TRUE container duration via ffprobe (the stream's own
 // duration, not a filesize estimate). Returns ok=false when ffprobe is missing or
 // the file has no parseable duration, so the caller can fall back to a flagged
-// estimate. ffprobe is resolved from PATH, mirroring internal/diagnosis/probe.go.
+// estimate. ffprobe is resolved from PATH via the shared audioutil.ProbeDurationSeconds
+// (also used by internal/fingerprint and internal/transcode — see TODO item 20 / AP-3b).
 func realDurationSec(filePath string) (int, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), ffprobeDurationTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "ffprobe",
-		"-v", "quiet",
-		"-show_entries", "format=duration",
-		"-of", "default=noprint_wrappers=1:nokey=1",
-		filePath)
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return 0, false // ffprobe missing or failed — caller estimates
-	}
-	secs, err := strconv.ParseFloat(strings.TrimSpace(stdout.String()), 64)
+	secs, err := audioutil.ProbeDurationSeconds(ctx, "", filePath)
 	if err != nil || secs <= 0 {
-		return 0, false
+		return 0, false // ffprobe missing, failed, or unparseable — caller estimates
 	}
 	return int(secs + 0.5), true
 }

--- a/internal/transcode/duration_unify_test.go
+++ b/internal/transcode/duration_unify_test.go
@@ -1,0 +1,93 @@
+// file: internal/transcode/duration_unify_test.go
+// version: 1.0.0
+// guid: 6a1e4c8b-3f7d-4b9e-a2c6-8d0f5b3e7c19
+// last-edited: 2026-07-18
+
+package transcode
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// b4GenSilentMP3 writes a silent mono MP3 of the given duration (seconds) to
+// dir/name via ffmpeg's lavfi anullsrc source.
+func b4GenSilentMP3(t *testing.T, ffmpegPath, dir, name string, seconds int) string {
+	t.Helper()
+	out := filepath.Join(dir, name)
+	cmd := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+		"-t", fmt.Sprintf("%d", seconds),
+		"-c:a", "libmp3lame",
+		out,
+	)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffmpeg generate fixture: %v", err)
+	}
+	return out
+}
+
+// TestProbeDuration_UnifiedProbe_RealFixture and
+// TestProbeFileDuration_UnifiedProbe_RealFixture are regression tests for
+// TODO item 20 / AP-3b (duration-extractor consolidation): both unexported
+// probers in this file now wrap the shared
+// internal/audioutil.ProbeDurationSeconds instead of independently shelling
+// out to ffprobe. probeDuration must keep returning float64 seconds
+// (BuildChapterMetadataWithProber multiplies by 1000 for chapter timestamps)
+// and probeFileDuration must keep returning int64 MICROSECONDS (the transcode
+// progress reporter sums these across input files).
+func TestProbeDuration_UnifiedProbe_RealFixture(t *testing.T) {
+	ffprobePath, err := exec.LookPath("ffprobe")
+	if err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not on PATH — skipping real-audio duration test")
+	}
+
+	dir := t.TempDir()
+	path := b4GenSilentMP3(t, ffmpegPath, dir, "b4-transcode-probe.mp3", 5)
+
+	dur, err := probeDuration(ffprobePath, path)
+	if err != nil {
+		t.Fatalf("probeDuration: %v", err)
+	}
+	if dur < 4.0 || dur > 6.0 {
+		t.Errorf("expected duration near 5.0s (float64 seconds), got %.3f", dur)
+	}
+}
+
+func TestProbeFileDuration_UnifiedProbe_RealFixture(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not on PATH — skipping real-audio duration test")
+	}
+
+	dir := t.TempDir()
+	path := b4GenSilentMP3(t, ffmpegPath, dir, "b4-transcode-probefile.mp3", 5)
+
+	us := probeFileDuration(path)
+	if us < 4_000_000 || us > 6_000_000 {
+		t.Errorf("expected duration near 5,000,000us (int64 microseconds), got %d", us)
+	}
+}
+
+// TestProbeFileDuration_UnifiedProbe_MissingBinary preserves the original
+// best-effort contract: probeFileDuration returns 0 (never an error) when
+// ffprobe cannot be resolved or the probe fails.
+func TestProbeFileDuration_UnifiedProbe_MissingFile(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not on PATH — skipping real-audio duration test")
+	}
+	us := probeFileDuration(filepath.Join(t.TempDir(), "does-not-exist.mp3"))
+	if us != 0 {
+		t.Errorf("expected 0 for a missing file, got %d", us)
+	}
+}

--- a/internal/transcode/transcode.go
+++ b/internal/transcode/transcode.go
@@ -1,14 +1,13 @@
 // file: internal/transcode/transcode.go
-// version: 1.5.2
+// version: 1.6.0
 // guid: f8a1b2c3-d4e5-6789-abcd-ef0123456789
-// last-edited: 2026-07-03
+// last-edited: 2026-07-18
 
 package transcode
 
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 )
@@ -108,31 +108,14 @@ func BuildConcatFile(inputFiles []string) (string, error) {
 	return f.Name(), nil
 }
 
-// probeDuration returns the duration of an audio file in seconds using ffprobe.
+// probeDuration returns the duration of an audio file in seconds using
+// ffprobe. This is a thin wrapper over the shared
+// audioutil.ProbeDurationSeconds (also used by internal/mediainfo and
+// internal/fingerprint — see TODO item 20 / AP-3b); it used to parse ffprobe's
+// JSON output directly, but that produced the same duration value as the
+// shared plain-text probe, so the duplicate implementation was removed.
 func probeDuration(ffprobePath, filePath string) (float64, error) {
-	cmd := exec.Command(ffprobePath,
-		"-v", "quiet",
-		"-print_format", "json",
-		"-show_format",
-		filePath,
-	)
-	output, err := cmd.Output()
-	if err != nil {
-		return 0, fmt.Errorf("ffprobe failed for %s: %w", filePath, err)
-	}
-	var result struct {
-		Format struct {
-			Duration string `json:"duration"`
-		} `json:"format"`
-	}
-	if err := json.Unmarshal(output, &result); err != nil {
-		return 0, fmt.Errorf("failed to parse ffprobe output: %w", err)
-	}
-	dur, err := strconv.ParseFloat(result.Format.Duration, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse duration %q: %w", result.Format.Duration, err)
-	}
-	return dur, nil
+	return audioutil.ProbeDurationSeconds(context.Background(), ffprobePath, filePath)
 }
 
 // BuildChapterMetadata probes each input file and generates an FFMetadata chapter file.
@@ -431,21 +414,17 @@ func Transcode(ctx context.Context, opts TranscodeOpts, store interface {
 }
 
 // probeFileDuration uses ffprobe to get a file's duration in microseconds.
+// Thin wrapper over the shared audioutil.ProbeDurationSeconds (see
+// probeDuration above and TODO item 20 / AP-3b) — converts the shared
+// seconds-float result to this call site's historical microsecond-int64
+// return, and preserves the original best-effort "0 on any failure" contract
+// (no error is surfaced; callers treat 0 as "could not determine").
 func probeFileDuration(filePath string) int64 {
 	ffprobePath, err := exec.LookPath("ffprobe")
 	if err != nil {
 		return 0
 	}
-	out, err := exec.Command(ffprobePath,
-		"-v", "error",
-		"-show_entries", "format=duration",
-		"-of", "default=noprint_wrappers=1:nokey=1",
-		filePath,
-	).Output()
-	if err != nil {
-		return 0
-	}
-	seconds, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+	seconds, err := audioutil.ProbeDurationSeconds(context.Background(), ffprobePath, filePath)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
## Summary

TODO item 20 / AP-3b: "Consolidate the 3 duration extractors into one."

### Findings — the 3 extractors

1. **`internal/mediainfo/mediainfo.go:46` `realDurationSec`** — the scanner's canonical duration source (feeds `BuildFromTag`/`inferFromFormat`, used by `internal/scanner/process_file.go`, `chapter_consolidation.go`, and `internal/plugins/maintenance/duration_reextract.go`). ffprobe, **plain-text** output (`-show_entries format=duration -of default=noprint_wrappers=1:nokey=1`), rounded to **`int` seconds**, `ok bool` on `<=0`/failure, wrapped in a 20s `context.WithTimeout`.
2. **`internal/fingerprint/fpcalc.go:348` `probeDuration`** — used to place the 7 acoustic-fingerprint segment offsets (`FileSegments`) and to fill `Result.Duration` (which feeds `AcoustIDFingerprintDurationSec`). ffprobe, **JSON** output (`-print_format json -show_format`), raw **`float64` seconds** (no rounding — needed for precise segment offsets), no timeout.
3. **`internal/transcode/transcode.go`** — two variants in one file:
   - `probeDuration` (line 112) for chapter-metadata timestamps (`BuildChapterMetadataWithProber`). ffprobe, **JSON** output, raw `float64` seconds, no timeout.
   - `probeFileDuration` (line 434) for transcode progress-bar total duration. ffprobe, **plain-text** output, converted to **`int64` microseconds**, swallows all errors as `0` (no error surfaced).

All three shelled out to ffprobe independently and had drifted in small ways (JSON vs plain-text parsing, `-v quiet` vs `-v error`, timeout vs none, 3 different return types/error contracts) — the same class of duplication behind past duration bugs (CONS-16/17/18, the ms-vs-seconds confusion in `internal/database/duration_sanity.go`).

**Deliberately out of scope:** `internal/diagnosis/probe.go` also reads duration via ffprobe (and via the `mediainfo` CLI as a second source) but only for diagnostic reporting (`FingerprintDiagnosticJSON`) — it is never "the" duration consumed by dedup/display, so it's left untouched. `internal/remux` has no duration-reading logic at all (checked, not a 4th extractor).

### Unification

New `internal/audioutil.ProbeDurationSeconds(ctx, ffprobePath, filePath) (float64, error)` — a single ffprobe subprocess implementation using the plain-text output style (proven equivalent to the JSON style: both read the same `format.duration` field). It does **not** apply rounding or a `<=0` validity check — that's left to each caller, since the callers disagreed on that policy and the task requires preserving each caller's exact behavior.

All three call sites now route through it as thin wrappers:
- `mediainfo.realDurationSec`: calls it inside its existing 20s-timeout context, then keeps its `int(secs+0.5)` rounding and `<=0 → ok=false` check.
- `fingerprint.probeDuration`: calls it with `context.Background()`, returns the raw `float64` unchanged.
- `transcode.probeDuration`: calls it with the caller-supplied `ffprobePath`, returns the raw `float64` unchanged.
- `transcode.probeFileDuration`: calls it, converts to `int64` microseconds, swallows any error to `0` (unchanged contract).

No externally observed duration values or units changed at any call site — this is purely a consolidation of the ffprobe-invocation mechanism.

## Test plan

- [x] `internal/audioutil/duration_test.go` — 6 new tests against `ProbeDurationSeconds` directly, using real silent audio generated via `ffmpeg -f lavfi anullsrc` (no LFS fixture dependency, skips gracefully if ffmpeg/ffprobe absent): real fixture with default/explicit ffprobe path, missing file, missing ffprobe binary, unparseable output, context-timeout cancellation.
- [x] Regression test per rerouted call site proving unit/behavior preserved after the reroute:
  - `internal/mediainfo/duration_unify_test.go` — `realDurationSec` still returns correct rounded `int` seconds.
  - `internal/fingerprint/duration_unify_test.go` — `probeDuration` still returns correct raw `float64` seconds.
  - `internal/transcode/duration_unify_test.go` — `probeDuration` (float64 seconds) and `probeFileDuration` (int64 microseconds, 0-on-missing) both still correct.
- [x] `go build ./...` and `go vet ./...` clean across the whole repo.
- [x] `go test ./internal/scanner/... ./internal/metadata/... ./internal/mediainfo/... ./internal/fingerprint/... ./internal/transcode/... ./internal/audioutil/... -race -count=1` — all pass.
- [x] `go test ./internal/plugins/maintenance/... ./internal/plugins/acoustid/... ./internal/database/... -race -count=1 -short` — all pass (duration-reextract maintenance plugin and AcoustID pipeline, which consume `mediainfo.Extract`/fingerprint duration values, unaffected).
- [x] `gofmt -l` clean on every touched/created file.
- [x] CHANGELOG.md + TODO.md updated (item 20 struck through as DONE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65