### PR TITLE
docs(execsum): retract "the suite can be trusted as a gate again" [skip changelog]

### DIFF
--- a/changelog.d/20260808_183500_execsum_retraction.md
+++ b/changelog.d/20260808_183500_execsum_retraction.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Corrects a claim in an executive summary. No product behaviour changed.
+-->

--- a/docs/executive-summaries/2026-08-08-the-safety-net-that-had-stopped-catching-executive-summary.md
+++ b/docs/executive-summaries/2026-08-08-the-safety-net-that-had-stopped-catching-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-08-the-safety-net-that-had-stopped-catching-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: b1ececb6-257a-4ad0-9722-453194d546da -->
 <!-- last-edited: 2026-08-08 -->
 
@@ -64,9 +64,24 @@ and pretending otherwise would put the suite right back where it started.
 tests, and not one of them was a real defect — the app has been behaving correctly
 throughout. The failures were entirely in the description of it.
 
-**The suite can be trusted as a gate again.** It is now safe to require these
-checks to pass before anything ships, which is what should have been true in April
-and would have caught the navigation upgrade going out unverified.
+**~~The suite can be trusted as a gate again.~~ — RETRACTED the same day.**
+This was written believing the whole suite passed. It does not. When the tests
+were finally run automatically, on a clean machine, for the first time ever, the
+score was **146 failed and 138 passed**. Roughly half the safety net is still on
+the floor.
+
+The claim above came from a run that looked clean and was not, for three separate
+reasons at once: it quietly reused a copy of the application that was hours out of
+date; it only actually ran 137 of 576 tests; and the way the command was written
+threw away the pass/fail answer entirely, so "it passed" was never something that
+had been measured.
+
+The thirty-four tests this work repaired are genuinely repaired, and the paragraph
+above them still stands. What is not true is that the rest of the suite is
+healthy. Running the tests automatically is what revealed that — on its first day,
+which is the strongest possible argument for having done it. The remaining
+failures are now written down and being worked through rather than sitting
+invisible.
 
 **The lesson is about disabled tests.** The six files were not deleted; they were
 silently skipped, and silence is indistinguishable from success. Where a feature


### PR DESCRIPTION
This morning's executive summary told you the e2e safety net was restored and that it was **"now safe to require these checks to pass before anything ships."** That was wrong, and it's the kind of wrong that matters — it's advice, and someone could have acted on it.

The first automated run on a clean machine scored **146 failed / 138 passed**. Roughly half the suite is red and always was.

## Why it looked green

Three independent problems, all failing in the same direction:

1. The run **reused an application build that was hours stale** (`reuseExistingServer`) — already retracted in #2198.
2. It **ran only 137 of 576 tests**. I saw "130 passed" and didn't ask why that was a strange number for a 576-test suite.
3. The command was piped through `tail`, so **the exit code I read as success was `tail`'s**, not Playwright's. The pass result was never measured at all.

Any one of these would have been enough to invalidate the reading. I had all three and reported confidence.

## What the retraction does

Written **in place** rather than deleting the sentence, so anyone re-reading sees what was believed and why it was wrong. That matters more than a clean document — a summary that quietly changes its mind teaches nobody anything.

The neighbouring claim is left intact and still stands: the 34 repaired tests found **no product defects**. That part was solid.

It also records the one thing that went right, because it's genuinely the point: automating the suite is exactly what exposed this, on its first day of existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp