### PR TITLE
fix(server): 404 unimplemented /auth/* instead of serving the SPA shell

### DIFF
--- a/changelog.d/20260801_122000_spa_catchall_auth_404.md
+++ b/changelog.d/20260801_122000_spa_catchall_auth_404.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/20260801_122000_spa_catchall_auth_404.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 636734ad-4b41-4250-b4c9-9aa80d967e85 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+- **Player apps could get stuck on a login that can never succeed.** Signing in from
+  AudioBooth ended at a Cloudflare "Invalid login session" error, with no way forward.
+
+  The app checks whether a server supports single sign-on by requesting
+  `/auth/openid` and seeing whether it exists. The server answered every unknown
+  address with the web app's own page rather than "not found", so the check came back
+  positive and the app started a sign-in process this server has no way to finish. The
+  error the user saw came from Cloudflare being handed a half-finished login.
+
+  Unimplemented sign-in addresses now correctly answer "not found", so the app's check
+  fails cleanly and it offers username-and-password login instead. Ordinary links into
+  the web app are unaffected.

--- a/internal/server/spa_fallback.go
+++ b/internal/server/spa_fallback.go
@@ -1,0 +1,62 @@
+// file: internal/server/spa_fallback.go
+// version: 1.0.0
+// guid: 1e6d90b4-27a5-4c31-8f9e-a3b715c8d604
+// last-edited: 2026-08-01
+
+package server
+
+import "strings"
+
+// nonSPAPrefixes are URL prefixes that must NEVER fall through to the SPA
+// shell. A request under one of these is asking the SERVER a question, and an
+// unmatched one has exactly one honest answer: 404.
+//
+// # Why this matters more than it looks
+//
+// The SPA fallback answers `200 text/html` for any unmatched path so that deep
+// links like /library/123 load the React app and let the client router take
+// over. Applied to a machine-facing path that is a protocol probe, that same
+// behaviour is an active lie.
+//
+// AudioBooth (an Audiobookshelf client) discovers whether a server supports
+// OpenID Connect SSO by probing the endpoint directly:
+//
+//	HEAD /auth/openid?client_id=AudioBooth&response_type=code&scope=openid
+//	     &redirect_uri=audiobooth://oauth&code_challenge=...
+//
+// It got 200 from the catch-all, concluded OIDC was supported, and launched a
+// PKCE flow expecting a redirect back to audiobooth://oauth. We have no OIDC
+// implementation, so the app received the React index page instead and the
+// login collapsed — surfacing to the user as Cloudflare Access's "Invalid login
+// session", because the edge could not reconcile a flow the origin never joined.
+//
+// Note the client had already been TOLD we do not support this: /status
+// advertises authMethods: ["local"] precisely so clients avoid an OIDC flow
+// they cannot complete against us (see handlers/abs/status.go). AudioBooth does
+// not take that at face value — it probes. So the advertisement alone is not a
+// sufficient defence; the endpoint itself has to answer honestly.
+//
+// Keep this list to prefixes that are unambiguously server-side. Anything a
+// human might type or bookmark belongs in the SPA.
+var nonSPAPrefixes = []string{
+	"/api",   // the JSON API, including the ABS-compatible surface
+	"/auth/", // login/OAuth/OIDC machinery; registered routes match before NoRoute
+}
+
+// isNonSPAPath reports whether an unmatched path must 404 rather than render the
+// SPA shell.
+//
+// Only UNMATCHED paths reach here — this runs from NoRoute, so real routes such
+// as /auth/temp-login are dispatched by gin long before it, and adding a prefix
+// here cannot shadow a registered handler.
+func isNonSPAPath(path string) bool {
+	for _, prefix := range nonSPAPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	// Exact "/auth" with no trailing slash is still server-side; the prefix form
+	// above deliberately requires the slash so a future SPA route like
+	// /authors is not captured by accident.
+	return path == "/auth"
+}

--- a/internal/server/spa_fallback_test.go
+++ b/internal/server/spa_fallback_test.go
@@ -1,0 +1,93 @@
+// file: internal/server/spa_fallback_test.go
+// version: 1.0.0
+// guid: 9a4c7e01-3f28-4b95-86d0-c1e57b2f0348
+// last-edited: 2026-08-01
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// isNonSPAPath decides whether an unmatched path 404s or renders the SPA shell.
+// Getting it wrong in either direction is bad: too narrow and we keep lying to
+// protocol probes, too broad and we break deep links into the app.
+func TestIsNonSPAPath(t *testing.T) {
+	mustNotBeSPA := []string{
+		// THE REGRESSION. AudioBooth probes this to discover OIDC support; a
+		// 200 from the SPA shell told it we support single sign-on, and it then
+		// launched a PKCE flow we can never complete.
+		"/auth/openid",
+		"/auth/openid?client_id=AudioBooth&response_type=code",
+		"/auth/openid/callback",
+		"/auth",
+		"/auth/",
+		"/api",
+		"/api/v1/nope",
+		"/api/me/sessions/xyz",
+	}
+	for _, p := range mustNotBeSPA {
+		require.True(t, isNonSPAPath(p), "%q is server-side and must 404, not render the SPA", p)
+	}
+
+	mustBeSPA := []string{
+		"/",
+		"/library",
+		"/library/01ABC",
+		"/settings",
+		// The prefix requires a trailing slash precisely so this is not
+		// swallowed. /authors is a real page in the app.
+		"/authors",
+		"/authors/123",
+		"/authentication-settings",
+		"/index.html",
+		"/assets/index-abc123.js",
+	}
+	for _, p := range mustBeSPA {
+		require.False(t, isNonSPAPath(p), "%q is a client route and must still render the SPA", p)
+	}
+}
+
+// The fix must not shadow a REGISTERED /auth route. NoRoute only fires for
+// unmatched paths, so /auth/temp-login is dispatched by gin long beforehand —
+// this pins that reasoning rather than trusting it.
+func TestAuthTempLoginStillRoutes(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	server.router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/temp-login?token=nope", nil))
+
+	// The handler redirects to /login with an error for a bad token. What
+	// matters is that it REACHED the handler: a 404 would mean the new prefix
+	// swallowed a live route.
+	require.NotEqual(t, http.StatusNotFound, w.Code,
+		"/auth/temp-login is a registered route and must not be captured by the SPA fallback")
+	require.Equal(t, http.StatusSeeOther, w.Code)
+	require.Contains(t, w.Header().Get("Location"), "/login")
+}
+
+// End-to-end shape of the bug: an unimplemented auth endpoint must answer 404,
+// not 200-with-HTML.
+func TestUnimplementedAuthEndpointIs404(t *testing.T) {
+	server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	for _, path := range []string{
+		"/auth/openid?client_id=AudioBooth&response_type=code&scope=openid&redirect_uri=audiobooth://oauth",
+		"/auth/openid",
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			w := httptest.NewRecorder()
+			server.router.ServeHTTP(w, httptest.NewRequest(method, path, nil))
+			require.Equal(t, http.StatusNotFound, w.Code,
+				"%s %s must 404 so a client's capability probe fails honestly", method, path)
+			require.NotContains(t, w.Body.String(), "<!doctype html",
+				"%s %s must not return the SPA shell", method, path)
+		}
+	}
+}

--- a/internal/server/static_embed.go
+++ b/internal/server/static_embed.go
@@ -1,7 +1,7 @@
 //go:build embed_frontend
-
+// version: 1.1.0
 // file: internal/server/static_embed.go
-// version: 1.4.0
+// last-edited: 2026-08-01
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 // last-edited: 2026-05-01
 
@@ -15,8 +15,8 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // webFS holds the embedded filesystem passed from main package
@@ -38,8 +38,10 @@ func (s *Server) setupStaticFiles() {
 
 	// NoRoute handler to serve static files or SPA index.html
 	s.router.NoRoute(func(c *gin.Context) {
-		// Return 404 for unknown API routes
-		if len(c.Request.URL.Path) >= 4 && c.Request.URL.Path[:4] == "/api" {
+		// Server-side paths must 404 rather than render the SPA shell. Serving
+		// the React index for an unimplemented protocol endpoint tells a client
+		// the feature exists — see isNonSPAPath for the AudioBooth OIDC case.
+		if isNonSPAPath(c.Request.URL.Path) {
 			httputil.RespondWithNotFound(c, "endpoint", "")
 			return
 		}

--- a/internal/server/static_nonembed.go
+++ b/internal/server/static_nonembed.go
@@ -1,7 +1,7 @@
 //go:build !embed_frontend
-
+// version: 1.1.0
 // file: internal/server/static_nonembed.go
-// version: 1.2.0
+// last-edited: 2026-08-01
 // guid: 2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e
 // last-edited: 2026-05-01
 
@@ -11,8 +11,8 @@ import (
 	"embed"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // SetEmbeddedFS is a no-op when not embedding frontend
@@ -100,8 +100,10 @@ func (s *Server) setupPlaceholder() {
 
 	// Return 404 for unknown routes
 	s.router.NoRoute(func(c *gin.Context) {
-		// Return 404 for unknown API routes
-		if len(c.Request.URL.Path) >= 4 && c.Request.URL.Path[:4] == "/api" {
+		// Server-side paths must 404 rather than render the SPA shell. Serving
+		// the React index for an unimplemented protocol endpoint tells a client
+		// the feature exists — see isNonSPAPath for the AudioBooth OIDC case.
+		if isNonSPAPath(c.Request.URL.Path) {
 			httputil.RespondWithNotFound(c, "endpoint", "")
 			return
 		}


### PR DESCRIPTION
## Symptom

Signing in to the **AudioBooth** player ends at Cloudflare Access **"Invalid login session"**, repeatably.

## Root cause — our catch-all lies to the app

Observed live in the prod journal, two attempts a minute apart:

```
12:16:03 | 200 | HEAD "/auth/openid?client_id=AudioBooth&response_type=code&scope=openid
                       &redirect_uri=audiobooth://oauth&code_challenge=...&code_challenge_method=S256"
12:16:51 | 200 | HEAD "/auth/openid?client_id=AudioBooth&response_type=code&scope=openid..."
```

AudioBooth probes `/auth/openid` to discover whether the server supports OIDC single sign-on. The SPA fallback answers `200 text/html` for **any** unmatched path, so the probe came back positive:

```
$ curl -I 'https://<origin>/auth/openid?client_id=AudioBooth&...'
HTTP/2 200
content-type: text/html; charset=utf-8          <- the React shell
```

The app concluded we support SSO and launched a PKCE flow expecting a redirect to `audiobooth://oauth`. We have no OIDC implementation, so it got the React index page. Cloudflare was then left holding a login flow the origin never joined — hence *"Invalid login session"*. **The error is a symptom; the origin is the cause.**

### The existing defence was bypassed

`handlers/abs/status.go:45` deliberately advertises only `authMethods: ["local"]`:

> advertising anything else would send clients down an OpenID flow they cannot complete against us

AudioBooth doesn't take that at face value — it **probes the endpoint**. So advertising honestly was never sufficient; the endpoint has to answer honestly too.

## Fix

Unmatched `/auth/*` and `/api*` now 404 instead of rendering the SPA. Serving the shell for an unmatched path is correct for deep links like `/library/123`, where the client router takes over — it's an active lie when applied to a machine-facing protocol probe.

Extracted to `isNonSPAPath`, shared by both fallbacks (`static_embed.go` / `static_nonembed.go`), which previously carried **duplicate copies** of the `/api` check and could drift.

Two subtleties, both pinned by tests:
- The `/auth` prefix requires a **trailing slash**, so the client route `/authors` isn't swallowed.
- `NoRoute` fires only for **unmatched** paths, so registered routes like `/auth/temp-login` are dispatched long before this runs.

## Tests — 3, all passing

| Test | Asserts |
|---|---|
| `IsNonSPAPath` | 8 server-side paths 404; 9 client routes still render — incl. `/authors` vs `/auth/` |
| `AuthTempLoginStillRoutes` | the live `/auth/temp-login` route is **not** captured (303 → `/login`, not 404) |
| `UnimplementedAuthEndpointIs404` | GET **and HEAD** `/auth/openid` → 404, and no `<!doctype html` in the body |

Full `internal/server` short suite green (428s). Verified `go build` under the `embed_frontend` tag too, since that's what production ships.

## Follow-up worth considering

This makes AudioBooth fall back to username/password — it unblocks login, it isn't SSO. **Implementing the ABS OpenID endpoints for real** would give the app genuine SSO with no password and no service token, which is the outcome originally wanted. That's a feature, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp