### PR TITLE
feat(review): put Approve/Reject at the top of an item, not only the bottom

### DIFF
--- a/changelog.d/20260801_115500_review_approve_at_top.md
+++ b/changelog.d/20260801_115500_review_approve_at_top.md
@@ -1,0 +1,12 @@
+<!-- file: changelog.d/20260801_115500_review_approve_at_top.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c85fe9f-61ed-4ec7-9f03-d37570341067 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Changed
+
+- The Review Queue now shows Approve and Reject buttons at the **top** of an expanded
+  item as well as at the bottom. Multi-disc groups can list dozens of files, and the
+  buttons were only underneath all of them — so deciding on an item you had already
+  sized up from its first line still meant scrolling to the end of the list. The
+  decision is now reachable from either end.

--- a/web/src/pages/ReviewQueue.tsx
+++ b/web/src/pages/ReviewQueue.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/ReviewQueue.tsx
-// version: 2.0.0
+// version: 2.1.0
 // guid: 4c8f2a17-5e93-4d60-a1b8-7f3c6d9e0a52
-// last-edited: 2026-07-26
+// last-edited: 2026-08-01
 
 import { useEffect, useMemo, useState } from 'react';
 import {
@@ -18,6 +18,8 @@ import {
   Stack,
   Tooltip,
   Typography,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import CheckIcon from '@mui/icons-material/Check.js';
@@ -320,6 +322,43 @@ export function ReviewQueue() {
     }
   };
 
+  // Approve/Reject pair for a single item. Defined here rather than at module
+  // scope so it closes over handleItemAction; rendered twice per item (above and
+  // below the member-file list) so the decision is reachable without scrolling
+  // past a long multi-disc listing.
+  const ItemActions = ({
+    item,
+    busy,
+    sx,
+  }: {
+    item: ReviewItem;
+    busy: boolean;
+    sx?: SxProps<Theme>;
+  }) => (
+    <Stack direction="row" spacing={1} sx={sx}>
+      <Button
+        size="small"
+        variant="contained"
+        color="success"
+        startIcon={<CheckIcon />}
+        disabled={busy}
+        onClick={() => handleItemAction(item, 'approve')}
+      >
+        Approve
+      </Button>
+      <Button
+        size="small"
+        variant="outlined"
+        color="error"
+        startIcon={<CloseIcon />}
+        disabled={busy}
+        onClick={() => handleItemAction(item, 'reject')}
+      >
+        Reject
+      </Button>
+    </Stack>
+  );
+
   return (
     <Box>
       <Typography variant="h4" gutterBottom>
@@ -401,29 +440,19 @@ export function ReviewQueue() {
                         </Typography>
                       </AccordionSummary>
                       <AccordionDetails>
+                        {/*
+                          Actions are rendered ABOVE the detail as well as below it.
+                          A multi-disc item can list dozens of member files, so with
+                          the buttons only at the bottom you had to scroll the whole
+                          list to act on an item you had already decided about after
+                          reading the first line. Repeating them costs one row and
+                          means the decision is always reachable from wherever you
+                          are — the top pair for a quick call, the bottom pair for
+                          when you have actually read to the end.
+                        */}
+                        <ItemActions item={item} busy={itemBusy} sx={{ mb: 2 }} />
                         <MemberFilesDetail item={item} />
-                        <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
-                          <Button
-                            size="small"
-                            variant="contained"
-                            color="success"
-                            startIcon={<CheckIcon />}
-                            disabled={itemBusy}
-                            onClick={() => handleItemAction(item, 'approve')}
-                          >
-                            Approve
-                          </Button>
-                          <Button
-                            size="small"
-                            variant="outlined"
-                            color="error"
-                            startIcon={<CloseIcon />}
-                            disabled={itemBusy}
-                            onClick={() => handleItemAction(item, 'reject')}
-                          >
-                            Reject
-                          </Button>
-                        </Stack>
+                        <ItemActions item={item} busy={itemBusy} sx={{ mt: 2 }} />
                       </AccordionDetails>
                     </Accordion>
                   );


### PR DESCRIPTION
## The complaint

> put a damn approve button at the top of the multi disk to 1 book stuff, so i don't have to scroll down through everything

Correct. In `ReviewQueue.tsx` the per-item actions sat *after* `<MemberFilesDetail>`:

```jsx
<AccordionDetails>
  <MemberFilesDetail item={item} />     {/* dozens of member files */}
  <Stack ...>Approve / Reject</Stack>   {/* only reachable at the bottom */}
</AccordionDetails>
```

A multi-disc group lists every member file with cover, title, chips and path. Deciding on an item you'd already sized up from its first line still meant scrolling the whole list.

## The change

Actions render **above** the detail as well as below it, extracted to a local `ItemActions` component so the two renders can't drift. It's defined inside `ReviewQueue` rather than at module scope because it closes over `handleItemAction`.

```jsx
<AccordionDetails>
  <ItemActions item={item} busy={itemBusy} sx={{ mb: 2 }} />
  <MemberFilesDetail item={item} />
  <ItemActions item={item} busy={itemBusy} sx={{ mt: 2 }} />
</AccordionDetails>
```

## What I deliberately did not do

I considered putting the buttons in the `AccordionSummary` row so you wouldn't need to expand at all — strictly fewer clicks. I didn't, because approve is the **mutating** path (it dispatches combine/link per kind), and a button in the always-visible header invites a misclick on a row the reviewer hasn't opened. Cheap to reach is the goal; cheap to hit by accident isn't.

Worth knowing: `review_apply_enabled` is currently off in prod, so approving mutates nothing today. That's a reason to be *more* careful about the affordance, not less — the flag will flip eventually and the muscle memory will already be built.

## Verification

```
npx tsc --noEmit -p tsconfig.json   → exit 0
npx eslint src/pages/ReviewQueue.tsx → exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp