### PR TITLE
docs(todo): search-and-filter e2e failures are a mock gap, not a product bug [skip changelog]

### DIFF
--- a/changelog.d/20260808_205500_search_mock_gap.md
+++ b/changelog.d/20260808_205500_search_mock_gap.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Records a traced root cause in a todo fragment. No product behaviour changed.
+-->

--- a/todo.d/20260808_205500_e2e_search_mock_gap.md
+++ b/todo.d/20260808_205500_e2e_search_mock_gap.md
@@ -1,0 +1,39 @@
+- [ ] **`search-and-filter.spec.ts` (10 failures) is a MOCK gap, not a product
+      defect — the e2e mock's `/audiobooks` handler ignores every filter
+      param.** Traced 2026-08-08. This downgrades the earlier flag that it
+      "might indicate a real product defect"; it does not.
+
+      **The chain, verified end to end:**
+
+      - `api.searchBooksPage()` (`src/services/api.ts:1023`) issues
+        `GET /audiobooks?search=<q>&limit=&offset=&is_primary_version=true`.
+        It does **not** call `/audiobooks/search`.
+      - The mock's `/api/v1/audiobooks` handler
+        (`tests/e2e/utils/test-helpers.ts:768`) reads **only** `offset` and
+        `limit`. `search`, `filters`, `tags`, `library_state`,
+        `fingerprint_status` and the rest are all ignored; it returns
+        `mockState.books.slice(offset, offset+limit)`.
+      - So a search returns the whole library, the non-matching book stays on
+        screen, and `expect(...).not.toBeVisible()` fails. The app is behaving
+        correctly; the fake server is not.
+      - Dead code worth deleting or wiring up: the mock has a
+        `/api/v1/audiobooks/search` handler that filters properly, and
+        **nothing in `src/` calls that endpoint**.
+
+      **Explicitly ruled out:** the empty-state fix (#2195), which now preserves
+      the last known-good page when a load fails, is NOT implicated. The search
+      request succeeds — it just returns everything — so the preserved-list
+      behaviour never engages here.
+
+      **Fix:** teach the mock's `/audiobooks` handler to honour the params the
+      app actually sends. Minimum for this spec is `search`; doing `filters`
+      (the JSON field-filter array) at the same time is worth it, because the
+      In Progress / Finished sidebar filters ride on that param and any future
+      test of them would hit the identical wall.
+
+      **Note for the real backend work.** This is the mock, so it says nothing
+      about the server. But it rhymes with the open server-side task: an
+      unrecognised filter param on the real API returns the entire
+      44,874-book library with HTTP 200 rather than failing closed. Two
+      different layers, same failure mode — a filter that is ignored rather
+      than rejected looks exactly like a filter that matched everything.


### PR DESCRIPTION
I flagged `search-and-filter.spec.ts` (10 failures) as the one sampled file that "might indicate a real product defect." Traced it. **It doesn't** — and the trace is clean.

## The chain, verified end to end

- `api.searchBooksPage()` issues `GET /audiobooks?search=<q>&limit=&offset=…`. It does **not** call `/audiobooks/search`.
- The mock's `/api/v1/audiobooks` handler reads **only `offset` and `limit`**. `search`, `filters`, `tags`, `library_state` — all ignored. It returns `mockState.books.slice(offset, offset+limit)`.
- So a search returns the entire library, the non-matching book stays on screen, and `expect(...).not.toBeVisible()` fails.

**The app is behaving correctly. The fake server isn't.**

Dead code worth noting: the mock *does* have an `/audiobooks/search` handler that filters properly — and **nothing in `src/` calls that endpoint**.

## Explicitly ruled out: my own change

#2195 made failed loads preserve the last known-good page instead of clearing it. I specifically wanted to be sure that wasn't masking a search that had begun working. It isn't — the search request **succeeds**, it just returns everything, so the preserved-list path never engages.

## Fix

Teach the mock's `/audiobooks` handler to honour the params the app actually sends. Minimum is `search`; doing `filters` at the same time is worth it, because the In Progress / Finished sidebar filters ride on that param and any future test of them hits the identical wall.

## Worth noticing

This is the mock, so it says nothing about the server. But it **rhymes** with the open backend task: an unrecognised filter param on the real API returns the entire 44,874-book library with HTTP 200 instead of failing closed.

Two different layers, same failure mode — **a filter that is ignored looks exactly like a filter that matched everything.** That's the argument for failing closed in the real engine, now with a second concrete example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp