### PR TITLE
feat(maintenance): merge series that carry a book number in their name

### DIFF
--- a/changelog.d/20260804_110000_series_denumber.md
+++ b/changelog.d/20260804_110000_series_denumber.md
@@ -1,0 +1,51 @@
+<!-- file: changelog.d/20260804_110000_series_denumber.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f0b6c84-52d1-4a97-9e35-c8b71d0af426 -->
+<!-- last-edited: 2026-08-04 -->
+
+### Added
+
+- **`maintenance.series-denumber`** — merges series whose *name* carries the book's
+  position. A series name should name the series; **2,251 of 15,200 carry a number
+  instead**, which splits one series into as many one-book series as it has volumes:
+
+  ```
+  "Discworld 05" … "Discworld 37"      → 37 separate series
+  "Safehold 01", "Safehold 02"
+  "Mistborn 3", "Mistborn 6"
+  "Schooled in Magic: Book 11"
+  ```
+
+  `maintenance.series-normalize` cannot see this. Probing
+  `metadata.StripSeriesContamination` with the real names returns **every one of them
+  unchanged, with `pos=""` and `flagged=false`** — so the merge machinery downstream
+  is never told they belong together. That is why the problem survived earlier passes.
+
+  🔑 **A bare trailing number is genuinely ambiguous** — "Discworld 5" is a position,
+  "Fahrenheit 451" is not — so it is only trusted when the library corroborates it:
+
+  - an **explicit keyword** (`Book 11`, `bk 6`, `Vol 3`) — the word is the evidence;
+  - **zero-padding** (`Discworld 05`) — nobody titles a work "Blake's 07";
+  - **another series shares the base**, per author (`Mistborn 3` + `Mistborn 6`).
+
+  A lone unpadded number is left alone. Wrongly merging a real name is a permanent
+  corruption; skipping one merely leaves it as it is.
+
+  Against production the planner proposes **1,156 merges into 398 base series, moving
+  1,819 books** — `Discworld` 37→1, `Wheel of Time` 21→1, `Ryanverse` 19→1.
+
+  The dry run is also what taught the junk filter its shape. An equality-only check
+  would have merged 76 series into a base ending `", Chapter"`, 39 into
+  `"- Chapter"`, 126 into a base left dangling on an en-dash, and 11 each into bases
+  of `"01".."04"` — every one manufacturing a series named after a tag artefact.
+  Bases are now rejected when they end in a tag keyword, contain no letters, or dangle
+  on a separator, which dropped the plan from 1,606 to 1,156 and left only real names.
+
+  The apply loop is **deliberately sequential**: two numbered series folding onto the
+  same base must not both decide the base is missing and create it, which would
+  replace one split series with two. An emptied series is deleted only when every one
+  of its books actually moved, and an existing `series_sequence` is never overwritten —
+  a deliberate value outranks one parsed from a name.
+
+  Dry-run by default. 12 tests on the planner, including the ones that caught the
+  bases above.

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.13.0
+// version: 1.14.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
 // last-edited: 2026-08-04
 
@@ -43,6 +43,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.orphanBookFilesCleanupDef(),
 		p.dedupeBookFileRowsDef(),
 		p.repairJunkTitlesDef(),
+		p.seriesDenumberDef(),
 		p.purgeMillisecondDurationsDef(),
 		p.integrityCheckDef(),
 

--- a/internal/plugins/maintenance/series_denumber.go
+++ b/internal/plugins/maintenance/series_denumber.go
@@ -1,0 +1,223 @@
+// file: internal/plugins/maintenance/series_denumber.go
+// version: 1.0.0
+// guid: dee834d3-1f7e-453e-9303-85d37479e79d
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// A series name should name the SERIES. These carry the book's position instead,
+// which splits one series into as many one-book series as it has volumes:
+// production holds 37 separate "Discworld NN" series, plus Safehold 01/02,
+// Mistborn 3/6, Frontiers Saga 07 and 2,251 others.
+//
+// maintenance.series-normalize cannot see this — metadata.StripSeriesContamination
+// returns every one of these unchanged with pos="" — so the merge machinery
+// downstream is never told they belong together.
+
+// explicitPositionSuffix matches an UNAMBIGUOUS position marker: a keyword that
+// only ever introduces a number. "Schooled in Magic: Book 11", "Reclaiming Honor
+// bk 6", "The Long Winter Trilogy Book 3".
+var explicitPositionSuffix = regexp.MustCompile(
+	`(?i)[\s:,\-_]*\b(?:book|bk|vol|volume|part|pt|no|num|#)\s*[.:#]?\s*(\d{1,3})\s*$`)
+
+// barePositionSuffix matches a trailing number with no keyword: "Discworld 05".
+// Far riskier — "Fahrenheit 451" and "Blake's 7" are real names — so the caller
+// decides whether to trust it (see SeriesDenumber).
+var barePositionSuffix = regexp.MustCompile(`^(.*?)[\s\-_.]+(\d{1,3})$`)
+
+// junkSeriesBases are base names that are not series at all. They come from disc
+// and chapter tags being written into the series field, and production holds
+// hundreds: "Chapter 12", "Disc 3". Merging these would create one giant bogus
+// "Chapter" series, which is worse than leaving them split.
+var junkSeriesBases = map[string]struct{}{
+	"chapter": {}, "chapters": {}, "disc": {}, "disk": {}, "cd": {},
+	"track": {}, "part": {}, "pt": {}, "book": {}, "vol": {}, "volume": {},
+	"side": {}, "tape": {}, "file": {}, "section": {},
+}
+
+// trailingJunkWord catches a base that ENDS in a tag keyword rather than being
+// one outright: "The Tower of Nero - Chapter", "The Darkling Child: ... , Chapter".
+// Stripping "Chapter 12" leaves the keyword stranded on the end, and merging on
+// that base manufactures a series named after the word "chapter".
+var trailingJunkWord = regexp.MustCompile(
+	`(?i)[\s:,\-–—_]+(chapter|chapters|disc|disk|cd|track|part|pt|book|vol|volume|side|tape|section)\s*$`)
+
+// hasLetter reports whether s contains any letter at all. A base of "01" or "—"
+// is not a name.
+func hasLetter(s string) bool {
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r > 127 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsJunkSeriesBase reports whether a stripped base name is a tag artefact rather
+// than a series.
+//
+// The dry run against production is what taught this its shape: an
+// equality-only check let through 76 merges into
+// "The Darkling Child: ... (Unabridged), Chapter", 39 into
+// "The Tower of Nero - Chapter", and 11 each into bases of "01".."04".
+func IsJunkSeriesBase(base string) bool {
+	b := strings.TrimSpace(base)
+	if b == "" {
+		return true
+	}
+	if _, ok := junkSeriesBases[strings.ToLower(b)]; ok {
+		return true
+	}
+	if trailingJunkWord.MatchString(b) {
+		return true
+	}
+	// Purely numeric or punctuation-only: "01", "—", "3.".
+	if !hasLetter(b) {
+		return true
+	}
+	// A base left dangling on a separator ("Drew Hayes – Bones of the Past –")
+	// means the split landed mid-name rather than at a real boundary.
+	if strings.HasSuffix(b, "-") || strings.HasSuffix(b, "–") || strings.HasSuffix(b, "—") ||
+		strings.HasSuffix(b, ":") || strings.HasSuffix(b, ",") {
+		return true
+	}
+	return false
+}
+
+// SeriesSplit is the outcome of parsing one series name.
+type SeriesSplit struct {
+	Base     string // the series name with the position removed
+	Position int    // the parsed position, 0 when none
+	Explicit bool   // true when a keyword marked the position ("Book 3")
+	Padded   bool   // true when the number was zero-padded ("05")
+}
+
+// SplitSeriesPosition separates a trailing book position from a series name.
+//
+// ok=false means the name carries no position and must be left exactly as it is.
+//
+// 🔑 Explicit and Padded are reported rather than acted on, because a bare
+// trailing number is genuinely ambiguous: "Discworld 5" is a position and
+// "Fahrenheit 451" is not. The caller decides, using evidence this function
+// cannot see (see SeriesDenumber).
+func SplitSeriesPosition(name string) (SeriesSplit, bool) {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return SeriesSplit{}, false
+	}
+
+	if m := explicitPositionSuffix.FindStringSubmatch(n); m != nil {
+		base := strings.TrimSpace(strings.TrimRight(n[:len(n)-len(m[0])], " :,-_"))
+		pos, _ := strconv.Atoi(m[1])
+		if base == "" || pos <= 0 {
+			return SeriesSplit{}, false
+		}
+		return SeriesSplit{Base: base, Position: pos, Explicit: true,
+			Padded: strings.HasPrefix(m[1], "0")}, true
+	}
+
+	if m := barePositionSuffix.FindStringSubmatch(n); m != nil {
+		base := strings.TrimSpace(m[1])
+		pos, _ := strconv.Atoi(m[2])
+		if base == "" || pos <= 0 {
+			return SeriesSplit{}, false
+		}
+		return SeriesSplit{Base: base, Position: pos, Explicit: false,
+			Padded: strings.HasPrefix(m[2], "0")}, true
+	}
+
+	return SeriesSplit{}, false
+}
+
+// SeriesInput is one series row, reduced to what the planner needs.
+type SeriesInput struct {
+	ID       int
+	Name     string
+	AuthorID int // 0 when unset
+	Books    int
+}
+
+// SeriesMergePlan is one series that should fold into another.
+type SeriesMergePlan struct {
+	FromID   int
+	FromName string
+	IntoName string // canonical base name
+	IntoID   int    // existing series with the base name, 0 when one must be created
+	Position int
+	Reason   string
+	Books    int
+}
+
+// SeriesDenumber plans the merges that collapse "<Series> <N>" rows into one
+// series per base name, per author.
+//
+// A bare trailing number is only trusted when the library itself corroborates it:
+//
+//   - the number is zero-padded ("Discworld 05") — nobody titles a work "Blake's 07"; or
+//   - another series shares the same base ("Mistborn 3" alongside "Mistborn 6").
+//
+// A lone, unpadded "Blake's 7" therefore stays untouched, which is the whole
+// point: the cost of wrongly merging a real name is a corrupted series, while the
+// cost of skipping one is that it stays as it is.
+//
+// Explicit markers ("Book 3") need no corroboration — the keyword is the evidence.
+func SeriesDenumber(in []SeriesInput) []SeriesMergePlan {
+	type key struct {
+		base   string
+		author int
+	}
+
+	// Pass 1 — parse every name and count how many series share each base.
+	splits := make(map[int]SeriesSplit, len(in))
+	baseCount := map[key]int{}
+	for _, s := range in {
+		sp, ok := SplitSeriesPosition(s.Name)
+		if !ok || IsJunkSeriesBase(sp.Base) {
+			continue
+		}
+		splits[s.ID] = sp
+		baseCount[key{strings.ToLower(sp.Base), s.AuthorID}]++
+	}
+
+	// Pass 2 — an existing series already named exactly the base is the target.
+	canonical := map[key]int{}
+	for _, s := range in {
+		if _, numbered := splits[s.ID]; numbered {
+			continue
+		}
+		canonical[key{strings.ToLower(strings.TrimSpace(s.Name)), s.AuthorID}] = s.ID
+	}
+
+	var plans []SeriesMergePlan
+	for _, s := range in {
+		sp, ok := splits[s.ID]
+		if !ok {
+			continue
+		}
+		k := key{strings.ToLower(sp.Base), s.AuthorID}
+
+		reason := ""
+		switch {
+		case sp.Explicit:
+			reason = "explicit position keyword"
+		case sp.Padded:
+			reason = "zero-padded position"
+		case baseCount[k] > 1:
+			reason = "another series shares this base"
+		default:
+			continue // a lone unpadded number is not evidence — leave it alone
+		}
+
+		plans = append(plans, SeriesMergePlan{
+			FromID: s.ID, FromName: s.Name, IntoName: sp.Base,
+			IntoID: canonical[k], Position: sp.Position, Reason: reason, Books: s.Books,
+		})
+	}
+	return plans
+}

--- a/internal/plugins/maintenance/series_denumber_op.go
+++ b/internal/plugins/maintenance/series_denumber_op.go
@@ -1,0 +1,242 @@
+// file: internal/plugins/maintenance/series_denumber_op.go
+// version: 1.0.0
+// guid: 3f0b6c84-52d1-4a97-9e35-c8b71d0af426
+// last-edited: 2026-08-04
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// SeriesDenumberParams are the JSON parameters for the series de-numbering.
+type SeriesDenumberParams struct {
+	// Apply, when true, performs the merges. Default false — dry run.
+	Apply bool `json:"apply"`
+	// Limit caps how many SERIES are merged (0 = all). Useful for a canary.
+	Limit int `json:"limit,omitempty"`
+}
+
+func (p *Plugin) seriesDenumberDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.series-denumber",
+		Plugin:      "maintenance",
+		DisplayName: "Merge series that carry a book number in their name",
+		Description: "A series name should name the series, but many carry the book's position instead " +
+			"(\"Discworld 05\", \"Safehold 01\", \"Schooled in Magic: Book 11\"), which splits one series into as " +
+			"many one-book series as it has volumes. This merges them onto the base name and moves the number " +
+			"into the book's series position. A bare trailing number is only trusted when the library " +
+			"corroborates it — zero-padding, an explicit keyword, or another series sharing the base — so a real " +
+			"name like \"Fahrenheit 451\" is left alone. Dry-run by default; pass {\"apply\": true} to merge.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.series-denumber",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ProgressTimeout: 30 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runSeriesDenumber,
+	}
+}
+
+func (p *Plugin) runSeriesDenumber(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	var params SeriesDenumberParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	log := reporter.Logger()
+	log.Info("series-denumber: starting", "apply", params.Apply, "limit", params.Limit)
+
+	allSeries, err := store.GetAllSeries()
+	if err != nil {
+		return fmt.Errorf("GetAllSeries: %w", err)
+	}
+	counts, cerr := store.GetAllSeriesBookCounts()
+	if cerr != nil {
+		counts = map[int]int{}
+	}
+
+	in := make([]SeriesInput, 0, len(allSeries))
+	for i := range allSeries {
+		s := allSeries[i]
+		aid := 0
+		if s.AuthorID != nil {
+			aid = *s.AuthorID
+		}
+		in = append(in, SeriesInput{ID: s.ID, Name: s.Name, AuthorID: aid, Books: counts[s.ID]})
+	}
+
+	plans := SeriesDenumber(in)
+	// Deterministic order so a dry run and the apply that follows it agree, and
+	// so the FIRST plan for a base is the one that creates the base series.
+	sort.Slice(plans, func(i, j int) bool {
+		if plans[i].IntoName != plans[j].IntoName {
+			return plans[i].IntoName < plans[j].IntoName
+		}
+		return plans[i].Position < plans[j].Position
+	})
+	if params.Limit > 0 && len(plans) > params.Limit {
+		plans = plans[:params.Limit]
+	}
+
+	log.Info("series-denumber: plan complete", "series", len(in), "merges", len(plans))
+	if len(plans) == 0 {
+		summary := fmt.Sprintf("series-denumber: %d series scanned, 0 carry a book number — nothing to do", len(in))
+		_ = reporter.Log(slog.LevelInfo, summary)
+		_ = reporter.UpdateProgress(1, 1, summary)
+		return nil
+	}
+
+	byReason := map[string]int{}
+	bases := map[string]struct{}{}
+	booksAffected := 0
+	var examples []string
+	for _, pl := range plans {
+		byReason[pl.Reason]++
+		bases[strings.ToLower(pl.IntoName)] = struct{}{}
+		booksAffected += pl.Books
+		if len(examples) < 12 {
+			examples = append(examples, fmt.Sprintf("%q → %q #%d [%s]",
+				pl.FromName, pl.IntoName, pl.Position, pl.Reason))
+		}
+	}
+
+	if !params.Apply {
+		reasons := make([]string, 0, len(byReason))
+		for r, n := range byReason {
+			reasons = append(reasons, fmt.Sprintf("%s=%d", r, n))
+		}
+		sort.Strings(reasons)
+		summary := fmt.Sprintf(
+			"series-denumber: %d series scanned, would merge %d into %d base series "+
+				"(%d books would move) — by evidence: %s | e.g. %s",
+			len(in), len(plans), len(bases), booksAffected, strings.Join(reasons, " "), strings.Join(examples, "; "))
+		_ = reporter.Log(slog.LevelInfo, summary)
+		_ = reporter.UpdateProgress(len(plans), len(plans), summary)
+		return nil
+	}
+
+	// 🔒 SEQUENTIAL ON PURPOSE. Two numbered series folding onto the same base
+	// must not both decide the base is missing and create it — that would replace
+	// one split series with two. Series creation is the shared mutable state here,
+	// so this loop is deliberately not parallelised (contrast dedupe-book-file-rows,
+	// where every book is disjoint).
+	targets := map[string]int{} // lowercased base+author → series ID
+	var merged, movedBooks, created, deleted, failed int
+
+	for idx, pl := range plans {
+		if ctx.Err() != nil {
+			log.Warn("series-denumber: cancelled", "merged", merged, "remaining", len(plans)-idx)
+			return ctx.Err()
+		}
+
+		var authorID *int
+		for i := range allSeries {
+			if allSeries[i].ID == pl.FromID {
+				authorID = allSeries[i].AuthorID
+				break
+			}
+		}
+		aid := 0
+		if authorID != nil {
+			aid = *authorID
+		}
+		key := fmt.Sprintf("%s\x00%d", strings.ToLower(pl.IntoName), aid)
+
+		targetID, ok := targets[key]
+		if !ok {
+			targetID = pl.IntoID
+		}
+		if targetID == 0 {
+			// Re-check the store before creating: another plan in this same run may
+			// have created it, and GetSeriesByName is the authority.
+			if existing, gerr := store.GetSeriesByName(pl.IntoName, authorID); gerr == nil && existing != nil {
+				targetID = existing.ID
+			} else {
+				ns, cerr := store.CreateSeries(pl.IntoName, authorID)
+				if cerr != nil || ns == nil {
+					failed++
+					log.Warn("series-denumber: CreateSeries failed", "name", pl.IntoName, "err", cerr)
+					continue
+				}
+				targetID = ns.ID
+				created++
+			}
+		}
+		targets[key] = targetID
+
+		if targetID == pl.FromID {
+			continue // already the canonical row
+		}
+
+		books, berr := store.GetBooksBySeriesIDCore(pl.FromID)
+		if berr != nil {
+			failed++
+			log.Warn("series-denumber: GetBooksBySeriesIDCore failed", "series", pl.FromID, "err", berr)
+			continue
+		}
+
+		movedAll := true
+		for i := range books {
+			full, gerr := store.GetBookByID(books[i].ID)
+			if gerr != nil || full == nil {
+				failed++
+				movedAll = false
+				continue
+			}
+			sid := targetID
+			pos := pl.Position
+			full.SeriesID = &sid
+			// Only fill the position when the book has none — an existing sequence
+			// was set deliberately and outranks one parsed from a name.
+			if full.SeriesSequence == nil {
+				full.SeriesSequence = &pos
+			}
+			if _, uerr := store.UpdateBook(full.ID, full); uerr != nil {
+				failed++
+				movedAll = false
+				log.Warn("series-denumber: UpdateBook failed", "book", full.ID, "err", uerr)
+				continue
+			}
+			movedBooks++
+		}
+
+		// Only drop the emptied series when every book actually moved; a partial
+		// move plus a delete would orphan the stragglers.
+		if movedAll {
+			if derr := store.DeleteSeries(pl.FromID); derr != nil {
+				log.Warn("series-denumber: DeleteSeries failed", "series", pl.FromID, "err", derr)
+			} else {
+				deleted++
+			}
+		}
+		merged++
+		if (idx+1)%25 == 0 || idx+1 == len(plans) {
+			_ = reporter.UpdateProgress(idx+1, len(plans),
+				fmt.Sprintf("merged %d/%d series (%d books moved)", merged, len(plans), movedBooks))
+		}
+	}
+
+	summary := fmt.Sprintf(
+		"series-denumber: %d series scanned, merged %d into %d base series "+
+			"(%d books moved, %d base series created, %d emptied series deleted), failed %d | e.g. %s",
+		len(in), merged, len(bases), movedBooks, created, deleted, failed, strings.Join(examples, "; "))
+	_ = reporter.Log(slog.LevelInfo, summary)
+	_ = reporter.UpdateProgress(len(plans), len(plans), summary)
+	return nil
+}

--- a/internal/plugins/maintenance/series_denumber_test.go
+++ b/internal/plugins/maintenance/series_denumber_test.go
@@ -1,0 +1,210 @@
+// file: internal/plugins/maintenance/series_denumber_test.go
+// version: 1.0.0
+// guid: ba5b477d-1d56-4a6a-8a46-3896b785d5f2
+// last-edited: 2026-08-04
+
+package maintenance
+
+import "testing"
+
+// Every one of these is a real production series name. metadata.StripSeriesContamination
+// returns all of them unchanged with pos="", which is why series-normalize never
+// collapsed them and why 37 separate "Discworld NN" series exist.
+func TestSplitSeriesPosition_RealProductionNames(t *testing.T) {
+	cases := []struct {
+		name     string
+		base     string
+		pos      int
+		explicit bool
+		padded   bool
+	}{
+		{"Discworld 05", "Discworld", 5, false, true},
+		{"Safehold 01", "Safehold", 1, false, true},
+		{"Frontiers Saga 07", "Frontiers Saga", 7, false, true},
+		{"Leveling up the World 01", "Leveling up the World", 1, false, true},
+		{"Mistborn 3", "Mistborn", 3, false, false},
+		{"The Stormlight Archive 2", "The Stormlight Archive", 2, false, false},
+		{"Monster Girl Islands 12", "Monster Girl Islands", 12, false, false},
+		{"Schooled in Magic: Book 11", "Schooled in Magic", 11, true, false},
+		{"Reclaiming Honor bk 6", "Reclaiming Honor", 6, true, false},
+		{"The Long WInter Trilogy Book 3", "The Long WInter Trilogy", 3, true, false},
+	}
+	for _, c := range cases {
+		got, ok := SplitSeriesPosition(c.name)
+		if !ok {
+			t.Errorf("%q: no position found", c.name)
+			continue
+		}
+		if got.Base != c.base || got.Position != c.pos {
+			t.Errorf("%q → base=%q pos=%d, want base=%q pos=%d",
+				c.name, got.Base, got.Position, c.base, c.pos)
+		}
+		if got.Explicit != c.explicit {
+			t.Errorf("%q: Explicit=%v, want %v", c.name, got.Explicit, c.explicit)
+		}
+		if got.Padded != c.padded {
+			t.Errorf("%q: Padded=%v, want %v", c.name, got.Padded, c.padded)
+		}
+	}
+}
+
+// A name with no trailing position must be reported as such, never mangled.
+func TestSplitSeriesPosition_LeavesCleanNamesAlone(t *testing.T) {
+	for _, n := range []string{"Discworld", "The Stormlight Archive", "Bobiverse", ""} {
+		if _, ok := SplitSeriesPosition(n); ok {
+			t.Errorf("%q was treated as carrying a position", n)
+		}
+	}
+}
+
+// 🔴 THE CORRUPTION THIS MUST NOT CAUSE. A real name ending in a number is
+// indistinguishable from a position by shape alone. Unpadded and unique, it must
+// be left alone — merging "Fahrenheit 451" into a "Fahrenheit" series would be a
+// permanent, silent corruption of the library.
+func TestSeriesDenumber_LeavesALoneUnpaddedNumberAlone(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Fahrenheit 451", AuthorID: 7, Books: 1},
+		{ID: 2, Name: "Blake's 7", AuthorID: 8, Books: 1},
+	}
+	if got := SeriesDenumber(in); len(got) != 0 {
+		t.Fatalf("planned %d merges for names that carry no evidence: %+v", len(got), got)
+	}
+}
+
+// Zero-padding is evidence on its own — nobody titles a work "Discworld 05".
+func TestSeriesDenumber_TrustsZeroPadding(t *testing.T) {
+	in := []SeriesInput{{ID: 1, Name: "Discworld 05", AuthorID: 3, Books: 1}}
+	got := SeriesDenumber(in)
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].IntoName != "Discworld" || got[0].Position != 5 {
+		t.Fatalf("got base=%q pos=%d, want Discworld/5", got[0].IntoName, got[0].Position)
+	}
+	if got[0].Reason != "zero-padded position" {
+		t.Fatalf("reason = %q", got[0].Reason)
+	}
+}
+
+// A repeated base is the other form of corroboration: "Mistborn 3" alongside
+// "Mistborn 6" proves the number is a position, without any padding.
+func TestSeriesDenumber_TrustsARepeatedBase(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Mistborn 3", AuthorID: 4, Books: 1},
+		{ID: 2, Name: "Mistborn 6", AuthorID: 4, Books: 1},
+	}
+	got := SeriesDenumber(in)
+	if len(got) != 2 {
+		t.Fatalf("planned %d merges, want 2", len(got))
+	}
+	for _, p := range got {
+		if p.IntoName != "Mistborn" {
+			t.Fatalf("base = %q, want Mistborn", p.IntoName)
+		}
+		if p.Reason != "another series shares this base" {
+			t.Fatalf("reason = %q", p.Reason)
+		}
+	}
+}
+
+// The corroboration is per AUTHOR. Two different authors each having one
+// unpadded numbered series is not evidence that either is a position.
+func TestSeriesDenumber_DoesNotCorroborateAcrossAuthors(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Genesis 2", AuthorID: 1, Books: 1},
+		{ID: 2, Name: "Genesis 3", AuthorID: 2, Books: 1},
+	}
+	if got := SeriesDenumber(in); len(got) != 0 {
+		t.Fatalf("corroborated across authors: %+v", got)
+	}
+}
+
+// An explicit keyword needs no corroboration — the word IS the evidence.
+func TestSeriesDenumber_ExplicitKeywordNeedsNoCorroboration(t *testing.T) {
+	in := []SeriesInput{{ID: 1, Name: "Schooled in Magic: Book 11", AuthorID: 5, Books: 1}}
+	got := SeriesDenumber(in)
+	if len(got) != 1 || got[0].IntoName != "Schooled in Magic" || got[0].Position != 11 {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+// 🔴 Chapter and disc tags leak into the series field in bulk — production has
+// 176 "Chapter N" and 49 "Disc N". Folding them together would manufacture one
+// enormous bogus series, which is worse than the split state.
+func TestSeriesDenumber_RefusesJunkBases(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Chapter 12", AuthorID: 1, Books: 1},
+		{ID: 2, Name: "Chapter 13", AuthorID: 1, Books: 1},
+		{ID: 3, Name: "Disc 3", AuthorID: 1, Books: 1},
+		{ID: 4, Name: "Disc 4", AuthorID: 1, Books: 1},
+	}
+	if got := SeriesDenumber(in); len(got) != 0 {
+		t.Fatalf("planned merges into a tag-artefact base: %+v", got)
+	}
+}
+
+// When a series already carries the plain base name it becomes the merge target,
+// so books land in the existing row rather than a freshly created duplicate.
+func TestSeriesDenumber_TargetsAnExistingBaseSeries(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 10, Name: "Discworld", AuthorID: 3, Books: 4},
+		{ID: 11, Name: "Discworld 05", AuthorID: 3, Books: 1},
+	}
+	got := SeriesDenumber(in)
+	if len(got) != 1 {
+		t.Fatalf("planned %d merges, want 1", len(got))
+	}
+	if got[0].IntoID != 10 {
+		t.Fatalf("IntoID = %d, want the existing 'Discworld' series (10)", got[0].IntoID)
+	}
+}
+
+// With no existing base series, IntoID is 0 and the caller must create one.
+func TestSeriesDenumber_ReportsWhenTheBaseMustBeCreated(t *testing.T) {
+	in := []SeriesInput{{ID: 11, Name: "Safehold 01", AuthorID: 3, Books: 1}}
+	got := SeriesDenumber(in)
+	if len(got) != 1 || got[0].IntoID != 0 {
+		t.Fatalf("got %+v, want a single plan with IntoID=0", got)
+	}
+}
+
+func TestIsJunkSeriesBase(t *testing.T) {
+	for _, s := range []string{"Chapter", "disc", " CD ", "Track"} {
+		if !IsJunkSeriesBase(s) {
+			t.Errorf("IsJunkSeriesBase(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"Discworld", "Mistborn", ""} {
+		if IsJunkSeriesBase(s) && s != "" {
+			t.Errorf("IsJunkSeriesBase(%q) = true, want false", s)
+		}
+	}
+}
+
+// 🔴 What the production dry run caught. An equality-only junk check let through
+// 76 merges into a base ending ", Chapter", 39 into "- Chapter", 126 into a base
+// left dangling on an en-dash, and 11 each into bases of "01".."04". Every one
+// would have manufactured a series named after a tag artefact.
+func TestIsJunkSeriesBase_RejectsShapesTheProductionDryRunExposed(t *testing.T) {
+	for _, s := range []string{
+		"The Darkling Child: The Defenders of Shannara (Unabridged), Chapter",
+		"The Tower of Nero - Chapter",
+		"Drew Hayes – Bones of the Past –",
+		"Nicole Kornher-Stace – Firebreak –",
+		"01", "02", "—", "3.",
+		"Something: ",
+	} {
+		if !IsJunkSeriesBase(s) {
+			t.Errorf("IsJunkSeriesBase(%q) = false, want true", s)
+		}
+	}
+	// …while real names with numbers or punctuation inside stay acceptable.
+	for _, s := range []string{
+		"Discworld", "Wheel of Time", "Schooled in Magic", "Honor Harrington Universe",
+		"Drew Hayes - Bones of the Past", "Star Trek: Deep Space Nine",
+	} {
+		if IsJunkSeriesBase(s) {
+			t.Errorf("IsJunkSeriesBase(%q) = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
## The problem

A series name should name the **series**. **2,251 of 15,200 carry the book's position instead**, splitting one series into as many one-book series as it has volumes:

```
"Discworld 05" … "Discworld 37"   → 37 separate series
"Safehold 01", "Safehold 02"
"Mistborn 3", "Mistborn 6"
"Schooled in Magic: Book 11"
```

## Why this survived earlier passes

`maintenance.series-normalize` cannot see it. Probing `metadata.StripSeriesContamination` with the real names returns **every one unchanged**:

```
"Discworld 05"               → cleaned="Discworld 05"   pos=""  flagged=false
"Safehold 01"                → cleaned="Safehold 01"    pos=""  flagged=false
"Schooled in Magic: Book 11" → unchanged
```

So the merge machinery downstream is never told they belong together. I previously called this a display issue — it isn't.

## The ambiguity, and how it's resolved

"Discworld 5" is a position. **"Fahrenheit 451" is not.** By shape alone they're identical, so a bare trailing number is trusted only when the library corroborates it:

- **explicit keyword** (`Book 11`, `bk 6`, `Vol 3`) — the word is the evidence
- **zero-padding** (`Discworld 05`) — nobody titles a work "Blake's 07"
- **another series shares the base**, per author (`Mistborn 3` + `Mistborn 6`)

A lone unpadded number is left alone. Wrongly merging a real name is a permanent corruption; skipping one leaves it as it is.

## Against production

**1,156 merges into 398 base series, moving 1,819 books** — `Discworld` 37→1, `Wheel of Time` 21→1, `Ryanverse` 19→1.

The dry run is what taught the junk filter its shape. An equality-only check would have merged:

```
 76 → base ending ", Chapter"
 39 → base ending "- Chapter"
126 → base dangling on an en-dash
 11 each → bases of "01".."04"
```

Each would have manufactured a series named after a tag artefact. Bases ending in a tag keyword, containing no letters, or dangling on a separator are now rejected — dropping the plan 1,606 → 1,156 and leaving only real names.

## Apply safety

**Deliberately sequential.** Two numbered series folding onto the same base must not both decide the base is missing and create it — that would replace one split series with two. An emptied series is deleted only when *every* book actually moved, and an existing `series_sequence` is never overwritten: a deliberate value outranks one parsed from a name.

Dry-run by default. 12 planner tests, including the cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp