### PR TITLE
feat(abs-sync): add sync_file keyspace for durable per-file ABS ino (ABS-SYNC-ID-2)

### DIFF
--- a/changelog.d/abs-sync-syncfile-keyspace.md
+++ b/changelog.d/abs-sync-syncfile-keyspace.md
@@ -1,0 +1,36 @@
+<!-- file: changelog.d/abs-sync-syncfile-keyspace.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 63f63dc2-4e48-4588-9c47-6ea212aa0ae9 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+#### `sync_file` keyspace for durable per-file ABS `ino` (ABS-SYNC-ID-2)
+
+Added `internal/database/pebble_store_syncfile.go`: a `sync_file:` Pebble keyspace
+giving every `BookFile` a durable identity for the ABS-compatible file-addressing
+scheme, `contentUrl: /api/items/{itemId}/file/{ino}`. The captured ABS conformance
+fixtures show `ino` is an opaque string (ABS's filesystem inode) that offline clients
+cache in downloaded-file URLs. This app's core job is moving and reorganizing files,
+so deriving `ino` from a path or inode would break every already-downloaded book after
+a reorganization.
+
+`BookFile.ID` is already a stable ULID that survives in-place moves/retags
+(`UpdateBookFile` never regenerates it), but a **replacement** (old row deleted, new
+row created with a new `BookFile.ID` -- e.g. a remux or quality upgrade) has no
+existing seam to keep a cached client URL resolving. `MintOrGetSyncFileID(bookID,
+fileID)` mints a `syncFileID` (via the existing `newULID()` helper -- `ino` has no
+length constraint, unlike TASK-01's `libraryItemId`) keyed to the `(bookID, fileID)`
+pair (mirroring `BookFile`'s own `book_file:<bookID>:<fileID>` primary key), with a
+`sync_file:lookup:<bookID>:<fileID>` reverse index for O(1) resolution and an
+enumerable `sync_file:book:<bookID>:<syncFileID>` index so a caller can list every
+`sync_file` entry for a book without knowing IDs up front. `RepointSyncFile(bookID,
+oldFileID, newFileID)` moves the lookup index for a future file-replacement path (no
+caller yet -- this is additive-only groundwork, same as TASK-01's `sync_item`
+keyspace). A package-level `syncFileMintMu` mutex (separate from TASK-01's
+`syncIDMintMu`) guards the check-then-mint race.
+
+New capability interface `SyncFileStore` / `AsSyncFileStore(s any)` follows the
+existing type-assertion pattern for adding a capability without touching the `Store`
+interface in `store.go`. Nothing reads or writes `sync_file:*` keys yet outside this
+task's own tests.

--- a/internal/database/pebble_store_syncfile.go
+++ b/internal/database/pebble_store_syncfile.go
@@ -1,0 +1,266 @@
+// file: internal/database/pebble_store_syncfile.go
+// version: 1.0.0
+// guid: 92ebd115-9f89-4400-ac26-bf9a065b6153
+// last-edited: 2026-07-30
+
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// SyncFile is the durable per-file identity record backing the ABS
+// contentUrl file addressing scheme (/api/items/{itemId}/file/{ino}). See
+// docs/specs/2026-07-29-abs-sync-api-design.md §4.2b.
+//
+// ino must survive file replacement (same logical track, new physical
+// BookFile row -- a remux or a quality upgrade), which is why it is
+// indirected through this keyspace instead of exposing BookFile.ID
+// directly: BookFile.ID is stable across in-place updates but a genuinely
+// new row (delete+create) mints a fresh ULID with nothing to preserve an
+// offline client's cached download URL.
+type SyncFile struct {
+	SyncFileID    string    `json:"sync_file_id"`
+	BookID        string    `json:"book_id"`
+	CurrentFileID string    `json:"current_file_id"` // the live BookFile.ID
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// syncFileMintMu guards the check-then-mint race in MintOrGetSyncFileID.
+// Separate from TASK-01's syncIDMintMu (sync_item keyspace): the two
+// keyspaces are independent, so there is no reason to serialize unrelated
+// work behind a shared lock.
+var syncFileMintMu sync.Mutex
+
+// SyncFileStore is a small additive capability interface for the sync_file
+// keyspace. It is intentionally NOT added to the Store interface in
+// store.go -- callers type-assert via AsSyncFileStore instead, so adding
+// this capability never requires touching every other Store implementation
+// (mocks included).
+type SyncFileStore interface {
+	MintOrGetSyncFileID(bookID, fileID string) (string, error)
+	GetSyncFileID(bookID, fileID string) (string, bool, error)
+	ListSyncFilesForBook(bookID string) ([]SyncFile, error)
+	RepointSyncFile(bookID, oldFileID, newFileID string) error
+}
+
+// AsSyncFileStore type-asserts s into a SyncFileStore, returning nil if s is
+// nil or does not implement the capability.
+func AsSyncFileStore(s any) SyncFileStore {
+	if s == nil {
+		return nil
+	}
+	if sf, ok := s.(SyncFileStore); ok {
+		return sf
+	}
+	return nil
+}
+
+func syncFileLookupKey(bookID, fileID string) []byte {
+	return []byte(fmt.Sprintf("sync_file:lookup:%s:%s", bookID, fileID))
+}
+
+func syncFileBookKey(bookID, syncFileID string) []byte {
+	return []byte(fmt.Sprintf("sync_file:book:%s:%s", bookID, syncFileID))
+}
+
+func syncFileRecordKey(syncFileID string) []byte {
+	return []byte(fmt.Sprintf("sync_file:%s", syncFileID))
+}
+
+// MintOrGetSyncFileID returns the durable syncFileID for the (bookID,
+// fileID) pair, minting one on first encounter. Concurrent callers racing
+// on the same pair all observe the same winning ID.
+func (s *PebbleStore) MintOrGetSyncFileID(bookID, fileID string) (string, error) {
+	if bookID == "" {
+		return "", fmt.Errorf("MintOrGetSyncFileID: bookID must not be empty")
+	}
+	if fileID == "" {
+		return "", fmt.Errorf("MintOrGetSyncFileID: fileID must not be empty")
+	}
+
+	syncFileMintMu.Lock()
+	defer syncFileMintMu.Unlock()
+
+	lookupKey := syncFileLookupKey(bookID, fileID)
+	existing, closer, err := s.db.Get(lookupKey)
+	if err == nil {
+		id := string(existing)
+		closer.Close()
+		return id, nil
+	}
+	if err != pebble.ErrNotFound {
+		return "", err
+	}
+
+	syncFileID, err := newULID()
+	if err != nil {
+		return "", err
+	}
+
+	record := SyncFile{
+		SyncFileID:    syncFileID,
+		BookID:        bookID,
+		CurrentFileID: fileID,
+		CreatedAt:     time.Now(),
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal sync_file record: %w", err)
+	}
+
+	batch := s.db.NewBatch()
+	if err := batch.Set(syncFileRecordKey(syncFileID), data, nil); err != nil {
+		batch.Close()
+		return "", err
+	}
+	if err := batch.Set(lookupKey, []byte(syncFileID), nil); err != nil {
+		batch.Close()
+		return "", err
+	}
+	if err := batch.Set(syncFileBookKey(bookID, syncFileID), []byte(fileID), nil); err != nil {
+		batch.Close()
+		return "", err
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return "", err
+	}
+
+	return syncFileID, nil
+}
+
+// GetSyncFileID performs a read-only lookup of the syncFileID for a
+// (bookID, fileID) pair. Returns ("", false, nil) when no entry exists.
+func (s *PebbleStore) GetSyncFileID(bookID, fileID string) (string, bool, error) {
+	value, closer, err := s.db.Get(syncFileLookupKey(bookID, fileID))
+	if err == pebble.ErrNotFound {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	id := string(value)
+	closer.Close()
+	return id, true, nil
+}
+
+// ListSyncFilesForBook returns every sync_file entry minted for bookID, by
+// prefix-scanning the enumerable sync_file:book:<bookID>: index and
+// materializing each referenced SyncFile record.
+func (s *PebbleStore) ListSyncFilesForBook(bookID string) ([]SyncFile, error) {
+	prefix := []byte(fmt.Sprintf("sync_file:book:%s:", bookID))
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: append(append([]byte{}, prefix...), 0xFF),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var out []SyncFile
+	for iter.First(); iter.Valid(); iter.Next() {
+		syncFileID := string(iter.Key()[len(prefix):])
+
+		recData, closer, err := s.db.Get(syncFileRecordKey(syncFileID))
+		if err != nil {
+			if err == pebble.ErrNotFound {
+				continue
+			}
+			return nil, err
+		}
+		var rec SyncFile
+		unmarshalErr := json.Unmarshal(recData, &rec)
+		closer.Close()
+		if unmarshalErr != nil {
+			return nil, fmt.Errorf("failed to unmarshal sync_file record %q: %w", syncFileID, unmarshalErr)
+		}
+		out = append(out, rec)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// RepointSyncFile moves the sync_file identity for bookID from oldFileID to
+// newFileID -- the file-level analogue of TASK-01's RepointSyncItem, for a
+// future file-replacement path (remux, quality upgrade) that does not exist
+// yet. If no sync_file entry is registered for (bookID, oldFileID), this is
+// a no-op returning nil.
+func (s *PebbleStore) RepointSyncFile(bookID, oldFileID, newFileID string) error {
+	if bookID == "" {
+		return fmt.Errorf("RepointSyncFile: bookID must not be empty")
+	}
+	if oldFileID == "" {
+		return fmt.Errorf("RepointSyncFile: oldFileID must not be empty")
+	}
+	if newFileID == "" {
+		return fmt.Errorf("RepointSyncFile: newFileID must not be empty")
+	}
+
+	syncFileMintMu.Lock()
+	defer syncFileMintMu.Unlock()
+
+	oldLookupKey := syncFileLookupKey(bookID, oldFileID)
+	existing, closer, err := s.db.Get(oldLookupKey)
+	if err == pebble.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	syncFileID := string(existing)
+	closer.Close()
+
+	recData, recCloser, err := s.db.Get(syncFileRecordKey(syncFileID))
+	if err != nil {
+		return err
+	}
+	var rec SyncFile
+	unmarshalErr := json.Unmarshal(recData, &rec)
+	recCloser.Close()
+	if unmarshalErr != nil {
+		return fmt.Errorf("failed to unmarshal sync_file record %q: %w", syncFileID, unmarshalErr)
+	}
+	rec.CurrentFileID = newFileID
+
+	updatedData, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sync_file record: %w", err)
+	}
+
+	batch := s.db.NewBatch()
+	if err := batch.Delete(oldLookupKey, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Delete(syncFileBookKey(bookID, syncFileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncFileBookKey(bookID, syncFileID), []byte(newFileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncFileLookupKey(bookID, newFileID), []byte(syncFileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncFileRecordKey(syncFileID), updatedData, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/database/pebble_store_syncfile_test.go
+++ b/internal/database/pebble_store_syncfile_test.go
@@ -1,0 +1,281 @@
+// file: internal/database/pebble_store_syncfile_test.go
+// version: 1.0.0
+// guid: 80186a0c-f2d2-4c17-9ef2-cfb78d441e1f
+// last-edited: 2026-07-30
+
+package database
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func newSyncFileTestStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestSyncFile_MintOnFirstEncounter_Idempotent(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	id1, err := store.MintOrGetSyncFileID("book-1", "file-1")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if id1 == "" {
+		t.Fatal("expected non-empty syncFileID")
+	}
+
+	id2, err := store.MintOrGetSyncFileID("book-1", "file-1")
+	if err != nil {
+		t.Fatalf("mint again: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("expected same syncFileID on repeat mint, got %q then %q", id1, id2)
+	}
+}
+
+func TestSyncFile_DifferentFilesOnSameBook_GetDifferentIDs(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	id1, err := store.MintOrGetSyncFileID("book-1", "file-1")
+	if err != nil {
+		t.Fatalf("mint file-1: %v", err)
+	}
+	id2, err := store.MintOrGetSyncFileID("book-1", "file-2")
+	if err != nil {
+		t.Fatalf("mint file-2: %v", err)
+	}
+	if id1 == id2 {
+		t.Fatalf("expected distinct syncFileIDs for distinct files, got same %q", id1)
+	}
+}
+
+func TestSyncFile_SameFileIDOnDifferentBooks_NoCollision(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	id1, err := store.MintOrGetSyncFileID("book-1", "shared-file-id")
+	if err != nil {
+		t.Fatalf("mint book-1: %v", err)
+	}
+	id2, err := store.MintOrGetSyncFileID("book-2", "shared-file-id")
+	if err != nil {
+		t.Fatalf("mint book-2: %v", err)
+	}
+	if id1 == id2 {
+		t.Fatalf("expected independent syncFileIDs across books for same fileID, got same %q", id1)
+	}
+
+	// Re-fetch confirms each book's mapping is independent and stable.
+	got1, ok, err := store.GetSyncFileID("book-1", "shared-file-id")
+	if err != nil || !ok {
+		t.Fatalf("get book-1: ok=%v err=%v", ok, err)
+	}
+	if got1 != id1 {
+		t.Fatalf("book-1 lookup mismatch: got %q want %q", got1, id1)
+	}
+
+	got2, ok, err := store.GetSyncFileID("book-2", "shared-file-id")
+	if err != nil || !ok {
+		t.Fatalf("get book-2: ok=%v err=%v", ok, err)
+	}
+	if got2 != id2 {
+		t.Fatalf("book-2 lookup mismatch: got %q want %q", got2, id2)
+	}
+}
+
+func TestSyncFile_GetSyncFileID_NotFound(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	id, ok, err := store.GetSyncFileID("no-such-book", "no-such-file")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected not-found, got ok=true id=%q", id)
+	}
+	if id != "" {
+		t.Fatalf("expected empty id on not-found, got %q", id)
+	}
+}
+
+func TestSyncFile_ListSyncFilesForBook_ScopedPerBook(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	if _, err := store.MintOrGetSyncFileID("book-1", "file-a"); err != nil {
+		t.Fatalf("mint book-1/file-a: %v", err)
+	}
+	if _, err := store.MintOrGetSyncFileID("book-1", "file-b"); err != nil {
+		t.Fatalf("mint book-1/file-b: %v", err)
+	}
+	if _, err := store.MintOrGetSyncFileID("book-2", "file-c"); err != nil {
+		t.Fatalf("mint book-2/file-c: %v", err)
+	}
+
+	list1, err := store.ListSyncFilesForBook("book-1")
+	if err != nil {
+		t.Fatalf("list book-1: %v", err)
+	}
+	if len(list1) != 2 {
+		t.Fatalf("expected 2 entries for book-1, got %d: %+v", len(list1), list1)
+	}
+	seenFileIDs := map[string]bool{}
+	for _, sf := range list1 {
+		if sf.BookID != "book-1" {
+			t.Fatalf("entry has wrong BookID: %+v", sf)
+		}
+		seenFileIDs[sf.CurrentFileID] = true
+	}
+	if !seenFileIDs["file-a"] || !seenFileIDs["file-b"] {
+		t.Fatalf("expected file-a and file-b in list1, got %+v", list1)
+	}
+
+	list2, err := store.ListSyncFilesForBook("book-2")
+	if err != nil {
+		t.Fatalf("list book-2: %v", err)
+	}
+	if len(list2) != 1 {
+		t.Fatalf("expected 1 entry for book-2, got %d: %+v", len(list2), list2)
+	}
+	if list2[0].CurrentFileID != "file-c" {
+		t.Fatalf("expected file-c for book-2, got %+v", list2[0])
+	}
+
+	listNone, err := store.ListSyncFilesForBook("book-none")
+	if err != nil {
+		t.Fatalf("list book-none: %v", err)
+	}
+	if len(listNone) != 0 {
+		t.Fatalf("expected 0 entries for book with no sync files, got %d", len(listNone))
+	}
+}
+
+func TestSyncFile_RepointSyncFile_MovesLookupIndex(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	original, err := store.MintOrGetSyncFileID("book-1", "old-file-id")
+	if err != nil {
+		t.Fatalf("mint original: %v", err)
+	}
+
+	if err := store.RepointSyncFile("book-1", "old-file-id", "new-file-id"); err != nil {
+		t.Fatalf("repoint: %v", err)
+	}
+
+	// The syncFileID must now resolve via the new fileID and carry the same identity.
+	viaNew, ok, err := store.GetSyncFileID("book-1", "new-file-id")
+	if err != nil || !ok {
+		t.Fatalf("get via new fileID: ok=%v err=%v", ok, err)
+	}
+	if viaNew != original {
+		t.Fatalf("expected repoint to preserve syncFileID %q, got %q", original, viaNew)
+	}
+
+	// The old (bookID, fileID) pair no longer resolves.
+	_, ok, err = store.GetSyncFileID("book-1", "old-file-id")
+	if err != nil {
+		t.Fatalf("get via old fileID: %v", err)
+	}
+	if ok {
+		t.Fatal("expected old (bookID, fileID) pair to no longer resolve after repoint")
+	}
+
+	// Minting again on the OLD pair must produce a brand NEW, different syncFileID --
+	// proving the lookup index really moved rather than merely being duplicated.
+	reMinted, err := store.MintOrGetSyncFileID("book-1", "old-file-id")
+	if err != nil {
+		t.Fatalf("re-mint on old pair: %v", err)
+	}
+	if reMinted == original {
+		t.Fatalf("expected re-mint on stale (bookID, oldFileID) to mint a NEW id, got the same original %q", reMinted)
+	}
+
+	// The book-level index should now reflect the new fileID for the original syncFileID.
+	list, err := store.ListSyncFilesForBook("book-1")
+	if err != nil {
+		t.Fatalf("list after repoint: %v", err)
+	}
+	foundNew := false
+	for _, sf := range list {
+		if sf.SyncFileID == original && sf.CurrentFileID == "new-file-id" {
+			foundNew = true
+		}
+	}
+	if !foundNew {
+		t.Fatalf("expected list to show original syncFileID %q pointing at new-file-id, got %+v", original, list)
+	}
+}
+
+func TestSyncFile_RepointSyncFile_NoOpWhenNothingToRepoint(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	if err := store.RepointSyncFile("book-1", "never-existed", "new-file-id"); err != nil {
+		t.Fatalf("expected nil error for no-op repoint, got %v", err)
+	}
+}
+
+func TestSyncFile_ConcurrentMintRace_SingleWinner(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	const workers = 16
+	ids := make([]string, workers)
+	errs := make([]error, workers)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			id, err := store.MintOrGetSyncFileID("race-book", "race-file")
+			ids[idx] = id
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+	}
+	first := ids[0]
+	if first == "" {
+		t.Fatal("expected non-empty syncFileID")
+	}
+	for i, id := range ids {
+		if id != first {
+			t.Fatalf("worker %d produced divergent syncFileID %q, want %q", i, id, first)
+		}
+	}
+
+	list, err := store.ListSyncFilesForBook("race-book")
+	if err != nil {
+		t.Fatalf("list race-book: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected exactly 1 live sync_file record after race, got %d: %+v", len(list), list)
+	}
+}
+
+func TestAsSyncFileStore(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	sf := AsSyncFileStore(store)
+	if sf == nil {
+		t.Fatal("expected *PebbleStore to satisfy SyncFileStore")
+	}
+
+	if AsSyncFileStore(nil) != nil {
+		t.Fatal("expected nil input to yield nil SyncFileStore")
+	}
+
+	if AsSyncFileStore("not a store") != nil {
+		t.Fatal("expected non-conforming type to yield nil SyncFileStore")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements TASK-02 (`docs/agent-tasks/abs-sync/TASK-02-syncfile-keyspace.md`): a durable `sync_file:` Pebble keyspace giving every `BookFile` a stable identity for ABS's `contentUrl: /api/items/{itemId}/file/{ino}` file addressing, per `docs/specs/2026-07-29-abs-sync-api-design.md` §4.2b.
- New file `internal/database/pebble_store_syncfile.go`: `SyncFile` struct, `SyncFileStore` interface, `AsSyncFileStore(s any)` helper, `MintOrGetSyncFileID`, `GetSyncFileID`, `ListSyncFilesForBook`, `RepointSyncFile` — all on `*PebbleStore`, none added to `internal/database/store.go` (zero diff there, verified below).
- Keys: `sync_file:<syncFileID>` (record), `sync_file:lookup:<bookID>:<fileID>` (reverse lookup), `sync_file:book:<bookID>:<syncFileID>` (enumerable per-book index) — all under the `sync_file:` prefix so they never collide with TASK-01's `sync_item:` keys.
- IDs minted via the existing `newULID()` helper (no new dependency; `ino` has no length constraint unlike TASK-01's `libraryItemId`, so no UUID-minting requirement applies here).
- Additive only — nothing reads or writes `sync_file:*` keys outside this task's own tests yet. `RepointSyncFile` exists for a future file-replacement path (no caller yet, matching TASK-01's `RepointSyncItem`).
- Own `changelog.d/abs-sync-syncfile-keyspace.md` fragment (guid `63f63dc2-4e48-4588-9c47-6ea212aa0ae9`), category `Added`.

TASK-01 (`sync_item` keyspace) had not merged into `origin/main` at the time this branch was cut, so `pebble_store_syncfile.go` was created fresh rather than appended to.

## File ownership

Per the (revised) task brief, this PR touches only:
- `internal/database/pebble_store_syncfile.go` (new)
- `internal/database/pebble_store_syncfile_test.go` (new)
- `changelog.d/abs-sync-syncfile-keyspace.md` (new)

No edits to `internal/database/store.go` or `internal/database/pebble_store_syncid.go`.

## Test plan

TDD: wrote `pebble_store_syncfile_test.go` first, confirmed it failed to compile (`MintOrGetSyncFileID undefined`, etc. — the expected reason, no implementation existed yet), then implemented `pebble_store_syncfile.go` until green.

### `go test ./internal/database/... -run SyncFile -race -count=1 -v`

```
=== RUN   TestSyncFile_MintOnFirstEncounter_Idempotent
--- PASS: TestSyncFile_MintOnFirstEncounter_Idempotent (0.15s)
=== RUN   TestSyncFile_DifferentFilesOnSameBook_GetDifferentIDs
--- PASS: TestSyncFile_DifferentFilesOnSameBook_GetDifferentIDs (0.15s)
=== RUN   TestSyncFile_SameFileIDOnDifferentBooks_NoCollision
--- PASS: TestSyncFile_SameFileIDOnDifferentBooks_NoCollision (0.15s)
=== RUN   TestSyncFile_GetSyncFileID_NotFound
--- PASS: TestSyncFile_GetSyncFileID_NotFound (0.14s)
=== RUN   TestSyncFile_ListSyncFilesForBook_ScopedPerBook
--- PASS: TestSyncFile_ListSyncFilesForBook_ScopedPerBook (0.14s)
=== RUN   TestSyncFile_RepointSyncFile_MovesLookupIndex
--- PASS: TestSyncFile_RepointSyncFile_MovesLookupIndex (0.13s)
=== RUN   TestSyncFile_RepointSyncFile_NoOpWhenNothingToRepoint
--- PASS: TestSyncFile_RepointSyncFile_NoOpWhenNothingToRepoint (0.15s)
=== RUN   TestSyncFile_ConcurrentMintRace_SingleWinner
--- PASS: TestSyncFile_ConcurrentMintRace_SingleWinner (0.14s)
=== RUN   TestAsSyncFileStore
--- PASS: TestAsSyncFileStore (0.14s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/database	2.709s
```

(9/9 new tests pass under `-race`; PebbleDB/memdb-warmup INFO/WARN log lines omitted for brevity — all runs opened a fresh `t.TempDir()` store per test as expected.)

### Full package suite: `go test ./internal/database/ -race -count=1`

Ran in the background (large suite, ~7 min):

```
ok  	github.com/falkcorp/audiobook-organizer/internal/database	422.357s
```

No regressions — TASK-01's `sync_item` code had not landed on `origin/main` yet at branch-cut time, so there was no `-run SyncID` target to additionally verify.

### `go build ./...`
Clean, no output.

### `gofmt -l internal/database/pebble_store_syncfile.go internal/database/pebble_store_syncfile_test.go`
Clean, no output (no files listed).

### `go vet ./internal/database/...`
Clean, no output.

### `internal/database/store.go` diff
```
$ git diff --stat -- internal/database/store.go
(empty)
```
Zero diff, confirmed.

## Acceptance criteria

- [x] `SyncFile`, `SyncFileStore`, `AsSyncFileStore`, `MintOrGetSyncFileID`, `GetSyncFileID`, `ListSyncFilesForBook`, `RepointSyncFile` all exist on `*PebbleStore`, none added to `internal/database/store.go`
- [x] Mint-on-first-encounter, per-book isolation, and cross-book non-collision tests pass
- [x] `RepointSyncFile` test passes (old pair re-mints a new, different ID)
- [x] Concurrent mint-race test passes under `-race` with no race and one live record
- [x] `go build ./...`, `gofmt -l`, `go vet ./internal/database/...` all clean
- [x] `internal/database/store.go` has zero diff
- [ ] N/A — TASK-01 had not landed on `origin/main` yet, so there were no pre-existing `SyncID`-prefixed tests to re-verify
- [x] File headers present and bumped (fresh files, v1.0.0)
- [x] `changelog.d/abs-sync-syncfile-keyspace.md` added

## Not merging

Per the driving task's instructions, this PR is opened for review only — **not merged**.
