### PR TITLE
docs(todo): gate the next deploy on configuring Prometheus auth [skip changelog]

### DIFF
--- a/todo.d/2026-08-01-metrics-auth-deploy-gate.md
+++ b/todo.d/2026-08-01-metrics-auth-deploy-gate.md
@@ -1,0 +1,51 @@
+<!-- file: todo.d/2026-08-01-metrics-auth-deploy-gate.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9b3cf479-67b4-4532-a76c-d2a8b5fd4b94 -->
+<!-- last-edited: 2026-08-01 -->
+
+## ⚠️ DEPLOY GATE: /metrics now requires auth — configure Prometheus BEFORE the next deploy
+
+**PR #2092 is merged but NOT deployed.** Deploying it without doing the below breaks
+metrics collection silently.
+
+There is a **live Prometheus + Grafana on the origin host**, scraping
+`http://127.0.0.1:8484/metrics` every 15s with **1 year / 500GB retention**
+(`--storage.tsdb.path=/mnt/cache/metrics/metrics2/`). It was found only by checking
+`ps` — nothing in this repo references it, and `deploy/prometheus/` is documented as
+"examples/snippets… nothing in this repo scrapes it", which is now false.
+
+Since #2092 gates `/metrics` behind authentication, the next `make deploy` makes every
+scrape 401 and leaves a gap in the series. Prometheus does not alert on its own scrape
+failing unless a rule exists for it.
+
+### Do this first (needs interactive sudo — that is why it was not done unattended)
+
+1. Mint an API key in the UI: **Settings → API keys**. It looks like `abk_…`.
+2. Install it readable only by Prometheus:
+   ```bash
+   sudo install -m 0600 -o prometheus -g prometheus /dev/null /etc/prometheus/abo.token
+   printf '%s' 'abk_…' | sudo tee /etc/prometheus/abo.token >/dev/null
+   ```
+3. Add to the audiobook-organizer job in `/etc/prometheus/prometheus.yml`:
+   ```yaml
+       authorization:
+         type: Bearer
+         credentials_file: /etc/prometheus/abo.token
+   ```
+   Use the `_file` form: Prometheus re-reads it each scrape, so rotating the key needs
+   no reload and the secret never lands in `prometheus.yml`.
+4. `sudo systemctl reload prometheus`
+5. Confirm the target is UP in Prometheus → Status → Targets, THEN deploy.
+
+### Verify after deploying
+
+```bash
+curl -ksS -o /dev/null -w '%{http_code}\n' https://<server>:8484/metrics            # want 401
+curl -ksS -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer abk_…' \
+     https://<server>:8484/metrics                                                  # want 200
+```
+
+### Also update
+
+`deploy/prometheus/README.md` claims nothing in this repo scrapes `/metrics`. A real
+scraper exists on the production host; the sentence is misleading and should say so.


### PR DESCRIPTION
**#2092 is merged but must not be deployed until Prometheus has a token.**

While deciding whether it was safe to ship, I checked what was actually calling `/metrics` rather than assuming nothing was:

```
| 200 | 127.0.0.1 | GET "/metrics"     <- every 15s

/usr/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
  --storage.tsdb.retention.time=1y --storage.tsdb.retention.size=500GB
/usr/share/grafana/bin/grafana server ...
```

**There is a live Prometheus + Grafana on the origin host with 1-year retention.** Nothing in this repo references it — `deploy/prometheus/README.md` states *"nothing in this repo scrapes it or alerts on it"*, which is now false.

Since #2092 puts `/metrics` behind auth, the next `make deploy` makes every scrape 401 and leaves a silent gap in the series. Prometheus doesn't alert on its own scrape failing unless a rule exists for it.

I could not configure it unattended — `/etc/prometheus` needs interactive sudo:
```
sudo -n test -w /etc/prometheus   → NEEDS PASSWORD
sudo -n systemctl reload prometheus → interactive authentication is required
```

So this records the exact steps (mint an `abk_` key → `credentials_file` → reload → confirm target UP → *then* deploy) plus the post-deploy verification, as a gate that can't be missed.

Also flags the stale claim in `deploy/prometheus/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp