### PR TITLE
feat(review-queue): anthology combines into one book + disc-vs-chapter labels

### DIFF
--- a/changelog.d/review-anthology-combine.md
+++ b/changelog.d/review-anthology-combine.md
@@ -1,0 +1,31 @@
+<!-- file: changelog.d/review-anthology-combine.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4b7e0c39-8a15-4d62-9f30-2e6c1b8d5a47 -->
+<!-- last-edited: 2026-07-26 -->
+
+### Changed
+
+#### Review queue: anthologies now combine into one book; clearer disc-vs-chapter labels
+
+**Anthology = one book.** An anthology / collection / omnibus is a single real
+audiobook (one ISBN), not multiple works to split apart (owner decision). Approving
+an anthology review hold now **combines** its files into one multi-file book — the
+same safe, tested operation as a multi-disc collapse — instead of doing nothing. The
+proposed-action text changed from "split into separate works" to "combine into one
+multi-file audiobook (anthology/collection)", `regroup.anthology` is wired to the
+combine handler, and anthology payloads now carry sequential chapter order (disc 0,
+tracks 1..N). The over-merge guard is unchanged: a plain author folder of distinct
+books with no anthology marker still never combines.
+
+**Clearer labels.** The review summary now distinguishes a genuine multi-disc set
+("Multi-disc: N discs → 1 book") from same-disc sequential chapters ("Chapters: N
+tracks → 1 book"), which previously both read "Multi-disc" and caused confusion.
+
+**Known edge (flagged for follow-up):** the anthology marker regex also matches
+"trilogy" / "boxed set" / "quartet", which can be *multiple* books (multiple ISBNs),
+not one. Those would now be *suggested* for combine — but every anthology hold is a
+human-reviewed decision (nothing auto-applies; the global `review_apply_enabled`
+switch is off), so a real trilogy is caught on review and rejected. A future refinement
+could split single-book markers (anthology/collection/omnibus → combine) from
+multi-book markers (trilogy/boxed set → offer keep-separate), folding into the planned
+ambiguous-resolution choices.

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 1e7d4a92-3c85-4b60-9f21-6a8c0d5e2b47
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 // Package service — deterministic (regex-only) shape classifier for the
 // shattered-book REGROUP review producer (PR-B1).
@@ -70,7 +70,7 @@ import (
 const (
 	KindMultidisc    = "regroup.multidisc"     // confident collapse: N single-file books = 1 audiobook
 	KindVersionGroup = "regroup.version-group" // Abridged + Unabridged editions in one folder
-	KindAnthology    = "regroup.anthology"     // multiple distinct works (anthology/trilogy/omnibus)
+	KindAnthology    = "regroup.anthology"     // anthology/collection/omnibus = ONE book → combine (owner: single ISBN)
 	KindAmbiguous    = "regroup.ambiguous"     // book-like folder, cannot confidently classify
 )
 
@@ -124,6 +124,12 @@ type RegroupGroup struct {
 	// not the raw file count (a novel split into 133 sequential chapter files is ONE
 	// work, not 133). Zero for every other Kind (callers fall back to len(Members)).
 	DistinctWorks int
+	// Structure is the dominant physical shape of the group's members:
+	// "disc" (real Disc N/CD N folders), "chapter" (`<Book> - N` subdirs),
+	// "flat" (sequential files in one folder), or "edition". It lets the review
+	// label distinguish a genuine multi-DISC set ("Multi-disc → 1 book") from
+	// same-disc CHAPTERS ("Chapters → 1 book"), which read identically otherwise.
+	Structure string
 }
 
 // ShapeStats reconciles every input book so the record count ties out (no silent
@@ -541,6 +547,7 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 			ProposedAction: action,
 			Members:        out,
 			DistinctWorks:  distinctWorks,
+			Structure:      structure,
 		}
 	}
 
@@ -562,11 +569,13 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 			"create a version group (Abridged + Unabridged), Unabridged primary", 0), true
 
 	case hasFolderAnthologyMarker && manyDistinctTitles:
-		// STRONG evidence: an anthology/omnibus/collection marker on the BOOK FOLDER
-		// itself AND multiple genuinely-distinct title stems → a real anthology. The
-		// human-facing count is the number of DISTINCT WORKS, not the raw file count.
+		// An anthology/omnibus/collection marker on the BOOK FOLDER itself AND multiple
+		// distinct title stems → an anthology. Owner decision (2026-07-26): an anthology
+		// is a SINGLE real book (one ISBN), not multiple works to split — so the action
+		// is to COMBINE the files into one multi-file audiobook, exactly like a disc set.
+		// DistinctWorks is still surfaced (it's the story/chapter count) for the label.
 		return build(KindAnthology, false,
-			"split into separate works (held — needs review to identify boundaries)",
+			"combine into one multi-file audiobook (anthology/collection)",
 			distinctStems), true
 
 	case hasFolderAnthologyMarker:

--- a/internal/itunes/service/fs_regroup_shape_test.go
+++ b/internal/itunes/service/fs_regroup_shape_test.go
@@ -7,6 +7,7 @@ package itunesservice
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -223,6 +224,24 @@ func TestClassify_GenuineAnthology(t *testing.T) {
 	}
 	if g.DistinctWorks != 5 {
 		t.Errorf("DistinctWorks=%d, want 5 distinct titles (not file count)", g.DistinctWorks)
+	}
+	// Owner decision 2026-07-26: an anthology is ONE book → the proposed action is to
+	// COMBINE, not split, and its files carry sequential chapter order (disc 0).
+	if !strings.Contains(g.ProposedAction, "combine into one") {
+		t.Errorf("anthology action = %q, want a 'combine into one' action (not split)", g.ProposedAction)
+	}
+	for _, m := range g.Members {
+		if m.DiscNumber != 0 {
+			t.Errorf("anthology member %s DiscNumber=%d, want 0 (one book, no disc)", m.BookID, m.DiscNumber)
+		}
+	}
+	// Track order must be a contiguous 1..N across the anthology's files.
+	seenTracks := map[int]bool{}
+	for _, m := range g.Members {
+		if m.TrackNumber < 1 || m.TrackNumber > len(g.Members) || seenTracks[m.TrackNumber] {
+			t.Errorf("anthology member %s TrackNumber=%d, want unique 1..%d", m.BookID, m.TrackNumber, len(g.Members))
+		}
+		seenTracks[m.TrackNumber] = true
 	}
 }
 

--- a/internal/plugins/maintenance/regroup_apply_test.go
+++ b/internal/plugins/maintenance/regroup_apply_test.go
@@ -732,3 +732,48 @@ func TestApplyMultidisc_LegacyPayload_NoNumbers(t *testing.T) {
 		assert.Equal(t, 0, f.TrackNumber)
 	}
 }
+
+// TestApplyMultidisc_AnthologyPayload_CombinesToOneBook proves the owner decision that
+// an anthology is ONE book: the combine handler (which anthology is wired to) collapses
+// the anthology's story files into a single multi-file book with sequential tracks and
+// preserved fingerprints — exactly the multidisc behavior, driven by an anthology-kind
+// payload.
+func TestApplyMultidisc_AnthologyPayload_CombinesToOneBook(t *testing.T) {
+	store := newApplyTestStore(t)
+
+	paths := []string{
+		"/lib/Dangerous Women/The Princess and the Queen.mp3",
+		"/lib/Dangerous Women/Some Desperate Glory.mp3",
+		"/lib/Dangerous Women/Bombshells.mp3",
+	}
+	ids, fpByPath := seedNumberedBooks(t, store, paths)
+	discs := []int{0, 0, 0}  // one book, no disc
+	tracks := []int{1, 2, 3} // sequential stories
+
+	item := multidiscItemWithNumbers(t, "/lib/Dangerous Women", ids, paths, discs, tracks)
+	item.Kind = "regroup.anthology" // the kind wired to the combine handler
+
+	apply := ApplyMultidisc(store, merge.NewService(store))
+	require.NoError(t, apply(context.Background(), item))
+
+	// Exactly one book survives, owning all three story files.
+	survivor := minID(ids...)
+	for _, id := range ids {
+		b, _ := store.GetBookByID(id)
+		if id == survivor {
+			require.NotNil(t, b, "anthology survivor must remain")
+		} else {
+			assert.Nil(t, b, "absorbed story book %s must be gone", id)
+		}
+	}
+	files, err := store.GetBookFiles(survivor)
+	require.NoError(t, err)
+	require.Len(t, files, 3, "anthology collapses to ONE book owning all stories")
+	wantTrack := map[string]int{paths[0]: 1, paths[1]: 2, paths[2]: 3}
+	for _, f := range files {
+		assert.Equal(t, 0, f.DiscNumber, "anthology is one book — no disc numbers")
+		assert.Equal(t, wantTrack[f.FilePath], f.TrackNumber, "story order for %s", f.FilePath)
+		assert.Equal(t, fpByPath[f.FilePath], f.AcoustIDFingerprint, "fingerprint survives (%s)", f.FilePath)
+	}
+	dbtest.AssertStoreInvariants(t, store)
+}

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_shattered_ai.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 8b3e6d21-4f97-4c05-a1d8-2e7b9c0f5a63
-// last-edited: 2026-07-25
+// last-edited: 2026-07-26
 
 // Package maintenance — op maintenance.regroup-shattered-ai (PR-B1).
 //
@@ -310,18 +310,24 @@ func regroupSummary(g itunesservice.RegroupGroup) string {
 	n := len(g.Members)
 	switch g.Kind {
 	case itunesservice.KindMultidisc:
-		return fmt.Sprintf("Multi-disc: %d tracks → 1 book — %s", n, g.FolderRef)
+		// Distinguish a genuine multi-DISC set from same-disc CHAPTERS — the owner's
+		// original confusion. Only a real Disc N/CD N folder structure is "Multi-disc";
+		// flat/chapter files are sequential chapters of ONE disc.
+		if g.Structure == "disc" {
+			return fmt.Sprintf("Multi-disc: %d discs → 1 book — %s", n, g.FolderRef)
+		}
+		return fmt.Sprintf("Chapters: %d tracks → 1 book — %s", n, g.FolderRef)
 	case itunesservice.KindVersionGroup:
 		return fmt.Sprintf("Version group (Abridged + Unabridged): %d files — %s", n, g.FolderRef)
 	case itunesservice.KindAnthology:
-		// Count is DISTINCT WORKS, not the raw file count (Bug 1): a novel split into
-		// N sequential chapter files is one work, not N. DistinctWorks is set by the
-		// classifier for anthologies; fall back to the file count only if it is unset.
+		// An anthology is ONE book (owner decision 2026-07-26) — approving combines its
+		// files into a single audiobook. DistinctWorks is the story/chapter count within
+		// that one book, shown for context.
 		works := g.DistinctWorks
 		if works <= 0 {
 			works = n
 		}
-		return fmt.Sprintf("Anthology/collection: %d works — %s", works, g.FolderRef)
+		return fmt.Sprintf("Anthology/collection: %d files (%d stories) → 1 book — %s", n, works, g.FolderRef)
 	default:
 		return fmt.Sprintf("Ambiguous folder (%d files) — needs review — %s", n, g.FolderRef)
 	}
@@ -343,10 +349,11 @@ func buildRegroupPayload(g itunesservice.RegroupGroup) (string, error) {
 	if g.Confident {
 		confidence = "high"
 	}
-	// Only confident collapses (the two multidisc-producing branches) carry disc/track;
-	// for any other kind the classifier left every member's numbers at 0, so drop the
-	// arrays (they'd be all-zero noise the apply path would skip anyway).
-	if !g.Confident {
+	// Disc/track are meaningful only for the COMBINE kinds — multidisc and anthology
+	// both collapse into one ordered multi-file book (an anthology is a single book,
+	// owner decision 2026-07-26), so both carry the classifier's chapter order.
+	// Version-group and ambiguous leave them nil (all-zero noise the apply path skips).
+	if g.Kind != itunesservice.KindMultidisc && g.Kind != itunesservice.KindAnthology {
 		discs, tracks = nil, nil
 	}
 	data, err := json.Marshal(regroupPayload{

--- a/internal/plugins/maintenance/regroup_shattered_ai_test.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -64,6 +65,72 @@ func TestBuildRegroupPayload_DiscTrackRoundTrip(t *testing.T) {
 		if tr != i+1 {
 			t.Errorf("track order: index %d has track %d, want %d", i, tr, i+1)
 		}
+	}
+}
+
+// TestBuildRegroupPayload_AnthologyCarriesTracks verifies the owner decision that an
+// anthology is ONE book: its payload now carries disc/track (so the combine gets
+// chapter order) and its proposed action is a COMBINE, not a split.
+func TestBuildRegroupPayload_AnthologyCarriesTracks(t *testing.T) {
+	base := "/mnt/bigdata/books/audiobook-organizer/George R R Martin/Dangerous Women Anthology"
+	titles := []string{"The Princess and the Queen", "Some Desperate Glory", "Bombshells", "Raisa Stepanova", "Noras Song"}
+	var books []itunesservice.ShatterBook
+	for i, title := range titles {
+		books = append(books, itunesservice.ShatterBook{
+			BookID:    fmt.Sprintf("a%02d", i),
+			FilePath:  fmt.Sprintf("%s/%s.mp3", base, title),
+			FileCount: 1,
+			IsPrimary: true,
+		})
+	}
+	groups, _ := itunesservice.ClassifyShatteredFolders(books)
+	g := groups[0]
+	if g.Kind != itunesservice.KindAnthology {
+		t.Fatalf("want anthology, got %q", g.Kind)
+	}
+	raw, err := buildRegroupPayload(g)
+	if err != nil {
+		t.Fatalf("buildRegroupPayload: %v", err)
+	}
+	p, err := decodeRegroupPayload(database.ReviewItem{Payload: raw})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Anthology now carries disc/track (combine kind) — this is the behavior change.
+	if len(p.DiscNumbers) != len(p.Files) || len(p.TrackNumbers) != len(p.Files) {
+		t.Fatalf("anthology payload must carry disc/track: files=%d discs=%d tracks=%d",
+			len(p.Files), len(p.DiscNumbers), len(p.TrackNumbers))
+	}
+	for i := range p.DiscNumbers {
+		if p.DiscNumbers[i] != 0 {
+			t.Errorf("anthology file %d disc=%d, want 0 (one book)", i, p.DiscNumbers[i])
+		}
+	}
+	if !strings.Contains(p.ProposedAction, "combine into one") {
+		t.Errorf("anthology action = %q, want combine", p.ProposedAction)
+	}
+}
+
+// TestRegroupSummary_Labels pins the owner-facing labels: a real disc set reads
+// "Multi-disc", same-disc chapters read "Chapters" (the original confusion), and an
+// anthology reads "→ 1 book" (combine, not split).
+func TestRegroupSummary_Labels(t *testing.T) {
+	cases := []struct {
+		name string
+		g    itunesservice.RegroupGroup
+		want string
+	}{
+		{"real disc set", itunesservice.RegroupGroup{Kind: itunesservice.KindMultidisc, Structure: "disc", Members: make([]itunesservice.ShatterBook, 3), FolderRef: "/x"}, "Multi-disc: 3 discs → 1 book"},
+		{"same-disc chapters", itunesservice.RegroupGroup{Kind: itunesservice.KindMultidisc, Structure: "flat", Members: make([]itunesservice.ShatterBook, 6), FolderRef: "/x"}, "Chapters: 6 tracks → 1 book"},
+		{"anthology", itunesservice.RegroupGroup{Kind: itunesservice.KindAnthology, DistinctWorks: 5, Members: make([]itunesservice.ShatterBook, 9), FolderRef: "/x"}, "Anthology/collection: 9 files (5 stories) → 1 book"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := regroupSummary(c.g)
+			if !strings.Contains(got, c.want) {
+				t.Errorf("summary = %q, want it to contain %q", got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.19.0
+// version: 2.20.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-14
+// last-edited: 2026-07-26
 
 package server
 
@@ -587,18 +587,22 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	// without re-wiring.
 	reviewH := reviewhandler.New(s.Store(), func() bool { return config.AppConfig.ReviewApplyEnabled })
 
-	// Register the regroup APPLY handlers (PR-B2) so approving a confident hold in
-	// the review UI performs the real merge. Only the two confident kinds get a
-	// handler; anthology/ambiguous stay handler-less (approve → "approved", never
-	// auto-applied). Guarded on a real store — with a nil store the review handler
-	// short-circuits before dispatch, so the closures would never run anyway.
+	// Register the regroup APPLY handlers (PR-B2) so approving a hold in the review
+	// UI performs the real action. Multidisc AND anthology both COMBINE into one
+	// multi-file book (an anthology/collection is a single real book with one ISBN —
+	// owner decision 2026-07-26 — NOT multiple works to split), so both use
+	// ApplyMultidisc. Version-group links editions. Only `ambiguous` stays
+	// handler-less (needs a human resolution choice — the review UI supplies it).
+	// Guarded on a real store — with a nil store the review handler short-circuits
+	// before dispatch, so the closures would never run anyway.
 	if s.Store() != nil {
 		mergeSvc := s.mergeService
 		if mergeSvc == nil {
 			mergeSvc = merge.NewService(s.Store())
 		}
-		reviewH.RegisterApplyHandler(itunesservice.KindMultidisc,
-			maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc))
+		combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc)
+		reviewH.RegisterApplyHandler(itunesservice.KindMultidisc, combine)
+		reviewH.RegisterApplyHandler(itunesservice.KindAnthology, combine)
 		reviewH.RegisterApplyHandler(itunesservice.KindVersionGroup,
 			maintenanceplugin.ApplyVersionGroup(s.Store()))
 	}


### PR DESCRIPTION
Continues the review-queue apply work. Two changes, both driven by owner feedback while reviewing the queue.

## 1. An anthology is ONE book — combine, don't split

You flagged that an anthology / collection / omnibus is **a single real audiobook with one ISBN**, not multiple works to split apart. The classifier's "split into separate works" was simply the wrong action. Now:

- `regroup.anthology` is wired to the existing **`ApplyMultidisc` combine handler** — approving an anthology collapses its files into one multi-file book (the same tested, fingerprint-safe path as a disc set) instead of silently doing nothing.
- Proposed-action text: "split into separate works" → **"combine into one multi-file audiobook (anthology/collection)"**.
- Anthology payloads now carry sequential chapter order (disc 0, tracks 1..N), so the combined book plays in order.
- **Over-merge guard unchanged**: a plain author folder of distinct books with no anthology marker still never combines (regression-tested).

## 2. Clearer labels (multi-disc vs chapters)

The summary now distinguishes a genuine multi-disc set (**"Multi-disc: N discs → 1 book"**) from same-disc sequential chapters (**"Chapters: N tracks → 1 book"**) — they previously both read "Multi-disc", which is what caused the original confusion. Done via a new `RegroupGroup.Structure` field.

## ⚠️ Known edge — needs your eventual call

The anthology marker regex also matches **"trilogy" / "boxed set" / "quartet"**, which can be *multiple* books (multiple ISBNs), not one. Those now get *suggested* for combine. Because every anthology hold is **human-reviewed and nothing auto-applies** (`review_apply_enabled` is off in prod), a real trilogy is caught on review and rejected — so this is safe today. A future refinement can split single-book markers (anthology/collection/omnibus → combine) from multi-book markers (trilogy/boxed-set → offer keep-separate). That folds naturally into the still-pending **ambiguous-resolution choices** work (task #7).

## Safety

- All behind the global `review_apply_enabled` switch (OFF in prod) — nothing auto-applies.
- Anthology reuses the already-tested `ApplyMultidisc` combine path (targeted field writes, fingerprint-preserving, deterministic survivor). No new create/split-book operation.

## Tests

- Classifier: anthology carries the combine action + disc 0 / tracks 1..N + `Structure`.
- Payload round-trip: anthology payload includes disc/track.
- Apply: `ApplyMultidisc` on an anthology-kind payload → one book, tracks set, fingerprints preserved.
- Summary labels: disc-set / chapters / anthology cases.
- All green in `-race`; affected + dependent packages (itunes/service, maintenance, review handler, merge) pass.

## Not in this PR (task #7)

Ambiguous cards still have no concrete action — their proposed text is "review: … unclear", which genuinely needs a human choice. Next PR adds resolution buttons (Combine / Version group / Keep separate) that dispatch to the matching handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt