### PR TITLE
fix(abs-sync): carry sync_file ino across CombineBooks and untagged-move book-id changes

### DIFF
--- a/changelog.d/20260730_090000_abs-sync-syncfile-crossbook-repoint.md
+++ b/changelog.d/20260730_090000_abs-sync-syncfile-crossbook-repoint.md
@@ -1,0 +1,49 @@
+<!-- file: changelog.d/20260730_090000_abs-sync-syncfile-crossbook-repoint.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c833c7d0-e839-4739-a601-7eab4bdf367d -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+- **Per-file sync `ino` now follows a file across a book-id change (abs-sync,
+  PR #2074 follow-up).** `sync_file` entries are keyed `(bookID, fileID)`, and
+  the existing `RepointSyncFile` could only move an entry's `fileID` within one
+  book — it could not carry an entry to a DIFFERENT book. Two paths move a
+  `BookFile` to a different book without changing the file itself:
+  `CombineBooks` (absorbed books' files are reassigned onto the survivor) and
+  the scanner's untagged-move / hash-duplicate version-link (the book itself
+  gets a new ULID). Neither carried the file's durable `ino` forward, so an
+  offline client's cached download URL (`/api/items/{itemId}/file/{ino}`)
+  could go stale after either operation, requiring a re-download of an
+  already-downloaded book. Item-level identity and progress/bookmarks were
+  unaffected (they key on the item, not the file).
+  - New `database.(*PebbleStore).RepointSyncFileToBook(oldBookID, newBookID,
+    fileID)` (`internal/database/pebble_store_syncfile.go`) moves a sync_file
+    entry across books in a single atomic Pebble batch, preserving the
+    sync-file ID. Idempotent (a re-run after a successful move is a no-op).
+    Collision rule: if the destination book already has its OWN entry for
+    that `fileID` (independently minted), the destination's existing identity
+    wins and the source is left untouched — never silently reassign which
+    syncFileID answers for a (book, file) pair a client may already be
+    resolving against. Guarded by the existing `syncFileMintMu` mutex idiom;
+    covered by a `-race` concurrent-repoint test asserting a single
+    consistent outcome.
+  - New `merge.FollowFileMove(db, oldBookID, newBookID, fileIDs)`
+    (`internal/merge/sync_follow.go`) is wired into `CombineBooks`'s main
+    file-move loop and into `attachVirtualFile`'s cross-book reattach branch
+    (both in `internal/merge/service.go`) — the two places CombineBooks
+    reassigns a `BookFile` row's owning book.
+  - `merge.FollowBookIDChange` (already the hook for the scanner's
+    hash-duplicate version-link path) now also carries every sync_file
+    registered on the superseded book onto the new book id, gated behind the
+    same "old book had a syncID" check as the existing identity/progress
+    carry — a book with no client-visible identity could not have had a
+    client-cached file URL either. No `internal/scanner/scanner.go` changes
+    were needed for this path: it already calls `FollowBookIDChange`.
+  - **Left for a follow-up:** `internal/dedup/book_dedup.go`'s `MergeBooks`
+    hard-delete path (`merge.FollowMergeWithStore` call around line 456) does
+    not move `BookFile` rows across books at all today (files stay attached
+    to whichever book id the dedup engine chose to keep), so no file-ino
+    carry was needed there for this gap. If that ever changes, it will need
+    the same `FollowFileMove` wiring — flagged here rather than edited, since
+    `internal/dedup/book_dedup.go` may have parallel work in flight.

--- a/internal/database/pebble_store_syncfile.go
+++ b/internal/database/pebble_store_syncfile.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_syncfile.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 92ebd115-9f89-4400-ac26-bf9a065b6153
 // last-edited: 2026-07-30
 
@@ -8,6 +8,7 @@ package database
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -47,6 +48,7 @@ type SyncFileStore interface {
 	GetSyncFileID(bookID, fileID string) (string, bool, error)
 	ListSyncFilesForBook(bookID string) ([]SyncFile, error)
 	RepointSyncFile(bookID, oldFileID, newFileID string) error
+	RepointSyncFileToBook(oldBookID, newBookID, fileID string) error
 }
 
 // AsSyncFileStore type-asserts s into a SyncFileStore, returning nil if s is
@@ -251,6 +253,125 @@ func (s *PebbleStore) RepointSyncFile(bookID, oldFileID, newFileID string) error
 		return err
 	}
 	if err := batch.Set(syncFileLookupKey(bookID, newFileID), []byte(syncFileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncFileRecordKey(syncFileID), updatedData, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RepointSyncFileToBook moves a sync_file entry from oldBookID to newBookID
+// for the SAME fileID, preserving the sync-file ID -- the cross-book
+// analogue of RepointSyncFile (which moves the fileID side within one book).
+// This is the primitive that lets a file's `ino` survive the two places a
+// BookFile can change owning books without the file itself changing:
+// CombineBooks (files move onto the surviving book) and an untagged move
+// (the whole book is re-keyed under a new ULID). See
+// docs/specs/2026-07-29-abs-sync-api-design.md and the PR #2074 follow-up
+// gap this closes.
+//
+// Same-book calls (oldBookID == newBookID) are a no-op: there is nothing to
+// move.
+//
+// Idempotent: if no sync_file entry exists for (oldBookID, fileID), this is
+// a no-op returning nil, matching RepointSyncFile's convention. A retried
+// call after a successful move lands here, since the old lookup key is gone.
+//
+// Collision rule: if newBookID already has its OWN sync_file entry for
+// fileID (a syncFileID minted independently under that exact (book, file)
+// pair -- see TestSyncFile_SameFileIDOnDifferentBooks_NoCollision), the
+// destination's existing identity wins and the move is skipped entirely. We
+// never silently reassign which syncFileID answers for (newBookID, fileID):
+// a client may already be resolving downloads against the destination's id,
+// and clobbering it would break a URL that was never stale to begin with.
+// The source entry is left exactly as it is; both wired call sites
+// (CombineBooks, the scanner's version-link path) hard-delete or retire
+// their source book row immediately after, so nothing is left dangling in
+// practice. Logged at Warn either way -- an unusual but not erroneous state.
+func (s *PebbleStore) RepointSyncFileToBook(oldBookID, newBookID, fileID string) error {
+	if oldBookID == "" {
+		return fmt.Errorf("RepointSyncFileToBook: oldBookID must not be empty")
+	}
+	if newBookID == "" {
+		return fmt.Errorf("RepointSyncFileToBook: newBookID must not be empty")
+	}
+	if fileID == "" {
+		return fmt.Errorf("RepointSyncFileToBook: fileID must not be empty")
+	}
+	if oldBookID == newBookID {
+		return nil
+	}
+
+	syncFileMintMu.Lock()
+	defer syncFileMintMu.Unlock()
+
+	oldLookupKey := syncFileLookupKey(oldBookID, fileID)
+	existing, closer, err := s.db.Get(oldLookupKey)
+	if err == pebble.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	syncFileID := string(existing)
+	closer.Close()
+
+	newLookupKey := syncFileLookupKey(newBookID, fileID)
+	destExisting, destCloser, err := s.db.Get(newLookupKey)
+	if err == nil {
+		destID := string(destExisting)
+		destCloser.Close()
+		if destID != syncFileID {
+			slog.Warn("sync_file repoint-to-book: destination already has its own entry for this fileID; keeping destination's identity, source left in place",
+				"old_book", oldBookID, "new_book", newBookID, "file_id", fileID,
+				"source_sync_file_id", syncFileID, "dest_sync_file_id", destID)
+		}
+		// destID == syncFileID would mean the move already landed (a racing
+		// retry); either way there is nothing left to do.
+		return nil
+	}
+	if err != pebble.ErrNotFound {
+		return err
+	}
+
+	recData, recCloser, err := s.db.Get(syncFileRecordKey(syncFileID))
+	if err != nil {
+		return err
+	}
+	var rec SyncFile
+	unmarshalErr := json.Unmarshal(recData, &rec)
+	recCloser.Close()
+	if unmarshalErr != nil {
+		return fmt.Errorf("failed to unmarshal sync_file record %q: %w", syncFileID, unmarshalErr)
+	}
+	rec.BookID = newBookID
+
+	updatedData, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sync_file record: %w", err)
+	}
+
+	batch := s.db.NewBatch()
+	if err := batch.Delete(oldLookupKey, nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Delete(syncFileBookKey(oldBookID, syncFileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(syncFileBookKey(newBookID, syncFileID), []byte(fileID), nil); err != nil {
+		batch.Close()
+		return err
+	}
+	if err := batch.Set(newLookupKey, []byte(syncFileID), nil); err != nil {
 		batch.Close()
 		return err
 	}

--- a/internal/database/pebble_store_syncfile_test.go
+++ b/internal/database/pebble_store_syncfile_test.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_syncfile_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 80186a0c-f2d2-4c17-9ef2-cfb78d441e1f
 // last-edited: 2026-07-30
 
@@ -260,6 +260,266 @@ func TestSyncFile_ConcurrentMintRace_SingleWinner(t *testing.T) {
 	}
 	if len(list) != 1 {
 		t.Fatalf("expected exactly 1 live sync_file record after race, got %d: %+v", len(list), list)
+	}
+}
+
+// --- RepointSyncFileToBook (cross-book move) ---
+//
+// This is the missing primitive from PR #2074's follow-up gap: sync_file
+// entries are keyed (bookID, fileID), and RepointSyncFile can only move an
+// entry's fileID WITHIN one book. CombineBooks (files move to the surviving
+// book) and an untagged move (the book gets a new ULID) both need to carry
+// the file's `ino` ACROSS a book-id change instead.
+
+func TestSyncFile_RepointSyncFileToBook_MovesAcrossBooks(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	original, err := store.MintOrGetSyncFileID("book-A", "file-1")
+	if err != nil {
+		t.Fatalf("mint original: %v", err)
+	}
+
+	if err := store.RepointSyncFileToBook("book-A", "book-B", "file-1"); err != nil {
+		t.Fatalf("repoint to book: %v", err)
+	}
+
+	// Resolves under the new book now, with the SAME syncFileID.
+	viaNew, ok, err := store.GetSyncFileID("book-B", "file-1")
+	if err != nil || !ok {
+		t.Fatalf("get via new book: ok=%v err=%v", ok, err)
+	}
+	if viaNew != original {
+		t.Fatalf("expected repoint to preserve syncFileID %q, got %q", original, viaNew)
+	}
+
+	// The old (bookID, fileID) pair no longer resolves.
+	_, ok, err = store.GetSyncFileID("book-A", "file-1")
+	if err != nil {
+		t.Fatalf("get via old book: %v", err)
+	}
+	if ok {
+		t.Fatal("expected old (bookID, fileID) pair to no longer resolve after repoint")
+	}
+
+	// The record itself must reflect the new BookID.
+	list, err := store.ListSyncFilesForBook("book-B")
+	if err != nil {
+		t.Fatalf("list book-B: %v", err)
+	}
+	found := false
+	for _, sf := range list {
+		if sf.SyncFileID == original {
+			found = true
+			if sf.BookID != "book-B" {
+				t.Fatalf("expected record BookID to be updated to book-B, got %q", sf.BookID)
+			}
+			if sf.CurrentFileID != "file-1" {
+				t.Fatalf("expected CurrentFileID to remain file-1, got %q", sf.CurrentFileID)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected book-B's list to contain the repointed syncFileID %q, got %+v", original, list)
+	}
+
+	listOld, err := store.ListSyncFilesForBook("book-A")
+	if err != nil {
+		t.Fatalf("list book-A: %v", err)
+	}
+	if len(listOld) != 0 {
+		t.Fatalf("expected book-A to own no sync_files after repoint, got %+v", listOld)
+	}
+}
+
+func TestSyncFile_RepointSyncFileToBook_NoOpWhenNothingToRepoint(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	if err := store.RepointSyncFileToBook("book-A", "book-B", "never-registered"); err != nil {
+		t.Fatalf("expected nil error for no-op repoint, got %v", err)
+	}
+
+	list, err := store.ListSyncFilesForBook("book-B")
+	if err != nil {
+		t.Fatalf("list book-B: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected no entries created by a no-op repoint, got %+v", list)
+	}
+}
+
+func TestSyncFile_RepointSyncFileToBook_SameBookIsNoOp(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	original, err := store.MintOrGetSyncFileID("book-A", "file-1")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	if err := store.RepointSyncFileToBook("book-A", "book-A", "file-1"); err != nil {
+		t.Fatalf("expected nil error for same-book repoint, got %v", err)
+	}
+
+	got, ok, err := store.GetSyncFileID("book-A", "file-1")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got != original {
+		t.Fatalf("expected syncFileID unchanged, got %q want %q", got, original)
+	}
+}
+
+func TestSyncFile_RepointSyncFileToBook_IdempotentReRunIsNoOp(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	original, err := store.MintOrGetSyncFileID("book-A", "file-1")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	if err := store.RepointSyncFileToBook("book-A", "book-B", "file-1"); err != nil {
+		t.Fatalf("first repoint: %v", err)
+	}
+	// Re-running must be a no-op, not a duplicate or an error.
+	if err := store.RepointSyncFileToBook("book-A", "book-B", "file-1"); err != nil {
+		t.Fatalf("second (idempotent) repoint: %v", err)
+	}
+
+	got, ok, err := store.GetSyncFileID("book-B", "file-1")
+	if err != nil || !ok {
+		t.Fatalf("get via book-B: ok=%v err=%v", ok, err)
+	}
+	if got != original {
+		t.Fatalf("expected syncFileID unchanged across re-run, got %q want %q", got, original)
+	}
+
+	list, err := store.ListSyncFilesForBook("book-B")
+	if err != nil {
+		t.Fatalf("list book-B: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected exactly 1 entry after idempotent re-run, got %d: %+v", len(list), list)
+	}
+}
+
+// TestSyncFile_RepointSyncFileToBook_CollisionDestinationWins covers the case
+// where the destination book already has its OWN sync_file entry for the same
+// fileID (a different syncFileID, minted independently under that book/file
+// pair -- see TestSyncFile_SameFileIDOnDifferentBooks_NoCollision). Rule: the
+// destination's existing identity wins and the source entry is left exactly
+// as it was. We do not silently reassign which syncFileID answers for
+// (newBookID, fileID) -- a client may already be resolving downloads against
+// the destination's id.
+func TestSyncFile_RepointSyncFileToBook_CollisionDestinationWins(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	sourceID, err := store.MintOrGetSyncFileID("book-A", "shared-file-id")
+	if err != nil {
+		t.Fatalf("mint book-A: %v", err)
+	}
+	destID, err := store.MintOrGetSyncFileID("book-B", "shared-file-id")
+	if err != nil {
+		t.Fatalf("mint book-B: %v", err)
+	}
+	if sourceID == destID {
+		t.Fatalf("test setup invariant broken: expected distinct ids, got same %q", sourceID)
+	}
+
+	if err := store.RepointSyncFileToBook("book-A", "book-B", "shared-file-id"); err != nil {
+		t.Fatalf("expected collision to be handled without error, got %v", err)
+	}
+
+	// Destination keeps its own pre-existing identity, unchanged.
+	gotDest, ok, err := store.GetSyncFileID("book-B", "shared-file-id")
+	if err != nil || !ok {
+		t.Fatalf("get book-B: ok=%v err=%v", ok, err)
+	}
+	if gotDest != destID {
+		t.Fatalf("expected destination's existing syncFileID %q to win, got %q", destID, gotDest)
+	}
+
+	// Source entry is untouched.
+	gotSource, ok, err := store.GetSyncFileID("book-A", "shared-file-id")
+	if err != nil || !ok {
+		t.Fatalf("get book-A: ok=%v err=%v", ok, err)
+	}
+	if gotSource != sourceID {
+		t.Fatalf("expected source's syncFileID %q to remain untouched, got %q", sourceID, gotSource)
+	}
+}
+
+// TestSyncFile_RepointSyncFileToBook_ConcurrentRace_SingleConsistentOutcome is
+// the load-bearing concurrency test: RepointSyncFileToBook's read-then-batch
+// is not atomic on its own (mirrors RepointSyncFile), so many goroutines
+// racing the SAME repoint must still converge on exactly one outcome under
+// syncFileMintMu, never a half-moved or duplicated entry. Run with -race.
+func TestSyncFile_RepointSyncFileToBook_ConcurrentRace_SingleConsistentOutcome(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	original, err := store.MintOrGetSyncFileID("race-book-A", "race-file")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	const workers = 16
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = store.RepointSyncFileToBook("race-book-A", "race-book-B", "race-file")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+	}
+
+	got, ok, err := store.GetSyncFileID("race-book-B", "race-file")
+	if err != nil || !ok {
+		t.Fatalf("get race-book-B: ok=%v err=%v", ok, err)
+	}
+	if got != original {
+		t.Fatalf("expected the single original syncFileID %q to survive, got %q", original, got)
+	}
+
+	listOld, err := store.ListSyncFilesForBook("race-book-A")
+	if err != nil {
+		t.Fatalf("list race-book-A: %v", err)
+	}
+	if len(listOld) != 0 {
+		t.Fatalf("expected race-book-A to own no entries after the race, got %+v", listOld)
+	}
+
+	listNew, err := store.ListSyncFilesForBook("race-book-B")
+	if err != nil {
+		t.Fatalf("list race-book-B: %v", err)
+	}
+	if len(listNew) != 1 {
+		t.Fatalf("expected exactly 1 live entry on race-book-B after the race, got %d: %+v", len(listNew), listNew)
+	}
+}
+
+func TestSyncFile_RepointSyncFileToBook_ValidatesArgs(t *testing.T) {
+	store := newSyncFileTestStore(t)
+
+	cases := []struct {
+		name                         string
+		oldBookID, newBookID, fileID string
+	}{
+		{"empty old book", "", "book-B", "file-1"},
+		{"empty new book", "book-A", "", "file-1"},
+		{"empty file id", "book-A", "book-B", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.RepointSyncFileToBook(tc.oldBookID, tc.newBookID, tc.fileID); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
 	}
 }
 

--- a/internal/merge/service.go
+++ b/internal/merge/service.go
@@ -1,5 +1,5 @@
 // file: internal/merge/service.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: 7d736d2d-e0df-40bd-9f4b-0a07bc2eb6ae
 // last-edited: 2026-07-30
 
@@ -399,6 +399,11 @@ func (ms *Service) CombineBooks(bookIDs []string, primaryID string, override *Co
 			if err := ms.db.MoveBookFilesToBook(ids, id, survivor.ID); err != nil {
 				return nil, fmt.Errorf("move files %s->%s: %w", id, survivor.ID, err)
 			}
+			// Carry each moved file's sync_file identity (ino) onto the
+			// survivor. Still inside mergeSerializeMu and well before the
+			// hard delete below, matching the FollowMerge call's own
+			// placement and rationale.
+			FollowFileMove(ms.db, id, survivor.ID, ids)
 			res.FilesMoved += len(files)
 		} else if book.FilePath != "" {
 			res.FilesMoved += ms.attachVirtualFile(book, survivor.ID)
@@ -507,10 +512,14 @@ func (ms *Service) attachVirtualFile(b *database.Book, targetBookID string) int 
 	existing, _ := ms.db.GetBookFileByPath(b.FilePath)
 	if existing != nil {
 		if existing.BookID != targetBookID {
-			if err := ms.db.MoveBookFilesToBook([]string{existing.ID}, existing.BookID, targetBookID); err != nil {
+			oldOwnerID := existing.BookID
+			if err := ms.db.MoveBookFilesToBook([]string{existing.ID}, oldOwnerID, targetBookID); err != nil {
 				slog.Warn("combine reattach existing file", "path", b.FilePath, "err", err)
 				return 0
 			}
+			// Same file-move shape as the main CombineBooks loop: the row's
+			// owning book id just changed, so its sync_file ino must follow.
+			FollowFileMove(ms.db, oldOwnerID, targetBookID, []string{existing.ID})
 		}
 		return 1
 	}

--- a/internal/merge/sync_follow.go
+++ b/internal/merge/sync_follow.go
@@ -1,5 +1,5 @@
 // file: internal/merge/sync_follow.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 50421381-9def-4b19-bd23-6fa1a03c24d3
 // last-edited: 2026-07-30
 
@@ -16,6 +16,17 @@
 //
 // See docs/specs/2026-07-29-abs-sync-api-design.md §4.2 (model), §4.3 (test
 // bar) and §5.5 (progress on merge).
+//
+// A second, file-scoped identity layer sits alongside the book-level one:
+// each BookFile has a durable sync_file `ino` backing the ABS contentUrl
+// scheme `/api/items/{itemId}/file/{ino}` (internal/database's
+// pebble_store_syncfile.go). PR #2074 wired item-level identity and progress
+// through CombineBooks and the untagged-move path but left per-file `ino`
+// behind, since sync_file entries are keyed (bookID, fileID) and the old
+// RepointSyncFile could only move a fileID within one book, never across
+// books. FollowFileMove (called from CombineBooks) and the file-carry inside
+// FollowBookIDChange (covering the untagged-move path) close that gap using
+// the new database.RepointSyncFileToBook primitive.
 package merge
 
 import (
@@ -105,6 +116,82 @@ func FollowMergeWithStore(db database.Store, winnerBookID string, loserBookIDs [
 	FollowMerge(db, follower, winnerBookID, loserBookIDs)
 }
 
+// FollowFileMove carries each moved file's sync_file identity (its durable
+// `ino`) from oldBookID to newBookID after the caller has physically moved
+// the underlying BookFile row(s) onto a different book -- CombineBooks
+// (MoveBookFilesToBook, and attachVirtualFile's cross-book reattach branch).
+// Call it with the EXACT list of file IDs that were just moved, still inside
+// whatever lock guards the operation's read-modify-write, and BEFORE any
+// hard delete of the source book row -- like FollowMerge, there is no
+// surviving row to repoint afterwards on that path.
+//
+// Best-effort and per-file: one file's repoint failing does not stop the
+// others from being attempted. A store that does not implement
+// SyncFileStore is a silent no-op everywhere else sync_file lives, but
+// CombineBooks hard-deletes its source row, so a skipped follow here is
+// unrecoverable -- logged at Warn once for the whole call, matching
+// FollowMergeWithStore's severity for the same reason. Each individual
+// repoint failure is logged at ERROR with both book IDs and the file ID,
+// because a silent failure here quietly breaks a user's downloaded file with
+// no trace.
+//
+// Idempotent and no-op-safe by construction: RepointSyncFileToBook is
+// idempotent (a re-run finds the source entry already moved) and empty
+// fileIDs entries are skipped.
+func FollowFileMove(db database.Store, oldBookID, newBookID string, fileIDs []string) {
+	if db == nil || oldBookID == "" || newBookID == "" || oldBookID == newBookID || len(fileIDs) == 0 {
+		return
+	}
+	sf := database.AsSyncFileStore(db)
+	if sf == nil {
+		slog.Warn("sync-identity file-follow: store does not implement SyncFileStore; file ino(s) will NOT be carried forward",
+			"old_book", oldBookID, "new_book", newBookID, "file_count", len(fileIDs))
+		return
+	}
+	for _, fileID := range fileIDs {
+		if fileID == "" {
+			continue
+		}
+		if err := sf.RepointSyncFileToBook(oldBookID, newBookID, fileID); err != nil {
+			slog.Error("sync-identity file-follow: repoint FAILED; a cached download URL for this file will go stale",
+				"old_book", oldBookID, "new_book", newBookID, "file_id", fileID, "err", err)
+		}
+	}
+}
+
+// followSyncFilesForBookChange is FollowFileMove's counterpart for
+// FollowBookIDChange's untagged-move path: unlike CombineBooks, the caller
+// there (internal/scanner) does not carry an explicit list of moved file
+// IDs, so this enumerates every sync_file already registered on oldBookID
+// via ListSyncFilesForBook and repoints each by its CurrentFileID. A book's
+// BookFile IDs are stable across the version-link (only the Book ULID
+// changes), so the enumerated fileIDs are exactly the ones that need to
+// move.
+//
+// Debug, not warn, when the store lacks the capability: both rows survive a
+// version-link (this is not a hard-delete path), matching
+// FollowBookIDChange's own severity choice for the identity/progress carry.
+func followSyncFilesForBookChange(db database.Store, oldBookID, newBookID string) {
+	sf := database.AsSyncFileStore(db)
+	if sf == nil {
+		slog.Debug("sync-identity follow: store does not implement SyncFileStore; skipping file ino carry-forward",
+			"old_book", oldBookID, "new_book", newBookID)
+		return
+	}
+	files, err := sf.ListSyncFilesForBook(oldBookID)
+	if err != nil {
+		slog.Error("sync-identity follow: could not list old book's sync_files; file ino(s) NOT carried forward",
+			"old_book", oldBookID, "new_book", newBookID, "err", err)
+		return
+	}
+	for _, f := range files {
+		if err := sf.RepointSyncFileToBook(oldBookID, newBookID, f.CurrentFileID); err != nil {
+			slog.Error("sync-identity follow: file repoint FAILED; a cached download URL for this file will go stale",
+				"old_book", oldBookID, "new_book", newBookID, "file_id", f.CurrentFileID, "sync_file_id", f.SyncFileID, "err", err)
+		}
+	}
+}
+
 // FollowBookIDChange carries a book's sync identity and per-user progress from
 // oldBookID to newBookID when a Book ULID is REPLACED rather than merged --
 // the untagged-move case, where a moved file is re-scanned, matched to its
@@ -151,6 +238,13 @@ func FollowBookIDChange(db database.Store, oldBookID, newBookID string) {
 			"sync_id", syncID, "old_book", oldBookID, "new_book", newBookID, "err", err)
 		return
 	}
+
+	// Carry each registered file's ino forward too. Independent of progress
+	// below (a file-repoint failure must not block a progress carry or vice
+	// versa), so this runs unconditionally once identity itself is repointed
+	// rather than being gated behind the progress-merge outcome.
+	followSyncFilesForBookChange(db, oldBookID, newBookID)
+
 	// The identity now resolves to newBookID, so progress keyed to oldBookID
 	// would look lost to a client. It is still on disk under the old id (this
 	// only fails forward, never destroys), but it must be logged loudly.

--- a/internal/merge/sync_follow_syncfile_test.go
+++ b/internal/merge/sync_follow_syncfile_test.go
@@ -1,0 +1,312 @@
+// file: internal/merge/sync_follow_syncfile_test.go
+// version: 1.0.0
+// guid: d74cf944-f953-4a7e-83eb-994193dbc7d1
+// last-edited: 2026-07-30
+
+package merge
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	ulid "github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// This file covers the PR #2074 follow-up gap: sync_file entries (the
+// per-file `ino` backing /api/items/{itemId}/file/{ino}) are keyed
+// (bookID, fileID) and did not follow CombineBooks or an untagged move, only
+// item-level identity and progress did. FollowFileMove and the file-carry
+// added to FollowBookIDChange close that gap.
+
+// --- FollowFileMove (direct unit tests) ---
+
+func TestFollowFileMove_RepointsEachFile(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf, "PebbleStore must implement SyncFileStore")
+
+	oldBookID := ulid.Make().String()
+	newBookID := ulid.Make().String()
+
+	idA, err := sf.MintOrGetSyncFileID(oldBookID, "file-a")
+	require.NoError(t, err)
+	idB, err := sf.MintOrGetSyncFileID(oldBookID, "file-b")
+	require.NoError(t, err)
+
+	FollowFileMove(store, oldBookID, newBookID, []string{"file-a", "file-b"})
+
+	gotA, ok, err := sf.GetSyncFileID(newBookID, "file-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, idA, gotA)
+
+	gotB, ok, err := sf.GetSyncFileID(newBookID, "file-b")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, idB, gotB)
+
+	_, ok, err = sf.GetSyncFileID(oldBookID, "file-a")
+	require.NoError(t, err)
+	require.False(t, ok, "old book must no longer resolve file-a")
+	_, ok, err = sf.GetSyncFileID(oldBookID, "file-b")
+	require.NoError(t, err)
+	require.False(t, ok, "old book must no longer resolve file-b")
+}
+
+// TestFollowFileMove_GuardsNilAndEmptyArgs exercises every early-return guard
+// -- none of these should panic, error, or mutate anything.
+func TestFollowFileMove_GuardsNilAndEmptyArgs(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+
+	bookID := ulid.Make().String()
+	otherBookID := ulid.Make().String()
+	originalID, err := sf.MintOrGetSyncFileID(bookID, "file-1")
+	require.NoError(t, err)
+
+	// nil store.
+	require.NotPanics(t, func() { FollowFileMove(nil, bookID, otherBookID, []string{"file-1"}) })
+	// empty old/new book ids.
+	FollowFileMove(store, "", otherBookID, []string{"file-1"})
+	FollowFileMove(store, bookID, "", []string{"file-1"})
+	// same book id -- nothing to move.
+	FollowFileMove(store, bookID, bookID, []string{"file-1"})
+	// empty file id list.
+	FollowFileMove(store, bookID, otherBookID, nil)
+
+	got, ok, err := sf.GetSyncFileID(bookID, "file-1")
+	require.NoError(t, err)
+	require.True(t, ok, "no guard-triggering call may have moved the entry")
+	require.Equal(t, originalID, got)
+}
+
+// TestFollowFileMove_SkipsEmptyFileIDsInSlice covers a defensive case: an
+// empty string sneaking into the fileIDs slice must be skipped, not passed
+// through to the store primitive (which would error on an empty fileID).
+func TestFollowFileMove_SkipsEmptyFileIDsInSlice(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+
+	oldBookID := ulid.Make().String()
+	newBookID := ulid.Make().String()
+	id, err := sf.MintOrGetSyncFileID(oldBookID, "file-1")
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		FollowFileMove(store, oldBookID, newBookID, []string{"", "file-1", ""})
+	})
+
+	got, ok, err := sf.GetSyncFileID(newBookID, "file-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, id, got)
+}
+
+// --- CombineBooks integration: files move to the surviving book ---
+
+// TestCombineBooks_SyncIdentity_FileInoCarriesToSurvivor covers the main
+// CombineBooks shape: real BookFile rows moved via MoveBookFilesToBook.
+// Every file's sync_file `ino` must resolve under the survivor afterward,
+// preserving the SAME syncFileID an offline client may have cached.
+func TestCombineBooks_SyncIdentity_FileInoCarriesToSurvivor(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/sf-survivor.mp3"}
+	shell := &database.Book{ID: ulid.Make().String(), Title: "Shell", Format: "mp3", FilePath: "/tmp/sf-shell.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(shell)
+	require.NoError(t, err)
+
+	shellFile := &database.BookFile{ID: ulid.Make().String(), BookID: shell.ID, FilePath: shell.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(shellFile))
+
+	shellSyncFileID, err := sf.MintOrGetSyncFileID(shell.ID, shellFile.ID)
+	require.NoError(t, err)
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, shell.ID}, survivor.ID, nil)
+	require.NoError(t, err)
+
+	gotID, ok, err := sf.GetSyncFileID(survivor.ID, shellFile.ID)
+	require.NoError(t, err)
+	require.True(t, ok, "the file's sync_file entry must resolve under the survivor")
+	require.Equal(t, shellSyncFileID, gotID, "the ino must be preserved across the combine, not re-minted")
+
+	_, ok, err = sf.GetSyncFileID(shell.ID, shellFile.ID)
+	require.NoError(t, err)
+	require.False(t, ok, "the absorbed shell's book id must no longer resolve the file")
+}
+
+// TestCombineBooks_SyncIdentity_NoSyncFileEntry_IsHarmlessNoOp covers the
+// common case where the file was never synced to a client: CombineBooks must
+// succeed exactly as before, and no sync_file entry is fabricated.
+func TestCombineBooks_SyncIdentity_NoSyncFileEntry_IsHarmlessNoOp(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+
+	survivor := &database.Book{ID: ulid.Make().String(), Title: "Survivor", Format: "mp3", FilePath: "/tmp/sf-survivor2.mp3"}
+	shell := &database.Book{ID: ulid.Make().String(), Title: "Shell", Format: "mp3", FilePath: "/tmp/sf-shell2.mp3"}
+	_, err := store.CreateBook(survivor)
+	require.NoError(t, err)
+	_, err = store.CreateBook(shell)
+	require.NoError(t, err)
+
+	shellFile := &database.BookFile{ID: ulid.Make().String(), BookID: shell.ID, FilePath: shell.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(shellFile))
+
+	ms := NewService(store)
+	_, err = ms.CombineBooks([]string{survivor.ID, shell.ID}, survivor.ID, nil)
+	require.NoError(t, err)
+
+	_, ok, err := sf.GetSyncFileID(survivor.ID, shellFile.ID)
+	require.NoError(t, err)
+	require.False(t, ok, "no sync_file entry should be fabricated for a file that was never synced")
+}
+
+// TestB3_AttachVirtualFile_ReattachExistingOwnedByOtherBook_CarriesFileIno
+// extends TestB3_AttachVirtualFile_ReattachExistingOwnedByOtherBook
+// (service_b3_realstore_test.go): attachVirtualFile's cross-book reattach
+// branch is also a file moving onto a different book id and must carry the
+// file's ino the same way the main CombineBooks loop does.
+func TestB3_AttachVirtualFile_ReattachExistingOwnedByOtherBook_CarriesFileIno(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+	ms := NewService(store)
+
+	strayOwner := &database.Book{ID: ulid.Make().String(), Title: "Stray owner", FilePath: "/tmp/sf-stray-owner.mp3"}
+	target := &database.Book{ID: ulid.Make().String(), Title: "Target", FilePath: "/tmp/sf-stray-shared.mp3"}
+	_, err := store.CreateBook(strayOwner)
+	require.NoError(t, err)
+	_, err = store.CreateBook(target)
+	require.NoError(t, err)
+
+	strayFile := &database.BookFile{ID: ulid.Make().String(), BookID: strayOwner.ID, FilePath: target.FilePath, Format: "mp3"}
+	require.NoError(t, store.CreateBookFile(strayFile))
+
+	strayID, err := sf.MintOrGetSyncFileID(strayOwner.ID, strayFile.ID)
+	require.NoError(t, err)
+
+	n := ms.attachVirtualFile(target, target.ID)
+	require.Equal(t, 1, n)
+
+	gotID, ok, err := sf.GetSyncFileID(target.ID, strayFile.ID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, strayID, gotID, "the ino must be preserved when the stray row is reattached")
+}
+
+// --- FollowBookIDChange (untagged move) ---
+
+// TestFollowBookIDChange_SyncFile_CarriesInoToNewBook covers the scanner's
+// hash-duplicate version-link path (internal/scanner's
+// followSyncIdentityOnVersionLink), which calls FollowBookIDChange directly.
+// Every sync_file registered on the superseded book must resolve under the
+// new book id afterward, alongside the identity/progress carry already
+// covered elsewhere.
+func TestFollowBookIDChange_SyncFile_CarriesInoToNewBook(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, ids)
+	require.NotNil(t, sf)
+
+	oldBook := &database.Book{ID: ulid.Make().String(), Title: "Old", Format: "mp3", FilePath: "/tmp/sf-old.mp3"}
+	newBook := &database.Book{ID: ulid.Make().String(), Title: "New", Format: "mp3", FilePath: "/tmp/sf-new.mp3"}
+	_, err := store.CreateBook(oldBook)
+	require.NoError(t, err)
+	_, err = store.CreateBook(newBook)
+	require.NoError(t, err)
+
+	// The old book must have a client-visible identity, or there is nothing
+	// a client could have cached a file URL against in the first place.
+	_, err = ids.MintOrGetSyncID(oldBook.ID)
+	require.NoError(t, err)
+
+	fileA, err := sf.MintOrGetSyncFileID(oldBook.ID, "file-a")
+	require.NoError(t, err)
+	fileB, err := sf.MintOrGetSyncFileID(oldBook.ID, "file-b")
+	require.NoError(t, err)
+
+	FollowBookIDChange(store, oldBook.ID, newBook.ID)
+
+	gotA, ok, err := sf.GetSyncFileID(newBook.ID, "file-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, fileA, gotA)
+
+	gotB, ok, err := sf.GetSyncFileID(newBook.ID, "file-b")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, fileB, gotB)
+
+	list, err := sf.ListSyncFilesForBook(oldBook.ID)
+	require.NoError(t, err)
+	require.Empty(t, list, "old book must own no sync_file entries after the follow")
+}
+
+// TestFollowBookIDChange_SyncFile_NoIdentity_FilesNotTouched documents the
+// gating decision: a book that never had a syncID minted could not have had
+// a client-cached download URL either (itemId in the contentUrl IS the
+// syncID), so FollowBookIDChange's existing early-return on "no syncID" is
+// correct for sync_file too -- there is deliberately no separate gate here.
+func TestFollowBookIDChange_SyncFile_NoIdentity_FilesNotTouched(t *testing.T) {
+	store := setupTestStore(t)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, sf)
+
+	oldBook := &database.Book{ID: ulid.Make().String(), Title: "Old", Format: "mp3", FilePath: "/tmp/sf-old2.mp3"}
+	newBook := &database.Book{ID: ulid.Make().String(), Title: "New", Format: "mp3", FilePath: "/tmp/sf-new2.mp3"}
+	_, err := store.CreateBook(oldBook)
+	require.NoError(t, err)
+	_, err = store.CreateBook(newBook)
+	require.NoError(t, err)
+
+	FollowBookIDChange(store, oldBook.ID, newBook.ID)
+
+	list, err := sf.ListSyncFilesForBook(newBook.ID)
+	require.NoError(t, err)
+	require.Empty(t, list)
+}
+
+// TestFollowBookIDChange_SyncFile_IdempotentReRun mirrors the package's
+// existing idempotency guarantee for identity/progress: a second call finds
+// no syncID on oldBookID (already repointed) and is a complete no-op,
+// including for sync_file entries.
+func TestFollowBookIDChange_SyncFile_IdempotentReRun(t *testing.T) {
+	store := setupTestStore(t)
+	ids := database.AsSyncIdentityStore(store)
+	sf := database.AsSyncFileStore(store)
+	require.NotNil(t, ids)
+	require.NotNil(t, sf)
+
+	oldBook := &database.Book{ID: ulid.Make().String(), Title: "Old", Format: "mp3", FilePath: "/tmp/sf-old3.mp3"}
+	newBook := &database.Book{ID: ulid.Make().String(), Title: "New", Format: "mp3", FilePath: "/tmp/sf-new3.mp3"}
+	_, err := store.CreateBook(oldBook)
+	require.NoError(t, err)
+	_, err = store.CreateBook(newBook)
+	require.NoError(t, err)
+	_, err = ids.MintOrGetSyncID(oldBook.ID)
+	require.NoError(t, err)
+	fileID, err := sf.MintOrGetSyncFileID(oldBook.ID, "file-1")
+	require.NoError(t, err)
+
+	FollowBookIDChange(store, oldBook.ID, newBook.ID)
+	FollowBookIDChange(store, oldBook.ID, newBook.ID) // must be a pure no-op
+
+	got, ok, err := sf.GetSyncFileID(newBook.ID, "file-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, fileID, got)
+
+	list, err := sf.ListSyncFilesForBook(newBook.ID)
+	require.NoError(t, err)
+	require.Len(t, list, 1, "re-running must not duplicate the entry")
+}


### PR DESCRIPTION
## Summary

Closes the PR #2074 follow-up gap: `sync_file` entries (the per-file `ino`
backing `/api/items/{itemId}/file/{ino}`) are keyed `(bookID, fileID)`, and
the existing `RepointSyncFile` could only move an entry's `fileID` **within**
one book -- it could not carry an entry to a **different** book. Two paths
move a `BookFile` to a different book without changing the file itself:

- **`CombineBooks`** -- absorbed books' files are reassigned onto the survivor.
- **The scanner's untagged-move / hash-duplicate version-link** -- the book
  itself gets a new ULID.

Neither carried the file's durable `ino` forward, so an offline client's
cached download URL could go stale after either operation, requiring a
re-download of an already-downloaded book. Item-level identity and
progress/bookmarks are unaffected (they key on the item, not the file).

## Changes

- New `database.(*PebbleStore).RepointSyncFileToBook(oldBookID, newBookID,
  fileID)` in `internal/database/pebble_store_syncfile.go`: moves a
  `sync_file` entry across books in a **single atomic Pebble batch**,
  preserving the sync-file ID.
  - **Idempotent**: a re-run after a successful move is a no-op (the old
    lookup key is gone).
  - **Collision rule**: if the destination book already has its **own**
    entry for that `fileID` (independently minted), the destination's
    existing identity wins and the source is left untouched -- never
    silently reassign which syncFileID answers for a `(book, file)` pair a
    client may already be resolving against.
  - Guarded by the existing `syncFileMintMu` mutex idiom; covered by a
    `-race` concurrent-repoint test asserting a single consistent outcome.
- New `merge.FollowFileMove(db, oldBookID, newBookID, fileIDs)` in
  `internal/merge/sync_follow.go`, wired into two call sites in
  `internal/merge/service.go`:
  - `CombineBooks`'s main file-move loop (right after `MoveBookFilesToBook`).
  - `attachVirtualFile`'s cross-book reattach branch (the "#1549 reattach-safe"
    path, already covered by an existing test that this PR extends).
- `merge.FollowBookIDChange` (already the hook for the scanner's
  hash-duplicate version-link path) now also carries every `sync_file`
  registered on the superseded book onto the new book id, gated behind the
  same "old book had a syncID" check as the existing identity/progress carry.
  **No `internal/scanner/scanner.go` changes were needed** -- it already
  calls `FollowBookIDChange`.

## Left for a follow-up

`internal/dedup/book_dedup.go`'s `MergeBooks` (hard-delete path, the
`merge.FollowMergeWithStore` call around line 456) does **not** move
`BookFile` rows across books today -- files stay attached to whichever book
id the dedup engine chose to keep -- so no file-ino carry was needed there
for this gap. Flagged rather than edited, per the task brief, since that
file may have parallel work in flight; documented in the changelog fragment
so it's visible if that assumption ever changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on all touched files (clean)
- [x] `go test ./internal/database/ -run 'TestSyncFile' -race -count=1 -v` (all pass, including the new `RepointSyncFileToBook` cases: cross-book move, no-op, same-book no-op, idempotent re-run, collision, concurrent race, arg validation)
- [x] `go test ./internal/merge/ -race -count=1` (full package, ~23s, all pass including the new `FollowFileMove` / `CombineBooks` / `attachVirtualFile` / `FollowBookIDChange` sync_file tests)
- [x] `go test ./internal/database/ -race -count=1` (full package, ~305s, `ok`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt