### PR TITLE
feat(oauth): use the full email address as the SSO username

### DIFF
--- a/changelog.d/20260731_234500_oauth_email_as_username.md
+++ b/changelog.d/20260731_234500_oauth_email_as_username.md
@@ -1,0 +1,14 @@
+<!-- file: changelog.d/20260731_234500_oauth_email_as_username.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9f2b6d14-7e83-4a05-b1c6-3d8e5f0a7b21 -->
+<!-- last-edited: 2026-07-31 -->
+
+### Changed
+
+- SSO/OAuth-provisioned accounts are now named by their full verified email address
+  instead of a username derived from the part before the `@`. Signing in with
+  `owner@example.com` creates the user `owner@example.com`, not `owner`. The old
+  derived form collided across domains and providers, and named the account something
+  the owner had never typed. Existing users are unaffected — this only applies when a
+  new account is auto-created, and sign-in still resolves an existing account by
+  identity link first and verified email second.

--- a/internal/oauth/resolve.go
+++ b/internal/oauth/resolve.go
@@ -1,7 +1,7 @@
 // file: internal/oauth/resolve.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6b0d3f81-9a27-4c54-8e16-2a5c7b9e0d43
-// last-edited: 2026-07-26
+// last-edited: 2026-07-31
 
 package oauth
 
@@ -90,14 +90,22 @@ func (c *Config) ResolveUser(store UserStore, claims IdentityClaims) (*database.
 	return user, nil
 }
 
-// uniqueUsername derives a username from the email local part, appending a numeric
-// suffix on collision.
+// uniqueUsername returns the verified email address itself as the username.
+//
+// The username IS the email, deliberately. A username derived from the local part
+// ("johnathan.falk" out of johnathan.falk@gmail.com) is ambiguous the moment a second
+// identity provider or a second domain is in play — two different people can own the
+// same local part — and it leaves an SSO-provisioned account whose name matches nothing
+// the owner ever typed. The verified email is already unique, already proven to belong
+// to the person, and is what they actually sign in with.
+//
+// The numeric-suffix loop is kept only for the pathological case where some pre-existing
+// local account has already claimed that exact username while NOT being reachable by the
+// email lookup in step (4) above — e.g. a hand-made account whose email field is empty.
+// Creating `user@example.com1` there is ugly, but silently binding a federated identity
+// to an unrelated local account would be an account-takeover bug.
 func (c *Config) uniqueUsername(store UserStore, claims IdentityClaims) string {
-	base := claims.Email
-	if at := strings.IndexByte(base, '@'); at > 0 {
-		base = base[:at]
-	}
-	base = sanitizeUsername(base)
+	base := sanitizeUsername(claims.Email)
 	if base == "" {
 		base = "user"
 	}
@@ -111,11 +119,19 @@ func (c *Config) uniqueUsername(store UserStore, claims IdentityClaims) string {
 	return candidate // extremely unlikely fall-through
 }
 
+// sanitizeUsername reduces an identity string to a conservative username charset.
+//
+// '@' and '+' are permitted so that a full email address survives intact — without '@'
+// an address would silently collapse to "johnathan.falkgmail.com", which looks like a
+// typo and is not the address anyone would type. Everything outside the allowlist is
+// dropped rather than escaped: usernames are compared and displayed in a lot of places,
+// and a restricted charset is the cheap way to keep them boring.
 func sanitizeUsername(s string) string {
 	s = strings.ToLower(strings.TrimSpace(s))
 	var b strings.Builder
 	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			r == '.' || r == '_' || r == '-' || r == '@' || r == '+' {
 			b.WriteRune(r)
 		}
 	}

--- a/internal/oauth/resolve_test.go
+++ b/internal/oauth/resolve_test.go
@@ -1,5 +1,5 @@
 // file: internal/oauth/resolve_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4c9e1b73-6a20-4d58-8f16-2b5a7c0e9d38
 
 package oauth
@@ -137,5 +137,57 @@ func TestResolveUser_AutoCreatesUser(t *testing.T) {
 	}
 	if gotAlgo != "oauth" {
 		t.Errorf("new oauth user PasswordHashAlgo=%q, want oauth", gotAlgo)
+	}
+}
+
+// An auto-created user is named by its FULL verified email, not the local part.
+//
+// Regression guard: the previous implementation cut the address at '@' and named this
+// user "new", which collides across domains and matches nothing the owner ever typed.
+// Reverting uniqueUsername to the local-part form fails this test on the '@' check.
+func TestResolveUser_UsernameIsFullEmail(t *testing.T) {
+	var gotUsername string
+	store := newResolverStore()
+	store.CreateUserFunc = func(username, email, algo, hash string, roles []string, status string) (*database.User, error) {
+		gotUsername = username
+		return &database.User{ID: "unew", Username: username, Email: email}, nil
+	}
+	cfg := New(Config{AllowedEmails: []string{"Owner.Name+abs@Example.com"}, DefaultRole: "admin"})
+	if _, err := cfg.ResolveUser(store, IdentityClaims{
+		Provider: ProviderCFAccess, Subject: "cf-1",
+		Email: "Owner.Name+abs@Example.com", EmailVerified: true,
+	}); err != nil {
+		t.Fatalf("ResolveUser: %v", err)
+	}
+	// Lower-cased, but otherwise the address intact — '@' and '+' must survive.
+	if want := "owner.name+abs@example.com"; gotUsername != want {
+		t.Errorf("username=%q, want %q", gotUsername, want)
+	}
+}
+
+// A username collision that the email lookup did NOT catch (a hand-made local account
+// with an empty email field holding the address as its username) must not silently bind
+// the federated identity to that account — it gets a suffixed name instead.
+func TestResolveUser_UsernameCollisionSuffixes(t *testing.T) {
+	var gotUsername string
+	store := newResolverStore()
+	store.GetUserByUsernameFunc = func(u string) (*database.User, error) {
+		if u == "taken@example.com" {
+			return &database.User{ID: "pre-existing", Username: u}, nil
+		}
+		return nil, nil
+	}
+	store.CreateUserFunc = func(username, email, algo, hash string, roles []string, status string) (*database.User, error) {
+		gotUsername = username
+		return &database.User{ID: "unew", Username: username, Email: email}, nil
+	}
+	cfg := New(Config{AllowedEmails: []string{"taken@example.com"}, DefaultRole: "viewer"})
+	if _, err := cfg.ResolveUser(store, IdentityClaims{
+		Provider: ProviderGoogle, Subject: "g-2", Email: "taken@example.com", EmailVerified: true,
+	}); err != nil {
+		t.Fatalf("ResolveUser: %v", err)
+	}
+	if want := "taken@example.com1"; gotUsername != want {
+		t.Errorf("colliding username=%q, want %q", gotUsername, want)
 	}
 }


### PR DESCRIPTION
## What

Auto-provisioned SSO/OAuth accounts were named from the email **local part** — `johnathan.falk@gmail.com` became the user `johnathan.falk`. The username is now the **verified email itself**, lower-cased.

Requested directly: *"get rid of stupid usernames and just make the email the username"*.

## Why

- The local part collides across domains and providers — two different people can own the same one.
- It names the account something the owner has never typed, which makes an SSO-provisioned user hard to match to the person who owns it.

## Changes

- `internal/oauth/resolve.go` — `uniqueUsername` returns the full email; `sanitizeUsername` now keeps `@` and `+` so the address survives intact instead of collapsing to `johnathan.falkgmail.com`.
- `internal/oauth/resolve_test.go` — two new regression tests.

## Blast radius

Narrow, and deliberately so:

- **Existing accounts are unaffected.** This code runs only on the auto-create branch (step 5). Sign-in still resolves by `(provider, subject)` identity link first, then by verified email — both take precedence.
- The **numeric-suffix fallback is kept** for the pathological case where a hand-made local account already holds that exact username but has no email set. Creating `taken@example.com1` is ugly; silently binding a federated identity to an unrelated local account would be an account-takeover bug.
- No username validator exists elsewhere in the codebase that would reject `@` (verified by grep), and `sanitizeUsername` has exactly one call site.

## Verification

Both new tests were **validated by reverting** `uniqueUsername` to the old implementation and confirming they fail:

```
--- FAIL: TestResolveUser_UsernameIsFullEmail
    username="owner.nameabs", want "owner.name+abs@example.com"
--- FAIL: TestResolveUser_UsernameCollisionSuffixes
    colliding username="taken", want "taken@example.com1"
```

With the fix in place, `go test ./internal/oauth/ -count=1` passes (7/7). `go vet` clean; both changed files are `gofmt`-clean (the two files `gofmt -l` still flags in this package are pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp