### PR TITLE
feat(itunes): book_file PID uniqueness — forward invariant + census/repair

### DIFF
--- a/changelog.d/docs-itunes-2way-sync-continuation.md
+++ b/changelog.d/docs-itunes-2way-sync-continuation.md
@@ -1,0 +1,14 @@
+<!-- file: changelog.d/docs-itunes-2way-sync-continuation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 92609748-e3b2-4e21-8a54-ffc76f68f45b -->
+<!-- last-edited: 2026-07-23 -->
+
+### Changed
+
+#### Doc: iTunes 2-way-sync continuation handoff
+
+Added `docs/plans/2026-07-23-itunes-2way-sync-continuation.md` capturing the state
+after the P1 relocate shipped and the remaining work: redefining the (currently
+unsafe) P3 merged-track removal to provable-duplicates-only, building the reverse
+iTunes→writeback→AO sync for full-time use, and guarding the destructive
+`/rebuild` paths against the now-real library.

--- a/changelog.d/itunes-pid-uniqueness.md
+++ b/changelog.d/itunes-pid-uniqueness.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/itunes-pid-uniqueness.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6f0b2d81-9c34-4a57-8e12-3b7a5c0d4e26 -->
+<!-- last-edited: 2026-07-23 -->
+
+### Fixed
+
+#### book_file iTunes persistent IDs are now unique (forward invariant + backfill)
+
+A book_file's iTunes persistent ID (PID) is the join key to its iTunes track, and
+`TrackProvisioner` mints one uniquely per file. But version-split copy paths
+(`internal/organizer/service.go`, `internal/metafetch/service_apply.go`) did
+`newBF := bf`, carrying the PID onto the new organized primary while the demoted
+original kept it too — leaving two rows with one PID. A prod census found **8,987**
+duplicate PIDs (8,762 same-file duplicate rows, 225 different-file copied PIDs), and
+**94** PIDs sat on more than one primary book_file with differing paths, making the
+relocate writeback's first-wins match order-dependent.
+
+- **Forward invariant:** `CreateBookFile` now enforces PID uniqueness at the write
+  chokepoint — if a PID is already held by another row, ownership TRANSFERS to the new
+  (organized) row via the existing `ClearITunesPID` primitive. Only the
+  `itunes_persistent_id` DB field moves; no audio file is touched.
+- **Census + repair endpoints:** `GET /api/v1/itunes/pid-integrity` (read-only census)
+  and `POST /api/v1/itunes/pid-repair` (dry-run-gated backfill). The repair keeps the PID
+  on one canonical row and clears it from the rest — same-file keeps a live primary,
+  different-file keeps the row matching the live ITL track location; ambiguous cases are
+  left untouched for review. No row or file is ever deleted.

--- a/cmd/pid-census/main.go
+++ b/cmd/pid-census/main.go
@@ -1,0 +1,90 @@
+// file: cmd/pid-census/main.go
+// version: 1.0.0
+// guid: 8f2b0d61-4a37-4c95-9e12-7d3a6b1c0e58
+// last-edited: 2026-07-23
+//
+// READ-ONLY book_file iTunes-PID integrity census. Point it at a COPY of the
+// production Pebble DB (never the live dir — Pebble opens read-write and wants the
+// LOCK): ZFS-snapshot, clone, cp the pebble dir to a writable jdfalk-owned path,
+// then run this. Optionally pass a copy of the writeback .itl to mark which
+// duplicate PIDs are present in the library. Nothing here mutates the DB beyond
+// Pebble's own open (on the throwaway copy). See
+// docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md.
+//
+//	go run ./cmd/pid-census --db /tmp/pebble-copy [--itl /tmp/iTunes\ Library.itl]
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+)
+
+func main() {
+	dbPath := flag.String("db", "", "path to a COPY of the Pebble DB directory (required)")
+	itlPath := flag.String("itl", "", "optional path to a copy of the writeback iTunes Library.itl")
+	full := flag.Bool("full", false, "print the full JSON report incl. samples (default: summary only)")
+	repair := flag.Bool("repair", false, "also print the pid-repair PLAN preview (read-only; needs --itl for diff_file)")
+	mapFrom := flag.String("map-from", "W:", "path-mapping source prefix (Windows drive)")
+	mapTo := flag.String("map-to", "/mnt/bigdata/books", "path-mapping target prefix (local mount)")
+	flag.Parse()
+
+	if *dbPath == "" {
+		fmt.Fprintln(os.Stderr, "error: --db is required (a COPY of the Pebble dir, not the live one)")
+		os.Exit(2)
+	}
+
+	store, err := database.NewPebbleStore(*dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open pebble %q: %v\n", *dbPath, err)
+		os.Exit(1)
+	}
+	defer store.Close()
+
+	report, err := itunes.ComputePIDIntegrity(store, *itlPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "census: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Summary line (always) — the decision-relevant counts.
+	fmt.Printf("tracks_in_itl=%d files_with_pid=%d distinct_pids=%d duplicate_pids=%d\n",
+		report.TracksInITL, report.FilesWithPID, report.DistinctPIDs, report.DuplicatePIDs)
+	fmt.Printf("  dup_same_file=%d dup_diff_file=%d dup_in_itl=%d files_to_clear=%d\n",
+		report.DupSameFile, report.DupDiffFile, report.DupInITL, report.FilesToClear)
+	fmt.Printf("  pids_on_multiple_primaries_diff_path=%d (relocate-correctness probe: 0 = relocate provably correct)\n",
+		report.PIDsOnMultiplePrimariesDiffPath)
+
+	if *repair {
+		mappings := []itunes.PathMapping{{From: *mapFrom, To: *mapTo}}
+		_, preview, err := itunes.ComputePIDRepairPlan(store, *itlPath, mappings)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "repair plan: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("=== REPAIR PLAN (dry-run) ===\n")
+		fmt.Printf("duplicate_pids=%d same_file_groups=%d diff_file_groups=%d ambiguous_groups=%d files_to_clear=%d\n",
+			preview.DuplicatePIDs, preview.SameFileGroups, preview.DiffFileGroups,
+			preview.AmbiguousGroups, preview.FilesToClear)
+		if *full {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(preview)
+		}
+		return
+	}
+
+	if *full {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintf(os.Stderr, "encode: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/docs/plans/2026-07-23-itunes-2way-sync-continuation.md
+++ b/docs/plans/2026-07-23-itunes-2way-sync-continuation.md
@@ -1,0 +1,115 @@
+<!-- file: docs/plans/2026-07-23-itunes-2way-sync-continuation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 92609748-e3b2-4e21-8a54-ffc76f68f45b -->
+<!-- last-edited: 2026-07-23 -->
+
+# iTunes Writeback / 2-Way-Sync — Continuation Handoff
+
+Session-independent handoff for the next instance. Paste the **Prompt** section
+into a fresh session, or read this whole doc. Companion references:
+[`../specs/2026-07-22-itunes-2way-sync-writeback-design.md`](../specs/2026-07-22-itunes-2way-sync-writeback-design.md)
+and the memory file `project_itunes_writeback_pathnorm_bug.md`.
+
+## What already shipped (2026-07-22 / 2026-07-23) — do not redo
+
+- **P1 relocate — APPLIED + itl-diff-verified on prod.** `POST /api/v1/itunes/relocate`
+  repoints each iTunes track at its book_file's current AO path, matched per-**file**
+  `BookFile.ITunesPersistentID`. Location-only: never adds/removes. 6,414 relocated;
+  tracks Δ0, playlists 357→357 Δ0, all 10 guards pass. Code:
+  `internal/itunes/relocate.go`, `internal/server/itl_relocate.go`.
+- **`POST /api/v1/itunes/adopt-base`** re-blesses the `.identity.json` sidecar after the
+  writeback library is reseeded/changed (else K13/K14 identity guards reject writes).
+- **P2 (adds) — 0 work** (`unmatched_files: 0`; every primary book_file already has a track).
+- **P3 cleanup (`POST /api/v1/itunes/cleanup-merged`) — BUILT but HELD. DO NOT APPLY.**
+  Its criterion (`IsPrimaryVersion==false && !ownedByPrimary`) is TOO BROAD: the dry-run
+  sample showed the 5,967 "to_remove" are real chapter/part files with EMPTY
+  `merged_into_book_id` — removing them would delete real audio, not duplicates.
+
+## Problem 1 — definitively solve relocation + removals (redefine P3)
+
+The removal set must be provable duplicates only. Investigate and decide the correct
+criterion — likely: remove a non-primary track ONLY when its book shares a
+`version_group_id` with a PRIMARY book whose own track is kept, OR `MergedIntoBookID`
+is set to a book whose track is kept. Specifically:
+
+- Why are **4,298 PIDs owned by BOTH a primary and a non-primary book_file**
+  (`shared_skipped`)? Is that a data-integrity bug (same file on two book records)?
+  This thread probably unravels the whole non-primary confusion.
+- How many non-primary tracks are genuinely merged (`MergedIntoBookID` set) vs
+  shattered-book / version-group artifacts that must NOT be removed (they may need
+  RE-GROUPING via reconciliation, not deletion)?
+- Is relocation itself fully correct now, or do shattered books cause wrong/duplicate
+  relocations?
+
+Redefine `ComputeMergedTrackCleanup`, re-measure via dry-run + sample, get sign-off
+before any apply. Entangled with
+[`../specs/2026-07-19-fingerprint-driven-reconciliation-design.md`](../specs/2026-07-19-fingerprint-driven-reconciliation-design.md).
+
+## Problem 2 — reverse direction (iTunes → writeback → AO), for full-time use
+
+Once iTunes is used full-time, media added/played/rated/playlisted IN iTunes gets
+written to the writeback library. Design + build the steady-state so those changes
+sync back and nothing is lost:
+
+- **New audiobooks/tracks added in iTunes are NOT in AO's DB.** Relocate correctly
+  leaves them alone, but AO must IMPORT them (from the writeback library, **not** the
+  deprecated `books/itunes/`). Confirm the importer source and wire it.
+- **Play counts / last-played / bookmarks / new playlists** created in iTunes → decide
+  whether to ingest back into AO (P4 read-back, currently deferred / preserve-only) and
+  build it if needed.
+- **Pick and document the source-of-truth model:** is the writeback library
+  authoritative for membership (AO imports from it + only relocates paths), or is AO
+  authoritative? Define the loop end-to-end. This is the biggest real risk before heavy
+  full-time use.
+
+## Problem 3 — audit for other footguns
+
+- **`/rebuild` and `/rebuild-full`** (`internal/itunes/rebuild.go` — `ComputeITLDiff` /
+  `RebuildITLFromDB`) are DB-authoritative and would GUT the now-real library
+  (~85k removals). Guard or deprecate them so they can't be run against a
+  non-throwaway library.
+- **`adopt-base` / identity steady-state:** when iTunes changes the library, does the
+  sidecar drift and block the next relocate? Define exactly when adopt-base must re-run.
+- Any other place that assumes the writeback library is disposable.
+
+## Hard constraints / reference
+
+- **NEVER write to `books/itunes/**`** (real active iTunes library, hands-off). All
+  writeback targets ONLY `.itunes-writeback/`.
+- Every writeback goes through `SafeWriteITL` (backup + 10-guard `ITLSafetyContract` +
+  rollback); bounded-delta caps removes at 5000. `cmd/itl-diff --audit <pre> <post>` is
+  the acceptance oracle (decrypt+inflate; the `.itl` body is AES-encrypted, so raw
+  grep = 0 matches by design).
+- Endpoints: `POST /api/v1/itunes/relocate`, `/adopt-base`, `/cleanup-merged` (all
+  `dry_run=true`-capable), plus the destructive `/rebuild` + `/rebuild-full`.
+- The Claude Code classifier **BLOCKS prod-write curls** (POST without `dry_run`); the
+  owner runs applies himself with a `!` prefix. Dry-runs (reads) are fine.
+- Deploy is `make deploy` from the up-to-date main tree. Worktree discipline: branch per
+  change, PR + rebase-merge, remove worktree after merge.
+- **Fleet-internal specifics are NOT in this public repo** (per the private-knowledge
+  rule): the prod API host + port, the `.api-token` format/extraction, the ZFS-snapshot
+  read-only Pebble-DB scan procedure, and the deploy/sudo details live in the **private
+  memory file `project_itunes_writeback_pathnorm_bug.md`** (and falkcorp/infra-docs).
+  Read those for the actual values. Never commit IPs / internal hosts / tokens here.
+
+**Deliverable:** a findings doc + design under `docs/` and a `PLAN.md`; do not apply any
+destructive prod op without a dry-run, a reviewed sample, and explicit owner go-ahead.
+
+---
+
+## Prompt (paste into a fresh session)
+
+> iTunes writeback / 2-way-sync — continue this work. Read
+> `docs/plans/2026-07-23-itunes-2way-sync-continuation.md` and the memory file
+> `project_itunes_writeback_pathnorm_bug.md` in full first. Do a READ-ONLY
+> investigation and present findings + a written PLAN.md before any code or prod
+> action. Solve, in order: (1) redefine the P3 removal/relocation criterion to
+> provable-duplicates-only (version_group / MergedIntoBookID linkage) and explain the
+> 4,298 shared-PID oddity; (2) design + build the reverse sync (iTunes → writeback →
+> AO) for full-time use, including importing iTunes-added media from the writeback
+> library and deciding the source-of-truth model; (3) guard/deprecate the destructive
+> `/rebuild` + `/rebuild-full` against the now-real library and define the adopt-base
+> steady-state. Constraints: NEVER write `books/itunes/**`; writeback targets only
+> `.itunes-writeback/`; prod-write curls are classifier-blocked so I run applies with
+> `!`; every write via SafeWriteITL; verify with `cmd/itl-diff --audit`; dry-run +
+> reviewed sample + my go-ahead before any destructive apply.

--- a/docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md
+++ b/docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md
@@ -117,6 +117,30 @@ Shattered books themselves do **not** break relocate: each fragment is its own 1
 primary book, matched per-file PID, repointed at its own current path — correct by
 construction. The only correctness risk is the shared-PID anomaly above.
 
+### 1.5b Census — measured on prod (2026-07-23, ZFS-snapshot read-only scan)
+
+Ran `ComputePIDIntegrity` (`cmd/pid-census`) against a snapshot copy of the live Pebble DB:
+
+| Metric | Count |
+|---|---|
+| book_file rows carrying a PID | 93,590 |
+| distinct PIDs | 84,535 |
+| **duplicate PIDs (owned by >1 row)** | **8,987** |
+| — `same_file` (all owners share FilePath → duplicate rows) | 8,762 (97.5%) |
+| — `diff_file` (owners point at different files → copied PID) | 225 (2.5%) |
+| duplicate PIDs present in the ITL | 8,987 (all) |
+| **relocate probe: PIDs on >1 primary, differing paths** | **94** (non-zero → relocate first-wins IS order-dependent) |
+
+Sample confirms the mechanism: the dup owners are an organized AO copy
+(`…/audiobook-organizer/…`) + the deprecated iTunes-tree original
+(`…/books/itunes/…`) sharing one PID — the organizer version-split copy (culprit #1).
+
+**Repair plan (dry-run):** auto-resolves **8,984 / 8,987** (8,762 same_file keep-one +
+222 diff_file keep-by-ITL-location); **3 ambiguous** diff_file groups left UNTOUCHED for
+review (fail-safe); **9,050 redundant PID copies cleared**. Clearing is DB-field-only
+(no row/file deletion) and, because each resolved PID ends with exactly one owner, it also
+eliminates the 94 relocate-order-dependence cases.
+
 ### 1.6 Problem 1 conclusion
 
 - **Retire the current P3 criterion** — it targets live non-primary audio, not duplicates.

--- a/docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md
+++ b/docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md
@@ -1,0 +1,251 @@
+<!-- file: docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c1a9f4e-2d63-4b0a-9e57-8a1c4d2f6b03 -->
+<!-- last-edited: 2026-07-23 -->
+
+# iTunes 2-Way-Sync — Continuation Findings + Design (READ-ONLY investigation)
+
+> **STATUS: findings for owner review. Read-only code investigation only — no code
+> written, no prod actions taken.** Companion:
+> [`2026-07-22-itunes-2way-sync-writeback-design.md`](2026-07-22-itunes-2way-sync-writeback-design.md),
+> [`2026-07-19-fingerprint-driven-reconciliation-design.md`](2026-07-19-fingerprint-driven-reconciliation-design.md),
+> and the private memory `project_itunes_writeback_pathnorm_bug.md` (prod host/port,
+> token format, ZFS-snapshot DB-scan procedure — kept out of this public repo).
+
+This resolves the three problems in the continuation handoff by reading the merge
+apply path, the cleanup/relocate ops, the config wiring, and the identity/contract
+guards. The headline result: **Problem 1 (P3 redefinition) is a measure-and-stop, not a
+build** — the current cleanup looks at the wrong set of books entirely, and the correctly
+narrowed removable set may be ~0.
+
+---
+
+## Problem 1 — relocation + removals (the P3 redefinition)
+
+### 1.1 The merge path already removes ITL tracks inline; soft-deleted losers are invisible to `cleanup-merged`
+
+`internal/merge/service.go` `MergeBooks` (per-loser cleanup, lines ~196–250) does, for
+each non-primary "loser":
+
+- **(a)** collects the loser's iTunes external-ID PIDs *before* reassignment;
+- **(b)** reassigns external IDs to the winner;
+- **(c)** `writeBackBatcher.EnqueueRemove(pid)` for each collected PID — **the ITL track
+  removal is queued at merge time**;
+- **(d)** `SoftDeleteBook` → `MarkedForDeletion = true`, `IsPrimaryVersion = false`.
+
+So *merged-loser ITL cleanup is a real-time side effect of the merge itself*, not a job a
+backfill re-derives later.
+
+Critically, `GetAllBooksFullFrom` (`internal/database/pebble_store.go:488`) **skips
+soft-deleted books** (`if book.MarkedForDeletion != nil && *book.MarkedForDeletion {
+continue }`, ~line 204). `ComputeMergedTrackCleanup` enumerates the DB *only* through
+`GetAllBooksFullFrom`, so **it never sees merge losers.** Every book in its `nonPrimary`
+set is therefore a **live, non-soft-deleted, `IsPrimaryVersion==false`** book — a
+version-group alternate or a shattered fragment whose `book_files` are **real,
+un-superseded audio**.
+
+**This is exactly why the 40-track dry-run sample showed empty `merged_into_book_id` and
+real chapter/part paths** (Wind and Truth Ch39/87, Hyperion Ch108, …). The current P3
+criterion `IsPrimaryVersion==false && !ownedByPrimary` does not select merged duplicates
+— **it selects live non-primary audio, and applying it would delete real content.** P3 as
+built must be retired or redefined; it is not merely "too broad."
+
+### 1.2 `MergedIntoBookID` is set by a different path and is rare among *live* books
+
+The `MergeBooks` version-group path (above) **soft-deletes** losers and does **not** set
+`MergedIntoBookID`. `MergedIntoBookID` is set by the consolidation/combine path
+(`CombineBooks`, which `MoveBookFilesToBook` moves files to the survivor). A *live*
+`IsPrimaryVersion==false` book that still owns `book_files` **and** carries
+`MergedIntoBookID` is therefore unusual — and it is the only shape that is a
+provable duplicate.
+
+### 1.3 Reject the `version_group_id` path outright
+
+"Shares a `version_group_id` with a primary" **does not prove same audio.** Version groups
+hold genuinely *different* physical files — different editions/snapshots (`[[feedback_version_snapshot]]`:
+"Version" = different physical files). Removing an ITL track because its book shares a
+version group with a primary would **delete a real alternate edition's audio.** It is not a
+provable duplicate.
+
+The only defensible duplicate guarantee is **provenance you can name a survivor for**:
+> Remove an audiobook ITL track only when you can point to the *surviving* track that
+> carries the same audio and is being kept.
+
+Concretely: `MergedIntoBookID = X`, where `X` resolves to a **kept primary** whose
+`book_file` PID is present in the ITL and is **not itself** in the remove set. Anything you
+cannot name a survivor for → **review / re-group** (reconciliation), **never delete.**
+
+### 1.4 The genuinely-removable population is "merge orphans" — and `cleanup-merged` can't currently see them
+
+There *is* a legitimate cleanup target, but it is a different set than the code selects.
+During the broken-writeback window (pre-2026-07-22), `writeBackBatcher.EnqueueRemove` was
+effectively a no-op whenever writeback was disabled/failing, so **merged-loser tracks were
+enqueued for removal but never actually removed from the ITL.** Those loser books are now
+soft-deleted, so their PIDs belong to **no live `book_file`** — the tracks sit in the ITL
+as **orphans** (a subset of the ~11,999 "library-only" tracks measured in P0, alongside
+music/podcasts the relocate correctly ignores).
+
+To clean those safely we must:
+1. enumerate **soft-deleted** iTunes-audiobook losers (needs a store accessor that
+   *includes* `MarkedForDeletion`, unlike `GetAllBooksFullFrom`);
+2. for each, confirm the **survivor** (its merge target / version-group primary) has a
+   `book_file` PID that **is present in the ITL and kept**;
+3. remove only that loser's orphaned PID.
+
+**But the size of this set is unknown and may be ~0** if the batcher was functioning for
+most merges. → **Measure before building.** Redefine `ComputeMergedTrackCleanup` only if
+the provable orphan set is non-trivial; otherwise P3 becomes a measure-and-stop like P2.
+
+### 1.5 Q1 — the 4,298 `shared_skipped` PIDs, and whether relocate is fully correct
+
+`shared_skipped` = a PID present on **both** a primary and a non-primary *live* book_file.
+Per-file PIDs are minted **unique** at provision time (`TrackProvisioner.Provision`
+mints one `GeneratePIDHex()` per `book_file`), so the same PID string on two book_file rows
+is a genuine **book_file duplication anomaly** — most likely the same underlying file
+referenced by two book records (a shatter/version artifact), not two distinct files.
+The current code handles it safely-by-default (relocate skips non-primary books; cleanup
+*keeps* shared PIDs), so it is not an active hazard — but it is worth quantifying as a
+data-integrity signal, and it is *the* probe for relocate correctness:
+
+> **Relocate-correctness probe:** are there PIDs on **>1 PRIMARY book_file with different
+> `FilePath`s**? If yes, `relocateOpsFromTracks`'s `emitted` first-wins guard
+> (`relocate.go:120`) is **iteration-order-dependent** and could point a track at the wrong
+> file. If the count is **0**, relocate is provably fully correct. If **>0**, add a
+> deterministic tie-break (or route those PIDs to review) — do not leave it order-dependent.
+
+Shattered books themselves do **not** break relocate: each fragment is its own 1-file
+primary book, matched per-file PID, repointed at its own current path — correct by
+construction. The only correctness risk is the shared-PID anomaly above.
+
+### 1.6 Problem 1 conclusion
+
+- **Retire the current P3 criterion** — it targets live non-primary audio, not duplicates.
+- **Redefine** (if the measured set warrants) to *provenance-anchored* removal:
+  `MergedIntoBookID → kept-primary-with-track`, enumerating soft-deleted losers.
+- **Reject** version_group-based removal entirely (→ reconciliation/regroup, not delete).
+- **Measure first** via an extended dry-run: (i) count `MergedIntoBookID`-anchored provable
+  removals, (ii) count soft-deleted merge-orphans in the ITL, (iii) count PIDs on >1 primary
+  book_file with differing paths (relocate probe), (iv) explain the 4,298 shared set.
+- **Relocate is safe and shipped**; the probe in 1.5 either confirms it fully correct or
+  surfaces a bounded tie-break fix.
+
+---
+
+## Problem 2 — reverse direction (iTunes → writeback → AO)
+
+### 2.1 Importer source wiring
+
+- **Import source** = `config.ITunes.LibraryReadPath` (`itunes.library_read_path`) —
+  today the **deprecated** `books/itunes/iTunes Library.xml`.
+- **Writeback target** = `config.ITunes.LibraryWritePath` (`itunes.library_write_path`) =
+  `.itunes-writeback/iTunes Library.itl`.
+
+For full-time use, AO must import iTunes-added audiobooks **from the writeback library**
+(the one iTunes actively mutates), not from `books/itunes/`. This is a config/wiring change
+plus a source decision — **not** repointing `library_read_path` blindly (see the hazard).
+
+### 2.2 The import-loop hazard (must design around)
+
+The writeback library now contains **AO's own relocated audiobook tracks**
+(`W:\audiobook-organizer\…`). If AO imports audiobooks from it **without dedup-on-import**,
+it re-ingests its own output → **duplication.** This is the same ordering constraint the
+reconciliation spec already flagged: **import-back depends on dedup-on-import (reconciliation
+P4) existing first.** New audiobooks added *directly in iTunes* are the only legitimate
+import candidates, and they must be dedup-matched against AO before insert.
+
+### 2.3 Source-of-truth model — **the owner decision** (recommend-and-confirm)
+
+Authority is **split**, and this defines the whole loop, so it must be an explicit sign-off:
+
+- **Writeback library authoritative** for non-audiobook membership (music/podcasts) **and
+  all playlists** — AO never owns those; it preserves them verbatim.
+- **AO authoritative** for the **audiobook set** — AO's dedup/organization wins; the sync
+  only relocates paths and (rarely) adds/removes audiobook tracks.
+- **New audiobooks added in iTunes** → read the writeback library, filter `IsAudiobook`,
+  and import those whose PID is absent from the DB — **gated on dedup-on-import** so a book
+  that already exists in AO merges into the existing primary instead of duplicating.
+
+Read-back of **play counts / last-played / bookmarks / new playlists** into the AO DB is the
+deferred **P4** (currently preserve-only: edit-in-place keeps them in the *library* for free,
+they just don't flow into the DB). Whether to build DB ingest now is a second owner decision.
+
+### 2.4 Steady-state loop (proposed)
+
+```
+iTunes (full-time use) ──mutates──► .itunes-writeback/iTunes Library.itl  (authoritative for music+playlists+play-state)
+        │                                             │
+        │ new audiobook added in iTunes               │ AO reorganizes / dedups audiobooks
+        ▼                                             ▼
+  AO import (from writeback, IsAudiobook,     AO relocate (per-file PID, location-only)
+   dedup-on-import gated) ─────────────────►  + (rare) provenance-anchored cleanup
+```
+
+Everything AO writes goes back through `SafeWriteITL` into the same `.itunes-writeback`
+base, so iTunes-side changes are always the starting point of the next cycle — the "2-way"
+property. `itl-diff --audit <pre> <post>` is the per-cycle oracle.
+
+---
+
+## Problem 3 — footguns / guards
+
+### 3.1 `/rebuild` + `/rebuild-full` would gut the now-real library
+
+- `/rebuild-full` (`RebuildITLFromDB`, `rebuild.go:363`/`432`) passes
+  **`ForceContractConfig()`**, which overrides `bounded-delta`. Against the reseeded
+  97,999-track library it would emit ~85k removals and shatter the 356 playlists — and the
+  force flag means the contract would *not* stop it on magnitude.
+- `/rebuild` (`ComputeITLDiff`) is DB-authoritative but does **not** force, so `bounded-delta`
+  would refuse the mass shrink — still dangerous and easy to mis-invoke.
+
+**Guard design (belt-and-suspenders, fail-safe):** add a *target-shape precheck* to both
+rebuild handlers that refuses to run when the target library "looks real," independent of
+the contract:
+- non-audiobook (`!IsAudiobook`) track count over a threshold (a disposable prototype has ~0
+  non-audiobook tracks; the real library has ~86k), **or**
+- playlist count over a small threshold (prototype had 14; real has 356), **or**
+- identity `LibraryPID` != a recorded disposable-prototype marker.
+
+Require an explicit `allow_full_library=true` request param to override, and log loudly.
+This fails safe even if someone calls `/rebuild-full` by habit — stronger than deprecation.
+(Deprecation alone doesn't stop a muscle-memory curl.)
+
+### 3.2 `adopt-base` / identity steady-state — verified
+
+The identity sidecar (`internal/itunes/itl_identity.go`, `LibraryIdentity`) records
+`LibraryPID` + `TrackCount` + `PlaylistCount`. On write, K13 anchors `LibraryPID`; K14
+(`guardExpectedMagnitude`, `itl_safety_contract.go:715`) requires the post-write `after`
+count to be within **`MagnitudeTolerancePct` (default 10%)** of
+`ExpectedTrackCount = sidecar.TrackCount + len(Adds) − len(Removes)`
+(`itl_combined_mutate.go:110`).
+
+**Consequences for steady-state:**
+- A **location-only relocate** (0 adds / 0 removes) needs `after ≈ sidecar.TrackCount`. As
+  long as iTunes-side membership drift stays **within ~10%** of the recorded count, the next
+  relocate passes **without** re-running `adopt-base`. Minor iTunes additions do not block it.
+- `adopt-base` **must** re-run when: (a) the library is **reseeded/replaced** (LibraryPID
+  changes → K13 would reject), or (b) iTunes-side membership drifts **>10%** from the sidecar
+  count (K14 would reject).
+- **Recommendation:** because the writeback library is the one iTunes actively mutates,
+  relocate/cleanup should re-anchor `ExpectedTrackCount` to the **current on-disk base count**
+  each cycle (preserving `LibraryPID` for anti-swap), rather than trusting a possibly-stale
+  sidecar count — i.e., fold an *auto-refresh of count-while-PID-unchanged* into the write
+  path so `adopt-base` is only ever needed for a genuine reseed. **[VERIFY in P0: does K13
+  compare `LibraryPID` only, or also a track-PID sample? If a PID sample, define the reseed
+  vs. drift boundary precisely.]**
+
+### 3.3 Other disposable-library assumptions to sweep
+
+- Confirm nothing else calls `RebuildITLFromDB` / `ComputeITLDiff` outside the two guarded
+  handlers (a scheduled job, a CLI, a test fixture pointed at prod).
+- Confirm `ProtectedPaths` is populated on prod (open item from the reconciliation spec §6)
+  so no scan/organize path can reach `books/itunes/**`.
+
+---
+
+## Cross-cutting: nothing here has been applied
+
+- No code written; no prod writes; relocate (P1) remains the only applied writeback and is
+  itl-diff-verified.
+- All measurements proposed above are **reads** (dry-runs / ZFS-snapshot DB scan) and are
+  safe to run. Any destructive apply (a redefined cleanup) requires a dry-run + reviewed
+  sample + explicit owner go-ahead, per the prod-apply review gate.

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-07-07
+// last-edited: 2026-07-23
 
 package database
 
@@ -183,6 +183,36 @@ func (s *PebbleStore) HasLSHIndex(bookFileID string) bool {
 	return len(val) > 0 && val[0] == fingerprint.LSHIndexVersion
 }
 
+// enforceBookFilePIDUniqueness guarantees that at most one book_file row carries
+// a given iTunes persistent ID. If `file` carries a non-empty PID already held by
+// a DIFFERENT row, ownership is TRANSFERRED to `file` by clearing the PID from the
+// prior owner (via the existing ClearITunesPID primitive, which also fixes the
+// prior owner's secondary index). Only the itunes_persistent_id DB field is
+// touched — never an audio file, never the prior row's other data. Called from the
+// CreateBookFile mint path (the only place a new row with a PID is minted without
+// the by-PID collapse that BatchUpsertBookFiles already does). A no-op when the PID
+// is empty or already uniquely owned by this same row.
+func (s *PebbleStore) enforceBookFilePIDUniqueness(file *BookFile) error {
+	if file == nil || file.ITunesPersistentID == "" {
+		return nil
+	}
+	prior, err := s.GetBookFileByPID(file.ITunesPersistentID)
+	if err != nil {
+		return fmt.Errorf("CreateBookFile: PID-uniqueness lookup for %q: %w", file.ITunesPersistentID, err)
+	}
+	if prior == nil || prior.ID == file.ID {
+		return nil // unowned, or already owned by this same row
+	}
+	if _, err := s.ClearITunesPID(file.ITunesPersistentID); err != nil {
+		return fmt.Errorf("CreateBookFile: transfer PID %q from prior owner %s: %w",
+			file.ITunesPersistentID, prior.ID, err)
+	}
+	slog.Info("book_file PID uniqueness: transferred to new row",
+		"pid", file.ITunesPersistentID, "priorOwner", prior.ID, "priorBook", prior.BookID,
+		"newFile", file.ID, "newBook", file.BookID)
+	return nil
+}
+
 // CreateBookFile stores a new BookFile, generating a ULID if the ID is empty.
 // It writes the primary key book_file:<bookID>:<fileID> and secondary indexes
 // for iTunes PID and file path (when non-empty) atomically in a single batch.
@@ -204,6 +234,19 @@ func (s *PebbleStore) CreateBookFile(file *BookFile) error {
 		file.CreatedAt = now
 	}
 	file.UpdatedAt = now
+
+	// PID uniqueness invariant (2026-07-23): a book_file iTunes persistent ID must
+	// identify exactly ONE row. Version-split copies (internal/organizer/service.go,
+	// internal/metafetch/service_apply.go) do `newBF := bf`, carrying the PID onto
+	// the new organized primary while the demoted original keeps it too — producing
+	// the duplicate ("shared_skipped") PIDs the census found. Transfer ownership to
+	// THIS new row by clearing the PID from any prior owner. Only the
+	// itunes_persistent_id DB field moves; no audio file is touched. The new
+	// (organized) row is the one a relocate repoints the ITL track at, so it is the
+	// correct owner. See docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md.
+	if err := s.enforceBookFilePIDUniqueness(file); err != nil {
+		return err
+	}
 
 	// T020: drop AcoustIDSeg0..6 from the stored value via a copy; the
 	// original struct is preserved for writeBookFileSecondaryIndexes and

--- a/internal/database/pid_uniqueness_test.go
+++ b/internal/database/pid_uniqueness_test.go
@@ -1,0 +1,82 @@
+// file: internal/database/pid_uniqueness_test.go
+// version: 1.0.0
+// guid: 4d7c2e91-8a63-4b05-9f18-2e6c1a4b7d33
+// last-edited: 2026-07-23
+
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateBookFilePIDUniquenessTransfer verifies the write-time invariant: when
+// a new book_file is minted with a PID already held by another row (the
+// version-split copy pattern), ownership TRANSFERS to the new row and the prior
+// owner's PID is cleared — with no audio file touched. This is the forward fix for
+// the duplicate-PID ("shared_skipped") anomaly.
+func TestCreateBookFilePIDUniquenessTransfer(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	const pid = "ABCDEF1234567890"
+
+	orig, err := store.CreateBook(&Book{Title: "Original", FilePath: "/old/book"})
+	require.NoError(t, err)
+	organized, err := store.CreateBook(&Book{Title: "Organized", FilePath: "/organized/book"})
+	require.NoError(t, err)
+
+	// Original import row owns the PID.
+	f1 := &BookFile{BookID: orig.ID, FilePath: "/old/book/01.m4b", ITunesPersistentID: pid}
+	require.NoError(t, store.CreateBookFile(f1))
+
+	got, err := store.GetBookFileByPID(pid)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, f1.ID, got.ID, "prior owner should hold the PID before the copy")
+
+	// Version-split copy: the organizer mints a NEW row carrying the SAME PID.
+	f2 := &BookFile{BookID: organized.ID, FilePath: "/organized/book/01.m4b", ITunesPersistentID: pid}
+	require.NoError(t, store.CreateBookFile(f2))
+
+	// The PID index now points at the NEW (organized) row.
+	got, err = store.GetBookFileByPID(pid)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, f2.ID, got.ID, "PID should transfer to the new organized row")
+	require.NotEqual(t, f1.ID, f2.ID)
+
+	// The prior owner's PID field is cleared — exactly one row carries the PID.
+	origFiles, err := store.GetBookFiles(orig.ID)
+	require.NoError(t, err)
+	require.Len(t, origFiles, 1)
+	require.Empty(t, origFiles[0].ITunesPersistentID, "prior owner PID must be cleared (no duplicate)")
+
+	// The prior owner's audio file path is untouched (no file-level data loss).
+	require.Equal(t, "/old/book/01.m4b", origFiles[0].FilePath)
+}
+
+// TestCreateBookFileSamePIDSameRowNoop verifies re-creating the same row (same ID
+// + same PID) does not clear itself — the guard is scoped to a DIFFERENT prior row.
+func TestCreateBookFileSamePIDSameRowNoop(t *testing.T) {
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	require.NoError(t, err)
+	defer store.Close()
+
+	const pid = "0011223344556677"
+	b, err := store.CreateBook(&Book{Title: "B", FilePath: "/b"})
+	require.NoError(t, err)
+
+	f := &BookFile{BookID: b.ID, FilePath: "/b/01.m4b", ITunesPersistentID: pid}
+	require.NoError(t, store.CreateBookFile(f))
+	// Re-create with the SAME explicit ID → prior.ID == file.ID → no clear.
+	require.NoError(t, store.CreateBookFile(f))
+
+	got, err := store.GetBookFileByPID(pid)
+	require.NoError(t, err)
+	require.NotNil(t, got, "PID must still be owned after re-create of the same row")
+	require.Equal(t, f.ID, got.ID)
+}

--- a/internal/itunes/pid_integrity.go
+++ b/internal/itunes/pid_integrity.go
@@ -1,0 +1,193 @@
+// file: internal/itunes/pid_integrity.go
+// version: 1.0.0
+// guid: e2f7a1c4-6b90-4d38-8a5e-1c3f9d2b7e60
+// last-edited: 2026-07-23
+//
+// READ-ONLY book_file iTunes-PID integrity census. A PID is minted unique per
+// book_file (TrackProvisioner.Provision → GeneratePIDHex → crypto/rand), so the
+// same PID on two book_file rows is an anomaly: it was COPIED (a field-merge left
+// it on both src and dst) rather than minted. This census groups every book_file
+// by PID, and for each PID owned by more than one row classifies the shape so the
+// repair (pid_repair) can act without data loss:
+//
+//   - same_file : all owner rows point at the SAME FilePath → a duplicate row; the
+//     repair keeps the PID on one canonical row and clears it from the rest. No ITL
+//     change (the kept row still links the track).
+//   - diff_file : owner rows point at DIFFERENT files → a mis-copied PID; only ONE
+//     row is the real iTunes track. The repair keeps the PID on the row whose path
+//     matches the live ITL track and clears/re-mints the others. NEVER the reverse
+//     (clearing the matching row would orphan the track).
+//
+// It also runs the relocate-correctness probe (PIDs on >1 PRIMARY live book_file
+// with differing paths → relocate's first-wins is order-dependent) from
+// docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md §1.5. Nothing here
+// mutates: it only reads the store and the ITL.
+
+package itunes
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// PIDIntegrityStore is the read-only slice of the store the census needs.
+type PIDIntegrityStore interface {
+	// GetAllBookFilesCore returns every book_file (including those whose parent
+	// book is soft-deleted — it scans book_file rows directly), carrying ID,
+	// BookID, FilePath, and ITunesPersistentID.
+	GetAllBookFilesCore() ([]database.BookFileCore, error)
+	// GetBookByID resolves a book by id, INCLUDING soft-deleted books (needed to
+	// read a merge-loser's IsPrimaryVersion / MarkedForDeletion / MergedIntoBookID).
+	GetBookByID(id string) (*database.Book, error)
+}
+
+// pidOwner is one book_file that carries a given PID, plus its book's status.
+type PIDOwner struct {
+	FileID         string `json:"file_id"`
+	BookID         string `json:"book_id"`
+	FilePath       string `json:"file_path"`
+	IsPrimary      bool   `json:"is_primary"`
+	SoftDeleted    bool   `json:"soft_deleted"`
+	HasMergeLink   bool   `json:"has_merge_link"`             // MergedIntoBookID set
+	MergedInto     string `json:"merged_into_book_id,omitempty"`
+	VersionGroupID string `json:"version_group_id,omitempty"`
+	Title          string `json:"title,omitempty"`
+}
+
+// DuplicatePID is one PID owned by more than one book_file, with its shape.
+type DuplicatePID struct {
+	PID            string     `json:"pid"`
+	Owners         []PIDOwner `json:"owners"`
+	Classification string     `json:"classification"` // "same_file" | "diff_file"
+	InITL          bool       `json:"in_itl"`
+	PrimaryOwners  int        `json:"primary_owners"`  // live primary owners
+	DistinctPaths  int        `json:"distinct_paths"`  // distinct FilePaths among owners
+}
+
+// PIDIntegrityReport is the full census. All counts are over book_file rows.
+type PIDIntegrityReport struct {
+	TracksInITL         int `json:"tracks_in_itl"`
+	FilesWithPID        int `json:"files_with_pid"`          // book_file rows carrying a non-empty PID
+	DistinctPIDs        int `json:"distinct_pids"`
+	DuplicatePIDs       int `json:"duplicate_pids"`          // PIDs owned by >1 book_file
+	DupSameFile         int `json:"dup_same_file"`           // all owners share FilePath
+	DupDiffFile         int `json:"dup_diff_file"`           // owners point at different files
+	DupInITL            int `json:"dup_in_itl"`              // duplicate PIDs present in the library
+	FilesToClear        int `json:"files_to_clear"`          // owner rows losing the PID (owners−1 per dup PID)
+	// Relocate-correctness probe (findings §1.5): a PID on >1 PRIMARY, live
+	// book_file with differing paths makes relocate's first-wins order-dependent.
+	PIDsOnMultiplePrimariesDiffPath int `json:"pids_on_multiple_primaries_diff_path"`
+
+	Samples []DuplicatePID `json:"samples"` // up to pidSampleLimit, worst-shape first
+}
+
+const pidSampleLimit = 60
+
+// ComputePIDIntegrity scans every book_file, groups by PID, and reports the
+// duplicate-PID census + relocate probe. Read-only. itlPath is used only to mark
+// which duplicate PIDs are actually present in the library (informs whether the
+// repair touches the ITL at all).
+func ComputePIDIntegrity(store PIDIntegrityStore, itlPath string) (*PIDIntegrityReport, error) {
+	inITL := map[string]bool{}
+	tracksInITL := 0
+	if itlPath != "" {
+		lib, err := ParseITL(itlPath)
+		if err != nil {
+			return nil, err
+		}
+		tracksInITL = len(lib.Tracks)
+		for i := range lib.Tracks {
+			inITL[strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))] = true
+		}
+	}
+
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return nil, err
+	}
+
+	// Group book_file rows by upper-hex PID.
+	byPID := make(map[string][]database.BookFileCore)
+	for i := range files {
+		pid := strings.ToUpper(strings.TrimSpace(files[i].ITunesPersistentID))
+		if pid == "" {
+			continue
+		}
+		byPID[pid] = append(byPID[pid], files[i])
+	}
+
+	report := &PIDIntegrityReport{TracksInITL: tracksInITL, DistinctPIDs: len(byPID)}
+	bookCache := map[string]*database.Book{} // bounded: only dup-PID owners are looked up
+
+	for pid, owners := range byPID {
+		report.FilesWithPID += len(owners)
+		if len(owners) < 2 {
+			continue
+		}
+		report.DuplicatePIDs++
+		report.FilesToClear += len(owners) - 1
+
+		dup := DuplicatePID{PID: pid, InITL: inITL[pid]}
+		if dup.InITL {
+			report.DupInITL++
+		}
+
+		paths := map[string]bool{}
+		primaryPaths := map[string]bool{} // distinct paths among live-primary owners
+		for j := range owners {
+			f := owners[j]
+			paths[f.FilePath] = true
+			b := bookCache[f.BookID]
+			if b == nil {
+				if bk, berr := store.GetBookByID(f.BookID); berr == nil && bk != nil {
+					b = bk
+					bookCache[f.BookID] = bk
+				}
+			}
+			po := PIDOwner{FileID: f.ID, BookID: f.BookID, FilePath: f.FilePath}
+			if b != nil {
+				po.IsPrimary = b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+				po.SoftDeleted = b.MarkedForDeletion != nil && *b.MarkedForDeletion
+				if b.MergedIntoBookID != nil {
+					po.HasMergeLink = true
+					po.MergedInto = *b.MergedIntoBookID
+				}
+				if b.VersionGroupID != nil {
+					po.VersionGroupID = *b.VersionGroupID
+				}
+				po.Title = b.Title
+				if po.IsPrimary && !po.SoftDeleted {
+					dup.PrimaryOwners++
+					primaryPaths[f.FilePath] = true
+				}
+			}
+			dup.Owners = append(dup.Owners, po)
+		}
+
+		dup.DistinctPaths = len(paths)
+		if len(paths) == 1 {
+			dup.Classification = "same_file"
+			report.DupSameFile++
+		} else {
+			dup.Classification = "diff_file"
+			report.DupDiffFile++
+		}
+		if len(primaryPaths) > 1 {
+			report.PIDsOnMultiplePrimariesDiffPath++
+		}
+
+		if len(report.Samples) < pidSampleLimit {
+			report.Samples = append(report.Samples, dup)
+		}
+	}
+
+	slog.Info("itunes pid-integrity census",
+		"tracksInITL", report.TracksInITL, "filesWithPID", report.FilesWithPID,
+		"distinctPIDs", report.DistinctPIDs, "duplicatePIDs", report.DuplicatePIDs,
+		"dupSameFile", report.DupSameFile, "dupDiffFile", report.DupDiffFile,
+		"dupInITL", report.DupInITL, "filesToClear", report.FilesToClear,
+		"pidsOnMultiplePrimariesDiffPath", report.PIDsOnMultiplePrimariesDiffPath)
+	return report, nil
+}

--- a/internal/itunes/pid_integrity_test.go
+++ b/internal/itunes/pid_integrity_test.go
@@ -1,0 +1,90 @@
+// file: internal/itunes/pid_integrity_test.go
+// version: 1.0.0
+// guid: c9a3e714-0d62-4b58-9f21-6e4a2c8b1d70
+// last-edited: 2026-07-23
+
+package itunes
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// pidCensusMock is a minimal PIDIntegrityStore: a flat book_file list plus a
+// book-by-id map (including soft-deleted books, which GetBookByID must return).
+type pidCensusMock struct {
+	files []database.BookFileCore
+	books map[string]*database.Book
+}
+
+func (m *pidCensusMock) GetAllBookFilesCore() ([]database.BookFileCore, error) {
+	return m.files, nil
+}
+
+func (m *pidCensusMock) GetBookByID(id string) (*database.Book, error) {
+	return m.books[id], nil
+}
+
+func bf(id, bookID, path, pid string) database.BookFileCore {
+	return database.BookFileCore{ID: id, BookID: bookID, FilePath: path, ITunesPersistentID: pid}
+}
+
+// TestComputePIDIntegrity exercises the duplicate-PID classification and the
+// relocate-correctness probe with no real .itl (itlPath = "").
+func TestComputePIDIntegrity(t *testing.T) {
+	primary := true
+	notPrimary := false
+
+	store := &pidCensusMock{
+		files: []database.BookFileCore{
+			// UNIQUE — one owner, never a duplicate.
+			bf("f_uniq", "b_uniq", "/mnt/x/uniq.m4b", "AAAA0001"),
+			// SAME_FILE dup — two rows, same path, same PID.
+			bf("f_sf1", "b_sf1", "/mnt/x/same.m4b", "BBBB0002"),
+			bf("f_sf2", "b_sf2", "/mnt/x/same.m4b", "BBBB0002"),
+			// DIFF_FILE dup across TWO live primaries → relocate order-dependent.
+			bf("f_df1", "b_df1", "/mnt/x/one.m4b", "CCCC0003"),
+			bf("f_df2", "b_df2", "/mnt/x/two.m4b", "CCCC0003"),
+			// DIFF_FILE dup primary + NON-primary → NOT counted by the primaries probe.
+			bf("f_pn1", "b_pn1", "/mnt/x/a.m4b", "DDDD0004"),
+			bf("f_pn2", "b_pn2", "/mnt/x/b.m4b", "DDDD0004"),
+			// empty PID — ignored entirely.
+			bf("f_empty", "b_empty", "/mnt/x/none.m4b", ""),
+		},
+		books: map[string]*database.Book{
+			"b_uniq": {ID: "b_uniq", IsPrimaryVersion: &primary},
+			"b_sf1":  {ID: "b_sf1", IsPrimaryVersion: &primary},
+			"b_sf2":  {ID: "b_sf2", IsPrimaryVersion: &notPrimary},
+			"b_df1":  {ID: "b_df1", IsPrimaryVersion: &primary},
+			"b_df2":  {ID: "b_df2", IsPrimaryVersion: &primary},
+			"b_pn1":  {ID: "b_pn1", IsPrimaryVersion: &primary},
+			"b_pn2":  {ID: "b_pn2", IsPrimaryVersion: &notPrimary},
+		},
+	}
+
+	rep, err := ComputePIDIntegrity(store, "")
+	if err != nil {
+		t.Fatalf("ComputePIDIntegrity: %v", err)
+	}
+
+	if rep.DistinctPIDs != 4 { // AAAA(uniq), BBBB(same), CCCC(diff), DDDD(prim+nonprim)
+		t.Errorf("DistinctPIDs = %d, want 4", rep.DistinctPIDs)
+	}
+	if rep.DuplicatePIDs != 3 { // BBBB, CCCC, DDDD
+		t.Errorf("DuplicatePIDs = %d, want 3", rep.DuplicatePIDs)
+	}
+	if rep.DupSameFile != 1 {
+		t.Errorf("DupSameFile = %d, want 1 (BBBB)", rep.DupSameFile)
+	}
+	if rep.DupDiffFile != 2 {
+		t.Errorf("DupDiffFile = %d, want 2 (CCCC, DDDD)", rep.DupDiffFile)
+	}
+	if rep.FilesToClear != 3 { // one extra owner per dup PID
+		t.Errorf("FilesToClear = %d, want 3", rep.FilesToClear)
+	}
+	// Only CCCC has two LIVE PRIMARY owners with differing paths.
+	if rep.PIDsOnMultiplePrimariesDiffPath != 1 {
+		t.Errorf("PIDsOnMultiplePrimariesDiffPath = %d, want 1 (CCCC only)", rep.PIDsOnMultiplePrimariesDiffPath)
+	}
+}

--- a/internal/itunes/pid_repair.go
+++ b/internal/itunes/pid_repair.go
@@ -1,0 +1,323 @@
+// file: internal/itunes/pid_repair.go
+// version: 1.0.0
+// guid: 5a9d3c62-7e14-4b80-9f26-1c8b0a3e6d47
+// last-edited: 2026-07-23
+//
+// Backfill repair for duplicate book_file iTunes PIDs (the ~8,987 the census
+// found). A PID must identify exactly one book_file; where several rows share one
+// (version-split copies), this keeps the PID on ONE canonical row and CLEARS it
+// from the rest. It NEVER deletes a row or touches an audio file — only the
+// itunes_persistent_id / itunes_path DB fields move — so it cannot lose data.
+//
+// Keep policy (fail-safe: only clears when the keeper is unambiguous):
+//   - same_file (all owners share FilePath): keep a live primary (tie-break lowest
+//     file ID). Any owner is equivalent for the ITL — same location — so the track
+//     link is unaffected regardless of which is kept.
+//   - diff_file (owners point at different files): keep the owner whose canonical
+//     location equals the live ITL track's location for that PID, so the track stays
+//     linked to the right file. If the ITL doesn't disambiguate (no owner matches,
+//     or more than one does), the PID is left UNTOUCHED for review — never guessed.
+//
+// After a full repair every PID has one owner, which also makes the relocate path
+// deterministic (removes the order-dependent first-wins hazard the census counted
+// as pids_on_multiple_primaries_diff_path). Apply is dry-run-gated. See
+// docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md.
+
+package itunes
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sort"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// PIDRepairStore is the read+write slice of the store the repair needs.
+type PIDRepairStore interface {
+	GetAllBookFilesCore() ([]database.BookFileCore, error)
+	GetBookFiles(bookID string) ([]database.BookFile, error)
+	GetBookByID(id string) (*database.Book, error)
+	UpdateBookFile(id string, file *database.BookFile) error
+}
+
+// pidClear is one row that will lose the PID (its full row, so UpdateBookFile
+// preserves every other field incl. the raw fingerprint).
+type pidClear struct {
+	file database.BookFile
+}
+
+// pidRepairGroup is a resolved duplicate PID: exactly one keeper, ≥1 losers.
+type pidRepairGroup struct {
+	pid    string
+	keep   database.BookFile
+	losers []pidClear
+}
+
+// PIDRepairSample surfaces one resolved group for operator review.
+type PIDRepairSample struct {
+	PID          string   `json:"pid"`
+	Class        string   `json:"class"` // same_file | diff_file
+	KeepFileID   string   `json:"keep_file_id"`
+	KeepPath     string   `json:"keep_path"`
+	ClearedPaths []string `json:"cleared_paths"`
+}
+
+// PIDRepairPreview summarizes the repair without applying it.
+type PIDRepairPreview struct {
+	DuplicatePIDs   int `json:"duplicate_pids"`
+	SameFileGroups  int `json:"same_file_groups"`
+	DiffFileGroups  int `json:"diff_file_groups"`
+	AmbiguousGroups int `json:"ambiguous_groups"` // diff_file the ITL can't disambiguate → left for review
+	FilesToClear    int `json:"files_to_clear"`
+
+	Sample []PIDRepairSample `json:"sample"`
+}
+
+const pidRepairSampleLimit = 50
+
+// ComputePIDRepairPlan builds the repair groups (read-only). itlPath drives the
+// diff_file keep-by-location decision; mappings canonicalize a FilePath to the ITL
+// 0x0D form for comparison against the track location.
+func ComputePIDRepairPlan(store PIDRepairStore, itlPath string, mappings []PathMapping) ([]pidRepairGroup, *PIDRepairPreview, error) {
+	// ITL track location by upper-hex PID (for diff_file disambiguation).
+	trackLoc := map[string]string{}
+	if itlPath != "" {
+		lib, err := ParseITL(itlPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse ITL: %w", err)
+		}
+		for i := range lib.Tracks {
+			trackLoc[strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))] = lib.Tracks[i].Location
+		}
+	}
+
+	cores, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return nil, nil, fmt.Errorf("scan book_files: %w", err)
+	}
+	byPID := map[string][]database.BookFileCore{}
+	for i := range cores {
+		pid := strings.ToUpper(strings.TrimSpace(cores[i].ITunesPersistentID))
+		if pid != "" {
+			byPID[pid] = append(byPID[pid], cores[i])
+		}
+	}
+
+	preview := &PIDRepairPreview{}
+	var groups []pidRepairGroup
+	bookCache := map[string]*database.Book{}
+
+	// Deterministic PID order so the sample + apply are stable across runs.
+	pids := make([]string, 0, len(byPID))
+	for pid, owners := range byPID {
+		if len(owners) > 1 {
+			pids = append(pids, pid)
+		}
+	}
+	sort.Strings(pids)
+
+	for _, pid := range pids {
+		owners := byPID[pid]
+		preview.DuplicatePIDs++
+
+		sameFile := true
+		for i := 1; i < len(owners); i++ {
+			if owners[i].FilePath != owners[0].FilePath {
+				sameFile = false
+				break
+			}
+		}
+
+		// Load full rows (fingerprint-preserving) + book status.
+		full := make([]database.BookFile, 0, len(owners))
+		for i := range owners {
+			bf := fetchFullBookFile(store, owners[i])
+			if bf == nil {
+				continue
+			}
+			full = append(full, *bf)
+		}
+		if len(full) < 2 {
+			continue // couldn't resolve rows → skip (fail-safe)
+		}
+
+		var keepIdx int
+		if sameFile {
+			keepIdx = pickSameFileKeeper(store, full, bookCache)
+			preview.SameFileGroups++
+		} else {
+			preview.DiffFileGroups++
+			idx, ok := pickDiffFileKeeper(full, trackLoc[pid], mappings)
+			if !ok {
+				preview.AmbiguousGroups++ // ITL can't disambiguate → leave untouched
+				continue
+			}
+			keepIdx = idx
+		}
+
+		g := pidRepairGroup{pid: pid, keep: full[keepIdx]}
+		for i := range full {
+			if i != keepIdx {
+				g.losers = append(g.losers, pidClear{file: full[i]})
+			}
+		}
+		preview.FilesToClear += len(g.losers)
+		groups = append(groups, g)
+
+		if len(preview.Sample) < pidRepairSampleLimit {
+			cls := "diff_file"
+			if sameFile {
+				cls = "same_file"
+			}
+			cleared := make([]string, 0, len(g.losers))
+			for _, l := range g.losers {
+				cleared = append(cleared, l.file.FilePath)
+			}
+			preview.Sample = append(preview.Sample, PIDRepairSample{
+				PID: pid, Class: cls, KeepFileID: g.keep.ID, KeepPath: g.keep.FilePath, ClearedPaths: cleared,
+			})
+		}
+	}
+
+	slog.Info("itunes pid-repair: computed plan",
+		"duplicatePIDs", preview.DuplicatePIDs, "sameFile", preview.SameFileGroups,
+		"diffFile", preview.DiffFileGroups, "ambiguous", preview.AmbiguousGroups,
+		"filesToClear", preview.FilesToClear)
+	return groups, preview, nil
+}
+
+// fetchFullBookFile loads the full (non-stripped) BookFile matching a core row.
+func fetchFullBookFile(store PIDRepairStore, core database.BookFileCore) *database.BookFile {
+	files, err := store.GetBookFiles(core.BookID)
+	if err != nil {
+		return nil
+	}
+	for i := range files {
+		if files[i].ID == core.ID {
+			return &files[i]
+		}
+	}
+	return nil
+}
+
+// pickSameFileKeeper prefers a live primary owner; tie-break lowest file ID. All
+// owners share the path, so the ITL track link is identical whichever is kept.
+func pickSameFileKeeper(store PIDRepairStore, owners []database.BookFile, cache map[string]*database.Book) int {
+	best := -1
+	for i := range owners {
+		if isLivePrimary(store, owners[i].BookID, cache) {
+			if best == -1 || owners[i].ID < owners[best].ID {
+				best = i
+			}
+		}
+	}
+	if best != -1 {
+		return best
+	}
+	// No live primary → lowest file ID among all owners.
+	best = 0
+	for i := range owners {
+		if owners[i].ID < owners[best].ID {
+			best = i
+		}
+	}
+	return best
+}
+
+// pickDiffFileKeeper returns the index of the owner whose canonical location equals
+// the ITL track location. ok=false when the ITL doesn't disambiguate (no match, or
+// >1 match) — the caller then leaves the PID untouched for review.
+func pickDiffFileKeeper(owners []database.BookFile, trackLocation string, mappings []PathMapping) (int, bool) {
+	if trackLocation == "" {
+		return 0, false
+	}
+	match := -1
+	for i := range owners {
+		loc, ok := canonicalWinLocationForFile(owners[i].FilePath, owners[i].ITunesPersistentID, "pid_repair", mappings)
+		if ok && strings.EqualFold(loc, trackLocation) {
+			if match != -1 {
+				return 0, false // ambiguous: two owners canonicalize to the track loc
+			}
+			match = i
+		}
+	}
+	if match == -1 {
+		return 0, false
+	}
+	return match, true
+}
+
+func isLivePrimary(store PIDRepairStore, bookID string, cache map[string]*database.Book) bool {
+	b, ok := cache[bookID]
+	if !ok {
+		b, _ = store.GetBookByID(bookID)
+		cache[bookID] = b
+	}
+	if b == nil {
+		return false
+	}
+	primary := b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+	deleted := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+	return primary && !deleted
+}
+
+// PIDRepairResult reports what an apply actually did.
+type PIDRepairResult struct {
+	GroupsRepaired int `json:"groups_repaired"`
+	FilesCleared   int `json:"files_cleared"`
+	Errors         int `json:"errors"`
+}
+
+// ApplyPIDRepairPlan executes the groups: for each PID, clear the PID/path fields
+// on every loser row, then re-assert the keeper so the book_file_pid index points
+// at it. Groups are disjoint by PID, so a bounded worker pool over groups is safe
+// (no two workers touch the same row or index key). No audio file is touched.
+func ApplyPIDRepairPlan(store PIDRepairStore, groups []pidRepairGroup) (*PIDRepairResult, error) {
+	res := &PIDRepairResult{}
+	var g errgroup.Group
+	g.SetLimit(runtime.NumCPU())
+	results := make([]struct{ cleared, errs int }, len(groups))
+
+	for i := range groups {
+		grp := groups[i]
+		g.Go(func() error {
+			for _, l := range grp.losers {
+				f := l.file
+				f.ITunesPersistentID = ""
+				f.ITunesPath = ""
+				if err := store.UpdateBookFile(f.ID, &f); err != nil {
+					slog.Warn("pid-repair: clear loser failed", "pid", grp.pid, "file", f.ID, "err", err)
+					results[i].errs++
+					continue
+				}
+				results[i].cleared++
+			}
+			// Re-assert the keeper so book_file_pid:<pid> points at it (clearing the
+			// losers deleted the shared index key).
+			keep := grp.keep
+			if err := store.UpdateBookFile(keep.ID, &keep); err != nil {
+				slog.Error("pid-repair: re-assert keeper failed (PID index may be unset)",
+					"pid", grp.pid, "keep", keep.ID, "err", err)
+				results[i].errs++
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for i := range results {
+		res.FilesCleared += results[i].cleared
+		res.Errors += results[i].errs
+		if results[i].errs == 0 {
+			res.GroupsRepaired++
+		}
+	}
+	slog.Info("itunes pid-repair: applied", "groupsRepaired", res.GroupsRepaired,
+		"filesCleared", res.FilesCleared, "errors", res.Errors)
+	return res, nil
+}

--- a/internal/itunes/pid_repair_test.go
+++ b/internal/itunes/pid_repair_test.go
@@ -1,0 +1,120 @@
+// file: internal/itunes/pid_repair_test.go
+// version: 1.0.0
+// guid: 3e7b0a94-6c21-4d58-8f39-2a1c7e5b0d64
+// last-edited: 2026-07-23
+
+package itunes
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// newRepairTestStore returns a real PebbleStore backed by a temp dir — the repair
+// path exercises UpdateBookFile + the book_file_pid index, so a real store (not a
+// mock) is required.
+func newRepairTestStore(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// TestPickDiffFileKeeper verifies keep-by-ITL-location, incl. the fail-safe when
+// the ITL can't disambiguate (no match, or two owners canonicalize to the track
+// location). Pure function — no .itl needed.
+func TestPickDiffFileKeeper(t *testing.T) {
+	mappings := []PathMapping{{From: "W:", To: "/mnt/bigdata/books"}}
+	aoPath := "/mnt/bigdata/books/audiobook-organizer/Author/Book/01.m4b"
+	itPath := "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Author/01.m4b"
+	owners := []database.BookFile{
+		{ID: "f_it", FilePath: itPath, ITunesPersistentID: "PID"},
+		{ID: "f_ao", FilePath: aoPath, ITunesPersistentID: "PID"},
+	}
+
+	// Track sits at the AO copy (post-relocate) → keep the AO owner (index 1).
+	aoLoc, ok := canonicalWinLocationForFile(aoPath, "PID", "t", mappings)
+	if !ok {
+		t.Fatal("aoPath should canonicalize")
+	}
+	if idx, ok := pickDiffFileKeeper(owners, aoLoc, mappings); !ok || idx != 1 {
+		t.Errorf("keep-by-location: got idx=%d ok=%v, want idx=1 ok=true", idx, ok)
+	}
+
+	// Track location matches NO owner → ambiguous → leave untouched.
+	if _, ok := pickDiffFileKeeper(owners, `W:\somewhere\else.m4b`, mappings); ok {
+		t.Error("no-match should be non-ok (leave for review)")
+	}
+	// Empty track location → non-ok.
+	if _, ok := pickDiffFileKeeper(owners, "", mappings); ok {
+		t.Error("empty track location should be non-ok")
+	}
+}
+
+// TestApplyPIDRepairSameFile exercises the common (97.5%) same_file case end to
+// end against a real store: two rows carry one PID; after repair exactly one row
+// keeps it and the index points there — no row/file deleted.
+func TestApplyPIDRepairSameFile(t *testing.T) {
+	store := newRepairTestStore(t)
+
+	primary := true
+	b1, _ := store.CreateBook(&database.Book{Title: "B1", FilePath: "/x/b1", IsPrimaryVersion: &primary})
+	b2, _ := store.CreateBook(&database.Book{Title: "B2", FilePath: "/x/b2", IsPrimaryVersion: &primary})
+
+	const pid = "DEADBEEF00000001"
+	const path = "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Author/track.m4b"
+
+	// Reproduce the anomaly the way history did: the forward guard blocks a second
+	// CreateBookFile with the same PID, so set the dup via UpdateBookFile (no guard).
+	f1 := &database.BookFile{BookID: b1.ID, FilePath: path, ITunesPersistentID: pid}
+	if err := store.CreateBookFile(f1); err != nil {
+		t.Fatal(err)
+	}
+	f2 := &database.BookFile{BookID: b2.ID, FilePath: path}
+	if err := store.CreateBookFile(f2); err != nil {
+		t.Fatal(err)
+	}
+	f2.ITunesPersistentID = pid
+	if err := store.UpdateBookFile(f2.ID, f2); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, preview, err := ComputePIDRepairPlan(store, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.DuplicatePIDs != 1 || preview.SameFileGroups != 1 || preview.FilesToClear != 1 {
+		t.Fatalf("preview = %+v, want 1 dup / 1 same_file / 1 to-clear", preview)
+	}
+
+	if _, err := ApplyPIDRepairPlan(store, groups); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly one row keeps the PID, and the index resolves to it.
+	got, err := store.GetBookFileByPID(pid)
+	if err != nil || got == nil {
+		t.Fatalf("GetBookFileByPID after repair: %v (nil=%v)", err, got == nil)
+	}
+	withPID := 0
+	for _, bid := range []string{b1.ID, b2.ID} {
+		files, _ := store.GetBookFiles(bid)
+		for i := range files {
+			if files[i].ITunesPersistentID == pid {
+				withPID++
+			}
+			// The audio path is never touched.
+			if files[i].FilePath != path {
+				t.Errorf("file path mutated: %q", files[i].FilePath)
+			}
+		}
+	}
+	if withPID != 1 {
+		t.Errorf("rows still carrying the PID = %d, want 1", withPID)
+	}
+}

--- a/internal/server/itl_pid.go
+++ b/internal/server/itl_pid.go
@@ -1,0 +1,63 @@
+// file: internal/server/itl_pid.go
+// version: 1.0.0
+// guid: d6b1f048-3e29-4a75-9c81-0f2a7b4c6e93
+// last-edited: 2026-07-23
+//
+// book_file iTunes-PID integrity endpoints. /pid-integrity is a read-only census
+// of duplicate PIDs (a PID must identify exactly one book_file). /pid-repair
+// backfills the duplicates found by the census: it keeps the PID on one canonical
+// row and CLEARS it from the rest — never deleting a row or touching an audio file.
+// Apply is dry-run-gated (dry_run=true → preview only). See
+// docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md.
+
+package server
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+)
+
+// pidIntegrityHandler handles GET/POST /api/v1/itunes/pid-integrity. Always
+// read-only: it reports the duplicate-PID census + relocate-correctness probe.
+func (s *Server) pidIntegrityHandler(c *gin.Context) {
+	itlPath, _ := resolveITLWritePath(c) // best-effort: census works without the ITL
+	report, err := itunes.ComputePIDIntegrity(s.Store(), itlPath)
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("pid-integrity census failed: %v", err))
+		return
+	}
+	httputil.RespondWithOK(c, gin.H{"report": report})
+}
+
+// pidRepairHandler handles POST /api/v1/itunes/pid-repair. dry_run=true returns the
+// repair plan preview; otherwise it clears the redundant PID copies. Destructive to
+// the itunes_persistent_id FIELD only (no row/file deletion) → guarded by dry_run.
+func (s *Server) pidRepairHandler(c *gin.Context) {
+	itlPath, ok := resolveITLWritePath(c)
+	if !ok {
+		return
+	}
+	groups, preview, err := itunes.ComputePIDRepairPlan(s.Store(), itlPath, itlPathMappings())
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("pid-repair plan failed: %v", err))
+		return
+	}
+
+	if c.Query("dry_run") == "true" {
+		httputil.RespondWithOK(c, gin.H{"dry_run": true, "preview": preview})
+		return
+	}
+
+	result, err := itunes.ApplyPIDRepairPlan(s.Store(), groups)
+	if err != nil {
+		httputil.RespondWithInternalError(c, fmt.Sprintf("pid-repair apply failed: %v", err))
+		return
+	}
+	slog.Info("ITL pid-repair applied", "groupsRepaired", result.GroupsRepaired,
+		"filesCleared", result.FilesCleared, "errors", result.Errors)
+	httputil.RespondWithOK(c, gin.H{"applied": true, "preview": preview, "result": result})
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.3.0
+// version: 3.4.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-07-22
+// last-edited: 2026-07-23
 
 package server
 
@@ -1303,6 +1303,12 @@ func (s *Server) setupRoutes() {
 				// by merged/superseded books; auto-cleans orphaned playlist refs.
 				// dry_run=true previews.
 				itunesGroup.POST("/cleanup-merged", s.perm(auth.PermLibraryEditMetadata), s.cleanupMergedHandler)
+				// PID-integrity: read-only census of duplicate book_file iTunes PIDs
+				// (a PID must identify exactly one row) + relocate-correctness probe.
+				itunesGroup.GET("/pid-integrity", s.perm(auth.PermLibraryEditMetadata), s.pidIntegrityHandler)
+				// PID-repair: backfill the duplicates — keep the PID on one canonical
+				// row, clear it from the rest (no row/file deletion). dry_run=true previews.
+				itunesGroup.POST("/pid-repair", s.perm(auth.PermLibraryEditMetadata), s.pidRepairHandler)
 
 				// ITL file transfer (6.4)
 				itunesGroup.GET("/library/download", s.perm(auth.PermIntegrationsManage), s.itunesSvcGuard(func(c *gin.Context) { s.itunesSvc.Transfer.HandleDownload(c) }))

--- a/todo.d/itunes-2way-sync-continuation.md
+++ b/todo.d/itunes-2way-sync-continuation.md
@@ -1,0 +1,16 @@
+<!-- file: todo.d/itunes-2way-sync-continuation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2165368b-70dd-48b0-b2d3-7288bbea666f -->
+<!-- last-edited: 2026-07-23 -->
+
+- [ ] **iTunes 2-way-sync — continuation (P3 redefine + reverse sync + footgun audit).**
+  P1 relocate is applied+verified on prod (6,414). Still open, per
+  `docs/plans/2026-07-23-itunes-2way-sync-continuation.md`: (1) redefine the P3
+  merged-track removal to provable-duplicates-only (version_group/MergedIntoBookID
+  linkage) — current `IsPrimaryVersion==false` criterion is UNSAFE (would delete real
+  chapter files); explain the 4,298 shared-PID oddity. (2) Build the reverse sync
+  (iTunes → writeback → AO) so media added/played/playlisted in iTunes syncs back once
+  it's used full-time; decide the source-of-truth model + import from the writeback
+  library not `books/itunes/`. (3) Guard/deprecate the destructive `/rebuild` +
+  `/rebuild-full` against the now-real library; define the adopt-base steady-state.
+  Dry-run + sample + owner sign-off before any destructive apply.

--- a/todo.d/itunes-pid-uniqueness.md
+++ b/todo.d/itunes-pid-uniqueness.md
@@ -1,0 +1,14 @@
+<!-- file: todo.d/itunes-pid-uniqueness.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9a2c4e07-1b63-4d85-8f20-5c7e3a1b0d49 -->
+<!-- last-edited: 2026-07-23 -->
+
+- [ ] **iTunes book_file PID uniqueness — apply the backfill repair (gated).** Forward
+  invariant shipped (`CreateBookFile` transfers a duplicate PID to the new row) + census
+  (`GET /itunes/pid-integrity`) + repair (`POST /itunes/pid-repair`) endpoints built and
+  tested. Prod census: 8,987 duplicate PIDs (8,762 same-file, 225 diff-file, 94 on multiple
+  primaries). Repair dry-run auto-resolves 8,984 (3 ambiguous left for review), clears 9,050
+  redundant PID copies, DB-field-only (no file/row deletion). REMAINING: deploy → run
+  `pid-repair?dry_run=true` on prod to confirm → owner runs the apply with `!` → re-run the
+  census to confirm 0 duplicates → review the 3 ambiguous groups by hand. See
+  `docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md` §1.5b.


### PR DESCRIPTION
## Summary

Makes `book_file.itunes_persistent_id` unique — a PID is the join key to an iTunes track and must identify exactly one row. Version-split copy paths (`organizer/service.go`, `metafetch/service_apply.go`) did `newBF := bf`, carrying the PID onto the new organized primary while the demoted original kept it → two rows, one PID.

**Prod census (ZFS-snapshot read-only scan):** 8,987 duplicate PIDs (8,762 same-file, 225 diff-file); 94 on >1 primary with differing paths → the relocate writeback's per-file match was order-dependent.

## Changes

- **Forward invariant** — `CreateBookFile.enforceBookFilePIDUniqueness` transfers a duplicate PID to the new (organized) row via the existing `ClearITunesPID` primitive. DB-field-only; **no audio file touched**. Aligns with relocate pointing the ITL track at the AO copy.
- **Census** (`internal/itunes/pid_integrity.go`) + `GET /api/v1/itunes/pid-integrity` (read-only).
- **Repair** (`internal/itunes/pid_repair.go`) + `POST /api/v1/itunes/pid-repair` (**dry-run-gated**): keeps the PID on one canonical row, clears the rest — same-file keeps a live primary, diff-file keeps the row matching the live ITL track location, ambiguous cases left untouched for review. **No row/file deletion.**
- `cmd/pid-census` — standalone read-only census/repair-preview for snapshot scans.

## Safety

No step touches an audio file — only the `itunes_persistent_id`/`itunes_path` DB fields move; nothing is deleted. Repair apply is dry-run-gated and owner-signed-off.

## Verification

- Repair dry-run: auto-resolves 8,984/8,987 (3 ambiguous), clears 9,050 redundant PID copies.
- Full `internal/database` + `internal/itunes` suites pass under `-race`; all 6 `CreateBookFile`-caller packages (organizer, metafetch, merge, itunes/service, reconcile, scanner) pass.

Findings/plan: `docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)