### PR TITLE
feat(dedup): persist per-signal-kind confidence bounds in DedupSignalConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,38 @@
   series) and assert the filter discriminates correctly (exact match,
   the other author's book excluded, and a nonexistent name returns 0 —
   not "everything").
+#### July 18, 2026 - feat(dedup): persist per-signal-kind confidence bounds in `DedupSignalConfig` (INIT-1 T05 follow-up, TODO #6)
+
+- **`config.DedupSignalConfig` gained a `Confidence map[string]DedupKindConfidence`
+  field** (`internal/config/config.go`), keyed by signal kind (e.g.
+  `embedding_med`, `lsh_acoustid`). Previously per-kind confidence bounds had
+  no field anywhere in the persisted config blob and were silently dropped by
+  `UpdateConfig`'s JSON round-trip — the exact gap
+  `dedup.calibrate-composite`'s Round 2 advisory sweep documented as the
+  reason its confidence-bound suggestions could never be persisted. A
+  kind absent from the map (including the nil zero-value — every existing
+  config) falls back to `unified.DefaultScoreConfig()`'s compiled-in bounds,
+  so existing configs are byte-for-byte unchanged.
+- **`unified.SetKindConfidenceOverrides`** (`internal/dedup/unified/config.go`)
+  injects the DB-persisted map into `LoadScoreConfig`, mirroring the existing
+  `SetBandThresholds` pattern exactly (same DB-override > Viper > defaults
+  precedence, same unified→config circular-import avoidance via a
+  package-local override type). Wired at startup from
+  `internal/server/registry_wire.go` alongside the existing band-threshold
+  wiring.
+- **Scope note (STOP-and-report, not silently expanded):** this closes the
+  *persistence* gap only. `unified.ComposeScore` still reads each signal's
+  `Confidence` directly and does not clamp it against `cfg.Signals[kind]`'s
+  bounds, so populating this field has **no effect on live scoring** yet —
+  only `dedup.calibrate-composite`'s own simulation consumes it today.
+  Whether `ComposeScore` should start clamping (and whether Round 2 should
+  then route through `UpdateConfig`) is recorded as an open decision:
+  [`docs/plans/DECISIONS-PENDING.md`](docs/plans/DECISIONS-PENDING.md) row 10.
+- Tests: `internal/dedup/unified/config_test.go`
+  (`TestSetKindConfidenceOverrides_*`, 6 cases covering override-one-kind-only,
+  unset-bound-falls-back, DB-over-Viper precedence, and unknown-kind
+  fail-closed) and `internal/config/dedup_signal_confidence_test.go`
+  (JSON round-trip + omitempty-by-default).
 
 #### July 18, 2026 - feat(metrics): per-operation progress exporter + op-stall alert (TODO #36)
 

--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,14 @@ Companion docs:
    OFF (6f2f7ce0); gated human decision (see DECISIONS-PENDING).
 5. **C8 — auto-file issues per `not_dup` cluster** (H1:1332; INIT-10 T5) — deferred.
 6. **INIT-1 T05 follow-up — per-kind confidence field in `DedupSignalConfig`** (H1:250)
-   — makes the confidence round applyable.
+   — **persistence scaffolding DONE** (2026-07-18): `config.DedupSignalConfig.Confidence`
+   + `unified.SetKindConfidenceOverrides` (mirrors `SetBandThresholds`) + `registry_wire.go`
+   wiring, so a per-kind confidence bound now survives `UpdateConfig`/restart. **Still
+   blocked**: `unified.ComposeScore` ignores `cfg.Signals[kind]` bounds entirely (reads
+   `Signal.Confidence` verbatim), so the field has no effect on live scoring yet, and
+   `dedup.calibrate-composite`'s Round 2 sweep still doesn't write it — decision needed
+   on whether `ComposeScore` should clamp against it (see
+   [`docs/plans/DECISIONS-PENDING.md`](docs/plans/DECISIONS-PENDING.md) row 10).
 7. **Async breakdown-refresh for bulk/cluster dismiss** (H1:1877) — per-pair synchronous
    refresh may need an async variant at scale (latency note).
 8. **Omnibus detection + dedup** — spec-only

--- a/docs/plans/DECISIONS-PENDING.md
+++ b/docs/plans/DECISIONS-PENDING.md
@@ -1,7 +1,7 @@
 <!-- file: docs/plans/DECISIONS-PENDING.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 38115603-5a52-4745-83a5-2c9ca4528a9d -->
-<!-- last-edited: 2026-07-17 -->
+<!-- last-edited: 2026-07-18 -->
 
 # Decisions Pending — the STOP-FOR-HUMAN queue
 
@@ -20,6 +20,7 @@ not a passing text reply). Consolidated from the 2026-07-17 docs audit.
 | 7 | **Product rename** (1.17) | pick a name | — | Branding sweep across UI/docs/binary | TODO #37 (H1:2751) |
 | 8 | **Flip `review_apply_enabled` ON in prod** | enable globally / enable per-hold-type / keep OFF | Sandbox-first validation before any enable | Review-queue apply path doing real work (merged #1953, default OFF) | [`2026-07-13-review-queue-and-regroup.md`](2026-07-13-review-queue-and-regroup.md); [`../operations/pending-prod-actions.md`](../operations/pending-prod-actions.md) row 8 |
 | 9 | **PH-2b purge wave scope** — which residual populations get purged, and how | per-population ops (fragment-floor / title-leak / stub) vs review-only drain | Never blanket-purge (four-population analysis) | Draining the ~9,074 exact-pending backlog | [`../dedup/STATUS.md`](../dedup/STATUS.md); [`../operations/pending-prod-actions.md`](../operations/pending-prod-actions.md) row 1 |
+| 10 | **Should `unified.ComposeScore` clamp primary-signal `Confidence` against `cfg.Signals[kind].Min/MaxConfidence`?** (TODO item 6 follow-up, 2026-07-18) — `config.DedupSignalConfig.Confidence` now persists per-kind confidence bounds and `unified.LoadScoreConfig` merges them, but `ComposeScore` still reads `Signal.Confidence` verbatim and ignores those bounds, so they have zero effect on live scoring (only `dedup.calibrate-composite`'s own simulation consumes them today) | (a) add clamping to `ComposeScore` for primary kinds only (mirrors the `scoreWithClamp` simulation already in `calibrate_composite.go`), confirmed no-op under default config by a test, THEN also route `calibrate-composite`'s Round 2 confidence suggestions through `UpdateConfig` (behind a separate `apply_confidence` param, not the existing `apply` band gate); (b) leave `ComposeScore` untouched and keep Round 2 advisory-only — the new field only helps a hand-edited `config.yaml`-equivalent persist across restarts | — | Whether the confidence round can ever move production auto-merge scores, vs. remaining report-only | [`../../internal/plugins/dedup/calibrate_composite.go`](../../internal/plugins/dedup/calibrate_composite.go) (see "Two calibration surfaces" doc comment); [`../../internal/dedup/unified/compose.go`](../../internal/dedup/unified/compose.go) |
 
 ## Process
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 // file: internal/config/config.go
-// version: 1.70.0
+// version: 1.71.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-14
+// last-edited: 2026-07-18
 
 package config
 
@@ -108,6 +108,41 @@ type DedupSignalConfig struct {
 	// BandReviewMin is the minimum score to classify a pair as REVIEW (default 60).
 	// Pairs scoring below this floor are not persisted.
 	BandReviewMin float64 `json:"band_review_min" mapstructure:"band_review_min"`
+	// Confidence holds per-signal-kind confidence-bound overrides, keyed by
+	// signal kind (e.g. "exact_file", "isbn_asin", "embedding_high" — see
+	// unified.SignalKind for the full set). A kind absent from this map —
+	// including a nil/unset map, the zero value — falls back to
+	// unified.DefaultScoreConfig()'s compiled-in Min/MaxConfidence for that
+	// kind, so existing configs are byte-for-byte unchanged in behaviour.
+	//
+	// INIT-1 T05 follow-up (TODO item 6): this is the persistence surface
+	// dedup.calibrate-composite's Round 2 advisory confidence sweep was
+	// missing — see internal/plugins/dedup/calibrate_composite.go's "Two
+	// calibration surfaces" doc comment. Adding this field lets a per-kind
+	// confidence bound survive a config update / restart via the normal
+	// UpdateConfig JSON round-trip instead of being silently dropped.
+	//
+	// NOTE: as of this change, populating this map has NO effect on live
+	// scoring — unified.ComposeScore reads each Signal's Confidence directly
+	// and does not clamp it against these bounds (see
+	// docs/plans/DECISIONS-PENDING.md row 10 for the open decision on
+	// whether ComposeScore should start doing so). This field is currently
+	// consumed only by unified.LoadScoreConfig (so it round-trips correctly)
+	// and is available for a human-reviewed follow-up to wire into scoring.
+	Confidence map[string]DedupKindConfidence `json:"confidence,omitempty" mapstructure:"confidence"`
+}
+
+// DedupKindConfidence is a per-signal-kind confidence-bound override, the
+// value type of DedupSignalConfig.Confidence. Both fields are optional —
+// zero means "not set", falling back to the unified package's compiled-in
+// default for that bound — because those are the two bounds
+// dedup.calibrate-composite's Round 2 sweep (the "confidence round")
+// recommends adjusting.
+type DedupKindConfidence struct {
+	// MinConfidence overrides the kind's confidence floor. Zero = not set.
+	MinConfidence float64 `json:"min_confidence,omitempty" mapstructure:"min_confidence"`
+	// MaxConfidence overrides the kind's confidence ceiling. Zero = not set.
+	MaxConfidence float64 `json:"max_confidence,omitempty" mapstructure:"max_confidence"`
 }
 
 // DedupConfig holds all deduplication settings that were previously flat fields

--- a/internal/config/dedup_signal_confidence_test.go
+++ b/internal/config/dedup_signal_confidence_test.go
@@ -1,0 +1,102 @@
+// file: internal/config/dedup_signal_confidence_test.go
+// version: 1.0.0
+// guid: 9a1c4e7d-2b6f-4a83-9d0e-5c7b1f3a8e42
+// last-edited: 2026-07-18
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDedupSignalConfig_ConfidenceRoundTripsThroughJSON verifies that
+// DedupSignalConfig.Confidence — the INIT-1 T05 follow-up field (TODO item
+// 6) — survives a JSON marshal/unmarshal round trip, which is exactly the
+// path UpdateConfig/SaveConfigToDatabase use to persist the config blob. This
+// is the behavior the "confidence round" was missing: before this field
+// existed, per-kind confidence bounds had nowhere to live in DedupSignalConfig
+// and were silently dropped by that same round trip.
+func TestDedupSignalConfig_ConfidenceRoundTripsThroughJSON(t *testing.T) {
+	orig := DedupSignalConfig{
+		BandCertainMin: 97.0,
+		BandHighMin:    90.0,
+		BandMediumMin:  75.0,
+		BandReviewMin:  60.0,
+		Confidence: map[string]DedupKindConfidence{
+			"embedding_med": {MinConfidence: 0.72, MaxConfidence: 0.83},
+			"lsh_acoustid":  {MinConfidence: 0.91},
+		},
+	}
+
+	raw, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var round DedupSignalConfig
+	if err := json.Unmarshal(raw, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(round.Confidence) != 2 {
+		t.Fatalf("expected 2 confidence entries after round trip, got %d", len(round.Confidence))
+	}
+	em, ok := round.Confidence["embedding_med"]
+	if !ok {
+		t.Fatal("expected embedding_med entry after round trip")
+	}
+	if em.MinConfidence != 0.72 || em.MaxConfidence != 0.83 {
+		t.Errorf("embedding_med: expected 0.72/0.83, got %.4f/%.4f", em.MinConfidence, em.MaxConfidence)
+	}
+	lsh, ok := round.Confidence["lsh_acoustid"]
+	if !ok {
+		t.Fatal("expected lsh_acoustid entry after round trip")
+	}
+	if lsh.MinConfidence != 0.91 {
+		t.Errorf("lsh_acoustid: expected MinConfidence 0.91, got %.4f", lsh.MinConfidence)
+	}
+	if lsh.MaxConfidence != 0 {
+		t.Errorf("lsh_acoustid: expected MaxConfidence 0 (unset), got %.4f", lsh.MaxConfidence)
+	}
+}
+
+// TestDedupSignalConfig_ConfidenceOmittedByDefault verifies that a
+// DedupSignalConfig with no Confidence set at all (the zero value — every
+// existing persisted config predating this field) marshals with the
+// "confidence" key entirely absent (omitempty) and round-trips to a nil map,
+// which unified.LoadScoreConfig/SetKindConfidenceOverrides both treat as a
+// complete no-op. This is the backward-compatibility guarantee: existing
+// configs are byte-for-byte unaffected by this field's addition.
+func TestDedupSignalConfig_ConfidenceOmittedByDefault(t *testing.T) {
+	orig := DedupSignalConfig{
+		BandCertainMin: 97.0,
+		BandHighMin:    90.0,
+		BandMediumMin:  75.0,
+		BandReviewMin:  60.0,
+	}
+
+	raw, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) == "" {
+		t.Fatal("expected non-empty JSON")
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+	if _, present := decoded["confidence"]; present {
+		t.Errorf("expected \"confidence\" key to be omitted for zero-value Confidence, got present: %v", decoded["confidence"])
+	}
+
+	var round DedupSignalConfig
+	if err := json.Unmarshal(raw, &round); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if round.Confidence != nil {
+		t.Errorf("expected nil Confidence map after round trip of a config without it, got %v", round.Confidence)
+	}
+}

--- a/internal/dedup/unified/config.go
+++ b/internal/dedup/unified/config.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/unified/config.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: d8a383db-5083-4257-be54-686ac2e72d32
-// last-edited: 2026-06-16
+// last-edited: 2026-07-18
 
 package unified
 
@@ -171,10 +171,43 @@ func SetBandThresholds(certainMin, highMin, mediumMin, reviewMin float64) {
 	bandOverride.reviewMin = reviewMin
 }
 
+// KindConfidenceOverride is a per-signal-kind confidence-bound override
+// value. It mirrors config.DedupKindConfidence's two fields without this
+// package importing internal/config — the same unified→config circular
+// import SetBandThresholds/bandOverride already avoid for band thresholds.
+// Zero on either field means "not set" for that bound.
+type KindConfidenceOverride struct {
+	MinConfidence float64
+	MaxConfidence float64
+}
+
+// confidenceMu guards confidenceOverride, the DB-persisted per-kind
+// confidence-bound overrides (INIT-1 T05 follow-up, TODO item 6).
+var (
+	confidenceMu       sync.RWMutex
+	confidenceOverride map[string]KindConfidenceOverride
+)
+
+// SetKindConfidenceOverrides injects DB-persisted per-kind confidence bound
+// overrides into LoadScoreConfig, mirroring SetBandThresholds. Called by
+// server init (registry_wire.go) after AppConfig is loaded from the
+// database, from config.DedupConfig.Signals.Confidence.
+//
+// A kind absent from overrides — or present with a field left at its zero
+// value — is treated as "not set" for that bound and LoadScoreConfig falls
+// back to the Viper / DefaultScoreConfig value for it instead, so passing a
+// nil or empty map is a complete no-op and existing behaviour is unchanged.
+func SetKindConfidenceOverrides(overrides map[string]KindConfidenceOverride) {
+	confidenceMu.Lock()
+	defer confidenceMu.Unlock()
+	confidenceOverride = overrides
+}
+
 // LoadScoreConfig reads overrides from injected band thresholds (DB-persisted,
-// set via SetBandThresholds) and Viper (config.yaml dedup.signals.*) on top of
-// DefaultScoreConfig.
-// Precedence (highest → lowest): SetBandThresholds > Viper > defaults.
+// set via SetBandThresholds), injected per-kind confidence bounds
+// (DB-persisted, set via SetKindConfidenceOverrides), and Viper (config.yaml
+// dedup.signals.*) on top of DefaultScoreConfig.
+// Precedence (highest → lowest): SetBandThresholds/SetKindConfidenceOverrides > Viper > defaults.
 // Returns an error if the resulting config fails Validate.
 func LoadScoreConfig() (ScoreConfig, error) {
 	cfg := DefaultScoreConfig()
@@ -238,6 +271,30 @@ func LoadScoreConfig() (ScoreConfig, error) {
 			kc.Boost = viper.GetFloat64(key + ".boost")
 		}
 		cfg.Signals[string(kind)] = kc
+	}
+
+	// Merge DB-persisted per-kind confidence overrides (highest precedence,
+	// mirroring the band thresholds above: DB override > Viper > defaults).
+	// Within one override entry, a zero MinConfidence/MaxConfidence field is
+	// "not set" and leaves that particular bound at its Viper/default value —
+	// only the non-zero bound(s) in an entry are applied. A kind not present
+	// in cfg.Signals (shouldn't happen — DefaultScoreConfig seeds every kind)
+	// is skipped rather than creating a partial entry.
+	confidenceMu.RLock()
+	confOverrides := confidenceOverride
+	confidenceMu.RUnlock()
+	for kindStr, ov := range confOverrides {
+		kc, ok := cfg.Signals[kindStr]
+		if !ok {
+			continue
+		}
+		if ov.MinConfidence > 0 {
+			kc.MinConfidence = ov.MinConfidence
+		}
+		if ov.MaxConfidence > 0 {
+			kc.MaxConfidence = ov.MaxConfidence
+		}
+		cfg.Signals[kindStr] = kc
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/internal/dedup/unified/config_test.go
+++ b/internal/dedup/unified/config_test.go
@@ -1,6 +1,7 @@
 // file: internal/dedup/unified/config_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f7a2c9b-8e3d-4b6f-a1c5-9e7b3d2f6a8c
+// last-edited: 2026-07-18
 
 package unified
 
@@ -268,5 +269,175 @@ func TestLoadScoreConfig_PerKindMinConfidenceOverride(t *testing.T) {
 	kc := cfg.Signals[string(SigEmbedMedium)]
 	if kc.MinConfidence != 0.70 {
 		t.Errorf("min_confidence override: expected 0.70, got %.4f", kc.MinConfidence)
+	}
+}
+
+// b6ResetConfidenceOverrides clears the package-level DB-persisted per-kind
+// confidence override state (SetKindConfidenceOverrides) before the test body
+// runs and again on cleanup, so TestSetKindConfidenceOverrides_* tests never
+// bleed into each other or into unrelated tests in this package (mirrors
+// resetViper's role for the Viper-backed state). Name is task-scoped (b6xxx,
+// INIT-1 T05 follow-up / TODO item 6) to avoid colliding with any other
+// worktree's helper of the same shape.
+func b6ResetConfidenceOverrides(t *testing.T) {
+	t.Helper()
+	SetKindConfidenceOverrides(nil)
+	t.Cleanup(func() { SetKindConfidenceOverrides(nil) })
+}
+
+// TestSetKindConfidenceOverrides_NoOverridesIsANoOp verifies that a nil/unset
+// override map (the default, and what SetKindConfidenceOverrides(nil) means)
+// leaves LoadScoreConfig's per-kind confidence bounds at their Viper/default
+// values — i.e. existing behaviour (and existing configs) are unaffected by
+// this feature existing at all.
+func TestSetKindConfidenceOverrides_NoOverridesIsANoOp(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigEmbedMedium)]
+	if kc.MinConfidence != 0.65 || kc.MaxConfidence != 0.80 {
+		t.Fatalf("expected untouched defaults 0.65/0.80, got %.4f/%.4f", kc.MinConfidence, kc.MaxConfidence)
+	}
+}
+
+// TestSetKindConfidenceOverrides_OverridesOnlyThatKind verifies that a
+// DB-persisted override for one kind changes only that kind's bounds in the
+// resulting ScoreConfig — every other kind (spot-checked here) keeps its
+// compiled-in default. This is the "(a) a per-kind confidence overrides the
+// default for that kind only" requirement.
+func TestSetKindConfidenceOverrides_OverridesOnlyThatKind(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	SetKindConfidenceOverrides(map[string]KindConfidenceOverride{
+		string(SigEmbedMedium): {MinConfidence: 0.72, MaxConfidence: 0.83},
+	})
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	overridden := cfg.Signals[string(SigEmbedMedium)]
+	if overridden.MinConfidence != 0.72 || overridden.MaxConfidence != 0.83 {
+		t.Errorf("SigEmbedMedium: expected 0.72/0.83, got %.4f/%.4f", overridden.MinConfidence, overridden.MaxConfidence)
+	}
+
+	// Untouched kind must still be at its compiled-in default.
+	untouched := cfg.Signals[string(SigEmbedHigh)]
+	if untouched.MinConfidence != 0.88 || untouched.MaxConfidence != 0.95 {
+		t.Errorf("SigEmbedHigh should be untouched: expected 0.88/0.95, got %.4f/%.4f", untouched.MinConfidence, untouched.MaxConfidence)
+	}
+}
+
+// TestSetKindConfidenceOverrides_UnsetBoundFallsBack verifies that an
+// override entry which sets ONLY one bound (the other left at its zero
+// value) leaves the other bound at whatever Viper/default would otherwise
+// produce — a per-field "not set" fallback, not an all-or-nothing entry.
+// This is the "(b) an unset per-kind value falls back to the prior
+// behaviour" requirement.
+func TestSetKindConfidenceOverrides_UnsetBoundFallsBack(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	SetKindConfidenceOverrides(map[string]KindConfidenceOverride{
+		// MaxConfidence deliberately left at zero == "not set".
+		string(SigEmbedMedium): {MinConfidence: 0.72},
+	})
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigEmbedMedium)]
+	if kc.MinConfidence != 0.72 {
+		t.Errorf("MinConfidence: expected overridden 0.72, got %.4f", kc.MinConfidence)
+	}
+	if kc.MaxConfidence != 0.80 {
+		t.Errorf("MaxConfidence: expected untouched default 0.80, got %.4f", kc.MaxConfidence)
+	}
+}
+
+// TestSetKindConfidenceOverrides_PrecedenceOverViper verifies the documented
+// precedence order (DB override > Viper > defaults): a Viper-set value AND a
+// DB-persisted override for the same kind/bound results in the DB value
+// winning, exactly like SetBandThresholds already wins over Viper for bands.
+func TestSetKindConfidenceOverrides_PrecedenceOverViper(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	viper.Set("dedup.signals."+string(SigEmbedMedium), true)
+	viper.Set("dedup.signals."+string(SigEmbedMedium)+".min_confidence", 0.66)
+
+	SetKindConfidenceOverrides(map[string]KindConfidenceOverride{
+		string(SigEmbedMedium): {MinConfidence: 0.74},
+	})
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc := cfg.Signals[string(SigEmbedMedium)]
+	if kc.MinConfidence != 0.74 {
+		t.Errorf("expected DB override 0.74 to win over Viper's 0.66, got %.4f", kc.MinConfidence)
+	}
+}
+
+// TestSetKindConfidenceOverrides_ConsumedByLoadScoreConfig is requirement (c):
+// the per-kind value is reflected by the config the rest of the package
+// consumes. As of this change (see docs/plans/DECISIONS-PENDING.md row 10),
+// ComposeScore itself does not yet clamp against these bounds — the wiring
+// stops at LoadScoreConfig's returned ScoreConfig, which is what
+// dedup.calibrate-composite and the dedup engine both read cfg.Signals from.
+// This test exercises exactly that boundary rather than asserting a
+// ComposeScore behaviour change that was deliberately not made here.
+func TestSetKindConfidenceOverrides_ConsumedByLoadScoreConfig(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	SetKindConfidenceOverrides(map[string]KindConfidenceOverride{
+		string(SigLSHAcoustID): {MinConfidence: 0.91, MaxConfidence: 0.96},
+	})
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kc, ok := cfg.Signals[string(SigLSHAcoustID)]
+	if !ok {
+		t.Fatal("expected SigLSHAcoustID entry in cfg.Signals")
+	}
+	if kc.MinConfidence != 0.91 || kc.MaxConfidence != 0.96 {
+		t.Errorf("expected 0.91/0.96, got %.4f/%.4f", kc.MinConfidence, kc.MaxConfidence)
+	}
+}
+
+// TestSetKindConfidenceOverrides_UnknownKindIsSkipped verifies that an
+// override for a kind string not present in cfg.Signals (shouldn't happen in
+// practice — DefaultScoreConfig seeds every known kind — but a stale/typo'd
+// persisted key must fail closed, not panic or create a partial entry) is
+// silently ignored rather than propagated.
+func TestSetKindConfidenceOverrides_UnknownKindIsSkipped(t *testing.T) {
+	resetViper(t)
+	b6ResetConfidenceOverrides(t)
+
+	SetKindConfidenceOverrides(map[string]KindConfidenceOverride{
+		"not_a_real_signal_kind": {MinConfidence: 0.5, MaxConfidence: 0.9},
+	})
+
+	cfg, err := LoadScoreConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.Signals["not_a_real_signal_kind"]; ok {
+		t.Error("unknown kind should not be created in cfg.Signals")
 	}
 }

--- a/internal/plugins/dedup/calibrate_composite.go
+++ b/internal/plugins/dedup/calibrate_composite.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/calibrate_composite.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4c2f7a91-8d3b-4e6a-9f10-5b7c2d1e8a34
-// last-edited: 2026-07-12
+// last-edited: 2026-07-18
 
 // Package dedup — op dedup.calibrate-composite (INIT-1 T5).
 //
@@ -26,22 +26,37 @@
 // clamping regime (tighten a stored confidence, or raise one below a new floor);
 // it cannot widen a value the collector already clamped away.
 //
-// CRITICAL persistence gap (found during implementation): the ONLY config-blob
-// surface for dedup.signals.* is the four band thresholds (config.DedupSignalConfig).
-// Per-kind confidences have NO field in the Config struct and would be silently
-// dropped by UpdateConfig's JSON round-trip (same failure class as the retired
-// flat keys). Adding a field is out of scope ("do NOT invent a new persistence
-// path / no config.go changes"). Therefore:
+// Persistence gap — CLOSED for storage, OPEN for live consumption (INIT-1 T05
+// follow-up / TODO item 6, 2026-07-18): config.DedupSignalConfig now has a
+// Confidence map[string]DedupKindConfidence field, so a per-kind confidence
+// bound survives UpdateConfig's JSON round-trip and a restart (previously it
+// had no field and was silently dropped, same failure class as the retired
+// flat keys). unified.SetKindConfidenceOverrides + registry_wire.go wire the
+// persisted map into unified.LoadScoreConfig exactly like SetBandThresholds
+// does for bands.
+//
+// That closes the STORAGE gap, but NOT the reason Round 2 stays advisory:
+// unified.ComposeScore reads Signal.Confidence DIRECTLY and does not clamp it
+// against cfg.Signals[kind].Min/MaxConfidence — a config's per-kind confidence
+// bounds (whether from Viper or now the DB blob) have ZERO effect on live
+// scoring. The only thing that reads those bounds today is this op's own
+// scoreWithClamp simulation below. Making Round 2 truly "applyable" (routing
+// its suggestions through UpdateConfig, and having them actually move
+// production scores) requires deciding whether ComposeScore should start
+// clamping — a change to the noisy-OR scorer that everything on the
+// auto-merge path depends on. That decision is intentionally NOT made in this
+// change; see docs/plans/DECISIONS-PENDING.md row 10. Until it lands:
 //
 //   - Round 1 — band thresholds under BASELINE (production) confidences — is the
 //     APPLICABLE recommendation. Its target-met flags accurately predict prod
 //     because prod runs baseline confidences + these bands. The apply path uses
 //     ONLY these, and the apply gate is computed from the EXACT config being
 //     persisted (baseline confidences + recommended bands).
-//   - Round 2 — per-signal confidence bounds — is ADVISORY only. It is reported so
-//     an operator can hand-edit config.yaml, but it is NEVER routed through
-//     UpdateConfig, NEVER gates the band apply, and NEVER contributes to the
-//     precision attributed to an applied band.
+//   - Round 2 — per-signal confidence bounds — remains ADVISORY only. It is
+//     reported so an operator can persist it (via config.yaml or, now, a direct
+//     UpdateConfig write to dedup.signals.confidence.<kind>.*), but this op
+//     still never writes it itself, never gates the band apply on it, and
+//     never contributes to the precision attributed to an applied band.
 //
 // # Discipline
 //

--- a/internal/plugins/dedup/calibrate_composite_test.go
+++ b/internal/plugins/dedup/calibrate_composite_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/dedup/calibrate_composite_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 7e5a1c3b-9d2f-4a08-8b61-3c4d5e6f7a89
-// last-edited: 2026-07-12
+// last-edited: 2026-07-18
 
 package dedup
 
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -131,7 +132,7 @@ func TestCalibrateCompositeDryRunWritesNothing(t *testing.T) {
 		t.Error("expected a recommended_high_min in the dry-run report")
 	}
 	after := config.Snapshot().Dedup.Signals
-	if before != after {
+	if !reflect.DeepEqual(before, after) {
 		t.Errorf("dry-run mutated config store: before=%+v after=%+v", before, after)
 	}
 }
@@ -213,7 +214,7 @@ func TestCalibrateCompositeTargetNotMetApplyWritesNothing(t *testing.T) {
 	if err := p.runCalibrateComposite(context.Background(), json.RawMessage(`{"min_scored_pairs":10,"apply":true}`), rep); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	if after := config.Snapshot().Dedup.Signals; before != after {
+	if after := config.Snapshot().Dedup.Signals; !reflect.DeepEqual(before, after) {
 		t.Errorf("apply on target-not-met mutated config: before=%+v after=%+v", before, after)
 	}
 }

--- a/internal/server/registry_wire.go
+++ b/internal/server/registry_wire.go
@@ -1,6 +1,6 @@
 // file: internal/server/registry_wire.go
-// version: 1.19.1
-// last-edited: 2026-07-11
+// version: 1.20.0
+// last-edited: 2026-07-18
 
 package server
 
@@ -162,6 +162,20 @@ func init() {
 			// to break the unified→config circular import.
 			sigs := cfg.Dedup.Signals
 			unified.SetBandThresholds(sigs.BandCertainMin, sigs.BandHighMin, sigs.BandMediumMin, sigs.BandReviewMin)
+			// Same wiring for per-kind confidence bound overrides (INIT-1 T05
+			// follow-up, TODO item 6): sigs.Confidence is the DB-persisted map,
+			// converted to unified's own override type so this package never
+			// needs to import internal/config. A nil/empty map is a no-op.
+			if len(sigs.Confidence) > 0 {
+				confOverrides := make(map[string]unified.KindConfidenceOverride, len(sigs.Confidence))
+				for kind, kc := range sigs.Confidence {
+					confOverrides[kind] = unified.KindConfidenceOverride{
+						MinConfidence: kc.MinConfidence,
+						MaxConfidence: kc.MaxConfidence,
+					}
+				}
+				unified.SetKindConfidenceOverrides(confOverrides)
+			}
 			return engine, nil
 		},
 	})


### PR DESCRIPTION
## Summary

INIT-1 T05 follow-up (TODO item 6): `config.DedupSignalConfig` gains a
`Confidence map[string]DedupKindConfidence` field, keyed by signal kind
(e.g. `embedding_med`, `lsh_acoustid`). Previously per-kind confidence
bounds had **no field anywhere in the persisted config blob** and were
silently dropped by `UpdateConfig`'s JSON round-trip — the exact gap
`dedup.calibrate-composite`'s Round 2 advisory sweep documented as the
reason its confidence-bound suggestions could never be persisted.

- `unified.SetKindConfidenceOverrides` (`internal/dedup/unified/config.go`)
  injects the DB-persisted map into `LoadScoreConfig`, mirroring the
  existing `SetBandThresholds` pattern exactly (same DB-override > Viper >
  defaults precedence, same unified→config circular-import avoidance).
- Wired at startup from `internal/server/registry_wire.go` alongside the
  existing band-threshold wiring.
- A kind absent from the map (including the nil zero-value — every
  existing config) falls back to `unified.DefaultScoreConfig()`'s
  compiled-in bounds, so existing configs are byte-for-byte unchanged.

## Scope note — STOP-and-report on the consumption half

Per the task's own instruction ("if this turns out larger/ambiguous than
a clean config-field addition, STOP and report"), this PR closes the
**persistence** gap only:

- `unified.ComposeScore` still reads each signal's `Confidence` directly
  and does **not** clamp it against `cfg.Signals[kind]`'s bounds, so
  populating this field has **no effect on live scoring** today — only
  `dedup.calibrate-composite`'s own simulation (`scoreWithClamp`) consumes
  these bounds, both before and after this change.
- Whether `ComposeScore` should start clamping against `cfg.Signals`
  (which would need its own no-op-under-defaults test, since it changes a
  scorer that everything on the auto-merge path depends on), and whether
  `calibrate-composite`'s Round 2 should then route its suggestions
  through `UpdateConfig`, is recorded as an **open decision**:
  [`docs/plans/DECISIONS-PENDING.md`](docs/plans/DECISIONS-PENDING.md) row 10.

TODO.md item 6 and calibrate_composite.go's header comment are both
updated to reflect exactly this split (persistence: done; consumption:
pending decision).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean for all touched packages
- [x] `go test ./internal/config/... ./internal/dedup/... ./internal/plugins/dedup/... -race -count=1 -short` — all green
- [x] New tests: `internal/dedup/unified/config_test.go`
      (`TestSetKindConfidenceOverrides_*`, 6 cases: override-one-kind-only,
      unset-bound-falls-back, no-override-no-op, DB-over-Viper precedence,
      consumed-by-LoadScoreConfig, unknown-kind-fail-closed) and
      `internal/config/dedup_signal_confidence_test.go` (JSON round-trip +
      omitempty-by-default).
- [x] Fixed two pre-existing `!=` struct comparisons in
      `calibrate_composite_test.go` that stopped compiling once
      `DedupSignalConfig` gained a map field (switched to
      `reflect.DeepEqual`).

Not merging — reporting PR number per instructions.

Claude-Session: https://claude.ai/code/session_01WdKeHNKm5K6oyop4bYNd65