### PR TITLE
fix(abs): serve only primary+organized library items, and stop counting them the slow way

### DIFF
--- a/changelog.d/20260803_010000_abs_primary_organized_items.md
+++ b/changelog.d/20260803_010000_abs_primary_organized_items.md
@@ -1,0 +1,32 @@
+<!-- file: changelog.d/20260803_010000_abs_primary_organized_items.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 92b1c34d-e852-4ac7-9971-5fa01eb0f75a -->
+<!-- last-edited: 2026-08-03 -->
+
+### Fixed
+
+- **The app listed 44,888 books where the library holds ~16,000, and every page took
+  1.3-3.0 s.** `GET /api/libraries/:id/items` counted and listed EVERY book row. The
+  app's own counts cache reports the real split — `total_books=44888`,
+  `organized_books=16491`, `unorganized_books=23928` — so roughly 28,000 raw imports,
+  iTunes-tree copies and alternate versions were being served as library items.
+
+  The item list now serves **primary versions that are organized into the library**,
+  excluding quarantined files, using the filtered store calls that already existed.
+
+- **Latency was a fixed full-library scan, not paging.** It was flat across pages
+  (page 0 = 2.01 s, page 9 = 1.29 s) because `CountAllBooks` iterates every `book:`
+  key **and `json.Unmarshal`s every book** purely to count them — 44,888 decodes per
+  request. The filtered count is now cached for 60 s, mirroring `CountPrimaryBooks`'s
+  existing TTL cache (PR #2021) rather than adding a second caching style. Reporting
+  the unfiltered total also made the client page forever into empty results, since it
+  uses `total` to decide whether another page exists.
+
+- **`sort` was silently ignored.** The client always sends
+  `sort=media.metadata.title` and the handler never read it, so the library was never
+  actually title-sorted. Now honoured via the sorted title index (O(offset+limit)),
+  with `?desc=1` reversing it.
+
+  No progress is at risk: §1.8.1 governs `mediaProgress`, a separate payload built
+  from the user's own position rows. A book that leaves the item list still appears in
+  `/api/me`, so the client deletes nothing.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
-// last-edited: 2026-08-02
+// last-edited: 2026-08-03
 
 package abs
 
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	servermiddleware "github.com/falkcorp/audiobook-organizer/internal/server/middleware"
@@ -148,6 +149,89 @@ func parsePageParams(c *gin.Context) pageParams {
 	return pageParams{Page: page, Limit: limit, Offset: page * limit}
 }
 
+// absItemsCountTTL bounds how long the filtered item count is served from cache.
+//
+// Short on purpose. The count is cosmetic — it drives the client's "is there another
+// page" decision — so a value a minute stale costs nothing, while recomputing it per
+// request costs a full-library scan. Mirrors primaryCountCacheTTL rather than
+// inventing a second caching style.
+const absItemsCountTTL = 60 * time.Second
+
+// absItemFilter builds the filter that defines WHAT THE LIBRARY IS on this surface.
+//
+// 🔴 Without it the app showed 44,888 items where the owner has ~16,000. The app's own
+// counts cache reports total_books=44888, organized_books=16491,
+// unorganized_books=23928 — the extra 28k are raw imports and iTunes-tree copies, plus
+// alternate versions of books already present.
+//
+//   - IsPrimaryVersion collapses alternate versions to a single entry.
+//   - LibraryState "organized" drops rows whose file is not in the managed library
+//     (pebble_store_stats.go computes its organized_books the same way, via a
+//     rootDir path prefix; the two are expected to agree and the acceptance check
+//     compares them).
+//   - ExcludeQuarantined: a quarantined file cannot be played, so listing it only
+//     produces a failed playback attempt.
+//
+// Sorting is honoured here too. The client always sends sort=media.metadata.title and
+// we previously IGNORED it, so the library was never actually title-sorted. SortBy
+// "title" is backed by a sorted radix index — O(offset+limit), not a full sort.
+func absItemFilter(c *gin.Context) database.BookSummaryFilter {
+	primary := true
+	f := database.BookSummaryFilter{
+		IsPrimaryVersion:   &primary,
+		LibraryState:       "organized",
+		ExcludeQuarantined: true,
+		SortAscending:      c.Query("desc") != "1",
+	}
+	// Only "title" is index-backed; anything else falls through to store default
+	// ordering rather than pretending to honour a sort we cannot do cheaply.
+	if strings.Contains(strings.ToLower(c.Query("sort")), "title") {
+		f.SortBy = "title"
+	}
+	return f
+}
+
+// countItems returns the filtered item count, cached for absItemsCountTTL.
+//
+// Keyed by the filter's identity so a differently-filtered request cannot be served
+// another filter's number — today only the sort varies (which does not change the
+// count), but keying it now means a future filter cannot silently reuse a stale total.
+func (h *Handler) countItems(f database.BookSummaryFilter) (int, error) {
+	key := itemsCountKey(f)
+	now := h.now()
+
+	h.itemsCountMu.Lock()
+	if entry, ok := h.itemsCount[key]; ok && now.Sub(entry.at) < absItemsCountTTL {
+		h.itemsCountMu.Unlock()
+		return entry.count, nil
+	}
+	h.itemsCountMu.Unlock()
+
+	// Computed OUTSIDE the lock: this is a full-library scan and holding the mutex
+	// across it would serialize every concurrent request behind one scan — turning a
+	// slow endpoint into a stalled one.
+	count, err := h.library.CountBookSummariesFiltered(f)
+	if err != nil {
+		return 0, err
+	}
+
+	h.itemsCountMu.Lock()
+	h.itemsCount[key] = itemsCountEntry{count: count, at: now}
+	h.itemsCountMu.Unlock()
+	return count, nil
+}
+
+// itemsCountKey identifies a filter for caching. Sort fields are deliberately
+// EXCLUDED — ordering cannot change how many rows match, and including them would
+// multiply the cache entries (and the scans) by the number of sort orders.
+func itemsCountKey(f database.BookSummaryFilter) string {
+	primary := "any"
+	if f.IsPrimaryVersion != nil {
+		primary = strconv.FormatBool(*f.IsPrimaryVersion)
+	}
+	return primary + "|" + f.LibraryState + "|" + strconv.FormatBool(f.ExcludeQuarantined)
+}
+
 // requestsPodcasts reports whether the caller is probing for podcast content.
 //
 // We hold no podcasts, so the correct answer is a well-formed EMPTY page: a 404 or a
@@ -181,14 +265,28 @@ func (h *Handler) LibraryItems(c *gin.Context) {
 		return
 	}
 
-	total, err := h.library.CountAllBooks()
+	filter := absItemFilter(c)
+
+	// 🔴 The FILTERED count, not CountAllBooks.
+	//
+	// Two separate reasons, and both bit us:
+	//
+	//  1. Correctness. CountAllBooks counts every row — 44,888 — while this endpoint
+	//     now serves only primary+organized items (16,491). Reporting the unfiltered
+	//     total makes the client page past the end into empty results forever.
+	//  2. Cost. CountAllBooks iterates every book: key AND json.Unmarshals every book
+	//     purely to count them (pebble_store.go:2509). That is a full 44,888-book
+	//     decode on EVERY request, and it is why latency was a flat ~2s regardless of
+	//     which page was asked for. Same hotspot class as CountPrimaryBooks, fixed in
+	//     PR #2021.
+	total, err := h.countItems(filter)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not count library items")
 		return
 	}
 	resp.Total = total
 
-	summaries, err := h.library.GetAllBookSummaries(p.Limit, p.Offset)
+	summaries, err := h.library.GetAllBookSummariesFiltered(p.Limit, p.Offset, filter)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not list library items")
 		return

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -114,6 +114,11 @@ type LibraryStore interface {
 	GetBookByID(id string) (*database.Book, error)
 	GetBooksByIDs(ids []string) ([]database.Book, error)
 	GetAllBookSummaries(limit, offset int) ([]database.BookSummary, error)
+	// The FILTERED pair is what the ABS item list uses. The unfiltered ones above
+	// remain for callers that genuinely want every row; this surface does not, and
+	// using them here is what showed 44,888 items instead of ~16,000.
+	GetAllBookSummariesFiltered(limit, offset int, f database.BookSummaryFilter) ([]database.BookSummary, error)
+	CountBookSummariesFiltered(f database.BookSummaryFilter) (int, error)
 	GetAllBooksCore(limit, offset int) ([]database.BookCore, error)
 	CountAllBooks() (int, error)
 	SearchBooks(query string, limit, offset int) ([]database.Book, error)
@@ -211,6 +216,12 @@ type Options struct {
 	LibraryName string
 }
 
+// itemsCountEntry is one cached filtered count and when it was computed.
+type itemsCountEntry struct {
+	count int
+	at    time.Time
+}
+
 // Handler serves the ABS auth surface.
 type Handler struct {
 	cfg      *absauth.Config
@@ -242,6 +253,13 @@ type Handler struct {
 	// token or a real CF identity, so its size is bounded by the number of genuine
 	// devices — an attacker replaying random tokens cannot make it grow.
 	refreshLocks sync.Map // sessionID -> *sync.Mutex
+
+	// itemsCount caches the filtered library-item count per filter identity.
+	// CountBookSummariesFiltered is a full-library scan, and this endpoint is polled
+	// on every library page, so an uncached count made latency a flat ~2s regardless
+	// of which page was requested. See countItems in browse.go.
+	itemsCountMu sync.Mutex
+	itemsCount   map[string]itemsCountEntry
 
 	// now and newID are injectable for deterministic tests.
 	now   func() time.Time
@@ -283,6 +301,7 @@ func New(o Options) (*Handler, error) {
 		bookmarks:   o.Bookmarks,
 		coverRoot:   o.CoverRoot,
 		libraryName: name,
+		itemsCount:  map[string]itemsCountEntry{},
 		now:         time.Now,
 		newID:       func() string { return ulid.Make().String() },
 	}

--- a/internal/server/handlers/abs/item_filter_test.go
+++ b/internal/server/handlers/abs/item_filter_test.go
@@ -1,0 +1,184 @@
+// file: internal/server/handlers/abs/item_filter_test.go
+// version: 1.0.0
+// guid: 1e63a04f-8c27-4d1b-95a0-2f78c6b3e419
+// last-edited: 2026-08-03
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// The app showed 44,888 items where the owner has ~16,000, because
+// GET /api/libraries/:id/items counted and listed EVERY book row. The library's own
+// counts cache reports the real split:
+//
+//	total_books=44888  organized_books=16491  unorganized_books=23928
+//
+// The extra ~28k are raw imports, iTunes-tree copies, and alternate versions of books
+// already in the list. These tests seed exactly those shapes and assert each one is
+// excluded — asserting on the handler's OUTPUT rather than on which filter struct it
+// happened to build, so the coverage survives a refactor of the filter plumbing.
+
+// seedNoise adds one book of each shape that must NOT appear in the library list, and
+// returns how many were added.
+func seedNoise(t *testing.T, w *writeHarness) int {
+	t.Helper()
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+	now := timeNowForSeed()
+
+	// An alternate version of a book already in the list.
+	w.seed.lib.addBook(&database.Book{
+		ID: "01ALTVERSIONBOOK000000000", Title: "The Odyssey",
+		FilePath: "/library/Homer/The Odyssey (Alt)/alt.m4b", Format: "m4b",
+		LibraryState: strp("organized"), IsPrimaryVersion: boolp(false),
+		CreatedAt: &now, UpdatedAt: &now,
+	}, nil, nil)
+
+	// A raw iTunes-tree copy: primary, but not organized into the library.
+	w.seed.lib.addBook(&database.Book{
+		ID: "01UNORGANIZEDBOOK00000000", Title: "Unorganized Import",
+		FilePath: "/iTunes Media/Audiobooks/raw.mp3", Format: "mp3",
+		LibraryState: strp("organized_source"), IsPrimaryVersion: boolp(true),
+		CreatedAt: &now, UpdatedAt: &now,
+	}, nil, nil)
+
+	// A quarantined file — cannot be played, so listing it only yields a failure.
+	quarantined := now
+	w.seed.lib.addBook(&database.Book{
+		ID: "01QUARANTINEDBOOK00000000", Title: "Quarantined Book",
+		FilePath: "/library/Broken/broken.m4b", Format: "m4b",
+		LibraryState: strp("organized"), IsPrimaryVersion: boolp(true),
+		QuarantinedAt: &quarantined, QuarantineReason: strp("unreadable"),
+		CreatedAt: &now, UpdatedAt: &now,
+	}, nil, nil)
+
+	return 3
+}
+
+// libraryItemTitles returns the titles on one page of the library list.
+func libraryItemTitles(t *testing.T, w *writeHarness, query string) ([]string, int) {
+	t.Helper()
+	code, body, raw := w.req(t, http.MethodGet,
+		"/api/libraries/"+w.libraryID()+"/items"+query, nil)
+	if code != http.StatusOK {
+		t.Fatalf("items%s = %d %s", query, code, raw)
+	}
+	total := int(requireNum(t, body, "total"))
+	titles := []string{}
+	for _, entry := range requireArray(t, body, "results") {
+		item, _ := entry.(map[string]any)
+		if item == nil {
+			continue
+		}
+		media, _ := item["media"].(map[string]any)
+		if media == nil {
+			continue
+		}
+		meta, _ := media["metadata"].(map[string]any)
+		if meta == nil {
+			continue
+		}
+		if title, _ := meta["title"].(string); title != "" {
+			titles = append(titles, title)
+		}
+	}
+	return titles, total
+}
+
+// 🔴 TestLibraryItems_ExcludesAlternateUnorganizedAndQuarantined is the regression for
+// "why do I have 44,888 books when I should have 16,000".
+func TestLibraryItems_ExcludesAlternateUnorganizedAndQuarantined(t *testing.T) {
+	w := newWriteHarness(t)
+	baseline, baseTotal := libraryItemTitles(t, w, "?limit=100&page=0")
+	seedNoise(t, w)
+
+	titles, total := libraryItemTitles(t, w, "?limit=100&page=0")
+
+	if total != baseTotal {
+		t.Errorf("total = %d after seeding 3 excluded books, want %d unchanged", total, baseTotal)
+	}
+	if len(titles) != len(baseline) {
+		t.Errorf("result count = %d, want %d — an excluded book leaked into the list", len(titles), len(baseline))
+	}
+	for _, unwanted := range []string{"Unorganized Import", "Quarantined Book"} {
+		if contains(titles, unwanted) {
+			t.Errorf("%q appears in the library list but must be filtered out: %v", unwanted, titles)
+		}
+	}
+	// The alternate version shares its title with the primary, so assert by COUNT:
+	// "The Odyssey" must not gain an extra entry.
+	var odyssey int
+	for _, tt := range titles {
+		if tt == "The Odyssey" {
+			odyssey++
+		}
+	}
+	var baseOdyssey int
+	for _, tt := range baseline {
+		if tt == "The Odyssey" {
+			baseOdyssey++
+		}
+	}
+	if odyssey != baseOdyssey {
+		t.Errorf("The Odyssey appears %d times, want %d — the alternate version was not collapsed",
+			odyssey, baseOdyssey)
+	}
+}
+
+// 🔴 TestLibraryItems_TotalIsTheFilteredCount. Reporting the unfiltered total makes the
+// client page forever into empty results, because it uses `total` to decide whether
+// another page exists.
+func TestLibraryItems_TotalIsTheFilteredCount(t *testing.T) {
+	w := newWriteHarness(t)
+	seedNoise(t, w)
+
+	titles, total := libraryItemTitles(t, w, "?limit=100&page=0")
+	if total != len(titles) {
+		t.Fatalf("total = %d but the page holds %d items and there is only one page — "+
+			"total is counting rows the list excludes", total, len(titles))
+	}
+}
+
+// TestLibraryItems_CountIsCached proves the full-library count scan is not repeated on
+// every request. Before caching, latency was a flat ~2s on EVERY page because
+// CountAllBooks json.Unmarshal'd all 44,888 books per call.
+func TestLibraryItems_CountIsCached(t *testing.T) {
+	w := newWriteHarness(t)
+	if _, _ = libraryItemTitles(t, w, "?limit=10&page=0"); true {
+		// primed
+	}
+	before := w.seed.lib.countCalls()
+	for range 5 {
+		libraryItemTitles(t, w, "?limit=10&page=0")
+	}
+	if after := w.seed.lib.countCalls(); after != before {
+		t.Fatalf("count was recomputed %d times across 5 cached requests — "+
+			"each one is a full-library scan", after-before)
+	}
+}
+
+// TestLibraryItems_SortIsHonoured. The client always sends
+// sort=media.metadata.title and we previously IGNORED it, so the library was never
+// actually title-sorted.
+func TestLibraryItems_SortIsHonoured(t *testing.T) {
+	w := newWriteHarness(t)
+
+	asc, _ := libraryItemTitles(t, w, "?limit=100&page=0&sort=media.metadata.title")
+	desc, _ := libraryItemTitles(t, w, "?limit=100&page=0&sort=media.metadata.title&desc=1")
+	if len(asc) < 2 {
+		t.Skipf("need >=2 items to observe ordering, have %d", len(asc))
+	}
+	for i := 1; i < len(asc); i++ {
+		if asc[i-1] > asc[i] {
+			t.Fatalf("ascending sort not applied: %v", asc)
+		}
+	}
+	if len(desc) == len(asc) && asc[0] == desc[0] && asc[0] != asc[len(asc)-1] {
+		t.Fatalf("?desc=1 did not reverse the order: asc=%v desc=%v", asc, desc)
+	}
+}

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -55,7 +55,22 @@ type fakeLibrary struct {
 
 	nextUUID int
 	listErr  error
+
+	// countFiltered counts CountBookSummariesFiltered calls so a test can prove the
+	// full-library count scan is cached rather than repeated per request.
+	countFiltered int
 }
+
+// countCalls reports how many times the filtered count was actually computed.
+func (f *fakeLibrary) countCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.countFiltered
+}
+
+// timeNowForSeed is a fixed timestamp for seeded rows. Fixed rather than time.Now so
+// ms-epoch assertions stay stable.
+func timeNowForSeed() time.Time { return time.UnixMilli(1785370201500) }
 
 func newFakeLibrary() *fakeLibrary {
 	return &fakeLibrary{
@@ -144,6 +159,84 @@ func (f *fakeLibrary) GetAllBookSummaries(limit, offset int) ([]database.BookSum
 		out = append(out, database.BookSummary{ID: b.ID, Title: b.Title, CreatedAt: b.CreatedAt})
 	}
 	return out, nil
+}
+
+// matchesFilter applies the same predicates the real store applies, so a test that
+// seeds a non-primary or unorganized book actually sees it excluded rather than
+// trusting the handler to have asked for the right thing.
+func (f *fakeLibrary) matchesFilter(b *database.Book, sum database.BookSummary, fl database.BookSummaryFilter) bool {
+	if fl.IsPrimaryVersion != nil {
+		isPrimary := b.IsPrimaryVersion == nil || *b.IsPrimaryVersion
+		if isPrimary != *fl.IsPrimaryVersion {
+			return false
+		}
+	}
+	if fl.LibraryState != "" {
+		state := ""
+		if b.LibraryState != nil {
+			state = *b.LibraryState
+		}
+		if state != fl.LibraryState {
+			return false
+		}
+	}
+	if fl.ExcludeQuarantined && b.QuarantinedAt != nil {
+		return false
+	}
+	_ = sum
+	return true
+}
+
+// filteredSummaries returns the seeded books matching fl, in the requested order.
+func (f *fakeLibrary) filteredSummaries(fl database.BookSummaryFilter) []database.BookSummary {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := []database.BookSummary{}
+	for _, id := range f.order {
+		b := f.books[id]
+		if b == nil {
+			continue
+		}
+		sum := database.BookSummary{ID: b.ID, Title: b.Title}
+		if f.matchesFilter(b, sum, fl) {
+			out = append(out, sum)
+		}
+	}
+	if fl.SortBy == "title" {
+		sort.SliceStable(out, func(i, j int) bool {
+			if fl.SortAscending {
+				return out[i].Title < out[j].Title
+			}
+			return out[i].Title > out[j].Title
+		})
+	}
+	return out
+}
+
+func (f *fakeLibrary) CountBookSummariesFiltered(fl database.BookSummaryFilter) (int, error) {
+	if f.listErr != nil {
+		return 0, f.listErr
+	}
+	n := len(f.filteredSummaries(fl))
+	f.mu.Lock()
+	f.countFiltered++
+	f.mu.Unlock()
+	return n, nil
+}
+
+func (f *fakeLibrary) GetAllBookSummariesFiltered(limit, offset int, fl database.BookSummaryFilter) ([]database.BookSummary, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	all := f.filteredSummaries(fl)
+	if offset >= len(all) {
+		return []database.BookSummary{}, nil
+	}
+	end := offset + limit
+	if limit <= 0 || end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], nil
 }
 
 func (f *fakeLibrary) GetAllBooksCore(limit, offset int) ([]database.BookCore, error) {
@@ -459,6 +552,11 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 	created := time.UnixMilli(1785370201391)
 	createdMulti := time.UnixMilli(1785370201438)
 	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+	// The ABS item list serves ONLY primary + organized books (see absItemFilter), so
+	// the fixture library must look like a normal organized library or every browse
+	// test would assert against an empty list.
+	organized, primary := strp("organized"), boolp(true)
 	intp := func(i int) *int { return &i }
 
 	// ── book 1: single-file m4b, 6 embedded chapters ─────────────────────────
@@ -472,6 +570,7 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 		ID: "01SINGLEFILEODYSSEYBOOK00", Title: "The Odyssey",
 		FilePath: m4b, Format: "QuickTime / MOV", Duration: intp(9975),
 		Genre: strp("Audiobook"), PrintYear: intp(800),
+		LibraryState: organized, IsPrimaryVersion: primary,
 		CreatedAt: &created, UpdatedAt: &created,
 	}
 	// The oracle's m4b carries NO track tag and no track number in its filename, so
@@ -496,9 +595,10 @@ func seedOracleLibrary(t *testing.T) *oracleSeed {
 	multi := &database.Book{
 		ID: "01MULTIFILEODYSSEYBOOK000", Title: "The Odyssey",
 		Format: "mp3", Duration: intp(9975),
-		Genre:       strp("Speech"),
-		Description: strp("http://archive.org/details/odyssey_butler_librivox"),
-		CreatedAt:   &createdMulti, UpdatedAt: &createdMulti,
+		Genre:        strp("Speech"),
+		Description:  strp("http://archive.org/details/odyssey_butler_librivox"),
+		LibraryState: organized, IsPrimaryVersion: primary,
+		CreatedAt: &createdMulti, UpdatedAt: &createdMulti,
 	}
 	var mp3s []database.BookFile
 	for i := 1; i <= 6; i++ {


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-08-03-abs-primary-organized-items-design.md`

The app listed **44,888** books where the library holds **~16,000**, and every page took **1.3–3.0 s**.

## 1. Wrong item set

`/api/libraries/:id/items` counted and listed **every** book row. The app's own counts cache reports the real split:

```
total_books=44888   organized_books=16491   unorganized_books=23928
```

So ~28,000 raw imports, iTunes-tree copies and alternate versions were being served as library items. `organized_books` is already computed as *primary version AND file under the library root* — i.e. 16,491 was always the right number. The filtered store calls (`GetAllBookSummariesFiltered` / `CountBookSummariesFiltered`) already existed and simply weren't used here.

## 2. Latency was a fixed full scan, not paging

Flat across pages — page 0 = 2.01 s, page 9 = 1.29 s — so it was never the offset walk. `CountAllBooks` iterates every `book:` key **and `json.Unmarshal`s every book** purely to count them: 44,888 decodes per request.

Same hotspot class as `CountPrimaryBooks`, fixed once already in #2021. The filtered count is now cached for 60 s, mirroring that existing TTL cache rather than adding a second caching style, and **computed outside the mutex** so concurrent requests don't serialize behind one scan.

Reporting the unfiltered total was a correctness bug on its own: the client uses `total` to decide whether another page exists, so it would page forever into empty results.

## 3. `sort` was silently ignored

The client always sends `sort=media.metadata.title`; the handler never read it. Your library was never actually title-sorted. Now honoured via the sorted title index (O(offset+limit)), `?desc=1` reverses.

## No progress is at risk

§1.8.1 governs `mediaProgress`, a **separate** payload built from the user's own position rows. A book leaving the item list still appears in `/api/me`, so `syncFromAPI` deletes nothing. Stating it because "items shrank by 28k" pattern-matches to a data-loss rule that doesn't apply here.

## Verification

The test seeds one book of each excluded shape (alternate version, unorganized iTunes copy, quarantined) and asserts on the handler's **output**, not on which filter struct it built. Verified to fail without the fix:

```
--- FAIL: TestLibraryItems_ExcludesAlternateUnorganizedAndQuarantined
    total = 5 after seeding 3 excluded books, want 2 unchanged
    "Unorganized Import" appears in the library list but must be filtered out
    "Quarantined Book" appears in the library list but must be filtered out
    The Odyssey appears 3 times, want 2 — the alternate version was not collapsed
```

```
go test ./internal/server/handlers/abs/... -count=1   ok  30.612s
```

Also pinned: `total` equals the filtered count, the count isn't recomputed across cached requests, and sort/desc are applied.

## Risk

**~28,000 books disappear from the app at once.** That's the intent, and it's fully reversible by relaxing the filter — no data is written or migrated, this only changes which rows a read path selects.

**Acceptance after deploy:** total lands near 16,491 and agrees with the web UI's organized count; `/items` latency drops materially from ~2 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp