### PR TITLE
docs(todo): record three findings from the AudioBooth session

### DIFF
--- a/changelog.d/20260802_013000_todo-fragments.md
+++ b/changelog.d/20260802_013000_todo-fragments.md
@@ -1,0 +1,12 @@
+<!-- file: changelog.d/20260802_013000_todo-fragments.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4a90c718-6e25-4b83-91df-c073e5a8b246 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Changed
+
+- Recorded three findings from the 2026-08-01 AudioBooth session as `todo.d`
+  fragments: the unbuilt ABS progress-mutation endpoints (Phase 6 write half, so
+  "reset progress" and "remove from continue listening" 404), cover-art coverage at
+  ~19.5% of the library, and a latent deep-link redirect bug in the web OAuth
+  callback that no shipped client currently reaches.

--- a/todo.d/2026-08-01-oauth-login-deeplink-return.md
+++ b/todo.d/2026-08-01-oauth-login-deeplink-return.md
@@ -1,0 +1,71 @@
+<!-- file: todo.d/2026-08-01-oauth-login-deeplink-return.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9a4f1e58-2d70-4b93-8c16-e05d7b3a92c1 -->
+<!-- last-edited: 2026-08-01 -->
+
+## LATENT: web OAuth callback silently discards a custom-scheme `return`, falling back to `/`
+
+**Severity:** latent. No shipped client currently exercises this path — see
+"Why this is not urgent" below. Filed so it is not rediscovered from scratch.
+
+`internal/server/handlers/oauth_login.go:145` picks the post-login destination:
+
+```go
+dest := "/"
+if payload.Return != "" { dest = payload.Return }
+http.Redirect(c.Writer, c.Request, dest, http.StatusFound)
+```
+
+`payload.Return` was set at `Start` via `sanitizeReturn(c.Query("return"))`, and
+`sanitizeReturn` requires a single leading slash:
+
+```go
+if ret == "" || !strings.HasPrefix(ret, "/") { return "" }
+```
+
+So a native-app deep link such as `audiobooth://oauth` becomes `""`, `dest`
+falls back to `"/"`, and the caller is sent to the web SPA root. **No error is
+raised and nothing is logged** — the redirect target is simply replaced. A client
+expecting to be handed back to its own URL scheme instead lands on the web UI,
+which surfaces as an opaque "it logged me into the website" rather than as a
+failure.
+
+### Why this is not urgent
+
+Production logs over 7 days show **zero** requests to `/auth/oauth/*` — the web
+provider flow is reached only by the SPA's login buttons, which legitimately want
+same-site paths. Audiobookshelf clients use `/auth/openid` +
+`/auth/openid/callback` (`internal/server/handlers/abs/openid.go`) instead, and
+that path already handles custom schemes correctly via `oidcRedirectAllowed` and
+`oidcRedirect`.
+
+This was misdiagnosed on 2026-08-01 as the cause of the AudioBooth login failure.
+It was not — the real cause was Cloudflare Access intercepting
+`/auth/openid/callback` before it reached the origin, fixed with a scoped Access
+bypass on that single path. Recording the distinction here so the next
+investigation does not repeat it: **a redirect-to-web-root symptom has two
+plausible causes, and only traffic logs distinguish them.**
+
+### Fix, if a client ever needs it
+
+Do **not** loosen `sanitizeReturn` — it is the open-redirect guard and the reason
+`d87cbf37` (account takeover via unregistered `redirect_uri`) cannot recur here.
+
+Instead mirror the ABS path: on an allowlisted deep link, mint a single-use
+PKCE-bound code via the `abs` package's existing code store and 302 to
+`audiobooth://oauth?code=…&state=…`, letting the client redeem it at the existing
+`/auth/openid/callback`. Two constraints that a naive implementation gets wrong:
+
+1. **Gate on `redirect_uri` AND `code_challenge` together.**
+   `/auth/oauth/:provider/start` is the unauthenticated web login endpoint; if a
+   bare `redirect_uri` could trigger a 400, anyone could break web login by
+   appending a query param to a link.
+2. **There are two distinct PKCE exchanges** — server↔IdP (verifier already in
+   `StatePayload.Verifier`) and app↔server (the app's own challenge). Conflating
+   them either breaks the upstream token exchange or issues codes with no
+   app-side proof of possession.
+
+Unverified assumption to settle before building: whether
+`ASWebAuthenticationSession` returns the `SameSite=Lax` `oauth_state` cookie on
+the hop back from the IdP. If it does not, `Callback` dies at
+`oauth_state_missing` regardless. Only a real-device test can answer it.

--- a/todo.d/2026-08-02-abs-cover-art-coverage.md
+++ b/todo.d/2026-08-02-abs-cover-art-coverage.md
@@ -1,0 +1,45 @@
+<!-- file: todo.d/2026-08-02-abs-cover-art-coverage.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e2c81f76-4b90-4d35-a617-9f0c53b8e2a4 -->
+<!-- last-edited: 2026-08-02 -->
+
+## GAP: only ~19.5% of books have cover art, so most ABS clients show placeholders
+
+**Severity:** cosmetic but pervasive. Not a code defect — `GET /api/items/:id/cover`
+behaves as designed.
+
+Observed 2026-08-02: AudioBooth's library grid rendered, and every cover request in
+the sample 404'd:
+
+```
+GET /api/items/cb6e44f7-…/cover  → 404
+GET /api/items/7840afbd-…/cover  → 404      (5 of 5 in the window)
+```
+
+On prod, `/mnt/bigdata/books/audiobook-organizer/covers/` holds **7,885** files
+against a library of roughly **40,400** books — about **19.5%** coverage.
+
+### Why this is not a bug
+
+`Handler.ItemCover` resolves via `metadata.CoverPathForBook`, which globs
+`<RootDir>/covers/<bookID>.{jpg,jpeg,png,webp,gif}` and returns `""` when nothing
+matches. The handler then answers 404, and its own comment records that as intended:
+*"A 404 here is correct and harmless: both clients fall back to a placeholder."*
+
+**Not yet confirmed:** whether those 5 specific items lack cover files, or whether the
+sync-UUID → Book-ULID resolution is picking the wrong ID. With 19.5% coverage, 5
+consecutive misses has a ~34% chance of being pure luck, so this is *likely* a data
+gap but has NOT been proven. Verify by resolving one of those sync IDs to its Book
+ULID and checking for `covers/<ULID>.*` before investing in a backfill — a mapping bug
+and an empty directory look identical from the client.
+
+### If it is the data gap
+
+A cover backfill over ~32,500 books is a full-library maintenance op and must be
+written to the repo's concurrency rules from the start (CLAUDE.md): bounded worker
+pool, `registry.RunItems`, never a plain `for range books`. Network-bound if it
+fetches from a metadata provider, so size concurrency to that provider's rate limits
+rather than `runtime.NumCPU()`.
+
+Look for an existing parallel sibling before writing a new loop — the acoustid
+backfill (`internal/plugins/acoustid/backfill.go`) is the established pattern.

--- a/todo.d/2026-08-02-abs-progress-mutation-endpoints.md
+++ b/todo.d/2026-08-02-abs-progress-mutation-endpoints.md
@@ -1,0 +1,61 @@
+<!-- file: todo.d/2026-08-02-abs-progress-mutation-endpoints.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b57d2409-8e13-4c6a-9f25-30ab8e17c4d2 -->
+<!-- last-edited: 2026-08-02 -->
+
+## MISSING: ABS progress-mutation endpoints — "reset progress" and "remove from continue listening" do nothing
+
+**Severity:** user-visible feature gap, not a regression. Reported from AudioBooth
+on 2026-08-02 immediately after the client reached a fully working state (SSO login,
+library browse, and playback all confirmed the same night).
+
+Observed in production:
+
+```
+01:13:17  GET /api/me/progress/44669fab-6544-4414-ae2d-fa8eba7c52f3  → 404
+```
+
+`remove-from-continue-listening` was reported as also not working. Its call does not
+appear in the log window that was checked, so it is recorded here from the spec
+rather than from an observation — confirm the exact path and method against
+AudioBooth before implementing.
+
+### This is planned work, not a defect
+
+`docs/specs/2026-07-29-abs-sync-api-design.md:839` puts all of it in **Phase 6**:
+
+> Progress + bookmarks: adapt playback store, `/api/me`, `PATCH /api/me/progress/:id`,
+> `/api/me/progress`, bookmarks CRUD (new), remove-from-continue-listening; §5 merge
+> policy
+
+Phase 6's read half shipped — `/api/me` and `POST /api/authorize` both serve the
+complete `mediaProgress` list from `UserDataProvider`. The **write** half was never
+built, so every client-side progress mutation 404s.
+
+### Endpoints to add
+
+- `PATCH /api/me/progress/:id` — update progress for one item
+- `GET`/`DELETE` on `/api/me/progress/:id` — AudioBooth issued a `GET`; check whether
+  reset is a `DELETE` and the `GET` is only a pre-read
+- `/api/me/progress` — batch
+- `…/remove-from-continue-listening`
+- bookmarks CRUD
+
+### Constraints that already apply
+
+- **`absReservedPaths`.** `/api/me/` is already a reserved *prefix*, so these inherit
+  the exclusion and will not 301 into `/api/v1`. No new reservation needed — unlike
+  `/api/authorize`, which needed an exact-path entry (see PR #2100).
+- **§1.8.1 still governs the read side.** Any handler that returns a user payload must
+  return the COMPLETE `mediaProgress` list or a 5xx. A mutation endpoint that responds
+  with a truncated user object destroys local progress exactly as `/api/me` would.
+- **`…/remove-from-continue-listening` needs a non-empty body** — `{}` suffices
+  (spec:318). An empty `200` is fatal to these decoders (§1.8.6).
+- **§5 merge policy** applies to writes: device↔device sync is explicitly out of scope
+  for the phase, but the merge rules for a single device's updates are specified.
+
+### Not a bug, do not "fix"
+
+`GET /api/me/listening-stats` → 404 and `GET /api/me/item/listening-sessions/:id` →
+404 are **correct**. The spec prefers 404 for the stats endpoints (~12 non-optional
+fields; callers use `try?`), and a half-correct body is worse than none.


### PR DESCRIPTION
Three `todo.d` fragments from the 2026-08-01 AudioBooth session. No code changes.

**`2026-08-02-abs-progress-mutation-endpoints.md`** — "reset progress" and "remove from continue listening" 404. Spec line 839 puts `PATCH /api/me/progress/:id`, `/api/me/progress`, bookmarks CRUD and remove-from-continue-listening in Phase 6; the **read** half shipped (`/api/me`, `POST /api/authorize`) and the **write** half was never built, which is why the gap wasn't obvious. Observed: `GET /api/me/progress/44669fab-… → 404`. Also records that `listening-stats` / `listening-sessions` 404s are *correct* per spec and must not be "fixed".

**`2026-08-02-abs-cover-art-coverage.md`** — 7,885 cover files against ~40,400 books (~19.5%), so most items render a placeholder. `ItemCover` behaves as designed. Explicitly flagged as **unconfirmed**: 5-of-5 misses has a ~34% chance of being luck at that coverage, so the fragment names the check (resolve a sync UUID → Book ULID, look for `covers/<ULID>.*`) needed to rule out an ID-resolution bug before anyone invests in a backfill.

**`2026-08-01-oauth-login-deeplink-return.md`** — `oauth_login.go:145` discards a custom-scheme `return` via `sanitizeReturn` and falls back to `/`. Real but latent: 7 days of production logs show **zero** requests to `/auth/oauth/*`. Recorded mainly because it was misdiagnosed as the AudioBooth login failure — the actual cause was Cloudflare Access intercepting `/auth/openid/callback`. Notes that only traffic logs distinguish the two, since both present as "redirected to the web root".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp