### PR TITLE
fix(scanner): actually invoke chapter extraction during scans

### DIFF
--- a/changelog.d/20260730_abs_sync_chapter_scan_wiring.md
+++ b/changelog.d/20260730_abs_sync_chapter_scan_wiring.md
@@ -1,0 +1,14 @@
+<!-- file: changelog.d/20260730_abs_sync_chapter_scan_wiring.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c88cec5e-61ce-4ece-b355-87fcbf06bef6 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+- **Chapters are now actually extracted during a scan.** `PersistChaptersForBook`
+  shipped in the previous change but had no call site, so no scan ever populated
+  chapters and item detail would have returned an empty chapter list. Wired into both
+  save paths in `internal/scanner/scanner.go` — the directory-based book path and the
+  per-file path. The second call site sits deliberately *outside* the
+  `SegmentFiles > 1` block so single-file books get their embedded m4b chapter marks
+  too. Failures warn and never abort a scan.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,5 +1,5 @@
 // file: internal/scanner/scanner.go
-// version: 1.50.0
+// version: 1.51.0
 // guid: 3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f
 // last-edited: 2026-07-30
 
@@ -845,6 +845,12 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 					errChan <- fmt.Errorf("failed to save book %s: %w", books[idx].FilePath, err)
 				} else {
 					createBookFilesForBook(dirPath, nil, scanLog)
+					// Chapters must be persisted AFTER the book files exist —
+					// the multi-file synthesis path reads BookFile durations to
+					// build the cumulative timeline. Never fatal to the scan.
+					if err := PersistChaptersForBook(ctx, dirPath, scanLog); err != nil {
+						scanLog.Warn("chapter persistence failed for %s: %v", dirPath, err)
+					}
 				}
 				return // Done with this directory-based book
 			}
@@ -1022,6 +1028,12 @@ func ProcessBooksParallel(ctx context.Context, books []Book, workers int, progre
 				// to avoid re-hashing each segment file (PERF-2b).
 				if len(books[idx].SegmentFiles) > 1 {
 					createBookFilesForBook(books[idx].FilePath, books[idx].SegmentFiles, scanLog, books[idx].SegmentHashes)
+				}
+				// Persist chapters. Deliberately OUTSIDE the SegmentFiles>1 block
+				// so it also runs for genuinely-single-file books, whose embedded
+				// m4b chapter marks are the primary source. Never fatal to the scan.
+				if err := PersistChaptersForBook(ctx, books[idx].FilePath, scanLog); err != nil {
+					scanLog.Warn("chapter persistence failed for %s: %v", books[idx].FilePath, err)
 				}
 				// Update scan cache so next incremental scan skips this file.
 				// Use a deferred recover guard in case GlobalStore is a non-nil interface


### PR DESCRIPTION
PersistChaptersForBook was implemented and tested in the previous change but had
NO call site, so no scan ever populated chapters -- ABS item detail would have
returned an empty chapters array and clients would show no chapter navigation.

Cause: the file-ownership rule for the parallel wave forbade the implementing
agent from editing scanner.go (another agent held it), while its brief required
two call-site insertions there. It correctly flagged this as blocking rather than
editing a file it did not own. scanner.go is now free, so this applies the wiring.

Two call sites, both re-verified against current content rather than line numbers:
- the directory-based book path, immediately after createBookFilesForBook, since
  multi-file chapter synthesis reads BookFile durations to build the cumulative
  timeline and therefore must run after the files exist;
- the per-file path, deliberately OUTSIDE the SegmentFiles > 1 block so it also
  runs for genuinely single-file books, whose embedded m4b chapter marks are the
  primary source.

Failures warn and never abort a scan.

Verified: go build ./... clean, go vet clean, go test ./internal/scanner/ ok
(30.0s), and PersistChaptersForBook now has 2 call sites where it previously had 0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
