### PR TITLE
fix(regroup): label a hold with its book folder, not the author folder

### DIFF
--- a/changelog.d/20260805_040000_regroup_folderref_label.md
+++ b/changelog.d/20260805_040000_regroup_folderref_label.md
@@ -1,0 +1,29 @@
+<!-- file: changelog.d/20260805_040000_regroup_folderref_label.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d721dc75-fe57-443d-9b94-7ffd831a58c3 -->
+<!-- last-edited: 2026-08-05 -->
+
+### Fixed
+
+- **Regroup holds could be labelled with the AUTHOR folder instead of the book.** A
+  production group of 17 tracks — every one of them
+  `Rysa Walker - The Delphi Effect ... (Unabridged)` — was shown as
+  `/abooks/imported/Rysa Walker`.
+
+  The grouping was correct; only the label was wrong. The parent directory carried an
+  edition marker, so `folderKeyOf` took the edition branch and returned the
+  *grandparent* — which is the book for `<Book>/<Book> (Unabridged)/files`, but the
+  author for `<Author>/<Book> (Unabridged)/files`.
+
+  🔑 This is a correctness problem, not a cosmetic one. With ~900 holds to work
+  through, a reviewer reading "Rysa Walker" would reasonably reject it as an
+  author-folder merge and discard a *good* regroup — the same mistrust that made this
+  queue feel unsafe in the first place.
+
+  The displayed folder is now the members' shared directory when they all sit in one,
+  and the grandparent only when they genuinely span sibling shells (the real shatter
+  shape, where naming one chapter dir would be worse). **Display only — the grouping
+  key is untouched, so which books belong together does not change.**
+
+  3 tests: the production shape, the spanning shape that must keep the grandparent,
+  and the helper's fallbacks.

--- a/internal/itunes/service/fs_regroup_folderref_test.go
+++ b/internal/itunes/service/fs_regroup_folderref_test.go
@@ -1,0 +1,106 @@
+// file: internal/itunes/service/fs_regroup_folderref_test.go
+// version: 1.0.0
+// guid: d721dc75-fe57-443d-9b94-7ffd831a58c3
+// last-edited: 2026-08-05
+
+package itunesservice
+
+import (
+	"fmt"
+	"testing"
+)
+
+// 🔴 THE REVIEW-TRUST BUG. A production group of 17 tracks — every one of them
+// "Rysa Walker - The Delphi Effect ... (Unabridged)" — was labelled
+// `/abooks/imported/Rysa Walker`, the AUTHOR folder.
+//
+// The grouping was correct. The label was not: the parent carried an edition
+// marker, so folderKeyOf took the edition branch and returned the grandparent. A
+// reviewer reading "Rysa Walker" would reasonably reject it as an author-folder
+// merge and discard a good regroup — and with ~900 holds to work through, a label
+// that misrepresents its group is a correctness problem, not a cosmetic one.
+func TestClassify_LabelsTheBookFolderNotTheAuthorFolder(t *testing.T) {
+	author := "/mnt/bigdata/books/abooks/imported/Rysa Walker"
+	book := author + "/Rysa Walker - The Delphi Effect The Delphi Trilogy, Book 1 (Unabridged)"
+
+	var books []ShatterBook
+	for i := 3; i <= 19; i++ {
+		books = append(books, ShatterBook{
+			BookID:      fmt.Sprintf("b%03d", i),
+			FilePath:    fmt.Sprintf("%s/The Delphi Effect The Delphi Trilogy, Book 1 (Unabridged) - %03d.mp3", book, i),
+			FileCount:   1,
+			IsPrimary:   true,
+			Title:       "The Delphi Effect",
+			DurationSec: 15 * 60,
+		})
+	}
+
+	groups, _ := ClassifyShatteredFolders(books)
+	if len(groups) == 0 {
+		t.Fatal("expected a group")
+	}
+	for _, g := range groups {
+		if g.FolderRef == author {
+			t.Fatalf("group labelled with the AUTHOR folder %q; a reviewer would read this "+
+				"as an author-folder merge and reject a correct regroup", g.FolderRef)
+		}
+		if g.FolderRef != book {
+			t.Fatalf("FolderRef = %q, want the book folder %q", g.FolderRef, book)
+		}
+	}
+}
+
+// 🔑 The grandparent is STILL right when members genuinely span sibling shells —
+// that is the shatter shape the grouping key climbs for, and collapsing the label
+// to one member's parent would name a single chapter dir as the whole book.
+func TestClassify_KeepsTheGrandparentWhenMembersSpanShells(t *testing.T) {
+	bookDir := "/lib/Author/Metro 2034"
+	var books []ShatterBook
+	for i := 1; i <= 6; i++ {
+		shell := fmt.Sprintf("%s/Metro 2034 - %02d", bookDir, i)
+		books = append(books, ShatterBook{
+			BookID:      fmt.Sprintf("b%02d", i),
+			FilePath:    fmt.Sprintf("%s/%02d Chapter %d.mp3", shell, i, i),
+			FileCount:   1,
+			IsPrimary:   true,
+			Title:       fmt.Sprintf("Chapter %d", i),
+			DurationSec: 12 * 60,
+		})
+	}
+
+	groups, _ := ClassifyShatteredFolders(books)
+	if len(groups) == 0 {
+		t.Fatal("expected a group")
+	}
+	for _, g := range groups {
+		if g.FolderRef != bookDir {
+			t.Fatalf("FolderRef = %q, want the book folder %q that holds the chapter shells",
+				g.FolderRef, bookDir)
+		}
+	}
+}
+
+func TestDisplayFolderRef(t *testing.T) {
+	same := []memberInfo{
+		{parentDir: "/lib/A/Book"},
+		{parentDir: "/lib/A/Book"},
+	}
+	if got := displayFolderRef(same, "/lib/A"); got != "/lib/A/Book" {
+		t.Errorf("one shared parent → got %q, want the parent", got)
+	}
+
+	spanning := []memberInfo{
+		{parentDir: "/lib/A/Book/Book - 01"},
+		{parentDir: "/lib/A/Book/Book - 02"},
+	}
+	if got := displayFolderRef(spanning, "/lib/A/Book"); got != "/lib/A/Book" {
+		t.Errorf("members spanning shells → got %q, want the group key", got)
+	}
+
+	if got := displayFolderRef(nil, "/fallback"); got != "/fallback" {
+		t.Errorf("empty members → got %q, want the group key", got)
+	}
+	if got := displayFolderRef([]memberInfo{{parentDir: ""}}, "/fallback"); got != "/fallback" {
+		t.Errorf("blank parentDir → got %q, want the group key", got)
+	}
+}

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -265,6 +265,7 @@ type memberInfo struct {
 	book       ShatterBook
 	structure  string // "disc" | "chapter" | "flat"
 	parentBase string // basename of the file's immediate parent dir
+	parentDir  string // FULL path of the file's immediate parent dir
 	fileBase   string // filename without extension
 	prefix     string // original-case title prefix (chapter prefix, or track prefix)
 	normPrefix string // normalized prefix for consensus voting
@@ -292,6 +293,7 @@ func folderKeyOf(fp string) (key string, mi memberInfo) {
 	pbase := filepath.Base(parent)
 	fileBase := strings.TrimSuffix(filepath.Base(fp), filepath.Ext(filepath.Base(fp)))
 	mi.parentBase = pbase
+	mi.parentDir = parent
 	mi.fileBase = fileBase
 
 	switch {
@@ -529,6 +531,42 @@ func versionMarkers(text string) (hasUnabridged, hasAbridged bool) {
 // review hold. Thresholds are documented inline; the classifier biases conservative
 // (ambiguous, not confident) whenever the evidence is weak — every group is a
 // human-reviewed hold, so the human is the backstop.
+// displayFolderRef picks the folder a HUMAN should be shown for this group.
+//
+// The grouping key deliberately climbs to the grandparent for the chapter/disc/
+// edition shapes, because `<Book>/<Book> - 01/file` needs every chapter shell to
+// land in one group. But the grandparent is only the BOOK when the group really
+// spans sibling shells. When every member sits in the SAME directory, that
+// directory is the book and the grandparent is one level too high.
+//
+// 🔴 WHY THIS MATTERS FOR REVIEW. A production group of 17 tracks — all of
+// "Rysa Walker - The Delphi Effect ... (Unabridged)" — was labelled
+// `/abooks/imported/Rysa Walker`, because the parent carried an edition marker and
+// the edition branch returns the grandparent. The grouping was correct; the label
+// named the AUTHOR. A reviewer reading "Rysa Walker" would reasonably reject it as
+// an author-folder merge and throw away a good regroup — and with ~900 holds to get
+// through, a label that misrepresents the group is a correctness problem in its own
+// right.
+//
+// Display only: the grouping key is untouched, so which books belong together does
+// not change.
+func displayFolderRef(members []memberInfo, groupKey string) string {
+	if len(members) == 0 {
+		return groupKey
+	}
+	first := members[0].parentDir
+	if first == "" {
+		return groupKey
+	}
+	for _, m := range members[1:] {
+		if m.parentDir != first {
+			// Members really do span sibling shells — the grandparent IS the book.
+			return groupKey
+		}
+	}
+	return first
+}
+
 func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 	n := len(members)
 
@@ -541,7 +579,7 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 	for _, m := range members {
 		fpVotes[m.fpKey]++
 	}
-	folderRef := dominantKey(fpVotes)
+	folderRef := displayFolderRef(members, dominantKey(fpVotes))
 	mergedViaItunes := len(fpVotes) > 1
 	folderName := filepath.Base(folderRef)
 	normFolder := normTitle(folderName)


### PR DESCRIPTION
## What

A production group of 17 tracks — every one of them `Rysa Walker - The Delphi Effect ... (Unabridged)` — was shown as:

```
/abooks/imported/Rysa Walker      ← the AUTHOR
```

The grouping was correct. The label was not. The parent directory carried an edition marker, so `folderKeyOf` took the edition branch and returned the **grandparent** — which is the book for `<Book>/<Book> (Unabridged)/files`, and the author for `<Author>/<Book> (Unabridged)/files`.

## Why it's a correctness problem, not a cosmetic one

With ~900 holds to work through, a reviewer reading "Rysa Walker" would reasonably reject it as an author-folder merge — and discard a **good** regroup. That's the same mistrust that made this queue feel unsafe to begin with.

## The fix

The displayed folder is now the members' shared directory when they all sit in one, and the grandparent only when they genuinely span sibling shells — the real shatter shape, where naming a single chapter dir would be worse.

**Display only.** The grouping key is untouched, so which books belong together does not change.

## Tests

3: the production shape, the spanning shape that must keep the grandparent, and the helper's fallbacks. Full package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp