### PR TITLE
fix(database): resolve concrete Pebble store through store decorators

### DIFF
--- a/changelog.d/20260731_172500_storecap_concrete_store.md
+++ b/changelog.d/20260731_172500_storecap_concrete_store.md
@@ -1,0 +1,50 @@
+<!-- file: changelog.d/20260731_172500_storecap_concrete_store.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c4d8e1a6-7f39-4b52-9e08-2a6b5d3c9f71 -->
+<!-- last-edited: 2026-07-31 -->
+
+### Fixed
+
+- **Two maintenance jobs had been silently degrading in production, and the
+  library-wipe fixups were failing outright.** All three are the concrete-type
+  half of the decorator bug fixed for capability interfaces in the previous
+  release: `Server.Start()` replaces the store with a Bleve search-index
+  decorator, and a bare `store.(*database.PebbleStore)` assertion fails against
+  that wrapper just as an interface assertion does. Because each of these call
+  sites had a deliberate "different backend" fallback written for SQLite and test
+  doubles, a wrapped Pebble store was indistinguishable from an unsupported
+  backend and the fallback made it look like a supported configuration:
+  - `sweep-pebble-metrics-ttl` logged "store is not a PebbleStore; skipping" and
+    no-opped on every production run, so expired Pebble metrics snapshots were
+    never swept and grew without bound past their 30-day retention window.
+  - `recompute-book-aggregates` took its interface fallback every run, which
+    skips the `book_aggregates_v1_done` sentinel — so instead of short-circuiting
+    on an already-completed backfill it recomputed all ~40k books each time.
+  - The six library-wipe fixups either failed with "unsupported store type
+    \*server.indexedStore" (`wipeSegments`, `wipeBooks`, `wipeAuthors`,
+    `wipeSeries`, `wipeExternalIDs`) or fell back to a slower interface loop that
+    reports an approximate count and misses the secondary-index prefixes
+    (`wipeBookFiles`).
+
+  All eight sites now resolve the concrete store through the new
+  `database.AsPebbleStore`, and a regression test drives the repaired wipe
+  fixups through the real `indexedStore` — it reproduces the exact production
+  error string if the bare assertions are restored.
+
+### Changed
+
+- `database.asCapability` is now exported as `database.AsCapability`, since the
+  same decorator problem has to be solved from `internal/server` and
+  `internal/maintenance/jobs` too. It works for concrete types as well as
+  interfaces.
+- `GetOpsV2` and `GetAIJobs` now delegate to `AsCapability` instead of each
+  carrying its own hand-inlined copy of the unwrap walk. Their behaviour is
+  unchanged, and the walk is now depth-bounded — the old loops would spin forever
+  on a decorator whose `Unwrap` returned itself.
+- Documented, and pinned with a test, the distinction that explains why this bug
+  hit some capabilities and not others: `OpsV2Store` and `AIJobsStore` are
+  subsets of `Store`'s method set, so any decorator embedding the `Store`
+  interface satisfies them directly and they were never at risk. Only
+  capabilities with at least one method outside `Store` (`SyncIdentityStore`,
+  `SyncFileStore`, `BookmarkStore`, and the concrete `*PebbleStore`) are
+  affected. The test fails if a capability ever crosses that line.

--- a/internal/database/pebble_store_bookmarks.go
+++ b/internal/database/pebble_store_bookmarks.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookmarks.go
-// version: 1.1.0
+// version: 1.1.1
 // guid: 35844383-1823-4889-9735-b64bceb2ab17
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 // Package database: named-bookmark keyspace.
 //
@@ -61,7 +61,7 @@ func AsBookmarkStore(s any) BookmarkStore {
 		return nil
 	}
 	// Looks through the indexedStore decorator; see store_capability.go.
-	if bs, ok := asCapability[BookmarkStore](s); ok {
+	if bs, ok := AsCapability[BookmarkStore](s); ok {
 		return bs
 	}
 	return nil

--- a/internal/database/pebble_store_syncfile.go
+++ b/internal/database/pebble_store_syncfile.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_syncfile.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 92ebd115-9f89-4400-ac26-bf9a065b6153
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package database
 
@@ -58,7 +58,7 @@ func AsSyncFileStore(s any) SyncFileStore {
 		return nil
 	}
 	// Looks through the indexedStore decorator; see store_capability.go.
-	if sf, ok := asCapability[SyncFileStore](s); ok {
+	if sf, ok := AsCapability[SyncFileStore](s); ok {
 		return sf
 	}
 	return nil

--- a/internal/database/pebble_store_syncid.go
+++ b/internal/database/pebble_store_syncid.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_syncid.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: 5b9bd4e0-2ee2-436d-ac81-16b93de80eb3
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 // Package database: sync_item keyspace — durable ABS `libraryItemId` identity.
 //
@@ -76,7 +76,7 @@ func AsSyncIdentityStore(s any) SyncIdentityStore {
 	// asCapability, not a bare type assertion: the server decorates s.store with
 	// indexedStore (which embeds the Store INTERFACE and so hides every
 	// capability method) during Start(). See store_capability.go.
-	if ss, ok := asCapability[SyncIdentityStore](s); ok {
+	if ss, ok := AsCapability[SyncIdentityStore](s); ok {
 		return ss
 	}
 	return nil

--- a/internal/database/store_capability.go
+++ b/internal/database/store_capability.go
@@ -1,7 +1,7 @@
 // file: internal/database/store_capability.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9a41c7e0-58b2-4c33-8f6d-1b0e9d2a7c45
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package database
 
@@ -35,6 +35,20 @@ package database
 // The fix is for capability lookups to walk the decorator chain. A decorator
 // opts in by exposing Unwrap; one that does not is treated as opaque on purpose
 // (see StoreUnwrapper).
+//
+// The same hazard applies to CONCRETE-type assertions, not just interfaces:
+// `store.(*PebbleStore)` fails through the decorator too, and its failure mode is
+// worse because such sites usually have a "different backend, degrade gracefully"
+// fallback written for SQLite/mock. A wrapped Pebble store takes that fallback and
+// looks like a supported configuration. Two prod jobs were silently degraded this
+// way for weeks — see AsPebbleStore. Resolve concrete stores through this file
+// too, never with a bare assertion on a value obtained from Server.Store().
+//
+// Rule of thumb for which values are affected: anything bound during NewServer
+// (the service-registry container via Override("store", ...), plugin.Deps, every
+// handler constructor) holds the BARE store and is unaffected. Anything that calls
+// Server.Store() at request time, op-run time, or inside a lazily-built service
+// gets the WRAPPED store and must resolve capabilities through this file.
 
 // maxUnwrapDepth bounds the walk so a decorator that accidentally returns itself
 // — or a cycle built from two decorators pointing at each other — cannot hang a
@@ -55,14 +69,21 @@ type StoreUnwrapper interface {
 	Unwrap() Store
 }
 
-// asCapability resolves T from s, looking through any decorator chain that opts
+// AsCapability resolves T from s, looking through any decorator chain that opts
 // in via StoreUnwrapper. It returns the zero value and false when no layer
 // implements T.
+//
+// T may be an interface (SyncIdentityStore, OpsV2Store, ...) or a concrete type
+// (*PebbleStore) — both fail identically through a decorator, so both belong here.
 //
 // The check runs on the OUTERMOST layer first, so a decorator that implements a
 // capability itself (to add indexing or auditing to it) still wins over the
 // inner store.
-func asCapability[T any](s any) (T, bool) {
+//
+// Exported because callers outside this package hit the same problem: package
+// server's maintenance fixups and package maintenance/jobs both need to reach the
+// concrete Pebble store through the search-index decorator.
+func AsCapability[T any](s any) (T, bool) {
 	var zero T
 	for depth := 0; s != nil && depth < maxUnwrapDepth; depth++ {
 		if c, ok := s.(T); ok {
@@ -81,4 +102,33 @@ func asCapability[T any](s any) (T, bool) {
 		s = inner
 	}
 	return zero, false
+}
+
+// AsPebbleStore resolves the concrete *PebbleStore out of s, looking through any
+// opted-in decorator chain. Returns nil when there is no Pebble store in the
+// chain — a genuinely non-Pebble backend (SQLite, a test double) or an opaque
+// decorator.
+//
+// Use this instead of `store.(*PebbleStore)` on any value that came from
+// Server.Store(). The bare assertion is what silently degraded these in prod,
+// where the Bleve decorator is always installed:
+//
+//   - sweep-pebble-metrics-ttl logged "store is not a PebbleStore; skipping" and
+//     no-opped, so expired metrics snapshots were never swept and grew unbounded.
+//   - recompute-book-aggregates fell back to its interface path, skipping the
+//     IsBookAggregatesBackfillDone sentinel and redoing the full 40k-book
+//     backfill on every run.
+//   - the maintenance wipe fixups either errored with "unsupported store type
+//     *server.indexedStore" or took an approximate fallback that misses the
+//     secondary-index prefixes.
+//
+// Every one of those sites had a deliberate non-Pebble fallback written for
+// SQLite/mock, which is exactly why the failure was invisible: a wrapped Pebble
+// store is indistinguishable from an unsupported backend at the assertion, and
+// the fallback makes it look like a supported configuration rather than a bug.
+func AsPebbleStore(s any) *PebbleStore {
+	if ps, ok := AsCapability[*PebbleStore](s); ok {
+		return ps
+	}
+	return nil
 }

--- a/internal/database/store_capability_concrete_test.go
+++ b/internal/database/store_capability_concrete_test.go
@@ -1,0 +1,169 @@
+// file: internal/database/store_capability_concrete_test.go
+// version: 1.0.0
+// guid: 3f7a1e28-9c44-4b16-8de3-5a02c7f9b418
+// last-edited: 2026-07-31
+
+package database
+
+import "testing"
+
+// concreteDecorator mirrors the shape of internal/server.indexedStore: it embeds
+// the Store INTERFACE (so it promotes only Store's method set and hides
+// everything else, including the concrete inner type) and opts into unwrapping.
+type concreteDecorator struct {
+	Store
+}
+
+func (d *concreteDecorator) Unwrap() Store { return d.Store }
+
+// opaqueDecorator embeds Store but deliberately does NOT implement
+// StoreUnwrapper, standing in for a wrapper whose behaviour must not be bypassed.
+type opaqueDecorator struct {
+	Store
+}
+
+// TestAsPebbleStoreThroughDecorator is the regression test for the bug this file
+// exists to prevent: a bare store.(*PebbleStore) assertion returns nil through a
+// decorator, and every caller of that assertion has a "non-Pebble backend"
+// fallback that makes the failure look like a supported configuration.
+func TestAsPebbleStoreThroughDecorator(t *testing.T) {
+	inner := &PebbleStore{}
+
+	t.Run("bare store resolves", func(t *testing.T) {
+		if got := AsPebbleStore(inner); got != inner {
+			t.Fatalf("AsPebbleStore(bare) = %p, want %p", got, inner)
+		}
+	})
+
+	t.Run("bare assertion fails through decorator", func(t *testing.T) {
+		// This is the bug, asserted directly so the test documents WHY
+		// AsPebbleStore has to exist. If this ever starts passing, Go's embedding
+		// semantics changed and the helper can go away.
+		var wrapped Store = &concreteDecorator{Store: inner}
+		if _, ok := wrapped.(*PebbleStore); ok {
+			t.Fatal("bare type assertion unexpectedly saw through the decorator; " +
+				"AsPebbleStore may no longer be necessary")
+		}
+	})
+
+	t.Run("AsPebbleStore resolves through one decorator", func(t *testing.T) {
+		var wrapped Store = &concreteDecorator{Store: inner}
+		if got := AsPebbleStore(wrapped); got != inner {
+			t.Fatalf("AsPebbleStore(1 decorator) = %p, want %p", got, inner)
+		}
+	})
+
+	t.Run("AsPebbleStore resolves through nested decorators", func(t *testing.T) {
+		var wrapped Store = &concreteDecorator{
+			Store: &concreteDecorator{Store: inner},
+		}
+		if got := AsPebbleStore(wrapped); got != inner {
+			t.Fatalf("AsPebbleStore(2 decorators) = %p, want %p", got, inner)
+		}
+	})
+
+	t.Run("opaque decorator is not bypassed", func(t *testing.T) {
+		// A wrapper that has not opted in stays opaque on purpose: reaching past
+		// an access-control or read-only wrapper would write through it.
+		var wrapped Store = &opaqueDecorator{Store: inner}
+		if got := AsPebbleStore(wrapped); got != nil {
+			t.Fatalf("AsPebbleStore(opaque) = %p, want nil", got)
+		}
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		if got := AsPebbleStore(nil); got != nil {
+			t.Fatalf("AsPebbleStore(nil) = %p, want nil", got)
+		}
+	})
+
+	t.Run("genuinely non-Pebble store yields nil", func(t *testing.T) {
+		// The legitimate case the callers' fallbacks were written for. It must
+		// still report nil, or a SQLite/mock backend would be handed a nil
+		// *PebbleStore and panic on first use.
+		if got := AsPebbleStore(struct{}{}); got != nil {
+			t.Fatalf("AsPebbleStore(non-store) = %p, want nil", got)
+		}
+	})
+}
+
+// TestAsCapabilityDepthCapTerminates covers the behaviour change made when
+// GetOpsV2/GetAIJobs were folded into AsCapability: their hand-rolled loops had no
+// depth bound, so a decorator whose Unwrap returned itself spun forever. This test
+// hangs (and fails on the package timeout) if maxUnwrapDepth is removed.
+//
+// It probes with *PebbleStore rather than OpsV2Store deliberately — see
+// TestCapabilityFamiliesDifferInVisibility for why an OpsV2Store probe would
+// resolve on the first layer and never reach the cycle at all.
+func TestAsCapabilityDepthCapTerminates(t *testing.T) {
+	c := &selfCycleDecorator{}
+	c.self = c
+
+	if _, ok := AsCapability[*PebbleStore](c); ok {
+		t.Fatal("AsCapability resolved a *PebbleStore from a cyclic decorator")
+	}
+}
+
+// TestCapabilityFamiliesDifferInVisibility pins down a distinction that is easy to
+// get wrong and that determines whether a given capability is at risk from a
+// Store-embedding decorator at all.
+//
+// A capability whose method set is a SUBSET of Store is satisfied by any decorator
+// that embeds the Store interface, because embedding promotes Store's whole method
+// set. Such capabilities were never broken by indexedStore — which is exactly why
+// GetOpsV2/GetAIJobs worked in production while AsSyncIdentityStore did not, even
+// though all four look like the same pattern in the source.
+//
+// A capability with even one method outside Store is invisible through the
+// decorator and MUST be resolved via AsCapability. If a future edit moves a
+// capability's methods into Store (or removes them), this test tells you which
+// side of the line it has landed on rather than leaving it to be discovered in
+// production.
+func TestCapabilityFamiliesDifferInVisibility(t *testing.T) {
+	inner := &PebbleStore{}
+	var wrapped Store = &concreteDecorator{Store: inner}
+
+	// Subset-of-Store family: visible directly through the decorator.
+	if _, ok := wrapped.(OpsV2Store); !ok {
+		t.Error("OpsV2Store is no longer a subset of Store; it has joined the " +
+			"at-risk family and every bare assertion on it needs auditing")
+	}
+	if _, ok := wrapped.(AIJobsStore); !ok {
+		t.Error("AIJobsStore is no longer a subset of Store; it has joined the " +
+			"at-risk family and every bare assertion on it needs auditing")
+	}
+
+	// At-risk family: invisible through the decorator, resolvable only by walking.
+	if _, ok := wrapped.(SyncIdentityStore); ok {
+		t.Error("SyncIdentityStore is now visible through a Store-embedding " +
+			"decorator; it may have been folded into Store")
+	}
+	if AsSyncIdentityStore(wrapped) == nil {
+		t.Error("AsSyncIdentityStore failed to resolve through the decorator")
+	}
+	if AsSyncFileStore(wrapped) == nil {
+		t.Error("AsSyncFileStore failed to resolve through the decorator")
+	}
+	if AsBookmarkStore(wrapped) == nil {
+		t.Error("AsBookmarkStore failed to resolve through the decorator")
+	}
+
+	// Both helpers must still resolve through the decorator regardless of which
+	// family they belong to — consolidating them onto AsCapability must not have
+	// changed their observable behaviour.
+	if GetOpsV2(wrapped) == nil {
+		t.Error("GetOpsV2 failed to resolve through the decorator")
+	}
+	if GetAIJobs(wrapped) == nil {
+		t.Error("GetAIJobs failed to resolve through the decorator")
+	}
+}
+
+// selfCycleDecorator returns itself from Unwrap, the degenerate cycle the old
+// unbounded loops could not escape.
+type selfCycleDecorator struct {
+	Store
+	self Store
+}
+
+func (d *selfCycleDecorator) Unwrap() Store { return d.self }

--- a/internal/database/storecap.go
+++ b/internal/database/storecap.go
@@ -1,25 +1,37 @@
 // file: internal/database/storecap.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-// last-edited: 2026-06-23
+// last-edited: 2026-07-31
 
 package database
+
+// These two helpers predate store_capability.go by five weeks and independently
+// discovered the same decorator problem, each with its own hand-inlined copy of
+// the unwrap walk and a locally-declared `unwrapper` interface. They now delegate
+// to AsCapability so there is exactly one implementation to reason about.
+//
+// Worth knowing before you copy this pattern: for THESE two capabilities the walk
+// is defensive, not load-bearing. OpsV2Store and AIJobsStore are subsets of Store's
+// method set, so a decorator that embeds the Store interface satisfies them on the
+// outermost layer and never needs unwrapping. That is precisely why GetOpsV2 and
+// GetAIJobs kept working in production while AsSyncIdentityStore silently returned
+// nil — the capabilities that broke are the ones with at least one method outside
+// Store. TestCapabilityFamiliesDifferInVisibility pins the distinction down and
+// fails if a capability crosses the line in either direction.
+//
+// Behaviour is otherwise unchanged except that the walk is now depth-bounded
+// (maxUnwrapDepth): the old loops would spin forever on a decorator whose Unwrap
+// returned itself. Both also treated a nil Unwrap() result as "keep going" and
+// relied on the `store != nil` loop condition to catch it on the next pass, which
+// worked but only by accident of ordering; AsCapability rejects it explicitly.
 
 // GetOpsV2 resolves the OpsV2Store capability from store, walking any Unwrap()
 // decorator chain. Returns nil if store is nil or no layer satisfies OpsV2Store.
 //
 // Use this instead of scattering `store.(database.OpsV2Store)` type assertions.
 func GetOpsV2(store Store) OpsV2Store {
-	type unwrapper interface{ Unwrap() Store }
-	for store != nil {
-		if v2, ok := store.(OpsV2Store); ok {
-			return v2
-		}
-		u, ok := store.(unwrapper)
-		if !ok {
-			break
-		}
-		store = u.Unwrap()
+	if v2, ok := AsCapability[OpsV2Store](store); ok {
+		return v2
 	}
 	return nil
 }
@@ -29,16 +41,8 @@ func GetOpsV2(store Store) OpsV2Store {
 //
 // Use this instead of scattering `store.(database.AIJobsStore)` type assertions.
 func GetAIJobs(store Store) AIJobsStore {
-	type unwrapper interface{ Unwrap() Store }
-	for store != nil {
-		if aij, ok := store.(AIJobsStore); ok {
-			return aij
-		}
-		u, ok := store.(unwrapper)
-		if !ok {
-			break
-		}
-		store = u.Unwrap()
+	if aij, ok := AsCapability[AIJobsStore](store); ok {
+		return aij
 	}
 	return nil
 }

--- a/internal/maintenance/jobs/recompute_book_aggregates.go
+++ b/internal/maintenance/jobs/recompute_book_aggregates.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/recompute_book_aggregates.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9b0c1d2e-3f4a-5b6c-7d8e-9f0a1b2c3d4e
-// last-edited: 2026-06-10
+// last-edited: 2026-07-31
 
 // Maintenance job: recompute-book-aggregates
 //
@@ -58,8 +58,15 @@ func (j *recomputeBookAggregatesJob) Run(
 	reporter maintenance.ProgressReporter,
 	dryRun bool,
 ) error {
-	pebbleStore, ok := store.(*database.PebbleStore)
-	if !ok {
+	// AsPebbleStore, not a bare assertion: this job runs through
+	// server.maintenance_job_op, which resolves Server.Store() at op-run time and
+	// therefore hands us the Bleve search-index decorator in production. A bare
+	// `store.(*database.PebbleStore)` failed against that wrapper, so every prod run
+	// took the interface fallback below — which skips the
+	// IsBookAggregatesBackfillDone sentinel checked further down and so redid the
+	// entire 40k-book backfill each time instead of short-circuiting.
+	pebbleStore := database.AsPebbleStore(store)
+	if pebbleStore == nil {
 		// Fallback for test double or SQLite: iterate via the Store interface.
 		return j.runViaInterface(ctx, store, reporter, dryRun)
 	}

--- a/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
+++ b/internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
@@ -1,6 +1,7 @@
 // file: internal/maintenance/jobs/sweep_pebble_metrics_ttl.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b8c9d0e1-f2a3-0008-1234-000000000008
+// last-edited: 2026-07-31
 
 // Package jobs — maintenance job: sweep expired Pebble metrics snapshots.
 //
@@ -46,8 +47,15 @@ func (j *sweepPebbleMetricsTTLJob) Run(
 	reporter maintenance.ProgressReporter,
 	dryRun bool,
 ) error {
-	ps, ok := store.(*database.PebbleStore)
-	if !ok {
+	// AsPebbleStore, not a bare assertion: this job runs through
+	// server.maintenance_job_op, which resolves Server.Store() at op-run time and
+	// therefore hands us the Bleve search-index decorator in production. A bare
+	// `store.(*database.PebbleStore)` failed against that wrapper, so this job took
+	// the skip branch below on every prod run and expired metrics snapshots were
+	// never swept. Nothing surfaced it because skipping is a legitimate outcome on
+	// a non-Pebble backend.
+	ps := database.AsPebbleStore(store)
+	if ps == nil {
 		// Not a Pebble backend — no-op (test double or SQLite fallback).
 		slog.Info("sweep-pebble-metrics-ttl: store is not a PebbleStore; skipping")
 		reporter.Log("info", "Store is not PebbleStore — skipped", nil)

--- a/internal/server/indexed_store_capability_test.go
+++ b/internal/server/indexed_store_capability_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/indexed_store_capability_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c7f4b18-6e93-4a52-9d81-5f0a3b6c8e27
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package server
 
@@ -84,5 +84,68 @@ func TestIndexedStoreCapabilityRoundTrip(t *testing.T) {
 	}
 	if !ok || got != minted {
 		t.Errorf("inner store has (%q, %v); want (%q, true)", got, ok, minted)
+	}
+}
+
+// TestIndexedStoreResolvesConcretePebbleStore covers the second half of the same
+// bug: the wipe fixups in maintenance_fixups.go assert on the CONCRETE
+// *database.PebbleStore rather than a narrow interface, and a bare assertion fails
+// through this decorator exactly the same way.
+//
+// Those sites are worse than the interface ones because each has a deliberate
+// "different backend" fallback written for SQLite and test doubles. A wrapped
+// Pebble store is indistinguishable from an unsupported backend at a bare
+// assertion, so the fallback fires and the configuration looks supported.
+func TestIndexedStoreResolvesConcretePebbleStore(t *testing.T) {
+	inner, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+
+	var wrapped database.Store = &indexedStore{Store: inner, server: nil}
+
+	if got := database.AsPebbleStore(wrapped); got != inner {
+		t.Fatalf("AsPebbleStore through indexedStore = %p, want the inner store %p",
+			got, inner)
+	}
+
+	// And the bare form still fails, which is the whole reason AsPebbleStore has
+	// to be used at those call sites.
+	if _, ok := wrapped.(*database.PebbleStore); ok {
+		t.Error("bare *database.PebbleStore assertion unexpectedly saw through " +
+			"indexedStore; the AsPebbleStore call sites may no longer need it")
+	}
+}
+
+// TestWipeFixupsReachPebbleThroughDecorator exercises the repaired call sites
+// themselves rather than the helper in isolation, because the helper being correct
+// says nothing about whether these six functions actually call it.
+//
+// Only the two fixups that assert BEFORE their dry-run branch are exercised —
+// wipeSegments and wipeExternalIDs. Both run a counting query in dry-run mode, so
+// nothing is deleted. The other four (wipeBookFiles, wipeBooks, wipeAuthors,
+// wipeSeries) return from their dry-run branch before reaching the assertion, so a
+// dry-run call cannot distinguish fixed from broken and a non-dry-run call would
+// wipe the store; they are covered by AsPebbleStore's own tests instead.
+func TestWipeFixupsReachPebbleThroughDecorator(t *testing.T) {
+	inner, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = inner.Close() })
+
+	var wrapped database.Store = &indexedStore{Store: inner, server: nil}
+	ms, ok := wrapped.(maintenanceStore)
+	if !ok {
+		t.Fatal("indexedStore does not satisfy maintenanceStore")
+	}
+
+	// Before the fix these returned "unsupported store type *server.indexedStore".
+	if _, err := wipeSegments(ms, true); err != nil {
+		t.Errorf("wipeSegments(dryRun) through the decorator: %v", err)
+	}
+	if _, err := wipeExternalIDs(ms, true); err != nil {
+		t.Errorf("wipeExternalIDs(dryRun) through the decorator: %v", err)
 	}
 }

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -1,7 +1,7 @@
 // file: internal/server/maintenance_fixups.go
-// version: 2.7.0
+// version: 2.8.0
 // guid: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-07-07
+// last-edited: 2026-07-31
 
 package server
 
@@ -237,13 +237,21 @@ func dryRunLabel(dryRun bool) string {
 }
 
 // wipeBookFiles deletes all book_file rows using the appropriate store backend.
+// The wipe* helpers below take their store from Server.Store() at REQUEST time,
+// which in production is the Bleve search-index decorator, not the bare
+// *PebbleStore. They must resolve the concrete store via database.AsPebbleStore —
+// a bare `store.(*database.PebbleStore)` assertion fails against the decorator and
+// silently sends each of these down its non-Pebble path: an "unsupported store
+// type" error for wipeSegments/wipeBooks/wipeAuthors/wipeSeries/wipeExternalIDs,
+// and for wipeBookFiles a slower interface loop that self-reports an approximate
+// count and misses the secondary-index prefixes. See database.AsPebbleStore.
 func wipeBookFiles(store maintenanceStore, dryRun bool) (int64, error) {
 	if dryRun {
 		// Count only.
 		n, err := store.CountFiles()
 		return int64(n), err
 	}
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		n, err := s.WipeByPrefixes([]string{"book_file:"})
 		return int64(n), err
 	}
@@ -271,7 +279,7 @@ func wipeBookFiles(store maintenanceStore, dryRun bool) (int64, error) {
 
 // wipeSegments deletes all book_segment rows using the appropriate store backend.
 func wipeSegments(store maintenanceStore, dryRun bool) (int64, error) {
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		// Pebble segments use "bf:" (primary) and "bfs:" (secondary) prefixes.
 		if dryRun {
 			n, err := s.CountByPrefix("bf:")
@@ -289,7 +297,7 @@ func wipeBooks(store maintenanceStore, dryRun bool) (int64, error) {
 		n, err := store.CountPrimaryBooks()
 		return int64(n), err
 	}
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		// Book keys: "book:" prefix. Include secondary indexes.
 		n, err := s.WipeByPrefixes([]string{"book:"})
 		return int64(n), err
@@ -303,7 +311,7 @@ func wipeAuthors(store maintenanceStore, dryRun bool) (int64, error) {
 		n, err := store.CountAuthors()
 		return int64(n), err
 	}
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		n, err := s.WipeByPrefixes([]string{"author:"})
 		return int64(n), err
 	}
@@ -316,7 +324,7 @@ func wipeSeries(store maintenanceStore, dryRun bool) (int64, error) {
 		n, err := store.CountSeries()
 		return int64(n), err
 	}
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		n, err := s.WipeByPrefixes([]string{"series:"})
 		return int64(n), err
 	}
@@ -325,7 +333,7 @@ func wipeSeries(store maintenanceStore, dryRun bool) (int64, error) {
 
 // wipeExternalIDs deletes all external_id_map rows using the appropriate store backend.
 func wipeExternalIDs(store maintenanceStore, dryRun bool) (int64, error) {
-	if s, ok := store.(*database.PebbleStore); ok {
+	if s := database.AsPebbleStore(store); s != nil {
 		if dryRun {
 			n, err := s.CountByPrefix("ext_id:")
 			return int64(n), err

--- a/todo.d/2026-07-31-server-suite-timeout-headroom.md
+++ b/todo.d/2026-07-31-server-suite-timeout-headroom.md
@@ -1,0 +1,12 @@
+- [ ] **TODO-SRVTIMEOUT** Split or speed up the `internal/server` test package —
+      it runs 434–480 s against Go's 600 s default per-package timeout, leaving
+      under 30% headroom. Any concurrent load on the machine tips the whole
+      package into a timeout that is indistinguishable from a deadlock: the
+      panic dump names whichever goroutine happened to be mid-teardown
+      (`operations/registry.(*Registry).Shutdown` blocked on `sync.WaitGroup.Wait`
+      at `registry.go:1030` in the observed case), which reads as a real hang and
+      sent a 2026-07-31 investigation down a false trail on PR #2083. Verified
+      not a deadlock: the same commit passes in 480 s when run without competing
+      load. Either shard the package, or set an explicit generous `-timeout` in
+      the Makefile test targets so a slow run fails as "too slow" rather than
+      masquerading as a lock bug.


### PR DESCRIPTION
Follow-up to #2083, which fixed the capability-**interface** half of the store-decorator bug. The concrete-type half was still live at **eight run-time call sites**, and two of them had been silently degrading in production.

## Root cause (same as #2083, different assertion form)

`Server.Start()` swaps `s.store` for an `indexedStore` whenever the Bleve index opens, and that decorator embeds the `database.Store` *interface*. A bare `store.(*database.PebbleStore)` fails against it exactly the way an interface assertion does.

What made this invisible rather than loud: **every affected site has a deliberate "different backend" fallback written for SQLite and test doubles.** A wrapped Pebble store is indistinguishable from an unsupported backend at a bare assertion, so the fallback fires and the configuration looks *supported*.

## Fallout found

| site | production behaviour before this PR |
|---|---|
| `sweep-pebble-metrics-ttl` | logged `store is not a PebbleStore; skipping` and no-opped **every run** — expired Pebble metrics snapshots never swept, grew past their 30-day retention window |
| `recompute-book-aggregates` | took its interface fallback every run, which skips the `book_aggregates_v1_done` sentinel — recomputed all ~40k books each time instead of short-circuiting |
| 6 library-wipe fixups | hard failure `unsupported store type *server.indexedStore` (`wipeSegments`, `wipeBooks`, `wipeAuthors`, `wipeSeries`, `wipeExternalIDs`), or a fallback reporting an approximate count and missing secondary-index prefixes (`wipeBookFiles`) |

No data-loss risk: the wipe ops fail closed, and the two jobs degrade rather than corrupt. None were run against prod during this work.

## Blast radius is bounded by binding time, and that is now documented

Only stores obtained from `Server.Store()` **at run time** are affected. Anything bound during `NewServer` — the service-registry container via `Override("store", resolvedStore)`, `plugin.Deps`, every handler constructor — holds the bare store and was never at risk. That is why the maintenance *plugins* are fine while the maintenance *jobs* were not. Audited all 17 concrete-type assertion sites: **8 broken, 9 safe.**

## Why some capabilities broke and others never did

An unexpected finding that corrected an earlier assumption in this PR's own comments:

```
SyncIdentityStore  subset of Store: NO   (missing method GetSyncIDForBook)
OpsV2Store         subset of Store: YES
AIJobsStore        subset of Store: YES
```

`OpsV2Store` and `AIJobsStore` are subsets of `Store`'s method set, so any `Store`-embedding decorator satisfies them on the outermost layer — the unwrap walk in `storecap.go` was defensive, never load-bearing. That is precisely why `GetOpsV2` kept working in prod while `AsSyncIdentityStore` returned nil, despite looking like the same pattern in source. `TestCapabilityFamiliesDifferInVisibility` pins this down and fails if a capability crosses the line in either direction.

## Changes

- **New `database.AsPebbleStore`** — resolves the concrete store through an opted-in decorator chain. All 8 sites use it.
- **`asCapability` → exported `AsCapability`** — the same problem has to be solved from `internal/server` and `internal/maintenance/jobs`. Works for concrete types as well as interfaces.
- **`GetOpsV2`/`GetAIJobs` folded onto `AsCapability`** — each carried a hand-inlined copy of the walk with no depth bound, which would spin forever on a decorator whose `Unwrap` returned itself. Behaviour otherwise unchanged.

## Verification

- `go build ./...` clean, `go vet` clean on all changed packages.
- `internal/database` ok 284.7s · `internal/maintenance` ok 0.2s · `internal/maintenance/jobs` ok 14.9s · `internal/server` capability tests ok.
- **The regression test was validated by reverting the fix**, which is the only thing that proves it isn't vacuous:

```
--- FAIL: TestWipeFixupsReachPebbleThroughDecorator
    wipeSegments: unsupported store type *server.indexedStore
    wipeExternalIDs: unsupported store type *server.indexedStore
```

Restoring the fix returns it to green. 4 new tests total, exercising the **real** `indexedStore`, not a stand-in.

## Also included

A `todo.d/` fragment recording a latent trap found during this work: `internal/server` tests run 434–480s against Go's 600s default timeout (<30% headroom), so any concurrent machine load flips the package into a timeout whose panic dump names whatever goroutine was mid-teardown. It read as a `Registry.Shutdown` deadlock on #2083 and cost real investigation time before being disproven by an isolated re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp