### PR TITLE
perf(maintenance): process dedupe books through a bounded worker pool

### DIFF
--- a/changelog.d/20260804_060000_dedupe_parallel_books.md
+++ b/changelog.d/20260804_060000_dedupe_parallel_books.md
@@ -1,0 +1,39 @@
+<!-- file: changelog.d/20260804_060000_dedupe_parallel_books.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: eef5897a-b0a5-43b8-bc12-79f2fc5a53bf -->
+<!-- last-edited: 2026-08-04 -->
+
+### Changed
+
+- `maintenance.dedupe-book-file-rows` now processes books through a bounded worker
+  pool (`registry.RunItems`, sized to `runtime.NumCPU()`) instead of one at a time.
+
+  The book loop was a plain sequential `for range bookIDs` doing per-book database
+  work — precisely the shape `CLAUDE.md`'s concurrency rule forbids, and the first
+  full production run showed why: **~1.7 minutes per book**, so 176 books could not
+  finish inside the op's own 2-hour timeout. Completing a 176-book cleanup meant
+  three or four separate invocations.
+
+  **Why parallelising is safe here.** Every unit of work is one book ID, and a
+  `book_file` row belongs to exactly one book, so two workers can never touch the
+  same row, the same keeper decision, or the same `RecomputeBookAggregates` target.
+  This is the partition-into-disjoint-sets case the concurrency rule calls for, not
+  a fan-out over shared state. The five counters and the examples slice are the only
+  genuinely shared values and are mutex-guarded.
+
+  `RunItems` also supersedes the intra-book heartbeat added a moment earlier: it
+  stamps `UpdateProgress` as each book *completes*, via a monotonic counter that
+  stays ordered even when books finish out of order — so the stuck-op watchdog is
+  fed by completions rather than by a hand-rolled liveness ping. The 30-minute
+  `ProgressTimeout` stays as defence for a single pathological book.
+
+  A failing book no longer abandons the sweep: the callback returns `nil` after
+  counting and logging, and `ErrModeCollect` governs cancellation. On cancellation
+  or timeout everything already committed remains correct — books are independent
+  and the op is idempotent — so a re-run picks up the remainder.
+
+  Two new integration tests seed a real PebbleStore (24 books × 6 duplicate rows)
+  and run the op end to end, so `go test -race` finally has a parallel path to
+  inspect; the package's other tests are pure functions and exercised none of this.
+  Verified the race detector actually catches a regression here: removing the mutex
+  around a single counter produces `WARNING: DATA RACE` and a failure.

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/dedupe_book_file_rows.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 1c7f4b93-6a05-42e8-9d31-8b0e5a2f7c46
 // last-edited: 2026-08-04
 
@@ -10,11 +10,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
 
@@ -49,12 +52,13 @@ func (p *Plugin) dedupeBookFileRowsDef() sdk.OperationDef {
 		//   registry: strike recorded kind=stuck message="no progress for 5m12s"
 		//   registry: canceling stuck op
 		//
-		// Per-book cost averages ~45s but is highly variable — a book with 47
-		// duplicate rows does far more work than one with 2 — so a single heavy book
-		// could exceed the window on its own. The primary fix is the intra-book
-		// heartbeat in the loop below; this override is defence in depth for a book
-		// pathological enough to outlast even that, and it matches the precedent set
-		// by malformed-m4b-transcode (backfill.go) for a slow-but-healthy per-item op.
+		// Per-book cost is highly variable — a book with 47 duplicate rows does far
+		// more work than one with 2 — so a single heavy book could exceed the window
+		// on its own. Liveness is now primarily handled by RunItems, which stamps
+		// UpdateProgress on every book completion; this override remains as defence
+		// in depth for one book pathological enough to outlast even that, and it
+		// matches the precedent malformed-m4b-transcode (backfill.go) set for a
+		// slow-but-healthy per-item op.
 		ProgressTimeout: 30 * time.Minute,
 		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
 		Run:             p.runDedupeBookFileRows,
@@ -209,30 +213,53 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 		"books_affected", len(affected),
 		"redundant_rows", dupRows)
 
-	prog := sdk.NewProgress(reporter, len(bookIDs))
-	prog.Start(fmt.Sprintf("%d book(s) hold duplicate book_file rows (%d redundant rows)",
-		len(affected), dupRows))
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"%d book(s) hold duplicate book_file rows (%d redundant rows)", len(affected), dupRows))
 
+	// 🔒 Counters are touched by every worker — see the pool below. A single mutex
+	// is right here: contention is negligible against per-book DB work, and the
+	// alternative (five atomics plus a locked slice) buys nothing but subtlety.
+	var mu sync.Mutex
 	var deleted, wouldDelete, failed, recomputed, salvaged int
 	var examples []string
 
 	// PASS 2 — per affected book only, so the expensive full-fidelity read is paid
 	// for the handful of books that need it rather than the whole library.
-	for i, bookID := range bookIDs {
-		if ctx.Err() != nil {
-			log.Warn("dedupe-book-file-rows: cancelled",
-				"deleted", deleted, "remaining", len(bookIDs)-i)
-			return ctx.Err()
-		}
+	//
+	// ⚡ PARALLEL BY BOOK. This was a plain sequential `for range bookIDs`, which
+	// CLAUDE.md's concurrency rule forbids for a whole-library loop doing per-item
+	// DB work — and the first full production run proved why: ~1.7 minutes per book
+	// meant 176 books could not finish inside the op's own 2-hour timeout.
+	//
+	// 🔑 SAFE BECAUSE THE PARTITION IS DISJOINT. Every unit of work is one bookID,
+	// and a book_file row belongs to exactly one book, so two workers can never
+	// touch the same row, the same keeper decision, or the same
+	// RecomputeBookAggregates target. This is the partition-into-disjoint-sets case
+	// the concurrency rule calls for, NOT a naive fan-out over shared state.
+	//
+	// RunItems also fixes the liveness problem properly: it stamps UpdateProgress as
+	// each book COMPLETES, via a monotonic atomic counter that stays ordered even
+	// when books finish out of order. The stuck-op watchdog therefore sees progress
+	// on every completion rather than once per sequential step.
+	workers := runtime.NumCPU()
+	if workers > len(bookIDs) {
+		workers = len(bookIDs)
+	}
+	log.Info("dedupe-book-file-rows: processing books in parallel",
+		"books", len(bookIDs), "workers", workers)
 
+	runErr := registry.RunItems(ctx, reporter, bookIDs, func(ctx context.Context, bookID string) error {
 		// GetBookFiles reads Pebble directly (raw prefix iteration), NOT memdb, so
 		// AcoustIDFingerprint is present and un-stripped here. That is exactly why
 		// the keeper decision happens in this pass and not the previous one.
 		files, ferr := store.GetBookFiles(bookID)
 		if ferr != nil {
+			mu.Lock()
 			failed++
+			mu.Unlock()
 			log.Warn("dedupe-book-file-rows: GetBookFiles failed", "book_id", bookID, "err", ferr)
-			continue
+			// nil, not the error: one unreadable book must not abort the sweep.
+			return nil
 		}
 		byPath := map[string][]database.BookFile{}
 		for fi := range files {
@@ -271,15 +298,20 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 			merged, changed := mergeMissingFields(keeper, redundant)
 			keeper = merged
 
+			mu.Lock()
 			if len(examples) < 10 {
 				examples = append(examples, fmt.Sprintf("%s: %d rows for %q (keeping %s)",
 					bookID, len(rows), shortPath(path), keeper.ID))
 			}
+			mu.Unlock()
+
 			if !params.Apply {
+				mu.Lock()
 				wouldDelete += len(redundant)
 				if changed {
 					salvaged++
 				}
+				mu.Unlock()
 				continue
 			}
 
@@ -289,53 +321,74 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 			// also deleting the only copy is not.
 			if changed {
 				if uerr := store.UpdateBookFile(keeper.ID, &keeper); uerr != nil {
+					mu.Lock()
 					failed++
+					mu.Unlock()
 					log.Warn("dedupe-book-file-rows: could not persist salvaged fields; leaving this group intact",
 						"book_id", bookID, "keeper", keeper.ID, "err", uerr)
 					continue
 				}
+				mu.Lock()
 				salvaged++
+				mu.Unlock()
 			}
 
 			for ri := range redundant {
 				if derr := store.DeleteBookFile(redundant[ri].ID); derr != nil {
+					mu.Lock()
 					failed++
+					mu.Unlock()
 					log.Warn("dedupe-book-file-rows: delete failed",
 						"book_id", bookID, "row_id", redundant[ri].ID, "err", derr)
 					continue
 				}
+				mu.Lock()
 				deleted++
+				mu.Unlock()
 				changedThisBook = true
 			}
 
-			// ⏱️ HEARTBEAT — this is a liveness signal, not a step.
-			//
-			// The watchdog cancels an op that goes ProgressTimeout without an
-			// UpdateProgress stamp, and it cannot tell "slow" from "hung". Reporting
-			// only once per book (at the bottom of this loop) killed the first full
-			// production run at book 19/194: one book's deletes took over five
-			// minutes and the op was cancelled mid-flight.
-			//
-			// StepN(i) deliberately re-reports the CURRENT index rather than i+1 —
-			// the book is not finished, so the bar must not advance. The point is
-			// solely to stamp lastProgressAt so a genuinely-working op is not
-			// mistaken for a stalled one.
-			prog.StepN(i, fmt.Sprintf("Processing book %d/%d (%d rows removed so far)",
-				i+1, len(bookIDs), deleted))
 		}
 
 		// Totals are a plain sum over the surviving rows, so they are only correct
 		// once the redundant rows are gone — recompute AFTER deleting, per book.
+		// Safe to do inside a worker: this book's rows belong to no other worker.
 		if params.Apply && changedThisBook {
 			if rerr := store.RecomputeBookAggregates(bookID); rerr != nil {
+				mu.Lock()
 				failed++
+				mu.Unlock()
 				log.Warn("dedupe-book-file-rows: RecomputeBookAggregates failed",
 					"book_id", bookID, "err", rerr)
 			} else {
+				mu.Lock()
 				recomputed++
+				mu.Unlock()
 			}
 		}
-		prog.StepN(i+1, fmt.Sprintf("Processed %d/%d affected books", i+1, len(bookIDs)))
+		// No explicit progress call: RunItems stamps UpdateProgress as each book
+		// completes, using a monotonic counter that stays ordered even when books
+		// finish out of order. That is also what keeps the stuck-op watchdog fed.
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: workers,
+		// ErrModeCollect: a single failing book must not abandon the other 175.
+		// Per-book failures are already counted and logged above, and the callback
+		// returns nil for them, so this mainly governs cancellation semantics.
+		ErrMode: registry.ErrModeCollect,
+		Label: func(i, total int) string {
+			return fmt.Sprintf("book %d/%d", i+1, total)
+		},
+	})
+	if runErr != nil && ctx.Err() != nil {
+		// Cancelled or timed out. Everything already committed stays correct — books
+		// are independent and the op is idempotent — so report and let a re-run
+		// pick up the remainder rather than pretending the work was lost.
+		log.Warn("dedupe-book-file-rows: cancelled", "deleted", deleted, "books", len(bookIDs))
+		return ctx.Err()
+	}
+	if runErr != nil {
+		log.Warn("dedupe-book-file-rows: some books failed", "err", runErr)
 	}
 
 	verb := fmt.Sprintf("would delete %d (would salvage fields on %d keepers)", wouldDelete, salvaged)
@@ -353,7 +406,7 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 			"| NOTE: corrected totals may not appear until memdb refreshes (restart) | e.g. %s",
 		len(cores), len(affected), dupRows, verb, failed, strings.Join(examples, "; "))
 	_ = reporter.Log(slog.LevelInfo, summary)
-	prog.Done(summary)
+	_ = reporter.UpdateProgress(len(bookIDs), len(bookIDs), summary)
 	return nil
 }
 

--- a/internal/plugins/maintenance/dedupe_book_file_rows_parallel_test.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows_parallel_test.go
@@ -1,0 +1,170 @@
+// file: internal/plugins/maintenance/dedupe_book_file_rows_parallel_test.go
+// version: 1.0.0
+// guid: 7f21c6ad-95be-4c30-8d02-5b3a1e6f4c99
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// concurrentReporter is deliberately NOT the package's shared fakeReporter: that
+// one appends to a plain slice, which would itself race once the op runs books in
+// parallel — and a racing test harness reports a race that is not in the code
+// under test. This one is mutex-guarded so `-race` failures mean something.
+type concurrentReporter struct {
+	mu       sync.Mutex
+	progress int
+}
+
+func (r *concurrentReporter) UpdateProgress(cur, _ int, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cur > r.progress {
+		r.progress = cur
+	}
+	return nil
+}
+func (r *concurrentReporter) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
+func (r *concurrentReporter) Logger() *slog.Logger                            { return slog.Default() }
+func (r *concurrentReporter) Checkpoint(_ any) error                          { return nil }
+func (r *concurrentReporter) IsCanceled() bool                                { return false }
+func (r *concurrentReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
+	return fn(ctx, r)
+}
+func (r *concurrentReporter) Trigger(_ context.Context, _ string, _ any) error { return nil }
+func (r *concurrentReporter) SetCurrentItem(_ string)                          {}
+
+// seedDupBooks creates `books` books, each holding `copies` rows that all point at
+// the SAME file path — the exact shape the op exists to collapse.
+func seedDupBooks(t *testing.T, s *database.PebbleStore, books, copies int) []string {
+	t.Helper()
+	ids := make([]string, 0, books)
+	for b := 0; b < books; b++ {
+		bk, err := s.CreateBook(&database.Book{Title: fmt.Sprintf("Dup Book %02d", b)})
+		if err != nil {
+			t.Fatalf("CreateBook: %v", err)
+		}
+		path := fmt.Sprintf("/lib/dup-%02d/track.m4b", b)
+		for c := 0; c < copies; c++ {
+			f := &database.BookFile{
+				BookID:   bk.ID,
+				FilePath: path,
+				Duration: 3600,
+				FileSize: 58000000, // ~129 kbps at 3600s — a plausible real bitrate
+			}
+			if err := s.CreateBookFile(f); err != nil {
+				t.Fatalf("CreateBookFile: %v", err)
+			}
+		}
+		ids = append(ids, bk.ID)
+	}
+	return ids
+}
+
+// 🔴 THE CONCURRENCY REGRESSION. The book loop was sequential, which CLAUDE.md's
+// concurrency rule forbids for a whole-library loop doing per-item DB work — and
+// the first full production run proved the cost: ~1.7 min/book meant 176 books
+// could not finish inside the op's own 2-hour timeout.
+//
+// Parallelising is only safe because the partition is disjoint: a book_file row
+// belongs to exactly one book, so two workers can never touch the same row or the
+// same RecomputeBookAggregates target. This exercises that for real — many books,
+// each with many duplicate rows — so `go test -race` has an actual parallel path
+// to inspect. The package's other tests are pure functions and prove nothing here.
+func TestDedupeBookFileRows_ParallelApplyCollapsesEveryBook(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	const books, copies = 24, 6
+
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	// Required: writes made before warmup publishes are dropped from memdb, and
+	// PASS 1 of this op reads GetAllBookFilesCore (memdb). Without this the op
+	// would see an empty library and "correctly" do nothing.
+	s.WaitForWarmup()
+
+	bookIDs := seedDupBooks(t, s, books, copies)
+
+	p := &Plugin{deps: fakeDeps{store: s}}
+	raw, _ := json.Marshal(DedupeBookFileRowsParams{Apply: true})
+	rep := &concurrentReporter{}
+
+	if err := p.runDedupeBookFileRows(context.Background(), raw, rep); err != nil {
+		t.Fatalf("runDedupeBookFileRows: %v", err)
+	}
+
+	// Every book must be collapsed to exactly one row, and it must be the same
+	// path — nothing invented, nothing cross-contaminated between workers.
+	for i, id := range bookIDs {
+		files, ferr := s.GetBookFiles(id)
+		if ferr != nil {
+			t.Fatalf("GetBookFiles(%s): %v", id, ferr)
+		}
+		if len(files) != 1 {
+			t.Fatalf("book %d (%s): %d rows survived, want exactly 1", i, id, len(files))
+		}
+		wantPath := fmt.Sprintf("/lib/dup-%02d/track.m4b", i)
+		if files[0].FilePath != wantPath {
+			t.Fatalf("book %d: surviving row path = %q, want %q", i, files[0].FilePath, wantPath)
+		}
+		// The survivor must still carry its data — a parallel worker must not have
+		// blanked it while collapsing a neighbouring book.
+		if files[0].Duration != 3600 {
+			t.Fatalf("book %d: surviving duration = %d, want 3600", i, files[0].Duration)
+		}
+	}
+
+	if rep.progress != books {
+		t.Fatalf("progress reported %d/%d books; RunItems must count every completion", rep.progress, books)
+	}
+}
+
+// A dry run must mutate nothing, and that has to hold under concurrency too —
+// a missing Apply check inside a worker would delete rows the operator never
+// approved, which is the one failure this op must never have.
+func TestDedupeBookFileRows_ParallelDryRunDeletesNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	const books, copies = 12, 4
+
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	bookIDs := seedDupBooks(t, s, books, copies)
+
+	p := &Plugin{deps: fakeDeps{store: s}}
+	raw, _ := json.Marshal(DedupeBookFileRowsParams{Apply: false})
+	if err := p.runDedupeBookFileRows(context.Background(), raw, &concurrentReporter{}); err != nil {
+		t.Fatalf("runDedupeBookFileRows (dry run): %v", err)
+	}
+
+	for i, id := range bookIDs {
+		files, ferr := s.GetBookFiles(id)
+		if ferr != nil {
+			t.Fatalf("GetBookFiles: %v", ferr)
+		}
+		if len(files) != copies {
+			t.Fatalf("book %d: dry run changed the row count to %d, want %d untouched",
+				i, len(files), copies)
+		}
+	}
+}


### PR DESCRIPTION
## What

The book loop in `maintenance.dedupe-book-file-rows` was a plain sequential `for range bookIDs` doing per-book database work — exactly the shape `CLAUDE.md`'s concurrency rule forbids. The first full production run showed the cost: **~1.7 min/book**, so 176 books could not finish inside the op's own 2-hour timeout, and completing the cleanup meant three or four invocations.

Now uses `registry.RunItems` sized to `runtime.NumCPU()` — the same pattern `acoustid/backfill.go` already uses.

## Why this is safe to parallelise

Every unit of work is **one book ID**, and a `book_file` row belongs to exactly one book. Two workers can never touch the same row, the same keeper decision, or the same `RecomputeBookAggregates` target. That's the partition-into-disjoint-sets case the rule calls for, not a fan-out over shared state.

The five counters and the `examples` slice are the only genuinely shared values. A single mutex guards them: contention is negligible against per-book DB work, and five atomics plus a locked slice would buy nothing but subtlety.

## Supersedes the heartbeat

`RunItems` stamps `UpdateProgress` as each book **completes**, via a monotonic counter that stays ordered even when books finish out of order. So the stuck-op watchdog is fed by real completions rather than the hand-rolled ping added in #2133. `ProgressTimeout: 30m` stays as defence for one pathological book.

A failing book no longer abandons the sweep — the callback returns `nil` after counting and logging, and `ErrModeCollect` governs cancellation. On cancel/timeout everything already committed stays correct (books are independent, the op is idempotent), so a re-run picks up the remainder.

## Tests

Two integration tests seed a **real PebbleStore** (24 books × 6 duplicate rows) and run the op end to end — the package's other tests are pure functions and exercised none of this, so `-race` previously had no parallel path to inspect.

They call `WaitForWarmup()` because PASS 1 reads memdb; without it the op sees an empty library and "correctly" does nothing (same trap as #2131).

**Verified the race detector catches a real regression here** — removing the mutex around one counter:

```
WARNING: DATA RACE
--- FAIL: TestDedupeBookFileRows_ParallelApplyCollapsesEveryBook
```

Restored: clean. Build, vet, and the full package under `-race` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp