### PR TITLE
feat(maintenance): recover book titles that were replaced by junk

### DIFF
--- a/changelog.d/20260804_100000_repair_junk_titles.md
+++ b/changelog.d/20260804_100000_repair_junk_titles.md
@@ -1,0 +1,51 @@
+<!-- file: changelog.d/20260804_100000_repair_junk_titles.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9c4e7a12-3b58-4d06-8f21-7ae5c0d94b63 -->
+<!-- last-edited: 2026-08-04 -->
+
+### Added
+
+- **`maintenance.repair-junk-titles`** — recovers book titles that were replaced by
+  something that is demonstrably not a title. A library scan found **2,061 such books**:
+
+  | stored title | count | cause |
+  |---|---|---|
+  | `read by narrator` | 1,595 | importer kept the filename's trailing credit instead of the leading title |
+  | `big finish ident` | 170 | track 1's ID3 tag promoted to the book title |
+  | `opening credits` | 152 | same |
+  | `intro` | 144 | same |
+
+  These are **real, full-length books with the wrong name** — 30.71h, 9.62h, 27.32h —
+  not junk records. The existing `dedup-books` Phase 1 deliberately deletes only those
+  with no author, series, ISBN or description, so these survive it and must be
+  *retitled*, never deleted.
+
+  `maintenance.title-repair` does not reach them either: a dry run against production
+  would have fixed **7 books**, skipping 34,912 as single-file and 3,742 for
+  "no agreement" — its all-chapters-agree check cannot work when the tracks
+  legitimately disagree ("Track 01", "Track 02"…).
+
+  Two evidence sources, chosen by shape:
+
+  - **Multi-file → the folder.** The organizer named these correctly; only the title
+    field is wrong: `.../Big Finish Productions/Dark Gallifrey/Dark Gallifrey - The War Master Part 2`.
+  - **Single-file → the filename**, parsed for the
+    `<Title> - <Author> - read by <narrator>` convention. Their folder is poisoned by
+    the same bad title (`.../Nocturne/read by narrator/`) and is useless.
+
+  🔑 The author name is what makes the filename parse safe. Naively dropping the last
+  `" - "` segment after the credit corrupts any title that legitimately contains one —
+  `"Dark Gallifrey - The War Master Part 2 - read by narrator.mp3"` would become
+  *"Dark Gallifrey - The War Master"*. The author is stripped only when it actually
+  matches, so with no author known only the credit is removed.
+
+  The op **refuses rather than guesses**: no evidence means the book is left alone,
+  because a known-bad title is still detectable later while an invented one is not. It
+  never swaps one junk title for another, never writes a result under two characters,
+  and honours user overrides, fetched values and provider-applied metadata exactly as
+  `title-repair` does. Dry-run by default, reporting old → new and which evidence was
+  used. Parallel by book; only the ~2k junk-titled books pay the per-book reads.
+
+  15 tests on the derivation, including the two corruptions an earlier draft actually
+  produced: an unbounded parent-directory walk that returned `"lib"` for
+  `/lib/A/intro.mp3` and the author's name for `/lib/Author/Some Book/Some Book.m4b`.

--- a/internal/plugins/maintenance/junk_title_derive.go
+++ b/internal/plugins/maintenance/junk_title_derive.go
@@ -1,0 +1,210 @@
+// file: internal/plugins/maintenance/junk_title_derive.go
+// version: 1.0.0
+// guid: 6fb9129d-4c59-4097-979e-6cfe61bc6894
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// junkTitles are stored Book.Title values that are demonstrably NOT a book title.
+// They come from two distinct accidents, both confirmed against production:
+//
+//   - "read by narrator" (1,595 books) — the on-disk convention is
+//     "<Title> - <Author> - read by <narrator>.<ext>" and the importer kept the
+//     trailing credit instead of the leading title. The organizer then *wrote*
+//     folders named after it, so the directory is poisoned too.
+//   - "intro" / "opening credits" / "big finish ident" (466 books) — track 1's
+//     ID3 title tag was promoted to the book title on a multi-file book.
+//
+// Matched case-insensitively after trimming.
+var junkTitles = map[string]struct{}{
+	"read by narrator":  {},
+	"intro":             {},
+	"opening credits":   {},
+	"big finish ident":  {},
+	"opening credits 1": {},
+}
+
+// IsJunkTitle reports whether a stored title is one of the known bad values.
+func IsJunkTitle(title string) bool {
+	_, ok := junkTitles[strings.ToLower(strings.TrimSpace(title))]
+	return ok
+}
+
+// audioExts are stripped from a filename before it is read as a title.
+var audioExts = map[string]struct{}{
+	".mp3": {}, ".m4a": {}, ".m4b": {}, ".mp4": {}, ".ogg": {},
+	".opus": {}, ".flac": {}, ".wav": {}, ".aac": {}, ".wma": {},
+}
+
+// stripAudioExt removes a known audio extension, and nothing else — an unknown
+// suffix is left alone rather than guessed at, so "Vol. 1.5" keeps its ".5".
+func stripAudioExt(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	if _, ok := audioExts[ext]; ok {
+		return name[:len(name)-len(ext)]
+	}
+	return name
+}
+
+// titleFromFilename recovers the title from a file named by the
+// "<Title> - <Author> - read by <narrator>" convention.
+//
+// 🔑 The author name is REQUIRED to strip safely, and that is the whole point.
+// Naively dropping the last " - " segment after the credit would corrupt any
+// title that legitimately contains one:
+//
+//	"Dark Gallifrey - The War Master Part 2 - read by narrator.mp3"
+//	  naive → "Dark Gallifrey - The War Master"   ✗ eats real title text
+//	  ours  → "Dark Gallifrey - The War Master Part 2"  ✓ (no author match, so
+//	                                                       only the credit goes)
+//
+// When author is known and present, both it and the credit are removed:
+//
+//	"Nocturne - 3 - Umbra Mortem - JD Glasscock - read by narrator.m4b"
+//	  → "Nocturne - 3 - Umbra Mortem"
+//
+// A filename carrying no credit at all is used whole.
+func titleFromFilename(filename, author string) string {
+	stem := strings.TrimSpace(stripAudioExt(filename))
+	if stem == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(stem)
+	idx := strings.LastIndex(lower, " - read by ")
+	if idx < 0 {
+		return stem // no credit suffix — the whole stem is the title
+	}
+	head := strings.TrimSpace(stem[:idx])
+
+	// Remove a trailing " - <Author>" only when it really is the author.
+	if a := strings.TrimSpace(author); a != "" {
+		suffix := " - " + strings.ToLower(a)
+		if strings.HasSuffix(strings.ToLower(head), suffix) {
+			head = strings.TrimSpace(head[:len(head)-len(suffix)])
+		}
+	}
+	return head
+}
+
+// majorityDirOf returns the directory holding the most of these files. Books
+// whose files span directories are common enough that picking the first would
+// be arbitrary.
+func majorityDirOf(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	counts := map[string]int{}
+	for _, p := range paths {
+		if d := filepath.Dir(p); d != "" && d != "." {
+			counts[d]++
+		}
+	}
+	best, bestN := "", -1
+	keys := make([]string, 0, len(counts))
+	for d := range counts {
+		keys = append(keys, d)
+	}
+	sort.Strings(keys) // deterministic when two dirs tie
+	for _, d := range keys {
+		if counts[d] > bestN {
+			best, bestN = d, counts[d]
+		}
+	}
+	return best
+}
+
+// DeriveJunkTitleReplacement works out the real title for a book whose stored
+// title is junk, and reports which evidence it used.
+//
+// Candidates are tried in order of trustworthiness for the shape observed:
+//
+//  1. Multi-file book → the deepest folder segment. These are the ID3-residue
+//     cases, and the organizer already named the folder correctly:
+//     ".../Big Finish Productions/Dark Gallifrey/Dark Gallifrey - The War Master Part 2"
+//  2. The filename, parsed for the "read by" convention. This is the only
+//     evidence for the single-file cases, whose folder was named from the same
+//     bad title and is therefore useless.
+//  3. Walking up the directory, first segment that is not itself junk — a last
+//     resort for ".../Kaiju Task/read by narrator/..." shapes.
+//
+// Returns ok=false when nothing trustworthy is found; the caller must then leave
+// the book alone rather than invent a title.
+func DeriveJunkTitleReplacement(storedTitle, author string, filePaths []string) (title, method string, ok bool) {
+	stored := strings.TrimSpace(storedTitle)
+
+	// corroborated: some path element already matches the stored title, which
+	// means the stored value is what the library actually says. Walking further
+	// up would then "repair" a correct title into its parent folder — how an
+	// early version of this turned "Some Book" into its author's name.
+	corroborated := false
+
+	accept := func(cand, how string) (string, string, bool) {
+		c := strings.TrimSpace(cand)
+		// Never swap one junk title for another, and never write an empty or
+		// single-character title.
+		if len(c) < 2 || IsJunkTitle(c) {
+			return "", "", false
+		}
+		if strings.EqualFold(c, stored) {
+			corroborated = true
+			return "", "", false
+		}
+		return c, how, true
+	}
+
+	dir := majorityDirOf(filePaths)
+
+	// 1. Multi-file: trust the folder.
+	if len(filePaths) >= 2 && dir != "" {
+		if t, m, good := accept(filepath.Base(dir), "folder"); good {
+			return t, m, true
+		}
+	}
+
+	// 2. The filename and its "read by" convention.
+	if len(filePaths) > 0 {
+		if t, m, good := accept(titleFromFilename(filepath.Base(filePaths[0]), author), "filename"); good {
+			return t, m, true
+		}
+	}
+
+	// 3. Walk up for the first non-junk segment — but only a BOUNDED distance,
+	//    and only if nothing so far corroborated the stored title.
+	//
+	//    🔴 Unbounded, this is actively destructive: it climbs past the book, past
+	//    the author, and happily returns a library root. It produced "lib" from
+	//    "/lib/A/intro.mp3" and "Author" from "/lib/Author/Some Book/Some Book.m4b"
+	//    before this bound existed. The real shape needing rescue is only ever one
+	//    level up — ".../Kaiju Task/read by narrator/<file>" — so one level is all
+	//    it gets.
+	//    The hop is also only taken to ESCAPE A POISONED FOLDER. If the folder was
+	//    rejected for any other reason — too short, corroborating the stored title —
+	//    the layout is not the shape this rescue understands, and climbing anyway
+	//    just returns whatever happens to sit above it (that is how "/lib/A/intro.mp3"
+	//    yielded "lib").
+	const maxAncestorHops = 1
+	if !corroborated && dir != "" && IsJunkTitle(filepath.Base(dir)) {
+		d := dir
+		for hop := 0; hop <= maxAncestorHops; hop++ {
+			if d == "" || d == "/" || d == "." {
+				break
+			}
+			if t, m, good := accept(filepath.Base(d), "ancestor-folder"); good {
+				return t, m, true
+			}
+			if corroborated {
+				break
+			}
+			d = filepath.Dir(d)
+		}
+	}
+
+	return "", "", false
+}

--- a/internal/plugins/maintenance/junk_title_derive_test.go
+++ b/internal/plugins/maintenance/junk_title_derive_test.go
@@ -1,0 +1,194 @@
+// file: internal/plugins/maintenance/junk_title_derive_test.go
+// version: 1.0.0
+// guid: 51758d2b-4a45-4c0b-9bd0-5b22cc579c19
+// last-edited: 2026-08-04
+
+package maintenance
+
+import "testing"
+
+// 🔴 THE CORRUPTION THIS MUST NOT CAUSE. Dropping the last " - " segment after
+// the credit is the obvious implementation and it silently eats real title text
+// whenever the title itself contains " - " — which, for series audiobooks, is
+// most of them. The author name is what makes the strip safe.
+func TestTitleFromFilename_DoesNotEatTitleTextWhenAuthorIsAbsent(t *testing.T) {
+	got := titleFromFilename("Dark Gallifrey - The War Master Part 2 - read by narrator.mp3", "")
+	want := "Dark Gallifrey - The War Master Part 2"
+	if got != want {
+		t.Fatalf("got %q, want %q — with no author to match, only the credit may be removed", got, want)
+	}
+}
+
+// With the author known, both the author and the credit come off.
+func TestTitleFromFilename_StripsAuthorAndCredit(t *testing.T) {
+	cases := []struct{ file, author, want string }{
+		{"Nocturne - 3 - Umbra Mortem - JD Glasscock - read by narrator.m4b",
+			"JD Glasscock", "Nocturne - 3 - Umbra Mortem"},
+		{"Bobiverse - 1 - We Are Legion (We Are Bob) - Dennis E. Taylor - read by narrator.m4b",
+			"Dennis E. Taylor", "Bobiverse - 1 - We Are Legion (We Are Bob)"},
+	}
+	for _, c := range cases {
+		if got := titleFromFilename(c.file, c.author); got != c.want {
+			t.Errorf("titleFromFilename(%q, %q) = %q, want %q", c.file, c.author, got, c.want)
+		}
+	}
+}
+
+// A filename with no credit at all is a title in its own right.
+func TestTitleFromFilename_NoCreditUsesWholeStem(t *testing.T) {
+	got := titleFromFilename("Kaiju Task Force_ Code Omega Season.m4b", "Some Author")
+	if got != "Kaiju Task Force_ Code Omega Season" {
+		t.Fatalf("got %q, want the whole stem", got)
+	}
+}
+
+// Author matching is case-insensitive, because the tag case and the filename
+// case disagree constantly in this library.
+func TestTitleFromFilename_AuthorMatchIsCaseInsensitive(t *testing.T) {
+	got := titleFromFilename("Some Book - DENNIS E. TAYLOR - read by narrator.mp3", "dennis e. taylor")
+	if got != "Some Book" {
+		t.Fatalf("got %q, want %q", got, "Some Book")
+	}
+}
+
+// Only real audio extensions are stripped; a version number must survive.
+func TestStripAudioExt_LeavesNonAudioSuffixesAlone(t *testing.T) {
+	if got := stripAudioExt("Vol. 1.5"); got != "Vol. 1.5" {
+		t.Fatalf("got %q, want %q — .5 is not an extension", got, "Vol. 1.5")
+	}
+	if got := stripAudioExt("Book.m4b"); got != "Book" {
+		t.Fatalf("got %q, want %q", got, "Book")
+	}
+}
+
+// 🔑 Shape B — the multi-file ID3-residue case. The folder is correct and is the
+// most trustworthy evidence, so it wins over the filename (which is a track name
+// like "01 Big Finish Ident.mp3" and would be worse than useless).
+func TestDeriveJunkTitleReplacement_MultiFileUsesFolder(t *testing.T) {
+	paths := []string{
+		"/lib/Big Finish Productions/Dark Gallifrey/Dark Gallifrey - The War Master Part 2/01 Big Finish Ident.mp3",
+		"/lib/Big Finish Productions/Dark Gallifrey/Dark Gallifrey - The War Master Part 2/02 The War Master Part 2 Track 01.mp3",
+	}
+	got, method, ok := DeriveJunkTitleReplacement("Big Finish Ident", "Big Finish Productions", paths)
+	if !ok {
+		t.Fatal("expected a derivation")
+	}
+	if got != "Dark Gallifrey - The War Master Part 2" {
+		t.Fatalf("title = %q, want the folder name", got)
+	}
+	if method != "folder" {
+		t.Fatalf("method = %q, want folder", method)
+	}
+}
+
+// 🔑 Shape A — single file whose FOLDER is poisoned by the same bad title. The
+// filename is the only evidence, and the folder must not be used.
+func TestDeriveJunkTitleReplacement_SingleFileUsesFilenameWhenFolderIsPoisoned(t *testing.T) {
+	paths := []string{
+		"/lib/Nocturne/read by narrator/Nocturne - 3 - Umbra Mortem - JD Glasscock - read by narrator.m4b",
+	}
+	got, method, ok := DeriveJunkTitleReplacement("read by narrator", "JD Glasscock", paths)
+	if !ok {
+		t.Fatal("expected a derivation")
+	}
+	if got != "Nocturne - 3 - Umbra Mortem" {
+		t.Fatalf("title = %q, want the filename-derived title", got)
+	}
+	if method != "filename" {
+		t.Fatalf("method = %q, want filename", method)
+	}
+}
+
+// A multi-file book whose folder IS junk must fall through to the filename
+// rather than accept the poisoned folder name.
+func TestDeriveJunkTitleReplacement_RejectsJunkFolderAndFallsThrough(t *testing.T) {
+	paths := []string{
+		"/lib/Nocturne/read by narrator/Nocturne - 3 - Umbra Mortem - JD Glasscock - read by narrator.m4b",
+		"/lib/Nocturne/read by narrator/Nocturne - 3 - Umbra Mortem.m4b",
+	}
+	got, _, ok := DeriveJunkTitleReplacement("read by narrator", "JD Glasscock", paths)
+	if !ok {
+		t.Fatal("expected a derivation")
+	}
+	if IsJunkTitle(got) {
+		t.Fatalf("derived another junk title: %q", got)
+	}
+	if got != "Nocturne - 3 - Umbra Mortem" {
+		t.Fatalf("title = %q, want %q", got, "Nocturne - 3 - Umbra Mortem")
+	}
+}
+
+// The ancestor walk rescues the ".../Kaiju Task/read by narrator/..." shape when
+// the filename itself is unhelpful.
+func TestDeriveJunkTitleReplacement_WalksUpToAnAncestorFolder(t *testing.T) {
+	paths := []string{"/lib/Kaiju Task/read by narrator/read by narrator.m4b"}
+	got, method, ok := DeriveJunkTitleReplacement("read by narrator", "", paths)
+	if !ok {
+		t.Fatal("expected a derivation from an ancestor folder")
+	}
+	if got != "Kaiju Task" {
+		t.Fatalf("title = %q, want %q", got, "Kaiju Task")
+	}
+	if method != "ancestor-folder" {
+		t.Fatalf("method = %q, want ancestor-folder", method)
+	}
+}
+
+// 🔴 Refuse rather than invent. A book with nothing usable must be left alone —
+// writing a guessed title is worse than leaving a known-bad one, because the bad
+// one is at least detectable by this same op later.
+func TestDeriveJunkTitleReplacement_RefusesWhenThereIsNoEvidence(t *testing.T) {
+	if _, _, ok := DeriveJunkTitleReplacement("read by narrator", "", nil); ok {
+		t.Fatal("derived a title from no files at all")
+	}
+	if _, _, ok := DeriveJunkTitleReplacement("read by narrator", "", []string{"read by narrator.m4b"}); ok {
+		t.Fatal("derived a title when every candidate was junk")
+	}
+}
+
+// A single-character result is not a title.
+func TestDeriveJunkTitleReplacement_RejectsTooShortResults(t *testing.T) {
+	if _, _, ok := DeriveJunkTitleReplacement("intro", "", []string{"/lib/A/intro.mp3"}); ok {
+		t.Fatal("accepted a one-character title")
+	}
+}
+
+// Never report a change when the derived value equals what is already stored.
+func TestDeriveJunkTitleReplacement_RejectsNoOpRewrite(t *testing.T) {
+	paths := []string{"/lib/Author/Some Book/Some Book.m4b"}
+	if _, _, ok := DeriveJunkTitleReplacement("Some Book", "Author", paths); ok {
+		t.Fatal("reported a change that would rewrite the title to itself")
+	}
+}
+
+// Ties between directories must resolve deterministically, so a dry run and the
+// apply that follows it agree.
+func TestMajorityDirOf_IsDeterministicOnTies(t *testing.T) {
+	paths := []string{"/b/zzz/1.mp3", "/a/aaa/2.mp3"}
+	first := majorityDirOf(paths)
+	for i := 0; i < 20; i++ {
+		if got := majorityDirOf(paths); got != first {
+			t.Fatalf("majorityDirOf is unstable: %q then %q", first, got)
+		}
+	}
+}
+
+func TestMajorityDirOf_PicksTheDirectoryHoldingMostFiles(t *testing.T) {
+	paths := []string{"/a/x/1.mp3", "/a/y/2.mp3", "/a/y/3.mp3"}
+	if got := majorityDirOf(paths); got != "/a/y" {
+		t.Fatalf("got %q, want /a/y", got)
+	}
+}
+
+func TestIsJunkTitle(t *testing.T) {
+	for _, s := range []string{"read by narrator", "  Read By Narrator ", "INTRO", "Big Finish Ident"} {
+		if !IsJunkTitle(s) {
+			t.Errorf("IsJunkTitle(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"Nocturne", "The Intro Files", ""} {
+		if IsJunkTitle(s) {
+			t.Errorf("IsJunkTitle(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
 // last-edited: 2026-08-04
 
@@ -42,6 +42,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.archiveSweepDef(),
 		p.orphanBookFilesCleanupDef(),
 		p.dedupeBookFileRowsDef(),
+		p.repairJunkTitlesDef(),
 		p.purgeMillisecondDurationsDef(),
 		p.integrityCheckDef(),
 

--- a/internal/plugins/maintenance/repair_junk_titles.go
+++ b/internal/plugins/maintenance/repair_junk_titles.go
@@ -1,0 +1,229 @@
+// file: internal/plugins/maintenance/repair_junk_titles.go
+// version: 1.0.0
+// guid: 9c4e7a12-3b58-4d06-8f21-7ae5c0d94b63
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// RepairJunkTitlesParams are the JSON parameters for the junk-title repair.
+type RepairJunkTitlesParams struct {
+	// Apply, when true, writes the recovered titles. Default false — dry run.
+	Apply bool `json:"apply"`
+	// Limit caps how many BOOKS are repaired (0 = all). Useful for a canary.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *Plugin) repairJunkTitlesDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.repair-junk-titles",
+		Plugin:      "maintenance",
+		DisplayName: "Recover book titles that were replaced by junk",
+		Description: "Repairs books whose stored title is demonstrably not a title — \"read by narrator\" " +
+			"(the importer kept the filename's trailing credit instead of the leading title) or a track tag " +
+			"promoted to the book title (\"Intro\", \"Opening Credits\", \"Big Finish Ident\"). Recovers the real " +
+			"title from the folder for multi-file books and from the filename convention for single-file books, " +
+			"and refuses rather than guesses when there is no trustworthy evidence. Honours user overrides, " +
+			"fetched values and provider-applied metadata. Dry-run by default; pass {\"apply\": true} to write.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.repair-junk-titles",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ProgressTimeout: 30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runRepairJunkTitles,
+	}
+}
+
+func (p *Plugin) runRepairJunkTitles(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params RepairJunkTitlesParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	log := reporter.Logger()
+	log.Info("repair-junk-titles: starting", "apply", params.Apply, "limit", params.Limit)
+
+	// PASS 1 — page the cheap Core projection and keep ONLY the junk-titled books.
+	// Filtering here rather than inside the worker matters: the per-book work
+	// (files, field states, author) is several reads, and this turns a 44k-book
+	// sweep into a ~2k-book one.
+	const pageSize = 1000
+	var candidates []database.BookCore
+	scanned := 0
+	for offset := 0; ; offset += pageSize {
+		page, err := store.GetAllBooksCore(pageSize, offset)
+		if err != nil {
+			return fmt.Errorf("GetAllBooksCore offset=%d: %w", offset, err)
+		}
+		scanned += len(page)
+		for i := range page {
+			if page[i].MarkedForDeletion != nil && *page[i].MarkedForDeletion {
+				continue
+			}
+			if IsJunkTitle(page[i].Title) {
+				candidates = append(candidates, page[i])
+			}
+		}
+		if len(page) < pageSize {
+			break
+		}
+	}
+	if params.Limit > 0 && len(candidates) > params.Limit {
+		candidates = candidates[:params.Limit]
+	}
+
+	log.Info("repair-junk-titles: scan complete", "scanned", scanned, "junk_titled", len(candidates))
+	if len(candidates) == 0 {
+		summary := fmt.Sprintf("repair-junk-titles: %d books scanned, 0 junk titles found — nothing to do", scanned)
+		_ = reporter.Log(slog.LevelInfo, summary)
+		_ = reporter.UpdateProgress(1, 1, summary)
+		return nil
+	}
+
+	var repaired, wouldRepair, skipProvenance, skipNoEvidence, failed atomic.Int64
+	byMethod := map[string]int{}
+	var mu sync.Mutex
+	var examples []string
+
+	// authorNames caches id→name; a whole series shares one author, so the same
+	// handful of ids repeat across hundreds of books.
+	authorNames := map[int]string{}
+	var authorMu sync.Mutex
+	authorName := func(id *int) string {
+		if id == nil {
+			return ""
+		}
+		authorMu.Lock()
+		defer authorMu.Unlock()
+		if n, ok := authorNames[*id]; ok {
+			return n
+		}
+		n := ""
+		if a, err := store.GetAuthorByID(*id); err == nil && a != nil {
+			n = a.Name
+		}
+		authorNames[*id] = n
+		return n
+	}
+
+	runErr := registry.RunItems(ctx, reporter, candidates, func(ctx context.Context, b database.BookCore) error {
+		// Provenance guard — same rules as maintenance.title-repair. A title a
+		// human set, or one a metadata provider supplied, is not ours to rewrite
+		// however wrong it looks.
+		states, serr := store.GetMetadataFieldStates(b.ID)
+		if serr != nil {
+			failed.Add(1)
+			log.Warn("repair-junk-titles: GetMetadataFieldStates failed", "book_id", b.ID, "err", serr)
+			return nil
+		}
+		for i := range states {
+			if states[i].Field != "title" {
+				continue
+			}
+			if states[i].OverrideLocked || states[i].OverrideValue != nil || states[i].FetchedValue != nil {
+				skipProvenance.Add(1)
+				return nil
+			}
+		}
+
+		files, ferr := store.GetBookFiles(b.ID)
+		if ferr != nil {
+			failed.Add(1)
+			log.Warn("repair-junk-titles: GetBookFiles failed", "book_id", b.ID, "err", ferr)
+			return nil
+		}
+		paths := make([]string, 0, len(files))
+		for i := range files {
+			if strings.TrimSpace(files[i].FilePath) != "" {
+				paths = append(paths, files[i].FilePath)
+			}
+		}
+
+		newTitle, method, ok := DeriveJunkTitleReplacement(b.Title, authorName(b.AuthorID), paths)
+		if !ok {
+			skipNoEvidence.Add(1)
+			return nil
+		}
+
+		mu.Lock()
+		byMethod[method]++
+		if len(examples) < 12 {
+			examples = append(examples, fmt.Sprintf("%q → %q [%s]", b.Title, newTitle, method))
+		}
+		mu.Unlock()
+
+		if !params.Apply {
+			wouldRepair.Add(1)
+			return nil
+		}
+
+		full, gerr := store.GetBookByID(b.ID)
+		if gerr != nil || full == nil {
+			failed.Add(1)
+			log.Warn("repair-junk-titles: GetBookByID failed", "book_id", b.ID, "err", gerr)
+			return nil
+		}
+		full.Title = newTitle
+		if _, uerr := store.UpdateBook(b.ID, full); uerr != nil {
+			failed.Add(1)
+			log.Warn("repair-junk-titles: UpdateBook failed", "book_id", b.ID, "err", uerr)
+			return nil
+		}
+		repaired.Add(1)
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency: titleRepairWorkers(),
+		ErrMode:     registry.ErrModeCollect,
+		Label: func(i, total int) string { return fmt.Sprintf("book %d/%d", i+1, total) },
+	})
+	if runErr != nil && ctx.Err() != nil {
+		log.Warn("repair-junk-titles: cancelled", "repaired", repaired.Load())
+		return ctx.Err()
+	}
+	if runErr != nil {
+		log.Warn("repair-junk-titles: some books failed", "err", runErr)
+	}
+
+	verb := fmt.Sprintf("would repair %d", wouldRepair.Load())
+	if params.Apply {
+		verb = fmt.Sprintf("repaired %d", repaired.Load())
+	}
+	mu.Lock()
+	methods := make([]string, 0, len(byMethod))
+	for m, n := range byMethod {
+		methods = append(methods, fmt.Sprintf("%s=%d", m, n))
+	}
+	ex := strings.Join(examples, "; ")
+	mu.Unlock()
+
+	summary := fmt.Sprintf(
+		"repair-junk-titles: %d books scanned, %d junk-titled, %s (by evidence: %s), "+
+			"skipped %d (protected provenance), %d (no trustworthy evidence), failed %d | e.g. %s",
+		scanned, len(candidates), verb, strings.Join(methods, " "),
+		skipProvenance.Load(), skipNoEvidence.Load(), failed.Load(), ex)
+	_ = reporter.Log(slog.LevelInfo, summary)
+	_ = reporter.UpdateProgress(len(candidates), len(candidates), summary)
+	return nil
+}


### PR DESCRIPTION
## The problem

A library scan found **2,061 books** whose stored title is demonstrably not a title:

| stored title | count | cause |
|---|---|---|
| `read by narrator` | 1,595 | importer kept the filename's trailing credit instead of the leading title |
| `big finish ident` | 170 | track 1's ID3 tag promoted to the book title |
| `opening credits` | 152 | same |
| `intro` | 144 | same |

These are **real, full-length books with the wrong name** — 30.71h, 9.62h, 27.32h — not junk records. `dedup-books` Phase 1 deliberately deletes only those with no author, series, ISBN or description, so these survive it and must be **retitled, never deleted**.

`maintenance.title-repair` doesn't reach them either. A production dry run would have fixed **7 books**, skipping 34,912 as single-file and 3,742 for "no agreement" — its all-chapters-agree check can't work when tracks legitimately disagree (`Track 01`, `Track 02`…).

## Two evidence sources, chosen by shape

**Multi-file → the folder.** The organizer named these correctly; only the title field is wrong:
```
.../Big Finish Productions/Dark Gallifrey/Dark Gallifrey - The War Master Part 2
file: 01 Big Finish Ident.mp3        ← this became the book title
```

**Single-file → the filename.** Their folder is poisoned by the same bad title and is useless:
```
folder: .../Nocturne/read by narrator/
file  : Nocturne - 3 - Umbra Mortem - JD Glasscock - read by narrator.m4b
```

## Why the author name matters

Naively dropping the last `" - "` segment after the credit corrupts any title that legitimately contains one:

```
"Dark Gallifrey - The War Master Part 2 - read by narrator.mp3"
  naive → "Dark Gallifrey - The War Master"        ✗ eats real title text
  ours  → "Dark Gallifrey - The War Master Part 2" ✓
```

The author is stripped only when it actually matches, so with no author known only the credit comes off.

## Safety

**Refuses rather than guesses** — no evidence means the book is left alone, because a known-bad title stays detectable by this same op later while an invented one does not. Never swaps one junk title for another, never writes a result under two characters, and honours user overrides, fetched values and provider-applied metadata exactly as `title-repair` does.

Dry-run by default, reporting old → new and which evidence was used. Parallel by book, and only the ~2k junk-titled books pay the per-book reads — the filter happens in the cheap `Core` pass.

## Tests

15 on the derivation, including **the two corruptions an earlier draft actually produced and these tests caught**: an unbounded parent-directory walk that returned `"lib"` for `/lib/A/intro.mp3`, and the author's name for `/lib/Author/Some Book/Some Book.m4b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp