### PR TITLE
docs: record the dedupe cleanup as complete, and what it did NOT fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.14.1 -->
+<!-- version: 10.15.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -215,9 +215,50 @@ Pebble-direct before deciding, because the memdb projection strips
       twin holds, and merging is strictly additive. But it is **hardening against a
       latent hazard, not a repair of an observed loss**; no such loss has been
       demonstrated.
-- [ ] **Apply to the remaining ~194 books** (3,239 − 338 rows). No longer blocked —
-      #2129 is merged and deployed, and the canary is now understood to have succeeded
-      on all 10 books rather than 8.
+- [x] **DONE 2026-08-04 — duplicate `book_file` rows are gone library-wide.** Final
+      verification dry run, after a restart so memdb was warm:
+
+      ```
+      314,153 rows scanned, 0 books affected, 0 redundant rows, would delete 0,
+      failed 0
+      ```
+
+      Total across all runs: **204 books, 3,239 redundant rows deleted, 0 failures**,
+      and "salvaged fields on 0 keepers" every time — no keeper anywhere was missing a
+      field one of its twins held, which is the third independent confirmation that the
+      data-loss finding was correctly retracted.
+
+      The run needed three attempts for reasons worth remembering:
+      1. cancelled at book 19/194 by the stuck-op watchdog (progress reported once per
+         book, one book took >5m) → fixed in #2133;
+      2. hit the op's own 2-hour `Timeout` at book 78/176 running sequentially at
+         ~1.7 min/book;
+      3. finished **95 books in 9.5 minutes** once the book loop was parallelised
+         (#2135) — the same work the sequential pass took two hours to half-finish.
+
+- [ ] **⚠️ Duplicate rows were only half the inflation.** Deduping fixed 8 of the 10
+      sampled books (`Shades of Glory` 144.71h → 12.06h, `The Undying Illusionist`
+      261.61h → 17.26h, `Darkness Rises` 205.41h → 14.78h). **Two did not**, because
+      their stored durations are milliseconds, not seconds:
+
+      ```
+      dur=241110   size=1600709   → 0.1 kbps as seconds |  53.1 kbps as ms
+      dur=1307193  size=7997209   → 0.0 kbps as seconds |  48.9 kbps as ms
+      ```
+
+      Every row lands at 48–53 kbps read as ms — a spoken-word MP3 — and
+      9,906h ÷ 1000 ≈ 9.9h, a real audiobook. #2125 fixed the **display** path via
+      `NormalizeDurationSec`; the **stored** rows were never rewritten. Measured
+      prevalence from a 2,733-row sample: **1.9% (53 rows)**, so roughly 6,000
+      library-wide.
+
+      `CreateBookFile` already calls `normalizeBookFileDuration` at the write
+      chokepoint (CONS-18), so no ingest path can re-create this — the affected rows
+      are purely un-backfilled history, which makes this a one-shot repair rather than
+      a recurring battle. `maintenance.duration-reextract` is the tool: fingerprint-
+      first off `AcoustIDFingerprintDurationSec` (verified whole-file ground truth),
+      ffprobe fallback, dry-run by default, writes back both `Book.Duration` and the
+      `book_file` rows. **Dry-run and review before applying.**
 - [ ] **`The Trapped Mind Project` is a 13-second stub, not an audiobook**
       (`01KNDB97CWFSMSEY68P82VDRBF`). Nothing to restore — but two things about it are
       still wrong and worth chasing as a class:

--- a/changelog.d/20260804_070000_dedupe_complete.md
+++ b/changelog.d/20260804_070000_dedupe_complete.md
@@ -1,0 +1,49 @@
+<!-- file: changelog.d/20260804_070000_dedupe_complete.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 10dc9860-7d45-4376-b851-20e7fde3ac0f -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- **Duplicate `book_file` rows are gone library-wide.** Final verification dry run,
+  run after a restart so the memdb read path was warm:
+
+  ```
+  314,153 rows scanned, 0 books affected, 0 redundant rows, would delete 0, failed 0
+  ```
+
+  Total across all runs: **3,239 redundant rows removed from 204 books, 0 failures**.
+  Every run reported "salvaged fields on 0 keepers" — no keeper anywhere was missing a
+  field one of its twins held, which is the third independent confirmation that the
+  earlier data-loss finding was correctly retracted.
+
+  Three attempts were needed, each blocked by a different property of the op rather
+  than by the data:
+
+  1. **Cancelled at book 19/194** by the registry's stuck-op watchdog. Progress was
+     reported once per book and one book took over five minutes, so a healthy op was
+     indistinguishable from a hung one (fixed in #2133).
+  2. **Hit the op's own 2-hour `Timeout` at book 78/176**, running sequentially at
+     ~1.7 min/book — the op could not complete its own workload in one pass.
+  3. **Finished 95 books in 9.5 minutes** once the book loop was parallelised (#2135),
+     the same work the sequential pass had spent two hours half-finishing.
+
+  Nothing was ever at risk: books commit independently and the op is idempotent, so
+  each cancelled attempt kept its completed work and the next run resumed the rest.
+
+  Verified on the sampled books after a memdb refresh — `Shades of Glory`
+  144.71h → 12.06h, `The Undying Illusionist` 261.61h → 17.26h, `Darkness Rises`
+  205.41h → 14.78h — all with exactly one row per distinct path.
+
+### Known issue
+
+- **Duplicate rows were only half the inflation.** Two of the ten sampled books are
+  still wrong (9,906h and 8,049h) because their *stored* durations are milliseconds.
+  Every row reads 48–53 kbps interpreted as ms versus ~0.1 kbps as seconds, and
+  9,906h ÷ 1000 ≈ 9.9h. The display path was fixed earlier via `NormalizeDurationSec`;
+  the stored rows were never rewritten. Measured prevalence: **1.9% of rows** (53 of a
+  2,733-row sample), roughly 6,000 library-wide.
+
+  This cannot spread — `CreateBookFile` already normalises at the write chokepoint
+  (CONS-18) — so it is a one-shot backfill via `maintenance.duration-reextract`, to be
+  dry-run and reviewed before applying.

--- a/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
+++ b/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 4c2a5631-03db-4f50-ab49-7056ec114fe6 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -100,6 +100,59 @@ That is its own bug and it is now written down rather than patched in a hurry, b
 it affects anything that changes a book's files, not just this one tool. In the
 meantime the cleanup tool says so plainly when it finishes, so nobody concludes it did
 nothing and runs it a second time.
+
+## The cleanup is finished
+
+Every duplicate record in the library is gone. The final check, run against the whole
+library:
+
+> **314,153 records scanned. 0 books affected. 0 duplicates. 0 failures.**
+
+In total **3,239 duplicate records across 204 books** were removed, with nothing lost
+along the way.
+
+It took three attempts, and the reasons are worth knowing because they were all about
+the tool rather than your data.
+
+The first attempt was **killed by a safety mechanism**. The app watches long-running
+jobs and cancels anything that stops reporting progress, on the assumption it has
+hung — a sensible rule that exists because a job once ran silently for hours. But this
+job only reported after finishing each book, and one book took longer than the
+five-minute limit. From the outside, working hard and hanging looked identical. It was
+stopped 19 books in.
+
+The second attempt ran out of its own two-hour budget at book 78 of 176. It was
+processing books **one at a time**, roughly a minute and three quarters each. At that
+rate the job could not finish the work it was created to do — it would have needed
+three or four separate runs.
+
+So the job was changed to process many books **at once**. That is safe here for a
+specific reason: each book's records belong to that book alone, so two workers can
+never reach for the same thing. The difference was stark — the third attempt finished
+**95 books in nine and a half minutes**, work the one-at-a-time version had spent two
+hours only half-completing.
+
+Nothing was ever at risk during any of this. Each book is saved as it completes, and
+re-running simply picks up where the last attempt stopped.
+
+## What is still wrong
+
+Duplicate records turned out to be only **half** the problem.
+
+Of ten books checked closely, eight are now correct — 144 hours became 12, 261 became
+17, 205 became 15. **Two are still wrong**, and for a different reason: their stored
+lengths are recorded in *milliseconds* rather than seconds. Reading them as
+milliseconds gives a bitrate that a real spoken-word recording would have; reading
+them as seconds gives one no audio file could possibly have. And 9,906 hours divided by
+1,000 is 9.9 hours — an ordinary audiobook.
+
+The earlier fix corrected how these are **displayed**. It never rewrote what is
+**stored**. About 1.9% of records are affected — roughly six thousand.
+
+The good news is this cannot spread: new files are already corrected as they are saved,
+so the affected records are purely old history. It is a one-time repair, and the tool
+for it already exists. That is the next job, and it will be previewed before anything
+is changed.
 
 ## Also fixed
 


### PR DESCRIPTION
## Done

Final verification dry run, after a restart so the memdb read path was warm:

```
314,153 rows scanned, 0 books affected, 0 redundant rows, would delete 0, failed 0
```

**Total: 3,239 redundant rows removed from 204 books, 0 failures.** Every run reported *"salvaged fields on 0 keepers"* — no keeper anywhere lacked a field one of its twins held. That's the third independent confirmation that the earlier data-loss finding was correctly retracted (#2132).

Verified on the sampled books after a memdb refresh: `Shades of Glory` 144.71h → **12.06h**, `The Undying Illusionist` 261.61h → **17.26h**, `Darkness Rises` 205.41h → **14.78h**, all with exactly one row per distinct path.

## Three attempts, all blocked by the op rather than the data

1. **Cancelled at book 19/194** by the stuck-op watchdog — progress reported once per book, one book took >5 min, so healthy and hung looked identical (#2133).
2. **Out of its own 2-hour `Timeout` at book 78/176**, sequential at ~1.7 min/book — the op could not complete its own workload in one pass.
3. **95 books in 9.5 minutes** once the loop was parallelised (#2135) — work the sequential pass had spent two hours half-finishing.

Nothing was ever at risk: books commit independently and the op is idempotent, so each cancelled attempt kept its completed work.

## The important negative result

**Duplicate rows were only half the inflation.** Two of the ten sampled books are still wrong (9,906 h and 8,049 h) because their *stored* durations are milliseconds:

```
dur=241110   size=1600709   → 0.1 kbps as seconds |  53.1 kbps as ms
dur=1307193  size=7997209   → 0.0 kbps as seconds |  48.9 kbps as ms
```

Every row lands at 48–53 kbps read as ms, and 9,906 h ÷ 1000 ≈ 9.9 h. #2125 fixed the **display** path via `NormalizeDurationSec`; the **stored** rows were never rewritten. Measured prevalence: **1.9%** (53 of a 2,733-row sample), ~6,000 library-wide.

This cannot spread — `CreateBookFile` already normalises at the write chokepoint (CONS-18) — so it's a one-shot backfill via `maintenance.duration-reextract`, to be dry-run and reviewed first.

Docs only. TODO, changelog fragment, and executive summary updated together per the post-task hygiene rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp