### PR TITLE
perf(database): cache CountPrimaryBooks to stop idle ~2-core CPU busy-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- file: CHANGELOG.md -->
-<!-- version: 3.180.0 -->
+<!-- version: 3.181.0 -->
 <!-- guid: 8c5a02ad-7cfe-4c6d-a4b7-3d5f92daabc1 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Features & Fixes
+
+#### July 18, 2026 - perf(database): cache CountPrimaryBooks to stop an idle ~2-core CPU busy-loop
+
+- **The server burned ~2 CPU cores continuously while idle.** `CountPrimaryBooks()`
+  (`internal/database/pebble_store.go`) full-scans every `book:` key and
+  `json.Unmarshal`s each Book — ~5.6s on the ~44K-book production library. The
+  5-second metrics/status ticker (`internal/server/server_lifecycle.go`) called it on
+  every tick, so with each scan taking longer than the tick interval the scans ran
+  back-to-back, pinning one core on the scan and a second on the GC churn from tens of
+  thousands of unmarshals per pass. It presented as prod sitting at ~189% CPU with
+  nothing in the logs but `deps_scheduler: sweep tick waiting_count=0`. Diagnosed via a
+  goroutine dump showing the sole runnable app goroutine spinning in
+  `Server.Start.func7 → CountPrimaryBooks → json.Unmarshal`. Not a recent regression —
+  the ticker path dates to 2026-05-01.
+- The same scan also made `GET /api/v1/health` take ~5.6s (health-probe timeout risk).
+- Fix: `CountPrimaryBooks` now caches its result in-memory for a short TTL
+  (`primaryCountCacheTTL`, 30s), with a recompute gate so a burst of concurrent callers
+  (e.g. `/health` probes) collapses to a single scan per window. The expensive scan runs
+  at most once per TTL instead of on every 5s tick; the count may lag a write by up to
+  the TTL, which is fine for a metrics gauge / health probe. Pure TTL (not
+  invalidate-on-write) is deliberate: invalidation would re-trigger the full scan on the
+  next tick during any import, reintroducing the busy-loop under load. The 5s ticker is
+  unchanged, so memory/goroutine metrics stay live. Regression test
+  `TestPebbleCountPrimaryBooksTTLCache` fails without the cache.
 
 #### July 18, 2026 - fix(audiobooks): hydrate author/series names for advanced-search FieldFilters (TODO #16b)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.7.0 -->
+<!-- version: 10.8.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-07-18 -->
 
@@ -152,7 +152,17 @@ Companion docs:
 32. **I1 + I6 — prod pprof verification** (H1:1515, 1538) — measure chromem-lazy
     effect + heap re-audit; measurement only.
 
-## Infra (4)
+## Infra (5)
+
+37. **CPU busy-loop: `CountPrimaryBooks` full-scan on the 5s metrics ticker** — ✅ DONE
+    (2026-07-18): the server burned ~2 cores continuously while idle because
+    `CountPrimaryBooks` (`internal/database/pebble_store.go`) full-scans + `json.Unmarshal`s
+    all ~44K books (~5.6s) and the 5s status ticker
+    (`internal/server/server_lifecycle.go`) called it every tick, running scans
+    back-to-back (presented as ~189% CPU with only `sweep tick waiting_count=0` logs; also
+    made `/api/v1/health` ~5.6s). Fixed with a 30s in-memory TTL cache + recompute gate on
+    `CountPrimaryBooks` (regression test `TestPebbleCountPrimaryBooksTTLCache`). Diagnosed
+    while health-checking the (now torn-down) dedup sandbox.
 
 33. **REPO-SIZE-1 decision** ([plan](docs/plans/2026-07-10-repo-size-history-rewrite-plan.md),
     [package](docs/plans/2026-07-12-repo-size-targeted-purge-package.md)) —

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.117.0
+// version: 1.118.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-17
+// last-edited: 2026-07-18
 
 package database
 
@@ -105,6 +105,19 @@ type PebbleStore struct {
 	libraryCountsRecomputeMu sync.Mutex // gates recompute to prevent stampede when N callers see dirty cache
 	UseMemDB                 bool       // feature flag: use in-memory query layer for aggregations / filtered reads
 
+	// Primary-book-count cache. CountPrimaryBooks full-scans every book: key and
+	// json.Unmarshal's each Book (~5.6s on a ~44K-book library). The 5s metrics
+	// ticker (server_lifecycle.go) called it on every tick, saturating ~2 cores
+	// on an otherwise-idle server. These fields cache the count for a short TTL so
+	// the expensive scan runs at most once per primaryCountCacheTTL. primaryCountMu
+	// guards the value fields; primaryCountRecomputeMu gates the recompute so a
+	// burst of callers collapses to a single scan per window.
+	primaryCountMu          sync.Mutex
+	primaryCountRecomputeMu sync.Mutex
+	primaryCount            int
+	primaryCountComputedAt  time.Time
+	primaryCountValid       bool
+
 	// warmupCancel cancels the async memdb warmup goroutine; warmupDone is
 	// closed when that goroutine exits. Close() cancels and waits on these
 	// before closing the underlying Pebble DB — otherwise the warmup's db.NewIter
@@ -146,6 +159,12 @@ func (p *PebbleStore) WaitForWarmup() {
 const statsLibraryKey = "stats:library"
 const statsLibraryTTL = 10 * time.Minute
 const defaultLibraryCountsMinIntervalSeconds = 600 // 10 minutes
+
+// primaryCountCacheTTL bounds how stale the cached CountPrimaryBooks value may
+// be. A metrics gauge / health probe tolerating tens of seconds of staleness is
+// fine; this caps the 5.6s full-scan to at most once per window so the 5s status
+// ticker stops re-scanning the whole library on every tick.
+const primaryCountCacheTTL = 30 * time.Second
 
 func getLibraryCountsMinIntervalSeconds() int {
 	if s := os.Getenv("LIBRARY_COUNTS_CACHE_MIN_INTERVAL_SECONDS"); s != "" {
@@ -2395,7 +2414,55 @@ func (p *PebbleStore) SearchBooks(query string, limit, offset int) ([]Book, erro
 	return filtered, nil
 }
 
+// CountPrimaryBooks returns the number of primary, non-deleted books.
+//
+// The underlying scan (countPrimaryBooksScan) iterates every book: key and
+// json.Unmarshal's each Book — ~5.6s on a ~44K-book library. The 5s metrics/status
+// ticker (server_lifecycle.go) and GET /health both call this, so an uncached scan
+// pinned ~2 cores continuously on an idle server. The result is cached for
+// primaryCountCacheTTL; the count may lag a write by up to that window, which is
+// fine for a metrics gauge / health probe.
 func (p *PebbleStore) CountPrimaryBooks() (int, error) {
+	// Fast path: fresh cached value.
+	p.primaryCountMu.Lock()
+	if p.primaryCountValid && time.Since(p.primaryCountComputedAt) < primaryCountCacheTTL {
+		c := p.primaryCount
+		p.primaryCountMu.Unlock()
+		return c, nil
+	}
+	p.primaryCountMu.Unlock()
+
+	// Gate the recompute so a burst of callers (e.g. concurrent /health probes)
+	// collapses to a single scan per window instead of each running its own 5.6s
+	// scan. Double-check the cache after acquiring the gate — a peer may have just
+	// refreshed it.
+	p.primaryCountRecomputeMu.Lock()
+	defer p.primaryCountRecomputeMu.Unlock()
+
+	p.primaryCountMu.Lock()
+	if p.primaryCountValid && time.Since(p.primaryCountComputedAt) < primaryCountCacheTTL {
+		c := p.primaryCount
+		p.primaryCountMu.Unlock()
+		return c, nil
+	}
+	p.primaryCountMu.Unlock()
+
+	count, err := p.countPrimaryBooksScan()
+	if err != nil {
+		return 0, err
+	}
+
+	p.primaryCountMu.Lock()
+	p.primaryCount = count
+	p.primaryCountComputedAt = time.Now()
+	p.primaryCountValid = true
+	p.primaryCountMu.Unlock()
+
+	return count, nil
+}
+
+// countPrimaryBooksScan is the uncached full scan behind CountPrimaryBooks.
+func (p *PebbleStore) countPrimaryBooksScan() (int, error) {
 	count := 0
 	iter, err := p.db.NewIter(&pebble.IterOptions{
 		LowerBound: []byte("book:0"),

--- a/internal/database/pebble_store_test.go
+++ b/internal/database/pebble_store_test.go
@@ -672,6 +672,11 @@ func TestPebbleCountPrimaryBooks(t *testing.T) {
 		}
 	}
 
+	// CountPrimaryBooks caches its result for primaryCountCacheTTL, so a read
+	// right after the writes would return the stale pre-create count. Invalidate
+	// the cache to force a fresh scan for this correctness assertion.
+	store.(*PebbleStore).invalidatePrimaryCountForTest()
+
 	// Act
 	newCount, err := store.CountPrimaryBooks()
 	if err != nil {
@@ -681,6 +686,57 @@ func TestPebbleCountPrimaryBooks(t *testing.T) {
 	// Assert
 	if newCount != initialCount+5 {
 		t.Errorf("Expected count to increase by 5, got %d -> %d", initialCount, newCount)
+	}
+}
+
+// invalidatePrimaryCountForTest drops the cached primary-book count so the next
+// CountPrimaryBooks call performs a fresh scan. Test-only seam living in the
+// _test file so it never ships in production binaries.
+func (p *PebbleStore) invalidatePrimaryCountForTest() {
+	p.primaryCountMu.Lock()
+	p.primaryCountValid = false
+	p.primaryCountMu.Unlock()
+}
+
+// TestPebbleCountPrimaryBooksTTLCache is a regression test for the CPU busy-loop
+// fix: CountPrimaryBooks must serve a cached value within primaryCountCacheTTL
+// instead of re-scanning the whole library on every call. Without the cache this
+// test fails, because the second read would immediately reflect the newly created
+// book.
+func TestPebbleCountPrimaryBooksTTLCache(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	// Prime the cache.
+	base, err := ps.CountPrimaryBooks()
+	if err != nil {
+		t.Fatalf("initial count: %v", err)
+	}
+
+	// Write a book WITHOUT invalidating the cache.
+	if _, err := ps.CreateBook(&Book{Title: "Cached Book", FilePath: "/test/cache/book.mp3"}); err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+
+	// Within the TTL, the cached (stale) value must be returned — proving the
+	// scan was skipped. An uncached implementation would return base+1 here.
+	cached, err := ps.CountPrimaryBooks()
+	if err != nil {
+		t.Fatalf("cached count: %v", err)
+	}
+	if cached != base {
+		t.Fatalf("expected cached count %d within TTL, got %d (cache not serving stale value)", base, cached)
+	}
+
+	// After invalidation the fresh scan must observe the new book.
+	ps.invalidatePrimaryCountForTest()
+	fresh, err := ps.CountPrimaryBooks()
+	if err != nil {
+		t.Fatalf("fresh count: %v", err)
+	}
+	if fresh != base+1 {
+		t.Fatalf("expected fresh count %d after invalidation, got %d", base+1, fresh)
 	}
 }
 


### PR DESCRIPTION
## Problem

Prod (`audiobook-organizer serve`) sat at **~189% CPU while idle** — nothing importing, logs showing only `deps_scheduler: sweep tick waiting_count=0`. Surfaced while health-checking the (now torn-down) dedup sandbox, which showed the identical symptom.

**Root cause:** `CountPrimaryBooks()` full-iterates every `book:` key and `json.Unmarshal`s the whole `Book` struct for all ~44K books — **5.6s per call** (timed via `GET /api/v1/health`, which calls it). The metrics/status ticker (`server_lifecycle.go`, every **5s**) called it on every tick, so with each scan taking longer than the tick the scans ran **back-to-back, continuously** — one core on the scan, a second on the GC churn from tens of thousands of unmarshals per pass.

**Diagnosis:** SIGQUIT of the disposable sandbox replica (identical symptom) → the only `[runnable]` app goroutine was spinning in `Server.Start.func7 → CountPrimaryBooks → json.Unmarshal`, alongside 48 busy GC mark workers.

**Not a recent regression** — the ticker path dates to 2026-05-01 (`79cc70f4`). Weeks of ~2 cores wasted. Also made `/api/v1/health` a ~5.6s response (probe-timeout risk).

## Fix

A 30s in-memory TTL cache on `CountPrimaryBooks` with a recompute gate (a burst of concurrent `/health` probes collapses to one scan per window). The expensive scan now runs at most once per TTL instead of on every 5s tick; the count may lag a write by ≤30s, fine for a metrics gauge / health probe.

**Design notes**
- **Pure TTL, not invalidate-on-write** — deliberate. Invalidation would re-trigger the full 5.6s scan on the very next 5s tick during any import, reintroducing the busy-loop under load (the same reason `GetDashboardStats` uses a min-interval guard). The observed bug is an *idle* loop; pure TTL fixes idle completely and is thrash-free under writes.
- **Ticker left at 5s** (smaller change than the approach originally sketched): once cached, the TTL governs the expensive path, so the ticker interval no longer affects CPU, and 5s keeps memory/goroutine metrics live in the UI.
- Fixes every caller at once (ticker, `/health`, diagnostics) with no call-site changes.
- Future optimization (out of scope): `CountPrimaryBooks` could count from the warm memdb like `computeLibraryStats` does (~150× faster), making even the recompute cheap.

## Testing

- `TestPebbleCountPrimaryBooksTTLCache` — regression test; **fails without the cache** (verified: the uncached path returns `base+1` immediately instead of the cached value).
- `TestPebbleCountPrimaryBooks` updated (count is now TTL-cached; invalidates before the correctness assertion).
- `go vet ./internal/database/ ./internal/server/` clean; `go test ./internal/database/ -race` green (269s); full `go build ./...` clean.

## Post-deploy verification

Re-time `GET /api/v1/health` (expect ~instant after the first call) and confirm prod CPU drops from ~189% toward baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)