### PR TITLE
fix(abs): make the Authors and Narrators tabs decodable by the client

### DIFF
--- a/changelog.d/20260802_090000_authors_narrators_decode.md
+++ b/changelog.d/20260802_090000_authors_narrators_decode.md
@@ -1,0 +1,31 @@
+<!-- file: changelog.d/20260802_090000_authors_narrators_decode.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1140b977-2b6b-4e4d-8d5d-603034447a68 -->
+<!-- last-edited: 2026-08-02 -->
+
+### Fixed
+
+- **The Authors and Narrators tabs were both blank in the app**, while both endpoints
+  answered `200`. Neither was a routing problem — both bodies were unparseable by the
+  client, so the failure was invisible in the access log.
+
+  **Authors:** real ABS switches response envelope when the caller paginates, and the
+  two shapes share no keys — `{"authors":[…]}` bare, versus
+  `{"results":[…],"total":…,"page":…,…}` with `?limit=&page=`. AudioBooth always
+  paginates and decodes into `Page<Author>`, whose `total` and `page` are required, so
+  the bare shape threw. We now serve whichever envelope the request asks for.
+
+  **Narrators:** every entry needs an `id`, which we never sent. The client's
+  `Narrator` declares `id` non-optionally, so one entry without it throws the entire
+  list. The id is now derived exactly as real ABS derives it —
+  `encodeURIComponent(base64(name))` — because narrators are not entities in ABS and
+  the name is the identity; a minted id would change on restart and rot every id the
+  client had cached. `numBooks` is omitted rather than sent as `0` (there is no
+  reverse narrator→book index, and `0` would render "0 books" beside every narrator).
+
+  **Why the fixtures missed both** — recorded as spec §1.8.11 so it does not recur:
+  the authors fixture was captured **without a query string**, so it pinned the shape
+  no client ever requests; and the narrators fixture body is `{"narrators": []}`, so
+  the conformance diff had **no element to compare** and passed vacuously. An empty
+  golden array pins nothing about its elements. A paginated-authors fixture is now
+  committed, and both element shapes have hand-written tests.

--- a/docs/specs/2026-07-29-abs-sync-api-design.md
+++ b/docs/specs/2026-07-29-abs-sync-api-design.md
@@ -1,5 +1,5 @@
 <!-- file: docs/specs/2026-07-29-abs-sync-api-design.md -->
-<!-- version: 7.5.0 -->
+<!-- version: 7.6.0 -->
 <!-- guid: 0869d58c-b186-45cb-9915-64bd18eaa45f -->
 <!-- last-edited: 2026-08-02 -->
 
@@ -414,6 +414,52 @@ Verified shapes (all four now served as 200):
 | `GET /api/me/listening-sessions` | `total`, `numPages`, `page`, `itemsPerPage`, `sessions[]` |
 | `GET /api/me/item/listening-sessions/:id` | `numPages`, `page`, `itemsPerPage`, `sessions[]` — **no `total`** |
 | `GET /api/me/stats/year/:year` | 6 numbers + `topAuthors`, `topGenres`, `booksWithCovers`, `finishedBooksWithCovers` |
+
+### 🔴 1.8.11 An EMPTY golden array pins nothing, and a fixture captured without query params pins the wrong shape
+
+Both the Authors and Narrators tabs rendered blank while both endpoints answered **200**. Neither was a
+routing problem — both bodies were unparseable, so nothing showed in the access log. Found 2026-08-02.
+
+**Authors — real ABS switches envelope on `limit`/`page`, and the two shapes share NO keys:**
+
+```
+GET …/authors                    -> {"authors":[…]}
+GET …/authors?limit=100&page=0   -> {"results":[…],"total":…,"limit":…,"page":…,"sortBy":…,"sortDesc":…,"minified":…}
+```
+
+AudioBooth **always** paginates (`?sort=name&minified=1&limit=100&page=0`) and decodes into `Page<Author>`,
+whose `total` and `page` use `try container.decode` — REQUIRED, not `decodeIfPresent`. We always served the
+bare shape, so the decode threw. This is exactly the failure §1.8.5 item 5 warned about; we had reproduced
+it, and **the committed fixture could not catch it because it was captured with no query string**. A second
+fixture (`get_api_libraries_id_authors_paginated.json`) now pins the paginated shape.
+
+**Narrators — the element needs an `id` we were not sending:**
+
+```swift
+public struct Narrator: Codable { public let id: String; public let name: String; public let numBooks: Int? }
+```
+
+`id` is non-optional, so one entry without it throws the whole list. **The conformance diff passed vacuously
+because the oracle fixture body is `{"narrators": []}`** — the fixture library has no narrators, so there was
+no element to compare.
+
+Narrators are **not entities** in ABS; the name IS the identity. Real ABS derives the id
+(`LibraryController.getNarrators`):
+
+```js
+id: encodeURIComponent(Buffer.from(name).toString('base64'))
+```
+
+Derive it the same way — a minted id would change on restart and rot every id the client cached. `numBooks`
+is optional and is **omitted** rather than sent as 0: there is no reverse narrator→book index, so a real
+count would need a library scan on a request path, and `0` would render "0 books" beside every narrator.
+
+**Two rules this establishes for every future fixture:**
+
+1. **A fixture must be captured with the query string the CLIENT actually sends.** Capturing the bare path
+   pins a shape no client ever requests.
+2. **An empty array in a golden fixture pins nothing about its elements.** Any endpoint whose fixture array
+   is empty needs a hand-written element-shape test, or a required field can go missing undetected.
 
 ### 1.8.7 Progress conflict resolution — client-side rules our server must respect
 

--- a/internal/server/handlers/abs/authors_narrators_test.go
+++ b/internal/server/handlers/abs/authors_narrators_test.go
@@ -1,0 +1,240 @@
+// file: internal/server/handlers/abs/authors_narrators_test.go
+// version: 1.0.0
+// guid: 4f8b23e7-16c0-4d95-a3e2-58971bd0c4fa
+// last-edited: 2026-08-02
+
+package abs_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The Authors and Narrators tabs both rendered EMPTY while both endpoints answered
+// 200. Neither was a routing problem — both bodies were unparseable by the client, so
+// the failure was invisible in the access log.
+//
+// Both causes are shape mismatches the committed fixtures could not catch:
+//
+//   - Authors: real ABS switches envelope when the caller paginates, and AudioBooth
+//     ALWAYS paginates. The fixture was captured WITHOUT query parameters, so it
+//     pinned the wrong one of the two shapes.
+//   - Narrators: the fixture body is `{"narrators": []}` — the oracle library has no
+//     narrators — so the conformance diff had no element to compare and passed
+//     vacuously. An empty golden array cannot pin an element shape.
+//
+// These tests assert the ELEMENT shapes directly, which is what neither fixture does.
+
+// ── authors ─────────────────────────────────────────────────────────────────
+
+// 🔴 TestAuthors_PaginatedRequestGetsThePageEnvelope is the Authors-tab regression.
+// AudioBooth sends `?sort=name&minified=1&limit=100&page=0` and decodes into
+// Page<Author>, whose `total` and `page` use `try container.decode` — REQUIRED, not
+// decodeIfPresent. Missing either throws and blanks the tab.
+func TestAuthors_PaginatedRequestGetsThePageEnvelope(t *testing.T) {
+	w := newWriteHarness(t)
+
+	code, body, raw := w.req(t, http.MethodGet,
+		"/api/libraries/"+w.libraryID()+"/authors?sort=name&minified=1&limit=100&page=0", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+
+	// The two fields whose absence threw.
+	requireNum(t, body, "total")
+	requireNum(t, body, "page")
+	results := requireArray(t, body, "results")
+	if len(results) == 0 {
+		t.Fatal("no authors in the page — the seeded library has two")
+	}
+
+	// Page<Author>'s element: id and name are non-optional.
+	first, _ := results[0].(map[string]any)
+	if first == nil {
+		t.Fatalf("results[0] is not an object: %#v", results[0])
+	}
+	for _, key := range []string{"id", "name"} {
+		v, ok := first[key].(string)
+		if !ok || v == "" {
+			t.Fatalf("author.%s = %#v, want a non-empty string (the client decodes it non-optionally)", key, first[key])
+		}
+	}
+}
+
+// TestAuthors_UnpaginatedRequestKeepsTheBareShape — the oracle's own behaviour, and
+// what the committed fixture pins. Both shapes must keep working.
+func TestAuthors_UnpaginatedRequestKeepsTheBareShape(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	requireArray(t, body, "authors")
+	if _, present := body["results"]; present {
+		t.Fatal("unpaginated request got the paginated envelope — real ABS returns the bare shape here")
+	}
+}
+
+// TestAuthors_TotalIsTheFullCountNotThePageSize — the client uses `total` to decide
+// whether more pages exist, so reporting the slice length would hide every author
+// past the first page.
+func TestAuthors_TotalIsTheFullCountNotThePageSize(t *testing.T) {
+	w := newWriteHarness(t)
+
+	_, all, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors", nil)
+	fullCount := len(requireArray(t, all, "authors"))
+	if fullCount < 2 {
+		t.Skipf("need >=2 authors to exercise paging, have %d", fullCount)
+	}
+
+	code, body, raw := w.req(t, http.MethodGet,
+		"/api/libraries/"+w.libraryID()+"/authors?limit=1&page=0", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	if got := len(requireArray(t, body, "results")); got != 1 {
+		t.Fatalf("results has %d entries, want 1 (limit=1)", got)
+	}
+	if got := int(requireNum(t, body, "total")); got != fullCount {
+		t.Fatalf("total = %d, want the full count %d — not the page size", got, fullCount)
+	}
+}
+
+// TestAuthors_PagePastTheEndIsEmptyNotAnError — a client scrolling past the last page
+// should see nothing more, not a failure.
+func TestAuthors_PagePastTheEndIsEmptyNotAnError(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet,
+		"/api/libraries/"+w.libraryID()+"/authors?limit=10&page=999", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	if got := len(requireArray(t, body, "results")); got != 0 {
+		t.Fatalf("results has %d entries past the end, want 0", got)
+	}
+}
+
+// ── narrators ───────────────────────────────────────────────────────────────
+
+// 🔴 TestNarrators_EveryEntryCarriesAnID is the Narrators-tab regression. AudioBooth's
+// `Narrator` declares `public let id: String` non-optionally, so one entry without it
+// throws the entire decode.
+func TestNarrators_EveryEntryCarriesAnID(t *testing.T) {
+	w := newWriteHarness(t)
+	w.seed.lib.addNarrators("Victor Bevine", "Homer, transl. Samuel Butler")
+
+	code, body, raw := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/narrators", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	narrators := requireArray(t, body, "narrators")
+	if len(narrators) == 0 {
+		// NOT a skip. An empty list is exactly how this bug survived: the committed
+		// oracle fixture is `{"narrators": []}`, so the conformance diff had no
+		// element to compare and passed vacuously. A test that skips on an empty
+		// library reproduces that same blind spot.
+		t.Fatal("no narrators in the seeded library — this assertion is about the ELEMENT " +
+			"shape, so an empty list makes it vacuous (that is how the missing id shipped)")
+	}
+	for i, raw := range narrators {
+		n, _ := raw.(map[string]any)
+		if n == nil {
+			t.Fatalf("narrators[%d] is not an object: %#v", i, raw)
+		}
+		id, ok := n["id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("narrators[%d].id = %#v — the client decodes it non-optionally and "+
+				"throws the WHOLE list without it", i, n["id"])
+		}
+		if name, ok := n["name"].(string); !ok || name == "" {
+			t.Fatalf("narrators[%d].name = %#v, want a non-empty string", i, n["name"])
+		}
+	}
+}
+
+// TestNarrators_IDMatchesTheRealABSFormula. Narrators are not entities in ABS — the
+// name IS the identity — so the id must be DERIVED, or it changes on restart and every
+// id the client cached rots. Real ABS uses
+// encodeURIComponent(Buffer.from(name).toString('base64')).
+//
+// Asserted through the HTTP RESPONSE rather than by calling the helper: a test that
+// recomputed the formula and compared it to itself would pass no matter what the
+// endpoint actually emits.
+func TestNarrators_IDMatchesTheRealABSFormula(t *testing.T) {
+	names := []string{
+		"Victor Bevine",
+		"Homer, transl. Samuel Butler", // comma + spaces
+		"Ellé Jones",                   // non-ASCII
+		"a?b&c=d",                      // characters that must survive escaping
+	}
+	w := newWriteHarness(t)
+	w.seed.lib.addNarrators(names...)
+
+	code, body, raw := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/narrators", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	byName := map[string]string{}
+	for _, entry := range requireArray(t, body, "narrators") {
+		if n, _ := entry.(map[string]any); n != nil {
+			name, _ := n["name"].(string)
+			id, _ := n["id"].(string)
+			byName[name] = id
+		}
+	}
+
+	for _, name := range names {
+		got, present := byName[name]
+		if !present {
+			t.Errorf("narrator %q missing from the response", name)
+			continue
+		}
+		want := url.QueryEscape(base64.StdEncoding.EncodeToString([]byte(name)))
+		if got != want {
+			t.Errorf("id for %q = %q, want %q (real ABS formula)", name, got, want)
+		}
+		// The id travels in a URL PATH segment (Narrator.imageURL builds
+		// api/narrators/<id>/image), so a raw '/' would split the path and address a
+		// different route. Base64 emits '/', which is why the escape is required.
+		if strings.Contains(got, "/") {
+			t.Errorf("id for %q = %q contains a raw '/', which breaks the image URL path", name, got)
+		}
+	}
+}
+
+// TestNarrators_NumBooksOmittedRatherThanZero — there is no reverse narrator->book
+// index, so a real count would need a library scan on a request path. The field is
+// optional in the client; omitting it beats rendering "0 books" beside every name.
+func TestNarrators_NumBooksOmittedRatherThanZero(t *testing.T) {
+	w := newWriteHarness(t)
+	w.seed.lib.addNarrators("Victor Bevine")
+	_, body, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/narrators", nil)
+	for _, raw := range requireArray(t, body, "narrators") {
+		n, _ := raw.(map[string]any)
+		if n == nil {
+			continue
+		}
+		if v, present := n["numBooks"]; present {
+			if count, ok := v.(float64); ok && count == 0 {
+				t.Fatal("numBooks is present and 0 — omit it instead of claiming the narrator has no books")
+			}
+		}
+	}
+}
+
+// TestAuthors_PaginatedConformsToOracle diffs our paginated body against a capture
+// from real ABS 2.36.0 taken with the CLIENT'S OWN query string. The pre-existing
+// authors fixture was captured without query parameters, so it pinned the bare shape
+// and could never have caught this.
+func TestAuthors_PaginatedConformsToOracle(t *testing.T) {
+	w := newWriteHarness(t)
+	code, body, raw := w.req(t, http.MethodGet,
+		"/api/libraries/"+w.libraryID()+"/authors?sort=name&minified=1&limit=100&page=0", nil)
+	if code != http.StatusOK {
+		t.Fatalf("got %d %s", code, raw)
+	}
+	assertConformant(t, "get_api_libraries_id_authors_paginated.json", body)
+}

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,12 +1,14 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
 // last-edited: 2026-08-02
 
 package abs
 
 import (
+	"encoding/base64"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -417,6 +419,15 @@ func (h *Handler) authorDTOs() ([]authorDTO, error) {
 }
 
 // LibraryAuthors handles GET /api/libraries/:libraryId/authors.
+//
+// 🔴 TWO RESPONSE SHAPES, chosen by whether the caller paginated. Real ABS does the
+// same (verified against the oracle 2026-08-02) and the shapes share no keys:
+//
+//	…/authors                    -> {"authors":[…]}
+//	…/authors?limit=100&page=0   -> {"results":[…],"total":…,"limit":…,"page":…,…}
+//
+// AudioBooth always paginates and decodes into Page<Author>, which requires `total`
+// and `page`. Serving the bare shape to it throws and blanks the Authors tab.
 func (h *Handler) LibraryAuthors(c *gin.Context) {
 	if !h.knownLibrary(c) {
 		return
@@ -426,7 +437,50 @@ func (h *Handler) LibraryAuthors(c *gin.Context) {
 		respondError(c, http.StatusInternalServerError, "could not list authors")
 		return
 	}
-	respondJSON(c, http.StatusOK, authorsResponse{Authors: authors})
+
+	_, hasLimit := c.GetQuery("limit")
+	_, hasPage := c.GetQuery("page")
+	if !hasLimit && !hasPage {
+		respondJSON(c, http.StatusOK, authorsResponse{Authors: authors})
+		return
+	}
+
+	total := len(authors)
+	limit := queryInt(c, "limit", total)
+	page := queryInt(c, "page", 0)
+	respondJSON(c, http.StatusOK, authorsPageResponse{
+		Limit:    limit,
+		Minified: c.Query("minified") == "1",
+		Page:     page,
+		// total is the FULL count, not the size of this slice — the client uses it to
+		// decide whether more pages exist.
+		Results:  pageSlice(authors, limit, page),
+		SortBy:   strings.TrimSpace(c.Query("sort")),
+		SortDesc: c.Query("desc") == "1",
+		Total:    total,
+	})
+}
+
+// pageSlice returns the requested window of items. A non-positive limit means "no
+// limit" (the caller sent ?page= alone), and a page past the end yields an EMPTY
+// slice rather than an error — a client scrolling past the last page should see
+// nothing more, not a failure.
+func pageSlice(items []authorDTO, limit, page int) []authorDTO {
+	if limit <= 0 || limit >= len(items) {
+		if page > 0 {
+			return []authorDTO{}
+		}
+		return items
+	}
+	start := page * limit
+	if start >= len(items) {
+		return []authorDTO{}
+	}
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[start:end]
 }
 
 // LibraryNarrators handles GET /api/libraries/:libraryId/narrators.
@@ -445,11 +499,25 @@ func (h *Handler) LibraryNarrators(c *gin.Context) {
 	out := make([]narratorDTO, 0, len(narrators))
 	for _, n := range narrators {
 		if name := strings.TrimSpace(n.Name); name != "" {
-			out = append(out, narratorDTO{Name: name})
+			out = append(out, narratorDTO{ID: narratorID(name), Name: name})
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	respondJSON(c, http.StatusOK, narratorsResponse{Narrators: out})
+}
+
+// narratorID derives a narrator's client-visible id from their name, matching real
+// ABS exactly (LibraryController.getNarrators):
+//
+//	id: encodeURIComponent(Buffer.from(name).toString('base64'))
+//
+// Derived rather than minted because narrators are NOT entities in Audiobookshelf —
+// the name is the identity. A generated id would change on restart and rot every id
+// the client had cached. url.QueryEscape is JavaScript's encodeURIComponent for this
+// alphabet: standard base64 emits only [A-Za-z0-9+/=], of which + / and = are the
+// only characters either function escapes, and both escape all three the same way.
+func narratorID(name string) string {
+	return url.QueryEscape(base64.StdEncoding.EncodeToString([]byte(name)))
 }
 
 // LibraryFilterData handles GET /api/libraries/:libraryId/filterdata.

--- a/internal/server/handlers/abs/dto_library.go
+++ b/internal/server/handlers/abs/dto_library.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/dto_library.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: c471e9a0-5b83-4d16-92fe-08a7c35d1b6e
-// last-edited: 2026-07-30
+// last-edited: 2026-08-02
 
 package abs
 
@@ -393,6 +393,33 @@ type authorsResponse struct {
 	Authors []authorDTO `json:"authors"`
 }
 
+// authorsPageResponse is what /api/libraries/:id/authors returns when the caller
+// sends pagination parameters.
+//
+// 🔴 REAL ABS SWITCHES ENVELOPE ON `limit`/`page`, and the two shapes share no keys.
+// Verified against the oracle 2026-08-02:
+//
+//	GET …/authors                    -> {"authors":[…]}
+//	GET …/authors?limit=100&page=0   -> {"results":[…],"total":…,"limit":…,"page":…,…}
+//
+// AudioBooth ALWAYS sends them (`?sort=name&minified=1&limit=100&page=0`) and decodes
+// into Page<Author>, whose `total` and `page` are `try container.decode` — REQUIRED,
+// not decodeIfPresent. Serving the bare shape to a paginated request therefore throws
+// in the client and the Authors tab renders empty with no error shown.
+//
+// This is precisely the failure §1.8.5 item 5 warned about ("abs-shim returns a bare
+// {authors:[…]} with neither → would throw"); we had reproduced it. The committed
+// fixture did not catch it because it was captured WITHOUT query parameters.
+type authorsPageResponse struct {
+	Limit    int         `json:"limit"`
+	Minified bool        `json:"minified"`
+	Page     int         `json:"page"`
+	Results  []authorDTO `json:"results"`
+	SortBy   string      `json:"sortBy,omitempty"`
+	SortDesc bool        `json:"sortDesc"`
+	Total    int         `json:"total"`
+}
+
 // narratorsResponse is /api/libraries/:id/narrators. The wrapper key is required
 // (§1.8.6) and entries are objects with a name and a book count.
 type narratorsResponse struct {
@@ -400,8 +427,27 @@ type narratorsResponse struct {
 }
 
 type narratorDTO struct {
-	Name     string `json:"name"`
-	NumBooks int    `json:"numBooks"`
+	// 🔴 ID IS REQUIRED BY THE CLIENT and was missing, which blanked the Narrators
+	// tab: AudioBooth's `Narrator` declares `public let id: String` non-optionally,
+	// so a narrator object without it throws the whole all-or-nothing decode.
+	//
+	// The committed oracle fixture is `{"narrators": []}` — the fixture library has
+	// no narrators — so the conformance diff had no element to compare and passed
+	// vacuously. An empty golden array cannot pin an element shape.
+	//
+	// Format matches real ABS exactly (LibraryController.getNarrators):
+	//   id: encodeURIComponent(Buffer.from(name).toString('base64'))
+	// Narrators are not entities in ABS — the name IS the identity — so the id has to
+	// be derived from the name rather than invented, or it would not survive a
+	// restart and the client's cached ids would rot.
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// NumBooks is a POINTER and omitted when unknown. There is no reverse
+	// narrator->book index in this store, so a real count would need a library scan
+	// on a request path. The field is optional in the client (`numBooks: Int?`), and
+	// omitting it is honest where emitting 0 would render "0 books" beside every
+	// narrator.
+	NumBooks *int `json:"numBooks,omitempty"`
 }
 
 // episodesResponse is /api/libraries/:id/recent-episodes — the podcast stub. The

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -95,6 +95,17 @@ func (f *fakeLibrary) addAuthor(id int, name string, bookIDs ...string) {
 	}
 }
 
+// addNarrators seeds narrator rows. The oracle's fixture library has none, so any
+// test asserting the narrator ELEMENT shape must seed its own — an empty list is
+// exactly how a missing required field shipped unnoticed.
+func (f *fakeLibrary) addNarrators(names ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, name := range names {
+		f.narrators = append(f.narrators, database.Narrator{ID: len(f.narrators) + i + 1, Name: name})
+	}
+}
+
 // ── LibraryStore ────────────────────────────────────────────────────────────
 
 func (f *fakeLibrary) GetBookByID(id string) (*database.Book, error) {

--- a/testdata/abs-fixtures/get_api_libraries_id_authors_paginated.json
+++ b/testdata/abs-fixtures/get_api_libraries_id_authors_paginated.json
@@ -1,0 +1,48 @@
+{
+  "request": {
+    "body": null,
+    "method": "GET",
+    "path": "/api/libraries/b5e3a5b2-a76e-471f-b18b-915e4716d053/authors?sort=name&minified=1&limit=100&page=0"
+  },
+  "response": {
+    "body": {
+      "limit": 100,
+      "minified": true,
+      "page": 0,
+      "results": [
+        {
+          "addedAt": 1785370201398,
+          "asin": null,
+          "description": null,
+          "id": "4c8fe05a-b38b-4e1f-9846-9b9ea23b8073",
+          "imagePath": null,
+          "lastFirst": "Homer",
+          "libraryId": "b5e3a5b2-a76e-471f-b18b-915e4716d053",
+          "name": "Homer",
+          "numBooks": 1,
+          "updatedAt": 1785370201398
+        },
+        {
+          "addedAt": 1785370201443,
+          "asin": null,
+          "description": null,
+          "id": "5d48ba82-7e75-49bd-8208-5e3f36e07a60",
+          "imagePath": null,
+          "lastFirst": "Homer, transl. Samuel Butler",
+          "libraryId": "b5e3a5b2-a76e-471f-b18b-915e4716d053",
+          "name": "transl. Samuel Butler Homer",
+          "numBooks": 1,
+          "updatedAt": 1785370201443
+        }
+      ],
+      "sortBy": "name",
+      "sortDesc": false,
+      "total": 2
+    },
+    "headers": {
+      "content-type": "application/json; charset=utf-8",
+      "etag": "W/\"270-Umrw7xTex/wKyGrH2VhHuGUG1xA\""
+    },
+    "status": 200
+  }
+}


### PR DESCRIPTION
Both tabs rendered **blank** while both endpoints answered **200**. Neither was a routing problem — both bodies were unparseable by the client, so the failure was completely invisible in the access log:

```
200 GET /api/libraries/…/narrators
200 GET /api/libraries/…/authors?sort=name&minified=1&limit=100&page=0
```

## Authors — real ABS switches envelope on `limit`/`page`

Verified against the live oracle; the two shapes share **no keys**:

| Request | Response keys |
|---|---|
| `/authors` | `authors` |
| `/authors?limit=100&page=0` | `results`, `total`, `limit`, `page`, `sortBy`, `sortDesc`, `minified` |

AudioBooth **always** paginates and decodes into `Page<Author>`:

```swift
self.total = try container.decode(Int.self, forKey: .total)   // REQUIRED
self.page  = try container.decode(Int.self, forKey: .page)    // REQUIRED
```

`try container.decode`, not `decodeIfPresent` — so the bare shape throws. This is precisely the failure spec §1.8.5 item 5 warned about ("abs-shim returns a bare `{authors:[…]}` with neither → would throw"); we had reproduced it. Now serves whichever envelope the request asks for.

## Narrators — the element needs an `id` we never sent

```swift
public struct Narrator: Codable { public let id: String; public let name: String; public let numBooks: Int? }
```

`id` is non-optional, so **one** entry without it throws the entire list. Now derived exactly as real ABS derives it (`LibraryController.getNarrators`):

```js
id: encodeURIComponent(Buffer.from(name).toString('base64'))
```

**Derived, not minted** — narrators aren't entities in ABS, the name *is* the identity, so a generated id would change on restart and rot every id the client cached. `numBooks` is **omitted** rather than sent as `0`: there's no reverse narrator→book index, so a real count needs a library scan on a request path, and `0` would render "0 books" beside every narrator.

## 🔑 Why the fixtures missed both — spec §1.8.11

This is the part worth carrying forward:

1. **The authors fixture was captured without a query string**, so it pinned the shape no client ever requests.
2. **The narrators fixture body is `{"narrators": []}`** — the oracle library has no narrators — so the conformance diff had **no element to compare** and passed vacuously.

Two rules now recorded: capture fixtures with the query string the *client* sends, and treat an empty golden array as pinning nothing about its elements.

## Verification

Both regressions verified to fail without the fix:

```
--- FAIL: TestAuthors_PaginatedRequestGetsThePageEnvelope
    required field "total" is ABSENT — the client's decode throws on this
--- FAIL: TestNarrators_EveryEntryCarriesAnID
    narrators[0].id = "" — the client decodes it non-optionally and throws the WHOLE list without it
```

```
go test ./internal/server/handlers/abs/... -count=1   ok  28.901s
go test ./internal/server/ -run TestABS -count=1      ok
```

The narrator test **seeds its own narrators and fails rather than skips** on an empty list — skipping would reproduce the exact blind spot that let this ship. A new `get_api_libraries_id_authors_paginated.json` fixture pins the paginated shape, and the `id`-formula test asserts through the HTTP response rather than recomputing the formula against itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp