### PR TITLE
fix(e2e): remove unknown "_page" fixture parameter that broke the suite

### DIFF
--- a/changelog.d/e2e-unknown-page-parameter.md
+++ b/changelog.d/e2e-unknown-page-parameter.md
@@ -1,0 +1,25 @@
+<!-- file: changelog.d/e2e-unknown-page-parameter.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f7a91c2-6d48-4b0e-9a25-8c1e5d4f7b32 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Fixed
+
+#### E2E suite: `unknown parameter "_page"` broke six spec files on main
+
+A lint sweep in April (`68d2a0ed`, "resolve all E2E test lint errors") renamed
+the unused `page` fixture parameter to `_page` in seven no-op
+`test.beforeEach(async ({ _page }) => { ... })` hooks. Playwright validates
+fixture names in the destructured parameter object at run time, so every test
+inside those `describe` blocks failed immediately with
+`Error: Test has unknown parameter "_page"` — the suite was broken on main
+and gated nothing.
+
+The seven hooks (in `dashboard.spec.ts`, `book-detail.spec.ts`,
+`error-handling.spec.ts`, `file-browser.spec.ts`,
+`operation-monitoring.spec.ts`, and two in `import-audiobook-file.spec.ts`)
+have comment-only bodies — each test does its own setup via
+`openLibrary()`/`openDashboard()`/`setupRoutes()` etc. — so the fix is to
+declare them with no parameters at all: `test.beforeEach(async () => { ... })`.
+This satisfies both the linter (no unused parameter) and Playwright (no
+unknown fixture).

--- a/web/tests/e2e/book-detail.spec.ts
+++ b/web/tests/e2e/book-detail.spec.ts
@@ -1,7 +1,7 @@
 // file: tests/e2e/book-detail.spec.ts
-// version: 1.12.0
+// version: 1.12.1
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
-// last-edited: 2026-03-04
+// last-edited: 2026-08-07
 
 import { expect, test } from '@playwright/test';
 import { mockEventSource } from './utils/test-helpers';
@@ -351,7 +351,7 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
 };
 
 test.describe('Book Detail page', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Each test calls setupRoutes which handles all setup including EventSource mocking
     // No setup needed here to avoid conflicts
   });

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/dashboard.spec.ts
-// version: 1.3.0
+// version: 1.3.1
 // guid: f6e23777-438b-4931-88d9-d2c6d2225a00
-// last-edited: 2026-03-02
+// last-edited: 2026-08-07
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -94,7 +94,7 @@ const openDashboard = async (page: Page) => {
 };
 
 test.describe('Dashboard', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openDashboard() which calls setupMockApi()
   });
 

--- a/web/tests/e2e/error-handling.spec.ts
+++ b/web/tests/e2e/error-handling.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/error-handling.spec.ts
-// version: 1.4.0
+// version: 1.4.1
 // guid: 2f4f5afa-c734-4a00-8a72-d288bcea714f
-// last-edited: 2026-03-02
+// last-edited: 2026-08-07
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -19,7 +19,7 @@ const openLibrary = async (
 };
 
 test.describe('Error Handling', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openLibrary() which calls setupMockApi()
   });
 

--- a/web/tests/e2e/file-browser.spec.ts
+++ b/web/tests/e2e/file-browser.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/file-browser.spec.ts
-// version: 1.4.0
+// version: 1.4.1
 // guid: bbd8bdb0-5dc1-448f-a520-def03ae76825
-// last-edited: 2026-02-04
+// last-edited: 2026-08-07
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -97,7 +97,7 @@ const openImportFileBrowser = async (page: Page) => {
 };
 
 test.describe('File Browser', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openImportFileBrowser() which calls setupMockApi()
   });
 

--- a/web/tests/e2e/import-audiobook-file.spec.ts
+++ b/web/tests/e2e/import-audiobook-file.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/import-audiobook-file.spec.ts
-// version: 1.4.0
+// version: 1.4.1
 // guid: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
-// last-edited: 2026-03-02
+// last-edited: 2026-08-07
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -128,7 +128,7 @@ const dialog = (page: Page) =>
   page.getByRole('dialog').filter({ hasText: 'Import Audiobook File' });
 
 test.describe('Import Audiobook File - Interactive Navigation', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openImportFileBrowser() which calls setupMockApi()
   });
 
@@ -382,7 +382,7 @@ test.describe('Import Audiobook File - Interactive Navigation', () => {
 });
 
 test.describe('Import Audiobook File - Error Handling', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openImportFileBrowser() which calls setupMockApi()
   });
 

--- a/web/tests/e2e/operation-monitoring.spec.ts
+++ b/web/tests/e2e/operation-monitoring.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/operation-monitoring.spec.ts
-// version: 2.0.0
+// version: 2.0.1
 // guid: 9845a5f8-e3e4-472f-ae99-2723b6163aae
-// last-edited: 2026-03-02
+// last-edited: 2026-08-07
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -127,7 +127,7 @@ const openOperations = async (page: Page, seed?: Partial<OperationSeed>) => {
 };
 
 test.describe('Operation Monitoring', () => {
-  test.beforeEach(async ({ _page }) => {
+  test.beforeEach(async () => {
     // Setup handled by openOperations() which calls setupMockApi()
   });
 


### PR DESCRIPTION
The e2e suite has been broken on main since April: an e2e lint sweep (68d2a0ed, "resolve all E2E test lint errors") renamed the unused `page` fixture parameter to `_page` in seven comment-only `test.beforeEach` hooks across six spec files. Playwright validates fixture names in the destructured parameter object at run time, so every test inside those `describe` blocks failed immediately with:

```
Error: beforeEach hook has unknown parameter "_page".
```

(reproduced verbatim on the pre-fix `dashboard.spec.ts` before applying this change).

## Fix

The affected hooks have comment-only bodies — each test performs its own setup via `openDashboard()` / `openLibrary()` / `setupRoutes()` etc. — so the hooks now declare **no parameters at all**: `test.beforeEach(async () => { ... })`. That satisfies both the linter (no unused parameter) and Playwright (no unknown fixture).

Touched (7 hooks, 6 files, version headers bumped):
- `web/tests/e2e/dashboard.spec.ts`
- `web/tests/e2e/book-detail.spec.ts`
- `web/tests/e2e/error-handling.spec.ts`
- `web/tests/e2e/file-browser.spec.ts`
- `web/tests/e2e/operation-monitoring.spec.ts`
- `web/tests/e2e/import-audiobook-file.spec.ts` (2 hooks)

Plus a `changelog.d/` fragment.

## Verification

With the fix, the previously-dead tests now execute for real. Note: some of them then fail on **pre-existing content drift** (e.g. the Dashboard specs assert stats text like `45.0 GB / 500.0 GB` that the UI no longer renders) — those failures were masked for four months by the fixture error and are out of scope here; they are being enumerated in the follow-up report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp