### PR TITLE
fix(deps): force brace-expansion >=5.0.7 in web via npm override

### DIFF
--- a/changelog.d/fix-brace-expansion-web.md
+++ b/changelog.d/fix-brace-expansion-web.md
@@ -1,0 +1,7 @@
+### Security
+
+#### Force `brace-expansion` >= 5.0.7 in `web/` via npm override
+
+The frontend pulled in a vulnerable transitive `brace-expansion@5.0.6` (ReDoS). Added a
+`brace-expansion` npm override in `web/package.json`, bumping it to 5.0.7. `npm` reports 0
+vulnerabilities.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2695,9 +2695,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,8 @@
     "zustand": "^4.4.7"
   },
   "overrides": {
-    "minimatch": ">=10.2.1"
+    "minimatch": ">=10.2.1",
+    "brace-expansion": "^5.0.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",


### PR DESCRIPTION
Closes the repo's one open Dependabot alert (brace-expansion 5.0.6 ReDoS, high). Adds a `brace-expansion` npm override in `web/package.json` → 5.0.7; `npm` reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)