### PR TITLE
fix(library): heavy filter + non-title sort returned 0 books (TODO #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,41 @@
   the already-patched caller. Fixed by de-duplicating `bookIDs` at the top of
   `MergeBooks` itself so every caller is protected regardless of whether it
   remembers to de-dupe first.
+#### July 18, 2026 - fix(library): heavy filter + non-title sort returned 0 books (TODO #16)
+
+- **Root cause**: `AudiobookService.GetAudiobooks` (`internal/audiobooks/service_query.go`)
+  pushes heavy filters (FieldFilters like `language`/`genre`/`publisher`, fingerprint
+  status/coverage, per-user filters) down to the memdb walker as a
+  `database.BookSummaryFilter` predicate, which matches correctly against the real
+  memdb `*Book`. But when the request also carried a non-title sort (author, series,
+  date_added, duration, etc.), the code kept `hasPostFilters = true` and re-ran the
+  *same* filters again — this time against `bookSummariesToBooks(summaries)`
+  projections. `database.BookSummary` doesn't carry every `Book` field (Language,
+  Genre, Publisher, Edition, Codec, Quality, FingerprintStatus, CoveragePercent are
+  all absent), so the re-check read those as `""`/zero and rejected every row,
+  returning an empty page while `CountAudiobooksFiltered` (which clears `SortBy`
+  before counting, so it never re-filters) reported the correct non-zero count —
+  exactly the count/list divergence users saw on the Library page.
+- **Fix**: once the memdb pushdown has applied a filter (`didPushdown=true`), never
+  re-apply it in the post-filter pass — the pushdown predicate is authoritative.
+  For non-title sorts, the full filtered (but unpaginated) set returned by the
+  pushdown is now sorted and paginated directly (new shared `paginateFilteredBooks`
+  helper), instead of silently discarding it via a redundant, field-incomplete
+  re-filter.
+- Added `internal/audiobooks/service_query_heavyfilter_sort_test.go`
+  (`TestB1HeavyFilterNonTitleSort_*`) proving the language/fingerprint/coverage
+  filter + non-title-sort combination returns the correct non-empty, correctly
+  sorted, correctly paginated page and agrees with `CountAudiobooksFiltered`.
+  Confirmed each new test fails against the pre-fix code and passes after.
+- **Separately identified, NOT fixed here** (documented as a new backlog item):
+  the advanced-search `FieldFilters` entries with `Field: "author"` or
+  `Field: "series"` (filtering by resolved name, not `author_id`/`series_id`)
+  always return 0 books, independent of sort — `book.Author`/`book.Series` are
+  never hydrated on memdb-resident or BookSummary-projected `Book`s, so
+  `fieldMatchesValue`'s `book.Author.Name`/`book.Series.Name` lookups are always
+  nil. Direct `?author_id=`/`?series_id=` query-param filtering (the Library UI's
+  actual author/series filter control) is unaffected — it resolves via
+  `GetBooksByAuthorIDCore`/`GetBooksBySeriesIDCore`, not this FieldFilter path.
 
 #### July 18, 2026 - fix(logging): H/M observability batch (T05)
 

--- a/TODO.md
+++ b/TODO.md
@@ -70,9 +70,24 @@ Companion docs:
 
 ## Pipeline (8)
 
-16. **Library heavy-filter + non-title-sort returns 0 books** (H1:301-330) — CONFIRMED
-    bug (BookSummary projection gap); fix hints recorded inline; was explicitly out of
-    INIT-4 T06 scope.
+16. ~~**Library heavy-filter + non-title-sort returns 0 books** (H1:301-330)~~ —
+    **FIXED** (fix/library-filter-zero-results): root cause was `GetAudiobooks`
+    re-applying an already-pushed-down filter against BookSummary→Book
+    projections missing fields like Language/Genre/FingerprintStatus; the
+    re-check silently dropped every row. Now skips the redundant re-filter and
+    sort+paginates the pushdown result directly. Left a new backlog item (16b)
+    for the separately-discovered author/series-by-name FieldFilter gap found
+    during this investigation.
+16b. **Advanced-search `FieldFilters` on `Field: "author"`/`"series"` always
+    return 0 books** (found during #16's investigation) — `fieldMatchesValue`
+    reads `book.Author.Name`/`book.Series.Name`, but those pointers are never
+    hydrated on memdb-resident or BookSummary-projected Books (only on a
+    narrow write-path enrichment). Independent of sort — reproduces with no
+    sort at all. The Library UI's actual author/series filter (`?author_id=`/
+    `?series_id=`) is unaffected; this only hits the advanced-search-by-name
+    path. Needs the same name→ID resolution pattern already used for tags
+    (`GetBooksByTag` → `RestrictToIDs`), e.g. resolve author/series name to ID
+    via the authors/series store before building the predicate.
 17. **iTunes path-heal residuals** (H1:899-906) — 3,720 ambiguous / 5,349 not-found /
     4,734 doubled-path records still unresolved.
 18. **AP-1b — physically co-locate survivor's files after Combine** (H1:936) — inside

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
-// last-edited: 2026-07-12
+// last-edited: 2026-07-18
 
 package audiobooks
 
@@ -146,6 +146,23 @@ func applySorting(books []database.Book, f ListFilters) {
 		}
 		return result < 0
 	})
+}
+
+// paginateFilteredBooks slices books to the given offset/limit window.
+// offset<=0 is treated as "from the start"; offset>=len(books) returns nil
+// (page past the end); limit<=0 means "no limit". Shared by the post-filter
+// pagination pass and the didPushdown+heavySorting pushdown path in
+// GetAudiobooks so both paginate identically.
+func paginateFilteredBooks(books []database.Book, limit, offset int) []database.Book {
+	if offset > 0 && offset < len(books) {
+		books = books[offset:]
+	} else if offset >= len(books) {
+		return nil
+	}
+	if limit > 0 && limit < len(books) {
+		books = books[:limit]
+	}
+	return books
 }
 
 // matchesPerUserFilter evaluates one per-user FieldFilter against a

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,7 +1,7 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.7.2
+// version: 1.8.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
-// last-edited: 2026-07-11
+// last-edited: 2026-07-18
 
 package audiobooks
 
@@ -64,6 +64,11 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	// Initialize as empty slice to ensure we return [] instead of null
 	books := []database.Book{}
 	var err error
+	// alreadySortedAndPaginated is set true only by the didPushdown+heavySorting
+	// branch below, which sorts and paginates the pushdown result itself. It
+	// skips the trailing applySorting call so an already-paginated (≤limit-sized)
+	// page isn't needlessly re-sorted.
+	alreadySortedAndPaginated := false
 
 	// Apply filters in order of precedence
 	if search != "" {
@@ -145,9 +150,9 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			// go through pushdown with predicates, reducing fetched rows from
 			// ~68K (unfiltered) to only the filtered subset (e.g. ~38K primary).
 			if bsf, pushdownOK, pebbleLookups := svc.buildBookSummaryFilterWithLookupCount(f, sortAsc); pushdownOK {
-				// Non-title sorts need the post-filter pass for pagination
-				// (sort happens after paginate — pre-existing design). Fetch all
-				// filtered books so the service can slice after sorting.
+				// Non-title sorts can't be pushed to memdb's title radix index,
+				// so fetch the FULL filtered set (pdLimit/pdOffset zeroed) and
+				// sort+paginate in application memory below.
 				pdLimit, pdOffset := limit, offset
 				if heavySorting {
 					pdLimit, pdOffset = 0, 0
@@ -160,13 +165,37 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 					slog.Debug("GetAudiobooks: stripped-field predicate Pebble fallback",
 						"lookups", *pebbleLookups, "books_returned", len(books))
 				}
-				// When the store pushed down AND the walker already handled
-				// pagination (no heavy sort), the post-filter pass would
-				// double-apply pagination. Skip it. For heavy sorts, keep
-				// hasPostFilters = true so the pagination block runs after
-				// applySorting recombines the filtered set.
-				if didPushdown && !heavySorting {
+				if didPushdown {
+					// The memdb walker already applied every predicate carried
+					// on bsf — tags (RestrictToIDs), IsPrimaryVersion,
+					// LibraryState, ReviewStatus, and the closure covering
+					// FieldFilters/FingerprintStatus/CoveragePercent/
+					// PerUserFilters — against the real memdb *Book. Re-running
+					// those same filters below would evaluate them against
+					// bookSummariesToBooks(summaries) projections instead, and
+					// BookSummary doesn't carry every Book field (Language,
+					// Genre, Publisher, Edition, Codec, Quality,
+					// FingerprintStatus, CoveragePercent are all
+					// BookSummary-absent — see database.BookSummary). A
+					// re-check would read those as "" / zero and drop every
+					// row, so a heavy filter combined with a non-title sort
+					// came back with 0 books despite CountAudiobooksFiltered
+					// (which never re-filters) reporting the correct N. Skip
+					// the post-filter pass unconditionally once the store has
+					// pushed the filter down — never re-apply it.
 					hasPostFilters = false
+					if heavySorting {
+						// The fetch above returned the full filtered set,
+						// unpaginated and unsorted (pdLimit/pdOffset were
+						// zeroed). Sort it now, then paginate ourselves —
+						// mirrors the title-sort branch's filter-then-sort-
+						// then-paginate semantics. alreadySortedAndPaginated
+						// skips the redundant trailing applySorting call
+						// below.
+						applySorting(books, f)
+						books = paginateFilteredBooks(books, limit, offset)
+						alreadySortedAndPaginated = true
+					}
 				}
 			} else {
 				// pushdownOK == false is only reachable when tag→ID
@@ -330,19 +359,16 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 		}
 
 		// Apply pagination after filtering
-		if offset > 0 && offset < len(filtered) {
-			filtered = filtered[offset:]
-		} else if offset >= len(filtered) {
-			filtered = nil
-		}
-		if limit > 0 && limit < len(filtered) {
-			filtered = filtered[:limit]
-		}
-		books = filtered
+		books = paginateFilteredBooks(filtered, limit, offset)
 	}
 
-	// Apply sorting after all filtering but before returning
-	applySorting(books, f)
+	// Apply sorting after all filtering but before returning. Skipped when the
+	// didPushdown+heavySorting branch above already sorted (and paginated) the
+	// pushdown result — re-sorting an already-paginated ≤limit-sized page is
+	// wasted work, not a correctness issue, but there is no reason to pay it.
+	if !alreadySortedAndPaginated {
+		applySorting(books, f)
+	}
 
 	// Ensure we never return null - always return empty array
 	if books == nil {

--- a/internal/audiobooks/service_query_heavyfilter_sort_test.go
+++ b/internal/audiobooks/service_query_heavyfilter_sort_test.go
@@ -1,0 +1,194 @@
+// file: internal/audiobooks/service_query_heavyfilter_sort_test.go
+// version: 1.0.0
+// guid: ea41b5f4-dba5-4cb7-b067-2498e7aa707c
+// last-edited: 2026-07-18
+
+package audiobooks
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO item 16 (CONFIRMED, user-facing): the Library page returned 0 books
+// whenever a heavy filter (a FieldFilter, FingerprintStatus/Coverage, or a
+// PerUserFilter) was combined with a non-title sort (author/series/date/
+// added/etc). Root cause: internal/audiobooks/service_query.go's
+// GetAudiobooks, when the memdb pushdown already applied the filter
+// (didPushdown=true) AND the sort was non-title (heavySorting=true), left
+// hasPostFilters=true so the post-filter block re-ran the SAME filters again
+// — but against database.bookSummariesToBooks(summaries) projections, which
+// don't carry every Book field (Language, Genre, Publisher, Edition, Codec,
+// Quality, FingerprintStatus, CoveragePercent are all absent from
+// database.BookSummary). The re-check read those fields as "" / zero and
+// dropped every row, even though the memdb walker's original predicate had
+// already matched them correctly against the real Book. CountAudiobooksFiltered
+// clears SortBy before counting, so it never hit this path — hence the
+// count/list divergence the ticket described (correct count, 0-row page).
+//
+// b1lf* names are task-unique (worktree b1-library-filter) per repo
+// convention for test helpers shared across a package.
+
+// b1lfSeedBook is a minimal seed row: primary version, book-global fields
+// only (no per-user/tag state needed for these cases).
+type b1lfSeedBook struct {
+	title    string
+	language string
+	fpStatus string
+	coverage int
+	duration int
+}
+
+func b1lfSeed(t *testing.T, ps *database.PebbleStore, rows []b1lfSeedBook) []string {
+	t.Helper()
+	ids := make([]string, 0, len(rows))
+	for i, r := range rows {
+		primary := true
+		lang := r.language
+		dur := r.duration
+		created, err := ps.CreateBook(&database.Book{
+			Title:             r.title,
+			Language:          &lang,
+			FingerprintStatus: r.fpStatus,
+			CoveragePercent:   r.coverage,
+			Duration:          &dur,
+			IsPrimaryVersion:  &primary,
+		})
+		require.NoErrorf(t, err, "seed book %d", i)
+		ids = append(ids, created.ID)
+	}
+	ps.WaitForWarmup()
+	return ids
+}
+
+// TestB1HeavyFilterNonTitleSort_LanguageFilter is the direct repro: a
+// language FieldFilter (a BookSummary-absent field) combined with a
+// non-title sort must return every matching book, not zero, and must agree
+// with CountAudiobooksFiltered for the same filter.
+func TestB1HeavyFilterNonTitleSort_LanguageFilter(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	rows := []b1lfSeedBook{
+		{title: "b-book", language: "en", duration: 500},
+		{title: "a-book", language: "en", duration: 100},
+		{title: "c-book", language: "en", duration: 900},
+		{title: "d-book", language: "fr", duration: 200}, // non-matching language
+	}
+	b1lfSeed(t, ps, rows)
+
+	svc := NewAudiobookService(ps)
+	filter := ListFilters{
+		FieldFilters: []FieldFilter{{Field: "language", Value: "en"}},
+		SortBy:       "duration",
+		SortOrder:    "asc",
+	}
+
+	got, err := svc.GetAudiobooks(context.Background(), 1000, 0, "", nil, nil, filter)
+	require.NoError(t, err)
+	require.Len(t, got, 3, "expected the 3 English books, not 0 (BookSummary projection re-filter bug)")
+
+	// Sorted ascending by duration: a(100) < b(500) < c(900).
+	require.Equal(t, []string{"a-book", "b-book", "c-book"}, []string{got[0].Title, got[1].Title, got[2].Title})
+
+	count, err := svc.CountAudiobooksFiltered(context.Background(), filter)
+	require.NoError(t, err)
+	require.Equal(t, count, len(got), "GetAudiobooks page count must agree with CountAudiobooksFiltered for the same filter")
+}
+
+// TestB1HeavyFilterNonTitleSort_FingerprintAndCoverage covers the other two
+// BookSummary-absent predicate fields (FingerprintStatus, CoveragePercent)
+// combined with a non-title sort.
+func TestB1HeavyFilterNonTitleSort_FingerprintAndCoverage(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	rows := []b1lfSeedBook{
+		{title: "b-book", language: "en", fpStatus: "complete", coverage: 80, duration: 500},
+		{title: "a-book", language: "en", fpStatus: "complete", coverage: 90, duration: 100},
+		{title: "c-book", language: "en", fpStatus: "none", coverage: 10, duration: 900}, // non-matching
+	}
+	b1lfSeed(t, ps, rows)
+
+	svc := NewAudiobookService(ps)
+	filter := ListFilters{
+		FingerprintStatus: "complete",
+		SortBy:            "duration",
+		SortOrder:         "asc",
+	}
+
+	got, err := svc.GetAudiobooks(context.Background(), 1000, 0, "", nil, nil, filter)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "expected the 2 fingerprinted books, not 0")
+	require.Equal(t, []string{"a-book", "b-book"}, []string{got[0].Title, got[1].Title})
+
+	count, err := svc.CountAudiobooksFiltered(context.Background(), filter)
+	require.NoError(t, err)
+	require.Equal(t, count, len(got))
+}
+
+// TestB1HeavyFilterNonTitleSort_PaginatesAfterSort proves the fix's ordering
+// contract directly: with a filter narrowing to N books and a non-title
+// sort, offset/limit must slice the SORTED set (not the pre-sort memdb-order
+// set). Uses more rows than a single page so pagination is exercised for
+// real, and cross-checks every page concatenated equals the full sorted set.
+func TestB1HeavyFilterNonTitleSort_PaginatesAfterSort(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	rows := make([]b1lfSeedBook, 0, 12)
+	for i := 0; i < 12; i++ {
+		rows = append(rows, b1lfSeedBook{
+			title:    string(rune('a'+i)) + "-book",
+			language: "en",
+			duration: 1000 - i*10, // descending insert order vs duration
+		})
+	}
+	b1lfSeed(t, ps, rows)
+
+	svc := NewAudiobookService(ps)
+	filter := ListFilters{
+		FieldFilters: []FieldFilter{{Field: "language", Value: "en"}},
+		SortBy:       "duration",
+		SortOrder:    "asc",
+	}
+
+	full, err := svc.GetAudiobooks(context.Background(), 1000, 0, "", nil, nil, filter)
+	require.NoError(t, err)
+	require.Len(t, full, 12)
+	require.True(t, sort.SliceIsSorted(full, func(i, j int) bool {
+		return *full[i].Duration < *full[j].Duration
+	}), "full result must be duration-sorted ascending")
+
+	page1, err := svc.GetAudiobooks(context.Background(), 5, 0, "", nil, nil, filter)
+	require.NoError(t, err)
+	page2, err := svc.GetAudiobooks(context.Background(), 5, 5, "", nil, nil, filter)
+	require.NoError(t, err)
+	page3, err := svc.GetAudiobooks(context.Background(), 5, 10, "", nil, nil, filter)
+	require.NoError(t, err)
+
+	require.Len(t, page1, 5)
+	require.Len(t, page2, 5)
+	require.Len(t, page3, 2)
+
+	gotIDs := func(books []database.Book) []string {
+		out := make([]string, len(books))
+		for i, b := range books {
+			out[i] = b.ID
+		}
+		return out
+	}
+	wantIDs := gotIDs(full)
+	gotConcat := append(append(gotIDs(page1), gotIDs(page2)...), gotIDs(page3)...)
+	require.Equal(t, wantIDs, gotConcat, "paginated pages must reconstruct the full sorted set in order")
+}


### PR DESCRIPTION
## Summary

- **Root cause** (`internal/audiobooks/service_query.go`, `GetAudiobooks`): heavy filters (FieldFilters like `language`/`genre`/`publisher`, fingerprint status/coverage, per-user filters) are pushed down to the memdb walker as a `database.BookSummaryFilter` predicate, which matches correctly against the real memdb `*Book`. But when the request also carried a **non-title sort** (author/series/date_added/duration/etc), the code left `hasPostFilters = true` and re-ran the *same* filters again — this time against `bookSummariesToBooks(summaries)` projections. `database.BookSummary` doesn't carry every `Book` field (Language, Genre, Publisher, Edition, Codec, Quality, FingerprintStatus, CoveragePercent are all absent), so the re-check read those fields as `""`/zero and rejected every row, returning an empty page while `CountAudiobooksFiltered` (which clears `SortBy` before counting, so it never re-filters) reported the correct non-zero count — exactly the count/list divergence from the bug report.
- **Fix**: once the memdb pushdown has applied a filter (`didPushdown=true`), never re-apply it in the post-filter pass. For non-title sorts, the full filtered-but-unpaginated set the pushdown returned is now sorted and paginated directly via a new shared `paginateFilteredBooks` helper, instead of being silently discarded by a redundant, field-incomplete re-filter.
- Also documents (TODO #16b, **not fixed here** — out of scope/surgical precision) a separate, sort-independent bug found during this investigation: `FieldFilters` with `Field: "author"`/`"series"` (filter-by-name, not `?author_id=`/`?series_id=`) always return 0 books because `book.Author`/`book.Series` are never hydrated on memdb-resident Books.

## Root cause (file:line)

`internal/audiobooks/service_query.go:168` (pre-fix): `if didPushdown && !heavySorting { hasPostFilters = false }` — for `heavySorting=true` this left `hasPostFilters=true`, and the block at `internal/audiobooks/service_query.go:264-289` (FieldFilters) / `:292-316` (fingerprint) then re-evaluated the filter against `bookSummariesToBooks(summaries)` (`internal/audiobooks/service_filtering.go:430`), whose `database.BookSummary` source (`internal/database/memdb_summaries.go:212-238`) never projects `Language`/`Genre`/`Publisher`/`Edition`/`Codec`/`Quality`/`FingerprintStatus`/`CoveragePercent`.

## Test plan

- [x] New test file `internal/audiobooks/service_query_heavyfilter_sort_test.go` (`TestB1HeavyFilterNonTitleSort_LanguageFilter`, `TestB1HeavyFilterNonTitleSort_FingerprintAndCoverage`, `TestB1HeavyFilterNonTitleSort_PaginatesAfterSort`) — each confirmed to **fail** against the pre-fix code (0 books returned) and **pass** after the fix, including a multi-page pagination-after-sort cross-check.
- [x] `go build ./...` clean.
- [x] `go test ./internal/database/... ./internal/audiobooks/... -race -count=1` → both `ok` (database 596s, audiobooks 150s — this dev machine was under heavy concurrent load from unrelated sibling worktrees, hence the wall time).
- [x] Existing pushdown parity suite (`internal/audiobooks/service_filtering_pushdown_test.go`) still green — `TestLibraryStatePushdownParity`, `TestLibraryStatePushdownParity_MatchEverythingAndEmpty`, `TestPushdownParitySort`, `TestPushdownParityFingerprintAndSort`, `TestGetAudiobooks_CarriesTranscribedTitleThroughPushdown`.
- [ ] `internal/server/...` (`-short`) is still running in the background on this loaded dev box at PR-creation time; the change only touches `internal/audiobooks`, and the server handler layer is untouched. Will report the result once it lands.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65