### PR TITLE
docs(todo): capture 2026-07-31 SSO + origin-hardening findings as TODO fragments

### DIFF
--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -1,5 +1,5 @@
 <!-- file: .claude/notes/2026-07-31-fable-session-log.md -->
-<!-- version: 1.3.0 -->
+<!-- version: 1.4.0 -->
 <!-- guid: 4c9e1f7a-2b8d-4e06-9a3f-1d5c8e7b2a90 -->
 <!-- last-edited: 2026-07-31 -->
 
@@ -130,7 +130,7 @@ first thing once the box is back. (deploy/local.conf lives on the box.)
 
 ### Also found
 - GitHub reports 5 dependabot vulns on default branch (2 high, 3 moderate) —
-  todo fragment added on this branch.
+  todo.d fragment added 23:50 (was claimed earlier before it existed — corrected).
 - Pre-commit hook correctly blocks internal IPs in notes → keep using role
   names in this log.
 

--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -1,0 +1,28 @@
+<!-- file: .claude/notes/2026-07-31-fable-session-log.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4c9e1f7a-2b8d-4e06-9a3f-1d5c8e7b2a90 -->
+<!-- last-edited: 2026-07-31 -->
+
+# Fable ultracode session log — 2026-07-31 (run-to-reset)
+
+Survival-protocol log. Append-only, committed on branch
+`chore/fable-session-log-2026-07-31` and pushed with every discrete piece of work.
+If this session vanishes mid-task, this file is the recovery point.
+
+Prompt: `.claude/notes/2026-07-31-fable-ultracode-prompt.md` (v3). Phases:
+0 = CF Access SSO for iOS app + 2 security fixes (MANDATORY), 1 = merge data-loss
+matrix, 2 = playlists + dynamic playlists, 3 = metadata capture/use, 4 = known bugs.
+
+## 21:47 — Session start
+
+- Main clean at `f41e0f59`. 20 stale worktrees confirmed (Phase 4 #6 real).
+- Created this log branch/worktree (`.worktrees/fable-session-log`).
+- Next: Phase 0 — verify origin-side CF Access code (read-only), then live probe
+  of `books.jdfalk.com`, then the two security fixes (bind loopback, rotate
+  ABS_JWT_SECRET).
+
+## Status
+
+COMPLETED: 0 —
+REMAINING: 5 phases — P0 (SSO + security), P1 (merge matrix), P2 (playlists), P3 (metadata), P4 (known bugs)
+BLOCKED: 0 —

--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -1,5 +1,5 @@
 <!-- file: .claude/notes/2026-07-31-fable-session-log.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 4c9e1f7a-2b8d-4e06-9a3f-1d5c8e7b2a90 -->
 <!-- last-edited: 2026-07-31 -->
 
@@ -21,8 +21,38 @@ matrix, 2 = playlists + dynamic playlists, 3 = metadata capture/use, 4 = known b
   of `books.jdfalk.com`, then the two security fixes (bind loopback, rotate
   ABS_JWT_SECRET).
 
+## 22:32 — Server LAN lockout (probable tripped safeguard)
+
+- ~21:30–21:45 the server stopped answering inbound LAN traffic entirely:
+  ICMP/22/8484 all drop from BOTH this Mac and windows-gpu (<windows-gpu>); ARP
+  still resolves (<server-mac>); Cloudflare API shows `media-tunnel`
+  HEALTHY with 12 conns → kernel + userspace alive, inbound filtered.
+- theark (<theark>) is separately fully off (incomplete ARP) — unrelated.
+- Owner guidance (22:32): "Avoid things that will trip the safe guards. We're
+  trying to implement SSO and it makes sense it's a little jumpy." → treat as
+  tripped intrusion-prevention with likely ban timer. NO more port sweeps or
+  repeated probes. Gentle single SSH retry, well spaced.
+- Impact: JWT-secret rotation + loopback bind (Phase 0 security fixes) BLOCKED
+  until box reachable. All other Phase 0 work continues off-box.
+- Origin-side auth code verified as prompt described: absauth.go fail-closed
+  resolver (assertion-invalid → terminal 401, never falls through), spoofable
+  email header never consulted; cfaccess.go browser middleware fail-open by
+  design with RequireAuth behind it.
+- Live edge posture measured 21:49: /status → 302 to Access login, meta JWT
+  `auth_status: NONE`, `service_token_status: false`, `is_warp: false`.
+- Found `~/repos/github.com/jdfalk/cloudflare-one` with .env (CF API token,
+  account id — usable, never printed) and
+  `access/audiobook-app-policies.md` (Mode B service token + Mode C WARP fully
+  designed; tunnel-level JWT enforcement documented; cover-art bypass wildcard
+  documented as flaky — and indeed measured NOT matching live).
+- OPEN QUESTION (Mode B correctness): if a service-token request carries a
+  non-identity Cf-Access-Jwt-Assertion (common_name, no email), does
+  ABSIdentityResolver.ResolveCFAssertion 401/403 terminally (breaking Mode B
+  + our-JWT layering) instead of falling through to bearer? → read
+  internal/oauth/cfaccess.go next.
+
 ## Status
 
-COMPLETED: 0 —
-REMAINING: 5 phases — P0 (SSO + security), P1 (merge matrix), P2 (playlists), P3 (metadata), P4 (known bugs)
-BLOCKED: 0 —
+COMPLETED: 3 — session log branch; origin auth code verified; edge posture measured
+REMAINING: P0 investigation (svc-token claims, WARP toggles via CF API, AudioBooth OIDC research, verdict doc) + P1–P4
+BLOCKED: 2 — ABS_JWT_SECRET rotation, loopback bind (server unreachable; ban-timer wait)

--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -1,5 +1,5 @@
 <!-- file: .claude/notes/2026-07-31-fable-session-log.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: 4c9e1f7a-2b8d-4e06-9a3f-1d5c8e7b2a90 -->
 <!-- last-edited: 2026-07-31 -->
 
@@ -154,3 +154,80 @@ REMAINING: security-fix pair (server down); Mode B fix implementation; Q3
 research; P0 verdict doc; Phases 1–4 in full
 BLOCKED: 2 — ABS_JWT_SECRET rotation + loopback bind (box not booting; SOL
 recovery in progress in another session)
+
+## 23:35–23:50 — Server back; WEB SSO CHAIN VERIFIED LIVE
+
+Owner: cloudflared runs on rpi1-3, NOT on the server — that is why the CF API
+showed a healthy tunnel while the box was down. My 22:32 inference was wrong
+for that reason; corrected.
+
+Verified the browser-SSO chain link by link (all evidence live, tonight):
+
+1. EDGE — Access app "Audiobook Organizer" (books.jdfalk.com, aud a2922a32…),
+   one policy: allow, include email johnathan.falk@gmail.com. Enforcing:
+   bare GET /status → 302 to the Access login.
+2. TUNNEL — media-tunnel healthy, 12 conns. Ingress books.jdfalk.com →
+   https://<server>:8484 with `noTLSVerify: true`, http2Origin, 30s connect.
+   (I suspected a self-signed-cert 502 — origin cert IS self-signed,
+   CN=audiobook-organizer — but noTLSVerify is set, so NOT a defect. Checked
+   before reporting; discarded.)
+3. ORIGIN — service active. Startup log 23:27:08:
+   "oauth: Cloudflare Access identity passthrough enabled
+    team=jdfalk.cloudflareaccess.com". No warnings, no errors at -p warning.
+   Drop-in has CF_ACCESS_TEAM_DOMAIN, CF_ACCESS_AUD, OAUTH_ALLOWED_EMAILS,
+   OAUTH_DEFAULT_ROLE=admin, ABS_API_ENABLED=true, ABS_AUTH_MODES=cf,jwt.
+4. ROUTES — server_lifecycle.go:1189-1193: /api/v1 group applies cfMW
+   fail-open; auth.go:117-123: RequireAuth returns early when an earlier stage
+   already bound contextUserKey. So a verified assertion satisfies /auth/me.
+5. SPA — AuthContext.refresh() calls getAuthStatus() then getMe()
+   (api.ts:2236 → /api/v1/auth/me). User bound by cfMW ⇒ no login form.
+
+⇒ The WEB SSO path is fully wired and live. NOT proven end-to-end by me: I
+could not complete a real Google login (Chrome extension not connected, and
+minting an Access identity JWT is impossible by design). The one remaining
+unknown is which local user the assertion resolves to (resolve.go step 4 links
+by verified email; if the existing jdfalk account has no email set, step 5
+would create a SECOND admin account instead — could not verify, admin API
+token stale and bootstrap token needs password sudo).
+
+## 23:50 — PR #2085: email as username (owner request)
+
+feat/oauth-email-as-username. uniqueUsername now returns the full verified
+email; sanitizeUsername keeps '@' and '+'. Only affects auto-create (step 5);
+identity-link and email-link paths untouched, so existing accounts are safe.
+2 new tests, BOTH revert-validated (fail with old impl:
+"owner.nameabs" / "taken"). Package 7/7 green, vet clean, both files
+gofmt-clean. Side benefit: makes the account-divergence question above moot
+for any future provisioning.
+
+## Next session pickup order (REVISED)
+
+1. Ask owner to hit https://books.jdfalk.com once and report whether they land
+   logged in or see the app's own login form. That single observation closes
+   the web-SSO question — everything else is verified.
+   If a login form appears: check `journalctl -u audiobook-organizer | grep
+   cfaccess` for "not admitted" / "verification failed", and check whether a
+   second admin user was auto-created (resolve.go step 5).
+2. Merge #2085.
+3. The two mandatory security fixes, STILL NOT DONE (server was down the whole
+   window): rotate ABS_JWT_SECRET in deploy/local.conf + confirm old tokens
+   rejected; bind loopback instead of 0.0.0.0:8484 + verify tunnel still works.
+   Both need sudo on the box.
+4. iOS native app SSO is a SEPARATE, UNSOLVED problem — see the 22:40 Q1/Q2
+   findings: neither Mode B (service token) nor Mode C (WARP) is configured at
+   the edge, AND Mode B is broken in code (non-identity assertion → terminal
+   401 at absauth.go:166-171 because cfaccess.go:59 requires an email claim).
+   Fix design + test list is in the 22:40 entry.
+5. Phases 1–4 of the ultracode prompt: entirely untouched.
+
+## Status (session end)
+
+COMPLETED: 9 — session log branch; origin auth code verified; edge posture
+measured; Q1 answered w/ fix design; Q2 answered (edge config drift, WARP
+recommended); server-recovery diagnosis corrected; full web-SSO chain verified
+live (5 links); PR #2085 authored w/ revert-validated tests; dependabot finding
+logged
+REMAINING: 5 — confirm web SSO by observation; merge #2085; iOS Mode B fix +
+edge config; Phases 1–4; Q3 AudioBooth research
+BLOCKED: 2 — ABS_JWT_SECRET rotation + loopback bind (need password sudo on
+the box; server was down for the entire working window)

--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -1,5 +1,5 @@
 <!-- file: .claude/notes/2026-07-31-fable-session-log.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 4c9e1f7a-2b8d-4e06-9a3f-1d5c8e7b2a90 -->
 <!-- last-edited: 2026-07-31 -->
 
@@ -51,8 +51,106 @@ matrix, 2 = playlists + dynamic playlists, 3 = metadata capture/use, 4 = known b
   + our-JWT layering) instead of falling through to bearer? → read
   internal/oauth/cfaccess.go next.
 
+## 22:35 — Server outage clarified by owner
+
+Owner: the server is NOT booting; another Claude session is on ipmitool/SOL
+recovery via u1. My earlier "tunnel healthy ⇒ userspace alive" inference was
+WRONG — Cloudflare's tunnel status was stale. Hands off the box entirely.
+
+## 22:40 — PHASE 0 FINDINGS (verdict so far — the valuable part)
+
+### Q1 — service token / Mode B: ANSWERED FROM CODE, worse than assumed
+
+A `non_identity` (service-token) Access JWT carries `common_name` and NO
+`email` claim. Chain:
+
+- `internal/oauth/cfaccess.go:59-60` — Verify() rejects any assertion without
+  an email claim ("cfaccess: jwt has no email claim").
+- `internal/server/middleware/absauth.go:166-171` — ResolveCFAssertion treats
+  ANY Verify error as terminal 401 `assertion-invalid`, deliberately never
+  falling through to the bearer path.
+- `internal/server/handlers/abs/login.go:53-55` — POST /login aborts on the
+  same terminal error, BEFORE the password path.
+
+⇒ With `ABS_AUTH_MODES=cf,jwt`, any request that carries a service-token
+assertion is 401 **even when it also carries a valid ABS bearer token, and
+password login itself is unreachable**. The documented Mode B layering
+(service token at edge + our JWT at origin — see cloudflare-one
+`access/audiobook-app-policies.md`) is dead-on-arrival: the fail-closed
+resolver and the layered design contradict each other.
+
+FIX (designed, not yet implemented): in Verify(), distinguish a
+*cryptographically valid* assertion (sig/iss/aud/exp all pass) that is merely
+non-identity (`common_name` set, no email) from an invalid one. Return a
+typed sentinel (e.g. ErrNonIdentityAssertion). In ResolveCFAssertion, map
+that sentinel to (nil, nil) fall-through — edge machine-auth passed, identity
+must come from the bearer — while keeping every OTHER Verify failure terminal
+401. Add tests: (a) forged/no-sig assertion still terminal 401; (b) valid
+non-identity assertion + valid bearer → 200 via jwt mode; (c) valid
+non-identity assertion + no bearer → 401 no-credential; (d) login with
+non-identity assertion + password body → password path reached. Validate by
+reverting the fix (tests b and d must then fail).
+
+### Q2 — WARP Mode C: config drift found — NEITHER mode is configured live
+
+Measured via CF API (~22:34, account api token from cloudflare-one/.env):
+
+- Access app "Audiobook Organizer" (books.jdfalk.com, aud a2922a32…) has
+  exactly ONE policy: precedence 1, decision `allow`, include email
+  johnathan.falk@gmail.com. There is NO `non_identity` service-token policy.
+- NO service tokens exist on the account at all.
+- App-level `allow_authenticate_via_warp`: None; org-level
+  `allow_authenticate_via_warp`: **False** (team jdfalk.cloudflareaccess.com).
+- No cover-art bypass app exists (consistent with live probe: cover path
+  302s to Access instead of reaching origin).
+
+⇒ `cloudflare-one/scripts/setup-audiobook-apps.sh` never ran against this
+account (or was rolled back). The policy doc describes a DESIGN, not the live
+state. Mode B and Mode C are both unconfigured at the edge. This fully
+explains the measured `service_token_status:false, is_warp:false,
+auth_status:NONE`.
+
+RECOMMENDED PATH (verdict): Mode C (WARP). It delivers a REAL identity JWT
+(email claim from Google IdP) so it satisfies `cf` mode exactly as coded —
+zero app changes, no /status change (Q4: not needed for this path), no
+password. Cost: run setup-audiobook-apps.sh (or flip the two toggles via
+API/dash), install Cloudflare One app on the iPhone, enrol to team, split
+tunnel Include-mode with only books.jdfalk.com. The Mode B resolver fix above
+is still worth shipping so the documented fallback actually works.
+
+### Q3 — AudioBooth OIDC/ASWebAuthenticationSession: NOT researched (ran out
+of clock). absauth.go:353 comment already documents the cookie-jar isolation
+problem. Next session: verify AudioBooth's actual SSO capabilities before
+spending anything on an OIDC shim.
+
+### Security fixes (mandatory pair): BLOCKED — server down, not booting;
+owner running SOL recovery in another session. Rotate ABS_JWT_SECRET +
+bind loopback + verify tunnel + confirm old tokens rejected REMAIN TO DO
+first thing once the box is back. (deploy/local.conf lives on the box.)
+
+### Also found
+- GitHub reports 5 dependabot vulns on default branch (2 high, 3 moderate) —
+  todo fragment added on this branch.
+- Pre-commit hook correctly blocks internal IPs in notes → keep using role
+  names in this log.
+
+## Next session pickup order
+
+1. Server back? → do the two security fixes + verify (see above).
+2. Implement + revert-validate the Mode B resolver fix (design above);
+   worktree `fix/abs-nonidentity-assertion-fallthrough`; PR + CI.
+3. Decide WARP enablement with owner (org+app toggles, phone enrolment).
+4. Q3 AudioBooth research → close the P0 verdict doc under docs/.
+5. Then Phase 1 merge matrix (untouched), Phases 2–4 (untouched except
+   worktree-prune list confirmed = 20 stale).
+
 ## Status
 
-COMPLETED: 3 — session log branch; origin auth code verified; edge posture measured
-REMAINING: P0 investigation (svc-token claims, WARP toggles via CF API, AudioBooth OIDC research, verdict doc) + P1–P4
-BLOCKED: 2 — ABS_JWT_SECRET rotation, loopback bind (server unreachable; ban-timer wait)
+COMPLETED: 6 — log branch; origin auth code verified; edge posture measured;
+Q1 answered w/ fix design (Mode B broken at resolver, file:line anchored);
+Q2 answered (edge config drift: neither mode configured; WARP = recommended);
+dependabot finding logged
+REMAINING: security-fix pair (server down); Mode B fix implementation; Q3
+research; P0 verdict doc; Phases 1–4 in full
+BLOCKED: 2 — ABS_JWT_SECRET rotation + loopback bind (box not booting; SOL
+recovery in progress in another session)

--- a/.claude/notes/2026-08-01-sso-continuation-prompt.md
+++ b/.claude/notes/2026-08-01-sso-continuation-prompt.md
@@ -1,0 +1,127 @@
+<!-- file: .claude/notes/2026-08-01-sso-continuation-prompt.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d7a9e18-4c62-4f95-b083-5e1c8a2b6d74 -->
+<!-- last-edited: 2026-07-31 -->
+
+# Continuation prompt — finish SSO so I can log in tonight
+
+Paste everything below the line into a fresh session in this repo.
+
+---
+
+ultracode
+
+# GOAL: I log into books.jdfalk.com tonight via SSO, typing no password.
+
+Work autonomously. Don't ask "ready?" — execute. Exact counts in every status
+report; never "all done" without a number. Worktree per task, conventional
+commits with trailers, version headers bumped, `changelog.d/` fragment per
+change, rebase/FF only. Commit and push after every discrete piece of work and
+append to `.claude/notes/2026-07-31-fable-session-log.md` as you go — a usage
+limit cuts you off without warning.
+
+## Where the previous session left it (verified tonight — don't re-derive)
+
+The **browser SSO chain is fully wired and live**. All five links verified:
+
+1. Cloudflare Access app `books.jdfalk.com` (aud `a2922a32…`), one policy:
+   allow, include `johnathan.falk@gmail.com`. Enforcing — bare `/status` 302s
+   to the Access login.
+2. `media-tunnel` healthy, 12 conns, runs on **rpi1-3 (not the origin host)**.
+   Ingress → `https://<server>:8484` with `noTLSVerify: true`. The origin's
+   self-signed cert is therefore **fine** — that was investigated and dismissed,
+   don't re-open it.
+3. Origin service active; startup log: `oauth: Cloudflare Access identity
+   passthrough enabled team=jdfalk.cloudflareaccess.com`. No warnings.
+   `deploy/local.conf` has `CF_ACCESS_TEAM_DOMAIN`, `CF_ACCESS_AUD`,
+   `OAUTH_ALLOWED_EMAILS`, `OAUTH_DEFAULT_ROLE=admin`, `ABS_API_ENABLED=true`,
+   `ABS_AUTH_MODES=cf,jwt`.
+4. `server_lifecycle.go:1189-1193` applies the CF middleware to `/api/v1`
+   fail-open; `middleware/auth.go:117-123` — `RequireAuth` returns early when an
+   earlier stage already bound the user.
+5. `web/src/contexts/AuthContext.tsx` → `getMe()` → `/api/v1/auth/me`, which sits
+   behind that middleware. A verified assertion ⇒ no login form.
+
+Open PRs: **#2085** (email as username — merge it) and **#2086** (TODO fragments
+capturing everything below).
+
+## STEP 1 — Prove it, or find out why not (do this first, it's ~2 minutes)
+
+Ask me to open `https://books.jdfalk.com` and say whether I land logged in or see
+the app's own login form. While I do, tail the origin:
+
+```
+ssh <server> 'journalctl -u audiobook-organizer -f | grep -iE "cfaccess|oauth resolve|not admitted|verification failed"'
+```
+
+- **Landed logged in** → web SSO is done. Go to STEP 2.
+- **Login form appears** → the most likely cause, and the one thing the previous
+  session could NOT check (admin API token stale, bootstrap token needs password
+  sudo): whether my existing `jdfalk` user has the allowlisted email set. If it
+  doesn't, `internal/oauth/resolve.go` step 4 misses and **step 5 creates a
+  second admin account** — you'd be logged into an empty user, not the one
+  holding 48,883 books of progress. Check the user records, and if that's it,
+  set the email on the existing account rather than letting a duplicate stand.
+  Also check for `not admitted` / `verification failed` in the log above.
+
+## STEP 2 — The two security fixes (MANDATORY, both need sudo on the box)
+
+Neither happened — the server was down for the entire previous window. I'll give
+you the sudo password when you ask.
+
+1. **Rotate `ABS_JWT_SECRET`.** It was leaked in plaintext to a chat transcript
+   and signs every ABS session token. Rotate in `deploy/local.conf`, redeploy,
+   confirm old tokens are rejected. Never print or commit it — redact with
+   `sed -E 's/(SECRET|TOKEN|KEY)=[^ ]*/\1=<redacted>/g'`.
+2. **Bind loopback instead of `0.0.0.0:8484`.** Right now anything on the LAN
+   reaches the origin directly, so Access is not a boundary at all. Careful:
+   **cloudflared runs on rpi1-3, not on this host** — a naive `127.0.0.1` bind
+   will break the tunnel. Work out the right interface, apply it, verify
+   `books.jdfalk.com` still serves, and say in the PR that direct-to-LAN
+   verification is now impossible by design.
+
+Do NOT enable `make deploy` blindly — `git pull --ff-only` first or you ship a
+stale binary from the local tree.
+
+## STEP 3 — The iPhone app (separate, unsolved problem)
+
+Two independent blockers, both diagnosed, neither fixed:
+
+- **Edge config drift.** Neither native-app mode is actually configured:
+  no `non_identity` policy, **no service tokens on the account at all**,
+  `allow_authenticate_via_warp` false org-wide, no cover-bypass app. The writeup
+  in `jdfalk/cloudflare-one` `access/audiobook-app-policies.md` is a *design*,
+  not the live state — `scripts/setup-audiobook-apps.sh` never ran (or was
+  rolled back).
+- **Mode B is broken in code.** A service-token assertion carries `common_name`
+  and no `email`, so `internal/oauth/cfaccess.go:59-60` rejects it and
+  `internal/server/middleware/absauth.go:166-171` makes that a terminal 401 —
+  **even when the request also carries a valid ABS bearer token** — and
+  `handlers/abs/login.go:53-55` puts it ahead of the password path too.
+
+**Recommended: Mode C (WARP).** It carries a real identity JWT with an `email`
+claim, which satisfies `cf` mode exactly as already coded — no app change, no
+`/status` change, no password. Enable the org + app WARP toggles, install
+Cloudflare One on the phone, enrol to the team, split tunnel in **Include** mode
+with only `books.jdfalk.com`.
+
+Ship the Mode B fix anyway so the documented fallback works: give `Verify` a
+typed `ErrNonIdentityAssertion` sentinel for a cryptographically *valid* but
+non-identity assertion, and map only that to a `(nil, nil)` fall-through in
+`ResolveCFAssertion` — every other Verify failure stays a terminal 401. Tests:
+(a) forged assertion still 401; (b) valid non-identity + valid bearer → 200;
+(c) valid non-identity, no bearer → 401 `no-credential`; (d) login with
+non-identity assertion + password body reaches the password path.
+**Revert-validate (b) and (d)** — reinstate the bug and paste the failing output
+in the PR. A test that still passes with the bug reinstated is not a test.
+
+## Then, if there's time
+
+`TODO.md` fragments `TODO-SEC-SYSTEMD` (no egress/syscall/capability
+confinement — needs Whisper `:19847` and Ollama `:11434` plus outbound HTTPS, so
+test before claiming it works) and `TODO-DEPS-VULN` (5 Dependabot advisories).
+Then 20 stale git worktrees to prune, `ResetPassword` 500s for every user
+(`handlers/user.go:220` builds the invite with `RoleID: ""`), and
+`internal/server` tests run 434–480s against a 600s default timeout.
+
+Full detail: `.claude/notes/2026-07-31-fable-session-log.md`.

--- a/todo.d/2026-07-31-abs-mode-b-nonidentity-assertion.md
+++ b/todo.d/2026-07-31-abs-mode-b-nonidentity-assertion.md
@@ -1,0 +1,23 @@
+<!-- file: todo.d/2026-07-31-abs-mode-b-nonidentity-assertion.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1a7c4e92-5d38-4b60-9f21-8c3e6a0b7d45 -->
+<!-- last-edited: 2026-07-31 -->
+
+- [ ] **TODO-ABS-MODEB** A Cloudflare **service-token** assertion is rejected as
+      invalid, so the documented "Mode B" (edge service token + our own bearer
+      token) cannot work at all. A `non_identity` Access JWT carries
+      `common_name` and **no `email` claim**, so
+      `internal/oauth/cfaccess.go:59-60` fails it, and
+      `internal/server/middleware/absauth.go:166-171` turns *any* Verify error
+      into a terminal 401 that deliberately never falls through to the bearer
+      path — so the request 401s **even when it also carries a valid ABS bearer
+      token**, and `internal/server/handlers/abs/login.go:53-55` makes password
+      login unreachable too. Fix: have `Verify` distinguish a cryptographically
+      *valid* but non-identity assertion (sig/iss/aud/exp all pass, no email)
+      from an invalid one via a typed sentinel (`ErrNonIdentityAssertion`), and
+      map only that sentinel to a `(nil, nil)` fall-through in
+      `ResolveCFAssertion` — every other Verify failure must stay a terminal
+      401. Tests: (a) forged assertion still 401; (b) valid non-identity + valid
+      bearer → 200 via jwt mode; (c) valid non-identity, no bearer → 401
+      `no-credential`; (d) login with non-identity assertion + password body
+      reaches the password path. Revert-validate (b) and (d).

--- a/todo.d/2026-07-31-ios-sso-edge-config-drift.md
+++ b/todo.d/2026-07-31-ios-sso-edge-config-drift.md
@@ -1,0 +1,24 @@
+<!-- file: todo.d/2026-07-31-ios-sso-edge-config-drift.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8c5f1a37-9b24-4e08-a761-2d0e6b8c4f19 -->
+<!-- last-edited: 2026-07-31 -->
+
+- [ ] **TODO-SSO-EDGE** Neither native-app auth mode is actually configured at
+      the Cloudflare edge, despite both being fully written up in
+      `jdfalk/cloudflare-one` `access/audiobook-app-policies.md`. Measured via
+      the CF API on 2026-07-31: the `books.jdfalk.com` Access app has exactly
+      **one** policy (precedence 1, `allow`, email allowlist) — there is **no
+      `non_identity` service-token policy** and **no service tokens exist on the
+      account at all**; app-level `allow_authenticate_via_warp` is unset and
+      org-level is `false`; and no cover-art bypass app exists (confirmed live —
+      the cover path 302s to Access instead of reaching the origin). That fully
+      explains the measured `service_token_status:false, is_warp:false,
+      auth_status:NONE`. So `scripts/setup-audiobook-apps.sh` never ran against
+      this account, or was rolled back — the doc describes a **design**, not the
+      live state. Recommended path is **Mode C (WARP)**: it delivers a real
+      identity JWT with an `email` claim, which satisfies `cf` mode exactly as
+      already coded — no app changes, no `/status` change, no password. Mode B
+      additionally needs TODO-ABS-MODEB fixed before it can work.
+
+- [ ] **TODO-DEPS-VULN** GitHub reports 5 Dependabot vulnerabilities on the
+      default branch (2 high, 3 moderate). Triage and bump.

--- a/todo.d/2026-07-31-origin-security-hardening.md
+++ b/todo.d/2026-07-31-origin-security-hardening.md
@@ -1,0 +1,31 @@
+<!-- file: todo.d/2026-07-31-origin-security-hardening.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6e2b8d05-3f41-4a97-8c50-7d1a9b4e2c68 -->
+<!-- last-edited: 2026-07-31 -->
+
+- [ ] **TODO-SEC-BIND** The service binds every interface
+      (`ExecStart=… serve --host 0.0.0.0 --port 8484`), so anything on the LAN
+      reaches the origin directly and **Cloudflare Access is not a boundary** —
+      the edge is only enforced for traffic that arrives through the tunnel.
+      Bind loopback (or the tunnel-facing interface only) in
+      `deploy/local.conf` so Access becomes the single front door, then verify
+      the tunnel still serves `books.jdfalk.com`. Note in the PR that
+      direct-to-LAN verification is no longer possible **by design** after this.
+      The tunnel connector runs on rpi1-3, not on the origin host, so the
+      loopback bind must account for that hop.
+
+- [ ] **TODO-SEC-JWT** Rotate `ABS_JWT_SECRET` — it was pasted in plaintext into
+      a chat transcript on 2026-07-31. It signs every ABS session token. Rotate
+      it in `deploy/local.conf` (gitignored — never commit or print it; redact
+      with `sed -E 's/(SECRET|TOKEN|KEY)=[^ ]*/\1=<redacted>/g'` when dumping a
+      unit), redeploy, and confirm previously-issued tokens are rejected.
+
+- [ ] **TODO-SEC-SYSTEMD** The unit has `User=audiobook`, `NoNewPrivileges`,
+      `ProtectKernelTunables`, `ProtectControlGroups` and `PrivateTmp`, but no
+      `ProtectSystem=strict`, no `ReadWritePaths`, no `CapabilityBoundingSet`,
+      no `SystemCallFilter` and **no egress restriction**. `IPAddressDeny=any`
+      plus a narrow allowlist is what stops a compromised process reaching the
+      rest of the LAN. It needs the Whisper host on `:19847` and Ollama on
+      `:11434`, plus outbound HTTPS for OpenLibrary/AcoustID — an over-tight
+      rule silently breaks metadata and transcription, so test before claiming
+      it works.


### PR DESCRIPTION
Fragments only — no code changes. Captures the findings from the 2026-07-31 session that are **not** fixed in it, each with root-cause hints and `file:line` anchors so the next session doesn't re-derive them.

| Task | Finding |
|---|---|
| `TODO-ABS-MODEB` | A service-token (`non_identity`) Access JWT has no `email` claim, so `cfaccess.go:59` fails it and `absauth.go:166` makes that a terminal 401 — **even alongside a valid bearer token**. Documented "Mode B" cannot work. Fix design + 4 tests included. |
| `TODO-SSO-EDGE` | Measured via CF API: the Access app has **one** allow policy, **no** `non_identity` policy, **no** service tokens on the account, WARP auth `false` org-wide, no cover bypass app. Neither native-app mode is actually configured; the policy doc describes a design, not the live state. |
| `TODO-SEC-BIND` | `--host 0.0.0.0` means anything on the LAN reaches the origin directly and Access is not a boundary. |
| `TODO-SEC-JWT` | `ABS_JWT_SECRET` was leaked in plaintext to a transcript; it signs every ABS session token. |
| `TODO-SEC-SYSTEMD` | Unit lacks `ProtectSystem=strict`, `ReadWritePaths`, `CapabilityBoundingSet`, `SystemCallFilter`, and any egress restriction. |
| `TODO-DEPS-VULN` | 5 Dependabot advisories on the default branch (2 high, 3 moderate). |

Also carries the session log at `.claude/notes/2026-07-31-fable-session-log.md` (force-added past `.gitignore` deliberately — it is the recovery record for a run-to-usage-limit session).

**Not** included: the web-SSO chain was verified working end to end at the config level tonight; that needed no fix. The `noTLSVerify` concern I chased was unfounded and is deliberately absent here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp