### PR TITLE
feat(abs): Phase 6 write half — progress mutations + bookmarks CRUD

### DIFF
--- a/changelog.d/20260802_010000_abs_phase6_progress_writes.md
+++ b/changelog.d/20260802_010000_abs_phase6_progress_writes.md
@@ -1,0 +1,43 @@
+<!-- file: changelog.d/20260802_010000_abs_phase6_progress_writes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6c2f81ad-4b39-4e70-95c1-8a03df2b71e6 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Added
+
+- **Audiobookshelf Phase 6 write half — progress mutations and bookmarks.** The read
+  half shipped earlier, so every client-side progress change 404'd: "reset progress"
+  and "remove from continue listening" appeared to do nothing. Adds
+  `GET`/`PATCH`/`DELETE /api/me/progress/:id`, `GET /api/me/progress`,
+  `PATCH /api/me/progress/batch/update`,
+  `POST /api/me/item/:id/remove-from-continue-listening`, and bookmarks CRUD
+  (`GET /api/me/bookmarks/:id`, `POST`/`PATCH /api/me/item/:id/bookmark`,
+  `DELETE /api/me/item/:id/bookmark/:time`) over the existing progress and bookmark
+  keyspaces. Writes merge through the §5 conflict policy (`progress.MergeExplicit`)
+  rather than last-write-wins.
+
+- **`hideFromContinueListening` is now persisted** (`UserBookState`), so removing a
+  book from Continue Listening survives a restart and is reported consistently by
+  `/api/me`, `/api/me/progress` and `/api/items/:id`.
+
+### Fixed
+
+- **A playback sync silently reset user intent on the book state.**
+  `persistProgress` constructed a fresh `UserBookState` on every sync instead of
+  read-modify-writing it, so every field it did not set was reset. That already
+  un-pinned a hand-set read status (`StatusManual`) roughly every 20 seconds of
+  listening, and would have un-hidden any book removed from Continue Listening within
+  seconds of the user hiding it. All ABS write paths now go through a single
+  read-modify-write helper.
+
+### Changed
+
+- **Two spec assumptions corrected against the reference oracle** (real ABS 2.36.0,
+  probed 2026-08-02; five new fixtures committed under `testdata/abs-fixtures/`):
+  - `DELETE /api/me/progress/:id` is keyed by the **`mediaProgress` row id**, not the
+    `libraryItemId` — deleting by item id answers 404 on real ABS. Our handlers accept
+    **both** forms, since a client may hold either.
+  - `POST /api/me/item/:id/remove-from-continue-listening` **does not exist** on ABS
+    2.36.0 (it answers "Cannot POST"); the real mechanism is a
+    `hideFromContinueListening` field on `PATCH /api/me/progress/:id`. Both are served,
+    because a client calls the POST form and was taking a 404.

--- a/docs/specs/2026-07-29-abs-sync-api-design.md
+++ b/docs/specs/2026-07-29-abs-sync-api-design.md
@@ -1,7 +1,7 @@
 <!-- file: docs/specs/2026-07-29-abs-sync-api-design.md -->
-<!-- version: 7.2.0 -->
+<!-- version: 7.3.0 -->
 <!-- guid: 0869d58c-b186-45cb-9915-64bd18eaa45f -->
-<!-- last-edited: 2026-07-30 -->
+<!-- last-edited: 2026-08-02 -->
 
 # Audiobookshelf-Compatible Sync API — Design Spec (Umbrella)
 
@@ -315,9 +315,50 @@ All of these tolerate failure, so **404/500 is strictly safer than a half-correc
 | listening-stats / year-stats | **prefer 404** | ~12 non-optional fields; callers use `try?` |
 
 Also: **an empty `200` body is fatal** for any typed endpoint (`NetworkService.swift:224-227`), and
-`…/remove-from-continue-listening` needs a non-empty body (`{}` suffices). A `200` serving the SPA
+`…/remove-from-continue-listening` needs a non-empty body (`{}` suffices). ⚠️ **Corrected 2026-08-02 —
+see §1.8.9: that route does not exist on real ABS at all.** A `200` serving the SPA
 `index.html` under `/api/` is fatal; a *404* with an HTML body is harmless to these two clients but must
 still be JSON for ShelfPlayer.
+
+### 🔴 1.8.9 CORRECTIONS from the oracle, 2026-08-02 (Phase 6 write half)
+
+Two claims elsewhere in this spec were **wrong**, found by probing the pinned ABS 2.36.0 oracle while
+building the write half. Fixtures for all of it are committed under `testdata/abs-fixtures/`.
+
+1. **`DELETE /api/me/progress/:id` is keyed by the `mediaProgress` ROW id, not the `libraryItemId`.**
+   Deleting by item id answers `404`; deleting by `mediaProgress[].id` answers `200 "OK"`. Our read half
+   renders that id as `"<userID>-<syncID>"`, so a client that read `/api/me` hands *that* back. The
+   handlers accept **both** forms, stripping the authenticated caller's own id as a prefix — so one user
+   can never address another's row by constructing an id.
+
+2. **`POST /api/me/item/:id/remove-from-continue-listening` DOES NOT EXIST on ABS 2.36.0.** It answers
+   `404 Cannot POST`. The real mechanism is `PATCH /api/me/progress/:id` with
+   `{"hideFromContinueListening": true}`. We serve **both**: the PATCH field because it is the genuine
+   mechanism, and the POST alias because a client calls it and was taking a 404 in production (the
+   owner-reported "remove from continue listening does nothing"). The alias answers `{}` — non-empty, per
+   §1.8.6.
+
+Verified response shapes for the whole write half (note that three of them are **`text/plain`**, not JSON):
+
+| Endpoint | Status | Body |
+|---|---|---|
+| `GET /api/me/progress` | 200 | `{"mediaProgress":[…]}` — **§1.8.1 applies: complete or 5xx** |
+| `GET /api/me/progress/:id` | 200 / 404 | a **bare** mediaProgress object / `text/plain "Not Found"` |
+| `PATCH /api/me/progress/:id` | 200 | `text/plain "OK"` |
+| `PATCH /api/me/progress/batch/update` | 200 | `text/plain "OK"`; request body is a **bare array** |
+| `DELETE /api/me/progress/:id` | 200 / 404 | `text/plain "OK"` |
+| `GET /api/me/bookmarks/:id` | 200 | `{"bookmarks":[…]}` |
+| `POST` / `PATCH /api/me/item/:id/bookmark` | 200 | a bare bookmark object |
+| `DELETE /api/me/item/:id/bookmark/:time` | 200 / 404 | `text/plain "OK"` |
+
+**§5 rule 3 (forward-only) does not fire on either write endpoint, and that is intentional.** Neither
+`PATCH /api/me/progress/:id` nor `POST /api/session/:id/sync` carries a client timestamp, so incoming is
+always "newer" and both accept a backwards position. Both report a *live* user action — refusing one would
+make scrubbing backwards impossible. The stale-device clobber is prevented one step earlier instead:
+`POST /api/items/:id/play` returns the server's TRUE latest position and §1.8.7 has AudioBooth take
+`max(local, session.currentTime)` ignoring timestamps, so a stale device is pulled forward and never has a
+behind position to push. Forward-only merging guards the one path with genuinely untrustworthy timestamps —
+offline replay, via `MergeOfflineReplay`.
 
 ### 1.8.7 Progress conflict resolution — client-side rules our server must respect
 

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.85.1
+// version: 2.86.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-07-26
+// last-edited: 2026-08-02
 
 package database
 
@@ -804,7 +804,17 @@ type UserBookState struct {
 	LastSegmentID        string    `json:"last_segment_id,omitempty"`
 	TotalListenedSeconds float64   `json:"total_listened_seconds,omitempty"`
 	ProgressPct          int       `json:"progress_pct"` // 0-100
-	UpdatedAt            time.Time `json:"updated_at"`
+	// HideFromContinueListening backs the Audiobookshelf surface's
+	// `mediaProgress[].hideFromContinueListening` flag — "remove this from Continue
+	// Listening" without discarding the position. Additive: rows written before this
+	// field existed unmarshal to false, which is the correct default (nothing was
+	// ever hidden).
+	//
+	// It is a USER INTENT, not derived state. Anything that rewrites a
+	// UserBookState must read-modify-write rather than construct a fresh literal, or
+	// the next playback sync silently un-hides what the user hid.
+	HideFromContinueListening bool      `json:"hide_from_continue_listening,omitempty"`
+	UpdatedAt                 time.Time `json:"updated_at"`
 }
 
 // UserBookStatus values. Auto-computed from UserPosition rows

--- a/internal/server/handlers/abs/abs_test.go
+++ b/internal/server/handlers/abs/abs_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/abs_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2c07b5e9-4d16-48fa-b930-71e5c8a04f6d
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs_test
 
@@ -258,13 +258,29 @@ func (f *fakeVerifier) Verify(_ context.Context, raw string) (*oauth.IdentityCla
 // ── fake user-data provider (Phase 6 stand-in) ──────────────────────────────
 
 type fakeUserData struct {
-	progress  []any
-	bookmarks []any
-	err       error
+	progress    []any
+	bookmarks   []any
+	progressFor map[string]any
+	err         error
 }
 
 func (f *fakeUserData) MediaProgress(string) ([]any, error) { return f.progress, f.err }
 func (f *fakeUserData) Bookmarks(string) ([]any, error)     { return f.bookmarks, f.err }
+
+// MediaProgressFor mirrors the real provider closely enough for handler tests: the
+// SAME error is reported (so a broken provider still yields a 5xx rather than a 404,
+// which is the distinction GET /api/me/progress/:id exists to preserve), and a
+// missing row is reported as ok=false rather than as an empty object.
+func (f *fakeUserData) MediaProgressFor(_, bookID string) (any, bool, error) {
+	if f.err != nil {
+		return nil, false, f.err
+	}
+	if f.progressFor == nil {
+		return nil, false, nil
+	}
+	row, ok := f.progressFor[bookID]
+	return row, ok, nil
+}
 
 // ── harness ─────────────────────────────────────────────────────────────────
 

--- a/internal/server/handlers/abs/bookmarks.go
+++ b/internal/server/handlers/abs/bookmarks.go
@@ -1,0 +1,229 @@
+// file: internal/server/handlers/abs/bookmarks.go
+// version: 1.0.0
+// guid: 8d3c15af-6e29-4b70-91c8-4a05f7e2b3d6
+// last-edited: 2026-08-02
+
+package abs
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+	"github.com/gin-gonic/gin"
+)
+
+// Phase 6 — bookmarks CRUD, over the keyspace TASK-09 built
+// (internal/database/pebble_store_bookmarks.go). Shapes captured from real
+// Audiobookshelf 2.36.0 on 2026-08-02:
+//
+//	GET    /api/me/bookmarks/:id              -> 200 {"bookmarks":[…]}
+//	POST   /api/me/item/:id/bookmark          -> 200 <bare bookmark object>
+//	PATCH  /api/me/item/:id/bookmark          -> 200 <bare bookmark object>
+//	DELETE /api/me/item/:id/bookmark/:time    -> 200 text/plain "OK" | 404
+//
+// 🔑 A BOOKMARK IS KEYED BY (item, time), NOT by an opaque id. The delete surface
+// puts the time value itself in the URL path and update matches on it, which is why
+// progress.CanonicalTimeKey exists: AudioBooth sends `time` as an Int in the path and
+// round-trips it as a Double in bodies, so "100", "100.0" and float noise must all
+// address the SAME stored row or a user's bookmark becomes undeletable.
+
+// bookmarkRequest is the POST/PATCH body. Time is a JSON number (Int or Double —
+// both decode into float64, which is the whole point) and Title is required, matching
+// real ABS and progress.ValidateBookmark.
+type bookmarkRequest struct {
+	Time  float64 `json:"time"`
+	Title string  `json:"title"`
+}
+
+// ── GET /api/me/bookmarks/:id ───────────────────────────────────────────────
+
+// ListItemBookmarks handles GET /api/me/bookmarks/:id.
+//
+// A read failure is a 5xx, never `{"bookmarks":[]}`. This list is item-scoped so it
+// carries none of §1.8.1's whole-library delete risk, but the same reasoning applies
+// in miniature: a client told "this book has no bookmarks" cannot distinguish that
+// from "we could not read them", and one of those answers is destructive to act on.
+func (h *Handler) ListItemBookmarks(c *gin.Context) {
+	user, syncID, _, ok := h.resolveTarget(c)
+	if !ok {
+		return
+	}
+	stored, err := h.bookmarks.ListBookmarks(user.ID, syncID)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "could not load bookmarks")
+		return
+	}
+	respondJSON(c, http.StatusOK, gin.H{"bookmarks": bookmarkDTOs(stored)})
+}
+
+// ── POST /api/me/item/:id/bookmark ──────────────────────────────────────────
+
+// CreateBookmark handles POST /api/me/item/:id/bookmark and answers with the created
+// bookmark, matching the oracle capture.
+//
+// CreateBookmark in the store is an UPSERT at (user, item, canonical time): saving
+// twice at the same spot updates the title rather than producing a duplicate, and the
+// original CreatedAt survives. That mirrors real ABS, where the create endpoint is
+// also the natural "re-save at the same spot" path a client may replay.
+func (h *Handler) CreateBookmark(c *gin.Context) {
+	user, syncID, _, ok := h.resolveTarget(c)
+	if !ok {
+		return
+	}
+	var req bookmarkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid bookmark body")
+		return
+	}
+
+	bookmark := progress.Bookmark{
+		UserID:  user.ID,
+		ItemID:  syncID,
+		TimeSec: req.Time,
+		Title:   strings.TrimSpace(req.Title),
+	}
+	if err := progress.ValidateBookmark(bookmark); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid bookmark: "+err.Error())
+		return
+	}
+	if err := h.bookmarks.CreateBookmark(bookmark); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not save bookmark")
+		return
+	}
+
+	// Read back rather than echo the request: CreatedAt is assigned by the store
+	// (and PRESERVED across an upsert), so echoing the input would report a fresh
+	// creation time for a bookmark that already existed.
+	respondJSON(c, http.StatusOK, h.readBackBookmark(c, user.ID, syncID, req.Time, bookmark))
+}
+
+// ── PATCH /api/me/item/:id/bookmark ─────────────────────────────────────────
+
+// UpdateBookmark handles PATCH /api/me/item/:id/bookmark — rename in place.
+//
+// The bookmark is addressed by the `time` in the BODY (there is no time path segment
+// on this route), and a time with no bookmark is a 404 rather than an implicit
+// create: the store's UpdateBookmarkTitle refuses to conjure a row, and silently
+// creating one would put a bookmark at a position the user never marked.
+func (h *Handler) UpdateBookmark(c *gin.Context) {
+	user, syncID, _, ok := h.resolveTarget(c)
+	if !ok {
+		return
+	}
+	var req bookmarkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid bookmark body")
+		return
+	}
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		respondError(c, http.StatusBadRequest, "bookmark title is required")
+		return
+	}
+
+	if err := h.bookmarks.UpdateBookmarkTitle(user.ID, syncID, req.Time, title); err != nil {
+		// The store reports "no such bookmark" as an error and has no typed
+		// sentinel for it, so existence is re-checked rather than guessed at: a
+		// genuine store failure must not be reported to the client as a 404, which
+		// reads as "your bookmark is gone".
+		if h.bookmarkExists(user.ID, syncID, req.Time) {
+			respondError(c, http.StatusInternalServerError, "could not update bookmark")
+			return
+		}
+		respondNotFoundPlain(c)
+		return
+	}
+	respondJSON(c, http.StatusOK, h.readBackBookmark(c, user.ID, syncID, req.Time, progress.Bookmark{
+		UserID: user.ID, ItemID: syncID, TimeSec: req.Time, Title: title,
+	}))
+}
+
+// ── DELETE /api/me/item/:id/bookmark/:time ──────────────────────────────────
+
+// DeleteBookmark handles DELETE /api/me/item/:id/bookmark/:time.
+//
+// The time arrives as a URL PATH SEGMENT, parsed with progress.ParseTimeSec
+// (ParseFloat, never ParseInt) because clients send "100" here and "100.0" elsewhere
+// for the same bookmark. A malformed time is a 404 rather than a 400: from the
+// client's perspective there is no bookmark at an unparseable position, and 404 is
+// what real ABS answers for a time with no bookmark.
+func (h *Handler) DeleteBookmark(c *gin.Context) {
+	user, syncID, _, ok := h.resolveTarget(c)
+	if !ok {
+		return
+	}
+	timeSec, err := progress.ParseTimeSec(c.Param("time"))
+	if err != nil {
+		respondNotFoundPlain(c)
+		return
+	}
+	if !h.bookmarkExists(user.ID, syncID, timeSec) {
+		respondNotFoundPlain(c)
+		return
+	}
+	if err := h.bookmarks.DeleteBookmark(user.ID, syncID, timeSec); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not delete bookmark")
+		return
+	}
+	respondPlainOK(c)
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+// bookmarkExists reports whether (user, item, time) names a stored bookmark,
+// comparing through CanonicalTimeKey so an Int and a Double form of the same instant
+// are recognised as the same row.
+func (h *Handler) bookmarkExists(userID, itemID string, timeSec float64) bool {
+	stored, err := h.bookmarks.ListBookmarks(userID, itemID)
+	if err != nil {
+		return false
+	}
+	want := progress.CanonicalTimeKey(timeSec)
+	for i := range stored {
+		if progress.CanonicalTimeKey(stored[i].TimeSec) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// readBackBookmark returns the stored row for (user, item, time), falling back to the
+// value just written when the read-back fails. The fallback keeps the response
+// non-empty — an empty 200 is fatal to these decoders (§1.8.6) — at the cost of a
+// possibly-wrong CreatedAt, which is strictly the lesser failure.
+func (h *Handler) readBackBookmark(_ *gin.Context, userID, itemID string, timeSec float64, fallback progress.Bookmark) bookmarkDTO {
+	want := progress.CanonicalTimeKey(timeSec)
+	if stored, err := h.bookmarks.ListBookmarks(userID, itemID); err == nil {
+		for i := range stored {
+			if progress.CanonicalTimeKey(stored[i].TimeSec) == want {
+				return toBookmarkDTO(stored[i])
+			}
+		}
+	}
+	return toBookmarkDTO(fallback)
+}
+
+// toBookmarkDTO renders one bookmark in the oracle's exact four-field shape: no id,
+// no userId, no updatedAt. Adding fields real ABS does not send is not free — a
+// strict decoder that tolerates them today may not after a client update.
+func toBookmarkDTO(b progress.Bookmark) bookmarkDTO {
+	return bookmarkDTO{
+		CreatedAt:     b.CreatedAt,
+		LibraryItemID: b.ItemID,
+		Time:          b.TimeSec,
+		Title:         b.Title,
+	}
+}
+
+// bookmarkDTOs renders a list, ordered by time so the client sees a stable sequence
+// across refreshes rather than the store's iteration order.
+func bookmarkDTOs(stored []progress.Bookmark) []bookmarkDTO {
+	out := make([]bookmarkDTO, 0, len(stored))
+	for i := range stored {
+		out = append(out, toBookmarkDTO(stored[i]))
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time < out[j].Time })
+	return out
+}

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
-// last-edited: 2026-08-01
+// last-edited: 2026-08-02
 
 // Package abs implements the Audiobookshelf-compatible auth surface (design spec
 // Phase 1): GET /ping, GET /status, POST /login, POST /auth/refresh, POST /logout,
@@ -31,6 +31,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/absauth"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
 )
@@ -65,6 +66,30 @@ type Store interface {
 type UserDataProvider interface {
 	MediaProgress(userID string) ([]any, error)
 	Bookmarks(userID string) ([]any, error)
+
+	// MediaProgressFor renders the single (user, book) row that GET
+	// /api/me/progress/:id serves, reporting ok=false when the user has never
+	// started the book (real ABS answers 404 there).
+	//
+	// It exists so the single-item body is produced by the SAME renderer as the
+	// list rather than by a parallel one. Clients compare the two for the same
+	// book — AudioBooth resolves conflicts on `lastUpdate` with strict `>` after
+	// truncating to whole seconds — so two renderers that drift by a field or a
+	// rounding step turn into a book that will not stop re-syncing.
+	MediaProgressFor(userID, bookID string) (any, bool, error)
+}
+
+// BookmarkStore is the named-bookmark CRUD slice (pebble_store_bookmarks.go).
+//
+// itemID here is the CLIENT-VISIBLE libraryItemId (the 36-char sync UUID), not a
+// Book ULID: the keyspace was defined that way to mirror real ABS, whose
+// create/update/delete surface addresses a bookmark by (item id, time) with the time
+// value in the URL path. userdata.go's Bookmarks reader depends on the same choice.
+type BookmarkStore interface {
+	CreateBookmark(b progress.Bookmark) error
+	ListBookmarks(userID, itemID string) ([]progress.Bookmark, error)
+	UpdateBookmarkTitle(userID, itemID string, timeSec float64, newTitle string) error
+	DeleteBookmark(userID, itemID string, timeSec float64) error
 }
 
 // LibraryStore is the read slice of the library the browse + playback surface needs
@@ -134,6 +159,12 @@ type ProgressStore interface {
 	SetUserPosition(userID, bookID, segmentID string, positionSeconds float64) error
 	GetUserBookState(userID, bookID string) (*database.UserBookState, error)
 	SetUserBookState(state *database.UserBookState) error
+	// ClearUserPositions backs DELETE /api/me/progress/:id ("reset progress"). It
+	// clears EVERY segment row for the (user, book), not just the ABS whole-book
+	// one: the user asked to start the book over, and leaving the app's own
+	// per-chapter positions behind would resurrect the old place the next time the
+	// in-app reader touched the book.
+	ClearUserPositions(userID, bookID string) error
 }
 
 // Options are the handler's dependencies.
@@ -156,6 +187,10 @@ type Options struct {
 	Identity IdentityStore
 	Chapters ChapterStore
 	Progress ProgressStore
+	// Bookmarks gates the bookmark CRUD routes. Nil means they are not registered
+	// at all rather than registered and answering 500 — a client that gets a 404
+	// hides the feature, while one that gets a 500 shows an error on every open.
+	Bookmarks BookmarkStore
 
 	// CoverRoot is config.AppConfig.RootDir — the library root that
 	// metadata.CoverPathForBook resolves covers under, and the base for the relative
@@ -178,6 +213,7 @@ type Handler struct {
 	identity    IdentityStore
 	chapters    ChapterStore
 	progress    ProgressStore
+	bookmarks   BookmarkStore
 	coverRoot   string
 	libraryName string
 
@@ -234,6 +270,7 @@ func New(o Options) (*Handler, error) {
 		identity:    o.Identity,
 		chapters:    o.Chapters,
 		progress:    o.Progress,
+		bookmarks:   o.Bookmarks,
 		coverRoot:   o.CoverRoot,
 		libraryName: name,
 		now:         time.Now,
@@ -341,7 +378,42 @@ func (h *Handler) Register(r gin.IRouter) {
 	// UUID, unguessable and scoped to one book for one user, and it stops working
 	// when the session expires.
 	r.GET("/public/session/:id/track/:index", h.PublicSessionTrack)
+
+	// ── Phase 6: progress mutation ──────────────────────────────────────────
+	//
+	// Registered after the browse block because every one of them resolves a
+	// client-visible libraryItemId through h.identity.
+	//
+	// gin routes the static "batch" sibling alongside the ":id" wildcard at the
+	// same depth correctly on v1.12.0 (verified: no panic, no mis-dispatch), so
+	// batch is a real route rather than a branch inside the :id handler.
+	r.GET("/api/me/progress", auth, h.MediaProgressList)
+	r.GET("/api/me/progress/:id", auth, h.MediaProgressGet)
+	r.PATCH("/api/me/progress/:id", auth, h.MediaProgressPatch)
+	r.PATCH("/api/me/progress/batch/update", auth, h.MediaProgressBatchUpdate)
+	r.DELETE("/api/me/progress/:id", auth, h.MediaProgressDelete)
+	// Real ABS 2.36.0 has NO such route — it answers "Cannot POST" — and the
+	// mechanism is really a hideFromContinueListening PATCH (verified against the
+	// oracle, 2026-08-02). It is registered anyway because a client calls it and
+	// §1.8.6/spec:318 records that it must answer a NON-EMPTY body; a 404 is what
+	// the owner reported as "remove from continue listening does nothing".
+	r.POST("/api/me/item/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
+
+	if h.bookmarks == nil {
+		return
+	}
+	// ── Phase 6: bookmarks CRUD ─────────────────────────────────────────────
+	r.GET("/api/me/bookmarks/:id", auth, h.ListItemBookmarks)
+	r.POST("/api/me/item/:id/bookmark", auth, h.CreateBookmark)
+	r.PATCH("/api/me/item/:id/bookmark", auth, h.UpdateBookmark)
+	// The TIME VALUE is the path parameter — real ABS keys a bookmark by
+	// (libraryItemId, time), not by an opaque bookmark id.
+	r.DELETE("/api/me/item/:id/bookmark/:time", auth, h.DeleteBookmark)
 }
+
+// HasBookmarkSurface reports whether the Phase 6 bookmark CRUD routes were
+// registered.
+func (h *Handler) HasBookmarkSurface() bool { return h.bookmarks != nil }
 
 // ── shared helpers ──────────────────────────────────────────────────────────
 

--- a/internal/server/handlers/abs/item.go
+++ b/internal/server/handlers/abs/item.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/item.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 9c8a2f60-1d75-4b38-a0e4-7f21b5c96d13
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs
 
@@ -112,6 +112,10 @@ func (h *Handler) mediaProgress(userID string, v *itemView) *mediaProgressDTO {
 		Duration:      v.DurationSec,
 		EbookProgress: 0,
 		FinishedAt:    finishedAt,
+		// Must agree with userdata.go's progressRow for the same book: a client
+		// that sees the book hidden on /api/me and visible on /api/items shows it
+		// in Continue Listening anyway, which is the bug the flag exists to fix.
+		HideFromContinueListening: state != nil && state.HideFromContinueListening,
 		// The id is derived from (user, item) rather than random so a client that
 		// stores it keeps matching the same row across restarts.
 		ID:            userID + "-" + v.SyncID,

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/library_fake_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d4a67f2-0c85-4f39-9b6e-3a71c5d0e824
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs_test
 
@@ -391,6 +391,16 @@ func (f *fakeLibrary) SetUserPosition(userID, bookID, segmentID string, pos floa
 		UserID: userID, BookID: bookID, SegmentID: segmentID,
 		PositionSeconds: pos, UpdatedAt: time.Now(),
 	}
+	return nil
+}
+
+// ClearUserPositions backs DELETE /api/me/progress/:id. It drops the (user, book)
+// entry entirely rather than zeroing it, matching PebbleStore's batch delete —
+// GetUserPosition must answer nil afterwards, not a row reading 0.
+func (f *fakeLibrary) ClearUserPositions(userID, bookID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.positions, userID+"|"+bookID)
 	return nil
 }
 

--- a/internal/server/handlers/abs/play.go
+++ b/internal/server/handlers/abs/play.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/play.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b06d4a13-5f28-4c71-9e0a-38f2c7d915e6
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs
 
@@ -468,15 +468,41 @@ func (h *Handler) persistProgress(s *playSession, position float64, clientDurati
 		}
 	}
 	_, timeListening, _ := s.snapshot()
-	_ = h.progress.SetUserBookState(&database.UserBookState{
-		UserID:               s.UserID,
-		BookID:               s.BookID,
-		Status:               status,
-		LastActivityAt:       now,
-		LastSegmentID:        absProgressSegmentID,
-		TotalListenedSeconds: timeListening,
-		ProgressPct:          pct,
+	// READ-MODIFY-WRITE, not a fresh literal. A fresh literal silently resets every
+	// field this path does not set, and two of them are USER INTENT rather than
+	// derived state: HideFromContinueListening (the user removed this book from
+	// Continue Listening) and StatusManual (the user pinned a read status by hand).
+	// A sync fires roughly every 20 s of listening, so constructing a literal here
+	// un-hides and un-pins within seconds of the user's choice.
+	_ = h.updateUserBookState(s.UserID, s.BookID, func(state *database.UserBookState) {
+		state.Status = status
+		state.LastActivityAt = now
+		state.LastSegmentID = absProgressSegmentID
+		state.TotalListenedSeconds = timeListening
+		state.ProgressPct = pct
 	})
+}
+
+// updateUserBookState read-modify-writes the (user, book) state row.
+//
+// Every ABS write path goes through here rather than through SetUserBookState
+// directly, so a caller that only means to move the playhead cannot drop a field it
+// never thought about. mutate receives either the stored row or a zero-valued one
+// with the keys already set, so it never has to branch on existence.
+func (h *Handler) updateUserBookState(userID, bookID string, mutate func(*database.UserBookState)) error {
+	if h.progress == nil {
+		return nil
+	}
+	state, err := h.progress.GetUserBookState(userID, bookID)
+	if err != nil || state == nil {
+		// A read error is treated as "no row yet" rather than propagated: losing the
+		// previous StatusManual/hide flag is bad, but refusing to record the user's
+		// new position is worse, and this path has already promised the client 200.
+		state = &database.UserBookState{UserID: userID, BookID: bookID}
+	}
+	mutate(state)
+	state.UserID, state.BookID = userID, bookID
+	return h.progress.SetUserBookState(state)
 }
 
 // respondPlainOK answers exactly what real ABS answers on /sync and /close: HTTP 200

--- a/internal/server/handlers/abs/progress.go
+++ b/internal/server/handlers/abs/progress.go
@@ -1,0 +1,482 @@
+// file: internal/server/handlers/abs/progress.go
+// version: 1.0.0
+// guid: 4f0a7d21-9c63-4b58-8e17-52d9a0b3fc84
+// last-edited: 2026-08-02
+
+package abs
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+	"github.com/gin-gonic/gin"
+)
+
+// Phase 6 — the progress WRITE half.
+//
+// Every shape here was captured from a real Audiobookshelf 2.36.0 server on
+// 2026-08-02 (testdata/abs-fixtures/), not inferred from the published docs, and two
+// of the captures contradicted this project's own spec:
+//
+//  1. DELETE /api/me/progress/:id is keyed by the mediaProgress ROW id, not by the
+//     libraryItemId — deleting by item id answers 404 on real ABS.
+//  2. POST /api/me/item/:id/remove-from-continue-listening DOES NOT EXIST on ABS
+//     2.36.0 (it answers "Cannot POST"). The real mechanism is the
+//     hideFromContinueListening field on PATCH /api/me/progress/:id.
+//
+// Both are handled below, and both are handled as a SUPERSET: we accept the id in
+// either form and we serve the POST alias as well as the PATCH field, because §1.8
+// makes "where the clients disagree, implement the superset" the standing rule and
+// because a 404 here is precisely the symptom the owner reported.
+
+// maxBatchProgressUpdates bounds PATCH /api/me/progress/batch/update.
+//
+// A client batch is a handful of books — this is not a whole-library collection, so
+// the loop is deliberately sequential (CLAUDE.md's worker-pool rule targets
+// library-scale work; parallelising a 5-element list would only add a race over the
+// same (user, book) rows). The cap exists so a malformed or hostile body cannot turn
+// one request into an unbounded write storm.
+const maxBatchProgressUpdates = 1000
+
+// progressPatchRequest is the PATCH /api/me/progress/:id body.
+//
+// Every field is a POINTER because absence and zero mean different things on this
+// endpoint: `{"hideFromContinueListening": true}` alone must not be read as
+// "currentTime: 0", which would rewind the listener to the start of the book. That
+// is the exact shape the remove-from-continue-listening path sends.
+//
+// `progress` is accepted and IGNORED: it is a derived 0.0-1.0 fraction of
+// currentTime/duration, and honouring a client's copy of it would let a stale
+// fraction contradict the position we just stored. We recompute it on read.
+type progressPatchRequest struct {
+	CurrentTime               *float64 `json:"currentTime"`
+	Duration                  *float64 `json:"duration"`
+	IsFinished                *bool    `json:"isFinished"`
+	HideFromContinueListening *bool    `json:"hideFromContinueListening"`
+	Progress                  *float64 `json:"progress"`
+	// LibraryItemID is only read on the batch path, where the id is in the body
+	// instead of the URL.
+	LibraryItemID string `json:"libraryItemId"`
+}
+
+// ── GET /api/me/progress ────────────────────────────────────────────────────
+
+// MediaProgressList handles GET /api/me/progress.
+//
+// 🔴 SAME DATA-LOSS RULE AS /api/me (§1.8.1), and easy to miss because this body is
+// a bare wrapper rather than a user object: AudioBooth's syncFromAPI DELETES every
+// local progress row absent from a server-supplied mediaProgress list. So this
+// endpoint returns the COMPLETE list or a 5xx — never a 200 with a short list, never
+// paginated. It shares userData.MediaProgress with /api/me rather than enumerating
+// again, so the two can never disagree about what "complete" means.
+func (h *Handler) MediaProgressList(c *gin.Context) {
+	user, ok := servermiddleware.CurrentUser(c)
+	if !ok || user == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	rows, _, err := h.userPayload(user.ID)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "could not load user data")
+		return
+	}
+	respondJSON(c, http.StatusOK, gin.H{"mediaProgress": rows})
+}
+
+// ── GET /api/me/progress/:id ────────────────────────────────────────────────
+
+// MediaProgressGet handles GET /api/me/progress/:id.
+//
+// This is the call AudioBooth made on 2026-08-02 that 404'd and stalled its
+// reset-progress flow. Real ABS answers a BARE mediaProgress object (not wrapped)
+// when a row exists and a plain-text 404 when it does not.
+func (h *Handler) MediaProgressGet(c *gin.Context) {
+	user, bookID, ok := h.resolveProgressTarget(c)
+	if !ok {
+		return
+	}
+	if h.userData == nil {
+		respondError(c, http.StatusInternalServerError, "progress is unavailable")
+		return
+	}
+	row, found, err := h.userData.MediaProgressFor(user.ID, bookID)
+	if err != nil {
+		// 5xx, never a 404: a 404 we are not sure about reads to the client as
+		// "you have no progress in this book", and acting on that costs a place.
+		respondError(c, http.StatusInternalServerError, "could not load progress")
+		return
+	}
+	if !found {
+		respondNotFoundPlain(c)
+		return
+	}
+	respondJSON(c, http.StatusOK, row)
+}
+
+// ── PATCH /api/me/progress/:id ──────────────────────────────────────────────
+
+// MediaProgressPatch handles PATCH /api/me/progress/:id.
+//
+// Real ABS answers `200 text/plain "OK"` here, so this returns respondPlainOK rather
+// than a JSON body — matched to the oracle capture rather than "improved", because
+// neither client reads the body and deviating buys nothing.
+func (h *Handler) MediaProgressPatch(c *gin.Context) {
+	user, bookID, ok := h.resolveProgressTarget(c)
+	if !ok {
+		return
+	}
+	var req progressPatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// An unparseable body on a write is a 400, unlike on /sync: /sync must never
+		// 4xx because a 4xx wedges an offline replay queue permanently (§1.7.3 #2),
+		// but this endpoint is interactive and a silent 200 would tell the user their
+		// change was saved when nothing was written.
+		respondError(c, http.StatusBadRequest, "invalid progress body")
+		return
+	}
+	if err := h.applyProgressUpdate(user.ID, bookID, req); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not save progress")
+		return
+	}
+	respondPlainOK(c)
+}
+
+// ── PATCH /api/me/progress/batch/update ─────────────────────────────────────
+
+// MediaProgressBatchUpdate handles PATCH /api/me/progress/batch/update.
+//
+// The body is a BARE ARRAY (verified against the oracle), each element carrying its
+// own libraryItemId. Elements that name an unknown item are SKIPPED rather than
+// failing the request: a batch is a best-effort catch-up from a client that may hold
+// ids for books since merged or removed, and rejecting the whole array would strand
+// every other element in it.
+func (h *Handler) MediaProgressBatchUpdate(c *gin.Context) {
+	user, ok := servermiddleware.CurrentUser(c)
+	if !ok || user == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	var batch []progressPatchRequest
+	if err := c.ShouldBindJSON(&batch); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid progress batch body")
+		return
+	}
+	if len(batch) > maxBatchProgressUpdates {
+		respondError(c, http.StatusBadRequest, "progress batch too large")
+		return
+	}
+
+	for _, item := range batch {
+		bookID, _, ok := h.resolveBookID(user.ID, item.LibraryItemID)
+		if !ok {
+			continue
+		}
+		if err := h.applyProgressUpdate(user.ID, bookID, item); err != nil {
+			respondError(c, http.StatusInternalServerError, "could not save progress")
+			return
+		}
+	}
+	respondPlainOK(c)
+}
+
+// ── DELETE /api/me/progress/:id ─────────────────────────────────────────────
+
+// MediaProgressDelete handles DELETE /api/me/progress/:id — "reset progress".
+//
+// It clears the stored positions AND resets the derived book state, because a
+// position row without its state leaves the book reading "finished" at 0:00. The
+// user's hide-from-continue-listening choice is deliberately cleared too: resetting a
+// book to unstarted and leaving it hidden would make it invisible everywhere with no
+// way to get it back from the client UI.
+func (h *Handler) MediaProgressDelete(c *gin.Context) {
+	user, bookID, ok := h.resolveProgressTarget(c)
+	if !ok {
+		return
+	}
+	if h.progress == nil {
+		respondError(c, http.StatusInternalServerError, "progress is unavailable")
+		return
+	}
+
+	// 404 when there was nothing to reset, matching real ABS. Checked BEFORE the
+	// delete so the answer describes what actually happened.
+	pos, err := h.progress.GetUserPosition(user.ID, bookID)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "could not load progress")
+		return
+	}
+	if pos == nil {
+		respondNotFoundPlain(c)
+		return
+	}
+
+	if err := h.progress.ClearUserPositions(user.ID, bookID); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not reset progress")
+		return
+	}
+	if err := h.updateUserBookState(user.ID, bookID, func(state *database.UserBookState) {
+		state.Status = database.UserBookStatusUnstarted
+		state.StatusManual = false
+		state.ProgressPct = 0
+		state.TotalListenedSeconds = 0
+		state.LastSegmentID = ""
+		state.HideFromContinueListening = false
+		state.LastActivityAt = h.now()
+	}); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not reset progress")
+		return
+	}
+	respondPlainOK(c)
+}
+
+// ── POST /api/me/item/:id/remove-from-continue-listening ────────────────────
+
+// RemoveFromContinueListening handles the POST alias for hiding a book from Continue
+// Listening.
+//
+// Real ABS 2.36.0 has no such route. It is served here because a client calls it and
+// took a 404 in production, and because the operation is unambiguous: it is exactly
+// PATCH /api/me/progress/:id with {"hideFromContinueListening": true}, which the
+// oracle confirmed is the actual mechanism.
+//
+// 🔴 The body must be NON-EMPTY (§1.8.6 / spec:318) — an empty 200 is fatal to these
+// decoders — so it answers `{}` rather than a bare 200 or a plain-text "OK".
+func (h *Handler) RemoveFromContinueListening(c *gin.Context) {
+	user, bookID, ok := h.resolveProgressTarget(c)
+	if !ok {
+		return
+	}
+	if h.progress == nil {
+		respondError(c, http.StatusInternalServerError, "progress is unavailable")
+		return
+	}
+	if err := h.updateUserBookState(user.ID, bookID, func(state *database.UserBookState) {
+		state.HideFromContinueListening = true
+	}); err != nil {
+		respondError(c, http.StatusInternalServerError, "could not update progress")
+		return
+	}
+	respondJSON(c, http.StatusOK, gin.H{})
+}
+
+// ── shared write path ───────────────────────────────────────────────────────
+
+// applyProgressUpdate is the single merge+persist path behind PATCH and batch.
+//
+// It applies §5's conflict policy through progress.MergeExplicit — the PATCH variant,
+// where the client DOES state isFinished and the server must honour rather than
+// contradict it, including re-opening a finished book. The alternative (last write
+// wins) is what silently rewinds a listener when a stale device wakes up.
+//
+// A body carrying ONLY hideFromContinueListening skips the merge entirely: with no
+// currentTime there is no position to reconcile, and running it through the merge
+// would compare the client's absent position (0) against the stored one and either
+// reject the whole update or, worse, write a 0.
+func (h *Handler) applyProgressUpdate(userID, bookID string, req progressPatchRequest) error {
+	if h.progress == nil {
+		return errNoProgressStore
+	}
+
+	if req.HideFromContinueListening != nil {
+		hide := *req.HideFromContinueListening
+		if err := h.updateUserBookState(userID, bookID, func(state *database.UserBookState) {
+			state.HideFromContinueListening = hide
+		}); err != nil {
+			return err
+		}
+	}
+	if req.CurrentTime == nil && req.IsFinished == nil {
+		// Nothing position-related to do. Not an error: a hide-only PATCH is a
+		// legitimate, complete request.
+		return nil
+	}
+
+	stored := progress.Progress{}
+	if pos, err := h.progress.GetUserPosition(userID, bookID); err == nil && pos != nil {
+		stored.CurrentTime = pos.PositionSeconds
+		stored.UpdatedAtMs = msEpoch(pos.UpdatedAt)
+	}
+	state, _ := h.progress.GetUserBookState(userID, bookID)
+	if state != nil {
+		stored.IsFinished = state.Status == database.UserBookStatusFinished
+		if ms := msEpoch(state.LastActivityAt); ms > stored.UpdatedAtMs {
+			stored.UpdatedAtMs = ms
+		}
+	}
+	stored.Duration = h.durationForBook(bookID, req.Duration)
+
+	now := h.now().UnixMilli()
+	incoming := progress.Progress{
+		CurrentTime: stored.CurrentTime,
+		Duration:    stored.Duration,
+		IsFinished:  stored.IsFinished,
+		// The client does not send a timestamp on this endpoint, so the write is
+		// stamped server-side and must be guaranteed to BEAT the client's own
+		// tie-break: AudioBooth truncates both sides to whole seconds and compares
+		// with strict >, so a same-second write is silently discarded (§1.8.7).
+		UpdatedAtMs: progress.NextServerTimestampMs(stored.UpdatedAtMs, now),
+	}
+	if req.CurrentTime != nil && *req.CurrentTime >= 0 {
+		incoming.CurrentTime = *req.CurrentTime
+	}
+	if req.IsFinished != nil {
+		incoming.IsFinished = *req.IsFinished
+	}
+
+	merged, accepted := progress.MergeExplicit(stored, incoming)
+	if !accepted {
+		// The stored record already wins. Reporting success is correct: the client's
+		// intent ("this book is at position X") is satisfied by a server value that
+		// is at or ahead of X.
+		return nil
+	}
+
+	if err := h.progress.SetUserPosition(userID, bookID, absProgressSegmentID, merged.CurrentTime); err != nil {
+		return err
+	}
+	status := database.UserBookStatusInProgress
+	switch {
+	case merged.IsFinished:
+		status = database.UserBookStatusFinished
+	case merged.CurrentTime <= 0:
+		status = database.UserBookStatusUnstarted
+	}
+	pct := 0
+	if merged.Duration > 0 {
+		pct = int(merged.CurrentTime / merged.Duration * 100)
+		if pct > 100 {
+			pct = 100
+		}
+	}
+	return h.updateUserBookState(userID, bookID, func(state *database.UserBookState) {
+		state.Status = status
+		state.ProgressPct = pct
+		state.LastSegmentID = absProgressSegmentID
+		state.LastActivityAt = h.now()
+	})
+}
+
+// durationForBook reproduces §5b's ONE-authoritative-duration rule: the sum of the
+// per-file durations, with Book.Duration used only for a book that has no file rows.
+// It matches userdata.go's durationFor and the mapper's loadOneItemView exactly —
+// mixing sources is what leaves a fully-listened book stuck at 99% forever.
+//
+// A client-supplied duration is a last-resort fallback only, never a preference.
+func (h *Handler) durationForBook(bookID string, clientDuration *float64) float64 {
+	if h.library != nil {
+		if files, err := h.library.GetBookFiles(bookID); err == nil && len(files) > 0 {
+			total := 0.0
+			for i := range files {
+				total += float64(files[i].Duration)
+			}
+			if total > 0 {
+				return total
+			}
+		}
+		if book, err := h.library.GetBookByID(bookID); err == nil && book != nil && book.Duration != nil {
+			return float64(*book.Duration)
+		}
+	}
+	if clientDuration != nil && *clientDuration > 0 {
+		return *clientDuration
+	}
+	return 0
+}
+
+// ── id resolution ───────────────────────────────────────────────────────────
+
+// resolveProgressTarget authenticates the caller and turns the `:id` path parameter
+// into an internal book id, writing the error response itself when it cannot.
+//
+// 🔴 THE `:id` ARRIVES IN TWO DIFFERENT FORMS and both are accepted:
+//
+//   - the libraryItemId (the 36-char sync UUID) — what a client holds from a browse
+//     response, and what our own /api/me/progress/:id GET is addressed with;
+//   - the mediaProgress ROW id, which our read half renders as "<userID>-<syncID>"
+//     (userdata.go / item.go). Real ABS keys DELETE /api/me/progress/:id by the ROW
+//     id — verified against the oracle 2026-08-02, where deleting by libraryItemId
+//     answers 404 — so a client that read the list and handed the row id back must
+//     be understood here or reset-progress silently does nothing.
+//
+// The row-id form is stripped by matching the AUTHENTICATED caller's own user id as
+// a prefix rather than by splitting on a separator. That is not defensiveness for its
+// own sake: it makes the parse independent of whether a user id can ever contain the
+// separator, and it means one user can never address another user's row by
+// constructing an id — the prefix that gets stripped is always their own.
+func (h *Handler) resolveProgressTarget(c *gin.Context) (*database.User, string, bool) {
+	user, _, bookID, ok := h.resolveTarget(c)
+	return user, bookID, ok
+}
+
+// resolveTarget is resolveProgressTarget plus the canonical syncID, which the
+// bookmark handlers need because the bookmark keyspace is keyed by the
+// CLIENT-VISIBLE libraryItemId rather than by the internal book id.
+func (h *Handler) resolveTarget(c *gin.Context) (user *database.User, syncID, bookID string, ok bool) {
+	u, found := servermiddleware.CurrentUser(c)
+	if !found || u == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return nil, "", "", false
+	}
+	bookID, syncID, found = h.resolveBookID(u.ID, c.Param("id"))
+	if !found {
+		respondNotFoundPlain(c)
+		return nil, "", "", false
+	}
+	return u, syncID, bookID, true
+}
+
+// resolveBookID maps a client-visible id to an internal Book id AND the canonical
+// syncID, accepting both the libraryItemId and the "<userID>-<syncID>" mediaProgress
+// row id. See resolveProgressTarget for why both forms exist.
+//
+// The syncID it returns is the CANONICAL one (ResolveSyncItem follows merge
+// redirects, spec §4.2), not the one the client sent. Callers that key storage by it
+// therefore converge on one id per book even when a client is still holding the
+// syncID of a book that has since lost a dedup merge.
+func (h *Handler) resolveBookID(userID, raw string) (bookID, syncID string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || h.identity == nil {
+		return "", "", false
+	}
+	candidates := []string{raw}
+	if prefix := userID + "-"; userID != "" && strings.HasPrefix(raw, prefix) {
+		// Tried FIRST: the row-id form is the more specific reading, and a bare
+		// syncID can never carry this prefix.
+		candidates = []string{strings.TrimPrefix(raw, prefix), raw}
+	}
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		item, err := h.identity.ResolveSyncItem(candidate)
+		if err == nil && item != nil && item.CurrentBookID != "" {
+			id := item.SyncID
+			if id == "" {
+				id = candidate
+			}
+			return item.CurrentBookID, id, true
+		}
+	}
+	return "", "", false
+}
+
+// errNoProgressStore is returned by the shared write path when the server booted
+// without a listening-progress store. Unreachable in production (wireABSRoutes
+// asserts the capability), but an explicit error beats a silent no-op that would
+// report a saved position the server never wrote.
+var errNoProgressStore = errors.New("abs: no listening-progress store is wired")
+
+// respondNotFoundPlain answers exactly what real ABS answers for a missing progress
+// row or bookmark: 404 with the plain-text body "Not Found".
+//
+// Plain text rather than JSON is matched to the oracle. Neither target client parses
+// a non-200 body, and the body is non-empty either way, so following the captured
+// shape costs nothing and removes one more place our surface could differ.
+func respondNotFoundPlain(c *gin.Context) {
+	c.String(http.StatusNotFound, "Not Found")
+	c.Abort()
+}

--- a/internal/server/handlers/abs/progress_write_test.go
+++ b/internal/server/handlers/abs/progress_write_test.go
@@ -1,0 +1,787 @@
+// file: internal/server/handlers/abs/progress_write_test.go
+// version: 1.0.0
+// guid: 2b7f4e91-8a05-4c63-b1d8-70e396a5cf42
+// last-edited: 2026-08-02
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	abshandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs"
+	"github.com/falkcorp/audiobook-organizer/internal/syncapi/progress"
+)
+
+// Phase 6 write half. These tests run against the REAL UserDataProvider wired over
+// the in-memory library, not against fakeUserData, because the property under test is
+// that a write is visible to the very next read in the exact shape the client
+// compares against. A fake provider would pass while the two disagreed.
+
+// ── fake capabilities the real provider needs ───────────────────────────────
+
+// ListUserPositionsSince backs MediaProgress's single user-keyed scan.
+func (f *fakeLibrary) ListUserPositionsSince(userID string, since time.Time) ([]database.UserPosition, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := []database.UserPosition{}
+	for _, pos := range f.positions {
+		if pos == nil || pos.UserID != userID || !pos.UpdatedAt.After(since) {
+			continue
+		}
+		out = append(out, *pos)
+	}
+	return out, nil
+}
+
+// GetSyncIDForBook is the read half of the sync-identity slice.
+func (f *fakeLibrary) GetSyncIDForBook(bookID string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id, ok := f.syncIDs[bookID]
+	return id, ok, nil
+}
+
+// fakeBookmarks is an in-memory BookmarkStore keyed exactly like the Pebble one:
+// (user, item, canonical time). Keying by the canonical time rather than the raw
+// float is the whole point — "100" and "100.0" must address one row.
+type fakeBookmarks struct {
+	rows map[string]progress.Bookmark
+	err  error
+}
+
+func newFakeBookmarks() *fakeBookmarks {
+	return &fakeBookmarks{rows: map[string]progress.Bookmark{}}
+}
+
+func (f *fakeBookmarks) key(userID, itemID string, t float64) string {
+	return userID + "|" + itemID + "|" + progress.CanonicalTimeKey(t)
+}
+
+func (f *fakeBookmarks) CreateBookmark(b progress.Bookmark) error {
+	if f.err != nil {
+		return f.err
+	}
+	k := f.key(b.UserID, b.ItemID, b.TimeSec)
+	// Upsert preserving CreatedAt, matching pebble_store_bookmarks.go.
+	if prev, ok := f.rows[k]; ok {
+		b.CreatedAt = prev.CreatedAt
+	} else {
+		b.CreatedAt = time.Now().UnixMilli()
+	}
+	b.UpdatedAt = time.Now().UnixMilli()
+	f.rows[k] = b
+	return nil
+}
+
+func (f *fakeBookmarks) ListBookmarks(userID, itemID string) ([]progress.Bookmark, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := []progress.Bookmark{}
+	for _, b := range f.rows {
+		if b.UserID == userID && b.ItemID == itemID {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeBookmarks) ListBookmarksForUser(userID string) ([]progress.Bookmark, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := []progress.Bookmark{}
+	for _, b := range f.rows {
+		if b.UserID == userID {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeBookmarks) UpdateBookmarkTitle(userID, itemID string, timeSec float64, title string) error {
+	if f.err != nil {
+		return f.err
+	}
+	k := f.key(userID, itemID, timeSec)
+	b, ok := f.rows[k]
+	if !ok {
+		return errNoSuchBookmark
+	}
+	b.Title = title
+	f.rows[k] = b
+	return nil
+}
+
+func (f *fakeBookmarks) DeleteBookmark(userID, itemID string, timeSec float64) error {
+	if f.err != nil {
+		return f.err
+	}
+	delete(f.rows, f.key(userID, itemID, timeSec))
+	return nil
+}
+
+var errNoSuchBookmark = errString("no such bookmark")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// ── harness ─────────────────────────────────────────────────────────────────
+
+type writeHarness struct {
+	*harness
+	seed      *oracleSeed
+	bookmarks *fakeBookmarks
+	token     string
+	userID    string
+	syncID    string // the single-file book
+	bookID    string
+}
+
+// newWriteHarness wires the REAL provider over the seeded library.
+func newWriteHarness(t *testing.T) *writeHarness {
+	t.Helper()
+	seed := seedOracleLibrary(t)
+	bm := newFakeBookmarks()
+	provider, err := abshandler.NewUserData(abshandler.UserDataOptions{
+		Progress: seed.lib, Bookmarks: bm, Identity: seed.lib, Library: seed.lib,
+	})
+	if err != nil {
+		t.Fatalf("NewUserData: %v", err)
+	}
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(provider),
+		func(o *abshandler.Options) { o.Bookmarks = bm })
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+
+	syncID, err := seed.lib.MintOrGetSyncID(seed.singleID)
+	if err != nil {
+		t.Fatalf("MintOrGetSyncID: %v", err)
+	}
+	return &writeHarness{
+		harness: h, seed: seed, bookmarks: bm, token: tok,
+		userID: "u1", syncID: syncID, bookID: seed.singleID,
+	}
+}
+
+func (w *writeHarness) req(t *testing.T, method, path string, body any) (int, map[string]any, string) {
+	t.Helper()
+	rec, decoded := w.do(t, request{method: method, path: path, body: body, headers: bearer(w.token)})
+	return rec.Code, decoded, rec.Body.String()
+}
+
+// rowID is the mediaProgress row id our read half emits: "<userID>-<syncID>".
+func (w *writeHarness) rowID() string { return w.userID + "-" + w.syncID }
+
+func (w *writeHarness) patch(t *testing.T, body any) {
+	t.Helper()
+	code, _, raw := w.req(t, http.MethodPatch, "/api/me/progress/"+w.syncID, body)
+	if code != http.StatusOK {
+		t.Fatalf("PATCH progress = %d %s", code, raw)
+	}
+}
+
+func (w *writeHarness) getRow(t *testing.T) map[string]any {
+	t.Helper()
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/progress/"+w.syncID, nil)
+	if code != http.StatusOK {
+		t.Fatalf("GET progress = %d %s", code, raw)
+	}
+	return body
+}
+
+func num(t *testing.T, m map[string]any, key string) float64 {
+	t.Helper()
+	v, ok := m[key].(float64)
+	if !ok {
+		t.Fatalf("%s must be a number, got %#v", key, m[key])
+	}
+	return v
+}
+
+// ── GET /api/me/progress — §1.8.1 completeness ──────────────────────────────
+
+// TestMediaProgressList_ReturnsEveryStoredRow pins §1.8.1 on the endpoint that is
+// easiest to overlook: the body is a bare wrapper, not a user object, but AudioBooth
+// DELETES every local progress row absent from it just the same.
+func TestMediaProgressList_ReturnsEveryStoredRow(t *testing.T) {
+	w := newWriteHarness(t)
+	if _, err := w.seed.lib.MintOrGetSyncID(w.seed.multiID); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	for _, id := range []string{w.seed.singleID, w.seed.multiID} {
+		if err := w.seed.lib.SetUserPosition("u1", id, "abs", 120); err != nil {
+			t.Fatalf("SetUserPosition: %v", err)
+		}
+	}
+
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/progress", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	rows, ok := body["mediaProgress"].([]any)
+	if !ok {
+		t.Fatalf("mediaProgress must be an array, got %#v", body["mediaProgress"])
+	}
+	if len(rows) != 2 {
+		t.Fatalf("mediaProgress has %d rows, want 2 — a short list makes the client DELETE the missing books", len(rows))
+	}
+}
+
+// TestMediaProgressList_ProviderErrorIs5xxNotEmptyList is the data-loss guard: a
+// read failure must never be reported as "you have no progress", because the client
+// acts on that by deleting its own copy.
+func TestMediaProgressList_ProviderErrorIs5xxNotEmptyList(t *testing.T) {
+	seed := seedOracleLibrary(t)
+	// The provider must be healthy for /login (which carries the same payload) and
+	// is broken only afterwards, so the failure under test is the read, not the auth.
+	broken := &fakeUserData{}
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(broken))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+	broken.err = errString("store down")
+
+	rec, body := h.do(t, request{method: http.MethodGet, path: "/api/me/progress", headers: bearer(tok)})
+	if rec.Code < 500 {
+		t.Fatalf("got %d, want 5xx — a 200 with an empty list destroys the user's positions", rec.Code)
+	}
+	if rows, present := body["mediaProgress"]; present {
+		t.Fatalf("error response must not carry a mediaProgress array, got %#v", rows)
+	}
+}
+
+// ── GET /api/me/progress/:id ────────────────────────────────────────────────
+
+// TestMediaProgressGet_AcceptsBothIDForms is the oracle finding of 2026-08-02:
+// real ABS keys this route by the mediaProgress ROW id, while a client that came
+// from a browse response holds the libraryItemId. Both must resolve, or
+// reset-progress silently does nothing for whichever form the client happens to use.
+func TestMediaProgressGet_AcceptsBothIDForms(t *testing.T) {
+	w := newWriteHarness(t)
+	if err := w.seed.lib.SetUserPosition("u1", w.bookID, "abs", 42); err != nil {
+		t.Fatalf("SetUserPosition: %v", err)
+	}
+
+	for name, id := range map[string]string{
+		"libraryItemId":   w.syncID,
+		"mediaProgressID": w.rowID(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			code, body, raw := w.req(t, http.MethodGet, "/api/me/progress/"+id, nil)
+			if code != http.StatusOK {
+				t.Fatalf("got %d %s", code, raw)
+			}
+			// A BARE object, not wrapped — matched to the oracle capture.
+			if body["libraryItemId"] != w.syncID {
+				t.Fatalf("libraryItemId = %#v, want %q", body["libraryItemId"], w.syncID)
+			}
+			if got := num(t, body, "currentTime"); got != 42 {
+				t.Fatalf("currentTime = %v, want 42", got)
+			}
+		})
+	}
+}
+
+// TestMediaProgressGet_UnstartedBookIs404 matches real ABS, which 404s a book the
+// user has never opened.
+func TestMediaProgressGet_UnstartedBookIs404(t *testing.T) {
+	w := newWriteHarness(t)
+	code, _, _ := w.req(t, http.MethodGet, "/api/me/progress/"+w.syncID, nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", code)
+	}
+}
+
+// TestMediaProgressGet_ProviderErrorIs5xxNot404 keeps "we could not read it" and
+// "there is nothing there" distinguishable. A 404 the server is not sure about reads
+// to the client as "no progress", and acting on that costs the user their place.
+func TestMediaProgressGet_ProviderErrorIs5xxNot404(t *testing.T) {
+	seed := seedOracleLibrary(t)
+	syncID, err := seed.lib.MintOrGetSyncID(seed.singleID)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	broken := &fakeUserData{}
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(broken))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+	broken.err = errString("store down")
+
+	rec, _ := h.do(t, request{method: http.MethodGet, path: "/api/me/progress/" + syncID, headers: bearer(tok)})
+	if rec.Code < 500 {
+		t.Fatalf("got %d, want 5xx", rec.Code)
+	}
+}
+
+// ── PATCH /api/me/progress/:id ──────────────────────────────────────────────
+
+func TestMediaProgressPatch_StoresPositionAndIsReadableBack(t *testing.T) {
+	w := newWriteHarness(t)
+	code, _, raw := w.req(t, http.MethodPatch, "/api/me/progress/"+w.syncID,
+		map[string]any{"currentTime": 300.0, "duration": 9975.0, "isFinished": false})
+	if code != http.StatusOK {
+		t.Fatalf("PATCH = %d %s", code, raw)
+	}
+	// Real ABS answers plain-text "OK" here, not JSON.
+	if raw != "OK" {
+		t.Fatalf("PATCH body = %q, want %q (oracle shape)", raw, "OK")
+	}
+	if got := num(t, w.getRow(t), "currentTime"); got != 300 {
+		t.Fatalf("currentTime = %v, want 300", got)
+	}
+}
+
+// TestMediaProgressPatch_HonoursAnExplicitBackwardsSeek pins §5 rule 2, which is
+// deliberately NOT forward-only: "a genuinely newer update is honoured even when it
+// seeks backwards — only a STALE update is position-gated."
+//
+// This endpoint is the user dragging the scrubber, and refusing it would snap the
+// book forward again under their finger. The multi-device clobber §5 rule 3 guards
+// against is a different path — POST /api/session/:id/sync, which merges through
+// MergeIncoming and IS forward-only (see TestSessionSync_* and policy_test.go).
+//
+// The reason this endpoint can trust the write is that clients do not push a stale
+// position here: AudioBooth compares lastUpdate with strict > and ADOPTS the server's
+// value when the server is newer (§1.8.7), so it only ever PATCHes a position it
+// believes is the most recent one.
+func TestMediaProgressPatch_HonoursAnExplicitBackwardsSeek(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 5000.0})
+	w.patch(t, map[string]any{"currentTime": 10.0})
+
+	if got := num(t, w.getRow(t), "currentTime"); got != 10 {
+		t.Fatalf("currentTime = %v, want 10 — an explicit PATCH is a user seek and must apply", got)
+	}
+}
+
+// TestPlaySession_StartsFromTheServersTrueLatestPosition is where the multi-device
+// clobber is ACTUALLY prevented, and it is worth being precise about, because the
+// obvious guess is wrong.
+//
+// Neither PATCH /api/me/progress/:id nor POST /api/session/:id/sync carries a
+// client-supplied timestamp, so incoming is always "newer" and §5 rule 3's
+// forward-only branch never fires on either. That is deliberate rather than a hole:
+// both endpoints report a LIVE, present-tense user action, and refusing a backwards
+// position on them would make scrubbing backwards impossible — the book would snap
+// forward again under the user's finger.
+//
+// The stale device is stopped one step earlier instead. A device that was offline
+// opens a session first, and §1.8.7 has AudioBooth take max(local, session.currentTime)
+// while IGNORING timestamps — so as long as this endpoint reports the server's TRUE
+// latest position, the stale device is pulled forward and never has a behind position
+// to sync in the first place. That property is what this test pins.
+//
+// Forward-only merging still guards the one path with genuinely untrustworthy
+// timestamps, offline replay, via progress.MergeOfflineReplay (policy_test.go).
+func TestPlaySession_StartsFromTheServersTrueLatestPosition(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 5000.0})
+
+	code, play, raw := w.req(t, http.MethodPost, "/api/items/"+w.syncID+"/play", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("play = %d %s", code, raw)
+	}
+	if got := num(t, play, "currentTime"); got != 5000 {
+		t.Fatalf("session currentTime = %v, want 5000 — a 0 or a stale value here silently "+
+			"rewinds the listener to the start of the book (§1.8.7)", got)
+	}
+	if got := num(t, play, "startTime"); got != 5000 {
+		t.Fatalf("session startTime = %v, want 5000", got)
+	}
+}
+
+// 🔴 TestMediaProgressPatch_HideOnlyDoesNotRewindPosition is the trap a naive
+// implementation falls into: `{"hideFromContinueListening": true}` carries no
+// currentTime, and a non-pointer decode reads that absence as 0, storing a rewind to
+// the start of the book. This is the exact body the remove-from-continue-listening
+// path sends, so getting it wrong loses the position of every book the user hides.
+func TestMediaProgressPatch_HideOnlyDoesNotRewindPosition(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 4321.0})
+	w.patch(t, map[string]any{"hideFromContinueListening": true})
+
+	row := w.getRow(t)
+	if got := num(t, row, "currentTime"); got != 4321 {
+		t.Fatalf("currentTime = %v, want 4321 — a hide-only PATCH must not touch the position", got)
+	}
+	if row["hideFromContinueListening"] != true {
+		t.Fatalf("hideFromContinueListening = %#v, want true", row["hideFromContinueListening"])
+	}
+}
+
+// TestMediaProgressPatch_ReopeningFinishedBookResetsPosition covers §5 rule 4 /
+// MergeExplicit: ABS allows re-opening a finished book, and doing so starts it over.
+func TestMediaProgressPatch_ReopeningFinishedBookResetsPosition(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 9975.0, "isFinished": true})
+	if row := w.getRow(t); row["isFinished"] != true {
+		t.Fatalf("isFinished = %#v, want true", row["isFinished"])
+	}
+
+	w.patch(t, map[string]any{"isFinished": false})
+	row := w.getRow(t)
+	if row["isFinished"] != false {
+		t.Fatalf("isFinished = %#v, want false after re-open", row["isFinished"])
+	}
+	if got := num(t, row, "currentTime"); got != 0 {
+		t.Fatalf("currentTime = %v, want 0 after re-opening a finished book", got)
+	}
+}
+
+// TestMediaProgressPatch_FinishedAlwaysCarriesDuration pins §1.8.7's null-duration
+// trap: isFinished:true with a zero duration sets the CLIENT's currentTime to 0.
+func TestMediaProgressPatch_FinishedAlwaysCarriesDuration(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 9975.0, "isFinished": true})
+
+	row := w.getRow(t)
+	if row["isFinished"] == true && num(t, row, "duration") <= 0 {
+		t.Fatal("isFinished:true with a zero duration ZEROES the client's saved position")
+	}
+}
+
+// ── PATCH /api/me/progress/batch/update ─────────────────────────────────────
+
+// TestMediaProgressBatchUpdate_AppliesEveryElement also proves the route itself
+// resolves: gin has to route the static "batch" segment alongside the ":id" wildcard
+// at the same depth, and a mis-dispatch would land this body in the single-item
+// handler with id="batch".
+func TestMediaProgressBatchUpdate_AppliesEveryElement(t *testing.T) {
+	w := newWriteHarness(t)
+	multiSync, err := w.seed.lib.MintOrGetSyncID(w.seed.multiID)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	code, _, raw := w.req(t, http.MethodPatch, "/api/me/progress/batch/update", []map[string]any{
+		{"libraryItemId": w.syncID, "currentTime": 111.0},
+		{"libraryItemId": multiSync, "currentTime": 222.0},
+		{"libraryItemId": "00000000-0000-4000-8000-000000000000", "currentTime": 333.0},
+	})
+	if code != http.StatusOK {
+		t.Fatalf("batch = %d %s", code, raw)
+	}
+	if got := num(t, w.getRow(t), "currentTime"); got != 111 {
+		t.Fatalf("single-file currentTime = %v, want 111", got)
+	}
+	code, body, _ := w.req(t, http.MethodGet, "/api/me/progress/"+multiSync, nil)
+	if code != http.StatusOK {
+		t.Fatalf("multi GET = %d", code)
+	}
+	if got := num(t, body, "currentTime"); got != 222 {
+		t.Fatalf("multi-file currentTime = %v, want 222", got)
+	}
+}
+
+// ── DELETE /api/me/progress/:id ─────────────────────────────────────────────
+
+func TestMediaProgressDelete_ResetsProgress(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 4321.0})
+
+	// Addressed by the ROW id, which is what a client that read /api/me hands back.
+	code, _, raw := w.req(t, http.MethodDelete, "/api/me/progress/"+w.rowID(), nil)
+	if code != http.StatusOK {
+		t.Fatalf("DELETE = %d %s", code, raw)
+	}
+	if raw != "OK" {
+		t.Fatalf("DELETE body = %q, want %q", raw, "OK")
+	}
+	if code, _, _ := w.req(t, http.MethodGet, "/api/me/progress/"+w.syncID, nil); code != http.StatusNotFound {
+		t.Fatalf("GET after reset = %d, want 404", code)
+	}
+}
+
+func TestMediaProgressDelete_NothingToResetIs404(t *testing.T) {
+	w := newWriteHarness(t)
+	if code, _, _ := w.req(t, http.MethodDelete, "/api/me/progress/"+w.syncID, nil); code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", code)
+	}
+}
+
+// ── remove-from-continue-listening ──────────────────────────────────────────
+
+// TestRemoveFromContinueListening_HidesAndAnswersNonEmptyBody covers both halves of
+// the reported bug: the route existing at all, and §1.8.6/spec:318's requirement
+// that its body be NON-EMPTY (an empty 200 is fatal to these decoders).
+func TestRemoveFromContinueListening_HidesAndAnswersNonEmptyBody(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 600.0})
+
+	code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/remove-from-continue-listening", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	if raw == "" {
+		t.Fatal("empty 200 body — fatal for these decoders (§1.8.6)")
+	}
+	row := w.getRow(t)
+	if row["hideFromContinueListening"] != true {
+		t.Fatalf("hideFromContinueListening = %#v, want true", row["hideFromContinueListening"])
+	}
+	if got := num(t, row, "currentTime"); got != 600 {
+		t.Fatalf("currentTime = %v, want 600 — hiding must not discard the position", got)
+	}
+}
+
+// 🔴 TestSessionSync_DoesNotClearHideFlag is the regression test for the clobber the
+// new field would otherwise inherit: persistProgress used to construct a FRESH
+// UserBookState on every sync, resetting every field it did not set. A sync fires
+// roughly every 20 s of listening, so a literal there un-hides a book within seconds
+// of the user hiding it.
+func TestSessionSync_DoesNotClearHideFlag(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 600.0})
+	code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/remove-from-continue-listening", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("hide = %d %s", code, raw)
+	}
+
+	// Open a real play session and sync it, exactly as a client would.
+	code, play, raw := w.req(t, http.MethodPost, "/api/items/"+w.syncID+"/play", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("play = %d %s", code, raw)
+	}
+	sessionID, _ := play["id"].(string)
+	if sessionID == "" {
+		t.Fatalf("play session has no id: %#v", play)
+	}
+	code, _, raw = w.req(t, http.MethodPost, "/api/session/"+sessionID+"/sync",
+		map[string]any{"currentTime": 900.0, "timeListened": 300.0})
+	if code != http.StatusOK {
+		t.Fatalf("sync = %d %s", code, raw)
+	}
+
+	row := w.getRow(t)
+	if row["hideFromContinueListening"] != true {
+		t.Fatal("a playback sync cleared hideFromContinueListening — the user's choice must survive it")
+	}
+	if got := num(t, row, "currentTime"); got != 900 {
+		t.Fatalf("currentTime = %v, want 900 (the sync must still advance the position)", got)
+	}
+}
+
+// TestSessionSync_DoesNotClearStatusManual covers the same clobber for the flag that
+// was ALREADY being reset before this change: a hand-pinned read status was silently
+// un-pinned by the next sync.
+func TestSessionSync_DoesNotClearStatusManual(t *testing.T) {
+	w := newWriteHarness(t)
+	if err := w.seed.lib.SetUserBookState(&database.UserBookState{
+		UserID: "u1", BookID: w.bookID, Status: database.UserBookStatusFinished, StatusManual: true,
+	}); err != nil {
+		t.Fatalf("SetUserBookState: %v", err)
+	}
+
+	code, play, raw := w.req(t, http.MethodPost, "/api/items/"+w.syncID+"/play", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("play = %d %s", code, raw)
+	}
+	sessionID, _ := play["id"].(string)
+	if code, _, raw := w.req(t, http.MethodPost, "/api/session/"+sessionID+"/sync",
+		map[string]any{"currentTime": 120.0}); code != http.StatusOK {
+		t.Fatalf("sync = %d %s", code, raw)
+	}
+
+	state, err := w.seed.lib.GetUserBookState("u1", w.bookID)
+	if err != nil || state == nil {
+		t.Fatalf("GetUserBookState: %v / %#v", err, state)
+	}
+	if !state.StatusManual {
+		t.Fatal("a playback sync cleared StatusManual — a hand-pinned status must survive it")
+	}
+}
+
+// ── bookmarks ───────────────────────────────────────────────────────────────
+
+func TestBookmarks_CreateListUpdateDelete(t *testing.T) {
+	w := newWriteHarness(t)
+
+	code, created, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "a good bit"})
+	if code != http.StatusOK {
+		t.Fatalf("create = %d %s", code, raw)
+	}
+	if created["title"] != "a good bit" || created["libraryItemId"] != w.syncID {
+		t.Fatalf("created bookmark = %#v", created)
+	}
+
+	code, listed, raw := w.req(t, http.MethodGet, "/api/me/bookmarks/"+w.syncID, nil)
+	if code != http.StatusOK {
+		t.Fatalf("list = %d %s", code, raw)
+	}
+	rows, _ := listed["bookmarks"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("bookmarks = %d rows, want 1", len(rows))
+	}
+
+	code, updated, raw := w.req(t, http.MethodPatch, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "renamed"})
+	if code != http.StatusOK {
+		t.Fatalf("update = %d %s", code, raw)
+	}
+	if updated["title"] != "renamed" {
+		t.Fatalf("updated title = %#v, want %q", updated["title"], "renamed")
+	}
+
+	code, _, raw = w.req(t, http.MethodDelete, "/api/me/item/"+w.syncID+"/bookmark/100", nil)
+	if code != http.StatusOK {
+		t.Fatalf("delete = %d %s", code, raw)
+	}
+	if raw != "OK" {
+		t.Fatalf("delete body = %q, want %q", raw, "OK")
+	}
+	_, listed, _ = w.req(t, http.MethodGet, "/api/me/bookmarks/"+w.syncID, nil)
+	if rows, _ := listed["bookmarks"].([]any); len(rows) != 0 {
+		t.Fatalf("bookmarks = %d rows after delete, want 0", len(rows))
+	}
+}
+
+// TestBookmarks_IntAndFloatTimeAddressTheSameRow is the Int-vs-Double requirement
+// exercised through the HTTP layer rather than only at the storage layer: AudioBooth
+// sends `time` as an Int in the DELETE path segment and round-trips it as a Double in
+// bodies. If the two do not collide, a bookmark becomes undeletable.
+func TestBookmarks_IntAndFloatTimeAddressTheSameRow(t *testing.T) {
+	w := newWriteHarness(t)
+	if code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 12.0, "title": "twelve"}); code != http.StatusOK {
+		t.Fatalf("create = %d %s", code, raw)
+	}
+	// Deleted with the INTEGER path form.
+	if code, _, raw := w.req(t, http.MethodDelete, "/api/me/item/"+w.syncID+"/bookmark/12", nil); code != http.StatusOK {
+		t.Fatalf("delete by int path = %d %s — \"12\" must address the bookmark created at 12.0", code, raw)
+	}
+}
+
+func TestBookmarks_DeleteMissingIs404(t *testing.T) {
+	w := newWriteHarness(t)
+	if code, _, _ := w.req(t, http.MethodDelete, "/api/me/item/"+w.syncID+"/bookmark/999", nil); code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", code)
+	}
+}
+
+func TestBookmarks_UpdateMissingIs404(t *testing.T) {
+	w := newWriteHarness(t)
+	code, _, _ := w.req(t, http.MethodPatch, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 999, "title": "nope"})
+	if code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404 — update must not implicitly create a bookmark", code)
+	}
+}
+
+// TestBookmarks_ListErrorIs5xxNotEmptyList keeps "could not read" distinguishable
+// from "there are none", same discipline as the progress list.
+func TestBookmarks_ListErrorIs5xxNotEmptyList(t *testing.T) {
+	w := newWriteHarness(t)
+	w.bookmarks.err = errString("store down")
+	code, body, _ := w.req(t, http.MethodGet, "/api/me/bookmarks/"+w.syncID, nil)
+	if code < 500 {
+		t.Fatalf("got %d, want 5xx", code)
+	}
+	if _, present := body["bookmarks"]; present {
+		t.Fatal("error response must not carry a bookmarks array")
+	}
+}
+
+// ── conformance against the real ABS 2.36.0 captures ────────────────────────
+
+// These diff our bodies against fixtures captured from the reference server on
+// 2026-08-02, field by field, checking PRESENCE and TYPE rather than values. A
+// missing field is the highest-severity finding on this surface: a client that
+// hard-requires it fails its whole decode, and for a progress body that failure
+// looks to the user like the book losing its place.
+
+func TestMediaProgressGet_ConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 42.0, "duration": 9975.48, "isFinished": false})
+	assertConformant(t, "get_api_me_progress_id.json", w.getRow(t))
+}
+
+func TestMediaProgressList_ConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 42.0, "duration": 9975.48, "isFinished": false})
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/progress", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	assertConformant(t, "get_api_me_progress.json", body)
+}
+
+func TestBookmarkCreate_ConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "conformance bookmark"})
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	assertConformant(t, "post_api_me_item_id_bookmark.json", body)
+}
+
+func TestBookmarkUpdate_ConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	if code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "conformance bookmark"}); code != http.StatusOK {
+		t.Fatalf("create = %d %s", code, raw)
+	}
+	code, body, raw := w.req(t, http.MethodPatch, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "conformance bookmark"})
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	assertConformant(t, "patch_api_me_item_id_bookmark.json", body)
+}
+
+func TestBookmarkList_ConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	if code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 100, "title": "conformance bookmark"}); code != http.StatusOK {
+		t.Fatalf("create = %d %s", code, raw)
+	}
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/bookmarks/"+w.syncID, nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	assertConformant(t, "get_api_me_bookmarks_id.json", body)
+}
+
+// ── cross-cutting ───────────────────────────────────────────────────────────
+
+// TestProgressWrites_RejectUnauthenticated proves the whole write surface sits behind
+// the fail-closed identity middleware rather than only the read half.
+func TestProgressWrites_RejectUnauthenticated(t *testing.T) {
+	w := newWriteHarness(t)
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/me/progress"},
+		{http.MethodGet, "/api/me/progress/" + w.syncID},
+		{http.MethodPatch, "/api/me/progress/" + w.syncID},
+		{http.MethodPatch, "/api/me/progress/batch/update"},
+		{http.MethodDelete, "/api/me/progress/" + w.syncID},
+		{http.MethodPost, "/api/me/item/" + w.syncID + "/remove-from-continue-listening"},
+		{http.MethodGet, "/api/me/bookmarks/" + w.syncID},
+		{http.MethodPost, "/api/me/item/" + w.syncID + "/bookmark"},
+		{http.MethodPatch, "/api/me/item/" + w.syncID + "/bookmark"},
+		{http.MethodDelete, "/api/me/item/" + w.syncID + "/bookmark/1"},
+	} {
+		rec, _ := w.do(t, request{method: tc.method, path: tc.path, body: map[string]any{}})
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s = %d, want 401", tc.method, tc.path, rec.Code)
+		}
+	}
+}
+
+// TestProgressWrites_CannotAddressAnotherUsersRow pins the id parse. The row-id form
+// is "<userID>-<syncID>", and the prefix stripped is always the AUTHENTICATED
+// caller's own — so constructing another user's row id cannot reach their data.
+func TestProgressWrites_CannotAddressAnotherUsersRow(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 555.0})
+
+	// u2's row id for the same book. It must not resolve for u1's credentials.
+	code, _, _ := w.req(t, http.MethodGet, "/api/me/progress/u2-"+w.syncID, nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("got %d, want 404 for another user's row id", code)
+	}
+}

--- a/internal/server/handlers/abs/userdata.go
+++ b/internal/server/handlers/abs/userdata.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/userdata.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 63289143-7fae-47b5-9ed9-888ac3c2034a
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs
 
@@ -55,6 +55,11 @@ import (
 type ProgressListStore interface {
 	ListUserPositionsSince(userID string, since time.Time) ([]database.UserPosition, error)
 	GetUserBookState(userID, bookID string) (*database.UserBookState, error)
+	// GetUserPosition serves MediaProgressFor. A single-key get rather than a
+	// filtered rescan of ListUserPositionsSince: GET /api/me/progress/:id is on
+	// the client's reset-progress path and there is no reason to walk every book
+	// the user has touched to answer a question about one of them.
+	GetUserPosition(userID, bookID string) (*database.UserPosition, error)
 }
 
 // BookmarkListStore is the named-bookmark slice. ListBookmarksForUser exists
@@ -230,6 +235,42 @@ func (p *userDataProvider) MediaProgress(userID string) ([]any, error) {
 	return rows, nil
 }
 
+// MediaProgressFor renders the single row GET /api/me/progress/:id serves.
+//
+// It routes through the SAME progressRow renderer the list uses, which is the
+// whole point of the method existing: the client compares the single-item body
+// against the copy of the same book inside /api/me's list, resolving conflicts on
+// `lastUpdate` with a strict `>` after truncating both sides to whole seconds. Two
+// renderers that disagree by one field — or by one rounding step in the finished
+// tolerance — produce a book that re-syncs forever.
+//
+// ok=false means the user has never started this book, which the handler turns
+// into the 404 real ABS answers there. An error means we could not tell, which
+// becomes a 5xx: a 404 we are not sure about reads to the client as "no progress",
+// and that is the one answer that can cost a position.
+func (p *userDataProvider) MediaProgressFor(userID, bookID string) (any, bool, error) {
+	if userID == "" || bookID == "" {
+		return nil, false, errors.New("abs: userdata: userID and bookID are required")
+	}
+	pos, err := p.progress.GetUserPosition(userID, bookID)
+	if err != nil {
+		return nil, false, fmt.Errorf("abs: userdata: load position for %s/%s: %w", userID, bookID, err)
+	}
+	if pos == nil {
+		return nil, false, nil
+	}
+	// GetUserPosition answers for the (user, book) without naming a segment, so
+	// normalize the keys the renderer relies on rather than trusting whichever
+	// segment row the store happened to return.
+	pos.UserID, pos.BookID = userID, bookID
+
+	row, err := p.progressRow(userID, *pos)
+	if err != nil {
+		return nil, false, err
+	}
+	return row, true, nil
+}
+
 // betterPosition decides which of two position rows for the SAME book wins.
 //
 // Newest write wins, and a timestamp TIE resolves to the further position rather
@@ -292,12 +333,17 @@ func (p *userDataProvider) progressRow(userID string, pos database.UserPosition)
 	}
 
 	lastUpdate := lastUpdateMs(pos, state)
+	// The user's own "remove from Continue Listening" choice, persisted on the
+	// book state. Never derived: a false here because the row could not be read
+	// would silently put a book the user hid back on their home screen.
+	hidden := state != nil && state.HideFromContinueListening
+
 	row := mediaProgressDTO{
 		CurrentTime: pos.PositionSeconds,
 		Duration:    duration,
 		// ebook fields: this surface serves audiobooks only. Null/zero, never absent.
 		EbookProgress:             0,
-		HideFromContinueListening: false,
+		HideFromContinueListening: hidden,
 		// Derived from (user, item) rather than random so a client that stores the id
 		// keeps matching the same row across restarts. Same formula as item.go.
 		ID:            userID + "-" + syncID,

--- a/internal/server/handlers/abs/userdata_test.go
+++ b/internal/server/handlers/abs/userdata_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/userdata_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7ac71a7b-e1cb-4416-a393-1fa38af8871f
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs_test
 
@@ -109,6 +109,30 @@ func (f *udFake) addBookmark(b progress.Bookmark) {
 }
 
 // ── ProgressListStore ───────────────────────────────────────────────────────
+
+// GetUserPosition serves MediaProgressFor. It picks the SAME row betterPosition
+// would pick out of the list — newest write, ties to the further position — so the
+// single-item body and the list body agree for a book with several segment rows.
+func (f *udFake) GetUserPosition(userID, bookID string) (*database.UserPosition, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.positionsErr != nil {
+		return nil, f.positionsErr
+	}
+	var best *database.UserPosition
+	for i := range f.positions {
+		pos := f.positions[i]
+		if pos.UserID != userID || pos.BookID != bookID {
+			continue
+		}
+		if best == nil || pos.UpdatedAt.After(best.UpdatedAt) ||
+			(pos.UpdatedAt.Equal(best.UpdatedAt) && pos.PositionSeconds > best.PositionSeconds) {
+			cp := pos
+			best = &cp
+		}
+	}
+	return best, nil
+}
 
 func (f *udFake) ListUserPositionsSince(userID string, since time.Time) ([]database.UserPosition, error) {
 	f.mu.Lock()

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
-// last-edited: 2026-08-01
+// last-edited: 2026-08-02
 
 package server
 
@@ -24,6 +24,16 @@ import (
 // either side would turn into an os.Exit(1) at boot instead of a build failure —
 // and the failure mode it guards is the /api/me empty-list data loss of §1.8.1.
 var _ abshandler.ProgressListStore = (*database.PebbleStore)(nil)
+
+// Same proof for the Phase 6 write half. ProgressStore gained ClearUserPositions
+// (DELETE /api/me/progress/:id) and BookmarkStore is asserted at runtime below; a
+// signature drift on either would otherwise surface as an os.Exit(1) at boot — or,
+// for ProgressStore, as a SILENTLY DISABLED write surface, since asProgressStore
+// answers nil on a failed assertion rather than exiting.
+var (
+	_ abshandler.ProgressStore = (*database.PebbleStore)(nil)
+	_ abshandler.BookmarkStore = (*database.PebbleStore)(nil)
+)
 
 // absReservedPaths are the exact top-level paths the Audiobookshelf-compatible surface
 // owns under /api/. They must be EXCLUDED from the global /api/* → /api/v1/* redirect
@@ -231,8 +241,11 @@ func (s *Server) wireABSRoutes() {
 		// Chapters and Progress are OPTIONAL by design: without chapters the mapper
 		// synthesizes one per track (what real ABS does for a multi-file book anyway),
 		// and without progress a session still plays, it just starts at 0.
-		Chapters:    asChapterStore(s.Store()),
-		Progress:    asProgressStore(s.Store()),
+		Chapters: asChapterStore(s.Store()),
+		Progress: asProgressStore(s.Store()),
+		// Phase 6 write half. Already asserted non-nil above (bookmarkStore), so
+		// the CRUD routes always register on the supported backend.
+		Bookmarks:   bookmarkStore,
 		CoverRoot:   config.AppConfig.RootDir,
 		LibraryName: "Books",
 	})
@@ -269,6 +282,11 @@ func (s *Server) wireABSRoutes() {
 		slog.Error("abs: the media-progress provider was NOT wired — /api/me would report an EMPTY mediaProgress " +
 			"list, and clients DELETE local progress rows absent from it. This should be unreachable: " +
 			"NewUserData above exits on failure.")
+		os.Exit(1)
+	}
+	if !handler.HasBookmarkSurface() {
+		slog.Error("abs: the bookmark CRUD routes were NOT registered — creating or deleting a bookmark would 404. " +
+			"This should be unreachable: the bookmark-keyspace assertion above exits on failure.")
 		os.Exit(1)
 	}
 	if !handler.HasBrowseSurface() {
@@ -365,5 +383,20 @@ func absRouteList() []string {
 		"POST /api/session/:id/sync",
 		"POST /api/session/:id/close",
 		"GET /public/session/:id/track/:index (unauthenticated)",
+		// Phase 6 — progress mutation. Every one is covered by the "/api/me/"
+		// entry in absReservedPathPrefixes; they are listed here because
+		// TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute walks THIS
+		// list, so a route missing from it is a route the guard never checks.
+		"GET /api/me/progress",
+		"GET /api/me/progress/:id",
+		"PATCH /api/me/progress/:id",
+		"PATCH /api/me/progress/batch/update",
+		"DELETE /api/me/progress/:id",
+		"POST /api/me/item/:id/remove-from-continue-listening",
+		// Phase 6 — bookmarks CRUD.
+		"GET /api/me/bookmarks/:id",
+		"POST /api/me/item/:id/bookmark",
+		"PATCH /api/me/item/:id/bookmark",
+		"DELETE /api/me/item/:id/bookmark/:time",
 	}
 }

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package server
 
@@ -48,6 +48,11 @@ func TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute(t *testing.T) {
 		":id":        "68929fc9-e296-4d25-b3aa-1c2930efd00d",
 		":ino":       "01JFILEIDABCDEFGHIJKLMNOP",
 		":index":     "1",
+		// The bookmark delete surface addresses a bookmark by its TIME value, which
+		// arrives as a bare path segment (real ABS keys a bookmark by (item, time),
+		// not by an opaque id). Integer form on purpose: that is what AudioBooth
+		// sends here even when it round-trips the same value as a Double elsewhere.
+		":time": "100",
 	}
 
 	checked := 0

--- a/testdata/abs-fixtures/delete_api_me_item_id_bookmark_time.json
+++ b/testdata/abs-fixtures/delete_api_me_item_id_bookmark_time.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "body": null,
+    "method": "DELETE",
+    "path": "/api/me/item/68929fc9-e296-4d25-b3aa-1c2930efd00d/bookmark/100"
+  },
+  "response": {
+    "body": {
+      "__non_json_body__": "OK"
+    },
+    "headers": {
+      "content-type": "text/plain; charset=utf-8",
+      "etag": "W/\"2-nOO9QiTIwXgNtWtBJezz8kv3SLc\""
+    },
+    "status": 200
+  }
+}

--- a/testdata/abs-fixtures/delete_api_me_progress_id.json
+++ b/testdata/abs-fixtures/delete_api_me_progress_id.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "body": null,
+    "method": "DELETE",
+    "path": "/api/me/progress/ea31ae8b-73cb-4550-ad37-ae12c514550e"
+  },
+  "response": {
+    "body": {
+      "__non_json_body__": "OK"
+    },
+    "headers": {
+      "content-type": "text/plain; charset=utf-8",
+      "etag": "W/\"2-nOO9QiTIwXgNtWtBJezz8kv3SLc\""
+    },
+    "status": 200
+  }
+}

--- a/testdata/abs-fixtures/get_api_me_progress_id.json
+++ b/testdata/abs-fixtures/get_api_me_progress_id.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "body": null,
+    "method": "GET",
+    "path": "/api/me/progress/68929fc9-e296-4d25-b3aa-1c2930efd00d"
+  },
+  "response": {
+    "body": {
+      "currentTime": 42,
+      "duration": 9975.48,
+      "ebookLocation": null,
+      "ebookProgress": 0,
+      "episodeId": null,
+      "finishedAt": null,
+      "hideFromContinueListening": false,
+      "id": "ea31ae8b-73cb-4550-ad37-ae12c514550e",
+      "isFinished": false,
+      "lastUpdate": 1785649380007,
+      "libraryItemId": "68929fc9-e296-4d25-b3aa-1c2930efd00d",
+      "mediaItemId": "a0b6c2b4-1c38-494c-b793-ce131d283855",
+      "mediaItemType": "book",
+      "progress": 0.004,
+      "startedAt": 1785649380007,
+      "userId": "e1c3fe66-990b-44f0-8ed6-2bf73cc8cd86"
+    },
+    "headers": {
+      "content-type": "application/json; charset=utf-8",
+      "etag": "W/\"1c9-3Xz6ULrJzCNK/eP1/nPAJ4D7y50\""
+    },
+    "status": 200
+  }
+}

--- a/testdata/abs-fixtures/patch_api_me_item_id_bookmark.json
+++ b/testdata/abs-fixtures/patch_api_me_item_id_bookmark.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "body": {
+      "time": 100,
+      "title": "conformance bookmark"
+    },
+    "method": "PATCH",
+    "path": "/api/me/item/68929fc9-e296-4d25-b3aa-1c2930efd00d/bookmark"
+  },
+  "response": {
+    "body": {
+      "createdAt": 1785649350565,
+      "libraryItemId": "68929fc9-e296-4d25-b3aa-1c2930efd00d",
+      "time": 100,
+      "title": "conformance bookmark"
+    },
+    "headers": {
+      "content-type": "application/json; charset=utf-8",
+      "etag": "W/\"7c-U2chWk9CmLAFXUIi1nr7NeJy7yw\""
+    },
+    "status": 200
+  }
+}

--- a/testdata/abs-fixtures/patch_api_me_progress_batch_update.json
+++ b/testdata/abs-fixtures/patch_api_me_progress_batch_update.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "body": [
+      {
+        "currentTime": 42.0,
+        "duration": 9975.48,
+        "isFinished": false,
+        "libraryItemId": "68929fc9-e296-4d25-b3aa-1c2930efd00d"
+      }
+    ],
+    "method": "PATCH",
+    "path": "/api/me/progress/batch/update"
+  },
+  "response": {
+    "body": {
+      "__non_json_body__": "OK"
+    },
+    "headers": {
+      "content-type": "text/plain; charset=utf-8",
+      "etag": "W/\"2-nOO9QiTIwXgNtWtBJezz8kv3SLc\""
+    },
+    "status": 200
+  }
+}

--- a/todo.d/2026-08-02-abs-play-counts-listening-history.md
+++ b/todo.d/2026-08-02-abs-play-counts-listening-history.md
@@ -1,0 +1,42 @@
+<!-- file: todo.d/2026-08-02-abs-play-counts-listening-history.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3a91c705-8de2-4f46-b0c3-1d75e29f4b83 -->
+<!-- last-edited: 2026-08-02 -->
+
+## UNSPECIFIED: play counts and listening history have no designed ABS surface
+
+Raised while building the Phase 6 write half (2026-08-02). The owner's goal statement
+names "play counts" as one of "all the backend features the application expects."
+**The design spec defines no endpoint for them**, so nothing was invented — this
+records the gap rather than guessing at a shape.
+
+### What exists today
+
+- `UserBookState.TotalListenedSeconds` accumulates per (user, book) and is written by
+  the ABS sync path.
+- `IncrementBookPlayStats` / `IncrementUserListenStats` /
+  `GetBookStats` / `GetUserStats` exist in `pebble_store_playback.go` but are **not**
+  wired to the ABS surface.
+- `Book.ITunesPlayCount` is an imported scalar from iTunes, unrelated to listening
+  recorded by this server.
+
+### What real ABS exposes (and why we currently 404 it deliberately)
+
+`GET /api/me/listening-stats` and `GET /api/me/item/listening-sessions/:id` are the
+surfaces a client asks for. Both are **intentionally 404** today per spec §1.8.6: they
+carry ~12 non-optional fields, callers wrap them in `try?`, and a half-correct body is
+worse than none. AudioBooth polled `/api/me/listening-stats` 7 times in the 2026-08-01
+window and tolerated every 404 without user-visible breakage.
+
+### Decision needed before building
+
+1. Is a play *count* even the right primitive here, or is `TotalListenedSeconds`
+   (already recorded) what the owner actually wants surfaced?
+2. If the ABS-shaped endpoints are to be implemented, all ~12 fields must be produced —
+   a partial body is a regression from the current honest 404.
+3. `POST /api/session/local[-all]` (offline replay) is the other half of an honest
+   listening history and is itself unbuilt; `progress.MergeOfflineReplay` exists and is
+   tested but has no HTTP caller.
+
+**Do not implement piecemeal.** Half a stats surface reads to a client as a broken
+server rather than an absent feature.


### PR DESCRIPTION
## What

The Phase 6 **read** half shipped; the **write** half never did, so every client-side progress mutation 404'd. AudioBooth's "reset progress" stalled on `GET /api/me/progress/:id → 404` (observed in prod 2026-08-02) and "remove from continue listening" did nothing.

Adds, over the keyspaces TASK-08/TASK-09 already built:

| Endpoint | Notes |
|---|---|
| `GET /api/me/progress` | complete list or 5xx (§1.8.1) |
| `GET`/`PATCH`/`DELETE /api/me/progress/:id` | |
| `PATCH /api/me/progress/batch/update` | bare-array body |
| `POST /api/me/item/:id/remove-from-continue-listening` | alias, see below |
| `GET /api/me/bookmarks/:id` | |
| `POST`/`PATCH /api/me/item/:id/bookmark` | |
| `DELETE /api/me/item/:id/bookmark/:time` | keyed by time, not an id |

Writes merge through the §5 conflict policy (`progress.MergeExplicit`), never last-write-wins.

## Two spec assumptions were wrong

Found by probing the pinned ABS 2.36.0 oracle. **5 new fixtures committed**; spec §1.8.9 records both.

1. **`DELETE /api/me/progress/:id` is keyed by the `mediaProgress` ROW id, not the `libraryItemId`** — deleting by item id answers 404 on real ABS. Our read half renders that id as `<userID>-<syncID>`, so both forms are accepted. The stripped prefix is always the *authenticated caller's own* id, so one user cannot address another's row by constructing one (tested).
2. **`POST …/remove-from-continue-listening` does not exist on ABS 2.36.0** — it answers `Cannot POST`. The real mechanism is a `hideFromContinueListening` field on PATCH. Both are served: the field because it is genuine, the alias because a client calls it and was taking the 404 the owner reported. The alias answers `{}` (non-empty, §1.8.6).

## Bug fixed along the way

`persistProgress` constructed a **fresh** `UserBookState` on every sync instead of read-modify-writing it, resetting every field it did not set. That already un-pinned a hand-set read status (`StatusManual`) roughly every 20 s of listening, and would have un-hidden any book removed from Continue Listening within seconds. All ABS write paths now go through one read-modify-write helper. Both regressions are tested.

## On §5 rule 3 (forward-only) — deliberately not firing here

Neither `PATCH /api/me/progress/:id` nor `POST /api/session/:id/sync` carries a client timestamp, so incoming is always "newer" and both accept a backwards position. That is correct: both report a **live** user action, and refusing one would make scrubbing backwards impossible. The stale-device clobber is prevented one step earlier — `POST /api/items/:id/play` returns the server's true latest position and §1.8.7 has AudioBooth take `max(local, session.currentTime)` ignoring timestamps, so a stale device is pulled forward and never has a behind position to push. Pinned by `TestPlaySession_StartsFromTheServersTrueLatestPosition`. Forward-only still guards offline replay via `MergeOfflineReplay`.

## Verification

```
go test ./internal/server/handlers/abs/... -race -count=1   ok  258.019s
go test ./internal/syncapi/... -race -count=1               ok
go test ./internal/server/ -run TestABS -count=1            ok
```

5 conformance tests diff our bodies field-by-field against the real ABS captures. The reserved-path guard caught a missing `:time` placeholder — fixed, so `TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` actually covers the new routes rather than passing vacuously.

⚠️ **Oracle-verified, not yet client-verified.** Production traffic shows zero PATCH/DELETE/remove-from-continue-listening calls — because the client aborted after the GET 404'd. The post-deploy check against the phone is what actually closes these out.

## Not done, deliberately

Play counts / listening history have **no** designed surface in the spec, so nothing was invented — `todo.d/2026-08-02-abs-play-counts-listening-history.md` records the gap and the decision needed. `/api/me/listening-stats` and `/api/me/item/listening-sessions/:id` stay 404 per §1.8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp