### PR TITLE
feat(review): evidence-backed recommendations on review holds, with a durable human override

### DIFF
--- a/changelog.d/20260806_140000_review_approve_action_dispatch.md
+++ b/changelog.d/20260806_140000_review_approve_action_dispatch.md
@@ -1,0 +1,61 @@
+<!-- file: changelog.d/20260806_140000_review_approve_action_dispatch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d9b71c6-58ea-4f27-9c04-6b1e2af8d035 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Changed
+
+- **Approving a review hold now runs the action a human chose, not the one its
+  category implies.** Until now the review queue dispatched approve on
+  `ReviewItem.Kind` — the shape the classifier saw. A Kind and the right action are
+  not the same question: a `regroup.multidisc` hold means "these files sit in disc
+  folders", which is true of three production holds whose members are each a
+  full-length novel, because the disc and chapter branches of the classifier never
+  evaluated its series guard. Approving those under Kind dispatch would have merged
+  distinct novels through an apply path that hard-deletes the absorbed rows.
+
+  Each hold now carries the classifier's `recommendedAction`, its reason, and the
+  arithmetic behind it (member count, how many runtimes are known, how many are
+  book-length, median and longest runtime, distinct title stems). Approve resolves
+  an action — the explicit `{"action": "..."}` in the request body when a reviewer
+  made a choice, otherwise the hold's own recommendation — and dispatches on that.
+
+  🔑 **A typo is a 400, never a fallback.** Approving with an action outside the
+  closed vocabulary (`combine`, `separate`, `version-group`, `duplicate-of`) is
+  refused rather than quietly downgraded to the recommendation. Someone who meant
+  "leave these six novels apart" and mistyped it must not be handed "combine".
+
+  Three more refusals, all deliberate:
+
+  - `insufficient-evidence` cannot be approved at all. It is the machine saying "I
+    cannot tell", not a decision a human can pick, and the holds carrying it are
+    exactly the ones with the least evidence.
+  - Every hold written before this change decodes with no recommended action, which
+    resolves to `insufficient-evidence`. Old holds are refused until a reviewer names
+    an action explicitly — they are never dispatched to a merge on the strength of a
+    field they do not carry. There is no backfill and no migration; a re-scan
+    refreshes a still-pending hold's payload.
+  - `duplicate-of` returns a "not implemented" error instead of marking the hold
+    decided while doing nothing. "Decided" is sticky — a re-scan never re-offers a
+    non-pending hold.
+
+  `separate` needs no apply handler and never will: every member is already its own
+  book, so the decision is a status transition and the queue's dedup-key idempotency
+  is what keeps it decided across re-scans.
+
+  Bulk approve uses **each item's own** recommendation rather than one action for the
+  whole batch — a single action over a heterogeneous batch is precisely the footgun
+  this change removes. Holds with no decidable action are reported in a `skipped`
+  list with their reason instead of aborting the run.
+
+  The four `Kind` strings are unchanged; they still describe shape and are still what
+  the review UI maps. `review_apply_enabled` remains off, and approving with it off
+  still records the decision without executing anything.
+
+  ⚠️ **One widening worth knowing about.** Under Kind dispatch `regroup.ambiguous`
+  had no apply handler and so could never merge anything. Keyed by action, an
+  ambiguous hold whose evidence recommends `combine` now reaches the combine path.
+  That is intended — the recommendation is evidence-backed where the Kind was only a
+  shape, and it refuses `combine` unless a strict majority of members have a known
+  runtime and those runtimes are short — but the gate is now the evidence, not the
+  category.

--- a/changelog.d/20260806_160000_review_override_persistence.md
+++ b/changelog.d/20260806_160000_review_override_persistence.md
@@ -1,0 +1,33 @@
+<!-- file: changelog.d/20260806_160000_review_override_persistence.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c47f8e21-9b53-4d06-8a1f-5e2c7b0d9a36 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Changed
+
+- **A reviewer's disagreement with the classifier is now written down, and it is what
+  actually runs later.** Approving a review hold with an explicit action recorded the
+  status and nothing else: the chosen action lived nowhere. That mattered because with
+  `review_apply_enabled` off — which is how production runs — approving executes
+  nothing, and the work is carried out later by the replay pass. Replay re-derived the
+  action from the hold's payload, so a hold the classifier wanted *combined* that a
+  human had approved as *keep separate* would come back as a merge, hard-deleting the
+  rows for books that person had explicitly said to keep apart.
+
+  The stopgap was to refuse those overrides with a 409. Safe, but it meant that in the
+  configuration production actually uses, a reviewer could not register a disagreement
+  at all — which is the entire feature.
+
+  Review items now carry the chosen action, written in the same atomic batch as the
+  status change, and replay reads it first. The 409 is gone. Two tests hold the line
+  in both directions: a `combine` hold approved as `separate` must come out of replay
+  *unmerged*, and a `separate` hold approved as `combine` must come out *merged* —
+  either one alone would pass on a replay that had simply stopped working.
+
+  The write is deliberately narrow. It re-reads the record inside the store rather
+  than writing back the caller's copy, touches only the status, the timestamp and the
+  chosen action, and has no way to *clear* the chosen action — so the later
+  approved→applied transition cannot erase the decision it is in the middle of
+  carrying out. Holds decided before this change carry no action and fall back to the
+  payload, which for a pre-recommendation hold means "not enough evidence": they keep
+  working, and keep failing closed.

--- a/changelog.d/20260806_161000_review_queue_recommendation_ui.md
+++ b/changelog.d/20260806_161000_review_queue_recommendation_ui.md
@@ -1,0 +1,28 @@
+<!-- file: changelog.d/20260806_161000_review_queue_recommendation_ui.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9f2b6d40-3a71-4e58-b09c-1d4e8a5f7c62 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Changed
+
+- **The review queue now shows why each hold is there, and lets you disagree with it.**
+  Every hold used to display the same sentence — literally the same one, on 762 of 777
+  holds — which is a queue nobody can work. Each hold now shows the recommended action,
+  the reason for it, and the numbers that reason is built from: how many files are in
+  the group, how many of them have a known runtime, how many are long enough to be a
+  book on their own, the median and longest runtime, and how many distinct titles are
+  mixed together. The known-runtime count is highlighted when most are missing, because
+  that gap is exactly why the system sometimes cannot decide.
+
+  Each hold has its own action picker, starting on the recommendation. Holds the
+  classifier could not call start on *nothing* and their Approve button stays disabled
+  until a person chooses — no guess is pre-filled, least of all on the holds with the
+  weakest evidence. "Not enough evidence" is shown as a state, never offered as a
+  choice, because it is the machine's statement rather than a decision anyone can take.
+  "Duplicate of an existing book" is offered but marked unimplemented, and the server's
+  refusal is shown verbatim rather than dressed up as a generic failure.
+
+  Approving a whole bucket still uses each hold's own recommendation, and the holds it
+  skipped are now listed by id with their reason instead of vanishing behind a count —
+  a bulk action that silently skips things is how someone comes to believe they cleared
+  a queue they did not.

--- a/internal/database/iface_review.go
+++ b/internal/database/iface_review.go
@@ -1,7 +1,7 @@
 // file: internal/database/iface_review.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7a1e4d63-2c9f-48b5-b0a7-6e3d51f8c294
-// last-edited: 2026-07-13
+// last-edited: 2026-08-06
 
 package database
 
@@ -31,8 +31,17 @@ type ReviewStore interface {
 	ReviewStatsByKind() ([]ReviewKindStat, error)
 
 	// SetReviewItemStatus transitions an item to a new status, moving its
-	// status-index row. Returns (nil, nil) when the item does not exist.
+	// status-index row. Returns (nil, nil) when the item does not exist. It does
+	// NOT touch ChosenAction — a status-only transition (reject, or replay's
+	// approved→applied) must never erase a recorded human decision.
 	SetReviewItemStatus(id, status string) (*ReviewItem, error)
+
+	// SetReviewItemDecision transitions an item AND records the action a human
+	// chose, atomically. A blank chosenAction leaves the stored one alone; there is
+	// deliberately no way to clear it. This is what makes an override durable: the
+	// replay path prefers ChosenAction over the payload's recommendation, so a
+	// `combine` hold approved as `separate` is never later replayed as a merge.
+	SetReviewItemDecision(id, status, chosenAction string) (*ReviewItem, error)
 
 	// DeleteReviewItem removes an item and all its index rows (record, status,
 	// dedup). Idempotent — deleting a missing id is a no-op. Deleting the dedup

--- a/internal/database/mock_store.go
+++ b/internal/database/mock_store.go
@@ -2735,4 +2735,7 @@ func (m *MockStore) ListReviewItems(_ ReviewFilter) ([]ReviewItem, int, error) {
 func (m *MockStore) CountReviewItems(_ string) (int, error)               { return 0, nil }
 func (m *MockStore) ReviewStatsByKind() ([]ReviewKindStat, error)         { return nil, nil }
 func (m *MockStore) SetReviewItemStatus(_, _ string) (*ReviewItem, error) { return nil, nil }
-func (m *MockStore) DeleteReviewItem(_ string) error                      { return nil }
+func (m *MockStore) SetReviewItemDecision(_, _, _ string) (*ReviewItem, error) {
+	return nil, nil
+}
+func (m *MockStore) DeleteReviewItem(_ string) error { return nil }

--- a/internal/database/mocks/mock_store.go
+++ b/internal/database/mocks/mock_store.go
@@ -50094,6 +50094,80 @@ func (_c *MockStore_SetRaw_Call) RunAndReturn(run func(key string, value []byte)
 	return _c
 }
 
+// SetReviewItemDecision provides a mock function for the type MockStore
+func (_mock *MockStore) SetReviewItemDecision(id string, status string, chosenAction string) (*database.ReviewItem, error) {
+	ret := _mock.Called(id, status, chosenAction)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetReviewItemDecision")
+	}
+
+	var r0 *database.ReviewItem
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) (*database.ReviewItem, error)); ok {
+		return returnFunc(id, status, chosenAction)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string, string, string) *database.ReviewItem); ok {
+		r0 = returnFunc(id, status, chosenAction)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*database.ReviewItem)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string, string, string) error); ok {
+		r1 = returnFunc(id, status, chosenAction)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStore_SetReviewItemDecision_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetReviewItemDecision'
+type MockStore_SetReviewItemDecision_Call struct {
+	*mock.Call
+}
+
+// SetReviewItemDecision is a helper method to define mock.On call
+//   - id string
+//   - status string
+//   - chosenAction string
+func (_e *MockStore_Expecter) SetReviewItemDecision(id any, status any, chosenAction any) *MockStore_SetReviewItemDecision_Call {
+	return &MockStore_SetReviewItemDecision_Call{Call: _e.mock.On("SetReviewItemDecision", id, status, chosenAction)}
+}
+
+func (_c *MockStore_SetReviewItemDecision_Call) Run(run func(id string, status string, chosenAction string)) *MockStore_SetReviewItemDecision_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_SetReviewItemDecision_Call) Return(reviewItem *database.ReviewItem, err error) *MockStore_SetReviewItemDecision_Call {
+	_c.Call.Return(reviewItem, err)
+	return _c
+}
+
+func (_c *MockStore_SetReviewItemDecision_Call) RunAndReturn(run func(id string, status string, chosenAction string) (*database.ReviewItem, error)) *MockStore_SetReviewItemDecision_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetReviewItemStatus provides a mock function for the type MockStore
 func (_mock *MockStore) SetReviewItemStatus(id string, status string) (*database.ReviewItem, error) {
 	ret := _mock.Called(id, status)

--- a/internal/database/review_store.go
+++ b/internal/database/review_store.go
@@ -1,7 +1,7 @@
 // file: internal/database/review_store.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f2c8a91-6b3d-4e57-9a02-8d1f5c7e3b40
-// last-edited: 2026-07-13
+// last-edited: 2026-08-06
 
 package database
 
@@ -67,6 +67,26 @@ type ReviewItem struct {
 	Payload   string    `json:"payload"`    // JSON blob: folder, listing, proposed action, member IDs, ...
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// ChosenAction is the action a HUMAN decided on when this item was approved —
+	// an itunesservice.Action* string ("combine", "separate", "version-group", …).
+	// Empty on a pending item, and empty on every item approved before 2026-08-06.
+	//
+	// 🔴 THIS FIELD IS WHY AN OVERRIDE SURVIVES. The classifier's suggestion lives in
+	// Payload.recommendedAction; this records what the reviewer actually picked, which
+	// may DISAGREE with it. Without it, approving a `combine` hold as `separate` wrote
+	// nothing but status="approved", and ReplayApprovedItems — which re-resolves the
+	// action later, after review_apply_enabled is flipped — would read the payload back
+	// and merge exactly the books the human said to keep apart. The combine apply path
+	// hard-deletes the absorbed Book rows, so that is unrecoverable.
+	//
+	// Additive and never backfilled: an empty value means "no human choice recorded",
+	// and readers fall back to the payload recommendation, which for a pre-2026-08-06
+	// hold resolves to insufficient-evidence — the fail-closed direction.
+	//
+	// Written only by SetReviewItemDecision. SetReviewItemStatus leaves it alone, so
+	// the later approved→applied transition cannot erase the decision it is carrying out.
+	ChosenAction string `json:"chosen_action,omitempty"`
 }
 
 // ReviewFilter controls ListReviewItems / list-by-status queries.
@@ -420,7 +440,42 @@ func (p *PebbleStore) ReviewStatsByKind() ([]ReviewKindStat, error) {
 // status-index row accordingly. Returns (nil, nil) when the item does not exist
 // so callers can respond 404. The dedupkey index is never touched (DedupKey is
 // stable), so a rejected item stays remembered across future producer re-scans.
+//
+// It records NO chosen action — see SetReviewItemDecision. That is what makes the
+// approved→applied transition in ReplayApprovedItems safe: it must not disturb the
+// human decision it is in the middle of carrying out.
 func (p *PebbleStore) SetReviewItemStatus(id, status string) (*ReviewItem, error) {
+	return p.SetReviewItemDecision(id, status, "")
+}
+
+// SetReviewItemDecision transitions a review item to a new status AND records the
+// action a human chose, in one atomic batch.
+//
+// 🔴 WHY BOTH IN ONE CALL, AND WHY THIS WRITE IS SAFE.
+//
+// The two facts — "this hold is approved" and "the human picked separate, not the
+// recommended combine" — must land together or not at all. Split across two writes,
+// a crash between them leaves status="approved" with no recorded action, and a later
+// replay falls back to the payload's recommendation: the precise merge-nobody-asked-for
+// this field exists to prevent. One Pebble batch, committed with Sync, removes that window.
+//
+// The write is NARROW BY CONSTRUCTION, which matters in a codebase whose dominant
+// incident class is a field wiped on write-back:
+//
+//   - The record is RE-READ here, inside the store, immediately before mutation. The
+//     caller's copy of the ReviewItem is never marshalled back — so a handler holding a
+//     stale item (fetched before some other writer touched Payload or Summary) cannot
+//     roll those fields back.
+//   - Exactly three fields are assigned: Status, UpdatedAt, and ChosenAction. Everything
+//     else — ID, Kind, DedupKey, FolderRef, Summary, Payload, CreatedAt — round-trips
+//     from the freshly-read record untouched.
+//   - An EMPTY chosenAction means "leave the stored value alone", never "clear it".
+//     That is what lets SetReviewItemStatus delegate here: reject, and replay's
+//     approved→applied transition, change status without erasing the recorded decision.
+//     Clearing requires no code path at all, so no caller can do it by accident.
+//
+// Returns (nil, nil) when the item does not exist.
+func (p *PebbleStore) SetReviewItemDecision(id, status, chosenAction string) (*ReviewItem, error) {
 	if status == "" {
 		return nil, fmt.Errorf("review item: status is required")
 	}
@@ -434,6 +489,9 @@ func (p *PebbleStore) SetReviewItemStatus(id, status string) (*ReviewItem, error
 	oldStatus := item.Status
 	item.Status = status
 	item.UpdatedAt = time.Now().UTC()
+	if chosenAction != "" {
+		item.ChosenAction = chosenAction
+	}
 
 	data, err := json.Marshal(item)
 	if err != nil {

--- a/internal/database/review_store_test.go
+++ b/internal/database/review_store_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/review_store_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 9d3b7f21-4a58-4c69-b8e2-1f0a6c5d4e37
-// last-edited: 2026-07-14
+// last-edited: 2026-08-06
 
 package database
 
@@ -283,6 +283,75 @@ func TestSetReviewItemStatus_MovesIndexRow(t *testing.T) {
 func TestSetReviewItemStatus_NotFound(t *testing.T) {
 	s := newReviewTestStore(t)
 	got, err := s.SetReviewItemStatus("nonexistent", ReviewStatusApproved)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing item, got %+v", got)
+	}
+}
+
+// 🔴 THE DECISION MUST OUTLIVE EVERY SUBSEQUENT WRITE. A recorded ChosenAction is
+// the only durable record that a human DISAGREED with the classifier; if any later
+// write clears it, the replay path silently falls back to the payload's
+// recommendation and merges books the reviewer said to keep apart.
+//
+// This walks the real sequence: decide → status-only transition (replay's
+// approved→applied) → producer re-scan, asserting the action survives all three, and
+// that no unrelated field was collateral damage of the decision write.
+func TestSetReviewItemDecision_PersistsAndIsNeverClearedByLaterWrites(t *testing.T) {
+	s := newReviewTestStore(t)
+	it, err := s.UpsertReviewItem(mkReviewItem(
+		"regroup.multidisc", "dk-dec", "/books/a", "sum", `{"recommendedAction":"combine"}`))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A reviewer overrides the recommendation.
+	got, err := s.SetReviewItemDecision(it.ID, ReviewStatusApproved, "separate")
+	if err != nil {
+		t.Fatalf("SetReviewItemDecision: %v", err)
+	}
+	if got.ChosenAction != "separate" || got.Status != ReviewStatusApproved {
+		t.Fatalf("got status=%q action=%q, want approved/separate", got.Status, got.ChosenAction)
+	}
+	// The narrow write must not have disturbed anything it was not asked to change.
+	if got.Kind != it.Kind || got.DedupKey != it.DedupKey || got.FolderRef != it.FolderRef ||
+		got.Summary != it.Summary || got.Payload != it.Payload || !got.CreatedAt.Equal(it.CreatedAt) {
+		t.Fatalf("decision write disturbed an unrelated field: %+v vs %+v", got, it)
+	}
+
+	// A status-only transition (what replay does after a successful apply) must leave
+	// the decision alone — a blank chosenAction means "don't touch", never "clear".
+	if _, err := s.SetReviewItemStatus(it.ID, ReviewStatusApplied); err != nil {
+		t.Fatalf("SetReviewItemStatus: %v", err)
+	}
+	reread, _ := s.GetReviewItem(it.ID)
+	if reread.ChosenAction != "separate" {
+		t.Fatalf("chosen_action = %q after a status-only write, want separate — the transition "+
+			"wiped the decision it was carrying out", reread.ChosenAction)
+	}
+	if reread.Status != ReviewStatusApplied {
+		t.Fatalf("status = %q, want applied", reread.Status)
+	}
+
+	// A producer re-scan is a full no-op on a decided row, so it cannot resurrect the
+	// recommendation either.
+	if _, err := s.UpsertReviewItem(mkReviewItem(
+		"regroup.multidisc", "dk-dec", "/books/a", "rescanned", `{"recommendedAction":"combine"}`)); err != nil {
+		t.Fatalf("re-scan upsert: %v", err)
+	}
+	reread, _ = s.GetReviewItem(it.ID)
+	if reread.ChosenAction != "separate" {
+		t.Fatalf("chosen_action = %q after a re-scan, want separate", reread.ChosenAction)
+	}
+}
+
+// Persisting a decision on a missing row behaves like every other store getter:
+// (nil, nil), so the handler can answer 404 rather than inventing a row.
+func TestSetReviewItemDecision_NotFound(t *testing.T) {
+	s := newReviewTestStore(t)
+	got, err := s.SetReviewItemDecision("nonexistent", ReviewStatusApproved, "combine")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/itunes/service/fs_regroup_recommend_test.go
+++ b/internal/itunes/service/fs_regroup_recommend_test.go
@@ -1,0 +1,546 @@
+// file: internal/itunes/service/fs_regroup_recommend_test.go
+// version: 1.0.0
+// guid: ef64c75d-a456-4afd-94fd-ca99116dc105
+// last-edited: 2026-08-06
+
+package itunesservice
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// This file covers the recommendation layer added on 2026-08-06 and the
+// survivor-title fix that shipped with it. Every case is calibrated against a
+// production measurement taken the same day (356 pending holds), recorded in
+// PLAN.md's calibration table; the per-case comments give the hold count each
+// shape represents so a future change that flips one knows what it is moving.
+//
+// The paths are real prod shapes, not invented ones. That matters: the whole
+// failure mode being fixed here is a classifier that reads plausibly on synthetic
+// input and mis-reads the actual library.
+
+// sbD builds a primary single-file ShatterBook with a known runtime.
+func sbD(id, path string, durationSec int) ShatterBook {
+	b := sb(id, path)
+	b.DurationSec = durationSec
+	return b
+}
+
+// sbDA is sbD plus a display author — needed for the survivor-title author guard,
+// which stays inert when no author holds a majority.
+func sbDA(id, path string, durationSec int, author string) ShatterBook {
+	b := sbD(id, path, durationSec)
+	b.Author = author
+	return b
+}
+
+const (
+	fifteenHours = 56736 // 15.76 h — a whole novel (the real "The Rising" runtime)
+	tenHours     = 38520 // 10.7 h  — a whole novel
+	twoHours     = 7200  // 2 h     — book-length by the 90-min rule
+	thirtyMin    = 1800  // 30 min  — a fragment
+	nineteenMin  = 1152  // 0.32 h  — the real the-final-strife median
+	twentyMin    = 1200  // 20 min  — a fragment
+)
+
+// assertRec checks the recommended action and that the reason actually quotes
+// numbers. A reason without numbers is a nicer generic string, which is precisely
+// the thing this change exists to replace (762 of 777 holds carried one identical
+// sentence before it).
+func assertRec(t *testing.T, g RegroupGroup, wantAction string) {
+	t.Helper()
+	if g.RecommendedAction != wantAction {
+		t.Errorf("recommendedAction=%q, want %q (reason: %q)",
+			g.RecommendedAction, wantAction, g.RecommendationReason)
+	}
+	if strings.TrimSpace(g.RecommendationReason) == "" {
+		t.Errorf("recommendationReason is empty for action %q", g.RecommendedAction)
+	}
+	if !strings.ContainsAny(g.RecommendationReason, "0123456789") {
+		t.Errorf("recommendationReason names no numbers: %q", g.RecommendationReason)
+	}
+}
+
+// ─── calibration table: ambiguous holds ──────────────────────────────────────
+
+// 137 prod holds. Two members, each a full 15.76 h novel, sharing an edition
+// folder. The classifier's Kind is ambiguous (the 762-of-777 flat-ambiguous
+// branch); the runtimes say these are two separate books.
+func TestRecommend_Ambiguous_MajorityBookLength_Separate(t *testing.T) {
+	base := shatterRoot + "/Ian Tregillis/The Rising (Unabridged)/The Rising (Unabridged)"
+	books := []ShatterBook{
+		sbD("r1", base+"/01.mp3", fifteenHours),
+		sbD("r2", base+"/02.mp3", fifteenHours),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Rising (Unabridged)")
+	if g.Kind != KindAmbiguous {
+		t.Fatalf("kind=%q, want %q (the Kind switch must be untouched)", g.Kind, KindAmbiguous)
+	}
+	assertRec(t, g, ActionSeparate)
+	if g.RecommendationEvidence.BookLengthMembers != 2 {
+		t.Errorf("bookLengthMembers=%d, want 2", g.RecommendationEvidence.BookLengthMembers)
+	}
+	if g.RecommendationEvidence.LongestKnownSec != fifteenHours {
+		t.Errorf("longestKnownSec=%d, want %d", g.RecommendationEvidence.LongestKnownSec, fifteenHours)
+	}
+	// The reason must be legible without opening the hold.
+	if !strings.Contains(g.RecommendationReason, "15.8 h") {
+		t.Errorf("reason should quote the longest runtime, got %q", g.RecommendationReason)
+	}
+	if g.SurvivorTitle != "The Rising" {
+		t.Errorf("survivorTitle=%q, want 'The Rising'", g.SurvivorTitle)
+	}
+}
+
+// 24 prod holds. Same folder shape, but every member is a 30-minute fragment.
+func TestRecommend_Ambiguous_AllFragments_Combine(t *testing.T) {
+	base := shatterRoot + "/Ian Tregillis/The Rising (Unabridged)/The Rising (Unabridged)"
+	books := []ShatterBook{
+		sbD("f1", base+"/01.mp3", thirtyMin),
+		sbD("f2", base+"/02.mp3", thirtyMin),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Rising (Unabridged)")
+	if g.Kind != KindAmbiguous {
+		t.Fatalf("kind=%q, want %q", g.Kind, KindAmbiguous)
+	}
+	assertRec(t, g, ActionCombine)
+	if g.RecommendationEvidence.MedianKnownSec != thirtyMin {
+		t.Errorf("medianKnownSec=%d, want %d", g.RecommendationEvidence.MedianKnownSec, thirtyMin)
+	}
+}
+
+// 5 prod holds. Two whole books and two fragments in one folder — neither side a
+// majority, so the members disagree about what they are and a human must look.
+func TestRecommend_Ambiguous_MixedRuntimes_InsufficientEvidence(t *testing.T) {
+	base := shatterRoot + "/Various/Mixed Bag (Unabridged)/Mixed Bag (Unabridged)"
+	books := []ShatterBook{
+		sbD("m1", base+"/Prologue.mp3", twoHours),
+		sbD("m2", base+"/Interlude.mp3", twoHours),
+		sbD("m3", base+"/Epilogue.mp3", twentyMin),
+		sbD("m4", base+"/Coda.mp3", twentyMin),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Mixed Bag (Unabridged)")
+	if g.Kind != KindAmbiguous {
+		t.Fatalf("kind=%q, want %q", g.Kind, KindAmbiguous)
+	}
+	assertRec(t, g, ActionInsufficientEvidence)
+	if !strings.Contains(g.RecommendationReason, "disagree") {
+		t.Errorf("reason should say the members disagree, got %q", g.RecommendationReason)
+	}
+	ev := g.RecommendationEvidence
+	if ev.BookLengthMembers != 2 || ev.DurationsKnown != 4 {
+		t.Errorf("evidence=%+v, want bookLengthMembers=2 durationsKnown=4", ev)
+	}
+}
+
+// 56 prod holds. No member has a known runtime. The reason must say the EVIDENCE
+// is missing — not that the members are unrelated, which would be a claim the
+// classifier cannot support.
+func TestRecommend_Ambiguous_NoDurations_InsufficientEvidence(t *testing.T) {
+	base := shatterRoot + "/Ian Tregillis/The Rising (Unabridged)/The Rising (Unabridged)"
+	books := []ShatterBook{
+		sb("z1", base+"/01.mp3"),
+		sb("z2", base+"/02.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Rising (Unabridged)")
+	assertRec(t, g, ActionInsufficientEvidence)
+	if !strings.Contains(g.RecommendationReason, "known runtime") {
+		t.Errorf("reason should blame the missing runtimes, got %q", g.RecommendationReason)
+	}
+	if g.RecommendationEvidence.DurationsKnown != 0 {
+		t.Errorf("durationsKnown=%d, want 0", g.RecommendationEvidence.DurationsKnown)
+	}
+}
+
+// A single known runtime among four unknowns is not a majority and must not carry
+// the group. This is the gap between "no evidence" and "enough evidence" — the
+// literal rule "every member with a known duration is short" would combine here
+// on one member's say-so.
+func TestRecommend_MinorityDurationsKnown_InsufficientEvidence(t *testing.T) {
+	base := shatterRoot + "/Various/Sparse Data (Unabridged)/Sparse Data (Unabridged)"
+	books := []ShatterBook{
+		sbD("s1", base+"/Prologue.mp3", twentyMin),
+		sb("s2", base+"/Interlude.mp3"),
+		sb("s3", base+"/Epilogue.mp3"),
+		sb("s4", base+"/Coda.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Sparse Data (Unabridged)")
+	assertRec(t, g, ActionInsufficientEvidence)
+	if g.RecommendedAction == ActionCombine {
+		t.Fatal("one known short runtime must never carry a destructive combine")
+	}
+}
+
+// 🔴 The membership itself is unconfirmed. Two DIFFERENT books under two different
+// authors, glued into one group only because their original iTunes album tag
+// collided. classifyGroup's first switch case already refuses to vouch for this
+// grouping; a recommendation that looked only at runtimes answered "combine" here
+// (both members are short), which would merge two unrelated books.
+//
+// Short runtimes are evidence about what the members ARE, not evidence that they
+// belong together.
+func TestRecommend_MergedViaItunes_NeverCombine(t *testing.T) {
+	books := []ShatterBook{
+		sbIT("mi1", shatterRoot+"/Author A/Book One/01.mp3", `W:\Audiobooks\Shared Album\01.mp3`),
+		sbIT("mi2", shatterRoot+"/Author B/Book Two/01.mp3", `W:\Audiobooks\Shared Album\02.mp3`),
+	}
+	books[0].DurationSec = thirtyMin
+	books[1].DurationSec = thirtyMin
+	groups, _ := ClassifyShatteredFolders(books)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 iTunes-glued group, got %d: %+v", len(groups), groups)
+	}
+	g := groups[0]
+	if g.Kind != KindAmbiguous {
+		t.Fatalf("kind=%q, want %q", g.Kind, KindAmbiguous)
+	}
+	if g.RecommendedAction == ActionCombine {
+		t.Fatalf("recommended COMBINE for a grouping the classifier declined to vouch "+
+			"for; reason was %q", g.RecommendationReason)
+	}
+	assertRec(t, g, ActionInsufficientEvidence)
+	if !strings.Contains(g.RecommendationReason, "iTunes album") {
+		t.Errorf("reason should name the iTunes-album glue, got %q", g.RecommendationReason)
+	}
+}
+
+// ─── calibration table: multidisc holds ──────────────────────────────────────
+
+// 121 prod holds. The real the-final-strife folder: 12 flat numbered files with a
+// 0.32 h median. Genuine chapter fragments.
+func TestRecommend_Multidisc_AllFragments_Combine(t *testing.T) {
+	base := "/mnt/bigdata/books/newbooks/audiobooks/the-final-strife 01/the-final-strife"
+	var books []ShatterBook
+	for i := 1; i <= 12; i++ {
+		books = append(books, sbD(fmt.Sprintf("tfs%02d", i),
+			fmt.Sprintf("%s/the-final-strife-%02d.mp3", base, i), nineteenMin))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "the-final-strife")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	assertRec(t, g, ActionCombine)
+	ev := g.RecommendationEvidence
+	if ev.Members != 12 || ev.DurationsKnown != 12 || ev.BookLengthMembers != 0 {
+		t.Errorf("evidence=%+v, want 12 members / 12 known / 0 book-length", ev)
+	}
+	if ev.NumberedMembers != 12 || ev.Structure != "flat" {
+		t.Errorf("evidence=%+v, want 12 numbered / flat structure", ev)
+	}
+	if g.SurvivorTitle != "the-final-strife" {
+		t.Errorf("survivorTitle=%q, want 'the-final-strife'", g.SurvivorTitle)
+	}
+}
+
+// 🔴 THE NEAR-MISS. 3 prod holds. The disc branch of classifyGroup never evaluates
+// the series guard, so two whole 10.7 h novels in Disc 1 / Disc 2 folders come out
+// as a CONFIDENT multidisc collapse. Approving that merges distinct novels through
+// an apply path that hard-deletes the absorbed Book rows.
+//
+// The Kind assertion is as load-bearing as the action assertion: it proves the Kind
+// switch was NOT perturbed by this change (design decision D1), which is the
+// cheapest regression guard available here.
+func TestRecommend_Multidisc_MajorityBookLength_Separate_NearMiss(t *testing.T) {
+	base := shatterRoot + "/Jonathan Moeller/Sevenfold Sword"
+	books := []ShatterBook{
+		sbD("sw1", base+"/Disc 1/track.mp3", tenHours),
+		sbD("sw2", base+"/Disc 2/track.mp3", tenHours),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Sevenfold Sword")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true — the Kind switch must be unchanged",
+			g.Kind, g.Confident)
+	}
+	assertRec(t, g, ActionSeparate)
+	if g.RecommendationEvidence.Structure != "disc" {
+		t.Errorf("structure=%q, want disc", g.RecommendationEvidence.Structure)
+	}
+	if g.SurvivorTitle != "Sevenfold Sword" {
+		t.Errorf("survivorTitle=%q, want 'Sevenfold Sword'", g.SurvivorTitle)
+	}
+}
+
+// The same near-miss through the CHAPTER branch, which likewise never evaluates the
+// series guard: `<Book>/<Book> - N/file` shells holding whole novels.
+func TestRecommend_MultidiscChapterShells_BookLength_Separate(t *testing.T) {
+	base := shatterRoot + "/Michael J. Sullivan/Riyria Revelations"
+	var books []ShatterBook
+	for i := 1; i <= 6; i++ {
+		books = append(books, sbD(fmt.Sprintf("rr%d", i),
+			fmt.Sprintf("%s/Riyria Revelations - %d/01.mp3", base, i), tenHours))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Riyria Revelations")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true", g.Kind, g.Confident)
+	}
+	assertRec(t, g, ActionSeparate)
+}
+
+// 🔴 THE SINGLE MOST IMPORTANT CASE. The 41-of-43 shape from the 2026-08-05 dry-run:
+// an iTunes author folder of numbered sequels, flat, numbered, n >= 4, one title
+// stem — a CONFIDENT multidisc collapse — with every runtime missing.
+//
+// membersAreBookLength counts unknown members as NOT book-length, so the series
+// guard is inert here and the Kind stays "confident". The recommendation is the
+// symmetric half of that rule: missing data must not fire a COLLAPSE either. This
+// must be insufficient-evidence, NEVER combine.
+func TestRecommend_ZeroDurationFlatNumbered_NeverCombine(t *testing.T) {
+	base := shatterRoot + "/iTunes Media/Audiobooks/Rick Cole"
+	books := []ShatterBook{
+		sb("ss1", base+"/Super Sales on Super Heroes.mp3"),
+		sb("ss2", base+"/Super Sales on Super Heroes 2.mp3"),
+		sb("ss3", base+"/Super Sales on Super Heroes 3.mp3"),
+		sb("ss4", base+"/Super Sales on Super Heroes 4.mp3"),
+		sb("ss5", base+"/Super Sales on Super Heroes 5.mp3"),
+		sb("ss6", base+"/Super Sales on Super Heroes 6.mp3"),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Rick Cole")
+	if g.Kind != KindMultidisc || !g.Confident {
+		t.Fatalf("kind=%q confident=%v, want multidisc/true (guard inert without runtimes)",
+			g.Kind, g.Confident)
+	}
+	if g.RecommendedAction == ActionCombine {
+		t.Fatalf("zero-duration group recommended COMBINE — an absent duration is not "+
+			"evidence; reason was %q", g.RecommendationReason)
+	}
+	assertRec(t, g, ActionInsufficientEvidence)
+}
+
+// ─── calibration table: anthology and version-group holds ────────────────────
+
+// 1 prod hold. An anthology marker on the folder plus distinct story titles = one
+// published book with one ISBN; the members are short stories, not novels.
+func TestRecommend_Anthology_Fragments_Combine(t *testing.T) {
+	base := shatterRoot + "/Rod Serling/Twilight Zone Anthology"
+	books := []ShatterBook{
+		sbD("a1", base+"/01 - The Monsters.mp3", thirtyMin),
+		sbD("a2", base+"/02 - Time Enough.mp3", thirtyMin),
+		sbD("a3", base+"/03 - Nightmare.mp3", thirtyMin),
+		sbD("a4", base+"/04 - The Howling Man.mp3", thirtyMin),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Twilight Zone Anthology")
+	if g.Kind != KindAnthology {
+		t.Fatalf("kind=%q, want %q", g.Kind, KindAnthology)
+	}
+	assertRec(t, g, ActionCombine)
+	if g.RecommendationEvidence.DistinctStems != 4 {
+		t.Errorf("distinctStems=%d, want 4", g.RecommendationEvidence.DistinctStems)
+	}
+}
+
+// 1 prod hold. An Abridged + Unabridged pair whose members are each a whole 10.7 h
+// novel.
+//
+// 🔴 THIS IS THE CASE THAT FORCED A FIFTH ACTION. Both editions are book-length, so
+// the runtime rule alone answers ActionSeparate — true in the narrow sense (they are
+// two distinct recordings) but operationally wrong: leaving them unlinked is exactly
+// the state the hold exists to fix. And because step 4 dispatches on the CHOSEN
+// action rather than on Kind, "separate" would make ApplyVersionGroup unreachable —
+// the one apply path that destroys nothing would become the one that never runs.
+//
+// KindVersionGroup therefore overrides the runtime recommendation with
+// ActionVersionGroup. Safe in a way the reverse would not be: the classifier reached
+// this Kind only via explicit abridged/unabridged markers PLUS a dominant shared
+// title, which is positive identity evidence runtime does not have.
+func TestRecommend_VersionGroup_OverridesRuntimeSeparate(t *testing.T) {
+	base := shatterRoot + "/Frank Herbert/Dune"
+	books := []ShatterBook{
+		sbD("v1", base+"/Dune (Unabridged)/01.mp3", tenHours),
+		sbD("v2", base+"/Dune (Abridged)/01.mp3", tenHours),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Dune")
+	if g.Kind != KindVersionGroup {
+		t.Fatalf("kind=%q, want %q", g.Kind, KindVersionGroup)
+	}
+	assertRec(t, g, ActionVersionGroup)
+	if g.SurvivorTitle != "Dune" {
+		t.Errorf("survivorTitle=%q, want 'Dune'", g.SurvivorTitle)
+	}
+	// The evidence block must still carry the real runtimes: the override changes
+	// the verdict, not the numbers the human is shown.
+	if g.RecommendationEvidence.BookLengthMembers != 2 {
+		t.Errorf("bookLengthMembers=%d, want 2 — evidence must survive the override",
+			g.RecommendationEvidence.BookLengthMembers)
+	}
+}
+
+// ─── deriveSurvivorTitle / survivorTitleFor regressions ──────────────────────
+
+// The observed prod failure: a hold under the AUTHOR folder `C. T. Phipps` was
+// labelled "C. T. Phipps". The members' own dominant stem names the book.
+func TestSurvivorTitle_AuthorFolder_UsesMemberStem(t *testing.T) {
+	base := shatterRoot + "/C. T. Phipps"
+	var books []ShatterBook
+	for i := 1; i <= 5; i++ {
+		books = append(books, sbDA(fmt.Sprintf("ph%d", i),
+			fmt.Sprintf("%s/Wraith Knight %02d.mp3", base, i), tenHours, "C. T. Phipps"))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "C. T. Phipps")
+	if g.SurvivorTitle == "C. T. Phipps" {
+		t.Fatal("survivorTitle is the AUTHOR name — the bug this fix exists for")
+	}
+	if g.SurvivorTitle != "Wraith Knight" {
+		t.Errorf("survivorTitle=%q, want 'Wraith Knight'", g.SurvivorTitle)
+	}
+	// Five whole novels in one author folder: separate, not combine.
+	assertRec(t, g, ActionSeparate)
+}
+
+// The folder says "Vol. 01"; every member file says "Vol. 9". The folder carries a
+// stale number, so the members win.
+func TestSurvivorTitle_WrongVolumeInFolder_MembersWin(t *testing.T) {
+	base := shatterRoot + "/Jim Butcher/The Dresden Files Vol. 01"
+	var books []ShatterBook
+	for i := 1; i <= 4; i++ {
+		books = append(books, sbD(fmt.Sprintf("df%d", i),
+			fmt.Sprintf("%s/The Dresden Files Vol. 9 - %02d.mp3", base, i), thirtyMin))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "The Dresden Files Vol. 01")
+	if g.SurvivorTitle != "The Dresden Files Vol. 9" {
+		t.Errorf("survivorTitle=%q, want 'The Dresden Files Vol. 9' (members carry the right volume)",
+			g.SurvivorTitle)
+	}
+}
+
+// The Coraline shape: the FOLDER is the book and the files are generically named
+// ("01 - Chapter.mp3"). Preferring the member stem unconditionally would label this
+// group "Chapter" — a fresh instance of the bug being fixed. The generic-title
+// guard sends it back to the folder name.
+func TestSurvivorTitle_GenericMemberStem_FallsBackToFolder(t *testing.T) {
+	base := shatterRoot + "/Neil Gaiman/Coraline"
+	var books []ShatterBook
+	for i := 1; i <= 8; i++ {
+		books = append(books, sbD(fmt.Sprintf("co%d", i),
+			fmt.Sprintf("%s/%02d - Chapter.mp3", base, i), twentyMin))
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	g := findGroup(t, groups, "Coraline")
+	if g.SurvivorTitle != "Coraline" {
+		t.Errorf("survivorTitle=%q, want 'Coraline' (generic stem must not win)", g.SurvivorTitle)
+	}
+}
+
+// Direct table test on the selector, covering the guards that are hard to reach
+// end-to-end (a group must EMIT a hold to be observable, and the worst titles come
+// from folders that emit for unrelated reasons).
+func TestSurvivorTitleFor_Table(t *testing.T) {
+	cases := []struct {
+		name         string
+		folderName   string
+		namedAfter   bool
+		stem         string
+		stemMajority bool
+		authorNorm   string
+		want         string
+	}{
+		{
+			name: "folder named after book wins", folderName: "Cage of Souls (Unabridged)",
+			namedAfter: true, stem: "Cage of Souls", stemMajority: true, want: "Cage of Souls",
+		},
+		{
+			name: "bare ordinal folder is rejected", folderName: "Volume 1",
+			namedAfter: true, stem: "Volume 1", stemMajority: true, want: "",
+		},
+		{
+			name:       "author name folder with no usable stem is rejected",
+			folderName: "C. T. Phipps", namedAfter: false, stem: "", stemMajority: false,
+			authorNorm: normTitle("C. T. Phipps"), want: "",
+		},
+		{
+			name:       "author name is rejected even when the stem agrees",
+			folderName: "C. T. Phipps", namedAfter: false, stem: "C. T. Phipps",
+			stemMajority: true, authorNorm: normTitle("C. T. Phipps"), want: "",
+		},
+		{
+			name: "generic stem falls back to the folder", folderName: "Coraline",
+			namedAfter: false, stem: "Chapter", stemMajority: true, want: "Coraline",
+		},
+		{
+			name: "bare number stem falls back to the folder", folderName: "Coraline",
+			namedAfter: false, stem: "07", stemMajority: true, want: "Coraline",
+		},
+		{
+			name:       "stale folder volume loses to the members",
+			folderName: "The Dresden Files Vol. 01", namedAfter: false,
+			stem: "The Dresden Files Vol. 9", stemMajority: true,
+			want: "The Dresden Files Vol. 9",
+		},
+		{
+			name:       "a plurality stem is not a majority, folder used",
+			folderName: "Assorted Works", namedAfter: false, stem: "One Odd Book",
+			stemMajority: false, want: "Assorted Works",
+		},
+		{
+			name: "nothing trustworthy yields empty", folderName: "Disc 3",
+			namedAfter: false, stem: "Track", stemMajority: true, want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := survivorTitleFor(tc.folderName, tc.namedAfter, tc.stem, tc.stemMajority, tc.authorNorm)
+			if got != tc.want {
+				t.Errorf("survivorTitleFor(%q, %v, %q, %v, %q) = %q, want %q",
+					tc.folderName, tc.namedAfter, tc.stem, tc.stemMajority, tc.authorNorm, got, tc.want)
+			}
+		})
+	}
+}
+
+// The median must ignore unknown (zero) runtimes: including them would make the
+// reason sentence quote a number no member actually has.
+func TestGatherEvidence_MedianExcludesUnknowns(t *testing.T) {
+	members := []memberInfo{
+		{book: ShatterBook{DurationSec: 0}},
+		{book: ShatterBook{DurationSec: 0}},
+		{book: ShatterBook{DurationSec: 600}},
+		{book: ShatterBook{DurationSec: 1200}},
+		{book: ShatterBook{DurationSec: 6000}},
+	}
+	ev := gatherEvidence(members, 1, 5, "flat")
+	if ev.DurationsKnown != 3 {
+		t.Errorf("durationsKnown=%d, want 3", ev.DurationsKnown)
+	}
+	if ev.MedianKnownSec != 1200 {
+		t.Errorf("medianKnownSec=%d, want 1200 (zeros excluded)", ev.MedianKnownSec)
+	}
+	if ev.LongestKnownSec != 6000 {
+		t.Errorf("longestKnownSec=%d, want 6000", ev.LongestKnownSec)
+	}
+	if ev.BookLengthMembers != 1 {
+		t.Errorf("bookLengthMembers=%d, want 1", ev.BookLengthMembers)
+	}
+}
+
+// duplicate-of is part of the closed vocabulary but nothing in this package emits
+// it — deciding "this folder duplicates an existing book" needs cross-book evidence
+// classifyGroup does not have. Pin that so a future change is deliberate.
+func TestRecommend_NeverEmitsDuplicateOf(t *testing.T) {
+	base := shatterRoot + "/Various/Whatever"
+	books := []ShatterBook{
+		sbD("dz1", base+"/01 - One.mp3", thirtyMin),
+		sbD("dz2", base+"/02 - Two.mp3", thirtyMin),
+		sbD("dz3", base+"/03 - Three.mp3", tenHours),
+		sbD("dz4", base+"/04 - Four.mp3", thirtyMin),
+	}
+	groups, _ := ClassifyShatteredFolders(books)
+	for _, g := range groups {
+		if g.RecommendedAction == ActionDuplicateOf {
+			t.Errorf("classifyGroup emitted %q, which it has no evidence for", ActionDuplicateOf)
+		}
+	}
+}

--- a/internal/itunes/service/fs_regroup_shape.go
+++ b/internal/itunes/service/fs_regroup_shape.go
@@ -1,7 +1,7 @@
 // file: internal/itunes/service/fs_regroup_shape.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 1e7d4a92-3c85-4b60-9f21-6a8c0d5e2b47
-// last-edited: 2026-07-26
+// last-edited: 2026-08-06
 
 // Package service — deterministic (regex-only) shape classifier for the
 // shattered-book REGROUP review producer (PR-B1).
@@ -58,6 +58,7 @@
 package itunesservice
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -72,6 +73,60 @@ const (
 	KindVersionGroup = "regroup.version-group" // Abridged + Unabridged editions in one folder
 	KindAnthology    = "regroup.anthology"     // anthology/collection/omnibus = ONE book → combine (owner: single ISBN)
 	KindAmbiguous    = "regroup.ambiguous"     // book-like folder, cannot confidently classify
+)
+
+// Recommended-action strings — the CLOSED vocabulary a review hold may recommend.
+//
+// These are deliberately SEPARATE from the Kind strings above and do not replace
+// them. A Kind says what SHAPE the classifier saw ("these files live in Disc N
+// folders"); an action says what a human should DO about it ("these are six
+// different novels — leave them apart"). Prod showed the two can disagree: 3 of the
+// 130 `regroup.multidisc` holds measured on 2026-08-06 hold members that are each
+// book-length, because the disc and chapter/edition branches of classifyGroup never
+// evaluate the series guard. Their Kind is still "multidisc" — the shape really is a
+// disc set — but the correct action is `separate`, and approving `combine` would
+// merge distinct novels through an apply path that hard-deletes absorbed Book rows.
+//
+// Exported because the approve handler (owner item 2) dispatches on the CHOSEN
+// action across package boundaries.
+const (
+	// ActionCombine — the members are parts of one book; merge them.
+	ActionCombine = "combine"
+	// ActionSeparate — the members are already N distinct books; leave them apart.
+	// Non-destructive: nothing to apply, only a status transition.
+	ActionSeparate = "separate"
+	// ActionDuplicateOf — the members are debris of a book that already exists
+	// correctly elsewhere.
+	//
+	// 🔴 NOTHING IN THIS FILE EVER EMITS THIS. It is defined here so the action
+	// vocabulary is closed and complete in one place, but deciding "this folder
+	// duplicates an existing book" requires cross-book identity evidence
+	// (fingerprints, ASIN/ISBN consensus) that classifyGroup does not have — it
+	// reasons over ONE folder's names and runtimes in isolation. The
+	// duplicate-detection track owns emitting it.
+	ActionDuplicateOf = "duplicate-of"
+	// ActionInsufficientEvidence — the classifier cannot tell. Emit-only: it is a
+	// statement BY the machine, not a decision a human can pick.
+	ActionInsufficientEvidence = "insufficient-evidence"
+	// ActionVersionGroup — the members are DIFFERENT EDITIONS of one work (an
+	// abridged and an unabridged recording, two narrators, a remaster). Link them
+	// into a version group with one primary; keep every file.
+	//
+	// 🔴 WHY THIS EXISTS AS A FIFTH ACTION, AND WHY RUNTIME CANNOT DECIDE IT.
+	// Two editions of the same novel are BOTH book-length by definition, so the
+	// runtime rule below sees a majority over bookLengthSec and answers
+	// ActionSeparate — technically true (they are distinct recordings) and
+	// operationally wrong (leaving them unlinked is exactly the state the hold
+	// exists to fix). Worse, once the approve handler dispatches on the CHOSEN
+	// action rather than on Kind, a version-group hold recommending "separate"
+	// makes ApplyVersionGroup permanently unreachable: the one apply path that
+	// destroys nothing would become the one that never runs.
+	//
+	// So KindVersionGroup overrides the runtime recommendation. That is safe in a
+	// way the reverse would not be — the classifier reached KindVersionGroup only
+	// via explicit abridged/unabridged edition markers PLUS a dominant shared
+	// title, which is positive identity evidence that runtime does not have.
+	ActionVersionGroup = "version-group"
 )
 
 // ShatterBook is the slim per-book view the classifier reasons over. Build it from
@@ -159,6 +214,190 @@ func membersAreBookLength(members []memberInfo) bool {
 	return long*2 > len(members)
 }
 
+// RecommendationEvidence is the numeric case FOR a recommendation — every number
+// the reason sentence quotes, so a reviewer can check the machine's arithmetic
+// instead of trusting it.
+//
+// This exists because of what the queue looked like before it: 762 of 777 holds
+// carried the SAME sentence ("review: flat folder shares a title but ordering is
+// unclear"), which tells a reviewer nothing they could act on. A reason without
+// numbers is just a nicer generic string; the numbers are the point.
+//
+// Every field is already computed by classifyGroup or trivially derived from the
+// members — nothing here needs new I/O. JSON tags are lowerCamelCase to match the
+// existing regroup payload style.
+type RecommendationEvidence struct {
+	// Members is the group's member count.
+	Members int `json:"members"`
+	// DurationsKnown is how many members have a non-zero DurationSec. The gap
+	// between this and Members is the whole reason a recommendation can be
+	// "insufficient-evidence": see recommendAction.
+	DurationsKnown int `json:"durationsKnown"`
+	// BookLengthMembers is how many members run >= bookLengthSec (90 min) and are
+	// therefore individually long enough to BE books.
+	BookLengthMembers int `json:"bookLengthMembers"`
+	// MedianKnownSec is the median runtime over members with a KNOWN duration
+	// (zeros excluded — including them would make the reason sentence state a
+	// number no member actually has). Lower-middle on an even count. 0 when no
+	// member has a known duration.
+	MedianKnownSec int `json:"medianKnownSec"`
+	// LongestKnownSec is the longest member runtime in seconds, 0 when unknown.
+	// It is the single most legible number for the separate case: "the longest
+	// member runs 15.8 h" reads as "that is a novel" without any further context.
+	LongestKnownSec int `json:"longestKnownSec"`
+	// DistinctStems is the number of distinct title stems among the members
+	// (classifyGroup's distinctPrefixes) — the anthology / over-merge signal.
+	DistinctStems int `json:"distinctStems"`
+	// NumberedMembers is how many members carry a parseable chapter/track ordinal.
+	NumberedMembers int `json:"numberedMembers"`
+	// Structure is the group's dominant physical shape, mirroring
+	// RegroupGroup.Structure ("disc" | "chapter" | "flat").
+	Structure string `json:"structure"`
+}
+
+// gatherEvidence tallies the runtime facts about a group's members. The
+// name-derived counts are passed in because classifyGroup already computed them.
+func gatherEvidence(members []memberInfo, distinctStems, numberedMembers int, structure string) RecommendationEvidence {
+	ev := RecommendationEvidence{
+		Members:         len(members),
+		DistinctStems:   distinctStems,
+		NumberedMembers: numberedMembers,
+		Structure:       structure,
+	}
+	known := make([]int, 0, len(members))
+	for _, m := range members {
+		d := m.book.DurationSec
+		if d <= 0 {
+			continue // unknown — deliberately NOT folded into any average
+		}
+		ev.DurationsKnown++
+		known = append(known, d)
+		if d >= bookLengthSec {
+			ev.BookLengthMembers++
+		}
+		if d > ev.LongestKnownSec {
+			ev.LongestKnownSec = d
+		}
+	}
+	if len(known) > 0 {
+		sort.Ints(known)
+		ev.MedianKnownSec = known[(len(known)-1)/2] // lower middle on an even count
+	}
+	return ev
+}
+
+// humanRuntime renders a runtime the way a reviewer thinks about it: hours for a
+// book, minutes for a chapter.
+func humanRuntime(sec int) string {
+	if sec >= 3600 {
+		return fmt.Sprintf("%.1f h", float64(sec)/3600)
+	}
+	return fmt.Sprintf("%d min", (sec+30)/60)
+}
+
+// recommendAction turns the runtime evidence into a recommended action and a
+// one-sentence reason that quotes its own numbers.
+//
+// 🔴 THE ONE RULE THAT MATTERS: AN ABSENT DURATION IS NOT EVIDENCE.
+//
+// The classifier's founding assumption is "files in one folder are tracks of one
+// book". That is true of the organized tree and FALSE of the iTunes tree, where
+// `iTunes Media/Audiobooks/<Author>/` holds an author's whole catalogue. Runtime is
+// the only signal that separates the two cases, because numbered SEQUELS share one
+// title stem ("Super Sales on Super Heroes" / " 2" / " 3") and so slip past every
+// name-based guard. A 2026-08-05 dry-run found 41 of 43 confident candidates were
+// exactly that shape.
+//
+// Which means a group with NO runtime data is not "probably chapters" — it is
+// UNKNOWN, and the same folder that looks like a chapter set with the durations
+// missing looks like a six-novel series with them present. So the majority-known
+// gate below is checked FIRST, unconditionally, with no structural exception: a
+// zero-duration chapter shatter recommends insufficient-evidence, not combine. The
+// asymmetry is deliberate and is the reason for the ordering — `combine` routes to
+// an apply path that HARD-DELETES the absorbed Book rows, while `separate` and
+// `insufficient-evidence` change nothing. Guessing wrong toward separate leaves a
+// book shattered (recoverable any time); guessing wrong toward combine destroys
+// rows. Only one of those is reversible.
+//
+// This is the same rule that made membersAreBookLength safe (it counts unknown
+// members as NOT book-length so the guard cannot fire on missing data); here the
+// symmetric half is enforced — missing data cannot fire a COLLAPSE either.
+//
+// Deliberately independent of Kind. A Kind describes the shape the classifier saw;
+// this describes what the runtimes say to do about it. The 3 multidisc holds whose
+// members are each book-length are exactly the case where the two disagree, and
+// suppressing the disagreement is what would lose books.
+//
+// distinctPathFolders is how many distinct FilePath book-folders the group spans; >1
+// means the membership itself is unconfirmed (see the gate below).
+func recommendAction(ev RecommendationEvidence, members []memberInfo,
+	distinctPathFolders int) (action, reason string) {
+	n := ev.Members
+
+	// (1) Not enough runtime evidence to say anything. A strict majority of members
+	// must have a known duration before ANY decisive call, so a lone known runtime
+	// among five unknowns cannot carry the group.
+	if ev.DurationsKnown*2 <= n {
+		if ev.DurationsKnown == 0 {
+			return ActionInsufficientEvidence, fmt.Sprintf(
+				"none of the %d members has a known runtime — an absent duration is not evidence, "+
+					"so chapters of one book cannot be told apart from separate books", n)
+		}
+		return ActionInsufficientEvidence, fmt.Sprintf(
+			"only %d of %d members has a known runtime — an absent duration is not evidence, "+
+				"so chapters of one book cannot be told apart from separate books",
+			ev.DurationsKnown, n)
+	}
+
+	// (1b) The group spans several FilePath folders and is held together ONLY by a
+	// shared original iTunes album. classifyGroup's first switch case already refuses
+	// to vouch for this grouping ("the two identity signals disagree"), and a
+	// recommendation that reasons purely about RUNTIMES would happily answer
+	// `combine` for it — recommending a destructive merge of a membership the
+	// classifier just declined to confirm. Two 30-minute files under
+	// `Author A/Book One` and `Author B/Book Two` are not two chapters of one book
+	// merely because both runtimes are short; they are two different books whose
+	// iTunes album tag collided.
+	//
+	// This is a GUARD on membership, not a second length threshold — bookLengthSec
+	// remains the only runtime cut-off in this file.
+	if distinctPathFolders > 1 {
+		return ActionInsufficientEvidence, fmt.Sprintf(
+			"these %d members span %d different file-path folders and are grouped only by a "+
+				"shared original iTunes album — whether they are one book is unconfirmed",
+			n, distinctPathFolders)
+	}
+
+	// (2) A strict majority of members are individually long enough to BE books, so
+	// this folder holds separate books that were grouped by name alone. Reuses the
+	// existing membersAreBookLength helper and its single bookLengthSec threshold —
+	// a second threshold here would be a second thing to get wrong.
+	if membersAreBookLength(members) {
+		return ActionSeparate, fmt.Sprintf(
+			"%d of %d members run 90 min or longer (longest %s) — each is book-length, "+
+				"so these are separate books, not parts of one",
+			ev.BookLengthMembers, n, humanRuntime(ev.LongestKnownSec))
+	}
+
+	// (3) Every member whose runtime we know is shorter than a book. Combined with
+	// the majority-known gate above, that is positive evidence of genuine
+	// disc/chapter fragments — the only branch that recommends a destructive merge.
+	if ev.BookLengthMembers == 0 {
+		return ActionCombine, fmt.Sprintf(
+			"all %d members with a known runtime are under 90 min (median %s) — "+
+				"chapter- or disc-length fragments of one book",
+			ev.DurationsKnown, humanRuntime(ev.MedianKnownSec))
+	}
+
+	// (4) Mixed: some members are book-length and some are fragments, but neither
+	// side is a majority. The members disagree about what they are, and a folder
+	// that mixes whole books with loose fragments needs a human to look at it.
+	return ActionInsufficientEvidence, fmt.Sprintf(
+		"members disagree on runtime: %d of %d run 90 min or longer and %d are shorter — "+
+			"neither a chapter set nor a clean set of separate books",
+		ev.BookLengthMembers, n, ev.DurationsKnown-ev.BookLengthMembers)
+}
+
 // RegroupGroup is one book folder the classifier flagged for a review hold.
 type RegroupGroup struct {
 	FolderRef      string        // the book folder (grandparent for chapter/disc; parent for flat)
@@ -178,6 +417,29 @@ type RegroupGroup struct {
 	// label distinguish a genuine multi-DISC set ("Multi-disc → 1 book") from
 	// same-disc CHAPTERS ("Chapters → 1 book"), which read identically otherwise.
 	Structure string
+
+	// RecommendedAction is what a human should DO about this group: one of
+	// ActionCombine, ActionSeparate, ActionVersionGroup, ActionDuplicateOf or
+	// ActionInsufficientEvidence (this file never emits ActionDuplicateOf — see
+	// its doc comment). It is computed from the members' RUNTIMES and is
+	// deliberately independent of Kind, which describes only the folder's physical
+	// SHAPE. The two can disagree, and the disagreement is the point: 3 prod
+	// `regroup.multidisc` holds carry members that are each book-length, because
+	// the disc and chapter/edition branches never evaluate the series guard.
+	//
+	// The ONE exception is KindVersionGroup, which overrides runtime with
+	// ActionVersionGroup — two editions of one work are both book-length, so
+	// runtime alone would say "separate" and strand ApplyVersionGroup behind an
+	// action nothing dispatches to. See ActionVersionGroup.
+	RecommendedAction string
+	// RecommendationReason is one human-readable sentence explaining WHY, quoting
+	// the numbers that produced it. Never a bare category name: the queue this
+	// replaces had 762 of 777 holds carrying one identical generic sentence, which
+	// is precisely what made it unworkable.
+	RecommendationReason string
+	// RecommendationEvidence is the arithmetic behind the reason, so a reviewer
+	// can check it rather than trust it.
+	RecommendationEvidence RecommendationEvidence
 }
 
 // ShapeStats reconciles every input book so the record count ties out (no silent
@@ -608,6 +870,16 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 	// Structural tallies.
 	var discCount, chapterCount, flatCount, numberedCount int
 	prefixVotes := map[string]int{}
+	// prefixDisplay maps each NORMALIZED prefix back to the first original-case form
+	// seen for it. prefixVotes is keyed by normPrefix (lowercased, non-alphanumerics
+	// stripped), so the winning key reads "therisingvol9" — unusable as a title. The
+	// survivor-title selector needs the original casing and punctuation.
+	prefixDisplay := map[string]string{}
+	// authorVotes tallies the members' display authors (normalized) so the survivor
+	// title can REJECT a candidate that is merely the author's name — the observed
+	// "C. T. Phipps" failure. Only a majority author is trusted; below that the
+	// guard stays inert rather than guessing.
+	authorVotes := map[string]int{}
 	for _, m := range members {
 		switch m.structure {
 		case "disc":
@@ -622,9 +894,19 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 		}
 		if m.normPrefix != "" {
 			prefixVotes[m.normPrefix]++
+			if _, seen := prefixDisplay[m.normPrefix]; !seen {
+				prefixDisplay[m.normPrefix] = m.prefix
+			}
+		}
+		if na := normTitle(m.book.Author); na != "" {
+			authorVotes[na]++
 		}
 	}
 	dominantPrefix, dominantCount := topStr(prefixVotes)
+	dominantAuthorNorm, dominantAuthorCount := topStr(authorVotes)
+	if dominantAuthorCount*2 <= n {
+		dominantAuthorNorm = "" // no majority author — leave the author guard inert
+	}
 	distinctPrefixes := len(prefixVotes)
 	structure := majorityStructure(discCount, chapterCount, flatCount)
 
@@ -648,20 +930,50 @@ func classifyGroup(members []memberInfo) (RegroupGroup, bool) {
 
 	sortMembers(members)
 	assignDiscTrack(members)
+
+	// The recommendation is computed ONCE, before the Kind switch, and closed over by
+	// build — it depends only on the members' runtimes, never on which branch fires.
+	// Keeping it out of build's signature keeps all nine build(...) call sites
+	// byte-identical, so this change cannot perturb the Kind switch by accident.
+	evidence := gatherEvidence(members, distinctPrefixes, numberedCount, structure)
+	recAction, recReason := recommendAction(evidence, members, len(fpVotes))
+	survivorTitle := survivorTitleFor(folderName, folderNamedAfterBook,
+		prefixDisplay[dominantPrefix], dominantCount*2 >= n, dominantAuthorNorm)
+
 	build := func(kind string, confident bool, action string, distinctWorks int) RegroupGroup {
 		out := make([]ShatterBook, 0, n)
 		for _, m := range members {
 			out = append(out, m.book)
 		}
+
+		// KindVersionGroup overrides the runtime recommendation. Both editions of
+		// one work are book-length, so recommendAction would answer ActionSeparate
+		// and — once approve dispatches on the chosen action — make
+		// ApplyVersionGroup unreachable. See ActionVersionGroup's comment for the
+		// full argument. The evidence block is still carried verbatim so the queue
+		// shows the runtimes the human is judging.
+		kindAction, kindReason := recAction, recReason
+		if kind == KindVersionGroup {
+			kindAction = ActionVersionGroup
+			kindReason = fmt.Sprintf(
+				"abridged and unabridged edition markers on a shared title across %d members "+
+					"(longest %s) — different recordings of one work, so link them as versions "+
+					"rather than merging or separating them",
+				evidence.Members, humanRuntime(evidence.LongestKnownSec))
+		}
+
 		return RegroupGroup{
-			FolderRef:      folderRef,
-			Kind:           kind,
-			Confident:      confident,
-			SurvivorTitle:  deriveSurvivorTitle(folderName),
-			ProposedAction: action,
-			Members:        out,
-			DistinctWorks:  distinctWorks,
-			Structure:      structure,
+			FolderRef:              folderRef,
+			Kind:                   kind,
+			Confident:              confident,
+			SurvivorTitle:          survivorTitle,
+			ProposedAction:         action,
+			Members:                out,
+			DistinctWorks:          distinctWorks,
+			Structure:              structure,
+			RecommendedAction:      kindAction,
+			RecommendationReason:   kindReason,
+			RecommendationEvidence: evidence,
 		}
 	}
 
@@ -834,9 +1146,89 @@ func assignDiscTrack(members []memberInfo) {
 	}
 }
 
-// deriveSurvivorTitle turns a book-folder name into a clean survivor title: strip a
+// genericTitleRe matches a candidate title that names a POSITION rather than a work:
+// "Volume 1", "Chapter", "Disc 3", "Part 2", "Untitled", or a bare "01". Such a
+// string is a container label, never a book title.
+//
+// Anchored at both ends and matched against the WHOLE cleaned candidate, never as a
+// substring — a substring match would eat legitimate titles like "The Rising Vol. 9"
+// or "Book of the New Sun".
+var genericTitleRe = regexp.MustCompile(
+	`(?i)^(?:\d+|(?:vol(?:ume)?|bk|books?|parts?|pts?|discs?|cds?|chapters?|tracks?|sides?|sections?|untitled)\.?\s*\d*)$`)
+
+// survivorTitleFor picks WHICH string should become the survivor title, then cleans
+// it with deriveSurvivorTitle. It exists because reading the folder name alone —
+// what this code did until 2026-08-06 — produced author names ("C. T. Phipps"), bare
+// ordinals ("Volume 1"), and WRONG volume numbers (a folder named "… Vol. 01" whose
+// member files all say "Vol. 9").
+//
+// The folder name and the members' dominant title stem are two independent claims
+// about what this book is called, and the choice between them is evidence-ranked:
+//
+//  1. folderNamedAfterBook — the members' own stem is a majority AND appears inside
+//     the folder name, so the two signals AGREE. The folder name is then the better
+//     of the two: it is the full human title, while the stem has had its ordinals
+//     stripped. This is also the case that keeps a correct existing behaviour.
+//  2. Otherwise the two DISAGREE, and the members win. The files are closer to the
+//     content than the directory that happens to hold them — this is what fixes the
+//     "Vol. 01 folder / Vol. 9 files" case, where the folder carries a stale number.
+//     Only a MAJORITY stem is trusted; a 1-of-6 plurality in an author folder is not
+//     a title, it is whichever book sorted first.
+//  3. If the members have nothing trustworthy to say, fall back to the folder name
+//     anyway — but only after the disqualification guards. This step is why a flat
+//     folder "Coraline" holding "01 - Chapter.mp3" … "08 - Chapter.mp3" still yields
+//     "Coraline": its dominant stem is the generic word "Chapter", which step 2
+//     rejects. Without this fallback, the fix would introduce a fresh instance of
+//     the very bug it exists to remove.
+//  4. If NEITHER source survives its guards, return "".
+//
+// 🔴 EMPTY IS BETTER THAN WRONG. A blank survivor title renders as "needs a title"
+// in the review queue — visibly incomplete, and a reviewer supplies one. A WRONG
+// title reads as authoritative and silently mislabels a book. SurvivorTitle is
+// display-only today (regroup_apply.go calls CombineBooks with a nil override, so
+// nothing is written to any Book row), but the label is what a reviewer decides on:
+// a hold labelled with the author's name is one a reasonable reviewer rejects,
+// throwing away a good regroup.
+//
+// dominantAuthorNorm is the NORMALIZED majority author, or "" when no author holds a
+// majority (guard inert).
+func survivorTitleFor(folderName string, folderNamedAfterBook bool,
+	dominantStem string, dominantIsMajority bool, dominantAuthorNorm string) string {
+	// acceptable applies the disqualification guards to an already-cleaned candidate.
+	acceptable := func(cand string) bool {
+		if cand == "" {
+			return false
+		}
+		if genericTitleRe.MatchString(cand) {
+			return false // "Volume 1", "Chapter", "01" — a position, not a work
+		}
+		if dominantAuthorNorm != "" && normTitle(cand) == dominantAuthorNorm {
+			return false // the author's name, not the book's — the "C. T. Phipps" case
+		}
+		return true
+	}
+
+	fromFolder := deriveSurvivorTitle(folderName)
+	if folderNamedAfterBook && acceptable(fromFolder) {
+		return fromFolder
+	}
+	if dominantIsMajority {
+		if fromMembers := deriveSurvivorTitle(dominantStem); acceptable(fromMembers) {
+			return fromMembers
+		}
+	}
+	if acceptable(fromFolder) {
+		return fromFolder
+	}
+	return ""
+}
+
+// deriveSurvivorTitle CLEANS one candidate string into a survivor title: strip a
 // leading "NN - " track prefix, a trailing "(era/year)" parenthetical, and a trailing
 // " - N" number. Author is intentionally NOT derived from the path.
+//
+// This is the pure string transform only. WHICH string reaches it — the book-folder
+// name or the members' dominant title stem — is survivorTitleFor's decision.
 func deriveSurvivorTitle(folderName string) string {
 	t := folderName
 	t = leadingNumRe.ReplaceAllString(t, "")

--- a/internal/plugins/maintenance/regroup_apply.go
+++ b/internal/plugins/maintenance/regroup_apply.go
@@ -1,24 +1,35 @@
 // file: internal/plugins/maintenance/regroup_apply.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: e2a7c9d4-1f68-4b03-9c5e-7a0d3f814b62
-// last-edited: 2026-07-25
+// last-edited: 2026-08-06
 
 // Package maintenance — the APPLY path for the regroup review queue (PR-B2).
 //
 // B1 (regroup_shattered_ai.go) is a dry-run producer: it writes one review-queue
 // HOLD per candidate folder and touches ZERO books. B2 is what makes the "Approve"
 // button in the review UI actually merge. It supplies one apply function per
-// CONFIDENT regroup Kind; the review handler dispatches on ReviewItem.Kind and, on
-// a nil error, transitions the item to "applied" (handler.go:approveOne).
+// executable ACTION; the review handler dispatches on the chosen action and, on a
+// nil error, transitions the item to "applied" (handler.go:approveOne).
 //
-// Only the two confident kinds get an apply function:
-//   - regroup.multidisc     → collapse N single-file books into 1 (CombineBooks).
-//   - regroup.version-group → share a VersionGroupID + designate one primary, via
+// Two actions have an apply function:
+//   - combine       → collapse N single-file books into 1 (CombineBooks).
+//   - version-group → share a VersionGroupID + designate one primary, via
 //     UpdateBook (NOT MergeBooks — both editions must stay visible; locked #8).
 //
-// regroup.anthology and regroup.ambiguous are deliberately handler-less: they need
-// human sub-decisions (which files are distinct works, how to split) that a single
-// apply function cannot make, so approving one only marks it "approved".
+// 🔴 DISPATCH MOVED FROM Kind TO ACTION ON 2026-08-06 (owner item 2), and this
+// comment used to claim a safety property the code no longer has. It read
+// "regroup.anthology and regroup.ambiguous are deliberately handler-less", i.e. no
+// ambiguous hold could ever merge anything. That is FALSE now: an `ambiguous` hold
+// whose evidence recommends `combine` (24 of 356 measured on 2026-08-06) dispatches
+// straight into ApplyMultidisc, which hard-deletes absorbed Book rows. The gate is
+// no longer the Kind — it is the recommendation, which refuses `combine` unless a
+// strict majority of members have a KNOWN runtime and those runtimes are short.
+// (Anthology had already lost its handler-less status on 2026-07-26, when an
+// anthology became one book to combine rather than several to split.)
+//
+// `separate` and `insufficient-evidence` have no apply function and never will:
+// the first is a status transition (every member is already its own book), the
+// second is not a decision a human may pick at all.
 //
 // DATA-LOSS SAFETY (this repo's dominant incident class is write-back wipes):
 //   - Multidisc uses CombineBooks(ids, primary, nil) — a NIL override. The only

--- a/internal/plugins/maintenance/regroup_shattered_ai.go
+++ b/internal/plugins/maintenance/regroup_shattered_ai.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/regroup_shattered_ai.go
-// version: 1.5.0
+// version: 1.6.0
 // guid: 8b3e6d21-4f97-4c05-a1d8-2e7b9c0f5a63
-// last-edited: 2026-07-26
+// last-edited: 2026-08-06
 
 // Package maintenance — op maintenance.regroup-shattered-ai (PR-B1).
 //
@@ -78,6 +78,27 @@ type regroupPayload struct {
 	// disc concept", distinct from a real "Disc N" set (see assignDiscTrack).
 	DiscNumbers  []int `json:"discNumbers,omitempty"`
 	TrackNumbers []int `json:"trackNumbers,omitempty"`
+
+	// RecommendedAction is what the classifier thinks a human should DO about this
+	// hold — one of the itunesservice.Action* strings. It is what the approve handler
+	// DISPATCHES on (owner item 2), so it is the most load-bearing field here.
+	//
+	// 🔴 ADDITIVE, AND DELIBERATELY NOT BACKFILLED. Every hold already sitting in
+	// prod's queue was written before this field existed and decodes with
+	// RecommendedAction == "". That empty string is the intended "old hold" tell:
+	// the approve handler treats it as ActionInsufficientEvidence, which has no apply
+	// handler, so an old hold can never dispatch to a merge on the strength of a
+	// field it does not carry. Refreshing them is a re-scan (UpsertReviewItem rewrites
+	// the payload of a still-pending hold), never a migration.
+	RecommendedAction string `json:"recommendedAction"`
+	// RecommendationReason is the one-sentence human-readable case for the action,
+	// quoting its own numbers. It replaces ProposedAction as the sentence a reviewer
+	// actually reads — 762 of 777 holds carried the same generic ProposedAction.
+	RecommendationReason string `json:"recommendationReason"`
+	// RecommendationEvidence is the arithmetic behind the reason so a reviewer can
+	// check it instead of trusting it. A value struct, not a pointer: an old hold
+	// decodes it as the zero value, which reads honestly as "no evidence recorded".
+	RecommendationEvidence itunesservice.RecommendationEvidence `json:"recommendationEvidence"`
 }
 
 func (p *Plugin) regroupShatteredAIDef() sdk.OperationDef {
@@ -403,6 +424,13 @@ func buildRegroupPayload(g itunesservice.RegroupGroup) (string, error) {
 		Confidence:     confidence,
 		DiscNumbers:    discs,
 		TrackNumbers:   tracks,
+		// Carried verbatim from the classifier — this producer never re-derives or
+		// second-guesses the recommendation. classifyGroup owns the rule (including
+		// the KindVersionGroup override); duplicating any of it here would be a second
+		// place for the vocabulary to drift.
+		RecommendedAction:      g.RecommendedAction,
+		RecommendationReason:   g.RecommendationReason,
+		RecommendationEvidence: g.RecommendationEvidence,
 	})
 	if err != nil {
 		return "", err

--- a/internal/server/handlers/review/handler.go
+++ b/internal/server/handlers/review/handler.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/review/handler.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 2b6f9c14-8e37-4a5d-91c6-0f4a7d2e8b53
 // last-edited: 2026-08-06
 
@@ -38,6 +38,15 @@
 // closed vocabulary in internal/itunes/service, and dispatches on that. A typo'd
 // action is a 400, never a silent fall back to the recommendation: a human who meant
 // "separate" must not be given "combine" because they mistyped.
+//
+// 🔴 AND THE CHOICE IS PERSISTED. ReviewItem.ChosenAction records what the human
+// picked, written atomically with the status by SetReviewItemDecision. That matters
+// because with review_apply_enabled OFF — production's setting — approving executes
+// nothing, and ReplayApprovedItems does the work later. Replay reads ChosenAction
+// first (effectiveActionFor) and only falls back to the payload's recommendation for
+// rows written before the field existed. Without that, an override would evaporate at
+// the moment it was recorded and the replay would merge books a human said to keep
+// apart. See effectiveActionFor and database.ReviewItem.ChosenAction.
 package reviewhandler
 
 import (
@@ -166,6 +175,30 @@ func recommendedActionFor(item database.ReviewItem) string {
 		return itunesservice.ActionInsufficientEvidence
 	}
 	return p.RecommendedAction
+}
+
+// effectiveActionFor answers the ONE question both approve and replay must answer
+// identically: what does this hold currently mean?
+//
+// 🔴 THE PERSISTED HUMAN CHOICE WINS OVER THE MACHINE'S SUGGESTION. ReviewItem.ChosenAction
+// is written when a reviewer approves (SetReviewItemDecision); the payload's
+// `recommendedAction` is what the classifier proposed. When they disagree, the human
+// is right by definition — that disagreement IS owner item 2. A hold recommending
+// `combine` that a human approved as `separate` must never be replayed as a merge,
+// because the combine apply path hard-deletes the absorbed Book rows.
+//
+// The fallback covers rows written before ChosenAction existed: those resolve through
+// the payload, and for a pre-recommendation hold that lands on insufficient-evidence,
+// which has no apply handler and is not approvable. Old rows therefore keep working
+// and keep failing closed.
+//
+// Both approveOne and ReplayApprovedItems route through here so the two can never
+// carry out different decisions for the same row.
+func effectiveActionFor(item database.ReviewItem) string {
+	if a := strings.TrimSpace(item.ChosenAction); a != "" {
+		return a
+	}
+	return recommendedActionFor(item)
 }
 
 // actionRejection is a per-item REFUSAL to approve — a caller error (bad action,
@@ -319,10 +352,14 @@ func (h *Handler) approveOne(ctx context.Context, id, requested string) (*databa
 		return nil, "", "", nil
 	}
 
-	recommended := recommendedActionFor(*item)
+	// The default is the hold's EFFECTIVE action, not the raw payload recommendation:
+	// re-approving an already-decided hold with an empty body must not silently revert
+	// a human's recorded override back to the machine's suggestion. Re-approve is a
+	// supported flow — it is the recovery path replay's skip reason advertises.
+	// Pending holds carry no ChosenAction, so for them this is the recommendation.
 	chosen := requested
 	if chosen == "" {
-		chosen = recommended
+		chosen = effectiveActionFor(*item)
 	}
 
 	// (1) Closed vocabulary. An unrecognised action is a 400, NEVER a fall back to
@@ -354,39 +391,28 @@ func (h *Handler) approveOne(ctx context.Context, id, requested string) (*databa
 				"Reject the hold instead, or choose combine/separate/version-group")
 	}
 
-	// (4) 🔴 AN OVERRIDE THAT CANNOT BE PERSISTED MUST NOT BE ACCEPTED.
+	// (4) 🔴 EVERY TRANSITION BELOW WRITES THE CHOSEN ACTION ALONGSIDE THE STATUS.
 	//
-	// The chosen action is NOT stored anywhere: SetReviewItemStatus writes status
-	// only, and UpsertReviewItem is a full no-op on a non-pending row, so there is no
-	// way to record "the human picked separate" on an already-approved hold. With the
-	// global switch OFF the override therefore evaporates — and ReplayApprovedItems,
-	// run after the switch is flipped (owner item 3), re-resolves the action from the
-	// PAYLOAD. A hold recommending `combine` that a human overrode to `separate` would
-	// be replayed as `combine`, hard-deleting the absorbed rows of books the human
-	// explicitly said to keep apart.
+	// This is what makes an override durable, and it is the reason the 409
+	// REVIEW_OVERRIDE_NOT_PERSISTABLE refusal that used to sit here is gone. Before
+	// SetReviewItemDecision existed the chosen action was stored NOWHERE, so with
+	// review_apply_enabled off — production's setting — a reviewer could not record a
+	// disagreement at all: approving a `combine` hold as `separate` wrote plain
+	// "approved", and ReplayApprovedItems re-resolved the action from the payload and
+	// would merge the books the human said to keep apart. Refusing the override was the
+	// only safe answer then, but it also meant owner item 2 did not actually ship.
 	//
-	// Narrow on purpose: this only fires when the RECOMMENDATION itself has an apply
-	// handler, i.e. exactly the case where a later replay would act on it. Overriding
-	// a hold that recommends separate/insufficient-evidence is still allowed, because
-	// replay skips those — the decision is lost, but nothing is destroyed.
-	//
-	// Removing this guard requires persisting the chosen action first.
-	if requested != "" && requested != recommended && !h.applyGloballyEnabled() {
-		if _, replayable := h.applyHandlerFor(recommended); replayable {
-			return nil, chosen, "", rejectf(http.StatusConflict, "REVIEW_OVERRIDE_NOT_PERSISTABLE",
-				"cannot record an override of '"+recommended+"' while review_apply_enabled is off: "+
-					"the chosen action is not stored, so a later replay would run '"+recommended+
-					"' instead. Reject this hold, or enable review_apply_enabled to apply the override now")
-		}
-	}
+	// Now the choice is persisted atomically with the status and replay prefers it
+	// (effectiveActionFor), so the override survives the switch being flipped later.
 
 	// (5) separate needs NO apply handler and never will. Every member is already its
 	// own book, so "separate into N" is a statement that the current on-disk state is
 	// correct — there is nothing to execute, only a decision to record. The dedup-key
 	// idempotency in UpsertReviewItem keeps it decided across re-scans, which is the
-	// whole mechanism: a re-scan skips a non-pending hold.
+	// whole mechanism: a re-scan skips a non-pending hold. Recording the action still
+	// matters: it is what stops a replay from falling back to a `combine` payload.
 	if chosen == itunesservice.ActionSeparate {
-		updated, serr := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
+		updated, serr := h.store.SetReviewItemDecision(id, database.ReviewStatusApproved, chosen)
 		if serr != nil {
 			return nil, "", "", serr
 		}
@@ -399,13 +425,14 @@ func (h *Handler) approveOne(ctx context.Context, id, requested string) (*databa
 		if err := fn(ctx, *item); err != nil {
 			return nil, "", "", err
 		}
-		updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApplied)
+		updated, err := h.store.SetReviewItemDecision(id, database.ReviewStatusApplied, chosen)
 		return updated, chosen, "", err
 	}
 	// Either no apply handler for this action, OR the global apply switch is OFF
 	// (review-only mode). Record the decision as "approved" but do NOT execute — the
-	// item stays visible/reviewable and nothing is merged.
-	updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
+	// item stays visible/reviewable and nothing is merged. The action is recorded even
+	// though nothing ran, which is precisely the case replay later reads back.
+	updated, err := h.store.SetReviewItemDecision(id, database.ReviewStatusApproved, chosen)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/internal/server/handlers/review/handler.go
+++ b/internal/server/handlers/review/handler.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/review/handler.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 2b6f9c14-8e37-4a5d-91c6-0f4a7d2e8b53
-// last-edited: 2026-07-14
+// last-edited: 2026-08-06
 
 // Package reviewhandler hosts the universal review-queue HTTP handlers (PR-A1).
 //
@@ -12,28 +12,72 @@
 // B, not built yet), so at A1 the queue starts empty and no apply handlers are
 // registered.
 //
-// Apply-handler registry + global switch: approving an item dispatches on its Kind
-// to a registered ApplyFunc, BUT only when the global apply "big switch"
-// (applyEnabled) is on. When a Kind has a handler AND the switch is on, approve runs
-// it and sets the item to "applied". Otherwise — no handler, OR the switch is off
-// (review-only mode, the default) — approve just sets "approved" and returns OK with
-// a note, never executing anything. This makes "see everything in the review pane,
-// nothing auto-merges" the default until the switch is deliberately flipped. Track
-// B's B2 registers the regroup apply handlers; config.ReviewApplyEnabled is the switch.
+// Apply-handler registry + global switch: approving an item dispatches on the
+// CHOSEN ACTION to a registered ApplyFunc, BUT only when the global apply "big
+// switch" (applyEnabled) is on. When an action has a handler AND the switch is on,
+// approve runs it and sets the item to "applied". Otherwise — no handler, OR the
+// switch is off (review-only mode, the default) — approve just sets "approved" and
+// returns OK with a note, never executing anything. This makes "see everything in
+// the review pane, nothing auto-merges" the default until the switch is deliberately
+// flipped. Track B's B2 registers the regroup apply handlers;
+// config.ReviewApplyEnabled is the switch.
+//
+// 🔴 DISPATCH IS ON THE ACTION, NOT THE KIND (owner item 2, 2026-08-06).
+//
+// Until this change the registry was keyed by ReviewItem.Kind, which conflated two
+// different questions: a Kind says what SHAPE the classifier saw ("these files live
+// in Disc N folders"), an action says what a human should DO about it ("these are
+// six different novels — leave them apart"). Prod proved the two disagree: 3 of the
+// 130 `regroup.multidisc` holds measured on 2026-08-06 hold members that are each
+// book-length, because the disc and chapter/edition branches of classifyGroup never
+// evaluate the series guard. Kind-keyed dispatch would merge those distinct novels
+// through an apply path that hard-deletes the absorbed Book rows.
+//
+// So approve now resolves an ACTION — the request body's explicit choice when the
+// human made one, else the hold's own `recommendedAction` — validates it against the
+// closed vocabulary in internal/itunes/service, and dispatches on that. A typo'd
+// action is a 400, never a silent fall back to the recommendation: a human who meant
+// "separate" must not be given "combine" because they mistyped.
 package reviewhandler
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/gin-gonic/gin"
 )
 
+// approvableActions is the CLOSED approve vocabulary: action → may a human CHOOSE
+// it. It mirrors the classifier's Action* constants
+// (internal/itunes/service/fs_regroup_shape.go) by IMPORTING them rather than
+// re-declaring the strings, so the producer and the dispatcher can never drift.
+//
+// ActionInsufficientEvidence is in the vocabulary but is NOT approvable — it is a
+// statement BY the machine ("I cannot tell"), not a decision a human can make.
+// Approving one would record a decision nobody took, on exactly the holds where the
+// evidence is weakest. ActionDuplicateOf is approvable in principle but has no apply
+// path yet; approveOne rejects it explicitly rather than no-op'ing (see there).
+var approvableActions = map[string]bool{
+	itunesservice.ActionCombine:              true,
+	itunesservice.ActionSeparate:             true,
+	itunesservice.ActionVersionGroup:         true,
+	itunesservice.ActionDuplicateOf:          true,
+	itunesservice.ActionInsufficientEvidence: false,
+}
+
 // ApplyFunc executes the real-world action an approved review item represents
-// (e.g. the regroup op collapsing shattered books). Registered per Kind.
+// (e.g. the regroup op collapsing shattered books). Registered per ACTION — see
+// RegisterApplyHandler and the package doc; it was per Kind before 2026-08-06.
 type ApplyFunc func(ctx context.Context, item database.ReviewItem) error
 
 // Handler hosts the review-queue HTTP endpoints.
@@ -47,10 +91,14 @@ type Handler struct {
 	// treated as disabled (fail-safe: never auto-apply unless explicitly turned on).
 	applyEnabled func() bool
 
-	// applyHandlers maps a review item's Kind to the action that applies it.
-	// Empty in A1; populated by producers (e.g. B2's regroup) via
-	// RegisterApplyHandler. Guarded by mu because registration may happen during
-	// wiring while requests could already be arriving.
+	// applyHandlers maps a CHOSEN ACTION (an itunesservice.Action* string) to the
+	// code that carries it out. Empty in A1; populated by producers (e.g. B2's
+	// regroup) via RegisterApplyHandler. Guarded by mu because registration may
+	// happen during wiring while requests could already be arriving.
+	//
+	// Keyed by action rather than by Kind since 2026-08-06 — see the package doc.
+	// Actions with no entry (separate, insufficient-evidence, duplicate-of) are
+	// handled by approveOne directly and never reach this map.
 	mu            sync.RWMutex
 	applyHandlers map[string]ApplyFunc
 }
@@ -72,19 +120,72 @@ func (h *Handler) applyGloballyEnabled() bool {
 	return h.applyEnabled != nil && h.applyEnabled()
 }
 
-// RegisterApplyHandler registers the apply action for a given review Kind.
-// Producers call this at wire time (B2 registers the regroup apply path).
-func (h *Handler) RegisterApplyHandler(kind string, fn ApplyFunc) {
+// RegisterApplyHandler registers the code that carries out one ACTION (an
+// itunesservice.Action* string, NOT a review Kind). Producers call this at wire
+// time (B2 registers the regroup apply paths).
+func (h *Handler) RegisterApplyHandler(action string, fn ApplyFunc) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.applyHandlers[kind] = fn
+	h.applyHandlers[action] = fn
 }
 
-func (h *Handler) applyHandlerFor(kind string) (ApplyFunc, bool) {
+func (h *Handler) applyHandlerFor(action string) (ApplyFunc, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	fn, ok := h.applyHandlers[kind]
+	fn, ok := h.applyHandlers[action]
 	return fn, ok
+}
+
+// recommendedActionFor reads the classifier's recommendation out of a hold's
+// payload, defaulting to ActionInsufficientEvidence.
+//
+// 🔴 EVERY FAILURE MODE HERE FAILS CLOSED TO insufficient-evidence, which has no
+// apply handler and is not approvable. A hold written before the recommendation
+// existed (all ~356 currently in prod's queue), a hold whose payload is not JSON,
+// and a hold carrying an empty action all land in the same place: approve refuses
+// until a human names an action explicitly. The alternative — guessing a default —
+// would guess `combine` on precisely the holds with the least evidence, and combine
+// routes to an apply path that hard-deletes absorbed Book rows.
+//
+// A malformed payload is logged rather than swallowed: it means a producer wrote
+// something this handler cannot read, which is a bug worth seeing even though the
+// safe behaviour is already guaranteed.
+func recommendedActionFor(item database.ReviewItem) string {
+	if item.Payload == "" {
+		return itunesservice.ActionInsufficientEvidence
+	}
+	var p struct {
+		RecommendedAction string `json:"recommendedAction"`
+	}
+	if err := json.Unmarshal([]byte(item.Payload), &p); err != nil {
+		slog.Warn("review approve: hold payload is not decodable JSON — treating as insufficient-evidence",
+			"item", item.ID, "kind", item.Kind, "err", err)
+		return itunesservice.ActionInsufficientEvidence
+	}
+	if p.RecommendedAction == "" {
+		return itunesservice.ActionInsufficientEvidence
+	}
+	return p.RecommendedAction
+}
+
+// actionRejection is a per-item REFUSAL to approve — a caller error (bad action,
+// unapprovable action, unimplemented action), never a server fault.
+//
+// It exists as a distinct type because approve is now reachable two ways with two
+// different correct responses: a single approve turns it into a 4xx/501, while a
+// BULK approve must SKIP that item and keep going. Before the action dispatch every
+// approveOne error was a genuine fault and bulk was right to abort on it; conflating
+// the two would let one unapprovable hold abort a 121-hold batch.
+type actionRejection struct {
+	status int    // HTTP status a single approve should return
+	code   string // stable machine-readable error code
+	msg    string // human-readable reason, safe to show a reviewer
+}
+
+func (e *actionRejection) Error() string { return e.msg }
+
+func rejectf(status int, code, msg string) *actionRejection {
+	return &actionRejection{status: status, code: code, msg: msg}
 }
 
 // GetReviewCount handles GET /api/v1/review/count.
@@ -146,18 +247,45 @@ func (h *Handler) ListReviewItems(c *gin.Context) {
 	httputil.RespondWithList(c, items, total, filter.Limit, filter.Offset)
 }
 
+// approveRequest is the OPTIONAL POST /api/v1/review/items/:id/approve body.
+//
+// Absent or empty Action means "do what the hold recommends". A present Action
+// OVERRIDES the recommendation — that is the entire point of owner item 2: the
+// machine proposes, the human disposes, and the human's choice is what runs.
+type approveRequest struct {
+	Action string `json:"action,omitempty"`
+}
+
 // ApproveReviewItem handles POST /api/v1/review/items/:id/approve.
 //
-// If a Kind has a registered apply handler, it runs then the item is set
-// "applied". Otherwise (A1 for every Kind) the item is set "approved" and a note
-// is returned — approving without a handler is never an error.
+// The chosen action is the body's `action` when supplied, else the hold's
+// `recommendedAction`. If that action has a registered apply handler AND the global
+// switch is on, it runs and the item is set "applied"; otherwise the item is set
+// "approved" with an explanatory note. Actions a human may not choose
+// (insufficient-evidence), actions outside the vocabulary, and actions with no
+// implementation (duplicate-of) are REFUSED, never quietly downgraded.
 func (h *Handler) ApproveReviewItem(c *gin.Context) {
 	if h.store == nil {
 		httputil.RespondWithServiceUnavailable(c, "review store not available")
 		return
 	}
+	// The body is optional (the pre-override frontend sends none), so an empty body
+	// is not an error — but a MALFORMED body is. Binding errors are surfaced rather
+	// than ignored: silently discarding an unparseable `{"action": ...}` would run
+	// the recommendation while the caller believes it overrode it.
+	var req approveRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		httputil.RespondWithBadRequest(c, "invalid request body: "+err.Error())
+		return
+	}
+
 	id := c.Param("id")
-	updated, note, err := h.approveOne(c.Request.Context(), id)
+	updated, chosen, note, err := h.approveOne(c.Request.Context(), id, strings.TrimSpace(req.Action))
+	var rej *actionRejection
+	if errors.As(err, &rej) {
+		httputil.RespondWithError(c, rej.status, rej.msg, rej.code)
+		return
+	}
 	if err != nil {
 		httputil.InternalError(c, "failed to approve review item", err)
 		return
@@ -166,45 +294,127 @@ func (h *Handler) ApproveReviewItem(c *gin.Context) {
 		httputil.RespondWithNotFound(c, "review item", id)
 		return
 	}
-	resp := gin.H{"item": updated}
+	// chosenAction is echoed so the caller can see WHICH action ran — with an empty
+	// body that is the recommendation, which the caller may not have read.
+	resp := gin.H{"item": updated, "chosenAction": chosen}
 	if note != "" {
 		resp["note"] = note
 	}
 	httputil.RespondWithOK(c, resp)
 }
 
-// approveOne applies + transitions a single item. Returns (nil, "", nil) when
-// the item does not exist. note is set when the item was approved without a
-// registered apply handler.
-func (h *Handler) approveOne(ctx context.Context, id string) (*database.ReviewItem, string, error) {
+// approveOne resolves, validates and dispatches the action for a single item, then
+// transitions it. Returns (nil, "", "", nil) when the item does not exist.
+//
+// requested is the caller's explicit override ("" = use the hold's recommendation).
+// The returned action is the one actually dispatched. A returned *actionRejection
+// means the caller asked for something that must not happen; any other error is a
+// genuine fault.
+func (h *Handler) approveOne(ctx context.Context, id, requested string) (*database.ReviewItem, string, string, error) {
 	item, err := h.store.GetReviewItem(id)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if item == nil {
-		return nil, "", nil
+		return nil, "", "", nil
 	}
-	fn, hasHandler := h.applyHandlerFor(item.Kind)
+
+	recommended := recommendedActionFor(*item)
+	chosen := requested
+	if chosen == "" {
+		chosen = recommended
+	}
+
+	// (1) Closed vocabulary. An unrecognised action is a 400, NEVER a fall back to
+	// the recommendation: a reviewer who typed "seperate" and meant "leave these six
+	// novels apart" must not be handed "combine" because of a typo. Silent fallback
+	// is how a merge happens that nobody chose.
+	approvable, known := approvableActions[chosen]
+	if !known {
+		return nil, chosen, "", rejectf(http.StatusBadRequest, "REVIEW_UNKNOWN_ACTION",
+			"unknown review action "+strconv.Quote(chosen)+"; expected one of combine, separate, version-group, duplicate-of")
+	}
+
+	// (2) insufficient-evidence is emitted BY the classifier, never chosen by a human.
+	// Reaching here by default (an old hold, or one whose members have no runtimes)
+	// means the machine has nothing to say, so the human must say it explicitly.
+	if !approvable {
+		return nil, chosen, "", rejectf(http.StatusBadRequest, "REVIEW_ACTION_NOT_DECIDABLE",
+			"this hold recommends 'insufficient-evidence' — the classifier cannot tell what to do, "+
+				"so approving requires an explicit {\"action\": \"...\"} choice (combine, separate or version-group)")
+	}
+
+	// (3) duplicate-of has no apply path yet (deciding a folder duplicates an existing
+	// book needs cross-book identity evidence the regroup classifier never gathers).
+	// Refuse loudly: accepting it would mark the hold decided while doing nothing,
+	// and "decided" is sticky — UpsertReviewItem never re-offers a non-pending hold.
+	if chosen == itunesservice.ActionDuplicateOf {
+		return nil, chosen, "", rejectf(http.StatusNotImplemented, "REVIEW_ACTION_NOT_IMPLEMENTED",
+			"action 'duplicate-of' is not implemented: the duplicate-detection track owns it. "+
+				"Reject the hold instead, or choose combine/separate/version-group")
+	}
+
+	// (4) 🔴 AN OVERRIDE THAT CANNOT BE PERSISTED MUST NOT BE ACCEPTED.
+	//
+	// The chosen action is NOT stored anywhere: SetReviewItemStatus writes status
+	// only, and UpsertReviewItem is a full no-op on a non-pending row, so there is no
+	// way to record "the human picked separate" on an already-approved hold. With the
+	// global switch OFF the override therefore evaporates — and ReplayApprovedItems,
+	// run after the switch is flipped (owner item 3), re-resolves the action from the
+	// PAYLOAD. A hold recommending `combine` that a human overrode to `separate` would
+	// be replayed as `combine`, hard-deleting the absorbed rows of books the human
+	// explicitly said to keep apart.
+	//
+	// Narrow on purpose: this only fires when the RECOMMENDATION itself has an apply
+	// handler, i.e. exactly the case where a later replay would act on it. Overriding
+	// a hold that recommends separate/insufficient-evidence is still allowed, because
+	// replay skips those — the decision is lost, but nothing is destroyed.
+	//
+	// Removing this guard requires persisting the chosen action first.
+	if requested != "" && requested != recommended && !h.applyGloballyEnabled() {
+		if _, replayable := h.applyHandlerFor(recommended); replayable {
+			return nil, chosen, "", rejectf(http.StatusConflict, "REVIEW_OVERRIDE_NOT_PERSISTABLE",
+				"cannot record an override of '"+recommended+"' while review_apply_enabled is off: "+
+					"the chosen action is not stored, so a later replay would run '"+recommended+
+					"' instead. Reject this hold, or enable review_apply_enabled to apply the override now")
+		}
+	}
+
+	// (5) separate needs NO apply handler and never will. Every member is already its
+	// own book, so "separate into N" is a statement that the current on-disk state is
+	// correct — there is nothing to execute, only a decision to record. The dedup-key
+	// idempotency in UpsertReviewItem keeps it decided across re-scans, which is the
+	// whole mechanism: a re-scan skips a non-pending hold.
+	if chosen == itunesservice.ActionSeparate {
+		updated, serr := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
+		if serr != nil {
+			return nil, "", "", serr
+		}
+		return updated, chosen, "action 'separate' needs no apply step — every member is already its own book; " +
+			"recorded as approved so re-scans leave it alone", nil
+	}
+
+	fn, hasHandler := h.applyHandlerFor(chosen)
 	if hasHandler && h.applyGloballyEnabled() {
 		if err := fn(ctx, *item); err != nil {
-			return nil, "", err
+			return nil, "", "", err
 		}
 		updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApplied)
-		return updated, "", err
+		return updated, chosen, "", err
 	}
-	// Either no apply handler for this Kind, OR the global apply switch is OFF
+	// Either no apply handler for this action, OR the global apply switch is OFF
 	// (review-only mode). Record the decision as "approved" but do NOT execute — the
 	// item stays visible/reviewable and nothing is merged.
 	updated, err := h.store.SetReviewItemStatus(id, database.ReviewStatusApproved)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	note := "no apply handler registered for kind " + item.Kind + "; marked approved"
+	note := "no apply handler registered for action " + chosen + "; marked approved"
 	if hasHandler {
 		note = "apply is disabled (review-only mode): item approved but NOT applied — " +
 			"enable review_apply_enabled to perform the merge"
 	}
-	return updated, note, nil
+	return updated, chosen, note, nil
 }
 
 // RejectReviewItem handles POST /api/v1/review/items/:id/reject.
@@ -229,20 +439,36 @@ func (h *Handler) RejectReviewItem(c *gin.Context) {
 // bulkRequest is the POST /api/v1/review/bulk body (decision #4: grouped bulk
 // actions). One of Kind or IDs must be set — an unscoped bulk over the whole
 // queue is rejected to avoid an accidental approve/reject-all.
+//
+// 🔴 Action here is the BULK VERB ("approve" | "reject"), and there is deliberately
+// NO batch-wide review action. A single review action applied to a heterogeneous
+// batch is the exact footgun this whole change exists to remove: a batch "combine"
+// over `regroup.multidisc` would merge the 3 series near-misses that motivated it.
+// Bulk approve instead uses EACH item's own recommendation, so it processes the 121
+// all-fragment holds and skips those 3 — the payoff, not a limitation.
 type bulkRequest struct {
 	Action string   `json:"action"` // "approve" | "reject"
 	Kind   string   `json:"kind,omitempty"`
 	IDs    []string `json:"ids,omitempty"`
 }
 
+// bulkSkip is one item a bulk approve refused to act on, with the reason a reviewer
+// needs in order to go handle it individually.
+type bulkSkip struct {
+	ID     string `json:"id"`
+	Action string `json:"action"` // the action that was refused (usually insufficient-evidence)
+	Reason string `json:"reason"`
+}
+
 // bulkResult reports the outcome of a bulk action.
 type bulkResult struct {
-	Action    string   `json:"action"`
-	Approved  []string `json:"approved,omitempty"`
-	Applied   []string `json:"applied,omitempty"`
-	Rejected  []string `json:"rejected,omitempty"`
-	NotFound  []string `json:"not_found,omitempty"`
-	Processed int      `json:"processed"`
+	Action    string     `json:"action"`
+	Approved  []string   `json:"approved,omitempty"`
+	Applied   []string   `json:"applied,omitempty"`
+	Rejected  []string   `json:"rejected,omitempty"`
+	NotFound  []string   `json:"not_found,omitempty"`
+	Skipped   []bulkSkip `json:"skipped,omitempty"`
+	Processed int        `json:"processed"`
 }
 
 // BulkReviewAction handles POST /api/v1/review/bulk.
@@ -291,7 +517,18 @@ func (h *Handler) BulkReviewAction(c *gin.Context) {
 	for _, id := range ids {
 		switch req.Action {
 		case "approve":
-			updated, _, err := h.approveOne(c.Request.Context(), id)
+			// "" = use this item's OWN recommendation. See bulkRequest's comment for
+			// why there is no batch-wide action.
+			updated, chosen, _, err := h.approveOne(c.Request.Context(), id, "")
+			// A per-item refusal (no decidable action, unimplemented action) SKIPS that
+			// item and the batch continues. Aborting the whole batch on one
+			// insufficient-evidence hold would make bulk approve useless on a queue
+			// where 70 of 356 holds are exactly that.
+			var rej *actionRejection
+			if errors.As(err, &rej) {
+				result.Skipped = append(result.Skipped, bulkSkip{ID: id, Action: chosen, Reason: rej.msg})
+				continue
+			}
 			if err != nil {
 				httputil.InternalError(c, "failed to approve review item "+id, err)
 				return

--- a/internal/server/handlers/review/handler_action_test.go
+++ b/internal/server/handlers/review/handler_action_test.go
@@ -1,0 +1,400 @@
+// file: internal/server/handlers/review/handler_action_test.go
+// version: 1.0.0
+// guid: 5c1f0a83-6d47-4e29-b0a5-3f7c8e2d94b1
+// last-edited: 2026-08-06
+
+// Tests for ACTION-KEYED approve dispatch (owner item 2, 2026-08-06).
+//
+// The contract under test: approve dispatches on the action a human CHOSE, or on
+// the hold's own recommendation when they chose nothing — never on ReviewItem.Kind.
+// The Kind strings themselves are untouched and still what the frontend maps.
+//
+// Several of these assert a NEGATIVE (the apply handler was NOT invoked). That is
+// deliberate: the failure this whole change prevents is a merge nobody asked for,
+// and the only way to test "it did not merge" is to register a fake under the
+// action that would have merged and assert its counter stayed at zero.
+
+package reviewhandler_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
+	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
+)
+
+// approveBody posts an approve with an explicit {"action": ...} body. Passing ""
+// posts no body at all, which is the pre-override frontend's request shape.
+func approveBody(t *testing.T, h *reviewhandler.Handler, id, action string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	var body any
+	if action != "" {
+		body = map[string]any{"action": action}
+	}
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+id+"/approve", body,
+		gin.Params{{Key: "id", Value: id}})
+	return w, decodeBody(t, w)
+}
+
+// doReqRaw posts a body that is not necessarily valid JSON, which doReq (which
+// marshals) cannot express.
+func doReqRaw(t *testing.T, fn gin.HandlerFunc, method, url, body string, params gin.Params) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(method, url, bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	c.Params = params
+	fn(c)
+	return w
+}
+
+// counters records which apply path ran, so a test can assert both that the right
+// one fired AND that the wrong one did not.
+type counters struct {
+	combine      int
+	versionGroup int
+}
+
+// newActionHandler wires a handler with fake apply funcs registered under the two
+// real actions, mirroring wire_handlers.go.
+func newActionHandler(s *database.PebbleStore, applyOn bool) (*reviewhandler.Handler, *counters) {
+	c := &counters{}
+	h := reviewhandler.New(s, func() bool { return applyOn })
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
+		c.combine++
+		return nil
+	})
+	h.RegisterApplyHandler(itunesservice.ActionVersionGroup, func(_ context.Context, _ database.ReviewItem) error {
+		c.versionGroup++
+		return nil
+	})
+	return h, c
+}
+
+// 🔴 THE POINT OF OWNER ITEM 2. The body's action beats the recommendation. A hold
+// the classifier wants combined, that a human recognises as two editions, must run
+// the version-group path — and must NOT run the combine path, which hard-deletes
+// absorbed rows.
+func TestApprove_ExplicitActionOverridesRecommendation(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	w, body := approveBody(t, h, it.ID, itunesservice.ActionVersionGroup)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.versionGroup != 1 {
+		t.Fatalf("version-group apply ran %d times, want 1", c.versionGroup)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine apply ran %d times — the override was ignored and books would have merged", c.combine)
+	}
+	data := body["data"].(map[string]any)
+	if data["chosenAction"] != itunesservice.ActionVersionGroup {
+		t.Fatalf("chosenAction = %v, want version-group", data["chosenAction"])
+	}
+}
+
+// No body → the hold's own recommendation is what runs.
+func TestApprove_EmptyBodyUsesRecommendation(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.version-group", "v1", itunesservice.ActionVersionGroup)
+	h, c := newActionHandler(s, true)
+
+	w, body := approveBody(t, h, it.ID, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.versionGroup != 1 || c.combine != 0 {
+		t.Fatalf("counters = %+v, want the recommendation (version-group) only", *c)
+	}
+	if data := body["data"].(map[string]any); data["chosenAction"] != itunesservice.ActionVersionGroup {
+		t.Fatalf("chosenAction = %v, want version-group", data["chosenAction"])
+	}
+}
+
+// 🔴 A typo must NOT fall back to the recommendation. "seperate" from someone who
+// meant "leave these six novels apart" cannot become "combine".
+func TestApprove_UnknownAction_Rejected_NoMutation(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	w, _ := approveBody(t, h, it.ID, "seperate")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code %d, want 400 for an unknown action", w.Code)
+	}
+	if c.combine != 0 || c.versionGroup != 0 {
+		t.Fatalf("counters = %+v, want nothing applied on a rejected action", *c)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusPending {
+		t.Fatalf("status = %q, want pending — a rejected action must not decide the hold", got.Status)
+	}
+}
+
+// insufficient-evidence is a statement BY the machine. A human may not pick it,
+// explicitly or by default.
+func TestApprove_InsufficientEvidence_NotApprovable(t *testing.T) {
+	s := newTestStore(t)
+	explicit := seedAction(t, s, "regroup.ambiguous", "a1", itunesservice.ActionCombine)
+	byDefault := seedAction(t, s, "regroup.ambiguous", "a2", itunesservice.ActionInsufficientEvidence)
+	h, c := newActionHandler(s, true)
+
+	w, _ := approveBody(t, h, explicit.ID, itunesservice.ActionInsufficientEvidence)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("explicit: code %d, want 400", w.Code)
+	}
+	w, _ = approveBody(t, h, byDefault.ID, "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("default: code %d, want 400 — the machine cannot tell, so a human must say", w.Code)
+	}
+	if c.combine != 0 || c.versionGroup != 0 {
+		t.Fatalf("counters = %+v, want nothing applied", *c)
+	}
+	for _, id := range []string{explicit.ID, byDefault.ID} {
+		got, _ := s.GetReviewItem(id)
+		if got.Status != database.ReviewStatusPending {
+			t.Fatalf("%s status = %q, want pending", id, got.Status)
+		}
+	}
+}
+
+// 🔴 OLD HOLDS. Every one of the ~356 holds in prod's queue was written before
+// recommendations existed. They must decode cleanly and behave as
+// insufficient-evidence — refused until a human names an action — never dispatch to
+// a merge on the strength of a field they do not carry.
+func TestApprove_OldPayloadWithoutRecommendation_IsInsufficientEvidence(t *testing.T) {
+	s := newTestStore(t)
+	old := seed(t, s, "regroup.multidisc", "m1") // payload "{}", the pre-2026-08-06 shape
+	h, c := newActionHandler(s, true)
+
+	w, _ := approveBody(t, h, old.ID, "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code %d, want 400 — an old hold has no recommendation to act on", w.Code)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine ran %d times on a hold carrying no recommendation", c.combine)
+	}
+
+	// …but an explicit action still works, which is how the queue gets drained
+	// without a payload migration.
+	w, _ = approveBody(t, h, old.ID, itunesservice.ActionCombine)
+	if w.Code != http.StatusOK {
+		t.Fatalf("explicit action on an old hold: code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 1 {
+		t.Fatalf("combine ran %d times, want 1", c.combine)
+	}
+}
+
+// 🔴 separate IS a status transition and nothing else. The assertion that matters
+// is the negative one: the combine apply path must not be invoked, even with the
+// global switch ON and a combine handler registered.
+func TestApprove_Separate_TransitionsWithoutApplying(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionSeparate)
+	h, c := newActionHandler(s, true) // switch ON — separate still applies nothing
+
+	w, body := approveBody(t, h, it.ID, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 0 || c.versionGroup != 0 {
+		t.Fatalf("counters = %+v — 'separate' must never invoke an apply path", *c)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApproved {
+		t.Fatalf("status = %q, want approved so re-scans leave the folder alone", got.Status)
+	}
+	data := body["data"].(map[string]any)
+	if data["chosenAction"] != itunesservice.ActionSeparate {
+		t.Fatalf("chosenAction = %v, want separate", data["chosenAction"])
+	}
+	if data["note"] == nil {
+		t.Fatal("expected a note explaining that separate needs no apply step")
+	}
+}
+
+// duplicate-of has no apply path yet. Refuse loudly rather than marking the hold
+// decided while doing nothing — "decided" is sticky across re-scans.
+func TestApprove_DuplicateOf_RejectedAsUnimplemented(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.ambiguous", "a1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	w, _ := approveBody(t, h, it.ID, itunesservice.ActionDuplicateOf)
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("code %d, want 501 for an action with no implementation", w.Code)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine ran %d times on a rejected duplicate-of", c.combine)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusPending {
+		t.Fatalf("status = %q, want pending — an unimplemented action must not decide the hold", got.Status)
+	}
+}
+
+// Anthology holds routed to the combine path under Kind dispatch (one anthology =
+// one book, owner decision 2026-07-26). Action dispatch must preserve that.
+func TestApprove_AnthologyRecommendingCombine_StillCombines(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.anthology", "an1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	if w, _ := approveBody(t, h, it.ID, ""); w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 1 {
+		t.Fatalf("combine ran %d times, want 1 — anthology routing regressed", c.combine)
+	}
+}
+
+// 🔴 DOCUMENTS A DELIBERATE WIDENING. Under Kind dispatch `regroup.ambiguous` had
+// no handler and could never merge. Keyed by action, an ambiguous hold whose
+// evidence says combine now reaches the combine path. That is intended — the
+// recommendation is evidence-backed where the Kind was only a shape — and this test
+// exists so the change is visible rather than discovered in an incident.
+func TestApprove_AmbiguousRecommendingCombine_NowCombines(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.ambiguous", "a1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	if w, _ := approveBody(t, h, it.ID, ""); w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 1 {
+		t.Fatalf("combine ran %d times, want 1", c.combine)
+	}
+}
+
+// 🔴 review_apply_enabled IS STILL THE GATE. With the switch OFF, an explicit
+// override to combine records the decision and executes NOTHING.
+func TestApprove_ApplyGateOff_OverrideRecordsButDoesNotApply(t *testing.T) {
+	s := newTestStore(t)
+	// Recommendation is insufficient-evidence, so the override-persistence guard
+	// does not fire (a later replay would skip this hold either way) and we get to
+	// test the apply gate itself.
+	it := seed(t, s, "regroup.ambiguous", "a1")
+	h, c := newActionHandler(s, false) // switch OFF
+
+	w, body := approveBody(t, h, it.ID, itunesservice.ActionCombine)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine apply ran %d times with review_apply_enabled OFF", c.combine)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApproved {
+		t.Fatalf("status = %q, want approved (recorded, not applied)", got.Status)
+	}
+	if body["data"].(map[string]any)["note"] == nil {
+		t.Fatal("expected the review-only note explaining nothing was applied")
+	}
+}
+
+// 🔴 AN OVERRIDE THAT CANNOT BE PERSISTED IS REFUSED. With the switch off the
+// chosen action is stored nowhere, and ReplayApprovedItems re-resolves from the
+// payload — so recording "approved" here would let a later replay run `combine` on
+// books a human said to keep apart.
+func TestApprove_OverrideOfReplayableRecommendation_RefusedWhileApplyIsOff(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, false) // switch OFF
+
+	w, _ := approveBody(t, h, it.ID, itunesservice.ActionSeparate)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("code %d, want 409 — the override would be silently lost and replayed as combine", w.Code)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine ran %d times", c.combine)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusPending {
+		t.Fatalf("status = %q, want pending", got.Status)
+	}
+
+	// The same override with the switch ON applies immediately, so there is nothing
+	// left for a replay to get wrong.
+	hOn, cOn := newActionHandler(s, true)
+	if w, _ := approveBody(t, hOn, it.ID, itunesservice.ActionSeparate); w.Code != http.StatusOK {
+		t.Fatalf("switch on: code %d body %s", w.Code, w.Body.String())
+	}
+	if cOn.combine != 0 {
+		t.Fatalf("combine ran %d times on a separate override", cOn.combine)
+	}
+}
+
+// 🔴 BULK APPROVE USES EACH ITEM'S OWN RECOMMENDATION and must not abort on one
+// undecidable hold. This is the whole payoff: the decisive holds get processed and
+// the ones with no evidence are reported for individual attention.
+func TestBulkApprove_UsesPerItemRecommendation_AndSkipsUndecidable(t *testing.T) {
+	s := newTestStore(t)
+	a := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	b := seedAction(t, s, "regroup.multidisc", "m2", itunesservice.ActionSeparate)
+	c := seed(t, s, "regroup.multidisc", "m3") // old payload → insufficient-evidence
+	h, cnt := newActionHandler(s, true)
+
+	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",
+		map[string]any{"action": "approve", "kind": "regroup.multidisc"}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+	}
+	data := decodeBody(t, w)["data"].(map[string]any)
+	if data["processed"].(float64) != 2 {
+		t.Fatalf("processed = %v, want 2 (the two decidable holds)", data["processed"])
+	}
+	skipped, _ := data["skipped"].([]any)
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %v, want the one undecidable hold (body %s)", skipped, w.Body.String())
+	}
+	if got := skipped[0].(map[string]any)["id"]; got != c.ID {
+		t.Fatalf("skipped id = %v, want %s", got, c.ID)
+	}
+	// Only the combine hold reached an apply path; the separate hold was a status
+	// transition and the undecidable one was skipped.
+	if cnt.combine != 1 {
+		t.Fatalf("combine ran %d times, want exactly 1", cnt.combine)
+	}
+	applied, _ := s.GetReviewItem(a.ID)
+	if applied.Status != database.ReviewStatusApplied {
+		t.Fatalf("combine hold status = %q, want applied", applied.Status)
+	}
+	sep, _ := s.GetReviewItem(b.ID)
+	if sep.Status != database.ReviewStatusApproved {
+		t.Fatalf("separate hold status = %q, want approved", sep.Status)
+	}
+	stillPending, _ := s.GetReviewItem(c.ID)
+	if stillPending.Status != database.ReviewStatusPending {
+		t.Fatalf("skipped hold status = %q, want pending — a skip must not decide it", stillPending.Status)
+	}
+}
+
+// A malformed body is a 400, not a silent run of the recommendation: a caller who
+// believes they overrode the action must never get the default instead.
+func TestApprove_MalformedBody_Rejected(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true)
+
+	w := doReqRaw(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve",
+		"{not json", gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code %d, want 400 for a malformed body", w.Code)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine ran %d times on a malformed request", c.combine)
+	}
+}

--- a/internal/server/handlers/review/handler_action_test.go
+++ b/internal/server/handlers/review/handler_action_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/review/handler_action_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 5c1f0a83-6d47-4e29-b0a5-3f7c8e2d94b1
 // last-edited: 2026-08-06
 
@@ -279,19 +279,22 @@ func TestApprove_AmbiguousRecommendingCombine_NowCombines(t *testing.T) {
 	}
 }
 
-// 🔴 review_apply_enabled IS STILL THE GATE. With the switch OFF, an explicit
-// override to combine records the decision and executes NOTHING.
+// 🔴 review_apply_enabled IS STILL THE GATE, AND THE OVERRIDE IS STILL RECORDED.
+// With the switch OFF — production's setting — an explicit override of a REPLAYABLE
+// recommendation must be accepted (that is the only way a reviewer can register a
+// disagreement at all), must execute nothing, and must persist what they chose.
+//
+// This case used to be a 409 REVIEW_OVERRIDE_NOT_PERSISTABLE, because there was
+// nowhere to store the choice and a later replay would have re-read `combine` from
+// the payload. ChosenAction is that storage, so the refusal is gone.
 func TestApprove_ApplyGateOff_OverrideRecordsButDoesNotApply(t *testing.T) {
 	s := newTestStore(t)
-	// Recommendation is insufficient-evidence, so the override-persistence guard
-	// does not fire (a later replay would skip this hold either way) and we get to
-	// test the apply gate itself.
-	it := seed(t, s, "regroup.ambiguous", "a1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h, c := newActionHandler(s, false) // switch OFF
 
-	w, body := approveBody(t, h, it.ID, itunesservice.ActionCombine)
+	w, body := approveBody(t, h, it.ID, itunesservice.ActionSeparate)
 	if w.Code != http.StatusOK {
-		t.Fatalf("code %d body %s", w.Code, w.Body.String())
+		t.Fatalf("code %d body %s — an override must be recordable while apply is off", w.Code, w.Body.String())
 	}
 	if c.combine != 0 {
 		t.Fatalf("combine apply ran %d times with review_apply_enabled OFF", c.combine)
@@ -300,40 +303,51 @@ func TestApprove_ApplyGateOff_OverrideRecordsButDoesNotApply(t *testing.T) {
 	if got.Status != database.ReviewStatusApproved {
 		t.Fatalf("status = %q, want approved (recorded, not applied)", got.Status)
 	}
+	if got.ChosenAction != itunesservice.ActionSeparate {
+		t.Fatalf("chosen_action = %q, want separate — the override must survive the write, "+
+			"or a later replay re-reads 'combine' from the payload and merges the books", got.ChosenAction)
+	}
 	if body["data"].(map[string]any)["note"] == nil {
 		t.Fatal("expected the review-only note explaining nothing was applied")
 	}
 }
 
-// 🔴 AN OVERRIDE THAT CANNOT BE PERSISTED IS REFUSED. With the switch off the
-// chosen action is stored nowhere, and ReplayApprovedItems re-resolves from the
-// payload — so recording "approved" here would let a later replay run `combine` on
-// books a human said to keep apart.
-func TestApprove_OverrideOfReplayableRecommendation_RefusedWhileApplyIsOff(t *testing.T) {
+// The recommendation is persisted too when the reviewer accepts it (empty body), so
+// replay never has to re-derive an action for a hold decided after 2026-08-06.
+func TestApprove_AcceptedRecommendationIsAlsoPersisted(t *testing.T) {
 	s := newTestStore(t)
 	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
-	h, c := newActionHandler(s, false) // switch OFF
+	h, _ := newActionHandler(s, false) // switch OFF: records, does not apply
 
-	w, _ := approveBody(t, h, it.ID, itunesservice.ActionSeparate)
-	if w.Code != http.StatusConflict {
-		t.Fatalf("code %d, want 409 — the override would be silently lost and replayed as combine", w.Code)
-	}
-	if c.combine != 0 {
-		t.Fatalf("combine ran %d times", c.combine)
+	if w, _ := approveBody(t, h, it.ID, ""); w.Code != http.StatusOK {
+		t.Fatalf("code %d", w.Code)
 	}
 	got, _ := s.GetReviewItem(it.ID)
-	if got.Status != database.ReviewStatusPending {
-		t.Fatalf("status = %q, want pending", got.Status)
+	if got.ChosenAction != itunesservice.ActionCombine {
+		t.Fatalf("chosen_action = %q, want combine", got.ChosenAction)
 	}
+}
 
-	// The same override with the switch ON applies immediately, so there is nothing
-	// left for a replay to get wrong.
-	hOn, cOn := newActionHandler(s, true)
-	if w, _ := approveBody(t, hOn, it.ID, itunesservice.ActionSeparate); w.Code != http.StatusOK {
-		t.Fatalf("switch on: code %d body %s", w.Code, w.Body.String())
+// 🔴 A RE-APPROVE WITH AN EMPTY BODY MUST NOT REVERT A RECORDED OVERRIDE. Re-approving
+// a decided hold is a supported flow (it is the recovery path replay's skip reason
+// advertises), so the default has to be the hold's EFFECTIVE action — what the human
+// last chose — not the payload's recommendation.
+func TestApprove_EmptyBodyOnDecidedHold_KeepsThePersistedOverride(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	h, c := newActionHandler(s, true) // switch ON, so a revert would MERGE
+
+	if w, _ := approveBody(t, h, it.ID, itunesservice.ActionSeparate); w.Code != http.StatusOK {
+		t.Fatalf("first approve: code %d", w.Code)
 	}
-	if cOn.combine != 0 {
-		t.Fatalf("combine ran %d times on a separate override", cOn.combine)
+	// Someone hits Approve again without choosing anything.
+	if w, body := approveBody(t, h, it.ID, ""); w.Code != http.StatusOK {
+		t.Fatalf("re-approve: code %d", w.Code)
+	} else if got := body["data"].(map[string]any)["chosenAction"]; got != itunesservice.ActionSeparate {
+		t.Fatalf("chosenAction = %v, want separate — the empty body reverted to the recommendation", got)
+	}
+	if c.combine != 0 {
+		t.Fatalf("combine ran %d times — a bare re-approve silently reverted the override and merged", c.combine)
 	}
 }
 

--- a/internal/server/handlers/review/handler_test.go
+++ b/internal/server/handlers/review/handler_test.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/review/handler_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 8e4a1c72-3d95-4b60-a7f1-9c2e6b0d5f83
-// last-edited: 2026-07-14
+// last-edited: 2026-08-06
 
 // Tests for the universal review-queue handlers. The store is exercised through
 // a REAL pebble-backed *database.PebbleStore (which implements the ReviewStore
@@ -22,6 +22,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
 )
 
@@ -38,14 +39,31 @@ func newTestStore(t *testing.T) *database.PebbleStore {
 	return s
 }
 
+// seed writes an OLD-SHAPE hold: payload "{}" with no recommendedAction, exactly
+// like the ~356 holds already sitting in prod's queue. Approve treats those as
+// insufficient-evidence and refuses them without an explicit action, so tests that
+// exercise the approve path use seedAction instead.
 func seed(t *testing.T, s *database.PebbleStore, kind, dedupKey string) database.ReviewItem {
+	t.Helper()
+	return seedPayload(t, s, kind, dedupKey, "{}")
+}
+
+// seedAction writes a hold carrying a recommendation, the shape every hold written
+// after 2026-08-06 has.
+func seedAction(t *testing.T, s *database.PebbleStore, kind, dedupKey, action string) database.ReviewItem {
+	t.Helper()
+	return seedPayload(t, s, kind, dedupKey,
+		`{"folder":"/f/`+dedupKey+`","recommendedAction":"`+action+`","recommendationReason":"test"}`)
+}
+
+func seedPayload(t *testing.T, s *database.PebbleStore, kind, dedupKey, payload string) database.ReviewItem {
 	t.Helper()
 	it, err := s.UpsertReviewItem(database.ReviewItem{
 		Kind:      kind,
 		DedupKey:  dedupKey,
 		FolderRef: "/f/" + dedupKey,
 		Summary:   "s",
-		Payload:   "{}",
+		Payload:   payload,
 	})
 	if err != nil {
 		t.Fatalf("seed: %v", err)
@@ -131,7 +149,7 @@ func TestListReviewItems(t *testing.T) {
 
 func TestApproveReviewItem_NoHandler_MarksApproved(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return true }) // no apply handlers registered (A1 state)
 
 	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve", nil,
@@ -152,11 +170,11 @@ func TestApproveReviewItem_NoHandler_MarksApproved(t *testing.T) {
 
 func TestApproveReviewItem_WithHandler_MarksApplied(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return true })
 
 	var applied bool
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, item database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, item database.ReviewItem) error {
 		applied = true
 		if item.ID != it.ID {
 			t.Errorf("apply handler got wrong item: %s", item.ID)
@@ -180,9 +198,9 @@ func TestApproveReviewItem_WithHandler_MarksApplied(t *testing.T) {
 
 func TestApproveReviewItem_HandlerError_StaysPending(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return true })
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		return context.DeadlineExceeded // any apply failure
 	})
 
@@ -206,10 +224,10 @@ func TestApproveReviewItem_HandlerError_StaysPending(t *testing.T) {
 // (nothing merges), and stay visible/reviewable.
 func TestApproveReviewItem_ApplyGateOff_ApprovesNotApplies(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	applied := false
 	h := reviewhandler.New(s, func() bool { return false }) // switch OFF
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		applied = true
 		return nil
 	})
@@ -232,10 +250,10 @@ func TestApproveReviewItem_ApplyGateOff_ApprovesNotApplies(t *testing.T) {
 // approve execute the registered handler and mark the item "applied".
 func TestApproveReviewItem_ApplyGateOn_Applies(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	applied := false
 	h := reviewhandler.New(s, func() bool { return true }) // switch ON
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		applied = true
 		return nil
 	})
@@ -307,8 +325,8 @@ func TestBulkReviewAction_RejectByKind(t *testing.T) {
 
 func TestBulkReviewAction_ByIDs(t *testing.T) {
 	s := newTestStore(t)
-	a := seed(t, s, "regroup.multidisc", "m1")
-	b := seed(t, s, "regroup.multidisc", "m2")
+	a := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	b := seedAction(t, s, "regroup.multidisc", "m2", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return true })
 
 	w := doReq(t, h.BulkReviewAction, http.MethodPost, "/review/bulk",

--- a/internal/server/handlers/review/replay.go
+++ b/internal/server/handlers/review/replay.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/review/replay.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 4d807d92-72d8-4df6-9da1-80123d2bf6b4
 // last-edited: 2026-08-06
 
@@ -75,37 +75,53 @@ func (h *Handler) ReplayApprovedItems(c *gin.Context) {
 		Kind   string `json:"kind"`
 		Reason string `json:"reason"`
 	}
-	// Resolve the ACTION the same way approveOne does (one place owns "empty →
-	// insufficient-evidence"), then look the handler up by action. Replay must agree
-	// with approve about what a hold means, or the two would carry out different
-	// decisions for the same row.
+	// 🔴 REPLAY RUNS WHAT THE HUMAN CHOSE, NOT WHAT THE MACHINE RECOMMENDED.
 	//
-	// Every hold approved before recommendations existed resolves to
-	// insufficient-evidence and lands in the skip list — which is why would_replay
-	// drops to near zero on a queue of pre-2026-08-06 approvals. That is the
-	// fail-closed direction: refusing to replay a hold whose intended action was
-	// never recorded beats guessing one.
+	// effectiveActionFor prefers the PERSISTED ReviewItem.ChosenAction and only falls
+	// back to the payload's `recommendedAction` when none was recorded. That ordering
+	// is the entire point of owner item 2: with review_apply_enabled off, approving is
+	// the only moment a human is in the loop and replay is where the work actually
+	// happens, so a hold recommending `combine` that a reviewer approved as `separate`
+	// must arrive here as `separate`. Reading the payload first would merge the books
+	// they said to keep apart, and the combine apply path hard-deletes absorbed rows.
+	//
+	// approveOne resolves through the SAME helper, so approve and replay can never
+	// carry out different decisions for one row.
+	//
+	// Holds approved before ChosenAction existed fall through to the payload; a
+	// pre-recommendation hold resolves to insufficient-evidence and lands in the skip
+	// list. That is the fail-closed direction: refusing to replay a hold whose intended
+	// action was never recorded beats guessing one.
 	//
 	// 🔴 THE RECOVERY PATH IS RE-APPROVE, NOT RE-SCAN. A re-scan cannot help here:
 	// UpsertReviewItem is a FULL no-op on a non-pending row, so it will not refresh
 	// an already-approved hold's payload. What does work is approving the hold again
 	// with an explicit {"action": "..."} — approveOne has no status guard, so an
-	// approved item can be re-approved and applied. The skip reason says so, because
-	// pointing an operator at a re-scan that silently does nothing is worse than
-	// saying nothing.
+	// approved item can be re-approved, and it now RECORDS the action, so a later
+	// replay honours it. The skip reason says so, because pointing an operator at a
+	// re-scan that silently does nothing is worse than saying nothing.
 	var replayable []database.ReviewItem
 	var noHandler []skipped
 	for _, it := range items {
-		action := recommendedActionFor(it)
+		action := effectiveActionFor(it)
 		if _, ok := h.applyHandlerFor(action); ok {
 			replayable = append(replayable, it)
 			continue
 		}
 		reason := "no apply handler registered for action " + action
-		if action == itunesservice.ActionInsufficientEvidence {
+		switch action {
+		case itunesservice.ActionInsufficientEvidence:
 			reason = "hold carries no recommended action (approved before recommendations existed, or the " +
 				"classifier could not tell) — approve it again with an explicit {\"action\": \"...\"} to decide it; " +
 				"a re-scan will NOT refresh an already-approved hold"
+		case itunesservice.ActionSeparate:
+			// Not a gap — a completed decision. Every member is already its own book,
+			// so there is nothing left to execute. Saying so matters when the reviewer
+			// OVERRODE a `combine` recommendation to get here: the skip is the override
+			// working, and an operator reading a bare "no apply handler" line could
+			// easily mistake it for the decision having been dropped.
+			reason = "action 'separate' needs no apply step — every member is already its own book, " +
+				"so this decision is complete"
 		}
 		noHandler = append(noHandler, skipped{it.ID, it.Kind, reason})
 	}
@@ -139,7 +155,8 @@ func (h *Handler) ReplayApprovedItems(c *gin.Context) {
 	var errs []string
 	for i := range replayable {
 		it := replayable[i]
-		fn, ok := h.applyHandlerFor(recommendedActionFor(it))
+		action := effectiveActionFor(it)
+		fn, ok := h.applyHandlerFor(action)
 		if !ok {
 			continue
 		}

--- a/internal/server/handlers/review/replay.go
+++ b/internal/server/handlers/review/replay.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/review/replay.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4d807d92-72d8-4df6-9da1-80123d2bf6b4
-// last-edited: 2026-08-05
+// last-edited: 2026-08-06
 
 package reviewhandler
 
@@ -11,6 +11,7 @@ import (
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
 	"github.com/falkcorp/audiobook-organizer/internal/httputil"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	"github.com/gin-gonic/gin"
 )
 
@@ -74,14 +75,39 @@ func (h *Handler) ReplayApprovedItems(c *gin.Context) {
 		Kind   string `json:"kind"`
 		Reason string `json:"reason"`
 	}
+	// Resolve the ACTION the same way approveOne does (one place owns "empty →
+	// insufficient-evidence"), then look the handler up by action. Replay must agree
+	// with approve about what a hold means, or the two would carry out different
+	// decisions for the same row.
+	//
+	// Every hold approved before recommendations existed resolves to
+	// insufficient-evidence and lands in the skip list — which is why would_replay
+	// drops to near zero on a queue of pre-2026-08-06 approvals. That is the
+	// fail-closed direction: refusing to replay a hold whose intended action was
+	// never recorded beats guessing one.
+	//
+	// 🔴 THE RECOVERY PATH IS RE-APPROVE, NOT RE-SCAN. A re-scan cannot help here:
+	// UpsertReviewItem is a FULL no-op on a non-pending row, so it will not refresh
+	// an already-approved hold's payload. What does work is approving the hold again
+	// with an explicit {"action": "..."} — approveOne has no status guard, so an
+	// approved item can be re-approved and applied. The skip reason says so, because
+	// pointing an operator at a re-scan that silently does nothing is worse than
+	// saying nothing.
 	var replayable []database.ReviewItem
 	var noHandler []skipped
 	for _, it := range items {
-		if _, ok := h.applyHandlerFor(it.Kind); ok {
+		action := recommendedActionFor(it)
+		if _, ok := h.applyHandlerFor(action); ok {
 			replayable = append(replayable, it)
 			continue
 		}
-		noHandler = append(noHandler, skipped{it.ID, it.Kind, "no apply handler registered for this kind"})
+		reason := "no apply handler registered for action " + action
+		if action == itunesservice.ActionInsufficientEvidence {
+			reason = "hold carries no recommended action (approved before recommendations existed, or the " +
+				"classifier could not tell) — approve it again with an explicit {\"action\": \"...\"} to decide it; " +
+				"a re-scan will NOT refresh an already-approved hold"
+		}
+		noHandler = append(noHandler, skipped{it.ID, it.Kind, reason})
 	}
 	if req.Limit > 0 && len(replayable) > req.Limit {
 		replayable = replayable[:req.Limit]
@@ -113,7 +139,7 @@ func (h *Handler) ReplayApprovedItems(c *gin.Context) {
 	var errs []string
 	for i := range replayable {
 		it := replayable[i]
-		fn, ok := h.applyHandlerFor(it.Kind)
+		fn, ok := h.applyHandlerFor(recommendedActionFor(it))
 		if !ok {
 			continue
 		}

--- a/internal/server/handlers/review/replay_test.go
+++ b/internal/server/handlers/review/replay_test.go
@@ -1,18 +1,20 @@
 // file: internal/server/handlers/review/replay_test.go
-// version: 1.0.0
+// version: 1.2.0
 // guid: 8e3c5a71-9d24-4b60-af18-2c47e0b96d35
-// last-edited: 2026-08-05
+// last-edited: 2026-08-06
 
 package reviewhandler_test
 
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
+	itunesservice "github.com/falkcorp/audiobook-organizer/internal/itunes/service"
 	reviewhandler "github.com/falkcorp/audiobook-organizer/internal/server/handlers/review"
 )
 
@@ -37,13 +39,13 @@ func approveWith(t *testing.T, h *reviewhandler.Handler, id string) {
 // replay, and the work actually happens.
 func TestReplayApproved_AppliesDecisionsMadeWhileApplyWasOff(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 
 	applyOn := false
 	h := reviewhandler.New(s, func() bool { return applyOn })
 
 	var appliedIDs []string
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, item database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, item database.ReviewItem) error {
 		appliedIDs = append(appliedIDs, item.ID)
 		return nil
 	})
@@ -86,11 +88,11 @@ func TestReplayApproved_AppliesDecisionsMadeWhileApplyWasOff(t *testing.T) {
 // every destructive path in this codebase.
 func TestReplayApproved_DryRunChangesNothing(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return false })
 
 	ran := 0
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		ran++
 		return nil
 	})
@@ -114,9 +116,9 @@ func TestReplayApproved_DryRunChangesNothing(t *testing.T) {
 // exists to fix.
 func TestReplayApproved_RefusesWhenApplyIsGloballyDisabled(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return false })
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		return nil
 	})
 	approveWith(t, h, it.ID)
@@ -132,11 +134,11 @@ func TestReplayApproved_RefusesWhenApplyIsGloballyDisabled(t *testing.T) {
 // Marking it applied after a failure would strand the work exactly as before.
 func TestReplayApproved_LeavesFailedItemsRetryable(t *testing.T) {
 	s := newTestStore(t)
-	it := seed(t, s, "regroup.multidisc", "m1")
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
 	h := reviewhandler.New(s, func() bool { return true })
 
 	fail := true
-	h.RegisterApplyHandler("regroup.multidisc", func(_ context.Context, _ database.ReviewItem) error {
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
 		if fail {
 			return context.DeadlineExceeded
 		}
@@ -172,9 +174,12 @@ func TestReplayApproved_LeavesFailedItemsRetryable(t *testing.T) {
 	}
 }
 
-// Kinds with no registered handler are reported as skipped, never silently
-// dropped — 779 of the current queue are regroup.ambiguous, which has none.
-func TestReplayApproved_ReportsKindsWithNoHandler(t *testing.T) {
+// Holds whose ACTION has no registered handler are reported as skipped, never
+// silently dropped. This one is seeded with the OLD payload shape (no
+// recommendedAction), which is every hold approved before 2026-08-06: it resolves
+// to insufficient-evidence and must be skipped with a reason that says why, rather
+// than replayed on a guessed action.
+func TestReplayApproved_ReportsItemsWithNoApplicableAction(t *testing.T) {
 	s := newTestStore(t)
 	it := seed(t, s, "regroup.ambiguous", "a1")
 	h := reviewhandler.New(s, func() bool { return true })
@@ -191,5 +196,49 @@ func TestReplayApproved_ReportsKindsWithNoHandler(t *testing.T) {
 	skipped, _ := data["skipped"].([]any)
 	if len(skipped) != 1 {
 		t.Fatalf("skipped = %v, want the one handler-less item (body %s)", skipped, w.Body.String())
+	}
+	reason, _ := skipped[0].(map[string]any)["reason"].(string)
+	if !strings.Contains(reason, "no recommended action") {
+		t.Fatalf("skip reason = %q, want it to name the missing recommendation so an operator "+
+			"knows a re-scan is the fix", reason)
+	}
+}
+
+// 🔴 THE RECOVERY PATH THE SKIP REASON ADVERTISES MUST ACTUALLY WORK. Replay skips
+// every hold approved before recommendations existed, and a re-scan cannot unstick
+// them — UpsertReviewItem is a full no-op on a non-pending row. The only way out is
+// re-approving with an explicit action, so this asserts an ALREADY-APPROVED hold can
+// be approved again and applied. Without this the skipped items are in a dead end.
+func TestApprove_AlreadyApprovedItem_CanBeReApprovedWithAnExplicitAction(t *testing.T) {
+	s := newTestStore(t)
+	it := seed(t, s, "regroup.ambiguous", "a1") // old payload → insufficient-evidence
+	if _, err := s.SetReviewItemStatus(it.ID, database.ReviewStatusApproved); err != nil {
+		t.Fatalf("seed approved: %v", err)
+	}
+	h, c := newActionHandler(s, true)
+
+	// A re-scan is a no-op on a non-pending row, which is why the skip reason must
+	// not recommend one.
+	again, err := s.UpsertReviewItem(database.ReviewItem{
+		Kind: it.Kind, DedupKey: it.DedupKey, FolderRef: it.FolderRef, Summary: "s",
+		Payload: `{"recommendedAction":"combine"}`,
+	})
+	if err != nil {
+		t.Fatalf("re-scan upsert: %v", err)
+	}
+	if again.Payload != "{}" {
+		t.Fatalf("payload = %q; a re-scan was expected to leave an approved hold untouched", again.Payload)
+	}
+
+	w, _ := approveBody(t, h, it.ID, itunesservice.ActionCombine)
+	if w.Code != http.StatusOK {
+		t.Fatalf("re-approve: code %d body %s", w.Code, w.Body.String())
+	}
+	if c.combine != 1 {
+		t.Fatalf("combine ran %d times, want 1", c.combine)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApplied {
+		t.Fatalf("status = %q, want applied", got.Status)
 	}
 }

--- a/internal/server/handlers/review/replay_test.go
+++ b/internal/server/handlers/review/replay_test.go
@@ -1,5 +1,5 @@
 // file: internal/server/handlers/review/replay_test.go
-// version: 1.2.0
+// version: 1.3.0
 // guid: 8e3c5a71-9d24-4b60-af18-2c47e0b96d35
 // last-edited: 2026-08-06
 
@@ -26,6 +26,159 @@ func approveWith(t *testing.T, h *reviewhandler.Handler, id string) {
 		gin.Params{{Key: "id", Value: id}})
 	if w.Code != http.StatusOK {
 		t.Fatalf("approve %s: code %d body %s", id, w.Code, w.Body.String())
+	}
+}
+
+// replayApply runs a real (non-dry) replay and fails on anything but 200.
+func replayApply(t *testing.T, h *reviewhandler.Handler) map[string]any {
+	t.Helper()
+	w := doReq(t, h.ReplayApprovedItems, http.MethodPost, "/review/replay-approved",
+		map[string]any{"apply": true}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay: code %d body %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w)
+	if data, ok := body["data"].(map[string]any); ok {
+		return data
+	}
+	return body
+}
+
+// ═══ THE OVERRIDE MUST SURVIVE TO REPLAY (owner item 2) ══════════════════════════
+//
+// These two are a PAIR and only mean something together. With review_apply_enabled
+// off — production's setting — approving executes nothing and replay does the real
+// work later, so the whole value of letting a human override the machine rests on the
+// choice still being there when replay reads it back. One test alone passes
+// vacuously: a replay that skipped everything would satisfy the suppression case, and
+// a replay that ran everything would satisfy the execution case.
+
+// 🔴 SUPPRESSION. The classifier said `combine`; the human said `separate`. Replay
+// must NOT merge. This is the exact incident the old 409
+// REVIEW_OVERRIDE_NOT_PERSISTABLE guard existed to prevent — combine's apply path
+// hard-deletes the absorbed Book rows, so a wrong replay here is unrecoverable.
+func TestReplayApproved_HonoursOverrideAwayFromCombine(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+
+	applyOn := false
+	h := reviewhandler.New(s, func() bool { return applyOn })
+	combined := 0
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
+		combined++
+		return nil
+	})
+
+	// Reviewer disagrees with the recommendation while apply is off.
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve",
+		map[string]any{"action": itunesservice.ActionSeparate}, gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("approve with override: code %d body %s", w.Code, w.Body.String())
+	}
+
+	// Operator flips the switch and replays.
+	applyOn = true
+	data := replayApply(t, h)
+
+	if combined != 0 {
+		t.Fatalf("combine apply ran %d times — replay used the RECOMMENDATION and merged books "+
+			"a human explicitly said to keep apart", combined)
+	}
+	if got := data["applied"]; got != float64(0) {
+		t.Fatalf("applied = %v, want 0", got)
+	}
+	skipped, _ := data["skipped"].([]any)
+	if len(skipped) != 1 {
+		t.Fatalf("skipped = %v, want the one separate-decided hold", skipped)
+	}
+	if reason, _ := skipped[0].(map[string]any)["reason"].(string); !strings.Contains(reason, "separate") {
+		t.Fatalf("skip reason = %q, want it to name 'separate' so the operator sees the override worked, "+
+			"not that a decision was dropped", reason)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApproved {
+		t.Fatalf("status = %q, want approved — nothing was applied", got.Status)
+	}
+	if got.ChosenAction != itunesservice.ActionSeparate {
+		t.Fatalf("chosen_action = %q, want separate", got.ChosenAction)
+	}
+}
+
+// 🔴 EXECUTION, the other direction. The classifier said `separate`; the human looked
+// at the folder and said `combine`. Replay must actually MERGE. Without this the
+// suppression test above would pass on a replay that had simply stopped working.
+func TestReplayApproved_HonoursOverrideTowardsCombine(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionSeparate)
+
+	applyOn := false
+	h := reviewhandler.New(s, func() bool { return applyOn })
+	var combinedIDs []string
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, item database.ReviewItem) error {
+		combinedIDs = append(combinedIDs, item.ID)
+		return nil
+	})
+
+	w := doReq(t, h.ApproveReviewItem, http.MethodPost, "/review/items/"+it.ID+"/approve",
+		map[string]any{"action": itunesservice.ActionCombine}, gin.Params{{Key: "id", Value: it.ID}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("approve with override: code %d body %s", w.Code, w.Body.String())
+	}
+	if len(combinedIDs) != 0 {
+		t.Fatalf("apply ran while the switch was off: %v", combinedIDs)
+	}
+
+	applyOn = true
+	data := replayApply(t, h)
+
+	if len(combinedIDs) != 1 || combinedIDs[0] != it.ID {
+		t.Fatalf("combine apply saw %v, want [%s] — replay fell back to the 'separate' recommendation "+
+			"and dropped the human's decision", combinedIDs, it.ID)
+	}
+	if got := data["applied"]; got != float64(1) {
+		t.Fatalf("applied = %v, want 1", got)
+	}
+	got, _ := s.GetReviewItem(it.ID)
+	if got.Status != database.ReviewStatusApplied {
+		t.Fatalf("status = %q, want applied", got.Status)
+	}
+	// The approved→applied transition must not have erased the decision it carried out.
+	if got.ChosenAction != itunesservice.ActionCombine {
+		t.Fatalf("chosen_action = %q after apply, want combine — the status write wiped the decision",
+			got.ChosenAction)
+	}
+}
+
+// 🔴 OLD ROWS KEEP WORKING. A hold approved before ChosenAction existed carries an
+// empty one; replay must fall back to the payload's recommendation rather than skip
+// it. (Its sibling — an old row whose payload predates recommendations too, so the
+// fallback lands on insufficient-evidence — is
+// TestReplayApproved_ReportsItemsWithNoApplicableAction.)
+func TestReplayApproved_FallsBackToPayloadWhenNoActionWasPersisted(t *testing.T) {
+	s := newTestStore(t)
+	it := seedAction(t, s, "regroup.multidisc", "m1", itunesservice.ActionCombine)
+	// SetReviewItemStatus writes NO chosen action, which is exactly the pre-2026-08-06
+	// approved-row shape.
+	if _, err := s.SetReviewItemStatus(it.ID, database.ReviewStatusApproved); err != nil {
+		t.Fatalf("seed approved: %v", err)
+	}
+	if got, _ := s.GetReviewItem(it.ID); got.ChosenAction != "" {
+		t.Fatalf("chosen_action = %q, want empty — this test models a row that predates the field",
+			got.ChosenAction)
+	}
+
+	h := reviewhandler.New(s, func() bool { return true })
+	combined := 0
+	h.RegisterApplyHandler(itunesservice.ActionCombine, func(_ context.Context, _ database.ReviewItem) error {
+		combined++
+		return nil
+	})
+
+	if data := replayApply(t, h); data["applied"] != float64(1) {
+		t.Fatalf("applied = %v, want 1", data["applied"])
+	}
+	if combined != 1 {
+		t.Fatalf("combine ran %d times, want 1 — the payload fallback regressed", combined)
 	}
 }
 

--- a/internal/server/wire_handlers.go
+++ b/internal/server/wire_handlers.go
@@ -1,7 +1,7 @@
 // file: internal/server/wire_handlers.go
-// version: 2.20.1
+// version: 2.21.0
 // guid: f7a8b9c0-d1e2-3456-7890-abcdef012345
-// last-edited: 2026-07-26
+// last-edited: 2026-08-06
 
 package server
 
@@ -588,11 +588,27 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 	reviewH := reviewhandler.New(s.Store(), func() bool { return config.AppConfig.ReviewApplyEnabled })
 
 	// Register the regroup APPLY handlers (PR-B2) so approving a hold in the review
-	// UI performs the real action. Multidisc AND anthology both COMBINE into one
-	// multi-file book (an anthology/collection is a single real book with one ISBN —
-	// owner decision 2026-07-26 — NOT multiple works to split), so both use
-	// ApplyMultidisc. Version-group links editions. Only `ambiguous` stays
-	// handler-less (needs a human resolution choice — the review UI supplies it).
+	// UI performs the real action.
+	//
+	// 🔴 REGISTERED PER ACTION, NOT PER KIND (owner item 2, 2026-08-06). Approve now
+	// dispatches on the action a hold recommends (or a human explicitly chose), so
+	// there are exactly two entries — one per thing the system can actually DO —
+	// instead of one per classifier Kind. ApplyMultidisc is the combine path
+	// (multidisc AND anthology both collapse into one multi-file book: an
+	// anthology/collection is a single real book with one ISBN, owner decision
+	// 2026-07-26); ApplyVersionGroup links editions without destroying anything.
+	// `separate` and `insufficient-evidence` deliberately have no entry — the former
+	// is a status transition, the latter is not approvable at all.
+	//
+	// 🔴 BLAST RADIUS THIS WIDENS, DELIBERATELY. Under Kind-keyed dispatch,
+	// `regroup.ambiguous` had no handler and so could never merge anything. Keyed by
+	// action, an ambiguous hold that recommends `combine` (24 of them as measured on
+	// 2026-08-06) now reaches ApplyMultidisc, which hard-deletes absorbed Book rows.
+	// That is intended — the recommendation is evidence-backed where the Kind was
+	// only a shape — but it is a real expansion, and it is why the recommendation
+	// refuses to say `combine` without a majority of known runtimes. Nothing here
+	// runs while review_apply_enabled is off.
+	//
 	// Guarded on a real store — with a nil store the review handler short-circuits
 	// before dispatch, so the closures would never run anyway.
 	if s.Store() != nil {
@@ -600,10 +616,9 @@ func (s *Server) wireHandlers(api *gin.RouterGroup, authMiddleware gin.HandlerFu
 		if mergeSvc == nil {
 			mergeSvc = merge.NewService(s.Store())
 		}
-		combine := maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc)
-		reviewH.RegisterApplyHandler(itunesservice.KindMultidisc, combine)
-		reviewH.RegisterApplyHandler(itunesservice.KindAnthology, combine)
-		reviewH.RegisterApplyHandler(itunesservice.KindVersionGroup,
+		reviewH.RegisterApplyHandler(itunesservice.ActionCombine,
+			maintenanceplugin.ApplyMultidisc(s.Store(), mergeSvc))
+		reviewH.RegisterApplyHandler(itunesservice.ActionVersionGroup,
 			maintenanceplugin.ApplyVersionGroup(s.Store()))
 	}
 

--- a/web/src/lib/__tests__/reviewPayload.test.ts
+++ b/web/src/lib/__tests__/reviewPayload.test.ts
@@ -1,9 +1,22 @@
-// file: web/src/pages/__tests__/reviewPayload.test.ts
-// version: 1.0.0
+// file: web/src/lib/__tests__/reviewPayload.test.ts
+// version: 1.1.0
 // guid: 6a1d8f30-4b52-4e97-9c08-1f7b2e6d3a45
+// last-edited: 2026-08-06
 
 import { describe, it, expect } from 'vitest';
-import { parsePayload, memberIDs, memberCount, memberEntries } from '../reviewPayload';
+import {
+  ACTION_INSUFFICIENT_EVIDENCE,
+  REVIEW_ACTIONS,
+  actionSpec,
+  defaultActionFor,
+  evidenceFacts,
+  humanRuntime,
+  labelForAction,
+  memberCount,
+  memberEntries,
+  memberIDs,
+  parsePayload,
+} from '../reviewPayload';
 
 // The Go producer (buildRegroupPayload) writes exactly this shape. These tests pin the
 // key names so the camelCase/snake_case mismatch that silently broke the old
@@ -84,5 +97,110 @@ describe('review payload parsing', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].disc).toBeUndefined();
     expect(entries[0].track).toBeUndefined();
+  });
+});
+
+// ═══ Recommendation, evidence, and the default action ════════════════════════════
+//
+// These pin the two rules the backend enforces on its side, so the UI and the API
+// can never disagree about what is offerable:
+//   1. `insufficient-evidence` is NOT an approvable choice — it is a statement BY the
+//      classifier, and approving with it is a deliberate 400.
+//   2. Absent evidence is not zero evidence — a hold with no evidence block must read
+//      as "nothing recorded", never as a row of confident-looking zeros.
+describe('review recommendations', () => {
+  it('defaultActionFor preselects an approvable recommendation', () => {
+    const p = parsePayload(JSON.stringify({ recommendedAction: 'combine' }));
+    expect(defaultActionFor(p)).toBe('combine');
+    expect(defaultActionFor(parsePayload(JSON.stringify({ recommendedAction: 'separate' }))))
+      .toBe('separate');
+  });
+
+  it('defaultActionFor preselects NOTHING for insufficient-evidence', () => {
+    // The backend 400s this action on purpose, and guessing a default here would
+    // guess `combine` on exactly the holds with the least evidence.
+    const p = parsePayload(JSON.stringify({ recommendedAction: ACTION_INSUFFICIENT_EVIDENCE }));
+    expect(defaultActionFor(p)).toBe('');
+  });
+
+  it('defaultActionFor preselects NOTHING for a pre-recommendation hold', () => {
+    // Every hold currently in prod's queue: no recommendedAction at all.
+    expect(defaultActionFor(parsePayload('{}'))).toBe('');
+    expect(defaultActionFor(null)).toBe('');
+  });
+
+  it('defaultActionFor preselects NOTHING for an action outside the vocabulary', () => {
+    const p = parsePayload(JSON.stringify({ recommendedAction: 'seperate' }));
+    expect(defaultActionFor(p)).toBe('');
+  });
+
+  it('insufficient-evidence is in the vocabulary but is never approvable', () => {
+    const spec = actionSpec(ACTION_INSUFFICIENT_EVIDENCE);
+    expect(spec).toBeDefined();
+    expect(spec?.approvable).toBe(false);
+    expect(REVIEW_ACTIONS.filter((a) => a.approvable).map((a) => a.value)).toEqual([
+      'combine',
+      'separate',
+      'version-group',
+      'duplicate-of',
+    ]);
+  });
+
+  it('duplicate-of is offered and flagged unimplemented rather than hidden', () => {
+    // The backend answers 501. Hiding the option would misrepresent the vocabulary;
+    // faking success would mark a hold decided while doing nothing.
+    expect(actionSpec('duplicate-of')?.unimplemented).toBe(true);
+    expect(actionSpec('duplicate-of')?.approvable).toBe(true);
+  });
+
+  it('evidenceFacts returns [] when a hold carries no evidence block', () => {
+    expect(evidenceFacts(undefined)).toEqual([]);
+    expect(evidenceFacts({})).toEqual([]);
+    expect(evidenceFacts({ members: 0 })).toEqual([]);
+  });
+
+  it('evidenceFacts surfaces the numbers a reviewer needs', () => {
+    const labels = evidenceFacts({
+      members: 6,
+      durationsKnown: 5,
+      bookLengthMembers: 4,
+      medianKnownSec: 40000,
+      longestKnownSec: 56880,
+      distinctStems: 6,
+      numberedMembers: 6,
+      structure: 'flat',
+    }).map((f) => f.label);
+    expect(labels).toContain('6 members');
+    expect(labels).toContain('5/6 runtimes known');
+    expect(labels).toContain('4 book-length');
+    expect(labels).toContain('longest 15.8 h');
+    expect(labels).toContain('6 distinct titles');
+    expect(labels).toContain('flat');
+  });
+
+  it('evidenceFacts flags the known-runtime gap that blocks a decisive call', () => {
+    // One known runtime among five members is why a recommendation lands on
+    // insufficient-evidence, so that chip has to stand out.
+    const gap = evidenceFacts({ members: 5, durationsKnown: 1 }).find((f) =>
+      f.label.includes('runtimes known')
+    );
+    expect(gap?.warn).toBe(true);
+    const fine = evidenceFacts({ members: 5, durationsKnown: 4 }).find((f) =>
+      f.label.includes('runtimes known')
+    );
+    expect(fine?.warn).toBe(false);
+  });
+
+  it('humanRuntime reads as hours for a book and minutes for a chapter', () => {
+    expect(humanRuntime(56880)).toBe('15.8 h');
+    expect(humanRuntime(2400)).toBe('40 min');
+    expect(humanRuntime(0)).toBe('—');
+    expect(humanRuntime(undefined)).toBe('—');
+  });
+
+  it('labelForAction falls back to the raw value for an unknown action', () => {
+    expect(labelForAction('combine')).toBe('Combine');
+    expect(labelForAction('some-future-action')).toBe('some-future-action');
+    expect(labelForAction(undefined)).toBe('');
   });
 });

--- a/web/src/lib/reviewPayload.ts
+++ b/web/src/lib/reviewPayload.ts
@@ -1,7 +1,7 @@
 // file: web/src/lib/reviewPayload.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 2f9c7b41-6d38-4a05-8e17-0b3d5c9a2e68
-// last-edited: 2026-07-26
+// last-edited: 2026-08-06
 
 // Parsing + shaping for a review-queue item's JSON payload. Kept out of the
 // ReviewQueue component file so these pure helpers are unit-testable and don't trip
@@ -13,6 +13,21 @@
 // multidisc collapses — the parallel discNumbers / trackNumbers arrays (index-aligned
 // with files/memberBookIDs). Snake_case aliases are kept as defensive fallbacks in
 // case a future producer emits a different shape; render only what is present.
+
+/** RecommendationEvidence mirrors itunesservice.RecommendationEvidence — the
+ *  arithmetic behind a recommendation, so a reviewer can CHECK the machine instead
+ *  of trusting it. Every field is optional here because a hold written before
+ *  2026-08-06 carries no evidence block at all. */
+export interface RecommendationEvidence {
+  members?: number;
+  durationsKnown?: number;
+  bookLengthMembers?: number;
+  medianKnownSec?: number;
+  longestKnownSec?: number;
+  distinctStems?: number;
+  numberedMembers?: number;
+  structure?: string;
+}
 
 export interface ReviewPayload {
   folder?: string;
@@ -28,7 +43,195 @@ export interface ReviewPayload {
   files?: string[];
   discNumbers?: number[];
   trackNumbers?: number[];
+  /** What the classifier thinks a human should DO — a REVIEW_ACTION key. Absent on
+   *  every hold written before 2026-08-06; the backend reads that absence as
+   *  "insufficient-evidence" and refuses to approve without an explicit choice. */
+  recommendedAction?: string;
+  /** The one-sentence case for recommendedAction, quoting its own numbers. This is
+   *  what replaces proposedAction, which was the SAME generic string on 762 of 777
+   *  holds. */
+  recommendationReason?: string;
+  recommendationEvidence?: RecommendationEvidence;
   [k: string]: unknown;
+}
+
+/** The closed action vocabulary, mirroring internal/itunes/service's Action*
+ *  constants. `approvable: false` means the backend deliberately 400s it — see
+ *  INSUFFICIENT_EVIDENCE below. */
+export interface ReviewActionSpec {
+  /** The wire value sent as {"action": ...}. */
+  value: string;
+  label: string;
+  /** One line explaining what picking this DOES, shown next to the choice. */
+  description: string;
+  /** Whether a human may approve with it. */
+  approvable: boolean;
+  /** True when the backend accepts the choice but has no implementation and answers
+   *  501. Offered anyway — hiding it would misrepresent the vocabulary, and faking
+   *  success would mark a hold decided while doing nothing. */
+  unimplemented?: boolean;
+  /** True when the action rewrites library rows (and, for combine, hard-deletes the
+   *  absorbed ones). Drives the destructive-action styling. */
+  destructive?: boolean;
+}
+
+export const ACTION_INSUFFICIENT_EVIDENCE = 'insufficient-evidence';
+
+export const REVIEW_ACTIONS: ReviewActionSpec[] = [
+  {
+    value: 'combine',
+    label: 'Combine',
+    description: 'These files are parts of ONE book — merge them into a single audiobook.',
+    approvable: true,
+    destructive: true,
+  },
+  {
+    value: 'separate',
+    label: 'Keep separate',
+    description:
+      'These are already distinct books — leave them apart. Nothing is merged or deleted; ' +
+      'the folder is just marked decided so future scans skip it.',
+    approvable: true,
+  },
+  {
+    value: 'version-group',
+    label: 'Link as editions',
+    description:
+      'Different editions of one work (abridged / unabridged). Links them as a version ' +
+      'group; no file or book row is destroyed.',
+    approvable: true,
+  },
+  {
+    value: 'duplicate-of',
+    label: 'Duplicate of an existing book',
+    description:
+      'Not implemented yet — the duplicate-detection track owns it. Choosing this returns ' +
+      'an error rather than silently marking the hold decided.',
+    approvable: true,
+    unimplemented: true,
+  },
+  {
+    value: ACTION_INSUFFICIENT_EVIDENCE,
+    label: 'Not enough evidence',
+    description:
+      'A statement BY the classifier, not a choice: it cannot tell what these files are. ' +
+      'A human has to decide.',
+    approvable: false,
+  },
+];
+
+const ACTION_BY_VALUE = new Map(REVIEW_ACTIONS.map((a) => [a.value, a]));
+
+export function actionSpec(value: string | undefined): ReviewActionSpec | undefined {
+  return value ? ACTION_BY_VALUE.get(value) : undefined;
+}
+
+/** labelForAction renders an action for display, falling back to the raw string so a
+ *  vocabulary the backend grows before the UI does never shows a blank. */
+export function labelForAction(value: string | undefined): string {
+  if (!value) return '';
+  return ACTION_BY_VALUE.get(value)?.label ?? value;
+}
+
+/** defaultActionFor is what the per-item selector starts on.
+ *
+ *  🔴 IT IS EMPTY WHEN THE RECOMMENDATION IS NOT APPROVABLE. `insufficient-evidence`
+ *  is every hold currently in prod's queue and ~70 of 356 even after a re-scan; the
+ *  backend 400s it on purpose. Pre-selecting anything for those holds would either
+ *  guess `combine` — a merge nobody chose, on precisely the holds with the least
+ *  evidence — or hand the reviewer a button that always fails. Empty means the UI
+ *  must ask. */
+export function defaultActionFor(payload: ReviewPayload | null): string {
+  const rec = payload?.recommendedAction;
+  const spec = actionSpec(rec);
+  return spec?.approvable ? spec.value : '';
+}
+
+/** humanRuntime mirrors the Go reason sentences' formatting (hours for a book,
+ *  minutes for a chapter) so the chips and the reason never disagree about a number. */
+export function humanRuntime(sec: number | undefined): string {
+  if (!sec || sec <= 0) return '—';
+  if (sec >= 3600) return `${(sec / 3600).toFixed(1)} h`;
+  return `${Math.round(sec / 60)} min`;
+}
+
+export interface EvidenceFact {
+  label: string;
+  value: string;
+  /** Longer explanation for a tooltip — what the number means, not just its name. */
+  hint: string;
+  /** True when this fact is the reason a recommendation could not be decisive. */
+  warn?: boolean;
+}
+
+/** evidenceFacts turns the evidence block into the chips a reviewer reads.
+ *
+ *  Returns [] when there is no evidence at all (a pre-2026-08-06 hold), so the UI can
+ *  say "no evidence recorded" rather than render a row of confident-looking zeros. */
+export function evidenceFacts(ev: RecommendationEvidence | undefined): EvidenceFact[] {
+  if (!ev || typeof ev.members !== 'number' || ev.members <= 0) return [];
+  const members = ev.members;
+  const known = ev.durationsKnown ?? 0;
+  const bookLength = ev.bookLengthMembers ?? 0;
+  const facts: EvidenceFact[] = [
+    {
+      label: `${members} member${members === 1 ? '' : 's'}`,
+      value: '',
+      hint: 'Files grouped into this hold.',
+    },
+    {
+      // The gap between known and members is the single most important number here:
+      // an absent runtime is not evidence, and a majority of unknowns is exactly why
+      // a recommendation lands on insufficient-evidence.
+      label: `${known}/${members} runtimes known`,
+      value: '',
+      hint:
+        'Members with a real duration. An absent duration is never treated as evidence, ' +
+        'so a group where most runtimes are unknown cannot get a decisive recommendation.',
+      warn: known * 2 <= members,
+    },
+    {
+      label: `${bookLength} book-length`,
+      value: '',
+      hint:
+        'Members running 90 minutes or more — long enough to BE a book on their own. ' +
+        'A majority here means these are probably separate novels, not chapters.',
+    },
+    {
+      label: `median ${humanRuntime(ev.medianKnownSec)}`,
+      value: '',
+      hint: 'Median runtime across members with a known duration (unknowns excluded).',
+    },
+    {
+      label: `longest ${humanRuntime(ev.longestKnownSec)}`,
+      value: '',
+      hint: 'The longest single member. "15.8 h" reads as "that is a novel" on its own.',
+    },
+  ];
+  if (typeof ev.distinctStems === 'number') {
+    facts.push({
+      label: `${ev.distinctStems} distinct title${ev.distinctStems === 1 ? '' : 's'}`,
+      value: '',
+      hint:
+        'Distinct title stems among the members — the anthology / over-merge signal. ' +
+        'Many distinct titles in one folder means combining would fuse different works.',
+    });
+  }
+  if (typeof ev.numberedMembers === 'number' && ev.numberedMembers > 0) {
+    facts.push({
+      label: `${ev.numberedMembers} numbered`,
+      value: '',
+      hint: 'Members carrying a parseable chapter or track ordinal.',
+    });
+  }
+  if (ev.structure) {
+    facts.push({
+      label: ev.structure,
+      value: '',
+      hint: 'The group\'s dominant physical shape on disk: disc set, chapter run, or flat folder.',
+    });
+  }
+  return facts;
 }
 
 export function parsePayload(raw: string): ReviewPayload | null {

--- a/web/src/pages/ReviewQueue.tsx
+++ b/web/src/pages/ReviewQueue.tsx
@@ -1,21 +1,25 @@
 // file: web/src/pages/ReviewQueue.tsx
-// version: 2.1.0
+// version: 2.2.0
 // guid: 4c8f2a17-5e93-4d60-a1b8-7f3c6d9e0a52
-// last-edited: 2026-08-01
+// last-edited: 2026-08-06
 
 import { useEffect, useMemo, useState } from 'react';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Alert,
+  AlertTitle,
   Avatar,
   Box,
   Button,
   Chip,
   CircularProgress,
   Divider,
+  MenuItem,
   Paper,
   Stack,
+  TextField,
   Tooltip,
   Typography,
   type SxProps,
@@ -25,12 +29,18 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore.js';
 import CheckIcon from '@mui/icons-material/Check.js';
 import CloseIcon from '@mui/icons-material/Close.js';
 import AlbumIcon from '@mui/icons-material/Album.js';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline.js';
 import * as api from '../services/api';
 import { type Book, type ReviewItem } from '../services/api';
 import { useReviewStore } from '../stores/useReviewStore';
 import { useAppStore } from '../stores/useAppStore';
 import { labelForKind } from '../lib/reviewKinds';
 import {
+  REVIEW_ACTIONS,
+  actionSpec,
+  defaultActionFor,
+  evidenceFacts,
+  labelForAction,
   type MemberEntry,
   memberCount,
   memberEntries,
@@ -153,6 +163,214 @@ function MemberRow({
   );
 }
 
+// RecommendationPanel is the part of a hold a reviewer actually reads before
+// deciding: what the classifier recommends, the sentence explaining why, and the
+// NUMBERS that sentence is built from.
+//
+// 🔴 THE NUMBERS ARE THE POINT. Before recommendations, 762 of 777 holds carried the
+// identical `proposedAction` string, which is a queue nobody can work. A reason
+// without its evidence would just be a nicer generic string — the member count, how
+// many runtimes are actually KNOWN, how many members are book-length, and the
+// median/longest runtime are what let a reviewer check the machine rather than
+// trust it. The known-vs-total runtime chip is highlighted when most runtimes are
+// missing, because that gap is exactly why a recommendation lands on
+// "insufficient evidence".
+function RecommendationPanel({
+  recommended,
+  reason,
+  facts,
+}: {
+  recommended: string | undefined;
+  reason: string | undefined;
+  facts: ReturnType<typeof evidenceFacts>;
+}) {
+  const spec = actionSpec(recommended);
+  const undecidable = !spec || !spec.approvable;
+
+  return (
+    <Alert
+      severity={undecidable ? 'warning' : 'info'}
+      icon={undecidable ? <HelpOutlineIcon fontSize="inherit" /> : false}
+      sx={{ mb: 2, '& .MuiAlert-message': { width: '100%' } }}
+    >
+      <AlertTitle sx={{ mb: 0.5 }}>
+        {undecidable
+          ? 'The classifier cannot tell — your decision is required'
+          : `Recommended: ${spec.label}`}
+      </AlertTitle>
+      {reason && (
+        <Typography variant="body2" sx={{ mb: facts.length ? 1 : 0 }}>
+          {reason}
+        </Typography>
+      )}
+      {!reason && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: facts.length ? 1 : 0 }}>
+          This hold predates evidence-backed recommendations. Re-run the regroup scan to
+          refresh it, or decide it here.
+        </Typography>
+      )}
+      {facts.length > 0 ? (
+        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+          {facts.map((f) => (
+            <Tooltip key={f.label} title={f.hint} placement="top">
+              <Chip
+                size="small"
+                label={f.label}
+                color={f.warn ? 'warning' : 'default'}
+                variant={f.warn ? 'filled' : 'outlined'}
+              />
+            </Tooltip>
+          ))}
+        </Stack>
+      ) : (
+        <Typography variant="caption" color="text.secondary">
+          No evidence recorded for this hold.
+        </Typography>
+      )}
+    </Alert>
+  );
+}
+
+// ActionSelector lets a reviewer OVERRIDE the recommendation per item. The chosen
+// action is sent as {"action": "..."} and persisted on the hold, so it survives to
+// the replay that does the real work once review_apply_enabled is on.
+//
+// 🔴 `insufficient-evidence` IS NOT AN OPTION. The backend 400s it deliberately — it
+// is a statement BY the machine, not a decision a human can take — so offering it
+// would be offering a button that always fails. Holds recommending it simply start
+// with nothing selected and Approve stays disabled until a real choice is made,
+// rather than pre-filling a guess (which would be `combine` on precisely the holds
+// with the least evidence).
+function ActionSelector({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+}) {
+  const chosen = actionSpec(value);
+  return (
+    <Stack spacing={0.5} sx={{ minWidth: 260 }}>
+      <TextField
+        select
+        size="small"
+        label="Action"
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        helperText={chosen?.description ?? 'Choose what should happen to these files.'}
+      >
+        <MenuItem value="">
+          <em>Choose an action…</em>
+        </MenuItem>
+        {REVIEW_ACTIONS.filter((a) => a.approvable).map((a) => (
+          <MenuItem key={a.value} value={a.value}>
+            {a.label}
+            {a.unimplemented && ' (not implemented)'}
+          </MenuItem>
+        ))}
+      </TextField>
+    </Stack>
+  );
+}
+
+// ItemActions is the action selector plus the Approve/Reject pair for one hold.
+//
+// Rendered TWICE per item — above and below the member-file list — because a
+// multi-disc hold can list dozens of files, and with the buttons only at the bottom
+// you had to scroll the whole listing to act on something you decided about after
+// reading the first line. Both copies read the same resolved `action` prop, so
+// changing the selector at the top is exactly what the bottom Approve sends.
+//
+// 🔴 Module scope, not inline in ReviewQueue. A component declared inside the parent
+// render is a NEW component type on every render, so React unmounts and remounts its
+// subtree — which would slam the action dropdown shut whenever anything else on the
+// page updated. The buttons this replaced were stateless and got away with it; a
+// select is not.
+//
+// Approve is DISABLED with no action selected. That is the whole insufficient-evidence
+// story on the client: those holds start empty (defaultActionFor) and stay
+// un-approvable until a human names something, matching the backend's deliberate 400.
+function ItemActions({
+  item,
+  action,
+  busy,
+  withSelector,
+  onApprove,
+  onReject,
+  onActionChange,
+  sx,
+}: {
+  item: ReviewItem;
+  action: string;
+  busy: boolean;
+  /** The selector is rendered once (top). The bottom copy shows the resolved action
+   *  read-only, so a reviewer who scrolled past a long listing can still see what
+   *  Approve is about to do without a second control drifting out of sync. */
+  withSelector?: boolean;
+  onApprove: (item: ReviewItem) => void;
+  onReject: (item: ReviewItem) => void;
+  onActionChange: (id: string, value: string) => void;
+  sx?: SxProps<Theme>;
+}) {
+  const spec = actionSpec(action);
+  return (
+    <Stack direction="row" spacing={1.5} alignItems="flex-start" flexWrap="wrap" useFlexGap sx={sx}>
+      {withSelector ? (
+        <ActionSelector
+          value={action}
+          disabled={busy}
+          onChange={(v) => onActionChange(item.id, v)}
+        />
+      ) : (
+        action && (
+          <Chip
+            size="small"
+            variant="outlined"
+            color={spec?.destructive ? 'warning' : 'default'}
+            label={`Will ${labelForAction(action).toLowerCase()}`}
+          />
+        )
+      )}
+      <Stack direction="row" spacing={1} sx={{ mt: withSelector ? 0.5 : 0 }}>
+        <Tooltip
+          title={
+            action
+              ? ''
+              : 'Pick an action first — this hold has no recommendation the system is willing to act on.'
+          }
+        >
+          {/* span so the Tooltip still fires on a disabled Button */}
+          <span>
+            <Button
+              size="small"
+              variant="contained"
+              color={spec?.destructive ? 'warning' : 'success'}
+              startIcon={<CheckIcon />}
+              disabled={busy || !action}
+              onClick={() => onApprove(item)}
+            >
+              Approve
+            </Button>
+          </span>
+        </Tooltip>
+        <Button
+          size="small"
+          variant="outlined"
+          color="error"
+          startIcon={<CloseIcon />}
+          disabled={busy}
+          onClick={() => onReject(item)}
+        >
+          Reject
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
 // MemberFilesDetail renders a review item's payload header plus a rich per-member
 // list. It fetches the member books lazily (it only mounts when the accordion is
 // expanded, via unmountOnExit) so opening the queue never fans out hundreds of
@@ -161,7 +379,6 @@ function MemberFilesDetail({ item }: { item: ReviewItem }) {
   const pathVars = usePathVars();
   const payload = useMemo(() => parsePayload(item.payload), [item.payload]);
   const folder = payload?.folder ?? item.folder_ref;
-  const proposed = payload?.proposedAction ?? payload?.proposed_action;
   const title = payload?.survivorTitle ?? payload?.derived_title ?? payload?.title;
   const confidence =
     typeof payload?.confidence === 'string'
@@ -201,11 +418,6 @@ function MemberFilesDetail({ item }: { item: ReviewItem }) {
         {title && (
           <Typography variant="body2">
             <strong>Proposed title:</strong> {title}
-          </Typography>
-        )}
-        {proposed && (
-          <Typography variant="body2">
-            <strong>Proposed action:</strong> {proposed}
           </Typography>
         )}
         <Stack direction="row" spacing={1} alignItems="center">
@@ -252,6 +464,20 @@ export function ReviewQueue() {
   const [busyItems, setBusyItems] = useState<Set<string>>(new Set());
   const [busyKinds, setBusyKinds] = useState<Set<string>>(new Set());
 
+  // Per-item chosen action. Keyed by item id and populated lazily: an id absent from
+  // this map has not been touched by the reviewer, so it falls back to the hold's own
+  // recommendation (or to "" when that recommendation is not approvable). Keeping the
+  // overrides here rather than in each row means the two ItemActions rendered per item
+  // — above and below the file list — always agree about what Approve will send.
+  const [chosenActions, setChosenActions] = useState<Record<string, string>>({});
+
+  // The last bulk run's skipped items, kept on screen until the next bulk action.
+  // A toast is the wrong home for these: the whole point is that a reviewer can go
+  // deal with them, which means the ids have to stay readable.
+  const [bulkSkips, setBulkSkips] = useState<
+    { kind: string; skipped: api.ReviewBulkSkip[] } | null
+  >(null);
+
   useEffect(() => {
     void loadItems({ status: 'pending' });
   }, [loadItems]);
@@ -274,16 +500,32 @@ export function ReviewQueue() {
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [items]);
 
+  // actionFor resolves what Approve will send for one item: the reviewer's explicit
+  // pick if they made one, else the hold's own approvable recommendation, else "" —
+  // which disables Approve rather than guessing.
+  const actionFor = (item: ReviewItem): string => {
+    const override = chosenActions[item.id];
+    if (override !== undefined) return override;
+    return defaultActionFor(parsePayload(item.payload));
+  };
+
   const handleItemAction = async (item: ReviewItem, action: 'approve' | 'reject') => {
     setBusyItems((prev) => new Set(prev).add(item.id));
     try {
       if (action === 'approve') {
-        await api.approveReviewItem(item.id);
+        // Always send the resolved action explicitly. The backend would accept an
+        // empty body and use the recommendation, but sending what the UI actually
+        // displayed removes any chance of the two disagreeing.
+        await api.approveReviewItem(item.id, actionFor(item));
       } else {
         await api.rejectReviewItem(item.id);
       }
       await refresh();
     } catch (err) {
+      // The backend's own message is surfaced verbatim. That matters most for
+      // `duplicate-of`, which answers 501 with an explanation of who owns it: a
+      // generic "failed to approve" would hide a refusal the reviewer needs to read,
+      // and pretending it succeeded would mark the hold decided while doing nothing.
       addNotification(
         `Failed to ${action} item: ${err instanceof Error ? err.message : 'unknown error'}`,
         'error'
@@ -297,16 +539,27 @@ export function ReviewQueue() {
     }
   };
 
+  const handleApprove = (item: ReviewItem) => void handleItemAction(item, 'approve');
+  const handleReject = (item: ReviewItem) => void handleItemAction(item, 'reject');
+  const handleActionChange = (id: string, value: string) =>
+    setChosenActions((prev) => ({ ...prev, [id]: value }));
+
   const handleBulkAction = async (kind: string, action: 'approve' | 'reject') => {
     setBusyKinds((prev) => new Set(prev).add(kind));
     try {
       const result = await api.bulkReviewAction({ action, kind });
+      const skipped = result.skipped ?? [];
+      // 🔴 REPORT THE SKIPS IN THE SAME BREATH AS THE SUCCESSES. Bulk approve runs
+      // each item's OWN recommendation and refuses the undecidable ones; a message
+      // quoting only `processed` would let a reviewer believe a bucket was cleared
+      // when a third of it is still sitting there.
       addNotification(
         `${action === 'approve' ? 'Approved' : 'Rejected'} ${result.processed} item${
           result.processed === 1 ? '' : 's'
-        }`,
-        'success'
+        }${skipped.length ? ` · ${skipped.length} skipped, listed below` : ''}`,
+        skipped.length ? 'warning' : 'success'
       );
+      setBulkSkips(skipped.length ? { kind, skipped } : null);
       await refresh();
     } catch (err) {
       addNotification(
@@ -321,43 +574,6 @@ export function ReviewQueue() {
       });
     }
   };
-
-  // Approve/Reject pair for a single item. Defined here rather than at module
-  // scope so it closes over handleItemAction; rendered twice per item (above and
-  // below the member-file list) so the decision is reachable without scrolling
-  // past a long multi-disc listing.
-  const ItemActions = ({
-    item,
-    busy,
-    sx,
-  }: {
-    item: ReviewItem;
-    busy: boolean;
-    sx?: SxProps<Theme>;
-  }) => (
-    <Stack direction="row" spacing={1} sx={sx}>
-      <Button
-        size="small"
-        variant="contained"
-        color="success"
-        startIcon={<CheckIcon />}
-        disabled={busy}
-        onClick={() => handleItemAction(item, 'approve')}
-      >
-        Approve
-      </Button>
-      <Button
-        size="small"
-        variant="outlined"
-        color="error"
-        startIcon={<CloseIcon />}
-        disabled={busy}
-        onClick={() => handleItemAction(item, 'reject')}
-      >
-        Reject
-      </Button>
-    </Stack>
-  );
 
   return (
     <Box>
@@ -403,16 +619,20 @@ export function ReviewQueue() {
                     <Chip size="small" label={bucket.items.length} />
                   </Box>
                   <Stack direction="row" spacing={1}>
-                    <Button
-                      size="small"
-                      variant="contained"
-                      color="success"
-                      startIcon={<CheckIcon />}
-                      disabled={kindBusy}
-                      onClick={() => handleBulkAction(bucket.kind, 'approve')}
-                    >
-                      Approve all
-                    </Button>
+                    <Tooltip title="Approves each hold with ITS OWN recommendation — there is no batch-wide action. Holds the classifier could not decide are skipped and listed, not approved.">
+                      <span>
+                        <Button
+                          size="small"
+                          variant="contained"
+                          color="success"
+                          startIcon={<CheckIcon />}
+                          disabled={kindBusy}
+                          onClick={() => handleBulkAction(bucket.kind, 'approve')}
+                        >
+                          Approve all
+                        </Button>
+                      </span>
+                    </Tooltip>
                     <Button
                       size="small"
                       variant="outlined"
@@ -425,9 +645,40 @@ export function ReviewQueue() {
                     </Button>
                   </Stack>
                 </Box>
+                {bulkSkips?.kind === bucket.kind && (
+                  <Alert
+                    severity="warning"
+                    sx={{ mb: 1 }}
+                    onClose={() => setBulkSkips(null)}
+                  >
+                    <AlertTitle>
+                      {bulkSkips.skipped.length} hold
+                      {bulkSkips.skipped.length === 1 ? ' was' : 's were'} skipped — still
+                      pending
+                    </AlertTitle>
+                    <Typography variant="body2" sx={{ mb: 1 }}>
+                      Bulk approve uses each hold&apos;s own recommendation. These had none it
+                      would act on, so they were left alone. Open them below and choose an
+                      action.
+                    </Typography>
+                    <Stack spacing={0.5}>
+                      {bulkSkips.skipped.map((s) => (
+                        <Typography key={s.id} variant="caption" display="block">
+                          <code>{s.id}</code>
+                          {s.action ? ` · ${labelForAction(s.action) || s.action}` : ''} — {s.reason}
+                        </Typography>
+                      ))}
+                    </Stack>
+                  </Alert>
+                )}
                 <Divider sx={{ mb: 1 }} />
                 {bucket.items.map((item) => {
                   const itemBusy = busyItems.has(item.id);
+                  const payload = parsePayload(item.payload);
+                  const action = actionFor(item);
+                  const recommended = payload?.recommendedAction;
+                  const recSpec = actionSpec(recommended);
+                  const needsHuman = !recSpec || !recSpec.approvable;
                   return (
                     <Accordion
                       key={item.id}
@@ -435,11 +686,40 @@ export function ReviewQueue() {
                       slotProps={{ transition: { unmountOnExit: true } }}
                     >
                       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography variant="body2" sx={{ flexGrow: 1 }}>
-                          {item.summary || item.folder_ref || item.id}
-                        </Typography>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          alignItems="center"
+                          sx={{ flexGrow: 1, minWidth: 0 }}
+                        >
+                          <Typography variant="body2" noWrap sx={{ flexGrow: 1, minWidth: 0 }}>
+                            {item.summary || item.folder_ref || item.id}
+                          </Typography>
+                          {/* The recommendation is shown COLLAPSED so a reviewer can
+                              triage a bucket without opening every row. An
+                              undecidable hold is flagged rather than hidden: those
+                              are the ones that need a person, and they are the
+                              majority of the current queue. */}
+                          <Chip
+                            size="small"
+                            label={
+                              needsHuman
+                                ? 'Needs a decision'
+                                : `Rec: ${labelForAction(recommended)}`
+                            }
+                            color={
+                              needsHuman ? 'warning' : recSpec?.destructive ? 'default' : 'info'
+                            }
+                            variant="outlined"
+                          />
+                        </Stack>
                       </AccordionSummary>
                       <AccordionDetails>
+                        <RecommendationPanel
+                          recommended={recommended}
+                          reason={payload?.recommendationReason}
+                          facts={evidenceFacts(payload?.recommendationEvidence)}
+                        />
                         {/*
                           Actions are rendered ABOVE the detail as well as below it.
                           A multi-disc item can list dozens of member files, so with
@@ -450,9 +730,26 @@ export function ReviewQueue() {
                           are — the top pair for a quick call, the bottom pair for
                           when you have actually read to the end.
                         */}
-                        <ItemActions item={item} busy={itemBusy} sx={{ mb: 2 }} />
+                        <ItemActions
+                          item={item}
+                          action={action}
+                          busy={itemBusy}
+                          withSelector
+                          onApprove={handleApprove}
+                          onReject={handleReject}
+                          onActionChange={handleActionChange}
+                          sx={{ mb: 2 }}
+                        />
                         <MemberFilesDetail item={item} />
-                        <ItemActions item={item} busy={itemBusy} sx={{ mt: 2 }} />
+                        <ItemActions
+                          item={item}
+                          action={action}
+                          busy={itemBusy}
+                          onApprove={handleApprove}
+                          onReject={handleReject}
+                          onActionChange={handleActionChange}
+                          sx={{ mt: 2 }}
+                        />
                       </AccordionDetails>
                     </Accordion>
                   );

--- a/web/src/pages/__tests__/ReviewQueue.recommendations.test.tsx
+++ b/web/src/pages/__tests__/ReviewQueue.recommendations.test.tsx
@@ -1,0 +1,188 @@
+// file: web/src/pages/__tests__/ReviewQueue.recommendations.test.tsx
+// version: 1.0.0
+// guid: 0d7a3e51-6c92-4b48-a05f-8e1c2d6b9f34
+// last-edited: 2026-08-06
+
+// Owner items 1+2 on the client: the queue shows WHY each hold exists (reason +
+// evidence numbers), and lets a human override the machine per item.
+//
+// The assertions that matter are the refusals — an insufficient-evidence hold must
+// not offer a working Approve, and an override must be what actually goes on the
+// wire. Both are places where a plausible-looking UI would quietly do the wrong
+// thing: pre-filling `combine` on a hold with no evidence, or showing "separate" and
+// posting nothing.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { ReviewQueue } from '../ReviewQueue';
+import { useReviewStore } from '../../stores/useReviewStore';
+import * as api from '../../services/api';
+
+function mkItem(id: string, payload: Record<string, unknown>): api.ReviewItem {
+  return {
+    id,
+    kind: 'regroup.multidisc',
+    dedup_key: `dk-${id}`,
+    folder_ref: `/books/${id}`,
+    status: 'pending',
+    summary: `hold ${id}`,
+    payload: JSON.stringify(payload),
+    created_at: '2026-08-06T00:00:00Z',
+    updated_at: '2026-08-06T00:00:00Z',
+  };
+}
+
+// A decisive hold: the classifier says separate and shows its arithmetic.
+const decisive = mkItem('itm-decisive', {
+  folder: '/books/series',
+  recommendedAction: 'separate',
+  recommendationReason:
+    'a strict majority of members (4 of 5 known runtimes) are book-length; the longest runs 15.8 h',
+  recommendationEvidence: {
+    members: 5,
+    durationsKnown: 5,
+    bookLengthMembers: 4,
+    medianKnownSec: 40000,
+    longestKnownSec: 56880,
+    distinctStems: 5,
+    numberedMembers: 5,
+    structure: 'flat',
+  },
+});
+
+// The shape of every hold currently in prod's queue: no recommendation at all.
+const undecidable = mkItem('itm-old', { folder: '/books/old' });
+
+function seedQueue(items: api.ReviewItem[]) {
+  useReviewStore.setState({
+    count: items.length,
+    byKind: { 'regroup.multidisc': items.length },
+    items,
+    itemsLoading: false,
+    _pollTimer: null,
+    loadItems: vi.fn().mockResolvedValue(undefined),
+    loadCount: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+/** openHold expands a hold's accordion and returns its details region. */
+function openHold(summary: string) {
+  fireEvent.click(screen.getByText(summary));
+  return screen.getByText(summary).closest('.MuiAccordion-root') as HTMLElement;
+}
+
+describe('ReviewQueue recommendations', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the per-hold reason instead of one generic string', () => {
+    seedQueue([decisive]);
+    renderWithProviders(<ReviewQueue />);
+    openHold('hold itm-decisive');
+    expect(screen.getByText(/the longest runs 15.8 h/)).toBeInTheDocument();
+    expect(screen.getByText(/Recommended: Keep separate/)).toBeInTheDocument();
+  });
+
+  it('shows the evidence numbers, not just the reason', () => {
+    // A reason without its arithmetic is just a nicer generic string.
+    seedQueue([decisive]);
+    renderWithProviders(<ReviewQueue />);
+    const hold = openHold('hold itm-decisive');
+    expect(within(hold).getByText('5 members')).toBeInTheDocument();
+    expect(within(hold).getByText('5/5 runtimes known')).toBeInTheDocument();
+    expect(within(hold).getByText('4 book-length')).toBeInTheDocument();
+    expect(within(hold).getByText('median 11.1 h')).toBeInTheDocument();
+    expect(within(hold).getByText('longest 15.8 h')).toBeInTheDocument();
+    expect(within(hold).getByText('5 distinct titles')).toBeInTheDocument();
+  });
+
+  it('flags an undecidable hold in the collapsed row so a bucket can be triaged', () => {
+    seedQueue([undecidable]);
+    renderWithProviders(<ReviewQueue />);
+    expect(screen.getByText('Needs a decision')).toBeInTheDocument();
+  });
+
+  // 🔴 The backend 400s `insufficient-evidence` on purpose. Offering an Approve that
+  // always fails — or, worse, pre-filling `combine` on the hold with the least
+  // evidence — is the failure this asserts against.
+  it('disables Approve on an insufficient-evidence hold until an action is picked', async () => {
+    const approve = vi.spyOn(api, 'approveReviewItem').mockResolvedValue(undecidable);
+    seedQueue([undecidable]);
+    renderWithProviders(<ReviewQueue />);
+    const hold = openHold('hold itm-old');
+
+    const approveButtons = within(hold).getAllByRole('button', { name: /approve/i });
+    approveButtons.forEach((b) => expect(b).toBeDisabled());
+    expect(approve).not.toHaveBeenCalled();
+
+    // Choosing an action unlocks it, and that action is what is sent.
+    fireEvent.mouseDown(within(hold).getByLabelText('Action'));
+    fireEvent.click(await screen.findByRole('option', { name: /combine/i }));
+    await waitFor(() =>
+      expect(within(hold).getAllByRole('button', { name: /approve/i })[0]).toBeEnabled()
+    );
+    fireEvent.click(within(hold).getAllByRole('button', { name: /approve/i })[0]);
+    await waitFor(() => expect(approve).toHaveBeenCalledWith('itm-old', 'combine'));
+  });
+
+  it('sends the recommendation when the reviewer does not override it', async () => {
+    const approve = vi.spyOn(api, 'approveReviewItem').mockResolvedValue(decisive);
+    seedQueue([decisive]);
+    renderWithProviders(<ReviewQueue />);
+    const hold = openHold('hold itm-decisive');
+    fireEvent.click(within(hold).getAllByRole('button', { name: /approve/i })[0]);
+    await waitFor(() => expect(approve).toHaveBeenCalledWith('itm-decisive', 'separate'));
+  });
+
+  // 🔴 OWNER ITEM 2 ON THE CLIENT. What the selector shows must be what the request
+  // carries; a UI that displayed the override and posted the recommendation would be
+  // worse than not offering the override at all.
+  it('sends the OVERRIDE, not the recommendation, when the reviewer changes it', async () => {
+    const approve = vi.spyOn(api, 'approveReviewItem').mockResolvedValue(decisive);
+    seedQueue([decisive]);
+    renderWithProviders(<ReviewQueue />);
+    const hold = openHold('hold itm-decisive');
+
+    fireEvent.mouseDown(within(hold).getByLabelText('Action'));
+    fireEvent.click(await screen.findByRole('option', { name: /^Combine$/ }));
+    fireEvent.click(within(hold).getAllByRole('button', { name: /approve/i })[0]);
+    await waitFor(() => expect(approve).toHaveBeenCalledWith('itm-decisive', 'combine'));
+  });
+
+  it('never offers insufficient-evidence as a choice', async () => {
+    seedQueue([decisive]);
+    renderWithProviders(<ReviewQueue />);
+    const hold = openHold('hold itm-decisive');
+    fireEvent.mouseDown(within(hold).getByLabelText('Action'));
+    const options = (await screen.findAllByRole('option')).map((o) => o.textContent);
+    expect(options).not.toContain('Not enough evidence');
+    // duplicate-of IS offered — the backend 501s it, and hiding it would misrepresent
+    // the vocabulary while faking success would mark a hold decided doing nothing.
+    expect(options.some((o) => o?.includes('Duplicate of an existing book'))).toBe(true);
+  });
+
+  // 🔴 A bulk action that silently skips items is how a reviewer thinks they cleared
+  // a queue they did not.
+  it('surfaces the ids a bulk approve skipped', async () => {
+    vi.spyOn(api, 'bulkReviewAction').mockResolvedValue({
+      action: 'approve',
+      processed: 1,
+      approved: ['itm-decisive'],
+      skipped: [
+        {
+          id: 'itm-old',
+          action: 'insufficient-evidence',
+          reason: 'this hold recommends insufficient-evidence',
+        },
+      ],
+    });
+    seedQueue([decisive, undecidable]);
+    renderWithProviders(<ReviewQueue />);
+
+    fireEvent.click(screen.getByRole('button', { name: /approve all/i }));
+    expect(await screen.findByText(/1 hold was skipped — still pending/)).toBeInTheDocument();
+    expect(screen.getByText('itm-old')).toBeInTheDocument();
+  });
+});

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,7 +1,7 @@
 // file: web/src/services/api.ts
-// version: 2.53.0
+// version: 2.54.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
-// last-edited: 2026-07-13
+// last-edited: 2026-08-06
 
 // API service layer for audiobook-organizer backend
 // Provides typed functions for all backend endpoints
@@ -5822,6 +5822,11 @@ export interface ReviewItem {
   payload: string;
   created_at: string;
   updated_at: string;
+  /** The action a HUMAN chose when approving, which may disagree with the payload's
+   *  recommendedAction. Empty while pending, and empty on holds decided before
+   *  2026-08-06. The replay path prefers it over the recommendation, so this is the
+   *  durable record that an override happened. */
+  chosen_action?: string;
 }
 
 /** GET /review/count → data.{count, byKind}. Both cover PENDING items only. */
@@ -5847,14 +5852,28 @@ export interface ReviewItemsFilter {
   offset?: number;
 }
 
+/** One item a bulk approve REFUSED to act on. Bulk approve uses each item's own
+ *  recommendation, so a hold whose recommendation is undecidable (or unimplemented)
+ *  is skipped and the batch continues. */
+export interface ReviewBulkSkip {
+  id: string;
+  /** The action that was refused — usually "insufficient-evidence". */
+  action: string;
+  reason: string;
+}
+
 /** POST /review/bulk → data.{action, processed, ...id buckets}. Note: the
- *  backend reports `processed`, NOT an `affected` count. */
+ *  backend reports `processed`, NOT an `affected` count.
+ *
+ *  🔴 `skipped` MUST BE SURFACED. A bulk approve that silently drops items is how a
+ *  reviewer believes they cleared a queue they did not. */
 export interface ReviewBulkResult {
   action: string;
   approved?: string[];
   applied?: string[];
   rejected?: string[];
   not_found?: string[];
+  skipped?: ReviewBulkSkip[];
   processed: number;
 }
 
@@ -5896,9 +5915,21 @@ export async function getReviewItems(filter: ReviewItemsFilter = {}): Promise<Re
   };
 }
 
-export async function approveReviewItem(id: string): Promise<ReviewItem> {
+/** approveReviewItem approves a hold, optionally OVERRIDING its recommended action.
+ *
+ *  Omitting `action` means "do what the hold recommends" — but the backend refuses to
+ *  default an `insufficient-evidence` hold (400), which is every hold written before
+ *  2026-08-06, so the UI must send an explicit choice for those. The chosen action is
+ *  persisted on the item, so an override survives to the later replay.
+ *
+ *  Errors carry the backend's own message (buildApiError reads `error`), which is how
+ *  the 501 for `duplicate-of` reaches the reviewer intact instead of as "failed". */
+export async function approveReviewItem(id: string, action?: string): Promise<ReviewItem> {
   const response = await apiFetch(`${API_BASE}/review/items/${encodeURIComponent(id)}/approve`, {
     method: 'POST',
+    ...(action
+      ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ action }) }
+      : {}),
   });
   if (!response.ok) {
     throw await buildApiError(response, 'Failed to approve review item');


### PR DESCRIPTION
Closes owner items 1 and 2.

## The problem

`proposedAction` was one generic string on **762 of 777** holds:

> review: flat folder shares a title but ordering is unclear

A queue where every row says the same thing is a queue nobody can work.

## Why it said that, and why it can stop now

The signal that separates "six chapters" from "six books" is member runtime. The check existed and was correct — but `DurationSec` was zero for **97.5%** of the queue, so it never fired and the classifier fell back to the folder name.

The 2026-08-05 relink populated `book_file` rows for 16.0k books. Measured across all 356 pending holds (1,831 member books probed via the API, every request asserting HTTP 200): **1,593 members now have a real summed duration.** The evidence had arrived; the queue was not using it.

Applying the codebase's own `membersAreBookLength` rule (strict majority ≥ `bookLengthSec`):

| kind | shape | holds | recommendation |
|---|---|---|---|
| ambiguous | majority ≥90m | 137 | `separate` |
| ambiguous | all <90m | 24 | `combine` |
| multidisc | all fragments | 121 | `combine` |
| **multidisc** | **majority ≥90m** | **3** | **`separate`** |
| any | no/partial evidence | 71 | `insufficient-evidence` |

**286 of 356 holds get a decisive recommendation.**

## What each hold now carries

`RecommendedAction`, `RecommendationReason`, and a `RecommendationEvidence` block (members, runtimes known, book-length count, median/longest runtime, distinct stems, numbered count, structure). The reason names its numbers — *"7 of 9 members run 90 min or longer (longest 15.8 h) — each is book-length, so these are separate books, not parts of one."* Evidence is what makes the queue workable; a reason alone is a nicer generic string.

## Guards

- **Absent duration NEVER yields `combine`.** A strict majority must have a known runtime before any decisive call, so one known runtime among five unknowns cannot carry a group.
- **Groups spanning several file-path folders glued only by a shared iTunes album** are `insufficient-evidence`. `classifyGroup` already declines to vouch for that grouping; a recommender reasoning purely about runtimes would have answered `combine`. Short runtimes are evidence about what members *are*, not that they *belong together*.
- **`KindVersionGroup` overrides runtime with `version-group`.** Both editions of one work are book-length, so runtime alone says `separate` — which, once dispatch keys on the action, would strand `ApplyVersionGroup` behind an action nothing routes to. The one apply path that destroys nothing would become the one that never runs.
- Reuses `bookLengthSec` / `membersAreBookLength`. No second threshold.

## The override, and the data-loss path it closed

Dispatch now keys on the **chosen** action, not `item.Kind`. `ApproveReviewItem` takes an optional `{"action": "..."}`; absent defaults to the recommendation, present overrides. Unknown → 400. `insufficient-evidence` as an approval target → 400 (it is a statement by the machine, not a choice). `duplicate-of` → 501, surfaced honestly rather than faked.

🔴 **The chosen action was originally stored nowhere.** `SetReviewItemStatus` wrote status only, and `ReplayApprovedItems` re-derived the action from the payload's `recommendedAction`. So a `combine` hold overridden to `separate` would be recorded as plain `approved` and later **replayed as `combine`** — hard-deleting rows for books a human explicitly said to keep apart. The override would have *looked* like it worked; the destruction would land on a later replay, disconnected from the click.

Fixed by persisting the decision: `ReviewItem.ChosenAction` plus `SetReviewItemDecision(id, status, chosenAction)`, writing status and action in **one Pebble batch** — split across two writes, a crash between them leaves `approved` with no action and replay falls back to the payload, which is the bug again.

Write safety: the store **re-reads the record internally** rather than marshalling the caller's copy, so a handler holding a stale item cannot roll back `Payload`/`Summary`; exactly three fields are assigned; an empty `chosenAction` means "leave alone", never "clear". Nothing clears it.

`effectiveActionFor` resolves persisted-then-payload, and **both** `approveOne` and `ReplayApprovedItems` route through it so they cannot disagree about a row.

**The replay tests are a pair, and either alone passes vacuously:**
- recommends `combine`, overridden to `separate` → replay must **not** merge
- recommends `separate`, overridden to `combine` → replay must merge **exactly once**

Mutation-tested by reverting `effectiveActionFor` → `recommendedActionFor`: **both fail**, with `replay used the RECOMMENDATION and merged books a human explicitly said to keep apart`.

## Blast radius, deliberate

Under `Kind` dispatch, `regroup.ambiguous` had no handler and could never merge. Keyed by action, an ambiguous hold recommending `combine` (24 of 356) now reaches `ApplyMultidisc`. Intended, flagged at the registration site, and covered by `TestApprove_AmbiguousRecommendingCombine_NowCombines`. **Read this before flipping owner item 3.**

## Bulk approve

No batch-wide action — one action over a heterogeneous batch is the exact footgun this removes (a batch `combine` over multidisc would merge the 3 near-misses). Bulk uses each item's own recommendation and returns a `skipped: [{id, action, reason}]` list, rendered persistently rather than as a toast count.

## `review_apply_enabled`

Untouched, still **OFF**, no bypass. `TestApprove_ApplyGateOff_OverrideRecordsButDoesNotApply` asserts the override is accepted, persists, and executes nothing.

## Verification

```
go build ./...                                                   exit 0
go vet ./...                                                     exit 0
go test ./internal/server/handlers/review/... ./internal/plugins/maintenance/... ./internal/itunes/... -race
  ok  handlers/review 16.388s · maintenance 27.413s · itunes 10.045s · itunes/service 23.509s
go test -short ./...        109 packages ok, 0 FAIL
make web-build / web-test   ✅ · 63 files, 421 tests passed
make web-lint               ✅ 0 errors
make mocks-check            ✅ up to date
```

**e2e not run** — `unknown parameter "_page"` is pre-existing on `main` and this branch touches zero files under `web/tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp