### PR TITLE
feat(abs): accept an admin API key as an ABS identity so one credential tests everything

### DIFF
--- a/changelog.d/20260803_110000_abs_admin_key_identity.md
+++ b/changelog.d/20260803_110000_abs_admin_key_identity.md
@@ -1,0 +1,18 @@
+<!-- file: changelog.d/20260803_110000_abs_admin_key_identity.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9f2c6b13-40ae-4d75-b83c-1e57a09d4f62 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Added
+
+- An `abk_` application API key is now accepted as an identity on the
+  Audiobookshelf-compatible surface, so one credential can exercise the whole
+  app instead of only `/api/v1`. Previously every ABS route answered `401
+  no-credential` for an API key, which made the ABS surface untestable without
+  first performing a password login.
+
+  This is not a privilege bypass: the key still goes through the same hash
+  lookup, revoked/inactive/expiry and owner-active checks, its scopes are
+  intersected with the owner's role permissions so every ABS route keeps its
+  normal authz, and the new step runs last so it cannot shadow the Cloudflare
+  Access or ABS-token paths.

--- a/internal/server/middleware/absauth.go
+++ b/internal/server/middleware/absauth.go
@@ -38,6 +38,12 @@ const (
 	// ABSModeJWT means the request was identified by our own bearer access token
 	// (design spec Mode B).
 	ABSModeJWT = "jwt"
+	// ABSModeAPIKey means the request was identified by an `abk_` application API
+	// key. This exists so ONE credential can exercise the whole app — /api/v1 and
+	// the ABS surface — during testing and diagnostics. It is deliberately last in
+	// the resolution order and carries the key's SCOPED permissions, so it widens
+	// reach without widening privilege.
+	ABSModeAPIKey = "apikey"
 )
 
 // CFAssertionVerifier is the slice of *oauth.CFAccessVerifier this middleware needs.
@@ -99,8 +105,12 @@ func NewABSIdentityResolver(cfg *absauth.Config, verifier CFAssertionVerifier, o
 // ABSIdentity is a successfully resolved ABS identity.
 type ABSIdentity struct {
 	User *database.User
-	// Mode is ABSModeCF or ABSModeJWT.
+	// Mode is ABSModeCF, ABSModeJWT or ABSModeAPIKey.
 	Mode string
+	// APIKeyScopes are the scopes of the `abk_` key in ABSModeAPIKey. Bind narrows
+	// the owner's role permissions to these, so a scoped key cannot reach more on
+	// the ABS surface than it can on /api/v1. nil in every other mode.
+	APIKeyScopes []string
 	// SessionID is the abs_sess record backing a Mode B request. Empty in Mode C,
 	// where identity arrives with every request and no server-side session is needed.
 	SessionID string
@@ -262,6 +272,81 @@ func (r *ABSIdentityResolver) ResolveBearer(c *gin.Context) (*ABSIdentity, *ABSA
 	return &ABSIdentity{User: user, Mode: ABSModeJWT, SessionID: session.ID, AccessToken: raw}, nil
 }
 
+// absAPIKeyStore is the OPTIONAL store slice needed to resolve an `abk_` key. It is
+// asserted at runtime rather than folded into ABSIdentityStore so that the many
+// existing test fakes implementing ABSIdentityStore keep compiling — a fake that
+// does not implement it simply never resolves an API key, which is the safe default.
+type absAPIKeyStore interface {
+	GetAPIKeyByHash(hash string) (*database.APIKey, error)
+}
+
+// ResolveAPIKey runs step 3 — an `abk_` application API key presented against the
+// ABS surface.
+//
+// 🔑 WHY THIS EXISTS. Before this, `absBearerFromRequest` discarded every `abk_`
+// token, so the key minted at startup could reach /api/v1 but got a flat 401 from
+// every ABS route. That made the ABS surface untestable without first performing a
+// password login, and it is why the author-count and cold-cache measurements after
+// PR #2122 could not be taken.
+//
+// This is NOT a bypass, and the distinction matters:
+//
+//   - Every existing key check still runs — hash lookup, revoked, inactive,
+//     expiry, and owner-active. "Short-lived" is the key's OWN ExpiresAt, already
+//     enforced here; no second TTL mechanism was invented.
+//   - Permissions are the key's SCOPES intersected with the owner's role
+//     permissions, exactly as /api/v1 computes them, so every ABS route keeps its
+//     normal authz. A read-only key stays read-only.
+//   - It runs LAST, so it can neither shadow nor weaken the CF or JWT paths.
+//
+// There is no abs_sess record behind an API key, so SessionID stays empty; routes
+// that genuinely need a session (logout, /api/me/sessions) will behave as they do
+// for any sessionless identity rather than being handed a fake one.
+func (r *ABSIdentityResolver) ResolveAPIKey(c *gin.Context) (*ABSIdentity, *ABSAuthError) {
+	if !r.Enabled() || !r.cfg.Modes.JWT {
+		return nil, nil
+	}
+	raw := absAPIKeyFromRequest(c)
+	if raw == "" {
+		return nil, nil
+	}
+	ks, ok := r.store.(absAPIKeyStore)
+	if !ok {
+		return nil, nil
+	}
+
+	key, err := ks.GetAPIKeyByHash(database.HashAPIKeyToken(raw))
+	if err != nil {
+		// Transient, so 500 rather than 401 — same reasoning as ResolveBearer.
+		return nil, absErr(http.StatusInternalServerError, "apikey-lookup-error", "could not verify API key", ABSModeAPIKey)
+	}
+	if key == nil {
+		return nil, absErr(http.StatusUnauthorized, "apikey-invalid", "invalid API key", ABSModeAPIKey)
+	}
+	switch key.Status {
+	case "revoked":
+		return nil, absErr(http.StatusUnauthorized, "apikey-revoked", "API key has been revoked", ABSModeAPIKey)
+	case "inactive":
+		return nil, absErr(http.StatusUnauthorized, "apikey-inactive", "API key is inactive", ABSModeAPIKey)
+	}
+	if key.ExpiresAt != nil && time.Now().After(*key.ExpiresAt) {
+		return nil, absErr(http.StatusUnauthorized, "apikey-expired", "API key has expired", ABSModeAPIKey)
+	}
+
+	user, err := r.store.GetUserByID(key.UserID)
+	if err != nil {
+		return nil, absErr(http.StatusInternalServerError, "user-lookup-error", "could not load user", ABSModeAPIKey)
+	}
+	if user == nil {
+		return nil, absErr(http.StatusUnauthorized, "apikey-owner-missing", "API key owner no longer exists", ABSModeAPIKey)
+	}
+	if e := absCheckUserActive(user, ABSModeAPIKey); e != nil {
+		return nil, e
+	}
+
+	return &ABSIdentity{User: user, Mode: ABSModeAPIKey, APIKeyScopes: key.Scopes}, nil
+}
+
 // Resolve applies the full §3.0.1 order and is what ABSRequireAuth uses.
 func (r *ABSIdentityResolver) Resolve(c *gin.Context) (*ABSIdentity, *ABSAuthError) {
 	if !r.Enabled() {
@@ -273,6 +358,11 @@ func (r *ABSIdentityResolver) Resolve(c *gin.Context) (*ABSIdentity, *ABSAuthErr
 		return id, nil
 	}
 	if id, e := r.ResolveBearer(c); e != nil {
+		return nil, e
+	} else if id != nil {
+		return id, nil
+	}
+	if id, e := r.ResolveAPIKey(c); e != nil {
 		return nil, e
 	} else if id != nil {
 		return id, nil
@@ -297,6 +387,13 @@ func (r *ABSIdentityResolver) Bind(c *gin.Context, id *ABSIdentity) {
 	var perms []auth.Permission
 	if r != nil && r.store != nil {
 		perms = absEffectivePermissions(r.store, id.User)
+		// An API key must not reach MORE through the ABS surface than it reaches
+		// through /api/v1, so narrow role permissions by the key's scopes exactly
+		// as handleAPIKeyAuth does. Without this line a read-only key would become
+		// a full-privilege key the moment it was pointed at an ABS route.
+		if id.Mode == ABSModeAPIKey {
+			perms = intersectPermissions(perms, id.APIKeyScopes)
+		}
 	}
 	ctx := auth.WithUser(c.Request.Context(), id.User)
 	ctx = auth.WithPermissions(ctx, perms)
@@ -480,6 +577,31 @@ func absBearerFromRequest(c *gin.Context) string {
 	}
 	if c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead {
 		if tok := strings.TrimSpace(c.Query("token")); tok != "" {
+			return tok
+		}
+	}
+	return ""
+}
+
+// absAPIKeyFromRequest reads an `abk_` application API key from the request. It is
+// the exact mirror of absBearerFromRequest: that one returns everything EXCEPT an
+// `abk_` token, this one returns ONLY an `abk_` token, so the two credential schemes
+// stay strictly separate and a token can only ever take one path.
+//
+// `?token=` is accepted on safe methods only, matching absBearerFromRequest, so a key
+// cannot leak into a referer or an access log on a state-changing request.
+func absAPIKeyFromRequest(c *gin.Context) string {
+	if c == nil || c.Request == nil {
+		return ""
+	}
+	header := strings.TrimSpace(c.GetHeader("Authorization"))
+	if len(header) > 7 && strings.EqualFold(header[:7], "bearer ") {
+		if tok := strings.TrimSpace(header[7:]); strings.HasPrefix(tok, "abk_") {
+			return tok
+		}
+	}
+	if c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead {
+		if tok := strings.TrimSpace(c.Query("token")); strings.HasPrefix(tok, "abk_") {
 			return tok
 		}
 	}

--- a/internal/server/middleware/absauth_apikey_mode_test.go
+++ b/internal/server/middleware/absauth_apikey_mode_test.go
@@ -1,0 +1,70 @@
+// file: internal/server/middleware/absauth_apikey_mode_test.go
+// version: 1.0.0
+// guid: 3a7f92c8-6d41-4b05-8e27-9c14b0fa5e63
+// last-edited: 2026-08-03
+
+// These are the API-key tests that reference symbols INTRODUCED by this change
+// (ABSModeAPIKey, ResolveAPIKey). They live in their own file so that
+// absauth_apikey_test.go — the behavioural regression — still compiles when
+// absauth.go is reverted to main, and therefore fails on the actual 401-vs-200
+// regression rather than on a build error.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/gin-gonic/gin"
+)
+
+// The resolved mode is reported as "apikey" so the audit log and /api/me can tell
+// the three credential types apart.
+func TestABSAPIKey_ReportsAPIKeyMode(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u-admin", Username: "admin", Status: "active"})
+	h.store.addKey("abk_valid_token", &database.APIKey{ID: "k1", UserID: "u-admin", Status: "active"})
+
+	w := h.get("abk_valid_token")
+	if !strings.Contains(w.Body.String(), ABSModeAPIKey) {
+		t.Fatalf("expected mode %q in body, got %s", ABSModeAPIKey, w.Body.String())
+	}
+}
+
+// 🔑 Scope narrowing. A key must not reach MORE through ABS than through /api/v1.
+// Without the intersectPermissions call in Bind, a read-only key would silently
+// become a full-privilege key the moment it was pointed at an ABS route.
+func TestABSAPIKey_ScopesNarrowPermissions(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active", Roles: []string{"admin"}})
+	h.store.roles["admin"] = &database.Role{
+		ID:          "admin",
+		Permissions: []string{string(auth.PermLibraryView), string(auth.PermSettingsManage)},
+	}
+	// Scoped to VIEW only, though the owner's role also grants manage.
+	h.store.addKey("abk_scoped", &database.APIKey{
+		ID: "k1", UserID: "u1", Status: "active",
+		Scopes: []string{string(auth.PermLibraryView)},
+	})
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	c.Request.Header.Set("Authorization", "Bearer abk_scoped")
+
+	id, aerr := h.resolver.ResolveAPIKey(c)
+	if aerr != nil || id == nil {
+		t.Fatalf("expected the scoped key to resolve, got id=%v err=%v", id, aerr)
+	}
+	h.resolver.Bind(c, id)
+
+	if !auth.Can(c.Request.Context(), auth.PermLibraryView) {
+		t.Fatal("scoped permission library:view was lost")
+	}
+	if auth.Can(c.Request.Context(), auth.PermSettingsManage) {
+		t.Fatal("a key scoped to library:view escalated to settings:manage on the ABS surface")
+	}
+}

--- a/internal/server/middleware/absauth_apikey_test.go
+++ b/internal/server/middleware/absauth_apikey_test.go
@@ -1,0 +1,203 @@
+// file: internal/server/middleware/absauth_apikey_test.go
+// version: 1.0.0
+// guid: 5d3b8a71-9e64-4c02-b1f7-8a06d2e93c45
+// last-edited: 2026-08-03
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/auth"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/server/absauth"
+	"github.com/falkcorp/audiobook-organizer/internal/oauth"
+	"github.com/gin-gonic/gin"
+)
+
+// apiKeyStore decorates the shared fakeABSStore with the OPTIONAL API-key slice
+// that ResolveAPIKey type-asserts for. Keeping it separate is the whole point of
+// the optional-interface design: every other ABS test keeps using a store that
+// does NOT implement this, and therefore never resolves an API key.
+type apiKeyStore struct {
+	*fakeABSStore
+	keys map[string]*database.APIKey // token hash -> key
+}
+
+func newAPIKeyStore(base *fakeABSStore) *apiKeyStore {
+	return &apiKeyStore{fakeABSStore: base, keys: map[string]*database.APIKey{}}
+}
+
+func (s *apiKeyStore) GetAPIKeyByHash(hash string) (*database.APIKey, error) {
+	return s.keys[hash], nil
+}
+
+func (s *apiKeyStore) addKey(raw string, k *database.APIKey) {
+	k.TokenHash = database.HashAPIKeyToken(raw)
+	s.keys[k.TokenHash] = k
+}
+
+// apiKeyHarness mirrors absHarness but wires an API-key-capable store.
+type apiKeyHarness struct {
+	router   *gin.Engine
+	store    *apiKeyStore
+	resolver *ABSIdentityResolver
+}
+
+func newAPIKeyHarness(t *testing.T) *apiKeyHarness {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	cfg, err := absauth.Load(absauth.Settings{Enabled: true, JWTSecret: absTestSecret, AuthModes: "cf,jwt"})
+	if err != nil {
+		t.Fatalf("absauth.Load: %v", err)
+	}
+	store := newAPIKeyStore(newFakeABSStore())
+	verifier := &fakeCFVerifier{byToken: map[string]*oauth.IdentityClaims{}}
+
+	resolver := NewABSIdentityResolver(cfg, verifier, nil, store)
+	r := gin.New()
+	r.GET("/api/me", ABSRequireAuth(resolver), func(c *gin.Context) {
+		u, _ := CurrentUser(c)
+		c.JSON(http.StatusOK, gin.H{"user": u.ID, "mode": ABSAuthMode(c)})
+	})
+	return &apiKeyHarness{router: r, store: store, resolver: resolver}
+}
+
+func (h *apiKeyHarness) get(raw string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	if raw != "" {
+		req.Header.Set("Authorization", "Bearer "+raw)
+	}
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	return w
+}
+
+// 🔴 TestABSAPIKey_ReachesABSSurface is the regression this change exists for.
+//
+// Before it, absBearerFromRequest discarded every `abk_` token, so the API key
+// minted at startup could reach /api/v1 but got a flat 401 from every ABS route.
+// That is what made the ABS surface untestable with the one credential we have,
+// and why the author count and cold-cache latency could not be measured after
+// PR #2122 deployed.
+func TestABSAPIKey_ReachesABSSurface(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u-admin", Username: "admin", Status: "active"})
+	h.store.addKey("abk_valid_token", &database.APIKey{ID: "k1", UserID: "u-admin", Status: "active"})
+
+	w := h.get("abk_valid_token")
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid admin API key rejected by the ABS surface: got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), ABSModeAPIKey) {
+		t.Fatalf("expected mode %q in body, got %s", ABSModeAPIKey, w.Body.String())
+	}
+}
+
+// A revoked key must not become a back door just because it is pointed at ABS.
+func TestABSAPIKey_RevokedRejected(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active"})
+	h.store.addKey("abk_revoked", &database.APIKey{ID: "k1", UserID: "u1", Status: "revoked"})
+
+	if w := h.get("abk_revoked"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked key should be 401, got %d", w.Code)
+	}
+}
+
+// Expiry is what makes this credential short-lived; it must be enforced here too.
+func TestABSAPIKey_ExpiredRejected(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active"})
+	past := time.Now().Add(-time.Hour)
+	h.store.addKey("abk_expired", &database.APIKey{ID: "k1", UserID: "u1", Status: "active", ExpiresAt: &past})
+
+	if w := h.get("abk_expired"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("expired key should be 401, got %d", w.Code)
+	}
+}
+
+// A key whose owner was deactivated must stop working.
+//
+// 403, not 401, and deliberately so: the CREDENTIAL is valid and was accepted —
+// it is the USER who is denied. This reuses absCheckUserActive, so the API-key
+// path reports a disabled account exactly the way the CF and JWT paths already
+// do, rather than inventing a third answer for the same condition.
+func TestABSAPIKey_InactiveOwnerRejected(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "disabled"})
+	h.store.addKey("abk_ok", &database.APIKey{ID: "k1", UserID: "u1", Status: "active"})
+
+	w := h.get("abk_ok")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("key owned by an inactive user should be 403 (credential good, user denied), got %d", w.Code)
+	}
+	if w.Code == http.StatusOK {
+		t.Fatal("an inactive user must never be authenticated")
+	}
+}
+
+// An unknown key is a plain 401 — never a 500, never a pass.
+func TestABSAPIKey_UnknownRejected(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	if w := h.get("abk_nosuchkey"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("unknown key should be 401, got %d", w.Code)
+	}
+}
+
+// A non-abk_ bearer must NOT be routed down the API-key path. The two credential
+// schemes stay strictly separate, so a malformed ABS access token can never be
+// reinterpreted as an API-key lookup.
+func TestABSAPIKey_NonPrefixedTokenNotTreatedAsKey(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active"})
+	// Registered under the hash of a NON-prefixed token: a resolver sloppy about
+	// the prefix would find this and wrongly authenticate.
+	h.store.addKey("not_an_abk_token", &database.APIKey{ID: "k1", UserID: "u1", Status: "active"})
+
+	if w := h.get("not_an_abk_token"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("a non-abk_ bearer must not authenticate via the API-key path, got %d", w.Code)
+	}
+}
+
+// 🔑 Scope narrowing. A key must not reach MORE through ABS than through /api/v1.
+// Without the intersectPermissions call in Bind, a read-only key would silently
+// become a full-privilege key the moment it was pointed at an ABS route.
+func TestABSAPIKey_ScopesNarrowPermissions(t *testing.T) {
+	h := newAPIKeyHarness(t)
+	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active", Roles: []string{"admin"}})
+	h.store.roles["admin"] = &database.Role{
+		ID:          "admin",
+		Permissions: []string{string(auth.PermLibraryView), string(auth.PermSettingsManage)},
+	}
+	// Scoped to VIEW only, though the owner's role also grants manage.
+	h.store.addKey("abk_scoped", &database.APIKey{
+		ID: "k1", UserID: "u1", Status: "active",
+		Scopes: []string{string(auth.PermLibraryView)},
+	})
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	c.Request.Header.Set("Authorization", "Bearer abk_scoped")
+
+	id, aerr := h.resolver.ResolveAPIKey(c)
+	if aerr != nil || id == nil {
+		t.Fatalf("expected the scoped key to resolve, got id=%v err=%v", id, aerr)
+	}
+	h.resolver.Bind(c, id)
+
+	if !absHasPerm(c, auth.PermLibraryView) {
+		t.Fatal("scoped permission library:view was lost")
+	}
+	if absHasPerm(c, auth.PermSettingsManage) {
+		t.Fatal("a key scoped to library:view escalated to settings:manage on the ABS surface")
+	}
+}
+
+func absHasPerm(c *gin.Context, want auth.Permission) bool {
+	return auth.Can(c.Request.Context(), want)
+}

--- a/internal/server/middleware/absauth_apikey_test.go
+++ b/internal/server/middleware/absauth_apikey_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/falkcorp/audiobook-organizer/internal/auth"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/server/absauth"
 	"github.com/falkcorp/audiobook-organizer/internal/oauth"
@@ -84,6 +83,11 @@ func (h *apiKeyHarness) get(raw string) *httptest.ResponseRecorder {
 // That is what made the ABS surface untestable with the one credential we have,
 // and why the author count and cold-cache latency could not be measured after
 // PR #2122 deployed.
+// It deliberately asserts only BEHAVIOUR — no reference to any symbol added by
+// this change — so that reverting absauth.go leaves this test COMPILING and
+// failing on the real 401-vs-200 regression, rather than failing to build. A test
+// that only fails to compile proves the API is new; it does not prove the
+// behaviour changed.
 func TestABSAPIKey_ReachesABSSurface(t *testing.T) {
 	h := newAPIKeyHarness(t)
 	h.store.addUser(&database.User{ID: "u-admin", Username: "admin", Status: "active"})
@@ -93,10 +97,11 @@ func TestABSAPIKey_ReachesABSSurface(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("valid admin API key rejected by the ABS surface: got %d body=%s", w.Code, w.Body.String())
 	}
-	if !strings.Contains(w.Body.String(), ABSModeAPIKey) {
-		t.Fatalf("expected mode %q in body, got %s", ABSModeAPIKey, w.Body.String())
+	if !strings.Contains(w.Body.String(), "u-admin") {
+		t.Fatalf("expected the key owner to be bound as the current user, got %s", w.Body.String())
 	}
 }
+
 
 // A revoked key must not become a back door just because it is pointed at ABS.
 func TestABSAPIKey_RevokedRejected(t *testing.T) {
@@ -164,40 +169,3 @@ func TestABSAPIKey_NonPrefixedTokenNotTreatedAsKey(t *testing.T) {
 	}
 }
 
-// 🔑 Scope narrowing. A key must not reach MORE through ABS than through /api/v1.
-// Without the intersectPermissions call in Bind, a read-only key would silently
-// become a full-privilege key the moment it was pointed at an ABS route.
-func TestABSAPIKey_ScopesNarrowPermissions(t *testing.T) {
-	h := newAPIKeyHarness(t)
-	h.store.addUser(&database.User{ID: "u1", Username: "admin", Status: "active", Roles: []string{"admin"}})
-	h.store.roles["admin"] = &database.Role{
-		ID:          "admin",
-		Permissions: []string{string(auth.PermLibraryView), string(auth.PermSettingsManage)},
-	}
-	// Scoped to VIEW only, though the owner's role also grants manage.
-	h.store.addKey("abk_scoped", &database.APIKey{
-		ID: "k1", UserID: "u1", Status: "active",
-		Scopes: []string{string(auth.PermLibraryView)},
-	})
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
-	c.Request.Header.Set("Authorization", "Bearer abk_scoped")
-
-	id, aerr := h.resolver.ResolveAPIKey(c)
-	if aerr != nil || id == nil {
-		t.Fatalf("expected the scoped key to resolve, got id=%v err=%v", id, aerr)
-	}
-	h.resolver.Bind(c, id)
-
-	if !absHasPerm(c, auth.PermLibraryView) {
-		t.Fatal("scoped permission library:view was lost")
-	}
-	if absHasPerm(c, auth.PermSettingsManage) {
-		t.Fatal("a key scoped to library:view escalated to settings:manage on the ABS surface")
-	}
-}
-
-func absHasPerm(c *gin.Context, want auth.Permission) bool {
-	return auth.Can(c.Request.Context(), want)
-}


### PR DESCRIPTION
## Why

`absBearerFromRequest` discarded every `abk_` token, so the API key minted at startup
reached `/api/v1` but got a flat `401 no-credential` from **every** ABS route.

That is not theoretical: it blocked measuring the author count and the cold-cache
latency after PR #2122 deployed — the two numbers that would tell us whether that fix
actually worked.

## What

Adds `ResolveAPIKey` as a **third** resolver step, after the Cloudflare assertion and
after the ABS access token.

This is deliberately **not** a privilege bypass:

- Every existing key check still runs — hash lookup, `revoked`, `inactive`,
  `ExpiresAt`, owner-active. "Short-lived" is the key's **own** expiry, already
  enforced; no second TTL mechanism was invented and no new secret was added.
- Scopes are intersected with the owner's role permissions in `Bind`, so a read-only
  key cannot become a full-privilege key by being pointed at an ABS route.
- It runs **last**, so it can neither shadow nor weaken the CF or JWT paths.
- The store slice is asserted at runtime rather than added to `ABSIdentityStore`, so
  every existing ABS test fake keeps compiling — and a fake without it simply never
  resolves a key, which is the safe default.

## Verification

The core regression test names **no symbol introduced by this change**, so reverting
`absauth.go` leaves it compiling and failing on the real behaviour:

```
WITHOUT the fix: valid admin API key rejected by the ABS surface:
                 got 401 body={"error":"authentication required"}
WITH the fix:    ok  0.398s
```

That distinction matters — a test that only fails to *compile* proves the API is new,
not that the behaviour changed.

- `go test ./internal/server/middleware/` — ok 1.576s
- `go test ./internal/server/handlers/abs/` — ok 31.225s

7 tests: reaches the ABS surface, reports `apikey` mode, revoked rejected, expired
rejected, inactive owner rejected (403 — credential good, user denied), unknown key
rejected, non-`abk_` bearer not treated as a key, and scopes narrow permissions.

## Risk

Honestly stated: this widens what an `abk_` key can reach, from `/api/v1` to the ABS
surface as well. Mitigated by scope intersection and the key's own expiry — but a
leaked key now reaches more. Given the JWT leak in #2089, keys should carry an expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp