### PR TITLE
fix(database): snapshot caller structs at enqueue in memdb write-throughs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.17.1 -->
+<!-- version: 10.17.2 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-07 -->
 
@@ -454,11 +454,16 @@ into one of the curated sections below, is a normal direct edit.
 <!-- guid: d3f81a56-9c47-4e20-b7d8-52069fe1c4a3 -->
 <!-- last-edited: 2026-08-07 -->
 
-- [ ] 🔴 **Data race: `UpsertBookToMemDB` retains the CALLER's `*Book` and
+- [x] 🔴 **Data race: `UpsertBookToMemDB` retains the CALLER's `*Book` and
   dereferences it later on the warmup goroutine.** Caught by the race detector
-  on CI during PR #2170 (a parser PR that touches no database file). Diagnosed,
-  not fixed — the fix lands in the production memdb write path and deserves its
-  own PR with a regression test.
+  on CI during PR #2170 (a parser PR that touches no database file).
+  ✅ FIXED 2026-08-07 (fix/memdb-warmup-caller-pointer-race): snapshot copied at
+  enqueue time in `UpsertBookToMemDB` and every same-shape sibling upsert
+  (BookFile/Author/Series/Narrator/ImportPath/AuthorAlias/BlockedHash + slice
+  copies in ReplaceBookAuthors/NarratorsInMemDB). Regression test
+  `TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue` forces the interleaving
+  deterministically under `-race`; verified it fires the race on the unfixed
+  code and is green on the fix.
 
   **The race, verbatim from CI:**
 

--- a/changelog.d/20260807_203700_fix_memdb_warmup_caller_pointer_race.md
+++ b/changelog.d/20260807_203700_fix_memdb_warmup_caller_pointer_race.md
@@ -1,0 +1,22 @@
+<!-- file: changelog.d/20260807_203700_fix_memdb_warmup_caller_pointer_race.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6b2e4f9a-1d70-4c38-8a5e-3f96c0d7e2b1 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Fixed
+
+- **Memdb warmup caller-pointer data race.** `UpsertBookToMemDB` captured the
+  caller's `*Book` in the write-through closure; while the async warmup was
+  still buffering, that closure ran much later on the warmup goroutine
+  (`publishWarmMemStore` → `applyMemSync` → `stripBookForMemdb`'s `cp := *src`),
+  reading the caller's live struct while the caller was still mutating it
+  (`UpdateBook` writes `book.ID` after the call returns). Under load during
+  startup — exactly when backfills and migrations run — this could write a torn,
+  half-updated Book projection into memdb. Fixed by snapshotting the struct at
+  enqueue time, and the same copy-at-enqueue rule was applied to every sibling
+  helper with the same shape (`UpsertBookFileToMemDB`, `UpsertAuthorToMemDB`,
+  `UpsertSeriesToMemDB`, `UpsertNarratorToMemDB`, `UpsertImportPathToMemDB`,
+  `UpsertAuthorAliasToMemDB`, `UpsertBlockedHashToMemDB`, plus slice copies in
+  `ReplaceBookAuthorsInMemDB`/`ReplaceBookNarratorsInMemDB`). Regression test
+  `TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue` forces the exact
+  interleaving deterministically under `-race` instead of hoping to catch it.

--- a/internal/database/memdb_sync.go
+++ b/internal/database/memdb_sync.go
@@ -1,7 +1,7 @@
 // file: internal/database/memdb_sync.go
-// version: 1.2.0
+// version: 1.2.1
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000005
-// last-edited: 2026-08-06
+// last-edited: 2026-08-07
 
 package database
 
@@ -111,24 +111,35 @@ type memTxn interface {
 
 // UpsertBookToMemDB inserts or replaces a book and its associated relationships
 // (book_authors flattened to rows, book_files reloaded from Pebble) in memdb.
+//
+// DATA-RACE RULE (applies to every Upsert* helper in this file): copy the
+// caller's struct BEFORE handing a closure to memSync. During the async warmup
+// window the closure is not run inline — it is buffered by memSync and replayed
+// much later on the warmup goroutine (publishWarmMemStore → applyMemSync), so a
+// closure that captures the caller's pointer dereferences the caller's LIVE
+// struct while the caller may still be mutating it (UpdateBook writes book.ID
+// after this returns, for example). Caught by -race on CI; see the 2026-08-07
+// memdb-warmup-caller-pointer-race todo for the full report.
 func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 	if book == nil {
 		return
 	}
+	// Snapshot NOW — the closure may run much later, on another goroutine.
+	snapshot := *book
 	p.memSync("UpsertBook", func(txn memTxn) error {
 		// Strip heavy fields (Description, BookSigV1, etc.) — memdb
 		// only needs lightweight projections for indexed iteration.
 		// Pebble retains the full Book; callers needing full payload
 		// hit GetBookByID. See memdb_strip.go.
-		if err := txn.Insert(memTableBooks, stripBookForMemdb(book)); err != nil {
+		if err := txn.Insert(memTableBooks, stripBookForMemdb(&snapshot)); err != nil {
 			return fmt.Errorf("insert book: %w", err)
 		}
 
 		// book_authors: clear existing rows for this book, then reinsert from Pebble.
-		if _, err := txn.DeleteAll(memTableBookAuthors, memIdxBookID, book.ID); err != nil {
+		if _, err := txn.DeleteAll(memTableBookAuthors, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_authors: %w", err)
 		}
-		if bas, baErr := p.GetBookAuthors(book.ID); baErr == nil {
+		if bas, baErr := p.GetBookAuthors(snapshot.ID); baErr == nil {
 			for i := range bas {
 				ba := bas[i]
 				if err := txn.Insert(memTableBookAuthors, &ba); err != nil {
@@ -138,10 +149,10 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		}
 
 		// book_narrators
-		if _, err := txn.DeleteAll(memTableBookNarrators, memIdxBookID, book.ID); err != nil {
+		if _, err := txn.DeleteAll(memTableBookNarrators, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_narrators: %w", err)
 		}
-		if bns, bnErr := p.GetBookNarrators(book.ID); bnErr == nil {
+		if bns, bnErr := p.GetBookNarrators(snapshot.ID); bnErr == nil {
 			for i := range bns {
 				bn := bns[i]
 				if err := txn.Insert(memTableBookNarrators, &bn); err != nil {
@@ -151,10 +162,10 @@ func (p *PebbleStore) UpsertBookToMemDB(ctx context.Context, book *Book) {
 		}
 
 		// book_files: clear and reload from Pebble
-		if _, err := txn.DeleteAll(memTableBookFiles, memIdxBookID, book.ID); err != nil {
+		if _, err := txn.DeleteAll(memTableBookFiles, memIdxBookID, snapshot.ID); err != nil {
 			return fmt.Errorf("clear book_files: %w", err)
 		}
-		files, fileErr := p.loadBookFilesForBookID(book.ID)
+		files, fileErr := p.loadBookFilesForBookID(snapshot.ID)
 		if fileErr == nil {
 			for i := range files {
 				bf := files[i]
@@ -199,8 +210,9 @@ func (p *PebbleStore) UpsertBookFileToMemDB(bf *BookFile) {
 	if bf == nil {
 		return
 	}
+	snapshot := *bf // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertBookFile", func(txn memTxn) error {
-		return txn.Insert(memTableBookFiles, stripBookFileForMemdb(bf))
+		return txn.Insert(memTableBookFiles, stripBookFileForMemdb(&snapshot))
 	})
 }
 
@@ -259,8 +271,9 @@ func (p *PebbleStore) UpsertAuthorToMemDB(a *Author) {
 	if a == nil {
 		return
 	}
+	snapshot := *a // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertAuthor", func(txn memTxn) error {
-		return txn.Insert(memTableAuthors, a)
+		return txn.Insert(memTableAuthors, &snapshot)
 	})
 }
 
@@ -280,8 +293,9 @@ func (p *PebbleStore) UpsertSeriesToMemDB(s *Series) {
 	if s == nil {
 		return
 	}
+	snapshot := *s // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertSeries", func(txn memTxn) error {
-		return txn.Insert(memTableSeries, s)
+		return txn.Insert(memTableSeries, &snapshot)
 	})
 }
 
@@ -301,8 +315,9 @@ func (p *PebbleStore) UpsertNarratorToMemDB(n *Narrator) {
 	if n == nil {
 		return
 	}
+	snapshot := *n // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertNarrator", func(txn memTxn) error {
-		return txn.Insert(memTableNarrators, n)
+		return txn.Insert(memTableNarrators, &snapshot)
 	})
 }
 
@@ -312,6 +327,9 @@ func (p *PebbleStore) ReplaceBookAuthorsInMemDB(bookID string, authors []BookAut
 	if bookID == "" {
 		return
 	}
+	// Copy the slice at enqueue — the closure iterates it much later during
+	// warmup replay, and the caller may reuse/mutate the backing array.
+	authors = append([]BookAuthor(nil), authors...)
 	p.memSync("ReplaceBookAuthors", func(txn memTxn) error {
 		if _, err := txn.DeleteAll(memTableBookAuthors, memIdxBookID, bookID); err != nil {
 			return err
@@ -330,6 +348,8 @@ func (p *PebbleStore) ReplaceBookNarratorsInMemDB(bookID string, narrators []Boo
 	if bookID == "" {
 		return
 	}
+	// Copy the slice at enqueue — see ReplaceBookAuthorsInMemDB.
+	narrators = append([]BookNarrator(nil), narrators...)
 	p.memSync("ReplaceBookNarrators", func(txn memTxn) error {
 		if _, err := txn.DeleteAll(memTableBookNarrators, memIdxBookID, bookID); err != nil {
 			return err
@@ -350,8 +370,9 @@ func (p *PebbleStore) UpsertImportPathToMemDB(ip *ImportPath) {
 	if ip == nil {
 		return
 	}
+	snapshot := *ip // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertImportPath", func(txn memTxn) error {
-		return txn.Insert(memTableImportPaths, ip)
+		return txn.Insert(memTableImportPaths, &snapshot)
 	})
 }
 
@@ -371,8 +392,9 @@ func (p *PebbleStore) UpsertAuthorAliasToMemDB(aa *AuthorAlias) {
 	if aa == nil {
 		return
 	}
+	snapshot := *aa // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertAuthorAlias", func(txn memTxn) error {
-		return txn.Insert(memTableAuthorAliases, aa)
+		return txn.Insert(memTableAuthorAliases, &snapshot)
 	})
 }
 
@@ -399,8 +421,9 @@ func (p *PebbleStore) UpsertBlockedHashToMemDB(b *DoNotImport) {
 	if b == nil {
 		return
 	}
+	snapshot := *b // copy at enqueue — see the data-race rule on UpsertBookToMemDB
 	p.memSync("UpsertBlockedHash", func(txn memTxn) error {
-		return txn.Insert(memTableBlockedHashes, b)
+		return txn.Insert(memTableBlockedHashes, &snapshot)
 	})
 }
 

--- a/internal/database/memdb_sync_race_test.go
+++ b/internal/database/memdb_sync_race_test.go
@@ -1,0 +1,90 @@
+// file: internal/database/memdb_sync_race_test.go
+// version: 1.0.0
+// guid: 4e7b9d21-8f3a-4c56-9e02-7a1d5b8c3f60
+// last-edited: 2026-08-07
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue is a regression test for
+// the memdb-warmup caller-pointer data race (CI, PR #2170): UpsertBookToMemDB
+// used to capture the caller's *Book in the memSync closure, and while warmup
+// buffering was active that closure ran much later on the warmup goroutine
+// (publishWarmMemStore -> applyMemSync -> stripBookForMemdb's `cp := *src`),
+// dereferencing the caller's live struct while the caller was still mutating
+// it (UpdateBook writes book.ID after the call returns).
+//
+// The race is timing-dependent in production: a full -race run of this package
+// passed 0-races locally while CI caught it. So this test does NOT hope to
+// catch it — it forces the exact interleaving deterministically:
+//
+//  1. arm the warmup pending buffer (as if warmup were still in flight),
+//  2. enqueue an upsert for a caller-owned *Book (the closure is buffered,
+//     not run inline),
+//  3. start a goroutine that mutates that same *Book in a tight loop with no
+//     synchronization,
+//  4. replay the buffered op via publishWarmMemStore while the mutator is
+//     provably running.
+//
+// On the unfixed code the replay's read of the caller's struct overlaps the
+// unsynchronized writes and the race detector flags it on every run. With the
+// fix (snapshot copied at enqueue time) the closure never touches the caller's
+// struct, so `go test -race` stays green. Run with -race or it proves nothing.
+func TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue(t *testing.T) {
+	store := setupTestPebbleStore(t)
+	store.WaitForWarmup()
+	require.True(t, store.UseMemDB, "test must exercise the memdb path")
+
+	// The caller-owned Book, exactly like CreateBook/UpdateBook callers hold.
+	book := &Book{
+		ID:       "race-book-0",
+		Title:    "original title",
+		FilePath: "/tmp/race-book.m4b",
+	}
+
+	// Re-arm the pending buffer, putting the store back into the async-warmup
+	// window: memSync now buffers the closure instead of running it inline.
+	store.beginMemWarmupBuffering()
+	store.UpsertBookToMemDB(context.Background(), book)
+
+	// Fresh MemStore to publish into, same as the warmup goroutine builds.
+	m, err := NewMemStore()
+	require.NoError(t, err)
+
+	// Mutate the caller's struct in a tight unsynchronized loop, exactly what
+	// UpdateBook's `book.ID = id` write-back does after the call returns.
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; ; i++ {
+			if i == 1 {
+				close(started) // loop is provably live before the replay runs
+			}
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			book.Title = fmt.Sprintf("mutated title %d", i)
+			book.ID = fmt.Sprintf("race-book-%d", i)
+		}
+	}()
+	<-started
+
+	// Replay the buffered op — this is the warmup-goroutine side of the race.
+	// On unfixed code this dereferences the caller's *Book right here, while
+	// the goroutine above is writing it.
+	require.True(t, store.publishWarmMemStore(m), "publish must succeed")
+
+	close(stop)
+	<-done
+}


### PR DESCRIPTION
## Summary

Fixes the memdb-warmup caller-pointer data race caught by `-race` on CI during PR #2170 (diagnosed in the `20260807_020500_memdb_warmup_caller_pointer_race` todo, now checked off in `TODO.md`).

`UpsertBookToMemDB` captured the caller's `*Book` in the `memSync` closure. While the async warmup is still buffering, that closure is not run inline — it is queued and replayed much later on the warmup goroutine (`publishWarmMemStore` → `applyMemSync` → `stripBookForMemdb`'s `cp := *src`), dereferencing the caller's **live** struct while the caller may still be mutating it (`UpdateBook` writes `book.ID` after the call returns). A torn read writes a half-updated Book projection into memdb — exactly during startup, when backfills and migrations run.

## Fix

Copy the struct when the op is **queued**, not when it is applied (`snapshot := *book` before the closure). The same rule is applied to every sibling with the same closure-captures-caller-pointer shape: `UpsertBookFileToMemDB`, `UpsertAuthorToMemDB`, `UpsertSeriesToMemDB`, `UpsertNarratorToMemDB`, `UpsertImportPathToMemDB`, `UpsertAuthorAliasToMemDB`, `UpsertBlockedHashToMemDB`, plus slice copies in `ReplaceBookAuthorsInMemDB` / `ReplaceBookNarratorsInMemDB`.

## Regression test

`TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue` forces the interleaving deterministically instead of hoping to catch it (the full package passed 0-races locally while CI fired): it re-arms the warmup pending buffer, enqueues an upsert, mutates the caller's `Book` in an unsynchronized tight loop, and replays via `publishWarmMemStore` while the mutator is provably live. On the unfixed code the race detector flags it on every run; green with the fix.

## Verification

- `go build ./...` clean
- `go test ./internal/database/ -race -run TestUpsertBookToMemDB_SnapshotsCallerBookAtEnqueue -count=1` — PASS on fixed code
- Pre-fix failure proof: reverting `memdb_sync.go` to main and re-running the test trips `WARNING: DATA RACE` (strip read on the replay path vs. caller write loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp