### PR TITLE
fix(server): bind Cloudflare Access identity on the /api/events SSE route

### DIFF
--- a/changelog.d/20260731_235800_sse_cf_access_identity.md
+++ b/changelog.d/20260731_235800_sse_cf_access_identity.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/20260731_235800_sse_cf_access_identity.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b755d63b-08fa-4bac-a0fc-a6b3159672c2 -->
+<!-- last-edited: 2026-07-31 -->
+
+### Fixed
+
+- The live-updates stream (`/api/events`) now works for browsers signed in through
+  Cloudflare Access SSO. It was returning 401 on a permanent reconnect loop, so the UI
+  showed a "Connection lost" banner even though the page had loaded and every other
+  request succeeded.
+
+  `/api/events` is registered as a top-level route rather than inside the `/api/v1`
+  group, so it inherited none of that group's middleware — including the Cloudflare
+  Access identity stage. Its auth guard assumed a browser would always present a
+  session cookie, which is true for password login but false under Access SSO, where
+  identity arrives only as a verified `Cf-Access-Jwt-Assertion` header. The route now
+  runs the same fail-open identity middleware as `/api/v1` before its auth guard.
+  Anonymous clients are still rejected (pen-test finding MED-2 is unaffected).

--- a/internal/server/events_chain.go
+++ b/internal/server/events_chain.go
@@ -1,0 +1,36 @@
+// file: internal/server/events_chain.go
+// version: 1.0.0
+// guid: 7a1c4f28-95d6-4b03-8e2f-c61d0a8b3947
+// last-edited: 2026-07-31
+
+package server
+
+import "github.com/gin-gonic/gin"
+
+// buildEventsChain composes the gin handler chain for the top-level /api/events
+// SSE route.
+//
+// /api/events is registered directly on the router rather than inside the
+// /api/v1 group (it must sit ahead of the /api/* redirect middleware), which
+// means it inherits none of that group's middleware and has to assemble an
+// equivalent chain by hand. The ordering mirrors /api/v1 exactly:
+//
+//	cfMW (fail-open identity binding)  →  authGuard (RequireAuth)  →  handler
+//
+// cfMW is optional and is nil whenever Cloudflare Access is not configured
+// (CF_ACCESS_TEAM_DOMAIN / CF_ACCESS_AUD unset), so it is appended only when
+// present — a nil gin.HandlerFunc in the chain would panic on dispatch.
+//
+// Why cfMW has to be here at all: under Cloudflare Access SSO the browser holds
+// no application session cookie. Identity arrives solely as a verified
+// Cf-Access-Jwt-Assertion header, and cfMW is the only stage that reads it and
+// binds the resolved user. Without cfMW the authGuard sees an anonymous request
+// and 401s, so EventSource enters a permanent reconnect loop and the UI shows
+// "Connection lost" even though every /api/v1 request succeeds.
+func buildEventsChain(cfMW, authGuard, handler gin.HandlerFunc) []gin.HandlerFunc {
+	chain := make([]gin.HandlerFunc, 0, 3)
+	if cfMW != nil {
+		chain = append(chain, cfMW)
+	}
+	return append(chain, authGuard, handler)
+}

--- a/internal/server/events_chain_test.go
+++ b/internal/server/events_chain_test.go
@@ -1,0 +1,103 @@
+// file: internal/server/events_chain_test.go
+// version: 1.0.0
+// guid: 3e8b56d1-04af-42c7-9b18-5d7a2f0c6e94
+// last-edited: 2026-07-31
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// boundUserKey mirrors the context key that middleware.CloudflareAccessAuth sets
+// and middleware.RequireAuth early-outs on. The real constant is unexported in
+// the middleware package; the contract it encodes — "an upstream stage may bind
+// a user, and the auth guard must then admit without a session" — is locked
+// independently by middleware/cfaccess_earlyout_test.go. These tests cover the
+// other half: that /api/events actually HAS that upstream stage in its chain.
+const boundUserKey = "user"
+
+// stubCFMW stands in for the Cloudflare Access middleware: it binds a user when
+// a verified assertion is present and otherwise passes through untouched
+// (fail-open), exactly as the real middleware does.
+func stubCFMW(c *gin.Context) {
+	if c.GetHeader("Cf-Access-Jwt-Assertion") != "" {
+		c.Set(boundUserKey, "cf-user")
+	}
+	c.Next()
+}
+
+// stubAuthGuard stands in for middleware.RequireAuth: admit if some upstream
+// stage already bound a user, otherwise demand a session cookie and 401.
+func stubAuthGuard(c *gin.Context) {
+	if _, ok := c.Get(boundUserKey); ok {
+		c.Next()
+		return
+	}
+	if _, err := c.Cookie("session"); err != nil {
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	c.Next()
+}
+
+func okHandler(c *gin.Context) { c.String(http.StatusOK, "stream") }
+
+func serveEvents(t *testing.T, chain []gin.HandlerFunc, setHeader bool) int {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/events", chain...)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	if setHeader {
+		req.Header.Set("Cf-Access-Jwt-Assertion", "verified-token")
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// The regression this file exists for. A browser authenticated purely by
+// Cloudflare Access has NO session cookie — identity is only in the assertion
+// header — so /api/events must carry the CF middleware or it 401s forever and
+// the UI shows a permanent "Connection lost" banner.
+func TestBuildEventsChain_CFAssertionAdmittedWithoutSessionCookie(t *testing.T) {
+	chain := buildEventsChain(stubCFMW, stubAuthGuard, okHandler)
+	if got := serveEvents(t, chain, true); got != http.StatusOK {
+		t.Fatalf("a verified Access assertion must be admitted without a session cookie; got %d, want %d", got, http.StatusOK)
+	}
+}
+
+// Proves the above test actually detects the bug: drop cfMW from the chain (the
+// pre-fix wiring) and the very same request 401s.
+func TestBuildEventsChain_WithoutCFMWTheAssertionIs401(t *testing.T) {
+	chain := buildEventsChain(nil, stubAuthGuard, okHandler)
+	if got := serveEvents(t, chain, true); got != http.StatusUnauthorized {
+		t.Fatalf("without cfMW an Access-only client must 401 (this is the bug being fixed); got %d, want %d", got, http.StatusUnauthorized)
+	}
+}
+
+// cfMW is fail-open, not fail-closed: it must not admit a request that carries
+// no assertion at all. Anonymous clients still get 401 (pen-test finding MED-2).
+func TestBuildEventsChain_AnonymousStill401(t *testing.T) {
+	chain := buildEventsChain(stubCFMW, stubAuthGuard, okHandler)
+	if got := serveEvents(t, chain, false); got != http.StatusUnauthorized {
+		t.Fatalf("anonymous clients must still be rejected; got %d, want %d", got, http.StatusUnauthorized)
+	}
+}
+
+// When Cloudflare Access is unconfigured cfMW is nil, and a nil handler in a gin
+// chain panics on dispatch. Assert it is omitted rather than appended.
+func TestBuildEventsChain_NilCFMWOmitted(t *testing.T) {
+	if got := len(buildEventsChain(nil, stubAuthGuard, okHandler)); got != 2 {
+		t.Fatalf("nil cfMW must be omitted from the chain; got %d handlers, want 2", got)
+	}
+	if got := len(buildEventsChain(stubCFMW, stubAuthGuard, okHandler)); got != 3 {
+		t.Fatalf("a non-nil cfMW must be prepended; got %d handlers, want 3", got)
+	}
+}

--- a/internal/server/server_lifecycle.go
+++ b/internal/server/server_lifecycle.go
@@ -1,7 +1,7 @@
 // file: internal/server/server_lifecycle.go
-// version: 3.5.0
+// version: 3.6.0
 // guid: 2f98675b-61e1-45a0-94e9-e7fdeb8f273e
-// last-edited: 2026-07-30
+// last-edited: 2026-07-31
 
 package server
 
@@ -1103,20 +1103,38 @@ func (s *Server) setupRoutes() {
 	s.router.GET("/api/health", func(c *gin.Context) { s.systemHandler.HealthCheck(c) })
 	s.router.GET("/api/v1/health", func(c *gin.Context) { s.systemHandler.HealthCheck(c) })
 
+	// OAuth2/OIDC login + Cloudflare Access passthrough (both no-ops unless
+	// configured). Built HERE, before the /api/events route below, rather than
+	// alongside the /api/v1 group further down: gin binds a route's middleware
+	// chain at registration time, so /api/events — a top-level route, not a
+	// child of /api/v1 — can only inherit cfMW if cfMW already exists when the
+	// route is registered. buildOAuthWiring is a pure constructor (it reads
+	// config and builds handlers/verifiers; it registers no routes), so calling
+	// it earlier is safe. It is still called exactly once.
+	oauthH, cfMW := s.buildOAuthWiring()
+
 	// Real-time events (SSE). Same pre-middleware-ordering rationale as /health.
 	// Gated behind auth (pen-test finding MED-2): the stream carries library
 	// events (imports, scan progress, metadata updates) that anonymous clients
-	// must not see. A browser EventSource automatically sends the HttpOnly
-	// session cookie, so the logged-in UI keeps working; anonymous clients get
-	// 401. When auth is disabled (local single-user mode) this is a no-op, like
-	// the rest of the API. Built inline because the shared authMiddleware is
-	// constructed later in this function (and routes registered before a
-	// router.Use() don't inherit it).
+	// must not see. Anonymous clients get 401. When auth is disabled (local
+	// single-user mode) this is a no-op, like the rest of the API. Built inline
+	// because the shared authMiddleware is constructed later in this function
+	// (and routes registered before a router.Use() don't inherit it).
+	//
+	// cfMW runs FIRST and fail-open, exactly as it does on /api/v1: it binds the
+	// user resolved from a valid Cf-Access-Jwt-Assertion so the RequireAuth below
+	// short-circuits, and otherwise passes through untouched. Without it this
+	// route was the one authenticated endpoint the Cloudflare Access passthrough
+	// never reached, because a browser under Access SSO has NO session cookie —
+	// identity arrives only in that header — so EventSource 401'd in a reconnect
+	// loop and the UI showed a permanent "Connection lost" banner while every
+	// /api/v1 call succeeded.
 	eventsAuth := gin.HandlerFunc(func(c *gin.Context) { c.Next() })
 	if config.AppConfig.EnableAuth {
 		eventsAuth = servermiddleware.RequireAuth(s.Store())
 	}
-	s.router.GET("/api/events", eventsAuth, func(c *gin.Context) { s.systemHandler.HandleEvents(c) })
+	s.router.GET("/api/events", buildEventsChain(cfMW, eventsAuth,
+		func(c *gin.Context) { s.systemHandler.HandleEvents(c) })...)
 
 	// Public temp-login consumer at the root so URLs are short and
 	// browser-friendly. Validates the token, deletes it (single-use),
@@ -1172,8 +1190,8 @@ func (s *Server) setupRoutes() {
 		slog.Warn("rate limiting is disabled (enable_rate_limitfalse) — the API is vulnerable to abuse. Set enable_rate_limit true in config.yaml for production deployments")
 	}
 
-	// OAuth2/OIDC login + Cloudflare Access passthrough (both no-ops unless configured).
-	oauthH, cfMW := s.buildOAuthWiring()
+	// oauthH and cfMW were built earlier, before the /api/events route that also
+	// needs cfMW — see the comment at that call site.
 
 	// Audiobookshelf-compatible surface. A separate TOP-LEVEL group, not a child of
 	// /api/v1, with its own FAIL-CLOSED identity middleware — it must not inherit the


### PR DESCRIPTION
## The bug

Signed in through Cloudflare Access SSO, the app loads and every `/api/v1` request
succeeds — but the UI shows a permanent **"Connection lost"** banner. Reproduced in a
desktop browser and in the iOS webview.

Origin log, one browser session:

```
| 200 |   1.68ms | GET "/api/v1/auth/me"
| 401 |   3.24ms | GET "/api/events"
| 401 | 577.437µs | GET "/api/events"
| 401 |    1.2ms | GET "/api/events"
| 401 | 448.442µs | GET "/api/events"     <- EventSource reconnect loop
```

## Root cause

`/api/events` is registered directly on the router (`server_lifecycle.go`), not inside
the `/api/v1` group — deliberately, so it sits ahead of the `/api/*` redirect
middleware. The consequence is that it inherits **none** of that group's middleware,
including the fail-open Cloudflare Access stage that binds the user resolved from a
verified `Cf-Access-Jwt-Assertion`.

The stale assumption was written in the route's own comment:

> A browser EventSource automatically sends the HttpOnly session cookie, so the
> logged-in UI keeps working

True for password login. **False under Access SSO**, where the browser holds no
application session cookie at all — identity arrives only in that header, and `cfMW` is
the only stage that reads it. `RequireAuth` alone saw an anonymous request and 401'd.

This was the one authenticated endpoint the Access passthrough never reached.

## The fix

gin binds a route's middleware chain at registration time, so a later `Use()` cannot
retrofit it. `buildOAuthWiring()` is hoisted above the route registration instead — it
is a pure constructor (reads config, builds handlers/verifiers, registers no routes)
and is still called exactly once.

Chain composition is extracted to `buildEventsChain()` so it is testable. It mirrors
`/api/v1` exactly — `cfMW` → `RequireAuth` → handler — and omits `cfMW` when nil
(Access unconfigured), since a nil handler in a gin chain panics on dispatch.

## Tests

`internal/server/events_chain_test.go`, 4 tests, all passing:

| Test | Asserts |
|---|---|
| `CFAssertionAdmittedWithoutSessionCookie` | Access assertion + no cookie → 200 |
| `WithoutCFMWTheAssertionIs401` | **revert-validation** — the pre-fix chain 401s the same request |
| `AnonymousStill401` | `cfMW` is fail-open, not fail-closed; MED-2 holds |
| `NilCFMWOmitted` | nil `cfMW` omitted (2 handlers) vs prepended (3) |

```
--- PASS: TestBuildEventsChain_CFAssertionAdmittedWithoutSessionCookie (0.00s)
--- PASS: TestBuildEventsChain_WithoutCFMWTheAssertionIs401 (0.00s)
--- PASS: TestBuildEventsChain_AnonymousStill401 (0.00s)
--- PASS: TestBuildEventsChain_NilCFMWOmitted (0.00s)
ok  github.com/falkcorp/audiobook-organizer/internal/server 0.757s
```

`WithoutCFMWTheAssertionIs401` is the guard that keeps this suite honest: it drives the
pre-fix wiring through the same request and requires the 401, so the passing case
cannot go green for the wrong reason.

## Security

No widening. `cfMW` is fail-open by design — it binds a user only for a
cryptographically verified assertion that passes the email allowlist, and otherwise
passes through untouched to `RequireAuth`. Anonymous clients still get 401. This route
now has exactly the auth posture `/api/v1` already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp