### PR TITLE
test(e2e): repair dedup spec and mock gaps — 146 failures down to 99 [skip changelog]

### DIFF
--- a/changelog.d/20260809_021500_e2e_dedup_repair.md
+++ b/changelog.d/20260809_021500_e2e_dedup_repair.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure repair only. No product behaviour changed.
+-->

--- a/todo.d/20260809_021500_unified_dedup_view_untested.md
+++ b/todo.d/20260809_021500_unified_dedup_view_untested.md
@@ -1,0 +1,22 @@
+- [ ] **The unified Dedup view has no e2e coverage at all.** Found 2026-08-09
+      while repairing `dedup.spec.ts`.
+
+      `/dedup` was redesigned: it now renders a unified candidate surface
+      (bands All / Certain / High / Medium / Review, a candidate table, "Find
+      Duplicates" / "Rescore" / "Force Full Rescan" actions). The old tabbed
+      Books / Authors / Series UI still exists but sits behind a **"Legacy
+      View"** toggle persisted as `sessionStorage.dedup_show_legacy`.
+
+      Every test in `dedup.spec.ts` covers the **legacy** view — they now opt
+      into it explicitly via `enableLegacyDedupView()`. That was the right fix
+      (the legacy features are still shipping and were previously untested by
+      accident), but it means the surface a user actually lands on has **zero**
+      automated coverage.
+
+      Worth covering: band filtering, the candidate table, merge/dismiss
+      actions, and the legacy toggle itself round-tripping through
+      sessionStorage.
+
+      Note the gap was invisible for the same reason the last one was: the
+      specs did not fail with "this UI no longer exists", they failed with
+      `element(s) not found`, which reads identically to a broken selector.

--- a/web/tests/e2e/dedup.spec.ts
+++ b/web/tests/e2e/dedup.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/dedup.spec.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-// last-edited: 2026-06-23
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -65,6 +65,31 @@ const booksForAuthor = [
   { id: 'b3', title: 'Oathbringer', author_name: 'Brandon Sanderson', cover_url: null },
 ];
 
+/**
+ * Opt into the legacy tabbed Dedup UI.
+ *
+ * /dedup was redesigned: it now renders a unified candidate view, and the
+ * tabbed Books/Authors/Series UI these tests cover sits behind a "Legacy View"
+ * toggle persisted in sessionStorage. Without this, `?tab=authors` renders the
+ * unified surface and every tab assertion fails with "element(s) not found".
+ *
+ * Must be called BEFORE page.goto — every test that navigates to /dedup needs
+ * it, including the ones that call page.goto directly rather than going
+ * through openDedupPage().
+ *
+ * The unified view itself is NOT covered by this spec; see the todo fragment
+ * filed alongside this change.
+ */
+async function enableLegacyDedupView(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      sessionStorage.setItem('dedup_show_legacy', '1');
+    } catch {
+      /* storage disabled — the test fails loudly rather than silently */
+    }
+  });
+}
+
 async function openDedupPage(page: Page, opts: {
   authorGroups?: MockAuthorDedupGroup[];
   seriesGroups?: MockSeriesDupGroup[];
@@ -87,6 +112,8 @@ async function openDedupPage(page: Page, opts: {
       body: JSON.stringify({ items: booksForAuthor, count: booksForAuthor.length }),
     });
   });
+
+  await enableLegacyDedupView(page);
 
   const tab = opts.tab ?? 'authors';
   await page.goto(`/dedup?tab=${tab}`);
@@ -169,10 +196,15 @@ test.describe('Author Dedup', () => {
       });
     });
 
+    // Arm the waiter BEFORE clicking. waitForRequest only observes requests
+    // made after it is called, and with the route above mocked the request
+    // fires and completes essentially instantly — so a waiter set up after the
+    // click could never see it. This was a race in the test, not app drift.
+    const resolveRequest = page.waitForRequest(req => req.url().includes('/resolve-production'));
+
     await page.getByRole('button', { name: /find real author/i }).first().click();
 
-    // Wait for the API request rather than sleeping — avoids flakiness under load.
-    await page.waitForRequest(req => req.url().includes('/resolve-production'));
+    await resolveRequest;
     expect(resolveCallCount).toBeGreaterThan(0);
   });
 
@@ -258,7 +290,7 @@ test.describe('Book Preview Popover', () => {
     await page.getByText('12 book(s)').click();
     await page.getByText('The Way of Kings').click();
 
-    await expect(page).toHaveURL(/\/books\/b1/);
+    await expect(page).toHaveURL(/\/library\/b1/);
   });
 
   test('popover closes when clicking outside', async ({ page }) => {
@@ -286,6 +318,7 @@ test.describe('Book Preview Popover', () => {
       });
     });
 
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -323,10 +356,14 @@ test.describe('Dedup Tab Navigation', () => {
       books: generateTestBooks(3),
       authorDedup: { groups: authorDedupGroups },
     });
+    await enableLegacyDedupView(page);
     await page.goto('/dedup');
     await page.waitForLoadState('networkidle');
 
-    const booksTab = page.getByRole('tab', { name: /books/i });
+    // TAB_NAMES[0] is still 'books', but its LABEL is now "Version Groups".
+    // /books/i matched "Split Books" — a different, correctly-unselected tab —
+    // so this assertion was checking the wrong element entirely.
+    const booksTab = page.getByRole('tab', { name: /version groups/i });
     await expect(booksTab).toHaveAttribute('aria-selected', 'true');
   });
 
@@ -420,7 +457,8 @@ test.describe('Dedup AI Review', () => {
   test('AI Review button is visible on authors tab', async ({ page }) => {
     await openDedupPage(page);
 
-    const aiBtn = page.getByRole('button', { name: /ai review/i });
-    await expect(aiBtn).toBeVisible();
+    // AI Review is a Tab in the legacy view (role="tab"), not a button.
+    const aiTab = page.getByRole('tab', { name: /ai review/i });
+    await expect(aiTab).toBeVisible();
   });
 });

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -267,6 +267,10 @@ export interface MockApiOptions {
   systemStatus?: Record<string, unknown>;
   authorDedup?: { groups: MockAuthorDedupGroup[]; needs_refresh?: boolean };
   seriesDedup?: { groups: MockSeriesDupGroup[]; total_series?: number };
+  /** Rows for GET /dedup/stats — the Dedup page fetches this on mount. */
+  dedupStats?: Array<{ entity_type: string; layer: string; status: string; count: number }>;
+  /** Rows for GET /dedup/candidates — also fetched on mount by the Dedup page. */
+  dedupCandidates?: unknown[];
   aiBackendsStatus?: {
     embedding_mode?: string;
     llm_mode?: string;
@@ -400,6 +404,8 @@ export async function setupMockApiRoutes(
     failures: options.failures || {},
     authorDedup: options.authorDedup || { groups: [] },
     seriesDedup: options.seriesDedup || { groups: [], total_series: 0 },
+    dedupStats: options.dedupStats || [],
+    dedupCandidates: options.dedupCandidates || [],
     aiBackendsStatus: {
       embedding_mode: 'disabled',
       llm_mode: 'disabled',
@@ -424,11 +430,39 @@ export async function setupMockApiRoutes(
     const method = request.method();
     console.log(`[Mock API] ${method} ${pathname}`);
 
-    const jsonResponse = (body: unknown, status = 200) => ({
-      status,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
+    /**
+     * Serialise a mock response, adding the `{ data: ... }` envelope the real
+     * API returns.
+     *
+     * 80 endpoints in `src/services/api.ts` read `body.data`. Wave 2 (#2191)
+     * hand-wrapped eight of them and the specs covering those went green; the
+     * rest were never audited, and an unwrapped handler leaves `body.data`
+     * undefined so the page renders nothing and every assertion fails. That is
+     * the single biggest cause in the 146-failure backlog.
+     *
+     * Wrapping here rather than per-handler is safe because the envelope is
+     * ADDITIVE: `{ ...body, data: body }` keeps every top-level key, so a
+     * reader doing `body.items` and a reader doing `body.data.items` both work.
+     * `data` points at the pre-spread object, so there is no self-reference for
+     * JSON.stringify to choke on.
+     *
+     * Two deliberate exclusions:
+     *  - Arrays. Spreading an array into an object yields `{0: ..., 1: ...}`
+     *    and breaks any `body.map(...)` reader.
+     *  - Bodies that already carry a `data` key, so hand-wrapped handlers and
+     *    error payloads are left exactly as they are.
+     */
+    const jsonResponse = (body: unknown, status = 200) => {
+      const envelope =
+        body && typeof body === 'object' && !Array.isArray(body) && !('data' in body)
+          ? { ...(body as Record<string, unknown>), data: body }
+          : body;
+      return {
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(envelope),
+      };
+    };
 
     // Failure injection helpers
     const maybeTimeout = (failure: number | string | undefined) => {
@@ -813,6 +847,24 @@ export async function setupMockApiRoutes(
         items: filtered.slice(0, limit),
         total: filtered.length,
       }));
+    }
+
+    // Page-level data for the Dedup page (pages/BookDedup.tsx). These are NOT
+    // optional extras: the page fetches both on mount, above the tab content,
+    // so leaving them unhandled meant the page never rendered and every tab —
+    // including Authors, whose own endpoint was mocked correctly — failed with
+    // "element(s) not found". They were logged 27 times per run as
+    // "Unhandled endpoint" and that warning was the only visible symptom.
+    if (pathname === '/api/v1/dedup/stats' && method === 'GET') {
+      return route.fulfill(jsonResponse({ stats: mockState.dedupStats ?? [] }));
+    }
+    if (pathname === '/api/v1/dedup/candidates' && method === 'GET') {
+      const limit = parseInt(url.searchParams.get('limit') || '50', 10);
+      const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+      const all = (mockState.dedupCandidates ?? []) as unknown[];
+      return route.fulfill(
+        jsonResponse({ candidates: all.slice(offset, offset + limit), total: all.length })
+      );
     }
 
     if (pathname === '/api/v1/audiobooks/duplicates' && method === 'GET') {


### PR DESCRIPTION
**`dedup.spec.ts`: 26 failed → 0 (27/27 passing).**
**Suite-wide: 146 failed / 138 passed → 99 failed / 185 passed.**

47 tests fixed — 26 in dedup, **21 elsewhere** from the shared mock changes.

## The root cause was not what triage predicted

I tested two hypotheses and *measured* each before finding the real one. Both moved the count by **zero**:

1. **The data-envelope gap.** Real and verified — `api.ts` reads `body.data`, the mock returned `/authors/duplicates` unwrapped. Fixed by making `jsonResponse` add the envelope **by default** (additive, so `body.items` and `body.data.items` both work; arrays and already-wrapped bodies skipped).
2. **`/dedup/stats` and `/dedup/candidates` were unhandled** — logged 27× per run as "Unhandled endpoint". Added handlers.

**The actual cause: `/dedup` was redesigned.** It now renders a unified candidate view, and the tabbed Books/Authors/Series UI the spec covers sits behind a **"Legacy View"** toggle in `sessionStorage`. The tests were asserting against a screen the app no longer shows by default. Opting in took it from 26 failures to 5.

Both earlier fixes are **kept** — they were genuine gaps, and the suite-wide delta proves it: 47 fixed versus 26 in dedup alone means the envelope default repaired tests in other files too.

## The last 5, diagnosed individually rather than pattern-matched

- Book detail route renamed `/books/:id` → `/library/:id`
- **"AI Review" is a `Tab` now, not a `Button`** — the role changed
- Two tests called `page.goto` directly, bypassing the legacy opt-in
- **"default tab is Books"**: that tab is *labelled* "Version Groups" now, and `/books/i` was matching **"Split Books"** — a different, correctly-unselected tab. The assertion had been checking the wrong element entirely.
- **"Find Real Author": a race in the test, not drift.** `waitForRequest` was armed *after* the click and cannot observe an already-fired request; against a mocked route it fires instantly. Waiter now armed first.

## Discipline

**No spec was deleted or skipped.** Six files were disabled-by-accident for four months and that's the incident this work exists to prevent.

Adds a `todo.d` fragment for a gap this surfaced: **the unified dedup view — the one users actually land on — has zero e2e coverage.** It was invisible for the same reason as the last gap, because the specs failed with `element(s) not found` rather than "this UI no longer exists".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp