### PR TITLE
feat(operations): declared write-sets + dispatcher conflict gate

### DIFF
--- a/changelog.d/20260807_210000_operation_write_set_conflict_gate.md
+++ b/changelog.d/20260807_210000_operation_write_set_conflict_gate.md
@@ -1,0 +1,21 @@
+<!-- file: changelog.d/20260807_210000_operation_write_set_conflict_gate.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7c2e5f9a-4b1d-4e8c-a3f6-9d0b2c5e8a14 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Added
+
+- Declared write-sets + scheduler conflict gate for operations. `OperationDef`
+  gains `Writes []Resource` / `Reads []Resource` (table-level: books,
+  book_files, authors, series, review_items, embeddings, operations), and the
+  dispatcher's new Gate 3b refuses to START an op whose declared `Writes`
+  overlap those of any currently running op — the op stays queued and
+  dispatches when the conflict clears, with one deduplicated log line per
+  deferral. Table-level granularity is deliberate: prod writes are whole-row
+  read-modify-write (`UpdateBook` carries every field), so field-disjoint ops
+  still lose fields when interleaved. Empty `Writes` = undeclared = gate
+  skipped, so rollout is incremental. First adopters (today's incident pair
+  plus siblings): `acoustid.backfill` (books, book_files),
+  `maintenance.repair-transcribe-status` (books),
+  `maintenance.intro-migrate-single-file` (book_files),
+  `maintenance.transcribe-book-intros` (books).

--- a/internal/operations/registry/dispatcher.go
+++ b/internal/operations/registry/dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/dispatcher.go
-// version: 2.0.1
+// version: 2.1.0
 // guid: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-06-10
+// last-edited: 2026-08-07
 
 package registry
 
@@ -40,6 +40,20 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 	if err != nil {
 		r.logger.Warn("registry: list queued ops failed", "error", err)
 		return
+	}
+
+	// Prune write-set deferral log-dedupe entries for ops that left the queue
+	// (dispatched, canceled, deleted) so the map cannot grow unbounded.
+	if len(r.writeSetDeferred) > 0 {
+		queuedIDs := make(map[string]struct{}, len(queued))
+		for _, row := range queued {
+			queuedIDs[row.ID] = struct{}{}
+		}
+		for opID := range r.writeSetDeferred {
+			if _, still := queuedIDs[opID]; !still {
+				delete(r.writeSetDeferred, opID)
+			}
+		}
 	}
 
 	for _, row := range queued {
@@ -98,6 +112,24 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			}
 		}
 
+		// Gate 3b: declared write-set conflict? An op with a non-empty Writes
+		// declaration must not start while any RUNNING op declares an
+		// overlapping write-set — whole-row read-modify-write on both sides
+		// means concurrent execution silently loses fields (the 2026-08-07
+		// acoustid.backfill × maintenance.repair-transcribe-status incident).
+		// The op stays QUEUED, exactly like the ConcurrencyKey gate, and
+		// dispatches when the conflicting op releases its handle. Ops with
+		// empty Writes bypass the gate entirely in both directions.
+		if len(def.Writes) > 0 {
+			r.mu.RLock()
+			holder, overlap := r.writeSetConflictLocked(row.ID, def.Writes)
+			r.mu.RUnlock()
+			if holder != nil {
+				r.logWriteSetDeferral(row.ID, row.DefID, holder, overlap)
+				continue
+			}
+		}
+
 		// Gate 4: DependsOn — all listed op defs must NOT be currently running.
 		if blocked := r.checkDependsOn(def.DependsOn); blocked {
 			continue
@@ -121,6 +153,14 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 				r.mu.Unlock()
 				continue
 			}
+		}
+		if len(def.Writes) > 0 {
+			if holder, _ := r.writeSetConflictLocked(row.ID, def.Writes); holder != nil {
+				r.mu.Unlock()
+				continue
+			}
+		}
+		if def.ConcurrencyKey != "" {
 			r.concurrencyKeys[def.ConcurrencyKey] = row.ID
 		}
 		r.pluginRunning[def.Plugin]++
@@ -133,6 +173,7 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			plugin:         def.Plugin,
 			concurrencyKey: def.ConcurrencyKey,
 			resumePolicy:   def.ResumePolicy,
+			writes:         def.Writes,
 		}
 		r.mu.Unlock()
 
@@ -148,6 +189,7 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 
 		select {
 		case r.nextRun <- qr:
+			delete(r.writeSetDeferred, row.ID)
 			r.logger.Info("registry: dispatched op", "op_id", row.ID, "def_id", row.DefID)
 		default:
 			// Worker channel is full; undo accounting and try next cycle.
@@ -164,6 +206,57 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			r.mu.Unlock()
 		}
 	}
+}
+
+// writeSetConflictLocked returns the first running op (other than candidateID
+// itself) whose declared write-set overlaps candidateWrites, plus the
+// overlapping resources. Returns (nil, nil) when there is no conflict.
+// v1 semantics: Writes∩Writes only — a running op's Reads never block a
+// writer, and ops with empty Writes are invisible to the gate.
+// Caller must hold r.mu (read or write).
+func (r *Registry) writeSetConflictLocked(candidateID string, candidateWrites []Resource) (*runHandle, []Resource) {
+	if len(candidateWrites) == 0 {
+		return nil, nil
+	}
+	for _, h := range r.running {
+		if h.id == candidateID || len(h.writes) == 0 {
+			continue
+		}
+		var overlap []Resource
+		for _, w := range candidateWrites {
+			for _, hw := range h.writes {
+				if w == hw {
+					overlap = append(overlap, w)
+					break
+				}
+			}
+		}
+		if len(overlap) > 0 {
+			return h, overlap
+		}
+	}
+	return nil, nil
+}
+
+// logWriteSetDeferral logs one clear line per (deferred op → blocking op)
+// pair. Without dedupe the 100ms dispatch ticker would repeat the line ten
+// times a second for as long as the conflict lasts. writeSetDeferred is only
+// ever touched from the dispatcher goroutine (dispatchCycle is single-caller),
+// so it needs no locking; entries are dropped once the blocking op changes or
+// the deferred op leaves the queue (see the prune in dispatchCycle).
+func (r *Registry) logWriteSetDeferral(opID, defID string, holder *runHandle, overlap []Resource) {
+	if r.writeSetDeferred[opID] == holder.id {
+		return
+	}
+	r.writeSetDeferred[opID] = holder.id
+	resources := make([]string, len(overlap))
+	for i, res := range overlap {
+		resources[i] = string(res)
+	}
+	r.logger.Info("registry: op deferred: write-set conflict with running op",
+		"op_id", opID, "def_id", defID,
+		"running_op_id", holder.id, "running_def_id", holder.defID,
+		"resources", resources)
 }
 
 // checkDependsOn returns true if any op in depDefIDs is currently running.

--- a/internal/operations/registry/registry.go
+++ b/internal/operations/registry/registry.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/registry.go
-// version: 3.9.0
+// version: 3.10.0
 // guid: f6a7b8c9-d0e1-2f3a-4b5c-6d7e8f9a0b1c
-// last-edited: 2026-07-18
+// last-edited: 2026-08-07
 
 package registry
 
@@ -24,12 +24,17 @@ import (
 // Registry is the central in-memory and DB-backed object that owns every
 // OperationDef, dispatches runs, enforces policies, and routes events.
 type Registry struct {
-	mu               sync.RWMutex
-	defs             map[string]OperationDef
-	running          map[string]*runHandle // opID → handle
-	pluginRunning    map[string]int        // plugin → count of running ops
-	pluginMax        map[string]int        // plugin → max_concurrent (0 = unlimited)
-	concurrencyKeys  map[string]string     // key → opID of holder
+	mu              sync.RWMutex
+	defs            map[string]OperationDef
+	running         map[string]*runHandle // opID → handle
+	pluginRunning   map[string]int        // plugin → count of running ops
+	pluginMax       map[string]int        // plugin → max_concurrent (0 = unlimited)
+	concurrencyKeys map[string]string     // key → opID of holder
+	// writeSetDeferred dedupes the Gate-3b deferral log line: queued opID →
+	// running opID last logged as blocking it. Dispatcher-goroutine-private
+	// (only dispatchCycle and its helpers touch it), so it is NOT guarded by
+	// mu; pruned every cycle against the live queued set.
+	writeSetDeferred map[string]string
 	nextRun          chan *queuedRun
 	dispatch         chan struct{}
 	store            database.OpsV2Store
@@ -143,6 +148,7 @@ func NewWithOptions(store database.OpsV2Store, logger *slog.Logger, workers int,
 		pluginRunning:    make(map[string]int),
 		pluginMax:        make(map[string]int),
 		concurrencyKeys:  make(map[string]string),
+		writeSetDeferred: make(map[string]string),
 		nextRun:          make(chan *queuedRun, workers*2),
 		dispatch:         make(chan struct{}, 1),
 		store:            store,

--- a/internal/operations/registry/types.go
+++ b/internal/operations/registry/types.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/types.go
-// version: 2.4.0
+// version: 2.5.0
 // guid: d4e5f6a7-b8c9-0d1e-2f3a-4b5c6d7e8f9a
-// last-edited: 2026-06-22
+// last-edited: 2026-08-07
 
 // Package registry provides the UOS-02 in-memory OperationDef registry,
 // dispatcher, and in-process worker pool. See the spec at
@@ -81,6 +81,33 @@ type OperationDef struct {
 
 	// Dependencies. Optional.
 	DependsOn []string // op def IDs that must NOT be running for this op to start
+
+	// Write/read sets. Optional (2026-08-07 owner design: "we declare what it
+	// does and then the system automatically won't schedule two things" that
+	// mutate the same data).
+	//
+	// Writes declares which logical tables this op mutates. The dispatcher's
+	// write-set conflict gate (Gate 3b, dispatcher.go) refuses to START an op
+	// whose Writes overlap the Writes of any currently RUNNING op — the op
+	// stays queued and dispatches when the conflicting op finishes, exactly
+	// like the ConcurrencyKey gate. Granularity is deliberately table-level,
+	// not field-level: prod writes are whole-row read-modify-write
+	// (GetBookByID → mutate → UpdateBook carries every field), so two ops
+	// touching DISJOINT fields of the same table still silently lose fields
+	// when interleaved. Motivating incident: acoustid.backfill running
+	// concurrently with maintenance.repair-transcribe-status on the same Book
+	// rows (2026-08-07), hand-serialized by watching journalctl.
+	//
+	// Empty Writes = declares nothing = the gate skips this op entirely
+	// (today's behaviour), so rollout is incremental and undeclared ops are
+	// unaffected in both directions.
+	Writes []Resource
+
+	// Reads declares which logical tables this op reads at whole-table scale.
+	// Declared for forward compatibility (a v2 gate may defer writers while a
+	// full-table reader runs); v1 enforces Writes∩Writes only and does not
+	// consult Reads.
+	Reads []Resource
 
 	// Requires are standing prerequisites evaluated before every enqueue of this op.
 	// Unlike DependsOn (which means "must NOT run concurrently"), Requires means
@@ -191,6 +218,24 @@ const (
 
 	CapSubprocessSpawn Capability = "subprocess.spawn"
 	CapDBMigrate       Capability = "db.migrate"
+)
+
+// Resource names a logical table an operation reads or writes, for the
+// dispatcher's write-set conflict gate. Table-level granularity is deliberate:
+// prod writes are whole-row (UpdateBook/UpdateBookFile carry every field), so
+// field-level tracking would still miss the lost-update collisions this gate
+// exists to prevent. The list mirrors the store interfaces in
+// internal/database (BookStore, AuthorStore, ...).
+type Resource string
+
+const (
+	ResBooks       Resource = "books"
+	ResBookFiles   Resource = "book_files"
+	ResAuthors     Resource = "authors"
+	ResSeries      Resource = "series"
+	ResReviewItems Resource = "review_items"
+	ResEmbeddings  Resource = "embeddings"
+	ResOperations  Resource = "operations"
 )
 
 // EventSubscription wires an event name to a handler on the OperationDef.

--- a/internal/operations/registry/worker.go
+++ b/internal/operations/registry/worker.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/worker.go
-// version: 2.12.0
+// version: 2.13.0
 // guid: b8c9d0e1-f2a3-4b5c-6d7e-8f9a0b1c2d3e
-// last-edited: 2026-07-18
+// last-edited: 2026-08-07
 
 package registry
 
@@ -46,10 +46,18 @@ type runHandle struct {
 	plugin         string
 	concurrencyKey string
 	resumePolicy   ResumePolicy
-	cancel         context.CancelFunc
-	abandoned      bool
-	currentItem    string
-	currentItemMu  sync.Mutex
+	// writes is the def's declared write-set, copied onto the handle so the
+	// dispatcher's Gate 3b can check running ops without a def lookup. Because
+	// it lives ON the handle, the slot is released wherever the handle is
+	// released — releaseRunHandle covers completion, failure, cancel, and the
+	// channel-full undo path all at once (same hygiene as concurrencyKey; the
+	// C-2 leak class cannot recur here because there is no separate map to
+	// forget to clear).
+	writes        []Resource
+	cancel        context.CancelFunc
+	abandoned     bool
+	currentItem   string
+	currentItemMu sync.Mutex
 	// lastProgressAt is stamped by the reporter on every UpdateProgress call.
 	// Stored as Unix nanoseconds; zero means progress has never been reported.
 	// The watchdog reads this first (lock-free) before falling back to the DB row.
@@ -186,6 +194,7 @@ func (r *Registry) executeRun(parentCtx context.Context, qr *queuedRun) (wasAban
 		plugin:         qr.plugin,
 		concurrencyKey: qr.concurrKey,
 		resumePolicy:   qr.resumePolicy,
+		writes:         def.Writes,
 		cancel:         cancel,
 	}
 	r.mu.Lock()

--- a/internal/operations/registry/writeset_gate_test.go
+++ b/internal/operations/registry/writeset_gate_test.go
@@ -1,0 +1,236 @@
+// file: internal/operations/registry/writeset_gate_test.go
+// version: 1.0.0
+// guid: 3f8a2b1c-9d4e-4f6a-8b2c-5e7d9a1f3c60
+// last-edited: 2026-08-07
+
+package registry_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/falkcorp/audiobook-organizer/internal/operations/registry"
+)
+
+// assertStaysQueued polls for `hold` and fails if the op leaves "queued".
+func assertStaysQueued(t *testing.T, store *fakeStore, opID string, hold time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(hold)
+	for time.Now().Before(deadline) {
+		if s := store.statusOf(opID); s != "queued" {
+			t.Fatalf("op %s left queued too early: status=%s", opID, s)
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+}
+
+// TestDispatcher_WriteSetOverlapDefers verifies the Gate-3b core contract:
+// an op whose declared Writes overlap a RUNNING op's Writes stays QUEUED
+// (not rejected, not failed) and dispatches after the running op completes.
+func TestDispatcher_WriteSetOverlapDefers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.New(store, slog.Default(), 4, nil)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	blocker := makeValidDef("test.ws-blocker")
+	blocker.Writes = []registry.Resource{registry.ResBooks, registry.ResBookFiles}
+	blocker.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(started)
+		select {
+		case <-release:
+		case <-runCtx.Done():
+		}
+		return nil
+	}
+
+	var overlapRan atomic.Bool
+	contender := makeValidDef("test.ws-contender")
+	contender.Writes = []registry.Resource{registry.ResBooks} // overlaps on books
+	contender.Run = func(_ context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		overlapRan.Store(true)
+		return nil
+	}
+
+	_ = r.RegisterOp(blocker)
+	_ = r.RegisterOp(contender)
+	r.Start(ctx)
+
+	op1, err := r.EnqueueOp(ctx, "test.ws-blocker", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp blocker: %v", err)
+	}
+	<-started
+
+	op2, err := r.EnqueueOp(ctx, "test.ws-contender", nil)
+	if err != nil {
+		t.Fatalf("EnqueueOp contender: %v", err)
+	}
+
+	// While the blocker holds books+book_files, the contender must sit queued.
+	assertStaysQueued(t, store, op2, 500*time.Millisecond)
+	if overlapRan.Load() {
+		t.Fatal("contender ran while blocker held an overlapping write-set")
+	}
+
+	// Release the blocker: the contender must now dispatch and complete.
+	close(release)
+	awaitStatus(t, store, op1, "completed", 5*time.Second)
+	awaitStatus(t, store, op2, "completed", 5*time.Second)
+	if !overlapRan.Load() {
+		t.Fatal("contender never ran after blocker completed")
+	}
+}
+
+// TestDispatcher_WriteSetDisjointRunsConcurrently verifies that ops writing
+// DIFFERENT tables are not serialized by the gate.
+func TestDispatcher_WriteSetDisjointRunsConcurrently(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.New(store, slog.Default(), 4, nil)
+
+	var running, maxOverlap int64
+	gate := make(chan struct{})
+	var gateClosed atomic.Bool
+
+	makeDef := func(id string, writes []registry.Resource) registry.OperationDef {
+		d := makeValidDef(id)
+		d.Writes = writes
+		d.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+			cur := atomic.AddInt64(&running, 1)
+			for {
+				old := atomic.LoadInt64(&maxOverlap)
+				if cur <= old || atomic.CompareAndSwapInt64(&maxOverlap, old, cur) {
+					break
+				}
+			}
+			if gateClosed.CompareAndSwap(false, true) {
+				close(gate)
+			}
+			select {
+			case <-gate:
+			case <-runCtx.Done():
+			}
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt64(&running, -1)
+			return nil
+		}
+		return d
+	}
+
+	_ = r.RegisterOp(makeDef("test.ws-books", []registry.Resource{registry.ResBooks}))
+	_ = r.RegisterOp(makeDef("test.ws-files", []registry.Resource{registry.ResBookFiles}))
+	r.Start(ctx)
+
+	op1, _ := r.EnqueueOp(ctx, "test.ws-books", nil)
+	op2, _ := r.EnqueueOp(ctx, "test.ws-files", nil)
+
+	awaitStatus(t, store, op1, "completed", 5*time.Second)
+	awaitStatus(t, store, op2, "completed", 5*time.Second)
+
+	if atomic.LoadInt64(&maxOverlap) < 2 {
+		// Timing-sensitive: serial execution is legal scheduling, so warn only —
+		// same convention as TestDispatcher_DifferentConcurrencyKeysRunConcurrently.
+		t.Logf("warning: disjoint write-set ops did not overlap (maxOverlap=%d) — may be test timing", atomic.LoadInt64(&maxOverlap))
+	}
+}
+
+// TestDispatcher_WriteSetUndeclaredUnaffected verifies incremental rollout:
+// an op with EMPTY Writes runs to completion while a declared writer is
+// still running — the gate ignores undeclared ops in both directions.
+func TestDispatcher_WriteSetUndeclaredUnaffected(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.New(store, slog.Default(), 4, nil)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	writer := makeValidDef("test.ws-declared-writer")
+	writer.Writes = []registry.Resource{registry.ResBooks}
+	writer.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(started)
+		select {
+		case <-release:
+		case <-runCtx.Done():
+		}
+		return nil
+	}
+
+	undeclared := makeValidDef("test.ws-undeclared")
+	// Writes deliberately empty.
+	_ = r.RegisterOp(writer)
+	_ = r.RegisterOp(undeclared)
+	r.Start(ctx)
+
+	op1, _ := r.EnqueueOp(ctx, "test.ws-declared-writer", nil)
+	<-started
+
+	// The undeclared op must complete WHILE the declared writer is running.
+	op2, _ := r.EnqueueOp(ctx, "test.ws-undeclared", nil)
+	awaitStatus(t, store, op2, "completed", 5*time.Second)
+	if s := store.statusOf(op1); s != "running" {
+		t.Errorf("declared writer should still be running while undeclared op completed, got %s", s)
+	}
+
+	close(release)
+	awaitStatus(t, store, op1, "completed", 5*time.Second)
+}
+
+// TestDispatcher_WriteSetReleasedOnFailure verifies the release path: a
+// FAILED op frees its write-set slot (releaseRunHandle drops the handle, and
+// the write-set lives on the handle), so a deferred contender dispatches
+// afterward. Release-on-completion is covered by
+// TestDispatcher_WriteSetOverlapDefers.
+func TestDispatcher_WriteSetReleasedOnFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := newFakeStore()
+	r := registry.New(store, slog.Default(), 4, nil)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	failing := makeValidDef("test.ws-failing")
+	failing.Writes = []registry.Resource{registry.ResBooks}
+	failing.Run = func(runCtx context.Context, _ json.RawMessage, _ registry.Reporter) error {
+		close(started)
+		select {
+		case <-release:
+		case <-runCtx.Done():
+		}
+		return errors.New("synthetic failure for write-set release test")
+	}
+
+	contender := makeValidDef("test.ws-after-failure")
+	contender.Writes = []registry.Resource{registry.ResBooks}
+
+	_ = r.RegisterOp(failing)
+	_ = r.RegisterOp(contender)
+	r.Start(ctx)
+
+	op1, _ := r.EnqueueOp(ctx, "test.ws-failing", nil)
+	<-started
+
+	op2, _ := r.EnqueueOp(ctx, "test.ws-after-failure", nil)
+	assertStaysQueued(t, store, op2, 300*time.Millisecond)
+
+	close(release)
+	awaitStatus(t, store, op1, "failed", 5*time.Second)
+	// The failed op's handle release must free the write-set slot.
+	awaitStatus(t, store, op2, "completed", 5*time.Second)
+}

--- a/internal/plugins/acoustid/backfill.go
+++ b/internal/plugins/acoustid/backfill.go
@@ -1,7 +1,7 @@
 // file: internal/plugins/acoustid/backfill.go
-// version: 1.7.0
+// version: 1.8.0
 // guid: f6a7b8c9-d0e1-2345-def0-123456789abc
-// last-edited: 2026-07-07
+// last-edited: 2026-08-07
 
 package acoustid
 
@@ -39,9 +39,15 @@ func (p *Plugin) backfillDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "acoustid.fingerprint",
-		Schedule:        &sched,
-		Isolate:         false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
-		Timeout:         24 * time.Hour,
+		// Writes verified 2026-08-07: UpdateBookFile (fingerprint columns,
+		// whole-row) and GetBookByID→mutate→UpdateBook (whole-row write-back).
+		// Declared so the dispatcher's write-set gate serializes this against
+		// other Book/BookFile writers (e.g. maintenance.repair-transcribe-status)
+		// instead of silently losing fields via concurrent read-modify-write.
+		Writes:   []sdk.Resource{sdk.ResBooks, sdk.ResBookFiles},
+		Schedule: &sched,
+		Isolate:  false, // DISABLED 2026-05-29: PR #1172 child-mode wire-up cannot work because Pebble is single-writer; child re-open fails. See MAYDEPLOY-A revisit.
+		Timeout:  24 * time.Hour,
 		Capabilities: []sdk.Capability{
 			sdk.CapLibraryRead,
 			sdk.CapLibraryWrite,

--- a/internal/plugins/maintenance/intro_migrate_single_file.go
+++ b/internal/plugins/maintenance/intro_migrate_single_file.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_migrate_single_file.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 6b0d94e7-1c58-4a32-bf07-9e5d2a17c630
 // last-edited: 2026-08-07
 
@@ -90,9 +90,12 @@ func (p *Plugin) introMigrateSingleFileDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.intro-migrate-single-file",
-		Cancellable:     true,
-		Isolate:         false,
-		Timeout:         2 * time.Hour,
+		// UpdateBookFile whole-row write-back on BookFile rows (reads Books).
+		Writes:      []sdk.Resource{sdk.ResBookFiles},
+		Reads:       []sdk.Resource{sdk.ResBooks},
+		Cancellable: true,
+		Isolate:     false,
+		Timeout:     2 * time.Hour,
 		// Pure DB work, no Whisper: pages complete in seconds, so the default
 		// 5-minute no-progress watchdog is generous already. Left explicit so a
 		// future change that adds I/O here has to think about it.

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.15.0
+// version: 3.16.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-08-07
 
@@ -89,9 +89,11 @@ func (p *Plugin) introTranscribeDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.transcribe-book-intros",
-		Cancellable:     true,
-		Isolate:         false,
-		Timeout:         10 * time.Hour,
+		// GetBookByID→mutate→UpdateBook whole-row write-back on Book rows.
+		Writes:      []sdk.Resource{sdk.ResBooks},
+		Cancellable: true,
+		Isolate:     false,
+		Timeout:     10 * time.Hour,
 		// A page of 200 books sent to the (remote GPU or local) Whisper backend
 		// can take several minutes to return. The default 5-minute no-progress
 		// watchdog would cancel the op mid-batch — which it did, repeatedly,

--- a/internal/plugins/maintenance/repair_transcribe_status.go
+++ b/internal/plugins/maintenance/repair_transcribe_status.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/repair_transcribe_status.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a5e3c81f-7204-4b96-9d3a-1f68b05e2c47
 // last-edited: 2026-08-07
 
@@ -194,6 +194,8 @@ func (p *Plugin) repairTranscribeStatusDef() sdk.OperationDef {
 		ResumePolicy:    sdk.ResumeRestart,
 		DefaultPriority: sdk.PriorityLow,
 		ConcurrencyKey:  "maintenance.repair-transcribe-status",
+		// GetBookByID→mutate→UpdateBook whole-row write-back on Book rows.
+		Writes:          []sdk.Resource{sdk.ResBooks},
 		Cancellable:     true,
 		Isolate:         false,
 		Timeout:         2 * time.Hour,

--- a/pkg/plugin/sdk/operation.go
+++ b/pkg/plugin/sdk/operation.go
@@ -1,7 +1,7 @@
 // file: pkg/plugin/sdk/operation.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f12345678901
-// last-edited: 2026-05-06
+// last-edited: 2026-08-07
 
 package sdk
 
@@ -13,6 +13,7 @@ type ResumePolicy = registry.ResumePolicy
 type Priority = registry.Priority
 type ActorMode = registry.ActorMode
 type Phase = registry.Phase
+type Resource = registry.Resource
 
 // Resume policy constants.
 const (
@@ -34,4 +35,19 @@ const (
 const (
 	ActorContext = registry.ActorContext
 	ActorSystem  = registry.ActorSystem
+)
+
+// Write-set resource constants for OperationDef.Writes / Reads.
+// Declaring Writes lets the dispatcher's conflict gate keep two ops that
+// mutate the same table from running concurrently (whole-row write-backs
+// silently lose fields when interleaved). Empty Writes = undeclared = the
+// gate ignores the op.
+const (
+	ResBooks       = registry.ResBooks
+	ResBookFiles   = registry.ResBookFiles
+	ResAuthors     = registry.ResAuthors
+	ResSeries      = registry.ResSeries
+	ResReviewItems = registry.ResReviewItems
+	ResEmbeddings  = registry.ResEmbeddings
+	ResOperations  = registry.ResOperations
 )


### PR DESCRIPTION
## Summary

Owner's 2026-08-07 design request: "we declare what it does and then the system automatically won't schedule two things" that mutate the same data. Motivating incident today: `acoustid.backfill` (auto-starts on restart, GetBookByID→mutate→UpdateBook whole-row write-back) running while `maintenance.repair-transcribe-status` applied the same-shape write to the same Book rows — lock-free read-modify-write on both sides silently loses fields; it was hand-serialized by watching journalctl.

## What changed

- **`OperationDef.Writes []Resource` / `Reads []Resource`** (registry + sdk alias). `Resource` is table-level (`books`, `book_files`, `authors`, `series`, `review_items`, `embeddings`, `operations`) — deliberately NOT field-level, because whole-row write-backs collide even on disjoint fields.
- **Gate 3b** in `dispatcher.go`: an op with non-empty `Writes` is not dispatched while any RUNNING op's declared `Writes` overlap (v1 = Writes∩Writes only; `Reads` declared for forward-compat, not yet enforced). On conflict the op **stays QUEUED** — same defer semantics as the ConcurrencyKey gate — and dispatches when the blocker finishes. TOCTOU re-check under the write lock before claiming.
- **Release hygiene**: the write-set lives ON the `runHandle`, so `releaseRunHandle` frees it on completion, failure, cancel, and the channel-full undo path — no separate map to leak (C-2 class structurally impossible).
- **Deferral log** deduped per (op, blocker) pair against the 100ms ticker; dedupe map is dispatcher-goroutine-private and pruned each cycle.
- **Empty `Writes` = undeclared = gate skipped** in both directions → incremental rollout, zero behavior change for every other op.
- **First adopters** (verified against their UpdateBook/UpdateBookFile call sites): `acoustid.backfill` (books, book_files), `maintenance.repair-transcribe-status` (books), `maintenance.intro-migrate-single-file` (book_files), `maintenance.transcribe-book-intros` (books).

## Tests

`writeset_gate_test.go`, modeled on the ConcurrencyKey dispatcher tests: overlap defers-then-dispatches; disjoint runs concurrently; undeclared unaffected; slot freed on failure. Full `go test ./internal/operations/... -race` green (registry 47.9s); `./internal/plugins/acoustid ./internal/plugins/maintenance -short` green; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp