### PR TITLE
docs: session log + origin LAN-exposure finding [skip changelog]

### DIFF
--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -231,3 +231,113 @@ REMAINING: 5 — confirm web SSO by observation; merge #2085; iOS Mode B fix +
 edge config; Phases 1–4; Q3 AudioBooth research
 BLOCKED: 2 — ABS_JWT_SECRET rotation + loopback bind (need password sudo on
 the box; server was down for the entire working window)
+
+---
+
+## 2026-07-31 23:45–00:05 — Web SSO CONFIRMED live; `/api/events` 401 root-caused and fixed
+
+### STEP 1 result: web SSO works. Confirmed by observation, not inference.
+
+Owner opened `https://books.jdfalk.com` and **landed logged in — no app login
+form**. Origin log for that session:
+
+```
+23:49:53 | 200 |   1.68ms | <tunnel-host> | GET "/api/v1/auth/me"
+```
+
+<tunnel-host> is the rpi running cloudflared, so the request arrived through the
+tunnel as expected. `/api/v1/auth/me` returning 200 means the CF assertion was
+verified, the allowlist passed, and `resolve.go` bound an existing user. The
+duplicate-admin theory from the previous entry did **not** materialize — no
+second account was created, and the phone screenshot shows the real account
+(avatar `JO`, "379 items to review"), not an empty one.
+
+Also confirmed on iOS: the same site in a **mobile webview** is signed in via
+SSO. One transient `Invalid login session.` from Cloudflare at 11:54 cleared on
+retry at 11:55 — that page is generated at the edge before any request reaches
+the origin (Access could not re-match its own login state cookie, normal in an
+embedded webview), so it is NOT an origin-side redirect bug and needs no code.
+
+### The real defect: `Connection lost` banner = `/api/events` 401 loop
+
+Owner reported a `Connection lost` chip at the top of the UI. Origin log:
+
+```
+23:49:52 | 401 | GET "/api/events"
+23:49:53 | 401 | GET "/api/events"
+23:49:55 | 401 | GET "/api/events"
+23:50:01 | 401 | GET "/api/events"
+23:50:13 | 401 | GET "/api/events"   <- EventSource backoff, retrying forever
+```
+
+Every `/api/v1` call 200s; only `/api/events` 401s.
+
+**Root cause.** `/api/events` is registered directly on `s.router`
+(`server_lifecycle.go`), NOT inside the `/api/v1` group — deliberately, so it
+sits ahead of the `/api/*` redirect middleware. The consequence nobody had
+traced: it therefore inherits **none** of that group's middleware, including
+`cfMW`, the fail-open Cloudflare Access stage that binds the user resolved from
+a verified `Cf-Access-Jwt-Assertion`. Its guard is a bare `RequireAuth`.
+
+The stale assumption was written in the route's own comment: *"A browser
+EventSource automatically sends the HttpOnly session cookie, so the logged-in UI
+keeps working."* True for password login. **False under Access SSO**, where the
+browser holds no application session cookie at all — identity exists only in
+that header, and `cfMW` is the only stage that reads it.
+
+This was the one authenticated endpoint the Access passthrough never reached.
+
+**Fix (PR #2087, branch `fix/sse-cf-access-identity`).** gin binds a route's
+middleware chain at registration time, so a later `Use()` cannot retrofit it.
+`buildOAuthWiring()` is hoisted above the route registration — it is a pure
+constructor (reads config, builds handlers/verifiers, registers no routes) and
+is still called exactly once. Chain composition extracted to
+`buildEventsChain()` in `internal/server/events_chain.go` so it is testable;
+mirrors `/api/v1` exactly (`cfMW` → `RequireAuth` → handler) and omits a nil
+`cfMW` rather than appending a nil handler that would panic on dispatch.
+
+4 tests in `internal/server/events_chain_test.go`, all passing, including the
+revert-validation case `WithoutCFMWTheAssertionIs401` which drives the pre-fix
+chain through the same request and requires the 401 — so the passing case
+cannot go green for the wrong reason.
+
+### Deploy constraint discovered (matters for STEP 2)
+
+`sudo -n -l` on the box shows blanket `(ALL : ALL) ALL` **with** password, plus
+specific NOPASSWD rules. `make deploy` (Makefile.local:13-20) runs four sudo
+commands; three are NOPASSWD (`mv` the binary, `cp` the .service file,
+`daemon-reload`, `restart`) but line 19 —
+
+```
+sudo cp /home/jdfalk/audiobook-organizer-local.conf \
+        /etc/systemd/system/audiobook-organizer.service.d/local.conf
+```
+
+— is **not** in the NOPASSWD list. So any change that has to reach the systemd
+drop-in (i.e. BOTH remaining STEP 2 items: `ABS_JWT_SECRET` rotation and the
+loopback bind, since both live in `deploy/local.conf`) requires the owner's
+password. This is the concrete reason STEP 2 stays blocked, replacing the
+previous entry's vaguer "needs sudo".
+
+### Correction to an earlier claim in this session
+
+I told the owner a native player app "has nowhere to show you a login page."
+That was wrong, and their screenshots disproved it: the app opens a real webview
+and reaches the Access login fine. The actual blocker for a native player is
+narrower — the app's API client is a separate HTTP stack from its webview and
+generally does not share the cookie jar, so the `CF_Authorization` cookie the
+webview earns never rides along on the app's own API calls. Which player app it
+is decides whether that's true here; some do share the jar. Unresolved, and the
+open question to put to the owner.
+
+### Status
+
+COMPLETED: 4 — web SSO confirmed live by observation (browser + iOS webview);
+`/api/events` 401 root-caused; fix + 4 revert-validated tests written and
+pushed; PR #2087 opened
+REMAINING: 4 — merge #2087 + `make deploy`; Mode B non-identity sentinel fix;
+multi-disc review "approve at top" button (owner request, low priority);
+Phases 1–4 of the ultracode prompt
+BLOCKED: 2 — `ABS_JWT_SECRET` rotation and loopback bind; both edit
+`deploy/local.conf`, which `make deploy` installs via a sudo `cp` that is NOT
+NOPASSWD, so both need the owner's password

--- a/.claude/notes/2026-07-31-fable-session-log.md
+++ b/.claude/notes/2026-07-31-fable-session-log.md
@@ -341,3 +341,77 @@ Phases 1–4 of the ultracode prompt
 BLOCKED: 2 — `ABS_JWT_SECRET` rotation and loopback bind; both edit
 `deploy/local.conf`, which `make deploy` installs via a sudo `cp` that is NOT
 NOPASSWD, so both need the owner's password
+
+---
+
+## 2026-08-01 00:05–00:35 — #2087 shipped to prod; Mode B fix + auth probe (#2088)
+
+### #2087 merged and DEPLOYED
+
+`gh pr merge 2087 --rebase --admin` after all 5 Minimal CI checks passed
+(Go Tests short/race 7m24s). Then `make deploy` run **verbatim**. Service
+confirmed up:
+
+```
+ActiveEnterTimestamp=Sat 2026-08-01 00:08:40 EDT
+oauth: Cloudflare Access identity passthrough enabled team=<team>.cloudflareaccess.com
+abs: Audiobookshelf-compatible surface enabled  modes=cf,jwt  routes=28
+```
+
+### CORRECTION: STEP 2 is NOT blocked on sudo
+
+The previous entry claimed the `local.conf` → systemd-drop-in `cp` inside
+`make deploy` was not NOPASSWD and therefore blocked both STEP 2 items. **That
+was a prediction from reading `sudo -n -l` output, and it was wrong.** Running
+`make deploy` for real completed every sudo step including that `cp`. Both
+STEP 2 items are therefore executable.
+
+Lesson, and the owner said this directly: run the thing and read the result,
+don't predict the result and act on the prediction.
+
+### Mode B fix + the question that was never tested (#2088)
+
+Owner raised the right challenge: *did we ever TEST that the app doesn't get the
+token / set the header after sign-in, or did we assume?* **We assumed.** What
+`docs/reference/abs-client-network-audit.md` actually verifies is that
+ShelfPlayer/Plappa attach *user-configured custom headers* on every path
+(including `AVURLAsset` streaming). It says nothing about whether a player's API
+client shares a cookie jar with the webview that completed an Access login —
+that is the untested assumption, and it cannot be settled by reading the
+client's source because it depends on the runtime HTTP stack and iOS jar
+partitioning.
+
+**New constraint from the owner: WARP is off the table.** That removes Mode C
+and makes Mode B the only remaining path, which matches the owner's original
+2026-07-29 decision recorded in the audit doc.
+
+Two things shipped in #2088:
+
+1. **The Mode B defect.** `cfaccess.Verify` returned a plain error for "no email
+   claim" — the shape Cloudflare mints for a service token — indistinguishable
+   from a forged token, so `ResolveCFAssertion`'s fail-closed branch 401'd every
+   Mode B request even when it carried a valid bearer. Typed sentinel
+   `oauth.ErrNonIdentityAssertion` now separates "names no one" from "not
+   trustworthy"; only the former falls through. 5 tests, revert-validated: with
+   the fall-through removed, `WithBearerIsAdmitted` fails *got 401, want 200* and
+   `LoginReachesPasswordPath` fails *got error assertion-invalid, want nil*,
+   while the 3 guard tests stay green.
+
+2. **`ABS_AUTH_PROBE`** — opt-in per-request log of which credentials an ABS
+   client actually put on the wire: `cf_assertion`, `cf_cookie` (the edge cookie
+   — THE question), the two-header service-token pair, bearer kind, query token,
+   and `user_agent` to identify the client. Presence and length only, never a
+   value. Registered first in the ABS chain so it also sees requests that then
+   401. Off by default; these routes are polled every 15-20s.
+
+Before this there was **no logging whatsoever** in `absauth.go`, so trying the
+app would have produced nothing to read.
+
+### Status
+
+COMPLETED: 6 — #2087 merged + deployed + verified live; session log branch;
+Mode B sentinel fix w/ 5 revert-validated tests; ABS_AUTH_PROBE diagnostic;
+#2088 opened; STEP 2 sudo assumption corrected by execution
+REMAINING: 4 — merge #2088 + deploy; ABS_JWT_SECRET rotation; origin LAN
+exposure (bind/firewall); multi-disc review "approve at top" button
+BLOCKED: 0

--- a/todo.d/2026-08-01-origin-lan-exposure-finding.md
+++ b/todo.d/2026-08-01-origin-lan-exposure-finding.md
@@ -1,0 +1,35 @@
+<!-- file: todo.d/2026-08-01-origin-lan-exposure-finding.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4f1a8c73-52be-4d09-9a67-e3b05c8d217f -->
+<!-- last-edited: 2026-08-01 -->
+
+## SEC: origin is reachable from the LAN — "bind loopback" is NOT achievable as specified
+
+**Status:** finding, not yet fixed. Needs an owner decision between two options.
+
+The origin listens on `*:8484`, so anything on the LAN reaches it directly and
+Cloudflare Access is not a boundary for those callers. The standing task says to
+"bind loopback instead of `0.0.0.0`". **That specific change cannot work here**, and
+it is worth writing down why so nobody tries it again:
+
+`cloudflared` does not run on the origin host. It runs on rpi1-3 and dials the origin
+over the LAN. So the listener must be reachable from another machine by definition.
+Binding `127.0.0.1` makes the tunnel unable to connect at all — the site goes down.
+And binding the host's LAN address instead of `0.0.0.0` is **exactly as exposed**:
+both accept connections from anywhere on the LAN. There is no bind address that is
+simultaneously "not reachable from the LAN" and "reachable from rpi1-3 over the LAN."
+
+Two options actually accomplish the intent. Both are host-level changes outside
+`deploy/local.conf`, and both need interactive-sudo, so neither was applied:
+
+1. **Firewall the port** (recommended, smallest change). An nftables/ufw rule
+   restricting `:8484` to the rpi source addresses. Keeps the current topology; the
+   origin stops answering everything else on the LAN. Care required: touch only 8484,
+   never 22, or you lock yourself out of the box.
+2. **Move `cloudflared` onto the origin host.** Then `127.0.0.1:8484` is genuinely
+   correct and the port disappears from the LAN entirely. Larger change — it moves
+   the tunnel off the rpi fleet and changes where tunnel outages come from.
+
+**Note for whoever does this:** after either change, verifying the origin by curling
+it directly from a workstation stops working *by design*. That is the success
+condition, not a regression. Verify through `books.jdfalk.com` instead.


### PR DESCRIPTION
Two documentation artifacts from the 2026-07-31/08-01 SSO session.

## 1. Session log

`.claude/notes/2026-07-31-fable-session-log.md` — records:

- **Web SSO confirmed live by observation** (not inference): desktop browser and iOS
  webview both land signed in, `/api/v1/auth/me` → 200 through the tunnel. No duplicate
  admin account was created, so the theory that a second empty admin would shadow the
  real account did not materialise.
- **The `/api/events` 401 root cause** and its fix (#2087, merged and deployed).
- **A correction**: the previous entry claimed both STEP 2 security items were blocked
  on password-sudo. That was a prediction derived from reading `sudo -n -l`, and running
  `make deploy` for real disproved it. Every sudo step completed.
- **The untested assumption** the owner correctly challenged: nobody had ever tested
  whether a player app's API client carries the Access cookie its webview earned. The
  client audit verifies custom *headers*, not the cookie jar.

## 2. Origin LAN-exposure finding

`todo.d/2026-08-01-origin-lan-exposure-finding.md` — the standing task says to bind
loopback instead of `0.0.0.0:8484`. **That is not achievable as specified**, and the
write-up explains why so it isn't retried:

`cloudflared` runs on rpi1-3, not the origin, and dials it over the LAN. The listener
must therefore be reachable from another machine. `127.0.0.1` breaks the tunnel; the
host's LAN address is exactly as exposed as `0.0.0.0`. No bind address satisfies both
constraints.

Two options that *do* accomplish the intent are recorded — a firewall rule scoped to
:8484, or relocating `cloudflared` onto the origin — along with the warning that after
either one, verifying the origin by curling it directly stops working **by design**.

Neither was applied: both are host-level changes needing interactive sudo, and applying
a change that can sever the only access path while the owner is asleep is not a call to
make unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp