### PR TITLE
docs(todo): dedup's 26 e2e failures are the known data-envelope bug [skip changelog]

### DIFF
--- a/changelog.d/20260808_193000_envelope_audit.md
+++ b/changelog.d/20260808_193000_envelope_audit.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Records a root-cause finding in a todo fragment. No product behaviour changed.
+-->

--- a/todo.d/20260808_193000_e2e_envelope_audit.md
+++ b/todo.d/20260808_193000_e2e_envelope_audit.md
@@ -1,0 +1,47 @@
+- [ ] **Audit every e2e mock handler against whether its app-side reader
+      unwraps `body.data`.** Likely the dominant cause of the 146 e2e failures,
+      and a systematic fix rather than 22 separate spec refreshes.
+
+      **Confirmed for `dedup.spec.ts` (26 failures, the largest single file).**
+      `src/services/api.ts:1402` reads:
+
+          const body = await response.json();
+          const data = body.data;
+          return { groups: data.groups || [], ... };
+
+      while `test-helpers.ts:825` mocks `/api/v1/authors/duplicates` as:
+
+          jsonResponse({ groups: dedup.groups, needs_refresh: ... })
+
+      — **unwrapped**. So `body.data` is `undefined`, the page renders zero
+      groups, and every assertion looking for an author heading fails. The spec
+      itself is fine; it passes real fixture groups in.
+
+      **Why this is probably not just dedup.** Wave 2 (#2191) fixed exactly this
+      envelope for **eight** endpoints — `/auth/status`, `/import-paths`,
+      `/authors`, `/series`, `/audiobooks/soft-deleted`, bare `/audiobooks/:id`,
+      `/audiobooks/:id/versions`, `/filesystem/*` — and those spec files are now
+      green. But **80 endpoints in `api.ts` unwrap `body.data`**. Eight are
+      covered. The remaining ~72 are unaudited, and `/authors/duplicates` being
+      broken is the first one anybody checked.
+
+      **⚠️ Confidence, stated honestly.** The dedup cause is *verified* by
+      reading both sides. The claim that this explains the other 21 files is
+      *plausible and unverified*. This estimate has already been revised twice
+      — first "a few cascading root causes", then "22 files of independent
+      drift" — so verify a second and third file before planning around it.
+      Cheapest check: pick a failing test in `library-browser.spec.ts` (14) and
+      `metadata-provenance.spec.ts` (12), find the endpoint its page calls, and
+      compare the mock's shape to the reader's.
+
+      **Suggested approach if it holds:** rather than hand-patching handlers one
+      at a time, make the envelope the default. A single helper — e.g. wrap
+      every `jsonResponse` body as `{ ...body, data: body }` unless the handler
+      opts out — matches what wave 2 already did piecemeal in
+      `test-helpers.ts` and would cover all ~72 at once. Opt-out matters:
+      endpoints that legitimately return bare arrays or non-envelope shapes must
+      not be double-wrapped.
+
+      **Do not skip or delete failing specs to make this go away.** Six files
+      were disabled-by-accident for four months and that is the incident this
+      entire thread exists to prevent.


### PR DESCRIPTION
Traced the largest failing spec file to a **verified** root cause, and it's one we've already fixed elsewhere.

## Confirmed for `dedup.spec.ts` (26 failures)

`src/services/api.ts:1402` reads:

```js
const body = await response.json();
const data = body.data;
return { groups: data.groups || [], ... };
```

`tests/e2e/utils/test-helpers.ts:825` mocks `/api/v1/authors/duplicates` as:

```js
jsonResponse({ groups: dedup.groups, needs_refresh: ... })
```

**Unwrapped.** So `body.data` is `undefined`, the page renders zero groups, and every assertion looking for an author heading fails. The spec itself is fine — it passes real fixture groups in.

## Why this probably isn't just dedup

Wave 2 (#2191) fixed exactly this envelope for **eight** endpoints, and those spec files are green today. But **80 endpoints in `api.ts` unwrap `body.data`**. Eight are covered. The other ~72 are unaudited — and `/authors/duplicates` is simply the first one anybody checked.

## Confidence, stated plainly

The dedup cause is **verified** by reading both sides. The generalisation to the other 21 files is **plausible and unverified**.

I've now revised this estimate twice — "a few cascading root causes," then "22 files of independent drift," now "possibly one systematic envelope gap." So the fragment says explicitly to confirm two more files before planning around it, and names the cheapest checks (`library-browser` 14, `metadata-provenance` 12).

## Suggested approach if it holds

Rather than hand-patching ~72 handlers, make the envelope the **default** in the mock — wrap every `jsonResponse` body as `{ ...body, data: body }` with an opt-out. That's what wave 2 did piecemeal. The opt-out matters: endpoints legitimately returning bare arrays must not be double-wrapped.

**Not an option:** skipping or deleting the failing specs. Six files were disabled-by-accident for four months and that's the incident this whole thread exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp