### PR TITLE
feat(transcribe): priority-based multi-endpoint Whisper dispatcher

### DIFF
--- a/changelog.d/20260807_223500_whisper_multi_endpoint_dispatcher.md
+++ b/changelog.d/20260807_223500_whisper_multi_endpoint_dispatcher.md
@@ -1,0 +1,18 @@
+<!-- file: changelog.d/20260807_223500_whisper_multi_endpoint_dispatcher.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: f569af86-775d-4540-acf8-d3809836ba9d -->
+<!-- last-edited: 2026-08-07 -->
+
+### Added
+
+- Multi-endpoint Whisper dispatch pool (`internal/transcribe/dispatcher.go`):
+  jobs are allocated across remote faster-whisper servers in priority order
+  (lower `priority` = preferred, e.g. GPU box 1, CPU box 100), each endpoint up
+  to its `concurrency` share, with spill to lower-priority endpoints. A failing
+  endpoint enters a time-based cooldown and its jobs are re-queued to surviving
+  endpoints; a `*TransportError` naming every endpoint is returned only when
+  the whole pool is exhausted, so an outage still writes no per-file verdicts.
+  Configured via env-authoritative `WHISPER_ENDPOINTS` (JSON array, e.g.
+  `[{"url":"http://whisper-1.local:8000","concurrency":2,"priority":1,"kind":"gpu"}]`);
+  empty falls back to `WHISPER_REMOTE_URL` as a one-element pool (unchanged
+  behaviour), else the local path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,12 @@
 // file: internal/config/config.go
-// version: 1.73.0
+// version: 1.74.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
-// last-edited: 2026-07-30
+// last-edited: 2026-08-07
 
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -526,6 +527,14 @@ type Config struct {
 	// Environment-authoritative (WHISPER_REMOTE_URL) — see applyEnvAuthoritativeConfig.
 	WhisperRemoteURL string `json:"whisper_remote_url" mapstructure:"whisper_remote_url"`
 
+	// WhisperEndpoints declares a pool of remote faster-whisper servers. When
+	// non-empty it takes precedence over WhisperRemoteURL. Plain structs only —
+	// this package must never import internal/transcribe; the conversion to
+	// transcribe.Endpoint happens at the TranscribeBatch seam.
+	// Environment-authoritative (WHISPER_ENDPOINTS, a JSON array string, e.g.
+	// `[{"url":"http://whisper-1.local:8000","concurrency":2,"priority":1,"kind":"gpu","label":"gpu-box"}]`).
+	WhisperEndpoints []WhisperEndpoint `json:"whisper_endpoints" mapstructure:"whisper_endpoints"`
+
 	// Performance
 	ConcurrentScans int `json:"concurrent_scans"`
 	// ChapterConsolidationThresholdMin is the per-file duration threshold (minutes)
@@ -815,6 +824,36 @@ func Mutate(fn func(*Config)) {
 // UI-set value that lives only in the blob is left untouched when no env var is present.
 // Env-authoritative keys ONLY: OAuth / Cloudflare Access / Whisper. UI-managed keys
 // (itunes.*, scheduled.*, etc.) are intentionally excluded — they belong to the blob.
+// WhisperEndpoint declares one remote Whisper server for the dispatch pool.
+// Mirror of transcribe.Endpoint kept as a plain config struct so this package
+// never imports internal/transcribe.
+type WhisperEndpoint struct {
+	URL         string `json:"url"         mapstructure:"url"`
+	Concurrency int    `json:"concurrency" mapstructure:"concurrency"`
+	Label       string `json:"label"       mapstructure:"label"`
+	// Priority: lower = preferred (GPU box 1, CPU box 100).
+	Priority int `json:"priority" mapstructure:"priority"`
+	// Kind is informational only ("gpu", "cpu", or "").
+	Kind string `json:"kind" mapstructure:"kind"`
+}
+
+// ParseWhisperEndpoints decodes the WHISPER_ENDPOINTS JSON array string.
+// Empty input or malformed JSON yields nil, which falls back to the
+// single-URL (or local) path rather than failing startup — the endpoint list
+// is an optimization, not a correctness requirement.
+func ParseWhisperEndpoints(s string) []WhisperEndpoint {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var endpoints []WhisperEndpoint
+	if err := json.Unmarshal([]byte(s), &endpoints); err != nil {
+		fmt.Fprintf(os.Stderr, "config: ignoring malformed whisper_endpoints (%v)\n", err)
+		return nil
+	}
+	return endpoints
+}
+
 func applyEnvAuthoritativeConfig(c *Config) {
 	if viper.IsSet("oauth_enabled") {
 		c.OAuthEnabled = viper.GetBool("oauth_enabled")
@@ -848,6 +887,9 @@ func applyEnvAuthoritativeConfig(c *Config) {
 	}
 	if viper.IsSet("whisper_remote_url") {
 		c.WhisperRemoteURL = viper.GetString("whisper_remote_url")
+	}
+	if viper.IsSet("whisper_endpoints") {
+		c.WhisperEndpoints = ParseWhisperEndpoints(viper.GetString("whisper_endpoints"))
 	}
 	// Audiobookshelf sync API. Env-authoritative for the same reason as the OAuth keys:
 	// LoadConfigFromDatabase replaces the whole struct with the blob, so without these
@@ -983,6 +1025,10 @@ func InitConfig() {
 	// Transcription: remote faster-whisper server URL (env-authoritative).
 	viper.SetDefault("whisper_remote_url", "")
 	viper.BindEnv("whisper_remote_url", "WHISPER_REMOTE_URL") //nolint:errcheck
+	// Multi-endpoint pool, JSON array string (env-authoritative; wins over
+	// whisper_remote_url when non-empty).
+	viper.SetDefault("whisper_endpoints", "")
+	viper.BindEnv("whisper_endpoints", "WHISPER_ENDPOINTS") //nolint:errcheck
 
 	// Set memory management defaults
 	viper.SetDefault("memory_limit_type", "items")
@@ -1343,6 +1389,7 @@ func InitConfig() {
 			CFAccessTeamDomain:      viper.GetString("cf_access_team_domain"),
 			CFAccessAUD:             viper.GetString("cf_access_aud"),
 			WhisperRemoteURL:        viper.GetString("whisper_remote_url"),
+			WhisperEndpoints:        ParseWhisperEndpoints(viper.GetString("whisper_endpoints")),
 
 			// Audiobookshelf sync API (feature-flagged OFF by default).
 			ABSAPIEnabled:       viper.GetBool("abs_api_enabled"),

--- a/internal/transcribe/batch.go
+++ b/internal/transcribe/batch.go
@@ -1,7 +1,7 @@
 // file: internal/transcribe/batch.go
-// version: 1.12.0
+// version: 1.13.0
 // guid: d4e5f6a7-b8c9-0123-defa-234567890123
-// last-edited: 2026-07-27
+// last-edited: 2026-08-07
 
 package transcribe
 
@@ -48,10 +48,14 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string, onProgress Pro
 		return nil, nil
 	}
 
-	if remoteURL := config.Snapshot().WhisperRemoteURL; remoteURL != "" {
-		results, err := transcribeRemote(ctx, remoteURL, jobs, onProgress)
+	// Remote precedence: non-empty whisper_endpoints → multi-endpoint pool;
+	// else whisper_remote_url as a one-element pool (functionally identical to
+	// the historical direct path); else the local uv path below.
+	snap := config.Snapshot()
+	if endpoints := poolEndpoints(snap.WhisperEndpoints, snap.WhisperRemoteURL); len(endpoints) > 0 {
+		results, err := transcribePool(ctx, endpoints, jobs, onProgress)
 		if err != nil {
-			// Do NOT fall back to the local uv path when WHISPER_REMOTE_URL is
+			// Do NOT fall back to the local uv path when remote endpoints are
 			// configured. The local subprocess loads the full Whisper model into
 			// RAM; at batch sizes of 100–200 books this reliably OOMs the server
 			// (signal: killed after 40+ minutes) and produces zero results anyway.
@@ -59,12 +63,13 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string, onProgress Pro
 			// warning, skip the page, and advance to the next one — far better
 			// than stalling for an hour and triggering the watchdog.
 			//
-			// 🔴 classifyTransport marks this as a BATCH-level failure carrying
-			// no per-file meaning, so the caller defers the page instead of
-			// writing whisper_error to every book in it. Returning a bare error
-			// here is what turned the 2026-07-01 outage into ~34,000 false
+			// 🔴 transcribePool returns a *TransportError (via classifyTransport)
+			// ONLY when every endpoint is exhausted — a BATCH-level failure
+			// carrying no per-file meaning, so the caller defers the page instead
+			// of writing whisper_error to every book in it. Returning a bare
+			// error here is what turned the 2026-07-01 outage into ~34,000 false
 			// per-book verdicts.
-			return nil, classifyTransport([]string{remoteURL}, err)
+			return nil, err
 		}
 		return results, nil
 	}
@@ -160,6 +165,37 @@ func TranscribeBatch(ctx context.Context, jobs map[string]string, onProgress Pro
 		onProgress(len(results), len(jobs))
 	}
 	return results, nil
+}
+
+// poolEndpoints converts config-layer endpoint declarations into transcribe
+// Endpoints, applying the precedence documented at the call site: a non-empty
+// whisper_endpoints list wins; otherwise a non-empty whisper_remote_url
+// becomes a one-element pool; otherwise nil (caller uses the local path).
+// The conversion lives here so internal/config never imports
+// internal/transcribe.
+func poolEndpoints(cfgEndpoints []config.WhisperEndpoint, singleURL string) []Endpoint {
+	if len(cfgEndpoints) > 0 {
+		endpoints := make([]Endpoint, 0, len(cfgEndpoints))
+		for _, e := range cfgEndpoints {
+			if e.URL == "" {
+				continue
+			}
+			endpoints = append(endpoints, Endpoint{
+				URL:         e.URL,
+				Concurrency: e.Concurrency,
+				Label:       e.Label,
+				Priority:    e.Priority,
+				Kind:        e.Kind,
+			})
+		}
+		if len(endpoints) > 0 {
+			return endpoints
+		}
+	}
+	if singleURL != "" {
+		return []Endpoint{{URL: singleURL, Concurrency: 1}}
+	}
+	return nil
 }
 
 // resolveUVBin returns the path to a uv binary that is NOT routed through

--- a/internal/transcribe/dispatcher.go
+++ b/internal/transcribe/dispatcher.go
@@ -1,0 +1,260 @@
+// file: internal/transcribe/dispatcher.go
+// version: 1.0.0
+// guid: ea9de4e6-980d-411f-a92c-878af1df490a
+// last-edited: 2026-08-07
+
+package transcribe
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Endpoint describes one Whisper server in the dispatch pool.
+//
+// Allocation is priority-ordered, not tier-routed: lower Priority numbers are
+// filled first (a GPU box gets 1, a CPU box gets 100), each up to its
+// Concurrency worth of batch-sized chunks, with the remainder spilling to
+// lower-priority endpoints. Deadline-less bulk work (tier 3) is expected to
+// land on low-priority CPU endpoints through this spill mechanism rather than
+// through any explicit tier routing table.
+type Endpoint struct {
+	// URL is the base URL of the faster-whisper server,
+	// e.g. "http://whisper-1.local:8000".
+	URL string
+	// Concurrency is the allocation weight: how many whisperBatchSize-sized
+	// chunks this endpoint is offered per allocation pass. Values < 1 are
+	// treated as 1.
+	Concurrency int
+	// Label is a human-readable name for logs ("gpu-box", "cpu-node").
+	Label string
+	// Priority orders allocation: lower = preferred. Healthy endpoints are
+	// filled in ascending Priority order; jobs spill to higher numbers only
+	// when lower-numbered endpoints are saturated or unhealthy.
+	Priority int
+	// Kind is informational only ("gpu", "cpu", or ""). A future /health
+	// auto-probe may fill it; nothing routes on it today.
+	Kind string
+}
+
+// Cooldown policy: an endpoint that fails a batch is benched for
+// cooldownBase × consecutive-failures, capped at cooldownMax, so a dead box
+// is retried occasionally without being hammered on every page.
+const (
+	cooldownBase = 30 * time.Second
+	cooldownMax  = 5 * time.Minute
+)
+
+// endpointHealth tracks per-URL consecutive failures and the cooldown window.
+// It is package-level (keyed by URL) so the bench persists across
+// TranscribeBatch calls within one process.
+type endpointHealth struct {
+	consecFails   int
+	cooldownUntil time.Time
+}
+
+var (
+	poolHealthMu sync.Mutex
+	poolHealth   = map[string]*endpointHealth{}
+)
+
+func markEndpointFailure(url string) {
+	poolHealthMu.Lock()
+	defer poolHealthMu.Unlock()
+	h := poolHealth[url]
+	if h == nil {
+		h = &endpointHealth{}
+		poolHealth[url] = h
+	}
+	h.consecFails++
+	d := time.Duration(h.consecFails) * cooldownBase
+	if d > cooldownMax {
+		d = cooldownMax
+	}
+	h.cooldownUntil = time.Now().Add(d)
+}
+
+func markEndpointSuccess(url string) {
+	poolHealthMu.Lock()
+	defer poolHealthMu.Unlock()
+	if h := poolHealth[url]; h != nil {
+		h.consecFails = 0
+		h.cooldownUntil = time.Time{}
+	}
+}
+
+func endpointInCooldown(url string) bool {
+	poolHealthMu.Lock()
+	defer poolHealthMu.Unlock()
+	h := poolHealth[url]
+	return h != nil && time.Now().Before(h.cooldownUntil)
+}
+
+// transcribePool distributes jobs across the endpoint pool.
+//
+// Round loop: healthy endpoints (not in cooldown) are filled in priority
+// order via allocateJobs, each endpoint's share is sent through
+// transcribeRemote concurrently, failures bench the endpoint and leave its
+// jobs in the remaining set to be re-queued to the survivors on the next
+// round. A *TransportError (naming every endpoint in the pool) is returned
+// ONLY when jobs remain and no healthy endpoint is left — per the locked
+// decision in PLAN.md, that error carries no per-file meaning and callers
+// must write nothing.
+func transcribePool(ctx context.Context, endpoints []Endpoint, jobs map[string]string, onProgress ProgressFunc) (map[string]BatchResult, error) {
+	if len(jobs) == 0 {
+		return nil, nil
+	}
+	if len(endpoints) == 0 {
+		return nil, classifyTransport(nil, fmt.Errorf("no whisper endpoints configured"))
+	}
+	// One endpoint: byte-for-byte the historical single-URL behaviour.
+	if len(endpoints) == 1 {
+		results, err := transcribeRemote(ctx, endpoints[0].URL, jobs, onProgress)
+		if err != nil {
+			return nil, classifyTransport([]string{endpoints[0].URL}, err)
+		}
+		return results, nil
+	}
+
+	ordered := make([]Endpoint, len(endpoints))
+	copy(ordered, endpoints)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Priority < ordered[j].Priority })
+
+	remaining := make(map[string]string, len(jobs))
+	for id, path := range jobs {
+		remaining[id] = path
+	}
+	results := make(map[string]BatchResult, len(jobs))
+	total := len(jobs)
+
+	// Pool-wide progress: each endpoint call reports its own cumulative
+	// (done, total); the adapter converts that to a shared pool-wide count.
+	var progressMu sync.Mutex
+	poolDone := 0
+	progressFor := func() ProgressFunc {
+		if onProgress == nil {
+			return nil
+		}
+		last := 0
+		return func(d, _ int) {
+			progressMu.Lock()
+			poolDone += d - last
+			last = d
+			cur := poolDone
+			progressMu.Unlock()
+			onProgress(cur, total)
+		}
+	}
+
+	var lastErr error
+	for len(remaining) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, classifyTransport(endpointURLs(ordered), err)
+		}
+		var healthy []Endpoint
+		for _, ep := range ordered {
+			if !endpointInCooldown(ep.URL) {
+				healthy = append(healthy, ep)
+			}
+		}
+		if len(healthy) == 0 {
+			if lastErr == nil {
+				lastErr = fmt.Errorf("all %d whisper endpoints in cooldown", len(ordered))
+			}
+			return nil, classifyTransport(endpointURLs(ordered), lastErr)
+		}
+
+		assignments := allocateJobs(healthy, remaining)
+
+		type epResult struct {
+			idx int
+			res map[string]BatchResult
+			err error
+		}
+		resCh := make(chan epResult, len(assignments))
+		var wg sync.WaitGroup
+		for idx, sub := range assignments {
+			if len(sub) == 0 {
+				continue
+			}
+			wg.Add(1)
+			go func(idx int, ep Endpoint, sub map[string]string) {
+				defer wg.Done()
+				r, err := transcribeRemote(ctx, ep.URL, sub, progressFor())
+				resCh <- epResult{idx: idx, res: r, err: err}
+			}(idx, healthy[idx], sub)
+		}
+		wg.Wait()
+		close(resCh)
+
+		for r := range resCh {
+			ep := healthy[r.idx]
+			if r.err != nil {
+				// Bench the endpoint; its jobs stay in remaining and are
+				// re-queued to a surviving endpoint on the next round.
+				markEndpointFailure(ep.URL)
+				lastErr = fmt.Errorf("%s: %w", ep.URL, r.err)
+				continue
+			}
+			markEndpointSuccess(ep.URL)
+			for id, br := range r.res {
+				results[id] = br
+			}
+			// Clear the whole assigned set, not just returned IDs: the
+			// transport skips unreadable WAVs without error (same as the
+			// single-URL path), so a missing result is a skip, not a retry.
+			for id := range assignments[r.idx] {
+				delete(remaining, id)
+			}
+		}
+	}
+	return results, nil
+}
+
+// allocateJobs assigns remaining jobs to healthy endpoints (already sorted by
+// ascending Priority). Each pass offers every endpoint up to
+// Concurrency×whisperBatchSize jobs in priority order; passes repeat until
+// all jobs are assigned, so overflow beyond total capacity distributes
+// proportionally to Concurrency while lower-Priority numbers fill first.
+// Job IDs are assigned in sorted order for determinism.
+func allocateJobs(healthy []Endpoint, remaining map[string]string) []map[string]string {
+	assignments := make([]map[string]string, len(healthy))
+	ids := make([]string, 0, len(remaining))
+	for id := range remaining {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	pos := 0
+	for pos < len(ids) {
+		for i, ep := range healthy {
+			c := ep.Concurrency
+			if c < 1 {
+				c = 1
+			}
+			take := c * whisperBatchSize
+			for n := 0; n < take && pos < len(ids); n++ {
+				if assignments[i] == nil {
+					assignments[i] = make(map[string]string)
+				}
+				assignments[i][ids[pos]] = remaining[ids[pos]]
+				pos++
+			}
+			if pos >= len(ids) {
+				break
+			}
+		}
+	}
+	return assignments
+}
+
+func endpointURLs(eps []Endpoint) []string {
+	urls := make([]string, 0, len(eps))
+	for _, ep := range eps {
+		urls = append(urls, ep.URL)
+	}
+	return urls
+}

--- a/internal/transcribe/dispatcher_test.go
+++ b/internal/transcribe/dispatcher_test.go
@@ -1,0 +1,114 @@
+// file: internal/transcribe/dispatcher_test.go
+// version: 1.0.0
+// guid: 1ca890f2-8505-4a42-9d74-209cc293077e
+// last-edited: 2026-08-07
+
+package transcribe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newWhisperStub returns an httptest server that answers the legacy per-file
+// protocol: /health 404s (so the dispatcher takes the per-file path) and
+// /transcribe returns a fixed transcript.
+func newWhisperStub(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/transcribe", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"text": "ok"})
+	})
+	return httptest.NewServer(mux)
+}
+
+// deadServerURL returns a URL whose listener has been closed, so every
+// connection is refused.
+func deadServerURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.NotFoundHandler())
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func tempWAVJobs(t *testing.T, n int) map[string]string {
+	t.Helper()
+	dir := t.TempDir()
+	jobs := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("book-%03d", i)
+		path := filepath.Join(dir, id+".wav")
+		if err := os.WriteFile(path, []byte("RIFF-fake-wav"), 0o644); err != nil {
+			t.Fatalf("write wav: %v", err)
+		}
+		jobs[id] = path
+	}
+	return jobs
+}
+
+// Test (b): one endpoint down, the survivor completes everything, nil error.
+func TestPoolOneEndpointDownSurvivorCompletes(t *testing.T) {
+	downURL := deadServerURL(t)
+	up := newWhisperStub(t)
+	defer up.Close()
+
+	endpoints := []Endpoint{
+		{URL: downURL, Concurrency: 1, Label: "gpu-dead", Priority: 1, Kind: "gpu"},
+		{URL: up.URL, Concurrency: 1, Label: "cpu-alive", Priority: 100, Kind: "cpu"},
+	}
+	jobs := tempWAVJobs(t, 5)
+
+	results, err := transcribePool(context.Background(), endpoints, jobs, nil)
+	if err != nil {
+		t.Fatalf("expected nil error when a survivor remains, got: %v", err)
+	}
+	if len(results) != len(jobs) {
+		t.Fatalf("expected %d results, got %d", len(jobs), len(results))
+	}
+	for id := range jobs {
+		r, ok := results[id]
+		if !ok {
+			t.Fatalf("missing result for %s", id)
+		}
+		if r.Text != "ok" || r.Error != "" {
+			t.Fatalf("unexpected result for %s: %+v", id, r)
+		}
+	}
+}
+
+// Test (c): every endpoint down -> *TransportError naming BOTH URLs.
+func TestPoolAllEndpointsDownTransportError(t *testing.T) {
+	urlA := deadServerURL(t)
+	urlB := deadServerURL(t)
+
+	endpoints := []Endpoint{
+		{URL: urlA, Concurrency: 1, Label: "a", Priority: 1},
+		{URL: urlB, Concurrency: 1, Label: "b", Priority: 2},
+	}
+	jobs := tempWAVJobs(t, 3)
+
+	results, err := transcribePool(context.Background(), endpoints, jobs, nil)
+	if err == nil {
+		t.Fatalf("expected error with all endpoints down, got results: %v", results)
+	}
+	var te *TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("expected *TransportError, got %T: %v", err, err)
+	}
+	found := map[string]bool{}
+	for _, u := range te.Endpoints {
+		found[u] = true
+	}
+	if !found[urlA] || !found[urlB] {
+		t.Fatalf("TransportError.Endpoints must name both URLs (%s, %s), got %v",
+			urlA, urlB, te.Endpoints)
+	}
+}


### PR DESCRIPTION
Priority-ordered endpoint pool per the owner's design (arbitrary servers, priority + gpu/cpu marking, priority rules dictate allocation). Transport failures write nothing (returns TransportError only when ALL endpoints are exhausted). Single-endpoint behaviour unchanged. Tests -race green.

Agent-built, coordinator-salvaged after repeated API stalls; final build+tests run by coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp