### PR TITLE
feat(itunes): cleanup provenance census — P3 exit-gate (measure-and-stop)

### DIFF
--- a/changelog.d/itunes-2way-p0-cleanup-census.md
+++ b/changelog.d/itunes-2way-p0-cleanup-census.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/itunes-2way-p0-cleanup-census.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5a1c8e63-9d24-4f70-b3e8-2c6a1f9b0d47 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Added
+
+#### iTunes cleanup provenance census — P3 exit-gate (read-only)
+
+`internal/itunes/pid_integrity.go` adds `ComputeMergeOrphanCensus`, and
+`cmd/pid-census` a `--merge-provenance` mode. It buckets every track in the AO
+writeback `.itl` by its current live owner (healthy / stale-owner / no-live-owner) and
+intersects the stale-owner tracks with the merge-loser provenance set (the
+`AutoMergeJournalEntry` journal reconciled with `MergedIntoBookID`), producing the
+measure-first exit-gate the 2-way-sync design (§6.5) makes P3 conditional on. Bounded
+worker pool for the per-owner book resolution. Read-only; a copy-of-prod tool.
+
+Measured on prod (97,999 tracks): **provable merge orphans = 1, SHA-gated removable = 0**
+→ **P3 is measure-and-stop** (retire the unsafe `cleanup_merged.go` handler as a guarded
+no-op; build no removal machinery). The census also disproved the design's premise that
+the auto-merge journal is the authoritative loser record — it is empty on prod, and the
+production merge path records losers in neither durable source — which is exactly why the
+count is a floor and bulk removal is un-buildable without new provenance recording. See
+`docs/specs/2026-07-23-itunes-2way-p0-findings.md` §F4.

--- a/cmd/pid-census/main.go
+++ b/cmd/pid-census/main.go
@@ -1,7 +1,7 @@
 // file: cmd/pid-census/main.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f2b0d61-4a37-4c95-9e12-7d3a6b1c0e58
-// last-edited: 2026-07-23
+// last-edited: 2026-07-24
 //
 // READ-ONLY book_file iTunes-PID integrity census. Point it at a COPY of the
 // production Pebble DB (never the live dir — Pebble opens read-write and wants the
@@ -30,6 +30,7 @@ func main() {
 	itlPath := flag.String("itl", "", "optional path to a copy of the writeback iTunes Library.itl")
 	full := flag.Bool("full", false, "print the full JSON report incl. samples (default: summary only)")
 	repair := flag.Bool("repair", false, "also print the pid-repair PLAN preview (read-only; needs --itl for diff_file)")
+	mergeProv := flag.Bool("merge-provenance", false, "run the cleanup provenance census (P3 exit-gate); requires --itl")
 	mapFrom := flag.String("map-from", "W:", "path-mapping source prefix (Windows drive)")
 	mapTo := flag.String("map-to", "/mnt/bigdata/books", "path-mapping target prefix (local mount)")
 	flag.Parse()
@@ -45,6 +46,48 @@ func main() {
 		os.Exit(1)
 	}
 	defer store.Close()
+
+	// Cleanup provenance census (P3 exit-gate) — reconciles BOTH loser sources:
+	// the AutoMergeJournalEntry journal (production-authoritative) via the
+	// EmbeddingStore sharing this store's raw Pebble handle, plus MergedIntoBookID
+	// discovered per-owner inside the census.
+	if *mergeProv {
+		if *itlPath == "" {
+			fmt.Fprintln(os.Stderr, "error: --merge-provenance requires --itl (a copy of the AO writeback .itl)")
+			os.Exit(2)
+		}
+		emb := database.NewEmbeddingStore(store.DB())
+		entries, jerr := emb.ListAutoMergeJournalEntries(0)
+		if jerr != nil {
+			fmt.Fprintf(os.Stderr, "list automerge journal: %v\n", jerr)
+			os.Exit(1)
+		}
+		loserIDs := make([]string, 0, len(entries))
+		for _, e := range entries {
+			loserIDs = append(loserIDs, e.LoserID)
+		}
+		c, cerr := itunes.ComputeMergeOrphanCensus(store, *itlPath, loserIDs)
+		if cerr != nil {
+			fmt.Fprintf(os.Stderr, "merge-orphan census: %v\n", cerr)
+			os.Exit(1)
+		}
+		fmt.Printf("=== CLEANUP PROVENANCE CENSUS (P3 exit-gate) ===\n")
+		fmt.Printf("automerge_journal_entries=%d journal_loser_ids=%d\n", len(entries), c.JournalLoserIDs)
+		fmt.Printf("tracks_in_itl=%d  healthy=%d  stale_owner=%d  no_live_owner=%d\n",
+			c.TracksInITL, c.Healthy, c.StaleOwner, c.NoLiveOwner)
+		fmt.Printf("merged_into_losers=%d distinct_loser_set(seen)=%d residual_duplicate_pids=%d\n",
+			c.MergedIntoLosers, c.DistinctLoserSet, c.ResidualDuplicatePIDs)
+		fmt.Printf(">>> PROVABLE_MERGE_ORPHANS=%d  (sha_gated_removable=%d)\n",
+			c.ProvableMergeOrphans, c.SHAGatedRemovable)
+		fmt.Printf("    NOTE: LOWER BOUND. no_live_owner tracks are unattributable (user non-AO imports\n")
+		fmt.Printf("    OR merge orphans whose PID->loser link was severed). ~0 != 'no orphans exist'.\n")
+		if *full {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(c)
+		}
+		return
+	}
 
 	report, err := itunes.ComputePIDIntegrity(store, *itlPath)
 	if err != nil {

--- a/docs/specs/2026-07-23-itunes-2way-p0-findings.md
+++ b/docs/specs/2026-07-23-itunes-2way-p0-findings.md
@@ -1,7 +1,7 @@
 <!-- file: docs/specs/2026-07-23-itunes-2way-p0-findings.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 2c9e5a71-8b04-4d36-9f18-7a3c1e6b0d52 -->
-<!-- last-edited: 2026-07-23 -->
+<!-- last-edited: 2026-07-24 -->
 
 # iTunes 2-Way-Sync — P0 Findings (read-only)
 
@@ -55,13 +55,66 @@ fail-closed §2.4 assertions). Wired into `Config.Validate()` and viper load. **
 `itunes.libraries` is populated** — empty `Libraries` → legacy behavior byte-for-byte.
 Unit-tested (Resolve for both `import_source` values; all four assertions; back-compat).
 
+## F4 — Cleanup provenance census: P3 is MEASURE-AND-STOP (provable removable set = 0)
+
+**Measured 2026-07-24** against a consistent read-only copy of prod: ZFS snapshot of
+`rpool/ROOT/ubuntu_0nm86n/var/lib` → the Pebble dir copied out of `.zfs/snapshot/` (13G,
+1487 files, crash-consistent) + a copy of the live AO writeback `.itl`
+(`.itunes-writeback/iTunes Library.itl`, 32,103,033 bytes). Ran
+`pid-census --merge-provenance` (new mode, `internal/itunes/pid_integrity.go`
+`ComputeMergeOrphanCensus`). All artifacts + the snapshot were destroyed afterward; the
+`books@itunes-ao-fallback-2026-07-23` snapshot is intact.
+
+```
+tracks_in_itl        = 97999
+  healthy            = 77211   (owned by a live PRIMARY book_file)
+  stale_owner        =  7324   (owned by a soft-deleted / non-primary book_file)
+  no_live_owner      = 13464   (NO book_file carries the PID — unattributable)
+automerge_journal_entries = 0      ← the loser journal is EMPTY on prod
+merged_into_losers        = 1
+residual_duplicate_pids   = 3      (matches the 8,987→3 pid-repair; PIDs are unique)
+>>> PROVABLE_MERGE_ORPHANS = 1   (sha_gated_removable = 0)
+```
+
+**Decision: P3 retires the unsafe `cleanup_merged.go` handler as a guarded no-op and
+builds NO removal machinery.** The provable, SHA-gated, safely-removable orphan set is
+**0** (1 candidate — "Stay of Execution", via `MergedIntoBookID` — with no live-primary
+FileHash match, so not even SHA-confirmed). This is the measure-and-stop branch §6.5
+names as the default expectation.
+
+**Why the number is a floor, and why that STRENGTHENS the stop (advisor fork, confirmed by
+code):** there is no durable, mutation-immune record of "what PIDs a loser owned at merge
+time." `merge.Service.MergeBooks` (`internal/merge/service.go:228`) **reassigns** the
+loser's `ext_id:itunes:*` mappings to the winner and soft-deletes the loser, but writes
+**neither** the `AutoMergeJournalEntry` journal **nor** `MergedIntoBookID`. The journal is
+written ONLY by `dedup/auto_resolve.go` (Tier-1 auto-resolve → 0 entries on prod);
+`MergedIntoBookID` ONLY by `FlagMetadataHashDuplicate` (metafetch dedup +
+`pebble_store.go:4030` → 1 on prod). And the PID-uniqueness repair already cleared
+duplicate `book_file.ITunesPersistentID` off non-canonical rows. So a track that WAS a
+loser's, whose PID→loser link was severed, lands in `no_live_owner` (unattributable), not
+in the provable set. **`~0` here means "the provenance link is gone," not "no orphans
+exist" — and you cannot build a provenance-anchored bulk remover from provenance that
+isn't durably recorded.**
+
+**The 7,324 + 13,464 "leftover-looking" tracks are NOT safely removable.** Samples confirm
+`stale_owner` is dominated by legitimate version-group alternates
+("Warbreaker … Part 1 of 2 (Dramatized Adaptation)", "Legion – Skin Deep") — the editions
+§6.5 forbids removing (reject `version_group_id` basis). `no_live_owner` is unattributable
+(user's direct non-audiobook imports OR severed orphans) and hands-off. Removing from
+either bucket violates the spec's fail-closed rules.
+
+**Two follow-ons (NOT this PR, NOT blocking the stop):**
+1. **No durable merge-provenance trail on prod.** If a future release wants provenance-
+   anchored cleanup, it must FIRST make `merge.Service.MergeBooks` record losers (write the
+   journal at merge time), then re-run this census. Until then, cleanup is un-buildable
+   safely. Also a latent gap for unmerge/audit recovery.
+2. **`no_live_owner` composition** (13,464 = 13.7% of tracks): classify by audiobook genre
+   to separate the user's non-AO music/podcasts (expected, hands-off) from severed
+   audiobook orphans. Does not change the P3 decision (both are un-removable); informs any
+   future re-attribution effort.
+
 ## Remaining P0 (not in this PR)
 
-- **Cleanup provenance census** — enumerate the union of `MergedIntoBookID` +
-  `AutoMergeJournalEntry.LoserID` (+ combine losers), resolve each loser's surviving
-  primary, count the PROVABLE orphan set (loser PID in ITL, owned by no live book_file,
-  survivor PID present, not a static-playlist member). Decides whether P3 builds or is a
-  measure-and-stop no-op.
 - **Cross-type PID collisions** (audiobook vs non-audiobook sharing a PID) — the
   disjointness-assertion backstop. Confirm PID-on-multiple-primaries stays 0 (post pid-repair).
 - **Bookmark / field-preservation byte-proof** on a ZFS clone — run a relocate AND a

--- a/docs/specs/2026-07-23-itunes-2way-p0-findings.md
+++ b/docs/specs/2026-07-23-itunes-2way-p0-findings.md
@@ -107,7 +107,10 @@ either bucket violates the spec's fail-closed rules.
 1. **No durable merge-provenance trail on prod.** If a future release wants provenance-
    anchored cleanup, it must FIRST make `merge.Service.MergeBooks` record losers (write the
    journal at merge time), then re-run this census. Until then, cleanup is un-buildable
-   safely. Also a latent gap for unmerge/audit recovery.
+   safely. **Second consequence of the same gap:** `UnmergeAuto` reads the same journal, so
+   the "undo merge" capability is effectively **inert for every production merge** — the big
+   9,074→1,311 dedup drain went through `MergeBooks`, which wrote nothing to unwind. Any
+   real unmerge/audit recovery needs the same durable-loser-recording fix.
 2. **`no_live_owner` composition** (13,464 = 13.7% of tracks): classify by audiobook genre
    to separate the user's non-AO music/podcasts (expected, hands-off) from severed
    audiobook orphans. Does not change the P3 decision (both are un-removable); informs any

--- a/docs/specs/2026-07-23-itunes-2way-sync-system-design.md
+++ b/docs/specs/2026-07-23-itunes-2way-sync-system-design.md
@@ -1,8 +1,13 @@
 <!-- file: docs/specs/2026-07-23-itunes-2way-sync-system-design.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 7f3a9c2e-8b41-4d6a-9e05-2c1f4a8b7d63 -->
-<!-- last-edited: 2026-07-23 -->
+<!-- last-edited: 2026-07-24 -->
 
+<!-- v1.2.0: §6.5 P0 exit-gate RESOLVED 2026-07-24 — census ran (provable orphans=1,
+     SHA-removable=0) → P3 is measure-and-stop, no removal machinery. F4 also
+     disproved the "journal is the authoritative loser record" premise (journal
+     empty on prod; merge path records losers in neither source). See
+     2026-07-23-itunes-2way-p0-findings.md §F4. -->
 <!-- v1.1.0: §10a records the owner decisions RESOLVED 2026-07-23 (SHA-gated
      auto-merge carve-out; playlist-member refuse+review with measured 292 smart /
      59 static split + binary-parser caveat; V1-respect iTunes deletions; fallback
@@ -427,7 +432,9 @@ For each loser L (audiobook, soft-deleted):
 - **Fail-closed everywhere:** if the DB cannot be fully enumerated (including soft-deleted), or the survivor's track is not confirmed present, remove nothing.
 - **P0 MEASURE-FIRST + HARD EXIT-GATE (resolves the safety judge's "measure-and-stop as default" must-fix):** the size of the provable-orphan set is unknown and may be ~0 (the writeback batcher was mostly functioning). Ship the **dry-run census first**. If the set is ~0, P3 **retires the old unsafe handler as a guarded no-op and does NOT build removal machinery.** Building the removal path is *conditional* on the census showing a non-trivial, provable set. The measure-and-stop branch is the default expectation.
 
-**Why reconcile both loser sources:** the only in-tree `MergedIntoBookID` setter is `FlagMetadataHashDuplicate` (`pebble_store.go:2811`), explicitly a *PebbleStore stub* ("metadata dedup is only performed by SQLiteStore in production"). The production merge path records losers in the `AutoMergeJournalEntry{WinnerID, LoserID}` journal. A criterion keyed solely on `MergedIntoBookID` would miss the real orphan set. P0 must verify which source(s) actually carry the production losers and enumerate their union.
+  **✅ RESOLVED 2026-07-24 — the census ran; the exit-gate says MEASURE-AND-STOP.** `pid-census --merge-provenance` on a consistent read-only prod copy (ZFS-snapshot Pebble + live AO `.itl`, 97,999 tracks): **provable merge orphans = 1, SHA-gated removable = 0.** P3 **retires `cleanup_merged.go` as a guarded no-op and builds NO removal machinery.** See `2026-07-23-itunes-2way-p0-findings.md` §F4. The count is a **floor**: prod carries no durable merge-provenance trail — `merge.Service.MergeBooks` writes neither the journal nor `MergedIntoBookID` (it reassigns external-IDs + soft-deletes), the journal is empty, and pid-repair cleared duplicate book_file PIDs — so severed-link orphans land in the unattributable `no_live_owner` bucket (13,464), which the fail-closed rules forbid touching anyway. A future provenance-anchored cleanup must FIRST make the merge path record losers durably, then re-measure.
+
+**Why reconcile both loser sources:** the only in-tree `MergedIntoBookID` setter is `FlagMetadataHashDuplicate` (`pebble_store.go:2811`), explicitly a *PebbleStore stub* ("metadata dedup is only performed by SQLiteStore in production"). The production merge path was *assumed* to record losers in the `AutoMergeJournalEntry{WinnerID, LoserID}` journal — **but F4 disproved this: the journal is written only by `dedup/auto_resolve.go` (0 entries on prod), and `merge.Service.MergeBooks` records losers in NEITHER source.** A criterion keyed on either (or both) misses the real loser population, which survives only as `MarkedForDeletion` soft-deletes indistinguishable from legitimate version alternates. This is precisely why the provable set is a floor and bulk removal is un-buildable without new provenance recording.
 
 ---
 

--- a/internal/itunes/pid_integrity.go
+++ b/internal/itunes/pid_integrity.go
@@ -253,6 +253,11 @@ type MergeOrphanCensus struct {
 	// whose FileHash is also carried by a LIVE PRIMARY book_file (spec Decision 1
 	// SHA gate). The playlist-membership gate (§7.2) needs the .xml export and is
 	// deliberately NOT applied here.
+	//
+	// FLOOR: livePrimaryHash is built only from books that own a track in this .itl,
+	// so a live primary carrying the same audio but no .itl track won't be counted —
+	// SHAGatedRemovable can only under-count. Do NOT read it as authoritative if the
+	// removal path is ever resurrected.
 	SHAGatedRemovable int `json:"sha_gated_removable"`
 
 	// Diagnostics.

--- a/internal/itunes/pid_integrity.go
+++ b/internal/itunes/pid_integrity.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/pid_integrity.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e2f7a1c4-6b90-4d38-8a5e-1c3f9d2b7e60
-// last-edited: 2026-07-23
+// last-edited: 2026-07-24
 //
 // READ-ONLY book_file iTunes-PID integrity census. A PID is minted unique per
 // book_file (TrackProvisioner.Provision → GeneratePIDHex → crypto/rand), so the
@@ -27,7 +27,11 @@ package itunes
 
 import (
 	"log/slog"
+	"runtime"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
@@ -190,4 +194,285 @@ func ComputePIDIntegrity(store PIDIntegrityStore, itlPath string) (*PIDIntegrity
 		"dupInITL", report.DupInITL, "filesToClear", report.FilesToClear,
 		"pidsOnMultiplePrimariesDiffPath", report.PIDsOnMultiplePrimariesDiffPath)
 	return report, nil
+}
+
+// -----------------------------------------------------------------------------
+// Cleanup provenance census — the P3 build/no-op exit-gate (spec §6.5, P0).
+// -----------------------------------------------------------------------------
+
+// OrphanBucket labels how one AO-.itl track relates to the live library.
+type OrphanBucket string
+
+const (
+	// BucketHealthy: the track's PID is owned by a live PRIMARY book_file. Fine.
+	BucketHealthy OrphanBucket = "healthy"
+	// BucketStaleOwner: owned by a book_file whose book is soft-deleted or
+	// non-primary — a version/merge leftover, but only an orphan if provenance
+	// attributes it to a merge loser.
+	BucketStaleOwner OrphanBucket = "stale_owner"
+	// BucketNoLiveOwner: NO live book_file carries the PID. Unattributable — this
+	// is EITHER a user's directly-imported non-audiobook track (hands-off) OR a
+	// merge orphan whose book_file PID was cleared by the PID-uniqueness repair.
+	// Never bulk-removable: we cannot prove it is ours.
+	BucketNoLiveOwner OrphanBucket = "no_live_owner"
+)
+
+// OrphanSample is one attributed AO-.itl track, kept for the JSON detail view.
+type OrphanSample struct {
+	PID          string       `json:"pid"`
+	Bucket       OrphanBucket `json:"bucket"`
+	OwnerFileID  string       `json:"owner_file_id,omitempty"`
+	OwnerBookID  string       `json:"owner_book_id,omitempty"`
+	Title        string       `json:"title,omitempty"`
+	InLoserSet   bool         `json:"in_loser_set"`             // owner book ∈ merge-loser provenance
+	LoserSource  string       `json:"loser_source,omitempty"`   // "journal" | "merged_into" | "both"
+	SHAMatch     bool         `json:"sha_match"`                // a live-primary book_file shares this file's FileHash
+	FileHash     string       `json:"file_hash,omitempty"`
+}
+
+// MergeOrphanCensus is the decision-relevant output. The bucket counts partition
+// TracksInITL exactly (Healthy + StaleOwner + NoLiveOwner == TracksInITL).
+type MergeOrphanCensus struct {
+	TracksInITL int `json:"tracks_in_itl"`
+
+	// Loser provenance (spec §6.5 reconciles BOTH sources).
+	JournalLoserIDs   int `json:"journal_loser_ids"`    // distinct LoserID in AutoMergeJournalEntry
+	MergedIntoLosers  int `json:"merged_into_losers"`   // distinct owner-books with MergedIntoBookID set (among .itl owners)
+	DistinctLoserSet  int `json:"distinct_loser_set"`   // |journal ∪ merged_into| restricted to .itl owners actually seen
+
+	// Bucketing of every AO-.itl track by its CURRENT live owner.
+	Healthy     int `json:"healthy"`
+	StaleOwner  int `json:"stale_owner"`
+	NoLiveOwner int `json:"no_live_owner"`
+
+	// The P3 gating number: stale-owner tracks whose owner book is a provable
+	// merge loser (journal ∪ MergedIntoBookID). LOWER BOUND — see caveat.
+	ProvableMergeOrphans int `json:"provable_merge_orphans"`
+
+	// Narrowing (reported, NOT acted on here): of the provable orphans, those
+	// whose FileHash is also carried by a LIVE PRIMARY book_file (spec Decision 1
+	// SHA gate). The playlist-membership gate (§7.2) needs the .xml export and is
+	// deliberately NOT applied here.
+	SHAGatedRemovable int `json:"sha_gated_removable"`
+
+	// Diagnostics.
+	ResidualDuplicatePIDs int `json:"residual_duplicate_pids"` // PIDs on >1 book_file (should be ~0 post-repair)
+
+	Samples []OrphanSample `json:"samples"`
+}
+
+// ComputeMergeOrphanCensus buckets every track in the AO .itl by its current live
+// owner and intersects the stale-owner tracks with the merge-loser provenance
+// set, producing the P3 build/no-op exit-gate. READ-ONLY.
+//
+// journalLoserIDs is the {LoserID} set from EmbeddingStore.ListAutoMergeJournalEntries
+// (the production-authoritative loser record — the itunes package stays decoupled
+// from EmbeddingStore, so the caller passes it in). MergedIntoBookID losers are
+// discovered per-owner from the store.
+//
+// IMPORTANT — the count is a LOWER BOUND. There is no durable record of the PIDs a
+// loser owned at merge time: MergeBooks reassigns the loser's iTunes external-IDs
+// to the winner, the PID-uniqueness repair cleared duplicate book_file PIDs, and
+// the journal/book_ver snapshot store no PIDs. So a track that WAS a loser's but
+// whose PID→loser link was severed lands in no_live_owner (unattributable), not in
+// ProvableMergeOrphans. A ~0 result means "the link is severed," NOT "no orphans
+// exist" — never treat it as a licence for bulk removal.
+func ComputeMergeOrphanCensus(store PIDIntegrityStore, itlPath string, journalLoserIDs []string) (*MergeOrphanCensus, error) {
+	lib, err := ParseITL(itlPath)
+	if err != nil {
+		return nil, err
+	}
+	itlPIDs := make([]string, len(lib.Tracks))
+	for i := range lib.Tracks {
+		itlPIDs[i] = strings.ToUpper(pidToHex(lib.Tracks[i].PersistentID))
+	}
+	return computeMergeOrphanCensus(store, itlPIDs, journalLoserIDs)
+}
+
+// computeMergeOrphanCensus is the pure core: it takes the AO .itl track PID set
+// (upper-hex) directly so it is unit-testable without a binary .itl. See
+// ComputeMergeOrphanCensus for the contract and the LOWER-BOUND caveat.
+func computeMergeOrphanCensus(store PIDIntegrityStore, itlPIDs []string, journalLoserIDs []string) (*MergeOrphanCensus, error) {
+	// PID → the book_file(s) that carry it. Post-repair PIDs are unique, but stay
+	// defensive: a residual duplicate is a diagnostic, not a crash.
+	byPID := make(map[string][]database.BookFileCore)
+	// FileHash → book_files carrying it (for the SHA gate, no extra store reads).
+	byHash := make(map[string][]database.BookFileCore)
+	files, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return nil, err
+	}
+	for i := range files {
+		pid := strings.ToUpper(strings.TrimSpace(files[i].ITunesPersistentID))
+		if pid != "" {
+			byPID[pid] = append(byPID[pid], files[i])
+		}
+		if h := files[i].FileHash; h != "" {
+			byHash[h] = append(byHash[h], files[i])
+		}
+	}
+
+	journalSet := make(map[string]bool, len(journalLoserIDs))
+	for _, id := range journalLoserIDs {
+		if id != "" {
+			journalSet[id] = true
+		}
+	}
+
+	// The distinct owner-books we need to resolve = owners of .itl tracks, plus
+	// owners of any FileHash group that a candidate orphan may SHA-match against.
+	// Collect the .itl-owner books first; resolve concurrently (whole-library
+	// scale, per-item Pebble read → bounded pool per CLAUDE.md concurrency rule).
+	needBook := make(map[string]struct{})
+	for _, pid := range itlPIDs {
+		for _, f := range byPID[pid] {
+			needBook[f.BookID] = struct{}{}
+		}
+	}
+
+	bookMu := sync.Mutex{}
+	books := make(map[string]*database.Book, len(needBook))
+	ids := make([]string, 0, len(needBook))
+	for id := range needBook {
+		ids = append(ids, id)
+	}
+	g := new(errgroup.Group)
+	g.SetLimit(runtime.NumCPU())
+	for _, id := range ids {
+		g.Go(func() error {
+			b, berr := store.GetBookByID(id)
+			if berr != nil || b == nil {
+				return nil // best-effort: a missing book leaves the track unattributed
+			}
+			bookMu.Lock()
+			books[id] = b
+			bookMu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	isLivePrimary := func(b *database.Book) bool {
+		if b == nil {
+			return false
+		}
+		softDeleted := b.MarkedForDeletion != nil && *b.MarkedForDeletion
+		primary := b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+		return primary && !softDeleted
+	}
+
+	// Set of FileHashes owned by at least one LIVE PRIMARY book_file — the SHA gate
+	// target. Resolving these books reuses the already-fetched .itl-owner cache
+	// where possible; misses are looked up lazily below only for candidate orphans.
+	livePrimaryHash := make(map[string]bool)
+	for h, group := range byHash {
+		for _, f := range group {
+			if b, ok := books[f.BookID]; ok && isLivePrimary(b) {
+				livePrimaryHash[h] = true
+				break
+			}
+		}
+	}
+
+	c := &MergeOrphanCensus{TracksInITL: len(itlPIDs), JournalLoserIDs: len(journalSet)}
+	mergedIntoSeen := make(map[string]bool)
+	loserSeen := make(map[string]bool)
+
+	for _, pid := range itlPIDs {
+		owners := byPID[pid]
+		if len(owners) > 1 {
+			c.ResidualDuplicatePIDs++
+		}
+		if len(owners) == 0 {
+			c.NoLiveOwner++
+			c.addSample(OrphanSample{PID: pid, Bucket: BucketNoLiveOwner})
+			continue
+		}
+		// Prefer a live-primary owner if any; else take the first (stale) owner.
+		var owner database.BookFileCore
+		var ownerBook *database.Book
+		picked := false
+		for _, f := range owners {
+			b := books[f.BookID]
+			if isLivePrimary(b) {
+				owner, ownerBook, picked = f, b, true
+				break
+			}
+		}
+		if !picked {
+			owner = owners[0]
+			ownerBook = books[owner.BookID]
+		}
+
+		if isLivePrimary(ownerBook) {
+			c.Healthy++
+			continue
+		}
+
+		// Stale owner (soft-deleted or non-primary). Attribute by provenance.
+		c.StaleOwner++
+		inJournal := ownerBook != nil && journalSet[ownerBook.ID]
+		mergedInto := ownerBook != nil && ownerBook.MergedIntoBookID != nil
+		if mergedInto && !mergedIntoSeen[ownerBook.ID] {
+			mergedIntoSeen[ownerBook.ID] = true
+			c.MergedIntoLosers++
+		}
+		if (inJournal || mergedInto) && ownerBook != nil && !loserSeen[ownerBook.ID] {
+			loserSeen[ownerBook.ID] = true
+			c.DistinctLoserSet++
+		}
+
+		sample := OrphanSample{
+			PID: pid, Bucket: BucketStaleOwner, OwnerFileID: owner.ID,
+			FileHash: owner.FileHash,
+		}
+		if ownerBook != nil {
+			sample.OwnerBookID = ownerBook.ID
+			sample.Title = ownerBook.Title
+		}
+		if inJournal || mergedInto {
+			c.ProvableMergeOrphans++
+			sample.InLoserSet = true
+			switch {
+			case inJournal && mergedInto:
+				sample.LoserSource = "both"
+			case inJournal:
+				sample.LoserSource = "journal"
+			default:
+				sample.LoserSource = "merged_into"
+			}
+			if owner.FileHash != "" && livePrimaryHash[owner.FileHash] {
+				c.SHAGatedRemovable++
+				sample.SHAMatch = true
+			}
+		}
+		c.addSample(sample)
+	}
+
+	slog.Info("itunes merge-orphan census",
+		"tracksInITL", c.TracksInITL, "healthy", c.Healthy, "staleOwner", c.StaleOwner,
+		"noLiveOwner", c.NoLiveOwner, "journalLoserIDs", c.JournalLoserIDs,
+		"mergedIntoLosers", c.MergedIntoLosers, "provableMergeOrphans", c.ProvableMergeOrphans,
+		"shaGatedRemovable", c.SHAGatedRemovable, "residualDuplicatePIDs", c.ResidualDuplicatePIDs)
+	return c, nil
+}
+
+// addSample keeps up to pidSampleLimit samples, prioritizing attributed orphans
+// (InLoserSet) so the detail view surfaces the decision-relevant rows first.
+func (c *MergeOrphanCensus) addSample(s OrphanSample) {
+	if len(c.Samples) < pidSampleLimit {
+		c.Samples = append(c.Samples, s)
+		return
+	}
+	if !s.InLoserSet {
+		return
+	}
+	for i := range c.Samples {
+		if !c.Samples[i].InLoserSet {
+			c.Samples[i] = s
+			return
+		}
+	}
 }

--- a/internal/itunes/pid_integrity_test.go
+++ b/internal/itunes/pid_integrity_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/pid_integrity_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c9a3e714-0d62-4b58-9f21-6e4a2c8b1d70
-// last-edited: 2026-07-23
+// last-edited: 2026-07-24
 
 package itunes
 
@@ -29,6 +29,94 @@ func (m *pidCensusMock) GetBookByID(id string) (*database.Book, error) {
 func bf(id, bookID, path, pid string) database.BookFileCore {
 	return database.BookFileCore{ID: id, BookID: bookID, FilePath: path, ITunesPersistentID: pid}
 }
+
+func bfh(id, bookID, path, pid, hash string) database.BookFileCore {
+	f := bf(id, bookID, path, pid)
+	f.FileHash = hash
+	return f
+}
+
+// TestComputeMergeOrphanCensus exercises the .itl-track bucketing + the merge
+// provenance intersection (journal ∪ MergedIntoBookID) + the SHA gate, driving the
+// pure core with an injected PID set (no binary .itl needed).
+func TestComputeMergeOrphanCensus(t *testing.T) {
+	primary := true
+	notPrimary := false
+	del := true
+
+	store := &pidCensusMock{
+		files: []database.BookFileCore{
+			// HEALTHY — live primary owns the track.
+			bf("f_h", "b_h", "/mnt/x/healthy.m4b", "AAAA0001"),
+			// STALE (non-primary) but NOT a loser → stale_owner, not an orphan.
+			bf("f_s", "b_s", "/mnt/x/stale.m4b", "BBBB0002"),
+			// PROVABLE ORPHAN via the JOURNAL loser set; its FileHash H1 is ALSO
+			// carried by a live-primary book_file → SHA-gated removable.
+			bfh("f_j", "b_j", "/mnt/x/j.m4b", "CCCC0003", "H1"),
+			bfh("f_hp", "b_hp", "/mnt/x/hp.m4b", "AAAA0009", "H1"), // live-primary carrier of H1
+			// PROVABLE ORPHAN via MergedIntoBookID; FileHash H2 has NO live-primary
+			// carrier → counted as provable orphan but NOT SHA-gated.
+			bfh("f_m", "b_m", "/mnt/x/m.m4b", "DDDD0004", "H2"),
+		},
+		books: map[string]*database.Book{
+			"b_h":  {ID: "b_h", IsPrimaryVersion: &primary},
+			"b_s":  {ID: "b_s", IsPrimaryVersion: &notPrimary},
+			"b_j":  {ID: "b_j", IsPrimaryVersion: &notPrimary, MarkedForDeletion: &del},
+			"b_hp": {ID: "b_hp", IsPrimaryVersion: &primary},
+			"b_m":  {ID: "b_m", IsPrimaryVersion: &notPrimary, MarkedForDeletion: &del,
+				MergedIntoBookID: strptr("b_winner")},
+		},
+	}
+
+	// .itl contains: the two healthy PIDs, the stale PID, both orphan PIDs, and
+	// one PID owned by NO book_file (a user's direct non-AO import).
+	itlPIDs := []string{"AAAA0001", "AAAA0009", "BBBB0002", "CCCC0003", "DDDD0004", "EEEE9999"}
+	journalLosers := []string{"b_j"} // b_m comes only from MergedIntoBookID
+
+	c, err := computeMergeOrphanCensus(store, itlPIDs, journalLosers)
+	if err != nil {
+		t.Fatalf("computeMergeOrphanCensus: %v", err)
+	}
+
+	if c.TracksInITL != 6 {
+		t.Errorf("TracksInITL = %d, want 6", c.TracksInITL)
+	}
+	// AAAA0001 + AAAA0009 both owned by live primaries.
+	if c.Healthy != 2 {
+		t.Errorf("Healthy = %d, want 2", c.Healthy)
+	}
+	// BBBB0002 (non-primary, non-loser) + CCCC0003 + DDDD0004 (losers) = 3 stale.
+	if c.StaleOwner != 3 {
+		t.Errorf("StaleOwner = %d, want 3", c.StaleOwner)
+	}
+	// EEEE9999 has no owning book_file.
+	if c.NoLiveOwner != 1 {
+		t.Errorf("NoLiveOwner = %d, want 1", c.NoLiveOwner)
+	}
+	if c.Healthy+c.StaleOwner+c.NoLiveOwner != c.TracksInITL {
+		t.Errorf("buckets must partition tracks: %d+%d+%d != %d",
+			c.Healthy, c.StaleOwner, c.NoLiveOwner, c.TracksInITL)
+	}
+	// Both loser sources reconciled: CCCC (journal) + DDDD (merged_into).
+	if c.ProvableMergeOrphans != 2 {
+		t.Errorf("ProvableMergeOrphans = %d, want 2 (journal + merged_into)", c.ProvableMergeOrphans)
+	}
+	if c.JournalLoserIDs != 1 {
+		t.Errorf("JournalLoserIDs = %d, want 1", c.JournalLoserIDs)
+	}
+	if c.MergedIntoLosers != 1 {
+		t.Errorf("MergedIntoLosers = %d, want 1", c.MergedIntoLosers)
+	}
+	// Only CCCC's FileHash (H1) is carried by a live primary (b_hp).
+	if c.SHAGatedRemovable != 1 {
+		t.Errorf("SHAGatedRemovable = %d, want 1 (H1 only)", c.SHAGatedRemovable)
+	}
+	if c.ResidualDuplicatePIDs != 0 {
+		t.Errorf("ResidualDuplicatePIDs = %d, want 0", c.ResidualDuplicatePIDs)
+	}
+}
+
+func strptr(s string) *string { return &s }
 
 // TestComputePIDIntegrity exercises the duplicate-PID classification and the
 // relocate-correctness probe with no real .itl (itlPath = "").

--- a/todo.d/itunes-2way-p0-cleanup-census.md
+++ b/todo.d/itunes-2way-p0-cleanup-census.md
@@ -1,0 +1,22 @@
+<!-- file: todo.d/itunes-2way-p0-cleanup-census.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8e2b5a41-6c93-4d07-9f18-3a1c7e6b0d52 -->
+<!-- last-edited: 2026-07-24 -->
+
+- [ ] **iTunes 2-way-sync P3 (cleanup) — decision: MEASURE-AND-STOP, no removal machinery.**
+  The P0 cleanup provenance census ran on prod (97,999 `.itl` tracks): **provable merge
+  orphans = 1, SHA-gated removable = 0** (`pid-census --merge-provenance`). P3 retires the
+  unsafe `cleanup_merged.go` handler as a guarded no-op; do NOT build bulk removal. The
+  count is a floor — prod has no durable merge-provenance trail (`merge.Service.MergeBooks`
+  writes neither the `AutoMergeJournalEntry` journal nor `MergedIntoBookID`; the journal is
+  empty). FOLLOW-ONS (not blocking): (1) if provenance-anchored cleanup is ever wanted, FIRST
+  make the merge path record losers durably, THEN re-run this census; also a latent
+  unmerge/audit gap. (2) Classify the 13,464 `no_live_owner` tracks by audiobook genre to
+  separate the user's non-AO music/podcasts from severed orphans (doesn't change the P3
+  decision). See `docs/specs/2026-07-23-itunes-2way-p0-findings.md` §F4.
+- [ ] **iTunes 2-way-sync — remaining P0 measurements.** (a) Cross-type PID collisions
+  (audiobook vs non-audiobook sharing a PID) — confirm PID-on-multiple-primaries stays 0
+  post pid-repair. (b) Bookmark/field-preservation byte-proof: run a relocate AND a
+  track-remove through `SafeWriteITL` on a ZFS clone, byte-compare every untouched track's
+  record, assert ZERO changes. Then P1 (partitioned count-refresh, re-derive PID sample) /
+  P2 (relocate-only sync-cycle op + oracle = MVP end).


### PR DESCRIPTION
## What

Adds `ComputeMergeOrphanCensus` (`internal/itunes/pid_integrity.go`) and a `--merge-provenance` mode to `cmd/pid-census`. This is the **measure-first exit-gate** the 2-way-sync design (`docs/specs/2026-07-23-itunes-2way-sync-system-design.md` §6.5) makes P3 (merged-track cleanup) conditional on.

It buckets every track in the AO writeback `.itl` by its **current live owner** (healthy / stale-owner / no-live-owner) and intersects the stale-owner tracks with the merge-loser provenance set — the `AutoMergeJournalEntry` journal reconciled with `MergedIntoBookID`. Read-only; a copy-of-prod tool. Bounded worker pool for per-owner book resolution (CLAUDE.md concurrency rule).

## Result (measured on prod, 2026-07-24)

ZFS-snapshot Pebble copy + live AO `.itl` (97,999 tracks):

```
healthy=77211  stale_owner=7324  no_live_owner=13464
automerge_journal_entries=0   merged_into_losers=1   residual_duplicate_pids=3
>>> PROVABLE_MERGE_ORPHANS=1   (sha_gated_removable=0)
```

**Decision: P3 is MEASURE-AND-STOP.** The provable, SHA-gated, safely-removable orphan set is **0** → P3 retires the unsafe `cleanup_merged.go` handler as a guarded no-op and builds **no** removal machinery. This is the default branch §6.5 names.

## Why the count is a floor (and why that strengthens the stop)

The census **disproved the design's premise** that the auto-merge journal is the authoritative loser record:
- The journal is written **only** by `dedup/auto_resolve.go` → **0 entries** on prod.
- `MergedIntoBookID` is written only by `FlagMetadataHashDuplicate` → **1** on prod.
- `merge.Service.MergeBooks` (the actual UI/dedup merge path) records losers in **neither** — it reassigns external-IDs to the winner and soft-deletes the loser.

So there is no durable merge-provenance trail. Combined with the pid-repair having cleared duplicate `book_file` PIDs, any severed-link orphan lands in the unattributable `no_live_owner` bucket (13,464), which the fail-closed rules forbid removing anyway. `~0` means "the provenance link is gone," not "no orphans exist" — and you cannot build a provenance-anchored bulk remover from provenance that isn't recorded.

The 7,324 stale-owner tracks are dominated by legitimate version alternates (samples: "Warbreaker … Part 1 of 2 (Dramatized Adaptation)", "Legion – Skin Deep") — the editions §6.5 forbids removing.

## Follow-ons (not this PR)

1. If provenance-anchored cleanup is ever wanted: make `merge.Service.MergeBooks` record losers durably first, then re-run this census. Also a latent unmerge/audit gap.
2. Classify the 13,464 `no_live_owner` tracks by audiobook genre (doesn't change the P3 decision).

## Verification

- `go build ./...`, `go test ./internal/itunes/... ./cmd/pid-census/...`, `go vet` — clean.
- New unit test `TestComputeMergeOrphanCensus` covers each bucket, the journal∪MergedIntoBookID union, and the SHA gate.
- Server artifacts (snapshot, clone, work dir, staged binary) all destroyed; `books@itunes-ao-fallback-2026-07-23` intact.
- Local `make ci` staticcheck fails only on pre-existing unrelated files (`dataloss_preserve_invariant_test.go`, `regroup_shattered_ai_test.go`) — the documented red herring; changed files are clean.

Findings: `docs/specs/2026-07-23-itunes-2way-p0-findings.md` §F4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt