### PR TITLE
fix(regroup): never collapse a numbered series into one book

### DIFF
--- a/changelog.d/20260805_030000_regroup_series_guard.md
+++ b/changelog.d/20260805_030000_regroup_series_guard.md
@@ -1,0 +1,53 @@
+<!-- file: changelog.d/20260805_030000_regroup_series_guard.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a2f464e2-f0d6-478e-a1f5-e3831ba95b30 -->
+<!-- last-edited: 2026-08-05 -->
+
+### Fixed
+
+- **The shattered-book classifier would have merged whole series into single books.**
+  A production dry-run on 2026-08-05 produced 930 regroup candidates; sampling the
+  `regroup.multidisc` ones — the *confident* kind, the only one with an apply
+  handler — found **41 of 43 were not chapter sets at all**:
+
+  ```
+  Super Sales on Super Heroes.m4b / 2 / 3 / 4 / 5      ← five separate novels
+  He Who Fights with Monsters 10 / 12 / Book 01        ← separate novels
+  Path Of The Voidwalker - BK01 / BK02 / BK03          ← "BK" = Book
+  ```
+
+  One grouped two entirely different titles (*Isekai Cheat Appraiser* with
+  *My Cottage Was Transferred to Another World*).
+
+  **Root cause:** every one of the 43 was an iTunes **author-level** folder —
+  `iTunes Media/Audiobooks/<Author>/`. The classifier's founding assumption, that
+  files sharing a folder are tracks of one book, holds in the organized tree
+  (`<Author>/<Title>/files`) and is false in the iTunes tree, where one folder holds
+  an author's entire catalogue.
+
+  The existing over-merge guard could not catch it. That guard keys on distinct
+  title *stems*, and numbered sequels all strip to one stem, so `manyDistinctTitles`
+  stayed false and the collapse was judged confident.
+
+  🔑 **Runtime is the discriminator the name cannot provide.** Six two-hour files are
+  six books; six three-minute files are six chapters. `ShatterBook` now carries
+  `DurationSec`, and a confident flat collapse is vetoed when a strict majority of
+  members are individually ≥90 minutes — a threshold in the empty band between
+  chapters and novels.
+
+  Deliberately conservative in both directions: a lone long member cannot veto a
+  real chapter set, and **unknown duration counts as not-book-length**, so a library
+  with missing durations does not have every collapse silently blocked. A vetoed
+  group falls through to `ambiguous` and is held for review rather than merged —
+  matching the existing rule that this classifier errs toward *not* grouping,
+  because leaving a book shattered is recoverable and merging distinct books is not
+  (the apply path hard-deletes absorbed rows).
+
+  This was only measurable because the duration data became trustworthy the day
+  before — the millisecond purge and duplicate-row cleanup are what make runtime a
+  usable signal here. Per-row values are normalised through `NormalizeDurationSec`
+  when summed, so a stale millisecond row cannot masquerade as book-length.
+
+  6 tests, including the production shape, a real chapter set that must still
+  collapse, and a check that the guard is load-bearing — removing it makes the
+  series case plan "a CONFIDENT collapse of 6 full-length books into one".

--- a/internal/itunes/service/fs_regroup_booklength_test.go
+++ b/internal/itunes/service/fs_regroup_booklength_test.go
@@ -1,0 +1,107 @@
+// file: internal/itunes/service/fs_regroup_booklength_test.go
+// version: 1.0.0
+// guid: a2f464e2-f0d6-478e-a1f5-e3831ba95b30
+// last-edited: 2026-08-05
+
+package itunesservice
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mkSeries builds N single-file books in ONE flat folder, each `sec` long, named
+// like numbered sequels — the exact shape found in production.
+func mkSeries(folder, stem string, n, sec int) []ShatterBook {
+	out := make([]ShatterBook, 0, n)
+	for i := 1; i <= n; i++ {
+		name := stem
+		if i > 1 {
+			name = fmt.Sprintf("%s %d", stem, i)
+		}
+		out = append(out, ShatterBook{
+			BookID:      fmt.Sprintf("b%02d", i),
+			FilePath:    fmt.Sprintf("%s/%s.m4b", folder, name),
+			FileCount:   1,
+			IsPrimary:   true,
+			Title:       name,
+			DurationSec: sec,
+		})
+	}
+	return out
+}
+
+// 🔴 THE NEAR-MISS. A 2026-08-05 production dry-run found 41 of 43
+// regroup.multidisc candidates were iTunes AUTHOR folders holding a whole
+// catalogue — `iTunes Media/Audiobooks/<Author>/` — not chapter sets. The
+// distinct-stem guard could not see it, because numbered sequels share one stem.
+//
+// Approving those would have merged entire series into single books, and the apply
+// path hard-deletes absorbed rows. Each of these files is a full novel.
+func TestClassify_DoesNotCollapseANumberedSeriesOfFullLengthBooks(t *testing.T) {
+	folder := "/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/William D. Arand (Super Sales on Super H"
+	books := mkSeries(folder, "Super Sales on Super Heroes", 6, 9*3600) // 9h each
+
+	groups, _ := ClassifyShatteredFolders(books)
+	for _, g := range groups {
+		if g.Kind == KindMultidisc && g.Confident {
+			t.Fatalf("planned a CONFIDENT collapse of %d full-length books into one:\n  folder=%s\n  action=%s",
+				len(g.Members), g.FolderRef, g.ProposedAction)
+		}
+	}
+}
+
+// The same shape at chapter length MUST still collapse — the guard has to
+// discriminate, not simply disable the feature.
+func TestClassify_StillCollapsesAChapterSet(t *testing.T) {
+	folder := "/lib/Some Author/Some Novel"
+	books := mkSeries(folder, "Some Novel", 8, 20*60) // 20 min each
+
+	groups, _ := ClassifyShatteredFolders(books)
+	found := false
+	for _, g := range groups {
+		if g.Kind == KindMultidisc && g.Confident {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("a genuine chapter set of 20-minute files was no longer collapsed — " +
+			"the guard must discriminate by length, not disable collapsing")
+	}
+}
+
+func TestMembersAreBookLength_RequiresAMajority(t *testing.T) {
+	long := memberInfo{book: ShatterBook{DurationSec: 5 * 3600}}
+	short := memberInfo{book: ShatterBook{DurationSec: 10 * 60}}
+
+	// One long member among many short ones must NOT veto: an omnibus track or a
+	// mis-tagged file cannot be allowed to block a real chapter set.
+	if membersAreBookLength([]memberInfo{long, short, short, short}) {
+		t.Error("a single long member vetoed a chapter set")
+	}
+	if !membersAreBookLength([]memberInfo{long, long, long, short}) {
+		t.Error("a majority of book-length members failed to veto")
+	}
+	if membersAreBookLength(nil) {
+		t.Error("empty input reported book-length")
+	}
+}
+
+// 🔑 Unknown duration is not evidence. A library with missing durations must not
+// have every collapse silently vetoed — the guard fires on positive evidence only.
+func TestMembersAreBookLength_TreatsUnknownDurationAsNotBookLength(t *testing.T) {
+	unknown := memberInfo{book: ShatterBook{DurationSec: 0}}
+	if membersAreBookLength([]memberInfo{unknown, unknown, unknown}) {
+		t.Fatal("members with unknown duration were treated as book-length")
+	}
+}
+
+// The threshold must sit in the empty band between chapters and novels.
+func TestBookLengthSec_SitsBetweenChaptersAndNovels(t *testing.T) {
+	if bookLengthSec <= 45*60 {
+		t.Fatalf("bookLengthSec = %ds — long chapters would be mistaken for books", bookLengthSec)
+	}
+	if bookLengthSec >= 4*3600 {
+		t.Fatalf("bookLengthSec = %ds — short novels would be mistaken for chapters", bookLengthSec)
+	}
+}

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -94,6 +94,13 @@ type ShatterBook struct {
 	Title      string // scanner-derived title (album tag); may be empty
 	Author     string // display author when known; never used for the FOLDER key
 
+	// DurationSec is the book's total runtime in SECONDS, 0 when unknown.
+	//
+	// 🔴 This is the signal that tells a SERIES apart from a CHAPTER SET, and its
+	// absence caused the worst near-miss this classifier has had. See
+	// membersAreBookLength.
+	DurationSec int
+
 	// DiscNumber / TrackNumber are OUTPUT fields, zero on the input view and
 	// populated by classifyGroup (assignDiscTrack) for the members of a combine.
 	// They carry the per-file play-order the apply path (ApplyMultidisc) writes onto
@@ -104,6 +111,52 @@ type ShatterBook struct {
 	// it is never persisted. Contiguous + unique by construction.
 	DiscNumber  int
 	TrackNumber int
+}
+
+// bookLengthSec is the runtime above which a single member is judged to be a
+// whole book rather than a chapter or a disc.
+//
+// 90 minutes sits in a wide empty band: audiobook chapters are minutes long, and
+// full novels are hours. A 90-minute *chapter* is vanishingly rare, and a novel
+// shorter than 90 minutes would be a single-file book, never a member of an N-way
+// group.
+const bookLengthSec = 90 * 60
+
+// membersAreBookLength reports whether most members are individually long enough
+// to BE books, which means the group is a series and must never be collapsed.
+//
+// 🔴 THE NEAR-MISS THIS PREVENTS. The flat branch's over-merge guard keys on
+// distinct title STEMS, and numbered sequels all share one stem:
+//
+//	Super Sales on Super Heroes.m4b
+//	Super Sales on Super Heroes 2.m4b … 5.m4b
+//
+// strips to a single stem, so manyDistinctTitles stayed false and the collapse
+// was judged "confident". A production dry-run on 2026-08-05 found 41 of 43
+// multidisc candidates were this shape — every one an iTunes AUTHOR folder
+// (`iTunes Media/Audiobooks/<Author>/`) holding that author's whole catalogue,
+// because the classifier's founding assumption ("files in one folder are tracks
+// of one book") is true of the organized tree and false of the iTunes tree.
+// Approving them would have merged entire series into single books, and the apply
+// path hard-deletes absorbed rows.
+//
+// Runtime is the discriminator stems cannot be: six two-hour files are six books,
+// six three-minute files are six chapters. Requires a strict majority so one long
+// member (an omnibus track, a mis-tagged file) cannot veto a real chapter set.
+//
+// Members with unknown duration are counted as NOT book-length: an absent value is
+// not evidence of a series, and the guard must not fire on missing data.
+func membersAreBookLength(members []memberInfo) bool {
+	if len(members) == 0 {
+		return false
+	}
+	long := 0
+	for _, m := range members {
+		if m.book.DurationSec >= bookLengthSec {
+			long++
+		}
+	}
+	return long*2 > len(members)
 }
 
 // RegroupGroup is one book folder the classifier flagged for a review hold.
@@ -625,7 +678,8 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 		return build(KindMultidisc, true,
 			"collapse disc set into 1 multi-file audiobook", 0), true
 
-	case structure == "flat" && numberedCount*2 >= n && n >= flatMultitrackMin && !manyDistinctTitles:
+	case structure == "flat" && numberedCount*2 >= n && n >= flatMultitrackMin &&
+		!manyDistinctTitles && !membersAreBookLength(members):
 		// Many members sit directly in ONE book folder and are sequentially numbered →
 		// flat multi-track collapse. The shared parent folder IS the book identity.
 		//
@@ -642,6 +696,13 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 		// per-chapter descriptive titles is left shattered (recoverable later) rather
 		// than N distinct books being wrongly merged into one (corruption). A dry-run
 		// on 2026-07-14 flagged 24/196 confident-multidisc holds as this shape.
+		//
+		// SERIES GUARD (!membersAreBookLength): stems alone are not enough, because
+		// numbered SEQUELS share one stem ("Super Sales on Super Heroes" / " 2" / " 3").
+		// A 2026-08-05 dry-run found 41 of 43 candidates were exactly that — iTunes
+		// AUTHOR folders holding a whole catalogue — and collapsing them would have
+		// merged entire series into one book. Runtime separates the two cases where the
+		// name cannot. See membersAreBookLength.
 		return build(KindMultidisc, true,
 			"collapse flat multi-track folder into 1 multi-file audiobook", 0), true
 

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -137,11 +137,22 @@ func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage,
 		if ferr != nil {
 			return nil // non-fatal: skip on read error
 		}
+		// Runtime is what tells a SERIES apart from a CHAPTER SET — six two-hour
+		// files are six books, six three-minute files are six chapters. Summed from
+		// the BookFile rows and normalised per row, because ~1.9% of historical rows
+		// stored milliseconds and a 1000x-inflated member would look book-length to
+		// the guard that depends on this.
+		durationSec := 0
+		for i := range files {
+			durationSec += database.NormalizeDurationSec(files[i].FileSize, files[i].Duration)
+		}
+
 		v := itunesservice.ShatterBook{
-			BookID:    b.ID,
-			Title:     b.Title,
-			FileCount: len(files),
-			IsPrimary: b.IsPrimaryVersion == nil || *b.IsPrimaryVersion,
+			BookID:      b.ID,
+			Title:       b.Title,
+			FileCount:   len(files),
+			IsPrimary:   b.IsPrimaryVersion == nil || *b.IsPrimaryVersion,
+			DurationSec: durationSec,
 		}
 		// Prefer the real BookFile path (more reliable than the virtual Book.FilePath);
 		// fall back to Book.FilePath for zero-file virtual shells.


### PR DESCRIPTION
## What the dry run found

A production dry-run on 2026-08-05 produced 930 regroup candidates. Sampling the `regroup.multidisc` ones — the **confident** kind, and the only one with an apply handler — found **41 of 43 were not chapter sets at all**:

```
Super Sales on Super Heroes.m4b / 2 / 3 / 4 / 5   ← five separate novels
He Who Fights with Monsters 10 / 12 / Book 01     ← separate novels
Path Of The Voidwalker - BK01 / BK02 / BK03       ← "BK" = Book
```

One grouped two entirely different titles — *Isekai Cheat Appraiser* with *My Cottage Was Transferred to Another World*.

Approving these would have merged whole series into single books. The apply path **hard-deletes absorbed rows**.

## Root cause

Every one of the 43 was an iTunes **author-level** folder:

```
/itunes/iTunes Media/Audiobooks/William D. Arand (Super Sales on Super H
/itunes/iTunes Media/Audiobooks/Shirtaloon, Travis Deverell
```

The classifier's founding assumption — *files sharing a folder are tracks of one book* — holds in the organized tree (`<Author>/<Title>/files`) and is **false** in the iTunes tree, where one folder holds an author's entire catalogue.

The existing over-merge guard couldn't catch it: it keys on distinct title **stems**, and numbered sequels all strip to one stem, so `manyDistinctTitles` stayed false.

## The fix

**Runtime is the discriminator the name cannot provide.** Six two-hour files are six books; six three-minute files are six chapters.

`ShatterBook` now carries `DurationSec`, and a confident flat collapse is vetoed when a strict majority of members are individually ≥90 minutes — a threshold in the empty band between chapters and novels.

Conservative in both directions:
- one long member cannot veto a real chapter set (majority required)
- **unknown duration counts as not-book-length**, so a library with missing durations isn't silently blocked from every collapse
- a vetoed group falls through to `ambiguous` and is held for review, matching the existing rule that this classifier errs toward *not* grouping

This was only measurable because durations became trustworthy the day before — the millisecond purge and duplicate-row cleanup are what make runtime usable here. Values are normalised via `NormalizeDurationSec` when summed, so a stale millisecond row can't masquerade as book-length.

## Tests

6, including the production shape, a real chapter set that must **still** collapse, and proof the guard is load-bearing — removing it makes the series case plan *"a CONFIDENT collapse of 6 full-length books into one"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp