### PR TITLE
feat(library): Browse by Tag starts collapsed with a top-5 preview

### DIFF
--- a/changelog.d/20260808_225500_tag_cloud_todo.md
+++ b/changelog.d/20260808_225500_tag_cloud_todo.md
@@ -1,7 +1,16 @@
-<!--
-Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
-"Leave every section commented out for a release-note-only entry (no changelog
-line)."
+### Changed
 
-Adds a todo fragment only. No product behaviour changed.
--->
+#### "Browse by Tag" starts collapsed and previews the busiest tags
+
+On a library with hundreds of tags the tag cloud rendered every one of them,
+expanded by default, pushing the actual book grid below the fold. It now starts
+collapsed showing the **top 5 tags by count** plus a "Show all (N)" button, and
+remembers whether you opened it.
+
+Two details beyond the literal request. Tags are now **sorted in the component**
+rather than trusting the order they arrive in — only font size depended on
+`count` before, so an unsorted list was invisible, and slicing a preview off one
+would have silently shown "the first five" instead of "the busiest five". And
+any **selected** tag outside the preview is still shown while collapsed, because
+hiding an active filter leaves you looking at a filtered list with no visible
+way to clear it.

--- a/changelog.d/20260808_225500_tag_cloud_todo.md
+++ b/changelog.d/20260808_225500_tag_cloud_todo.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Adds a todo fragment only. No product behaviour changed.
+-->

--- a/todo.d/20260808_225500_tag_cloud_collapsed_by_default.md
+++ b/todo.d/20260808_225500_tag_cloud_collapsed_by_default.md
@@ -1,0 +1,47 @@
+- [ ] **"Browse by Tag" should start collapsed, or show only the top few tags.**
+      Reported by the owner 2026-08-08: *"Browse by tag should start minimized
+      as we have tons of tags or only show the top 5."* On a library this size
+      the tag cloud renders as a wall of chips that pushes the actual book grid
+      below the fold.
+
+      **Current behaviour** (`web/src/components/library/TagCloud.tsx`):
+
+      - Line 41: `const [expanded, setExpanded] = useState(true)` — it defaults
+        to **open**.
+      - It renders `availableTags.map(...)` with **no cap**: every tag in the
+        library, every time.
+      - The collapse machinery already exists (header row toggles, `Collapse`,
+        rotating chevron, correct `aria-label`), so "start minimized" is
+        essentially a one-word change.
+
+      **Two options the owner offered; they are not exclusive and the good
+      version is both:**
+
+      1. **Start collapsed** — flip line 41 to `useState(false)`. Trivial, and
+         it makes the component honest: a disclosure control whose default is
+         "already disclosed" is not doing anything.
+      2. **Show the top N (5) when collapsed-ish** — render a short preview row
+         of the highest-count tags with a "Show all (N)" affordance, so the
+         feature is still discoverable without costing a screenful. This is the
+         better UX of the two, because a fully collapsed panel gives no hint
+         that tags are worth browsing.
+
+      **⚠️ Verify sort order before slicing.** `availableTags` is passed
+      straight through from `Library.tsx` (lines 1971 and 1993 — note it feeds
+      **both** `TagCloud` and `FilterSidebar`) and **it has not been confirmed
+      that it arrives sorted by count descending**. `TagCloud` currently only
+      uses `count` for font size, where order does not matter, so a latent
+      sort bug would be invisible today and would silently make "top 5" mean
+      "first 5 alphabetically". Sort explicitly in the component rather than
+      trusting the caller.
+
+      **Persist the open/closed choice** in `localStorage` alongside the other
+      Library view preferences (`STORAGE_KEYS`), so someone who opens it does
+      not have to re-open it on every visit. Without that, "start collapsed"
+      trades one annoyance for another.
+
+      **Acceptance:** on a fresh visit to /library the book grid is visible
+      without scrolling past the tag cloud; tags remain reachable in one click;
+      and if a top-N preview is used, the tags shown are genuinely the most
+      common ones, verified against a library with many tags rather than a
+      handful of fixtures.

--- a/todo.d/20260808_225500_tag_cloud_collapsed_by_default.md
+++ b/todo.d/20260808_225500_tag_cloud_collapsed_by_default.md
@@ -1,4 +1,4 @@
-- [ ] **"Browse by Tag" should start collapsed, or show only the top few tags.**
+- [x] **"Browse by Tag" should start collapsed, or show only the top few tags.**
       Reported by the owner 2026-08-08: *"Browse by tag should start minimized
       as we have tons of tags or only show the top 5."* On a library this size
       the tag cloud renders as a wall of chips that pushes the actual book grid
@@ -45,3 +45,22 @@
       and if a top-N preview is used, the tags shown are genuinely the most
       common ones, verified against a library with many tags rather than a
       handful of fixtures.
+
+      **✅ SHIPPED same day.** Implemented as *both* options rather than either:
+
+      - Starts **collapsed** (`useState(readStoredExpanded)`, default false).
+      - Collapsed still shows the **top 5 by count** plus a "Show all (N)"
+        button, so the feature stays discoverable. A disclosure control that
+        reveals nothing tells the user nothing.
+      - **Sorted explicitly in the component** (`count` desc, then name), which
+        the note above flagged: the caller's order was never guaranteed and
+        slicing an unsorted list would have quietly shown "the first five".
+      - **Persisted** via `STORAGE_KEYS.LIBRARY_TAG_CLOUD_EXPANDED`, wrapped in
+        try/catch so private-browsing storage failures fall back to collapsed
+        rather than throwing.
+      - The header shows the total tag count while collapsed, so the panel says
+        how much is hidden.
+      - **Selected tags outside the top 5 are always shown** while collapsed.
+        This was not in the original request but is required for correctness:
+        hiding an active filter leaves the user looking at a filtered list with
+        no visible control to clear it.

--- a/web/src/components/library/TagCloud.test.tsx
+++ b/web/src/components/library/TagCloud.test.tsx
@@ -1,7 +1,7 @@
 // file: web/src/components/library/TagCloud.test.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 4f3d2c1b-8a9e-4d7c-b6a5-2e1f9c8d7b6a
-// last-edited: 2026-07-01
+// last-edited: 2026-08-08
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
@@ -23,7 +23,23 @@ function defaultProps(overrides: Partial<Parameters<typeof TagCloud>[0]> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The panel persists its open/closed state, so tests would otherwise leak
+  // into each other depending on execution order.
+  localStorage.clear();
 });
+
+/** Enough tags to exceed PREVIEW_COUNT (5), ordered so sorting is observable. */
+function manyTags() {
+  return [
+    { tag: 'alpha', count: 1 },
+    { tag: 'bravo', count: 90 },
+    { tag: 'charlie', count: 3 },
+    { tag: 'delta', count: 80 },
+    { tag: 'echo', count: 70 },
+    { tag: 'foxtrot', count: 60 },
+    { tag: 'golf', count: 50 },
+  ];
+}
 
 describe('TagCloud', () => {
   it('renders a chip for every available tag', () => {
@@ -77,12 +93,59 @@ describe('TagCloud', () => {
     expect(selectedChip).toHaveClass('MuiChip-colorPrimary');
   });
 
-  it('toggles collapse when the header is clicked', () => {
+  it('starts collapsed, so the book grid is not pushed below the fold', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    expect(screen.getByLabelText('Expand tag cloud')).toBeInTheDocument();
+  });
+
+  it('toggles open when the header is clicked', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    fireEvent.click(screen.getByText(/Browse by Tag/));
+    expect(screen.getByLabelText('Collapse tag cloud')).toBeInTheDocument();
+  });
+
+  it('shows only the top 5 tags by count while collapsed', () => {
+    renderWithProviders(<TagCloud {...defaultProps({ availableTags: manyTags() })} />);
+
+    // The five busiest, regardless of the order they were passed in.
+    for (const label of ['bravo (90)', 'delta (80)', 'echo (70)', 'foxtrot (60)', 'golf (50)']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    // The long tail stays hidden until asked for.
+    expect(screen.queryByText('charlie (3)')).not.toBeInTheDocument();
+    expect(screen.queryByText('alpha (1)')).not.toBeInTheDocument();
+  });
+
+  it('reveals the full cloud via "Show all"', () => {
+    renderWithProviders(<TagCloud {...defaultProps({ availableTags: manyTags() })} />);
+    fireEvent.click(screen.getByRole('button', { name: /Show all 7/ }));
+    expect(screen.getByText('alpha (1)')).toBeInTheDocument();
+    expect(screen.getByText('charlie (3)')).toBeInTheDocument();
+  });
+
+  // A selected tag outside the preview must stay visible, or the user is left
+  // looking at a filtered list with no visible control to clear it.
+  it('always shows a selected tag even when it falls outside the top 5', () => {
+    renderWithProviders(
+      <TagCloud {...defaultProps({ availableTags: manyTags(), selectedTags: ['alpha'] })} />
+    );
+    expect(screen.getByText('alpha (1)')).toBeInTheDocument();
+  });
+
+  it('renders each tag once while collapsed', () => {
+    renderWithProviders(<TagCloud {...defaultProps()} />);
+    // Regression guard: Collapse keeps children mounted by default, which
+    // rendered every chip twice (preview + hidden list) until unmountOnExit.
+    expect(screen.getAllByText('fantasy (100)')).toHaveLength(1);
+  });
+
+  it('remembers that the cloud was opened', () => {
+    const { unmount } = renderWithProviders(<TagCloud {...defaultProps()} />);
+    fireEvent.click(screen.getByText(/Browse by Tag/));
+    expect(screen.getByLabelText('Collapse tag cloud')).toBeInTheDocument();
+    unmount();
+
     renderWithProviders(<TagCloud {...defaultProps()} />);
     expect(screen.getByLabelText('Collapse tag cloud')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('Browse by Tag'));
-
-    expect(screen.getByLabelText('Expand tag cloud')).toBeInTheDocument();
   });
 });

--- a/web/src/components/library/TagCloud.tsx
+++ b/web/src/components/library/TagCloud.tsx
@@ -1,11 +1,13 @@
 // file: web/src/components/library/TagCloud.tsx
-// version: 1.0.0
+// version: 1.1.0
 // guid: 7e6c9a1d-3f2b-4c8e-9a5d-1b6f8e2c4d9a
-// last-edited: 2026-07-01
+// last-edited: 2026-08-08
 
 import { useMemo, useState } from 'react';
-import { Box, Chip, Collapse, IconButton, Stack, Typography } from '@mui/material';
+import { Box, Button, Chip, Collapse, IconButton, Stack, Typography } from '@mui/material';
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+
+import { STORAGE_KEYS } from '../../lib/storageKeys';
 
 export interface TagCloudProps {
   availableTags: Array<{ tag: string; count: number }>;
@@ -15,6 +17,14 @@ export interface TagCloudProps {
 
 const MIN_FONT_SIZE = 0.75; // rem
 const MAX_FONT_SIZE = 1.5; // rem
+
+/**
+ * How many tags to show while the cloud is collapsed.
+ *
+ * A fully collapsed panel gives no hint that tags are worth browsing, so the
+ * collapsed state still shows the busiest few rather than nothing at all.
+ */
+const PREVIEW_COUNT = 5;
 
 /**
  * Compute a font size (in rem) for a tag proportional to its count relative
@@ -31,29 +41,91 @@ function fontSizeForCount(count: number, maxCount: number): number {
   return Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, size));
 }
 
+function readStoredExpanded(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.LIBRARY_TAG_CLOUD_EXPANDED) === 'true';
+  } catch {
+    // Private browsing / storage disabled — fall back to the collapsed default.
+    return false;
+  }
+}
+
 /**
  * Browsable tag cloud for the main Library page. Reuses the existing
  * selectedTags/onTagsChange (handleTagFilterChange) state shared with
  * FilterSidebar so both UIs stay in sync. Tag chip font-size scales with
  * frequency (count) so heavily-used tags are visually larger.
+ *
+ * Starts COLLAPSED. On a library with hundreds of tags the expanded cloud is a
+ * wall of chips that pushes the book grid below the fold, which is what the
+ * page is actually for. Collapsed still shows the top few, so the feature stays
+ * discoverable — a disclosure control that reveals nothing tells the user
+ * nothing. The open/closed choice persists, so anyone who does want the full
+ * cloud only has to say so once.
  */
 export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloudProps) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(readStoredExpanded);
+
+  // Sort here rather than trusting the caller. `availableTags` is passed
+  // straight through from Library.tsx and is not guaranteed to arrive ordered
+  // by count; until now only font size depended on `count`, where order is
+  // irrelevant, so an unsorted list would have been invisible. Slicing a
+  // preview off an unsorted list would silently show "the first five" instead
+  // of "the busiest five".
+  const sortedTags = useMemo(
+    () => [...availableTags].sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag)),
+    [availableTags]
+  );
 
   const maxCount = useMemo(
     () => availableTags.reduce((max, t) => Math.max(max, t.count), 0),
     [availableTags]
   );
 
+  // While collapsed, always include any SELECTED tag that falls outside the
+  // preview. Hiding an active filter would leave the user looking at a filtered
+  // list with no visible control to clear it.
+  const previewTags = useMemo(() => {
+    const top = sortedTags.slice(0, PREVIEW_COUNT);
+    const shown = new Set(top.map((t) => t.tag));
+    const selectedOutside = sortedTags.filter((t) => selectedTags.includes(t.tag) && !shown.has(t.tag));
+    return [...top, ...selectedOutside];
+  }, [sortedTags, selectedTags]);
+
   if (availableTags.length === 0) {
     return null;
   }
+
+  const setExpandedPersisted = (next: boolean) => {
+    setExpanded(next);
+    try {
+      localStorage.setItem(STORAGE_KEYS.LIBRARY_TAG_CLOUD_EXPANDED, String(next));
+    } catch {
+      // Non-fatal: the panel still works for this session.
+    }
+  };
 
   const handleToggleTag = (tag: string) => {
     const exists = selectedTags.includes(tag);
     const newTags = exists ? selectedTags.filter((x) => x !== tag) : [...selectedTags, tag];
     onTagsChange(newTags);
   };
+
+  const renderChip = (t: { tag: string; count: number }) => {
+    const isSelected = selectedTags.includes(t.tag);
+    return (
+      <Chip
+        key={t.tag}
+        label={`${t.tag} (${t.count})`}
+        onClick={() => handleToggleTag(t.tag)}
+        color={isSelected ? 'primary' : undefined}
+        variant={isSelected ? 'filled' : 'outlined'}
+        sx={{ fontSize: `${fontSizeForCount(t.count, maxCount)}rem`, height: 'auto', py: 0.5 }}
+      />
+    );
+  };
+
+  const hiddenCount = sortedTags.length - previewTags.length;
 
   return (
     <Box sx={{ p: 1.5, border: 1, borderColor: 'divider', borderRadius: 1 }}>
@@ -62,15 +134,17 @@ export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloud
         alignItems="center"
         justifyContent="space-between"
         sx={{ cursor: 'pointer' }}
-        onClick={() => setExpanded((prev) => !prev)}
+        onClick={() => setExpandedPersisted(!expanded)}
       >
-        <Typography variant="subtitle2">Browse by Tag</Typography>
+        <Typography variant="subtitle2">
+          Browse by Tag{!expanded && sortedTags.length > 0 ? ` (${sortedTags.length})` : ''}
+        </Typography>
         <IconButton
           size="small"
           aria-label={expanded ? 'Collapse tag cloud' : 'Expand tag cloud'}
           onClick={(e) => {
             e.stopPropagation();
-            setExpanded((prev) => !prev);
+            setExpandedPersisted(!expanded);
           }}
         >
           <ExpandMoreIcon
@@ -81,22 +155,28 @@ export function TagCloud({ availableTags, selectedTags, onTagsChange }: TagCloud
           />
         </IconButton>
       </Stack>
-      <Collapse in={expanded}>
+
+      {!expanded && (
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1, alignItems: 'center' }}>
+          {previewTags.map(renderChip)}
+          {hiddenCount > 0 && (
+            <Button size="small" onClick={() => setExpandedPersisted(true)}>
+              Show all {sortedTags.length}
+            </Button>
+          )}
+        </Box>
+      )}
+
+      {/*
+        unmountOnExit is required, not cosmetic. Collapse keeps its children
+        mounted by default, so without it the collapsed state renders every
+        chip twice — once in the preview above, once hidden in here. That is a
+        duplicated accessible name for every tag, and it breaks any query that
+        expects a tag to appear once.
+      */}
+      <Collapse in={expanded} unmountOnExit>
         <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 1 }}>
-          {availableTags.map((t) => {
-            const isSelected = selectedTags.includes(t.tag);
-            const fontSize = fontSizeForCount(t.count, maxCount);
-            return (
-              <Chip
-                key={t.tag}
-                label={`${t.tag} (${t.count})`}
-                onClick={() => handleToggleTag(t.tag)}
-                color={isSelected ? 'primary' : undefined}
-                variant={isSelected ? 'filled' : 'outlined'}
-                sx={{ fontSize: `${fontSize}rem`, height: 'auto', py: 0.5 }}
-              />
-            );
-          })}
+          {sortedTags.map(renderChip)}
         </Box>
       </Collapse>
     </Box>

--- a/web/src/lib/storageKeys.ts
+++ b/web/src/lib/storageKeys.ts
@@ -1,7 +1,7 @@
 // file: web/src/lib/storageKeys.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5c8a3d7b-2e1f-4a9c-b3d5-1e8f2a9c7d4b
-// last-edited: 2026-06-19
+// last-edited: 2026-08-08
 
 /** Centralised localStorage key constants. */
 export const STORAGE_KEYS = {
@@ -19,6 +19,7 @@ export const STORAGE_KEYS = {
   METADATA_REVIEW_PAGE_SIZE: 'metadata-review-page-size',
   DEDUP_PAGE_SIZE: 'dedup-page-size',
   DEDUP_MULTI_SELECT: 'dedup-multi-select',
+  LIBRARY_TAG_CLOUD_EXPANDED: 'library-tag-cloud-expanded',
 } as const;
 
 export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];


### PR DESCRIPTION
> *"Browse by tag should start minimized as we have tons of tags or only show the top 5."*

Implemented as **both**, since either alone is worse: it starts collapsed, but collapsed still shows the five busiest tags plus a **Show all (N)** button. A disclosure control that reveals nothing gives no hint the feature is worth opening.

It also remembers whether you opened it, so anyone who wants the full cloud says so once.

## Three things beyond the literal request

Each because the obvious version is subtly wrong:

**Tags are sorted in the component.** `availableTags` comes straight through from `Library.tsx` and was never guaranteed ordered. Only font size depended on `count`, where order is irrelevant — so an unsorted list was invisible, and slicing a preview off it would have silently shown *"the first five"* instead of *"the busiest five"*.

**A selected tag outside the preview is always shown.** Hiding an active filter leaves you looking at a filtered list with no visible control to clear it.

**`Collapse` needs `unmountOnExit`.** It keeps children mounted by default, so the collapsed state rendered **every chip twice** — once in the preview, once in the hidden list — a duplicated accessible name for every tag.

## The existing tests caught my bug

There was already a `TagCloud.test.tsx` I hadn't checked for before writing. It failed immediately with `getMultipleElementsFoundError`, which is exactly the duplicate-render bug above. That's the only reason it didn't ship.

I updated the one test that asserted the old expanded-by-default behaviour, and added coverage for: collapsed default, top-5 **by count regardless of input order**, Show all, selected-tag-outside-preview, single render while collapsed, and persistence across remount. `localStorage` is cleared per test so persistence can't leak between them.

## Verification

- **448/448** frontend tests (up from 442)
- `tsc --noEmit` clean
- `eslint` 0 errors, 24 warnings (all pre-existing, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp