### PR TITLE
test(merge): complete MergeService/CombineBooks unit-test coverage (4.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,37 @@
   `internal/fingerprint/duration_unify_test.go`,
   `internal/transcode/duration_unify_test.go`) proving each still returns the
   correct value/unit after the reroute.
+#### July 18, 2026 - test(merge): MergeService/CombineBooks unit-test coverage (4.10)
+
+- **`internal/merge` coverage 70.3% → 96.6%**: 34 new tests covering
+  external-ID (PID/ASIN) reassignment to the merge winner, iTunes ITL-removal
+  enqueue for losers (including filtering out non-itunes and tombstoned
+  mappings), loser soft-delete vs winner survival, the `CombineBooks`
+  nil-override and empty-override wipe-safety guarantee (a combine must never
+  blank Title/Author/Narrator via a partial write), the Title/Narrator/Author
+  override happy paths (including author reuse-vs-create), version-group
+  integrity (exactly one live primary across N books), the merge-family
+  serialization lock helpers (`LockMergeRMW`/`UnlockMergeRMW`), and the
+  `CombineBooks` file-transfer path (`ensureOwnFile`/`attachVirtualFile`,
+  including the #1549 reattach-safe branch) plus its warn-and-continue error
+  paths (failed external-ID reassignment, failed aggregate recompute, failed
+  author lookup/creation/link) and its hard-abort error paths (a book still
+  owning files after a move, a failed file move, a failed delete).
+- **Fixed a genuine bug found while writing the version-group-integrity
+  test**: `Service.MergeBooks` did not de-duplicate its `bookIDs` argument. If
+  a caller passed the primary ID twice (exactly the caller mistake PR #2007
+  / F6-T10 patched, but only at the one call site in
+  `applyBookMergeReroute`), the version-group loop wrote that book's row
+  twice — the second write's index no longer matched `bestIdx`, silently
+  demoting the winner back to `IsPrimaryVersion=false` — while the
+  loser-cleanup loop still skipped both occurrences as "the primary" and
+  never soft-deleted it. Net effect: the winner ended up neither primary nor
+  soft-deleted, and the version group lost its only live primary. Several
+  other callers (e.g. `POST /audiobooks/merge`) pass request-supplied
+  `BookIDs` straight through without de-duping, so this was reachable outside
+  the already-patched caller. Fixed by de-duplicating `bookIDs` at the top of
+  `MergeBooks` itself so every caller is protected regardless of whether it
+  remembers to de-dupe first.
 
 #### July 18, 2026 - fix(logging): H/M observability batch (T05)
 

--- a/TODO.md
+++ b/TODO.md
@@ -162,7 +162,14 @@ Companion docs:
 ## Other / close-out (10)
 
 40. **4.8 — Store ISP sweep** (H1:2787) — ~38-file sweep + 18-file noop cleanup remain.
-41. **4.10 — MergeService mock-store unit tests** (H1:2789) — partial.
+41. ~~**4.10 — MergeService mock-store unit tests** (H1:2789)~~ — DONE: `internal/merge`
+    coverage 70.3%→96.6%. Added 34 tests across external-ID reassignment, ITL-removal
+    enqueue, loser soft-delete, nil/empty-override wipe-safety, version-group integrity
+    (incl. a real bug found: `MergeBooks` didn't de-dupe `bookIDs`, so a caller passing
+    the primary twice — the exact class PR #2007 patched only at one caller — silently
+    demoted the winner to non-primary with no soft-delete; fixed defensively in
+    `Service.MergeBooks` itself), CombineBooks file-transfer/author-override error paths,
+    and the merge-family serialization lock helpers.
 42. **2026-05-01 re-audit block close-out pass** (H1:3137-3177) — TEST-2, DEP-1a-e,
     DEAD-1, CTX-4, LOG-5, R-9, R-10 mostly stale: DEP-1 0 non-test hits, DEP-1e moot
     (post-SQLite removal), PERF-1 OBSOLETE as scoped (Jul-16 truncation fix made

--- a/docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md
+++ b/docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 2f8a6c34-9b71-4d02-8e15-3a7c0d5e9b46 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -42,3 +42,20 @@ The fix ships with tests that merge books on a real database and confirm the
 dropped entry is retired (not erased), its iTunes link now resolves to the kept
 entry, its listening stats moved across, and the kept entry can never be
 accidentally deleted or demoted when it appears on both sides of a merge.
+
+## Follow-up: the same-day fix only protected the one button that had it
+
+The "listed on both sides of the merge" guard above was added at the call site
+for the duplicate-merge button (it de-duplicates before handing the list to the
+shared merge engine). A same-day pass writing exhaustive tests for that shared
+merge engine confirmed the engine itself had no equivalent guard — so every
+*other* place in the app that also uses it (the main "merge these books"
+button, an automatic dedup-resolution job, and others) was still exposed to the
+identical bug: asking to keep a book that also appears elsewhere in the list
+being merged could silently leave that book neither the kept copy nor the
+retired one — invisible in the version history and not shown in search either
+way.
+
+This was caught by a test, not by a user report, and is now fixed inside the
+shared merge engine itself, so every caller is protected the same way going
+forward regardless of whether it remembers to filter the list first.

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,7 +1,7 @@
 // file: internal/merge/service.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
-// last-edited: 2026-07-16
+// last-edited: 2026-07-18
 
 package merge
 
@@ -97,6 +97,32 @@ func NewService(db database.Store) *Service {
 // preferred, then highest bitrate, then largest file).
 // If primaryID is provided, that book is set as the primary.
 func (ms *Service) MergeBooks(bookIDs []string, primaryID string) (*Result, error) {
+	// De-duplicate the incoming ID list before anything else. Every current
+	// caller either de-dupes itself or trusts a request body (e.g. the
+	// /audiobooks/merge handler passes req.BookIDs straight through) — if
+	// duplicate IDs reach here, the version-group loop below writes that
+	// book's row twice, and the LAST write wins. A duplicated primary would
+	// get its own IsPrimaryVersion=true immediately overwritten back to
+	// false by its second occurrence, while the loser-cleanup loop (which
+	// skips only book.ID == resolvedPrimaryID) still treats both occurrences
+	// as "the primary" and never soft-deletes it — leaving the book neither
+	// primary nor soft-deleted, and the version group with NO live primary.
+	// This is the exact corruption class applyBookMergeReroute (#2007 /
+	// F6-T10) already guards against by de-duping before calling in, but that
+	// guard lived only at that one caller; enforcing it here protects every
+	// caller, present and future, regardless of whether it remembers to
+	// de-dupe first.
+	seen := make(map[string]bool, len(bookIDs))
+	deduped := make([]string, 0, len(bookIDs))
+	for _, id := range bookIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		deduped = append(deduped, id)
+	}
+	bookIDs = deduped
+
 	if len(bookIDs) < 2 {
 		return nil, fmt.Errorf("need at least 2 book IDs to merge")
 	}

--- a/internal/merge/service_b3_fault_test.go
+++ b/internal/merge/service_b3_fault_test.go
@@ -1,0 +1,488 @@
+// file: internal/merge/service_b3_fault_test.go
+// version: 1.0.0
+// guid: 9c1d3e7a-4b6f-4a2d-8c5e-1f0a3b7d9e42
+// last-edited: 2026-07-18
+
+package merge
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// b3FaultStore wraps a real database.Store and lets a test force specific
+// methods to fail (or return a fixed value), while delegating everything
+// else to the embedded store. A real PebbleStore's writes don't fail under
+// normal test conditions, so this is how the warn-and-continue /
+// abort-with-error branches in MergeBooks and CombineBooks that depend on a
+// store call failing get exercised without hand-rolling a full mock
+// expectation sequence for the whole read-modify-write.
+type b3FaultStore struct {
+	database.Store
+
+	failReassignExternalIDsFor map[string]bool
+	failMoveBookFilesToBookFor map[string]bool
+	failDeleteBookFor          map[string]bool
+	failRecomputeAggregates    bool
+	failUpdateBook             bool
+	failGetAuthorByName        bool
+	failCreateAuthor           bool
+	failSetBookAuthors         bool
+	failCreateBookFile         bool
+
+	// stickyFilesFor forces GetBookFiles(id) to always report a fixed
+	// non-empty file list for id, regardless of the underlying store's real
+	// state — used to simulate the "book still owns files after move" guard.
+	stickyFilesFor map[string][]database.BookFile
+
+	// vanishAfterFirstGet makes GetBookByID(id) return (nil, nil) starting
+	// on the SECOND call for this id (the first call — validation — still
+	// sees the real book).
+	vanishAfterFirstGet string
+	getCount            map[string]int
+
+	// failGetBookByIDAfterFirstFor makes GetBookByID(id) return an error for
+	// id starting on its SECOND call — the first call is MergeBooks' own
+	// initial fetch (must succeed so the merge proceeds); the second is
+	// SoftDeleteBook's own re-fetch inside the loser-cleanup loop, which is
+	// the call this is meant to fail.
+	failGetBookByIDAfterFirstFor map[string]bool
+}
+
+func (f *b3FaultStore) GetBookByID(id string) (*database.Book, error) {
+	if f.failGetBookByIDAfterFirstFor[id] {
+		if f.getCount == nil {
+			f.getCount = map[string]int{}
+		}
+		f.getCount[id]++
+		if f.getCount[id] > 1 {
+			return nil, fmt.Errorf("b3 injected GetBookByID failure")
+		}
+		return f.Store.GetBookByID(id)
+	}
+	if f.vanishAfterFirstGet == id {
+		if f.getCount == nil {
+			f.getCount = map[string]int{}
+		}
+		f.getCount[id]++
+		if f.getCount[id] > 1 {
+			return nil, nil
+		}
+	}
+	return f.Store.GetBookByID(id)
+}
+
+func (f *b3FaultStore) GetBookFiles(id string) ([]database.BookFile, error) {
+	if files, ok := f.stickyFilesFor[id]; ok {
+		return files, nil
+	}
+	return f.Store.GetBookFiles(id)
+}
+
+func (f *b3FaultStore) ReassignExternalIDs(oldID, newID string) error {
+	if f.failReassignExternalIDsFor[oldID] {
+		return fmt.Errorf("b3 injected ReassignExternalIDs failure")
+	}
+	return f.Store.ReassignExternalIDs(oldID, newID)
+}
+
+func (f *b3FaultStore) MoveBookFilesToBook(fileIDs []string, sourceBookID, targetBookID string) error {
+	if f.failMoveBookFilesToBookFor[sourceBookID] {
+		return fmt.Errorf("b3 injected MoveBookFilesToBook failure")
+	}
+	return f.Store.MoveBookFilesToBook(fileIDs, sourceBookID, targetBookID)
+}
+
+func (f *b3FaultStore) DeleteBook(id string) error {
+	if f.failDeleteBookFor[id] {
+		return fmt.Errorf("b3 injected DeleteBook failure")
+	}
+	return f.Store.DeleteBook(id)
+}
+
+func (f *b3FaultStore) RecomputeBookAggregates(bookID string) error {
+	if f.failRecomputeAggregates {
+		return fmt.Errorf("b3 injected RecomputeBookAggregates failure")
+	}
+	return f.Store.RecomputeBookAggregates(bookID)
+}
+
+func (f *b3FaultStore) UpdateBook(id string, b *database.Book) (*database.Book, error) {
+	if f.failUpdateBook {
+		return nil, fmt.Errorf("b3 injected UpdateBook failure")
+	}
+	return f.Store.UpdateBook(id, b)
+}
+
+func (f *b3FaultStore) GetAuthorByName(name string) (*database.Author, error) {
+	if f.failGetAuthorByName {
+		return nil, fmt.Errorf("b3 injected GetAuthorByName failure")
+	}
+	return f.Store.GetAuthorByName(name)
+}
+
+func (f *b3FaultStore) CreateAuthor(name string) (*database.Author, error) {
+	if f.failCreateAuthor {
+		return nil, fmt.Errorf("b3 injected CreateAuthor failure")
+	}
+	return f.Store.CreateAuthor(name)
+}
+
+func (f *b3FaultStore) SetBookAuthors(bookID string, authors []database.BookAuthor) error {
+	if f.failSetBookAuthors {
+		return fmt.Errorf("b3 injected SetBookAuthors failure")
+	}
+	return f.Store.SetBookAuthors(bookID, authors)
+}
+
+func (f *b3FaultStore) CreateBookFile(file *database.BookFile) error {
+	if f.failCreateBookFile {
+		return fmt.Errorf("b3 injected CreateBookFile failure")
+	}
+	return f.Store.CreateBookFile(file)
+}
+
+// ---------- MergeBooks warn-and-continue branches ----------
+
+func TestB3_MergeBooks_ReassignExternalIDsError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+	fault := &b3FaultStore{Store: real}
+
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3reid-loser.mp3"}
+	winner := &database.Book{ID: ulid.Make().String(), Title: "Winner", Format: "m4b", FilePath: "/tmp/b3reid-winner.m4b"}
+	_, err := real.CreateBook(loser)
+	require.NoError(t, err)
+	_, err = real.CreateBook(winner)
+	require.NoError(t, err)
+
+	fault.failReassignExternalIDsFor = map[string]bool{loser.ID: true}
+
+	ms := NewService(fault)
+	result, err := ms.MergeBooks([]string{loser.ID, winner.ID}, winner.ID)
+	require.NoError(t, err, "a failed external-id reassignment must not fail the whole merge")
+	assert.Equal(t, winner.ID, result.PrimaryID)
+
+	// The loser is still soft-deleted despite the reassignment failure.
+	l, err := real.GetBookByID(loser.ID)
+	require.NoError(t, err)
+	require.NotNil(t, l.MarkedForDeletion)
+	assert.True(t, *l.MarkedForDeletion)
+}
+
+func TestB3_MergeBooks_SoftDeleteError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+	fault := &b3FaultStore{Store: real}
+
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3sderr-loser.mp3"}
+	winner := &database.Book{ID: ulid.Make().String(), Title: "Winner", Format: "m4b", FilePath: "/tmp/b3sderr-winner.m4b"}
+	_, err := real.CreateBook(loser)
+	require.NoError(t, err)
+	_, err = real.CreateBook(winner)
+	require.NoError(t, err)
+
+	// SoftDeleteBook's own GetBookByID re-fetch fails, so it can't even
+	// attempt the fallback hard delete's read step.
+	fault.failGetBookByIDAfterFirstFor = map[string]bool{loser.ID: true}
+
+	ms := NewService(fault)
+	result, err := ms.MergeBooks([]string{loser.ID, winner.ID}, winner.ID)
+	require.NoError(t, err, "a failed soft-delete must be warned, not fail the whole merge")
+	assert.Equal(t, winner.ID, result.PrimaryID)
+
+	w, err := real.GetBookByID(winner.ID)
+	require.NoError(t, err)
+	require.NotNil(t, w.IsPrimaryVersion)
+	assert.True(t, *w.IsPrimaryVersion, "winner must still be primary")
+}
+
+// ---------- CombineBooks warn-and-continue / abort branches ----------
+
+func TestB3_CombineBooks_BookVanishesBetweenValidateAndProcess_SkippedGracefully(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3vanish-survivor.mp3"}
+	ghost := &database.Book{ID: ulid.Make().String(), Title: "Ghost", Format: "mp3", FilePath: "/tmp/b3vanish-ghost.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(ghost)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, vanishAfterFirstGet: ghost.ID}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, ghost.ID}, survivor.ID, nil)
+	require.NoError(t, err, "a book vanishing mid-combine must be skipped, not fail the whole combine")
+	assert.Equal(t, 0, res.BooksDeleted, "the vanished book was never processed, so nothing was deleted")
+
+	// The ghost book is untouched (never deleted, still real in the store —
+	// our fault store only faked ITS OWN second GetBookByID return, the real
+	// store still has the row).
+	g, err := real.GetBookByID(ghost.ID)
+	require.NoError(t, err)
+	require.NotNil(t, g, "the real store never actually lost the book")
+}
+
+func TestB3_CombineBooks_MoveBookFilesToBookError(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3moveerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3moveerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+	require.NoError(t, real.CreateBookFile(&database.BookFile{
+		ID: ulid.Make().String(), BookID: loser.ID, FilePath: loser.FilePath, Format: "mp3",
+	}))
+
+	fault := &b3FaultStore{Store: real, failMoveBookFilesToBookFor: map[string]bool{loser.ID: true}}
+	ms := NewService(fault)
+
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "move files")
+
+	// Aborted before delete: the loser must still exist.
+	l, err := real.GetBookByID(loser.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, l, "loser must not be deleted when the file move failed")
+}
+
+func TestB3_CombineBooks_ReassignExternalIDsError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3creid-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3creid-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failReassignExternalIDsFor: map[string]bool{loser.ID: true}}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.NoError(t, err, "a failed external-id reassignment must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+
+	l, err := real.GetBookByID(loser.ID)
+	require.NoError(t, err)
+	assert.Nil(t, l, "loser is still deleted despite the reassignment warning")
+}
+
+func TestB3_CombineBooks_FilesRemainingAfterMove_AbortsDelete(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3remain-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3remain-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+	loserFile := database.BookFile{ID: ulid.Make().String(), BookID: loser.ID, FilePath: loser.FilePath, Format: "mp3"}
+	require.NoError(t, real.CreateBookFile(&loserFile))
+
+	// Force GetBookFiles(loser.ID) to always report the file is still there,
+	// even after the real MoveBookFilesToBook call succeeds — simulating a
+	// phantom stuck file so the "still owns files after move" guard fires.
+	fault := &b3FaultStore{Store: real, stickyFilesFor: map[string][]database.BookFile{loser.ID: {loserFile}}}
+	ms := NewService(fault)
+
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still owns")
+	assert.Contains(t, err.Error(), "aborting delete")
+
+	l, err := real.GetBookByID(loser.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, l, "the guard must abort BEFORE DeleteBook runs")
+}
+
+func TestB3_CombineBooks_DeleteBookError(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3delerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3delerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failDeleteBookFor: map[string]bool{loser.ID: true}}
+	ms := NewService(fault)
+
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete absorbed book")
+}
+
+func TestB3_CombineBooks_RecomputeAggregatesError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/b3aggerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3aggerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failRecomputeAggregates: true}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.NoError(t, err, "a failed aggregate recompute must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+}
+
+// ---------- CombineBooks override error branches ----------
+
+func TestB3_CombineBooks_OverrideUpdateBookError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Old Title", Format: "mp3", FilePath: "/tmp/b3ovupderr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3ovupderr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	// UpdateBook is only reached from the override block in CombineBooks
+	// (the main move/delete loop never calls it), so failing it always
+	// exercises BOTH warn branches: the title/narrator write and the
+	// author-backward-compat AuthorID write.
+	fault := &b3FaultStore{Store: real, failUpdateBook: true}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID,
+		&CombineOverride{Title: "New Title", Author: "Some New Author"})
+	require.NoError(t, err, "a failed override write must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+
+	fresh, err := real.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Old Title", fresh.Title, "the override write failed, so the title must be unchanged")
+}
+
+func TestB3_CombineBooks_OverrideGetAuthorByNameError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "T", Format: "mp3", FilePath: "/tmp/b3ovganerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3ovganerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failGetAuthorByName: true}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Author: "Whoever"})
+	require.NoError(t, err, "a failed author lookup must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+
+	fresh, err := real.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Nil(t, fresh.AuthorID, "author lookup failed, so no author should have been linked")
+}
+
+func TestB3_CombineBooks_OverrideCreateAuthorError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "T", Format: "mp3", FilePath: "/tmp/b3ovcaerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3ovcaerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failCreateAuthor: true}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Author: "Brand New"})
+	require.NoError(t, err, "a failed author creation must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+
+	fresh, err := real.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Nil(t, fresh.AuthorID, "author creation failed, so no author should have been linked")
+}
+
+func TestB3_CombineBooks_OverrideSetBookAuthorsError_StillSetsAuthorID(t *testing.T) {
+	real := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "T", Format: "mp3", FilePath: "/tmp/b3ovsbaerr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3ovsbaerr-loser.mp3"}
+	_, err := real.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = real.CreateBook(loser)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failSetBookAuthors: true}
+	ms := NewService(fault)
+
+	res, err := ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Author: "Reaches Fallback"})
+	require.NoError(t, err, "a failed SetBookAuthors must not fail the whole combine")
+	assert.Equal(t, 1, res.BooksDeleted)
+
+	// SetBookAuthors failing does not gate the backward-compat AuthorID
+	// write on the book row — the two are independent.
+	fresh, err := real.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fresh.AuthorID, "book-row AuthorID should still be set even though SetBookAuthors failed")
+
+	author, err := real.GetAuthorByName("Reaches Fallback")
+	require.NoError(t, err)
+	require.NotNil(t, author)
+	assert.Equal(t, author.ID, *fresh.AuthorID)
+}
+
+// ---------- attachVirtualFile error branches (unexported helper) ----------
+
+func TestB3_AttachVirtualFile_MoveBookFilesToBookError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	strayOwner := &database.Book{ID: ulid.Make().String(), Title: "Stray", FilePath: "/tmp/b3avmoveerr-stray.mp3"}
+	target := &database.Book{ID: ulid.Make().String(), Title: "Target", FilePath: "/tmp/b3avmoveerr-shared.mp3"}
+	_, err := real.CreateBook(strayOwner)
+	require.NoError(t, err)
+	_, err = real.CreateBook(target)
+	require.NoError(t, err)
+	require.NoError(t, real.CreateBookFile(&database.BookFile{
+		ID: ulid.Make().String(), BookID: strayOwner.ID, FilePath: target.FilePath, Format: "mp3",
+	}))
+
+	fault := &b3FaultStore{Store: real, failMoveBookFilesToBookFor: map[string]bool{strayOwner.ID: true}}
+	ms := NewService(fault)
+
+	n := ms.attachVirtualFile(target, target.ID)
+	assert.Equal(t, 0, n, "a failed reattach move must be warned and return 0, not panic")
+
+	// The stray file is still owned by its original book — the move never
+	// actually happened.
+	strayFiles, err := real.GetBookFiles(strayOwner.ID)
+	require.NoError(t, err)
+	assert.Len(t, strayFiles, 1)
+}
+
+func TestB3_AttachVirtualFile_CreateBookFileError_NonFatal(t *testing.T) {
+	real := setupTestStore(t)
+
+	b := &database.Book{ID: ulid.Make().String(), Title: "No existing row", FilePath: "/tmp/b3avcreateerr.mp3"}
+	_, err := real.CreateBook(b)
+	require.NoError(t, err)
+
+	fault := &b3FaultStore{Store: real, failCreateBookFile: true}
+	ms := NewService(fault)
+
+	n := ms.attachVirtualFile(b, b.ID)
+	assert.Equal(t, 0, n, "a failed CreateBookFile must be warned and return 0, not panic")
+
+	files, err := real.GetBookFiles(b.ID)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}

--- a/internal/merge/service_b3_misc_test.go
+++ b/internal/merge/service_b3_misc_test.go
@@ -1,0 +1,84 @@
+// file: internal/merge/service_b3_misc_test.go
+// version: 1.0.0
+// guid: 2f8b6d1c-5e9a-4c3f-8b7d-0a1e2c4f6d8b
+// last-edited: 2026-07-18
+
+package merge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestB3_AsExternalIDReassigner_Nil covers the s == nil branch: passing a
+// literal nil (not a typed-nil store) must return nil, not panic on the
+// type assertion.
+func TestB3_AsExternalIDReassigner_Nil(t *testing.T) {
+	assert.Nil(t, AsExternalIDReassigner(nil))
+}
+
+// b3NotAReassigner is any concrete type that does NOT implement
+// ExternalIDReassigner, to exercise AsExternalIDReassigner's failed
+// type-assertion branch.
+type b3NotAReassigner struct{}
+
+// TestB3_AsExternalIDReassigner_NotImplementing covers the case where the
+// argument is non-nil but does not implement ReassignExternalIDs.
+func TestB3_AsExternalIDReassigner_NotImplementing(t *testing.T) {
+	assert.Nil(t, AsExternalIDReassigner(&b3NotAReassigner{}))
+	assert.Nil(t, AsExternalIDReassigner("just a string"))
+}
+
+// TestB3_SetWriteBackBatcher_Wires verifies the setter actually assigns the
+// unexported field (exercised indirectly via a merge that has a PID to
+// enqueue — the batcher-not-nil branch is separately covered by
+// TestB3_MergeBooks_ITunesPIDCollectionAndITLEnqueue, so here we only check
+// that a nil batcher is a legal no-op set, matching the "itunes-disabled"
+// PostInit path documented on lifecycle.go).
+func TestB3_SetWriteBackBatcher_NilIsLegalNoOp(t *testing.T) {
+	ms := NewService(nil)
+	assert.NotPanics(t, func() { ms.SetWriteBackBatcher(nil) })
+}
+
+// TestB3_LockUnlockMergeRMW_RoundTrips exercises the exported
+// LockMergeRMW/UnlockMergeRMW pair used by dedup.MergeBooks to share the
+// package-level merge serialization lock. A bare lock/unlock round trip
+// must not deadlock or panic, and must leave the lock available for the
+// next acquirer (proven by acquiring it again afterward).
+func TestB3_LockUnlockMergeRMW_RoundTrips(t *testing.T) {
+	LockMergeRMW()
+	UnlockMergeRMW()
+
+	// If Unlock didn't actually release it, this second Lock would hang
+	// forever and the test would time out rather than fail cleanly — that's
+	// an acceptable signal for a mutex round-trip test.
+	LockMergeRMW()
+	UnlockMergeRMW()
+}
+
+// TestB3_QuickHash_ComputesStableHash covers collision.go's QuickHash: same
+// content hashes the same, different content hashes differently.
+func TestB3_QuickHash_ComputesStableHash(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.bin")
+	pathB := filepath.Join(dir, "b.bin")
+	require.NoError(t, os.WriteFile(pathA, []byte("b3 same content"), 0o644))
+	require.NoError(t, os.WriteFile(pathB, []byte("b3 different content"), 0o644))
+
+	hashA1 := QuickHash(pathA)
+	hashA2 := QuickHash(pathA)
+	hashB := QuickHash(pathB)
+
+	assert.NotEmpty(t, hashA1)
+	assert.Equal(t, hashA1, hashA2, "hashing the same file twice must be stable")
+	assert.NotEqual(t, hashA1, hashB, "different content must hash differently")
+}
+
+// TestB3_QuickHash_MissingFile_ReturnsEmpty covers the os.Open error branch.
+func TestB3_QuickHash_MissingFile_ReturnsEmpty(t *testing.T) {
+	assert.Empty(t, QuickHash(filepath.Join(t.TempDir(), "does-not-exist.bin")))
+}

--- a/internal/merge/service_b3_realstore_test.go
+++ b/internal/merge/service_b3_realstore_test.go
@@ -1,0 +1,463 @@
+// file: internal/merge/service_b3_realstore_test.go
+// version: 1.0.0
+// guid: 6a2f9e14-3c7b-4d8a-9e10-b8f2a5c6d7e1
+// last-edited: 2026-07-18
+
+package merge
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/database/dbtest"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// b3FakeEnqueuer is a minimal WriteBackEnqueuer that just records every PID
+// it was asked to remove, so tests can assert the ITL-cleanup enqueue call
+// (MergeBooks step 3 in the doc comment) actually fires with the right PIDs.
+type b3FakeEnqueuer struct {
+	removed []string
+}
+
+func (f *b3FakeEnqueuer) EnqueueRemove(pid string) { f.removed = append(f.removed, pid) }
+
+// TestB3_MergeBooks_ITunesPIDCollectionAndITLEnqueue drives the full loser
+// cleanup sequence on a real store: the loser's iTunes PID is collected
+// BEFORE reassignment, external IDs move to the winner, and the collected
+// PID is enqueued for ITL removal via the batcher. A non-itunes / tombstoned
+// mapping on the loser must NOT be enqueued.
+func TestB3_MergeBooks_ITunesPIDCollectionAndITLEnqueue(t *testing.T) {
+	store := setupTestStore(t)
+
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3loser.mp3"}
+	winner := &database.Book{ID: ulid.Make().String(), Title: "Winner", Format: "m4b", FilePath: "/tmp/b3winner.m4b"}
+	_, err := store.CreateBook(loser)
+	require.NoError(t, err)
+	_, err = store.CreateBook(winner)
+	require.NoError(t, err)
+
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: "B3-PID-LIVE", BookID: loser.ID,
+	}))
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "audible", ExternalID: "B3-ASIN-1", BookID: loser.ID,
+	}))
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: "B3-PID-TOMBSTONED", BookID: loser.ID, Tombstoned: true,
+	}))
+
+	enq := &b3FakeEnqueuer{}
+	ms := NewService(store)
+	ms.SetWriteBackBatcher(enq)
+
+	result, err := ms.MergeBooks([]string{loser.ID, winner.ID}, winner.ID)
+	require.NoError(t, err)
+	assert.Equal(t, winner.ID, result.PrimaryID)
+
+	// Only the live itunes PID is enqueued for ITL removal — not the audible
+	// ASIN, and not the tombstoned itunes mapping.
+	assert.Equal(t, []string{"B3-PID-LIVE"}, enq.removed)
+
+	// External IDs (both itunes and audible) are reassigned to the winner.
+	mappings, err := store.GetExternalIDsForBook(winner.ID)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, m := range mappings {
+		got[m.ExternalID] = true
+	}
+	assert.True(t, got["B3-PID-LIVE"], "live itunes PID reassigned to winner")
+	assert.True(t, got["B3-ASIN-1"], "audible ASIN reassigned to winner")
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestB3_MergeBooks_NoWriteBackBatcher_SkipsEnqueueSilently verifies the
+// documented best-effort behavior: a nil writeBackBatcher (e.g. iTunes
+// write-back disabled) must not panic and must not block the merge.
+func TestB3_MergeBooks_NoWriteBackBatcher_SkipsEnqueueSilently(t *testing.T) {
+	store := setupTestStore(t)
+
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3nobatch-loser.mp3"}
+	winner := &database.Book{ID: ulid.Make().String(), Title: "Winner", Format: "m4b", FilePath: "/tmp/b3nobatch-winner.m4b"}
+	_, err := store.CreateBook(loser)
+	require.NoError(t, err)
+	_, err = store.CreateBook(winner)
+	require.NoError(t, err)
+	require.NoError(t, store.CreateExternalIDMapping(&database.ExternalIDMapping{
+		Source: "itunes", ExternalID: "B3-PID-NOBATCH", BookID: loser.ID,
+	}))
+
+	ms := NewService(store) // writeBackBatcher left nil
+	result, err := ms.MergeBooks([]string{loser.ID, winner.ID}, winner.ID)
+	require.NoError(t, err)
+	assert.Equal(t, winner.ID, result.PrimaryID)
+}
+
+// TestB3_MergeBooks_DuplicatePrimaryInBookIDs_NoDoublePrimary is a
+// regression lock for the class of bug PR #2007 fixed at the caller layer
+// (applyBookMergeReroute failing to exclude keepID from the loser set
+// before F6/T10). Even if a malformed bookIDs list includes the primary
+// twice, MergeBooks itself must still produce exactly one live primary and
+// must not soft-delete the winner.
+func TestB3_MergeBooks_DuplicatePrimaryInBookIDs_NoDoublePrimary(t *testing.T) {
+	store := setupTestStore(t)
+
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3dup-loser.mp3"}
+	winner := &database.Book{ID: ulid.Make().String(), Title: "Winner", Format: "m4b", FilePath: "/tmp/b3dup-winner.m4b"}
+	_, err := store.CreateBook(loser)
+	require.NoError(t, err)
+	_, err = store.CreateBook(winner)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	// winner.ID appears twice — as itself and (erroneously) as if it were
+	// also a loser to merge into itself.
+	result, err := ms.MergeBooks([]string{loser.ID, winner.ID, winner.ID}, winner.ID)
+	require.NoError(t, err)
+	assert.Equal(t, winner.ID, result.PrimaryID)
+
+	w, err := store.GetBookByID(winner.ID)
+	require.NoError(t, err)
+	require.NotNil(t, w.IsPrimaryVersion)
+	assert.True(t, *w.IsPrimaryVersion, "winner must still be primary")
+	if w.MarkedForDeletion != nil {
+		assert.False(t, *w.MarkedForDeletion, "winner must NOT be soft-deleted despite appearing twice in bookIDs")
+	}
+
+	l, err := store.GetBookByID(loser.ID)
+	require.NoError(t, err)
+	require.NotNil(t, l.MarkedForDeletion)
+	assert.True(t, *l.MarkedForDeletion, "the real loser is still soft-deleted")
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestB3_MergeBooks_ThreeBooks_ExactlyOnePrimary locks the version-group
+// integrity invariant for the N>2 case: exactly one book ends up primary,
+// the rest are all soft-deleted losers sharing the same version group.
+func TestB3_MergeBooks_ThreeBooks_ExactlyOnePrimary(t *testing.T) {
+	store := setupTestStore(t)
+
+	var ids []string
+	for i, format := range []string{"mp3", "mp3", "m4b"} {
+		b := &database.Book{
+			ID:       ulid.Make().String(),
+			Title:    "Three-way dup",
+			Format:   format,
+			FilePath: "/tmp/b3three-" + ulid.Make().String() + "." + format,
+		}
+		_, err := store.CreateBook(b)
+		require.NoError(t, err)
+		ids = append(ids, b.ID)
+		_ = i
+	}
+
+	ms := NewService(store)
+	result, err := ms.MergeBooks(ids, "")
+	require.NoError(t, err)
+
+	primaryCount := 0
+	var groupIDs []string
+	for _, id := range ids {
+		b, err := store.GetBookByID(id)
+		require.NoError(t, err)
+		require.NotNil(t, b.IsPrimaryVersion)
+		if *b.IsPrimaryVersion {
+			primaryCount++
+			if b.MarkedForDeletion != nil {
+				assert.False(t, *b.MarkedForDeletion, "primary must not be soft-deleted")
+			}
+		} else {
+			require.NotNil(t, b.MarkedForDeletion)
+			assert.True(t, *b.MarkedForDeletion, "non-primary must be soft-deleted")
+		}
+		require.NotNil(t, b.VersionGroupID)
+		groupIDs = append(groupIDs, *b.VersionGroupID)
+	}
+	assert.Equal(t, 1, primaryCount, "exactly one book must be primary")
+	assert.Equal(t, result.PrimaryID, ids[2], "the m4b should auto-win")
+	for _, g := range groupIDs {
+		assert.Equal(t, groupIDs[0], g, "all books must share one version group")
+	}
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// ---------- CombineBooks validation branches ----------
+
+func TestB3_CombineBooks_PrimaryNotFound(t *testing.T) {
+	store := setupTestStore(t)
+	a := &database.Book{ID: ulid.Make().String(), Title: "A", Format: "mp3", FilePath: "/tmp/b3pnf-a.mp3"}
+	_, err := store.CreateBook(a)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{a.ID, "b3-ghost-primary"}, "b3-ghost-primary", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestB3_CombineBooks_DuplicateBookID(t *testing.T) {
+	store := setupTestStore(t)
+	a := &database.Book{ID: ulid.Make().String(), Title: "A", Format: "mp3", FilePath: "/tmp/b3dupid-a.mp3"}
+	b := &database.Book{ID: ulid.Make().String(), Title: "B", Format: "mp3", FilePath: "/tmp/b3dupid-b.mp3"}
+	_, err := store.CreateBook(a)
+	require.NoError(t, err)
+	_, err = store.CreateBook(b)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{a.ID, b.ID, a.ID}, a.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate book id")
+}
+
+func TestB3_CombineBooks_BookIDNotFound(t *testing.T) {
+	store := setupTestStore(t)
+	a := &database.Book{ID: ulid.Make().String(), Title: "A", Format: "mp3", FilePath: "/tmp/b3idnf-a.mp3"}
+	_, err := store.CreateBook(a)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{a.ID, "b3-ghost-member"}, a.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "b3-ghost-member")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---------- CombineBooks override: nil-override wipe-safety ----------
+
+// TestB3_CombineBooks_NilOverride_DoesNotWipeSurvivorMetadata is the
+// explicit nil-override wipe-safety regression test: a combine performed
+// with override == nil must leave the survivor's existing Title/Author/
+// Narrator completely untouched. CombineBooks must never fall back to a
+// blanket UpdateBook(survivor) that would zero out fields the caller didn't
+// intend to change.
+func TestB3_CombineBooks_NilOverride_DoesNotWipeSurvivorMetadata(t *testing.T) {
+	store := setupTestStore(t)
+
+	author, err := store.CreateAuthor("B3 Original Author")
+	require.NoError(t, err)
+
+	narrator := "B3 Original Narrator"
+	survivor := &database.Book{
+		ID:       ulid.Make().String(),
+		Title:    "B3 Original Title",
+		Format:   "mp3",
+		FilePath: "/tmp/b3nilov-survivor.mp3",
+		AuthorID: &author.ID,
+		Narrator: &narrator,
+	}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3nilov-loser.mp3"}
+	_, err = store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, nil)
+	require.NoError(t, err)
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "B3 Original Title", fresh.Title, "nil override must not touch Title")
+	require.NotNil(t, fresh.Narrator)
+	assert.Equal(t, "B3 Original Narrator", *fresh.Narrator, "nil override must not touch Narrator")
+	require.NotNil(t, fresh.AuthorID)
+	assert.Equal(t, author.ID, *fresh.AuthorID, "nil override must not touch AuthorID")
+
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestB3_CombineBooks_EmptyOverride_DoesNotWipeSurvivorMetadata covers the
+// sibling case: override is a non-nil *CombineOverride with every field left
+// as the zero value. The "any non-empty field" guard must treat this
+// identically to nil — no UpdateBook call, no field wiped.
+func TestB3_CombineBooks_EmptyOverride_DoesNotWipeSurvivorMetadata(t *testing.T) {
+	store := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "B3 Keep Me", Format: "mp3", FilePath: "/tmp/b3emptyov-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3emptyov-loser.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{})
+	require.NoError(t, err)
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "B3 Keep Me", fresh.Title)
+}
+
+func TestB3_CombineBooks_OverrideTitleOnly(t *testing.T) {
+	store := setupTestStore(t)
+
+	narrator := "Keep This Narrator"
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Old Title", Format: "mp3", FilePath: "/tmp/b3title-survivor.mp3", Narrator: &narrator}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3title-loser.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Title: "New Title"})
+	require.NoError(t, err)
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "New Title", fresh.Title)
+	require.NotNil(t, fresh.Narrator)
+	assert.Equal(t, "Keep This Narrator", *fresh.Narrator, "omitted override field must not be wiped")
+}
+
+func TestB3_CombineBooks_OverrideNarratorOnly(t *testing.T) {
+	store := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Keep This Title", Format: "mp3", FilePath: "/tmp/b3narr-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3narr-loser.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Narrator: "New Narrator"})
+	require.NoError(t, err)
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Keep This Title", fresh.Title, "omitted override field must not be wiped")
+	require.NotNil(t, fresh.Narrator)
+	assert.Equal(t, "New Narrator", *fresh.Narrator)
+}
+
+func TestB3_CombineBooks_OverrideAuthorNew(t *testing.T) {
+	store := setupTestStore(t)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "T", Format: "mp3", FilePath: "/tmp/b3authnew-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3authnew-loser.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Author: "Brand New Author"})
+	require.NoError(t, err)
+
+	author, err := store.GetAuthorByName("Brand New Author")
+	require.NoError(t, err)
+	require.NotNil(t, author, "author should have been created")
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fresh.AuthorID)
+	assert.Equal(t, author.ID, *fresh.AuthorID)
+}
+
+func TestB3_CombineBooks_OverrideAuthorExisting(t *testing.T) {
+	store := setupTestStore(t)
+
+	existing, err := store.CreateAuthor("Already Here")
+	require.NoError(t, err)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "T", Format: "mp3", FilePath: "/tmp/b3authex-survivor.mp3"}
+	loser := &database.Book{ID: ulid.Make().String(), Title: "Loser", Format: "mp3", FilePath: "/tmp/b3authex-loser.mp3"}
+	_, err = store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(loser)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, loser.ID}, survivor.ID, &CombineOverride{Author: "Already Here"})
+	require.NoError(t, err)
+
+	fresh, err := store.GetBookByID(survivor.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fresh.AuthorID)
+	assert.Equal(t, existing.ID, *fresh.AuthorID, "must reuse the existing author, not create a duplicate")
+}
+
+// ---------- ensureOwnFile / attachVirtualFile (unexported helpers) ----------
+
+func TestB3_EnsureOwnFile_NoFilePath_ReturnsZero(t *testing.T) {
+	store := setupTestStore(t)
+	ms := NewService(store)
+
+	b := &database.Book{ID: ulid.Make().String(), Title: "No path"}
+	assert.Equal(t, 0, ms.ensureOwnFile(b))
+}
+
+func TestB3_EnsureOwnFile_AlreadyMaterialized_ReturnsZero(t *testing.T) {
+	store := setupTestStore(t)
+	ms := NewService(store)
+
+	b := &database.Book{ID: ulid.Make().String(), Title: "Has file", FilePath: "/tmp/b3already.mp3"}
+	_, err := store.CreateBook(b)
+	require.NoError(t, err)
+	require.NoError(t, store.CreateBookFile(&database.BookFile{
+		ID: ulid.Make().String(), BookID: b.ID, FilePath: b.FilePath, Format: "mp3",
+	}))
+
+	assert.Equal(t, 0, ms.ensureOwnFile(b), "book already has a BookFile row; nothing to materialize")
+}
+
+// TestB3_AttachVirtualFile_ReattachExistingOwnedByOtherBook exercises the
+// "#1549 reattach-safe" branch documented on attachVirtualFile: a BookFile
+// row already exists at the target path but is owned by a DIFFERENT book
+// (a stray/orphaned row from an earlier partial operation). attachVirtualFile
+// must MOVE that row onto the target book rather than creating a duplicate.
+func TestB3_AttachVirtualFile_ReattachExistingOwnedByOtherBook(t *testing.T) {
+	store := setupTestStore(t)
+	ms := NewService(store)
+
+	strayOwner := &database.Book{ID: ulid.Make().String(), Title: "Stray owner", FilePath: "/tmp/b3stray-owner.mp3"}
+	target := &database.Book{ID: ulid.Make().String(), Title: "Target", FilePath: "/tmp/b3stray-shared.mp3"}
+	_, err := store.CreateBook(strayOwner)
+	require.NoError(t, err)
+	_, err = store.CreateBook(target)
+	require.NoError(t, err)
+
+	strayFile := &database.BookFile{ID: ulid.Make().String(), BookID: strayOwner.ID, FilePath: target.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(strayFile))
+
+	n := ms.attachVirtualFile(target, target.ID)
+	assert.Equal(t, 1, n)
+
+	files, err := store.GetBookFiles(target.ID)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, strayFile.ID, files[0].ID, "the existing row was moved, not duplicated")
+
+	strayFiles, err := store.GetBookFiles(strayOwner.ID)
+	require.NoError(t, err)
+	assert.Empty(t, strayFiles, "the stray owner no longer owns the file")
+}
+
+// TestB3_AttachVirtualFile_SetsDurationFromBook covers the create-new-file
+// path where the book being materialized has a Duration set — it must
+// carry over onto the new BookFile row.
+func TestB3_AttachVirtualFile_SetsDurationFromBook(t *testing.T) {
+	store := setupTestStore(t)
+	ms := NewService(store)
+
+	dur := 4242
+	b := &database.Book{ID: ulid.Make().String(), Title: "Has duration", FilePath: "/tmp/b3duration.mp3", Duration: &dur}
+	_, err := store.CreateBook(b)
+	require.NoError(t, err)
+
+	n := ms.attachVirtualFile(b, b.ID)
+	assert.Equal(t, 1, n)
+
+	files, err := store.GetBookFiles(b.ID)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, dur, files[0].Duration)
+}


### PR DESCRIPTION
## Summary

Completes TODO item 41 (4.10 — MergeService mock-store unit tests, partial) for `internal/merge`, the `merge.Service.MergeBooks`/`CombineBooks` path that the legacy hard-delete book-merge was rerouted onto in PR #2007.

- **Coverage: 70.3% → 96.6%** (`go test ./internal/merge/... -race -count=1 -cover`)
- 34 new tests across 3 files:
  - `internal/merge/service_b3_realstore_test.go` — real-PebbleStore tests for external-ID (PID/ASIN) reassignment to the winner, iTunes ITL-removal enqueue (filters out non-itunes and tombstoned mappings), version-group integrity (exactly one live primary across N books), `CombineBooks` validation errors, the nil/empty-override wipe-safety guarantee, Title/Narrator/Author override happy paths, and the `ensureOwnFile`/`attachVirtualFile` file-transfer helpers (including the #1549 reattach-safe branch).
  - `internal/merge/service_b3_fault_test.go` — a `b3FaultStore` wrapper (same pattern as the existing `serializeProbe`) that lets a test force one store method to fail, exercising `MergeBooks`/`CombineBooks`' warn-and-continue branches and hard-abort branches (files still owned after move, failed file move/delete, book vanishing mid-combine).
  - `internal/merge/service_b3_misc_test.go` — `AsExternalIDReassigner` edge cases, the `LockMergeRMW`/`UnlockMergeRMW` round trip, `QuickHash`.

## Production bug found and fixed (separate commit)

Writing the version-group-integrity test surfaced a genuine bug: **`Service.MergeBooks` did not de-duplicate its `bookIDs` argument.** If a caller passes the primary ID twice — the exact mistake PR #2007/F6-T10 patched, but only at its one call site (`applyBookMergeReroute`) — the version-group loop writes that book's row twice. The second write's loop index no longer matches `bestIdx`, silently demoting the winner back to `IsPrimaryVersion=false`, while the loser-cleanup loop still skips both occurrences as "the primary" and never soft-deletes it. Net effect: the winner ends up **neither primary nor soft-deleted**, and the version group loses its only live primary.

Several other callers (e.g. `POST /audiobooks/merge`, which passes request-supplied `BookIDs` straight through) don't de-dupe defensively, so this was reachable outside the already-patched caller. Fixed by de-duplicating `bookIDs` at the top of `MergeBooks` itself (commit `7997843b`) so every caller is protected regardless of whether it remembers to de-dupe first — the test-writing commit follows it so the regression test (which requires the fix to pass) lands green.

Also added a short follow-up section to `docs/executive-summaries/2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md` (the exec summary for the related #2007 fix) explaining this hardening, and ticked off TODO item 41.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/merge/... -race -count=1 -cover` → `ok`, 96.6% coverage
- [x] The `internal/server` merge-reroute tests (`TestApplyBookMergeReroute_*`) still pass in isolation (confirms the defensive dedup doesn't change existing caller behavior)
- [ ] Note: a full `go test ./internal/dedup/... ./internal/server/...` run hit the pre-existing `internal/server` package stall documented in project memory ("CI Go Tests intermittent stalls... reproduce in isolation before over-investigating"); reproduced identically on unmodified `main` with the same command, confirming it is unrelated to this change.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65