### PR TITLE
feat(abs-sync): add persisted Chapter type + Pebble keyspace on PebbleStore

### DIFF
--- a/changelog.d/20260730_060600_abs-sync-chapter-persistence.md
+++ b/changelog.d/20260730_060600_abs-sync-chapter-persistence.md
@@ -1,0 +1,11 @@
+<!-- file: changelog.d/20260730_060600_abs-sync-chapter-persistence.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 83e4309d-6551-404b-816b-11b475cf8a92 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+- **Persisted chapter storage (abs-sync Phase 4).** Added a `database.Chapter` type and
+  `PebbleStore.{Get,Save,Delete}ChaptersForBook` methods, storing one ordered chapter list per book
+  under a new `chapters:<bookID>` Pebble key. Chapters are deleted when their book is deleted. Pure
+  persistence layer — extraction (ffprobe) and scanner wiring land in a follow-up task.

--- a/internal/database/pebble_store.go
+++ b/internal/database/pebble_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store.go
-// version: 1.118.0
+// version: 1.119.0
 // guid: 0c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f
-// last-edited: 2026-07-18
+// last-edited: 2026-07-30
 
 package database
 
@@ -2323,6 +2323,12 @@ func (p *PebbleStore) DeleteBook(id string) error {
 	// EmbeddingStore dependency on PebbleStore.
 	embKey := []byte(embVecPfx + "book:" + id)
 	if err := batch.Delete(embKey, nil); err != nil {
+		batch.Close()
+		return err
+	}
+
+	// Delete this book's persisted chapter list (abs-sync TASK-06).
+	if err := batch.Delete([]byte("chapters:"+id), nil); err != nil {
 		batch.Close()
 		return err
 	}

--- a/internal/database/pebble_store_chapters.go
+++ b/internal/database/pebble_store_chapters.go
@@ -1,0 +1,83 @@
+// file: internal/database/pebble_store_chapters.go
+// version: 1.0.0
+// guid: 0f6522aa-ef55-433a-a7b2-73cc1c898134
+// last-edited: 2026-07-30
+
+package database
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// Chapter is a single navigable chapter in a book's playback timeline,
+// persisted per-book in Pebble. Mirrors the four fields a real
+// Audiobookshelf 2.36.0 server requires verbatim
+// (docs/specs/2026-07-29-abs-sync-api-design.md §1.8.5 item 7): chapters[]
+// needs id:Int, start, end, title, with id being an Int index while every
+// other ABS id is a String. ID 0 is a valid first chapter, so it is a plain
+// int, never a pointer/omitempty.
+type Chapter struct {
+	ID       int     `json:"id"`
+	StartSec float64 `json:"start_sec"`
+	EndSec   float64 `json:"end_sec"`
+	Title    string  `json:"title"`
+}
+
+// chaptersKeyPrefix is the prefix every per-book chapters key shares.
+const chaptersKeyPrefix = "chapters:"
+
+func chaptersKey(bookID string) []byte {
+	return []byte(chaptersKeyPrefix + bookID)
+}
+
+// GetChaptersForBook reads the ordered chapter list for bookID, or returns
+// (nil, nil) when no chapters have ever been saved for it. Order is exactly
+// as written by SaveChaptersForBook -- this method never re-sorts.
+func (p *PebbleStore) GetChaptersForBook(bookID string) ([]Chapter, error) {
+	val, closer, err := p.db.Get(chaptersKey(bookID))
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pebble get chapters:%s: %w", bookID, err)
+	}
+	defer closer.Close()
+
+	var chapters []Chapter
+	if err := json.Unmarshal(val, &chapters); err != nil {
+		return nil, fmt.Errorf("decode chapters:%s: %w", bookID, err)
+	}
+	return chapters, nil
+}
+
+// SaveChaptersForBook writes (or replaces) the ordered chapter list for
+// bookID. The caller controls order; this method never re-sorts. Saving a
+// nil or empty slice is equivalent to deleting the entry -- it does not
+// store an empty JSON array blob, so a subsequent GetChaptersForBook returns
+// (nil, nil) rather than ([]Chapter{}, nil).
+func (p *PebbleStore) SaveChaptersForBook(bookID string, chapters []Chapter) error {
+	if len(chapters) == 0 {
+		return p.DeleteChaptersForBook(bookID)
+	}
+	data, err := json.Marshal(chapters)
+	if err != nil {
+		return fmt.Errorf("encode chapters:%s: %w", bookID, err)
+	}
+	if err := p.db.Set(chaptersKey(bookID), data, pebble.Sync); err != nil {
+		return fmt.Errorf("pebble set chapters:%s: %w", bookID, err)
+	}
+	return nil
+}
+
+// DeleteChaptersForBook removes the chapter list for bookID. Missing keys
+// are not an error (mirrors DeleteMetadataCache).
+func (p *PebbleStore) DeleteChaptersForBook(bookID string) error {
+	if err := p.db.Delete(chaptersKey(bookID), pebble.Sync); err != nil {
+		return fmt.Errorf("pebble delete chapters:%s: %w", bookID, err)
+	}
+	return nil
+}

--- a/internal/database/pebble_store_chapters_test.go
+++ b/internal/database/pebble_store_chapters_test.go
@@ -1,0 +1,170 @@
+// file: internal/database/pebble_store_chapters_test.go
+// version: 1.0.0
+// guid: efc1583b-2f69-4546-980f-92bea6798fb2
+// last-edited: 2026-07-30
+
+package database
+
+import (
+	"reflect"
+	"testing"
+)
+
+// odysseyChapters mirrors the real, verified ffprobe -show_chapters output
+// for the committed fixture
+// testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4b (see
+// docs/specs/2026-07-29-abs-sync-api-design.md §5b): 6 embedded chapters,
+// first starting at 0.000000, last ending at 9975.428000. These exact float
+// values are the ground truth this persistence layer must round-trip without
+// coercion or rounding.
+func odysseyChapters() []Chapter {
+	return []Chapter{
+		{ID: 0, StartSec: 0.000000, EndSec: 1386.057000, Title: "Chapter 1: odyssey_01_homer_butler_64kb"},
+		{ID: 1, StartSec: 1386.057000, EndSec: 2788.701000, Title: "Chapter 2: odyssey_02_homer_butler_64kb"},
+		{ID: 2, StartSec: 2788.701000, EndSec: 4309.210000, Title: "Chapter 3: odyssey_03_homer_butler_64kb"},
+		{ID: 3, StartSec: 4309.210000, EndSec: 6928.977000, Title: "Chapter 4: odyssey_04_homer_butler_64kb"},
+		{ID: 4, StartSec: 6928.977000, EndSec: 8602.198000, Title: "Chapter 5: odyssey_05_homer_butler_64kb"},
+		{ID: 5, StartSec: 8602.198000, EndSec: 9975.428000, Title: "Chapter 6: odyssey_06_homer_butler_64kb"},
+	}
+}
+
+// TestGetChaptersForBook_Absent_ReturnsNilNil verifies that a book ID which
+// never had chapters saved returns (nil, nil), not an error -- callers must be
+// able to distinguish "no chapters yet" from a store failure without
+// inspecting error text.
+func TestGetChaptersForBook_Absent_ReturnsNilNil(t *testing.T) {
+	store, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+
+	chs, err := store.GetChaptersForBook("book-that-never-existed")
+	if err != nil {
+		t.Fatalf("GetChaptersForBook() error = %v, want nil", err)
+	}
+	if chs != nil {
+		t.Fatalf("GetChaptersForBook() = %v, want nil", chs)
+	}
+}
+
+// TestSaveAndGetChaptersForBook_RoundTrip saves the real Odyssey fixture's 6
+// chapters and reads them back, asserting exact equality including order --
+// SaveChaptersForBook must not re-sort or coerce the float seconds on write,
+// and GetChaptersForBook must not re-sort on read.
+func TestSaveAndGetChaptersForBook_RoundTrip(t *testing.T) {
+	store, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+
+	const bookID = "book-odyssey"
+	want := odysseyChapters()
+
+	if err := store.SaveChaptersForBook(bookID, want); err != nil {
+		t.Fatalf("SaveChaptersForBook() error = %v", err)
+	}
+
+	got, err := store.GetChaptersForBook(bookID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetChaptersForBook() = %+v, want %+v", got, want)
+	}
+}
+
+// TestSaveChaptersForBook_EmptySlice_DeletesExistingEntry verifies that
+// saving an empty/nil chapter list is equivalent to deleting the entry, not
+// storing an empty JSON array blob -- a subsequent Get must return (nil, nil).
+func TestSaveChaptersForBook_EmptySlice_DeletesExistingEntry(t *testing.T) {
+	store, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+
+	const bookID = "book-odyssey"
+	if err := store.SaveChaptersForBook(bookID, odysseyChapters()); err != nil {
+		t.Fatalf("SaveChaptersForBook(non-empty) error = %v", err)
+	}
+
+	if err := store.SaveChaptersForBook(bookID, nil); err != nil {
+		t.Fatalf("SaveChaptersForBook(nil) error = %v", err)
+	}
+
+	got, err := store.GetChaptersForBook(bookID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetChaptersForBook() after empty save = %v, want nil", got)
+	}
+
+	// Also verify the []Chapter{} (non-nil, zero-length) form behaves the same.
+	if err := store.SaveChaptersForBook(bookID, odysseyChapters()); err != nil {
+		t.Fatalf("SaveChaptersForBook(non-empty) error = %v", err)
+	}
+	if err := store.SaveChaptersForBook(bookID, []Chapter{}); err != nil {
+		t.Fatalf("SaveChaptersForBook([]Chapter{}) error = %v", err)
+	}
+	got, err = store.GetChaptersForBook(bookID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetChaptersForBook() after []Chapter{} save = %v, want nil", got)
+	}
+}
+
+// TestDeleteChaptersForBook_Idempotent verifies that deleting chapters for a
+// book that never had any is not an error (matches Pebble delete-absent-key
+// semantics, mirroring DeleteMetadataCache).
+func TestDeleteChaptersForBook_Idempotent(t *testing.T) {
+	store, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.DeleteChaptersForBook("book-that-never-had-chapters"); err != nil {
+		t.Fatalf("DeleteChaptersForBook() error = %v, want nil", err)
+	}
+	// Calling it a second time must also be a no-op, not an error.
+	if err := store.DeleteChaptersForBook("book-that-never-had-chapters"); err != nil {
+		t.Fatalf("DeleteChaptersForBook() second call error = %v, want nil", err)
+	}
+}
+
+// TestDeleteBook_CascadesChapters verifies that PebbleStore.DeleteBook tears
+// down the book's persisted chapter list, so chapters never outlive their
+// book as orphaned, unreadable Pebble rows.
+func TestDeleteBook_CascadesChapters(t *testing.T) {
+	store, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer store.Close()
+
+	created, err := store.CreateBook(&Book{Title: "Odyssey", FilePath: "/lib/odyssey.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook() error = %v", err)
+	}
+
+	if err := store.SaveChaptersForBook(created.ID, odysseyChapters()); err != nil {
+		t.Fatalf("SaveChaptersForBook() error = %v", err)
+	}
+
+	if err := store.DeleteBook(created.ID); err != nil {
+		t.Fatalf("DeleteBook() error = %v", err)
+	}
+
+	got, err := store.GetChaptersForBook(created.ID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetChaptersForBook() after DeleteBook = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `database.Chapter{ID, StartSec, EndSec, Title}` — the exact four fields a real
  Audiobookshelf 2.36.0 server requires for `chapters[]` (docs/specs/2026-07-29-abs-sync-api-design.md
  §1.8.5 item 7). `ID` is a plain `int` (never `*int`/omitempty) since chapter `0` is a legitimate
  first chapter.
- New `chapters:<bookID>` Pebble keyspace, modeled on the existing `metadata_cache:` single-blob-per-book
  pattern: `GetChaptersForBook`, `SaveChaptersForBook`, `DeleteChaptersForBook` on `*PebbleStore`.
  Saving an empty/nil slice deletes the entry rather than storing an empty JSON array.
- `PebbleStore.DeleteBook` now cascades: one additive `batch.Delete([]byte("chapters:"+id), nil)`
  call next to the dozen sibling secondary-index deletes, before the final `batch.Commit`.
- Pure persistence layer — no ffprobe, no scanner wiring, no `Store` interface changes. TASK-07
  (separate task) consumes these methods via `store.(*database.PebbleStore)`.

Ground-truth chapter values used in the round-trip test were pulled directly from
`ffprobe -show_chapters` on the committed fixture
`testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4b` (6 chapters, first start
`0.000000`, last end `9975.428000`) — not hand-typed approximations.

## Deviation flagged (non-blocking)

The brief's acceptance-criteria grep `grep -c "func (p \*PebbleStore) DeleteBook" internal/database/pebble_store.go`
returns **3**, not the stated expectation of 1 — but this is because the pattern is an unanchored
substring that also matches the pre-existing `DeleteBookTombstone` and `DeleteBookVersion` functions,
not because a duplicate `DeleteBook` was created. Verified with a precise anchor instead:
`grep -cE '^func \(p \*PebbleStore\) DeleteBook\(id string\) error \{' internal/database/pebble_store.go`
→ `1`, confirming no duplicate function was introduced. This is exactly the kind of "line numbers /
greps drift" case the brief itself warned about.

## Verification

`go test ./internal/database/ -run 'Chapter' -race -count=1 -v` (all 5 tests from Step 1):

```
=== RUN   TestGetChaptersForBook_Absent_ReturnsNilNil
--- PASS: TestGetChaptersForBook_Absent_ReturnsNilNil (0.60s)
=== RUN   TestSaveAndGetChaptersForBook_RoundTrip
--- PASS: TestSaveAndGetChaptersForBook_RoundTrip (0.63s)
=== RUN   TestSaveChaptersForBook_EmptySlice_DeletesExistingEntry
--- PASS: TestSaveChaptersForBook_EmptySlice_DeletesExistingEntry (0.90s)
=== RUN   TestDeleteChaptersForBook_Idempotent
--- PASS: TestDeleteChaptersForBook_Idempotent (0.57s)
=== RUN   TestDeleteBook_CascadesChapters
--- PASS: TestDeleteBook_CascadesChapters (0.86s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/database	8.450s
```

Full package, `-race -count=1` (ran in background, ~7.5 min):

```
ok  	github.com/falkcorp/audiobook-organizer/internal/database	450.475s
```

```
$ gofmt -l internal/database/pebble_store_chapters.go internal/database/pebble_store_chapters_test.go internal/database/pebble_store.go
(no output — clean)

$ go vet ./internal/database/...
(no output — clean)

$ go build ./...
(exit 0 — clean)
```

## File ownership

- New: `internal/database/pebble_store_chapters.go`, `internal/database/pebble_store_chapters_test.go`
- One additive line (+ header bump) in `internal/database/pebble_store.go`'s `DeleteBook`, the
  single approved exception in the brief.
- `internal/database/store.go` untouched. `pebble_store_syncid.go` / `pebble_store_syncfile.go`
  untouched (owned by parallel abs-sync tasks; re-confirmed those are read-only grep references in
  the sibling briefs, not conflicting edits).
- Changelog fragment: `changelog.d/20260730_060600_abs-sync-chapter-persistence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
