### PR TITLE
feat(abs): serve the listening-stats family as 200 so the client's status dot stays green

### DIFF
--- a/changelog.d/20260802_080000_abs_stats_endpoints.md
+++ b/changelog.d/20260802_080000_abs_stats_endpoints.md
@@ -1,0 +1,37 @@
+<!-- file: changelog.d/20260802_080000_abs_stats_endpoints.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f3c5fecb-63ea-4028-a4b4-22fe634c19d7 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- **The app's connection indicator "turned orange randomly" because our deliberate
+  404s flipped it.** AudioBooth's `NetworkService` sets the server status on every
+  response — `guard 200...299 … else { updateStatus(.connectionError) }`, then
+  `updateStatus(.connected)` — and `.connectionError` is the orange dot on the home
+  screen. `/api/me/listening-stats` is fetched on every home-screen refresh and
+  answered 404 by design, so the dot flipped orange and back on every refresh.
+
+  Spec §1.8.6's reasoning ("callers use `try?`, so 404 is safe") was wrong twice:
+  `try?` swallows the *error* but the status side-effect already fired, and
+  `ListeningStats` has **four** required fields, not "~12".
+
+### Added
+
+- **Four listening-statistics endpoints**, all 200 with shape-complete, **truthful**
+  bodies: `GET /api/me/listening-stats`, `/api/me/listening-sessions`,
+  `/api/me/stats/year/:year`, `/api/me/item/listening-sessions/:id`.
+
+  `listening-stats` reports a real `totalTime`, summed from the per-book listened
+  totals the playback sync maintains. The per-day breakdowns are emitted **empty
+  rather than fabricated** — attributing a book's whole total to its last-activity
+  date would put invented numbers on the user's stats screen — and the session
+  histories are empty because play sessions are in-memory by design, which makes an
+  empty history the correct answer rather than a stub.
+
+  A store failure reports zeros with a 200 rather than a 5xx: a 5xx trips the same
+  indicator these endpoints exist to keep green.
+
+  ⚠️ Covers are deliberately **not** changed: the client builds cover URLs directly
+  for Nuke/AsyncImage rather than through `NetworkService`, so the ~80% of books with
+  no cover art cannot trip the indicator. `GET /api/items/:id/cover` → 404 stays.

--- a/docs/specs/2026-07-29-abs-sync-api-design.md
+++ b/docs/specs/2026-07-29-abs-sync-api-design.md
@@ -1,5 +1,5 @@
 <!-- file: docs/specs/2026-07-29-abs-sync-api-design.md -->
-<!-- version: 7.4.0 -->
+<!-- version: 7.5.0 -->
 <!-- guid: 0869d58c-b186-45cb-9915-64bd18eaa45f -->
 <!-- last-edited: 2026-08-02 -->
 
@@ -312,7 +312,7 @@ All of these tolerate failure, so **404/500 is strictly safer than a half-correc
 | `…/narrators` | `{"narrators":[]}` | wrapper key required |
 | `…/recent-episodes` | `{"episodes":[]}` | wrapper key required |
 | listening-sessions | all five of `total,numPages,page,itemsPerPage,sessions` | all required |
-| listening-stats / year-stats | **prefer 404** | ~12 non-optional fields; callers use `try?` |
+| listening-stats / year-stats | ~~prefer 404~~ **200, see §1.8.10** | the `try?` reasoning was wrong — a 404 flips the client's connection indicator |
 
 Also: **an empty `200` body is fatal** for any typed endpoint (`NetworkService.swift:224-227`), and
 `…/remove-from-continue-listening` needs a non-empty body (`{}` suffices). ⚠️ **Corrected 2026-08-02 —
@@ -373,6 +373,47 @@ make scrubbing backwards impossible. The stale-device clobber is prevented one s
 `max(local, session.currentTime)` ignoring timestamps, so a stale device is pulled forward and never has a
 behind position to push. Forward-only merging guards the one path with genuinely untrustworthy timestamps —
 offline replay, via `MergeOfflineReplay`.
+
+### 🔴 1.8.10 CORRECTION — a 404 is NOT free: it turns the client's status indicator orange
+
+**Supersedes §1.8.6's "prefer 404" guidance for the listening-stats family.** Established 2026-08-02
+from AudioBooth's source, after the owner reported the app's connection dot "still turns orange
+randomly".
+
+`NetworkService.performRequest` sets the server's status on **every** response:
+
+```swift
+guard 200...299 ~= httpResponse.statusCode else { … await updateStatus(.connectionError) }
+await updateStatus(.connected)
+```
+
+`.connectionError` is the **orange dot** on the home screen (`HomePage.connectionStatusColor`). So ANY
+non-2xx — including a deliberate 404 — flips the indicator, and the next 2xx flips it back.
+`/api/me/listening-stats` is fetched on every home-screen refresh, which produced exactly the reported
+random flicker.
+
+§1.8.6's reasoning ("callers use `try?`") was wrong twice over:
+
+1. `try?` swallows the **error**; the status **side effect** has already happened.
+2. `ListeningStats` has **four** required fields, not "~12": `totalTime`, `days`, `dayOfWeek`, `today`
+   (`recentSessions` and `items` are optional). All four are trivially satisfiable.
+
+**Rule:** on any endpoint the client reaches through `NetworkService`, prefer a shape-complete 200 with
+truthful zero/empty values over a 404. Reserve non-2xx for cases where the client must actually treat
+the call as failed.
+
+⚠️ **Covers are exempt** and must NOT be "fixed" the same way: the client builds cover URLs directly for
+Nuke/AsyncImage rather than going through `NetworkService`, so the ~80% of books with no cover art
+cannot trip the indicator. `GET /api/items/:id/cover` → 404 stays correct.
+
+Verified shapes (all four now served as 200):
+
+| Endpoint | Required fields |
+|---|---|
+| `GET /api/me/listening-stats` | `totalTime`, `today` (numbers); `days`, `dayOfWeek` (objects) |
+| `GET /api/me/listening-sessions` | `total`, `numPages`, `page`, `itemsPerPage`, `sessions[]` |
+| `GET /api/me/item/listening-sessions/:id` | `numPages`, `page`, `itemsPerPage`, `sessions[]` — **no `total`** |
+| `GET /api/me/stats/year/:year` | 6 numbers + `topAuthors`, `topGenres`, `booksWithCovers`, `finishedBooksWithCovers` |
 
 ### 1.8.7 Progress conflict resolution — client-side rules our server must respect
 

--- a/internal/server/acoustid_stats_handler_test.go
+++ b/internal/server/acoustid_stats_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/activity_handlers_test.go
+++ b/internal/server/activity_handlers_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/activity_integration_test.go
+++ b/internal/server/activity_integration_test.go
@@ -15,10 +15,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 )
 
 func TestActivity_Integration_RecordAndHTTPQuery(t *testing.T) {

--- a/internal/server/ai_jobs_handlers_test.go
+++ b/internal/server/ai_jobs_handlers_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/audio_sample.go
+++ b/internal/server/audio_sample.go
@@ -11,9 +11,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/audio"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // handleAudioSample streams a short MP3 clip from an audiobook file.

--- a/internal/server/auth_accept_invite.go
+++ b/internal/server/auth_accept_invite.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/internal/server/auth_lockout_test.go
+++ b/internal/server/auth_lockout_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
+	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -33,17 +33,17 @@ func (s *stubAuthStore) CreateUser(username, email, algo, hash string, roles []s
 	return nil, nil
 }
 func (s *stubAuthStore) GetRoleByID(id string) (*database.Role, error)     { return nil, nil }
-func (s *stubAuthStore) GetRoleByName(name string) (*database.Role, error)  { return nil, nil }
-func (s *stubAuthStore) GetSession(id string) (*database.Session, error)    { return nil, nil }
-func (s *stubAuthStore) GetUserByID(id string) (*database.User, error)      { return s.user, s.err }
+func (s *stubAuthStore) GetRoleByName(name string) (*database.Role, error) { return nil, nil }
+func (s *stubAuthStore) GetSession(id string) (*database.Session, error)   { return nil, nil }
+func (s *stubAuthStore) GetUserByID(id string) (*database.User, error)     { return s.user, s.err }
 func (s *stubAuthStore) GetUserByUsername(username string) (*database.User, error) {
 	return s.user, s.err
 }
 func (s *stubAuthStore) ListUserSessions(userID string) ([]database.Session, error) {
 	return nil, nil
 }
-func (s *stubAuthStore) RevokeSession(id string) error          { return nil }
-func (s *stubAuthStore) UpdateUser(user *database.User) error   { return nil }
+func (s *stubAuthStore) RevokeSession(id string) error        { return nil }
+func (s *stubAuthStore) UpdateUser(user *database.User) error { return nil }
 
 func newTestUser(t *testing.T) *database.User {
 	t.Helper()

--- a/internal/server/bench.go
+++ b/internal/server/bench.go
@@ -20,12 +20,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/ai"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 )

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -24,11 +24,11 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/bootstrap_security_test.go
+++ b/internal/server/bootstrap_security_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 // fakeSettingsStore is a minimal in-memory SettingsReadWriter that mirrors the

--- a/internal/server/cover_history.go
+++ b/internal/server/cover_history.go
@@ -16,11 +16,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/covers"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/security/safepath"
+	"github.com/gin-gonic/gin"
 )
 
 // handleListCoverHistory returns the cover art history for a book.

--- a/internal/server/cover_history_test.go
+++ b/internal/server/cover_history_test.go
@@ -14,10 +14,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/covers"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func setupCoverHistoryServer(t *testing.T) (*Server, database.Store, string) {

--- a/internal/server/covers.go
+++ b/internal/server/covers.go
@@ -14,11 +14,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/covers"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/security/safepath"
+	"github.com/gin-gonic/gin"
 )
 
 // handleCoverProxy proxies and caches cover images from external URLs.

--- a/internal/server/deluge_discovery.go
+++ b/internal/server/deluge_discovery.go
@@ -13,11 +13,11 @@ package server
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	delugeclient "github.com/falkcorp/audiobook-organizer/internal/deluge"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/importer"
+	"github.com/gin-gonic/gin"
 )
 
 // handleDelugeDiscover returns Deluge torrents not yet in the library.

--- a/internal/server/deluge_integration.go
+++ b/internal/server/deluge_integration.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/deluge"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // getDelugeClient is a package-level shim so server-internal code that still

--- a/internal/server/deluge_integration_test.go
+++ b/internal/server/deluge_integration_test.go
@@ -16,10 +16,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/deluge"
+	"github.com/gin-gonic/gin"
 )
 
 func TestNotifyDelugeMoveStorage_EmptyHash(t *testing.T) {

--- a/internal/server/diagnostics_ops.go
+++ b/internal/server/diagnostics_ops.go
@@ -15,8 +15,8 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/diagnostics"
-	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
 type diagnosticsExportOpParams struct {

--- a/internal/server/entity_tag_handlers.go
+++ b/internal/server/entity_tag_handlers.go
@@ -10,10 +10,10 @@ package server
 import (
 	"strconv"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // entityTagOps bundles the store operations for one tagged-entity type

--- a/internal/server/entity_tag_handlers_test.go
+++ b/internal/server/entity_tag_handlers_test.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func setupEntityTagServer(t *testing.T) (*Server, database.Store) {

--- a/internal/server/error_handler_test.go
+++ b/internal/server/error_handler_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 func TestRespondWithBadRequest(t *testing.T) {

--- a/internal/server/file_ops_handlers.go
+++ b/internal/server/file_ops_handlers.go
@@ -12,8 +12,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 type pendingFileOp struct {

--- a/internal/server/fingerprint_rescan.go
+++ b/internal/server/fingerprint_rescan.go
@@ -8,9 +8,9 @@ package server
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/fingerprint"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // FingerprintRescanRequest controls the scope of a manual fingerprint rescan.

--- a/internal/server/fingerprint_rescan_test.go
+++ b/internal/server/fingerprint_rescan_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/handlers/abs/abs_test.go
+++ b/internal/server/handlers/abs/abs_test.go
@@ -258,10 +258,11 @@ func (f *fakeVerifier) Verify(_ context.Context, raw string) (*oauth.IdentityCla
 // ── fake user-data provider (Phase 6 stand-in) ──────────────────────────────
 
 type fakeUserData struct {
-	progress    []any
-	bookmarks   []any
-	progressFor map[string]any
-	err         error
+	progress        []any
+	bookmarks       []any
+	progressFor     map[string]any
+	listenedSeconds float64
+	err             error
 }
 
 func (f *fakeUserData) MediaProgress(string) ([]any, error) { return f.progress, f.err }
@@ -271,6 +272,15 @@ func (f *fakeUserData) Bookmarks(string) ([]any, error)     { return f.bookmarks
 // SAME error is reported (so a broken provider still yields a 5xx rather than a 404,
 // which is the distinction GET /api/me/progress/:id exists to preserve), and a
 // missing row is reported as ok=false rather than as an empty object.
+// ListenedSeconds mirrors the real provider's forgiving contract: statistics are
+// cosmetic, so a broken store reports 0 rather than failing the request.
+func (f *fakeUserData) ListenedSeconds(string) (float64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.listenedSeconds, nil
+}
+
 func (f *fakeUserData) MediaProgressFor(_, bookID string) (any, bool, error) {
 	if f.err != nil {
 		return nil, false, f.err

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/handler.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: fb0271c6-3a49-4d85-9e13-8c507b2ad64f
 // last-edited: 2026-08-02
 
@@ -77,6 +77,16 @@ type UserDataProvider interface {
 	// truncating to whole seconds — so two renderers that drift by a field or a
 	// rounding step turn into a book that will not stop re-syncing.
 	MediaProgressFor(userID, bookID string) (any, bool, error)
+
+	// ListenedSeconds is the user's total listened time across every book they
+	// have touched. It backs GET /api/me/listening-stats.
+	//
+	// Enumeration lives here rather than in the handler because this provider
+	// already owns the ONE user-keyed prefix scan that makes a complete per-user
+	// answer affordable on a request path (see userdata.go). A handler-side
+	// re-implementation would either duplicate that scan or reach for a
+	// whole-library one.
+	ListenedSeconds(userID string) (float64, error)
 }
 
 // BookmarkStore is the named-bookmark CRUD slice (pebble_store_bookmarks.go).
@@ -419,6 +429,20 @@ func (h *Handler) Register(r gin.IRouter) {
 	r.POST("/api/me/progress/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
 	r.POST("/api/me/item/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
 	r.GET("/api/me/item/:id/remove-from-continue-listening", auth, h.RemoveFromContinueListening)
+
+	// ── Phase 6: listening statistics ───────────────────────────────────────
+	//
+	// 200 rather than 404 — NOT cosmetic. AudioBooth's NetworkService flips the
+	// server's connection indicator to `.connectionError` (the orange dot) on ANY
+	// non-2xx, and /api/me/listening-stats is fetched on every home-screen refresh.
+	// See stats.go for why §1.8.6's "prefer 404" guidance was wrong.
+	r.GET("/api/me/listening-stats", auth, h.ListeningStats)
+	r.GET("/api/me/listening-sessions", auth, h.ListeningSessions)
+	r.GET("/api/me/stats/year/:year", auth, h.YearStats)
+	// Registered BEFORE the bookmark block so it is not gated on a bookmark store,
+	// and note the literal "listening-sessions" sits where /api/me/item/:id would —
+	// gin routes the static sibling ahead of the wildcard, which the tests pin.
+	r.GET("/api/me/item/listening-sessions/:id", auth, h.ItemListeningSessions)
 
 	if h.bookmarks == nil {
 		return

--- a/internal/server/handlers/abs/stats.go
+++ b/internal/server/handlers/abs/stats.go
@@ -1,0 +1,186 @@
+// file: internal/server/handlers/abs/stats.go
+// version: 1.0.0
+// guid: a71e5c04-3d68-4b29-85f0-c26d914b7e38
+// last-edited: 2026-08-02
+
+package abs
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// Listening statistics.
+//
+// 🔴 THESE EXIST TO STOP A 404, AND THE 404 WAS NOT HARMLESS.
+//
+// Spec §1.8.6 said to "prefer 404" here, reasoning that the endpoints carry ~12
+// non-optional fields and callers wrap them in `try?`. Both halves of that were
+// wrong, and the second one is the expensive mistake:
+//
+//  1. ListeningStats has FOUR required fields, not twelve
+//     (totalTime, days, dayOfWeek, today — recentSessions and items are optional).
+//     Verified against AudioBooth's own model, not inferred.
+//
+//  2. `try?` swallows the ERROR, but the SIDE EFFECT already happened.
+//     NetworkService.performRequest sets the server's status on every response:
+//
+//     guard 200...299 ~= httpResponse.statusCode else { ... updateStatus(.connectionError) }
+//     await updateStatus(.connected)
+//
+//     ANY non-2xx flips the connection indicator to `.connectionError` — the orange
+//     dot on the home screen — and the next 2xx flips it back. /api/me/listening-stats
+//     is requested on every home-screen refresh, so a deliberate 404 there showed up
+//     as the owner-reported "it still turns orange randomly".
+//
+// So these answer 200 with a SHAPE-COMPLETE, TRUTHFUL body. Truthful is the important
+// word: this server does not persist listening sessions (play sessions are in-memory
+// by design — see play.go), so an empty session history is the correct answer rather
+// than a placeholder. Only totals we can actually substantiate are reported.
+//
+// Covers do NOT go through this path — the client builds cover URLs directly for
+// Nuke/AsyncImage — so the ~80% of books with no cover art cannot trip the indicator.
+
+// listeningStatsResponse matches AudioBooth's `ListeningStats` exactly.
+//
+// days and dayOfWeek are objects keyed by date / weekday. They are emitted EMPTY, not
+// fabricated: attributing a book's whole listened total to its last-activity date
+// would put invented numbers on the user's stats screen, and this server keeps no
+// per-day listening history to derive them from honestly. Empty maps decode fine.
+type listeningStatsResponse struct {
+	Today     float64            `json:"today"`
+	TotalTime float64            `json:"totalTime"`
+	Days      map[string]float64 `json:"days"`
+	DayOfWeek map[string]float64 `json:"dayOfWeek"`
+}
+
+// ListeningStats handles GET /api/me/listening-stats.
+func (h *Handler) ListeningStats(c *gin.Context) {
+	user, ok := servermiddleware.CurrentUser(c)
+	if !ok || user == nil {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	total := 0.0
+	if h.userData != nil {
+		if seconds, err := h.userData.ListenedSeconds(user.ID); err == nil {
+			total = seconds
+		}
+		// A read failure reports 0 rather than 5xx. A 5xx trips the SAME
+		// connection-error indicator this endpoint exists to keep green, so failing
+		// here would swap one cosmetic bug for the identical one.
+	}
+
+	respondJSON(c, http.StatusOK, listeningStatsResponse{
+		Today:     0, // no per-day history to derive this from; see the type comment
+		TotalTime: total,
+		Days:      map[string]float64{},
+		DayOfWeek: map[string]float64{},
+	})
+}
+
+// listeningSessionsPage matches AudioBooth's `ListeningHistoryResponse`. Every field
+// is required; `sessions` must be `[]` and never null.
+type listeningSessionsPage struct {
+	ItemsPerPage int   `json:"itemsPerPage"`
+	NumPages     int   `json:"numPages"`
+	Page         int   `json:"page"`
+	Sessions     []any `json:"sessions"`
+	Total        int   `json:"total"`
+}
+
+// ListeningSessions handles GET /api/me/listening-sessions.
+//
+// Always an empty page: play sessions are in-memory and deliberately not persisted
+// (play.go — the durable thing is the user's POSITION, which is written through on
+// every sync). An empty history is therefore the truthful answer, not a stub.
+func (h *Handler) ListeningSessions(c *gin.Context) {
+	if _, ok := servermiddleware.CurrentUser(c); !ok {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	respondJSON(c, http.StatusOK, listeningSessionsPage{
+		ItemsPerPage: queryInt(c, "itemsPerPage", 10),
+		NumPages:     0,
+		Page:         queryInt(c, "page", 0),
+		Sessions:     []any{},
+		Total:        0,
+	})
+}
+
+// itemListeningSessionsPage matches the anonymous response struct AudioBooth decodes
+// for GET /api/me/item/listening-sessions/:id. Note it has NO `total` — the shapes
+// differ between the two session endpoints, so they do not share a type.
+type itemListeningSessionsPage struct {
+	ItemsPerPage int   `json:"itemsPerPage"`
+	NumPages     int   `json:"numPages"`
+	Page         int   `json:"page"`
+	Sessions     []any `json:"sessions"`
+}
+
+// ItemListeningSessions handles GET /api/me/item/listening-sessions/:id.
+func (h *Handler) ItemListeningSessions(c *gin.Context) {
+	if _, ok := servermiddleware.CurrentUser(c); !ok {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	respondJSON(c, http.StatusOK, itemListeningSessionsPage{
+		ItemsPerPage: queryInt(c, "itemsPerPage", 10),
+		NumPages:     0,
+		Page:         queryInt(c, "page", 0),
+		Sessions:     []any{},
+	})
+}
+
+// yearStatsResponse matches AudioBooth's `YearStats`. The four optional pointers are
+// omitted; every array must be present and non-null.
+type yearStatsResponse struct {
+	BooksWithCovers           []string `json:"booksWithCovers"`
+	FinishedBooksWithCovers   []string `json:"finishedBooksWithCovers"`
+	NumBooksFinished          int      `json:"numBooksFinished"`
+	NumBooksListened          int      `json:"numBooksListened"`
+	TopAuthors                []any    `json:"topAuthors"`
+	TopGenres                 []any    `json:"topGenres"`
+	TotalBookListeningTime    float64  `json:"totalBookListeningTime"`
+	TotalListeningSessions    int      `json:"totalListeningSessions"`
+	TotalListeningTime        float64  `json:"totalListeningTime"`
+	TotalPodcastListeningTime float64  `json:"totalPodcastListeningTime"`
+}
+
+// YearStats handles GET /api/me/stats/year/:year.
+//
+// Zeroed for the same reason ListeningSessions is empty: a year breakdown needs
+// per-session history this server does not keep. The `:year` parameter is accepted
+// and ignored rather than validated — a client asking about a year we have no data
+// for should see an empty year, not an error.
+func (h *Handler) YearStats(c *gin.Context) {
+	if _, ok := servermiddleware.CurrentUser(c); !ok {
+		respondError(c, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	respondJSON(c, http.StatusOK, yearStatsResponse{
+		BooksWithCovers:         []string{},
+		FinishedBooksWithCovers: []string{},
+		TopAuthors:              []any{},
+		TopGenres:               []any{},
+	})
+}
+
+// queryInt reads a non-negative integer query parameter, falling back to def.
+// Echoing the client's own paging values keeps the response self-consistent.
+func queryInt(c *gin.Context, key string, def int) int {
+	raw := strings.TrimSpace(c.Query(key))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}

--- a/internal/server/handlers/abs/stats_test.go
+++ b/internal/server/handlers/abs/stats_test.go
@@ -1,0 +1,211 @@
+// file: internal/server/handlers/abs/stats_test.go
+// version: 1.0.0
+// guid: 0a6d29c8-51b7-4e30-bf94-8c73e105ad62
+// last-edited: 2026-08-02
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The listening-stats family used to answer 404 on purpose (spec §1.8.6). That was
+// wrong in a way `try?` hides: AudioBooth's NetworkService sets the server's
+// connection status on EVERY response —
+//
+//	guard 200...299 ~= httpResponse.statusCode else { ... updateStatus(.connectionError) }
+//	await updateStatus(.connected)
+//
+// — so any non-2xx flips the home-screen dot orange and the next 2xx flips it back.
+// /api/me/listening-stats is fetched on every home refresh, which is precisely the
+// owner-reported "it still turns orange randomly".
+//
+// The tests below therefore assert TWO things per endpoint: the status is 2xx (the
+// indicator stays green) and every field the client's decoder requires is present
+// with the right JSON type. A field-complete body behind a 404 would be useless, and
+// a 200 with a missing field throws in Swift's all-or-nothing decode.
+
+// requireNum asserts a JSON number is present at key.
+func requireNum(t *testing.T, body map[string]any, key string) float64 {
+	t.Helper()
+	v, ok := body[key]
+	if !ok {
+		t.Fatalf("required field %q is ABSENT — the client's decode throws on this", key)
+	}
+	n, ok := v.(float64)
+	if !ok {
+		t.Fatalf("field %q = %#v, want a JSON number", key, v)
+	}
+	return n
+}
+
+// requireArray asserts a non-null JSON array is present at key.
+func requireArray(t *testing.T, body map[string]any, key string) []any {
+	t.Helper()
+	v, ok := body[key]
+	if !ok {
+		t.Fatalf("required field %q is ABSENT", key)
+	}
+	arr, ok := v.([]any)
+	if !ok || arr == nil {
+		t.Fatalf("field %q = %#v, want a non-null JSON array", key, v)
+	}
+	return arr
+}
+
+// requireObject asserts a non-null JSON object is present at key.
+func requireObject(t *testing.T, body map[string]any, key string) map[string]any {
+	t.Helper()
+	v, ok := body[key]
+	if !ok {
+		t.Fatalf("required field %q is ABSENT", key)
+	}
+	obj, ok := v.(map[string]any)
+	if !ok || obj == nil {
+		t.Fatalf("field %q = %#v, want a non-null JSON object", key, v)
+	}
+	return obj
+}
+
+// 🔴 TestListeningStats_Is200SoTheConnectionDotStaysGreen is the whole point.
+func TestListeningStats_Is200SoTheConnectionDotStaysGreen(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/listening-stats", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s — any non-2xx flips AudioBooth's connection indicator orange", code, raw)
+	}
+	// ListeningStats' four required fields. recentSessions and items are optional.
+	requireNum(t, body, "totalTime")
+	requireNum(t, body, "today")
+	requireObject(t, body, "days")
+	requireObject(t, body, "dayOfWeek")
+}
+
+// TestListeningStats_ReportsRealListenedTime — the total is substantiated from the
+// per-book state the playback sync maintains, not a placeholder.
+func TestListeningStats_ReportsRealListenedTime(t *testing.T) {
+	w := newWriteHarness(t)
+
+	code, play, raw := w.req(t, http.MethodPost, "/api/items/"+w.syncID+"/play", map[string]any{})
+	if code != http.StatusOK {
+		t.Fatalf("play = %d %s", code, raw)
+	}
+	sessionID, _ := play["id"].(string)
+	if code, _, raw := w.req(t, http.MethodPost, "/api/session/"+sessionID+"/sync",
+		map[string]any{"currentTime": 900.0, "timeListened": 450.0}); code != http.StatusOK {
+		t.Fatalf("sync = %d %s", code, raw)
+	}
+
+	_, body, _ := w.req(t, http.MethodGet, "/api/me/listening-stats", nil)
+	if got := requireNum(t, body, "totalTime"); got != 450 {
+		t.Fatalf("totalTime = %v, want 450 — the listened delta from the sync", got)
+	}
+}
+
+// TestListeningStats_StaysGreenWhenTheStoreFails: failing with a 5xx here would trip
+// the SAME orange indicator this endpoint exists to keep green, so a read failure
+// reports 0 instead.
+func TestListeningStats_StaysGreenWhenTheStoreFails(t *testing.T) {
+	seed := seedOracleLibrary(t)
+	broken := &fakeUserData{}
+	h := newHarness(t, "jwt", nil, withLibrary(seed), withUserData(broken))
+	h.seedUser(t, "u1", "oracle", "", "pw-pw-pw-pw")
+	tok := str(t, userObj(t, h.login(t, "oracle", "pw-pw-pw-pw")), "accessToken")
+	broken.err = errString("store down")
+
+	rec, body := h.do(t, request{method: http.MethodGet, path: "/api/me/listening-stats", headers: bearer(tok)})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 — a 5xx turns the dot orange just like a 404 did", rec.Code)
+	}
+	if got := requireNum(t, body, "totalTime"); got != 0 {
+		t.Fatalf("totalTime = %v, want 0 when the store is unreadable", got)
+	}
+}
+
+func TestListeningSessions_ConformsToTheClientDecoder(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/listening-sessions?page=2&itemsPerPage=25", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	// ListeningHistoryResponse: all five required.
+	requireNum(t, body, "total")
+	requireNum(t, body, "numPages")
+	requireArray(t, body, "sessions")
+	if got := requireNum(t, body, "page"); got != 2 {
+		t.Fatalf("page = %v, want the requested 2", got)
+	}
+	if got := requireNum(t, body, "itemsPerPage"); got != 25 {
+		t.Fatalf("itemsPerPage = %v, want the requested 25", got)
+	}
+}
+
+func TestItemListeningSessions_ConformsToTheClientDecoder(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/item/listening-sessions/"+w.syncID, nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	// This response has numPages/page/itemsPerPage/sessions — and NO total.
+	requireNum(t, body, "numPages")
+	requireNum(t, body, "page")
+	requireNum(t, body, "itemsPerPage")
+	requireArray(t, body, "sessions")
+}
+
+func TestYearStats_ConformsToTheClientDecoder(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/stats/year/2026", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	for _, key := range []string{
+		"totalListeningSessions", "totalListeningTime",
+		"totalBookListeningTime", "totalPodcastListeningTime",
+		"numBooksFinished", "numBooksListened",
+	} {
+		requireNum(t, body, key)
+	}
+	for _, key := range []string{"topAuthors", "topGenres", "booksWithCovers", "finishedBooksWithCovers"} {
+		requireArray(t, body, key)
+	}
+}
+
+// 🔴 TestItemListeningSessions_DoesNotShadowTheBookmarkRoutes. Both hang off
+// /api/me/item/: one with a LITERAL "listening-sessions" segment, one with a :id
+// wildcard. gin must route them independently — if the wildcard swallowed the
+// literal, bookmarks would break, and if the literal swallowed the wildcard, a book
+// whose id happened to collide would.
+func TestItemListeningSessions_DoesNotShadowTheBookmarkRoutes(t *testing.T) {
+	w := newWriteHarness(t)
+
+	if code, _, raw := w.req(t, http.MethodPost, "/api/me/item/"+w.syncID+"/bookmark",
+		map[string]any{"time": 30, "title": "still routable"}); code != http.StatusOK {
+		t.Fatalf("bookmark create = %d %s — the stats route shadowed it", code, raw)
+	}
+	code, body, raw := w.req(t, http.MethodGet, "/api/me/item/listening-sessions/"+w.syncID, nil)
+	if code != http.StatusOK {
+		t.Fatalf("item listening-sessions = %d %s", code, raw)
+	}
+	if _, present := body["sessions"]; !present {
+		t.Fatalf("item listening-sessions returned the wrong handler's body: %#v", body)
+	}
+}
+
+// TestStatsEndpoints_RequireAuth — statistics are user-scoped; they must sit behind
+// the same fail-closed middleware as the rest of /api/me.
+func TestStatsEndpoints_RequireAuth(t *testing.T) {
+	w := newWriteHarness(t)
+	for _, path := range []string{
+		"/api/me/listening-stats",
+		"/api/me/listening-sessions",
+		"/api/me/stats/year/2026",
+		"/api/me/item/listening-sessions/" + w.syncID,
+	} {
+		rec, _ := w.do(t, request{method: http.MethodGet, path: path})
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s = %d, want 401", path, rec.Code)
+		}
+	}
+}

--- a/internal/server/handlers/abs/userdata.go
+++ b/internal/server/handlers/abs/userdata.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/userdata.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 63289143-7fae-47b5-9ed9-888ac3c2034a
 // last-edited: 2026-08-02
 
@@ -467,6 +467,62 @@ func (p *userDataProvider) durationFor(bookID string) (float64, error) {
 		return float64(*book.Duration), nil
 	}
 	return 0, nil
+}
+
+// ListenedSeconds totals the user's listened time across every book they have
+// touched, from the per-book UserBookState the playback sync maintains.
+//
+// One user-keyed prefix scan for the book list, then bounded per-book state reads —
+// the same shape and the same cost as MediaProgress, and for the same reason: this
+// is a request path and nothing here may scan the library.
+//
+// A per-book state that cannot be read contributes 0 rather than failing the whole
+// total. That is the opposite of MediaProgress's discipline, and deliberately so: an
+// under-reported statistic is cosmetic, while an under-reported PROGRESS LIST makes
+// the client delete books (§1.8.1). Failing this call instead would turn a cosmetic
+// gap into an orange "connection error" on the client's home screen.
+func (p *userDataProvider) ListenedSeconds(userID string) (float64, error) {
+	if userID == "" {
+		return 0, errors.New("abs: userdata: userID is required")
+	}
+	positions, err := p.progress.ListUserPositionsSince(userID, time.Time{})
+	if err != nil {
+		return 0, fmt.Errorf("abs: userdata: list positions for user %s: %w", userID, err)
+	}
+	seen := make(map[string]struct{}, len(positions))
+	bookIDs := make([]string, 0, len(positions))
+	for _, pos := range positions {
+		if pos.BookID == "" {
+			continue
+		}
+		if _, dup := seen[pos.BookID]; dup {
+			continue
+		}
+		seen[pos.BookID] = struct{}{}
+		bookIDs = append(bookIDs, pos.BookID)
+	}
+	if len(bookIDs) == 0 {
+		return 0, nil
+	}
+
+	totals := make([]float64, len(bookIDs))
+	g := new(errgroup.Group)
+	g.SetLimit(p.concurrency)
+	for i := range bookIDs {
+		g.Go(func() error {
+			state, serr := p.progress.GetUserBookState(userID, bookIDs[i])
+			if serr == nil && state != nil && state.TotalListenedSeconds > 0 {
+				totals[i] = state.TotalListenedSeconds
+			}
+			return nil
+		})
+	}
+	_ = g.Wait() // no goroutine returns an error; see the note above
+	sum := 0.0
+	for _, t := range totals {
+		sum += t
+	}
+	return sum, nil
 }
 
 // Bookmarks returns the user's COMPLETE bookmark list, or an error.

--- a/internal/server/handlers/activity.go
+++ b/internal/server/handlers/activity.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // ActivityService is the narrow interface ActivityHandler requires from the

--- a/internal/server/handlers/ai.go
+++ b/internal/server/handlers/ai.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/ai"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
@@ -30,6 +29,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/handlers/ai_test.go
+++ b/internal/server/handlers/ai_test.go
@@ -12,13 +12,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	databasemocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/handlers/apikeys.go
+++ b/internal/server/handlers/apikeys.go
@@ -9,12 +9,12 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
 )
 
 // apiKeyRotationGraceWindow is how long the OLD key keeps working after a

--- a/internal/server/handlers/apikeys_test.go
+++ b/internal/server/handlers/apikeys_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/server/handlers/audiobooks/handler_crud.go
+++ b/internal/server/handlers/audiobooks/handler_crud.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	audiobookspkg "github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/falkcorp/audiobook-organizer/internal/batch"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -25,6 +24,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
+	"github.com/gin-gonic/gin"
 )
 
 // UpdateAudiobook handles PUT /audiobooks/:id. Full-column replacement via the

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -18,13 +18,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metadata"
 	"github.com/falkcorp/audiobook-organizer/internal/organizer"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
+	"github.com/gin-gonic/gin"
 )
 
 // relocateTargetAllowed reports whether absPath is inside an allowed directory

--- a/internal/server/handlers/audiobooks/handler_metadata.go
+++ b/internal/server/handlers/audiobooks/handler_metadata.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // maxHistoryLimit caps the ?limit= query param on the per-book metadata

--- a/internal/server/handlers/audiobooks/handler_tags.go
+++ b/internal/server/handlers/audiobooks/handler_tags.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // GetAudiobookTags handles GET /audiobooks/:id/tags.

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -11,10 +11,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/internal/server/handlers/auth_test.go
+++ b/internal/server/handlers/auth_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/server/handlers/cache.go
+++ b/internal/server/handlers/cache.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )

--- a/internal/server/handlers/diagnostics.go
+++ b/internal/server/handlers/diagnostics.go
@@ -21,13 +21,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/ai"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/diagnostics"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -120,13 +120,13 @@ type dbHealthMetadataCache struct {
 // parser) so the handler is mockable and package handlers never imports package
 // server.
 type DiagnosticsHandler struct {
-	store          database.Store         // full store (db-health type switch + apply/export paths)
-	diagService    DiagnosticsService     // diagnostics service (CollectAllBooks); may be nil
-	mergeService   MergeService           // merge service (MergeBooks); may be nil
+	store          database.Store           // full store (db-health type switch + apply/export paths)
+	diagService    DiagnosticsService       // diagnostics service (CollectAllBooks); may be nil
+	mergeService   MergeService             // merge service (MergeBooks); may be nil
 	embeddingStore *database.EmbeddingStore // embeddings health stats; may be nil
-	aiScanStore    *database.AIScanStore  // ai-scan health stats; may be nil
-	registry       OperationsRegistry     // shared ops registry (EnqueueOp only)
-	batchParser    *ai.OpenAIParser       // resolved from server.batchPoller.parser; may be nil
+	aiScanStore    *database.AIScanStore    // ai-scan health stats; may be nil
+	registry       OperationsRegistry       // shared ops registry (EnqueueOp only)
+	batchParser    *ai.OpenAIParser         // resolved from server.batchPoller.parser; may be nil
 }
 
 // NewDiagnosticsHandler constructs a DiagnosticsHandler. Field/param order:

--- a/internal/server/handlers/diagnostics_test.go
+++ b/internal/server/handlers/diagnostics_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	databasemocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/handlers/entities/handler.go
+++ b/internal/server/handlers/entities/handler.go
@@ -17,12 +17,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/handlers/entities/handler_test.go
+++ b/internal/server/handlers/entities/handler_test.go
@@ -12,13 +12,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/audiobooks"
 	"github.com/falkcorp/audiobook-organizer/internal/cache"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers/entities"
 	entitiesmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/entities/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/work"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/handlers/filesystem.go
+++ b/internal/server/handlers/filesystem.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/fileops"
@@ -28,6 +27,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
 	"github.com/falkcorp/audiobook-organizer/internal/scanner"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/handlers/itunes.go
+++ b/internal/server/handlers/itunes.go
@@ -150,8 +150,8 @@ type ITunesTestMappingRequest struct {
 
 // ITunesTestMappingResponse returns sample results from testing a mapping.
 type ITunesTestMappingResponse struct {
-	Tested   int                `json:"tested"`
-	Found    int                `json:"found"`
+	Tested   int                 `json:"tested"`
+	Found    int                 `json:"found"`
 	Examples []ITunesTestExample `json:"examples"`
 }
 

--- a/internal/server/handlers/itunes_test.go
+++ b/internal/server/handlers/itunes_test.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/handlers/metadata_cache.go
+++ b/internal/server/handlers/metadata_cache.go
@@ -17,11 +17,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metabatch"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+	"github.com/gin-gonic/gin"
 )
 
 // MetadataCacheBookStore is the narrow persistence interface required by

--- a/internal/server/handlers/oauth_login_sanitize_test.go
+++ b/internal/server/handlers/oauth_login_sanitize_test.go
@@ -13,11 +13,11 @@ func TestSanitizeReturn(t *testing.T) {
 		{"/library", "/library"},
 		{"/", "/"},
 		{"", ""},
-		{"//evil.com", ""},        // protocol-relative
-		{"/\\evil.com", ""},       // backslash → browser normalizes to //
-		{"/path\\x", ""},          // any backslash rejected
-		{"https://evil.com", ""},  // absolute URL
-		{"evil.com", ""},          // no leading slash
+		{"//evil.com", ""},       // protocol-relative
+		{"/\\evil.com", ""},      // backslash → browser normalizes to //
+		{"/path\\x", ""},         // any backslash rejected
+		{"https://evil.com", ""}, // absolute URL
+		{"evil.com", ""},         // no leading slash
 	}
 	for _, c := range cases {
 		if got := sanitizeReturn(c.in); got != c.want {

--- a/internal/server/handlers/operations/handler.go
+++ b/internal/server/handlers/operations/handler.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
@@ -38,6 +37,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	"github.com/falkcorp/audiobook-organizer/internal/sweep"
 	"github.com/falkcorp/audiobook-organizer/internal/undo"
+	"github.com/gin-gonic/gin"
 )
 
 // Handler hosts the operations-domain HTTP endpoints.

--- a/internal/server/handlers/operations/handler_test.go
+++ b/internal/server/handlers/operations/handler_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/scheduler"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers/operations"
 	operationsmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/operations/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/undo"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/server/handlers/operations_v2.go
+++ b/internal/server/handlers/operations_v2.go
@@ -15,10 +15,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/gin-gonic/gin"
 )
 
 // OperationsRegistry is the narrow interface OperationsV2Handler requires from

--- a/internal/server/handlers/operations_v2_test.go
+++ b/internal/server/handlers/operations_v2_test.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	databasemocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/handlers/organize.go
+++ b/internal/server/handlers/organize.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/deluge"
@@ -29,6 +28,7 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/logger"
 	"github.com/falkcorp/audiobook-organizer/internal/organizer"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/handlers/playlists.go
+++ b/internal/server/handlers/playlists.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/playlist"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
+	"github.com/gin-gonic/gin"
 )
 
 // -----------------------------------------------------------------------
@@ -73,8 +73,8 @@ type PlaylistStore interface {
 
 // PlaylistHandler handles all /playlists routes.
 type PlaylistHandler struct {
-	store      PlaylistStore
-	indexFn    func() *search.BleveIndex // lazily resolved — smart playlists return 503 when nil
+	store   PlaylistStore
+	indexFn func() *search.BleveIndex // lazily resolved — smart playlists return 503 when nil
 }
 
 // NewPlaylistHandler constructs a PlaylistHandler.

--- a/internal/server/handlers/playlists_test.go
+++ b/internal/server/handlers/playlists_test.go
@@ -10,10 +10,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/handlers/plugins.go
+++ b/internal/server/handlers/plugins.go
@@ -6,10 +6,10 @@
 package handlers
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/plugin"
+	"github.com/gin-gonic/gin"
 )
 
 // PluginRegistrar is the narrow interface PluginsHandler requires for the plugin registry.

--- a/internal/server/handlers/reading.go
+++ b/internal/server/handlers/reading.go
@@ -6,12 +6,12 @@
 package handlers
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/readstatus"
 	svrmw "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
+	"github.com/gin-gonic/gin"
 )
 
 // SetPositionRequest is the JSON body for POST /api/v1/books/:id/position.

--- a/internal/server/handlers/split_book.go
+++ b/internal/server/handlers/split_book.go
@@ -13,11 +13,11 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
-	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	dedupengine "github.com/falkcorp/audiobook-organizer/internal/dedup"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/gin-gonic/gin"
 )
 
 // SplitBookOpEnqueuer is the narrow interface required to trigger a
@@ -40,7 +40,7 @@ type SplitBookCandidateStore interface {
 // when the embedding store is unavailable). Handlers check for nil and
 // return 503 gracefully.
 type SplitBookHandler struct {
-	opEnqueuer SplitBookOpEnqueuer    // may be nil
+	opEnqueuer SplitBookOpEnqueuer     // may be nil
 	candStore  SplitBookCandidateStore // may be nil
 	mergeStore database.Store          // required by MergeSplitBookCluster
 }

--- a/internal/server/handlers/system/interfaces.go
+++ b/internal/server/handlers/system/interfaces.go
@@ -14,10 +14,10 @@
 package system
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/sysinfo"
+	"github.com/gin-gonic/gin"
 )
 
 // SystemStore is the narrow database.Store subset the system handlers require.
@@ -40,9 +40,9 @@ type SystemStore interface {
 	database.SettingsStore // factoryReset -> config.SaveConfigToDatabase
 
 	// health metrics
-	CountPrimaryBooks() (int, error)   // BookStore
-	CountAuthors() (int, error) // StatsStore
-	CountSeries() (int, error)  // StatsStore
+	CountPrimaryBooks() (int, error) // BookStore
+	CountAuthors() (int, error)      // StatsStore
+	CountSeries() (int, error)       // StatsStore
 
 	// announcements
 	GetAllAuthors() ([]database.Author, error) // AuthorStore
@@ -55,8 +55,8 @@ type SystemStore interface {
 	GetSystemActivityLogs(source string, limit int) ([]database.SystemActivityLog, error) // SystemActivityStore
 
 	// reset / factory-reset
-	Reset() error             // LifecycleStore
-	InvalidateLibraryStats()  // StatsStore
+	Reset() error            // LifecycleStore
+	InvalidateLibraryStats() // StatsStore
 
 	// dashboard
 	GetDashboardStats() (*database.DashboardStats, error)        // StatsStore

--- a/internal/server/handlers/user_security_test.go
+++ b/internal/server/handlers/user_security_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/server/handlers/versions.go
+++ b/internal/server/handlers/versions.go
@@ -12,9 +12,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/handlers/versions_test.go
+++ b/internal/server/handlers/versions_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/handlers"
 	handlersmocks "github.com/falkcorp/audiobook-organizer/internal/server/handlers/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/import_collision.go
+++ b/internal/server/import_collision.go
@@ -9,9 +9,9 @@
 package server
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/importer"
+	"github.com/gin-gonic/gin"
 )
 
 // handleImportCollisionPreview checks whether importing a file

--- a/internal/server/import_collision_test.go
+++ b/internal/server/import_collision_test.go
@@ -14,9 +14,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/merge"
+	"github.com/gin-gonic/gin"
 )
 
 func setupImportCollisionServer(t *testing.T) (*Server, database.Store) {

--- a/internal/server/itl_cleanup.go
+++ b/internal/server/itl_cleanup.go
@@ -15,10 +15,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	"github.com/gin-gonic/gin"
 )
 
 // cleanupMergedHandler handles POST /api/v1/itunes/cleanup-merged.

--- a/internal/server/itl_pid.go
+++ b/internal/server/itl_pid.go
@@ -16,9 +16,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/itunes"
+	"github.com/gin-gonic/gin"
 )
 
 // pidIntegrityHandler handles GET/POST /api/v1/itunes/pid-integrity. Always

--- a/internal/server/itl_rebuild.go
+++ b/internal/server/itl_rebuild.go
@@ -23,12 +23,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
+	"github.com/gin-gonic/gin"
 )
 
 // ITLRebuildPreview summarizes the diff between the DB and the

--- a/internal/server/itl_relocate.go
+++ b/internal/server/itl_relocate.go
@@ -18,12 +18,12 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/itunes"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/security/pathvalidation"
+	"github.com/gin-gonic/gin"
 )
 
 // resolveITLWritePath reads and validates the configured ITL write path, writing

--- a/internal/server/itunes_path_ops.go
+++ b/internal/server/itunes_path_ops.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/library_list_warmer.go
+++ b/internal/server/library_list_warmer.go
@@ -675,13 +675,13 @@ func (s *Server) runTrickleWarmer(backlog []qry) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var (
-		idx        int
-		hits       int
-		misses     int
-		cached     int
-		skipped    int
-		resampled  int
-		backoff    time.Duration
+		idx       int
+		hits      int
+		misses    int
+		cached    int
+		skipped   int
+		resampled int
+		backoff   time.Duration
 	)
 	for idx < len(backlog) {
 		select {

--- a/internal/server/library_writeback_op.go
+++ b/internal/server/library_writeback_op.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"

--- a/internal/server/maintenance_dispatcher.go
+++ b/internal/server/maintenance_dispatcher.go
@@ -8,11 +8,11 @@ package server
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/maintenance"
+	"github.com/gin-gonic/gin"
 	ulid "github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/maintenance_fixups.go
+++ b/internal/server/maintenance_fixups.go
@@ -13,11 +13,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/activity"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // maintenanceStore is the narrow slice of database.Store that the
@@ -571,4 +571,3 @@ func (s *Server) handleGetAcoustIDStats(c *gin.Context) {
 	}
 	httputil.RespondWithOK(c, stats)
 }
-

--- a/internal/server/maintenance_window_handlers_test.go
+++ b/internal/server/maintenance_window_handlers_test.go
@@ -13,10 +13,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/scheduler"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/metadata_handlers_test.go
+++ b/internal/server/metadata_handlers_test.go
@@ -12,8 +12,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func setupRatingTestServer(t *testing.T) *Server {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/internal/server/middleware/auth_permission_test.go
+++ b/internal/server/middleware/auth_permission_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 // setupAuthTestStore returns a PebbleStore with seed roles + one

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/middleware/basicauth.go
+++ b/internal/server/middleware/basicauth.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/gin-gonic/gin"
 )
 
 // BasicAuth returns a Gin middleware that enforces HTTP Basic Authentication

--- a/internal/server/middleware/basicauth_test.go
+++ b/internal/server/middleware/basicauth_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
+	"github.com/gin-gonic/gin"
 )
 
 func setupBasicAuthRouter() *gin.Engine {

--- a/internal/server/middleware/ratelimit.go
+++ b/internal/server/middleware/ratelimit.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 	"golang.org/x/time/rate"
 )
 

--- a/internal/server/middleware/request_size.go
+++ b/internal/server/middleware/request_size.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 func methodHasBody(method string) bool {

--- a/internal/server/openlibrary_service.go
+++ b/internal/server/openlibrary_service.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
 	"github.com/falkcorp/audiobook-organizer/internal/openlibrary"
 	"github.com/falkcorp/audiobook-organizer/internal/security/safepath"
+	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/operations_v2_handlers.go
+++ b/internal/server/operations_v2_handlers.go
@@ -13,9 +13,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // operationV2Response is the JSON shape returned by the timeline and single-op

--- a/internal/server/operations_v2_handlers_test.go
+++ b/internal/server/operations_v2_handlers_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	opsregistry "github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/server/playlist_handlers_test.go
+++ b/internal/server/playlist_handlers_test.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
+	"github.com/gin-gonic/gin"
 )
 
 // setupPlaylistTestServer wires a PebbleStore + Bleve index + Gin

--- a/internal/server/quarantine_handlers.go
+++ b/internal/server/quarantine_handlers.go
@@ -5,9 +5,9 @@
 package server
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // quarantineBook handles POST /api/v1/audiobooks/:id/quarantine

--- a/internal/server/reading_handlers_test.go
+++ b/internal/server/reading_handlers_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func setupReadingTestServer(t *testing.T) *Server {

--- a/internal/server/reconcile.go
+++ b/internal/server/reconcile.go
@@ -9,10 +9,10 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/reconcile"
+	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
 )
 

--- a/internal/server/reset_handler_test.go
+++ b/internal/server/reset_handler_test.go
@@ -13,9 +13,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 // TestResetSystem_Success tests the reset endpoint with successful reset

--- a/internal/server/server_coverage_phase2_test.go
+++ b/internal/server/server_coverage_phase2_test.go
@@ -12,10 +12,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/internal/server/server_import_file_mocks_test.go
+++ b/internal/server/server_import_file_mocks_test.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
@@ -24,6 +23,7 @@ import (
 	metamocks "github.com/falkcorp/audiobook-organizer/internal/metadata/mocks"
 	"github.com/falkcorp/audiobook-organizer/internal/operations"
 	queuemocks "github.com/falkcorp/audiobook-organizer/internal/operations/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/internal/server/server_queue_test.go
+++ b/internal/server/server_queue_test.go
@@ -10,8 +10,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	dbmocks "github.com/falkcorp/audiobook-organizer/internal/database/mocks"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/server/server_title_helpers.go
+++ b/internal/server/server_title_helpers.go
@@ -172,4 +172,3 @@ func stripSubtitle(title string) string {
 	}
 	return title
 }
-

--- a/internal/server/similar_books.go
+++ b/internal/server/similar_books.go
@@ -12,10 +12,10 @@ package server
 import (
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
+	"github.com/gin-gonic/gin"
 )
 
 // handleSimilarBooks returns books similar to the given book.

--- a/internal/server/similar_books_test.go
+++ b/internal/server/similar_books_test.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/search"
+	"github.com/gin-gonic/gin"
 )
 
 func setupSimilarBooksServer(t *testing.T) *Server {

--- a/internal/server/static_embed.go
+++ b/internal/server/static_embed.go
@@ -1,4 +1,5 @@
 //go:build embed_frontend
+
 // version: 1.1.0
 // file: internal/server/static_embed.go
 // last-edited: 2026-08-01

--- a/internal/server/static_nonembed.go
+++ b/internal/server/static_nonembed.go
@@ -1,4 +1,5 @@
 //go:build !embed_frontend
+
 // version: 1.1.0
 // file: internal/server/static_nonembed.go
 // last-edited: 2026-08-01

--- a/internal/server/update_handlers.go
+++ b/internal/server/update_handlers.go
@@ -6,9 +6,9 @@
 package server
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // getUpdateStatus returns the last update check info.

--- a/internal/server/user_handlers_test.go
+++ b/internal/server/user_handlers_test.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 )
 
 func setupUserHandlerServer(t *testing.T) (*Server, database.Store) {

--- a/internal/server/user_tags.go
+++ b/internal/server/user_tags.go
@@ -8,9 +8,9 @@ package server
 import (
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // normalizeTag normalizes a single tag by trimming whitespace, converting to lowercase,

--- a/internal/server/user_tags_authz_test.go
+++ b/internal/server/user_tags_authz_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/server/version_lifecycle.go
+++ b/internal/server/version_lifecycle.go
@@ -10,11 +10,11 @@ package server
 import (
 	"log/slog"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
+	"github.com/gin-gonic/gin"
 )
 
 // handleTrashVersion moves a version to trash.

--- a/internal/server/version_lifecycle_test.go
+++ b/internal/server/version_lifecycle_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/versions"
+	"github.com/gin-gonic/gin"
 )
 
 func setupVersionLifecycleServer(t *testing.T) (*Server, database.Store) {

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes.go
-// version: 1.4.0
+// version: 1.5.0
 // guid: 9c6b13f8-40a2-4e57-b18d-72e0a5c4d396
 // last-edited: 2026-08-02
 
@@ -398,6 +398,12 @@ func absRouteList() []string {
 		"POST /api/me/progress/:id/remove-from-continue-listening",
 		"POST /api/me/item/:id/remove-from-continue-listening",
 		"GET /api/me/item/:id/remove-from-continue-listening",
+		// Phase 6 — listening statistics. 200, not 404: any non-2xx flips the
+		// client's connection indicator orange (see stats.go).
+		"GET /api/me/listening-stats",
+		"GET /api/me/listening-sessions",
+		"GET /api/me/stats/year/:year",
+		"GET /api/me/item/listening-sessions/:id",
 		// Phase 6 — bookmarks CRUD.
 		"GET /api/me/bookmarks/:id",
 		"POST /api/me/item/:id/bookmark",

--- a/internal/server/wire_abs_routes_test.go
+++ b/internal/server/wire_abs_routes_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/wire_abs_routes_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 3ea1d764-95c8-4b02-8f31-6d70a5be2c49
 // last-edited: 2026-08-02
 
@@ -53,6 +53,8 @@ func TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute(t *testing.T) {
 		// not by an opaque id). Integer form on purpose: that is what AudioBooth
 		// sends here even when it round-trips the same value as a Double elsewhere.
 		":time": "100",
+		// The year-stats path parameter. Any 4-digit year; the handler ignores it.
+		":year": "2026",
 	}
 
 	checked := 0


### PR DESCRIPTION
> Stacked on #2116 — retarget to `main` once that merges.

## The orange dot was ours

The owner reported the connection indicator "still turns orange randomly". AudioBooth's `NetworkService` sets the server status on **every** response:

```swift
guard 200...299 ~= httpResponse.statusCode else { … await updateStatus(.connectionError) }
await updateStatus(.connected)
```

`.connectionError` **is** the orange dot (`HomePage.connectionStatusColor`). Any non-2xx flips it; the next 2xx flips it back. `/api/me/listening-stats` is fetched on every home-screen refresh and we answered **404 on purpose** — reproducing the reported flicker exactly. Production logs show 7+ such 404s in a single window.

Spec §1.8.6's reasoning was wrong twice:
1. `try?` swallows the **error**; the status **side effect** already fired.
2. `ListeningStats` has **four** required fields — `totalTime`, `days`, `dayOfWeek`, `today` — not the "~12" claimed. `recentSessions` and `items` are optional.

## What's added

Four endpoints, all 200, field-matched to the client's own decoders:

| Endpoint | Required fields |
|---|---|
| `/api/me/listening-stats` | `totalTime`, `today`; `days`, `dayOfWeek` (objects) |
| `/api/me/listening-sessions` | `total`, `numPages`, `page`, `itemsPerPage`, `sessions[]` |
| `/api/me/item/listening-sessions/:id` | `numPages`, `page`, `itemsPerPage`, `sessions[]` — **no `total`** |
| `/api/me/stats/year/:year` | 6 numbers + 4 arrays |

## Truthful, not stubbed

This is the part I'd want reviewed:

- `totalTime` is **real** — summed from the per-book listened totals the playback sync maintains, via a bounded pool over the user's own books (same shape and cost as `/api/me`; no library scan).
- The per-day breakdowns are **empty, not fabricated**. Attributing a book's whole listened total to its last-activity date would put invented numbers on the user's stats screen. We keep no per-day history, so `{}` is the honest answer.
- Session histories are empty because play sessions are **in-memory by design** (`play.go` — the durable thing is the position). An empty history is correct, not a stub.
- A store failure reports zeros with a **200**, not a 5xx — a 5xx trips the same indicator these endpoints exist to keep green.

## ⚠️ Covers deliberately unchanged

Tempting to "fix" the ~80% of books that 404 on cover art the same way. **Don't** — the client builds cover URLs directly for Nuke/AsyncImage rather than through `NetworkService`, so they cannot trip the indicator. `GET /api/items/:id/cover` → 404 stays correct. Recorded in the spec so nobody re-derives it.

## Verification

```
go test ./internal/server/handlers/abs/... -count=1   ok  28.779s
go test ./internal/server/ -run TestABS -count=1      ok  (route guard)
```

Tests assert both halves per endpoint: 2xx status *and* every client-required field present with the right JSON type. Plus a routing test that `/api/me/item/listening-sessions/:id` (literal segment) and `/api/me/item/:id/bookmark` (wildcard) don't shadow each other in gin's tree.

Spec §1.8.10 records the correction and the general rule: on any endpoint the client reaches through `NetworkService`, prefer a shape-complete 200 with truthful zeros over a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp