### PR TITLE
fix(metadata): apply only the gated fields from a transcription match

### DIFF
--- a/changelog.d/20260803_202000_transcription_fields_allowlist.md
+++ b/changelog.d/20260803_202000_transcription_fields_allowlist.md
@@ -1,0 +1,17 @@
+<!-- file: changelog.d/20260803_202000_transcription_fields_allowlist.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5e83b06f-1d47-4a29-95c8-72fb3e0a1d64 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Fixed
+
+- Auto-applying a transcription match wrote the **entire** metadata candidate —
+  narrator, series, series position, year, publisher, ISBN, description,
+  language and cover URL — even though only **title and author** were ever
+  checked by the gates that authorised the apply.
+
+  `ApplyTranscriptionCandidate` passed a nil field list to
+  `ApplyMetadataCandidate`, and nil means "no allowlist". The apply is now
+  narrowed to `["title", "author"]`, matching exactly what
+  `runAutoMatchTranscribed` gates on (normalized exact title equality plus author
+  containment). Widening it is now a deliberate edit rather than a default.

--- a/internal/server/server_maintenance_deps.go
+++ b/internal/server/server_maintenance_deps.go
@@ -526,9 +526,26 @@ func (s *Server) ApplyTranscriptionCandidate(_ context.Context, bookID, gatedTit
 			bookID, gatedTitle, gatedAuthor, cand.Title, cand.Author)
 	}
 
-	_, err = s.metadataFetchService.ApplyMetadataCandidate(bookID, cand, nil)
+	// 🔴 APPLY ONLY WHAT WAS GATED. This used to pass nil, which means "no
+	// allowlist" — so the ENTIRE candidate landed: narrator, series,
+	// series_position, year, publisher, ISBN, description, language and
+	// cover_url, none of which any gate above ever looked at.
+	//
+	// The three gates in runAutoMatchTranscribed and the two TOCTOU re-checks
+	// here all reason about exactly two fields: title and author. Writing eight
+	// more on the strength of those two checks is an unreviewed write, and this
+	// repo has already shipped write-back bugs that wiped Author/Series.
+	//
+	// Widening this is a deliberate decision, not a default — add a field here
+	// only once something actually gates on it.
+	_, err = s.metadataFetchService.ApplyMetadataCandidate(bookID, cand, transcriptionApplyFields)
 	return err
 }
+
+// transcriptionApplyFields is the allowlist for auto-applied transcription
+// matches. It must stay in lockstep with what runAutoMatchTranscribed gates on
+// (normalized exact title equality + author containment).
+var transcriptionApplyFields = []string{"title", "author"}
 
 // WaitForOp implements maintenance.ServerDeps. It polls the database at 5-second
 // intervals until the operation reaches a terminal state or ctx is canceled.

--- a/internal/server/server_maintenance_fields_test.go
+++ b/internal/server/server_maintenance_fields_test.go
@@ -1,0 +1,97 @@
+// file: internal/server/server_maintenance_fields_test.go
+// version: 1.0.0
+// guid: 7c4e1b58-2a93-4f60-9d17-5b8e03c2a7f4
+// last-edited: 2026-08-03
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/metafetch"
+)
+
+// 🔴 TestApplyTranscriptionCandidate_AppliesOnlyGatedFields is the over-apply
+// regression.
+//
+// ApplyTranscriptionCandidate used to call ApplyMetadataCandidate with a nil
+// fields list, which means "no allowlist" — so the ENTIRE candidate was written:
+// narrator, series, series_position, year, publisher, ISBN, description,
+// language and cover_url.
+//
+// Nothing ever gated on those. The three gates in runAutoMatchTranscribed and
+// both TOCTOU re-checks reason about exactly two fields, title and author. So a
+// single passing title comparison authorised eight further unreviewed writes —
+// in a repo that has already shipped write-back bugs that wiped Author/Series.
+//
+// This asserts the write is narrowed to what was actually checked.
+func TestApplyTranscriptionCandidate_AppliesOnlyGatedFields(t *testing.T) {
+	bookID := "book-fields"
+	book := &database.Book{ID: bookID, Title: "Old Title"}
+
+	// A candidate rich in ungated fields. Only Title and Author were gated.
+	cand := metafetch.MetadataCandidate{
+		Title:       "The Stable Book",
+		Author:      "Stable Author",
+		Narrator:    "Some Narrator Nobody Checked",
+		Series:      "A Series Nobody Checked",
+		Publisher:   "A Publisher Nobody Checked",
+		ISBN:        "9780000000001",
+		Description: "A description nobody checked.",
+		Language:    "xx",
+		Year:        1999,
+		Score:       0.9,
+		Source:      "test",
+	}
+	entry := mustCandidateCache(t, bookID, cand)
+
+	store, updateCalls := newTOCTOUCacheStore(t, book, entry, entry)
+	s := &Server{store: store, metadataFetchService: metafetch.NewService(store)}
+	ctx := context.Background()
+
+	candTitle, candAuthor, _, found, err := s.SearchTranscriptionCandidate(ctx, bookID, "irrelevant", "irrelevant")
+	if err != nil || !found {
+		t.Fatalf("SearchTranscriptionCandidate() = (found=%v, err=%v), want found=true", found, err)
+	}
+	if applyErr := s.ApplyTranscriptionCandidate(ctx, bookID, candTitle, candAuthor); applyErr != nil {
+		t.Fatalf("ApplyTranscriptionCandidate() = %v, want nil", applyErr)
+	}
+	if len(*updateCalls) == 0 {
+		t.Fatal("UpdateBook was never called — the gated fields must still apply")
+	}
+
+	got := (*updateCalls)[len(*updateCalls)-1]
+
+	// The gated fields SHOULD land.
+	if got.Title != cand.Title {
+		t.Errorf("title = %q, want %q — the gated field must still be written", got.Title, cand.Title)
+	}
+
+	// Every ungated field must NOT land.
+	if got.Publisher != nil && *got.Publisher != "" {
+		t.Errorf("publisher = %q was written but nothing gated on it", *got.Publisher)
+	}
+	if got.ISBN13 != nil && *got.ISBN13 != "" {
+		t.Errorf("isbn13 = %q was written but nothing gated on it", *got.ISBN13)
+	}
+	if got.ISBN10 != nil && *got.ISBN10 != "" {
+		t.Errorf("isbn10 = %q was written but nothing gated on it", *got.ISBN10)
+	}
+	if got.Description != nil && *got.Description != "" {
+		t.Errorf("description was written (%q) but nothing gated on it", *got.Description)
+	}
+	if got.Language != nil && *got.Language != "" {
+		t.Errorf("language = %q was written but nothing gated on it", *got.Language)
+	}
+	if got.PrintYear != nil && *got.PrintYear != 0 {
+		t.Errorf("print_year = %d was written but nothing gated on it", *got.PrintYear)
+	}
+	if got.AudiobookReleaseYear != nil && *got.AudiobookReleaseYear != 0 {
+		t.Errorf("audiobook_release_year = %d was written but nothing gated on it", *got.AudiobookReleaseYear)
+	}
+	if got.Narrator != nil && *got.Narrator != "" {
+		t.Errorf("narrator = %q was written but nothing gated on it", *got.Narrator)
+	}
+}


### PR DESCRIPTION
## The defect

`ApplyTranscriptionCandidate` passed a **nil** field list to `ApplyMetadataCandidate`,
and nil means *"no allowlist"* — so the **entire** candidate landed: narrator, series,
series_position, year, publisher, ISBN, description, language and cover_url.

Nothing ever gated on those. The three gates in `runAutoMatchTranscribed` and both
TOCTOU re-checks reason about exactly **two** fields: title and author. A single
passing title comparison was authorising eight further unreviewed writes — in a repo
that has already shipped write-back bugs that wiped Author/Series.

## The fix

Narrowed to `["title", "author"]`, matching what is actually checked. Widening it is
now a deliberate edit rather than a default.

## Verification

With the production file reverted to main, the test reports **six** ungated fields
being written:

```
--- FAIL: TestApplyTranscriptionCandidate_AppliesOnlyGatedFields
    publisher   = "A Publisher Nobody Checked" was written but nothing gated on it
    isbn13      = "9780000000001"              was written but nothing gated on it
    description = "A description nobody checked."
    language    = "xx"
    print_year  = 1999
    narrator    = "Some Narrator Nobody Checked"
```

With the fix: `ok internal/server 1.040s`.

## Note on scope

This PR does **not** change `SearchTranscriptionCandidate` to actually search using the
transcription — that remains open. It discards its transcribed title/author arguments
and reads only the pre-existing metadata cache, which is why the dry-run found just
**191 eligible books out of 44,888**. Making it search is the larger change, and it
carries an external-API volume decision worth taking deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp