### PR TITLE
feat(database): store intro transcription per BookFile + make first-file selection disc-aware

### DIFF
--- a/changelog.d/20260806_120000_per-file-intro-transcription-storage.md
+++ b/changelog.d/20260806_120000_per-file-intro-transcription-storage.md
@@ -1,0 +1,46 @@
+<!-- file: changelog.d/20260806_120000_per-file-intro-transcription-storage.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8e3a7c14-6b95-4d02-a1f8-27d59b4e0c63 -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- **Per-file intro transcription storage.** The spoken
+  "<Title> by <Author>, read by <Narrator>" opening is now recorded per
+  `BookFile`, not only per `Book`. Eight fields were added to `BookFile`
+  (`IntroTranscription`, `TranscribedTitle/Author/Narrator`,
+  `IntroTranscribedAt`, `TranscribeStatus`, `TranscribeError`,
+  `TranscribeAttemptedAt`), mirroring the existing `Book` fields exactly, and
+  surfaced through `GET /audiobooks/:id/files` and the frontend `BookFile` type.
+
+  Storing this per book captured exactly ONE file's opening, so a folder of 12
+  files that are one book was indistinguishable from 12 files that are 12
+  separate books. Per file the sequence is decisive: real library rows read
+  "This is a reading of Overlord, Book 7. This part includes the prologue and
+  Chapter 1" / "...includes Chapter 2" / "...Volume 7, Chapter 3", which proves
+  continuation rather than a new book start.
+
+  `Book.IntroTranscription` is unchanged and still populated, so existing
+  consumers (notably `maintenance.auto-match-transcribed`) keep working.
+
+  Only the raw transcript is stripped from the in-memory projection. At
+  ~0.5-1.5 KB across ~317K files it would add ~160-475 MB to a memdb that
+  stripping already takes from ~10 GB to ~2 GB; the other seven fields are small,
+  are what queries actually filter on, and are retained. Stripping one field
+  instead of eight also narrows the write-back preserve-guard to a single field.
+
+### Fixed
+
+- **`transcribe-book-intros` picked the wrong "first file" on multi-disc books.**
+  `nthAudioFile` sorted candidates by `(track, path)`, ignoring `DiscNumber`, so
+  disc-2-track-1 tied with disc-1-track-1 and the file path broke the tie
+  arbitrarily — a book whose disc 2 sorted lexically first had disc 2's opening
+  transcribed as its intro. The comparator now matches
+  `PebbleStore.GetBookFiles` verbatim: `(disc, track, path)`.
+
+  Books written by the iTunes regroup path were never affected (`assignDiscTrack`
+  flattens discs to `DiscNumber=0` with contiguous track numbers, so the two
+  comparators agree); the break was in legacy rows carrying real disc numbers
+  from tag scans. This is load-bearing for the per-file signal above, which rests
+  on "track 1 carries the opening, tracks 2..N do not" — a sort that disagrees
+  about which row is track 1 makes that discriminator read the wrong row.

--- a/internal/database/bookfilecore.go
+++ b/internal/database/bookfilecore.go
@@ -1,7 +1,7 @@
 // file: internal/database/bookfilecore.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 715f4b68-2d23-4f52-b1dd-1b3d0357a4f6
-// last-edited: 2026-07-05
+// last-edited: 2026-08-06
 
 package database
 
@@ -9,10 +9,16 @@ import "time"
 
 // BookFileCore is the projection of BookFile that survives the memdb strip
 // performed by stripBookFileForMemdb. It contains every BookFile field EXCEPT
-// the heavy fingerprint-diagnostic set that memdb clears before insertion:
+// the heavy set that memdb clears before insertion:
 //
 //	FingerprintFailureReason, FingerprintFailureDetail, FingerprintDiagnosticJSON,
-//	AcoustIDFingerprint, AcoustIDSeg0..6
+//	AcoustIDFingerprint, AcoustIDSeg0..6, IntroTranscription
+//
+// IntroTranscription is the only member of the per-file intro-transcription
+// group that is stripped. The other SEVEN (TranscribedTitle/Author/Narrator,
+// IntroTranscribedAt, TranscribeStatus, TranscribeError, TranscribeAttemptedAt)
+// are RETAINED here — they are the small, queryable fields, and the raw
+// transcript carries ~99% of the group's bytes. See memdb_strip.go for the math.
 //
 // Note the two fingerprint-adjacent fields that are intentionally RETAINED
 // (they are NOT stripped in memdb_strip.go and therefore belong on Core):
@@ -74,6 +80,16 @@ type BookFileCore struct {
 	DownloadHash         string     `json:"download_hash,omitempty"`
 	DelugeOriginalPath   string     `json:"deluge_original_path,omitempty"`
 	ImportedFromDelugeAt *time.Time `json:"imported_from_deluge_at,omitempty"`
+
+	// Per-file intro transcription — the 7 RETAINED fields. IntroTranscription
+	// (the raw transcript) is deliberately absent: it is the stripped one.
+	TranscribedTitle      *string    `json:"transcribed_title,omitempty"`
+	TranscribedAuthor     *string    `json:"transcribed_author,omitempty"`
+	TranscribedNarrator   *string    `json:"transcribed_narrator,omitempty"`
+	IntroTranscribedAt    *time.Time `json:"intro_transcribed_at,omitempty"`
+	TranscribeStatus      *string    `json:"transcribe_status,omitempty"`
+	TranscribeError       *string    `json:"transcribe_error,omitempty"`
+	TranscribeAttemptedAt *time.Time `json:"transcribe_attempted_at,omitempty"`
 }
 
 // Core returns the BookFileCore projection of f — every BookFile field that
@@ -120,5 +136,12 @@ func (f *BookFile) Core() BookFileCore {
 		DownloadHash:                   f.DownloadHash,
 		DelugeOriginalPath:             f.DelugeOriginalPath,
 		ImportedFromDelugeAt:           f.ImportedFromDelugeAt,
+		TranscribedTitle:               f.TranscribedTitle,
+		TranscribedAuthor:              f.TranscribedAuthor,
+		TranscribedNarrator:            f.TranscribedNarrator,
+		IntroTranscribedAt:             f.IntroTranscribedAt,
+		TranscribeStatus:               f.TranscribeStatus,
+		TranscribeError:                f.TranscribeError,
+		TranscribeAttemptedAt:          f.TranscribeAttemptedAt,
 	}
 }

--- a/internal/database/bookfilecore_test.go
+++ b/internal/database/bookfilecore_test.go
@@ -1,7 +1,7 @@
 // file: internal/database/bookfilecore_test.go
-// version: 1.1.0
+// version: 1.2.0
 // guid: 29325171-4866-4142-82c6-e010f724ae5e
-// last-edited: 2026-07-05
+// last-edited: 2026-08-06
 
 package database
 
@@ -28,6 +28,10 @@ var strippedBookFileFields = []string{
 	"FingerprintDiagnosticJSON",
 	"FingerprintFailureDetail",
 	"FingerprintFailureReason",
+	// The raw ~90s Whisper transcript. The ONLY stripped member of the eight-field
+	// per-file intro-transcription group; the other seven are small/queryable and
+	// stay on Core. See the rationale block in memdb_strip.go.
+	"IntroTranscription",
 }
 
 // structFieldNames is defined once in bookcore_test.go (same package) and

--- a/internal/database/dataloss_bookfile_transcript_test.go
+++ b/internal/database/dataloss_bookfile_transcript_test.go
@@ -1,0 +1,158 @@
+// file: internal/database/dataloss_bookfile_transcript_test.go
+// version: 1.0.0
+// guid: 6c1e94a7-8f20-4d63-b5a1-9e07c2f8d4b6
+// last-edited: 2026-08-06
+
+package database
+
+import (
+	"testing"
+)
+
+// The per-file intro transcript is memdb-stripped (stripBookFileForMemdb nils
+// IntroTranscription), which puts it in this repo's dominant data-loss shape: a
+// whole-library job reads a SLIM BookFile, edits an unrelated field, and writes
+// the struct back — silently blanking a transcript that costs a Whisper run to
+// regenerate.
+//
+// TestRoundTrip_UpdateBookFile does NOT cover this. It writes a FULLY-POPULATED
+// struct, so every field is non-nil on the way in and the preserve-on-nil branch
+// is never exercised. These tests drive the nil-incoming case specifically, once
+// per write path, because the three paths guard independently:
+//
+//	UpdateBookFile        — guards against `old`
+//	UpsertBookFile        — guards against `existing`, then delegates to UpdateBookFile
+//	BatchUpsertBookFiles  — guards against `existing` and writes STRAIGHT into the
+//	                        batch (no UpdateBookFile delegation), so its guard is
+//	                        the only protection on that path.
+
+const dlTranscript = "Overlord, Book 7, by Kugane Maruyama, read by Emily Woo Zeller."
+
+// seedTranscribedFile creates a book + one BookFile carrying a stored transcript.
+func seedTranscribedFile(t *testing.T, ps *PebbleStore) (bookID string, file *BookFile) {
+	t.Helper()
+	book, err := ps.CreateBook(&Book{Title: "dl-transcript-book", FilePath: "/lib/dl-transcript.m4b"})
+	if err != nil {
+		t.Fatalf("CreateBook: %v", err)
+	}
+	tr := dlTranscript
+	f := &BookFile{
+		BookID:             book.ID,
+		FilePath:           "/lib/dl-transcript/01.mp3",
+		IntroTranscription: &tr,
+	}
+	if err := ps.CreateBookFile(f); err != nil {
+		t.Fatalf("CreateBookFile: %v", err)
+	}
+	return book.ID, f
+}
+
+// readBackTranscript fetches the stored file and returns its transcript.
+func readBackTranscript(t *testing.T, ps *PebbleStore, bookID, fileID string) *string {
+	t.Helper()
+	files, err := ps.GetBookFiles(bookID)
+	if err != nil {
+		t.Fatalf("GetBookFiles: %v", err)
+	}
+	for i := range files {
+		if files[i].ID == fileID {
+			return files[i].IntroTranscription
+		}
+	}
+	t.Fatalf("book file %s not found", fileID)
+	return nil
+}
+
+// assertTranscriptSurvived fails with the data-loss framing when the guard leaks.
+func assertTranscriptSurvived(t *testing.T, got *string, path string) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s WIPED the stored intro transcript on a nil-incoming write "+
+			"(memdb round-trip data loss); the preserve-on-nil guard is missing or broken", path)
+	}
+	if *got != dlTranscript {
+		t.Errorf("%s: transcript = %q, want %q", path, *got, dlTranscript)
+	}
+}
+
+// TestUpdateBookFile_PreservesTranscriptOnNilIncoming simulates the exact bug
+// shape: read a slim (memdb-stripped) row, change an unrelated field, write back.
+func TestUpdateBookFile_PreservesTranscriptOnNilIncoming(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	bookID, seed := seedTranscribedFile(t, ps)
+
+	// A slim row exactly as GetAllBookFiles would hand it back.
+	slim := stripBookFileForMemdb(seed)
+	if slim.IntroTranscription != nil {
+		t.Fatal("stripBookFileForMemdb must nil IntroTranscription — the strip is the premise of this test")
+	}
+	slim.TrackNumber = 42 // the unrelated edit the maintenance job makes
+
+	if err := ps.UpdateBookFile(seed.ID, slim); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+	assertTranscriptSurvived(t, readBackTranscript(t, ps, bookID, seed.ID), "UpdateBookFile")
+}
+
+// TestUpsertBookFile_PreservesTranscriptOnNilIncoming covers the path-matched
+// upsert, which guards once itself and again via UpdateBookFile.
+func TestUpsertBookFile_PreservesTranscriptOnNilIncoming(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	bookID, seed := seedTranscribedFile(t, ps)
+
+	slim := stripBookFileForMemdb(seed)
+	slim.TrackNumber = 42
+
+	if err := ps.UpsertBookFile(slim); err != nil {
+		t.Fatalf("UpsertBookFile: %v", err)
+	}
+	assertTranscriptSurvived(t, readBackTranscript(t, ps, bookID, seed.ID), "UpsertBookFile")
+}
+
+// TestBatchUpsertBookFiles_PreservesTranscriptOnNilIncoming covers the batch
+// path. This is the highest-blast-radius one: it writes directly into the Pebble
+// batch, so a missing guard wipes every transcript in the library in one commit.
+func TestBatchUpsertBookFiles_PreservesTranscriptOnNilIncoming(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	bookID, seed := seedTranscribedFile(t, ps)
+
+	slim := stripBookFileForMemdb(seed)
+	slim.TrackNumber = 42
+
+	if err := ps.BatchUpsertBookFiles([]*BookFile{slim}); err != nil {
+		t.Fatalf("BatchUpsertBookFiles: %v", err)
+	}
+	assertTranscriptSurvived(t, readBackTranscript(t, ps, bookID, seed.ID), "BatchUpsertBookFiles")
+}
+
+// TestUpdateBookFile_StillWritesANewTranscript is the counterweight: the guard
+// must not become a write-block. A real (re)transcription supplies a non-nil
+// value and MUST overwrite the stored one.
+func TestUpdateBookFile_StillWritesANewTranscript(t *testing.T) {
+	store, cleanup := setupPebbleTestDB(t)
+	defer cleanup()
+	ps := store.(*PebbleStore)
+
+	bookID, seed := seedTranscribedFile(t, ps)
+
+	updated := *seed
+	fresh := "This part includes Chapter 2."
+	updated.IntroTranscription = &fresh
+
+	if err := ps.UpdateBookFile(seed.ID, &updated); err != nil {
+		t.Fatalf("UpdateBookFile: %v", err)
+	}
+	got := readBackTranscript(t, ps, bookID, seed.ID)
+	if got == nil || *got != fresh {
+		t.Errorf("a fresh non-nil transcript must overwrite the stored one: got %v, want %q", got, fresh)
+	}
+}

--- a/internal/database/memdb_strip.go
+++ b/internal/database/memdb_strip.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_strip.go
-// version: 1.3.0
+// version: 1.4.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-stripbook0001
-// last-edited: 2026-07-05
+// last-edited: 2026-08-06
 
 package database
 
@@ -61,8 +61,29 @@ func stripBookForMemdb(src *Book) *Book {
 //	FingerprintDiagnosticJSON (*string, KB-class)    → can dominate when populated
 //	FingerprintFailureReason / Detail (*string)      → small but per-row
 //	FingerprintFailedAt (*time.Time)                 → 24B retained (needed by LSH builder)
+//	IntroTranscription (*string, ~0.5-1.5 KB/file)   → ~160-475 MB at full coverage
 //
 // Combined drop from Seg0..6 + diagnostic fields: ~550-900 MB + diagnostic overhead.
+//
+// IntroTranscription strip rationale (per-file intro transcription):
+//
+// The per-file intro-transcription group is EIGHT fields, and only this one is
+// stripped — a deliberate hybrid rather than all-or-nothing. A 90s transcript runs
+// ~0.5-1.5 KB; across 317,054 book_files that is ~160-475 MB, squarely inside the
+// band this codebase already treats as clearly worth stripping (AcoustIDSeg0..6 at
+// ~550-900 MB, above). stripBookForMemdb takes memdb from ~10 GB to ~2 GB, so a
+// half-gigabyte regression from a single additive field is not acceptable.
+//
+// Stripping ONLY the raw transcript captures ~99% of the group's bytes while
+// keeping every field a query would actually filter on — TranscribedTitle/Author/
+// Narrator, IntroTranscribedAt, TranscribeStatus, TranscribeError,
+// TranscribeAttemptedAt are all small and all remain in the memdb projection (and
+// therefore on BookFileCore). It also narrows the write-back preserve-guard in
+// pebble_store_bookfiles.go to ONE field instead of eight, which matters because a
+// bare memdb round-trip write-back is this repo's dominant data-loss incident class.
+//
+// Readers needing the raw transcript go Pebble-direct via GetBookFile /
+// GetBookFiles, the same contract AcoustIDFingerprint has had since PERF-7.
 //
 // FingerprintFailedAt is intentionally NOT stripped: it is 24 bytes per row (~7 MB
 // at 308K rows) and is read by the LSH index builder to skip permanently-failed files
@@ -112,5 +133,10 @@ func stripBookFileForMemdb(src *BookFile) *BookFile {
 	cp.AcoustIDSeg4 = ""
 	cp.AcoustIDSeg5 = ""
 	cp.AcoustIDSeg6 = ""
+	// IntroTranscription: raw ~90s Whisper transcript (~0.5-1.5 KB/file,
+	// ~160-475 MB at full coverage). The ONLY stripped member of the eight-field
+	// per-file intro-transcription group — see the rationale block above. The
+	// other seven are small, queryable, and retained (they are on BookFileCore).
+	cp.IntroTranscription = nil
 	return &cp
 }

--- a/internal/database/pebble_store_bookfiles.go
+++ b/internal/database/pebble_store_bookfiles.go
@@ -1,5 +1,5 @@
 // file: internal/database/pebble_store_bookfiles.go
-// version: 1.10.0
+// version: 1.11.0
 // guid: bee03868-fbc4-48b0-9c9a-11180e19779e
 // last-edited: 2026-08-06
 
@@ -330,6 +330,29 @@ func (s *PebbleStore) UpdateBookFile(id string, file *BookFile) error {
 	// field-scoped update under the GetAllBookFiles->BookFileCore retype (STOREFID W3).
 	if len(file.AcoustIDFingerprint) == 0 {
 		file.AcoustIDFingerprint = old.AcoustIDFingerprint
+	}
+
+	// Preserve the memdb-stripped raw intro transcript on a slim round-trip, for
+	// exactly the same reason as AcoustIDFingerprint above: stripBookFileForMemdb
+	// nils IntroTranscription, so any whole-library job that reads a slim BookFile,
+	// edits an unrelated field, and writes the struct back here would blank a
+	// transcript that costs a Whisper run to regenerate.
+	//
+	// Unlike the fingerprint DIAGNOSTIC fields (which are deliberately NOT guarded
+	// — see the note below — because backfill.go legitimately clears them to nil
+	// through this method), there is no write path that legitimately clears a
+	// transcript: a re-transcription always supplies a fresh non-empty value, and a
+	// FAILED attempt writes TranscribeStatus/TranscribeError while deliberately
+	// leaving the last good transcript in place (reparse_only depends on it). So
+	// preserve-on-nil can never strand stale state here, and there is intentionally
+	// no escape hatch — genuinely erasing a transcript would require a deliberate
+	// field-scoped op, which does not exist today.
+	//
+	// Only IntroTranscription needs this guard. The other seven per-file
+	// transcription fields survive the strip (they are on BookFileCore), so a slim
+	// round-trip carries their real values and writing them back is a no-op.
+	if file.IntroTranscription == nil {
+		file.IntroTranscription = old.IntroTranscription
 	}
 
 	// T020: drop AcoustIDSeg0..6 from the stored value via a copy.
@@ -1106,6 +1129,12 @@ func (s *PebbleStore) UpsertBookFile(file *BookFile) error {
 	if file.FingerprintDiagnosticJSON == nil {
 		file.FingerprintDiagnosticJSON = existing.FingerprintDiagnosticJSON
 	}
+	// IntroTranscription is memdb-stripped too — same wipe risk. UpdateBookFile
+	// guards this again below; the double-guard is idempotent and mirrors the
+	// existing AcoustIDFingerprint pattern.
+	if file.IntroTranscription == nil {
+		file.IntroTranscription = existing.IntroTranscription
+	}
 
 	return s.UpdateBookFile(existing.ID, file)
 }
@@ -1173,6 +1202,15 @@ func (s *PebbleStore) BatchUpsertBookFiles(files []*BookFile) error {
 			}
 			if file.FingerprintDiagnosticJSON == nil {
 				file.FingerprintDiagnosticJSON = existing.FingerprintDiagnosticJSON
+			}
+			// IntroTranscription is memdb-stripped as well (~0.5-1.5 KB/file of
+			// Whisper output). Unlike UpsertBookFile, this method writes straight
+			// into the batch rather than delegating to UpdateBookFile, so THIS is
+			// the only guard on the batch path — a whole-library round-trip
+			// (maintenance.tag-backfill et al.) would otherwise wipe every
+			// transcript in one commit.
+			if file.IntroTranscription == nil {
+				file.IntroTranscription = existing.IntroTranscription
 			}
 
 			if err := s.deleteBookFileSecondaryIndexes(batch, existing); err != nil {

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -1,7 +1,7 @@
 // file: internal/database/store.go
-// version: 2.86.0
+// version: 2.87.0
 // guid: 8a9b0c1d-2e3f-4a5b-6c7d-8e9f0a1b2c3d
-// last-edited: 2026-08-02
+// last-edited: 2026-08-06
 
 package database
 
@@ -783,6 +783,51 @@ type BookFile struct {
 	DownloadHash         string     `json:"download_hash,omitempty"`
 	DelugeOriginalPath   string     `json:"deluge_original_path,omitempty"`
 	ImportedFromDelugeAt *time.Time `json:"imported_from_deluge_at,omitempty"`
+
+	// ---- Per-file intro transcription -------------------------------------
+	//
+	// These mirror the Book-level fields of the same names (see Book, above) but
+	// are recorded PER FILE. The Book-level copies are retained as a derived
+	// convenience (file 1's values) for existing consumers such as
+	// maintenance.auto-match-transcribed; they are NOT deprecated by these.
+	//
+	// Why per-file at all: an audiobook opens with a spoken
+	// "<Title> by <Author>, read by <Narrator>" announcement, which marks a book
+	// START. Storing that on Book alone captures exactly ONE file's opening, so a
+	// folder holding 12 files that are one book is indistinguishable from 12 files
+	// that are 12 separate books. Per file, the sequence is decisive — real prod
+	// rows read "This is a reading of Overlord, Book 7. This part includes the
+	// prologue and Chapter 1" / "...includes Chapter 2" / "...Volume 7, Chapter 3",
+	// which proves continuation. At book level that signal is invisible.
+
+	// IntroTranscription is the raw Whisper transcript of the first ~90 seconds of
+	// THIS file. It is the one field in this group that stripBookFileForMemdb
+	// clears — see the memory math in memdb_strip.go. Readers that need it must go
+	// Pebble-direct (GetBookFile / GetBookFiles), never the memdb projection.
+	IntroTranscription *string `json:"intro_transcription,omitempty"`
+	// TranscribedTitle / TranscribedAuthor / TranscribedNarrator are the fields
+	// parsed from IntroTranscription ("TITLE by AUTHOR. Read by NARRATOR.").
+	// Stored separately from the file's own tags so transcription errors cannot
+	// overwrite curated metadata. Retained in memdb: these are what a query
+	// filters on, and they are small.
+	TranscribedTitle    *string `json:"transcribed_title,omitempty"`
+	TranscribedAuthor   *string `json:"transcribed_author,omitempty"`
+	TranscribedNarrator *string `json:"transcribed_narrator,omitempty"`
+	// IntroTranscribedAt is when IntroTranscription was last populated.
+	IntroTranscribedAt *time.Time `json:"intro_transcribed_at,omitempty"`
+	// TranscribeStatus records the outcome of the most recent transcription
+	// ATTEMPT for this file. One of: "ok", "source_file_missing", "no_audio",
+	// "ffmpeg_error", "whisper_error", "empty". This is the queryable drill-down
+	// field — count files by status to see exactly why transcription is or isn't
+	// producing data.
+	TranscribeStatus *string `json:"transcribe_status,omitempty"`
+	// TranscribeError holds a short human-readable detail for a non-ok status —
+	// typically the tail of ffmpeg stderr or the Whisper error string. Empty on ok.
+	TranscribeError *string `json:"transcribe_error,omitempty"`
+	// TranscribeAttemptedAt is when the most recent transcription attempt ran
+	// (success OR failure), distinct from IntroTranscribedAt which only advances
+	// on a successful transcription.
+	TranscribeAttemptedAt *time.Time `json:"transcribe_attempted_at,omitempty"`
 }
 
 // UserPosition is one user's resume point for one segment of one

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.12.1
+// version: 3.13.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-05
+// last-edited: 2026-08-06
 
 package maintenance
 
@@ -793,7 +793,8 @@ func firstAudioFile(store database.Store, book database.Book) (path, cacheKey, b
 }
 
 // nthAudioFile returns the path, cache key, and BookFile ID for the nth audio
-// file of book (sorted by track number, then path). n=0 is the first file.
+// file of book, sorted by (disc, track, path) — the same canonical ordering
+// GetBookFiles uses. n=0 is the first file.
 // The book-level FilePath fallback (for single-track iTunes imports with no
 // BookFile rows) is only used when n==0 and no BookFile records exist.
 // Cache key priority: FileHash > fp:sha256(AcoustIDFingerprint) > path:sha256(FilePath).
@@ -823,11 +824,39 @@ func nthAudioFile(store database.Store, book database.Book, n int) (path, cacheK
 		return "", "", "", nil
 	}
 
+	// Sort: disc ASC, track ASC, file_path ASC — IDENTICAL to the canonical
+	// ordering in PebbleStore.GetBookFiles (pebble_store_bookfiles.go).
+	//
+	// This comparator used to omit DiscNumber, comparing only (track, path). That
+	// is not a cosmetic difference: GetBookFiles hands the slice back already in
+	// (disc, track, path) order, and re-sorting without the disc key DESTROYS it.
+	// For a book whose DiscNumber came from tags on scan, disc-2-track-1 ties with
+	// disc-1-track-1 and FilePath breaks the tie arbitrarily — so "the first file"
+	// could be the opening of disc 2.
+	//
+	// Why that matters more per-file than it did per-book: the per-file intro
+	// signal rests on "track 1 carries the spoken opening, tracks 2..N do not", and
+	// POSITION is the discriminator that separates a genuine book start from a
+	// continuation. If this sort disagrees about which row IS track 1, the
+	// discriminator reads the wrong row and the whole signal silently misfires. At
+	// book level the same bug was merely a wrong sample.
+	//
+	// Books written by the iTunes regroup path are unaffected either way:
+	// assignDiscTrack (internal/itunes/service/fs_regroup_shape.go) stamps
+	// DiscNumber=0 and TrackNumber=1..N contiguously over play order, per the
+	// owner decision that discs are flattened. With disc always 0 the two
+	// comparators agree. It is the legacy/tag-scanned multi-disc rows, which
+	// predate that convention and still carry real disc numbers, that were broken.
+	//
+	// Kept as an explicit re-sort rather than relying on GetBookFiles' ordering:
+	// `store` is the database.Store INTERFACE, and no implementation is
+	// contractually bound to return files in any particular order.
 	sort.Slice(audio, func(i, j int) bool {
-		ti := audio[i].TrackNumber
-		tj := audio[j].TrackNumber
-		if ti != tj {
-			return ti < tj
+		if audio[i].DiscNumber != audio[j].DiscNumber {
+			return audio[i].DiscNumber < audio[j].DiscNumber
+		}
+		if audio[i].TrackNumber != audio[j].TrackNumber {
+			return audio[i].TrackNumber < audio[j].TrackNumber
 		}
 		return audio[i].FilePath < audio[j].FilePath
 	})

--- a/internal/plugins/maintenance/intro_transcribe_sort_test.go
+++ b/internal/plugins/maintenance/intro_transcribe_sort_test.go
@@ -1,0 +1,115 @@
+// file: internal/plugins/maintenance/intro_transcribe_sort_test.go
+// version: 1.0.0
+// guid: 4f2b9c81-7d36-4a5e-9b02-3c8e1a6d5f47
+// last-edited: 2026-08-06
+
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// newSortStore returns a MockStore serving a fixed BookFile set for any bookID.
+// Deliberately named for this test file only — a generic helper name in this
+// package would collide with sibling tests added by parallel work.
+func newSortStore(files []database.BookFile) *database.MockStore {
+	return &database.MockStore{
+		GetBookFilesFunc: func(_ string) ([]database.BookFile, error) {
+			return files, nil
+		},
+	}
+}
+
+// TestNthAudioFile_MultiDiscPicksDisc1Track1 pins the first-file selection for a
+// genuine multi-disc set — the case the old (track, path) comparator got wrong.
+//
+// The old sort ignored DiscNumber entirely, so disc-1-track-1 and disc-2-track-1
+// TIED on track number and FilePath broke the tie. Here disc 2's paths sort
+// lexically BEFORE disc 1's ("/lib/a-disc2/..." < "/lib/b-disc1/..."), so the old
+// comparator returned disc 2's opening as "the first file". The correct answer is
+// disc 1, track 1.
+//
+// This matters beyond picking a wrong sample: the per-file intro signal rests on
+// "track 1 carries the spoken opening, tracks 2..N do not", with position as the
+// discriminator. A sort that disagrees about which row is track 1 makes the
+// discriminator read the wrong row.
+//
+// Input order is deliberately scrambled so the test exercises nthAudioFile's own
+// comparator rather than any ordering a store happened to return.
+func TestNthAudioFile_MultiDiscPicksDisc1Track1(t *testing.T) {
+	files := []database.BookFile{
+		{ID: "d2t2", BookID: "b1", FilePath: "/lib/a-disc2/track02.mp3", DiscNumber: 2, TrackNumber: 2},
+		{ID: "d1t2", BookID: "b1", FilePath: "/lib/b-disc1/track02.mp3", DiscNumber: 1, TrackNumber: 2},
+		{ID: "d2t1", BookID: "b1", FilePath: "/lib/a-disc2/track01.mp3", DiscNumber: 2, TrackNumber: 1},
+		{ID: "d1t1", BookID: "b1", FilePath: "/lib/b-disc1/track01.mp3", DiscNumber: 1, TrackNumber: 1},
+	}
+	store := newSortStore(files)
+	book := database.Book{ID: "b1"}
+
+	_, _, gotID, err := firstAudioFile(store, book)
+	if err != nil {
+		t.Fatalf("firstAudioFile: %v", err)
+	}
+	if gotID != "d1t1" {
+		t.Errorf("first file = %q, want %q (disc 1 track 1); "+
+			"a disc-blind sort returns %q because disc 2's path sorts first",
+			gotID, "d1t1", "d2t1")
+	}
+
+	// Full (disc, track, path) order — matches PebbleStore.GetBookFiles.
+	want := []string{"d1t1", "d1t2", "d2t1", "d2t2"}
+	for n, wantID := range want {
+		_, _, gotID, err := nthAudioFile(store, book, n)
+		if err != nil {
+			t.Fatalf("nthAudioFile(%d): %v", n, err)
+		}
+		if gotID != wantID {
+			t.Errorf("nthAudioFile(%d) = %q, want %q", n, gotID, wantID)
+		}
+	}
+}
+
+// TestNthAudioFile_FlattenedDiscsUnaffected covers the shape the iTunes regroup
+// path produces: assignDiscTrack (internal/itunes/service/fs_regroup_shape.go)
+// stamps DiscNumber=0 and TrackNumber=1..N contiguously over play order, per the
+// owner decision that discs are flattened. With disc constant the disc key is
+// inert and ordering falls through to track — so the fix must be a no-op here.
+func TestNthAudioFile_FlattenedDiscsUnaffected(t *testing.T) {
+	files := []database.BookFile{
+		{ID: "t3", BookID: "b1", FilePath: "/lib/bk/c.mp3", DiscNumber: 0, TrackNumber: 3},
+		{ID: "t1", BookID: "b1", FilePath: "/lib/bk/a.mp3", DiscNumber: 0, TrackNumber: 1},
+		{ID: "t2", BookID: "b1", FilePath: "/lib/bk/b.mp3", DiscNumber: 0, TrackNumber: 2},
+	}
+	store := newSortStore(files)
+	book := database.Book{ID: "b1"}
+
+	for n, wantID := range []string{"t1", "t2", "t3"} {
+		_, _, gotID, err := nthAudioFile(store, book, n)
+		if err != nil {
+			t.Fatalf("nthAudioFile(%d): %v", n, err)
+		}
+		if gotID != wantID {
+			t.Errorf("nthAudioFile(%d) = %q, want %q", n, gotID, wantID)
+		}
+	}
+}
+
+// TestNthAudioFile_UntaggedFallsBackToPath covers rows with no disc/track tags at
+// all (both zero): ordering must fall through to FilePath, unchanged by the fix.
+func TestNthAudioFile_UntaggedFallsBackToPath(t *testing.T) {
+	files := []database.BookFile{
+		{ID: "z", BookID: "b1", FilePath: "/lib/bk/z.mp3"},
+		{ID: "a", BookID: "b1", FilePath: "/lib/bk/a.mp3"},
+	}
+	store := newSortStore(files)
+
+	_, _, gotID, err := firstAudioFile(store, database.Book{ID: "b1"})
+	if err != nil {
+		t.Fatalf("firstAudioFile: %v", err)
+	}
+	if gotID != "a" {
+		t.Errorf("first file = %q, want %q (lowest path when disc+track are absent)", gotID, "a")
+	}
+}

--- a/internal/server/handlers/audiobooks/handler_files.go
+++ b/internal/server/handlers/audiobooks/handler_files.go
@@ -1,7 +1,7 @@
 // file: internal/server/handlers/audiobooks/handler_files.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: 82f8d1f7-46d5-4ead-b5c1-ba796fd785f9
-// last-edited: 2026-07-03
+// last-edited: 2026-08-06
 
 // File / segment endpoints for the audiobooks domain: segment listing,
 // book-file listing + patch, track-info extraction, relocate, and segment
@@ -159,6 +159,19 @@ func (h *Handler) ListBookFiles(c *gin.Context) {
 			"file_exists":                 !f.Missing,
 			"created_at":                  f.CreatedAt,
 			"updated_at":                  f.UpdatedAt,
+			// Per-file intro transcription. This response is built from an
+			// explicit key list, so new BookFile fields are invisible to the UI
+			// until added here by hand — unlike the Pebble row, this layer is NOT
+			// additive-safe. GetBookFiles reads Pebble-direct, so intro_transcription
+			// is populated here despite being stripped from the memdb projection.
+			"intro_transcription":     f.IntroTranscription,
+			"transcribed_title":       f.TranscribedTitle,
+			"transcribed_author":      f.TranscribedAuthor,
+			"transcribed_narrator":    f.TranscribedNarrator,
+			"intro_transcribed_at":    f.IntroTranscribedAt,
+			"transcribe_status":       f.TranscribeStatus,
+			"transcribe_error":        f.TranscribeError,
+			"transcribe_attempted_at": f.TranscribeAttemptedAt,
 		})
 	}
 	httputil.RespondWithOK(c, gin.H{"files": results, "count": len(results)})

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.54.0
+// version: 2.55.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-08-06
 
@@ -278,6 +278,20 @@ export interface BookFile {
   deluge_hash?: string | null;
   deluge_original_path?: string | null;
   imported_from_deluge_at?: string | null;
+  // Per-file intro transcription: the spoken "<Title> by <Author>, read by
+  // <Narrator>" opening, recorded per FILE rather than per book so that a
+  // continuation ("...this part includes Chapter 2") is distinguishable from a
+  // genuine book start. intro_transcription is the raw Whisper transcript; the
+  // transcribed_* fields are what the parser extracted from it and are never
+  // treated as canonical metadata.
+  intro_transcription?: string | null;
+  transcribed_title?: string | null;
+  transcribed_author?: string | null;
+  transcribed_narrator?: string | null;
+  intro_transcribed_at?: string | null;
+  transcribe_status?: string | null;
+  transcribe_error?: string | null;
+  transcribe_attempted_at?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Foundation for a per-file audiobook identity signal. Storage + a sort fix. No behaviour change to the transcription op or the classifier yet — those are follow-ons.

## Why per-file

An audiobook opens with a spoken **"&lt;Title&gt; by &lt;Author&gt;, read by &lt;Narrator&gt;"** announcement. That marks a book **start**. Stored per-*book*, only one file's opening is ever captured, so "12 files that are one book" is indistinguishable from "12 files that are 12 books".

Real production evidence — one folder's files transcribe as:

```
file 1: "This is a reading of Overlord, Book 7. This part includes the prologue and Chapter 1."
file 2: "This is a reading of Overlord Volume 7. This part includes Chapter 2."
file 3: "Hello... This is Overlord Volume 7, Chapter 3."
```

Per-file, that sequence is proof of continuation. Per-book it is invisible.

It also explains the measured **45.8%** credit-parse rate across 1,476 review-queue member books: the op samples *one arbitrary file* per book, so for a 40-file shattered import it usually misses the opening entirely.

## The memdb split, and why it isn't all-or-nothing

8 fields go on `BookFile`; **7** go on `BookFileCore`. `IntroTranscription` is deliberately stripped from the memdb shape.

`stripBookForMemdb` exists to cut memdb from ~10 GB to ~2 GB, and this codebase already strips `AcoustIDSeg0..6` at ~550–900 MB as clearly worth it. A 90-second transcript at ~0.5–1.5 KB × **317,054 files** is **~160–475 MB** — squarely inside that band.

Stripping only the raw transcript captures ~99% of the bytes while keeping every field a query would filter on, and narrows the write-back preserve-guard to **one** field instead of eight.

`Book.IntroTranscription` is **retained**, not deprecated, so existing consumers (notably `maintenance.auto-match-transcribed`) keep working.

## The sort fix is a regression fix, not an omission

`nthAudioFile` received an already-correctly-ordered slice and **re-sorted it by `(track, path)`, destroying the disc key**. The canonical order is `(disc, track, path)`, set in `GetBookFiles` (`pebble_store_bookfiles.go:394-402`) and referenced by `assignDiscTrack`'s own comment.

It never affected regroup-written books — `assignDiscTrack` flattens to `DiscNumber=0` with contiguous tracks, and with disc constant the two comparators are indistinguishable. But rows carrying **real** disc numbers genuinely exist: `internal/scanner/scanner.go:1519` sets `bf.DiscNumber` straight from file tags, as do `tag_backfill.go:176` and the iTunes importer.

🔴 **This is load-bearing for the feature, not cleanup.** The per-file design rests on "track 1 carries the opening, tracks 2..N do not" — position is the discriminator that will fix the parser's `"by"` false positives. If the sort disagrees about which file is track 1, that discriminator reads the wrong row and the fix silently does not work.

## Both fixes are mutation-verified, not just observed green

- Reverting the comparator makes the test report `first file = "d2t1"` — disc 2's opening chosen as the book's intro.
- Neutralizing each write-path guard produces `WIPED the stored intro transcript`.

## A gap in the existing safety net

`TestRoundTrip_UpdateBookFile` populates **every** field reflectively, so the preserve-on-nil branch never executes — it cannot catch a wipe. There was no `BookFile` equivalent of the Book-level tripwire in `dataloss_preserve_invariant_test.go`, so `dataloss_bookfile_transcript_test.go` is new.

`BatchUpsertBookFiles` matters most there: it writes straight into the batch with no `UpdateBookFile` delegation, so its guard is the only protection on that path.

## Two things checked rather than assumed

- **`marshalBookFileDropSegs` was the real risk, and it is safe** — it is a shallow struct copy (`pebble_store.go:3824`), so all 8 fields persist. Had it been a field-enumerating shadow struct, every new field would have been silently dropped on write. Worth checking before trusting "additive-safe".
- **The API is NOT additive-safe.** `ListBookFiles` (`handler_files.go:117-163`) builds a hand-written `gin.H` with ~32 explicit keys, so new fields are invisible until added there. Same for `interface BookFile` in `web/src/services/api.ts`.

## Verification

```
go build ./...     exit 0
go vet ./...       exit 0
make mocks-check   ✅ up to date (struct fields only, no Store method)
make web-build     ✓ built

go test -race -count=1
ok  internal/database            423.846s
ok  internal/database/mocks        1.392s
ok  internal/plugins/maintenance  25.927s
ok  internal/itunes                8.702s
ok  internal/itunes/service       24.248s
```

Note: an earlier race run was **discarded as invalid** — mutation checks had modified files inside its scope, and `if false { … }` compiles silently, so it could have gone green against neutered guards. The numbers above are a fresh run against the clean tree.

## Scope fence

`ParseAudiobookIntro`, the op's book→file iteration, and the regroup classifier are all untouched — separate follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp