### PR TITLE
fix(auth): read OAuth/Cloudflare-Access config via os.Getenv, not viper

### DIFF
--- a/changelog.d/fix-oauth-env-osgetenv.md
+++ b/changelog.d/fix-oauth-env-osgetenv.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/fix-oauth-env-osgetenv.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5e9a1c73-8b04-4d62-9f17-3a6c2b0e9d51 -->
+<!-- last-edited: 2026-07-26 -->
+
+### Fixed
+
+#### OAuth / Cloudflare Access config now read from env vars (os.Getenv, not viper)
+
+The OAuth2/OIDC + Cloudflare Access settings (`CF_ACCESS_TEAM_DOMAIN`, `CF_ACCESS_AUD`,
+`OAUTH_ALLOWED_EMAILS`, `OAUTH_*`) were wired through `viper.BindEnv`, which does not
+reliably surface a systemd-set env var into config at runtime in this app (config is
+loaded from config.yaml + the DB settings store). A drop-in `Environment=` value was
+silently dropped, so the Cloudflare Access passthrough middleware never initialized and
+users still hit the app's own login. These are now read via `os.Getenv` (env-first,
+viper fallback), matching the established `WHISPER_REMOTE_URL` pattern. Also: the CF
+Access middleware now falls back to the `CF_Authorization` cookie when the header is
+absent, and logs (at Warn) when a present JWT fails verification or a verified identity
+is not admitted, so misconfig is no longer silent.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -757,6 +757,30 @@ func Mutate(fn func(*Config)) {
 }
 
 // InitConfig initializes the application configuration
+// envOr returns env when it is non-empty (trimmed), else the fallback. Env vars are
+// read via os.Getenv directly because viper's env binding does not reliably surface a
+// systemd-set env var into config in this app (config is loaded from config.yaml + the
+// DB settings store). Mirrors the WHISPER_REMOTE_URL os.Getenv pattern.
+func envOr(env, fallback string) string {
+	if strings.TrimSpace(env) != "" {
+		return strings.TrimSpace(env)
+	}
+	return fallback
+}
+
+// envOrBool parses a truthy env value ("1"/"true"/"yes"/"on", case-insensitive),
+// falling back to the given value when the env var is unset or unparseable.
+func envOrBool(env string, fallback bool) bool {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}
+
 func InitConfig() {
 	// Set core defaults
 	viper.SetDefault("database_type", "pebble")
@@ -837,16 +861,16 @@ func InitConfig() {
 	viper.SetDefault("oauth_default_role", "viewer")
 	viper.SetDefault("cf_access_team_domain", "")
 	viper.SetDefault("cf_access_aud", "")
-	viper.BindEnv("oauth_enabled", "OAUTH_ENABLED")                          //nolint:errcheck
-	viper.BindEnv("oauth_github_client_id", "OAUTH_GITHUB_CLIENT_ID")        //nolint:errcheck
+	viper.BindEnv("oauth_enabled", "OAUTH_ENABLED")                           //nolint:errcheck
+	viper.BindEnv("oauth_github_client_id", "OAUTH_GITHUB_CLIENT_ID")         //nolint:errcheck
 	viper.BindEnv("oauth_github_client_secret", "OAUTH_GITHUB_CLIENT_SECRET") //nolint:errcheck
-	viper.BindEnv("oauth_google_client_id", "OAUTH_GOOGLE_CLIENT_ID")        //nolint:errcheck
+	viper.BindEnv("oauth_google_client_id", "OAUTH_GOOGLE_CLIENT_ID")         //nolint:errcheck
 	viper.BindEnv("oauth_google_client_secret", "OAUTH_GOOGLE_CLIENT_SECRET") //nolint:errcheck
-	viper.BindEnv("oauth_redirect_base_url", "OAUTH_REDIRECT_BASE_URL")      //nolint:errcheck
-	viper.BindEnv("oauth_allowed_emails", "OAUTH_ALLOWED_EMAILS")            //nolint:errcheck
-	viper.BindEnv("oauth_default_role", "OAUTH_DEFAULT_ROLE")                //nolint:errcheck
-	viper.BindEnv("cf_access_team_domain", "CF_ACCESS_TEAM_DOMAIN")          //nolint:errcheck
-	viper.BindEnv("cf_access_aud", "CF_ACCESS_AUD")                         //nolint:errcheck
+	viper.BindEnv("oauth_redirect_base_url", "OAUTH_REDIRECT_BASE_URL")       //nolint:errcheck
+	viper.BindEnv("oauth_allowed_emails", "OAUTH_ALLOWED_EMAILS")             //nolint:errcheck
+	viper.BindEnv("oauth_default_role", "OAUTH_DEFAULT_ROLE")                 //nolint:errcheck
+	viper.BindEnv("cf_access_team_domain", "CF_ACCESS_TEAM_DOMAIN")           //nolint:errcheck
+	viper.BindEnv("cf_access_aud", "CF_ACCESS_AUD")                           //nolint:errcheck
 
 	// Set memory management defaults
 	viper.SetDefault("memory_limit_type", "items")
@@ -1191,16 +1215,23 @@ func InitConfig() {
 			BasicAuthUsername:                viper.GetString("basic_auth_username"),
 			BasicAuthPassword:                viper.GetString("basic_auth_password"),
 
-			OAuthEnabled:            viper.GetBool("oauth_enabled"),
-			OAuthGithubClientID:     viper.GetString("oauth_github_client_id"),
-			OAuthGithubClientSecret: viper.GetString("oauth_github_client_secret"),
-			OAuthGoogleClientID:     viper.GetString("oauth_google_client_id"),
-			OAuthGoogleClientSecret: viper.GetString("oauth_google_client_secret"),
-			OAuthRedirectBaseURL:    viper.GetString("oauth_redirect_base_url"),
-			OAuthAllowedEmails:      viper.GetString("oauth_allowed_emails"),
-			OAuthDefaultRole:        viper.GetString("oauth_default_role"),
-			CFAccessTeamDomain:      viper.GetString("cf_access_team_domain"),
-			CFAccessAUD:             viper.GetString("cf_access_aud"),
+			// Env-first (os.Getenv), viper fallback. viper's env binding does NOT
+			// reliably surface a systemd-set env var into config at runtime in this app
+			// (config comes from config.yaml + the DB settings store); the established
+			// pattern is os.Getenv directly — see WHISPER_REMOTE_URL in
+			// internal/transcribe/batch.go. A systemd Environment= drop-in value was
+			// silently dropped when these were viper-only (2026-07-26 Cloudflare Access
+			// passthrough never initialized).
+			OAuthEnabled:            envOrBool(os.Getenv("OAUTH_ENABLED"), viper.GetBool("oauth_enabled")),
+			OAuthGithubClientID:     envOr(os.Getenv("OAUTH_GITHUB_CLIENT_ID"), viper.GetString("oauth_github_client_id")),
+			OAuthGithubClientSecret: envOr(os.Getenv("OAUTH_GITHUB_CLIENT_SECRET"), viper.GetString("oauth_github_client_secret")),
+			OAuthGoogleClientID:     envOr(os.Getenv("OAUTH_GOOGLE_CLIENT_ID"), viper.GetString("oauth_google_client_id")),
+			OAuthGoogleClientSecret: envOr(os.Getenv("OAUTH_GOOGLE_CLIENT_SECRET"), viper.GetString("oauth_google_client_secret")),
+			OAuthRedirectBaseURL:    envOr(os.Getenv("OAUTH_REDIRECT_BASE_URL"), viper.GetString("oauth_redirect_base_url")),
+			OAuthAllowedEmails:      envOr(os.Getenv("OAUTH_ALLOWED_EMAILS"), viper.GetString("oauth_allowed_emails")),
+			OAuthDefaultRole:        envOr(os.Getenv("OAUTH_DEFAULT_ROLE"), viper.GetString("oauth_default_role")),
+			CFAccessTeamDomain:      envOr(os.Getenv("CF_ACCESS_TEAM_DOMAIN"), viper.GetString("cf_access_team_domain")),
+			CFAccessAUD:             envOr(os.Getenv("CF_ACCESS_AUD"), viper.GetString("cf_access_aud")),
 
 			// Memory management
 			MemoryLimitType:           viper.GetString("memory_limit_type"),

--- a/internal/server/middleware/cfaccess.go
+++ b/internal/server/middleware/cfaccess.go
@@ -7,6 +7,7 @@ package middleware
 
 import (
 	"github.com/gin-gonic/gin"
+	"log/slog"
 
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -41,18 +42,30 @@ func CloudflareAccessAuth(a *CFAccessAuthenticator) gin.HandlerFunc {
 			c.Next()
 			return
 		}
+		// Prefer the Cf-Access-Jwt-Assertion header; fall back to the CF_Authorization
+		// cookie (browser flows may deliver only the cookie — Cloudflare says the header
+		// is "not guaranteed to be passed" in some setups).
 		raw := c.GetHeader(oauth.CFAccessHeader)
+		if raw == "" {
+			if ck, err := c.Cookie("CF_Authorization"); err == nil {
+				raw = ck
+			}
+		}
 		if raw == "" {
 			c.Next()
 			return
 		}
 		claims, err := a.verifier.Verify(c.Request.Context(), raw)
 		if err != nil {
-			c.Next() // not a valid Access token — let normal auth handle it
+			// Diagnostic: a JWT was present but did not verify (aud/issuer/keyset/expiry).
+			// Rate-limited-ish by being Warn; falls through to normal auth.
+			slog.Warn("cfaccess: Access JWT present but verification failed", "err", err)
+			c.Next()
 			return
 		}
 		user, err := a.cfg.ResolveUser(a.store, *claims)
 		if err != nil {
+			slog.Warn("cfaccess: verified identity not admitted", "email", claims.Email, "err", err)
 			c.Next() // not allowlisted / not verified — normal auth will 401
 			return
 		}


### PR DESCRIPTION
**Root cause of the Cloudflare Access passthrough not working after deploy.**

The `CF_ACCESS_*` / `OAUTH_*` settings were wired via `viper.BindEnv`, but viper's env binding does **not** reliably surface a systemd-set env var into `config.AppConfig` at runtime in this app (config comes from config.yaml + the DB settings store). So the `Environment=` values in the systemd drop-in were confirmed on the unit (`systemctl show -p Environment`) but arrived **empty** in config — the CF Access middleware never initialized (no "passthrough enabled" startup log), and users kept hitting the app's own login instead of being auto-logged-in from their Cloudflare Access session.

**Fix:** read these env-first via `os.Getenv` (viper fallback), matching the established `WHISPER_REMOTE_URL` pattern already used elsewhere in the codebase precisely because viper env is unreliable here.

**Also hardened** (from the Cloudflare validating-JWT docs):
- CF Access middleware falls back to the `CF_Authorization` cookie when the `Cf-Access-Jwt-Assertion` header is absent.
- Logs at Warn when a present JWT fails verification or a verified identity isn't admitted — so a misconfig is never silent again.

Config-only + middleware-logging change; low risk. Verified with `go build ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt