### PR TITLE
feat(abs-sync): sync-ID + iTunes position backfill jobs (ABS-SYNC-ID-4)

### DIFF
--- a/changelog.d/20260730_abs_sync_backfills.md
+++ b/changelog.d/20260730_abs_sync_backfills.md
@@ -1,0 +1,96 @@
+<!-- file: changelog.d/20260730_abs_sync_backfills.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4e08af99-a4da-425d-a8f3-0e1b3f58d550 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+#### `backfill-sync-ids` — idempotent ABS identity backfill for the whole library
+
+New maintenance job that mints a `sync_item` syncID for every Book and a `sync_file`
+syncFileID for every BookFile that does not have one yet, in a single pass. Both
+keyspaces already mint on first encounter at request time, so this is not required for
+correctness — it exists so the entire library is identity-consistent *before* any
+Audiobookshelf-compatible client connects: no first-request latency spike, and no window
+where half the library has stable IDs and half does not.
+
+Idempotent by construction rather than by checkpoint. `MintOrGetSyncID` and
+`MintOrGetSyncFileID` are each independently idempotent, so re-running the job from book 0
+after an interruption is both correct and cheap (an already-minted book or file is a single
+point-get skip). `CanResume()` therefore returns `false` on purpose — there is no index
+worth persisting, unlike `backfill_file_hashes.go`'s `resumeIndex` — and a regression test
+snapshots every minted ID after run 1 and asserts run 2 produces a byte-identical set.
+
+The per-book work runs through `registry.RunItems` with `Concurrency: runtime.NumCPU()`.
+A bare `for range books` loop of exactly this shape is what took a `dedup.full-scan` run
+silent for 3+ hours at 100% CPU on a single core on 2026-07-05, and
+`RunItemsOptions.Concurrency` treats both 0 and 1 as sequential — so the value is a named
+function a test asserts is `> 1`, guarding against a future edit silently reverting to the
+default. Book IDs come from `ListBookIDs()`, never a paginated `GetAllBooksFrom` walk,
+whose memdb fast path silently caps a page at 2× the requested limit and can therefore
+miss books. `ErrMode: ErrModeCollect` keeps a handful of unreadable books from cancelling
+the remaining tens of thousands.
+
+#### `backfill-itunes-positions` — carry existing Apple Books listening positions across
+
+New maintenance job that migrates each book's saved `Book.ITunesBookmark` into the
+per-user progress store (`UserPosition` + `UserBookState`), so moving off iTunes/Apple
+Books does not start from a blank slate. `ITunesBookmark` is **milliseconds** and a single
+scalar per book representing the *farthest position read* — a whole-book resume offset,
+not a per-track value and not a bookmark collection — so it is converted to float seconds
+and placed on the cumulative timeline.
+
+**Every write is routed through `progress.MergeIncoming`, never written bare.** That is
+what makes §5's forward-only rule apply: a user who has already listened further on a real
+device can never be rewound by stale iTunes data, while an iTunes position that *is*
+further along still advances. Two extra safeguards back that up. The incoming timestamp is
+derived from real data (`ITunesLastPlayed`, then `ITunesDateAdded`, then the book's own row
+timestamps) and never `time.Now()` — a fresh stamp would win the newer-wins branch
+outright and overwrite a device's newer position, and would also beat AudioBooth's own
+truncated-seconds comparison client-side. It is then clamped to the server's existing
+stamp, so when a stored record exists the merge can only ever accept via the forward-only
+branch. The server-side position fed to the merge is `max(PositionSeconds)` across all
+existing segment rows rather than the most recent one, because legacy rows are opaque
+per-device segments that are not directly comparable to a whole-book scalar.
+
+`isFinished` is derived with §5b's ≥2 s tolerance via `IsWithinFinishedTolerance`, against
+**one** authoritative duration per book — the sum of track durations, the timeline clients
+actually seek within, falling back to `Book.Duration`. The same book legitimately reports
+three different durations (container `9975.480544`, last-chapter-end `9975.428000`,
+track-sum `9975.431111` on the measured Odyssey fixture), and with a tight epsilon a fully
+listened book never auto-marks finished and sits at 99% forever. `progress` is derived as a
+0.0–1.0 fraction — exported as `ITunesPositionProgressFraction` so the future DTO layer
+cannot re-derive it as a percentage — and an unfinished book is never rendered as 100%.
+`lastUpdate` is stored as an exact integer ms epoch on `UserBookState.LastActivityAt`
+(`UserPosition.UpdatedAt` cannot serve that role: the store stamps it `time.Now()`
+unconditionally); an absent `updatedAt` would make the server permanently lose every
+conflict, since clients compare it against their own wall clock.
+
+A nil or non-positive bookmark is **skipped, never zeroed** — a spurious 0 reads as "start
+over" to a client and would fabricate progress the user never had. A manual status override
+(`StatusManual`) is preserved, and `TotalListenedSeconds` is left untouched, since a
+position is not an amount of audio listened. Re-running is a true no-op when nothing
+changed, and a state row that drifted from its stored position is repaired without the
+position ever being touched, so a run interrupted between the two writes self-heals.
+Per-book failures log the book ID and continue; the job reports exact
+migrated / skipped / failed / no-duration counts rather than "done".
+
+As a courtesy, one named bookmark (`Imported from Apple Books`) is dropped at the migrated
+offset so the position is visible and jumpable, not just an invisible resume point. Exactly
+one, and only on an accepted migration — the ABS named-bookmark keyspace is an independent
+system clients populate themselves, and there is nothing in a single resume scalar to
+synthesize a bookmark list from. It is best-effort: a bookmark-store failure is logged and
+the book still counts as migrated, because the resume position is the requirement.
+
+Which user the positions belong to is a genuinely ambiguous mapping — iTunes has no user
+concept — so it is resolved explicitly and never guessed silently:
+`ABS_ITUNES_POSITION_BACKFILL_USER_ID` if set (an ID matching no user is a hard error, not
+a silent fallback), otherwise the only user, otherwise the earliest-created account with a
+`WARN` naming the choice and the override.
+
+**This job is invoke-only and must not be run before the ABS media-progress provider is
+wired.** Maintenance jobs run solely via `POST /maintenance/jobs/:job_id` and there is no
+cron path to this one, which is deliberate: AudioBooth's `MediaProgress.syncFromAPI`
+*deletes* any local progress row absent from `/api/me`'s `mediaProgress` list, and that
+provider is still nil. Real progress records existing server-side while `/api/me` reports
+an empty list would make a connecting client destroy its own local progress.

--- a/internal/maintenance/jobs/abs_backfill_reporter.go
+++ b/internal/maintenance/jobs/abs_backfill_reporter.go
@@ -1,0 +1,91 @@
+// file: internal/maintenance/jobs/abs_backfill_reporter.go
+// version: 1.0.0
+// guid: c17b031b-c063-4d55-bdf7-7e01c4fe0969
+// last-edited: 2026-07-30
+
+package jobs
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// BackfillConcurrency is the worker-pool size every ABS-sync backfill job in
+// this package passes to registry.RunItems.
+//
+// It is a function, not a bare const, for two reasons: the value depends on the
+// host (runtime.NumCPU()), and a test needs to read it to assert it is > 1.
+// RunItemsOptions.Concurrency treats 0 AND 1 as "sequential", and a sequential
+// loop over tens of thousands of books doing per-item Pebble writes is the
+// exact shape that stalled a dedup.full-scan run for 3+ hours at 100% CPU on a
+// single core on 2026-07-05 (see CLAUDE.md's concurrency rule and
+// docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md). The work
+// here is local Pebble I/O — CPU/disk-bound, not network-bound — so NumCPU
+// sizing applies rather than a small fixed network-politeness limit.
+func BackfillConcurrency() int {
+	if n := runtime.NumCPU(); n > 1 {
+		return n
+	}
+	// A single-CPU host still gets 2 workers: the per-item cost is dominated by
+	// Pebble commit latency, not CPU, so one in-flight write per core would
+	// leave the store idle between batches — and returning 1 here would make
+	// RunItems silently sequential.
+	return 2
+}
+
+// absBackfillReporter bridges maintenance.ProgressReporter (the 3-method
+// interface a MaintenanceJob's Run receives) to registry.Reporter (the
+// 7-method interface registry.RunItems needs to drive its worker pool).
+//
+// This mirrors internal/server/embedding_backfill.go's embeddingBackfillReporter
+// and exists for the same reason its comment gives: a plain maintenance job,
+// like that background goroutine, has no registry.Reporter already in scope.
+// Most methods are deliberately thin or no-op — the maintenance side has no
+// equivalent concept for checkpoints, phases, or event triggers.
+//
+// The name is task-unique on purpose: several agents add helpers to this
+// package in parallel, and a generically-named shared helper is a known
+// post-merge collision source in this repo.
+type absBackfillReporter struct {
+	ctx   context.Context
+	inner maintenance.ProgressReporter
+}
+
+var _ registry.Reporter = (*absBackfillReporter)(nil)
+
+// UpdateProgress ignores current/total: maintenance.ProgressReporter counts
+// completions itself via SetTotal + Increment, and RunItems already calls this
+// exactly once per completed item (monotonically, even in parallel mode).
+func (r *absBackfillReporter) UpdateProgress(_, _ int, _ string) error {
+	r.inner.Increment()
+	return nil
+}
+
+func (r *absBackfillReporter) Log(level slog.Level, message string, attrs ...slog.Attr) error {
+	slog.Default().LogAttrs(context.Background(), level, message, attrs...)
+	return nil
+}
+
+func (r *absBackfillReporter) Logger() *slog.Logger { return slog.Default() }
+
+// Checkpoint is a no-op: these backfills are idempotent per item, so
+// re-running from the start after an interruption is the resume story and
+// there is no index worth persisting.
+func (r *absBackfillReporter) Checkpoint(_ any) error { return nil }
+
+func (r *absBackfillReporter) IsCanceled() bool { return r.ctx != nil && r.ctx.Err() != nil }
+
+func (r *absBackfillReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, r)
+}
+
+func (r *absBackfillReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }
+
+// SetCurrentItem is dropped: the ephemeral "currently working on" label fans
+// out via the operations SSE stream, which a maintenance.ProgressReporter has
+// no channel for.
+func (r *absBackfillReporter) SetCurrentItem(_ string) {}

--- a/internal/maintenance/jobs/backfill_itunes_positions.go
+++ b/internal/maintenance/jobs/backfill_itunes_positions.go
@@ -1,0 +1,594 @@
+// file: internal/maintenance/jobs/backfill_itunes_positions.go
+// version: 1.0.0
+// guid: 19a97553-68fc-4ef6-a326-cc9e694d8698
+// last-edited: 2026-07-30
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+func init() { maintenance.Register(&backfillITunesPositionsJob{}) }
+
+// ITunesPositionWholeBookSegmentID is the UserPosition.SegmentID the migrated
+// iTunes/Apple Books position is written under.
+//
+// ABS progress is a single whole-book scalar (`currentTime` in seconds), not a
+// per-track value, and Book.ITunesBookmark is likewise one scalar per book —
+// there is no track to attribute it to. A dedicated, well-known segment ID
+// keeps the migrated row distinguishable from the opaque per-device segment IDs
+// legacy playback code writes (see internal/merge/sync_follow.go, which treats
+// segment IDs as opaque per-user bookkeeping), which is what makes a re-run's
+// "did I already write this?" check exact rather than a guess.
+const ITunesPositionWholeBookSegmentID = "abs-whole-book"
+
+// ITunesPositionBackfillUserIDEnv names the environment variable that pins
+// which user the migrated positions belong to.
+//
+// This knob is an env var rather than a job parameter because
+// maintenance.MaintenanceJob.Run only receives dryRun — the dispatcher
+// (internal/server/maintenance_dispatcher.go) decodes nothing else from the
+// request body, so DefaultParams is display-only for the UI.
+const ITunesPositionBackfillUserIDEnv = "ABS_ITUNES_POSITION_BACKFILL_USER_ID"
+
+// ITunesPositionBookmarkTitle is the title of the ONE named bookmark this job
+// drops at the migrated position, so the owner can see and jump back to where
+// Apple Books left them rather than only inheriting an invisible resume point.
+//
+// Exactly one, and only at the migrated offset. Book.ITunesBookmark is a single
+// scalar resume position — the farthest point read — not a bookmark collection,
+// so there is nothing to synthesize a list from. The ABS named-bookmark feature
+// (internal/database/pebble_store_bookmarks.go, whose own doc comment makes the
+// same distinction) is an independent system that clients populate themselves;
+// this job must not backfill that keyspace beyond this single courtesy marker.
+const ITunesPositionBookmarkTitle = "Imported from Apple Books"
+
+// ITunesPositionProgressFraction returns the ABS `progress` value: a fraction
+// in [0.0, 1.0], NEVER a 0-100 percentage.
+//
+// It is exported because the Phase-6 ABS mediaProgress DTO needs exactly this
+// computation and must not re-derive it differently — a percentage leaking into
+// `progress` reads as 5000% complete on a client, and an unclamped value >1.0
+// is rejected outright by AudioBooth's strict decoder. A non-positive or
+// non-finite duration yields 0.0: the fraction is genuinely unknown then, and
+// guessing is what trips §1.8.7's null-duration trap.
+func ITunesPositionProgressFraction(currentTimeSec, durationSec float64) float64 {
+	if durationSec <= 0 || math.IsNaN(durationSec) || math.IsInf(durationSec, 0) {
+		return 0
+	}
+	if math.IsNaN(currentTimeSec) || currentTimeSec <= 0 {
+		return 0
+	}
+	f := currentTimeSec / durationSec
+	if f > 1 {
+		return 1
+	}
+	return f
+}
+
+// ResolveITunesPositionBackfillUser decides which user owns the migrated
+// positions.
+//
+// The progress store is user-keyed but an iTunes bookmark is not: iTunes/Apple
+// Books is a single-person library with no user concept at all, so the mapping
+// is genuinely ambiguous the moment more than one user exists. Rather than
+// guess silently, the resolution order is:
+//
+//  1. ABS_ITUNES_POSITION_BACKFILL_USER_ID, if set — and an ID that matches no
+//     user is a hard error, not a silent fallback. Migrating a whole library's
+//     positions onto the wrong account because of a typo is worse than not
+//     running.
+//  2. Exactly one user in the store — unambiguous, no warning needed.
+//  3. Otherwise the earliest-created user (ties broken by ID so the choice is
+//     stable across runs), with a WARN naming the chosen user and the override.
+//     "Earliest created" is the owner's own account in practice: it is the
+//     account the bootstrap flow creates before any other.
+func ResolveITunesPositionBackfillUser(store database.Store) (string, error) {
+	users, err := store.ListUsers()
+	if err != nil {
+		return "", fmt.Errorf("list users: %w", err)
+	}
+	if len(users) == 0 {
+		return "", fmt.Errorf("no users exist — there is no account to migrate iTunes positions onto")
+	}
+
+	if override := strings.TrimSpace(os.Getenv(ITunesPositionBackfillUserIDEnv)); override != "" {
+		for _, u := range users {
+			if u.ID == override {
+				return u.ID, nil
+			}
+		}
+		return "", fmt.Errorf("%s=%q matches no existing user", ITunesPositionBackfillUserIDEnv, override)
+	}
+
+	if len(users) == 1 {
+		return users[0].ID, nil
+	}
+
+	sorted := make([]database.User, len(users))
+	copy(sorted, users)
+	sort.Slice(sorted, func(i, j int) bool {
+		if !sorted[i].CreatedAt.Equal(sorted[j].CreatedAt) {
+			return sorted[i].CreatedAt.Before(sorted[j].CreatedAt)
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+	chosen := sorted[0]
+	slog.Warn("backfill-itunes-positions: more than one user exists and iTunes bookmarks carry no user identity — "+
+		"defaulting to the earliest-created account",
+		"chosen_user", chosen.ID, "chosen_username", chosen.Username,
+		"users", len(users), "override_with", ITunesPositionBackfillUserIDEnv)
+	return chosen.ID, nil
+}
+
+// backfillITunesPositionsJob migrates Book.ITunesBookmark into the per-user
+// progress store so the owner's existing listening positions survive the move
+// off iTunes/Apple Books. Starting from a blank slate is an explicit non-goal.
+//
+// ⚠️ DOWNSTREAM DEPENDENCY — do not run this before the ABS media-progress
+// provider is wired. §1.8.1: AudioBooth's MediaProgress.syncFromAPI DELETES any
+// local progress row whose bookID is absent from /api/me's mediaProgress list.
+// That provider is still nil (internal/server/wire_abs_routes.go logs
+// "no media-progress provider is wired"), so real progress records existing
+// server-side while /api/me reports an empty list would make a connecting
+// client destroy its own local progress. This job is invoke-only — maintenance
+// jobs run solely via POST /maintenance/jobs/:job_id and there is no cron path
+// to it — which is deliberate, not incidental.
+type backfillITunesPositionsJob struct{}
+
+func (j *backfillITunesPositionsJob) ID() string       { return "backfill-itunes-positions" }
+func (j *backfillITunesPositionsJob) Name() string     { return "Backfill iTunes/Apple Books Positions" }
+func (j *backfillITunesPositionsJob) Category() string { return "itunes" }
+
+func (j *backfillITunesPositionsJob) Description() string {
+	return "Migrates each book's saved iTunes/Apple Books bookmark into the per-user progress store, forward-only so a newer position from a device is never rewound"
+}
+
+func (j *backfillITunesPositionsJob) DefaultParams() any {
+	return struct {
+		DryRun bool   `json:"dry_run"`
+		UserID string `json:"user_id_env_hint"`
+	}{DryRun: false, UserID: ITunesPositionBackfillUserIDEnv}
+}
+
+// CanResume is false for the same reason as backfill-sync-ids: every per-book
+// decision is recomputed from scratch and the merge policy makes a re-run a
+// no-op when nothing changed, so restarting from book 0 IS the resume story.
+func (j *backfillITunesPositionsJob) CanResume() bool { return false }
+
+// migrateResult is what one book's worker decided, for counting.
+type migrateResult struct {
+	outcome positionOutcome
+	// hadDuration is false when no authoritative duration was determinable, in
+	// which case the position still carried over but the book can never
+	// auto-mark finished.
+	hadDuration     bool
+	bookmarkCreated bool
+}
+
+// positionOutcome is the per-book disposition.
+type positionOutcome int
+
+const (
+	outcomeMigrated positionOutcome = iota
+	outcomeNoBookmark
+	outcomeNotAccepted
+	outcomeUnchanged
+	outcomeMissingBook
+	outcomeFailed
+)
+
+func (j *backfillITunesPositionsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	userID, err := ResolveITunesPositionBackfillUser(store)
+	if err != nil {
+		return fmt.Errorf("backfill-itunes-positions: %w", err)
+	}
+
+	// ListBookIDs, not GetAllBooksFrom: the latter's memdb fast path silently
+	// caps a page at 2× the requested limit, so a paginated walk can miss books
+	// — and a missed book here is a listening position quietly not migrated.
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("backfill-itunes-positions: list book ids: %w", err)
+	}
+	reporter.SetTotal(len(ids))
+
+	// The courtesy bookmark is best-effort: a store that does not implement the
+	// bookmark capability must not stop the resume positions — which are the
+	// actual requirement — from migrating.
+	bookmarkStore := database.AsBookmarkStore(store)
+	if bookmarkStore == nil {
+		slog.Warn("backfill-itunes-positions: store does not implement the bookmark capability — " +
+			"resume positions will migrate but no courtesy bookmark will be dropped")
+	}
+
+	slog.Info("backfill-itunes-positions: starting", "books", len(ids), "user", userID,
+		"dry_run", dryRun, "concurrency", BackfillConcurrency())
+
+	var migrated, noBookmark, notAccepted, unchanged, missingBook, failed, noDuration, bookmarks atomic.Int64
+
+	rep := &absBackfillReporter{ctx: ctx, inner: reporter}
+	runErr := registry.RunItems(ctx, rep, ids, func(_ context.Context, bookID string) error {
+		res := j.migrateOne(store, bookmarkStore, userID, bookID, dryRun)
+		if res.outcome == outcomeMigrated && !res.hadDuration {
+			noDuration.Add(1)
+		}
+		if res.bookmarkCreated {
+			bookmarks.Add(1)
+		}
+		switch res.outcome {
+		case outcomeMigrated:
+			migrated.Add(1)
+		case outcomeNoBookmark:
+			noBookmark.Add(1)
+		case outcomeNotAccepted:
+			notAccepted.Add(1)
+		case outcomeUnchanged:
+			unchanged.Add(1)
+		case outcomeMissingBook:
+			missingBook.Add(1)
+		case outcomeFailed:
+			failed.Add(1)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		// Per-book work partitions cleanly by book ID — two workers can never
+		// touch the same (user, book) rows — so the pool needs no extra
+		// locking. Bounded at NumCPU: a bare sequential loop over the whole
+		// library is the pattern behind this repo's 3-hour single-core stall.
+		Concurrency: BackfillConcurrency(),
+		ErrMode:     registry.ErrModeCollect,
+		Label:       func(i, total int) string { return fmt.Sprintf("book %d/%d", i+1, total) },
+	})
+
+	summary := fmt.Sprintf(
+		"backfill-itunes-positions complete (dry_run=%t, user=%s): migrated=%d no_bookmark=%d "+
+			"not_accepted=%d unchanged=%d missing_book=%d failed=%d no_duration=%d bookmarks=%d of %d books",
+		dryRun, userID, migrated.Load(), noBookmark.Load(), notAccepted.Load(), unchanged.Load(),
+		missingBook.Load(), failed.Load(), noDuration.Load(), bookmarks.Load(), len(ids))
+	slog.Info(summary)
+	reporter.Log("info", summary, nil)
+
+	return runErr
+}
+
+// migrateOne carries one book's iTunes resume position onto (userID, bookID).
+//
+// Every failure path logs the book ID and returns outcomeFailed rather than
+// returning nil quietly: a silently skipped book is a listening position the
+// owner loses without ever being told.
+func (j *backfillITunesPositionsJob) migrateOne(store database.Store, bookmarkStore database.BookmarkStore, userID, bookID string, dryRun bool) migrateResult {
+	book, err := store.GetBookByID(bookID)
+	if err != nil {
+		slog.Warn("backfill-itunes-positions: get book failed", "book", bookID, "err", err)
+		return migrateResult{outcome: outcomeFailed}
+	}
+	if book == nil {
+		slog.Warn("backfill-itunes-positions: book id listed but not readable", "book", bookID)
+		return migrateResult{outcome: outcomeMissingBook}
+	}
+
+	// ITunesBookmark is MILLISECONDS and is a single scalar per book. nil means
+	// the book was never opened — writing a zero position there would fabricate
+	// progress the user never had, so it is skipped, not zeroed. A zero or
+	// negative value is the same "not started" signal.
+	if book.ITunesBookmark == nil || *book.ITunesBookmark <= 0 {
+		return migrateResult{outcome: outcomeNoBookmark}
+	}
+	positionSec := float64(*book.ITunesBookmark) / 1000.0
+
+	durationSec, hadDuration := j.authoritativeDurationSec(store, book)
+	if !hadDuration {
+		slog.Warn("backfill-itunes-positions: no authoritative duration — position carries over "+
+			"but the book can never auto-mark finished (§5b/§1.8.7)", "book", bookID)
+	}
+
+	existingPositions, err := store.ListUserPositionsForBook(userID, bookID)
+	if err != nil {
+		slog.Warn("backfill-itunes-positions: list existing positions failed", "book", bookID, "err", err)
+		return migrateResult{outcome: outcomeFailed, hadDuration: hadDuration}
+	}
+	existingState, err := store.GetUserBookState(userID, bookID)
+	if err != nil {
+		slog.Warn("backfill-itunes-positions: get existing state failed", "book", bookID, "err", err)
+		return migrateResult{outcome: outcomeFailed, hadDuration: hadDuration}
+	}
+
+	server := j.serverProgress(existingPositions, existingState, durationSec)
+	incoming := progress.Progress{
+		CurrentTime: positionSec,
+		Duration:    durationSec,
+		UpdatedAtMs: j.incomingUpdatedAtMs(book, server.UpdatedAtMs),
+	}
+
+	// MergeIncoming, never a bare write: it is what applies §5's newer-wins and
+	// forward-only rules, so a user who already listened further on a device
+	// cannot be rewound, and it is what derives IsFinished with §5b's ≥2s
+	// tolerance instead of an epsilon that would leave a finished book at 99%
+	// forever.
+	merged, accepted := progress.MergeIncoming(server, incoming)
+	if !accepted {
+		// The stored position is newer-or-equal AND at least as far along.
+		// Still repair a state row that drifted out of sync with it, so a
+		// half-applied earlier run is self-healing rather than permanently
+		// stale — but never touch the position itself.
+		return migrateResult{
+			outcome:     j.repairStateOnly(store, userID, bookID, server, existingState, dryRun),
+			hadDuration: hadDuration,
+		}
+	}
+
+	if dryRun {
+		return migrateResult{outcome: outcomeMigrated, hadDuration: hadDuration}
+	}
+
+	// Position first, state second: the position is the load-bearing datum (the
+	// actual resume point); state is derived from it and is repairable by a
+	// re-run via repairStateOnly above.
+	if err := store.SetUserPosition(userID, bookID, ITunesPositionWholeBookSegmentID, merged.CurrentTime); err != nil {
+		slog.Warn("backfill-itunes-positions: write position failed", "book", bookID, "err", err)
+		return migrateResult{outcome: outcomeFailed, hadDuration: hadDuration}
+	}
+	if err := store.SetUserBookState(j.desiredState(userID, bookID, merged, existingState)); err != nil {
+		slog.Warn("backfill-itunes-positions: write user-book state failed (position was written)",
+			"book", bookID, "err", err)
+		return migrateResult{outcome: outcomeFailed, hadDuration: hadDuration}
+	}
+	slog.Debug("backfill-itunes-positions: migrated", "book", bookID, "user", userID,
+		"position_sec", merged.CurrentTime, "duration_sec", merged.Duration,
+		"is_finished", merged.IsFinished)
+
+	return migrateResult{
+		outcome:         outcomeMigrated,
+		hadDuration:     hadDuration,
+		bookmarkCreated: j.dropCourtesyBookmark(bookmarkStore, userID, bookID, merged.CurrentTime),
+	}
+}
+
+// dropCourtesyBookmark writes the single named bookmark described by
+// ITunesPositionBookmarkTitle at the migrated offset, and reports whether it
+// wrote one.
+//
+// Deliberately best-effort and never fatal: the resume position is the
+// requirement, this marker is a courtesy, so a bookmark-store failure is logged
+// and the book still counts as migrated. It only runs on an accepted migration,
+// which is also what makes it idempotent in practice — a re-run's merge rejects
+// before reaching here, so CreateBookmark's UpdatedAt is not re-stamped.
+//
+// itemID is the Book ULID, the same identity the UserPosition/UserBookState
+// rows written above use. Mapping to a sync_item syncID belongs to the DTO
+// layer that eventually serves these to a client, not to two different
+// identities inside one migration.
+func (j *backfillITunesPositionsJob) dropCourtesyBookmark(bookmarkStore database.BookmarkStore, userID, bookID string, timeSec float64) bool {
+	if bookmarkStore == nil {
+		return false
+	}
+	if err := bookmarkStore.CreateBookmark(progress.Bookmark{
+		UserID:  userID,
+		ItemID:  bookID,
+		TimeSec: timeSec,
+		Title:   ITunesPositionBookmarkTitle,
+	}); err != nil {
+		slog.Warn("backfill-itunes-positions: courtesy bookmark failed (the resume position was still migrated)",
+			"book", bookID, "user", userID, "err", err)
+		return false
+	}
+	return true
+}
+
+// serverProgress builds the merge policy's "server" side from what is already
+// stored.
+//
+// CurrentTime is max(PositionSeconds) across every segment row, not the
+// most-recently-written row that GetUserPosition would return. That is
+// deliberately more conservative than §5's live-PATCH rule: legacy rows are
+// per-device/per-segment (internal/merge/sync_follow.go calls segment IDs
+// "opaque per-user bookkeeping") and are not directly comparable to a
+// whole-book scalar, so a migration must treat the furthest of them as the
+// position it must not rewind. UpdatedAtMs likewise takes the newest stamp
+// available, which only makes the incoming clamp stricter.
+func (j *backfillITunesPositionsJob) serverProgress(positions []database.UserPosition, state *database.UserBookState, durationSec float64) progress.Progress {
+	out := progress.Progress{Duration: durationSec}
+	for _, p := range positions {
+		if p.PositionSeconds > out.CurrentTime {
+			out.CurrentTime = p.PositionSeconds
+		}
+		if ms := p.UpdatedAt.UnixMilli(); !p.UpdatedAt.IsZero() && ms > out.UpdatedAtMs {
+			out.UpdatedAtMs = ms
+		}
+	}
+	if state != nil {
+		out.IsFinished = state.Status == database.UserBookStatusFinished
+		for _, ts := range []time.Time{state.LastActivityAt, state.UpdatedAt} {
+			if ms := ts.UnixMilli(); !ts.IsZero() && ms > out.UpdatedAtMs {
+				out.UpdatedAtMs = ms
+			}
+		}
+	}
+	return out
+}
+
+// incomingUpdatedAtMs picks the ms epoch that stands in for "when iTunes last
+// knew this position", then clamps it to the server's existing stamp.
+//
+// The stamp itself comes from real data — ITunesLastPlayed, then
+// ITunesDateAdded, then the book's own row timestamps — never time.Now(): a
+// fresh stamp would win §5's newer-wins branch outright and let a stale iTunes
+// bookmark overwrite a device's genuinely newer position, which is precisely
+// the rewind this job must not cause. (It would also beat AudioBooth's own
+// truncated-seconds comparison client-side and make the client discard its
+// newer local value.)
+//
+// The clamp is the belt to that braces: when the server already has a stamp,
+// the incoming one is capped at it, so the merge can only ever accept via the
+// forward-only branch — i.e. only when the iTunes position is strictly further
+// along. This is an honest statement about the data, not a trick: any
+// server-side progress row was written by a live device after the library was
+// imported, so the iTunes bookmark is by construction not newer.
+//
+// A zero result would be worse than useless: §1.7.3 #1 notes an absent
+// updatedAt makes the server lose every conversation about conflicts, because
+// clients compare it against their own wall clock. Hence the final fallback to
+// 1 ms rather than 0.
+func (j *backfillITunesPositionsJob) incomingUpdatedAtMs(book *database.Book, serverUpdatedAtMs int64) int64 {
+	var chosen int64
+	for _, ts := range []*time.Time{book.ITunesLastPlayed, book.ITunesDateAdded, book.UpdatedAt, book.CreatedAt} {
+		if ts == nil || ts.IsZero() {
+			continue
+		}
+		if ms := ts.UnixMilli(); ms > 0 {
+			chosen = ms
+			break
+		}
+	}
+	if chosen <= 0 {
+		chosen = 1
+	}
+	if serverUpdatedAtMs > 0 && chosen > serverUpdatedAtMs {
+		chosen = serverUpdatedAtMs
+	}
+	return chosen
+}
+
+// desiredState renders a merged Progress into the store's UserBookState shape.
+//
+// Two representation notes worth stating out loud:
+//   - UserBookState.ProgressPct is an int 0-100 (this store's long-standing
+//     shape). The authoritative value derived here is the 0.0-1.0 fraction from
+//     ITunesPositionProgressFraction — which is what the ABS `progress` field
+//     must carry — and the percentage is a lossy rendering of it at the store
+//     boundary, not the other way round.
+//   - LastActivityAt carries the merged ms epoch exactly (time.UnixMilli
+//     round-trips ms losslessly), and is the field the ABS DTO should report as
+//     lastUpdate. UserPosition.UpdatedAt cannot serve that role:
+//     PebbleStore.SetUserPosition stamps it time.Now() unconditionally.
+//
+// TotalListenedSeconds is deliberately left as-is: a bookmark is a position,
+// not an amount of audio listened, and inventing one would corrupt listening
+// stats. A manual status override (StatusManual) is likewise preserved — it is
+// a user decision this migration has no standing to overrule.
+func (j *backfillITunesPositionsJob) desiredState(userID, bookID string, merged progress.Progress, existing *database.UserBookState) *database.UserBookState {
+	state := database.UserBookState{UserID: userID, BookID: bookID}
+	if existing != nil {
+		state = *existing
+		state.UserID = userID
+		state.BookID = bookID
+	}
+
+	fraction := ITunesPositionProgressFraction(merged.CurrentTime, merged.Duration)
+	state.ProgressPct = int(math.Round(fraction * 100))
+	if state.ProgressPct < 0 {
+		state.ProgressPct = 0
+	}
+	if state.ProgressPct > 100 {
+		state.ProgressPct = 100
+	}
+
+	if !state.StatusManual {
+		if merged.IsFinished {
+			state.Status = database.UserBookStatusFinished
+			state.ProgressPct = 100
+		} else {
+			state.Status = database.UserBookStatusInProgress
+		}
+	}
+	// Never render an unfinished book as 100%: rounding a fraction like 0.9997
+	// (3 s short of a 9975 s book — outside §5b's 2 s tolerance, so genuinely
+	// not finished) up to 100 would contradict the status beside it. The
+	// authoritative fraction is untouched; this only affects the lossy
+	// percentage rendering.
+	if state.Status != database.UserBookStatusFinished && state.ProgressPct >= 100 {
+		state.ProgressPct = 99
+	}
+	state.LastSegmentID = ITunesPositionWholeBookSegmentID
+	state.LastActivityAt = time.UnixMilli(merged.UpdatedAtMs).UTC()
+	return &state
+}
+
+// repairStateOnly runs when the merge rejected the incoming position (the
+// stored one is newer-or-equal and at least as far along). The position is left
+// strictly untouched; only a state row that disagrees with the stored position
+// is rewritten, so a run that died between the two writes heals on the next
+// run instead of leaving the book permanently mis-labelled.
+func (j *backfillITunesPositionsJob) repairStateOnly(store database.Store, userID, bookID string, server progress.Progress, existing *database.UserBookState, dryRun bool) positionOutcome {
+	if server.CurrentTime <= 0 {
+		// Nothing stored to describe.
+		return outcomeNotAccepted
+	}
+	derived := server
+	derived.IsFinished = server.IsFinished || progress.IsWithinFinishedTolerance(server.CurrentTime, server.Duration)
+	if existing != nil && derived.UpdatedAtMs > 0 {
+		// Keep the existing stamp — this is a repair, not a new observation.
+		derived.UpdatedAtMs = existing.LastActivityAt.UnixMilli()
+		if derived.UpdatedAtMs <= 0 {
+			derived.UpdatedAtMs = server.UpdatedAtMs
+		}
+	}
+	want := j.desiredState(userID, bookID, derived, existing)
+
+	if existing != nil &&
+		existing.Status == want.Status &&
+		existing.ProgressPct == want.ProgressPct &&
+		existing.LastActivityAt.Equal(want.LastActivityAt) {
+		return outcomeUnchanged
+	}
+	if existing != nil && existing.Status == "" && want.Status == "" {
+		return outcomeUnchanged
+	}
+	if dryRun {
+		return outcomeNotAccepted
+	}
+	if err := store.SetUserBookState(want); err != nil {
+		slog.Warn("backfill-itunes-positions: repair user-book state failed", "book", bookID, "err", err)
+		return outcomeFailed
+	}
+	slog.Info("backfill-itunes-positions: repaired a user-book state that had drifted from its stored position",
+		"book", bookID, "user", userID, "status", want.Status, "progress_pct", want.ProgressPct)
+	return outcomeNotAccepted
+}
+
+// authoritativeDurationSec returns the ONE duration per book that §5b requires
+// be used consistently for progress math, and whether one was determinable.
+//
+// Preference order is the spec's recommendation: the sum of track durations,
+// "since it matches the timeline clients actually seek within (and matches real
+// ABS startOffset values exactly)". Book.Duration (the container's own value)
+// is the fallback — the same book legitimately reports three different
+// durations from three sources (container / last-chapter-end / track-sum,
+// ~52 ms apart on the measured Odyssey fixture), and mixing them across the
+// fraction and the finished check is what produces a book stuck at 99%.
+func (j *backfillITunesPositionsJob) authoritativeDurationSec(store database.Store, book *database.Book) (float64, bool) {
+	files, err := store.GetBookFiles(book.ID)
+	if err != nil {
+		slog.Warn("backfill-itunes-positions: list book files failed, falling back to Book.Duration",
+			"book", book.ID, "err", err)
+	} else {
+		var sum int
+		for _, f := range files {
+			if f.Duration > 0 {
+				sum += f.Duration
+			}
+		}
+		if sum > 0 {
+			return float64(sum), true
+		}
+	}
+	if book.Duration != nil && *book.Duration > 0 {
+		return float64(*book.Duration), true
+	}
+	return 0, false
+}

--- a/internal/maintenance/jobs/backfill_itunes_positions_test.go
+++ b/internal/maintenance/jobs/backfill_itunes_positions_test.go
@@ -1,0 +1,534 @@
+// file: internal/maintenance/jobs/backfill_itunes_positions_test.go
+// version: 1.0.0
+// guid: 5577372a-b3ed-4283-9217-345d654e2a57
+// last-edited: 2026-07-30
+
+// Package jobs_test — coverage for the backfill-itunes-positions maintenance
+// job. The owner is migrating off iTunes/Apple Books and their existing
+// listening positions must carry over, so the load-bearing assertions here are
+// the negative ones: a nil bookmark must not become a zero position, and a
+// newer position from a real device must never be rewound by stale iTunes data.
+package jobs_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance/jobs"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newPositionUser(t *testing.T, store *database.PebbleStore, username string) *database.User {
+	t.Helper()
+	u, err := store.CreateUser(username, username+"@example.test", "argon2id", "hash", []string{"admin"}, "active")
+	require.NoError(t, err)
+	return u
+}
+
+// seedBookmarkedBook creates a book whose track durations sum to trackSecs
+// (spec §5b's recommended authoritative duration) and whose ITunesBookmark is
+// bookmarkMs. A nil bookmarkMs means "no saved position".
+func seedBookmarkedBook(t *testing.T, store *database.PebbleStore, title string, bookmarkMs *int64, trackSecs []int, lastPlayed *time.Time) *database.Book {
+	t.Helper()
+	book, err := store.CreateBook(&database.Book{
+		Title:            title,
+		FilePath:         "/library/" + title,
+		ITunesBookmark:   bookmarkMs,
+		ITunesLastPlayed: lastPlayed,
+	})
+	require.NoError(t, err)
+	for i, secs := range trackSecs {
+		require.NoError(t, store.CreateBookFile(&database.BookFile{
+			BookID:   book.ID,
+			FilePath: fmt.Sprintf("/library/%s/track-%02d.mp3", title, i),
+			Duration: secs,
+		}))
+	}
+	return book
+}
+
+func runPositionBackfill(t *testing.T, store database.Store, dryRun bool) *noopReporter {
+	t.Helper()
+	j, err := maintenance.Get("backfill-itunes-positions")
+	require.NoError(t, err)
+	rep := &noopReporter{}
+	require.NoError(t, j.Run(context.Background(), store, rep, dryRun))
+	return rep
+}
+
+func int64p(v int64) *int64 { return &v }
+
+// wholeBookPosition returns the migrated whole-book row, or nil.
+func wholeBookPosition(t *testing.T, store *database.PebbleStore, userID, bookID string) *database.UserPosition {
+	t.Helper()
+	rows, err := store.ListUserPositionsForBook(userID, bookID)
+	require.NoError(t, err)
+	for i := range rows {
+		if rows[i].SegmentID == jobs.ITunesPositionWholeBookSegmentID {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+func TestBackfillITunesPositionsJob_Registered(t *testing.T) {
+	assertJobRegistered(t, "backfill-itunes-positions")
+	j, err := maintenance.Get("backfill-itunes-positions")
+	require.NoError(t, err)
+	require.NotEmpty(t, j.Name())
+	require.NotEmpty(t, j.Description())
+	require.NotEmpty(t, j.Category())
+	require.NotNil(t, j.DefaultParams())
+	require.False(t, j.CanResume())
+}
+
+// ---------------------------------------------------------------------------
+// Conversion + derivation
+// ---------------------------------------------------------------------------
+
+// ITunesBookmark is MILLISECONDS; ABS positions are float SECONDS.
+func TestBackfillITunesPositions_ConvertsMillisecondsToFloatSeconds(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "half-listened", int64p(1234567), []int{1000, 1000}, nil)
+
+	runPositionBackfill(t, store, false)
+
+	pos := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos, "no whole-book position row was written")
+	require.InDelta(t, 1234.567, pos.PositionSeconds, 1e-9)
+}
+
+// progress must be a 0.0-1.0 fraction, never a percentage.
+func TestITunesPositionProgressFraction_IsAFractionNotAPercentage(t *testing.T) {
+	require.InDelta(t, 0.5, jobs.ITunesPositionProgressFraction(50, 100), 1e-9)
+	require.InDelta(t, 0.0, jobs.ITunesPositionProgressFraction(0, 100), 1e-9)
+	require.InDelta(t, 1.0, jobs.ITunesPositionProgressFraction(100, 100), 1e-9)
+	// Clamped: a position past the (int-seconds) duration sum must not report
+	// 1.04, which a strict client decoder would reject.
+	require.InDelta(t, 1.0, jobs.ITunesPositionProgressFraction(104, 100), 1e-9)
+	// Unknown duration cannot yield a fraction.
+	require.InDelta(t, 0.0, jobs.ITunesPositionProgressFraction(50, 0), 1e-9)
+}
+
+// §5b: a fully-listened book must auto-mark finished despite duration skew.
+// The Odyssey fixture's three legitimate durations disagree by ~52 ms
+// (container 9975.480544 / last-chapter-end 9975.428 / track-sum 9975.431111);
+// BookFile.Duration is whole seconds, so the skew against a millisecond
+// bookmark is up to ~1 s per track — which is exactly why the tolerance is 2 s
+// and not an epsilon.
+func TestBackfillITunesPositions_FinishedWithinToleranceOfDuration(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	tracks := []int{1663, 1663, 1663, 1663, 1663, 1660} // sums to 9975
+	// 9973.5 s — 1.5 s short of the track sum, inside FinishedToleranceSec.
+	finished := seedBookmarkedBook(t, store, "odyssey-finished", int64p(9973500), tracks, nil)
+	// 9972.0 s — 3 s short, outside the tolerance.
+	unfinished := seedBookmarkedBook(t, store, "odyssey-unfinished", int64p(9972000), tracks, nil)
+
+	require.Equal(t, 2.0, progress.FinishedToleranceSec, "test assumes the spec §5b 2s tolerance")
+
+	runPositionBackfill(t, store, false)
+
+	st, err := store.GetUserBookState(user.ID, finished.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, database.UserBookStatusFinished, st.Status)
+	require.Equal(t, 100, st.ProgressPct)
+
+	st2, err := store.GetUserBookState(user.ID, unfinished.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st2)
+	require.Equal(t, database.UserBookStatusInProgress, st2.Status)
+	require.Less(t, st2.ProgressPct, 100)
+}
+
+// lastUpdate must be a real integer ms epoch, taken from ITunesLastPlayed.
+func TestBackfillITunesPositions_StampsMillisecondEpochLastUpdate(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	lastPlayed := time.UnixMilli(1_700_000_123_456).UTC()
+	book := seedBookmarkedBook(t, store, "stamped", int64p(600000), []int{1200}, &lastPlayed)
+
+	runPositionBackfill(t, store, false)
+
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, int64(1_700_000_123_456), st.LastActivityAt.UnixMilli(),
+		"LastActivityAt must carry the exact ms epoch the ABS DTO reports as lastUpdate")
+}
+
+// ---------------------------------------------------------------------------
+// The negative guarantees
+// ---------------------------------------------------------------------------
+
+// A nil bookmark means "no saved position" — writing a zero would fabricate
+// progress the user never had.
+func TestBackfillITunesPositions_NilBookmarkWritesNothing(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "never-opened", nil, []int{1200}, nil)
+
+	runPositionBackfill(t, store, false)
+
+	require.Nil(t, wholeBookPosition(t, store, user.ID, book.ID))
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.Nil(t, st, "a book with no iTunes bookmark must get no user-book state at all")
+}
+
+// A zero (or negative) bookmark is the same "not started" signal.
+func TestBackfillITunesPositions_ZeroBookmarkWritesNothing(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	zero := seedBookmarkedBook(t, store, "zero-bookmark", int64p(0), []int{1200}, nil)
+	neg := seedBookmarkedBook(t, store, "negative-bookmark", int64p(-5), []int{1200}, nil)
+
+	runPositionBackfill(t, store, false)
+
+	require.Nil(t, wholeBookPosition(t, store, user.ID, zero.ID))
+	require.Nil(t, wholeBookPosition(t, store, user.ID, neg.ID))
+}
+
+// THE data-loss guard: a user who already listened further on a device must not
+// be rewound by stale iTunes data.
+func TestBackfillITunesPositions_NeverRewindsANewerPosition(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "already-ahead", int64p(1_000_000), []int{6000}, nil) // iTunes at 1000s
+	require.NoError(t, store.SetUserPosition(user.ID, book.ID, "device-1", 5000))              // device at 5000s
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: book.ID,
+		Status: database.UserBookStatusInProgress, ProgressPct: 83,
+		LastActivityAt: time.Now().UTC(),
+	}))
+
+	runPositionBackfill(t, store, false)
+
+	require.Nil(t, wholeBookPosition(t, store, user.ID, book.ID),
+		"stale iTunes data must not write a whole-book row behind the device's position")
+
+	latest, err := store.GetUserPosition(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	require.InDelta(t, 5000, latest.PositionSeconds, 1e-9)
+
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, 83, st.ProgressPct, "existing state must be left untouched")
+}
+
+// Forward-only still advances: iTunes further along than the stored position is
+// a legitimate carry-over.
+func TestBackfillITunesPositions_AdvancesWhenITunesIsFurther(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "itunes-ahead", int64p(5_000_000), []int{6000}, nil) // iTunes at 5000s
+	require.NoError(t, store.SetUserPosition(user.ID, book.ID, "device-1", 100))
+
+	runPositionBackfill(t, store, false)
+
+	pos := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos)
+	require.InDelta(t, 5000, pos.PositionSeconds, 1e-9)
+}
+
+// A manual status override is a user decision; the migration must not stomp it.
+func TestBackfillITunesPositions_RespectsManualStatus(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "abandoned-on-purpose", int64p(600_000), []int{6000}, nil)
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: book.ID,
+		Status: database.UserBookStatusAbandoned, StatusManual: true,
+	}))
+
+	runPositionBackfill(t, store, false)
+
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, database.UserBookStatusAbandoned, st.Status)
+	require.True(t, st.StatusManual)
+	// The position itself still carries over.
+	pos := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos)
+	require.InDelta(t, 600, pos.PositionSeconds, 1e-9)
+}
+
+// ---------------------------------------------------------------------------
+// Dry run + idempotency
+// ---------------------------------------------------------------------------
+
+func TestBackfillITunesPositions_DryRunWritesNothing(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "dry", int64p(600_000), []int{6000}, nil)
+
+	runPositionBackfill(t, store, true)
+
+	require.Nil(t, wholeBookPosition(t, store, user.ID, book.ID))
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.Nil(t, st)
+}
+
+// Re-running must be a true no-op. UserPosition.UpdatedAt is stamped
+// time.Now() by the store on every write, so an unchanged UpdatedAt is proof
+// the second run did not write.
+func TestBackfillITunesPositions_RerunIsANoOp(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "twice", int64p(600_000), []int{6000}, nil)
+
+	runPositionBackfill(t, store, false)
+	pos1 := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos1)
+	st1, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st1)
+
+	time.Sleep(2 * time.Millisecond) // so a second write would be visibly newer
+	rep := runPositionBackfill(t, store, false)
+
+	pos2 := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos2)
+	require.Equal(t, *pos1, *pos2, "re-run rewrote the position row")
+	st2, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.Equal(t, *st1, *st2, "re-run rewrote the user-book state")
+
+	require.True(t, summaryContains(rep, "migrated=0"),
+		"re-run should report zero migrations, got logs: %v", rep.logs)
+}
+
+// A state row lost or corrupted after the position was written must be repaired
+// by a re-run rather than left permanently stale.
+func TestBackfillITunesPositions_RepairsMissingStateOnRerun(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "state-drift", int64p(600_000), []int{6000}, nil)
+	runPositionBackfill(t, store, false)
+
+	// Simulate a half-applied write: neutralize the state row, keep the position.
+	require.NoError(t, store.SetUserBookState(&database.UserBookState{
+		UserID: user.ID, BookID: book.ID, Status: "", ProgressPct: 0,
+	}))
+
+	runPositionBackfill(t, store, false)
+
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, database.UserBookStatusInProgress, st.Status)
+	require.Equal(t, 10, st.ProgressPct)
+}
+
+// ---------------------------------------------------------------------------
+// Target-user resolution
+// ---------------------------------------------------------------------------
+
+func TestResolveITunesPositionBackfillUser_EnvOverrideWins(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	newPositionUser(t, store, "first")
+	second := newPositionUser(t, store, "second")
+
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, second.ID)
+	got, err := jobs.ResolveITunesPositionBackfillUser(store)
+	require.NoError(t, err)
+	require.Equal(t, second.ID, got)
+}
+
+func TestResolveITunesPositionBackfillUser_RejectsUnknownOverride(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	newPositionUser(t, store, "first")
+
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, "no-such-user")
+	_, err := jobs.ResolveITunesPositionBackfillUser(store)
+	require.Error(t, err, "an unknown override must fail loudly, not silently fall back")
+}
+
+func TestResolveITunesPositionBackfillUser_SingleUser(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	only := newPositionUser(t, store, "solo")
+
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, "")
+	got, err := jobs.ResolveITunesPositionBackfillUser(store)
+	require.NoError(t, err)
+	require.Equal(t, only.ID, got)
+}
+
+func TestResolveITunesPositionBackfillUser_MultiUserIsDeterministic(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	a := newPositionUser(t, store, "alpha")
+	b := newPositionUser(t, store, "bravo")
+
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, "")
+	first, err := jobs.ResolveITunesPositionBackfillUser(store)
+	require.NoError(t, err)
+	require.Contains(t, []string{a.ID, b.ID}, first)
+	for i := 0; i < 3; i++ {
+		again, err := jobs.ResolveITunesPositionBackfillUser(store)
+		require.NoError(t, err)
+		require.Equal(t, first, again, "ambiguous user choice must be stable across runs")
+	}
+}
+
+func TestResolveITunesPositionBackfillUser_NoUsersIsAnError(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, "")
+	_, err := jobs.ResolveITunesPositionBackfillUser(store)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Unknown duration + reporting
+// ---------------------------------------------------------------------------
+
+// Without a duration, isFinished cannot be derived (§1.8.7's null-duration
+// trap) — but the position itself is still the user's data and must carry over.
+func TestBackfillITunesPositions_MigratesPositionWithoutDuration(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "no-duration", int64p(600_000), nil, nil)
+
+	rep := runPositionBackfill(t, store, false)
+
+	pos := wholeBookPosition(t, store, user.ID, book.ID)
+	require.NotNil(t, pos)
+	require.InDelta(t, 600, pos.PositionSeconds, 1e-9)
+
+	st, err := store.GetUserBookState(user.ID, book.ID)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.Equal(t, database.UserBookStatusInProgress, st.Status)
+	require.Equal(t, 0, st.ProgressPct, "no duration means no computable fraction")
+	require.True(t, summaryContains(rep, "no_duration=1"), "logs: %v", rep.logs)
+}
+
+// The repo's status-reporting convention: exact counts, never "all done".
+func TestBackfillITunesPositions_ReportsExactCounts(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	seedBookmarkedBook(t, store, "m1", int64p(600_000), []int{6000}, nil)
+	seedBookmarkedBook(t, store, "m2", int64p(700_000), []int{6000}, nil)
+	seedBookmarkedBook(t, store, "skipped", nil, []int{6000}, nil)
+
+	rep := runPositionBackfill(t, store, false)
+
+	require.True(t, summaryContains(rep, "migrated=2"), "logs: %v", rep.logs)
+	require.True(t, summaryContains(rep, "no_bookmark=1"), "logs: %v", rep.logs)
+	require.True(t, summaryContains(rep, "failed=0"), "logs: %v", rep.logs)
+}
+
+// ---------------------------------------------------------------------------
+// The single courtesy bookmark
+// ---------------------------------------------------------------------------
+
+// A migrated position also drops ONE named bookmark at the same offset so the
+// owner can see and jump back to where Apple Books left them. Exactly one —
+// the iTunes value is a single resume scalar, not a bookmark collection, and
+// the ABS bookmarks feature is otherwise an independent system clients populate
+// themselves.
+func TestBackfillITunesPositions_DropsOneNamedBookmarkAtTheSameOffset(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "with-marker", int64p(1_234_567), []int{6000}, nil)
+
+	rep := runPositionBackfill(t, store, false)
+
+	marks, err := store.ListBookmarks(user.ID, book.ID)
+	require.NoError(t, err)
+	require.Len(t, marks, 1, "exactly one bookmark, never a synthesized list")
+	require.InDelta(t, 1234.567, marks[0].TimeSec, 1e-3)
+	require.Equal(t, jobs.ITunesPositionBookmarkTitle, marks[0].Title)
+	require.Greater(t, marks[0].CreatedAt, int64(0), "CreatedAt must be a real ms epoch")
+	require.True(t, summaryContains(rep, "bookmarks=1"), "logs: %v", rep.logs)
+}
+
+func TestBackfillITunesPositions_NoBookmarkWhenNothingMigrated(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	// nil bookmark, and a book whose stored position is already further along.
+	skipped := seedBookmarkedBook(t, store, "no-marker", nil, []int{6000}, nil)
+	ahead := seedBookmarkedBook(t, store, "already-ahead-marker", int64p(1_000), []int{6000}, nil)
+	require.NoError(t, store.SetUserPosition(user.ID, ahead.ID, "device-1", 5000))
+
+	runPositionBackfill(t, store, false)
+
+	for _, id := range []string{skipped.ID, ahead.ID} {
+		marks, err := store.ListBookmarks(user.ID, id)
+		require.NoError(t, err)
+		require.Empty(t, marks, "book %s should have no courtesy bookmark", id)
+	}
+}
+
+func TestBackfillITunesPositions_DryRunCreatesNoBookmark(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	user := newPositionUser(t, store, "owner")
+	t.Setenv(jobs.ITunesPositionBackfillUserIDEnv, user.ID)
+
+	book := seedBookmarkedBook(t, store, "dry-marker", int64p(600_000), []int{6000}, nil)
+
+	runPositionBackfill(t, store, true)
+
+	marks, err := store.ListBookmarks(user.ID, book.ID)
+	require.NoError(t, err)
+	require.Empty(t, marks)
+}
+
+func summaryContains(rep *noopReporter, want string) bool {
+	for _, l := range rep.logs {
+		if strings.Contains(l, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/maintenance/jobs/backfill_sync_ids.go
+++ b/internal/maintenance/jobs/backfill_sync_ids.go
@@ -1,0 +1,150 @@
+// file: internal/maintenance/jobs/backfill_sync_ids.go
+// version: 1.0.0
+// guid: 85ae5c94-d001-49d9-9f65-97f73f32522b
+// last-edited: 2026-07-30
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+func init() { maintenance.Register(&backfillSyncIDsJob{}) }
+
+// backfillSyncIDsJob assigns durable ABS identities to the existing library:
+// a sync_item syncID per Book and a sync_file syncFileID per BookFile. See
+// docs/agent-tasks/abs-sync/TASK-04-syncid-backfill.md and
+// docs/specs/2026-07-29-abs-sync-api-design.md §4 / §4.2b.
+//
+// Both keyspaces mint on first encounter at request time anyway, so this job is
+// not required for correctness — it exists so the whole library is
+// identity-consistent BEFORE any client connects: no first-request latency
+// spike, and no window where half the library has stable IDs and half does not.
+type backfillSyncIDsJob struct{}
+
+func (j *backfillSyncIDsJob) ID() string       { return "backfill-sync-ids" }
+func (j *backfillSyncIDsJob) Name() string     { return "Backfill ABS Sync IDs" }
+func (j *backfillSyncIDsJob) Category() string { return "library" }
+
+func (j *backfillSyncIDsJob) Description() string {
+	return "Mints durable ABS sync_item/sync_file identities for every book and book file that doesn't have one yet"
+}
+
+func (j *backfillSyncIDsJob) DefaultParams() any {
+	return struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: false}
+}
+
+// CanResume returns false deliberately, and NOT because the job is
+// restart-unsafe. Every mint call (MintOrGetSyncID / MintOrGetSyncFileID) is
+// independently idempotent, so re-running the whole job from book 0 after an
+// interruption is both correct and cheap — an already-minted book or file is a
+// single point-get skip, not re-work. There is therefore no index worth
+// checkpointing, unlike backfill_file_hashes.go's resumeIndex.
+func (j *backfillSyncIDsJob) CanResume() bool { return false }
+
+func (j *backfillSyncIDsJob) Run(ctx context.Context, store database.Store, reporter maintenance.ProgressReporter, dryRun bool) error {
+	syncStore := database.AsSyncIdentityStore(store)
+	fileStore := database.AsSyncFileStore(store)
+	if syncStore == nil || fileStore == nil {
+		return fmt.Errorf("backfill-sync-ids: store does not implement the sync-identity capability interfaces")
+	}
+
+	// ListBookIDs, never GetAllBooksFrom: the latter's memdb fast path silently
+	// caps a page at 2× the requested limit, so a paginated walk can miss books
+	// (fixed once in #1647, still the documented hazard for new full-library
+	// jobs). ListBookIDs returns the complete ID set with no pagination cap.
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("backfill-sync-ids: list book ids: %w", err)
+	}
+	reporter.SetTotal(len(ids))
+	slog.Info("backfill-sync-ids: starting", "books", len(ids), "dry_run", dryRun,
+		"concurrency", BackfillConcurrency())
+
+	var booksMinted, booksAlready, filesMinted, filesAlready, failures atomic.Int64
+
+	rep := &absBackfillReporter{ctx: ctx, inner: reporter}
+	runErr := registry.RunItems(ctx, rep, ids, func(_ context.Context, bookID string) error {
+		// Point-get first so a re-run's logging and counters distinguish
+		// "already had one" from "minted now". MintOrGetSyncID would be correct
+		// on its own — this is bookkeeping clarity, not a correctness need.
+		_, hadSyncID, err := syncStore.GetSyncIDForBook(bookID)
+		if err != nil {
+			failures.Add(1)
+			slog.Warn("backfill-sync-ids: read syncID failed", "book", bookID, "err", err)
+			return nil
+		}
+
+		if !dryRun && !hadSyncID {
+			if _, err := syncStore.MintOrGetSyncID(bookID); err != nil {
+				failures.Add(1)
+				slog.Warn("backfill-sync-ids: mint syncID failed", "book", bookID, "err", err)
+				// Keep going into the file loop anyway: MintOrGetSyncFileID does
+				// not depend on the book having a sync_item.
+			}
+		}
+		if hadSyncID {
+			booksAlready.Add(1)
+		} else {
+			booksMinted.Add(1)
+		}
+
+		files, ferr := store.GetBookFiles(bookID)
+		if ferr != nil {
+			failures.Add(1)
+			slog.Warn("backfill-sync-ids: list book files failed", "book", bookID, "err", ferr)
+			return nil
+		}
+		for _, f := range files {
+			if f.ID == "" {
+				failures.Add(1)
+				slog.Warn("backfill-sync-ids: book file has no ID", "book", bookID, "path", f.FilePath)
+				continue
+			}
+			_, hadFileID, err := fileStore.GetSyncFileID(bookID, f.ID)
+			if err != nil {
+				failures.Add(1)
+				slog.Warn("backfill-sync-ids: read syncFileID failed", "book", bookID, "file", f.ID, "err", err)
+				continue
+			}
+			if hadFileID {
+				filesAlready.Add(1)
+				continue
+			}
+			if !dryRun {
+				if _, err := fileStore.MintOrGetSyncFileID(bookID, f.ID); err != nil {
+					failures.Add(1)
+					slog.Warn("backfill-sync-ids: mint syncFileID failed", "book", bookID, "file", f.ID, "err", err)
+					continue
+				}
+			}
+			filesMinted.Add(1)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: BackfillConcurrency(),
+		// ErrModeCollect, not the ErrModeFail default: a handful of unreadable
+		// books must not cancel the remaining tens of thousands. Per-item
+		// errors are already absorbed above (warn + counter + return nil), so
+		// this only matters for anything RunItems itself surfaces.
+		ErrMode: registry.ErrModeCollect,
+		Label:   func(i, total int) string { return fmt.Sprintf("book %d/%d", i+1, total) },
+	})
+
+	summary := fmt.Sprintf(
+		"backfill-sync-ids complete (dry_run=%t): books %d minted / %d already had one, files %d minted / %d already had one, %d failures",
+		dryRun, booksMinted.Load(), booksAlready.Load(), filesMinted.Load(), filesAlready.Load(), failures.Load())
+	slog.Info(summary)
+	reporter.Log("info", summary, nil)
+
+	return runErr
+}

--- a/internal/maintenance/jobs/backfill_sync_ids_test.go
+++ b/internal/maintenance/jobs/backfill_sync_ids_test.go
@@ -1,0 +1,218 @@
+// file: internal/maintenance/jobs/backfill_sync_ids_test.go
+// version: 1.0.0
+// guid: a20f7354-5d7e-49aa-b3b5-94758d52bfc9
+// last-edited: 2026-07-30
+
+// Package jobs_test — coverage for the backfill-sync-ids maintenance job
+// (TASK-04). Every test drives a real PebbleStore because the sync_item /
+// sync_file keyspaces are *PebbleStore-only capability interfaces
+// (database.AsSyncIdentityStore / AsSyncFileStore), not part of database.Store.
+package jobs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/falkcorp/audiobook-organizer/internal/maintenance/jobs"
+)
+
+// seedSyncLibrary creates n books, each with filesPerBook BookFiles, and
+// returns the book IDs in creation order.
+func seedSyncLibrary(t *testing.T, store *database.PebbleStore, n, filesPerBook int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		book, err := store.CreateBook(&database.Book{
+			Title:    fmt.Sprintf("Sync Backfill Book %d", i),
+			FilePath: fmt.Sprintf("/library/sync-%d", i),
+		})
+		require.NoError(t, err)
+		for f := 0; f < filesPerBook; f++ {
+			require.NoError(t, store.CreateBookFile(&database.BookFile{
+				BookID:   book.ID,
+				FilePath: fmt.Sprintf("/library/sync-%d/track-%02d.mp3", i, f),
+			}))
+		}
+		ids = append(ids, book.ID)
+	}
+	return ids
+}
+
+// collectSyncIDs snapshots every book's syncID and every file's syncFileID so
+// two runs can be compared byte-for-byte.
+func collectSyncIDs(t *testing.T, store *database.PebbleStore, bookIDs []string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, id := range bookIDs {
+		syncID, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		if ok {
+			out["book:"+id] = syncID
+		}
+		files, err := store.GetBookFiles(id)
+		require.NoError(t, err)
+		for _, f := range files {
+			sfID, ok, err := store.GetSyncFileID(id, f.ID)
+			require.NoError(t, err)
+			if ok {
+				out["file:"+id+":"+f.ID] = sfID
+			}
+		}
+	}
+	return out
+}
+
+func newSyncPebbleStore(t *testing.T) *database.PebbleStore {
+	t.Helper()
+	store, err := database.NewPebbleStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestBackfillSyncIDsJob_Registered(t *testing.T) {
+	assertJobRegistered(t, "backfill-sync-ids")
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+	require.NotEmpty(t, j.Name())
+	require.NotEmpty(t, j.Description())
+	require.NotEmpty(t, j.Category())
+	require.NotNil(t, j.DefaultParams())
+	// Idempotent re-run from book 0 IS the resume story — no checkpoint index.
+	require.False(t, j.CanResume())
+}
+
+// Test 1 — fresh library: every book gets a syncID, every file a syncFileID.
+func TestBackfillSyncIDsJob_FreshLibrary(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	bookIDs := seedSyncLibrary(t, store, 20, 3)
+
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, false))
+
+	for _, id := range bookIDs {
+		syncID, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		require.True(t, ok, "book %s has no syncID", id)
+		require.Len(t, syncID, 36, "syncID must be a 36-char UUID (§1.7.1)")
+
+		files, err := store.GetBookFiles(id)
+		require.NoError(t, err)
+		require.Len(t, files, 3)
+		for _, f := range files {
+			_, ok, err := store.GetSyncFileID(id, f.ID)
+			require.NoError(t, err)
+			require.True(t, ok, "file %s of book %s has no syncFileID", f.ID, id)
+		}
+	}
+}
+
+// Test 2 — idempotent re-run: the full ID set must be byte-identical.
+func TestBackfillSyncIDsJob_IdempotentRerun(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	bookIDs := seedSyncLibrary(t, store, 12, 2)
+
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, false))
+	first := collectSyncIDs(t, store, bookIDs)
+	require.Len(t, first, 12+12*2)
+
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, false))
+	second := collectSyncIDs(t, store, bookIDs)
+
+	require.Equal(t, first, second, "re-run must not re-mint any ID")
+}
+
+// Test 3 — partial pre-existing state (mint-on-first-encounter already hit some
+// books): those IDs survive untouched and the rest get minted.
+func TestBackfillSyncIDsJob_PreservesPreExistingIDs(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	bookIDs := seedSyncLibrary(t, store, 10, 2)
+
+	pre := map[string]string{}
+	for i, id := range bookIDs {
+		if i%2 != 0 {
+			continue
+		}
+		syncID, err := store.MintOrGetSyncID(id)
+		require.NoError(t, err)
+		pre[id] = syncID
+	}
+
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, false))
+
+	for id, want := range pre {
+		got, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, want, got, "pre-existing syncID for %s was re-minted", id)
+	}
+	for _, id := range bookIDs {
+		_, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		require.True(t, ok, "book %s still has no syncID after backfill", id)
+	}
+}
+
+// Test 4 — dryRun mints nothing at all.
+func TestBackfillSyncIDsJob_DryRunMintsNothing(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	bookIDs := seedSyncLibrary(t, store, 8, 2)
+
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, true))
+
+	for _, id := range bookIDs {
+		_, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		require.False(t, ok, "dry run minted a syncID for %s", id)
+
+		files, err := store.GetBookFiles(id)
+		require.NoError(t, err)
+		for _, f := range files {
+			_, ok, err := store.GetSyncFileID(id, f.ID)
+			require.NoError(t, err)
+			require.False(t, ok, "dry run minted a syncFileID for %s", f.ID)
+		}
+	}
+}
+
+// Test 5 — concurrency sanity under -race: exactly one syncID per book, and
+// ListSyncFilesForBook sees exactly one entry per file.
+func TestBackfillSyncIDsJob_ConcurrentRaceSanity(t *testing.T) {
+	store := newSyncPebbleStore(t)
+	bookIDs := seedSyncLibrary(t, store, 50, 2)
+
+	j, err := maintenance.Get("backfill-sync-ids")
+	require.NoError(t, err)
+	require.NoError(t, j.Run(context.Background(), store, &noopReporter{}, false))
+
+	for _, id := range bookIDs {
+		_, ok, err := store.GetSyncIDForBook(id)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		syncFiles, err := store.ListSyncFilesForBook(id)
+		require.NoError(t, err)
+		require.Len(t, syncFiles, 2, "book %s must have exactly one sync_file per file", id)
+	}
+}
+
+// Test 6 — the worker pool is bounded but NOT sequential. Guards against a
+// future edit silently reverting to RunItemsOptions' Concurrency: 0 default,
+// which is the exact anti-pattern behind this repo's 3-hour single-core stall.
+func TestBackfillSyncIDsConcurrencyIsNotSequential(t *testing.T) {
+	require.Greater(t, jobs.BackfillConcurrency(), 1,
+		"backfill concurrency must be > 1 (RunItemsOptions.Concurrency 0/1 == sequential)")
+}


### PR DESCRIPTION
Two explicitly-invoked `internal/maintenance` jobs, shipped in one PR because both add files to `internal/maintenance/jobs/` and share one reporter adapter — splitting them would have collided.

## Job 1 — `backfill-sync-ids` (TASK-04 / ABS-SYNC-ID-4)

Mints a `sync_item` syncID for every Book and a `sync_file` syncFileID for every BookFile that lacks one, in a single pass over the library. Both keyspaces already mint on first encounter, so this is not required for correctness — it exists so the whole library is identity-consistent *before* any client connects.

Idempotent by construction, not by checkpoint: `MintOrGetSyncID` / `MintOrGetSyncFileID` are each independently idempotent, so re-running from book 0 after an interruption is correct and cheap. `CanResume()` is `false` on purpose (documented in a comment so it isn't read as "not restart-safe").

## Job 2 — `backfill-itunes-positions`

Migrates `Book.ITunesBookmark` (**milliseconds**, one scalar per book, the *farthest position read*) into the per-user progress store (`UserPosition` + `UserBookState`), so moving off iTunes/Apple Books does not start from a blank slate.

**Every write goes through `progress.MergeIncoming` — never bare.** That is what makes §5's forward-only rule apply: a user who already listened further on a real device can never be rewound, while an iTunes position that *is* further along still advances. Two extra safeguards back that up:

- The incoming timestamp comes from real data (`ITunesLastPlayed` → `ITunesDateAdded` → the book's own row timestamps) and **never `time.Now()`** — a fresh stamp would win the newer-wins branch outright and overwrite a device's newer position, and would also beat AudioBooth's truncated-seconds comparison client-side.
- It is then **clamped to the server's existing stamp**, so when a stored record exists the merge can only ever accept via the forward-only branch.
- The server-side position fed to the merge is `max(PositionSeconds)` across all existing segment rows, not the most recent one — legacy rows are opaque per-device segments and are not directly comparable to a whole-book scalar, so a migration must treat the furthest as the one it must not rewind.

Other §5/§5b requirements:

- `isFinished` uses `IsWithinFinishedTolerance` (≥2 s) against **one** authoritative duration per book — sum of track durations, falling back to `Book.Duration`. The same book legitimately reports three durations (container `9975.480544` / last-chapter-end `9975.428000` / track-sum `9975.431111`, ~52 ms apart); with a tight epsilon a fully-listened book never auto-marks finished and sits at 99% forever.
- `progress` is a **0.0–1.0 fraction**, exported as `ITunesPositionProgressFraction` so the future DTO layer cannot re-derive it as a percentage. An unfinished book is never rendered as 100%.
- `lastUpdate` is an exact integer ms epoch on `UserBookState.LastActivityAt`. `UserPosition.UpdatedAt` cannot serve that role — `PebbleStore.SetUserPosition` stamps it `time.Now()` unconditionally and that file is off-limits.
- A nil or non-positive bookmark is **skipped, never zeroed**. `StatusManual` overrides are preserved; `TotalListenedSeconds` is left untouched (a position is not an amount listened).
- Re-running is a true no-op when nothing changed. A state row that drifted from its stored position is repaired **without touching the position**, so a run interrupted between the two writes self-heals.

**Courtesy bookmark (owner's optional ask):** exactly one named bookmark, `Imported from Apple Books`, at the migrated offset, so the position is visible and jumpable rather than an invisible resume point. Only on an accepted migration, best-effort (a bookmark-store failure is logged and the book still counts as migrated). **No bookmark list is synthesized** from a single resume scalar, and the `bookmark:` keyspace gets nothing else.

**Target user** is resolved explicitly, never guessed silently: `ABS_ITUNES_POSITION_BACKFILL_USER_ID` if set (an ID matching no user is a **hard error**, not a silent fallback) → the only user → the earliest-created account with a `WARN` naming the choice and the override. Zero users is an error. It is an env var because `MaintenanceJob.Run` only receives `dryRun` — the dispatcher decodes nothing else from the request body.

## ⚠️ Do NOT run job 2 before the ABS media-progress provider is wired

§1.8.1: AudioBooth's `MediaProgress.syncFromAPI` **deletes** any local progress row whose bookID is absent from `/api/me`'s `mediaProgress` list. That provider is still `nil` — `internal/server/wire_abs_routes.go:166` logs `"no media-progress provider is wired — /api/me will report an EMPTY mediaProgress list"`. Real progress records existing server-side while `/api/me` reports an empty list would make a connecting client destroy its own local progress.

Job 2 is therefore invoke-only, and that is deliberate rather than incidental: maintenance jobs run **solely** via `POST /maintenance/jobs/:job_id` (`internal/server/maintenance_dispatcher.go`) and there is no cron path to them. The warning is repeated in the job's own doc comment.

## Concurrency

Both jobs walk `store.ListBookIDs()` — never `GetAllBooksFrom`, whose memdb fast path silently caps a page at 2× the requested limit and can miss books (a missed book here is a listening position quietly not migrated) — and drive per-book work through `registry.RunItems` with `Concurrency: runtime.NumCPU()` and `ErrMode: ErrModeCollect`.

A bare `for range books` loop of exactly this shape is what took a `dedup.full-scan` run silent for 3+ hours at 100% CPU on a single core on 2026-07-05. `RunItemsOptions.Concurrency` treats **both 0 and 1** as sequential, so the value is a named function (`BackfillConcurrency()`) that a test asserts is `> 1` — guarding against a future edit silently reverting to the zero-value default. Per-book work partitions cleanly by book ID (two workers can never touch the same `(user, book)` rows), so no extra locking is needed; that's stated in a comment.

## Files

**6 new files, 0 modified.** No shared file was edited — not `internal/operations/registry/register.go`, not `internal/database/store.go`, no `pebble_store_*.go`, nothing under `internal/syncapi/**`, `internal/server/**`, `internal/scanner/**`, `internal/merge/**`, and no `go.mod`/`go.sum` change. Registration works purely via `init()` + `maintenance.Register`, because `internal/server/server.go:38` already blank-imports the `jobs` package.

- `internal/maintenance/jobs/abs_backfill_reporter.go` — `absBackfillReporter` (`maintenance.ProgressReporter` → `registry.Reporter`, modeled on `embedding_backfill.go`'s adapter) + `BackfillConcurrency()`. Task-unique name on purpose: several agents add helpers to this package in parallel, and a generically-named shared helper is a known post-merge collision source here.
- `internal/maintenance/jobs/backfill_sync_ids.go` + `_test.go`
- `internal/maintenance/jobs/backfill_itunes_positions.go` + `_test.go`
- `changelog.d/20260730_abs_sync_backfills.md`

## Verification — real output

```
$ go test ./internal/maintenance/... -race -count=1
ok  	github.com/falkcorp/audiobook-organizer/internal/maintenance	1.310s
ok  	github.com/falkcorp/audiobook-organizer/internal/maintenance/jobs	11.065s

$ go vet ./...
(no output — clean)

$ go build ./...
(no output — clean)

$ gofmt -l <the 5 touched .go files>
(no output — clean)

$ go test ./internal/server/ -short -count=1 -run 'Maintenance|Jobs'
ok  	github.com/falkcorp/audiobook-organizer/internal/server	5.987s
```

**30/30 new tests passing**, TDD throughout (each suite was run red on an undefined symbol before implementation):

- **Job 1 — 7:** registered/metadata, fresh library (36-char UUID syncIDs + a syncFileID per file), byte-identical re-run, pre-existing IDs not re-minted, dry-run mints nothing, `-race` over 50 books with exactly one `sync_file` per file, `Concurrency > 1` guard.
- **Job 2 — 23:** ms→float-seconds, fraction is 0.0–1.0 and clamped, finished within the 2 s tolerance (and *not* finished 3 s short), exact ms-epoch `lastUpdate`, nil bookmark writes nothing, zero/negative bookmark writes nothing, **never rewinds a newer position**, still advances when iTunes is further, respects `StatusManual`, dry-run writes nothing, re-run is a no-op (proven via the store's own `time.Now()` write stamp being unchanged), drifted state repaired on re-run, 5 user-resolution cases incl. unknown-override-is-an-error and no-users-is-an-error, position migrates without a duration, exact-count reporting, and 3 courtesy-bookmark cases.

## Counts

**COMPLETED: 2 — `backfill-sync-ids`, `backfill-itunes-positions` (30/30 tests passing, vet/build/gofmt clean)**
**REMAINING: 0**
**BLOCKED: 0**

Runtime counts the jobs themselves report, per the repo's status convention: job 1 logs `books N minted / M already had one, files N minted / M already had one, K failures`; job 2 logs `migrated=N no_bookmark=N not_accepted=N unchanged=N missing_book=N failed=N no_duration=N bookmarks=N of N books`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt
