### PR TITLE
feat(abs-sync): add sync_item keyspace for durable ABS identity (ABS-SYNC-ID-1)

### DIFF
--- a/changelog.d/abs-sync-syncitem-keyspace.md
+++ b/changelog.d/abs-sync-syncitem-keyspace.md
@@ -1,0 +1,35 @@
+<!-- file: changelog.d/abs-sync-syncitem-keyspace.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 791ba524-e776-4bee-861d-7df49c26b297 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+#### `sync_item` keyspace — durable identity for the upcoming ABS sync API (ABS-SYNC-ID-1)
+
+Added a new Pebble keyspace, `sync_item:<syncID>` plus reverse index
+`sync_item:book:<bookID>`, that will back the `libraryItemId` every
+Audiobookshelf-compatible client (Absorb, AudioBooth, etc.) stores progress and
+bookmarks against.
+
+- **Why a separate identity from the Book ULID:** this app's core loop is moving,
+  retagging, and merging books. If the client-visible id were the raw ULID, every
+  dedup merge and every untagged move (which mints a new ULID via version-linking)
+  would silently orphan a device's saved place.
+- **Why a 36-char UUID, not our 26-char ULID:** Absorb (source-audited) splits
+  compound podcast keys by fixed byte offset — `substring(0, 36)` / `substring(37)` —
+  at multiple call sites. A 26-char ULID breaks episode splitting; anything longer
+  than 36 chars is mis-truncated into the wrong `/api/me/progress/...` path. The
+  minted id is a canonical, hyphenated, lowercase UUIDv4, minted by hand via
+  `crypto/rand` (16 lines of stdlib) rather than adding `google/uuid` as a direct
+  dependency.
+- New store methods on `*PebbleStore` (`internal/database/pebble_store_syncid.go`):
+  `MintOrGetSyncID`, `GetSyncIDForBook`, `ResolveSyncItem` (follows merge-redirect
+  chains, capped at 10 hops with cycle detection), `RepointSyncItem` (untagged-move
+  support), and `RecordSyncMerge` (idempotent merge-loser → merge-winner redirect,
+  used by a later merge-hook task). Exposed via a `SyncIdentityStore` capability
+  interface + `AsSyncIdentityStore` type-assertion helper, following this repo's
+  established "don't touch `store.go`" pattern.
+- This PR is additive-only: nothing reads or writes these keys yet. No existing
+  behavior changes. The scanner's merge/move paths, and the ABS HTTP handlers
+  themselves, are wired up by follow-up tasks.

--- a/internal/database/pebble_store_syncid.go
+++ b/internal/database/pebble_store_syncid.go
@@ -1,0 +1,363 @@
+// file: internal/database/pebble_store_syncid.go
+// version: 1.0.0
+// guid: 5b9bd4e0-2ee2-436d-ac81-16b93de80eb3
+// last-edited: 2026-07-30
+
+// Package database: sync_item keyspace — durable ABS `libraryItemId` identity.
+//
+// libraryItemId is the key every Audiobookshelf-compatible client stores
+// progress and bookmarks against. Book ULIDs churn under untagged moves
+// (version-link mints a new ULID) and dedup merges (the surviving ULID
+// changes), so the id exposed to clients must be a separate, never-reused
+// identity that we can repoint underneath a churning ULID.
+//
+// See docs/specs/2026-07-29-abs-sync-api-design.md §1.7.1, §4 for the full
+// design. In short: Absorb (a target client) splits compound podcast keys by
+// FIXED BYTE OFFSET (substring(0,36) / substring(37)) at 4+ call sites. Our
+// Book IDs are 26-char ULIDs -- too short, and would break episode splitting.
+// The syncID minted here MUST be exactly 36 characters in canonical
+// hyphenated UUID form (8-4-4-4-12 hex groups) or Absorb mis-truncates it
+// into the wrong /api/me/progress/... path.
+//
+// Two keys:
+//   - sync_item:<syncID>        -> JSON-encoded SyncItem record.
+//   - sync_item:book:<bookID>   -> raw bytes of the syncID (reverse index,
+//     same "value is the id as raw bytes" convention as book:path:<path>).
+//
+// This file does not wire up any live HTTP path -- nothing reads or writes
+// these keys yet. It is the foundation TASK-03 (merge-follow), TASK-04
+// (backfill), and TASK-05 (survival tests) build on.
+package database
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// SyncItem is the durable identity record behind an ABS-visible
+// libraryItemId. RedirectTo empty means this is a live, client-visible
+// record; non-empty means this syncID was a merge loser and now redirects to
+// the winner's syncID (see RecordSyncMerge). CurrentBookID is meaningless on
+// a redirect record -- it is left as whatever it was at merge time; readers
+// must follow RedirectTo first (see ResolveSyncItem).
+type SyncItem struct {
+	SyncID        string    `json:"sync_id"`
+	CurrentBookID string    `json:"current_book_id,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	MergedFrom    []string  `json:"merged_from,omitempty"`
+	RedirectTo    string    `json:"redirect_to,omitempty"`
+}
+
+// SyncIdentityStore is implemented by PebbleStore. Consumers that only have a
+// database.Store value obtain it via AsSyncIdentityStore's type assertion --
+// this keeps store.go untouched (repo rule: nobody edits it; every new
+// capability lives in its own file) and means MemStore/mocks are not required
+// to implement it.
+type SyncIdentityStore interface {
+	MintOrGetSyncID(bookID string) (string, error)
+	GetSyncIDForBook(bookID string) (string, bool, error)
+	ResolveSyncItem(syncID string) (*SyncItem, error)
+	RepointSyncItem(oldBookID, newBookID string) error
+	RecordSyncMerge(loserBookID, winnerBookID string) error
+}
+
+// AsSyncIdentityStore returns s as a SyncIdentityStore if it implements the
+// interface (true for *PebbleStore), or nil otherwise. Callers MUST nil-check
+// the result exactly like internal/merge/service.go's eidStore != nil checks.
+func AsSyncIdentityStore(s any) SyncIdentityStore {
+	if s == nil {
+		return nil
+	}
+	if ss, ok := s.(SyncIdentityStore); ok {
+		return ss
+	}
+	return nil
+}
+
+// syncIDMintMu serializes the check-then-mint-then-write section of
+// MintOrGetSyncID so two concurrent first-encounters of the same book cannot
+// both mint a syncID and race the reverse-index write (mirrors the
+// mergeSerializeMu idiom in internal/merge/serialize.go). It is not held
+// across any Pebble iteration or I/O beyond the point-read/point-writes that
+// method needs.
+var syncIDMintMu sync.Mutex
+
+// newSyncID mints a random UUIDv4 by hand via crypto/rand -- deliberately not
+// using google/uuid, which is an indirect-only dependency today; promoting it
+// to direct is reserved for a different task. The bit-twiddling below is what
+// makes the string a valid UUIDv4 (version 4, variant 10) that satisfies
+// Absorb's fixed-offset length check.
+func newSyncID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+func syncItemKey(syncID string) []byte {
+	return []byte(fmt.Sprintf("sync_item:%s", syncID))
+}
+
+func syncItemBookKey(bookID string) []byte {
+	return []byte(fmt.Sprintf("sync_item:book:%s", bookID))
+}
+
+// getSyncItem reads and unmarshals the sync_item:<syncID> record. Returns
+// (nil, nil) on not-found, mirroring GetBookByID's convention.
+func (p *PebbleStore) getSyncItem(syncID string) (*SyncItem, error) {
+	value, closer, err := p.db.Get(syncItemKey(syncID))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+
+	var item SyncItem
+	if err := json.Unmarshal(value, &item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// MintOrGetSyncID returns the durable syncID for bookID, minting a fresh one
+// on first encounter and persisting both the SyncItem record and the reverse
+// index in a single batch. Subsequent calls for the same bookID return the
+// same syncID. This store is a pure key-value layer -- it does not validate
+// that bookID refers to a real Book; that is the caller's job.
+func (p *PebbleStore) MintOrGetSyncID(bookID string) (string, error) {
+	if bookID == "" {
+		return "", fmt.Errorf("bookID required")
+	}
+
+	syncIDMintMu.Lock()
+	defer syncIDMintMu.Unlock()
+
+	existing, closer, err := p.db.Get(syncItemBookKey(bookID))
+	if err == nil {
+		id := string(existing)
+		closer.Close()
+		return id, nil
+	}
+	if err != pebble.ErrNotFound {
+		return "", err
+	}
+
+	id, err := newSyncID()
+	if err != nil {
+		return "", err
+	}
+	item := SyncItem{
+		SyncID:        id,
+		CurrentBookID: bookID,
+		CreatedAt:     time.Now(),
+	}
+	data, err := json.Marshal(item)
+	if err != nil {
+		return "", err
+	}
+
+	batch := p.db.NewBatch()
+	if err := batch.Set(syncItemKey(id), data, nil); err != nil {
+		batch.Close()
+		return "", err
+	}
+	if err := batch.Set(syncItemBookKey(bookID), []byte(id), nil); err != nil {
+		batch.Close()
+		return "", err
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// GetSyncIDForBook is a read-only point-get of the reverse index. It returns
+// ("", false, nil) when bookID has no sync item yet -- "no sync item yet" is
+// a normal state, not an error.
+func (p *PebbleStore) GetSyncIDForBook(bookID string) (string, bool, error) {
+	value, closer, err := p.db.Get(syncItemBookKey(bookID))
+	if err == pebble.ErrNotFound {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	defer closer.Close()
+	return string(value), true, nil
+}
+
+// ResolveSyncItem reads the sync_item:<syncID> record and follows RedirectTo
+// chains left behind by merges until it reaches a live record (RedirectTo ==
+// ""). It caps at 10 hops and tracks visited ids to guard against a cycle or
+// runaway chain; hitting either returns an error instead of looping forever
+// or returning stale data. Returns (nil, nil) if the starting syncID itself
+// does not exist, mirroring GetBookByID's not-found convention.
+func (p *PebbleStore) ResolveSyncItem(syncID string) (*SyncItem, error) {
+	const maxHops = 10
+	visited := make(map[string]bool, maxHops)
+
+	current := syncID
+	for hop := 0; hop < maxHops; hop++ {
+		if visited[current] {
+			return nil, fmt.Errorf("sync item redirect chain too long or cyclic starting at %s", syncID)
+		}
+		visited[current] = true
+
+		item, err := p.getSyncItem(current)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			if current == syncID {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("sync item redirect chain too long or cyclic starting at %s", syncID)
+		}
+		if item.RedirectTo == "" {
+			return item, nil
+		}
+		current = item.RedirectTo
+	}
+	return nil, fmt.Errorf("sync item redirect chain too long or cyclic starting at %s", syncID)
+}
+
+// RepointSyncItem moves the reverse index from oldBookID to newBookID and
+// updates the SyncItem record's CurrentBookID -- the untagged-move case,
+// where a version-link mints a new Book ULID but the client-visible identity
+// must survive. If oldBookID has no sync item yet, there is nothing to carry
+// forward and this is a no-op (returns nil). This method has no caller yet;
+// wiring it into the scanner's untagged-move/version-link path is out of
+// scope for this task.
+func (p *PebbleStore) RepointSyncItem(oldBookID, newBookID string) error {
+	syncID, has, err := p.GetSyncIDForBook(oldBookID)
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+
+	item, err := p.getSyncItem(syncID)
+	if err != nil {
+		return err
+	}
+	if item == nil {
+		return fmt.Errorf("sync item %s referenced by reverse index but record missing", syncID)
+	}
+	item.CurrentBookID = newBookID
+	data, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	batch := p.db.NewBatch()
+	if err := batch.Delete(syncItemBookKey(oldBookID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncItemBookKey(newBookID), []byte(syncID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncItemKey(syncID), data, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	return batch.Commit(pebble.Sync)
+}
+
+// RecordSyncMerge is the primitive the merge hook calls when loserBookID
+// merges into winnerBookID. It ensures the winner has a syncID (merges can
+// involve two books that never had one minted yet), redirects the loser's
+// syncID to the winner's, and appends the loser's syncID to the winner's
+// MergedFrom (deduplicated -- a merge can be retried).
+//
+// If the loser never had a client-visible identity (no sync item minted),
+// this is a no-op: nothing to redirect.
+//
+// Idempotent: if the loser's record already redirects to the winner's
+// syncID, this returns nil without touching either record again -- safe to
+// re-run on a retried merge or a backfill sweep that re-touches the same
+// pair.
+//
+// sync_item:book:<loserBookID> is deliberately left untouched, still
+// pointing at loserSyncID -- a future lookup of the loser's (soft-deleted)
+// book resolves to loserSyncID, and ResolveSyncItem follows the redirect to
+// the winner. Deleting it would make a stale client request 404 instead of
+// correctly resolving.
+func (p *PebbleStore) RecordSyncMerge(loserBookID, winnerBookID string) error {
+	winnerSyncID, err := p.MintOrGetSyncID(winnerBookID)
+	if err != nil {
+		return err
+	}
+
+	loserSyncID, has, err := p.GetSyncIDForBook(loserBookID)
+	if err != nil {
+		return err
+	}
+	if !has {
+		return nil
+	}
+
+	loserItem, err := p.getSyncItem(loserSyncID)
+	if err != nil {
+		return err
+	}
+	if loserItem == nil {
+		return fmt.Errorf("sync item %s referenced by reverse index but record missing", loserSyncID)
+	}
+	if loserItem.RedirectTo == winnerSyncID {
+		// Already recorded.
+		return nil
+	}
+
+	winnerItem, err := p.getSyncItem(winnerSyncID)
+	if err != nil {
+		return err
+	}
+	if winnerItem == nil {
+		return fmt.Errorf("sync item %s just minted/looked-up but record missing", winnerSyncID)
+	}
+
+	loserItem.RedirectTo = winnerSyncID
+	loserData, err := json.Marshal(loserItem)
+	if err != nil {
+		return err
+	}
+
+	alreadyMerged := false
+	for _, id := range winnerItem.MergedFrom {
+		if id == loserSyncID {
+			alreadyMerged = true
+			break
+		}
+	}
+	if !alreadyMerged {
+		winnerItem.MergedFrom = append(winnerItem.MergedFrom, loserSyncID)
+	}
+	winnerData, err := json.Marshal(winnerItem)
+	if err != nil {
+		return err
+	}
+
+	batch := p.db.NewBatch()
+	if err := batch.Set(syncItemKey(loserSyncID), loserData, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncItemKey(winnerSyncID), winnerData, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	return batch.Commit(pebble.Sync)
+}

--- a/internal/database/pebble_store_syncid.go
+++ b/internal/database/pebble_store_syncid.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_syncid.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5b9bd4e0-2ee2-436d-ac81-16b93de80eb3
 // last-edited: 2026-07-30
 
@@ -78,6 +78,11 @@ func AsSyncIdentityStore(s any) SyncIdentityStore {
 	}
 	return nil
 }
+
+// Compile-time assertion that *PebbleStore satisfies SyncIdentityStore, so a
+// future signature drift on either side fails the build instead of only
+// surfacing at AsSyncIdentityStore's first caller.
+var _ SyncIdentityStore = (*PebbleStore)(nil)
 
 // syncIDMintMu serializes the check-then-mint-then-write section of
 // MintOrGetSyncID so two concurrent first-encounters of the same book cannot

--- a/internal/database/pebble_store_syncid_test.go
+++ b/internal/database/pebble_store_syncid_test.go
@@ -1,0 +1,308 @@
+// file: internal/database/pebble_store_syncid_test.go
+// version: 1.0.0
+// guid: c4877e93-ba6a-468d-b428-30be15fdfa27
+// last-edited: 2026-07-30
+
+// Tests for the sync_item:/sync_item:book: keyspace (durable ABS libraryItemId
+// identity). Covers: mint-on-first-encounter idempotency, distinct IDs per book,
+// UUIDv4 shape, unminted lookup, repoint on untagged move, merge-redirect
+// resolution (including a 3-way chain), merge idempotency, and a concurrent
+// mint race under -race.
+
+package database
+
+import (
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+)
+
+// newPebbleStoreForSyncID opens a fresh PebbleStore in a temp directory and
+// registers cleanup. Returns a *PebbleStore so tests can call sync-id-specific
+// methods directly.
+func newPebbleStoreForSyncID(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "syncid-db"))
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+var syncIDShapeRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestSyncID_MintOnFirstEncounter_IsIdempotent(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	first, err := store.MintOrGetSyncID("book-a")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID first call: %v", err)
+	}
+	second, err := store.MintOrGetSyncID("book-a")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID second call: %v", err)
+	}
+	if first != second {
+		t.Fatalf("MintOrGetSyncID not idempotent: first=%q second=%q", first, second)
+	}
+}
+
+func TestSyncID_DifferentBooksGetDifferentIDs(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	idA, err := store.MintOrGetSyncID("book-a")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-a: %v", err)
+	}
+	idB, err := store.MintOrGetSyncID("book-b")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-b: %v", err)
+	}
+	if idA == idB {
+		t.Fatalf("two different books got the same syncID: %q", idA)
+	}
+}
+
+func TestSyncID_MintedIDMatchesUUIDv4Shape(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	id, err := store.MintOrGetSyncID("book-a")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID: %v", err)
+	}
+	if len(id) != 36 {
+		t.Fatalf("syncID length = %d, want 36 (Absorb splits compound keys at fixed offset substring(0,36)): %q", len(id), id)
+	}
+	if !syncIDShapeRE.MatchString(id) {
+		t.Fatalf("syncID %q does not match canonical UUIDv4 shape %s", id, syncIDShapeRE.String())
+	}
+}
+
+func TestSyncID_GetSyncIDForBook_Unminted(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	id, ok, err := store.GetSyncIDForBook("never-seen-book")
+	if err != nil {
+		t.Fatalf("GetSyncIDForBook on unminted book returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("GetSyncIDForBook on unminted book returned ok=true, want false")
+	}
+	if id != "" {
+		t.Fatalf("GetSyncIDForBook on unminted book returned id=%q, want empty", id)
+	}
+}
+
+func TestSyncID_RepointSyncItem_MovesReverseIndexAndCurrentBookID(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	oldID, err := store.MintOrGetSyncID("book-old")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-old: %v", err)
+	}
+
+	if err := store.RepointSyncItem("book-old", "book-new"); err != nil {
+		t.Fatalf("RepointSyncItem: %v", err)
+	}
+
+	// The reverse index for the OLD book id must be gone.
+	_, ok, err := store.GetSyncIDForBook("book-old")
+	if err != nil {
+		t.Fatalf("GetSyncIDForBook book-old after repoint: %v", err)
+	}
+	if ok {
+		t.Fatalf("GetSyncIDForBook book-old after repoint still resolves, want gone")
+	}
+
+	// The reverse index for the NEW book id must resolve to the SAME syncID.
+	newLookupID, ok, err := store.GetSyncIDForBook("book-new")
+	if err != nil {
+		t.Fatalf("GetSyncIDForBook book-new after repoint: %v", err)
+	}
+	if !ok {
+		t.Fatalf("GetSyncIDForBook book-new after repoint: want ok=true")
+	}
+	if newLookupID != oldID {
+		t.Fatalf("repoint changed the syncID itself: got %q, want %q (same identity, new current book)", newLookupID, oldID)
+	}
+
+	// The SyncItem record's CurrentBookID must be updated.
+	item, err := store.ResolveSyncItem(oldID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem: %v", err)
+	}
+	if item == nil {
+		t.Fatalf("ResolveSyncItem returned nil for a known syncID")
+	}
+	if item.CurrentBookID != "book-new" {
+		t.Fatalf("SyncItem.CurrentBookID = %q, want %q", item.CurrentBookID, "book-new")
+	}
+
+	// Calling MintOrGetSyncID on the OLD book id now must mint a BRAND NEW,
+	// different ID — proving the reverse index really moved, not just got
+	// copied.
+	freshOldID, err := store.MintOrGetSyncID("book-old")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-old after repoint: %v", err)
+	}
+	if freshOldID == oldID {
+		t.Fatalf("MintOrGetSyncID book-old after repoint returned the SAME id %q, want a new one (reverse index should have moved, not been copied)", freshOldID)
+	}
+}
+
+func TestSyncID_RecordSyncMerge_RedirectsLoserToWinner(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	loserID, err := store.MintOrGetSyncID("book-loser")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-loser: %v", err)
+	}
+	winnerID, err := store.MintOrGetSyncID("book-winner")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-winner: %v", err)
+	}
+
+	if err := store.RecordSyncMerge("book-loser", "book-winner"); err != nil {
+		t.Fatalf("RecordSyncMerge: %v", err)
+	}
+
+	resolved, err := store.ResolveSyncItem(loserID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem(loserID): %v", err)
+	}
+	if resolved == nil {
+		t.Fatalf("ResolveSyncItem(loserID) returned nil, want the winner's live record")
+	}
+	if resolved.SyncID != winnerID {
+		t.Fatalf("ResolveSyncItem(loserID).SyncID = %q, want winner's %q", resolved.SyncID, winnerID)
+	}
+	if resolved.RedirectTo != "" {
+		t.Fatalf("resolved (winner) record has RedirectTo=%q, want empty (live record)", resolved.RedirectTo)
+	}
+
+	winnerItem, err := store.ResolveSyncItem(winnerID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem(winnerID): %v", err)
+	}
+	found := false
+	for _, m := range winnerItem.MergedFrom {
+		if m == loserID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("winner's MergedFrom %v does not contain loser's syncID %q", winnerItem.MergedFrom, loserID)
+	}
+
+	// Idempotency: calling RecordSyncMerge again with the same pair is a no-op.
+	if err := store.RecordSyncMerge("book-loser", "book-winner"); err != nil {
+		t.Fatalf("RecordSyncMerge (second call): %v", err)
+	}
+	winnerItem2, err := store.ResolveSyncItem(winnerID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem(winnerID) after second merge: %v", err)
+	}
+	if len(winnerItem2.MergedFrom) != len(winnerItem.MergedFrom) {
+		t.Fatalf("MergedFrom length changed on re-run: before=%d after=%d", len(winnerItem.MergedFrom), len(winnerItem2.MergedFrom))
+	}
+
+	loserRaw, err := store.ResolveSyncItem(loserID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem(loserID) after second merge: %v", err)
+	}
+	if loserRaw.SyncID != winnerID {
+		t.Fatalf("RedirectTo changed on re-run: resolved to %q, want %q", loserRaw.SyncID, winnerID)
+	}
+}
+
+func TestSyncID_RecordSyncMerge_ThreeWayRedirectChain(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	bID, err := store.MintOrGetSyncID("book-b")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-b: %v", err)
+	}
+	if _, err := store.MintOrGetSyncID("book-a"); err != nil {
+		t.Fatalf("MintOrGetSyncID book-a: %v", err)
+	}
+	cID, err := store.MintOrGetSyncID("book-c")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID book-c: %v", err)
+	}
+
+	// Merge B into A.
+	if err := store.RecordSyncMerge("book-b", "book-a"); err != nil {
+		t.Fatalf("RecordSyncMerge(B into A): %v", err)
+	}
+	// Merge A's book into C (A's syncID now redirects to C's).
+	if err := store.RecordSyncMerge("book-a", "book-c"); err != nil {
+		t.Fatalf("RecordSyncMerge(A into C): %v", err)
+	}
+
+	// B's ORIGINAL syncID must resolve all the way through A to C's live record.
+	resolved, err := store.ResolveSyncItem(bID)
+	if err != nil {
+		t.Fatalf("ResolveSyncItem(bID): %v", err)
+	}
+	if resolved == nil {
+		t.Fatalf("ResolveSyncItem(bID) returned nil, want C's live record")
+	}
+	if resolved.SyncID != cID {
+		t.Fatalf("ResolveSyncItem(bID).SyncID = %q, want C's %q (chain B->A->C not followed)", resolved.SyncID, cID)
+	}
+	if resolved.RedirectTo != "" {
+		t.Fatalf("resolved (C's) record has RedirectTo=%q, want empty (live record)", resolved.RedirectTo)
+	}
+}
+
+func TestSyncID_ConcurrentMintRace_SingleWinner(t *testing.T) {
+	store := newPebbleStoreForSyncID(t)
+
+	const goroutines = 16
+	results := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			id, err := store.MintOrGetSyncID("race-book")
+			results[i] = id
+			errs[i] = err
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: MintOrGetSyncID error: %v", i, err)
+		}
+	}
+
+	want := results[0]
+	if want == "" {
+		t.Fatalf("goroutine 0 returned empty syncID")
+	}
+	for i, got := range results {
+		if got != want {
+			t.Fatalf("goroutine %d returned syncID %q, want %q (all callers should mint/observe the SAME id)", i, got, want)
+		}
+	}
+
+	// Exactly one live record for the book — no orphaned second sync_item
+	// record from a lost race.
+	finalID, ok, err := store.GetSyncIDForBook("race-book")
+	if err != nil {
+		t.Fatalf("GetSyncIDForBook: %v", err)
+	}
+	if !ok {
+		t.Fatalf("GetSyncIDForBook: want ok=true after concurrent mint")
+	}
+	if finalID != want {
+		t.Fatalf("GetSyncIDForBook returned %q, want %q", finalID, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/database/pebble_store_syncid.go` (+ `_test.go`) implementing the
`sync_item` keyspace: durable 36-char UUIDv4 identity for the future ABS
`libraryItemId`, per `docs/specs/2026-07-29-abs-sync-api-design.md` §1.7.1 and §4.

- New keyspace `sync_item:<syncID>` (JSON `SyncItem` record) + reverse index
  `sync_item:book:<bookID>` (raw syncID bytes).
- `MintOrGetSyncID`, `GetSyncIDForBook`, `ResolveSyncItem` (follows merge-redirect
  chains, capped at 10 hops with cycle detection), `RepointSyncItem` (untagged-move
  support), `RecordSyncMerge` (idempotent merge-loser → merge-winner redirect).
- `SyncIdentityStore` capability interface + `AsSyncIdentityStore` type-assertion
  helper — `internal/database/store.go` is untouched (repo convention).
- UUIDv4 minted by hand via `crypto/rand` (no `google/uuid` promotion — reserved
  for a different task; `go.mod`/`go.sum` have zero diff).
- Additive only: nothing reads or writes these keys yet, so this PR cannot change
  existing behavior. Consumers land in follow-up tasks (merge-hook, backfill,
  survival tests).

## Test plan

TDD: wrote `internal/database/pebble_store_syncid_test.go` first, confirmed it
failed to compile (`MintOrGetSyncID undefined` etc. — the implementation didn't
exist yet), then implemented `pebble_store_syncid.go` to make it pass.

### Filtered run — `go test ./internal/database/... -run SyncID -race -count=1 -v`

```
=== RUN   TestSyncID_MintOnFirstEncounter_IsIdempotent
--- PASS: TestSyncID_MintOnFirstEncounter_IsIdempotent (0.14s)
=== RUN   TestSyncID_DifferentBooksGetDifferentIDs
--- PASS: TestSyncID_DifferentBooksGetDifferentIDs (0.14s)
=== RUN   TestSyncID_MintedIDMatchesUUIDv4Shape
--- PASS: TestSyncID_MintedIDMatchesUUIDv4Shape (0.13s)
=== RUN   TestSyncID_GetSyncIDForBook_Unminted
--- PASS: TestSyncID_GetSyncIDForBook_Unminted (0.13s)
=== RUN   TestSyncID_RepointSyncItem_MovesReverseIndexAndCurrentBookID
--- PASS: TestSyncID_RepointSyncItem_MovesReverseIndexAndCurrentBookID (0.15s)
=== RUN   TestSyncID_RecordSyncMerge_RedirectsLoserToWinner
--- PASS: TestSyncID_RecordSyncMerge_RedirectsLoserToWinner (0.15s)
=== RUN   TestSyncID_RecordSyncMerge_ThreeWayRedirectChain
--- PASS: TestSyncID_RecordSyncMerge_ThreeWayRedirectChain (0.15s)
=== RUN   TestSyncID_ConcurrentMintRace_SingleWinner
--- PASS: TestSyncID_ConcurrentMintRace_SingleWinner (0.15s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/database	2.579s
```

(PebbleDB open/warmup log lines omitted for brevity — full raw output was captured
during development and every test passed, no failures/skips.)

### Full package run — `go test ./internal/database/ -race -count=1`

```
ok  	github.com/falkcorp/audiobook-organizer/internal/database	505.050s
```

No pre-existing test in the package regressed.

### Other checks

```
$ go vet ./internal/database/...
(clean, no output)

$ gofmt -l internal/database/pebble_store_syncid.go internal/database/pebble_store_syncid_test.go
(clean, no output)

$ go build ./...
(clean, no output)

$ git diff --stat origin/main -- internal/database/store.go
(empty — zero diff)

$ git diff --stat origin/main -- go.mod go.sum
(empty — zero diff)

$ grep -c "func (p \*PebbleStore)" internal/database/pebble_store_syncid.go
6   (>= 5 required: MintOrGetSyncID, GetSyncIDForBook, ResolveSyncItem,
     RepointSyncItem, RecordSyncMerge, + private getSyncItem helper)
```

## Acceptance criteria

- [x] `internal/database/pebble_store_syncid.go` exists with `SyncItem`,
      `SyncIdentityStore`, `AsSyncIdentityStore`, `newSyncID`, `MintOrGetSyncID`,
      `GetSyncIDForBook`, `ResolveSyncItem`, `RepointSyncItem`, `RecordSyncMerge` —
      all on `*PebbleStore`, none added to `internal/database/store.go`
- [x] `grep -c "func (p \*PebbleStore)"` returns 6 (≥ 5)
- [x] Minted IDs match the UUIDv4 regex, asserted explicitly in
      `TestSyncID_MintedIDMatchesUUIDv4Shape`
- [x] Redirect-chain test (3-way: B→A→C) passes
      (`TestSyncID_RecordSyncMerge_ThreeWayRedirectChain`)
- [x] Concurrent mint-race test passes under `-race`, no race detected, no
      duplicate live record (`TestSyncID_ConcurrentMintRace_SingleWinner`)
- [x] `go build ./...`, `gofmt -l`, `go vet ./internal/database/...` all clean
- [x] `internal/database/store.go` has zero diff vs `origin/main`
- [x] File headers present and bumped on every created/modified file
- [x] `changelog.d/abs-sync-syncitem-keyspace.md` added (guid
      `791ba524-e776-4bee-861d-7df49c26b297`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
