### PR TITLE
test(e2e): cover the Library sidebar filters — 6/6 green on chromium [skip changelog]

### DIFF
--- a/changelog.d/20260808_091500_e2e_sidebar_filter_coverage.md
+++ b/changelog.d/20260808_091500_e2e_sidebar_filter_coverage.md
@@ -1,0 +1,10 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+This PR adds e2e coverage for the Library sidebar filters and a todo fragment
+about wiring the e2e suite into CI. Neither changes behaviour, so there is
+nothing to tell a reader of CHANGELOG.md — the user-facing fix itself was
+already announced when #2193 shipped.
+-->

--- a/todo.d/20260808_085500_run_e2e_in_ci.md
+++ b/todo.d/20260808_085500_run_e2e_in_ci.md
@@ -1,0 +1,40 @@
+- [ ] **Nothing runs the e2e suite automatically — wire it into CI.** Found
+      2026-08-08 while adding sidebar-filter coverage. `grep -rl
+      "test-e2e\|test:e2e\|playwright test" .github/workflows/` returns
+      **nothing**. The suite exists, is maintained (43 specs were repaired
+      across #2185/#2187/#2191 this week), and gates nothing. A regression in
+      any of it lands on `main` unnoticed until someone runs `make test-e2e` by
+      hand.
+
+      That is exactly how the six spec files broken by the `_page` fixture error
+      stayed dead **from April to August 2026** — roughly four months of silent
+      rot, only noticed because #2178 happened to unmask it.
+
+      **Two traps to fix at the same time, or CI will lie to you:**
+
+      1. **`reuseExistingServer: !process.env.CI`** in
+         `web/tests/e2e/playwright.config.ts`. Locally this attaches to whatever
+         already listens on 127.0.0.1:8484 instead of building. On 2026-08-08 a
+         server left running since **00:31** was silently reused for hours,
+         producing a fully green 130-test suite that had exercised a frontend
+         bundle predating the fixes under test — and it was reported as
+         verification before the mistake was caught. The flag is already
+         disabled under `CI`, so CI itself is safe; the hazard is local runs and
+         anyone trusting them. Consider making the config refuse a server older
+         than the working tree, or dropping the flag entirely.
+      2. **Browser binaries drift per worktree.** A fresh `npm ci` in a new
+         worktree installed a Playwright wanting `webkit-2336`, which was not in
+         `~/Library/Caches/ms-playwright`, so every webkit test errored with
+         "Executable doesn't exist" — which reads like a test failure but is an
+         environment failure. CI needs an explicit `npx playwright install
+         --with-deps` step, and the distinction should be obvious in the logs.
+
+      **Cost consideration.** A full run is ~20 minutes (chromium + webkit) and
+      rebuilds frontend + Go binary, so it does not belong in the fast PR gate
+      alongside Minimal CI. Options worth weighing: chromium-only on PRs with
+      both engines nightly; or a required-but-slower job that runs in parallel
+      with the rest. Decide deliberately rather than defaulting to "everything
+      on every PR" and then disabling it when it gets annoying.
+
+      **Acceptance:** a PR that breaks any e2e spec fails a check, and the
+      failure names the spec rather than surfacing as a browser-launch error.

--- a/web/tests/e2e/library-sidebar-filters.spec.ts
+++ b/web/tests/e2e/library-sidebar-filters.spec.ts
@@ -1,9 +1,9 @@
 // file: web/tests/e2e/library-sidebar-filters.spec.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: 3c9a71e5-84fd-4b26-a0d7-6f2e5b81c934
 // last-edited: 2026-08-08
 
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 
 import { generateTestBooks, setupLibraryWithBooks } from './utils/test-helpers';
 
@@ -19,9 +19,44 @@ import { generateTestBooks, setupLibraryWithBooks } from './utils/test-helpers';
  *   2. A stuck `isInternalUpdate` guard in Library.tsx discarded the incoming
  *      `search` param and rewrote the URL back, so the click applied nothing.
  *
- * #2193 fixed both, but only with unit tests. These tests exercise the real
- * click path so a regression fails CI rather than being reported by the owner.
+ * #2193 fixed both, but only with unit tests. These exercise the real click
+ * path so a regression fails CI instead of being reported by the owner.
+ *
+ * NOTE for anyone running this locally: `playwright.config.ts` sets
+ * `reuseExistingServer: !process.env.CI`, so a stray server on 127.0.0.1:8484
+ * will be reused and you will silently test whatever bundle IT was built from.
+ * Confirm with `ps -o lstart -p $(lsof -ti :8484)` or kill it first.
  */
+
+/** The Library sub-item buttons, which live inside the collapsible group. */
+function subItems(page: Page): Locator {
+  return page.locator('.MuiCollapse-root:visible .MuiListItemButton-root');
+}
+
+/**
+ * Whichever sub-items are currently highlighted.
+ *
+ * Asserting on this set rather than on each item's class is deliberate: it
+ * states the real invariant — exactly one item is lit, and it is the right
+ * one — and it does not depend on resolving an individual button, which MUI
+ * makes awkward (the label sits in a nested node, so the computed accessible
+ * name does not equal the label).
+ *
+ * `:visible` and the `.MuiCollapse-root` scope are both load-bearing. Sidebar
+ * renders its content TWICE — once for the temporary (mobile) Drawer and once
+ * for the permanent one — so an unscoped `.Mui-selected` matches five elements
+ * on a plain /library visit: ["Library", "All Books", "", "Library",
+ * "All Books"]. Scoping to the Collapse drops the parent "Library" item, which
+ * is highlighted by pathname and is not one of these filters; `:visible` drops
+ * the offscreen duplicate drawer.
+ */
+function selectedSubItems(page: Page): Locator {
+  return page.locator('.MuiCollapse-root:visible .MuiListItemButton-root.Mui-selected');
+}
+
+function clickSubItem(page: Page, name: string) {
+  return subItems(page).filter({ hasText: new RegExp(`^${name}$`) }).click();
+}
 
 /** Records every audiobooks list request the page issues. */
 function recordBookRequests(page: Page): string[] {
@@ -33,107 +68,81 @@ function recordBookRequests(page: Page): string[] {
   return urls;
 }
 
-/**
- * The sidebar sub-item button.
- *
- * Filtered on exact text rather than `getByRole('button', { name })`: MUI's
- * ListItemButton wraps the label in a nested element alongside an icon, so the
- * computed accessible name does not match the label exactly.
- */
-function sidebarItem(page: Page, name: string) {
-  return page.getByRole('button').filter({ hasText: new RegExp(`^${name}$`) });
+async function openLibrary(page: Page) {
+  await setupLibraryWithBooks(page, generateTestBooks(5));
+  await page.goto('/library');
+  await page.waitForLoadState('networkidle');
 }
 
 test.describe('Library sidebar filters', () => {
+  test('a plain /library visit highlights All Books alone', async ({ page }) => {
+    await openLibrary(page);
+    await expect(selectedSubItems(page)).toHaveText(['All Books']);
+  });
+
   test('clicking In Progress moves the highlight off All Books', async ({ page }) => {
-    await setupLibraryWithBooks(page, generateTestBooks(5));
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
+    await openLibrary(page);
+    await expect(selectedSubItems(page)).toHaveText(['All Books']);
 
-    // GIVEN: a plain /library visit selects All Books.
-    await expect(sidebarItem(page, 'All Books')).toHaveClass(/Mui-selected/);
-    await expect(sidebarItem(page, 'In Progress')).not.toHaveClass(/Mui-selected/);
+    await clickSubItem(page, 'In Progress');
 
-    // WHEN: the user clicks In Progress.
-    await sidebarItem(page, 'In Progress').click();
-    await page.waitForLoadState('networkidle');
-
-    // THEN: the highlight actually moves. Before #2193 the comparison was
-    // against location.pathname, so All Books stayed lit forever.
-    await expect(sidebarItem(page, 'In Progress')).toHaveClass(/Mui-selected/);
-    await expect(sidebarItem(page, 'All Books')).not.toHaveClass(/Mui-selected/);
+    // Before #2193 the comparison was against location.pathname, so All Books
+    // stayed lit forever and In Progress could never match.
+    await expect(selectedSubItems(page)).toHaveText(['In Progress']);
   });
 
   test('clicking In Progress survives the URL settling with page=1', async ({ page }) => {
-    await setupLibraryWithBooks(page, generateTestBooks(5));
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
-
-    await sidebarItem(page, 'In Progress').click();
-    await page.waitForLoadState('networkidle');
+    await openLibrary(page);
+    await clickSubItem(page, 'In Progress');
 
     // Library.tsx re-encodes the colon and appends page=1 once its effects
     // settle. The filter must survive that rewrite — the stuck guard used to
     // throw the search away and restore a bare page=1.
     await expect(page).toHaveURL(/[?&]search=read_status(%3A|:)in_progress/);
-
-    // Decoded comparison, mirroring how the sidebar decides selection.
-    const search = new URL(page.url()).searchParams.get('search');
-    expect(search).toBe('read_status:in_progress');
+    expect(new URL(page.url()).searchParams.get('search')).toBe('read_status:in_progress');
   });
 
   test('clicking In Progress sends the filter to the server', async ({ page }) => {
     const requests = recordBookRequests(page);
-    await setupLibraryWithBooks(page, generateTestBooks(5));
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
+    await openLibrary(page);
 
     const before = requests.length;
-    await sidebarItem(page, 'In Progress').click();
-    await page.waitForLoadState('networkidle');
+    await clickSubItem(page, 'In Progress');
+    await expect(page).toHaveURL(/search=read_status(%3A|:)in_progress/);
 
-    // THEN: a NEW list request went out carrying the read_status filter.
-    // This is the half of the bug the user described as "not actually
-    // filtering or adding any filter" — the click used to be a pure no-op,
-    // so no request with a filter was ever issued.
-    const after = requests.slice(before);
-    expect(after.length).toBeGreaterThan(0);
-    const filtered = after.filter((u) => {
-      const filters = new URL(u).searchParams.get('filters');
-      return !!filters && filters.includes('read_status') && filters.includes('in_progress');
-    });
-    expect(filtered.length).toBeGreaterThan(0);
+    // The half the owner described as "not actually filtering or adding any
+    // filter": the click used to be a pure no-op, so no filtered request was
+    // ever issued.
+    await expect
+      .poll(() =>
+        requests.slice(before).filter((u) => {
+          const f = new URL(u).searchParams.get('filters');
+          return !!f && f.includes('read_status') && f.includes('in_progress');
+        }).length
+      )
+      .toBeGreaterThan(0);
   });
 
   test('Finished is fixed by the same change', async ({ page }) => {
-    await setupLibraryWithBooks(page, generateTestBooks(5));
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
+    await openLibrary(page);
+    await clickSubItem(page, 'Finished');
 
-    await sidebarItem(page, 'Finished').click();
-    await page.waitForLoadState('networkidle');
-
-    await expect(sidebarItem(page, 'Finished')).toHaveClass(/Mui-selected/);
-    await expect(sidebarItem(page, 'All Books')).not.toHaveClass(/Mui-selected/);
+    await expect(selectedSubItems(page)).toHaveText(['Finished']);
     expect(new URL(page.url()).searchParams.get('search')).toBe('read_status:finished');
   });
 
   test('All Books clears the filter and takes the highlight back', async ({ page }) => {
-    await setupLibraryWithBooks(page, generateTestBooks(5));
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
-
-    await sidebarItem(page, 'In Progress').click();
-    await page.waitForLoadState('networkidle');
-    await expect(sidebarItem(page, 'In Progress')).toHaveClass(/Mui-selected/);
+    await openLibrary(page);
+    await clickSubItem(page, 'In Progress');
+    await expect(selectedSubItems(page)).toHaveText(['In Progress']);
 
     // All Books navigates with ?reset=1, which Library.tsx handles BEFORE its
     // echo guard — the reason it kept working even while the others were dead.
-    await sidebarItem(page, 'All Books').click();
-    await page.waitForLoadState('networkidle');
+    await clickSubItem(page, 'All Books');
 
-    await expect(sidebarItem(page, 'All Books')).toHaveClass(/Mui-selected/);
-    await expect(sidebarItem(page, 'In Progress')).not.toHaveClass(/Mui-selected/);
-    expect(new URL(page.url()).searchParams.get('search')).toBeNull();
+    await expect(selectedSubItems(page)).toHaveText(['All Books']);
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('search'))
+      .toBeNull();
   });
 });

--- a/web/tests/e2e/library-sidebar-filters.spec.ts
+++ b/web/tests/e2e/library-sidebar-filters.spec.ts
@@ -1,0 +1,139 @@
+// file: web/tests/e2e/library-sidebar-filters.spec.ts
+// version: 1.0.0
+// guid: 3c9a71e5-84fd-4b26-a0d7-6f2e5b81c934
+// last-edited: 2026-08-08
+
+import { test, expect, type Page } from '@playwright/test';
+
+import { generateTestBooks, setupLibraryWithBooks } from './utils/test-helpers';
+
+/**
+ * Regression coverage for the Library sidebar filter items (#2193).
+ *
+ * Two independent bugs made "In Progress" and "Finished" dead controls, and
+ * both were invisible to the existing suite:
+ *
+ *   1. The selected highlight compared `location.pathname` against a path that
+ *      carries a query string, so "In Progress" could never match while
+ *      "All Books" matched on every /library URL — the highlight was pinned.
+ *   2. A stuck `isInternalUpdate` guard in Library.tsx discarded the incoming
+ *      `search` param and rewrote the URL back, so the click applied nothing.
+ *
+ * #2193 fixed both, but only with unit tests. These tests exercise the real
+ * click path so a regression fails CI rather than being reported by the owner.
+ */
+
+/** Records every audiobooks list request the page issues. */
+function recordBookRequests(page: Page): string[] {
+  const urls: string[] = [];
+  page.on('request', (req) => {
+    const u = new URL(req.url());
+    if (u.pathname === '/api/v1/audiobooks') urls.push(req.url());
+  });
+  return urls;
+}
+
+/**
+ * The sidebar sub-item button.
+ *
+ * Filtered on exact text rather than `getByRole('button', { name })`: MUI's
+ * ListItemButton wraps the label in a nested element alongside an icon, so the
+ * computed accessible name does not match the label exactly.
+ */
+function sidebarItem(page: Page, name: string) {
+  return page.getByRole('button').filter({ hasText: new RegExp(`^${name}$`) });
+}
+
+test.describe('Library sidebar filters', () => {
+  test('clicking In Progress moves the highlight off All Books', async ({ page }) => {
+    await setupLibraryWithBooks(page, generateTestBooks(5));
+    await page.goto('/library');
+    await page.waitForLoadState('networkidle');
+
+    // GIVEN: a plain /library visit selects All Books.
+    await expect(sidebarItem(page, 'All Books')).toHaveClass(/Mui-selected/);
+    await expect(sidebarItem(page, 'In Progress')).not.toHaveClass(/Mui-selected/);
+
+    // WHEN: the user clicks In Progress.
+    await sidebarItem(page, 'In Progress').click();
+    await page.waitForLoadState('networkidle');
+
+    // THEN: the highlight actually moves. Before #2193 the comparison was
+    // against location.pathname, so All Books stayed lit forever.
+    await expect(sidebarItem(page, 'In Progress')).toHaveClass(/Mui-selected/);
+    await expect(sidebarItem(page, 'All Books')).not.toHaveClass(/Mui-selected/);
+  });
+
+  test('clicking In Progress survives the URL settling with page=1', async ({ page }) => {
+    await setupLibraryWithBooks(page, generateTestBooks(5));
+    await page.goto('/library');
+    await page.waitForLoadState('networkidle');
+
+    await sidebarItem(page, 'In Progress').click();
+    await page.waitForLoadState('networkidle');
+
+    // Library.tsx re-encodes the colon and appends page=1 once its effects
+    // settle. The filter must survive that rewrite — the stuck guard used to
+    // throw the search away and restore a bare page=1.
+    await expect(page).toHaveURL(/[?&]search=read_status(%3A|:)in_progress/);
+
+    // Decoded comparison, mirroring how the sidebar decides selection.
+    const search = new URL(page.url()).searchParams.get('search');
+    expect(search).toBe('read_status:in_progress');
+  });
+
+  test('clicking In Progress sends the filter to the server', async ({ page }) => {
+    const requests = recordBookRequests(page);
+    await setupLibraryWithBooks(page, generateTestBooks(5));
+    await page.goto('/library');
+    await page.waitForLoadState('networkidle');
+
+    const before = requests.length;
+    await sidebarItem(page, 'In Progress').click();
+    await page.waitForLoadState('networkidle');
+
+    // THEN: a NEW list request went out carrying the read_status filter.
+    // This is the half of the bug the user described as "not actually
+    // filtering or adding any filter" — the click used to be a pure no-op,
+    // so no request with a filter was ever issued.
+    const after = requests.slice(before);
+    expect(after.length).toBeGreaterThan(0);
+    const filtered = after.filter((u) => {
+      const filters = new URL(u).searchParams.get('filters');
+      return !!filters && filters.includes('read_status') && filters.includes('in_progress');
+    });
+    expect(filtered.length).toBeGreaterThan(0);
+  });
+
+  test('Finished is fixed by the same change', async ({ page }) => {
+    await setupLibraryWithBooks(page, generateTestBooks(5));
+    await page.goto('/library');
+    await page.waitForLoadState('networkidle');
+
+    await sidebarItem(page, 'Finished').click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(sidebarItem(page, 'Finished')).toHaveClass(/Mui-selected/);
+    await expect(sidebarItem(page, 'All Books')).not.toHaveClass(/Mui-selected/);
+    expect(new URL(page.url()).searchParams.get('search')).toBe('read_status:finished');
+  });
+
+  test('All Books clears the filter and takes the highlight back', async ({ page }) => {
+    await setupLibraryWithBooks(page, generateTestBooks(5));
+    await page.goto('/library');
+    await page.waitForLoadState('networkidle');
+
+    await sidebarItem(page, 'In Progress').click();
+    await page.waitForLoadState('networkidle');
+    await expect(sidebarItem(page, 'In Progress')).toHaveClass(/Mui-selected/);
+
+    // All Books navigates with ?reset=1, which Library.tsx handles BEFORE its
+    // echo guard — the reason it kept working even while the others were dead.
+    await sidebarItem(page, 'All Books').click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(sidebarItem(page, 'All Books')).toHaveClass(/Mui-selected/);
+    await expect(sidebarItem(page, 'In Progress')).not.toHaveClass(/Mui-selected/);
+    expect(new URL(page.url()).searchParams.get('search')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes the "not verified interactively" caveat on #2193 with real browser coverage. Six tests, **6/6 green on chromium against a freshly built app**:

- a plain `/library` visit highlights **All Books** alone
- clicking **In Progress** moves the highlight off All Books
- the URL survives `Library.tsx` settling it to `?search=read_status%3Ain_progress&page=1`
- the filter actually reaches the server as a `filters` param
- **Finished** is fixed by the same change
- **All Books** resets both the highlight and the query

That last-but-one is the half the owner described as *"not actually filtering or adding any filter."* It now has a test.

## Two locator lessons, baked into the helpers

**Sidebar renders its content twice** — once for the temporary (mobile) Drawer, once for the permanent one. An unscoped `.Mui-selected` matches **five** elements on a plain `/library` visit:

```
["Library", "All Books", "", "Library", "All Books"]
```

Scoping to `.MuiCollapse-root:visible` drops both the offscreen duplicate drawer *and* the parent "Library" item (highlighted by pathname, not one of these filters).

Asserting on the **set** of highlighted sub-items rather than each item's class also states the real invariant — exactly one is lit, and it's the right one — and avoids `getByRole(..., { name })`, which MUI defeats by nesting the label so the computed accessible name doesn't equal it.

## Honest limits

- **Webkit did not run.** This worktree's `npm ci` wants `webkit-2336`, absent from the local browser cache, so it errors at launch rather than failing a test. Chromium only.
- **This test gates nothing yet.** `grep -rl "test-e2e\|test:e2e\|playwright test" .github/workflows/` returns **nothing** — the e2e suite is not wired into CI at all. Added as a `todo.d` fragment, because that gap is exactly how six spec files stayed broken from **April to August 2026**. The fragment also records the `reuseExistingServer` trap and the per-worktree browser-binary drift, since wiring up CI without fixing those would just produce confident-looking noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp