### PR TITLE
perf(abs): cache the built author list so jump-to-letter stops rescanning the library

### DIFF
--- a/changelog.d/20260803_020000_authors_document_cache.md
+++ b/changelog.d/20260803_020000_authors_document_cache.md
@@ -1,0 +1,22 @@
+<!-- file: changelog.d/20260803_020000_authors_document_cache.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f73c1f6e-cf17-45f4-bc67-bb711ba9e436 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Fixed
+
+- **Jumping to a letter in the Authors tab took ~37 seconds.** Per-request latency was
+  never the real metric — request COUNT was. AudioBooth pages authors 100 at a time and
+  its jump-to-letter feature keeps loading pages until the target letter appears
+  (`AuthorsPageModel`: `itemsPerPage = 100`,
+  `hasMorePages = currentPage * itemsPerPage < total`). With ~9,200 authors, reaching
+  "Z" is ~93 consecutive requests.
+
+  Each of those rebuilt the whole author list, and `GetAllAuthorBookCounts` is by its
+  own description a "Full Pebble book scan combined with junction table scan" — all
+  44,888 books walked, per page. 93 full library scans.
+
+  The built list is now cached for 5 minutes, so pages 2..93 are slice arithmetic. The
+  same cache serves the home screen's author shelf, which rebuilt it on every refresh
+  too. Built outside the lock, so a burst of page requests does not serialize behind
+  one rebuild.

--- a/internal/server/handlers/abs/authors_cache_test.go
+++ b/internal/server/handlers/abs/authors_cache_test.go
@@ -1,0 +1,91 @@
+// file: internal/server/handlers/abs/authors_cache_test.go
+// version: 1.0.0
+// guid: 6b90d248-1f37-4c05-a3e8-71d24f9068ba
+// last-edited: 2026-08-03
+
+package abs_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// AudioBooth pages authors 100 at a time and its jump-to-letter feature keeps
+// loading pages until the target letter appears (AuthorsPageModel: itemsPerPage=100,
+// hasMorePages = currentPage*itemsPerPage < total). With ~9,200 authors, jumping to
+// "Z" is ~93 consecutive requests.
+//
+// Each of those used to call GetAllAuthorBookCounts — by its own description a "Full
+// Pebble book scan combined with junction table scan", walking all 44,888 books. 93
+// full library scans is why reaching the end of the alphabet took ~37 seconds.
+
+// 🔴 TestAuthors_ListBuiltOncePerTTL is the regression. The value under test is the
+// NUMBER OF REBUILDS across a burst of page requests, because that is what the
+// jump-to-letter interaction actually generates.
+func TestAuthors_ListBuiltOncePerTTL(t *testing.T) {
+	w := newWriteHarness(t)
+
+	// Prime, then simulate the client walking pages toward a letter.
+	w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors?limit=100&page=0", nil)
+	before := w.seed.lib.authorCountCalls()
+
+	for page := 1; page <= 20; page++ {
+		code, _, raw := w.req(t, http.MethodGet,
+			"/api/libraries/"+w.libraryID()+"/authors?limit=100&page="+itoa(page), nil)
+		if code != http.StatusOK {
+			t.Fatalf("page %d = %d %s", page, code, raw)
+		}
+	}
+
+	if after := w.seed.lib.authorCountCalls(); after != before {
+		t.Fatalf("author list rebuilt %d times across 20 paged requests — each rebuild is a "+
+			"full library scan, and the client issues up to 93 of these in a row", after-before)
+	}
+}
+
+// TestAuthors_CachedListStillServesCorrectPages — a cache that returns stale or
+// wrongly-sliced pages would be worse than the slow path it replaces.
+func TestAuthors_CachedListStillServesCorrectPages(t *testing.T) {
+	w := newWriteHarness(t)
+
+	_, all, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors", nil)
+	full := requireArray(t, all, "authors")
+	if len(full) < 2 {
+		t.Skipf("need >=2 authors, have %d", len(full))
+	}
+
+	// Page through with limit=1 and confirm we see each author exactly once, in order.
+	var seen []string
+	for page := 0; page < len(full); page++ {
+		_, body, _ := w.req(t, http.MethodGet,
+			"/api/libraries/"+w.libraryID()+"/authors?limit=1&page="+itoa(page), nil)
+		results := requireArray(t, body, "results")
+		if len(results) != 1 {
+			t.Fatalf("page %d returned %d results, want 1", page, len(results))
+		}
+		item, _ := results[0].(map[string]any)
+		name, _ := item["name"].(string)
+		seen = append(seen, name)
+		if got := int(requireNum(t, body, "total")); got != len(full) {
+			t.Fatalf("page %d total = %d, want %d", page, got, len(full))
+		}
+	}
+	for i, entry := range full {
+		want, _ := entry.(map[string]any)
+		if seen[i] != want["name"] {
+			t.Fatalf("paged order diverged at %d: got %q want %v", i, seen[i], want["name"])
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/abs/browse.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 5e0b83c7-2a41-4d96-b7e8-1c53fd90a2b4
 // last-edited: 2026-08-03
 
@@ -394,7 +394,7 @@ func (h *Handler) Personalized(c *gin.Context) {
 		recentlyAdded = append(recentlyAdded, h.minifiedItem(&views[i]))
 	}
 
-	authors, err := h.authorDTOs()
+	authors, err := h.authorDTOsCached()
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not build home shelves")
 		return
@@ -489,6 +489,57 @@ func (h *Handler) LibrarySeries(c *gin.Context) {
 	respondJSON(c, http.StatusOK, pageResponse{Results: results, Total: len(results)})
 }
 
+// absAuthorsCacheTTL bounds how long the built author list is reused.
+//
+// Generous on purpose: authors change only when books are added, and the owner
+// explicitly accepted a slightly-stale list. The cost being avoided is large — see
+// authorDTOsCached.
+const absAuthorsCacheTTL = 5 * time.Minute
+
+// authorDTOsCached returns the full, sorted author list, rebuilt at most once per
+// absAuthorsCacheTTL.
+//
+// 🔴 THE CLIENT ASKS FOR THIS UP TO 93 TIMES IN A ROW, and each rebuild is a full
+// library scan.
+//
+// AudioBooth pages authors 100 at a time (AuthorsPageModel: itemsPerPage = 100,
+// hasMorePages = currentPage*itemsPerPage < total) and its jump-to-letter feature
+// keeps loading pages until the target letter appears. With ~9,200 authors, jumping
+// to "Z" is ~93 sequential requests.
+//
+// Each of those requests called GetAllAuthorBookCounts, which is by its own
+// description a "Full Pebble book scan combined with junction table scan" — 44,888
+// books walked, per page. 93 pages x ~400ms was ~37 seconds to reach the end of the
+// alphabet.
+//
+// Building the list once turns pages 2..93 into slice arithmetic. That is why this
+// caches the whole DOCUMENT rather than just the count: the count was never the
+// expensive part here.
+func (h *Handler) authorDTOsCached() ([]authorDTO, error) {
+	now := h.now()
+
+	h.authorsCacheMu.Lock()
+	if h.authorsCache != nil && now.Sub(h.authorsCacheAt) < absAuthorsCacheTTL {
+		cached := h.authorsCache
+		h.authorsCacheMu.Unlock()
+		return cached, nil
+	}
+	h.authorsCacheMu.Unlock()
+
+	// Built OUTSIDE the lock. Holding it across a full-library scan would serialize
+	// every concurrent page request behind one rebuild — which is precisely the
+	// 93-requests-in-a-row access pattern this exists to serve.
+	built, err := h.authorDTOs()
+	if err != nil {
+		return nil, err
+	}
+
+	h.authorsCacheMu.Lock()
+	h.authorsCache, h.authorsCacheAt = built, now
+	h.authorsCacheMu.Unlock()
+	return built, nil
+}
+
 // authorDTOs builds the author list once, shared by /authors and /personalized.
 func (h *Handler) authorDTOs() ([]authorDTO, error) {
 	authors, err := h.library.GetAllAuthors()
@@ -530,7 +581,7 @@ func (h *Handler) LibraryAuthors(c *gin.Context) {
 	if !h.knownLibrary(c) {
 		return
 	}
-	authors, err := h.authorDTOs()
+	authors, err := h.authorDTOsCached()
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not list authors")
 		return

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -261,6 +261,13 @@ type Handler struct {
 	itemsCountMu sync.Mutex
 	itemsCount   map[string]itemsCountEntry
 
+	// authorsCache holds the fully-built author list. The client requests up to 93
+	// consecutive pages of it (jump-to-letter), and building it walks the whole
+	// library — see authorDTOsCached in browse.go.
+	authorsCacheMu sync.Mutex
+	authorsCache   []authorDTO
+	authorsCacheAt time.Time
+
 	// now and newID are injectable for deterministic tests.
 	now   func() time.Time
 	newID func() string

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -59,6 +59,16 @@ type fakeLibrary struct {
 	// countFiltered counts CountBookSummariesFiltered calls so a test can prove the
 	// full-library count scan is cached rather than repeated per request.
 	countFiltered int
+	authorCounts  int
+}
+
+// authorCountCalls reports how many times the full author-count scan ran. The
+// jump-to-letter interaction issues up to 93 paged requests in a row, so the value
+// that matters is how many of those trigger a rebuild.
+func (f *fakeLibrary) authorCountCalls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.authorCounts
 }
 
 // countCalls reports how many times the filtered count was actually computed.
@@ -335,6 +345,9 @@ func (f *fakeLibrary) GetAllAuthors() ([]database.Author, error) {
 }
 
 func (f *fakeLibrary) GetAllAuthorBookCounts() (map[int]int, error) {
+	f.mu.Lock()
+	f.authorCounts++
+	f.mu.Unlock()
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := map[int]int{}


### PR DESCRIPTION
Per-request latency was never the metric that mattered — **request count** was.

## What the client actually does

`AuthorsPageModel`:

```swift
private let itemsPerPage: Int = 100
hasMorePages = (currentPage * itemsPerPage) < response.total
```

plus `targetLetter` / `checkTargetLetterAfterLoad()`. **Jump-to-letter keeps loading pages until the target letter appears.** With ~9,200 authors, reaching "Z" is **~93 consecutive requests**.

## What each of those cost

Every one rebuilt the full author list, and `GetAllAuthorBookCounts` is — by its own comment — a *"Full Pebble book scan combined with junction table scan"*, walking all 44,888 books.

**93 full library scans at ~400 ms each ≈ 37 seconds** to reach the end of the alphabet. That's the "still has latency / doesn't fetch until you scroll" report.

## Fix

Cache the built list for 5 minutes. Pages 2..93 become slice arithmetic. The same cache also serves the home screen's author shelf, which was rebuilding it on **every** refresh.

Rebuild happens **outside the mutex** — holding it across a full-library scan would serialize precisely the 93-requests-in-a-row pattern this exists to serve.

5 minutes because authors only change when books are added and you accepted a slightly-stale list. Dirty-flag invalidation deferred until we know the TTL is actually insufficient.

## Verification

The test asserts on the **number of rebuilds** across a burst of paged requests, not on latency — that's the property that broke. Verified to fail without the cache:

```
--- FAIL: TestAuthors_ListBuiltOncePerTTL
    author list rebuilt 20 times across 20 paged requests — each rebuild is a
    full library scan, and the client issues up to 93 of these in a row
```

A companion test pages through with `limit=1` and confirms every author appears exactly once, in the same order as the unpaginated list, with a stable `total` — a cache that returned wrongly-sliced pages would be worse than the slow path.

```
go test ./internal/server/handlers/abs/... -count=1   ok  29.650s
```

## Not in this PR

The Authors list is also **polluted with ~117 high-confidence junk rows** — `& Beth Chalmers`, `&#169;2013 by HarperCollinsPublishers`, `(Long Earth 01) The Long Earth`, `(c) 2001 Stephen Hawking`, `+Brandon Sanderson`. That's a separate parser bug plus a data-cleanup decision, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp