### PR TITLE
docs(series): spec + plan for embedded series-position shapes (owner item 4)

### DIFF
--- a/changelog.d/20260806_012000_series_embedded_positions_spec.md
+++ b/changelog.d/20260806_012000_series_embedded_positions_spec.md
@@ -1,0 +1,28 @@
+<!-- file: changelog.d/20260806_012000_series_embedded_positions_spec.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9d3e7182-4c05-46ba-b71f-e0328a6c95d4 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- **Design + implementation plan for series names that carry a book position in
+  an embedded (non-trailing) shape** — owner item 4. Documentation only.
+
+  Whole-population measurement on production: of 12,201 distinct series names
+  covering 32,119 books, **982 books across 769 names** carry a position the
+  current parser cannot see, in four shapes — `<Series> N: <Title>` (343 books),
+  `<Series> (N)`/`[N]` (307), `N - <Title>` (271), and
+  `<Series> Book N: <Title>` (61).
+
+  The spec records why this is riskier than the trailing case already handled:
+  a leading or embedded number is frequently part of the real title.
+  `86—EIGHTY-SIX` (17 books) and `5-Minute Sherlock` are genuine series names,
+  while `08. Battle for the Abyss` and `11. Fallen Angels` are genuine positions
+  — identical shape, opposite meaning. `The Demon Wars Saga [07] Immortalis [02]`
+  carries two candidate numbers and a naive last-match takes the wrong one.
+
+  Design answer is confidence tiers rather than one regex: keyword-introduced
+  positions auto-apply, single-bracket positions auto-apply, bare leading numbers
+  emit a review hold, and multi-number names are refused outright. The
+  `IsJunkSeriesBase` guard — which stopped 285 bad merges in the earlier dry run
+  — is extended in the same commit as the parser, never after.

--- a/docs/plans/2026-08-06-series-embedded-positions-plan.md
+++ b/docs/plans/2026-08-06-series-embedded-positions-plan.md
@@ -1,0 +1,103 @@
+<!-- file: docs/plans/2026-08-06-series-embedded-positions-plan.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6f28c0d3-91ba-4e75-83c1-05de7492ab61 -->
+<!-- last-edited: 2026-08-06 -->
+
+# Series embedded positions — implementation plan
+
+Spec: [`2026-08-06-series-embedded-positions-design.md`](../specs/2026-08-06-series-embedded-positions-design.md)
+
+## Goal
+
+Teach `maintenance.series-denumber` the three embedded-position shapes (982 books
+across 769 distinct series names), with a confidence tier so the genuinely
+ambiguous cases go to review instead of being guessed.
+
+## Files
+
+- `internal/plugins/maintenance/series_denumber.go` — add the embedded-shape
+  regexes, a `Confidence` field on `SeriesSplit`, and the `IsJunkSeriesBase`
+  extensions. **Both in the same commit** — the guard must never lag the parser.
+- `internal/plugins/maintenance/series_denumber_test.go` — table tests built from
+  the real production names below.
+- `internal/plugins/maintenance/series_denumber_op.go` — thread confidence
+  through; only `high`/`medium` are apply-eligible, `low` emits a review hold.
+- `changelog.d/`, `todo.d/` fragments.
+
+## Steps
+
+1. **`Confidence` on `SeriesSplit`** (`high` | `medium` | `low`), defaulting the
+   existing trailing shapes to their current behaviour so nothing regresses.
+   Pure type change + existing tests still green.
+2. **Extend `IsJunkSeriesBase` FIRST** (spec D6), with tests, before any new
+   shape can reach it. Landing the guard ahead of the parser means a mistake in
+   step 3 fails closed.
+3. **Add the embedded shapes**, each with its confidence:
+   - keyword-embedded (`… Book 4: …`, `… Vol 09: …`) → **high**
+   - single bracketed at end (`Dragon Born [04]`) → **medium**
+   - bare leading (`08. Battle for the Abyss`) → **low**
+   - **multi-number names refuse outright** (spec D5)
+4. **Sibling corroboration** (spec D4): promote `low` → `medium` when other books
+   share the base/folder with a different leading number. Lone occurrences stay
+   `low`.
+5. **Op wiring**: `high`/`medium` apply under the existing apply flag; `low`
+   emits a review hold. Report counts per tier.
+6. **Dry run on production, read the numbers, then apply.**
+
+## Test strategy
+
+Table tests must include these REAL production names as explicit cases:
+
+**Must NOT be split** (real titles):
+- `86—EIGHTY-SIX` (17 books — the loudest failure available)
+- `5-Minute Sherlock`
+- `Rebirth Online 2: Rebirth Online` (base == title → junk)
+
+**Must split, high confidence:**
+- `Vampire Hunter D: Vol 09: The Rose Princess` → base `Vampire Hunter D`, pos 9
+- `Evil Genius: Book 4: Becoming the Apex Supervillain` → pos 4
+- `Frontiers Saga Part 2: Rogue Castes` → pos 2
+
+**Must split, medium:**
+- `Dragon Born [04]` → base `Dragon Born`, pos 4
+
+**Must REFUSE (multi-number):**
+- `The Demon Wars Saga [07] Immortalis [02]`
+- `The Stormlight Archive [01] The Way Of Kings [02]`
+
+**Must be low (held, not applied):**
+- `08. Battle for the Abyss`
+- `Station 64: The Doll Dungeon`
+
+Commands:
+
+```
+go test ./internal/plugins/maintenance/... -race -run TestSeriesDenumber
+go test ./internal/plugins/maintenance/... -race -run TestIsJunkSeriesBase
+make ci
+```
+
+Green means: every "must NOT be split" case returns no split; every refuse case
+returns no split; tier assignments match exactly.
+
+## Dry-run acceptance gate
+
+Before ANY apply, the production dry run must report:
+
+- total candidates ≈ **982 books / 769 names** (the measured figure; a wildly
+  different number means the parser is matching something unintended)
+- **zero** candidates whose base fails `IsJunkSeriesBase`
+- `86—EIGHTY-SIX` absent from the apply set entirely
+- per-tier counts, with `low` clearly separated and NOT in the apply set
+
+If the candidate count materially exceeds 982, stop — the parser is over-matching.
+
+## Rollback
+
+- Parser changes are additive and behind the existing dry-run/apply flag.
+- Each book write is re-fetch-then-mutate on `series_name` + `series_position`
+  only — never a partial `UpdateBook` write-back.
+- The dry-run report lists every (book, old name, new name, position) so an
+  incorrect apply can be reversed from it. **Write that report to a file before
+  applying**, as with the multidisc canary.
+- `git worktree remove .worktrees/series && git branch -D fix/series-embedded-positions`

--- a/docs/specs/2026-08-06-series-embedded-positions-design.md
+++ b/docs/specs/2026-08-06-series-embedded-positions-design.md
@@ -1,0 +1,114 @@
+<!-- file: docs/specs/2026-08-06-series-embedded-positions-design.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3b7e0a94-52d1-4c68-91af-7d0c48e35b26 -->
+<!-- last-edited: 2026-08-06 -->
+
+# Series names that carry a book position — embedded shapes (design)
+
+Owner item 4. Extends `maintenance.series-denumber`, which today only handles
+**trailing** positions, to the shapes where the number sits at the front or in
+the middle.
+
+## Measurement (whole population, production, 2026-08-06)
+
+12,201 distinct series names covering 32,119 books. Bucketed by shape:
+
+| Shape | names | books | status |
+|---|---:|---:|---|
+| trailing keyword + number (`… Book 11`) | 18 | 31 | already handled |
+| trailing bare number (`Discworld 05`) | 936 | 1,434 | already handled |
+| **`<Series> N: <Title>`** | **303** | **343** | **NEW** |
+| **`<Series> (N)` / `[N]`** | **238** | **307** | **NEW** |
+| **`N - <Title>`** | **211** | **271** | **NEW** |
+| **`<Series> Book N: <Title>`** | **17** | **61** | **NEW** |
+| no position embedded | 10,478 | 29,672 | — |
+
+**982 books across 769 distinct names** are in scope. (The owner's estimate was
+~874; the difference is the parenthesised shape, which is easy to miss by eye.)
+
+## 🔴 The reason this is dangerous, in the data
+
+The existing parser matches trailing positions only. That is **not an oversight —
+it is the safe half.** A leading or embedded number is far more often part of the
+real title:
+
+| Name | Reality |
+|---|---|
+| `86—EIGHTY-SIX` (17 books) | **Real series title.** "86" IS the name. |
+| `5-Minute Sherlock` | **Real title.** "5-Minute" is a descriptor. |
+| `08. Battle for the Abyss` | Genuine Horus Heresy position 8. |
+| `11. Fallen Angels` | Genuine position 11. |
+| `Station 64: The Doll Dungeon` | **Ambiguous.** Position 64, or a series called "Station 64"? |
+| `The Demon Wars Saga [07] Immortalis [02]` | **TWO** numbers; 07 is the series position, 02 is not. A naive last-bracket match takes the wrong one. |
+| `Renegade Star: Publisher's Pack 7: Renegade Star` | "Pack 7" is a bundle number, not a series position. |
+| `The Best of the Best: Volume 2: …` (27 books) | Genuine anthology volume. |
+
+Same shape, opposite meaning. This is why `IsJunkSeriesBase` exists and why it
+must be extended **alongside** the parser, never after: that guard is what stopped
+**285 bad merges** in the earlier dry run, and series merges are destructive.
+
+## Design
+
+### Locked decisions
+
+**D1 — This is a DATA fix, not display.** The number belongs in the series
+*position* field; the series *name* keeps only the base. The owner has corrected
+this reading twice; do not re-derive it.
+
+**D2 — Confidence tiers, not one regex.** Each shape gets a confidence, and only
+`high` is eligible for auto-apply:
+
+- **high** — an explicit keyword introduces the number (`Book 4`, `Vol 09`,
+  `Part 2`). Keywords do not appear by accident.
+- **medium** — a bracketed/parenthesised number at the end (`Dragon Born [04]`),
+  with exactly ONE bracketed group in the name.
+- **low** — a bare leading number (`08. Battle for the Abyss`). Correct often,
+  catastrophically wrong on `86—EIGHTY-SIX`.
+
+**D3 — Low confidence NEVER auto-applies.** It produces a review hold. There is
+no threshold tuning that separates `86—EIGHTY-SIX` from `08. Battle for the
+Abyss` on the string alone — they are the same shape. Corroboration must come
+from outside the name (below).
+
+**D4 — Corroborate a leading number against its siblings.** A bare leading number
+is trustworthy only when the *same base* appears with *several different*
+leading numbers. `08. Battle for the Abyss` / `11. Fallen Angels` /
+`22. Shadows of Treachery` share no base text at all, so that signal is weak
+here — but the books DO share an author and folder. Use: sibling books whose
+series names differ only in the leading number, or which share the parent folder.
+A lone occurrence stays `low`.
+
+**D5 — Refuse multi-number names.** `The Demon Wars Saga [07] Immortalis [02]`
+has two candidate positions. Refuse and hold for review rather than guessing
+which one is the series position — guessing wrong writes a wrong position AND a
+wrong base.
+
+**D6 — Extend `IsJunkSeriesBase` in the same change.** New rejections needed:
+- a base that is now empty or a single character after stripping
+- a base that is purely a number-word artefact (`Volume`, `Pack`, `Publisher's Pack`)
+- a base identical to the stripped title (`Rebirth Online 2: Rebirth Online` →
+  base and title are the same string, which means the split found nothing real)
+
+### Non-goals
+
+- Renaming the underlying `series` rows or merging series. This change writes
+  `series_position` and a corrected `series_name` per book; any merging of
+  now-identical series names is a SEPARATE, later step, gated on its own dry run.
+- Touching `books/itunes/**`.
+- Guessing on the `low` tier.
+
+## Failure modes
+
+| Failure | Consequence | Mitigation |
+|---|---|---|
+| Real title parsed as a position | Series renamed to a fragment; books scattered | D3 low tier holds; D6 guard; dry run |
+| Wrong number chosen (multi-number) | Wrong position AND wrong base | D5 refuses outright |
+| Base collapses to junk | Bogus series absorbing unrelated books | D6 `IsJunkSeriesBase` extension |
+| Position written, name unchanged | Duplicate-looking series persist | Both fields written in one re-fetch-then-mutate |
+
+## Open questions
+
+1. Should a corrected series name that now collides with an existing series
+   auto-merge, or hold? (Proposed: hold — merging is the destructive part.)
+2. `Renegade Star: Publisher's Pack 7` — pack numbers are not series positions.
+   Add "pack" to the junk-keyword list, or treat as `low`?


### PR DESCRIPTION
Design + plan only, no code. Owner item 4.

## Measured, whole population

12,201 distinct series names / 32,119 books. **982 books across 769 names** carry a position the current parser cannot see:

| Shape | names | books |
|---|---:|---:|
| `<Series> N: <Title>` | 303 | 343 |
| `<Series> (N)` / `[N]` | 238 | 307 |
| `N - <Title>` | 211 | 271 |
| `<Series> Book N: <Title>` | 17 | 61 |

Owner estimated ~874; the gap is the parenthesised shape, easy to miss by eye.

## Why this is riskier than the trailing case

The existing parser matches **trailing** positions only. That is not an oversight — it's the safe half. Embedded numbers are frequently part of the real title:

| Name | Reality |
|---|---|
| `86—EIGHTY-SIX` (17 books) | **real series title** |
| `5-Minute Sherlock` | **real title** |
| `08. Battle for the Abyss` | genuine position 8 |
| `11. Fallen Angels` | genuine position 11 |

Same shape, opposite meaning — no string-only rule separates them.

`The Demon Wars Saga [07] Immortalis [02]` carries **two** candidate numbers, and a naive last-bracket match takes the wrong one (02, when 07 is the series position).

## Design

Confidence tiers rather than one regex:
- **high** — keyword-introduced (`Book 4`, `Vol 09`) → auto-apply
- **medium** — single bracketed at end (`Dragon Born [04]`) → auto-apply
- **low** — bare leading number → **review hold, never auto-applied**
- **multi-number → refuse outright**

`IsJunkSeriesBase` is extended in the **same commit** as the parser. That guard stopped **285 bad merges** in the earlier dry run; landing it first means a parser mistake fails closed.

## Acceptance gate

Dry run must show candidates near 982, zero junk bases, and `86—EIGHTY-SIX` absent from the apply set. Materially more than 982 means over-matching — stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BX5CwAbTV8uus158BYiSdp