### PR TITLE
fix(abs): register remove-from-continue-listening at the path the client actually calls

### DIFF
--- a/changelog.d/20260802_070000_rfcl_real_path.md
+++ b/changelog.d/20260802_070000_rfcl_real_path.md
@@ -1,0 +1,32 @@
+<!-- file: changelog.d/20260802_070000_rfcl_real_path.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 83d53b90-2e96-44bf-a436-931f06421779 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- **"Remove from Continue Listening" was registered at the wrong path AND the wrong
+  HTTP method, so every tap 404'd before reaching a handler.** It stayed broken
+  through two fix attempts because neither source we had could settle it: real ABS
+  2.36.0 has **no such route at all** (the oracle answers `Cannot POST`), and this
+  project's spec recorded the wrong shape.
+
+  AudioBooth's own source is the authority, and it says
+  (`SessionService.swift:181-193`, MPL-2.0):
+
+  ```swift
+  NetworkRequest(path: "/api/me/progress/\(progressID)/remove-from-continue-listening",
+                 method: .get)
+  ```
+
+  A **GET**, under **`/api/me/progress/:id`** — not the `POST /api/me/item/:id/…` we
+  had shipped. That is why nothing ever appeared in the audit log for it: the request
+  never matched a route.
+
+  Now registered at the real shape, plus three tolerated aliases (POST on the same
+  path, and both methods on the old `/api/me/item` form), since a 404 here is
+  user-visible breakage and an extra route costs nothing.
+
+  Spec §1.8.9 updated with the correction and with the rule it establishes: **where
+  the client and the oracle disagree, the client wins** — it is the thing making the
+  request; the oracle is authoritative only for routes real ABS actually serves.

--- a/docs/specs/2026-07-29-abs-sync-api-design.md
+++ b/docs/specs/2026-07-29-abs-sync-api-design.md
@@ -1,5 +1,5 @@
 <!-- file: docs/specs/2026-07-29-abs-sync-api-design.md -->
-<!-- version: 7.3.0 -->
+<!-- version: 7.4.0 -->
 <!-- guid: 0869d58c-b186-45cb-9915-64bd18eaa45f -->
 <!-- last-edited: 2026-08-02 -->
 
@@ -333,10 +333,24 @@ building the write half. Fixtures for all of it are committed under `testdata/ab
 
 2. **`POST /api/me/item/:id/remove-from-continue-listening` DOES NOT EXIST on ABS 2.36.0.** It answers
    `404 Cannot POST`. The real mechanism is `PATCH /api/me/progress/:id` with
-   `{"hideFromContinueListening": true}`. We serve **both**: the PATCH field because it is the genuine
-   mechanism, and the POST alias because a client calls it and was taking a 404 in production (the
-   owner-reported "remove from continue listening does nothing"). The alias answers `{}` — non-empty, per
-   §1.8.6.
+   `{"hideFromContinueListening": true}`.
+
+   🔴 **CORRECTED AGAIN 2026-08-02, from AudioBooth's own source** — the oracle could not answer this
+   because real ABS has no such route, and the shape recorded above (and in §1.8.6) was wrong, so the
+   feature stayed broken through two fix attempts. `SessionService.swift:181-193`:
+
+   ```swift
+   NetworkRequest(path: "/api/me/progress/\(progressID)/remove-from-continue-listening",
+                  method: .get)
+   ```
+
+   It is a **GET**, and it hangs off **`/api/me/progress/:id`** — not a POST on `/api/me/item/:id`.
+   `:id` is the mediaProgress ROW id. The response must be a non-empty JSON object (`{}` suffices):
+   the client decodes into an empty `struct Response: Codable {}` and its NetworkService treats an
+   empty body as a decoding error even on a 2xx.
+
+   **Where the client and the oracle disagree, the CLIENT wins** — it is the thing making the request.
+   The oracle is authoritative only for routes real ABS actually serves.
 
 Verified response shapes for the whole write half (note that three of them are **`text/plain`**, not JSON):
 

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
 // last-edited: 2026-08-02
 
@@ -392,12 +392,33 @@ func (h *Handler) Register(r gin.IRouter) {
 	r.PATCH("/api/me/progress/:id", auth, h.MediaProgressPatch)
 	r.PATCH("/api/me/progress/batch/update", auth, h.MediaProgressBatchUpdate)
 	r.DELETE("/api/me/progress/:id", auth, h.MediaProgressDelete)
-	// Real ABS 2.36.0 has NO such route — it answers "Cannot POST" — and the
-	// mechanism is really a hideFromContinueListening PATCH (verified against the
-	// oracle, 2026-08-02). It is registered anyway because a client calls it and
-	// §1.8.6/spec:318 records that it must answer a NON-EMPTY body; a 404 is what
-	// the owner reported as "remove from continue listening does nothing".
+	// ── remove from Continue Listening ──────────────────────────────────────
+	//
+	// 🔴 THE PATH AND THE METHOD ARE BOTH NON-OBVIOUS. Read before "tidying".
+	//
+	// Verified against AudioBooth's own source (SessionService.swift:181-193,
+	// MPL-2.0), which is the authority here — the oracle has no such route at all
+	// and this spec's §1.8.6 recorded the wrong shape:
+	//
+	//	NetworkRequest(path: "/api/me/progress/\(progressID)/remove-from-continue-listening",
+	//	               method: .get)
+	//
+	// So it is a **GET**, not a POST, and it hangs off **/api/me/progress/:id**,
+	// not /api/me/item/:id. We shipped only the POST-on-/api/me/item form, so every
+	// tap 404'd before reaching a handler — which is exactly why the owner reported
+	// this as still broken after the Phase 6 write half shipped.
+	//
+	// :id is the mediaProgress ROW id; resolveBookID accepts that and the bare
+	// libraryItemId. The response must be a NON-EMPTY JSON object: the client
+	// decodes into an empty `struct Response: Codable {}` and NetworkService treats
+	// an empty body as a decoding error (§1.8.6).
+	r.GET("/api/me/progress/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
+	// Tolerated aliases. Cheap, and each is a shape some ABS client or a future
+	// AudioBooth version could plausibly use; a 404 here is user-visible breakage
+	// while an extra route costs nothing.
+	r.POST("/api/me/progress/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
 	r.POST("/api/me/item/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
+	r.GET("/api/me/item/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
 
 	if h.bookmarks == nil {
 		return

--- a/internal/server/handlers/abs/remove_continue_listening_test.go
+++ b/internal/server/handlers/abs/remove_continue_listening_test.go
@@ -1,0 +1,133 @@
+// file: internal/server/handlers/abs/remove_continue_listening_test.go
+// version: 1.0.0
+// guid: 6c07d13a-b284-4e59-90f7-1a53e2c8b046
+// last-edited: 2026-08-02
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// "Remove from Continue Listening" stayed broken after the Phase 6 write half
+// shipped, and neither the reference oracle nor this project's spec explained why:
+// ABS 2.36.0 has no such route at all, and §1.8.6 recorded the wrong shape.
+//
+// AudioBooth's own source settled it (SessionService.swift:181-193, MPL-2.0):
+//
+//	NetworkRequest(path: "/api/me/progress/\(progressID)/remove-from-continue-listening",
+//	               method: .get)
+//
+// A **GET**, under **/api/me/progress/:id** — not the POST-on-/api/me/item form we
+// had registered. Every tap 404'd before reaching a handler, which is why nothing
+// appeared in the audit log for it.
+//
+// These tests pin the client's exact call so a future "cleanup" cannot quietly drop
+// it back to the shape the spec claims.
+
+// TestRemoveFromContinueListening_ClientsExactCall is the regression that matters:
+// the precise method and path AudioBooth sends.
+func TestRemoveFromContinueListening_ClientsExactCall(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 600.0})
+
+	// progressID is the mediaProgress row id — what the client holds.
+	code, _, raw := w.req(t, http.MethodGet,
+		"/api/me/progress/"+w.rowID()+"/remove-from-continue-listening", nil)
+	if code != http.StatusOK {
+		t.Fatalf("GET .../remove-from-continue-listening = %d %s — this is the exact call "+
+			"AudioBooth makes; a non-200 means the feature is dead on the device", code, raw)
+	}
+	// 🔴 NetworkService treats an empty body as a decoding error even on a 2xx, and
+	// the client decodes into an empty `struct Response: Codable {}` — so the body
+	// must be a non-empty JSON object (§1.8.6).
+	if raw == "" {
+		t.Fatal("empty 200 body — the client's decoder fails on it (§1.8.6)")
+	}
+
+	row := w.getRow(t)
+	if row["hideFromContinueListening"] != true {
+		t.Fatalf("hideFromContinueListening = %#v, want true", row["hideFromContinueListening"])
+	}
+	// Hiding is not forgetting: the position must survive.
+	if got := num(t, row, "currentTime"); got != 600 {
+		t.Fatalf("currentTime = %v, want 600 — hiding must not discard the position", got)
+	}
+	if ids := continueListeningIDs(t, w); contains(ids, w.syncID) {
+		t.Fatalf("book is still on the Continue Listening shelf: %v", ids)
+	}
+}
+
+// TestRemoveFromContinueListening_AcceptsTheLibraryItemIDToo — the client sends the
+// row id, but the bare libraryItemId is the other id a client can plausibly hold,
+// and resolveBookID accepts both. Pinned so the tolerance is not lost.
+func TestRemoveFromContinueListening_AcceptsTheLibraryItemIDToo(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 600.0})
+
+	code, _, raw := w.req(t, http.MethodGet,
+		"/api/me/progress/"+w.syncID+"/remove-from-continue-listening", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	if w.getRow(t)["hideFromContinueListening"] != true {
+		t.Fatal("the libraryItemId form did not hide the book")
+	}
+}
+
+// TestRemoveFromContinueListening_AllToleratedShapesWork covers the aliases. Each is
+// a shape some ABS client — or a future AudioBooth version — could plausibly send,
+// and a 404 on any of them is user-visible breakage for zero benefit.
+func TestRemoveFromContinueListening_AllToleratedShapesWork(t *testing.T) {
+	for name, tc := range map[string]struct{ method, prefix string }{
+		"GET  /api/me/progress": {http.MethodGet, "/api/me/progress/"},
+		"POST /api/me/progress": {http.MethodPost, "/api/me/progress/"},
+		"POST /api/me/item":     {http.MethodPost, "/api/me/item/"},
+		"GET  /api/me/item":     {http.MethodGet, "/api/me/item/"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := newWriteHarness(t)
+			w.patch(t, map[string]any{"currentTime": 600.0})
+
+			code, _, raw := w.req(t, tc.method,
+				tc.prefix+w.syncID+"/remove-from-continue-listening", map[string]any{})
+			if code != http.StatusOK {
+				t.Fatalf("%s = %d %s", name, code, raw)
+			}
+			if w.getRow(t)["hideFromContinueListening"] != true {
+				t.Fatalf("%s returned 200 but did not hide the book", name)
+			}
+		})
+	}
+}
+
+// TestRemoveFromContinueListening_RequiresAuth — the route must sit behind the
+// fail-closed identity middleware like every other /api/me path.
+func TestRemoveFromContinueListening_RequiresAuth(t *testing.T) {
+	w := newWriteHarness(t)
+	rec, _ := w.do(t, request{
+		method: http.MethodGet,
+		path:   "/api/me/progress/" + w.syncID + "/remove-from-continue-listening",
+	})
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d, want 401", rec.Code)
+	}
+}
+
+// TestRemoveFromContinueListening_DoesNotShadowTheProgressRead proves the two GETs
+// coexist: gin must route /api/me/progress/:id and
+// /api/me/progress/:id/remove-from-continue-listening independently. A mis-registered
+// tree would make one swallow the other, and the failure would look like a data bug.
+func TestRemoveFromContinueListening_DoesNotShadowTheProgressRead(t *testing.T) {
+	w := newWriteHarness(t)
+	w.patch(t, map[string]any{"currentTime": 600.0})
+
+	row := w.getRow(t) // GET /api/me/progress/:id — must still return the row
+	if got := num(t, row, "currentTime"); got != 600 {
+		t.Fatalf("GET /api/me/progress/:id returned currentTime %v, want 600", got)
+	}
+	if row["libraryItemId"] != w.syncID {
+		t.Fatalf("progress read returned the wrong item: %#v", row["libraryItemId"])
+	}
+}

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-02
 
@@ -392,7 +392,12 @@ func absRouteList() []string {
 		"PATCH /api/me/progress/:id",
 		"PATCH /api/me/progress/batch/update",
 		"DELETE /api/me/progress/:id",
+		// The shape AudioBooth actually sends (GET, under /api/me/progress) plus
+		// tolerated aliases — see Handler.Register.
+		"GET /api/me/progress/:id/remove-from-continue-listening",
+		"POST /api/me/progress/:id/remove-from-continue-listening",
 		"POST /api/me/item/:id/remove-from-continue-listening",
+		"GET /api/me/item/:id/remove-from-continue-listening",
 		// Phase 6 — bookmarks CRUD.
 		"GET /api/me/bookmarks/:id",
 		"POST /api/me/item/:id/bookmark",


### PR DESCRIPTION
## Why it stayed broken through two fix attempts

Neither source we had could settle the shape:

- **The reference oracle couldn't** — real ABS 2.36.0 has **no such route at all** (`Cannot POST`).
- **The spec was wrong** — §1.8.6 recorded `POST …/remove-from-continue-listening` on `/api/me/item/:id`.

So I shipped the spec's shape, it 404'd before reaching a handler, and **nothing appeared in the audit log** — which made it look like the client wasn't sending anything at all.

## The authority is the client's source

`SessionService.swift:181-193` (AudioBooth, MPL-2.0):

```swift
NetworkRequest(path: "/api/me/progress/\(progressID)/remove-from-continue-listening",
               method: .get)
```

**A `GET`, under `/api/me/progress/:id`** — wrong method *and* wrong path in what we shipped. `:id` is the mediaProgress row id (`resolveBookID` already accepts that and the bare `libraryItemId`).

Now registered at the real shape, plus three tolerated aliases (POST on the same path; both methods on the old `/api/me/item` form) — a 404 here is user-visible breakage and an extra route costs nothing.

## Full client-vs-implementation audit

Every `/api/me` path in the client's source, checked against our routes:

| Client call | Method | Ours | |
|---|---|---|---|
| `/api/me/progress/{bookID}` | PATCH | ✅ | |
| `/api/me/progress/{bookID}` | GET | ✅ | |
| `/api/me/progress/{progressID}` | DELETE | ✅ | confirmed working in prod |
| `/api/me/progress/{progressID}/remove-from-continue-listening` | **GET** | ❌→✅ | **this PR** |
| `/api/me/item/{bookID}/bookmark` | POST / PATCH | ✅ | |
| `/api/me/item/{bookID}/bookmark/{time}` | DELETE | ✅ | |
| `/api/me/listening-stats` | GET | ❌ 404 | follow-up — see below |
| `/api/me/listening-sessions` | GET | ❌ 404 | follow-up |
| `/api/me/stats/year/{year}` | GET | ❌ 404 | follow-up |
| `/api/me/item/listening-sessions/{id}` | GET | ❌ 404 | follow-up |

Note the client never calls `/api/me` — it gets user data from `/api/authorize`.

## Verification

The regression test issues the client's **exact** call and was verified to fail without the fix:

```
=== with only the old route ===
--- FAIL: TestRemoveFromContinueListening_ClientsExactCall
    GET .../remove-from-continue-listening = 404 404 page not found — this is the
    exact call AudioBooth makes; a non-200 means the feature is dead on the device

=== with the fix ===
ok  github.com/falkcorp/audiobook-organizer/internal/server/handlers/abs  2.066s
ok  github.com/falkcorp/audiobook-organizer/internal/server (TestABS route guard)
```

A companion test proves `GET /api/me/progress/:id` and `GET /api/me/progress/:id/remove-from-continue-listening` coexist in gin's tree rather than one shadowing the other.

## Spec

§1.8.9 updated with the correction and the rule it establishes: **where the client and the oracle disagree, the client wins** — it is the thing making the request. The oracle is authoritative only for routes real ABS actually serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp