### PR TITLE
feat(itunes): P0 config scaffold (4-state LibrarySet) + read findings

### DIFF
--- a/changelog.d/itunes-2way-p0-config-scaffold.md
+++ b/changelog.d/itunes-2way-p0-config-scaffold.md
@@ -1,0 +1,18 @@
+<!-- file: changelog.d/itunes-2way-p0-config-scaffold.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7b3e0c94-2a61-4d85-9f27-1c8a5b0e4d63 -->
+<!-- last-edited: 2026-07-23 -->
+
+### Added
+
+#### iTunes 4-state library config model (`LibrarySet`) — scaffold, inert by default
+
+`internal/config/itunes_libraries.go` adds the explicit 4-state iTunes library model
+(`LibraryRef`/`LibrarySet`: Original/AO × .itl/.xml, plus separated `PointedAt` and
+`ImportSource` mode facts) from the 2-way-sync system design. `ITunesConfig.Resolve()`
+derives the legacy `LibraryReadPath`/`LibraryWritePath` shims from it, and
+`ValidateLibraries()` adds four fail-closed config-load assertions (Original tree must be
+covered by `protected_paths`; the AO write target must never resolve under `books/itunes/**`;
+the Original must be frozen once `pointed_at=="ao"`; no zero-value write target while sync is
+enabled). Entirely inert until `itunes.libraries` is populated — existing deployments behave
+byte-for-byte as before. P0 of the phased plan (design + measurement only; nothing applied).

--- a/docs/specs/2026-07-23-itunes-2way-p0-findings.md
+++ b/docs/specs/2026-07-23-itunes-2way-p0-findings.md
@@ -1,0 +1,69 @@
+<!-- file: docs/specs/2026-07-23-itunes-2way-p0-findings.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2c9e5a71-8b04-4d36-9f18-7a3c1e6b0d52 -->
+<!-- last-edited: 2026-07-23 -->
+
+# iTunes 2-Way-Sync — P0 Findings (read-only)
+
+Executes P0 of `2026-07-23-itunes-2way-sync-system-design.md`. Verified against HEAD
+`c5c311a6`. Read-only; nothing applied.
+
+## F1 — K13 library-identity is NOT `LibraryPID`-only (RESOLVES §10b.2, the P1 blocker)
+
+`guardLibraryIdentity` (`internal/itunes/itl_safety_contract.go:749`) checks **both**:
+1. `LibraryPID` equality (via `ExtractLibraryPIDHex(hdr)` vs `ExpectedIdentity.LibraryPID`).
+2. **track-PID sample overlap**: `ExpectedIdentity.SampleOverlapPct(after)` must be
+   ≥ `IdentityMinOverlapPct` (**default 90**, `itl_safety_contract.go:1357`). The sidecar
+   stores `PIDSample` = up to **1024** evenly-spaced track PIDs in payload order
+   (`itl_identity.go:44,64`); overlap = how many still exist in the written library
+   (`SampleOverlapPct`, `itl_identity.go`).
+
+**Consequences for the design (§5 correction):**
+- Normal iTunes activity is SAFE: adds don't remove sampled PIDs; play-state changes
+  don't touch PIDs. Overlap stays ~100%.
+- **Deletions/replacements of sampled tracks erode overlap.** At 90%, up to ~102 of the
+  1024 sampled PIDs may vanish before K13 rejects.
+- Therefore the steady-state count-auto-refresh (`RefreshLibraryTrackCount`, §5.3) MUST
+  **re-derive the PID sample** from the current on-disk library each cycle (keeping
+  `LibraryPID` pinned) — not merely refresh the count — or accumulated legitimate churn
+  eventually false-rejects a valid relocate.
+- **Drift-vs-reseed boundary is now concrete:** `LibraryPID` change = reseed (needs
+  `adopt-base`); a large single-step sampled-PID loss = suspicious → the §5.2 drift-ceiling
+  + §3.4 settle/quiescence gate catch it. K13 arming is well-defined; no blocker remains.
+
+## F2 — Rebuild-caller audit CLEAN
+
+`RebuildITLFromDB` and `ComputeITLDiff` are called ONLY from the two guarded handlers
+(`internal/server/itl_rebuild.go:76` and `:171`); `rebuild.go:352` is the internal slog,
+not a caller. Both handlers now carry `GuardRebuildTarget`. No unguarded rebuild path exists.
+
+## F3 — `ProtectedPaths` is EMPTY on prod (safety gap to close)
+
+Prod `/config` reports `protected_paths` empty/unset. So `books/itunes/**` is currently
+NOT in the in-process protected set; the scanner avoids it only because it is not a
+configured scan root (config-based, not a hard skip). **Action:** populate `ProtectedPaths`
+with `books/itunes/**` on prod and adopt the config-load assertion (below) before any
+`itunes.libraries`-driven op runs. The assertion is inert until `itunes.libraries` is
+populated, so it does not affect the current deployment.
+
+## Config scaffold landed (this PR)
+
+`internal/config/itunes_libraries.go` — the 4-state model (`LibraryRef`/`LibrarySet` with
+`PointedAt`/`ImportSource`), `ITunesConfig.Resolve()` (derives the legacy
+`LibraryReadPath`/`LibraryWritePath` shims), and `ValidateLibraries()` (the four
+fail-closed §2.4 assertions). Wired into `Config.Validate()` and viper load. **Inert until
+`itunes.libraries` is populated** — empty `Libraries` → legacy behavior byte-for-byte.
+Unit-tested (Resolve for both `import_source` values; all four assertions; back-compat).
+
+## Remaining P0 (not in this PR)
+
+- **Cleanup provenance census** — enumerate the union of `MergedIntoBookID` +
+  `AutoMergeJournalEntry.LoserID` (+ combine losers), resolve each loser's surviving
+  primary, count the PROVABLE orphan set (loser PID in ITL, owned by no live book_file,
+  survivor PID present, not a static-playlist member). Decides whether P3 builds or is a
+  measure-and-stop no-op.
+- **Cross-type PID collisions** (audiobook vs non-audiobook sharing a PID) — the
+  disjointness-assertion backstop. Confirm PID-on-multiple-primaries stays 0 (post pid-repair).
+- **Bookmark / field-preservation byte-proof** on a ZFS clone — run a relocate AND a
+  track-remove through `SafeWriteITL`, then byte-compare every untouched track's record;
+  assert ZERO changes (incl. the bookmark mhod). No preservation claim until it passes.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,12 @@ type ITunesConfig struct {
 	WindowsRootPath  string          `json:"windows_root_path"  mapstructure:"windows_root_path"`
 	MediaRoot        string          `json:"media_root"         mapstructure:"media_root"`
 	PathMappings     []ITunesPathMap `json:"path_mappings"      mapstructure:"path_mappings"`
+
+	// Libraries is the explicit 4-state library model (Original/AO x .itl/.xml)
+	// plus the PointedAt/ImportSource mode facts. Inert until populated: when empty,
+	// the legacy LibraryReadPath/LibraryWritePath fields are used as-is. See
+	// itunes_libraries.go and docs/specs/2026-07-23-itunes-2way-sync-system-design.md.
+	Libraries LibrarySet `json:"libraries" mapstructure:"libraries"`
 }
 
 // MaintenanceConfig holds settings for the nightly maintenance window.
@@ -1198,6 +1204,20 @@ func InitConfig() {
 				WindowsRootPath:  viper.GetString("itunes.windows_root_path"),
 				MediaRoot:        viper.GetString("itunes.media_root"),
 				// PathMappings loaded from DB blob, not viper
+				Libraries: LibrarySet{
+					Original: LibraryRef{
+						ITLPath: viper.GetString("itunes.libraries.original.itl_path"),
+						XMLPath: viper.GetString("itunes.libraries.original.xml_path"),
+						Frozen:  viper.GetBool("itunes.libraries.original.frozen"),
+					},
+					AO: LibraryRef{
+						ITLPath: viper.GetString("itunes.libraries.ao.itl_path"),
+						XMLPath: viper.GetString("itunes.libraries.ao.xml_path"),
+						Frozen:  viper.GetBool("itunes.libraries.ao.frozen"),
+					},
+					PointedAt:    viper.GetString("itunes.libraries.pointed_at"),
+					ImportSource: viper.GetString("itunes.libraries.import_source"),
+				},
 			},
 
 			// Download client integration
@@ -1539,6 +1559,12 @@ func (c *Config) Validate() error {
 	}
 
 	var errs []string
+
+	// iTunes 4-state model: derive the legacy path shims, then run the fail-closed
+	// library assertions (inert unless itunes.libraries is populated). See
+	// itunes_libraries.go / spec §2.
+	c.ITunes.Resolve()
+	errs = append(errs, c.ITunes.ValidateLibraries(c.ProtectedPaths)...)
 
 	switch c.DatabaseType {
 	case "pebble", "sqlite":

--- a/internal/config/itunes_libraries.go
+++ b/internal/config/itunes_libraries.go
@@ -1,0 +1,146 @@
+// file: internal/config/itunes_libraries.go
+// version: 1.0.0
+// guid: 5b2e9c47-1a08-4d63-8f92-3c7a0e6b1d54
+// last-edited: 2026-07-23
+//
+// The 4-state iTunes library model + its config-load Resolve/Validate. Two physical
+// libraries (Original = the real hands-off tree under books/itunes/**; AO = the
+// writeback library under .itunes-writeback/), each with a binary .itl (the only
+// write/authority surface) and a read-only .xml export iTunes regenerates and never
+// reads back. See docs/specs/2026-07-23-itunes-2way-sync-system-design.md §2.
+//
+// This is SCAFFOLD (P0): the types + derivation + fail-closed assertions. It is
+// inert until an operator populates ITunesConfig.Libraries — when Libraries is
+// empty, Resolve() is a no-op and the legacy LibraryReadPath/LibraryWritePath are
+// left exactly as loaded, so nothing changes for existing deployments.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LibraryRef is one physical iTunes library: its live binary DB and its read-only
+// regenerated export. iTunes only ever READS the .itl; the .xml is a one-way
+// convenience export (never read back by iTunes).
+type LibraryRef struct {
+	ITLPath string `json:"itl_path" mapstructure:"itl_path"` // binary runtime DB — the write/authority surface
+	XMLPath string `json:"xml_path" mapstructure:"xml_path"` // read-only export — parse-convenience only
+	Frozen  bool   `json:"frozen"   mapstructure:"frozen"`   // true => HANDS-OFF, read-only recoverable fallback
+}
+
+// LibrarySet models the full 4-state world plus the two orthogonal mode facts.
+type LibrarySet struct {
+	// Original: the REAL externally-managed iTunes library under books/itunes/**.
+	// ALWAYS Frozen=true in steady state. NEVER a write target.
+	Original LibraryRef `json:"original" mapstructure:"original"`
+
+	// AO: the writeback library iTunes is pointed at, under .itunes-writeback/.
+	// Its ITLPath is the sole live edit target and, post-cutover, the sole runtime truth.
+	AO LibraryRef `json:"ao" mapstructure:"ao"`
+
+	// PointedAt = which library iTunes itself is currently running against:
+	// "original" | "ao". Set by the human when they repoint iTunes.
+	PointedAt string `json:"pointed_at" mapstructure:"pointed_at"`
+
+	// ImportSource = which library the importer reads NEW audiobooks from:
+	// "original" (legacy one-time import) | "ao" (steady-state re-import).
+	ImportSource string `json:"import_source" mapstructure:"import_source"`
+}
+
+// Configured reports whether an operator has populated the 4-state model at all.
+// When false, the whole subsystem stays on the legacy 2-path behavior.
+func (s LibrarySet) Configured() bool {
+	return s.AO.ITLPath != "" || s.Original.ITLPath != "" || s.Original.XMLPath != ""
+}
+
+// Resolve derives the legacy LibraryReadPath/LibraryWritePath shims from the
+// 4-state model so every ambient reader keeps working unchanged (spec §2.3). It is
+// a no-op when Libraries is not configured, preserving legacy behavior exactly.
+//
+//   - LibraryWritePath := Libraries.AO.ITLPath — always (the write target never changes).
+//   - LibraryReadPath  := ImportSource=="ao" ? Libraries.AO.ITLPath : Libraries.Original.XMLPath.
+func (c *ITunesConfig) Resolve() {
+	if c == nil || !c.Libraries.Configured() {
+		return
+	}
+	if c.Libraries.AO.ITLPath != "" {
+		c.LibraryWritePath = c.Libraries.AO.ITLPath
+	}
+	switch c.Libraries.ImportSource {
+	case "ao":
+		if c.Libraries.AO.ITLPath != "" {
+			c.LibraryReadPath = c.Libraries.AO.ITLPath
+		}
+	default: // "original" or unset
+		if c.Libraries.Original.XMLPath != "" {
+			c.LibraryReadPath = c.Libraries.Original.XMLPath
+		}
+	}
+}
+
+// booksItunesSegment matches the hands-off Original tree by path segment, so it
+// catches the real library regardless of the absolute mount prefix.
+const booksItunesSegment = "books/itunes/"
+
+func underBooksItunes(p string) bool {
+	if p == "" {
+		return false
+	}
+	clean := strings.ReplaceAll(p, "\\", "/")
+	return strings.Contains(clean+"/", booksItunesSegment)
+}
+
+func pathCoveredByProtected(p string, protected []string) bool {
+	if p == "" {
+		return true // nothing to protect
+	}
+	clean := strings.ReplaceAll(p, "\\", "/")
+	for _, pref := range protected {
+		if pref == "" {
+			continue
+		}
+		if strings.HasPrefix(clean, strings.ReplaceAll(pref, "\\", "/")) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateLibraries returns the fail-closed assertion failures (spec §2.4). Empty
+// slice = OK. Inert when Libraries is not configured (so existing deployments are
+// unaffected until they adopt the 4-state model). protectedPaths is the effective
+// Config.ProtectedPaths.
+func (c *ITunesConfig) ValidateLibraries(protectedPaths []string) []string {
+	if c == nil || !c.Libraries.Configured() {
+		return nil
+	}
+	var errs []string
+	L := c.Libraries
+
+	// 1. The Original tree MUST be covered by ProtectedPaths (both files).
+	if L.Original.ITLPath != "" && !pathCoveredByProtected(L.Original.ITLPath, protectedPaths) {
+		errs = append(errs, fmt.Sprintf("itunes.libraries.original.itl_path %q is not covered by any protected_paths prefix (the hands-off Original tree must be protected)", L.Original.ITLPath))
+	}
+	if L.Original.XMLPath != "" && !pathCoveredByProtected(L.Original.XMLPath, protectedPaths) {
+		errs = append(errs, fmt.Sprintf("itunes.libraries.original.xml_path %q is not covered by any protected_paths prefix", L.Original.XMLPath))
+	}
+
+	// 2. The AO write target must NEVER resolve under books/itunes/**.
+	if underBooksItunes(L.AO.ITLPath) {
+		errs = append(errs, fmt.Sprintf("itunes.libraries.ao.itl_path %q resolves under books/itunes/** — the writeback target must never point at the Original library", L.AO.ITLPath))
+	}
+
+	// 3. The fallback source cannot be silently mutable once AO is authoritative.
+	if L.PointedAt == "ao" && L.Original.ITLPath != "" && !L.Original.Frozen {
+		errs = append(errs, "itunes.libraries.original.frozen must be true while pointed_at==\"ao\" (the recoverable fallback source cannot be mutable)")
+	}
+
+	// 4. No zero-value write target while any sync-cycle op is enabled.
+	if (c.SyncEnabled || c.WriteBackEnabled) && L.AO.ITLPath == "" {
+		errs = append(errs, "itunes.libraries.ao.itl_path must be set when itunes sync/write-back is enabled (no zero-value write target)")
+	}
+
+	return errs
+}

--- a/internal/config/itunes_libraries_test.go
+++ b/internal/config/itunes_libraries_test.go
@@ -1,0 +1,127 @@
+// file: internal/config/itunes_libraries_test.go
+// version: 1.0.0
+// guid: 8a1c4e70-2d63-4b95-9f28-5c0e7a3b1d46
+// last-edited: 2026-07-23
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLibrarySetResolve(t *testing.T) {
+	const aoITL = "/mnt/bigdata/books/audiobook-organizer/.itunes-writeback/iTunes Library.itl"
+	const origXML = "/mnt/bigdata/books/itunes/iTunes Library.xml"
+
+	t.Run("unconfigured is a no-op (legacy paths preserved)", func(t *testing.T) {
+		c := &ITunesConfig{LibraryReadPath: "/legacy/read.xml", LibraryWritePath: "/legacy/write.itl"}
+		c.Resolve()
+		if c.LibraryReadPath != "/legacy/read.xml" || c.LibraryWritePath != "/legacy/write.itl" {
+			t.Fatalf("unconfigured Resolve mutated legacy paths: read=%q write=%q", c.LibraryReadPath, c.LibraryWritePath)
+		}
+	})
+
+	t.Run("import_source=ao reads + writes the AO itl", func(t *testing.T) {
+		c := &ITunesConfig{Libraries: LibrarySet{
+			AO:           LibraryRef{ITLPath: aoITL},
+			Original:     LibraryRef{XMLPath: origXML},
+			ImportSource: "ao",
+		}}
+		c.Resolve()
+		if c.LibraryWritePath != aoITL {
+			t.Errorf("write path = %q, want AO itl", c.LibraryWritePath)
+		}
+		if c.LibraryReadPath != aoITL {
+			t.Errorf("read path = %q, want AO itl (import_source=ao)", c.LibraryReadPath)
+		}
+	})
+
+	t.Run("import_source=original reads the Original xml, still writes AO itl", func(t *testing.T) {
+		c := &ITunesConfig{Libraries: LibrarySet{
+			AO:           LibraryRef{ITLPath: aoITL},
+			Original:     LibraryRef{XMLPath: origXML},
+			ImportSource: "original",
+		}}
+		c.Resolve()
+		if c.LibraryWritePath != aoITL {
+			t.Errorf("write path = %q, want AO itl (write target never changes)", c.LibraryWritePath)
+		}
+		if c.LibraryReadPath != origXML {
+			t.Errorf("read path = %q, want Original xml", c.LibraryReadPath)
+		}
+	})
+}
+
+func TestValidateLibraries(t *testing.T) {
+	const origITL = "/mnt/bigdata/books/itunes/iTunes Library.itl"
+	const aoITL = "/mnt/bigdata/books/audiobook-organizer/.itunes-writeback/iTunes Library.itl"
+	protected := []string{"/mnt/bigdata/books/itunes/"}
+
+	good := func() *ITunesConfig {
+		return &ITunesConfig{
+			WriteBackEnabled: true,
+			Libraries: LibrarySet{
+				Original:     LibraryRef{ITLPath: origITL, Frozen: true},
+				AO:           LibraryRef{ITLPath: aoITL},
+				PointedAt:    "ao",
+				ImportSource: "ao",
+			},
+		}
+	}
+
+	t.Run("unconfigured returns no errors (back-compat)", func(t *testing.T) {
+		if errs := (&ITunesConfig{WriteBackEnabled: true}).ValidateLibraries(protected); errs != nil {
+			t.Fatalf("unconfigured should be inert, got %v", errs)
+		}
+	})
+
+	t.Run("valid config passes", func(t *testing.T) {
+		if errs := good().ValidateLibraries(protected); len(errs) != 0 {
+			t.Fatalf("valid config should pass, got %v", errs)
+		}
+	})
+
+	t.Run("original not protected -> error", func(t *testing.T) {
+		errs := good().ValidateLibraries(nil) // no protected paths
+		if !hasErr(errs, "not covered by any protected_paths") {
+			t.Fatalf("expected protected-paths error, got %v", errs)
+		}
+	})
+
+	t.Run("AO under books/itunes -> error", func(t *testing.T) {
+		c := good()
+		c.Libraries.AO.ITLPath = "/mnt/bigdata/books/itunes/iTunes Library.itl"
+		errs := c.ValidateLibraries(protected)
+		if !hasErr(errs, "under books/itunes") {
+			t.Fatalf("expected books/itunes error, got %v", errs)
+		}
+	})
+
+	t.Run("original not frozen while pointed_at=ao -> error", func(t *testing.T) {
+		c := good()
+		c.Libraries.Original.Frozen = false
+		errs := c.ValidateLibraries(protected)
+		if !hasErr(errs, "frozen must be true") {
+			t.Fatalf("expected frozen error, got %v", errs)
+		}
+	})
+
+	t.Run("no AO write target while enabled -> error", func(t *testing.T) {
+		c := good()
+		c.Libraries.AO.ITLPath = ""
+		errs := c.ValidateLibraries(protected)
+		if !hasErr(errs, "must be set when itunes sync") {
+			t.Fatalf("expected zero-value-target error, got %v", errs)
+		}
+	})
+}
+
+func hasErr(errs []string, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
P0 of `docs/specs/2026-07-23-itunes-2way-sync-system-design.md`. **Read-only + config-only; nothing applied to prod.**

## Config scaffold (inert until `itunes.libraries` populated)
- `LibraryRef`/`LibrarySet` — the 4-state model (Original/AO × .itl/.xml) + separated `PointedAt`/`ImportSource` mode facts.
- `ITunesConfig.Resolve()` derives the legacy `LibraryReadPath`/`LibraryWritePath` shims.
- `ValidateLibraries()` — four fail-closed assertions (Original under `protected_paths`; AO target never under `books/itunes/**`; Original frozen once `pointed_at=="ao"`; no zero-value write target while sync enabled). Wired into `Config.Validate()` + viper.
- Empty `Libraries` → **legacy behavior byte-for-byte** (full config suite passes).

## Read findings (`docs/specs/2026-07-23-itunes-2way-p0-findings.md`)
- **F1 — K13 is not LibraryPID-only:** identity = `LibraryPID` **AND** ≥90% overlap of a 1,024-PID track sample. So the steady-state count-refresh must **re-derive the PID sample** each cycle. Resolves the P1 arming blocker.
- **F2 — rebuild callers clean** (only the two guarded handlers).
- **F3 — `ProtectedPaths` empty on prod** → populate `books/itunes/**` before adopting `itunes.libraries` (assertion is inert until then).

## Remaining P0 (follow-up)
Cleanup provenance census (decides if P3 builds), cross-type PID collisions, bookmark byte-preservation proof on a ZFS clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)