### PR TITLE
docs(todo): e2e triage — local now matches CI exactly, and the 146 are one class [skip changelog]

### DIFF
--- a/changelog.d/20260808_191000_e2e_triage.md
+++ b/changelog.d/20260808_191000_e2e_triage.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Triage findings recorded in a todo fragment. No product behaviour changed.
+-->

--- a/todo.d/20260808_172000_e2e_suite_half_red.md
+++ b/todo.d/20260808_172000_e2e_suite_half_red.md
@@ -54,16 +54,45 @@
 
       **Work, in order:**
 
-      1. **Re-run the full suite locally with output captured to a file, not
-         piped into `tail`, and check `${PIPESTATUS[0]}`.** Establish why 439
-         tests did not run. This is cheap and must come first — every prior
-         local reading of this suite has been an artifact of how it was
-         invoked rather than a fact about the tests.
-      2. **Triage the 146 failures.** `auth-flow.spec.ts` fails early and
-         broadly (`toHaveURL` mismatches, `element(s) not found`), which smells
-         like one shared setup/auth problem cascading — the same shape as the
-         `{ data: ... }` envelope bug that accounted for 24 of the last 34
-         failures. Expect a small number of root causes, not 146.
+      1. ~~Re-run the full suite locally with output captured properly.~~
+         ✅ **DONE 2026-08-08 18:47.** Fresh build, port 8484 confirmed clear,
+         full output to a file, exit code read from Playwright itself
+         (`PLAYWRIGHT_EXIT=1`). Result: **146 failed / 138 passed / 4 skipped**
+         — *identical to CI*. Local and CI now agree test-for-test, so local
+         triage is trustworthy again. The earlier "130 passed" was entirely an
+         artifact of the truncating pipe plus the stale server; there was never
+         a collection problem.
+      2. **Triage the 146 failures.** ⚠️ **The "expect a small number of root
+         causes" guess above was wrong and is corrected here.** It is not one
+         cascading bug. It is **the same failure CLASS spread across 22 spec
+         files that nobody has refreshed yet**:
+
+           26 dedup                 7 scan-import-organize   3 diagnostics
+           14 library-browser       7 backup-restore         2 itunes-import
+           12 metadata-provenance   6 version-management     2 error-handling
+           11 transcode-and-counting 6 dynamic-ui-interactions 2 auth-flow
+           11 batch-operations      5 settings-configuration  1 settings-ai-persistence
+           10 search-and-filter     4 itunes-bidirectional-sync 1 library-enhancements
+            8 dedup-operations      4 files-history           1 import-paths
+                                    3 unified-dedup-tab
+
+         Error signatures across all 146: `toBeVisible` 67, `element(s) not
+         found` 64, `locator.click` 50, `strict mode violation` 9. That is
+         overwhelmingly "the test looks for an affordance the app no longer
+         renders" — the exact drift already fixed in waves 1 and 2.
+
+         **The strong evidence that this is tractable:** 13 spec files are
+         **fully green**, and they include *every* file repaired in waves 1
+         and 2 — `dashboard`, `book-detail`, `file-browser`,
+         `import-audiobook-file`, `operation-monitoring` — plus the two new
+         specs added 2026-08-08. The repair pattern works and holds; it has
+         simply never been applied to the other 22 files. This is 22 files of
+         known, mechanical work, not 146 mysteries.
+
+         Suggested order: biggest first (`dedup` 26, `library-browser` 14,
+         `metadata-provenance` 12), since shared helpers in those will likely
+         drop several files at once — that is how one `{ data: ... }` envelope
+         fix cleared 24 of 34 in wave 2.
       3. **Flip `continue-on-error` off** once green, and say so in the PR.
       4. **Correct the executive summary** rather than leaving a claim on the
          record that the safety net is restored when half of it is on the floor.


### PR DESCRIPTION
Step 1 of the filed triage is done, and it resolves every open question about this suite.

## Local and CI now agree exactly

Fresh build, port 8484 confirmed clear, full output to a file, exit code read from Playwright itself:

```
PLAYWRIGHT_EXIT=1
146 failed / 138 passed / 4 skipped
```

**Identical to CI.** The "collection gap" theory is fully dead — the earlier "130 passed" was entirely an artifact of the truncating pipe plus the stale server. Local triage is trustworthy again, which matters because it's ~20 minutes locally versus a CI round trip.

## The optimistic guess was wrong — corrected

I filed this expecting "a small number of root causes, not 146," by analogy with the `{ data: ... }` envelope bug that caused 24 of the last 34. That's not what this is.

It's **the same drift class across 22 spec files nobody has refreshed**:

| | | |
|---|---|---|
| 26 dedup | 7 scan-import-organize | 3 diagnostics |
| 14 library-browser | 7 backup-restore | 2 itunes-import |
| 12 metadata-provenance | 6 version-management | 2 error-handling |
| 11 transcode-and-counting | 6 dynamic-ui-interactions | 2 auth-flow |
| 11 batch-operations | 5 settings-configuration | 1 settings-ai-persistence |
| 10 search-and-filter | 4 itunes-bidirectional-sync | 1 library-enhancements |
| 8 dedup-operations | 4 files-history | 1 import-paths |
| | 3 unified-dedup-tab | |

Signatures: `toBeVisible` 67, `element(s) not found` 64, `locator.click` 50, `strict mode violation` 9 — overwhelmingly "the test looks for an affordance the app no longer renders."

## Why this is tractable, not grim

**13 spec files are fully green** — and they include *every* file repaired in waves 1 and 2 (`dashboard`, `book-detail`, `file-browser`, `import-audiobook-file`, `operation-monitoring`) plus the two specs added today.

The repair pattern works and holds. It has simply never been applied to the other 22 files. This is mechanical work at a known scale with a proven method, not 146 mysteries.

Suggested order is biggest-first (`dedup` 26, `library-browser` 14, `metadata-provenance` 12), since shared helpers there will likely clear several files at once — that's exactly how one envelope fix cleared 24 of 34 in wave 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp