### PR TITLE
docs(specs): design + plans for 3 workstreams (UNVERIFIED drafts)

### DIFF
--- a/changelog.d/20260805_223000_workstream_specs_partial.md
+++ b/changelog.d/20260805_223000_workstream_specs_partial.md
@@ -1,0 +1,24 @@
+<!-- file: changelog.d/20260805_223000_workstream_specs_partial.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 71fc3d82-64ab-4e09-b5d7-2039c81ea6f4 -->
+<!-- last-edited: 2026-08-05 -->
+
+### Added
+
+- **Design specs + implementation plans for 3 of 11 open workstreams** (~25,600
+  words). Documentation only. Covers review-queue recommendations + per-hold
+  overrides (owner items 1 and 2), duplicate detection with combine-by-template
+  and version-grouping (the "assembled copy already exists" class), and full
+  playlist support.
+
+  ⚠️ **Marked UNVERIFIED in-document.** These were authored by agents but the
+  adversarial verification pass — which grep-checks that every cited function,
+  struct field, op ID and path actually exists — did not run; the workflow was
+  halted by API rate limiting (429/529) partway through. Each file carries a
+  banner saying so. The design reasoning and the measured production numbers are
+  sound; the code citations are what needs checking before execution.
+
+  The remaining 8 workstreams (multidisc canary, series-as-book-numbers,
+  metadata-results cold start, First Aid orchestrator, version-group acoustic
+  audit, chapters serve + backfill, reading/review status sync, Deluge
+  integration) still have their `todo.d/` fragments and are unaffected.

--- a/docs/plans/2026-08-05-duplicate-detect-version-group-plan.md
+++ b/docs/plans/2026-08-05-duplicate-detect-version-group-plan.md
@@ -1,0 +1,472 @@
+<!-- file: docs/plans/2026-08-05-duplicate-detect-version-group-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0bf1d605-f8e1-49dc-984b-fd4b0c33389e -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Implementation plan — Duplicate detection, combine-by-template, version-group
+
+**Slug:** `duplicate-detect-version-group`
+**Design:** [`docs/specs/2026-08-05-duplicate-detect-version-group-design.md`](../specs/2026-08-05-duplicate-detect-version-group-design.md)
+**Read the design first.** Every locked decision referenced below as `LD1`…`LD10` is defined there.
+
+---
+
+## 0. Worktree setup (mandatory — CLAUDE.md worktree discipline)
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git worktree list                       # confirm you are NOT about to edit main
+git fetch origin main
+git worktree add .worktrees/dupmatch -b feat/duplicate-detect-version-group origin/main
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.worktrees/dupmatch
+```
+
+Every path below is relative to that worktree root. Every file created or modified needs
+a version header (`// file:` / `// version:` / `// guid:` / `// last-edited:` for Go,
+`<!-- ... -->` for MD/TS) and a version bump on modification.
+
+Each step below is one commit and one reviewable PR. Steps 1–3 are pure additions that
+touch nothing existing; step 4 is the only refactor of shipped code; steps 5–7 wire it up.
+
+---
+
+## Step 1 — `internal/dupmatch`: the pure matcher
+
+**Commit:** `feat(dupmatch): duration-template matcher for redundant-copy detection`
+
+### Files to create
+
+| File | Intent |
+|---|---|
+| `internal/dupmatch/match.go` | `DurSource`, `Track`, `Tier`, `Assignment`, `Skip`/`SkipReason`, `TemplateResult`, `Config`, `DefaultConfig()`, `MatchTemplate`. Exactly the shapes in design §3.1. No imports beyond `sort`, `strings`, `fmt` — **no `database`, no `os`**, so the package cannot grow I/O by accident. |
+| `internal/dupmatch/histogram.go` | `DeltaHistogram` (`map[int]int`) with `Add`, `Render`, `FractionWithin`. `Render` emits fixed buckets `0,1,2,3,4,5,6-10,>10` with counts and cumulative percentages, deterministic ordering. |
+| `internal/dupmatch/primary.go` | `PrimaryCandidate`, `PickMostComplete` — LD6: order by `MatchedTracks` desc, then `FileCount` desc, then `BookID` asc (earliest ULID). |
+| `internal/dupmatch/match_test.go` | Table tests, see below. |
+| `internal/dupmatch/histogram_test.go` | Bucketing + `FractionWithin` boundaries. |
+| `internal/dupmatch/primary_test.go` | The full D2 ordering incl. both tie-break levels. |
+
+### Non-obvious implementation notes
+
+- `MatchTemplate` must be **deterministic**: sort candidate pairs by the total order
+  `(tierRank, |delta|, -FileSize, -DurSec, DebrisFileID)` before the greedy assign. There
+  must be no `range` over a map in any code path that affects output ordering.
+- The histogram is fed **every** considered delta within `ProbeToleranceSec`, accepted or
+  not. That is what makes it usable for calibration — a histogram of only accepted
+  matches is circular.
+- `Source == SourceUnknown` short-circuits to `SkipNoDuration` before any comparison
+  (LD2). Write the assertion as an explicit early branch, not as a numeric guard, so it
+  survives refactoring.
+- `MaxBucketFanout` is evaluated per **debris track** (count of candidate slots), not per
+  index bucket, so the matcher stays independent of how the caller indexes.
+
+### Tests — what green means
+
+```bash
+go test ./internal/dupmatch/... -race -run 'TestMatchTemplate|TestPickMostComplete|TestDeltaHistogram' -v
+```
+
+Required cases (each an explicit named subtest):
+
+1. `TestMatchTemplate_SuccessorsFragment` — reference = 13 synthetic tracks; debris = the
+   four real durations `2474, 1620, 3018, 868` from the measured case
+   (`.claude/notes/2026-08-05-unlinked-books-investigation.md:96-99`) → assignments to
+   slots `3, 4, 6, 13`, zero skips, `MissingSlots` contains the other nine.
+2. `TestMatchTemplate_UnknownDurationNeverMatches` — a debris track with
+   `Source: SourceUnknown` and a `DurSec` that exactly equals a slot → `SkipNoDuration`,
+   **zero** assignments. Guards LD2.
+3. `TestMatchTemplate_MixedSourceRequiresCorroborator` — fingerprint reference vs
+   container debris, delta 0, no corroborators → dropped; same pair with
+   `TitleStem` equal → `TierProbable` assignment.
+4. `TestMatchTemplate_RedundantLoserPrefersLongerLarger` — two debris files at delta 0 on
+   one slot, differing `FileSize` → the larger wins, the smaller carries
+   `Redundant: true` and keeps `RefTrackIndex`.
+5. `TestMatchTemplate_AmbiguousBucketSkipped` — 100 identical-duration slots with
+   `MaxBucketFanout: 64` → `SkipAmbiguousBucket`, not a silent first-match.
+6. `TestMatchTemplate_BelowMinLength` — a 30 s debris file with `MinMatchableSec: 60` →
+   `SkipTooShort`.
+7. `TestMatchTemplate_Deterministic` — run the same input 50 times, assert byte-identical
+   JSON of the result.
+8. `TestMatchTemplate_Reconciles` — for a randomised input, assert
+   `len(uniqueDebrisIDs) == len(nonRedundantAssignments) + len(redundantAssignments) + len(Skipped)`.
+9. `TestPickMostComplete_D2Ordering` — `{A: 12 slots}` vs `{B: 13 slots}` → B;
+   equal slots + differing file counts → higher file count; both equal → smaller ULID.
+
+Green = all pass under `-race`, and `go vet ./internal/dupmatch/...` is clean.
+
+---
+
+## Step 2 — `maintenance.detect-redundant-copies`: the detector op
+
+**Commit:** `feat(maintenance): detect-redundant-copies dry-run detector`
+**Depends on:** Step 1.
+
+### Files to create
+
+| File | Intent |
+|---|---|
+| `internal/plugins/maintenance/detect_redundant_copies.go` | The op def, params, the five phases (design §4.1), the duration index, hold payload marshalling, `UpsertReviewItem`, the `RECONCILE:` line and the histogram render. |
+| `internal/plugins/maintenance/detect_redundant_copies_test.go` | Phase-level tests against a fake store. |
+
+### Files to modify
+
+| File | Change |
+|---|---|
+| `internal/plugins/maintenance/plugin.go` | Register `p.detectRedundantCopiesDef()` in the op list. Put it next to `p.relinkUnlinkedBooksDef()` (line 83) under the reconcile group, with a one-line comment saying it is tier 2 and consumes what relink produced. Bump the file's version header. |
+
+### Non-obvious implementation notes
+
+- **Concurrency is mandatory** (CLAUDE.md): phases 2 and 4 use
+  `registry.RunItems(ctx, reporter, ids, fn, registry.RunItemsOptions{Concurrency: runtime.NumCPU(), ProgressTotal: len(ids), ErrMode: registry.ErrModeCollect, Label: ...})`
+  — copy the call shape from `internal/plugins/maintenance/relink_unlinked.go:117-156`.
+  Results are appended under a `sync.Mutex`; **all writes happen in single-threaded phase 5**,
+  so two workers can never touch the same row.
+- **Frozen-iTunes exclusion** uses `config.UnderFrozenITunesTree` on both
+  `BookFile.FilePath` and `BookFile.ITunesPath`, mirroring
+  `internal/plugins/maintenance/regroup_shattered_ai.go:191`. Applied to **both** the
+  debris and the reference candidate sets (LD3), with a per-reference `excludedFrozen`
+  list in the payload.
+- **Duration source resolution** is one small helper:
+  ```go
+  func trackDuration(bf database.BookFile) (int, dupmatch.DurSource) {
+      if bf.AcoustIDFingerprintDurationSec > 0 {
+          return int(math.Round(bf.AcoustIDFingerprintDurationSec)), dupmatch.SourceFingerprint
+      }
+      if d := database.NormalizeDurationSec(bf.FileSize, bf.Duration); d > 0 {
+          return d, dupmatch.SourceContainer
+      }
+      return 0, dupmatch.SourceUnknown
+  }
+  ```
+  `NormalizeDurationSec` is at `internal/database/duration_sanity.go:61`; skipping it
+  would let a millisecond-valued row (~1.9 % of history) match nothing and be counted as
+  a real negative.
+- **Index entries are the slim struct from design §5**, never `database.BookFile`.
+- `HistogramOnly: true` runs phases 1–4 and logs the histogram, then returns before any
+  `UpsertReviewItem`. This is the calibration mode and it is what the acceptance gate
+  runs first.
+- The op must **not** declare `sdk.CapFilesRead` (LD5).
+- Reconcile assertion is in-process: build the counters, compare, and
+  `return fmt.Errorf(...)` if they do not tie (LD10).
+
+### Tests — what green means
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run 'TestDetectRedundantCopies' -v
+```
+
+Required cases:
+
+1. `TestDetectRedundantCopies_EmitsHoldForSuccessorsShape` — fake store with one 13-file
+   reference and 11 debris books/17 files whose durations match 12 slots →
+   exactly **one** `UpsertReviewItem` call, `Kind == "firstaid.redundant-copy"`,
+   payload `coveredTracks` length 12, `missingTracks == [7]`, `internallyRedundant`
+   length 5.
+2. `TestDetectRedundantCopies_SkipsFrozenITunesReference` — reference under
+   `.../books/itunes/...` → zero holds, `skipped-frozen` counted.
+3. `TestDetectRedundantCopies_SkipsFrozenITunesDebris` — 10 frozen debris rows appear in
+   `excludedFrozen` and are **not** in `debrisBookIds`.
+4. `TestDetectRedundantCopies_SingleFileDebrisNeedsCorroborator` — one debris file, one
+   slot, no corroborator → no hold, `SkipNoCorroborator` counted; add a matching title
+   stem → hold emitted.
+5. `TestDetectRedundantCopies_ZeroWritesToBooks` — the fake store fails the test if
+   `UpdateBook`, `UpdateBookFile`, `CreateBookFile`, `DeleteBook`, or
+   `MoveBookFilesToBook` is called at all. This is the "dry-run means dry-run" assertion.
+6. `TestDetectRedundantCopies_Reconciles` — the `RECONCILE:` counters tie and the op
+   returns nil; a deliberately-broken counter makes it return an error.
+7. `TestDetectRedundantCopies_HistogramOnly` — zero `UpsertReviewItem` calls, histogram
+   present in the reporter log.
+8. `TestDetectRedundantCopies_Idempotent` — running twice produces the same `DedupKey`
+   and the same payload bytes.
+
+Green = all pass under `-race`; no book/file mutation in any test.
+
+---
+
+## Step 3 — Frontend: label + payload typing
+
+**Commit:** `feat(web): review-queue label and payload fields for firstaid.redundant-copy`
+**Depends on:** nothing (can land in parallel with 1–2).
+
+| File | Change |
+|---|---|
+| `web/src/lib/reviewKinds.ts` | Add `'firstaid.redundant-copy': 'Redundant copies (assembled original exists)'` to `REVIEW_KIND_LABELS` (currently lines 10-15). Version → 1.1.0. |
+| `web/src/lib/reviewPayload.ts` | Add optional typed fields `referenceBookId`, `referenceTitle`, `referenceTrackCount`, `coveredTracks`, `missingTracks`, `debrisBookIds`, `internallyRedundant`, `excludedFrozen` to `ReviewPayload`; extend `memberIDs()` (line 46) with a `debrisBookIds` fallback so `memberCount()` renders. Version → 1.1.0. |
+| `web/src/lib/__tests__/reviewPayload.test.ts` | Add a case parsing a real `firstaid.redundant-copy` payload and asserting `memberIDs()` returns the debris IDs. |
+
+```bash
+cd web && npm run test -- src/lib/__tests__/reviewPayload.test.ts
+```
+
+Green = the new case passes and no existing case changed.
+
+---
+
+## Step 4 — Extract `linkVersionGroup` (the only refactor of shipped code)
+
+**Commit:** `refactor(maintenance): extract linkVersionGroup with injected primary selection`
+**Depends on:** nothing. **Land this before step 5.**
+
+| File | Change |
+|---|---|
+| `internal/plugins/maintenance/version_group_link.go` (new) | `linkVersionGroup(store, memberIDs, pick, logKV...) (groupID, primaryID string, err error)` carrying, verbatim, the three invariants from `regroup_apply.go`: existing-group reuse (lines 222-224, 246-252), cross-group refusal (236-245), stale-primary demotion (286-312). Plus `pickEarliestULIDBook([]*database.Book) string`. Re-fetch-and-patch only; mutate **only** `VersionGroupID` and `IsPrimaryVersion`. |
+| `internal/plugins/maintenance/regroup_apply.go` | `ApplyVersionGroup` (line 188) becomes a thin wrapper: decode payload → `linkVersionGroup(store, p.MemberBookIDs, pickEarliestULIDBook, "item", item.ID, "folder", p.Folder)`. Delete the inlined logic. Version header → 1.3.0. |
+
+**This step must change zero behaviour.** The proof is that `regroup_apply_test.go` is
+**not edited** and still passes:
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run 'TestApplyVersionGroup|TestApplyMultidisc' -v
+git diff --stat internal/plugins/maintenance/regroup_apply_test.go   # must be empty
+```
+
+Green = every existing `ApplyVersionGroup` test passes with an unmodified test file. If a
+test needs editing, the extraction changed behaviour — stop and fix the extraction.
+
+---
+
+## Step 5 — `ApplyRedundantCopy`: the fixer
+
+**Commit:** `feat(maintenance): ApplyRedundantCopy — combine debris by template, then version-group`
+**Depends on:** Steps 1, 2, 4.
+
+| File | Change |
+|---|---|
+| `internal/plugins/maintenance/redundant_copy_apply.go` (new) | `ApplyRedundantCopy(store, combiner)` per design §4.2 (10 ordered steps), plus `applyTemplateTrackNumbers` per §4.3. Reuses `presentMembers` (`regroup_apply.go:338`), `pickPrimary` (`regroup_apply.go:364`) and the `bookCombiner` interface (`regroup_apply.go:68`) — do not duplicate or widen any of them. |
+| `internal/plugins/maintenance/redundant_copy_apply_test.go` (new) | The invariant suite below. |
+
+### Non-obvious implementation notes
+
+- `CombineBooks(present, survivorID, **nil**)` — the nil override is load-bearing. A
+  non-nil override is the only thing that makes `merge.Service` call `UpdateBook` on the
+  survivor (`internal/merge/service.go:444-457`).
+- `applyTemplateTrackNumbers` has **no** group-level "already numbered → bail" guard, and
+  its doc comment must say why, citing `relink_unlinked.go:355` (LD7). Reviewers will try
+  to reunify it with `applyDiscTrackNumbers`; the comment is the defence.
+- Redundant and skipped files are written `TrackNumber = 0, DiscNumber = 0` — "position
+  unknown, deliberately".
+- The step-3 guard (`referenceID ∉ debrisBookIds`) and the step-4 frozen-tree re-check
+  both run **before** any store write.
+
+### Tests — what green means
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run 'TestApplyRedundantCopy' -v
+```
+
+Required cases:
+
+1. `TestApplyRedundantCopy_ReferenceNeverInCombineCall` — the fake combiner records its
+   `bookIDs` argument; assert the reference ID is absent and that `primaryID` is a debris
+   ID. **This is the LD4 guard and the single most important test in the workstream.**
+2. `TestApplyRedundantCopy_RefusesReferenceInDebrisList` — hand-corrupted payload with
+   the reference listed as debris → error, and the fake store records **zero** writes.
+3. `TestApplyRedundantCopy_ReferenceStaysPrimary` — after apply, reference has
+   `IsPrimaryVersion == true` and the debris survivor `false`; both share one
+   `VersionGroupID`; neither is soft-deleted.
+4. `TestApplyRedundantCopy_PreservesFingerprintAndAuthor` — survivor `BookFile` rows keep
+   `AcoustIDFingerprint`; the reference `Book`'s `Author`, `Series` and `Narrator` are
+   byte-identical before and after. Guards the repo's dominant incident class.
+5. `TestApplyRedundantCopy_NumbersOverPreExistingRelinkTrackNumbers` — survivor files
+   arrive carrying `TrackNumber = 1..n` from relink; assert they are **rewritten** to the
+   template slots. This is the regression that reusing `applyDiscTrackNumbers` would
+   cause (LD7).
+6. `TestApplyRedundantCopy_RedundantFilesGetTrackZero` — the 5 internally-redundant files
+   end at `TrackNumber == 0` and are counted in the returned `leftUnnumbered`.
+7. `TestApplyRedundantCopy_Idempotent` — apply twice; second run performs zero combines,
+   reuses the same `VersionGroupID`, and writes no `UpdateBookFile` (per-file values
+   already equal).
+8. `TestApplyRedundantCopy_SoftDeletedDebrisSkipped` — a `MarkedForDeletion` debris book
+   is never passed to `CombineBooks` and never made primary.
+9. `TestApplyRedundantCopy_RefusesFrozenITunesMember` — reference or debris under
+   `books/itunes/**` → error, zero writes.
+10. `TestApplyRedundantCopy_RefusesCrossVersionGroups` — reference in group A, survivor in
+    group B → error from `linkVersionGroup`, zero `UpdateBook` calls.
+11. `TestApplyRedundantCopy_SingleDebrisBookSkipsCombine` — one debris book → no
+    `CombineBooks` call at all, straight to numbering + version-group.
+
+Green = all 11 pass under `-race`, plus the whole package:
+
+```bash
+go test ./internal/plugins/maintenance/... -race -short
+```
+
+---
+
+## Step 6 — Wire the apply handler
+
+**Commit:** `feat(server): register the firstaid.redundant-copy apply handler`
+**Depends on:** Step 5.
+
+| File | Change |
+|---|---|
+| `internal/server/wire_handlers.go` | Inside the existing `if s.Store() != nil` block (lines 598-608), add `reviewH.RegisterApplyHandler("firstaid.redundant-copy", maintenanceplugin.ApplyRedundantCopy(s.Store(), mergeSvc))`. Reuse the `mergeSvc` already resolved on line 600. Extend the block comment to say the handler is inert until `config.ReviewApplyEnabled` is flipped. Bump the version header. |
+| `internal/plugins/maintenance/kinds.go` (new, ~20 lines) | Export `const KindRedundantCopy = "firstaid.redundant-copy"` with a comment marking it LOAD-BEARING (the frontend maps it verbatim, mirroring `fs_regroup_shape.go:68-74`). Use it from the detector, the apply wiring and the tests — no string literals in three places. |
+
+```bash
+go build ./... && go test ./internal/server/... -race -short
+```
+
+Green = build clean, server tests pass. **Note:** this step changes nothing observable in
+prod — `config.ReviewApplyEnabled` defaults OFF and is not set in prod
+(`internal/server/handlers/review/handler.go:16-23`), so approving a hold records the
+decision and executes nothing.
+
+---
+
+## Step 7 — Docs and fragments
+
+**Commit:** `docs(dupmatch): changelog + todo fragments for redundant-copy detection`
+
+| File | Change |
+|---|---|
+| `changelog.d/<scriv-generated>.md` | Required by `changelog-check.yml` CI. Run `scriv create`. |
+| `todo.d/20260805_*_first_aid_library_validate_repair.md` | Do **not** edit (add-only fragment system). Tick the sub-task in `TODO.md` directly once merged — that is a normal direct edit. |
+| `docs/executive-summaries/2026-08.md` | Qualifies: wide blast radius (merge path + review queue) and a data-corruption-adjacent class. Prepend, never replace. |
+
+```bash
+make ci
+```
+
+Green = `make ci` passes (mocks / staticcheck / short tests / 30 % coverage gate).
+**Known:** local `make ci` staticcheck is red on `main` itself; the real gate is the
+"Minimal CI" GitHub workflow. Compare against a `main` baseline run before treating a
+staticcheck finding as yours.
+
+---
+
+## Full verification suite (run before opening any PR)
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.worktrees/dupmatch
+
+go build ./...
+go vet ./internal/dupmatch/... ./internal/plugins/maintenance/...
+go test ./internal/dupmatch/... -race -count=1
+go test ./internal/plugins/maintenance/... -race -count=1
+go test ./internal/merge/... -race -count=1          # CombineBooks contract unchanged
+go test ./internal/server/... -race -short -count=1
+go test ./... -short                                  # store-getter footgun: subset runs hide vacuous mocks
+cd web && npm run test -- src/lib/
+```
+
+`go test ./... -short` in full is not optional: a getter/interface change makes old mocks
+silently vacuous-pass in *other* packages, which a subset run cannot see.
+
+---
+
+## Dry-run acceptance gate on prod (BEFORE any apply)
+
+Deploy from the **main checkout** — `Makefile.local`'s `LOCAL_ROOT` is hardcoded to it, so
+deploying from a worktree ships main's binary:
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git pull --ff-only        # required: server-side merges must be local before deploy
+make deploy
+```
+
+Get an API key with the `server-bootstrap` skill (writes `.claude/.api-token`), then:
+
+### Gate run A — histogram only, whole library
+
+```bash
+TOKEN=$(cat /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.claude/.api-token)
+curl -sS -X POST https://<server>:8484/api/v1/operations/v2 \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.detect-redundant-copies",
+       "params":{"histogramOnly":true,"probeToleranceSec":10}}'
+# -> {"op_id":"..."}; then poll:
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  https://<server>:8484/api/v1/operations/<op_id>/logs
+```
+
+### Gate run B — single-reference canary on the measured case
+
+```bash
+curl -sS -X POST https://<server>:8484/api/v1/operations/v2 \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.detect-redundant-copies",
+       "params":{"referenceBookId":"01KQAXKG7HYMT44GRNCGSJBXG1","probeToleranceSec":10}}'
+```
+
+### Gate run C — whole library, holds written
+
+```bash
+curl -sS -X POST https://<server>:8484/api/v1/operations/v2 \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.detect-redundant-copies","params":{"probeToleranceSec":10}}'
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  'https://<server>:8484/api/v1/review/count'      # byKind["firstaid.redundant-copy"]
+```
+
+### Numbers that MUST be observed before anyone flips `review_apply_enabled`
+
+| # | Requirement | Where observed |
+|---|---|---|
+| A1 | **≥95 %** of accepted matches at `\|delta\| <= 1 s`, with a visible trough before the noise floor | Gate run A histogram |
+| A2 | If the histogram is **flat** out to 10 s → **STOP**. Duration matching is not separating signal at this data quality; do not ship a tolerance | Gate run A |
+| B1 | `01KQAXKG7HYMT44GRNCGSJBXG1` selected as reference | Gate run B payload |
+| B2 | `coveredTracks` length **12**, `missingTracks == [7]` | Gate run B payload |
+| B3 | `debrisBookIds` length **11**, `debrisFileCount` **17** | Gate run B payload |
+| B4 | `internallyRedundant` length **5** | Gate run B payload |
+| B5 | `excludedFrozen` length **10** — present and counted, not silently dropped | Gate run B payload |
+| C1 | `RECONCILE:` line ties: `examined == matched + unmatched + skipped-no-duration + skipped-frozen + skipped-short + skipped-ambiguous-bucket + errors`, and `examined == len(ListBookIDs())` (≈44,887) | Gate run C log |
+| C2 | Library-wide hold count reported, **split** into "debris books contributing ≥2 slots" vs "exactly 1 slot (corroborator-gated)". If the single-slot share exceeds ~20 %, tighten the corroborator rule before proceeding | Gate run C summary |
+| C3 | `skipped-no-duration` reported with `maintenance.duration-reextract` named as the producer. A large value is a signal to run that op and re-run, **not** a reason to widen tolerance | Gate run C summary |
+| C4 | Zero book/file mutations: `GET /api/v1/audiobooks?limit=1` total count identical before and after gate run C | prod API |
+
+Only when A1, B1–B5 and C1 all hold is `tolFingerprintSec` locked to the value the
+histogram supports (proposed 2) and the design doc updated with the observed
+distribution. **Applying anything is a separate, explicit human decision** made via
+`AskUserQuestion`, not a text reply.
+
+---
+
+## Rollback
+
+Rollback is cheap by construction, in four independent layers:
+
+1. **Nothing is on by default.** The detector has no apply flag (LD9) and the apply
+   handler is gated by `config.ReviewApplyEnabled`, which defaults OFF and is **not set
+   in prod**. Merging steps 1–7 changes zero prod behaviour until someone flips it.
+2. **Un-flip the switch.** If applies misbehave, set `review_apply_enabled` back to false
+   and restart. Approving a hold then records the decision and executes nothing
+   (`internal/server/handlers/review/handler.go:16-23`).
+3. **Purge the holds.** The holds are review-queue rows keyed by a stable `DedupKey`.
+   Delete the pending `firstaid.redundant-copy` items via
+   `DELETE /api/v1/review/items/:id`, or simply leave them — they mutate nothing.
+4. **Revert the code.** Steps are independent commits. Step 4 (the `linkVersionGroup`
+   extraction) is the only one that touches shipped code; reverting it restores
+   `ApplyVersionGroup`'s inlined body exactly, and its unmodified test file proves
+   equivalence in both directions.
+
+**What is NOT cheaply reversible:** an *applied* hold. `CombineBooks` hard-deletes
+absorbed debris rows (`internal/merge/service.go:432-436`). The files survive on the
+survivor, and re-splitting is manual. This is why the gate above is a gate and not a
+checklist. Before the first apply, take a DB snapshot on prod (the ZFS dataset holding
+PebbleDB) so a bad batch can be rolled back wholesale.
+
+---
+
+## Sequencing notes
+
+- **This workstream assumes relink has already run.** Tasks #1/#2 are marked complete;
+  if durations are still missing for the debris population, run
+  `maintenance.duration-reextract` and re-run the detector rather than widening tolerance
+  (LD5, gate C3). That re-run-until-clean loop *is* the First Aid convergence property.
+- Do **not** run this in parallel with `maintenance.regroup-shattered-ai` on prod: both
+  write review-queue rows, and interleaved holds make the reconcile numbers unreadable.
+  They have different `ConcurrencyKey`s so the registry will not stop you.
+- The First Aid orchestrator (separate workstream) will eventually sequence this op; do
+  not build sequencing here (non-goal §7.7).

--- a/docs/plans/2026-08-05-playlists-plan.md
+++ b/docs/plans/2026-08-05-playlists-plan.md
@@ -1,0 +1,512 @@
+<!-- file: docs/plans/2026-08-05-playlists-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 29e3bb09-815f-46b7-9ef8-009c5e4595fd -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Playlists — implementation plan
+
+Design: [`docs/specs/2026-08-05-playlists-design.md`](../specs/2026-08-05-playlists-design.md)
+Base: `main` @ `8c39469a`
+Branch: `feat/playlists-file-level-entries`
+
+> **Worktree discipline (CLAUDE.md, non-negotiable).** Before any edit:
+> ```bash
+> git -C /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer worktree list
+> git -C /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer worktree add \
+>     /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.worktrees/playlists \
+>     -b feat/playlists-file-level-entries
+> ```
+> All paths below are relative to that worktree root. Every file created or
+> modified gets a version header (`// file:` / `// version:` / `// guid:` /
+> `// last-edited:` for Go; `<!-- ... -->` for everything else) and a version
+> bump on every change.
+
+---
+
+## 0. Sequencing rationale
+
+Steps 1-8 have **no dependency on the ABS oracle** and can all land first.
+**Step 9 is intentionally empty** — the scan-time hook it once held was dropped
+(design §8 non-goal 11); the number is kept so the "step 10 / steps 11-12 /
+step 14.x" references in this file and in the design stay valid.
+Step 10 is a hard gate: **nothing in 11-12 may be written before a real ABS
+playlist fixture exists** (design §6.2). Step 13 is the prod dry-run gate;
+step 14 is the only apply.
+
+Each step below is one commit and one reviewable diff. Steps 1-3 must land in
+order (later steps compile against them); 4-8 are independent of each other.
+**No step in this plan modifies any file under `internal/scanner/`** (step 9).
+
+---
+
+## Step 1 — `PlaylistEntry` type + store interface (no implementation)
+
+**Intent:** land the types and the interface so every later step compiles
+against a stable surface, and so the mock churn happens once.
+
+| File | Intent |
+|---|---|
+| `internal/database/store.go` | **modify.** Add `PlaylistEntry`, `EntryTiming`, `EntryState` + its four constants, immediately after `UserPlaylist` (currently ends line 417) and before `PlaylistItem` (line 426). Add the nine provenance/counter fields to `UserPlaylist` (design §3.2). Do **not** add an `Entries` field — that is the whole point of D1; put a comment saying so, citing `pebble_store_playlists.go:311`. |
+| `internal/database/iface_misc.go` | **modify.** Add the six new methods to `UserPlaylistStore` (currently lines 232-245), each with the doc comment from design §3.3. |
+
+**Verify:**
+```bash
+go build ./... 2>&1 | head -40          # EXPECT: failures in PebbleStore + mocks only
+go vet ./internal/database/...
+```
+Green means: the only build errors are "PebbleStore does not implement
+UserPlaylistStore" and the two mock types. Anything else means the type
+placement is wrong.
+
+---
+
+## Step 2 — PebbleStore implementation of the entry keyspace
+
+| File | Intent |
+|---|---|
+| `internal/database/pebble_store_playlist_entries.go` | **create.** All six methods. Keys exactly as design §D1. `ReplacePlaylistEntries` = one `p.db.NewBatch()`: delete the old `uplent:<id>:` range + old `idx:uplent:bf:*` + `idx:uplent:unres:*` entries for that playlist, write the new ones, then **re-fetch the owning row via `p.GetUserPlaylist(id)`, mutate ONLY `BookIDs`/`EntryCount`/`UnresolvedCount`, marshal that, `Set("upl:"+id)`** — never marshal a caller-supplied struct. Same re-fetch discipline in `SetPlaylistImportProvenance`. |
+| `internal/database/pebble_store_playlist_entries_test.go` | **create.** See tests below. |
+| `internal/database/iface_assert.go` | **modify.** It already carries compile-time `var _ Store = (*PebbleStore)(nil)`-style assertions; confirm nothing new is needed, else add. |
+
+**Tests (all in the new `_test.go`):**
+- `TestPlaylistEntryKeyspace_DoesNotCollideWithUserPlaylistScan` — 🔴 the
+  load-bearing one. Create a playlist, call `ReplacePlaylistEntries` with 3
+  entries, then call `ListUserPlaylists("", 0, 0)` and assert it returns
+  **exactly 1** row. This is the regression test for the collision analysed in
+  design §D1.a (`listUserPlaylists` iterates `["upl:", "upl:~")`,
+  `pebble_store_playlists.go:262-264`, and `encoding/json` would silently decode
+  an entry blob into a blank `UserPlaylist`).
+- `TestReplacePlaylistEntries_PreservesUnrelatedPlaylistFields` — 🔴 the
+  write-back-wipe test. Create a playlist with `Name`, `Description`, `Query`,
+  `SortJSON`, `Limit`, `ITunesPersistentID`, `ITunesRawCriteriaB64`,
+  `CreatedByUserID`, `Dirty`. Call `ReplacePlaylistEntries`. Re-read and assert
+  **every one** is unchanged and `Version` incremented by exactly 1.
+- `TestReplacePlaylistEntries_ProjectsBookIDsInFirstAppearanceOrder` — entries
+  `[bfA→bookX, bfB→bookY, bfC→bookX]` yield `BookIDs == ["X","Y"]`.
+- `TestReplacePlaylistEntries_UnresolvedEntriesArePersistedAndCounted` —
+  20 unresolved of 60 → `EntryCount==60`, `UnresolvedCount==20`,
+  `len(ListPlaylistEntries())==60`. (Design D2.)
+- `TestReplacePlaylistEntries_IsAtomicSwapNotAppend` — call twice with different
+  lists; second call's result contains only the second list.
+- `TestListPlaylistsCitingBookFile_ReverseIndex` + a delete case proving the
+  reverse index is cleaned on replace.
+- `TestUpdatePlaylistEntryResolution_TouchesOnlyResolutionFields` — asserts
+  `Title`, `Artist`, `RawPath`, `Timing`, `FirstSeenAt` survive.
+
+```bash
+go test ./internal/database/... -race -run 'TestPlaylistEntry|TestReplacePlaylistEntries|TestListPlaylistsCiting|TestUpdatePlaylistEntryResolution'
+```
+Green means: all 7 pass under `-race`, and in particular the collision test
+returns 1 playlist not 4.
+
+---
+
+## Step 3 — regenerate both mock surfaces
+
+There are **two** and both break: the mockery-generated one and a hand-written
+func-field one.
+
+| File | Intent |
+|---|---|
+| `internal/database/mocks/mock_store.go` | **regenerate.** `UserPlaylistStore` is listed at `.mockery.yaml:48`; `Store` embeds it. Run `make mocks` (which runs bare `mockery`). ⚠️ Per the mockery v3.7.1-vs-v2.53.6 drift note in project memory: check `mockery --version` matches what CI uses **before** committing, and commit only the diff for the playlist methods — never an unscoped whole-file regen. |
+| `internal/database/mock_store.go` | **modify by hand.** Add the six `…Func` fields next to the existing playlist block (currently `internal/database/mock_store.go:262-270`) and the six method bodies next to `CreateUserPlaylist` (`:1575`). |
+
+**Verify:**
+```bash
+make mocks
+make mocks-check          # EXPECT: pass — committed mocks match generation
+make check-mock-fresh
+go build ./... && go vet ./...
+go test ./internal/database/... -race -short
+```
+Green means: `mocks-check` passes (this is a `make ci` gate, `Makefile:350`) and
+the full package builds.
+
+---
+
+## Step 4 — format parsers (pure, no I/O, no store)
+
+| File | Intent |
+|---|---|
+| `internal/playlist/parse/parse.go` | **create.** `Format` enum, `Detect(name string, data []byte) Format`, `ParsedEntry`, `ParsedPlaylist`. |
+| `internal/playlist/parse/m3u.go` | **create.** `ParseM3U`. `#EXTINF:-1` → `DurationSec 0` (unknown). 🔴 **Does not `os.Stat`-filter** — the existing transient parser at `internal/scanner/scanner.go:1610-1614` drops any line that fails to stat, which is exactly the absent-evidence-as-negative bug (design D2). Cite that line in the doc comment. |
+| `internal/playlist/parse/pls.go` | **create.** `ParsePLS`. `NumberOfEntries` advisory only. |
+| `internal/playlist/parse/xspf.go` | **create.** `ParseXSPF`. `<duration>` is **milliseconds** → `/1000`. |
+| `internal/playlist/parse/cue.go` | **create.** `ParseCUE`. Supersedes and extends `scanner.go:1567-1592` (which reads only `TITLE` + `FILE`): adds `PERFORMER`, `TRACK nn AUDIO`, `INDEX 00`/`INDEX 01` at `mm:ss:ff` with ff/75.0, and per-track `TITLE`. N tracks over one `FILE` → N entries sharing `RawPath`, distinct `Timing`. |
+| `internal/playlist/parse/testdata/` | **create.** One golden file per format plus the pathological cases below. |
+| `internal/playlist/parse/*_test.go` | **create.** |
+
+**Tests:**
+- `TestParseM3U_ExtinfMinusOneMeansUnknownNotZeroLength`
+- `TestParseM3U_KeepsEntriesWhosePathsDoNotExist` — 🔴 D2 regression.
+- `TestParseM3U_RelativeAndAbsoluteAndFileURI`
+- `TestParseM3U_HTTPEntryIsRecordedNotFetched`
+- `TestParsePLS_NumberOfEntriesDisagreesWithFileKeys` — keeps all `FileN`.
+- `TestParseXSPF_DurationIsMilliseconds` — 🔴 input `<duration>3600000</duration>`
+  must yield `DurationSec == 3600`. The library has a documented ms/sec incident
+  class (`database.NormalizeDurationSec`, used at
+  `internal/plugins/maintenance/relink_unlinked.go:378`; op
+  `maintenance.purge-millisecond-durations` exists for the fallout).
+- `TestParseCUE_IndexOffsetsAreFramesAt75fps` — `INDEX 01 02:30:37` → `150.4933…`.
+- `TestParseCUE_MultipleTracksOneFileShareRawPath`
+- `TestParseCUE_PregapOnlyTrackIsKeptWithWarning` — D2 / failure mode F14.
+- `TestParseCUE_MultipleFileDirectives`
+- `TestDetect_ByExtensionAndBySniff`
+- Property test (`-short`-skippable, matching the repo's existing convention —
+  `Makefile:171-172` notes playlist property tests are skipped in short mode):
+  parse→export→parse round-trip preserves entry count and order.
+
+```bash
+go test ./internal/playlist/parse/... -race
+go test ./internal/playlist/parse/... -race -run TestParseXSPF_DurationIsMilliseconds -v
+```
+Green means: every test passes and the XSPF one is visibly asserting 3600.
+
+---
+
+## Step 5 — `playlists.import-scan` op (dry-run capable, apply-gated)
+
+| File | Intent |
+|---|---|
+| `internal/plugins/maintenance/playlist_import.go` | **create.** `playlistImportParams` mirroring `relinkParams` (`relink_unlinked.go:55-67`): `Apply bool`, `Limit int`, `Roots []string`, `Formats []string`. `playlistImportScanDef()` mirroring `relinkUnlinkedBooksDef()` (`relink_unlinked.go:69-87`) — `ResumeDrop`, `Cancellable: true`, `Isolate: false`, `Timeout: 120*time.Minute`, `ConcurrencyKey: "playlists.import-scan"`. Four phases per design §4.1, each a `linkintegrity.PhaseResult`. Enumerate + parse + resolve run under `registry.RunItems` with `Concurrency: runtime.NumCPU()`, `ErrMode: registry.ErrModeCollect`, results under a `sync.Mutex`; **all writes single-threaded after the pool drains** — copy the structure and the comment rationale from `relink_unlinked.go:107-156`. Fail the op when `report.UnreconciledPhases()` is non-empty, as `relink_unlinked.go:222-224` does. |
+| `internal/plugins/maintenance/plugin.go` | **modify.** Add `p.playlistImportScanDef(),` to the slice that currently contains `p.relinkUnlinkedBooksDef(),` at line 83. |
+| `internal/plugins/maintenance/playlist_import_test.go` | **create.** |
+
+**Tests:**
+- `TestPlaylistImport_DryRunWritesNothing` — a mock store whose every write
+  method fails the test if called; run with default params; assert no error and
+  a populated report.
+- `TestPlaylistImport_ReconcilesExaminedEqualsActionedPlusSkippedPlusErrors` —
+  asserts `PhaseResult.Reconciles()` (`internal/linkintegrity/report.go:134`)
+  for every phase.
+- `TestPlaylistImport_UnresolvedEntriesAreCountedNotDropped` — 60 entries, 20
+  with no `book_file` row; assert 60 stored, `unresolved==20`, and the RECONCILE
+  log line contains all four numbers.
+- `TestPlaylistImport_ReimportSameHashIsNoop`
+- `TestPlaylistImport_ReimportChangedHashReplacesInPlace`
+- `TestPlaylistImport_ReimportOfUserModifiedCreatesNewPlaylist`
+- `TestPlaylistImport_MissingSourceMarksNotDeletes` — F7.
+- `TestPlaylistImport_NeverCallsBookOrBookFileWriters` — 🔴 D4. Use the
+  hand-written `database.MockStore` (`internal/database/mock_store.go`) with
+  `UpdateBookFunc`/`UpdateBookFileFunc`/`CreateBookFileFunc`/`DeleteBookFileFunc`
+  set to `t.Fatal`.
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run TestPlaylistImport
+go test ./internal/plugins/maintenance/... -race -short
+```
+Green means: all eight pass, and the whole maintenance package is still green
+(it holds the relink/regroup suites that must not regress).
+
+---
+
+## Step 6 — source-grep guard for D4
+
+**Intent:** make "never touches book rows" mechanically enforced, not
+conventional — the same class of guard as `make sdkguard` (`Makefile:248-252`).
+
+| File | Intent |
+|---|---|
+| `internal/plugins/maintenance/playlist_writeguard_test.go` | **create.** Parse `playlist_import.go`, `playlist_export.go`, `playlist_resolve.go` with `go/parser` and fail if any selector expression names `UpdateBook`, `UpdateBookFile`, `CreateBookFile`, `DeleteBookFile`, `DeleteBookFilesForBook`, `MergeBooks`, or `SaveChaptersForBook`. Doc comment cites design D4 and D7 and the `relink_unlinked.go:293-297` precedent. |
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run TestPlaylistOpsNeverCallBookWriters -v
+```
+Green means: it passes, and it demonstrably **fails** if you temporarily add a
+`store.UpdateBook(...)` line (verify this by hand before committing — a guard
+that cannot fail is not a guard).
+
+---
+
+## Step 7 — `playlists.resolve-entries` and `playlists.export` ops
+
+| File | Intent |
+|---|---|
+| `internal/plugins/maintenance/playlist_resolve.go` | **create.** Params `{apply, limit}`. `ListUnresolvedPlaylistEntries(limit)` → parallel `GetBookFileByPath` → single-threaded `UpdatePlaylistEntryResolution`. Also **demotes** entries whose `BookFileID` no longer resolves (F12). `PhaseResult` reconcile + fail-on-unreconciled. |
+| `internal/plugins/maintenance/playlist_export.go` | **create.** Params `{apply, playlist_ids, format, dest}`. `dest` defaults to `config.AppConfig.PlaylistDir` (`internal/config/config.go:470`). 🔴 **Rejects** `dest` when `config.UnderFrozenITunesTree(dest)` is true (`internal/config/itunes_libraries.go:98`). Emits `#EXTM3U`, `#EXTINF:<dur or -1>,<Artist> - <Title>`, path. Exports unresolved entries using `RawPath` (D2). |
+| `internal/playlist/playlist.go` | **modify.** Export `GeneratePlaylistFile` (currently unexported at line 42, reachable only from `GeneratePlaylistsForSeries` which unconditionally errors at lines 34-37) **or** leave it alone and write the emitter in the op. Prefer the latter: the existing helper sorts by `Position` then `Title` (`playlist.go:44-49`), which would silently re-order a playlist whose order is the point. If left alone, bump the header version only if the file is touched at all. |
+| `internal/plugins/maintenance/plugin.go` | **modify.** Register both defs. |
+| `internal/plugins/maintenance/playlist_resolve_test.go`, `playlist_export_test.go` | **create.** |
+
+**Tests:**
+- `TestPlaylistResolve_PromotesOnlyWhenRowExists`
+- `TestPlaylistResolve_DemotesDanglingEntryKeepsRawPath` — F12.
+- `TestPlaylistResolve_DryRunWritesNothing`
+- `TestPlaylistExport_RefusesFrozenITunesDestination` — 🔴 D6. Assert an
+  **error**, not a warning, for `dest = "/mnt/bigdata/books/itunes/x"`.
+- `TestPlaylistExport_UnknownDurationRoundTripsAsMinusOne`
+- `TestPlaylistExport_UnresolvedEntriesAreExportedNotDropped`
+- `TestPlaylistExport_RoundTripsThroughParseM3U` — export then `ParseM3U` yields
+  the same ordered `RawPath` list.
+
+```bash
+go test ./internal/plugins/maintenance/... -race -run 'TestPlaylistResolve|TestPlaylistExport'
+```
+
+---
+
+## Step 8 — app API: entries, timings, grouping evidence, export stream
+
+| File | Intent |
+|---|---|
+| `internal/server/handlers/playlist_entries.go` | **create.** `GET /api/v1/playlists/:id/entries` (ownership-gated via the existing `ownedByCaller`, `handlers/playlists.go:105`), `GET /api/v1/playlists/:id/export` (streams `.m3u8`, no disk write), `GET /api/v1/books/:id/playlist-timings` (design §3.4), `GET /api/v1/playlists/grouping-evidence` (design §3.5, includes `under_frozen_itunes_tree` per Q4). |
+| `internal/server/handlers/playlists.go` | **modify.** Extend the narrow `PlaylistStore` interface (line 63-68) with the six new methods. **Do not** change `UpdatePlaylist`/`AddBooksToPlaylist`/`RemoveBookFromPlaylist`/`ReorderPlaylist`/`GetPlaylist` write paths — they must keep round-tripping only the fields they already own (D1). Bump header from 2.1.0. |
+| `internal/server/wire_library_routes.go` | **modify.** Register the four routes after the existing playlist block (lines 77-85). Read routes gate on `auth.PermLibraryView` (`internal/auth/permissions.go:23`); export gates on `PermLibraryView`; nothing here needs `PermPlaylistsCreate` (`permissions.go:56`) because nothing here mutates. |
+| `internal/server/playlist_entries_handlers_test.go` | **create.** |
+
+**Tests:**
+- `TestGetPlaylistEntries_404sForAnotherUsersPlaylist` — IDOR parity with the
+  existing suite (`internal/server/playlist_handlers_test.go`).
+- `TestGetPlaylistEntries_IncludesUnresolvedWithState`
+- `TestExportPlaylistStream_ContentTypeAndBody`
+- `TestGroupingEvidence_MarksFrozenITunesSources`
+- `TestBookPlaylistTimings_EmptyWhenNoCueSource`
+- 🔴 `TestGetSmartPlaylist_DoesNotWipeEntries` — the highest-value regression in
+  the whole plan. `GetPlaylist` writes back on **read** of a smart playlist
+  (`handlers/playlists.go:218-221`). Create a smart playlist, attach entries,
+  `GET` it, then assert `ListPlaylistEntries` still returns them. This test is
+  what proves D1's structural claim end-to-end.
+
+```bash
+go test ./internal/server/... -race -run 'TestPlaylist|TestGroupingEvidence|TestBookPlaylistTimings'
+go test ./internal/server/... -race -short
+```
+
+---
+
+## Step 9 — INTENTIONALLY EMPTY (scan-time hook dropped). No work.
+
+**Do not implement anything under this number.** An earlier draft of this plan
+added `OnPlaylistFileSeen(path, format string)` to `scanner.ScanHooks`
+(`internal/scanner/hooks.go:10-13` — currently exactly two methods,
+`OnBookScanned` and `OnImportDedup`). **Design §8 non-goal 11 drops it**, for
+three reasons, all verified:
+
+1. **Zero capability gained.** `playlists.import-scan` (step 5) already walks the
+   configured roots itself and finds the same files. The hook duplicates
+   discovery that already exists.
+2. **Compile-breaking change to an interface with live implementers** —
+   `serverScanHooks` (`internal/server/server_search.go:141`) and
+   `testDedupScanHooks` (`internal/scanner/save_book_to_database_test.go:163`).
+   Adding a method breaks both.
+3. **Wrong blast radius.** `internal/scanner` is the one package where a
+   regression creates or destroys books. Touching it for a convenience is not
+   worth it.
+
+`internal/scanner` is therefore **not modified by this workstream at all**.
+`findPlaylistGroupings` (`scanner.go:1635`) and its caller (`scanner.go:1833`)
+keep their current transient behaviour — see design Q2, which files the possible
+retirement of that path as a separate question, not as work here.
+
+The step number is preserved (rather than renumbering 10-14) because both this
+plan and the design reference "step 10", "steps 11-12" and "step 14.1/14.2/14.3"
+as stable identifiers.
+
+**Verification for this step:** the diff touches no file under
+`internal/scanner/`. Assert it mechanically before opening the PR:
+
+```bash
+git diff --name-only origin/main...HEAD | grep '^internal/scanner/' && \
+  echo "VIOLATION: step 9 is empty; internal/scanner must not be touched" && exit 1
+```
+Green means: the grep finds nothing and the command exits non-zero on the grep
+(no output above).
+
+---
+
+## Step 10 — 🔴 GATE: capture the ABS playlist fixture
+
+**Nothing in steps 11-12 may be written until this produces a real fixture.**
+
+```bash
+python3 scripts/abs_capture_fixtures.py --help     # confirm the invocation
+# capture against the ABS oracle:
+#   GET /api/libraries/<id>/playlists
+#   GET /api/libraries/<id>/playlists?limit=10&page=0     ← envelope-switch probe
+#   GET /api/playlists/<playlistId>                        ← if it exists
+```
+
+| File | Intent |
+|---|---|
+| `testdata/abs-fixtures/get_api_libraries_id_playlists.json` | **create (captured, not authored).** |
+| `testdata/abs-fixtures/get_api_libraries_id_playlists_paginated.json` | **create if the envelope differs** — `/authors` provably switches envelope on `limit`/`page` and "the two shapes share no keys" (`internal/server/handlers/abs/dto_library.go`, `authorsPageResponse` comment, verified against the oracle 2026-08-02). Assume nothing about `/playlists`. |
+| `docs/plans/2026-08-05-playlists-plan.md` | **modify.** Record the captured shape and strike design §6.2's five unknowns one by one. |
+
+**Exit criterion:** a fixture file exists in `testdata/abs-fixtures/` whose
+`response.body` came from a real ABS server. If the oracle is unreachable, **stop
+here and ship steps 1-8**; leaving `EmptyPage` wired is the correct behaviour,
+because a guessed DTO produces a route that "exists and looks implemented while
+behaving broken" — the exact failure `absRouteList()`
+(`internal/server/wire_abs_routes.go:369`) exists to prevent, stated verbatim in
+its doc comment at `wire_abs_routes.go:366-368`.
+
+---
+
+## Step 11 — ABS playlists DTO + handler (blocked on step 10)
+
+| File | Intent |
+|---|---|
+| `internal/server/handlers/abs/dto_playlist.go` | **create.** DTO written **against the captured fixture**, not from recall. |
+| `internal/server/handlers/abs/browse.go` | **modify.** Replace the `EmptyPage` wiring for playlists with a real `Playlists` handler. Keep `EmptyPage` for `/collections` (`handler.go:386`). Preserve `knownLibrary(c)` gating (`browse.go:333`). Project `UserPlaylist.BookIDs` — ABS is book-level (design §6.3). |
+| `internal/server/handlers/abs/handler.go` | **modify.** Line 387: `r.GET("/api/libraries/:libraryId/playlists", auth, h.Playlists)`. |
+| `internal/server/wire_abs_routes.go` | **modify.** No new path needed in `absReservedPathPrefixes` — `"/api/libraries/"` at line 64 already covers it. If step 10 revealed a top-level `/api/playlists/...` surface, that **does** need a new reserved prefix, or it 301s into `/api/v1` and silently breaks. Update `absRouteList()` (line 377+) either way, or `TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` never checks it. |
+| `internal/server/handlers/abs/playlists_test.go` | **create.** Includes a conformance test using `conformance.LoadFixture` (`internal/syncapi/conformance/fixture.go:35`) + `Fixture.CompareBody` (`:49`). |
+
+```bash
+go test ./internal/server/handlers/abs/... -race
+go test ./internal/server/... -race -run TestABSReservedPath
+```
+Green means: the conformance diff against the captured fixture is **empty**, and
+the reserved-path guard passes.
+
+---
+
+## Step 12 — frontend surfacing (minimum viable)
+
+| File | Intent |
+|---|---|
+| `web/src/services/playlistApi.ts` | **modify.** Add `getEntries`, `getGroupingEvidence`, `exportPlaylist`. |
+| `web/src/pages/PlaylistDetail.tsx` | **modify.** Show `entry_count` / `unresolved_count`; list entries with their state when present. An unresolved entry renders its stored `Title`/`RawPath` — never hidden (D2). |
+| `web/src/pages/Playlists.tsx` | **modify.** Column for entry count + unresolved badge. |
+| `web/src/pages/PlaylistDetail.test.tsx` | **create/modify.** |
+
+```bash
+cd web && npm run test -- --run playlist
+```
+Design §9-Q6 flags that a fuller file-level UI is unscoped; do not expand here.
+
+---
+
+## Step 13 — 🔴 PROD DRY-RUN ACCEPTANCE GATE
+
+**No apply may run until every number below has been observed and recorded.**
+There is no prior count of playlist files in this library, so this plan does not
+invent target numbers — it specifies the quantities that must be *produced and
+reconciled* before anyone presses apply.
+
+Deploy from the **main checkout**, not a worktree (`Makefile.local`'s
+`LOCAL_ROOT` is hardcoded to the main checkout; deploying from a worktree ships
+main's binary — see the first-aid note's "Next" item 1), then:
+
+```bash
+# from the main checkout, after the PR merges and `git pull --ff-only`
+make deploy
+# then, against prod:
+POST /api/v1/operations  {"type":"playlists.import-scan"}          # apply defaults to FALSE
+```
+
+**Record all of these from the RECONCILE log lines:**
+
+| Quantity | Must satisfy |
+|---|---|
+| `roots_walked` | equals the number of configured library roots |
+| `playlist_files_found` total, and broken out by `m3u` / `m3u8` / `pls` / `cue` / `xspf` | sums to the total |
+| `files_under_frozen_itunes_tree` | reported separately (design Q4) |
+| `files_parsed` / `files_with_zero_entries` / `files_parse_errors` | `found == parsed + zero_entries + parse_errors` |
+| `entries_parsed` | — |
+| `entries_resolved` | — |
+| `entries_unresolved_no_row` | — |
+| `entries_unresolved_missing` | — |
+| `entries_unresolved_off_root` | — |
+| **per-phase reconcile** | `examined == actioned + skipped + errors` for **every** phase; `report.UnreconciledPhases()` empty (`internal/linkintegrity/report.go:173`) |
+| `playlists_would_create` / `would_replace` / `would_skip_unchanged` | sums to `files_parsed` |
+
+**Stop conditions — do NOT apply if any of these hold:**
+
+1. `UnreconciledPhases()` is non-empty. The op already returns an error in this
+   case (`relink_unlinked.go:222-224` pattern); treat any occurrence as a bug in
+   the counting, not a data problem to work around.
+2. `entries_unresolved_no_row / entries_parsed > 0.10`. Relink has already been
+   applied (task #1 complete, ~16,027 books relinked), so the 38.2% zero-`book_file`
+   population that motivated the fragment's sequencing warning should be largely
+   drained. A double-digit unresolved rate means either relink did not take or the
+   path-normalisation in the resolver is wrong — investigate before writing
+   anything.
+3. `files_parse_errors > 0` without each one being individually explained in the
+   log. A parser that fails silently on a whole format is worse than not shipping
+   it.
+4. `playlist_files_found == 0`. That means the walk is wrong (or the library
+   genuinely has none, in which case the whole workstream needs re-justifying
+   before an apply is even meaningful).
+
+**Also run, and record, the second dry run:** re-run the identical command and
+assert the numbers are **byte-identical**. A dry run that is not idempotent is
+not evidence.
+
+---
+
+## Step 14 — apply, staged
+
+Only after step 13's gate passes and the owner signs off with a real
+`AskUserQuestion` decision (per `feedback_prod_apply_review_gate`), not a text
+reply.
+
+```bash
+# 1. canary — 25 playlist files
+POST /api/v1/operations {"type":"playlists.import-scan","params":{"apply":true,"limit":25}}
+# verify: 25 playlists exist, entry counts match the dry run's per-file numbers,
+#         zero book/book_file rows changed (compare total_file_count histogram
+#         via GET /api/v1/audiobooks?limit=500 paging before and after)
+# 2. full
+POST /api/v1/operations {"type":"playlists.import-scan","params":{"apply":true}}
+# 3. resolve pass
+POST /api/v1/operations {"type":"playlists.resolve-entries","params":{"apply":true}}
+```
+
+---
+
+## Test strategy summary — exact commands and what green means
+
+| Command | Green means |
+|---|---|
+| `go test ./internal/playlist/parse/... -race` | all four format parsers correct, incl. the XSPF ms→s and CUE 75fps unit tests |
+| `go test ./internal/database/... -race -run 'TestPlaylistEntry\|TestReplacePlaylistEntries'` | keyspace does not collide with the `upl:` scan; entry writes preserve every unrelated `UserPlaylist` field |
+| `go test ./internal/plugins/maintenance/... -race -short` | ops reconcile, dry-run writes nothing, no book/book_file writer is reachable — **and** the pre-existing relink/regroup suites still pass |
+| `go test ./internal/server/... -race -short` | handlers, IDOR gating, and `TestGetSmartPlaylist_DoesNotWipeEntries` |
+| `go test ./internal/server/handlers/abs/... -race` | conformance diff vs the captured fixture is empty |
+| `git diff --name-only origin/main...HEAD \| grep '^internal/scanner/'` | **no output.** Step 9 is empty; `internal/scanner` is out of scope entirely (design §8 non-goal 11) |
+| `make mocks-check && make check-mock-fresh` | committed mocks match generation (a `make ci` gate, `Makefile:350`) |
+| `make ci` | the whole gate: `mocks-check check-mock-fresh staticcheck sdkguard test-all-short coverage-check-short` |
+| `cd web && npm run test -- --run playlist` | frontend playlist tests pass |
+
+⚠️ **Do not run only a subset after touching a store interface.** The
+store-getter migration lesson (`feedback_storegetter_migration_full_suite_test`)
+is that old mocks silently vacuous-pass in unrelated packages; run
+`go test ./... -short` at least once before opening the PR.
+
+---
+
+## Rollback
+
+| Stage | Rollback |
+|---|---|
+| Any step before step 14 | Revert the PR. The `uplent:` keyspace is additive and unread by any pre-existing code path, so leftover keys are inert. No migration to undo. |
+| After a canary apply (step 14.1) | The op created `UserPlaylist` rows + `uplent:` entries only. Delete them with the existing `DELETE /api/v1/playlists/:id` (`wire_library_routes.go:81`) for the ≤25 created IDs — recorded in the op's log. **Nothing else changed**: D4 is enforced by the step-6 grep guard, so no book or `book_file` row can have been touched. |
+| After a full apply (step 14.2) | Same, at scale. Because every created playlist carries `SourceKind != ""` and `SourcePath != ""` (design §3.2), the set is exactly identifiable; a one-off cleanup script filters `ListUserPlaylists` on `SourceKind != ""` and `ImportedAt >= <run start>`. Write that script **before** the full apply, not after. |
+| After `playlists.resolve-entries` (step 14.3) | It only writes resolution fields on entries that already exist. Re-running it is idempotent. There is nothing to roll back that a re-run does not fix. |
+| Frontend | Independent PR; revert alone. |
+| ABS handler | Revert to `h.EmptyPage` at `handler.go:387` — a one-line change that restores the current, known-safe stub. |
+
+---
+
+## Post-task hygiene (CLAUDE.md, mandatory)
+
+- `changelog.d/` fragment (do **not** hand-edit `CHANGELOG.md`).
+- `todo.d/` fragment only for **new** tasks; checking the playlists task off is a
+  direct edit of `TODO.md`.
+- Executive summary: this qualifies — it spans multiple files with a wide blast
+  radius and closes a tracked owner item. Update the **current month's** file in
+  `docs/executive-summaries/` in the **same PR**, per
+  `docs/process/executive-summaries.md`.
+- Remove the worktree after merge: `git worktree remove .worktrees/playlists && git worktree prune`.

--- a/docs/plans/2026-08-05-review-queue-recommendations-plan.md
+++ b/docs/plans/2026-08-05-review-queue-recommendations-plan.md
@@ -1,0 +1,501 @@
+<!-- file: docs/plans/2026-08-05-review-queue-recommendations-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d5b9e07-84f1-4c62-a0d9-7b1e2f6c8a34 -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Review-queue recommendations + per-hold override actions — IMPLEMENTATION PLAN
+
+Design: [`docs/specs/2026-08-05-review-queue-recommendations-design.md`](../specs/2026-08-05-review-queue-recommendations-design.md)
+Fragment: `todo.d/20260805_220000_review_queue_recommendations_and_overrides.md`
+
+**Prerequisite already satisfied:** `maintenance.relink-unlinked-books` (PR #2147)
+has been applied; member duration coverage is 92.2%. Do not start this
+workstream on a library where that is not true — the recommender's decisive
+signal is `ShatterBook.DurationSec`.
+
+**Worktree.** All work happens in a dedicated worktree, never the primary
+checkout:
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git worktree add .worktrees/review-recommendations -b feat/review-queue-recommendations
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.worktrees/review-recommendations
+```
+
+Every file created or modified gets/keeps a version header (path, version, guid,
+last-edited) and a version bump.
+
+---
+
+## Step order and why
+
+Steps 1-3 are backend-pure and land with **zero behaviour change** to the apply
+path — they only enrich the payload. Step 4-6 change dispatch. Step 7 is the
+frontend. Splitting it this way means a bisect that lands on step 3 has a richer
+queue and identical apply semantics.
+
+Each step is one commit and one reviewable diff.
+
+---
+
+## Step 1 — Action vocabulary + `groupSignals` extraction (no behaviour change)
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/itunes/service/regroup_actions.go` | **NEW.** `Action*` constants, `ValidChosenAction`, `DefaultActionForKind`. Pure, no imports beyond stdlib. |
+| `internal/itunes/service/fs_regroup_shape.go` | Extract the block from line 578 (`fpVotes`) through line 648 (`folderNamedAfterBook`) into `func collectSignals(members []memberInfo) groupSignals`, returning a struct. `classifyGroup`'s switch (lines 668-770) reads `sig.X` instead of the local variables. **Do not change one branch condition.** |
+| `internal/itunes/service/regroup_actions_test.go` | **NEW.** Table test over `DefaultActionForKind` for all four Kinds + an unknown kind → `""`; `ValidChosenAction` accepts the four choosable actions and rejects `insufficient-evidence`, `""`, `"COMBINE"`, `"delete"`. |
+
+### `DefaultActionForKind` table (must match `wire_handlers.go:604-607`)
+
+`regroup.multidisc`→`combine`, `regroup.anthology`→`combine`,
+`regroup.version-group`→`version-group`, `regroup.ambiguous`→`""`, unknown→`""`.
+
+### Tests
+
+```bash
+go test ./internal/itunes/service/... -race -run 'TestClassify|TestDefaultActionForKind|TestValidChosenAction' -count=1
+```
+
+**Green means:** every pre-existing test in `fs_regroup_shape_test.go`,
+`fs_regroup_booklength_test.go`, `fs_regroup_folderref_test.go` passes
+unmodified. If any of them needed editing, the refactor was not
+behaviour-preserving — revert and redo.
+
+---
+
+## Step 2 — The recommender (payload-invisible; pure function + tests)
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/itunes/service/regroup_recommend.go` | **NEW.** `RecommendationEvidence` struct (design §4.3) and `recommend(sig groupSignals, members []memberInfo) (action, reason string, ev RecommendationEvidence)` implementing rules R1-R11 in order. Reuses `bookLengthSec` (`fs_regroup_shape.go:123`) and `flatMultitrackMin` (`fs_regroup_shape.go:220`) — no new magic numbers. Every reason string interpolates the numbers that fired it. |
+| `internal/itunes/service/fs_regroup_shape.go` | `RegroupGroup` (lines 162-181) gains `RecommendedAction`, `RecommendationReason`, `Evidence`, `SurvivorTitleSource`. The `build` closure (lines 651-666) populates the first three from `recommend(sig, members)`. |
+| `internal/itunes/service/regroup_recommend_test.go` | **NEW.** See below. |
+
+### Required tests (name them exactly; these are the acceptance criteria)
+
+1. **`TestRecommend_AllDurationsUnknown_NeverCombines`** — 6 members,
+   `DurationSec == 0` on every one, flat structure, filenames `01.mp3`…`06.mp3`
+   (so `numberedCount == 6`), one shared stem (so `manyDistinctTitles` is
+   false). Assert `action == ActionInsufficientEvidence` and
+   `ev.DurationsMissing == 6`.
+   **This is the load-bearing test.** `membersAreBookLength` counts unknown
+   durations as *not* book-length (`fs_regroup_shape.go:148-159`), so with
+   durations missing the series guard is silently false and the flat branch
+   falls straight through to a confident collapse — the 41-of-43 shape
+   documented at `fs_regroup_shape.go:128-148`. R1 running before every combine
+   rule is the only thing preventing it. Do not merge without this test green.
+2. **`TestRecommend_BookLengthMembers_Separate`** — 5 members at 7200s each →
+   `separate`, reason contains `5 of 5` and `≥90 min`.
+3. **`TestRecommend_ChapterLengthMembers_Combine`** — 8 members at 900s, flat,
+   numbered, one stem → `combine`, `ev.MedianKnownSec == 900`.
+4. **`TestRecommend_MixedDurations_MajorityLong_Separate`** — 3× 7200s + 2× 600s
+   → `separate` (strict majority per R3).
+5. **`TestRecommend_MergedViaITunes_InsufficientEvidence`** — members spanning
+   two FilePath folders glued by a shared `ITunesPath` → `insufficient-evidence`.
+6. **`TestRecommend_AbridgedUnabridged_VersionGroup`**.
+7. **`TestRecommend_BoxedSet_Separate`** — folder `The Foundation Trilogy Boxed Set`,
+   3 distinct stems → `separate` (R4 beats R8).
+8. **`TestRecommend_Anthology_Combine`** — folder `… Anthology`, 5 distinct
+   stems, all short → `combine`.
+9. **`TestRecommend_DiscStructure_CombinesDespiteMissingDurations`** — the R1
+   exception: disc subfolders + `folderNamedAfterBook` → `combine` even with
+   durations unknown; assert `ev.DurationsMissing > 0` so the human sees it.
+10. **`TestRecommend_ReasonAlwaysCarriesNumbers`** — run every fixture group
+    through `recommend` and assert each reason matches `\d` at least once. A
+    reason without a number is a nicer generic string, which is the bug.
+11. **`TestRecommend_EvidenceReconciles`** — for every fixture:
+    `ev.DurationsKnown + ev.DurationsMissing == ev.Members`,
+    `ev.DiscMembers + ev.ChapterMembers + ev.FlatMembers == ev.Members`,
+    `len(ev.MemberDurationsSec) == ev.Members`. No silent filtering.
+
+```bash
+go test ./internal/itunes/service/... -race -run TestRecommend -count=1
+go test ./internal/itunes/service/... -race -count=1
+```
+
+**Green means:** all of the above pass **and** every pre-existing test in the
+package still passes untouched.
+
+---
+
+## Step 3 — Survivor title fix + payload emission
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/itunes/service/fs_regroup_shape.go` | Re-signature `deriveSurvivorTitle` (line 840) to `(folderName string, folderNamedAfterBook bool, dominantStem, dominantAuthor string) (title, source string)` per design §6. Add `bareOrdinalRe = regexp.MustCompile(`(?i)^(vol(?:ume)?\|bk\|book\|part\|pt\|disc\|cd)\s*\.?\s*\d+$`)` beside the other cleaning regexes (lines 254-258). Add `dominantAuthor` to `groupSignals` (majority `ShatterBook.Author`, `""` when no majority). Update the call site at line 660 to set both `SurvivorTitle` and `SurvivorTitleSource`. |
+| `internal/itunes/service/fs_regroup_survivortitle_test.go` | **NEW.** See below. |
+| `internal/plugins/maintenance/regroup_shattered_ai.go` | `regroupPayload` (lines 64-81) gains the four `omitempty` fields from design §4.4. `buildRegroupPayload` (lines 374-411) populates them. Add a `RECOMMEND:` histogram log line next to the existing `RECONCILE:` line (lines 220-223) — counts per action, plus `combine-with-missing-durations`, plus `survivor-title-empty` and `survivor-title-source-*`. |
+| `internal/plugins/maintenance/regroup_shattered_ai_test.go` | Extend: assert `buildRegroupPayload` round-trips the new fields, that `proposedAction` is still present and unchanged, and that a payload with the new fields still decodes into the *old* struct shape (forward-compat is free with `encoding/json`, but assert it so a future rename is caught). |
+
+### `deriveSurvivorTitle` tests (exact cases from the fragment)
+
+- `folderNamedAfterBook=false`, `dominantAuthor="C. T. Phipps"`,
+  `folderName="C. T. Phipps"`, `dominantStem=""` → `("", "none")`.
+  (The author guard fires; without a members-derived title there is nothing
+  trustworthy to emit.)
+- `folderName="Volume 1"`, `folderNamedAfterBook=true` → `("", "none")`
+  (bare-ordinal guard).
+- `folderName="The Wandering Inn Vol. 01"`, `folderNamedAfterBook=false`,
+  `dominantStem="The Wandering Inn Vol 9"` → `("The Wandering Inn Vol 9", "members")`.
+- `folderName="Dune (Unabridged) (2019)"`, `folderNamedAfterBook=true` →
+  `("Dune", "folder")`.
+- `folderName="03 - Cage of Souls - 2"`, `folderNamedAfterBook=true` →
+  `("Cage of Souls", "folder")` (existing cleaning behaviour preserved).
+- Neither signal trustworthy → `("", "none")` — **empty, never a wrong title.**
+
+```bash
+go test ./internal/itunes/service/... -race -run 'TestDeriveSurvivorTitle' -count=1
+go test ./internal/plugins/maintenance/... -race -run 'TestRegroup|TestBuildRegroupPayload' -count=1
+```
+
+**Green means:** the six cases above pass and `regroup_shattered_ai_test.go`'s
+existing assertions are unmodified.
+
+**Checkpoint.** After step 3 the queue payload is richer and the apply path is
+byte-identical. This is the first deployable-and-useful state, and the first
+half of the prod dry-run gate (§Gate A) can run here.
+
+---
+
+## Step 4 — Persist the chosen action (store layer)
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/database/review_store.go` | `ReviewItem` (lines 60-70) gains `ChosenAction string \`json:"chosen_action,omitempty"\``. Add `SetReviewItemDecision(id, status, action string) (*ReviewItem, error)`: the body of the current `SetReviewItemStatus` (lines 423-459) plus `if action != "" { item.ChosenAction = action }`. Re-implement `SetReviewItemStatus(id, status)` as `SetReviewItemDecision(id, status, "")`. **Do not construct a fresh `ReviewItem`** — the existing code already re-fetches and mutates in place (lines 427-436); keep that shape. |
+| `internal/database/iface_review.go` | Add `SetReviewItemDecision` to the `ReviewStore` interface with a doc comment stating that `action == ""` means "leave `ChosenAction` unchanged". |
+| `internal/database/mock_store.go` | Add the method to the hand-written `MockStore` (siblings at lines 2721-2728). Without this the compile-time `Store` assertion at the top of the file breaks the build. Bump the file header version. |
+| `internal/database/mocks/mock_store.go` | **Regenerate only.** `database.Store` embeds `ReviewStore` (`internal/database/store.go:57`), so the mockery mock needs the new method. |
+| `internal/database/review_store_test.go` (or nearest existing) | Tests below. |
+
+### Mock regeneration — scoped
+
+```bash
+make mocks
+git diff --stat internal/database/mocks/mock_store.go
+```
+
+The diff must touch **only** the `SetReviewItemDecision` addition. Mockery is
+pinned to v3.7.1 (Makefile:191-197); a diff that rewrites unrelated mocks means
+the wrong binary is on PATH — run `scripts/setup-mockery.sh` and redo. Never
+commit an unscoped regen.
+
+### Tests
+
+- **`TestSetReviewItemDecision_RecordsAction`** — approve with `combine`, read
+  back, `ChosenAction == "combine"`.
+- **`TestSetReviewItemStatus_PreservesChosenAction`** — set decision
+  `(approved, "separate")`, then `SetReviewItemStatus(id, applied)`;
+  `ChosenAction` must still be `"separate"`.
+- **`TestUpsertReviewItem_PreservesChosenActionOnDecidedRow`** — set decision,
+  then re-upsert the same DedupKey with a new Summary/Payload; the row must be a
+  full no-op (`review_store.go:239-242`) and `ChosenAction` intact.
+- **`TestUpsertReviewItem_PendingUpdatePreservesChosenAction`** — belt and
+  braces on the patch-in-place path (`review_store.go:245-250`).
+
+```bash
+make mocks && git diff --stat internal/database/mocks/
+go test ./internal/database/... -race -run 'TestSetReviewItem|TestUpsertReviewItem' -count=1
+go build ./...
+```
+
+**Green means:** those four tests pass, `go build ./...` succeeds (proving both
+mocks satisfy `Store`), and the mocks diff is one method.
+
+---
+
+## Step 5 — Action-keyed dispatch in the review handler
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/plugins/maintenance/regroup_apply.go` | **NEW func** `ApplySeparate() func(context.Context, database.ReviewItem) error` — decodes the payload for logging (`decodeRegroupPayload`, line 322), logs folder + member count + "members are already separate books; no library change", returns `nil`. It must perform **zero writes**; add a comment saying so. |
+| `internal/server/handlers/review/handler.go` | Rename `RegisterApplyHandler`→`RegisterActionHandler` and `applyHandlerFor`→`actionHandlerFor` (lines 77-88); the map is now keyed by action. `approveOne` (lines 179-208) takes a `chosenAction string` param and resolves per design §7.1 (explicit → payload `recommendedAction` → `DefaultActionForKind(item.Kind)`), dispatches on the resolved action, and calls `SetReviewItemDecision(id, status, resolved)`. `ApproveReviewItem` (lines 154-174) binds the optional body with `_ = c.ShouldBindJSON(&req)` — **the pattern at `replay.go:58`, not a hard bind**; returns 400 `INVALID_REVIEW_ACTION` when `req.Action != "" && !ValidChosenAction(req.Action)`; adds `"action": resolved` to the response. `bulkRequest` (lines 232-236) gains `ItemAction string \`json:"item_action,omitempty"\``; `bulkResult` gains `ByAction map[string]int \`json:"by_action,omitempty"\``. |
+| `internal/server/handlers/review/replay.go` | Lines 80 and 116: dispatch via `actionFor(it)` (`it.ChosenAction` → payload `recommendedAction` → `DefaultActionForKind(it.Kind)`) instead of `it.Kind`. Add `would_replay_by_action` / `applied_by_action` to the two responses. |
+| `internal/server/wire_handlers.go` | Lines 603-607 → three `RegisterActionHandler` calls (`combine`, `version-group`, `separate`) per design §7.4. Rewrite the comment block above it (lines 590-602) to explain action-keyed dispatch. |
+| `internal/server/handlers/review/handler_test.go` | Extend (real `PebbleStore`, per the file's existing approach at lines 30-38). |
+| `internal/server/handlers/review/replay_test.go` | Extend for the action-aware replay. |
+
+### Required tests
+
+- **`TestApprove_EmptyBody_NoContentType_Still200`** — the F7 regression. Use
+  `doReq(..., nil, ...)` (helper at line 55), which sends no body and no
+  `Content-Type`.
+- **`TestApprove_LegacyAmbiguousPayload_NoDispatch`** — a `regroup.ambiguous`
+  item whose payload has no `recommendedAction`: status `approved`, note
+  mentions no handler, **no apply function invoked**. Byte-identical to today.
+- **`TestApprove_UsesRecommendationWhenNoBody`** — ambiguous item with
+  `recommendedAction: "separate"`, `separate` handler registered, switch ON →
+  handler ran, status `applied`, `chosen_action == "separate"`.
+- **`TestApprove_ExplicitActionOverridesRecommendation`** — payload recommends
+  `combine`, body says `{"action":"separate"}` → the **separate** handler ran,
+  the combine handler did not. Assert with two closures recording invocation.
+- **`TestApprove_InvalidAction_400`** — `{"action":"insufficient-evidence"}` and
+  `{"action":"delete"}` both 400, and the item's status is **unchanged**.
+- **`TestApprove_SwitchOff_RecordsChosenAction`** — switch OFF, body
+  `{"action":"separate"}` → status `approved`, `chosen_action == "separate"`,
+  no handler invoked.
+- **`TestReplayApproved_DispatchesStoredChosenAction`** — the F3 regression, and
+  the reason D5 exists. Seed the item from the previous test's end state, flip
+  the switch on, `POST /review/replay-approved {"apply":true}` → the
+  **separate** handler runs, not the Kind default. Assert `applied_by_action`
+  is `{"separate":1}`.
+- **`TestBulk_NoItemAction_UsesKindDefault`** — bulk approve over a kind whose
+  items recommend `combine`, with no `item_action`: dispatch must use
+  `DefaultActionForKind`, i.e. today's behaviour (D6).
+- **`TestBulk_ItemAction_AppliedToAll`** + **`TestBulk_InvalidItemAction_400`**.
+- **`TestApplySeparate_WritesNothing`** (in `regroup_apply_test.go`) — run
+  `ApplySeparate()` against a store seeded with N books; assert every book row
+  is byte-identical afterwards and no `book_file` row changed.
+
+```bash
+go test ./internal/server/handlers/review/... -race -count=1
+go test ./internal/plugins/maintenance/... -race -run 'TestApplySeparate|TestApplyMultidisc|TestApplyVersionGroup' -count=1
+go test ./internal/server/... -race -count=1
+```
+
+**Green means:** all of the above pass **and** the pre-existing approve/bulk
+tests (`handler_test.go:137-344`) pass with at most a mechanical rename of
+`RegisterApplyHandler` — if any of their **assertions** had to change, dispatch
+semantics regressed for an existing Kind.
+
+---
+
+## Step 6 — API client + payload types (frontend, no UI yet)
+
+### Files
+
+| File | Intent |
+|---|---|
+| `web/src/lib/reviewActions.ts` | **NEW.** Mirrors `reviewKinds.ts:8-13`. `REVIEW_ACTIONS` (the five strings), `CHOOSABLE_ACTIONS` (four), `ACTION_LABELS` (`combine`→"Combine into one book", `separate`→"Keep separate", `version-group`→"Link as versions", `duplicate-of`→"Duplicate of another book", `insufficient-evidence`→"Not enough evidence"), `labelForAction`. |
+| `web/src/lib/reviewPayload.ts` | Add `recommendedAction?`, `recommendationReason?`, `recommendationEvidence?: RecommendationEvidence`, `survivorTitleSource?` to `ReviewPayload` (lines 17-32). Add `RecommendationEvidence` interface mirroring design §4.3 with every field optional (an old hold has none). Add `recommendationOf(payload)` returning `{action, reason, evidence} | null`. Update the file's header comment, which currently enumerates the producer's keys. |
+| `web/src/services/api.ts` | `approveReviewItem(id, action?)` (line 5899): when `action` is given, send `headers: {'Content-Type': 'application/json'}` and `body: JSON.stringify({action})` — the header matters; the current call sends neither (lines 5900-5902). `ReviewBulkRequest` gains `item_action?`; `ReviewBulkResult` gains `by_action?`. `ReviewItem` gains `chosen_action?: string`. |
+| `web/src/lib/__tests__/reviewPayload.test.ts` | Extend: an old payload (the existing fixture at line 20) yields `recommendationOf() === null`; a new payload yields the parsed triple; a malformed `recommendationEvidence` (string instead of object) does not throw. |
+| `web/src/lib/__tests__/reviewActions.test.ts` | **NEW.** `labelForAction` covers all five and falls back readably for an unknown string. |
+
+```bash
+cd web && npx vitest run src/lib/__tests__/reviewPayload.test.ts src/lib/__tests__/reviewActions.test.ts
+cd web && npx tsc --noEmit
+```
+
+**Green means:** both suites pass and `tsc` is clean.
+
+---
+
+## Step 7 — Review-queue UI
+
+### Files
+
+| File | Intent |
+|---|---|
+| `web/src/pages/ReviewQueue.tsx` | In `MemberFilesDetail` (lines 160-242): above the existing "Proposed action" row (lines 205-210), render a **Recommendation** block — a Chip with `labelForAction(recommendedAction)` (colour: `combine`→primary, `separate`→info, `insufficient-evidence`→warning), the reason sentence, and a compact evidence grid (members, durations known/missing, book-length members, distinct titles, numbered, structure, folder-named-after-book). Keep `proposedAction` rendered below as legacy context. Show `survivorTitle` only when `survivorTitleSource !== 'none'`; when it is `'none'`, render "Proposed title: (not derivable)" rather than a blank. In `ItemActions` (lines 329-360): replace the single Approve button with a split button — primary action = the recommendation (label `Approve: <action label>`), dropdown = the other three choosable actions; `handleItemAction` (line 277) passes the chosen action to `api.approveReviewItem`. When `recommendedAction === 'insufficient-evidence'`, the primary button is **disabled** with a tooltip "not enough evidence yet — leave pending"; Reject stays available but is **not** styled as the suggested path (D4/F5). Bucket header (lines 405-426): "Approve all" opens a menu requiring an explicit action, sent as `item_action` (D6). |
+| `web/src/lib/reviewKinds.ts` | Unchanged — the four Kind labels stay verbatim (D1). Listed here so a reviewer knows the omission is deliberate. |
+| `web/src/pages/__tests__/ReviewQueue.test.tsx` | **NEW** if absent. Render a hold with a recommendation → the chip, reason and evidence numbers appear; clicking `Approve: Keep separate` calls `approveReviewItem(id, 'separate')`; an `insufficient-evidence` hold has a disabled primary button; a legacy payload (no recommendation) renders exactly the old layout. |
+
+```bash
+cd web && npx vitest run src/pages/__tests__/ReviewQueue.test.tsx
+make web-test
+make test-all-short
+```
+
+**Green means:** the new suite passes, `make web-test` is clean, and
+`make test-all-short` is green.
+
+---
+
+## Step 8 — Docs, changelog, TODO
+
+| File | Intent |
+|---|---|
+| `changelog.d/<scriv-fragment>.md` | Required by `changelog-check.yml`. Run `scriv create`. |
+| `todo.d/20260805_220000_review_queue_recommendations_and_overrides.md` | Leave it — `TODO.md` fragments are add-only; the checkbox is ticked in `TODO.md` directly once merged. |
+| `docs/executive-summaries/2026-08.md` | Update. This qualifies: multi-file, wide blast radius (it changes what the Approve button does), and it closes owner items 1+2. Plain language, no jargon. |
+| `.claude/notes/2026-08-05-first-aid-architecture.md` | Add a line under "Shipped so far". |
+
+---
+
+## Full pre-merge verification
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.worktrees/review-recommendations
+go build ./...
+go test ./internal/itunes/service/... -race -count=1
+go test ./internal/plugins/maintenance/... -race -count=1
+go test ./internal/server/handlers/review/... -race -count=1
+go test ./internal/database/... -race -run 'TestReview|TestUpsertReviewItem|TestSetReviewItem' -count=1
+make mocks-check
+make ci
+```
+
+`make ci` = `mocks-check check-mock-fresh staticcheck sdkguard test-all-short
+coverage-check-short` (Makefile:350). Note that local `staticcheck` is red on
+`main` itself; the authoritative gate is GitHub's **Minimal CI**. Compare
+`staticcheck` output against a `main` baseline rather than treating any output
+as a blocker.
+
+---
+
+## Deployment
+
+Deploy from the **primary checkout**, not the worktree — `Makefile.local`'s
+`LOCAL_ROOT` is hardcoded to the main checkout, so deploying from a worktree
+ships main's binary.
+
+```bash
+cd /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer
+git checkout main && git pull --ff-only
+make deploy
+```
+
+`review_apply_enabled` stays **OFF** for the whole of this workstream.
+
+---
+
+## Dry-run acceptance gate
+
+Two gates. **Gate A** can run after step 3 (payload-only). **Gate B** runs after
+step 7 and is the one that must pass before anyone considers flipping
+`review_apply_enabled` (which is owner item 3's canary, not this workstream).
+
+### Before: capture the baseline
+
+From the **current** prod binary, before deploying, save the last
+`maintenance.regroup-shattered-ai` run's `RECONCILE:` and result lines
+(`regroup_shattered_ai.go:220-223, 274-279`). In particular record the exact
+`bykind=map[...]` string and `groups=`.
+
+Reference numbers already measured on 2026-08-05:
+
+- **Pre-relink:** 777 holds, 762 (98.1%) carrying the single generic string
+  `review: flat folder shares a title but ordering is unclear`.
+- **Post-relink (current):** queue 357 → **356**; member duration coverage 2.5%
+  → **92.2%**.
+
+Do not conflate the two: 762/777 measures the *problem*; **356** is what the
+post-change dry-run must reproduce.
+
+### Gate A — payload enrichment (after step 3)
+
+Run the dry-run (no apply flag exists; the op is dry-run only by construction —
+`regroup_shattered_ai.go:83-104` declares only `CapLibraryRead`):
+
+```bash
+TOKEN=$(cat /Users/jdfalk/repos/github.com/jdfalk/audiobook-organizer/.claude/.api-token)
+# Enqueue: POST /api/v1/operations/v2 {def_id, params} -> {"op_id": "..."}
+#   (internal/server/wire_operations_routes.go:27, internal/server/handlers/operations_v2.go:149-164)
+OP=$(curl -sS -X POST https://<host>/api/v1/operations/v2 \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.regroup-shattered-ai","params":{}}' | python3 -c 'import json,sys;print(json.load(sys.stdin)["op_id"])')
+# Logs: GET /api/v1/operations/:id/logs
+curl -sS "https://<host>/api/v1/operations/$OP/logs?tail=200" -H "Authorization: Bearer $TOKEN"
+```
+
+Then read the op log for the `RECONCILE:`, `RECOMMEND:` and result lines.
+**All six must hold:**
+
+| # | Assertion | Threshold |
+|---|---|---|
+| A1 | `bykind=` map is **identical** to the pre-deploy baseline capture | exact string equality, no tolerance |
+| A2 | `groups=` equals the **pre-deploy baseline capture**, exactly | Compare against the number you captured minutes earlier, **not** a literal. 356 is the 2026-08-05 reference, not the gate value — the library changes between runs, and an engineer who captures 361 and sees 361 must pass, not halt (and must never "fix" the classifier to hit 356). Any drift from *your own* baseline means the `groupSignals` refactor perturbed the Kind switch — stop. |
+| A3 | New `RECOMMEND:` histogram counts sum to `groups=` | exact: `combine + separate + version-group + insufficient-evidence == groups` |
+| A4 | Holds recommending `combine` while `durationsMissing*2 > members` | **exactly 0** — this is the direct guard on the 41-of-43 incident |
+| A5 | Holds whose `survivorTitle` equals their dominant member author | **exactly 0** |
+| A6 | Every hold carries a non-empty `recommendationReason` | **100%** (this one cannot fail after step 3 — it is a smoke check that the field is wired, not a quality bar) |
+| A7 | Distinct `(recommendedAction, recommendationReason)` pairs across all holds | **≥ 6**. This is the gate with teeth and the actual restatement of the problem: the pre-relink queue had **1** distinct string on 762 of 777 holds (98.1%). If R11 (`insufficient-evidence`, the catch-all) absorbs everything you get 1-2 pairs and this fires. |
+
+Plus one distributional sanity check that is informative, not blocking:
+`insufficient-evidence` should be a **minority** of the 356 now that duration
+coverage is 92.2%. If it is >60%, R1's majority threshold is mis-tuned against
+real data — investigate before proceeding, do not just relax the rule.
+
+Verification query for A3-A7 (read-only, run against the live API):
+
+```bash
+curl -sS "https://<host>/api/v1/review/items?status=pending&limit=1000" \
+  -H "Authorization: Bearer $(cat .claude/.api-token)" \
+| python3 -c '
+import json,sys,collections
+items=json.load(sys.stdin)["items"]
+hist=collections.Counter(); bad_combine=0; empty_title=0; src=collections.Counter()
+for it in items:
+    p=json.loads(it["payload"] or "{}")
+    a=p.get("recommendedAction",""); hist[a]+=1
+    e=p.get("recommendationEvidence") or {}
+    if a=="combine" and e.get("durationsMissing",0)*2 > e.get("members",0): bad_combine+=1
+    if not p.get("survivorTitle"): empty_title+=1
+    src[p.get("survivorTitleSource","")]+=1
+print("total",len(items)); print("hist",dict(hist))
+print("A4 combine-with-missing-durations",bad_combine)
+print("empty survivorTitle",empty_title,"sources",dict(src))
+'
+```
+
+A4 must print `0`.
+
+### Gate B — dispatch + UI (after step 7)
+
+With `review_apply_enabled` still **OFF**:
+
+| # | Assertion | How |
+|---|---|---|
+| B1 | Approving a hold with no body still returns 200 and does not merge | approve one `regroup.multidisc` hold; assert status `approved`, note mentions review-only mode, and the member Book IDs still resolve via `GET /api/v1/audiobooks/<id>` |
+| B2 | An explicit override is recorded | approve one `regroup.ambiguous` hold with `{"action":"separate"}`; `GET /review/items?status=approved` shows `chosen_action: "separate"` |
+| B3 | Replay dry-run sees the stored action | `POST /review/replay-approved` (no body) → `would_replay_by_action` includes `separate: 1`; `dry_run: true`; **nothing applied** |
+| B4 | Nothing was written to the library | `GET /api/v1/audiobooks?limit=1` `total` unchanged from before Gate B |
+| B5 | Human agreement sample | the owner opens 20 holds spanning all four Kinds and agrees with **≥18** recommendations. Below 18 → retune the rules, do not proceed |
+| B6 | No hold under `books/itunes/` | `skipped-frozen-itunes=` in the result line is >0 and no pending hold's `folder_ref` contains `books/itunes/` |
+
+**Only after B1-B6 pass** may `review_apply_enabled` be considered — and that
+decision belongs to owner item 3's multidisc canary
+(`todo.d/20260805_220100_multidisc_apply_canary.md`), with its own before/after
+snapshot. This workstream never flips it.
+
+---
+
+## Rollback
+
+| Situation | Action |
+|---|---|
+| Gate A fails A1 (bykind drift) | The step-1 `groupSignals` extraction was not behaviour-preserving. `git revert` the step-1 commit and redo mechanically, one local variable at a time, re-running `go test ./internal/itunes/service/... -race` after each. |
+| Gate A fails A4 (combine with missing durations) | Rule ordering bug in `recommend`. Revert step 2's commit only — steps 1 and 3 are independent — fix R1's placement, re-run. No prod state to undo: the op writes only review rows. |
+| Recommendations are wrong but harmless | Nothing to roll back on the data side. Deploy the previous binary and re-run the dry-run: `UpsertReviewItem` patches pending rows in place (`review_store.go:245-250`), so the old payloads simply overwrite the new ones. **Decided rows are untouched** (`review_store.go:239-242`). |
+| Dispatch regression after step 5 | Revert the step-5 commit. `ChosenAction` (step 4) is additive and harmless on its own — an unused field. |
+| A wrong merge actually happened | Only possible if someone flipped `review_apply_enabled`, which this plan forbids. `CombineBooks` hard-deletes absorbed Book rows (`regroup_apply.go:28`); **the files are not deleted**, so the recovery path is a rescan, which regenerates a Book for any file no `book_file` row claims. Do **not** attempt to reconstruct rows by hand. |
+| Mocks diff is larger than one method | Wrong mockery binary. `bash scripts/setup-mockery.sh`, `git checkout internal/database/mocks/`, `make mocks` again. |
+
+**What is genuinely irreversible here:** nothing, as long as
+`review_apply_enabled` stays OFF. That is the whole reason the switch exists and
+the reason this plan does not touch it.
+
+---
+
+## Ship
+
+```bash
+git push -u origin feat/review-queue-recommendations
+gh pr create --title "feat(review): structured recommendations + per-hold override actions" --body "..."
+gh pr merge <n> --rebase        # this repo is rebase/FF only
+git checkout main && git pull --ff-only
+make deploy                     # from the PRIMARY checkout
+git worktree remove .worktrees/review-recommendations && git worktree prune
+```

--- a/docs/specs/2026-08-05-duplicate-detect-version-group-design.md
+++ b/docs/specs/2026-08-05-duplicate-detect-version-group-design.md
@@ -1,0 +1,716 @@
+<!-- file: docs/specs/2026-08-05-duplicate-detect-version-group-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b4df2a8c-aeae-4969-ba81-5368a61332c3 -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Design — Duplicate detection, combine-by-template, version-group ("The Successors" class)
+
+**Workstream slug:** `duplicate-detect-version-group`
+**Tier:** First Aid tier 2 (escalation) + tier 3 (fixer)
+**Source fragment:** `todo.d/20260805_220300_first_aid_library_validate_repair.md:59-69` ("Never delete — re-associate")
+**Architecture:** `.claude/notes/2026-08-05-first-aid-architecture.md` (§"Never delete — re-associate", decisions D2/D3/D5)
+**Measurements:** `.claude/notes/2026-08-05-unlinked-books-investigation.md` (§"The Successors — a third shape")
+
+---
+
+## 1. Problem statement
+
+### 1.1 The measured case
+
+Measured on prod 2026-08-05 (`.claude/notes/2026-08-05-unlinked-books-investigation.md:87-108`):
+
+Book `01KQAXKG7HYMT44GRNCGSJBXG1` at `/mnt/bigdata/books/newbooks/audiobooks/The Successors`
+is a **correctly assembled** Warhammer anthology: 13 `book_file` rows, track numbers 1–13
+in order, each carrying its own story title, 10h42m total. Its only defect is that
+`Book.Title` reads **"The Empty Place"** — story 1's name, inherited at import.
+
+Coexisting with it, in the same library:
+
+| Cohort | Rows | Files | Note |
+|---|---|---|---|
+| shattered single-story rows under `/books/audiobook-organizer/…` | ~8 | ~8 | one story each |
+| `01KQGD0Z4GV9KN77W3VVAQMM7Q` | 1 | 4 | every file named `2.mp3`; durations 2474/1620/3018/868 s match reference tracks **3, 4, 6, 13** |
+| other debris rows | balance of 11 | balance of 17 | — |
+| **debris total** | **11** | **17** | covers **12 of 13** reference tracks (track 7 absent); **5** files are internally redundant (two files claim one reference track) |
+| rows under frozen `books/itunes/**` | 10 | — | **hands off**, must never be touched |
+
+So the user sees 11+ tiles all reading "The Successors" next to one tile reading
+"The Empty Place" which is the only correct row in the set.
+
+### 1.2 Why the existing machinery gets this class wrong
+
+- `maintenance.regroup-shattered-ai` only ever proposes **combine** (`regroup.multidisc`,
+  `regroup.anthology`) or **link editions** (`regroup.version-group`)
+  (`internal/itunes/service/fs_regroup_shape.go:70-74`). Neither is right here: combining
+  debris *into* the reference would pour 17 partly-redundant files onto a book that is
+  already correct; separating does nothing.
+- The debris and the reference live in **different folders**, so the folder-grouping
+  classifier never sees them as one group at all
+  (`fs_regroup_shape.go:23-31` — the grouping key is the book folder).
+- `maintenance.orphan-book-files-cleanup`, `reconcile-scan` and `file-integrity-check`
+  all report every one of these rows healthy — each row has a file, and the file exists
+  (`.claude/notes/2026-08-05-unlinked-books-investigation.md:76-85`).
+- Deleting the debris rows is **not idempotent**: rescan regenerates a book for any file
+  no `book_file` row claims, so the rows come straight back
+  (`internal/linkintegrity/report.go:60-70`).
+
+### 1.3 What this workstream builds
+
+Three things, in dependency order:
+
+1. **`internal/dupmatch`** — a pure, I/O-free package that answers "do these debris
+   tracks map onto that reference book's track list?", matching **by duration**, never
+   by guessing boundaries from filenames.
+2. **`maintenance.detect-redundant-copies`** — a tier-2 detector op. Whole-library,
+   bounded worker pool, **writes zero book/file rows**; its only writes are idempotent
+   review-queue holds of a new Kind `firstaid.redundant-copy`.
+3. **`ApplyRedundantCopy`** — the tier-3 fixer, registered as the review-queue apply
+   handler for that Kind: combine the debris into ONE book using the reference's track
+   list as a template, then version-group that combined book with the reference,
+   primary = most complete.
+
+---
+
+## 2. Locked decisions
+
+Each decision names the evidence that forced it.
+
+### LD1 — Match by **duration**, never by filename boundaries
+
+The debris fragment `01KQGD0Z4GV9KN77W3VVAQMM7Q` has four files **all named `2.mp3`**.
+Filenames carry zero boundary information here. Their durations (2474/1620/3018/868 s)
+identify tracks 3/4/6/13 unambiguously. The fragment
+(`todo.d/20260805_220300_first_aid_library_validate_repair.md:65-67`) makes this
+explicit: "matching by duration instead of guessing boundaries from filenames (the path
+that produced the 41-of-43 near-miss)".
+
+Filename/title stems are used **only as corroborators**, never as the primary key.
+
+### LD2 — Duration **source class** is part of the match, and unknown never matches
+
+There are two duration sources on a `book_file` row and they are not interchangeable:
+
+| Source | Field | Trust |
+|---|---|---|
+| fingerprint | `BookFile.AcoustIDFingerprintDurationSec` (`internal/database/store.go:735`) | real decode duration measured by fpcalc; authoritative |
+| container | `BookFile.Duration` (`internal/database/store.go:717`), passed through `database.NormalizeDurationSec` (`internal/database/duration_sanity.go:61`) | container metadata; **historically ~2× too short for m4b/m4a** — the entire reason `maintenance.duration-reextract` exists (`internal/plugins/maintenance/duration_reextract.go:8-13`) |
+
+Rules:
+
+- **both sides fingerprint** → tolerance `TolFingerprintSec` (ships at 2, locked by the
+  §6 dry-run histogram) → tier `confirmed`.
+- **mixed, or both container** → tolerance `TolContainerSec` (ships at 5) **and at least
+  one non-duration corroborator required** → tier `probable`.
+- **either side unknown** (`AcoustIDFingerprintDurationSec == 0` and `Duration <= 0`) →
+  **NO MATCH**. Not "refuted": counted as `skipped-no-duration`, reported by file ID,
+  and the report names `maintenance.duration-reextract` as the op that produces the
+  missing input.
+
+> 🔴 This is CLAUDE-rule 3 ("absent evidence must never mean negative evidence")
+> implemented, not gestured at. The prior violation cost a whole review queue: a
+> `DurationSec == 0` silently disabled `membersAreBookLength` across 97.5% of it
+> (`internal/linkintegrity/report.go:20-29`).
+
+### LD3 — Frozen iTunes rows are excluded from **both** the debris set and the reference set
+
+`books/itunes/**` is externally managed and marked Frozen
+(`internal/config/itunes_libraries.go:83-98`). `regroup_shattered_ai.go:191` already
+excludes it at the source, and that fix removed 561 of 777 bogus ambiguous holds
+(commit `786aa73d`).
+
+Excluding it from the **reference** side too is not obvious but is required: a frozen
+book chosen as version-group primary would take an `UpdateBook` on a frozen row
+(`ApplyVersionGroup` mutates `VersionGroupID` + `IsPrimaryVersion`,
+`regroup_apply.go:267-279`). Test both `BookFile.FilePath` **and** `BookFile.ITunesPath`,
+mirroring `regroup_shattered_ai.go:191`.
+
+Excluded rows are **counted and reported per hold** (`excludedFrozen`), never silently
+dropped — otherwise the operator cannot tell "we ignored 10 iTunes rows" from "there
+were no iTunes rows".
+
+### LD4 — The reference is **never** a member of the `CombineBooks` call
+
+`merge.Service.CombineBooks` hard-deletes every absorbed row and moves its files onto
+the survivor (`internal/merge/service.go:336-437`). If the reference ever appears in
+`bookIDs`, the correct 13-track assembly is destroyed — either it absorbs 17 redundant
+debris files, or (worse, if it is not `primaryID`) it is itself deleted.
+
+Sequence is therefore strictly: **combine debris-only → then version-group the debris
+survivor with the untouched reference.** An explicit guard asserts
+`referenceID ∉ debrisBookIDs` and errors before any write; a unit test pins it.
+
+**Why hard-deleting the 10 absorbed *debris rows* is not the forbidden delete.** CLAUDE
+rule 4 forbids deleting to resolve a duplicate because rescan regenerates a book for any
+file no `book_file` row claims. Here the files move first, and `CombineBooks` refuses the
+delete if the row still owns files:
+`"book %s still owns %d files after move; aborting delete"` (`internal/merge/service.go:430`).
+Every file keeps an owning `book_file` row throughout, so there is nothing for rescan to
+regenerate. The rule is about orphaning **files**, not about **rows**.
+
+### LD5 — The detector consumes **stored** durations only. No ffprobe.
+
+The measured case works from stored values: the fragment's durations
+(2474/1620/3018/868) are already in the DB. Consequences of this decision, all
+deliberate:
+
+- the op declares `sdk.CapLibraryRead` only — **not** `CapFilesRead` — so it cannot
+  touch the filesystem even by accident;
+- a whole-library pass stays a pure-DB pass (fast enough to run repeatedly during
+  calibration);
+- probing is left to the tier-2 duration-probe workstream and to the First Aid
+  orchestrator's missing-input triggering, which is the correct owner
+  (`.claude/notes/2026-08-05-first-aid-architecture.md:42-66`).
+
+Do not "fix" this later by adding an ffprobe fallback inside the detector. If durations
+are missing, run `maintenance.duration-reextract` and re-run the detector — that is the
+convergence property the whole First Aid design rests on.
+
+### LD6 — Version-group primary = **most complete**, ties to earliest ULID
+
+Owner decision D2 (`.claude/notes/2026-08-05-first-aid-architecture.md:76-77`).
+Completeness is measured as **(matched template slots, then file count)** — never as
+summed duration, which a single mis-tagged long file distorts. Reference 13 slots beats
+combined-debris 12 slots, so the reference wins and stays primary.
+
+> ⚠️ `ApplyVersionGroup` does **not** currently implement D2. `regroup_apply.go:258-263`
+> picks the smallest ULID unconditionally — "earliest ULID", full stop. It cannot be
+> reused as-is, and it must not be copy-pasted: its three hard-won invariants
+> (group-reuse, cross-group refusal `regroup_apply.go:236-245`, stale-primary demotion
+> `regroup_apply.go:286-312`) would then exist twice and drift. §4.4 extracts them into
+> one helper with the primary selector injected.
+
+### LD7 — Template numbering is a **new** step, not `applyDiscTrackNumbers`
+
+`applyDiscTrackNumbers` has a group-level bail-out: if **any** survivor file already
+carries a non-zero disc or track number, the whole set is left alone
+(`regroup_apply.go:155-162`). That is correct for its own use case and fatal for ours:
+`maintenance.relink-unlinked-books` stamps `track = i+1` on every file it creates for a
+directory-shaped book (`internal/plugins/maintenance/relink_unlinked.go:355`), so most
+combined debris survivors arrive already numbered and the reused function would silently
+number nothing.
+
+The new step is per-file, not group-level, and its doc comment must say why — or someone
+will "simplify" it back into the shared helper.
+
+### LD8 — One review Kind, `firstaid.redundant-copy`
+
+A second Kind (e.g. `firstaid.internally-redundant`) would need a second frontend label
+and a second apply handler with no defined action. The internally-redundant files are
+reported **inside** the one hold's payload (`internallyRedundant: [{fileId,
+duplicateOfTrack}]`) and are a declared non-goal to resolve (§7).
+
+### LD9 — Dry-run by default; there is no apply flag on the detector at all
+
+Owner decision D3 (`.claude/notes/2026-08-05-first-aid-architecture.md:78-80`). The
+detector is a review-queue producer, exactly like `regroup-shattered-ai`
+(`internal/plugins/maintenance/regroup_shattered_ai.go:16-19`). The apply path is the
+review queue's own approve button, which is itself gated by the global switch
+`config.ReviewApplyEnabled` — **default OFF and not set in prod**. Shipping the apply
+handler therefore changes nothing in prod until that switch is deliberately flipped
+(`internal/server/handlers/review/handler.go:16-23`, `internal/server/wire_handlers.go:588`).
+
+### LD10 — Every count reconciles
+
+`examined == matched + unmatched + skipped-no-duration + skipped-frozen + skipped-short + errors`,
+asserted in-process and logged as a `RECONCILE:` line, mirroring
+`relink_unlinked.go:216-224` and `regroup_shattered_ai.go:214-218`. A run whose numbers
+do not add up returns an error rather than reporting success.
+
+---
+
+## 3. Data model
+
+### 3.1 `internal/dupmatch` (new package, pure, no I/O)
+
+```go
+// DurSource records WHICH stored field a duration came from. Comparing a
+// fingerprint duration against a container duration is not comparing like with like.
+type DurSource string
+
+const (
+    SourceFingerprint DurSource = "fingerprint" // BookFile.AcoustIDFingerprintDurationSec
+    SourceContainer   DurSource = "container"   // BookFile.Duration via NormalizeDurationSec
+    SourceUnknown     DurSource = "unknown"     // neither present -> never matches (LD2)
+)
+
+// Track is the slim per-file view the matcher reasons over. Deliberately NOT a
+// database.BookFile: the index holds one of these per file for the whole library
+// (~275K rows), so it must stay small.
+type Track struct {
+    FileID    string
+    BookID    string
+    Path      string
+    TitleStem string // linkintegrity.TitleStem(BookFile.Title), falling back to basename
+    Author    string // Book-level display author, for corroboration only
+    DurSec    int
+    Source    DurSource
+    FileSize  int64
+}
+
+type Tier string
+
+const (
+    TierConfirmed Tier = "confirmed" // both sides fingerprint, |delta| <= TolFingerprintSec
+    TierProbable  Tier = "probable"  // mixed/container within TolContainerSec + >=1 corroborator
+)
+
+// Assignment is one debris file placed (or contested) against one reference slot.
+type Assignment struct {
+    DebrisFileID  string
+    DebrisBookID  string
+    RefTrackIndex int // 1-based index into the reference's ordered track list
+    RefFileID     string
+    DeltaSec      int
+    Tier          Tier
+    Corroborators []string // subset of {"title-stem","fingerprint","author","filesize"}
+    Redundant     bool     // lost the contest for this slot; keeps RefTrackIndex for reporting
+}
+
+type SkipReason string
+
+const (
+    SkipNoDuration      SkipReason = "no-duration"       // LD2: run maintenance.duration-reextract
+    SkipTooShort        SkipReason = "below-min-length"  // duration alone is not evidence
+    SkipAmbiguousBucket SkipReason = "ambiguous-bucket"  // >MaxBucketFanout candidates at this length
+    SkipNoSlot          SkipReason = "no-matching-slot"
+    SkipNoCorroborator  SkipReason = "single-file-no-corroborator"
+)
+
+type Skip struct {
+    FileID string
+    Reason SkipReason
+}
+
+type TemplateResult struct {
+    Assignments   []Assignment // includes Redundant ones
+    Skipped       []Skip
+    CoveredSlots  []int // sorted, distinct, non-redundant
+    MissingSlots  []int // reference slots no debris file claimed
+    Histogram     DeltaHistogram
+}
+
+type Config struct {
+    TolFingerprintSec int // default 2   — LOCKED only after the §6 histogram gate
+    TolContainerSec   int // default 5
+    ProbeToleranceSec int // default 10  — histogram width; >= both tolerances above
+    MinMatchableSec   int // default 60  — below this, duration alone is not evidence
+    MaxBucketFanout   int // default 64  — see LD-index trap below
+}
+
+// MatchTemplate is the whole matcher. Deterministic: identical inputs -> identical output.
+func MatchTemplate(ref []Track, debris []Track, cfg Config) TemplateResult
+
+// DeltaHistogram buckets |delta| in seconds so a dry run can show WHERE the mass sits
+// before a tolerance is locked. Render() is deterministic and diff-friendly.
+type DeltaHistogram map[int]int
+func (h DeltaHistogram) Add(deltaSec int)
+func (h DeltaHistogram) Render() string
+func (h DeltaHistogram) FractionWithin(sec int) float64
+
+// PrimaryCandidate + PickMostComplete implement owner decision D2 (LD6).
+type PrimaryCandidate struct {
+    BookID        string
+    MatchedTracks int // template slots this book covers
+    FileCount     int
+}
+func PickMostComplete(c []PrimaryCandidate) string
+```
+
+**`MatchTemplate` algorithm** (deterministic, no map iteration in the output path):
+
+1. Reference slots are 1-based indices into `ref`, which the caller supplies ordered by
+   `(TrackNumber, FilePath)`.
+2. For each debris track: `Source == SourceUnknown` → `Skip{SkipNoDuration}`;
+   `DurSec < MinMatchableSec` → `Skip{SkipTooShort}`.
+3. Candidate pairs = every (debris, slot) with `|delta| <= tol(pairSources)` where
+   `tol = TolFingerprintSec` if both sides are `SourceFingerprint`, else `TolContainerSec`.
+   Every considered delta within `ProbeToleranceSec` is fed to the histogram, whether or
+   not it is accepted — that is what makes the histogram usable for calibration.
+4. A debris track whose candidate-slot count exceeds `MaxBucketFanout` →
+   `Skip{SkipAmbiguousBucket}` (see §5 trap 2).
+5. Mixed/container pairs with zero corroborators are dropped.
+6. Sort candidate pairs by `(tierRank, |delta|, -FileSize, -DurSec, DebrisFileID)` — a
+   total order with no ties, so the result is reproducible.
+   `-FileSize, -DurSec` encodes the architecture note's rule: "when two files claim one
+   reference track, prefer the longer/larger and hold the loser"
+   (`.claude/notes/2026-08-05-first-aid-architecture.md:104-107`).
+7. Greedy assign in that order. First claimant of a slot wins; a later claimant of the
+   same slot is emitted with `Redundant = true` and its `RefTrackIndex` retained.
+8. Debris tracks with no accepted pair → `Skip{SkipNoSlot}`.
+9. `CoveredSlots` / `MissingSlots` are derived from non-redundant assignments.
+
+**Corroborators** (computed by the caller, passed on the `Track`, evaluated in the matcher):
+
+| Corroborator | Test |
+|---|---|
+| `title-stem` | `linkintegrity.TitleStem` of the debris file's `BookFile.Title` (or basename) equals the reference slot's stem, and is non-empty |
+| `fingerprint` | both rows have non-empty `AcoustIDFingerprint` and they are byte-identical |
+| `author` | debris `Book` author equals reference `Book` author, case-folded, non-empty |
+| `filesize` | `\|sizeA - sizeB\| / max(sizeA,sizeB) <= 0.02` and both non-zero |
+
+Absence of a corroborator is never negative evidence — it only fails to *raise* the tier.
+
+### 3.2 Review hold payload (`firstaid.redundant-copy`)
+
+Written by the detector, read by the frontend and by the apply handler. camelCase, per
+the existing producer convention (`web/src/lib/reviewPayload.ts:10-15`).
+
+```jsonc
+{
+  "referenceBookId": "01KQAXKG7HYMT44GRNCGSJBXG1",
+  "referenceTitle": "The Empty Place",
+  "referencePath": "/mnt/bigdata/books/newbooks/audiobooks/The Successors",
+  "referenceTrackCount": 13,
+  "referenceDurationSec": 38520,
+  "referenceTitleLooksInherited": true,   // Book.Title == track-1 BookFile.Title (report only, §7)
+  "debrisBookIds": ["01KQGD0Z4GV9KN77W3VVAQMM7Q", "..."],
+  "debrisFileCount": 17,
+  "coveredTracks": [1,2,3,4,5,6,8,9,10,11,12,13],
+  "missingTracks": [7],
+  "assignments": [
+    {"fileId":"...","bookId":"...","path":".../2.mp3","refTrack":3,"deltaSec":0,
+     "tier":"confirmed","corroborators":["filesize"],"redundant":false}
+  ],
+  "internallyRedundant": [{"fileId":"...","duplicateOfTrack":6}],
+  "skipped": [{"fileId":"...","reason":"no-duration"}],
+  "excludedFrozen": ["<bookID>", "..."],
+  "proposedAction": "Combine 11 debris rows (17 files) into one book using the 13-track reference as a template, then version-group with 01KQAXKG7HYMT44GRNCGSJBXG1 as primary",
+  "confidence": "confirmed",
+  "probeToleranceSec": 10,
+  "tolFingerprintSec": 2,
+  "tolContainerSec": 5
+}
+```
+
+`confidence` is `"confirmed"` only when **every** non-redundant assignment is
+`TierConfirmed`; otherwise `"probable"`.
+
+### 3.3 Review item fields
+
+| Field | Value |
+|---|---|
+| `Kind` | `firstaid.redundant-copy` |
+| `DedupKey` | `sha256("firstaid.redundant-copy|" + referenceBookId)` — one hold per reference book, so re-running upserts rather than duplicating (`database.UpsertReviewItem`, `internal/database/review_store.go:132`) |
+| `FolderRef` | the reference book's `FilePath` |
+| `Summary` | `"11 rows / 17 files duplicate 12 of 13 tracks of \"The Empty Place\" — combine + version-group"` |
+
+Keying on the **reference book ID** rather than a folder is deliberate: debris is spread
+across many folders, and the reference is the only stable identity in the group.
+
+---
+
+## 4. API / op surface
+
+### 4.1 `maintenance.detect-redundant-copies` (new op)
+
+```go
+sdk.OperationDef{
+    ID:              "maintenance.detect-redundant-copies",
+    Plugin:          "maintenance",
+    DisplayName:     "Detect redundant copies (dry-run · review-queue producer)",
+    ResumePolicy:    sdk.ResumeDrop,
+    DefaultPriority: sdk.PriorityLow,
+    ConcurrencyKey:  "maintenance.detect-redundant-copies",
+    Cancellable:     true,
+    Isolate:         false,
+    Timeout:         120 * time.Minute,
+    Capabilities:    []sdk.Capability{sdk.CapLibraryRead}, // LD5: no CapFilesRead
+    Run:             p.runDetectRedundantCopies,
+}
+```
+
+Params:
+
+```go
+type detectRedundantParams struct {
+    Limit              int    `json:"limit"`              // cap holds written (0 = all)
+    ProbeToleranceSec  int    `json:"probeToleranceSec"`  // default 10
+    TolFingerprintSec  int    `json:"tolFingerprintSec"`  // default 2
+    TolContainerSec    int    `json:"tolContainerSec"`    // default 5
+    MinReferenceTracks int    `json:"minReferenceTracks"` // default 3
+    MaxDebrisFiles     int    `json:"maxDebrisFiles"`     // default 8
+    MinMatchableSec    int    `json:"minMatchableSec"`    // default 60
+    MaxBucketFanout    int    `json:"maxBucketFanout"`    // default 64
+    HistogramOnly      bool   `json:"histogramOnly"`      // compute + log the histogram, write ZERO holds
+    ReferenceBookID    string `json:"referenceBookId"`    // single-reference canary
+}
+```
+
+There is no `apply` field — see LD9.
+
+Phases:
+
+| Phase | Work | Concurrency |
+|---|---|---|
+| 1/5 | `store.ListBookIDs()` (`internal/database/iface_book.go:50`) | — |
+| 2/5 | Per book: `GetBookByID` + `GetBookFiles`, build `[]dupmatch.Track`. Skip non-primary, soft-deleted, frozen-iTunes. | `registry.RunItems` at `runtime.NumCPU()` (`internal/operations/registry/run_items.go:82`), `ErrModeCollect`, results collected under a mutex — the exact shape `relink_unlinked.go:117-156` uses |
+| 3/5 | Build the duration index over **reference-eligible** books (`len(files) >= MinReferenceTracks`) | single-threaded, pure map build |
+| 4/5 | Per debris-eligible book (`1 <= len(files) <= MaxDebrisFiles`): probe the index, tally per candidate reference, pick the best | `registry.RunItems` at `runtime.NumCPU()`; **read-only**, results under a mutex |
+| 5/5 | Group debris by reference, run `dupmatch.MatchTemplate` once per reference, `UpsertReviewItem` | single-threaded (writes) |
+
+**Why phase 5 is single-threaded:** it is the only phase that writes, the hold count is
+bounded by the number of references (hundreds, not tens of thousands), and
+`UpsertReviewItem`/`DeleteReviewItem` share one mutex — a pool would add contention only.
+Same reasoning as `reconcileStaleHolds` (`regroup_shattered_ai.go:286-292`).
+
+**Hold-emission threshold**, per debris **book**:
+
+- `>= 2` distinct non-redundant slots matched, **or**
+- exactly 1 slot matched **and** at least one corroborator on that assignment
+  (`SkipNoCorroborator` otherwise).
+
+The single-file rule exists because single-file debris is where false positives live: one
+duration coincidence between two unrelated 40-minute files is entirely plausible; two
+independent coincidences against the same reference is not.
+
+### 4.2 `ApplyRedundantCopy(store database.Store, combiner bookCombiner) func(context.Context, database.ReviewItem) error`
+
+Registered in `internal/server/wire_handlers.go` next to the existing regroup handlers
+(`wire_handlers.go:598-608`). `bookCombiner` is the existing narrow interface
+(`regroup_apply.go:68-70`) — reuse it, do not widen it.
+
+Ordered steps, all of which abort before any write on failure:
+
+1. Decode payload.
+2. `GetBookByID(referenceBookId)`; nil or `MarkedForDeletion` → error (the hold is about
+   this book; there is nothing to group against).
+3. **LD4 guard:** `referenceBookId ∈ debrisBookIds` → error, zero writes.
+4. **LD3 re-check:** `config.UnderFrozenITunesTree` on the reference's file paths and on
+   each surviving debris book's paths → error listing the offenders, zero writes.
+5. `present := presentMembers(store, debrisBookIds)` — reuse the existing helper verbatim
+   (`regroup_apply.go:338-358`); it already skips hard-deleted and soft-deleted rows,
+   which matters because a hold can be days older than its approve.
+6. `len(present) == 0` → log and return nil (already applied; idempotent re-approve).
+7. `len(present) >= 2` → `survivorID := pickPrimary(present)` (`regroup_apply.go:364`,
+   earliest ULID among the **debris**) then
+   `combiner.CombineBooks(present, survivorID, nil)`.
+   **`nil` override is mandatory** — a non-nil override is the only thing that makes
+   `merge.Service` call `UpdateBook` on the survivor (`internal/merge/service.go:444-457`),
+   and that is this repo's dominant incident class.
+   `len(present) == 1` → `survivorID = present[0]`, no combine.
+8. `applyTemplateTrackNumbers(store, survivorID, payload)` — §4.3.
+9. `linkVersionGroup(store, []string{referenceBookId, survivorID}, pick)` — §4.4, where
+   `pick` is `dupmatch.PickMostComplete` over
+   `{reference: referenceTrackCount, refFileCount}` and
+   `{survivor: len(coveredTracks), survivorFileCount}`.
+10. Log a single structured line with survivor, group ID, primary, files numbered, files
+    left unnumbered.
+
+### 4.3 `applyTemplateTrackNumbers` (new, per LD7)
+
+```go
+// applyTemplateTrackNumbers stamps the template's slot numbers onto the combined
+// survivor's files. Returns (numbered, leftUnnumbered, error).
+//
+// NOT applyDiscTrackNumbers: that function bails on the WHOLE group if any file
+// already carries disc/track metadata (regroup_apply.go:155-162), and
+// relink-unlinked-books stamps track = i+1 on every directory-shaped book it
+// repairs (relink_unlinked.go:355). Reusing it here would silently number nothing.
+//
+// DATA-LOSS SAFETY: re-fetch-and-patch. GetBookFiles returns FULL rows (fingerprint
+// intact); we mutate ONLY TrackNumber and DiscNumber and write via UpdateBookFile,
+// which itself restores AcoustIDFingerprint on an empty incoming value. Never a
+// fresh or partial BookFile write-back.
+func applyTemplateTrackNumbers(store database.Store, survivorID string, p redundantCopyPayload) (int, int, error)
+```
+
+- Winner assignments (`redundant == false`) → `TrackNumber = refTrack`, `DiscNumber = 0`
+  (discs are flattened away by owner decision — `fs_regroup_shape.go:104-110`).
+- Redundant + skipped files → `TrackNumber = 0`, `DiscNumber = 0`. Zero means "position
+  unknown, deliberately". Writing 0 rather than leaving a stale relink-derived number
+  prevents a redundant file presenting as a real track and colliding with its winner.
+- Per-file idempotency: skip the write when the row already carries the target values.
+- Files on the survivor that the payload does not mention at all are left untouched and
+  counted.
+
+### 4.4 `linkVersionGroup` — extracted shared helper (per LD6)
+
+New file `internal/plugins/maintenance/version_group_link.go`:
+
+```go
+// linkVersionGroup applies the version-group invariants to a member set, with the
+// primary-selection policy INJECTED.
+//
+// Extracted from ApplyVersionGroup so the three hard-won invariants below exist
+// exactly once:
+//   - existing-group reuse (idempotent re-approve)                regroup_apply.go:222-224,246-252
+//   - REFUSE members spanning two existing groups                 regroup_apply.go:236-245
+//   - demote any stale primary across the WHOLE group             regroup_apply.go:286-312
+//
+// Members are re-fetched and patched (UpdateBook is a full-column replace); only
+// VersionGroupID and IsPrimaryVersion are ever mutated.
+func linkVersionGroup(
+    store database.Store,
+    memberIDs []string,
+    pick func(books []*database.Book) string,
+    logKV ...any,
+) (groupID string, primaryID string, err error)
+```
+
+`ApplyVersionGroup` becomes a thin wrapper passing `pickEarliestULIDBook` — behaviour
+byte-for-byte unchanged, proven by the existing `regroup_apply_test.go` passing without
+edits. `ApplyRedundantCopy` passes a closure over `dupmatch.PickMostComplete`.
+
+### 4.5 Frontend
+
+- `web/src/lib/reviewKinds.ts` → add
+  `'firstaid.redundant-copy': 'Redundant copies (assembled original exists)'`.
+  Without this the queue page renders the fallback title-case
+  (`reviewKinds.ts:20-27`) — functional but wrong-looking.
+- `web/src/lib/reviewPayload.ts` → the `ReviewPayload` interface already has an index
+  signature (`reviewPayload.ts:31`), so the new keys parse without change; add optional
+  typed fields `referenceBookId`, `coveredTracks`, `missingTracks`,
+  `internallyRedundant`, `excludedFrozen` for the card, and `memberIDs()` gains a
+  `debrisBookIds` fallback so the existing member-count rendering works.
+
+No new page or component. The existing `ReviewQueue.tsx` list rendering is sufficient
+for v1; a richer card is a follow-up.
+
+---
+
+## 5. Index design and its two traps
+
+The index is `map[int][]indexEntry`, keyed by whole seconds, queried over
+`[d - probeTol, d + probeTol]`.
+
+```go
+type indexEntry struct {
+    BookID    string
+    FileID    string
+    Slot      int    // 1-based position in the reference's ordered track list
+    DurSec    int
+    Source    dupmatch.DurSource
+    TitleStem string
+}
+```
+
+**Memory budget.** ~275K `book_file` rows library-wide (fingerprint coverage figure,
+`internal/plugins/maintenance/duration_reextract.go:35-38`). Only reference-eligible
+books are indexed, so realistically well under that; at ~120 bytes/entry the worst case
+is ~35 MB. **Do not store `database.BookFile` structs in the index** — `RawTags` and
+`AcoustIDFingerprint` alone would make this hundreds of MB.
+
+**Trap 1 — `DurSec <= 0` must never be indexed or queried.** A zero-duration bucket would
+match everything against everything. Enforced by `Source == SourceUnknown` short-circuits
+in both the builder and the matcher (LD2).
+
+**Trap 2 — bucket fan-out.** Exactly-30-minute chapters exist all over a library. A
+debris file whose candidate-slot count exceeds `MaxBucketFanout` (default 64) is
+**skipped with `SkipAmbiguousBucket` and counted**, never resolved by "take the first".
+Silently taking the first is precisely the silent-filtering failure rule 6 exists to
+prevent, and it would be invisible in the output.
+
+---
+
+## 6. The dry-run acceptance gate (tolerance is NOT locked by this document)
+
+The fragment proposes ±2 s; the 17 measured files showed deltas of 0–1 s. That is one
+group. The tolerance is locked only after a whole-library dry run at
+`probeToleranceSec: 10` satisfies **all four** of:
+
+**(a) Histogram shape.** ≥95 % of accepted matches at `|delta| <= 1 s`, with a visible
+trough between the true-match mode and the noise floor. If the histogram is flat out to
+10 s, duration matching is not separating signal from noise at this library's data
+quality and the workstream stops here rather than shipping a guess.
+
+**(b) The measured case reproduces exactly.**
+- `01KQAXKG7HYMT44GRNCGSJBXG1` is selected as the reference;
+- **12 of 13** tracks covered, `missingTracks == [7]`;
+- **17** debris files across **11** debris books;
+- **5** entries in `internallyRedundant`;
+- **10** frozen-iTunes rows in `excludedFrozen` — present and counted, not silently
+  dropped.
+
+**(c) Reconciliation.**
+`examined == matched + unmatched + skipped-no-duration + skipped-frozen + skipped-short + skipped-ambiguous-bucket + errors`,
+on the `RECONCILE:` line, with `examined` tying back to `len(ListBookIDs())`.
+
+**(d) The single-file share is reported separately.** The summary must break the
+library-wide match count into "debris books contributing ≥2 slots" vs "debris books
+contributing exactly 1 slot (corroborator-gated)". Single-file debris is where false
+positives live; if it dominates, the corroborator rule needs tightening before any apply.
+
+---
+
+## 7. Non-goals
+
+1. **Fixing the reference's inherited title.** `01KQAXKG7HYMT44GRNCGSJBXG1` should read
+   "The Successors", not "The Empty Place". That is `maintenance.title-repair` /
+   `metadata-refresh` territory (tier 3 / tier 4 in the roster,
+   `.claude/notes/2026-08-05-first-aid-architecture.md:119-125`). The detector **reports**
+   the signal (`referenceTitleLooksInherited`) and changes nothing.
+2. **Probing durations.** LD5. Missing durations are reported with
+   `maintenance.duration-reextract` named as the producer.
+3. **Deleting anything.** No delete disposition exists in `linkintegrity`
+   (`internal/linkintegrity/report.go:60-70`) and none is added.
+4. **Touching `books/itunes/**`.** LD3.
+5. **Resolving the internally-redundant debris files.** They are reported and left with
+   `TrackNumber = 0`. Deciding which of two copies of track 6 is "the" copy is a human
+   call and there is no forced choice.
+6. **Folding this into the dedup subsystem.** Owner decision D5
+   (`.claude/notes/2026-08-05-first-aid-architecture.md:83-85`): dedup keeps its own
+   queue, gold labels and calibrated thresholds. This shares the *matching idea*, not the
+   orchestration. Folding it in wholesale is how 57 ops accumulated.
+7. **Orchestration / sequencing / missing-input triggering.** Separate workstream
+   (`todo.d/…:31,33-38`).
+8. **Auto-apply.** LD9. Approve is a human action behind a globally-off switch.
+9. **Chapter-level or fingerprint-only matching.** Fingerprints are a corroborator only;
+   65 % of files are unfingerprinted, so a fingerprint-primary design would be inert
+   (`MEMORY` → matching + dedup findings, 2026-07-02).
+
+---
+
+## 8. Failure modes
+
+| # | Failure | Detection | Behaviour |
+|---|---|---|---|
+| F1 | Debris file has no usable duration | `Source == SourceUnknown` | `SkipNoDuration`, counted, file ID reported, `maintenance.duration-reextract` named. **Never** treated as "no match" in the confidence calculation (LD2) |
+| F2 | Two debris files claim one reference slot | greedy assign, slot already taken | later claimant → `Redundant = true`, retains `RefTrackIndex`, gets `TrackNumber = 0` on apply, listed in `internallyRedundant` |
+| F3 | Reference has an inherited/junk title | `Book.Title == files[0].Title` | `referenceTitleLooksInherited: true`, reported only (§7.1) |
+| F4 | A debris row is soft-deleted between hold and approve | `presentMembers` (`regroup_apply.go:350`) | skipped with a reason; if that leaves 0, the apply is a logged no-op |
+| F5 | Reference vanished or soft-deleted between hold and approve | step 2 | error → item lands in `failed` with a reason; zero writes |
+| F6 | Reference appears in `debrisBookIds` (payload corruption, hand-edit, future bug) | step 3 guard | error, zero writes. Unit-tested |
+| F7 | Reference or a debris book is under `books/itunes/**` | LD3 re-check at apply | error listing offenders, zero writes |
+| F8 | Reference and debris survivor already sit in **two different** version groups | `linkVersionGroup` cross-group refusal (`regroup_apply.go:236-245`) | error, item → `failed`, human resolves. Never silently merges groups |
+| F9 | Re-approve of an already-applied hold | `presentMembers` returns 0 or 1; `linkVersionGroup` reuses the existing group; per-file numbering skips equal values | idempotent no-op |
+| F10 | `CombineBooks` fails partway | it aborts before `DeleteBook` if the row still owns files (`internal/merge/service.go:427-431`) | error propagates; item → `failed`; no version-group write happens (step 9 is after step 7) |
+| F11 | Duration bucket over-populated (e.g. many exactly-30-min chapters) | `MaxBucketFanout` | `SkipAmbiguousBucket`, counted. Never "take the first" |
+| F12 | Whole-library scan silently truncates | `RECONCILE` line + `Report.UnreconciledPhases()` (`internal/linkintegrity/report.go:172-181`) | op returns an error rather than reporting success (LD10) |
+| F13 | A single duration coincidence produces a bogus single-file match | corroborator requirement | `SkipNoCorroborator`, counted; the single-file share is reported separately in the summary (gate (d)) |
+| F14 | Two concurrent applies touch the same books | `mergeSerializeMu` inside `CombineBooks` (`internal/merge/service.go:353`) serializes the whole merge-family RMW | second waits; `presentMembers` then sees the absorbed rows as gone and no-ops |
+| F15 | Op cancelled mid-run | `ctx.Err()` checks in the write loop, `Cancellable: true` | partial holds already upserted are valid (idempotent DedupKey); a re-run completes the set |
+
+---
+
+## 9. Open questions
+
+1. **Is `MaxBucketFanout = 64` right?** It is a guess. The first dry run should log the
+   bucket-size distribution so the value can be set from data rather than intuition.
+2. **Should a `probable`-confidence hold be applicable at all**, or only `confirmed`?
+   Current design lets a human approve either (the switch is off by default anyway). If
+   the dry run shows `probable` dominating, consider registering the apply handler only
+   for `confirmed` and routing `probable` to a handler-less display-only path, exactly as
+   `regroup.ambiguous` is handled today (`regroup_apply.go:19-21`).
+3. **Reference eligibility floor.** `MinReferenceTracks = 3` excludes 2-track references.
+   Unmeasured; the dry run should report how many candidate references sit at exactly 2.
+4. **Should the detector emit a `linkintegrity.Finding` with
+   `DispositionVersionGroup`/`DuplicateOfBookID`?** Those fields already exist
+   (`internal/linkintegrity/report.go:76-78,112-115`) and are currently unused. Wiring the
+   detector's output into the shared `Report` would let the First Aid orchestrator
+   aggregate it. Deferred to the orchestrator workstream to avoid coupling this PR to a
+   design that is not settled.
+5. **Cross-reference debris.** A debris book whose files match slots in *two* different
+   reference books is currently assigned to the best-scoring one. Whether it should
+   instead be held as ambiguous is unmeasured; the dry run should count how often it
+   happens.

--- a/docs/specs/2026-08-05-playlists-design.md
+++ b/docs/specs/2026-08-05-playlists-design.md
@@ -1,0 +1,805 @@
+<!-- file: docs/specs/2026-08-05-playlists-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 032b075a-0d45-43c2-8955-d306155ca0aa -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Playlists — import, static, dynamic, CRUD, export (design)
+
+Workstream slug: `playlists`
+Fragment: [`todo.d/20260805_214200_playlists_full_support.md`](../../todo.d/20260805_214200_playlists_full_support.md)
+Sibling context: [`.claude/notes/2026-08-05-first-aid-architecture.md`], [`.claude/notes/2026-08-05-unlinked-books-investigation.md`]
+
+---
+
+## 0. Read this first — the fragment overstates the greenfield
+
+The owner asked to "basically implement everything to do with playlists, dynamic
+playlists, static, etc." A code survey on 2026-08-05 (main = `8c39469a`) found
+that **most of that already ships**. Building it again would be a rewrite, not a
+feature. What actually exists:
+
+| Capability | Status | Evidence |
+|---|---|---|
+| Static playlists (ordered book list) | **SHIPPED** | `database.UserPlaylist.BookIDs` — `internal/database/store.go:393`; `UserPlaylistTypeStatic` — `store.go:421` |
+| Dynamic ("smart") playlists — stored query evaluated at read time | **SHIPPED** | `playlist.EvaluateSmartPlaylist` — `internal/playlist/evaluator.go:73`; sort directives `PlaylistSort` — `evaluator.go:41`; per-user filters `applyPerUserFilters` — `evaluator.go:129` |
+| CRUD + reorder over the app API | **SHIPPED** | 9 routes, `internal/server/wire_library_routes.go:77-85`; handlers `internal/server/handlers/playlists.go:120-486` |
+| Per-user ownership / IDOR guard | **SHIPPED** | `ownedByCaller` — `handlers/playlists.go:105`; `ListUserPlaylistsForUser` — `internal/database/iface_misc.go:241` |
+| Materialize smart → static snapshot | **SHIPPED** | `MaterializePlaylist` — `handlers/playlists.go:432` |
+| Pebble persistence + name/iTunes-PID/dirty indexes | **SHIPPED** | `internal/database/pebble_store_playlists.go:142-410` |
+| iTunes smart-playlist import + push-back | **SHIPPED** | `internal/itunes/service/playlist_sync.go` |
+| React UI (list, detail, add-to-playlist) | **SHIPPED** | `web/src/pages/Playlists.tsx`, `PlaylistDetail.tsx`, `components/audiobooks/AddToPlaylistDialog.tsx`, `services/playlistApi.ts` |
+
+**The real delta is four items.** Everything below is scoped to those four.
+
+| # | Gap | Evidence it is missing |
+|---|---|---|
+| **G1** | Membership is **book-granular**, not `book_file`-granular. The fragment explicitly requires resolving entries to `book_file` rows so a reorganise cannot break them. | `UserPlaylist.BookIDs []string` — `store.go:393`. There is no file-level field on the struct and no file-level keyspace in `pebble_store_playlists.go`. |
+| **G2** | **No playlist-file import.** `.m3u`/`.m3u8`/`.cue` are parsed *transiently* by the scanner for folder grouping and then thrown away; `.pls` and `.xspf` are not handled at all; nothing is persisted; CUE `TRACK`/`INDEX` timings are read past and discarded. | `parseCueFile` — `internal/scanner/scanner.go:1567` (reads only `TITLE` and `FILE`); `parseM3UFile` — `scanner.go:1595`; consumed only by `findPlaylistGroupings` — `scanner.go:1635`, whose sole caller builds `albumGroups` at `scanner.go:1833`. `grep -ril 'pls\|xspf'` over `internal/` returns no parser. |
+| **G3** | **ABS surface is a stub.** iOS clients see zero playlists. | `r.GET("/api/libraries/:libraryId/playlists", auth, h.EmptyPage)` — `internal/server/handlers/abs/handler.go:387`; `EmptyPage` returns `pageResponse{Results: []any{}}` — `internal/server/handlers/abs/browse.go:332-338`. **No playlist fixture exists**: `ls testdata/abs-fixtures/ \| grep -i playlist` is empty (28 fixtures present, none for playlists or collections). |
+| **G4** | **Export is dead code.** | `generatePlaylistFile` — `internal/playlist/playlist.go:42` is unexported; its only in-package caller path is `GeneratePlaylistsForSeries`, which returns an error unconditionally (`playlist.go:34-37`). No route, no op. |
+
+---
+
+## 1. Problem statement, with the numbers that constrain it
+
+### 1.1 The number that governs sequencing
+
+A whole-library survey on 2026-08-05 found **17,149 of 44,887 books (38.2%) own
+ZERO `book_file` rows** ([unlinked-books investigation, headline]). Of 4,655
+sampled paths: 4,321 (92.8%) resolve to a real file, 332 (7.1%) to a directory,
+2 to nothing; extrapolated library-wide: **16,027 file / 1,029 directory / 93
+missing**.
+
+An imported playlist entry resolves against `book_file` rows via
+`GetBookFileByPath` (`internal/database/iface_misc.go:161`). If 38.2% of books
+have no such rows, a naive importer drops entries en masse and the feature looks
+broken for a reason that has nothing to do with playlists. The relink op
+(`maintenance.relink-unlinked-books`, `internal/plugins/maintenance/relink_unlinked.go`,
+PR #2147) has since been applied (task #1 complete), so the live number should
+now be far smaller — but **the design must not assume it is zero**. See §4.3.
+
+### 1.2 The number that governs the concurrency shape
+
+The library is ~44,887 books. Import walks library roots for playlist files and
+then does one `GetBookFileByPath` per entry — a per-item DB read over an
+unbounded collection. That is exactly the shape that hung `dedup.full-scan` for
+3+ hours at 100% CPU on a single core on 2026-07-05
+(`docs/audits/2026-07-05-concurrency-single-threaded-hotspots.md`, cited from
+`CLAUDE.md`). Bounded worker pool, mandatory. See §5.
+
+### 1.3 The number that governs the ABS work
+
+**Zero** playlist fixtures exist. The conformance harness
+(`internal/syncapi/conformance/fixture.go:35`, `Fixture.CompareBody` at
+`fixture.go:49`) and the capture script (`scripts/abs_capture_fixtures.py`) both
+exist and are used for 28 other endpoints. The ABS DTO **cannot be written from
+recall**. See §6 and §9-Q1.
+
+---
+
+## 2. Locked decisions
+
+### D1 — Playlist entries live in their own Pebble keyspace, NOT on the `UserPlaylist` document. 🔴
+
+`UpdateUserPlaylist` is a **full-document replace**:
+
+```go
+// internal/database/pebble_store_playlists.go:311,316
+data, err := json.Marshal(pl)
+...
+if err := b.Set([]byte("upl:"+pl.ID), data, nil); err != nil {
+```
+
+Six existing call sites round-trip a `UserPlaylist` struct through that write:
+`UpdatePlaylist` (`handlers/playlists.go:279`), `AddBooksToPlaylist`
+(`:346`), `RemoveBookFromPlaylist` (`:382`), `ReorderPlaylist` (`:422`),
+`MaterializePlaylist`'s create path (`:473`), and — worst — `GetPlaylist`,
+which **writes back on READ** of a smart playlist (`:218-221`).
+
+If `Entries []PlaylistEntry` were added to the struct, every one of those paths
+that loads, mutates one field, and re-marshals would silently discard entries.
+That is this repo's dominant incident class (`UpdateBookFile` fingerprint wipe,
+Author/Series write-back wipe — see MEMORY index). The defence chosen here is
+the same **structural** one `relink_unlinked.go:293-297` documents for itself
+("there is no `UpdateBook` call in this file at all"): make the dangerous write
+physically incapable of touching the data.
+
+**Keyspace** (verified non-colliding, §2.D1.a):
+
+```
+uplent:<playlistID>:<seq>              → JSON PlaylistEntry      (seq = %08d, sorts lexically = play order)
+idx:uplent:bf:<bookFileID>:<playlistID>:<seq>   → ""             (reverse: which playlists cite this file)
+idx:uplent:unres:<playlistID>:<seq>    → ""                      (worklist for the re-resolve op)
+```
+
+**D1.a — range-collision check, run, not assumed.** `listUserPlaylists`
+iterates `[ "upl:", "upl:~" )` (`pebble_store_playlists.go:262-264`). A key
+landing inside that range would be `json.Unmarshal`ed into a `UserPlaylist`;
+unknown JSON fields are ignored by `encoding/json`, so a `PlaylistEntry` blob
+would decode *successfully* into a blank playlist and appear in the list. Byte
+comparison was executed rather than reasoned about:
+
+| key | in `[upl:, upl:~)` | why |
+|---|---|---|
+| `upl:01XYZ` | **true** | the real playlist rows |
+| `uplent:01ABC:00000001` | **false** | bytes 0-2 tie on `upl`; byte 3 is `'e'` (0x65) vs the upper bound's `':'` (0x3A), so `'e' > ':'` puts the whole key **above** `upl:~` |
+| `uplentry:x` | **false** | same reason |
+| `idx:uplent:bf:…` | **false** | different first byte |
+
+Executed with a throwaway `bytes.Compare` program, not reasoned about. `uplent:`
+is safe. **Any future prefix added near `upl` must repeat this check** — and
+note that a colliding key would not error, it would decode into a blank
+`UserPlaylist` and appear in every user's list.
+
+**D1.b — `BookIDs` stays and stays authoritative for book-level consumers, and
+the entry path NEVER overwrites it.** `playlist_sync.go` pushes `BookIDs` to the
+ITL, the React UI reads it, and the ABS DTO projects from it. Entries are
+**additive**. A playlist with no entries behaves exactly as it does today — zero
+behaviour change for every existing row.
+
+An earlier draft had `ReplacePlaylistEntries` refresh `BookIDs` on the `upl:`
+document. **That is rejected**, for two independent reasons:
+
+1. **Lost update.** `AddBooksToPlaylist` (`handlers/playlists.go:342`) appends to
+   `BookIDs` directly and knows nothing about entries. A subsequent
+   `ReplacePlaylistEntries` would silently discard the book the user just added.
+2. **No compare-and-swap.** `UpdateUserPlaylist` sets `pl.Version = prev.Version + 1`
+   (`pebble_store_playlists.go:310`) but never *checks* the caller's version. Two
+   writers owning overlapping fields on one document will drift. `GetPlaylist`
+   writes back on read (`handlers/playlists.go:218-221`) from a `pl` fetched
+   before the entry write, so a concurrent resolve pass would have its counters
+   silently reverted.
+
+Instead, the entry-derived view lives in its own key (D1.c) and the `upl:`
+document is written by exactly one code path (`UpdateUserPlaylist`), as today.
+
+**D1.c — the derived view is a sibling key, not fields on the document.**
+
+```
+uplcnt:<playlistID> → {"entry_count":N,"unresolved_count":M,"derived_book_ids":[...]}
+```
+
+Written **only** by `ReplacePlaylistEntries` / `UpdatePlaylistEntryResolution`;
+read by the list DTO, the detail DTO and the ABS projection. Range-checked the
+same way as `uplent:` (§D1.a): `uplcnt:` byte 3 is `'c'` (0x63) > `':'` (0x3A),
+so it falls **above** `upl:~` and is invisible to `listUserPlaylists`. Verified
+by execution, not inference.
+
+`derived_book_ids` is `entry.BookID` in first-appearance order, de-duplicated. It
+is a **cache**, recomputed from `uplent:` by `playlists.resolve-entries`, and is
+never a correctness input — a consumer that needs certainty reads
+`ListPlaylistEntries`. For an *imported* playlist the import op seeds
+`UserPlaylist.BookIDs` once at `CreateUserPlaylist` time (there is no user data
+to lose on a brand-new row) and never rewrites it afterwards.
+
+### D2 — Absent evidence is never negative evidence: entries carry a resolution STATE, not a nullable FK. 🔴
+
+`GetBookFileByPath` returns `(nil, nil)` for "no row" (`iface_misc.go:161`;
+Pebble impl returns nil,nil on `ErrNotFound`). That means **"cannot verify right
+now"**, never "this entry is junk". A `DurationSec == 0` silently disabling the
+`membersAreBookLength` series-guard across 97.5% of a review queue
+(`internal/itunes/service/fs_regroup_shape.go:149-159`) is the precedent.
+
+Every parsed entry is persisted, always, with:
+
+```go
+type EntryState string
+const (
+    EntryResolved         EntryState = "resolved"           // BookFileID set
+    EntryUnresolvedNoRow  EntryState = "unresolved_no_row"  // file exists on disk, no book_file row claims it
+    EntryUnresolvedMissing EntryState = "unresolved_missing" // path does not stat
+    EntryUnresolvedOffRoot EntryState = "unresolved_off_root"// resolves outside every configured library root
+)
+```
+
+`RawPath` (as written in the playlist file) and `ResolvedPath` (absolute,
+symlink-free) are **retained forever**, so a later re-resolution pass — after a
+relink, after a reorganise, after a rescan — can promote an entry without
+re-reading the source file. An import that resolves 40 of 60 entries stores
+**all 60** and reports `examined=60 resolved=40 unresolved=20 errors=0`.
+Dropping the 20 is the silent-filter failure mode the RECONCILE lines exist to
+catch.
+
+### D3 — Import is dry-run by default, with an explicit `apply` flag.
+
+Mirrors `relinkParams` (`relink_unlinked.go:55-67`) exactly. Params:
+`{"apply": false, "limit": 0, "roots": [], "formats": ["m3u","m3u8","pls","cue","xspf"]}`.
+Detection always covers the whole scope even when `limit` caps writes, so a
+capped run can never look like a clean bill of health (same rationale as
+`relink_unlinked.go:59-61`).
+
+### D4 — Import NEVER creates, mutates, or deletes `Book` or `BookFile` rows.
+
+The import op's write surface is exactly three things: `UserPlaylist` rows,
+`uplent:` entry rows, and playlist-timing records (§3.4). It calls no
+`UpdateBook`, no `UpdateBookFile`, no `CreateBookFile`, no `DeleteBookFile`.
+This is asserted by a test that greps the package source (§ plan step 9), not
+just by convention — same enforcement style as the SDK guard (`make sdkguard`).
+
+### D5 — Never delete to resolve a duplicate playlist.
+
+Re-importing the same `.m3u` must be idempotent, not additive. Identity of an
+imported playlist is `(sourcePath, sourceContentHash)`. On re-import:
+- same path, same hash → **no-op**, counted as `skipped_unchanged`
+- same path, changed hash → **replace the entry list in place**, bump
+  `SourceContentHash`, keep the playlist ID, keep user edits recorded as
+  `UserModified` (see §4.4)
+- new path → new playlist
+
+A playlist whose source file vanished is marked `SourceMissing`, **never
+deleted** — deleting is not idempotent here for the same reason it is not for
+book rows (`internal/linkintegrity/report.go:62-68`): a rescan finds the file
+again and remints it.
+
+### D6 — `books/itunes/**` is frozen: read-only for import, forbidden for export.
+
+`config.UnderFrozenITunesTree(p)` (`internal/config/itunes_libraries.go:98`;
+segment match `booksItunesSegment = "books/itunes/"` at `:85`) is the single
+predicate. Import **may read** playlist files found there (the iTunes tree is a
+legitimate source of human-authored grouping). Export **refuses** any
+destination for which `UnderFrozenITunesTree` is true, and the refusal is an
+error, not a warning.
+
+### D7 — Cue timings are EMITTED, not written into chapters.
+
+Chapters live at `chapters:<bookID>` and are written by
+`SaveChaptersForBook(bookID string, chapters []Chapter)`
+(`internal/database/pebble_store_chapters.go:62`), which is itself a
+**whole-list replace** (`:33` key, single Pebble value). A playlist importer
+calling it would clobber whatever the chapters workstream put there.
+
+The playlist workstream therefore persists a **playlist-owned timing record**
+(§3.4) and exposes it read-only. The chapters workstream
+([[chapters-backfill-from-duplicates]]) consumes it. No cross-writes.
+
+### D8 — Grouping evidence is EMITTED, not acted on.
+
+An imported playlist that lists 13 files in order is a human-authored assertion
+that those files belong together — the signal `ClassifyShatteredFolders`
+(`internal/itunes/service/fs_regroup_shape.go:454`) currently has to infer from
+filenames. The playlist workstream exposes that evidence via a read API
+(§3.5). It does **not** call combine, merge, regroup-apply, or version-group.
+The regroup apply path already has guards (`membersAreBookLength` at
+`fs_regroup_shape.go:149`, the frozen-tree skip); a second writer bypassing them
+is how over-merges happen.
+
+### D9 — Dynamic (smart) playlists are not redesigned.
+
+`EvaluateSmartPlaylist` (`evaluator.go:73`), the DSL (`search.ParseQuery` /
+`search.Translate`), the sort directives and the per-user filters stay exactly
+as they are. The only change touching smart playlists is that
+`MaterializePlaylist` gains the ability to write file-level entries for the
+snapshot (§3.3), and even that is opt-in.
+
+### D11 — A `UserModified` playlist is never re-entried by an importer. 🔴
+
+`ReplacePlaylistEntries` **returns an error** when the target row has
+`UserModified == true`. §4.4 already routes that case to "create a new
+playlist", but the refusal is enforced in the **store**, not left to the op —
+same reasoning as D1: put the guard where it cannot be forgotten by the next
+caller.
+
+`UserModified` is set to true by the four human-facing mutation handlers
+(`UpdatePlaylist`, `AddBooksToPlaylist`, `RemoveBookFromPlaylist`,
+`ReorderPlaylist` — `handlers/playlists.go:279,346,382,422`) whenever the target
+playlist has `SourceKind != ""`. It is **not** set by `GetPlaylist`'s
+materialization write-back (`:218-221`), which is machine-driven, not a human
+decision.
+
+### D10 — Export writes only to `config.AppConfig.PlaylistDir`, or to an HTTP response body.
+
+`PlaylistDir` is the existing configured directory (`internal/config/config.go:470`,
+validated at `:1790`). Export has two modes: `GET /api/v1/playlists/:id/export?format=m3u8`
+streams the file to the caller (no disk write at all — the safest default), and
+the op `playlists.export` writes into `PlaylistDir`. Nothing else is a legal
+target. See D6.
+
+---
+
+## 3. Data model
+
+### 3.1 `database.PlaylistEntry` (new)
+
+Lives in `internal/database/store.go` next to `UserPlaylist`. **Never embedded
+in `UserPlaylist`** (D1).
+
+```go
+// PlaylistEntry is one ordered member of a playlist, resolved to a
+// book_file row rather than to a raw path so a later reorganise cannot
+// break it. Persisted in its own keyspace (uplent:) — see D1.
+type PlaylistEntry struct {
+    PlaylistID string `json:"playlist_id"`
+    Seq        int    `json:"seq"`          // 0-based play order; key is %08d of this
+
+    // Resolution. BookFileID is empty unless State == EntryResolved.
+    BookFileID string     `json:"book_file_id,omitempty"`
+    BookID     string     `json:"book_id,omitempty"`     // denormalized parent, for BookIDs projection
+    State      EntryState `json:"state"`
+    // RawPath is EXACTLY the line as written in the source playlist file
+    // (relative or absolute, original separators). Never rewritten.
+    RawPath      string `json:"raw_path"`
+    // ResolvedPath is RawPath made absolute against the playlist file's
+    // directory and cleaned. Empty when RawPath could not be made absolute.
+    ResolvedPath string `json:"resolved_path,omitempty"`
+
+    // Display metadata carried by the source format (EXTINF title, PLS Title,
+    // XSPF <title>/<creator>, CUE TITLE/PERFORMER). Preserved verbatim so an
+    // unresolved entry still renders as something a human recognises.
+    Title    string `json:"title,omitempty"`
+    Artist   string `json:"artist,omitempty"`
+    DurationSec int `json:"duration_sec,omitempty"` // -1 in EXTINF means unknown → 0 here, NOT "zero-length"
+
+    // Timing carries CUE INDEX offsets for entries that came from a cue sheet.
+    // nil for every other format. Read-only evidence for the chapters
+    // workstream — see D7.
+    Timing *EntryTiming `json:"timing,omitempty"`
+
+    FirstSeenAt time.Time `json:"first_seen_at"`
+    LastCheckedAt time.Time `json:"last_checked_at"`
+}
+
+// EntryTiming is a CUE sheet's per-track offsets within ONE audio file.
+type EntryTiming struct {
+    TrackNumber int     `json:"track_number"`
+    StartSec    float64 `json:"start_sec"`  // from INDEX 01
+    PregapSec   float64 `json:"pregap_sec,omitempty"` // INDEX 00, when present
+    // EndSec is NOT stored: a cue sheet does not state it. It is the next
+    // track's StartSec, or the file duration for the last track. Storing a
+    // derived 0 here would read as "zero-length chapter" — absent evidence
+    // must not become negative evidence (D2).
+}
+```
+
+⚠️ **`DurationSec` note.** `#EXTINF:-1,...` is the *overwhelmingly common* M3U
+form (the scanner's own writer emits it — `internal/playlist/playlist.go:68`)
+and means "duration unknown". It is stored as `0` with `State` untouched; it is
+**never** interpreted as a zero-length track, and the export path re-emits `-1`
+for a stored `0` rather than emitting `0`.
+
+### 3.2 `UserPlaylist` additions
+
+Only fields that describe the playlist *as a whole* and that no existing caller
+would ever want to clear. Because `UpdateUserPlaylist` is a full replace (D1),
+each of these is written **only** by the import/export ops via a dedicated
+surgical store method (§3.6), never by the generic handler path.
+
+```go
+    // ── import provenance (empty for app-native playlists) ──
+    SourceKind        string    `json:"source_kind,omitempty"`        // "m3u"|"m3u8"|"pls"|"cue"|"xspf"|"" (native)
+    SourcePath        string    `json:"source_path,omitempty"`        // absolute path of the file it was imported from
+    SourceContentHash string    `json:"source_content_hash,omitempty"`// sha256 of the source bytes (D5 identity)
+    SourceMissing     bool      `json:"source_missing,omitempty"`     // source file no longer stats — NEVER auto-deleted
+    ImportedAt        time.Time `json:"imported_at,omitempty"`
+    // UserModified is set the moment a human edits an imported playlist. A
+    // re-import of a UserModified playlist creates a NEW playlist rather than
+    // overwriting the human's work (D5), and ReplacePlaylistEntries refuses
+    // outright (D11).
+    UserModified      bool      `json:"user_modified,omitempty"`
+```
+
+🔴 **No `EntryCount` / `UnresolvedCount` / entry-derived `BookIDs` on this
+struct.** They live in `uplcnt:<playlistID>` (D1.c). Putting them here would
+give two writers overlapping ownership of one document that has no
+compare-and-swap, and `GetPlaylist`'s write-back-on-read
+(`handlers/playlists.go:218-221`) would revert them.
+
+Every field above is written **only** by `SetPlaylistImportProvenance` (§3.3),
+which re-fetches the row first. The generic `UpdateUserPlaylist` path never sets
+them.
+
+**Migration**: none required. Pebble values are JSON; absent fields decode as
+zero values, and `internal/database/migrations.go` already tolerates additive
+fields (same pattern as `RawTags` on `BookFile` — `store.go:713`, documented as
+"Additive JSON field; nil on rows imported before…").
+
+### 3.3 Store surface (new methods on `UserPlaylistStore`)
+
+Added to `internal/database/iface_misc.go:232-245`. Every one is surgical —
+none of them marshals a whole `UserPlaylist` from caller-supplied data.
+
+```go
+    // ── entries (separate keyspace; see D1) ──
+    ListPlaylistEntries(playlistID string) ([]PlaylistEntry, error)
+    // ReplacePlaylistEntries atomically swaps the whole ordered entry list for
+    // one playlist, rewrites the reverse + unresolved indexes, and rewrites the
+    // uplcnt:<id> derived view. It NEVER writes the upl:<id> document — see
+    // D1.b/D1.c. Returns an error when the target has UserModified == true (D11).
+    ReplacePlaylistEntries(playlistID string, entries []PlaylistEntry) error
+    // GetPlaylistEntryCounts reads the uplcnt:<id> derived view. Returns
+    // (0, 0, nil, nil) when the playlist has never had entries — that is
+    // "no entries", not an error.
+    GetPlaylistEntryCounts(playlistID string) (entryCount, unresolvedCount int, derivedBookIDs []string, err error)
+    // UpdatePlaylistEntryResolution surgically promotes ONE entry from an
+    // unresolved state to resolved (or between unresolved states). Touches
+    // BookFileID, BookID, State, ResolvedPath, LastCheckedAt and nothing else.
+    UpdatePlaylistEntryResolution(playlistID string, seq int, bookFileID, bookID string, state EntryState, resolvedPath string) error
+    // ListPlaylistsCitingBookFile is the reverse index: which playlists
+    // reference this book_file. Used by the reorganise-safety check and by the
+    // grouping-evidence reader.
+    ListPlaylistsCitingBookFile(bookFileID string) ([]string, error)
+    // ListUnresolvedPlaylistEntries returns the re-resolve worklist without a
+    // full uplent: scan. limit<=0 = all.
+    ListUnresolvedPlaylistEntries(limit int) ([]PlaylistEntry, error)
+    // SetPlaylistImportProvenance surgically stamps SourceKind/SourcePath/
+    // SourceContentHash/SourceMissing/ImportedAt on an existing row by
+    // re-fetching it first. The generic UpdateUserPlaylist path must never be
+    // used for this.
+    SetPlaylistImportProvenance(playlistID string, kind, path, contentHash string, missing bool) error
+```
+
+🔴 **The re-fetch-mutate-write discipline is inside the store, not spread across
+callers.** `SetPlaylistImportProvenance` does `prev, _ := p.GetUserPlaylist(id)`
+→ mutate only the named provenance fields on `prev` → marshal `prev`. No caller
+ever hands the store a `*UserPlaylist` it built itself. This is the mechanical
+form of rule 2. `ReplacePlaylistEntries` goes one better and does not touch the
+`upl:` document at all (D1.b).
+
+**Number of code paths that write `upl:<id>` after this change: still exactly
+one** — `UpdateUserPlaylist`, plus `SetPlaylistImportProvenance` which re-fetches
+first. That count is the invariant to protect in review.
+
+### 3.4 Timing records
+
+Timings live **on the entry** (`PlaylistEntry.Timing`, §3.1), not in a separate
+keyspace. Rationale: a cue sheet's timings are meaningless without the entry's
+file identity, and co-locating them means one write, one read, no orphan class.
+
+The consumer-facing read is:
+
+```
+GET /api/v1/books/:id/playlist-timings
+→ { "sources": [ { "playlist_id", "source_path", "source_kind": "cue",
+                   "book_file_id", "tracks": [ {track_number, start_sec, title} ] } ] }
+```
+
+built by walking `ListPlaylistsCitingBookFile` for each of the book's files.
+**Read-only.** No `SaveChaptersForBook` call anywhere in this workstream (D7).
+
+### 3.5 Grouping-evidence read API
+
+```
+GET /api/v1/playlists/grouping-evidence?limit=&offset=
+→ { "assertions": [ {
+      "playlist_id", "source_path", "source_kind",
+      "ordered_book_file_ids": [...],        // resolved entries only, in order
+      "ordered_raw_paths": [...],            // ALL entries, in order (resolved or not)
+      "distinct_book_ids": [...],            // parents of the resolved entries
+      "unresolved_count": N,
+      "under_frozen_itunes_tree": bool       // config.UnderFrozenITunesTree on source_path
+  } ], "total": N }
+```
+
+Contract notes the consumer needs:
+- `distinct_book_ids` with `len > 1` is the interesting case: a human said these
+  N book rows are one thing.
+- `unresolved_count > 0` means the assertion is **partial**, not wrong. A
+  consumer must treat it as "cannot verify the full membership", never as
+  refutation (D2).
+- `under_frozen_itunes_tree == true` means the *source file* is in the frozen
+  tree. The evidence is still usable; any structural action derived from it must
+  still run the regroup path's own frozen-tree skip.
+- The regroup consumer's natural join key is the book folder, computed by
+  `folderKeyOf` — which is **unexported** (`fs_regroup_shape.go:291`). Joining
+  will therefore require either exporting a helper or matching on
+  `ordered_raw_paths`. **This is a known open item — see §9-Q3.** This spec does
+  not change `fs_regroup_shape.go`.
+
+### 3.6 What is deliberately NOT changed
+
+- `UserPlaylist.BookIDs` semantics for existing rows.
+- `EvaluateSmartPlaylist` and the smart-playlist DSL (D9).
+- `PlaylistStore` (the legacy series-playlist generator, `iface_misc.go:223-229`)
+  and `database.Playlist` / `database.PlaylistItem` (`store.go:375,426`). Dead
+  weight, but out of scope — removing it is a separate cleanup.
+- The iTunes push contract in `playlist_sync.go`.
+
+---
+
+## 4. Operations
+
+All four are registered from `internal/plugins/maintenance/plugin.go` (the
+`relinkUnlinkedBooksDef()` entry at `plugin.go:83` is the pattern) using
+`sdk.OperationDef` (`internal/operations/registry/types.go:21`).
+
+### 4.1 `playlists.import-scan` — find and import playlist files
+
+| Field | Value | Why |
+|---|---|---|
+| `ResumePolicy` | `sdk.ResumeDrop` | matches `relinkUnlinkedBooksDef` (`relink_unlinked.go:78`); a partial import is safely re-runnable because identity is `(sourcePath, contentHash)` (D5) |
+| `Cancellable` | `true` | |
+| `Isolate` | `false` | |
+| `Timeout` | `120 * time.Minute` | same as relink |
+| `ConcurrencyKey` | `"playlists.import-scan"` | self-serializing |
+| `Capabilities` | `CapLibraryRead`, `CapFilesRead` **only in dry-run**; `CapLibraryWrite` declared because apply writes playlist rows | note: it writes *playlist* rows, never book rows (D4) |
+
+Params: `{"apply": bool, "limit": int, "roots": []string, "formats": []string}`.
+
+Phases:
+1. **enumerate** — walk each configured root, collect files whose extension is
+   in `formats`. Bounded-parallel `filepath.WalkDir` per root.
+2. **parse** — per file: read bytes, sha256, dispatch to the format parser
+   (§4.1.1). Parallel, results under a mutex.
+3. **resolve** — per entry: `GetBookFileByPath(resolvedPath)`; on `(nil,nil)`
+   fall back to `os.Stat` to distinguish `unresolved_no_row` from
+   `unresolved_missing`; check the path is under a configured root for
+   `unresolved_off_root`. Parallel.
+4. **write** (apply only, **single-threaded**) — `CreateUserPlaylist` /
+   `ReplacePlaylistEntries` / `SetPlaylistImportProvenance` per source file.
+
+Reconcile line, per phase, using `linkintegrity.PhaseResult`
+(`internal/linkintegrity/report.go:116`) so `Reconciles()` (`report.go:134`) and
+`UnreconciledPhases()` (`report.go:173`) apply unchanged. A non-empty
+`UnreconciledPhases()` **fails the op**, exactly as `relink_unlinked.go:222-224`
+does.
+
+#### 4.1.1 Format parsers (new package `internal/playlist/parse`)
+
+Pure functions, no I/O beyond the `[]byte` handed in — so they are trivially
+unit-testable and cannot touch the store.
+
+```go
+type ParsedEntry struct { RawPath, Title, Artist string; DurationSec int; Timing *database.EntryTiming }
+type ParsedPlaylist struct { Name string; Entries []ParsedEntry; Warnings []string }
+
+func ParseM3U(data []byte) (*ParsedPlaylist, error)   // .m3u (latin-1 tolerated), .m3u8 (UTF-8)
+func ParsePLS(data []byte) (*ParsedPlaylist, error)   // INI: File1=/Title1=/Length1=, NumberOfEntries
+func ParseXSPF(data []byte) (*ParsedPlaylist, error)  // XML: trackList/track/location|title|creator|duration(ms)
+func ParseCUE(data []byte) (*ParsedPlaylist, error)   // FILE/TRACK/INDEX/TITLE/PERFORMER
+func Detect(name string, data []byte) Format
+```
+
+Behaviour locked per format:
+
+- **M3U/M3U8** — `#EXTM3U` header optional. `#EXTINF:<secs>,<Artist> - <Title>`
+  parsed; `<secs> == -1` → `DurationSec = 0` (unknown, §3.1). Lines starting `#`
+  that are not recognised directives are ignored, not errors. `file://` URIs are
+  percent-decoded to a path; `http(s)://` entries are recorded with
+  `State = unresolved_off_root` and a warning — they are not fetched.
+  The current transient parser (`scanner.go:1595-1617`) *drops any line whose
+  path does not `os.Stat`* — that is precisely the absent-evidence-as-negative
+  bug (D2) and the new parser does not do it.
+- **PLS** — `[playlist]` section; `FileN` / `TitleN` / `LengthN` keyed by N;
+  `NumberOfEntries` is **advisory**: if it disagrees with the count of `FileN`
+  keys, keep every `FileN` found and emit a warning. `LengthN == -1` → 0.
+- **XSPF** — `<location>` is a URI; `file://` decoded, relative allowed.
+  `<duration>` is **milliseconds** (XSPF spec) → divide by 1000 into
+  `DurationSec`. ⚠️ This library has a documented millisecond/second confusion
+  class (`database.NormalizeDurationSec`, used at `relink_unlinked.go:378`;
+  the `maintenance.purge-millisecond-durations` op exists for the fallout) — the
+  XSPF divide is the one place a unit error would reintroduce it, so it gets its
+  own test.
+- **CUE** — extends the existing shape at `scanner.go:1567-1592`, which reads
+  only the first `TITLE` and the `FILE` lines. New parser additionally reads
+  `PERFORMER`, `TRACK nn AUDIO`, `INDEX 00`/`INDEX 01` (`mm:ss:ff`, ff = frames
+  at 75 fps → `sec = mm*60 + ss + ff/75.0`), and the per-track `TITLE`.
+  One CUE with one `FILE` and N `TRACK`s produces **N entries all sharing the
+  same `RawPath`** with distinct `Timing.TrackNumber`/`StartSec` — that is what
+  makes it a chapter source (D7). A CUE with multiple `FILE`s produces entries
+  grouped per file.
+
+### 4.2 `playlists.resolve-entries` — re-resolve unresolved entries
+
+Runs `ListUnresolvedPlaylistEntries(limit)` → for each,
+`GetBookFileByPath(resolvedPath)` → on hit,
+`UpdatePlaylistEntryResolution(...)`. Bounded pool for the lookups, writes
+single-threaded. Dry-run by default. This is what makes the ordering constraint
+in §1.1 soft: import can run **before** a relink and simply be re-resolved after.
+
+### 4.3 `playlists.export` — write `.m3u8` files
+
+Params `{"apply": bool, "playlist_ids": []string, "format": "m3u8", "dest": ""}`.
+`dest` defaults to `config.AppConfig.PlaylistDir` and is **rejected** if
+`config.UnderFrozenITunesTree(dest)` (D6). Emits `#EXTM3U`, then per entry
+`#EXTINF:<durationSec or -1>,<Artist> - <Title>` + the path. Path written is
+`ResolvedPath` for resolved entries and `RawPath` for unresolved ones — an
+unresolved entry is **exported, not dropped** (D2), so a round-trip
+import→export is lossless.
+
+### 4.4 Re-import semantics (D5), stated as a table
+
+| source path | content hash | playlist `UserModified` | action |
+|---|---|---|---|
+| known | unchanged | either | no-op, `skipped_unchanged++` |
+| known | changed | `false` | `ReplacePlaylistEntries` in place, keep ID |
+| known | changed | `true` | create a NEW playlist named `<name> (reimported YYYY-MM-DD)`; leave the human's copy alone |
+| known | source file gone | either | set `SourceMissing = true`; **never delete** |
+| new | — | — | create |
+
+---
+
+## 5. Concurrency
+
+Copied structurally from `relink_unlinked.go:113-156`:
+
+```go
+var mu sync.Mutex
+err := registry.RunItems(ctx, reporter, items, func(ctx context.Context, it T) error { ... },
+    registry.RunItemsOptions{
+        Concurrency:   runtime.NumCPU(),
+        ProgressTotal: len(items),
+        ErrMode:       registry.ErrModeCollect,
+        Label:         func(i, total int) string { ... },
+    })
+```
+
+(`registry.RunItems` — `internal/operations/registry/run_items.go:82`;
+`RunItemsOptions` — `:33`; `ErrModeCollect` — `:29`.)
+
+Rules for this workstream:
+- **Every** parallel phase is read-only. All writes happen after the pool drains,
+  single-threaded, so two workers can never touch one row. Same argument as
+  `relink_unlinked.go:107-112`.
+- The reverse index `idx:uplent:bf:*` is written inside
+  `ReplacePlaylistEntries`, which holds one Pebble batch per playlist — playlists
+  are disjoint, so per-playlist batches are the natural partition if this ever
+  needs to go parallel.
+- `filepath.WalkDir` per root runs in its own goroutine; the number of roots is
+  small and fixed, so an `errgroup` with `SetLimit(len(roots))` is the shape, not
+  an unbounded fan-out.
+
+---
+
+## 6. ABS-compatible surface
+
+### 6.1 What is known
+
+- The route exists and is currently a stub:
+  `r.GET("/api/libraries/:libraryId/playlists", auth, h.EmptyPage)` —
+  `internal/server/handlers/abs/handler.go:387`.
+- `EmptyPage` returns `pageResponse{Results: []any{}}` —
+  `browse.go:331-338`. `pageResponse` is `{include,limit,minified,page,results,sortDesc,total}`
+  — `dto_library.go:362-370`, with the note that a bare `{}` **throws** in the
+  client because `Page<T>` needs `total` and `page` even when empty (§1.8.6).
+- The route is covered by `absReservedPathPrefixes` via `"/api/libraries/"`
+  (`wire_abs_routes.go:64`), so it will not 301 into `/api/v1`.
+- It must appear in `absRouteList()` (`wire_abs_routes.go:377+`) or the guard
+  test `TestABSReservedPath_CoversEVERYRegisteredUnversionedRoute` never checks
+  it.
+- The conformance harness is `internal/syncapi/conformance` — `LoadFixture`
+  (`fixture.go:35`), `Fixture.CompareBody` (`fixture.go:49`).
+- The capture tool is `scripts/abs_capture_fixtures.py`, and 28 fixtures already
+  live in `testdata/abs-fixtures/`.
+
+### 6.2 What is NOT known — do not guess it 🔴
+
+**No playlist fixture has ever been captured.** The following are explicitly
+*unasserted* by this spec and must be resolved by capturing against the ABS
+oracle before the DTO is written:
+
+1. Envelope shape for `GET /api/libraries/:id/playlists` — bare array vs
+   `Page<T>` vs a `{playlists:[…]}` wrapper.
+2. Whether ABS **switches envelope on `limit`/`page`**. It provably does this for
+   `/authors`: "🔴 REAL ABS SWITCHES ENVELOPE ON `limit`/`page`, and the two
+   shapes share no keys. Verified against the oracle 2026-08-02"
+   (`dto_library.go`, the `authorsPageResponse` comment). Treat this as a live
+   risk for `/playlists`.
+3. The playlist item shape — whether entries carry `libraryItemId` alone, or
+   `libraryItemId` + `episodeId`, and whether the full `libraryItem` is inlined.
+4. Whether ABS exposes per-playlist detail (`GET /api/playlists/:id`) and
+   mutation (`POST /api/playlists`, `POST /api/playlists/:id/item`) that iOS
+   clients call, or only the library-scoped list.
+5. Field name for ordering — ABS may or may not expose an explicit order index.
+
+Writing a plausible DTO from recall and shipping it produces the exact failure
+that `absRouteList()` was built to prevent: a route that **exists and looks
+implemented while behaving broken** (`wire_abs_routes.go:370-375`). The plan
+therefore makes fixture capture a hard gate (plan step 10), and until it passes,
+`EmptyPage` **stays wired**.
+
+### 6.3 What the ABS surface projects
+
+Whatever the shape, the *content* is settled: ABS is a **book-level** protocol
+(`libraryItemId`), so the ABS playlist projects `UserPlaylist.BookIDs` — the
+de-duplicated, order-preserving projection of entries (D1.b). File-level entries
+are not exposed over ABS. Unresolved entries contribute nothing to `BookIDs` and
+so are invisible to ABS clients; the app API is where their existence is
+surfaced.
+
+---
+
+## 7. Failure modes and what happens on each
+
+| # | Failure | Behaviour | Why |
+|---|---|---|---|
+| F1 | Playlist entry path has no `book_file` row | Entry persisted with `State=unresolved_no_row`, counted, reported; `playlists.resolve-entries` promotes it later | D2. This was 38.2% of books before relink; assuming it is zero is how the feature silently loses data |
+| F2 | Playlist entry path does not stat | `State=unresolved_missing`, persisted, reported | D2 — an offline mount is indistinguishable from a deleted file (`relink_unlinked.go:239-243` makes the same call) |
+| F3 | Entry resolves outside every library root | `State=unresolved_off_root`, persisted, warning | Prevents a playlist from silently importing paths we do not manage |
+| F4 | Playlist file is malformed / partially parseable | Parse what is parseable, record the rest in `ParsedPlaylist.Warnings`, count the file as `errors++` if **zero** entries came out, else `actioned` with warnings | Silent total failure on one bad line is worse than a partial import that says so |
+| F5 | Two playlist files at different paths with identical content | Two playlists. Identity is `(sourcePath, contentHash)` (D5), not content alone | Different folders asserting the same grouping is two pieces of evidence, not one |
+| F6 | Re-import after a human edited the playlist | New playlist created; the human's copy untouched (`UserModified` table, §4.4) | Never destroy a human decision to satisfy an importer |
+| F7 | Source playlist file deleted | `SourceMissing = true`, playlist and entries retained | D5 — deletion is not idempotent; a rescan would remint it |
+| F8 | Export destination under `books/itunes/**` | Op **fails** with an error naming the path | D6 — the frozen tree is never written |
+| F9 | `UnreconciledPhases()` non-empty | Op returns an error; the run is not a health verdict | `report.go:173`; matches `relink_unlinked.go:222-224` |
+| F10 | Reorganise moves a file after import | Entry's `BookFileID` is unchanged and still correct — the whole point of G1. `ResolvedPath` goes stale and is refreshed by `playlists.resolve-entries` | Path-keyed playlists break here; row-keyed ones do not |
+| F11 | Book is merged/combined into another | `BookFileID` survives (`MoveBookFilesToBook` — `iface_misc.go:168` — moves the row, keeps the ID); `PlaylistEntry.BookID` goes stale | Mitigation: `BookID` is denormalized *cache*, re-derived on read from the `book_file` row; the `BookIDs` projection is rebuilt by `playlists.resolve-entries`. Documented as a known staleness window |
+| F12 | `book_file` row deleted | Entry becomes dangling. `playlists.resolve-entries` demotes it to `unresolved_no_row` and keeps `RawPath` | Never silently drop |
+| F13 | ABS client receives a malformed playlists payload | Guarded by not shipping a guessed DTO (§6.2) and by the conformance test | A malformed response red-screens the client — same class as the `/api/me` empty-list data loss warned about at `wire_abs_routes.go:196-205` |
+| F14 | CUE with `INDEX 00` pregap only, no `INDEX 01` | Track recorded with `StartSec` from `INDEX 00` and a warning; **not** dropped, **not** defaulted to 0 | D2 |
+| F15 | XSPF `<duration>` in ms mistaken for seconds | Guarded by a dedicated unit test asserting a 3,600,000 ms input yields `DurationSec == 3600` | The library has a documented ms/sec incident class (`purge-millisecond-durations`) |
+| F16 | A user `GET`s a smart playlist while `playlists.resolve-entries` is writing its counters | Nothing is lost: the GET's write-back touches only `upl:<id>`, the resolve pass touches only `uplent:`/`uplcnt:` (D1.c). The two documents have disjoint writers | The rejected design — counters on `upl:` — would have had the GET revert `UnresolvedCount` 0→20, because `UpdateUserPlaylist` bumps `Version` but never checks it (`pebble_store_playlists.go:310`) |
+| F17 | A user adds a book to an imported playlist, then the source file changes and re-import runs | `AddBooksToPlaylist` set `UserModified = true`, so `ReplacePlaylistEntries` **errors** (D11) and §4.4 routes the re-import to a new playlist. The user's added book survives | The rejected design had the entry path overwrite `BookIDs`, silently discarding it |
+
+---
+
+## 8. Non-goals
+
+1. **Not** redesigning smart playlists, the search DSL, or `EvaluateSmartPlaylist` (D9).
+2. **Not** writing chapters. No `SaveChaptersForBook` call exists in this
+   workstream (D7).
+3. **Not** calling combine / merge / regroup-apply / version-group. Evidence is
+   emitted only (D8).
+4. **Not** creating, mutating, or deleting `Book` or `BookFile` rows (D4).
+5. **Not** writing anything under `books/itunes/**`, export included (D6).
+6. **Not** removing the legacy `PlaylistStore` / `database.Playlist` /
+   `database.PlaylistItem` surface (`iface_misc.go:223`, `store.go:375,426`) or
+   the dead `GeneratePlaylistsForSeries` (`playlist.go:34`). Separate cleanup.
+7. **Not** fetching remote (`http(s)://`) playlist entries.
+8. **Not** changing the iTunes push contract in `playlist_sync.go`.
+9. **Not** exporting `.pls`, `.cue`, or `.xspf`. Import reads four formats;
+   export writes one (`.m3u8`), per the fragment ("Export back to `.m3u`").
+10. **Not** a scheduled job. Import runs on demand.
+11. **Not** adding a scan-time discovery hook. An earlier draft added
+    `OnPlaylistFileSeen` to `ScanHooks` (`internal/scanner/hooks.go:11-14`).
+    Dropped: it duplicates what `playlists.import-scan` already does by walking
+    the roots itself, and it is a compile-breaking change to an interface with
+    live implementers (`serverScanHooks` — `internal/server/server_search.go:141`;
+    `testDedupScanHooks` — `internal/scanner/save_book_to_database_test.go:163`)
+    inside the one package where a regression creates or destroys books. Not
+    worth the blast radius for zero capability. See §9-Q7.
+
+---
+
+## 9. Open questions
+
+**Q1 — ABS playlist wire shape (BLOCKING for step 10-11).** Must be captured
+from the oracle before any DTO is written. See §6.2 for the five specific
+unknowns. Owner action: confirm the ABS oracle is still reachable for
+`scripts/abs_capture_fixtures.py`.
+
+**Q2 — Does the scanner's transient CUE/M3U grouping get retired?**
+`findPlaylistGroupings` (`scanner.go:1635`) currently uses playlist files as a
+last-resort album-grouping fallback (`scanner.go:1833`). Once import persists
+the same information as first-class evidence, the transient path is redundant —
+but changing scanner grouping behaviour changes what books get created, which is
+a much larger blast radius. **Recommendation: leave it alone in this
+workstream**, and file the consolidation separately. Flagged, not decided.
+
+**Q3 — How does the regroup classifier join to grouping evidence?** The natural
+key is the book folder computed by `folderKeyOf`, which is unexported
+(`fs_regroup_shape.go:291`). Options: (a) export a `FolderKeyOf` helper,
+(b) have the consumer match on `ordered_raw_paths`, (c) have the evidence API
+also return folder paths and let the consumer compute. Owned by the regroup
+workstream; this spec ships (c)'s data (`ordered_raw_paths`) so any of the three
+remains possible.
+
+**Q4 — Should `playlists.import-scan` skip `books/itunes/**` sources by
+default?** D6 permits reading them. But the iTunes tree contains iTunes' own
+playlist exports, which may duplicate what `playlist_sync.go` already imports
+from the ITL (`MigrateSmartPlaylists`, `playlist_sync.go:55`). Risk is duplicate
+playlists, not data loss. **Proposed default: include, and surface
+`under_frozen_itunes_tree` on every finding so the dry run shows the overlap
+before anyone applies.** Confirm on the dry-run numbers.
+
+**Q5 — Per-user scoping of imported playlists.** `CreatedByUserID == ""` is
+treated as legacy/unowned and visible to every caller (`ownedByCaller`,
+`handlers/playlists.go:109-111`; mirrored in `listUserPlaylists`,
+`pebble_store_playlists.go:278-284`). An op-created import has no calling user.
+**Proposed: leave `CreatedByUserID` empty**, which makes imports library-wide —
+consistent with how iTunes imports already behave. Confirm this is wanted rather
+than assigning them to the triggering user.
+
+**Q6 — Frontend.** `web/src/pages/PlaylistDetail.tsx` renders book-level
+membership. Showing file-level entries and their unresolved state is a UI change
+of unknown size; this spec does not scope it. Minimum viable: surface
+`entry_count` / `unresolved_count` on the existing list and detail views.

--- a/docs/specs/2026-08-05-review-queue-recommendations-design.md
+++ b/docs/specs/2026-08-05-review-queue-recommendations-design.md
@@ -1,0 +1,654 @@
+<!-- file: docs/specs/2026-08-05-review-queue-recommendations-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0a7c4f19-52d6-4b83-9e10-c6b7a3f8d245 -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** This document was authored by
+> an agent on 2026-08-05 but the adversarial verification pass (which grep-verifies
+> that every cited function, struct field, op ID and file path actually exists) did
+> NOT run — the workflow was halted by API rate limiting before stage 2.
+>
+> **Treat every code citation as a claim, not a fact.** The most common failure mode
+> in generated plans is a confidently-cited symbol that does not exist. Verify before
+> executing. The design reasoning and the measured production numbers are still sound
+> and were drawn from real observations; the code references are what needs checking.
+
+
+# Review-queue recommendations + per-hold override actions — DESIGN
+
+Owner items 1 and 2 (2026-08-05). Fragment:
+`todo.d/20260805_220000_review_queue_recommendations_and_overrides.md`.
+
+Companion plan: [`docs/plans/2026-08-05-review-queue-recommendations-plan.md`](../plans/2026-08-05-review-queue-recommendations-plan.md)
+
+---
+
+## 1. Problem statement
+
+### 1.1 The queue says the same thing on almost every row
+
+`maintenance.regroup-shattered-ai` writes one review hold per candidate book
+folder. Every hold carries a `proposedAction` string produced by
+`classifyGroup` (`internal/itunes/service/fs_regroup_shape.go:570-771`), which
+is a hard-coded literal per branch.
+
+**Measured 2026-08-05 (pre-relink population, 777 holds): 762 of 777 holds
+(98.1%) carried the single string**
+
+> `review: flat folder shares a title but ordering is unclear`
+
+emitted by the flat-ambiguous branch at
+`internal/itunes/service/fs_regroup_shape.go:760-764`. A queue where 98% of
+rows say the same sentence is a queue nobody can work: there is no way to tell
+"six three-minute chapters of one novel" from "six two-hour novels by one
+author" without opening each hold and reading file paths by hand.
+
+### 1.2 This is NOT a missing-data problem — that was already fixed
+
+The obvious hypothesis was that the classifier was starved of runtime data.
+`ShatterBook.DurationSec` (`fs_regroup_shape.go:97-102`) is summed by the
+producer from `store.GetBookFiles(id)`
+(`internal/plugins/maintenance/regroup_shattered_ai.go:151-154`), and 97.5% of
+review-queue members had zero `book_file` rows
+(`.claude/notes/2026-08-05-unlinked-books-investigation.md`), so `DurationSec`
+was 0 and `membersAreBookLength` (`fs_regroup_shape.go:149-160`) could not fire.
+
+`maintenance.relink-unlinked-books` (PR #2147) has since been applied.
+
+**Measured after relink: member duration coverage went 2.5% → 92.2%, and the
+review queue moved 357 → 356 holds.**
+
+One hold. The classifier saw real runtimes for 92.2% of members and changed its
+mind about exactly one folder. That measurement is what makes this workstream a
+**classifier-output and UX problem, not a data problem**, and it is why the
+design below adds a *reporting* layer over the existing signals rather than
+retuning the classification branches.
+
+### 1.3 The human cannot override the machine
+
+`approveOne` (`internal/server/handlers/review/handler.go:179-208`) looks up the
+apply function by `item.Kind`:
+
+```go
+fn, hasHandler := h.applyHandlerFor(item.Kind)   // handler.go:187
+```
+
+Wiring registers three Kinds (`internal/server/wire_handlers.go:604-607`):
+`regroup.multidisc` → `ApplyMultidisc`, `regroup.anthology` → `ApplyMultidisc`,
+`regroup.version-group` → `ApplyVersionGroup`. `regroup.ambiguous` is
+deliberately handler-less.
+
+So the human's only expressible decisions are "do whatever this Kind means" and
+"reject". A reviewer who reads a `regroup.ambiguous` hold, concludes "these are
+six separate novels", and clicks Approve gets… nothing: status `approved`, a
+note, no action, and `ReplayApprovedItems` will list it forever as
+`no apply handler registered for this kind` (`replay.go:84`).
+
+### 1.4 `deriveSurvivorTitle` returns wrong titles
+
+`deriveSurvivorTitle` (`fs_regroup_shape.go:840-853`) takes **only the folder
+name** and strips a leading ordinal / trailing parenthetical / trailing `- N`.
+It is called at `fs_regroup_shape.go:660` with `folderName` alone, discarding
+the two signals computed 15 lines earlier — `dominantPrefix`
+(`fs_regroup_shape.go:627`) and `folderNamedAfterBook`
+(`fs_regroup_shape.go:645-647`).
+
+Observed outputs: author names (`C. T. Phipps`), bare ordinals (`Volume 1`),
+and wrong volume numbers (a folder named `… Vol. 01` whose member files all say
+`Vol. 9`). `SurvivorTitle` is display-only today — the apply path calls
+`CombineBooks(present, primaryID, nil)` with a **nil** override
+(`internal/plugins/maintenance/regroup_apply.go:100`), so the survivor's
+metadata is never rewritten — but a title that names the author is exactly the
+kind of label that makes a reviewer reject a good regroup
+(`fs_regroup_shape.go:534-552` documents the identical failure for `FolderRef`).
+
+---
+
+## 2. Scope
+
+**In scope**
+
+1. A structured recommendation (`recommendedAction`, `recommendationReason`,
+   `recommendationEvidence`) computed from signals `classifyGroup` already has,
+   emitted on every hold.
+2. A closed action vocabulary and an action-keyed apply-handler registry, so
+   `approveOne` dispatches on the **chosen** action.
+3. `POST /api/v1/review/items/:id/approve` accepting an optional
+   `{"action": "..."}` body.
+4. Persisting the chosen action on the `ReviewItem` so `ReplayApprovedItems`
+   replays the human's decision, not the Kind's default.
+5. Fixing `deriveSurvivorTitle` and reporting its provenance.
+6. Frontend: render the recommendation + evidence; let the reviewer pick.
+
+**Out of scope** — see §8 Non-goals.
+
+---
+
+## 3. Locked decisions
+
+### D1 — The four `Kind` strings do not change, and neither does the Kind switch
+
+`KindMultidisc` / `KindVersionGroup` / `KindAnthology` / `KindAmbiguous`
+(`fs_regroup_shape.go:70-75`) stay exactly as they are, and **not one branch
+condition in `classifyGroup`'s switch (`fs_regroup_shape.go:668-770`) is
+touched.**
+
+*Why.* The Kind strings are load-bearing: the frontend maps them verbatim
+(`web/src/lib/reviewKinds.ts:8-13`), `regroupDedupKey` hashes
+`(Kind, FolderRef)` (`regroup_shattered_ai.go:340-343`) so changing a Kind
+orphans every existing hold, and `reconcileStaleHolds` keys off the
+`regroup.` prefix (`regroup_shattered_ai.go:318`). Leaving the switch untouched
+also gives the acceptance gate a **free exact regression test**: the
+`bykind=` map in the RECONCILE line (`regroup_shattered_ai.go:220-223`) must be
+byte-identical to the pre-change run. Any drift means the classifier was
+perturbed by accident.
+
+The recommendation is computed **alongside** the Kind, from the same signals,
+and stored in the payload. The fragment says it explicitly: *"put the decision
+in the payload, do not add Kinds."*
+
+### D2 — Action vocabulary (closed set), and the fifth action
+
+The fragment names four: `combine`, `separate`, `duplicate-of`,
+`insufficient-evidence`. This design adds a **fifth**, `version-group`.
+
+*Why the addition is required.* Once dispatch keys off the chosen action rather
+than `item.Kind`, `ApplyVersionGroup` (`regroup_apply.go:188`) — today
+registered under `KindVersionGroup` at `wire_handlers.go:606-607` — becomes
+**unreachable** unless an action names it. Dropping it would silently disable
+the Abridged/Unabridged linking path. Flagged here for owner review rather than
+buried in the plan.
+
+| Action | Meaning | Handler | Destructive? |
+|---|---|---|---|
+| `combine` | These files are one book. | `ApplyMultidisc` → `CombineBooks` | **Yes** — absorbed Book rows are hard-deleted (`regroup_apply.go:28`) |
+| `separate` | These are already N separate books; leave them. | `ApplySeparate` (no-op, new) | No |
+| `version-group` | Two editions of one work; link, keep both visible. | `ApplyVersionGroup` | No (locked decision #8: never soft-deletes) |
+| `duplicate-of` | Debris of a book that already exists correctly. | **none in this workstream** | n/a |
+| `insufficient-evidence` | The machine cannot tell. | **emit-only, not choosable** | n/a |
+
+### D3 — `separate` gets a registered no-op handler, not "no handler"
+
+The fragment is right that `separate` needs no *work*: every member is already
+its own book. But "no handler" is not the same as "no work". With no handler,
+`approveOne` records `approved` + a note (`handler.go:202`), and
+`ReplayApprovedItems` will re-list that item as skipped on every future replay
+(`replay.go:84`) — permanent noise that never drains.
+
+So `separate` gets `ApplySeparate`: a registered `ApplyFunc` that logs the
+decision and returns `nil`, which drives the item to `applied` — a terminal
+state. `UpsertReviewItem` full-no-ops on non-pending rows
+(`review_store.go:239-242`), so the decision survives every re-scan, exactly as
+the fragment describes.
+
+**Honest caveat:** while `review_apply_enabled` is OFF in prod (it is — see
+`wire_handlers.go:588` and the memory note *review-apply switch OFF in prod*),
+a `separate` approve still lands on `approved` + note, because
+`applyGloballyEnabled()` gates *all* dispatch (`handler.go:188`). The benefit of
+the no-op handler is dormant until the switch flips or `replay-approved` runs.
+
+### D4 — `insufficient-evidence` is emit-only; overriding to it is a 400
+
+A recommendation of `insufficient-evidence` is a statement *by the machine*.
+There is no human action it maps to: the human either knows the answer (and
+picks `combine`/`separate`/`version-group`) or does not (and leaves the hold
+pending). `POST …/approve` with `{"action":"insufficient-evidence"}` returns
+400.
+
+**Critically, the UI must not steer these toward Reject.** `rejected` is
+remembered forever — the dedup index is never deleted for a decided row
+(`review_store.go:115-131`, "rejected is remembered"), and `reconcileStaleHolds`
+only purges *pending* holds (`regroup_shattered_ai.go:314-329`). Rejecting an
+`insufficient-evidence` hold permanently suppresses a folder that the tier-2
+duration probe (First Aid task #3) could resolve next month. Leaving it pending
+is the correct outcome.
+
+### D5 — The chosen action is PERSISTED on the ReviewItem
+
+New field `ReviewItem.ChosenAction` (`internal/database/review_store.go:60-70`)
+plus `SetReviewItemDecision(id, status, action string)` on `ReviewStore`.
+
+*Why this is non-negotiable.* `ReplayApprovedItems` exists precisely because
+approved decisions were being silently discarded — read `replay.go:30-46`, which
+documents that `ReviewStatusApproved` appeared in exactly two places in the
+codebase before it was written: the constant, and the one line that sets it.
+It dispatches with `h.applyHandlerFor(it.Kind)` (`replay.go:80` and
+`replay.go:116`). If the chosen action lives only in the HTTP request, then a
+human who overrides an ambiguous hold to `separate` while the switch is off has
+their decision replayed later as *the Kind's default* — recreating the exact
+class of bug `replay.go` was written to fix, one layer up.
+
+Storage safety: `SetReviewItemStatus` already re-reads the record and mutates
+in place (`review_store.go:427-436`), and the pending-upsert path likewise
+patches the fetched row (`review_store.go:245-250`) — both are the safe
+re-fetch-and-patch shape, so `ChosenAction` survives a producer re-scan with no
+extra code. The one fresh-struct construction is the dangling-dedup-index
+recovery branch (`review_store.go:207-221`), where the record is *gone* and
+there is nothing to preserve; that branch is documented, not changed.
+
+### D6 — Bulk approve NEVER uses per-item recommendations
+
+`BulkReviewAction` (`handler.go:253-324`) calls `approveOne` per id
+(`handler.go:294`). After this change:
+
+- `bulkRequest` gains an optional `action` field. When set, it is validated once
+  and applied to **every** target.
+- When absent, bulk uses `defaultActionForKind(item.Kind)` — which reproduces
+  today's dispatch exactly (multidisc/anthology → `combine`, version-group →
+  `version-group`, ambiguous → `""` → no handler → `approved` + note).
+
+*Why.* A recommendation is a per-item claim about a specific folder. Approving
+300 of them from a bucket header without reading any is the precise failure mode
+that produced the 41-of-43 near-miss documented at `fs_regroup_shape.go:128-148`.
+Single-item approve honours the recommendation; bulk requires the human to name
+one action for the whole batch.
+
+### D7 — Combine recommendations are gated on positive duration evidence
+
+`membersAreBookLength` counts unknown durations as **not** book-length
+(`fs_regroup_shape.go:148-159`). That is correct for a *guard* — an absent value
+must not fire a veto — but it means that when durations are missing the series
+guard is silently false and the flat branch falls straight through to a
+confident collapse. That is the 41-of-43 shape.
+
+So the recommender applies rule **R1 before any combine rule**: if a majority of
+members have `DurationSec == 0`, the recommendation is `insufficient-evidence`,
+with the missing count in the evidence. **Absent evidence is never negative
+evidence.** (Exception, narrowly: a `disc`- or `chapter`-structured group whose
+folder is named after the book carries independent structural proof and may
+still recommend `combine` — recorded as `durationsMissing` in the evidence so
+the human sees it.)
+
+### D8 — The recommender is a pure function, run in the existing single-threaded phase
+
+No new whole-library loop. `runRegroupShatteredAI` fans the per-book *read* out
+over `registry.RunItems` at `runtime.NumCPU()`
+(`regroup_shattered_ai.go:124-137, 200-207`); grouping, classification and the
+review-row writes are deliberately single-threaded afterwards
+(`regroup_shattered_ai.go:128-130, 212-213`). The recommender is a pure function
+over the already-materialised `memberInfo` slice, called once per group inside
+`classifyGroup` — O(members) with no I/O. The CLAUDE.md concurrency mandate is
+satisfied by construction; nothing new to parallelise.
+
+### D9 — The frozen iTunes tree stays excluded, unchanged
+
+`books/itunes/**` members are dropped at the source
+(`regroup_shattered_ai.go:191-194`, via `config.UnderFrozenITunesTree`,
+`internal/config/itunes_libraries.go:98`). No recommendation logic re-derives or
+relaxes that policy.
+
+---
+
+## 4. Data model
+
+### 4.1 Action vocabulary (Go)
+
+New file `internal/itunes/service/regroup_actions.go`:
+
+```go
+const (
+    ActionCombine              = "combine"
+    ActionSeparate             = "separate"
+    ActionVersionGroup         = "version-group"
+    ActionDuplicateOf          = "duplicate-of"
+    ActionInsufficientEvidence = "insufficient-evidence"
+)
+```
+
+`ValidChosenAction(a string) bool` → true for `combine`, `separate`,
+`version-group`, `duplicate-of`; **false** for `insufficient-evidence` and
+anything else (D4).
+
+`DefaultActionForKind(kind string) string`:
+
+| Kind | Default action |
+|---|---|
+| `regroup.multidisc` | `combine` |
+| `regroup.anthology` | `combine` |
+| `regroup.version-group` | `version-group` |
+| `regroup.ambiguous` | `""` (no dispatch) |
+
+This table is a behaviour-preserving restatement of `wire_handlers.go:604-607`
+and is what legacy holds (payloads written before `recommendedAction` existed)
+fall back to. **`regroup.ambiguous` → `""` is load-bearing**: it guarantees a
+pre-existing ambiguous hold cannot suddenly become a merge.
+
+### 4.2 `RegroupGroup` additions
+
+`internal/itunes/service/fs_regroup_shape.go`, struct at
+`fs_regroup_shape.go:162-181`:
+
+```go
+    RecommendedAction   string                 // one of the Action* constants
+    RecommendationReason string                // one sentence, quotes its own numbers
+    Evidence            RecommendationEvidence
+    SurvivorTitleSource string                 // "folder" | "members" | "none"
+```
+
+### 4.3 `RecommendationEvidence`
+
+New type in `internal/itunes/service/regroup_recommend.go`. Every field is a
+number `classifyGroup` already computes or trivially derives; nothing here
+requires new I/O.
+
+```go
+type RecommendationEvidence struct {
+    Members            int   `json:"members"`
+    DurationsKnown     int   `json:"durationsKnown"`
+    DurationsMissing   int   `json:"durationsMissing"`
+    MemberDurationsSec []int `json:"memberDurationsSec"` // play order, 0 = unknown
+    MedianKnownSec     int   `json:"medianKnownSec"`
+    TotalKnownSec      int   `json:"totalKnownSec"`
+    BookLengthMembers  int   `json:"bookLengthMembers"`  // DurationSec >= bookLengthSec (5400)
+
+    DistinctStems      int    `json:"distinctStems"`      // == distinctPrefixes
+    DominantStem       string `json:"dominantStem"`       // == dominantPrefix
+    DominantStemCount  int    `json:"dominantStemCount"`  // == dominantCount
+
+    NumberedMembers    int    `json:"numberedMembers"`
+    DiscMembers        int    `json:"discMembers"`
+    ChapterMembers     int    `json:"chapterMembers"`
+    FlatMembers        int    `json:"flatMembers"`
+    Structure          string `json:"structure"`          // "disc"|"chapter"|"flat"|"edition"
+
+    FolderNamedAfterBook bool `json:"folderNamedAfterBook"`
+    MergedViaITunes      bool `json:"mergedViaItunes"`
+    SingleBookMarker     bool `json:"singleBookMarker"`   // anthology/omnibus/collection
+    MultiBookMarker      bool `json:"multiBookMarker"`    // trilogy/quartet/boxed set
+    HasUnabridged        bool `json:"hasUnabridged"`
+    HasAbridged          bool `json:"hasAbridged"`
+}
+```
+
+Source of each existing signal, so no one re-derives them:
+`distinctPrefixes` / `dominantPrefix` / `dominantCount`
+(`fs_regroup_shape.go:627-628`); `discCount` / `chapterCount` / `flatCount` /
+`numberedCount` (`fs_regroup_shape.go:609-626`); `structure`
+(`fs_regroup_shape.go:629`); `folderNamedAfterBook`
+(`fs_regroup_shape.go:645-647`); `mergedViaItunes` (`fs_regroup_shape.go:581`);
+markers (`fs_regroup_shape.go:604-606`); `bookLengthSec = 90*60`
+(`fs_regroup_shape.go:123`).
+
+### 4.4 `regroupPayload` additions
+
+`internal/plugins/maintenance/regroup_shattered_ai.go:64-81`. Existing fields
+are **unchanged** (`proposedAction` stays — the frontend reads it at
+`web/src/pages/ReviewQueue.tsx:164` and old holds still carry it):
+
+```go
+    RecommendedAction    string                                `json:"recommendedAction,omitempty"`
+    RecommendationReason string                                `json:"recommendationReason,omitempty"`
+    Evidence             *itunesservice.RecommendationEvidence `json:"recommendationEvidence,omitempty"`
+    SurvivorTitleSource  string                                `json:"survivorTitleSource,omitempty"`
+```
+
+`omitempty` everywhere: a hold written by the old binary decodes cleanly into
+the new struct with zero values, and `DefaultActionForKind` covers it.
+
+### 4.5 `ReviewItem` addition
+
+`internal/database/review_store.go:60-70`:
+
+```go
+    ChosenAction string `json:"chosen_action,omitempty"` // action the human picked at approve time
+```
+
+Empty for every existing row and for `reject`.
+
+---
+
+## 5. The recommender
+
+`func recommend(sig groupSignals, members []memberInfo) (action, reason string, ev RecommendationEvidence)`
+in `internal/itunes/service/regroup_recommend.go`.
+
+`groupSignals` is a new struct holding the values `classifyGroup` already
+computes between `fs_regroup_shape.go:578` and `:648`; `classifyGroup` is
+refactored to populate it once and use it in both the (unchanged) Kind switch
+and the recommender. **This refactor must be behaviour-preserving for the Kind
+switch** — that is what the identical-`bykind` gate proves.
+
+Rules are evaluated **in order**. Safety asymmetry is deliberate: `combine`
+hard-deletes absorbed Book rows (`regroup_apply.go:28`), `separate` does
+nothing. So every guard that could yield `separate` or
+`insufficient-evidence` is checked **before** any combine rule.
+
+| # | Condition | Action | Reason template |
+|---|---|---|---|
+| R1 | `DurationsKnown*2 <= Members` **and not** (`Structure` ∈ {disc, chapter} ∧ `FolderNamedAfterBook`) | `insufficient-evidence` | "%d of %d members have no known runtime — cannot tell chapters from separate books" |
+| R2 | `MergedViaITunes` | `insufficient-evidence` | "grouped only by a shared original iTunes album across %d different file-path folders" |
+| R3 | `BookLengthMembers*2 > Members` | `separate` | "%d of %d members run ≥90 min — each is book-length, so this folder holds separate books" |
+| R4 | `MultiBookMarker && DistinctStems >= 3 && DistinctStems*2 > Members` | `separate` | "folder is marked as a trilogy/boxed set and carries %d distinct titles" |
+| R5 | `HasUnabridged && HasAbridged && DominantStemCount*2 >= Members` | `version-group` | "both Abridged and Unabridged markers with one dominant title (%d of %d members)" |
+| R6 | `Structure == "disc" && DiscMembers*2 > Members` | `combine` | "%d of %d members sit in Disc/CD subfolders" |
+| R7 | `Structure ∈ {chapter, edition} && FolderNamedAfterBook && DistinctStems <= 1` | `combine` | "chapter/edition shells all named after the folder's book, one title stem" |
+| R8 | `SingleBookMarker && DistinctStems >= 3 && DistinctStems*2 > Members` | `combine` | "anthology/omnibus marker with %d distinct story titles — one published book" |
+| R9 | `Structure == "flat" && NumberedMembers*2 >= Members && Members >= 4 && !manyDistinctTitles && MedianKnownSec < 5400` | `combine` | "%d of %d files numbered, median runtime %s — chapter-length, one book" |
+| R10 | `DistinctStems >= 3 && DistinctStems*2 > Members && !FolderNamedAfterBook` | `separate` | "%d distinct titles and the folder is not named after any of them" |
+| R11 | otherwise | `insufficient-evidence` | "no decisive signal: %d members, %d distinct titles, structure %s" |
+
+Notes:
+
+- `manyDistinctTitles` in R9 is the existing expression at
+  `fs_regroup_shape.go:638` (`DistinctStems >= 3 && DistinctStems*2 > n`).
+- R9's `MedianKnownSec < 5400` is a positive-evidence requirement, not a guard.
+  It is reachable only after R1 established a duration majority.
+- `4` in R9 is `flatMultitrackMin` (`fs_regroup_shape.go:220`); `5400` is
+  `bookLengthSec` (`fs_regroup_shape.go:123`). Use the constants.
+- Every reason string interpolates the numbers that fired the rule. A reason
+  without numbers is a nicer generic string, which is the thing being fixed.
+
+**The single most important test in the suite** (see plan step 2): N members,
+all `DurationSec == 0`, flat structure, numbered, `n >= 4` → must yield
+`insufficient-evidence`, **never** `combine`. That is the 41-of-43 shape with
+its guard inert.
+
+`duplicate-of` is never emitted by this recommender (§8).
+
+---
+
+## 6. `deriveSurvivorTitle`
+
+New signature:
+
+```go
+func deriveSurvivorTitle(folderName string, folderNamedAfterBook bool,
+    dominantStem string, dominantAuthor string) (title, source string)
+```
+
+Rules:
+
+1. If `folderNamedAfterBook` → clean(`folderName`), source `"folder"`.
+2. Else if `dominantStem != ""` → clean(original-case dominant prefix), source
+   `"members"`.
+3. Else → `""`, source `"none"`.
+
+Then three rejection guards; a title failing any of them becomes `""` with
+source `"none"`:
+
+- **Author guard.** `normTitle(candidate) == normTitle(dominantAuthor)` →
+  reject. Fixes `C. T. Phipps`. `dominantAuthor` is the majority
+  `ShatterBook.Author` (`fs_regroup_shape.go:95`) among members; when no author
+  has a majority it is `""` and the guard is inert.
+- **Bare-ordinal guard.** New regex
+  `^(?i)(vol(?:ume)?|bk|book|part|pt|disc|cd)\s*\.?\s*\d+$` on the cleaned
+  candidate → reject. Fixes `Volume 1`.
+- **Empty guard.** Cleaning left nothing → reject.
+
+The existing cleaning helpers stay: `leadingNumRe`, `trailingParenRe`,
+`trailingNumSuffixRe` (`fs_regroup_shape.go:254-258`).
+
+Rule 2 uses **`dominantPrefix`, not `ShatterBook.Title`.** The package doc is
+explicit that per-track tags are unreliable and that the library folder is the
+only reliable identity signal (`fs_regroup_shape.go:12-15`, "decision #6:
+regex-only v1"), and `Title` is documented as "may be empty"
+(`fs_regroup_shape.go:94`). Preferring the tag would contradict the
+classifier's own founding rationale. Fixing the *wrong-volume-number* case
+(`Vol. 01` folder over `Vol. 9` files) falls out of rule 2: when the folder is
+not named after the members' dominant stem, the members win.
+
+`SurvivorTitle` remains display-only — nothing in `regroup_apply.go` reads it,
+and `CombineBooks` is called with a nil override (`regroup_apply.go:100`), so
+this change writes nothing to any Book row.
+
+---
+
+## 7. API surface
+
+### 7.1 `POST /api/v1/review/items/:id/approve`
+
+Optional body:
+
+```json
+{ "action": "combine" }
+```
+
+Binding **must** use the optional-body pattern from `replay.go:58`
+(`_ = c.ShouldBindJSON(&req)`), not a hard bind — every existing caller,
+including `web/src/services/api.ts:5899-5908`, POSTs with no body and no
+`Content-Type`, and a hard bind would 400 all of them.
+
+Resolution order inside `approveOne`:
+
+1. `req.Action` if non-empty → must satisfy `ValidChosenAction`, else **400**
+   `INVALID_REVIEW_ACTION`.
+2. else `payload.recommendedAction` if it satisfies `ValidChosenAction`.
+3. else `DefaultActionForKind(item.Kind)`.
+
+Then `fn, ok := h.actionHandlerFor(resolvedAction)`. Same gate as today:
+handler present **and** `applyGloballyEnabled()` → run, then
+`SetReviewItemDecision(id, applied, resolvedAction)`. Otherwise
+`SetReviewItemDecision(id, approved, resolvedAction)` + note.
+
+Response adds `"action": "<resolved>"` alongside the existing `item` / `note`
+keys, so the UI can confirm what it just did.
+
+### 7.2 `POST /api/v1/review/bulk`
+
+`bulkRequest` (`handler.go:232-236`) gains `Action string \`json:"item_action,omitempty"\``
+— named `item_action` because `action` is already taken by
+`approve`/`reject`. Validated once with `ValidChosenAction`; when empty, D6
+applies (`DefaultActionForKind`, i.e. today's behaviour).
+
+`bulkResult` gains `by_action map[string]int` so the operator can read
+"applied 12 combine, 40 separate" instead of "applied 52".
+
+### 7.3 `POST /api/v1/review/replay-approved`
+
+`replay.go:80` and `replay.go:116` change from
+`h.applyHandlerFor(it.Kind)` to `h.actionHandlerFor(actionFor(it))`, where
+`actionFor` is: `it.ChosenAction` → else payload `recommendedAction` → else
+`DefaultActionForKind(it.Kind)`.
+
+The dry-run response gains `would_replay_by_action` and the apply response
+gains `applied_by_action` (per D3's caveat: an operator must not read
+`applied=300` as 300 merges when 250 of them are no-op `separate`s).
+
+### 7.4 Handler registry
+
+`RegisterApplyHandler(kind, fn)` → `RegisterActionHandler(action, fn)`
+(`handler.go:77-81`); `applyHandlerFor` → `actionHandlerFor`
+(`handler.go:83-88`). The map is now keyed by action, never by Kind.
+
+Wiring (`wire_handlers.go:603-607`) becomes:
+
+```go
+combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc)
+reviewH.RegisterActionHandler(itunesservice.ActionCombine, combine)
+reviewH.RegisterActionHandler(itunesservice.ActionVersionGroup,
+    maintenanceplugin.ApplyVersionGroup(s.Store()))
+reviewH.RegisterActionHandler(itunesservice.ActionSeparate,
+    maintenanceplugin.ApplySeparate())
+```
+
+Note that `KindMultidisc` and `KindAnthology` collapsing to one `combine`
+registration is behaviour-identical: both already registered the same closure
+(`wire_handlers.go:604-605`).
+
+---
+
+## 8. Non-goals
+
+- **No new `Kind` strings, no changes to `classifyGroup`'s switch conditions**
+  (D1). If the recommender and the Kind disagree, that is information for the
+  human, not a bug to fix here.
+- **No `duplicate-of` detector.** Detecting "this group's member durations
+  already appear as tracks of another book" (the Successors class,
+  `.claude/notes/2026-08-05-unlinked-books-investigation.md`) needs cross-book
+  comparison — First Aid tier 2, task #10. This workstream reserves the action
+  string and validates it; no producer emits it and no handler is registered,
+  so choosing it records `approved` + note.
+- **No tier-2 duration probing.** `insufficient-evidence` holds stay pending
+  until task #3 gives them real runtimes.
+- **No deletion of anything, ever.** Rescan regenerates a book for any file no
+  `book_file` row claims; duplicates are resolved by re-association, never
+  deletion.
+- **No writes to `books/itunes/**`** (D9).
+- **No change to `review_apply_enabled`'s default (OFF).** Enabling it is
+  owner item 3's canary, a separate workstream.
+- **No auto-apply.** Every hold remains a human decision.
+- **No retuning of thresholds** (`bookLengthSec`, `flatMultitrackMin`,
+  `manyDistinctTitles`). The recommender reuses them verbatim.
+
+---
+
+## 9. Failure modes
+
+| # | Failure | What happens | Mitigation |
+|---|---|---|---|
+| F1 | **Recommendation escalates an inert hold into a merge.** Today `regroup.ambiguous` has no handler, so Approve is a no-op. After this change an ambiguous hold recommending `combine` is one click from `CombineBooks`, which hard-deletes absorbed rows (`regroup_apply.go:28`). | Intended per the fragment — but the blast radius is real. | `review_apply_enabled` is OFF in prod, so nothing executes until it is deliberately flipped; single-item only (D6); `combine` gated on duration evidence (D7/R1); the acceptance gate below requires zero `combine` recommendations with a duration majority missing. |
+| F2 | **Legacy hold with no `recommendedAction`.** | `DefaultActionForKind` → for `regroup.ambiguous` that is `""` → no handler → `approved` + note, i.e. **byte-identical to today**. | Explicit test. |
+| F3 | **Human overrides, switch is off, decision evaporates.** | Prevented: `ChosenAction` is persisted (D5) and `replay-approved` reads it. | Test: approve with `{"action":"separate"}` while disabled → item is `approved` with `chosen_action=separate`; enable + replay → dispatches `separate`, not the Kind default. |
+| F4 | **Producer re-scan wipes `ChosenAction`.** | Cannot happen: decided rows full-no-op (`review_store.go:239-242`), pending rows are patched in place (`review_store.go:245-250`). The one fresh-struct path is dangling-index recovery (`review_store.go:207-221`) where the record no longer exists. | Regression test that upserts over a decided row and asserts `ChosenAction` survives. |
+| F5 | **`insufficient-evidence` holds get rejected en masse to clear the queue.** | `rejected` is remembered forever (`review_store.go:131`); the folder never resurfaces even after tier-2 probing gives it durations. | D4: UI never offers Reject as the recommended path for these; copy says "leave pending — more evidence is coming". Open question §10.1 asks whether a distinct status is warranted. |
+| F6 | **Replay count conflation.** `applied=300` reads as 300 merges when 250 are no-op `separate`s. | Per-action counts in every response (§7.2, §7.3) and in the op log. |
+| F7 | **Hard body-bind 400s every existing approve call.** | `_ = c.ShouldBindJSON(&req)` per `replay.go:58`; test with an empty body and no `Content-Type`. |
+| F8 | **`groupSignals` refactor silently perturbs the Kind switch.** | The `bykind=` map in the RECONCILE line must be **identical** to the prior prod run (§11). Any drift → stop, do not apply. |
+| F9 | **Evidence array bloat.** `memberDurationsSec` on a 133-member group adds ~700 bytes of JSON per hold. At ~360 holds that is ~250 KB total. | Acceptable. Payloads already carry parallel `files`/`discNumbers`/`trackNumbers` arrays of the same length (`regroup_shattered_ai.go:376-385`). |
+| F10 | **Mock drift.** `database.Store` embeds `ReviewStore` (`internal/database/store.go:57`); adding an interface method breaks the hand-written `MockStore` compile assertion (`internal/database/mock_store.go:2721-2728`) and the mockery-generated mock. | Plan step 4 edits both; `make mocks` is scoped to the review diff (Makefile:191-197 — mockery v3.7.1 pinned; never commit an unscoped regen). |
+| F11 | **An override targets an action whose handler errors** (e.g. `version-group` on members spanning two existing groups — `regroup_apply.go:236-245`). | Unchanged behaviour: the error propagates, `approveOne` returns it, the item stays in its prior status and the operator sees the reason. |
+
+---
+
+## 10. Open questions
+
+1. **Does `insufficient-evidence` deserve its own `ReviewStatus`?** Today it is
+   a payload value on a `pending` row. A distinct status (`needs-evidence`)
+   would let the queue filter them out of the human's working set and let First
+   Aid's missing-input triggering enqueue the producer op. Deferred — it
+   touches the status index (`review_store.go:39-43`) and the frontend's status
+   filter, and is only worth it once tier-2 exists.
+2. **Should the item-level Approve button apply the recommendation, or require
+   an explicit pick?** This design says "defaults to the recommendation" per the
+   fragment (`ApproveReviewItem` takes an optional body *defaulting to*
+   `recommendedAction`). If the owner prefers a forced explicit choice on
+   `regroup.ambiguous` specifically, that is a one-line change in `approveOne`
+   step 2.
+3. **Should `recommendedAction` disagreeing with the hold's `Kind` be
+   surfaced as a queue-level metric?** E.g. "38 multidisc holds recommend
+   separate" would be a strong signal that the Kind switch needs retuning —
+   which D1 explicitly defers.
+4. **Does the reason string need i18n / structured form?** Currently a
+   pre-formatted English sentence. The evidence object is the machine-readable
+   half, so the reason can stay prose.
+5. **Bulk `item_action` on a mixed-Kind selection** — should it be refused when
+   the targeted ids span more than one Kind? Current design allows it (the
+   human named one action explicitly). Flagged for owner review.
+
+---
+
+## 11. Acceptance gate (summary; full numbers in the plan)
+
+Nothing is applied to production until a **dry-run** of
+`maintenance.regroup-shattered-ai` on prod reports all of:
+
+- `bykind=` **identical** to the pre-change run (D1/F8).
+- New `RECOMMEND:` histogram whose counts **sum exactly** to `groups=`.
+- Holds recommending `combine` while `durationsMissing*2 > members`: **exactly 0**
+  (D7).
+- Holds whose `survivorTitle` equals their dominant member author: **exactly 0**.
+- Share of holds carrying the old generic flat-ambiguous string as their *only*
+  guidance: **0%** (every hold now carries a reason with numbers), against the
+  pre-relink baseline of 762/777 = 98.1%.
+
+`review_apply_enabled` stays **OFF** throughout. Flipping it is owner item 3.


### PR DESCRIPTION
Saves ~25,600 words of design work so it is not lost. Docs only.

**Covers 3 of 11 workstreams:**
- review-queue recommendations + per-hold overrides (owner items 1+2)
- duplicate detection + combine-by-template + version-group (the Successors class)
- playlists (import, static, dynamic, CRUD, export)

## ⚠️ These are UNVERIFIED drafts

The adversarial verification pass — which grep-checks that every cited function, struct field, op ID and path actually exists — **did not run**. The workflow was halted by API rate limiting (429/529) partway through. Every file carries an in-document banner saying so.

The design reasoning and the measured production numbers are sound (they came from real observations this session: 762/777 generic proposedAction strings, the 41-of-43 near-miss, 16,027 books relinked, the Successors 12-of-13 debris). **The code citations are what needs checking before anyone executes from them** — a confidently-cited symbol that does not exist is the most common failure mode in generated plans.

## Note

The pre-commit hook caught an agent writing internal server IPs into one plan; scrubbed to `<server>` placeholders before commit. Worth knowing: ~38 pre-existing docs in this repo already contain internal IPs from earlier work — a separate cleanup, not introduced here.

The remaining 8 workstreams keep their `todo.d/` fragments and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp