### PR TITLE
perf(database): batch book_file deletes to one commit and one notify per book

### DIFF
--- a/changelog.d/20260806_150000_delete_book_files_batch.md
+++ b/changelog.d/20260806_150000_delete_book_files_batch.md
@@ -1,5 +1,5 @@
 <!-- file: changelog.d/20260806_150000_delete_book_files_batch.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 8e5b3db9-c5ac-40b2-88a9-3b387e21cabf -->
 <!-- last-edited: 2026-08-06 -->
 
@@ -40,10 +40,20 @@
   store disagrees with the store, and a disagreement discovered partway through a
   destructive operation is the worst possible moment to press on with the other N−1
   rows. That is this repo's dominant incident shape: write-backs that proceeded on a
-  stale view and silently erased fields. Fail-closed is cheap here specifically because
-  both callers re-read their row set from the store on every run, so a stale ID is
-  simply absent from the next run's list and the deferred work completes then — nothing
-  is lost, at most one batch slips by one run.
+  stale view and silently erased fields.
+
+  **How cheap fail-closed is depends on where the caller got its IDs, and that is not
+  uniform.** `dedupe-book-file-rows` re-reads its rows from Pebble (`GetBookFiles`) every
+  run, so a stale ID is simply absent next time — genuinely self-healing, at most one
+  batch slips by one run. `orphan-book-files-cleanup` does **not** have that property:
+  its list comes from `GetAllBookFilesCore`, which is served from memdb whenever
+  `UseMemDB` is on. memdb is a derived cache that can hold a row Pebble no longer has,
+  so a phantom row yields an ID that can never resolve, and plain fail-closed would abort
+  the same 500-row chunk on every nightly run until the process restarts and memdb
+  rebuilds — strictly worse than the per-row loop it replaced, which skipped the phantom
+  and deleted the other 499. That caller therefore keeps an explicit degraded path (see
+  below). The rule for new callers: fail-closed is the right default for a batch, but if
+  your IDs come from a cache rather than from Pebble, you need a fallback.
 
   Both of `DeleteBookFile`'s lookup paths are preserved (the `book_file_id` index first,
   then the legacy full scan). The scan fallback matters *more* under fail-closed than it
@@ -74,20 +84,30 @@
 - `maintenance.orphan-book-files-cleanup` deletes through the same batched method, in
   chunks of 500. Unlike `dedupe-book-file-rows` this path has **no** trailing
   `RecomputeBookAggregates` of its own, so it depends entirely on the batch method
-  notifying once per affected book. Chunking bounds the blast radius of a single
-  unresolvable ID to one chunk — which the next run picks up anyway, since the orphan
-  scan rebuilds its list from scratch — and preserves the cancellation check and
-  progress tick that the per-row loop provided for free, the latter being what keeps the
-  stuck-op watchdog fed on a multi-thousand-row sweep.
+  notifying once per affected book. (In practice a genuine orphan's owning book does not
+  exist — that is what makes it an orphan — so the recompute finds no book and returns
+  early. The notification still has to be issued, because orphanhood is decided from a
+  snapshot and a book that turns out to exist after all must have its totals corrected.)
+
+  A chunk the store rejects is retried **row by row** through `DeleteBookFile`, which
+  tolerates "already gone" by design. This is the degraded path that keeps a phantom
+  memdb row from wedging the same 500 rows on every nightly run; it is slow — precisely
+  the per-row cost the batch exists to avoid — but it only runs on the chunk that hit
+  the anomaly, and it makes progress instead of deadlocking. That fallback stamps
+  progress per row rather than per chunk: at ~1.35 s/row a 500-row recovery is ~11
+  minutes, well past the registry's 5-minute default `ProgressTimeout`, which this op
+  does not override, so without a per-row stamp the watchdog would cancel the op
+  mid-recovery.
 
 - `PebbleStore.DeleteBookFilesFromMemDB` batches N memdb row deletions into one write
   transaction. The saving is not transaction bookkeeping — it is the contention removed
   from every other writer in the process, since go-memdb serialises all writers behind a
   single global mutex.
 
-  Ten tests cover this: the notification count per affected book (asserted against a
+  Eleven tests cover this: the notification count per affected book (asserted against a
   control test that shows the per-row path still producing one snapshot per row, so the
   "exactly one" figure is anchored rather than vacuous), fail-closed behaviour leaving
   every row intact, secondary-index teardown, duplicate and empty ID handling, the
   salvage-failure ordering rule with a control book that must still collapse, and the
-  orphan path's chunking and per-chunk failure isolation.
+  orphan path's chunking plus the row-by-row recovery of a rejected chunk (asserting the
+  499 real orphans in it actually get deleted, not merely that the run continues).

--- a/changelog.d/20260806_150000_delete_book_files_batch.md
+++ b/changelog.d/20260806_150000_delete_book_files_batch.md
@@ -1,0 +1,93 @@
+<!-- file: changelog.d/20260806_150000_delete_book_files_batch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8e5b3db9-c5ac-40b2-88a9-3b387e21cabf -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- `Store.DeleteBookFilesByIDs(ids []string) error` — deletes many `book_file` rows in
+  **one** Pebble batch with one `Sync` commit, **one** go-memdb write transaction, and
+  **one** aggregate recompute per affected book, however many rows are being removed.
+
+  **This closes out the question the previous `DeleteBookFile` change left open.** That
+  entry noted the per-delete cost was dominated by "fixed overhead (the `Sync` commit
+  and the change notification)" and that the real cost of
+  `maintenance.dedupe-book-file-rows` was "still unattributed". It is now attributed,
+  and it was the change notification. The op cost **~1.35 s per deleted row** of fixed
+  overhead, with only ~7 ms of it scaling with the book's remaining file count. Per-row
+  deltas stayed flat — 1.85 / 1.94 / 1.42 / 1.66 / 1.54 s — while the book's
+  `total_files` fell from 65 to 34, which is what rules out an O(R²) walk and pins the
+  cost on per-**book** work being run once per **row**. Across the 2,901 redundant rows
+  on production that is roughly 1.3 hours of almost pure waste.
+
+  Per deleted row, `DeleteBookFile`'s `notifyBookFileChange` →
+  `RecomputeBookAggregates` → `UpdateBook` chain paid two `pebble.Sync` commits, one
+  full copy-on-write `book_ver:<id>:<nanos>` snapshot that re-marshals the *entire* old
+  `Book` just to record a changed duration, two go-memdb write transactions (each
+  queueing on memdb's single global writer mutex), and two reads of the book's file set
+  that both unmarshal `AcoustIDFingerprint` blobs neither one wants. None of that is
+  per-row work in principle. The new method hoists all of it out of the loop, following
+  the shape of the existing `DeleteBookFilesForBook`; the only real difference is that
+  the row set arrives as IDs, so the grouping by owning book has to be derived rather
+  than assumed.
+
+  **It is fail-closed.** Resolution happens in a first pass that mutates nothing, and if
+  *any* ID fails to resolve, nothing is deleted and the error names the offenders. This
+  deliberately diverges from `DeleteBookFile`, which treats an unresolvable ID as
+  "already gone" and returns `nil` — defensible for a single row, because nothing else
+  rides along and the caller's intent is fully satisfied by doing nothing, but not
+  defensible for a batch. An ID that does not resolve means the caller's view of the
+  store disagrees with the store, and a disagreement discovered partway through a
+  destructive operation is the worst possible moment to press on with the other N−1
+  rows. That is this repo's dominant incident shape: write-backs that proceeded on a
+  stale view and silently erased fields. Fail-closed is cheap here specifically because
+  both callers re-read their row set from the store on every run, so a stale ID is
+  simply absent from the next run's list and the deferred work completes then — nothing
+  is lost, at most one batch slips by one run.
+
+  Both of `DeleteBookFile`'s lookup paths are preserved (the `book_file_id` index first,
+  then the legacy full scan). The scan fallback matters *more* under fail-closed than it
+  did per-row: dropping it would turn pre-index rows that are merely slow to delete
+  today into rows that abort an entire batch.
+
+  `DeleteBookFile` itself is unchanged — other callers still rely on its per-row notify,
+  and a test asserts that its behaviour did not shift.
+
+### Changed
+
+- `maintenance.dedupe-book-file-rows` now accumulates each book's redundant row IDs and
+  deletes them in one batched call instead of one `DeleteBookFile` per row. The op
+  already ran a single `RecomputeBookAggregates` after its delete loop, so the per-row
+  notification was pure duplicated work here.
+
+  **The salvage write stays a separate, earlier commit, and must.** Rescued keeper
+  fields are persisted *before* the donor rows they came from are deleted, and a failed
+  salvage skips its group with the donors left intact. Folding that write into the
+  atomic delete batch would silently remove the escape: the group would commit both or
+  neither, and "neither" is indistinguishable from "nothing to do" on the next run, so a
+  keeper whose rescue failed could never be repaired from its twins again. Losing a
+  duration is recoverable; losing it while also deleting the only other copy is not.
+  Accumulating IDs across groups actually strengthens the ordering — every salvage in a
+  book commits before any donor in that book is deleted — and a group whose salvage
+  failed simply never enters the accumulator.
+
+- `maintenance.orphan-book-files-cleanup` deletes through the same batched method, in
+  chunks of 500. Unlike `dedupe-book-file-rows` this path has **no** trailing
+  `RecomputeBookAggregates` of its own, so it depends entirely on the batch method
+  notifying once per affected book. Chunking bounds the blast radius of a single
+  unresolvable ID to one chunk — which the next run picks up anyway, since the orphan
+  scan rebuilds its list from scratch — and preserves the cancellation check and
+  progress tick that the per-row loop provided for free, the latter being what keeps the
+  stuck-op watchdog fed on a multi-thousand-row sweep.
+
+- `PebbleStore.DeleteBookFilesFromMemDB` batches N memdb row deletions into one write
+  transaction. The saving is not transaction bookkeeping — it is the contention removed
+  from every other writer in the process, since go-memdb serialises all writers behind a
+  single global mutex.
+
+  Ten tests cover this: the notification count per affected book (asserted against a
+  control test that shows the per-row path still producing one snapshot per row, so the
+  "exactly one" figure is anchored rather than vacuous), fail-closed behaviour leaving
+  every row intact, secondary-index teardown, duplicate and empty ID handling, the
+  salvage-failure ordering rule with a control book that must still collapse, and the
+  orphan path's chunking and per-chunk failure isolation.

--- a/internal/database/delete_book_files_by_ids_test.go
+++ b/internal/database/delete_book_files_by_ids_test.go
@@ -1,0 +1,276 @@
+// file: internal/database/delete_book_files_by_ids_test.go
+// version: 1.0.0
+// guid: 4e7a1c92-3d58-4b6f-9a0e-2c8f5b1d7e43
+// last-edited: 2026-08-06
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// countBookVersions counts the book_ver:<bookID>:<nanos> copy-on-write snapshots
+// that exist for one book.
+//
+// WHY THIS IS THE MEASUREMENT. notifyBookFileChange is unexported and cannot be
+// mocked, so "was this book notified once or N times?" has to be observed through
+// something the notification leaves behind. Every notification that actually
+// changes an aggregate runs UpdateBook, and every UpdateBook writes exactly one
+// book_ver snapshot marshalling the whole old Book. So the snapshot delta across
+// a call IS the number of effective notifications — and it is also the single
+// most expensive artefact of the per-row path, which makes it the right thing to
+// be counting rather than a proxy for it.
+func countBookVersions(t *testing.T, s *PebbleStore, bookID string) int {
+	t.Helper()
+	prefix := fmt.Sprintf("book_ver:%s:", bookID)
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: []byte(prefix),
+		UpperBound: []byte(prefix + "\xff"),
+	})
+	if err != nil {
+		t.Fatalf("NewIter: %v", err)
+	}
+	defer iter.Close()
+	n := 0
+	for iter.First(); iter.Valid(); iter.Next() {
+		n++
+	}
+	return n
+}
+
+// seedBookWithFiles creates one book holding len(durations) rows, each at its own
+// path, and returns the book ID plus the row IDs in order.
+func seedBookWithFiles(t *testing.T, s *PebbleStore, title string, durations []int) (string, []string) {
+	t.Helper()
+	bk, err := s.CreateBook(&Book{Title: title})
+	if err != nil {
+		t.Fatalf("CreateBook(%s): %v", title, err)
+	}
+	ids := make([]string, 0, len(durations))
+	for i, d := range durations {
+		f := &BookFile{
+			BookID:   bk.ID,
+			FilePath: fmt.Sprintf("/lib/%s/track%02d.m4b", bk.ID, i),
+			Duration: d,
+			FileSize: int64(d) * 16000,
+		}
+		if err := s.CreateBookFile(f); err != nil {
+			t.Fatalf("CreateBookFile: %v", err)
+		}
+		ids = append(ids, f.ID)
+	}
+	return bk.ID, ids
+}
+
+func newBatchDeleteStore(t *testing.T) *PebbleStore {
+	t.Helper()
+	s, err := NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// 🔑 THIS IS THE FIX, AND THIS TEST IS THE PROOF OF IT.
+//
+// maintenance.dedupe-book-file-rows cost ~1.35s of FIXED overhead per deleted
+// row — flat per-row deltas (1.85/1.94/1.42/1.66/1.54s) while the book's file
+// count fell 65 → 34, which is what rules out an O(R²) walk and pins it on
+// per-row work that should have been per-book. Over 2,901 redundant production
+// rows that is ~1.3 hours.
+//
+// The single biggest component is the copy-on-write book_ver snapshot: one full
+// re-marshal of the entire Book, per deleted row. So the assertion is not "it
+// feels faster", it is a COUNT: three rows deleted across two books must produce
+// exactly one snapshot per affected book, never one per row.
+func TestDeleteBookFilesByIDs_NotifiesEachAffectedBookExactlyOnce(t *testing.T) {
+	s := newBatchDeleteStore(t)
+
+	// Durations are all distinct and non-zero so that removing rows genuinely
+	// changes each book's summed Duration/FileSize. This matters: RecomputeBook-
+	// Aggregates early-returns without writing when nothing changed, so a fixture
+	// whose totals happen to stay put would record a delta of 0 and pass this test
+	// vacuously — proving nothing about how many times it was called.
+	bookA, filesA := seedBookWithFiles(t, s, "Book A", []int{100, 200, 300})
+	bookB, filesB := seedBookWithFiles(t, s, "Book B", []int{400, 500})
+
+	beforeA := countBookVersions(t, s, bookA)
+	beforeB := countBookVersions(t, s, bookB)
+
+	// Two rows from A and one from B — deliberately interleaved so the grouping
+	// cannot be an accident of input ordering.
+	ids := []string{filesA[1], filesB[1], filesA[2]}
+	if err := s.DeleteBookFilesByIDs(ids); err != nil {
+		t.Fatalf("DeleteBookFilesByIDs: %v", err)
+	}
+
+	if got := countBookVersions(t, s, bookA) - beforeA; got != 1 {
+		t.Fatalf("book A: %d new book_ver snapshots after deleting 2 rows, want exactly 1 — "+
+			"the per-row notify is still in the loop", got)
+	}
+	if got := countBookVersions(t, s, bookB) - beforeB; got != 1 {
+		t.Fatalf("book B: %d new book_ver snapshots after deleting 1 row, want exactly 1", got)
+	}
+
+	// The rows must actually be gone, and the RIGHT ones.
+	filesLeftA, err := s.GetBookFiles(bookA)
+	if err != nil {
+		t.Fatalf("GetBookFiles(A): %v", err)
+	}
+	if len(filesLeftA) != 1 || filesLeftA[0].ID != filesA[0] {
+		t.Fatalf("book A: %d rows survived (%v), want exactly the untouched first row",
+			len(filesLeftA), filesLeftA)
+	}
+	filesLeftB, err := s.GetBookFiles(bookB)
+	if err != nil {
+		t.Fatalf("GetBookFiles(B): %v", err)
+	}
+	if len(filesLeftB) != 1 || filesLeftB[0].ID != filesB[0] {
+		t.Fatalf("book B: %d rows survived, want exactly the untouched first row", len(filesLeftB))
+	}
+
+	// Aggregates must reflect the survivors — batching must not cost correctness.
+	bkA, err := s.GetBookByID(bookA)
+	if err != nil {
+		t.Fatalf("GetBookByID(A): %v", err)
+	}
+	if bkA.Duration == nil || *bkA.Duration != 100 {
+		t.Fatalf("book A duration = %v, want 100 (the one surviving row)", bkA.Duration)
+	}
+}
+
+// The counterpart to the test above: the OLD path, on the SAME fixture, must
+// produce one snapshot PER ROW. Without this the "exactly 1" assertion above is
+// unanchored — a reader cannot tell whether 1 is a win or simply what this
+// fixture always produces.
+func TestDeleteBookFile_PerRowPathStillNotifiesPerRow(t *testing.T) {
+	s := newBatchDeleteStore(t)
+	bookID, fileIDs := seedBookWithFiles(t, s, "Per-row Book", []int{100, 200, 300})
+
+	before := countBookVersions(t, s, bookID)
+	for _, id := range fileIDs[1:] { // delete 2 rows, one call each
+		if err := s.DeleteBookFile(id); err != nil {
+			t.Fatalf("DeleteBookFile(%s): %v", id, err)
+		}
+	}
+	if got := countBookVersions(t, s, bookID) - before; got != 2 {
+		t.Fatalf("per-row path produced %d snapshots for 2 deletes, want 2 — "+
+			"DeleteBookFile's own behaviour must NOT have changed; other callers rely on it", got)
+	}
+}
+
+// FAIL-CLOSED. An ID that does not resolve means the caller's view of the store
+// disagrees with the store, and this is a DESTRUCTIVE operation. Nothing is
+// deleted, and the error names the offender.
+//
+// This deliberately differs from DeleteBookFile, which treats an unresolvable ID
+// as "already gone" and returns nil — defensible for one row because nothing else
+// rides along, indefensible for a batch. Both callers re-read their row sets from
+// the store on every run, so the deferred work simply happens on the next run.
+func TestDeleteBookFilesByIDs_FailsClosedOnUnresolvableID(t *testing.T) {
+	s := newBatchDeleteStore(t)
+	bookID, fileIDs := seedBookWithFiles(t, s, "Fail-closed Book", []int{100, 200, 300})
+
+	before := countBookVersions(t, s, bookID)
+
+	err := s.DeleteBookFilesByIDs([]string{fileIDs[0], "no-such-book-file-id", fileIDs[1]})
+	if err == nil {
+		t.Fatal("DeleteBookFilesByIDs returned nil for an unresolvable id, want an error")
+	}
+	if !strings.Contains(err.Error(), "no-such-book-file-id") {
+		t.Fatalf("error %q does not name the unresolvable id — an operator cannot act on it", err)
+	}
+
+	// NOTHING may have been deleted, including the two IDs that did resolve.
+	left, gerr := s.GetBookFiles(bookID)
+	if gerr != nil {
+		t.Fatalf("GetBookFiles: %v", gerr)
+	}
+	if len(left) != 3 {
+		t.Fatalf("%d rows survived a failed batch, want all 3 — fail-closed means "+
+			"the resolvable rows are spared too", len(left))
+	}
+	if got := countBookVersions(t, s, bookID) - before; got != 0 {
+		t.Fatalf("%d book_ver snapshots written by a batch that deleted nothing, want 0", got)
+	}
+}
+
+// Duplicate IDs in the input must not double-delete or double-notify. Callers
+// accumulate IDs across groups, so a duplicate is a plausible caller bug rather
+// than a theoretical one.
+func TestDeleteBookFilesByIDs_IgnoresDuplicateAndEmptyIDs(t *testing.T) {
+	s := newBatchDeleteStore(t)
+	bookID, fileIDs := seedBookWithFiles(t, s, "Dup-input Book", []int{100, 200, 300})
+
+	before := countBookVersions(t, s, bookID)
+	if err := s.DeleteBookFilesByIDs([]string{fileIDs[2], "", fileIDs[2]}); err != nil {
+		t.Fatalf("DeleteBookFilesByIDs: %v", err)
+	}
+	if got := countBookVersions(t, s, bookID) - before; got != 1 {
+		t.Fatalf("%d snapshots, want 1 — a repeated id was treated as a second row", got)
+	}
+	left, _ := s.GetBookFiles(bookID)
+	if len(left) != 2 {
+		t.Fatalf("%d rows survived, want 2", len(left))
+	}
+}
+
+// An empty ID list is a no-op, not an error: callers that accumulate IDs may
+// legitimately end a book with nothing to delete.
+func TestDeleteBookFilesByIDs_EmptyInputIsNoOp(t *testing.T) {
+	s := newBatchDeleteStore(t)
+	bookID, _ := seedBookWithFiles(t, s, "Empty-input Book", []int{100})
+	before := countBookVersions(t, s, bookID)
+
+	if err := s.DeleteBookFilesByIDs(nil); err != nil {
+		t.Fatalf("DeleteBookFilesByIDs(nil) = %v, want nil", err)
+	}
+	if got := countBookVersions(t, s, bookID) - before; got != 0 {
+		t.Fatalf("%d snapshots written for an empty batch, want 0", got)
+	}
+}
+
+// Secondary indexes must be torn down by the batch path exactly as they are by
+// the per-row path. A row whose primary key is gone but whose book_file_id index
+// entry survives is precisely the state that makes a LATER DeleteBookFilesByIDs
+// "resolve" a row that no longer exists.
+func TestDeleteBookFilesByIDs_RemovesSecondaryIndexes(t *testing.T) {
+	s := newBatchDeleteStore(t)
+	bk, err := s.CreateBook(&Book{Title: "Index Book"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	f := &BookFile{
+		BookID:             bk.ID,
+		FilePath:           "/lib/index/track01.m4b",
+		Duration:           600,
+		FileSize:           9600000,
+		ITunesPersistentID: "DEADBEEF12345678",
+		FileHash:           "sha256:indexhash",
+	}
+	if err := s.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+
+	if err := s.DeleteBookFilesByIDs([]string{f.ID}); err != nil {
+		t.Fatalf("DeleteBookFilesByIDs: %v", err)
+	}
+
+	if got, _ := s.GetBookFileByPID("DEADBEEF12345678"); got != nil {
+		t.Fatal("PID index entry survived the batch delete")
+	}
+	if got, _ := s.GetBookFileByPath("/lib/index/track01.m4b"); got != nil {
+		t.Fatal("path index entry survived the batch delete")
+	}
+	// The ID index is what DeleteBookFilesByIDs itself resolves through, so a
+	// stale entry here would let a second delete "find" a row that is gone.
+	if err := s.DeleteBookFilesByIDs([]string{f.ID}); err == nil {
+		t.Fatal("re-deleting an already-deleted id succeeded — the book_file_id " +
+			"index entry is stale, so resolution is lying about what exists")
+	}
+}

--- a/internal/database/iface_misc.go
+++ b/internal/database/iface_misc.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_misc.go
-// version: 1.20.1
+// version: 1.21.0
 // guid: 473781a7-1a31-4914-b7c7-8efc91f9f7e6
-// last-edited: 2026-07-12
+// last-edited: 2026-08-06
 
 package database
 
@@ -162,6 +162,16 @@ type BookFileStore interface {
 	GetBookFileByAcoustID(fingerprint string) (*BookFile, error)
 	GetBookFileByAcoustIDFuzzy(fingerprint string, minSimilarity float64) (*BookFile, error)
 	DeleteBookFile(id string) error
+	// DeleteBookFilesByIDs deletes many rows in one Pebble batch, one memdb
+	// transaction, and one aggregate recompute PER AFFECTED BOOK — as opposed to
+	// DeleteBookFile, which pays that entire fixed cost once per row (~1.35s/row
+	// measured on production). Prefer it for any caller deleting more than a
+	// couple of rows.
+	//
+	// Fail-closed: if ANY id does not resolve to a live row, nothing is deleted
+	// and an error naming the unresolved ids is returned. Chunk large id sets so
+	// one stale id defers only its own chunk.
+	DeleteBookFilesByIDs(ids []string) error
 	DeleteBookFilesForBook(bookID string) error
 	UpsertBookFile(file *BookFile) error
 	BatchUpsertBookFiles(files []*BookFile) error

--- a/internal/database/memdb_sync.go
+++ b/internal/database/memdb_sync.go
@@ -1,6 +1,7 @@
 // file: internal/database/memdb_sync.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000005
+// last-edited: 2026-08-06
 
 package database
 
@@ -153,6 +154,42 @@ func (p *PebbleStore) DeleteBookFileFromMemDB(fileID string) {
 		obj, err := txn.First(memTableBookFiles, memIdxID, fileID)
 		if err == nil && obj != nil {
 			return txn.Delete(memTableBookFiles, obj)
+		}
+		return nil
+	})
+}
+
+// DeleteBookFilesFromMemDB removes many book_file rows in ONE memdb write
+// transaction.
+//
+// WHY this exists rather than looping DeleteBookFileFromMemDB: go-memdb serialises
+// every writer behind a single global mutex, so N calls means N acquisitions of a
+// lock that every other writer in the process is also queuing on. Deleting 15 rows
+// for one book took 15 turns through that mutex; it now takes one. The saving is
+// not the txn bookkeeping, it is the contention removed from unrelated writers.
+//
+// Semantics are otherwise identical to N successive DeleteBookFileFromMemDB calls:
+// IDs that are absent from memdb are skipped silently (Pebble stays authoritative,
+// and memdb is a derived cache that a later resync will correct anyway).
+func (p *PebbleStore) DeleteBookFilesFromMemDB(fileIDs []string) {
+	if len(fileIDs) == 0 {
+		return
+	}
+	p.memSync("DeleteBookFiles", func(txn memTxn) error {
+		for _, id := range fileIDs {
+			if id == "" {
+				continue
+			}
+			obj, err := txn.First(memTableBookFiles, memIdxID, id)
+			if err != nil || obj == nil {
+				// Not present (or unreadable). memSync aborts the WHOLE txn on a
+				// returned error, so a single missing row must not be one — that
+				// would drop the other N-1 deletes for no benefit.
+				continue
+			}
+			if err := txn.Delete(memTableBookFiles, obj); err != nil {
+				return fmt.Errorf("delete book_file %s: %w", id, err)
+			}
 		}
 		return nil
 	})

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/mock_store.go
-// version: 1.81.1
+// version: 1.82.0
 // guid: b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7e
-// last-edited: 2026-07-26
+// last-edited: 2026-08-06
 
 package database
 
@@ -365,6 +365,7 @@ type MockStore struct {
 	GetBookFileByAcoustIDFunc               func(fingerprint string) (*BookFile, error)
 	GetBookFileByAcoustIDFuzzyFunc          func(fingerprint string, minSimilarity float64) (*BookFile, error)
 	DeleteBookFileFunc                      func(id string) error
+	DeleteBookFilesByIDsFunc                func(ids []string) error
 	DeleteBookFilesForBookFunc              func(bookID string) error
 	UpsertBookFileFunc                      func(file *BookFile) error
 	BatchUpsertBookFilesFunc                func(files []*BookFile) error
@@ -2493,6 +2494,14 @@ func (m *MockStore) DeleteBookFile(id string) error {
 	if m.DeleteBookFileFunc != nil {
 		return m.DeleteBookFileFunc(id)
 	}
+	return nil
+}
+func (m *MockStore) DeleteBookFilesByIDs(ids []string) error {
+	if m.DeleteBookFilesByIDsFunc != nil {
+		return m.DeleteBookFilesByIDsFunc(ids)
+	}
+	// Default to the same fallback DeleteBookFileFunc-less mocks get: succeed
+	// silently. Tests that care about which rows were deleted set the Func.
 	return nil
 }
 func (m *MockStore) DeleteBookFilesForBook(bookID string) error {

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -14477,6 +14477,57 @@ func (_c *MockBookFileStore_DeleteBookFile_Call) RunAndReturn(run func(id string
 	return _c
 }
 
+// DeleteBookFilesByIDs provides a mock function for the type MockBookFileStore
+func (_mock *MockBookFileStore) DeleteBookFilesByIDs(ids []string) error {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBookFilesByIDs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = returnFunc(ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBookFileStore_DeleteBookFilesByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBookFilesByIDs'
+type MockBookFileStore_DeleteBookFilesByIDs_Call struct {
+	*mock.Call
+}
+
+// DeleteBookFilesByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockBookFileStore_Expecter) DeleteBookFilesByIDs(ids any) *MockBookFileStore_DeleteBookFilesByIDs_Call {
+	return &MockBookFileStore_DeleteBookFilesByIDs_Call{Call: _e.mock.On("DeleteBookFilesByIDs", ids)}
+}
+
+func (_c *MockBookFileStore_DeleteBookFilesByIDs_Call) Run(run func(ids []string)) *MockBookFileStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBookFileStore_DeleteBookFilesByIDs_Call) Return(err error) *MockBookFileStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBookFileStore_DeleteBookFilesByIDs_Call) RunAndReturn(run func(ids []string) error) *MockBookFileStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteBookFilesForBook provides a mock function for the type MockBookFileStore
 func (_mock *MockBookFileStore) DeleteBookFilesForBook(bookID string) error {
 	ret := _mock.Called(bookID)
@@ -32682,6 +32733,57 @@ func (_c *MockStore_DeleteBookFile_Call) Return(err error) *MockStore_DeleteBook
 }
 
 func (_c *MockStore_DeleteBookFile_Call) RunAndReturn(run func(id string) error) *MockStore_DeleteBookFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteBookFilesByIDs provides a mock function for the type MockStore
+func (_mock *MockStore) DeleteBookFilesByIDs(ids []string) error {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBookFilesByIDs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = returnFunc(ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_DeleteBookFilesByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBookFilesByIDs'
+type MockStore_DeleteBookFilesByIDs_Call struct {
+	*mock.Call
+}
+
+// DeleteBookFilesByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockStore_Expecter) DeleteBookFilesByIDs(ids any) *MockStore_DeleteBookFilesByIDs_Call {
+	return &MockStore_DeleteBookFilesByIDs_Call{Call: _e.mock.On("DeleteBookFilesByIDs", ids)}
+}
+
+func (_c *MockStore_DeleteBookFilesByIDs_Call) Run(run func(ids []string)) *MockStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFilesByIDs_Call) Return(err error) *MockStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_DeleteBookFilesByIDs_Call) RunAndReturn(run func(ids []string) error) *MockStore_DeleteBookFilesByIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
 // last-edited: 2026-08-06
 
@@ -929,15 +929,28 @@ func (s *PebbleStore) DeleteBookFilesForBook(bookID string) error {
 // class is exactly that shape — write-backs that proceeded on a stale view and
 // silently erased fields (see the AcoustIDFingerprint and Author/Series wipes).
 //
-// Fail-closed is cheap here specifically because both callers are re-runnable and
-// self-healing: they re-read the current row set from the store on every run, so a
-// stale ID simply is not in the next run's list and the deferred work completes
-// then. Nothing is lost, at most one batch is deferred by one run. Skip-and-
-// continue, by contrast, would normalise the disagreement into a silent counter
-// nobody reads.
+// Skip-and-continue, by contrast, would normalise the disagreement into a silent
+// counter nobody reads.
 //
-// Callers that delete large ID sets should chunk them so that one stale ID defers
-// only its own chunk (see the orphan-book-files cleanup, which chunks at 500).
+// ⚠️ HOW CHEAP FAIL-CLOSED IS DEPENDS ON WHERE THE CALLER GOT ITS IDs, and this is
+// NOT uniform across the two callers:
+//
+//   - dedupe-book-file-rows re-reads its row set from Pebble (GetBookFiles) on
+//     every run, so an ID that no longer exists is never queued a second time. A
+//     failed batch there costs one deferred run and nothing else. Genuinely
+//     self-healing.
+//   - orphan-book-files-cleanup gets its list from GetAllBookFilesCore, which is
+//     served from MEMDB when UseMemDB is on. memdb is a derived cache that can
+//     hold a row Pebble no longer has, so a phantom row produces an ID that will
+//     never resolve — and would abort the same chunk on every run until the
+//     process restarts and memdb rebuilds. NOT self-healing. That caller
+//     therefore keeps an explicit row-by-row fallback via DeleteBookFile (which
+//     tolerates "already gone") for any chunk this method rejects.
+//
+// The rule for new callers: fail-closed is the right default for a batch, but if
+// your IDs come from a cache rather than from Pebble, you need a degraded path.
+// Chunk large ID sets either way, so one stale ID cannot take the whole sweep
+// with it (the orphan cleanup chunks at 500).
 //
 // ── RESOLUTION PATH ───────────────────────────────────────────────────────────
 //

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,7 +1,7 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.8.0
+// version: 1.9.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
-// last-edited: 2026-08-04
+// last-edited: 2026-08-06
 
 package database
 
@@ -881,6 +881,166 @@ func (s *PebbleStore) DeleteBookFilesForBook(bookID string) error {
 	// Recompute book-level aggregates after bulk-deleting all files for this book.
 	// The book likely has Duration=0 after deletion, which is correct — nothing to sum.
 	s.notifyBookFileChange(bookID)
+	return nil
+}
+
+// DeleteBookFilesByIDs removes many BookFile rows (and their secondary indexes)
+// in ONE Pebble batch, ONE memdb transaction, and ONE aggregate recompute per
+// affected book — regardless of how many rows are being deleted.
+//
+// ── WHY THIS EXISTS ───────────────────────────────────────────────────────────
+//
+// DeleteBookFile pays a large FIXED cost per row, and that cost is the whole
+// problem. Measured against production, maintenance.dedupe-book-file-rows spent
+// ~1.35s PER DELETED ROW with only ~7ms of that scaling with the book's remaining
+// file count. Per-row deltas stayed flat (1.85/1.94/1.42/1.66/1.54s) while the
+// book's total_files fell 65 → 34, which is what proves it is fixed overhead and
+// not an O(R²) walk. Over the 2,901 redundant rows on prod that is ~1.3 hours of
+// almost pure waste.
+//
+// Per deleted row, DeleteBookFile's notifyBookFileChange → RecomputeBookAggregates
+// → UpdateBook chain pays:
+//   - two pebble.Sync commits (the row delete, then the book write)
+//   - one full copy-on-write book_ver:<id>:<nanos> snapshot, which marshals the
+//     ENTIRE old Book just to record that a duration changed
+//   - two go-memdb write transactions, each queueing on memdb's single global
+//     writer mutex
+//   - the book's file set read twice (RecomputeBookAggregates and the memdb
+//     resync), both unmarshalling AcoustIDFingerprint blobs neither one wants
+//
+// None of that is per-row work in principle — it is per-BOOK work being run once
+// per row. This method hoists it out of the loop. This is the same shape as the
+// existing DeleteBookFilesForBook, which is the proven pattern here; the only
+// difference is that the row set is given by ID instead of by owning book, so the
+// grouping has to be derived rather than assumed.
+//
+// ── FAIL-CLOSED ON UNRESOLVABLE IDs ───────────────────────────────────────────
+//
+// Resolution happens in a first pass that mutates NOTHING. If any ID fails to
+// resolve, this returns an error naming the offenders and deletes nothing at all.
+//
+// This deliberately DIVERGES from DeleteBookFile, which treats an unresolvable ID
+// as "already gone" and returns nil. That is defensible for a single row — there
+// is nothing else riding along, so the caller's intent is fully satisfied by doing
+// nothing. It is not defensible for a batch: an ID that does not resolve means the
+// caller's view of the store disagrees with the store, and a disagreement
+// discovered midway through a DESTRUCTIVE operation is the worst possible moment
+// to decide to press on with the other N-1 rows. This repo's dominant incident
+// class is exactly that shape — write-backs that proceeded on a stale view and
+// silently erased fields (see the AcoustIDFingerprint and Author/Series wipes).
+//
+// Fail-closed is cheap here specifically because both callers are re-runnable and
+// self-healing: they re-read the current row set from the store on every run, so a
+// stale ID simply is not in the next run's list and the deferred work completes
+// then. Nothing is lost, at most one batch is deferred by one run. Skip-and-
+// continue, by contrast, would normalise the disagreement into a silent counter
+// nobody reads.
+//
+// Callers that delete large ID sets should chunk them so that one stale ID defers
+// only its own chunk (see the orphan-book-files cleanup, which chunks at 500).
+//
+// ── RESOLUTION PATH ───────────────────────────────────────────────────────────
+//
+// Both of DeleteBookFile's lookup paths are preserved: the book_file_id index
+// first, then the legacy full scan. The scan fallback matters MORE under
+// fail-closed than it did per-row — a row written before the index existed is
+// still deletable today, and dropping the fallback would turn those rows from
+// "slow" into "aborts the entire batch".
+//
+// Rows are resolved to full BookFile structs here rather than accepted from the
+// caller on purpose: deleteBookFileSecondaryIndexes needs the AcoustID segment
+// fields, and the projections callers tend to have on hand (BookFileCore, memdb
+// rows) strip exactly those. An ID-only signature makes that mistake unavailable.
+func (s *PebbleStore) DeleteBookFilesByIDs(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// ── Pass 1: resolve everything. No mutation happens in this loop. ──
+	seen := make(map[string]struct{}, len(ids))
+	resolved := make([]*BookFile, 0, len(ids))
+	resolvedIDs := make([]string, 0, len(ids))
+	// Affected books in first-seen order, so notification order is deterministic
+	// and a test can assert on it.
+	var affectedBooks []string
+	bookSeen := make(map[string]struct{})
+	var unresolved []string
+
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			// A duplicate ID in the input would otherwise queue the same key for
+			// deletion twice. Harmless in Pebble, but it would also double-count
+			// the row, so drop it here.
+			continue
+		}
+		seen[id] = struct{}{}
+
+		found := s.lookupBookFileByIDIndex(id)
+		if found == nil {
+			found = s.scanForBookFileByID(id)
+		}
+		if found == nil {
+			unresolved = append(unresolved, id)
+			continue
+		}
+
+		resolved = append(resolved, found)
+		resolvedIDs = append(resolvedIDs, id)
+		if _, ok := bookSeen[found.BookID]; !ok {
+			bookSeen[found.BookID] = struct{}{}
+			affectedBooks = append(affectedBooks, found.BookID)
+		}
+	}
+
+	if len(unresolved) > 0 {
+		// Name the offenders, but cap the list — a caller that hands us 500 stale
+		// IDs should not produce a 500-item error string in the op log.
+		shown := unresolved
+		suffix := ""
+		if len(shown) > 10 {
+			shown = shown[:10]
+			suffix = fmt.Sprintf(" (+%d more)", len(unresolved)-10)
+		}
+		return fmt.Errorf("DeleteBookFilesByIDs: %d of %d book_file id(s) did not resolve, nothing deleted: %s%s",
+			len(unresolved), len(ids), strings.Join(shown, ", "), suffix)
+	}
+	if len(resolved) == 0 {
+		return nil
+	}
+
+	// ── Pass 2: one batch, one Sync commit. ──
+	batch := s.db.NewBatch()
+	for _, f := range resolved {
+		primaryKey := []byte(fmt.Sprintf("book_file:%s:%s", f.BookID, f.ID))
+		if err := batch.Delete(primaryKey, nil); err != nil {
+			batch.Close()
+			return err
+		}
+		if err := s.deleteBookFileSecondaryIndexes(batch, f); err != nil {
+			batch.Close()
+			return err
+		}
+	}
+	if err := batch.Commit(pebble.Sync); err != nil {
+		return err
+	}
+
+	// ── Pass 3: derived state. Everything below is best-effort by design. ──
+	// The rows are committed and gone; a failure to refresh a cache or an
+	// aggregate must not be reported as a failed delete, or a caller would retry
+	// a delete that already succeeded. Same rule DeleteBookFile follows.
+	s.InvalidateLibraryStats()
+	s.MarkQuickQueryDirty("no_fingerprints", "delete_book_files_by_ids")
+	s.DeleteBookFilesFromMemDB(resolvedIDs)
+
+	// ONE recompute per affected book, not one per row. This is the actual fix —
+	// everything above is just what makes it safe to do.
+	for _, bookID := range affectedBooks {
+		s.notifyBookFileChange(bookID)
+	}
 	return nil
 }
 

--- a/internal/plugins/maintenance/batch_delete_rows_test.go
+++ b/internal/plugins/maintenance/batch_delete_rows_test.go
@@ -319,10 +319,20 @@ func TestOrphanBookFilesCleanup_ChunksLargeOrphanSets(t *testing.T) {
 	}
 }
 
-// A fail-closed chunk must be counted as wholly failed and must NOT abandon the
-// remaining chunks — the rows it left behind are picked up by the next run,
-// because findOrphanBookFiles rescans from scratch every time.
-func TestOrphanBookFilesCleanup_FailedChunkDoesNotAbortRemainingChunks(t *testing.T) {
+// ⚠️ THE REGRESSION THIS GUARDS AGAINST IS SUBTLE AND WAS ALMOST SHIPPED.
+//
+// Fail-closed is self-healing for dedupe-book-file-rows, which re-reads its rows
+// from Pebble every run. It is NOT self-healing here: findOrphanBookFiles gets its
+// list from GetAllBookFilesCore, which is served from MEMDB in production. memdb
+// can hold a row Pebble no longer has, and that phantom yields an ID that will
+// never resolve — so a naive fail-closed chunk would abort the SAME 500 rows on
+// every nightly 02:15 run until the process restarts and memdb rebuilds. The
+// per-row loop this replaced skipped the phantom and deleted the other 499.
+//
+// Hence the degraded path: a rejected chunk is retried one row at a time through
+// DeleteBookFile, which tolerates "already gone". Assert that the survivors of a
+// failed chunk actually get deleted — not merely that the run continues.
+func TestOrphanBookFilesCleanup_RejectedChunkFallsBackToPerRowDeletes(t *testing.T) {
 	const orphanCount = 1200
 
 	files := make([]database.BookFileCore, 0, orphanCount)
@@ -334,16 +344,26 @@ func TestOrphanBookFilesCleanup_FailedChunkDoesNotAbortRemainingChunks(t *testin
 		})
 	}
 
-	calls := 0
+	batchCalls := 0
+	var perRow []string
 	store := &database.MockStore{
 		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
 		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
 			return []database.BookCore{{ID: "book-alive"}}, nil
 		},
 		DeleteBookFilesByIDsFunc: func(ids []string) error {
-			calls++
-			if calls == 1 {
-				return fmt.Errorf("simulated: 1 of %d ids did not resolve, nothing deleted", len(ids))
+			batchCalls++
+			if batchCalls == 1 {
+				// Exactly the shape DeleteBookFilesByIDs produces for a phantom row.
+				return fmt.Errorf("DeleteBookFilesByIDs: 1 of %d book_file id(s) did not "+
+					"resolve, nothing deleted: orphan-0007", len(ids))
+			}
+			return nil
+		},
+		DeleteBookFileFunc: func(id string) error {
+			perRow = append(perRow, id)
+			if id == "orphan-0007" {
+				return fmt.Errorf("simulated: phantom row, not in pebble")
 			}
 			return nil
 		},
@@ -352,11 +372,34 @@ func TestOrphanBookFilesCleanup_FailedChunkDoesNotAbortRemainingChunks(t *testin
 	p := &Plugin{deps: fakeDeps{store: store}}
 	raw, _ := json.Marshal(OrphanBookFilesCleanupParams{Delete: true})
 	if err := p.runOrphanBookFilesCleanup(context.Background(), raw, &fakeReporter{}); err != nil {
-		t.Fatalf("runOrphanBookFilesCleanup returned %v; a failing chunk is logged and "+
-			"counted, not propagated", err)
+		t.Fatalf("runOrphanBookFilesCleanup returned %v; a failing chunk is recovered and "+
+			"logged, not propagated", err)
 	}
-	if calls != 3 {
+
+	if batchCalls != 3 {
 		t.Fatalf("DeleteBookFilesByIDs called %d times, want 3 — a failing chunk aborted "+
-			"the chunks after it", calls)
+			"the chunks after it", batchCalls)
 	}
+	// THE ASSERTION: the rejected chunk's 500 rows were retried individually, so
+	// the 499 real orphans still got deleted rather than being stuck forever.
+	if len(perRow) != 500 {
+		t.Fatalf("per-row fallback attempted %d rows, want 500 — the rejected chunk's "+
+			"rows would be abandoned on every run until memdb rebuilds", len(perRow))
+	}
+	if perRow[0] != "orphan-0000" || perRow[499] != "orphan-0499" {
+		t.Fatalf("fallback covered the wrong rows: first=%s last=%s", perRow[0], perRow[499])
+	}
+	// Only the phantom is left behind; the other 499 in that chunk succeeded.
+	if !containsID(perRow, "orphan-0007") {
+		t.Fatal("the phantom row was never retried individually")
+	}
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/plugins/maintenance/batch_delete_rows_test.go
+++ b/internal/plugins/maintenance/batch_delete_rows_test.go
@@ -1,0 +1,362 @@
+// file: internal/plugins/maintenance/batch_delete_rows_test.go
+// version: 1.0.0
+// guid: 6c1f9b2e-7a04-4d38-95e6-1b8d3f0a2c57
+// last-edited: 2026-08-06
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dedupe-book-file-rows: salvage must still commit BEFORE its donors are deleted
+// ─────────────────────────────────────────────────────────────────────────────
+
+// salvageFailingStore fails UpdateBookFile for one specific row and delegates
+// everything else to the real store underneath.
+//
+// It exists to exercise the one ordering rule that batching could plausibly have
+// broken: rescued keeper fields are written in their OWN commit, before the
+// donors they were rescued from are deleted. If the salvage write fails, the
+// group must be abandoned with the donors untouched, so the next run can try
+// again from the same evidence.
+type salvageFailingStore struct {
+	database.Store
+	failForFileID string
+	attempts      int
+}
+
+func (s *salvageFailingStore) UpdateBookFile(id string, f *database.BookFile) error {
+	if id == s.failForFileID {
+		s.attempts++
+		return fmt.Errorf("simulated salvage write failure for %s", id)
+	}
+	return s.Store.UpdateBookFile(id, f)
+}
+
+// seedSalvageBook creates one book with two rows at the SAME path, split so that
+// each row holds evidence the other lacks:
+//
+//	row 0: has a fingerprint, no duration  ← ranks first, becomes the keeper
+//	row 1: has a duration, no fingerprint  ← the donor the keeper needs
+//
+// That split is what forces mergeMissingFields to report changed=true and makes
+// the op attempt a salvage write, which is the code path under test.
+func seedSalvageBook(t *testing.T, s *database.PebbleStore, title, path string) (bookID, keeperID, donorID string) {
+	t.Helper()
+	bk, err := s.CreateBook(&database.Book{Title: title})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	keeper := &database.BookFile{
+		BookID:              bk.ID,
+		FilePath:            path,
+		AcoustIDFingerprint: []byte{0x01, 0x02, 0x03, 0x04},
+	}
+	if err := s.CreateBookFile(keeper); err != nil {
+		t.Fatalf("CreateBookFile(keeper): %v", err)
+	}
+	donor := &database.BookFile{
+		BookID:   bk.ID,
+		FilePath: path,
+		Duration: 3600,
+		FileSize: 58000000,
+	}
+	if err := s.CreateBookFile(donor); err != nil {
+		t.Fatalf("CreateBookFile(donor): %v", err)
+	}
+	return bk.ID, keeper.ID, donor.ID
+}
+
+// 🔴 THE ORDERING RULE, ASSERTED DIRECTLY.
+//
+// Batching the deletes must not tempt anyone into folding the salvage
+// UpdateBookFile into the same atomic batch. Doing so silently removes the "if
+// the salvage write fails, skip this group" escape: the group would commit both
+// or neither, and "neither" is indistinguishable from "nothing to do" on the next
+// run — so a keeper whose rescue failed could never be repaired from its twins
+// again. This repo's dominant incident class is exactly that (the
+// AcoustIDFingerprint and Author/Series write-back wipes).
+//
+// So: when the salvage write fails, the donor must still be there afterwards.
+func TestDedupeBookFileRows_FailedSalvageLeavesDonorsIntact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+
+	// The book whose salvage will fail, and a control book that must still be
+	// collapsed — otherwise a bug that skips EVERY book would pass this test.
+	failBook, failKeeper, failDonor := seedSalvageBook(t, s, "Salvage Fails", "/lib/fail/track.m4b")
+	okBook, _, _ := seedSalvageBook(t, s, "Salvage Succeeds", "/lib/ok/track.m4b")
+
+	// PASS 1 of the op reads GetAllBookFilesCore, which is served from memdb.
+	s.WaitForWarmup()
+
+	wrapped := &salvageFailingStore{Store: s, failForFileID: failKeeper}
+	p := &Plugin{deps: fakeDeps{store: wrapped}}
+	raw, _ := json.Marshal(DedupeBookFileRowsParams{Apply: true})
+
+	if err := p.runDedupeBookFileRows(context.Background(), raw, &concurrentReporter{}); err != nil {
+		t.Fatalf("runDedupeBookFileRows: %v", err)
+	}
+
+	if wrapped.attempts == 0 {
+		t.Fatal("the salvage write was never attempted — the fixture no longer exercises " +
+			"the path under test, so this test proves nothing")
+	}
+
+	// THE ASSERTION: both rows survive. The donor still carries the duration the
+	// keeper failed to receive, so the next run can rescue it.
+	left, err := s.GetBookFiles(failBook)
+	if err != nil {
+		t.Fatalf("GetBookFiles(failBook): %v", err)
+	}
+	if len(left) != 2 {
+		t.Fatalf("%d rows survived after a FAILED salvage, want 2 — the donor was deleted "+
+			"even though the data it held was never rescued", len(left))
+	}
+	foundDonor := false
+	for i := range left {
+		if left[i].ID == failDonor {
+			foundDonor = true
+			if left[i].Duration != 3600 {
+				t.Fatalf("donor duration = %d, want 3600 — the only surviving copy was damaged",
+					left[i].Duration)
+			}
+		}
+	}
+	if !foundDonor {
+		t.Fatalf("the donor row %s is gone; its duration was never salvaged onto the keeper",
+			failDonor)
+	}
+
+	// The control book must still have collapsed — proving the skip is scoped to
+	// the group whose salvage failed, not to the whole run.
+	okLeft, err := s.GetBookFiles(okBook)
+	if err != nil {
+		t.Fatalf("GetBookFiles(okBook): %v", err)
+	}
+	if len(okLeft) != 1 {
+		t.Fatalf("control book has %d rows, want 1 — one failing group aborted unrelated work",
+			len(okLeft))
+	}
+	if okLeft[0].Duration != 3600 || len(okLeft[0].AcoustIDFingerprint) == 0 {
+		t.Fatalf("control keeper lost salvaged evidence: duration=%d fingerprint_len=%d, "+
+			"want 3600 and non-empty", okLeft[0].Duration, len(okLeft[0].AcoustIDFingerprint))
+	}
+}
+
+// The batched path must still collapse a plain duplicate group end to end. This
+// is the "did rerouting the caller break the op" guard.
+func TestDedupeBookFileRows_BatchedDeleteStillCollapses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("seeds a real PebbleStore; skipped in -short")
+	}
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer s.Close()
+	s.WaitForWarmup()
+
+	bookIDs := seedDupBooks(t, s, 3, 5)
+
+	p := &Plugin{deps: fakeDeps{store: s}}
+	raw, _ := json.Marshal(DedupeBookFileRowsParams{Apply: true})
+	if err := p.runDedupeBookFileRows(context.Background(), raw, &concurrentReporter{}); err != nil {
+		t.Fatalf("runDedupeBookFileRows: %v", err)
+	}
+
+	for i, id := range bookIDs {
+		files, ferr := s.GetBookFiles(id)
+		if ferr != nil {
+			t.Fatalf("GetBookFiles(%s): %v", id, ferr)
+		}
+		if len(files) != 1 {
+			t.Fatalf("book %d: %d rows survived, want 1", i, len(files))
+		}
+		// Aggregates must reflect the single survivor, not the 5 original rows.
+		bk, berr := s.GetBookByID(id)
+		if berr != nil {
+			t.Fatalf("GetBookByID(%s): %v", id, berr)
+		}
+		if bk.Duration == nil || *bk.Duration != 3600 {
+			t.Fatalf("book %d duration = %v, want 3600 (one surviving row, not 5)", i, bk.Duration)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// orphan-book-files-cleanup: must route through the notifying batch method
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ⚠️ THIS PATH HAS NO TRAILING RecomputeBookAggregates OF ITS OWN, unlike
+// dedupe-book-file-rows. Its aggregate freshness comes entirely from
+// DeleteBookFilesByIDs notifying once per affected book, so the thing worth
+// asserting at this layer is that the op goes through that method and not through
+// some non-notifying shortcut. (That the method itself recomputes is asserted
+// directly in internal/database/delete_book_files_by_ids_test.go.)
+//
+// For a GENUINE orphan the owning book is gone by definition, so the recompute
+// finds nothing and returns early — but the notification still has to be issued,
+// because orphanhood is decided from a snapshot and a book that turns out to
+// exist after all must have its totals corrected rather than left counting rows
+// that no longer exist.
+func TestOrphanBookFilesCleanup_DeletesViaNotifyingBatchMethod(t *testing.T) {
+	books := []database.Book{{ID: "book-alive", Title: "Alive"}}
+	files := []database.BookFileCore{
+		{ID: "f1", BookID: "book-alive", FilePath: "/lib/keep.m4b"},
+		{ID: "f2", BookID: "book-ghost", FilePath: "/lib/orphan-1.m4b"},
+		{ID: "f3", BookID: "book-ghost", FilePath: "/lib/orphan-2.m4b"},
+	}
+
+	var batchCalls [][]string
+	var perRowCalls []string
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			cores := make([]database.BookCore, len(books))
+			for i := range books {
+				cores[i] = books[i].Core()
+			}
+			return cores, nil
+		},
+		DeleteBookFilesByIDsFunc: func(ids []string) error {
+			batchCalls = append(batchCalls, append([]string(nil), ids...))
+			return nil
+		},
+		DeleteBookFileFunc: func(id string) error {
+			perRowCalls = append(perRowCalls, id)
+			return nil
+		},
+	}
+
+	p := &Plugin{deps: fakeDeps{store: store}}
+	raw, _ := json.Marshal(OrphanBookFilesCleanupParams{Delete: true})
+	if err := p.runOrphanBookFilesCleanup(context.Background(), raw, &fakeReporter{}); err != nil {
+		t.Fatalf("runOrphanBookFilesCleanup: %v", err)
+	}
+
+	if len(perRowCalls) != 0 {
+		t.Fatalf("the per-row DeleteBookFile was called %d times (%v) — the op is still paying "+
+			"~1.35s of fixed overhead per row", len(perRowCalls), perRowCalls)
+	}
+	if len(batchCalls) != 1 {
+		t.Fatalf("DeleteBookFilesByIDs called %d times for 2 orphans, want 1", len(batchCalls))
+	}
+	got := map[string]bool{}
+	for _, id := range batchCalls[0] {
+		got[id] = true
+	}
+	if len(got) != 2 || !got["f2"] || !got["f3"] {
+		t.Fatalf("batched ids = %v, want exactly f2 and f3", batchCalls[0])
+	}
+}
+
+// Chunking exists so that one unresolvable ID defers only its own chunk rather
+// than the whole sweep — and so the per-row cancellation check and progress tick
+// the old loop gave us for free survive. Both depend on the list actually being
+// split, so assert the split rather than trusting the constant.
+func TestOrphanBookFilesCleanup_ChunksLargeOrphanSets(t *testing.T) {
+	const orphanCount = 1200 // > 2 chunks at 500
+
+	books := []database.Book{{ID: "book-alive", Title: "Alive"}}
+	files := make([]database.BookFileCore, 0, orphanCount)
+	for i := 0; i < orphanCount; i++ {
+		files = append(files, database.BookFileCore{
+			ID:       fmt.Sprintf("orphan-%04d", i),
+			BookID:   "book-ghost",
+			FilePath: fmt.Sprintf("/lib/orphan-%04d.m4b", i),
+		})
+	}
+
+	var chunkSizes []int
+	seen := map[string]int{}
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{books[0].Core()}, nil
+		},
+		DeleteBookFilesByIDsFunc: func(ids []string) error {
+			chunkSizes = append(chunkSizes, len(ids))
+			for _, id := range ids {
+				seen[id]++
+			}
+			return nil
+		},
+	}
+
+	p := &Plugin{deps: fakeDeps{store: store}}
+	raw, _ := json.Marshal(OrphanBookFilesCleanupParams{Delete: true})
+	if err := p.runOrphanBookFilesCleanup(context.Background(), raw, &fakeReporter{}); err != nil {
+		t.Fatalf("runOrphanBookFilesCleanup: %v", err)
+	}
+
+	if len(chunkSizes) != 3 {
+		t.Fatalf("chunk count = %d (sizes %v), want 3 for %d orphans at 500/chunk — "+
+			"an unchunked call would make one stale id abort the entire sweep",
+			len(chunkSizes), chunkSizes, orphanCount)
+	}
+	if len(seen) != orphanCount {
+		t.Fatalf("%d distinct ids deleted, want %d — chunking dropped or duplicated rows",
+			len(seen), orphanCount)
+	}
+	for id, n := range seen {
+		if n != 1 {
+			t.Fatalf("id %s was submitted %d times, want exactly 1", id, n)
+		}
+	}
+}
+
+// A fail-closed chunk must be counted as wholly failed and must NOT abandon the
+// remaining chunks — the rows it left behind are picked up by the next run,
+// because findOrphanBookFiles rescans from scratch every time.
+func TestOrphanBookFilesCleanup_FailedChunkDoesNotAbortRemainingChunks(t *testing.T) {
+	const orphanCount = 1200
+
+	files := make([]database.BookFileCore, 0, orphanCount)
+	for i := 0; i < orphanCount; i++ {
+		files = append(files, database.BookFileCore{
+			ID:       fmt.Sprintf("orphan-%04d", i),
+			BookID:   "book-ghost",
+			FilePath: fmt.Sprintf("/lib/orphan-%04d.m4b", i),
+		})
+	}
+
+	calls := 0
+	store := &database.MockStore{
+		GetAllBookFilesCoreFunc: func() ([]database.BookFileCore, error) { return files, nil },
+		GetAllBooksCoreFunc: func(limit, offset int) ([]database.BookCore, error) {
+			return []database.BookCore{{ID: "book-alive"}}, nil
+		},
+		DeleteBookFilesByIDsFunc: func(ids []string) error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("simulated: 1 of %d ids did not resolve, nothing deleted", len(ids))
+			}
+			return nil
+		},
+	}
+
+	p := &Plugin{deps: fakeDeps{store: store}}
+	raw, _ := json.Marshal(OrphanBookFilesCleanupParams{Delete: true})
+	if err := p.runOrphanBookFilesCleanup(context.Background(), raw, &fakeReporter{}); err != nil {
+		t.Fatalf("runOrphanBookFilesCleanup returned %v; a failing chunk is logged and "+
+			"counted, not propagated", err)
+	}
+	if calls != 3 {
+		t.Fatalf("DeleteBookFilesByIDs called %d times, want 3 — a failing chunk aborted "+
+			"the chunks after it", calls)
+	}
+}

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/dedupe_book_file_rows.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 1c7f4b93-6a05-42e8-9d31-8b0e5a2f7c46
-// last-edited: 2026-08-04
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -271,6 +271,26 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 		}
 
 		changedThisBook := false
+		// Redundant row IDs accumulate here and are deleted in ONE batch call after
+		// the group loop, instead of one DeleteBookFile per row.
+		//
+		// 🔴 THE SALVAGE WRITE BELOW MUST NOT JOIN THIS BATCH. Rescued keeper fields
+		// have to be COMMITTED BEFORE their donor rows are deleted, and the whole
+		// point of the "if the salvage write fails, skip this group" escape is that
+		// the donors are still there to try again from. Folding the salvage into an
+		// atomic delete batch silently removes that escape: the group would either
+		// commit both or neither, which sounds safer but actually means a keeper
+		// whose salvage write failed can no longer be repaired from its twins on the
+		// next run, because "neither" is indistinguishable from "nothing to do".
+		// Losing a duration is recoverable; losing it while also deleting the only
+		// other copy is not. That asymmetry is why the two commits stay separate and
+		// ordered. This is the repo's dominant incident class (fingerprint /
+		// Author / Series wipes on write-back) — do not "simplify" this.
+		//
+		// Accumulating across groups keeps that ordering STRONGER, not weaker: every
+		// salvage in this book commits before any donor in this book is deleted, and
+		// a group whose salvage failed simply never enters the accumulator.
+		var pendingDeletes []string
 		for path, rows := range byPath {
 			if len(rows) < 2 {
 				continue
@@ -333,26 +353,44 @@ func (p *Plugin) runDedupeBookFileRows(ctx context.Context, raw json.RawMessage,
 				mu.Unlock()
 			}
 
+			// Salvage for this group is committed; its donors may now be queued.
 			for ri := range redundant {
-				if derr := store.DeleteBookFile(redundant[ri].ID); derr != nil {
-					mu.Lock()
-					failed++
-					mu.Unlock()
-					log.Warn("dedupe-book-file-rows: delete failed",
-						"book_id", bookID, "row_id", redundant[ri].ID, "err", derr)
-					continue
-				}
+				pendingDeletes = append(pendingDeletes, redundant[ri].ID)
+			}
+		}
+
+		// One batched delete for the whole book. DeleteBookFilesByIDs is fail-closed
+		// on unresolvable IDs, so a partial delete cannot happen here — either every
+		// queued row goes or none do. If none do, the rows survive and the next run
+		// of this op re-reads them and collapses them again, so the failure costs a
+		// re-run and nothing else.
+		if len(pendingDeletes) > 0 {
+			if derr := store.DeleteBookFilesByIDs(pendingDeletes); derr != nil {
 				mu.Lock()
-				deleted++
+				failed++
+				mu.Unlock()
+				log.Warn("dedupe-book-file-rows: batched delete failed; leaving this book's rows intact",
+					"book_id", bookID, "rows", len(pendingDeletes), "err", derr)
+			} else {
+				mu.Lock()
+				deleted += len(pendingDeletes)
 				mu.Unlock()
 				changedThisBook = true
 			}
-
 		}
 
 		// Totals are a plain sum over the surviving rows, so they are only correct
 		// once the redundant rows are gone — recompute AFTER deleting, per book.
 		// Safe to do inside a worker: this book's rows belong to no other worker.
+		//
+		// This LOOKS redundant now that DeleteBookFilesByIDs already notifies once
+		// per affected book, and it is nearly free rather than actually redundant:
+		// RecomputeBookAggregates early-returns when neither Duration nor FileSize
+		// changed, which is exactly the state the batch delete just left the book
+		// in. Keep it anyway — it is what feeds the `recomputed` counter this op
+		// reports, and it is the only recompute that happens on the paths where the
+		// batch delete was skipped. Removing it would silently zero a counter the
+		// op's output is read for.
 		if params.Apply && changedThisBook {
 			if rerr := store.RecomputeBookAggregates(bookID); rerr != nil {
 				mu.Lock()

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
-// last-edited: 2026-07-07
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -20,8 +20,8 @@ import (
 // book_files cleanup op. When Delete is false (default), the op reports the
 // count of orphan rows but does not modify the database.
 type OrphanBookFilesCleanupParams struct {
-	// Delete, when true, removes each detected orphan book_file row via
-	// Store.DeleteBookFile. When false (default), the op is a dry run.
+	// Delete, when true, removes the detected orphan book_file rows via
+	// Store.DeleteBookFilesByIDs. When false (default), the op is a dry run.
 	Delete bool `json:"delete"`
 }
 
@@ -92,27 +92,63 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	prog.Start(fmt.Sprintf("Found %d orphan book_file row(s) out of %d (valid books: %d)",
 		total, totalFiles, totalBooks))
 	var deleted, failed int
-	for i, of := range orphans {
+
+	// Deletes go through Store.DeleteBookFilesByIDs in chunks rather than one
+	// DeleteBookFile per row. Per-row deletion costs ~1.35s of FIXED overhead each
+	// (a Sync commit, a full book-version snapshot, two memdb write transactions,
+	// and an aggregate recompute — all per-book work being run per row), which on a
+	// multi-thousand-row orphan sweep is hours of pure waste.
+	//
+	// ⚠️ THIS PATH HAS NO TRAILING RecomputeBookAggregates of its own, unlike
+	// dedupe-book-file-rows. It relies entirely on DeleteBookFilesByIDs notifying
+	// once per affected book. Do not "optimise" that notification away.
+	//
+	// (In practice a genuine orphan's owning book does not exist — that is what
+	// makes it an orphan — so the recompute finds no book and returns early. The
+	// notification still has to happen: findOrphanBookFiles decides orphanhood from
+	// a snapshot, and if a book turns out to exist after all, its aggregates must be
+	// corrected rather than left counting rows that are gone.)
+	//
+	// WHY CHUNKED and not one call for the whole list: DeleteBookFilesByIDs is
+	// fail-closed, so a single unresolvable ID aborts its entire call. Chunking
+	// bounds that blast radius to one chunk, which the next run picks up anyway
+	// because findOrphanBookFiles rescans from scratch. Chunking also preserves the
+	// two things the per-row loop gave us for free — a cancellation check and a
+	// progress tick often enough to keep the stuck-op watchdog fed.
+	const orphanDeleteChunk = 500
+	for start := 0; start < total; start += orphanDeleteChunk {
 		if ctx.Err() != nil {
 			_ = reporter.Log(slog.LevelWarn, "Orphan delete cancelled",
 				slog.Int("deleted", deleted),
 				slog.Int("failed", failed),
-				slog.Int("remaining", total-i),
+				slog.Int("remaining", total-start),
 			)
 			return ctx.Err()
 		}
-		if err := store.DeleteBookFile(of.ID); err != nil {
-			failed++
-			_ = reporter.Log(slog.LevelWarn, "Failed to delete orphan book_file",
-				slog.String("book_file_id", of.ID),
-				slog.String("book_id", of.BookID),
-				slog.String("file_path", of.FilePath),
+		end := min(start+orphanDeleteChunk, total)
+		chunk := orphans[start:end]
+
+		ids := make([]string, 0, len(chunk))
+		for i := range chunk {
+			ids = append(ids, chunk[i].ID)
+		}
+
+		if err := store.DeleteBookFilesByIDs(ids); err != nil {
+			// Fail-closed: nothing in this chunk was deleted, so count the whole
+			// chunk as failed rather than guessing at a partial result.
+			failed += len(ids)
+			_ = reporter.Log(slog.LevelWarn, "Failed to delete orphan book_file chunk",
+				slog.Int("chunk_start", start),
+				slog.Int("chunk_size", len(ids)),
+				slog.String("first_book_file_id", chunk[0].ID),
+				slog.String("first_book_id", chunk[0].BookID),
+				slog.String("first_file_path", chunk[0].FilePath),
 				slog.String("error", err.Error()),
 			)
 			continue
 		}
-		deleted++
-		prog.StepN(i+1, fmt.Sprintf("Deleting orphan book_files: %d/%d", i+1, total))
+		deleted += len(ids)
+		prog.StepN(end, fmt.Sprintf("Deleting orphan book_files: %d/%d", end, total))
 	}
 
 	final := fmt.Sprintf("Orphan book_file cleanup: deleted %d, failed %d (of %d detected)",
@@ -129,8 +165,8 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 // return projections of the underlying tables without per-row decoding cost.
 //
 // This is the testable core of runOrphanBookFilesCleanup. It does not delete
-// anything — callers that want to delete iterate over the result and call
-// Store.DeleteBookFile themselves.
+// anything — callers that want to delete pass the resulting IDs to
+// Store.DeleteBookFilesByIDs themselves, in chunks.
 func findOrphanBookFiles(ctx context.Context, store database.Store) (orphans []database.BookFileCore, totalFiles int, totalBooks int, err error) {
 	if ctx.Err() != nil {
 		return nil, 0, 0, ctx.Err()

--- a/internal/plugins/maintenance/orphan_book_files.go
+++ b/internal/plugins/maintenance/orphan_book_files.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/orphan_book_files.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9d2c4f6a-8e1b-4c5d-9a7b-3e5f1a2c4b6d
 // last-edited: 2026-08-06
 
@@ -111,10 +111,8 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 	//
 	// WHY CHUNKED and not one call for the whole list: DeleteBookFilesByIDs is
 	// fail-closed, so a single unresolvable ID aborts its entire call. Chunking
-	// bounds that blast radius to one chunk, which the next run picks up anyway
-	// because findOrphanBookFiles rescans from scratch. Chunking also preserves the
-	// two things the per-row loop gave us for free — a cancellation check and a
-	// progress tick often enough to keep the stuck-op watchdog fed.
+	// bounds that blast radius to one chunk and keeps a cancellation check and a
+	// progress tick happening often enough to feed the stuck-op watchdog.
 	const orphanDeleteChunk = 500
 	for start := 0; start < total; start += orphanDeleteChunk {
 		if ctx.Err() != nil {
@@ -134,17 +132,60 @@ func (p *Plugin) runOrphanBookFilesCleanup(ctx context.Context, raw json.RawMess
 		}
 
 		if err := store.DeleteBookFilesByIDs(ids); err != nil {
-			// Fail-closed: nothing in this chunk was deleted, so count the whole
-			// chunk as failed rather than guessing at a partial result.
-			failed += len(ids)
-			_ = reporter.Log(slog.LevelWarn, "Failed to delete orphan book_file chunk",
+			// ⚠️ FAIL-CLOSED IS NOT SELF-HEALING ON THIS PATH — hence the fallback.
+			//
+			// The dedupe op can simply retry next run, because it re-reads its row
+			// set from Pebble (GetBookFiles) and an ID that no longer exists is
+			// therefore never queued twice. THIS op cannot make that claim: its list
+			// comes from findOrphanBookFiles → GetAllBookFilesCore, which is served
+			// from memdb whenever UseMemDB is on (i.e. in production). memdb is a
+			// derived cache that can hold a row Pebble no longer has, so a phantom
+			// row yields an ID that can never resolve — and under plain fail-closed
+			// it would abort the same 500-row chunk on EVERY nightly run until the
+			// process restarts and memdb is rebuilt. That is strictly worse than the
+			// per-row loop this replaced, which skipped the phantom and deleted the
+			// other 499.
+			//
+			// So the store layer stays fail-closed (a batch must never act on a view
+			// it cannot fully verify), and the caller that reads from a cache gets an
+			// explicit degraded path: retry this chunk one row at a time via
+			// DeleteBookFile, which tolerates "already gone" by design. Slow — this is
+			// exactly the ~1.35s/row cost the batch exists to avoid — but it only ever
+			// runs on the chunk that actually hit the anomaly, and it makes progress
+			// instead of deadlocking the op run after run.
+			_ = reporter.Log(slog.LevelWarn, "Batched orphan delete failed; retrying chunk row by row",
 				slog.Int("chunk_start", start),
 				slog.Int("chunk_size", len(ids)),
-				slog.String("first_book_file_id", chunk[0].ID),
-				slog.String("first_book_id", chunk[0].BookID),
-				slog.String("first_file_path", chunk[0].FilePath),
 				slog.String("error", err.Error()),
 			)
+			for i := range chunk {
+				if ctx.Err() != nil {
+					_ = reporter.Log(slog.LevelWarn, "Orphan delete cancelled",
+						slog.Int("deleted", deleted),
+						slog.Int("failed", failed),
+						slog.Int("remaining", total-(start+i)),
+					)
+					return ctx.Err()
+				}
+				if derr := store.DeleteBookFile(chunk[i].ID); derr != nil {
+					failed++
+					_ = reporter.Log(slog.LevelWarn, "Failed to delete orphan book_file",
+						slog.String("book_file_id", chunk[i].ID),
+						slog.String("book_id", chunk[i].BookID),
+						slog.String("file_path", chunk[i].FilePath),
+						slog.String("error", derr.Error()),
+					)
+					continue
+				}
+				deleted++
+				// Tick per row here, not per chunk. The fallback is ~1.35s/row, so a
+				// 500-row chunk is ~11 minutes — well past the registry's 5m default
+				// ProgressTimeout, which this op does not override. Without a stamp in
+				// this loop the watchdog would cancel the op mid-recovery.
+				prog.StepN(start+i+1, fmt.Sprintf("Deleting orphan book_files (row-by-row): %d/%d",
+					start+i+1, total))
+			}
+			// Progress is already stamped by the loop above; fall through.
 			continue
 		}
 		deleted += len(ids)

--- a/internal/server/handlers/mocks/mock_reading_store.go
+++ b/internal/server/handlers/mocks/mock_reading_store.go
@@ -309,6 +309,57 @@ func (_c *MockReadingStore_DeleteBookFile_Call) RunAndReturn(run func(id string)
 	return _c
 }
 
+// DeleteBookFilesByIDs provides a mock function for the type MockReadingStore
+func (_mock *MockReadingStore) DeleteBookFilesByIDs(ids []string) error {
+	ret := _mock.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteBookFilesByIDs")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func([]string) error); ok {
+		r0 = returnFunc(ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockReadingStore_DeleteBookFilesByIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBookFilesByIDs'
+type MockReadingStore_DeleteBookFilesByIDs_Call struct {
+	*mock.Call
+}
+
+// DeleteBookFilesByIDs is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockReadingStore_Expecter) DeleteBookFilesByIDs(ids any) *MockReadingStore_DeleteBookFilesByIDs_Call {
+	return &MockReadingStore_DeleteBookFilesByIDs_Call{Call: _e.mock.On("DeleteBookFilesByIDs", ids)}
+}
+
+func (_c *MockReadingStore_DeleteBookFilesByIDs_Call) Run(run func(ids []string)) *MockReadingStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 []string
+		if args[0] != nil {
+			arg0 = args[0].([]string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReadingStore_DeleteBookFilesByIDs_Call) Return(err error) *MockReadingStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockReadingStore_DeleteBookFilesByIDs_Call) RunAndReturn(run func(ids []string) error) *MockReadingStore_DeleteBookFilesByIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteBookFilesForBook provides a mock function for the type MockReadingStore
 func (_mock *MockReadingStore) DeleteBookFilesForBook(bookID string) error {
 	ret := _mock.Called(bookID)


### PR DESCRIPTION
## The measurement

`maintenance.dedupe-book-file-rows` was reported as "~45 s per book, enough to blow its own 2-hour timeout." Profiling against the production journal corrected that on three points:

1. **It never hit the 2 h `Timeout`** — it hit the **5-minute `ProgressTimeout`** watchdog, at book 19/194. Both liveness bugs are already fixed on main (heartbeat `1908396b`, worker pool `df20b8d6`).
2. **Total work is ~1.3 h, not 2.4 h.** Real denominator: `redundant_rows=2901` across 194 books. The "194 × 45 s" extrapolation double-counted skew — books process in sorted-ID order and the first 19 happened to carry 22–47 duplicates against a mean of 15.
3. **The unit is per-ROW, not per-book.** ~45 s/book is just R × ~1.35 s on heavy books.

Measured cost: **~1.35 s fixed per deleted row**, +~7 ms per remaining file. Proven two ways — the dry-run of the identical read loop over all 194 books took 2.2 s total (so the read path is ~2% of one apply-book), and the per-row delta stays flat (1.85/1.94/1.42/1.66/1.54 s) as `total_files` falls 65 → 34, which rules out an O(R²) re-read as the driver.

## The cause

`DeleteBookFile` calls `notifyBookFileChange` **once per row deleted**, and each call runs the full `RecomputeBookAggregates` → `UpdateBook` chain. Per row that is two `pebble.Sync` commits, a full copy-on-write `book_ver` snapshot marshalling the entire old Book, and two global go-memdb write transactions — the latter on a **single global writer mutex**, held across Pebble I/O.

## The fix

`DeleteBookFilesByIDs([]string) error`, modelled on the existing `DeleteBookFilesForBook`: group by owning book, one Pebble batch, one `Sync`, one memdb transaction, one notify per affected book. `DeleteBookFile` is untouched — other callers rely on its per-row notify.

Collapses, per book: 2R fsyncs → 2, R memdb write txns → 1, R `book_ver` snapshots → 1.

**Salvage is deliberately NOT folded into the batch.** Rescued keeper fields must be committed *before* donor rows are deleted; an atomic batch would silently remove the "if the salvage write fails, skip this group" escape. This repo's dominant incident class is field wipes on write-back.

## Fail-closed, and the one caller where that wasn't enough

If any ID fails to resolve, nothing is deleted and the error names the offenders — an unresolvable ID means the caller's view disagrees with the store.

That is self-healing for `dedupe-book-file-rows`, which re-reads its row set from Pebble each run. It is **not** self-healing for `orphan-book-files-cleanup`: `findOrphanBookFiles` reads `GetAllBookFilesCore`, served from **memdb** when `UseMemDB` is on (i.e. production). memdb is a derived cache that can hold a row Pebble no longer has, so a single phantom row would abort the same 500-row chunk on every nightly run until restart — strictly worse than the old per-row loop, which skipped the phantom and deleted the other 499.

So the store stays fail-closed and the orphan caller retries a rejected chunk row-by-row, stamping progress **per row** so the 5-minute `ProgressTimeout` cannot fire mid-recovery.

## Testing

The "notified exactly once" assertion counts `book_ver:<bookID>:` snapshot keys before and after — measuring the actual expensive artifact rather than a proxy — and is anchored by a paired control test asserting the per-row path still produces one snapshot *per row*. Without that control, "exactly 1" could pass vacuously.

```
go build ./...                                                    OK
go vet ./internal/database/... ./internal/plugins/maintenance/...  OK
go test ./internal/database/... ./internal/plugins/maintenance/... -race -count=1
ok  	internal/database         597.397s
ok  	internal/database/mocks     1.506s
ok  	internal/plugins/maintenance 33.911s
```

## Noted, not fixed

- `DeleteBookFilesForBook` — the pattern this was modelled on — never calls `DeleteBookFileFromMemDB` or `MarkQuickQueryDirty`, so it leaves stale memdb rows behind. Latent inconsistency, out of scope here.
- `UpsertBookToMemDB` does three Pebble reads *inside* go-memdb's global writer mutex. That is a system-wide ceiling on every `UpdateBook`, not specific to this op, and is the natural follow-up.
- `failed` in dedupe now counts per-book batch failures rather than per-row, so the op's reported numbers shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp