### PR TITLE
feat(review-queue): rich per-file metadata cards + payload-key fix

### DIFF
--- a/changelog.d/review-queue-rich-cards.md
+++ b/changelog.d/review-queue-rich-cards.md
@@ -1,0 +1,28 @@
+<!-- file: changelog.d/review-queue-rich-cards.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3e8b1d92-5a47-4c60-9f21-6d0a4c7e2b83 -->
+<!-- last-edited: 2026-07-26 -->
+
+### Changed
+
+#### Review-queue cards now show rich per-file metadata (and read the real payload)
+
+Review-queue cards ("Multi-disc", "Ambiguous folder", …) previously rendered only a
+bare list of file-path strings — not enough to make an informed approve/reject call.
+Expanding a card now shows a per-member row for each file with cover art, title,
+author, series/position, format, duration, size, bitrate, codec, and the **proposed
+disc/track** the classifier will write on approve (so a same-disc chapter set visibly
+shows disc 0 + tracks 1..N, and a real disc set shows its true disc numbers). Member
+metadata is fetched client-side via `getBook` in bounded batches, lazily on expand, so
+opening the queue never fans out hundreds of requests up front.
+
+Also fixes a latent payload-key mismatch: the card reader used snake_case keys
+(`proposed_action`, `member_ids`, `derived_title`) and expected `confidence` as a
+number, but the Go producer (`buildRegroupPayload`) emits camelCase
+(`proposedAction`, `memberBookIDs`, `survivorTitle`) with `confidence` as a string —
+so previously only the folder and raw file list rendered, and the member count
+silently fell back to the file-array length. The payload parsing/zipping now lives in
+a unit-tested `web/src/lib/reviewPayload.ts` (camelCase primary, snake_case fallback),
+and the byte-size/duration formatters were extracted to a shared
+`web/src/utils/mediaFormat.ts` reused by both the review cards and the dedup compare
+view.

--- a/todo.d/2026-07-25-review-queue-disc-metadata.md
+++ b/todo.d/2026-07-25-review-queue-disc-metadata.md
@@ -1,19 +1,3 @@
-- [ ] **REVIEW-QUEUE-CARDS** Bring the dedup tab's rich per-file compare view to
-      the review-queue cards. Today "Multi-disc"/"Ambiguous folder" holds render
-      only bare file-path strings (`ReviewQueue.tsx` `PayloadDetails`) — not enough
-      to make an informed approve/reject call. Generalize dedup's
-      `FileInfoCompare`/`BookFilesColumn` to a provider-agnostic shape, extract the
-      shared `formatBytes`/`formatDuration`/quality-chip helpers out of
-      `UnifiedDedupTab.tsx`, and render per-file rows (duration/format/bitrate/size/
-      disc+track) enriched client-side via `getBook()` over `member_ids`. Groups can
-      have >2 files, so use per-file rows, not a strict pairwise A/B layout. Also
-      surface the proposed disc/track the classifier now emits (so a same-disc
-      "Multi-disc" set visibly shows disc 0 + tracks 1..N, replacing the misleading
-      "Multi-disc" label for that case).
-- [ ] **REVIEW-QUEUE-PAYLOAD-KEY** Fix the `memberBookIDs` (payload, camelCase) vs
-      `member_ids`/`member_count` (frontend `ReviewQueue.tsx`, snake_case) key
-      mismatch — `memberCount()` silently falls back to `files.length` today. Do this
-      as part of REVIEW-QUEUE-CARDS.
 - [ ] **REGROUP-PARTCHAPTER-PARSER** The Mistborn-style "Ambiguous folder" case
       (`01 P0-C0.mp3`, `07 P1-C6.mp3` — Part/Chapter naming, non-contiguous numbers)
       has no parser and stays classified as ambiguous (unaffected by the disc/track

--- a/web/src/components/dedup/FileInfoCompare.tsx
+++ b/web/src/components/dedup/FileInfoCompare.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/dedup/FileInfoCompare.tsx
-// version: 1.1.0
+// version: 1.2.0
 // guid: e4d5f6a7-b8c9-0123-defa-ed4567890123
-// last-edited: 2026-06-19
+// last-edited: 2026-07-26
 
 // FileInfoCompare renders a side-by-side comparison of two books' file lists.
 // Used inside CandidateCompareDrawer.
@@ -9,21 +9,7 @@
 import { Box, Chip, Divider, Stack, Tooltip, Typography } from '@mui/material';
 import type { DedupBookDetail } from '../../services/api';
 import { formatPath, usePathVars, type PathVar } from '../../utils/formatPath';
-
-function formatBytes(bytes: number | undefined): string {
-  if (bytes == null) return '';
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
-
-function formatDuration(seconds: number | undefined): string {
-  if (seconds == null) return '';
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
-}
+import { formatBytes, formatDuration } from '../../utils/mediaFormat';
 
 interface BookFilesColumnProps {
   book: DedupBookDetail;

--- a/web/src/lib/__tests__/reviewPayload.test.ts
+++ b/web/src/lib/__tests__/reviewPayload.test.ts
@@ -1,0 +1,88 @@
+// file: web/src/pages/__tests__/reviewPayload.test.ts
+// version: 1.0.0
+// guid: 6a1d8f30-4b52-4e97-9c08-1f7b2e6d3a45
+
+import { describe, it, expect } from 'vitest';
+import { parsePayload, memberIDs, memberCount, memberEntries } from '../reviewPayload';
+
+// The Go producer (buildRegroupPayload) writes exactly this shape. These tests pin the
+// key names so the camelCase/snake_case mismatch that silently broke the old
+// member-count/enrichment can never regress.
+const producerPayload = JSON.stringify({
+  folder: '/lib/When We Were Sisters',
+  files: [
+    '/lib/When We Were Sisters/When We Were Sisters_1.mp3',
+    '/lib/When We Were Sisters/When We Were Sisters_2.mp3',
+    '/lib/When We Were Sisters/When We Were Sisters_3.mp3',
+  ],
+  proposedAction: 'collapse flat multi-track folder into 1 multi-file audiobook',
+  memberBookIDs: ['b1', 'b2', 'b3'],
+  survivorTitle: 'When We Were Sisters',
+  confidence: 'high',
+  discNumbers: [0, 0, 0],
+  trackNumbers: [1, 2, 3],
+});
+
+describe('review payload parsing', () => {
+  it('parsePayload returns null on empty / malformed input', () => {
+    expect(parsePayload('')).toBeNull();
+    expect(parsePayload('{not json')).toBeNull();
+  });
+
+  it('memberIDs reads the producer camelCase key', () => {
+    const p = parsePayload(producerPayload);
+    expect(memberIDs(p)).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('memberIDs falls back to the snake_case alias', () => {
+    const p = parsePayload(JSON.stringify({ member_ids: ['x', 'y'] }));
+    expect(memberIDs(p)).toEqual(['x', 'y']);
+  });
+
+  it('memberCount uses member IDs, not the files fallback, for the real payload', () => {
+    const p = parsePayload(producerPayload);
+    // Regression guard: the old code read member_ids and silently fell through to
+    // files.length because the producer emits memberBookIDs. Both are length 3 here,
+    // but memberCount must resolve via IDs first.
+    expect(memberCount(p)).toBe(3);
+  });
+
+  it('memberEntries zips files/ids/disc/track index-aligned', () => {
+    const p = parsePayload(producerPayload);
+    const entries = memberEntries(p);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({
+      filePath: '/lib/When We Were Sisters/When We Were Sisters_1.mp3',
+      bookId: 'b1',
+      disc: 0,
+      track: 1,
+    });
+    // Flat same-disc chapters: disc 0, contiguous tracks.
+    expect(entries.map((e) => e.disc)).toEqual([0, 0, 0]);
+    expect(entries.map((e) => e.track)).toEqual([1, 2, 3]);
+  });
+
+  it('memberEntries preserves real disc numbers for a genuine disc set', () => {
+    const p = parsePayload(
+      JSON.stringify({
+        files: ['/x/Disc 1/t.mp3', '/x/Disc 2/t.mp3'],
+        memberBookIDs: ['d1', 'd2'],
+        discNumbers: [1, 2],
+        trackNumbers: [1, 1],
+      })
+    );
+    const entries = memberEntries(p);
+    expect(entries.map((e) => e.disc)).toEqual([1, 2]);
+    expect(entries.map((e) => e.track)).toEqual([1, 1]);
+  });
+
+  it('memberEntries tolerates a legacy payload with no disc/track arrays', () => {
+    const p = parsePayload(
+      JSON.stringify({ files: ['/x/a.mp3'], memberBookIDs: ['b1'] })
+    );
+    const entries = memberEntries(p);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].disc).toBeUndefined();
+    expect(entries[0].track).toBeUndefined();
+  });
+});

--- a/web/src/lib/reviewPayload.ts
+++ b/web/src/lib/reviewPayload.ts
@@ -1,0 +1,92 @@
+// file: web/src/lib/reviewPayload.ts
+// version: 1.0.0
+// guid: 2f9c7b41-6d38-4a05-8e17-0b3d5c9a2e68
+// last-edited: 2026-07-26
+
+// Parsing + shaping for a review-queue item's JSON payload. Kept out of the
+// ReviewQueue component file so these pure helpers are unit-testable and don't trip
+// react-refresh's "component files should only export components" rule.
+//
+// The producer (internal/plugins/maintenance/regroup_shattered_ai.go,
+// buildRegroupPayload) writes camelCase keys: folder, files, proposedAction,
+// memberBookIDs, survivorTitle, confidence ("high" | "review"), and — for confident
+// multidisc collapses — the parallel discNumbers / trackNumbers arrays (index-aligned
+// with files/memberBookIDs). Snake_case aliases are kept as defensive fallbacks in
+// case a future producer emits a different shape; render only what is present.
+
+export interface ReviewPayload {
+  folder?: string;
+  proposedAction?: string;
+  proposed_action?: string;
+  survivorTitle?: string;
+  derived_title?: string;
+  title?: string;
+  memberBookIDs?: string[];
+  member_ids?: string[];
+  member_count?: number;
+  confidence?: string | number;
+  files?: string[];
+  discNumbers?: number[];
+  trackNumbers?: number[];
+  [k: string]: unknown;
+}
+
+export function parsePayload(raw: string): ReviewPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as ReviewPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** memberIDs returns the member book IDs, tolerating the producer's camelCase key
+ *  and the older snake_case alias. */
+export function memberIDs(payload: ReviewPayload | null): string[] {
+  if (!payload) return [];
+  if (Array.isArray(payload.memberBookIDs)) return payload.memberBookIDs;
+  if (Array.isArray(payload.member_ids)) return payload.member_ids;
+  return [];
+}
+
+export function memberCount(payload: ReviewPayload | null): number | undefined {
+  if (!payload) return undefined;
+  if (typeof payload.member_count === 'number') return payload.member_count;
+  const ids = memberIDs(payload);
+  if (ids.length > 0) return ids.length;
+  if (Array.isArray(payload.files)) return payload.files.length;
+  return undefined;
+}
+
+// A single member of a review group: its original file path, the (still-present)
+// source book ID, and the play-order the classifier proposes to write on approve.
+export interface MemberEntry {
+  filePath: string;
+  bookId?: string;
+  disc?: number;
+  track?: number;
+}
+
+/** memberEntries zips the payload's parallel arrays (files / memberBookIDs /
+ *  discNumbers / trackNumbers) into per-member records. Files is the spine; the
+ *  other arrays are optional and index-aligned. */
+export function memberEntries(payload: ReviewPayload | null): MemberEntry[] {
+  if (!payload) return [];
+  const files = Array.isArray(payload.files) ? payload.files : [];
+  const ids = memberIDs(payload);
+  const discs = Array.isArray(payload.discNumbers) ? payload.discNumbers : [];
+  const tracks = Array.isArray(payload.trackNumbers) ? payload.trackNumbers : [];
+  // Fall back to the member-ID list as the spine when no file paths were recorded.
+  const n = Math.max(files.length, ids.length);
+  const out: MemberEntry[] = [];
+  for (let i = 0; i < n; i++) {
+    out.push({
+      filePath: files[i] ?? '',
+      bookId: ids[i],
+      disc: discs[i],
+      track: tracks[i],
+    });
+  }
+  return out;
+}

--- a/web/src/pages/ReviewQueue.tsx
+++ b/web/src/pages/ReviewQueue.tsx
@@ -1,80 +1,196 @@
 // file: web/src/pages/ReviewQueue.tsx
-// version: 1.0.0
+// version: 2.0.0
 // guid: 4c8f2a17-5e93-4d60-a1b8-7f3c6d9e0a52
-// last-edited: 2026-07-13
+// last-edited: 2026-07-26
 
 import { useEffect, useMemo, useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Avatar,
   Box,
   Button,
   Chip,
   CircularProgress,
   Divider,
-  List,
-  ListItem,
   Paper,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import CheckIcon from '@mui/icons-material/Check.js';
 import CloseIcon from '@mui/icons-material/Close.js';
+import AlbumIcon from '@mui/icons-material/Album.js';
 import * as api from '../services/api';
-import { type ReviewItem } from '../services/api';
+import { type Book, type ReviewItem } from '../services/api';
 import { useReviewStore } from '../stores/useReviewStore';
 import { useAppStore } from '../stores/useAppStore';
 import { labelForKind } from '../lib/reviewKinds';
+import {
+  type MemberEntry,
+  memberCount,
+  memberEntries,
+  parsePayload,
+} from '../lib/reviewPayload';
+import { formatBytes, formatDuration } from '../utils/mediaFormat';
+import { formatPath, usePathVars } from '../utils/formatPath';
 
-// A defensively-typed view of a review item's JSON payload. The producer op
-// (Track B) is not built yet, so NOTHING writes this shape in the current repo
-// state — every field is optional and parsing is wrapped in try/catch. Render
-// only what is present; never assume a key exists.
-interface ReviewPayload {
-  folder?: string;
-  proposed_action?: string;
-  action?: string;
-  derived_title?: string;
-  title?: string;
-  member_ids?: string[];
-  member_count?: number;
-  confidence?: number;
-  files?: string[];
-  [k: string]: unknown;
-}
-
-function parsePayload(raw: string): ReviewPayload | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? (parsed as ReviewPayload) : null;
-  } catch {
-    return null;
+// fetchBooksByIds resolves member book IDs to full Book records in bounded batches
+// (a group can hold dozens of files; don't fire dozens of concurrent requests). A
+// member that was hard-deleted since the hold was created simply resolves to
+// undefined — the row still renders from its file path.
+async function fetchBooksByIds(
+  ids: string[],
+  signal: AbortSignal
+): Promise<Map<string, Book>> {
+  const out = new Map<string, Book>();
+  const unique = Array.from(new Set(ids.filter((id) => id)));
+  const BATCH = 6;
+  for (let i = 0; i < unique.length; i += BATCH) {
+    if (signal.aborted) break;
+    const slice = unique.slice(i, i + BATCH);
+    const results = await Promise.allSettled(slice.map((id) => api.getBook(id)));
+    results.forEach((r, j) => {
+      if (r.status === 'fulfilled' && r.value) out.set(slice[j], r.value);
+    });
   }
+  return out;
 }
 
-function memberCount(payload: ReviewPayload | null): number | undefined {
-  if (!payload) return undefined;
-  if (typeof payload.member_count === 'number') return payload.member_count;
-  if (Array.isArray(payload.member_ids)) return payload.member_ids.length;
-  if (Array.isArray(payload.files)) return payload.files.length;
-  return undefined;
+// MemberRow renders one member of a review group with as much metadata as we could
+// resolve — cover, title, author, series, format/duration/size/bitrate chips, and the
+// proposed disc/track order. When the source book couldn't be fetched (e.g. it was
+// hard-deleted since the hold was created) it degrades to the bare file path.
+function MemberRow({
+  entry,
+  book,
+  pathVars,
+}: {
+  entry: MemberEntry;
+  book: Book | undefined;
+  pathVars: ReturnType<typeof usePathVars>;
+}) {
+  const title = book?.title || entry.filePath.split('/').pop() || '(unknown)';
+  const size = book?.file_size;
+  const duration = book?.duration;
+  const bitrate = book?.bitrate;
+  const codec = book?.codec;
+  const hasDisc = typeof entry.disc === 'number' && entry.disc > 0;
+  const hasTrack = typeof entry.track === 'number' && entry.track > 0;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1.25,
+        p: 1,
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        alignItems: 'flex-start',
+        minWidth: 0,
+      }}
+    >
+      <Avatar
+        variant="rounded"
+        src={book?.cover_url || book?.cover_image || undefined}
+        sx={{ width: 40, height: 40, bgcolor: 'action.selected' }}
+      >
+        <AlbumIcon fontSize="small" />
+      </Avatar>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography variant="body2" fontWeight={600} noWrap title={title}>
+          {title}
+        </Typography>
+        {(book?.author_name || book?.series_name) && (
+          <Typography variant="caption" color="text.secondary" noWrap display="block">
+            {book?.author_name}
+            {book?.series_name && (
+              <>
+                {book?.author_name ? ' · ' : ''}
+                {book.series_name}
+                {book.series_position != null ? ` #${book.series_position}` : ''}
+              </>
+            )}
+          </Typography>
+        )}
+        <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }} flexWrap="wrap" useFlexGap>
+          {(hasDisc || hasTrack) && (
+            <Chip
+              size="small"
+              color="primary"
+              variant="outlined"
+              label={`${hasDisc ? `Disc ${entry.disc} · ` : ''}Track ${hasTrack ? entry.track : '?'}`}
+            />
+          )}
+          {book?.format && <Chip size="small" label={book.format.toUpperCase()} />}
+          {duration != null && (
+            <Chip size="small" variant="outlined" label={formatDuration(duration)} />
+          )}
+          {size != null && <Chip size="small" variant="outlined" label={formatBytes(size)} />}
+          {bitrate != null && (
+            <Chip size="small" variant="outlined" label={`${bitrate}kbps`} />
+          )}
+          {codec && <Chip size="small" variant="outlined" label={codec} />}
+        </Stack>
+        {entry.filePath && (
+          <Tooltip title={entry.filePath} placement="bottom-start"
+            componentsProps={{ tooltip: { sx: { maxWidth: 600 } } }}>
+            <Typography
+              variant="caption"
+              sx={{ fontFamily: 'monospace', fontSize: '0.65rem', display: 'block', mt: 0.5 }}
+              noWrap
+            >
+              {formatPath(entry.filePath, pathVars)}
+            </Typography>
+          </Tooltip>
+        )}
+      </Box>
+    </Box>
+  );
 }
 
-function PayloadDetails({ item }: { item: ReviewItem }) {
-  const payload = parsePayload(item.payload);
+// MemberFilesDetail renders a review item's payload header plus a rich per-member
+// list. It fetches the member books lazily (it only mounts when the accordion is
+// expanded, via unmountOnExit) so opening the queue never fans out hundreds of
+// getBook calls up front.
+function MemberFilesDetail({ item }: { item: ReviewItem }) {
+  const pathVars = usePathVars();
+  const payload = useMemo(() => parsePayload(item.payload), [item.payload]);
   const folder = payload?.folder ?? item.folder_ref;
-  const proposed = payload?.proposed_action ?? payload?.action;
-  const title = payload?.derived_title ?? payload?.title;
+  const proposed = payload?.proposedAction ?? payload?.proposed_action;
+  const title = payload?.survivorTitle ?? payload?.derived_title ?? payload?.title;
+  const confidence =
+    typeof payload?.confidence === 'string'
+      ? payload.confidence
+      : typeof payload?.confidence === 'number'
+        ? payload.confidence.toFixed(2)
+        : undefined;
+  const entries = useMemo(() => memberEntries(payload), [payload]);
   const members = memberCount(payload);
-  const confidence = typeof payload?.confidence === 'number' ? payload.confidence : undefined;
-  const files = Array.isArray(payload?.files) ? payload!.files! : undefined;
+
+  const [books, setBooks] = useState<Map<string, Book>>(new Map());
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const ids = entries.map((e) => e.bookId).filter((id): id is string => !!id);
+    if (ids.length === 0) return;
+    const ctrl = new AbortController();
+    setLoading(true);
+    fetchBooksByIds(ids, ctrl.signal)
+      .then((m) => {
+        if (!ctrl.signal.aborted) setBooks(m);
+      })
+      .finally(() => {
+        if (!ctrl.signal.aborted) setLoading(false);
+      });
+    return () => ctrl.abort();
+  }, [entries]);
 
   return (
     <Box sx={{ pl: 1 }}>
-      <Stack spacing={0.5} sx={{ mb: files ? 1 : 0 }}>
+      <Stack spacing={0.5} sx={{ mb: 1 }}>
         {folder && (
           <Typography variant="body2">
             <strong>Folder:</strong> <code>{folder}</code>
@@ -82,7 +198,7 @@ function PayloadDetails({ item }: { item: ReviewItem }) {
         )}
         {title && (
           <Typography variant="body2">
-            <strong>Derived title:</strong> {title}
+            <strong>Proposed title:</strong> {title}
           </Typography>
         )}
         {proposed && (
@@ -90,39 +206,34 @@ function PayloadDetails({ item }: { item: ReviewItem }) {
             <strong>Proposed action:</strong> {proposed}
           </Typography>
         )}
-        {members !== undefined && (
-          <Typography variant="body2">
-            <strong>Members:</strong> {members} file{members === 1 ? '' : 's'}
-          </Typography>
-        )}
-        {confidence !== undefined && (
-          <Typography variant="body2">
-            <strong>Confidence:</strong> {confidence.toFixed(2)}
-          </Typography>
-        )}
+        <Stack direction="row" spacing={1} alignItems="center">
+          {members !== undefined && (
+            <Typography variant="body2">
+              <strong>Members:</strong> {members} file{members === 1 ? '' : 's'}
+            </Typography>
+          )}
+          {confidence && (
+            <Chip
+              size="small"
+              label={confidence === 'high' ? 'High confidence' : confidence}
+              color={confidence === 'high' ? 'success' : 'default'}
+              variant="outlined"
+            />
+          )}
+          {loading && <CircularProgress size={14} />}
+        </Stack>
       </Stack>
-      {files && files.length > 0 && (
-        <Box>
-          <Typography variant="caption" color="text.secondary">
-            Files
-          </Typography>
-          <List dense disablePadding sx={{ pl: 1 }}>
-            {files.slice(0, 25).map((f, i) => (
-              <ListItem key={i} disableGutters sx={{ py: 0 }}>
-                <Typography variant="caption" sx={{ wordBreak: 'break-all' }}>
-                  {f}
-                </Typography>
-              </ListItem>
-            ))}
-            {files.length > 25 && (
-              <ListItem disableGutters sx={{ py: 0 }}>
-                <Typography variant="caption" color="text.secondary">
-                  …and {files.length - 25} more
-                </Typography>
-              </ListItem>
-            )}
-          </List>
-        </Box>
+      {entries.length > 0 && (
+        <Stack spacing={0.75}>
+          {entries.map((e, i) => (
+            <MemberRow
+              key={e.bookId ?? e.filePath ?? i}
+              entry={e}
+              book={e.bookId ? books.get(e.bookId) : undefined}
+              pathVars={pathVars}
+            />
+          ))}
+        </Stack>
       )}
     </Box>
   );
@@ -279,14 +390,18 @@ export function ReviewQueue() {
                 {bucket.items.map((item) => {
                   const itemBusy = busyItems.has(item.id);
                   return (
-                    <Accordion key={item.id} disableGutters>
+                    <Accordion
+                      key={item.id}
+                      disableGutters
+                      slotProps={{ transition: { unmountOnExit: true } }}
+                    >
                       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                         <Typography variant="body2" sx={{ flexGrow: 1 }}>
                           {item.summary || item.folder_ref || item.id}
                         </Typography>
                       </AccordionSummary>
                       <AccordionDetails>
-                        <PayloadDetails item={item} />
+                        <MemberFilesDetail item={item} />
                         <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
                           <Button
                             size="small"

--- a/web/src/utils/mediaFormat.ts
+++ b/web/src/utils/mediaFormat.ts
@@ -1,0 +1,26 @@
+// file: web/src/utils/mediaFormat.ts
+// version: 1.0.0
+// guid: 5b1e9c30-7a42-4d68-9f0c-2e6b3d8a1c74
+// last-edited: 2026-07-26
+
+// Shared human-readable formatters for media file metadata (byte sizes, durations).
+// Extracted from the dedup compare view so the review-queue cards render identical
+// units without a third copy of the same logic. Keep these pure and dependency-free.
+
+/** formatBytes renders a byte count as B / KB / MB. Returns '' for null/undefined. */
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/** formatDuration renders a second count as "Hh Mm" (or "Mm" under an hour).
+ *  Returns '' for null/undefined. */
+export function formatDuration(seconds: number | undefined | null): string {
+  if (seconds == null) return '';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}


### PR DESCRIPTION
Follow-up to #2052 (disc/track fix). Makes the review-queue cards actually usable for approve/reject decisions.

## Before / after

Cards used to render just a bare list of file-path strings — *"that tells me jack shit about the files."* Now expanding a card shows a **rich per-member row** for each file:

- Cover art thumbnail, title, author, series + position
- Format / duration / size / bitrate / codec chips
- The **proposed disc/track** the classifier will write on approve — so a same-disc chapter set visibly shows **disc 0 + tracks 1..N**, and a genuine boxed set shows its **true disc numbers** (pairs with #2052)

Member metadata is fetched via `getBook` in **bounded batches (6 at a time)**, **lazily on accordion expand** (`slotProps.transition.unmountOnExit`), so opening the queue never fans out hundreds of requests up front. A member that was hard-deleted since the hold was created degrades gracefully to its bare file path.

## Also fixes a latent bug

The card reader used snake_case keys (`proposed_action`, `member_ids`, `derived_title`) and expected `confidence` as a **number**, but the Go producer (`buildRegroupPayload`) emits camelCase (`proposedAction`, `memberBookIDs`, `survivorTitle`) with `confidence` as a **string**. So previously **only the folder and raw file list rendered**, and the member count silently fell back to `files.length`. Now reads the real payload (camelCase primary, snake_case fallback).

## Structure

- Payload parsing/zipping → unit-tested `web/src/lib/reviewPayload.ts` (next to `reviewKinds.ts`).
- Byte-size/duration formatters → shared `web/src/utils/mediaFormat.ts`, reused by the review cards **and** the dedup compare view (`FileInfoCompare.tsx` de-duplicated its local copies).

## Tests

- `reviewPayload.test.ts` (7 cases) pins the producer key names + the disc/track zip so the mismatch can't regress.
- `tsc` + `eslint` clean (no warnings); full frontend suite green (**402 tests**); production build succeeds.

## Not included (tracked in `todo.d/`)

- Part/Chapter (`P0-C0`) parser for the Mistborn-style ambiguous case.

> Note: no backend change — the payload already carries `memberBookIDs` + disc/track; `getBook` supplies the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt