### PR TITLE
docs: reconcile TODO.md with what shipped, record six session findings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.16.3 -->
+<!-- version: 10.17.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-06 -->
 
@@ -271,10 +271,32 @@ into one of the curated sections below, is a normal direct edit.
 <!-- guid: 4e91b7c2-06d8-4a35-9f17-b3820e5cd641 -->
 <!-- last-edited: 2026-08-05 -->
 
-- [ ] **Give review holds a real recommendation, and let the human override it**
-  — owner items 1 and 2 (2026-08-05). Two halves of one change; building the
-  recommendation as a string first and bolting override on later means rewriting
-  the first half.
+- [x] **Give review holds a real recommendation, and let the human override it**
+  — owner items 1 and 2 (2026-08-05, shipped 2026-08-06 in PR #2163). Two halves
+  of one change, done together as planned.
+
+  **Outcome.** 286 of 356 pending holds now carry a decisive recommendation with
+  the numbers behind it. The prerequisite this entry warned about turned out to
+  be already met: the 2026-08-05 relink populated `book_file` rows, and a probe
+  of all 1,831 member books found 1,593 with a real summed duration. The queue's
+  item count had barely moved (367 → 356), which read like nothing had changed —
+  but the *evidence* had arrived and the classifier simply was not using it.
+
+  🔴 **A data-loss path was found and closed on the way.** The chosen action was
+  originally stored nowhere: `SetReviewItemStatus` wrote status only, and
+  `ReplayApprovedItems` re-derived the action from the payload's
+  `recommendedAction`. A `combine` hold overridden to `separate` would have been
+  recorded as plain `approved` and later **replayed as `combine`**, hard-deleting
+  rows for books a human explicitly said to keep apart — with nothing connecting
+  the destruction back to the click. Fixed by persisting the decision
+  (`ReviewItem.ChosenAction` + `SetReviewItemDecision`, status and action in one
+  Pebble batch). Two paired replay tests pin it, and both fail under mutation.
+
+  ⚠️ **Read before flipping [[multidisc-apply-canary]].** Dispatch now keys on
+  the chosen action rather than `Kind`. Under `Kind` dispatch `regroup.ambiguous`
+  had no handler and could never merge; now an ambiguous hold recommending
+  `combine` (24 of 356) reaches `ApplyMultidisc`. Intended, but it widens the
+  blast radius of turning `review_apply_enabled` on.
 
   **The problem.** `proposedAction` is one generic string on **762 of 777** holds
   ("review: flat folder shares a title but ordering is unclear") and
@@ -501,9 +523,24 @@ into one of the curated sections below, is a normal direct edit.
   endpoint does not populate it.
 
 - [ ] **Remaining after the first apply:** 1,019 directory-shaped books held for
-  review (see [[first-aid-library-validate-repair]] tier-2 duration probe) and 93
-  missing reported only (already `reconcile-scan`'s remit; some may be offline
-  mounts rather than deleted audio).
+  review and 93 missing reported only (already `reconcile-scan`'s remit; some may
+  be offline mounts rather than deleted audio).
+
+  **The tier-2 probe now exists and has been measured** — `maintenance.probe-directory-books`,
+  PR #2162, dry-run against production 2026-08-06 (op `01KZC8A30Z22B81R8NKDHBFZFX`):
+
+  ```
+  examined=1019  actioned=0  skipped=1019  errors=0
+  actions: link=434  review=585
+  ```
+
+  **434 of the 1,019 are confidently linkable.** They were in review only because
+  `classifyUnlinked` passed `nil` durations, so `ClassifyDir`'s series guard could
+  never fire — the classifier existed and was correct, it was simply being called
+  with the one argument that disables it. 585 correctly remain in review.
+
+  What is left here is the **apply**, which needs a human gate. The 93 missing are
+  untouched by this and stay with `reconcile-scan`.
 
 - [ ] **Re-run `regroup-shattered-ai` after relink and re-measure the queue.**
   With durations present the series-guard becomes live for the first time across
@@ -572,8 +609,38 @@ into one of the curated sections below, is a normal direct edit.
 <!-- guid: 8333f42a-bd0d-4a2f-8221-403d11576e7c -->
 <!-- last-edited: 2026-08-04 -->
 
-- [ ] **PERF: `maintenance.dedupe-book-file-rows` spends ~45 seconds per book, and
+- [x] **PERF: `maintenance.dedupe-book-file-rows` spends ~45 seconds per book, and
       that is enough to blow its own 2-hour timeout.**
+      RESOLVED 2026-08-06 in PR #2161 — but almost every premise below was wrong,
+      so read this correction before trusting the analysis that follows it.
+
+      **It never hit the 2-hour `Timeout`.** It hit the 5-minute `ProgressTimeout`
+      watchdog, at book 19/194. Both liveness bugs were already fixed on main
+      (heartbeat `1908396b`, worker pool `df20b8d6`).
+
+      **Total work is ~1.3 h, not 2.4 h.** Real denominator from the scan line:
+      `redundant_rows=2901` across 194 books. The "194 × 45 s" extrapolation
+      double-counted skew — books process in sorted-ID order and the first 19
+      happened to carry 22–47 duplicates against a mean of 15.
+
+      **The unit is per-ROW, not per-book:** ~1.35 s fixed per deleted row, +~7 ms
+      per remaining file. Proven twice — the dry run of the identical read loop over
+      all 194 books took 2.2 s total, and the per-row delta stays flat
+      (1.85/1.94/1.42/1.66/1.54 s) as `total_files` falls 65 → 34, which rules out
+      the O(R²) re-read hypothesis below.
+
+      **Actual cause:** `DeleteBookFile` fires `notifyBookFileChange` per row, and
+      each runs the full `RecomputeBookAggregates` → `UpdateBook` chain: two
+      `pebble.Sync` commits, a full copy-on-write `book_ver` snapshot of the entire
+      old Book, and two global go-memdb write transactions. Hypothesis 1 below was
+      right about the *structure* and wrong about the cost (`InvalidateLibraryStats`
+      is a lazy single NoSync delete, not a recompute); hypothesis 2 was refuted
+      outright — `RecomputeBookAggregates` reads only the book's own files.
+
+      **Fix:** `DeleteBookFilesByIDs` — one batch, one Sync, one notify per affected
+      book. Salvage deliberately NOT folded into the batch: rescued keeper fields
+      must commit *before* donors are deleted, and an atomic batch would remove the
+      skip-on-failure escape.
 
       Measured on the full production run (2026-08-04, op
       `01KZ6W1H46696CZDBHCZF10W6C`): 9 books in ~7 minutes, steady. Extrapolated over

--- a/changelog.d/20260806_160000_session_reconcile.md
+++ b/changelog.d/20260806_160000_session_reconcile.md
@@ -1,0 +1,27 @@
+<!-- file: changelog.d/20260806_160000_session_reconcile.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b3f70d21-8c46-4e59-a1d7-2065fe83b94c -->
+<!-- last-edited: 2026-08-06 -->
+
+### Changed
+
+- **`TODO.md` reconciled against what shipped on 2026-08-06**, and an executive
+  summary added for the review-queue work.
+
+  Three entries are now closed: owner items 1+2 (recommendations + override,
+  #2163), the `dedupe-book-file-rows` performance item (#2161), and the
+  directory-shaped-books residue, which now records the measured dry-run result
+  (434 of 1,019 linkable).
+
+  The `dedupe-book-file-rows` entry keeps its original analysis but leads with a
+  correction, because nearly every premise in it was wrong: the op was dying on
+  the 5-minute progress watchdog rather than its 2-hour timeout, the real total
+  was ~1.3 h rather than 2.4 h, and the cost is per-deleted-row rather than
+  per-book. Leaving the original text without that correction would have taught
+  the next reader three false things.
+
+  Six new findings were also recorded as `todo.d/` fragments — the residual
+  react-router advisory and why it is accepted, two frontend navigation sinks
+  that are safe only by accident, the broken e2e suite, two memdb write-path
+  follow-ups, the three multidisc holds that turned out to be duplicates, and a
+  survey of how far behind the frontend framework versions are.

--- a/docs/executive-summaries/2026-08-06-a-review-queue-you-could-not-work-executive-summary.md
+++ b/docs/executive-summaries/2026-08-06-a-review-queue-you-could-not-work-executive-summary.md
@@ -1,0 +1,122 @@
+<!-- file: docs/executive-summaries/2026-08-06-a-review-queue-you-could-not-work-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 1f4e73b8-6d92-4c05-a71e-3820b5cd9f64 -->
+<!-- last-edited: 2026-08-06 -->
+
+# A review queue you could not work
+
+> **Status.** Everything described here is merged and deployed, except the two
+> items called out explicitly at the end as not yet done.
+
+## The thing that was wrong
+
+The library holds back anything it is not sure about. A folder full of audio files
+might be one book split into chapters, or six different books that happen to sit next
+to each other. Guessing wrong one way leaves a book in pieces. Guessing wrong the
+other way **merges six novels into one and deletes five of them**. So uncertain cases
+go to a review queue for a person to decide.
+
+The queue had 777 items. **762 of them said the same sentence:**
+
+> review: flat folder shares a title but ordering is unclear
+
+That is not a queue, it is a pile. Every row looks identical, none says what it
+actually found, and the only way to decide one is to go look at the files yourself —
+at which point the queue has saved you nothing.
+
+## Why it said the same thing every time
+
+The one fact that separates the two cases was missing.
+
+The difference between "six chapters" and "six books" is **how long each piece is**.
+Six three-minute files are chapters; six two-hour files are books. Nothing in the name
+reliably tells you — numbered sequels share a title just as chapters do.
+
+The library knew this. The check existed and was correct. But it read each piece's
+length from a record that, for **97.5% of the queue**, said zero — not "zero seconds
+long" but "nobody ever wrote this down". A check that needs a number, given no number,
+cannot fire. So it never fired, and the classifier fell back to the only thing left:
+the folder name. Hence one sentence, 762 times.
+
+The same missing number is what let a run earlier this month propose merging **41 of
+43** groups that were actually separate novels.
+
+## What was measured
+
+Repair work in the preceding days had finally filled in those lengths for 16,000
+books. Nobody had checked what that unlocked, and the queue's own item count barely
+moved — which read like nothing had changed.
+
+It had. Measuring all 356 remaining queue items against their now-known lengths,
+**1,593 of 1,831 pieces have a real runtime.** The evidence had arrived; the queue
+simply was not using it. Under the library's own existing rule, 286 of the 356 items
+fall into a clear answer and 70 honestly cannot be called.
+
+That measurement is what the remaining work is built on, and it corrected the
+assumption everyone was operating under — that the queue was still starved of
+evidence.
+
+## What shipped
+
+**Three items were one bad click from destroying books.** They were labelled
+"multi-disc set", which normally means safe-to-combine. Their contents are two copies
+of one whole book each — *Brother Wulf* at 6.3 hours twice, *Sevenfold Sword* at about
+21 hours twice, *The Warring Son* at 11.8 hours twice. Combining those would merge them
+and permanently delete one copy of each. A complete record of all 132 groups and all
+4,146 files was written to disk first, because that operation cannot be undone and
+there would otherwise be no record of what was lost.
+
+**A repair job that could not finish now can.** A cleanup task was being killed partway
+through. The cause was not the work — it was repeating an expensive bookkeeping step
+once per row deleted instead of once per book, about 1.35 seconds of pure overhead each
+time, measured. Batching it removes that repetition; the job should now complete in one
+pass rather than needing a second run. (The end-to-end timing has not been re-measured
+against the real library yet.)
+
+**A second measurement pass was built** for the 1,000-odd folders that were never
+checked properly the first time — they were sent to review not because they were
+unknowable but because nothing had measured them. It has not yet been run against the
+real library.
+
+**Five security advisories in third-party code were closed.** One fix required a major
+upgrade of the page-navigation library. That upgrade closes three problems and
+introduces one that only applies to a mode this application does not use. The reasoning
+is written down so nobody has to reconstruct it from the alert later.
+
+**The queue now explains itself.** Each item carries a proposed action, the reason in
+actual numbers — *"7 of 9 pieces run 90 minutes or longer, longest 15.8 hours — each is
+book-length, so these are separate books, not parts of one"* — and the evidence behind
+it. **286 of 356 items** get a decisive answer; the remaining 70 honestly say they
+cannot tell, which is a useful thing for a queue to say and something it could not say
+before. A person can overrule any of it, and the system then does what the person chose.
+
+**A second measurement pass ran against the real library.** The ~1,019 folders that
+were never properly checked the first time have now been measured: **434 of them can be
+linked up confidently**, 585 genuinely do need a human. They had been sitting in review
+not because they were unknowable, but because the check that would have settled them was
+being called with the one piece of information missing.
+
+## One fault worth understanding, because it would have hidden
+
+Partway through, it emerged that **a person's overrule was not being written down
+anywhere.** Only the fact of approval was stored. A later automated pass would re-read
+the *machine's* original suggestion and act on that instead.
+
+So someone could look at two books, say "these are different, keep them apart", watch
+the system accept it — and have the system merge them and delete one, some time later,
+with nothing linking the deletion back to the decision that was supposed to prevent it.
+It would not have looked like a bug. It would have looked like the person's click simply
+never happened.
+
+That is fixed. The decision itself is now recorded alongside the approval, in a single
+write so a crash cannot leave one without the other, and what gets replayed is what the
+person chose. Two tests pin it from both directions — overruling *away* from a merge
+must not merge, and overruling *toward* one must merge exactly once — and both fail if
+the fix is removed.
+
+## Still not done
+
+Nothing in the library has actually been merged or separated. The switch that lets
+approvals change real data remains **off**, deliberately, until a small batch has been
+checked by ear against the snapshot described above. And the 434 linkable folders have
+been identified but not yet linked — that is a write, and it is waiting on a decision.

--- a/todo.d/20260806_150000_react_router_v8_residual_advisory.md
+++ b/todo.d/20260806_150000_react_router_v8_residual_advisory.md
@@ -1,0 +1,30 @@
+<!-- file: todo.d/20260806_150000_react_router_v8_residual_advisory.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4d81e9c3-7a26-4f50-b83d-19e6c07af241 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **react-router GHSA-qwww-vcr4-c8h2 — accepted, not reachable, do not
+  re-litigate.** The v6 → v7.18.2 upgrade (2026-08-06) closed three advisories
+  and opened this one. It is **expected**, it was a deliberate trade, and the
+  analysis is recorded here so the next person to see the alert does not redo it.
+
+  **The trade.** No single version closes all four. The three originals
+  (open redirect via backslash in `<Link>`/`useNavigate`, open-redirect-to-XSS,
+  arbitrary constructor injection via `deserializeErrors()`) are first patched at
+  **7.18.0**. This one — RSC-mode CSRF bypass, vulnerable range 7.12.0–8.2.0 — is
+  only fixed at **8.3.0**.
+
+  **Why we did not go to v8.** It requires `react >= 19.2.7` (repo is on 18.2.0),
+  and `react-router-dom` does not exist at 8.x at all (E404), so it would also
+  mean rewriting all 49 import sites. That is a React-major migration, not a
+  dependency bump.
+
+  **Why the residual is not reachable.** It is an RSC-mode vulnerability and this
+  is a plain SPA. Verified zero hits for `@react-router/*`, `react-server`,
+  `unstable_RSC`, and `createStaticHandler`. The three closed advisories, by
+  contrast, were in `<Link>` and `useNavigate` — code paths used constantly.
+  Closing reachable risk while accepting unreachable risk is the right direction
+  even though the alert count goes the wrong way.
+
+  Revisit when the app moves to React 19 for its own reasons. Do not take the
+  React major *for* this advisory.

--- a/todo.d/20260806_150100_frontend_open_redirect_invariants.md
+++ b/todo.d/20260806_150100_frontend_open_redirect_invariants.md
@@ -1,0 +1,30 @@
+<!-- file: todo.d/20260806_150100_frontend_open_redirect_invariants.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9e34a7b1-05df-4c82-a6e9-3b7150d2f8ce -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **Two frontend navigation sinks are unvalidated and safe only by
+  accident.** Found 2026-08-06 while auditing the react-router open-redirect
+  advisories. Neither is exploitable today. Both rest on an invariant that a
+  future change breaks **silently** — nothing fails, nothing warns, the sink just
+  becomes live.
+
+  1. `web/src/pages/Login.tsx:78-81` — `location.state?.from` is passed straight
+     to `navigate()` with no validation. Safe **only because nothing writes
+     `state.from`** (zero writers in the codebase). Wire a `?returnTo=` param
+     into it and it is immediately exploitable.
+  2. `web/src/pages/BookDetail.tsx:938,968` — `sessionStorage`'s
+     `library_return_url` goes to `navigate()` unvalidated. Safe **only because
+     the writer runs on the exact routes** `/library` and `/fingerprints`.
+     Changing that to `/library/*` makes it exploitable.
+
+  The remedy is to validate at the sink rather than rely on the writer's reach:
+  the Go side already does exactly this, and does it well —
+  `sanitizeReturn` (`internal/server/handlers/oauth_login.go:260-271`) implements
+  the backslash guard the advisory describes, and `abs/openid.go:246-257`
+  validates `redirect_uri` before error redirects too. Mirror that on the client.
+
+  🔴 **Do not "fix" [[TODO-SSO-EDGE]] / the OAuth-callback entry at `TODO.md`
+  around line 1040 by loosening `sanitizeReturn`.** That entry is a *functional*
+  gap — the guard correctly rejecting a custom-scheme return — not a
+  vulnerability. Loosening it would convert a working defence into one of these.

--- a/todo.d/20260806_150200_e2e_suite_broken_on_main.md
+++ b/todo.d/20260806_150200_e2e_suite_broken_on_main.md
@@ -1,0 +1,19 @@
+<!-- file: todo.d/20260806_150200_e2e_suite_broken_on_main.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2c7f480a-6b13-49de-95a1-8e4d3b6f0721 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **The Playwright e2e suite is broken on `main` and gates nothing.** Every
+  test dies at fixture collection with `unknown parameter "_page"` — 49 errors.
+  Confirmed pre-existing on 2026-08-06: the identical failure reproduces on the
+  pre-react-router-v7 tree with unchanged specs, and the v7 PR touched zero files
+  under `web/tests/`.
+
+  Why this matters beyond the red: the react-router v6 → v7 upgrade merged with
+  **no runtime routing signal at all**. `tsc` was clean and 402 frontend unit
+  tests passed, but nothing exercised actual navigation. A routing major landing
+  without e2e coverage is precisely the case the suite exists for.
+
+  Fix the fixture signature, then re-run against the v7 tree to retroactively
+  confirm the upgrade — and treat `make test-e2e` as a required gate for any
+  future routing or auth-flow change.

--- a/todo.d/20260806_150300_memdb_write_path_followups.md
+++ b/todo.d/20260806_150300_memdb_write_path_followups.md
@@ -1,0 +1,29 @@
+<!-- file: todo.d/20260806_150300_memdb_write_path_followups.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7b09fd52-3e84-4c17-a1b6-5f2d80e94c63 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **`UpsertBookToMemDB` holds go-memdb's global writer mutex across Pebble
+  I/O.** Found 2026-08-06 while profiling `dedupe-book-file-rows` (fixed in
+  #2161). This is a **system-wide ceiling on every `UpdateBook`**, not something
+  specific to that op, and it is the natural next performance win.
+
+  go-memdb has a single global writer mutex (`memdb.go:34-35`, `:73-76` — one
+  writer at a time, `Txn(true)` takes `db.writer.Lock()`). Inside that lock,
+  `UpsertBookToMemDB` performs three Pebble reads: `GetBookAuthors`
+  (`memdb_sync.go:72`), `GetBookNarrators` (`:85`), and `loadBookFilesForBookID`
+  (`:98` — a full prefix scan that unmarshals every remaining fingerprint-bearing
+  row). Every other writer in the process waits on that I/O.
+
+  Fix: fetch first, then take `Txn(true)`. Consequence worth stating — this is
+  also why adding worker pools to book-level maintenance ops buys far less than
+  `NumCPU×`: the workers serialize here regardless.
+
+- [ ] **`DeleteBookFilesForBook` leaves stale memdb rows behind.** It never calls
+  `DeleteBookFileFromMemDB` or `MarkQuickQueryDirty`, so Pebble and memdb diverge
+  after it runs. Noticed 2026-08-06 while modelling `DeleteBookFilesByIDs` on it
+  (#2161) — the new method does both; its model does not.
+
+  Latent, and it pairs badly with the known "corrected aggregates are invisible
+  until memdb refreshes" problem: a divergence here looks exactly like that
+  staleness, so the two will be confused during diagnosis.

--- a/todo.d/20260806_150400_multidisc_holds_are_duplicates.md
+++ b/todo.d/20260806_150400_multidisc_holds_are_duplicates.md
@@ -1,0 +1,32 @@
+<!-- file: todo.d/20260806_150400_multidisc_holds_are_duplicates.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5a1e83c7-42b9-4dc6-8e07-6c39f2a1b5d8 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **The 3 dangerous multidisc holds are DUPLICATES, not series — feed them to
+  the duplicate-detection track.** Measured 2026-08-06 from a full pre-apply
+  snapshot of all 132 pending `regroup.multidisc` holds (4,146 member books,
+  zero unreadable).
+
+  `TODO.md` predicted ~9 holds with book-length members, presumed to be series
+  the guard would have caught. There are **3**, and all three are two-member
+  holds whose members have near-identical runtimes:
+
+  | hold | members |
+  |---|---|
+  | `01KXF8BNKENR530AKMMKJYD5E1` | `Brother Wulf` 6.30 h + `Brother Wulf - Joseph Delaney` 6.30 h |
+  | `01KXF8BNKACGA6ZAEBPCQK09FX` | `Sevenfold Sword` 20.56 h + `Sevenfold Sword` 21.47 h |
+  | `01KXF8BNHY7AE56CPZWY9VW9VF` | `The Warring Son` 11.77 h + `The Warring Son` 11.77 h |
+
+  Same title, same runtime, two rows. That is the never-delete / re-associate
+  shape, not a series of distinct novels.
+
+  **The recommender emits `separate` for them, and that is the correct default.**
+  Separate destroys nothing and leaves them for a signal that can actually
+  establish identity. 🔴 Do NOT tune the recommender toward `duplicate-of` on
+  runtime similarity — equal runtimes are not identity evidence. Two different
+  books can share a runtime, and acting on that would merge distinct works
+  through a path that hard-deletes the absorbed row.
+
+  These 3 are a clean, small, real test set for
+  [[never-delete-re-associate]] — use them rather than inventing fixtures.

--- a/todo.d/20260806_153000_frontend_framework_versions.md
+++ b/todo.d/20260806_153000_frontend_framework_versions.md
@@ -1,0 +1,47 @@
+<!-- file: todo.d/20260806_153000_frontend_framework_versions.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8c14e620-9b7d-4a35-b0f2-73de5a91c4e7 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **Frontend framework versions — how far behind we actually are, and the
+  order to fix it in.** Surveyed 2026-08-06 at owner request ("are we on
+  TypeScript 7 and the latest React?"). Answer: **no to both.**
+
+  | Package | Installed | Latest | Behind |
+  |---|---|---|---|
+  | `typescript` | 5.9.3 | **7.0.2** | 2 majors |
+  | `react` / `react-dom` | 18.3.1 | **19.2.8** | 1 major |
+  | `@mui/material` | 5.18.0 | **9.3.1** | **4 majors** |
+  | `jsdom` | 23.2.0 | **30.0.1** | **7 majors** |
+  | `vite` | 7.3.6 | 8.2.1 | 1 major |
+  | `eslint` | 9.39.5 | 10.8.0 | 1 major |
+  | `zustand` | 4.5.7 | 5.0.14 | 1 major |
+  | `react-router` | 7.18.2 | 8.x | 1 major (gated on React 19) |
+  | `vitest` | 4.1.10 | 4.1.10 | current |
+
+  **React 19 is worth more than it looks, because it is also a security fix.**
+  [[react-router-v8-residual-advisory]] (GHSA-qwww-vcr4-c8h2) is only patched in
+  react-router **v8**, which requires `react >= 19.2.7` and does not publish
+  `react-router-dom` at all. So "upgrade React" and "close that open high-severity
+  alert" are one piece of work, not two. That changes its cost/benefit — do not
+  price the React major as pure maintenance.
+
+  **TypeScript 7 is not a version bump.** It is the native Go compiler rewrite —
+  roughly 10× faster type-checking, but a different implementation with its own
+  compatibility surface. Budget it as a migration.
+
+  **MUI 5 → 9 is the largest single lift.** Four majors, and MUI majors move the
+  styling engine and component APIs. `@mui/material` is imported across most of
+  the UI, so this is the one that is genuinely days rather than hours.
+
+  Suggested order, cheapest-value-first:
+  1. **React 19 + react-router 8** — closes a live advisory, moderate scope.
+  2. **jsdom + eslint + zustand + vite** — cheap, can ride along with (1).
+  3. **TypeScript 7** — real migration, big payoff in CI time.
+  4. **MUI 9** — largest, purely maintenance, do last.
+
+  🔴 **Do not attempt any of this until the e2e suite is fixed.** See
+  [[e2e-suite-broken-on-main]] — it currently dies at fixture collection and
+  gates nothing, which is why the react-router v6 → v7 upgrade merged with zero
+  runtime navigation coverage. A React major without e2e is exactly the change
+  that suite exists to catch.


### PR DESCRIPTION
Documentation only. No code changes.

## TODO.md reconciled

Three entries closed against merged work:

- **Owner items 1+2** — recommendations + override (#2163). Notes the data-loss path found and closed, and warns that dispatch now keys on the chosen action rather than `Kind`, which widens the blast radius of turning `review_apply_enabled` on.
- **`dedupe-book-file-rows` perf** (#2161).
- **Directory-shaped books residue** — now carries the measured production dry-run: `examined=1019 link=434 review=585 errors=0`.

The perf entry **keeps its original analysis but leads with a correction**, because nearly every premise in it was wrong:

| The entry said | Actually |
|---|---|
| blows its 2-hour `Timeout` | died on the 5-minute `ProgressTimeout` watchdog, at book 19/194 |
| ~2.4 h of work | ~1.3 h (`redundant_rows=2901`; the 194 × 45 s figure double-counted skew) |
| ~45 s per book | ~1.35 s per deleted **row** |
| suspect: `RecomputeBookAggregates` re-reads a library aggregate | refuted — it reads only the book's own files |

Deleting the original text would have hidden that those readings were plausible and wrong; leaving it uncorrected would have taught the next reader three false things. So it now leads with the correction.

## Six findings recorded as `todo.d/` fragments

None of these were the work being done; all six were turned up by doing it, and each would otherwise be rediscovered from scratch.

1. **react-router GHSA-qwww-vcr4-c8h2 — accepted, not reachable, do not re-litigate.** Today's v6→v7 security upgrade closed three advisories and opened this one. Records why v8 is unavailable (needs React 19; `react-router-dom` does not exist at 8.x) and why the residual is unreachable (RSC-mode vuln, this is a plain SPA).
2. **Two frontend navigation sinks** unvalidated and safe only because nothing currently feeds them. Both break silently. Includes a warning not to "fix" the tracked OAuth entry by loosening `sanitizeReturn`, which is a working defence.
3. **The e2e suite is broken on `main`** and gates nothing — which is how a routing major landed with zero runtime navigation coverage.
4. **Two memdb write-path follow-ups**: `UpsertBookToMemDB` holds go-memdb's global writer mutex across three Pebble reads (a ceiling on *every* `UpdateBook`, and why worker pools on book-level ops buy less than `NumCPU×`), and `DeleteBookFilesForBook` leaves stale memdb rows.
5. **The three dangerous multidisc holds are duplicates, not series** — same title, same runtime, two rows. Includes the measured before-state and a warning not to tune the recommender toward `duplicate-of` on runtime similarity, since equal runtimes are not identity evidence.
6. **Frontend framework version survey** with the upgrade order, including the point that React 19 is not pure maintenance — it is the prerequisite for the react-router v8 that closes finding 1.

## Executive summary

`docs/executive-summaries/2026-08-06-a-review-queue-you-could-not-work-executive-summary.md`, written for the non-engineer reader.

It states plainly what is **not** done: nothing in the library has been merged or separated, the apply switch is still off, and the 434 linkable folders are identified but not linked.

An earlier draft of this file described unmerged work in the present tense, including calling the override data-loss fix "now fixed" while it was still in flight. That was corrected before commit — an executive summary that merges ahead of the code it describes would tell a future reader a live bug had been handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp