### PR TITLE
fix(operations): guard writeSetDeferred with r.mu — real data race in the dispatcher

### DIFF
--- a/changelog.d/20260808_024500_fix_dispatcher_writeset_race.md
+++ b/changelog.d/20260808_024500_fix_dispatcher_writeset_race.md
@@ -1,0 +1,36 @@
+### Fixed
+
+#### Data race on the dispatcher's write-set deferral map
+
+`Registry.writeSetDeferred` — the log-dedupe map added with the Gate 3b
+write-set conflict gate — was read, ranged, and deleted from at six sites in
+`internal/operations/registry/dispatcher.go` with no locking at all, while the
+`Registry` already carried an `mu sync.RWMutex` used for its sibling state
+(`pluginRunning`, `concurrencyKeys`, `running`). `-race` caught it as a
+concurrent map read at the prune in `dispatchCycle` against a `mapdelete` from
+a second `dispatchCycle` on the same `Registry`, failing
+`TestServerStartGracefulShutdown` and with it the Coverage Floor gate on an
+unrelated docs-only PR.
+
+The code carried an explicit comment asserting the map was safe:
+
+    // writeSetDeferred is only ever touched from the dispatcher goroutine
+    // (dispatchCycle is single-caller), so it needs no locking
+
+That is true within a single `Start()`, which spawns exactly one dispatcher
+goroutine — but `Start()` is deliberately restartable after `Shutdown()` (it
+clears `notifyStopped` for precisely that case) and neither waits for nor
+excludes a prior dispatcher still draining. During a restart two
+`dispatchCycle` calls therefore overlap on the same `Registry`, and the
+assumption breaks.
+
+All six accesses are now guarded by `r.mu`. The dedupe check-and-set in
+`logWriteSetDeferral` takes a single acquisition rather than two: splitting it
+would let two goroutines both miss the entry and emit the same line twice,
+which is the exact log spam the dedupe exists to suppress. No call site held
+`r.mu` already — the Gate 3b path releases it before logging — so no lock
+ordering changed and there is no deadlock risk.
+
+Verified with `go test -race`: `internal/server` (the failing test, 3
+consecutive runs) and `internal/operations/registry` both pass with zero race
+reports.

--- a/internal/operations/registry/dispatcher.go
+++ b/internal/operations/registry/dispatcher.go
@@ -1,7 +1,7 @@
 // file: internal/operations/registry/dispatcher.go
-// version: 2.1.0
+// version: 2.1.1
 // guid: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
-// last-edited: 2026-08-07
+// last-edited: 2026-08-08
 
 package registry
 
@@ -44,6 +44,7 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 
 	// Prune write-set deferral log-dedupe entries for ops that left the queue
 	// (dispatched, canceled, deleted) so the map cannot grow unbounded.
+	r.mu.Lock()
 	if len(r.writeSetDeferred) > 0 {
 		queuedIDs := make(map[string]struct{}, len(queued))
 		for _, row := range queued {
@@ -55,6 +56,7 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 			}
 		}
 	}
+	r.mu.Unlock()
 
 	for _, row := range queued {
 		if ctx.Err() != nil {
@@ -189,7 +191,9 @@ func (r *Registry) dispatchCycle(ctx context.Context) {
 
 		select {
 		case r.nextRun <- qr:
+			r.mu.Lock()
 			delete(r.writeSetDeferred, row.ID)
+			r.mu.Unlock()
 			r.logger.Info("registry: dispatched op", "op_id", row.ID, "def_id", row.DefID)
 		default:
 			// Worker channel is full; undo accounting and try next cycle.
@@ -240,15 +244,29 @@ func (r *Registry) writeSetConflictLocked(candidateID string, candidateWrites []
 
 // logWriteSetDeferral logs one clear line per (deferred op → blocking op)
 // pair. Without dedupe the 100ms dispatch ticker would repeat the line ten
-// times a second for as long as the conflict lasts. writeSetDeferred is only
-// ever touched from the dispatcher goroutine (dispatchCycle is single-caller),
-// so it needs no locking; entries are dropped once the blocking op changes or
-// the deferred op leaves the queue (see the prune in dispatchCycle).
+// times a second for as long as the conflict lasts. Entries are dropped once
+// the blocking op changes or the deferred op leaves the queue (see the prune
+// in dispatchCycle).
+//
+// writeSetDeferred is guarded by r.mu. An earlier version of this comment
+// claimed the map needed no locking because "dispatchCycle is single-caller".
+// That holds only within one Start(): Start() is explicitly restartable after
+// Shutdown() and does not wait for or exclude a prior dispatcher goroutine, so
+// during a restart two dispatchCycle calls can overlap on the same Registry.
+// That is a real race -- caught by -race as a concurrent map read/delete
+// between the prune in dispatchCycle and this dedupe write.
+//
+// The check and the set must happen under one acquisition: splitting them
+// would let two goroutines both miss the entry and log the same line twice,
+// which is the exact spam this dedupe exists to prevent.
 func (r *Registry) logWriteSetDeferral(opID, defID string, holder *runHandle, overlap []Resource) {
+	r.mu.Lock()
 	if r.writeSetDeferred[opID] == holder.id {
+		r.mu.Unlock()
 		return
 	}
 	r.writeSetDeferred[opID] = holder.id
+	r.mu.Unlock()
 	resources := make([]string, len(overlap))
 	for i, res := range overlap {
 		resources[i] = string(res)


### PR DESCRIPTION
Found while diagnosing why the **Coverage Floor gate failed on #2189, a docs-only PR**. It wasn't a flake — it's a real data race introduced with last night's Gate 3b write-set conflict gate.

## The race

`-race` caught a concurrent map read at the prune in `dispatchCycle` against a `mapdelete` from a *second* `dispatchCycle` on the same `Registry`:

```
WARNING: DATA RACE
Read at 0x00c0029f14d0 by goroutine 14392:
  registry.(*Registry).dispatchCycle()  dispatcher.go:47
Previous write at 0x00c0029f14d0 by goroutine 14408:
  runtime.mapdelete_faststr()
  registry.(*Registry).dispatchCycle()  dispatcher.go:192
```

`Registry.writeSetDeferred` was read, ranged, and deleted from at **six sites** with no locking — even though `Registry` already carries an `mu sync.RWMutex` guarding its sibling state (`pluginRunning`, `concurrencyKeys`, `running`).

## Why the existing safety argument was wrong

The code asserted its own safety in a comment:

```go
// writeSetDeferred is only ever touched from the dispatcher goroutine
// (dispatchCycle is single-caller), so it needs no locking
```

That holds *within a single* `Start()`, which spawns exactly one dispatcher goroutine. But `Start()` is **deliberately restartable after `Shutdown()`** — it clears `notifyStopped` for precisely that case — and it neither waits for nor excludes a prior dispatcher goroutine that is still draining. During a restart, two `dispatchCycle` calls overlap on the same `Registry` and the assumption breaks. The comment has been replaced with one that explains this.

## The fix

All six accesses now take `r.mu`. Two details worth reviewing:

- **`logWriteSetDeferral`'s check-and-set uses one acquisition, not two.** Splitting it would let two goroutines both miss the entry and emit the same line twice — the exact log spam the dedupe exists to suppress (the 100ms ticker would otherwise repeat it ten times a second).
- **No lock ordering changed.** No call site already held `r.mu` — the Gate 3b path `RUnlock`s before calling the logger — so there's no deadlock risk from the added acquisitions.

## Verification

```
go test -race -run TestServerStartGracefulShutdown -count=3 ./internal/server/
  ok  github.com/falkcorp/audiobook-organizer/internal/server  44.734s

go test -race -short ./internal/operations/registry/
  ok  github.com/falkcorp/audiobook-organizer/internal/operations/registry  47.563s
```

Zero `DATA RACE` reports in either. `go build` and `go vet` clean.

No dedicated regression test is added — the race is already caught by the existing `-race` suite, which is what surfaced it. A deterministic reproducer would require forcing the restart-overlap window.

## Follow-up worth considering (not fixed here)

The deeper question is whether `Start()` should refuse to run, or wait on `goroutineWG`, while a prior dispatcher is still live. Two concurrent dispatchers on one Registry could double-dispatch operations in production, which the mutex makes memory-safe but not logically correct. Flagging rather than changing startup semantics at 3am.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp