### PR TITLE
fix(regroup): write correct disc/track numbers on multidisc approve

### DIFF
--- a/changelog.d/regroup-multidisc-disc-track-numbers.md
+++ b/changelog.d/regroup-multidisc-disc-track-numbers.md
@@ -1,0 +1,31 @@
+<!-- file: changelog.d/regroup-multidisc-disc-track-numbers.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c7f0a3d1-9b26-4e58-8a04-2f6b1d7e3c90 -->
+<!-- last-edited: 2026-07-25 -->
+
+### Fixed
+
+#### Review-queue multidisc approve now writes correct disc/track numbers
+
+Approving a "Multi-disc" regroup hold previously merged the folder's single-file books
+into one book but wrote **no** `DiscNumber`/`TrackNumber` at all — so a merged audiobook
+carried no play-order metadata, and the "Multi-disc" label was misleading for what were
+often just sequentially-numbered chapters of one recording (e.g. `When We Were Sisters_1.mp3`
+… `_6.mp3`).
+
+The regroup classifier (`internal/itunes/service/fs_regroup_shape.go`,
+`assignDiscTrack`) now derives per-file numbers from each member's real structure:
+
+- Files in genuine `Disc N`/`CD N` subfolders (a real boxed set, e.g. Star Wars) get their
+  true `DiscNumber` per file.
+- Flat/chapter files on one disc get `DiscNumber = 0` (no disc concept — never fake disc
+  numbers spread across chapters) and a contiguous `TrackNumber` in play order.
+
+Numbers are threaded through the review payload (`regroupPayload.DiscNumbers`/`TrackNumbers`)
+and written on approve (`internal/plugins/maintenance/regroup_apply.go`,
+`applyDiscTrackNumbers`). The write is a targeted field-only update via `UpdateBookFile`
+(fingerprint-preserving — never a full-record write-back) and is guarded group-level: if any
+file already carries disc/track metadata, the whole set is left untouched ("unless the disc is
+already set, then leave it"). By construction every `(disc, track)` pair in a group is unique,
+so the file-order sort can never collide. Backward compatible: holds written before this
+change (no arrays) merge exactly as before, just without numbering.

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1e7d4a92-3c85-4b60-9f21-6a8c0d5e2b47
-// last-edited: 2026-07-14
+// last-edited: 2026-07-25
 
 // Package service — deterministic (regex-only) shape classifier for the
 // shattered-book REGROUP review producer (PR-B1).
@@ -93,6 +93,22 @@ type ShatterBook struct {
 	IsPrimary  bool   // non-primary version members are ignored
 	Title      string // scanner-derived title (album tag); may be empty
 	Author     string // display author when known; never used for the FOLDER key
+
+	// DiscNumber / TrackNumber are OUTPUT fields, zero on the input view and
+	// populated by classifyGroup (assignDiscTrack) for the members of a confident
+	// multidisc collapse. They carry the per-file play-order the apply path
+	// (ApplyMultidisc) writes onto the merged book's BookFile rows. Semantics:
+	//   - a member living in a real "Disc N"/"CD N" subfolder gets DiscNumber = N
+	//     (the true physical disc, e.g. a Star Wars boxed set) and a track rank
+	//     WITHIN that disc;
+	//   - a member that is just a sequentially-numbered chapter/flat file on ONE
+	//     disc (e.g. "When We Were Sisters_1.mp3".."_6.mp3") gets DiscNumber = 0
+	//     (no disc concept — do NOT spread fake disc numbers across chapters) and
+	//     TrackNumber = its sequence position.
+	// Both are collision-free within the group by construction (a running per-disc
+	// counter), so the (disc, track, path) sort in GetBookFiles orders cleanly.
+	DiscNumber  int
+	TrackNumber int
 }
 
 // RegroupGroup is one book folder the classifier flagged for a review hold.
@@ -511,6 +527,7 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 		dominantCount*2 >= n
 
 	sortMembers(members)
+	assignDiscTrack(members)
 	build := func(kind string, confident bool, action string, distinctWorks int) RegroupGroup {
 		out := make([]ShatterBook, 0, n)
 		for _, m := range members {
@@ -643,6 +660,45 @@ func sortMembers(members []memberInfo) {
 		}
 		return members[i].book.BookID < members[j].book.BookID
 	})
+}
+
+// assignDiscTrack stamps each member's book with the (DiscNumber, TrackNumber) the
+// apply path will write onto the merged BookFile rows. It MUST run after sortMembers
+// so the sequence follows play order. The rule mirrors the two real shapes the owner
+// called out:
+//
+//   - A member in a genuine "Disc N"/"CD N" subfolder (structure=="disc") is a real
+//     physical disc: DiscNumber = its disc-folder number, TrackNumber = its rank
+//     within that disc. (A Star Wars boxed set with actual disc folders.)
+//   - Any other member (flat / chapter / edition) is a sequential file on ONE disc:
+//     DiscNumber = 0 (there is NO disc concept — never spread fake disc numbers 1..N
+//     across chapters of a single recording), TrackNumber = its sequence position.
+//
+// TrackNumber is a running per-disc counter (disc 0 is its own bucket), so every
+// (disc, track) pair in the group is unique — the (disc, track, path) ordering in
+// GetBookFiles can never collide. We deliberately renumber to a contiguous 1..N per
+// disc rather than trusting the parsed filename ordinal: the apply path only writes
+// these when the file currently has NO disc/track metadata at all, so a clean
+// contiguous sequence is the right default for an otherwise-unnumbered file.
+//
+// Assignment is by each member's OWN structure, not the group's classified Kind. This
+// is intentional and correct: a file physically living in "Disc 2/" belongs to disc 2
+// regardless of its neighbors, and a bare chapter file belongs to no disc. In the rare
+// mixed folder (a stray loose file alongside real "Disc N" subfolders), the loose file
+// gets disc 0 and the disc files get their true numbers — a sensible hybrid, never the
+// failure the owner flagged (fake disc numbers 1..N spread across chapters of one
+// recording), which only happens if you key off group order instead of real structure.
+func assignDiscTrack(members []memberInfo) {
+	trackByDisc := map[int]int{}
+	for i := range members {
+		disc := 0
+		if members[i].structure == "disc" {
+			disc = members[i].num
+		}
+		trackByDisc[disc]++
+		members[i].book.DiscNumber = disc
+		members[i].book.TrackNumber = trackByDisc[disc]
+	}
 }
 
 // deriveSurvivorTitle turns a book-folder name into a clean survivor title: strip a

--- a/internal/itunes/service/fs_regroup_shape_test.go
+++ b/internal/itunes/service/fs_regroup_shape_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 4d2a7f81-6c93-4e50-b8a1-0f5e2c9d3b76
-// last-edited: 2026-07-14
+// last-edited: 2026-07-25
 
 package itunesservice
 
@@ -110,6 +110,76 @@ func TestClassify_DiscSubfolders_Multidisc(t *testing.T) {
 	g := findGroup(t, groups, "The Name of the Wind")
 	if g.Kind != KindMultidisc || !g.Confident {
 		t.Errorf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+}
+
+// memberByID returns the classified member with the given BookID (disc/track are set
+// by assignDiscTrack for confident collapses).
+func memberByID(t *testing.T, g RegroupGroup, id string) ShatterBook {
+	t.Helper()
+	for _, m := range g.Members {
+		if m.BookID == id {
+			return m
+		}
+	}
+	t.Fatalf("no member %q in group %s", id, g.FolderRef)
+	return ShatterBook{}
+}
+
+// Flat sequential chapters of ONE recording must get TrackNumber 1..N and DiscNumber 0
+// — the "When We Were Sisters_1..N" case. NO fake disc numbers across chapters.
+func TestClassify_FlatSameDisc_DiscTrackNumbers(t *testing.T) {
+	base := shatterRoot + "/Ann Napolitano/When We Were Sisters"
+	var books []ShatterBook
+	for i := 1; i <= 6; i++ {
+		books = append(books, sb(fmt.Sprintf("wws%02d", i),
+			fmt.Sprintf("%s/When We Were Sisters_%d.mp3", base, i)))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "When We Were Sisters")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	for i := 1; i <= 6; i++ {
+		m := memberByID(t, g, fmt.Sprintf("wws%02d", i))
+		if m.DiscNumber != 0 {
+			t.Errorf("file _%d: DiscNumber=%d, want 0 (same-disc chapters get no disc)", i, m.DiscNumber)
+		}
+		if m.TrackNumber != i {
+			t.Errorf("file _%d: TrackNumber=%d, want %d", i, m.TrackNumber, i)
+		}
+	}
+}
+
+// Real "Disc N"/"CD N" folders must get their true DiscNumber per file, track 1 each
+// (one file per disc), with no (disc,track) collision.
+func TestClassify_RealDiscSet_DiscTrackNumbers(t *testing.T) {
+	base := shatterRoot + "/Patrick Rothfuss/The Wise Mans Fear"
+	books := []ShatterBook{
+		sb("wd1", base+"/Disc 1/track.mp3"),
+		sb("wd2", base+"/Disc 2/track.mp3"),
+		sb("wd3", base+"/CD 3/track.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Wise Mans Fear")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	want := map[string]int{"wd1": 1, "wd2": 2, "wd3": 3}
+	seen := map[[2]int]bool{}
+	for id, wantDisc := range want {
+		m := memberByID(t, g, id)
+		if m.DiscNumber != wantDisc {
+			t.Errorf("%s: DiscNumber=%d, want %d", id, m.DiscNumber, wantDisc)
+		}
+		if m.TrackNumber != 1 {
+			t.Errorf("%s: TrackNumber=%d, want 1 (one file per disc)", id, m.TrackNumber)
+		}
+		key := [2]int{m.DiscNumber, m.TrackNumber}
+		if seen[key] {
+			t.Errorf("(disc,track) collision at %v", key)
+		}
+		seen[key] = true
 	}
 }
 

--- a/internal/plugins/maintenance/regroup_apply.go
+++ b/internal/plugins/maintenance/regroup_apply.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_apply.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: e2a7c9d4-1f68-4b03-9c5e-7a0d3f814b62
-// last-edited: 2026-07-17
+// last-edited: 2026-07-25
 
 // Package maintenance — the APPLY path for the regroup review queue (PR-B2).
 //
@@ -26,6 +26,12 @@
 //     with nil the survivor row is never rewritten and its AcoustIDFingerprint /
 //     Author / Series survive. Absorbed books' FILES move by file ID (fingerprints
 //     ride along); absorbed ROWS are hard-deleted intentionally.
+//   - AFTER the combine, applyDiscTrackNumbers stamps the merged files' play order.
+//     It re-reads the FULL BookFile rows (fingerprint retained) and writes ONLY
+//     DiscNumber/TrackNumber via UpdateBookFile (which also restores the fingerprint
+//     on an empty incoming value) — never a full/partial BookFile write-back. It is
+//     guarded group-level ("any file already numbered → leave the whole set alone")
+//     and best-effort (a numbering error warns, never fails the merge).
 //   - Version-group uses re-fetch-and-patch: GetBookByID returns the FULL row, we
 //     mutate ONLY VersionGroupID, then UpdateBook. Never construct a fresh/partial
 //     Book and write it back — UpdateBook is a full-column replace.
@@ -98,8 +104,77 @@ func ApplyMultidisc(store database.Store, combiner bookCombiner) func(context.Co
 		slog.Info("regroup multidisc apply: collapsed folder",
 			"item", item.ID, "folder", p.Folder, "survivor", res.PrimaryID,
 			"files_moved", res.FilesMoved, "books_deleted", res.BooksDeleted)
+
+		// Stamp the merged book's files with the per-file disc/track order the classifier
+		// derived. Best-effort: the combine (the actual merge) already committed, so a
+		// numbering failure logs a warning but does NOT fail the review item — the disc/
+		// track can be re-derived by re-running the dry-run, and leaving the item "failed"
+		// would wrongly imply the books weren't merged.
+		if n, derr := applyDiscTrackNumbers(store, res.PrimaryID, p); derr != nil {
+			slog.Warn("regroup multidisc apply: disc/track numbering incomplete",
+				"item", item.ID, "folder", p.Folder, "survivor", res.PrimaryID, "updated", n, "err", derr)
+		} else if n > 0 {
+			slog.Info("regroup multidisc apply: set disc/track numbers",
+				"item", item.ID, "survivor", res.PrimaryID, "files_numbered", n)
+		}
 		return nil
 	}
+}
+
+// applyDiscTrackNumbers writes the payload's per-file (disc, track) order onto the
+// merged survivor's BookFile rows. It returns the number of files updated.
+//
+// Safety rules (this repo's dominant incident class is BookFile write-back wipes):
+//   - Reads the FULL rows via GetBookFiles (fingerprint retained in storage) and
+//     mutates ONLY DiscNumber/TrackNumber, then writes via UpdateBookFile — which
+//     itself restores AcoustIDFingerprint on an empty incoming value. Never a full
+//     fresh/partial BookFile write-back.
+//   - GROUP-LEVEL "already set → leave it" guard: if ANY survivor file already carries
+//     disc/track metadata, the whole group is left untouched. That both honors the
+//     owner's "unless the disk is already set, then leave it" and prevents a collision
+//     between a pre-tagged file's track and a freshly-sequenced one.
+//   - Backward compatible: a hold written before DiscNumbers/TrackNumbers existed has
+//     empty arrays → no-op.
+func applyDiscTrackNumbers(store database.Store, survivorID string, p regroupPayload) (int, error) {
+	if len(p.DiscNumbers) == 0 || len(p.TrackNumbers) == 0 {
+		return 0, nil // old payload or a non-confident kind — nothing to assign
+	}
+	// Map each member FilePath → its (disc, track). Files/DiscNumbers/TrackNumbers are
+	// parallel by index; guard against a short/ragged array rather than trusting length.
+	type dt struct{ disc, track int }
+	want := make(map[string]dt, len(p.Files))
+	for i, path := range p.Files {
+		if i < len(p.DiscNumbers) && i < len(p.TrackNumbers) {
+			want[path] = dt{p.DiscNumbers[i], p.TrackNumbers[i]}
+		}
+	}
+	files, err := store.GetBookFiles(survivorID)
+	if err != nil {
+		return 0, fmt.Errorf("read survivor files: %w", err)
+	}
+	// Group-level guard: respect any pre-existing disc/track tagging on the whole set.
+	for i := range files {
+		if files[i].DiscNumber != 0 || files[i].TrackNumber != 0 {
+			slog.Info("regroup multidisc apply: survivor already carries disc/track metadata — leaving as-is",
+				"survivor", survivorID)
+			return 0, nil
+		}
+	}
+	updated := 0
+	for i := range files {
+		f := files[i] // full row incl. AcoustIDFingerprint
+		d, ok := want[f.FilePath]
+		if !ok || (d.disc == 0 && d.track == 0) {
+			continue
+		}
+		f.DiscNumber = d.disc
+		f.TrackNumber = d.track
+		if err := store.UpdateBookFile(f.ID, &f); err != nil {
+			return updated, fmt.Errorf("set disc/track on %s: %w", f.ID, err)
+		}
+		updated++
+	}
+	return updated, nil
 }
 
 // ApplyVersionGroup builds the apply function for regroup.version-group holds: it

--- a/internal/plugins/maintenance/regroup_apply_test.go
+++ b/internal/plugins/maintenance/regroup_apply_test.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_apply_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: a9d3f1c7-6b40-4e28-8f95-2c1e7b0a4d63
-// last-edited: 2026-07-17
+// last-edited: 2026-07-25
 
 package maintenance
 
@@ -551,4 +551,184 @@ func TestApplyMultidisc_BadPayload(t *testing.T) {
 		ID: ulid.Make().String(), Kind: "regroup.multidisc", Payload: "{not json",
 	})
 	require.Error(t, err)
+}
+
+// multidiscItemWithNumbers builds a multidisc hold whose payload carries the parallel
+// per-file disc/track arrays the classifier now emits. files/discs/tracks are parallel
+// by index; memberIDs is parallel too (one book per file).
+func multidiscItemWithNumbers(t *testing.T, folder string, memberIDs, files []string, discs, tracks []int) database.ReviewItem {
+	t.Helper()
+	payload, err := json.Marshal(regroupPayload{
+		Folder:         folder,
+		Files:          files,
+		MemberBookIDs:  memberIDs,
+		DiscNumbers:    discs,
+		TrackNumbers:   tracks,
+		ProposedAction: "collapse into one multi-file book",
+		SurvivorTitle:  "Survivor",
+		Confidence:     "high",
+	})
+	require.NoError(t, err)
+	return database.ReviewItem{
+		ID:        ulid.Make().String(),
+		Kind:      "regroup.multidisc",
+		FolderRef: folder,
+		Payload:   string(payload),
+	}
+}
+
+// seedNumberedBooks creates one single-file, fingerprinted book per path and returns the
+// book IDs (parallel to paths) plus a path→fingerprint map for post-merge assertions.
+func seedNumberedBooks(t *testing.T, store database.Store, paths []string) ([]string, map[string][]byte) {
+	t.Helper()
+	ids := make([]string, len(paths))
+	fpByPath := map[string][]byte{}
+	for i, path := range paths {
+		id := ulid.Make().String()
+		ids[i] = id
+		_, err := store.CreateBook(&database.Book{ID: id, Title: "Chapter", Format: "mp3", FilePath: path})
+		require.NoError(t, err)
+		fp := []byte("fp-" + id)
+		fpByPath[path] = fp
+		require.NoError(t, store.CreateBookFile(&database.BookFile{
+			ID: ulid.Make().String(), BookID: id, FilePath: path, Format: "mp3",
+			AcoustIDFingerprint: fp,
+		}))
+	}
+	return ids, fpByPath
+}
+
+// TestApplyMultidisc_FlatSameDisc_SetsTracksNotDiscs is the owner's core case: flat,
+// sequentially-numbered chapter files of ONE recording (e.g. "…_1.mp3".."_6.mp3") must
+// get TrackNumber 1..N and DiscNumber 0 — NEVER fake disc numbers spread across the
+// chapters. Fingerprints must survive the merge.
+func TestApplyMultidisc_FlatSameDisc_SetsTracksNotDiscs(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	paths := []string{
+		"/lib/When We Were Sisters/When We Were Sisters_1.mp3",
+		"/lib/When We Were Sisters/When We Were Sisters_2.mp3",
+		"/lib/When We Were Sisters/When We Were Sisters_3.mp3",
+	}
+	ids, fpByPath := seedNumberedBooks(t, store, paths)
+	discs := []int{0, 0, 0}   // no disc concept — same recording
+	tracks := []int{1, 2, 3}  // sequential chapters
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	item := multidiscItemWithNumbers(t, "/lib/When We Were Sisters", ids, paths, discs, tracks)
+	require.NoError(t, apply(context.Background(), item))
+
+	files, err := store.GetBookFiles(minID(ids...))
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	wantTrack := map[string]int{paths[0]: 1, paths[1]: 2, paths[2]: 3}
+	for _, f := range files {
+		assert.Equal(t, 0, f.DiscNumber, "flat same-disc chapters must NOT get a disc number (%s)", f.FilePath)
+		assert.Equal(t, wantTrack[f.FilePath], f.TrackNumber, "track number for %s", f.FilePath)
+		assert.Equal(t, fpByPath[f.FilePath], f.AcoustIDFingerprint, "fingerprint must survive (%s)", f.FilePath)
+	}
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestApplyMultidisc_RealDiscSet_SetsDiscNumbers is the genuine boxed-set case: files
+// living in real "Disc N" folders get their true DiscNumber per file (disc 1 / disc 2 /
+// disc 3), so a (disc, track) sort orders across discs correctly with no collision.
+func TestApplyMultidisc_RealDiscSet_SetsDiscNumbers(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	paths := []string{
+		"/lib/Star Wars/Disc 1/track.mp3",
+		"/lib/Star Wars/Disc 2/track.mp3",
+		"/lib/Star Wars/Disc 3/track.mp3",
+	}
+	ids, fpByPath := seedNumberedBooks(t, store, paths)
+	discs := []int{1, 2, 3}  // real physical discs
+	tracks := []int{1, 1, 1} // one track per disc
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	item := multidiscItemWithNumbers(t, "/lib/Star Wars", ids, paths, discs, tracks)
+	require.NoError(t, apply(context.Background(), item))
+
+	files, err := store.GetBookFiles(minID(ids...))
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	wantDisc := map[string]int{paths[0]: 1, paths[1]: 2, paths[2]: 3}
+	for _, f := range files {
+		assert.Equal(t, wantDisc[f.FilePath], f.DiscNumber, "disc number for %s", f.FilePath)
+		assert.Equal(t, 1, f.TrackNumber, "one-track-per-disc → track 1 (%s)", f.FilePath)
+		assert.Equal(t, fpByPath[f.FilePath], f.AcoustIDFingerprint, "fingerprint must survive (%s)", f.FilePath)
+	}
+	// The (disc, track, path) sort GetBookFiles applies must be strictly increasing —
+	// no two files collide on (disc, track).
+	seen := map[[2]int]bool{}
+	for _, f := range files {
+		key := [2]int{f.DiscNumber, f.TrackNumber}
+		assert.False(t, seen[key], "(disc,track) collision at %v", key)
+		seen[key] = true
+	}
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestApplyMultidisc_PreExistingNumbers_LeftAlone verifies the "unless the disc is
+// already set, then leave it" rule: if ANY survivor file already carries disc/track
+// metadata, the whole group is left untouched (both to honor existing tagging and to
+// avoid colliding a pre-set track with a freshly-sequenced one).
+func TestApplyMultidisc_PreExistingNumbers_LeftAlone(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	paths := []string{"/lib/x/a.mp3", "/lib/x/b.mp3", "/lib/x/c.mp3"}
+	ids, _ := seedNumberedBooks(t, store, paths)
+
+	// The survivor's own file already has a real disc/track from an earlier tag import.
+	survivor := minID(ids...)
+	sfiles, err := store.GetBookFiles(survivor)
+	require.NoError(t, err)
+	require.Len(t, sfiles, 1)
+	preset := sfiles[0]
+	preset.DiscNumber = 2
+	preset.TrackNumber = 7
+	require.NoError(t, store.UpdateBookFile(preset.ID, &preset))
+
+	discs := []int{0, 0, 0}
+	tracks := []int{1, 2, 3}
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	item := multidiscItemWithNumbers(t, "/lib/x", ids, paths, discs, tracks)
+	require.NoError(t, apply(context.Background(), item))
+
+	files, err := store.GetBookFiles(survivor)
+	require.NoError(t, err)
+	require.Len(t, files, 3)
+	// The pre-set file keeps its (2,7); the guard means the OTHER files were NOT
+	// renumbered either (whole group left alone).
+	for _, f := range files {
+		if f.ID == preset.ID {
+			assert.Equal(t, 2, f.DiscNumber)
+			assert.Equal(t, 7, f.TrackNumber)
+		} else {
+			assert.Equal(t, 0, f.DiscNumber, "group with pre-existing metadata must be left untouched")
+			assert.Equal(t, 0, f.TrackNumber, "group with pre-existing metadata must be left untouched")
+		}
+	}
+	dbtest.AssertStoreInvariants(t, store)
+}
+
+// TestApplyMultidisc_LegacyPayload_NoNumbers verifies a hold written before the
+// disc/track arrays existed (nil DiscNumbers/TrackNumbers) still merges cleanly and
+// simply skips numbering — backward compatibility.
+func TestApplyMultidisc_LegacyPayload_NoNumbers(t *testing.T) {
+	store := newApplyTestStore(t)
+	paths := []string{"/lib/legacy/a.mp3", "/lib/legacy/b.mp3"}
+	ids, _ := seedNumberedBooks(t, store, paths)
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	// multidiscItem (no numbers) is the pre-change payload shape.
+	require.NoError(t, apply(context.Background(), multidiscItem(t, "/lib/legacy", ids)))
+
+	files, err := store.GetBookFiles(minID(ids...))
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, 0, f.DiscNumber)
+		assert.Equal(t, 0, f.TrackNumber)
+	}
 }

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_shattered_ai.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8b3e6d21-4f97-4c05-a1d8-2e7b9c0f5a63
-// last-edited: 2026-07-14
+// last-edited: 2026-07-25
 
 // Package maintenance — op maintenance.regroup-shattered-ai (PR-B1).
 //
@@ -66,6 +66,16 @@ type regroupPayload struct {
 	MemberBookIDs  []string `json:"memberBookIDs"`
 	SurvivorTitle  string   `json:"survivorTitle"`
 	Confidence     string   `json:"confidence"` // "high" (confident) | "review"
+
+	// DiscNumbers / TrackNumbers are PARALLEL to Files (same index = same member) and
+	// carry the play-order the apply path (ApplyMultidisc) writes onto the merged
+	// book's BookFile rows. They are set only for confident multidisc collapses; other
+	// kinds leave them nil. omitempty + the apply path's length guard keep holds
+	// written before this field existed working unchanged (they just skip the
+	// disc/track write). A DiscNumber of 0 means "sequential chapters on one disc — no
+	// disc concept", distinct from a real "Disc N" set (see assignDiscTrack).
+	DiscNumbers  []int `json:"discNumbers,omitempty"`
+	TrackNumbers []int `json:"trackNumbers,omitempty"`
 }
 
 func (p *Plugin) regroupShatteredAIDef() sdk.OperationDef {
@@ -321,13 +331,23 @@ func regroupSummary(g itunesservice.RegroupGroup) string {
 func buildRegroupPayload(g itunesservice.RegroupGroup) (string, error) {
 	files := make([]string, 0, len(g.Members))
 	ids := make([]string, 0, len(g.Members))
+	discs := make([]int, 0, len(g.Members))
+	tracks := make([]int, 0, len(g.Members))
 	for _, m := range g.Members {
 		files = append(files, m.FilePath)
 		ids = append(ids, m.BookID)
+		discs = append(discs, m.DiscNumber)
+		tracks = append(tracks, m.TrackNumber)
 	}
 	confidence := "review"
 	if g.Confident {
 		confidence = "high"
+	}
+	// Only confident collapses (the two multidisc-producing branches) carry disc/track;
+	// for any other kind the classifier left every member's numbers at 0, so drop the
+	// arrays (they'd be all-zero noise the apply path would skip anyway).
+	if !g.Confident {
+		discs, tracks = nil, nil
 	}
 	data, err := json.Marshal(regroupPayload{
 		Folder:         g.FolderRef,
@@ -336,6 +356,8 @@ func buildRegroupPayload(g itunesservice.RegroupGroup) (string, error) {
 		MemberBookIDs:  ids,
 		SurvivorTitle:  g.SurvivorTitle,
 		Confidence:     confidence,
+		DiscNumbers:    discs,
+		TrackNumbers:   tracks,
 	})
 	if err != nil {
 		return "", err

--- a/internal/plugins/maintenance/regroup_shattered_ai_test.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai_test.go
@@ -1,18 +1,71 @@
 // file: internal/plugins/maintenance/regroup_shattered_ai_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a9f6c04-8e21-4b57-9d0a-6f2e7c1b5a48
-// last-edited: 2026-07-13
+// last-edited: 2026-07-25
 
 package maintenance
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 )
+
+// TestBuildRegroupPayload_DiscTrackRoundTrip closes the classifier→payload→apply seam:
+// a real classified group serialized by buildRegroupPayload and decoded back by
+// decodeRegroupPayload must preserve the per-file disc/track arrays, index-aligned with
+// Files/MemberBookIDs. This guards the parallel-array copy the apply path relies on.
+func TestBuildRegroupPayload_DiscTrackRoundTrip(t *testing.T) {
+	// A flat, sequentially-numbered same-disc set (the "When We Were Sisters" shape).
+	base := "/mnt/bigdata/books/audiobook-organizer/Ann Napolitano/When We Were Sisters"
+	var books []itunesservice.ShatterBook
+	for i := 1; i <= 5; i++ {
+		books = append(books, itunesservice.ShatterBook{
+			BookID:    fmt.Sprintf("b%02d", i),
+			FilePath:  fmt.Sprintf("%s/When We Were Sisters_%d.mp3", base, i),
+			FileCount: 1,
+			IsPrimary: true,
+		})
+	}
+	groups, _ := itunesservice.ClassifyShatteredFolders(books)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 group, got %d", len(groups))
+	}
+	g := groups[0]
+	if g.Kind != itunesservice.KindMultidisc || !g.Confident {
+		t.Fatalf("want confident multidisc, got kind=%q confident=%v", g.Kind, g.Confident)
+	}
+
+	raw, err := buildRegroupPayload(g)
+	if err != nil {
+		t.Fatalf("buildRegroupPayload: %v", err)
+	}
+	p, err := decodeRegroupPayload(database.ReviewItem{Payload: raw})
+	if err != nil {
+		t.Fatalf("decodeRegroupPayload: %v", err)
+	}
+
+	if len(p.DiscNumbers) != len(p.Files) || len(p.TrackNumbers) != len(p.Files) {
+		t.Fatalf("arrays not parallel: files=%d discs=%d tracks=%d",
+			len(p.Files), len(p.DiscNumbers), len(p.TrackNumbers))
+	}
+	// Every member is a same-disc chapter: disc 0, contiguous track numbers.
+	for i := range p.Files {
+		if p.DiscNumbers[i] != 0 {
+			t.Errorf("file %d (%s): disc=%d, want 0", i, p.Files[i], p.DiscNumbers[i])
+		}
+	}
+	// The classifier ordered members by track, so tracks are 1..N in payload order.
+	for i, tr := range p.TrackNumbers {
+		if tr != i+1 {
+			t.Errorf("track order: index %d has track %d, want %d", i, tr, i+1)
+		}
+	}
+}
 
 // seedShatterBook creates a single-file book at a chapter-shatter path so the dry-run
 // op's scan groups it into a review hold.

--- a/todo.d/2026-07-25-review-queue-disc-metadata.md
+++ b/todo.d/2026-07-25-review-queue-disc-metadata.md
@@ -1,0 +1,21 @@
+- [ ] **REVIEW-QUEUE-CARDS** Bring the dedup tab's rich per-file compare view to
+      the review-queue cards. Today "Multi-disc"/"Ambiguous folder" holds render
+      only bare file-path strings (`ReviewQueue.tsx` `PayloadDetails`) — not enough
+      to make an informed approve/reject call. Generalize dedup's
+      `FileInfoCompare`/`BookFilesColumn` to a provider-agnostic shape, extract the
+      shared `formatBytes`/`formatDuration`/quality-chip helpers out of
+      `UnifiedDedupTab.tsx`, and render per-file rows (duration/format/bitrate/size/
+      disc+track) enriched client-side via `getBook()` over `member_ids`. Groups can
+      have >2 files, so use per-file rows, not a strict pairwise A/B layout. Also
+      surface the proposed disc/track the classifier now emits (so a same-disc
+      "Multi-disc" set visibly shows disc 0 + tracks 1..N, replacing the misleading
+      "Multi-disc" label for that case).
+- [ ] **REVIEW-QUEUE-PAYLOAD-KEY** Fix the `memberBookIDs` (payload, camelCase) vs
+      `member_ids`/`member_count` (frontend `ReviewQueue.tsx`, snake_case) key
+      mismatch — `memberCount()` silently falls back to `files.length` today. Do this
+      as part of REVIEW-QUEUE-CARDS.
+- [ ] **REGROUP-PARTCHAPTER-PARSER** The Mistborn-style "Ambiguous folder" case
+      (`01 P0-C0.mp3`, `07 P1-C6.mp3` — Part/Chapter naming, non-contiguous numbers)
+      has no parser and stays classified as ambiguous (unaffected by the disc/track
+      fix). Consider a Part→disc / Chapter→track parser as a fast-follow so these
+      collapse with correct numbering too.


### PR DESCRIPTION
## What

Approving a **"Multi-disc"** regroup review hold used to merge the folder's single-file books into one book but write **no** `DiscNumber`/`TrackNumber` at all. Two problems fell out of that:

- Merged audiobooks carried **no play-order metadata** — nothing to write into iTunes.
- The **"Multi-disc" label was misleading** for what were often just sequentially-numbered chapters of a *single* recording (e.g. `When We Were Sisters_1.mp3` … `_6.mp3`), not a real multi-disc set.

## Fix

`assignDiscTrack` (`fs_regroup_shape.go`) derives per-file numbers from **each member's real folder structure**:

- Files in genuine `Disc N`/`CD N` subfolders (a real boxed set — e.g. Star Wars) → their **true `DiscNumber`** per file.
- Flat/chapter files on one disc → `DiscNumber = 0` (**no fake disc numbers** spread across chapters) and a contiguous `TrackNumber` in play order.

Numbers are threaded through `regroupPayload.DiscNumbers`/`TrackNumbers` and written on approve by `applyDiscTrackNumbers` (`regroup_apply.go`).

## Data safety

This repo's dominant incident class is BookFile write-back wipes, so:

- The write is a **targeted field-only** `UpdateBookFile` (fingerprint-preserving — reads the full row, mutates only disc/track, never a full/partial record write-back).
- **Group-level guard**: if *any* file already carries disc/track metadata, the whole set is left untouched ("unless the disc is already set, then leave it").
- Every `(disc, track)` pair in a group is **unique by construction**, so the `(disc, track, path)` file-order sort can never collide.
- **Backward compatible**: holds written before this change (no arrays) merge exactly as before.

`CombineBooks` is untouched — the disc/track write is a separate best-effort step after the merge commits (a numbering error warns, never fails the merge).

## Tests

- Classifier disc/track assignment: flat same-disc (disc 0, tracks 1..N) vs real disc set (true disc numbers, no collision).
- `buildRegroupPayload` → `decodeRegroupPayload` round-trip preserves the parallel arrays.
- Apply-path regressions: **fingerprint survives the merge**, pre-existing metadata left alone, legacy payload no-op.

All affected + dependent packages (itunes/service, maintenance, merge, database) green in `-short` and `-race`. (Local `make ci` staticcheck is red on two pre-existing smells unrelated to this diff — the documented red herring; Minimal CI doesn't run staticcheck.)

## Follow-ups (tracked in `todo.d/`)

- Rich per-file compare UI for review-queue cards (port dedup's view) + fix the `memberBookIDs`/`member_ids` payload-key mismatch.
- Part/Chapter (`P0-C0`) parser for the Mistborn-style ambiguous case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt