### PR TITLE
deps(security): upgrade React Router v6.30.4 -> v7.18.2

### DIFF
--- a/changelog.d/20260806_130000_react_router_v7_advisories.md
+++ b/changelog.d/20260806_130000_react_router_v7_advisories.md
@@ -1,0 +1,39 @@
+<!-- file: changelog.d/20260806_130000_react_router_v7_advisories.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f1b1c5d5-a99d-45f2-b686-07f3b4f17d0a -->
+<!-- last-edited: 2026-08-06 -->
+
+### Security
+
+- **Upgraded React Router from `v6.30.4` to `v7.18.2`, closing three open
+  Dependabot alerts.** Two are open-redirect class — a `to=`/`navigate()`
+  target beginning with a backslash could escape to an external origin
+  (GHSA-wrjc-x8rr-h8h6), plus an arbitrary-constructor injection in SSR
+  hydration (GHSA-337j-9hxr-rhxg). The third alert, against `react-router-dom`
+  `6.30.2`–`6.30.4`, has **no 6.x patch at all** — its "first patched version"
+  is null. That is what forced a major bump rather than a point release: there
+  was no version of the 6 line left to move to.
+
+  Despite being a major, this is a small change, because the app only ever used
+  the classic declarative API — `BrowserRouter`, `MemoryRouter`, `Routes`,
+  `Route`, `Link`, `Navigate`, `useLocation`, `useNavigate`, `useParams`,
+  `useSearchParams`. v7 keeps all of them with unchanged signatures, and
+  `react-router-dom` still exists as a re-export package, so all **49** files
+  importing from `'react-router-dom'` were left untouched. None of the
+  data-router APIs (`createBrowserRouter`, `RouterProvider`, `useLoaderData`,
+  loaders/actions) are in use — that is the part of a v6→v7 migration that
+  actually hurts, and it does not apply here.
+
+  The one thing that did need changing: v7 **removes the `future` prop** from
+  `BrowserRouter`/`MemoryRouter`, because the flags it used to gate are now the
+  permanent behavior. The repository had already opted into
+  `v7_startTransition` and `v7_relativeSplatPath` at all 18 call sites across
+  11 files, so deleting the prop is a semantic no-op — the app was already
+  running the v7 routing semantics under v6. That earlier opt-in is the reason
+  this bump carries no behavioral risk; the routing change everyone fears from
+  v6→v7 had already been absorbed and shipped.
+
+  Also verified there are no relative `..` links beneath a splat route, the one
+  pattern `v7_relativeSplatPath` changes the meaning of. The single splat route
+  (`path="*"` → `<Navigate to="/login" replace />`) navigates to an absolute
+  path.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,7 @@
         "esbuild": "0.28.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.2",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -1481,14 +1481,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2882,6 +2874,18 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -5036,33 +5040,39 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {
@@ -5257,6 +5267,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "esbuild": "0.28.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.2",
     "zustand": "^4.4.7"
   },
   "overrides": {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/App.test.tsx
-// version: 1.0.9
+// version: 1.0.10
 // guid: 9a0b1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d
-// last-edited: 2026-06-24
+// last-edited: 2026-08-06
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -72,7 +72,7 @@ beforeEach(() => {
 describe('App', () => {
   it('renders without crashing', async () => {
     render(
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <BrowserRouter>
         <ThemeProvider theme={theme}>
           <AuthProvider>
             <App />
@@ -86,7 +86,7 @@ describe('App', () => {
 
   it('renders navigation items', async () => {
     render(
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <BrowserRouter>
         <ThemeProvider theme={theme}>
           <AuthProvider>
             <App />

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,6 @@
 // file: web/src/main.tsx
-// version: 1.4.0
+// version: 1.4.1
+// last-edited: 2026-08-06
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
 
 import React, { useMemo } from 'react';
@@ -20,9 +21,7 @@ function AppRoot() {
 
   const app = (
     <ErrorBoundary>
-      <BrowserRouter
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
+      <BrowserRouter>
         <ThemeProvider theme={theme}>
           <CssBaseline />
           <AuthProvider>

--- a/web/src/pages/BookDetail.files-history.test.tsx
+++ b/web/src/pages/BookDetail.files-history.test.tsx
@@ -1,5 +1,6 @@
 // file: web/src/pages/BookDetail.files-history.test.tsx
-// version: 1.1.0
+// version: 1.1.1
+// last-edited: 2026-08-06
 // guid: e6be4c8c-534d-44aa-bcb7-9089a8796df4
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -95,7 +96,6 @@ describe('BookDetail Files & History', () => {
     render(
       <MemoryRouter
         initialEntries={['/library/book-1?tab=files']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <Routes>
           <Route path="/library/:id" element={<BookDetail />} />

--- a/web/src/pages/BookDetail.hash-chain.test.tsx
+++ b/web/src/pages/BookDetail.hash-chain.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDetail.hash-chain.test.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: 4b2d9f7e-1c3a-4e5b-8a6d-9f0e1c2d3b4a
-// last-edited: 2026-07-11
+// last-edited: 2026-08-06
 
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -99,7 +99,6 @@ function setup(files: api.BookFile[]) {
   return render(
     <MemoryRouter
       initialEntries={['/library/book-1?tab=files']}
-      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Routes>
         <Route path="/library/:id" element={<BookDetail />} />

--- a/web/src/pages/BookDetail.race.test.tsx
+++ b/web/src/pages/BookDetail.race.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDetail.race.test.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: 7c1d9e2a-4f5b-4a6c-9d3e-2b8f7a1c0e6d
-// last-edited: 2026-07-13
+// last-edited: 2026-08-06
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
@@ -64,7 +64,6 @@ describe('BookDetail load race (BOOKDETAIL-RACE)', () => {
     render(
       <MemoryRouter
         initialEntries={['/library/book-a']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <NavCapture />
         <Routes>

--- a/web/src/pages/BookDetail.unlock.test.tsx
+++ b/web/src/pages/BookDetail.unlock.test.tsx
@@ -1,5 +1,6 @@
 // file: web/src/pages/BookDetail.unlock.test.tsx
-// version: 1.3.0
+// version: 1.3.1
+// last-edited: 2026-08-06
 // guid: 2b197bb0-4a61-49ef-8b75-1f9c6c23c84e
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -57,7 +58,6 @@ describe('BookDetail override unlock', () => {
     render(
       <MemoryRouter
         initialEntries={['/library/book-1']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <Routes>
           <Route path="/library/:id" element={<BookDetail />} />

--- a/web/src/pages/Library.bulkFetch.test.tsx
+++ b/web/src/pages/Library.bulkFetch.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.bulkFetch.test.tsx
-// version: 1.5.0
+// version: 1.5.1
 // guid: 5b7b0d6f-5c2b-4d57-9b6c-8dbb7a9e9e2c
-// last-edited: 2026-07-01
+// last-edited: 2026-08-06
 
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -86,9 +86,7 @@ describe('Library bulk metadata fetch', () => {
   it('triggers bulk fetch when confirmed', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );
@@ -123,9 +121,7 @@ describe('Library bulk metadata fetch', () => {
   it('triggers bulk save to files when confirmed', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );

--- a/web/src/pages/Library.importFile.test.tsx
+++ b/web/src/pages/Library.importFile.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.importFile.test.tsx
-// version: 1.6.0
+// version: 1.6.1
 // guid: 6f4a7b0d-9c9f-4f0b-8d85-1dd9e1ffb913
-// last-edited: 2026-07-01
+// last-edited: 2026-08-06
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -104,7 +104,7 @@ afterEach(() => {
 describe('Library import dialog', () => {
   it('imports a selected file path', async () => {
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );
@@ -134,7 +134,7 @@ describe('Library import dialog', () => {
     const getBooksMock = vi.mocked(api.getBooks);
 
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );
@@ -175,7 +175,7 @@ describe('Library import dialog', () => {
     // while still letting us fast-forward the app's 1500ms reload timers.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );

--- a/web/src/pages/Library.resetNavigation.test.tsx
+++ b/web/src/pages/Library.resetNavigation.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.resetNavigation.test.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: 4c8b1a2d-9e3f-4a7b-8c1d-2e3f4a5b6c7d
-// last-edited: 2026-07-11
+// last-edited: 2026-08-06
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
@@ -79,7 +79,6 @@ describe('Library reset navigation (/library?reset=1)', () => {
     render(
       <MemoryRouter
         initialEntries={['/library?tag=metadata']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <ResetNavButton />
         <Library />
@@ -115,7 +114,6 @@ describe('Library reset navigation (/library?reset=1)', () => {
     render(
       <MemoryRouter
         initialEntries={['/library?search=foo']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
       >
         <ResetNavButton />
         <Library />

--- a/web/src/pages/Library.savedFilterPresets.test.tsx
+++ b/web/src/pages/Library.savedFilterPresets.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/Library.savedFilterPresets.test.tsx
-// version: 1.0.0
+// version: 1.0.1
 // guid: e7f8a9b0-c1d2-4e3f-8a9b-0c1d2e3f4a5b
-// last-edited: 2026-07-01
+// last-edited: 2026-08-06
 
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -75,7 +75,7 @@ describe('Library saved filter presets', () => {
   it('applying a saved preset updates the active filters', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );
@@ -95,7 +95,7 @@ describe('Library saved filter presets', () => {
   it('saving the current filters as a new preset persists it', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );
@@ -125,7 +125,7 @@ describe('Library saved filter presets', () => {
   it('deleting a preset removes it from the list', async () => {
     const user = userEvent.setup();
     render(
-      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter>
         <Library />
       </MemoryRouter>
     );

--- a/web/src/test/renderWithProviders.tsx
+++ b/web/src/test/renderWithProviders.tsx
@@ -1,5 +1,6 @@
 // file: web/src/test/renderWithProviders.tsx
-// version: 1.1.0
+// version: 1.1.1
+// last-edited: 2026-08-06
 
 import React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
@@ -26,7 +27,7 @@ export function renderWithProviders(
 
   function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <MemoryRouter initialEntries={initialEntries} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <MemoryRouter initialEntries={initialEntries}>
         <ThemeProvider theme={testTheme}>{children}</ThemeProvider>
       </MemoryRouter>
     );


### PR DESCRIPTION
Closes the three remaining Dependabot alerts. Split from #2159 (postcss + grpc) because this is a **major** version bump and deserves its own review.

## Alerts closed (3)

| severity | package | vulnerable range | first patched | now |
|---|---|---|---|---|
| medium | `react-router` (GHSA-wrjc-x8rr-h8h6) | `>=6.0.0, <7.18.0` | 7.18.0 | **7.18.2** |
| medium | `react-router` (GHSA-337j-9hxr-rhxg) | `>=6.4.0, <7.18.0` | 7.18.0 | **7.18.2** |
| medium | `react-router-dom` | `>=6.30.2, <=6.30.4` | **null** | **7.18.2** |

> ⚠️ **This bump also introduces one NEW high-severity advisory** (RSC-mode CSRF, not reachable in this SPA and not closable without React 19). Net alert change is **−3 / +1** — see [the section at the bottom](#) before merging.

That third row is why this is a major bump rather than a point release: its first-patched-version is **null**. There is no version of the 6.x line left to move to.

## Why a major bump is a small diff here

The app only ever used the classic declarative API — `BrowserRouter`, `MemoryRouter`, `Routes`, `Route`, `Link`, `Navigate`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams`. v7 keeps every one of them with unchanged signatures, and `react-router-dom` still exists in v7 as a re-export package. **All 49 files importing from `'react-router-dom'` are untouched.**

None of the data-router APIs (`createBrowserRouter`, `RouterProvider`, `useLoaderData`, loaders/actions) are in use. That is the part of a v6→v7 migration that actually hurts, and it does not apply to this codebase.

## The one incompatibility — a pure deletion

`tsc` flagged exactly **18 errors across 11 files**, all the same class:

```
src/main.tsx(24,9): error TS2322: Property 'future' does not exist on type
  'IntrinsicAttributes & BrowserRouterProps'.
```

v7 **removes** the `future` prop from `BrowserRouter`/`MemoryRouter`, because the flags it used to gate are now permanent behavior. This repo had **already opted into** `v7_startTransition` and `v7_relativeSplatPath` at all 18 call sites — so deleting the prop is a semantic no-op. The app was already running v7 routing semantics under v6, which is precisely why this bump carries no behavioral risk: the routing change everyone fears from v6→v7 had already been absorbed and shipped.

```diff
-      <BrowserRouter
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
+      <BrowserRouter>
```

Also verified: **no relative `..` links sit beneath a splat route**, the one pattern `v7_relativeSplatPath` changes the meaning of. The single splat route (`App.tsx:234`, `path="*"` → `<Navigate to="/login" replace />`) navigates to an absolute path.

The diff was kept surgical on purpose — an initial pass ran Prettier over the touched files, which reformatted ~90 unrelated lines to a different line width than what is committed. That was reverted; the final diff is 12 insertions / 24 deletions and contains nothing but the prop removal.

## Verification

`tsc --noEmit` — **0 errors** (18 before the prop removal).

`make web-build`:
```
dist/assets/mui-BUpWQSW3.js                  453.70 kB │ gzip: 136.49 kB │ map: 2,319.23 kB
✓ built in 6.22s
✅ Frontend built (web/dist)
```

`make web-test`:
```
 RUN  v4.1.10 .../.worktrees/deps-react-router-v7/web

 Test Files  62 passed (62)
      Tests  402 passed (402)
   Duration  36.43s

✅ Frontend tests passed
```

`make web-lint`: `✖ 24 problems (0 errors, 24 warnings)` — all pre-existing `no-explicit-any` / `react-refresh` warnings, none in touched files.

### E2E: attempted, no signal — the suite is broken on `main`

`make test-e2e` was run. Every test errors at fixture-collection time, before any routing executes:

```
beforeEach hook has unknown parameter "_page".

> 354 |   test.beforeEach(async ({ _page }) => {
      |        ^
```

**This is pre-existing and unrelated.** Confirmed empirically: running `--list` against the *unmodified* specs on the react-router **v6** tree produces the identical **49** errors. This PR touches **0** files under `web/tests/`. The e2e suite gives no signal either way here and needs a separate fix (`_page` is not a valid Playwright fixture name).

## Security note — the version bump is not the whole answer

Two of these advisories are open-redirect class, so I audited whether user-controlled input actually reaches a navigation target. **No exploitable sink exists today**, front or back — the Go side implements the exact backslash guard the advisory describes (`sanitizeReturn`, `oauth_login.go:260-271`). But two frontend sinks are structurally unvalidated and merely *unreachable*, each resting on an invariant a future change could silently break:

1. **`web/src/pages/Login.tsx:78-81`** — `location.state?.from` flows unvalidated into `navigate()` (`:93`, `:106`). No leading-slash check, no backslash rejection. Currently safe only because **nothing in the app ever writes `state.from`** (zero writers found), so it is always the `'/dashboard'` literal. Wire `from` to a query param and it is immediately exploitable with no other change.
2. **`web/src/pages/BookDetail.tsx:938,968`** — `sessionStorage.getItem('library_return_url')` → `navigate(returnUrl)`, unvalidated at the sink. Safe only because the writer (`Library.tsx:1162-1165`) runs on the **exact** routes `/library` and `/fingerprints` (`App.tsx:242-243`), so the stored path can never start `//` or `/\`. Changing that to a splat route (`/library/*`) would silently make it exploitable.

Both are worth a `sanitizeReturn`-equivalent guard. Deliberately **not** fixed here — that is app-level hardening, not a dependency bump. The tracked OAuth-callback TODO (`TODO.md:1040`) is a functional gap, not a vulnerability: it is the guard correctly rejecting a custom-scheme return, and should not be "fixed" by loosening `sanitizeReturn`.

## Merge-order note

This PR and #2159 both modify `web/package-lock.json` and will conflict on rebase. Whichever merges second needs `npm install` re-run to regenerate the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp

---

## ⚠️ This bump introduces one NEW advisory — read before merging

`npm audit` on this branch confirms the three target advisories are gone (no `react-router` open-redirect or SSR-hydration entries remain). But v7.18.2 falls inside the range of a **newer, high-severity** advisory that did not affect v6:

```
react-router  7.12.0 - 8.2.0
Severity: high
React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response
  - https://github.com/advisories/GHSA-qwww-vcr4-c8h2
```

**There is no version that closes all four.** The three original advisories are first patched in `7.18.0`; this new one affects everything from `7.12.0` through `8.2.0`. The only fixed version is **`8.3.0`**, and v8 is not reachable from here:

- `react-router@8.3.0` requires `react >= 19.2.7` / `react-dom >= 19.2.7`. This repo is on `react@^18.2.0` — closing it means a React 18 → 19 upgrade.
- **`react-router-dom` does not exist at 8.x** (`npm view react-router-dom@8.3.0` → E404). v8 drops the compat package, so all **49** import sites would have to be rewritten from `'react-router-dom'` to `'react-router'`.

**It is not exploitable in this app.** The advisory is scoped to **RSC (React Server Components) mode**, which requires explicit opt-in via framework mode. This app is a pure client-side SPA: `BrowserRouter` + declarative `<Routes>`, no `@react-router/*` framework packages, no `react-server` entry, no server-side action handling. Verified by grep — zero hits for `@react-router/`, `react-server`, `unstable_RSC`, `createStaticHandler`, or `renderToPipeableStream`.

**Net effect on the alert count: −3, +1.** Trading three advisories (two of them open-redirect class, one with no patch available at all on the 6.x line) for one non-applicable RSC-mode advisory is a clear improvement, but Dependabot will open the new one, so it should not come as a surprise. Closing it properly is a React 19 migration and belongs in its own tracked piece of work.

### Also visible in this branch's audit: postcss

`npm audit` here also reports `postcss <= 8.5.22` (high). That is **not** a regression from this PR — this branch is cut from `main`, which still has postcss `8.5.15`. #2159 raises it to `8.5.26`, above the affected range. It resolves once both PRs land.
