### PR TITLE
feat(itunes): --sync-apply commits the P2 relocate cycle (first live write done)

### DIFF
--- a/changelog.d/itunes-2way-sync-apply-mode.md
+++ b/changelog.d/itunes-2way-sync-apply-mode.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/itunes-2way-sync-apply-mode.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d71c94b2-0fce-427a-b3f6-7930c50da729 -->
+<!-- last-edited: 2026-07-25 -->
+
+### Added
+
+#### iTunes 2-way-sync: `pid-census --sync-apply` (the P2 relocate COMMIT path)
+
+`cmd/pid-census` gains `--sync-apply`, the committing counterpart to `--sync-dry-run`. It
+runs `RunRelocateSyncCycle` with `Apply=true`, so the relocate-only sync cycle enforces the
+quiescence gate, arms the `SafeWriteITL` contract (identity + magnitude + F7 scope +
+pre-rename SHA re-verify), takes a `.bak`, runs the pre-commit oracle, writes only on a clean
+verdict, then re-verifies post-commit and **auto-rolls-back from the `.bak`** on any
+violation. The `--itl` path is the LIVE write target; `--db` is a copy of the Pebble DB.
+
+`SyncCycleResult` now surfaces `PlaylistsPreserved` (from the oracle's playlist-list
+byte-identity check, #2049) so the apply reports `playlists_preserved` explicitly; on Apply it
+reflects the authoritative post-commit verdict.
+
+First live use: a single drifted track in the production AO library was relocated
+(`applied=true oracle_ok=true relocated_verified=1 playlists_preserved=true`, 358 playlists
+preserved, 97,999 tracks unchanged); the post-apply dry-run confirmed the drift resolved
+(`planned=0 already_correct=77,211`).

--- a/cmd/pid-census/main.go
+++ b/cmd/pid-census/main.go
@@ -1,7 +1,7 @@
 // file: cmd/pid-census/main.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8f2b0d61-4a37-4c95-9e12-7d3a6b1c0e58
-// last-edited: 2026-07-24
+// last-edited: 2026-07-25
 //
 // READ-ONLY book_file iTunes-PID integrity census. Point it at a COPY of the
 // production Pebble DB (never the live dir — Pebble opens read-write and wants the
@@ -33,6 +33,7 @@ func main() {
 	mergeProv := flag.Bool("merge-provenance", false, "run the cleanup provenance census (P3 exit-gate); requires --itl")
 	crossType := flag.Bool("cross-type", false, "run the cross-type PID-collision census (relocate disjointness backstop); requires --itl")
 	syncDryRun := flag.Bool("sync-dry-run", false, "P2 relocate sync cycle DRY-RUN (plan + in-memory verify, NO write); requires --itl")
+	syncApply := flag.Bool("sync-apply", false, "P2 relocate sync cycle APPLY — COMMITS to the --itl file (contract + quiescence gate + .bak backup + oracle + auto-rollback); requires --itl. The --itl path is the LIVE write target.")
 	syncRoot := flag.String("sync-writeback-root", "audiobook-organizer/.itunes-writeback/", "F7 AllowedWritebackRoot for the AO library's own media root")
 	mapFrom := flag.String("map-from", "W:", "path-mapping source prefix (Windows drive)")
 	mapTo := flag.String("map-to", "/mnt/bigdata/books", "path-mapping target prefix (local mount)")
@@ -82,6 +83,61 @@ func main() {
 			}
 		}
 		fmt.Printf("    (DRY-RUN: nothing written. Review the plan + sample new locations before Apply=true.)\n")
+		if *full {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(r)
+		}
+		return
+	}
+
+	// P2 relocate sync cycle — APPLY (COMMITS to --itl). Same composition as the
+	// dry-run, but Apply=true: the cycle enforces the quiescence gate, arms the
+	// SafeWriteITL contract, takes a .bak, runs the pre-commit oracle, writes only on
+	// a clean verdict, then re-verifies post-commit and auto-rolls-back from the .bak
+	// on any violation. The --itl path is the LIVE write target.
+	if *syncApply {
+		if *itlPath == "" {
+			fmt.Fprintln(os.Stderr, "error: --sync-apply requires --itl (the LIVE AO writeback .itl to commit to)")
+			os.Exit(2)
+		}
+		mappings := []itunes.PathMapping{{From: *mapFrom, To: *mapTo}}
+		r, serr := itunes.RunRelocateSyncCycle(store, itunes.SyncCycleConfig{
+			ITLPath:              *itlPath,
+			AllowedWritebackRoot: *syncRoot,
+			Mappings:             mappings,
+			Apply:                true, // COMMIT
+		})
+		fmt.Printf("=== P2 RELOCATE SYNC CYCLE — APPLY (COMMIT) ===\n")
+		if r != nil {
+			fmt.Printf("planned=%d already_correct=%d unmatched=%d unmappable=%d\n",
+				r.Planned, r.AlreadyCorrect, r.Unmatched, r.Unmappable)
+			fmt.Printf(">>> APPLIED=%v ORACLE_OK=%v relocated_verified=%d playlists_preserved=%v\n",
+				r.Applied, r.OracleOK, r.RelocatedVerified, r.PlaylistsPreserved)
+			fmt.Printf("    library_in_use=%v rolled_back=%v backup=%s violations=%d\n",
+				r.LibraryInUse, r.RolledBack, r.BackupPath, len(r.OracleViolations))
+			if r.LibraryInUseReason != "" {
+				fmt.Printf("    library_in_use_reason: %s\n", r.LibraryInUseReason)
+			}
+			for i, v := range r.OracleViolations {
+				if i >= 5 {
+					fmt.Printf("    ... +%d more\n", len(r.OracleViolations)-5)
+					break
+				}
+				fmt.Printf("    VIOLATION pid=%s kind=%s %s\n", v.PID, v.Kind, v.Detail)
+			}
+		}
+		if serr != nil {
+			// Not necessarily data loss: a quiescence refusal or a clean auto-rollback
+			// also returns an error. The printed result above says which.
+			fmt.Fprintf(os.Stderr, "sync apply: %v\n", serr)
+			if *full && r != nil {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(r)
+			}
+			os.Exit(1)
+		}
 		if *full {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")

--- a/docs/executive-summaries/2026-07-25-itunes-2way-sync-first-live-write-executive-summary.md
+++ b/docs/executive-summaries/2026-07-25-itunes-2way-sync-first-live-write-executive-summary.md
@@ -1,0 +1,54 @@
+<!-- file: docs/executive-summaries/2026-07-25-itunes-2way-sync-first-live-write-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a2486931-3a5e-46e1-a19c-bebcad1f0566 -->
+<!-- last-edited: 2026-07-25 -->
+
+# Executive Summary: The First Real Write to Your Live iTunes Library
+
+**Related spec:** `docs/specs/2026-07-23-itunes-2way-sync-system-design.md`.
+**Builds on:** `docs/executive-summaries/2026-07-24-itunes-2way-sync-p0-and-primitives-executive-summary.md`
+(the safety proofs) — this is the milestone where we finally used them.
+
+## In plain language
+
+Up to now, everything the organizer did with your iTunes library was a rehearsal —
+run against a copy, never the real thing. Today it made its **first actual change to
+your live iTunes library**: it corrected one book whose file location iTunes had
+recorded incorrectly.
+
+We did it the careful way, start to finish:
+
+- **We waited until iTunes was closed.** The tool refuses to write while iTunes has
+  the library open, and it double-checks the library file hasn't changed in the
+  moments right before it writes — so it can never step on iTunes mid-save.
+
+- **We worked from a frozen copy and kept a backup.** Before writing, it saved a
+  complete backup of your library file (kept on disk), so the previous version can be
+  restored instantly if anything ever looked wrong.
+
+- **We checked the result the same instant we made it.** Right after the write, the
+  tool re-read the file and confirmed, byte for byte, that **only** that one book's
+  file location changed — nothing else. Your playlists (all 358 of them, including
+  smart-playlist rules), your bookmarks, play counts, ratings, and every other track
+  were left exactly as they were. If any of that had shifted, it would have
+  automatically undone the change.
+
+- **We confirmed it stuck.** A follow-up check shows the library is now fully in sync
+  — the one out-of-place book is fixed, and all 97,999 tracks are accounted for.
+
+## Why it matters
+
+This is the point where the two-way sync stops being a design and becomes something
+that safely touches your real library. The single-book fix is small on purpose: it's
+the smallest possible real change, used to prove the whole safety chain — wait for
+iTunes to be idle, back up, write, verify, auto-undo on any surprise — works end to
+end on the live library, not just on a copy. Everything larger builds on this exact
+path.
+
+## What's next
+
+The next step widens what gets synced: today the organizer only corrects **file
+locations**; next it will also push the audiobook details it owns (title, author,
+series, genre) from its database into iTunes — while treating your listening state
+(where you left off, play counts, ratings) as strictly off-limits. That work starts
+design-first, dry-run-first, with the same "prove it, then do it" discipline.

--- a/internal/itunes/relocate_sync_cycle.go
+++ b/internal/itunes/relocate_sync_cycle.go
@@ -1,5 +1,5 @@
 // file: internal/itunes/relocate_sync_cycle.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 6c2f9a81-7b54-4d60-9e18-3c7b5a0e2d73
 // last-edited: 2026-07-25
 //
@@ -89,6 +89,13 @@ type SyncCycleResult struct {
 	RelocatedVerified int               `json:"relocated_verified"` // tracks the oracle confirmed changed location-only
 	OracleViolations  []OracleViolation `json:"oracle_violations,omitempty"`
 
+	// PlaylistsPreserved reflects the oracle's playlist-preservation check (#2049):
+	// the entire playlist-list section (msdh type 2 — static + smart playlists,
+	// names, membership, SmartCriteria rules) is byte-identical before vs after.
+	// On Apply this is the POST-COMMIT verdict (what actually landed); in dry-run it
+	// is the in-memory verdict. A relocate must never touch playlists.
+	PlaylistsPreserved bool `json:"playlists_preserved"`
+
 	Applied    bool   `json:"applied"` // true only if committed
 	DryRun     bool   `json:"dry_run"` // true if no write was attempted
 	BackupPath string `json:"backup_path,omitempty"`
@@ -172,6 +179,7 @@ func RunRelocateSyncCycle(store RebuildStore, cfg SyncCycleConfig) (*SyncCycleRe
 	res.OracleOK = verdict.OK
 	res.RelocatedVerified = verdict.RelocatedVerified
 	res.OracleViolations = verdict.Violations
+	res.PlaylistsPreserved = verdict.PlaylistsPreserved
 
 	// Quiescence gate: is iTunes actively using the library right now? A read-only
 	// reader (Apple Devices, Music.app browsing) never trips this — reads don't
@@ -224,18 +232,23 @@ func RunRelocateSyncCycle(store RebuildStore, cfg SyncCycleConfig) (*SyncCycleRe
 	rawAfterCommit, rerr := os.ReadFile(cfg.ITLPath)
 	if rerr == nil {
 		if committed, derr := DecryptAndInflateITL(rawAfterCommit); derr == nil {
-			if v2, verr := VerifyRelocateWrite(before, committed, relocatedPIDs); verr == nil && !v2.OK {
-				res.OracleViolations = v2.Violations
-				res.OracleOK = false
-				if res.BackupPath != "" {
-					if rbErr := restoreITLBackup(res.BackupPath, cfg.ITLPath); rbErr == nil {
-						res.RolledBack = true
-						res.Applied = false
-					} else {
-						return res, fmt.Errorf("sync cycle: post-commit oracle FAILED and rollback FAILED (%v) — .itl may be bad; restore %s manually", rbErr, res.BackupPath)
+			if v2, verr := VerifyRelocateWrite(before, committed, relocatedPIDs); verr == nil {
+				// Post-commit verdict is authoritative for what actually landed.
+				res.PlaylistsPreserved = v2.PlaylistsPreserved
+				res.RelocatedVerified = v2.RelocatedVerified
+				if !v2.OK {
+					res.OracleViolations = v2.Violations
+					res.OracleOK = false
+					if res.BackupPath != "" {
+						if rbErr := restoreITLBackup(res.BackupPath, cfg.ITLPath); rbErr == nil {
+							res.RolledBack = true
+							res.Applied = false
+						} else {
+							return res, fmt.Errorf("sync cycle: post-commit oracle FAILED and rollback FAILED (%v) — .itl may be bad; restore %s manually", rbErr, res.BackupPath)
+						}
 					}
+					return res, fmt.Errorf("sync cycle: post-commit oracle failed; rolled back from %s", res.BackupPath)
 				}
-				return res, fmt.Errorf("sync cycle: post-commit oracle failed; rolled back from %s", res.BackupPath)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds `pid-census --sync-apply`, the committing counterpart to `--sync-dry-run`, completing the P2 relocate sync-cycle MVP. It runs `RunRelocateSyncCycle` with `Apply=true`: quiescence gate → `SafeWriteITL` contract (identity + magnitude + F7 scope + pre-rename SHA re-verify) → `.bak` → pre-commit oracle → write only on a clean verdict → post-commit re-verify → **auto-rollback from `.bak`** on any violation. `--itl` is the LIVE write target; `--db` is a copy of the Pebble DB.

Also surfaces `SyncCycleResult.PlaylistsPreserved` (from the oracle's playlist-list byte-identity check, #2049) so the apply reports `playlists_preserved` explicitly; on Apply it reflects the authoritative post-commit verdict.

## First live write (production)

Ran against the live AO writeback `.itl` with a ZFS-snapshot copy of the prod Pebble DB:

```
planned=1 already_correct=77210 unmatched=0 unmappable=0
>>> APPLIED=true ORACLE_OK=true relocated_verified=1 playlists_preserved=true
    library_in_use=false rolled_back=false violations=0
    backup=…/iTunes Library.itl.bak-2026-07-25T13-40-56…Z-00
```

SafeWriteITL logged 97,999 tracks + 358 playlists preserved, atomic rename. Post-apply dry-run confirmed the drift resolved: `planned=0 already_correct=77,211`, integrity census `pidsOnMultiplePrimariesDiffPath=0`, 97,999 tracks intact. Work snapshot + pebble copy cleaned up; fallback snapshot `books@itunes-ao-fallback-2026-07-23` intact; `.bak` retained on disk.

## Safety

- Only the AO `.itunes-writeback/` copy is written — never the hands-off `books/itunes/**` tree.
- Byte-oracle proves location-only change + playlist/bookmark/playcount/rating/date preservation; auto-rollback on any surprise.
- `.bak` + ZFS snapshots are the escape hatches.

## Test plan

- [x] `go build ./cmd/pid-census/`, `gofmt`, `go vet` clean
- [x] `go test ./internal/itunes/ -run 'RelocateSyncCycle|RelocateWrite|Oracle|Playlist|Relocate'` passes
- [x] Live apply + post-apply verification (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)