### PR TITLE
ci(e2e): run the Playwright suite in CI — chromium on PRs, both engines nightly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,135 @@
+# file: .github/workflows/e2e.yml
+# version: 1.0.0
+# guid: 6a2f47c9-1e83-4d05-b7f6-92c4a0d81b3e
+# last-edited: 2026-08-08
+
+# Runs the Playwright end-to-end suite.
+#
+# Until now NOTHING ran this suite automatically. That is how six spec files,
+# silently broken by a bad fixture parameter in April 2026, stayed dead until
+# August — four months during which the suite existed, was maintained, and
+# caught nothing.
+#
+# Split by cost. A full run builds the frontend AND the Go binary and then
+# drives two browser engines; that is far too slow to sit in the fast PR gate
+# next to Minimal CI. So:
+#   - pull_request -> chromium only, which catches essentially all content
+#     drift and logic regressions
+#   - nightly      -> chromium + webkit, catching the engine-specific failures
+#     a single-engine PR run would miss
+#
+# Note on the stale-server trap: playwright.config.ts sets
+# `reuseExistingServer: !process.env.CI`. GitHub Actions sets CI=true, so CI
+# always builds its own server and can never attach to a stale one. The hazard
+# is purely local runs — see the todo entry; a local run silently reused a
+# server that was hours old on 2026-08-08 and produced a fully green suite
+# against a bundle predating the fixes under test.
+
+name: E2E
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'web/**'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/e2e.yml'
+  schedule:
+    - cron: '17 5 * * *' # 05:17 UTC nightly, off the :00 stampede
+  workflow_dispatch:
+    inputs:
+      projects:
+        description: 'Playwright projects to run'
+        required: false
+        type: choice
+        options:
+          - chromium
+          - chromium+webkit
+        default: chromium
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E (${{ github.event_name == 'pull_request' && 'chromium' || 'chromium + webkit' }})
+    runs-on: ubuntu-latest
+    # A full two-engine run measured ~20 minutes locally; allow generous
+    # headroom for a cold CI runner that must also build the Go binary.
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libtag1-dev
+
+      - name: Install npm dependencies
+        run: cd web && npm ci
+
+      # --with-deps is load-bearing, not boilerplate. Browser binaries are
+      # tied to the installed Playwright version, and a mismatch fails at
+      # LAUNCH ("Executable doesn't exist at .../webkit-NNNN") rather than as
+      # a test failure — which reads like a broken suite when it is a broken
+      # environment. Installing them explicitly here keeps that distinction
+      # obvious in the logs.
+      - name: Install Playwright browsers
+        env:
+          # Passed via env rather than interpolated into the script body.
+          # Neither value is attacker-controlled (event_name is a fixed enum,
+          # projects is a constrained choice input), but interpolating GitHub
+          # context straight into a shell command is the habit that produces
+          # workflow injections, so it is avoided uniformly.
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PROJECTS: ${{ inputs.projects }}
+        run: |
+          cd web
+          if [ "$EVENT_NAME" = "pull_request" ] || \
+             { [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INPUT_PROJECTS" != "chromium+webkit" ]; }; then
+            npx playwright install --with-deps chromium
+          else
+            npx playwright install --with-deps chromium webkit
+          fi
+
+      - name: Run E2E suite
+        env:
+          GOEXPERIMENT: jsonv2
+          CI: 'true'
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PROJECTS: ${{ inputs.projects }}
+        run: |
+          cd web
+          case "$EVENT_NAME" in
+            pull_request) PROJECTS="--project=chromium" ;;
+            workflow_dispatch)
+              if [ "$INPUT_PROJECTS" = "chromium+webkit" ]; then
+                PROJECTS="--project=chromium --project=webkit"
+              else
+                PROJECTS="--project=chromium"
+              fi
+              ;;
+            *) PROJECTS="--project=chromium --project=webkit" ;;
+          esac
+          echo "Running with: $PROJECTS"
+          npx playwright test -c tests/e2e/playwright.config.ts $PROJECTS --reporter=line

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,16 +134,21 @@ jobs:
           INPUT_PROJECTS: ${{ inputs.projects }}
         run: |
           cd web
+          # Array, not a string. A plain string would have to be left unquoted
+          # to split into separate arguments, which is exactly what shellcheck
+          # SC2086 flags — and quoting it would pass "--project=chromium
+          # --project=webkit" as ONE argument, which Playwright rejects. An
+          # array expands correctly AND lints clean.
           case "$EVENT_NAME" in
-            pull_request) PROJECTS="--project=chromium" ;;
+            pull_request) PROJECTS=(--project=chromium) ;;
             workflow_dispatch)
               if [ "$INPUT_PROJECTS" = "chromium+webkit" ]; then
-                PROJECTS="--project=chromium --project=webkit"
+                PROJECTS=(--project=chromium --project=webkit)
               else
-                PROJECTS="--project=chromium"
+                PROJECTS=(--project=chromium)
               fi
               ;;
-            *) PROJECTS="--project=chromium --project=webkit" ;;
+            *) PROJECTS=(--project=chromium --project=webkit) ;;
           esac
-          echo "Running with: $PROJECTS"
-          npx playwright test -c tests/e2e/playwright.config.ts $PROJECTS --reporter=line
+          echo "Running with: ${PROJECTS[*]}"
+          npx playwright test -c tests/e2e/playwright.config.ts "${PROJECTS[@]}" --reporter=line

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,6 +94,20 @@ jobs:
       # a test failure — which reads like a broken suite when it is a broken
       # environment. Installing them explicitly here keeps that distinction
       # obvious in the logs.
+      # Pre-build so playwright.config.ts's webServer only has to START the
+      # binary, not compile it. Without this the first CI run died on
+      # "Timed out waiting 120000ms from config.webServer" — the webServer
+      # command builds the frontend AND the Go binary, which does not fit in
+      # the old window on a cold runner with an empty Go build cache. The
+      # config timeout was raised too, but warming the caches here is what
+      # keeps the wait short rather than merely survivable.
+      - name: Pre-build frontend and Go binary
+        env:
+          GOEXPERIMENT: jsonv2
+        run: |
+          cd web && npm run build
+          cd .. && go build -tags embed_frontend -o audiobook-organizer .
+
       - name: Install Playwright browsers
         env:
           # Passed via env rather than interpolated into the script body.

--- a/changelog.d/20260808_163000_e2e_in_ci.md
+++ b/changelog.d/20260808_163000_e2e_in_ci.md
@@ -1,0 +1,31 @@
+### Added
+
+#### The end-to-end suite now runs in CI
+
+Until now **nothing** ran the Playwright suite automatically. It existed, was
+maintained, and gated nothing — which is how six spec files, silently broken by
+a bad fixture parameter in April 2026, stayed dead until August. Four months in
+which every one of those tests could have caught a regression and none of them
+could report it.
+
+Split by cost, because a full run builds the frontend *and* the Go binary and
+then drives two browser engines — far too slow to sit in the fast PR gate next
+to Minimal CI:
+
+- **pull requests** run chromium only, and only when `web/**` or Go sources
+  changed. That catches essentially all content drift and logic regressions.
+- **nightly** runs chromium and webkit, catching the engine-specific failures a
+  single-engine PR run would miss.
+- **manual dispatch** can request either.
+
+Playwright browsers are installed explicitly with `--with-deps`. That is
+load-bearing rather than boilerplate: browser binaries are pinned to the
+installed Playwright version, and a mismatch fails at *launch* — "Executable
+doesn't exist at .../webkit-NNNN" — which reads like a broken test suite when
+it is actually a broken environment.
+
+The companion `reuseExistingServer` hazard needs no fix here: the config
+disables reuse whenever `CI` is set, so CI always builds its own server. The
+danger is confined to local runs, where on 2026-08-08 a server left running for
+hours was silently reused and produced a fully green 130-test suite against a
+frontend bundle that predated the fixes under test.

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 // file: tests/e2e/playwright.config.ts
-// version: 1.7.0
+// version: 1.8.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
-// last-edited: 2026-06-23
+// last-edited: 2026-08-08
 
 import { defineConfig, devices } from '@playwright/test';
 import { fileURLToPath } from 'url';
@@ -70,7 +70,13 @@ export default defineConfig({
     // GOEXPERIMENT=jsonv2 is required for the Go backend (encoding/json/v2)
     command: `bash -c 'export GOEXPERIMENT=jsonv2 && cd ${__dirname}/../../.. && cd web && npm run build && cd .. && go build -tags embed_frontend -o audiobook-organizer . && rm -rf /tmp/ao-e2e-db && mkdir -p /tmp/ao-e2e-db /tmp/ao-e2e-books && ./audiobook-organizer serve --tls-cert "" --tls-key "" --host 127.0.0.1 --db /tmp/ao-e2e-db/e2e.pebble --dir /tmp/ao-e2e-books'`,
     url: 'http://127.0.0.1:8484',
-    timeout: 120000,
+    // The command above builds the frontend AND compiles the Go binary before
+    // it can serve anything. 120s was enough on a warm developer machine and
+    // nowhere near enough on a cold CI runner with an empty Go build cache —
+    // the first CI run of this suite died on exactly this. Raised to 10
+    // minutes: it is a ceiling, not a delay, so a warm local run still starts
+    // as fast as it ever did.
+    timeout: 600000,
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
**Nothing ran the e2e suite automatically.** It existed, was actively maintained (43 specs repaired across #2185/#2187/#2191 this week), and gated nothing.

That is how six spec files — silently broken by a bad fixture parameter in **April 2026** — stayed dead until **August**. Four months in which every one of those tests could have caught a regression and none could report it.

## Split by cost

A full run builds the frontend *and* the Go binary, then drives two browser engines. Measured ~20 minutes locally. That is far too slow to sit in the fast PR gate next to Minimal CI, so:

| Trigger | Engines | When |
|---|---|---|
| `pull_request` | chromium | only when `web/**` or Go sources change |
| `schedule` | chromium + webkit | nightly, 05:17 UTC (off the `:00` stampede) |
| `workflow_dispatch` | either | manual |

Chromium-on-PR catches essentially all content drift and logic regressions; the nightly two-engine run catches the engine-specific failures a single-engine run would miss.

**This PR self-tests** — the `paths` filter includes `.github/workflows/e2e.yml`, so the E2E job runs here.

## Two traps handled

**`--with-deps` is load-bearing, not boilerplate.** Browser binaries are pinned to the installed Playwright version, and a mismatch fails at *launch* — `Executable doesn't exist at .../webkit-NNNN` — which reads like a broken suite when it's a broken environment. I hit exactly this locally today.

**`reuseExistingServer` needs no fix here.** The config disables reuse whenever `CI` is set, so CI always builds its own server. The hazard is confined to local runs, where earlier today a server left up for hours was silently reused and produced a fully green 130-test suite against a bundle predating the fixes under test (retracted in #2198).

## Security

All GitHub context is passed through `env:` rather than interpolated into `run:` bodies. Neither value is attacker-controlled — `event_name` is a fixed enum, `projects` is a constrained `choice` — but interpolating context straight into shell is the habit that produces workflow injections, so it's avoided uniformly.

## Deliberately not included

**No artifact upload.** This repo SHA-pins every action and has no existing `upload-artifact` reference to copy. Inventing an unverified pin is worse than reading failures from the log. Worth adding once a pin can be verified against the real release.

YAML validated locally: `jobs=[e2e]`, `triggers=[pull_request, schedule, workflow_dispatch]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp