### PR TITLE
docs: 2 more workstream specs + version-group index bug report

### DIFF
--- a/changelog.d/20260806_002000_version_group_index_bug.md
+++ b/changelog.d/20260806_002000_version_group_index_bug.md
@@ -1,0 +1,19 @@
+<!-- file: changelog.d/20260806_002000_version_group_index_bug.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8b04f713-25ce-4a09-9d16-4f2703ab85c1 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- **Specs + plans for 2 more workstreams** (multidisc apply canary, metadata-results
+  cold start), marked UNVERIFIED in-document — the symbol-check pass did not run.
+
+- **Recorded a production bug:** `GetBooksByVersionGroup` silently under-reports
+  version-group membership when its index is partially populated, because the
+  full-scan fallback only triggers on a ZERO-result index rather than on a
+  suspected-incomplete one. This breaks the one-primary-per-group invariant:
+  `set-primary` demotes only what the lookup returns, so a group can end up with
+  two primaries and show two tiles for one book. The same function backs
+  `ApplyVersionGroup`'s stray-primary demotion, so approving a version-group
+  review hold is affected too. Found while version-grouping the two copies of
+  "The Successors" on production.

--- a/docs/plans/2026-08-05-metadata-results-cold-start-plan.md
+++ b/docs/plans/2026-08-05-metadata-results-cold-start-plan.md
@@ -1,0 +1,245 @@
+<!-- file: docs/plans/2026-08-05-metadata-results-cold-start-plan.md -->
+<!-- version: 2.0.0 -->
+<!-- guid: e4638536-a13f-431b-84f1-3120fb4f4995 -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** Authored by an agent on
+> 2026-08-05; the adversarial verification pass did not run (the workflow was
+> halted by API rate limiting). Treat every code citation as a claim, not a fact.
+> The design reasoning and measured production numbers are sound; the code
+> references need checking before execution.
+
+
+# Plan — metadata-results cold start
+
+Implements [`docs/specs/2026-08-05-metadata-results-cold-start-design.md`](../specs/2026-08-05-metadata-results-cold-start-design.md)
+(owner item 6). Four steps, each independently committable and independently
+revertable.
+
+**Branch:** `fix/metadata-results-cold-start` (worktree only — never main).
+**Nothing in this plan writes to the library.** No `UpdateBook`, no `UpdateBookFile`,
+no filesystem access, no `books/itunes/**`. Every change is to in-process cache
+plumbing and one additive JSON field.
+
+---
+
+## Step 1 — Stale-while-revalidate + boot warmer (D1 + D2)
+
+One commit. The warmer alone is not shippable value (a 60 s TTL means a boot warm
+covers 60 seconds), so it lands with SWR.
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/server/metadata_results_cache.go` | **Modify.** Add `metadataResultsStaleMax = 15 * time.Minute`. Add `inflight bool` to the `metadataResultsCache` struct (`:38`). Rewrite `latestMetadataResultsByBookCached` (`:55`) into the three-state fresh / stale / cold form from spec D2, returning an extra `age time.Duration`. Add `refreshMetadataResultsCacheAsync(store)` — one goroutine, guarded by `inflight`, `defer warmerRecover("metadata-results-refresh")`. Add `(*Server).warmMetadataResultsCache()` calling the cached getter and logging. Add a `trigger` field (`boot` \| `demand` \| `refresh`) to the existing `slog.Info("metadata-results cache rebuilt", ...)` at `:71-72`. Bump header to `1.1.0`. |
+| `internal/server/server_lifecycle.go` | **Modify.** In `startCacheWarmers` (`:718`), after the `series-warmer` block (ends `:774`), add the `metadata-results-warmer` block exactly as spec D1 shows — `s.bgWG.Add` / `defer s.bgWG.Done` / `defer warmerRecover("metadata-results")` / `if s.bgCtx.Err() != nil { return }`. Bump header. |
+| `internal/server/metadata_batch_candidates.go` | **Modify.** `handleListMetadataResults` (`:844`) takes the new `age` return at `:857` and adds `"cache_age_seconds": int(age.Seconds())` to the `gin.H` at `:932-938`. Bump header. |
+| `web/src/services/api.ts` | **Modify.** Add `cache_age_seconds?: number;` to `MetadataResultsResponse` (`:3580-3586`). Optional field — no caller changes. Bump header. |
+
+### Signature change to watch
+
+`latestMetadataResultsByBookCached` currently returns
+`(map[string]database.OperationResult, map[string]int, error)`. Adding `age` changes
+every call site. Verified call sites: `internal/server/metadata_batch_candidates.go:857`
+(the only non-test one) and `internal/server/metadata_results_cache_test.go:41`. Confirm
+with:
+
+```bash
+cd "$WORKTREE"   # e.g. <repo-root>/.worktrees/metadata-results-cold-start
+grep -rn "latestMetadataResultsByBookCached" --include="*.go" .
+```
+
+If that returns more than those two, update them too before compiling.
+
+### Do NOT
+
+- Do **not** gate the warmer on `WaitForWarmup` / `memReadyChecker`. The build reads
+  only `operation:` / `op_result:` keys; there is no memdb path (spec D1).
+- Do **not** change `metadataResultsCacheTTL`.
+  `TestMetadataResultsCacheTTL_IsShortEnoughToFeelLive`
+  (`internal/server/metadata_results_cache_test.go:94`) enforces `5s ≤ TTL ≤ 5m`.
+- Do **not** touch `invalidateMetadataResultsCache` (`:86`) in this step — two tests
+  depend on its nil-everything semantics.
+
+---
+
+## Step 2 — Stale, not nil, on the three write paths (D3)
+
+One commit. Independent of step 1's shipping decision only in the sense that it can be
+reverted alone; it *requires* step 1's stale branch to exist.
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/server/metadata_results_cache.go` | **Modify.** Add `markMetadataResultsCacheStale()`: under `mu`, if `latest != nil`, set `at = time.Now().Add(-metadataResultsCacheTTL - time.Second)`. Leave `invalidateMetadataResultsCache` untouched. Bump header to `1.2.0`. |
+| `internal/server/metadata_batch_candidates.go` | **Modify.** Change the three `defer invalidateMetadataResultsCache()` lines — `:478` (`handleBatchApplyCandidates`, declared `:475`), `:583`, `:647` — to `defer markMetadataResultsCacheStale()`. Update each accompanying comment (the one at `:476-477` explains why invalidation exists) to say the list is now served stale-but-labelled for one refresh cycle instead of blocking. Bump header. |
+
+### Why this is not a lie
+
+`CreateOperationResult` (`internal/database/pebble_store_operations.go:469-477`) keys on
+`op_result:<OperationID>:<BookID>`, and all three handlers write back with the same
+`OperationID` and `BookID` they read (`:540`, `:622`, `:686`) — an in-place row update.
+The stale set differs from truth by exactly the statuses the user just changed, for
+exactly one cycle, and `cache_age_seconds` from step 1 makes that visible.
+
+---
+
+## Step 3 — ABS contributor warm: enrol + SWR (D4)
+
+One commit. Fully independent of steps 1-2 — different package, different cache.
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/server/wire_abs_routes.go` | **Modify.** Wrap the bare `go func() { ... }()` at `:266-271` in the standard warmer shape: `s.bgWG.Add("abs-contributors-warmer")`, `defer s.bgWG.Done("abs-contributors-warmer")`, `defer warmerRecover("abs-contributors")`, and a `s.bgCtx.Err()` check **both before and after** `ps.WaitForWarmup()` — the exact body is in spec D4 item 1. **Keep** the `ps.WaitForWarmup()` call at `:268`, the comment at `:262-265` that justifies it, and `context.Background()` at `:270`. Bump header. |
+| `internal/server/handlers/abs/browse.go` | **Modify.** Add `absContributorsStaleMax` — **proposed** `30 * time.Minute`, a judgment call, not a derived number: long enough that nobody is served a stale contributor list across a working session, short enough that a rebuild wedged for half an hour surfaces as slow rather than silently ancient. See plan open item below. Add an `inflight` guard field. Rewrite `contributorsCached` (`:525`) into fresh / stale / cold, using `h.now()` (field at `internal/server/handlers/abs/handler.go:273`) for all time reads. `WarmContributors` (`:1009`) is unchanged — it just calls `contributorsCached`. Bump header. |
+| `internal/server/handlers/abs/handler.go` | **Modify.** Add the `inflight bool` field beside `authorsCacheAt` (`:270`), under the existing `authorsCacheMu` (`:267`). Bump header. |
+
+### Do NOT
+
+- Do **not** remove `ps.WaitForWarmup()`. Unlike the metadata-results build, this one
+  is derived from *visible* books (`contributorDTOs` → `h.visibleBookSummaries`,
+  `internal/server/handlers/abs/browse.go:613-615`); building pre-memdb caches a library
+  that does not exist yet and then serves it for the whole TTL.
+- Do **not** thread `s.bgCtx` into `handler.WarmContributors`. `WaitForWarmup`
+  (`internal/database/pebble_store.go:153`) is a bare `<-p.warmupDone` with no context,
+  so it cannot observe cancellation; `Shutdown` cancels `bgCtx` then calls
+  `s.bgWG.Wait()` (`internal/server/server_lifecycle.go:576`), and a cancellable context
+  inside the build buys nothing while changing its semantics mid-run. The
+  **second `bgCtx` check, placed after `WaitForWarmup` returns**, is what actually
+  prevents a 6-second scan against a closing store. Full rationale: spec D4 item 1.
+- Do **not** change `absAuthorsCacheTTL` (`:504`).
+
+### Open item for this step
+
+`absContributorsStaleMax = 30 * time.Minute` is a proposed value, not a measured one.
+If a reviewer prefers a different bound, change it here — nothing else in the design
+depends on the number, only on there *being* a finite bound (spec D2, F2).
+
+---
+
+## Step 4 — Tests
+
+One commit, alongside or immediately after the code. New tests go in existing files
+where they exist.
+
+### Files
+
+| File | Intent |
+|---|---|
+| `internal/server/metadata_results_cache_test.go` | **Modify.** Add: (a) a stale entry is served **without blocking** — prime `at` at `TTL + 5s` ago with a store that would take measurable time, assert the call returns in well under a second and returns the primed map; (b) an entry older than `metadataResultsStaleMax` takes the **cold** branch; (c) `markMetadataResultsCacheStale` leaves `latest` non-nil while making `time.Since(at) >= metadataResultsCacheTTL`; (d) `invalidateMetadataResultsCache` still nils both maps (existing test at `:75` must stay green); (e) concurrent stale reads spawn **one** refresh — a counting fake store plus `-race`. Bump header. |
+| `internal/server/cache_warmers_bgwg_test.go` | **Modify.** Extend the existing assertions (`:54`, `:86`) so `metadata-results-warmer` and `abs-contributors-warmer` are both named and both drained by `Shutdown`. Bump header. |
+| `internal/server/handlers/abs/browse_contributors_swr_test.go` | **Create.** ABS-side twin: drive `h.now` forward past `absAuthorsCacheTTL`, assert the stale list is returned immediately and a refresh is kicked; drive past `absContributorsStaleMax`, assert the cold branch blocks. Full header (path / version 1.0.0 / fresh guid / last-edited). |
+
+### Commands, and what green means
+
+```bash
+cd "$WORKTREE"   # e.g. <repo-root>/.worktrees/metadata-results-cold-start
+
+# 1. The cache itself, with the race detector. THIS IS THE LOAD-BEARING RUN —
+#    SWR introduces a detached goroutine writing shared state.
+go test ./internal/server/ -run 'MetadataResults' -race -count=1 -v
+
+# 2. The warmer-enrolment contract. Matches the two existing tests
+#    TestStartCacheWarmers_SkipOnCanceledCtx and _EnrolledInBgWG.
+go test ./internal/server/ -run 'TestStartCacheWarmers' -race -count=1 -v
+
+# 3. The ABS contributor cache.
+go test ./internal/server/handlers/abs/... -race -count=1
+
+# 4. Full backend, short — a getter signature change can vacuously pass a
+#    subset while breaking a mock elsewhere.
+go test ./... -short
+
+# 5. Frontend types.
+cd web && npm run build
+
+# 6. Repo CI gate.
+cd "$WORKTREE" && make ci
+```
+
+**Green means:** (1)-(3) pass with **zero** `DATA RACE` reports and zero
+`WARNING: DATA RACE` lines; (4) reports `ok` or `no test files` for every package with
+no `FAIL`; (5) exits 0 with no TS errors; (6) `make ci` passes its 30% coverage gate.
+Anything less is not green — do not proceed to the acceptance gate on a partial run.
+
+---
+
+## Acceptance gate — the numbers that must be observed
+
+There is no apply in this workstream, so the gate is observational rather than
+dry-run/apply. **All six observations below must hold on a real restart before this is
+called working.** `<server>` stands in for the deployment host; use
+`https://<server>:8484`.
+
+1. **Boot warm fires and completes before any user request.** In the logs after a
+   restart, `metadata-results cache rebuilt` appears with `trigger=boot`, and its
+   timestamp precedes the first `GET /api/v1/library/metadata-results` access-log line.
+   **Record** its `duration_ms` for the record — the spec's §1.1 observations put the
+   build at 21,000–34,000 ms, but a faster host legitimately landing well under that is
+   not a failure, so this is not a pass/fail threshold. The correctness check is item 2,
+   which is. Only one combination warrants a look before accepting: a sub-second
+   `duration_ms` **together with** a `books=` count near zero, which means the build
+   found nothing and the warm is proving nothing.
+2. **No rows lost.** The `books=` count on the `trigger=boot` line must equal the
+   `books=` count on the next `trigger=demand` or `trigger=refresh` line taken from the
+   same store with no fetch operation in between. Reference from the code comment:
+   `36,805` results folded to the latest-per-book set. A **drop is a hard stop** — do
+   not ship.
+3. **First request after restart is fast.** Time the first call:
+   ```bash
+   curl -s -o /dev/null -w '%{time_total}\n' \
+     -H "Authorization: Bearer $ABK_TOKEN" \
+     'https://<server>:8484/api/v1/library/metadata-results?limit=3'
+   ```
+   Must be **under 0.5 s**, against the 34 s baseline. Its `cache_age_seconds` must be
+   greater than 0 (proving it was served from the boot warm, not built on demand).
+4. **A minute-5 arrival is also fast.** Repeat the same curl at T+5 min (well past the
+   60 s TTL). Must still be **under 0.5 s**, and the logs must show a
+   `trigger=refresh` rebuild starting at that moment. This is the observation that
+   distinguishes SWR from a bare boot warm — a bare warmer fails here at ~34 s.
+5. **Post-apply is fast.** Apply a small batch through the match UI, then immediately
+   reload the list. Must be **under 0.5 s** (today: a full cold build). The applied
+   books show their pre-apply status for at most one refresh cycle, and
+   `cache_age_seconds` on that response is non-zero.
+6. **ABS side.** `abs: contributor cache warmed` appears in the boot logs with a
+   `duration_ms` near the recorded **6,104 ms** cold figure. A contributor page request
+   at T+6 min (past the 5-minute TTL) returns near the **105 ms** warm figure rather
+   than ~6 s.
+
+Additionally, `journalctl`/service logs must show **no** `pebble: closed` panic and no
+`cache warmer panicked` line for `metadata-results`, `metadata-results-refresh` or
+`abs-contributors` across a full start → serve → `Shutdown` cycle.
+
+---
+
+## Rollback
+
+Every step is a separate commit with a self-contained revert.
+
+| Step | Revert effect |
+|---|---|
+| 4 (tests) | No production behaviour change. |
+| 3 (ABS) | Returns to today's bare `go func()` warm + hard 5-minute TTL. No data implication. |
+| 2 (stale-not-nil) | Returns to `invalidateMetadataResultsCache` on the three write paths — the 34 s post-apply block returns, nothing is corrupted. |
+| 1 (SWR + warmer) | Returns to the plain 60 s memo with no boot warm. `cache_age_seconds` disappears from the response; the TS field is optional so the frontend keeps compiling. |
+
+**No data migration, no backfill, nothing persisted.** The entire change is in-process
+cache state that is rebuilt from `operation:` / `op_result:` on the next read. A
+rollback at any point is a binary swap plus a restart — there is no state to unwind.
+
+---
+
+## Post-task hygiene (per `CLAUDE.md`)
+
+- Add a fragment under `changelog.d/` (e.g. `20260805_223000_metadata_results_swr.md`).
+  **Do not hand-edit `CHANGELOG.md`.**
+- Tick the item in `TODO.md` (checking off is a normal direct edit; only *new* tasks go
+  through `todo.d/`).
+- **Executive summary: not required.** Against
+  `docs/process/executive-summaries.md`'s criteria this is a single-PR performance fix
+  with no data-loss or corruption exposure and no multi-PR tracked set. `CHANGELOG` +
+  `TODO` are sufficient.

--- a/docs/plans/2026-08-05-multidisc-apply-canary-plan.md
+++ b/docs/plans/2026-08-05-multidisc-apply-canary-plan.md
@@ -1,0 +1,449 @@
+<!-- file: docs/plans/2026-08-05-multidisc-apply-canary-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: fa550401-5c6d-4334-a07b-09849b3026fe -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** Authored by an agent on
+> 2026-08-05; the adversarial verification pass did not run (the workflow was
+> halted by API rate limiting). Treat every code citation as a claim, not a fact.
+> The design reasoning and measured production numbers are sound; the code
+> references need checking before execution.
+
+
+# Multidisc apply canary — IMPLEMENTATION PLAN
+
+Design: [`docs/specs/2026-08-05-multidisc-apply-canary-design.md`](../specs/2026-08-05-multidisc-apply-canary-design.md).
+Fragment: [`todo.d/20260805_220100_multidisc_apply_canary.md`](../../todo.d/20260805_220100_multidisc_apply_canary.md).
+
+**Sequencing.** Land after `review-queue-recommendations-and-overrides` (design §2.3).
+Steps S1–S3 are independent of it and can be built in parallel; S4 and S6 touch files
+that workstream also edits.
+
+**Worktree.** `git worktree add ../audiobook-organizer-multidisc-canary -b feat/multidisc-apply-canary`.
+Never edit the primary checkout.
+
+---
+
+## 1. Goal
+
+Make it impossible to run a `regroup.multidisc` / `regroup.anthology` apply without a
+durable on-disk record of everything it is about to destroy, give the operator a ranked
+list so the first applies are a checkable handful, and close the one-click 132-merge path.
+
+---
+
+## 2. Ordered steps
+
+Each step is one commit and one PR-able unit. Each leaves the tree green.
+
+### S1 — `internal/applysnapshot` package (no callers yet)
+
+**Create**
+
+| File | Intent |
+|---|---|
+| `internal/applysnapshot/snapshot.go` | `Snapshot`, `Member`, `File`, `RiskSignals`, `Diff` types (design §4). Pure data + JSON tags. `SchemaVersion = 1`. |
+| `internal/applysnapshot/recorder.go` | `Recorder` interface; `FileRecorder` with `O_APPEND\|O_CREATE\|O_WRONLY` + `f.Sync()` before returning; `Has`, `Path`. `NewFileRecorder(dir, kind string)` errors on empty dir and on `config.UnderFrozenITunesTree(dir)` (design D9). |
+| `internal/applysnapshot/dir.go` | `DefaultDir()` = `filepath.Join(filepath.Dir(config.AppConfig.DatabasePath), "apply-snapshots")`; returns an error when `DatabasePath` is empty (design D3 / §9.4). |
+| `internal/applysnapshot/build.go` | `BuildSnapshot(store database.Store, item database.ReviewItem, payloadJSON string, presentIDs []string, chosenPrimary string) (Snapshot, error)` — resolves members via `GetBookByID` / `GetBookFiles`, normalizes with `database.NormalizeDurationSec`, resolves author/series names via `GetAuthorByID` / `GetSeriesByID` (failures leave the name empty, never an error), computes `RiskSignals`. |
+| `internal/applysnapshot/risk.go` | `bookLengthSec = 90 * 60`; `majorityBookLength(long, present int) bool` = `long*2 > present`; `band(RiskSignals) string`. Duplicates `fs_regroup_shape.go` deliberately — design §9.1. |
+| `internal/applysnapshot/load.go` | `LoadLast(path string) (map[string]Snapshot, error)` — last record per `ItemID` (design D12). |
+| `internal/applysnapshot/*_test.go` | See §4. |
+
+**Note.** `internal/applysnapshot` imports `internal/database` and `internal/config`.
+It must **not** import `internal/plugins/maintenance` or `internal/merge` — the gate
+depends on it, not the other way round.
+
+**Why first.** It has no callers, so it cannot break anything, and every later step
+depends on its types.
+
+---
+
+### S2 — Gate `ApplyMultidisc` on the recorder
+
+**Modify** `internal/plugins/maintenance/regroup_apply.go` (bump header to `1.3.0`,
+`last-edited: 2026-08-05`).
+
+- Signature → `ApplyMultidisc(store database.Store, combiner bookCombiner, rec applysnapshot.Recorder) func(context.Context, database.ReviewItem) error`.
+- Between `primaryID := pickPrimary(present)` (line 99) and
+  `combiner.CombineBooks(...)` (line 100):
+
+```go
+if rec == nil {
+    return fmt.Errorf("regroup multidisc apply: no snapshot recorder configured — "+
+        "refusing to combine %q (%d books): the absorbed rows are hard-deleted and "+
+        "the on-disk snapshot is the only record", p.Folder, len(present))
+}
+snap, serr := applysnapshot.BuildSnapshot(store, item, item.Payload, present, primaryID)
+if serr != nil {
+    return fmt.Errorf("regroup multidisc apply: build snapshot for %s: %w", item.ID, serr)
+}
+snap.Origin = "apply-gate"
+if serr := rec.Record(ctx, snap); serr != nil {
+    return fmt.Errorf("regroup multidisc apply: record snapshot for %s: %w", item.ID, serr)
+}
+```
+
+- Extend the `DATA-LOSS SAFETY` block in the file header (lines 23-38) with the gate's
+  rationale.
+- Leave `ApplyVersionGroup` untouched (design D2).
+
+**Modify** `internal/server/wire_handlers.go` (bump header). Inside the existing
+`if s.Store() != nil {` block at line 598:
+
+```go
+snapDir, derr := applysnapshot.DefaultDir()
+if derr != nil {
+    return fmt.Errorf("review apply wiring: %w", derr)   // or slog.Error + skip registration
+}
+snapRec, rerr := applysnapshot.NewFileRecorder(snapDir, "regroup-combine")
+if rerr != nil { ... }
+combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc, snapRec)
+```
+
+If `wireHandlers` cannot return an error, log at `slog.LevelError` and **do not register
+the combine handler at all** — an unregistered handler makes approve fall through to
+`"approved"` with a note ([`handler.go:195-207`](../../internal/server/handlers/review/handler.go)),
+which is the fail-safe direction. Never register with a nil recorder.
+
+**Post-sibling adjustment.** The two `RegisterApplyHandler(Kind…, combine)` lines become
+one `RegisterActionHandler(itunesservice.ActionCombine, combine)`. The `ApplyMultidisc`
+call is identical either way (design §2.3).
+
+**Modify** `internal/plugins/maintenance/regroup_apply_test.go` — every existing
+`ApplyMultidisc(store, combiner)` call site gains a third argument.
+
+---
+
+### S3 — The canary op
+
+**Create** `internal/plugins/maintenance/multidisc_apply_canary.go`:
+
+- `canaryParams` (design §6.1) — **no `apply` field**.
+- `(p *Plugin) multidiscApplyCanaryDef() sdk.OperationDef` per design §6.
+- `runMultidiscApplyCanary(ctx, raw, reporter)` dispatching on `Mode`.
+- `before`: `store.ListReviewItems` per kind → `registry.RunItems` at
+  `runtime.NumCPU()` with `ErrMode: registry.ErrModeCollect` → sort by `ItemID` →
+  single-threaded `rec.Record` with `Origin = "canary-before"` → `linkintegrity.Report`
+  + `RECONCILE:` line + `report.UnreconciledPhases()` check, mirroring
+  [`relink_unlinked.go:113-225`](../../internal/plugins/maintenance/relink_unlinked.go).
+- `after`: `applysnapshot.LoadLast` → per-record `Diff` (design §6.3) → band-style
+  summary with `ok` / `attention` counts that reconcile against the record count.
+
+**Modify** `internal/plugins/maintenance/plugin.go` — add `p.multidiscApplyCanaryDef(),`
+to the `Register` slice ([`plugin.go:32`](../../internal/plugins/maintenance/plugin.go)),
+directly after `p.regroupShatteredAIDef()` at line 108. Bump header.
+
+**Create** `internal/plugins/maintenance/multidisc_apply_canary_test.go`.
+
+---
+
+### S4 — Refuse kind-scoped bulk approve while apply is on
+
+**Modify** `internal/server/handlers/review/handler.go` (bump header to `1.2.0`).
+Insert the D8 guard immediately after the existing
+`if req.Kind == "" && len(req.IDs) == 0` block (lines 267-270), exactly as written in
+design §7. Requires adding `"net/http"` to the imports.
+
+**Modify** `internal/server/handlers/review/replay.go` — drive-by fix for the swapped
+argument pair at lines 106-108. `RespondWithError` is
+`(c, statusCode, message string, code string)`
+([`httputil/respond.go:18`](../../internal/httputil/respond.go)); replay.go passes code
+then message, so that 409 currently returns `error: "REVIEW_APPLY_DISABLED"` and
+`code: "review apply is globally disabled; …"`. Swap them and bump the header. One line,
+same function family, worth carrying rather than leaving for someone to trip over while
+reading the new guard beside it.
+
+**Modify** `internal/server/handlers/review/handler_test.go` (or a new
+`bulk_apply_guard_test.go` if the existing file is crowded) — see §4.
+
+**Conflict note.** The sibling workstream rewrites `bulkRequest`, `bulkResult` and the
+dispatch inside this same function. Rebase onto it; the guard is additive and sits above
+all of its changes.
+
+---
+
+### S5 — Frontend confirmation on bucket-level approve
+
+**Modify** `web/src/pages/ReviewQueue.tsx` (bump header):
+
+- `handleBulkAction` (line 300): before the `api.bulkReviewAction` call, `window.confirm`
+  naming the kind and the bucket's pending count.
+- The existing `catch` already routes the error through `addNotification`; the 409's
+  message text surfaces unchanged. Verify the API client does not swallow the body.
+
+Cosmetic only — S4 is the enforcement.
+
+---
+
+### S6 — Docs and fragments
+
+- `changelog.d/` fragment (required by `changelog-check.yml`).
+- `TODO.md`: tick task #6 only after the §7 gate is observed on prod; do **not** tick on
+  merge.
+- Executive summary: this qualifies (`docs/process/executive-summaries.md` — "fixes
+  something that could have silently caused data loss"). Update the **current month's**
+  file in `docs/executive-summaries/` in the same PR as the CHANGELOG fragment.
+
+---
+
+## 3. Files touched — summary
+
+**Create (8)**
+
+```
+internal/applysnapshot/snapshot.go
+internal/applysnapshot/recorder.go
+internal/applysnapshot/dir.go
+internal/applysnapshot/build.go
+internal/applysnapshot/risk.go
+internal/applysnapshot/load.go
+internal/plugins/maintenance/multidisc_apply_canary.go
+docs/… (this plan + the design, already written)
+```
+
+**Modify (6)**
+
+```
+internal/plugins/maintenance/regroup_apply.go          # gate + header rationale
+internal/plugins/maintenance/regroup_apply_test.go     # third arg at every call site
+internal/plugins/maintenance/plugin.go                 # register the op
+internal/server/wire_handlers.go                       # construct + pass the recorder
+internal/server/handlers/review/handler.go             # D8 bulk refusal
+web/src/pages/ReviewQueue.tsx                          # confirm dialog
+```
+
+**Tests (4 new)**
+
+```
+internal/applysnapshot/recorder_test.go
+internal/applysnapshot/build_test.go
+internal/applysnapshot/risk_test.go
+internal/plugins/maintenance/multidisc_apply_canary_test.go
+```
+
+Every created and modified file carries the mandatory 4-line header (path / version /
+guid / last-edited); modified files get a version bump.
+
+---
+
+## 4. Test strategy
+
+### 4.1 Unit — the gate is unbypassable
+
+`internal/plugins/maintenance/regroup_apply_test.go`:
+
+| Test | Green means |
+|---|---|
+| `TestApplyMultidisc_NilRecorderRefusesToCombine` | error returned **and** the fake `bookCombiner` recorded **zero** `CombineBooks` calls |
+| `TestApplyMultidisc_RecorderErrorRefusesToCombine` | recorder returns `errors.New("disk full")` → same assertions |
+| `TestApplyMultidisc_SnapshotWrittenBeforeCombine` | the fake recorder appends to a shared `[]string` ordering log and the fake combiner appends after it; assert `["record","combine"]` |
+| `TestApplyMultidisc_SnapshotCapturesAbsorbedRowsBeforeDeletion` | snapshot's `Members` contains every absorbed book's ID, title, file IDs and durations; the combiner then reports them deleted |
+| existing tests | still pass with the third argument |
+
+```bash
+go test ./internal/plugins/maintenance/ -run 'TestApplyMultidisc' -race -count=1 -v
+```
+
+### 4.2 Unit — recorder durability and refusal
+
+`internal/applysnapshot/recorder_test.go`:
+
+- `TestFileRecorder_AppendsOneLinePerRecord` — two records → two lines, each valid JSON.
+- `TestFileRecorder_SurvivesReopen` — reopen the same path, `Has(id)` is true.
+- `TestFileRecorder_RefusesFrozenITunesDir` — a dir containing the `books/itunes`
+  segment errors (design D9).
+- `TestDefaultDir_ErrorsOnEmptyDatabasePath` — with `config.AppConfig.DatabasePath = ""`,
+  `DefaultDir()` returns an error, **not** a usable path (design §9.4).
+- `TestLoadLast_TakesLastRecordPerItem` — two records for one ID → the later one wins.
+
+```bash
+go test ./internal/applysnapshot/ -race -count=1 -v
+```
+
+### 4.3 Unit — risk banding refuses to launder absent evidence
+
+`internal/applysnapshot/risk_test.go`:
+
+| Test | Green means |
+|---|---|
+| `TestBand_AbsentDurationIsNeverGreen` | one member with `DurationEvidence == "absent"` → band is `amber` (or `red`), never `green` — rule 3 |
+| `TestBand_MajorityBookLengthIsRed` | 3 of 5 members ≥ 5400s → `red` |
+| `TestBand_NormalizedIsAmberNotMeasured` | a member with a millisecond-shaped raw duration bands `amber` and reports `NormalizedMembers == 1` (design D5) |
+| `TestBookLengthThresholdIsNinetyMinutes` | asserts the local constant `== 90*60`. ⚠️ This pins the **literal**, not the classifier's `bookLengthSec` — that constant is unexported and unimportable (design §9.1), so a change to `fs_regroup_shape.go` will **not** fail this test. The duplication is real and unguarded; the test only stops *this* copy drifting silently. Say so in the test comment. |
+
+### 4.4 Unit — bulk refusal
+
+`internal/server/handlers/review/` (mirroring `replay_test.go`'s `doReq` helper style):
+
+| Test | Green means |
+|---|---|
+| `TestBulk_KindScopedApproveRefusedWhenApplyEnabled` | apply gate returns true + a handler registered for the kind → **409**, `BULK_APPLY_REQUIRES_IDS`, and the store saw **zero** `SetReviewItemStatus` calls |
+| `TestBulk_KindScopedApproveAllowedWhenApplyDisabled` | gate false → 200, items transition to `approved` (review-only bookkeeping still works) |
+| `TestBulk_ExplicitIDsAllowedWhenApplyEnabled` | `ids:[a,b]` → 200 |
+| `TestBulk_KindScopedRejectAlwaysAllowed` | `action:"reject"` → 200 in both gate states |
+
+```bash
+go test ./internal/server/handlers/review/ -race -count=1 -v
+```
+
+### 4.5 Unit — canary op
+
+`internal/plugins/maintenance/multidisc_apply_canary_test.go`:
+
+- `TestCanaryBefore_WritesOneRecordPerHold` — 3 holds in a fake store → 3 JSONL lines.
+- `TestCanaryBefore_ReconcilesCounts` — `examined == snapshotted + skipped + errored`;
+  a hold with an undecodable payload lands in `skipped` with a reason, never dropped
+  (rule 6).
+- `TestCanaryBefore_TouchesNoBooks` — the fake store records zero `UpdateBook`,
+  `UpdateBookFile`, `CreateBookFile`, `DeleteBook` calls.
+- `TestCanaryBefore_ChosenPrimaryMatchesPickPrimary` — smallest ULID among **present**
+  members, and a soft-deleted smallest-ULID member is excluded.
+- `TestCanaryAfter_DetectsMissingFileID` — remove one file from the survivor →
+  `MissingFileIDs` non-empty and `Verdict == "attention"`.
+- `TestCanaryAfter_DetectsSurvivingAbsorbedRow` — an absorbed row still resolving →
+  `AbsorbedSurvived` non-empty.
+
+### 4.6 Full suite
+
+Per `feedback_storegetter_migration_full_suite_test`, a signature change to a
+store-consuming function needs the whole suite, not a subset:
+
+```bash
+go build ./...
+go test ./... -short -count=1
+make ci
+```
+
+Green = `go build` clean, no test failures, `make ci` passes its 30% coverage gate.
+Frontend: `cd web && npm run build && npm test`.
+
+---
+
+## 5. Deployment
+
+Deploy from the **primary checkout**, not the worktree — `Makefile.local`'s `LOCAL_ROOT`
+is hardcoded to it and deploying from a worktree ships main's binary
+(`reference_worktree_deploy_gotchas`). After any server-side merge, `git pull --ff-only`
+**before** `make deploy` or you ship a stale binary.
+
+```bash
+git -C <primary-checkout> pull --ff-only
+make deploy
+```
+
+`review_apply_enabled` stays **false**. Nothing in this change flips it.
+
+---
+
+## 6. Rollback
+
+| Stage | Rollback |
+|---|---|
+| Any step, pre-deploy | `git revert` the commit. S1 has no callers; S3 adds an op nothing calls; S4/S5 are additive guards. |
+| After deploy, gate misbehaving | Revert S2 only. The op (S3) and the guard (S4) are independent and can stay. |
+| After deploy, op misbehaving | Do not run it. It is manual (no `Schedule`), read-only over the library, and its only write is an append to its own JSONL file. |
+| Snapshot dir wrong / unwritable | Pass `{"mode":"before","snapshotDir":"<writable path>"}`. For the **gate**, an unwritable dir means applies fail closed — that is correct behavior, not an incident. |
+| A canary apply produced a wrong merge | **Do not delete anything** (rule 4). Use the snapshot to re-create the members as separate books and re-associate; a deletion-based "undo" is not idempotent because rescan regenerates any file no `book_file` row claims. |
+
+---
+
+## 7. Dry-run acceptance gate
+
+🔴 **No apply — not one — until every line below is observed and recorded.**
+
+### 7.1 Run the before-pass
+
+The v2 enqueue endpoint is `POST /api/v1/operations/v2`
+([`wire_operations_routes.go:27`](../../internal/server/wire_operations_routes.go) →
+`opsV2H.TriggerOperationV2`). Its body is `{"def_id": …, "params": …}` and it returns
+`202` with `{"op_id": …}` (`operations_v2.go:149-164`). Note `def_id`, **not** `type` —
+`POST /api/v1/operations` is a GET-only listing route.
+
+```bash
+curl -sS -X POST https://<server>:8484/api/v1/operations/v2 \
+  -H "Authorization: Bearer $ABK_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.multidisc-apply-canary",
+       "params":{"mode":"before","kinds":["regroup.multidisc"],"status":"pending"}}'
+```
+
+Then poll `GET /api/v1/operations/:id/status` and `…/logs` with the returned `op_id`, and
+read the JSONL file.
+
+### 7.2 Numbers that MUST be observed
+
+| # | Metric | Required value | Why |
+|---|---|---|---|
+| G1 | `holdsExamined` | **132** | Fragment's count. A different number means the queue moved since 2026-08-05 — re-baseline before proceeding, do not assume. |
+| G2 | Reconciliation | `examined == snapshotted + skipped + errored`, exactly | Rule 6. `UnreconciledPhases()` fails the op otherwise. |
+| G3 | JSONL line count | `== snapshotted` | The file is the deliverable; a short file is a failed run. |
+| G4 | `FrozenTreeMembers` summed over all holds | **0** | Rule 5. Nonzero = a stale hold predating the 2026-08-05 frozen-tree fix; STOP. |
+| G5a | Holds with `MajorityBookLength == true` | Expect ≈ **9** | The fragment's measured count. Materially higher = the classifier is producing more of the 41-of-43 shape than believed; **STOP** and re-open the classifier question (design §9.3). |
+| G5b | Holds with `DistinctSeriesIDs > 1` | **Record only — do not gate** | This signal has never been measured on this queue. Gating on it means tripping a STOP with no baseline to interpret. Report the number; it becomes the baseline for the next run. |
+| G5c | Total holds banded **red** | Reported as the sum of G4 + G5a + G5b | The red band is broader than the fragment's measurement, so the aggregate alone is uninterpretable. Always read the three sub-counts, never the total. |
+| G6 | `ZeroDurationMembers` summed | Recorded, and each such hold banded non-green | Absent ≠ refuted (rule 3). A green hold with any zero-duration member is a spec violation; STOP. |
+| G7 | Holds banded **green** | ≥ 3, else there is nothing safe to canary | With < 3, do not flip the switch. **Predicted cause if this fails:** directory-shaped members carry seeded-zero per-file durations — `relink_unlinked.go:351-354` deliberately leaves per-file duration 0 for the directory shape ("Seeding the BOOK's total onto every track would be actively wrong"), so those members are `absent` and can never be green. The unblock is **task #3** (tier-2 duration probe for the 1,019 review-held directories), *not* a relaxation of this gate. |
+| G8 | Every green hold's `Members[].Title`, `DurationSec`, `Files[].FilePath` | Present and non-empty in the JSONL | The fragment's stated minimum. A record missing them cannot serve as the only record. |
+| G9 | Every hold's `ChosenPrimary` | Equals the smallest ULID in `PresentBookIDs` | Matches `pickPrimary` ([`regroup_apply.go:364`](../../internal/plugins/maintenance/regroup_apply.go)); a mismatch means the snapshot does not describe what the apply will do. |
+| G10 | Book/file mutations during the run | **0** | Confirm via the activity log / op capabilities: the op declares no `CapLibraryWrite`. |
+
+### 7.3 Human step — no automation substitutes for it
+
+Pick **3 to 5** green holds. For each, open the recorded `Files[].FilePath` list and
+**listen** to the first ~30 seconds of the first two files. Confirm they are consecutive
+parts of one work, not two different books. Record the verdict per hold ID.
+
+The 41-of-43 near-miss was caught by exactly this and by nothing else.
+
+### 7.4 The canary apply
+
+Only after G1–G10 and §7.3:
+
+1. Owner flips `review_apply_enabled` to `true` and restarts.
+2. Approve **by explicit ids**, one request, ≤ 5 ids:
+
+```bash
+curl -sS -X POST https://<server>:8484/api/v1/review/bulk \
+  -H "Authorization: Bearer $ABK_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"action":"approve","ids":["<id1>","<id2>","<id3>"]}'
+```
+
+   The kind-scoped form is now refused server-side while the switch is on (design D8) —
+   attempt it once and confirm the **409** before doing anything else. That is the proof
+   the footgun is closed.
+
+### 7.5 The after-pass
+
+```bash
+curl -sS -X POST https://<server>:8484/api/v1/operations/v2 \
+  -H "Authorization: Bearer $ABK_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"def_id":"maintenance.multidisc-apply-canary","params":{"mode":"after"}}'
+```
+
+| # | Metric | Required value |
+|---|---|---|
+| A1 | `MissingFileIDs` across all diffs | **empty** — every pre-snapshot `BookFile.ID` is on the survivor (design D7) |
+| A2 | `DurationAfterSec` vs `DurationBeforeSec` per hold | **equal** |
+| A3 | `FingerprintedAfter` vs `FingerprintedBefore` | `after >= before` for every hold |
+| A4 | `SurvivorPresent` / `SurvivorSoftDeleted` | `true` / `false` for every hold |
+| A5 | `AbsorbedSurvived` | **empty** — every absorbed ID resolves to `(nil, nil)` |
+| A6 | `TrackOrderOK` | `true`, or the group-level "already numbered" guard demonstrably fired ([`regroup_apply.go:155-162`](../../internal/plugins/maintenance/regroup_apply.go)) |
+| A7 | `ExtraFileIDs` | Recorded and explained per hold (`ensureOwnFile` / `attachVirtualFile` materialization). Not an assertion — design D7. |
+| A8 | Verdicts | `ok == records`, `attention == 0` |
+
+Then **listen again** to the merged survivor. If A1–A8 are clean and the audio is right,
+widen to the next batch of green holds — still by explicit ids, still in batches, still
+with an after-pass each time. Amber holds require the tier-2 duration probe first; red
+holds are not approved at all under this plan.
+
+### 7.6 Reporting
+
+Per CLAUDE.md status honesty, every status update on this workstream ends with:
+
+```
+COMPLETED: <n> — <hold ids applied and verified>
+REMAINING: <n> — <hold ids still pending>
+BLOCKED:   <n> — <hold ids red/amber and why>
+```
+
+Starting point: `COMPLETED: 0`, `REMAINING: 132`, `BLOCKED: ~9 (book-length members)`.

--- a/docs/specs/2026-08-05-metadata-results-cold-start-design.md
+++ b/docs/specs/2026-08-05-metadata-results-cold-start-design.md
@@ -1,0 +1,481 @@
+<!-- file: docs/specs/2026-08-05-metadata-results-cold-start-design.md -->
+<!-- version: 3.0.0 -->
+<!-- guid: 8a3492bd-5c2e-4b8f-93d0-ae9232a3fdda -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** Authored by an agent on
+> 2026-08-05; the adversarial verification pass did not run (the workflow was
+> halted by API rate limiting). Treat every code citation as a claim, not a fact.
+> The design reasoning and measured production numbers are sound; the code
+> references need checking before execution.
+
+
+# Design — kill the cold start on the metadata-results build (and its twin, the ABS contributor build)
+
+Owner item 6, 2026-08-05.
+Source fragment: [`todo.d/20260805_220400_metadata_results_cold_start.md`](../../todo.d/20260805_220400_metadata_results_cold_start.md).
+
+> **Note on the two context notes named in the workstream brief.**
+> `.claude/notes/2026-08-05-first-aid-architecture.md` and
+> `.claude/notes/2026-08-05-unlinked-books-investigation.md` are **not present in this
+> worktree** — `.claude/notes/` here contains only `2026-07-31-fable-session-log.md` and
+> `2026-08-01-sso-continuation-prompt.md`. They were therefore not read while writing
+> this revision, and nothing here depends on them. That is defensible for this
+> workstream specifically: it has no apply path, writes no files, deletes nothing, and
+> never touches book or book_file rows (§5). Any later revision that gains a write path
+> must re-read them first.
+
+This is the **smallest** workstream in the 2026-08-05 set and the spec is deliberately
+short. It is longer than "add a warmer" for exactly one reason: warming a **60-second**
+TTL cache at boot buys 60 seconds of relief and nothing more. Three other defects
+turned up during verification; all three are recorded as **known defects (§7)** rather
+than folded into the work, so the plan stays at four steps.
+
+---
+
+## 1. Problem
+
+### 1.1 The numbers, and where each one comes from
+
+Every figure below was read out of the tree at the cited location, or comes from the
+owner's own fragment.
+
+| Number | Source (verified) |
+|---|---|
+| **34 s** cold build of the metadata-results set | Owner observation 2026-08-05, recorded in the fragment |
+| **21.9 s** for the same build | In-code comment, `internal/server/metadata_results_cache.go:24` (PR #2142) |
+| **36,805** result rows in that build | `internal/server/metadata_results_cache.go:25`; repeated at `internal/server/metadata_results_cache_test.go:32` |
+| **60 s** memo TTL | `metadataResultsCacheTTL`, `internal/server/metadata_results_cache.go:20` |
+| **5000** operations pulled per build | `store.GetRecentOperations(5000)`, `internal/server/metadata_batch_candidates.go:796` |
+| **6,104 ms** cold vs **105 ms** warm, ABS contributor build | `internal/server/wire_abs_routes.go:260` |
+| **44,888** books walked per contributor rebuild | `internal/server/handlers/abs/browse.go:518` |
+| up to **93** consecutive contributor page requests from one client action | `internal/server/handlers/abs/browse.go:509`, `:514` |
+| **~9,200** authors | `internal/server/handlers/abs/browse.go:514` |
+| **5 min** ABS contributor TTL | `absAuthorsCacheTTL`, `internal/server/handlers/abs/browse.go:504` |
+| **~2.5 min** memdb warmup on this library | `internal/server/library_list_warmer.go:211-212` |
+
+The 34 s and 21.9 s figures are two observations of the same build against a growing
+operations keyspace at different times. Neither supersedes the other, and nothing in
+this design depends on which is right — only on both being "many seconds", which they
+are.
+
+### 1.2 What is cold, and for how long
+
+`GET /api/v1/library/metadata-results` is routed at
+`internal/server/server_lifecycle.go:1423` to `handleListMetadataResults`
+(`internal/server/metadata_batch_candidates.go:844`), which reads through
+`latestMetadataResultsByBookCached` (`internal/server/metadata_results_cache.go:55`).
+That memoises `latestMetadataResultsByBook`
+(`internal/server/metadata_batch_candidates.go:795`) for `metadataResultsCacheTTL`.
+
+**Nothing pre-populates the memo.** `startCacheWarmers`
+(`internal/server/server_lifecycle.go:718`, called from `:308`) launches exactly five
+warmers plus one sweep — `facets-warmer` (`:720`), `library-sizes-warmer` (`:733`),
+`library-list-warmer` (`:751`), `authors-warmer` (`:757`), `series-warmer` (`:766`),
+`apikey-expiry-sweep` (`:777`). There is no metadata-results warmer. Grep confirms the
+only non-test caller of `latestMetadataResultsByBookCached` is the one HTTP handler at
+`metadata_batch_candidates.go:857`.
+
+So after every restart, the first person into the match UI pays the full build.
+
+**A boot warm alone is not the fix.** With a 60 s TTL it covers the first 60 seconds of
+uptime. Anyone arriving at minute 5 pays the same 34 s the owner is complaining about.
+The fragment asks for a warmer; the warmer is necessary and insufficient.
+
+### 1.3 The invalidate cliff hits exactly the user this workstream serves
+
+`invalidateMetadataResultsCache` (`internal/server/metadata_results_cache.go:86`) sets
+`latest` and `counts` to `nil`. It is deferred from three write paths in
+`internal/server/metadata_batch_candidates.go` — lines **478**, **583**, **647**
+(`handleBatchApplyCandidates` at `:475` and its reject / unreject siblings).
+
+Consequence: the user approves a batch of matches and their **very next** page load
+hits a fully-empty cache and blocks for the whole build. The person picking matches —
+the exact person the memo was added for — is the one guaranteed to eat the cold path.
+Boot-warming does nothing about this.
+
+### 1.4 The twin: authors + narrators on first paint
+
+The fragment pairs this item with "authors/narrators failing to load on first paint".
+The verified picture:
+
+- **The internal entity endpoints are not the problem.** `entities.Handler.ListAuthors`
+  (`internal/server/handlers/entities/handler.go:305`) is backed by `s.authorsCache`
+  (declared `internal/server/server.go:186`, constructed `:410` with a 24 h TTL) **and**
+  already has a boot warmer (`warmAuthorsCache`,
+  `internal/server/entity_cache_warmers.go:15`, enrolled as `authors-warmer` at
+  `server_lifecycle.go:757`). `ListNarrators`
+  (`internal/server/handlers/entities/handler.go:1077`) and `CountNarrators` (`:1091`)
+  are uncached, but they reach `PebbleStore.ListNarrators`
+  (`internal/database/pebble_store_authors.go:774`), a single `narrator:` prefix scan —
+  cheap. **There is no `narratorsCache` field on `Server`**; grep of
+  `internal/server/server.go` confirms only `authorsCache` (`:186`) and `seriesCache`
+  (`:187`) exist. It does not need one.
+- **The ABS surface is the problem**, and it is the only build in the repo producing
+  authors *and* narrators together: `contributorsCached`
+  (`internal/server/handlers/abs/browse.go:525`) returns
+  `([]authorDTO, []narratorDTO, error)` off `h.authorsCache` / `h.narratorsCache` /
+  `h.authorsCacheAt` (`internal/server/handlers/abs/handler.go:268-270`), TTL
+  `absAuthorsCacheTTL` = 5 minutes (`browse.go:504`). Its warm at
+  `internal/server/wire_abs_routes.go:266-271` is a **bare `go func()`**: grep for
+  `bgWG` in `wire_abs_routes.go` returns nothing, making it the only cache warmer in
+  the server not enrolled in the shutdown wait-group. It first blocks on
+  `ps.WaitForWarmup()` (`internal/database/pebble_store.go:153`), ~2.5 min on this
+  library.
+
+So the ABS Authors/Narrators tab is cold for the first ~2.5 minutes after every restart
+and cold again every 5 minutes thereafter. Same pattern, same fix.
+
+**A hypothesis that was checked and is wrong — recorded so nobody re-derives it.** The
+`authors-warmer` / `series-warmer` do **not** need a `WaitForWarmup` gate.
+`WaitForWarmup`'s own doc (`internal/database/pebble_store.go:145-152`) states memdb
+publication is atomic and reads fall back to Pebble until it publishes;
+`GetAllAuthorBookCounts` (`internal/database/pebble_store_authors.go:491-494`)
+therefore reads either a fully published memdb or a **complete** Pebble scan
+(`:495`, "Full Pebble book scan combined with junction table scan"). Warming pre-memdb
+is slower, never wrong. `AuthorSeriesService.ListAuthorsWithCounts`
+(`internal/audiobooks/author_series.go:77`) does call `GetAllAuthorBookCounts`
+(`:86`) — verified, the chain is real — but the *conclusion* about it was not. No
+change is proposed there.
+
+---
+
+## 2. Goal
+
+Nobody waits on a metadata-results or ABS contributor build, whether they arrive at
+second 1 or minute 40, and whether or not they just approved a batch.
+
+**Non-goal:** making the build fast enough that caching is unnecessary. It will still
+take seconds. This design makes the wait never fall on a request.
+
+---
+
+## 3. Locked decisions
+
+### D1 — Boot warmer, enrolled exactly like the other five
+
+New `(*Server).warmMetadataResultsCache()` calling
+`latestMetadataResultsByBookCached(s.Store())` and logging the outcome, registered in
+`startCacheWarmers` (`internal/server/server_lifecycle.go:718`) as
+`metadata-results-warmer` with the identical shape the five existing warmers use:
+
+```go
+s.bgWG.Add("metadata-results-warmer")
+go func() {
+    defer s.bgWG.Done("metadata-results-warmer")
+    defer warmerRecover("metadata-results")
+    if s.bgCtx.Err() != nil {
+        return // server already shutting down — skip, never warm a closing store
+    }
+    s.warmMetadataResultsCache()
+}()
+```
+
+`s.bgWG` is `namedWaitGroup` (`internal/server/server.go:266`, defined in
+`internal/server/bg_wg.go:24`); `warmerRecover` is
+`internal/server/server_lifecycle.go:712`; `s.Store()` is
+`internal/server/server.go:313`.
+
+**WHY the bgWG + bgCtx pair is non-optional.** `server_lifecycle.go:699-706` records
+that fire-and-forget warmers outliving `Store().Close()` panicked with `pebble: closed`
+(the PEBBLE-CLOSED family, #1781/#1794). A new warmer that skips enrolment reopens
+that. `internal/server/cache_warmers_bgwg_test.go:54` / `:86` already assert on this
+shape.
+
+**WHY it does NOT wait for memdb.** Unlike `warmAudiobookListCache`
+(`internal/server/library_list_warmer.go:196`, which gates on `memReadyChecker`,
+declared `:145`, asserted `:204`) and unlike the ABS warm, this build reads only
+`operation:` and `op_result:` keys straight from Pebble — no memdb path exists for
+either (`PebbleStore.GetRecentOperations`,
+`internal/database/pebble_store_operations.go:61`; `PebbleStore.GetOperationResults`,
+`:479`). Gating on a ~2.5 min memdb warmup would delay it for no correctness gain. The
+`unfetched` bucket *does* use `store.ListBookIDs()`
+(`internal/database/iface_book.go:50`), but that lives in the **handler**
+(`internal/server/metadata_batch_candidates.go:871`), outside the cached build, and is
+not warmed (see §8 Q2).
+
+**WHY its own file, not `entity_cache_warmers.go`.** That file's header
+(`internal/server/entity_cache_warmers.go:6-9`) declares its scope as "the non-HTTP
+author/series cache warmers" explicitly. The metadata-results warmer belongs in
+`internal/server/metadata_results_cache.go`, next to the cache it warms.
+
+### D2 — Stale-while-revalidate, because a boot warm covers 60 seconds
+
+This is the decision that makes the fragment's ask actually work.
+
+`latestMetadataResultsByBookCached` gains three states instead of two:
+
+| State | Condition | Behaviour |
+|---|---|---|
+| **fresh** | entry present, age < `metadataResultsCacheTTL` (60 s) | serve, no rebuild |
+| **stale** | entry present, 60 s ≤ age < `metadataResultsStaleMax` | **serve immediately**, kick at most one background rebuild |
+| **cold** | no entry, or age ≥ `metadataResultsStaleMax` | block on the rebuild (today's behaviour) |
+
+- `metadataResultsStaleMax = 15 * time.Minute`. **WHY a hard bound at all:** without
+  one, a rebuild that fails forever would keep serving a set of unbounded age while
+  looking authoritative. With it, a wedged rebuild degrades to slow-or-erroring, which
+  is honest, instead of silently ancient, which is not.
+- At most one background rebuild in flight, guarded by a new `inflight bool` field
+  inside the existing `metadataResultsCache` struct
+  (`internal/server/metadata_results_cache.go:38`) under the existing `mu`. **Not
+  `singleflight`** — one bool is enough and adds no dependency.
+- **The background rebuild goroutine MUST carry its own `recover()`.** Reuse
+  `warmerRecover("metadata-results-refresh")`. Today's
+  `TestLatestMetadataResultsByBookCached_ServesAFreshEntryWithoutRebuilding`
+  (`internal/server/metadata_results_cache_test.go:35`) passes a **nil store** and
+  proves no rebuild happened by relying on a build panicking. That specific test primes
+  a *fresh* entry, so it stays green under SWR — but the pattern is established in the
+  file, and the moment anyone primes an *expired* entry and calls the cached function
+  with a nil store, an unrecovered panic in a detached goroutine takes the process
+  down. The recover is what turns that into a logged warning instead of a crash.
+- The response gains `cache_age_seconds` so the UI can say "as of 40 s ago" rather than
+  implying live data. **Stale must be labelled stale, never disguised.**
+
+### D3 — Stale, not nil, on apply / reject / unreject
+
+The three `defer invalidateMetadataResultsCache()` call sites
+(`internal/server/metadata_batch_candidates.go:478`, `:583`, `:647`) switch to a new
+`markMetadataResultsCacheStale()` that **keeps the map** and back-dates
+`metaResultsCache.at` past the TTL, so the next read takes the D2 **stale** branch:
+serve instantly, refresh in the background.
+
+**WHY this is honest rather than a lie.** `PebbleStore.CreateOperationResult`
+(`internal/database/pebble_store_operations.go:469-477`) writes key
+`op_result:<OperationID>:<BookID>`. The apply path
+(`internal/server/metadata_batch_candidates.go:540`), reject (`:622`) and unreject
+(`:686`) all write with the *same* `OperationID` and `BookID` they read, so they
+**overwrite the row in place**. The stale set therefore differs from truth by exactly
+the statuses of the books the user just acted on, for exactly one refresh cycle — and
+the response labels its own age via `cache_age_seconds`. That is strictly better than
+today's behaviour, which blocks that same user for 34 s.
+
+**Rejected alternative, and what it would cost.** A copy-on-write patch — clone
+`latest`, set `Status` on the named `req.BookIDs`, recompute `counts`, install the
+clone — would reflect the change immediately with no stale window. It is correct and
+implementable (the handlers know both the IDs and the target status). It is **not**
+taken here because it is a new mechanism with its own concurrency surface, and this
+workstream is scoped to the cold start. Recorded as §8 Q1 for a follow-up.
+
+`invalidateMetadataResultsCache()` is **kept unchanged** as the nil-everything escape
+hatch: `resetMetadataResultsCache` (`internal/server/metadata_results_cache_test.go:17`)
+and `TestInvalidateMetadataResultsCache_ClearsTheEntry` (`:75`) both depend on
+nil-everything semantics, and a genuine "I have no idea what changed" caller should
+still exist.
+
+### D4 — Same two fixes for the ABS contributor warm
+
+1. **Enrol the warm** at `internal/server/wire_abs_routes.go:266-271` in `s.bgWG` as
+   `abs-contributors-warmer`, with `warmerRecover("abs-contributors")` and a `s.bgCtx`
+   skip — the same protection every other warmer received in #1781/#1794 and which this
+   one alone lacks. `wireABSRoutes` is a `*Server` method
+   (`internal/server/wire_abs_routes.go:99`), so `s.bgWG` and `s.bgCtx` are in scope.
+
+   **The `bgCtx` check must appear TWICE — before AND after `WaitForWarmup()`:**
+
+   ```go
+   s.bgWG.Add("abs-contributors-warmer")
+   go func() {
+       defer s.bgWG.Done("abs-contributors-warmer")
+       defer warmerRecover("abs-contributors")
+       if s.bgCtx.Err() != nil { return }
+       if ps, ok := s.Store().(*database.PebbleStore); ok {
+           ps.WaitForWarmup()
+       }
+       if s.bgCtx.Err() != nil { return } // shutdown arrived during the ~2.5 min wait
+       handler.WarmContributors(context.Background())
+   }()
+   ```
+
+   **WHY not pass `s.bgCtx` into `WarmContributors` instead.** That looks tidier and is
+   wrong. `WaitForWarmup` (`internal/database/pebble_store.go:153`) takes **no context**
+   — it is a bare `<-p.warmupDone` — so a warmer blocked in it cannot observe
+   cancellation at all. `Shutdown` cancels `bgCtx` and *then* calls `s.bgWG.Wait()`
+   (`internal/server/server_lifecycle.go:576`). Enrolling this goroutine therefore makes
+   `Wait()` block for the remainder of the ~2.5 min warmup no matter what context
+   `WarmContributors` receives. The second `bgCtx` check is what actually matters: it
+   stops a **6-second full-library scan against a store that is about to close**, which
+   is the real PEBBLE-CLOSED exposure D4 exists to remove. Threading a cancellable
+   context into the build would additionally change `WarmContributors`'s semantics
+   mid-build for no gain.
+2. **Give `contributorsCached`** (`internal/server/handlers/abs/browse.go:525`) the same
+   stale-while-revalidate treatment as D2, so the 5-minute TTL stops producing one cold
+   request every 5 minutes. State lives on the existing `h.authorsCacheMu` /
+   `h.authorsCache` / `h.narratorsCache` / `h.authorsCacheAt`
+   (`internal/server/handlers/abs/handler.go:267-270`); time comes from the existing
+   injected `h.now` field (`internal/server/handlers/abs/handler.go:273`), so tests can
+   drive the clock without sleeping.
+
+**The `WaitForWarmup()` gate stays.** That one *is* load-bearing, for the reason stated
+verbatim at `internal/server/wire_abs_routes.go:262-265`: the contributor set is derived
+from *visible* books (`contributorDTOs` → `h.visibleBookSummaries`,
+`internal/server/handlers/abs/browse.go:613-615`), so building it pre-memdb would cache
+a view of a library that does not exist yet and then serve it for the whole TTL.
+
+---
+
+## 4. Data model / API
+
+**No schema change. No store-interface change. No new operation, no new op ID.**
+
+`GET /api/v1/library/metadata-results` gains one additive field alongside the existing
+`items` / `total` / `by_status` / `limit` / `offset` (built at
+`internal/server/metadata_batch_candidates.go:932-938`; typed in TS as
+`MetadataResultsResponse`, `web/src/services/api.ts:3580-3586`):
+
+| Field | Type | Meaning |
+|---|---|---|
+| `cache_age_seconds` | number | age in seconds of the served build; `0` when the build was performed for this request |
+
+Additive only: the TS interface gains one optional field and no existing caller
+changes. `getMetadataResults` (`web/src/services/api.ts:3597`) needs no edit to keep
+working.
+
+---
+
+## 5. Failure modes
+
+| # | Failure | Handling |
+|---|---|---|
+| F1 | Background refresh goroutine panics | `warmerRecover("metadata-results-refresh")` inside it; the stale entry survives, the next request re-kicks |
+| F2 | Rebuild fails forever (store error) | stale served until `metadataResultsStaleMax` (15 min), then requests block and surface the real error rather than serving something ancient |
+| F3 | Refresh stampede — N concurrent requests each spawn a rebuild | `inflight` bool under the existing `mu`; at most one in flight |
+| F4 | Warmer outlives `Store().Close()` → `pebble: closed` panic | `bgWG` enrolment + `bgCtx` skip, exactly as `internal/server/server_lifecycle.go:718-774` does for the other five (D1, D4) |
+| F5 | ABS warm outlives shutdown | closed by D4 step 1. **Residual, stated so it is not a surprise:** because `WaitForWarmup` is uncancellable, `bgWG.Wait()` can still block for the remainder of the ~2.5 min memdb warmup on a shutdown issued during boot. What D4 removes is the 6-second scan against a closing store, not the wait itself |
+| F6 | User acts on a batch, then reads a stale list | one refresh cycle only, and the response carries `cache_age_seconds` so the staleness is visible, not disguised (D3) |
+| F7 | Boot warmer competes with memdb warmup for disk IO | accepted: it is one build, and the alternative (gating on ~2.5 min memdb) leaves the endpoint cold *longer* than today |
+| F8 | Read error inside the build silently drops books | **not fixed here** — inherited known defect, §7.1. Named so it is not mistaken for something this design closed |
+| F9 | >5000 mixed-type operations push older fetch ops out of the window | **not fixed here** — inherited known defect, §7.2 |
+| F10 | Parallelised build loses or reorders rows | not applicable — the build is not parallelised here (§7.3) |
+
+**No write-back-wipe surface.** Nothing in this design calls `UpdateBook` or
+`UpdateBookFile`; neither symbol appears in any file it touches. The dominant incident
+class is structurally absent here, not merely avoided.
+
+---
+
+## 6. Explicit non-goals
+
+- **No apply path.** Nothing is written, moved, merged or deleted. The dry-run/apply
+  gate that governs the other 2026-08-05 workstreams has no subject here; §9 defines
+  what stands in for it.
+- **No `books/itunes/**` access, and no filesystem access at all.** This design reads
+  `operation:`, `op_result:`, and (via the ABS path) author / narrator / book keys.
+- Not making the build fast enough to drop the cache.
+- **Not parallelising `latestMetadataResultsByBook`** — see §7.3 for why this is a
+  documented defect rather than in-scope work.
+- Not adding a narrators cache to the internal entities handler (§1.4: single cheap
+  prefix scan).
+- Not changing the values of `absAuthorsCacheTTL` or `metadataResultsCacheTTL`. SWR
+  removes the need to tune them.
+- Not touching `authors-warmer` / `series-warmer` (§1.4 correction: no bug there).
+- No frontend redesign. One optional response field; consuming it is optional.
+
+---
+
+## 7. Known defects found while verifying — NOT fixed here
+
+Each carries its evidence so a follow-up does not have to re-derive it.
+
+### 7.1 A read error is laundered into "never fetched"
+
+`internal/server/metadata_batch_candidates.go:810-813`:
+
+```go
+results, err := store.GetOperationResults(op.ID)
+if err != nil {
+    continue
+}
+```
+
+A failed read silently drops every book in that operation from `latest`. Those books
+then appear in the response as **`unfetched`**, because `handleListMetadataResults`
+derives that bucket by diffing `store.ListBookIDs()` against `latest`
+(`internal/server/metadata_batch_candidates.go:871-880`). A read error is rendered to
+the user as "this book has never been fetched".
+
+That is *absent evidence presented as negative evidence*, in the one endpoint whose
+entire job is reporting what has and has not been fetched. Nothing counts or logs it
+today. A fix would WARN-log per failure with the op ID, carry a `result_read_errors`
+count on the rebuild log line and in the response, and set an
+`unfetched_is_exact: false` flag whenever that count is non-zero so callers know the
+`unfetched` number is a ceiling and not a measurement. **Out of scope: it is a
+correctness fix to the build, not a cold-start fix.**
+
+### 7.2 The 5000-operation window silently truncates history
+
+`GetRecentOperations(5000)` (`internal/server/metadata_batch_candidates.go:796`) is
+implemented at `internal/database/pebble_store_operations.go:61`: it scans the entire
+`operation:` keyspace, unmarshals every record, sorts **all** of them by `CreatedAt`
+descending (`:80-82`), and truncates to the limit (`:84-86`) — all *before* the caller
+filters to `op.Type == "metadata_candidate_fetch"`
+(`internal/server/metadata_batch_candidates.go:807`). Once the library accumulates more
+than 5,000 mixed-type operations, older fetch operations fall out of the window and
+their books silently become `unfetched`.
+
+Fixing it needs a type-scoped operation lookup. **There is no `GetOperationsByType` on
+`database.OperationStore`** — grep across the whole repo returns nothing, and
+`internal/database/iface_ops.go:11-60` has no such method. Adding one is a
+store-interface change, which §4 rules out for this workstream.
+
+### 7.3 The build is a serial per-operation DB fan-out
+
+`latestMetadataResultsByBook` (`internal/server/metadata_batch_candidates.go:795-829`)
+opens one fresh Pebble prefix iterator per operation via `GetOperationResults`
+(`internal/database/pebble_store_operations.go:479`) — up to 5,000 iterator opens plus
+36,805 JSON unmarshals, **serially, on one core**.
+
+`CLAUDE.md` § "Concurrency — Prefer Multi-Core Design (MANDATORY)" describes this shape
+("a loop over a large collection doing a DB read per item"). It is a **pre-existing**
+loop, not one this workstream introduces, and under D2 no request ever waits on it. If
+it is parallelised later, the correct tool is
+`errgroup.Group` + `SetLimit(runtime.NumCPU())` (`golang.org/x/sync v0.22.0` is already
+at `go.mod:39`), **not** `registry.RunItems`
+(`internal/operations/registry/run_items.go:82`) — that takes a `registry.Reporter`, and
+there is no operation and no reporter on a warmer or HTTP path.
+
+A parallel version **must** add a deterministic tiebreak: today the winner is whichever
+result has the later `CreatedAt` with a strict `.After()`
+(`internal/server/metadata_batch_candidates.go:816-819`), so ties resolve by iteration
+order, which `GetRecentOperations`'s descending sort makes stable and which per-worker
+merging would make **non**-deterministic. Tiebreak on `OperationID` lexicographically,
+**not** on `OperationResult.ID`: that field exists
+(`internal/database/store.go:510`) but `CreateOperationResult`
+(`internal/database/pebble_store_operations.go:469-477`) never assigns it and callers
+construct the struct without it (e.g. `internal/server/metadata_ops.go:290`, `:379`,
+`:700`, `:767`). It is always `0` on this backend.
+
+---
+
+## 8. Open questions
+
+1. **Should apply/reject/unreject patch the cache instead of marking it stale?** D3
+   takes the smaller option. The copy-on-write patch (clone `latest`, set `Status` for
+   `req.BookIDs`, recompute `counts`) would remove even the one-cycle stale window.
+   Proposed: revisit only if that one cycle is actually noticed in use.
+2. **Should the boot warmer also pre-warm the `unfetched` diff?** It needs
+   `store.ListBookIDs()` and therefore memdb. Proposed: **no** — it is a handler-side
+   concern reached only with `include_unfetched=true`, and warming it would drag a
+   memdb dependency into a warmer that currently has none (D1).
+3. **Should `metadataResultsStaleMax` be configurable?** Proposed: no, a const, until
+   something demands otherwise.
+4. **Does the ABS client tolerate a stale contributor list across a 93-page sequence?**
+   `absAuthorsCacheTTL`'s comment (`internal/server/handlers/abs/browse.go:499-503`)
+   records that the owner already accepted a 5-minute-stale list, so SWR at the same
+   bound should be safe — worth one confirmation before shipping D4.
+
+---
+
+## 9. What stands in for a dry-run gate
+
+There is no apply, so the gate is observational. The instrument already exists —
+`internal/server/metadata_results_cache.go:71-72` logs:
+
+```
+metadata-results cache rebuilt   books=<n> duration_ms=<ms>
+```
+
+Adding a `trigger` field (`boot` | `demand` | `refresh`) makes the gate checkable from
+logs alone. The ABS side has its twin at
+`internal/server/handlers/abs/browse.go:1015` (`abs: contributor cache warmed`, with
+`duration_ms`). The exact numbers that must be observed before this is called working
+are in the plan's **Acceptance gate** section.

--- a/docs/specs/2026-08-05-multidisc-apply-canary-design.md
+++ b/docs/specs/2026-08-05-multidisc-apply-canary-design.md
@@ -1,0 +1,772 @@
+<!-- file: docs/specs/2026-08-05-multidisc-apply-canary-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 03f6e432-d7ad-49e4-93e4-680940fd99bd -->
+<!-- last-edited: 2026-08-05 -->
+
+> ⚠️ **UNVERIFIED DRAFT — symbols not grep-checked.** Authored by an agent on
+> 2026-08-05; the adversarial verification pass did not run (the workflow was
+> halted by API rate limiting). Treat every code citation as a claim, not a fact.
+> The design reasoning and measured production numbers are sound; the code
+> references need checking before execution.
+
+
+# Multidisc apply canary with before/after snapshot — DESIGN
+
+Owner item 3 (2026-08-05). Fragment:
+[`todo.d/20260805_220100_multidisc_apply_canary.md`](../../todo.d/20260805_220100_multidisc_apply_canary.md).
+
+Related: [`2026-08-05-review-queue-recommendations-design.md`](2026-08-05-review-queue-recommendations-design.md)
+(this workstream depends on it — see §2.3),
+[`.claude/notes/2026-08-05-first-aid-architecture.md`](../../.claude/notes/2026-08-05-first-aid-architecture.md),
+[`.claude/notes/2026-08-05-unlinked-books-investigation.md`](../../.claude/notes/2026-08-05-unlinked-books-investigation.md).
+
+---
+
+## 1. Problem statement
+
+### 1.1 The numbers
+
+| Quantity | Value | Source |
+|---|---|---|
+| Pending `regroup.multidisc` holds | **132** | fragment (was 138; the series-guard demoted 6 on 2026-08-05) |
+| Holds whose members are individually book-length | **9 of 138** | fragment, measured 2026-08-05 |
+| "Confident" multidisc candidates that were actually whole author catalogues | **41 of 43** | [`fs_regroup_shape.go:125-159`](../../internal/itunes/service/fs_regroup_shape.go) doc comment |
+| Library size | 44,887 books | first-aid note |
+| `review_apply_enabled` in prod | **false** | [`config.go:1917`](../../internal/config/config.go) default; not set in prod |
+
+### 1.2 The apply path hard-deletes
+
+`ApplyMultidisc` ([`regroup_apply.go:78`](../../internal/plugins/maintenance/regroup_apply.go))
+calls `combiner.CombineBooks(present, primaryID, nil)` at line 100.
+`merge.Service.CombineBooks` ([`service.go:336`](../../internal/merge/service.go))
+moves every absorbed book's `book_file` rows onto the survivor and then **hard-deletes
+the absorbed `Book` rows** — the file header at `regroup_apply.go:28` says so in as many
+words: *"absorbed ROWS are hard-deleted intentionally."*
+
+There is no tombstone to read back. `CombineResult` ([`service.go:309-313`](../../internal/merge/service.go))
+carries only `PrimaryID`, `FilesMoved`, `BooksDeleted` — three integers. Once the merge
+commits, the *only* possible record of which books existed, what they were called, how
+long they were and where their files lived is a record made **before** the call.
+
+That is the whole of this workstream: make that record, make it mandatory, and make the
+first real applies small enough to check by ear.
+
+### 1.3 The kind-scoped bulk footgun
+
+`BulkReviewAction` ([`handler.go:253`](../../internal/server/handlers/review/handler.go))
+accepts `{"action":"approve","kind":"regroup.multidisc"}` with **no ids**. Lines 273-288
+then list *every* pending item of that Kind up to `bulkScanLimit = 100_000`
+([`handler.go:328`](../../internal/server/handlers/review/handler.go)) and loop
+`approveOne` over all of them (line 294). The frontend wires exactly that shape:
+`handleBulkAction(kind, action)` at [`ReviewQueue.tsx:300`](../../web/src/pages/ReviewQueue.tsx)
+posts `{action, kind}` and is bound to the bucket-header buttons at lines 412 and 422.
+
+With `review_apply_enabled` flipped on, one click on "Approve all" in the
+`regroup.multidisc` bucket header fires 132 `CombineBooks` calls with no confirmation,
+no snapshot and no undo.
+
+### 1.4 Absent evidence is not negative evidence — and it is still absent for some holds
+
+`membersAreBookLength` ([`fs_regroup_shape.go:149`](../../internal/itunes/service/fs_regroup_shape.go))
+counts unknown durations as **not** book-length, which is correct for a guard but means
+a zero-duration group falls straight through the flat branch's
+`!membersAreBookLength(members)` condition ([`fs_regroup_shape.go:720`](../../internal/itunes/service/fs_regroup_shape.go))
+into a *confident* collapse. The relink op ([`relink_unlinked.go`](../../internal/plugins/maintenance/relink_unlinked.go))
+restored durations for the file-shaped population, but nothing guarantees every current
+hold's members now carry one.
+
+Worse, the guard is only in the **flat** branch. Read the switch at
+[`fs_regroup_shape.go:715-757`](../../internal/itunes/service/fs_regroup_shape.go):
+
+- `case structure == "disc" && discCount*2 > n:` → `KindMultidisc`, **no** book-length check
+- `case structure == "flat" && … && !membersAreBookLength(members):` → `KindMultidisc`, checked
+- `case (structure == "chapter" || structure == "edition") && folderNamedAfterBook && distinctPrefixes <= 1:` → `KindMultidisc`, **no** book-length check
+
+So the fragment's "9 of 138 have book-length members" is exactly the population the disc
+and chapter/edition branches never evaluated. Those 9 are still sitting in the queue and
+are the highest-risk rows in it.
+
+---
+
+## 2. Scope
+
+### 2.1 In scope
+
+1. A durable, on-disk **before-snapshot** format and writer (`internal/applysnapshot`).
+2. A **structural gate**: `ApplyMultidisc` cannot reach `CombineBooks` without a
+   successful snapshot write.
+3. A **canary op** `maintenance.multidisc-apply-canary` with `before` and `after` modes,
+   including a per-hold risk ranking so the operator can choose the safest handful.
+4. A **server-side refusal** of kind-scoped bulk approve while apply is globally enabled.
+
+### 2.2 Non-goals
+
+- **No undo/rollback of a committed combine.** The snapshot is a *record*, not a
+  reversal. Reconstructing hard-deleted rows is out of scope (and rule 4 says the
+  remedy for a bad merge is re-association, not deletion — a separate workstream).
+- **No changes to the classifier.** Whether `membersAreBookLength` should also run on
+  the disc and chapter branches is a real finding (§9.2) but a `regroup-shattered-ai`
+  change, not a canary change.
+- **No gate on the manual combine endpoint** `POST /api/v1/audiobooks/combine`
+  ([`wire_dedup_routes.go:75`](../../internal/server/wire_dedup_routes.go) →
+  [`duplicates/handler.go:325`](../../internal/server/handlers/duplicates/handler.go)),
+  which reaches `merge.Service.CombineBooks` independently. See D1's scope note.
+- **No changes to `ApplyVersionGroup`.** It uses re-fetch-and-patch `UpdateBook` and
+  never deletes ([`regroup_apply.go:264-279`](../../internal/plugins/maintenance/regroup_apply.go));
+  losing a version link is recoverable, so it does not need the gate. Surgical scope.
+- **No flipping of `review_apply_enabled`.** This spec produces the evidence that makes
+  flipping it a decision rather than a gamble. The flip itself is an owner action.
+- **No new UI beyond one confirmation dialog.** The review queue's per-hold override UI
+  belongs to the sibling workstream.
+- **No writes anywhere under `books/itunes/**`.** The producer already excludes the
+  frozen tree ([`regroup_shattered_ai.go:191`](../../internal/plugins/maintenance/regroup_shattered_ai.go)
+  calls `config.UnderFrozenITunesTree`); the canary re-checks and refuses (D9).
+
+### 2.3 Dependency on the recommendations workstream
+
+The fragment declares a dependency on `review-queue-recommendations-and-overrides` so
+approval targets one hold at a time. That spec's §7.4 rekeys the handler registry from
+Kind to action: `RegisterApplyHandler(kind, fn)` → `RegisterActionHandler(action, fn)`,
+and rewrites [`wire_handlers.go:603-607`](../../internal/server/wire_handlers.go) — the
+exact five lines this workstream also edits.
+
+**Resolution:** this workstream lands *after* it, and the plan is written against the
+post-sibling shape. The third constructor argument is identical either way:
+
+```go
+// post-sibling (expected):
+combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc, snapRecorder)
+reviewH.RegisterActionHandler(itunesservice.ActionCombine, combine)
+
+// if this workstream lands FIRST, the registration lines are today's:
+combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc, snapRecorder)
+reviewH.RegisterApplyHandler(itunesservice.KindMultidisc, combine)
+reviewH.RegisterApplyHandler(itunesservice.KindAnthology, combine)
+```
+
+Only the registration call differs. Nothing else in this spec depends on which lands first.
+
+---
+
+## 3. Locked decisions
+
+### D1 — The snapshot is a precondition inside `ApplyMultidisc`, not a separate op you are supposed to remember to run
+
+`ApplyMultidisc` gains a third parameter:
+
+```go
+func ApplyMultidisc(
+    store database.Store,
+    combiner bookCombiner,
+    rec applysnapshot.Recorder,
+) func(context.Context, database.ReviewItem) error
+```
+
+and, between `pickPrimary` (line 99) and `CombineBooks` (line 100), it captures and
+writes the snapshot. **A nil recorder, or any write error, returns an error and the
+combine never runs.**
+
+**Scope of the guarantee, stated exactly.** This makes `CombineBooks` unreachable
+**from the review-apply path**. It does **not** make `merge.Service.CombineBooks`
+unreachable in general — grepped, there is a second live caller:
+
+```
+internal/server/handlers/duplicates/handler.go:325  func (h *Handler) CombineBooks(c *gin.Context)
+internal/server/handlers/duplicates/handler.go:351  result, err := ms.CombineBooks(append(req.MergeIDs, req.KeepID), req.KeepID, req.Override)
+internal/server/wire_dedup_routes.go:75             protected.POST("/audiobooks/combine", …, duplicatesH.CombineBooks)
+```
+
+That is the **manual** combine — a human explicitly naming `keep_id` and `merge_ids` in
+one request, with a non-nil `override`. It hard-deletes the same way and is **not** gated
+by this work (§2.2). Gating it is defensible follow-up work; it is out of scope here
+because this workstream is about the 132-hold queue, and because a hand-typed two-book
+combine is a different risk profile from a bulk button that fires 132 of them. Do not
+read D1 as "no combine can happen without a snapshot" — read it as "no *review-queue
+approve* can."
+
+*Why this shape and not an op you run first.* CLAUDE.md rule 2's instruction is to
+"prefer designs where the dangerous call is unreachable." There are three ways into this
+closure today — `ApproveReviewItem` → `approveOne` ([`handler.go:154`, `:179`](../../internal/server/handlers/review/handler.go)),
+`BulkReviewAction` → `approveOne` ([`handler.go:294`](../../internal/server/handlers/review/handler.go)),
+and `ReplayApprovedItems` ([`replay.go:120`](../../internal/server/handlers/review/replay.go)) —
+and the sibling workstream is adding per-item action overrides as a fourth. A procedural
+"snapshot first" rule has to be re-enforced at each one and re-remembered at every future
+call site. A parameter cannot be forgotten: it will not compile.
+
+*Why nil is an error and not a silent skip.* A recorder that no-ops when it cannot write
+re-opens the exact hole the gate closes, and it would fail open at precisely the moment
+disk is full or the directory is unwritable. Fail closed.
+
+### D2 — `ApplyVersionGroup` is NOT gated
+
+Version-group links are `UpdateBook`-based re-fetch-and-patch with no delete
+([`regroup_apply.go:264-279`](../../internal/plugins/maintenance/regroup_apply.go)); a
+wrong link is undone by clearing `VersionGroupID`. The gate exists for irreversibility,
+so applying it here would be cargo-culting. `regroup.anthology` **is** covered, because
+[`wire_handlers.go:604-605`](../../internal/server/wire_handlers.go) registers the *same*
+`combine` closure for it — anthology also calls `CombineBooks` and also hard-deletes.
+
+### D3 — Snapshot file: append-only JSONL beside the database, one line per hold
+
+Path: `filepath.Join(filepath.Dir(config.AppConfig.DatabasePath), "apply-snapshots", "<kind>-<RFC3339-date>.jsonl")`.
+
+*Why beside the database and not under `RootDir()`.* `ServerDeps` exposes `RootDir()`
+([`deps.go:~131`](../../internal/plugins/maintenance/deps.go)) and no database-path
+accessor, but `RootDir()` is the **library** root — writing operational records into the
+books tree is wrong on its own terms, and part of that tree is the frozen iTunes library
+(rule 5). `config.AppConfig` is a package global ([`config.go:786`](../../internal/config/config.go))
+and `DatabasePath` ([`config.go:467`](../../internal/config/config.go)) already has its
+parent directory validated as existing and writable at startup
+([`config.go:1784-1788`](../../internal/config/config.go)). The maintenance package
+already imports `internal/config` ([`regroup_shattered_ai.go:47`](../../internal/plugins/maintenance/regroup_shattered_ai.go)),
+so nothing new is threaded through `ServerDeps`.
+
+*Empty `DatabasePath`.* There is **no** `viper.SetDefault("database_path", …)` in
+`config.go` — the value can be empty in a mis-set config. When it is empty and no
+explicit `snapshotDir` override was given, the recorder constructor **returns an error**
+and the op/apply fails. Never a silent skip (D1).
+
+*Why JSONL and not one JSON document.* Append-only means a crash mid-run loses at most
+the final partial line, and every earlier hold's record is already durable. A single JSON
+array would have to be rewritten whole on each append.
+
+*Durability.* Each record is written with `O_APPEND|O_CREATE|O_WRONLY`, followed by
+`f.Sync()` **before** `Record` returns. The combine must not start until the bytes are on
+the platter.
+
+### D4 — Snapshot contents are exactly the fields needed to reconstruct the human question
+
+Full schema in §4. The fragment names the minimum — "every member book ID, title,
+duration, file path, and which ID `pickPrimary` will select" — and this design adds the
+per-*file* level, because the after-diff's only exact invariant is file-ID set
+containment (D7) and that needs file IDs.
+
+**Fingerprints are recorded as presence + byte length, never as bytes.**
+`BookFile.AcoustIDFingerprint` is `[]byte` ([`store.go:~731`](../../internal/database/store.go)),
+4 bytes per frame at 8 frames/sec — a 10-hour book is megabytes. Presence and length are
+sufficient to prove retention and keep the snapshot readable.
+
+### D5 — Duration evidence is a three-valued field, not a boolean
+
+Per file: `durationRaw` (the stored `BookFile.Duration`) **and** `durationSec`
+(`database.NormalizeDurationSec(FileSize, Duration)` — the same call the producer makes
+at [`regroup_shattered_ai.go:~153`](../../internal/plugins/maintenance/regroup_shattered_ai.go)).
+Per member, `durationEvidence` is one of:
+
+| Value | Meaning |
+|---|---|
+| `measured` | non-zero and `durationRaw == durationSec` for every file |
+| `normalized` | non-zero, but at least one file's raw value was rescaled |
+| `absent` | the member's summed `durationSec` is 0 |
+
+*Why the third value.* `NormalizeDurationSec` exists because ~1.9% of historical rows
+stored **milliseconds** ([`relink_unlinked.go:300-304`](../../internal/plugins/maintenance/relink_unlinked.go)).
+A 1000×-inflated row reads as book-length to the series signal. Collapsing `normalized`
+into `measured` would let the risk ranking say "this hold looks like a series" when the
+truthful statement is "this hold looks like a series *because of a millisecond row*."
+
+`absent` means **cannot verify** and is ranked as a hazard, never as "safe to merge"
+(rule 3). It is the state that made the guard inert across 97.5% of the queue.
+
+### D6 — The canary op is dry-run by default with an explicit `apply` flag it does not own
+
+`maintenance.multidisc-apply-canary` **never merges anything.** Its `before` mode is
+read-only over the review queue and the book store; its `after` mode is read-only too.
+Applying stays where it already lives — the review HTTP surface, behind
+`review_apply_enabled` and (post-sibling) per-item `ids`.
+
+*Why the op does not apply.* Two independent kill switches are better than one, and an
+op that both snapshots and merges could be invoked by the scheduler. The op has
+`Capabilities: []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesWrite}` — library **read**
+only; `CapFilesWrite` is for the snapshot file itself. No `CapLibraryWrite`, mirroring
+how `regroupShatteredAIDef` withholds it at
+[`regroup_shattered_ai.go:99-101`](../../internal/plugins/maintenance/regroup_shattered_ai.go).
+
+### D7 — The after-diff gates on file-ID **set containment**, not on a file **count** identity
+
+Every `BookFile.ID` recorded in the before-snapshot for a hold MUST be present on the
+survivor afterwards. That is exact and needs no model of the combine's internals.
+
+The count delta is **reported, not asserted.** `CombineBooks` can legitimately change the
+file count in ways the snapshot cannot predict: `ensureOwnFile`
+([`service.go:497`](../../internal/merge/service.go)) materializes the survivor's own
+virtual file when it has none, and `attachVirtualFile` ([`service.go:511`](../../internal/merge/service.go))
+looks the absorbed member's path up with `GetBookFileByPath` and, when a row already
+exists **under a different owner**, *moves* that row rather than creating one. So the
+arithmetic depends on rows outside the snapshot. The diff therefore records three numbers
+side by side and lets a human read them:
+
+- `filesBefore` — Σ member `fileCount` from the snapshot (exact)
+- `filesMovedReported` — `CombineResult.FilesMoved` ([`service.go:311`](../../internal/merge/service.go))
+- `filesAfter` — `len(store.GetBookFiles(survivorID))`
+
+### D8 — Kind-scoped bulk **approve** is refused while apply is globally enabled
+
+In `BulkReviewAction`: when `len(req.IDs) == 0` (kind-scoped), `req.Action == "approve"`,
+the resolved target has a registered handler, **and** `h.applyGloballyEnabled()` is true
+→ respond `409` with code `BULK_APPLY_REQUIRES_IDS`.
+
+*Why no count threshold.* A magic number (`> 10 → refuse`) is a tuning parameter nobody
+can defend and it drifts. The boolean is exact: with the switch **off**, kind-scoped bulk
+is a bookkeeping operation — it is how the queue gets reviewed *before* apply, and
+`ReplayApprovedItems` exists specifically to make those decisions count later
+([`replay.go:30-46`](../../internal/server/handlers/review/replay.go)) — so it stays
+allowed. With the switch **on**, the same click is 132 hard-deleting merges, and the
+fragment says never. `reject` is unaffected in both states.
+
+### D9 — The canary refuses to write its snapshot inside the frozen iTunes tree
+
+Before opening the file the recorder calls `config.UnderFrozenITunesTree(dir)`
+([`itunes_libraries.go:98`](../../internal/config/itunes_libraries.go)) and returns an
+error if it is true. Under a sane config this can never fire; it exists so that a
+mis-set `database_path` cannot turn a safety feature into a rule-5 violation.
+
+Separately, the canary counts members whose `FilePath` or first file's `ITunesPath` is
+under the frozen tree and reports the count. It should be **0** — the producer already
+excludes them at [`regroup_shattered_ai.go:191`](../../internal/plugins/maintenance/regroup_shattered_ai.go) —
+so a nonzero value means a stale hold predating that fix and is a hard blocker.
+
+### D10 — Concurrency: member resolution is a bounded worker pool over holds
+
+`before` mode fans out across **holds** with
+`registry.RunItems(ctx, reporter, ids, fn, registry.RunItemsOptions{Concurrency: runtime.NumCPU(), ProgressTotal: len(ids), ErrMode: registry.ErrModeCollect, Label: …})`
+— the same call shape `relink_unlinked.go:117-156` uses.
+
+*Why a pool for only 132 holds.* Per hold the work is `len(members)` × (`GetBookByID` +
+`GetBookFiles`), so the real item count is in the thousands of DB reads, and the CLAUDE.md
+mandate is to design for concurrency *from the start* rather than bolt it on. Sharding by
+hold (not by member) keeps each worker's set disjoint. The pass is **read-only**, so
+there is no shared-mutation hazard; results are collected under one mutex, exactly as
+`relink_unlinked.go:113-147` does.
+
+The **write** of the JSONL file stays single-threaded after the scan, so line order is
+deterministic (sorted by hold ID) and two dry runs diff cleanly.
+
+### D11 — Counts must reconcile, with no silent filtering
+
+Both modes emit a `RECONCILE:` log line and reuse `linkintegrity.Report` /
+`linkintegrity.PhaseResult` — the same types `relink_unlinked.go:165-224` uses, including
+its `report.UnreconciledPhases()` check that **fails the op** when a phase does not
+balance. The identity is:
+
+```
+holdsExamined == holdsSnapshotted + holdsSkipped + holdsErrored
+```
+
+with every skip carrying a reason string. `after` mode reconciles the same way over the
+snapshot's records.
+
+### D12 — The snapshot is keyed by `ReviewItem.ID`, and re-recording is allowed
+
+`Recorder.Has(itemID)` reports whether a record already exists, but a second `Record` for
+the same item **appends a new line** rather than being suppressed. Approve → fail →
+re-approve is a real sequence (`ReplayApprovedItems` leaves failed items retryable,
+[`replay.go:125-127`](../../internal/server/handlers/review/replay.go)), and the second
+attempt's world-state may differ from the first's — `presentMembers`
+([`regroup_apply.go:338`](../../internal/plugins/maintenance/regroup_apply.go)) may
+resolve fewer members. Both attempts are evidence. Readers take the **last** record for a
+given item ID.
+
+---
+
+## 4. Data model
+
+### 4.1 Package `internal/applysnapshot`
+
+```go
+// Recorder captures an irreversible apply's inputs before it runs.
+type Recorder interface {
+    // Record durably writes one snapshot. It MUST fsync before returning nil.
+    // A non-nil error MUST prevent the caller from performing the apply.
+    Record(ctx context.Context, s Snapshot) error
+    // Has reports whether any record for itemID exists in this recorder's file.
+    // Consumer: `after` mode, to separate "this hold was applied but never
+    // snapshotted" (a gate failure — investigate) from "this hold was never
+    // applied" (expected). Not used to suppress a re-record — see D12.
+    Has(itemID string) (bool, error)
+    // Path returns the file being appended to (for logs and the op report).
+    Path() string
+}
+```
+
+### 4.2 `Snapshot` — one review hold, one JSONL line
+
+```go
+type Snapshot struct {
+    SchemaVersion int       `json:"schema_version"` // 1
+    CapturedAt    time.Time `json:"captured_at"`
+    Origin        string    `json:"origin"`        // "apply-gate" | "canary-before"
+
+    // ── the review hold, verbatim ────────────────────────────────────────
+    ItemID    string `json:"item_id"`    // database.ReviewItem.ID
+    Kind      string `json:"kind"`       // ReviewItem.Kind
+    DedupKey  string `json:"dedup_key"`  // ReviewItem.DedupKey
+    FolderRef string `json:"folder_ref"` // ReviewItem.FolderRef
+    Status    string `json:"status"`     // ReviewItem.Status at capture
+    Summary   string `json:"summary"`    // ReviewItem.Summary
+    Payload   string `json:"payload"`    // ReviewItem.Payload, raw JSON string
+
+    // ── the decoded proposal ─────────────────────────────────────────────
+    Folder         string   `json:"folder"`          // regroupPayload.Folder
+    ProposedAction string   `json:"proposed_action"` // regroupPayload.ProposedAction
+    SurvivorTitle  string   `json:"survivor_title"`  // regroupPayload.SurvivorTitle
+    Confidence     string   `json:"confidence"`      // regroupPayload.Confidence
+    MemberBookIDs  []string `json:"member_book_ids"` // regroupPayload.MemberBookIDs, as written
+    PayloadFiles   []string `json:"payload_files"`   // regroupPayload.Files
+    DiscNumbers    []int    `json:"disc_numbers,omitempty"`
+    TrackNumbers   []int    `json:"track_numbers,omitempty"`
+
+    // ── what the apply will actually do ──────────────────────────────────
+    PresentBookIDs []string `json:"present_book_ids"` // presentMembers() result
+    ChosenPrimary  string   `json:"chosen_primary"`   // pickPrimary(PresentBookIDs)
+    PrimaryRule    string   `json:"primary_rule"`     // "smallest-ULID" (regroup_apply.go:360-372)
+
+    // ── the members, fully ───────────────────────────────────────────────
+    Members []Member `json:"members"`
+
+    // ── derived risk signals (see §5) ────────────────────────────────────
+    Risk RiskSignals `json:"risk"`
+}
+```
+
+`Payload` is stored **verbatim as a string**, not re-marshalled. A future `regroupPayload`
+field this struct does not know about still survives in the record.
+
+### 4.3 `Member`
+
+```go
+type Member struct {
+    BookID   string `json:"book_id"`
+    Present  bool   `json:"present"`  // resolved and not soft-deleted
+    Absence  string `json:"absence,omitempty"` // "not-found" | "soft-deleted"
+
+    Title    string `json:"title"`     // Book.Title
+    FilePath string `json:"file_path"` // Book.FilePath (virtual/shell path)
+
+    AuthorID       *int `json:"author_id,omitempty"`       // Book.AuthorID
+    SeriesID       *int `json:"series_id,omitempty"`       // Book.SeriesID
+    SeriesSequence *int `json:"series_sequence,omitempty"` // Book.SeriesSequence
+    AuthorName     string `json:"author_name,omitempty"`   // resolved via GetAuthorByID
+    SeriesName     string `json:"series_name,omitempty"`   // resolved via GetSeriesByID
+
+    BookDurationSnapshot *int    `json:"book_duration_snapshot,omitempty"` // Book.Duration
+    LibraryState         *string `json:"library_state,omitempty"`
+    VersionGroupID       *string `json:"version_group_id,omitempty"`
+    IsPrimaryVersion     *bool   `json:"is_primary_version,omitempty"`
+    MarkedForDeletion    *bool   `json:"marked_for_deletion,omitempty"`
+
+    FileCount        int    `json:"file_count"`         // len(GetBookFiles)
+    DurationSec      int    `json:"duration_sec"`       // Σ NormalizeDurationSec over files
+    DurationEvidence string `json:"duration_evidence"`  // measured | normalized | absent (D5)
+    UnderFrozenTree  bool   `json:"under_frozen_tree"`  // D9
+
+    Files []File `json:"files"`
+}
+```
+
+`AuthorName`/`SeriesName` come from `GetAuthorByID(id int)`
+([`iface_author.go:13`](../../internal/database/iface_author.go)) and `GetSeriesByID(id int)`
+([`iface_series.go:10`](../../internal/database/iface_series.go)) — `Book` itself stores
+only the integer IDs ([`store.go:125-126`](../../internal/database/store.go)). Lookup
+failure leaves the name empty and is **not** an error: the ID is the durable part.
+
+### 4.4 `File`
+
+```go
+type File struct {
+    ID               string `json:"id"`                 // BookFile.ID — the after-gate key (D7)
+    FilePath         string `json:"file_path"`
+    OriginalFilename string `json:"original_filename,omitempty"`
+    ITunesPath       string `json:"itunes_path,omitempty"`
+    DurationRaw      int    `json:"duration_raw"`       // BookFile.Duration as stored
+    DurationSec      int    `json:"duration_sec"`       // NormalizeDurationSec(FileSize, Duration)
+    FileSize         int64  `json:"file_size"`
+    DiscNumber       int    `json:"disc_number"`
+    TrackNumber      int    `json:"track_number"`
+    Format           string `json:"format,omitempty"`
+    FileHash         string `json:"file_hash,omitempty"`
+    FingerprintBytes int    `json:"fingerprint_bytes"`  // len(AcoustIDFingerprint), never the bytes (D4)
+}
+```
+
+### 4.5 `RiskSignals`
+
+```go
+type RiskSignals struct {
+    MemberCount         int    `json:"member_count"`
+    PresentCount        int    `json:"present_count"`
+    TotalDurationSec    int    `json:"total_duration_sec"`
+    LongMembers         int    `json:"long_members"`          // members with DurationSec >= 5400
+    MajorityBookLength  bool   `json:"majority_book_length"`  // LongMembers*2 > PresentCount
+    ZeroDurationMembers int    `json:"zero_duration_members"`
+    NormalizedMembers   int    `json:"normalized_members"`
+    DistinctSeriesIDs   int    `json:"distinct_series_ids"`
+    FrozenTreeMembers   int    `json:"frozen_tree_members"`
+    AlreadyMultiFile    int    `json:"already_multi_file"`    // members with FileCount > 1
+    Band                string `json:"band"`                  // "red" | "amber" | "green"
+}
+```
+
+`5400` is `90*60`, the same threshold as `bookLengthSec`
+([`fs_regroup_shape.go:~124`](../../internal/itunes/service/fs_regroup_shape.go)), and
+`MajorityBookLength` reproduces `membersAreBookLength`'s strict-majority rule
+([`fs_regroup_shape.go:149-167`](../../internal/itunes/service/fs_regroup_shape.go)).
+Both are **re-implemented in `applysnapshot`, not imported** — see §9.1 for why, and for
+the consequence.
+
+---
+
+## 5. Risk banding
+
+Evaluated per hold in `before` mode. Bands are advisory ordering for a human, never an
+automatic action.
+
+| Band | Condition | Reading |
+|---|---|---|
+| **red** | `MajorityBookLength` **or** `FrozenTreeMembers > 0` **or** `DistinctSeriesIDs > 1` | This is the 41-of-43 shape, a rule-5 violation, or a group spanning series. Do not approve. |
+| **amber** | `ZeroDurationMembers > 0` **or** `LongMembers > 0` **or** `NormalizedMembers > 0` **or** `AlreadyMultiFile > 0` | Cannot verify, or a partial series signal, or a millisecond row, or a member that is already a real multi-file book. Needs a listen. |
+| **green** | none of the above, and every member has `DurationEvidence == "measured"` | Positive duration evidence, all members chapter-length. Canary candidates come from here. |
+
+**A hold with any `absent` member can never be green.** Absent duration is "cannot
+verify" (rule 3) — it is precisely the state that made the guard inert across 97.5% of
+the queue, and it must not be laundered into a green light by the absence of a red flag.
+
+---
+
+## 6. Op definition
+
+```
+ID:              maintenance.multidisc-apply-canary
+Plugin:          maintenance
+DisplayName:     Multidisc apply canary (before/after snapshot · read-only)
+ResumePolicy:    sdk.ResumeDrop
+DefaultPriority: sdk.PriorityNormal
+ConcurrencyKey:  maintenance.multidisc-apply-canary
+Cancellable:     true
+Isolate:         false
+Timeout:         30 * time.Minute
+Capabilities:    sdk.CapLibraryRead, sdk.CapFilesWrite   // FilesWrite = the snapshot file only
+Schedule:        (none — manual, per first-aid decision D3)
+```
+
+Registered by appending `p.multidiscApplyCanaryDef()` to the slice in `(*Plugin).Register`
+([`plugin.go:32`](../../internal/plugins/maintenance/plugin.go)), next to
+`p.regroupShatteredAIDef()` at line 108.
+
+### 6.1 Params
+
+```go
+type canaryParams struct {
+    Mode        string   `json:"mode"`        // "before" (default) | "after"
+    Kinds       []string `json:"kinds"`       // default: [regroup.multidisc]
+    Status      string   `json:"status"`      // default: pending; "after" defaults to applied
+    IDs         []string `json:"ids"`         // restrict to these ReviewItem IDs
+    SnapshotDir string   `json:"snapshotDir"` // override D3's derived directory
+    SnapshotFile string  `json:"snapshotFile"`// "after" mode: read this file (default: newest for kind)
+}
+```
+
+There is **no `apply` param** (D6).
+
+### 6.2 `before` mode
+
+1. `store.ListReviewItems(database.ReviewFilter{Status: params.Status, Kind: k, Limit: 0})`
+   for each kind ([`iface_review.go:24`](../../internal/database/iface_review.go)); filter
+   to `params.IDs` when given.
+2. `registry.RunItems` over hold IDs at `runtime.NumCPU()` (D10). Per hold:
+   `decodeRegroupPayload`-equivalent decode, `GetBookByID` + `GetBookFiles` per member,
+   presence/soft-delete classification mirroring `presentMembers`
+   ([`regroup_apply.go:338-358`](../../internal/plugins/maintenance/regroup_apply.go)),
+   `pickPrimary` over the present set, duration normalization, risk banding.
+3. Sort by `ItemID`, write every snapshot through the recorder (single-threaded).
+4. Emit the `RECONCILE:` line and the band histogram; fail on `UnreconciledPhases()`.
+
+### 6.3 `after` mode
+
+1. Load the snapshot file; take the **last** record per `ItemID` (D12).
+2. For each record, re-read `GetBookByID(ChosenPrimary)` and
+   `GetBookFiles(ChosenPrimary)`, plus `GetBookByID` for every absorbed member ID.
+3. Emit one `Diff` per record:
+
+```go
+type Diff struct {
+    ItemID           string   `json:"item_id"`
+    SurvivorID       string   `json:"survivor_id"`
+    SurvivorPresent  bool     `json:"survivor_present"`
+    SurvivorSoftDeleted bool  `json:"survivor_soft_deleted"`
+    FilesBefore      int      `json:"files_before"`
+    FilesAfter       int      `json:"files_after"`
+    MissingFileIDs   []string `json:"missing_file_ids"`     // D7 — MUST be empty
+    ExtraFileIDs     []string `json:"extra_file_ids"`       // reported, not asserted
+    DurationBeforeSec int     `json:"duration_before_sec"`
+    DurationAfterSec  int     `json:"duration_after_sec"`
+    FingerprintedBefore int   `json:"fingerprinted_before"`
+    FingerprintedAfter  int   `json:"fingerprinted_after"`  // MUST be >= before
+    AbsorbedGone     []string `json:"absorbed_gone"`
+    AbsorbedSurvived []string `json:"absorbed_survived"`    // unexpected; investigate
+    TrackNumbers     []int    `json:"track_numbers"`
+    TrackOrderOK     bool     `json:"track_order_ok"`       // 1..N contiguous & unique, OR guard fired
+    Verdict          string   `json:"verdict"`              // "ok" | "attention"
+}
+```
+
+`AbsorbedGone` is determined by `GetBookByID(id) == (nil, nil)`. That contract is
+verified: `PebbleStore.GetBookByID` returns `nil, nil` on `pebble.ErrNotFound`
+([`pebble_store.go:753-758`](../../internal/database/pebble_store.go)).
+
+`TrackOrderOK` tolerates "no numbering happened": `applyDiscTrackNumbers` returns `(0, nil)`
+without writing when the payload has no disc/track arrays, or when **any** survivor file
+already carried disc/track metadata — the group-level guard at
+[`regroup_apply.go:155-162`](../../internal/plugins/maintenance/regroup_apply.go).
+
+---
+
+## 7. API surface change
+
+Only one, in `BulkReviewAction` ([`handler.go:253`](../../internal/server/handlers/review/handler.go)),
+implementing D8. Inserted after the existing `req.Kind == "" && len(req.IDs) == 0` guard
+at lines 267-270:
+
+```go
+if req.Action == "approve" && len(req.IDs) == 0 && h.applyGloballyEnabled() {
+    if _, hasHandler := h.applyHandlerFor(req.Kind); hasHandler {
+        httputil.RespondWithError(c, http.StatusConflict,
+            "review apply is enabled: kind-scoped bulk approve would execute every pending "+
+                "item of this kind. Pass explicit 'ids' instead.",
+            "BULK_APPLY_REQUIRES_IDS")
+        return
+    }
+}
+```
+
+Post-sibling this becomes `h.actionHandlerFor(resolvedAction)` per that spec's §7.4; the
+condition is otherwise identical.
+
+🐛 **Pre-existing bug found while verifying this signature.** The real declaration is
+`RespondWithError(c *gin.Context, statusCode int, message string, code string)`
+([`httputil/respond.go:18`](../../internal/httputil/respond.go)) — **message third, code
+fourth**. [`replay.go:106-108`](../../internal/server/handlers/review/replay.go) passes
+them the other way round:
+
+```go
+httputil.RespondWithError(c, http.StatusConflict, "REVIEW_APPLY_DISABLED",
+    "review apply is globally disabled; enable review_apply_enabled before replaying approved items")
+```
+
+so that 409's JSON body currently reports `error: "REVIEW_APPLY_DISABLED"` and
+`code: "review apply is globally disabled; …"` — the two fields are swapped. Cosmetic (no
+data risk) but it is in the same function family this workstream touches; the plan fixes
+it as a one-line drive-by in S4.
+
+Frontend ([`ReviewQueue.tsx:300`](../../web/src/pages/ReviewQueue.tsx)): `handleBulkAction`
+surfaces the 409's message verbatim through the existing `addNotification` error path, and
+the bucket-header Approve button (line 412) gains a `window.confirm` naming the bucket's
+pending count. Cosmetic — the server refusal is the load-bearing half.
+
+---
+
+## 8. Failure modes
+
+| # | Failure | Consequence | Mitigation |
+|---|---|---|---|
+| F1 | Snapshot directory unwritable / disk full | Apply must not proceed | `Record` errors → `ApplyMultidisc` returns the error → item lands in `failed` with a reason; `ReplayApprovedItems` leaves it retryable ([`replay.go:125-127`](../../internal/server/handlers/review/replay.go)) |
+| F2 | `DatabasePath` empty in config | Nowhere to write | Recorder constructor errors at wire time; the op errors; nothing silently no-ops (D3) |
+| F3 | Snapshot written, then combine fails mid-way | Orphan record for a merge that partly happened | Acceptable and desirable — the record describes the pre-state either way. `presentMembers` makes the retry idempotent ([`regroup_apply.go:87-98`](../../internal/plugins/maintenance/regroup_apply.go)) |
+| F4 | Hold is days old; members merged away since | Fewer members than the payload lists | Already handled: `presentMembers` skips not-found and `MarkedForDeletion`; the snapshot records both `MemberBookIDs` (as proposed) and `PresentBookIDs` (as will be acted on) so the divergence is visible |
+| F5 | Two approves race on overlapping holds | Double-merge | `CombineBooks` takes `mergeSerializeMu` for the whole read-modify-write ([`service.go:~348`](../../internal/merge/service.go)). The canary op never mutates, so it adds no new race |
+| F6 | Snapshot fsync succeeds but the file is later deleted | Record lost | Out of scope; the file lives beside the database and inherits its backup policy |
+| F7 | `after` mode run against the wrong snapshot file | Bogus diff | Records carry `CapturedAt`, `ItemID`, `DedupKey`, `SchemaVersion`; `after` reports the file path and capture window in its summary |
+| F8 | An operator flips `review_apply_enabled` and clicks a bucket header anyway | 132 merges | D8 refuses server-side; the click cannot reach `approveOne` |
+| F9 | Green band assigned to a hold with absent durations | The exact 2026-08-05 inertness bug, laundered | §5 makes `absent` disqualifying for green by construction, and `ZeroDurationMembers` is printed in the op summary |
+| F10 | Fingerprint lost during combine | Silent data loss | `FingerprintedAfter >= FingerprintedBefore` in the after-gate. (The apply path is already designed against this — nil override means the survivor row is never rewritten, [`regroup_apply.go:24-28`](../../internal/plugins/maintenance/regroup_apply.go) — so a regression here means that guarantee broke) |
+
+---
+
+## 9. Missing symbols and honest gaps
+
+### 9.1 `membersAreBookLength` and `bookLengthSec` are unexported
+
+Both live in `package service` ([`fs_regroup_shape.go:149`, `:~124`](../../internal/itunes/service/fs_regroup_shape.go)),
+and `membersAreBookLength` takes `[]memberInfo` — an **unexported** struct
+([`fs_regroup_shape.go:264`](../../internal/itunes/service/fs_regroup_shape.go)) that
+wraps a `ShatterBook` in an unexported `book` field. It cannot be called from
+`internal/applysnapshot` or `internal/plugins/maintenance` as it stands.
+
+**Decision:** the canary re-implements the rule (`long*2 > n`, `long` = members with
+`DurationSec >= 5400`) rather than exporting the classifier's internals, and the spec
+records the duplication here so the next reader knows there are two copies. A test
+asserts the threshold constant equals `90*60` so a change to one is visible.
+
+*Alternative considered and rejected:* export `MembersAreBookLength(members []ShatterBook) bool`
+and `BookLengthSec` from `internal/itunes/service`. It is the cleaner long-term shape, but
+it edits the classifier — the sibling recommendations workstream's territory — during a
+release whose entire purpose is to not disturb the classifier. Flagged as follow-up work.
+
+### 9.2 `regroupPayload` has no `Structure` field — this is a real limitation
+
+`RegroupGroup.Structure` exists ([`fs_regroup_shape.go:~176`](../../internal/itunes/service/fs_regroup_shape.go))
+but is **not** carried into `regroupPayload` ([`regroup_shattered_ai.go:64-81`](../../internal/plugins/maintenance/regroup_shattered_ai.go)),
+so a hold on disk does not say whether it came from the disc, flat, chapter or edition
+branch.
+
+Consequence, stated plainly: the canary **cannot** reproduce the recommendations spec's
+D7 structural carve-out (*"a `disc`- or `chapter`-structured group whose folder is named
+after the book carries independent structural proof and may still recommend combine"*).
+A disc-structured hold with long members will be banded **amber** by this canary even
+where that spec's recommender would pass it as `combine`. That is a deliberate
+false-positive bias: the canary's job is to slow the operator down, not to agree with the
+recommender.
+
+Adding `Structure string \`json:"structure,omitempty"\`` to `regroupPayload` is a small
+additive change that would close this, but it belongs to whichever workstream is already
+editing that struct (the sibling spec's §4.4 adds four fields to it).
+
+### 9.3 The classifier's book-length guard is missing from two branches
+
+Confirmed by reading the switch at [`fs_regroup_shape.go:715-757`](../../internal/itunes/service/fs_regroup_shape.go):
+`!membersAreBookLength(members)` appears **only** in the `structure == "flat"` case
+(line 720). The `structure == "disc"` case (line 716) and the
+`chapter`/`edition` case (line 749) mint `KindMultidisc` with `Confident: true` and never
+consult it. The fragment's "9 of 138" is that population.
+
+This spec does not fix it (§2.2 — no classifier changes). It **surfaces** it: every one
+of those holds bands red, so an operator working the ranked list meets them first.
+
+### 9.4 There is no `viper.SetDefault("database_path", …)`
+
+Grepped: `database_path` appears at [`config.go:467`, `:1267`, `:1784`, `:1786`](../../internal/config/config.go)
+and nowhere else. It is read straight from viper with no default. `cmd/child_mode.go:62-63`
+has its own `"audiobooks.pebble"` fallback, which is child-process-specific and not
+reachable from the server path. Hence D3's explicit empty-value error.
+
+---
+
+## 10. Open questions
+
+1. **Retention.** Snapshot files accumulate one line per apply forever. Should
+   `maintenance.cleanup-old-backups` ([`cleanup.go:198`](../../internal/plugins/maintenance/cleanup.go),
+   which removes `.bak-*` under `RootDir()`) learn about them, or are they permanently
+   kept? Recommendation: **keep permanently** — the whole point is that they are the only
+   record — and revisit if the directory exceeds a few hundred MB.
+2. **Should `after` mode be automatic?** A post-apply hook could run the diff immediately.
+   Deliberately not specified: the first canary is a handful of holds a human checks by
+   ear, and automation would encourage skipping that.
+3. **Where does the operator read the diff?** Today: op logs plus the JSONL file over
+   SSH. A `GET /api/v1/review/apply-snapshots` endpoint is an obvious follow-up but is not
+   needed for the canary itself.
+4. **Should `AuthorName`/`SeriesName` resolution be batched?** `GetSeriesByIDs`
+   ([`iface_series.go:16`](../../internal/database/iface_series.go)) takes a slice; there
+   is no equivalent `GetAuthorsByIDs` in `iface_author.go`. At 132 holds this is not worth
+   optimizing, but it would be at 10,000.
+5. **What is the acceptable `ExtraFileIDs` count?** D7 reports rather than asserts because
+   `attachVirtualFile`'s move-vs-create behavior is state-dependent. After the first
+   canary we will know the empirical distribution and can decide whether it can become an
+   assertion.
+
+---
+
+## 11. Acceptance gate (summary)
+
+No apply — not one — until a `before` run over all 132 pending `regroup.multidisc` holds
+has been written to disk and read. Full numbers, commands and thresholds are in
+[`docs/plans/2026-08-05-multidisc-apply-canary-plan.md`](../plans/2026-08-05-multidisc-apply-canary-plan.md) §7.

--- a/todo.d/20260806_001500_version_group_index_underreports.md
+++ b/todo.d/20260806_001500_version_group_index_underreports.md
@@ -1,0 +1,54 @@
+<!-- file: todo.d/20260806_001500_version_group_index_underreports.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f1a7d520-9c34-4e86-b0d2-73e5814cb96f -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] 🐛 **`GetBooksByVersionGroup` silently under-reports group membership, which
+  breaks the one-primary-per-group invariant.** Found in production 2026-08-06
+  while version-grouping the two copies of *The Successors*.
+
+  **Symptom.** Two books both carry `version_group_id =
+  01KNDBPNB289W2Y6TMXS2DDSEG`, but `GET /api/v1/version-groups/<gid>` returns
+  only ONE member. `PUT /audiobooks/<id>/set-primary` therefore leaves BOTH books
+  flagged `is_primary_version = true`, so the library shows two tiles for one
+  book. Re-running set-primary does not help — it demotes only what the lookup
+  returns.
+
+  **Root cause** (`internal/database/pebble_store.go`, `GetBooksByVersionGroup`).
+  The fast path iterates a `book:versiongroup:<gid>:<id>` index, then falls back
+  to a full scan **only when the index yields ZERO results**:
+
+      if len(books) > 0 { sortVersions(books); return books, nil }
+      // Fallback: full scan for groups whose index hasn't been backfilled yet
+
+  A *partially* populated index — some members indexed, some not — returns the
+  partial set and never falls back. The zero-result guard reads like a correct
+  fallback and is exactly wrong for partial data.
+
+  The index is only refreshed by `UpdateBook` when `VersionGroupID` **changes**,
+  so a book that acquires a group through a path that does not trip that
+  comparison never gets an index entry. Re-POSTing
+  `/audiobooks/<id>/versions` does not repair it: the group ID is already
+  correct, so nothing changes and no index write occurs.
+
+  **Blast radius is wider than the one endpoint.** `ApplyVersionGroup`
+  (`internal/plugins/maintenance/regroup_apply.go`) uses the same function to
+  "enumerate every current member and demote strays" — the safety net that keeps
+  one primary per group when a `regroup.version-group` hold is approved. With a
+  partial index that net silently does nothing, so approving a version-group hold
+  can leave two primaries behind.
+
+  **Fix directions** (pick after measuring):
+  1. Make the fallback trigger on *suspected incompleteness*, not just zero — e.g.
+     always cross-check against the authoritative rows, or verify the returned
+     count against a group-size counter.
+  2. Write the index entry on every `UpdateBook` where `VersionGroupID` is
+     non-empty, not only when it changes (idempotent write).
+  3. Add a repair op that rebuilds `book:versiongroup:*` from the Book rows, and
+     run it once — existing groups are already affected.
+
+  **Also needs an invariant test**: after linking N books into a group and
+  setting one primary, exactly one member must have `IsPrimaryVersion == true`.
+
+  Related: [[version-group-acoustic-audit]] (which will read group membership and
+  would inherit this under-reporting), [[first-aid-library-validate-repair]].


### PR DESCRIPTION
Salvages the 2 workstreams that completed before I stopped the spec workflow, and records a real production bug found tonight.

## Specs (UNVERIFIED)
- multidisc apply canary (owner item 3)
- metadata-results cold start (owner item 6)

Both carry an in-document banner: the symbol-check pass never ran, so code citations are claims not facts.

## 🐛 Bug: `GetBooksByVersionGroup` under-reports group membership

Found while version-grouping the two copies of *The Successors*. Two books both carry the same `version_group_id`, but the lookup returns only ONE — so `set-primary` leaves **both** flagged primary and the library shows two tiles for one book.

**Root cause:** the fast path iterates a `book:versiongroup:<gid>:<id>` index and falls back to a full scan **only when the index yields zero results**. A *partially* populated index returns the partial set and never falls back. The zero-result guard reads like a correct fallback and is exactly wrong for partial data. The index is only refreshed when `VersionGroupID` *changes*, so re-linking does not repair it.

**Blast radius:** `ApplyVersionGroup` uses the same function for its "enumerate every member and demote strays" safety net, so approving a `regroup.version-group` hold can silently leave two primaries.

Fragment includes three fix directions and the invariant test it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp