### PR TITLE
feat(abs-sync): add server-persisted bookmarks CRUD (TASK-09)

### DIFF
--- a/changelog.d/20260730_abs_sync_bookmarks.md
+++ b/changelog.d/20260730_abs_sync_bookmarks.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/20260730_abs_sync_bookmarks.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f4a2553b-df75-4772-a0ca-86418ac0c64f -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+- **Server-persisted bookmarks CRUD (abs-sync Phase 6 foundation).** No named-bookmark feature
+  existed in this codebase before -- only the unrelated single scalar `Book.ITunesBookmark`
+  (milliseconds, one value per book, imported from iTunes). Added
+  `internal/syncapi/progress/bookmarks.go` (pure `Bookmark` type, `ParseTimeSec`,
+  `CanonicalTimeKey`, `ValidateBookmark`) and `internal/database/pebble_store_bookmarks.go` (new
+  `bookmark:` Pebble keyspace + `BookmarkStore` interface, satisfied by `*PebbleStore`). Keyed by
+  `(userID, itemID, time)` with no separate bookmark ID, matching real Audiobookshelf's own
+  addressing (`DELETE .../bookmark/:time` puts the time value in the URL path). `CreateBookmark`
+  is an upsert: creating twice at the same time updates the title and preserves the original
+  `CreatedAt` (serialized under a mutex so two concurrent same-key upserts can't corrupt it).
+  `CanonicalTimeKey` rounds to the nearest millisecond and zero-pads to a fixed width so `"12"`
+  and `"12.0"` (AudioBooth sends bookmark `time` as an Int in some paths, as a Double in others)
+  resolve to the identical stored bookmark and sort lexicographically in numeric order.
+  `ListBookmarksForUser` aggregates every bookmark across all of a user's items via a one-segment-
+  wider prefix scan, feeding the `/api/me` response's `bookmarks[]` array built on every login and
+  home-screen refresh. Storage-only: no HTTP handler wired yet, and `BookmarkStore` is
+  deliberately not embedded into the composed `Store` interface -- that is later Phase-6 scope.

--- a/internal/database/pebble_store_bookmarks.go
+++ b/internal/database/pebble_store_bookmarks.go
@@ -1,0 +1,233 @@
+// file: internal/database/pebble_store_bookmarks.go
+// version: 1.0.0
+// guid: 35844383-1823-4889-9735-b64bceb2ab17
+// last-edited: 2026-07-30
+
+// Package database: named-bookmark keyspace.
+//
+// This is a genuinely new feature -- the only prior "bookmark" concept in
+// this codebase is the single scalar Book.ITunesBookmark (*int64,
+// milliseconds, one value per book, imported from iTunes). It is unrelated
+// to the ABS named-bookmark concept implemented here: a per-(user, item)
+// list of named timestamps a listener can jump back to.
+//
+// Real ABS keys a bookmark by (libraryItemId, time), not a separate
+// bookmark ID -- DELETE /api/me/item/:id/bookmark/:time puts the time value
+// itself in the URL path. This store mirrors that: no bookmark ID field
+// anywhere, the natural key is (userID, itemID, canonicalized time).
+//
+// Pebble key: "bookmark:" + userID + ":" + itemID + ":" +
+// progress.CanonicalTimeKey(timeSec), prefix-scanned per (userID, itemID)
+// using the same LowerBound/UpperBound("~") pattern as GetUserPosition in
+// pebble_store_playback.go (that file is read for the pattern but not
+// edited -- see the workstream's file-ownership rule).
+//
+// No HTTP handler is wired here. BookmarkStore is deliberately NOT embedded
+// into the composed Store interface in store.go; a later task decides
+// whether to embed it or accept it narrowly (the way ReadingStore does in
+// internal/server/handlers/reading.go) once it builds the bookmark
+// endpoints.
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+// BookmarkStore is a narrow interface satisfied structurally by *PebbleStore.
+// Deliberately NOT embedded into the composed Store interface in store.go --
+// wiring a bookmark HTTP handler (which would need that) is out of scope for
+// this task; whichever later task adds the handler decides then whether to
+// embed this into Store or accept it narrowly the way ReadingStore does in
+// internal/server/handlers/reading.go.
+type BookmarkStore interface {
+	CreateBookmark(b progress.Bookmark) error
+	ListBookmarks(userID, itemID string) ([]progress.Bookmark, error)
+	ListBookmarksForUser(userID string) ([]progress.Bookmark, error)
+	UpdateBookmarkTitle(userID, itemID string, timeSec float64, newTitle string) error
+	DeleteBookmark(userID, itemID string, timeSec float64) error
+}
+
+// AsBookmarkStore returns s as a BookmarkStore if it implements the
+// interface (true for *PebbleStore), or nil otherwise. Callers MUST nil-check
+// the result exactly like AsSyncIdentityStore's callers do.
+func AsBookmarkStore(s any) BookmarkStore {
+	if s == nil {
+		return nil
+	}
+	if bs, ok := s.(BookmarkStore); ok {
+		return bs
+	}
+	return nil
+}
+
+// Compile-time assertion that *PebbleStore satisfies BookmarkStore, so a
+// future signature drift on either side fails the build instead of only
+// surfacing at AsBookmarkStore's first caller.
+var _ BookmarkStore = (*PebbleStore)(nil)
+
+func bookmarkKey(userID, itemID string, timeSec float64) []byte {
+	return []byte(fmt.Sprintf("bookmark:%s:%s:%s", userID, itemID, progress.CanonicalTimeKey(timeSec)))
+}
+
+func bookmarkPrefix(userID, itemID string) []byte {
+	return []byte(fmt.Sprintf("bookmark:%s:%s:", userID, itemID))
+}
+
+// bookmarkUserPrefix bounds every bookmark for userID across ALL items --
+// the "bookmark:<userID>:" prefix is a strict prefix of every
+// per-item bookmarkPrefix, so scanning it aggregates across items the same
+// way ListUserPositionsSince's "upos:<userID>:" prefix does in
+// pebble_store_playback.go.
+func bookmarkUserPrefix(userID string) []byte {
+	return []byte(fmt.Sprintf("bookmark:%s:", userID))
+}
+
+// createBookmarkMu serializes CreateBookmark's get-then-set upsert section so
+// two concurrent upserts at the identical (userID, itemID, time) key cannot
+// race: without this, both goroutines could read "not found", both decide to
+// set CreatedAt to now, and the loser's write could still land last with a
+// title that lost the race non-deterministically alongside a doubled
+// CreatedAt decision. Mirrors the syncIDMintMu idiom in
+// pebble_store_syncid.go. Not held across ListBookmarks/DeleteBookmark/
+// UpdateBookmarkTitle -- only the create-upsert path needs this.
+var createBookmarkMu sync.Mutex
+
+// CreateBookmark upserts (creates or replaces the title of) a bookmark at
+// (b.UserID, b.ItemID, CanonicalTimeKey(b.TimeSec)). Calling it twice with
+// the same time and a different title updates the title rather than
+// erroring -- real ABS's create endpoint is also the natural "move the
+// playhead and re-save at the same spot" path a client might replay.
+// CreatedAt is set only if no record exists yet at that key (preserving the
+// original creation time across an upsert); UpdatedAt always advances.
+func (p *PebbleStore) CreateBookmark(b progress.Bookmark) error {
+	if err := progress.ValidateBookmark(b); err != nil {
+		return err
+	}
+
+	createBookmarkMu.Lock()
+	defer createBookmarkMu.Unlock()
+
+	key := bookmarkKey(b.UserID, b.ItemID, b.TimeSec)
+	nowMs := time.Now().UnixMilli()
+
+	existingData, closer, err := p.db.Get(key)
+	switch {
+	case err == nil:
+		var existing progress.Bookmark
+		if unmarshalErr := json.Unmarshal(existingData, &existing); unmarshalErr != nil {
+			closer.Close()
+			return unmarshalErr
+		}
+		closer.Close()
+		b.CreatedAt = existing.CreatedAt
+	case err == pebble.ErrNotFound:
+		b.CreatedAt = nowMs
+	default:
+		return err
+	}
+	b.UpdatedAt = nowMs
+
+	data, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	return p.db.Set(key, data, pebble.NoSync)
+}
+
+// ListBookmarks returns every bookmark for (userID, itemID), prefix-scanned
+// using the same LowerBound/UpperBound("~") pattern as GetUserPosition in
+// pebble_store_playback.go.
+func (p *PebbleStore) ListBookmarks(userID, itemID string) ([]progress.Bookmark, error) {
+	if userID == "" || itemID == "" {
+		return nil, nil
+	}
+	prefix := bookmarkPrefix(userID, itemID)
+	upper := append(append([]byte{}, prefix...), '~')
+	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var out []progress.Bookmark
+	for iter.First(); iter.Valid(); iter.Next() {
+		var b progress.Bookmark
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// ListBookmarksForUser returns every bookmark for userID across ALL items --
+// the source the `/api/me` `bookmarks[]` array is built from on every login
+// and home-screen refresh. Uses the same prefix-scan pattern as
+// ListBookmarks, just bounded one segment higher (by userID alone rather
+// than userID+itemID).
+func (p *PebbleStore) ListBookmarksForUser(userID string) ([]progress.Bookmark, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	prefix := bookmarkUserPrefix(userID)
+	upper := append(append([]byte{}, prefix...), '~')
+	iter, err := p.db.NewIter(&pebble.IterOptions{LowerBound: prefix, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	var out []progress.Bookmark
+	for iter.First(); iter.Valid(); iter.Next() {
+		var b progress.Bookmark
+		if err := json.Unmarshal(iter.Value(), &b); err != nil {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// UpdateBookmarkTitle changes the title of an existing bookmark at
+// (userID, itemID, timeSec). It returns an error and does not create a new
+// bookmark if none exists at that key.
+func (p *PebbleStore) UpdateBookmarkTitle(userID, itemID string, timeSec float64, newTitle string) error {
+	key := bookmarkKey(userID, itemID, timeSec)
+
+	data, closer, err := p.db.Get(key)
+	if err == pebble.ErrNotFound {
+		return fmt.Errorf("database: no bookmark for user %q item %q time %v", userID, itemID, timeSec)
+	}
+	if err != nil {
+		return err
+	}
+	var b progress.Bookmark
+	unmarshalErr := json.Unmarshal(data, &b)
+	closer.Close()
+	if unmarshalErr != nil {
+		return unmarshalErr
+	}
+
+	b.Title = newTitle
+	b.UpdatedAt = time.Now().UnixMilli()
+	if err := progress.ValidateBookmark(b); err != nil {
+		return err
+	}
+
+	newData, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	return p.db.Set(key, newData, pebble.NoSync)
+}
+
+// DeleteBookmark removes the bookmark at (userID, itemID, timeSec), if any.
+func (p *PebbleStore) DeleteBookmark(userID, itemID string, timeSec float64) error {
+	return p.db.Delete(bookmarkKey(userID, itemID, timeSec), pebble.NoSync)
+}

--- a/internal/database/pebble_store_bookmarks_test.go
+++ b/internal/database/pebble_store_bookmarks_test.go
@@ -1,0 +1,293 @@
+// file: internal/database/pebble_store_bookmarks_test.go
+// version: 1.0.0
+// guid: c95887b8-c5f3-4469-b0e8-d053d02bf1ea
+// last-edited: 2026-07-30
+
+package database
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+func newPebbleStoreForBookmarks(t *testing.T) *PebbleStore {
+	t.Helper()
+	store, err := NewPebbleStore(filepath.Join(t.TempDir(), "bookmarks-db"))
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestCreateBookmark_ThenList(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	b1 := progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: "first"}
+	b2 := progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 30, Title: "second"}
+
+	if err := store.CreateBookmark(b1); err != nil {
+		t.Fatalf("CreateBookmark(b1): %v", err)
+	}
+	if err := store.CreateBookmark(b2); err != nil {
+		t.Fatalf("CreateBookmark(b2): %v", err)
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bookmarks, got %d: %+v", len(got), got)
+	}
+}
+
+func TestCreateBookmark_UpsertSameTimeUpdatesTitle(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 30, Title: "A"}); err != nil {
+		t.Fatalf("CreateBookmark(A): %v", err)
+	}
+	first, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks (first): %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("expected 1 bookmark after first create, got %d", len(first))
+	}
+	firstCreatedAt := first[0].CreatedAt
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 30, Title: "B"}); err != nil {
+		t.Fatalf("CreateBookmark(B): %v", err)
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks (second): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 bookmark after upsert, got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "B" {
+		t.Errorf("expected title %q after upsert, got %q", "B", got[0].Title)
+	}
+	if got[0].CreatedAt != firstCreatedAt {
+		t.Errorf("expected CreatedAt preserved across upsert: first=%d, second=%d", firstCreatedAt, got[0].CreatedAt)
+	}
+	if got[0].UpdatedAt < firstCreatedAt {
+		t.Errorf("expected UpdatedAt to advance, got %d (created at %d)", got[0].UpdatedAt, firstCreatedAt)
+	}
+}
+
+func TestCreateBookmark_IntAndFloatTimeCollide(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	intTime, err := progress.ParseTimeSec("12")
+	if err != nil {
+		t.Fatalf("ParseTimeSec(12): %v", err)
+	}
+	floatTime, err := progress.ParseTimeSec("12.0")
+	if err != nil {
+		t.Fatalf("ParseTimeSec(12.0): %v", err)
+	}
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: intTime, Title: "int-encoded"}); err != nil {
+		t.Fatalf("CreateBookmark(int): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: floatTime, Title: "float-encoded"}); err != nil {
+		t.Fatalf("CreateBookmark(float): %v", err)
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 bookmark (int/float time collide), got %d: %+v", len(got), got)
+	}
+}
+
+func TestUpdateBookmarkTitle_NoSuchBookmarkErrors(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	if err := store.UpdateBookmarkTitle("u1", "i1", 42, "new title"); err == nil {
+		t.Error("expected error updating a nonexistent bookmark, got nil")
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected UpdateBookmarkTitle on missing key to not create one, got %d bookmarks", len(got))
+	}
+}
+
+func TestDeleteBookmark_RemovesOnlyThatOne(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: "keep-me"}); err != nil {
+		t.Fatalf("CreateBookmark(10): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 20, Title: "delete-me"}); err != nil {
+		t.Fatalf("CreateBookmark(20): %v", err)
+	}
+
+	if err := store.DeleteBookmark("u1", "i1", 20); err != nil {
+		t.Fatalf("DeleteBookmark(20): %v", err)
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 bookmark remaining, got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "keep-me" {
+		t.Errorf("expected remaining bookmark title %q, got %q", "keep-me", got[0].Title)
+	}
+}
+
+func TestListBookmarks_ScopedToUserAndItem(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: "u1-i1"}); err != nil {
+		t.Fatalf("CreateBookmark(u1,i1): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u2", ItemID: "i1", TimeSec: 10, Title: "u2-i1"}); err != nil {
+		t.Fatalf("CreateBookmark(u2,i1): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i2", TimeSec: 10, Title: "u1-i2"}); err != nil {
+		t.Fatalf("CreateBookmark(u1,i2): %v", err)
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks(u1,i1): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 bookmark for (u1,i1), got %d: %+v", len(got), got)
+	}
+	if got[0].Title != "u1-i1" {
+		t.Errorf("expected title %q, got %q", "u1-i1", got[0].Title)
+	}
+}
+
+func TestListBookmarksForUser_AggregatesAcrossItemsButNotOtherUsers(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: "u1-i1"}); err != nil {
+		t.Fatalf("CreateBookmark(u1,i1): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u1", ItemID: "i2", TimeSec: 20, Title: "u1-i2"}); err != nil {
+		t.Fatalf("CreateBookmark(u1,i2): %v", err)
+	}
+	if err := store.CreateBookmark(progress.Bookmark{UserID: "u2", ItemID: "i1", TimeSec: 10, Title: "u2-i1"}); err != nil {
+		t.Fatalf("CreateBookmark(u2,i1): %v", err)
+	}
+
+	got, err := store.ListBookmarksForUser("u1")
+	if err != nil {
+		t.Fatalf("ListBookmarksForUser(u1): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 bookmarks for u1 across both items, got %d: %+v", len(got), got)
+	}
+	titles := map[string]bool{}
+	for _, b := range got {
+		titles[b.Title] = true
+		if b.UserID != "u1" {
+			t.Errorf("ListBookmarksForUser(u1) returned a bookmark for user %q", b.UserID)
+		}
+	}
+	if !titles["u1-i1"] || !titles["u1-i2"] {
+		t.Errorf("expected both u1-i1 and u1-i2 present, got %+v", got)
+	}
+}
+
+func TestConcurrentCreateBookmark_DifferentTimesNoRace(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = store.CreateBookmark(progress.Bookmark{
+				UserID:  "u1",
+				ItemID:  "i1",
+				TimeSec: float64(i * 10),
+				Title:   fmt.Sprintf("bookmark-%d", i),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("CreateBookmark(%d) failed: %v", i, err)
+		}
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("expected %d bookmarks, got %d: %+v", n, len(got), got)
+	}
+}
+
+// TestConcurrentCreateBookmark_SameTimeUpsertNoRace exercises N concurrent
+// upserts at the SAME (userID, itemID, time) key -- the shape
+// TestConcurrentCreateBookmark_DifferentTimesNoRace does not cover, since it
+// only spans distinct times. Proves the get-then-set upsert path in
+// CreateBookmark is serialized (via createBookmarkMu) so a concurrent
+// same-key upsert cannot corrupt CreatedAt or leave two rows behind.
+func TestConcurrentCreateBookmark_SameTimeUpsertNoRace(t *testing.T) {
+	store := newPebbleStoreForBookmarks(t)
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = store.CreateBookmark(progress.Bookmark{
+				UserID:  "u1",
+				ItemID:  "i1",
+				TimeSec: 30,
+				Title:   fmt.Sprintf("racer-%d", i),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("CreateBookmark(%d) failed: %v", i, err)
+		}
+	}
+
+	got, err := store.ListBookmarks("u1", "i1")
+	if err != nil {
+		t.Fatalf("ListBookmarks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 bookmark after %d concurrent same-key upserts, got %d: %+v", n, len(got), got)
+	}
+	if got[0].CreatedAt == 0 {
+		t.Errorf("expected CreatedAt to be set, got 0")
+	}
+	if got[0].UpdatedAt < got[0].CreatedAt {
+		t.Errorf("expected UpdatedAt >= CreatedAt, got UpdatedAt=%d CreatedAt=%d", got[0].UpdatedAt, got[0].CreatedAt)
+	}
+}

--- a/internal/syncapi/progress/bookmarks.go
+++ b/internal/syncapi/progress/bookmarks.go
@@ -1,0 +1,84 @@
+// file: internal/syncapi/progress/bookmarks.go
+// version: 1.0.0
+// guid: 5666fa81-dccd-4eb3-b60f-b3050aa10c55
+// last-edited: 2026-07-30
+
+package progress
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// Bookmark is a named, server-persisted position within one (user, item)'s
+// audio. "item" is opaque here, same as Progress.CurrentTime's item -- a raw
+// Book ULID today, an ABS sync_item syncID once TASK-01 ships. Deliberately
+// has no separate ID field: real ABS keys a bookmark by (libraryItemId, time)
+// -- the create/update/delete surface addresses it by time, not by an opaque
+// ID -- so this type mirrors that rather than inventing a redundant key.
+type Bookmark struct {
+	UserID    string
+	ItemID    string
+	TimeSec   float64 // the natural key within (UserID, ItemID); see CanonicalTimeKey
+	Title     string
+	CreatedAt int64 // ms epoch
+	UpdatedAt int64 // ms epoch
+}
+
+// ParseTimeSec parses a bookmark `time` value from either an HTTP request
+// body's JSON number or a URL path segment string. Uses strconv.ParseFloat
+// (never ParseInt) specifically because AudioBooth sends bookmark `time` as
+// an Int in some paths (including the URL path segment on delete) while
+// other call sites round-trip it as a Double -- ParseFloat accepts both
+// "12" and "12.5" and "12.0" and returns the same float64 for "12" and
+// "12.0". This is the single normalization point; callers must not add a
+// second int-vs-float parsing path elsewhere.
+func ParseTimeSec(raw string) (float64, error) {
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("progress: invalid bookmark time %q: %w", raw, err)
+	}
+	return v, nil
+}
+
+// CanonicalTimeKey converts a bookmark time in seconds into a sortable,
+// collision-safe string suitable for use as (part of) a storage key: rounds
+// to the nearest millisecond and zero-pads to a fixed width so lexicographic
+// ordering matches numeric ordering. This guarantees "12" and "12.0" and
+// "11.9996" (float rounding noise) all resolve to the identical stored
+// bookmark, which is what "accept both Int and Double" actually requires at
+// the storage layer -- the type-level distinction is erased here, not at
+// the JSON boundary.
+func CanonicalTimeKey(timeSec float64) string {
+	ms := int64(math.Round(timeSec * 1000))
+	if ms < 0 {
+		ms = 0
+	}
+	// Zero-padded to 16 digits: comfortably wider than any realistic audio
+	// duration in milliseconds (16 digits covers ~317,000 years), so
+	// lexicographic string ordering always matches numeric ordering.
+	return fmt.Sprintf("%016d", ms)
+}
+
+// ValidateBookmark checks the invariants a Bookmark must satisfy before
+// being persisted: UserID, ItemID non-empty, TimeSec >= 0 (a negative
+// position is never valid), Title non-empty (real ABS requires a title;
+// an untitled bookmark is not a supported case here). Returns a descriptive
+// error, never panics.
+func ValidateBookmark(b Bookmark) error {
+	if b.UserID == "" {
+		return errors.New("progress: bookmark UserID must not be empty")
+	}
+	if b.ItemID == "" {
+		return errors.New("progress: bookmark ItemID must not be empty")
+	}
+	if b.TimeSec < 0 {
+		return fmt.Errorf("progress: bookmark TimeSec must be >= 0, got %v", b.TimeSec)
+	}
+	if b.Title == "" {
+		return errors.New("progress: bookmark Title must not be empty")
+	}
+	return nil
+}

--- a/internal/syncapi/progress/bookmarks_test.go
+++ b/internal/syncapi/progress/bookmarks_test.go
@@ -1,0 +1,100 @@
+// file: internal/syncapi/progress/bookmarks_test.go
+// version: 1.0.0
+// guid: 57379a49-1562-45d1-94bb-6ca07373721c
+// last-edited: 2026-07-30
+
+package progress
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseTimeSec_AcceptsIntAndFloatStrings(t *testing.T) {
+	cases := []string{"12", "12.0", "12.5", "0"}
+	for _, raw := range cases {
+		if _, err := ParseTimeSec(raw); err != nil {
+			t.Errorf("ParseTimeSec(%q) unexpected error: %v", raw, err)
+		}
+	}
+
+	intVal, err := ParseTimeSec("12")
+	if err != nil {
+		t.Fatalf("ParseTimeSec(%q) unexpected error: %v", "12", err)
+	}
+	floatVal, err := ParseTimeSec("12.0")
+	if err != nil {
+		t.Fatalf("ParseTimeSec(%q) unexpected error: %v", "12.0", err)
+	}
+	if intVal != floatVal {
+		t.Errorf("ParseTimeSec(\"12\")=%v != ParseTimeSec(\"12.0\")=%v, want equal", intVal, floatVal)
+	}
+}
+
+func TestParseTimeSec_RejectsGarbage(t *testing.T) {
+	cases := []string{"abc", "", "12.5.5"}
+	for _, raw := range cases {
+		if _, err := ParseTimeSec(raw); err == nil {
+			t.Errorf("ParseTimeSec(%q) expected error, got nil", raw)
+		}
+	}
+}
+
+func TestCanonicalTimeKey_IntAndFloatCollide(t *testing.T) {
+	a := CanonicalTimeKey(12)
+	b := CanonicalTimeKey(12.0)
+	if a != b {
+		t.Errorf("CanonicalTimeKey(12)=%q != CanonicalTimeKey(12.0)=%q, want identical", a, b)
+	}
+}
+
+func TestCanonicalTimeKey_OrdersNumerically(t *testing.T) {
+	values := []float64{0, 1, 1.5, 10, 100.25, 9999}
+	keys := make([]string, len(values))
+	for i, v := range values {
+		keys[i] = CanonicalTimeKey(v)
+	}
+
+	sorted := make([]string, len(keys))
+	copy(sorted, keys)
+	sort.Strings(sorted)
+
+	for i := range keys {
+		if keys[i] != sorted[i] {
+			t.Fatalf("CanonicalTimeKey outputs not in numeric order: got %v, sorted %v (input values %v)", keys, sorted, values)
+		}
+	}
+}
+
+func TestValidateBookmark_RejectsNegativeTime(t *testing.T) {
+	b := Bookmark{UserID: "u1", ItemID: "i1", TimeSec: -1, Title: "t"}
+	if err := ValidateBookmark(b); err == nil {
+		t.Error("expected error for negative TimeSec, got nil")
+	}
+}
+
+func TestValidateBookmark_RejectsEmptyTitle(t *testing.T) {
+	b := Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: ""}
+	if err := ValidateBookmark(b); err == nil {
+		t.Error("expected error for empty Title, got nil")
+	}
+}
+
+func TestValidateBookmark_RejectsEmptyUserOrItem(t *testing.T) {
+	cases := []Bookmark{
+		{UserID: "", ItemID: "i1", TimeSec: 10, Title: "t"},
+		{UserID: "u1", ItemID: "", TimeSec: 10, Title: "t"},
+	}
+	for _, b := range cases {
+		if err := ValidateBookmark(b); err == nil {
+			t.Errorf("expected error for %+v, got nil", b)
+		}
+	}
+}
+
+func TestValidateBookmark_AcceptsValid(t *testing.T) {
+	b := Bookmark{UserID: "u1", ItemID: "i1", TimeSec: 10, Title: "t"}
+	if err := ValidateBookmark(b); err != nil {
+		t.Errorf("expected valid bookmark to pass, got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

TASK-09 (abs-sync Phase 6 foundation): server-persisted, named **bookmarks**
CRUD. No such feature existed in this codebase before -- the only prior
"bookmark" concept is the unrelated single scalar `Book.ITunesBookmark`
(`*int64`, milliseconds, one value per book, imported from iTunes).

- `internal/syncapi/progress/bookmarks.go` -- pure `Bookmark` type,
  `ParseTimeSec`, `CanonicalTimeKey`, `ValidateBookmark`. Zero
  `internal/database` import (verified via grep).
- `internal/database/pebble_store_bookmarks.go` -- new `bookmark:` Pebble
  keyspace + `BookmarkStore` interface (satisfied structurally by
  `*PebbleStore`, deliberately **not** embedded in the composed `Store`
  interface). `CreateBookmark`/`ListBookmarks`/`UpdateBookmarkTitle`/
  `DeleteBookmark`, plus `ListBookmarksForUser` (aggregates a user's
  bookmarks across all items via a one-segment-wider prefix scan -- the
  source the future `/api/me` `bookmarks[]` array needs).

Keyed by `(userID, itemID, time)` with **no separate bookmark ID**, matching
real Audiobookshelf's own addressing (`DELETE .../bookmark/:time` puts the
time value in the URL path). `CreateBookmark` is an upsert: creating twice at
the same time updates the title and preserves the original `CreatedAt`
(serialized under a mutex so two concurrent same-key upserts can't corrupt
it). `CanonicalTimeKey` rounds to the nearest millisecond and zero-pads to a
fixed width, so `"12"` and `"12.0"` -- AudioBooth sends bookmark `time` as an
Int in some paths (including the URL path segment on delete) and as a Double
in others -- resolve to the identical stored bookmark and sort
lexicographically in numeric order.

**No HTTP handler is wired in this task** -- that's later Phase-6 scope, per
the task brief.

## File ownership / off-limits check

```
$ git diff --stat origin/main -- internal/database/store.go internal/database/pebble_store_playback.go
(empty output -- neither file touched)

$ grep -n '"github.com/falkcorp/audiobook-organizer/internal/database"' internal/syncapi/progress/bookmarks.go
(no match -- pure package has zero internal/database import)
```

## Test plan

TDD throughout: every test below was written first, confirmed to fail for
the right reason (`undefined: ParseTimeSec` / `undefined: CanonicalTimeKey`
/ `undefined: Bookmark` / `undefined: ValidateBookmark`, then later
`store.CreateBookmark undefined` / `store.ListBookmarksForUser undefined`),
then implemented.

```
$ go test ./internal/database/ ./internal/syncapi/progress/ -race -count=1 -v 2>&1 | grep -E "^(--- |FAIL|PASS|ok)"
... 553 "--- PASS" lines, 0 "--- FAIL" lines ...
ok  	github.com/falkcorp/audiobook-organizer/internal/database	357.501s
ok  	github.com/falkcorp/audiobook-organizer/internal/syncapi/progress	1.115s
```

All 17 new tests from this PR, individually:

```
--- PASS: TestParseTimeSec_AcceptsIntAndFloatStrings (0.00s)
--- PASS: TestParseTimeSec_RejectsGarbage (0.00s)
--- PASS: TestCanonicalTimeKey_IntAndFloatCollide (0.00s)
--- PASS: TestCanonicalTimeKey_OrdersNumerically (0.00s)
--- PASS: TestValidateBookmark_RejectsNegativeTime (0.00s)
--- PASS: TestValidateBookmark_RejectsEmptyTitle (0.00s)
--- PASS: TestValidateBookmark_RejectsEmptyUserOrItem (0.00s)
--- PASS: TestValidateBookmark_AcceptsValid (0.00s)
--- PASS: TestCreateBookmark_ThenList (0.24s)
--- PASS: TestCreateBookmark_UpsertSameTimeUpdatesTitle (0.25s)
--- PASS: TestCreateBookmark_IntAndFloatTimeCollide (0.26s)
--- PASS: TestUpdateBookmarkTitle_NoSuchBookmarkErrors (0.25s)
--- PASS: TestDeleteBookmark_RemovesOnlyThatOne (0.24s)
--- PASS: TestListBookmarks_ScopedToUserAndItem (0.25s)
--- PASS: TestListBookmarksForUser_AggregatesAcrossItemsButNotOtherUsers (0.23s)
--- PASS: TestConcurrentCreateBookmark_DifferentTimesNoRace (0.24s)
--- PASS: TestConcurrentCreateBookmark_SameTimeUpsertNoRace (0.22s)
```

(`TestListBookmarksForUser_...` and `TestConcurrentCreateBookmark_SameTimeUpsertNoRace`
go beyond TASK-09's literal file, added per the orchestrator brief's explicit
"list-all-for-user" requirement for the `/api/me` response, plus closing a
same-key upsert race the get-then-set `CreateBookmark` path had.)

```
$ go vet ./internal/syncapi/progress/... ./internal/database/...
(clean)

$ go vet ./...
(clean)

$ gofmt -l internal/syncapi/progress/ internal/database/
(all 4 new/changed files in this PR are clean; the command does list some
PRE-EXISTING files in internal/database unrelated to this change -- verified
none of activity_types.go, dual_write_activity_store.go, legacy_migration.go,
memdb_indexers.go, memdb_schema.go, mock_store.go, pebble_activity_backfill.go,
pebble_metrics_store.go, settings.go, transcribe_stats.go, and their _test.go
siblings were touched by this PR)

$ go build ./...
(succeeds repo-wide)
```

## Non-negotiables checklist

- [x] TDD: failing test first, confirmed fail-for-right-reason, then implement
- [x] File version headers + fresh GUIDs on every new file
- [x] `internal/database/store.go` and `pebble_store_playback.go` untouched
- [x] `changelog.d/20260730_abs_sync_bookmarks.md` added
- [x] Conventional commit, correct co-author trailer
- [x] No HTTP wiring / router registration

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
