### PR TITLE
fix(maintenance): transport failures no longer write per-file whisper_error

### DIFF
--- a/changelog.d/20260807_210000_transport-error-no-per-file-status.md
+++ b/changelog.d/20260807_210000_transport-error-no-per-file-status.md
@@ -1,0 +1,21 @@
+<!-- file: changelog.d/20260807_210000_transport-error-no-per-file-status.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3d9e6f1a-4b7c-4e28-a5d0-8c2f9b1e6d47 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Fixed
+
+- **Transport failures no longer write per-file transcription status.** When
+  the Whisper batch call fails with a `*transcribe.TransportError` (endpoint
+  unreachable, connection refused, timeout — the request never reached a
+  model), `processTranscribePage` now writes ZERO `TranscribeStatus` rows and
+  defers the page for retry on the next run, instead of stamping every book
+  in the batch as `whisper_error`. This closes the caller-side half of the
+  bug that recorded the 2026-07-01 day-long endpoint outage as ~34,000 false
+  per-book `whisper_error` verdicts (the error-classification half shipped in
+  PR #2173; the historical rows were repaired by
+  `maintenance.repair-transcribe-status`). Per-file errors reported inside a
+  successful batch (`BatchResult.Error`) still write `whisper_error` for that
+  book, and genuine non-transport batch failures keep the old whole-batch
+  behaviour as defence for the local path. Regression tests cover both
+  directions in `internal/plugins/maintenance/intro_transcribe_transport_test.go`.

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.14.0
+// version: 3.15.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-08-07
 
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,6 +26,11 @@ import (
 	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
 	"github.com/falkcorp/audiobook-organizer/pkg/plugin/sdk"
 )
+
+// transcribeBatchFn is a test seam over transcribe.TranscribeBatch so tests can
+// substitute a stub (e.g. one returning *transcribe.TransportError) without a
+// live Whisper endpoint. Production code never reassigns it.
+var transcribeBatchFn = transcribe.TranscribeBatch
 
 const (
 	introTranscribePageSize  = 200
@@ -566,9 +572,22 @@ func (p *Plugin) processTranscribePage(
 
 	// Step 3: one Python/Whisper process for the whole page.
 	log.Info("transcribe-book-intros: calling whisper batch", "jobs", len(batchJobs))
-	batchResults, err := transcribe.TranscribeBatch(ctx, batchJobs, onBook)
-	if err != nil {
+	batchResults, err := transcribeBatchFn(ctx, batchJobs, onBook)
+	var te *transcribe.TransportError
+	switch {
+	case errors.As(err, &te):
+		// Endpoint problem, not a file problem. Write NOTHING; the page is
+		// deferred and will be retried next run. On 2026-07-01 this exact
+		// branch's absence recorded a day-long endpoint outage as ~34,000
+		// false per-book whisper_error verdicts.
+		log.Warn("transcribe: endpoints unreachable, page deferred (no status written)",
+			"jobs", len(batchJobs), "endpoints", te.Endpoints, "recognized", te.Recognized, "err", te.Err)
+		return 0
+	case err != nil:
 		// Whole-batch failure: every book that had a WAV is a whisper_error.
+		// Note classifyTransport wraps EVERY batch-level error from the remote
+		// path as a TransportError, so in practice this arm is unreachable from
+		// the remote path; kept as defence for the local path.
 		log.Warn("transcribe: whisper batch failed", "jobs", len(batchJobs), "err", err)
 		detail := truncateDetail(err.Error())
 		for bookID := range batchJobs {
@@ -619,7 +638,7 @@ func (p *Plugin) processTranscribePage(
 			}
 		}
 		if len(retry1Jobs) > 0 {
-			if r1, rerr := transcribe.TranscribeBatch(ctx, retry1Jobs, onBook); rerr == nil {
+			if r1, rerr := transcribeBatchFn(ctx, retry1Jobs, onBook); rerr == nil {
 				for id, res := range r1 {
 					if res.Text != "" {
 						batchResults[id] = res
@@ -655,7 +674,7 @@ func (p *Plugin) processTranscribePage(
 				}
 			}
 			if len(retry2Jobs) > 0 {
-				if r2, rerr := transcribe.TranscribeBatch(ctx, retry2Jobs, onBook); rerr == nil {
+				if r2, rerr := transcribeBatchFn(ctx, retry2Jobs, onBook); rerr == nil {
 					for id, res := range r2 {
 						if res.Text != "" {
 							batchResults[id] = res

--- a/internal/plugins/maintenance/intro_transcribe_transport_test.go
+++ b/internal/plugins/maintenance/intro_transcribe_transport_test.go
@@ -1,0 +1,135 @@
+// file: internal/plugins/maintenance/intro_transcribe_transport_test.go
+// version: 1.0.0
+// guid: 7f2b4a8d-9c3e-4d15-b6a2-0e8f1c5d7a93
+// last-edited: 2026-08-07
+
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/database"
+	"github.com/falkcorp/audiobook-organizer/internal/transcribe"
+)
+
+// transportTestFixture wires up everything processTranscribePage needs to reach
+// the TranscribeBatch call without ffmpeg or a live endpoint:
+//   - a pre-populated WAV clip cache so the extraction step is a cache hit
+//     (the cache-hit path runs before the source-file stat, so the source
+//     path never needs to exist),
+//   - a MockStore whose GetBookFiles returns one audio file with a FileHash
+//     matching the cached clip, and whose UpdateBook captures every write.
+func transportTestFixture(t *testing.T, bookID, fileHash string) (*database.MockStore, *[]database.Book, []database.Book, string) {
+	t.Helper()
+
+	cacheDir := t.TempDir()
+	t.Setenv("WHISPER_CLIP_CACHE_DIR", cacheDir)
+	clip := cachedClipPath(cacheDir, fileHash)
+	if err := os.WriteFile(clip, []byte("RIFF fake wav"), 0o644); err != nil {
+		t.Fatalf("write cached clip: %v", err)
+	}
+
+	written := &[]database.Book{}
+	store := &database.MockStore{
+		GetBookFilesFunc: func(id string) ([]database.BookFile, error) {
+			return []database.BookFile{{
+				ID:       "f-" + id,
+				BookID:   id,
+				FilePath: filepath.Join(t.TempDir(), "does-not-exist.m4b"),
+				FileHash: fileHash,
+			}}, nil
+		},
+		UpdateBookFunc: func(_ string, b *database.Book) (*database.Book, error) {
+			*written = append(*written, *b)
+			return b, nil
+		},
+	}
+	books := []database.Book{{ID: bookID}}
+	return store, written, books, t.TempDir() // last value = rootDir (cache env overrides it)
+}
+
+// swapTranscribeBatchFn substitutes the transcribeBatchFn test seam and
+// restores it on cleanup. Tests using it must not run in parallel.
+func swapTranscribeBatchFn(t *testing.T, fn func(context.Context, map[string]string, transcribe.ProgressFunc) (map[string]transcribe.BatchResult, error)) {
+	t.Helper()
+	orig := transcribeBatchFn
+	transcribeBatchFn = fn
+	t.Cleanup(func() { transcribeBatchFn = orig })
+}
+
+// TestProcessTranscribePage_TransportErrorWritesNoStatus is the regression test
+// for the 2026-07-01 outage: when TranscribeBatch fails with a
+// *transcribe.TransportError (endpoint dead, request never reached a model),
+// processTranscribePage must write ZERO TranscribeStatus rows — the page is
+// deferred and retried next run, never recorded as ~200 false whisper_errors.
+func TestProcessTranscribePage_TransportErrorWritesNoStatus(t *testing.T) {
+	store, written, books, rootDir := transportTestFixture(t, "b-transport", "hash-transport")
+	var calls int
+	swapTranscribeBatchFn(t, func(_ context.Context, jobs map[string]string, _ transcribe.ProgressFunc) (map[string]transcribe.BatchResult, error) {
+		calls++
+		if len(jobs) != 1 {
+			t.Errorf("expected 1 job to reach the batch call, got %d", len(jobs))
+		}
+		return nil, &transcribe.TransportError{
+			Endpoints:  []string{"http://whisper-a.test", "http://whisper-b.test"},
+			Err:        errors.New("dial tcp: connection refused"),
+			Recognized: true,
+		}
+	})
+
+	p := New(fakeDeps{store: store})
+	accum := newTranscribeStatsAccum(nil, "op", 0, time.Now())
+	processed := p.processTranscribePage(context.Background(), store, slog.Default(),
+		books, rootDir, nil, accum, false)
+
+	if calls != 1 {
+		t.Fatalf("TranscribeBatch stub called %d times, want 1", calls)
+	}
+	if processed != 0 {
+		t.Errorf("processed = %d, want 0", processed)
+	}
+	if len(*written) != 0 {
+		t.Fatalf("transport error must write ZERO TranscribeStatus rows, got %d UpdateBook calls; first: %+v",
+			len(*written), (*written)[0])
+	}
+}
+
+// TestProcessTranscribePage_PerFileErrorStillWritesWhisperError is the
+// no-over-correction guard: a per-file failure reported INSIDE a successful
+// batch (BatchResult{Error: "boom"}) is a genuine per-file verdict and must
+// still be written as whisper_error for that book.
+func TestProcessTranscribePage_PerFileErrorStillWritesWhisperError(t *testing.T) {
+	store, written, books, rootDir := transportTestFixture(t, "b-perfile", "hash-perfile")
+	swapTranscribeBatchFn(t, func(_ context.Context, jobs map[string]string, _ transcribe.ProgressFunc) (map[string]transcribe.BatchResult, error) {
+		out := make(map[string]transcribe.BatchResult, len(jobs))
+		for id := range jobs {
+			out[id] = transcribe.BatchResult{Error: "boom"}
+		}
+		return out, nil
+	})
+
+	p := New(fakeDeps{store: store})
+	accum := newTranscribeStatsAccum(nil, "op", 0, time.Now())
+	processed := p.processTranscribePage(context.Background(), store, slog.Default(),
+		books, rootDir, nil, accum, false)
+
+	if processed != 0 {
+		t.Errorf("processed = %d, want 0 (whisper_error does not count as processed)", processed)
+	}
+	if len(*written) != 1 {
+		t.Fatalf("expected exactly 1 UpdateBook for the per-file error, got %d", len(*written))
+	}
+	w := (*written)[0]
+	if w.TranscribeStatus == nil || *w.TranscribeStatus != statusWhisperError {
+		t.Errorf("TranscribeStatus = %v, want %q", w.TranscribeStatus, statusWhisperError)
+	}
+	if w.TranscribeError == nil || *w.TranscribeError != "boom" {
+		t.Errorf("TranscribeError = %v, want \"boom\"", w.TranscribeError)
+	}
+}

--- a/todo.d/20260807_203000_all_ops_must_support_dry_run.md
+++ b/todo.d/20260807_203000_all_ops_must_support_dry_run.md
@@ -1,0 +1,50 @@
+<!-- file: todo.d/20260807_203000_all_ops_must_support_dry_run.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a7f28c15-9364-4e0b-b8d2-46c1e0937fa5 -->
+<!-- last-edited: 2026-08-07 -->
+
+- [ ] **Require every operation to support `dry_run`, and enforce it at the
+      registry rather than by convention.** Any op that mutates state must be
+      runnable in a mode that computes and reports exactly what it WOULD do,
+      writing nothing — so it can be tested independently and reviewed before it
+      touches prod.
+
+      **Motivating case (2026-08-07).** Three maintenance ops were run in one
+      session and they did not agree with each other:
+
+        maintenance.repair-transcribe-status      dry_run, defaults TRUE
+        maintenance.intro-migrate-single-file     dry_run, defaults TRUE
+        maintenance.transcribe-book-intros        NO dry_run at all
+
+      The first two could be previewed, reconciled bucket-by-bucket against the
+      full book count, and gated on real numbers. The third — a reparse that
+      rewrites parsed title/author/narrator across the library — had no preview
+      mode whatsoever: dispatching it IS applying it. The only reason that was
+      acceptable was an unrelated internal guard (reparse only ever upgrades),
+      which is luck, not design.
+
+      **What "supported" should mean** — a bare `dry_run` bool is not enough:
+
+      - **Declared, not optional.** Put it on `OperationDef` (e.g.
+        `SupportsDryRun bool`, or better, make the param struct embed a shared
+        `DryRunParams`). An op declaring `CapLibraryWrite` without dry-run
+        support should fail registration, so the gap is caught at startup rather
+        than discovered while someone is deciding whether to hit apply.
+      - **Default TRUE for destructive ops.** Both ops that had it defaulted to
+        dry-run; that is the right default and should not be per-author choice.
+      - **Report per-reason counts that RECONCILE.** The value of the two
+        previewable ops was that every item landed in exactly one labelled
+        bucket and the buckets summed to the population — 11,315 + 19,505 + 0 +
+        12,587 + 1,463 + 7 = 44,877 exactly. "would change 30,820" with no
+        account of the rest is the shape of report that hides a bug. Consider a
+        shared result type so this is structural rather than remembered.
+      - **Same code path.** The dry run must execute the identical decision
+        logic and diverge only at the write, or it is testing something other
+        than what will run. Both existing ops do this correctly (classify, then
+        branch on `dryRun` immediately before the store call) — that pattern is
+        the one to generalise.
+
+      Related: the write-set/scheduler-conflict work
+      (`OperationDef.Writes []Resource`). Both are the same idea — an op should
+      DECLARE what it does, and the system should enforce it, instead of every
+      author re-deciding by hand.


### PR DESCRIPTION
## What

The caller-side half of the July-1 fix. `processTranscribePage` now distinguishes a `*transcribe.TransportError` (endpoint unreachable — introduced in #2173) from a genuine batch failure:

- **Transport error → writes NOTHING.** The page is deferred and retried next run. Previously every book in the page was marked `whisper_error` — this exact path recorded a one-day network outage as ~34,000 false per-book verdicts, which took `maintenance.repair-transcribe-status` (applied 2026-08-07, 30,820 books) to undo.
- **Genuine batch failure → existing behaviour kept** (defence for the local path; the remote path always wraps).

## Tests

- `TestProcessTranscribePage_TransportErrorWritesNoStatus` — transport error, asserts **0** UpdateBook calls.
- `TestProcessTranscribePage_PerFileErrorStillWritesWhisperError` — per-file error in a successful batch still writes `whisper_error` (no over-correction).

Both `-race`, full maintenance package green. Minimal seam: `var transcribeBatchFn = transcribe.TranscribeBatch`.

Also carries: `todo.d` fragment requiring dry_run on every mutating op (registry-enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp