### PR TITLE
feat(itunes): P3 merged-track cleanup writeback

### DIFF
--- a/changelog.d/feat-itunes-cleanup-merged.md
+++ b/changelog.d/feat-itunes-cleanup-merged.md
@@ -1,0 +1,20 @@
+<!-- file: changelog.d/feat-itunes-cleanup-merged.md -->
+<!-- version: 0.1.0 -->
+<!-- guid: c7e1b0a4-5d92-4f68-8b03-2a9f1e6d4c07 -->
+<!-- last-edited: 2026-07-22 -->
+
+### Added
+
+#### iTunes merged-track cleanup (`/cleanup-merged`) — P3 of the 2-way-sync writeback
+
+New `POST /api/v1/itunes/cleanup-merged` removes stale duplicate audiobook tracks
+left in the library by books that were merged/superseded — the merge-cleanup that
+never applied while the writeback was broken. A track is removed only if its PID
+belongs to a **non-primary** book_file and **no primary** book_file also owns it
+(shared PIDs are kept, defensively). Removal goes through `RemoveTracksByPIDLE`,
+which excises the master track and auto-cleans orphaned playlist references in one
+pass; the `no-new-dangling-refs` and bounded-delta (≤5000 removes) guards are the
+safety net. Candidates come only from DB book_files, so music and podcast tracks
+are never touched. `dry_run=true` previews the removal (to-remove / shared-skipped /
+primary / non-primary counts). Implements P3 of
+`docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md`.

--- a/docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md
+++ b/docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md
@@ -1,5 +1,5 @@
 <!-- file: docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md -->
-<!-- version: 0.3.0 -->
+<!-- version: 0.4.0 -->
 <!-- guid: 193a875e-d0ca-4bc5-b34f-6461e03a0edb -->
 <!-- last-edited: 2026-07-22 -->
 
@@ -161,10 +161,20 @@ back into the DB is deferred to a later phase (P4), not v1.
   (`dry_run` supported) + `POST /api/v1/itunes/adopt-base` (re-bless reseeded sidecar). Unit
   tested (`relocate_test.go`). **Next: dry-run on prod, then `itl-diff --audit` pre/post oracle
   (expect tracks Δ0, playlists Δ0, only Location changed) before applying.**
-- **P2 — Add-path.** Never-in-iTunes AO books via `AddTracksLE` + playlist insertion.
-- **P3 — Topology + playlist-ref remap.** Remove/merge with playlist integrity (§5.2). Highest
-  risk; most adversarial testing.
-- **P4 — iTunes→AO read-back** (if in scope per §5.4).
+- **P2 — Add-path. ✅ NO WORK (measured 2026-07-22).** The prod relocate dry-run reported
+  `unmatched_files: 0` — every primary book_file already has a matching library track, so there
+  are no never-in-iTunes AO books to add. (The `ITLNewTrack.PersistentID`-honoring add path would
+  be needed if this becomes non-zero later.)
+- **P3 — Merged-track cleanup. ✅ BUILT (2026-07-22).** `ComputeMergedTrackCleanup`
+  (`internal/itunes/cleanup_merged.go`) + `POST /api/v1/itunes/cleanup-merged` (dry_run). Removes
+  stale duplicate audiobook tracks whose PID belongs to a non-primary/merged book_file and not to
+  any primary — the merge-cleanup that never applied while the writeback was broken. Removal
+  auto-cleans orphaned playlist refs (`RemoveTracksByPIDLE` v1.2.0), so no manual remap is needed;
+  bounded-delta (≤5000) + no-new-dangling-refs guard it. Estimated ~4,061 candidates (85,783
+  matched − 81,722 primary). **Destructive → dry-run + count review before apply.** Note: this is
+  the *already-merged* cleanup; reflecting *future* AO merges/reassembly still depends on the
+  upstream reconciliation engine (see reconciliation spec).
+- **P4 — iTunes→AO read-back** (deferred per §5.4 — preserve-only in v1).
 
 Each phase is sandbox-proven before prod, using the existing ZFS-clone sandbox (rebuild scripts
 in infra-docs) and `itl-diff` as the acceptance oracle.

--- a/internal/itunes/cleanup_merged.go
+++ b/internal/itunes/cleanup_merged.go
@@ -1,0 +1,115 @@
+// file: internal/itunes/cleanup_merged.go
+// version: 1.0.0
+// guid: 9c4e7a20-1b83-4d6f-a2e9-5c0d3b8f1a74
+// last-edited: 2026-07-22
+//
+// P3 of the 2-way-sync writeback: remove stale duplicate audiobook tracks left
+// in the library by books that were merged/superseded (the merge-cleanup that
+// never applied while the writeback was broken). A superseded track = a library
+// track whose PID belongs to a NON-primary book_file (a merged "loser" or
+// alternate version) and does NOT also belong to any primary book_file. Removal
+// goes through RemoveTracksByPIDLE, which excises the track AND cleans orphaned
+// playlist references. Only ever targets audiobook PIDs sourced from the DB —
+// music/podcast tracks are never in the candidate set. See
+// docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md (P3).
+
+package itunes
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// MergedCleanupPreview summarizes the superseded-track removal without applying.
+type MergedCleanupPreview struct {
+	TracksInITL    int `json:"tracks_in_itl"`
+	PrimaryPIDs    int `json:"primary_pids"`     // distinct primary book_file PIDs present in the ITL
+	NonPrimaryPIDs int `json:"non_primary_pids"` // distinct non-primary book_file PIDs present in the ITL
+	ToRemove       int `json:"to_remove"`        // non-primary PIDs that are NOT also a primary PID
+	SharedSkipped  int `json:"shared_skipped"`   // non-primary PIDs also owned by a primary (kept, defensive)
+}
+
+// ComputeMergedTrackCleanup finds superseded audiobook tracks to remove. It emits
+// ONLY Removes; never adds/relocates. A non-primary book_file PID is removed only
+// if no primary book_file also carries it (so we never remove a live track).
+func ComputeMergedTrackCleanup(store RebuildStore, itlPath string) (*ITLOperationSet, *MergedCleanupPreview, error) {
+	lib, err := ParseITL(itlPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse ITL: %w", err)
+	}
+	inITL := make(map[string]bool, len(lib.Tracks))
+	for i := range lib.Tracks {
+		inITL[strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))] = true
+	}
+	ops, preview := computeMergedCleanupFromInITL(inITL, store)
+	return ops, preview, nil
+}
+
+// computeMergedCleanupFromInITL is the ITL-independent core: given the set of
+// PIDs present in the library, it walks the DB's book_files and builds the
+// remove set (non-primary PIDs not also owned by a primary). Split out for unit
+// testing without minting a real .itl.
+func computeMergedCleanupFromInITL(inITL map[string]bool, store RebuildStore) (*ITLOperationSet, *MergedCleanupPreview) {
+	primary := make(map[string]bool)    // PID → is a primary book_file's PID
+	nonPrimary := make(map[string]bool) // PID → is a non-primary book_file's PID (in ITL)
+
+	const pageSize = 500
+	afterID := ""
+	for {
+		books, err := store.GetAllBooksFullFrom(afterID, pageSize)
+		if err != nil {
+			// Fail closed: if we can't fully enumerate the DB we cannot safely
+			// decide what is superseded, so remove nothing.
+			slog.Error("cleanup-merged: get books failed, aborting (remove nothing)", "err", err)
+			return &ITLOperationSet{Removes: map[string]bool{}}, &MergedCleanupPreview{TracksInITL: len(inITL)}
+		}
+		if len(books) == 0 {
+			break
+		}
+		for i := range books {
+			b := &books[i]
+			isPrimary := b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+			files, ferr := store.GetBookFiles(b.ID)
+			if ferr != nil {
+				continue
+			}
+			for j := range files {
+				pid := strings.ToUpper(files[j].ITunesPersistentID)
+				if pid == "" || !inITL[pid] {
+					continue
+				}
+				if isPrimary {
+					primary[pid] = true
+				} else {
+					nonPrimary[pid] = true
+				}
+			}
+		}
+		afterID = books[len(books)-1].ID
+		if len(books) < pageSize {
+			break
+		}
+	}
+
+	ops := ITLOperationSet{Removes: map[string]bool{}}
+	preview := &MergedCleanupPreview{
+		TracksInITL:    len(inITL),
+		PrimaryPIDs:    len(primary),
+		NonPrimaryPIDs: len(nonPrimary),
+	}
+	for pid := range nonPrimary {
+		if primary[pid] {
+			preview.SharedSkipped++ // a live primary also owns this PID — never remove
+			continue
+		}
+		ops.Removes[pid] = true
+		preview.ToRemove++
+	}
+
+	slog.Info("itunes cleanup-merged: computed superseded-track removal",
+		"tracksInITL", preview.TracksInITL, "primaryPIDs", preview.PrimaryPIDs,
+		"nonPrimaryPIDs", preview.NonPrimaryPIDs, "toRemove", preview.ToRemove,
+		"sharedSkipped", preview.SharedSkipped)
+	return &ops, preview
+}

--- a/internal/itunes/cleanup_merged_test.go
+++ b/internal/itunes/cleanup_merged_test.go
@@ -1,0 +1,70 @@
+// file: internal/itunes/cleanup_merged_test.go
+// version: 1.0.0
+// guid: 7d3a0c81-4e29-4b6f-90a5-1c8e2f7b0d43
+// last-edited: 2026-07-22
+
+package itunes
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// mergedCleanupTracks builds an itlTracks-equivalent inITL set and drives the
+// (unexported) core so we don't need a real .itl. It mirrors the split used by
+// ComputeMergedTrackCleanup: a non-primary PID is removed only if no primary
+// book_file also owns it, and a track absent from the DB (music) is never a
+// candidate.
+func TestComputeMergedTrackCleanup_core(t *testing.T) {
+	primaryV := true
+	nonPrimary := false
+
+	store := &mockRebuildStore{
+		books: map[string]*database.Book{
+			"bookP":  {ID: "bookP", IsPrimaryVersion: &primaryV},
+			"bookM":  {ID: "bookM", IsPrimaryVersion: &nonPrimary},
+			"bookS":  {ID: "bookS", IsPrimaryVersion: &primaryV},
+			"bookM2": {ID: "bookM2", IsPrimaryVersion: &nonPrimary},
+		},
+		bookFiles: map[string][]database.BookFile{
+			"bookP":  {{ITunesPersistentID: "AAAA0001", FilePath: "/x/p.m4b"}},
+			"bookM":  {{ITunesPersistentID: "NNNN0001", FilePath: "/x/n.m4b"}},
+			"bookS":  {{ITunesPersistentID: "5A5A0001", FilePath: "/x/s.m4b"}},
+			"bookM2": {{ITunesPersistentID: "5A5A0001", FilePath: "/x/s2.m4b"}},
+		},
+	}
+
+	// inITL: the primary P1, the merged N1, the shared PID, plus a MUSIC track
+	// with no DB book at all.
+	inITL := map[string]bool{
+		"AAAA0001": true, // primary
+		"NNNN0001": true, // merged non-primary → remove
+		"5A5A0001": true, // shared (primary+non-primary) → keep
+		"1234BEEF": true, // music, not in DB → never a candidate
+	}
+
+	ops, preview := computeMergedCleanupFromInITL(inITL, store)
+
+	if preview.ToRemove != 1 {
+		t.Errorf("ToRemove=%d, want 1 (only NNNN0001)", preview.ToRemove)
+	}
+	if preview.SharedSkipped != 1 {
+		t.Errorf("SharedSkipped=%d, want 1 (5A5A0001)", preview.SharedSkipped)
+	}
+	if !ops.Removes["NNNN0001"] {
+		t.Errorf("expected NNNN0001 in Removes")
+	}
+	if ops.Removes["5A5A0001"] {
+		t.Errorf("shared PID 5A5A0001 must NOT be removed")
+	}
+	if ops.Removes["AAAA0001"] {
+		t.Errorf("primary PID AAAA0001 must NOT be removed")
+	}
+	if ops.Removes["1234BEEF"] {
+		t.Errorf("music PID 1234BEEF (not in DB) must NOT be removed")
+	}
+	if len(ops.Adds) != 0 || len(ops.LocationUpdates) != 0 {
+		t.Errorf("cleanup must emit only Removes")
+	}
+}

--- a/internal/server/itl_cleanup.go
+++ b/internal/server/itl_cleanup.go
@@ -1,0 +1,61 @@
+// file: internal/server/itl_cleanup.go
+// version: 1.0.0
+// guid: 1e8b3d47-6a02-4c9f-b73e-2d5a0f8c1b96
+// last-edited: 2026-07-22
+//
+// P3 merged-track cleanup handler: removes stale duplicate audiobook tracks left
+// in the library by merged/superseded books. Removal auto-cleans orphaned
+// playlist references (RemoveTracksByPIDLE) and never targets music/podcast
+// tracks (candidates are sourced only from DB book_files). dry_run=true previews.
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+)
+
+// cleanupMergedHandler handles POST /api/v1/itunes/cleanup-merged.
+// Query param: dry_run=true returns the superseded-track removal preview without
+// applying. Otherwise removes the tracks via the SafeWriteITL pipeline.
+func (s *Server) cleanupMergedHandler(c *gin.Context) {
+	itlPath, ok := resolveITLWritePath(c)
+	if !ok {
+		return
+	}
+
+	store := s.Store()
+	ops, preview, err := itunes.ComputeMergedTrackCleanup(store, itlPath)
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("cleanup-merged diff failed: %v", err))
+		return
+	}
+
+	if c.Query("dry_run") == "true" {
+		httputil.RespondWithOK(c, gin.H{"dry_run": true, "preview": preview})
+		return
+	}
+
+	if ops.IsEmpty() {
+		httputil.RespondWithOK(c, gin.H{"applied": true, "preview": preview})
+		return
+	}
+
+	// Removal excises the master tracks and cleans orphaned playlist refs. The
+	// default contract's bounded-delta cap (max 5000 removes) is the safety net —
+	// a larger removal is refused rather than force-applied.
+	if err := itunesservice.SafeWriteITL(itlPath, *ops); err != nil {
+		httputil.RespondWithSuccess(c, http.StatusInternalServerError,
+			gin.H{"applied": false, "preview": preview, "error": err.Error()})
+		return
+	}
+
+	slog.Info("ITL cleanup-merged applied", "toRemove", preview.ToRemove, "sharedSkipped", preview.SharedSkipped)
+	httputil.RespondWithOK(c, gin.H{"applied": true, "preview": preview})
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,5 +1,5 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.2.0
+// version: 3.3.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
 // last-edited: 2026-07-22
 
@@ -1299,6 +1299,10 @@ func (s *Server) setupRoutes() {
 				// Adopt-base: re-bless the identity sidecar after reseeding the
 				// writeback slot from a different library (else K13/K14 reject writes).
 				itunesGroup.POST("/adopt-base", s.perm(auth.PermLibraryEditMetadata), s.adoptBaseHandler)
+				// Cleanup-merged (P3): remove stale duplicate audiobook tracks left
+				// by merged/superseded books; auto-cleans orphaned playlist refs.
+				// dry_run=true previews.
+				itunesGroup.POST("/cleanup-merged", s.perm(auth.PermLibraryEditMetadata), s.cleanupMergedHandler)
 
 				// ITL file transfer (6.4)
 				itunesGroup.GET("/library/download", s.perm(auth.PermIntegrationsManage), s.itunesSvcGuard(func(c *gin.Context) { s.itunesSvc.Transfer.HandleDownload(c) }))


### PR DESCRIPTION
## What

Implements **P3** of the 2-way-sync writeback and records that **P2 has no work**.

- **P3 — `POST /api/v1/itunes/cleanup-merged`** (`dry_run` supported). Removes stale duplicate audiobook tracks left in the library by merged/superseded books — the merge-cleanup that never applied while the writeback was broken. A track is removed only if its PID belongs to a **non-primary** book_file and **no primary** book_file also owns it. Removal auto-cleans orphaned playlist refs (`RemoveTracksByPIDLE` v1.2.0); `no-new-dangling-refs` + bounded-delta (≤5000) guard it. Candidates come only from DB book_files, so music/podcasts are never touched.
- **P2 — no work.** Prod relocate dry-run reported `unmatched_files: 0`; every primary book_file already matches a library track.

## Measured on prod

Relocate dry-run: 81,722 matched, **6,414 to relocate**, 0 unmatched. P3 estimate ~4,061 superseded candidates (85,783 matched − 81,722 primary).

## Safety

`/cleanup-merged` is **destructive** (removes tracks) — dry-run + count review before apply. Applied via `SafeWriteITL` (backup + contract + rollback). Unit tested; build green, vet clean.

Follows `docs/specs/2026-07-22-itunes-2way-sync-writeback-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)