### PR TITLE
feat(maintenance): add a dry-run op to remove duplicate book_file rows

### DIFF
--- a/changelog.d/20260803_210000_dedupe_book_file_rows.md
+++ b/changelog.d/20260803_210000_dedupe_book_file_rows.md
@@ -1,0 +1,23 @@
+<!-- file: changelog.d/20260803_210000_dedupe_book_file_rows.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8d51c72a-3f96-4b18-a0e4-27c60b9f5e31 -->
+<!-- last-edited: 2026-08-03 -->
+
+### Added
+
+- `maintenance.dedupe-book-file-rows` — a dry-run-by-default op that removes
+  duplicate `book_file` rows, where one book holds more than one row for the
+  same `file_path`.
+
+  Because a book's total duration and file size are a plain sum over its rows,
+  duplication multiplies those totals by the duplication factor. Nine sampled
+  books were affected at roughly 1.92×, including one showing 675.9 hours from
+  66 rows covering 34 real files. This is distinct from the duration-unit
+  problem: the units are correct, the rows are not.
+
+  The op keeps the best-evidenced row — one carrying an AcoustID fingerprint
+  wins over one with only a duration, which wins over one with only a file hash
+  — and falls back to a stable id ordering so a dry run and the apply that
+  follows it always choose the same keeper. Book aggregates are recomputed after
+  each book's deletions. Pass `{"apply": true}` to delete; the default reports
+  only.

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -1,0 +1,258 @@
+// file: internal/plugins/maintenance/dedupe_book_file_rows.go
+// version: 1.0.0
+// guid: 1c7f4b93-6a05-42e8-9d31-8b0e5a2f7c46
+// last-edited: 2026-08-03
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// DedupeBookFileRowsParams are the JSON parameters for the duplicate book_file
+// row cleanup.
+type DedupeBookFileRowsParams struct {
+	// Apply, when true, deletes the redundant rows. Default false — dry run.
+	// Mirrors maintenance.title-repair's convention: a destructive op must be
+	// asked for explicitly, never reached by forgetting a flag.
+	Apply bool `json:"apply"`
+	// Limit caps how many BOOKS are processed (0 = all). Useful for a canary.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *Plugin) dedupeBookFileRowsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.dedupe-book-file-rows",
+		Plugin:      "maintenance",
+		DisplayName: "De-duplicate book_file rows",
+		Description: "Finds books holding MORE THAN ONE book_file row for the same file_path and removes the redundant rows, then recomputes the book's aggregates. Duplicated rows inflate a book's total duration and file size by the duplication factor. Dry-run by default — pass {\"apply\": true} to delete.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.dedupe-book-file-rows",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runDedupeBookFileRows,
+	}
+}
+
+// dupGroup is one (book, file_path) that has more than one row.
+type dupGroup struct {
+	bookID   string
+	filePath string
+	rowIDs   []string // every row for this path, keeper first after ranking
+}
+
+// rankKeeper orders rows so the BEST-EVIDENCED row sorts first and therefore
+// survives.
+//
+// 🔴 THE ORDER HERE IS DATA-LOSS-CRITICAL. This repo has already shipped bugs
+// that wiped AcoustIDFingerprint (see the UpdateBookFile fingerprint-wipe
+// incident). Deleting the wrong twin would destroy a fingerprint that took a
+// full-file decode to produce, and nothing downstream would report it — the book
+// would simply stop matching in dedup.
+//
+// Preference order, most to least important:
+//  1. has an AcoustID fingerprint  — expensive to recompute, impossible to guess
+//  2. has a non-zero duration      — the field this whole cleanup exists to fix
+//  3. has a file hash              — used by integrity checks
+//  4. lexicographically smallest ID — arbitrary but STABLE, so a dry run and the
+//     apply that follows it choose the same keeper
+func rankKeeper(files []database.BookFile) []database.BookFile {
+	out := append([]database.BookFile(nil), files...)
+	score := func(f database.BookFile) (int, int, int) {
+		fp, dur, hash := 0, 0, 0
+		if len(f.AcoustIDFingerprint) > 0 {
+			fp = 1
+		}
+		if f.Duration > 0 {
+			dur = 1
+		}
+		if strings.TrimSpace(f.FileHash) != "" {
+			hash = 1
+		}
+		return fp, dur, hash
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		fi, di, hi := score(out[i])
+		fj, dj, hj := score(out[j])
+		if fi != fj {
+			return fi > fj
+		}
+		if di != dj {
+			return di > dj
+		}
+		if hi != hj {
+			return hi > hj
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params DedupeBookFileRowsParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	log := reporter.Logger()
+	log.Info("dedupe-book-file-rows: starting", "apply", params.Apply, "limit", params.Limit)
+
+	// PASS 1 — cheap. The Core projection is a memdb read, so it is fast enough
+	// to sweep the whole library, and file_path is all we need to FIND duplicates.
+	//
+	// It is deliberately NOT used to DECIDE anything: the Core projection does not
+	// carry AcoustIDFingerprint, so choosing a keeper from it would be choosing
+	// blind on the one field we must not lose.
+	cores, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return fmt.Errorf("scan book_files: %w", err)
+	}
+	byBookPath := map[string][]string{}
+	for i := range cores {
+		c := cores[i]
+		if c.BookID == "" || strings.TrimSpace(c.FilePath) == "" {
+			continue // orphan / pathless rows belong to orphan-book-files-cleanup
+		}
+		key := c.BookID + "\x00" + c.FilePath
+		byBookPath[key] = append(byBookPath[key], c.ID)
+	}
+
+	affected := map[string][]dupGroup{} // bookID -> duplicate groups
+	dupRows := 0
+	for key, ids := range byBookPath {
+		if len(ids) < 2 {
+			continue
+		}
+		parts := strings.SplitN(key, "\x00", 2)
+		g := dupGroup{bookID: parts[0], filePath: parts[1], rowIDs: ids}
+		affected[g.bookID] = append(affected[g.bookID], g)
+		dupRows += len(ids) - 1
+	}
+
+	bookIDs := make([]string, 0, len(affected))
+	for id := range affected {
+		bookIDs = append(bookIDs, id)
+	}
+	sort.Strings(bookIDs) // deterministic order so runs are comparable
+	if params.Limit > 0 && len(bookIDs) > params.Limit {
+		bookIDs = bookIDs[:params.Limit]
+	}
+
+	log.Info("dedupe-book-file-rows: scan complete",
+		"total_rows", len(cores),
+		"books_affected", len(affected),
+		"redundant_rows", dupRows)
+
+	prog := sdk.NewProgress(reporter, len(bookIDs))
+	prog.Start(fmt.Sprintf("%d book(s) hold duplicate book_file rows (%d redundant rows)",
+		len(affected), dupRows))
+
+	var deleted, wouldDelete, failed, recomputed int
+	var examples []string
+
+	// PASS 2 — per affected book only, so the expensive full-fidelity read is paid
+	// for the handful of books that need it rather than the whole library.
+	for i, bookID := range bookIDs {
+		if ctx.Err() != nil {
+			log.Warn("dedupe-book-file-rows: cancelled",
+				"deleted", deleted, "remaining", len(bookIDs)-i)
+			return ctx.Err()
+		}
+
+		// GetBookFiles reads Pebble directly (raw prefix iteration), NOT memdb, so
+		// AcoustIDFingerprint is present and un-stripped here. That is exactly why
+		// the keeper decision happens in this pass and not the previous one.
+		files, ferr := store.GetBookFiles(bookID)
+		if ferr != nil {
+			failed++
+			log.Warn("dedupe-book-file-rows: GetBookFiles failed", "book_id", bookID, "err", ferr)
+			continue
+		}
+		byPath := map[string][]database.BookFile{}
+		for fi := range files {
+			f := files[fi]
+			if strings.TrimSpace(f.FilePath) == "" {
+				continue
+			}
+			byPath[f.FilePath] = append(byPath[f.FilePath], f)
+		}
+
+		changedThisBook := false
+		for path, rows := range byPath {
+			if len(rows) < 2 {
+				continue
+			}
+			ranked := rankKeeper(rows)
+			keeper, redundant := ranked[0], ranked[1:]
+
+			if len(examples) < 10 {
+				examples = append(examples, fmt.Sprintf("%s: %d rows for %q (keeping %s)",
+					bookID, len(rows), shortPath(path), keeper.ID))
+			}
+			if !params.Apply {
+				wouldDelete += len(redundant)
+				continue
+			}
+			for ri := range redundant {
+				if derr := store.DeleteBookFile(redundant[ri].ID); derr != nil {
+					failed++
+					log.Warn("dedupe-book-file-rows: delete failed",
+						"book_id", bookID, "row_id", redundant[ri].ID, "err", derr)
+					continue
+				}
+				deleted++
+				changedThisBook = true
+			}
+		}
+
+		// Totals are a plain sum over the surviving rows, so they are only correct
+		// once the redundant rows are gone — recompute AFTER deleting, per book.
+		if params.Apply && changedThisBook {
+			if rerr := store.RecomputeBookAggregates(bookID); rerr != nil {
+				failed++
+				log.Warn("dedupe-book-file-rows: RecomputeBookAggregates failed",
+					"book_id", bookID, "err", rerr)
+			} else {
+				recomputed++
+			}
+		}
+		prog.StepN(i+1, fmt.Sprintf("Processed %d/%d affected books", i+1, len(bookIDs)))
+	}
+
+	verb := fmt.Sprintf("would delete %d", wouldDelete)
+	if params.Apply {
+		verb = fmt.Sprintf("deleted %d (recomputed %d books)", deleted, recomputed)
+	}
+	summary := fmt.Sprintf(
+		"dedupe-book-file-rows: %d rows scanned, %d books affected, %d redundant rows, %s, failed %d | e.g. %s",
+		len(cores), len(affected), dupRows, verb, failed, strings.Join(examples, "; "))
+	_ = reporter.Log(slog.LevelInfo, summary)
+	prog.Done(summary)
+	return nil
+}
+
+// shortPath trims a long path to its last two segments for log readability.
+func shortPath(p string) string {
+	parts := strings.Split(p, "/")
+	if len(parts) <= 2 {
+		return p
+	}
+	return ".../" + strings.Join(parts[len(parts)-2:], "/")
+}

--- a/internal/plugins/maintenance/dedupe_book_file_rows_test.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows_test.go
@@ -1,0 +1,113 @@
+// file: internal/plugins/maintenance/dedupe_book_file_rows_test.go
+// version: 1.0.0
+// guid: 3b6d19a7-4e52-4c08-b7f1-90a5e2c4d738
+// last-edited: 2026-08-03
+
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// 🔴 The keeper choice is the data-loss-critical part of this op. Every one of
+// these asserts that the row carrying irreplaceable evidence SURVIVES, because
+// the rows that lose are deleted outright.
+//
+// This repo has already shipped a bug that wiped AcoustIDFingerprint, and a
+// fingerprint costs a full-file decode to regenerate. Deleting the wrong twin
+// would be silent: the book would simply stop matching in dedup, with nothing
+// reporting why.
+func TestRankKeeper_PrefersTheFingerprintedRow(t *testing.T) {
+	rows := []database.BookFile{
+		{ID: "aaa-first-alphabetically", Duration: 600, FileHash: "h1"},
+		{ID: "zzz-last-alphabetically", Duration: 600, FileHash: "h1",
+			AcoustIDFingerprint: []byte{0x01, 0x02, 0x03}},
+	}
+	got := rankKeeper(rows)[0]
+	if got.ID != "zzz-last-alphabetically" {
+		t.Fatalf("keeper = %q, want the FINGERPRINTED row — a fingerprint costs a "+
+			"full-file decode and cannot be guessed back", got.ID)
+	}
+}
+
+// Duration is the field this cleanup exists to fix, so a row that has one beats
+// a row that does not — but only when neither side has a fingerprint.
+func TestRankKeeper_PrefersRowWithDuration(t *testing.T) {
+	rows := []database.BookFile{
+		{ID: "a", Duration: 0},
+		{ID: "b", Duration: 3600},
+	}
+	if got := rankKeeper(rows)[0]; got.ID != "b" {
+		t.Fatalf("keeper = %q, want the row with a duration", got.ID)
+	}
+}
+
+// A fingerprint outranks a duration: losing a duration is recoverable by
+// re-probing the file, losing a fingerprint is not cheap to undo.
+func TestRankKeeper_FingerprintOutranksDuration(t *testing.T) {
+	rows := []database.BookFile{
+		{ID: "has-duration-only", Duration: 3600},
+		{ID: "has-fingerprint-only", AcoustIDFingerprint: []byte{0x09}},
+	}
+	if got := rankKeeper(rows)[0]; got.ID != "has-fingerprint-only" {
+		t.Fatalf("keeper = %q, want the fingerprinted row", got.ID)
+	}
+}
+
+// 🔑 Stability matters operationally: the dry run and the apply that follows it
+// must choose the SAME keeper, or the report the owner approved describes a
+// different deletion than the one performed.
+func TestRankKeeper_IsDeterministicAcrossRuns(t *testing.T) {
+	mk := func() []database.BookFile {
+		return []database.BookFile{
+			{ID: "ccc", Duration: 600},
+			{ID: "aaa", Duration: 600},
+			{ID: "bbb", Duration: 600},
+		}
+	}
+	first := rankKeeper(mk())[0].ID
+	for i := 0; i < 20; i++ {
+		if got := rankKeeper(mk())[0].ID; got != first {
+			t.Fatalf("keeper changed between runs: %q then %q — a dry run would not "+
+				"describe the same deletion the apply performs", first, got)
+		}
+	}
+	if first != "aaa" {
+		t.Fatalf("keeper = %q, want the lexicographically smallest id as the stable tiebreak", first)
+	}
+}
+
+// All else equal the file hash breaks the tie before the id does.
+func TestRankKeeper_PrefersRowWithFileHash(t *testing.T) {
+	rows := []database.BookFile{
+		{ID: "aaa", Duration: 600},
+		{ID: "zzz", Duration: 600, FileHash: "abc123"},
+	}
+	if got := rankKeeper(rows)[0]; got.ID != "zzz" {
+		t.Fatalf("keeper = %q, want the row carrying a file hash", got.ID)
+	}
+}
+
+// A single row is returned untouched — nothing to choose, nothing to delete.
+func TestRankKeeper_SingleRowUnchanged(t *testing.T) {
+	rows := []database.BookFile{{ID: "only", Duration: 42}}
+	got := rankKeeper(rows)
+	if len(got) != 1 || got[0].ID != "only" {
+		t.Fatalf("single row was altered: %+v", got)
+	}
+}
+
+// rankKeeper must not mutate its input: the caller still holds the original
+// slice and uses ranked[1:] to decide what to delete.
+func TestRankKeeper_DoesNotMutateInput(t *testing.T) {
+	rows := []database.BookFile{
+		{ID: "aaa"},
+		{ID: "zzz", AcoustIDFingerprint: []byte{0x01}},
+	}
+	_ = rankKeeper(rows)
+	if rows[0].ID != "aaa" || rows[1].ID != "zzz" {
+		t.Fatalf("input slice was reordered: %s, %s", rows[0].ID, rows[1].ID)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -41,6 +41,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.trashCleanupDef(),
 		p.archiveSweepDef(),
 		p.orphanBookFilesCleanupDef(),
+		p.dedupeBookFileRowsDef(),
 		p.integrityCheckDef(),
 
 		// --- database ---


### PR DESCRIPTION
## Why

Nine sampled books hold roughly **two** `book_file` rows per real file:

```
The Path of Ascension Vol. 1   rows=66  distinct_paths=34   1.94x   675.9h
Dark Ages: Mage                rows=54  distinct_paths=28   1.93x   249.6h
San Kuo                        rows=58  distinct_paths=30   1.93x   294.0h
```

A book's total duration and file size are a **plain sum over its rows**, so
duplication multiplies those totals by the duplication factor.

This is a *different* defect from the duration-unit problem fixed in #2125 — here the
units are correct and the rows are not, which is why `duration-reextract` corrected 798
books but left these inflated.

No existing op covers it: `orphan-book-files-cleanup` removes rows whose **book is
gone**, not two live rows for the same path.

## Safety

**Dry-run by default** (`Apply=false`), mirroring `maintenance.title-repair` — a
destructive op must be asked for, never reached by forgetting a flag.

**Two passes, deliberately:**

1. `GetAllBookFilesCore` (memdb, cheap) to **find** duplicate `(book, path)` pairs.
2. `GetBookFiles` per affected book to **decide**, because it reads Pebble directly and
   therefore still carries `AcoustIDFingerprint`.

That split is the point. The Core projection **strips the fingerprint**, so choosing a
keeper from pass 1 would be choosing blind on the one field that must not be lost — and
this repo has already shipped a bug that wiped `AcoustIDFingerprint`. Deleting the wrong
twin would be silent: the book would just stop matching in dedup.

## Keeper ranking

Fingerprint > duration > file hash > lexicographically smallest id.

The final tiebreak is **stable on purpose**: a dry run and the apply that follows must
choose the same keeper, or the report you approved describes a different deletion than
the one performed. That's asserted directly (`TestRankKeeper_IsDeterministicAcrossRuns`,
20 iterations).

## Verification

7 tests, all on the data-loss-critical path:

- fingerprinted row always survives
- fingerprint outranks duration
- duration outranks nothing-at-all
- file hash breaks the next tie
- ranking is deterministic across runs
- a single row is untouched
- the input slice is not mutated (the caller uses `ranked[1:]` to decide deletions)

`go test ./internal/plugins/maintenance/ -short` — ok 5.445s

## Not included

The other 5 inflated books (Wind and Truth 426 rows, Ajax's Ascension 272) have
**all-distinct paths** — multiple physical copies grouped into one Book, the Hyperion
pattern. Nothing to delete there; that needs regrouping and is being surfaced through
the review queue instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp