### PR TITLE
feat(review): add replay-approved so review decisions are not silently discarded

### DIFF
--- a/changelog.d/20260805_050000_review_replay_approved.md
+++ b/changelog.d/20260805_050000_review_replay_approved.md
@@ -1,0 +1,41 @@
+<!-- file: changelog.d/20260805_050000_review_replay_approved.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 847a0a62-8ea1-4714-a331-929c4048bd3e -->
+<!-- last-edited: 2026-08-05 -->
+
+### Added
+
+- **`POST /api/v1/review/replay-approved`** — re-runs the apply handler for review
+  items already marked `approved`.
+
+  🔴 **Approved decisions were being silently discarded.** `approveOne` applies an
+  item only *inside* the approve request, and only when `review_apply_enabled` is on.
+  With the switch off it records `status="approved"` and returns a note — and nothing
+  ever read that state back. Before this endpoint, `ReviewStatusApproved` appeared in
+  exactly two places in the entire codebase: the constant, and the single line that
+  sets it.
+
+  So a human could work through hundreds of holds in review-only mode and lose every
+  decision:
+
+  - flipping `review_apply_enabled` later does **not** revisit them, because apply
+    only ever happens inside approve; and
+  - the regroup scan reports them as `already-decided` and **skips** the folder, so
+    they are never even re-offered.
+
+  With ~928 holds currently queued, that is a large amount of human judgement with
+  nowhere to land. This makes the queue safe to work through *before* apply is
+  enabled.
+
+  Dry-run by default, reporting what would replay and which items have no handler
+  (779 of the current queue are `regroup.ambiguous`, which has none by design).
+
+  **Refuses to execute while the global switch is off**, with a 409, rather than
+  quietly doing nothing — silently re-marking items without doing the work is the
+  exact failure this exists to fix.
+
+  A failing apply leaves the item `approved` so a later replay retries it; marking it
+  applied after a failure would strand the work just as before.
+
+  5 tests, including the full round-trip — approve with apply off, flip the switch,
+  replay, and assert the handler actually ran and the status became `applied`.

--- a/internal/server/handlers/review/replay.go
+++ b/internal/server/handlers/review/replay.go
@@ -1,0 +1,147 @@
+// file: internal/server/handlers/review/replay.go
+// version: 1.0.0
+// guid: 4d807d92-72d8-4df6-9da1-80123d2bf6b4
+// last-edited: 2026-08-05
+
+package reviewhandler
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	"github.com/gin-gonic/gin"
+)
+
+// replayRequest is the POST /api/v1/review/replay-approved body.
+type replayRequest struct {
+	// Apply must be true to execute. Default false — dry run, matching every other
+	// destructive operation in this codebase.
+	Apply bool `json:"apply"`
+	// Kind narrows the replay to one review kind ("" = all kinds).
+	Kind string `json:"kind,omitempty"`
+	// Limit caps how many items are replayed (0 = all). Useful for a canary.
+	Limit int `json:"limit,omitempty"`
+}
+
+// ReplayApprovedItems re-runs the apply handler for items already marked approved.
+//
+// 🔴 WHY THIS EXISTS — approved decisions were being silently discarded.
+//
+// approveOne applies an item ONLY inside the approve request, and only when the
+// global switch is on. With the switch off it records status="approved" and
+// returns a note. Nothing ever read that state back: before this handler,
+// ReviewStatusApproved appeared in exactly two places in the codebase — the
+// constant, and the one line that sets it.
+//
+// So a human could work through hundreds of holds in review-only mode, and every
+// one of those decisions would evaporate:
+//   - flipping review_apply_enabled later does NOT revisit them, because apply
+//     only ever happens inside approve; and
+//   - the regroup scan reports them as "already-decided" and SKIPS the folder, so
+//     they are never even re-offered.
+//
+// This closes that gap: the queue can be reviewed before apply is enabled, and the
+// decisions still count afterwards.
+//
+// Dry-run by default. Refuses to execute while the global switch is off rather
+// than silently doing nothing — an operator asking to replay deserves to be told
+// the switch is the reason, not left guessing.
+func (h *Handler) ReplayApprovedItems(c *gin.Context) {
+	if h.store == nil {
+		httputil.RespondWithServiceUnavailable(c, "review store not available")
+		return
+	}
+	var req replayRequest
+	// A body is optional: no body means a dry run over every kind.
+	_ = c.ShouldBindJSON(&req)
+
+	items, _, err := h.store.ListReviewItems(database.ReviewFilter{
+		Status: database.ReviewStatusApproved,
+		Kind:   req.Kind,
+		Limit:  0,
+	})
+	if err != nil {
+		httputil.InternalError(c, "failed to list approved review items", err)
+		return
+	}
+
+	// Partition BEFORE doing anything, so a dry run reports exactly what an apply
+	// would touch — including the items it would have to skip.
+	type skipped struct {
+		ID     string `json:"id"`
+		Kind   string `json:"kind"`
+		Reason string `json:"reason"`
+	}
+	var replayable []database.ReviewItem
+	var noHandler []skipped
+	for _, it := range items {
+		if _, ok := h.applyHandlerFor(it.Kind); ok {
+			replayable = append(replayable, it)
+			continue
+		}
+		noHandler = append(noHandler, skipped{it.ID, it.Kind, "no apply handler registered for this kind"})
+	}
+	if req.Limit > 0 && len(replayable) > req.Limit {
+		replayable = replayable[:req.Limit]
+	}
+
+	if !req.Apply {
+		httputil.RespondWithOK(c, gin.H{
+			"dry_run":        true,
+			"approved_total": len(items),
+			"would_replay":   len(replayable),
+			"skipped":        noHandler,
+			"apply_enabled":  h.applyGloballyEnabled(),
+			"note":           "dry run — nothing applied. Pass {\"apply\": true} to execute.",
+		})
+		return
+	}
+
+	// Fail loudly rather than quietly no-op'ing: replaying with the switch off would
+	// re-mark items without doing the work, which is the exact failure this handler
+	// exists to fix.
+	if !h.applyGloballyEnabled() {
+		httputil.RespondWithError(c, http.StatusConflict, "REVIEW_APPLY_DISABLED",
+			"review apply is globally disabled; enable review_apply_enabled before replaying approved items")
+		return
+	}
+
+	ctx := c.Request.Context()
+	applied, failed := 0, 0
+	var errs []string
+	for i := range replayable {
+		it := replayable[i]
+		fn, ok := h.applyHandlerFor(it.Kind)
+		if !ok {
+			continue
+		}
+		if err := fn(ctx, it); err != nil {
+			failed++
+			if len(errs) < 10 {
+				errs = append(errs, fmt.Sprintf("%s (%s): %v", it.ID, it.Kind, err))
+			}
+			// Leave the item "approved" so a later replay retries it. Marking it
+			// applied after a failure would strand the work exactly as before.
+			continue
+		}
+		if _, serr := h.store.SetReviewItemStatus(it.ID, database.ReviewStatusApplied); serr != nil {
+			failed++
+			if len(errs) < 10 {
+				errs = append(errs, fmt.Sprintf("%s: applied but status write failed: %v", it.ID, serr))
+			}
+			continue
+		}
+		applied++
+	}
+
+	httputil.RespondWithOK(c, gin.H{
+		"dry_run":        false,
+		"approved_total": len(items),
+		"applied":        applied,
+		"failed":         failed,
+		"skipped":        noHandler,
+		"errors":         errs,
+	})
+}

--- a/internal/server/handlers/review/replay_test.go
+++ b/internal/server/handlers/review/replay_test.go
@@ -1,0 +1,195 @@
+// file: internal/server/handlers/review/replay_test.go
+// version: 1.0.0
+// guid: 8e3c5a71-9d24-4b60-af18-2c47e0b96d35
+// last-edited: 2026-08-05
+
+package reviewhandler_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
+)
+
+// approveWith drives the real approve path so items reach "approved" exactly the
+// way a human would leave them.
+func approveWith(t *testing.T, h *reviewhandler.Handler, id string) {
+	t.Helper()
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+id+"/approve", nil,
+		gin.Params{{Key: "id", Value: id}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("approve %s: code %d body %s", id, w.Code, w.Body.String())
+	}
+}
+
+// 🔴 THE LOST-WORK BUG. Approving while the global switch is OFF records
+// status="approved" and never executes. Nothing else in the codebase read that
+// state back, so a human could work through hundreds of holds and have every
+// decision silently discarded — flipping the switch later does not revisit them,
+// and the regroup scan reports them "already-decided" and skips the folder.
+//
+// This asserts the decisions survive: approve with apply off, turn apply on,
+// replay, and the work actually happens.
+func TestReplayApproved_AppliesDecisionsMadeWhileApplyWasOff(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+
+	applyOn := false
+	h := reviewhandler.New(s, func() bool { return applyOn })
+
+	var appliedIDs []string
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, item database.ReviewItem) error {
+		appliedIDs = append(appliedIDs, item.ID)
+		return nil
+	})
+
+	// Review-only mode: the decision is recorded but nothing runs.
+	approveWith(t, h, it.ID)
+	if len(appliedIDs) != 0 {
+		t.Fatalf("apply ran while the global switch was off: %v", appliedIDs)
+	}
+
+	// Operator flips the switch, then replays.
+	applyOn = true
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved",
+		map[string]any{"apply": true}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay: code %d body %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w)
+	data, _ := body["data"].(map[string]any)
+	if data == nil {
+		data = body
+	}
+	if got := data["applied"]; got != float64(1) {
+		t.Fatalf("applied = %v, want 1 (body %s)", got, w.Body.String())
+	}
+	if len(appliedIDs) != 1 || appliedIDs[0] != it.ID {
+		t.Fatalf("apply handler saw %v, want [%s]", appliedIDs, it.ID)
+	}
+
+	got, err := s.GetReviewItem(it.ID)
+	if err != nil {
+		t.Fatalf("GetReviewItem: %v", err)
+	}
+	if got.Status != database.ReviewStatusApplied {
+		t.Fatalf("status = %q, want applied", got.Status)
+	}
+}
+
+// A dry run must report what WOULD happen and change nothing — the default for
+// every destructive path in this codebase.
+func TestReplayApproved_DryRunChangesNothing(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s, func() bool { return false })
+
+	ran := 0
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		ran++
+		return nil
+	})
+	approveWith(t, h, it.ID)
+
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved", nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("dry run: code %d", w.Code)
+	}
+	if ran != 0 {
+		t.Fatalf("dry run executed %d apply handlers", ran)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApproved {
+		t.Fatalf("dry run changed status to %q", got.Status)
+	}
+}
+
+// 🔑 Replaying with the switch off must FAIL LOUDLY, not quietly no-op. Silently
+// re-marking items without doing the work is the exact failure this endpoint
+// exists to fix.
+func TestReplayApproved_RefusesWhenApplyIsGloballyDisabled(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s, func() bool { return false })
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		return nil
+	})
+	approveWith(t, h, it.ID)
+
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved",
+		map[string]any{"apply": true}, nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("code = %d, want 409 so the operator learns the switch is the reason", w.Code)
+	}
+}
+
+// 🔴 A failing apply must leave the item APPROVED so a later replay retries it.
+// Marking it applied after a failure would strand the work exactly as before.
+func TestReplayApproved_LeavesFailedItemsRetryable(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.multidisc", "m1")
+	h := reviewhandler.New(s, func() bool { return true })
+
+	fail := true
+	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+		if fail {
+			return context.DeadlineExceeded
+		}
+		return nil
+	})
+
+	// Approve with apply ON would apply immediately, so force the approved state
+	// directly to model an item left over from review-only mode.
+	if _, err := s.SetReviewItemStatus(it.ID, database.ReviewStatusApproved); err != nil {
+		t.Fatalf("seed approved: %v", err)
+	}
+
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved",
+		map[string]any{"apply": true}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d", w.Code)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApproved {
+		t.Fatalf("status = %q after a failed apply, want approved so a retry can pick it up", got.Status)
+	}
+
+	// A later replay, once the cause is fixed, must succeed.
+	fail = false
+	w = doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved",
+		map[string]any{"apply": true}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("retry code %d", w.Code)
+	}
+	got, _ = s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApplied {
+		t.Fatalf("status = %q after retry, want applied", got.Status)
+	}
+}
+
+// Kinds with no registered handler are reported as skipped, never silently
+// dropped — 779 of the current queue are regroup.ambiguous, which has none.
+func TestReplayApproved_ReportsKindsWithNoHandler(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.ambiguous", "a1")
+	h := reviewhandler.New(s, func() bool { return true })
+	if _, err := s.SetReviewItemStatus(it.ID, database.ReviewStatusApproved); err != nil {
+		t.Fatalf("seed approved: %v", err)
+	}
+
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved", nil, nil)
+	body := decodeBody(t, w)
+	data, _ := body["data"].(map[string]any)
+	if data == nil {
+		data = body
+	}
+	skipped, _ := data["skipped"].([]any)
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %v, want the one handler-less item (body %s)", skipped, w.Body.String())
+	}
+}

--- a/internal/server/wire_review_routes.go
+++ b/internal/server/wire_review_routes.go
@@ -23,4 +23,8 @@ func (s *Server) wireReviewRoutes(protected *gin.RouterGroup, reviewH *reviewhan
 	protected.POST("/review/items/:id/approve", s.perm(auth.PermLibraryEditMetadata), reviewH.ApproveReviewItem)
 	protected.POST("/review/items/:id/reject", s.perm(auth.PermLibraryEditMetadata), reviewH.RejectReviewItem)
 	protected.POST("/review/bulk", s.perm(auth.PermLibraryEditMetadata), reviewH.BulkReviewAction)
+	// Re-runs apply for items already marked approved. Exists because approving
+	// while the global switch is off records the decision but never executes it, and
+	// nothing else ever reads that state back.
+	protected.POST("/review/replay-approved", s.perm(auth.PermLibraryEditMetadata), reviewH.ReplayApprovedItems)
 }


### PR DESCRIPTION
## The bug

`approveOne` applies an item **only inside the approve request**, and only when `review_apply_enabled` is on. With the switch off it records `status="approved"` and returns a note — and **nothing ever read that state back**.

Before this endpoint, `ReviewStatusApproved` appeared in exactly two places in the entire codebase:

```
internal/database/review_store.go:48        ReviewStatusApproved = "approved"     ← the constant
internal/server/handlers/review/handler.go  SetReviewItemStatus(id, Approved)     ← the one line that sets it
```

So a human could work through hundreds of holds in review-only mode and lose every decision:

- flipping `review_apply_enabled` later does **not** revisit them — apply only ever happens inside approve
- the regroup scan reports them as `already-decided` and **skips** the folder, so they're never re-offered

With ~928 holds currently queued, that's a lot of human judgement with nowhere to land.

## The fix

`POST /api/v1/review/replay-approved` re-runs the apply handler for items already in the `approved` state, so the queue can be reviewed **before** apply is enabled and the decisions still count afterwards.

- **Dry-run by default**, reporting what would replay and which items have no handler (779 of the current queue are `regroup.ambiguous`, which has none by design)
- **Refuses with 409 while the global switch is off**, rather than quietly doing nothing — silently re-marking items without doing the work is the exact failure this exists to fix
- **A failing apply leaves the item `approved`** so a later replay retries it; marking it applied after a failure would strand the work just as before

## Tests

5, including the full round-trip: approve with apply **off** → flip the switch → replay → assert the handler ran and the status became `applied`. Plus the dry run changing nothing, the 409 refusal, retryability after failure, and handler-less kinds being reported rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp