### PR TITLE
fix(scripts): validate the Prometheus config with a promtool that matches the server

### DIFF
--- a/changelog.d/20260802_040000_promtool_version_resolution.md
+++ b/changelog.d/20260802_040000_promtool_version_resolution.md
@@ -1,0 +1,26 @@
+<!-- file: changelog.d/20260802_040000_promtool_version_resolution.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a3f92e0-5c14-4d8b-a06f-1e58b7d3ca94 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- **`setup-prometheus-auth.py` rejected a valid config because it validated with the
+  wrong `promtool`.** The script called `shutil.which("promtool")` and trusted PATH
+  order. On the production host an unpackaged **promtool 2.13.1 (built 2019)** sits in
+  `/usr/local/bin`, ahead of the packaged **2.53.5** in `/usr/bin` that matches the
+  running Prometheus. The 2019 binary predates the `authorization:` scrape-config
+  field (added in Prometheus 2.26), so it failed with:
+
+  ```
+  field authorization not found in type config.plain
+  ```
+
+  The script then correctly restored the original config and reported failure — so the
+  error read as a bad config rather than a bad validator, which is the confusing part.
+
+  `find_promtool()` now picks the `promtool` whose version matches
+  `prometheus --version`, falling back to the newest available, and logs which one it
+  chose and why (explicitly calling out when the winner is *not* first on PATH). A
+  validator newer than the server can only be over-permissive; an older one produces
+  false rejections like this one.

--- a/changelog.d/20260802_040000_promtool_version_resolution.md
+++ b/changelog.d/20260802_040000_promtool_version_resolution.md
@@ -1,5 +1,5 @@
 <!-- file: changelog.d/20260802_040000_promtool_version_resolution.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7a3f92e0-5c14-4d8b-a06f-1e58b7d3ca94 -->
 <!-- last-edited: 2026-08-02 -->
 
@@ -24,3 +24,10 @@
   chose and why (explicitly calling out when the winner is *not* first on PATH). A
   validator newer than the server can only be over-permissive; an older one produces
   false rejections like this one.
+
+- **The same script's rollback was incomplete.** On a validation failure it restored
+  `prometheus.yml` but left the shared `file_sd` discovery entry moved aside, so the
+  target ended up in **neither** the shared job nor the dedicated one — silently
+  scraped by nothing, which is worse than either intended end state. Both edits are
+  now rolled back together, and the docstring no longer overpromises "the original is
+  restored".

--- a/scripts/setup-prometheus-auth.py
+++ b/scripts/setup-prometheus-auth.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # file: scripts/setup-prometheus-auth.py
-# version: 1.0.1
+# version: 1.1.0
 # guid: 4d90a2f6-13bc-4e58-9071-8c25e6b3f0a7
-# last-edited: 2026-08-01
+# last-edited: 2026-08-02
 
 """Point Prometheus at audiobook-organizer's now-authenticated /metrics.
 
@@ -45,6 +45,7 @@ import grp
 import json
 import os
 import pwd
+import re
 import shutil
 import ssl
 import subprocess
@@ -127,6 +128,75 @@ def probe_metrics(token: str) -> int:
         return 0
 
 
+def _binary_version(binary: str) -> str:
+    """Return the bare version a Prometheus-family binary reports, or ""."""
+    try:
+        out = subprocess.run([binary, "--version"], capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    text = (out.stdout or "") + (out.stderr or "")
+    m = re.search(r"version (\d+\.\d+\.\d+)", text)
+    return m.group(1) if m else ""
+
+
+def find_promtool() -> tuple[str | None, str]:
+    """Resolve the promtool that matches the RUNNING Prometheus.
+
+    🔴 PATH ORDER IS NOT TRUSTWORTHY HERE, and trusting it silently breaks this
+    script in the most confusing way possible.
+
+    Observed on this server 2026-08-02: an unpackaged promtool 2.13.1 (built
+    2019) sat in /usr/local/bin, ahead of the packaged 2.53.5 in /usr/bin that
+    matches the running Prometheus. `shutil.which` returned the 2019 one, which
+    does not know the `authorization:` scrape-config field at all -- it was
+    added in Prometheus 2.26 -- so it rejected a PERFECTLY VALID config with:
+
+        field authorization not found in type config.plain
+
+    The script then dutifully restored the original and reported failure, so the
+    error looked like a bad config rather than a bad validator.
+
+    Strategy: prefer an exact version match with `prometheus --version`, else
+    the newest candidate, and say out loud which one was chosen and why. A
+    validator NEWER than the server can only be over-permissive (it accepts
+    fields the server ignores); an OLDER one produces false rejections like the
+    one above, which is the failure worth engineering against.
+
+    Returns (path_or_None, note_to_log).
+    """
+    seen: list[str] = []
+    for directory in os.environ.get("PATH", "").split(os.pathsep) + ["/usr/bin", "/bin", "/usr/local/bin"]:
+        if not directory:
+            continue
+        candidate = os.path.join(directory, "promtool")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK) and candidate not in seen:
+            seen.append(candidate)
+    if not seen:
+        return None, ""
+
+    server = _binary_version("prometheus")
+    versions = {c: _binary_version(c) for c in seen}
+
+    if server:
+        for candidate, version in versions.items():
+            if version == server:
+                note = f"promtool: using {candidate} (v{version}, matches Prometheus)"
+                if candidate != seen[0]:
+                    note += f" — NOT the first on PATH ({seen[0]} is v{versions[seen[0]] or '?'})"
+                return candidate, note
+
+    def sort_key(path: str) -> tuple[int, ...]:
+        version = versions.get(path) or "0.0.0"
+        return tuple(int(part) for part in version.split("."))
+
+    best = max(seen, key=sort_key)
+    note = f"promtool: using {best} (v{versions[best] or '?'})"
+    if server:
+        note += (f" — no exact match for Prometheus v{server}; "
+                 "an older validator can reject a valid config")
+    return best, note
+
+
 def main() -> None:
     print("\n  Prometheus auth setup for audiobook-organizer\n")
 
@@ -186,17 +256,21 @@ def main() -> None:
         PROM_CONFIG.write_text(config_text.rstrip("\n") + "\n" + JOB_BLOCK)
         info(f"Appended job '{JOB_NAME}'")
 
-        promtool = shutil.which("promtool")
+        promtool, promtool_note = find_promtool()
         if promtool:
+            if promtool_note:
+                info(promtool_note)
             check = subprocess.run(
                 [promtool, "check", "config", str(PROM_CONFIG)],
                 capture_output=True, text=True,
             )
             if check.returncode != 0:
                 shutil.copy2(backup, PROM_CONFIG)
-                die("promtool rejected the new config — ORIGINAL RESTORED:\n"
-                    f"{check.stdout}\n{check.stderr}")
-            info("promtool: config valid")
+                die(f"promtool ({promtool}) rejected the new config — ORIGINAL RESTORED:\n"
+                    f"{check.stdout}\n{check.stderr}\n"
+                    "If this mentions 'field authorization not found', the validator is\n"
+                    "older than the running Prometheus — see find_promtool().")
+            info(f"promtool: config valid ({promtool})")
         else:
             info("promtool not found — skipping validation (reload will catch errors)")
 

--- a/scripts/setup-prometheus-auth.py
+++ b/scripts/setup-prometheus-auth.py
@@ -33,8 +33,9 @@ the shared discovery file is disabled.
 Safety
 ------
 Nothing is modified until the key is proven to work, the config is backed up
-before editing, promtool must accept the result, and the original is restored
-automatically if it does not. Re-running is safe: existing state is detected and
+before editing, promtool must accept the result, and BOTH edits (the config and
+the moved file_sd entry) are rolled back together if it does not — rolling back
+only one would leave the target scraped by neither job. Re-running is safe: existing state is detected and
 left alone rather than duplicated.
 """
 
@@ -235,9 +236,17 @@ def main() -> None:
     info(f"Wrote {TOKEN_FILE} (0600 prometheus:prometheus)")
 
     # ---- 3. Disable the shared-job discovery entry -------------------------
+    #
+    # Tracked so step 4 can UNDO it. Disabling the shared entry only makes sense
+    # alongside the dedicated job that replaces it: if validation then rejects the
+    # config and only prometheus.yml is rolled back, the target ends up in NEITHER
+    # job and is silently scraped by nothing. That happened in production on
+    # 2026-08-02 and is strictly worse than either intended end state.
+    moved_sd_file = False
     if SHARED_SD_FILE.exists():
         DISABLED_SD_FILE.parent.mkdir(parents=True, exist_ok=True)
         shutil.move(str(SHARED_SD_FILE), str(DISABLED_SD_FILE))
+        moved_sd_file = True
         info(f"Moved {SHARED_SD_FILE.name} out of the shared file_sd job")
         info(f"  -> {DISABLED_SD_FILE}")
     else:
@@ -266,7 +275,14 @@ def main() -> None:
             )
             if check.returncode != 0:
                 shutil.copy2(backup, PROM_CONFIG)
-                die(f"promtool ({promtool}) rejected the new config — ORIGINAL RESTORED:\n"
+                restored = "prometheus.yml restored"
+                # Undo step 3 too. Rolling back only the config would leave the
+                # target in neither the shared job nor the dedicated one.
+                if moved_sd_file and DISABLED_SD_FILE.exists():
+                    SHARED_SD_FILE.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.move(str(DISABLED_SD_FILE), str(SHARED_SD_FILE))
+                    restored += f"; {SHARED_SD_FILE.name} put back in the shared file_sd job"
+                die(f"promtool ({promtool}) rejected the new config — ROLLED BACK ({restored}):\n"
                     f"{check.stdout}\n{check.stderr}\n"
                     "If this mentions 'field authorization not found', the validator is\n"
                     "older than the running Prometheus — see find_promtool().")


### PR DESCRIPTION
## What happened

`setup-prometheus-auth.py` failed in production tonight with:

```
ERROR: promtool rejected the new config — ORIGINAL RESTORED:
  FAILED: parsing YAML file /etc/prometheus/prometheus.yml: yaml: unmarshal errors:
  line 187: field authorization not found in type config.plain
```

**The config was fine.** The *validator* was nine years stale.

The script called `shutil.which("promtool")` and trusted PATH order. On the production host:

| binary | version | packaged? |
|---|---|---|
| `/usr/local/bin/promtool` (first on PATH) | **2.13.1**, built Nov 2019 | no — unpackaged leftover |
| `/usr/bin/promtool` | **2.53.5** | yes, matches the running Prometheus |

`authorization:` was added to scrape configs in Prometheus **2.26**, so the 2019 binary rejects it outright. Confirmed directly on the host — the identical config:

```
=== 2.13.1 (/usr/local/bin) ===  FAILED: field authorization not found in type config.plain
=== 2.53.5 (/usr/bin)      ===  SUCCESS: is valid prometheus config file syntax
```

The script then correctly restored the original and reported failure — which is exactly why this was confusing: the safety worked, but the message pointed at the config rather than the tool.

## Fix

`find_promtool()` resolves by **version**, not PATH order: exact match against `prometheus --version` first, newest available otherwise. It logs which binary it chose and why, explicitly calling out when the winner is *not* first on PATH. The failure message now also names the binary and points at the version-skew explanation.

A validator *newer* than the server can only be over-permissive (it accepts fields the server ignores). An *older* one produces false rejections like this one — that's the failure worth engineering against.

## Verified against the live host

```
prometheus                   : 2.53.5
/usr/local/bin/promtool      : 2.13.1
/usr/bin/promtool            : 2.53.5
CHOSEN      : /usr/bin/promtool
NOTE        : promtool: using /usr/bin/promtool (v2.53.5, matches Prometheus)
              — NOT the first on PATH (/usr/local/bin/promtool is v2.13.1)
```

The stale `/usr/local/bin/promtool` is being removed from the host separately; this keeps the script correct regardless, and turns a silent false rejection into a named one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp