### PR TITLE
docs(todo): BookFile 2x duplication + millisecond durations corrupting ABS [skip changelog]

### DIFF
--- a/todo.d/2026-08-02-bookfile-duplication-and-duration-units.md
+++ b/todo.d/2026-08-02-bookfile-duplication-and-duration-units.md
@@ -1,0 +1,78 @@
+<!-- file: todo.d/2026-08-02-bookfile-duplication-and-duration-units.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9b41c7e2-05d8-4a63-b7f0-3e26c8149ad5 -->
+<!-- last-edited: 2026-08-02 -->
+
+## DATA: BookFile rows are duplicated 2× AND their durations are milliseconds, not seconds
+
+Found 2026-08-02 while chasing why the app showed **Hyperion at "0%, 48h 31m
+remaining"** on its Continue Listening shelf. Two independent defects compound, and
+either alone corrupts every duration-derived number on the ABS surface.
+
+### Measured, on `01KNDBK4MM369VJXA1QKQ6YR8S` ("Hyperion")
+
+```
+total BookFile rows: 298
+distinct tracks:     149   | tracks with >1 row: 148
+duplication factor:  2.00x
+
+duration min=521  max=1803755
+rows >50000 (impossible as SECONDS for one track — that is >13h): 297 of 298
+sum as-is       = 41276.8 h      <- what the code computes today
+sum if ms       =    41.3 h
+halved + ms     =    20.6 h      <- Hyperion's actual length ✓
+```
+
+### Defect 1 — every track has two BookFile rows
+
+One from the organized tree, one from the iTunes tree:
+
+```
+464039s track=1  data/books/audiobook-organizer/Dan Simmons/Hyperion/Hyperion
+464065s track=1  /iTunes Media/Audiobooks/Dan Simmons/01 Hyperion 001-149.mp3
+```
+
+The pair's durations differ by ~26 ms, so they are the same audio measured twice —
+not two genuine files.
+
+### Defect 2 — durations are stored in milliseconds
+
+`BookFile.Duration` is **seconds** by contract: the committed oracle fixture uses
+`Duration: 9975` for a 9975-second book, and `seedOracleLibrary` uses `1662` for
+~27-minute tracks. But 297 of these 298 rows are 6–7 digit values that only make
+sense as ms. Track 144 is the smoking gun — it carries **both** forms:
+
+```
+521534s   track=144   (milliseconds)
+   521s   track=144   (seconds — same value, correct unit)
+```
+
+### Why it matters
+
+`durationFor` (`abs/userdata.go`) and the mapper both sum `BookFile.Duration` as
+seconds, and §5b makes that sum the ONE authoritative duration for `media.duration`,
+the play session, `startOffset`, synthesized chapters, and the progress fraction. With
+a ~2000× inflated denominator, `currentTime / duration` rounds to zero — which is
+exactly the reported **"0%"** — and the remaining-time readout is nonsense.
+
+### Scope is UNKNOWN — measure before fixing
+
+Confirmed for this one book. Whether it is iTunes-import-specific or library-wide is
+**not** established, and that decides the size of the job:
+
+```bash
+# per book: row count vs distinct track count, and how many durations look like ms
+curl -sk -H "Authorization: Bearer $ABK" \
+  "https://127.0.0.1:8484/api/v1/audiobooks/<id>/files"
+```
+
+### Do not fix blind
+
+- Deduping BookFile rows is a **destructive prod mutation** — it needs a dry-run and
+  an explicit decision, and it interacts with the dedup subsystem and with
+  `books/itunes/**` being HANDS-OFF.
+- A units migration must be **idempotent and detectable**: track 144 proves both units
+  already coexist, so a blanket `/1000` would corrupt the rows that are already
+  correct. Any repair has to classify per row, not per book.
+- Fixing units without deduping (or vice versa) leaves the duration wrong by 2×,
+  which is still enough to misplace every chapter boundary.


### PR DESCRIPTION
Docs-only. Found while chasing why the app showed **Hyperion at "0%, 48h 31m remaining"** on Continue Listening.

## Measured on `01KNDBK4MM369VJXA1QKQ6YR8S`

```
total BookFile rows: 298
distinct tracks:     149   | tracks with >1 row: 148
duplication factor:  2.00x

duration min=521 max=1803755
rows >50000 (impossible as SECONDS for one track — >13h): 297 of 298
sum as-is    = 41276.8 h     <- what the code computes today
sum if ms    =    41.3 h
halved + ms  =    20.6 h     <- Hyperion's actual length ✓
```

## Two independent defects

**1. Every track has two rows** — one from the organized tree, one from iTunes:

```
464039s track=1  data/books/audiobook-organizer/Dan Simmons/Hyperion/Hyperion
464065s track=1  /iTunes Media/Audiobooks/Dan Simmons/01 Hyperion 001-149.mp3
```

Durations differ by ~26 ms — the same audio measured twice, not two genuine files.

**2. Durations are milliseconds.** `BookFile.Duration` is seconds by contract (the committed oracle fixture uses `9975` for a 9975-second book). Track 144 is the smoking gun — it carries **both** forms:

```
521534s  track=144   (milliseconds)
   521s  track=144   (seconds — same value, correct unit)
```

## Why it produces the "0%"

`durationFor` and the mapper sum these as seconds, and spec §5b makes that sum the **one** authoritative duration for `media.duration`, the play session, `startOffset`, synthesized chapters, and the progress fraction. A ~2000× inflated denominator rounds `currentTime / duration` to zero.

## Not fixed here, deliberately

- **Scope is unestablished** — confirmed for one book; iTunes-specific vs library-wide decides the size of the job. The fragment records the measurement command rather than guessing.
- **Deduping rows is a destructive prod mutation** — needs a dry-run and an explicit decision, and it interacts with the dedup subsystem and with `books/itunes/**` being hands-off.
- **A blanket `/1000` would corrupt the rows already stored correctly** — track 144 proves both units coexist, so any repair must classify per row, not per book.
- Fixing one half without the other still leaves duration wrong by 2×, enough to misplace every chapter boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp