### PR TITLE
fix(auth): make password reset work — it 500'd for every user, always

### DIFF
--- a/changelog.d/20260801_094500_reset_password_500.md
+++ b/changelog.d/20260801_094500_reset_password_500.md
@@ -1,0 +1,25 @@
+<!-- file: changelog.d/20260801_094500_reset_password_500.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b7fcb9ad-bf93-4d07-8a72-3801fdbddcaf -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+- **Resetting a user's password now works.** The button on the Users page returned a
+  server error every single time, for every user — it had never worked.
+
+  The underlying cause was worse than the error suggested. Password reset was built on
+  the *invitation* system, which exists to create brand-new accounts and deliberately
+  refuses to act on a username that already exists. So the feature could not have
+  worked even once the error was fixed; it would simply have failed later and more
+  quietly, handing an administrator a reset link that dead-ends when the user clicks
+  it.
+
+  Reset now issues a genuine single-use sign-in link for the existing account. The
+  administrator sends the link, the user clicks it, and sets their own password —
+  meaning nobody but the account holder ever knows it. The link expires after 15
+  minutes, cannot be used twice, and is refused outright for deactivated accounts. The
+  Users page now copies the full link to the clipboard rather than a bare token.
+
+  Administrators who instead want to set a password *for* someone can still do so
+  directly; that path was unaffected.

--- a/internal/server/auth_reset_password.go
+++ b/internal/server/auth_reset_password.go
@@ -1,0 +1,68 @@
+// file: internal/server/auth_reset_password.go
+// version: 1.0.0
+// guid: 6b2d94f1-7a08-4c53-9e16-3d8f05a2c761
+// last-edited: 2026-08-01
+
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+)
+
+// handleResetPassword handles POST /api/v1/users/:id/reset-password.
+//
+// It hands the admin a single-use link the target user clicks to get a session,
+// after which they set their own password via PUT /api/v1/auth/me/password. The
+// admin never chooses or sees the new password.
+//
+// # Why this is a *Server method rather than a UserHandler one
+//
+// The temp-login token store is package state in this package, and `server`
+// imports `handlers`, so a handlers-side implementation cannot reach it without
+// an import cycle. Same reasoning as handleAcceptInvite.
+//
+// # What this replaces, and why the old version could never have worked
+//
+// The previous implementation minted a database.Invite for the existing user's
+// username. That was broken twice over:
+//
+//  1. It passed RoleID: "" and CreateInvite rejects an empty role_id, so every
+//     call returned 500 — for every user, 100% of the time.
+//  2. Fixing only that would have been WORSE. Invites are the new-account
+//     mechanism: ConsumeInvite creates a user and explicitly refuses a token
+//     whose username already exists ("username %q taken since invite was
+//     created"). So a role-carrying invite for an existing user would have
+//     produced a token that hands the admin a reset link which then fails at
+//     redemption — trading a loud 500 for a silent dead end.
+//
+// The 500 was the only thing preventing a broken reset link from reaching a real
+// user, so this is a behaviour fix, not merely an error-handling one.
+//
+// Note there is a second, already-working path for the different intent of "an
+// admin sets a password directly": PUT /api/v1/auth/me/password accepts a
+// user_id and skips the current-password check for callers holding
+// users.manage. This endpoint deliberately does NOT duplicate that — it exists
+// for the case where the user should choose their own password.
+func (s *Server) handleResetPassword(c *gin.Context) {
+	if s.Store() == nil {
+		httputil.RespondWithInternalError(c, "database not initialized")
+		return
+	}
+	id := c.Param("id")
+	user, err := s.Store().GetUserByID(id)
+	if err != nil || user == nil {
+		httputil.RespondWithNotFound(c, "user", id)
+		return
+	}
+
+	payload, ok := s.mintTempLoginPayload(c, user)
+	if !ok {
+		return
+	}
+	// 200, not 201: the previous implementation answered 200 and the Users page
+	// reads the body without checking the status. Nothing is created in the
+	// database here either — the token lives in memory until it is used.
+	httputil.RespondWithOK(c, payload)
+}

--- a/internal/server/auth_reset_password_test.go
+++ b/internal/server/auth_reset_password_test.go
@@ -1,0 +1,161 @@
+// file: internal/server/auth_reset_password_test.go
+// version: 1.0.0
+// guid: 0e7c53a9-1d84-4b26-97f5-2a6b8fc04d13
+// last-edited: 2026-08-01
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// resetPasswordRouter wires the handler WITHOUT the users.manage permission
+// middleware. Authorization is enforced at the route (wire_library_routes.go)
+// and covered elsewhere; these tests are about whether the token this endpoint
+// returns actually works, which is the part that was broken.
+func resetPasswordRouter(s *Server) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/users/:id/reset-password", s.handleResetPassword)
+	r.GET("/auth/temp-login", s.consumeTempLoginToken)
+	return r
+}
+
+// THE REGRESSION. The old implementation minted a database.Invite with
+// RoleID: "", which CreateInvite rejects outright — so this endpoint returned
+// 500 for every user, every time.
+func TestResetPassword_ReturnsUsableToken(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	user, err := s.Store().CreateUser("resetme", "resetme@example.com", "bcrypt", "hash", []string{"viewer"}, "active")
+	require.NoError(t, err)
+
+	r := resetPasswordRouter(s)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/users/"+user.ID+"/reset-password", nil))
+
+	require.Equal(t, http.StatusOK, w.Code, "reset-password must not 500 (body: %s)", w.Body.String())
+
+	var resp struct {
+		Data struct {
+			Token    string `json:"token"`
+			LoginURL string `json:"login_url"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.Data.Token, "a reset with no token is useless to the admin")
+	require.Contains(t, resp.Data.LoginURL, resp.Data.Token)
+}
+
+// Beyond "does not 500": the token must actually be redeemable. The old
+// invite-based implementation could never satisfy this even with a valid
+// RoleID, because ConsumeInvite creates a NEW user and refuses a token whose
+// username already exists. Fixing only the 500 would have produced a token that
+// dead-ends at redemption, which is a worse failure than a loud error.
+func TestResetPassword_TokenRedeemsToASession(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	user, err := s.Store().CreateUser("redeemer", "redeemer@example.com", "bcrypt", "hash", []string{"viewer"}, "active")
+	require.NoError(t, err)
+
+	r := resetPasswordRouter(s)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/users/"+user.ID+"/reset-password", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	redeem := httptest.NewRecorder()
+	r.ServeHTTP(redeem, httptest.NewRequest(http.MethodGet, "/auth/temp-login?token="+resp.Data.Token, nil))
+
+	require.Equal(t, http.StatusSeeOther, redeem.Code)
+	require.Equal(t, "/", redeem.Header().Get("Location"),
+		"a redeemable token lands on the app root; a rejected one redirects to /login with an error")
+
+	var sessionCookie string
+	for _, ck := range redeem.Result().Cookies() {
+		if strings.Contains(strings.ToLower(ck.Name), "session") {
+			sessionCookie = ck.Value
+		}
+	}
+	require.NotEmpty(t, sessionCookie, "redeeming must actually establish a session")
+}
+
+// Single-use is a security property of the underlying token, and routing
+// reset-password through it must not weaken that.
+func TestResetPassword_TokenIsSingleUse(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	user, err := s.Store().CreateUser("onceonly", "onceonly@example.com", "bcrypt", "hash", []string{"viewer"}, "active")
+	require.NoError(t, err)
+
+	r := resetPasswordRouter(s)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/users/"+user.ID+"/reset-password", nil))
+	var resp struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	first := httptest.NewRecorder()
+	r.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/auth/temp-login?token="+resp.Data.Token, nil))
+	require.Equal(t, "/", first.Header().Get("Location"))
+
+	second := httptest.NewRecorder()
+	r.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/auth/temp-login?token="+resp.Data.Token, nil))
+	require.Contains(t, second.Header().Get("Location"), "invalid_or_expired_token",
+		"a reset link must not be replayable")
+}
+
+// An inactive account must not be revivable through a reset link. The guard
+// lives in consumeTempLoginToken; this pins that reset-password inherits it.
+func TestResetPassword_InactiveUserCannotRedeem(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	user, err := s.Store().CreateUser("disabled", "disabled@example.com", "bcrypt", "hash", []string{"viewer"}, "suspended")
+	require.NoError(t, err)
+
+	r := resetPasswordRouter(s)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/users/"+user.ID+"/reset-password", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	redeem := httptest.NewRecorder()
+	r.ServeHTTP(redeem, httptest.NewRequest(http.MethodGet, "/auth/temp-login?token="+resp.Data.Token, nil))
+	require.Contains(t, redeem.Header().Get("Location"), "account_inactive")
+}
+
+func TestResetPassword_UnknownUserIs404(t *testing.T) {
+	s, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	r := resetPasswordRouter(s)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/users/does-not-exist/reset-password", nil))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/server/auth_temp_login.go
+++ b/internal/server/auth_temp_login.go
@@ -1,7 +1,7 @@
 // file: internal/server/auth_temp_login.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5b6c7d8e-9f0a-1b2c-3d4e-5f6a7b8c9d0e
-// last-edited: 2026-06-22
+// last-edited: 2026-08-01
 
 // Temp-login token: admin mints a short-lived single-use URL for a user.
 // User clicks the URL → server consumes the token → 24h session cookie
@@ -20,10 +20,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 )
 
 // tempLoginEntry tracks one minted token. Tokens are kept in memory
@@ -93,10 +94,28 @@ func (s *Server) createTempLoginToken(c *gin.Context) {
 		return
 	}
 
+	payload, ok := s.mintTempLoginPayload(c, user)
+	if !ok {
+		return
+	}
+	httputil.RespondWithCreated(c, payload)
+}
+
+// mintTempLoginPayload registers a single-use temp-login token for user and
+// builds the response body describing it. It reports false after having already
+// written an error response, so callers just return.
+//
+// Shared by POST /auth/temp-tokens and POST /users/:id/reset-password: both
+// hand an admin a one-time link the target user clicks to get a session. The
+// only difference is how the user is addressed (body vs path param) and the
+// success status, so the token lifecycle lives here once rather than being
+// duplicated — a second copy of "generate, register under the mutex, build the
+// URL" is exactly where a single-use or TTL guarantee gets quietly dropped.
+func (s *Server) mintTempLoginPayload(c *gin.Context, user *database.User) (gin.H, bool) {
 	token, err := newTempLoginToken()
 	if err != nil {
 		httputil.RespondWithInternalError(c, "failed to generate token")
-		return
+		return nil, false
 	}
 	expires := time.Now().Add(handlers.TempLoginTokenTTL)
 
@@ -116,7 +135,7 @@ func (s *Server) createTempLoginToken(c *gin.Context) {
 		loginURL = s.externalURL + relativePath
 	}
 
-	httputil.RespondWithCreated(c, gin.H{
+	return gin.H{
 		"token":      token,
 		"login_url":  loginURL,
 		"expires_at": expires,
@@ -125,7 +144,7 @@ func (s *Server) createTempLoginToken(c *gin.Context) {
 			"username": user.Username,
 		},
 		"session_ttl_hours": int(handlers.DefaultSessionTTL.Hours()),
-	})
+	}, true
 }
 
 // consumeTempLoginToken handles GET /auth/temp-login?token=xxx.

--- a/internal/server/handlers/user.go
+++ b/internal/server/handlers/user.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/user.go
-// version: 1.3.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-ef0123456789
-// last-edited: 2026-06-04
+// last-edited: 2026-08-01
 
 // Package handlers contains extracted HTTP handler types for the audiobook
 // organizer server. UserHandler covers user management and invite endpoints.
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -213,28 +213,4 @@ func (h *UserHandler) ReactivateUser(c *gin.Context) {
 	}
 	// Safe shape only — never echo the raw *database.User (leaks password hash, CRIT-2).
 	httputil.RespondWithOK(c, gin.H{"user": buildAuthUserResponse(user)})
-}
-
-// ResetPassword handles POST /api/v1/users/:id/reset-password — generates a
-// reset invite so the user can set a new password.
-func (h *UserHandler) ResetPassword(c *gin.Context) {
-	id := c.Param("id")
-	user, err := h.store.GetUserByID(id)
-	if err != nil || user == nil {
-		httputil.RespondWithNotFound(c, "user", id)
-		return
-	}
-
-	token := generateToken()
-	invite := &database.Invite{
-		Token:     token,
-		Username:  user.Username,
-		RoleID:    "",
-		ExpiresAt: time.Now().Add(24 * time.Hour),
-	}
-	if _, err := h.store.CreateInvite(invite); err != nil {
-		httputil.InternalError(c, "create reset invite", err)
-		return
-	}
-	httputil.RespondWithOK(c, gin.H{"token": token, "expires_at": invite.ExpiresAt})
 }

--- a/internal/server/wire_library_routes.go
+++ b/internal/server/wire_library_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_library_routes.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f23456789012
-// last-edited: 2026-06-23
+// last-edited: 2026-08-01
 
 package server
 
@@ -93,7 +93,7 @@ func (s *Server) wireLibraryRoutes(
 		users.DELETE("/invites/:token", s.perm("users.manage"), userH.DeleteInvite)
 		users.POST("/:id/deactivate", s.perm("users.manage"), userH.DeactivateUser)
 		users.POST("/:id/reactivate", s.perm("users.manage"), userH.ReactivateUser)
-		users.POST("/:id/reset-password", s.perm("users.manage"), userH.ResetPassword)
+		users.POST("/:id/reset-password", s.perm("users.manage"), s.handleResetPassword)
 	}
 
 	// Version groups

--- a/web/src/pages/Users.tsx
+++ b/web/src/pages/Users.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Users.tsx
-// version: 1.0.1
+// version: 1.1.0
 // guid: 4d2e3f1a-5b6c-4a70-b8c5-3d7e0f1b9a99
 
 import { useCallback, useEffect, useState, useRef } from 'react';
@@ -88,9 +88,15 @@ export default function Users() {
   const handleResetPassword = useCallback(async (id: string) => {
     const resp = await fetch(`${API_BASE}/users/${id}/reset-password`, { method: 'POST' });
     const data = await resp.json();
-    if (data.token) {
-      setCopiedToken(data.token);
-      navigator.clipboard.writeText(data.token).catch(() => {});
+    // The endpoint returns { token, login_url }. Copy the URL — it is what the
+    // user actually clicks. The bare token is kept as a fallback for a server
+    // that predates login_url, and because login_url is relative when
+    // EXTERNAL_URL is unset (the admin then prepends the address themselves).
+    const payload = data?.data ?? data;
+    const copyable = payload?.login_url || payload?.token;
+    if (copyable) {
+      setCopiedToken(copyable);
+      navigator.clipboard.writeText(copyable).catch(() => {});
     }
     load();
   }, [load]);


### PR DESCRIPTION
## The bug

`POST /api/v1/users/:id/reset-password` returned **500 for every user, every time.** It has never worked.

```go
invite := &database.Invite{
    Token:    token,
    Username: user.Username,
    RoleID:   "",          // <-- CreateInvite: "invite: role_id required"
    ...
}
```

## The bug behind the bug

Fixing `RoleID` alone would have been **worse than leaving it broken.**

Password reset was built on the *invite* system, and invites exist to create **new accounts**. `ConsumeInvite` creates a user, and explicitly refuses any token whose username already exists:

```go
Roles: []string{inv.RoleID}, Status: "active",   // creates a NEW user
...
if _, closer, err := p.db.Get([]byte("idx:user:username:"+lowerUser)); err == nil {
    return nil, fmt.Errorf("username %q taken since invite was created", inv.Username)
}
```

Since reset always targets an **existing** user, a role-carrying invite would have produced a token that dead-ends at redemption. That converts a loud 500 into an admin confidently sending a real person a link that fails when clicked.

**The 500 was load-bearing** — it's the only reason a broken reset link never reached anyone.

## The fix

Reset now issues a single-use **temp-login token** for the existing account — the mechanism already built for exactly this shape (`auth_temp_login.go`): 15-minute TTL, deleted on first read, refused for non-active users.

The admin sends the link; the user clicks it, gets a session, and sets their own password via the existing `PUT /auth/me/password`. **The admin never learns the password.**

Three implementation notes:

- **Token lifecycle extracted to `mintTempLoginPayload`**, shared with `POST /auth/temp-tokens` rather than copied. A second copy of "generate → register under the mutex → build the URL" is precisely where a single-use or TTL guarantee gets quietly dropped.
- **`*Server` method, not `UserHandler`** — the token store is package state in `server`, and `server` imports `handlers`, so a handlers-side version can't reach it without an import cycle. Same reasoning as `handleAcceptInvite`.
- **Not duplicated:** `PUT /auth/me/password` already accepts a `user_id` and skips the current-password check for callers with `users.manage`. That's the different intent of "admin sets a password *for* someone" and it works — this endpoint deliberately covers the other case.

## Contract

Unchanged (`token`, `expires_at`) plus `login_url`. `Users.tsx` now copies the URL, falling back to the bare token.

## Tests — 5, all passing

| Test | Asserts |
|---|---|
| `ReturnsUsableToken` | 200 + non-empty token (the 500 regression) |
| `TokenRedeemsToASession` | **token actually redeems** → 303 to `/` + session cookie |
| `TokenIsSingleUse` | second redemption → `invalid_or_expired_token` |
| `InactiveUserCannotRedeem` | suspended account → `account_inactive` |
| `UnknownUserIs404` | 404, not 500 |

```
--- PASS: TestResetPassword_ReturnsUsableToken (1.31s)
--- PASS: TestResetPassword_TokenRedeemsToASession (1.29s)
--- PASS: TestResetPassword_TokenIsSingleUse (1.27s)
--- PASS: TestResetPassword_InactiveUserCannotRedeem (1.29s)
--- PASS: TestResetPassword_UnknownUserIs404 (1.30s)
ok  github.com/falkcorp/audiobook-organizer/internal/server 7.349s
```

`TokenRedeemsToASession` is the one that matters: it asserts the property the old implementation **could never have satisfied** even with the `RoleID` fixed. A test that only checked "not 500" would have passed against the silently-broken version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp