### PR TITLE
feat(changelog): adopt changelog.d fragments assembled by scriv

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,62 @@
+# file: .github/workflows/changelog-check.yml
+# version: 1.0.0
+# guid: f0377e85-bfb7-42b2-bb99-6cdd80d34a73
+
+name: Changelog Fragment Check
+
+# Requires a changelog fragment under changelog.d/ on every PR. Self-skips if the
+# repo has no changelog.d/scriv.ini. See changelog.d/README.md. Shipped as a
+# small per-repo workflow because this repo's CI does not consume reusable-ci.yml.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-fragment:
+    name: Require changelog fragment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Require a changelog fragment
+        run: |
+          set -euo pipefail
+          if [ ! -f changelog.d/scriv.ini ]; then
+            echo "::notice::changelog.d/scriv.ini not present — changelog fragments not enabled here."
+            exit 0
+          fi
+          if [ "${SKIP_LABEL}" = "true" ]; then
+            echo "::notice::'skip-changelog' label present — skipping."
+            exit 0
+          fi
+          case "${PR_TITLE}" in
+            *"[skip changelog]"*)
+              echo "::notice::'[skip changelog]' in PR title — skipping."
+              exit 0 ;;
+          esac
+          git fetch --no-tags origin "${BASE_REF}"
+          added="$(git diff --name-only --diff-filter=A "origin/${BASE_REF}...HEAD" \
+            | { grep -E '^changelog\.d/.*\.md$' || true; } \
+            | { grep -vE '^changelog\.d/(README\.md$|templates/)' || true; })"
+          if [ -n "${added}" ]; then
+            echo "Found changelog fragment(s):"; echo "${added}"; exit 0
+          fi
+          echo "::error::No changelog fragment under changelog.d/. Run 'scriv create'"
+          echo "(see changelog.d/README.md), or add the 'skip-changelog' label or"
+          echo "'[skip changelog]' to the PR title if no changelog entry is needed."
+          exit 1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   prerelease:
     name: Create Prerelease Build
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # v2.14.4 (cleanup-step self-delete guard)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a8646210dae833d728538f1d9006ea45f4a4f488 # main: changelog.d collect step (org rollout)
     with:
       release-type: 'auto'
       prerelease: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   release:
     name: Create Production Release
-    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@7ff6ed85d901b86dd836254c973134a7a764fa51 # v2.14.4 (cleanup-step self-delete guard)
+    uses: falkcorp/github-common/.github/workflows/reusable-release.yml@a8646210dae833d728538f1d9006ea45f4a4f488 # main: changelog.d collect step (org rollout)
     with:
       release-type: ${{ github.event.inputs.release-type }}
       prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # Changelog
 
+<!-- scriv-insert-here -->
+
+<!-- scriv-end-here: releases below predate the changelog.d fragment system. -->
+
 ## [Unreleased]
 
 ### Features & Fixes

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,73 @@
+<!-- file: changelog.d/README.md -->
+<!-- version: 1.1.0 -->
+<!-- guid: 8d3a1f26-4c7b-4e59-b0a2-6f1d9c8e5a34 -->
+<!-- last-edited: 2026-07-16 -->
+
+# Changelog fragments (`changelog.d/`)
+
+`CHANGELOG.md` is **assembled** from the fragment files in this directory — you
+do **not** edit `CHANGELOG.md` by hand. Every change that is worth recording
+drops a small, uniquely-named Markdown fragment here instead. At release time
+the automation folds all fragments into a new dated section of `CHANGELOG.md`
+and deletes them.
+
+This exists because many contributors and AI agents open PRs in parallel. If
+everyone edited the single `## [Unreleased]` block in `CHANGELOG.md` directly,
+every PR would collide. A fragment-per-change means PRs never touch the same
+file, so there are no changelog merge conflicts.
+
+> This is a focused revival of the retired JSON "doc-update" system, using the
+> maintained open-source [`scriv`](https://scriv.readthedocs.io/) tool instead
+> of bespoke scripts.
+
+## Add a fragment
+
+```bash
+pip install scriv           # first time only (also in requirements.txt)
+scriv create                # writes changelog.d/<timestamp>_<branch>.md
+```
+
+Open the generated file, uncomment the section(s) that apply, and fill them in.
+You can also just create the file by hand following the format below. A CI check
+fails any PR that changes code without adding a fragment.
+
+## Format
+
+A fragment is a slice of Markdown grouped under Keep a Changelog category
+headings. Give each entry a `####` title and a short explanatory paragraph — a
+changelog carries **more detail than a release note**: what changed, why, and
+any impact or reproduction.
+
+```markdown
+### Fixed
+
+#### `reusable-release.yml` — cleanup step no longer deletes the stable release
+
+The cleanup step deleted the just-created stable release when its tag showed up
+in the "drafts or prereleases" set. Added a guard that skips any tag matching
+the new stable version.
+```
+
+- **Categories:** `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
+  `Security` (Keep a Changelog).
+- **Conventional-commit → category:** `feat` → Added, `fix` → Fixed,
+  `perf`/`refactor` → Changed; deprecations → Deprecated, removals → Removed,
+  security fixes → Security.
+- One fragment per logical change. Use several category sections in one fragment
+  only when a single change genuinely spans them.
+- Fragments are **exempt from the file-header rule** — do not add the
+  `file`/`version`/`guid` header (it would leak into `CHANGELOG.md`).
+
+## How assembly works
+
+- `scriv collect --version <tag>` (run by the shared release workflow
+  `reusable-release.yml` on stable releases) inserts a new
+  `## <version> — <date>` section at the `<!-- scriv-insert-here -->` marker in
+  `CHANGELOG.md`, grouped by category, and removes the collected fragments.
+- The PR fragment check comes from this repo's `changelog-check.yml` workflow.
+  Both the check and the collect step activate for any repo that has this
+  `changelog.d/scriv.ini`.
+- Configuration lives in [`scriv.ini`](scriv.ini); the new-fragment scaffold is
+  [`templates/new_fragment.md.j2`](templates/new_fragment.md.j2).
+- GitHub **release notes** stay commit-based; this detailed changelog is the
+  separate, richer artifact.

--- a/changelog.d/adopt-changelog-fragments.md
+++ b/changelog.d/adopt-changelog-fragments.md
@@ -1,0 +1,8 @@
+### Changed
+
+#### Adopt changelog fragments (`changelog.d/`) for assembling CHANGELOG.md
+
+`CHANGELOG.md` is now assembled from per-change Markdown fragments under
+`changelog.d/` by the shared release workflow (`scriv`), instead of being edited
+by hand. Contributors add a fragment with `scriv create`; a CI check requires
+one on each PR. This removes changelog merge conflicts across parallel PRs.

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,22 @@
+# file: changelog.d/scriv.ini
+# version: 1.0.0
+# guid: 5b1c9a7e-0d2f-4a63-9c81-3e6f4b2a8d10
+
+# scriv configuration for assembling CHANGELOG.md from changelog fragments.
+# https://scriv.readthedocs.io/  —  self-contained here so the repo root
+# stays free of a pyproject.toml just for this tool.
+[scriv]
+# Markdown fragments/output, matching the existing hand-written CHANGELOG.md.
+format = md
+output_file = CHANGELOG.md
+fragment_directory = changelog.d
+
+# Version heading renders at level 2 (## X.Y.Z — date), categories at level 3
+# (### Added), matching Keep a Changelog and the existing file structure.
+md_header_level = 2
+
+# Keep a Changelog categories, in the order they should appear in each release.
+categories = Added, Changed, Deprecated, Removed, Fixed, Security
+
+# Custom scaffold produced by `scriv create` (see templates/new_fragment.md.j2).
+new_fragment_template = file: changelog.d/templates/new_fragment.md.j2

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -1,0 +1,29 @@
+{#- Scaffold rendered by `scriv create`. Do NOT add a file header here — the -#}
+{#- rendered output is concatenated into CHANGELOG.md verbatim, so a header -#}
+{#- would leak into the changelog. -#}
+<!--
+Add ONE fragment per logical change. Uncomment the section(s) that apply below
+and replace the placeholder text, then delete the sections you do not use.
+
+A changelog entry carries MORE detail than a release note: state what changed,
+why, and any impact or reproduction — mirror the "#### short title" +
+explanatory paragraph style already used in CHANGELOG.md.
+
+Conventional-commit type -> category:
+  feat -> Added        fix -> Fixed         perf, refactor -> Changed
+  (deprecations -> Deprecated, removals -> Removed, security fixes -> Security)
+
+Leave every section commented out for a release-note-only entry (no changelog
+line). This file is auto-named and unique, so it never conflicts with other
+contributors' fragments.
+-->
+{% for cat in config.categories -%}
+<!--
+### {{ cat }}
+
+#### Short imperative title for the change
+
+A detailed explanation of the change: what it does, why it was needed, and any
+impact, migration note, or reproduction detail worth recording.
+-->
+{% endfor -%}


### PR DESCRIPTION
## Summary

Adopts the org-wide changelog-fragments system (built in `falkcorp/github-common`
#323/#324). Instead of hand-editing `CHANGELOG.md` — which collides on every
parallel PR — each change drops a small Markdown fragment under `changelog.d/`,
and the shared release workflow folds them into `CHANGELOG.md` at release time
via [`scriv`](https://scriv.readthedocs.io/).

## Issues Addressed

### feat(changelog): assemble CHANGELOG.md from changelog.d/ fragments

**Description:** Adds the `changelog.d/` scaffolding, marks the assembly point in
`CHANGELOG.md`, ships a per-repo fragment check, and bumps the shared
release-workflow pin so the `scriv collect` step runs on stable releases.

**Files Modified:**

- [`changelog.d/scriv.ini`](./changelog.d/scriv.ini) - scriv config (Keep a Changelog categories, Markdown, level-2 headings)
- [`changelog.d/templates/new_fragment.md.j2`](./changelog.d/templates/new_fragment.md.j2) - fragment scaffold for `scriv create`
- [`changelog.d/README.md`](./changelog.d/README.md) - contributor guide
- [`changelog.d/adopt-changelog-fragments.md`](./changelog.d/adopt-changelog-fragments.md) - seed fragment for this change
- [`CHANGELOG.md`](./CHANGELOG.md) - add `scriv-insert-here` / `scriv-end-here` markers above the existing (legacy) entries
- [`.github/workflows/changelog-check.yml`](./.github/workflows/changelog-check.yml) - require a fragment on PRs (self-skips without `changelog.d/scriv.ini`; `skip-changelog` label / `[skip changelog]` title escape hatch)
- [`.github/workflows/release-prod.yml`](./.github/workflows/release-prod.yml) / [`.github/workflows/prerelease.yml`](./.github/workflows/prerelease.yml) - bump `reusable-release.yml` pin to the main SHA that includes the `scriv collect` step

## Testing

- `scriv collect --version v0.0.0-test` on a copy of this repo's `CHANGELOG.md` +
  `changelog.d/` — the seed fragment assembles into a new `## v0.0.0-test`
  section at the marker, grouped by category, and the fragment is consumed; the
  existing `## [Unreleased]` and all prior releases are preserved below
  `scriv-end-here`.
- The adoption PR itself carries a fragment, so `changelog-check.yml` passes on
  this PR.

## Additional Notes

The fragment check ships as a small per-repo workflow because this repo's CI does
not consume `reusable-ci.yml` (it uses `reusable-ci-minimal.yml`); the `scriv
collect` step rides the shared `reusable-release.yml` that `release-prod.yml`
already calls. Going forward, do not edit `CHANGELOG.md` by hand — run
`scriv create` (`pip install scriv`). Opened as a draft for review.

## Breaking Changes

Process change: `CHANGELOG.md` is assembled from `changelog.d/` fragments; a CI
check requires a fragment on each PR (bypass with the `skip-changelog` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsNZiDgk29rvsrk5aWsqDW)_