### PR TITLE
fix(abs): let a non-identity Access assertion fall through to the bearer

### DIFF
--- a/changelog.d/20260801_003000_abs_nonidentity_assertion.md
+++ b/changelog.d/20260801_003000_abs_nonidentity_assertion.md
@@ -1,0 +1,31 @@
+<!-- file: changelog.d/20260801_003000_abs_nonidentity_assertion.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a3055725-e818-471e-b4e7-d5525fa4515a -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+- Audiobookshelf clients reaching the server through a Cloudflare Access **service
+  token** are no longer rejected. Cloudflare mints a token with no email claim for a
+  service token — it identifies a machine, not a person — and the server treated that
+  as a forged credential and returned a terminal 401, even when the request also
+  carried a perfectly valid bearer token. That made the whole service-token topology
+  unusable, which is the one a native player app needs.
+
+  A valid-but-anonymous assertion now falls through to the bearer token, exactly as if
+  no assertion had been sent. Every other verification failure — forged signature,
+  wrong issuer, wrong audience, expired — remains a hard 401, and a service token with
+  no bearer alongside it is still rejected: it proves a device may reach the server,
+  never who the user is.
+
+### Added
+
+- An opt-in diagnostic that logs which credentials each Audiobookshelf client actually
+  puts on the wire — set `ABS_AUTH_PROBE=1`. It records presence and length only, never
+  a credential value, and is off by default because these routes are polled every
+  15–20 seconds.
+
+  It exists to settle by observation a question no amount of reading a client's source
+  can answer: after a player app signs in through its embedded web view, does its
+  ordinary API client actually carry the resulting Cloudflare cookie, or does it use a
+  separate cookie store and silently drop it?

--- a/internal/oauth/cfaccess.go
+++ b/internal/oauth/cfaccess.go
@@ -1,17 +1,35 @@
 // file: internal/oauth/cfaccess.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3a7e0c92-8b41-4d56-9f08-1c6b2a5d7e39
-// last-edited: 2026-07-26
+// last-edited: 2026-08-01
 
 package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	oidc "github.com/coreos/go-oidc/v3/oidc"
 )
+
+// ErrNonIdentityAssertion reports an Access token that is cryptographically VALID —
+// correct signature, issuer, expiry and aud — but carries no identity, i.e. no email
+// claim. Cloudflare mints exactly this shape for a service token, where the caller is
+// a machine credential rather than a person.
+//
+// It is a distinct sentinel because "no identity in this token" and "this token is
+// not trustworthy" demand opposite handling. A forged or expired token must be a
+// terminal 401: the credential is bad and no other credential should rescue it. A
+// non-identity token is merely silent about who the caller is, so the request should
+// fall through to whatever other credential it carries — for us, the ABS bearer token
+// — instead of being rejected outright. Collapsing the two (the original bug) made a
+// service token fatal even when the request also presented a perfectly valid bearer,
+// which is precisely the Mode B topology the edge is configured for.
+//
+// Callers MUST match with errors.Is, not string comparison; it is returned wrapped.
+var ErrNonIdentityAssertion = errors.New("cfaccess: assertion carries no identity (no email claim)")
 
 // CFAccessHeader is the request header Cloudflare Access injects with the signed
 // application token once a user has authenticated at the edge.
@@ -57,7 +75,11 @@ func (v *CFAccessVerifier) Verify(ctx context.Context, rawJWT string) (*Identity
 		return nil, fmt.Errorf("cfaccess: parse claims: %w", err)
 	}
 	if claims.Email == "" {
-		return nil, fmt.Errorf("cfaccess: jwt has no email claim")
+		// Wrapped, not returned bare, so the sub is available for logging while
+		// errors.Is(err, ErrNonIdentityAssertion) still matches. Reaching here means
+		// the signature/issuer/aud checks above all PASSED — this is a trusted token
+		// that simply names no person.
+		return nil, fmt.Errorf("%w (sub=%q)", ErrNonIdentityAssertion, claims.Sub)
 	}
 	subject := claims.Sub
 	if subject == "" {

--- a/internal/server/middleware/absauth.go
+++ b/internal/server/middleware/absauth.go
@@ -1,7 +1,7 @@
 // file: internal/server/middleware/absauth.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: e7051b93-6c28-4a0f-9d34-b8f2a61c05de
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package middleware
 
@@ -165,8 +165,24 @@ func (r *ABSIdentityResolver) ResolveCFAssertion(c *gin.Context) (*ABSIdentity, 
 
 	claims, err := r.verifier.Verify(c.Request.Context(), raw)
 	if err != nil {
-		// FAIL CLOSED. This is the single most important difference from
-		// CloudflareAccessAuth: no c.Next(), no fall-through to the bearer path.
+		// A cryptographically VALID assertion that simply names no person — the shape
+		// Cloudflare mints for a service token — is NOT a bad credential. Report "no
+		// CF identity here" and let the caller try the bearer token, exactly as if no
+		// assertion had been sent at all. This is the Mode B topology: the service
+		// token proves the device may reach the origin, and our own ABS JWT proves
+		// who the user is. Treating it as fatal (the original bug) 401'd every Mode B
+		// request even when it carried a perfectly valid bearer alongside.
+		//
+		// Note this does NOT widen access: falling through lands on the bearer path,
+		// which is itself fail-closed. A request with a service token and no bearer
+		// still gets 401 — it has simply not proven who it is.
+		if errors.Is(err, oauth.ErrNonIdentityAssertion) {
+			return nil, nil
+		}
+		// Everything else FAILS CLOSED — forged signature, wrong issuer, wrong aud,
+		// expired. This is the single most important difference from
+		// CloudflareAccessAuth: no c.Next(), no fall-through to the bearer path. A
+		// bad credential must not be rescued by presenting a second one.
 		return nil, absErr(http.StatusUnauthorized, "assertion-invalid",
 			"invalid Cloudflare Access assertion", ABSModeCF)
 	}

--- a/internal/server/middleware/absauth_nonidentity_test.go
+++ b/internal/server/middleware/absauth_nonidentity_test.go
@@ -1,0 +1,141 @@
+// file: internal/server/middleware/absauth_nonidentity_test.go
+// version: 1.0.0
+// guid: 8d3f07c5-1b96-4e2a-a740-6f5c93b1e082
+// last-edited: 2026-08-01
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/oauth"
+	"github.com/gin-gonic/gin"
+)
+
+// These tests cover the Mode B topology: Cloudflare Access admits the request on a
+// SERVICE TOKEN (a machine credential, no person attached), and our own ABS bearer
+// token says who the user is. The assertion Cloudflare mints in that case is
+// cryptographically valid but has no email claim.
+//
+// The original bug collapsed "valid but anonymous" into "invalid", so every Mode B
+// request was a terminal 401 even when it carried a perfectly good bearer alongside.
+// The fix distinguishes the two with oauth.ErrNonIdentityAssertion. The danger in a
+// fix like this is over-correcting into a fail-open, so the tests below pin BOTH
+// edges: the non-identity case falls through, and every other verification failure
+// stays a hard 401.
+
+const svcTokenAssertion = "valid-but-no-identity"
+
+func nonIdentityHarness(t *testing.T) *absHarness {
+	t.Helper()
+	h := newABSHarness(t, "cf,jwt", []string{"owner@example.com"})
+	h.verifier.nonIdentity = map[string]bool{svcTokenAssertion: true}
+	return h
+}
+
+// (a) A forged assertion must STILL be a terminal 401, and must still refuse to be
+// rescued by a valid bearer. This is the over-correction guard: if the sentinel were
+// matched too loosely (say, by string matching, or by treating any Verify error as
+// non-identity), this test goes red.
+func TestABSAuth_NonIdentity_ForgedAssertionStillHard401(t *testing.T) {
+	h := nonIdentityHarness(t)
+	h.store.addUser(activeUser("u1", "owner"))
+	h.store.addSession(liveABSSession("s1", "u1"))
+	bearer := h.mintAccess(t, "u1", "s1")
+
+	for _, forged := range []string{"not-a-jwt", "a.b.c", "forged", svcTokenAssertion + "-tampered"} {
+		w := h.do(http.MethodGet, "/api/me", map[string]string{
+			oauth.CFAccessHeader: forged,
+			"Authorization":      "Bearer " + bearer,
+		})
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("forged assertion %q: got %d, want 401 — a bad credential must never be rescued by a second one (body: %s)",
+				forged, w.Code, w.Body.String())
+		}
+	}
+}
+
+// (b) THE FIX. A valid service-token assertion carries no identity, so the request
+// must fall through to the bearer token and be admitted as that user.
+func TestABSAuth_NonIdentity_WithBearerIsAdmitted(t *testing.T) {
+	h := nonIdentityHarness(t)
+	h.store.addUser(activeUser("u1", "owner"))
+	h.store.addSession(liveABSSession("s1", "u1"))
+	bearer := h.mintAccess(t, "u1", "s1")
+
+	w := h.do(http.MethodGet, "/api/me", map[string]string{
+		oauth.CFAccessHeader: svcTokenAssertion,
+		"Authorization":      "Bearer " + bearer,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 — a service-token assertion carries no identity and must fall through to the bearer (body: %s)",
+			w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"u1"`) {
+		t.Fatalf("resolved the wrong user: %s", w.Body.String())
+	}
+	// The user was proven by the BEARER, not the assertion. If this reported the CF
+	// mode, the assertion would have been credited with an identity it never carried.
+	if strings.Contains(w.Body.String(), `"mode":"cf"`) {
+		t.Fatalf("mode must not be cf — identity came from the bearer, not the assertion: %s", w.Body.String())
+	}
+}
+
+// (c) Falling through is NOT the same as being admitted. A service token alone
+// proves a device may reach the origin; it never says who the user is, so with no
+// bearer the request must still be rejected.
+func TestABSAuth_NonIdentity_WithoutBearerIs401(t *testing.T) {
+	h := nonIdentityHarness(t)
+	h.store.addUser(activeUser("u1", "owner"))
+
+	w := h.do(http.MethodGet, "/api/me", map[string]string{
+		oauth.CFAccessHeader: svcTokenAssertion,
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401 — a service token is not an identity; falling through must not mean admitting (body: %s)",
+			w.Code, w.Body.String())
+	}
+}
+
+// (d) POST /login and POST /auth/refresh call ResolveCFAssertion directly, and read
+// its (nil, nil) return as "no CF identity here, do the normal password check". A
+// service-token assertion must produce exactly that, so a Mode B client can still log
+// in with a username and password. Before the fix it produced a terminal 401 instead,
+// making login impossible for the very topology Mode B exists to serve.
+func TestABSAuth_NonIdentity_LoginReachesPasswordPath(t *testing.T) {
+	h := nonIdentityHarness(t)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/login", nil)
+	c.Request.Header.Set(oauth.CFAccessHeader, svcTokenAssertion)
+
+	identity, authErr := h.resolver.ResolveCFAssertion(c)
+	if authErr != nil {
+		t.Fatalf("got error %+v, want nil — a service-token assertion must not block /login; "+
+			"the client has to be able to fall through to the password check", authErr)
+	}
+	if identity != nil {
+		t.Fatalf("got identity %+v, want nil — the assertion named no person, so nothing may be resolved from it", identity)
+	}
+}
+
+// A forged assertion on /login must still be terminal. Pairs with (d): the fall-
+// through is granted to the non-identity case ONLY.
+func TestABSAuth_NonIdentity_LoginStillRejectsForgedAssertion(t *testing.T) {
+	h := nonIdentityHarness(t)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/login", nil)
+	c.Request.Header.Set(oauth.CFAccessHeader, "forged")
+
+	identity, authErr := h.resolver.ResolveCFAssertion(c)
+	if authErr == nil {
+		t.Fatalf("want a terminal error for a forged assertion on /login, got nil (identity=%+v)", identity)
+	}
+	if authErr.Status != http.StatusUnauthorized {
+		t.Fatalf("got status %d, want 401 for a forged assertion", authErr.Status)
+	}
+}

--- a/internal/server/middleware/absauth_test.go
+++ b/internal/server/middleware/absauth_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/middleware/absauth_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b41e6d09-8a37-4f52-9c10-25d7b8e0f346
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package middleware
 
@@ -30,14 +30,24 @@ type fakeCFVerifier struct {
 	// byToken maps a raw assertion to the identity it verifies to. Anything not in
 	// the map fails verification, which is what a forged/malformed header looks like.
 	byToken map[string]*oauth.IdentityClaims
-	calls   int
-	mu      sync.Mutex
+	// nonIdentity holds assertions that are cryptographically VALID but carry no
+	// email claim -- the shape Cloudflare mints for a service token. Distinct from
+	// "not in byToken", which means the token did not verify at all. nil by default,
+	// so existing tests are unaffected.
+	nonIdentity map[string]bool
+	calls       int
+	mu          sync.Mutex
 }
 
 func (f *fakeCFVerifier) Verify(_ context.Context, raw string) (*oauth.IdentityClaims, error) {
 	f.mu.Lock()
 	f.calls++
 	f.mu.Unlock()
+	if f.nonIdentity[raw] {
+		// Mirrors the real verifier: signature/issuer/aud all PASSED, there is simply
+		// no person named in the token.
+		return nil, fmt.Errorf("%w (sub=%q)", oauth.ErrNonIdentityAssertion, "svc-token")
+	}
 	if c, ok := f.byToken[raw]; ok {
 		return c, nil
 	}
@@ -154,6 +164,10 @@ type absHarness struct {
 	store    *fakeABSStore
 	cfg      *absauth.Config
 	verifier *fakeCFVerifier
+	// resolver is exposed so tests can call ResolveCFAssertion directly. That is
+	// the exact entry point POST /login and POST /auth/refresh use, and its
+	// (nil, nil) return is what "fall through to the password check" means.
+	resolver *ABSIdentityResolver
 }
 
 func newABSHarness(t *testing.T, modes string, allowed []string) *absHarness {
@@ -175,7 +189,7 @@ func newABSHarness(t *testing.T, modes string, allowed []string) *absHarness {
 			"user": u.ID, "mode": ABSAuthMode(c), "sid": ABSSessionID(c),
 		})
 	})
-	return &absHarness{router: r, store: store, cfg: cfg, verifier: verifier}
+	return &absHarness{router: r, store: store, cfg: cfg, verifier: verifier, resolver: resolver}
 }
 
 func (h *absHarness) do(method, path string, headers map[string]string) *httptest.ResponseRecorder {

--- a/internal/server/middleware/absauthprobe.go
+++ b/internal/server/middleware/absauthprobe.go
@@ -1,5 +1,5 @@
 // file: internal/server/middleware/absauthprobe.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c9f21a7-3e64-48db-b0d2-9a8e7c4f6103
 // last-edited: 2026-08-01
 
@@ -48,12 +48,22 @@ func ABSAuthProbe() gin.HandlerFunc {
 		assertion := strings.TrimSpace(c.GetHeader(oauth.CFAccessHeader))
 		authz := strings.TrimSpace(c.GetHeader("Authorization"))
 
-		// The edge cookie. Its PRESENCE is the whole question: it means the app's
-		// API client shares a cookie jar with the webview that logged in, and the
-		// request would satisfy Cloudflare Access on its own.
-		cfCookie := ""
-		if ck, err := c.Request.Cookie("CF_Authorization"); err == nil && ck != nil {
-			cfCookie = ck.Value
+		// The edge cookie. Its presence is the whole question: it means the app's API
+		// client shares a cookie jar with the webview that logged in, and the request
+		// would satisfy Cloudflare Access on its own.
+		//
+		// We log the NAMES of every cookie rather than probing for "CF_Authorization"
+		// specifically. Access normally uses that name, but it can be configured with
+		// a custom one, and a hardcoded lookup would then report "no cookie" for a
+		// request that carried it — a false negative on the single question this probe
+		// exists to answer. Names cannot authenticate anything; values are never read.
+		cookieNames := make([]string, 0, 4)
+		cfCookieLen := 0
+		for _, ck := range c.Request.Cookies() {
+			cookieNames = append(cookieNames, ck.Name)
+			if strings.HasPrefix(strings.ToUpper(ck.Name), "CF_") {
+				cfCookieLen += len(ck.Value)
+			}
 		}
 
 		bearerKind := "none"
@@ -77,9 +87,12 @@ func ABSAuthProbe() gin.HandlerFunc {
 			// Mode C / browser-SSO signal: the edge verified a person and injected this.
 			"cf_assertion", assertion != "",
 			"cf_assertion_len", len(assertion),
-			// THE question this probe was built for.
-			"cf_cookie", cfCookie != "",
-			"cf_cookie_len", len(cfCookie),
+			// THE question this probe was built for. cookie_names is the ground truth
+			// (a CF_-prefixed name means the edge cookie rode along); cf_cookie_len is
+			// the convenience roll-up.
+			"cookie_names", strings.Join(cookieNames, ","),
+			"cf_cookie", cfCookieLen > 0,
+			"cf_cookie_len", cfCookieLen,
 			// Mode B signal: the two-header service-token form. Plappa cannot use the
 			// single-header Authorization variant (it collides with ABS auth), so this
 			// pair is what a working Mode B request looks like.

--- a/internal/server/middleware/absauthprobe.go
+++ b/internal/server/middleware/absauthprobe.go
@@ -1,0 +1,95 @@
+// file: internal/server/middleware/absauthprobe.go
+// version: 1.0.0
+// guid: 5c9f21a7-3e64-48db-b0d2-9a8e7c4f6103
+// last-edited: 2026-08-01
+
+package middleware
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/oauth"
+)
+
+// ABSAuthProbeEnvVar gates the probe. Unset/empty = the middleware is never
+// registered and costs nothing.
+const ABSAuthProbeEnvVar = "ABS_AUTH_PROBE"
+
+// ABSAuthProbe logs WHICH credentials an ABS client actually put on the wire, so
+// client behaviour can be settled by observation instead of inference.
+//
+// It exists to answer one question that no amount of reading the client's source
+// can: after a native player completes a Cloudflare Access login in its embedded
+// webview, does its ordinary API client carry the resulting CF_Authorization
+// cookie? iOS apps frequently use a URLSession whose cookie jar is separate from
+// the webview's, in which case the cookie is earned and then never sent, and every
+// API call is bounced at the edge. Reading the app's source does not answer this
+// either — it depends on which HTTP stack the app built and how iOS partitioned
+// the jar at runtime.
+//
+// # It never logs a credential value
+//
+// Every field below is a bool, an int length, or a fixed enum. A length is safe and
+// is worth having: it distinguishes a real JWT from a stray empty header, and shows
+// at a glance whether an assertion is the identity shape or the much shorter
+// service-token shape. Nothing here can be replayed.
+//
+// # Why env-gated rather than always-on at DEBUG
+//
+// The ABS surface is polled hard — clients hit /ping every 20s and sync every 15s
+// (§1.9.4) — so an always-on per-request log line is real journal volume for a
+// signal that is only wanted during a deliberate diagnostic window. Turning it on
+// is an explicit act, and leaving it on is visible in the unit file.
+func ABSAuthProbe() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		assertion := strings.TrimSpace(c.GetHeader(oauth.CFAccessHeader))
+		authz := strings.TrimSpace(c.GetHeader("Authorization"))
+
+		// The edge cookie. Its PRESENCE is the whole question: it means the app's
+		// API client shares a cookie jar with the webview that logged in, and the
+		// request would satisfy Cloudflare Access on its own.
+		cfCookie := ""
+		if ck, err := c.Request.Cookie("CF_Authorization"); err == nil && ck != nil {
+			cfCookie = ck.Value
+		}
+
+		bearerKind := "none"
+		switch {
+		case authz == "":
+		case len(authz) > 7 && strings.EqualFold(authz[:7], "bearer "):
+			if strings.HasPrefix(strings.TrimSpace(authz[7:]), "abk_") {
+				bearerKind = "app-api-key" // abk_ — our own API key, NOT an ABS token
+			} else {
+				bearerKind = "abs-access-token"
+			}
+		default:
+			bearerKind = "non-bearer-scheme"
+		}
+
+		slog.Info("abs: auth probe",
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path,
+			// Identifies WHICH client is calling — ShelfPlayer, Plappa, a browser, curl.
+			"user_agent", c.Request.UserAgent(),
+			// Mode C / browser-SSO signal: the edge verified a person and injected this.
+			"cf_assertion", assertion != "",
+			"cf_assertion_len", len(assertion),
+			// THE question this probe was built for.
+			"cf_cookie", cfCookie != "",
+			"cf_cookie_len", len(cfCookie),
+			// Mode B signal: the two-header service-token form. Plappa cannot use the
+			// single-header Authorization variant (it collides with ABS auth), so this
+			// pair is what a working Mode B request looks like.
+			"cf_client_id", c.GetHeader("CF-Access-Client-Id") != "",
+			"cf_client_secret", c.GetHeader("CF-Access-Client-Secret") != "",
+			// Our own credential.
+			"bearer", bearerKind,
+			"query_token", c.Query("token") != "",
+		)
+
+		c.Next()
+	}
+}

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.2.0
+// version: 1.1.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 package server
 
@@ -247,6 +247,18 @@ func (s *Server) wireABSRoutes() {
 		int64(config.AppConfig.JSONBodyLimitMB)*1024*1024,
 		int64(config.AppConfig.UploadBodyLimitMB)*1024*1024,
 	))
+
+	// Opt-in diagnostic: log which credentials each ABS client actually sends. Off
+	// unless ABS_AUTH_PROBE is set, because these routes are polled every 15-20s and
+	// an always-on per-request line is journal noise outside a diagnostic window.
+	// Registered FIRST so it observes every request, including ones the identity
+	// middleware then rejects — a request that 401s is exactly the one worth seeing.
+	if strings.TrimSpace(os.Getenv(servermiddleware.ABSAuthProbeEnvVar)) != "" {
+		absGroup.Use(servermiddleware.ABSAuthProbe())
+		slog.Warn("abs: auth probe ENABLED — every ABS request logs which credentials it carried. " +
+			"Credential VALUES are never logged (booleans and lengths only), but this is verbose; " +
+			"unset " + servermiddleware.ABSAuthProbeEnvVar + " when the diagnostic window is over")
+	}
 	handler.Register(absGroup)
 
 	if !handler.HasUserDataProvider() {


### PR DESCRIPTION
## The bug

Cloudflare mints an Access token with **no email claim** for a **service token** — the
credential identifies a machine, not a person. `cfaccess.Verify` returned a plain
`fmt.Errorf` for that case:

```go
if claims.Email == "" {
    return nil, fmt.Errorf("cfaccess: jwt has no email claim")
}
```

indistinguishable from a forged token. `ResolveCFAssertion` treats *every* `Verify`
error as fail-closed, so a service-token request became a terminal 401 — **even when it
carried a perfectly valid bearer token alongside**. That makes the service-token
topology, the one a native player app needs, impossible to use.

## The fix

A typed sentinel separates the two cases, because they demand opposite handling:

| | Meaning | Correct response |
|---|---|---|
| Forged / expired / wrong aud | credential is **not trustworthy** | terminal 401 — never rescued by a second credential |
| No email claim | credential is **valid but anonymous** | defer to whatever other credential the request carries |

`oauth.ErrNonIdentityAssertion` is returned wrapped (so `sub` stays available for
logging) and matched with `errors.Is`. `ResolveCFAssertion` maps only that sentinel to
`(nil, nil)`.

**This does not widen access.** Falling through lands on the bearer path, which is
itself fail-closed — a service token with no bearer still gets 401. It proves a device
may reach the origin; it never says who the user is.

## Tests — `internal/server/middleware/absauth_nonidentity_test.go`

| Test | Asserts |
|---|---|
| `ForgedAssertionStillHard401` | forged + valid bearer → 401 (over-correction guard) |
| `WithBearerIsAdmitted` | service token + bearer → 200, and mode is **not** `cf` |
| `WithoutBearerIs401` | service token alone → 401 |
| `LoginReachesPasswordPath` | `ResolveCFAssertion` → `(nil, nil)` so `/login` does the password check |
| `LoginStillRejectsForgedAssertion` | forged on `/login` → terminal 401 |

### Revert-validation

With the fall-through removed, exactly the two fix-dependent tests fail and the three
guards stay green — so the passing suite cannot be green for the wrong reason:

```
--- PASS: TestABSAuth_NonIdentity_ForgedAssertionStillHard401 (0.00s)
    absauth_nonidentity_test.go:74: got 401, want 200 — a service-token assertion
      carries no identity and must fall through to the bearer
      (body: {"error":"invalid Cloudflare Access assertion"})
--- FAIL: TestABSAuth_NonIdentity_WithBearerIsAdmitted (0.00s)
--- PASS: TestABSAuth_NonIdentity_WithoutBearerIs401 (0.00s)
    absauth_nonidentity_test.go:117: got error assertion-invalid, want nil — a
      service-token assertion must not block /login; the client has to be able to
      fall through to the password check
--- FAIL: TestABSAuth_NonIdentity_LoginReachesPasswordPath (0.00s)
--- PASS: TestABSAuth_NonIdentity_LoginStillRejectsForgedAssertion (0.00s)
FAIL
```

The existing `absauth_test.go` suite is unchanged and still passes; the fake verifier
gained a `nonIdentity` set that is `nil` by default, so no existing test's behaviour moves.

## Also: `ABS_AUTH_PROBE`

An opt-in per-request log of **which** credentials an ABS client actually sent —
`cf_assertion`, `cf_cookie` (the edge cookie), `cf_client_id`/`cf_client_secret` (the
two-header service-token form), `bearer` kind, `query_token`, plus `user_agent` to
identify the client. **Booleans and lengths only, never a value** — nothing logged can
be replayed.

It exists to settle empirically a question source-reading cannot answer: after a player
app signs in through its embedded webview, does its ordinary API client carry the
resulting `CF_Authorization` cookie, or does it use a separate cookie jar and silently
drop it? Registered first in the ABS chain so it also observes requests that then 401 —
those are the interesting ones. Off unless the env var is set, because these routes are
polled every 15–20s (§1.9.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp