### PR TITLE
deps(security): bump postcss to 8.5.26 and grpc to v1.82.1

### DIFF
--- a/changelog.d/20260806_120000_deps_postcss_grpc_advisories.md
+++ b/changelog.d/20260806_120000_deps_postcss_grpc_advisories.md
@@ -1,0 +1,32 @@
+<!-- file: changelog.d/20260806_120000_deps_postcss_grpc_advisories.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c5e1abb4-d9dc-4230-a186-e4e1e25e649e -->
+<!-- last-edited: 2026-08-06 -->
+
+### Security
+
+- **Closed two high-severity Dependabot alerts: `postcss` and
+  `google.golang.org/grpc`.** Both are dependencies we never import directly, so
+  neither bump changes a single line of our own code — but both were flagged
+  against ranges the repository was sitting inside.
+
+  `postcss` reached us transitively through Vite's build pipeline, pinned at
+  `8.5.15` against a vulnerable range of `<= 8.5.17`. `npm update postcss`
+  resolves it to `8.5.26`, comfortably inside the `^8.5.6` range Vite already
+  asks for, so no `overrides` entry was needed and Vite's own dependency
+  contract is untouched. The same update carried `nanoid` from `3.3.12` to
+  `3.3.17` as a side effect — postcss depends on it, and npm refreshed it while
+  it was in the tree.
+
+  `google.golang.org/grpc` moved `v1.81.1` → `v1.82.1` (first patched version).
+  It is an indirect dependency, arriving via the OpenTelemetry OTLP trace
+  exporter and grpc-gateway; nothing in this repository imports it. Worth noting
+  because it was the one real risk in this change: grpc `v1.82.1` declares
+  `go 1.25.0`, so on a module still pinned to an older Go it would have silently
+  rewritten the `go`/`toolchain` directives and turned a dependency patch into a
+  language-version bump. `go.mod` already declares `go 1.26.0`, so it did not —
+  `go mod tidy` produced a clean one-line change with no cascade into the otel
+  or grpc-gateway versions.
+
+  These are the two advisories with no API surface to review, deliberately split
+  from the React Router `v6 → v7` major bump that closes the remaining alerts.

--- a/go.mod
+++ b/go.mod
@@ -158,6 +158,6 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4573,9 +4573,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -4867,9 +4867,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4886,7 +4886,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Closes the two **high**-severity Dependabot alerts that need no API review. The React Router alerts are handled separately in a companion PR, because those require a major version bump.

## Alerts closed (2)

| severity | package | installed | vulnerable range | first patched | now |
|---|---|---|---|---|---|
| high | `postcss` | 8.5.15 (transitive) | `<= 8.5.17` | 8.5.18 | **8.5.26** |
| high | `google.golang.org/grpc` | v1.81.1 (indirect) | `< 1.82.1` | 1.82.1 | **v1.82.1** |

Neither package is imported by any first-party code, so no application code changes.

## Notes

**postcss** arrives transitively through Vite's build pipeline. `npm update postcss` resolves 8.5.26, which is inside the `^8.5.6` range Vite already requests — so no `overrides` entry was needed and Vite's own dependency contract is untouched. `nanoid` moved 3.3.12 → 3.3.17 alongside it as postcss's own dependency.

**grpc** was the one real risk here. v1.82.1 declares `go 1.25.0`; on a module pinned to an older Go, `go get` would have silently rewritten the `go`/`toolchain` directives and turned a dependency patch into a language-version bump. `go.mod` already declares `go 1.26.0`, so it did not — `go mod tidy` produced a clean one-line change with no cascade into the otel or grpc-gateway versions:

```diff
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
```

## Verification

`make build-api`:
```
🔨 Building audiobook-organizer (API only)...
✅ Built ./audiobook-organizer
```

`make web-build` (the Go binary embeds `web/dist` via `//go:embed`, so a broken frontend build breaks the backend build too):
```
dist/assets/mui-lCLIrHtA.js                  453.70 kB │ gzip: 136.49 kB │ map: 2,319.23 kB
✓ built in 6.62s
✅ Frontend built (web/dist)
```

`make test-short` (`go test ./... -short -race`) — result posted in a comment below.

`npm audit` confirms the postcss high-severity entry is gone from the report.

## Merge-order note

This PR and the React Router PR both modify `web/package-lock.json` and will conflict on rebase. Whichever merges second needs `npm install` re-run to regenerate the lockfile.

## Not addressed

`npm audit` also reports a **high** on `brace-expansion` (4.0.0–5.0.8, two DoS advisories). The repo's existing `overrides` pin is `"brace-expansion": "^5.0.7"`, which resolves inside the vulnerable range. This is **not** one of the five tracked Dependabot alerts and is left alone deliberately rather than scope-creeping this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp