### PR TITLE
feat(abs-sync): carry sync identity + progress through all four ULID-retiring paths (ABS-SYNC-ID-3/ID-12)

### DIFF
--- a/changelog.d/abs-sync-identity-follow-hooks.md
+++ b/changelog.d/abs-sync-identity-follow-hooks.md
@@ -1,0 +1,50 @@
+<!-- file: changelog.d/abs-sync-identity-follow-hooks.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7e668999-8957-45fc-b83e-9c65a77a8431 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+#### A device's listening position now survives every merge and untagged move (ABS-SYNC-ID-3 / ID-12)
+
+The durable sync identity added in the `sync_item` keyspace only helps if every
+code path that retires a Book ULID carries it forward. Four paths did not, and
+each one silently orphaned a client's saved place in a book:
+
+- **`merge.Service.MergeBooks`** (the UI/dedup merge) — the winner keeps its ULID
+  and losers are soft-deleted, so this is a loser-only redirect: the winner's
+  syncID is minted if absent, and each loser's syncID becomes a redirect record
+  pointing at it. A client still holding a loser's `libraryItemId` now resolves
+  through to the winner (chains included, e.g. B→A→C).
+- **`merge.Service.CombineBooks`** — absorbed shells are **hard-deleted**, so the
+  follow runs *before* the delete; there would be no row left to repoint after.
+- **`dedup.MergeBooks`** (still live via `internal/reconcile/itunes_heal.go`) —
+  also hard-deletes losers. This was the unrecoverable case: without the hook, a
+  routine heal run destroyed the only row that could have carried the identity.
+- **Untagged move** (`internal/scanner`) — a moved file with no
+  `AUDIOBOOK_ORGANIZER_ID` tag cannot be re-linked to its own row, so the scanner
+  mints a brand-new ULID and version-links it to the predecessor. The identity now
+  follows to the new ULID when the predecessor's file is gone from disk (a real
+  move); a second copy whose original still exists leaves the identity alone.
+
+Each user's listening progress moves with the identity, favouring whichever side
+is further along (`UserBookState.ProgressPct`, ties broken by the more recent
+`LastActivityAt`), and the retired book id is drained so no progress is left
+resolvable — or listable by status — under a book that no longer exists. The
+losing side is only drained *after* the carry-forward succeeds, so a store failure
+mid-way can never destroy the position it was meant to preserve.
+
+All four hooks are best-effort with respect to the merge itself (a sync-identity
+hiccup never fails a merge that would otherwise succeed) but never silent: every
+failure logs at ERROR with both book IDs. The merge hooks run inside the existing
+process-wide `mergeSerializeMu` critical section, which makes them exactly-once
+against concurrent merges by construction — no additional partitioning was added.
+A 16-goroutine `-race` test against a real PebbleStore asserts a single redirect,
+a single `MergedFrom` entry, and the correct surviving progress value after
+concurrent identical merges.
+
+**Known gap (follow-up):** the `sync_file` keyspace is keyed `(bookID, fileID)` and
+its `RepointSyncFile` primitive cannot move an entry to a different book, so
+per-file `ino` ids are not yet carried across `CombineBooks` (files move to the
+survivor) or an untagged move. That only affects an offline client's cached
+per-file download URLs, not progress or bookmarks.

--- a/internal/dedup/book_dedup.go
+++ b/internal/dedup/book_dedup.go
@@ -1,7 +1,7 @@
 // file: internal/dedup/book_dedup.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-18
+// last-edited: 2026-07-30
 
 // Package dedup: book_dedup.go contains the extracted execution logic for the
 // "dedup.book-scan" and "dedup.book-merge" async operations.  The *Server
@@ -440,6 +440,20 @@ func MergeBooks(
 
 		// Transfer useful iTunes metadata from merge book to keep book (first-win).
 		TransferITunesMetadataFirstWin(kBook, mergeBook)
+
+		// Carry the loser's ABS sync identity (libraryItemId) and each user's
+		// listening position onto the kept book BEFORE the hard delete below.
+		// This path is the worst case for an un-followed merge: store.DeleteBook
+		// removes the row outright, so unlike merge.Service.MergeBooks (which
+		// soft-deletes) there is nothing left to repoint afterwards and the
+		// device's place in the book would be lost permanently. Done here, not
+		// after the delete, so a crash between the two fails in the recoverable
+		// direction (a redirect for a book that still exists) rather than the
+		// unrecoverable one. Best-effort and never fails the merge; it logs at
+		// ERROR with both book IDs on failure. We already hold the process-wide
+		// merge.LockMergeRMW taken at the top of this function, so this is
+		// exactly-once w.r.t. every other merge-family path.
+		merge.FollowMergeWithStore(store, keepID, []string{mergeID})
 
 		if err := store.DeleteBook(mergeID); err != nil {
 			result.Errors = append(result.Errors,

--- a/internal/dedup/book_dedup_sync_follow_test.go
+++ b/internal/dedup/book_dedup_sync_follow_test.go
@@ -1,0 +1,106 @@
+// file: internal/dedup/book_dedup_sync_follow_test.go
+// version: 1.0.0
+// guid: 993dc044-1180-490b-a583-a67b30067e92
+// last-edited: 2026-07-30
+
+package dedup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeBooks_SyncIdentityFollowsHardDelete is the highest-stakes case in
+// the identity layer: this package's MergeBooks HARD-deletes losers (it is
+// still live via internal/reconcile/itunes_heal.go), so an unrecorded redirect
+// leaves nothing behind to repoint later -- the device's listening position is
+// gone permanently.
+func TestMergeBooks_SyncIdentityFollowsHardDelete(t *testing.T) {
+	store := newConcurrentTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	require.NotNil(t, ids)
+
+	user, err := store.CreateUser("listener", "listener@example.com", "argon2id", "x", []string{"user"}, "active")
+	require.NoError(t, err)
+
+	keepID := ulid.Make().String()
+	loserID := ulid.Make().String()
+	_, err = store.CreateBook(&database.Book{ID: keepID, Title: "Keep", Format: "m4b", FilePath: "/tmp/keep.m4b"})
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{ID: loserID, Title: "Loser", Format: "mp3", FilePath: "/tmp/loser.mp3"})
+	require.NoError(t, err)
+
+	keepSync, err := ids.MintOrGetSyncID(keepID)
+	require.NoError(t, err)
+	loserSync, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: loserID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 42, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, loserID, "seg-1", 314))
+
+	res, err := MergeBooks(context.Background(), store, ulid.Make().String(), keepID, []string{loserID}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.MergedCount)
+	require.Empty(t, res.Errors)
+
+	// The loser row really is gone — this is the hard-delete path.
+	gone, err := store.GetBookByID(loserID)
+	require.NoError(t, err)
+	require.Nil(t, gone)
+
+	resolved, err := ids.ResolveSyncItem(loserSync)
+	require.NoError(t, err)
+	require.NotNil(t, resolved, "the loser's sync item must still resolve after a hard delete")
+	require.Equal(t, keepSync, resolved.SyncID)
+
+	state, err := store.GetUserBookState(user.ID, keepID)
+	require.NoError(t, err)
+	require.NotNil(t, state, "the loser's listening position must have moved to the kept book")
+	require.Equal(t, 42, state.ProgressPct)
+
+	positions, err := store.ListUserPositionsForBook(user.ID, keepID)
+	require.NoError(t, err)
+	require.Len(t, positions, 1)
+	require.InDelta(t, 314.0, positions[0].PositionSeconds, 0.001)
+
+	orphaned, err := store.ListUserPositionsForBook(user.ID, loserID)
+	require.NoError(t, err)
+	require.Empty(t, orphaned, "no position may remain under the hard-deleted book id")
+}
+
+// TestMergeBooks_SyncIdentityIdempotent re-runs the same merge (the second
+// call finds the loser already deleted) and asserts the redirect chain is not
+// corrupted and MergedFrom does not grow.
+func TestMergeBooks_SyncIdentityIdempotent(t *testing.T) {
+	store := newConcurrentTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+
+	keepID := ulid.Make().String()
+	loserID := ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{ID: keepID, Title: "Keep", Format: "m4b", FilePath: "/tmp/keep2.m4b"})
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{ID: loserID, Title: "Loser", Format: "mp3", FilePath: "/tmp/loser2.mp3"})
+	require.NoError(t, err)
+	keepSync, err := ids.MintOrGetSyncID(keepID)
+	require.NoError(t, err)
+	loserSync, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	opID := ulid.Make().String()
+	_, err = MergeBooks(context.Background(), store, opID, keepID, []string{loserID}, nil)
+	require.NoError(t, err)
+	_, err = MergeBooks(context.Background(), store, opID, keepID, []string{loserID}, nil)
+	require.NoError(t, err)
+
+	item, err := ids.ResolveSyncItem(keepSync)
+	require.NoError(t, err)
+	require.Equal(t, []string{loserSync}, item.MergedFrom)
+}

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,7 +1,7 @@
 // file: internal/merge/service.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
-// last-edited: 2026-07-18
+// last-edited: 2026-07-30
 
 package merge
 
@@ -50,11 +50,24 @@ func AsExternalIDReassigner(s any) ExternalIDReassigner {
 type Service struct {
 	db               database.Store
 	writeBackBatcher WriteBackEnqueuer
+	syncFollower     SyncFollower
 }
 
 // SetWriteBackBatcher sets the iTunes write-back batcher.
 func (ms *Service) SetWriteBackBatcher(b WriteBackEnqueuer) {
 	ms.writeBackBatcher = b
+}
+
+// SetSyncFollower overrides the sync-identity follower wired by NewService.
+//
+// Why a settable field instead of a type assertion at the call site: tests (and
+// some production wiring) hand this Service a wrapper that EMBEDS
+// database.Store — e.g. serializeProbe in service_concurrent_test.go — and a
+// database.AsSyncIdentityStore assertion through such a wrapper returns nil,
+// which would silently no-op the whole hook without failing anything. Injecting
+// once, mirroring SetWriteBackBatcher, makes that failure mode explicit.
+func (ms *Service) SetSyncFollower(f SyncFollower) {
+	ms.syncFollower = f
 }
 
 // Result contains the outcome of a merge operation.
@@ -64,9 +77,22 @@ type Result struct {
 	MergedCount    int    `json:"merged_count"`
 }
 
-// NewService creates a new Service.
+// NewService creates a new Service. The sync-identity follower is wired
+// automatically when db supports it (the production *PebbleStore does); stores
+// that do not — mocks, wrappers that embed database.Store — yield nil and the
+// merge paths simply do not touch sync identity. Override with
+// SetSyncFollower.
 func NewService(db database.Store) *Service {
-	return &Service{db: db}
+	follower := database.AsSyncIdentityStore(db)
+	if follower == nil {
+		// Say so out loud. A nil follower silently disables the whole
+		// merge-follow hook, and the only way it can happen in production is
+		// someone wrapping the concrete store in a decorator that embeds
+		// database.Store — exactly the kind of change whose blast radius is
+		// invisible otherwise.
+		slog.Warn("merge: store does not implement SyncIdentityStore; merges will NOT carry ABS sync identity or listening progress")
+	}
+	return &Service{db: db, syncFollower: follower}
 }
 
 // MergeBooks merges a set of books into a single version group.
@@ -249,6 +275,29 @@ func (ms *Service) MergeBooks(bookIDs []string, primaryID string) (*Result, erro
 		}
 	}
 
+	// --- Sync-identity + progress follow ---
+	//
+	// Still inside mergeSerializeMu (see the Lock above): that single
+	// process-wide lock already makes every merge-family read-modify-write
+	// mutually exclusive with every other one, so anything added here is
+	// exactly-once with respect to concurrent merges by construction. Do NOT
+	// "fix" this by adding per-book-pair partitioning on top — CLAUDE.md's
+	// partition-by-book-ID guidance targets whole-library batch loops, not a
+	// single already-fully-serialized RMW, and a second scheme could subtly
+	// fight this lock.
+	//
+	// The winner's ULID never changes here (resolvedPrimaryID is an existing
+	// book's ID) and losers are only soft-deleted, so the winner's reverse
+	// index needs no repoint: this is a loser-only redirect. Kept as its own
+	// separately-testable step rather than folded into the loop above.
+	losers := make([]string, 0, len(books)-1)
+	for _, book := range books {
+		if book.ID != resolvedPrimaryID {
+			losers = append(losers, book.ID)
+		}
+	}
+	FollowMerge(ms.db, ms.syncFollower, resolvedPrimaryID, losers)
+
 	return &Result{
 		PrimaryID:      resolvedPrimaryID,
 		VersionGroupID: versionGroupID,
@@ -361,6 +410,14 @@ func (ms *Service) CombineBooks(bookIDs []string, primaryID string, override *Co
 				slog.Warn("combine ReassignExternalIDs", "from", id, "to", survivor.ID, "err", err)
 			}
 		}
+
+		// Carry the absorbed shell's sync identity and listening position onto
+		// the survivor BEFORE the hard delete below. Unlike MergeBooks (which
+		// soft-deletes), there is no surviving row to repoint afterwards, so a
+		// missed follow here is unrecoverable: the client's stored
+		// libraryItemId would resolve to nothing forever. Still inside
+		// mergeSerializeMu, so this is exactly-once w.r.t. every other merge.
+		FollowMerge(ms.db, ms.syncFollower, survivor.ID, []string{id})
 
 		// Guard (mirrors applyFSRegroup): never delete a book that still owns
 		// files — that would orphan audio. After the move it must be empty.

--- a/internal/merge/sync_follow.go
+++ b/internal/merge/sync_follow.go
@@ -1,0 +1,286 @@
+// file: internal/merge/sync_follow.go
+// version: 1.0.0
+// guid: 50421381-9def-4b19-bd23-6fa1a03c24d3
+// last-edited: 2026-07-30
+
+// Package merge: sync-identity follow hooks.
+//
+// The ABS-compatible sync layer exposes a durable `libraryItemId` (a syncID,
+// see internal/database/pebble_store_syncid.go) rather than the raw Book ULID,
+// because this app's core loop -- moving, retagging and merging books --
+// churns ULIDs. Every code path that retires or replaces a Book ULID must
+// therefore carry the syncID (and the per-user listening position keyed to the
+// old ULID) forward, or a device's place in a book is silently orphaned. On the
+// HARD-delete paths (dedup.MergeBooks, CombineBooks) there is no surviving row
+// to repoint afterwards, so an un-followed merge there is unrecoverable.
+//
+// See docs/specs/2026-07-29-abs-sync-api-design.md §4.2 (model), §4.3 (test
+// bar) and §5.5 (progress on merge).
+package merge
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// SyncFollower is satisfied by anything that can record a merge in the
+// sync-identity layer (internal/database's SyncIdentityStore). Optional: nil
+// is a valid, no-op value -- a store that does not implement it (a mock, a
+// MemStore) simply means merges do not touch sync identity.
+type SyncFollower interface {
+	MintOrGetSyncID(bookID string) (string, error)
+	RecordSyncMerge(loserBookID, winnerBookID string) error
+}
+
+// syncRepointMu serializes FollowBookIDChange's read-then-repoint. Unlike the
+// merge paths (which run inside mergeSerializeMu already), the scanner's
+// version-link path is NOT under any merge lock and runs on parallel scan
+// workers, and RepointSyncItem's own GetSyncIDForBook -> batch-commit is not
+// atomic. Without this, two workers version-linking against the SAME
+// predecessor book could both read its syncID and both write a reverse index,
+// leaving two live books pointing at one syncID. Deliberately NOT
+// mergeSerializeMu: that lock is held across whole merges and a scan worker
+// blocking on it (or vice versa) is a needless coupling of two unrelated
+// subsystems.
+var syncRepointMu sync.Mutex
+
+// FollowMerge carries sync identity and per-user progress from every loser
+// onto the winner of a merge. Call it while still holding whatever lock
+// guards the merge's read-modify-write, BEFORE any hard delete of a loser row.
+//
+// Best-effort by design, matching this package's convention for optional
+// side-effects (eidStore, writeBackBatcher): a sync-identity hiccup must never
+// fail a merge that would otherwise succeed. Every failure is logged at
+// ERROR with both book IDs, because a silent failure here loses a user's
+// listening position with no trace.
+//
+// Exactly-once: the store primitives it calls are idempotent
+// (MintOrGetSyncID returns the existing id; RecordSyncMerge returns early when
+// the redirect is already recorded and de-duplicates MergedFrom), so a retried
+// or concurrently repeated merge cannot double-redirect or grow a chain.
+func FollowMerge(db database.Store, follower SyncFollower, winnerBookID string, loserBookIDs []string) {
+	if follower == nil || db == nil || winnerBookID == "" {
+		return
+	}
+
+	// Ensure the winner has a client-visible identity before redirecting
+	// anything at it. If this fails, redirecting a loser would point at
+	// nothing, so stop here rather than record a dangling redirect.
+	if _, err := follower.MintOrGetSyncID(winnerBookID); err != nil {
+		slog.Error("sync-identity merge-follow: could not mint winner syncID; losers NOT redirected",
+			"winner", winnerBookID, "losers", loserBookIDs, "err", err)
+		return
+	}
+
+	for _, loserID := range loserBookIDs {
+		if loserID == "" || loserID == winnerBookID {
+			continue
+		}
+		if err := follower.RecordSyncMerge(loserID, winnerBookID); err != nil {
+			slog.Error("sync-identity merge-follow: redirect NOT recorded; a client holding the loser's id will not resolve",
+				"loser", loserID, "winner", winnerBookID, "err", err)
+		}
+		if err := mergeUserProgress(db, loserID, winnerBookID); err != nil {
+			slog.Error("sync-identity merge-follow: progress NOT merged onto winner",
+				"loser", loserID, "winner", winnerBookID, "err", err)
+		}
+	}
+}
+
+// FollowMergeWithStore is FollowMerge for callers that only hold a
+// database.Store and cannot reach a *Service (dedup.MergeBooks). It derives
+// the follower by type assertion; a store that does not implement
+// SyncIdentityStore yields a nil follower and the whole call is a no-op.
+func FollowMergeWithStore(db database.Store, winnerBookID string, loserBookIDs []string) {
+	follower := database.AsSyncIdentityStore(db)
+	if follower == nil {
+		// Warn, not debug: the only in-tree caller is a HARD-delete merge, so
+		// a silently-skipped follow there is unrecoverable.
+		slog.Warn("sync-identity merge-follow: store does not implement SyncIdentityStore; this merge will NOT carry identity or progress",
+			"winner", winnerBookID, "losers", loserBookIDs)
+	}
+	FollowMerge(db, follower, winnerBookID, loserBookIDs)
+}
+
+// FollowBookIDChange carries a book's sync identity and per-user progress from
+// oldBookID to newBookID when a Book ULID is REPLACED rather than merged --
+// the untagged-move case, where a moved file is re-scanned, matched to its
+// predecessor by hash, and a brand-new ULID is minted for the new path
+// (internal/scanner's version-link path). Both rows survive there, so this is
+// a repoint (RepointSyncItem), not a redirect.
+//
+// No-op when oldBookID has no syncID yet: there is no client-visible identity
+// to carry, and in that case the per-user progress rows are deliberately left
+// where they are -- moving them would change long-standing scanner behaviour
+// for installs that do not use the sync layer at all.
+//
+// Idempotent: a second call finds no syncID on oldBookID (the reverse index
+// moved) and returns without touching anything.
+func FollowBookIDChange(db database.Store, oldBookID, newBookID string) {
+	if db == nil || oldBookID == "" || newBookID == "" || oldBookID == newBookID {
+		return
+	}
+	ids := database.AsSyncIdentityStore(db)
+	if ids == nil {
+		// Debug, not warn (unlike FollowMergeWithStore): both rows survive a
+		// version-link, so a skipped follow here is recoverable by repointing
+		// later, and this runs on every hash-duplicate import.
+		slog.Debug("sync-identity follow: store does not implement SyncIdentityStore; skipping repoint",
+			"old_book", oldBookID, "new_book", newBookID)
+		return
+	}
+
+	syncRepointMu.Lock()
+	defer syncRepointMu.Unlock()
+
+	syncID, has, err := ids.GetSyncIDForBook(oldBookID)
+	if err != nil {
+		slog.Error("sync-identity follow: could not read the old book's syncID; identity NOT carried forward",
+			"old_book", oldBookID, "new_book", newBookID, "err", err)
+		return
+	}
+	if !has {
+		return
+	}
+
+	if err := ids.RepointSyncItem(oldBookID, newBookID); err != nil {
+		slog.Error("sync-identity follow: repoint FAILED; clients still resolve to the retired book id",
+			"sync_id", syncID, "old_book", oldBookID, "new_book", newBookID, "err", err)
+		return
+	}
+	// The identity now resolves to newBookID, so progress keyed to oldBookID
+	// would look lost to a client. It is still on disk under the old id (this
+	// only fails forward, never destroys), but it must be logged loudly.
+	if err := mergeUserProgress(db, oldBookID, newBookID); err != nil {
+		slog.Error("sync-identity follow: identity repointed but progress NOT migrated; positions still keyed to the old book id",
+			"sync_id", syncID, "old_book", oldBookID, "new_book", newBookID, "err", err)
+		return
+	}
+	slog.Info("sync-identity followed a book id change",
+		"sync_id", syncID, "old_book", oldBookID, "new_book", newBookID)
+}
+
+// mergeUserProgress merges every user's listening progress on loserBookID onto
+// winnerBookID, then drains the loser side.
+//
+// The loop is over USERS, not books: UserBookState/UserPosition are keyed
+// user-first (`ubs:<userID>:<bookID>`, `upos:<userID>:<bookID>:<segmentID>`)
+// with no book -> users reverse index, so there is no way to ask "who has
+// progress on this book". This is bounded by the number of accounts on the
+// instance (a household, not the library), so a plain sequential loop is
+// correct here -- deliberately NOT a worker pool, per CLAUDE.md's own
+// "whole-library-scale" threshold.
+func mergeUserProgress(db database.Store, loserBookID, winnerBookID string) error {
+	users, err := db.ListUsers()
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+	var firstErr error
+	for _, u := range users {
+		if u.ID == "" {
+			continue
+		}
+		if err := mergeUserProgressFor(db, u.ID, loserBookID, winnerBookID); err != nil {
+			// Keep going: one user's failure must not strand every other
+			// user's position.
+			slog.Error("sync-identity merge-follow: progress merge failed for one user",
+				"user", u.ID, "loser", loserBookID, "winner", winnerBookID, "err", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+// mergeUserProgressFor merges one user's progress from loser onto winner.
+//
+// "Furthest position" rule (deliberately narrower than §5's full live-PATCH
+// policy, which resolves two updates to the SAME item): compare
+// UserBookState.ProgressPct, an already-normalized 0-100 value that is
+// comparable across two different-length books -- raw PositionSeconds is not,
+// since two books have unrelated segment schemes and durations. Ties go to the
+// more recent LastActivityAt.
+//
+// The loser side is drained ONLY after a successful copy, so a mid-way store
+// failure can never destroy the position it was supposed to carry forward.
+func mergeUserProgressFor(db database.Store, userID, loserBookID, winnerBookID string) error {
+	loserState, err := db.GetUserBookState(userID, loserBookID)
+	if err != nil {
+		return fmt.Errorf("get loser state: %w", err)
+	}
+	loserPositions, err := db.ListUserPositionsForBook(userID, loserBookID)
+	if err != nil {
+		return fmt.Errorf("list loser positions: %w", err)
+	}
+	if loserState == nil && len(loserPositions) == 0 {
+		return nil // nothing to merge for this user
+	}
+
+	winnerState, err := db.GetUserBookState(userID, winnerBookID)
+	if err != nil {
+		return fmt.Errorf("get winner state: %w", err)
+	}
+
+	if loserIsFurther(loserState, winnerState) {
+		if loserState != nil {
+			carried := *loserState
+			carried.BookID = winnerBookID
+			if err := db.SetUserBookState(&carried); err != nil {
+				return fmt.Errorf("carry state onto winner: %w", err)
+			}
+		}
+		// Segment IDs are opaque per-user bookkeeping, not meaningfully
+		// comparable across books either way, so they are carried as-is.
+		for _, pos := range loserPositions {
+			if err := db.SetUserPosition(userID, winnerBookID, pos.SegmentID, pos.PositionSeconds); err != nil {
+				return fmt.Errorf("carry position %s onto winner: %w", pos.SegmentID, err)
+			}
+		}
+	}
+
+	// Drain the loser regardless of which side won: its book is merged away,
+	// and progress that is only resolvable under a retired book id is a leak
+	// (it can still surface in a per-status listing for a book that no longer
+	// exists).
+	if len(loserPositions) > 0 {
+		if err := db.ClearUserPositions(userID, loserBookID); err != nil {
+			return fmt.Errorf("clear loser positions: %w", err)
+		}
+	}
+	if loserState != nil {
+		// There is no DeleteUserBookState in the database layer, so the row is
+		// neutralized in place. An empty Status also removes it from the
+		// ubs status index (see PebbleStore.SetUserBookState), which is what
+		// keeps a merged-away book out of "in progress" listings.
+		drained := *loserState
+		drained.Status = ""
+		drained.StatusManual = false
+		drained.ProgressPct = 0
+		drained.TotalListenedSeconds = 0
+		drained.LastSegmentID = ""
+		if err := db.SetUserBookState(&drained); err != nil {
+			return fmt.Errorf("drain loser state: %w", err)
+		}
+	}
+	return nil
+}
+
+// loserIsFurther reports whether the losing book's state should win. A winner
+// with no state at all always loses (nothing to preserve on that side); two
+// nil states mean there is only position data to carry.
+func loserIsFurther(loserState, winnerState *database.UserBookState) bool {
+	if winnerState == nil {
+		return true
+	}
+	if loserState == nil {
+		return false
+	}
+	if loserState.ProgressPct != winnerState.ProgressPct {
+		return loserState.ProgressPct > winnerState.ProgressPct
+	}
+	return loserState.LastActivityAt.After(winnerState.LastActivityAt)
+}

--- a/internal/merge/sync_follow_concurrent_test.go
+++ b/internal/merge/sync_follow_concurrent_test.go
@@ -1,0 +1,101 @@
+// file: internal/merge/sync_follow_concurrent_test.go
+// version: 1.0.0
+// guid: df75ad6b-54e4-4a58-b5dd-4e07ec76fb2f
+// last-edited: 2026-07-30
+
+package merge
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMergeBooks_SyncIdentity_ConcurrentSamePair_ExactlyOnce is the
+// load-bearing concurrency test for the identity hook. 16 goroutines run the
+// SAME merge through ONE Service against a real PebbleStore. The hook lives
+// inside MergeBooks' existing mergeSerializeMu critical section, so it is
+// exactly-once by construction; this test proves the post-conditions rather
+// than merely "no race detected":
+//
+//  1. -race reports nothing.
+//  2. the loser resolves to the winner in exactly one hop (not a chain, not
+//     empty).
+//  3. the winner's MergedFrom has exactly ONE entry -- 16 appends would still
+//     be race-free under the mutex, so only this assertion catches a missing
+//     idempotency guard.
+//  4. the single seeded progress record survives on the winner with its
+//     original value (not zeroed by a lost update, not double-applied).
+//
+// The Service is built with NewService(store) and the follower is injected
+// explicitly via SetSyncFollower so the test cannot silently pass with a
+// nil (no-op) follower.
+func TestMergeBooks_SyncIdentity_ConcurrentSamePair_ExactlyOnce(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	require.NotNil(t, ids)
+
+	user := seedSyncUser(t, store)
+
+	// B is m4b so BookIsBetter deterministically picks it as the winner no
+	// matter how the goroutines interleave.
+	aID := ulid.Make().String()
+	bID := ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{ID: aID, Title: "Dup A", Format: "mp3", FilePath: "/tmp/ca.mp3"})
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{ID: bID, Title: "Dup B", Format: "m4b", FilePath: "/tmp/cb.m4b"})
+	require.NoError(t, err)
+
+	aSync, err := ids.MintOrGetSyncID(aID)
+	require.NoError(t, err)
+	bSync, err := ids.MintOrGetSyncID(bID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: aID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 50, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, aID, "seg-1", 1234))
+
+	ms := NewService(store)
+	ms.SetSyncFollower(database.AsSyncIdentityStore(store))
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = ms.MergeBooks([]string{aID, bID}, bID)
+		}()
+	}
+	wg.Wait()
+
+	resolved, err := ids.ResolveSyncItem(aSync)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, bSync, resolved.SyncID, "loser must resolve to the winner")
+
+	winnerItem, err := ids.ResolveSyncItem(bSync)
+	require.NoError(t, err)
+	require.NotNil(t, winnerItem)
+	require.Len(t, winnerItem.MergedFrom, 1, "MergedFrom must have exactly one entry after 16 identical merges")
+	require.Equal(t, aSync, winnerItem.MergedFrom[0])
+	require.Equal(t, "", winnerItem.RedirectTo, "the winner must stay live, never redirected")
+
+	state, err := store.GetUserBookState(user.ID, bID)
+	require.NoError(t, err)
+	require.NotNil(t, state, "the lone progress record must have survived onto the winner")
+	require.Equal(t, 50, state.ProgressPct)
+
+	positions, err := store.ListUserPositionsForBook(user.ID, bID)
+	require.NoError(t, err)
+	require.Len(t, positions, 1)
+	require.InDelta(t, 1234.0, positions[0].PositionSeconds, 0.001)
+
+	assertLoserProgressDrained(t, store, user.ID, aID)
+}

--- a/internal/merge/sync_follow_test.go
+++ b/internal/merge/sync_follow_test.go
@@ -1,0 +1,301 @@
+// file: internal/merge/sync_follow_test.go
+// version: 1.0.0
+// guid: e424f3c3-3b6c-4345-b703-20ca6809ec0f
+// last-edited: 2026-07-30
+
+package merge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// seedSyncUser creates one user for the progress-merge assertions.
+func seedSyncUser(t *testing.T, store database.Store) *database.User {
+	t.Helper()
+	u, err := store.CreateUser("reader", "reader@example.com", "argon2id", "x", []string{"user"}, "active")
+	require.NoError(t, err)
+	return u
+}
+
+// seedSyncBooks creates a winner (m4b) and a loser (mp3) and returns their IDs.
+func seedSyncBooks(t *testing.T, store database.Store) (winnerID, loserID string) {
+	t.Helper()
+	winnerID = ulid.Make().String()
+	loserID = ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{ID: winnerID, Title: "Winner", Format: "m4b", FilePath: "/tmp/win.m4b"})
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{ID: loserID, Title: "Loser", Format: "mp3", FilePath: "/tmp/lose.mp3"})
+	require.NoError(t, err)
+	return winnerID, loserID
+}
+
+func TestMergeBooks_SyncIdentity_LoserRedirectsToWinner(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	require.NotNil(t, ids, "PebbleStore must implement SyncIdentityStore")
+
+	winnerID, loserID := seedSyncBooks(t, store)
+	winnerSync, err := ids.MintOrGetSyncID(winnerID)
+	require.NoError(t, err)
+	loserSync, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+	require.NoError(t, err)
+
+	// A client still holding the loser's id must resolve to the winner's item.
+	resolved, err := ids.ResolveSyncItem(loserSync)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, winnerSync, resolved.SyncID, "loser syncID must resolve to the winner's item")
+
+	loserItem, err := ids.ResolveSyncItem(winnerSync)
+	require.NoError(t, err)
+	require.Equal(t, []string{loserSync}, loserItem.MergedFrom, "winner records the loser exactly once")
+
+	// The winner's own identity is unchanged.
+	stillWinner, has, err := ids.GetSyncIDForBook(winnerID)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, winnerSync, stillWinner)
+}
+
+// TestMergeBooks_SyncIdentity_MintsWinnerWhenAbsent covers the common
+// production shape once the backfill lands: the loser has a client-visible
+// identity, the winner does not yet.
+func TestMergeBooks_SyncIdentity_MintsWinnerWhenAbsent(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	winnerID, loserID := seedSyncBooks(t, store)
+	loserSync, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+	require.NoError(t, err)
+
+	winnerSync, has, err := ids.GetSyncIDForBook(winnerID)
+	require.NoError(t, err)
+	require.True(t, has, "merge must mint a syncID for the winner")
+	resolved, err := ids.ResolveSyncItem(loserSync)
+	require.NoError(t, err)
+	require.Equal(t, winnerSync, resolved.SyncID)
+}
+
+func TestMergeBooks_SyncIdentity_ProgressLoserFurtherWins(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	user := seedSyncUser(t, store)
+	winnerID, loserID := seedSyncBooks(t, store)
+	_, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: winnerID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 20, LastActivityAt: time.Now().Add(-time.Hour),
+	}))
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: loserID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 80, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, loserID, "seg-1", 4242))
+
+	ms := NewService(store)
+	_, err = ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+	require.NoError(t, err)
+
+	got, err := store.GetUserBookState(user.ID, winnerID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, 80, got.ProgressPct, "the further-along loser state must survive on the winner")
+	require.Equal(t, winnerID, got.BookID)
+
+	positions, err := store.ListUserPositionsForBook(user.ID, winnerID)
+	require.NoError(t, err)
+	require.Len(t, positions, 1)
+	require.Equal(t, "seg-1", positions[0].SegmentID)
+	require.InDelta(t, 4242.0, positions[0].PositionSeconds, 0.001)
+
+	// Nothing resolvable is left under the soft-deleted loser.
+	assertLoserProgressDrained(t, store, user.ID, loserID)
+}
+
+func TestMergeBooks_SyncIdentity_ProgressWinnerFurtherWins(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	user := seedSyncUser(t, store)
+	winnerID, loserID := seedSyncBooks(t, store)
+	_, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: winnerID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 90, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, winnerID, "seg-w", 900))
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: loserID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 10, LastActivityAt: time.Now().Add(-time.Hour),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, loserID, "seg-l", 100))
+
+	ms := NewService(store)
+	_, err = ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+	require.NoError(t, err)
+
+	got, err := store.GetUserBookState(user.ID, winnerID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, 90, got.ProgressPct, "winner state must not be rewound by a behind loser")
+
+	positions, err := store.ListUserPositionsForBook(user.ID, winnerID)
+	require.NoError(t, err)
+	require.Len(t, positions, 1, "the behind loser's positions must not be copied over")
+	require.Equal(t, "seg-w", positions[0].SegmentID)
+
+	assertLoserProgressDrained(t, store, user.ID, loserID)
+}
+
+func TestMergeBooks_SyncIdentity_NoProgressNoRows(t *testing.T) {
+	store := setupTestStore(t)
+	user := seedSyncUser(t, store)
+	winnerID, loserID := seedSyncBooks(t, store)
+
+	ms := NewService(store)
+	_, err := ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+	require.NoError(t, err)
+
+	got, err := store.GetUserBookState(user.ID, winnerID)
+	require.NoError(t, err)
+	require.Nil(t, got, "no progress anywhere must not fabricate a state row")
+	got, err = store.GetUserBookState(user.ID, loserID)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestMergeBooks_SyncIdentity_IdempotentRemerge(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	winnerID, loserID := seedSyncBooks(t, store)
+	winnerSync, err := ids.MintOrGetSyncID(winnerID)
+	require.NoError(t, err)
+	loserSync, err := ids.MintOrGetSyncID(loserID)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	for i := 0; i < 3; i++ {
+		_, err = ms.MergeBooks([]string{winnerID, loserID}, winnerID)
+		require.NoError(t, err, "re-merge %d", i)
+	}
+
+	item, err := ids.ResolveSyncItem(winnerSync)
+	require.NoError(t, err)
+	require.Equal(t, []string{loserSync}, item.MergedFrom, "MergedFrom must not grow on re-merge")
+	resolved, err := ids.ResolveSyncItem(loserSync)
+	require.NoError(t, err)
+	require.Equal(t, winnerSync, resolved.SyncID)
+}
+
+// TestMergeBooks_SyncIdentity_ChainedMerges covers B -> A then A -> C: a client
+// holding B's id must resolve all the way to C (ResolveSyncItem's hop
+// following), not stop at the now-redirected A.
+func TestMergeBooks_SyncIdentity_ChainedMerges(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+
+	aID := ulid.Make().String()
+	bID := ulid.Make().String()
+	cID := ulid.Make().String()
+	for _, b := range []*database.Book{
+		{ID: aID, Title: "A", Format: "mp3", FilePath: "/tmp/a.mp3"},
+		{ID: bID, Title: "B", Format: "mp3", FilePath: "/tmp/b.mp3"},
+		{ID: cID, Title: "C", Format: "mp3", FilePath: "/tmp/c.mp3"},
+	} {
+		_, err := store.CreateBook(b)
+		require.NoError(t, err)
+	}
+	bSync, err := ids.MintOrGetSyncID(bID)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.MergeBooks([]string{aID, bID}, aID) // B -> A
+	require.NoError(t, err)
+	_, err = ms.MergeBooks([]string{cID, aID}, cID) // A -> C
+	require.NoError(t, err)
+
+	cSync, has, err := ids.GetSyncIDForBook(cID)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	resolved, err := ids.ResolveSyncItem(bSync)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, cSync, resolved.SyncID, "B must resolve through A to C")
+}
+
+func TestCombineBooks_SyncIdentity_ShellRedirectsToSurvivor(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	user := seedSyncUser(t, store)
+
+	survivorID := ulid.Make().String()
+	shellID := ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{ID: survivorID, Title: "Survivor", Format: "mp3", FilePath: "/tmp/s1.mp3"})
+	require.NoError(t, err)
+	_, err = store.CreateBook(&database.Book{ID: shellID, Title: "Shell", Format: "mp3", FilePath: "/tmp/s2.mp3"})
+	require.NoError(t, err)
+
+	survivorSync, err := ids.MintOrGetSyncID(survivorID)
+	require.NoError(t, err)
+	shellSync, err := ids.MintOrGetSyncID(shellID)
+	require.NoError(t, err)
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: shellID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 55, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, shellID, "seg-1", 77))
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivorID, shellID}, survivorID, nil)
+	require.NoError(t, err)
+
+	// The absorbed shell is HARD-deleted here: an unrecorded redirect would be
+	// unrecoverable, there is no surviving row to repoint later.
+	resolved, err := ids.ResolveSyncItem(shellSync)
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Equal(t, survivorSync, resolved.SyncID)
+
+	got, err := store.GetUserBookState(user.ID, survivorID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, 55, got.ProgressPct)
+	assertLoserProgressDrained(t, store, user.ID, shellID)
+}
+
+// assertLoserProgressDrained asserts no resumable progress is left addressable
+// under a merged-away book id. The database package has no
+// DeleteUserBookState, so the row is neutralized in place (empty status, zero
+// percent, no positions) rather than removed -- an empty Status also drops it
+// from the ubs status index, so it can no longer surface in a
+// ListUserBookStatesByStatus listing for a book that no longer exists.
+func assertLoserProgressDrained(t *testing.T, store database.Store, userID, loserBookID string) {
+	t.Helper()
+	positions, err := store.ListUserPositionsForBook(userID, loserBookID)
+	require.NoError(t, err)
+	require.Empty(t, positions, "loser positions must be cleared")
+
+	state, err := store.GetUserBookState(userID, loserBookID)
+	require.NoError(t, err)
+	if state == nil {
+		return
+	}
+	require.Equal(t, 0, state.ProgressPct, "loser state must be neutralized")
+	require.Equal(t, "", state.Status, "loser state must be dropped from the status index")
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,7 @@
 // file: internal/scanner/scanner.go
-// version: 1.49.0
+// version: 1.50.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
-// last-edited: 2026-07-17
+// last-edited: 2026-07-30
 
 package scanner
 
@@ -29,6 +29,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/logging"
 	"github.com/falkcorp/audiobook-organizer/internal/matcher"
+	"github.com/falkcorp/audiobook-organizer/internal/merge"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/util"
 	"github.com/oklog/ulid/v2"
@@ -2015,6 +2016,15 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 			}
 		}
 
+		// supersededBook* records the predecessor row when a hash-duplicate is
+		// version-linked below and a BRAND NEW Book ULID is minted for this
+		// path. It is the untagged-move case: the file has no
+		// AUDIOBOOK_ORGANIZER_ID tag to re-link by, so the moved file cannot
+		// reuse its old row and the ABS sync identity (plus the listening
+		// position keyed to the old ULID) has to be carried forward explicitly
+		// once the new row exists. See followSyncIdentityOnVersionLink.
+		var supersededBookID, supersededBookPath string
+
 		// Upsert semantics with duplicate detection:
 		// 1. Try lookup by file path first (exact match)
 		existing, err := getStore().GetBookByFilePath(book.FilePath)
@@ -2096,6 +2106,10 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 					dbBook.IsPrimaryVersion = &newPrimary
 					defaultLog.Info("Auto-linked hash-duplicate as version group %s (primary=%s): %s <-> %s",
 						groupID, existing.FilePath, existing.FilePath, book.FilePath)
+					// A new ULID is about to be minted for this path; remember
+					// the row it supersedes so the sync identity can follow if
+					// this turns out to be a move rather than a second copy.
+					supersededBookID, supersededBookPath = existing.ID, existing.FilePath
 					// Fall through to create the new (non-primary) record below
 					existing = nil
 				}
@@ -2170,6 +2184,8 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 					dbBook.IsPrimaryVersion = &newPrimary
 					defaultLog.Info("Multi-file dedup: linked %q as version group %s (%d/%d files matched)",
 						matchedBook.Title, groupID, bestCount, len(book.SegmentFiles))
+					// Same untagged-move follow as the single-hash branch above.
+					supersededBookID, supersededBookPath = matchedBook.ID, matchedBook.FilePath
 					// Leave existing == nil so CreateBook runs below with the version fields set.
 				} else {
 					defaultLog.Debug("Multi-file dedup: best match %d/%d files (threshold %d) — treating as new book: %s",
@@ -2218,6 +2234,7 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 
 			_, err = getStore().CreateBook(dbBook)
 			if err == nil {
+				followSyncIdentityOnVersionLink(supersededBookID, supersededBookPath, dbBook.ID)
 				// Check for metadata hash duplicates
 				detectMetadataHashDuplicate(dbBook, defaultLog)
 				if scanHooks != nil {
@@ -2254,6 +2271,45 @@ func saveBookToDatabase(ctx context.Context, book *Book) error {
 	}
 
 	return fmt.Errorf("database store not initialized")
+}
+
+// followSyncIdentityOnVersionLink carries a superseded book's ABS sync identity
+// (its durable libraryItemId) and each user's listening position onto the
+// freshly created row when a hash-duplicate version-link mints a NEW Book ULID
+// for a path.
+//
+// Why the on-disk check decides it: the two situations reaching this point are
+// indistinguishable from the DB alone.
+//
+//   - The predecessor's file is GONE -> the file was moved and, being untagged,
+//     could not be re-linked to its own row. The new row is the live book, so
+//     the identity must follow it or the device's place in the book is orphaned
+//     on a row that points at a path that no longer exists.
+//   - The predecessor's file still EXISTS -> a genuine second copy/version.
+//     Both books are real; the identity stays on the original.
+//
+// Note the IsPrimaryVersion flag cannot be used as that signal: in this branch
+// newPrimary is `newInRoot && !existingInRoot`, which the enclosing else-if
+// has already excluded, so it is always false regardless of what happened on
+// disk.
+//
+// Best-effort and never fails the import; merge.FollowBookIDChange logs at
+// ERROR (with both book IDs) if the carry-forward fails, and is a no-op when
+// the predecessor never had a sync identity minted.
+func followSyncIdentityOnVersionLink(supersededID, supersededPath, newBookID string) {
+	if supersededID == "" || supersededPath == "" || newBookID == "" {
+		return
+	}
+	if _, err := os.Stat(supersededPath); err == nil {
+		return // predecessor file still present: a second copy, not a move
+	} else if !os.IsNotExist(err) {
+		// Cannot prove the predecessor is gone (permissions, unmounted share).
+		// Stay conservative and leave the identity where it is.
+		defaultLog.Warn("sync-identity: cannot stat superseded book path %s, leaving identity on %s: %v",
+			supersededPath, supersededID, err)
+		return
+	}
+	merge.FollowBookIDChange(getStore(), supersededID, newBookID)
 }
 
 // ComputeSegmentFileHash computes SHA256 of the first 1MB of a file for use as

--- a/internal/scanner/sync_identity_move_test.go
+++ b/internal/scanner/sync_identity_move_test.go
@@ -1,0 +1,146 @@
+// file: internal/scanner/sync_identity_move_test.go
+// version: 1.0.0
+// guid: 5867d69f-d4f1-4d1e-9850-300c607a271b
+// last-edited: 2026-07-30
+
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// syncMoveFixture wires a real PebbleStore as both the scanner store and the
+// global store, with RootDir cleared so the hash-duplicate branch takes the
+// version-link path (mint a NEW Book ULID) rather than the in-place
+// organized-path promotion (which keeps the same ULID and needs no hook).
+func syncMoveFixture(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	store, cleanup := setupPebbleStore(t)
+	t.Cleanup(cleanup)
+
+	prevStore := database.GetGlobalStore()
+	database.SetGlobalStore(store)
+	SetStore(store)
+	prevConfig := config.AppConfig
+	config.AppConfig.RootDir = ""
+	t.Cleanup(func() {
+		database.SetGlobalStore(prevStore)
+		SetStore(nil)
+		config.AppConfig = prevConfig
+	})
+	return store
+}
+
+// TestSaveBookToDatabase_UntaggedMove_CarriesSyncIdentity: an untagged file is
+// moved on disk and re-scanned. There is no AUDIOBOOK_ORGANIZER_ID tag to
+// re-link by, so the scanner matches it to its predecessor by hash and mints a
+// BRAND NEW Book ULID for the new path. The predecessor's file is gone, so the
+// client-visible identity (and the listening position keyed to the old ULID)
+// must follow to the new ULID.
+func TestSaveBookToDatabase_UntaggedMove_CarriesSyncIdentity(t *testing.T) {
+	store := syncMoveFixture(t)
+	ids := database.AsSyncIdentityStore(store)
+	require.NotNil(t, ids)
+
+	user, err := store.CreateUser("mover", "mover@example.com", "argon2id", "x", []string{"user"}, "active")
+	require.NoError(t, err)
+
+	const hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	oldPath := filepath.Join(t.TempDir(), "gone", "moved.mp3") // deliberately NOT created
+	oldID := ulid.Make().String()
+	_, err = store.CreateBook(&database.Book{
+		ID: oldID, Title: "Moved Book", Format: "mp3",
+		FilePath: oldPath, FileHash: strPtr(hash), OriginalFileHash: strPtr(hash),
+	})
+	require.NoError(t, err)
+
+	syncID, err := ids.MintOrGetSyncID(oldID)
+	require.NoError(t, err)
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: oldID, Status: database.UserBookStatusInProgress,
+		ProgressPct: 64, LastActivityAt: time.Now(),
+	}))
+	require.NoError(t, store.SetUserPosition(user.ID, oldID, "seg-1", 987))
+
+	newPath := filepath.Join(t.TempDir(), "moved.mp3")
+	require.NoError(t, os.WriteFile(newPath, []byte("audio"), 0o644))
+	require.NoError(t, saveBookToDatabase(context.Background(), &Book{
+		FilePath: newPath, Title: "Moved Book", Format: ".mp3", FileHash: hash,
+	}))
+
+	newBook, err := store.GetBookByFilePath(newPath)
+	require.NoError(t, err)
+	require.NotNil(t, newBook, "the moved file must have been imported")
+	require.NotEqual(t, oldID, newBook.ID, "this path mints a new ULID; if it did not, there is nothing to follow")
+
+	// The identity followed to the new ULID.
+	got, has, err := ids.GetSyncIDForBook(newBook.ID)
+	require.NoError(t, err)
+	require.True(t, has, "the new book must own the existing syncID")
+	require.Equal(t, syncID, got)
+
+	item, err := ids.ResolveSyncItem(syncID)
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	require.Equal(t, newBook.ID, item.CurrentBookID)
+	require.Equal(t, "", item.RedirectTo, "a move is a repoint, not a merge redirect")
+
+	// And so did the listening position.
+	state, err := store.GetUserBookState(user.ID, newBook.ID)
+	require.NoError(t, err)
+	require.NotNil(t, state, "the position must not be stranded on the retired ULID")
+	require.Equal(t, 64, state.ProgressPct)
+	positions, err := store.ListUserPositionsForBook(user.ID, newBook.ID)
+	require.NoError(t, err)
+	require.Len(t, positions, 1)
+	require.InDelta(t, 987.0, positions[0].PositionSeconds, 0.001)
+}
+
+// TestSaveBookToDatabase_SecondCopy_KeepsSyncIdentity: same hash, but the
+// predecessor's file is STILL on disk. That is a genuine second copy, not a
+// move — both books are real, so the identity must stay put on the original.
+func TestSaveBookToDatabase_SecondCopy_KeepsSyncIdentity(t *testing.T) {
+	store := syncMoveFixture(t)
+	ids := database.AsSyncIdentityStore(store)
+
+	const hash = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.mp3")
+	require.NoError(t, os.WriteFile(firstPath, []byte("audio"), 0o644))
+
+	firstID := ulid.Make().String()
+	_, err := store.CreateBook(&database.Book{
+		ID: firstID, Title: "Two Copies", Format: "mp3",
+		FilePath: firstPath, FileHash: strPtr(hash), OriginalFileHash: strPtr(hash),
+	})
+	require.NoError(t, err)
+	syncID, err := ids.MintOrGetSyncID(firstID)
+	require.NoError(t, err)
+
+	secondPath := filepath.Join(dir, "second.mp3")
+	require.NoError(t, os.WriteFile(secondPath, []byte("audio"), 0o644))
+	require.NoError(t, saveBookToDatabase(context.Background(), &Book{
+		FilePath: secondPath, Title: "Two Copies", Format: ".mp3", FileHash: hash,
+	}))
+
+	stillFirst, has, err := ids.GetSyncIDForBook(firstID)
+	require.NoError(t, err)
+	require.True(t, has, "the original book keeps its identity when its file still exists")
+	require.Equal(t, syncID, stillFirst)
+
+	second, err := store.GetBookByFilePath(secondPath)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	_, hasSecond, err := ids.GetSyncIDForBook(second.ID)
+	require.NoError(t, err)
+	require.False(t, hasSecond, "a second copy must not inherit the original's identity")
+}


### PR DESCRIPTION
## What

Closes the identity-durability gaps: **all four** code paths that retire or replace a Book ULID now carry the durable `sync_item` identity (the ABS `libraryItemId`) and each user's listening position forward. TASK-03 and TASK-12 done together, because `CombineBooks` lives in the same file as `MergeBooks`.

| # | Path | Delete semantics | Hooked | Mechanism |
|---|---|---|---|---|
| 1 | `merge.Service.MergeBooks` | soft-delete | ✅ | `RecordSyncMerge` (loser-only redirect) + progress merge |
| 2 | `merge.Service.CombineBooks` | **hard-delete** | ✅ | same, run **before** the delete |
| 3 | `dedup.MergeBooks` (live via `reconcile/itunes_heal.go`) | **hard-delete** | ✅ | same, run **before** the delete — this was the *unrecoverable* case |
| 4 | Untagged move (`internal/scanner`) | new ULID via `CreateBook` + version-link | ✅ | `RepointSyncItem` + progress migration |

Ground truth re-verified before editing: `resolvedPrimaryID := books[bestIdx].ID` (winner ULID never changes), `dedup.MergeBooks` is still live and still `store.DeleteBook`s losers, and `mergeSerializeMu` is a single process-wide lock covering all three merge paths.

## Design notes worth reviewing

- **Concurrency: no new lock on the merge paths.** All three merge hooks run inside the *existing* `mergeSerializeMu` critical section, which already serializes every merge-family read-modify-write process-wide — so the hooks are exactly-once against concurrent merges by construction. A comment at the hook site says why per-book-pair partitioning was deliberately *not* added on top. The scanner's version-link path is **not** under any merge lock (parallel scan workers), and `RepointSyncItem`'s own read→batch is not atomic, so `FollowBookIDChange` takes its own small mutex — deliberately not `mergeSerializeMu`, which is held across whole merges.
- **Untagged move: the on-disk check is the signal.** Predecessor file gone ⇒ it was a move, identity follows the new ULID. Predecessor file still present ⇒ genuine second copy, identity stays. `IsPrimaryVersion` *cannot* be used: in that branch `newPrimary = newInRoot && !existingInRoot`, which the enclosing `else if` has already excluded, so it is always `false`.
- **Progress rule** (narrower than §5's live-PATCH policy): higher `UserBookState.ProgressPct` wins (normalized 0–100, comparable across two different-length books, unlike raw `PositionSeconds`), ties broken by more recent `LastActivityAt`.
- **Drain only after a successful carry.** The loser side is cleared strictly after the copy onto the winner succeeds, so a store failure mid-way cannot destroy the position it was meant to preserve.
- **Loser state is neutralized, not deleted.** The database layer has no `DeleteUserBookState` and this PR does not own `pebble_store_playback.go`, so the loser's row is zeroed with an empty `Status` — which also removes it from the `ubs` status index, keeping a merged-away book out of "in progress" listings. Positions are genuinely deleted (`ClearUserPositions`).
- **Never silent.** Every failure logs at ERROR with both book IDs. The type-assertion trap that would no-op the entire hook (a store wrapper embedding `database.Store`) warns at `NewService` construction and at the hard-delete call site; `SetSyncFollower` exists so tests inject a real follower instead of silently passing with `nil`. Verified that production passes a raw `*PebbleStore` (`database.InitializeStore` → `NewPebbleStore`, no decorator), so the assertion holds in prod.
- **Idempotent.** Re-running any merge or move cannot double-redirect or grow `MergedFrom`; a repeated move finds no reverse index and returns.

## Tests (TDD — each written red first, confirmed failing for the right reason, then implemented)

```
$ go test ./internal/merge/ -run SyncIdentity -race -count=1 -v
--- PASS: TestMergeBooks_SyncIdentity_ConcurrentSamePair_ExactlyOnce (0.54s)
--- PASS: TestMergeBooks_SyncIdentity_LoserRedirectsToWinner (0.20s)
--- PASS: TestMergeBooks_SyncIdentity_MintsWinnerWhenAbsent (0.18s)
--- PASS: TestMergeBooks_SyncIdentity_ProgressLoserFurtherWins (0.19s)
--- PASS: TestMergeBooks_SyncIdentity_ProgressWinnerFurtherWins (0.20s)
--- PASS: TestMergeBooks_SyncIdentity_NoProgressNoRows (0.18s)
--- PASS: TestMergeBooks_SyncIdentity_IdempotentRemerge (0.26s)
--- PASS: TestMergeBooks_SyncIdentity_ChainedMerges (0.25s)
--- PASS: TestCombineBooks_SyncIdentity_ShellRedirectsToSurvivor (0.19s)
ok  	github.com/falkcorp/audiobook-organizer/internal/merge	3.604s

$ go test ./internal/dedup/ -run SyncIdentity -race -count=1 -v
--- PASS: TestMergeBooks_SyncIdentityFollowsHardDelete (0.20s)
--- PASS: TestMergeBooks_SyncIdentityIdempotent (0.17s)
ok  	github.com/falkcorp/audiobook-organizer/internal/dedup	1.943s

$ go test ./internal/scanner/ -run SyncIdentity -race -count=1 -v
--- PASS: TestSaveBookToDatabase_UntaggedMove_CarriesSyncIdentity (1.00s)
--- PASS: TestSaveBookToDatabase_SecondCopy_KeepsSyncIdentity (0.97s)
ok  	github.com/falkcorp/audiobook-organizer/internal/scanner	3.544s
```

The 16-goroutine `-race` test asserts the **post-conditions**, not just "no race detected": exactly one redirect hop, `len(MergedFrom) == 1` (16 appends would still be race-free under the mutex — only this assertion catches a missing idempotency guard), the winner never redirected, and the lone seeded progress record surviving on the winner with its original value.

Full required suite:

```
$ go build ./... && go vet ./...
=== BUILD+VET CLEAN ===

$ go test ./internal/merge/ ./internal/dedup/ ./internal/scanner/ ./internal/database/ -race -count=1
ok  	github.com/falkcorp/audiobook-organizer/internal/merge	22.440s
ok  	github.com/falkcorp/audiobook-organizer/internal/dedup	31.580s
ok  	github.com/falkcorp/audiobook-organizer/internal/scanner	29.420s
ok  	github.com/falkcorp/audiobook-organizer/internal/database	272.930s

$ go test ./internal/reconcile/ ./internal/plugins/maintenance/ ./internal/plugins/dedup/ -count=1 -short
ok  	github.com/falkcorp/audiobook-organizer/internal/reconcile	4.603s
ok  	github.com/falkcorp/audiobook-organizer/internal/plugins/maintenance	12.404s
ok  	github.com/falkcorp/audiobook-organizer/internal/plugins/dedup	26.914s
```

`gofmt -l` on every file touched by this PR: clean. (`gofmt -l internal/` reports 204 files repo-wide, all pre-existing and untouched here.)

## Known gap (follow-up, not fixed here)

`sync_file` entries are keyed `(bookID, fileID)` and `RepointSyncFile` cannot move an entry to a *different* book, so per-file `ino` ids are **not** carried across `CombineBooks` (files move to the survivor) or an untagged move. Fixing it needs a primitive in `internal/database/pebble_store_syncfile.go`, which this PR does not own. Impact is limited to an offline client's cached per-file download URLs — progress and bookmarks are unaffected.

## Files

- `internal/merge/sync_follow.go` (new) — `SyncFollower`, `FollowMerge`, `FollowMergeWithStore`, `FollowBookIDChange`, progress-merge policy
- `internal/merge/service.go` — `syncFollower` field, `SetSyncFollower`, `NewService` wiring, hooks in `MergeBooks` + `CombineBooks`
- `internal/dedup/book_dedup.go` — hook before `store.DeleteBook`
- `internal/scanner/scanner.go` — predecessor tracking in both version-link branches + `followSyncIdentityOnVersionLink`
- 4 new test files, 1 changelog fragment. No changes to `store.go`, `pebble_store_syncid.go`, `pebble_store_syncfile.go`, `pebble_store_chapters.go`, `process_file.go`, `syncapi/progress/**`, `internal/server/**`, `go.mod`/`go.sum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
