### PR TITLE
feat(itunes): relocate acceptance oracle (2-way-sync auto-rollback trigger)

### DIFF
--- a/changelog.d/itunes-2way-relocate-oracle.md
+++ b/changelog.d/itunes-2way-relocate-oracle.md
@@ -1,0 +1,23 @@
+<!-- file: changelog.d/itunes-2way-relocate-oracle.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4d9c1e73-8b52-4a60-9f18-2c7b5a0e3d61 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Added
+
+#### iTunes 2-way-sync — relocate acceptance oracle (auto-rollback trigger, not yet wired)
+
+`internal/itunes/relocate_oracle.go` adds `VerifyRelocateWrite(before, after,
+relocatedPIDs)`, the post-write acceptance oracle the P2 decoupled write cycle uses to
+gate an atomic rename / trigger auto-rollback. It compares the decompressed ITL payload
+before vs after at the per-track **raw-byte** level and confirms the write did exactly
+what was planned: every relocated PID changed only its location pair (0x0D/0x0B), every
+other track is byte-identical, and no track was added or removed. Raw-byte comparison
+catches any unintended change — including atoms the LE parser does not decode (resume
+bookmark, artwork, sort keys) — which a parsed-field diff cannot see.
+
+Proven on the real 97,999-track library (env-gated test): a genuine 300-track relocate
+verifies clean (300 relocated, 97,699 untouched byte-identical) and a single tampered
+byte in an untouched track is caught. Purely additive and fully unit-tested (happy
+relocate, undeclared change, non-location mutation, track removal, idempotence). Nothing
+calls it yet; the P2 sync cycle wires it in a later PR. Independent of the F7 blocker.

--- a/internal/itunes/relocate_oracle.go
+++ b/internal/itunes/relocate_oracle.go
@@ -1,0 +1,261 @@
+// file: internal/itunes/relocate_oracle.go
+// version: 1.0.0
+// guid: 7a2e9c14-6b83-4d50-9f27-1c8b5a0e3d62
+// last-edited: 2026-07-24
+//
+// Post-write acceptance oracle for the 2-way-sync relocate path (P2 of the
+// 2-way-sync system design). After a relocate write, this compares the decompressed
+// ITL payload BEFORE vs AFTER at the per-track RAW-BYTE level and confirms the write
+// did EXACTLY what was planned and nothing else:
+//
+//   - every relocated PID changed ONLY its location pair (0x0D/0x0B); every other
+//     byte of the track — the mith header (play count, rating, resume bookmark,
+//     dates) and every other mhod atom — is byte-identical;
+//   - every other track is byte-identical;
+//   - no track was added or removed (relocate is 0 adds / 0 removes).
+//
+// Raw-byte comparison is the point: it catches ANY unintended change, including
+// atoms the LE parser does not decode (bookmarks, artwork, sort keys) — which a
+// parsed-field diff (ComputeITLDiff) cannot see. A non-empty verdict.Violations is
+// the auto-rollback trigger: the decoupled write cycle restores the .bak and alerts.
+//
+// The byte-preservation property this checks was proven on the real 97,999-track
+// library by internal/itunes/itl_preserve_proof_test.go (findings §F6); this oracle
+// enforces it on every production write rather than trusting it.
+
+package itunes
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// OracleViolationKind classifies how a write departed from a pure relocate.
+type OracleViolationKind string
+
+const (
+	ViolationAdded          OracleViolationKind = "track-added"          // PID present after, absent before
+	ViolationRemoved        OracleViolationKind = "track-removed"        // PID present before, absent after
+	ViolationUnexpected     OracleViolationKind = "unexpected-change"    // a NON-relocated track's bytes changed
+	ViolationNonLocationMut OracleViolationKind = "non-location-mutated" // a relocated track changed beyond its location pair
+)
+
+// OracleViolation is one departure from the planned relocate.
+type OracleViolation struct {
+	PID    string              `json:"pid"`
+	Kind   OracleViolationKind `json:"kind"`
+	Detail string              `json:"detail,omitempty"`
+}
+
+// RelocateOracleVerdict is the acceptance result. OK is true iff Violations is empty.
+type RelocateOracleVerdict struct {
+	OK                bool              `json:"ok"`
+	TracksBefore      int               `json:"tracks_before"`
+	TracksAfter       int               `json:"tracks_after"`
+	RelocatedExpected int               `json:"relocated_expected"`
+	RelocatedVerified int               `json:"relocated_verified"` // relocated PIDs with all non-location bytes identical
+	UnchangedVerified int               `json:"unchanged_verified"` // untouched PIDs byte-identical
+	LocationChanged   int               `json:"location_changed"`   // relocated PIDs whose location pair actually differs
+	Violations        []OracleViolation `json:"violations,omitempty"`
+}
+
+// oracleMaxViolations caps the violation list so a catastrophic write (everything
+// changed) cannot produce an unbounded report; the count fields stay exact.
+const oracleMaxViolations = 200
+
+// VerifyRelocateWrite is the relocate acceptance oracle. before/after are the
+// DECOMPRESSED LE payloads (e.g. from DecryptAndInflateITL) of the library before
+// and after the write; relocatedPIDs is the set of lower-hex PIDs the plan intended
+// to relocate. READ-ONLY. Returns a verdict; Violations non-empty ⇒ auto-rollback.
+func VerifyRelocateWrite(before, after []byte, relocatedPIDs map[string]bool) (*RelocateOracleVerdict, error) {
+	beforeBlocks, err := splitMithBlocksByPID(before)
+	if err != nil {
+		return nil, fmt.Errorf("oracle: split before: %w", err)
+	}
+	afterBlocks, err := splitMithBlocksByPID(after)
+	if err != nil {
+		return nil, fmt.Errorf("oracle: split after: %w", err)
+	}
+
+	v := &RelocateOracleVerdict{
+		TracksBefore:      len(beforeBlocks),
+		TracksAfter:       len(afterBlocks),
+		RelocatedExpected: len(relocatedPIDs),
+	}
+	addViol := func(pid string, kind OracleViolationKind, detail string) {
+		if len(v.Violations) < oracleMaxViolations {
+			v.Violations = append(v.Violations, OracleViolation{PID: pid, Kind: kind, Detail: detail})
+		}
+	}
+
+	for pid, beforeBlock := range beforeBlocks {
+		afterBlock, present := afterBlocks[pid]
+		if !present {
+			addViol(pid, ViolationRemoved, "track disappeared (relocate removes nothing)")
+			continue
+		}
+		if relocatedPIDs[pid] {
+			mutated, locChanged := relocateTrackDelta(beforeBlock, afterBlock)
+			if mutated {
+				addViol(pid, ViolationNonLocationMut, "track changed beyond its location pair")
+			} else {
+				v.RelocatedVerified++
+			}
+			if locChanged {
+				v.LocationChanged++
+			}
+		} else if !bytes.Equal(beforeBlock, afterBlock) {
+			addViol(pid, ViolationUnexpected, "non-relocated track changed")
+		} else {
+			v.UnchangedVerified++
+		}
+	}
+	// Additions: a PID present after but not before.
+	for pid := range afterBlocks {
+		if _, ok := beforeBlocks[pid]; !ok {
+			addViol(pid, ViolationAdded, "track appeared (relocate adds nothing)")
+		}
+	}
+
+	v.OK = len(v.Violations) == 0
+	return v, nil
+}
+
+// relocateTrackDelta compares one track's before/after blocks and reports whether
+// anything OTHER than the location pair changed (mutated), and whether the location
+// pair itself changed (locChanged). A relocate is valid iff !mutated.
+func relocateTrackDelta(before, after []byte) (mutated, locChanged bool) {
+	hlB, atomsB := splitMhodAtoms(before)
+	hlA, atomsA := splitMhodAtoms(after)
+
+	// mith header must be identical except the 4-byte totalLen at offset 8, which
+	// legitimately changes when the location string length changes.
+	if hlB != hlA || !bytes.Equal(before[:8], after[:8]) || !bytes.Equal(before[12:hlB], after[12:hlA]) {
+		mutated = true
+	}
+
+	// Compare non-location atoms element-wise (order preserved by the writer); and
+	// detect whether the location atoms changed.
+	nb := filterOutLocation(atomsB)
+	na := filterOutLocation(atomsA)
+	if len(nb) != len(na) {
+		mutated = true
+	} else {
+		for i := range nb {
+			if nb[i].typ != na[i].typ || !bytes.Equal(nb[i].bytes, na[i].bytes) {
+				mutated = true
+				break
+			}
+		}
+	}
+
+	lb := filterLocation(atomsB)
+	la := filterLocation(atomsA)
+	if len(lb) != len(la) {
+		locChanged = true
+	} else {
+		for i := range lb {
+			if lb[i].typ != la[i].typ || !bytes.Equal(lb[i].bytes, la[i].bytes) {
+				locChanged = true
+				break
+			}
+		}
+	}
+	return mutated, locChanged
+}
+
+// mhodAtom is one mhoh chunk within a track block (its hohmType + raw bytes).
+type oracleMhod struct {
+	typ   uint32
+	bytes []byte
+}
+
+func filterOutLocation(atoms []oracleMhod) []oracleMhod {
+	out := make([]oracleMhod, 0, len(atoms))
+	for _, a := range atoms {
+		if a.typ == 0x0D || a.typ == 0x0B {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+func filterLocation(atoms []oracleMhod) []oracleMhod {
+	out := make([]oracleMhod, 0, 2)
+	for _, a := range atoms {
+		if a.typ == 0x0D || a.typ == 0x0B {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// splitMhodAtoms splits one mith track block into its header length and ordered mhoh
+// atoms (each carries its hohmType at +12).
+func splitMhodAtoms(block []byte) (headerLen int, atoms []oracleMhod) {
+	if len(block) < 8 {
+		return 0, nil
+	}
+	headerLen = int(readUint32LE(block, 4))
+	off := headerLen
+	for off+16 <= len(block) {
+		if readTag(block, off) != "mhoh" {
+			break
+		}
+		hl := int(readUint32LE(block, off+4))
+		tl := int(readUint32LE(block, off+8))
+		l := hl
+		if tl > hl && tl <= len(block)-off {
+			l = tl
+		}
+		if l < 8 || off+l > len(block) {
+			break
+		}
+		atoms = append(atoms, oracleMhod{typ: readUint32LE(block, off+12), bytes: block[off : off+l]})
+		off += l
+	}
+	return headerLen, atoms
+}
+
+// splitMithBlocksByPID walks the track section (msdh type 1) and returns lower-hex
+// PID -> raw mith block bytes. Production analogue of the byte-proof test helper.
+func splitMithBlocksByPID(data []byte) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	msdhOffset, msdhHeaderLen, msdhTotalLen := findMsdhByType(data, 1)
+	if msdhOffset < 0 {
+		return nil, fmt.Errorf("track section (msdh type 1) not found")
+	}
+	contentStart := msdhOffset + msdhHeaderLen
+	contentEnd := msdhOffset + msdhTotalLen
+	if contentEnd > len(data) {
+		contentEnd = len(data)
+	}
+	mlthHeaderLen := 0
+	if contentStart+12 <= contentEnd && readTag(data, contentStart) == "mlth" {
+		mlthHeaderLen = int(readUint32LE(data, contentStart+4))
+	}
+	offset := contentStart + mlthHeaderLen
+	for offset+8 <= contentEnd {
+		tag := readTag(data, offset)
+		if tag == "" {
+			break
+		}
+		hl := int(readUint32LE(data, offset+4))
+		tl := int(readUint32LE(data, offset+8))
+		length := hl
+		if tl > hl && tl <= contentEnd-offset {
+			length = tl
+		}
+		if length < 8 || offset+length > contentEnd {
+			break
+		}
+		if tag == "mith" && offset+136 <= len(data) {
+			pid := extractMithPIDLE(data, offset)
+			// Copy so the returned slice is independent of the input backing array.
+			out[pid] = append([]byte(nil), data[offset:offset+length]...)
+		}
+		offset += length
+	}
+	return out, nil
+}

--- a/internal/itunes/relocate_oracle_test.go
+++ b/internal/itunes/relocate_oracle_test.go
@@ -1,0 +1,234 @@
+// file: internal/itunes/relocate_oracle_test.go
+// version: 1.0.0
+// guid: 2b8f1c93-7a64-4d50-9e18-3f6c5a0e2d71
+// last-edited: 2026-07-24
+
+package itunes
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// anyPID returns one lower-hex track PID from a decompressed payload.
+func anyPID(t *testing.T, payload []byte) string {
+	t.Helper()
+	blocks, err := splitMithBlocksByPID(payload)
+	if err != nil {
+		t.Fatalf("splitMithBlocksByPID: %v", err)
+	}
+	for pid := range blocks {
+		return pid
+	}
+	t.Fatal("no tracks in payload")
+	return ""
+}
+
+func TestVerifyRelocateWrite_HappyRelocate(t *testing.T) {
+	before := buildCleanPayload()
+	pid := anyPID(t, before)
+
+	after, n := UpdateMetadataLE(before, []ITLMetadataUpdate{{PersistentID: pid, Location: `W:\PROOF\moved.mp3`}})
+	if n != 1 {
+		t.Fatalf("relocate applied %d, want 1", n)
+	}
+
+	v, err := VerifyRelocateWrite(before, after, map[string]bool{pid: true})
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if !v.OK {
+		t.Fatalf("expected OK, got violations: %+v", v.Violations)
+	}
+	if v.RelocatedVerified != 1 || v.LocationChanged != 1 {
+		t.Errorf("RelocatedVerified=%d LocationChanged=%d, want 1/1", v.RelocatedVerified, v.LocationChanged)
+	}
+	if v.TracksBefore != v.TracksAfter {
+		t.Errorf("track count changed %d->%d on a relocate", v.TracksBefore, v.TracksAfter)
+	}
+	if v.UnchangedVerified != v.TracksBefore-1 {
+		t.Errorf("UnchangedVerified=%d, want %d", v.UnchangedVerified, v.TracksBefore-1)
+	}
+}
+
+func TestVerifyRelocateWrite_UnexpectedChange(t *testing.T) {
+	before := buildCleanPayload()
+	pid := anyPID(t, before)
+
+	// Relocate a track but DON'T declare it in the plan — the oracle must flag it.
+	after, n := UpdateMetadataLE(before, []ITLMetadataUpdate{{PersistentID: pid, Location: `W:\PROOF\x.mp3`}})
+	if n != 1 {
+		t.Fatalf("relocate applied %d, want 1", n)
+	}
+	v, err := VerifyRelocateWrite(before, after, map[string]bool{}) // empty plan
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if v.OK {
+		t.Fatal("expected a violation for an undeclared change")
+	}
+	found := false
+	for _, viol := range v.Violations {
+		if viol.PID == pid && viol.Kind == ViolationUnexpected {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unexpected-change on %s, got %+v", pid, v.Violations)
+	}
+}
+
+func TestVerifyRelocateWrite_NonLocationMutation(t *testing.T) {
+	before := buildCleanPayload()
+	pid := anyPID(t, before)
+
+	// Change the track NAME (a non-location field) but declare it as a relocate —
+	// the oracle must reject because a relocate may touch ONLY the location pair.
+	after, n := UpdateMetadataLE(before, []ITLMetadataUpdate{{PersistentID: pid, Name: "Tampered Title"}})
+	if n != 1 {
+		t.Fatalf("metadata update applied %d, want 1", n)
+	}
+	v, err := VerifyRelocateWrite(before, after, map[string]bool{pid: true})
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if v.OK {
+		t.Fatal("expected non-location-mutated violation")
+	}
+	found := false
+	for _, viol := range v.Violations {
+		if viol.PID == pid && viol.Kind == ViolationNonLocationMut {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected non-location-mutated on %s, got %+v", pid, v.Violations)
+	}
+}
+
+func TestVerifyRelocateWrite_TrackRemoved(t *testing.T) {
+	before := buildCleanPayload()
+	pid := anyPID(t, before)
+
+	after, removed := RemoveTracksByPIDLE(before, map[string]bool{pid: true})
+	if removed != 1 {
+		t.Fatalf("removed %d, want 1", removed)
+	}
+	v, err := VerifyRelocateWrite(before, after, map[string]bool{})
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if v.OK {
+		t.Fatal("expected track-removed violation (relocate removes nothing)")
+	}
+	found := false
+	for _, viol := range v.Violations {
+		if viol.PID == pid && viol.Kind == ViolationRemoved {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected track-removed on %s, got %+v", pid, v.Violations)
+	}
+}
+
+func TestVerifyRelocateWrite_Idempotent(t *testing.T) {
+	before := buildCleanPayload()
+	v, err := VerifyRelocateWrite(before, before, map[string]bool{})
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if !v.OK || v.UnchangedVerified != v.TracksBefore {
+		t.Errorf("identical payloads must verify clean: OK=%v unchanged=%d/%d %+v",
+			v.OK, v.UnchangedVerified, v.TracksBefore, v.Violations)
+	}
+}
+
+// TestVerifyRelocateWrite_RealLibrary runs the oracle on a real relocate of a copy
+// of the real .itl (ITL_PRESERVE_PROOF_PATH; skips in CI): a genuine 300-track
+// relocate must verify clean, and a single tampered byte in an untouched track must
+// be caught.
+func TestVerifyRelocateWrite_RealLibrary(t *testing.T) {
+	path := os.Getenv("ITL_PRESERVE_PROOF_PATH")
+	if path == "" {
+		t.Skip("set ITL_PRESERVE_PROOF_PATH to a COPY of a real .itl to run the real-library oracle test")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	before, err := DecryptAndInflateITL(raw)
+	if err != nil {
+		t.Fatalf("decrypt/inflate: %v", err)
+	}
+	lib, err := ParseITL(path)
+	if err != nil {
+		t.Fatalf("ParseITL: %v", err)
+	}
+
+	var updates []ITLMetadataUpdate
+	plan := map[string]bool{}
+	var victim string // an untouched PID, for the tamper check
+	for i := range lib.Tracks {
+		tr := &lib.Tracks[i]
+		p := strings.ToLower(pidToHex(tr.PersistentID))
+		if len(updates) < 300 {
+			if !strings.HasPrefix(tr.Location, `W:\`) {
+				continue
+			}
+			updates = append(updates, ITLMetadataUpdate{PersistentID: p, Location: `W:\PROOF\` + tr.Location[3:]})
+			plan[p] = true
+		} else if victim == "" && !plan[p] {
+			victim = p
+		}
+	}
+	after, n := UpdateMetadataLE(before, updates)
+	if n != len(updates) {
+		t.Fatalf("relocate applied %d, want %d", n, len(updates))
+	}
+
+	v, err := VerifyRelocateWrite(before, after, plan)
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite: %v", err)
+	}
+	if !v.OK {
+		t.Fatalf("real relocate should verify clean, got %d violations e.g. %+v", len(v.Violations), firstN(v.Violations, 3))
+	}
+	t.Logf("REAL-LIBRARY ORACLE: relocated_verified=%d location_changed=%d unchanged_verified=%d (tracks %d)",
+		v.RelocatedVerified, v.LocationChanged, v.UnchangedVerified, v.TracksBefore)
+
+	// Tamper an UNTOUCHED track (change its Name) and confirm the oracle catches it
+	// as an unexpected change — the auto-rollback trigger.
+	if victim == "" {
+		t.Skip("no untouched track available to tamper")
+	}
+	tamperedAfter, tn := UpdateMetadataLE(after, []ITLMetadataUpdate{{PersistentID: victim, Name: "TAMPERED"}})
+	if tn != 1 {
+		t.Fatalf("tamper update applied %d, want 1", tn)
+	}
+	vt, err := VerifyRelocateWrite(before, tamperedAfter, plan)
+	if err != nil {
+		t.Fatalf("VerifyRelocateWrite(tampered): %v", err)
+	}
+	if vt.OK {
+		t.Fatal("oracle failed to catch a tampered untouched track")
+	}
+	caught := false
+	for _, viol := range vt.Violations {
+		if viol.PID == victim && viol.Kind == ViolationUnexpected {
+			caught = true
+		}
+	}
+	if !caught {
+		t.Errorf("expected unexpected-change on tampered %s, got %+v", victim, firstN(vt.Violations, 3))
+	}
+	t.Logf("oracle correctly caught tamper on untouched track %s", victim)
+}
+
+func firstN(v []OracleViolation, n int) []OracleViolation {
+	if len(v) < n {
+		return v
+	}
+	return v[:n]
+}


### PR DESCRIPTION
P2 groundwork: VerifyRelocateWrite — the post-write acceptance oracle the decoupled write cycle uses to gate an atomic rename / trigger auto-rollback. Per-track RAW-BYTE comparison of the decompressed payload before vs after: every relocated PID changed ONLY its location pair (0x0D/0x0B), every other track byte-identical, no adds/removes. Raw-byte comparison catches unintended changes to atoms the parser ignores (resume bookmark, artwork, sort keys) that a parsed-field diff cannot see.

Proven on the real 97,999-track library (env-gated): 300-track relocate verifies clean (300 relocated, 97,699 untouched byte-identical) + a tampered untouched track is caught. Fully unit-tested. Nothing calls it yet; P2 wires it later. Independent of the F7 blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)