### PR TITLE
feat(series): read book positions embedded in series names, tiered by confidence

### DIFF
--- a/changelog.d/20260806_070000_series-embedded-positions.md
+++ b/changelog.d/20260806_070000_series-embedded-positions.md
@@ -1,0 +1,35 @@
+<!-- file: changelog.d/20260806_070000_series-embedded-positions.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5a9d17c4-8e3b-46f2-9071-c3d84be5f2a1 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- **`maintenance.series-denumber` now reads positions embedded in a series name, not just trailing
+  ones.** A series name should name the series, but many carry the book's position instead, which
+  splits one series into as many one-book series as it has volumes. The op previously handled only
+  trailing positions (`Discworld 05`); it now also reads keyword-embedded
+  (`Evil Genius: Book 4: Becoming the Apex Supervillain`), bracketed (`Dragon Born [04]`),
+  mid-colon (`Station 64: The Doll Dungeon`) and leading-bare (`08. Battle for the Abyss`) shapes.
+  A whole-library census found 769 distinct names in these shapes.
+
+  Each shape carries a **confidence**, because the same string shape means opposite things in real
+  data: `86—EIGHTY-SIX` is a genuine series title covering 17 books, while `08. Battle for the
+  Abyss` is a genuine Horus Heresy position. Only a keyword-vouched position applies unattended; a
+  bracketed one requires `{"applyMedium": true}`; a bare number is **only ever reported** and cannot
+  be applied at any setting. Names offering two candidate positions
+  (`The Demon Wars Saga [07] Immortalis [02]`) are refused rather than guessed at.
+
+- **`reportPath` parameter on `maintenance.series-denumber`.** Writes every candidate — including
+  the tiers that will never be applied — as TSV before any row is touched. A merge creates and
+  deletes series rows, so there is no transaction to abort; replaying this file is the only rollback.
+  Applying without it now logs a warning.
+
+### Fixed
+
+- **`IsJunkSeriesBase` missed artefacts stranded at the front of a name.** The guard only checked
+  suffixes, because the parser only stripped suffixes. Stripping a leading number strands the
+  punctuation at the front instead (`. Battle for the Abyss`), where none of those checks could see
+  it. Also added bundle words (`Publisher's Pack`, `Omnibus`, `Box Set`) — a pack number is not a
+  series position — and now rejects single-character bases. This guard stopped 285 bad merges in an
+  earlier production dry run, and the new shapes give it more ways to be reached.

--- a/internal/plugins/maintenance/series_denumber.go
+++ b/internal/plugins/maintenance/series_denumber.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/series_denumber.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: dee834d3-1f7e-453e-9303-85d37479e79d
-// last-edited: 2026-08-04
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -31,6 +31,53 @@ var explicitPositionSuffix = regexp.MustCompile(
 // decides whether to trust it (see SeriesDenumber).
 var barePositionSuffix = regexp.MustCompile(`^(.*?)[\s\-_.]+(\d{1,3})$`)
 
+// ─── Embedded positions (owner item 4) ───────────────────────────────────────
+//
+// The two regexes above are `$`-anchored. That is NOT an oversight — trailing is
+// the SAFE half. A number at the front or in the middle of a series name is far
+// more often part of the real title, and the shapes are indistinguishable:
+//
+//	86—EIGHTY-SIX             ← "86" IS the series name (17 books in production)
+//	08. Battle for the Abyss  ← "08" IS a Horus Heresy position
+//
+// Same shape, opposite meaning. So each embedded shape carries a confidence and
+// only the ones a keyword vouches for are eligible to apply unattended.
+// Design: docs/specs/2026-08-06-series-embedded-positions-design.md
+
+// embeddedKeywordPosition matches a keyword-introduced position with the TITLE
+// still trailing behind it: "Evil Genius: Book 4: Becoming the Apex Supervillain",
+// "Vampire Hunter D: Vol 09: The Rose Princess", "Frontiers Saga Part 2: Rogue
+// Castes". The keyword is the evidence, exactly as it is for the trailing shape.
+var embeddedKeywordPosition = regexp.MustCompile(
+	`(?i)^(.{2,}?)[\s,:\-]+(?:book|bk|vol|volume|part|pt)\s*\.?\s*(\d{1,3})\s*[:\-–—]\s*(\S.*)$`)
+
+// bracketedPosition matches a single parenthesised/bracketed number at the end:
+// "Dragon Born [04]", "The Hollows (7)". Brackets around a bare number are a
+// deliberate mark — no real title wears them — but the number is unvouched, so
+// this is medium rather than high.
+var bracketedPosition = regexp.MustCompile(
+	`(?i)^(.{2,}?)\s*[\(\[]\s*(?:book|bk|vol|volume|part|pt|#)?\s*(\d{1,3})\s*[\)\]]\s*$`)
+
+// midColonPosition matches a bare number sitting between the series and the
+// title: "Station 64: The Doll Dungeon". The largest new bucket (303 names) and
+// the least trustworthy — "Station 64" is a perfectly plausible series name — so
+// it is LOW and never applies unattended.
+var midColonPosition = regexp.MustCompile(`^(.{2,}?)\s+(\d{1,3})\s*:\s*(\S.*)$`)
+
+// leadingBarePosition matches a number at the very front: "08. Battle for the
+// Abyss", "11. Fallen Angels".
+//
+// 🔑 The separator class is the load-bearing part. A genuine position prefix is
+// punctuated like a list item — "08. ", "1 - " — while a number fused to the
+// next word by an unspaced dash is part of the NAME: "86—EIGHTY-SIX",
+// "5-Minute Sherlock". Requiring either a period or a SPACED dash is what keeps
+// those two out of the candidate set entirely rather than relying on the low
+// tier to hold them.
+var leadingBarePosition = regexp.MustCompile(`^\s*(\d{1,3})\s*(?:[.)\]]|\s[-–—:]|\s)\s*(\S.*)$`)
+
+// anyNumber counts position candidates for the multi-number refusal (spec D5).
+var anyNumber = regexp.MustCompile(`\d+`)
+
 // junkSeriesBases are base names that are not series at all. They come from disc
 // and chapter tags being written into the series field, and production holds
 // hundreds: "Chapter 12", "Disc 3". Merging these would create one giant bogus
@@ -39,6 +86,10 @@ var junkSeriesBases = map[string]struct{}{
 	"chapter": {}, "chapters": {}, "disc": {}, "disk": {}, "cd": {},
 	"track": {}, "part": {}, "pt": {}, "book": {}, "vol": {}, "volume": {},
 	"side": {}, "tape": {}, "file": {}, "section": {},
+	// Bundle/packaging words. "Renegade Star: Publisher's Pack 7" numbers the
+	// PACK, not the series — merging on it would gather unrelated bundles.
+	"pack": {}, "publisher's pack": {}, "publishers pack": {}, "publisher": {},
+	"box set": {}, "boxset": {}, "omnibus": {}, "collection": {}, "set": {},
 }
 
 // trailingJunkWord catches a base that ENDS in a tag keyword rather than being
@@ -46,7 +97,13 @@ var junkSeriesBases = map[string]struct{}{
 // Stripping "Chapter 12" leaves the keyword stranded on the end, and merging on
 // that base manufactures a series named after the word "chapter".
 var trailingJunkWord = regexp.MustCompile(
-	`(?i)[\s:,\-–—_]+(chapter|chapters|disc|disk|cd|track|part|pt|book|vol|volume|side|tape|section)\s*$`)
+	`(?i)[\s:,\-–—_]+(chapter|chapters|disc|disk|cd|track|part|pt|book|vol|volume|side|tape|section|pack|omnibus|box set|boxset)\s*$`)
+
+// leadingSeparator catches the mirror-image artefact the embedded shapes create.
+// The existing guard only checks SUFFIXES because it was built for a parser that
+// only stripped suffixes; stripping a LEADING number strands the separator at the
+// front instead — ". Battle for the Abyss", "- Fallen Angels".
+var leadingSeparator = regexp.MustCompile(`^[\s:,\-–—_.)\]]+`)
 
 // hasLetter reports whether s contains any letter at all. A base of "01" or "—"
 // is not a name.
@@ -68,13 +125,21 @@ func hasLetter(s string) bool {
 // "The Tower of Nero - Chapter", and 11 each into bases of "01".."04".
 func IsJunkSeriesBase(base string) bool {
 	b := strings.TrimSpace(base)
-	if b == "" {
+	// A single character is never a series name, and the embedded shapes can
+	// strip a name down to one ("2: A" → base "A"). Landing this WITH the parser
+	// rather than after it is deliberate: a mistake in a new shape fails closed.
+	if len([]rune(b)) < 2 {
 		return true
 	}
 	if _, ok := junkSeriesBases[strings.ToLower(b)]; ok {
 		return true
 	}
 	if trailingJunkWord.MatchString(b) {
+		return true
+	}
+	// The leading-number shapes strand punctuation at the FRONT, where the
+	// suffix checks below cannot see it.
+	if leadingSeparator.MatchString(b) {
 		return true
 	}
 	// Purely numeric or punctuation-only: "01", "—", "3.".
@@ -90,12 +155,50 @@ func IsJunkSeriesBase(base string) bool {
 	return false
 }
 
+// SeriesShape names which textual pattern carried the position. It exists so the
+// op can gate and report per shape: the two trailing shapes are long-established
+// production behaviour, the embedded ones are new and land behind their own gate.
+type SeriesShape string
+
+const (
+	ShapeTrailingKeyword SeriesShape = "trailing-keyword" // "Schooled in Magic: Book 11"
+	ShapeTrailingBare    SeriesShape = "trailing-bare"    // "Discworld 05"
+	ShapeEmbeddedKeyword SeriesShape = "embedded-keyword" // "Evil Genius: Book 4: Becoming…"
+	ShapeBracketed       SeriesShape = "bracketed"        // "Dragon Born [04]"
+	ShapeMidColon        SeriesShape = "mid-colon"        // "Station 64: The Doll Dungeon"
+	ShapeLeadingBare     SeriesShape = "leading-bare"     // "08. Battle for the Abyss"
+)
+
+// SeriesConfidence is how much the name alone vouches for the number being a
+// position. Only high is eligible to apply unattended; low NEVER applies, at any
+// setting, because no string-only rule separates "86—EIGHTY-SIX" from
+// "08. Battle for the Abyss" (spec D3).
+type SeriesConfidence string
+
+const (
+	ConfidenceHigh   SeriesConfidence = "high"
+	ConfidenceMedium SeriesConfidence = "medium"
+	ConfidenceLow    SeriesConfidence = "low"
+)
+
 // SeriesSplit is the outcome of parsing one series name.
 type SeriesSplit struct {
 	Base     string // the series name with the position removed
 	Position int    // the parsed position, 0 when none
 	Explicit bool   // true when a keyword marked the position ("Book 3")
 	Padded   bool   // true when the number was zero-padded ("05")
+	Shape    SeriesShape
+	// Confidence is the SHAPE's inherent trust. For the trailing-bare shape it is
+	// only a floor — SeriesDenumber raises it when the library corroborates the
+	// number (padding, or a sibling series sharing the base), which is evidence
+	// this function cannot see.
+	Confidence SeriesConfidence
+}
+
+// countPositionCandidates counts digit runs in a name. Two or more means the name
+// offers two candidate positions and picking one is a guess.
+func countPositionCandidates(name string) int {
+	return len(anyNumber.FindAllString(name, -1))
 }
 
 // SplitSeriesPosition separates a trailing book position from a series name.
@@ -112,6 +215,9 @@ func SplitSeriesPosition(name string) (SeriesSplit, bool) {
 		return SeriesSplit{}, false
 	}
 
+	// ── Trailing shapes, tried FIRST and left exactly as they were. Anything the
+	// op already handles in production must keep resolving identically, so the
+	// new shapes below can only ever claim names these two decline.
 	if m := explicitPositionSuffix.FindStringSubmatch(n); m != nil {
 		base := strings.TrimSpace(strings.TrimRight(n[:len(n)-len(m[0])], " :,-_"))
 		pos, _ := strconv.Atoi(m[1])
@@ -119,7 +225,8 @@ func SplitSeriesPosition(name string) (SeriesSplit, bool) {
 			return SeriesSplit{}, false
 		}
 		return SeriesSplit{Base: base, Position: pos, Explicit: true,
-			Padded: strings.HasPrefix(m[1], "0")}, true
+			Padded: strings.HasPrefix(m[1], "0"),
+			Shape:  ShapeTrailingKeyword, Confidence: ConfidenceHigh}, true
 	}
 
 	if m := barePositionSuffix.FindStringSubmatch(n); m != nil {
@@ -128,11 +235,105 @@ func SplitSeriesPosition(name string) (SeriesSplit, bool) {
 		if base == "" || pos <= 0 {
 			return SeriesSplit{}, false
 		}
+		// Low is the FLOOR, not the verdict: SeriesDenumber promotes this to high
+		// on padding or a sibling base, and drops it entirely without either.
 		return SeriesSplit{Base: base, Position: pos, Explicit: false,
-			Padded: strings.HasPrefix(m[2], "0")}, true
+			Padded: strings.HasPrefix(m[2], "0"),
+			Shape:  ShapeTrailingBare, Confidence: ConfidenceLow}, true
+	}
+
+	// ── Spec D5: refuse a name offering two candidate positions.
+	//
+	// "The Demon Wars Saga [07] Immortalis [02]" — 07 is the series position, 02
+	// is not, and nothing in the string says which. Guessing writes a wrong
+	// position AND a wrong base, so refuse outright.
+	//
+	// This gate sits BELOW the trailing shapes on purpose. Applying it to them
+	// would newly refuse names like "The 100 Book 3" that production already
+	// resolves correctly — a coverage regression dressed up as caution. Neither
+	// two-bracket example reaches here by accident: both end in "]", which
+	// barePositionSuffix cannot match.
+	if countPositionCandidates(n) > 1 {
+		return SeriesSplit{}, false
+	}
+
+	// Explicit stays FALSE for every embedded shape even where a keyword vouches
+	// for it. SeriesDenumber's evidence switch has a `case sp.Explicit` arm that
+	// applies unattended; inheriting it here would ship 61 books' worth of merges
+	// on the first apply with no gate of their own. Shape is the wiring now.
+	if m := embeddedKeywordPosition.FindStringSubmatch(n); m != nil {
+		if sp, ok := embeddedSplit(m[1], m[2], m[3], ShapeEmbeddedKeyword, ConfidenceHigh); ok {
+			return sp, true
+		}
+		return SeriesSplit{}, false
+	}
+
+	if m := bracketedPosition.FindStringSubmatch(n); m != nil {
+		if sp, ok := embeddedSplit(m[1], m[2], "", ShapeBracketed, ConfidenceMedium); ok {
+			return sp, true
+		}
+		return SeriesSplit{}, false
+	}
+
+	if m := midColonPosition.FindStringSubmatch(n); m != nil {
+		if sp, ok := embeddedSplit(m[1], m[2], m[3], ShapeMidColon, ConfidenceLow); ok {
+			return sp, true
+		}
+		return SeriesSplit{}, false
+	}
+
+	// rest is "" here, not m[2]: for a leading number the remainder IS the base,
+	// so passing it as rest would trip the base==title check on every name.
+	if m := leadingBarePosition.FindStringSubmatch(n); m != nil {
+		if sp, ok := embeddedSplit(m[2], m[1], "", ShapeLeadingBare, ConfidenceLow); ok {
+			return sp, true
+		}
+		return SeriesSplit{}, false
 	}
 
 	return SeriesSplit{}, false
+}
+
+// embeddedSplit validates one embedded-shape match into a SeriesSplit.
+//
+// rest is the title text trailing the number, empty when the shape has none. A
+// base identical to that title means the split found nothing real —
+// "Rebirth Online 2: Rebirth Online" is one name repeated, not a series and its
+// volume (spec D6).
+func embeddedSplit(rawBase, rawPos, rest string, shape SeriesShape, conf SeriesConfidence) (SeriesSplit, bool) {
+	base := strings.TrimSpace(rawBase)
+	pos, err := strconv.Atoi(rawPos)
+	if err != nil || pos <= 0 {
+		return SeriesSplit{}, false
+	}
+	if IsJunkSeriesBase(base) {
+		return SeriesSplit{}, false
+	}
+	if rest != "" && strings.EqualFold(base, strings.TrimSpace(rest)) {
+		return SeriesSplit{}, false
+	}
+	return SeriesSplit{
+		Base: base, Position: pos, Padded: strings.HasPrefix(rawPos, "0"),
+		Shape: shape, Confidence: conf,
+	}, true
+}
+
+// ApplyEligible reports whether a plan may be executed unattended.
+//
+// 🔒 Low is unconditional: there is no parameter that lets it through. The whole
+// reason the tier exists is that "86—EIGHTY-SIX" and "08. Battle for the Abyss"
+// are the same string shape, and a merge creates and deletes series rows.
+// allowMedium exists so the first production apply can be scoped to keyword-
+// vouched names only, with the dry run reporting what medium WOULD have done.
+func ApplyEligible(p SeriesMergePlan, allowMedium bool) bool {
+	switch p.Confidence {
+	case ConfidenceHigh:
+		return true
+	case ConfidenceMedium:
+		return allowMedium
+	default:
+		return false
+	}
 }
 
 // SeriesInput is one series row, reduced to what the planner needs.
@@ -152,6 +353,11 @@ type SeriesMergePlan struct {
 	Position int
 	Reason   string
 	Books    int
+	Shape    SeriesShape
+	// Confidence decides eligibility, not Reason. It lives on the PLAN and not
+	// only on the split because the op consumes plans, and a merge that creates
+	// and deletes series rows is the destructive step that needs the gate.
+	Confidence SeriesConfidence
 }
 
 // SeriesDenumber plans the merges that collapse "<Series> <N>" rows into one
@@ -203,20 +409,38 @@ func SeriesDenumber(in []SeriesInput) []SeriesMergePlan {
 		k := key{strings.ToLower(sp.Base), s.AuthorID}
 
 		reason := ""
+		conf := sp.Confidence
 		switch {
-		case sp.Explicit:
-			reason = "explicit position keyword"
-		case sp.Padded:
-			reason = "zero-padded position"
-		case baseCount[k] > 1:
-			reason = "another series shares this base"
+		// ── Trailing shapes: verdicts unchanged from the shipped behaviour. ──
+		case sp.Shape == ShapeTrailingKeyword:
+			reason, conf = "explicit position keyword", ConfidenceHigh
+		case sp.Shape == ShapeTrailingBare && sp.Padded:
+			reason, conf = "zero-padded position", ConfidenceHigh
+		case sp.Shape == ShapeTrailingBare && baseCount[k] > 1:
+			reason, conf = "another series shares this base", ConfidenceHigh
+		case sp.Shape == ShapeTrailingBare:
+			// A lone unpadded trailing number is not evidence. Dropped outright
+			// rather than reported as low, so "Fahrenheit 451" never appears in a
+			// report an operator might act on.
+			continue
+
+		// ── Embedded shapes (owner item 4). ──
+		case sp.Shape == ShapeEmbeddedKeyword:
+			reason = "embedded position keyword"
+		case sp.Shape == ShapeBracketed:
+			reason = "bracketed position"
+		case sp.Shape == ShapeMidColon:
+			reason = "bare number before the title"
+		case sp.Shape == ShapeLeadingBare:
+			reason = "bare leading number"
 		default:
-			continue // a lone unpadded number is not evidence — leave it alone
+			continue
 		}
 
 		plans = append(plans, SeriesMergePlan{
 			FromID: s.ID, FromName: s.Name, IntoName: sp.Base,
 			IntoID: canonical[k], Position: sp.Position, Reason: reason, Books: s.Books,
+			Shape: sp.Shape, Confidence: conf,
 		})
 	}
 	return plans

--- a/internal/plugins/maintenance/series_denumber_op.go
+++ b/internal/plugins/maintenance/series_denumber_op.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/series_denumber_op.go
-// version: 1.0.0
+// version: 2.0.0
 // guid: 3f0b6c84-52d1-4a97-9e35-c8b71d0af426
-// last-edited: 2026-08-04
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -22,7 +24,50 @@ type SeriesDenumberParams struct {
 	// Apply, when true, performs the merges. Default false — dry run.
 	Apply bool `json:"apply"`
 	// Limit caps how many SERIES are merged (0 = all). Useful for a canary.
+	// It caps the APPLY set, never the report: a dry run always reports every
+	// candidate so the operator sees the whole picture before scoping the apply.
 	Limit int `json:"limit,omitempty"`
+	// ApplyMedium extends the apply set to medium-confidence plans — a single
+	// bracketed number, "Dragon Born [04]". Default false, so the first
+	// production apply is scoped to names a keyword vouches for, and the dry run
+	// reports what medium WOULD have done before anyone risks it.
+	//
+	// There is deliberately no equivalent for low. See ApplyEligible.
+	ApplyMedium bool `json:"applyMedium,omitempty"`
+	// ReportPath, when set, writes every candidate (all tiers, eligible or not)
+	// as TSV before a single row is touched.
+	//
+	// 🔑 This is the rollback artefact. A merge creates and deletes series rows,
+	// so "undo" means replaying this file — there is no transaction to abort.
+	// Write it during the dry run and keep it.
+	ReportPath string `json:"reportPath,omitempty"`
+}
+
+// writeSeriesDenumberReport dumps every candidate as TSV, eligible or not.
+//
+// TSV rather than JSON because the point of this file is to be read by a person
+// deciding whether to proceed, and sorted/grepped by shape or tier while they do
+// it. The `eligible` column records the decision made at THIS invocation's
+// settings, so the file explains itself later without the params alongside.
+func writeSeriesDenumberReport(path string, plans []SeriesMergePlan, allowMedium bool) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o775); err != nil {
+			return err
+		}
+	}
+	var b strings.Builder
+	b.WriteString("from_series_id\tfrom_name\tinto_name\tposition\tbooks\tshape\tconfidence\teligible\treason\n")
+	for _, pl := range plans {
+		// Tabs and newlines inside a name would break the column alignment and
+		// silently shift every field after it.
+		clean := func(s string) string {
+			return strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
+		}
+		fmt.Fprintf(&b, "%d\t%s\t%s\t%d\t%d\t%s\t%s\t%t\t%s\n",
+			pl.FromID, clean(pl.FromName), clean(pl.IntoName), pl.Position, pl.Books,
+			pl.Shape, pl.Confidence, ApplyEligible(pl, allowMedium), clean(pl.Reason))
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o664)
 }
 
 func (p *Plugin) seriesDenumberDef() sdk.OperationDef {
@@ -35,7 +80,12 @@ func (p *Plugin) seriesDenumberDef() sdk.OperationDef {
 			"many one-book series as it has volumes. This merges them onto the base name and moves the number " +
 			"into the book's series position. A bare trailing number is only trusted when the library " +
 			"corroborates it — zero-padding, an explicit keyword, or another series sharing the base — so a real " +
-			"name like \"Fahrenheit 451\" is left alone. Dry-run by default; pass {\"apply\": true} to merge.",
+			"name like \"Fahrenheit 451\" is left alone. Also reads positions embedded in the middle or at the " +
+			"front of a name (\"Evil Genius: Book 4: ...\", \"Dragon Born [04]\", \"08. Battle for the Abyss\"), " +
+			"each scored by confidence — a keyword-vouched position applies, a bracketed one needs " +
+			"{\"applyMedium\": true}, and a bare number is only ever reported, because \"86—EIGHTY-SIX\" is a real " +
+			"series name with the same shape. Dry-run by default; pass {\"apply\": true} to merge and " +
+			"{\"reportPath\": \"...\"} to write the rollback report.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.series-denumber",
@@ -81,26 +131,61 @@ func (p *Plugin) runSeriesDenumber(ctx context.Context, raw json.RawMessage, rep
 		in = append(in, SeriesInput{ID: s.ID, Name: s.Name, AuthorID: aid, Books: counts[s.ID]})
 	}
 
-	plans := SeriesDenumber(in)
+	candidates := SeriesDenumber(in)
 	// Deterministic order so a dry run and the apply that follows it agree, and
 	// so the FIRST plan for a base is the one that creates the base series.
-	sort.Slice(plans, func(i, j int) bool {
-		if plans[i].IntoName != plans[j].IntoName {
-			return plans[i].IntoName < plans[j].IntoName
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].IntoName != candidates[j].IntoName {
+			return candidates[i].IntoName < candidates[j].IntoName
 		}
-		return plans[i].Position < plans[j].Position
+		return candidates[i].Position < candidates[j].Position
 	})
-	if params.Limit > 0 && len(plans) > params.Limit {
-		plans = plans[:params.Limit]
-	}
 
-	log.Info("series-denumber: plan complete", "series", len(in), "merges", len(plans))
-	if len(plans) == 0 {
+	log.Info("series-denumber: plan complete", "series", len(in), "candidates", len(candidates))
+	if len(candidates) == 0 {
 		summary := fmt.Sprintf("series-denumber: %d series scanned, 0 carry a book number — nothing to do", len(in))
 		_ = reporter.Log(slog.LevelInfo, summary)
 		_ = reporter.UpdateProgress(1, 1, summary)
 		return nil
 	}
+
+	// 🔑 The report covers EVERY candidate, including the tiers that will never
+	// be applied. Written before anything is touched, because a merge creates and
+	// deletes series rows and replaying this file is the only way back.
+	if params.ReportPath != "" {
+		if err := writeSeriesDenumberReport(params.ReportPath, candidates, params.ApplyMedium); err != nil {
+			// Fail closed: an apply with no rollback artefact is exactly the
+			// situation the report exists to prevent.
+			return fmt.Errorf("write report %s: %w", params.ReportPath, err)
+		}
+		log.Info("series-denumber: report written", "path", params.ReportPath, "rows", len(candidates))
+	} else if params.Apply {
+		log.Warn("series-denumber: applying with no reportPath — there will be no rollback artefact")
+	}
+
+	// Partition by eligibility. Low never appears in plans, at any setting.
+	plans := make([]SeriesMergePlan, 0, len(candidates))
+	byTier := map[SeriesConfidence]int{}
+	booksByTier := map[SeriesConfidence]int{}
+	heldExamples := make([]string, 0, 6)
+	for _, pl := range candidates {
+		byTier[pl.Confidence]++
+		booksByTier[pl.Confidence] += pl.Books
+		if ApplyEligible(pl, params.ApplyMedium) {
+			plans = append(plans, pl)
+		} else if len(heldExamples) < 6 {
+			heldExamples = append(heldExamples, fmt.Sprintf("%q → %q #%d [%s/%s]",
+				pl.FromName, pl.IntoName, pl.Position, pl.Shape, pl.Confidence))
+		}
+	}
+	if params.Limit > 0 && len(plans) > params.Limit {
+		plans = plans[:params.Limit]
+	}
+
+	tiers := fmt.Sprintf("high=%d(%d books) medium=%d(%d books) low=%d(%d books)",
+		byTier[ConfidenceHigh], booksByTier[ConfidenceHigh],
+		byTier[ConfidenceMedium], booksByTier[ConfidenceMedium],
+		byTier[ConfidenceLow], booksByTier[ConfidenceLow])
 
 	byReason := map[string]int{}
 	bases := map[string]struct{}{}
@@ -123,11 +208,24 @@ func (p *Plugin) runSeriesDenumber(ctx context.Context, raw json.RawMessage, rep
 		}
 		sort.Strings(reasons)
 		summary := fmt.Sprintf(
-			"series-denumber: %d series scanned, would merge %d into %d base series "+
-				"(%d books would move) — by evidence: %s | e.g. %s",
-			len(in), len(plans), len(bases), booksAffected, strings.Join(reasons, " "), strings.Join(examples, "; "))
+			"series-denumber: %d series scanned, %d carry a position (%s). "+
+				"Would merge %d into %d base series (%d books would move) — by evidence: %s | "+
+				"applying: %s | held: %s",
+			len(in), len(candidates), tiers,
+			len(plans), len(bases), booksAffected, strings.Join(reasons, " "),
+			strings.Join(examples, "; "), strings.Join(heldExamples, "; "))
 		_ = reporter.Log(slog.LevelInfo, summary)
-		_ = reporter.UpdateProgress(len(plans), len(plans), summary)
+		_ = reporter.UpdateProgress(len(candidates), len(candidates), summary)
+		return nil
+	}
+
+	if len(plans) == 0 {
+		summary := fmt.Sprintf(
+			"series-denumber: %d candidates found (%s) but none are eligible to apply — "+
+				"pass applyMedium to include bracketed positions; low never applies",
+			len(candidates), tiers)
+		_ = reporter.Log(slog.LevelInfo, summary)
+		_ = reporter.UpdateProgress(1, 1, summary)
 		return nil
 	}
 

--- a/internal/plugins/maintenance/series_embedded_position_test.go
+++ b/internal/plugins/maintenance/series_embedded_position_test.go
@@ -1,0 +1,359 @@
+// file: internal/plugins/maintenance/series_embedded_position_test.go
+// version: 1.0.0
+// guid: 7c41ba05-3e92-4d18-b6a7-51fd0e93c284
+// last-edited: 2026-08-06
+
+package maintenance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every name below is a REAL production series name, taken from the whole-library
+// shape census in docs/specs/2026-08-06-series-embedded-positions-design.md.
+// They are not illustrative — each one is a case the parser gets wrong if a
+// discriminator is dropped.
+
+// 🔴 THE CORRUPTION THIS MUST NOT CAUSE.
+//
+// "86—EIGHTY-SIX" is a real series title covering 17 production books: the number
+// IS the name. It has the same shape as "08. Battle for the Abyss", where the
+// number is a genuine Horus Heresy position. The only thing separating them in
+// the string is how the number is punctuated — a list-style "08. " versus a
+// number fused to the next word by an unspaced dash.
+//
+// If this test fails, 17 books get scattered into a series called "EIGHTY-SIX"
+// and the real name is deleted.
+func TestSplitSeriesPosition_RefusesRealTitlesThatOpenWithANumber(t *testing.T) {
+	for _, n := range []string{
+		"86—EIGHTY-SIX",
+		"5-Minute Sherlock",
+		"24-Hour Comics",
+		"1-800-Where-R-You",
+	} {
+		if got, ok := SplitSeriesPosition(n); ok {
+			t.Errorf("%q was split into base=%q pos=%d — it is a real title",
+				n, got.Base, got.Position)
+		}
+	}
+}
+
+// A keyword introducing the number is the evidence, whether it sits at the end of
+// the name or in the middle of it. These are the only shape allowed to apply
+// unattended on the first production run.
+func TestSplitSeriesPosition_EmbeddedKeywordIsHighConfidence(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		pos  int
+	}{
+		{"Vampire Hunter D: Vol 09: The Rose Princess", "Vampire Hunter D", 9},
+		{"Evil Genius: Book 4: Becoming the Apex Supervillain", "Evil Genius", 4},
+		{"Frontiers Saga Part 2: Rogue Castes", "Frontiers Saga", 2},
+		{"The Best of the Best: Volume 2: Twenty Years of the Best", "The Best of the Best", 2},
+	}
+	for _, c := range cases {
+		got, ok := SplitSeriesPosition(c.name)
+		if !ok {
+			t.Errorf("%q: no position found", c.name)
+			continue
+		}
+		if got.Base != c.base || got.Position != c.pos {
+			t.Errorf("%q → base=%q pos=%d, want base=%q pos=%d",
+				c.name, got.Base, got.Position, c.base, c.pos)
+		}
+		if got.Shape != ShapeEmbeddedKeyword {
+			t.Errorf("%q: shape=%q, want %q", c.name, got.Shape, ShapeEmbeddedKeyword)
+		}
+		if got.Confidence != ConfidenceHigh {
+			t.Errorf("%q: confidence=%q, want high", c.name, got.Confidence)
+		}
+	}
+}
+
+// 🔑 Explicit must stay false for embedded shapes. SeriesDenumber's evidence
+// switch had a `case sp.Explicit` arm that applies unattended; if an embedded
+// keyword inherited it, 61 books' worth of merges would ride in on the trailing
+// shape's permission with no gate of their own.
+func TestSplitSeriesPosition_EmbeddedKeywordDoesNotInheritExplicit(t *testing.T) {
+	got, ok := SplitSeriesPosition("Evil Genius: Book 4: Becoming the Apex Supervillain")
+	if !ok {
+		t.Fatal("no position found")
+	}
+	if got.Explicit {
+		t.Error("Explicit=true — embedded shapes must be gated by Shape, not by the trailing shape's flag")
+	}
+}
+
+// A bracketed bare number is a deliberate mark — no real title wears one — but
+// nothing vouches for the number itself, so it is medium and needs an operator
+// to opt in.
+func TestSplitSeriesPosition_BracketedIsMediumConfidence(t *testing.T) {
+	got, ok := SplitSeriesPosition("Dragon Born [04]")
+	if !ok {
+		t.Fatal("Dragon Born [04]: no position found")
+	}
+	if got.Base != "Dragon Born" || got.Position != 4 {
+		t.Fatalf("base=%q pos=%d, want Dragon Born/4", got.Base, got.Position)
+	}
+	if got.Confidence != ConfidenceMedium {
+		t.Fatalf("confidence=%q, want medium", got.Confidence)
+	}
+	if !got.Padded {
+		t.Error("Padded=false for \"04\"")
+	}
+}
+
+// 🔴 Spec D5. Two bracketed numbers offer two candidate positions and the string
+// says nothing about which is the series'. In "The Demon Wars Saga [07]
+// Immortalis [02]" the answer is 07, and a last-match regex takes 02 — writing a
+// wrong position AND a wrong base. Refuse instead of guessing.
+func TestSplitSeriesPosition_RefusesTwoCandidateNumbers(t *testing.T) {
+	for _, n := range []string{
+		"The Demon Wars Saga [07] Immortalis [02]",
+		"The Stormlight Archive [01] The Way Of Kings [02]",
+	} {
+		if got, ok := SplitSeriesPosition(n); ok {
+			t.Errorf("%q was split into base=%q pos=%d — two numbers means guessing",
+				n, got.Base, got.Position)
+		}
+	}
+}
+
+// The multi-number refusal must NOT reach back into the trailing shapes. They
+// already resolve correctly in production, and refusing a name like "The 100 Book
+// 3" would be a coverage regression dressed up as caution.
+func TestSplitSeriesPosition_MultiNumberGateSparesTrailingShapes(t *testing.T) {
+	got, ok := SplitSeriesPosition("The 100 Book 3")
+	if !ok {
+		t.Fatal("The 100 Book 3: trailing keyword shape stopped matching")
+	}
+	if got.Base != "The 100" || got.Position != 3 {
+		t.Fatalf("base=%q pos=%d, want \"The 100\"/3", got.Base, got.Position)
+	}
+}
+
+// A bare number in front of a title is right often enough to be worth surfacing
+// and wrong often enough that it can never apply itself.
+//
+// Note what the base becomes for "08. Battle for the Abyss": "Battle for the
+// Abyss", which is the BOOK's title, not the series ("Horus Heresy"). The correct
+// series name simply is not present in the string. That is the clearest statement
+// of why this tier holds rather than applies.
+func TestSplitSeriesPosition_BareNumbersAreLowConfidence(t *testing.T) {
+	cases := []struct {
+		name  string
+		base  string
+		pos   int
+		shape SeriesShape
+	}{
+		{"08. Battle for the Abyss", "Battle for the Abyss", 8, ShapeLeadingBare},
+		{"11. Fallen Angels", "Fallen Angels", 11, ShapeLeadingBare},
+		{"22. Shadows of Treachery", "Shadows of Treachery", 22, ShapeLeadingBare},
+		{"Station 64: The Doll Dungeon", "Station", 64, ShapeMidColon},
+	}
+	for _, c := range cases {
+		got, ok := SplitSeriesPosition(c.name)
+		if !ok {
+			t.Errorf("%q: no position found", c.name)
+			continue
+		}
+		if got.Base != c.base || got.Position != c.pos || got.Shape != c.shape {
+			t.Errorf("%q → base=%q pos=%d shape=%q, want %q/%d/%q",
+				c.name, got.Base, got.Position, got.Shape, c.base, c.pos, c.shape)
+		}
+		if got.Confidence != ConfidenceLow {
+			t.Errorf("%q: confidence=%q, want low", c.name, got.Confidence)
+		}
+	}
+}
+
+// Spec D6. "Rebirth Online 2: Rebirth Online" splits into a base and a title that
+// are the same string — which means the split found a repetition, not a volume.
+func TestSplitSeriesPosition_RefusesWhenBaseEqualsTitle(t *testing.T) {
+	for _, n := range []string{
+		"Rebirth Online 2: Rebirth Online",
+		"Renegade Star 3: renegade star",
+	} {
+		if got, ok := SplitSeriesPosition(n); ok {
+			t.Errorf("%q was split into base=%q — base and title are the same name",
+				n, got.Base)
+		}
+	}
+}
+
+// Spec D6. A bundle number is not a series position: "Publisher's Pack 7" numbers
+// the pack. Merging on it would gather unrelated bundles into one bogus series.
+func TestIsJunkSeriesBase_RejectsBundleWords(t *testing.T) {
+	for _, s := range []string{
+		"Renegade Star: Publisher's Pack",
+		"Pack", "Omnibus", "The Expanse - Box Set",
+		"D", // single character — the embedded shapes can strip a name this far
+	} {
+		if !IsJunkSeriesBase(s) {
+			t.Errorf("IsJunkSeriesBase(%q) = false, want true", s)
+		}
+	}
+}
+
+// 🔑 The mirror-image artefact. The shipped guard only checked SUFFIXES because
+// the parser only stripped suffixes; a leading-number strip strands the
+// punctuation at the FRONT, where none of those checks can see it.
+func TestIsJunkSeriesBase_RejectsAStrandedLeadingSeparator(t *testing.T) {
+	for _, s := range []string{
+		". Battle for the Abyss",
+		"- Fallen Angels",
+		": Shadows of Treachery",
+		"— Immortalis",
+	} {
+		if !IsJunkSeriesBase(s) {
+			t.Errorf("IsJunkSeriesBase(%q) = false, want true", s)
+		}
+	}
+}
+
+// The whole point of the shape census is that "Renegade Star: Publisher's Pack 7:
+// Renegade Star" must not survive to a plan. It carries a number in a shape the
+// parser now reads, and only the junk guard stops it.
+func TestSeriesDenumber_RefusesAPackNumber(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Renegade Star: Publisher's Pack 7: Renegade Star", AuthorID: 2, Books: 1},
+	}
+	if got := SeriesDenumber(in); len(got) != 0 {
+		t.Fatalf("planned a merge on a pack number: %+v", got)
+	}
+}
+
+// 🔒 The gate itself. Low must never be eligible, at any setting, and medium only
+// when an operator has opted in.
+func TestApplyEligible_LowNeverApplies(t *testing.T) {
+	cases := []struct {
+		conf        SeriesConfidence
+		allowMedium bool
+		want        bool
+	}{
+		{ConfidenceHigh, false, true},
+		{ConfidenceHigh, true, true},
+		{ConfidenceMedium, false, false},
+		{ConfidenceMedium, true, true},
+		{ConfidenceLow, false, false},
+		{ConfidenceLow, true, false}, // ← the one that matters
+	}
+	for _, c := range cases {
+		got := ApplyEligible(SeriesMergePlan{Confidence: c.conf}, c.allowMedium)
+		if got != c.want {
+			t.Errorf("ApplyEligible(%s, allowMedium=%v) = %v, want %v",
+				c.conf, c.allowMedium, got, c.want)
+		}
+	}
+}
+
+// End-to-end on the tiers: a library holding one name of each shape produces
+// plans whose confidences match, and only the keyword-vouched one is eligible
+// under the default settings.
+func TestSeriesDenumber_AssignsTiersAndGatesTheApplySet(t *testing.T) {
+	in := []SeriesInput{
+		{ID: 1, Name: "Evil Genius: Book 4: Becoming the Apex Supervillain", AuthorID: 1, Books: 3},
+		{ID: 2, Name: "Dragon Born [04]", AuthorID: 2, Books: 2},
+		{ID: 3, Name: "08. Battle for the Abyss", AuthorID: 3, Books: 1},
+		{ID: 4, Name: "86—EIGHTY-SIX", AuthorID: 4, Books: 17},
+	}
+	plans := SeriesDenumber(in)
+
+	byName := map[string]SeriesMergePlan{}
+	for _, p := range plans {
+		byName[p.FromName] = p
+	}
+	if _, planned := byName["86—EIGHTY-SIX"]; planned {
+		t.Fatal("86—EIGHTY-SIX produced a plan — it is a real series name")
+	}
+	if len(plans) != 3 {
+		t.Fatalf("planned %d merges, want 3: %+v", len(plans), plans)
+	}
+	for name, wantConf := range map[string]SeriesConfidence{
+		"Evil Genius: Book 4: Becoming the Apex Supervillain": ConfidenceHigh,
+		"Dragon Born [04]":                                    ConfidenceMedium,
+		"08. Battle for the Abyss":                            ConfidenceLow,
+	} {
+		if got := byName[name].Confidence; got != wantConf {
+			t.Errorf("%q: confidence=%q, want %q", name, got, wantConf)
+		}
+	}
+
+	var eligible int
+	for _, p := range plans {
+		if ApplyEligible(p, false) {
+			eligible++
+		}
+	}
+	if eligible != 1 {
+		t.Fatalf("%d plans eligible by default, want 1 (the keyword-vouched one)", eligible)
+	}
+}
+
+// The report is the rollback artefact: a merge creates and deletes series rows,
+// so there is no transaction to abort and replaying this file is the only way
+// back. It must therefore list EVERY candidate — including the held ones, which
+// are exactly what an operator is deciding about.
+func TestWriteSeriesDenumberReport_ListsHeldCandidatesToo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "report.tsv")
+	plans := []SeriesMergePlan{
+		{FromID: 1, FromName: "Evil Genius: Book 4: X", IntoName: "Evil Genius", Position: 4,
+			Books: 3, Shape: ShapeEmbeddedKeyword, Confidence: ConfidenceHigh, Reason: "embedded position keyword"},
+		{FromID: 2, FromName: "Dragon Born [04]", IntoName: "Dragon Born", Position: 4,
+			Books: 2, Shape: ShapeBracketed, Confidence: ConfidenceMedium, Reason: "bracketed position"},
+		{FromID: 3, FromName: "08. Battle for the Abyss", IntoName: "Battle for the Abyss", Position: 8,
+			Books: 1, Shape: ShapeLeadingBare, Confidence: ConfidenceLow, Reason: "bare leading number"},
+	}
+	if err := writeSeriesDenumberReport(path, plans, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("%d lines, want 1 header + 3 candidates:\n%s", len(lines), raw)
+	}
+	if !strings.HasPrefix(lines[0], "from_series_id\tfrom_name") {
+		t.Errorf("header = %q", lines[0])
+	}
+	// Eligibility is recorded per row so the file explains itself without the
+	// params that produced it.
+	wantEligible := []bool{true, false, false}
+	for i, want := range wantEligible {
+		cols := strings.Split(lines[i+1], "\t")
+		if len(cols) != 9 {
+			t.Fatalf("row %d has %d columns, want 9: %q", i, len(cols), lines[i+1])
+		}
+		got := cols[7] == "true"
+		if got != want {
+			t.Errorf("row %d (%s): eligible=%v, want %v", i, cols[1], got, want)
+		}
+	}
+}
+
+// A tab inside a series name would shift every column after it and silently
+// misattribute the position and tier of that row.
+func TestWriteSeriesDenumberReport_NeutralisesTabsInNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.tsv")
+	plans := []SeriesMergePlan{{
+		FromID: 1, FromName: "Broken\tName\nHere", IntoName: "Broken", Position: 2,
+		Shape: ShapeMidColon, Confidence: ConfidenceLow, Reason: "bare number before the title",
+	}}
+	if err := writeSeriesDenumberReport(path, plans, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("%d lines, want 2 — an embedded newline split the row:\n%s", len(lines), raw)
+	}
+	if cols := strings.Split(lines[1], "\t"); len(cols) != 9 {
+		t.Fatalf("%d columns, want 9 — an embedded tab shifted the row: %q", len(cols), lines[1])
+	}
+}


### PR DESCRIPTION
Owner item 4 — "series names that are really book numbers".

`maintenance.series-denumber` only handled **trailing** positions (`Discworld 05`). A whole-library census found **769 more distinct series names** carrying the position at the front or in the middle.

## Why this needed tiers rather than a fourth regex

The trailing-only restriction was not an oversight — it is the safe half. Same shape, opposite meaning:

| Name | Reality |
|---|---|
| `86—EIGHTY-SIX` | **Real series title**, 17 production books. "86" IS the name. |
| `08. Battle for the Abyss` | Genuine Horus Heresy position 8. |
| `Station 64: The Doll Dungeon` | Ambiguous — position 64, or a series called "Station 64"? |
| `The Demon Wars Saga [07] Immortalis [02]` | Two numbers; 07 is the position, a last-match regex takes 02. |

So each shape carries a confidence:

- **high** — a keyword vouches for the number (`Book 4`, `Vol 09`, `Part 2`). Applies unattended.
- **medium** — a single bracketed number (`Dragon Born [04]`). Requires `{"applyMedium": true}`.
- **low** — a bare number (`08. Battle for the Abyss`, `Station 64: …`). **Reported only, never applied at any setting.** `ApplyEligible` has no parameter that lets it through.

Multi-number names are refused outright rather than guessed at.

## Two guards, not one

The leading-number separator must be list-style — `08. `, `1 - `. A number fused to the next word by an *unspaced* dash never enters the candidate set at all, so `86—EIGHTY-SIX` and `5-Minute Sherlock` are excluded before the tier system is even consulted.

`IsJunkSeriesBase` is extended **in the same commit**, deliberately. It only checked suffixes because the parser only stripped suffixes; a leading-number strip strands punctuation at the *front*, where none of those checks could see it. Landing the guard with the parser means a mistake in a new shape fails closed. That guard stopped **285 bad merges** in an earlier production dry run.

Also added: bundle words (`Publisher's Pack`, `Omnibus`, `Box Set`) — a pack number is not a series position — and single-character bases.

## Rollback

New `reportPath` param writes every candidate, including held ones, as TSV **before any row is touched**. A merge creates and deletes series rows, so there is no transaction to abort — replaying that file is the only rollback available. Applying without it logs a warning.

## Deviations from the merged plan (stated, not quiet)

1. **`medium` does not apply by default.** Spec D2 said high-only, plan step 5 said high+medium. Made it a param defaulting to the stricter reading, so the dry run reports what medium *would* do before anyone risks it.
2. **`low` emits no review Kind.** A new kind needs frontend mapping and `review_apply_enabled` is off in production, so an approved hold would mutate nothing. The report file meets the same need.
3. **Sibling corroboration (D4) not built.** `SeriesInput` carries no folder data, and it is safety-*optional* — without it every bare number stays `low`, which is what D3 mandates anyway. Build it only if the dry-run numbers justify it.

## Testing

- 27/27 unit tests pass; **12 pre-existing tests unchanged and still green** — no behaviour change to the shapes production already handles.
- Full `internal/plugins/maintenance` package green with `-race`.
- New tests are built from real production names, including the two self-inflicted bugs caught during implementation (base-equals-title firing on every leading-number name; `Explicit: true` letting embedded keywords ride in on the trailing shape's permission).

**Not yet run against production.** Dry run with `reportPath` comes next, checked against the acceptance gate: candidates ≤ 982, zero junk bases, `86—EIGHTY-SIX` absent from the apply set.

Spec: `docs/specs/2026-08-06-series-embedded-positions-design.md`
Plan: `docs/plans/2026-08-06-series-embedded-positions-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2fEU5ud6uWagzKbUYAPRK