### PR TITLE
feat(abs): serve real mediaProgress + bookmarks on /api/me (ABS Phase 6)

### DIFF
--- a/changelog.d/20260730_213000_abs-sync-userdata-provider.md
+++ b/changelog.d/20260730_213000_abs-sync-userdata-provider.md
@@ -1,0 +1,32 @@
+<!-- file: changelog.d/20260730_213000_abs-sync-userdata-provider.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0595c914-c060-4e4c-8a35-263b9852403e -->
+<!-- last-edited: 2026-07-30 -->
+
+### Added
+
+- **Audiobookshelf user progress + bookmarks (Phase 6).** `GET /api/me`, `POST
+  /login` and `POST /auth/refresh` now serve the user's real `mediaProgress[]`
+  and `bookmarks[]` instead of empty arrays. New
+  `internal/server/handlers/abs/userdata.go` implements the `UserDataProvider`
+  interface over the existing listening-progress and named-bookmark keyspaces,
+  and `wireABSRoutes` wires it (the startup warning about a missing provider is
+  gone).
+
+  This closes the last blocker before an ABS client can resume a book where it
+  left off. It is also the endpoint that can destroy data if it under-reports:
+  AudioBooth deletes every local progress row absent from the server's list, so
+  the list is built complete or not at all -- a read failure anywhere returns an
+  error (rendered as 5xx) and the partially-built list is discarded, never
+  served. `libraryItemId` is the 36-char sync UUID (a raw Book ULID
+  mis-truncates at the client's fixed byte offset of 36), `lastUpdate` is an
+  integer millisecond epoch taken from `UserBookState.LastActivityAt`,
+  `duration` is always present (`isFinished` with a zero duration zeroes the
+  client's saved position, so it is cleared instead), `progress` is a 0.0-1.0
+  fraction derived from `currentTime/duration` rather than the store's lossy
+  integer percent, and `isFinished` uses the 2-second tolerance so a
+  fully-listened book does not sit at 99% forever.
+
+  Both lists are built from user-keyed prefix scans, so the cost is proportional
+  to the books that user has touched rather than to the library; the per-book
+  follow-up reads run in a bounded worker pool.

--- a/internal/server/handlers/abs/userdata.go
+++ b/internal/server/handlers/abs/userdata.go
@@ -1,0 +1,470 @@
+// file: internal/server/handlers/abs/userdata.go
+// version: 1.0.0
+// guid: 63289143-7fae-47b5-9ed9-888ac3c2034a
+// last-edited: 2026-07-30
+
+package abs
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+	"golang.org/x/sync/errgroup"
+)
+
+// This file implements UserDataProvider (see handler.go) — the `mediaProgress[]`
+// and `bookmarks[]` arrays carried by GET /api/me, POST /login and
+// POST /auth/refresh.
+//
+// 🔴 READ THIS BEFORE CHANGING ANYTHING HERE.
+// §1.8.1: AudioBooth's MediaProgress.syncFromAPI walks the device's LOCAL progress
+// rows and DELETES every one whose bookID is absent from the server's list, sparing
+// only the currently-playing book. Three consequences shape every decision below:
+//
+//  1. The list must be COMPLETE. There is no pagination, no limit, no "skip the
+//     awkward row" path. Anything we omit, the client destroys.
+//  2. A partial read must become an ERROR, never a short list. Every helper here
+//     propagates its error up through MediaProgress, which returns a nil slice
+//     alongside it so a caller physically cannot serve a truncated body; the
+//     handler turns that into a 5xx (me.go). A retry costs nothing.
+//  3. When a single field cannot be produced safely we DEGRADE THE FIELD, never
+//     drop the row — see the isFinished clamp in progressRow.
+//
+// Cost: this payload is rebuilt on every login and every home-screen refresh, so
+// nothing here may scan the library. The enumeration primitives are both
+// USER-KEYED prefix scans (ListUserPositionsSince over "upos:<userID>:" and
+// ListBookmarksForUser over "bookmark:<userID>:"), so the work is proportional to
+// the books THIS USER has touched, not to the 40,000-book library. The per-book
+// follow-up reads then run in a bounded worker pool (CLAUDE.md's concurrency
+// rule).
+
+// ProgressListStore is the enumeration + state slice of the listening-progress
+// keyspace this provider needs. It is deliberately separate from ProgressStore
+// (handler.go), which is the per-book read/write slice the play path uses.
+//
+// ListUserPositionsSince is the load-bearing method: it prefix-scans
+// "upos:<userID>:" across ALL books, which is what makes a complete list
+// affordable on a request path. There is no whole-library iteration anywhere in
+// this file, and there must never be one.
+type ProgressListStore interface {
+	ListUserPositionsSince(userID string, since time.Time) ([]database.UserPosition, error)
+	GetUserBookState(userID, bookID string) (*database.UserBookState, error)
+}
+
+// BookmarkListStore is the named-bookmark slice. ListBookmarksForUser exists
+// specifically so this response can be built with one scan
+// (pebble_store_bookmarks.go).
+type BookmarkListStore interface {
+	ListBookmarksForUser(userID string) ([]progress.Bookmark, error)
+}
+
+// SyncIDStore resolves a Book ULID to its durable, client-visible 36-char sync
+// UUID. GetSyncIDForBook is the read path; MintOrGetSyncID is the fallback for a
+// book that has progress but no sync_item yet — see syncIDFor for why minting on
+// a read path is the correct trade.
+type SyncIDStore interface {
+	GetSyncIDForBook(bookID string) (string, bool, error)
+	MintOrGetSyncID(bookID string) (string, error)
+}
+
+// UserDataLibraryStore is the two-method duration slice. LibraryStore already
+// satisfies it structurally, so the caller passes the same value.
+type UserDataLibraryStore interface {
+	GetBookByID(id string) (*database.Book, error)
+	GetBookFiles(bookID string) ([]database.BookFile, error)
+}
+
+// UserDataOptions are the provider's dependencies. Every one is REQUIRED:
+// NewUserData refuses to build without any of them, because a provider missing a
+// dependency would answer an empty list where records exist, and an empty list is
+// only safe when it is genuinely the complete list.
+type UserDataOptions struct {
+	Progress  ProgressListStore
+	Bookmarks BookmarkListStore
+	Identity  SyncIDStore
+	Library   UserDataLibraryStore
+
+	// Concurrency bounds the per-book follow-up reads. Zero means
+	// runtime.NumCPU(). Never unbounded: the collection is user-scoped but a
+	// heavy listener can still have thousands of rows.
+	Concurrency int
+}
+
+// bookmarkDTO is one ABS named bookmark, matching the oracle capture in
+// testdata/abs-fixtures/get_api_me.json exactly: four fields, no id, no userId,
+// no updatedAt.
+//
+// Time is SECONDS as a JSON number (int or float both encode as a number, which
+// is what clients accept — AudioBooth sends an Int on some paths and a Double on
+// others). CreatedAt is an integer ms epoch like every other date on this
+// surface (§1.7.3 item 5).
+type bookmarkDTO struct {
+	CreatedAt     int64   `json:"createdAt"`
+	LibraryItemID string  `json:"libraryItemId"`
+	Time          float64 `json:"time"`
+	Title         string  `json:"title"`
+}
+
+type userDataProvider struct {
+	progress    ProgressListStore
+	bookmarks   BookmarkListStore
+	identity    SyncIDStore
+	library     UserDataLibraryStore
+	concurrency int
+}
+
+var _ UserDataProvider = (*userDataProvider)(nil)
+
+// NewUserData builds the Phase 6 progress/bookmark provider.
+//
+// It returns an error rather than a degraded provider when a dependency is
+// missing. The caller (wireABSRoutes) exits on that error: booting with a
+// provider that reports an empty mediaProgress while the store holds real
+// records would delete the owner's listening positions on the next home-screen
+// refresh, which is strictly worse than not booting.
+func NewUserData(o UserDataOptions) (UserDataProvider, error) {
+	if o.Progress == nil {
+		return nil, errors.New("abs: userdata: a progress store is required (an empty list deletes the user's positions)")
+	}
+	if o.Bookmarks == nil {
+		return nil, errors.New("abs: userdata: a bookmark store is required (an empty list deletes the user's bookmarks)")
+	}
+	if o.Identity == nil {
+		return nil, errors.New("abs: userdata: a sync-identity store is required (libraryItemId must be the 36-char sync UUID)")
+	}
+	if o.Library == nil {
+		return nil, errors.New("abs: userdata: a library store is required (isFinished with a zero duration zeroes the client's position)")
+	}
+	limit := o.Concurrency
+	if limit <= 0 {
+		limit = runtime.NumCPU()
+	}
+	return &userDataProvider{
+		progress:    o.Progress,
+		bookmarks:   o.Bookmarks,
+		identity:    o.Identity,
+		library:     o.Library,
+		concurrency: limit,
+	}, nil
+}
+
+// MediaProgress returns the user's COMPLETE progress list, or an error.
+//
+// Shape of the work:
+//
+//  1. ONE user-keyed prefix scan enumerates every stored position row. The
+//     "since" argument is the zero time, i.e. "since the beginning of time" —
+//     the store filters with UpdatedAt.After(since), so the zero value keeps
+//     every row. Passing anything else here would silently truncate the list.
+//  2. Rows collapse to one per book. The UserPosition keyspace is per
+//     (user, book, SEGMENT) because the app's own reader tracks a position per
+//     segment; ABS has exactly one whole-book position per item.
+//  3. The per-book follow-ups (sync id, duration, derived state) run in a bounded
+//     pool, writing into a pre-sized slice by index so concurrency cannot reorder
+//     or short the list.
+func (p *userDataProvider) MediaProgress(userID string) ([]any, error) {
+	if userID == "" {
+		// An empty id would prefix-scan "upos::" and answer a confidently wrong
+		// list for nobody. Refuse.
+		return nil, errors.New("abs: userdata: userID is required")
+	}
+
+	positions, err := p.progress.ListUserPositionsSince(userID, time.Time{})
+	if err != nil {
+		return nil, fmt.Errorf("abs: userdata: list positions for user %s: %w", userID, err)
+	}
+
+	latest := make(map[string]database.UserPosition, len(positions))
+	for _, pos := range positions {
+		if pos.BookID == "" {
+			// A row with no book cannot be named with a libraryItemId, so no client
+			// can have it either — skipping it drops nothing the client could
+			// delete. Logged because it means a corrupt write happened somewhere.
+			slog.Warn("abs: userdata: skipping a stored position with no book id", "user_id", userID, "segment_id", pos.SegmentID)
+			continue
+		}
+		cur, seen := latest[pos.BookID]
+		if !seen || betterPosition(pos, cur) {
+			latest[pos.BookID] = pos
+		}
+	}
+	if len(latest) == 0 {
+		// Non-nil: `mediaProgress` must marshal as [] and never as null.
+		return []any{}, nil
+	}
+
+	bookIDs := make([]string, 0, len(latest))
+	for id := range latest {
+		bookIDs = append(bookIDs, id)
+	}
+	// Sorted so the body is byte-stable across refreshes rather than reshuffling
+	// with Go's map iteration order.
+	sort.Strings(bookIDs)
+
+	rows := make([]any, len(bookIDs))
+	g := new(errgroup.Group)
+	g.SetLimit(p.concurrency)
+	for i := range bookIDs {
+		i := i
+		g.Go(func() error {
+			row, err := p.progressRow(userID, latest[bookIDs[i]])
+			if err != nil {
+				return err
+			}
+			rows[i] = row
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		// The partially-filled slice is DISCARDED on purpose. Handing it back would
+		// let a caller serve a 200 with holes in it, and every hole is a book whose
+		// progress the client then deletes (§1.8.1).
+		return nil, err
+	}
+	return rows, nil
+}
+
+// betterPosition decides which of two position rows for the SAME book wins.
+//
+// Newest write wins, and a timestamp TIE resolves to the further position rather
+// than to whichever row the iterator happened to reach first. That tie-break is
+// deliberately forward-only: rewinding the listener is the failure this whole
+// surface exists to prevent, and the resulting position can only ever be >= the
+// one GetUserPosition (pebble_store_playback.go) picks for the same book, so
+// /api/items and /api/me can never disagree in the direction that loses a place
+// in a book.
+func betterPosition(candidate, current database.UserPosition) bool {
+	if candidate.UpdatedAt.After(current.UpdatedAt) {
+		return true
+	}
+	if current.UpdatedAt.After(candidate.UpdatedAt) {
+		return false
+	}
+	return candidate.PositionSeconds > current.PositionSeconds
+}
+
+// progressRow renders one mediaProgress entry.
+//
+// Every field is a verified client requirement, not a nicety — the field-by-field
+// reasoning is in item.go's mediaProgress (the /api/items/:id twin), and the two
+// must stay consistent because a client compares them for the same book. In
+// short: lastUpdate is an integer ms epoch (omit it and the server loses every
+// future conflict, because clients compare it against their own wall clock and
+// ties go to local); duration is always emitted alongside isFinished; progress is
+// a 0.0–1.0 FRACTION, never a percentage.
+func (p *userDataProvider) progressRow(userID string, pos database.UserPosition) (mediaProgressDTO, error) {
+	syncID, err := p.syncIDFor(pos.BookID)
+	if err != nil {
+		return mediaProgressDTO{}, err
+	}
+	duration, err := p.durationFor(pos.BookID)
+	if err != nil {
+		return mediaProgressDTO{}, err
+	}
+	state, err := p.progress.GetUserBookState(userID, pos.BookID)
+	if err != nil {
+		return mediaProgressDTO{}, fmt.Errorf("abs: userdata: load book state for %s/%s: %w", userID, pos.BookID, err)
+	}
+
+	// §5b's >=2s tolerance, never a tight compare: a book's three legitimate
+	// durations disagree by ~52ms (container vs chapter marks vs track sum), so an
+	// exact comparison leaves a fully-listened book stuck at 99% forever.
+	finished := progress.IsWithinFinishedTolerance(pos.PositionSeconds, duration)
+	if state != nil && state.Status == database.UserBookStatusFinished {
+		finished = true
+	}
+
+	fraction := 0.0
+	if duration > 0 {
+		fraction = pos.PositionSeconds / duration
+		if fraction > 1 || finished {
+			// A finished book reads 1.0 exactly. Reporting 0.99998 next to
+			// isFinished:true is the "sits at 99% forever" symptom of §5b showing up
+			// in the progress bar instead of in the finished flag.
+			fraction = 1
+		}
+	}
+
+	lastUpdate := lastUpdateMs(pos, state)
+	row := mediaProgressDTO{
+		CurrentTime: pos.PositionSeconds,
+		Duration:    duration,
+		// ebook fields: this surface serves audiobooks only. Null/zero, never absent.
+		EbookProgress:             0,
+		HideFromContinueListening: false,
+		// Derived from (user, item) rather than random so a client that stores the id
+		// keeps matching the same row across restarts. Same formula as item.go.
+		ID:            userID + "-" + syncID,
+		IsFinished:    finished,
+		LastUpdate:    lastUpdate,
+		LibraryItemID: syncID,
+		MediaItemID:   syncID,
+		MediaItemType: "book",
+		Progress:      fraction,
+		StartedAt:     lastUpdate,
+		UserID:        userID,
+	}
+	if finished {
+		at := lastUpdate
+		row.FinishedAt = &at
+	}
+
+	// §1.8.7's null-duration trap: `isFinished:true` with a zero duration sets the
+	// client's currentTime to 0 — it DESTROYS the very position this row exists to
+	// report. When we cannot prove a duration (a fileless book, a book whose row is
+	// gone), the safe answer is to clear isFinished and keep the position, NOT to
+	// drop the row: dropping it is what makes the client delete its own copy.
+	if err := progress.ValidateFinishedDuration(progress.Progress{
+		CurrentTime: row.CurrentTime, Duration: row.Duration,
+		IsFinished: row.IsFinished, UpdatedAtMs: row.LastUpdate,
+	}); err != nil {
+		slog.Warn("abs: userdata: clearing isFinished for a book with no known duration — "+
+			"reporting it would zero the client's saved position",
+			"user_id", userID, "book_id", pos.BookID, "library_item_id", syncID, "err", err)
+		row.IsFinished = false
+		row.FinishedAt = nil
+		row.Progress = 0
+	}
+	return row, nil
+}
+
+// lastUpdateMs picks the millisecond epoch clients conflict-resolve against.
+//
+// §1.7.3 item 1 makes this the single highest-value field in the protocol: omit
+// it (or emit a 0) and the server permanently loses every conflict, because
+// AudioBooth compares it against its own wall clock — truncating BOTH sides via
+// integer /1000 and comparing with strict > — so a tie goes to the client's
+// cached value.
+//
+// UserBookState.LastActivityAt is the authoritative source: UserPosition.UpdatedAt
+// is stamped time.Now() by the store on every write and so cannot carry a
+// caller-supplied timestamp. The fallbacks exist only so a row written before its
+// state existed still gets a usable value instead of a 0; a 0 would hand every
+// future conflict to the client, which at least keeps the client's own position
+// rather than losing it.
+func lastUpdateMs(pos database.UserPosition, state *database.UserBookState) int64 {
+	if state != nil {
+		if ms := msEpoch(state.LastActivityAt); ms > 0 {
+			return ms
+		}
+		if ms := msEpoch(state.UpdatedAt); ms > 0 {
+			return ms
+		}
+	}
+	return msEpoch(pos.UpdatedAt)
+}
+
+// syncIDFor resolves the client-visible 36-char sync UUID for a book.
+//
+// 🔴 libraryItemId MUST be the sync UUID and never the raw 26-char Book ULID:
+// Absorb splits compound ids by FIXED BYTE OFFSET substring(0,36) at 4+ call
+// sites (§1.7.1), so a ULID mis-truncates into the wrong /api/me/progress path.
+//
+// A book with progress but no sync_item yet is MINTED here rather than skipped.
+// Minting is a write on a read path, which is not free — but the alternative is
+// omitting a row the client holds, and the client deletes what we omit. The mint
+// is idempotent, happens at most once per book ever, and after the identity
+// backfill it happens for nothing at all.
+func (p *userDataProvider) syncIDFor(bookID string) (string, error) {
+	id, ok, err := p.identity.GetSyncIDForBook(bookID)
+	if err != nil {
+		return "", fmt.Errorf("abs: userdata: resolve sync id for book %s: %w", bookID, err)
+	}
+	if ok && id != "" {
+		return id, nil
+	}
+	id, err = p.identity.MintOrGetSyncID(bookID)
+	if err != nil {
+		return "", fmt.Errorf("abs: userdata: mint sync id for book %s: %w", bookID, err)
+	}
+	if id == "" {
+		return "", fmt.Errorf("abs: userdata: minted an empty sync id for book %s", bookID)
+	}
+	return id, nil
+}
+
+// durationFor returns the book's authoritative duration in seconds.
+//
+// §5b requires ONE duration per book used consistently across media.duration, the
+// play session and the progress math, because the three legitimate sources
+// disagree by ~52ms and mixing them leaves a finished book stuck at 99%. This
+// reproduces the mapper's rule exactly (loadOneItemView in mapper.go): the sum of
+// the per-file durations, with Book.Duration used ONLY for a book that has no
+// BookFile rows at all. Do not "improve" one of the two in isolation.
+//
+// A book that resolves to nothing at all returns 0, which is honest: 0 makes
+// IsWithinFinishedTolerance false, so no row can claim isFinished without a
+// duration to back it.
+func (p *userDataProvider) durationFor(bookID string) (float64, error) {
+	files, err := p.library.GetBookFiles(bookID)
+	if err != nil {
+		return 0, fmt.Errorf("abs: userdata: load files for book %s: %w", bookID, err)
+	}
+	if len(files) > 0 {
+		total := 0.0
+		for i := range files {
+			total += float64(files[i].Duration)
+		}
+		return total, nil
+	}
+	book, err := p.library.GetBookByID(bookID)
+	if err != nil {
+		return 0, fmt.Errorf("abs: userdata: load book %s: %w", bookID, err)
+	}
+	if book != nil && book.Duration != nil {
+		return float64(*book.Duration), nil
+	}
+	return 0, nil
+}
+
+// Bookmarks returns the user's COMPLETE bookmark list, or an error.
+//
+// One user-keyed prefix scan, no per-item work, no library access — which is why
+// ListBookmarksForUser exists. Same error discipline as MediaProgress: a read
+// failure is an error, never a short list.
+func (p *userDataProvider) Bookmarks(userID string) ([]any, error) {
+	if userID == "" {
+		return nil, errors.New("abs: userdata: userID is required")
+	}
+	stored, err := p.bookmarks.ListBookmarksForUser(userID)
+	if err != nil {
+		return nil, fmt.Errorf("abs: userdata: list bookmarks for user %s: %w", userID, err)
+	}
+
+	out := make([]any, 0, len(stored))
+	for _, b := range stored {
+		if b.ItemID == "" {
+			// Unnameable, exactly like a position row with no book: no client can
+			// hold it, so skipping it deletes nothing.
+			slog.Warn("abs: userdata: skipping a stored bookmark with no item id", "user_id", userID, "time_sec", b.TimeSec)
+			continue
+		}
+		// ItemID is ALREADY the client-visible libraryItemId — the bookmark keyspace
+		// is keyed by (userID, libraryItemId, time), mirroring real ABS, whose
+		// create/delete surface addresses a bookmark by the item id and the time
+		// value in the URL path. It is not translated here.
+		out = append(out, bookmarkDTO{
+			CreatedAt:     b.CreatedAt,
+			LibraryItemID: b.ItemID,
+			Time:          b.TimeSec,
+			Title:         b.Title,
+		})
+	}
+	// Deterministic ordering (item, then time) so the body is byte-stable across
+	// refreshes: the store's scan order is already sorted per item, but the slice
+	// crosses items and a client that diffs bodies should see no churn.
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i].(bookmarkDTO), out[j].(bookmarkDTO)
+		if a.LibraryItemID != b.LibraryItemID {
+			return a.LibraryItemID < b.LibraryItemID
+		}
+		return a.Time < b.Time
+	})
+	return out, nil
+}

--- a/internal/server/handlers/abs/userdata_test.go
+++ b/internal/server/handlers/abs/userdata_test.go
@@ -1,0 +1,942 @@
+// file: internal/server/handlers/abs/userdata_test.go
+// version: 1.0.0
+// guid: 7ac71a7b-e1cb-4416-a393-1fa38af8871f
+// last-edited: 2026-07-30
+
+package abs_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	abshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+// ── fake stores ─────────────────────────────────────────────────────────────
+//
+// Deliberately named with a `ud` prefix rather than reusing fakeLibrary: this
+// provider needs the two ENUMERATION primitives (ListUserPositionsSince,
+// ListBookmarksForUser) that the browse fake has no reason to hold, and a
+// uniquely-named helper cannot collide with a sibling worktree adding another
+// helper to this same package.
+type udFake struct {
+	mu sync.Mutex
+
+	positions []database.UserPosition
+	states    map[string]*database.UserBookState
+	bookmarks []progress.Bookmark
+	books     map[string]*database.Book
+	files     map[string][]database.BookFile
+	syncIDs   map[string]string
+
+	positionsErr error
+	bookmarksErr error
+	stateErr     map[string]error
+	filesErr     map[string]error
+	syncErr      map[string]error
+
+	mints int
+}
+
+func newUDFake() *udFake {
+	return &udFake{
+		states:   map[string]*database.UserBookState{},
+		books:    map[string]*database.Book{},
+		files:    map[string][]database.BookFile{},
+		syncIDs:  map[string]string{},
+		stateErr: map[string]error{},
+		filesErr: map[string]error{},
+		syncErr:  map[string]error{},
+	}
+}
+
+// udSyncID mints a 36-char canonical-UUID-shaped id, the same shape the real
+// sync_item keyspace mints. A fake that handed back a 26-char Book ULID would
+// let the §1.7.1 fixed-offset regression through unnoticed.
+func udSyncID(n int) string {
+	return fmt.Sprintf("%08d-0000-4000-8000-%012d", n, n)
+}
+
+// addBook seeds a book with one BookFile per supplied track duration (seconds).
+// With no tracks the book carries only its own Book.Duration fallback.
+func (f *udFake) addBook(bookID string, bookDuration *int, trackDurations ...int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.books[bookID] = &database.Book{ID: bookID, Title: "book " + bookID, Duration: bookDuration}
+	for i, d := range trackDurations {
+		f.files[bookID] = append(f.files[bookID], database.BookFile{
+			ID: fmt.Sprintf("%s-f%d", bookID, i), BookID: bookID,
+			FilePath: fmt.Sprintf("/lib/%s/%02d.m4b", bookID, i),
+			Duration: d, TrackNumber: i + 1,
+		})
+	}
+}
+
+func (f *udFake) presetSyncID(bookID, syncID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.syncIDs[bookID] = syncID
+}
+
+func (f *udFake) addPosition(userID, bookID, segment string, seconds float64, at time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.positions = append(f.positions, database.UserPosition{
+		UserID: userID, BookID: bookID, SegmentID: segment,
+		PositionSeconds: seconds, UpdatedAt: at,
+	})
+}
+
+func (f *udFake) setState(s *database.UserBookState) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.states[s.UserID+"|"+s.BookID] = s
+}
+
+func (f *udFake) addBookmark(b progress.Bookmark) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bookmarks = append(f.bookmarks, b)
+}
+
+// ── ProgressListStore ───────────────────────────────────────────────────────
+
+func (f *udFake) ListUserPositionsSince(userID string, since time.Time) ([]database.UserPosition, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.positionsErr != nil {
+		return nil, f.positionsErr
+	}
+	var out []database.UserPosition
+	for _, p := range f.positions {
+		// Mirrors the real store's filter exactly, so a provider that passed a
+		// non-zero "since" would visibly drop rows here.
+		if p.UserID == userID && p.UpdatedAt.After(since) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func (f *udFake) GetUserBookState(userID, bookID string) (*database.UserBookState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.stateErr[bookID]; err != nil {
+		return nil, err
+	}
+	return f.states[userID+"|"+bookID], nil
+}
+
+// ── BookmarkListStore ───────────────────────────────────────────────────────
+
+func (f *udFake) ListBookmarksForUser(userID string) ([]progress.Bookmark, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.bookmarksErr != nil {
+		return nil, f.bookmarksErr
+	}
+	var out []progress.Bookmark
+	for _, b := range f.bookmarks {
+		if b.UserID == userID {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+// ── SyncIDStore ─────────────────────────────────────────────────────────────
+
+func (f *udFake) GetSyncIDForBook(bookID string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.syncErr[bookID]; err != nil {
+		return "", false, err
+	}
+	id, ok := f.syncIDs[bookID]
+	return id, ok, nil
+}
+
+func (f *udFake) MintOrGetSyncID(bookID string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.syncErr[bookID]; err != nil {
+		return "", err
+	}
+	if id, ok := f.syncIDs[bookID]; ok {
+		return id, nil
+	}
+	f.mints++
+	id := udSyncID(f.mints)
+	f.syncIDs[bookID] = id
+	return id, nil
+}
+
+// ── UserDataLibraryStore ────────────────────────────────────────────────────
+
+func (f *udFake) GetBookByID(id string) (*database.Book, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.books[id], nil
+}
+
+func (f *udFake) GetBookFiles(bookID string) ([]database.BookFile, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.filesErr[bookID]; err != nil {
+		return nil, err
+	}
+	return f.files[bookID], nil
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func udProvider(t *testing.T, f *udFake) abshandler.UserDataProvider {
+	t.Helper()
+	p, err := abshandler.NewUserData(abshandler.UserDataOptions{
+		Progress:  f,
+		Bookmarks: f,
+		Identity:  f,
+		Library:   f,
+	})
+	if err != nil {
+		t.Fatalf("NewUserData: %v", err)
+	}
+	return p
+}
+
+// udRows re-encodes the provider's rows through JSON, because the JSON wire shape
+// IS the contract: a Swift/Dart decoder never sees the Go struct. Numbers come
+// back as json.Number so a test can assert "integer ms epoch" rather than merely
+// "some number".
+func udRows(t *testing.T, rows []any) []map[string]json.Number {
+	t.Helper()
+	out := make([]map[string]json.Number, 0, len(rows))
+	for _, row := range rows {
+		raw, err := json.Marshal(row)
+		if err != nil {
+			t.Fatalf("marshal row: %v", err)
+		}
+		var generic map[string]any
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.UseNumber()
+		if err := dec.Decode(&generic); err != nil {
+			t.Fatalf("decode row: %v", err)
+		}
+		typed := map[string]json.Number{}
+		for k, v := range generic {
+			if n, ok := v.(json.Number); ok {
+				typed[k] = n
+			}
+		}
+		// Keep the non-numeric fields reachable too by stashing them as strings.
+		for k, v := range generic {
+			if _, ok := v.(json.Number); ok {
+				continue
+			}
+			switch tv := v.(type) {
+			case string:
+				typed["str:"+k] = json.Number(tv)
+			case bool:
+				typed["bool:"+k] = json.Number(fmt.Sprintf("%t", tv))
+			case nil:
+				typed["null:"+k] = "null"
+			}
+		}
+		out = append(out, typed)
+	}
+	return out
+}
+
+func udFloat(t *testing.T, row map[string]json.Number, key string) float64 {
+	t.Helper()
+	n, ok := row[key]
+	if !ok {
+		t.Fatalf("field %q missing or not a JSON number: %v", key, row)
+	}
+	v, err := n.Float64()
+	if err != nil {
+		t.Fatalf("field %q is not numeric (%q): %v", key, n, err)
+	}
+	return v
+}
+
+func udInt(t *testing.T, row map[string]json.Number, key string) int64 {
+	t.Helper()
+	n, ok := row[key]
+	if !ok {
+		t.Fatalf("field %q missing or not a JSON number: %v", key, row)
+	}
+	// An integer ms epoch must be encoded as an integer literal: AudioBooth decodes
+	// dates as Int64 and Dart throws on `42.0 as int?` (§1.7.3 item 5).
+	if strings.ContainsAny(string(n), ".eE") {
+		t.Fatalf("field %q must be an INTEGER ms epoch, got the literal %q", key, n)
+	}
+	v, err := n.Int64()
+	if err != nil {
+		t.Fatalf("field %q is not an integer (%q): %v", key, n, err)
+	}
+	return v
+}
+
+func udStr(t *testing.T, row map[string]json.Number, key string) string {
+	t.Helper()
+	v, ok := row["str:"+key]
+	if !ok {
+		t.Fatalf("field %q missing or not a JSON string: %v", key, row)
+	}
+	return string(v)
+}
+
+func udBool(t *testing.T, row map[string]json.Number, key string) bool {
+	t.Helper()
+	v, ok := row["bool:"+key]
+	if !ok {
+		t.Fatalf("field %q missing or not a JSON boolean: %v", key, row)
+	}
+	return v == "true"
+}
+
+func udRowByItem(t *testing.T, rows []map[string]json.Number, libraryItemID string) map[string]json.Number {
+	t.Helper()
+	for _, r := range rows {
+		if udStr(t, r, "libraryItemId") == libraryItemID {
+			return r
+		}
+	}
+	t.Fatalf("no row for libraryItemId %q in %v", libraryItemID, rows)
+	return nil
+}
+
+// ── constructor ─────────────────────────────────────────────────────────────
+
+// TestUserDataProviderRefusesMissingDependencies: every dependency is required.
+// A provider built without one would answer an EMPTY list where records exist,
+// and AudioBooth deletes every local progress row absent from that list (§1.8.1).
+// Refusing to build is the only safe outcome; the caller exits on the error.
+func TestUserDataProviderRefusesMissingDependencies(t *testing.T) {
+	f := newUDFake()
+	full := abshandler.UserDataOptions{Progress: f, Bookmarks: f, Identity: f, Library: f}
+
+	cases := map[string]func(o *abshandler.UserDataOptions){
+		"progress":  func(o *abshandler.UserDataOptions) { o.Progress = nil },
+		"bookmarks": func(o *abshandler.UserDataOptions) { o.Bookmarks = nil },
+		"identity":  func(o *abshandler.UserDataOptions) { o.Identity = nil },
+		"library":   func(o *abshandler.UserDataOptions) { o.Library = nil },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			o := full
+			mutate(&o)
+			if _, err := abshandler.NewUserData(o); err == nil {
+				t.Fatalf("NewUserData succeeded with a nil %s — it would serve an empty list and destroy progress", name)
+			}
+		})
+	}
+	if _, err := abshandler.NewUserData(full); err != nil {
+		t.Fatalf("NewUserData with every dependency: %v", err)
+	}
+}
+
+// ── mediaProgress: completeness ─────────────────────────────────────────────
+
+// TestUserDataMediaProgressIsComplete is the §1.8.1 data-loss guard at the
+// provider level: every book the user has a position for must appear, with no
+// pagination and no cap.
+func TestUserDataMediaProgressIsComplete(t *testing.T) {
+	f := newUDFake()
+	const n = 120
+	base := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		bookID := fmt.Sprintf("bk%03d", i)
+		f.addBook(bookID, nil, 1800, 1800)
+		f.presetSyncID(bookID, udSyncID(1000+i))
+		f.addPosition("u1", bookID, "abs", float64(60+i), base.Add(time.Duration(i)*time.Minute))
+	}
+	// A second user's rows must never leak into u1's list.
+	f.addBook("other", nil, 100)
+	f.addPosition("u2", "other", "abs", 50, base)
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != n {
+		t.Fatalf("got %d rows want %d — a truncated list DELETES the user's positions", len(rows), n)
+	}
+	decoded := udRows(t, rows)
+	seen := map[string]bool{}
+	for i := range decoded {
+		seen[udStr(t, decoded[i], "libraryItemId")] = true
+	}
+	for i := 0; i < n; i++ {
+		if !seen[udSyncID(1000+i)] {
+			t.Fatalf("book bk%03d is missing from the list", i)
+		}
+	}
+	if seen[udSyncID(9999)] {
+		t.Fatal("another user's row leaked into the list")
+	}
+}
+
+// TestUserDataMediaProgressEmptyIsEmptyNotNil: a user with no records gets a
+// non-nil empty slice, which /api/me renders as `[]` rather than `null`.
+func TestUserDataMediaProgressEmptyIsEmptyNotNil(t *testing.T) {
+	rows, err := udProvider(t, newUDFake()).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if rows == nil {
+		t.Fatal("rows must be a non-nil empty slice")
+	}
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows want 0", len(rows))
+	}
+}
+
+// ── mediaProgress: partial failure MUST be an error ─────────────────────────
+
+// TestUserDataMediaProgressPartialFailureIsAnError is the single most important
+// test in this file. When one book's data cannot be read, the provider must
+// return an ERROR (so /api/me answers 5xx) and NOT the rows it did manage to
+// build. A truncated 200 makes the client delete the missing books' progress.
+func TestUserDataMediaProgressPartialFailureIsAnError(t *testing.T) {
+	base := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	seed := func() *udFake {
+		f := newUDFake()
+		for i, id := range []string{"good1", "bad", "good2"} {
+			f.addBook(id, nil, 3600)
+			f.presetSyncID(id, udSyncID(10+i))
+			f.addPosition("u1", id, "abs", float64(100+i), base)
+		}
+		return f
+	}
+
+	cases := map[string]func(f *udFake){
+		"book files unreadable": func(f *udFake) { f.filesErr["bad"] = errors.New("pebble: files down") },
+		"sync identity failure": func(f *udFake) { f.syncErr["bad"] = errors.New("pebble: sync_item down") },
+		"book state unreadable": func(f *udFake) { f.stateErr["bad"] = errors.New("pebble: ubs down") },
+		"position scan failure": func(f *udFake) { f.positionsErr = errors.New("pebble: iterator failed") },
+	}
+	for name, breakIt := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := seed()
+			breakIt(f)
+			rows, err := udProvider(t, f).MediaProgress("u1")
+			if err == nil {
+				t.Fatalf("MediaProgress returned %d rows and no error — a partial list destroys progress", len(rows))
+			}
+			if rows != nil {
+				t.Fatalf("MediaProgress returned a %d-row list alongside its error; callers must get nothing to serve", len(rows))
+			}
+		})
+	}
+}
+
+// ── mediaProgress: field contract ───────────────────────────────────────────
+
+// TestUserDataMediaProgressFieldContract checks every client-verified field of a
+// single row: the 36-char sync id, ms-epoch lastUpdate read from
+// UserBookState.LastActivityAt, seconds currentTime, an always-present duration,
+// and a 0.0-1.0 progress FRACTION derived from currentTime/duration rather than
+// the store's lossy integer ProgressPct.
+func TestUserDataMediaProgressFieldContract(t *testing.T) {
+	f := newUDFake()
+	// 3 tracks summing to 9975.48s — the oracle fixture's duration.
+	f.addBook("bk1", nil, 3325, 3325, 3325)
+	f.presetSyncID("bk1", udSyncID(7))
+	posAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	activity := time.Date(2026, 7, 30, 12, 5, 30, 123_000_000, time.UTC)
+	f.addPosition("u1", "bk1", "abs", 1234.5, posAt)
+	f.setState(&database.UserBookState{
+		UserID: "u1", BookID: "bk1", Status: database.UserBookStatusInProgress,
+		LastActivityAt: activity,
+		// 12% is what the store cached; the DTO must NOT be derived from it.
+		ProgressPct: 12, TotalListenedSeconds: 1234.5,
+	})
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	row := udRows(t, rows)[0]
+
+	if got := udStr(t, row, "libraryItemId"); got != udSyncID(7) {
+		t.Fatalf("libraryItemId = %q, want the sync UUID %q", got, udSyncID(7))
+	}
+	if got := udStr(t, row, "libraryItemId"); len(got) != 36 {
+		t.Fatalf("libraryItemId is %d chars (%q) — Absorb splits ids at byte offset 36", len(got), got)
+	}
+	if got := udStr(t, row, "mediaItemId"); len(got) != 36 {
+		t.Fatalf("mediaItemId is %d chars — same fixed-offset contract", len(got))
+	}
+	if got := udStr(t, row, "mediaItemType"); got != "book" {
+		t.Fatalf("mediaItemType = %q want \"book\"", got)
+	}
+	if got := udStr(t, row, "userId"); got != "u1" {
+		t.Fatalf("userId = %q want u1", got)
+	}
+	if got := udStr(t, row, "id"); got == "" {
+		t.Fatal("id must be stable and non-empty")
+	}
+
+	// lastUpdate: integer ms epoch, sourced from UserBookState.LastActivityAt.
+	if got, want := udInt(t, row, "lastUpdate"), activity.UnixMilli(); got != want {
+		t.Fatalf("lastUpdate = %d, want %d (UserBookState.LastActivityAt in ms)", got, want)
+	}
+	if got := udInt(t, row, "startedAt"); got <= 0 {
+		t.Fatalf("startedAt = %d, want a positive ms epoch", got)
+	}
+
+	// currentTime: float SECONDS, never ms.
+	if got := udFloat(t, row, "currentTime"); got != 1234.5 {
+		t.Fatalf("currentTime = %v want 1234.5 seconds", got)
+	}
+	// duration: always emitted, sum of the track durations.
+	if got := udFloat(t, row, "duration"); got != 9975 {
+		t.Fatalf("duration = %v want 9975 (sum of tracks)", got)
+	}
+	// progress: 0.0-1.0 fraction from currentTime/duration, NOT ProgressPct/100.
+	wantFraction := 1234.5 / 9975.0
+	if got := udFloat(t, row, "progress"); got != wantFraction {
+		t.Fatalf("progress = %v want %v (currentTime/duration, not the lossy ProgressPct)", got, wantFraction)
+	}
+	if got := udFloat(t, row, "progress"); got > 1 || got < 0 {
+		t.Fatalf("progress = %v must be a 0.0-1.0 fraction", got)
+	}
+	if udBool(t, row, "isFinished") {
+		t.Fatal("isFinished must be false at 12% through the book")
+	}
+	if udBool(t, row, "hideFromContinueListening") {
+		t.Fatal("hideFromContinueListening must be false")
+	}
+	if _, isNull := row["null:finishedAt"]; !isNull {
+		t.Fatal("finishedAt must be null for an unfinished book")
+	}
+	if _, isNull := row["null:episodeId"]; !isNull {
+		t.Fatal("episodeId must be null for a book")
+	}
+	if _, isNull := row["null:ebookLocation"]; !isNull {
+		t.Fatal("ebookLocation must be null")
+	}
+}
+
+// TestUserDataMediaProgressLastUpdateFallsBackWhenStateMissing: a position with
+// no UserBookState row still needs a usable ms epoch, or the server loses every
+// future conflict for that book.
+func TestUserDataMediaProgressLastUpdateFallsBackWhenStateMissing(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil, 3600)
+	f.presetSyncID("bk1", udSyncID(3))
+	posAt := time.Date(2026, 7, 30, 9, 30, 0, 0, time.UTC)
+	f.addPosition("u1", "bk1", "abs", 60, posAt)
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	row := udRows(t, rows)[0]
+	if got, want := udInt(t, row, "lastUpdate"), posAt.UnixMilli(); got != want {
+		t.Fatalf("lastUpdate = %d, want the position's own timestamp %d as the fallback", got, want)
+	}
+}
+
+// ── mediaProgress: finished detection ───────────────────────────────────────
+
+// TestUserDataMediaProgressFinishedTolerance: §5b's >=2s tolerance, not a tight
+// compare. Three legitimate durations of the same book disagree by ~52ms, so a
+// tight epsilon leaves a fully-listened book stuck at 99% forever.
+func TestUserDataMediaProgressFinishedTolerance(t *testing.T) {
+	cases := []struct {
+		name        string
+		position    float64
+		wantFinishd bool
+	}{
+		{"52ms short of the end is finished", 3599.948, true},
+		{"1.9s short of the end is finished", 3598.1, true},
+		{"2.5s short of the end is not finished", 3597.5, false},
+		{"exactly at the end is finished", 3600, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newUDFake()
+			f.addBook("bk1", nil, 3600)
+			f.presetSyncID("bk1", udSyncID(4))
+			f.addPosition("u1", "bk1", "abs", tc.position, time.Now())
+
+			rows, err := udProvider(t, f).MediaProgress("u1")
+			if err != nil {
+				t.Fatalf("MediaProgress: %v", err)
+			}
+			row := udRows(t, rows)[0]
+			if got := udBool(t, row, "isFinished"); got != tc.wantFinishd {
+				t.Fatalf("isFinished = %v want %v at position %v of 3600", got, tc.wantFinishd, tc.position)
+			}
+			if got := udFloat(t, row, "duration"); got <= 0 {
+				t.Fatalf("duration = %v — isFinished with a zero duration sets the client's currentTime to 0", got)
+			}
+			if tc.wantFinishd {
+				if got := udInt(t, row, "finishedAt"); got <= 0 {
+					t.Fatalf("finishedAt = %d, want a positive ms epoch on a finished book", got)
+				}
+				if got := udFloat(t, row, "progress"); got != 1 {
+					t.Fatalf("progress = %v, a finished book must clamp to exactly 1.0", got)
+				}
+			}
+		})
+	}
+}
+
+// TestUserDataMediaProgressFinishedStateWins: a manually-finished book reports
+// isFinished even when the stored position is nowhere near the end.
+func TestUserDataMediaProgressFinishedStateWins(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil, 3600)
+	f.presetSyncID("bk1", udSyncID(5))
+	f.addPosition("u1", "bk1", "abs", 10, time.Now())
+	f.setState(&database.UserBookState{
+		UserID: "u1", BookID: "bk1", Status: database.UserBookStatusFinished,
+		LastActivityAt: time.Now(),
+	})
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	row := udRows(t, rows)[0]
+	if !udBool(t, row, "isFinished") {
+		t.Fatal("a book whose state says finished must report isFinished")
+	}
+	if got := udFloat(t, row, "duration"); got <= 0 {
+		t.Fatalf("duration = %v must stay positive alongside isFinished", got)
+	}
+}
+
+// TestUserDataMediaProgressFinishedIsClampedWithoutDuration is §1.8.7's
+// null-duration trap: `isFinished:true` with a zero duration sets the client's
+// currentTime to 0 — it DESTROYS the position it was meant to report. When the
+// duration is unknown, isFinished must be cleared rather than the row dropped.
+func TestUserDataMediaProgressFinishedIsClampedWithoutDuration(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil) // no files, no Book.Duration -> duration unknown
+	f.presetSyncID("bk1", udSyncID(6))
+	f.addPosition("u1", "bk1", "abs", 500, time.Now())
+	f.setState(&database.UserBookState{
+		UserID: "u1", BookID: "bk1", Status: database.UserBookStatusFinished,
+		LastActivityAt: time.Now(),
+	})
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1 — the row must survive, only isFinished is unsafe", len(rows))
+	}
+	row := udRows(t, rows)[0]
+	if udBool(t, row, "isFinished") {
+		t.Fatal("isFinished:true with a zero duration zeroes the client's currentTime — it must be cleared")
+	}
+	if got := udFloat(t, row, "currentTime"); got != 500 {
+		t.Fatalf("currentTime = %v want 500 — the position must survive intact", got)
+	}
+}
+
+// ── mediaProgress: duration source ──────────────────────────────────────────
+
+// TestUserDataMediaProgressDurationFallsBackToBookDuration mirrors the mapper's
+// rule (§5b: ONE authoritative duration per book): sum of the track durations,
+// with Book.Duration used only for a book with no BookFile rows at all.
+func TestUserDataMediaProgressDurationFallsBackToBookDuration(t *testing.T) {
+	fileless := 4242
+	f := newUDFake()
+	f.addBook("bk1", &fileless)
+	f.presetSyncID("bk1", udSyncID(8))
+	f.addPosition("u1", "bk1", "abs", 100, time.Now())
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	row := udRows(t, rows)[0]
+	if got := udFloat(t, row, "duration"); got != 4242 {
+		t.Fatalf("duration = %v want 4242 (Book.Duration fallback for a fileless book)", got)
+	}
+}
+
+// ── mediaProgress: identity ─────────────────────────────────────────────────
+
+// TestUserDataMediaProgressMintsMissingSyncID: a book with progress but no
+// sync_item yet must still appear. Dropping it because it has no client-visible
+// id would make the client delete that book's progress.
+func TestUserDataMediaProgressMintsMissingSyncID(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil, 3600)
+	f.addPosition("u1", "bk1", "abs", 100, time.Now())
+	// deliberately NO presetSyncID
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1 — a book with no sync id must still be reported", len(rows))
+	}
+	row := udRows(t, rows)[0]
+	if got := udStr(t, row, "libraryItemId"); len(got) != 36 {
+		t.Fatalf("libraryItemId is %d chars (%q), want a freshly minted 36-char UUID", len(got), got)
+	}
+}
+
+// TestUserDataMediaProgressSurvivesMissingBook: progress for a book that no
+// longer resolves (a merge loser, a deleted row) is still reported. Silence
+// there is indistinguishable from "delete it" to the client.
+func TestUserDataMediaProgressSurvivesMissingBook(t *testing.T) {
+	f := newUDFake()
+	f.presetSyncID("ghost", udSyncID(9))
+	f.addPosition("u1", "ghost", "abs", 321, time.Now())
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want 1", len(rows))
+	}
+	row := udRows(t, rows)[0]
+	if got := udFloat(t, row, "currentTime"); got != 321 {
+		t.Fatalf("currentTime = %v want 321", got)
+	}
+	if udBool(t, row, "isFinished") {
+		t.Fatal("an unknown-duration book must not claim isFinished")
+	}
+}
+
+// ── mediaProgress: one row per book ─────────────────────────────────────────
+
+// TestUserDataMediaProgressCollapsesSegmentsToOneRowPerBook: the UserPosition
+// keyspace is per (user, book, SEGMENT) because the app's own reader tracks a
+// position per segment. ABS has exactly one whole-book position per item, so the
+// segments must collapse to a single row — and the winner must never be BEHIND
+// the newest position, or the client is rewound.
+func TestUserDataMediaProgressCollapsesSegmentsToOneRowPerBook(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil, 7200)
+	f.presetSyncID("bk1", udSyncID(11))
+	base := time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC)
+	f.addPosition("u1", "bk1", "chapter-1", 100, base)
+	f.addPosition("u1", "bk1", "abs", 4000, base.Add(2*time.Hour))
+	f.addPosition("u1", "bk1", "chapter-2", 250, base.Add(time.Hour))
+
+	rows, err := udProvider(t, f).MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows want exactly 1 per book", len(rows))
+	}
+	row := udRows(t, rows)[0]
+	if got := udFloat(t, row, "currentTime"); got != 4000 {
+		t.Fatalf("currentTime = %v want 4000 (the newest segment position)", got)
+	}
+}
+
+// TestUserDataMediaProgressTieBreaksForward: two segments written inside the same
+// instant must resolve to the FURTHEST position. Picking the smaller one would
+// rewind the listener, which is the exact failure this whole surface exists to
+// prevent.
+func TestUserDataMediaProgressTieBreaksForward(t *testing.T) {
+	at := time.Date(2026, 7, 30, 8, 0, 0, 0, time.UTC)
+	for _, order := range [][]float64{{900, 100}, {100, 900}} {
+		f := newUDFake()
+		f.addBook("bk1", nil, 7200)
+		f.presetSyncID("bk1", udSyncID(12))
+		f.addPosition("u1", "bk1", "s1", order[0], at)
+		f.addPosition("u1", "bk1", "s2", order[1], at)
+
+		rows, err := udProvider(t, f).MediaProgress("u1")
+		if err != nil {
+			t.Fatalf("MediaProgress: %v", err)
+		}
+		row := udRows(t, rows)[0]
+		if got := udFloat(t, row, "currentTime"); got != 900 {
+			t.Fatalf("currentTime = %v want 900 — a timestamp tie must never rewind the listener", got)
+		}
+	}
+}
+
+// TestUserDataMediaProgressIsDeterministic: the same state must serialize in the
+// same order every time, so a client (or a conformance diff) never sees the list
+// reshuffle between refreshes.
+func TestUserDataMediaProgressIsDeterministic(t *testing.T) {
+	f := newUDFake()
+	for i := 0; i < 25; i++ {
+		id := fmt.Sprintf("bk%02d", i)
+		f.addBook(id, nil, 600)
+		f.presetSyncID(id, udSyncID(200+i))
+		f.addPosition("u1", id, "abs", float64(i), time.Now())
+	}
+	p := udProvider(t, f)
+	first, err := p.MediaProgress("u1")
+	if err != nil {
+		t.Fatalf("MediaProgress: %v", err)
+	}
+	firstJSON, _ := json.Marshal(first)
+	for i := 0; i < 5; i++ {
+		again, err := p.MediaProgress("u1")
+		if err != nil {
+			t.Fatalf("MediaProgress: %v", err)
+		}
+		againJSON, _ := json.Marshal(again)
+		if !bytes.Equal(firstJSON, againJSON) {
+			t.Fatal("mediaProgress ordering is not deterministic across calls")
+		}
+	}
+}
+
+// ── bookmarks ───────────────────────────────────────────────────────────────
+
+// TestUserDataBookmarksShape checks the ABS bookmark contract captured in
+// testdata/abs-fixtures/get_api_me.json: {createdAt, libraryItemId, time, title}
+// with createdAt an integer ms epoch and time a JSON number in SECONDS.
+func TestUserDataBookmarksShape(t *testing.T) {
+	f := newUDFake()
+	f.addBookmark(progress.Bookmark{
+		UserID: "u1", ItemID: udSyncID(21), TimeSec: 100, Title: "conformance bookmark",
+		CreatedAt: 1785370279374, UpdatedAt: 1785370279374,
+	})
+	f.addBookmark(progress.Bookmark{
+		UserID: "u1", ItemID: udSyncID(21), TimeSec: 4212.5, Title: "half way",
+		CreatedAt: 1785370299374, UpdatedAt: 1785370299374,
+	})
+	f.addBookmark(progress.Bookmark{
+		UserID: "u2", ItemID: udSyncID(22), TimeSec: 7, Title: "someone else",
+		CreatedAt: 1785370299374,
+	})
+
+	rows, err := udProvider(t, f).Bookmarks("u1")
+	if err != nil {
+		t.Fatalf("Bookmarks: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d bookmarks want 2 (and none of another user's)", len(rows))
+	}
+	decoded := udRows(t, rows)
+	for _, row := range decoded {
+		if got := udStr(t, row, "libraryItemId"); len(got) != 36 {
+			t.Fatalf("bookmark libraryItemId is %d chars (%q), want the 36-char sync id", len(got), got)
+		}
+		if got := udStr(t, row, "title"); got == "" {
+			t.Fatal("bookmark title must be present")
+		}
+		if got := udInt(t, row, "createdAt"); got <= 0 {
+			t.Fatalf("createdAt = %d, want an integer ms epoch", got)
+		}
+	}
+	// An int-valued time stays an integer literal; a fractional one survives as a
+	// float. Both are JSON numbers, never strings.
+	if got := udFloat(t, decoded[0], "time"); got != 100 {
+		t.Fatalf("time = %v want 100 seconds", got)
+	}
+	if got := udFloat(t, decoded[1], "time"); got != 4212.5 {
+		t.Fatalf("time = %v want 4212.5 seconds", got)
+	}
+}
+
+// TestUserDataBookmarksEmptyIsEmptyNotNil keeps `bookmarks` a JSON array.
+func TestUserDataBookmarksEmptyIsEmptyNotNil(t *testing.T) {
+	rows, err := udProvider(t, newUDFake()).Bookmarks("u1")
+	if err != nil {
+		t.Fatalf("Bookmarks: %v", err)
+	}
+	if rows == nil || len(rows) != 0 {
+		t.Fatalf("got %v, want a non-nil empty slice", rows)
+	}
+}
+
+// TestUserDataBookmarksErrorIsAnError: same rule as mediaProgress — never a
+// silently short list.
+func TestUserDataBookmarksErrorIsAnError(t *testing.T) {
+	f := newUDFake()
+	f.addBookmark(progress.Bookmark{UserID: "u1", ItemID: udSyncID(23), TimeSec: 1, Title: "x", CreatedAt: 1})
+	f.bookmarksErr = errors.New("pebble: bookmark scan failed")
+
+	rows, err := udProvider(t, f).Bookmarks("u1")
+	if err == nil {
+		t.Fatal("Bookmarks must return an error when it cannot read the complete list")
+	}
+	if rows != nil {
+		t.Fatalf("Bookmarks returned %d rows alongside its error", len(rows))
+	}
+}
+
+// TestUserDataRejectsEmptyUserID: an empty user id would prefix-scan the whole
+// keyspace, so it is rejected rather than answered.
+func TestUserDataRejectsEmptyUserID(t *testing.T) {
+	p := udProvider(t, newUDFake())
+	if _, err := p.MediaProgress(""); err == nil {
+		t.Fatal("MediaProgress(\"\") must error")
+	}
+	if _, err := p.Bookmarks(""); err == nil {
+		t.Fatal("Bookmarks(\"\") must error")
+	}
+}
+
+// ── end to end through /api/me ──────────────────────────────────────────────
+
+// TestUserDataProviderServesAPIMe wires the REAL provider into the handler and
+// checks the rendered /api/me body, which is what the client actually decodes.
+func TestUserDataProviderServesAPIMe(t *testing.T) {
+	f := newUDFake()
+	f.addBook("bk1", nil, 3600, 3600)
+	f.presetSyncID("bk1", udSyncID(31))
+	f.addPosition("u1", "bk1", "abs", 1800, time.Date(2026, 7, 30, 10, 0, 0, 0, time.UTC))
+	f.setState(&database.UserBookState{
+		UserID: "u1", BookID: "bk1", Status: database.UserBookStatusInProgress,
+		LastActivityAt: time.Date(2026, 7, 30, 10, 0, 5, 0, time.UTC),
+	})
+	f.addBookmark(progress.Bookmark{
+		UserID: "u1", ItemID: udSyncID(31), TimeSec: 100, Title: "conformance bookmark",
+		CreatedAt: 1785370279374,
+	})
+
+	h := newHarness(t, "cf,jwt", nil, withUserData(udProvider(t, f)))
+	h.seedPasswordUser(t, "u1", "owner", "pw-pw-pw-pw")
+	access := str(t, userObj(t, h.login(t, "owner", "pw-pw-pw-pw")), "accessToken")
+
+	w, body := h.do(t, request{method: http.MethodGet, path: "/api/me",
+		headers: map[string]string{"Authorization": "Bearer " + access}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	rows, ok := body["mediaProgress"].([]any)
+	if !ok || len(rows) != 1 {
+		t.Fatalf("mediaProgress = %v, want exactly 1 row", body["mediaProgress"])
+	}
+	first, _ := rows[0].(map[string]any)
+	if got, _ := first["libraryItemId"].(string); got != udSyncID(31) {
+		t.Fatalf("libraryItemId = %v want %s", first["libraryItemId"], udSyncID(31))
+	}
+	if got, _ := first["currentTime"].(float64); got != 1800 {
+		t.Fatalf("currentTime = %v want 1800", got)
+	}
+	if got, _ := first["progress"].(float64); got != 0.25 {
+		t.Fatalf("progress = %v want 0.25", got)
+	}
+	marks, ok := body["bookmarks"].([]any)
+	if !ok || len(marks) != 1 {
+		t.Fatalf("bookmarks = %v, want exactly 1", body["bookmarks"])
+	}
+}

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-07-30
 
@@ -18,6 +18,12 @@ import (
 	abshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
 )
+
+// Compile-time proof that the production store satisfies the Phase 6 capability the
+// block in wireABSRoutes asserts at runtime. Without this, a signature drift on
+// either side would turn into an os.Exit(1) at boot instead of a build failure —
+// and the failure mode it guards is the /api/me empty-list data loss of §1.8.1.
+var _ abshandler.ProgressListStore = (*database.PebbleStore)(nil)
 
 // absReservedPaths are the exact top-level paths the Audiobookshelf-compatible surface
 // owns under /api/. They must be EXCLUDED from the global /api/* → /api/v1/* redirect
@@ -169,15 +175,52 @@ func (s *Server) wireABSRoutes() {
 		os.Exit(1)
 	}
 
+	// Phase 6: the user-scoped payload of /api/me, /login and /auth/refresh.
+	//
+	// FAIL CLOSED, and harder than the rest of this function does. Once the store
+	// holds a single ABS progress record, a nil provider is not "not implemented yet"
+	// — it is active data destruction: /api/me would answer a 200 with an empty
+	// mediaProgress, and AudioBooth DELETES every local progress row absent from that
+	// list (§1.8.1). Exiting is the only honest outcome, and it is unreachable in
+	// practice because PebbleDB (the only supported backend) satisfies both
+	// capabilities asserted here, as well as the sync-identity and library ones
+	// already asserted above.
+	progressList, ok := s.Store().(abshandler.ProgressListStore)
+	if !ok {
+		slog.Error("abs: refusing to start — the configured store cannot enumerate a user's listening positions, " +
+			"so /api/me could only ever report an EMPTY mediaProgress list. Clients DELETE local progress rows " +
+			"absent from that list, so serving it would destroy the owner's place in every book.")
+		os.Exit(1)
+	}
+	bookmarkStore := database.AsBookmarkStore(s.Store())
+	if bookmarkStore == nil {
+		slog.Error("abs: refusing to start — the configured store lacks the named-bookmark keyspace, so /api/me " +
+			"could only ever report an EMPTY bookmarks list.")
+		os.Exit(1)
+	}
+	userData, err := abshandler.NewUserData(abshandler.UserDataOptions{
+		Progress:  progressList,
+		Bookmarks: bookmarkStore,
+		// syncIdentity supplies libraryItemId. It MUST be the 36-char sync UUID: a raw
+		// 26-char Book ULID mis-truncates at Absorb's fixed offset of 36.
+		Identity: syncIdentity,
+		// libraryStore is the duration source (sum-of-tracks, §5b). `isFinished:true`
+		// with a zero duration sets the client's currentTime to 0.
+		Library: libraryStore,
+	})
+	if err != nil {
+		slog.Error("abs: refusing to start — the media-progress provider could not be built", "err", err)
+		os.Exit(1)
+	}
+
 	resolver := servermiddleware.NewABSIdentityResolver(cfg, verifier, oauthCfg, identityStore)
 	handler, err := abshandler.New(abshandler.Options{
 		Config:   cfg,
 		Store:    absStore,
 		Resolver: resolver,
-		// UserData stays nil in Phase 1: no ABS progress records exist yet, so the
-		// empty list genuinely IS the complete list. Phase 6 wires the real provider,
-		// and the warning below makes the gap visible until it does.
-		UserData: nil,
+		// The COMPLETE per-user progress + bookmark lists. Never nil, never paginated:
+		// see the fail-closed block above and internal/server/handlers/abs/userdata.go.
+		UserData: userData,
 
 		Library:  libraryStore,
 		Identity: absIdentityAdapter{SyncIdentityStore: syncIdentity, SyncFileStore: syncFiles},
@@ -207,9 +250,10 @@ func (s *Server) wireABSRoutes() {
 	handler.Register(absGroup)
 
 	if !handler.HasUserDataProvider() {
-		slog.Warn("abs: no media-progress provider is wired — /api/me will report an EMPTY mediaProgress list. " +
-			"That is correct only while the server holds no ABS progress records at all: clients DELETE local " +
-			"progress rows absent from this list. Phase 6 must wire the provider before any progress is stored.")
+		slog.Error("abs: the media-progress provider was NOT wired — /api/me would report an EMPTY mediaProgress " +
+			"list, and clients DELETE local progress rows absent from it. This should be unreachable: " +
+			"NewUserData above exits on failure.")
+		os.Exit(1)
 	}
 	if !handler.HasBrowseSurface() {
 		slog.Error("abs: the browse + playback routes were NOT registered — /api/libraries, /api/items and " +
@@ -222,7 +266,7 @@ func (s *Server) wireABSRoutes() {
 			"rewinds the listener to the start of the book.")
 	}
 
-	slog.Info("abs: Audiobookshelf-compatible surface enabled (auth + library browse + direct playback)",
+	slog.Info("abs: Audiobookshelf-compatible surface enabled (auth + library browse + direct playback + user progress/bookmarks)",
 		"modes", strings.Join(cfg.ModeNames(), ","),
 		"server_version", cfg.ServerVersion,
 		"access_token_ttl", cfg.AccessTTL.String(),


### PR DESCRIPTION
## What

Implements the `UserDataProvider` interface declared at `internal/server/handlers/abs/handler.go:65` and wires it in `wireABSRoutes`. `GET /api/me`, `POST /login` and `POST /auth/refresh` now carry the user's real `mediaProgress[]` and `bookmarks[]` instead of empty arrays — the last blocker before an Audiobookshelf-compatible client can resume a book where it left off.

New file: `internal/server/handlers/abs/userdata.go` (+ `userdata_test.go`). One wiring edit: `internal/server/wire_abs_routes.go`. No store, syncapi, scanner, merge, maintenance or go.mod changes.

## Why this is the dangerous endpoint

AudioBooth's `syncFromAPI` **DELETES** every local progress row absent from the server's list, sparing only the currently-playing book (§1.8.1). So the list is built complete or not at all:

- **Every** read failure — position scan, sync id, book files, book state — returns an error, and the partially-built slice is **discarded** so a caller physically cannot serve a truncated body. `me.go` renders that as 5xx. Verified by mutation: returning the partial slice fails the test.
- A row that cannot be fully described is degraded **field-wise, never dropped**. A book with no known duration keeps its position and loses only `isFinished`, because `isFinished:true` with a zero duration sets the client's `currentTime` to **0** (§1.8.7) — and dropping the row is exactly what makes the client delete it.
- A book with progress but no `sync_item` yet is **minted** rather than skipped. Minting on a read path is not free, but omitting a row the client holds costs the user their place in that book.

## Field contract

| field | source / rule |
|---|---|
| `libraryItemId`, `mediaItemId` | the 36-char sync UUID, never the 26-char Book ULID (Absorb splits ids at a fixed byte offset of 36, §1.7.1) |
| `lastUpdate` | integer **ms** epoch from `UserBookState.LastActivityAt` — `UserPosition.UpdatedAt` is re-stamped `time.Now()` by the store and cannot carry it. Fallbacks (`state.UpdatedAt`, then `pos.UpdatedAt`) so a stateless row never reports 0 and hands away every future conflict |
| `currentTime` | float **seconds**, whole-book offset |
| `duration` | always emitted: sum of track durations, `Book.Duration` only for a fileless book — the same rule as `mapper.go`, because §5b requires ONE authoritative duration per book |
| `progress` | 0.0–1.0 fraction from `currentTime/duration`, **not** the store's lossy integer `ProgressPct`; clamps to exactly 1.0 when finished so a finished book does not read 99.998% |
| `isFinished` | `IsWithinFinishedTolerance` (≥2 s, §5b), not a tight compare |
| bookmarks | `{createdAt, libraryItemId, time, title}` matching `testdata/abs-fixtures/get_api_me.json`; `time` is a JSON number in seconds (int or float) |

## Performance

Both arrays come from **user-keyed prefix scans** — `ListUserPositionsSince` over `upos:<userID>:` and `ListBookmarksForUser` over `bookmark:<userID>:` — so nothing here touches the 40,000-book library on a request path. Cost is proportional to the books that user has touched. The per-book follow-up reads (sync id, duration, derived state) run in an `errgroup` pool bounded to `runtime.NumCPU()`, writing into a pre-sized slice by index so concurrency can neither reorder nor short the list (CLAUDE.md concurrency rule).

## Startup warning removed

The `Warn` claiming no provider is wired is gone. In its place: a fail-closed capability assertion (`ProgressListStore` + `AsBookmarkStore`, both `os.Exit(1)` on failure, matching the surrounding style) and a **compile-time** `var _ abshandler.ProgressListStore = (*database.PebbleStore)(nil)` so a signature drift breaks the build rather than exiting at boot.

## Tests — 20 functions, all named `TestUserData*`

Written first, confirmed failing, then implemented. Coverage: completeness (120 books, no truncation, no cross-user leakage), partial-failure-is-an-error on all four failure sources, the field contract asserted against the **JSON wire shape** (integer ms literals with no `.`/`e`, real JSON booleans, real JSON nulls), the finished-tolerance boundary (52 ms / 1.9 s / 2.5 s / exact), the null-duration clamp, `Book.Duration` fallback, sync-id minting, a book that no longer resolves, segment collapsing with a forward-only tie break, determinism across repeated calls, and an end-to-end `/api/me` render through the handler harness.

Each critical assertion was mutation-checked (partial list returned → fails; `ProgressPct`-derived fraction → fails; `lastUpdate` from `pos.UpdatedAt` → fails; tight finished compare → fails).

### Verification

```
go test ./internal/server/handlers/abs/ -run UserData -race -count=1   ok (20/20 PASS, 3.4s)
go test ./internal/server/handlers/abs/ -race -count=1                 ok  224.303s
go test ./internal/server/ -run ABS -count=1                           ok    0.813s
go vet ./...                                                           exit 0, no output
gofmt -l <touched files>                                               clean
go build ./...                                                         OK
```

## Deviations / notes for review

1. `lastUpdate` reads `UserBookState.LastActivityAt`, while `item.go`'s `/api/items/:id` twin reads `pos.UpdatedAt` for the same field (it uses `LastActivityAt` for `startedAt`). Both are stamped by `persistProgress` within the same wall-clock instant and clients truncate to whole seconds, so they agree in practice — but the two are not literally the same expression. Flagging rather than editing `item.go`, which this branch does not own.
2. `progress` clamps to exactly 1.0 when `isFinished`. Not spelled out in the brief; done so the "sits at 99% forever" symptom of §5b cannot resurface in the progress bar after the finished flag was fixed.
3. A timestamp tie between two segments of the same book resolves to the **further** position. `GetUserPosition` resolves ties first-wins, so this can only ever be ≥ its pick — never a rewind.
4. Progress rows for a merged-away book emit that book's own sync id without following `RedirectTo`, keeping the list 1:1 with stored rows; `ResolveSyncItem` follows the redirect when the client reads the item. Combining two rows onto one surviving item is `MergeCombine`'s job, not this endpoint's.
5. No `docs/executive-summaries/` entry: several sibling worktrees are live on this month's file and the brief scoped the deliverables to code + tests + changelog fragment. Happy to add one if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J29y3VpN7FTczJmLeUJimt