### PR TITLE
feat(maintenance): dry_run for reparse_only intro runs, defaulting ON

### DIFF
--- a/changelog.d/20260807_224500_feat_reparse_dry_run.md
+++ b/changelog.d/20260807_224500_feat_reparse_dry_run.md
@@ -1,0 +1,16 @@
+<!-- file: changelog.d/20260807_224500_feat_reparse_dry_run.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4e7a9c12-5b3d-4f68-9a21-8c6d0e4f7b35 -->
+<!-- last-edited: 2026-08-07 -->
+
+### Changed
+
+- **`maintenance.transcribe-book-intros` with `reparse_only=true` now DEFAULTS
+  to `dry_run=true`.** This is a behaviour change: a reparse-only dispatch with
+  no explicit `dry_run` no longer writes anything — it runs the identical
+  classification+comparison logic, reports "Dry run — would update N of M
+  transcribed", and skips every `UpdateBook` call. Pass `dry_run=false` to
+  apply. Motivated by the 2026-08-07 reparse of 12,990 books being dispatched
+  with no preview (acceptable only because reparse is upgrade-only). The new
+  `dry_run` param is currently honoured by `reparse_only` runs only; the
+  full-transcribe path ignores it.

--- a/internal/plugins/maintenance/intro_reparse_guard_test.go
+++ b/internal/plugins/maintenance/intro_reparse_guard_test.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_reparse_guard_test.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: 8f2b6d41-7e05-4c39-b8a7-1d94e30c5f26
 // last-edited: 2026-08-07
 
@@ -7,6 +7,7 @@ package maintenance
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/falkcorp/audiobook-organizer/internal/database"
@@ -83,7 +84,7 @@ func TestReparseNeverClearsAnUnreproducibleParse(t *testing.T) {
 
 	store := newReparseStore(degraded, prose)
 	p := &Plugin{}
-	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order); err != nil {
+	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order, false); err != nil {
 		t.Fatalf("reparseStoredIntros: %v", err)
 	}
 
@@ -115,7 +116,7 @@ func TestReparseStillUpgradesACorrectableParse(t *testing.T) {
 	}
 	store := newReparseStore(stale)
 	p := &Plugin{}
-	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order); err != nil {
+	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order, false); err != nil {
 		t.Fatalf("reparseStoredIntros: %v", err)
 	}
 
@@ -143,7 +144,7 @@ func TestReparseKeepsExistingNarratorWhenNewParseHasNone(t *testing.T) {
 	}
 	store := newReparseStore(b)
 	p := &Plugin{}
-	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order); err != nil {
+	if err := p.reparseStoredIntros(context.Background(), store, &fakeReporter{}, store.order, false); err != nil {
 		t.Fatalf("reparseStoredIntros: %v", err)
 	}
 	if got := deref(store.books["book-no-narrator"].TranscribedNarrator); got != "Christopher Hurt" {
@@ -160,6 +161,69 @@ func TestSilenceSentinelIsSharedWithClassifier(t *testing.T) {
 	}
 	if c := transcribe.ClassifyIntro(silenceSentinel, transcribe.UnknownPosition); c.Kind != transcribe.IntroKindUnknown {
 		t.Errorf("sentinel classified %q, want unknown", c.Kind)
+	}
+}
+
+// progressReporter captures the last progress message so dry-run reporting can
+// be asserted on.
+type progressReporter struct {
+	fakeReporter
+	lastMsg string
+}
+
+func (r *progressReporter) UpdateProgress(_, _ int, msg string) error {
+	r.lastMsg = msg
+	return nil
+}
+
+// TestReparseDryRunWritesNothingButReportsWouldUpdate pins the dry_run
+// contract: identical classification+comparison logic runs, the would-update
+// count is reported, and ZERO UpdateBook calls are made. A second pass with
+// dryRun=false over the same fixture confirms the write path still writes.
+func TestReparseDryRunWritesNothingButReportsWouldUpdate(t *testing.T) {
+	// A correctable stored parse (the leaked-verb defect): a fresh parse of the
+	// stored transcript differs from the stored fields, so a real run would
+	// rewrite them.
+	fixture := func() *database.Book {
+		return &database.Book{
+			ID:                 "book-dry-run",
+			IntroTranscription: sp("Awakened Essence 1 Written by Jacob Poole Performed by Alex Perrone"),
+			TranscribedTitle:   sp("Awakened Essence 1 Written"),
+			TranscribedAuthor:  sp("Jacob Poole"),
+		}
+	}
+
+	// Dry run: nonzero would-update reported, nothing written.
+	store := newReparseStore(fixture())
+	rep := &progressReporter{}
+	p := &Plugin{}
+	if err := p.reparseStoredIntros(context.Background(), store, rep, store.order, true); err != nil {
+		t.Fatalf("reparseStoredIntros(dryRun=true): %v", err)
+	}
+	if n := len(store.updates); n != 0 {
+		t.Fatalf("dry run made %d UpdateBook calls, want 0", n)
+	}
+	if got := deref(store.books["book-dry-run"].TranscribedTitle); got != "Awakened Essence 1 Written" {
+		t.Errorf("dry run mutated stored title: %q", got)
+	}
+	if !strings.Contains(rep.lastMsg, "would update 1 of 1") {
+		t.Errorf("final progress = %q, want it to contain %q", rep.lastMsg, "would update 1 of 1")
+	}
+
+	// Same fixture, dryRun=false: the write happens and is reported as applied.
+	store2 := newReparseStore(fixture())
+	rep2 := &progressReporter{}
+	if err := p.reparseStoredIntros(context.Background(), store2, rep2, store2.order, false); err != nil {
+		t.Fatalf("reparseStoredIntros(dryRun=false): %v", err)
+	}
+	if n := len(store2.updates); n != 1 {
+		t.Fatalf("real run made %d UpdateBook calls, want 1", n)
+	}
+	if got := deref(store2.books["book-dry-run"].TranscribedTitle); got != "Awakened Essence 1" {
+		t.Errorf("real run title = %q, want %q", got, "Awakened Essence 1")
+	}
+	if !strings.Contains(rep2.lastMsg, "updated 1 of 1") {
+		t.Errorf("final progress = %q, want it to contain %q", rep2.lastMsg, "updated 1 of 1")
 	}
 }
 

--- a/internal/plugins/maintenance/intro_transcribe.go
+++ b/internal/plugins/maintenance/intro_transcribe.go
@@ -1,5 +1,5 @@
 // file: internal/plugins/maintenance/intro_transcribe.go
-// version: 3.16.0
+// version: 3.17.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
 // last-edited: 2026-08-07
 
@@ -78,6 +78,15 @@ type introTranscribeParams struct {
 	// cache: extract-only first (fast, CPU-bound), then a normal run transcribes
 	// off the warm cache (cache hits → no ffmpeg, only the GPU step remains).
 	ExtractOnly *bool `json:"extract_only,omitempty"`
+	// DryRun previews what a run WOULD change without writing anything.
+	// Currently honoured by reparse_only runs only; the full-transcribe path
+	// ignores it (registry-wide dry-run enforcement is tracked separately).
+	//
+	// ⚠️ Behaviour change (2026-08-07): for reparse_only runs, dry_run DEFAULTS
+	// TO TRUE. The 2026-08-07 reparse of 12,990 books was dispatched with no
+	// preview at all; that was acceptable only because reparse is upgrade-only.
+	// Pass dry_run=false explicitly to apply changes.
+	DryRun *bool `json:"dry_run,omitempty"`
 }
 
 func (p *Plugin) introTranscribeDef() sdk.OperationDef {
@@ -128,11 +137,15 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 	// parser over stored transcripts and rewrites the parsed fields. Used to apply
 	// a parser fix to existing books cheaply.
 	if reparseOnly {
+		// ⚠️ dry_run defaults to TRUE on the reparse path (behaviour change
+		// 2026-08-07): previews are free, and the alternative is dispatching a
+		// library-wide write blind. Pass dry_run=false to apply.
+		dryRun := params.DryRun == nil || *params.DryRun
 		ids, err := store.ListBookIDs()
 		if err != nil {
 			return fmt.Errorf("list book ids: %w", err)
 		}
-		return p.reparseStoredIntros(ctx, store, reporter, ids)
+		return p.reparseStoredIntros(ctx, store, reporter, ids, dryRun)
 	}
 
 	// Load the FULL, ordered list of book IDs up front. This is the proven
@@ -293,13 +306,21 @@ func (p *Plugin) runIntroTranscribe(ctx context.Context, rawParams json.RawMessa
 // UpdateBook does full-column replacement, and GetBookByID returns the full
 // row, so only the three parsed fields change. IntroTranscribedAt is left
 // untouched (reparse is not a new transcription).
+//
+// With dryRun=true (the default for reparse_only runs) the identical
+// classification+comparison logic runs and every bucket is counted, but the
+// UpdateBook call is skipped — nothing is written.
 func (p *Plugin) reparseStoredIntros(ctx context.Context, store interface {
 	ListBookIDs() ([]string, error)
 	GetBookByID(string) (*database.Book, error)
 	UpdateBook(string, *database.Book) (*database.Book, error)
-}, reporter sdk.Reporter, ids []string) error {
+}, reporter sdk.Reporter, ids []string, dryRun bool) error {
 	log := reporter.Logger()
 	total := len(ids)
+	verb := "updated"
+	if dryRun {
+		verb = "would update"
+	}
 	var scanned, changed int
 	for i, id := range ids {
 		if i%500 == 0 {
@@ -309,7 +330,7 @@ func (p *Plugin) reparseStoredIntros(ctx context.Context, store interface {
 			default:
 			}
 			_ = reporter.UpdateProgress(i, total,
-				fmt.Sprintf("Reparsing intros — %d/%d (%d updated)", i, total, changed))
+				fmt.Sprintf("Reparsing intros — %d/%d (%d %s)", i, total, changed, verb))
 		}
 		b, err := store.GetBookByID(id)
 		if err != nil || b == nil || b.IntroTranscription == nil || *b.IntroTranscription == "" {
@@ -347,15 +368,23 @@ func (p *Plugin) reparseStoredIntros(ctx context.Context, store interface {
 			continue // unchanged — skip the write
 		}
 		b.TranscribedTitle, b.TranscribedAuthor, b.TranscribedNarrator = nt, na, nn
-		if _, err := store.UpdateBook(b.ID, b); err != nil {
-			log.Warn("reparse-intros: update failed", "book_id", b.ID, "err", err)
-			continue
+		if !dryRun {
+			if _, err := store.UpdateBook(b.ID, b); err != nil {
+				log.Warn("reparse-intros: update failed", "book_id", b.ID, "err", err)
+				continue
+			}
 		}
 		changed++
 	}
-	log.Info("reparse-intros: complete", "scanned", scanned, "changed", changed, "total_books", total)
-	_ = reporter.UpdateProgress(total, total,
-		fmt.Sprintf("Reparse complete — %d updated of %d transcribed (%d books)", changed, scanned, total))
+	log.Info("reparse-intros: complete", "dry_run", dryRun,
+		"scanned", scanned, "changed", changed, "total_books", total)
+	if dryRun {
+		_ = reporter.UpdateProgress(total, total,
+			fmt.Sprintf("Dry run — would update %d of %d transcribed (%d books, nothing written; pass dry_run=false to apply)", changed, scanned, total))
+	} else {
+		_ = reporter.UpdateProgress(total, total,
+			fmt.Sprintf("Reparse complete — updated %d of %d transcribed (%d books)", changed, scanned, total))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes tonight's concrete dry-run gap: `maintenance.transcribe-book-intros` with `reparse_only=true` wrote immediately with no preview — the 2026-08-07 reparse of 12,990 books was dispatched blind (acceptable only because reparse is upgrade-only).

## Changes
- New `dry_run` param on `introTranscribeParams` — currently honoured by `reparse_only` runs only; the full-transcribe path ignores it (documented on the param).
- **BEHAVIOUR CHANGE:** `reparse_only` runs now default `dry_run` to **true**. Pass `dry_run=false` explicitly to apply. Changelog fragment under `### Changed` calls this out.
- Dry run executes the identical classification+comparison logic and counts would-update rows, skipping only `UpdateBook`. Final progress: `Dry run — would update N of M transcribed (…, nothing written; pass dry_run=false to apply)` vs `Reparse complete — updated N of M transcribed`.

## Tests
- `TestReparseDryRunWritesNothingButReportsWouldUpdate`: dry run makes 0 UpdateBook calls while reporting "would update 1 of 1" on a fixture whose stored fields differ from a fresh parse; the same fixture with `dry_run=false` still writes and upgrades.
- Existing guard tests updated to pass `dryRun=false` (they test the write path).
- `go test ./internal/plugins/maintenance/ -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp