### PR TITLE
perf(server): serve metadata-results stale-while-revalidate

### DIFF
--- a/changelog.d/20260806_005000_metadata_results_swr.md
+++ b/changelog.d/20260806_005000_metadata_results_swr.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/20260806_005000_metadata_results_swr.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6e2b41c0-9738-4d5a-b0e1-27fa5c8039d4 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Fixed
+
+- **The metadata-results list no longer stalls for ~30 seconds every minute.**
+  The cache expired after 60s and made the next caller rebuild synchronously — a
+  build that costs ~30s on this library. Measured on production: **39.4s** on the
+  first request after a restart and **28.9s** on a request 70s later with no
+  restart involved. Anyone not clicking at least once a minute paid the full
+  build every single time.
+
+  Pre-warming at boot (#2152) fixed exactly one occurrence; the cliff returned
+  sixty seconds later. That change alone did not deliver what it claimed.
+
+  The cache is now **stale-while-revalidate**: an expired entry is served
+  immediately while a single background rebuild runs. A stampede guard means many
+  concurrent callers trigger at most one rebuild rather than one each.
+
+  Serving stale is safe because the TTL was never the correctness mechanism —
+  `invalidateMetadataResultsCache()` already fires on apply/reject/unreject, the
+  only events that make an entry misleading. Freshness comes from that explicit
+  invalidation; the TTL now only decides when to refresh in the background. An
+  invalidation still forces the next caller onto the synchronous path, because
+  after it there is no trustworthy set left to serve.

--- a/internal/server/metadata_results_cache.go
+++ b/internal/server/metadata_results_cache.go
@@ -1,7 +1,7 @@
 // file: internal/server/metadata_results_cache.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 65b9ee5d-b3df-43ed-95a3-b393bb0532a7
-// last-edited: 2026-08-05
+// last-edited: 2026-08-06
 
 package server
 
@@ -13,10 +13,9 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 )
 
-// metadataResultsCacheTTL bounds how long the joined metadata-result set is
-// reused. Short enough that a fetch running in the background shows up promptly,
-// long enough that paging through the list costs one build rather than one per
-// page.
+// metadataResultsCacheTTL is how long a built set is served before a refresh is
+// TRIGGERED. It is not an expiry cliff: past it the cached set is still served
+// immediately while a rebuild runs in the background.
 const metadataResultsCacheTTL = 60 * time.Second
 
 // metadataResultsCache memoises latestMetadataResultsByBook.
@@ -29,50 +28,104 @@ const metadataResultsCacheTTL = 60 * time.Second
 //	metadata_candidate_fetch operation, folded into a latest-per-book map.
 //
 // The page slice was applied afterwards, so `?limit=3` paid exactly what
-// `?limit=5000` did. That made choosing metadata matches impractical: every
-// interaction cost twenty seconds.
+// `?limit=5000` did.
 //
-// Caching the BUILD rather than the page mirrors what the ABS contributor cache
-// does for the same reason — the expensive part is assembling the set, and every
-// page is a free slice of it.
+// 🔴 WHY IT IS STALE-WHILE-REVALIDATE (measured on production 2026-08-06).
+// v1 expired the entry after the TTL and made the next caller rebuild
+// SYNCHRONOUSLY. With a build costing ~30s and a TTL of 60s that is close to
+// useless — measured 39.4s on the first request after a restart, and **28.9s on
+// a request 70s later with no restart involved**. Anyone not clicking at least
+// once a minute paid the full build every time. Pre-warming at boot (#2152)
+// fixed exactly one occurrence; the cliff returned sixty seconds later.
+//
+// Serving stale is safe because the TTL was never the correctness mechanism:
+// invalidateMetadataResultsCache() is called explicitly from the apply / reject /
+// unreject paths, which are the only events that make an entry misleading.
+// Freshness comes from that invalidation; the TTL only decides when to refresh in
+// the background. A cache whose staleness bound is enforced by making a user wait
+// thirty seconds is not protecting them from anything.
 type metadataResultsCache struct {
 	mu     sync.Mutex
 	latest map[string]database.OperationResult
 	counts map[string]int
 	at     time.Time
+	// rebuilding guards against a stampede: once a background rebuild is in
+	// flight, later callers keep serving the stale set rather than each starting
+	// their own ~30s build.
+	rebuilding bool
 }
 
 var metaResultsCache metadataResultsCache
 
-// latestMetadataResultsByBookCached returns the memoised result set, rebuilding
-// when the entry is older than metadataResultsCacheTTL.
+// latestMetadataResultsByBookCached returns the memoised result set.
 //
-// The rebuild happens OUTSIDE the lock. Holding it across a multi-second build
-// would serialise every concurrent request behind one rebuild — which is exactly
-// the access pattern a UI paging through results produces. Two callers racing a
-// cold cache may both build; that costs a duplicated build once, and is strictly
-// better than making every caller wait on a mutex through it.
+//   - FRESH — return it.
+//   - STALE but present — return it IMMEDIATELY and kick off ONE background
+//     rebuild. No caller ever blocks on a refresh.
+//   - ABSENT (truly cold: first call after boot before the warmer finishes, or
+//     right after an explicit invalidation) — build synchronously, because there
+//     is nothing to serve.
+//
+// The synchronous build stays outside the lock. Holding it across a multi-second
+// build would serialise every concurrent request behind one rebuild, which is
+// exactly the access pattern a UI paging through results produces.
 func latestMetadataResultsByBookCached(store database.Store) (map[string]database.OperationResult, map[string]int, error) {
 	now := time.Now()
 
 	metaResultsCache.mu.Lock()
-	if metaResultsCache.latest != nil && now.Sub(metaResultsCache.at) < metadataResultsCacheTTL {
-		l, c := metaResultsCache.latest, metaResultsCache.counts
-		metaResultsCache.mu.Unlock()
-		return l, c, nil
+	haveEntry := metaResultsCache.latest != nil
+	fresh := haveEntry && now.Sub(metaResultsCache.at) < metadataResultsCacheTTL
+	l, c := metaResultsCache.latest, metaResultsCache.counts
+	startRefresh := haveEntry && !fresh && !metaResultsCache.rebuilding
+	if startRefresh {
+		metaResultsCache.rebuilding = true
 	}
 	metaResultsCache.mu.Unlock()
 
+	if haveEntry {
+		if startRefresh {
+			go refreshMetadataResultsCache(store)
+		}
+		// Fresh or stale, the caller gets an answer now rather than in 30 seconds.
+		return l, c, nil
+	}
+
+	// Truly cold: nothing to serve, so this caller has to build it.
+	return buildAndStoreMetadataResults(store, "cold")
+}
+
+// refreshMetadataResultsCache rebuilds in the background and clears the in-flight
+// flag. Errors are logged and swallowed: the previous entry keeps being served,
+// which is strictly better than failing a request that already had a usable
+// answer.
+func refreshMetadataResultsCache(store database.Store) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("metadata-results background refresh panicked", "panic", r)
+		}
+		metaResultsCache.mu.Lock()
+		metaResultsCache.rebuilding = false
+		metaResultsCache.mu.Unlock()
+	}()
+	if _, _, err := buildAndStoreMetadataResults(store, "background"); err != nil {
+		slog.Info("metadata-results background refresh failed — still serving the previous set", "err", err)
+	}
+}
+
+// buildAndStoreMetadataResults runs the expensive build and installs the result.
+// reason is logged so a cold build (a user waited) is distinguishable from a
+// background refresh (nobody waited) when reading production logs.
+func buildAndStoreMetadataResults(store database.Store, reason string) (map[string]database.OperationResult, map[string]int, error) {
 	started := time.Now()
 	latest, counts, err := latestMetadataResultsByBook(store)
 	if err != nil {
 		return nil, nil, err
 	}
 	slog.Info("metadata-results cache rebuilt",
-		"books", len(latest), "duration_ms", time.Since(started).Milliseconds())
+		"reason", reason, "books", len(latest), "duration_ms", time.Since(started).Milliseconds())
 
 	metaResultsCache.mu.Lock()
-	metaResultsCache.latest, metaResultsCache.counts, metaResultsCache.at = latest, counts, now
+	metaResultsCache.latest, metaResultsCache.counts, metaResultsCache.at = latest, counts, time.Now()
 	metaResultsCache.mu.Unlock()
 	return latest, counts, nil
 }
@@ -80,9 +133,13 @@ func latestMetadataResultsByBookCached(store database.Store) (map[string]databas
 // invalidateMetadataResultsCache drops the memoised set so the next read sees
 // fresh state.
 //
-// Called from the apply / reject / unreject paths: those change a book's status,
-// and a stale list would keep offering a candidate the user just acted on — the
-// one kind of staleness that is actively confusing rather than merely old.
+// This — not the TTL — is what keeps the list correct. It is called from the
+// apply / reject / unreject paths: those change a book's status, and a stale list
+// would keep offering a candidate the user just acted on, which is the one kind
+// of staleness that is actively confusing rather than merely old.
+//
+// It deliberately forces the NEXT caller onto the synchronous cold path: after an
+// explicit invalidation there is no trustworthy set left to serve.
 func invalidateMetadataResultsCache() {
 	metaResultsCache.mu.Lock()
 	metaResultsCache.latest, metaResultsCache.counts = nil, nil

--- a/internal/server/metadata_results_swr_test.go
+++ b/internal/server/metadata_results_swr_test.go
@@ -1,0 +1,145 @@
+// file: internal/server/metadata_results_swr_test.go
+// version: 1.0.0
+// guid: 3ca5f9d1-807b-42e6-95af-1d60428c7bf3
+// last-edited: 2026-08-06
+
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// resetMetaResultsCache puts the package cache in a known state for a test.
+func resetMetaResultsCache() {
+	metaResultsCache.mu.Lock()
+	metaResultsCache.latest = nil
+	metaResultsCache.counts = nil
+	metaResultsCache.at = time.Time{}
+	metaResultsCache.rebuilding = false
+	metaResultsCache.mu.Unlock()
+}
+
+// TestStaleEntryServedImmediately is the whole point of the change: once an entry
+// exists, an expired TTL must NOT make the caller wait for a rebuild.
+//
+// Production measurement 2026-08-06: with the old expire-then-rebuild behaviour a
+// request 70s after the last build took 28.9 SECONDS. The TTL was a cliff, not a
+// refresh trigger.
+func TestStaleEntryServedImmediately(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	// Install an entry and age it well past the TTL.
+	seeded := map[string]database.OperationResult{"book-1": {}}
+	metaResultsCache.mu.Lock()
+	metaResultsCache.latest = seeded
+	metaResultsCache.counts = map[string]int{"book-1": 1}
+	metaResultsCache.at = time.Now().Add(-10 * metadataResultsCacheTTL)
+	metaResultsCache.mu.Unlock()
+
+	store := &database.MockStore{}
+	start := time.Now()
+	got, _, err := latestMetadataResultsByBookCached(store)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("stale read returned an error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected the stale set to be served, got %d entries", len(got))
+	}
+	// The caller must not have blocked on a rebuild. Generous bound so this is not
+	// timing-flaky on a loaded CI box; the real regression would be seconds.
+	if elapsed > 2*time.Second {
+		t.Errorf("stale read blocked for %v — it must return immediately", elapsed)
+	}
+}
+
+// TestColdReadBuildsSynchronously: with nothing cached there is nothing to serve,
+// so the caller has to build. This is the one case where waiting is correct.
+func TestColdReadBuildsSynchronously(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	store := &database.MockStore{}
+	got, _, err := latestMetadataResultsByBookCached(store)
+	if err != nil {
+		t.Fatalf("cold read failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("cold read returned a nil map; the cache would stay cold forever")
+	}
+
+	metaResultsCache.mu.Lock()
+	populated := metaResultsCache.latest != nil
+	metaResultsCache.mu.Unlock()
+	if !populated {
+		t.Error("cold read did not populate the cache")
+	}
+}
+
+// TestRebuildingFlagPreventsStampede: many concurrent callers hitting a stale
+// entry must trigger AT MOST one background rebuild, not one each. Each rebuild
+// costs ~30s on production, so a stampede would be far worse than the original
+// problem.
+func TestRebuildingFlagPreventsStampede(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	metaResultsCache.mu.Lock()
+	metaResultsCache.latest = map[string]database.OperationResult{"b": {}}
+	metaResultsCache.counts = map[string]int{"b": 1}
+	metaResultsCache.at = time.Now().Add(-10 * metadataResultsCacheTTL)
+	metaResultsCache.mu.Unlock()
+
+	store := &database.MockStore{}
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _ = latestMetadataResultsByBookCached(store)
+		}()
+	}
+	wg.Wait()
+
+	// Whatever happened, the cache must be left consistent and not permanently
+	// stuck in the rebuilding state (which would block all future refreshes).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		metaResultsCache.mu.Lock()
+		stuck := metaResultsCache.rebuilding
+		metaResultsCache.mu.Unlock()
+		if !stuck {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Error("rebuilding flag never cleared — future refreshes would be blocked forever")
+}
+
+// TestInvalidateForcesColdPath: after an explicit invalidation there is no
+// trustworthy set, so the next caller must rebuild rather than serve stale. This
+// is what stops the list offering a candidate the user just acted on.
+func TestInvalidateForcesColdPath(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	metaResultsCache.mu.Lock()
+	metaResultsCache.latest = map[string]database.OperationResult{"b": {}}
+	metaResultsCache.at = time.Now()
+	metaResultsCache.mu.Unlock()
+
+	invalidateMetadataResultsCache()
+
+	metaResultsCache.mu.Lock()
+	cleared := metaResultsCache.latest == nil
+	metaResultsCache.mu.Unlock()
+	if !cleared {
+		t.Error("invalidate must clear the entry so the next read cannot serve stale data")
+	}
+}


### PR DESCRIPTION
Follow-up to #2152, which **did not fix the problem it claimed to**.

## What I got wrong

#2152 pre-warmed the cache at boot on the theory that the 34s wait was a cold-start issue. Measured on production after deploying it:

| | |
|---|---|
| first request after restart | **39.4s** |
| request 70s later, no restart | **28.9s** |

The problem was never mainly cold-boot. The 60s TTL was an **expiry cliff**: past it the next caller rebuilt synchronously, and the build costs ~30s. Warming at boot fixed exactly one occurrence and the cliff returned a minute later. Anyone not clicking at least once a minute paid full price every time.

## The fix

Stale-while-revalidate. An expired entry is served **immediately** while one background rebuild runs, with a stampede guard so 25 concurrent callers trigger one rebuild, not 25.

Only a truly absent entry builds synchronously — first call after boot, or right after an explicit invalidation — because then there is genuinely nothing to serve.

**Why serving stale is safe:** the TTL was never the correctness mechanism. `invalidateMetadataResultsCache()` already fires on apply/reject/unreject — the only events that make an entry misleading. Freshness comes from that; the TTL now just schedules a background refresh.

## Tests (`-race`)

- stale entry returns without blocking
- cold read builds and populates
- 25 concurrent stale readers never leave the rebuilding flag stuck (that would block all future refreshes)
- invalidate forces the cold path

Will verify the same two measurements on production after deploy rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp