### PR TITLE
docs(todo): record the per-file intro-transcription follow-on work

### DIFF
--- a/changelog.d/20260806_220200_per_file_intro_followups.md
+++ b/changelog.d/20260806_220200_per_file_intro_followups.md
@@ -1,0 +1,22 @@
+<!-- file: changelog.d/20260806_220200_per_file_intro_followups.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c40a7e15-8362-4b9d-a17e-539f2c68b0da -->
+<!-- last-edited: 2026-08-06 -->
+
+### Added
+
+- **Two TODO fragments recording the per-file intro-transcription initiative** —
+  the follow-on work after the storage move and disc-aware sort fix landed.
+
+  The first captures the design and every measurement behind it: why per-book
+  storage made "12 files that are one book" indistinguishable from "12 files that
+  are 12 books", the confirmed parser false positives, the four-tier backfill that
+  turns ~284,000 files of GPU work into roughly 43,000 decision-critical ones, and
+  the ordering constraint that relinking must precede transcription (195 of 204
+  "untranscribed" review-queue members turned out to have no file at all).
+
+  The second records U1 (`unimatrixone`) as a prepared but unbuilt second Whisper
+  worker — 48 cores, 251 GB, **CPU-only**, Tdarr idle with an empty queue, uv and
+  pip installed. It states plainly that CPU int8 is not a second GPU and must be
+  benchmarked rather than assumed, and points it at the deadline-free tier where
+  "slower" costs nothing.

--- a/docs/continuation/2026-08-06-per-file-intro-continuation.md
+++ b/docs/continuation/2026-08-06-per-file-intro-continuation.md
@@ -1,0 +1,148 @@
+<!-- file: docs/continuation/2026-08-06-per-file-intro-continuation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9b52e738-1c40-4af6-8d29-63105ea7f8b1 -->
+<!-- last-edited: 2026-08-06 -->
+
+# Continuation prompt — per-file intro transcription (tasks #21 → #24)
+
+Paste the block under **PROMPT** into a fresh session. Everything above it is
+context for a human deciding whether to.
+
+---
+
+## Where things stand
+
+**Done and merged 2026-08-06:**
+
+| PR | What |
+|---|---|
+| #2168 | Per-file intro transcription **storage** + disc-aware first-file sort |
+| #2163 | Review-queue recommendations + durable human override |
+| #2162 | First Aid tier-2 duration probe |
+| #2161 | `dedupe-book-file-rows` per-row cost fix |
+| #2166 | memdb warmup write-loss fix |
+| #2159 / #2160 | All 5 Dependabot advisories |
+| #2165 | Frontend dependency upgrade report |
+| #2167 | ESLint 10 · TypeScript 6 · plugin-react 5 |
+
+**Open:** #2169 (these TODO fragments).
+
+**Blocked, documented, do not retry:** TypeScript 7 (`typescript-eslint` peers
+`<6.1.0`; npm refuses; no stable compiler API until 7.1) and Vite 8 (crashed every
+page here in June 2026 via a rolldown CJS/ESM interop bug; the fixing version was
+never confirmed). Full reasoning in
+`docs/2026-08-06-frontend-dependency-upgrade-report.md`.
+
+## The idea being built
+
+An audiobook opens with a spoken *"&lt;Title&gt; by &lt;Author&gt;, read by &lt;Narrator&gt;"*
+announcement. That marks a book **start**; a file without one is a continuation.
+It is **direct identity evidence**, where the shipped classifier has only runtime —
+a proxy.
+
+Storage is now per-`BookFile`, so the sequence across a book's files is finally
+visible. This is what a real multi-file book looks like:
+
+```
+file 1: "This is a reading of Overlord, Book 7. This part includes the prologue and Chapter 1."
+file 2: "This is a reading of Overlord Volume 7. This part includes Chapter 2."
+file 3: "Hello... This is Overlord Volume 7, Chapter 3."
+```
+
+Per-file, that is proof of one book. Per-book it was invisible — which is also why
+the credit-parse rate is only **45.8%** across 1,476 review-queue members: the op
+sampled one arbitrary file per book.
+
+## Measurements that should drive decisions (do not re-derive)
+
+- **Library shape** (600-book random sample; 7.0 files/book vs library-wide 7.1, so
+  representative): 72.7% single-file · 6.5% 2–5 · 6.8% 6–20 · **11.3% 21+** · 2.7%
+  zero files. **89.7% of all 317,054 files sit in multi-file books.**
+- **Review queue:** 356 pending holds, 1,476 member books. Under the shipped
+  runtime rule: 137 ambiguous→separate, 24 ambiguous→combine, 121
+  multidisc→combine, **3 multidisc→separate**, 71 insufficient-evidence.
+- **Transcript coverage on queue members:** 45.8% credits parsed · 40.4%
+  transcribed but no credits grammar · 13.8% no transcript.
+- 🔴 **195 of those 204 "no transcript" books have ZERO `book_file` rows.** They are
+  **unlinked**, not un-transcribed. There is no file to clip. **Relink first.**
+- **Book-level transcription is saturated** — a full `only_missing` run over 221
+  pages transcribed **0** books. No warm-up value remains.
+- **The WAV clip cache is keyed by file path**, so clips already extracted survive
+  the per-file move and ffmpeg is skipped on re-run.
+
+## The rule that keeps being violated
+
+**Absent evidence means "cannot verify", never a specific cause.** Four distinct
+instances in one session:
+
+| Absent value | Was read as | Cost |
+|---|---|---|
+| `DurationSec == 0` | "short" | series guard inert across 97.5% of the queue |
+| a 404 response body | "zero files" | a confident, exactly-inverted measurement |
+| `memPtr == nil` | "nothing to do" | writes silently dropped for the process lifetime |
+| empty `intro_transcription` | "needs transcribing" | actually meant "has no file" |
+
+---
+
+## PROMPT
+
+> Continue the per-file audiobook identity signal. Storage and the disc-aware
+> first-file sort are merged (#2168). Read
+> `docs/continuation/2026-08-06-per-file-intro-continuation.md` and the two
+> `todo.d/20260806_2200*` fragments first — they carry every measurement, so do not
+> re-derive them.
+>
+> Work these in order, one PR each, worktree per task, verifying with real output
+> before claiming anything passes:
+>
+> **#21 — three-outcome parser.** `ParseAudiobookIntro`
+> (`internal/transcribe/parse.go:70`) splits on the first standalone `"by"` and
+> returns credits-or-nothing. Confirmed production false positives: a book in a
+> *Girls with Rebel Souls* folder parsed as `"Meet Me in Paradise / Libby
+> Hubscher"`, and prose *"...he wasn't mildly amused by Memphis fortunes"* parsed as
+> TITLE/AUTHOR. Make it distinguish **book-opening credits** / **chapter
+> announcement** (*"This part includes Chapter 2"*, *"Welcome to X Audio Books"*) /
+> **prose**. Use **track position** as the new discriminator — a genuine opening is
+> at track 1, prose-containing-"by" occurs anywhere. Absent transcript must yield
+> "cannot verify", never "continuation".
+>
+> **#22 — tiered backfill.** Tier 0: single-file books migrate by copy, zero GPU
+> (~32,600 books) — but verify against `intro_transcribe.go`'s "second audio file"
+> retry, which breaks the copy assumption for some books. Tier 1: assembled
+> multi-file books, probe the first 3 files only. Tier 1b: **escalate to the full
+> set if all 3 carry credits** — that is what makes the cheap tier safe rather than
+> merely cheap. Tier 2: bookless/shattered/queue members get every file. Tier 3: a
+> lazy, interruptible, checkpointed full sweep so every file eventually has a
+> transcript, yielding to every tier above it. Keep it a bounded worker pool per
+> CLAUDE.md; the item count goes ~7× when iterating files instead of books, so
+> re-check page sizing and the 5-minute `ProgressTimeout`.
+>
+> **#23 — wire into the classifier.** The credits signal should outrank runtime
+> where both exist: every member has credits → `separate`; file 1 credits + rest
+> continuations → `combine`; disagreement → review; no transcript → fall back to
+> the runtime rule. Extend `RecommendationEvidence` with the transcript counts.
+> **Validate by diffing against the 356 holds already measured under the runtime
+> rule** and inspecting every disagreement by hand before shipping.
+>
+> **#24 — wire into First Aid.** Credits belong in **tier 2**, beside the duration
+> probe — two independent signals whose agreement is what makes a verdict
+> trustworthy. Let the verdict pick the fixer, and when a transcript is missing,
+> **enqueue** the transcription op rather than parking (TODO.md notes that
+> `waiting_deps` parking waits but never enqueues the producer).
+>
+> Standing constraints: worktree per task, never edit the primary checkout; PR each
+> one and give me the **full GitHub link on `main` after merge** — I am usually not
+> on the Mac. `review_apply_enabled` stays OFF; prod applies need an explicit gate.
+> This is a **public repo** — never commit internal IPs or tokens; the pre-commit
+> hook will reject them.
+
+## Also outstanding (separate from this chain)
+
+- **#4** multidisc canary — snapshot captured (132 holds, 4,146 members, zero
+  unreadable); needs #23 plus an explicit human gate to flip `review_apply_enabled`.
+- **#6 follow-through** — apply the 434 confidently-linkable directory-shaped books.
+- **Package upgrades** — zustand, jsdom, Testing Library are ~1 day combined and
+  independent. React 19 → react-router 8 next. MUI 5→6→7→9 is ~1 week and ~75% of
+  the total. **Fix the e2e suite first** (`unknown parameter "_page"`, broken on
+  `main`, gates nothing) — it is the exact gap that let Vite 8 merge green in June.
+- **#7, #8, #10–#18** — see `TODO.md`.

--- a/todo.d/20260806_220000_per_file_intro_identity_signal.md
+++ b/todo.d/20260806_220000_per_file_intro_identity_signal.md
@@ -1,0 +1,75 @@
+<!-- file: todo.d/20260806_220000_per_file_intro_identity_signal.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3a7c2e94-5b18-4d60-9f27-c8140b6e3d52 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **Per-file intro transcription as the primary book-identity signal** — owner
+  design 2026-08-06. Storage and the first-file sort fix are **DONE** (PRs #2168);
+  the parser, the tiered backfill, and the wiring are open.
+
+  **The idea.** An audiobook opens with a spoken *"&lt;Title&gt; by &lt;Author&gt;, read by
+  &lt;Narrator&gt;"* announcement. That announcement marks a book **start**. A file
+  without one is a continuation. That is direct identity evidence, where the
+  current classifier only has runtime — a proxy.
+
+  **Why it needed per-file storage.** Transcripts lived on `Book`, so only ONE
+  file's opening was ever captured and "12 files that are one book" was
+  indistinguishable from "12 files that are 12 books". Measured on prod, one
+  folder's files read:
+
+  ```
+  file 1: "This is a reading of Overlord, Book 7. This part includes the prologue and Chapter 1."
+  file 2: "This is a reading of Overlord Volume 7. This part includes Chapter 2."
+  file 3: "Hello... This is Overlord Volume 7, Chapter 3."
+  ```
+
+  Per-file that sequence is proof of continuation; per-book it is invisible. It
+  also explains the measured **45.8%** credit-parse rate across 1,476 review-queue
+  members — the op sampled one arbitrary file per book.
+
+  ### Remaining work
+
+  - [ ] **Three-outcome parser.** `ParseAudiobookIntro` splits on the first
+        standalone `"by"` and returns credits-or-nothing. Confirmed prod false
+        positives: a book in a *Girls with Rebel Souls* folder parsed as
+        `"Meet Me in Paradise / Libby Hubscher"`, and prose *"...he wasn't mildly
+        amused by Memphis fortunes"* parsed as TITLE/AUTHOR. Must distinguish
+        **book-opening credits** / **chapter announcement** (*"This part includes
+        Chapter 2"*, *"Welcome to X Audio Books"*) / **prose**. Per-file storage
+        unlocks the discriminator that fixes this: **position** — a real opening
+        is at track 1, prose-containing-"by" is at any track. That is why the
+        disc-aware sort fix (#2168) was a prerequisite and not cleanup.
+  - [ ] **Tiered backfill.** Naive "every file" is ~284,000 files ≈ 12–14 days of
+        GPU. Tiers: **0** single-file books migrate by copy (zero GPU, ~32,600
+        books); **1** assembled multi-file books probe the first 3 files only;
+        **1b** escalate to the full set if all 3 carry credits — which is what
+        makes the cheap tier *safe*, since it cannot silently be wrong; **2**
+        bookless/shattered/queue members get every file; **3** a lazy, indefinite
+        full sweep so every file eventually has a transcript.
+  - [ ] **Wire into the regroup classifier**, outranking runtime where both exist.
+        Validate by diffing against the 356 holds already measured under the
+        runtime rule.
+  - [ ] **Wire into First Aid** as a tier-2 signal beside the duration probe, and
+        let the verdict pick the fixer.
+
+  ### Measured facts worth keeping
+
+  - 72.7% of books are single-file; 11.3% have 21+ files and hold most of the
+    317,054 rows. The signal is precisely targeted at the fraction that is
+    actually ambiguous.
+  - **195 of 204** "untranscribed" review-queue members have ZERO `book_file`
+    rows — unlinked, not un-transcribed. **Relink before transcribing** or they
+    need a second pass. [[first-aid-library-validate-repair]]'s probe already
+    found 434 of 1,019 directory-shaped books confidently linkable.
+  - The WAV clip cache is keyed by **file path**, so clips already extracted
+    survive the per-file move and ffmpeg is skipped on re-run.
+  - Book-level transcription is already **saturated** — a full `only_missing` run
+    over 221 pages transcribed 0 books. There is no warm-up value left; the
+    per-file pass is the entire remaining work.
+
+  🔴 **Absent transcript means "cannot verify", never "continuation".** This
+  codebase has now been bitten by absent-value-read-as-evidence four separate
+  ways: `DurationSec == 0` read as "short" (disabled the series guard across 97.5%
+  of the queue), a 404 body read as "zero files", `memPtr == nil` read as "nothing
+  to do" (silently dropped writes for the process lifetime), and an empty
+  `intro_transcription` read as "needs transcribing" when it meant "has no file".

--- a/todo.d/20260806_220100_whisper_second_worker_u1.md
+++ b/todo.d/20260806_220100_whisper_second_worker_u1.md
@@ -1,0 +1,38 @@
+<!-- file: todo.d/20260806_220100_whisper_second_worker_u1.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6f31d4b8-92ae-4c07-b5f1-08e3a7d26c94 -->
+<!-- last-edited: 2026-08-06 -->
+
+- [ ] **Stand up a second Whisper worker on the spare CPU node.** Owner request
+  2026-08-06. Host prepared, worker not built. (Host address and credentials are
+  fleet-internal — see the private infra notes, not this repo.)
+
+  **Why it is cheap to try:** the transcription backend is already a pluggable
+  HTTP service — `WHISPER_REMOTE_URL` points at a faster-whisper instance on the
+  GPU host. Adding a second worker is a deployment question, not a code change.
+  `internal/transcribe/batch.go:51` reads a single URL today, so the only code work
+  is fanning out across several endpoints.
+
+  **The node as measured 2026-08-06:** Ubuntu 26.04, 48 cores, 251 GB RAM,
+  **no GPU**. Its Tdarr node registers CPU-only with `transcodegpu: 0`, the Tdarr
+  queue is **empty** (`table1Count: 0`), and both node processes sit at 0.0% CPU —
+  so nothing needs stopping to free it. Python 3.14.3 with pip 25.1.1 and uv 0.12.2
+  (both installed 2026-08-06).
+
+  🔴 **CPU-only is the whole caveat.** faster-whisper with int8 quantisation on 48
+  cores is real, but it is **not** a second GPU. **Benchmark against a real clip
+  batch before promising throughput** — do not assume it halves the backfill.
+
+  **Prefer an HTTP endpoint over the in-process `uv` path.** `whisper.go` also has
+  `runPythonWhisper` (`uv run --with openai-whisper whisper`), and uv is now
+  installed so that route works — but `batch.go:54-57` warns it loads the full
+  model into RAM and *"reliably OOMs the server"* at batch sizes of 100–200. That
+  warning was written about the **web-serving host**; the spare node has 251 GB and
+  serves nothing, so the reasoning does not transfer directly. Even so, a second
+  HTTP endpoint matches the existing interface, avoids the OOM class entirely, and
+  needs no special batch sizing.
+
+  **Point it at tier 3 first.** The lazy full sweep in
+  [[per-file-intro-identity-signal]] has no deadline, which makes it the natural
+  consumer for a slower worker — "slower than GPU" costs nothing there, while the
+  decision-critical tiers keep the GPU.


### PR DESCRIPTION
Documentation only. Two `todo.d/` fragments plus a changelog fragment.

Storage and the disc-aware sort fix landed in #2168. These record what remains and the measurements behind it, so none of it gets re-derived.

## Fragment 1 — the per-file identity signal

An audiobook opens with a spoken *"&lt;Title&gt; by &lt;Author&gt;, read by &lt;Narrator&gt;"* announcement, which marks a book **start**. Per-*book* storage captured only one file's opening, making "12 files that are one book" indistinguishable from "12 files that are 12 books".

Records:

- **The measured evidence** — one production folder whose files read `"...prologue and Chapter 1"` / `"...Chapter 2"` / `"...Chapter 3"`. Per-file that sequence proves continuation; per-book it is invisible. It also explains the **45.8%** credit-parse rate across 1,476 review-queue members.
- **The confirmed parser false positives** — narrative prose containing "by" scoring as TITLE/AUTHOR — and why **position** is the discriminator that fixes them. That is why the disc-aware sort was a prerequisite, not cleanup.
- **The four-tier backfill:** single-file books migrate by copy (zero GPU, ~32,600 books); assembled multi-file books probe 3 files; **escalate to the full set if all 3 carry credits**; bookless books get every file; a lazy sweep finishes the corpus. ~284,000 files of GPU work → ~43,000 decision-critical ones.
- **The ordering constraint:** **195 of 204** "untranscribed" review-queue members have zero `book_file` rows. They are unlinked, not un-transcribed. Relink first or they need a second pass.
- **That book-level transcription is saturated** — a full `only_missing` run over 221 pages transcribed 0 books. There is no warm-up value left.

## Fragment 2 — a second Whisper worker on the spare CPU node

Prepared, not built. 48 cores, 251 GB, **no GPU**, Tdarr node idle with an empty queue, uv and pip installed today.

States plainly that CPU int8 is real but **is not a second GPU** and must be benchmarked rather than assumed; recommends an HTTP endpoint over the in-process `uv` path (which `batch.go` warns reliably OOMs); and points it at the deadline-free tier where "slower" costs nothing.

Host addresses are deliberately omitted — this is a public repo, and the pre-commit hook correctly rejected the first draft for containing internal IPs. Fleet-internal detail belongs in the private infra notes.

## Why the detail

Both fragments restate the rule this codebase has now been bitten by **four distinct ways in one session**:

| Absent value | Read as | Consequence |
|---|---|---|
| `DurationSec == 0` | "short" | disabled the series guard across 97.5% of the queue |
| a 404 body | "zero files" | a confident, exactly-inverted measurement |
| `memPtr == nil` | "nothing to do" | writes silently dropped for the process lifetime |
| empty `intro_transcription` | "needs transcribing" | it actually meant "has no file at all" |

**Absent evidence means "cannot verify", never a specific cause.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp