### PR TITLE
feat(abs-sync): add extension-based DRM detection for Audible AAX/AAXC

### DIFF
--- a/changelog.d/20260730_061000_abs-sync-drm-detection.md
+++ b/changelog.d/20260730_061000_abs-sync-drm-detection.md
@@ -1,0 +1,12 @@
+<!-- file: changelog.d/20260730_061000_abs-sync-drm-detection.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 21aa1272-250b-446d-bf74-ceb98e762cfb -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+- **DRM detection for Audible AAX/AAXC (abs-sync Phase 4, first step).** Added
+  `audioutil.DetectDRM`, a cheap extension-based check flagging `.aax`/`.aaxc` files as
+  DRM-protected-and-unplayable, with a documented reason string. Detection only, not yet wired into
+  the scanner or surfaced to users -- that's a follow-up task once a schema-owning task decides
+  where the "unplayable" flag lives.

--- a/internal/audioutil/drm.go
+++ b/internal/audioutil/drm.go
@@ -1,0 +1,48 @@
+// file: internal/audioutil/drm.go
+// version: 1.0.0
+// guid: 6ba10228-85ba-455d-a6a0-33ee1169bfbc
+// last-edited: 2026-07-30
+
+package audioutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// DRM reason strings returned by DetectDRM. Kept as plain strings (not an
+// exported type) so callers can log/serialize them without a conversion --
+// mirrors how audioutil.Chapter's Title is a plain string, not an enum.
+const (
+	ReasonAudibleAAX  = "audible-aax"
+	ReasonAudibleAAXC = "audible-aaxc"
+)
+
+// DetectDRM reports whether filePath is a DRM-protected audiobook format
+// this app cannot decode or play, and why.
+//
+// Detection is extension-only (case-insensitive) and deliberately does NOT
+// probe the container or codec: ffprobe/ffmpeg ship an unrelated demuxer
+// literally named "aax" (CRIWARE AAX, a game-audio codec, nothing to do
+// with Audible), and Audible's own AAX/AAXC container is otherwise a
+// standard MPEG-4 box structure that ffprobe reads happily -- only the
+// audio ESSENCE is encrypted, so there is no verified, repo-testable
+// codec/format signature to check without a real Audible sample file
+// (none exists in testdata/ and none should be fabricated). This means a
+// renamed .aax -> .m4b file defeats detection; that is a known,
+// documented limitation, not an oversight.
+//
+// Every extension in config.AppConfig's default SupportedExtensions list
+// is otherwise treated as NOT protected -- this function must never flag a
+// legitimate m4b/m4a/mp3/flac/etc. file.
+func DetectDRM(filePath string) (protected bool, reason string) {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".aax":
+		return true, ReasonAudibleAAX
+	case ".aaxc":
+		return true, ReasonAudibleAAXC
+	default:
+		return false, ""
+	}
+}

--- a/internal/audioutil/drm_test.go
+++ b/internal/audioutil/drm_test.go
@@ -1,0 +1,115 @@
+// file: internal/audioutil/drm_test.go
+// version: 1.1.0
+// guid: f4be988f-5955-47d8-9379-ed828481fe27
+// last-edited: 2026-07-30
+
+package audioutil
+
+import "testing"
+
+// realFixturePaths are legitimate, DRM-free audio fixtures already committed
+// to this repo. DetectDRM must never flag any of these as protected -- a
+// false positive here would make a user's legitimate library unplayable,
+// which is worse than the opaque-failure bug this task is fixing.
+var realFixturePaths = []string{
+	"../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4b",
+	"../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_01_homer_butler_64kb.mp3",
+	"../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4a",
+	"../../testdata/fixtures/test_sample.flac",
+	"../../testdata/fixtures/test_sample.m4b",
+	"../../testdata/fixtures/test_sample.mp3",
+}
+
+func TestDetectDRM_AAXExtension_Protected(t *testing.T) {
+	cases := []string{
+		"/any/path/book.aax",
+		"/any/path/book.AAX",
+		"/any/path/book.Aax",
+		"/any/path/book.aAx",
+	}
+	for _, path := range cases {
+		protected, reason := DetectDRM(path)
+		if !protected {
+			t.Errorf("DetectDRM(%q) protected = false, want true", path)
+		}
+		if reason != ReasonAudibleAAX {
+			t.Errorf("DetectDRM(%q) reason = %q, want %q", path, reason, ReasonAudibleAAX)
+		}
+	}
+}
+
+func TestDetectDRM_AAXCExtension_Protected(t *testing.T) {
+	cases := []string{
+		"/any/path/book.aaxc",
+		"/any/path/book.AAXC",
+		"/any/path/book.Aaxc",
+		"/any/path/book.aAxC",
+	}
+	for _, path := range cases {
+		protected, reason := DetectDRM(path)
+		if !protected {
+			t.Errorf("DetectDRM(%q) protected = false, want true", path)
+		}
+		if reason != ReasonAudibleAAXC {
+			t.Errorf("DetectDRM(%q) reason = %q, want %q", path, reason, ReasonAudibleAAXC)
+		}
+	}
+}
+
+func TestDetectDRM_RealFixtures_NotMisclassified(t *testing.T) {
+	for _, path := range realFixturePaths {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			requireFixture(t, path)
+
+			protected, reason := DetectDRM(path)
+			if protected {
+				t.Errorf("DetectDRM(%q) protected = true, want false", path)
+			}
+			if reason != "" {
+				t.Errorf("DetectDRM(%q) reason = %q, want empty", path, reason)
+			}
+		})
+	}
+}
+
+func TestDetectDRM_UnrelatedExtensions_NotProtected(t *testing.T) {
+	// The full non-DRM list from config.AppConfig's default
+	// SupportedExtensions, minus .aax/.aaxc. Synthetic paths -- this proves
+	// the string-matching logic itself doesn't over-match (e.g. doesn't
+	// accidentally treat ".m4a" as matching some ".aax"-adjacent check).
+	extensions := []string{
+		".m4b", ".mp3", ".m4a", ".aac", ".ogg", ".flac", ".wma",
+		".opus", ".oga", ".wav", ".aiff", ".aif", ".mka",
+	}
+	for _, ext := range extensions {
+		path := "/library/book" + ext
+		protected, reason := DetectDRM(path)
+		if protected {
+			t.Errorf("DetectDRM(%q) protected = true, want false", path)
+		}
+		if reason != "" {
+			t.Errorf("DetectDRM(%q) reason = %q, want empty", path, reason)
+		}
+	}
+}
+
+func TestDetectDRM_EmptyPath_NotProtected(t *testing.T) {
+	protected, reason := DetectDRM("")
+	if protected {
+		t.Errorf("DetectDRM(\"\") protected = true, want false")
+	}
+	if reason != "" {
+		t.Errorf("DetectDRM(\"\") reason = %q, want empty", reason)
+	}
+}
+
+func TestDetectDRM_NoExtension_NotProtected(t *testing.T) {
+	protected, reason := DetectDRM("/path/README")
+	if protected {
+		t.Errorf("DetectDRM(\"/path/README\") protected = true, want false")
+	}
+	if reason != "" {
+		t.Errorf("DetectDRM(\"/path/README\") reason = %q, want empty", reason)
+	}
+}


### PR DESCRIPTION
## Summary

Implements TASK-10 (abs-sync Phase 4, Wave 1) — adds `audioutil.DetectDRM(filePath string) (protected bool, reason string)`, a dependency-free, extension-only check that flags Audible's DRM-protected `.aax`/`.aaxc` formats. Detection only: no scanner wiring, no config/store changes, no import-pipeline change. `.aax`/`.aaxc` are already in the default `SupportedExtensions` (`internal/config/config.go:2016`) with zero DRM awareness today — this is the first step toward surfacing those files as "unplayable, here's why" instead of importing them to fail opaquely at play time.

## Scope discipline

- Touches only `internal/audioutil/drm.go` (new) and `internal/audioutil/drm_test.go` (new), plus the changelog fragment.
- No edits to `internal/scanner/**`, `internal/config/**`, or `internal/database/**`.
- No `go.mod`/`go.sum` changes — standard library only (`path/filepath`, `strings`).

## Design decision: extension-only, not codec/format-based

Verified via `ffprobe -demuxers | grep -i aax` that ffmpeg's `"aax"` demuxer is CRIWARE game audio, unrelated to Audible's format. Audible's real AAX/AAXC container is a standard MPEG-4 box structure (only the audio *essence* is encrypted), so there is no verified, repo-testable codec/format signature to check without a real Audible sample — none exists in `testdata/` and none should be fabricated. `DetectDRM` is therefore extension-only for the MVP; the doc comment states this limitation explicitly (a renamed `evil.aax` → `evil.m4b` defeats detection) rather than shipping an unverified heuristic.

## Deviations from the brief (flagged explicitly per instructions)

1. The brief's background section predicted `grep -rn "DRM" internal | grep -v _test` would return 0 hits before this task. It does not: `internal/diagnosis/probe.go` already has an unrelated, richer DRM probe (`HasActiveDRM`, `WasOriginallyDRM`, `ReasonActiveDRM`/`ReasonOriginallyDRM`, mediainfo-based). This does not conflict with this task's scope (different package, different detection approach, no `DetectDRM`/`IsDRMProtected` symbol existed) — noting it here as a natural spot a future scanner-wiring task may want to reconcile with this cheap extension check.
2. Added two extra real fixtures to the negative-test table beyond the brief's four (`testdata/fixtures/test_sample.m4b`, `testdata/fixtures/test_sample.mp3`) for closer alignment with the launching instructions' named negative fixtures. All 6 real-fixture subtests pass (no skips needed — all fixtures present in this environment).

## Test plan

```
$ gofmt -l internal/audioutil/drm.go internal/audioutil/drm_test.go
(no output)

$ go vet ./internal/audioutil/...
(no output)

$ go test ./internal/audioutil/... -run TestDetectDRM -race -count=1 -v
=== RUN   TestDetectDRM_AAXExtension_Protected
--- PASS: TestDetectDRM_AAXExtension_Protected (0.00s)
=== RUN   TestDetectDRM_AAXCExtension_Protected
--- PASS: TestDetectDRM_AAXCExtension_Protected (0.00s)
=== RUN   TestDetectDRM_RealFixtures_NotMisclassified
    --- PASS: .../odyssey_complete.m4b (0.00s)
    --- PASS: .../odyssey_01_homer_butler_64kb.mp3 (0.00s)
    --- PASS: .../odyssey_complete.m4a (0.00s)
    --- PASS: .../test_sample.flac (0.00s)
    --- PASS: .../test_sample.m4b (0.00s)
    --- PASS: .../test_sample.mp3 (0.00s)
--- PASS: TestDetectDRM_RealFixtures_NotMisclassified (0.00s)
=== RUN   TestDetectDRM_UnrelatedExtensions_NotProtected
--- PASS: TestDetectDRM_UnrelatedExtensions_NotProtected (0.00s)
=== RUN   TestDetectDRM_EmptyPath_NotProtected
--- PASS: TestDetectDRM_EmptyPath_NotProtected (0.00s)
=== RUN   TestDetectDRM_NoExtension_NotProtected
--- PASS: TestDetectDRM_NoExtension_NotProtected (0.00s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/audioutil	1.244s

$ go test ./internal/audioutil/... -race -count=1
ok  	github.com/falkcorp/audiobook-organizer/internal/audioutil	1.894s

$ go build ./...
(clean, no output)
```

- [x] `internal/audioutil/drm.go` exists with `DetectDRM(filePath string) (protected bool, reason string)`, extension-only, no I/O, no ffprobe subprocess call
- [x] All 6 test groups pass (no skips needed in this environment; fixtures all present)
- [x] Case-insensitive: `.AAX`/`.Aax`/`.aAx` and `.AAXC`/`.Aaxc`/`.aAxC` all detected identically
- [x] None of the real fixtures or any entry in `config.AppConfig`'s default non-DRM extension list is ever flagged `protected=true`
- [x] No edit to `internal/scanner/**`, `internal/config/**`, or `internal/database/**`
- [x] `gofmt -l` and `go vet` clean
- [x] File headers present with fresh GUIDs on both new files
- [x] Changelog fragment added at `changelog.d/20260730_061000_abs-sync-drm-detection.md`

Not merging this PR per instructions — leaving open for review/CI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt