### PR TITLE
fix(oauth): hand native clients back to their own URL scheme instead of the SPA root

### DIFF
--- a/changelog.d/20260802_020000_oauth_login_deeplink.md
+++ b/changelog.d/20260802_020000_oauth_login_deeplink.md
@@ -1,0 +1,38 @@
+<!-- file: changelog.d/20260802_020000_oauth_login_deeplink.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0b74e1c9-3d52-4a86-97f0-5e2c81a4bd37 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- **The web OAuth callback silently discarded a native client's custom-scheme
+  `return`, dropping it on the web SPA root instead.** `sanitizeReturn` correctly
+  requires a same-site path, so `audiobooth://oauth` became `""` and the destination
+  fell back to `/` — with no error and nothing logged, which surfaced as "it logged me
+  into the website" rather than as a failure.
+
+  `/auth/oauth/:provider/start` now accepts a registered native callback and, on
+  success, hands the client a single-use PKCE-bound authorization code on its own URL
+  scheme, redeemable at the existing `/auth/openid/callback`. `sanitizeReturn` is
+  **unchanged** — it is the open-redirect guard, and the deep-link path goes through
+  the same exact-match allowlist `/auth/openid` already enforces rather than loosening
+  it.
+
+  Three things this deliberately gets right:
+
+  - **The native path engages only when `redirect_uri` AND `code_challenge` are both
+    present.** `/auth/oauth/:provider/start` is the unauthenticated endpoint the SPA's
+    login buttons hit, so if a bare `redirect_uri` could trigger a 400, anyone could
+    break login for every user by getting one query parameter appended to a shared
+    link. A request carrying only one of the two is treated as an ordinary web login
+    and the stray parameter is ignored.
+  - **The two PKCE exchanges stay separate.** Server↔IdP uses our own verifier;
+    app↔server uses the client's challenge, which we only ever store. Conflating them
+    would either break the upstream token exchange or issue codes with no client-side
+    proof of possession.
+  - **No browser session is minted on the native path.** The caller is an
+    `ASWebAuthenticationSession` whose cookie jar is discarded when it closes, so a
+    session created there would be an unusable row written on every app login.
+
+  Latent when fixed — production logs showed zero `/auth/oauth/*` traffic over 7 days,
+  and Audiobookshelf clients use `/auth/openid` instead.

--- a/internal/oauth/state.go
+++ b/internal/oauth/state.go
@@ -1,7 +1,7 @@
 // file: internal/oauth/state.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1d6f8b03-4a29-4c57-9e08-2b7a5c0e3d94
-// last-edited: 2026-07-26
+// last-edited: 2026-08-02
 
 package oauth
 
@@ -21,11 +21,32 @@ import (
 // IdP, then verifies it on callback: the `state` query param must equal Payload.State
 // (CSRF), and Payload.Verifier is the PKCE code verifier sent in the token exchange.
 type StatePayload struct {
-	State     string `json:"s"`
-	Verifier  string `json:"v"`
-	Provider  string `json:"p"`
-	Return    string `json:"r,omitempty"` // optional post-login return path
-	IssuedAt  int64  `json:"t"`
+	State    string `json:"s"`
+	Verifier string `json:"v"`
+	Provider string `json:"p"`
+	Return   string `json:"r,omitempty"` // optional post-login return path
+	IssuedAt int64  `json:"t"`
+
+	// ── native-client deep link (optional) ──────────────────────────────────
+	//
+	// 🔴 THERE ARE TWO INDEPENDENT PKCE EXCHANGES IN THIS FLOW AND CONFLATING
+	// THEM BREAKS ONE OF THEM:
+	//
+	//	Verifier      server <-> IdP.  WE choose it, WE send the challenge to
+	//	                               Google/GitHub, WE redeem with the verifier.
+	//	AppChallenge  app <-> server.  THE CLIENT chooses it and keeps its own
+	//	                               verifier; we only ever see the challenge and
+	//	                               hand it to the code store to check later.
+	//
+	// Reusing Verifier for the app hop would issue codes with no client-side proof
+	// of possession; reusing AppChallenge upstream would break the token exchange.
+	//
+	// AppRedirectURI is only ever set to a value that already passed the exact-match
+	// allowlist, so nothing downstream re-validates it — but nothing downstream may
+	// widen it either.
+	AppRedirectURI string `json:"au,omitempty"`
+	AppChallenge   string `json:"ac,omitempty"`
+	AppState       string `json:"as,omitempty"`
 }
 
 // StateCodec signs/verifies StatePayload blobs with an HMAC secret. A fresh random

--- a/internal/server/handlers/abs/openid.go
+++ b/internal/server/handlers/abs/openid.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/openid.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3b8e5a14-70c9-4f26-9d51-a2c60f7b8e93
-// last-edited: 2026-08-01
+// last-edited: 2026-08-02
 
 package abs
 
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -162,6 +163,62 @@ func oidcRedirectAllowed(uri string) bool {
 		}
 	}
 	return false
+}
+
+// ── seam for the web OAuth deep-link flow (internal/server/handlers) ────────
+//
+// The web provider flow (/auth/oauth/:provider/start) can hand a native client back
+// to its own URL scheme instead of the SPA root. It resolves identity through
+// Google/GitHub rather than through a Cloudflare Access assertion, but the last hop
+// is IDENTICAL: mint a single-use PKCE-bound code here and let the client redeem it
+// at /auth/openid/callback. These two functions are the only way in.
+//
+// They are exported rather than the code store itself so there is exactly one place
+// that decides what a valid app callback is, and so no caller can put a code into
+// the store without a challenge to bind it to.
+
+// AppRedirectURIAllowed reports whether uri is a registered native-client callback.
+//
+// It is the SAME exact-match allowlist /auth/openid enforces (see
+// oidcRedirectAllowed): this is the control that prevents account takeover, and a
+// second flow reaching the same code store must not get a second, looser opinion
+// about which targets are legitimate.
+func AppRedirectURIAllowed(uri string) bool { return oidcRedirectAllowed(uri) }
+
+// MintAppAuthorizationCode issues a single-use authorization code bound to challenge
+// (the CLIENT's PKCE challenge — never the server's own IdP verifier) and to the
+// resolved user. It expires in oidcCodeTTL and is redeemable exactly once, at
+// /auth/openid/callback.
+//
+// challenge is required. A code minted without one would be a bearer credential
+// sitting in a URL on a custom scheme that any other installed app can register —
+// which is precisely the takeover PKCE exists to stop — so this refuses rather than
+// defaulting to an unbound code.
+func MintAppAuthorizationCode(userID, email, challenge string) (string, error) {
+	if strings.TrimSpace(userID) == "" {
+		return "", errors.New("abs: cannot mint an authorization code with no user")
+	}
+	if strings.TrimSpace(challenge) == "" {
+		return "", errors.New("abs: cannot mint an authorization code with no PKCE challenge")
+	}
+	code, err := absauth.NewRefreshSeed() // 256-bit URL-safe random; not a refresh token
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	oidcCodes.put(code, oidcPendingCode{
+		UserID:    userID,
+		Email:     email,
+		Challenge: challenge,
+		ExpiresAt: now.Add(oidcCodeTTL),
+	}, now)
+	return code, nil
+}
+
+// AppRedirectURL assembles the callback URL a native client is sent back to. Empty
+// params are skipped, and the custom scheme survives verbatim.
+func AppRedirectURL(target, code, state string) string {
+	return buildOIDCRedirect(target, map[string]string{"code": code, "state": state})
 }
 
 // OpenIDAuthorize handles GET /auth/openid.

--- a/internal/server/handlers/oauth_login.go
+++ b/internal/server/handlers/oauth_login.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/oauth_login.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2e9c0b47-6a31-4d58-8f04-1b5a7c2e9d63
-// last-edited: 2026-07-26
+// last-edited: 2026-08-02
 
 package handlers
 
@@ -15,6 +15,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/oauth"
+	"github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs"
 )
 
 // oauthStateCookie carries the signed CSRF-state + PKCE blob across the IdP redirect.
@@ -70,8 +71,17 @@ func (h *OAuthHandler) Start(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "oauth verifier")
 		return
 	}
+	app, ok := appDeepLinkParams(c)
+	if !ok {
+		return // appDeepLinkParams already answered
+	}
+
 	blob, err := h.codec.Encode(oauth.StatePayload{
 		State: state, Verifier: verifier, Provider: provider, Return: sanitizeReturn(c.Query("return")),
+		// Empty unless the caller is a registered native client (see
+		// appDeepLinkParams). The two PKCE exchanges are kept apart here: Verifier
+		// above is ours for the IdP hop, AppChallenge is the client's for its own.
+		AppRedirectURI: app.redirectURI, AppChallenge: app.challenge, AppState: app.state,
 	})
 	if err != nil {
 		httputil.RespondWithInternalError(c, "oauth state encode")
@@ -131,6 +141,24 @@ func (h *OAuthHandler) Callback(c *gin.Context) {
 		httputil.RespondWithInternalError(c, "oauth resolve user")
 		return
 	}
+	// A native client gets an authorization code on its own URL scheme instead of a
+	// browser session. Deliberately BEFORE CreateSession: the caller is an
+	// ASWebAuthenticationSession whose cookie jar is discarded the moment it closes,
+	// so issuing a browser session here would leave an unusable row in the store on
+	// every app login. The app's real session comes from redeeming the code.
+	if payload.AppRedirectURI != "" && payload.AppChallenge != "" {
+		code, mintErr := abs.MintAppAuthorizationCode(user.ID, claims.Email, payload.AppChallenge)
+		if mintErr != nil {
+			redirectToLogin(c, "oauth_code_mint_failed")
+			return
+		}
+		// The target already passed the exact-match allowlist at Start and travelled
+		// inside an HMAC-signed blob, so it cannot have been swapped in between.
+		http.Redirect(c.Writer, c.Request,
+			abs.AppRedirectURL(payload.AppRedirectURI, code, payload.AppState), http.StatusFound)
+		return
+	}
+
 	session, err := h.store.CreateSession(
 		user.ID,
 		strings.TrimSpace(c.ClientIP()),
@@ -147,6 +175,56 @@ func (h *OAuthHandler) Callback(c *gin.Context) {
 		dest = payload.Return
 	}
 	http.Redirect(c.Writer, c.Request, dest, http.StatusFound)
+}
+
+// appDeepLink is the native-client half of a /auth/oauth/:provider/start request.
+type appDeepLink struct {
+	redirectURI string
+	challenge   string
+	state       string
+}
+
+// appDeepLinkParams decides whether this Start request is a native-client deep link,
+// answering the request itself and reporting false when it is malformed.
+//
+// 🔴 THE GATE IS "BOTH PRESENT", AND THAT IS A SECURITY PROPERTY, NOT TIDINESS.
+// /auth/oauth/:provider/start is the UNAUTHENTICATED web login endpoint that the SPA's
+// buttons hit. If a bare redirect_uri could trigger a 400, anyone could break web
+// login for everyone by getting a query parameter appended to a shared link. So a
+// request carrying only one of the two is treated as an ordinary web login and the
+// stray parameter is ignored — no error, no behaviour change.
+//
+// Once BOTH are present the caller has unambiguously asked for the native flow, and
+// from there every failure is a hard 400: the target must be on the exact-match
+// allowlist and the method must be S256. "plain" is refused because on a custom URL
+// scheme another installed app can register the same scheme and observe the redirect,
+// so a plain challenge protects nothing.
+func appDeepLinkParams(c *gin.Context) (appDeepLink, bool) {
+	// redirect_uri is the OAuth-standard name; `callback` is the alias AudioBooth
+	// also sends on /auth/openid. Accepted here so one client does not need two
+	// spellings across two endpoints.
+	redirectURI := strings.TrimSpace(c.Query("redirect_uri"))
+	if redirectURI == "" {
+		redirectURI = strings.TrimSpace(c.Query("callback"))
+	}
+	challenge := strings.TrimSpace(c.Query("code_challenge"))
+
+	if redirectURI == "" || challenge == "" {
+		// Not a deep-link request (or not a well-formed one). Ordinary web login.
+		return appDeepLink{}, true
+	}
+	if !abs.AppRedirectURIAllowed(redirectURI) {
+		// Answered INLINE, never by redirecting to the rejected target — bouncing to
+		// an unvalidated URI to report that it is unvalidated is still an open
+		// redirect. This is the control that makes account takeover impossible here.
+		httputil.RespondWithBadRequest(c, "redirect_uri is not registered")
+		return appDeepLink{}, false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.Query("code_challenge_method")), "S256") {
+		httputil.RespondWithBadRequest(c, "code_challenge_method must be S256")
+		return appDeepLink{}, false
+	}
+	return appDeepLink{redirectURI: redirectURI, challenge: challenge, state: c.Query("state")}, true
 }
 
 // setOAuthStateCookie writes the signed state blob (SameSite=Lax, ~10 min).

--- a/internal/server/handlers/oauth_login_deeplink_test.go
+++ b/internal/server/handlers/oauth_login_deeplink_test.go
@@ -1,0 +1,316 @@
+// file: internal/server/handlers/oauth_login_deeplink_test.go
+// version: 1.0.0
+// guid: 5e04b7c2-1a68-4d39-b0f5-93c7e2016d84
+// last-edited: 2026-08-02
+
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/oauth"
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+)
+
+// The web provider flow can hand a registered native client back to its own URL
+// scheme instead of the SPA root. The tests below split into two groups that matter
+// for different reasons:
+//
+//   - the deep link WORKS, and the code it issues is bound to the CLIENT's PKCE
+//     challenge (not the server's own IdP verifier — conflating the two exchanges is
+//     the mistake this flow invites);
+//   - the deep link CANNOT BREAK ORDINARY WEB LOGIN, which is the security property
+//     behind the both-params gate: /auth/oauth/:provider/start is unauthenticated, so
+//     if one stray query parameter could 400 it, anyone could break login for everyone
+//     by getting a parameter appended to a shared link.
+
+const testDeepLink = "audiobooth://oauth"
+
+// stubProvider is an IdP that always succeeds, so the tests exercise OUR half of the
+// handshake rather than a network.
+type stubProvider struct {
+	email        string
+	lastVerifier string
+}
+
+func (p *stubProvider) Name() string { return "google" }
+
+func (p *stubProvider) AuthCodeURL(state, challenge, redirectURI string) string {
+	return "https://idp.example/authorize?state=" + url.QueryEscape(state) +
+		"&code_challenge=" + url.QueryEscape(challenge)
+}
+
+func (p *stubProvider) Exchange(_ context.Context, _, verifier, _ string) (*oauth.IdentityClaims, error) {
+	p.lastVerifier = verifier
+	return &oauth.IdentityClaims{
+		Provider: "google", Subject: "sub-1", Email: p.email, EmailVerified: true,
+	}, nil
+}
+
+type deepLinkHarness struct {
+	router   *gin.Engine
+	provider *stubProvider
+	codec    *oauth.StateCodec
+}
+
+func newDeepLinkHarness(t *testing.T) *deepLinkHarness {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	store, err := database.NewPebbleStore(filepath.Join(t.TempDir(), "oauth-db"))
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cfg := oauth.New(oauth.Config{
+		Enabled:            true,
+		GoogleClientID:     "cid",
+		GoogleClientSecret: "secret",
+		RedirectBaseURL:    "https://books.example.com",
+		AllowedEmails:      []string{"owner@example.com"},
+		DefaultRole:        "viewer",
+	})
+	codec, err := oauth.NewStateCodec(10 * time.Minute)
+	if err != nil {
+		t.Fatalf("NewStateCodec: %v", err)
+	}
+	provider := &stubProvider{email: "owner@example.com"}
+	h := NewOAuthHandler(store, cfg, codec, map[string]oauth.Provider{"google": provider})
+
+	r := gin.New()
+	r.GET("/auth/oauth/:provider/start", h.Start)
+	r.GET("/auth/oauth/:provider/callback", h.Callback)
+	return &deepLinkHarness{router: r, provider: provider, codec: codec}
+}
+
+// start issues a Start request and returns the response plus the state cookie.
+func (h *deepLinkHarness) start(t *testing.T, query string) (*httptest.ResponseRecorder, *http.Cookie) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/auth/oauth/google/start"+query, http.NoBody))
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == oauthStateCookie && ck.Value != "" {
+			return rec, ck
+		}
+	}
+	return rec, nil
+}
+
+// callback completes the handshake using the state cookie from start.
+func (h *deepLinkHarness) callback(t *testing.T, ck *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+	payload, err := h.codec.Decode(ck.Value)
+	if err != nil {
+		t.Fatalf("decode state: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet,
+		"/auth/oauth/google/callback?code=idp-code&state="+url.QueryEscape(payload.State), http.NoBody)
+	req.AddCookie(ck)
+	rec := httptest.NewRecorder()
+	h.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func challengeFor(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// ── the deep link works ─────────────────────────────────────────────────────
+
+// TestDeepLink_ReturnsCodeToTheRegisteredScheme is the whole point: before this
+// change the custom scheme was silently discarded and the caller landed on the web
+// SPA root, which surfaced as "it logged me into the website" rather than as a
+// failure.
+func TestDeepLink_ReturnsCodeToTheRegisteredScheme(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	appChallenge := challengeFor("app-verifier-app-verifier-app-verifier")
+
+	_, ck := h.start(t, "?redirect_uri="+url.QueryEscape(testDeepLink)+
+		"&code_challenge="+appChallenge+"&code_challenge_method=S256&state=app-state")
+	if ck == nil {
+		t.Fatal("Start did not set the state cookie")
+	}
+
+	rec := h.callback(t, ck)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, testDeepLink+"?") {
+		t.Fatalf("Location = %q, want a redirect to %q — the custom scheme must survive verbatim", loc, testDeepLink)
+	}
+	parsed, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	if parsed.Query().Get("code") == "" {
+		t.Fatalf("Location %q carries no code", loc)
+	}
+	if got := parsed.Query().Get("state"); got != "app-state" {
+		t.Fatalf("state = %q, want %q — the client's own state must round-trip", got, "app-state")
+	}
+}
+
+// 🔴 TestDeepLink_KeepsTheTwoPKCEExchangesSeparate. There are two independent PKCE
+// handshakes here: server<->IdP (our verifier) and app<->server (the client's
+// challenge). Conflating them either breaks the upstream token exchange or issues a
+// code with no client-side proof of possession.
+func TestDeepLink_KeepsTheTwoPKCEExchangesSeparate(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	appVerifier := "app-verifier-app-verifier-app-verifier"
+	appChallenge := challengeFor(appVerifier)
+
+	_, ck := h.start(t, "?redirect_uri="+url.QueryEscape(testDeepLink)+
+		"&code_challenge="+appChallenge+"&code_challenge_method=S256")
+	if ck == nil {
+		t.Fatal("Start did not set the state cookie")
+	}
+	payload, err := h.codec.Decode(ck.Value)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if payload.Verifier == "" {
+		t.Fatal("the server's own IdP verifier must still be minted")
+	}
+	if payload.Verifier == appVerifier || payload.Verifier == appChallenge {
+		t.Fatal("the server's IdP verifier was replaced by the client's PKCE material — " +
+			"this breaks the upstream token exchange")
+	}
+	if payload.AppChallenge != appChallenge {
+		t.Fatalf("AppChallenge = %q, want the client's challenge %q", payload.AppChallenge, appChallenge)
+	}
+
+	h.callback(t, ck)
+	// The upstream exchange must have received OUR verifier, not the client's.
+	if h.provider.lastVerifier != payload.Verifier {
+		t.Fatalf("IdP exchange used verifier %q, want the server's own %q",
+			h.provider.lastVerifier, payload.Verifier)
+	}
+}
+
+// ── the deep link cannot break ordinary web login ───────────────────────────
+
+// 🔴 TestStart_StrayParamDoesNotBreakWebLogin is the gate's reason for existing.
+// /auth/oauth/:provider/start is UNAUTHENTICATED, so if a bare redirect_uri (or a
+// bare code_challenge) could 400 it, anyone could disable login for every user by
+// getting one query parameter appended to a shared link.
+func TestStart_StrayParamDoesNotBreakWebLogin(t *testing.T) {
+	for name, query := range map[string]string{
+		"bare redirect_uri":   "?redirect_uri=" + url.QueryEscape("https://evil.example"),
+		"bare callback":       "?callback=" + url.QueryEscape("https://evil.example"),
+		"bare code_challenge": "?code_challenge=" + challengeFor("x"),
+		"redirect_uri with return": "?redirect_uri=" + url.QueryEscape("https://evil.example") +
+			"&return=%2Flibrary",
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newDeepLinkHarness(t)
+			rec, ck := h.start(t, query)
+			if rec.Code != http.StatusFound {
+				t.Fatalf("Start = %d, want 302 to the IdP — a stray parameter must not break web login", rec.Code)
+			}
+			if ck == nil {
+				t.Fatal("Start did not set the state cookie")
+			}
+			payload, err := h.codec.Decode(ck.Value)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if payload.AppRedirectURI != "" {
+				t.Fatalf("AppRedirectURI = %q, want empty — the deep-link path must not engage "+
+					"without BOTH redirect_uri and code_challenge", payload.AppRedirectURI)
+			}
+		})
+	}
+}
+
+// TestStart_UnregisteredDeepLinkIsRejectedInline covers the open-redirect guard:
+// once both parameters are present the caller has unambiguously asked for the native
+// flow, so an unregistered target is a hard 400 — answered INLINE, never by
+// redirecting to the rejected URI.
+func TestStart_UnregisteredDeepLinkIsRejectedInline(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	rec, _ := h.start(t, "?redirect_uri="+url.QueryEscape("https://evil.example")+
+		"&code_challenge="+challengeFor("v")+"&code_challenge_method=S256")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Start = %d, want 400 for an unregistered redirect_uri", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("rejected request redirected to %q — reporting the rejection by navigating to "+
+			"the unvalidated target is still an open redirect", loc)
+	}
+}
+
+// TestStart_PlainPKCEIsRejected: on a custom URL scheme another installed app can
+// register the same scheme and observe the redirect, so a "plain" challenge protects
+// nothing.
+func TestStart_PlainPKCEIsRejected(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	rec, _ := h.start(t, "?redirect_uri="+url.QueryEscape(testDeepLink)+
+		"&code_challenge=abc&code_challenge_method=plain")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Start = %d, want 400 for code_challenge_method=plain", rec.Code)
+	}
+}
+
+// TestWebLogin_StillLandsOnTheSPA is the regression guard for the untouched path:
+// a plain web login must still end at the sanitized same-site return path and must
+// still receive a browser session cookie.
+func TestWebLogin_StillLandsOnTheSPA(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	_, ck := h.start(t, "?return=%2Flibrary")
+	if ck == nil {
+		t.Fatal("Start did not set the state cookie")
+	}
+
+	rec := h.callback(t, ck)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/library" {
+		t.Fatalf("Location = %q, want %q", loc, "/library")
+	}
+	var sawSession bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == servermiddleware.SessionCookieName && c.Value != "" {
+			sawSession = true
+		}
+	}
+	if !sawSession {
+		t.Fatal("web login did not set a session cookie")
+	}
+}
+
+// TestDeepLink_DoesNotMintABrowserSession: the caller is an
+// ASWebAuthenticationSession whose cookie jar is discarded when it closes, so a
+// browser session issued here would be an unusable row created on every app login.
+func TestDeepLink_DoesNotMintABrowserSession(t *testing.T) {
+	h := newDeepLinkHarness(t)
+	_, ck := h.start(t, "?redirect_uri="+url.QueryEscape(testDeepLink)+
+		"&code_challenge="+challengeFor("v")+"&code_challenge_method=S256")
+	if ck == nil {
+		t.Fatal("Start did not set the state cookie")
+	}
+
+	rec := h.callback(t, ck)
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == servermiddleware.SessionCookieName && c.Value != "" {
+			t.Fatal("the deep-link path issued a browser session cookie the client can never use")
+		}
+	}
+}


### PR DESCRIPTION
## What

`Callback` picked its destination from `payload.Return`, set at `Start` via `sanitizeReturn` — which requires a single leading slash. So `audiobooth://oauth` became `""`, `dest` fell back to `/`, and the caller landed on the web SPA. **No error, nothing logged** — the redirect target was simply replaced, which surfaces as "it logged me into the website" rather than as a failure.

`sanitizeReturn` is **unchanged**. It is the open-redirect guard and the reason `d87cbf37` (account takeover via an unregistered `redirect_uri`) cannot recur here. The native path instead mirrors `/auth/openid`: on an allowlisted deep link, mint a single-use PKCE-bound code and 302 to the client's scheme, letting it redeem at the existing `/auth/openid/callback`. Both flows now share one exact-match allowlist (`abs.AppRedirectURIAllowed`) and one code store, so neither can develop a looser opinion about which callbacks are legitimate.

## The three things a naive implementation gets wrong

1. **The gate is "both params present", and that is a security property.** `/auth/oauth/:provider/start` is the **unauthenticated** endpoint the SPA's login buttons hit. If a bare `redirect_uri` could trigger a 400, anyone could break login for every user by getting one query parameter appended to a shared link. A request carrying only one of the two is treated as ordinary web login and the stray parameter is ignored — covered by `TestStart_StrayParamDoesNotBreakWebLogin` across 4 shapes.
2. **The two PKCE exchanges stay separate.** `StatePayload.Verifier` is ours for the server↔IdP hop; the new `AppChallenge` is the client's for app↔server. Conflating them breaks the upstream token exchange or issues codes with no proof of possession. `TestDeepLink_KeepsTheTwoPKCEExchangesSeparate` asserts both directions, including that the IdP `Exchange` received *our* verifier.
3. **No browser session on the native path.** The caller is an `ASWebAuthenticationSession` whose cookie jar is discarded on close, so a session created there is an unusable row written on every app login.

Once both params *are* present the caller has unambiguously asked for the native flow, so failures are hard 400s: unregistered target, or `code_challenge_method` != S256. The rejection is answered **inline**, never by redirecting to the rejected URI — bouncing to an unvalidated target to report that it is unvalidated is still an open redirect.

## Verification

```
go test ./internal/server/handlers/ -race -count=1        ok  5.255s
go test ./internal/oauth/... -race -count=1               ok  1.348s
go test ./internal/server/handlers/abs/... -race -count=1  ok  180.722s
```

8 new tests: 2 that the deep link works, 6 that it cannot break or loosen anything — including `TestWebLogin_StillLandsOnTheSPA` (untouched path still returns to the sanitized same-site path *and* sets a session cookie).

## Known limits

- **Latent.** 7 days of production logs show **zero** `/auth/oauth/*` traffic; ABS clients use `/auth/openid`, which is untouched.
- ⚠️ **Unverified on device:** whether `ASWebAuthenticationSession` returns the `SameSite=Lax` `oauth_state` cookie on the hop back from the IdP. If it does not, `Callback` fails at `oauth_state_missing` regardless of this change — only a real-device test can settle it. Recorded in the original `todo.d` fragment and left standing. The existing `/auth/openid` path AudioBooth actually uses is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp