### PR TITLE
fix(library): stop claiming the library is empty when the server is unreachable

### DIFF
--- a/changelog.d/20260808_060000_fix_library_empty_state.md
+++ b/changelog.d/20260808_060000_fix_library_empty_state.md
@@ -1,0 +1,51 @@
+### Fixed
+
+#### The Library no longer claims to be empty when it simply cannot reach the server
+
+Restarting the backend made the Library announce **"No Audiobooks Found"** — to
+someone with a 44,000-book library. It was never true; the request had just
+failed.
+
+Two things combined to produce it. `useLibraryQuery` responded to a failed load
+by calling `setAudiobooks([])`, actively discarding whatever was on screen, and
+its `finally` block then set `loading` to false. `LibraryBookGrid` in turn chose
+its empty state with:
+
+    audiobooks.length === 0 && !loading && !searchQuery
+
+with no error branch anywhere — and the component was not even passed one; its
+props carried only `loading: boolean`, so it was structurally incapable of
+telling a failed fetch from an empty library. A failed request produced exactly
+the state that condition looks for.
+
+This is not an edge case. The backend is unreachable for roughly **40 seconds
+after every deploy** while memdb warms over the whole library (measured
+2026-08-08: `/api/v1/system/status` refused connections for ~40s after a
+restart, then answered normally). Every single deploy hit this window.
+
+Three changes:
+
+- **Failed loads no longer wipe the list.** The last known-good page stays on
+  screen, so a mid-session blip leaves the shelf intact instead of blanking it.
+- **The empty state is gated on a load that actually succeeded.** The decision
+  moved into a pure `libraryContentState()` helper whose branch order *is* the
+  fix: `reconnecting` is checked before `empty`, so only a request that resolved
+  with zero results may claim the library is empty.
+- **Failed loads retry automatically** with exponential backoff from 500ms,
+  capped at 5s — chosen well under the warmup window so the Library repopulates
+  within seconds of the backend answering. Retries continue indefinitely for
+  transient failures (network error, connection refused, 5xx) because those all
+  resolve on their own; a 4xx is a real client-side fault and is not retried. An
+  explicit cancel stops the retry loop, and the timer is cleared on unmount.
+
+While the library is unreachable the user now sees "Loading your library…" with
+a note that this is normal for up to a minute after an update, instead of being
+told their collection is gone.
+
+Also moves `isSubItemSelected` out of `Sidebar.tsx` into its own module,
+resolving a `react-refresh/only-export-components` warning introduced with the
+In Progress filter fix. Net lint warnings drop from 25 to 24.
+
+Covered by `libraryContentState.test.ts` (10 cases), including an exhaustive
+sweep asserting that `empty` is reachable **only** from a clean, settled,
+genuinely-zero result.

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 // file: web/src/components/layout/Sidebar.tsx
-// version: 1.16.0
+// version: 1.17.0
 // guid: 6f7a8b9c-0d1e-2f3a-4b5c-6d7e8f9a0b1c
 // last-edited: 2026-08-08
 
@@ -37,6 +37,7 @@ import TimelineIcon from '@mui/icons-material/Timeline';
 import WavesIcon from '@mui/icons-material/Waves';
 import FactCheckIcon from '@mui/icons-material/FactCheck';
 import { useReviewStore } from '../../stores/useReviewStore';
+import { isSubItemSelected } from './sidebarSelection';
 
 const MOBILE_DRAWER_WIDTH = 240;
 
@@ -66,31 +67,6 @@ const librarySubItems = [
   { text: 'Series', icon: <CollectionsBookmarkIcon />, path: '/series' },
   { text: 'Authors', icon: <PeopleIcon />, path: '/authors' },
 ];
-
-/**
- * Decides whether a Library sub-item should render as selected.
- *
- * Exported for tests. The previous implementation compared
- * `location.pathname` against `item.matchPath ?? item.path`, which is wrong in
- * both directions for the filter items: `pathname` never carries a query
- * string, so 'In Progress' (path '/library?search=...') could never match,
- * while 'All Books' (matchPath '/library') matched on *every* /library URL.
- * The highlight was therefore pinned to All Books permanently.
- *
- * Items that declare `matchSearch` are compared on the parsed, decoded
- * `search` param rather than the raw path, so they still match once
- * Library.tsx settles the URL into `?search=read_status%3Ain_progress&page=1`.
- */
-export function isSubItemSelected(
-  item: { path: string; matchPath?: string; matchSearch?: string },
-  pathname: string,
-  search: string,
-): boolean {
-  const itemPath = (item.matchPath ?? item.path).split('?')[0];
-  if (pathname !== itemPath) return false;
-  if (item.matchSearch === undefined) return true;
-  return (new URLSearchParams(search).get('search') ?? '') === item.matchSearch;
-}
 
 const menuItems = [
   { text: 'Dashboard', icon: <DashboardIcon />, path: '/dashboard' },

--- a/web/src/components/layout/sidebarSelection.test.ts
+++ b/web/src/components/layout/sidebarSelection.test.ts
@@ -1,11 +1,11 @@
-// file: web/src/components/layout/Sidebar.test.tsx
+// file: web/src/components/layout/sidebarSelection.test.ts
 // version: 1.0.0
 // guid: 5c1d9e42-7f38-4a61-9b0e-2d84c6f1a705
 // last-edited: 2026-08-08
 
 import { describe, expect, it } from 'vitest';
 
-import { isSubItemSelected } from './Sidebar';
+import { isSubItemSelected } from './sidebarSelection';
 
 // Mirrors the librarySubItems entries under test. Kept local so the test
 // documents the contract rather than depending on the array's ordering.

--- a/web/src/components/layout/sidebarSelection.ts
+++ b/web/src/components/layout/sidebarSelection.ts
@@ -1,0 +1,33 @@
+// file: web/src/components/layout/sidebarSelection.ts
+// version: 1.0.0
+// guid: 9d41f0b7-2ac6-4e83-b5d0-61e7c9a3f882
+// last-edited: 2026-08-08
+
+/**
+ * Decides whether a Library sub-item should render as selected.
+ *
+ * Lives in its own module so Sidebar.tsx only exports components
+ * (react-refresh/only-export-components), and so this is unit-testable
+ * without mounting the sidebar.
+ *
+ * Exported for tests. The previous implementation compared
+ * `location.pathname` against `item.matchPath ?? item.path`, which is wrong in
+ * both directions for the filter items: `pathname` never carries a query
+ * string, so 'In Progress' (path '/library?search=...') could never match,
+ * while 'All Books' (matchPath '/library') matched on *every* /library URL.
+ * The highlight was therefore pinned to All Books permanently.
+ *
+ * Items that declare `matchSearch` are compared on the parsed, decoded
+ * `search` param rather than the raw path, so they still match once
+ * Library.tsx settles the URL into `?search=read_status%3Ain_progress&page=1`.
+ */
+export function isSubItemSelected(
+  item: { path: string; matchPath?: string; matchSearch?: string },
+  pathname: string,
+  search: string,
+): boolean {
+  const itemPath = (item.matchPath ?? item.path).split('?')[0];
+  if (pathname !== itemPath) return false;
+  if (item.matchSearch === undefined) return true;
+  return (new URLSearchParams(search).get('search') ?? '') === item.matchSearch;
+}

--- a/web/src/components/library/LibraryBookGrid.tsx
+++ b/web/src/components/library/LibraryBookGrid.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/LibraryBookGrid.tsx
-// version: 1.7.0
+// version: 1.8.0
 // guid: c3d4e5f6-a7b8-9012-cdef-123456789012
-// last-edited: 2026-07-11
+// last-edited: 2026-08-08
 
 import {
   Typography,
@@ -37,10 +37,19 @@ import type { ViewMode } from '../audiobooks/SearchBar';
 import type { ParsedSearch } from '../../utils/searchParser';
 import type { ImportPath } from '../../pages/libraryTypes';
 import { STORAGE_KEYS } from '../../lib/storageKeys';
+import { libraryContentState } from './libraryContentState';
 
 interface LibraryBookGridProps {
   audiobooks: Audiobook[];
   loading: boolean;
+  /**
+   * Non-null when the most recent load failed. Gates the empty state: an empty
+   * `audiobooks` array with a load error means "we could not fetch", NOT "the
+   * library is empty", and the two must never look the same to the user.
+   */
+  loadError?: Error | null;
+  /** True while a failed load is waiting on its retry backoff. */
+  isRetrying?: boolean;
   onCancelLoad?: () => void;
   searchQuery: string;
   setSearchQuery: (q: string) => void;
@@ -112,6 +121,8 @@ interface LibraryBookGridProps {
 export const LibraryBookGrid = ({
   audiobooks,
   loading,
+  loadError,
+  isRetrying,
   onCancelLoad,
   searchQuery,
   setSearchQuery,
@@ -180,7 +191,17 @@ export const LibraryBookGrid = ({
   handleTagFilterChange,
 }: LibraryBookGridProps) => (
   <>
-    {audiobooks.length === 0 && !loading && !searchQuery ? (
+    {libraryContentState({ bookCount: audiobooks.length, loading, loadError, searchQuery }) === 'reconnecting' ? (
+      <Paper sx={{ p: 4, textAlign: 'center', bgcolor: 'background.default' }}>
+        <CircularProgress sx={{ mb: 2 }} />
+        <Alert severity="info" sx={{ textAlign: 'center' }}>
+          <AlertTitle>Loading your library…</AlertTitle>
+          {isRetrying
+            ? "Can't reach the server right now — retrying automatically. This is normal for up to a minute after an update while the library loads."
+            : 'Waiting for the server to respond.'}
+        </Alert>
+      </Paper>
+    ) : libraryContentState({ bookCount: audiobooks.length, loading, loadError, searchQuery }) === 'empty' ? (
       <Paper sx={{ p: 4, textAlign: 'center', bgcolor: 'background.default' }}>
         <FolderOpenIcon sx={{ fontSize: 80, color: 'text.secondary', mb: 2 }} />
         <Alert severity="info" sx={{ textAlign: 'center' }}>

--- a/web/src/components/library/libraryContentState.test.ts
+++ b/web/src/components/library/libraryContentState.test.ts
@@ -1,0 +1,105 @@
+// file: web/src/components/library/libraryContentState.test.ts
+// version: 1.0.0
+// guid: 2b6f14ad-8c07-4d9e-9f31-5a70c8e2d4b6
+// last-edited: 2026-08-08
+
+import { describe, expect, it } from 'vitest';
+
+import { libraryContentState } from './libraryContentState';
+
+const ERR = new Error('Failed to fetch');
+
+describe('libraryContentState', () => {
+  it('shows the empty state only for a load that succeeded with zero books', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: false, loadError: null, searchQuery: '' }),
+    ).toBe('empty');
+  });
+
+  // The bug. A failed request also leaves the list empty with loading=false;
+  // before the fix that rendered "No Audiobooks Found", telling the owner of a
+  // 44,000-book library it was empty every time the backend restarted.
+  it('never shows the empty state when the load failed', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: false, loadError: ERR, searchQuery: '' }),
+    ).toBe('reconnecting');
+  });
+
+  it('shows reconnecting during the post-deploy warmup window', () => {
+    // Same shape as above: request settled, failed, nothing cached to show.
+    const state = libraryContentState({
+      bookCount: 0,
+      loading: false,
+      loadError: new Error('NetworkError when attempting to fetch resource.'),
+      searchQuery: '',
+    });
+    expect(state).toBe('reconnecting');
+    expect(state).not.toBe('empty');
+  });
+
+  it('defers to the normal body while a request is in flight', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: true, loadError: null, searchQuery: '' }),
+    ).toBe('content');
+  });
+
+  // A request can be in flight *and* the previous one have failed (a retry).
+  // The in-flight state wins so the UI does not flip between two spinners.
+  it('prefers the in-flight state over a stale error while retrying', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: true, loadError: ERR, searchQuery: '' }),
+    ).toBe('content');
+  });
+
+  it('never shows the empty state while books are on screen', () => {
+    for (const loadError of [null, ERR]) {
+      expect(
+        libraryContentState({ bookCount: 20, loading: false, loadError, searchQuery: '' }),
+      ).toBe('content');
+    }
+  });
+
+  // Keeping the last known-good page on error is the other half of the fix:
+  // a mid-session blip must leave the shelf intact rather than blanking it.
+  it('keeps showing cached books when a refresh fails', () => {
+    expect(
+      libraryContentState({ bookCount: 20, loading: false, loadError: ERR, searchQuery: '' }),
+    ).toBe('content');
+  });
+
+  it('lets the normal body handle a search that matched nothing', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: false, loadError: null, searchQuery: 'zzz' }),
+    ).toBe('content');
+  });
+
+  it('still reports reconnecting when a filtered search fails', () => {
+    expect(
+      libraryContentState({ bookCount: 0, loading: false, loadError: ERR, searchQuery: 'zzz' }),
+    ).toBe('reconnecting');
+  });
+
+  it('returns exactly one state for every input combination', () => {
+    const valid = new Set(['reconnecting', 'empty', 'content']);
+    for (const bookCount of [0, 5]) {
+      for (const loading of [true, false]) {
+        for (const loadError of [null, ERR]) {
+          for (const searchQuery of ['', 'query']) {
+            const state = libraryContentState({ bookCount, loading, loadError, searchQuery });
+            expect(valid.has(state)).toBe(true);
+            // The invariant that matters: 'empty' requires a clean, settled,
+            // genuinely-zero result. Nothing else may produce it.
+            if (state === 'empty') {
+              expect({ bookCount, loading, loadError, searchQuery }).toEqual({
+                bookCount: 0,
+                loading: false,
+                loadError: null,
+                searchQuery: '',
+              });
+            }
+          }
+        }
+      }
+    }
+  });
+});

--- a/web/src/components/library/libraryContentState.ts
+++ b/web/src/components/library/libraryContentState.ts
@@ -1,0 +1,47 @@
+// file: web/src/components/library/libraryContentState.ts
+// version: 1.0.0
+// guid: 7e3a5c81-46bd-4f02-9c18-3d5b9e07a2f4
+// last-edited: 2026-08-08
+
+/** Which of the three mutually-exclusive Library bodies to render. */
+export type LibraryContentState = 'reconnecting' | 'empty' | 'content';
+
+/**
+ * Decides what the Library shows when it has no books to display.
+ *
+ * Lives in its own module rather than in LibraryBookGrid.tsx so that file only
+ * exports components (react-refresh/only-export-components), and so this can
+ * be unit-tested without mounting the grid and its ~50 props.
+ *
+ * The ordering IS the fix. The previous condition was
+ * `audiobooks.length === 0 && !loading && !searchQuery`, with no error branch
+ * anywhere — so a failed request, which also leaves the list empty and
+ * `loading` false, rendered "No Audiobooks Found". The backend is unreachable
+ * for ~40s after every deploy while memdb warms over the whole library, so a
+ * routine restart told the user their 44,000-book library was empty.
+ *
+ * `reconnecting` is therefore checked BEFORE `empty`: only a load that
+ * RESOLVED with zero results may claim the library is empty.
+ */
+export function libraryContentState({
+  bookCount,
+  loading,
+  loadError,
+  searchQuery,
+}: {
+  bookCount: number;
+  loading: boolean;
+  loadError?: Error | null;
+  searchQuery: string;
+}): LibraryContentState {
+  // Anything to show, or a request still in flight — the normal body handles
+  // both, including its own in-grid spinner.
+  if (bookCount > 0 || loading) return 'content';
+  // Settled, but it FAILED. Never claim emptiness on the strength of a request
+  // that did not come back.
+  if (loadError) return 'reconnecting';
+  // Settled successfully with zero results. A search that matched nothing is
+  // handled inside the normal body, which offers to clear the query.
+  if (!searchQuery) return 'empty';
+  return 'content';
+}

--- a/web/src/hooks/useLibraryQuery.ts
+++ b/web/src/hooks/useLibraryQuery.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.ts
-// version: 1.3.0
+// version: 1.4.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789003
-// last-edited: 2026-07-11
+// last-edited: 2026-08-08
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -11,6 +11,15 @@ import { SortField, SortOrder } from '../types';
 import type { Audiobook } from '../types';
 import type { ParsedSearch } from '../utils/searchParser';
 import type { ImportPath } from '../pages/libraryTypes';
+
+/** First retry delay after a failed load. Doubles per consecutive failure. */
+const RETRY_BASE_DELAY_MS = 500;
+/**
+ * Ceiling on the retry backoff. Chosen well under the ~40s memdb warmup window
+ * so the Library repopulates within a few seconds of the backend answering,
+ * rather than sitting dark for another full backoff period.
+ */
+const RETRY_MAX_DELAY_MS = 5000;
 
 interface UseLibraryQueryFilters {
   author?: string;
@@ -63,6 +72,17 @@ export function useLibraryQuery({
   const [audiobooks, setAudiobooks] = useState<Audiobook[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(false);
+  // Non-null while the most recent load failed. Consumers MUST consult this
+  // before rendering an "empty library" state: an empty `audiobooks` array
+  // means "we have nothing to show", which is not the same as "there is
+  // nothing to show". The backend is unreachable for ~40s after every deploy
+  // while memdb warms over the whole library, so this is routine, not exotic.
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  // True while a failed load waits on its backoff timer, so the UI can say
+  // "reconnecting" instead of showing a silent spinner forever.
+  const [isRetrying, setIsRetrying] = useState(false);
+  const retryAttemptRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [totalPages, setTotalPages] = useState(1);
   const [softDeletedBooks, setSoftDeletedBooks] = useState<Audiobook[]>([]);
   const [softDeletedCount, setSoftDeletedCount] = useState(0);
@@ -95,6 +115,44 @@ export function useLibraryQuery({
     }
   }, []);
 
+  // Held so scheduleRetry can invoke the latest loadAudiobooks without the two
+  // useCallbacks depending on each other (which cannot be expressed directly).
+  const loadAudiobooksRef = useRef<(() => Promise<void>) | null>(null);
+
+  const cancelPendingRetry = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  /** Clears failure state after a load resolves successfully. */
+  const clearLoadFailure = useCallback(() => {
+    cancelPendingRetry();
+    retryAttemptRef.current = 0;
+    setIsRetrying(false);
+    setLoadError(null);
+  }, [cancelPendingRetry]);
+
+  /**
+   * Re-attempts a failed load after an exponential backoff, capped at
+   * RETRY_MAX_DELAY_MS. Retries indefinitely by design: the failure modes this
+   * exists for (memdb warmup after a deploy, a restart, a brief network drop)
+   * all resolve on their own, and giving up would strand the user on a screen
+   * that never recovers without a manual refresh. The cap keeps recovery
+   * prompt once the backend returns.
+   */
+  const scheduleRetry = useCallback(() => {
+    cancelPendingRetry();
+    const delay = Math.min(RETRY_MAX_DELAY_MS, RETRY_BASE_DELAY_MS * 2 ** retryAttemptRef.current);
+    retryAttemptRef.current += 1;
+    setIsRetrying(true);
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null;
+      void loadAudiobooksRef.current?.();
+    }, delay);
+  }, [cancelPendingRetry]);
+
   const loadAudiobooks = useCallback(async () => {
     const requestId = ++latestRequestIdRef.current;
     abortControllerRef.current?.abort();
@@ -126,6 +184,8 @@ export function useLibraryQuery({
         setTotalPages(cached.totalPages);
         setImportPaths(cached.importPaths);
         setLoading(false);
+        // A cache hit is a resolved load, so any prior failure is over.
+        clearLoadFailure();
         return;
       }
 
@@ -186,6 +246,9 @@ export function useLibraryQuery({
       setTotalCount(total);
       setTotalPages(totalPages);
       setImportPaths(importPathsData);
+      // Success: this result is authoritative, so an empty list here really
+      // does mean an empty library and the empty state may render.
+      clearLoadFailure();
     } catch (error) {
       // A cancelled fetch (user clicked Cancel, or a newer request superseded
       // this one and aborted it) is not a failure — skip the error toast/
@@ -209,14 +272,34 @@ export function useLibraryQuery({
         toast('Request timed out.', 'error');
       }
       console.error('Failed to load audiobooks:', error);
-      setAudiobooks([]);
-      setTotalPages(1);
+      // Deliberately do NOT clear `audiobooks` here. Emptying the list on
+      // failure is what made a transient backend outage render as "No
+      // Audiobooks Found" — the most alarming possible way to display a
+      // temporary error to someone with a 44,000-book library. Keeping the
+      // last known-good page means a mid-session blip leaves the shelf intact,
+      // and `loadError` tells the UI to say "reconnecting" over the top.
+      setLoadError(error instanceof Error ? error : new Error(String(error)));
+      // A 4xx is a real client-side problem and retrying cannot fix it.
+      // Anything else — network failure, connection refused, 5xx, or the
+      // memdb-warmup window after a deploy — is transient by assumption.
+      const isTransient =
+        !(error instanceof api.ApiError) || error.status === 0 || error.status >= 500;
+      if (isTransient) {
+        scheduleRetry();
+      }
     } finally {
       if (requestId === latestRequestIdRef.current) {
         setLoading(false);
       }
     }
-  }, [buildFieldFilters, debouncedSearch, filters, itemsPerPage, page, parsedSearch, selectedTags, sortBy, sortOrder, navigate, toast, setImportPaths, convertBook]);
+  }, [buildFieldFilters, debouncedSearch, filters, itemsPerPage, page, parsedSearch, selectedTags, sortBy, sortOrder, navigate, toast, setImportPaths, convertBook, clearLoadFailure, scheduleRetry]);
+
+  // Keep the retry timer pointed at the current closure, so a retry that fires
+  // after filters/page changed re-runs the CURRENT query rather than the stale
+  // one that happened to fail.
+  useEffect(() => {
+    loadAudiobooksRef.current = loadAudiobooks;
+  }, [loadAudiobooks]);
 
   // Reload books when scan/organize completes
   useEffect(() => {
@@ -265,7 +348,15 @@ export function useLibraryQuery({
   const cancelLoad = useCallback(() => {
     abortControllerRef.current?.abort();
     setLoading(false);
-  }, []);
+    // An explicit cancel must also stop the retry loop, or the request the
+    // user just cancelled would quietly come back a second later.
+    cancelPendingRetry();
+    retryAttemptRef.current = 0;
+    setIsRetrying(false);
+  }, [cancelPendingRetry]);
+
+  // Never leave a retry timer running past unmount.
+  useEffect(() => cancelPendingRetry, [cancelPendingRetry]);
 
   return {
     audiobooks,
@@ -273,6 +364,8 @@ export function useLibraryQuery({
     totalCount,
     setTotalCount,
     loading,
+    loadError,
+    isRetrying,
     totalPages,
     softDeletedBooks,
     softDeletedCount,

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.78.1
+// version: 1.79.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-08-08
 
@@ -662,6 +662,8 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     setAudiobooks,
     totalCount,
     loading,
+    loadError,
+    isRetrying,
     totalPages,
     softDeletedBooks,
     softDeletedCount,
@@ -1901,6 +1903,8 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
         <LibraryBookGrid
           audiobooks={audiobooks}
           loading={loading}
+          loadError={loadError}
+          isRetrying={isRetrying}
           onCancelLoad={handleCancelLoad}
           searchQuery={searchQuery}
           setSearchQuery={setSearchQuery}


### PR DESCRIPTION
Fixes the owner's report: *"make sure the library never gives a no items unless it's first startup. Always show the loading and continue to retry and load the library items."*

## What was wrong

Restarting the backend made the Library announce **"No Audiobooks Found"** — to someone with a 44,000-book library. It was never true; the request had simply failed.

Two things combined:

1. `useLibraryQuery` answered a failed load with `setAudiobooks([])` — **actively discarding whatever was on screen** — and its `finally` block then set `loading` to false.
2. `LibraryBookGrid` chose its empty state with `audiobooks.length === 0 && !loading && !searchQuery`, with **no error branch anywhere**. The component wasn't even passed one: its props carried only `loading: boolean`, so it was *structurally incapable* of telling a failed fetch from an empty library.

A failed request produced exactly the state that condition looks for.

**This is not an edge case.** Measured 2026-08-08: after `make deploy`, `/api/v1/system/status` refused connections for **~40 seconds** while memdb warmed over the library, then answered normally. Every single deploy hit this window.

## The fix

- **Failed loads no longer wipe the list.** The last known-good page stays on screen, so a mid-session blip leaves the shelf intact.
- **The empty state is gated on a load that actually succeeded.** The decision moved into a pure `libraryContentState()` helper whose branch order *is* the fix — `reconnecting` is checked before `empty`, so only a request that resolved with zero results may claim the library is empty.
- **Failed loads retry automatically**, exponential backoff from 500ms capped at 5s — deliberately well under the warmup window so the Library repopulates within seconds of the backend answering. Transient failures (network error, connection refused, 5xx) retry **indefinitely**, because they all resolve on their own and giving up would strand the user on a screen that never recovers without a manual refresh. A 4xx is a real client-side fault and is not retried. Explicit cancel stops the loop; the timer is cleared on unmount.

While unreachable, the user now sees "Loading your library…" with a note that this is normal for up to a minute after an update.

## Also included

Moves `isSubItemSelected` out of `Sidebar.tsx` into its own module, clearing a `react-refresh/only-export-components` warning **I introduced in #2193**. Net lint warnings go 25 → 24.

## Verification

- **442/442** tests across 65 files (up from 432 — 10 new)
- `tsc --noEmit` clean
- `eslint` 0 errors, 24 warnings (one fewer than the pre-existing baseline)

The new `libraryContentState.test.ts` includes an exhaustive sweep over every combination of `bookCount × loading × loadError × searchQuery`, asserting `empty` is reachable **only** from a clean, settled, genuinely-zero result. That's the invariant the bug violated.

**Not verified interactively.** The retry timing and the reconnecting copy are reasoned and unit-tested, not observed against a restarting backend. The natural check is to restart the service with the Library page open: it should show "Loading your library…" for the warmup window and then populate on its own, never claiming emptiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp