### PR TITLE
fix(maintenance): heartbeat during the dedupe loop so the watchdog stops killing it

### DIFF
--- a/changelog.d/20260804_040000_dedupe_progress_heartbeat.md
+++ b/changelog.d/20260804_040000_dedupe_progress_heartbeat.md
@@ -1,0 +1,40 @@
+<!-- file: changelog.d/20260804_040000_dedupe_progress_heartbeat.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6bcb2b54-a9b1-4b78-b7f5-8d0c47704606 -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- `maintenance.dedupe-book-file-rows` is no longer killed mid-run by the registry's
+  stuck-op watchdog. The first full production run was cancelled at **book 19 of 194**:
+
+  ```
+  registry: strike recorded  kind=stuck  message="no progress for 5m12s (timeout=5m0s)"
+  registry: canceling stuck op
+  ```
+
+  The op reported progress exactly once per book, at the bottom of the loop. Per-book
+  cost averages ~45s but varies widely — a book with 47 duplicate rows does far more
+  work than one with 2 — so a single heavy book could exceed the watchdog's 5-minute
+  window on its own. From the outside a healthy op was indistinguishable from a hung
+  one, and the watchdog is right to be aggressive: it exists because of the
+  "silent for hours" incident class.
+
+  Two changes, one primary and one defensive:
+
+  - The per-book loop now emits a **heartbeat after each duplicate group**, deliberately
+    re-reporting the *current* index rather than advancing it — the book is not
+    finished, so the bar must not move. The only purpose is to stamp `lastProgressAt`.
+  - `ProgressTimeout` is declared at 30 minutes, matching the precedent
+    `malformed-m4b-transcode` set for a slow-but-healthy per-item op.
+
+  No data was at risk — books commit independently and the op is idempotent, so the 19
+  completed books stayed correct and a re-run resumes the remainder. But at ~19 books
+  per cancelled run the op could not finish its own workload, which made a
+  194-book cleanup a ten-invocation chore.
+
+  Separately, the code comment claiming this op had destroyed a duration on
+  `The Trapped Mind Project` is corrected in place. That finding was retracted: the
+  book's entire audio is a 13.5-second file, and a full-library dry run reported
+  "would salvage fields on 0 keepers" across all 194 books. The keeper field-merge
+  guard remains as defence against a real-but-unobserved hazard.

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedupe_book_file_rows.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 1c7f4b93-6a05-42e8-9d31-8b0e5a2f7c46
-// last-edited: 2026-08-03
+// last-edited: 2026-08-04
 
 package maintenance
 
@@ -41,6 +41,21 @@ func (p *Plugin) dedupeBookFileRowsDef() sdk.OperationDef {
 		Cancellable:     true,
 		Isolate:         false,
 		Timeout:         2 * time.Hour,
+		// The registry watchdog cancels an op that goes ProgressTimeout without an
+		// UpdateProgress stamp (default 5m — see
+		// internal/operations/registry/watchdog.go). The first full production run
+		// was killed at book 19/194 by exactly that:
+		//
+		//   registry: strike recorded kind=stuck message="no progress for 5m12s"
+		//   registry: canceling stuck op
+		//
+		// Per-book cost averages ~45s but is highly variable — a book with 47
+		// duplicate rows does far more work than one with 2 — so a single heavy book
+		// could exceed the window on its own. The primary fix is the intra-book
+		// heartbeat in the loop below; this override is defence in depth for a book
+		// pathological enough to outlast even that, and it matches the precedent set
+		// by malformed-m4b-transcode (backfill.go) for a slow-but-healthy per-item op.
+		ProgressTimeout: 30 * time.Minute,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
 		Run:             p.runDedupeBookFileRows,
 	}
@@ -240,10 +255,15 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 			// keeper that carries a fingerprint but no duration silently loses the
 			// duration held by one of its twins.
 			//
-			// That is not hypothetical: the first canary run left "The Trapped Mind
-			// Project" (130 rows for one file) reading 0.00h, because the
-			// fingerprinted row it kept had Duration == 0 while a discarded twin had
-			// the real value.
+			// This was originally written up as an observed loss on "The Trapped Mind
+			// Project", which read 0.00h after its 130 rows were collapsed. That was
+			// WRONG and is retracted: the book's entire audio is a 13.5-second,
+			// 91,958-byte MP3, the surviving row matches the file exactly, and 0.00h
+			// is simply what 13 seconds renders as. A later full-library dry run
+			// confirmed it — "would salvage fields on 0 keepers" across all 194 books.
+			//
+			// The guard stays because the hazard is real even though this was not an
+			// instance of it. Treat it as defence, not as a fix for a known incident.
 			//
 			// So salvage every field the keeper is missing before its twins are
 			// deleted. Only ever FILLS empty fields — a value the keeper already has
@@ -287,6 +307,21 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 				deleted++
 				changedThisBook = true
 			}
+
+			// ⏱️ HEARTBEAT — this is a liveness signal, not a step.
+			//
+			// The watchdog cancels an op that goes ProgressTimeout without an
+			// UpdateProgress stamp, and it cannot tell "slow" from "hung". Reporting
+			// only once per book (at the bottom of this loop) killed the first full
+			// production run at book 19/194: one book's deletes took over five
+			// minutes and the op was cancelled mid-flight.
+			//
+			// StepN(i) deliberately re-reports the CURRENT index rather than i+1 —
+			// the book is not finished, so the bar must not advance. The point is
+			// solely to stamp lastProgressAt so a genuinely-working op is not
+			// mistaken for a stalled one.
+			prog.StepN(i, fmt.Sprintf("Processing book %d/%d (%d rows removed so far)",
+				i+1, len(bookIDs), deleted))
 		}
 
 		// Totals are a plain sum over the surviving rows, so they are only correct

--- a/internal/plugins/maintenance/dedupe_book_file_rows_test.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows_test.go
@@ -1,12 +1,13 @@
 // file: internal/plugins/maintenance/dedupe_book_file_rows_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3b6d19a7-4e52-4c08-b7f1-90a5e2c4d738
-// last-edited: 2026-08-03
+// last-edited: 2026-08-04
 
 package maintenance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
@@ -160,6 +161,28 @@ func TestMergeMissingFields_NoChangeWhenNothingToSalvage(t *testing.T) {
 	_, changed := mergeMissingFields(keeper, []database.BookFile{{ID: "t"}})
 	if changed {
 		t.Fatal("merge reported a change with nothing to salvage")
+	}
+}
+
+// 🔴 THE PRODUCTION-RUN REGRESSION. The first full run was cancelled at book
+// 19/194 by the registry watchdog:
+//
+//	registry: strike recorded kind=stuck message="no progress for 5m12s"
+//	registry: canceling stuck op
+//
+// The op reported progress only once per book, and one book's deletes took
+// longer than the watchdog's 5-minute default — so a healthy op was
+// indistinguishable from a hung one. The declared override must survive, or the
+// op silently reverts to being killable mid-run.
+func TestDedupeBookFileRowsDef_DeclaresAGenerousProgressTimeout(t *testing.T) {
+	def := (&Plugin{}).dedupeBookFileRowsDef()
+	if def.ProgressTimeout <= 5*time.Minute {
+		t.Fatalf("ProgressTimeout = %v, want > 5m (the watchdog default) — a slow "+
+			"but healthy book must not be cancelled as 'stuck'", def.ProgressTimeout)
+	}
+	// The op must still be bounded overall; an unbounded op can wedge a worker slot.
+	if def.Timeout <= def.ProgressTimeout {
+		t.Fatalf("Timeout (%v) must exceed ProgressTimeout (%v)", def.Timeout, def.ProgressTimeout)
 	}
 }
 


### PR DESCRIPTION
## The failure

The first full production run of `maintenance.dedupe-book-file-rows` was cancelled at **book 19 of 194**:

```
registry: strike recorded  kind=stuck  message="no progress for 5m12s (timeout=5m0s)"
registry: canceling stuck op
```

The op reported progress exactly once per book, at the bottom of the loop. Per-book cost averages ~45s but varies widely — a book with 47 duplicate rows does far more work than one with 2 — so a single heavy book could exceed the watchdog's 5-minute window on its own.

From the outside, a healthy op was indistinguishable from a hung one. The watchdog is right to be aggressive; it exists because of the "silent for hours" incident class.

## The fix

**Primary** — emit a heartbeat after each duplicate group, deliberately re-reporting the *current* index rather than advancing it. The book is not finished, so the bar must not move; the only purpose is to stamp `lastProgressAt`.

**Defence in depth** — declare `ProgressTimeout: 30m`, matching the precedent `malformed-m4b-transcode` set (`backfill.go:130`) for a slow-but-healthy per-item op.

## Blast radius

No data was ever at risk. Books commit independently and the op is idempotent, so the 19 completed books stayed correct and a re-run resumes the remainder. But at ~19 books per cancelled run, a 194-book cleanup became a ten-invocation chore.

## Also

Corrects the in-code comment citing `The Trapped Mind Project` as an observed data loss. That finding is **retracted** (#2132) — the book's entire audio is a 13.5-second file, and the full-library dry run reported *"would salvage fields on 0 keepers"* across all 194 books. The keeper field-merge guard stays as defence against a real-but-unobserved hazard, and the comment now says so rather than claiming an incident.

## Verification

- `go build ./...` clean, `go vet` clean
- Full `internal/plugins/maintenance` package passes (12 tests)
- Regression test asserts the declared `ProgressTimeout`. **Verified it fails on behaviour, not on a build error**, with the override removed:

```
--- FAIL: TestDedupeBookFileRowsDef_DeclaresAGenerousProgressTimeout
    ProgressTimeout = 0s, want > 5m (the watchdog default)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp