### PR TITLE
feat(itunes): P1 — delta-aware library-identity refresh (2-way-sync)

### DIFF
--- a/changelog.d/itunes-2way-p1-identity-refresh.md
+++ b/changelog.d/itunes-2way-p1-identity-refresh.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/itunes-2way-p1-identity-refresh.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6e1c9a83-4b70-4d52-8f19-3c7a5b2e0d64 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Added
+
+#### iTunes 2-way-sync P1 — delta-aware library-identity refresh (primitive, not yet wired)
+
+`internal/itunes/itl_identity_refresh.go` adds the steady-state counterpart to
+`AdoptLibraryIdentity`:
+
+- **`RefreshLibraryIdentity(itlPath, opts)`** re-derives the `.identity.json` sidecar (K13
+  PID sample + K14 track/playlist counts) from the current library while **pinning the
+  LibraryPID**. A changed PID (reseed/baseline swap) or a track-count swing beyond a drift
+  ceiling (`RefreshOptions.MaxDriftPct`, default 25%) errors out rather than silently
+  re-blessing — that is `AdoptLibraryIdentity`'s job. This lets K13/K14 track legitimate
+  iTunes churn each sync cycle without false-rejecting a valid relocate (findings §F1).
+- **`PartitionedTrackCount(itlPath)`** splits the live library into audiobook vs
+  non-audiobook tracks so the P2 sync cycle can arm K14 as
+  `plan.AudiobookCount + liveNonAudiobookCount` (AO owns the audiobook count; iTunes owns the
+  rest). Approximate per F5's `isAudiobookITL` caveat — a magnitude anchor, never a targeting
+  filter.
+
+Purely additive and fully unit-tested (pinned-PID, PID-changed → error, drift ceiling,
+missing sidecar, partition completeness). Nothing calls it yet; the P2 sync cycle wires it in
+a later PR. Independent of the F7 location-form blocker.

--- a/internal/itunes/itl_identity_refresh.go
+++ b/internal/itunes/itl_identity_refresh.go
@@ -1,0 +1,161 @@
+// file: internal/itunes/itl_identity_refresh.go
+// version: 1.0.0
+// guid: 5c8e2f13-7a94-4d60-9b18-2e6c1a7b0d53
+// last-edited: 2026-07-24
+//
+// Delta-aware library-identity refresh for the 2-way-sync steady state (P1 of the
+// 2-way-sync system design, §5.3). Between AO write cycles iTunes legitimately
+// mutates the library (adds music/podcasts, changes play state). K13 (identity)
+// samples up to 1024 track PIDs and K14 (magnitude) pins an expected track count;
+// if the sidecar is never refreshed, accumulated legitimate churn eventually erodes
+// the PID-sample overlap below IdentityMinOverlapPct (default 90) or moves the count
+// past MagnitudeTolerancePct, and a perfectly valid relocate is false-rejected (F1).
+//
+// AdoptLibraryIdentity (relocate.go) already re-blesses whatever library is on disk
+// — but it is all-or-nothing and blesses a CHANGED LibraryPID too, which is correct
+// for a deliberate reseed but wrong for the steady state (it would silently accept a
+// swapped library). RefreshLibraryIdentity is the steady-state counterpart: it PINS
+// the LibraryPID (a changed PID is a reseed → error, use Adopt), applies a drift
+// ceiling (a large count swing is a reseed/mass-deletion, not churn → error), and
+// only then re-derives the PID sample + counts.
+
+package itunes
+
+import (
+	"fmt"
+)
+
+// RefreshOptions tunes the steady-state identity refresh.
+type RefreshOptions struct {
+	// MaxDriftPct is the largest allowed change in track count (relative to the
+	// existing sidecar) that is still treated as legitimate churn. A larger swing
+	// errors out — it is a reseed or mass deletion that must be adopted
+	// deliberately, not absorbed silently. Default 25 when zero.
+	MaxDriftPct int
+}
+
+const defaultRefreshMaxDriftPct = 25
+
+// RefreshResult reports what a refresh changed, for logging/telemetry.
+type RefreshResult struct {
+	LibraryPID     string `json:"library_pid"`
+	PrevTrackCount int    `json:"prev_track_count"`
+	NewTrackCount  int    `json:"new_track_count"`
+	PrevSampleSize int    `json:"prev_sample_size"`
+	NewSampleSize  int    `json:"new_sample_size"`
+	DriftPct       int    `json:"drift_pct"`
+}
+
+// RefreshLibraryIdentity re-derives the .identity.json sidecar (PID sample + track/
+// playlist counts) for the library currently at itlPath, KEEPING the LibraryPID
+// pinned. It is the steady-state refresh the sync cycle runs each pass so K13/K14
+// track legitimate iTunes churn without false-rejecting a valid relocate.
+//
+// Fails (and writes nothing) when:
+//   - no sidecar exists yet (bootstrap must go through AdoptLibraryIdentity);
+//   - the on-disk LibraryPID differs from the sidecar's (a reseed/baseline swap —
+//     use AdoptLibraryIdentity to bless the new library deliberately);
+//   - the track count drifted more than opts.MaxDriftPct from the sidecar (a reseed
+//     or mass deletion masquerading as churn).
+//
+// On success the sidecar is rewritten with the fresh sample/counts and the pinned
+// LibraryPID, and the refreshed identity is returned.
+func RefreshLibraryIdentity(itlPath string, opts RefreshOptions) (*LibraryIdentity, *RefreshResult, error) {
+	maxDrift := opts.MaxDriftPct
+	if maxDrift <= 0 {
+		maxDrift = defaultRefreshMaxDriftPct
+	}
+
+	prev, err := LoadLibraryIdentity(itlPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("refresh: load sidecar: %w", err)
+	}
+	if prev == nil {
+		return nil, nil, fmt.Errorf("refresh: no identity sidecar at %s — bootstrap with AdoptLibraryIdentity first", IdentitySidecarPath(itlPath))
+	}
+
+	hdr, payload, err := decodeITLForContractFile(itlPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("refresh: decode %s: %w", itlPath, err)
+	}
+
+	fresh, err := ComputeLibraryIdentity(payload, hdr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("refresh: compute identity: %w", err)
+	}
+
+	// K13 anchor: the LibraryPID must be stable. A different PID is a different
+	// library (reseed / baseline swap) — never silently re-bless it here.
+	if prev.LibraryPID != "" && fresh.LibraryPID != prev.LibraryPID {
+		return nil, nil, fmt.Errorf("refresh: LibraryPID changed %s -> %s (reseed/baseline swap) — use AdoptLibraryIdentity to bless the new library deliberately",
+			prev.LibraryPID, fresh.LibraryPID)
+	}
+
+	// Drift ceiling: a large count swing is a reseed or mass deletion, not churn.
+	drift := driftPct(prev.TrackCount, fresh.TrackCount)
+	if drift > maxDrift {
+		return nil, nil, fmt.Errorf("refresh: track count drifted %d%% (%d -> %d) > MaxDriftPct %d%% — refusing (reseed or mass deletion; adopt deliberately if intended)",
+			drift, prev.TrackCount, fresh.TrackCount, maxDrift)
+	}
+
+	// Keep the pinned LibraryPID (fresh.LibraryPID equals it, but be explicit) and
+	// carry forward the last-written FileSHA256 anchor — this refresh does not write
+	// the .itl, so the recorded on-disk hash of our last write is unchanged.
+	fresh.LibraryPID = prev.LibraryPID
+	fresh.FileSHA256 = prev.FileSHA256
+
+	if err := SaveLibraryIdentity(itlPath, fresh); err != nil {
+		return nil, nil, fmt.Errorf("refresh: save sidecar: %w", err)
+	}
+
+	res := &RefreshResult{
+		LibraryPID:     fresh.LibraryPID,
+		PrevTrackCount: prev.TrackCount,
+		NewTrackCount:  fresh.TrackCount,
+		PrevSampleSize: len(prev.PIDSample),
+		NewSampleSize:  len(fresh.PIDSample),
+		DriftPct:       drift,
+	}
+	return fresh, res, nil
+}
+
+// driftPct returns the absolute percentage change from prev to cur. A move from
+// zero to non-zero is treated as 100% (any change off an empty baseline is total).
+func driftPct(prev, cur int) int {
+	if prev == cur {
+		return 0
+	}
+	if prev == 0 {
+		return 100
+	}
+	d := cur - prev
+	if d < 0 {
+		d = -d
+	}
+	return d * 100 / prev
+}
+
+// PartitionedTrackCount classifies the LIVE library at itlPath into audiobook vs
+// non-audiobook tracks (isAudiobookITL). The P2 sync cycle uses this to arm K14 as
+// ExpectedTrackCount = plan.AudiobookCount + liveNonAudiobookCount — AO owns the
+// audiobook count (DB-authoritative, moves only by our plan), iTunes owns the
+// non-audiobook count (refreshed from the live library each cycle).
+//
+// CAVEAT (F5): isAudiobookITL under-classifies audiobooks (misses "Audio Book"/
+// literary genres), so this partition is APPROXIMATE. It is only a K14 magnitude
+// anchor, never a targeting filter — a slightly-off split still bounds the expected
+// count adequately for the ±MagnitudeTolerancePct band.
+func PartitionedTrackCount(itlPath string) (audiobook, nonAudiobook int, err error) {
+	lib, err := ParseITL(itlPath)
+	if err != nil {
+		return 0, 0, fmt.Errorf("partitioned count: parse %s: %w", itlPath, err)
+	}
+	for i := range lib.Tracks {
+		if isAudiobookITL(&lib.Tracks[i]) {
+			audiobook++
+		} else {
+			nonAudiobook++
+		}
+	}
+	return audiobook, nonAudiobook, nil
+}

--- a/internal/itunes/itl_identity_refresh_test.go
+++ b/internal/itunes/itl_identity_refresh_test.go
@@ -6,9 +6,63 @@
 package itunes
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestRefreshLibraryIdentity_RealLibrary is an env-gated empirical smoke test
+// against a COPY of a real .itl (ITL_PRESERVE_PROOF_PATH, same fixture the byte-proof
+// uses). It adopts the library (bootstrap sidecar), refreshes it (must be a no-op:
+// same library → drift 0, PID pinned, sample re-derived identically), and partitions
+// the track count. Skips in CI. Copies the input to a temp dir so it never writes a
+// sidecar next to the caller's file.
+func TestRefreshLibraryIdentity_RealLibrary(t *testing.T) {
+	src := os.Getenv("ITL_PRESERVE_PROOF_PATH")
+	if src == "" {
+		t.Skip("set ITL_PRESERVE_PROOF_PATH to a COPY of a real .itl to run the real-library smoke test")
+	}
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	work := filepath.Join(t.TempDir(), "iTunes Library.itl")
+	if err := os.WriteFile(work, raw, 0o644); err != nil {
+		t.Fatalf("write work copy: %v", err)
+	}
+
+	adopted, err := AdoptLibraryIdentity(work)
+	if err != nil {
+		t.Fatalf("AdoptLibraryIdentity: %v", err)
+	}
+	t.Logf("adopted: LibraryPID=%s trackCount=%d playlistCount=%d sampleSize=%d",
+		adopted.LibraryPID, adopted.TrackCount, adopted.PlaylistCount, len(adopted.PIDSample))
+
+	fresh, res, err := RefreshLibraryIdentity(work, RefreshOptions{})
+	if err != nil {
+		t.Fatalf("RefreshLibraryIdentity on unchanged real library: %v", err)
+	}
+	if res.DriftPct != 0 {
+		t.Errorf("drift on unchanged library = %d%%, want 0", res.DriftPct)
+	}
+	if fresh.LibraryPID != adopted.LibraryPID {
+		t.Errorf("LibraryPID not pinned: %s -> %s", adopted.LibraryPID, fresh.LibraryPID)
+	}
+	if fresh.TrackCount != adopted.TrackCount || len(fresh.PIDSample) != len(adopted.PIDSample) {
+		t.Errorf("refresh changed counts on unchanged library: tracks %d->%d, sample %d->%d",
+			adopted.TrackCount, fresh.TrackCount, len(adopted.PIDSample), len(fresh.PIDSample))
+	}
+
+	ab, nonAB, err := PartitionedTrackCount(work)
+	if err != nil {
+		t.Fatalf("PartitionedTrackCount: %v", err)
+	}
+	if ab+nonAB != fresh.TrackCount {
+		t.Errorf("partition %d+%d != trackCount %d", ab, nonAB, fresh.TrackCount)
+	}
+	t.Logf("REAL-LIBRARY SMOKE: refresh no-op (drift 0, PID pinned), partition audiobook=%d non-audiobook=%d (total %d)",
+		ab, nonAB, ab+nonAB)
+}
 
 // writeRefreshFixtureITL writes a small encrypted .itl with the given LibraryPID and
 // returns its path + its true identity (for assertions).

--- a/internal/itunes/itl_identity_refresh_test.go
+++ b/internal/itunes/itl_identity_refresh_test.go
@@ -1,0 +1,128 @@
+// file: internal/itunes/itl_identity_refresh_test.go
+// version: 1.0.0
+// guid: 9d3f1a82-4c60-4b95-8e17-2f6c5b0e1d74
+// last-edited: 2026-07-24
+
+package itunes
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// writeRefreshFixtureITL writes a small encrypted .itl with the given LibraryPID and
+// returns its path + its true identity (for assertions).
+func writeRefreshFixtureITL(t *testing.T, pid [8]byte) (string, *LibraryIdentity) {
+	t.Helper()
+	payload := buildCleanPayload()
+	hdr := headerWithLibraryPID(payload, pid)
+	path := filepath.Join(t.TempDir(), "iTunes Library.itl")
+	if err := writeITLFileRaw(path, hdr, payload, false); err != nil {
+		t.Fatalf("writeITLFileRaw: %v", err)
+	}
+	id, err := ComputeLibraryIdentity(payload, hdr)
+	if err != nil {
+		t.Fatalf("ComputeLibraryIdentity: %v", err)
+	}
+	return path, id
+}
+
+func TestRefreshLibraryIdentity_Happy(t *testing.T) {
+	path, trueID := writeRefreshFixtureITL(t, fxLibraryPID)
+	// Bootstrap a matching sidecar (as AdoptLibraryIdentity would), but with a
+	// deliberately stale sample so we can prove the refresh re-derives it.
+	stale := *trueID
+	stale.PIDSample = []string{"deadbeefdeadbeef"} // wrong sample
+	stale.FileSHA256 = "priorwritehash"
+	if err := SaveLibraryIdentity(path, &stale); err != nil {
+		t.Fatalf("SaveLibraryIdentity: %v", err)
+	}
+
+	fresh, res, err := RefreshLibraryIdentity(path, RefreshOptions{})
+	if err != nil {
+		t.Fatalf("RefreshLibraryIdentity: %v", err)
+	}
+	if fresh.LibraryPID != fxLibraryPIDHex {
+		t.Errorf("LibraryPID = %q, want pinned %q", fresh.LibraryPID, fxLibraryPIDHex)
+	}
+	if fresh.TrackCount != trueID.TrackCount {
+		t.Errorf("TrackCount = %d, want %d", fresh.TrackCount, trueID.TrackCount)
+	}
+	if len(fresh.PIDSample) != len(trueID.PIDSample) || (len(fresh.PIDSample) > 0 && fresh.PIDSample[0] == "deadbeefdeadbeef") {
+		t.Errorf("PIDSample not re-derived: got %v", fresh.PIDSample)
+	}
+	if fresh.FileSHA256 != "priorwritehash" {
+		t.Errorf("FileSHA256 anchor should carry forward, got %q", fresh.FileSHA256)
+	}
+	// Persisted to disk.
+	reloaded, err := LoadLibraryIdentity(path)
+	if err != nil || reloaded == nil {
+		t.Fatalf("reload sidecar: %v", err)
+	}
+	if reloaded.TrackCount != trueID.TrackCount {
+		t.Errorf("persisted TrackCount = %d, want %d", reloaded.TrackCount, trueID.TrackCount)
+	}
+	if res.DriftPct != 0 {
+		t.Errorf("DriftPct = %d, want 0 (same library)", res.DriftPct)
+	}
+}
+
+func TestRefreshLibraryIdentity_NoSidecar(t *testing.T) {
+	path, _ := writeRefreshFixtureITL(t, fxLibraryPID)
+	if _, _, err := RefreshLibraryIdentity(path, RefreshOptions{}); err == nil {
+		t.Fatal("expected error when no sidecar exists (must Adopt first)")
+	}
+}
+
+func TestRefreshLibraryIdentity_PIDChanged(t *testing.T) {
+	path, trueID := writeRefreshFixtureITL(t, fxLibraryPID)
+	// Sidecar claims a DIFFERENT LibraryPID than the file on disk → reseed.
+	swapped := *trueID
+	swapped.LibraryPID = "0000000000000000"
+	if err := SaveLibraryIdentity(path, &swapped); err != nil {
+		t.Fatalf("SaveLibraryIdentity: %v", err)
+	}
+	if _, _, err := RefreshLibraryIdentity(path, RefreshOptions{}); err == nil {
+		t.Fatal("expected error when LibraryPID changed (reseed → must Adopt)")
+	}
+}
+
+func TestRefreshLibraryIdentity_DriftOverCeiling(t *testing.T) {
+	path, trueID := writeRefreshFixtureITL(t, fxLibraryPID)
+	// Sidecar claims a huge track count; the real library is tiny → drift ceiling.
+	inflated := *trueID
+	inflated.TrackCount = trueID.TrackCount + 10_000
+	if err := SaveLibraryIdentity(path, &inflated); err != nil {
+		t.Fatalf("SaveLibraryIdentity: %v", err)
+	}
+	if _, _, err := RefreshLibraryIdentity(path, RefreshOptions{MaxDriftPct: 25}); err == nil {
+		t.Fatal("expected drift-ceiling error (mass deletion / reseed)")
+	}
+}
+
+func TestPartitionedTrackCount(t *testing.T) {
+	path, trueID := writeRefreshFixtureITL(t, fxLibraryPID)
+	ab, nonAB, err := PartitionedTrackCount(path)
+	if err != nil {
+		t.Fatalf("PartitionedTrackCount: %v", err)
+	}
+	if ab+nonAB != trueID.TrackCount {
+		t.Errorf("partition %d+%d != total %d", ab, nonAB, trueID.TrackCount)
+	}
+}
+
+func TestDriftPct(t *testing.T) {
+	cases := []struct{ prev, cur, want int }{
+		{100, 100, 0},
+		{100, 125, 25},
+		{100, 75, 25},
+		{0, 5, 100},
+		{0, 0, 0},
+		{200, 300, 50},
+	}
+	for _, c := range cases {
+		if got := driftPct(c.prev, c.cur); got != c.want {
+			t.Errorf("driftPct(%d,%d) = %d, want %d", c.prev, c.cur, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
P1 of the 2-way-sync design (§5.3): steady-state delta-aware counterpart to AdoptLibraryIdentity. RefreshLibraryIdentity re-derives the .identity.json sidecar (K13 PID sample + K14 counts) while PINNING the LibraryPID; a changed PID or track-count swing beyond MaxDriftPct (default 25%) errors instead of silently re-blessing. PartitionedTrackCount splits the live library audiobook/non-audiobook for K14. Purely additive, fully unit-tested, nothing calls it yet; independent of the F7 location-form blocker. Findings §F1/§F5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)