### PR TITLE
fix(maintenance): salvage missing fields into the keeper before deleting its twins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 <!-- file: TODO.md -->
 <!-- version: 10.13.9 -->
+<!-- version: 10.14.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -108,16 +109,29 @@ the play session, `startOffset`, synthesized chapters, and the progress fraction
 a ~2000× inflated denominator, `currentTime / duration` rounds to zero — which is
 exactly the reported **"0%"** — and the remaining-time readout is nonsense.
 
-### Scope is UNKNOWN — measure before fixing
+### Scope — MEASURED 2026-08-03
 
-Confirmed for this one book. Whether it is iTunes-import-specific or library-wide is
-**not** established, and that decides the size of the job:
+Both defects were measured library-wide, and the two turned out to have very
+different shapes than this single-book sample suggested.
 
-```bash
-# per book: row count vs distinct track count, and how many durations look like ms
-curl -sk -H "Authorization: Bearer $ABK" \
-  "https://127.0.0.1:8484/api/v1/audiobooks/<id>/files"
-```
+**Defect 2 (units) is small and was mostly a _display_ bug, not stored corruption.**
+Only ~2% of rows actually hold milliseconds. The library-wide symptom — 25,938 books
+showing absurd totals — came from `service_filtering.go`, which divided **every**
+duration by 1000 unconditionally while summing, and truncated each row to an integer
+before adding. Correct second-valued rows were the ones being destroyed, on read.
+Fixed in #2125 by routing the sum through `database.NormalizeDurationSec`, which
+classifies **per row** from the bitrate the file size implies — exactly the
+idempotent, per-row test this entry demanded. Zero of 843 multi-file books still show
+the symptom.
+
+**Defect 1 (duplication) is real, larger, and is NOT a uniform 2×.** The "2.00x"
+figure was an artifact of the one book sampled. The true shape is a single file
+duplicated up to **130 times**: `The Trapped Mind Project` had 130 rows for one file,
+and one m4b's runtime was being counted 26 times (`568,802s = 26 × 21,877` exactly).
+Addressed by a new dry-run-by-default op, `maintenance.dedupe-book-file-rows`
+(#2128), which finds candidates on the cheap memdb path and then re-reads each group
+Pebble-direct before deciding, because the memdb projection strips
+`AcoustIDFingerprint`.
 
 ### Do not fix blind
 
@@ -129,6 +143,33 @@ curl -sk -H "Authorization: Bearer $ABK" \
   correct. Any repair has to classify per row, not per book.
 - Fixing units without deduping (or vice versa) leaves the duration wrong by 2×,
   which is still enough to misplace every chapter boundary.
+
+### Status 2026-08-04
+
+- [x] **Defect 2 — units.** Fixed on the read path (#2125) plus 798 stored durations
+      corrected. `NormalizeDurationSec` classifies per row, so it is idempotent and
+      cannot corrupt already-correct rows.
+- [x] **Dry-run op for Defect 1.** `maintenance.dedupe-book-file-rows` shipped
+      (#2128), dry-run by default, mirroring `maintenance.title-repair`'s `Apply=false`.
+- [x] **Canary applied — 10 books, 338 rows deleted.** Every corrected total verified
+      after restart (`Defending the Lost` 158.00h → 12.15h, `San Kuo` 294.05h → 19.66h)
+      with `fingerprinted_file_count` unchanged on all 10.
+- [x] **Canary defect — keeper lost data.** Ranking picks a whole row, so a
+      fingerprinted keeper with no duration lost the duration to deletion. The keeper
+      now merges every missing field from its twins before they are destroyed (#2129).
+- [ ] **Apply to the remaining ~194 books** (3,239 − 338 rows). Blocked on #2129
+      deploying; re-running before then would repeat the data loss above.
+- [ ] **Restore `The Trapped Mind Project`** (`01KNDB97CWFSMSEY68P82VDRBF`) — left at
+      0.00h by the canary. The file is intact, so `maintenance.duration-reextract`
+      recovers it from ffprobe.
+- [ ] **5 books are multi-copy, not row-duplicated** — distinct paths for the same
+      book (`Wind and Truth` 426 files, `Ajax's Ascension` 272). Deduping rows is the
+      wrong tool; these need regrouping and should surface in the review queue.
+- [ ] **`Call to Arms` (9,957h)** — 96 *distinct* files, unchanged by the dedupe run.
+      A third shape, not yet diagnosed.
+- [ ] **Corrected aggregates are invisible until memdb refreshes** — see the
+      2026-08-04 entry on `RecomputeBookAggregates`. Not a duration bug, but it makes
+      every duration fix look like a no-op until a restart.
 
 <!-- file: todo.d/2026-08-01-assignorphanvgs-offset-pagination.md -->
 <!-- version: 1.0.0 -->
@@ -1133,12 +1174,16 @@ Companion docs:
 45. **Performance items #1/#2/#6** (2026-04-14 set) — still open.
 46. **Duration/filesize aggregation** — Book fields show snapshots instead of sums;
     likely stale (F5-T026 shipped) — verify then close.
-    - **46b. `/audiobooks` LIST endpoint mis-serializes `duration`** (found 2026-07-19) —
-      low-severity display bug: the list endpoint returns e.g. `duration: 4` for a book
-      whose *detail* endpoint (and stored data) correctly returns `4680` (~78 min). Looks
-      like a seconds-vs-ms unit slip in the list serializer only; stored/file-level data is
-      fine (NOT corruption). Fix the list handler's duration field. Cross-ref
-      `internal/server/handlers/audiobooks/handler.go`.
+    - ~~**46b. `/audiobooks` LIST endpoint mis-serializes `duration`** (found
+      2026-07-19)~~ **DONE 2026-08-03 (#2125).** The reported symptom — list says
+      `duration: 4` where the detail endpoint says `4680` — was the arithmetic itself:
+      `4680 / 1000` truncates to `4`. `service_filtering.go:923` divided every
+      duration by 1000 unconditionally while aggregating, so the rows it corrupted
+      were the *correct* second-valued ones. Now routed through
+      `database.NormalizeDurationSec`, which classifies per row from the implied
+      bitrate. Same fix applied to `handlers/versions.go` and
+      `handlers/audiobooks/handler_files.go` (×2). Far from low-severity: it affected
+      25,938 books.
 47. **Library centralization backlog** — needs a brainstorming session; future work.
 48. **Transcription quality filter** — ~40% of transcripts low-quality/unparsed; list
     endpoint omits transcription fields.

--- a/changelog.d/20260804_010000_dedupe_keeper_field_merge.md
+++ b/changelog.d/20260804_010000_dedupe_keeper_field_merge.md
@@ -1,0 +1,41 @@
+<!-- file: changelog.d/20260804_010000_dedupe_keeper_field_merge.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: ea73f5ef-cfab-4f6a-80c9-88fc14bacb1e -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- `maintenance.dedupe-book-file-rows` no longer destroys data held only by the rows
+  it deletes. The op collapses redundant `book_file` rows that all describe the same
+  file on disk, and it chose which row to keep by ranking them. But ranking picks a
+  whole **row**, and the best row is not guaranteed to be the most complete one: a
+  row carrying an AcoustID fingerprint could have no duration at all, while the
+  duration lived on a twin that was then deleted.
+
+  The first canary run made this concrete. `The Trapped Mind Project` had 130 rows
+  for one file. The op correctly kept the fingerprinted row — a fingerprint costs a
+  full-file decode to regenerate — and correctly deleted the other 129, but that row
+  had `Duration == 0`, so the book went to **0.00h**.
+
+  The keeper now absorbs every field it is missing from the rows about to be
+  destroyed: duration, AcoustID fingerprint, fingerprint duration, file hash, and
+  file size. The merge is strictly additive — a value the keeper already holds always
+  wins — so it can only recover data, never degrade it. The salvaged row is written
+  **before** any twin is deleted, and a failed write skips the whole group rather
+  than deleting donors whose data was never rescued.
+
+  The canary that found this was run against 10 books (338 rows deleted) precisely
+  so a design error would surface at that scale instead of across the whole library.
+
+### Changed
+
+- `maintenance.dedupe-book-file-rows` now states in its completion message that
+  corrected totals may not be visible until the in-memory index refreshes. The same
+  canary showed all 10 durations unchanged immediately after the apply, with a
+  restart then revealing the already-correct values (`Defending the Lost`
+  158.00h → 12.15h) — the data in PebbleDB was right the whole time and only the
+  memdb-backed read was stale. The underlying cause is recorded in `todo.d/`:
+  `RecomputeBookAggregates` early-returns without calling `UpdateBook` when the
+  recomputed values match the stored ones, and `UpdateBook` is what triggers the
+  memdb reload of `book_files`. Saying so beats letting an operator conclude the run
+  did nothing.

--- a/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
+++ b/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
@@ -1,0 +1,107 @@
+<!-- file: docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4c2a5631-03db-4f50-ab49-7056ec114fe6 -->
+<!-- last-edited: 2026-08-04 -->
+
+# Almost every audiobook was showing the wrong running time
+
+## What was wrong
+
+Book lengths in the library were nonsense. A twelve-hour book listed as **158 hours**.
+Another showed **294 hours** — twelve solid days. Elsewhere the opposite: a
+seventy-eight-minute book listed as **4 minutes**.
+
+This was not cosmetic. The running time is the number everything else divides by, so
+when it is wrong, your listening progress reads **0%** no matter how far in you are,
+the "time remaining" is meaningless, and chapter positions land in the wrong place.
+About **26,000 books** were affected.
+
+There were also two smaller complaints that turned out to be worth chasing: the
+Authors tab was full of names that were not authors, and the Narrators tab was nearly
+empty.
+
+## What was actually happening
+
+**Two completely separate problems** were producing the same symptom, which is why it
+looked like one big mysterious mess.
+
+**The first was arithmetic, and it was the larger of the two.** Audiobook lengths are
+stored in seconds. Somewhere along the way the code became convinced they were stored
+in *milliseconds*, so every time it added up a book's length it first divided by
+1,000 — and threw away the remainder. A 78-minute book (4,680 seconds) became 4,680 ÷
+1,000 = 4.68, rounded down to **4**. The rows being destroyed were the *correct* ones.
+
+Only about 2% of records genuinely were in milliseconds, left behind by an old import.
+The fix was not to divide everything, nor to divide nothing, but to work out each
+record individually: knowing a file's size and its claimed length tells you its
+implied bitrate, and only one of the two interpretations produces a bitrate a real
+audio file could have. That test is safe to run repeatedly — a record already correct
+stays correct.
+
+**The second problem was duplicate records**, and it was stranger. A single audio file
+could be recorded in the database dozens of times over. One book had **130 copies** of
+the same file. Another had a single audiobook's runtime counted **26 times** — the
+294-hour book was one 21,877-second file added up 26 times, exactly.
+
+## What we changed
+
+The arithmetic fix went out first, since it was the bigger cause and carried no risk
+of losing anything: it only changes how a number is *read*. Every multi-file book we
+could check now shows a sane length.
+
+For the duplicates we built a dedicated cleanup tool that **does nothing at all unless
+explicitly told to** — it reports what it would remove and stops there. Deleting
+records is irreversible, and duplicate rows are not identical: one copy might carry
+the acoustic fingerprint used to recognise the audio, another the length, another the
+file checksum. Choosing wrong destroys something expensive to rebuild.
+
+We then ran it on **ten books only**, and checked the outcome book by book.
+
+## What the ten-book trial caught
+
+It caught a real flaw, which is exactly why it was run.
+
+Eight of the ten came out perfect — 158 hours to 12.15, 294 to 19.66 — with every
+acoustic fingerprint intact. But the tool picked which *record* to keep, and the best
+record is not always the most complete one. For one book it kept the copy holding the
+fingerprint, correctly, and deleted the 129 others — but that copy had no length
+stored, and the length only existed on the copies just deleted. The book dropped to
+**zero hours**.
+
+Had that run against the whole library instead of ten books, it would have quietly
+blanked the length on an unknown number of books while appearing to succeed.
+
+The tool now takes the best of *every* piece of information from the records it is
+about to remove and merges it into the one it keeps — it can only ever fill in a gap,
+never overwrite something already there. The rescued record is saved **before**
+anything is deleted, and if that save fails the whole group is skipped rather than
+half-cleaned. The one damaged book can be fully recovered, since the audio file itself
+was never touched.
+
+The remaining ~194 books are deliberately **not** cleaned up yet. That waits until the
+corrected tool is deployed.
+
+## One more thing worth knowing
+
+The trial surfaced a second, subtler issue: after the cleanup ran, every length still
+looked wrong. Only after restarting the server did the corrected values appear — they
+had been right in the database the entire time, but the app's fast in-memory copy had
+not been told to refresh.
+
+That is its own bug and it is now written down rather than patched in a hurry, because
+it affects anything that changes a book's files, not just this one tool. In the
+meantime the cleanup tool says so plainly when it finishes, so nobody concludes it did
+nothing and runs it a second time.
+
+## Also fixed
+
+- **The Authors tab listed people who were not authors.** The library was showing
+  16,491 books but building the author list from all 44,888 records, including hidden
+  and duplicate ones. Both lists now come from the books you can actually see.
+- **The Narrators tab was nearly empty.** Narrators are recorded in three different
+  places depending on where the data came from, and the tab was only reading one of
+  them, while the book's own detail page read all three. The two now share the same
+  logic, so they cannot drift apart again.
+- **Metadata from automatic transcription was overwriting too much.** When the app
+  matched a book by listening to it, it applied *every* field it had inferred. It now
+  applies only title and author — the two it is actually reliable at.

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -100,6 +100,40 @@ func rankKeeper(files []database.BookFile) []database.BookFile {
 	return out
 }
 
+// mergeMissingFields fills fields the keeper lacks from the twins about to be
+// deleted, and reports whether anything was salvaged.
+//
+// Strictly additive: a field the keeper already has is never touched, so the
+// merge can only ever recover data, never degrade it. The twins are scanned in
+// ranked order, so the best-evidenced donor is consulted first.
+func mergeMissingFields(keeper database.BookFile, twins []database.BookFile) (database.BookFile, bool) {
+	changed := false
+	for i := range twins {
+		t := twins[i]
+		if keeper.Duration <= 0 && t.Duration > 0 {
+			keeper.Duration = t.Duration
+			changed = true
+		}
+		if len(keeper.AcoustIDFingerprint) == 0 && len(t.AcoustIDFingerprint) > 0 {
+			keeper.AcoustIDFingerprint = t.AcoustIDFingerprint
+			changed = true
+		}
+		if strings.TrimSpace(keeper.FileHash) == "" && strings.TrimSpace(t.FileHash) != "" {
+			keeper.FileHash = t.FileHash
+			changed = true
+		}
+		if keeper.FileSize <= 0 && t.FileSize > 0 {
+			keeper.FileSize = t.FileSize
+			changed = true
+		}
+		if keeper.AcoustIDFingerprintDurationSec <= 0 && t.AcoustIDFingerprintDurationSec > 0 {
+			keeper.AcoustIDFingerprintDurationSec = t.AcoustIDFingerprintDurationSec
+			changed = true
+		}
+	}
+	return keeper, changed
+}
+
 func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
 	var params DedupeBookFileRowsParams
 	if len(raw) > 0 {
@@ -164,7 +198,7 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 	prog.Start(fmt.Sprintf("%d book(s) hold duplicate book_file rows (%d redundant rows)",
 		len(affected), dupRows))
 
-	var deleted, wouldDelete, failed, recomputed int
+	var deleted, wouldDelete, failed, recomputed, salvaged int
 	var examples []string
 
 	// PASS 2 — per affected book only, so the expensive full-fidelity read is paid
@@ -202,14 +236,47 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 			ranked := rankKeeper(rows)
 			keeper, redundant := ranked[0], ranked[1:]
 
+			// 🔴 MERGE, DON'T JUST PICK. Ranking alone chooses a whole ROW, so a
+			// keeper that carries a fingerprint but no duration silently loses the
+			// duration held by one of its twins.
+			//
+			// That is not hypothetical: the first canary run left "The Trapped Mind
+			// Project" (130 rows for one file) reading 0.00h, because the
+			// fingerprinted row it kept had Duration == 0 while a discarded twin had
+			// the real value.
+			//
+			// So salvage every field the keeper is missing before its twins are
+			// deleted. Only ever FILLS empty fields — a value the keeper already has
+			// always wins, so this can never overwrite good data with worse.
+			merged, changed := mergeMissingFields(keeper, redundant)
+			keeper = merged
+
 			if len(examples) < 10 {
 				examples = append(examples, fmt.Sprintf("%s: %d rows for %q (keeping %s)",
 					bookID, len(rows), shortPath(path), keeper.ID))
 			}
 			if !params.Apply {
 				wouldDelete += len(redundant)
+				if changed {
+					salvaged++
+				}
 				continue
 			}
+
+			// Persist the salvaged fields BEFORE deleting the donors. If the write
+			// fails we skip this group entirely rather than delete rows whose data
+			// was never rescued — losing a duration is recoverable, losing it while
+			// also deleting the only copy is not.
+			if changed {
+				if uerr := store.UpdateBookFile(keeper.ID, &keeper); uerr != nil {
+					failed++
+					log.Warn("dedupe-book-file-rows: could not persist salvaged fields; leaving this group intact",
+						"book_id", bookID, "keeper", keeper.ID, "err", uerr)
+					continue
+				}
+				salvaged++
+			}
+
 			for ri := range redundant {
 				if derr := store.DeleteBookFile(redundant[ri].ID); derr != nil {
 					failed++
@@ -236,12 +303,19 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 		prog.StepN(i+1, fmt.Sprintf("Processed %d/%d affected books", i+1, len(bookIDs)))
 	}
 
-	verb := fmt.Sprintf("would delete %d", wouldDelete)
+	verb := fmt.Sprintf("would delete %d (would salvage fields on %d keepers)", wouldDelete, salvaged)
 	if params.Apply {
-		verb = fmt.Sprintf("deleted %d (recomputed %d books)", deleted, recomputed)
+		verb = fmt.Sprintf("deleted %d (salvaged fields on %d keepers, recomputed %d books)",
+			deleted, salvaged, recomputed)
 	}
+	// ⚠️ Operational note, learned the hard way on the first canary: the corrected
+	// totals are NOT visible until memdb catches up. Immediately after an apply the
+	// list projection still reported the pre-delete duration and file count, and a
+	// service restart was what surfaced the (already correct) values. Say so, or
+	// the next operator concludes the op did nothing.
 	summary := fmt.Sprintf(
-		"dedupe-book-file-rows: %d rows scanned, %d books affected, %d redundant rows, %s, failed %d | e.g. %s",
+		"dedupe-book-file-rows: %d rows scanned, %d books affected, %d redundant rows, %s, failed %d "+
+			"| NOTE: corrected totals may not appear until memdb refreshes (restart) | e.g. %s",
 		len(cores), len(affected), dupRows, verb, failed, strings.Join(examples, "; "))
 	_ = reporter.Log(slog.LevelInfo, summary)
 	prog.Done(summary)

--- a/internal/plugins/maintenance/dedupe_book_file_rows_test.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows_test.go
@@ -90,6 +90,79 @@ func TestRankKeeper_PrefersRowWithFileHash(t *testing.T) {
 	}
 }
 
+// 🔴 THE CANARY REGRESSION. "The Trapped Mind Project" had 130 rows for one
+// file. Ranking kept the fingerprinted row, which had Duration == 0, and the
+// book dropped to 0.00h — the duration existed only on rows that were then
+// deleted.
+//
+// Ranking picks a ROW; the keeper must instead end up with the best of EVERY
+// field before its twins are destroyed.
+func TestMergeMissingFields_RecoversDurationFromADiscardedTwin(t *testing.T) {
+	keeper := database.BookFile{ID: "keeper", AcoustIDFingerprint: []byte{0x01}}
+	twins := []database.BookFile{
+		{ID: "twin-a", Duration: 0},
+		{ID: "twin-b", Duration: 21877},
+	}
+	got, changed := mergeMissingFields(keeper, twins)
+	if !changed {
+		t.Fatal("merge reported no change, but the keeper was missing a duration")
+	}
+	if got.Duration != 21877 {
+		t.Fatalf("duration = %d, want 21877 recovered from the twin that is about to be deleted", got.Duration)
+	}
+	if len(got.AcoustIDFingerprint) != 1 {
+		t.Fatal("the keeper's own fingerprint was lost during the merge")
+	}
+}
+
+// The merge must be strictly additive: a value the keeper already holds always
+// wins, so this can never replace good data with worse.
+func TestMergeMissingFields_NeverOverwritesExistingValues(t *testing.T) {
+	keeper := database.BookFile{
+		ID: "keeper", Duration: 3600, FileHash: "good", FileSize: 999,
+		AcoustIDFingerprint: []byte{0xAA},
+	}
+	twins := []database.BookFile{{
+		ID: "twin", Duration: 1, FileHash: "worse", FileSize: 1,
+		AcoustIDFingerprint: []byte{0xBB},
+	}}
+	got, changed := mergeMissingFields(keeper, twins)
+	if changed {
+		t.Fatal("merge reported a change although the keeper was complete")
+	}
+	if got.Duration != 3600 || got.FileHash != "good" || got.FileSize != 999 ||
+		got.AcoustIDFingerprint[0] != 0xAA {
+		t.Fatalf("an existing keeper value was overwritten: %+v", got)
+	}
+}
+
+// A fingerprint can be salvaged too, not just a duration.
+func TestMergeMissingFields_RecoversFingerprintAndFpDuration(t *testing.T) {
+	keeper := database.BookFile{ID: "keeper", Duration: 600}
+	twins := []database.BookFile{{
+		ID: "twin", AcoustIDFingerprint: []byte{0x07, 0x08},
+		AcoustIDFingerprintDurationSec: 601.5,
+	}}
+	got, changed := mergeMissingFields(keeper, twins)
+	if !changed || len(got.AcoustIDFingerprint) != 2 {
+		t.Fatalf("fingerprint was not salvaged: %+v", got)
+	}
+	if got.AcoustIDFingerprintDurationSec != 601.5 {
+		t.Fatalf("fingerprint duration = %v, want 601.5", got.AcoustIDFingerprintDurationSec)
+	}
+}
+
+// Nothing to salvage means nothing is written — the op must not issue a pointless
+// UpdateBookFile, which is the one write path that bypasses the millisecond guard.
+func TestMergeMissingFields_NoChangeWhenNothingToSalvage(t *testing.T) {
+	keeper := database.BookFile{ID: "k", Duration: 100, FileSize: 10, FileHash: "h",
+		AcoustIDFingerprint: []byte{0x01}, AcoustIDFingerprintDurationSec: 100}
+	_, changed := mergeMissingFields(keeper, []database.BookFile{{ID: "t"}})
+	if changed {
+		t.Fatal("merge reported a change with nothing to salvage")
+	}
+}
+
 // A single row is returned untouched — nothing to choose, nothing to delete.
 func TestRankKeeper_SingleRowUnchanged(t *testing.T) {
 	rows := []database.BookFile{{ID: "only", Duration: 42}}

--- a/todo.d/2026-08-04-recompute-aggregates-stale-memdb.md
+++ b/todo.d/2026-08-04-recompute-aggregates-stale-memdb.md
@@ -1,0 +1,40 @@
+<!-- file: todo.d/2026-08-04-recompute-aggregates-stale-memdb.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4a29d7e1-83b6-4c50-9f27-1e08b5c3a64d -->
+<!-- last-edited: 2026-08-04 -->
+
+- [ ] **Corrected book aggregates are invisible until memdb refreshes.**
+      Observed on the first `maintenance.dedupe-book-file-rows` canary
+      (2026-08-03): 338 redundant rows were deleted from 10 books and every
+      duration was **unchanged** immediately afterwards. `total_file_count` still
+      read 50 for a book whose files endpoint already returned 26. A service
+      restart surfaced the corrected values — e.g. "Defending the Lost"
+      158.00h → **12.15h** — so the data in Pebble was right the whole time and
+      only the memdb-backed read was stale.
+
+      Where to look: `DeleteBookFile`
+      (`internal/database/pebble_store_bookfiles.go:730`) does the right things in
+      the right order — Pebble delete, `DeleteBookFileFromMemDB`, then
+      `notifyBookFileChange`. The suspect is
+      `RecomputeBookAggregates`
+      (`internal/database/pebble_store_book_aggregates.go:131-134`), which
+      **early-returns without calling `UpdateBook`** when the recomputed values
+      equal the stored ones. `UpdateBook` is what triggers `UpsertBookToMemDB`,
+      and that is the call which reloads `book_files` from Pebble
+      (`internal/database/memdb_sync.go:53-55`). Skip the write and memdb keeps
+      the stale file set.
+
+      Why it matters beyond this op: any caller that deletes book_files and
+      relies on the aggregate being visible has the same blind spot, and the
+      library list computes duration from the memdb file map, not the stored
+      field.
+
+      Until it is fixed, `dedupe-book-file-rows` says so in its completion
+      message rather than letting an operator conclude the run did nothing.
+
+- [ ] **Restore the duration on `The Trapped Mind Project`**
+      (`01KNDB97CWFSMSEY68P82VDRBF`). The first canary kept a fingerprinted row
+      whose `Duration` was 0 and deleted the 129 twins that held the real value,
+      leaving the book at 0.00h. The merge fix prevents recurrence but cannot
+      undo it — the file itself is intact, so
+      `maintenance.duration-reextract` will recover the value from ffprobe.


### PR DESCRIPTION
## What the canary found

The first real run (10 books, 338 rows deleted, 0 fingerprints lost) worked — and
exposed a design error in #2128.

Ranking chooses a whole **row**. So a keeper carrying a fingerprint but **no duration**
silently lost the duration held by a twin that was then deleted.

`The Trapped Mind Project` — 130 rows for a single file — dropped to **0.00h** exactly
this way. The fingerprinted row it kept had `Duration == 0`.

## The fix

`mergeMissingFields` fills every field the keeper lacks from the rows about to be
destroyed: duration, fingerprint, fingerprint duration, file hash, file size.

- **Strictly additive** — a value the keeper already holds always wins, so the merge can
  only recover data, never degrade it.
- The salvaged keeper is persisted **before** any twin is deleted.
- A failed write **skips the group** rather than deleting donors whose data was never
  rescued. Losing a duration is recoverable; losing it while also deleting the only
  remaining copy is not.

## Second finding: corrected totals are invisible until memdb refreshes

Immediately after the apply, **all 10 durations were unchanged** and `total_file_count`
still read 50 for a book whose files endpoint already returned 26. A restart surfaced
the already-correct values:

```
Defending the Lost   158.00h -> 12.15h
Dark Ages: Mage      249.58h -> 17.83h
Impersonation        238.04h -> 12.87h
San Kuo              294.05h -> 19.66h
```

Suspect is `RecomputeBookAggregates` early-returning without calling `UpdateBook`, which
is what triggers `UpsertBookToMemDB` and its reload of `book_files` from Pebble. Filed
in `todo.d/` with the trace. The op now states this in its completion message so the
next operator doesn't conclude the run did nothing.

## Tests

4 new, 11 total on this op:

- duration recovered from a discarded twin (**the exact canary regression**)
- existing keeper values are never overwritten
- fingerprint and fingerprint-duration are salvageable too
- no write is issued when there is nothing to salvage — `UpdateBookFile` is the one path
  that bypasses the millisecond guard, so a pointless write is worth avoiding

`go test ./internal/plugins/maintenance/ -short` — ok 5.426s

## Not fixed here

`The Trapped Mind Project` is already at 0.00h and the merge cannot undo it. The file is
intact, so `maintenance.duration-reextract` will recover it — noted in `todo.d/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp