### PR TITLE
fix(database): resolve capability interfaces through store decorators

### DIFF
--- a/changelog.d/20260730_224500_store_capability_unwrap.md
+++ b/changelog.d/20260730_224500_store_capability_unwrap.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/20260730_224500_store_capability_unwrap.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4e81c05a-3b76-4d29-9c14-8a2f6b0d7e93 -->
+<!-- last-edited: 2026-07-30 -->
+
+### Fixed
+
+- **Capability-interface lookups no longer break behind the search-index store
+  decorator.** `Server.Start()` replaces `s.store` with an `indexedStore` whenever
+  the Bleve index opens successfully. Because that decorator embeds the
+  `database.Store` *interface*, it promoted only that interface's methods and hid
+  every narrow capability interface declared outside it — so
+  `database.AsSyncIdentityStore`, `AsSyncFileStore` and `AsBookmarkStore` all
+  started returning `nil` in production, with no compile error. Observed fallout:
+  the `backfill-sync-ids` maintenance job failed outright with "store does not
+  implement the sync-identity capability interfaces", and `internal/merge`'s
+  sync-follow hook — which keeps a listener's position attached to a book across a
+  dedup merge — silently degraded to a no-op. The lookups now walk the decorator
+  chain via an opt-in `Unwrap`, and a new regression test asserts the real
+  `indexedStore` preserves each capability. The wrap only happens when Bleve is
+  active, which is why this reproduced on the production host and nowhere else.
+- Added the missing compile-time assertion that `*PebbleStore` satisfies
+  `SyncFileStore`, so a future signature drift fails the build instead of
+  resurfacing as a runtime `nil`.

--- a/internal/database/pebble_store_bookmarks.go
+++ b/internal/database/pebble_store_bookmarks.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookmarks.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 35844383-1823-4889-9735-b64bceb2ab17
 // last-edited: 2026-07-30
 
@@ -60,7 +60,8 @@ func AsBookmarkStore(s any) BookmarkStore {
 	if s == nil {
 		return nil
 	}
-	if bs, ok := s.(BookmarkStore); ok {
+	// Looks through the indexedStore decorator; see store_capability.go.
+	if bs, ok := asCapability[BookmarkStore](s); ok {
 		return bs
 	}
 	return nil

--- a/internal/database/pebble_store_syncfile.go
+++ b/internal/database/pebble_store_syncfile.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_syncfile.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 92ebd115-9f89-4400-ac26-bf9a065b6153
 // last-edited: 2026-07-30
 
@@ -57,11 +57,18 @@ func AsSyncFileStore(s any) SyncFileStore {
 	if s == nil {
 		return nil
 	}
-	if sf, ok := s.(SyncFileStore); ok {
+	// Looks through the indexedStore decorator; see store_capability.go.
+	if sf, ok := asCapability[SyncFileStore](s); ok {
 		return sf
 	}
 	return nil
 }
+
+// Compile-time assertion that *PebbleStore satisfies SyncFileStore. This was
+// missing when RepointSyncFileToBook was added to the interface, which meant a
+// signature drift would have surfaced only as a nil from AsSyncFileStore at
+// runtime rather than as a build failure.
+var _ SyncFileStore = (*PebbleStore)(nil)
 
 func syncFileLookupKey(bookID, fileID string) []byte {
 	return []byte(fmt.Sprintf("sync_file:lookup:%s:%s", bookID, fileID))

--- a/internal/database/pebble_store_syncid.go
+++ b/internal/database/pebble_store_syncid.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_syncid.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5b9bd4e0-2ee2-436d-ac81-16b93de80eb3
 // last-edited: 2026-07-30
 
@@ -73,7 +73,10 @@ func AsSyncIdentityStore(s any) SyncIdentityStore {
 	if s == nil {
 		return nil
 	}
-	if ss, ok := s.(SyncIdentityStore); ok {
+	// asCapability, not a bare type assertion: the server decorates s.store with
+	// indexedStore (which embeds the Store INTERFACE and so hides every
+	// capability method) during Start(). See store_capability.go.
+	if ss, ok := asCapability[SyncIdentityStore](s); ok {
 		return ss
 	}
 	return nil

--- a/internal/database/store_capability.go
+++ b/internal/database/store_capability.go
@@ -1,0 +1,84 @@
+// file: internal/database/store_capability.go
+// version: 1.0.0
+// guid: 9a41c7e0-58b2-4c33-8f6d-1b0e9d2a7c45
+// last-edited: 2026-07-30
+
+package database
+
+// This file exists because of a production failure worth stating in full, so the
+// next person to add a capability interface does not rediscover it the hard way.
+//
+// Narrow capability interfaces (SyncIdentityStore, SyncFileStore, BookmarkStore,
+// ...) are deliberately NOT part of the big Store interface — the repo rule is
+// that nobody edits store.go, so each new capability lives in its own file with
+// its own interface, discovered at runtime by a type assertion.
+//
+// internal/server.indexedStore decorates the store during Server.Start() by
+// EMBEDDING the Store interface:
+//
+//	type indexedStore struct { database.Store; server *Server }
+//
+// Embedding an interface promotes only THAT interface's method set. Every
+// capability method is therefore invisible through the decorator, so a plain
+// `s.(SyncIdentityStore)` returns nil once the wrap is installed — with no
+// compile error, because a failed type assertion is a legal runtime outcome.
+// The per-capability `var _ SyncIdentityStore = (*PebbleStore)(nil)` assertions
+// prove the INNER type conforms and say nothing about a decorator.
+//
+// The wrap only happens when the Bleve search index opened successfully, which
+// is true in production and false in most local runs — so the whole class of bug
+// reproduces nowhere except prod. It surfaced on 2026-07-30 as
+// "backfill-sync-ids: store does not implement the sync-identity capability
+// interfaces", and it silently disabled the merge-follow hook that keeps ABS
+// listening progress attached to a book across a dedup merge.
+//
+// The fix is for capability lookups to walk the decorator chain. A decorator
+// opts in by exposing Unwrap; one that does not is treated as opaque on purpose
+// (see StoreUnwrapper).
+
+// maxUnwrapDepth bounds the walk so a decorator that accidentally returns itself
+// — or a cycle built from two decorators pointing at each other — cannot hang a
+// request. The real chain is one deep today; 16 is slack, not a design target.
+const maxUnwrapDepth = 16
+
+// StoreUnwrapper is implemented by a decorator that is willing to have narrow
+// capability interfaces resolved against the store it wraps.
+//
+// Implementing it is an explicit statement: "callers may reach past me for
+// capabilities I do not implement myself." Do NOT implement it on a decorator
+// whose behaviour must not be bypassed — an access-control or read-only wrapper,
+// for instance — because a caller that resolves a capability from the inner
+// store writes through it directly. indexedStore implements it because the
+// capabilities in question (sync identity, sync files, bookmarks) touch
+// keyspaces it does not index, so reaching past it loses nothing.
+type StoreUnwrapper interface {
+	Unwrap() Store
+}
+
+// asCapability resolves T from s, looking through any decorator chain that opts
+// in via StoreUnwrapper. It returns the zero value and false when no layer
+// implements T.
+//
+// The check runs on the OUTERMOST layer first, so a decorator that implements a
+// capability itself (to add indexing or auditing to it) still wins over the
+// inner store.
+func asCapability[T any](s any) (T, bool) {
+	var zero T
+	for depth := 0; s != nil && depth < maxUnwrapDepth; depth++ {
+		if c, ok := s.(T); ok {
+			return c, true
+		}
+		u, ok := s.(StoreUnwrapper)
+		if !ok {
+			// Not a decorator, or one that has not opted in. Stop here rather
+			// than guess at its internals.
+			return zero, false
+		}
+		inner := u.Unwrap()
+		if inner == nil {
+			return zero, false
+		}
+		s = inner
+	}
+	return zero, false
+}

--- a/internal/database/store_capability_test.go
+++ b/internal/database/store_capability_test.go
@@ -1,0 +1,113 @@
+// file: internal/database/store_capability_test.go
+// version: 1.0.0
+// guid: 6f2b0a91-4d3c-4e57-9a10-2c8d5b7e4f13
+// last-edited: 2026-07-30
+
+package database
+
+import "testing"
+
+// decoratorStore mimics internal/server.indexedStore: it embeds the
+// database.Store INTERFACE, so only that interface's method set is promoted.
+// Every narrow capability interface (SyncIdentityStore, SyncFileStore,
+// BookmarkStore) is deliberately absent from database.Store, so a plain type
+// assertion against a decorator finds nothing — which is the production bug this
+// test pins down.
+type decoratorStore struct {
+	Store
+}
+
+func (d *decoratorStore) Unwrap() Store { return d.Store }
+
+// decoratorNoUnwrap is a decorator that forgot to expose Unwrap. Capability
+// discovery through it MUST fail: silently reaching around a decorator that has
+// not opted in would bypass whatever behaviour it exists to add.
+type decoratorNoUnwrap struct {
+	Store
+}
+
+func newCapabilityTestStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	ps, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = ps.Close() })
+	return ps
+}
+
+// TestCapabilityLookupsSurviveOneDecorator is the regression test for the
+// production failure "backfill-sync-ids: store does not implement the
+// sync-identity capability interfaces": the server wraps s.store in an
+// indexedStore during Start(), and every As*Store helper then returned nil.
+func TestCapabilityLookupsSurviveOneDecorator(t *testing.T) {
+	inner := newCapabilityTestStore(t)
+	var wrapped Store = &decoratorStore{Store: inner}
+
+	if AsSyncIdentityStore(wrapped) == nil {
+		t.Error("AsSyncIdentityStore through a decorator == nil; want the inner capability")
+	}
+	if AsSyncFileStore(wrapped) == nil {
+		t.Error("AsSyncFileStore through a decorator == nil; want the inner capability")
+	}
+	if AsBookmarkStore(wrapped) == nil {
+		t.Error("AsBookmarkStore through a decorator == nil; want the inner capability")
+	}
+}
+
+// TestCapabilityLookupsSurviveNestedDecorators guards against a future second
+// decorator being layered on (the wrap site already stacks conditionally).
+func TestCapabilityLookupsSurviveNestedDecorators(t *testing.T) {
+	inner := newCapabilityTestStore(t)
+	var wrapped Store = &decoratorStore{Store: &decoratorStore{Store: inner}}
+
+	if AsSyncIdentityStore(wrapped) == nil {
+		t.Error("AsSyncIdentityStore through two decorators == nil")
+	}
+	if AsSyncFileStore(wrapped) == nil {
+		t.Error("AsSyncFileStore through two decorators == nil")
+	}
+	if AsBookmarkStore(wrapped) == nil {
+		t.Error("AsBookmarkStore through two decorators == nil")
+	}
+}
+
+// TestCapabilityLookupsStillFindBareStore pins the pre-existing behaviour so the
+// unwrap change cannot regress the common case.
+func TestCapabilityLookupsStillFindBareStore(t *testing.T) {
+	var bare Store = newCapabilityTestStore(t)
+
+	if AsSyncIdentityStore(bare) == nil {
+		t.Error("AsSyncIdentityStore on a bare *PebbleStore == nil")
+	}
+	if AsSyncFileStore(bare) == nil {
+		t.Error("AsSyncFileStore on a bare *PebbleStore == nil")
+	}
+	if AsBookmarkStore(bare) == nil {
+		t.Error("AsBookmarkStore on a bare *PebbleStore == nil")
+	}
+}
+
+// TestCapabilityLookupsRefuseOpaqueDecorator asserts we do NOT reach through a
+// decorator that has not opted in via Unwrap.
+func TestCapabilityLookupsRefuseOpaqueDecorator(t *testing.T) {
+	inner := newCapabilityTestStore(t)
+	var opaque Store = &decoratorNoUnwrap{Store: inner}
+
+	if AsSyncIdentityStore(opaque) != nil {
+		t.Error("AsSyncIdentityStore reached through a decorator with no Unwrap; want nil")
+	}
+}
+
+// TestCapabilityLookupsHandleNilAndNilChain covers the degenerate inputs.
+func TestCapabilityLookupsHandleNilAndNilChain(t *testing.T) {
+	if AsSyncIdentityStore(nil) != nil {
+		t.Error("AsSyncIdentityStore(nil) != nil")
+	}
+	// A decorator whose inner store is nil must not panic and must not claim a
+	// capability it cannot serve.
+	var nilChain Store = &decoratorStore{Store: nil}
+	if got := AsSyncIdentityStore(nilChain); got != nil {
+		t.Errorf("AsSyncIdentityStore over a nil inner store = %v; want nil", got)
+	}
+}

--- a/internal/server/indexed_store.go
+++ b/internal/server/indexed_store.go
@@ -1,6 +1,7 @@
 // file: internal/server/indexed_store.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5d2e4f3a-7b5a-4a70-b8c5-3d7e0f1b9a79
+// last-edited: 2026-07-30
 //
 // indexedStore decorates a database.Store so that every successful
 // book mutation (create / update / delete) schedules an async
@@ -25,10 +26,22 @@ import (
 // indexedStore wraps an inner Store and fires index-update events on
 // book mutations. The embedded interface forwards every other method
 // to the underlying store transparently.
+//
+// "Every other method" means every method DECLARED ON database.Store. Embedding
+// an interface promotes only that interface's method set, so the narrow
+// capability interfaces that deliberately live outside database.Store
+// (SyncIdentityStore, SyncFileStore, BookmarkStore, ...) are NOT reachable
+// through this type. Unwrap below is what makes them discoverable again.
 type indexedStore struct {
 	database.Store
 	server *Server
 }
+
+// Compile-time proof that this decorator advertises the unwrap capability, which
+// is what lets database.As*Store lookups resolve capabilities against the store
+// it wraps. If Unwrap is ever dropped or renamed, the build fails here instead of
+// the failure reappearing at runtime as a silent nil in an unrelated package.
+var _ database.StoreUnwrapper = (*indexedStore)(nil)
 
 // CreateBook writes to the inner store and schedules an index
 // refresh for the newly-assigned book ID on success.
@@ -51,8 +64,17 @@ func (s *indexedStore) UpdateBook(id string, b *database.Book) (*database.Book, 
 	return updated, err
 }
 
-// Unwrap returns the inner store so decorator-aware helpers (e.g.
-// unwrapAIJobsStore) can peel layers and reach concrete sub-interfaces.
+// Unwrap returns the inner store so decorator-aware helpers can peel layers and
+// reach concrete sub-interfaces. database.asCapability walks this chain, which is
+// what makes database.AsSyncIdentityStore / AsSyncFileStore / AsBookmarkStore
+// keep working once this decorator is installed in Start().
+//
+// Reaching past this decorator is safe for those capabilities specifically: sync
+// identity, sync files and bookmarks live in keyspaces this type does not index,
+// so a caller that writes to them directly loses no index update. Book mutations
+// still arrive through the explicit CreateBook/UpdateBook/DeleteBook overrides,
+// which is what actually keeps Bleve in sync. Do NOT rely on Unwrap to bypass a
+// decorator whose behaviour is load-bearing.
 func (s *indexedStore) Unwrap() database.Store {
 	return s.Store
 }

--- a/internal/server/indexed_store_capability_test.go
+++ b/internal/server/indexed_store_capability_test.go
@@ -1,0 +1,88 @@
+// file: internal/server/indexed_store_capability_test.go
+// version: 1.0.0
+// guid: 2c7f4b18-6e93-4a52-9d81-5f0a3b6c8e27
+// last-edited: 2026-07-30
+
+package server
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestIndexedStorePreservesCapabilityLookups pins the production regression at
+// its real site.
+//
+// Server.Start() replaces s.store with &indexedStore{Store: inner} whenever the
+// Bleve index opened successfully — true on the production host, false in most
+// local runs, which is why this class of bug reproduced nowhere else. Because
+// indexedStore embeds the database.Store INTERFACE, every narrow capability
+// interface that deliberately lives outside database.Store became unreachable
+// through it, and every database.As*Store lookup started returning nil.
+//
+// Observed fallout on 2026-07-30: the backfill-sync-ids maintenance job failed
+// with "store does not implement the sync-identity capability interfaces", and
+// internal/merge's sync-follow hook — the thing that keeps a listener's position
+// attached to a book across a dedup merge — silently degraded to a no-op.
+func TestIndexedStorePreservesCapabilityLookups(t *testing.T) {
+	inner, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+
+	// The real decorator, constructed exactly as server_lifecycle.go does.
+	// server is nil: no test here triggers a book mutation, so the index-enqueue
+	// path is never reached.
+	var wrapped database.Store = &indexedStore{Store: inner, server: nil}
+
+	if database.AsSyncIdentityStore(wrapped) == nil {
+		t.Error("AsSyncIdentityStore through indexedStore == nil; " +
+			"the ABS sync-identity backfill and merge-follow hook both break")
+	}
+	if database.AsSyncFileStore(wrapped) == nil {
+		t.Error("AsSyncFileStore through indexedStore == nil; " +
+			"per-file ABS ids stop resolving")
+	}
+	if database.AsBookmarkStore(wrapped) == nil {
+		t.Error("AsBookmarkStore through indexedStore == nil; " +
+			"/api/me would report an empty bookmark list")
+	}
+}
+
+// TestIndexedStoreCapabilityRoundTrip proves the resolved capability actually
+// writes through to the inner store, rather than merely satisfying the type
+// assertion.
+func TestIndexedStoreCapabilityRoundTrip(t *testing.T) {
+	inner, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+
+	var wrapped database.Store = &indexedStore{Store: inner, server: nil}
+
+	ids := database.AsSyncIdentityStore(wrapped)
+	if ids == nil {
+		t.Fatal("AsSyncIdentityStore through indexedStore == nil")
+	}
+
+	minted, err := ids.MintOrGetSyncID("book-capability-roundtrip")
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID through the decorator: %v", err)
+	}
+	if len(minted) != 36 {
+		t.Errorf("minted sync id = %q (len %d); want a 36-char UUID", minted, len(minted))
+	}
+
+	// Read it back through the BARE inner store: proves the write landed in the
+	// real Pebble keyspace and was not absorbed by the decorator.
+	got, ok, err := inner.GetSyncIDForBook("book-capability-roundtrip")
+	if err != nil {
+		t.Fatalf("GetSyncIDForBook on the inner store: %v", err)
+	}
+	if !ok || got != minted {
+		t.Errorf("inner store has (%q, %v); want (%q, true)", got, ok, minted)
+	}
+}


### PR DESCRIPTION
## The bug

`Server.Start()` replaces `s.store` with `&indexedStore{Store: inner}` whenever the Bleve search index opened successfully (`server_lifecycle.go:290`).

`indexedStore` embeds the `database.Store` **interface**. Embedding an interface promotes only *that interface's* method set — so every narrow capability interface that deliberately lives **outside** `database.Store` became unreachable through the decorator:

- `SyncIdentityStore`
- `SyncFileStore`
- `BookmarkStore`

Every `database.As*Store` lookup therefore returned `nil` in production. There is no compile error, because a failed type assertion is a legal runtime outcome — and the existing `var _ SyncIdentityStore = (*PebbleStore)(nil)` assertions prove the **inner** type conforms while saying nothing about a decorator.

## Observed fallout (production, 2026-07-30)

1. `backfill-sync-ids` failed in **84ms**: `store does not implement the sync-identity capability interfaces`.
2. `internal/merge`'s sync-follow hook — the thing that keeps a listener's position attached to a book across a dedup merge — **silently degraded to a no-op** (it nil-checks and skips).

The wrap only happens when Bleve is active: true on the prod host, false in most local runs. That is why this reproduced on prod and nowhere else, and why local test runs and the local ABS smoke test both passed.

`wireABSRoutes` is **not** affected: `setupRoutes()` runs inside `NewServer`, before `Start()` installs the wrap, so the ABS handlers captured pre-wrap capability interfaces and its `os.Exit(1)` guards did not trip.

## The fix

`As*Store` helpers now resolve through the decorator chain via an opt-in `Unwrap` (`database.StoreUnwrapper`), checking the outermost layer first so a decorator that implements a capability itself still wins.

A decorator **without** `Unwrap` stays opaque on purpose — silently reaching around one would bypass whatever behaviour it exists to add. `indexedStore` already had an `Unwrap` method that was orphaned when its only caller (`unwrapAIJobsStore`) was deleted; it is now load-bearing and compile-time asserted.

Also adds the missing `var _ SyncFileStore = (*PebbleStore)(nil)`, absent since `RepointSyncFileToBook` joined that interface — the exact gap that let this hide.

## Verification

TDD: the two decorator tests failed first with `AsSyncIdentityStore through a decorator == nil`, reproducing the prod error in a unit test.

```
go test ./internal/database/ -run TestCapabilityLookups -race -count=1   ok  5/5 PASS
go test ./internal/server/  -run TestIndexedStore      -count=1          ok  6/6 PASS
go build ./...                                                          exit 0
go vet ./internal/database/ ./internal/server/                          exit 0
gofmt -l <7 touched files>                                              clean
```

`TestIndexedStoreCapabilityRoundTrip` goes further than the type assertion: it mints a sync ID **through** the decorator and reads it back from the **bare** inner store, proving the write lands in the real Pebble keyspace.

The 6/6 in `internal/server` includes the 4 pre-existing `indexedStore` tests — the indexing behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp