### PR TITLE
test(e2e): refresh Dashboard + Book Detail specs for content drift (wave 1 of 43-failure backlog)

### DIFF
--- a/changelog.d/20260807_223000_e2e_dashboard_bookdetail_refresh.md
+++ b/changelog.d/20260807_223000_e2e_dashboard_bookdetail_refresh.md
@@ -1,0 +1,16 @@
+<!-- file: changelog.d/20260807_223000_e2e_dashboard_bookdetail_refresh.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f9c1a72-5d4e-4b8a-9c6f-2e7d8a1b4c5d -->
+<!-- last-edited: 2026-08-07 -->
+
+### Fixed
+
+- **E2E content-drift refresh, wave 1: Dashboard (6) + Book Detail (3) specs.** All nine
+  failures were stale mocks, not product bugs: the frontend api layer now unwraps a
+  `{ data: ... }` response envelope, but the e2e mock helper (`web/tests/e2e/utils/test-helpers.ts`)
+  still returned raw bodies, so `getSystemStatus`/`startScan`/`startOrganize` resolved to
+  `undefined` (zeroed stat cards, no `/operations` navigation). The Dashboard also now prefers
+  the previously unmocked `/api/v1/system/storage` endpoint, so the real machine's statfs
+  leaked into the storage card. Book Detail's in-page fetch mock didn't cover
+  `/api/v1/auth/status` + `/api/v1/auth/me`, so the app bounced to the Login screen. Mocks now
+  serve both the envelope and top-level fields; no product code changed.

--- a/todo.d/20260807_210800_e2e_content_drift_refresh.md
+++ b/todo.d/20260807_210800_e2e_content_drift_refresh.md
@@ -1,14 +1,16 @@
-- [ ] **Refresh the 43 content-drift e2e failures unmasked by the `_page` fix.**
+- [ ] **Refresh the remaining content-drift e2e failures unmasked by the `_page` fix.**
       PR #2178 (2026-08-07) fixed the fixture error that had silently killed six
       e2e spec files since April 2026. With the mask gone the suite fails
-      honestly: **43 failures, all pre-existing assertion drift** — tests assert
-      hardcoded UI text the app no longer renders (Dashboard expects
-      `45.0 GB / 500.0 GB`, `9% of disk used`, fixed stat-card counts; the
-      `organize all` quick action expects navigation to `/operations` but the
-      dialog now stays on `/dashboard`). Per-file counts: Dashboard 6,
-      Book Detail 3, Error Handling 3, File Browser 9, Import Audiobook File 14,
-      Operation Monitoring 10. This is a mock-fixture/assertion refresh pass —
-      bring the mocks and expected copy up to what the app actually renders,
-      file-by-file; no product code should need to change. Budget ~1 session;
-      each e2e run rebuilds frontend+backend, so batch fixes per file rather
-      than per test.
+      honestly: all failures are pre-existing assertion drift — tests assert
+      hardcoded UI text the app no longer renders. Wave 1 (2026-08-07) fixed
+      Dashboard (6) and Book Detail (3): the api layer's `{ data: ... }`
+      response envelope, the unmocked `/api/v1/system/storage` endpoint, the
+      `/operations` → `/activity` route rename, and unmocked auth endpoints.
+      **Remaining: 34 failures in 4 files** — Error Handling 3, File Browser 9,
+      Import Audiobook File 14, Operation Monitoring 10. This is a
+      mock-fixture/assertion refresh pass — bring the mocks and expected copy up
+      to what the app actually renders, file-by-file; no product code should
+      need to change. Most fixes are the same envelope pattern already applied
+      to `web/tests/e2e/utils/test-helpers.ts` (wrap responses as
+      `{ ...body, data: body }`). Budget ~1 session; each e2e run rebuilds
+      frontend+backend, so batch fixes per file rather than per test.

--- a/web/tests/e2e/book-detail.spec.ts
+++ b/web/tests/e2e/book-detail.spec.ts
@@ -410,14 +410,14 @@ test.describe('Book Detail page', () => {
     await expect(
       page.getByRole('heading', { name: 'The Test Book' })
     ).toBeVisible();
+    // The Files and Versions tabs merged into a single "Files & History" tab;
+    // it shows a "Files (N)" table plus a "Versions" section.
     await page.getByRole('tab', { name: 'Files' }).click();
-    await expect(page.getByText('File Path')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^Files \(/ })).toBeVisible();
+    await expect(page.getByText('/library/test-book.m4b').first()).toBeVisible();
 
-    await page.getByRole('tab', { name: /Versions/ }).click();
-    await expect(page.getByText(/Versions/).first()).toBeVisible();
-    await expect(
-      page.getByText(/Second Version|No additional versions linked yet/i)
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Versions' })).toBeVisible();
+    await expect(page.getByText(/Ingested/).first()).toBeVisible();
   });
 
   test('soft delete, restore, and purge flow', async ({ page }) => {

--- a/web/tests/e2e/book-detail.spec.ts
+++ b/web/tests/e2e/book-detail.spec.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/book-detail.spec.ts
-// version: 1.12.1
+// version: 1.13.0
 // guid: 2a3b4c5d-6e7f-8a9b-0c1d-2e3f4a5b6c7d
 // last-edited: 2026-08-07
 
@@ -168,16 +168,40 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
 
       Object.keys(tagState.tags).forEach((field) => recomputeEffective(field));
 
-      const jsonResponse = (body: unknown, status = 200) =>
-        new Response(JSON.stringify(body), {
+      // The frontend api layer unwraps a { data: ... } envelope on most
+      // endpoints; serve both the top-level fields and the envelope so raw
+      // readers and `.data` readers both work.
+      const jsonResponse = (body: unknown, status = 200) => {
+        const payload =
+          body && typeof body === 'object' && !Array.isArray(body) && !('data' in body)
+            ? { ...(body as Record<string, unknown>), data: body }
+            : body;
+        return new Response(JSON.stringify(payload), {
           status,
           headers: { 'Content-Type': 'application/json' },
         });
+      };
 
       const originalFetch = window.fetch.bind(window);
       window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.url;
         const method = (init?.method || 'GET').toUpperCase();
+
+        // Auth — the app checks these on boot; without a mock they hit the
+        // real backend, which 401s and bounces the page to the Login screen.
+        if (url.includes('/api/v1/auth/status')) {
+          return Promise.resolve(
+            jsonResponse({
+              auth_enabled: true,
+              has_users: false,
+              requires_auth: false,
+              bootstrap_ready: true,
+            })
+          );
+        }
+        if (url.includes('/api/v1/auth/me')) {
+          return Promise.resolve(jsonResponse({ user: null }));
+        }
 
         // Health/system
         if (url.includes('/api/v1/health')) {
@@ -196,15 +220,38 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
           );
         }
 
-        // Book detail + list
-        if (
-          url.includes(`/api/v1/audiobooks/${injectedBookId}`) &&
-          !url.includes('/tags') &&
-          !url.includes('/versions') &&
-          !url.includes('/restore') &&
-          !url.includes('/fetch-metadata') &&
-          !url.includes('/parse-with-ai')
-        ) {
+        // Book files (Files & History tab) — must be handled before the
+        // generic book route; getBookFiles unwraps { data: { files, count } }.
+        if (url.includes(`/api/v1/audiobooks/${injectedBookId}/files`)) {
+          return Promise.resolve(
+            jsonResponse({
+              files: [
+                {
+                  id: 'file-1',
+                  book_id: injectedBookId,
+                  file_path: book.file_path,
+                  file_size: 1024 * 1024,
+                  format: 'm4b',
+                  file_hash: book.file_hash,
+                },
+              ],
+              count: 1,
+            })
+          );
+        }
+
+        // Legacy segments endpoint — expects { data: [] } (an array).
+        if (url.includes(`/api/v1/audiobooks/${injectedBookId}/segments`)) {
+          return Promise.resolve(jsonResponse({ data: [] }));
+        }
+
+        // Book detail + list — match only the bare book URL (optionally with a
+        // query string), so subresource routes (/files, /history, ...) never
+        // fall through to this handler and crash array consumers.
+        const bareBookUrl = new RegExp(
+          `/api/v1/audiobooks/${injectedBookId}(\\?|$)`
+        );
+        if (bareBookUrl.test(url)) {
           if (method === 'GET') {
             if (purged) {
               return Promise.resolve(jsonResponse({}, 404));

--- a/web/tests/e2e/dashboard.spec.ts
+++ b/web/tests/e2e/dashboard.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/dashboard.spec.ts
-// version: 1.3.1
+// version: 1.4.0
 // guid: f6e23777-438b-4931-88d9-d2c6d2225a00
 // last-edited: 2026-08-07
 
@@ -143,8 +143,8 @@ test.describe('Dashboard', () => {
     // Act
     await page.getByRole('button', { name: 'Scan All Import Paths' }).click();
 
-    // Assert
-    await expect(page).toHaveURL(/\/operations/);
+    // Assert — /operations now redirects to /activity (route rename)
+    await expect(page).toHaveURL(/\/(operations|activity)/);
   });
 
   test('quick action: organize all import books', async ({ page }) => {
@@ -158,7 +158,7 @@ test.describe('Dashboard', () => {
       .getByRole('button', { name: 'Organize' })
       .click();
 
-    // Assert
-    await expect(page).toHaveURL(/\/operations/);
+    // Assert — /operations now redirects to /activity (route rename)
+    await expect(page).toHaveURL(/\/(operations|activity)/);
   });
 });

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/utils/test-helpers.ts
-// version: 2.8.0
+// version: 2.9.0
 // guid: a1b2c3d4-e5f6-7890-abcd-e1f2a3b4c5d6
-// last-edited: 2026-07-03
+// last-edited: 2026-08-07
 
 import { Page } from '@playwright/test';
 
@@ -610,28 +610,53 @@ export async function setupMockApiRoutes(
         (mockState.systemStatus as { disk_total_bytes?: number })
           .disk_total_bytes || 500 * 1024 * 1024 * 1024;
 
+      // The frontend api layer (getSystemStatus) unwraps a { data: ... }
+      // envelope; keep top-level fields too for any legacy consumers.
+      const statusPayload = {
+        ...mockState.systemStatus,
+        status: 'ok',
+        library: {
+          book_count: totalBooks,
+          folder_count: 1,
+          total_size: librarySize,
+        },
+        import_paths: {
+          folder_count: mockState.importPaths.length,
+          book_count: mockState.books.filter((b: Record<string, unknown>) => b.library_state === 'import').length,
+        },
+        operations: { recent: (mockState.operations as { history?: unknown[] }).history || [] },
+        library_book_count: totalBooks,
+        import_book_count: mockState.books.filter((b: Record<string, unknown>) => b.library_state === 'import').length,
+        total_book_count: totalBooks,
+        library_size_bytes: librarySize,
+        total_size_bytes: librarySize,
+        disk_used_bytes: librarySize,
+        disk_free_bytes: Math.max(0, diskTotal - librarySize),
+      };
       return route.fulfill(
-        jsonResponse({
-          ...mockState.systemStatus,
-          status: 'ok',
-          library: {
-            book_count: totalBooks,
-            folder_count: 1,
-            total_size: librarySize,
-          },
-          import_paths: {
-            folder_count: mockState.importPaths.length,
-            book_count: mockState.books.filter((b: Record<string, unknown>) => b.library_state === 'import').length,
-          },
-          operations: { recent: (mockState.operations as { history?: unknown[] }).history || [] },
-          library_book_count: totalBooks,
-          import_book_count: mockState.books.filter((b: Record<string, unknown>) => b.library_state === 'import').length,
-          total_book_count: totalBooks,
-          library_size_bytes: librarySize,
-          total_size_bytes: librarySize,
-          disk_used_bytes: librarySize,
-          disk_free_bytes: Math.max(0, diskTotal - librarySize),
-        })
+        jsonResponse({ ...statusPayload, data: statusPayload })
+      );
+    }
+
+    // System storage (statfs of the data volume) — the Dashboard prefers this
+    // endpoint over system/status disk fields, so mock it from the same state.
+    if (pathname === '/api/v1/system/storage') {
+      const librarySize = mockState.books.reduce(
+        (sum, book) => sum + (book.file_size || 0),
+        0
+      );
+      const diskTotal =
+        (mockState.systemStatus as { disk_total_bytes?: number })
+          .disk_total_bytes || 500 * 1024 * 1024 * 1024;
+      const storagePayload = {
+        path: '/library',
+        total_bytes: diskTotal,
+        used_bytes: librarySize,
+        free_bytes: Math.max(0, diskTotal - librarySize),
+        percent_used: diskTotal > 0 ? (librarySize / diskTotal) * 100 : 0,
+      };
+      return route.fulfill(
+        jsonResponse({ ...storagePayload, data: storagePayload })
       );
     }
 
@@ -1037,7 +1062,8 @@ export async function setupMockApiRoutes(
     }
 
     if (pathname === '/api/v1/operations/scan' && method === 'POST') {
-      return route.fulfill(jsonResponse({ id: 'op-scan-1', status: 'running', type: 'scan', progress: 0 }, 201));
+      const scanOp = { id: 'op-scan-1', status: 'running', type: 'scan', progress: 0 };
+      return route.fulfill(jsonResponse({ ...scanOp, data: scanOp }, 201));
     }
 
     if (pathname === '/api/v1/operations/organize' && method === 'POST') {
@@ -1063,14 +1089,16 @@ export async function setupMockApiRoutes(
         return b;
       }) as typeof mockState.books;
       if (errorBook) {
-        return route.fulfill(jsonResponse({
+        const errorOp = {
           id: 'op-org-1', status: 'error', type: 'organize',
           error_message: (errorBook as Record<string, unknown>).organize_error,
           progress: bookIds.indexOf((errorBook as Record<string, unknown>).id as string),
           total: bookIds.length,
-        }, 200));
+        };
+        return route.fulfill(jsonResponse({ ...errorOp, data: errorOp }, 200));
       }
-      return route.fulfill(jsonResponse({ id: 'op-org-1', status: 'completed', type: 'organize', progress: bookIds.length || mockState.books.length, total: bookIds.length || mockState.books.length }, 201));
+      const organizeOp = { id: 'op-org-1', status: 'completed', type: 'organize', progress: bookIds.length || mockState.books.length, total: bookIds.length || mockState.books.length };
+      return route.fulfill(jsonResponse({ ...organizeOp, data: organizeOp }, 201));
     }
 
     if (pathname.match(/\/api\/v1\/operations\/[^/]+$/) && method === 'DELETE') {


### PR DESCRIPTION
## Summary

Wave 1 of the e2e content-drift refresh tracked in `todo.d/20260807_210800_e2e_content_drift_refresh.md`: fixes all 9 failures in the two smallest spec files, `web/tests/e2e/dashboard.spec.ts` (6) and `web/tests/e2e/book-detail.spec.ts` (3). **No product code changed** — every failure was a stale mock or drifted assertion:

- **`{ data: ... }` envelope**: the frontend api layer now unwraps a `data` envelope on `getSystemStatus`, `startScan`, and `startOrganize`, but the shared mock helper returned raw bodies, so the Dashboard rendered all-zero stat cards and quick actions never navigated. `test-helpers.ts` mock responses now serve `{ ...body, data: body }` (both shapes, so legacy readers keep working).
- **Unmocked `/api/v1/system/storage`**: the Dashboard now prefers this endpoint for the storage card; unmocked, the dev machine's real statfs leaked into the assertion. Now mocked from the same book-derived state (45 GB used / 500 GB total → the spec's original expected copy is correct again).
- **`/operations` → `/activity` route rename**: quick-action URL assertions accept the redirect target.
- **book-detail auth bounce**: the in-page fetch mock didn't cover `/auth/status` + `/auth/me`, so the app rendered the Login screen instead of the book. Also added `/files` + legacy `/segments` handlers and restricted the generic book route to the bare book URL (subresource routes were returning a book object to array consumers → `M.slice is not a function` crash).
- **Merged "Files & History" tab**: the separate Versions tab is gone; assertions updated to the Files (N) table + Versions section that actually render.

## Test results

`npx playwright test -c tests/e2e/playwright.config.ts --project=chromium dashboard.spec.ts book-detail.spec.ts`: **9/9 passing** (was 0/9). No `test.fixme()` needed — nothing looked genuinely broken, all drift.

## Remaining

34 failures in 4 files (Error Handling 3, File Browser 9, Import Audiobook File 14, Operation Monitoring 10) — todo fragment updated with counts and the envelope pattern to reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp