### PR TITLE
fix(db): normalize Duration to seconds on UpdateBookFile, and backfill the old rows

### DIFF
--- a/changelog.d/20260804_080000_purge_millisecond_durations.md
+++ b/changelog.d/20260804_080000_purge_millisecond_durations.md
@@ -1,0 +1,50 @@
+<!-- file: changelog.d/20260804_080000_purge_millisecond_durations.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7ad86e89-caff-4b83-8cdb-ec0403de1d98 -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- **`UpdateBookFile` now normalises `Duration` to the stored standard (seconds).** It
+  was the last write path that did not. `CreateBookFile`, `UpsertBookFile` and
+  `BatchUpsertBookFiles` all called `normalizeBookFileDuration`; an *update* did not —
+  so an update could reintroduce exactly the millisecond corruption those three exist
+  to prevent. The unit invariant now holds at the store, not at each caller's
+  discretion.
+
+  Applying it unconditionally is safe because `DurationLooksLikeMillis` only fires when
+  reading the value as seconds implies an impossible sub-4 kbps file **and** dividing by
+  1000 lands back inside a plausible audio band. A correct row is never touched, and a
+  corrected row is never divided twice.
+
+  Four tests cover it — conversion on update, inertness on good data, idempotence, and
+  fingerprint preservation (this path writes the whole struct, and a fingerprint-wipe
+  bug has shipped here before). Verified all three failure cases fail on *behaviour*
+  with the guard removed: `stored duration = 1048000, want 1048`.
+
+### Added
+
+- **`maintenance.purge-millisecond-durations`** — a one-shot backfill for rows written
+  before the guard existed. Closing the write path stops new corruption but rewrites
+  nothing, and production holds roughly 6,000 millisecond rows (measured: 1.9% of a
+  2,733-row sample).
+
+  The symptom is stark. A book reading **9,906 hours** is 34 rows of milliseconds;
+  9,906 h ÷ 1000 ≈ 9.9 h, an ordinary audiobook. Every row in it reads 48–53 kbps
+  interpreted as milliseconds versus ~0.1 kbps as seconds — only one interpretation
+  describes a real audio file.
+
+  Design mirrors `dedupe-book-file-rows`, which is now well proven:
+
+  - **Two passes.** Discovery reads the cheap memdb `Core` projection (which already
+    carries `Duration` and `FileSize`, all the predicate needs); the repair re-reads
+    each book Pebble-direct, because the memdb projection strips `AcoustIDFingerprint`
+    and this path writes the whole struct.
+  - **Re-tests every row against the full-fidelity copy** rather than trusting
+    discovery. The memdb snapshot can be stale — it was, twice today — and a row
+    already corrected must not be divided again.
+  - **Dry-run by default**, reporting old → new per row.
+  - **Parallel by book** via `registry.RunItems`, safe for the same disjoint-partition
+    reason: a `book_file` row belongs to exactly one book.
+  - Recomputes each book's aggregates only where rows actually changed, and notes that
+    corrected totals stay invisible until memdb refreshes.

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
 // last-edited: 2026-08-04
 
@@ -284,6 +284,18 @@ func (s *PebbleStore) CreateBookFile(file *BookFile) error {
 // UpdateBookFile replaces an existing BookFile, cleaning up stale secondary
 // indexes when the PID or path changes.
 func (s *PebbleStore) UpdateBookFile(id string, file *BookFile) error {
+	// CONS-18: normalise to the stored standard — Duration is SECONDS. This was the
+	// last write path that did not, while CreateBookFile, UpsertBookFile and
+	// BatchUpsertBookFiles all did, which meant an update could reintroduce the
+	// millisecond corruption those three exist to prevent. Every write now agrees on
+	// the unit, so the invariant holds at the store rather than at each caller.
+	//
+	// Safe to apply unconditionally: DurationLooksLikeMillis only fires when reading
+	// the value as seconds implies an impossible sub-4 kbps file AND dividing by 1000
+	// lands back in a plausible audio band, so a correct row is never touched and a
+	// corrected row is never divided twice.
+	normalizeBookFileDuration(file)
+
 	// We need the bookID to build the primary key; it must be set on file.
 	old, err := s.getBookFileByID(file.BookID, id)
 	if err != nil {

--- a/internal/database/update_bookfile_normalizes_test.go
+++ b/internal/database/update_bookfile_normalizes_test.go
@@ -1,0 +1,157 @@
+// file: internal/database/update_bookfile_normalizes_test.go
+// version: 1.0.0
+// guid: 1ba802ee-d7e8-478f-a5e3-a82dbef6ac2c
+// last-edited: 2026-08-04
+
+package database
+
+import "testing"
+
+// 🔴 UpdateBookFile was the LAST write path that did not normalise Duration to the
+// stored standard (seconds). CreateBookFile, UpsertBookFile and BatchUpsertBookFiles
+// all called normalizeBookFileDuration; an update did not, so it could reintroduce
+// the millisecond corruption those three exist to prevent.
+//
+// That is not theoretical: production held ~6,000 millisecond rows, and a book
+// reading 9,906h was 34 rows of milliseconds (9,906h/1000 ≈ 9.9h — a real audiobook).
+func TestUpdateBookFile_NormalizesMillisecondDurationToSeconds(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	book, err := s.CreateBook(&Book{Title: "Unit Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	// 1,048,000 bytes at 1,048,000 "seconds" implies 8 bits/sec — impossible. Read as
+	// milliseconds it is 1,048s ≈ 8 kbps, an ordinary spoken-word MP3.
+	f := &BookFile{BookID: book.ID, FilePath: "/lib/Unit Book/01.mp3", Duration: 1048, FileSize: 1048000}
+	if err := s.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	// Now push a millisecond value through UPDATE, the path that used to accept it.
+	f.Duration = 1048000
+	if err := s.UpdateBookFile(f.ID, f); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+
+	got, err := s.GetBookFiles(book.ID)
+	if err != nil {
+		t.Fatalf("GetBookFiles: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	if got[0].Duration != 1048 {
+		t.Fatalf("stored duration = %d, want 1048 — UpdateBookFile must normalise "+
+			"milliseconds to seconds like every other write path", got[0].Duration)
+	}
+}
+
+// 🔑 The guard must be inert on correct data. A plausible duration is never touched,
+// so this can be applied unconditionally on every update without risk.
+func TestUpdateBookFile_LeavesPlausibleDurationsAlone(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	book, err := s.CreateBook(&Book{Title: "Sane Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	// 3600s at 58MB ≈ 129 kbps — an ordinary audiobook.
+	f := &BookFile{BookID: book.ID, FilePath: "/lib/Sane Book/01.m4b", Duration: 3600, FileSize: 58_000_000}
+	if err := s.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	f.Title = "touched"
+	if err := s.UpdateBookFile(f.ID, f); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+	got, _ := s.GetBookFiles(book.ID)
+	if got[0].Duration != 3600 {
+		t.Fatalf("duration = %d, want 3600 untouched — the guard must not fire on good data",
+			got[0].Duration)
+	}
+}
+
+// 🔴 IDEMPOTENCE. An already-repaired row must never be divided a second time; that
+// would turn a correct 9,906-second book into 9 seconds. Updating twice must be a
+// no-op after the first conversion.
+func TestUpdateBookFile_NormalizationIsIdempotent(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	book, err := s.CreateBook(&Book{Title: "Idem Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	f := &BookFile{BookID: book.ID, FilePath: "/lib/Idem Book/01.mp3", Duration: 1048, FileSize: 1048000}
+	if err := s.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	f.Duration = 1048000 // ms
+	if err := s.UpdateBookFile(f.ID, f); err != nil {
+		t.Fatalf("UpdateBookFile #1: %v", err)
+	}
+	after1, _ := s.GetBookFiles(book.ID)
+	row := after1[0]
+
+	if err := s.UpdateBookFile(row.ID, &row); err != nil {
+		t.Fatalf("UpdateBookFile #2: %v", err)
+	}
+	after2, _ := s.GetBookFiles(book.ID)
+	if after2[0].Duration != 1048 {
+		t.Fatalf("duration = %d after a second update, want 1048 — the conversion "+
+			"must not compound", after2[0].Duration)
+	}
+}
+
+// The guard must not wipe the fingerprint it travels alongside. UpdateBookFile writes
+// the whole struct, and this repo has already shipped a fingerprint-wipe bug once.
+func TestUpdateBookFile_NormalizationPreservesFingerprint(t *testing.T) {
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	book, err := s.CreateBook(&Book{Title: "FP Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	f := &BookFile{
+		BookID: book.ID, FilePath: "/lib/FP Book/01.mp3",
+		Duration: 1048, FileSize: 1048000,
+		AcoustIDFingerprint: []byte{0x01, 0x02, 0x03, 0x04},
+	}
+	if err := s.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	f.Duration = 1048000
+	if err := s.UpdateBookFile(f.ID, f); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+	got, _ := s.GetBookFiles(book.ID)
+	if got[0].Duration != 1048 {
+		t.Fatalf("duration = %d, want 1048", got[0].Duration)
+	}
+	if len(got[0].AcoustIDFingerprint) != 4 {
+		t.Fatalf("fingerprint lost during a normalising update: %v", got[0].AcoustIDFingerprint)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.11.0
+// version: 1.12.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-07-17
+// last-edited: 2026-08-04
 
 package maintenance
 
@@ -42,6 +42,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.archiveSweepDef(),
 		p.orphanBookFilesCleanupDef(),
 		p.dedupeBookFileRowsDef(),
+		p.purgeMillisecondDurationsDef(),
 		p.integrityCheckDef(),
 
 		// --- database ---

--- a/internal/plugins/maintenance/purge_millisecond_durations.go
+++ b/internal/plugins/maintenance/purge_millisecond_durations.go
@@ -1,0 +1,261 @@
+// file: internal/plugins/maintenance/purge_millisecond_durations.go
+// version: 1.0.0
+// guid: 7ad86e89-caff-4b83-8cdb-ec0403de1d98
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// PurgeMillisecondDurationsParams are the JSON parameters for the ms→seconds
+// backfill.
+type PurgeMillisecondDurationsParams struct {
+	// Apply, when true, writes the corrected durations. Default false — dry run.
+	// Same convention as maintenance.dedupe-book-file-rows and title-repair: a
+	// destructive op must be asked for explicitly, never reached by forgetting a flag.
+	Apply bool `json:"apply"`
+	// Limit caps how many BOOKS are processed (0 = all). Useful for a canary.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *Plugin) purgeMillisecondDurationsDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.purge-millisecond-durations",
+		Plugin:      "maintenance",
+		DisplayName: "Convert millisecond book_file durations to seconds",
+		Description: "BookFile.Duration is seconds by convention, but an old iTunes import path stored " +
+			"milliseconds (TotalTime) without dividing by 1000. Those rows inflate every duration-derived " +
+			"number by ~1000×. This finds them by implied bitrate — a duration is only treated as " +
+			"milliseconds when reading it as seconds implies an impossible sub-4 kbps file AND dividing by " +
+			"1000 lands back in a plausible audio band — and rewrites them as seconds, then recomputes the " +
+			"book's aggregates. Dry-run by default; pass {\"apply\": true} to write.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.purge-millisecond-durations",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		// Same reasoning as dedupe-book-file-rows: RunItems stamps progress per book
+		// completion, but one pathological book must not be mistaken for a hang by the
+		// watchdog's 5-minute default.
+		ProgressTimeout: 30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runPurgeMillisecondDurations,
+	}
+}
+
+// msFix is one row that needs converting, carried from the cheap discovery pass
+// to the full-fidelity repair pass.
+type msFix struct {
+	fileID string
+	oldDur int
+	newDur int
+}
+
+func (p *Plugin) runPurgeMillisecondDurations(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params PurgeMillisecondDurationsParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	log := reporter.Logger()
+	log.Info("purge-millisecond-durations: starting", "apply", params.Apply, "limit", params.Limit)
+
+	// PASS 1 — cheap discovery. The Core projection is a memdb read and already
+	// carries Duration and FileSize, which is everything DurationLooksLikeMillis
+	// needs. Sweeping the whole library here is fine; it is the per-row REPAIR that
+	// must be full-fidelity.
+	cores, err := store.GetAllBookFilesCore()
+	if err != nil {
+		return fmt.Errorf("scan book_files: %w", err)
+	}
+
+	byBook := map[string][]msFix{}
+	candidates := 0
+	for i := range cores {
+		c := cores[i]
+		if c.BookID == "" {
+			continue // orphan rows belong to orphan-book-files-cleanup
+		}
+		// 🔑 THE ONLY TEST. DurationLooksLikeMillis fires only when reading the value
+		// as seconds implies an impossible sub-4 kbps file AND dividing by 1000 lands
+		// back inside a plausible audio band. A genuinely low-bitrate clip is rejected
+		// because its /1000 would imply an absurd multi-Mbps rate. This is the same
+		// predicate the write chokepoint (normalizeBookFileDuration) and the read path
+		// (NormalizeDurationSec) already use, so this backfill cannot disagree with
+		// what the rest of the system believes.
+		if !database.DurationLooksLikeMillis(c.FileSize, c.Duration) {
+			continue
+		}
+		byBook[c.BookID] = append(byBook[c.BookID], msFix{
+			fileID: c.ID, oldDur: c.Duration,
+			newDur: database.NormalizeDurationSec(c.FileSize, c.Duration),
+		})
+		candidates++
+	}
+
+	bookIDs := make([]string, 0, len(byBook))
+	for id := range byBook {
+		bookIDs = append(bookIDs, id)
+	}
+	sort.Strings(bookIDs) // deterministic order so a dry run and its apply agree
+	if params.Limit > 0 && len(bookIDs) > params.Limit {
+		bookIDs = bookIDs[:params.Limit]
+	}
+
+	log.Info("purge-millisecond-durations: scan complete",
+		"total_rows", len(cores), "books_affected", len(byBook), "ms_rows", candidates)
+
+	if len(bookIDs) == 0 {
+		summary := fmt.Sprintf(
+			"purge-millisecond-durations: %d rows scanned, 0 millisecond durations found — nothing to do",
+			len(cores))
+		_ = reporter.Log(slog.LevelInfo, summary)
+		_ = reporter.UpdateProgress(1, 1, summary)
+		return nil
+	}
+
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"%d book(s) hold %d millisecond-valued durations", len(byBook), candidates))
+
+	// 🔒 Shared across workers — see the pool below.
+	var mu sync.Mutex
+	var fixed, wouldFix, failed, recomputed, skipped int
+	var examples []string
+
+	// PASS 2 — full fidelity, per affected book. Parallel by book: a book_file row
+	// belongs to exactly one book, so workers never touch the same row or the same
+	// RecomputeBookAggregates target (same disjoint-partition argument as
+	// dedupe-book-file-rows).
+	workers := runtime.NumCPU()
+	if workers > len(bookIDs) {
+		workers = len(bookIDs)
+	}
+	log.Info("purge-millisecond-durations: repairing in parallel",
+		"books", len(bookIDs), "workers", workers)
+
+	runErr := registry.RunItems(ctx, reporter, bookIDs, func(ctx context.Context, bookID string) error {
+		// GetBookFiles reads Pebble directly, NOT memdb. That matters: the memdb
+		// projection strips AcoustIDFingerprint, and UpdateBookFile writes the whole
+		// struct — so repairing from a memdb copy would wipe every fingerprint on the
+		// row. This repo has already shipped that exact bug once.
+		files, ferr := store.GetBookFiles(bookID)
+		if ferr != nil {
+			mu.Lock()
+			failed++
+			mu.Unlock()
+			log.Warn("purge-millisecond-durations: GetBookFiles failed", "book_id", bookID, "err", ferr)
+			return nil // one unreadable book must not abort the sweep
+		}
+
+		changedThisBook := false
+		for fi := range files {
+			f := files[fi]
+
+			// Re-test against the FULL-FIDELITY row rather than trusting PASS 1. The
+			// memdb snapshot can be stale (it has been, today), and a row that has
+			// since been corrected must not be divided a second time — that would turn
+			// a good 9,906-second duration into 9 seconds.
+			if !database.DurationLooksLikeMillis(f.FileSize, f.Duration) {
+				mu.Lock()
+				skipped++
+				mu.Unlock()
+				continue
+			}
+
+			oldDur := f.Duration
+			newDur := database.NormalizeDurationSec(f.FileSize, f.Duration)
+
+			mu.Lock()
+			if len(examples) < 10 {
+				examples = append(examples, fmt.Sprintf("%s: %ds → %ds (%s)",
+					bookID, oldDur, newDur, shortPath(f.FilePath)))
+			}
+			mu.Unlock()
+
+			if !params.Apply {
+				mu.Lock()
+				wouldFix++
+				mu.Unlock()
+				continue
+			}
+
+			f.Duration = newDur
+			if uerr := store.UpdateBookFile(f.ID, &f); uerr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+				log.Warn("purge-millisecond-durations: write failed; leaving the row as-is",
+					"book_id", bookID, "file_id", f.ID, "err", uerr)
+				continue
+			}
+			mu.Lock()
+			fixed++
+			mu.Unlock()
+			changedThisBook = true
+		}
+
+		// Book.Duration is a sum over the rows, so it is only right once the rows are.
+		if params.Apply && changedThisBook {
+			if rerr := store.RecomputeBookAggregates(bookID); rerr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+				log.Warn("purge-millisecond-durations: RecomputeBookAggregates failed",
+					"book_id", bookID, "err", rerr)
+			} else {
+				mu.Lock()
+				recomputed++
+				mu.Unlock()
+			}
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: workers,
+		ErrMode:     registry.ErrModeCollect,
+		Label: func(i, total int) string {
+			return fmt.Sprintf("book %d/%d", i+1, total)
+		},
+	})
+	if runErr != nil && ctx.Err() != nil {
+		log.Warn("purge-millisecond-durations: cancelled", "fixed", fixed, "books", len(bookIDs))
+		return ctx.Err()
+	}
+	if runErr != nil {
+		log.Warn("purge-millisecond-durations: some books failed", "err", runErr)
+	}
+
+	verb := fmt.Sprintf("would convert %d row(s)", wouldFix)
+	if params.Apply {
+		verb = fmt.Sprintf("converted %d row(s), recomputed %d book(s)", fixed, recomputed)
+	}
+	// Same operational caveat as the dedupe op: the corrected totals are not visible
+	// on the memdb-backed read path until it refreshes.
+	summary := fmt.Sprintf(
+		"purge-millisecond-durations: %d rows scanned, %d book(s) affected, %d ms row(s), %s, "+
+			"skipped %d (already seconds), failed %d "+
+			"| NOTE: corrected totals may not appear until memdb refreshes (restart) | e.g. %s",
+		len(cores), len(byBook), candidates, verb, skipped, failed, strings.Join(examples, "; "))
+	_ = reporter.Log(slog.LevelInfo, summary)
+	_ = reporter.UpdateProgress(len(bookIDs), len(bookIDs), summary)
+	return nil
+}


### PR DESCRIPTION
## The real fix: close the last write path

`UpdateBookFile` was the only write path that did **not** normalize `Duration` to the stored standard. `CreateBookFile`, `UpsertBookFile` and `BatchUpsertBookFiles` all call `normalizeBookFileDuration`; an *update* did not — so an update could reintroduce exactly the millisecond corruption those three exist to prevent.

The unit invariant now holds **at the store**, not at each caller's discretion.

Applying it unconditionally is safe: `DurationLooksLikeMillis` only fires when reading the value as seconds implies an impossible sub-4 kbps file **and** dividing by 1000 lands back inside a plausible audio band. A correct row is never touched; a corrected row is never divided twice.

This also closes the tracked "unguarded `UpdateBookFile`" defect.

## Plus a one-shot backfill

Closing the write path stops new corruption but rewrites nothing, and production holds **~6,000 millisecond rows** (measured: 1.9% of a 2,733-row sample).

The symptom is stark — a book reading **9,906 hours** is 34 rows of milliseconds:

```
dur=241110   size=1600709   → 0.1 kbps as seconds |  53.1 kbps as ms
dur=1307193  size=7997209   → 0.0 kbps as seconds |  48.9 kbps as ms
```

9,906 h ÷ 1000 ≈ 9.9 h — an ordinary audiobook. Only one interpretation describes a real audio file.

`maintenance.purge-millisecond-durations` mirrors `dedupe-book-file-rows`, which is now well proven:

- **Two passes** — cheap memdb `Core` projection to *find* (it already carries `Duration` and `FileSize`), Pebble-direct re-read to *repair*, because the memdb projection strips `AcoustIDFingerprint` and this path writes the whole struct.
- **Re-tests every row against the full-fidelity copy** instead of trusting discovery. The memdb snapshot can be stale — it was, twice today — and an already-corrected row must not be divided again.
- **Dry-run by default**, reporting old → new per row.
- **Parallel by book** via `RunItems`, safe for the same disjoint-partition reason.
- Recomputes aggregates only where rows changed; notes that corrected totals stay invisible until memdb refreshes.

Both use `database.NormalizeDurationSec` rather than a hand-rolled `/1000`, so the backfill cannot disagree with the write chokepoint or the read path.

## Tests

Four on the store guard — conversion on update, inertness on good data, idempotence, and fingerprint preservation (a fingerprint-wipe bug has shipped on this exact path before).

**Verified they fail on behaviour** with the guard removed:

```
stored duration = 1048000, want 1048 — UpdateBookFile must normalise milliseconds
duration = 1048000 after a second update, want 1048 — the conversion must not compound
```

The three pre-existing `UpdateBookFile` fingerprint tests still pass. Build, vet, and both packages clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp