### PR TITLE
docs(scripts): correct setup-prometheus-auth invocation to an absolute path

### DIFF
--- a/changelog.d/20260801_175600_docs_prom_script_abs_path.md
+++ b/changelog.d/20260801_175600_docs_prom_script_abs_path.md
@@ -1,0 +1,11 @@
+<!-- file: changelog.d/20260801_175600_docs_prom_script_abs_path.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8b1c47e2-5f30-4a96-b2d1-0e7a93c46f18 -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+- `scripts/setup-prometheus-auth.py` documented a repo-relative invocation, but
+  the production host has no git checkout (deployment ships only the binary to
+  `/usr/local/bin`). The docstring now shows the `scp` + absolute-path form that
+  actually works.

--- a/scripts/setup-prometheus-auth.py
+++ b/scripts/setup-prometheus-auth.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 # file: scripts/setup-prometheus-auth.py
-# version: 1.0.0
+# version: 1.0.1
 # guid: 4d90a2f6-13bc-4e58-9071-8c25e6b3f0a7
 # last-edited: 2026-08-01
 
 """Point Prometheus at audiobook-organizer's now-authenticated /metrics.
 
-Run ON THE SERVER, as root:
+This runs ON THE SERVER, which has NO git checkout -- deployment ships only the
+binary to /usr/local/bin. So copy the file over and run it by absolute path:
 
-    sudo python3 scripts/setup-prometheus-auth.py
+    scp scripts/setup-prometheus-auth.py <server>:/home/<user>/
+    ssh <server>
+    sudo python3 /home/<user>/setup-prometheus-auth.py
 
 It prompts for an API key (Settings -> API keys, `abk_...`), then:
 


### PR DESCRIPTION
The docstring told the reader to run `sudo python3 scripts/setup-prometheus-auth.py` on the server, but the server has **no git checkout** — `make deploy` ships only the binary to `/usr/local/bin`. The relative path masked that, so the documented command fails with `no such file`.

Now shows the `scp` + absolute-path form that actually works.

Docstring-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp