### PR TITLE
fix(duration): stop dividing correct second-valued durations by 1000 on read

### DIFF
--- a/changelog.d/20260803_194500_duration_display_unit.md
+++ b/changelog.d/20260803_194500_duration_display_unit.md
@@ -1,0 +1,23 @@
+<!-- file: changelog.d/20260803_194500_duration_display_unit.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7a0c5e38-2f91-4b64-8d05-63c1a9e47f20 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Fixed
+
+- Book durations displayed as near-zero across the library. Four read paths
+  divided `BookFile.Duration` by 1000 on the assumption it stores milliseconds.
+  It stores **seconds** by convention — only about 2% of rows are milliseconds,
+  written by the iTunes importer.
+
+  Worse, the library-list aggregate applied that integer division **per row
+  before summing**, so every file shorter than 1000 seconds contributed exactly
+  zero. Hyperion listed 20 seconds against a stored 174,658, and 25,938 of
+  44,886 books showed an implausibly small duration — every one of them a book
+  that has files, while the books that looked correct were the ones with no
+  files, which skip the aggregation entirely.
+
+  All four sites now use `database.NormalizeDurationSec`, which divides only when
+  the file's implied bitrate proves the value is milliseconds. Correct rows pass
+  through untouched, genuine millisecond rows are still repaired, and books with
+  mixed units are judged row by row.

--- a/internal/audiobooks/duration_unit_test.go
+++ b/internal/audiobooks/duration_unit_test.go
@@ -1,0 +1,93 @@
+// file: internal/audiobooks/duration_unit_test.go
+// version: 1.0.0
+// guid: 4d9e2a71-6b58-4c03-9f14-8e7a05b3d62c
+// last-edited: 2026-08-03
+
+package audiobooks
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// 🔴 TestAggregateFileMetadata_DoesNotDivideCorrectSeconds is the library-list
+// duration regression.
+//
+// aggregateFileMetadataWithFiles did `agg.totalDuration += f.Duration / 1000`,
+// assuming BookFile.Duration is milliseconds. It is SECONDS by convention
+// (database/duration_sanity.go); only ~2% of rows are milliseconds, from the
+// iTunes importer.
+//
+// Two compounding effects, both reproduced here:
+//   - correct values were divided by 1000;
+//   - the division is INTEGER and applied PER ROW BEFORE summing, so every file
+//     shorter than 1000 s contributed exactly 0.
+//
+// On production that showed Hyperion as 20 s against a stored 174,658 s, and
+// left 25,938 of 44,886 books with an implausibly small listed duration.
+func TestAggregateFileMetadata_DoesNotDivideCorrectSeconds(t *testing.T) {
+	svc := &AudiobookService{}
+
+	// A realistic multi-file book: 5 tracks, ~10 min each, all well under the
+	// 1000 s that used to truncate to zero. ~64 kbps implied, plainly plausible.
+	const track = 600      // 10 minutes
+	const size = 4_800_000 // 4.8 MB -> 64 kbps at 600 s
+	files := make([]database.BookFileCore, 0, 5)
+	for i := 0; i < 5; i++ {
+		files = append(files, database.BookFileCore{Duration: track, FileSize: size})
+	}
+
+	books := []database.Book{{ID: "b1"}}
+	svc.aggregateFileMetadataWithFiles(books, map[string][]database.BookFileCore{"b1": files})
+
+	if books[0].Duration == nil {
+		t.Fatal("duration was not aggregated at all")
+	}
+	want := track * 5 // 3000 s
+	if got := *books[0].Duration; got != want {
+		t.Fatalf("aggregated duration = %d, want %d — correct seconds must not be divided (old code gave %d)",
+			got, want, 0)
+	}
+}
+
+// A genuine millisecond row must STILL be repaired, so the fix narrows the
+// division rather than removing it.
+func TestAggregateFileMetadata_StillNormalizesMillisecondRows(t *testing.T) {
+	svc := &AudiobookService{}
+
+	// 4.8 MB with a 600,000 "second" duration implies 64 bits/sec — far below
+	// the 4 kbps floor — while /1000 lands back at a plausible 64 kbps. That is
+	// exactly the millisecond signature DurationLooksLikeMillis detects.
+	files := []database.BookFileCore{{Duration: 600_000, FileSize: 4_800_000}}
+
+	books := []database.Book{{ID: "b1"}}
+	svc.aggregateFileMetadataWithFiles(books, map[string][]database.BookFileCore{"b1": files})
+
+	if books[0].Duration == nil {
+		t.Fatal("duration was not aggregated at all")
+	}
+	if got := *books[0].Duration; got != 600 {
+		t.Fatalf("aggregated duration = %d, want 600 — a real millisecond row must still be normalized", got)
+	}
+}
+
+// Mixed units inside one book: each row is judged on its own evidence.
+func TestAggregateFileMetadata_MixedUnitsInOneBook(t *testing.T) {
+	svc := &AudiobookService{}
+
+	files := []database.BookFileCore{
+		{Duration: 600, FileSize: 4_800_000},     // seconds — keep
+		{Duration: 600_000, FileSize: 4_800_000}, // milliseconds — normalize to 600
+	}
+
+	books := []database.Book{{ID: "b1"}}
+	svc.aggregateFileMetadataWithFiles(books, map[string][]database.BookFileCore{"b1": files})
+
+	if books[0].Duration == nil {
+		t.Fatal("duration was not aggregated at all")
+	}
+	if got := *books[0].Duration; got != 1200 {
+		t.Fatalf("aggregated duration = %d, want 1200 — each row must be judged on its own implied bitrate", got)
+	}
+}

--- a/internal/audiobooks/service_filtering.go
+++ b/internal/audiobooks/service_filtering.go
@@ -920,7 +920,22 @@ func (svc *AudiobookService) aggregateFileMetadataWithFiles(books []database.Boo
 			if f.Missing {
 				continue
 			}
-			agg.totalDuration += f.Duration / 1000
+			// 🔴 NEVER DIVIDE UNCONDITIONALLY. This was `f.Duration / 1000` on the
+			// assumption that BookFile.Duration is milliseconds. It is SECONDS by
+			// convention (see database/duration_sanity.go) — only ~2% of rows are
+			// milliseconds, from the iTunes importer.
+			//
+			// So this divided correct values by 1000, and because it truncated per
+			// row BEFORE summing, every file shorter than 1000 s contributed
+			// exactly 0. Hyperion listed 20 s against a stored 174,658 s, and
+			// 25,938 of 44,886 books showed an implausibly small duration — every
+			// one of them a book that HAS files, while the "plausible" ones were
+			// books with none, which skip this loop entirely.
+			//
+			// NormalizeDurationSec divides only when the file's implied bitrate
+			// proves the value is milliseconds, so a correct row passes through
+			// untouched and a genuine ms row is still repaired.
+			agg.totalDuration += database.NormalizeDurationSec(f.FileSize, f.Duration)
 			agg.totalSize += f.FileSize
 		}
 		if idx, ok := bookIDMap[bookID]; ok {

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -80,7 +80,9 @@ func (h *Handler) ListAudiobookSegments(c *gin.Context) {
 			"file_path":        f.FilePath,
 			"format":           f.Format,
 			"size_bytes":       f.FileSize,
-			"duration_seconds": f.Duration / 1000, // BookFile stores ms
+			// Seconds by convention; normalize only genuine ms rows. See
+			// database.NormalizeDurationSec.
+			"duration_seconds": database.NormalizeDurationSec(f.FileSize, f.Duration),
 			"track_number":     f.TrackNumber,
 			"total_tracks":     f.TrackCount,
 			"segment_title":    f.Title,
@@ -521,7 +523,7 @@ func (h *Handler) GetSegmentTags(c *gin.Context) {
 		"file_path":              found.FilePath,
 		"format":                 found.Format,
 		"size_bytes":             found.FileSize,
-		"duration_sec":           found.Duration / 1000,
+		"duration_sec":           database.NormalizeDurationSec(found.FileSize, found.Duration),
 		"track_number":           found.TrackNumber,
 		"total_tracks":           found.TrackCount,
 		"tags":                   tags,

--- a/internal/server/handlers/versions.go
+++ b/internal/server/handlers/versions.go
@@ -356,7 +356,11 @@ func (h *VersionsHandler) SplitSegmentsToBooks(c *gin.Context) {
 			title = sourceBook.Title + " (split)"
 		}
 
-		durationSec := f.Duration / 1000 // BookFile stores ms
+		// BookFile.Duration is SECONDS by convention; only ~2% of rows are
+		// milliseconds (iTunes importer). Normalize per row on the file's implied
+		// bitrate instead of dividing unconditionally, which was turning correct
+		// values into near-zero.
+		durationSec := database.NormalizeDurationSec(f.FileSize, f.Duration)
 		newBook := &database.Book{
 			Title:     title,
 			AuthorID:  sourceBook.AuthorID,

--- a/todo.d/2026-08-03-flaky-backfill-syncids-race-sanity.md
+++ b/todo.d/2026-08-03-flaky-backfill-syncids-race-sanity.md
@@ -1,0 +1,14 @@
+<!-- file: todo.d/2026-08-03-flaky-backfill-syncids-race-sanity.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2e58c9a1-7b34-4f60-a812-3d90f6c47b25 -->
+<!-- last-edited: 2026-08-03 -->
+
+- [ ] **Flaky: `TestBackfillSyncIDsJob_ConcurrentRaceSanity`** (`internal/maintenance/jobs`)
+      failed the Coverage Floor gate on PR #2123, a PR that touches only
+      `internal/server/middleware/absauth.go` and cannot affect this package.
+      Verified as a flake, not a regression: **10 consecutive passes on the PR
+      branch and 10 on `main`** locally. It fails only under CI load, which fits
+      a timing-sensitive concurrency assertion.
+      Do not just keep re-running it — find the timing assumption (likely a
+      fixed sleep or an unsynchronised goroutine handoff) and make the test wait
+      on a condition instead of a duration. Related: [[project_ci_gotests_intermittent_stalls]].


### PR DESCRIPTION
## The symptom

Book durations displayed as near-zero across the library. Hyperion listed **20 seconds**
against a stored 174,658.

## Why

Four read paths did `BookFile.Duration / 1000`, assuming the field stores milliseconds.
It stores **seconds** by convention (`database/duration_sanity.go`) — only ~2% of rows
are milliseconds, written by the iTunes importer.

The library-list aggregate was the worst of the four, because the integer division was
applied **per row before summing**, so every file shorter than 1000 s contributed
exactly 0.

That reproduces the production numbers precisely: **25,938 of 44,886 books** showed an
implausibly small duration, and every one of them is a book that *has* files — while
the books that looked correct were the ones with **no** files, which skip the
aggregation loop entirely.

## The fix

All four sites now use `database.NormalizeDurationSec`, which divides only when the
file's implied bitrate proves the value is milliseconds:

- `internal/audiobooks/service_filtering.go` — the library-list aggregate
- `internal/server/handlers/versions.go`
- `internal/server/handlers/audiobooks/handler_files.go` (x2)

The remaining `/1000` in the tree are inside the two **guarded** repair paths
(`normalizeBookFileDuration`, `maintenance.duration-backfill`), which is correct.

Note this **narrows** the division rather than removing it — genuine millisecond rows
are still repaired, and a book with mixed units is judged row by row.

## Verification

With `service_filtering.go` reverted to main:

```
--- FAIL: TestAggregateFileMetadata_DoesNotDivideCorrectSeconds
    aggregated duration = 0, want 3000 — correct seconds must not be divided
--- FAIL: TestAggregateFileMetadata_MixedUnitsInOneBook
    aggregated duration = 600, want 1200
```

`TestAggregateFileMetadata_StillNormalizesMillisecondRows` passes **either way**, which
is the point: the fix does not regress the one case the old code got right.

- `go test ./internal/audiobooks/ ./internal/server/handlers/... ./internal/database/ -short` — pass

## Also

Records the flaky `TestBackfillSyncIDsJob_ConcurrentRaceSanity` in `todo.d/`. It failed
the Coverage Floor gate on PR #2123 — a PR that cannot affect that package — and passes
**10/10 locally on both that branch and main**. Filed rather than silently re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp