### PR TITLE
feat(maintenance): tier-0 per-file intro migration for single-file books

### DIFF
--- a/changelog.d/20260807_120000_intro_tier0_migration.md
+++ b/changelog.d/20260807_120000_intro_tier0_migration.md
@@ -1,0 +1,45 @@
+<!-- file: changelog.d/20260807_120000_intro_tier0_migration.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d8f60a4-9b27-4e15-8c03-71a5be2d94f6 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Added
+
+- **`maintenance.intro-migrate-single-file` — tier 0 of the per-file intro
+  backfill.** Copies the book-level intro transcript onto the book's one
+  `BookFile` row for the **33,780 single-file books (75.3% of the library)** at
+  **zero GPU cost**. Storage landed in #2168 and the classifier in #2170, but no
+  op wrote per-file transcripts until now.
+
+  A full-library sweep on 2026-08-07 (all 44,875 books) sized the tiers exactly:
+
+  | shape | books | % | files |
+  |---|---|---|---|
+  | 0 `book_file` rows | 1,122 | 2.5% | 0 |
+  | 1 file — **this tier** | 33,780 | 75.3% | 33,780 |
+  | 2–5 files | 2,884 | 6.4% | 7,829 |
+  | 6–20 files | 2,775 | 6.2% | 34,601 |
+  | 21+ files | 4,314 | 9.6% | 228,681 |
+  | **total** | **44,875** | | **304,891** |
+
+  **9.6% of books hold 75% of all files**, so tiering is what makes the backfill
+  affordable rather than a nice-to-have: ~12–14 GPU-days naive versus ~1.4 days
+  once this tier is free and the rest probe three files each.
+
+  🔴 **Multi-file books are refused on provenance grounds, not skipped for
+  convenience.** The book-level transcript does not record which file produced
+  it, and the silence path retries against the *second* audio file — so copying
+  onto file 1 would assert evidence the data cannot support. For a single-file
+  book the ambiguity provably cannot arise (`nthAudioFile` returns `""` once
+  `n >= len(audio)`, and the retry skips on an empty source). Books with zero
+  `book_file` rows are reported as skipped, never counted as migrated: they are
+  unlinked, not un-transcribed.
+
+  The write guard: all mutation is isolated in one function whose permitted field
+  set is declared as data, and a reflective test fills every `BookFile` field with
+  a distinguishable value and fails if *any* field outside that set changes —
+  verified to bite by injecting a rogue write. A companion test fails when a new
+  transcription-shaped field is added to `BookFile` without deciding whether tier
+  0 carries it, so schema growth cannot silently leave columns empty on 33,780
+  migrated rows. Pages partition books into disjoint sets so no two workers touch
+  the same row. `dry_run` defaults to true.

--- a/docs/continuation/2026-08-07-repair-then-backfill-continuation.md
+++ b/docs/continuation/2026-08-07-repair-then-backfill-continuation.md
@@ -1,0 +1,147 @@
+<!-- file: docs/continuation/2026-08-07-repair-then-backfill-continuation.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e2b74f05-3c19-48a6-95d7-6a08f31be4c2 -->
+<!-- last-edited: 2026-08-07 -->
+
+# Continuation prompt — run the repair, then finish the per-file backfill
+
+Paste the block under **PROMPT** into a fresh session. Everything above it is
+context for a human deciding whether to.
+
+---
+
+## Where things stand
+
+**Merged 2026-08-07:**
+
+| PR | What |
+|---|---|
+| #2170 | Three-outcome intro classifier (`ClassifyIntro`) + reparse data-loss guard |
+| #2171 | `maintenance.repair-transcribe-status` — fixes the July-1 status falsification |
+| #2172 | `maintenance.intro-migrate-single-file` — tier 0 of the per-file backfill |
+
+**Nothing has been applied to prod.** Both new ops default to `dry_run=true`.
+
+## The two ops waiting to run
+
+### 1. `maintenance.repair-transcribe-status` — run this FIRST
+
+A day-long transcription-endpoint outage on **2026-07-01** tripped
+`processTranscribePage`'s whole-batch error path, which marks **every** book in
+a page `whisper_error`. Measured 2026-08-07:
+
+- **76.7%** of a 300-book random sample carried `whisper_error`
+- **229 of those 230 books had good transcript text**, dated **2026-06-27** —
+  four days *before* the outage
+- a 400-book sample put every failure in **17 timestamps, all on 2026-07-01**,
+  every error a connection failure
+- the most recent run (2026-08-06) had **25 errors out of 1,993** — Whisper is
+  healthy
+
+No transcript was damaged; `applyOutcome` refuses to overwrite good text with
+nothing. **Only the status is wrong.** The library is in the state "everything
+looks broken while everything is fine".
+
+**Why first:** every "what still needs work" query — including the backfill's —
+filters on status, and would currently over-count by roughly 4×.
+
+### 2. `maintenance.intro-migrate-single-file` — tier 0, run second
+
+Copies the book-level transcript onto the one `BookFile` row for the **33,780
+single-file books (75.3% of the library)** at **zero GPU cost**.
+
+## Measurements that should drive decisions (do not re-derive)
+
+Full-library sweep 2026-08-07, all 44,875 books:
+
+| shape | books | % | files |
+|---|---|---|---|
+| 0 `book_file` rows | 1,122 | 2.5% | 0 |
+| 1 file (tier 0) | 33,780 | 75.3% | 33,780 |
+| 2–5 files | 2,884 | 6.4% | 7,829 |
+| 6–20 files | 2,775 | 6.2% | 34,601 |
+| 21+ files | 4,314 | 9.6% | 228,681 |
+| **total** | **44,875** | | **304,891** |
+
+- **9.6% of books hold 75% of all files.** The long tail is the entire cost.
+- Naive backfill ≈ 12–14 GPU-days. Tiered ≈ **1.4 days**.
+- Parser corpus (987 distinct books): `written by` is the **most common** credit
+  variant (24.1%) and **24.8% of stored titles** had a credit verb welded on.
+- **1.4% of books (~644)** hold a parse their *current* transcript cannot
+  regenerate — which is why reparse only ever upgrades, never clears.
+
+## 🔴 Traps already paid for — do not rediscover these
+
+1. **The prod API paginates on `offset`/`limit` and accepts-then-SILENTLY-IGNORES
+   `?page=`.** A page-based sampler returns the same window every time. This
+   produced one confidently wrong measurement already.
+2. **`CheckpointFn` is NOT called in concurrent mode** (`run_items.go:54`).
+   Tier 3 is both concurrent and resumable → it needs `OpFreshness.Stamp`.
+3. **`internal/server` tests time out locally at 10 min** under parallel load
+   (`setupTestServer` runs 21 Pebble migrations per test). It does this on
+   unmodified `main` too — 600.71s vs 600.78s. Not a regression. CI passes.
+4. **A latent data race exists in `UpsertBookToMemDB`** — it retains the caller's
+   `*Book` across a deferred closure. Diagnosed, filed, NOT fixed:
+   `todo.d/20260807_020500_memdb_warmup_caller_pointer_race.md`. It fires
+   intermittently under `-race` on CI.
+5. **Never commit the GPU host address or any fleet-internal IP.** Public repo;
+   the pre-commit hook will reject tokens, but not IPs.
+
+---
+
+## PROMPT
+
+> Continue the per-file audiobook identity signal. #2170 (classifier), #2171
+> (status repair) and #2172 (tier-0 migration) are merged. Read
+> `docs/continuation/2026-08-07-repair-then-backfill-continuation.md` first — it
+> carries every measurement and the traps already paid for, so do not re-derive
+> them.
+>
+> **Step 1 — run the status repair on prod.** Dispatch
+> `maintenance.repair-transcribe-status` with `dry_run=true` first, show me the
+> counts per bucket (`recomputed_ok`, `recomputed_unparsed`,
+> `cleared_to_never_attempted`, `skip_genuine_failure_kept`,
+> `skip_silence_sentinel`), and **stop for an explicit decision from me before
+> applying**. Sanity-check the dry-run against the expectation that ~77% of the
+> library is affected and that almost all of it should land in `recomputed_ok`
+> or `recomputed_unparsed` — a large `cleared_to_never_attempted` count would
+> mean the transcripts are not where we think they are, and that is a reason to
+> stop and re-measure, not to proceed.
+>
+> **Step 2 — run tier 0** (`maintenance.intro-migrate-single-file`), same
+> pattern: dry-run, show the per-reason counts, explicit gate before applying.
+> Expect ~33,780 in `would_write` and ~1,122 in `skip_no_book_file_rows`. Verify
+> afterwards that a sample of migrated books really have per-file
+> `intro_transcription` set, by reading `GET /api/v1/audiobooks/{id}/files` —
+> not by trusting the op's own counters.
+>
+> **Step 3 — build the multi-endpoint Whisper dispatcher.** `batch.go:51` reads
+> a single `WhisperRemoteURL`; the U1 host is prepared (48 cores, 251 GB, **no
+> GPU**, Python 3.14.3 + uv) but no worker is built. Benchmark int8
+> faster-whisper against a real clip batch before promising any throughput — it
+> is not a second GPU. 🔴 The dispatcher must distinguish "endpoint unreachable"
+> from "this file failed to transcribe" and write per-file status ONLY for the
+> second; collapsing those is exactly how a network outage got recorded 34,000
+> times as a file problem. Point the slow node at tier 3, which has no deadline.
+>
+> **Step 4 — tiers 1/1b and 2/3**, then **#23** (wire the classifier into the
+> regroup recommender, validating against the 356 measured holds) and **#24**
+> (First Aid tier 2, enqueueing transcription rather than parking).
+>
+> Standing constraints: worktree per task, never edit the primary checkout; PR
+> each one and give me the **full GitHub link on `main` after merge** — I am
+> usually not on the Mac. Prod applies need a real gate, not a text reply.
+> `review_apply_enabled` stays OFF. Public repo — never commit internal IPs.
+
+## Also outstanding (separate from this chain)
+
+- **memdb warmup data race** — diagnosed and filed, one-line fix + a regression
+  test that must *force* the interleaving (a green local run proves nothing;
+  the full package passed 0-races locally while CI caught it).
+- **#4** multidisc canary — needs #23 plus an explicit gate to flip
+  `review_apply_enabled`.
+- **#6 follow-through** — apply the 434 confidently-linkable directory-shaped
+  books. Relevant here: **1,122 books have zero `book_file` rows** and can never
+  receive a per-file transcript until they are relinked.
+- **Package upgrades** — fix the e2e suite first (`unknown parameter "_page"`,
+  broken on `main`, gates nothing).

--- a/internal/plugins/maintenance/intro_migrate_single_file.go
+++ b/internal/plugins/maintenance/intro_migrate_single_file.go
@@ -1,0 +1,320 @@
+// file: internal/plugins/maintenance/intro_migrate_single_file.go
+// version: 1.0.0
+// guid: 6b0d94e7-1c58-4a32-bf07-9e5d2a17c630
+// last-edited: 2026-08-07
+
+package maintenance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
+)
+
+// Tier 0 of the per-file intro backfill: migrate the book-level transcript onto
+// the file it came from, for books where "the file it came from" is knowable.
+//
+// Measured on the full library 2026-08-07 (all 44,875 books):
+//
+//	0 book_file rows   1,122   2.5%          0 files  <- unlinked, cannot migrate
+//	1 file            33,780  75.3%     33,780 files  <- THIS TIER, zero GPU
+//	2-5 files          2,884   6.4%      7,829 files
+//	6-20 files         2,775   6.2%     34,601 files
+//	21+ files          4,314   9.6%    228,681 files
+//	                  ------                 -------
+//	                  44,875                 304,891
+//
+// Three quarters of the library migrates here for free. The remaining tiers pay
+// GPU; this one pays a Pebble write.
+//
+// 🔴 WHY SINGLE-FILE ONLY — this is a correctness constraint, not a scope cut.
+//
+// The book-level transcript does not record WHICH file produced it. The
+// transcribe op retries a silent book against the SECOND audio file
+// (intro_transcribe.go retry2), so for a multi-file book the stored transcript
+// may have come from file 2 — and nothing distinguishes that from file 1.
+// Copying it onto file 1 would assert a provenance the data cannot support.
+//
+// For a single-file book the ambiguity cannot arise: nthAudioFile returns ""
+// once n >= len(audio) (intro_transcribe.go:64) and retry2 skips on an empty
+// source (:644), so retry2 provably never fired. The transcript came from the
+// one file, possibly via retry1's longer clip — same file either way.
+//
+// Books with ZERO book_file rows are skipped, not "migrated with no effect".
+// They are unlinked, not un-transcribed; 195 of 204 apparently-untranscribed
+// review-queue members were in this state. Relink first.
+
+// introMigrateParams controls the tier-0 migration.
+type introMigrateParams struct {
+	// DryRun reports what WOULD be written without writing it. Defaults to
+	// TRUE: this op touches ~33,780 rows, and the counts per skip-reason are
+	// the thing worth reading before any of that happens.
+	DryRun *bool `json:"dry_run,omitempty"`
+	// LastBookID resumes past a prior run's checkpoint.
+	LastBookID string `json:"last_book_id,omitempty"`
+	// Overwrite re-copies onto files that already carry a transcript. Off by
+	// default so re-runs are cheap and idempotent.
+	Overwrite *bool `json:"overwrite,omitempty"`
+}
+
+// migrate outcome reasons — every book lands in exactly one, and the totals are
+// reported. A book that is skipped must say WHY; "processed 44,875, wrote 33,780"
+// with no account of the other 11,095 is the shape of report that hides a bug.
+const (
+	migrateWrote          = "wrote"
+	migrateDryRun         = "would_write"
+	migrateNoRows         = "skip_no_book_file_rows"
+	migrateMultiFile      = "skip_multi_file_provenance"
+	migrateNoTranscript   = "skip_book_has_no_transcript"
+	migrateAlreadyPresent = "skip_file_already_has_transcript"
+	migrateNoAudio        = "skip_no_audio_file"
+	migrateWriteFailed    = "write_failed"
+)
+
+const introMigratePageSize = 500
+
+func (p *Plugin) introMigrateSingleFileDef() sdk.OperationDef {
+	return sdk.OperationDef{
+		ID:              "maintenance.intro-migrate-single-file",
+		Plugin:          "maintenance",
+		DisplayName:     "Migrate intro transcripts to single-file books",
+		Description:     "Tier 0 of the per-file intro backfill. Copies the book-level intro transcript onto the book's one BookFile row, for the ~33,780 single-file books (75.3% of the library). Zero GPU: it is a copy, not a transcription. Multi-file books are deliberately refused because the book-level transcript does not record which file produced it and the silence-retry path may have used file 2. Defaults to dry_run=true; pass dry_run=false to write.",
+		ResumePolicy:    sdk.ResumeRestart,
+		DefaultPriority: sdk.PriorityLow,
+		ConcurrencyKey:  "maintenance.intro-migrate-single-file",
+		Cancellable:     true,
+		Isolate:         false,
+		Timeout:         2 * time.Hour,
+		// Pure DB work, no Whisper: pages complete in seconds, so the default
+		// 5-minute no-progress watchdog is generous already. Left explicit so a
+		// future change that adds I/O here has to think about it.
+		ProgressTimeout: 5 * time.Minute,
+		Capabilities:    []sdk.Capability{sdk.CapLibraryRead, sdk.CapLibraryWrite},
+		Run:             p.runIntroMigrateSingleFile,
+	}
+}
+
+func (p *Plugin) runIntroMigrateSingleFile(ctx context.Context, rawParams json.RawMessage, reporter sdk.Reporter) error {
+	store := p.deps.Store()
+	if store == nil {
+		return fmt.Errorf("database not initialized")
+	}
+
+	var params introMigrateParams
+	if len(rawParams) > 0 {
+		_ = json.Unmarshal(rawParams, &params)
+	}
+	dryRun := params.DryRun == nil || *params.DryRun
+	overwrite := params.Overwrite != nil && *params.Overwrite
+
+	log := reporter.Logger()
+
+	allIDs, err := store.ListBookIDs()
+	if err != nil {
+		return fmt.Errorf("list book ids: %w", err)
+	}
+	startIdx := 0
+	if params.LastBookID != "" {
+		for i, id := range allIDs {
+			if id == params.LastBookID {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+	total := len(allIDs)
+	log.Info("intro-migrate-single-file: starting",
+		"dry_run", dryRun, "overwrite", overwrite,
+		"total_books", total, "start_index", startIdx)
+
+	if startIdx >= total {
+		_ = reporter.UpdateProgress(1, 1, "Done — nothing to migrate")
+		return nil
+	}
+
+	pages := chunkIDs(allIDs[startIdx:], introMigratePageSize)
+
+	var mu sync.Mutex
+	counts := map[string]int{}
+	record := func(reason string, n int) {
+		mu.Lock()
+		counts[reason] += n
+		mu.Unlock()
+	}
+
+	// Pages partition the library by book ID into DISJOINT sets, so two workers
+	// can never touch the same book_file row. That matters because UpdateBookFile
+	// is a read-modify-write with no store-level lock: concurrent writers to the
+	// SAME row could interleave. Disjoint partitioning is what makes this safe,
+	// per the concurrency rules in CLAUDE.md — do not replace the page split with
+	// anything that lets two workers share a book.
+	err = registry.RunItems(ctx, reporter, pages, func(ctx context.Context, ids []string) error {
+		for _, id := range ids {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			reason := p.migrateOneBook(store, log, id, dryRun, overwrite)
+			record(reason, 1)
+		}
+		return nil
+	}, registry.RunItemsOptions{
+		Concurrency:   8,
+		ProgressTotal: len(pages),
+		Label: func(i, t int) string {
+			return fmt.Sprintf("Page %d/%d", i+1, t)
+		},
+	})
+
+	mu.Lock()
+	snapshot := make(map[string]int, len(counts))
+	for k, v := range counts {
+		snapshot[k] = v
+	}
+	mu.Unlock()
+
+	// Report EVERY bucket, including the zeros: a reader must be able to add the
+	// numbers up to the book count and find nothing unaccounted for.
+	log.Info("intro-migrate-single-file: complete",
+		"dry_run", dryRun,
+		"wrote", snapshot[migrateWrote],
+		"would_write", snapshot[migrateDryRun],
+		"skip_no_book_file_rows", snapshot[migrateNoRows],
+		"skip_multi_file_provenance", snapshot[migrateMultiFile],
+		"skip_book_has_no_transcript", snapshot[migrateNoTranscript],
+		"skip_file_already_has_transcript", snapshot[migrateAlreadyPresent],
+		"skip_no_audio_file", snapshot[migrateNoAudio],
+		"write_failed", snapshot[migrateWriteFailed],
+		"total_books", total)
+
+	verb := "Would migrate"
+	n := snapshot[migrateDryRun]
+	if !dryRun {
+		verb = "Migrated"
+		n = snapshot[migrateWrote]
+	}
+	_ = reporter.UpdateProgress(1, 1, fmt.Sprintf(
+		"%s %d single-file books — skipped: %d unlinked, %d multi-file, %d no transcript, %d already done (of %d)",
+		verb, n, snapshot[migrateNoRows], snapshot[migrateMultiFile],
+		snapshot[migrateNoTranscript], snapshot[migrateAlreadyPresent], total))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrateOneBook evaluates and (unless dry-run) performs the tier-0 copy for a
+// single book, returning the outcome reason.
+func (p *Plugin) migrateOneBook(store database.Store, log interface {
+	Info(string, ...any)
+	Warn(string, ...any)
+}, bookID string, dryRun, overwrite bool) string {
+	b, err := store.GetBookByID(bookID)
+	if err != nil || b == nil {
+		return migrateNoRows
+	}
+	if b.IntroTranscription == nil || strings.TrimSpace(*b.IntroTranscription) == "" {
+		return migrateNoTranscript
+	}
+
+	// GetBookFiles is the Pebble-direct read: it returns FULL rows with
+	// IntroTranscription intact. Reading through a memdb path here would hand
+	// back a slim row whose transcript is nil, and writing that back would blank
+	// the very field this op exists to populate.
+	files, err := store.GetBookFiles(bookID)
+	if err != nil {
+		return migrateNoRows
+	}
+	if len(files) == 0 {
+		return migrateNoRows
+	}
+
+	reason, target := classifyMigrateCandidate(*b, files, overwrite)
+	if reason != "" {
+		return reason
+	}
+	if dryRun {
+		return migrateDryRun
+	}
+
+	applyBookIntroFieldsToFile(target, *b)
+	if err := store.UpdateBookFile(target.ID, target); err != nil {
+		log.Warn("intro-migrate: update failed", "book_id", bookID, "file_id", target.ID, "err", err)
+		return migrateWriteFailed
+	}
+	return migrateWrote
+}
+
+// classifyMigrateCandidate decides whether a book is eligible for the tier-0
+// copy, and if so which file receives it. It is pure — no store, no clock — so
+// the eligibility rules (which are the whole correctness story of this tier)
+// are testable directly.
+//
+// Returns ("", target) when eligible, or (reason, nil) when not.
+func classifyMigrateCandidate(b database.Book, files []database.BookFile, overwrite bool) (string, *database.BookFile) {
+	var audio []database.BookFile
+	for _, f := range files {
+		if f.FilePath != "" && audioExtSet[strings.ToLower(filepath.Ext(f.FilePath))] {
+			audio = append(audio, f)
+		}
+	}
+	switch {
+	case len(audio) == 0:
+		return migrateNoAudio, nil
+	case len(audio) > 1:
+		// See the provenance note at the top of this file. Refusing here is the
+		// POINT of the tier, not a limitation of it: the book-level transcript
+		// does not record which file produced it, and retry2 may have used file 2.
+		return migrateMultiFile, nil
+	}
+
+	target := audio[0]
+	if !overwrite && target.IntroTranscription != nil && strings.TrimSpace(*target.IntroTranscription) != "" {
+		return migrateAlreadyPresent, nil
+	}
+	return "", &target
+}
+
+// introMigratedFields is the exact set of BookFile fields this migration is
+// permitted to touch. It is declared as data, not just as code, so a test can
+// assert reflectively that applyBookIntroFieldsToFile modifies these and
+// NOTHING else — the guard against a full-row write-back quietly clobbering an
+// unrelated column, which is this repo's dominant data-loss shape.
+var introMigratedFields = []string{
+	"IntroTranscription",
+	"TranscribedTitle",
+	"TranscribedAuthor",
+	"TranscribedNarrator",
+	"IntroTranscribedAt",
+	"TranscribeStatus",
+	"TranscribeError",
+	"TranscribeAttemptedAt",
+}
+
+// applyBookIntroFieldsToFile copies the eight-field intro-transcription group
+// from a Book onto one of its BookFiles. It is the ONLY place this migration
+// mutates a BookFile, so the blast radius is one small function with a
+// reflective test pinning it.
+//
+// dst must be a FULL Pebble row (from GetBookFiles), never a memdb projection:
+// the caller writes dst back wholesale, so every field it does not set must
+// already hold the stored value.
+func applyBookIntroFieldsToFile(dst *database.BookFile, src database.Book) {
+	dst.IntroTranscription = src.IntroTranscription
+	dst.TranscribedTitle = src.TranscribedTitle
+	dst.TranscribedAuthor = src.TranscribedAuthor
+	dst.TranscribedNarrator = src.TranscribedNarrator
+	dst.IntroTranscribedAt = src.IntroTranscribedAt
+	dst.TranscribeStatus = src.TranscribeStatus
+	dst.TranscribeError = src.TranscribeError
+	dst.TranscribeAttemptedAt = src.TranscribeAttemptedAt
+}

--- a/internal/plugins/maintenance/intro_migrate_single_file_test.go
+++ b/internal/plugins/maintenance/intro_migrate_single_file_test.go
@@ -1,0 +1,236 @@
+// file: internal/plugins/maintenance/intro_migrate_single_file_test.go
+// version: 1.0.0
+// guid: 91e4c07b-5a63-4d28-8f10-2b74e9d6a35c
+// last-edited: 2026-08-07
+
+package maintenance
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+)
+
+// TestApplyBookIntroFieldsTouchesNothingElse is THE guard on this migration.
+//
+// The op writes the whole BookFile row back via UpdateBookFile (full-column
+// replacement), so the only thing standing between "copy 8 fields" and "clobber
+// an unrelated column" is that applyBookIntroFieldsToFile mutates exactly the 8
+// and no more. This repo's dominant data-loss shape is precisely a full-row
+// write-back that carried a stale or zero value into a field nobody meant to
+// touch (the AcoustIDFingerprint wipe, the Author/Series wipe).
+//
+// Rather than eyeballing the assignments, this fills EVERY field of a BookFile
+// with a distinguishable non-zero value, applies the migration, and diffs every
+// field reflectively. A new field added to BookFile is covered automatically.
+func TestApplyBookIntroFieldsTouchesNothingElse(t *testing.T) {
+	var dst database.BookFile
+	fillAllFields(t, reflect.ValueOf(&dst).Elem(), 1)
+	before := dst // struct copy: the pre-state of every field
+
+	src := database.Book{
+		IntroTranscription:    strp("Dune by Frank Herbert read by Scott Brick"),
+		TranscribedTitle:      strp("Dune"),
+		TranscribedAuthor:     strp("Frank Herbert"),
+		TranscribedNarrator:   strp("Scott Brick"),
+		IntroTranscribedAt:    timep(time.Unix(1700000000, 0)),
+		TranscribeStatus:      strp("ok"),
+		TranscribeError:       nil,
+		TranscribeAttemptedAt: timep(time.Unix(1700000001, 0)),
+	}
+	applyBookIntroFieldsToFile(&dst, src)
+
+	allowed := map[string]bool{}
+	for _, f := range introMigratedFields {
+		allowed[f] = true
+	}
+
+	bt := reflect.TypeOf(before)
+	bv, av := reflect.ValueOf(before), reflect.ValueOf(dst)
+	var changed []string
+	for i := 0; i < bt.NumField(); i++ {
+		name := bt.Field(i).Name
+		if !bt.Field(i).IsExported() {
+			continue
+		}
+		if !reflect.DeepEqual(bv.Field(i).Interface(), av.Field(i).Interface()) {
+			changed = append(changed, name)
+			if !allowed[name] {
+				t.Errorf("field %q was modified but is NOT in introMigratedFields — "+
+					"a full-row write-back would persist this unintended change", name)
+			}
+		}
+	}
+
+	// The converse: every field we claim to migrate must actually have changed,
+	// or the list is lying and a future reader will trust it.
+	changedSet := map[string]bool{}
+	for _, c := range changed {
+		changedSet[c] = true
+	}
+	for _, want := range introMigratedFields {
+		if !changedSet[want] {
+			t.Errorf("field %q is listed in introMigratedFields but was NOT modified", want)
+		}
+	}
+}
+
+// TestClassifyMigrateCandidate pins the eligibility rules — the correctness
+// story of tier 0.
+func TestClassifyMigrateCandidate(t *testing.T) {
+	book := database.Book{ID: "b1", IntroTranscription: strp("Dune by Frank Herbert")}
+	mp3 := func(id, path string) database.BookFile {
+		return database.BookFile{ID: id, BookID: "b1", FilePath: path}
+	}
+
+	cases := []struct {
+		name       string
+		files      []database.BookFile
+		overwrite  bool
+		wantReason string
+		wantTarget string // file ID, "" when ineligible
+	}{
+		{
+			name:       "single_audio_file_is_eligible",
+			files:      []database.BookFile{mp3("f1", "/lib/a.mp3")},
+			wantReason: "", wantTarget: "f1",
+		},
+		{
+			// 🔴 The provenance constraint. retry2 may have transcribed file 2 and
+			// nothing records which file won, so a copy would fabricate evidence.
+			name:       "multi_file_is_REFUSED_on_provenance",
+			files:      []database.BookFile{mp3("f1", "/lib/a.mp3"), mp3("f2", "/lib/b.mp3")},
+			wantReason: migrateMultiFile,
+		},
+		{
+			name:       "no_audio_extension_is_not_audio",
+			files:      []database.BookFile{mp3("f1", "/lib/cover.jpg")},
+			wantReason: migrateNoAudio,
+		},
+		{
+			// Non-audio siblings must not push a genuinely single-file book into
+			// the multi-file refusal — cover art is not a second recording.
+			name:       "single_audio_plus_cover_art_still_eligible",
+			files:      []database.BookFile{mp3("f1", "/lib/a.mp3"), mp3("f2", "/lib/cover.jpg")},
+			wantReason: "", wantTarget: "f1",
+		},
+		{
+			name: "already_migrated_is_skipped",
+			files: []database.BookFile{{
+				ID: "f1", BookID: "b1", FilePath: "/lib/a.mp3",
+				IntroTranscription: strp("already here"),
+			}},
+			wantReason: migrateAlreadyPresent,
+		},
+		{
+			name: "overwrite_forces_recopy",
+			files: []database.BookFile{{
+				ID: "f1", BookID: "b1", FilePath: "/lib/a.mp3",
+				IntroTranscription: strp("already here"),
+			}},
+			overwrite:  true,
+			wantReason: "", wantTarget: "f1",
+		},
+		{
+			name:       "no_files_at_all",
+			files:      nil,
+			wantReason: migrateNoAudio,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, target := classifyMigrateCandidate(book, tc.files, tc.overwrite)
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+			switch {
+			case tc.wantTarget == "" && target != nil:
+				t.Errorf("expected no target, got %q", target.ID)
+			case tc.wantTarget != "" && target == nil:
+				t.Errorf("expected target %q, got nil", tc.wantTarget)
+			case tc.wantTarget != "" && target.ID != tc.wantTarget:
+				t.Errorf("target = %q, want %q", target.ID, tc.wantTarget)
+			}
+		})
+	}
+}
+
+// TestMigratedFieldsMatchBookFileSchema fails when someone adds a per-file
+// transcription field to BookFile without deciding whether tier 0 should carry
+// it. Without this, a new field silently stays empty on 33,780 migrated rows.
+func TestMigratedFieldsMatchBookFileSchema(t *testing.T) {
+	bf := reflect.TypeOf(database.BookFile{})
+	for _, name := range introMigratedFields {
+		if _, ok := bf.FieldByName(name); !ok {
+			t.Errorf("introMigratedFields names %q, which BookFile does not have", name)
+		}
+	}
+	// Every BookFile field whose name looks like part of the transcription group
+	// must be accounted for.
+	listed := map[string]bool{}
+	for _, n := range introMigratedFields {
+		listed[n] = true
+	}
+	for i := 0; i < bf.NumField(); i++ {
+		n := bf.Field(i).Name
+		looksTranscription := len(n) >= 5 &&
+			(n[:5] == "Intro" || (len(n) >= 10 && n[:10] == "Transcribe") || (len(n) >= 11 && n[:11] == "Transcribed"))
+		if looksTranscription && !listed[n] {
+			t.Errorf("BookFile.%s looks like a transcription field but is not in "+
+				"introMigratedFields — decide explicitly whether tier 0 carries it", n)
+		}
+	}
+}
+
+// fillAllFields sets every settable exported field to a distinguishable
+// non-zero value so the diff above can detect an unintended write to any of them.
+func fillAllFields(t *testing.T, v reflect.Value, seed int) {
+	t.Helper()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if !f.CanSet() {
+			continue
+		}
+		switch f.Kind() {
+		case reflect.String:
+			f.SetString("v" + string(rune('a'+i%26)))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			f.SetInt(int64(i + seed))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			f.SetUint(uint64(i + seed))
+		case reflect.Float32, reflect.Float64:
+			f.SetFloat(float64(i) + 0.5)
+		case reflect.Bool:
+			f.SetBool(true)
+		case reflect.Slice:
+			f.Set(reflect.MakeSlice(f.Type(), 1, 1))
+		case reflect.Map:
+			f.Set(reflect.MakeMap(f.Type()))
+		case reflect.Ptr:
+			p := reflect.New(f.Type().Elem())
+			switch p.Elem().Kind() {
+			case reflect.String:
+				p.Elem().SetString("p" + string(rune('a'+i%26)))
+			case reflect.Int, reflect.Int64:
+				p.Elem().SetInt(int64(i + seed))
+			case reflect.Bool:
+				p.Elem().SetBool(true)
+			case reflect.Struct:
+				if tv, ok := p.Interface().(*time.Time); ok {
+					*tv = time.Unix(int64(1600000000+i), 0)
+				}
+			}
+			f.Set(p)
+		case reflect.Struct:
+			if tv, ok := f.Addr().Interface().(*time.Time); ok {
+				*tv = time.Unix(int64(1500000000+i), 0)
+			}
+		}
+	}
+}
+
+func strp(s string) *string        { return &s }
+func timep(t time.Time) *time.Time { return &t }

--- a/internal/plugins/maintenance/plugin.go
+++ b/internal/plugins/maintenance/plugin.go
@@ -90,6 +90,7 @@ func (p *Plugin) Register(r sdk.Registry) error {
 		p.itunesHealDef(),
 		p.introTranscribeDef(),
 		p.repairTranscribeStatusDef(),
+		p.introMigrateSingleFileDef(),
 		p.extractWAVClipsDef(),
 
 		// --- title cleanup ---


### PR DESCRIPTION
Tier 0 of the per-file intro backfill (#22 of the #21→#24 chain). Storage landed
in #2168, the classifier in #2170 — **no op wrote per-file transcripts until
now**.

## The library, measured exactly

Full sweep 2026-08-07, all 44,875 books:

| shape | books | % | files |
|---|---|---|---|
| 0 `book_file` rows | 1,122 | 2.5% | 0 |
| **1 file — this tier** | **33,780** | **75.3%** | 33,780 |
| 2–5 files | 2,884 | 6.4% | 7,829 |
| 6–20 files | 2,775 | 6.2% | 34,601 |
| 21+ files | 4,314 | 9.6% | **228,681** |
| **total** | **44,875** | | **304,891** |

**9.6% of books hold 75% of all files.** Tiering isn't an optimisation — the
long tail *is* the cost. Naive is ~12–14 GPU-days; tiered is ~1.4 days once this
tier is free and the rest probe three files each.

This tier costs **zero GPU**: it's a copy, not a transcription.

## 🔴 Why single-file only — a correctness constraint, not a scope cut

The book-level transcript **does not record which file produced it**, and the
silence path retries against the *second* audio file. So for a multi-file book,
copying onto file 1 would assert a provenance the data cannot support.

For a single-file book the ambiguity provably cannot arise: `nthAudioFile`
returns `""` once `n >= len(audio)`, and retry2 skips on an empty source — so it
never fired. The transcript came from the one file.

| shape | provenance | copy? |
|---|---|---|
| 1 audio file | unambiguous | ✅ |
| 2+ audio files | **unknowable** | ❌ refused |
| 0 rows | nothing to write to | ❌ relink first |

The 1,122 zero-row books are reported as **skipped**, never counted as migrated —
they're unlinked, not un-transcribed.

## The write guard

The op writes the whole row back via `UpdateBookFile` (full-column replacement),
so the only thing between "copy 8 fields" and "clobber a column" is that the
mutation touches exactly 8. Rather than trusting the assignments:

- all mutation lives in one function, `applyBookIntroFieldsToFile`
- its permitted field set is declared **as data** (`introMigratedFields`)
- a reflective test fills **every** `BookFile` field with a distinguishable
  value, applies the migration, and fails if any field outside the set changed —
  **verified to bite** by injecting a rogue `FilePath` write
- a companion test fails when a new transcription-shaped field is added to
  `BookFile` without deciding whether tier 0 carries it, so schema growth can't
  silently leave columns empty on 33,780 migrated rows

Pages partition books into **disjoint** sets so no two workers touch the same
row — `UpdateBookFile` is a read-modify-write with no store-level lock, and
disjoint partitioning is what makes the pool safe.

## Not included

- **The prod apply.** `dry_run` defaults to true; the ~33,780-row write needs an
  explicit gate and the dry-run counts read first.
- **Tiers 1/1b, 2, 3.** Separate PRs. Note tier 3 is both concurrent *and*
  resumable, and `CheckpointFn` is silently skipped in concurrent mode
  (`run_items.go:54`) — it will need `OpFreshness.Stamp`.