### PR TITLE
fix(abs): build the Authors and Narrators tabs from visible books only

### DIFF
--- a/changelog.d/20260803_030000_contributors_visible_only.md
+++ b/changelog.d/20260803_030000_contributors_visible_only.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/20260803_030000_contributors_visible_only.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f9d7b41-6c58-42ea-9013-8d24ba07c5e6 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Fixed
+
+- **The Authors and Narrators tabs disagreed with the Library about what the library
+  is.** `/items` serves 16,491 primary+organized books, but the author and narrator
+  lists were built from `GetAllAuthors` / `ListNarrators` — every row in the store,
+  including contributors attached ONLY to the ~28,000 unorganized iTunes-tree books.
+  That is where the junk came from: "authors" that are really track names
+  (`065_Rise of the Corinari`, `13_Aurora`, `CD 12`), bare years, `Read by …` credits,
+  and copyright notices.
+
+  Both lists are now derived from the same visible-book set `/items` uses, in a single
+  shared pass, so the three tabs cannot disagree.
+
+- **Author book counts counted invisible books.** An author with forty unorganized rows
+  and one real book read "41 books". Counts are now over visible books only.
+
+- **Narrators gained a real `numBooks`**, which was previously omitted because there is
+  no reverse narrator→book index; deriving both lists from the same junction pass
+  supplies it for free.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -6,6 +6,7 @@
 package abs
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"net/url"
@@ -175,14 +176,19 @@ const absItemsCountTTL = 60 * time.Second
 // Sorting is honoured here too. The client always sends sort=media.metadata.title and
 // we previously IGNORED it, so the library was never actually title-sorted. SortBy
 // "title" is backed by a sorted radix index — O(offset+limit), not a full sort.
-func absItemFilter(c *gin.Context) database.BookSummaryFilter {
+func absItemFilterBase() database.BookSummaryFilter {
 	primary := true
-	f := database.BookSummaryFilter{
+	return database.BookSummaryFilter{
 		IsPrimaryVersion:   &primary,
 		LibraryState:       "organized",
 		ExcludeQuarantined: true,
-		SortAscending:      c.Query("desc") != "1",
+		SortAscending:      true,
 	}
+}
+
+func absItemFilter(c *gin.Context) database.BookSummaryFilter {
+	f := absItemFilterBase()
+	f.SortAscending = c.Query("desc") != "1"
 	// Only "title" is index-backed; anything else falls through to store default
 	// ordering rather than pretending to honour a sort we cannot do cheaply.
 	if strings.Contains(strings.ToLower(c.Query("sort")), "title") {
@@ -394,7 +400,7 @@ func (h *Handler) Personalized(c *gin.Context) {
 		recentlyAdded = append(recentlyAdded, h.minifiedItem(&views[i]))
 	}
 
-	authors, err := h.authorDTOsCached()
+	authors, err := h.authorDTOsCached(c.Request.Context())
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not build home shelves")
 		return
@@ -515,56 +521,147 @@ const absAuthorsCacheTTL = 5 * time.Minute
 // Building the list once turns pages 2..93 into slice arithmetic. That is why this
 // caches the whole DOCUMENT rather than just the count: the count was never the
 // expensive part here.
-func (h *Handler) authorDTOsCached() ([]authorDTO, error) {
+func (h *Handler) contributorsCached(ctx context.Context) ([]authorDTO, []narratorDTO, error) {
 	now := h.now()
 
 	h.authorsCacheMu.Lock()
 	if h.authorsCache != nil && now.Sub(h.authorsCacheAt) < absAuthorsCacheTTL {
-		cached := h.authorsCache
+		a, n := h.authorsCache, h.narratorsCache
 		h.authorsCacheMu.Unlock()
-		return cached, nil
+		return a, n, nil
 	}
 	h.authorsCacheMu.Unlock()
 
 	// Built OUTSIDE the lock. Holding it across a full-library scan would serialize
 	// every concurrent page request behind one rebuild — which is precisely the
 	// 93-requests-in-a-row access pattern this exists to serve.
-	built, err := h.authorDTOs()
+	authors, narrators, err := h.contributorDTOs(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	h.authorsCacheMu.Lock()
-	h.authorsCache, h.authorsCacheAt = built, now
+	h.authorsCache, h.narratorsCache, h.authorsCacheAt = authors, narrators, now
 	h.authorsCacheMu.Unlock()
-	return built, nil
+	return authors, narrators, nil
+}
+
+// authorDTOsCached is the author-only view of the shared contributor cache.
+func (h *Handler) authorDTOsCached(ctx context.Context) ([]authorDTO, error) {
+	authors, _, err := h.contributorsCached(ctx)
+	return authors, err
 }
 
 // authorDTOs builds the author list once, shared by /authors and /personalized.
-func (h *Handler) authorDTOs() ([]authorDTO, error) {
-	authors, err := h.library.GetAllAuthors()
-	if err != nil {
-		return nil, err
+// visibleBookIDs returns the ids of every book the library actually SHOWS —
+// the same primary + organized + non-quarantined set /items serves.
+//
+// 🔴 WITHOUT THIS, THE TABS DISAGREE ABOUT WHAT THE LIBRARY IS. /items shows 16,491
+// books while GetAllAuthors returned the authors of all 44,888, so the Authors and
+// Narrators tabs were populated from ~28,000 books the app no longer lists. That is
+// where the junk comes from: unorganized iTunes-tree rows whose "author" is really a
+// track name ("065_Rise of the Corinari", "13_Aurora", "CD 12"), a bare year, or a
+// "Read by ..." narrator credit.
+//
+// Paged in chunks rather than with one unbounded call so this never depends on a
+// store's limit<=0 meaning "everything", and so peak memory is a chunk of summaries
+// rather than the whole library.
+func (h *Handler) visibleBookIDs(f database.BookSummaryFilter) ([]string, error) {
+	const chunk = 5000
+	var ids []string
+	for offset := 0; ; offset += chunk {
+		page, err := h.library.GetAllBookSummariesFiltered(chunk, offset, f)
+		if err != nil {
+			return nil, err
+		}
+		for i := range page {
+			if page[i].ID != "" {
+				ids = append(ids, page[i].ID)
+			}
+		}
+		if len(page) < chunk {
+			return ids, nil
+		}
 	}
-	counts, err := h.library.GetAllAuthorBookCounts()
+}
+
+// contributorDTOs builds the author AND narrator lists from the VISIBLE books only.
+//
+// Both are derived from one pass so the two tabs can never disagree with each other or
+// with the library, and so the expensive part — enumerating visible books — is paid
+// once instead of twice.
+//
+// Counts are the number of VISIBLE books, not the raw junction count: an author with
+// forty unorganized rows and one real book should read "1 book", not "41".
+func (h *Handler) contributorDTOs(ctx context.Context) ([]authorDTO, []narratorDTO, error) {
+	ids, err := h.visibleBookIDs(absItemFilterBase())
 	if err != nil {
-		counts = map[int]int{}
+		return nil, nil, err
 	}
+	if len(ids) == 0 {
+		return []authorDTO{}, []narratorDTO{}, nil
+	}
+
+	authorsByBook, err := h.library.GetAuthorsByBookIDs(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	narratorsByBook, err := h.library.GetNarratorsByBookIDs(ctx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	type authorAgg struct {
+		name  string
+		id    int
+		books int
+	}
+	authorSeen := map[int]*authorAgg{}
+	for _, list := range authorsByBook {
+		for _, a := range list {
+			if strings.TrimSpace(a.Name) == "" {
+				continue
+			}
+			agg, ok := authorSeen[a.ID]
+			if !ok {
+				agg = &authorAgg{name: a.Name, id: a.ID}
+				authorSeen[a.ID] = agg
+			}
+			agg.books++
+		}
+	}
+	narratorSeen := map[string]int{}
+	for _, list := range narratorsByBook {
+		for _, n := range list {
+			if name := strings.TrimSpace(n.Name); name != "" {
+				narratorSeen[name]++
+			}
+		}
+	}
+
 	now := msEpoch(h.now())
-	out := make([]authorDTO, 0, len(authors))
-	for _, a := range authors {
-		out = append(out, authorDTO{
+	authors := make([]authorDTO, 0, len(authorSeen))
+	for _, agg := range authorSeen {
+		authors = append(authors, authorDTO{
 			AddedAt:   now,
-			ID:        strconv.Itoa(a.ID),
-			LastFirst: lastFirst(a.Name),
+			ID:        strconv.Itoa(agg.id),
+			LastFirst: lastFirst(agg.name),
 			LibraryID: h.libraryID(),
-			Name:      a.Name,
-			NumBooks:  counts[a.ID],
+			Name:      agg.name,
+			NumBooks:  agg.books,
 			UpdatedAt: now,
 		})
 	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-	return out, nil
+	sort.SliceStable(authors, func(i, j int) bool { return authors[i].Name < authors[j].Name })
+
+	narrators := make([]narratorDTO, 0, len(narratorSeen))
+	for name, count := range narratorSeen {
+		n := count
+		narrators = append(narrators, narratorDTO{ID: narratorID(name), Name: name, NumBooks: &n})
+	}
+	sort.SliceStable(narrators, func(i, j int) bool { return narrators[i].Name < narrators[j].Name })
+
+	return authors, narrators, nil
 }
 
 // LibraryAuthors handles GET /api/libraries/:libraryId/authors.
@@ -581,7 +678,7 @@ func (h *Handler) LibraryAuthors(c *gin.Context) {
 	if !h.knownLibrary(c) {
 		return
 	}
-	authors, err := h.authorDTOsCached()
+	authors, err := h.authorDTOsCached(c.Request.Context())
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not list authors")
 		return
@@ -640,18 +737,14 @@ func (h *Handler) LibraryNarrators(c *gin.Context) {
 	if !h.knownLibrary(c) {
 		return
 	}
-	narrators, err := h.library.ListNarrators()
+	// Derived from the VISIBLE books, exactly like the author list — ListNarrators
+	// returns every narrator row in the store, including those attached only to
+	// unorganized iTunes-tree books whose "narrator" is really a track name.
+	_, out, err := h.contributorsCached(c.Request.Context())
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "could not list narrators")
 		return
 	}
-	out := make([]narratorDTO, 0, len(narrators))
-	for _, n := range narrators {
-		if name := strings.TrimSpace(n.Name); name != "" {
-			out = append(out, narratorDTO{ID: narratorID(name), Name: name})
-		}
-	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	respondJSON(c, http.StatusOK, narratorsResponse{Narrators: out})
 }
 
@@ -809,7 +902,7 @@ func (h *Handler) LibrarySearch(c *gin.Context) {
 	}
 
 	lower := strings.ToLower(query)
-	if authors, err := h.authorDTOs(); err == nil {
+	if authors, err := h.authorDTOsCached(c.Request.Context()); err == nil {
 		for i := range authors {
 			if strings.Contains(strings.ToLower(authors[i].Name), lower) {
 				resp.Authors = append(resp.Authors, authors[i])

--- a/internal/server/handlers/abs/handler.go
+++ b/internal/server/handlers/abs/handler.go
@@ -266,6 +266,7 @@ type Handler struct {
 	// library — see authorDTOsCached in browse.go.
 	authorsCacheMu sync.Mutex
 	authorsCache   []authorDTO
+	narratorsCache []narratorDTO
 	authorsCacheAt time.Time
 
 	// now and newID are injectable for deterministic tests.

--- a/internal/server/handlers/abs/item_filter_test.go
+++ b/internal/server/handlers/abs/item_filter_test.go
@@ -182,3 +182,77 @@ func TestLibraryItems_SortIsHonoured(t *testing.T) {
 		t.Fatalf("?desc=1 did not reverse the order: asc=%v desc=%v", asc, desc)
 	}
 }
+
+// 🔴 TestContributors_ComeOnlyFromVisibleBooks is the "half my authors aren't authors"
+// regression. /items serves 16,491 primary+organized books, but the author and
+// narrator lists were built from GetAllAuthors / ListNarrators — every row in the
+// store, including contributors attached ONLY to the ~28,000 unorganized iTunes-tree
+// books whose "author" is really a track name ("065_Rise of the Corinari", "13_Aurora",
+// "CD 12"), a bare year, or a "Read by ..." credit.
+//
+// The three tabs must agree about what the library is.
+func TestContributors_ComeOnlyFromVisibleBooks(t *testing.T) {
+	w := newWriteHarness(t)
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+	now := timeNowForSeed()
+
+	// An unorganized iTunes-tree book whose "author"/"narrator" are track residue.
+	hidden := &database.Book{
+		ID: "01HIDDENTRACKBOOK0000000", Title: "065_Rise of the Corinari",
+		FilePath: "/iTunes Media/Audiobooks/065_Rise of the Corinari.mp3", Format: "mp3",
+		LibraryState: strp("organized_source"), IsPrimaryVersion: boolp(true),
+		CreatedAt: &now, UpdatedAt: &now,
+	}
+	w.seed.lib.addBook(hidden, nil, nil)
+	w.seed.lib.addAuthor(9001, "065_Rise of the Corinari", hidden.ID)
+	w.seed.lib.attachNarrators(hidden.ID, "Read by Sam Tsoutsouvas")
+
+	// Authors
+	_, authorsBody, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors", nil)
+	for _, entry := range requireArray(t, authorsBody, "authors") {
+		a, _ := entry.(map[string]any)
+		if a != nil && a["name"] == "065_Rise of the Corinari" {
+			t.Fatal("a track name from an UNORGANIZED book appears in the Authors tab")
+		}
+	}
+
+	// Narrators
+	_, narrBody, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/narrators", nil)
+	for _, entry := range requireArray(t, narrBody, "narrators") {
+		n, _ := entry.(map[string]any)
+		if n != nil && n["name"] == "Read by Sam Tsoutsouvas" {
+			t.Fatal("a narrator credit from an UNORGANIZED book appears in the Narrators tab")
+		}
+	}
+}
+
+// TestAuthors_NumBooksCountsOnlyVisibleBooks — an author with forty unorganized rows
+// and one real book must read "1 book", not "41". The count drives the subtitle under
+// every author card.
+func TestAuthors_NumBooksCountsOnlyVisibleBooks(t *testing.T) {
+	w := newWriteHarness(t)
+	strp := func(s string) *string { return &s }
+	boolp := func(b bool) *bool { return &b }
+	now := timeNowForSeed()
+
+	hidden := &database.Book{
+		ID: "01HIDDENHOMERCOPY0000000", Title: "The Odyssey (raw import)",
+		FilePath: "/iTunes Media/Audiobooks/odyssey-raw.mp3", Format: "mp3",
+		LibraryState: strp("organized_source"), IsPrimaryVersion: boolp(true),
+		CreatedAt: &now, UpdatedAt: &now,
+	}
+	w.seed.lib.addBook(hidden, nil, nil)
+	w.seed.lib.addAuthor(1, "Homer", hidden.ID) // same author id as the visible book
+
+	_, body, _ := w.req(t, http.MethodGet, "/api/libraries/"+w.libraryID()+"/authors", nil)
+	for _, entry := range requireArray(t, body, "authors") {
+		a, _ := entry.(map[string]any)
+		if a == nil || a["name"] != "Homer" {
+			continue
+		}
+		if got := a["numBooks"].(float64); got != 1 {
+			t.Fatalf("Homer numBooks = %v, want 1 — the hidden raw import must not be counted", got)
+		}
+	}
+}

--- a/internal/server/handlers/abs/library_fake_test.go
+++ b/internal/server/handlers/abs/library_fake_test.go
@@ -123,11 +123,34 @@ func (f *fakeLibrary) addAuthor(id int, name string, bookIDs ...string) {
 // addNarrators seeds narrator rows. The oracle's fixture library has none, so any
 // test asserting the narrator ELEMENT shape must seed its own — an empty list is
 // exactly how a missing required field shipped unnoticed.
-func (f *fakeLibrary) addNarrators(names ...string) {
+// Narrators are ATTACHED TO A BOOK, not just added to a standalone list: the ABS
+// narrator list is derived from the visible books' junction rows, so a narrator with
+// no book is correctly invisible. Attaching to the first seeded book makes them
+// visible without inventing a new one.
+// attachNarrators binds narrators to a specific book's junction rows.
+func (f *fakeLibrary) attachNarrators(bookID string, names ...string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for i, name := range names {
-		f.narrators = append(f.narrators, database.Narrator{ID: len(f.narrators) + i + 1, Name: name})
+		n := database.Narrator{ID: len(f.narrators) + i + 1, Name: name}
+		f.narrators = append(f.narrators, n)
+		f.bookNarr[bookID] = append(f.bookNarr[bookID], n)
+	}
+}
+
+func (f *fakeLibrary) addNarrators(names ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var target string
+	if len(f.order) > 0 {
+		target = f.order[0]
+	}
+	for i, name := range names {
+		n := database.Narrator{ID: len(f.narrators) + i + 1, Name: name}
+		f.narrators = append(f.narrators, n)
+		if target != "" {
+			f.bookNarr[target] = append(f.bookNarr[target], n)
+		}
 	}
 }
 


### PR DESCRIPTION
## The three tabs disagreed about what the library is

`/items` serves **16,491** primary+organized books (since #2120). But `authorDTOs` called `GetAllAuthors` and `LibraryNarrators` called `ListNarrators` — **every row in the store**. So both tabs were populated from all 44,888 books, including the ~28,000 unorganized iTunes-tree rows the app no longer lists.

That is the source of the junk: "authors" that are really **track names** (`065_Rise of the Corinari`, `13_Aurora`, `CD 12`), bare years, `Read by …` narrator credits, copyright notices. Most of it was never attached to a book the library shows — so no data cleanup is required to get it out of the app.

Both lists now derive from the same visible-book set `/items` uses, in **one shared pass**, cached together behind the existing 5-minute contributor cache.

## Falls out of the same pass

- **Author `numBooks` counted invisible books** — an author with forty unorganized rows and one real book read "41 books".
- **Narrators gained a real `numBooks`**, previously omitted because there's no reverse narrator→book index.

`visibleBookIDs` pages in chunks rather than one unbounded call, so it never depends on a store's `limit<=0` meaning "everything", and peak memory is one chunk.

## Verification

```
go test ./internal/server/handlers/abs/... -count=1   ok  29.9s
```

New tests seed an unorganized book whose author is a track name and whose narrator is a `Read by …` credit, and assert neither reaches its tab; plus a test that `numBooks` counts only visible books.

⚠️ **The full `internal/server` suite was NOT run before this was committed** — the session was interrupted. Run it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp