### PR TITLE
feat(abs-sync): extract and persist chapters at scan time

### DIFF
--- a/changelog.d/20260730_060700_abs-sync-scanner-chapter-hook.md
+++ b/changelog.d/20260730_060700_abs-sync-scanner-chapter-hook.md
@@ -1,0 +1,23 @@
+<!-- file: changelog.d/20260730_060700_abs-sync-scanner-chapter-hook.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4240a974-775f-489f-9e3f-491ccd12544d -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+- **Chapter extraction at scan time (abs-sync Phase 4).** New
+  `scanner.PersistChaptersForBook` (`internal/scanner/process_file.go`) wires the
+  already-merged `internal/audioutil` chapter primitives and the newly-merged
+  `database.Chapter` persistence into the scan pipeline: single-file books keep
+  their embedded chapters as-is; multi-file books get one synthesized chapter per
+  file, titled from each file's own tag. Multi-file chapter boundaries use
+  re-probed, unrounded per-track durations (not the stored, rounded
+  `BookFile.Duration`), so the total matches real Audiobookshelf `startOffset`
+  precision. Idempotent — a rescan skips re-extraction for books that already
+  have chapters.
+  - **Not yet wired into `scanner.go`.** This PR adds the function and its full
+    test suite but intentionally does not add the two `scanner.go` call sites
+    described in the task brief, because `scanner.go` was flagged as owned by a
+    parallel in-flight change at the time this task ran. The feature is inert
+    (dead code, covered by direct-call tests only) until a follow-up applies the
+    two-line hook after each of `scanner.go`'s book-save call sites.

--- a/internal/scanner/chapter_persistence_test.go
+++ b/internal/scanner/chapter_persistence_test.go
@@ -1,0 +1,237 @@
+// file: internal/scanner/chapter_persistence_test.go
+// version: 1.0.0
+// guid: cb2ed4a4-974b-4d88-8d46-0a0f365ba430
+// last-edited: 2026-07-30
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// odysseyM4B is the real, committed 115 MB fixture with 6 embedded chapters,
+// mirroring internal/audioutil/chapters_test.go's fixture constant (same
+// relative depth: internal/scanner is two levels below the repo root, same
+// as internal/audioutil).
+const chapterTestOdysseyM4B = "../../testdata/audio/librivox/odyssey_butler_librivox/odyssey_complete.m4b"
+
+// chapterTestOdysseyMP3Track fires the mp3 fixture for a given 1-based
+// track number (1..6) in the 6-file version of the same book.
+func chapterTestOdysseyMP3Track(n int) string {
+	return filepath.Join("..", "..", "testdata", "audio", "librivox", "odyssey_butler_librivox",
+		trackFilename(n))
+}
+
+func trackFilename(n int) string {
+	return "odyssey_0" + string(rune('0'+n)) + "_homer_butler_64kb.mp3"
+}
+
+// odysseyTrackTitle is the known embedded `title` tag for track n (1..6),
+// verified via `ffprobe -show_entries format_tags=title` during this task's
+// authoring: "The Odyssey: Book 0N".
+func odysseyTrackTitle(n int) string {
+	return "The Odyssey: Book 0" + string(rune('0'+n))
+}
+
+func requireChapterTestFFprobe(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not found on PATH, skipping")
+	}
+}
+
+func requireChapterTestFixture(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("fixture missing at %s, skipping: %v", path, err)
+	}
+}
+
+func TestPersistChaptersForBook_SingleFileM4B_UsesEmbeddedChapters(t *testing.T) {
+	requireChapterTestFFprobe(t)
+	requireChapterTestFixture(t, chapterTestOdysseyM4B)
+
+	store, cleanup := setupPebbleStore(t)
+	defer cleanup()
+	SetStore(store)
+	defer SetStore(nil)
+
+	book, err := store.CreateBook(&database.Book{FilePath: chapterTestOdysseyM4B, Title: "The Odyssey"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := PersistChaptersForBook(ctx, book.FilePath, nil); err != nil {
+		t.Fatalf("PersistChaptersForBook: %v", err)
+	}
+
+	chs, err := store.GetChaptersForBook(book.ID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(chs) != 6 {
+		t.Fatalf("got %d chapters, want 6: %+v", len(chs), chs)
+	}
+	if chs[0].StartSec != 0 {
+		t.Errorf("chs[0].StartSec = %v, want 0", chs[0].StartSec)
+	}
+	wantTitle := "Chapter 1: odyssey_01_homer_butler_64kb"
+	if chs[0].Title != wantTitle {
+		t.Errorf("chs[0].Title = %q, want %q", chs[0].Title, wantTitle)
+	}
+	const wantEnd = 9975.428000
+	if diff := chs[5].EndSec - wantEnd; diff > 0.001 || diff < -0.001 {
+		t.Errorf("chs[5].EndSec = %v, want within 0.001 of %v (m4b's own last-chapter end)", chs[5].EndSec, wantEnd)
+	}
+}
+
+func TestPersistChaptersForBook_MultiFileMP3s_SynthesizesFromTrackTags(t *testing.T) {
+	requireChapterTestFFprobe(t)
+	for n := 1; n <= 6; n++ {
+		requireChapterTestFixture(t, chapterTestOdysseyMP3Track(n))
+	}
+
+	store, cleanup := setupPebbleStore(t)
+	defer cleanup()
+	SetStore(store)
+	defer SetStore(nil)
+
+	book, err := store.CreateBook(&database.Book{FilePath: chapterTestOdysseyMP3Track(1), Title: "The Odyssey"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	for n := 1; n <= 6; n++ {
+		bf := &database.BookFile{
+			BookID:      book.ID,
+			FilePath:    chapterTestOdysseyMP3Track(n),
+			Title:       odysseyTrackTitle(n),
+			TrackNumber: n,
+		}
+		if err := store.CreateBookFile(bf); err != nil {
+			t.Fatalf("CreateBookFile track %d: %v", n, err)
+		}
+	}
+
+	ctx := context.Background()
+	if err := PersistChaptersForBook(ctx, book.FilePath, nil); err != nil {
+		t.Fatalf("PersistChaptersForBook: %v", err)
+	}
+
+	chs, err := store.GetChaptersForBook(book.ID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(chs) != 6 {
+		t.Fatalf("got %d chapters, want 6: %+v", len(chs), chs)
+	}
+	if chs[0].Title != "The Odyssey: Book 01" {
+		t.Errorf("chs[0].Title = %q, want %q (from tag, not filename)", chs[0].Title, "The Odyssey: Book 01")
+	}
+	if chs[0].StartSec != 0 {
+		t.Errorf("chs[0].StartSec = %v, want 0", chs[0].StartSec)
+	}
+	for i := 1; i < len(chs); i++ {
+		if chs[i].StartSec <= chs[i-1].StartSec {
+			t.Fatalf("chapter offsets not monotonically increasing at index %d: %v <= %v", i, chs[i].StartSec, chs[i-1].StartSec)
+		}
+	}
+
+	const wantSumOfTracks = 9975.431111
+	const containerDuration = 9975.480544
+	if diff := chs[5].EndSec - wantSumOfTracks; diff > 0.001 || diff < -0.001 {
+		t.Errorf("chs[5].EndSec = %v, want within 0.001 of sum-of-tracks %v", chs[5].EndSec, wantSumOfTracks)
+	}
+	if diff := chs[5].EndSec - containerDuration; diff > -0.01 && diff < 0.01 {
+		t.Errorf("chs[5].EndSec = %v must NOT be close to container duration %v (this book has no container in this path)", chs[5].EndSec, containerDuration)
+	}
+}
+
+func TestPersistChaptersForBook_Idempotent_SkipsReExtraction(t *testing.T) {
+	requireChapterTestFFprobe(t)
+	requireChapterTestFixture(t, chapterTestOdysseyM4B)
+
+	store, cleanup := setupPebbleStore(t)
+	defer cleanup()
+	SetStore(store)
+	defer SetStore(nil)
+
+	book, err := store.CreateBook(&database.Book{FilePath: chapterTestOdysseyM4B, Title: "The Odyssey"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	sentinel := []database.Chapter{{ID: 0, StartSec: 1, EndSec: 2, Title: "sentinel"}}
+	if err := store.SaveChaptersForBook(book.ID, sentinel); err != nil {
+		t.Fatalf("SaveChaptersForBook: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := PersistChaptersForBook(ctx, book.FilePath, nil); err != nil {
+		t.Fatalf("PersistChaptersForBook: %v", err)
+	}
+
+	chs, err := store.GetChaptersForBook(book.ID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if len(chs) != 1 || chs[0].Title != "sentinel" {
+		t.Fatalf("expected untouched sentinel chapter list, got %+v", chs)
+	}
+}
+
+func TestPersistChaptersForBook_NoEmbeddedChaptersSingleTrack_NoOp(t *testing.T) {
+	requireChapterTestFFprobe(t)
+	requireChapterTestFixture(t, chapterTestOdysseyMP3Track(1))
+
+	store, cleanup := setupPebbleStore(t)
+	defer cleanup()
+	SetStore(store)
+	defer SetStore(nil)
+
+	book, err := store.CreateBook(&database.Book{FilePath: chapterTestOdysseyMP3Track(1), Title: "Track 1 Alone"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := PersistChaptersForBook(ctx, book.FilePath, nil); err != nil {
+		t.Fatalf("PersistChaptersForBook: %v", err)
+	}
+
+	chs, err := store.GetChaptersForBook(book.ID)
+	if err != nil {
+		t.Fatalf("GetChaptersForBook: %v", err)
+	}
+	if chs != nil {
+		t.Fatalf("expected (nil, nil) for a single track with no embedded chapters, got %+v", chs)
+	}
+}
+
+func TestPersistChaptersForBook_NonPebbleStore_LogsWarning(t *testing.T) {
+	mockDB := &database.MockStore{
+		GetBookByFilePathFunc: func(path string) (*database.Book, error) {
+			return &database.Book{ID: "book-1", FilePath: path}, nil
+		},
+	}
+	SetStore(mockDB)
+	defer SetStore(nil)
+
+	before := chapterStoreAssertErrCount.Load()
+
+	ctx := context.Background()
+	if err := PersistChaptersForBook(ctx, "/some/path.m4b", nil); err != nil {
+		t.Fatalf("PersistChaptersForBook: expected nil error, got %v", err)
+	}
+
+	after := chapterStoreAssertErrCount.Load()
+	if after != before+1 {
+		t.Fatalf("chapterStoreAssertErrCount = %d, want %d (exactly one increment)", after, before+1)
+	}
+}

--- a/internal/scanner/process_file.go
+++ b/internal/scanner/process_file.go
@@ -1,6 +1,7 @@
 // file: internal/scanner/process_file.go
-// version: 1.2.1
+// version: 1.3.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+// last-edited: 2026-07-30
 
 // Package scanner provides file scanning and processing utilities for the
 // audiobook organizer. ProcessFile is the single-pass entry point that opens
@@ -8,13 +9,20 @@
 package scanner
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
 
 	"github.com/dhowden/tag"
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/mediainfo"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 )
@@ -26,7 +34,21 @@ const (
 	// allocations. It equals hashChunkSize so CodeQL can statically verify that
 	// every make([]byte, MaxScanBufferBytes) call is bounded.
 	MaxScanBufferBytes = hashChunkSize // 10 MB
+
+	// chapterProbeTimeout bounds each ffprobe subprocess call made while
+	// extracting/synthesizing chapters. Matches mediainfo's
+	// ffprobeDurationTimeout value — ffprobe only reads container/stream
+	// headers for these calls, so 20s is generous while still bounding a
+	// hung subprocess.
+	chapterProbeTimeout = 20 * time.Second
 )
+
+// chapterStoreAssertErrCount counts PersistChaptersForBook calls where the
+// package store is non-nil but not a *database.PebbleStore — a wiring
+// mismatch, not a per-book data condition. Logged via warnSampled (1st +
+// every 1000th) rather than every call, alongside this file's existing
+// dupLookupErrCount-style counters in scanner.go.
+var chapterStoreAssertErrCount atomic.Int64
 
 // ProcessFile opens filePath exactly once and returns:
 //   - meta: extracted audio metadata (never nil on success)
@@ -143,4 +165,171 @@ func computeHashFromReader(f *os.File, fileSize int64) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// PersistChaptersForBook extracts and persists the chapter list for the book
+// whose Book.FilePath is bookFilePath, unless it already has one. It takes a
+// file path rather than a book ID because scanner.Book (the in-memory
+// scan-time struct) has no ID field -- the scan pipeline always re-looks-up
+// the persisted database.Book by path after saving, and this function does
+// the same.
+//
+// Two cases, per docs/specs/2026-07-29-abs-sync-api-design.md §1.8.5 (real
+// Audiobookshelf 2.36.0 ground truth):
+//   - Single-file book (0 or 1 BookFile rows): trust the file's own embedded
+//     chapters as-is.
+//   - Multi-file book (>1 BookFile rows): synthesize one chapter per file
+//     from re-probed, unrounded per-track durations and each file's own
+//     title tag -- never that file's own embedded sub-chapters, even if
+//     present.
+//
+// Behavior on edge cases, in order of evaluation:
+//   - No store wired (getStore() == nil): silent no-op, mirrors every other
+//     `if store == nil` guard in this package.
+//   - Store wired but not a *database.PebbleStore: a genuine wiring
+//     regression (the chapter methods only exist on the concrete type) --
+//     logged via warnSampled (1st occurrence + every 1000th), not silent.
+//   - Book not found by path: quiet no-op -- "not saved yet" is a data
+//     condition/race, not a wiring bug.
+//   - Chapters already persisted: quiet no-op (idempotent -- a rescan of an
+//     unchanged book must not re-run ffprobe every pass).
+//   - ffprobe failure for a given file: logged via scanLog (nil-safe,
+//     falls back to defaultLog) and swallowed -- non-fatal to the scan.
+//
+// LABELED SCOPE DECISION (§5b): this function does NOT implement the
+// ≥2s finished-detection tolerance §5b also recommends. There is no
+// finished-detection code in this package to hang it on yet -- that
+// mechanism lives in the not-yet-built progress adapter (Phase 6, per the
+// spec). See the DURATION-AUTHORITY comment on synthesizeMultiFileChapters
+// for what Phase 6 must do instead.
+func PersistChaptersForBook(ctx context.Context, bookFilePath string, scanLog logger.Logger) error {
+	store := getStore()
+	if store == nil {
+		return nil
+	}
+
+	ps, ok := store.(*database.PebbleStore)
+	if !ok {
+		warnSampled(&chapterStoreAssertErrCount, scanLog,
+			"scanner.PersistChaptersForBook: store is %T, not *database.PebbleStore -- chapter extraction skipped for %s",
+			store, bookFilePath)
+		return nil
+	}
+
+	dbBook, err := store.GetBookByFilePath(bookFilePath)
+	if err != nil || dbBook == nil {
+		// "Book not saved yet" (or a stale path) is a data condition, not a
+		// wiring bug -- stay quiet.
+		return nil
+	}
+
+	existingChapters, err := ps.GetChaptersForBook(dbBook.ID)
+	if err != nil {
+		logChapterWarn(scanLog, "scanner.PersistChaptersForBook: GetChaptersForBook(%s) failed: %v", dbBook.ID, err)
+		return nil
+	}
+	if len(existingChapters) > 0 {
+		return nil // idempotent: already extracted on a previous scan
+	}
+
+	files, err := store.GetBookFiles(dbBook.ID)
+	if err != nil {
+		logChapterWarn(scanLog, "scanner.PersistChaptersForBook: GetBookFiles(%s) failed: %v", dbBook.ID, err)
+		return nil
+	}
+
+	var chapters []audioutil.Chapter
+	if len(files) <= 1 {
+		filePath := dbBook.FilePath
+		if len(files) == 1 && files[0].FilePath != "" {
+			filePath = files[0].FilePath
+		}
+		chapters = probeSingleFileChapters(ctx, filePath, scanLog)
+	} else {
+		chapters = synthesizeMultiFileChapters(ctx, files, scanLog)
+	}
+	if len(chapters) == 0 {
+		return nil // nothing to persist
+	}
+
+	dbChapters := make([]database.Chapter, len(chapters))
+	for i, c := range chapters {
+		dbChapters[i] = database.Chapter{ID: c.ID, StartSec: c.StartSec, EndSec: c.EndSec, Title: c.Title}
+	}
+	if err := ps.SaveChaptersForBook(dbBook.ID, dbChapters); err != nil {
+		logChapterWarn(scanLog, "scanner.PersistChaptersForBook: SaveChaptersForBook(%s) failed: %v", dbBook.ID, err)
+	}
+	return nil
+}
+
+// probeSingleFileChapters probes filePath's own embedded chapters and
+// returns them as-is (nil, non-error result on a file with no chapters --
+// audioutil.ProbeChapters's own documented convention). ffprobe failures are
+// logged and swallowed; this function never returns an error itself so
+// PersistChaptersForBook's dispatch stays a short, uniform caller.
+func probeSingleFileChapters(ctx context.Context, filePath string, scanLog logger.Logger) []audioutil.Chapter {
+	probeCtx, cancel := context.WithTimeout(ctx, chapterProbeTimeout)
+	defer cancel()
+	chs, err := audioutil.ProbeChapters(probeCtx, "", filePath)
+	if err != nil {
+		logChapterWarn(scanLog, "scanner.PersistChaptersForBook: ProbeChapters(%s) failed: %v", filePath, err)
+		return nil
+	}
+	return chs
+}
+
+// synthesizeMultiFileChapters builds one chapter per BookFile in files
+// (already ordered disc/track/path ASC by GetBookFiles) from each file's own
+// title tag and re-probed, unrounded duration -- never from that file's own
+// embedded sub-chapters, even when present (real ABS ground truth,
+// docs/specs/2026-07-29-abs-sync-api-design.md §1.8.5). Runs sequentially,
+// one ffprobe subprocess call per file, inside the caller's already-bounded
+// scan worker slot -- see the concurrency note on PersistChaptersForBook's
+// caller in scanner.go; this function must never spawn its own goroutines
+// per track, which would multiply concurrency beyond the scan's configured
+// worker count.
+//
+// DURATION-AUTHORITY NOTE (§5b -- read before touching finished-detection):
+// the resulting chapters[len-1].EndSec is the SUM of these re-probed,
+// unrounded per-track durations. That is, BY DESIGN, a different number from
+// the book's own, already-persisted Book.Duration field (an *int, set
+// elsewhere in the scan pipeline from the container/estimate path -- see
+// mediainfo.BuildFromTag / BookFile.DurationEstimated). On the committed
+// odyssey fixture the three legitimate durations disagree by ~52ms: m4b
+// container duration, m4b last-embedded-chapter end, and sum-of-tracks. Any
+// future finished-detection code (the §5b-recommended ≥2s tolerance,
+// deferred to a later phase and NOT implemented here) MUST compare against
+// this chapter-derived, sum-of-tracks value -- not Book.Duration -- since it
+// matches real Audiobookshelf startOffset values exactly.
+func synthesizeMultiFileChapters(ctx context.Context, files []database.BookFile, scanLog logger.Logger) []audioutil.Chapter {
+	tracks := make([]audioutil.TrackInfo, len(files))
+	for i, f := range files {
+		probeCtx, cancel := context.WithTimeout(ctx, chapterProbeTimeout)
+		dur, err := audioutil.ProbeDurationSeconds(probeCtx, "", f.FilePath)
+		cancel()
+		if err != nil {
+			logChapterWarn(scanLog, "scanner.PersistChaptersForBook: ProbeDurationSeconds(%s) failed: %v", f.FilePath, err)
+			// dur stays 0 -- this one track contributes no offset rather
+			// than aborting chapter extraction for the whole book.
+		}
+		tracks[i] = audioutil.TrackInfo{
+			Title:       f.Title,
+			Filename:    filepath.Base(f.FilePath),
+			DurationSec: dur,
+		}
+	}
+	return audioutil.SynthesizeChapters(tracks)
+}
+
+// logChapterWarn logs a non-sampled, per-call warning for chapter
+// extraction failures (ffprobe errors, store read/write errors) -- distinct
+// from the sampled chapterStoreAssertErrCount wiring warning, since these
+// are per-book data-path failures worth seeing individually, not a
+// high-frequency wiring mismatch that needs sampling. scanLog is nil-safe.
+func logChapterWarn(scanLog logger.Logger, format string, args ...interface{}) {
+	if scanLog != nil {
+		scanLog.Warn(format, args...)
+		return
+	}
+	defaultLog.Warn(format, args...)
 }


### PR DESCRIPTION
## Summary

Implements TASK-07 (`docs/agent-tasks/abs-sync/TASK-07-scanner-chapter-hook.md`): extract + persist
chapters at scan time. New `PersistChaptersForBook` in `internal/scanner/process_file.go` wires the
already-merged `internal/audioutil` chapter primitives (`ProbeChapters`, `SynthesizeChapters`,
`CumulativeOffsets`) and the already-merged `database.Chapter`/`GetChaptersForBook`/`SaveChaptersForBook`
(TASK-06) into a single dispatcher function:

- **Single-file book** (0 or 1 `BookFile` rows): trust the file's own embedded chapters as-is.
- **Multi-file book** (>1 `BookFile` rows): synthesize one chapter per file from re-probed, unrounded
  per-track durations (`audioutil.ProbeDurationSeconds`) and each file's own title tag — **never** that
  file's own embedded sub-chapters, even if present.
- **Idempotent**: a book that already has a persisted chapter list is skipped (no ffprobe re-run on
  rescan).
- **Wiring-mismatch safety**: if the package store is non-nil but not a `*database.PebbleStore`, this is
  logged via the existing `warnSampled` helper (1st + every 1000th occurrence) rather than silently
  no-op'd. A missing book, or a book with genuinely no chapters, stays a quiet no-op (data condition, not
  a wiring bug).

## ⚠️ Blocking caveat — chapters are NOT yet wired into the scan pipeline

This PR does **not** add the two `scanner.go` call sites described in the task brief's Step 4. My launch
instructions for this task explicitly said:

> Files you own: `internal/scanner/process_file.go` and new files under `internal/scanner/`. Do NOT edit
> `internal/scanner/scanner.go` — a parallel agent owns it right now.

That conflicts with the task brief itself, which calls for two one-line insertions into `scanner.go` (and
says no other task brief claims that file — I re-verified with
`grep -rln 'scanner\.go' docs/agent-tasks/abs-sync/TASK-*.md` and confirmed TASK-10 explicitly defers to
this task for `scanner.go` ownership, and TASK-01/TASK-05 only reference it read-only). I also checked
every sibling worktree (`abs-sync-*`, `abs2-*`) for an in-progress `scanner.go` diff and found none. Even
so, "a parallel agent owns it right now" is a live coordination claim my launcher can see and I can't —
absence of a diff doesn't prove absence of an owner — so I did not override it.

**Net effect: `PersistChaptersForBook` is currently dead code from the scan pipeline's point of view.**
It is fully implemented and tested via direct calls, but nothing in `scanner.go` invokes it yet, so a real
scan will not extract or persist chapters until a follow-up change applies the hook. I checked for an
existing indirection (a callback/hook `scanner.go` already invokes, e.g. the pre-existing but currently
unused `ScanHooks`/`SetScanHooks` in `internal/scanner/hooks.go`) that could avoid touching `scanner.go` —
none fits: `ScanHooks.OnBookScanned` fires from inside `saveBookToDatabase`, **before**
`createBookFilesForBook` runs for multi-file books, so by the time it fires there are no `BookFile` rows
yet for the multi-file synth path, and it also only fires on brand-new-book creation, not on the
book-file-creation branch this task needs. No safe alternative hook point exists in files I'm allowed to
touch.

**The exact patch a follow-up should apply** (content-matched, from the brief's Step 4 — re-verify against
current `scanner.go` since it drifts, don't trust raw line numbers):

```go
// Immediately after: createBookFilesForBook(dirPath, nil, scanLog)
if err := PersistChaptersForBook(ctx, dirPath, scanLog); err != nil {
    scanLog.Warn("chapter persistence failed for %s: %v", dirPath, err)
}
```

```go
// Immediately after the `if len(books[idx].SegmentFiles) > 1 { createBookFilesForBook(...) }` block
// (outside the `if`, so it also runs for the genuinely-single-file case), before the scan-cache-update
// func() { ... }():
if err := PersistChaptersForBook(ctx, books[idx].FilePath, scanLog); err != nil {
    scanLog.Warn("chapter persistence failed for %s: %v", books[idx].FilePath, err)
}
```

## Labeled scope decision — §5b finished-detection tolerance NOT implemented

Per the task brief, this PR does **not** implement the §5b-recommended ≥2s finished-detection tolerance.
There is no finished-detection code anywhere in this task's file ownership (`process_file.go`) to hang it
on — that mechanism belongs to the not-yet-built progress adapter (Phase 6, per
`docs/specs/2026-07-29-abs-sync-api-design.md` §5). This task's narrower, in-scope job re: §5b is making
sure the **precise, unrounded** duration (sum of re-probed track durations) is what ends up in
`chapters[len-1].EndSec`, so Phase 6 has an accurate number to build the tolerance on top of instead of
re-deriving one from a rounded `Book.Duration` or the container's own duration.

A source comment documenting this is left directly above `synthesizeMultiFileChapters` in
`internal/scanner/process_file.go`, explaining that `Book.Duration` (an `*int`, container/estimate-derived)
and `chapters[len-1].EndSec` (a `float64`, sum-of-tracks) disagree **by design** (~52ms spread on the
committed fixture), and that future finished-detection code must read the chapter-derived value, not
`Book.Duration`.

## Deviation from the orchestrator brief's third case

My launch instructions listed a third case ("multi-file book where individual files each carry their own
embedded chapters → rebase with `ShiftChapters`"). The actual TASK-07 brief explicitly excludes this:
multi-file books always get one synthesized chapter per file, titled from the file's tag, "**never** from
that file's own embedded sub-chapters, even if present." I followed the TASK-07 brief (the primary,
detailed source of truth) over the orchestrator summary here, since the brief is explicit and the summary
was a paraphrase. `ShiftChapters` is therefore unused by this PR — it remains available in
`internal/audioutil` for a future task if that behavior is ever wanted.

## Verification

```
$ gofmt -l internal/scanner/process_file.go internal/scanner/chapter_persistence_test.go
(no output — clean)

$ go vet ./...
(no output — clean)

$ go build ./...
(no output — clean)

$ go test ./internal/scanner/ ./internal/audioutil/ -run 'PersistChaptersForBook' -race -count=1 -v
=== RUN   TestPersistChaptersForBook_SingleFileM4B_UsesEmbeddedChapters
--- PASS: TestPersistChaptersForBook_SingleFileM4B_UsesEmbeddedChapters (1.15s)
=== RUN   TestPersistChaptersForBook_MultiFileMP3s_SynthesizesFromTrackTags
--- PASS: TestPersistChaptersForBook_MultiFileMP3s_SynthesizesFromTrackTags (1.33s)
=== RUN   TestPersistChaptersForBook_Idempotent_SkipsReExtraction
--- PASS: TestPersistChaptersForBook_Idempotent_SkipsReExtraction (0.97s)
=== RUN   TestPersistChaptersForBook_NoEmbeddedChaptersSingleTrack_NoOp
--- PASS: TestPersistChaptersForBook_NoEmbeddedChaptersSingleTrack_NoOp (1.03s)
=== RUN   TestPersistChaptersForBook_NonPebbleStore_LogsWarning
--- PASS: TestPersistChaptersForBook_NonPebbleStore_LogsWarning (0.00s)
PASS
ok  	github.com/falkcorp/audiobook-organizer/internal/scanner	6.023s

$ go test ./internal/scanner/ ./internal/audioutil/ -race -count=1
ok  	github.com/falkcorp/audiobook-organizer/internal/scanner	16.793s
ok  	github.com/falkcorp/audiobook-organizer/internal/audioutil	6.919s
```

All 5 tests ran for real (ffprobe + fixtures were present on this machine — none skipped). No SKIP
reasons to report here; if CI lacks `ffprobe`, these tests are written to `t.Skip` with a printed reason
rather than fail.

## Files touched

- `internal/scanner/process_file.go` — `PersistChaptersForBook`, `probeSingleFileChapters`,
  `synthesizeMultiFileChapters`, `logChapterWarn`, `chapterStoreAssertErrCount`, `chapterProbeTimeout`.
- `internal/scanner/chapter_persistence_test.go` — new, 5 tests per the brief's Step 1.
- `changelog.d/20260730_060700_abs-sync-scanner-chapter-hook.md` — new fragment (includes the
  not-yet-wired caveat).
- `internal/scanner/scanner.go` — **NOT touched** (see blocking caveat above).

## Concurrency

No new goroutines spawned per track/file — `synthesizeMultiFileChapters` probes tracks sequentially
inside whatever caller goroutine invokes `PersistChaptersForBook`, which (once wired) will be the
existing bounded per-book worker slot inside `ProcessBooksParallel`'s semaphore-bounded pool. Verified by
inspection: only `context.WithTimeout`/`defer cancel()` per track, no `go func()`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
