### PR TITLE
docs: retract the canary data-loss finding — the op was correct on all 10 books

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.13.9 -->
-<!-- version: 10.14.0 -->
+<!-- version: 10.14.1 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -154,14 +153,35 @@ Pebble-direct before deciding, because the memdb projection strips
 - [x] **Canary applied — 10 books, 338 rows deleted.** Every corrected total verified
       after restart (`Defending the Lost` 158.00h → 12.15h, `San Kuo` 294.05h → 19.66h)
       with `fingerprinted_file_count` unchanged on all 10.
-- [x] **Canary defect — keeper lost data.** Ranking picks a whole row, so a
-      fingerprinted keeper with no duration lost the duration to deletion. The keeper
-      now merges every missing field from its twins before they are destroyed (#2129).
-- [ ] **Apply to the remaining ~194 books** (3,239 − 338 rows). Blocked on #2129
-      deploying; re-running before then would repeat the data loss above.
-- [ ] **Restore `The Trapped Mind Project`** (`01KNDB97CWFSMSEY68P82VDRBF`) — left at
-      0.00h by the canary. The file is intact, so `maintenance.duration-reextract`
-      recovers it from ffprobe.
+- [x] **~~Canary defect — keeper lost data.~~ RETRACTED 2026-08-04 — there was no
+      data loss.** The claim was that `The Trapped Mind Project` dropped to 0.00h
+      because ranking kept a fingerprinted row whose `Duration` was 0. Checking the
+      actual audio disproves it: that book's entire content is a **13.5-second,
+      91,958-byte MP3**, and both the surviving row and the file on disk agree.
+
+      ```
+      iTunes copy       91958 bytes   duration=13.485s   bit_rate=54554
+      surviving DB row  file_size=91958                  duration=13
+      ```
+
+      130 rows × 13s ≈ 1,690s ≈ 0.47h inflated → 13s after dedupe. **0.00h is the
+      correct answer for a 13-second file**, and the op behaved exactly as designed.
+      The error was reading "0.00h" as lost data without checking the audio.
+- [x] **Keeper field-merge shipped anyway (#2129).** It is still right on its own
+      merits — ranking selects a whole *row*, so a keeper genuinely can lack a field a
+      twin holds, and merging is strictly additive. But it is **hardening against a
+      latent hazard, not a repair of an observed loss**; no such loss has been
+      demonstrated.
+- [ ] **Apply to the remaining ~194 books** (3,239 − 338 rows). No longer blocked —
+      #2129 is merged and deployed, and the canary is now understood to have succeeded
+      on all 10 books rather than 8.
+- [ ] **`The Trapped Mind Project` is a 13-second stub, not an audiobook**
+      (`01KNDB97CWFSMSEY68P82VDRBF`). Nothing to restore — but two things about it are
+      still wrong and worth chasing as a class:
+      its book-level `file_size` reads **532,805,172** (532 MB) for a 91 KB file, and
+      the API reports `file_exists: true` for a `file_path` that is absent from disk.
+      Both are book-level fields disagreeing with the underlying file. See the
+      duration/filesize aggregation item — same family of defect.
 - [ ] **5 books are multi-copy, not row-duplicated** — distinct paths for the same
       book (`Wind and Truth` 426 files, `Ajax's Ascension` 272). Deduping rows is the
       wrong tool; these need regrouping and should surface in the review queue.

--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,49 @@ into one of the curated sections below, is a normal direct edit.
       fixed sleep or an unsynchronised goroutine handoff) and make the test wait
       on a condition instead of a duration. Related: [[project_ci_gotests_intermittent_stalls]].
 
+      **Update 2026-08-04 — a sibling test failed the same way, and there is now a
+      concrete mechanism to test.** `TestBackfillSyncIDsJob_FreshLibrary` (same
+      file) failed CI on PR #2129, which touches only `internal/plugins/maintenance`
+      and docs — a different package entirely. It seeds 20 books and then asserts
+      each has a syncID; one did not:
+
+      ```
+      backfill_sync_ids_test.go:102: Should be true
+        Messages: book 01KZ6QV6AZPW2AE93P7M0TRVFN has no syncID
+      ```
+
+      25/25 passes locally with `-race`, so it is timing-dependent like its sibling.
+
+      **Mechanism — CONFIRMED by reading the warmup path; fix shipped in #2131.**
+      The job enumerates with `store.ListBookIDs()`, and its comment
+      (`backfill_sync_ids.go:61-64`) correctly rules out the `GetAllBooksFrom`
+      pagination cap — but `ListBookIDs` still takes the memdb fast path
+      (`pebble_store.go:594`). `NewPebbleStore` starts warmup in a goroutine and
+      publishes only at the very end (`memPtr.Store(memStore)`, `pebble_store.go:291`).
+      Until it does, `mem()` is nil — which makes *reads* safe, since they fall back
+      to Pebble, but silently no-ops every *write's* memdb write-through. A test
+      seeding books in that window leaves them in Pebble while the published memdb
+      never saw them, so those books are never enumerated and never get a syncID.
+
+      `PebbleStore.WaitForWarmup` documents this as mandatory for tests
+      (`pebble_store.go:147-152`) and three helpers were skipping it —
+      `newSyncPebbleStore`, `newPebbleTestStore`, `newRepairTestStore`. #2131 adds
+      the call to all three.
+
+      **Keep this item open until a green CI streak earns closing it.** The fix rests
+      on the documented invariant plus a matching failure signature, *not* on a
+      reproduced red test: on an empty temp DB the window is sub-millisecond, and 40
+      iterations under 20× CPU contention would not force it. Calling `WaitForWarmup`
+      is correct regardless of whether it proves to be the whole story.
+
+      Production is not affected — warmup is a one-time startup affair there and
+      reads fall back to Pebble until it publishes.
+
+      Note this is a *different* mechanism from
+      `todo.d/2026-08-01-assignorphanvgs-offset-pagination.md`, which is about offset
+      arithmetic over a swapping snapshot. Same underlying async-warmup design, two
+      distinct failure modes; a fix should consider both.
+
 <!-- file: todo.d/2026-08-02-bookfile-duplication-and-duration-units.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 9b41c7e2-05d8-4a63-b7f0-3e26c8149ad5 -->

--- a/changelog.d/20260804_010000_dedupe_keeper_field_merge.md
+++ b/changelog.d/20260804_010000_dedupe_keeper_field_merge.md
@@ -1,21 +1,26 @@
 <!-- file: changelog.d/20260804_010000_dedupe_keeper_field_merge.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: ea73f5ef-cfab-4f6a-80c9-88fc14bacb1e -->
 <!-- last-edited: 2026-08-04 -->
 
 ### Fixed
 
-- `maintenance.dedupe-book-file-rows` no longer destroys data held only by the rows
+- `maintenance.dedupe-book-file-rows` can no longer lose data held only by the rows
   it deletes. The op collapses redundant `book_file` rows that all describe the same
   file on disk, and it chose which row to keep by ranking them. But ranking picks a
   whole **row**, and the best row is not guaranteed to be the most complete one: a
   row carrying an AcoustID fingerprint could have no duration at all, while the
   duration lived on a twin that was then deleted.
 
-  The first canary run made this concrete. `The Trapped Mind Project` had 130 rows
-  for one file. The op correctly kept the fingerprinted row — a fingerprint costs a
-  full-file decode to regenerate — and correctly deleted the other 129, but that row
-  had `Duration == 0`, so the book went to **0.00h**.
+  **Correction (2026-08-04):** this was first written up as a confirmed loss on
+  `The Trapped Mind Project`, which showed 0.00h after its 130 rows were collapsed.
+  That was wrong. The book's entire audio is a 13.5-second, 91,958-byte MP3, and the
+  surviving row matches the file exactly — 0.00h is simply what 13 seconds looks
+  like, and the op behaved correctly on all 10 canary books.
+
+  The change below is therefore **hardening against a latent hazard, not a repair of
+  an observed loss**: ranking selects a whole row, so a keeper genuinely can lack a
+  field one of its twins holds, and merging is strictly additive.
 
   The keeper now absorbs every field it is missing from the rows about to be
   destroyed: duration, AcoustID fingerprint, fingerprint duration, file hash, and

--- a/changelog.d/20260804_030000_canary_finding_retraction.md
+++ b/changelog.d/20260804_030000_canary_finding_retraction.md
@@ -1,0 +1,30 @@
+<!-- file: changelog.d/20260804_030000_canary_finding_retraction.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 53903694-6576-4606-8206-cd3fdf1a51be -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- Corrects the record on the `maintenance.dedupe-book-file-rows` canary. It was written
+  up as having destroyed the duration on `The Trapped Mind Project`, leaving the book at
+  0.00h. **That was wrong, and the op behaved correctly on all 10 canary books, not 8.**
+
+  The book's entire audio content is a 13.5-second, 91,958-byte MP3 — a stub, not a real
+  audiobook — and the surviving row matches the file exactly:
+
+  ```
+  iTunes copy        91958 bytes   duration=13.485s   bit_rate=54554
+  surviving DB row   file_size=91958                  duration=13
+  ```
+
+  130 rows × 13s ≈ 1,690s ≈ 0.47h before the run; one row of 13s after. `0.00h` is
+  simply what 13 seconds renders as. The mistake was treating a rounded display value
+  as evidence of loss without probing the underlying file.
+
+  The keeper field-merge shipped for this remains correct and stays — ranking selects a
+  whole row, so a keeper genuinely can lack a field one of its twins holds — but it is
+  **hardening against a latent hazard, not a repair of an observed loss**.
+
+  Two real defects on that book did surface while checking, and are now tracked: its
+  book-level `file_size` reads 532,805,172 (532 MB) for a 91 KB file, and the API
+  reports `file_exists: true` for a `file_path` that is absent from disk.

--- a/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
+++ b/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 4c2a5631-03db-4f50-ab49-7056ec114fe6 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -57,29 +57,37 @@ file checksum. Choosing wrong destroys something expensive to rebuild.
 
 We then ran it on **ten books only**, and checked the outcome book by book.
 
-## What the ten-book trial caught
+## What the ten-book trial showed
 
-It caught a real flaw, which is exactly why it was run.
+All ten came out correct — 158 hours to 12.15, 294 to 19.66 — with every acoustic
+fingerprint intact.
 
-Eight of the ten came out perfect — 158 hours to 12.15, 294 to 19.66 — with every
-acoustic fingerprint intact. But the tool picked which *record* to keep, and the best
-record is not always the most complete one. For one book it kept the copy holding the
-fingerprint, correctly, and deleted the 129 others — but that copy had no length
-stored, and the length only existed on the copies just deleted. The book dropped to
-**zero hours**.
+One of them looked at first like a failure and turned out not to be, and the
+distinction is worth recording because it nearly caused a wrong conclusion. A book
+called *The Trapped Mind Project* had 130 copies of one record, and after cleanup it
+read **0.00 hours**. That looks exactly like a length being wiped.
 
-Had that run against the whole library instead of ten books, it would have quietly
-blanked the length on an unknown number of books while appearing to succeed.
+It was not. That book's entire audio content is a **13.5-second, 91-kilobyte file** —
+a stub or truncated download, not a real audiobook. 130 copies of 13 seconds added up
+to the roughly 28 minutes it showed before; one copy of 13 seconds is 0.00 hours. The
+tool was right, and the reported "damage" was a rounded display value being mistaken
+for evidence.
 
-The tool now takes the best of *every* piece of information from the records it is
-about to remove and merges it into the one it keeps — it can only ever fill in a gap,
-never overwrite something already there. The rescued record is saved **before**
-anything is deleted, and if that save fails the whole group is skipped rather than
-half-cleaned. The one damaged book can be fully recovered, since the audio file itself
-was never touched.
+The lesson generalises: when a number goes to zero, check the underlying file before
+concluding something was destroyed. The stored data and the file agreed here all along.
 
-The remaining ~194 books are deliberately **not** cleaned up yet. That waits until the
-corrected tool is deployed.
+The tool was still hardened as a result, because the concern behind the false alarm is
+real even if this was not an instance of it: it picks which *record* to keep, and the
+best record is not always the most complete one. It now takes the best of *every* piece
+of information from the records it is about to remove and merges it into the one it
+keeps — only ever filling a gap, never overwriting. The rescued record is saved
+**before** anything is deleted, and if that save fails the whole group is skipped
+rather than half-cleaned. That is protection against a hazard we reasoned about, not a
+repair of a loss we observed.
+
+Two unrelated things about that book are genuinely wrong and are now on the list: its
+stored file size reads **532 MB** for a 91 KB file, and the app reports the file as
+present at a path where it does not exist.
 
 ## One more thing worth knowing
 

--- a/todo.d/2026-08-04-dedupe-op-45s-per-book.md
+++ b/todo.d/2026-08-04-dedupe-op-45s-per-book.md
@@ -1,0 +1,36 @@
+<!-- file: todo.d/2026-08-04-dedupe-op-45s-per-book.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8333f42a-bd0d-4a2f-8221-403d11576e7c -->
+<!-- last-edited: 2026-08-04 -->
+
+- [ ] **PERF: `maintenance.dedupe-book-file-rows` spends ~45 seconds per book, and
+      that is enough to blow its own 2-hour timeout.**
+
+      Measured on the full production run (2026-08-04, op
+      `01KZ6W1H46696CZDBHCZF10W6C`): 9 books in ~7 minutes, steady. Extrapolated over
+      the 194 affected books that is **~2.4 hours against a `Timeout: 2 * time.Hour`**
+      declared in `dedupeBookFileRowsDef()`, so the op cancels itself with roughly
+      the last 40 books unprocessed and needs a second invocation to finish.
+
+      Not a correctness problem — each book is committed independently and the op is
+      idempotent, so a re-run simply picks up the remainder. But an op that cannot
+      complete its own workload in one pass is mis-sized, and it will get worse, not
+      better, as the library grows.
+
+      **~45s to delete ~15 rows from one book is the anomaly worth explaining.** The
+      per-book work is small: one `GetBookFiles` (Pebble-direct), a handful of
+      `DeleteBookFile` calls, one `RecomputeBookAggregates`. Suspects, cheapest to
+      check first:
+
+      - `DeleteBookFile` → `notifyBookFileChange` may trigger a library-stats
+        invalidation and full recompute **per row deleted**, not per book.
+      - `RecomputeBookAggregates` re-reads the book's files; if it re-reads the whole
+        library-level aggregate instead, that is the 5.6s full-scan class of bug
+        already seen in `CountPrimaryBooks` (see
+        [[project_countprimarybooks_cpu_fix]] — same shape, different caller).
+      - The book loop is sequential. Per `CLAUDE.md`'s concurrency rule this is
+        exactly a whole-library-scale loop doing meaningful per-item DB work, so it
+        should have been a bounded `errgroup` pool from the start. Partition by book
+        ID — books are disjoint, so parallel workers cannot touch the same row.
+
+      Fixing the per-book cost is the real answer; raising the timeout only hides it.

--- a/todo.d/2026-08-04-recompute-aggregates-stale-memdb.md
+++ b/todo.d/2026-08-04-recompute-aggregates-stale-memdb.md
@@ -1,5 +1,5 @@
 <!-- file: todo.d/2026-08-04-recompute-aggregates-stale-memdb.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 4a29d7e1-83b6-4c50-9f27-1e08b5c3a64d -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -32,9 +32,11 @@
       Until it is fixed, `dedupe-book-file-rows` says so in its completion
       message rather than letting an operator conclude the run did nothing.
 
-- [ ] **Restore the duration on `The Trapped Mind Project`**
-      (`01KNDB97CWFSMSEY68P82VDRBF`). The first canary kept a fingerprinted row
-      whose `Duration` was 0 and deleted the 129 twins that held the real value,
-      leaving the book at 0.00h. The merge fix prevents recurrence but cannot
-      undo it — the file itself is intact, so
-      `maintenance.duration-reextract` will recover the value from ffprobe.
+- [x] ~~**Restore the duration on `The Trapped Mind Project`**~~ **RETRACTED
+      2026-08-04 — nothing to restore.** The original claim here was that the
+      canary kept a fingerprinted row whose `Duration` was 0 and deleted the 129
+      twins holding the real value. Probing the audio disproves it: the book's
+      entire content is a 13.5-second, 91,958-byte MP3, and the surviving row
+      (`file_size=91958`, `duration=13`) matches it exactly. 0.00h is simply what
+      13 seconds looks like. The op behaved correctly; the error was reading a
+      rounded display value as evidence of loss without checking the file.


### PR DESCRIPTION
## Retraction

The dedupe canary was written up as having destroyed the duration on `The Trapped Mind Project`, leaving it at 0.00h. **That was wrong.**

That book's entire audio content is a **13.5-second, 91,958-byte MP3** — a stub, not a real audiobook — and the surviving row matches the file exactly:

```
iTunes copy        91958 bytes   duration=13.485s   bit_rate=54554
surviving DB row   file_size=91958                  duration=13
```

130 rows × 13s ≈ 1,690s ≈ 0.47h before the run; one row of 13s after. `0.00h` is simply what 13 seconds renders as. The error was treating a rounded display value as evidence of loss without probing the underlying file.

## What changes

- The canary succeeded on **10/10** books, not 8/10.
- Nothing to restore — that TODO item is retracted rather than left open pointing at a `duration-reextract` that would find nothing to re-probe.
- **#2129's keeper field-merge stays, and stays justified** — ranking selects a whole *row*, so a keeper genuinely can lack a field a twin holds. But it is hardening against a *latent hazard*, **not** a repair of an observed loss, and the changelog fragment now says so.
- "Apply to the remaining ~194 books" is unblocked.

## Two real defects found while checking

Both now tracked — book-level fields disagreeing with the file they describe:

- book-level `file_size` reads **532,805,172** (532 MB) for a 91 KB file
- API reports `file_exists: true` for a `file_path` absent from disk

## Also

Collapses a duplicated `<!-- version: -->` line in `TODO.md`, left when the daily assembler re-added a header alongside a manual bump.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp