### PR TITLE
fix(itunes): scope location-form staging-marker check to write target (F7) [REVIEW-GATED]

### DIFF
--- a/changelog.d/itunes-location-form-scope-writeback.md
+++ b/changelog.d/itunes-location-form-scope-writeback.md
@@ -1,0 +1,30 @@
+<!-- file: changelog.d/itunes-location-form-scope-writeback.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8c3f1a94-6b70-4d52-9e18-2f7c5a0e1d63 -->
+<!-- last-edited: 2026-07-24 -->
+
+### Changed
+
+#### iTunes location-form guard: scope the `.itunes-writeback/` staging-marker check to the write target (F7)
+
+The `location-form` safety guard rejects any track location containing
+`.itunes-writeback/` as a staging-dir leak (the "damaged-4" class). But when iTunes is
+pointed AT the AO writeback library — the locked hard-cutover design — that library's own
+media legitimately lives under its `.itunes-writeback/iTunes Media/` root, so every track
+carries the substring correctly. The unconditional check therefore rejected the **entire
+live AO library (82,981 track-locations)**, making the P2 relocate op unable to write it
+(findings §F7).
+
+`ContractConfig.AllowedWritebackRoot` now scopes the check: a marker whose location sits
+**under** the configured root (the AO library's own media root, e.g.
+`audiobook-organizer/.itunes-writeback/`) is allowed; a marker anywhere else is still a
+leak and rejected. Matched case-insensitively with path separators normalized, so it
+applies to both the 0x0D WinPath and 0x0B URL forms. **Empty (default) = strict — ALL
+`.itunes-writeback/` rejected, fully backward-compatible and fail-closed.** Only the sync
+cycle writing the AO library sets it (from the 4-state `LibrarySet` config); it is never
+set when writing the Original library.
+
+Verified on the real library: strict flags 82,981 staging violations; AO-scoped flags 0.
+Unit-tested via the pure `stagingMarkerIsLeak` decision (strict / scoped-allow /
+leak-under-different-root / misconfigured-root → fail-closed). This adds the guard
+capability; the P2 sync cycle wires it in a later PR. Review-gated (production safety guard).

--- a/internal/itunes/itl_location_form_scope_test.go
+++ b/internal/itunes/itl_location_form_scope_test.go
@@ -1,0 +1,87 @@
+// file: internal/itunes/itl_location_form_scope_test.go
+// version: 1.1.0
+// guid: 1f8c3a72-5b94-4d60-8e17-2c6b5a0e9d43
+// last-edited: 2026-07-24
+
+package itunes
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestStagingMarkerIsLeak covers the F7 decision: the ".itunes-writeback/" staging
+// marker is a leak by default (strict), NOT a leak when the location sits under the
+// configured AllowedWritebackRoot (the AO library's own media root), and STILL a leak
+// when it does not match the configured root (fail-closed). The location value is
+// tested directly (0x0B URL and 0x0D WinPath forms) because the canonicalizing write
+// path scrubs ".itunes-writeback/" and so cannot construct a synthetic marker — the
+// real markers exist only in libraries written before the pathnorm fix (see the
+// env-gated real-library test below).
+func TestStagingMarkerIsLeak(t *testing.T) {
+	const aoURL = `file://localhost/W:/audiobook-organizer/.itunes-writeback/iTunes%20Media/Audiobooks/x.m4b`
+	const aoWin = `W:\audiobook-organizer\.itunes-writeback\iTunes Media\Audiobooks\x.m4b`
+	const leakURL = `file://localhost/W:/itunes/.itunes-writeback/iTunes%20Media/leak.m4b`
+
+	aoRoot := normalizeStagingPath(`audiobook-organizer/.itunes-writeback/`)
+	winRoot := normalizeStagingPath(`audiobook-organizer\.itunes-writeback\`) // backslash form normalizes the same
+
+	cases := []struct {
+		name string
+		loc  string
+		root string
+		want bool // want leak?
+	}{
+		{"strict rejects AO url", aoURL, "", true},
+		{"strict rejects AO winpath", aoWin, "", true},
+		{"scoped allows AO url", aoURL, aoRoot, false},
+		{"scoped allows AO winpath (backslash form)", aoWin, aoRoot, false},
+		{"scoped allows AO url via backslash root", aoURL, winRoot, false},
+		{"scoped still rejects a leak under a different root", leakURL, aoRoot, true},
+		{"wrong root rejects the AO path (misconfig → fail-closed)", aoURL, normalizeStagingPath(`some/other/lib/.itunes-writeback/`), true},
+	}
+	for _, c := range cases {
+		if got := stagingMarkerIsLeak(c.loc, c.root); got != c.want {
+			t.Errorf("%s: stagingMarkerIsLeak=%v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestLocationFormScope_RealLibrary confirms on a copy of the real .itl (env-gated)
+// that the strict guard flags the whole library's .itunes-writeback/ paths (the F7
+// repro) while the AO-scoped guard accepts them.
+func TestLocationFormScope_RealLibrary(t *testing.T) {
+	path := os.Getenv("ITL_PRESERVE_PROOF_PATH")
+	if path == "" {
+		t.Skip("set ITL_PRESERVE_PROOF_PATH to a COPY of a real .itl")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	payload, err := DecryptAndInflateITL(raw)
+	if err != nil {
+		t.Fatalf("decrypt/inflate: %v", err)
+	}
+
+	countStaging := func(res GuardResult) int {
+		n := 0
+		for _, v := range res.Violations {
+			if strings.Contains(v.Message, ".itunes-writeback/") {
+				n++
+			}
+		}
+		return n
+	}
+
+	strict := countStaging(guardLocationForm(nil, payload, nil, ContractConfig{}))
+	if strict == 0 {
+		t.Fatal("expected the strict guard to flag the real library's .itunes-writeback/ paths (F7 repro)")
+	}
+	scoped := countStaging(guardLocationForm(nil, payload, nil, ContractConfig{AllowedWritebackRoot: `audiobook-organizer/.itunes-writeback/`}))
+	t.Logf("F7 FIX on real library: strict staging violations=%d, AO-scoped staging violations=%d", strict, scoped)
+	if scoped != 0 {
+		t.Errorf("AO-scoped guard must accept the library's own .itunes-writeback/ media root, still got %d violations", scoped)
+	}
+}

--- a/internal/itunes/itl_safety_contract.go
+++ b/internal/itunes/itl_safety_contract.go
@@ -133,6 +133,22 @@ type ContractConfig struct {
 	// MagnitudeTolerancePct is the allowed deviation for expected-magnitude.
 	// Default 10.
 	MagnitudeTolerancePct int
+
+	// AllowedWritebackRoot scopes the location-form staging-marker guard to the
+	// WRITE TARGET (F7). The guard rejects any location containing
+	// ".itunes-writeback/" as a staging-dir leak (the damaged-4 class). But when
+	// iTunes is pointed AT the AO writeback library, that library's own media
+	// legitimately lives under its ".itunes-writeback/iTunes Media/" root, so every
+	// track carries the substring correctly. Set this to the AO library's own root
+	// fragment (e.g. "audiobook-organizer/.itunes-writeback/"): a location whose
+	// ".itunes-writeback/" occurrence is UNDER this root is allowed; a marker not
+	// matching it is still a leak and rejected. Matched case-insensitively with
+	// path separators normalized (so it applies to both the 0x0D WinPath and 0x0B
+	// URL forms). Empty (default) = strict: ALL ".itunes-writeback/" rejected —
+	// fully backward-compatible and fail-closed. Only the sync cycle writing the AO
+	// library sets it (from the 4-state LibrarySet config); never set it when
+	// writing the Original library.
+	AllowedWritebackRoot string
 }
 
 // DefaultContractConfig returns the SPEC-mandated defaults.
@@ -540,9 +556,14 @@ func mhohNonStandardLen(hohmType uint32) bool {
 //     markers (damaged-4 leaked staging-dir paths).
 //
 // Catches: K4 (URL written into 0x0D) and the staging-path leak.
-func guardLocationForm(before, after []byte, _ *hdfmHeader, _ ContractConfig) GuardResult {
+func guardLocationForm(before, after []byte, _ *hdfmHeader, cfg ContractConfig) GuardResult {
 	const name = "location-form"
 	var viol []Violation
+
+	// F7: when writing the AO library (which legitimately lives under its own
+	// ".itunes-writeback/" media root), the staging-marker check is scoped to that
+	// root — a marker UNDER it is not a leak. Empty root = strict (reject all).
+	allowedRoot := normalizeStagingPath(cfg.AllowedWritebackRoot)
 
 	// Pair-consistency (0x0B decodes to the same path as 0x0D) is a NO-NEW
 	// check: the golden corpus proves iTunes itself leaves stale pairs behind
@@ -559,7 +580,8 @@ func guardLocationForm(before, after []byte, _ *hdfmHeader, _ ContractConfig) Gu
 			val     string
 			field   string
 		}{{has0D, loc0D, "0x0D"}, {has0B, loc0B, "0x0B"}} {
-			if pair.present && strings.Contains(pair.val, ".itunes-writeback/") {
+			if pair.present && strings.Contains(pair.val, ".itunes-writeback/") &&
+				stagingMarkerIsLeak(pair.val, allowedRoot) {
 				viol = append(viol, Violation{Offset: trackOffset, Chunk: "mhoh", Message: fmt.Sprintf("%s contains staging marker '.itunes-writeback/': %q", pair.field, truncStr(pair.val))})
 			}
 		}
@@ -607,6 +629,30 @@ func guardLocationForm(before, after []byte, _ *hdfmHeader, _ ContractConfig) Gu
 	})
 
 	return GuardResult{Guard: name, Violations: viol}
+}
+
+// normalizeStagingPath lowercases a location value and normalizes path separators
+// (backslash → forward slash) so the F7 AllowedWritebackRoot check matches against
+// both the 0x0D WinPath form (backslashes) and the 0x0B URL form (forward slashes).
+// Returns "" for an empty input so the strict-by-default behavior is preserved.
+func normalizeStagingPath(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToLower(strings.ReplaceAll(s, "\\", "/"))
+}
+
+// stagingMarkerIsLeak decides whether a location that contains ".itunes-writeback/"
+// is a staging-dir LEAK (true → reject) versus the AO library's own legitimate media
+// root (false → allow). allowedRootNormalized is cfg.AllowedWritebackRoot already run
+// through normalizeStagingPath. Empty allowed root = strict: every marker is a leak
+// (backward-compatible, fail-closed). Otherwise the marker is legitimate only when
+// the location sits UNDER the configured root.
+func stagingMarkerIsLeak(locationVal, allowedRootNormalized string) bool {
+	if allowedRootNormalized == "" {
+		return true
+	}
+	return !strings.Contains(normalizeStagingPath(locationVal), allowedRootNormalized)
 }
 
 // localURLsEquivalent reports whether two file://localhost/ URLs decode to the


### PR DESCRIPTION
## ⚠️ Review-gated — production safety guard change (do not admin-merge without review)

This implements **option 1** for the F7 blocker (you chose "scope the guard").

## Problem (F7)

The `location-form` safety guard rejects any track location containing `.itunes-writeback/` as a staging-dir leak (the "damaged-4" corruption class). But the AO writeback library physically lives at `W:\audiobook-organizer\.itunes-writeback\`, so iTunes' media folder is `…\.itunes-writeback\iTunes Media\` and **every** track legitimately carries the substring. The unconditional check therefore rejected the **entire live AO library — 82,981 track-locations** — making the P2 relocate op unable to write it.

## Fix

`ContractConfig.AllowedWritebackRoot` scopes the check to the **write target**:
- a marker whose location sits **under** the configured root (the AO library's own media root, e.g. `audiobook-organizer/.itunes-writeback/`) is **allowed**;
- a marker **anywhere else** is still a leak → **rejected**;
- **empty (default) = strict** — all `.itunes-writeback/` rejected, fully backward-compatible and fail-closed.

Matched case-insensitively with separators normalized, so it applies to both the 0x0D WinPath and 0x0B URL forms. Only the sync cycle writing the AO library sets it (from the 4-state `LibrarySet` config); it is **never** set when writing the Original library.

## Verification

- **Real library** (env-gated): strict flags **82,981** staging violations; AO-scoped flags **0**. So the fix unblocks the live library while keeping the guard fully strict for anything not under the AO root.
- **Unit test** of the pure `stagingMarkerIsLeak` decision: strict-rejects, scoped-allows (URL + WinPath forms), leak-under-a-different-root still rejected, misconfigured root → fail-closed.
- `go build ./...`, full `internal/itunes` short suite — clean (no regression in existing guard tests).

## Scope

This adds the guard **capability** and is **inert until a caller sets `AllowedWritebackRoot`** (nothing sets it yet → current behavior unchanged everywhere). The **P2 sync cycle** wires it from the `LibrarySet` config in a later PR. Depends conceptually on the 4-state config (already merged) and pairs with P1 (#2044) + the relocate oracle (#2043).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt