### PR TITLE
fix(server): don't let an in-flight rebuild undo a metadata-results invalidation

### DIFF
--- a/changelog.d/20260806_010000_metadata_results_invalidation_race.md
+++ b/changelog.d/20260806_010000_metadata_results_invalidation_race.md
@@ -1,0 +1,26 @@
+<!-- file: changelog.d/20260806_010000_metadata_results_invalidation_race.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 0a3f7d29-64b1-4e08-95c7-812de6403bfa -->
+<!-- last-edited: 2026-08-06 -->
+
+### Fixed
+
+- **Metadata-results cache: an invalidation could be silently undone by an
+  in-flight rebuild.** Flagged by automated security review of #2153.
+
+  The build runs outside the lock and takes ~30s. If a user applied or rejected a
+  candidate during that window, `invalidateMetadataResultsCache()` cleared the
+  entry — and then the in-flight build finished and wrote back the snapshot it
+  had read *before* the invalidation. The cache ended up holding exactly the
+  stale set the invalidation existed to purge, so the list kept offering a
+  candidate the user had just acted on: the one kind of staleness this cache is
+  explicitly not allowed to have.
+
+  Fixed with a generation counter. A build captures the generation before
+  reading; every invalidation bumps it; the build refuses to install its result
+  if the generation moved, leaving the cache cold so the next read rebuilds from
+  current state.
+
+  The race existed in the pre-#2153 code too (the build was always outside the
+  lock), but background refreshes were rare there — only on a cold miss. #2153
+  made them routine, which turned a narrow window into a regularly-hit one.

--- a/internal/server/metadata_results_cache.go
+++ b/internal/server/metadata_results_cache.go
@@ -53,6 +53,19 @@ type metadataResultsCache struct {
 	// flight, later callers keep serving the stale set rather than each starting
 	// their own ~30s build.
 	rebuilding bool
+
+	// gen is bumped by every invalidation. A build captures it before starting
+	// and refuses to install its result if it changed while the build was running.
+	//
+	// 🔴 WITHOUT THIS, INVALIDATION IS DEFEATED BY ITS OWN SLOWNESS. The build
+	// takes ~30s and runs outside the lock. If a user applies or rejects a
+	// candidate during that window, invalidateMetadataResultsCache() clears the
+	// entry — and then the in-flight build finishes and writes back the snapshot
+	// it read BEFORE the invalidation. The cache ends up holding exactly the
+	// stale set the invalidation existed to purge, so the list keeps offering a
+	// candidate the user just acted on: the one kind of staleness this cache is
+	// explicitly not allowed to have.
+	gen uint64
 }
 
 var metaResultsCache metadataResultsCache
@@ -116,6 +129,12 @@ func refreshMetadataResultsCache(store database.Store) {
 // reason is logged so a cold build (a user waited) is distinguishable from a
 // background refresh (nobody waited) when reading production logs.
 func buildAndStoreMetadataResults(store database.Store, reason string) (map[string]database.OperationResult, map[string]int, error) {
+	// Capture the generation BEFORE reading. Anything that invalidates while this
+	// build runs bumps it, and we must then discard our now-stale result.
+	metaResultsCache.mu.Lock()
+	startGen := metaResultsCache.gen
+	metaResultsCache.mu.Unlock()
+
 	started := time.Now()
 	latest, counts, err := latestMetadataResultsByBook(store)
 	if err != nil {
@@ -125,8 +144,21 @@ func buildAndStoreMetadataResults(store database.Store, reason string) (map[stri
 		"reason", reason, "books", len(latest), "duration_ms", time.Since(started).Milliseconds())
 
 	metaResultsCache.mu.Lock()
-	metaResultsCache.latest, metaResultsCache.counts, metaResultsCache.at = latest, counts, time.Now()
+	superseded := metaResultsCache.gen != startGen
+	if !superseded {
+		metaResultsCache.latest, metaResultsCache.counts, metaResultsCache.at = latest, counts, time.Now()
+	}
 	metaResultsCache.mu.Unlock()
+
+	if superseded {
+		// An apply/reject landed mid-build. Installing now would resurrect the
+		// pre-invalidation snapshot, so drop it and leave the cache cold — the
+		// next read rebuilds from current state.
+		slog.Info("metadata-results build superseded by an invalidation — discarding result",
+			"reason", reason)
+	}
+	// Return the freshly built set to THIS caller regardless: it is the newest
+	// data this goroutine has, and a cold-path caller must not be handed nil.
 	return latest, counts, nil
 }
 
@@ -143,5 +175,8 @@ func buildAndStoreMetadataResults(store database.Store, reason string) (map[stri
 func invalidateMetadataResultsCache() {
 	metaResultsCache.mu.Lock()
 	metaResultsCache.latest, metaResultsCache.counts = nil, nil
+	// Bump the generation so any build already in flight discards its result
+	// instead of writing back the snapshot it read before this call.
+	metaResultsCache.gen++
 	metaResultsCache.mu.Unlock()
 }

--- a/internal/server/metadata_results_swr_test.go
+++ b/internal/server/metadata_results_swr_test.go
@@ -20,6 +20,7 @@ func resetMetaResultsCache() {
 	metaResultsCache.counts = nil
 	metaResultsCache.at = time.Time{}
 	metaResultsCache.rebuilding = false
+	metaResultsCache.gen = 0
 	metaResultsCache.mu.Unlock()
 }
 
@@ -141,5 +142,73 @@ func TestInvalidateForcesColdPath(t *testing.T) {
 	metaResultsCache.mu.Unlock()
 	if !cleared {
 		t.Error("invalidate must clear the entry so the next read cannot serve stale data")
+	}
+}
+
+// TestInvalidationDuringBuildIsNotOverwritten reproduces the invalidation race
+// flagged by security review on 2026-08-06.
+//
+// A build runs OUTSIDE the lock and takes ~30s in production. If an apply/reject
+// invalidates during that window, the in-flight build must NOT install the
+// snapshot it captured beforehand — doing so resurrects exactly the stale set the
+// invalidation existed to purge, and the list goes on offering a candidate the
+// user just acted on.
+func TestInvalidationDuringBuildIsNotOverwritten(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	// Simulate a build that captured the generation, then an invalidation landing
+	// mid-flight, then the build attempting to install.
+	metaResultsCache.mu.Lock()
+	startGen := metaResultsCache.gen
+	metaResultsCache.mu.Unlock()
+
+	// The apply/reject path fires while the build is still running.
+	invalidateMetadataResultsCache()
+
+	// The build now finishes and tries to install its pre-invalidation snapshot.
+	metaResultsCache.mu.Lock()
+	superseded := metaResultsCache.gen != startGen
+	if !superseded {
+		metaResultsCache.latest = map[string]database.OperationResult{"stale": {}}
+	}
+	installed := metaResultsCache.latest
+	metaResultsCache.mu.Unlock()
+
+	if !superseded {
+		t.Fatal("generation did not change across an invalidation — the guard cannot work")
+	}
+	if installed != nil {
+		t.Error("a build that started before an invalidation must not install its result; " +
+			"the cache would serve a candidate the user already acted on")
+	}
+}
+
+// TestGenerationSurvivesConcurrentInvalidations: the guard must hold under real
+// concurrency, not just in the sequential reproduction above.
+func TestGenerationSurvivesConcurrentInvalidations(t *testing.T) {
+	resetMetaResultsCache()
+	defer resetMetaResultsCache()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			invalidateMetadataResultsCache()
+		}()
+	}
+	wg.Wait()
+
+	metaResultsCache.mu.Lock()
+	gen := metaResultsCache.gen
+	latest := metaResultsCache.latest
+	metaResultsCache.mu.Unlock()
+
+	if gen != 50 {
+		t.Errorf("gen = %d, want 50 — invalidations must each bump the generation", gen)
+	}
+	if latest != nil {
+		t.Error("cache must be cleared after invalidation")
 	}
 }


### PR DESCRIPTION
Found by automated security review of #2153. Real bug, introduced-in-effect by that PR.

## The race

The build runs outside the lock and takes ~30s:

1. Background rebuild starts, reads the current set
2. User applies or rejects a candidate → `invalidateMetadataResultsCache()` clears the entry
3. Rebuild finishes ~30s later and **writes back the snapshot from step 1**

The cache now holds exactly the pre-invalidation data the invalidation existed to purge — so the list keeps offering a candidate the user just acted on. That is precisely what `invalidateMetadataResultsCache`'s own doc comment calls "the one kind of staleness that is actively confusing rather than merely old."

## Fix

Generation counter. A build captures `gen` before reading; every invalidation bumps it; the build refuses to install if `gen` moved, leaving the cache cold so the next read rebuilds from current state. The building caller still receives its freshly-built set, so a cold-path request is never handed nil.

## Honest note on provenance

The race predates #2153 — the build was always outside the lock. But background refreshes were rare there, only on a cold miss. #2153 made them routine (every 60s under load), which turned a narrow window into a regularly-hit one. So it's fair to call this one mine.

## Tests (`-race`)

- a build that started before an invalidation must not install its result
- 50 concurrent invalidations each bump the generation and leave the cache cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp