### PR TITLE
fix(test): wait for the memdb warmup in three store helpers that skipped it

### DIFF
--- a/changelog.d/20260804_020000_test_warmup_race.md
+++ b/changelog.d/20260804_020000_test_warmup_race.md
@@ -1,0 +1,34 @@
+<!-- file: changelog.d/20260804_020000_test_warmup_race.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: ca529382-cc13-4ac3-9995-17472e216759 -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- Three test helpers that build a real `PebbleStore` now call `WaitForWarmup()`, which
+  `PebbleStore` documents as mandatory (`pebble_store.go:147-152`) and which all three
+  were skipping. This is the likely cause of two intermittent CI failures that had been
+  written off as generic flakes — `TestBackfillSyncIDsJob_ConcurrentRaceSanity` and
+  `TestBackfillSyncIDsJob_FreshLibrary`, the latter failing on a PR that touches neither
+  package.
+
+  The memdb warmup runs asynchronously from `NewPebbleStore` and publishes only at the
+  very end (`memPtr.Store(memStore)`). Until it does, `mem()` is nil — which makes
+  *reads* safe, since they fall back to Pebble, but silently discards every *write's*
+  memdb write-through. A test that seeds books in that window leaves them in Pebble
+  while the published memdb never sees them, and `ListBookIDs` takes the memdb fast
+  path. The job then never visits those books, so they never get a syncID:
+
+  ```
+  backfill_sync_ids_test.go:102: Should be true
+    Messages: book 01KZ6QV6AZPW2AE93P7M0TRVFN has no syncID
+  ```
+
+  On an empty temp database that window is sub-millisecond, which is why this surfaces
+  only under CI load and resisted 40 local iterations under 20× CPU contention. The fix
+  rests on the documented invariant and a matching failure signature rather than on a
+  reproduced failing test, so the two TODO entries stay open until a green CI streak
+  confirms it.
+
+  Production is not affected: warmup is a one-time startup affair there, and reads fall
+  back to Pebble until it publishes.

--- a/internal/itunes/pid_repair_test.go
+++ b/internal/itunes/pid_repair_test.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/pid_repair_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3e7b0a94-6c21-4d58-8f39-2a1c7e5b0d64
-// last-edited: 2026-07-23
+// last-edited: 2026-08-04
 
 package itunes
 
@@ -21,6 +21,11 @@ func newRepairTestStore(t *testing.T) *database.PebbleStore {
 	if err != nil {
 		t.Fatalf("NewPebbleStore: %v", err)
 	}
+	// Required, not optional — see PebbleStore.WaitForWarmup. Writes made while
+	// the async warmup is still snapshotting have their memdb write-through
+	// dropped, and the published memdb then omits them. Without this the repair
+	// tests read back a book_file that is in Pebble but missing from memdb.
+	store.WaitForWarmup()
 	t.Cleanup(func() { _ = store.Close() })
 	return store
 }

--- a/internal/maintenance/jobs/backfill_sync_ids_test.go
+++ b/internal/maintenance/jobs/backfill_sync_ids_test.go
@@ -1,7 +1,7 @@
 // file: internal/maintenance/jobs/backfill_sync_ids_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a20f7354-5d7e-49aa-b3b5-94758d52bfc9
-// last-edited: 2026-07-30
+// last-edited: 2026-08-04
 
 // Package jobs_test — coverage for the backfill-sync-ids maintenance job
 // (TASK-04). Every test drives a real PebbleStore because the sync_item /
@@ -71,6 +71,13 @@ func newSyncPebbleStore(t *testing.T) *database.PebbleStore {
 	t.Helper()
 	store, err := database.NewPebbleStore(t.TempDir())
 	require.NoError(t, err)
+	// Required, not optional — see PebbleStore.WaitForWarmup. The memdb warmup
+	// runs async from NewPebbleStore, and while it is in flight mem() is nil, so
+	// every CreateBook write-through is silently dropped; warmup then publishes a
+	// memdb built from the empty just-opened DB. The books exist in Pebble but not
+	// in memdb, and this job enumerates with ListBookIDs, which takes the memdb
+	// fast path — so a seeded book is never visited and never gets a syncID.
+	store.WaitForWarmup()
 	t.Cleanup(func() { _ = store.Close() })
 	return store
 }

--- a/internal/maintenance/jobs/retention_and_hygiene_test.go
+++ b/internal/maintenance/jobs/retention_and_hygiene_test.go
@@ -1,6 +1,7 @@
 // file: internal/maintenance/jobs/retention_and_hygiene_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: f8d0e5b9-c2a4-5b1d-9e7f-8c3d2a1b0f5e
+// last-edited: 2026-08-04
 
 package jobs
 
@@ -396,6 +397,10 @@ func newPebbleTestStore(t *testing.T) (database.Store, func()) {
 	if err != nil {
 		t.Fatalf("NewPebbleStore: %v", err)
 	}
+	// Required, not optional — see PebbleStore.WaitForWarmup. Seeding before the
+	// async warmup publishes loses those rows from memdb, which every GetAll*
+	// read then takes the fast path into.
+	store.WaitForWarmup()
 	return store, func() { store.Close() }
 }
 


### PR DESCRIPTION
## What

Three test helpers build a real `PebbleStore` and never call `WaitForWarmup()`, which `PebbleStore` documents as **mandatory** for tests (`internal/database/pebble_store.go:147-152`):

- `newSyncPebbleStore` — `internal/maintenance/jobs/backfill_sync_ids_test.go`
- `newPebbleTestStore` — `internal/maintenance/jobs/retention_and_hygiene_test.go`
- `newRepairTestStore` — `internal/itunes/pid_repair_test.go`

Both intermittent CI failures currently logged in `TODO.md` as generic flakes live in those packages.

## Mechanism

`memPtr.Store(memStore)` publishes **only at the end** of `WarmFromPebble` (`pebble_store.go:291`). Until then `mem()` is nil, which makes *reads* safe — they fall back to Pebble — but silently no-ops every *write's* memdb write-through.

A test seeding books in that window leaves them in Pebble while the published memdb never saw them. The backfill job enumerates with `ListBookIDs`, which takes the memdb fast path, so a seeded book is never visited and never gets a syncID:

```
backfill_sync_ids_test.go:102: Should be true
  Messages: book 01KZ6QV6AZPW2AE93P7M0TRVFN has no syncID
```

That failure landed on #2129, which touches only `internal/plugins/maintenance` and docs — it cannot reach `internal/maintenance/jobs`.

## What this is not

**Not a reproduced red test.** On an empty temp DB the window is sub-millisecond; 40 iterations under 20× CPU contention would not force it. This rests on the documented invariant plus a failure signature that matches it exactly.

So **both TODO entries stay open**, with the mechanism now recorded, until a green CI streak earns closing them. Calling `WaitForWarmup` is correct regardless of whether it proves to be the whole story.

## Verification

- `go build ./...` clean
- `go vet` clean on both packages
- `internal/maintenance/jobs` — 10× `-race -short`, pass
- `internal/itunes` — 10× `-race -short`, pass

Production is unaffected: warmup is a one-time startup affair and reads fall back to Pebble until it publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp