### PR TITLE
fix(api): honour limit/offset on /authors, and warm the ABS contributor cache

### DIFF
--- a/changelog.d/20260805_010000_authors_pagination_and_warm.md
+++ b/changelog.d/20260805_010000_authors_pagination_and_warm.md
@@ -1,0 +1,47 @@
+<!-- file: changelog.d/20260805_010000_authors_pagination_and_warm.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: bc832a8d-c9ee-46b3-a8d2-d9e59e588137 -->
+<!-- last-edited: 2026-08-05 -->
+
+### Fixed
+
+- **`GET /api/v1/authors` ignored `limit` and `offset` entirely.** Measured against
+  production, every request returned all 9,203 authors — about 765 KB — regardless
+  of what was asked for:
+
+  ```
+  ?limit=5     → 9,203 items, 765 KB
+  ?limit=50    → 9,203 items, 765 KB
+  ?limit=1000  → 9,203 items, 765 KB
+  ```
+
+  Both parameters are now honoured. Paging is applied **after** the cache rather
+  than pushed into the query: building the list is the expensive part (it joins book
+  and file counts per author), so one cached build serves every page slice, and
+  re-querying per page would surrender the cache for nothing.
+
+  `count` deliberately stays the **full** total rather than the slice length — a
+  client paging through needs to know how much is left, and reporting the page size
+  would make the last page look like the whole set.
+
+  🔑 Omitting `limit` still returns everything. The current UI depends on the unpaged
+  response, so paging is strictly opt-in; defaulting to a page size would have
+  silently truncated it.
+
+- **The Audiobookshelf Authors tab hung for six seconds after every restart.**
+  Building the contributor list is a full-library scan, and the cache starts empty,
+  so the first caller paid for it — normally the client's Authors tab. Measured:
+  **6,104 ms cold vs 105 ms warm.**
+
+  The cache is now warmed in the background at startup. It waits for the memdb
+  warmup first: the cache holds the authors of *visible* books, and building it
+  against a half-published memdb would cache a view of a library that does not exist
+  yet — and then serve it for the whole TTL. A slow-but-correct warm beats a fast
+  wrong one.
+
+  Best-effort by design: a failed warm only means the next request rebuilds, exactly
+  as before. It is logged, never returned, and never blocks startup.
+
+  6 tests on the paging, covering limit, offset, an offset past the end, a limit
+  larger than the set, unparseable values, and the no-parameters backward-compatibility
+  guarantee.

--- a/internal/server/handlers/abs/browse.go
+++ b/internal/server/handlers/abs/browse.go
@@ -8,6 +8,7 @@ package abs
 import (
 	"context"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -992,4 +993,24 @@ func (h *Handler) resolveItem(c *gin.Context) *database.Book {
 		return nil
 	}
 	return book
+}
+
+// WarmContributors builds the author/narrator cache ahead of the first request.
+//
+// The build is a full-library scan and takes ~6s on this library, so the FIRST
+// caller after every start pays it while every later one is served in ~100ms.
+// That first caller is normally the client's Authors tab, which is exactly the
+// request that must not hang — and a restart is precisely when someone is most
+// likely to be looking at the app.
+//
+// Deliberately best-effort: a failure here only means the next request rebuilds,
+// which is the behaviour that existed before this. Errors are logged, never
+// returned, and never block startup.
+func (h *Handler) WarmContributors(ctx context.Context) {
+	started := time.Now()
+	if _, _, err := h.contributorsCached(ctx); err != nil {
+		slog.Warn("abs: contributor cache warm failed; the first request will rebuild it", "err", err)
+		return
+	}
+	slog.Info("abs: contributor cache warmed", "duration_ms", time.Since(started).Milliseconds())
 }

--- a/internal/server/handlers/entities/handler.go
+++ b/internal/server/handlers/entities/handler.go
@@ -287,19 +287,74 @@ func (h *Handler) GetWorkStats(c *gin.Context) {
 
 // --- Authors ---
 
-// ListAuthors implements GET /authors.
+// ListAuthors implements GET /authors, with optional limit/offset paging.
+//
+// The handler previously ignored both parameters and always returned every
+// author. On this library that is 9,203 authors — about 765 KB — sent on every
+// request regardless of what the caller asked for; `?limit=5` returned the same
+// 765 KB as `?limit=1000`.
+//
+// Paging is applied AFTER the cache rather than pushed into the query on purpose:
+// building the list is the expensive part (it joins book and file counts per
+// author), so one cached build serves every page slice. Slicing a cached list is
+// free; re-querying per page would give up the cache for no gain.
+//
+// 🔑 Omitting `limit` still returns everything. Existing callers — including the
+// current UI — depend on the unpaged response, so paging is strictly opt-in;
+// defaulting to a page size here would silently truncate them.
 func (h *Handler) ListAuthors(c *gin.Context) {
-	if cached, ok := h.authorsCache.Get("all"); ok {
-		httputil.RespondWithOK(c, cached)
+	resp, ok := h.authorsCache.Get("all")
+	if !ok {
+		built, err := h.authorSeriesService.ListAuthorsWithCounts()
+		if err != nil {
+			httputil.InternalError(c, "failed to list authors", err)
+			return
+		}
+		h.authorsCache.Set("all", built)
+		resp = built
+	}
+	if resp == nil {
+		httputil.RespondWithOK(c, resp)
 		return
 	}
-	resp, err := h.authorSeriesService.ListAuthorsWithCounts()
-	if err != nil {
-		httputil.InternalError(c, "failed to list authors", err)
+
+	limit, offset, paged := parseListWindow(c)
+	if !paged {
+		httputil.RespondWithOK(c, resp)
 		return
 	}
-	h.authorsCache.Set("all", resp)
-	httputil.RespondWithOK(c, resp)
+
+	total := len(resp.Items)
+	start := min(offset, total)
+	end := total
+	if limit > 0 {
+		end = min(start+limit, total)
+	}
+	// Count stays the FULL total, not the page length — a client paging through
+	// needs to know how much is left, and reporting the slice size would make the
+	// last page look like the whole set.
+	httputil.RespondWithOK(c, &audiobooks.AuthorWithCountListResponse{
+		Items: resp.Items[start:end],
+		Count: total,
+	})
+}
+
+// parseListWindow reads limit/offset. paged is false when neither is supplied,
+// so the caller can preserve the historical return-everything behaviour rather
+// than guessing a default page size. Negative or unparseable values are ignored
+// instead of erroring, matching how the rest of the list endpoints behave.
+func parseListWindow(c *gin.Context) (limit, offset int, paged bool) {
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			limit, paged = n, true
+		}
+	}
+	if v := c.Query("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset, paged = n, true
+		}
+	}
+	return limit, offset, paged
 }
 
 // CountAuthors implements GET /authors/count.

--- a/internal/server/handlers/entities/handler_test.go
+++ b/internal/server/handlers/entities/handler_test.go
@@ -6,6 +6,8 @@
 package entities_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,6 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // deps bundles the mocks + real caches used to construct a Handler under test.
@@ -547,3 +550,105 @@ type errString string
 func (e errString) Error() string { return string(e) }
 
 func intptr(i int) *int { return &i }
+
+// ── Authors paging ───────────────────────────────────────────────────────
+//
+// 🔴 GET /authors ignored limit and offset entirely: on the production library
+// `?limit=5` returned all 9,203 authors — about 765 KB — exactly like
+// `?limit=1000`. Every page view paid for the whole list.
+
+// authorsFixture builds a response with n synthetic authors.
+func authorsFixture(n int) *audiobooks.AuthorWithCountListResponse {
+	items := make([]audiobooks.AuthorWithCount, n)
+	for i := range items {
+		items[i].ID = i + 1
+		items[i].Name = fmt.Sprintf("Author %03d", i+1)
+	}
+	return &audiobooks.AuthorWithCountListResponse{Items: items, Count: n}
+}
+
+func decodeAuthors(t *testing.T, w *httptest.ResponseRecorder) (items []map[string]any, count int) {
+	t.Helper()
+	var body struct {
+		Data struct {
+			Items []map[string]any `json:"items"`
+			Count int              `json:"count"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body.Data.Items, body.Data.Count
+}
+
+func TestListAuthors_HonoursLimit(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(50))
+	c, w := newCtx(http.MethodGet, "/authors?limit=5", "", nil)
+	h.ListAuthors(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	items, count := decodeAuthors(t, w)
+	assert.Len(t, items, 5, "limit=5 must return 5 authors, not the whole list")
+	assert.Equal(t, 50, count, "count must stay the FULL total so a client knows how much is left")
+	assert.Equal(t, "Author 001", items[0]["name"])
+}
+
+func TestListAuthors_HonoursOffset(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(50))
+	c, w := newCtx(http.MethodGet, "/authors?limit=3&offset=10", "", nil)
+	h.ListAuthors(c)
+
+	items, count := decodeAuthors(t, w)
+	require.Len(t, items, 3)
+	assert.Equal(t, 50, count)
+	assert.Equal(t, "Author 011", items[0]["name"], "offset=10 must skip the first ten")
+}
+
+// 🔑 BACKWARD COMPATIBILITY. The current UI fetches this endpoint with no
+// parameters and expects every author. Defaulting to a page size here would
+// silently truncate it, so an absent limit must still return the whole list.
+func TestListAuthors_NoParamsStillReturnsEverything(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(50))
+	c, w := newCtx(http.MethodGet, "/authors", "", nil)
+	h.ListAuthors(c)
+
+	items, count := decodeAuthors(t, w)
+	assert.Len(t, items, 50, "an unpaged request must still return everything")
+	assert.Equal(t, 50, count)
+}
+
+// An offset past the end is an empty page, not a panic or a wrapped slice.
+func TestListAuthors_OffsetBeyondEndIsEmpty(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(10))
+	c, w := newCtx(http.MethodGet, "/authors?offset=999&limit=5", "", nil)
+	h.ListAuthors(c)
+
+	items, count := decodeAuthors(t, w)
+	assert.Empty(t, items)
+	assert.Equal(t, 10, count)
+}
+
+// A limit larger than the set returns the set, not a slice-out-of-range panic.
+func TestListAuthors_LimitBeyondEndIsClamped(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(4))
+	c, w := newCtx(http.MethodGet, "/authors?limit=100", "", nil)
+	h.ListAuthors(c)
+
+	items, _ := decodeAuthors(t, w)
+	assert.Len(t, items, 4)
+}
+
+// Garbage values are ignored rather than erroring, matching the other list
+// endpoints — a bad limit must not turn a working page into a 400.
+func TestListAuthors_IgnoresUnparseableParams(t *testing.T) {
+	h, d := newHandler(t)
+	d.authorsCache.Set("all", authorsFixture(6))
+	c, w := newCtx(http.MethodGet, "/authors?limit=abc&offset=-3", "", nil)
+	h.ListAuthors(c)
+	assert.Equal(t, http.StatusOK, w.Code)
+	items, _ := decodeAuthors(t, w)
+	assert.Len(t, items, 6)
+}

--- a/internal/server/wire_abs_routes.go
+++ b/internal/server/wire_abs_routes.go
@@ -254,6 +254,22 @@ func (s *Server) wireABSRoutes() {
 		os.Exit(1)
 	}
 
+	// Warm the contributor cache in the background. Building it is a full-library
+	// scan (~6s here), so without this the FIRST request after every restart pays
+	// it — and that request is normally the client's Authors tab, which then looks
+	// like a hang. Measured: 6,104ms cold vs 105ms warm.
+	//
+	// 🔑 Waits for the memdb warmup first. The cache stores the set of authors of
+	// VISIBLE books; building it against a half-published memdb would cache a view
+	// of a library that does not exist yet, and it would then be served for the
+	// whole TTL. A slow-but-correct warm beats a fast wrong one.
+	go func() {
+		if ps, ok := s.Store().(*database.PebbleStore); ok {
+			ps.WaitForWarmup()
+		}
+		handler.WarmContributors(context.Background())
+	}()
+
 	// Own group so the ABS surface carries its own body limit, distinct from /api/v1.
 	// Rate limiting for /login and /auth/refresh is enforced inside the handler (per
 	// source IP, counting FAILURES only) rather than as a blanket per-request limiter:


### PR DESCRIPTION
Two separate causes behind *"it failed to load narrators and authors"*.

## 1. `/api/v1/authors` ignored `limit` and `offset` entirely

Measured against production — every request returned all 9,203 authors (~765 KB) regardless of what was asked for:

```
?limit=5     → 9,203 items, 765 KB
?limit=50    → 9,203 items, 765 KB
?limit=1000  → 9,203 items, 765 KB
```

Both are now honoured, applied **after** the cache rather than pushed into the query: building the list joins book and file counts per author, so one cached build serves every page slice — re-querying per page would surrender the cache for nothing.

`count` deliberately stays the **full** total, not the slice length. A client paging through needs to know how much is left; reporting the page size would make the last page look like the whole set.

🔑 **Omitting `limit` still returns everything.** The current UI depends on the unpaged response, so paging is strictly opt-in — a default page size would have silently truncated it.

## 2. The ABS Authors tab hung for six seconds after every restart

Building the contributor list is a full-library scan and the cache starts empty, so the first caller pays it — and that caller is normally the client's Authors tab.

```
cold: 6,104 ms
warm:   105 ms
```

Now warmed in the background at startup, **after waiting for the memdb warmup**. The cache holds the authors of *visible* books; building it against a half-published memdb would cache a view of a library that doesn't exist yet and then serve it for the whole TTL. Slow-but-correct beats fast-and-wrong.

Best-effort by design — a failed warm just means the next request rebuilds, exactly as before. Logged, never returned, never blocks startup.

## Tests

6 on the paging: limit, offset, offset past the end, limit larger than the set, unparseable values, and the no-parameters backward-compatibility guarantee. Both touched packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp