### PR TITLE
feat(abs-sync): add pure progress-merge policy package (#TASK-08)

### DIFF
--- a/changelog.d/20260730_abs_sync_progress_merge_policy.md
+++ b/changelog.d/20260730_abs_sync_progress_merge_policy.md
@@ -1,0 +1,83 @@
+<!-- file: changelog.d/20260730_abs_sync_progress_merge_policy.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f62b62db-6859-4ff2-920e-9dbce91be438 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+#### Progress conflict-resolution policy (`internal/syncapi/progress`)
+
+Added the pure, I/O-free decision functions implementing the ABS Sync API progress
+conflict-resolution rules from `docs/specs/2026-07-29-abs-sync-api-design.md` §5, §5b and
+§1.8.7. Nothing here imports `internal/database`, touches HTTP, or reads the clock —
+callers pass every timestamp in explicitly — so every rule the spec locks down is
+deterministically unit-testable ahead of the Phase-6 `UserBookState`/`UserPosition` store
+adapter and the handlers that will call it. Modeled on the sibling pure package
+`internal/audioutil` (`CumulativeOffsets`, `SynthesizeChapters`). No production wiring
+yet; this change is standalone and has no callers.
+
+The base rule is §5's newer-wins-with-forward-only-fallback: a strictly newer
+`updatedAt` is accepted wholesale, and an *older* update is accepted **only** when its
+position is ahead of the server's. That asymmetry is the whole point — an offline device
+that listened further while offline must still advance the position, while one that is
+merely behind can never rewind newer server progress. A rejected merge returns the stored
+record field-for-field untouched, which the tests assert with `reflect.DeepEqual` rather
+than only checking the accept flag. A stale-but-ahead accept advances `UpdatedAtMs`
+monotonically (it never moves the stored timestamp backwards), since a rewound server
+timestamp would make the *next* update from any device falsely look newer and win a
+conflict it should lose.
+
+**Three different merge entry points, deliberately not one.** The two rules that both
+sound like "don't go backwards" are separate mechanisms for separate endpoints and must
+not share a code path:
+
+- `MergeIncoming` — `POST /api/session/:id/sync`, where clients do not send `isFinished`
+  at all and the server derives it. Finished is **sticky** here: it is OR'd with the
+  tolerance check and never cleared, because this endpoint has no way to express
+  "un-finish".
+- `MergeExplicit` — `PATCH /api/me/progress/:id`, where Absorb *does* send `isFinished`
+  and the server must honour rather than contradict it. Only a strictly-newer update may
+  override the stored flag, including clearing it (re-opening a finished book, which ABS
+  allows); that true→false transition also resets the position to 0, mirroring real ABS
+  "mark as not started". A forward-only accept can never carry an explicit `isFinished`,
+  so it keeps the sticky behaviour.
+- `MergeOfflineReplay` — `POST /api/session/local[-all]`, where timestamps are
+  **unusable**: offline clients re-stamp stale backlog entries with `updatedAt = now`
+  before replaying them, so a far-behind position arrives looking newer. This guard
+  ignores timestamps entirely and is forward-only on position alone. A regression test
+  feeds the same inputs to both functions and asserts `MergeIncoming` accepts while
+  `MergeOfflineReplay` rejects — which is exactly why they are two functions.
+
+`MergeCombine` covers the dedup merge-follow case (§5 rule 5): two previously independent
+progress records for what turned out to be one book are combined unconditionally with
+max-position / OR-finished / max-timestamp, since both are real device positions and
+there is no staleness question to answer.
+
+**Why the finished tolerance is 2 seconds, not an epsilon.** A single book has three
+legitimate, mutually disagreeing durations, measured on the committed Odyssey fixture:
+m4b container `9975.480544`, m4b last-chapter-end `9975.428000`, and sum-of-mp3-tracks
+`9975.431111`. The ~52 ms spread is structural (m4b chapter marks are millisecond-
+quantized via `time_base 1/1000` while per-track durations are frame-accurate), so a
+client that plays to the end of the final *chapter* stops short of the *container*
+duration. With a tight epsilon a fully listened book never auto-marks finished and sits
+at 99% forever; `FinishedToleranceSec = 2.0` is comfortably above the worst inter-source
+skew and far below a meaningful amount of audio. A regression test drives a merge at the
+real last-chapter-end position and asserts finished becomes true.
+
+Also included, each with the silent-failure mode it prevents:
+
+- `NextServerTimestampMs` — AudioBooth compares `lastUpdate` with strict `>` *after*
+  truncating both sides via integer `/1000`, so two writes inside the same wall-clock
+  second compare equal and the client's cached value wins, silently discarding the
+  server's update. This returns a stamp guaranteed to beat that tie-break by a whole
+  second, without inflating a timestamp that is already ahead.
+- `AddListenedDelta` vs `SetListenedCumulative` — `/sync`'s `timeListened` (past tense)
+  is a **delta to add**, while `/session/local[-all]`'s `timeListening` (gerund) is a
+  **cumulative set**. Reading the wrong key records zero listening time from both
+  clients (a known reference implementation does exactly this). The delta form clamps
+  non-positive values instead of subtracting; the cumulative form is idempotent and
+  forward-only so a replayed session cannot rewind the total. Both discard NaN and
+  infinities rather than poisoning the stored total.
+- `ValidateFinishedDuration` — sending `isFinished: true` without a duration zeroes the
+  client's position, so `Progress.Duration` is a required non-pointer field and this
+  guard is checkable before the future DTO layer serializes a response body.

--- a/internal/syncapi/progress/policy.go
+++ b/internal/syncapi/progress/policy.go
@@ -1,0 +1,342 @@
+// file: internal/syncapi/progress/policy.go
+// version: 1.0.0
+// guid: f93d8147-df19-4993-a09b-39f727b522ad
+// last-edited: 2026-07-30
+
+// Package progress implements the ABS-sync progress conflict-resolution policy
+// from docs/specs/2026-07-29-abs-sync-api-design.md §5, §5b and §1.8.7 as pure,
+// I/O-free decision functions.
+//
+// "Pure" is load-bearing: nothing here imports internal/database, touches HTTP,
+// or reads the clock. Callers pass every timestamp in explicitly (see
+// NextServerTimestampMs's nowMs parameter), which makes each rule in §5
+// deterministically unit-testable ahead of the Phase-6 UserBookState /
+// UserPosition store adapter and the handlers that will eventually call it.
+// This package is modeled on the sibling pure package internal/audioutil
+// (CumulativeOffsets, SynthesizeChapters).
+//
+// Every rule below exists because a real client silently loses data without it;
+// the per-function doc comments cite the spec section and, where the spec cites
+// one, the client source line that proves it.
+package progress
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// Progress is the pure (user, item) progress record this package operates on.
+// "item" is deliberately opaque here (a raw Book ULID today, an ABS sync_item
+// syncID once TASK-01 ships) — this package does not know or care which
+// identity scheme the caller uses.
+type Progress struct {
+	// CurrentTime is the whole-book position in seconds. It is never a
+	// percentage, and per spec §1.8.7 it must be the user's true latest
+	// position — AudioBooth takes max() on position at session start while
+	// ignoring timestamps (SessionManager.swift:175-180), so a session-start
+	// snapshot or 0 here silently rewinds the client.
+	CurrentTime float64
+
+	// Duration is the book's duration in seconds. Spec §5b: pick ONE
+	// authoritative duration per book (sum-of-tracks recommended) and pass it
+	// consistently — this package does not compute duration, it only compares
+	// against it. It is a required non-pointer float64 specifically so
+	// ValidateFinishedDuration can enforce §1.8.7's null-duration invariant
+	// before the DTO layer ever serializes a response.
+	Duration float64
+
+	// IsFinished is derived by the server on the /sync path and supplied by the
+	// client on the PATCH /api/me/progress/:id path — see MergeIncoming versus
+	// MergeExplicit.
+	IsFinished bool
+
+	// UpdatedAtMs is a millisecond epoch, server-authoritative once stored.
+	// Spec §1.7.3 #1: this is the single highest-value field in the whole
+	// protocol — omit it and the server permanently loses every conflict,
+	// because clients compare it against their own wall clock and ties go to
+	// the client.
+	UpdatedAtMs int64
+}
+
+// FinishedToleranceSec is the §5b tolerance: currentTime within this many
+// seconds of duration counts as finished. Measured worst-case
+// container/chapter/track-sum skew on a real m4b is ~52ms (9975.480544 vs
+// 9975.428000 vs 9975.431111 for the same book — m4b chapter marks are
+// millisecond-quantized via time_base 1/1000 while per-track durations are
+// frame-accurate); 2s is comfortably above that and far below a meaningful
+// amount of unlistened audio. A tighter epsilon means a fully-listened book
+// never auto-marks finished and sits at 99% forever.
+const FinishedToleranceSec = 2.0
+
+// ErrFinishedWithoutDuration is returned by ValidateFinishedDuration for a
+// Progress that claims IsFinished with no positive Duration. Callers should
+// match it with errors.Is.
+var ErrFinishedWithoutDuration = errors.New("progress marked finished without a positive duration")
+
+// IsWithinFinishedTolerance reports whether currentTime has reached duration
+// within FinishedToleranceSec (spec §5b). A non-positive duration is never
+// within tolerance: duration is unknown at that point, so claiming "finished"
+// would both be a guess and trip §1.8.7's null-duration trap.
+func IsWithinFinishedTolerance(currentTime, duration float64) bool {
+	if duration <= 0 || math.IsNaN(duration) || math.IsNaN(currentTime) {
+		return false
+	}
+	return currentTime >= duration-FinishedToleranceSec
+}
+
+// applyBaseRules implements the two §5 base rules that MergeIncoming and
+// MergeExplicit share, and nothing else — it deliberately does NOT decide
+// IsFinished, because that is exactly where those two endpoints differ (server-
+// derived on /sync, client-supplied on PATCH /api/me/progress/:id). The
+// returned Progress carries whatever IsFinished the winning record had; every
+// caller must overwrite it.
+//
+//   - Rule 2, newer wins: incoming.UpdatedAtMs strictly greater -> take
+//     incoming wholesale, with one carve-out: Duration is not a position, so a
+//     payload that omits it (Duration <= 0) keeps the server's known duration
+//     rather than erasing it. Erasing it would disable finished-detection
+//     outright (§5b's "sits at 99% forever") and make any later isFinished
+//     response trip §1.8.7's null-duration trap, which zeroes the client's
+//     position. A positive incoming Duration always wins.
+//   - Rule 3, stale device forward-only: otherwise accept only if
+//     incoming.CurrentTime > server.CurrentTime. A stale device that listened
+//     further while offline still advances; a stale device that is behind can
+//     never rewind newer server progress. An equal timestamp counts as "not
+//     newer" and therefore lands here.
+//
+// viaNewerWins reports which branch accepted, so MergeExplicit can restrict
+// client-supplied isFinished handling to the strictly-newer branch.
+//
+// MergeOfflineReplay deliberately does NOT call this helper: its whole point is
+// that timestamps are unusable, so it must not share a code path with rules
+// that consult them.
+func applyBaseRules(server, incoming Progress) (result Progress, accepted, viaNewerWins bool) {
+	if incoming.UpdatedAtMs > server.UpdatedAtMs {
+		result = incoming
+		if result.Duration <= 0 {
+			result.Duration = server.Duration
+		}
+		return result, true, true
+	}
+	if incoming.CurrentTime > server.CurrentTime {
+		result = server
+		result.CurrentTime = incoming.CurrentTime
+		// "Advance" UpdatedAtMs monotonically. On this branch incoming's
+		// timestamp is <= the server's by construction, so taking the max
+		// leaves the server's value in place: a stale-but-ahead accept must
+		// never rewind the stored timestamp, or the next update from any device
+		// would falsely look newer and win a conflict it should lose (spec
+		// §1.7.3 #1). The Phase-6 store adapter is expected to re-stamp the
+		// write with NextServerTimestampMs anyway.
+		if incoming.UpdatedAtMs > result.UpdatedAtMs {
+			result.UpdatedAtMs = incoming.UpdatedAtMs
+		}
+		// Duration is not a position and is never "stale": adopt a positive
+		// incoming duration so finished-detection has something to compare
+		// against even when the stored record predates duration probing. A
+		// zero/absent incoming duration never clobbers a known one.
+		if incoming.Duration > 0 {
+			result.Duration = incoming.Duration
+		}
+		return result, true, false
+	}
+	return server, false, false
+}
+
+// MergeIncoming implements spec §5 rules 2-4 for endpoints where the server
+// DERIVES isFinished (POST /api/session/:id/sync — clients do not send
+// isFinished/progress there, spec §1.8.7's amendment to §5). In order:
+//
+//  1. Newer wins: if incoming.UpdatedAtMs > server.UpdatedAtMs, accept incoming
+//     wholesale, EXCEPT isFinished, which is sticky-OR'd (rule 3 below) rather
+//     than overwritten, and EXCEPT an omitted Duration, which never wipes a
+//     known one (see applyBaseRules). Note this means a genuinely newer update
+//     is honoured even when it seeks backwards — only a STALE update is
+//     position-gated.
+//  2. Stale device, forward-only: otherwise (incoming not newer, including an
+//     equal timestamp) accept ONLY IF incoming.CurrentTime > server.CurrentTime
+//     — advance CurrentTime and UpdatedAtMs (monotonically; see
+//     applyBaseRules), still sticky-OR isFinished. A stale-and-behind update is
+//     rejected outright: accepted=false and result is the server record
+//     unchanged, field for field.
+//  3. Finished is sticky: result.IsFinished = server.IsFinished ||
+//     IsWithinFinishedTolerance(result.CurrentTime, result.Duration). Once true
+//     it can only ever become true again here — /sync has no path to clear it,
+//     because the client never sends isFinished on this endpoint at all (any
+//     value in incoming.IsFinished is ignored). MergeExplicit is the only path
+//     that can clear it.
+//
+// Returns the merged Progress and whether incoming caused any change.
+func MergeIncoming(server, incoming Progress) (result Progress, accepted bool) {
+	result, accepted, _ = applyBaseRules(server, incoming)
+	if !accepted {
+		return server, false
+	}
+	result.IsFinished = server.IsFinished || IsWithinFinishedTolerance(result.CurrentTime, result.Duration)
+	return result, true
+}
+
+// MergeExplicit implements the PATCH /api/me/progress/:id path, where Absorb
+// DOES send isFinished/progress explicitly and the server must honour rather
+// than contradict them (spec §1.8.7's amendment to §5). It applies the same
+// newer-wins / forward-only base rules as MergeIncoming, but:
+//
+//   - only when accepted via the "newer wins" branch may incoming.IsFinished
+//     override server.IsFinished — including clearing it back to false, i.e.
+//     "re-opening" a finished book, which ABS allows per spec §5 rule 4. On that
+//     branch the tolerance heuristic is deliberately NOT consulted: the client
+//     stated its intent, and second-guessing it is the "contradict" failure the
+//     spec forbids;
+//   - a strictly-newer isFinished true->false transition additionally resets
+//     result.CurrentTime to 0 (mirrors real ABS "mark as not started"). Duration
+//     survives the reset, so the response can never trip §1.8.7's
+//     null-duration trap.
+//
+// A forward-only accept via base rule 3 can NEVER carry an explicit isFinished
+// — /sync-style forward-only updates do not originate from a client that
+// supplies isFinished in this codepath — so that branch keeps MergeIncoming's
+// sticky-OR behaviour exactly.
+func MergeExplicit(server, incoming Progress) (result Progress, accepted bool) {
+	result, accepted, viaNewerWins := applyBaseRules(server, incoming)
+	if !accepted {
+		return server, false
+	}
+	if viaNewerWins {
+		result.IsFinished = incoming.IsFinished
+		if server.IsFinished && !incoming.IsFinished {
+			result.CurrentTime = 0
+		}
+		return result, true
+	}
+	result.IsFinished = server.IsFinished || IsWithinFinishedTolerance(result.CurrentTime, result.Duration)
+	return result, true
+}
+
+// MergeOfflineReplay implements the abs-shim-derived guard for
+// POST /api/session/local[-all] (spec §1.8.7 last bullet, abs-shim
+// src/index.ts:534-541 — a distinct requirement from §1.7.3 #2's "return 200
+// for unknown IDs" rule, which is an HTTP-layer concern for a later task, not
+// this function's job).
+//
+// Offline clients re-stamp stale backlog entries with updatedAt = now before
+// replaying them, which defeats a timestamp-based comparison outright: a
+// backlog entry can look "newer" by timestamp while its position is far behind
+// current server state. This guard therefore IGNORES timestamps entirely and is
+// forward-only on CurrentTime alone — accept iff
+// incoming.CurrentTime > server.CurrentTime.
+//
+// When accepted, UpdatedAtMs is bumped via NextServerTimestampMs so downstream
+// conflict checks (and the client's own truncated-seconds comparison) see a
+// fresh write rather than the replayed entry's fictional timestamp; the
+// incoming stamp is used only as the "now" input, never as a comparison key.
+// isFinished stays server-derived and sticky here, exactly as on /sync: this is
+// the same session-report family of endpoints, where clients never send it.
+func MergeOfflineReplay(server, incoming Progress) (result Progress, accepted bool) {
+	if !(incoming.CurrentTime > server.CurrentTime) {
+		return server, false
+	}
+	result = server
+	result.CurrentTime = incoming.CurrentTime
+	if incoming.Duration > 0 {
+		result.Duration = incoming.Duration
+	}
+	result.UpdatedAtMs = NextServerTimestampMs(server.UpdatedAtMs, incoming.UpdatedAtMs)
+	result.IsFinished = server.IsFinished || IsWithinFinishedTolerance(result.CurrentTime, result.Duration)
+	return result, true
+}
+
+// MergeCombine implements spec §5 rule 5 / §4.2's merge-follow hook: when two
+// items combine (a dedup merge surfacing two previously-independent progress
+// records for the same book), the combined record takes max(currentTime),
+// OR(isFinished) and max(updatedAt). Duration takes the larger of the two so a
+// zero/unknown duration never clobbers a known one.
+//
+// Unlike the Merge* functions above this is unconditional and commutative: both
+// inputs are already "this device's real position", so there is no
+// stale/forward-only question to answer.
+func MergeCombine(a, b Progress) Progress {
+	return Progress{
+		CurrentTime: math.Max(a.CurrentTime, b.CurrentTime),
+		Duration:    math.Max(a.Duration, b.Duration),
+		IsFinished:  a.IsFinished || b.IsFinished,
+		UpdatedAtMs: max(a.UpdatedAtMs, b.UpdatedAtMs),
+	}
+}
+
+// NextServerTimestampMs returns an UpdatedAtMs value for a server-initiated
+// write that is guaranteed to beat AudioBooth's tie-break (spec §1.8.7 second
+// bullet): AudioBooth compares timestamps with strict `>` after truncating
+// BOTH sides via integer `/1000` (whole seconds) in MediaProgress.swift:163,
+// so two writes inside the same wall-clock second compare equal and the
+// client's cached value wins, silently discarding the server's update.
+//
+// It returns max(nowMs, prevUpdatedAtMs+1000) whenever nowMs's
+// truncated-to-seconds value would not already exceed prevUpdatedAtMs's,
+// guaranteeing result/1000 > prevUpdatedAtMs/1000. When nowMs is already a
+// whole second ahead it is returned unchanged — no artificial inflation.
+//
+// Both arguments are millisecond epochs and are expected to be non-negative;
+// integer division truncates toward zero, so negative inputs are not
+// meaningful here.
+func NextServerTimestampMs(prevUpdatedAtMs, nowMs int64) int64 {
+	if nowMs/1000 > prevUpdatedAtMs/1000 {
+		return nowMs
+	}
+	// nowMs/1000 <= prevUpdatedAtMs/1000 implies nowMs < prevUpdatedAtMs+1000,
+	// so prevUpdatedAtMs+1000 IS max(nowMs, prevUpdatedAtMs+1000).
+	return prevUpdatedAtMs + 1000
+}
+
+// AddListenedDelta implements POST /api/session/{id}/sync's "timeListened"
+// (past tense) semantics (spec §1.8.4, SessionService.swift:131-134 /
+// SessionManager.swift:351): a DELTA the server must ADD to the running total.
+//
+// Non-positive deltas (a malformed or clock-skewed client) are clamped to 0
+// rather than subtracted, so a buggy client can never rewind total listened
+// time. NaN and infinities are discarded for the same reason — one poisoned
+// payload would otherwise make the stored total permanently unusable.
+func AddListenedDelta(runningTotalSec, deltaSec float64) float64 {
+	if math.IsNaN(deltaSec) || math.IsInf(deltaSec, 0) || deltaSec <= 0 {
+		return runningTotalSec
+	}
+	return runningTotalSec + deltaSec
+}
+
+// SetListenedCumulative implements POST /api/session/local[-all]'s
+// "timeListening" (gerund) semantics (spec §1.8.4, SessionSync.swift:11): a
+// CUMULATIVE total (idempotent set), NEVER additive — reading it as a delta is
+// the exact abs-shim bug the spec calls out (src/index.ts:336 reads
+// "timeListening" on /sync and therefore records zero listening time from both
+// clients).
+//
+// Forward-only: returns max(runningTotalSec, cumulativeSec) so a stale replayed
+// session (see MergeOfflineReplay, which the same request body drives) cannot
+// rewind a total a newer session already advanced past. NaN and infinities are
+// discarded.
+func SetListenedCumulative(runningTotalSec, cumulativeSec float64) float64 {
+	if math.IsNaN(cumulativeSec) || math.IsInf(cumulativeSec, 0) {
+		return runningTotalSec
+	}
+	if cumulativeSec > runningTotalSec {
+		return cumulativeSec
+	}
+	return runningTotalSec
+}
+
+// ValidateFinishedDuration enforces the invariant behind spec §1.8.7's
+// null-duration trap ("isFinished: true with a null duration sets the client's
+// currentTime to 0", MediaProgress.swift:137-140): any Progress about to be
+// serialized with IsFinished true must carry a positive Duration. Returns an
+// error wrapping ErrFinishedWithoutDuration otherwise.
+//
+// This is a guard for the future Phase-6 DTO layer to call before writing a
+// response body — it is deliberately not enforced inside the Merge* functions,
+// which must stay total (they always return a usable result) and which cannot
+// invent a duration the caller never supplied.
+func ValidateFinishedDuration(p Progress) error {
+	if p.IsFinished && !(p.Duration > 0) {
+		return fmt.Errorf("%w (duration=%v, currentTime=%v)", ErrFinishedWithoutDuration, p.Duration, p.CurrentTime)
+	}
+	return nil
+}

--- a/internal/syncapi/progress/policy_test.go
+++ b/internal/syncapi/progress/policy_test.go
@@ -1,0 +1,785 @@
+// file: internal/syncapi/progress/policy_test.go
+// version: 1.0.0
+// guid: 74b0ad2a-9045-4293-b79b-886bf28d0428
+// last-edited: 2026-07-30
+
+package progress
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// The four decision paths, written out before any test was written (TASK-08
+// step 2). Each endpoint family gets its OWN merge function; the rules below
+// must never be collapsed into a shared code path, because "sticky finished"
+// (spec §5 rule 4) and the offline-replay guard (spec §1.8.7 last bullet) are
+// two different mechanisms that happen to both sound like "don't go
+// backwards".
+//
+//  1. POST /api/session/:id/sync                        -> MergeIncoming
+//     Clients do NOT send isFinished/progress here (spec §1.8.7 amendment to
+//     §5): the SERVER derives isFinished. Governed by §5 rules 2+3 (newer
+//     wins, else forward-only on currentTime) and §5 rule 4 as a one-way
+//     sticky-OR — this path has no way to express "un-finish".
+//
+//  2. PATCH /api/me/progress/:id                        -> MergeExplicit
+//     Absorb DOES send isFinished/progress, and spec §1.8.7 says the server
+//     must honour rather than contradict them. Same §5 rule 2/3 base, but the
+//     newer-wins branch lets incoming.IsFinished win outright — including
+//     clearing it (§5 rule 4's "ABS allows re-opening a finished book"),
+//     which additionally resets CurrentTime to 0. The forward-only branch is
+//     identical to MergeIncoming: it cannot carry an explicit isFinished.
+//
+//  3. POST /api/session/local[-all]                     -> MergeOfflineReplay
+//     Timestamps are UNUSABLE here: offline clients re-stamp stale backlog
+//     entries with updatedAt = now before replaying, so a far-behind position
+//     can arrive looking "newer" (spec §1.8.7 last bullet, abs-shim
+//     src/index.ts:534-541). Therefore this path ignores timestamps entirely
+//     and is forward-only on CurrentTime alone. Note this is a DIFFERENT
+//     requirement from §1.7.3 #2's "200 for unknown IDs", which is an
+//     HTTP-layer concern and not this package's job.
+//
+//  4. Dedup merge-follow (§4.2 / §5 rule 5)             -> MergeCombine
+//     Two previously-independent progress records for what turned out to be
+//     one book. Both are real positions from real devices, so there is no
+//     stale/forward-only question at all: unconditional max(currentTime),
+//     OR(isFinished), max(updatedAt).
+//
+// ---------------------------------------------------------------------------
+
+const epsilon = 1e-9
+
+func floatsClose(a, b float64) bool {
+	return math.Abs(a-b) < epsilon
+}
+
+// Real measured durations for the Odyssey fixture (spec §5b table). These
+// three values all legitimately describe the SAME book and disagree by ~52ms.
+const (
+	odysseyContainerDuration = 9975.480544 // m4b container duration
+	odysseyLastChapterEnd    = 9975.428000 // m4b last chapter end
+	odysseyTrackSum          = 9975.431111 // sum of the 6 mp3 track durations
+)
+
+// -------------------------- IsWithinFinishedTolerance ----------------------
+
+func TestIsWithinFinishedTolerance(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentTime float64
+		duration    float64
+		want        bool
+	}{
+		{"exactly at duration", 100, 100, true},
+		{"past duration", 101, 100, true},
+		{"one second short is within tolerance", 99, 100, true},
+		{"two seconds short is exactly at the tolerance edge", 98, 100, true},
+		{"three seconds short is outside tolerance", 97, 100, false},
+		{"start of book", 0, 100, false},
+		{"zero duration is never finished", 0, 0, false},
+		{"negative duration is never finished", 5, -1, false},
+		{"m4b last-chapter-end vs container duration (§5b, ~52ms skew)", odysseyLastChapterEnd, odysseyContainerDuration, true},
+		{"mp3 track-sum vs container duration (§5b)", odysseyTrackSum, odysseyContainerDuration, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsWithinFinishedTolerance(tt.currentTime, tt.duration); got != tt.want {
+				t.Fatalf("IsWithinFinishedTolerance(%v, %v) = %v, want %v",
+					tt.currentTime, tt.duration, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFinishedToleranceSec_IsAtLeastTwoSeconds(t *testing.T) {
+	// Spec §5b: "Use an explicit tolerance of >= 2 s". A tighter epsilon makes
+	// a fully-listened book sit at 99% forever.
+	if FinishedToleranceSec < 2.0 {
+		t.Fatalf("FinishedToleranceSec = %v, want >= 2.0 (spec §5b)", FinishedToleranceSec)
+	}
+}
+
+// --------------------------- NextServerTimestampMs -------------------------
+
+// TestNextServerTimestampMs_TieCase is the exact case spec §1.8.7 calls out:
+// AudioBooth compares lastUpdate with strict `>` AFTER truncating both sides
+// with integer /1000, so two writes inside the same wall-clock second compare
+// equal and the client's cached value wins — silently discarding the server's
+// update.
+func TestNextServerTimestampMs_TieCase(t *testing.T) {
+	const prev = int64(1000)
+	const now = int64(1500)
+	got := NextServerTimestampMs(prev, now)
+	if got/1000 <= prev/1000 {
+		t.Fatalf("NextServerTimestampMs(%d, %d) = %d; %d/1000 = %d must be > %d/1000 = %d",
+			prev, now, got, got, got/1000, prev, prev/1000)
+	}
+	if got < 2000 {
+		t.Fatalf("NextServerTimestampMs(%d, %d) = %d, want >= 2000", prev, now, got)
+	}
+}
+
+func TestNextServerTimestampMs_NowAlreadyAheadIsUsedAsIs(t *testing.T) {
+	const prev = int64(1000)
+	const now = int64(2500) // already a full second-plus ahead
+	if got := NextServerTimestampMs(prev, now); got != now {
+		t.Fatalf("NextServerTimestampMs(%d, %d) = %d, want %d (no artificial inflation)",
+			prev, now, got, now)
+	}
+}
+
+func TestNextServerTimestampMs_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		prev int64
+		now  int64
+		want int64
+	}{
+		{"same second, now ahead in ms", 1000, 1500, 2000},
+		{"identical values", 1000, 1000, 2000},
+		{"same second, now behind in ms", 1900, 1100, 2900},
+		{"now a clock-skewed full second behind", 10000, 5000, 11000},
+		{"now already in the next second", 1000, 2000, 2000},
+		{"now far ahead", 1000, 999000, 999000},
+		{"no previous write", 0, 1500, 1500},
+		{"no previous write, same second as epoch", 0, 500, 1000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NextServerTimestampMs(tt.prev, tt.now)
+			if got != tt.want {
+				t.Fatalf("NextServerTimestampMs(%d, %d) = %d, want %d", tt.prev, tt.now, got, tt.want)
+			}
+			// The whole point of the function: truncated-to-seconds must beat prev.
+			if got/1000 <= tt.prev/1000 {
+				t.Fatalf("NextServerTimestampMs(%d, %d) = %d: %d/1000 does not exceed %d/1000",
+					tt.prev, tt.now, got, got, tt.prev)
+			}
+		})
+	}
+}
+
+// ------------------------------ AddListenedDelta ---------------------------
+
+// TestAddListenedDelta_Adds pins the /sync semantics: "timeListened" (past
+// tense) is a DELTA the server ADDS to the running total (spec §1.8.4).
+func TestAddListenedDelta_Adds(t *testing.T) {
+	tests := []struct {
+		name    string
+		running float64
+		delta   float64
+		want    float64
+	}{
+		{"first delta", 0, 15, 15},
+		{"second delta accumulates", 15, 15, 30},
+		{"fractional delta", 30, 0.5, 30.5},
+		{"zero delta is a no-op", 30, 0, 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddListenedDelta(tt.running, tt.delta); !floatsClose(got, tt.want) {
+				t.Fatalf("AddListenedDelta(%v, %v) = %v, want %v", tt.running, tt.delta, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddListenedDelta_ClampsNegative(t *testing.T) {
+	tests := []struct {
+		name    string
+		running float64
+		delta   float64
+		want    float64
+	}{
+		{"negative delta must not subtract", 100, -50, 100},
+		{"tiny negative delta", 100, -0.001, 100},
+		{"NaN delta is ignored", 100, math.NaN(), 100},
+		{"+Inf delta is ignored", 100, math.Inf(1), 100},
+		{"-Inf delta is ignored", 100, math.Inf(-1), 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddListenedDelta(tt.running, tt.delta); !floatsClose(got, tt.want) {
+				t.Fatalf("AddListenedDelta(%v, %v) = %v, want %v", tt.running, tt.delta, got, tt.want)
+			}
+		})
+	}
+}
+
+// --------------------------- SetListenedCumulative -------------------------
+
+// TestSetListenedCumulative_SetsNotAdds proves the /session/local[-all]
+// "timeListening" (gerund) value is a CUMULATIVE total, not a delta — the
+// exact abs-shim bug in spec §1.8.4 (src/index.ts:336 reads the wrong key and
+// records zero listening time from both clients). Calling it twice with the
+// same cumulative value must be idempotent.
+func TestSetListenedCumulative_SetsNotAdds(t *testing.T) {
+	const cumulative = 600.0
+	first := SetListenedCumulative(0, cumulative)
+	if !floatsClose(first, cumulative) {
+		t.Fatalf("SetListenedCumulative(0, %v) = %v, want %v", cumulative, first, cumulative)
+	}
+	second := SetListenedCumulative(first, cumulative)
+	if !floatsClose(second, cumulative) {
+		t.Fatalf("SetListenedCumulative(%v, %v) = %v, want %v (must be idempotent, not additive)",
+			first, cumulative, second, cumulative)
+	}
+	third := SetListenedCumulative(second, cumulative+30)
+	if !floatsClose(third, cumulative+30) {
+		t.Fatalf("SetListenedCumulative(%v, %v) = %v, want %v",
+			second, cumulative+30, third, cumulative+30)
+	}
+}
+
+func TestSetListenedCumulative_ForwardOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		running    float64
+		cumulative float64
+		want       float64
+	}{
+		{"stale replayed session cannot rewind the total", 600, 120, 600},
+		{"equal is a no-op", 600, 600, 600},
+		{"newer cumulative advances", 600, 900, 900},
+		{"negative cumulative cannot rewind", 600, -5, 600},
+		{"NaN cumulative is ignored", 600, math.NaN(), 600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SetListenedCumulative(tt.running, tt.cumulative)
+			if !floatsClose(got, tt.want) {
+				t.Fatalf("SetListenedCumulative(%v, %v) = %v, want %v",
+					tt.running, tt.cumulative, got, tt.want)
+			}
+		})
+	}
+}
+
+// -------------------------------- MergeIncoming ----------------------------
+//
+// Path 1: POST /api/session/:id/sync. isFinished is SERVER-derived here.
+
+// baseServer is the "server already has real state" fixture the MergeIncoming
+// tests share: mid-book, not finished, written at ms 5000.
+func baseServer() Progress {
+	return Progress{CurrentTime: 200, Duration: 10000, IsFinished: false, UpdatedAtMs: 5000}
+}
+
+func TestMergeIncoming_NewerWins(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{CurrentTime: 4321.5, Duration: 10000, IsFinished: false, UpdatedAtMs: 6000}
+
+	got, accepted := MergeIncoming(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeIncoming(%+v, %+v) accepted = false, want true", server, incoming)
+	}
+	if !floatsClose(got.CurrentTime, incoming.CurrentTime) {
+		t.Errorf("CurrentTime = %v, want %v (incoming wins wholesale)", got.CurrentTime, incoming.CurrentTime)
+	}
+	if !floatsClose(got.Duration, incoming.Duration) {
+		t.Errorf("Duration = %v, want %v", got.Duration, incoming.Duration)
+	}
+	if got.UpdatedAtMs != incoming.UpdatedAtMs {
+		t.Errorf("UpdatedAtMs = %d, want %d", got.UpdatedAtMs, incoming.UpdatedAtMs)
+	}
+	if got.IsFinished {
+		t.Errorf("IsFinished = true, want false (position is nowhere near duration)")
+	}
+}
+
+// TestMergeIncoming_StaleForwardAdvances is spec §5 rule 3's exact example: an
+// offline device that listened FURTHER still advances the position, even though
+// its timestamp is older than the server's.
+func TestMergeIncoming_StaleForwardAdvances(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{CurrentTime: 300, Duration: 10000, IsFinished: false, UpdatedAtMs: 4000}
+
+	got, accepted := MergeIncoming(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeIncoming(%+v, %+v) accepted = false, want true (stale but ahead)", server, incoming)
+	}
+	if !floatsClose(got.CurrentTime, 300) {
+		t.Errorf("CurrentTime = %v, want 300 (position advances)", got.CurrentTime)
+	}
+	if got.UpdatedAtMs < server.UpdatedAtMs {
+		t.Errorf("UpdatedAtMs = %d, want >= %d (a stale accept must never rewind the server timestamp)",
+			got.UpdatedAtMs, server.UpdatedAtMs)
+	}
+}
+
+// TestMergeIncoming_StaleBehindRejected is THE specific clobber spec §5 rule 3
+// fears: a stale device that is BEHIND can never rewind newer server progress.
+// Asserted field-for-field, not just on the accepted flag.
+func TestMergeIncoming_StaleBehindRejected(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{CurrentTime: 100, Duration: 10000, IsFinished: false, UpdatedAtMs: 4000}
+
+	got, accepted := MergeIncoming(server, incoming)
+	if accepted {
+		t.Fatalf("MergeIncoming(%+v, %+v) accepted = true, want false", server, incoming)
+	}
+	if !reflect.DeepEqual(got, server) {
+		t.Fatalf("MergeIncoming returned %+v, want the server record untouched: %+v", got, server)
+	}
+}
+
+// TestMergeIncoming_StaleDeviceMatrix is the property-style matrix over
+// {incoming older, equal, newer timestamp} x {incoming ahead, behind, equal
+// position}. An equal timestamp counts as "not newer" and therefore falls to
+// the forward-only branch (spec §5 rules 2-3).
+func TestMergeIncoming_StaleDeviceMatrix(t *testing.T) {
+	const (
+		olderTS = int64(4000)
+		equalTS = int64(5000) // same as baseServer().UpdatedAtMs
+		newerTS = int64(6000)
+
+		behindPos = 100.0
+		equalPos  = 200.0 // same as baseServer().CurrentTime
+		aheadPos  = 300.0
+	)
+	tests := []struct {
+		name            string
+		incomingTS      int64
+		incomingPos     float64
+		wantAccepted    bool
+		wantCurrentTime float64
+		wantUpdatedAtMs int64
+	}{
+		{"newer + ahead -> newer wins", newerTS, aheadPos, true, aheadPos, newerTS},
+		// A genuinely newer write that seeked BACKWARDS is honoured: spec §5
+		// rule 2 accepts a newer update wholesale. Only STALE-and-behind is a
+		// clobber.
+		{"newer + behind -> newer wins wholesale (deliberate seek back)", newerTS, behindPos, true, behindPos, newerTS},
+		{"newer + equal position -> accepted, timestamp advances", newerTS, equalPos, true, equalPos, newerTS},
+
+		{"equal timestamp + ahead -> forward-only accept", equalTS, aheadPos, true, aheadPos, equalTS},
+		{"equal timestamp + behind -> rejected", equalTS, behindPos, false, equalPos, equalTS},
+		{"equal timestamp + equal position -> rejected (no-op)", equalTS, equalPos, false, equalPos, equalTS},
+
+		{"older + ahead -> forward-only accept (listened further offline)", olderTS, aheadPos, true, aheadPos, equalTS},
+		{"older + behind -> rejected (the clobber §5 rule 3 fears)", olderTS, behindPos, false, equalPos, equalTS},
+		{"older + equal position -> rejected", olderTS, equalPos, false, equalPos, equalTS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := baseServer()
+			incoming := Progress{
+				CurrentTime: tt.incomingPos,
+				Duration:    10000,
+				UpdatedAtMs: tt.incomingTS,
+			}
+			got, accepted := MergeIncoming(server, incoming)
+			if accepted != tt.wantAccepted {
+				t.Fatalf("MergeIncoming(%+v, %+v) accepted = %v, want %v",
+					server, incoming, accepted, tt.wantAccepted)
+			}
+			if !floatsClose(got.CurrentTime, tt.wantCurrentTime) {
+				t.Errorf("CurrentTime = %v, want %v", got.CurrentTime, tt.wantCurrentTime)
+			}
+			if got.UpdatedAtMs != tt.wantUpdatedAtMs {
+				t.Errorf("UpdatedAtMs = %d, want %d", got.UpdatedAtMs, tt.wantUpdatedAtMs)
+			}
+			if !tt.wantAccepted && !reflect.DeepEqual(got, server) {
+				t.Errorf("rejected merge returned %+v, want the server record untouched: %+v", got, server)
+			}
+		})
+	}
+}
+
+// TestMergeIncoming_FinishedIsSticky covers spec §5 rule 4 on the /sync path:
+// /sync cannot express "un-finish" (clients do not send isFinished at all
+// there), so once the server has recorded finished, a newer /sync update with a
+// position back near the start must NOT clear it.
+func TestMergeIncoming_FinishedIsSticky(t *testing.T) {
+	server := Progress{CurrentTime: 9975.43, Duration: odysseyContainerDuration, IsFinished: true, UpdatedAtMs: 5000}
+	incoming := Progress{CurrentTime: 30, Duration: odysseyContainerDuration, UpdatedAtMs: 6000}
+
+	got, accepted := MergeIncoming(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeIncoming accepted = false, want true (incoming is strictly newer)")
+	}
+	if !got.IsFinished {
+		t.Errorf("IsFinished = false, want true (sticky: /sync has no un-finish path)")
+	}
+	if !floatsClose(got.CurrentTime, 30) {
+		t.Errorf("CurrentTime = %v, want 30 (the newer position is still accepted)", got.CurrentTime)
+	}
+}
+
+// TestMergeIncoming_IgnoresClientSuppliedFinished pins the §1.8.7 amendment:
+// on /sync the server DERIVES isFinished, so a stray client-supplied
+// IsFinished=true well short of the end must not be honoured on this path
+// (MergeExplicit is the only path that honours an explicit value).
+func TestMergeIncoming_IgnoresClientSuppliedFinished(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{CurrentTime: 300, Duration: 10000, IsFinished: true, UpdatedAtMs: 6000}
+
+	got, _ := MergeIncoming(server, incoming)
+	if got.IsFinished {
+		t.Errorf("IsFinished = true, want false (server derives isFinished on /sync)")
+	}
+}
+
+// TestMergeIncoming_FinishedDetection_LastChapterEnd is the spec §5b regression
+// test: a client that plays to the end of the final CHAPTER stops ~52ms short
+// of the CONTAINER duration. With a tight epsilon the book would sit at 99%
+// forever; with the >=2s tolerance it auto-marks finished.
+func TestMergeIncoming_FinishedDetection_LastChapterEnd(t *testing.T) {
+	if !IsWithinFinishedTolerance(odysseyLastChapterEnd, odysseyContainerDuration) {
+		t.Fatalf("IsWithinFinishedTolerance(%v, %v) = false, want true (spec §5b, ~52ms skew)",
+			odysseyLastChapterEnd, odysseyContainerDuration)
+	}
+
+	server := Progress{CurrentTime: 9000, Duration: odysseyContainerDuration, IsFinished: false, UpdatedAtMs: 5000}
+	incoming := Progress{CurrentTime: odysseyLastChapterEnd, Duration: odysseyContainerDuration, UpdatedAtMs: 6000}
+
+	got, accepted := MergeIncoming(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeIncoming accepted = false, want true")
+	}
+	if !got.IsFinished {
+		t.Fatalf("IsFinished = false at last-chapter-end position %v of duration %v; "+
+			"want true (this is the 'stuck at 99%% forever' bug)",
+			odysseyLastChapterEnd, odysseyContainerDuration)
+	}
+	if err := ValidateFinishedDuration(got); err != nil {
+		t.Errorf("ValidateFinishedDuration(%+v) = %v, want nil", got, err)
+	}
+}
+
+// -------------------------- ValidateFinishedDuration -----------------------
+
+// TestValidateFinishedDuration_RejectsZeroDurationWhenFinished guards spec
+// §1.8.7's null-duration trap: "isFinished: true with a null duration sets the
+// client's currentTime to 0" (MediaProgress.swift:137-140).
+func TestValidateFinishedDuration_RejectsZeroDurationWhenFinished(t *testing.T) {
+	tests := []struct {
+		name string
+		p    Progress
+	}{
+		{"finished with zero duration", Progress{CurrentTime: 100, Duration: 0, IsFinished: true}},
+		{"finished with negative duration", Progress{CurrentTime: 100, Duration: -1, IsFinished: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFinishedDuration(tt.p)
+			if err == nil {
+				t.Fatalf("ValidateFinishedDuration(%+v) = nil, want an error", tt.p)
+			}
+			if !errors.Is(err, ErrFinishedWithoutDuration) {
+				t.Fatalf("ValidateFinishedDuration(%+v) error = %v, want errors.Is ErrFinishedWithoutDuration",
+					tt.p, err)
+			}
+		})
+	}
+}
+
+func TestValidateFinishedDuration_AllowsUnfinishedZeroDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		p    Progress
+	}{
+		{"unfinished with zero duration", Progress{CurrentTime: 0, Duration: 0, IsFinished: false}},
+		{"unfinished with real duration", Progress{CurrentTime: 10, Duration: 100, IsFinished: false}},
+		{"finished with real duration", Progress{CurrentTime: 100, Duration: 100, IsFinished: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateFinishedDuration(tt.p); err != nil {
+				t.Fatalf("ValidateFinishedDuration(%+v) = %v, want nil", tt.p, err)
+			}
+		})
+	}
+}
+
+// -------------------------------- MergeExplicit ----------------------------
+//
+// Path 2: PATCH /api/me/progress/:id. isFinished is CLIENT-supplied here and
+// spec §1.8.7 says the server must honour rather than contradict it.
+
+// TestMergeExplicit_CanClearFinished covers §5 rule 4's escape hatch: ABS allows
+// re-opening a finished book, and a strictly-newer explicit isFinished:false
+// additionally resets the position to 0 (real ABS "mark as not started").
+func TestMergeExplicit_CanClearFinished(t *testing.T) {
+	server := Progress{CurrentTime: odysseyLastChapterEnd, Duration: odysseyContainerDuration, IsFinished: true, UpdatedAtMs: 5000}
+	incoming := Progress{CurrentTime: odysseyLastChapterEnd, Duration: odysseyContainerDuration, IsFinished: false, UpdatedAtMs: 6000}
+
+	got, accepted := MergeExplicit(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeExplicit accepted = false, want true (incoming is strictly newer)")
+	}
+	if got.IsFinished {
+		t.Errorf("IsFinished = true, want false (explicit re-open, spec §5 rule 4)")
+	}
+	if !floatsClose(got.CurrentTime, 0) {
+		t.Errorf("CurrentTime = %v, want 0 (a finished->unfinished transition resets the position)", got.CurrentTime)
+	}
+	if !floatsClose(got.Duration, odysseyContainerDuration) {
+		t.Errorf("Duration = %v, want %v (duration must survive the reset, spec §1.8.7)",
+			got.Duration, odysseyContainerDuration)
+	}
+}
+
+// TestMergeExplicit_HonoursExplicitFinishedTrue: the client says finished at a
+// position nowhere near the end (e.g. the user tapped "mark as finished"); the
+// server must honour that, not contradict it with its own tolerance math.
+func TestMergeExplicit_HonoursExplicitFinishedTrue(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{CurrentTime: 300, Duration: 10000, IsFinished: true, UpdatedAtMs: 6000}
+
+	got, accepted := MergeExplicit(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeExplicit accepted = false, want true")
+	}
+	if !got.IsFinished {
+		t.Errorf("IsFinished = false, want true (server must honour an explicit isFinished)")
+	}
+	if !floatsClose(got.CurrentTime, 300) {
+		t.Errorf("CurrentTime = %v, want 300 (no reset on a false->true transition)", got.CurrentTime)
+	}
+	if err := ValidateFinishedDuration(got); err != nil {
+		t.Errorf("ValidateFinishedDuration(%+v) = %v, want nil", got, err)
+	}
+}
+
+// TestMergeExplicit_ForwardOnlyBranchCannotClearFinished: a forward-only accept
+// (rule 3) can never carry an explicit isFinished, so the sticky-OR applies
+// there exactly as it does on /sync. Only the strictly-newer branch may clear.
+func TestMergeExplicit_ForwardOnlyBranchCannotClearFinished(t *testing.T) {
+	server := Progress{CurrentTime: 200, Duration: 10000, IsFinished: true, UpdatedAtMs: 5000}
+	incoming := Progress{CurrentTime: 300, Duration: 10000, IsFinished: false, UpdatedAtMs: 4000}
+
+	got, accepted := MergeExplicit(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeExplicit accepted = false, want true (stale but ahead)")
+	}
+	if !got.IsFinished {
+		t.Errorf("IsFinished = false, want true (a stale update may not clear finished)")
+	}
+	if !floatsClose(got.CurrentTime, 300) {
+		t.Errorf("CurrentTime = %v, want 300", got.CurrentTime)
+	}
+}
+
+func TestMergeExplicit_StaleBehindRejected(t *testing.T) {
+	server := Progress{CurrentTime: 200, Duration: 10000, IsFinished: true, UpdatedAtMs: 5000}
+	tests := []struct {
+		name     string
+		incoming Progress
+	}{
+		{"older and behind", Progress{CurrentTime: 100, Duration: 10000, UpdatedAtMs: 4000}},
+		{"older and equal", Progress{CurrentTime: 200, Duration: 10000, UpdatedAtMs: 4000}},
+		{"equal timestamp and behind", Progress{CurrentTime: 100, Duration: 10000, UpdatedAtMs: 5000}},
+		{"stale un-finish attempt", Progress{CurrentTime: 0, Duration: 10000, IsFinished: false, UpdatedAtMs: 4000}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, accepted := MergeExplicit(server, tt.incoming)
+			if accepted {
+				t.Fatalf("MergeExplicit(%+v, %+v) accepted = true, want false", server, tt.incoming)
+			}
+			if !reflect.DeepEqual(got, server) {
+				t.Fatalf("MergeExplicit returned %+v, want the server record untouched: %+v", got, server)
+			}
+		})
+	}
+}
+
+// ----------------------------- MergeOfflineReplay --------------------------
+//
+// Path 3: POST /api/session/local[-all]. Timestamps are UNUSABLE here.
+
+// TestMergeOfflineReplay_IgnoresReStampedTimestamp is the case that would
+// falsely WIN under MergeIncoming's rules: an offline client re-stamps a stale
+// backlog entry with updatedAt = now, so it looks newer by timestamp while its
+// position is far behind the server's. Proof that this function consults no
+// timestamps at all (spec §1.8.7 last bullet, abs-shim src/index.ts:534-541).
+func TestMergeOfflineReplay_IgnoresReStampedTimestamp(t *testing.T) {
+	server := baseServer()
+	incoming := Progress{
+		CurrentTime: 100,               // far BEHIND the server's 200
+		Duration:    10000,             //
+		UpdatedAtMs: 9_999_999_999_999, // re-stamped "now", absurdly newer
+	}
+
+	got, accepted := MergeOfflineReplay(server, incoming)
+	if accepted {
+		t.Fatalf("MergeOfflineReplay(%+v, %+v) accepted = true, want false", server, incoming)
+	}
+	if !reflect.DeepEqual(got, server) {
+		t.Fatalf("MergeOfflineReplay returned %+v, want the server record untouched: %+v", got, server)
+	}
+
+	// Contrast: the very same inputs WOULD be accepted by MergeIncoming, which
+	// is exactly why these two rules must not share a code path.
+	if _, wouldAccept := MergeIncoming(server, incoming); !wouldAccept {
+		t.Fatalf("precondition failed: MergeIncoming should accept the re-stamped entry " +
+			"(if it does not, this test no longer proves anything)")
+	}
+}
+
+func TestMergeOfflineReplay_AdvancesWhenAhead(t *testing.T) {
+	tests := []struct {
+		name        string
+		incomingTS  int64
+		incomingPos float64
+		wantAccept  bool
+	}{
+		{"ahead with an older timestamp", 1000, 300, true},
+		{"ahead with an equal timestamp", 5000, 300, true},
+		{"ahead with a re-stamped future timestamp", 9_999_999_999_999, 300, true},
+		{"behind with an older timestamp", 1000, 100, false},
+		{"equal position is a no-op", 5000, 200, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := baseServer()
+			incoming := Progress{CurrentTime: tt.incomingPos, Duration: 10000, UpdatedAtMs: tt.incomingTS}
+			got, accepted := MergeOfflineReplay(server, incoming)
+			if accepted != tt.wantAccept {
+				t.Fatalf("MergeOfflineReplay(%+v, %+v) accepted = %v, want %v",
+					server, incoming, accepted, tt.wantAccept)
+			}
+			if !tt.wantAccept {
+				if !reflect.DeepEqual(got, server) {
+					t.Fatalf("rejected merge returned %+v, want %+v", got, server)
+				}
+				return
+			}
+			if !floatsClose(got.CurrentTime, tt.incomingPos) {
+				t.Errorf("CurrentTime = %v, want %v", got.CurrentTime, tt.incomingPos)
+			}
+			// An accepted replay must look like a FRESH server write, or the
+			// next client comparison discards it (spec §1.8.7 tie-break).
+			if got.UpdatedAtMs/1000 <= server.UpdatedAtMs/1000 {
+				t.Errorf("UpdatedAtMs = %d; %d/1000 must exceed %d/1000 after an accepted replay",
+					got.UpdatedAtMs, got.UpdatedAtMs, server.UpdatedAtMs)
+			}
+		})
+	}
+}
+
+// TestMergeOfflineReplay_DerivesFinished: /session/local is a /sync-family
+// endpoint, so isFinished stays server-derived and sticky here too.
+func TestMergeOfflineReplay_DerivesFinished(t *testing.T) {
+	server := Progress{CurrentTime: 9000, Duration: odysseyContainerDuration, IsFinished: false, UpdatedAtMs: 5000}
+	incoming := Progress{CurrentTime: odysseyLastChapterEnd, Duration: odysseyContainerDuration, UpdatedAtMs: 1000}
+
+	got, accepted := MergeOfflineReplay(server, incoming)
+	if !accepted {
+		t.Fatalf("MergeOfflineReplay accepted = false, want true")
+	}
+	if !got.IsFinished {
+		t.Errorf("IsFinished = false, want true (last-chapter-end within §5b tolerance)")
+	}
+
+	// Sticky: a replayed entry cannot clear a finished flag either.
+	finishedServer := Progress{CurrentTime: 200, Duration: 10000, IsFinished: true, UpdatedAtMs: 5000}
+	ahead := Progress{CurrentTime: 300, Duration: 10000, IsFinished: false, UpdatedAtMs: 6000}
+	if got, _ := MergeOfflineReplay(finishedServer, ahead); !got.IsFinished {
+		t.Errorf("IsFinished = false, want true (sticky on the replay path)")
+	}
+}
+
+// -------------------------------- MergeCombine -----------------------------
+//
+// Path 4: dedup merge-follow (spec §4.2 / §5 rule 5). Unconditional.
+
+func TestMergeCombine_TakesMaxAndOr(t *testing.T) {
+	tests := []struct {
+		name string
+		a    Progress
+		b    Progress
+		want Progress
+	}{
+		{
+			name: "a is ahead, b is finished and newer",
+			a:    Progress{CurrentTime: 5000, Duration: 10000, IsFinished: false, UpdatedAtMs: 7000},
+			b:    Progress{CurrentTime: 300, Duration: 10000, IsFinished: true, UpdatedAtMs: 9000},
+			want: Progress{CurrentTime: 5000, Duration: 10000, IsFinished: true, UpdatedAtMs: 9000},
+		},
+		{
+			name: "b is ahead and newer, a is finished",
+			a:    Progress{CurrentTime: 100, Duration: 10000, IsFinished: true, UpdatedAtMs: 1000},
+			b:    Progress{CurrentTime: 800, Duration: 10000, IsFinished: false, UpdatedAtMs: 4000},
+			want: Progress{CurrentTime: 800, Duration: 10000, IsFinished: true, UpdatedAtMs: 4000},
+		},
+		{
+			name: "neither finished",
+			a:    Progress{CurrentTime: 100, Duration: 10000, UpdatedAtMs: 1000},
+			b:    Progress{CurrentTime: 200, Duration: 10000, UpdatedAtMs: 2000},
+			want: Progress{CurrentTime: 200, Duration: 10000, UpdatedAtMs: 2000},
+		},
+		{
+			name: "a has no known duration",
+			a:    Progress{CurrentTime: 900, Duration: 0, UpdatedAtMs: 3000},
+			b:    Progress{CurrentTime: 100, Duration: 10000, UpdatedAtMs: 1000},
+			want: Progress{CurrentTime: 900, Duration: 10000, UpdatedAtMs: 3000},
+		},
+		{
+			name: "identical records",
+			a:    Progress{CurrentTime: 42, Duration: 100, IsFinished: false, UpdatedAtMs: 5},
+			b:    Progress{CurrentTime: 42, Duration: 100, IsFinished: false, UpdatedAtMs: 5},
+			want: Progress{CurrentTime: 42, Duration: 100, IsFinished: false, UpdatedAtMs: 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeCombine(tt.a, tt.b)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("MergeCombine(%+v, %+v) = %+v, want %+v", tt.a, tt.b, got, tt.want)
+			}
+			// Commutative: merge order must not matter for a dedup follow-up.
+			if swapped := MergeCombine(tt.b, tt.a); !reflect.DeepEqual(swapped, tt.want) {
+				t.Fatalf("MergeCombine(%+v, %+v) = %+v, want %+v (must be commutative)",
+					tt.b, tt.a, swapped, tt.want)
+			}
+		})
+	}
+}
+
+// TestMerge_NewerUpdateNeverWipesKnownDuration guards the one carve-out to §5
+// rule 2's "accept incoming wholesale": Duration is not a position, and a
+// payload that simply omits it must not erase a duration the server already
+// knows. Wiping it would disable finished-detection entirely (the book sits at
+// 99% forever, spec §5b) and would make any later isFinished response trip
+// §1.8.7's null-duration trap, which zeroes the client's position.
+func TestMerge_NewerUpdateNeverWipesKnownDuration(t *testing.T) {
+	merges := map[string]func(a, b Progress) (Progress, bool){
+		"MergeIncoming":      MergeIncoming,
+		"MergeExplicit":      MergeExplicit,
+		"MergeOfflineReplay": MergeOfflineReplay,
+	}
+	for name, merge := range merges {
+		t.Run(name+"/newer incoming without duration", func(t *testing.T) {
+			server := baseServer() // Duration 10000
+			incoming := Progress{CurrentTime: 300, Duration: 0, UpdatedAtMs: 6000}
+			got, accepted := merge(server, incoming)
+			if !accepted {
+				t.Fatalf("accepted = false, want true")
+			}
+			if !floatsClose(got.Duration, server.Duration) {
+				t.Errorf("Duration = %v, want %v (a missing duration must not wipe a known one)",
+					got.Duration, server.Duration)
+			}
+			if !floatsClose(got.CurrentTime, 300) {
+				t.Errorf("CurrentTime = %v, want 300", got.CurrentTime)
+			}
+		})
+		t.Run(name+"/incoming supplies a duration the server lacks", func(t *testing.T) {
+			server := Progress{CurrentTime: 100, Duration: 0, UpdatedAtMs: 5000}
+			incoming := Progress{CurrentTime: 300, Duration: 10000, UpdatedAtMs: 6000}
+			got, accepted := merge(server, incoming)
+			if !accepted {
+				t.Fatalf("accepted = false, want true")
+			}
+			if !floatsClose(got.Duration, 10000) {
+				t.Errorf("Duration = %v, want 10000 (adopt a duration the server did not have)", got.Duration)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## TASK-08 — pure progress-merge policy package

New package `internal/syncapi/progress` implementing the progress conflict-resolution
policy from `docs/specs/2026-07-29-abs-sync-api-design.md` §5, §5b and §1.8.7 as pure,
I/O-free decision functions. Zero imports outside the standard library — no
`internal/database`, no HTTP, no `time.Now()` inside any function (callers pass timestamps
in). No store or handler wiring: that is later Phase-6 scope, so nothing in the repo
imports this package yet.

Modeled on the sibling pure package `internal/audioutil/timeline.go`.

### API

`Progress` + `FinishedToleranceSec` (= 2.0), and:

| Function | Endpoint / purpose |
|---|---|
| `MergeIncoming` | `POST /api/session/:id/sync` — server DERIVES isFinished; sticky-OR, never cleared |
| `MergeExplicit` | `PATCH /api/me/progress/:id` — client SUPPLIES isFinished; strictly-newer may clear it (and resets position to 0) |
| `MergeOfflineReplay` | `POST /api/session/local[-all]` — timestamps are unusable; forward-only on position alone |
| `MergeCombine` | dedup merge-follow (§5 rule 5) — unconditional max/OR/max, commutative |
| `NextServerTimestampMs` | beats AudioBooth's truncated-to-seconds `>` tie-break |
| `AddListenedDelta` | `/sync`'s `timeListened` — a DELTA to add, non-positive clamped to 0 |
| `SetListenedCumulative` | `/session/local*`'s `timeListening` — a CUMULATIVE set, idempotent + forward-only |
| `ValidateFinishedDuration` | §1.8.7 null-duration trap guard (`ErrFinishedWithoutDuration`) |
| `IsWithinFinishedTolerance` | §5b tolerance check |

### Why the two "don't go backwards" rules are two functions

`MergeIncoming`'s sticky-finished and `MergeOfflineReplay`'s guard sound alike but are
different mechanisms for different endpoints and deliberately do not share a code path
(the reasoning is written out as a comment block at the top of `policy_test.go`, per the
task brief's step 2). `TestMergeOfflineReplay_IgnoresReStampedTimestamp` feeds identical
inputs to both and asserts `MergeIncoming` accepts while `MergeOfflineReplay` rejects —
that is the whole point: an offline client re-stamps a stale backlog entry with
`updatedAt = now`, so a far-behind position arrives looking newer.

### Why the finished tolerance is 2s, not an epsilon

Three legitimate, mutually-disagreeing durations for one book (measured, §5b): container
`9975.480544`, last-chapter-end `9975.428000`, track-sum `9975.431111` — ~52 ms spread,
structurally caused (m4b chapter marks are ms-quantized, track durations are
frame-accurate). A tight epsilon leaves a fully-listened book at 99% forever.
`TestMergeIncoming_FinishedDetection_LastChapterEnd` is the regression test at those exact
values.

### Deviations from the brief (both flagged deliberately, neither silent)

1. **`UpdatedAtMs` advances monotonically on a forward-only accept.** The brief says the
   forward-only branch "advances CurrentTime and UpdatedAtMs"; on that branch incoming's
   timestamp is `<=` the server's by construction, so taking incoming's literally would
   *rewind* the stored timestamp and make the next update from any device falsely look
   newer, losing a conflict it should lose. Implemented as `max(server, incoming)` (i.e.
   the server's value stands), documented at the call site. The Phase-6 store adapter is
   expected to re-stamp writes with `NextServerTimestampMs` anyway. Locked by the
   `wantUpdatedAtMs` column of the stale-device matrix.
2. **An omitted `Duration` never wipes a known one** — one carve-out to §5 rule 2's
   "accept incoming wholesale". `Duration` is not a position; erasing it disables
   finished-detection outright (§5b's "sits at 99% forever") and makes any later
   `isFinished` response trip §1.8.7's null-duration trap, which zeroes the client's
   position. A positive incoming duration always wins. Locked by
   `TestMerge_NewerUpdateNeverWipesKnownDuration`.

Minor additions beyond the brief: NaN/±Inf are discarded in the listened-time helpers and
the tolerance check (one poisoned payload would otherwise make a stored total permanently
unusable), and the property matrix has 9 rows rather than the required minimum of 6.

### Verification

`go test ./internal/syncapi/progress/ -race -count=1 -v` (27 top-level tests, all 19
brief-mandated names present):

```
--- PASS: TestIsWithinFinishedTolerance (0.00s)
--- PASS: TestFinishedToleranceSec_IsAtLeastTwoSeconds (0.00s)
--- PASS: TestNextServerTimestampMs_TieCase (0.00s)
--- PASS: TestNextServerTimestampMs_NowAlreadyAheadIsUsedAsIs (0.00s)
--- PASS: TestNextServerTimestampMs_Table (0.00s)
--- PASS: TestAddListenedDelta_Adds (0.00s)
--- PASS: TestAddListenedDelta_ClampsNegative (0.00s)
--- PASS: TestSetListenedCumulative_SetsNotAdds (0.00s)
--- PASS: TestSetListenedCumulative_ForwardOnly (0.00s)
--- PASS: TestMergeIncoming_NewerWins (0.00s)
--- PASS: TestMergeIncoming_StaleForwardAdvances (0.00s)
--- PASS: TestMergeIncoming_StaleBehindRejected (0.00s)
--- PASS: TestMergeIncoming_StaleDeviceMatrix (0.00s)
--- PASS: TestMergeIncoming_FinishedIsSticky (0.00s)
--- PASS: TestMergeIncoming_IgnoresClientSuppliedFinished (0.00s)
--- PASS: TestMergeIncoming_FinishedDetection_LastChapterEnd (0.00s)
--- PASS: TestValidateFinishedDuration_RejectsZeroDurationWhenFinished (0.00s)
--- PASS: TestValidateFinishedDuration_AllowsUnfinishedZeroDuration (0.00s)
--- PASS: TestMergeExplicit_CanClearFinished (0.00s)
--- PASS: TestMergeExplicit_HonoursExplicitFinishedTrue (0.00s)
--- PASS: TestMergeExplicit_ForwardOnlyBranchCannotClearFinished (0.00s)
--- PASS: TestMergeExplicit_StaleBehindRejected (0.00s)
--- PASS: TestMergeOfflineReplay_IgnoresReStampedTimestamp (0.00s)
--- PASS: TestMergeOfflineReplay_AdvancesWhenAhead (0.00s)
--- PASS: TestMergeOfflineReplay_DerivesFinished (0.00s)
--- PASS: TestMergeCombine_TakesMaxAndOr (0.00s)
--- PASS: TestMerge_NewerUpdateNeverWipesKnownDuration (0.00s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/syncapi/progress	1.198s
```

Also clean: `go vet ./internal/syncapi/progress/`, `staticcheck ./internal/syncapi/progress/`,
`gofmt -l internal/syncapi/progress/` (no output), `go build ./...`, and
`grep -n '"github.com/falkcorp/audiobook-organizer/internal/' internal/syncapi/progress/policy.go`
→ 0 hits.

Changelog fragment: `changelog.d/20260730_abs_sync_progress_merge_policy.md`.
Anti-over-suppression: N/A — every reject path returns `accepted=false` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
