### PR TITLE
feat(audioutil): chapter extraction and multi-file timeline primitives

### DIFF
--- a/changelog.d/20260729_010000_chapter_extraction.md
+++ b/changelog.d/20260729_010000_chapter_extraction.md
@@ -1,0 +1,36 @@
+<!-- file: changelog.d/20260729_010000_chapter_extraction.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8b0f5f8b-4d3c-4b7a-9f7d-2b6a1e0c5d97 -->
+<!-- last-edited: 2026-07-29 -->
+
+### Added
+
+#### Chapter extraction and multi-file timeline primitives (`internal/audioutil`)
+
+Added the chapter model and extraction/synthesis primitives that ABS Sync API Phase 4
+(`docs/specs/2026-07-29-abs-sync-api-design.md` §7) will persist and serve. This codebase
+had no chapter concept at all before this change — `ffprobe` was used for duration only.
+
+`internal/audioutil/chapters.go` adds `ProbeChapters`, which shells out to
+`ffprobe -show_chapters -print_format json` and parses each chapter's `start_time`/
+`end_time` string fields into a `Chapter{ID, StartSec, EndSec, Title}` (deliberately not
+the sibling `start`/`end` integer + `time_base` pair, to preserve full float precision). A
+file with no embedded chapters returns `(nil, nil)` — not an error.
+
+`internal/audioutil/timeline.go` adds the pure, I/O-free timeline math a multi-file book
+needs: `CumulativeOffsets` (running start offset per track), `SynthesizeChapters` (one
+synthetic chapter per track, title falling back to filename when the track has no title
+tag — mirroring real ABS behavior for multi-file books with no embedded chapters), and
+`ShiftChapters` (rebases a track's own embedded chapters onto the whole-book timeline).
+
+Verified against real Audiobookshelf 2.36.0 ground truth captured in
+`testdata/abs-fixtures/README.md` (items 3-4) and against the committed Odyssey
+(Butler/LibriVox) audio fixtures: the single-file m4b's 6 embedded chapters extract with
+`StartSec == 0` and the last `EndSec` matching the file's total duration
+(~9975.428s); the 6-track mp3 split's per-file durations reproduce the exact real ABS
+`startOffset` sequence (`0, 1386.057143, 2788.702041, 4309.211429, ...`) via
+`CumulativeOffsets`, confirmed with a sub-microsecond epsilon test.
+
+Persistence and scanner wiring (a `Chapter` DB type, `process_file.go` integration) are
+deliberately out of scope for this change to avoid colliding with parallel work on those
+shared files; this PR delivers only the extraction/synthesis primitives and their tests.

--- a/internal/audioutil/chapters.go
+++ b/internal/audioutil/chapters.go
@@ -1,0 +1,96 @@
+// file: internal/audioutil/chapters.go
+// version: 1.0.0
+// guid: 69dd107e-d06d-429a-9a3b-3c85551edf7e
+// last-edited: 2026-07-29
+
+package audioutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+)
+
+// ffprobeChaptersOutput mirrors the JSON shape of
+// `ffprobe -show_chapters -print_format json`. ffprobe reports each
+// chapter's boundaries two ways: start/end as integers paired with a
+// time_base fraction, and start_time/end_time as decimal-string seconds. We
+// deliberately parse the *_time string fields (see ProbeChapters) rather
+// than doing the start*time_base division ourselves, since that is exactly
+// what real ABS ground truth expects (float seconds with full precision,
+// not reconstructed from an integer+rational pair).
+type ffprobeChaptersOutput struct {
+	Chapters []ffprobeChapter `json:"chapters"`
+}
+
+type ffprobeChapter struct {
+	ID        int    `json:"id"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	Tags      struct {
+		Title string `json:"title"`
+	} `json:"tags"`
+}
+
+// ProbeChapters shells out to ffprobe and returns the container's embedded
+// chapter list, parsed from `-show_chapters -print_format json`.
+//
+// ffprobePath selects which ffprobe binary to invoke; pass "" to resolve
+// "ffprobe" from PATH, matching ProbeDurationSeconds's convention. ctx bounds
+// the subprocess.
+//
+// A file with no embedded chapters is NOT an error: ffprobe reports an empty
+// "chapters" array for e.g. a bare mp3 track, and ProbeChapters returns
+// (nil, nil) in that case so callers can distinguish "no chapters" from
+// "ffprobe failed" without inspecting the error. Chapter.Title is taken from
+// tags.title; if absent, it is left as the empty string and callers decide a
+// fallback (see SynthesizeChapters for the multi-file fallback-to-filename
+// case this mirrors in real ABS).
+func ProbeChapters(ctx context.Context, ffprobePath, filePath string) ([]Chapter, error) {
+	bin := ffprobePath
+	if bin == "" {
+		bin = "ffprobe"
+	}
+	cmd := exec.CommandContext(ctx, bin,
+		"-v", "error",
+		"-show_chapters",
+		"-print_format", "json",
+		filePath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("ffprobe chapters %s: %w: %s", filePath, err, stderr.String())
+	}
+
+	var parsed ffprobeChaptersOutput
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		return nil, fmt.Errorf("ffprobe chapters parse %s: %w", filePath, err)
+	}
+
+	if len(parsed.Chapters) == 0 {
+		return nil, nil
+	}
+
+	chapters := make([]Chapter, len(parsed.Chapters))
+	for i, c := range parsed.Chapters {
+		start, err := strconv.ParseFloat(c.StartTime, 64)
+		if err != nil {
+			return nil, fmt.Errorf("ffprobe chapters %s: chapter %d start_time %q: %w", filePath, i, c.StartTime, err)
+		}
+		end, err := strconv.ParseFloat(c.EndTime, 64)
+		if err != nil {
+			return nil, fmt.Errorf("ffprobe chapters %s: chapter %d end_time %q: %w", filePath, i, c.EndTime, err)
+		}
+		chapters[i] = Chapter{
+			ID:       c.ID,
+			StartSec: start,
+			EndSec:   end,
+			Title:    c.Tags.Title,
+		}
+	}
+	return chapters, nil
+}

--- a/internal/audioutil/chapters_test.go
+++ b/internal/audioutil/chapters_test.go
@@ -1,0 +1,172 @@
+// file: internal/audioutil/chapters_test.go
+// version: 1.0.0
+// guid: 0699787d-233a-4b4c-a830-c5069e762c00
+// last-edited: 2026-07-29
+
+package audioutil
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// odysseyM4B is the real, committed 115 MB fixture with 6 embedded chapters.
+// See testdata/abs-fixtures/README.md item 4 for the ABS ground truth this
+// mirrors: the single-file m4b's 6 real embedded chapters are reported as-is.
+const odysseyM4B = "../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4b"
+
+// odysseyMP3Track1 is one of the 6 per-chapter mp3 fixtures for the same
+// book. Individual tracks carry no embedded chapter metadata (confirmed via
+// `ffprobe -show_chapters` returning an empty chapters array), which is the
+// no-chapters-is-not-an-error case ProbeChapters must handle.
+const odysseyMP3Track1 = "../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_01_homer_butler_64kb.mp3"
+
+func requireFFprobe(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not found on PATH, skipping")
+	}
+}
+
+func requireFixture(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("fixture missing at %s, skipping: %v", path, err)
+	}
+}
+
+func TestProbeChapters_NoChapters_NotAnError(t *testing.T) {
+	requireFFprobe(t)
+	requireFixture(t, odysseyMP3Track1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	chs, err := ProbeChapters(ctx, "", odysseyMP3Track1)
+	if err != nil {
+		t.Fatalf("ProbeChapters(%s) returned error, want nil for a file with no chapters: %v", odysseyMP3Track1, err)
+	}
+	if chs != nil {
+		t.Fatalf("ProbeChapters(%s) = %v, want nil for a file with no chapters", odysseyMP3Track1, chs)
+	}
+}
+
+func TestProbeChapters_MissingFile_ReturnsWrappedError(t *testing.T) {
+	requireFFprobe(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := ProbeChapters(ctx, "", filepath.Join(t.TempDir(), "does-not-exist.m4b"))
+	if err == nil {
+		t.Fatal("ProbeChapters on a missing file returned nil error, want a wrapped error")
+	}
+}
+
+func TestProbeChapters_BadFFprobePath_ReturnsWrappedError(t *testing.T) {
+	requireFixture(t, odysseyMP3Track1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := ProbeChapters(ctx, "/nonexistent/ffprobe-binary-xyz", odysseyMP3Track1)
+	if err == nil {
+		t.Fatal("ProbeChapters with a nonexistent ffprobe binary returned nil error, want a wrapped error")
+	}
+}
+
+// TestProbeChapters_OdysseyM4B_SixEmbeddedChapters is the integration test
+// against the real 115 MB fixture. Ground truth (captured directly via
+// `ffprobe -v error -show_chapters -print_format json` against this exact
+// file, matching the task's stated values): 6 chapters, first starts at
+// 0.000000 titled "Chapter 1: odyssey_01_homer_butler_64kb", starts strictly
+// increasing, last EndSec ~= 9975.428 (total duration ~= 9975.48s).
+func TestProbeChapters_OdysseyM4B_SixEmbeddedChapters(t *testing.T) {
+	requireFFprobe(t)
+	requireFixture(t, odysseyM4B)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	chs, err := ProbeChapters(ctx, "", odysseyM4B)
+	if err != nil {
+		t.Fatalf("ProbeChapters(%s) error: %v", odysseyM4B, err)
+	}
+	if len(chs) != 6 {
+		t.Fatalf("ProbeChapters(%s) returned %d chapters, want 6", odysseyM4B, len(chs))
+	}
+
+	if chs[0].StartSec != 0 {
+		t.Errorf("chs[0].StartSec = %v, want 0", chs[0].StartSec)
+	}
+	wantFirstTitle := "Chapter 1: odyssey_01_homer_butler_64kb"
+	if chs[0].Title != wantFirstTitle {
+		t.Errorf("chs[0].Title = %q, want %q", chs[0].Title, wantFirstTitle)
+	}
+
+	for i := 1; i < len(chs); i++ {
+		if chs[i].StartSec <= chs[i-1].StartSec {
+			t.Errorf("chapter starts not monotonically increasing at index %d: chs[%d].StartSec=%v <= chs[%d].StartSec=%v",
+				i, i, chs[i].StartSec, i-1, chs[i-1].StartSec)
+		}
+		// ABS's own contract: each chapter's start immediately follows the
+		// previous chapter's end (no gaps) for embedded m4b chapters.
+		if !floatsClose(chs[i].StartSec, chs[i-1].EndSec) {
+			t.Errorf("chapter %d start (%v) does not match chapter %d end (%v)", i, chs[i].StartSec, i-1, chs[i-1].EndSec)
+		}
+	}
+
+	const wantTotalDuration = 9975.428
+	lastEnd := chs[len(chs)-1].EndSec
+	if diff := lastEnd - wantTotalDuration; diff > 0.01 || diff < -0.01 {
+		t.Errorf("last chapter EndSec = %v, want ~= %v (within 0.01s)", lastEnd, wantTotalDuration)
+	}
+
+	for i, c := range chs {
+		if c.ID != i {
+			t.Errorf("chs[%d].ID = %d, want %d", i, c.ID, i)
+		}
+	}
+}
+
+// TestProbeChapters_JSONShape documents (via a table-free smoke check) that
+// ProbeChapters is parsing ffprobe's real JSON shape: start_time/end_time as
+// strings, not the sibling start/end integer+time_base pair. This guards
+// against silently falling back to the int fields, which the task explicitly
+// says must NOT be preferred.
+func TestProbeChapters_JSONShape(t *testing.T) {
+	// Sanity-check our own assumption about ffprobe's JSON shape using a
+	// literal captured sample (see task ground truth), independent of the
+	// fixture files, so this test never skips.
+	sample := []byte(`{
+		"chapters": [
+			{
+				"id": 0,
+				"time_base": "1/1000",
+				"start": 0,
+				"start_time": "0.000000",
+				"end": 1386057,
+				"end_time": "1386.057000",
+				"tags": {"title": "Chapter 1: odyssey_01_homer_butler_64kb"}
+			}
+		]
+	}`)
+	var parsed ffprobeChaptersOutput
+	if err := json.Unmarshal(sample, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal sample ffprobe chapters JSON: %v", err)
+	}
+	if len(parsed.Chapters) != 1 {
+		t.Fatalf("parsed %d chapters, want 1", len(parsed.Chapters))
+	}
+	if parsed.Chapters[0].StartTime != "0.000000" {
+		t.Errorf("StartTime = %q, want %q", parsed.Chapters[0].StartTime, "0.000000")
+	}
+	if parsed.Chapters[0].EndTime != "1386.057000" {
+		t.Errorf("EndTime = %q, want %q", parsed.Chapters[0].EndTime, "1386.057000")
+	}
+}

--- a/internal/audioutil/timeline.go
+++ b/internal/audioutil/timeline.go
@@ -1,0 +1,92 @@
+// file: internal/audioutil/timeline.go
+// version: 1.0.0
+// guid: 4a87c956-6abc-4362-a3ac-578108f0387d
+// last-edited: 2026-07-29
+
+package audioutil
+
+// Chapter is a single navigable chapter entry, matching the shape a real
+// Audiobookshelf 2.36.0 server reports: {id, start, end, title} with start/end
+// in float seconds. See docs/specs/2026-07-29-abs-sync-api-design.md §1 and
+// testdata/abs-fixtures/README.md items 3-4 for the ground truth this mirrors.
+type Chapter struct {
+	ID       int
+	StartSec float64
+	EndSec   float64
+	Title    string
+}
+
+// TrackInfo is the minimal per-file input SynthesizeChapters needs to build
+// one synthetic chapter per audio file for a multi-file book.
+type TrackInfo struct {
+	// Title is the track's embedded title tag (e.g. "The Odyssey: Book 01").
+	// Real ABS prefers this over the filename when present.
+	Title string
+	// Filename is the fallback chapter title used when Title is empty.
+	Filename string
+	// DurationSec is the track's duration in seconds, unrounded.
+	DurationSec float64
+}
+
+// CumulativeOffsets returns the running start offset of each duration in
+// durations: offsets[0] == 0, offsets[i] == sum(durations[0:i]). This is the
+// same arithmetic ABS uses to compute multi-file startOffset values (see
+// testdata/abs-fixtures/README.md item 3: "0, 1386.057143, 2788.702041, ...").
+// No rounding is applied at any step.
+func CumulativeOffsets(durations []float64) []float64 {
+	if len(durations) == 0 {
+		return nil
+	}
+	offsets := make([]float64, len(durations))
+	var running float64
+	for i, d := range durations {
+		offsets[i] = running
+		running += d
+	}
+	return offsets
+}
+
+// SynthesizeChapters builds one chapter per track with cumulative start/end
+// offsets, mirroring real ABS behavior for a multi-file book with no embedded
+// chapters (testdata/abs-fixtures/README.md item 4): chapter IDs start at 0,
+// and each chapter's title is the track's Title if non-empty, else its
+// Filename.
+func SynthesizeChapters(tracks []TrackInfo) []Chapter {
+	if len(tracks) == 0 {
+		return nil
+	}
+	chapters := make([]Chapter, len(tracks))
+	var start float64
+	for i, t := range tracks {
+		end := start + t.DurationSec
+		title := t.Title
+		if title == "" {
+			title = t.Filename
+		}
+		chapters[i] = Chapter{ID: i, StartSec: start, EndSec: end, Title: title}
+		start = end
+	}
+	return chapters
+}
+
+// ShiftChapters returns a copy of chs with every StartSec/EndSec shifted by
+// offsetSec, leaving ID and Title untouched and the input slice unmodified.
+// Used when a multi-file book's individual files each carry their own
+// embedded chapters that must be rebased onto the whole-book timeline (e.g.
+// track 3 starts at cumulative offset X, so its embedded chapters must be
+// shifted by X before being merged into the book-level chapter list).
+func ShiftChapters(chs []Chapter, offsetSec float64) []Chapter {
+	if len(chs) == 0 {
+		return nil
+	}
+	shifted := make([]Chapter, len(chs))
+	for i, c := range chs {
+		shifted[i] = Chapter{
+			ID:       c.ID,
+			StartSec: c.StartSec + offsetSec,
+			EndSec:   c.EndSec + offsetSec,
+			Title:    c.Title,
+		}
+	}
+	return shifted
+}

--- a/internal/audioutil/timeline_test.go
+++ b/internal/audioutil/timeline_test.go
@@ -1,0 +1,144 @@
+// file: internal/audioutil/timeline_test.go
+// version: 1.0.0
+// guid: 7fd599c0-529b-4987-acdd-d87d40c32802
+// last-edited: 2026-07-29
+
+package audioutil
+
+import (
+	"math"
+	"testing"
+)
+
+const epsilon = 1e-6
+
+func floatsClose(a, b float64) bool {
+	return math.Abs(a-b) < epsilon
+}
+
+func TestCumulativeOffsets_Empty(t *testing.T) {
+	got := CumulativeOffsets(nil)
+	if len(got) != 0 {
+		t.Fatalf("CumulativeOffsets(nil) = %v, want empty", got)
+	}
+}
+
+func TestCumulativeOffsets_Single(t *testing.T) {
+	got := CumulativeOffsets([]float64{42.5})
+	want := []float64{0}
+	if len(got) != len(want) || !floatsClose(got[0], want[0]) {
+		t.Fatalf("CumulativeOffsets([42.5]) = %v, want %v", got, want)
+	}
+}
+
+// TestCumulativeOffsets_RealOdysseyTracks reproduces the real ABS ground-truth
+// startOffset values captured from a live Audiobookshelf 2.36.0 server for the
+// 6-file Odyssey (Butler/LibriVox) book: 0, 1386.057143, 2788.702041,
+// 4309.211429, ... (see testdata/abs-fixtures/README.md item 3). The input
+// durations here are the real ffprobe-reported durations of the 6 committed
+// mp3 fixtures. This test intentionally uses exact literal float values (not
+// rounded) and a small epsilon, per the task's float-precision requirement.
+func TestCumulativeOffsets_RealOdysseyTracks(t *testing.T) {
+	durations := []float64{
+		1386.057143,
+		1402.644898,
+		1520.509388,
+		2619.767800,
+		1673.221224,
+		1373.230658,
+	}
+	want := []float64{
+		0,
+		1386.057143,
+		2788.702041,
+		4309.211429,
+		6928.979229,
+		8602.200453,
+	}
+	got := CumulativeOffsets(durations)
+	if len(got) != len(want) {
+		t.Fatalf("CumulativeOffsets returned %d offsets, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !floatsClose(got[i], want[i]) {
+			t.Errorf("offset[%d] = %v, want %v (diff %v)", i, got[i], want[i], math.Abs(got[i]-want[i]))
+		}
+	}
+}
+
+func TestSynthesizeChapters_TitleFallsBackToFilename(t *testing.T) {
+	tracks := []TrackInfo{
+		{Title: "The Odyssey: Book 01", Filename: "odyssey_01_homer_butler_64kb.mp3", DurationSec: 1386.057143},
+		{Title: "", Filename: "odyssey_02_homer_butler_64kb.mp3", DurationSec: 1402.644898},
+	}
+	chs := SynthesizeChapters(tracks)
+	if len(chs) != 2 {
+		t.Fatalf("SynthesizeChapters returned %d chapters, want 2", len(chs))
+	}
+	if chs[0].ID != 0 || chs[1].ID != 1 {
+		t.Errorf("chapter IDs = %d, %d, want 0, 1", chs[0].ID, chs[1].ID)
+	}
+	if chs[0].Title != "The Odyssey: Book 01" {
+		t.Errorf("chs[0].Title = %q, want %q", chs[0].Title, "The Odyssey: Book 01")
+	}
+	if chs[1].Title != "odyssey_02_homer_butler_64kb.mp3" {
+		t.Errorf("chs[1].Title (fallback) = %q, want filename", chs[1].Title)
+	}
+	if !floatsClose(chs[0].StartSec, 0) {
+		t.Errorf("chs[0].StartSec = %v, want 0", chs[0].StartSec)
+	}
+	if !floatsClose(chs[0].EndSec, 1386.057143) {
+		t.Errorf("chs[0].EndSec = %v, want 1386.057143", chs[0].EndSec)
+	}
+	if !floatsClose(chs[1].StartSec, chs[0].EndSec) {
+		t.Errorf("chs[1].StartSec = %v, want to match chs[0].EndSec = %v", chs[1].StartSec, chs[0].EndSec)
+	}
+	wantEnd := 1386.057143 + 1402.644898
+	if !floatsClose(chs[1].EndSec, wantEnd) {
+		t.Errorf("chs[1].EndSec = %v, want %v", chs[1].EndSec, wantEnd)
+	}
+}
+
+func TestSynthesizeChapters_Empty(t *testing.T) {
+	got := SynthesizeChapters(nil)
+	if len(got) != 0 {
+		t.Fatalf("SynthesizeChapters(nil) = %v, want empty", got)
+	}
+}
+
+func TestShiftChapters(t *testing.T) {
+	in := []Chapter{
+		{ID: 0, StartSec: 0, EndSec: 100.5, Title: "Chapter 1"},
+		{ID: 1, StartSec: 100.5, EndSec: 250.25, Title: "Chapter 2"},
+	}
+	got := ShiftChapters(in, 4309.211429)
+	if len(got) != 2 {
+		t.Fatalf("ShiftChapters returned %d chapters, want 2", len(got))
+	}
+	if !floatsClose(got[0].StartSec, 4309.211429) {
+		t.Errorf("got[0].StartSec = %v, want %v", got[0].StartSec, 4309.211429)
+	}
+	if !floatsClose(got[0].EndSec, 4309.211429+100.5) {
+		t.Errorf("got[0].EndSec = %v, want %v", got[0].EndSec, 4309.211429+100.5)
+	}
+	if !floatsClose(got[1].StartSec, 4309.211429+100.5) {
+		t.Errorf("got[1].StartSec = %v, want %v", got[1].StartSec, 4309.211429+100.5)
+	}
+	if got[0].Title != "Chapter 1" || got[1].Title != "Chapter 2" {
+		t.Errorf("ShiftChapters must not alter titles, got %q, %q", got[0].Title, got[1].Title)
+	}
+	if got[0].ID != 0 || got[1].ID != 1 {
+		t.Errorf("ShiftChapters must not alter IDs, got %d, %d", got[0].ID, got[1].ID)
+	}
+	// Original slice must not be mutated.
+	if !floatsClose(in[0].StartSec, 0) {
+		t.Errorf("ShiftChapters mutated its input: in[0].StartSec = %v, want 0", in[0].StartSec)
+	}
+}
+
+func TestShiftChapters_ZeroOffsetEmpty(t *testing.T) {
+	got := ShiftChapters(nil, 0)
+	if len(got) != 0 {
+		t.Fatalf("ShiftChapters(nil, 0) = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

This codebase had **no chapter model at all** — `ffprobe` was used for duration only. ABS clients render and seek by chapter and never parse the audio file themselves, so the server must supply chapters.

Adds two new files to `internal/audioutil` (no shared files touched):
- `chapters.go` — `ProbeChapters` via `ffprobe -show_chapters -print_format json`. Parses the `start_time`/`end_time` **string** fields rather than the `start`/`end` int + `time_base` pair. A file with no chapters returns `(nil, nil)` — that's not an error.
- `timeline.go` — pure, I/O-free: `CumulativeOffsets`, `SynthesizeChapters`, `ShiftChapters`.

## Ground truth, matched exactly

Real ABS synthesizes one chapter per file for multi-file books, titled from the embedded **title tag** (not the filename). Verified against the committed LibriVox fixtures — the same book exists as both a 6-file mp3 set and a single m4b with 6 real embedded chapters:

```
{ID: 0, Start: 0.000000,    End: 1386.057000, Title: "Chapter 1: odyssey_01_..."}
{ID: 1, Start: 1386.057000, End: 2788.701000, Title: "Chapter 2: odyssey_02_..."}
```

Cumulative offsets reproduce the real server's values **exactly**: `[0, 1386.057143, 2788.702041, 4309.211429]`. Floats are not rounded — there's a test asserting this against the captured fixture values with a 1e-6 epsilon.

## A finding worth knowing

The three available "durations" disagree by ~52ms — m4b container `9975.480544`, m4b last-chapter end `9975.428000`, sum of mp3 tracks `9975.431111`. Structural, not sloppiness: m4b chapter marks are millisecond-quantized (`time_base 1/1000`) while track durations are frame-accurate.

This is a latent bug for finished-detection: with a tight epsilon, a book played to the end of its final chapter **never auto-marks finished** and sits at 99% forever. Recorded in the spec (§5b) with a mandated ≥2s tolerance and a single authoritative duration.

## Scope

Extraction + timeline primitives only. Persistence (a DB chapter type) and scanner wiring are deliberately **out of scope** to avoid colliding with parallel work — `store.go`, `process_file.go`, `go.mod`, `go.sum` untouched.

## Test plan

TDD — tests first, 11 `undefined:` build failures confirmed before implementing.

```
go test ./internal/audioutil/ -race -count=1 -v → PASS (17 tests, incl. pre-existing duration suite)
go vet ./internal/audioutil/                    → clean
gofmt -l internal/audioutil/                    → clean
```

Integration tests use the committed fixtures and `t.Skip` gracefully if `ffprobe` or the fixture is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt