### PR TITLE
docs(series): record the production apply and the shattered-book discovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -351,26 +351,29 @@ into one of the curated sections below, is a normal direct edit.
 <!-- guid: 2f57e91b-8c04-4d73-a6e8-95b013fc287d -->
 <!-- last-edited: 2026-08-05 -->
 
-- [ ] **Series names that are really book numbers (~874 books)** — owner item 4
-  (2026-08-05).
+- [x] **Series names that are really book numbers** — owner item 4
+  (2026-08-05, shipped + applied to production 2026-08-06, PR #2156).
 
-  Shapes still unhandled: `<Series> N: <Title>`, `N - <Title>`, and `N (paren)`.
-  `the world 4` means **book 4 of `the world`** — the number belongs in the
-  series *position* field, not baked into the series *name*.
+  `maintenance.series-denumber` now reads the embedded shapes as well as the
+  trailing ones, each scored by confidence. Applied on production: **25 series
+  merged into 21 base series, 52 books given a real series position, 0 failures**;
+  a re-run confirmed the high tier drained 25 → 0 with the other tiers untouched.
 
-  🔴 **This is a DATA bug, not a display bug.** The owner has corrected that
-  reading twice. Do not re-derive it, and do not "fix" it in the frontend.
+  🔴 **This was a DATA bug, not a display bug** — the number belongs in the
+  series *position* field, not baked into the series *name*. Kept here because
+  the owner corrected that reading twice; do not re-derive it.
 
-  `maintenance.series-denumber` already exists and handles the trailing-number
-  shape; these are the remaining shapes.
+  What the tiers are for, in the production data:
+  - **high** (keyword-vouched, e.g. `Evil Genius: Book 4: …`) — applied.
+  - **medium** (bracketed, e.g. `Dragon Born [04]`) — 198 rows, **NOT applied**.
+    ~180 of them turned out to be shattered-book debris, not series positions.
+    See the follow-up task below.
+  - **low** (bare number, e.g. `08. Battle for the Abyss`) — 466 rows, reported
+    only, and unappliable by construction. `86—EIGHTY-SIX` is a real series name
+    in this library with the identical shape.
 
-  🔴 **Extend `IsJunkSeriesBase` ALONGSIDE the parser, not after it.** That guard
-  is what stopped **285 bad merges** in the dry run. A parser extension that
-  lands before the guard extension will happily collapse series bases the guard
-  would have rejected — and series merges are destructive.
-
-  Dry-run first and read the numbers; independent of the First Aid track, so it
-  can proceed in parallel.
+  Rollback artefacts on the server:
+  `/var/lib/audiobook-organizer/series-denumber-{,APPLY-,VERIFY-}2026-08-06.tsv`.
 
 <!-- file: todo.d/20260805_220300_first_aid_library_validate_repair.md -->
 <!-- version: 1.0.0 -->

--- a/changelog.d/20260806_093500_series-denumber-production-apply.md
+++ b/changelog.d/20260806_093500_series-denumber-production-apply.md
@@ -1,0 +1,21 @@
+<!-- file: changelog.d/20260806_093500_series-denumber-production-apply.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2e7b0a49-6f13-4c85-9d02-b7513ac86f2e -->
+<!-- last-edited: 2026-08-06 -->
+
+### Changed
+
+- **Applied `maintenance.series-denumber` (high tier) to production.** 25 fragmented
+  series merged into 21 base series, 52 books given a real `series_position`, 11 base
+  series created, 25 emptied series deleted, 0 failures. A follow-up dry run confirmed the
+  high tier drained 25 → 0 with the medium (198) and low (466) tiers untouched. Rollback
+  reports: `/var/lib/audiobook-organizer/series-denumber-{,APPLY-,VERIFY-}2026-08-06.tsv`.
+
+  The dry run also established that the acceptance gate holds against real data: 689
+  candidates (under the 982 ceiling), zero candidates whose base fails `IsJunkSeriesBase`,
+  and `86—EIGHTY-SIX` — which exists in production in three spelling variants — absent
+  from the candidate set entirely.
+
+  The medium tier was deliberately NOT applied. See TODO: ~180 of its 198 rows are one
+  shattered book each (80 rows for a single Megan E. O'Keefe novel, 63 more from a Scribd
+  scrape writing page titles into series names), not series positions.

--- a/docs/executive-summaries/2026-08-06-series-that-were-really-book-numbers-executive-summary.md
+++ b/docs/executive-summaries/2026-08-06-series-that-were-really-book-numbers-executive-summary.md
@@ -1,0 +1,90 @@
+<!-- file: docs/executive-summaries/2026-08-06-series-that-were-really-book-numbers-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8b06e2f4-1c57-4a93-b2e8-40d19f7c6a15 -->
+<!-- last-edited: 2026-08-06 -->
+
+# Series that were really book numbers
+
+## What was wrong
+
+A series name is supposed to name the *series*. Many in this library named the series
+**and** the book's number in it, jammed together into one string:
+
+- `Evil Genius: Book 4: Becoming the Apex Supervillain`
+- `Legend of Drizzt Book 14 - The Sellswords`
+- `Vampire Hunter D: Vol 09: The Rose Princess`
+
+The consequence is that a six-book series stops being one series. It becomes six
+separate one-book series, because `Evil Genius: Book 4` and `Evil Genius 6` are
+different strings, and nothing in the system knew they were the same shelf. Browsing by
+series showed you fragments instead of series, and nothing downstream could tell that
+those books belonged together.
+
+The library already handled the simplest version of this — a number at the *end*, like
+`Discworld 05`. The rest had never been touched.
+
+## Why it had never been touched
+
+Because the same shape means opposite things, and the two cases are indistinguishable
+by looking at the text.
+
+`86—EIGHTY-SIX` is a **real series title**. The "86" is the name. This library holds
+seventeen books in it.
+
+`08. Battle for the Abyss` is a **real book number**. The "08" is position 8 in the
+Horus Heresy.
+
+Both are a number, then a separator, then words. Any rule confident enough to fix the
+second one will destroy the first — scattering seventeen books into a series called
+"EIGHTY-SIX" and deleting the real name. That is not recoverable by re-running
+anything, because the original name is gone.
+
+## What was done
+
+Rather than write one clever rule and hope, each pattern was **scored by how much the
+name itself vouches for the number**:
+
+- **A keyword vouches for it** — `Book 4`, `Vol 09`, `Part 2`. Words like that do not
+  appear by accident. These are safe to fix automatically.
+- **Brackets mark it** — `Dragon Born [04]`. Suggestive, but nothing confirms it.
+  Requires someone to explicitly opt in.
+- **A bare number** — `08. Battle for the Abyss`. Reported for a human to look at, and
+  **cannot be applied at all**, by construction. There is no setting that turns this
+  on, because there is no amount of tuning that separates it from `86—EIGHTY-SIX`.
+
+Names offering *two* candidate numbers — `The Demon Wars Saga [07] Immortalis [02]` —
+are refused outright rather than guessed at. Picking the wrong one writes a wrong
+number *and* a wrong series name.
+
+Before anything is changed, the system now writes a full list of every proposed change
+to a file. Fixing a series creates and deletes rows, so there is no "undo" button —
+that file is the only way back, and the operation refuses to run if it cannot write it.
+
+## What actually changed in your library
+
+**25 fragmented series were folded back into 21 real ones, and 52 books got a proper
+book number.** No failures. Re-running the check afterwards confirmed the work was done
+and nothing was left half-finished.
+
+The other 664 candidates were deliberately left alone and written to a report.
+
+## The thing worth knowing about
+
+The cautious setting paid for itself immediately.
+
+Checking the "brackets mark it" group — the 198 that *would* have been changed under
+the less careful reading — showed that most of them were not series at all. They were
+**single books that had been shattered into pieces**, with the piece number ending up in
+the series field:
+
+- One Megan E. O'Keefe novel had become **80 separate rows**, numbered (1) through (80).
+- One Jill Santopolo novel had become **25 rows**.
+- Sixty-three more rows turned out to be *web page titles* from a Scribd scrape, with
+  the page number in brackets.
+
+Applying that group would have created an eighty-volume "series" out of a single novel.
+It was stopped by defaulting to the stricter of two readings — and by looking at the
+report before pressing the button rather than after.
+
+Those ~180 books have a real problem, but it is a different one: they need reassembling
+into single books, not renaming. They are now recorded as their own piece of work.

--- a/todo.d/20260806_093000_bracketed_series_are_shattered_books.md
+++ b/todo.d/20260806_093000_bracketed_series_are_shattered_books.md
@@ -1,0 +1,35 @@
+<!-- file: todo.d/20260806_093000_bracketed_series_are_shattered_books.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9d3f621c-47ea-4b05-8c93-2f1a7de04b58 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **~180 "bracketed series" are actually one shattered book each** — found by
+  the `maintenance.series-denumber` dry run, 2026-08-06.
+
+  The dry run flagged 198 series names carrying a bracketed number
+  (`Dragon Born [04]`, `… Called Peace (12)`). Roughly 18 are genuine series
+  positions. The rest are **one novel exploded into per-chunk series rows**:
+
+  | Target base | Rows | Books | Reality |
+  |---|---:|---:|---|
+  | `Megan E. O'Keefe - Catalyst Gate` | 80 | 80 | one novel |
+  | `Listening-to-ClassA-Threat-by-Dan-Sugralinov--Scribd` | 36 | 36 | scraped page titles |
+  | `Listening-to-Arcane-Kingdom-Online-Dark-Magic-by-Jakob-Tanner--Scribd` | 27 | 27 | scraped page titles |
+  | `The Light We Lost` | 25 | 25 | one novel |
+  | `Arkady Martine - A Desolation Called Peace` | 12 | 12 | one novel |
+  | `Dragon Born`, `Warbreaker`, `Guardian`, `Otherworld Academy`, … | ~18 | ~24 | **genuine** |
+
+  🔴 **Do not resolve this by applying `applyMedium`.** That would manufacture an
+  80-volume "Catalyst Gate" series out of a single book, and a 36-volume series
+  out of a Scribd listing page. The denumber op deliberately holds them; the
+  parser is behaving correctly, the *shape* is a lie.
+
+  These belong to the **combine-into-one-book** track (The Successors class), not
+  the series track: a bracketed `(47)` on a novel title is a disc/chunk marker
+  that leaked into the series field. The `Listening-to-…--Scribd` rows are a
+  distinct, narrower bug — a web scrape wrote page titles into series names, and
+  those need their own cleanup rather than any kind of merge.
+
+  Start from the report:
+  `/var/lib/audiobook-organizer/series-denumber-2026-08-06.tsv`
+  (`shape=bracketed`, group by `into_name`, anything with >3 rows is suspect).

--- a/todo.d/20260806_093100_series_denumber_low_tier_consumer.md
+++ b/todo.d/20260806_093100_series_denumber_low_tier_consumer.md
@@ -1,0 +1,30 @@
+<!-- file: todo.d/20260806_093100_series_denumber_low_tier_consumer.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c1e84b76-3d29-4f05-a917-6b2508fd3e14 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **Give the 466 low-confidence series positions somewhere to go** — deferred
+  deliberately on 2026-08-06 (owner decision), revisit after owner items 1 and 2.
+
+  `maintenance.series-denumber` now reports 466 series names carrying a bare
+  number (`08. Battle for the Abyss` → position 8, `Station 64: The Doll Dungeon`
+  → position 64) covering ~580 books. They are correct often enough to be worth
+  surfacing and wrong often enough that they can never apply themselves —
+  `86—EIGHTY-SIX` is a real series name in this library with the identical shape.
+
+  Today they exist only in the `reportPath` TSV. Nothing consumes them.
+
+  🔑 **Why no review-queue Kind was built yet:** a new Kind needs frontend
+  mapping, and `review_apply_enabled` is OFF in production, so approving such a
+  hold would mutate nothing. Wiring these in only makes sense once holds have
+  real per-item actions — i.e. after owner item 1 (recommendations) and item 2
+  (overrides). Doing it in that order avoids building a producer for a consumer
+  that cannot act.
+
+  Note for whoever picks this up: for `08. Battle for the Abyss` the parsed base
+  is `Battle for the Abyss` — the BOOK's title. The real series (`Horus Heresy`)
+  is not present in the string at all. So the low tier cannot be resolved by
+  better parsing; it needs evidence from outside the name (sibling books sharing
+  a folder/author with different leading numbers — spec D4, unbuilt), or a human.
+
+  Design: [`docs/specs/2026-08-06-series-embedded-positions-design.md`].


### PR DESCRIPTION
Follow-up to #2156. Docs and task-tracking only — no code.

## Applied to production

`maintenance.series-denumber` high tier: **25 series merged into 21 base series, 52 books given a real series position, 11 base series created, 25 emptied deleted, 0 failures.**

Verified by re-running the dry run afterwards:

| | total | eligible | high | medium | low |
|---|---:|---:|---:|---:|---:|
| before | 689 | 25 (52 books) | 25 | 198 | 466 |
| after | 664 | **0** | **0** | 198 | 466 |

Exactly −25, everything else untouched. Idempotent.

## Acceptance gate, against real data

- 689 candidates — under the 982 ceiling, as predicted (that figure counted raw name shapes before the junk guard and tier filtering)
- **zero** candidates whose base fails `IsJunkSeriesBase`
- **zero** low-confidence rows in the apply set
- `86—EIGHTY-SIX` absent from the candidate set — and the check is **not vacuous**: it exists in production in three variants (`86—EIGHTY-SIX`, `86—EIGHTY`, `86--EIGHTY-SIX`), alongside `5-Minute Sherlock` and `96 Hours`

## What the dry run caught

The medium tier is 198 bracketed rows. Plan step 5 would have applied them. They are **not series positions** — ~180 are one shattered book each:

| Target base | Rows | Reality |
|---|---:|---|
| `Megan E. O'Keefe - Catalyst Gate` | 80 | one novel |
| `Listening-to-ClassA-Threat-…-Scribd` | 36 | scraped page titles |
| `Listening-to-Arcane-Kingdom-Online-…-Scribd` | 27 | scraped page titles |
| `The Light We Lost` | 25 | one novel |
| `Arkady Martine - A Desolation Called Peace` | 12 | one novel |
| `Dragon Born`, `Warbreaker`, `Guardian`, … | ~18 | **genuine** |

Applying `applyMedium` would have manufactured an **80-volume "series" out of a single novel**. Defaulting to the spec's stricter reading rather than the plan's is what stopped it.

The parser is behaving correctly here — a bracketed `(47)` on a novel title is a disc/chunk marker that leaked into the series field. Recorded as its own task on the combine-into-one-book track (The Successors class). The `Listening-to-…--Scribd` rows are a separate, narrower bug: a web scrape wrote page titles into series names.

## Low tier

466 rows stay report-only, per owner decision. A review Kind needs frontend mapping and `review_apply_enabled` is off in production, so an approved hold would mutate nothing. Revisit after owner items 1 and 2 give holds real per-item actions.

Worth recording for whoever picks it up: for `08. Battle for the Abyss` the parsed base is `Battle for the Abyss` — the *book's* title. The real series (`Horus Heresy`) is not in the string at all. So this tier cannot be fixed by better parsing; it needs evidence from outside the name, or a human.

## Contents

- `TODO.md` — owner item 4 checked off with the applied numbers (direct edit; checking off is not a fragment operation)
- `todo.d/` — two fragments: the shattered-book discovery, and the low-tier consumer
- `changelog.d/` — production apply record
- `docs/executive-summaries/2026-08-06-…` — plain-language write-up. Qualifies on two counts: closes out a tracked owner item end to end, and the medium-tier near-miss is the silent-corruption class these summaries exist to explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2fEU5ud6uWagzKbUYAPRK