### PR TITLE
fix(regroup): stop proposing changes inside the frozen iTunes tree

### DIFF
--- a/changelog.d/20260805_060000_regroup_skip_frozen_itunes.md
+++ b/changelog.d/20260805_060000_regroup_skip_frozen_itunes.md
@@ -1,0 +1,40 @@
+<!-- file: changelog.d/20260805_060000_regroup_skip_frozen_itunes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5b1f8c47-2a93-4e06-bd75-8f2c4a1e903d -->
+<!-- last-edited: 2026-08-05 -->
+
+### Fixed
+
+- **The regroup producer no longer proposes changes inside the frozen iTunes tree.**
+  `books/itunes/**` is the externally-managed Original library — the config layer
+  already marks it `Frozen` and read-only — but the shattered-book scan never
+  consulted that, and generated holds for it anyway.
+
+  The result dominated the review queue: **561 of 777 ambiguous holds (72%) were
+  iTunes AUTHOR folders**, `iTunes Media/Audiobooks/<Author>/`. That layout puts an
+  author's whole catalogue in one directory, and a folder-grouping classifier reads a
+  shared folder as a shared book.
+
+  Every one of those proposals was wrong twice over:
+
+  - **the books were not shattered.** Sampling their members shows complete, correct
+    audiobooks — 11.79 h, 25.30 h, 8.86 h, one file each, real titles. Combining them
+    would have merged distinct novels; and
+  - **the tree may not be reorganised anyway**, so the proposal was unactionable even
+    if it had been right.
+
+  Excluded at the source, using the existing `UnderFrozenITunesTree` policy helper
+  (newly exported) rather than a fresh heuristic, so no downstream classifier has to
+  re-derive the rule. The count is reported as `skipped-frozen-itunes=N` in the run
+  summary, so the queue shrinking is visibly a policy decision rather than a silent
+  bug.
+
+  Both `FilePath` and `ITunesPath` are checked: the classifier folds the original
+  iTunes album path in as a second grouping signal, so testing only one would let a
+  book back in through the other.
+
+  🔑 **This removes noise, not work.** The excluded books are already correct as
+  separate books. What IS wrong with them is metadata — four different novels all
+  titled `Super Sales on Super Heroes, Book 2`, two titled
+  `He Who Fights with Monsters 4`, one titled `Herald of Shalia 1/?` — which is a
+  matching problem the regroup queue was never going to solve.

--- a/internal/config/frozen_itunes_test.go
+++ b/internal/config/frozen_itunes_test.go
@@ -1,0 +1,42 @@
+// file: internal/config/frozen_itunes_test.go
+// version: 1.0.0
+// guid: 5b1f8c47-2a93-4e06-bd75-8f2c4a1e903d
+// last-edited: 2026-08-05
+
+package config
+
+import "testing"
+
+// 🔴 books/itunes/** is the externally-managed Original library, marked Frozen and
+// read-only. Producers that PROPOSE structural changes must skip it: 561 of 777
+// ambiguous regroup holds were iTunes AUTHOR folders, because that layout puts an
+// author's whole catalogue in one directory and a folder-grouping classifier reads
+// a shared folder as a shared book. Every one of those proposals was both wrong
+// (distinct novels, 8-29h each) and unactionable (a tree we may not reorganise).
+func TestUnderFrozenITunesTree(t *testing.T) {
+	frozen := []string{
+		"/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Shirtaloon, Travis Deverell/x.m4b",
+		"/mnt/bigdata/books/itunes/iTunes Media/Audiobooks/Tamryn Tamer",
+		"books/itunes/anything",
+		`W:\books\itunes\iTunes Media\Audiobooks\A\b.m4b`, // windows separators
+	}
+	for _, p := range frozen {
+		if !UnderFrozenITunesTree(p) {
+			t.Errorf("UnderFrozenITunesTree(%q) = false, want true", p)
+		}
+	}
+
+	// The organized trees are ours and must stay eligible — excluding them would
+	// silently disable regrouping for the books we CAN fix.
+	ours := []string{
+		"/mnt/bigdata/books/audiobook-organizer/Author/Book/01.m4b",
+		"/mnt/bigdata/books/abooks/imported/Rysa Walker/x.mp3",
+		"/mnt/bigdata/books/newbooks/audiobooks/four hex/01.mp3",
+		"",
+	}
+	for _, p := range ours {
+		if UnderFrozenITunesTree(p) {
+			t.Errorf("UnderFrozenITunesTree(%q) = true, want false", p)
+		}
+	}
+}

--- a/internal/config/itunes_libraries.go
+++ b/internal/config/itunes_libraries.go
@@ -84,6 +84,19 @@ func (c *ITunesConfig) Resolve() {
 // catches the real library regardless of the absolute mount prefix.
 const booksItunesSegment = "books/itunes/"
 
+// UnderFrozenITunesTree reports whether a path lives in the hands-off Original
+// iTunes tree (books/itunes/**).
+//
+// That tree is externally managed by iTunes itself and is marked Frozen —
+// read-only, never reorganised by us. Callers that PROPOSE structural changes
+// (regroup holds, merges, moves) must consult this and skip such paths, because a
+// proposal we are not permitted to carry out is noise in a human's queue at best
+// and a data-loss invitation at worst.
+//
+// Exported for producers outside this package; underBooksItunes remains the
+// internal spelling used by validation.
+func UnderFrozenITunesTree(p string) bool { return underBooksItunes(p) }
+
 func underBooksItunes(p string) bool {
 	if p == "" {
 		return false

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -41,8 +41,10 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/falkcorp/audiobook-organizer/internal/config"
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
@@ -127,6 +129,10 @@ func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage,
 	// the review-row writes run single-threaded AFTER the scan, so there are no write
 	// races — the only shared state here is the slim-view slice, guarded by mu.
 	var mu sync.Mutex
+	// skippedFrozen counts books excluded because they live in the hands-off
+	// books/itunes/** tree; reported so an operator can see the queue shrank by
+	// policy rather than by a silent bug.
+	var skippedFrozen atomic.Int64
 	views := make([]itunesservice.ShatterBook, 0, len(ids))
 	scanErr := registry.RunItems(ctx, reporter, ids, func(ctx context.Context, id string) error {
 		b, err := store.GetBookByID(id)
@@ -168,6 +174,25 @@ func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage,
 		if len(files) >= 1 {
 			v.ITunesPath = files[0].ITunesPath
 		}
+		// 🔴 SKIP THE FROZEN iTunes TREE. books/itunes/** is the externally-managed
+		// Original library, marked Frozen and read-only — we are never permitted to
+		// reorganise it. Proposing regroups there is worse than useless:
+		//
+		//   - 561 of 777 ambiguous holds (72%) were iTunes AUTHOR folders
+		//     (`iTunes Media/Audiobooks/<Author>/`), because that layout puts an
+		//     author's whole catalogue in one directory and the classifier reads a
+		//     shared folder as a shared book; and
+		//   - approving one would propose merging distinct novels into a single book
+		//     inside a tree we must not touch.
+		//
+		// A proposal we cannot carry out is noise in a human's queue at best, and an
+		// invitation to destroy a series at worst. Excluded at the SOURCE so no
+		// downstream classifier heuristic has to re-derive the policy.
+		if config.UnderFrozenITunesTree(v.FilePath) || config.UnderFrozenITunesTree(v.ITunesPath) {
+			skippedFrozen.Add(1)
+			return nil
+		}
+
 		mu.Lock()
 		views = append(views, v)
 		mu.Unlock()
@@ -247,8 +272,9 @@ func (p *Plugin) runRegroupShatteredAI(ctx context.Context, raw json.RawMessage,
 	purged := reconcileStaleHolds(ctx, store, reporter, groups, params.Limit)
 
 	result := fmt.Sprintf(
-		"DRY RUN — review holds written=%d (already-decided=%d, write-errors=%d, stale-purged=%d) from %d detected groups; library untouched. bykind=%v",
-		written, alreadyDecided, writeErrs, purged, len(groups), st.ByKind)
+		"DRY RUN — review holds written=%d (already-decided=%d, write-errors=%d, stale-purged=%d, "+
+			"skipped-frozen-itunes=%d) from %d detected groups; library untouched. bykind=%v",
+		written, alreadyDecided, writeErrs, purged, skippedFrozen.Load(), len(groups), st.ByKind)
 	_ = reporter.Log(slog.LevelInfo, result)
 	_ = reporter.UpdateProgress(len(ids)+1, len(ids)+1, result)
 	if writeErrs > 0 {


### PR DESCRIPTION
## What

`books/itunes/**` is the externally-managed Original library — the config layer already marks it `Frozen` and read-only — but the shattered-book scan never consulted that and generated holds for it anyway.

The result dominated the review queue: **561 of 777 ambiguous holds (72%) were iTunes AUTHOR folders**, `iTunes Media/Audiobooks/<Author>/`. That layout puts an author's whole catalogue in one directory, and a folder-grouping classifier reads a shared folder as a shared book.

## Every one of those proposals was wrong twice over

**The books were not shattered.** Sampling their members:

```
11.79h  files=1  Super Sales on Super Heroes, Book 2
25.30h  files=1  He Who Fights with Monsters 10
 8.86h  files=1  Isekai Cheat Appraiser
```

Complete, correct audiobooks — one file each, real titles. Combining them would have merged distinct novels.

**And the tree may not be reorganised anyway**, so the proposal was unactionable even if it had been right.

## The fix

Excluded at the source using the existing `UnderFrozenITunesTree` policy helper (newly exported) rather than a fresh heuristic, so no downstream classifier has to re-derive the rule.

Reported as `skipped-frozen-itunes=N` in the run summary, so the queue shrinking is visibly a policy decision rather than a silent bug.

Both `FilePath` **and** `ITunesPath` are checked — the classifier folds the original iTunes album path in as a second grouping signal, so testing only one would let a book back in through the other.

## This removes noise, not work

The excluded books are already correct as separate books. What *is* wrong with them is metadata:

```
Super Sales on Super Heroes, Book 2   ← four different novels, same title
He Who Fights with Monsters 4         ← two different novels, same title
Herald of Shalia 1/?                  ← garbled
```

That's a matching problem the regroup queue was never going to solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp