### PR TITLE
fix(itunes): guard /rebuild + /rebuild-full against the real library

### DIFF
--- a/changelog.d/itunes-rebuild-guards.md
+++ b/changelog.d/itunes-rebuild-guards.md
@@ -1,0 +1,20 @@
+<!-- file: changelog.d/itunes-rebuild-guards.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4c8e1b70-5d92-4a37-8f16-2b7a0c3e6d95 -->
+<!-- last-edited: 2026-07-23 -->
+
+### Fixed
+
+#### `/rebuild` + `/rebuild-full` refuse to gut the real iTunes library
+
+The DB-authoritative writebacks (`ComputeITLDiff` / `RebuildITLFromDB`) were designed
+for a disposable, audiobook-only prototype library. Against the now-reseeded real
+library (~98k tracks, ~86k music/podcasts, 357 playlists) they would mark every
+non-audiobook / unmatched track for removal and shatter the playlists —
+`/rebuild-full` especially, since it passes `ForceContractConfig()` which bypasses the
+bounded-delta guard. Added an explicit, fail-closed target-shape precheck
+(`GuardRebuildTarget`): the apply path refuses when the target library "looks real"
+(non-audiobook track count over 1000, or more than 50 playlists), unless the caller
+deliberately passes `allow_full_library=true`. Dry-runs are unaffected. This is
+belt-and-suspenders over the existing K15 shrink-acknowledgement gate — it fails safe
+even when the operation would not trip a >50% shrink.

--- a/internal/itunes/library_shape.go
+++ b/internal/itunes/library_shape.go
@@ -1,0 +1,100 @@
+// file: internal/itunes/library_shape.go
+// version: 1.0.0
+// guid: 2b7e9c14-6a05-4d38-9f27-8c1b3a0e5d62
+// last-edited: 2026-07-23
+//
+// Target-shape guard for the destructive rebuild writebacks. The DB-authoritative
+// /rebuild (ComputeITLDiff) and /rebuild-full (RebuildITLFromDB) were designed for a
+// disposable, audiobook-only prototype library. Run against the now-reseeded REAL
+// library (97,999 tracks / 357 playlists / ~86k music+podcasts) they would mark every
+// non-audiobook / unmatched track for removal and shatter the playlists. The existing
+// bounded-delta / K15-shrink guards catch a mass shrink, but this adds an explicit,
+// fail-closed refusal keyed on what the target library actually IS — so the endpoints
+// cannot be run by habit against a non-throwaway library without a deliberate override.
+// See docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md §3.1.
+
+package itunes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Thresholds distinguishing the real library from a disposable audiobook-only
+// prototype. The prototype had ~0 non-audiobook tracks and 14 playlists; the real
+// library has ~86k non-audiobook tracks and 357 playlists. A legitimate
+// audiobook-only library has ~0 non-audiobook tracks and few playlists, so these
+// never false-positive on the intended use.
+const (
+	realLibraryNonAudiobookTrackThreshold = 1000
+	realLibraryPlaylistThreshold          = 50
+)
+
+// isAudiobookITL classifies a binary ITLTrack as an audiobook, mirroring the core
+// of IsAudiobook (which takes the XML *Track): Kind, Genre, and Location signals.
+func isAudiobookITL(t *ITLTrack) bool {
+	if t == nil {
+		return false
+	}
+	kind := strings.ToLower(t.Kind)
+	if strings.Contains(kind, "audiobook") || strings.Contains(kind, "spoken word") {
+		return true
+	}
+	genre := strings.ToLower(t.Genre)
+	if strings.Contains(genre, "audiobook") || strings.Contains(genre, "spoken") {
+		return true
+	}
+	loc := strings.ToLower(t.Location)
+	return strings.Contains(loc, "audiobooks")
+}
+
+// LibraryShape summarizes the target library for the rebuild guard.
+type LibraryShape struct {
+	Tracks             int  `json:"tracks"`
+	NonAudiobookTracks int  `json:"non_audiobook_tracks"`
+	Playlists          int  `json:"playlists"`
+	LooksReal          bool `json:"looks_real"`
+}
+
+// InspectLibraryShape parses the ITL and classifies whether it "looks real" (a
+// populated general-purpose library) vs a disposable audiobook-only prototype.
+func InspectLibraryShape(itlPath string) (*LibraryShape, error) {
+	lib, err := ParseITL(itlPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse ITL for shape guard: %w", err)
+	}
+	return shapeFromLibrary(lib), nil
+}
+
+// shapeFromLibrary is the pure classification core (no I/O), split out for testing.
+func shapeFromLibrary(lib *ITLLibrary) *LibraryShape {
+	shape := &LibraryShape{Tracks: len(lib.Tracks), Playlists: len(lib.Playlists)}
+	for i := range lib.Tracks {
+		if !isAudiobookITL(&lib.Tracks[i]) {
+			shape.NonAudiobookTracks++
+		}
+	}
+	shape.LooksReal = shape.NonAudiobookTracks > realLibraryNonAudiobookTrackThreshold ||
+		shape.Playlists > realLibraryPlaylistThreshold
+	return shape
+}
+
+// GuardRebuildTarget refuses a destructive DB-authoritative rebuild when the target
+// library looks real, unless the caller passes an explicit override. Returns a
+// non-nil error describing the refusal when blocked; nil when the rebuild may
+// proceed. Fail-closed: a parse error blocks (returns an error), never allows.
+func GuardRebuildTarget(itlPath string, allowFullLibrary bool) (*LibraryShape, error) {
+	shape, err := InspectLibraryShape(itlPath)
+	if err != nil {
+		return nil, err
+	}
+	if shape.LooksReal && !allowFullLibrary {
+		return shape, fmt.Errorf(
+			"refusing DB-authoritative rebuild: target library looks REAL "+
+				"(%d tracks, %d non-audiobook, %d playlists) — this would remove music/podcasts "+
+				"and shatter playlists. Use the edit-in-place /relocate + /cleanup-merged path instead. "+
+				"To override deliberately, pass allow_full_library=true",
+			shape.Tracks, shape.NonAudiobookTracks, shape.Playlists)
+	}
+	return shape, nil
+}

--- a/internal/itunes/library_shape_test.go
+++ b/internal/itunes/library_shape_test.go
@@ -1,0 +1,56 @@
+// file: internal/itunes/library_shape_test.go
+// version: 1.0.0
+// guid: 7d2b9e04-3a61-4c85-9f18-6c0e1a5b3d72
+// last-edited: 2026-07-23
+
+package itunes
+
+import "testing"
+
+func TestIsAudiobookITL(t *testing.T) {
+	cases := []struct {
+		name string
+		t    ITLTrack
+		want bool
+	}{
+		{"kind audiobook", ITLTrack{Kind: "Audiobook"}, true},
+		{"kind spoken word", ITLTrack{Kind: "Purchased spoken word"}, true},
+		{"genre audiobook", ITLTrack{Genre: "Audiobook"}, true},
+		{"location audiobooks", ITLTrack{Location: `W:\itunes\iTunes Media\Audiobooks\A\1.m4b`}, true},
+		{"music track", ITLTrack{Kind: "MPEG audio file", Genre: "Rock", Location: `W:\Music\B\2.mp3`}, false},
+		{"podcast", ITLTrack{Kind: "Podcast", Genre: "News", Location: `W:\Podcasts\C\3.mp3`}, false},
+	}
+	for _, c := range cases {
+		if got := isAudiobookITL(&c.t); got != c.want {
+			t.Errorf("%s: isAudiobookITL = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestShapeFromLibraryAndGuard(t *testing.T) {
+	music := ITLTrack{Kind: "MPEG audio file", Genre: "Rock", Location: `W:\Music\x.mp3`}
+	book := ITLTrack{Kind: "Audiobook", Location: `W:\itunes\iTunes Media\Audiobooks\a.m4b`}
+
+	// Disposable prototype: audiobook-only, few playlists → NOT real.
+	proto := &ITLLibrary{Tracks: []ITLTrack{book, book, book}, Playlists: make([]ITLPlaylist, 5)}
+	if s := shapeFromLibrary(proto); s.LooksReal {
+		t.Errorf("prototype should not look real: %+v", s)
+	}
+
+	// Real library: many non-audiobook tracks → real.
+	tracks := make([]ITLTrack, 0, 1200)
+	for range 1100 {
+		tracks = append(tracks, music)
+	}
+	real1 := &ITLLibrary{Tracks: tracks, Playlists: make([]ITLPlaylist, 10)}
+	s := shapeFromLibrary(real1)
+	if !s.LooksReal || s.NonAudiobookTracks != 1100 {
+		t.Errorf("real-by-nonaudiobook: %+v, want LooksReal + 1100 non-audiobook", s)
+	}
+
+	// Real by playlist count alone (many playlists, few tracks).
+	real2 := &ITLLibrary{Tracks: []ITLTrack{book}, Playlists: make([]ITLPlaylist, 60)}
+	if !shapeFromLibrary(real2).LooksReal {
+		t.Error("60 playlists should look real")
+	}
+}

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -1,7 +1,7 @@
 // file: internal/server/itl_rebuild.go
-// version: 3.3.0
+// version: 3.4.0
 // guid: 8f7e6d5c-4b3a-2c1d-0e9f-8a7b6c5d4e3f
-// last-edited: 2026-07-03
+// last-edited: 2026-07-23
 //
 // iTunes library rebuild service: diffs the current DB state
 // against the current ITL file and computes the minimal set of
@@ -88,6 +88,13 @@ func (s *Server) rebuildITLHandler(c *gin.Context) {
 		return
 	}
 
+	// Target-shape guard: refuse to gut a real library (music/podcasts/playlists)
+	// with this DB-authoritative diff unless deliberately overridden.
+	if _, gerr := itunes.GuardRebuildTarget(itlPath, c.Query("allow_full_library") == "true"); gerr != nil {
+		httputil.RespondWithBadRequest(c, gerr.Error())
+		return
+	}
+
 	// Apply.
 	if ops.IsEmpty() {
 		httputil.RespondWithOK(c, itunes.ITLRebuildResult{
@@ -150,6 +157,14 @@ func (s *Server) rebuildITLFullHandler(c *gin.Context) {
 			DryRun  bool                     `json:"dry_run"`
 			Preview itunes.ITLRebuildPreview `json:"preview"`
 		}{DryRun: true, Preview: preview})
+		return
+	}
+
+	// Target-shape guard: /rebuild-full passes ForceContractConfig (bypasses
+	// bounded-delta), so add an explicit fail-closed refusal when the target looks
+	// like the real library — belt-and-suspenders over the K15 shrink gate.
+	if _, gerr := itunes.GuardRebuildTarget(itlPath, c.Query("allow_full_library") == "true"); gerr != nil {
+		httputil.RespondWithBadRequest(c, gerr.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary

The DB-authoritative rebuild writebacks (`ComputeITLDiff` / `RebuildITLFromDB`) were designed for a disposable, audiobook-only prototype library. Against the now-reseeded **real** library (~98k tracks, ~86k music/podcasts, 357 playlists) they would mark every non-audiobook / unmatched track for removal and shatter the playlists — `/rebuild-full` especially, since it passes `ForceContractConfig()` which bypasses `bounded-delta`.

## Change

`GuardRebuildTarget` (`internal/itunes/library_shape.go`) — a fail-closed target-shape precheck wired into **both** apply paths (`rebuildITLHandler`, `rebuildITLFullHandler`). It refuses when the target library "looks real" (>1000 non-audiobook tracks **or** >50 playlists) unless the caller passes `allow_full_library=true`. Dry-runs are unaffected.

Belt-and-suspenders over the existing K15 shrink-acknowledgement gate: it fails safe even when the operation would not trip a >50% shrink (e.g. the DB grew to match the track count but the op would still mangle music/podcasts/playlists).

## Tests

`TestIsAudiobookITL`, `TestShapeFromLibraryAndGuard` — classification + threshold logic. `internal/itunes` + `internal/server` build & vet clean.

Part of the iTunes 2-way-sync continuation (Problem 3). Findings: `docs/specs/2026-07-23-itunes-2way-sync-continuation-findings.md` §3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)