### PR TITLE
fix(itunes): canonicalize ITL writeback locations (native W:\ + 0x0B) — unblocks library populate

### DIFF
--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -95,3 +95,35 @@ deploy-debug: web-build
 	    *) echo "❌ Deployed version does NOT match git describe — stale binary shipped?"; exit 1 ;; \
 	  esac
 	@echo "✅ Debug build deployed to $(DEPLOY_HOST)."
+
+# ============================================================================
+# Sandbox: disposable full-fidelity replica for testing RISKY / DESTRUCTIVE changes
+# ----------------------------------------------------------------------------
+# Runs a SECOND instance of the app on :8485 against a ZFS *clone* of the media
+# tree + a *copy* of the production DB, inside a mount namespace that redirects the
+# production paths to the clones. Because the DB stores absolute paths and there is
+# no path-rewrite hook, redirecting BELOW the app (at the kernel) is what makes the
+# isolation correct-by-construction: a hardcoded path or a stale cache entry lands
+# on the clone, not production. Use it before any change that moves/deletes files,
+# rewrites the ITL, purges candidates, etc. — verify on the clone, then ship to prod.
+#
+# The proven scripts + full runbook live in the (private) infra-docs repo under
+# scripts/dedup-sandbox/. Fill the vars below with YOUR datasets/paths in the
+# gitignored Makefile.local; do NOT commit real ZFS dataset names or host paths.
+#
+#   SANDBOX_SCRIPTS_SRC := /path/to/infra-docs/scripts/dedup-sandbox
+#   SANDBOX_SCRIPTS_DST := /tmp/abk-sandbox/scripts
+#   SANDBOX_BIN_REMOTE  := /tmp/abk-sandbox/audiobook-organizer-fix
+#
+# Prereqs on the server (one-time): kernel.unprivileged_userns_clone=1, and a
+# sudoers rule letting the deploy user run /usr/sbin/zfs NOPASSWD.
+#
+# Targets (see Makefile.local for the wired-up versions):
+#   sandbox-bootstrap  one-time/refresh: snapshot prod media + build pristine DB image
+#   sandbox-reset      THE checkpoint: destroy+re-clone media, restore DB from pristine
+#   sandbox-fix        cross-compile the current tree, ship it as the sandbox binary
+#   sandbox-run        launch the 2nd instance on :8485 (uses the fix binary if present)
+#   sandbox-verify     ISOLATION GATE — delete a prod-path file in the ns, confirm prod survives
+#   sandbox-destroy    stop the instance + zfs destroy the clone (prod untouched)
+#   sandbox            full cycle: scripts -> reset -> fix -> run -> verify
+# ============================================================================

--- a/changelog.d/fix-itunes-writeback-location-canonicalization.md
+++ b/changelog.d/fix-itunes-writeback-location-canonicalization.md
@@ -1,0 +1,24 @@
+### Fixed
+
+#### iTunes ITL writeback now produces valid, safety-contract-clean track locations
+
+The `rebuild` / `rebuild-full` / export writeback wrote each track's location as
+the raw stored `ITunesPath` — a mix of `file://…%20` URLs and Linux `/mnt/…`
+paths — straight into the ITL `0x0D` Location field, which `SafeWriteITL`'s
+`ITLSafetyContract` rejected wholesale (the class of bad write that corrupted the
+generated library on 2026-07-05). Two fixes:
+
+- Every track location is now derived from the book's **current** `FilePath`,
+  reverse-mapped via the configured iTunes path mappings and canonicalized to a
+  native Windows path (`W:\…`), so the ITL points iTunes at wherever the file
+  currently lives (the `audiobook-organizer` copy for organized books) rather than
+  the frozen original path. Unmappable locations are skipped-with-warn + metric,
+  never written raw. Track **adds** now also write the required `0x0B` LocalURL
+  sibling (the metadata-update path already did; adds did not).
+- `startCacheWarmers` fire-and-forget goroutines gained a `recover()` guard so a
+  warmup fault (e.g. a store read tripping a dependency bug, or a torn DB on a
+  clone) degrades to a cold cache instead of crashing the server at startup.
+
+Validated end-to-end on a full-fidelity ZFS-clone replica of production: a blank
+library populated cleanly (11,819 tracks added, contract accepted) where the old
+code was rejected on every track.

--- a/internal/itunes/itl_le_mutate.go
+++ b/internal/itunes/itl_le_mutate.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/itl_le_mutate.go
-// version: 1.2.0
+// version: 2.1.0
 // guid: d5e6f7a8-b9c0-1d2e-3f4a-5b6c7d8e9f00
 //
 // LE-format ITL mutation: add and remove tracks from v10+ (msdh/mith/mhoh)
@@ -75,9 +75,17 @@ func AddTracksLE(data []byte, tracks []ITLNewTrack) []byte {
 		// rather than writing an invented encoding (CRIT-1) — all six below are
 		// in the table.
 		var mhohData []byte
-		// Location first (0x0D), then metadata — matches iTunes convention
+		// Location first (0x0D + its sibling 0x0B), then metadata — matches iTunes
+		// convention. A 0x0D native path MUST be accompanied by the 0x0B LocalURL
+		// (the ITLSafetyContract rejects a lone 0x0D). tr.Location is the canonical
+		// WinPath; derive the pair and write BOTH, mirroring the update path. If it
+		// can't be normalized, skip the location entirely rather than emit a bare
+		// 0x0D that the safety contract would reject.
 		if tr.Location != "" {
-			mhohData = appendMhohLE(mhohData, 0x0D, tr.Location)
+			if pair, err := normalizeLocationValue(tr.Location); err == nil {
+				mhohData = appendMhohLE(mhohData, 0x0D, pair.WinPath)
+				mhohData = appendMhohLE(mhohData, 0x0B, pair.URL)
+			}
 		}
 		if tr.Name != "" {
 			mhohData = appendMhohLE(mhohData, 0x02, tr.Name)

--- a/internal/itunes/rebuild.go
+++ b/internal/itunes/rebuild.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/rebuild.go
-// version: 2.2.0
+// version: 2.3.0
 // guid: 3f2e1d0c-9b8a-7c6d-5e4f-3a2b1c0d9e8f
 // last-edited: 2026-07-07
 
@@ -11,7 +11,44 @@ import (
 	"strings"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metrics"
 )
+
+// canonicalWinLocation derives the native Windows ITL location (hohm 0x0D) for a
+// book from its CURRENT local FilePath, reverse-mapped to a Windows path via the
+// configured iTunes path mappings. Per the deprecation design the ITL points iTunes
+// at wherever the file currently lives (the audiobook-organizer copy for organized
+// books), NOT the frozen original ITunesPath. Returns ("", false) — the caller MUST
+// skip the track — for any path that cannot be canonicalized: a raw/invalid location
+// (a Linux path, a file:// URL, a %XX-escaped value) is NEVER written into 0x0D,
+// which is exactly what the ITLSafetyContract rejects (CRIT-2 / K4).
+func canonicalWinLocation(store RebuildStore, book *database.Book, mappings []PathMapping) (string, bool) {
+	localPath := book.FilePath
+	if bfs, err := store.GetBookFiles(book.ID); err == nil && len(bfs) > 0 && bfs[0].FilePath != "" {
+		localPath = bfs[0].FilePath
+	}
+	if localPath == "" {
+		return "", false
+	}
+	// ReverseRemapPath yields a Windows-rooted path but with forward slashes
+	// (e.g. "W:/audiobook-organizer/Author/01.m4b"); the ITL 0x0D form is a NATIVE
+	// Windows path with backslashes, and isWindowsAbsPath rejects any '/'. Flip the
+	// separators before validating. A path that didn't map (still "/mnt/...") becomes
+	// "\mnt\..." with no drive letter and is correctly rejected below → skipped.
+	winish := strings.ReplaceAll(ReverseRemapPath(localPath, mappings), "/", `\`)
+	pair, err := NewLocationPair(winish)
+	if err != nil {
+		metrics.RecordITunesLocationUnmappable("rebuild_invalid_path")
+		pid := ""
+		if book.ITunesPersistentID != nil {
+			pid = *book.ITunesPersistentID
+		}
+		slog.Warn("ITL rebuild: skipping track with unmappable location (never written raw — CRIT-2)",
+			"pid", pid, "local", localPath, "error", err.Error())
+		return "", false
+	}
+	return pair.WinPath, true
+}
 
 // RebuildStore is the minimal store interface needed by ITL rebuild functions:
 // read access to books plus the ability to look up book files
@@ -28,7 +65,7 @@ type RebuildStore interface {
 // ComputeITLDiff reads the current ITL and the current DB state,
 // and returns the ITLOperationSet that would synchronize them
 // plus a preview of what that set contains.
-func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLRebuildPreview, error) {
+func ComputeITLDiff(store RebuildStore, itlPath string, mappings []PathMapping) (*ITLOperationSet, *ITLRebuildPreview, error) {
 	// Parse the current ITL to get all existing tracks.
 	lib, err := ParseITL(itlPath)
 	if err != nil {
@@ -98,8 +135,12 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 		track, inITL := itlTracks[pid]
 		if !inITL {
 			// Book has a PID but no ITL entry → add.
-			// Build an ITLNewTrack from the book's metadata.
-			newTrack := buildNewTrackFromBook(store, book)
+			// Build an ITLNewTrack from the book's metadata. Skip the add if the
+			// location can't be canonicalized — never insert a raw/invalid 0x0D.
+			newTrack, ok := buildNewTrackFromBook(store, book, mappings)
+			if !ok {
+				continue
+			}
 			ops.Adds = append(ops.Adds, newTrack)
 			preview.ToAdd++
 			continue
@@ -141,12 +182,10 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 			preview.ToUpdateMeta++
 		}
 
-		// Location update.
-		wantLoc := ""
-		if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 && bfs[0].ITunesPath != "" {
-			wantLoc = bfs[0].ITunesPath
-		}
-		if wantLoc != "" && track.Location != wantLoc {
+		// Location update: canonicalize the book's CURRENT FilePath to a native
+		// Windows path (0x0D). Unmappable locations are skipped (never written raw).
+		wantLoc, locOK := canonicalWinLocation(store, book, mappings)
+		if locOK && track.Location != wantLoc {
 			ops.LocationUpdates = append(ops.LocationUpdates, ITLLocationUpdate{
 				PersistentID: pid,
 				NewLocation:  wantLoc,
@@ -154,7 +193,7 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 			preview.ToUpdateLoc++
 		}
 
-		if !needsMetaUpdate && (wantLoc == "" || track.Location == wantLoc) {
+		if !needsMetaUpdate && (!locOK || track.Location == wantLoc) {
 			preview.AlreadySynced++
 		}
 	}
@@ -162,25 +201,28 @@ func ComputeITLDiff(store RebuildStore, itlPath string) (*ITLOperationSet, *ITLR
 	return &ops, &preview, nil
 }
 
-// BuildNewTrackFromBook constructs an ITLNewTrack from a database
-// Book for insertion into the ITL. Fills as many fields as
-// possible from the book's metadata.
-func BuildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack {
-	return buildNewTrackFromBook(store, book)
+// BuildNewTrackFromBook constructs an ITLNewTrack from a database Book for
+// insertion into the ITL. Returns ok=false when the book's location cannot be
+// canonicalized into a native Windows path (the track must then be skipped, never
+// inserted with a raw 0x0D). mappings is the iTunes↔local path mapping set.
+func BuildNewTrackFromBook(store RebuildStore, book *database.Book, mappings []PathMapping) (ITLNewTrack, bool) {
+	return buildNewTrackFromBook(store, book, mappings)
 }
 
 // buildNewTrackFromBook constructs an ITLNewTrack from a database
 // Book for insertion into the ITL. Fills as many fields as
 // possible from the book's metadata.
-func buildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack {
+func buildNewTrackFromBook(store RebuildStore, book *database.Book, mappings []PathMapping) (ITLNewTrack, bool) {
+	// Canonicalize the current location to a native Windows path (0x0D). If it can't
+	// be mapped, signal skip — the caller must not insert a track with a raw location.
+	location, ok := canonicalWinLocation(store, book, mappings)
+	if !ok {
+		return ITLNewTrack{}, false
+	}
 	authorName := resolveAuthorName(store, book)
 	genre := "Audiobook"
 	if book.Genre != nil && *book.Genre != "" {
 		genre = *book.Genre
-	}
-	location := book.FilePath
-	if bfs, bfErr := store.GetBookFiles(book.ID); bfErr == nil && len(bfs) > 0 && bfs[0].ITunesPath != "" {
-		location = bfs[0].ITunesPath
 	}
 	totalTime := 0
 	if book.Duration != nil {
@@ -206,7 +248,7 @@ func buildNewTrackFromBook(store RebuildStore, book *database.Book) ITLNewTrack 
 		Kind:      "MPEG audio file", // default; the real kind comes from the file format
 		Size:      int(size),
 		TotalTime: totalTime,
-	}
+	}, true
 }
 
 // resolveAuthorName returns the author name for a book. Takes the
@@ -259,7 +301,7 @@ type ITLRebuildResult struct {
 // "rebuild" into "mass deletion" (the July 2026 stub class), and Force
 // (needed legitimately for bounded-delta here) would otherwise be the only
 // gate. A >50% shrink without acknowledgment is an error, never a write.
-func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledgeShrink bool) (*ITLRebuildResult, error) {
+func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, mappings []PathMapping, acknowledgeShrink bool) (*ITLRebuildResult, error) {
 	lib, err := ParseITL(itlPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse ITL: %w", err)
@@ -295,7 +337,9 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledg
 			if b.ITunesPersistentID == nil || *b.ITunesPersistentID == "" {
 				continue
 			}
-			adds = append(adds, buildNewTrackFromBook(store, b))
+			if nt, ok := buildNewTrackFromBook(store, b, mappings); ok {
+				adds = append(adds, nt)
+			}
 		}
 		afterID = books[len(books)-1].ID
 		if len(books) < pageSize {
@@ -342,7 +386,7 @@ func RebuildITLFromDB(store RebuildStore, itlPath, outputPath string, acknowledg
 // DB books. The resulting bytes are returned (not written to disk); the caller
 // is responsible for sending them to the client.
 // If bookIDs is empty, all primary-version non-deleted books with PIDs are included.
-func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) ([]byte, error) {
+func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string, mappings []PathMapping) ([]byte, error) {
 	// Collect the requested books from the store.
 	wantIDs := make(map[string]bool, len(bookIDs))
 	for _, id := range bookIDs {
@@ -374,7 +418,9 @@ func BuildExportITL(store RebuildStore, templatePath string, bookIDs []string) (
 			if len(wantIDs) > 0 && !wantIDs[b.ID] {
 				continue
 			}
-			adds = append(adds, buildNewTrackFromBook(store, b))
+			if nt, ok := buildNewTrackFromBook(store, b, mappings); ok {
+				adds = append(adds, nt)
+			}
 		}
 		afterID = books[len(books)-1].ID
 		if len(books) < pageSize {

--- a/internal/itunes/rebuild_test.go
+++ b/internal/itunes/rebuild_test.go
@@ -247,12 +247,20 @@ func TestBuildNewTrackFromBook(t *testing.T) {
 		books: map[string]*database.Book{bookID: book},
 		bookFiles: map[string][]database.BookFile{
 			bookID: {{
-				ITunesPath: "/itunes/books/Test Audiobook.m4b",
+				// Current local path (organized copy) — the writeback emits THIS,
+				// reverse-mapped to a native Windows path, not the frozen ITunesPath.
+				FilePath: "/mnt/library/Author Name/Test Audiobook/01.m4b",
 			}},
 		},
 	}
+	// W: on Windows == /mnt/library on the server; the same entry serves both
+	// directions (import forward, writeback reverse).
+	mappings := []PathMapping{{From: "W:", To: "/mnt/library"}}
 
-	track := buildNewTrackFromBook(store, book)
+	track, ok := buildNewTrackFromBook(store, book, mappings)
+	if !ok {
+		t.Fatalf("expected buildNewTrackFromBook to succeed for a mappable path")
+	}
 
 	// Verify track fields
 	if track.Name != title {
@@ -273,8 +281,8 @@ func TestBuildNewTrackFromBook(t *testing.T) {
 	if track.Size != int(fileSize) {
 		t.Errorf("expected Size=%d, got %d", fileSize, track.Size)
 	}
-	if track.Location != "/itunes/books/Test Audiobook.m4b" {
-		t.Errorf("expected Location from BookFile, got %q", track.Location)
+	if track.Location != `W:\Author Name\Test Audiobook\01.m4b` {
+		t.Errorf("expected canonical native Windows Location, got %q", track.Location)
 	}
 }
 
@@ -316,14 +324,19 @@ func TestBuildNewTrackFromBookWithDefaults(t *testing.T) {
 	book := &database.Book{
 		ID:       bookID,
 		Title:    title,
-		FilePath: "/path/to/book.m4b",
+		// Book-level FilePath is used when there are no book files.
+		FilePath: "/mnt/library/Minimal/01.m4b",
 	}
 
 	store := &mockRebuildStore{
 		books: map[string]*database.Book{bookID: book},
 	}
+	mappings := []PathMapping{{From: "W:", To: "/mnt/library"}}
 
-	track := buildNewTrackFromBook(store, book)
+	track, ok := buildNewTrackFromBook(store, book, mappings)
+	if !ok {
+		t.Fatalf("expected buildNewTrackFromBook to succeed for a mappable path")
+	}
 
 	// Verify defaults
 	if track.Name != title {
@@ -332,10 +345,43 @@ func TestBuildNewTrackFromBookWithDefaults(t *testing.T) {
 	if track.Genre != "Audiobook" {
 		t.Errorf("expected Genre=Audiobook, got %q", track.Genre)
 	}
-	if track.Location != book.FilePath {
-		t.Errorf("expected Location from FilePath, got %q", track.Location)
+	if track.Location != `W:\Minimal\01.m4b` {
+		t.Errorf("expected canonical native Windows Location, got %q", track.Location)
 	}
 	if track.TotalTime != 0 {
 		t.Errorf("expected TotalTime=0 (no duration), got %d", track.TotalTime)
+	}
+}
+
+// TestCanonicalWinLocation covers the three real-world location shapes that broke
+// the writeback (Linux path, and the two Windows forms) plus the skip behavior.
+func TestCanonicalWinLocation(t *testing.T) {
+	mappings := []PathMapping{{From: "W:", To: "/mnt/bigdata/books"}}
+	book := func(fp string) *database.Book { return &database.Book{ID: "b", FilePath: fp} }
+	st := &mockRebuildStore{}
+
+	cases := []struct {
+		name    string
+		file    string
+		wantLoc string
+		wantOK  bool
+	}{
+		{"organized AO path -> W:\\audiobook-organizer",
+			"/mnt/bigdata/books/audiobook-organizer/Author/Book/01.m4b",
+			`W:\audiobook-organizer\Author\Book\01.m4b`, true},
+		{"still-in-itunes path -> W:\\itunes",
+			"/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/A/01.mp3",
+			`W:\itunes\iTunes Media\Audiobooks\A\01.mp3`, true},
+		{"unmappable path outside the mapped root -> skip",
+			"/var/other/place/01.m4b", "", false},
+		{"empty path -> skip", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := canonicalWinLocation(st, book(c.file), mappings)
+			if ok != c.wantOK || got != c.wantLoc {
+				t.Fatalf("canonicalWinLocation(%q) = (%q,%v), want (%q,%v)", c.file, got, ok, c.wantLoc, c.wantOK)
+			}
+		})
 	}
 }

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,5 +1,5 @@
 // file: internal/server/itl_rebuild.go
-// version: 3.2.2
+// version: 3.3.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
 // last-edited: 2026-07-03
 //
@@ -43,6 +43,20 @@ type ITLRebuildPreview = itunes.ITLRebuildPreview
 // Deprecated: Use itunes.ITLRebuildResult instead.
 type ITLRebuildResult = itunes.ITLRebuildResult
 
+// itlPathMappings converts the configured iTunes path mappings into the itunes
+// package type so the rebuild/export writeback can canonicalize each book's local
+// FilePath into a native Windows ITL location. If the config is empty (the mapping
+// hasn't been set), locations that aren't already native Windows paths are skipped
+// rather than written raw — so the ITL never contains an invalid 0x0D.
+func itlPathMappings() []itunes.PathMapping {
+	cfg := config.AppConfig.ITunes.PathMappings
+	out := make([]itunes.PathMapping, len(cfg))
+	for i, m := range cfg {
+		out[i] = itunes.PathMapping{From: m.From, To: m.To}
+	}
+	return out
+}
+
 // rebuildITLHandler handles POST /api/v1/itunes/rebuild.
 // Query param: dry_run=true returns the diff preview without
 // applying. Otherwise applies the diff via itunesservice.SafeWriteITL.
@@ -59,7 +73,7 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 	}
 
 	store := s.Store()
-	ops, preview, err := itunes.ComputeITLDiff(store, itlPath)
+	ops, preview, err := itunes.ComputeITLDiff(store, itlPath, itlPathMappings())
 	if err != nil {
 		httputil.RespondWithInternalError(c, fmt.Sprintf("diff failed: %v", err))
 		return
@@ -139,7 +153,7 @@ func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 		return
 	}
 
-	result, err := itunes.RebuildITLFromDB(store, itlPath, itlPath, c.Query("acknowledge_shrink") == "true")
+	result, err := itunes.RebuildITLFromDB(store, itlPath, itlPath, itlPathMappings(), c.Query("acknowledge_shrink") == "true")
 	if err != nil {
 		httputil.RespondWithInternalError(c, fmt.Sprintf("full rebuild failed: %v", err))
 		return
@@ -170,7 +184,7 @@ func (s *Server) exportITLPartialHandler(c *gin.Context) {
 	}
 	_ = c.ShouldBindJSON(&body) // empty body = all books
 
-	data, err := itunes.BuildExportITL(s.Store(), itlPath, body.BookIDs)
+	data, err := itunes.BuildExportITL(s.Store(), itlPath, body.BookIDs, itlPathMappings())
 	if err != nil {
 		httputil.RespondWithInternalError(c, fmt.Sprintf("build export ITL: %v", err))
 		return

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 1.46.0
+// version: 3.1.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-07-18
 
@@ -703,11 +703,24 @@ func (s *Server) Start(cfg ServerConfig) error {
 // (PEBBLE-CLOSED family). Each launch also skips on an already-canceled
 // bgCtx — a SKIP-on-shutdown guard, not a startup gate: a live bgCtx must
 // still run every warmer.
+// warmerRecover logs and swallows a panic in a fire-and-forget cache warmer.
+// Warmers are best-effort by design (they only pre-populate a TTL cache), so a
+// warmup fault — a transient store read error, a store read that trips a
+// dependency bug — must degrade to a cold cache, never crash the whole server.
+// Without this, an unrecovered panic in one warmer goroutine takes the process
+// down at startup.
+func warmerRecover(name string) {
+	if r := recover(); r != nil {
+		slog.Error("cache warmer panicked — continuing with a cold cache", "warmer", name, "panic", r)
+	}
+}
+
 func (s *Server) startCacheWarmers() {
 	// Pre-warm facets cache (genres/languages) - lightweight, <1 second
 	s.bgWG.Add("facets-warmer")
 	go func() {
 		defer s.bgWG.Done("facets-warmer")
+		defer warmerRecover("facets")
 		if s.bgCtx.Err() != nil {
 			return // server already shutting down — skip, never warm a closing store
 		}
@@ -720,6 +733,7 @@ func (s *Server) startCacheWarmers() {
 	s.bgWG.Add("library-sizes-warmer")
 	go func() {
 		defer s.bgWG.Done("library-sizes-warmer")
+		defer warmerRecover("library-sizes")
 		if s.bgCtx.Err() != nil {
 			return // server already shutting down — skip, never warm a closing store
 		}
@@ -737,11 +751,13 @@ func (s *Server) startCacheWarmers() {
 	s.bgWG.Add("library-list-warmer")
 	go func() {
 		defer s.bgWG.Done("library-list-warmer")
+		defer warmerRecover("library-list")
 		s.warmAudiobookListCache()
 	}()
 	s.bgWG.Add("authors-warmer")
 	go func() {
 		defer s.bgWG.Done("authors-warmer")
+		defer warmerRecover("authors")
 		if s.bgCtx.Err() != nil {
 			return // server already shutting down — skip, never warm a closing store
 		}
@@ -750,6 +766,7 @@ func (s *Server) startCacheWarmers() {
 	s.bgWG.Add("series-warmer")
 	go func() {
 		defer s.bgWG.Done("series-warmer")
+		defer warmerRecover("series")
 		if s.bgCtx.Err() != nil {
 			return // server already shutting down — skip, never warm a closing store
 		}


### PR DESCRIPTION
## What
Fixes the iTunes ITL writeback so it produces **valid, `ITLSafetyContract`-clean** track locations — the class of bad write that corrupted the generated library on 2026-07-05.

- Track locations now derive from the book's **current `FilePath`**, reverse-mapped + canonicalized to a native Windows path (`W:\…`) → points iTunes at the `audiobook-organizer` copies (the deprecation end-state), not the frozen `ITunesPath`. Unmappable → skip-with-warn (never raw).
- Track **adds** now write the required **`0x0B` LocalURL sibling** (the update path already did; adds didn't — the last thing the contract rejected).
- `startCacheWarmers` goroutines gained a `recover()` guard so a warmup fault can't crash the server at startup.

Part B (persist `itunes_path_mappings`) needed **no code** — the config round-trip already persists nested fields; send `{"itunes":{"path_mappings":[…]}}`.

## Proven end-to-end on a ZFS-clone replica of prod
`rebuild-full` applied cleanly (removed 374, **added 11,819, contract ACCEPTED**), `.itl` 373 KB → 2.16 MB populated — where the old code rejected every track. Prod never touched.

## Populate note
Use **`rebuild-full`** to populate a blank library (it passes `ForceContractConfig()` to override the bounded-delta cap); set the mapping first via `PUT /config {"itunes":{"path_mappings":[{"from":"W:","to":"/mnt/bigdata/books"}]}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)