### PR TITLE
docs(todo): the envelope theory does not generalise — e2e causes are mixed [skip changelog]

### DIFF
--- a/changelog.d/20260808_195500_e2e_mixed_causes.md
+++ b/changelog.d/20260808_195500_e2e_mixed_causes.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Corrects a triage hypothesis in a todo fragment. No product behaviour changed.
+-->

--- a/todo.d/20260808_195500_e2e_causes_are_mixed.md
+++ b/todo.d/20260808_195500_e2e_causes_are_mixed.md
@@ -1,0 +1,34 @@
+- [ ] **The e2e failures have MIXED causes — do not plan a single systematic
+      fix.** Sampled 2026-08-08 after a fragment filed an hour earlier
+      speculated that one data-envelope gap might explain most of the 146.
+      **It does not.** Four files sampled, at least three distinct causes:
+
+      - **`dedup.spec.ts` (26)** — the data-envelope bug, *verified*.
+        `api.ts:1402` reads `body.data.groups`; the mock returns
+        `/authors/duplicates` unwrapped. Fix: wrap the handler.
+      - **`library-browser.spec.ts` (14)** — genuine affordance drift. The test
+        clicks `getByRole('combobox', { name: 'Sort by' })`; no such control
+        exists. Nothing to do with data shape.
+      - **`metadata-provenance.spec.ts` (12)** — book-detail page renders no
+        heading for the fixture book. Could be an envelope gap on a book
+        endpoint or a navigation change; not yet traced.
+      - **`search-and-filter.spec.ts` (10)** — behavioural, not structural. The
+        test searches, then asserts a non-matching book disappears; "The Hobbit"
+        stays visible. Either the mock never implements filtering, or search is
+        genuinely not filtering. **Worth tracing first** — it is the only one of
+        the four that might indicate a real product defect rather than test rot,
+        and it sits next to the known server-side filtering weakness (an
+        unrecognised filter param returns the entire library with HTTP 200).
+
+      **Estimate history, kept deliberately.** This has now been framed three
+      ways in one evening: "a few cascading root causes" → "22 files of
+      independent drift" → "probably one envelope gap". The middle one was
+      closest. The third came from verifying exactly ONE file and generalising,
+      which is the same error each time — concluding from the first sample that
+      agreed with a convenient theory. Whoever picks this up should assume mixed
+      causes and re-sample rather than trust any single framing, including this
+      one.
+
+      **Practical consequence:** budget per-file work, not one sweep. The
+      envelope fix is still worth doing (it is cheap and clears the largest
+      file), but it will not clear the other 21.


### PR DESCRIPTION
An hour ago I filed that one data-envelope gap might explain most of the 146 e2e failures. I'd verified exactly **one** file and generalised. I sampled three more, and it's wrong.

| File | Cause |
|---|---|
| `dedup` (26) | Envelope bug — **verified** |
| `library-browser` (14) | `getByRole('combobox', { name: 'Sort by' })` doesn't exist — affordance drift |
| `metadata-provenance` (12) | Book-detail heading never renders — untraced |
| `search-and-filter` (10) | Search doesn't filter; a non-matching book stays visible |

At least **three distinct causes across four files**. The earlier "22 files of independent drift" framing was closest and is restored.

## One of these might be a real bug

`search-and-filter` is worth tracing **first**. It's the only sampled failure that could be a genuine product defect rather than test rot — the test searches, then asserts a non-matching book disappears, and "The Hobbit" stays visible. Either the mock never implements filtering, or search genuinely isn't filtering.

That sits uncomfortably close to the known server-side weakness where an unrecognised filter param returns the entire 44,874-book library with HTTP 200.

## Estimate history kept on purpose

This has been framed three ways in one evening: "a few cascading root causes" → "22 files of independent drift" → "probably one envelope gap." The error was **identical each time** — generalising from the first sample that agreed with a convenient theory.

The fragment says so explicitly and tells whoever picks it up to re-sample rather than trust any framing, **including this one**. That seemed more useful than presenting a fourth confident answer.

**Practical consequence:** budget per-file work, not one sweep. The envelope fix is still worth doing — it's cheap and clears the largest file — but it will not clear the other 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp