### PR TITLE
feat(maintenance): tier-2 duration probe for directory-shaped unlinked books

### DIFF
--- a/changelog.d/tier2-probe-directory-books.md
+++ b/changelog.d/tier2-probe-directory-books.md
@@ -1,5 +1,5 @@
 <!-- file: changelog.d/tier2-probe-directory-books.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 7e3b0c95-8d24-4f61-a07c-5b19d2e6a834 -->
 <!-- last-edited: 2026-08-06 -->
 
@@ -66,3 +66,14 @@ contribute zeros fails three tests, including one whose numbers are chosen so
 that exclusion *alone* decides the verdict (4 files sharing a stem, one measured
 at 6,000s and three unprobeable — counted as zeros that is 1-of-4 long and
 auto-links; excluded it is 1-of-1 long and the series guard fires).
+
+The apply path refuses on its own rather than trusting its caller: it errors out
+when handed a verdict that is not one-book, and when the folder's audio contents
+changed between probing and applying (the verdict describes the folder *as
+measured*, and a file that arrived since was never measured). Both refusals are
+mutation-tested — removing the verdict guard fails
+`TestLinkProbedFolder_RefusesSeriesVerdict`. The run report also samples the
+folders that *stayed* in review with their new measured reason, and tallies them
+by category (`confirmed-series` / `unprobeable-files` / `distinct-titles` /
+`no-audio`), since proof that the series guard fired for the right reason on the
+right folders is what an operator needs before authorising an apply.

--- a/changelog.d/tier2-probe-directory-books.md
+++ b/changelog.d/tier2-probe-directory-books.md
@@ -1,0 +1,68 @@
+<!-- file: changelog.d/tier2-probe-directory-books.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7e3b0c95-8d24-4f61-a07c-5b19d2e6a834 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+#### `maintenance.probe-directory-books`: tier-2 duration probe for the 1,019 directory-shaped books stuck in review
+
+`maintenance.relink-unlinked-books` (PR #2147) relinked 16.0k of 17,149 unlinked
+books, but 1,019 directory-shaped books went to review — not because they were
+unknowable, but because they were never measured. `classifyUnlinked` calls
+`linkintegrity.ClassifyDir(names, subdirs, nil)`: durations are always `nil`,
+because a whole-library pass over 44,887 books can afford one DB read and one
+`os.Stat` per book and nothing more. Without durations, `ClassifyDir`'s series
+guard cannot fire, so it correctly refuses to auto-link and every multi-file
+folder is parked with the reason "no durations are known — cannot rule out a
+series".
+
+That refusal is right at tier 1 and wrong as a final answer. The new op is the
+First Aid tier-2 escalation: the flagged set is ~1,019 folders rather than 44,887
+books, which is small enough to afford an `ffprobe` per audio file. It reuses the
+tier-1 detection (`classifyUnlinked`) rather than reimplementing it, then re-runs
+the *same* classifier through the new `linkintegrity.ClassifyDirProbed` with the
+measured durations filled in. Writing a second classifier here would let tier 1
+and tier 2 drift into disagreeing about the same folder. Dry run by default;
+nothing is written unless the caller passes `{"apply": true}`.
+
+🔴 **Absent evidence means "cannot verify", never "refuted."** A probe that fails
+contributes nothing to the verdict — never a zero. A zero duration reads as
+"short file, therefore a chapter, therefore safe to merge", and that exact
+substitution (`DurationSec == 0` taken as evidence rather than as its absence)
+disabled the regroup series guard across 97.5% of the review queue and came
+within one apply of merging 41 of 43 distinct novels. The invariant is now
+carried structurally by `linkintegrity.ProbedDuration`'s `OK` flag instead of by
+convention, and it treats a *successful* `ffprobe` exit reporting zero seconds
+(a truncated or header-only container) as unmeasured too — `ProbeDurationSeconds`
+deliberately does not validate that itself. A coverage guard additionally keeps
+any folder with an unprobeable file in review, because excluding failures alone
+still lets a barely-inspected folder pass when its one measured file happens to
+read chapter-length.
+
+A missing `ffprobe` makes the op fail before it touches the store, rather than
+classifying all 1,019 folders as unknown-duration — which would look exactly like
+a successful run that found nothing to do. `internal/audioutil` gained
+`LookupFFprobe` / `FFprobeAvailable` / `ErrFFprobeNotAvailable`, following the
+detect-or-disable convention `internal/fingerprint` already uses.
+
+Concurrency is a bounded `registry.RunItems` pool at the folder level sized to
+`runtime.NumCPU()`, per the CLAUDE.md mandate; files *within* a folder are probed
+sequentially, because a nested pool would put NumCPU² `ffprobe` processes on the
+box at once. Progress is stamped mid-folder rather than only between folders: the
+registry watchdog kills any op quiet for longer than `ProgressTimeout` (default 5
+minutes), and a 23-file folder each hitting the 20s per-file `ffprobe` timeout
+runs ~7.7 minutes — the same way `maintenance.dedupe-book-file-rows` previously
+died at book 19/194. The apply path writes the *measured* duration onto each new
+`book_file` row (tier 1 must seed 0, having never probed); a zero there would
+leave the regroup series guard just as inert as having no rows at all. Like its
+tier-1 sibling, the file contains no `UpdateBook` call at all, so the write-back
+wipe class is structurally unreachable.
+
+Verified with `go build ./...`, `go vet`, and
+`go test ./internal/linkintegrity/... ./internal/plugins/maintenance/... -race
+-count=1` (green). The exclusion guard is mutation-tested: making failed probes
+contribute zeros fails three tests, including one whose numbers are chosen so
+that exclusion *alone* decides the verdict (4 files sharing a stem, one measured
+at 6,000s and three unprobeable — counted as zeros that is 1-of-4 long and
+auto-links; excluded it is 1-of-1 long and the series guard fires).

--- a/internal/audioutil/duration.go
+++ b/internal/audioutil/duration.go
@@ -1,7 +1,7 @@
 // file: internal/audioutil/duration.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 03399668-0f87-4d27-b118-8315b574ef23
-// last-edited: 2026-07-18
+// last-edited: 2026-08-06
 
 // Package audioutil holds small, dependency-free helpers shared by the audio
 // processing packages (internal/mediainfo, internal/fingerprint,
@@ -12,11 +12,45 @@ package audioutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
 )
+
+// ErrFFprobeNotAvailable is returned by LookupFFprobe when no ffprobe binary can
+// be resolved. It is a sentinel so callers can distinguish "the tool is missing"
+// from "the tool ran and the file was unreadable" — a distinction that matters
+// because the two demand opposite responses. A missing binary means EVERY probe
+// in a run will fail, so an op that treats it as a per-file error reports a
+// library full of unprobeable files: a clean-looking run that actually measured
+// nothing. Callers must check availability ONCE, up front, and refuse to run.
+var ErrFFprobeNotAvailable = errors.New("audioutil: ffprobe not found on PATH — install ffmpeg (which ships ffprobe)")
+
+// LookupFFprobe resolves the ffprobe binary on PATH, returning the absolute path
+// for callers to pass to ProbeDurationSeconds.
+//
+// This mirrors the detect-or-disable convention the fingerprint package already
+// uses (fingerprint.ErrNotAvailable + fingerprint.Available): resolve the binary
+// once, and let a feature that depends on it announce that it cannot run rather
+// than degrade into silently producing empty results.
+//
+// Resolving once and passing the path down also avoids re-running a PATH search
+// per file, which matters for ops that probe thousands of files.
+func LookupFFprobe() (string, error) {
+	p, err := exec.LookPath("ffprobe")
+	if err != nil {
+		return "", ErrFFprobeNotAvailable
+	}
+	return p, nil
+}
+
+// FFprobeAvailable reports whether LookupFFprobe would succeed.
+func FFprobeAvailable() bool {
+	_, err := LookupFFprobe()
+	return err == nil
+}
 
 // ProbeDurationSeconds shells out to ffprobe and returns the container's
 // reported duration in seconds, as a float64 with no rounding applied.

--- a/internal/linkintegrity/classify.go
+++ b/internal/linkintegrity/classify.go
@@ -1,7 +1,7 @@
 // file: internal/linkintegrity/classify.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a3e15c8-4b92-4d07-a6f3-1c85920be47d
-// last-edited: 2026-08-05
+// last-edited: 2026-08-06
 
 package linkintegrity
 
@@ -89,6 +89,14 @@ type DirVerdict struct {
 	DistinctStems int
 	// AudioCount is how many audio files the folder held.
 	AudioCount int
+
+	// ProbesOK / ProbesFailed are set only by ClassifyDirProbed and record how
+	// much of the folder was actually MEASURED. They are reported separately
+	// from AudioCount on purpose: "4 files, 4 measured" and "4 files, 1
+	// measured" can produce the same verdict from very different evidence, and
+	// an operator reading the queue needs to see which one they are looking at.
+	ProbesOK     int
+	ProbesFailed int
 }
 
 // ClassifyDir decides whether a directory's audio files are one book.
@@ -161,6 +169,85 @@ func ClassifyDir(names []string, subdirCount int, durationsSec []int) DirVerdict
 
 	v.OneBook = true
 	v.Reason = fmt.Sprintf("%d audio files share one title and are chapter-length — one book", len(audio))
+	return v
+}
+
+// ── tier-2: classification with PROBED durations ─────────────────────────────
+//
+// ClassifyDir's series guard is inert without durations, so a whole-library
+// tier-1 scan (one DB read + one os.Stat per book, no budget for subprocesses)
+// can only ever route a multi-file folder to review. Tier 2 revisits that much
+// smaller flagged set and spends an ffprobe per file to supply the missing
+// signal. ClassifyDirProbed is the seam between the two: same classifier, better
+// inputs.
+
+// ProbedDuration is one audio file's probe OUTCOME — deliberately not a bare
+// int.
+//
+// 🔴 THIS TYPE EXISTS TO KEEP "COULD NOT MEASURE" FROM BECOMING "MEASURED
+// ZERO". A failed probe expressed as 0 seconds does not read as missing data
+// downstream; it reads as a very short file, which the series guard interprets
+// as "a chapter, therefore safe to merge into one book". That exact substitution
+// — DurationSec==0 taken as evidence rather than as its absence — disabled the
+// regroup series guard across 97.5% of the review queue and came within one
+// apply of merging 41 of 43 distinct novels. Carrying the OK flag alongside the
+// number makes the failure impossible to express.
+type ProbedDuration struct {
+	// Name is the audio file's basename, for reporting.
+	Name string
+	// Sec is the measured runtime in seconds. Meaningful ONLY when OK is true.
+	Sec int
+	// OK is true only when the file was genuinely measured. Construct it as
+	// (err == nil && secs > 0): ffprobe can exit 0 having reported nothing
+	// usable for a truncated or header-only container, and audioutil's
+	// ProbeDurationSeconds deliberately does not validate that itself ("callers
+	// apply their own validity rules"). A zero from a successful exit is still
+	// an absence of evidence.
+	OK bool
+}
+
+// ClassifyDirProbed classifies a directory using per-file probe outcomes.
+//
+// It feeds ClassifyDir ONLY the durations that were actually measured — a failed
+// probe contributes nothing at all rather than a zero — and then applies a
+// coverage guard on top of the result.
+//
+// WHY THE COVERAGE GUARD IS NEEDED ON TOP OF THE EXCLUSION. Excluding failures
+// already fixes the dangerous direction in most shapes: with 4 files sharing one
+// stem where only one measured 6,000s, the guard sees 1-of-1 long and fires.
+// But the reverse partial is still unsafe — one file measured at chapter length
+// and three unknown yields "0 of 1 are long", which passes the guard and would
+// auto-link a folder we have barely looked at. So when ANY probe failed, a
+// multi-file folder cannot be called one book no matter how the measured subset
+// reads. Absent evidence means "cannot verify", never "confirmed".
+//
+// The single-audio-file case is exempt because its verdict never depended on
+// duration: one file in a folder is one book whether or not it could be probed.
+func ClassifyDirProbed(names []string, subdirCount int, probes []ProbedDuration) DirVerdict {
+	known := make([]int, 0, len(probes))
+	failed := 0
+	for _, p := range probes {
+		// Re-check Sec > 0 rather than trusting OK alone: this is the one place
+		// the invariant is enforced, and a caller that sets OK from err==nil
+		// only must not be able to smuggle a zero past it.
+		if p.OK && p.Sec > 0 {
+			known = append(known, p.Sec)
+			continue
+		}
+		failed++
+	}
+
+	v := ClassifyDir(names, subdirCount, known)
+	v.ProbesOK = len(known)
+	v.ProbesFailed = failed
+
+	if failed > 0 && v.OneBook && v.AudioCount > 1 {
+		v.OneBook = false
+		v.Reason = fmt.Sprintf(
+			"%d audio files share one title and the %d that could be measured are chapter-length, "+
+				"but %d file(s) could not be probed — cannot rule out a series on partial evidence",
+			v.AudioCount, len(known), failed)
+	}
 	return v
 }
 

--- a/internal/linkintegrity/classify_probed_test.go
+++ b/internal/linkintegrity/classify_probed_test.go
@@ -1,0 +1,180 @@
+// file: internal/linkintegrity/classify_probed_test.go
+// version: 1.0.0
+// guid: 2d84f13b-6a09-4c72-9e51-8b3f0d6a4c27
+// last-edited: 2026-08-06
+
+package linkintegrity
+
+import (
+	"strings"
+	"testing"
+)
+
+const testHour = 3600
+
+// TestClassifyDirProbed_ChapterLengthFolderResolves is the case the nil
+// durations were blocking. Tier 1 could only park this folder with "no
+// durations are known"; measuring it must resolve it to one book.
+func TestClassifyDirProbed_ChapterLengthFolderResolves(t *testing.T) {
+	files := []string{
+		"The Given Sacrifice_01_.mp3", "The Given Sacrifice_02_.mp3",
+		"The Given Sacrifice_03_.mp3", "The Given Sacrifice_04_.mp3",
+	}
+
+	// Baseline: this is exactly what tier 1 sees, and why 1,019 folders queued.
+	if v := ClassifyDir(files, 0, nil); v.OneBook {
+		t.Fatal("precondition failed: tier 1 must NOT resolve this without durations")
+	}
+
+	probes := []ProbedDuration{
+		{Name: files[0], Sec: 1500, OK: true},
+		{Name: files[1], Sec: 1480, OK: true},
+		{Name: files[2], Sec: 1520, OK: true},
+		{Name: files[3], Sec: 1495, OK: true},
+	}
+	got := ClassifyDirProbed(files, 0, probes)
+	if !got.OneBook {
+		t.Errorf("OneBook = false, want true — chapter-length files sharing one stem are one book; reason=%q", got.Reason)
+	}
+	if got.ProbesOK != 4 || got.ProbesFailed != 0 {
+		t.Errorf("ProbesOK/Failed = %d/%d, want 4/0", got.ProbesOK, got.ProbesFailed)
+	}
+}
+
+// TestClassifyDirProbed_SeriesGuardFires is the "Super Sales on Super Heroes
+// 1..5" shape: one shared stem, but every member is a whole novel. Duration is
+// the ONLY signal that separates it from a chapter set, so this is the case that
+// justifies probing at all — and it must stay in review.
+func TestClassifyDirProbed_SeriesGuardFires(t *testing.T) {
+	files := []string{
+		"Super Sales on Super Heroes 1.m4b",
+		"Super Sales on Super Heroes 2.m4b",
+		"Super Sales on Super Heroes 3.m4b",
+		"Super Sales on Super Heroes 4.m4b",
+		"Super Sales on Super Heroes 5.m4b",
+	}
+	probes := make([]ProbedDuration, 0, len(files))
+	for _, f := range files {
+		probes = append(probes, ProbedDuration{Name: f, Sec: 9 * testHour, OK: true})
+	}
+
+	got := ClassifyDirProbed(files, 0, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — this would MERGE 5 distinct novels into one row; reason=%q", got.Reason)
+	}
+	if !strings.Contains(got.Reason, "whole books") {
+		t.Errorf("reason must name the evidence that fired the series guard, got %q", got.Reason)
+	}
+}
+
+// 🔴 TestClassifyDirProbed_PartialFailureExcludedNotZeroed is the regression
+// test for the incident this op exists to avoid reproducing.
+//
+// The numbers are chosen so that EXCLUSION ALONE decides the verdict, which
+// means the test cannot pass on the coverage guard by accident:
+//
+//	4 files, one stem. One measures 6,000s (book-length); three fail.
+//	  counted as zero  → long=1, n=4 → 1*2 > 4 is FALSE → OneBook (WRONG)
+//	  excluded         → long=1, n=1 → 1*2 > 1 is TRUE  → series guard fires
+//
+// If failed probes ever start contributing zeros, this flips to OneBook=true and
+// the test fails — which is the whole point.
+func TestClassifyDirProbed_PartialFailureExcludedNotZeroed(t *testing.T) {
+	files := []string{
+		"Wandering Inn 1.mp3", "Wandering Inn 2.mp3",
+		"Wandering Inn 3.mp3", "Wandering Inn 4.mp3",
+	}
+	probes := []ProbedDuration{
+		{Name: files[0], Sec: 6000, OK: true},
+		{Name: files[1]}, // probe failed — OK false, Sec zero-valued
+		{Name: files[2]},
+		{Name: files[3]},
+	}
+
+	got := ClassifyDirProbed(files, 0, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — a failed probe was counted as a zero-length chapter; reason=%q", got.Reason)
+	}
+	if got.ProbesOK != 1 || got.ProbesFailed != 3 {
+		t.Errorf("ProbesOK/Failed = %d/%d, want 1/3 — the failures must be COUNTED as unmeasured",
+			got.ProbesOK, got.ProbesFailed)
+	}
+	// Pin the mechanism, not just the verdict: the durations slice handed to
+	// ClassifyDir must have held one entry, so the guard's denominator was 1.
+	if !strings.Contains(got.Reason, "whole books") {
+		t.Errorf("expected the series guard to fire on the measured subset, got %q", got.Reason)
+	}
+}
+
+// The reverse partial: the measured subset reads as chapter-length, so exclusion
+// alone would happily auto-link a folder we have barely looked at. This is the
+// case the coverage guard exists for.
+func TestClassifyDirProbed_PartialFailureBlocksOneBookVerdict(t *testing.T) {
+	files := []string{
+		"Skyward 1.mp3", "Skyward 2.mp3", "Skyward 3.mp3", "Skyward 4.mp3",
+	}
+	probes := []ProbedDuration{
+		{Name: files[0], Sec: 1200, OK: true}, // chapter-length
+		{Name: files[1]},                      // unprobeable
+		{Name: files[2]},
+		{Name: files[3]},
+	}
+
+	got := ClassifyDirProbed(files, 0, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true on 1 of 4 files measured — partial evidence must not confirm; reason=%q", got.Reason)
+	}
+	if !strings.Contains(got.Reason, "could not be probed") {
+		t.Errorf("reason must name the unmeasured files as the blocker, got %q", got.Reason)
+	}
+}
+
+// A successful ffprobe exit reporting zero is NOT a measurement. Callers build
+// OK as (err == nil && secs > 0), but the classifier re-checks so a caller that
+// forgets cannot smuggle a zero into the guard.
+func TestClassifyDirProbed_ZeroSecondsIsNotEvidence(t *testing.T) {
+	files := []string{"Nona 1.mp3", "Nona 2.mp3", "Nona 3.mp3", "Nona 4.mp3"}
+	probes := []ProbedDuration{
+		{Name: files[0], Sec: 6000, OK: true},
+		{Name: files[1], Sec: 0, OK: true}, // header-only container, exit 0
+		{Name: files[2], Sec: 0, OK: true},
+		{Name: files[3], Sec: 0, OK: true},
+	}
+
+	got := ClassifyDirProbed(files, 0, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — a zero-second 'success' was admitted as evidence; reason=%q", got.Reason)
+	}
+	if got.ProbesOK != 1 || got.ProbesFailed != 3 {
+		t.Errorf("ProbesOK/Failed = %d/%d, want 1/3 — zero-second results must count as unmeasured",
+			got.ProbesOK, got.ProbesFailed)
+	}
+}
+
+// A single audio file is one book whether or not it could be measured — its
+// verdict never depended on duration, so the coverage guard must not park it.
+func TestClassifyDirProbed_SingleFileExemptFromCoverageGuard(t *testing.T) {
+	files := []string{"The Rising.m4b"}
+	got := ClassifyDirProbed(files, 0, []ProbedDuration{{Name: files[0]}})
+	if !got.OneBook {
+		t.Errorf("OneBook = false — a lone audio file is one book regardless of probe success; reason=%q", got.Reason)
+	}
+}
+
+// Folders whose files carry many distinct titles are decided by stems, before
+// duration is consulted at all. Measuring must not rescue them.
+func TestClassifyDirProbed_DistinctTitlesStayInReview(t *testing.T) {
+	files := []string{
+		"01 Skinwalker part 1.mp3", "02 Blood Cross Part 1.mp3",
+		"03 Mercy Blade Part 1.mp3",
+	}
+	probes := []ProbedDuration{
+		{Name: files[0], Sec: 1200, OK: true},
+		{Name: files[1], Sec: 1200, OK: true},
+		{Name: files[2], Sec: 1200, OK: true},
+	}
+	got := ClassifyDirProbed(files, 0, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — distinct novels sharing a folder must never merge; reason=%q", got.Reason)
+	}
+}

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/plugin.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: b2c3d4e5-f6a7-8901-bcde-123456789012
-// last-edited: 2026-08-04
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -81,6 +81,12 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		// path resolves fine but which own zero book_file rows (17,149 of 44,886
 		// on 2026-08-05). Neither can see the other's population.
 		p.relinkUnlinkedBooksDef(),
+		// probe-directory-books is relink's TIER-2 escalation, not a rival: relink
+		// classifies 44,887 books on a one-stat budget and must pass nil durations,
+		// which leaves ClassifyDir's series guard inert and parks every multi-file
+		// folder (1,019 of them). This op re-runs the same classifier over just
+		// that flagged set with real ffprobe durations filled in.
+		p.probeDirectoryBooksDef(),
 		p.itunesHealDef(),
 		p.introTranscribeDef(),
 		p.extractWAVClipsDef(),

--- a/internal/plugins/maintenance/probe_directory_books.go
+++ b/internal/plugins/maintenance/probe_directory_books.go
@@ -1,0 +1,561 @@
+// file: internal/plugins/maintenance/probe_directory_books.go
+// version: 1.0.0
+// guid: 6f2a90d4-3c81-4e57-b0a6-9d47e1c85b23
+// last-edited: 2026-08-06
+
+// Package maintenance — op maintenance.probe-directory-books.
+//
+// TIER 2 OF FIRST AID: re-decide, with measured evidence, the directory-shaped
+// books that tier 1 could only park.
+//
+// 🔴 THE PROBLEM THIS EXISTS TO CLOSE. maintenance.relink-unlinked-books
+// relinked 16.0k of 17,149 unlinked books. The 1,019 that went to review are NOT
+// unknowable — they were never MEASURED. classifyUnlinked calls
+// linkintegrity.ClassifyDir(names, subdirs, nil): durations are always nil,
+// because a whole-library pass over 44,887 books can afford one DB read and one
+// os.Stat per book and nothing more. ClassifyDir's series guard cannot fire
+// without durations, so it refuses — correctly — and every multi-file folder
+// lands in review carrying the reason "no durations are known — cannot rule out
+// a series".
+//
+// That refusal is right at tier 1 and wrong as a final answer. Tier 2's whole
+// premise is that the flagged set is small enough (~1,019 folders, not 44,887
+// books) to afford what tier 1 could not: an ffprobe per audio file. This op
+// spends exactly that, then re-runs THE SAME classifier with the durations
+// filled in.
+//
+// SAME CLASSIFIER, NOT A SECOND ONE. Detection reuses classifyUnlinked from
+// relink_unlinked.go and the verdict comes from linkintegrity.ClassifyDirProbed,
+// which wraps ClassifyDir. Writing a parallel classifier here would let tier 1
+// and tier 2 drift into disagreeing about the same folder, which is worse than
+// either being wrong on its own.
+//
+// 🔴 ABSENT EVIDENCE MEANS "CANNOT VERIFY", NEVER "REFUTED". A probe that fails
+// contributes NOTHING to the verdict — never a zero. A zero duration reads as
+// "short file, therefore a chapter, therefore safe to merge", and that exact
+// substitution disabled the regroup series guard across 97.5% of the review
+// queue and nearly merged 41 of 43 distinct novels. The invariant is carried
+// structurally by linkintegrity.ProbedDuration's OK flag rather than by
+// convention, and a folder with ANY unprobeable file stays in review.
+//
+// The same rule governs a missing ffprobe: the op refuses to start rather than
+// classifying all 1,019 folders as unknown-duration, which would look like a
+// successful run that simply found nothing to do.
+//
+// 🔴 DATA-LOSS SAFETY. Like relink_unlinked.go, this file contains NO UpdateBook
+// call — the defence is structural, not a promise. This repo's dominant incident
+// class is the write-back wipe (a bare UpdateBook clearing AcoustIDFingerprint /
+// Author / Series). The only write here is CreateBookFile, which is additive.
+//
+// DRY RUN BY DEFAULT, matching its tier-1 sibling: nothing is written unless the
+// caller passes {"apply": true}.
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/linkintegrity"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// probeDirParams configures the op.
+type probeDirParams struct {
+	// Apply gates every write. False (the default) makes this a pure re-classifier
+	// that reports what the measured durations would change.
+	Apply bool `json:"apply"`
+	// Limit caps how many folders are LINKED this run (0 = no cap). Probing and
+	// re-classification always cover the whole flagged set, mirroring
+	// relink-unlinked-books: a capped run must never look like a clean bill of
+	// health, so the cap applies to the writes and never to the measurement.
+	Limit int `json:"limit"`
+}
+
+// probeFileTimeout bounds one ffprobe invocation.
+//
+// This mirrors the value of internal/mediainfo's ffprobeDurationTimeout (20s),
+// which is unexported and therefore cannot be imported. ffprobe only reads the
+// container header, so 20s is generous even for a multi-GB audiobook; the
+// timeout exists for a wedged mount, not for slow files.
+const probeFileTimeout = 20 * time.Second
+
+// ── injection seam for tests ─────────────────────────────────────────────────
+//
+// ProbeDurationSeconds and LookupFFprobe are package-level functions, so tests
+// substitute them through these two vars rather than shelling out to a real
+// ffprobe. Keeping the seam this narrow (two vars, default-wired to the real
+// implementations) means production takes exactly the code path it always did.
+//
+// Tests that swap these must NOT run in parallel and must restore via
+// t.Cleanup — they are process-global.
+var (
+	probeDurationSecondsFn = audioutil.ProbeDurationSeconds
+	lookupFFprobeFn        = audioutil.LookupFFprobe
+)
+
+func (p *Plugin) probeDirectoryBooksDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:          "maintenance.probe-directory-books",
+		Plugin:      "maintenance",
+		DisplayName: "Probe directory-shaped books (tier 2 · re-classify)",
+		Description: "Tier-2 escalation over the directory-shaped unlinked books that relink-unlinked-books could only " +
+			"send to review. Tier 1 passes nil durations, so ClassifyDir's series guard cannot fire and every multi-file " +
+			"folder is parked. This op probes each audio file's real duration with ffprobe and re-runs the SAME " +
+			"classifier with that evidence, resolving folders that were un-probed rather than unknowable. Files that " +
+			"cannot be probed are excluded, never counted as zero, and a folder with any unprobeable file stays in " +
+			"review. Refuses to run when ffprobe is unavailable. DRY RUN unless {\"apply\": true}.",
+		ResumePolicy:    sdk.ResumeDrop,
+		DefaultPriority: sdk.PriorityNormal,
+		// Shares tier 1's key: both ops create book_file rows for the same
+		// unlinked population, and running them concurrently would let each see
+		// a half-repaired library.
+		ConcurrencyKey: "maintenance.relink-unlinked-books",
+		Cancellable:    true,
+		Isolate:        false,
+		Timeout:        120 * time.Minute,
+		Capabilities:   []sdk.Capability{sdk.CapLibraryRead, sdk.CapFilesRead, sdk.CapLibraryWrite},
+		Run:            p.runProbeDirectoryBooks,
+	}
+}
+
+// probeCandidate pairs a tier-1 finding with the folder contents tier 2 measured.
+type probeCandidate struct {
+	finding linkintegrity.Finding
+	// beforeReason is tier 1's verdict text, kept so the report can show what
+	// measurement actually changed rather than only the new state.
+	beforeReason string
+	probes       []linkintegrity.ProbedDuration
+	verdict      linkintegrity.DirVerdict
+}
+
+func (p *Plugin) runProbeDirectoryBooks(ctx context.Context, raw json.RawMessage, reporter sdk.Reporter) error {
+	params := probeDirParams{}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return fmt.Errorf("invalid params: %w", err)
+		}
+	}
+
+	// ── Phase 0: refuse to run without ffprobe ───────────────────────────────
+	//
+	// This check comes FIRST — before the store is even fetched — because the
+	// only honest outcome of a missing ffprobe is a hard failure. Every probe
+	// would fail, every folder would be classified unknown-duration, and the op
+	// would report the same "nothing resolved" summary it reports when the
+	// library is genuinely healthy. Those two states must not look alike.
+	ffprobePath, err := lookupFFprobeFn()
+	if err != nil {
+		return fmt.Errorf("cannot run: this op measures real durations and has no fallback — %w", err)
+	}
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf("using ffprobe at %s", ffprobePath))
+
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	if !params.Apply {
+		_ = reporter.Log(slog.LevelInfo, "DRY RUN — no book_file rows will be created")
+	}
+
+	// ── Phase 1: find the directory-shaped books held for review ─────────────
+	_ = reporter.UpdateProgress(0, 0, "Phase 1/3: enumerating library…")
+	ids, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("ListBookIDs: %w", err)
+	}
+
+	// CONCURRENCY (CLAUDE.md mandate): identical shape to tier 1's detection
+	// sweep — a serial os.Stat pass over 44,887 books on ZFS is the hotspot that
+	// hung dedup.full-scan for 3+ hours on one core. Detection is read-only, so
+	// results are collected under a mutex and every write happens later.
+	var mu sync.Mutex
+	candidates := make([]probeCandidate, 0, 1024)
+	var examined, skipped, dirAlreadyLinkable int
+
+	scanErr := registry.RunItems(ctx, reporter, ids, func(_ context.Context, id string) error {
+		b, err := store.GetBookByID(id)
+		if err != nil || b == nil {
+			mu.Lock()
+			skipped++
+			mu.Unlock()
+			return nil // a book that vanished mid-scan is not this op's problem
+		}
+		files, ferr := store.GetBookFiles(id)
+		if ferr != nil {
+			mu.Lock()
+			skipped++
+			mu.Unlock()
+			return nil
+		}
+		mu.Lock()
+		examined++
+		mu.Unlock()
+
+		if len(files) > 0 {
+			return nil // already linked
+		}
+		path := strings.TrimSpace(b.FilePath)
+		if path == "" {
+			return nil
+		}
+
+		// REUSE, don't reimplement: this is the identical call tier 1 makes, so
+		// the two ops cannot disagree about which books are in scope.
+		f := classifyUnlinked(b, path)
+		if f.Shape != linkintegrity.ShapeDirectory {
+			return nil
+		}
+		if f.Action != linkintegrity.DispositionReview {
+			// A directory tier 1 could already resolve (the single-audio-file
+			// case). Counted, not re-probed — tier 1 owns it.
+			mu.Lock()
+			dirAlreadyLinkable++
+			mu.Unlock()
+			return nil
+		}
+		mu.Lock()
+		candidates = append(candidates, probeCandidate{finding: f, beforeReason: f.Reason})
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   runtime.NumCPU(),
+		ProgressTotal: len(ids),
+		ErrMode:       registry.ErrModeCollect,
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Phase 1/3: checking book %d/%d…", i+1, total)
+		},
+	})
+	if scanErr != nil {
+		return fmt.Errorf("library scan: %w", scanErr)
+	}
+
+	// Deterministic order so two dry runs diff cleanly and a capped apply always
+	// picks the same prefix.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].finding.BookID < candidates[j].finding.BookID
+	})
+
+	// ── Phase 2: probe every folder, re-classify with real durations ─────────
+	//
+	// CONCURRENCY: one bounded pool at the FOLDER level, sized to
+	// runtime.NumCPU(). ffprobe is a subprocess doing CPU+IO work, so NumCPU is
+	// the right width. Files WITHIN a folder are probed sequentially and
+	// deliberately: a nested pool would put NumCPU² ffprobe processes on the box
+	// at once, which on a 32-core server is a fork bomb dressed as parallelism.
+	var doneFolders atomic.Int64
+	totalFolders := len(candidates)
+
+	if err := probeAll(ctx, reporter, ffprobePath, candidates, &doneFolders, totalFolders); err != nil {
+		return fmt.Errorf("duration probe: %w", err)
+	}
+
+	// Fold the new verdict back into each finding. Reason carries the EVIDENCE,
+	// per linkintegrity's report contract — a queue of rows all saying
+	// "ambiguous" is the failure this whole effort exists to correct.
+	// transitionCap bounds the worked example list: enough to sanity-check a dry
+	// run by eye, not so many that the log becomes the report.
+	const transitionCap = 10
+	var nowOneBook, stillReview, withFailedProbes int
+	transitions := make([]string, 0, transitionCap)
+	for i := range candidates {
+		c := &candidates[i]
+		c.finding.Reason = c.verdict.Reason
+		if c.verdict.OneBook {
+			c.finding.Action = linkintegrity.DispositionLink
+			nowOneBook++
+			// Show BEFORE → AFTER for the folders measurement actually moved.
+			// A count alone ("812 resolved") is not reviewable; the owner has to
+			// be able to see that the evidence justifies the change before
+			// authorising an apply.
+			if len(transitions) < transitionCap {
+				transitions = append(transitions, fmt.Sprintf("%s [%s]: %q → %q",
+					c.finding.BookID, linkintegrity.DirNameOf(c.finding.FilePath),
+					c.beforeReason, c.verdict.Reason))
+			}
+		} else {
+			c.finding.Action = linkintegrity.DispositionReview
+			stillReview++
+		}
+		if c.verdict.ProbesFailed > 0 {
+			withFailedProbes++
+		}
+	}
+
+	// ── Phase 3: apply (only with apply=true) ────────────────────────────────
+	linked, linkErrs := 0, 0
+	if params.Apply {
+		_ = reporter.UpdateProgress(totalFolders, totalFolders+1, "Phase 3/3: creating book_file rows…")
+		for i := range candidates {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if params.Limit > 0 && linked >= params.Limit {
+				break
+			}
+			c := candidates[i]
+			if c.finding.Action != linkintegrity.DispositionLink {
+				continue
+			}
+			n, err := linkProbedFolder(store, c)
+			if err != nil {
+				_ = reporter.Log(slog.LevelWarn, fmt.Sprintf(
+					"link %s (%s): %v", c.finding.BookID, c.finding.FilePath, err))
+				linkErrs++
+				continue
+			}
+			if n > 0 {
+				linked++
+			}
+		}
+	}
+
+	findings := make([]linkintegrity.Finding, 0, len(candidates))
+	for i := range candidates {
+		findings = append(findings, candidates[i].finding)
+	}
+
+	phase := linkintegrity.PhaseResult{
+		Name:     "probe-directory-books",
+		Examined: len(candidates),
+		Applied:  params.Apply,
+		Actioned: linked,
+		Errors:   linkErrs,
+		// Every examined folder lands in exactly one bucket, so the phase
+		// reconciles. A phase that does not reconcile fails the op.
+		Skipped:  len(candidates) - linked - linkErrs,
+		Findings: findings,
+	}
+
+	report := linkintegrity.Report{
+		LibraryTotal: len(ids),
+		DryRun:       !params.Apply,
+		Phases:       []linkintegrity.PhaseResult{phase},
+	}
+
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"RECONCILE: library=%d examined=%d scan-skipped=%d dir-review=%d dir-already-linkable=%d",
+		len(ids), examined, skipped, len(candidates), dirAlreadyLinkable))
+	_ = reporter.Log(slog.LevelInfo, fmt.Sprintf(
+		"RECLASSIFIED with measured durations: now-one-book=%d still-review=%d folders-with-unprobeable-files=%d",
+		nowOneBook, stillReview, withFailedProbes))
+	for _, tr := range transitions {
+		_ = reporter.Log(slog.LevelInfo, "resolved by measurement: "+tr)
+	}
+	_ = reporter.Log(slog.LevelInfo, report.Summary())
+	_ = reporter.UpdateProgress(totalFolders+1, totalFolders+1, strings.TrimSpace(report.Summary()))
+
+	if bad := report.UnreconciledPhases(); len(bad) > 0 {
+		return fmt.Errorf("phase(s) did not reconcile: %s", strings.Join(bad, ", "))
+	}
+	return nil
+}
+
+// probeAll runs the folder-level worker pool, writing each folder's probes and
+// verdict back into candidates[i] in place.
+//
+// Writing through the index (rather than RunItems' by-value item) is why this is
+// a separate function: each worker owns exactly one index and no two workers
+// ever touch the same element, so the in-place writes need no lock. That
+// partitioning is the same discipline CLAUDE.md requires of any parallel apply
+// path — disjoint sets, stated explicitly.
+func probeAll(
+	ctx context.Context,
+	reporter sdk.Reporter,
+	ffprobePath string,
+	candidates []probeCandidate,
+	doneFolders *atomic.Int64,
+	totalFolders int,
+) error {
+	idx := make([]int, len(candidates))
+	for i := range idx {
+		idx[i] = i
+	}
+
+	return registry.RunItems(ctx, reporter, idx, func(ctx context.Context, i int) error {
+		c := &candidates[i]
+		names, subdirs := readDirNames(c.finding.FilePath)
+		audio := folderAudioNames(names)
+
+		// 🔴 PROGRESS MUST BE STAMPED MID-FOLDER. The registry watchdog cancels
+		// any op whose gap between UpdateProgress calls exceeds ProgressTimeout
+		// (default 5 minutes). RunItems only stamps BETWEEN items, and a folder
+		// of 23 files each hitting the 20s ffprobe timeout takes ~7.7 minutes —
+		// so a single slow folder would get the op killed as stuck. That is not
+		// hypothetical: it is exactly how maintenance.dedupe-book-file-rows died
+		// at book 19/194.
+		//
+		// The reported `current` is the completed-FOLDER count, never the file
+		// index, so the number stays monotonic while workers finish out of
+		// order; the message carries the live per-file detail. SetCurrentItem is
+		// NOT sufficient here — it is in-memory/SSE only and never touches the
+		// clock the watchdog reads.
+		onFile := func(fileIdx int, name string) {
+			_ = reporter.UpdateProgress(int(doneFolders.Load()), totalFolders, fmt.Sprintf(
+				"Phase 2/3: probing %s — file %d/%d (%s)",
+				linkintegrity.DirNameOf(c.finding.FilePath), fileIdx+1, len(audio), name))
+		}
+
+		c.probes = probeFolderDurations(ctx, ffprobePath, c.finding.FilePath, audio, onFile)
+		c.verdict = linkintegrity.ClassifyDirProbed(names, subdirs, c.probes)
+
+		doneFolders.Add(1)
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   runtime.NumCPU(),
+		ProgressTotal: totalFolders,
+		ErrMode:       registry.ErrModeCollect,
+		// PerItemTimeout is deliberately unset: it would cap a whole FOLDER,
+		// and a legitimately large folder would be truncated mid-measurement,
+		// producing exactly the partial evidence this op refuses to act on.
+		// The bound that matters is per-FILE, inside probeFolderDurations.
+		Label: func(i, total int) string {
+			return fmt.Sprintf("Phase 2/3: probing folder %d/%d…", i+1, total)
+		},
+	})
+}
+
+// folderAudioNames returns a directory's audio basenames in deterministic order.
+//
+// Both the probe pass and the apply pass call this, so the file list they act on
+// cannot disagree. ClassifyDir applies the same IsAudioFile filter internally;
+// building the list here through the same predicate keeps the durations aligned
+// with the files the classifier counted.
+func folderAudioNames(names []string) []string {
+	audio := make([]string, 0, len(names))
+	for _, n := range names {
+		if linkintegrity.IsAudioFile(n) {
+			audio = append(audio, n)
+		}
+	}
+	sort.Strings(audio)
+	return audio
+}
+
+// probeFolderDurations probes each audio file in one folder, sequentially.
+//
+// onFile, when non-nil, is called before each probe so the caller can stamp
+// progress — see the watchdog note at the call site.
+func probeFolderDurations(
+	ctx context.Context,
+	ffprobePath, dir string,
+	audio []string,
+	onFile func(fileIdx int, name string),
+) []linkintegrity.ProbedDuration {
+	out := make([]linkintegrity.ProbedDuration, 0, len(audio))
+	for i, name := range audio {
+		if onFile != nil {
+			onFile(i, name)
+		}
+		if ctx.Err() != nil {
+			// Cancelled: record the remainder as UNMEASURED rather than
+			// dropping them. Dropping would shrink the probe list and make a
+			// truncated run look like a fully-measured one.
+			out = append(out, linkintegrity.ProbedDuration{Name: name})
+			continue
+		}
+		out = append(out, probeOne(ctx, ffprobePath, filepath.Join(dir, name), name))
+	}
+	return out
+}
+
+// probeOne measures a single file. It is the ONE place where an ffprobe result
+// becomes evidence, so it is the one place the OK invariant has to hold.
+func probeOne(ctx context.Context, ffprobePath, fullPath, name string) linkintegrity.ProbedDuration {
+	fctx, cancel := context.WithTimeout(ctx, probeFileTimeout)
+	defer cancel()
+
+	secs, err := probeDurationSecondsFn(fctx, ffprobePath, fullPath)
+	if err != nil {
+		return linkintegrity.ProbedDuration{Name: name} // OK stays false
+	}
+	// 🔴 A SUCCESSFUL EXIT REPORTING ZERO IS STILL A FAILED MEASUREMENT.
+	// ProbeDurationSeconds does not validate its result ("callers apply their
+	// own validity rules") and ffprobe can exit 0 with a zero or negative
+	// duration for a truncated or header-only container. Admitting that value
+	// would hand the series guard a zero — the precise failure this op exists
+	// to avoid — so it is treated as unmeasured.
+	if secs <= 0 {
+		return linkintegrity.ProbedDuration{Name: name}
+	}
+	// Round rather than truncate, matching duration_reextract.go's handling of
+	// the same float→int conversion.
+	return linkintegrity.ProbedDuration{Name: name, Sec: int(secs + 0.5), OK: true}
+}
+
+// linkProbedFolder creates the book_file rows for a folder that measurement has
+// confirmed to be one book, and returns how many it created.
+//
+// 🔴 NO UpdateBook CALL. Like relinkOne, this touches only book_file rows via
+// the additive CreateBookFile. The Book row is never rewritten, so the
+// write-back wipe class (AcoustIDFingerprint / Author / Series cleared by a bare
+// UpdateBook) is structurally unreachable from here.
+//
+// Unlike relinkOne — which must seed 0 for directory members because tier 1 has
+// no per-file durations — this path writes the MEASURED duration onto each row.
+// That is the point of having probed: a zero-duration book_file row leaves the
+// regroup series guard just as inert as no row at all.
+func linkProbedFolder(store database.Store, c probeCandidate) (int, error) {
+	b, err := store.GetBookByID(c.finding.BookID)
+	if err != nil {
+		return 0, fmt.Errorf("refetch book: %w", err)
+	}
+	if b == nil {
+		return 0, nil // vanished since detection — not an error
+	}
+	// Re-check under the write path: a concurrent import may have linked this
+	// book between detection and apply. Never create a second row for a file
+	// that is already owned.
+	existing, err := store.GetBookFiles(c.finding.BookID)
+	if err != nil {
+		return 0, fmt.Errorf("recheck files: %w", err)
+	}
+	if len(existing) > 0 {
+		return 0, nil
+	}
+
+	// Re-read the directory rather than trusting the probe-time snapshot: the
+	// folder may have changed, and a row must never be created for a file that
+	// is no longer there.
+	names, _ := readDirNames(c.finding.FilePath)
+	audio := folderAudioNames(names)
+	if len(audio) == 0 {
+		return 0, nil
+	}
+
+	// Index the measured durations by name so a folder that changed between
+	// probe and apply still pairs each row with ITS OWN measurement, never a
+	// neighbour's by position.
+	bySec := make(map[string]int, len(c.probes))
+	for _, p := range c.probes {
+		if p.OK && p.Sec > 0 {
+			bySec[p.Name] = p.Sec
+		}
+	}
+
+	created := 0
+	for i, n := range audio {
+		// A name with no measurement seeds 0 — the existing convention for
+		// "unknown", which maintenance.duration-backfill later fills in. For a
+		// multi-file folder this is unreachable: the coverage guard means a
+		// folder with any unprobeable file never reaches OneBook. It is
+		// reachable only for the single-file folder, whose verdict never
+		// depended on duration.
+		if err := createBookFileFor(store, b, filepath.Join(c.finding.FilePath, n), bySec[n], i+1); err != nil {
+			return created, err
+		}
+		created++
+	}
+	return created, nil
+}

--- a/internal/plugins/maintenance/probe_directory_books.go
+++ b/internal/plugins/maintenance/probe_directory_books.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/probe_directory_books.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6f2a90d4-3c81-4e57-b0a6-9d47e1c85b23
 // last-edited: 2026-08-06
 
@@ -269,6 +269,8 @@ func (p *Plugin) runProbeDirectoryBooks(ctx context.Context, raw json.RawMessage
 	const transitionCap = 10
 	var nowOneBook, stillReview, withFailedProbes int
 	transitions := make([]string, 0, transitionCap)
+	heldSamples := make([]string, 0, transitionCap)
+	heldByCategory := map[string]int{}
 	for i := range candidates {
 		c := &candidates[i]
 		c.finding.Reason = c.verdict.Reason
@@ -287,6 +289,16 @@ func (p *Plugin) runProbeDirectoryBooks(ctx context.Context, raw json.RawMessage
 		} else {
 			c.finding.Action = linkintegrity.DispositionReview
 			stillReview++
+			// A folder that STAYS in review is not a non-event: its reason has
+			// changed from "no durations are known" to a measured verdict, and
+			// that is the half an operator most needs to spot-check — proof the
+			// series guard fired for the right reason on the right folders,
+			// before authorising any apply.
+			heldByCategory[reviewCategory(c.verdict)]++
+			if len(heldSamples) < transitionCap {
+				heldSamples = append(heldSamples, fmt.Sprintf("%s [%s]: %q",
+					c.finding.BookID, linkintegrity.DirNameOf(c.finding.FilePath), c.verdict.Reason))
+			}
 		}
 		if c.verdict.ProbesFailed > 0 {
 			withFailedProbes++
@@ -352,6 +364,21 @@ func (p *Plugin) runProbeDirectoryBooks(ctx context.Context, raw json.RawMessage
 		nowOneBook, stillReview, withFailedProbes))
 	for _, tr := range transitions {
 		_ = reporter.Log(slog.LevelInfo, "resolved by measurement: "+tr)
+	}
+	if len(heldByCategory) > 0 {
+		cats := make([]string, 0, len(heldByCategory))
+		for k := range heldByCategory {
+			cats = append(cats, k)
+		}
+		sort.Strings(cats) // deterministic so two dry runs diff cleanly
+		parts := make([]string, 0, len(cats))
+		for _, k := range cats {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, heldByCategory[k]))
+		}
+		_ = reporter.Log(slog.LevelInfo, "STILL IN REVIEW by category: "+strings.Join(parts, " "))
+	}
+	for _, h := range heldSamples {
+		_ = reporter.Log(slog.LevelInfo, "still in review: "+h)
 	}
 	_ = reporter.Log(slog.LevelInfo, report.Summary())
 	_ = reporter.UpdateProgress(totalFolders+1, totalFolders+1, strings.TrimSpace(report.Summary()))
@@ -424,6 +451,29 @@ func probeAll(
 			return fmt.Sprintf("Phase 2/3: probing folder %d/%d…", i+1, total)
 		},
 	})
+}
+
+// reviewCategory buckets a still-in-review verdict by WHY it was held, so 1,019
+// individual reasons collapse into a few numbers an operator can act on.
+//
+// It keys off the verdict's structured fields rather than matching its Reason
+// text: the reason strings are written for humans and will be reworded, and a
+// tally that silently miscategorises after a copy edit is worse than no tally.
+// Order matters — an unprobeable file is reported ahead of any content-based
+// conclusion, because "we could not measure this" is a different problem from
+// "we measured it and it is a series", and only the former is fixable by
+// re-running.
+func reviewCategory(v linkintegrity.DirVerdict) string {
+	switch {
+	case v.AudioCount == 0:
+		return "no-audio"
+	case v.ProbesFailed > 0:
+		return "unprobeable-files"
+	case v.DistinctStems > 1:
+		return "distinct-titles"
+	default:
+		return "confirmed-series"
+	}
 }
 
 // folderAudioNames returns a directory's audio basenames in deterministic order.
@@ -507,6 +557,18 @@ func probeOne(ctx context.Context, ffprobePath, fullPath, name string) linkinteg
 // That is the point of having probed: a zero-duration book_file row leaves the
 // regroup series guard just as inert as no row at all.
 func linkProbedFolder(store database.Store, c probeCandidate) (int, error) {
+	// 🔴 THE VERDICT GATES THE WRITE, HERE, NOT ONLY AT THE CALL SITE.
+	// Phase 3 already skips anything not dispositioned Link, so reaching this
+	// function with a review verdict means a caller has a bug — and the blast
+	// radius of that bug is the one this whole op exists to prevent: linking a
+	// folder of five distinct novels into a single book, whose later merge
+	// hard-deletes the absorbed rows. Refusing loudly rather than returning 0
+	// keeps the mistake visible instead of silently doing nothing.
+	if !c.verdict.OneBook {
+		return 0, fmt.Errorf("refusing to link %s: verdict is not one-book (%s)",
+			c.finding.BookID, c.verdict.Reason)
+	}
+
 	b, err := store.GetBookByID(c.finding.BookID)
 	if err != nil {
 		return 0, fmt.Errorf("refetch book: %w", err)
@@ -534,13 +596,31 @@ func linkProbedFolder(store database.Store, c probeCandidate) (int, error) {
 		return 0, nil
 	}
 
-	// Index the measured durations by name so a folder that changed between
-	// probe and apply still pairs each row with ITS OWN measurement, never a
-	// neighbour's by position.
+	// Index the measured durations by name so each row pairs with ITS OWN
+	// measurement, never a neighbour's by position.
 	bySec := make(map[string]int, len(c.probes))
+	probed := make(map[string]struct{}, len(c.probes))
 	for _, p := range c.probes {
+		probed[p.Name] = struct{}{}
 		if p.OK && p.Sec > 0 {
 			bySec[p.Name] = p.Sec
+		}
+	}
+
+	// 🔴 THE VERDICT DESCRIBES THE FOLDER AS IT WAS MEASURED. If the contents
+	// changed between probe and apply, the "one book" conclusion was reached
+	// about a different set of files than the one about to be linked — a new
+	// arrival could be another novel entirely, and it would be linked with a
+	// duration of 0 that nothing ever measured. Refuse and let the next run
+	// re-probe; this op is designed to be re-run until it converges.
+	if len(audio) != len(probed) {
+		return 0, fmt.Errorf("refusing to link %s: folder changed since probing (%d audio files now, %d measured)",
+			c.finding.BookID, len(audio), len(probed))
+	}
+	for _, n := range audio {
+		if _, ok := probed[n]; !ok {
+			return 0, fmt.Errorf("refusing to link %s: %q appeared since probing and was never measured",
+				c.finding.BookID, n)
 		}
 	}
 

--- a/internal/plugins/maintenance/probe_directory_books_test.go
+++ b/internal/plugins/maintenance/probe_directory_books_test.go
@@ -1,0 +1,444 @@
+// file: internal/plugins/maintenance/probe_directory_books_test.go
+// version: 1.0.0
+// guid: 4a71c9e6-2b58-4d03-8f19-7c6e0b2a5d84
+// last-edited: 2026-08-06
+
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/audioutil"
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/linkintegrity"
+)
+
+// ── test doubles ─────────────────────────────────────────────────────────────
+//
+// The prober is injected rather than shelling out to a real ffprobe: these tests
+// must assert what the op does with probe FAILURES, and a real binary cannot be
+// made to fail on demand. Swapping the package vars is process-global, so no
+// test here calls t.Parallel and every swap is restored via t.Cleanup.
+
+// fakeProber returns durations by file basename. A name absent from the map
+// fails, which is how "could not probe" is expressed.
+type fakeProber struct {
+	mu    sync.Mutex
+	bySec map[string]float64
+	calls int
+}
+
+func (f *fakeProber) probe(_ context.Context, _, filePath string) (float64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if secs, ok := f.bySec[filepath.Base(filePath)]; ok {
+		return secs, nil
+	}
+	return 0, fmt.Errorf("ffprobe %s: exit status 1", filePath)
+}
+
+// installProber points the op at fp and restores the real prober afterwards.
+func installProber(t *testing.T, fp *fakeProber) {
+	t.Helper()
+	prev := probeDurationSecondsFn
+	probeDurationSecondsFn = fp.probe
+	t.Cleanup(func() { probeDurationSecondsFn = prev })
+}
+
+// installFFprobeLookup overrides binary resolution for the duration of a test.
+func installFFprobeLookup(t *testing.T, path string, err error) {
+	t.Helper()
+	prev := lookupFFprobeFn
+	lookupFFprobeFn = func() (string, error) { return path, err }
+	t.Cleanup(func() { lookupFFprobeFn = prev })
+}
+
+// makeFolder writes zero-byte files with the given names into a new temp dir.
+// Contents are irrelevant — the prober is faked; only the directory listing and
+// the names matter.
+func makeFolder(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+// classifyFolder runs the op's real probe+classify pipeline over one directory.
+func classifyFolder(t *testing.T, dir string) linkintegrity.DirVerdict {
+	t.Helper()
+	names, subdirs := readDirNames(dir)
+	audio := folderAudioNames(names)
+	probes := probeFolderDurations(context.Background(), "ffprobe", dir, audio, nil)
+	return linkintegrity.ClassifyDirProbed(names, subdirs, probes)
+}
+
+// ── the four required cases ──────────────────────────────────────────────────
+
+// Chapter-length files sharing one stem: the case nil durations were blocking.
+func TestProbeDirectoryBooks_ChapterFolderBecomesOneBook(t *testing.T) {
+	files := []string{
+		"The Given Sacrifice_01_.mp3", "The Given Sacrifice_02_.mp3",
+		"The Given Sacrifice_03_.mp3",
+	}
+	dir := makeFolder(t, files...)
+	installProber(t, &fakeProber{bySec: map[string]float64{
+		files[0]: 1500.4, files[1]: 1480.6, files[2]: 1520.0,
+	}})
+
+	got := classifyFolder(t, dir)
+	if !got.OneBook {
+		t.Fatalf("OneBook = false, want true once durations are measured; reason=%q", got.Reason)
+	}
+	if got.ProbesOK != 3 || got.ProbesFailed != 0 {
+		t.Errorf("ProbesOK/Failed = %d/%d, want 3/0", got.ProbesOK, got.ProbesFailed)
+	}
+}
+
+// Book-length files sharing one stem: the "Super Sales on Super Heroes 1..5"
+// shape. Measurement must CONFIRM the review hold, not dissolve it.
+func TestProbeDirectoryBooks_BookLengthFolderStaysInReview(t *testing.T) {
+	files := []string{
+		"Super Sales on Super Heroes 1.m4b", "Super Sales on Super Heroes 2.m4b",
+		"Super Sales on Super Heroes 3.m4b", "Super Sales on Super Heroes 4.m4b",
+		"Super Sales on Super Heroes 5.m4b",
+	}
+	dir := makeFolder(t, files...)
+	secs := map[string]float64{}
+	for _, f := range files {
+		secs[f] = 9 * 3600
+	}
+	installProber(t, &fakeProber{bySec: secs})
+
+	got := classifyFolder(t, dir)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — this would merge 5 distinct novels; reason=%q", got.Reason)
+	}
+	if !strings.Contains(got.Reason, "whole books") {
+		t.Errorf("reason must name the series-guard evidence, got %q", got.Reason)
+	}
+}
+
+// 🔴 Partial probe failure. Numbers chosen so EXCLUSION alone decides: one
+// book-length file measured, three unprobeable. Counting the failures as zero
+// would yield 1-of-4 long → OneBook (wrong); excluding them yields 1-of-1 long →
+// series guard fires.
+func TestProbeDirectoryBooks_FailedProbesExcludedNotZeroed(t *testing.T) {
+	files := []string{
+		"Wandering Inn 1.mp3", "Wandering Inn 2.mp3",
+		"Wandering Inn 3.mp3", "Wandering Inn 4.mp3",
+	}
+	dir := makeFolder(t, files...)
+	// Only the first file probes; the other three are absent from the map and
+	// therefore fail.
+	installProber(t, &fakeProber{bySec: map[string]float64{files[0]: 6000}})
+
+	names, subdirs := readDirNames(dir)
+	audio := folderAudioNames(names)
+	probes := probeFolderDurations(context.Background(), "ffprobe", dir, audio, nil)
+
+	// Assert the exclusion directly: a failed probe must carry OK=false, and the
+	// slice must still hold one entry per file so a truncated run is visible.
+	if len(probes) != 4 {
+		t.Fatalf("probes = %d, want one entry per audio file", len(probes))
+	}
+	okCount := 0
+	for _, p := range probes {
+		if p.OK {
+			okCount++
+			continue
+		}
+		if p.Sec != 0 {
+			t.Errorf("failed probe for %q carries Sec=%d — a failure must not carry a duration", p.Name, p.Sec)
+		}
+	}
+	if okCount != 1 {
+		t.Fatalf("okCount = %d, want exactly 1 measured file", okCount)
+	}
+
+	got := linkintegrity.ClassifyDirProbed(names, subdirs, probes)
+	if got.OneBook {
+		t.Fatalf("OneBook = true — the three failed probes were counted as zero-length chapters; reason=%q", got.Reason)
+	}
+	if got.ProbesOK != 1 || got.ProbesFailed != 3 {
+		t.Errorf("ProbesOK/Failed = %d/%d, want 1/3", got.ProbesOK, got.ProbesFailed)
+	}
+}
+
+// The reverse partial: measured subset looks chapter-length, but most of the
+// folder is unmeasured. Must not confirm on partial evidence.
+func TestProbeDirectoryBooks_PartialEvidenceCannotConfirmOneBook(t *testing.T) {
+	files := []string{"Skyward 1.mp3", "Skyward 2.mp3", "Skyward 3.mp3", "Skyward 4.mp3"}
+	dir := makeFolder(t, files...)
+	installProber(t, &fakeProber{bySec: map[string]float64{files[0]: 1200}})
+
+	got := classifyFolder(t, dir)
+	if got.OneBook {
+		t.Fatalf("OneBook = true on 1 of 4 files measured; reason=%q", got.Reason)
+	}
+	if !strings.Contains(got.Reason, "could not be probed") {
+		t.Errorf("reason must name the unmeasured files, got %q", got.Reason)
+	}
+}
+
+// ffprobe entirely unavailable: the op must REFUSE, not report a clean run.
+//
+// The check runs before the store is touched, so a nil-deps Plugin is enough —
+// which is itself the assertion that nothing else happened first.
+func TestProbeDirectoryBooks_RefusesWhenFFprobeMissing(t *testing.T) {
+	installFFprobeLookup(t, "", audioutil.ErrFFprobeNotAvailable)
+
+	rep := &mockReporter{}
+	p := New(nil)
+	err := p.runProbeDirectoryBooks(context.Background(), nil, rep)
+
+	if err == nil {
+		t.Fatal("op returned nil — a missing ffprobe must fail the run, not report that nothing was found")
+	}
+	if !errors.Is(err, audioutil.ErrFFprobeNotAvailable) {
+		t.Errorf("error must wrap ErrFFprobeNotAvailable so callers can distinguish " +
+			"'tool missing' from 'files unreadable'")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "ffprobe") {
+		t.Errorf("error must name ffprobe, got %q", err)
+	}
+	// A cannot-run must not look like a successful empty run.
+	for _, l := range rep.logs {
+		if strings.Contains(l, "RECONCILE") || strings.Contains(l, "First Aid") {
+			t.Errorf("op emitted a run summary %q despite being unable to measure anything", l)
+		}
+	}
+}
+
+// ── probe-result semantics ───────────────────────────────────────────────────
+
+// A successful ffprobe exit reporting zero or negative seconds is not a
+// measurement. ProbeDurationSeconds explicitly does not validate this, so the op
+// must.
+func TestProbeOne_ZeroOrNegativeIsNotMeasured(t *testing.T) {
+	for _, secs := range []float64{0, -1} {
+		prev := probeDurationSecondsFn
+		probeDurationSecondsFn = func(context.Context, string, string) (float64, error) { return secs, nil }
+		got := probeOne(context.Background(), "ffprobe", "/x/a.mp3", "a.mp3")
+		probeDurationSecondsFn = prev
+
+		if got.OK {
+			t.Errorf("probeOne(secs=%v).OK = true — a zero/negative duration is an absence of evidence", secs)
+		}
+		if got.Sec != 0 {
+			t.Errorf("probeOne(secs=%v).Sec = %d, want 0", secs, got.Sec)
+		}
+	}
+}
+
+// Rounding, not truncation — matching duration_reextract.go's handling of the
+// same float→int conversion.
+func TestProbeOne_RoundsToNearestSecond(t *testing.T) {
+	prev := probeDurationSecondsFn
+	probeDurationSecondsFn = func(context.Context, string, string) (float64, error) { return 1499.6, nil }
+	got := probeOne(context.Background(), "ffprobe", "/x/a.mp3", "a.mp3")
+	probeDurationSecondsFn = prev
+
+	if !got.OK || got.Sec != 1500 {
+		t.Errorf("probeOne = {Sec:%d OK:%v}, want {Sec:1500 OK:true}", got.Sec, got.OK)
+	}
+}
+
+// Non-audio entries must never be probed: they are not evidence about the book
+// and every needless probe costs a subprocess.
+func TestFolderAudioNames_FiltersAndSorts(t *testing.T) {
+	names := []string{"cover.jpg", "b.mp3", "notes.txt", "a.M4B", "Disc 1"}
+	got := folderAudioNames(names)
+	want := []string{"a.M4B", "b.mp3"}
+	if len(got) != len(want) {
+		t.Fatalf("folderAudioNames = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("folderAudioNames = %v, want %v (deterministic order)", got, want)
+		}
+	}
+}
+
+// ── concurrency ──────────────────────────────────────────────────────────────
+
+// probeAll fans folders across a worker pool and writes each verdict back
+// in place. Each worker owns one index, so the writes need no lock — this test
+// exists to prove that under -race with enough folders to force real overlap.
+func TestProbeAll_ParallelWritesAreIndexPartitioned(t *testing.T) {
+	const folders = 40
+	secs := map[string]float64{}
+	cands := make([]probeCandidate, 0, folders)
+	for i := 0; i < folders; i++ {
+		// Alternate the two shapes so the verdicts differ per index and a
+		// cross-worker write would show up as a wrong verdict, not just a race.
+		var files []string
+		dur := 1200.0
+		if i%2 == 1 {
+			dur = 9 * 3600
+		}
+		for j := 1; j <= 3; j++ {
+			n := fmt.Sprintf("Book %02d Part %d.mp3", i, j)
+			files = append(files, n)
+			secs[n] = dur
+		}
+		dir := makeFolder(t, files...)
+		cands = append(cands, probeCandidate{
+			finding: linkintegrity.Finding{BookID: fmt.Sprintf("b%02d", i), FilePath: dir},
+		})
+	}
+	installProber(t, &fakeProber{bySec: secs})
+
+	var done atomic.Int64
+	rep := &concurrentReporter{}
+	if err := probeAll(context.Background(), rep, "ffprobe", cands, &done, len(cands)); err != nil {
+		t.Fatalf("probeAll: %v", err)
+	}
+
+	if int(done.Load()) != folders {
+		t.Errorf("completed folders = %d, want %d", done.Load(), folders)
+	}
+	for i, c := range cands {
+		wantOne := i%2 == 0 // chapter-length folders resolve, book-length do not
+		if c.verdict.OneBook != wantOne {
+			t.Errorf("folder %d: OneBook = %v, want %v — a verdict landed on the wrong index; reason=%q",
+				i, c.verdict.OneBook, wantOne, c.verdict.Reason)
+		}
+		if len(c.probes) != 3 {
+			t.Errorf("folder %d: probes = %d, want 3", i, len(c.probes))
+		}
+	}
+}
+
+// ── apply path ───────────────────────────────────────────────────────────────
+
+// The apply path writes MEASURED durations onto the new book_file rows. Seeding
+// zero — which tier 1 must do, having never probed — would leave the regroup
+// series guard just as inert as having no rows at all, defeating the point of
+// probing.
+func TestLinkProbedFolder_WritesMeasuredDurations(t *testing.T) {
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	files := []string{"Chapter 01.mp3", "Chapter 02.mp3", "Chapter 03.mp3"}
+	dir := makeFolder(t, files...)
+	bk, err := s.CreateBook(&database.Book{Title: "Probed Book", FilePath: dir})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	c := probeCandidate{
+		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		probes: []linkintegrity.ProbedDuration{
+			{Name: files[0], Sec: 1500, OK: true},
+			{Name: files[1], Sec: 1480, OK: true},
+			{Name: files[2], Sec: 1520, OK: true},
+		},
+	}
+
+	n, err := linkProbedFolder(s, c)
+	if err != nil {
+		t.Fatalf("linkProbedFolder: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("created = %d, want 3", n)
+	}
+
+	rows, err := s.GetBookFiles(bk.ID)
+	if err != nil {
+		t.Fatalf("GetBookFiles: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("book_file rows = %d, want 3", len(rows))
+	}
+	byName := map[string]int{}
+	for _, r := range rows {
+		byName[filepath.Base(r.FilePath)] = r.Duration
+	}
+	for name, want := range map[string]int{files[0]: 1500, files[1]: 1480, files[2]: 1520} {
+		if got := byName[name]; got != want {
+			t.Errorf("%s duration = %d, want the MEASURED %d — a zero here leaves the series guard inert",
+				name, got, want)
+		}
+	}
+}
+
+// Idempotency: a book that gained rows between probe and apply must not get a
+// second set. Re-running the op is expected operationally, and duplicate rows
+// are what maintenance.dedupe-book-file-rows exists to clean up.
+func TestLinkProbedFolder_SkipsAlreadyLinkedBook(t *testing.T) {
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	files := []string{"Chapter 01.mp3", "Chapter 02.mp3"}
+	dir := makeFolder(t, files...)
+	bk, err := s.CreateBook(&database.Book{Title: "Already Linked", FilePath: dir})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	c := probeCandidate{
+		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		probes: []linkintegrity.ProbedDuration{
+			{Name: files[0], Sec: 1500, OK: true},
+			{Name: files[1], Sec: 1480, OK: true},
+		},
+	}
+
+	if _, err := linkProbedFolder(s, c); err != nil {
+		t.Fatalf("first linkProbedFolder: %v", err)
+	}
+	n, err := linkProbedFolder(s, c)
+	if err != nil {
+		t.Fatalf("second linkProbedFolder: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second run created %d rows, want 0 — the op must be idempotent", n)
+	}
+	rows, _ := s.GetBookFiles(bk.ID)
+	if len(rows) != 2 {
+		t.Errorf("book_file rows = %d, want 2 after two runs", len(rows))
+	}
+}
+
+// ── reconcile arithmetic ─────────────────────────────────────────────────────
+
+// The op fails itself when a phase does not reconcile, so the bucket arithmetic
+// has to hold in both the dry-run and applied shapes. Every examined folder must
+// land in exactly one of actioned/skipped/errors.
+func TestProbeDirectoryBooks_PhaseReconciles(t *testing.T) {
+	cases := []struct{ examined, linked, errs int }{
+		{examined: 1019, linked: 0, errs: 0},   // dry run
+		{examined: 1019, linked: 812, errs: 3}, // applied
+		{examined: 0, linked: 0, errs: 0},      // nothing flagged
+	}
+	for _, tc := range cases {
+		phase := linkintegrity.PhaseResult{
+			Name:     "probe-directory-books",
+			Examined: tc.examined,
+			Actioned: tc.linked,
+			Errors:   tc.errs,
+			Skipped:  tc.examined - tc.linked - tc.errs,
+		}
+		if !phase.Reconciles() {
+			t.Errorf("phase %+v does not reconcile — the op would fail itself at the finish line", phase)
+		}
+	}
+}

--- a/internal/plugins/maintenance/probe_directory_books_test.go
+++ b/internal/plugins/maintenance/probe_directory_books_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/probe_directory_books_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4a71c9e6-2b58-4d03-8f19-7c6e0b2a5d84
 // last-edited: 2026-08-06
 
@@ -344,6 +344,7 @@ func TestLinkProbedFolder_WritesMeasuredDurations(t *testing.T) {
 
 	c := probeCandidate{
 		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		verdict: linkintegrity.DirVerdict{OneBook: true, AudioCount: 3, ProbesOK: 3},
 		probes: []linkintegrity.ProbedDuration{
 			{Name: files[0], Sec: 1500, OK: true},
 			{Name: files[1], Sec: 1480, OK: true},
@@ -396,6 +397,7 @@ func TestLinkProbedFolder_SkipsAlreadyLinkedBook(t *testing.T) {
 	}
 	c := probeCandidate{
 		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		verdict: linkintegrity.DirVerdict{OneBook: true, AudioCount: 2, ProbesOK: 2},
 		probes: []linkintegrity.ProbedDuration{
 			{Name: files[0], Sec: 1500, OK: true},
 			{Name: files[1], Sec: 1480, OK: true},
@@ -439,6 +441,123 @@ func TestProbeDirectoryBooks_PhaseReconciles(t *testing.T) {
 		}
 		if !phase.Reconciles() {
 			t.Errorf("phase %+v does not reconcile — the op would fail itself at the finish line", phase)
+		}
+	}
+}
+
+// 🔴 THE CENTRAL SAFETY PROPERTY: a folder measurement CONFIRMED to be a series
+// must never have its files linked into one book. Phase 3's disposition check is
+// the live gate, but the consequence of getting it wrong is the incident this
+// whole op exists to prevent — five distinct novels merged into one row, whose
+// later merge hard-deletes the absorbed rows — so the write path refuses on its
+// own rather than trusting its caller.
+func TestLinkProbedFolder_RefusesSeriesVerdict(t *testing.T) {
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	files := []string{
+		"Super Sales on Super Heroes 1.m4b", "Super Sales on Super Heroes 2.m4b",
+		"Super Sales on Super Heroes 3.m4b",
+	}
+	dir := makeFolder(t, files...)
+	bk, err := s.CreateBook(&database.Book{Title: "Super Sales on Super Heroes", FilePath: dir})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	probes := make([]linkintegrity.ProbedDuration, 0, len(files))
+	for _, f := range files {
+		probes = append(probes, linkintegrity.ProbedDuration{Name: f, Sec: 9 * 3600, OK: true})
+	}
+	names, subdirs := readDirNames(dir)
+	verdict := linkintegrity.ClassifyDirProbed(names, subdirs, probes)
+	if verdict.OneBook {
+		t.Fatal("precondition failed: book-length members must classify as a series")
+	}
+
+	c := probeCandidate{
+		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		verdict: verdict,
+		probes:  probes,
+	}
+	n, err := linkProbedFolder(s, c)
+	if err == nil {
+		t.Error("linkProbedFolder returned nil error for a series verdict — it must refuse loudly, " +
+			"not silently do nothing, so a caller bug stays visible")
+	}
+	if n != 0 {
+		t.Errorf("created = %d rows for a CONFIRMED SERIES — this is the 5-novels-into-1 merge", n)
+	}
+	rows, _ := s.GetBookFiles(bk.ID)
+	if len(rows) != 0 {
+		t.Fatalf("book_file rows = %d, want 0 — no file of a confirmed series may be linked", len(rows))
+	}
+}
+
+// The verdict describes the folder AS MEASURED. A file that appeared between
+// probe and apply was never measured and could be another work entirely, so the
+// apply must refuse rather than link it with a duration of zero.
+func TestLinkProbedFolder_RefusesWhenFolderChangedSinceProbing(t *testing.T) {
+	s, err := database.NewPebbleStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	files := []string{"Chapter 01.mp3", "Chapter 02.mp3"}
+	dir := makeFolder(t, files...)
+	bk, err := s.CreateBook(&database.Book{Title: "Drifting Book", FilePath: dir})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+
+	c := probeCandidate{
+		finding: linkintegrity.Finding{BookID: bk.ID, FilePath: dir, Shape: linkintegrity.ShapeDirectory},
+		verdict: linkintegrity.DirVerdict{OneBook: true, AudioCount: 2, ProbesOK: 2},
+		probes: []linkintegrity.ProbedDuration{
+			{Name: files[0], Sec: 1500, OK: true},
+			{Name: files[1], Sec: 1480, OK: true},
+		},
+	}
+
+	// A third file lands after the probe pass — never measured, not covered by
+	// the verdict.
+	if err := os.WriteFile(filepath.Join(dir, "Chapter 03.mp3"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	n, err := linkProbedFolder(s, c)
+	if err == nil {
+		t.Error("linkProbedFolder accepted a folder that changed since probing")
+	}
+	if n != 0 {
+		t.Errorf("created = %d rows, want 0 — the verdict describes different contents", n)
+	}
+	rows, _ := s.GetBookFiles(bk.ID)
+	if len(rows) != 0 {
+		t.Errorf("book_file rows = %d, want 0", len(rows))
+	}
+}
+
+// reviewCategory buckets by the verdict's structured fields, not its prose, so a
+// reworded Reason cannot silently miscategorise the tally an operator reads.
+func TestReviewCategory_BucketsByEvidence(t *testing.T) {
+	cases := []struct {
+		name string
+		v    linkintegrity.DirVerdict
+		want string
+	}{
+		{"measured series", linkintegrity.DirVerdict{AudioCount: 5, DistinctStems: 1, ProbesOK: 5}, "confirmed-series"},
+		{"unmeasurable files", linkintegrity.DirVerdict{AudioCount: 4, DistinctStems: 1, ProbesOK: 1, ProbesFailed: 3}, "unprobeable-files"},
+		{"many works", linkintegrity.DirVerdict{AudioCount: 3, DistinctStems: 3, ProbesOK: 3}, "distinct-titles"},
+		{"empty folder", linkintegrity.DirVerdict{AudioCount: 0}, "no-audio"},
+	}
+	for _, tc := range cases {
+		if got := reviewCategory(tc.v); got != tc.want {
+			t.Errorf("%s: reviewCategory = %q, want %q", tc.name, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## The problem

`maintenance.relink-unlinked-books` (#2147) relinked 16.0k of 17,149 unlinked books. **1,019 directory-shaped books went to review not because they are unknowable, but because they were never probed.**

The mechanism was already in the code. `classifyUnlinked` calls:

```go
v := linkintegrity.ClassifyDir(names, subdirs, nil)
//                                             ^^^ durations always nil
```

and `ClassifyDir` has a series guard that cannot fire without them (`classify.go:145`) — so it returns "cannot rule out a series" and routes to review.

A whole-library tier-1 scan (44,887 books, budget: one DB read + one `os.Stat`) genuinely cannot afford to probe. ~1,019 folders can. That is exactly what First Aid's tier 2 is for.

## What this adds

`maintenance.probe-directory-books`. Detection reuses `classifyUnlinked` **verbatim** — the point is to re-run the same classification with better inputs, not to write a second classifier that can drift from the first. It then re-runs through `ClassifyDirProbed` with measured durations.

Dry-run by default (`apply`, matching its tier-1 sibling). `limit` caps writes only, never measurement.

## Absent evidence never becomes negative evidence

This is the rule the op exists to respect, and it is enforced twice:

`ProbedDuration{Name, Sec, OK}` sets `OK` only on `err == nil && secs > 0` — so a *successful* ffprobe exit reporting zero (truncated or header-only container) also counts as unmeasured.

1. **Exclusion** — failures contribute nothing. Four files sharing one stem, one measuring 6000s and three failing: as zeros that reads 1-of-4 long → auto-link, which is wrong. Excluded, it reads 1-of-1 long → the series guard fires.
2. **Coverage guard** — exclusion alone still lets the reverse partial through (one file measuring chapter-length, three unknown), so any folder with an unprobeable file stays in review regardless.

Mutation-tested: making failures contribute zeros fails 3 tests, one scoped so exclusion alone decides it.

This is the same failure that disabled the regroup series guard across 97.5% of the review queue by reading `DurationSec == 0` as evidence, and nearly merged 41 of 43 distinct novels.

## Concurrency

Bounded `registry.RunItems` pool at the **folder** level, sized to `runtime.NumCPU()`. Files within a folder are probed sequentially on purpose — a nested pool would put NumCPU² ffprobe processes on the box.

Note `reset_all.go`'s `RunItems` pattern does not transfer directly: its closure mutates a shared counter unsynchronized, safe only because that path runs at `Concurrency: 1`. This uses index-partitioned in-place writes so each worker owns exactly one element.

## Watchdog

`RunItems` only stamps progress between items, and a 23-file folder at the 20s per-file timeout runs ~7.7 min against the 5-minute `ProgressTimeout`. Progress is stamped **mid-folder** via `UpdateProgress` — not `SetCurrentItem`, which is in-memory/SSE only and never touches the clock the watchdog reads — reporting completed-*folder* count so it stays monotonic under out-of-order workers.

This is not hypothetical: it is exactly how `dedupe-book-file-rows` died at book 19/194.

## Missing ffprobe

Checked before the store is even fetched; returns an error wrapping `ErrFFprobeNotAvailable`. The test asserts **no summary line is emitted**, so a cannot-run cannot be mistaken for a clean run that found nothing.

## Defence in depth on the write path

`linkProbedFolder` now refuses a non-one-book verdict on its own, rather than relying solely on the caller's disposition check — that check was the only thing between a confirmed series and an apply. It also refuses when folder contents changed between probe and apply.

## Verification

```
go build ./...                                                    OK
go vet (all three changed packages)                               clean
go test ./internal/linkintegrity/... ./internal/plugins/maintenance/... -race -count=1
ok  	internal/linkintegrity          1.116s
ok  	internal/plugins/maintenance   20.019s
```

23 new tests.

## Not included

No frontend button, and not wired into the First Aid orchestrator — that sub-task is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp