### PR TITLE
fix(abs): implement POST /api/authorize — clients silently lost their session

### DIFF
--- a/changelog.d/20260801_230000_abs-authorize-endpoint.md
+++ b/changelog.d/20260801_230000_abs-authorize-endpoint.md
@@ -1,0 +1,36 @@
+<!-- file: changelog.d/20260801_230000_abs-authorize-endpoint.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6b3a97e2-1c48-4f5d-83b0-d29e70fa514c -->
+<!-- last-edited: 2026-08-01 -->
+
+### Fixed
+
+- **`POST /api/authorize` was missing, so Audiobookshelf clients could log in and
+  then silently lose their session.** The route was never registered, so gin's
+  path-fixer answered it with a `301` to `/api/v1/authorize`. A `301` permits a
+  client to downgrade the method, so the app re-issued the call as `GET`, took a
+  `404` from the app API, and never refreshed — presenting as "connected" and then
+  failing on the next authenticated request. Observed in production on 2026-08-01:
+  `POST /api/authorize → 301`, `GET /api/v1/authorize → 404`, then
+  `GET /api/libraries → 401` fifty seconds later.
+
+  The endpoint now re-validates the caller's existing credential and returns the
+  standard authorize payload. It **echoes** the presented access and refresh tokens
+  rather than minting new ones, so an app foregrounding repeatedly no longer creates
+  a session row per call.
+
+  It carries the same §1.8.1 obligation as `/api/me`: AudioBooth's
+  `MediaProgress.syncFromAPI` **deletes** every local progress row absent from
+  `user.mediaProgress`, and it calls this endpoint on foreground — so a `200` with an
+  empty or partial list would erase the user's position in every omitted book on
+  every app launch. The handler therefore answers `5xx` rather than ever serving a
+  short list, and a test asserts it.
+
+  `/api/authorize` was also added to `absReservedPaths`, without which the `301`
+  would return even with the handler present. The existing
+  `TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` guard derives its input
+  from `absRouteList()`, so it now enforces that pairing automatically.
+
+- **`GET /api/me/listening-stats` returning `404` is correct and was left alone.**
+  The ABS sync spec prefers a `404` there (~12 non-optional fields; callers use
+  `try?`), so a half-correct body would be worse than none.

--- a/internal/server/handlers/abs/authorize.go
+++ b/internal/server/handlers/abs/authorize.go
@@ -1,0 +1,92 @@
+// file: internal/server/handlers/abs/authorize.go
+// version: 1.0.0
+// guid: 7e14b0c9-53a6-4d82-91f7-2c8de6a04b13
+// last-edited: 2026-08-01
+
+package abs
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/server/absauth"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+)
+
+// Authorize handles POST /api/authorize — the endpoint an already-logged-in client
+// calls to re-validate its token and refresh its view of the server.
+//
+// 🔴 THIS ENDPOINT CAN DESTROY USER DATA IF IT UNDER-REPORTS (§1.8.1), for exactly
+// the same reason Me does: AudioBooth's MediaProgress.syncFromAPI DELETES every local
+// progress row whose bookID is absent from `user.mediaProgress`. AudioBooth calls this
+// on foreground, so a 200 carrying an empty or partial list wipes the user's place in
+// every book, repeatedly, with no error shown. The complete list or a 5xx — never a
+// convenient empty array.
+//
+// # Why it must exist at all, and why its absence was invisible
+//
+// Without this route, gin's path-fixer answered POST /api/authorize with a 301 to
+// /api/v1/authorize. A 301 lets a client downgrade the method, so the app re-issued it
+// as GET, got a 404 from the app API, and silently never refreshed its session — the
+// app showed "connected", then failed on the next authenticated call. Observed in
+// production 2026-08-01:
+//
+//	POST /api/authorize          → 301
+//	GET  /api/v1/authorize       → 404
+//	GET  /api/libraries          → 401   (50s later, session never refreshed)
+//
+// That is the failure mode absReservedPaths exists to prevent, which is why this route
+// is registered in Handler.Register AND listed in absReservedPaths in
+// wire_abs_routes.go. Adding one without the other reintroduces the bug.
+//
+// # No new session is minted here
+//
+// Authorize VALIDATES the caller's existing credential; it does not issue one. Minting
+// a session per call would create a row on every app foreground. So the tokens the
+// caller presented are echoed back rather than reissued:
+//
+//   - accessToken: echoed from the request. In Mode C there may be no bearer at all, so
+//     a token is minted for the CURRENT session rather than emitting "", which clients
+//     decode as a non-optional String.
+//   - refreshToken: echoed only if the caller sent one. It is never regenerated — we
+//     store only its hash and could not reproduce it anyway. Echoing what the client
+//     already holds keeps Absorb's isLegacy flag clear (§1.7.2) without minting secrets.
+func (h *Handler) Authorize(c *gin.Context) {
+	user, ok := servermiddleware.CurrentUser(c)
+	if !ok || user == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	progress, bookmarks, err := h.userPayload(user.ID)
+	if err != nil {
+		absauth.Audit(absauth.AuditEvent{
+			Action: "authorize", Outcome: absauth.OutcomeError,
+			Mode: servermiddleware.ABSAuthMode(c), SourceIP: c.ClientIP(),
+			UserID: user.ID, Username: user.Username,
+			Reason: "user-data-unavailable", Path: c.Request.URL.Path,
+		})
+		// Never a 200 with an incomplete list. See the note above.
+		respondError(c, http.StatusInternalServerError, "could not load user data")
+		return
+	}
+
+	accessToken := currentAccessToken(c)
+	if accessToken == "" {
+		if minted, _, mintErr := h.cfg.MintAccessToken(user.ID, servermiddleware.ABSSessionID(c), h.now()); mintErr == nil {
+			accessToken = minted
+		}
+	}
+
+	absauth.Audit(absauth.AuditEvent{
+		Action: "authorize", Outcome: absauth.OutcomeSuccess,
+		Mode: servermiddleware.ABSAuthMode(c), SourceIP: c.ClientIP(),
+		UserID: user.ID, Username: user.Username,
+		SessionID: servermiddleware.ABSSessionID(c),
+		Path:      c.Request.URL.Path, UserAgent: c.Request.UserAgent(),
+	})
+
+	respondJSON(c, http.StatusOK, h.buildAuthResponse(
+		user, accessToken, refreshTokenFromRequest(c), progress, bookmarks))
+}

--- a/internal/server/handlers/abs/authorize_test.go
+++ b/internal/server/handlers/abs/authorize_test.go
@@ -1,0 +1,126 @@
+// file: internal/server/handlers/abs/authorize_test.go
+// version: 1.0.0
+// guid: 2f6c8d31-94b7-4e05-a8c2-51db307ea9f6
+// last-edited: 2026-08-01
+
+package abs_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// authorizeHarness sets up a logged-in user and returns the harness plus a bearer.
+func authorizeHarness(t *testing.T, ud *fakeUserData) (*harness, string) {
+	t.Helper()
+	h := newHarness(t, "cf,jwt", nil, withUserData(ud))
+	h.seedPasswordUser(t, "u1", "owner", "pw-pw-pw-pw")
+	access := str(t, userObj(t, h.login(t, "owner", "pw-pw-pw-pw")), "accessToken")
+	return h, access
+}
+
+func progressRow(id string) any {
+	return map[string]any{"libraryItemId": id, "currentTime": 10.0, "progress": 0.5}
+}
+
+// TestAuthorizeReturnsCompleteProgressList is the §1.8.1 data-loss guard.
+//
+// AudioBooth DELETES local progress rows absent from this array, and it calls
+// /api/authorize on foreground. A short list here erases the user's place in every
+// book it omits, silently, on every app launch.
+func TestAuthorizeReturnsCompleteProgressList(t *testing.T) {
+	ud := &fakeUserData{
+		progress:  []any{progressRow("item-1"), progressRow("item-2"), progressRow("item-3")},
+		bookmarks: []any{},
+	}
+	h, access := authorizeHarness(t, ud)
+
+	w, body := h.do(t, request{method: http.MethodPost, path: "/api/authorize",
+		headers: map[string]string{"Authorization": "Bearer " + access}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+
+	user := userObj(t, body)
+	rows, ok := user["mediaProgress"].([]any)
+	if !ok {
+		t.Fatalf("mediaProgress missing or not an array: %v", user["mediaProgress"])
+	}
+	if len(rows) != 3 {
+		t.Fatalf("mediaProgress has %d rows, want all 3 — a short list DELETES the "+
+			"user's progress for every omitted book (§1.8.1)", len(rows))
+	}
+}
+
+// TestAuthorizeUserDataFailureIsErrorNotEmptyList: when the progress list cannot be
+// read we must fail loudly. A 200 carrying [] is indistinguishable to the client from
+// "you have no progress anywhere", which it then makes true.
+func TestAuthorizeUserDataFailureIsErrorNotEmptyList(t *testing.T) {
+	// Log in while the provider is healthy, THEN break it. Constructing the harness
+	// with the error already set would fail at /login (which carries the identical
+	// §1.8.1 guard) and never exercise authorize at all.
+	ud := &fakeUserData{progress: []any{progressRow("item-1")}, bookmarks: []any{}}
+	h, access := authorizeHarness(t, ud)
+	ud.err = errors.New("store unavailable")
+
+	w, body := h.do(t, request{method: http.MethodPost, path: "/api/authorize",
+		headers: map[string]string{"Authorization": "Bearer " + access}})
+	if w.Code < 500 {
+		t.Fatalf("got %d, want 5xx: a 200 with an empty list destroys user progress", w.Code)
+	}
+	if _, present := body["user"]; present {
+		t.Fatalf("error response must not carry a user payload: %v", body)
+	}
+}
+
+// TestAuthorizeRequiresAuthentication: it re-validates a credential, so it must demand
+// one. Unauthenticated callers get 401, never a populated body.
+func TestAuthorizeRequiresAuthentication(t *testing.T) {
+	h := newHarness(t, "cf,jwt", nil, withUserData(&fakeUserData{progress: []any{}, bookmarks: []any{}}))
+
+	w, _ := h.do(t, request{method: http.MethodPost, path: "/api/authorize"})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", w.Code)
+	}
+}
+
+// TestAuthorizeUserDefaultLibraryIDIsNonNull is the §1.8.2 login blocker: AudioBooth
+// decodes userDefaultLibraryId as a non-optional String, so null makes it unable to
+// log in at all.
+func TestAuthorizeUserDefaultLibraryIDIsNonNull(t *testing.T) {
+	h, access := authorizeHarness(t, &fakeUserData{progress: []any{}, bookmarks: []any{}})
+
+	_, body := h.do(t, request{method: http.MethodPost, path: "/api/authorize",
+		headers: map[string]string{"Authorization": "Bearer " + access}})
+
+	id, ok := body["userDefaultLibraryId"].(string)
+	if !ok || id == "" {
+		t.Fatalf("userDefaultLibraryId = %v, want a non-empty String (§1.8.2)", body["userDefaultLibraryId"])
+	}
+}
+
+// TestAuthorizeDoesNotMintANewSession: authorize VALIDATES a credential, it does not
+// issue one. Minting per call would add a session row on every app foreground.
+func TestAuthorizeDoesNotMintANewSession(t *testing.T) {
+	h, access := authorizeHarness(t, &fakeUserData{progress: []any{}, bookmarks: []any{}})
+
+	before, err := h.store.ListABSSessionsForUser("u1")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if w, _ := h.do(t, request{method: http.MethodPost, path: "/api/authorize",
+			headers: map[string]string{"Authorization": "Bearer " + access}}); w.Code != http.StatusOK {
+			t.Fatalf("call %d: got %d", i, w.Code)
+		}
+	}
+	after, err := h.store.ListABSSessionsForUser("u1")
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("sessions grew %d -> %d across 3 authorize calls; it must not mint sessions",
+			len(before), len(after))
+	}
+}

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
-// last-edited: 2026-07-30
+// last-edited: 2026-08-01
 
 // Package abs implements the Audiobookshelf-compatible auth surface (design spec
 // Phase 1): GET /ping, GET /status, POST /login, POST /auth/refresh, POST /logout,
@@ -291,6 +291,10 @@ func (h *Handler) Register(r gin.IRouter) {
 
 	auth := servermiddleware.ABSRequireAuth(h.resolver)
 	r.POST("/logout", auth, h.Logout)
+	// Re-validates an existing credential and re-reports the user. Carries the same
+	// §1.8.1 complete-mediaProgress obligation as /api/me — see authorize.go. Must
+	// also appear in absReservedPaths, or gin 301s it into the app API.
+	r.POST("/api/authorize", auth, h.Authorize)
 	r.GET("/api/me", auth, h.Me)
 	r.GET("/api/me/sessions", auth, h.Sessions)
 	r.DELETE("/api/me/sessions/:id", auth, h.DeleteSession)

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-01
 
@@ -34,6 +34,10 @@ var _ abshandler.ProgressListStore = (*database.PebbleStore)(nil)
 // Kept as an explicit list rather than a broad prefix so adding an ABS endpoint is a
 // deliberate act, and so a future /api/v1 route can never be captured by accident.
 var absReservedPaths = []string{
+	// POST. Omitting it let gin 301 the call into /api/v1/authorize; the client
+	// downgraded the redirected POST to GET, took a 404, and never refreshed its
+	// session — "connected", then 401 on the next call. Observed in prod 2026-08-01.
+	"/api/authorize",
 	"/api/me",
 	"/api/libraries",
 }
@@ -335,6 +339,7 @@ func absRouteList() []string {
 		"POST /login",
 		"POST /auth/refresh",
 		"POST /logout",
+		"POST /api/authorize",
 		"GET /api/me",
 		"GET /api/me/sessions",
 		"DELETE /api/me/sessions/:id",


### PR DESCRIPTION
## What broke

AudioBooth logged in successfully, then went orange a minute later. Production logs, 2026-08-01:

```
22:52:21  POST /api/authorize          → 301
22:52:21  GET  /api/v1/authorize       → 404
22:52:57  GET  /api/libraries          → 401
```

`/api/authorize` was never registered. Gin's path-fixer answered it with a `301` to `/api/v1/authorize`; a `301` permits a client to downgrade the method, so the app re-issued it as `GET`, took a `404`, and never refreshed its session.

This is the exact failure `absReservedPathPrefixes` already documents — *"the endpoint exists, a curl appears to work (301 → 200), and the client silently receives the /api/v1 shape or a 401. It looks implemented and behaves broken."* The existing guard protects **registered** routes; it could not catch one that was never registered at all.

## The data-loss angle

Per spec §1.8.1, `MediaProgress.syncFromAPI` **deletes** every local progress row absent from `user.mediaProgress` — and AudioBooth calls this endpoint on foreground. A `200` carrying an empty or partial list would erase the user's position in every omitted book, on every app launch, with no error surfaced.

So the handler answers `5xx` rather than ever serving a short list, mirroring `/api/me`. `TestAuthorizeReturnsCompleteProgressList` and `TestAuthorizeUserDataFailureIsErrorNotEmptyList` assert both halves.

## Design notes

- **No session minted.** Authorize *validates* a credential; it doesn't issue one. Tokens the caller presented are echoed back, so foregrounding doesn't add a session row per call (`TestAuthorizeDoesNotMintANewSession`).
- **`refreshToken` echoed, never regenerated** — only its hash is stored. Echoing what the client holds keeps Absorb's `isLegacy` flag clear (§1.7.2) without minting secrets.
- **Both registrations, deliberately.** Route in `Handler.Register` *and* path in `absReservedPaths`. `TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` derives from `absRouteList()`, so it now enforces the pairing automatically.

## Left alone on purpose

`GET /api/me/listening-stats` → `404` is **correct**. The spec prefers 404 there (~12 non-optional fields; callers use `try?`), so a half-correct body would be worse than none.

## Tests

5 new, all green with `-race`; `internal/server/handlers/abs` and `internal/server` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp