### PR TITLE
docs: millisecond durations purged library-wide, and a correction to my estimate

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.15.0 -->
+<!-- version: 10.16.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -236,7 +236,7 @@ Pebble-direct before deciding, because the memdb projection strips
       3. finished **95 books in 9.5 minutes** once the book loop was parallelised
          (#2135) — the same work the sequential pass took two hours to half-finish.
 
-- [ ] **⚠️ Duplicate rows were only half the inflation.** Deduping fixed 8 of the 10
+- [x] **⚠️ Duplicate rows were only half the inflation.** Deduping fixed 8 of the 10
       sampled books (`Shades of Glory` 144.71h → 12.06h, `The Undying Illusionist`
       261.61h → 17.26h, `Darkness Rises` 205.41h → 14.78h). **Two did not**, because
       their stored durations are milliseconds, not seconds:
@@ -252,13 +252,36 @@ Pebble-direct before deciding, because the memdb projection strips
       prevalence from a 2,733-row sample: **1.9% (53 rows)**, so roughly 6,000
       library-wide.
 
-      `CreateBookFile` already calls `normalizeBookFileDuration` at the write
-      chokepoint (CONS-18), so no ingest path can re-create this — the affected rows
-      are purely un-backfilled history, which makes this a one-shot repair rather than
-      a recurring battle. `maintenance.duration-reextract` is the tool: fingerprint-
-      first off `AcoustIDFingerprintDurationSec` (verified whole-file ground truth),
-      ffprobe fallback, dry-run by default, writes back both `Book.Duration` and the
-      `book_file` rows. **Dry-run and review before applying.**
+      **DONE 2026-08-04 (#2137).** Fixed in two parts:
+
+      1. **`UpdateBookFile` now normalises to seconds.** It was the *last* write path
+         that did not — `CreateBookFile`, `UpsertBookFile` and `BatchUpsertBookFiles`
+         all did — so an update could reintroduce the very corruption those three
+         exist to prevent. This also closes the tracked "unguarded `UpdateBookFile`"
+         defect. The unit invariant now holds at the store, not per caller.
+      2. **`maintenance.purge-millisecond-durations`** backfilled the historical rows.
+
+      ```
+      apply : 314,153 rows scanned, 214 books affected, 1,384 ms rows,
+              converted 1,384, recomputed 214 books,
+              skipped 9,352 (already seconds), failed 0
+      verify: 314,153 rows scanned, 0 millisecond durations found — nothing to do
+      ```
+
+      The two books that survived deduping are now right:
+      `01KNDB9V04D7MBTFVDKYWX286E` 19,294.11h → 9,906.11h → **9.90h**, and
+      `01KNDB9ZHJSMBY7D98Y82PQTK0` 15,556.96h → 8,049.06h → **8.05h**. All ten sampled
+      books now read 8–17h.
+
+      ⚠️ **Correct the earlier estimate:** the "1.9% ≈ 6,000 rows" figure extrapolated
+      from a 2,733-row sample was **wrong by ~4×**. The real count is **1,384 rows
+      (0.44%)** — that sample was a targeted dump, not a random one, so its rate did
+      not generalise. Prefer a full scan over an extrapolated sample for anything
+      load-bearing.
+
+      The 9,352 skipped rows are the reassuring part: they sit *inside* the same 214
+      affected books and were correctly left alone, so the predicate discriminates per
+      row, not per book.
 - [ ] **`The Trapped Mind Project` is a 13-second stub, not an audiobook**
       (`01KNDB97CWFSMSEY68P82VDRBF`). Nothing to restore — but two things about it are
       still wrong and worth chasing as a class:

--- a/changelog.d/20260804_090000_ms_purge_complete.md
+++ b/changelog.d/20260804_090000_ms_purge_complete.md
@@ -1,0 +1,36 @@
+<!-- file: changelog.d/20260804_090000_ms_purge_complete.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6a535402-a856-4b04-9aed-fdc81fef7f1e -->
+<!-- last-edited: 2026-08-04 -->
+
+### Fixed
+
+- **Millisecond durations are gone library-wide.** `maintenance.purge-millisecond-durations`
+  applied against production:
+
+  ```
+  apply : 314,153 rows scanned, 214 books affected, 1,384 ms rows,
+          converted 1,384, recomputed 214 books,
+          skipped 9,352 (already seconds), failed 0
+  verify: 314,153 rows scanned, 0 millisecond durations found — nothing to do
+  ```
+
+  The two books that survived the row-dedupe are now correct:
+  `01KNDB9V04D7MBTFVDKYWX286E` 19,294.11h → 9,906.11h → **9.90h**, and
+  `01KNDB9ZHJSMBY7D98Y82PQTK0` 15,556.96h → 8,049.06h → **8.05h**. All ten books
+  tracked through this work now read 8–17h.
+
+  The 9,352 skipped rows are the reassuring detail: they sit *inside* the same 214
+  affected books and were correctly left untouched, so the predicate discriminates per
+  row rather than condemning a whole book.
+
+  Together with the `UpdateBookFile` normalisation, the unit corruption is both
+  repaired and closed off — every write path now agrees that `Duration` is seconds.
+
+### Corrected
+
+- The earlier estimate of "~6,000 millisecond rows (1.9%)" was **wrong by roughly 4×**.
+  The true count is **1,384 rows (0.44%)**. That figure was extrapolated from a
+  2,733-row sample which turned out to be a targeted dump rather than a random one, so
+  its rate did not generalise. Recorded because the mistake is reusable: prefer a full
+  scan over an extrapolated sample for any number that drives a decision.

--- a/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
+++ b/docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-04-audiobook-running-times-executive-summary.md -->
-<!-- version: 1.2.0 -->
+<!-- version: 1.3.0 -->
 <!-- guid: 4c2a5631-03db-4f50-ab49-7056ec114fe6 -->
 <!-- last-edited: 2026-08-04 -->
 
@@ -135,7 +135,37 @@ hours only half-completing.
 Nothing was ever at risk during any of this. Each book is saved as it completes, and
 re-running simply picks up where the last attempt stopped.
 
-## What is still wrong
+## And now the second half is fixed too
+
+The millisecond problem described below has since been repaired, and the fix came in
+two parts.
+
+The **first** matters more than the cleanup itself. Audiobook lengths are saved in
+several different places in the code, and all but one of them already corrected a
+millisecond value on the way in. The one that didn't was the path used when a book is
+**updated** — so an edit could quietly reintroduce the very problem the others existed
+to prevent. That gap is now closed, which means this cannot come back.
+
+The **second** was a one-time repair of the records already stored wrong:
+
+> **314,153 records scanned. 214 books affected. 1,384 corrected. 0 failures.**
+>
+> Re-checked afterwards: **0 remaining.**
+
+The two stubborn books are now right — the one that read **19,294 hours** now reads
+**9.90 hours**, and the one that read 15,557 now reads 8.05. Every one of the ten
+books tracked through this work now shows a believable length, between 8 and 17 hours.
+
+A detail worth trusting the tool for: within those same 214 books, **9,352 records
+were examined and correctly left alone** because they were already in seconds. The
+test is applied to each individual record, not assumed for a whole book.
+
+One correction to an earlier figure. This was estimated at "about 6,000 records"
+based on a sample. The true number is **1,384** — the sample was not representative,
+and the estimate was roughly four times too high. The full scan is the number to
+trust.
+
+## What was still wrong (now fixed — see above)
 
 Duplicate records turned out to be only **half** the problem.
 


### PR DESCRIPTION
## Done

```
apply : 314,153 rows scanned, 214 books affected, 1,384 ms rows,
        converted 1,384, recomputed 214 books,
        skipped 9,352 (already seconds), failed 0

verify: 314,153 rows scanned, 0 millisecond durations found — nothing to do
```

The two books that survived the row-dedupe are now correct:

| book | original | after dedupe | after ms purge |
|---|---|---|---|
| `01KNDB9V04…` | 19,294.11 h | 9,906.11 h | **9.90 h** |
| `01KNDB9ZHJ…` | 15,556.96 h | 8,049.06 h | **8.05 h** |

All ten books tracked through this work now read 8–17 h.

The **9,352 skipped rows** are the reassuring detail: they sit *inside* the same 214 affected books and were correctly left untouched, so the predicate discriminates per row rather than condemning a whole book.

## Correction

My earlier estimate of **"~6,000 rows (1.9%)"** was wrong by roughly **4×**. The true count is **1,384 rows (0.44%)**.

It was extrapolated from a 2,733-row sample that turned out to be a targeted dump rather than a random one, so its rate did not generalise. Recording it because the mistake is reusable: prefer a full scan over an extrapolated sample for any number that drives a decision.

Docs only. TODO, changelog fragment, and executive summary updated together per the post-task hygiene rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp