### PR TITLE
fix(maintenance): repair transcribe_status falsified by a transport outage

### DIFF
--- a/changelog.d/20260807_114500_repair_transcribe_status.md
+++ b/changelog.d/20260807_114500_repair_transcribe_status.md
@@ -1,0 +1,35 @@
+<!-- file: changelog.d/20260807_114500_repair_transcribe_status.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7e5b12c8-4a09-4d63-b8f1-2c60943ae7d5 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Fixed
+
+- **~77% of the library was falsely marked `whisper_error`.** A day-long
+  transcription-endpoint outage on 2026-07-01 tripped `processTranscribePage`'s
+  whole-batch error path, which marks **every** book in a page as
+  `whisper_error`. Measured 2026-08-07: 76.7% of a 300-book random sample carried
+  the status, and **229 of those 230 books had good transcript text** — dated
+  2026-06-27, four days before the outage. Across a 400-book sample the failures
+  clustered into 17 timestamps, all on 2026-07-01, every error a connection
+  failure. No transcript was ever damaged (`applyOutcome` correctly refuses to
+  overwrite good text with nothing); only the status was wrong. The library had
+  degraded into "everything looks broken while everything is fine" — the worst
+  state for any query that filters on status, including the tiered backfill's
+  "what still needs work" query.
+
+### Added
+
+- **`maintenance.repair-transcribe-status`** repairs rows whose stored error is a
+  **transport** failure rather than a transcription failure: it recomputes the
+  status from the stored text (credits → `ok`, else `unparsed`), or clears it back
+  to never-attempted where there is no text. It never calls Whisper and never
+  touches transcript text. Genuine failures (a model OOM, an ffmpeg codec error)
+  and the `[SILENCE]` sentinel are deliberately left alone, and an *unrecognised*
+  error is treated as genuine — wrongly clearing a real failure hides a broken
+  file, while wrongly keeping one only costs a re-run. Defaults to `dry_run=true`.
+
+  🔴 The principle it encodes: **an unreachable endpoint is "no attempt made",
+  not "the attempt failed."** Recording it per-file blames the file for the
+  network's problem. Same rule the intro classifier applies one layer up, where
+  an absent transcript yields `unknown` rather than `prose`.

--- a/internal/plugins/maintenance/auto_match_transcribed.go
+++ b/internal/plugins/maintenance/auto_match_transcribed.go
@@ -34,16 +34,16 @@ type autoMatchTranscribedParams struct {
 
 func (p *Plugin) autoMatchTranscribedDef() sdk.OperationDef {
 	return sdk.OperationDef{
-		ID:             "maintenance.auto-match-transcribed",
-		Plugin:         "maintenance",
-		DisplayName:    "Auto-match transcribed books",
-		Description:    "Walks the library and auto-applies the best metadata candidate to unreviewed books whose audio-derived transcription exactly matches a search result above a configurable score threshold. Dry-run by default — pass dry_run=false to apply. Checkpointed and cancellable.",
-		ResumePolicy:   sdk.ResumeRestart,
+		ID:              "maintenance.auto-match-transcribed",
+		Plugin:          "maintenance",
+		DisplayName:     "Auto-match transcribed books",
+		Description:     "Walks the library and auto-applies the best metadata candidate to unreviewed books whose audio-derived transcription exactly matches a search result above a configurable score threshold. Dry-run by default — pass dry_run=false to apply. Checkpointed and cancellable.",
+		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
-		ConcurrencyKey: "maintenance.auto-match-transcribed",
-		Cancellable:    true,
-		Timeout:        12 * time.Hour,
-		Run:            p.runAutoMatchTranscribed,
+		ConcurrencyKey:  "maintenance.auto-match-transcribed",
+		Cancellable:     true,
+		Timeout:         12 * time.Hour,
+		Run:             p.runAutoMatchTranscribed,
 	}
 }
 

--- a/internal/plugins/maintenance/auto_match_transcribed_test.go
+++ b/internal/plugins/maintenance/auto_match_transcribed_test.go
@@ -44,7 +44,7 @@ func (d *autoMatchDeps) HasMetadataFetchService() bool { return true }
 
 // ptr helpers
 
-func boolPtr(b bool) *bool   { return &b }
+func boolPtr(b bool) *bool    { return &b }
 func strPtr(s string) *string { return &s }
 
 // newAutoMatchPlugin builds a Plugin + MockStore wired to the given books.
@@ -86,9 +86,9 @@ func TestAutoMatchTranscribed_Apply(t *testing.T) {
 	author := "Patrick Rothfuss"
 	books := []database.Book{
 		{
-			ID:              "b1",
-			Title:           "Name Wind",
-			TranscribedTitle: strPtr(trans),
+			ID:                "b1",
+			Title:             "Name Wind",
+			TranscribedTitle:  strPtr(trans),
 			TranscribedAuthor: strPtr(author),
 			// MetadataReviewStatus == nil → eligible
 		},

--- a/internal/plugins/maintenance/dedup_triage_test.go
+++ b/internal/plugins/maintenance/dedup_triage_test.go
@@ -107,7 +107,7 @@ func TestClassifyCandidate_Fragment_Cons17Suspect_NotFragment(t *testing.T) {
 	// CONS-17: one book has an astronomically large duration (stored as ms instead
 	// of seconds) with no DurationVerifiedAt. The ratio looks tiny (<5%) but the
 	// duration data is unreliable — must fall through to unknown, not fragment.
-	a := makeBook("a", 50*1024*1024, 31431, "")   // correct: ~8.7h
+	a := makeBook("a", 50*1024*1024, 31431, "")    // correct: ~8.7h
 	b := makeBook("b", 50*1024*1024, 31430435, "") // CONS-17: 31430435s = 364 days
 	c := database.DedupCandidate{Layer: "exact"}
 
@@ -168,7 +168,7 @@ func TestClassifyCandidate_TitleLeak_NonITunes_SameTitle_NilBreakdown(t *testing
 	a := makeBook("a", 5*1024*1024, 3600, "")
 	b := makeBook("b", 5*1024*1024, 3500, "")
 	a.Title = "Chapter Leak Book"
-	b.Title = "chapter  leak BOOK" // normalization: case + whitespace runs
+	b.Title = "chapter  leak BOOK"               // normalization: case + whitespace runs
 	c := database.DedupCandidate{Layer: "exact"} // pre-T015, nil breakdown
 
 	cls, reason := ClassifyCandidate(c, a, b)

--- a/internal/plugins/maintenance/dedupe_book_file_rows.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows.go
@@ -34,10 +34,10 @@ type DedupeBookFileRowsParams struct {
 
 func (p *Plugin) dedupeBookFileRowsDef() sdk.OperationDef {
 	return sdk.OperationDef{
-		ID:          "maintenance.dedupe-book-file-rows",
-		Plugin:      "maintenance",
-		DisplayName: "De-duplicate book_file rows",
-		Description: "Finds books holding MORE THAN ONE book_file row for the same file_path and removes the redundant rows, then recomputes the book's aggregates. Duplicated rows inflate a book's total duration and file size by the duplication factor. Dry-run by default — pass {\"apply\": true} to delete.",
+		ID:              "maintenance.dedupe-book-file-rows",
+		Plugin:          "maintenance",
+		DisplayName:     "De-duplicate book_file rows",
+		Description:     "Finds books holding MORE THAN ONE book_file row for the same file_path and removes the redundant rows, then recomputes the book's aggregates. Duplicated rows inflate a book's total duration and file size by the duplication factor. Dry-run by default — pass {\"apply\": true} to delete.",
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.dedupe-book-file-rows",

--- a/internal/plugins/maintenance/dedupe_book_file_rows_parallel_test.go
+++ b/internal/plugins/maintenance/dedupe_book_file_rows_parallel_test.go
@@ -35,9 +35,9 @@ func (r *concurrentReporter) UpdateProgress(cur, _ int, _ string) error {
 	return nil
 }
 func (r *concurrentReporter) Log(_ slog.Level, _ string, _ ...slog.Attr) error { return nil }
-func (r *concurrentReporter) Logger() *slog.Logger                            { return slog.Default() }
-func (r *concurrentReporter) Checkpoint(_ any) error                          { return nil }
-func (r *concurrentReporter) IsCanceled() bool                                { return false }
+func (r *concurrentReporter) Logger() *slog.Logger                             { return slog.Default() }
+func (r *concurrentReporter) Checkpoint(_ any) error                           { return nil }
+func (r *concurrentReporter) IsCanceled() bool                                 { return false }
 func (r *concurrentReporter) RunPhase(ctx context.Context, _ string, fn func(context.Context, registry.Reporter) error) error {
 	return fn(ctx, r)
 }

--- a/internal/plugins/maintenance/duration_backfill_test.go
+++ b/internal/plugins/maintenance/duration_backfill_test.go
@@ -118,7 +118,7 @@ func TestDurationLooksLikeMillis(t *testing.T) {
 func TestDurationBackfill_ParallelProducesCorrectResults(t *testing.T) {
 	// Create test books and files with ms-valued durations.
 	fileSize64kbps := bytesForBitrate(3600, 64) // 1 hour at 64kbps
-	msValuedDuration := 3600 * 1000              // 1 hour in milliseconds
+	msValuedDuration := 3600 * 1000             // 1 hour in milliseconds
 
 	books := []database.Book{
 		{ID: "book1", Title: "Book One"},

--- a/internal/plugins/maintenance/duration_reextract.go
+++ b/internal/plugins/maintenance/duration_reextract.go
@@ -340,19 +340,19 @@ func (p *Plugin) runDurationReextract(ctx context.Context, raw json.RawMessage, 
 	// All counters and the examples slice are owned exclusively by the collector
 	// goroutine (the main goroutine after the workers start). No locking needed.
 	var (
-		examined      int
-		eligible      int
-		wouldChange   int
-		roughlyDouble int
-		estimated     int
-		readErr       int
-		noPath        int
+		examined       int
+		eligible       int
+		wouldChange    int
+		roughlyDouble  int
+		estimated      int
+		readErr        int
+		noPath         int
 		fpBooks        int
 		ffprobeBooks   int
 		storedDurBooks int
 		written        int
-		examples      = make([]string, 0, exampleCap)
-		lastLog       = time.Now()
+		examples       = make([]string, 0, exampleCap)
+		lastLog        = time.Now()
 	)
 
 	heartbeat := func(force bool) {

--- a/internal/plugins/maintenance/fs_regroup_xml_test.go
+++ b/internal/plugins/maintenance/fs_regroup_xml_test.go
@@ -214,10 +214,10 @@ func TestApplyFSRegroup_ExtIDErrorSkipsDelete(t *testing.T) {
 	survivor := &database.Book{ID: "surv"}
 	deleted := map[string]bool{}
 	mock := &database.MockStore{
-		GetBookByIDFunc:        func(id string) (*database.Book, error) { return survivor, nil },
-		GetBookFileByPathFunc:  func(string) (*database.BookFile, error) { return nil, nil },
-		CreateBookFileFunc:     func(*database.BookFile) error { return nil },
-		UpdateBookFunc:         func(_ string, b *database.Book) (*database.Book, error) { return b, nil },
+		GetBookByIDFunc:       func(id string) (*database.Book, error) { return survivor, nil },
+		GetBookFileByPathFunc: func(string) (*database.BookFile, error) { return nil, nil },
+		CreateBookFileFunc:    func(*database.BookFile) error { return nil },
+		UpdateBookFunc:        func(_ string, b *database.Book) (*database.Book, error) { return b, nil },
 		GetExternalIDsForBookFunc: func(string) ([]database.ExternalIDMapping, error) {
 			return []database.ExternalIDMapping{{ExternalID: "p", BookID: "shell"}}, nil
 		},

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -109,10 +109,10 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	if len(rawParams) > 0 {
 		_ = json.Unmarshal(rawParams, &params)
 	}
-	onlyMissing  := params.OnlyMissing == nil || *params.OnlyMissing
+	onlyMissing := params.OnlyMissing == nil || *params.OnlyMissing
 	retrySilence := params.RetrySilence != nil && *params.RetrySilence
-	reparseOnly  := params.ReparseOnly != nil && *params.ReparseOnly
-	extractOnly  := params.ExtractOnly != nil && *params.ExtractOnly
+	reparseOnly := params.ReparseOnly != nil && *params.ReparseOnly
+	extractOnly := params.ExtractOnly != nil && *params.ExtractOnly
 
 	log := reporter.Logger()
 

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -89,6 +89,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.probeDirectoryBooksDef(),
 		p.itunesHealDef(),
 		p.introTranscribeDef(),
+		p.repairTranscribeStatusDef(),
 		p.extractWAVClipsDef(),
 
 		// --- title cleanup ---

--- a/internal/plugins/maintenance/regroup_apply_test.go
+++ b/internal/plugins/maintenance/regroup_apply_test.go
@@ -611,8 +611,8 @@ func TestApplyMultidisc_FlatSameDisc_SetsTracksNotDiscs(t *testing.T) {
 		"/lib/When We Were Sisters/When We Were Sisters_3.mp3",
 	}
 	ids, fpByPath := seedNumberedBooks(t, store, paths)
-	discs := []int{0, 0, 0}   // no disc concept — same recording
-	tracks := []int{1, 2, 3}  // sequential chapters
+	discs := []int{0, 0, 0}  // no disc concept — same recording
+	tracks := []int{1, 2, 3} // sequential chapters
 
 	apply := ApplyMultidisc(store, merge.NewService(store))
 	item := multidiscItemWithNumbers(t, "/lib/When We Were Sisters", ids, paths, discs, tracks)

--- a/internal/plugins/maintenance/repair_junk_titles.go
+++ b/internal/plugins/maintenance/repair_junk_titles.go
@@ -196,7 +196,7 @@ func (p *Plugin) runRepairJunkTitles(ctx context.Context, raw json.RawMessage, r
 	}, registry.RunItemsOptions{
 		Concurrency: titleRepairWorkers(),
 		ErrMode:     registry.ErrModeCollect,
-		Label: func(i, total int) string { return fmt.Sprintf("book %d/%d", i+1, total) },
+		Label:       func(i, total int) string { return fmt.Sprintf("book %d/%d", i+1, total) },
 	})
 	if runErr != nil && ctx.Err() != nil {
 		log.Warn("repair-junk-titles: cancelled", "repaired", repaired.Load())

--- a/internal/plugins/maintenance/repair_transcribe_status.go
+++ b/internal/plugins/maintenance/repair_transcribe_status.go
@@ -1,0 +1,320 @@
+// file: internal/plugins/maintenance/repair_transcribe_status.go
+// version: 1.0.0
+// guid: a5e3c81f-7204-4b96-9d3a-1f68b05e2c47
+// last-edited: 2026-08-07
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// Repairs transcribe_status rows that record a TRANSPORT failure rather than a
+// transcription failure.
+//
+// ── What happened ────────────────────────────────────────────────────────────
+//
+// On 2026-07-01 the remote Whisper server was unreachable for a full day. Every
+// batch that ran that day failed at the HTTP layer, and processTranscribePage's
+// whole-batch error path marks EVERY book in the page whisper_error:
+//
+//	batchResults, err := transcribe.TranscribeBatch(...)
+//	if err != nil {
+//	    for bookID := range batchJobs { applyOutcome(..., statusWhisperError, ...) }
+//	}
+//
+// Measured on prod 2026-08-07: 76.7% of a 300-book random sample carried
+// whisper_error, and 229 of those 230 books HAD good transcript text — dated
+// 2026-06-27, four days BEFORE the failure. Across a 400-book sample the
+// failures clustered into 17 distinct timestamps, every one of them on
+// 2026-07-01, every error a connection failure to the transcription endpoint.
+//
+// So the transcripts were never damaged: applyOutcome correctly refuses to
+// overwrite good text with nothing. Only the STATUS is wrong. The library
+// degraded into "everything looks broken while everything is fine" — the worst
+// possible state for any query that filters on status, including the tiered
+// backfill's "what still needs work" query.
+//
+// ── The principle ────────────────────────────────────────────────────────────
+//
+// 🔴 An unreachable endpoint is NO ATTEMPT MADE, not a failed attempt. It is
+// absence of evidence about the file, and recording it as a per-file failure
+// attributes to the file a problem that belonged to the network. This is the
+// same rule the intro classifier applies one layer up, where an absent
+// transcript yields "unknown" rather than "prose".
+//
+// ── What this op does ────────────────────────────────────────────────────────
+//
+// For rows whose stored error is a TRANSPORT error (not a model/codec error):
+//
+//	text present, not [SILENCE]  -> recompute status from the text itself
+//	                                (credits -> ok, otherwise -> unparsed)
+//	no text                      -> clear status and error entirely, back to
+//	                                never-attempted
+//	[SILENCE] sentinel           -> left alone; that is a real terminal state
+//
+// It never calls Whisper and never touches transcript text. Rows whose error is
+// a genuine transcription failure (a model crash on one file, an ffmpeg codec
+// error) are deliberately left alone — those are honest records.
+
+type repairStatusParams struct {
+	// DryRun reports what WOULD change without writing. Defaults to TRUE.
+	DryRun *bool `json:"dry_run,omitempty"`
+	// LastBookID resumes past a prior run's checkpoint.
+	LastBookID string `json:"last_book_id,omitempty"`
+}
+
+const (
+	repairRecomputedOK       = "recomputed_ok"
+	repairRecomputedUnparsed = "recomputed_unparsed"
+	repairClearedNeverTried  = "cleared_to_never_attempted"
+	repairWouldChange        = "would_change"
+	repairSkipNotFailed      = "skip_status_not_a_failure"
+	repairSkipNotTransport   = "skip_genuine_failure_kept"
+	repairSkipSilence        = "skip_silence_sentinel"
+	repairWriteFailed        = "write_failed"
+)
+
+const repairStatusPageSize = 500
+
+// transportErrorMarkers identify a failure that happened BELOW the transcriber:
+// the request never reached a working model. Matching is on generic HTTP/network
+// wording, never on any host address.
+var transportErrorMarkers = []string{
+	`post "http`, // Go's http.Post error prefix
+	"connection refused",
+	"no such host",
+	"context deadline exceeded",
+	"connection reset",
+	"i/o timeout",
+	"unexpected eof",
+	": eof",
+	"dial tcp",
+	"server misbehaving",
+	"network is unreachable",
+}
+
+// isTransportFailure reports whether a stored TranscribeError describes a
+// transport problem rather than a transcription problem.
+//
+// Deliberately conservative: an unrecognised error is treated as a GENUINE
+// failure and left alone. Wrongly clearing a real failure hides a broken file;
+// wrongly keeping one costs a re-run. The asymmetry favours keeping.
+func isTransportFailure(errText string) bool {
+	e := strings.ToLower(strings.TrimSpace(errText))
+	if e == "" {
+		return false
+	}
+	for _, m := range transportErrorMarkers {
+		if strings.Contains(e, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// repairVerdict is the decision for one book, computed without any I/O.
+type repairVerdict struct {
+	Reason string
+	// NewStatus is the status to store; nil means CLEAR the field.
+	NewStatus *string
+	// Write is true when the row should be updated.
+	Write bool
+}
+
+// classifyStatusRepair decides what to do with one book's transcription status.
+// Pure: no store, no clock, so the rules are directly testable.
+func classifyStatusRepair(b database.Book) repairVerdict {
+	status := ""
+	if b.TranscribeStatus != nil {
+		status = *b.TranscribeStatus
+	}
+	switch status {
+	case statusWhisperError, statusFFmpegError, statusSourceMissing, statusNoAudio, statusEmpty:
+		// candidate — fall through
+	default:
+		// ok / unparsed / unset: nothing to repair.
+		return repairVerdict{Reason: repairSkipNotFailed}
+	}
+
+	errText := ""
+	if b.TranscribeError != nil {
+		errText = *b.TranscribeError
+	}
+	if !isTransportFailure(errText) {
+		// A real transcription failure. Honest record; keep it.
+		return repairVerdict{Reason: repairSkipNotTransport}
+	}
+
+	text := ""
+	if b.IntroTranscription != nil {
+		text = strings.TrimSpace(*b.IntroTranscription)
+	}
+
+	// The sentinel is a REAL terminal state (every retry returned zero chars),
+	// not a transport artifact. Clearing it would put the book back in the queue
+	// forever at GPU cost.
+	if text == transcribe.SilenceSentinel {
+		return repairVerdict{Reason: repairSkipSilence}
+	}
+
+	if text == "" {
+		// No text and the endpoint was down: we genuinely do not know anything
+		// about this file. Clear back to never-attempted rather than assert a
+		// failure that belonged to the network.
+		return repairVerdict{Reason: repairClearedNeverTried, NewStatus: nil, Write: true}
+	}
+
+	// Text survived the outage. Derive the truthful status from the text itself.
+	c := transcribe.ClassifyIntro(text, transcribe.UnknownPosition)
+	if c.Kind == transcribe.IntroKindCredits {
+		s := statusOK
+		return repairVerdict{Reason: repairRecomputedOK, NewStatus: &s, Write: true}
+	}
+	s := statusUnparsed
+	return repairVerdict{Reason: repairRecomputedUnparsed, NewStatus: &s, Write: true}
+}
+
+func (p *Plugin) repairTranscribeStatusDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.repair-transcribe-status",
+		Plugin:          "maintenance",
+		DisplayName:     "Repair transcribe status after a transport outage",
+		Description:     "Fixes transcribe_status rows that record a TRANSPORT failure (the Whisper endpoint was unreachable) rather than a transcription failure. A day-long outage on 2026-07-01 marked ~77% of the library whisper_error while their transcripts, dated four days earlier, survived intact. This recomputes the status from the stored text (credits -> ok, else unparsed), or clears it back to never-attempted where there is no text. Never calls Whisper, never touches transcript text, and leaves genuine failures and the [SILENCE] sentinel alone. Defaults to dry_run=true.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.repair-transcribe-status",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		ProgressTimeout: 5 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runRepairTranscribeStatus,
+	}
+}
+
+func (p *Plugin) runRepairTranscribeStatus(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params repairStatusParams
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &params)
+	}
+	dryRun := params.DryRun == nil || *params.DryRun
+	log := reporter.Logger()
+
+	allIDs, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("list book ids: %w", err)
+	}
+	startIdx := 0
+	if params.LastBookID != "" {
+		for i, id := range allIDs {
+			if id == params.LastBookID {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+	total := len(allIDs)
+	log.Info("repair-transcribe-status: starting", "dry_run", dryRun, "total_books", total)
+	if startIdx >= total {
+		_ = reporter.UpdateProgress(1, 1, "Done — nothing to repair")
+		return nil
+	}
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+
+	// Pages partition books into DISJOINT sets so no two workers touch the same
+	// row — UpdateBook is a read-modify-write with no store-level lock.
+	pages := chunkIDs(allIDs[startIdx:], repairStatusPageSize)
+	err = registry.RunItems(ctx, reporter, pages, func(ctx context.Context, ids []string) error {
+		local := map[string]int{}
+		for _, id := range ids {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			b, gerr := store.GetBookByID(id)
+			if gerr != nil || b == nil {
+				continue
+			}
+			v := classifyStatusRepair(*b)
+			if !v.Write {
+				local[v.Reason]++
+				continue
+			}
+			if dryRun {
+				local[repairWouldChange]++
+				local[v.Reason]++
+				continue
+			}
+			// Only the two status fields change. GetBookByID returns the full
+			// row, so writing it back preserves everything else — and critically
+			// this op never assigns IntroTranscription, so the transcript cannot
+			// be disturbed by a repair.
+			b.TranscribeStatus = v.NewStatus
+			b.TranscribeError = nil
+			if _, uerr := store.UpdateBook(b.ID, b); uerr != nil {
+				log.Warn("repair-transcribe-status: update failed", "book_id", b.ID, "err", uerr)
+				local[repairWriteFailed]++
+				continue
+			}
+			local[v.Reason]++
+		}
+		mu.Lock()
+		for k, n := range local {
+			counts[k] += n
+		}
+		mu.Unlock()
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   8,
+		ProgressTotal: len(pages),
+		Label:         func(i, t int) string { return fmt.Sprintf("Page %d/%d", i+1, t) },
+	})
+
+	mu.Lock()
+	snap := make(map[string]int, len(counts))
+	for k, v := range counts {
+		snap[k] = v
+	}
+	mu.Unlock()
+
+	log.Info("repair-transcribe-status: complete",
+		"dry_run", dryRun,
+		"recomputed_ok", snap[repairRecomputedOK],
+		"recomputed_unparsed", snap[repairRecomputedUnparsed],
+		"cleared_to_never_attempted", snap[repairClearedNeverTried],
+		"skip_status_not_a_failure", snap[repairSkipNotFailed],
+		"skip_genuine_failure_kept", snap[repairSkipNotTransport],
+		"skip_silence_sentinel", snap[repairSkipSilence],
+		"write_failed", snap[repairWriteFailed],
+		"total_books", total)
+
+	changed := snap[repairRecomputedOK] + snap[repairRecomputedUnparsed] + snap[repairClearedNeverTried]
+	verb := "Would repair"
+	if !dryRun {
+		verb = "Repaired"
+	}
+	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf(
+		"%s %d books — %d ok, %d unparsed, %d cleared; kept %d genuine failures, %d silence (of %d)",
+		verb, changed, snap[repairRecomputedOK], snap[repairRecomputedUnparsed],
+		snap[repairClearedNeverTried], snap[repairSkipNotTransport], snap[repairSkipSilence], total))
+	return err
+}

--- a/internal/plugins/maintenance/repair_transcribe_status_test.go
+++ b/internal/plugins/maintenance/repair_transcribe_status_test.go
@@ -1,0 +1,198 @@
+// file: internal/plugins/maintenance/repair_transcribe_status_test.go
+// version: 1.0.0
+// guid: cf20a915-6b83-4e47-a0d2-38f1e75c9b60
+// last-edited: 2026-08-07
+
+package maintenance
+
+import (
+	"testing"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
+)
+
+func rsp(s string) *string { return &s }
+
+// TestClassifyStatusRepair pins every branch of the repair decision. These rules
+// are the entire safety story: the op rewrites status on ~34k prod rows.
+func TestClassifyStatusRepair(t *testing.T) {
+	// The verbatim production error shape from the 2026-07-01 outage, with the
+	// host address elided — it is fleet-internal and must not enter this repo.
+	const transportErr = `transcribe remote: transcribe-batch chunk 0-32: Post "http://<host>/transcribe-batch": dial tcp: connect: connection refused`
+
+	cases := []struct {
+		name       string
+		book       database.Book
+		wantReason string
+		wantWrite  bool
+		wantStatus *string // nil means "cleared"; only checked when wantWrite
+	}{
+		{
+			// The dominant case: 229 of 230 sampled whisper_error books looked
+			// exactly like this — good text from four days before the outage.
+			name: "transport_failure_with_good_credits_text_becomes_ok",
+			book: database.Book{
+				TranscribeStatus:   rsp(statusWhisperError),
+				TranscribeError:    rsp(transportErr),
+				IntroTranscription: rsp("Dune by Frank Herbert read by Scott Brick"),
+			},
+			wantReason: repairRecomputedOK, wantWrite: true, wantStatus: rsp(statusOK),
+		},
+		{
+			name: "transport_failure_with_prose_text_becomes_unparsed",
+			book: database.Book{
+				TranscribeStatus:   rsp(statusWhisperError),
+				TranscribeError:    rsp(transportErr),
+				IntroTranscription: rsp("Chapter 12 Fury drove through DC. He had a lot on his mind that day."),
+			},
+			wantReason: repairRecomputedUnparsed, wantWrite: true, wantStatus: rsp(statusUnparsed),
+		},
+		{
+			// 🔴 An unreachable endpoint is NO ATTEMPT MADE. Recording it as a
+			// per-file failure blames the file for the network's problem.
+			name: "transport_failure_with_no_text_clears_to_never_attempted",
+			book: database.Book{
+				TranscribeStatus: rsp(statusWhisperError),
+				TranscribeError:  rsp(transportErr),
+			},
+			wantReason: repairClearedNeverTried, wantWrite: true, wantStatus: nil,
+		},
+		{
+			// The sentinel means every retry already returned zero characters.
+			// Clearing it would re-queue the book forever at GPU cost.
+			name: "silence_sentinel_is_never_cleared",
+			book: database.Book{
+				TranscribeStatus:   rsp(statusWhisperError),
+				TranscribeError:    rsp(transportErr),
+				IntroTranscription: rsp(transcribe.SilenceSentinel),
+			},
+			wantReason: repairSkipSilence,
+		},
+		{
+			// A genuine model failure is an honest record — keep it.
+			name: "genuine_model_failure_is_kept",
+			book: database.Book{
+				TranscribeStatus:   rsp(statusWhisperError),
+				TranscribeError:    rsp("CUDA out of memory while decoding segment 3"),
+				IntroTranscription: rsp("Dune by Frank Herbert read by Scott Brick"),
+			},
+			wantReason: repairSkipNotTransport,
+		},
+		{
+			name: "genuine_ffmpeg_failure_is_kept",
+			book: database.Book{
+				TranscribeStatus: rsp(statusFFmpegError),
+				TranscribeError:  rsp("Invalid data found when processing input"),
+			},
+			wantReason: repairSkipNotTransport,
+		},
+		{
+			name:       "already_ok_is_untouched",
+			book:       database.Book{TranscribeStatus: rsp(statusOK), IntroTranscription: rsp("Dune by Frank Herbert")},
+			wantReason: repairSkipNotFailed,
+		},
+		{
+			name:       "unset_status_is_untouched",
+			book:       database.Book{},
+			wantReason: repairSkipNotFailed,
+		},
+		{
+			// A failure status with NO recorded error tells us nothing about the
+			// cause, so we must not assume it was the network.
+			name:       "failure_with_empty_error_is_kept",
+			book:       database.Book{TranscribeStatus: rsp(statusWhisperError)},
+			wantReason: repairSkipNotTransport,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyStatusRepair(tc.book)
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+			if got.Write != tc.wantWrite {
+				t.Errorf("Write = %v, want %v", got.Write, tc.wantWrite)
+			}
+			if !tc.wantWrite {
+				return
+			}
+			switch {
+			case tc.wantStatus == nil && got.NewStatus != nil:
+				t.Errorf("expected status CLEARED, got %q", *got.NewStatus)
+			case tc.wantStatus != nil && got.NewStatus == nil:
+				t.Errorf("expected status %q, got cleared", *tc.wantStatus)
+			case tc.wantStatus != nil && *got.NewStatus != *tc.wantStatus:
+				t.Errorf("status = %q, want %q", *got.NewStatus, *tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestIsTransportFailureIsConservative pins the asymmetry: an unrecognised error
+// must be treated as GENUINE and left alone. Wrongly clearing a real failure
+// hides a broken file; wrongly keeping one only costs a re-run.
+func TestIsTransportFailureIsConservative(t *testing.T) {
+	transport := []string{
+		`Post "http://host:19847/transcribe-batch": dial tcp: connection refused`,
+		"context deadline exceeded",
+		"dial tcp 10.0.0.1:80: i/o timeout",
+		"lookup whisper.local: no such host",
+		"read: connection reset by peer",
+		"network is unreachable",
+	}
+	for _, e := range transport {
+		if !isTransportFailure(e) {
+			t.Errorf("should be transport: %q", e)
+		}
+	}
+
+	genuine := []string{
+		"CUDA out of memory",
+		"Invalid data found when processing input",
+		"model failed to load weights",
+		"ffmpeg exited with status 1",
+		"", // no information at all — never assume the network
+		"whisper returned empty text",
+		// Must not be caught by a loose "eof" substring — the word appears
+		// inside ordinary text and inside file paths.
+		"could not decode /library/Neofeud/track01.mp3",
+	}
+	for _, e := range genuine {
+		if isTransportFailure(e) {
+			t.Errorf("should NOT be transport (must be kept): %q", e)
+		}
+	}
+}
+
+// TestRepairNeverTouchesTranscriptText is the data-loss guard. The op's whole
+// justification is that the TEXT is fine and only the STATUS is wrong, so a
+// repair that disturbed text would be strictly worse than doing nothing.
+func TestRepairNeverTouchesTranscriptText(t *testing.T) {
+	const text = "Dune by Frank Herbert read by Scott Brick"
+	b := database.Book{
+		TranscribeStatus:    rsp(statusWhisperError),
+		TranscribeError:     rsp(`Post "http://h/transcribe-batch": connection refused`),
+		IntroTranscription:  rsp(text),
+		TranscribedTitle:    rsp("Dune"),
+		TranscribedAuthor:   rsp("Frank Herbert"),
+		TranscribedNarrator: rsp("Scott Brick"),
+	}
+	before := *b.IntroTranscription
+
+	v := classifyStatusRepair(b)
+	if !v.Write {
+		t.Fatal("expected a repair")
+	}
+	// classifyStatusRepair is pure — it must not have mutated the input at all.
+	if *b.IntroTranscription != before {
+		t.Errorf("transcript mutated: %q -> %q", before, *b.IntroTranscription)
+	}
+	if b.TranscribedTitle == nil || *b.TranscribedTitle != "Dune" {
+		t.Error("parsed fields must be left alone by a status repair")
+	}
+	if b.TranscribeStatus == nil || *b.TranscribeStatus != statusWhisperError {
+		t.Error("classify must not mutate the book it inspects")
+	}
+}

--- a/internal/plugins/maintenance/series_embedded_position_test.go
+++ b/internal/plugins/maintenance/series_embedded_position_test.go
@@ -275,8 +275,8 @@ func TestSeriesDenumber_AssignsTiersAndGatesTheApplySet(t *testing.T) {
 	}
 	for name, wantConf := range map[string]SeriesConfidence{
 		"Evil Genius: Book 4: Becoming the Apex Supervillain": ConfidenceHigh,
-		"Dragon Born [04]":                                    ConfidenceMedium,
-		"08. Battle for the Abyss":                            ConfidenceLow,
+		"Dragon Born [04]":         ConfidenceMedium,
+		"08. Battle for the Abyss": ConfidenceLow,
 	} {
 		if got := byName[name].Confidence; got != wantConf {
 			t.Errorf("%q: confidence=%q, want %q", name, got, wantConf)


### PR DESCRIPTION
## What happened

A day-long transcription-endpoint outage on **2026-07-01** tripped
`processTranscribePage`'s whole-batch error path, which marks **every** book in
the page `whisper_error`:

```go
batchResults, err := transcribe.TranscribeBatch(...)
if err != nil {                        // whole-batch failure
    for bookID := range batchJobs {    // marks EVERY book in the page
        p.applyOutcome(..., statusWhisperError, ...)
    }
}
```

## Measured on prod, 2026-08-07

| | |
|---|---|
| 300-book random sample carrying `whisper_error` | **76.7%** |
| of those, books that **have good transcript text** | **229 / 230** |
| date of that text | **2026-06-27** — four days *before* the outage |
| distinct failure timestamps across a 400-book sample | **17, all on 2026-07-01** |
| every stored error | a connection failure to the endpoint |
| most recent run (2026-08-06), `whisper_error` | **25 of 1,993** — Whisper is healthy |

**No transcript was ever damaged.** `applyOutcome` correctly refuses to
overwrite good text with nothing. Only the *status* is wrong.

The consequence is worse than cosmetic: the library degraded into *"everything
looks broken while everything is fine"*, which is the worst possible state for
any query that filters on status — including the tiered backfill's "what still
needs work" query, which would have over-counted by ~4x.

## The principle

🔴 **An unreachable endpoint is "no attempt made", not "the attempt failed."**

Recording it as a per-file failure attributes to the file a problem that
belonged to the network. This is the same absent-evidence rule the intro
classifier applies one layer up, where an absent transcript yields `unknown`
rather than `prose`.

## What the op does

`maintenance.repair-transcribe-status`, for rows whose stored error is a
**transport** failure:

| stored state | action |
|---|---|
| text present, not `[SILENCE]` | recompute status from the text (credits → `ok`, else `unparsed`) |
| no text | clear status **and** error back to never-attempted |
| `[SILENCE]` sentinel | **left alone** — a real terminal state |
| genuine model/codec failure | **left alone** — an honest record |
| unrecognised error | **treated as genuine**, left alone |

It never calls Whisper and never touches transcript text.

Conservative in both directions on purpose: wrongly clearing a real failure
hides a broken file, while wrongly keeping one only costs a re-run — so the
asymmetry favours keeping. Clearing `[SILENCE]` would re-queue those books
forever at GPU cost.

`dry_run` defaults to **true**.

## Testing

12 subtests covering every branch, including:
- the dominant production shape (transport error + good text → `ok`)
- `[SILENCE]` never cleared
- genuine CUDA/ffmpeg failures kept
- a failure with an *empty* error string kept (no information ≠ network)
- `isTransportFailure` conservatism, including that a path like
  `/library/Neofeud/track01.mp3` is not caught by a loose `eof` match
- a guard that the pure classifier never mutates the book it inspects

## Not included

The **prod apply**. This ships the op with `dry_run=true`; running it for real
against ~34k rows needs an explicit gate, and the dry-run counts should be read
first.