### PR TITLE
fix(audiobooks): hydrate author/series names for advanced-search FieldFilters (TODO 16b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.179.0 -->
+<!-- version: 3.180.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,41 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - fix(audiobooks): hydrate author/series names for advanced-search FieldFilters (TODO #16b)
+
+- **Advanced-search `FieldFilters` on `Field: "author"`/`"series"` always
+  returned 0 books**, independent of sort. Root cause: `fieldMatchesValue`
+  (`internal/audiobooks/service_filtering.go`) reads `book.Author.Name` /
+  `book.Series.Name`, but `database.Book.Author`/`.Series` are "Related
+  objects (populated via joins, not stored in DB)" — the memdb-resident
+  `*Book` used by the production listing pushdown never carries them (only
+  `AuthorID`/`SeriesID` survive), and the Pebble `GetBookByID` raw-JSON
+  fallback doesn't hydrate them either. Every author/series FieldFilter
+  therefore compared against `""` and rejected every row. The Library UI's
+  normal `?author_id=`/`?series_id=` filter uses a different indexed path and
+  was never affected — this was specific to the free-text advanced-search
+  filter.
+- Fix: `buildAuthorSeriesNameMaps` (new, `service_filtering.go`) builds
+  authorID→name / seriesID→name maps once per query — via the same
+  `GetAllAuthors`/`GetAllSeries` accessor `author_series.go`'s
+  `ListSeriesWithCounts` already uses for its author-name join — only when
+  the filter set actually references "author"/"series". `matchesFieldFilters
+  WithStrippedFallback` (the single choke point both the memdb pushdown
+  predicate in `buildBookSummaryFilterWithLookupCount` and the mock/
+  non-pushdown post-filter path in `service_query.go` route through) now
+  hydrates a per-book copy's `Author`/`Series` from those maps before running
+  `fieldMatchesValue` — no per-book store call, maps are nil (no-op) for
+  queries that don't filter on author/series. `CountAudiobooksFiltered`
+  shares the same predicate builder, so the paginated "total" is fixed too
+  (previously: list=0 AND count=0 for the same query).
+- New regression tests (`internal/audiobooks/service_fieldfilter_authorseries_test.go`,
+  real `PebbleStore` + warm memdb so the production pushdown path is
+  actually exercised): `TestFieldFilterAuthor_MemdbHydration` and
+  `TestFieldFilterSeries_MemdbHydration` seed two authors (one with a
+  series) and assert the filter discriminates correctly (exact match,
+  the other author's book excluded, and a nonexistent name returns 0 —
+  not "everything").
 
 #### July 18, 2026 - feat(metrics): per-operation progress exporter + op-stall alert (TODO #36)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.6.0 -->
+<!-- version: 10.7.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -78,16 +78,25 @@ Companion docs:
     sort+paginates the pushdown result directly. Left a new backlog item (16b)
     for the separately-discovered author/series-by-name FieldFilter gap found
     during this investigation.
-16b. **Advanced-search `FieldFilters` on `Field: "author"`/`"series"` always
-    return 0 books** (found during #16's investigation) — `fieldMatchesValue`
-    reads `book.Author.Name`/`book.Series.Name`, but those pointers are never
-    hydrated on memdb-resident or BookSummary-projected Books (only on a
-    narrow write-path enrichment). Independent of sort — reproduces with no
-    sort at all. The Library UI's actual author/series filter (`?author_id=`/
-    `?series_id=`) is unaffected; this only hits the advanced-search-by-name
-    path. Needs the same name→ID resolution pattern already used for tags
-    (`GetBooksByTag` → `RestrictToIDs`), e.g. resolve author/series name to ID
-    via the authors/series store before building the predicate.
+16b. ~~**Advanced-search `FieldFilters` on `Field: "author"`/`"series"` always
+    return 0 books** (found during #16's investigation)~~ — **FIXED**
+    (fix/fieldfilter-author-series-hydration): confirmed root cause —
+    `fieldMatchesValue` (`internal/audiobooks/service_filtering.go:274`) reads
+    `book.Author.Name`/`book.Series.Name`, but per `database.Book`'s own doc
+    comment those are "Related objects (populated via joins, not stored in
+    DB)" — the memdb-resident `*Book` never carries them (only
+    AuthorID/SeriesID), and even the Pebble `GetBookByID` raw-JSON fallback
+    doesn't hydrate them either, so every author/series FieldFilter compared
+    against `""` and rejected every row. Fix: `buildAuthorSeriesNameMaps`
+    fetches all authors/series once per query (cheap — small, fully in-memory
+    collections, same `GetAllAuthors`/`GetAllSeries` accessor
+    `author_series.go`'s `ListSeriesWithCounts` already uses) and
+    `hydrateAuthorSeriesNames` populates a per-book copy's Author/Series from
+    those maps before `fieldMatchesValue` runs, at the single choke point
+    (`matchesFieldFiltersWithStrippedFallback`) both the memdb pushdown
+    predicate and the mock/non-pushdown post-filter path go through — no
+    per-book store call. `CountAudiobooksFiltered` shares the same predicate
+    builder so the paginated total is fixed too.
 17. **iTunes path-heal residuals** (H1:899-906) — 3,720 ambiguous / 5,349 not-found /
     4,734 doubled-path records still unresolved.
 18. **AP-1b — physically co-locate survivor's files after Combine** (H1:936) — inside

--- a/internal/audiobooks/service_fieldfilter_authorseries_test.go
+++ b/internal/audiobooks/service_fieldfilter_authorseries_test.go
@@ -1,0 +1,156 @@
+// file: internal/audiobooks/service_fieldfilter_authorseries_test.go
+// version: 1.0.0
+// guid: 7d4c2e91-8a3f-4b6d-9e5c-1f2a3b4c5d6e
+// last-edited: 2026-07-18
+
+package audiobooks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO item 16b regression test: a FieldFilter{Field:"author"} or
+// {Field:"series"} on the Library listing always returned 0 books,
+// independent of sort. Root cause: fieldMatchesValue (service_filtering.go)
+// reads book.Author.Name / book.Series.Name, but those joined struct fields
+// are populated ONLY via joins (see database.Book's "Related objects" doc
+// comment) — the memdb-resident *Book used by the production pushdown path
+// never carries them, only AuthorID/SeriesID. So every author/series
+// FieldFilter compared against "" and rejected every row.
+//
+// This harness uses a real PebbleStore (like service_filtering_pushdown_test.go)
+// so the production memdb pushdown path is actually exercised — a mock store
+// would bypass the bug entirely.
+
+// b5AuthorSeriesFixture seeds two authors (each with a series) and one
+// author-only book, so a FieldFilter can discriminate between authors/series
+// instead of just "matched something".
+type b5AuthorSeriesFixture struct {
+	authorAID, authorBID int
+	seriesAID            int
+	bookAID, bookBID     string // bookA: author A + series A; bookB: author B, no series
+}
+
+func b5SeedAuthorSeriesBooks(t *testing.T, ps *database.PebbleStore) b5AuthorSeriesFixture {
+	t.Helper()
+
+	authorA, err := ps.CreateAuthor("Ursula Le Guin")
+	require.NoError(t, err)
+	authorB, err := ps.CreateAuthor("Frank Herbert")
+	require.NoError(t, err)
+
+	seriesA, err := ps.CreateSeries("Earthsea", &authorA.ID)
+	require.NoError(t, err)
+
+	bookA, err := ps.CreateBook(&database.Book{
+		Title:    "A Wizard of Earthsea",
+		AuthorID: &authorA.ID,
+		SeriesID: &seriesA.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.SetBookAuthors(bookA.ID, []database.BookAuthor{
+		{BookID: bookA.ID, AuthorID: authorA.ID, Role: "author", Position: 0},
+	}))
+
+	bookB, err := ps.CreateBook(&database.Book{
+		Title:    "Dune",
+		AuthorID: &authorB.ID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ps.SetBookAuthors(bookB.ID, []database.BookAuthor{
+		{BookID: bookB.ID, AuthorID: authorB.ID, Role: "author", Position: 0},
+	}))
+
+	return b5AuthorSeriesFixture{
+		authorAID: authorA.ID,
+		authorBID: authorB.ID,
+		seriesAID: seriesA.ID,
+		bookAID:   bookA.ID,
+		bookBID:   bookB.ID,
+	}
+}
+
+// TestFieldFilterAuthor_MemdbHydration proves an author-name FieldFilter
+// returns exactly the matching book(s) via the memdb-resident *Book path
+// (book.Author is never persisted; only AuthorID is), not zero regardless of
+// which author is searched.
+func TestFieldFilterAuthor_MemdbHydration(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	fx := b5SeedAuthorSeriesBooks(t, ps)
+	svc := NewAudiobookService(ps)
+	ctx := context.Background()
+
+	// Positive: filtering by "Le Guin" must return exactly bookA, not bookB.
+	got, err := svc.GetAudiobooks(ctx, 1000, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "author", Value: "Le Guin"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "author FieldFilter must return exactly the matching book, not 0 or all")
+	require.Equal(t, fx.bookAID, got[0].ID)
+
+	// The count pushdown shares buildBookSummaryFilterWithLookupCount, so it
+	// must agree with the list result (previously: list=0 AND count=0).
+	count, err := svc.CountAudiobooksFiltered(ctx, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "author", Value: "Le Guin"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// Discriminating positive: filtering by the OTHER author must return
+	// exactly bookB, proving the filter isn't just matching everything.
+	got, err = svc.GetAudiobooks(ctx, 1000, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "author", Value: "Herbert"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, fx.bookBID, got[0].ID)
+
+	// Negative: an author name that matches nothing must return 0 books, not
+	// silently match everything.
+	got, err = svc.GetAudiobooks(ctx, 1000, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "author", Value: "NoSuchAuthorXYZ"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestFieldFilterSeries_MemdbHydration is the series-field analogue.
+func TestFieldFilterSeries_MemdbHydration(t *testing.T) {
+	ps, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+	ps.WaitForWarmup()
+
+	fx := b5SeedAuthorSeriesBooks(t, ps)
+	svc := NewAudiobookService(ps)
+	ctx := context.Background()
+
+	// Positive: only bookA carries a series (Earthsea); bookB has none.
+	got, err := svc.GetAudiobooks(ctx, 1000, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "series", Value: "Earthsea"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "series FieldFilter must return exactly the matching book")
+	require.Equal(t, fx.bookAID, got[0].ID)
+
+	count, err := svc.CountAudiobooksFiltered(ctx, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "series", Value: "Earthsea"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// Negative: a series name that matches nothing must return 0 books.
+	got, err = svc.GetAudiobooks(ctx, 1000, 0, "", nil, nil, ListFilters{
+		FieldFilters: []FieldFilter{{Field: "series", Value: "NoSuchSeriesXYZ"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got)
+}

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_filtering.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: b4e8c3d2-e5f6-7a80-9b0c-1d2e3f4a5b6c
 // last-edited: 2026-07-18
 
@@ -238,6 +238,16 @@ func matchesFieldFilters(book database.Book, filters []FieldFilter) bool {
 // pre-fix behavior where memdb books silently failed all
 // stripped-field filters.
 //
+// authorNames/seriesNames are optional authorID→name / seriesID→name maps
+// (see buildAuthorSeriesNameMaps). memBook.Author / memBook.Series are
+// "Related objects (populated via joins, not stored in DB)" — see
+// database.Book's doc comment — so neither the memdb-resident copy NOR the
+// raw-JSON Pebble fetchFull result ever carries them; only AuthorID/SeriesID
+// survive. Without these maps, an "author"/"series" FieldFilter always
+// compared against "" and rejected every row (TODO 16b). Both maps are nil
+// when the filter set doesn't reference author/series, so callers pay
+// nothing extra for the common case.
+//
 // pebbleLookups is incremented once per actual GetBookByID call so the
 // caller can log a per-query count at DEBUG.
 func matchesFieldFiltersWithStrippedFallback(
@@ -246,9 +256,17 @@ func matchesFieldFiltersWithStrippedFallback(
 	fetchFull func(id string) (*database.Book, error),
 	pebbleLookups *int64,
 	warnOnce func(id string, err error),
+	authorNames, seriesNames map[int]string,
 ) bool {
-	if len(cheap) > 0 && !matchesFieldFilters(*memBook, cheap) {
-		return false
+	if len(cheap) > 0 {
+		cheapBook := memBook
+		if authorNames != nil || seriesNames != nil {
+			hydrated := hydrateAuthorSeriesNames(*memBook, authorNames, seriesNames)
+			cheapBook = &hydrated
+		}
+		if !matchesFieldFilters(*cheapBook, cheap) {
+			return false
+		}
 	}
 	if len(stripped) == 0 {
 		return true
@@ -264,6 +282,62 @@ func matchesFieldFiltersWithStrippedFallback(
 		return false
 	}
 	return matchesFieldFilters(*full, stripped)
+}
+
+// hydrateAuthorSeriesNames returns a copy of book with Author/Series
+// populated from the given id→name maps when the book carries an
+// AuthorID/SeriesID but no already-resolved Author/Series struct. Safe to
+// call with nil maps (no-op) or when the book's Author/Series is already
+// set (left untouched).
+func hydrateAuthorSeriesNames(book database.Book, authorNames, seriesNames map[int]string) database.Book {
+	if book.Author == nil && book.AuthorID != nil && authorNames != nil {
+		if name, ok := authorNames[*book.AuthorID]; ok {
+			book.Author = &database.Author{ID: *book.AuthorID, Name: name}
+		}
+	}
+	if book.Series == nil && book.SeriesID != nil && seriesNames != nil {
+		if name, ok := seriesNames[*book.SeriesID]; ok {
+			book.Series = &database.Series{ID: *book.SeriesID, Name: name}
+		}
+	}
+	return book
+}
+
+// buildAuthorSeriesNameMaps returns authorID→name / seriesID→name maps when
+// filters contains an "author" / "series" FieldFilter, or nil maps
+// otherwise. Authors/Series are small, fully in-memory collections (unlike
+// Books), so fetching all of them once per query — the same GetAllAuthors /
+// GetAllSeries accessor author_series.go's ListSeriesWithCounts already uses
+// for its author-name join — is cheap and avoids a per-book store call
+// inside the filter loop (see CLAUDE.md's concurrency/per-item-DB-call
+// guidance).
+func (svc *AudiobookService) buildAuthorSeriesNameMaps(filters []FieldFilter) (authorNames, seriesNames map[int]string) {
+	needAuthor, needSeries := false, false
+	for _, f := range filters {
+		switch f.Field {
+		case "author":
+			needAuthor = true
+		case "series":
+			needSeries = true
+		}
+	}
+	if needAuthor {
+		if authors, err := svc.store.GetAllAuthors(); err == nil {
+			authorNames = make(map[int]string, len(authors))
+			for _, a := range authors {
+				authorNames[a.ID] = a.Name
+			}
+		}
+	}
+	if needSeries {
+		if series, err := svc.store.GetAllSeries(); err == nil {
+			seriesNames = make(map[int]string, len(series))
+			for _, s := range series {
+				seriesNames[s.ID] = s.Name
+			}
+		}
+	}
+	return authorNames, seriesNames
 }
 
 // fieldMatchesValue checks whether a book's field value matches the search
@@ -678,6 +752,7 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 				"stripped_fields", strippedFieldNames(strippedFF),
 				"cheap_filter_count", len(cheapFF))
 		}
+		authorNames, seriesNames := svc.buildAuthorSeriesNameMaps(remainingFF)
 		// Per-query Pebble-lookup counter + once-per-query warn for
 		// nil/err. The walker invokes the predicate row-by-row on the
 		// caller's goroutine, so a plain int64 + sync.Once captured in the
@@ -696,7 +771,7 @@ func (svc *AudiobookService) buildBookSummaryFilterWithLookupCount(f ListFilters
 		}
 		predicate = func(b *database.Book) bool {
 			if len(remainingFF) > 0 {
-				if !matchesFieldFiltersWithStrippedFallback(b, cheapFF, strippedFF, fetchFull, pebbleLookups, warnFn) {
+				if !matchesFieldFiltersWithStrippedFallback(b, cheapFF, strippedFF, fetchFull, pebbleLookups, warnFn, authorNames, seriesNames) {
 					return false
 				}
 			}

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
 // last-edited: 2026-07-18
 
@@ -303,10 +303,16 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 			fetchFull := func(id string) (*database.Book, error) {
 				return svc.store.GetBookByID(id)
 			}
+			// author/series names are never persisted on the Book row itself
+			// (populated only via joins), so this fallback path needs the
+			// same id→name hydration as the memdb pushdown predicate — see
+			// buildAuthorSeriesNameMaps / hydrateAuthorSeriesNames in
+			// service_filtering.go (TODO 16b).
+			authorNames, seriesNames := svc.buildAuthorSeriesNameMaps(f.FieldFilters)
 			fieldFiltered := make([]database.Book, 0, len(filtered))
 			for i := range filtered {
 				b := filtered[i]
-				if matchesFieldFiltersWithStrippedFallback(&b, cheapFF, strippedFF, fetchFull, &pebbleLookups, warnFn) {
+				if matchesFieldFiltersWithStrippedFallback(&b, cheapFF, strippedFF, fetchFull, &pebbleLookups, warnFn, authorNames, seriesNames) {
 					fieldFiltered = append(fieldFiltered, b)
 				}
 			}


### PR DESCRIPTION
## Summary

- **Bug (TODO item 16b):** an advanced-search `FieldFilter{Field: "author"}` or `{Field: "series"}` on the Library listing always returned **0 books**, independent of sort. The Library UI's normal `?author_id=`/`?series_id=` filter uses a different indexed path and was never affected — this is specific to the free-text advanced-search filter.
- **Root cause confirmed:** `fieldMatchesValue` (`internal/audiobooks/service_filtering.go:274`) reads `book.Author.Name` / `book.Series.Name`, but per `database.Book`'s own doc comment those are "Related objects (populated via joins, not stored in DB)" (`internal/database/store.go:296-298`). The memdb-resident `*Book` used by the production listing pushdown never carries them — only `AuthorID`/`SeriesID` survive — and the Pebble `GetBookByID` raw-JSON fallback (the existing "stripped field" recovery path) doesn't hydrate them either, since Author/Series structs aren't persisted on the `book:<id>` JSON blob. So every author/series FieldFilter compared against `""` and rejected every row, on both the memdb and Pebble paths.
- **Fix (Option B — resolve via the store, same accessor the display path uses):** new `buildAuthorSeriesNameMaps` (`service_filtering.go`) builds `authorID -> name` / `seriesID -> name` maps **once per query** via `store.GetAllAuthors()` / `store.GetAllSeries()` — the same accessor `author_series.go`'s `ListSeriesWithCounts` already uses for its author-name join — and only when the filter set actually references `"author"`/`"series"`. `matchesFieldFiltersWithStrippedFallback` — the single choke point both the memdb pushdown predicate (`buildBookSummaryFilterWithLookupCount`) and the mock/non-pushdown post-filter path (`service_query.go`) route through — now hydrates a per-book **copy's** `Author`/`Series` from those maps (new `hydrateAuthorSeriesNames`) before `fieldMatchesValue` runs. No per-book store call (maps are nil/no-op when the filter set doesn't touch author/series), and the live memdb-resident object is never mutated. `CountAudiobooksFiltered` shares the same predicate builder, so the paginated "total" is fixed for free (previously: list=0 **and** count=0 for the same query).

## Test plan

- [x] New regression tests in `internal/audiobooks/service_fieldfilter_authorseries_test.go`, using a real `PebbleStore` + warm memdb (same harness as `service_filtering_pushdown_test.go`) so the production pushdown path is actually exercised:
  - `TestFieldFilterAuthor_MemdbHydration` — seeds two authors (one with a series), asserts `FieldFilter{"author","Le Guin"}` returns exactly the matching book (not 0, not both), the other author's filter returns exactly *their* book, a nonexistent name returns 0, and `CountAudiobooksFiltered` agrees with the list result.
  - `TestFieldFilterSeries_MemdbHydration` — same discrimination shape for `"series"`.
  - Confirmed **red** against pre-fix code (`0 books` in both tests, matching the reported bug exactly) before implementing the fix, then **green** after.
- [x] `go test ./internal/audiobooks/... -race -count=1` — full package passes (54s).
- [x] `go build ./...` clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65