### PR TITLE
test(e2e): make the mock honour query params — 99 failures down to 89 [skip changelog]

### DIFF
--- a/changelog.d/20260809_013000_e2e_mock_query_params.md
+++ b/changelog.d/20260809_013000_e2e_mock_query_params.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/changelog.d/20260809_021500_e2e_dedup_repair.md
+++ b/changelog.d/20260809_021500_e2e_dedup_repair.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure repair only. No product behaviour changed.
+-->

--- a/todo.d/20260809_013000_library_sort_control_gone.md
+++ b/todo.d/20260809_013000_library_sort_control_gone.md
@@ -1,0 +1,30 @@
+- [ ] **The library "Sort by" control no longer exists — 4 e2e tests target a
+      surface that is gone.** Found 2026-08-09 while repairing
+      `library-browser.spec.ts`.
+
+      `sorts books by title ascending` / `title descending` / `author` /
+      `date added` all do:
+
+          await page.getByRole('combobox', { name: 'Sort by' }).click();
+          await page.getByRole('option', { name: 'Title' }).click();
+
+      There is **no such control anywhere in the library UI**. Grepping the
+      components turns up no `Sort by` label and no sort dropdown in
+      `FilterPanel`, `LibraryToolbar` or `SearchBar`. Sorting now happens
+      through the table view's column headers
+      (`LibraryBookGrid`'s `handleColumnSortChange` → `ConfigurableTable` /
+      `AudiobookList`), which the default grid view does not show at all.
+
+      **This is a rewrite, not a selector tweak**, which is why it was left out
+      of the mock-fix PR: the tests must switch to list/table view first and
+      then drive column-header sorting, and the assertions about resulting
+      order need to match however that view renders.
+
+      The mock now honours `sort_by` / `sort_order` correctly (added
+      2026-08-09), so once the tests drive the real control the backend half of
+      this is already in place.
+
+      **Check before rewriting:** confirm sorting is genuinely still reachable
+      by a user in the default grid view. If it is not, that is a product
+      question — "you can no longer sort the library without switching views"
+      — and should be raised rather than encoded into a test.

--- a/todo.d/20260809_021500_unified_dedup_view_untested.md
+++ b/todo.d/20260809_021500_unified_dedup_view_untested.md
@@ -1,0 +1,22 @@
+- [ ] **The unified Dedup view has no e2e coverage at all.** Found 2026-08-09
+      while repairing `dedup.spec.ts`.
+
+      `/dedup` was redesigned: it now renders a unified candidate surface
+      (bands All / Certain / High / Medium / Review, a candidate table, "Find
+      Duplicates" / "Rescore" / "Force Full Rescan" actions). The old tabbed
+      Books / Authors / Series UI still exists but sits behind a **"Legacy
+      View"** toggle persisted as `sessionStorage.dedup_show_legacy`.
+
+      Every test in `dedup.spec.ts` covers the **legacy** view — they now opt
+      into it explicitly via `enableLegacyDedupView()`. That was the right fix
+      (the legacy features are still shipping and were previously untested by
+      accident), but it means the surface a user actually lands on has **zero**
+      automated coverage.
+
+      Worth covering: band filtering, the candidate table, merge/dismiss
+      actions, and the legacy toggle itself round-tripping through
+      sessionStorage.
+
+      Note the gap was invisible for the same reason the last one was: the
+      specs did not fail with "this UI no longer exists", they failed with
+      `element(s) not found`, which reads identically to a broken selector.

--- a/web/tests/e2e/dedup.spec.ts
+++ b/web/tests/e2e/dedup.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/dedup.spec.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-// last-edited: 2026-06-23
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -65,6 +65,31 @@ const booksForAuthor = [
   { id: 'b3', title: 'Oathbringer', author_name: 'Brandon Sanderson', cover_url: null },
 ];
 
+/**
+ * Opt into the legacy tabbed Dedup UI.
+ *
+ * /dedup was redesigned: it now renders a unified candidate view, and the
+ * tabbed Books/Authors/Series UI these tests cover sits behind a "Legacy View"
+ * toggle persisted in sessionStorage. Without this, `?tab=authors` renders the
+ * unified surface and every tab assertion fails with "element(s) not found".
+ *
+ * Must be called BEFORE page.goto — every test that navigates to /dedup needs
+ * it, including the ones that call page.goto directly rather than going
+ * through openDedupPage().
+ *
+ * The unified view itself is NOT covered by this spec; see the todo fragment
+ * filed alongside this change.
+ */
+async function enableLegacyDedupView(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      sessionStorage.setItem('dedup_show_legacy', '1');
+    } catch {
+      /* storage disabled — the test fails loudly rather than silently */
+    }
+  });
+}
+
 async function openDedupPage(page: Page, opts: {
   authorGroups?: MockAuthorDedupGroup[];
   seriesGroups?: MockSeriesDupGroup[];
@@ -87,6 +112,8 @@ async function openDedupPage(page: Page, opts: {
       body: JSON.stringify({ items: booksForAuthor, count: booksForAuthor.length }),
     });
   });
+
+  await enableLegacyDedupView(page);
 
   const tab = opts.tab ?? 'authors';
   await page.goto(`/dedup?tab=${tab}`);
@@ -169,10 +196,15 @@ test.describe('Author Dedup', () => {
       });
     });
 
+    // Arm the waiter BEFORE clicking. waitForRequest only observes requests
+    // made after it is called, and with the route above mocked the request
+    // fires and completes essentially instantly — so a waiter set up after the
+    // click could never see it. This was a race in the test, not app drift.
+    const resolveRequest = page.waitForRequest(req => req.url().includes('/resolve-production'));
+
     await page.getByRole('button', { name: /find real author/i }).first().click();
 
-    // Wait for the API request rather than sleeping — avoids flakiness under load.
-    await page.waitForRequest(req => req.url().includes('/resolve-production'));
+    await resolveRequest;
     expect(resolveCallCount).toBeGreaterThan(0);
   });
 
@@ -258,7 +290,7 @@ test.describe('Book Preview Popover', () => {
     await page.getByText('12 book(s)').click();
     await page.getByText('The Way of Kings').click();
 
-    await expect(page).toHaveURL(/\/books\/b1/);
+    await expect(page).toHaveURL(/\/library\/b1/);
   });
 
   test('popover closes when clicking outside', async ({ page }) => {
@@ -286,6 +318,7 @@ test.describe('Book Preview Popover', () => {
       });
     });
 
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -323,10 +356,14 @@ test.describe('Dedup Tab Navigation', () => {
       books: generateTestBooks(3),
       authorDedup: { groups: authorDedupGroups },
     });
+    await enableLegacyDedupView(page);
     await page.goto('/dedup');
     await page.waitForLoadState('networkidle');
 
-    const booksTab = page.getByRole('tab', { name: /books/i });
+    // TAB_NAMES[0] is still 'books', but its LABEL is now "Version Groups".
+    // /books/i matched "Split Books" — a different, correctly-unselected tab —
+    // so this assertion was checking the wrong element entirely.
+    const booksTab = page.getByRole('tab', { name: /version groups/i });
     await expect(booksTab).toHaveAttribute('aria-selected', 'true');
   });
 
@@ -420,7 +457,8 @@ test.describe('Dedup AI Review', () => {
   test('AI Review button is visible on authors tab', async ({ page }) => {
     await openDedupPage(page);
 
-    const aiBtn = page.getByRole('button', { name: /ai review/i });
-    await expect(aiBtn).toBeVisible();
+    // AI Review is a Tab in the legacy view (role="tab"), not a button.
+    const aiTab = page.getByRole('tab', { name: /ai review/i });
+    await expect(aiTab).toBeVisible();
   });
 });

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -798,17 +798,81 @@ export async function setupMockApiRoutes(
       );
     }
 
-    // Books endpoints
+    // Books endpoints.
+    //
+    // This handler used to read ONLY offset and limit, silently ignoring
+    // search, filters, tags, library_state and sort. That made every
+    // search/filter/sort assertion in the suite fail in the most confusing way
+    // possible: the request succeeded, the response looked fine, and the page
+    // simply showed every book. A filter that is IGNORED is indistinguishable
+    // from a filter that matched everything — the same failure mode the real
+    // API has (an unrecognised param returns the whole library with HTTP 200),
+    // which is tracked separately as the fail-closed work.
+    //
+    // Param names mirror src/services/api.ts getBooks() exactly; if that
+    // function gains a param, add it here or tests will silently over-match.
     if (pathname === '/api/v1/audiobooks' && method === 'GET') {
       const t = maybeTimeout(mockState.failures.getBooks); if (t) return t;
       const f = maybeFailStatus(mockState.failures.getBooks, 'Server error occurred.'); if (f) return f;
-      const offset = parseInt(url.searchParams.get('offset') || '0', 10);
-      const limit = parseInt(url.searchParams.get('limit') || '12', 10);
-      const paginatedBooks = mockState.books.slice(offset, offset + limit);
+
+      const q = url.searchParams;
+      const str = (b: Record<string, unknown>, k: string) => String(b[k] ?? '').toLowerCase();
+      let rows = [...(mockState.books as Array<Record<string, unknown>>)];
+
+      const search = (q.get('search') || '').toLowerCase().trim();
+      if (search) {
+        // Field-scoped syntax ("title:foo") is parsed client-side into the
+        // `filters` param, so anything arriving here is free text.
+        rows = rows.filter(
+          (b) =>
+            str(b, 'title').includes(search) ||
+            str(b, 'author_name').includes(search) ||
+            str(b, 'series_name').includes(search)
+        );
+      }
+
+      const libraryState = q.get('library_state');
+      if (libraryState) rows = rows.filter((b) => str(b, 'library_state') === libraryState.toLowerCase());
+
+      const tag = q.get('tag');
+      if (tag) {
+        rows = rows.filter((b) => {
+          const tags = b.tags;
+          return Array.isArray(tags) && tags.map((x) => String(x).toLowerCase()).includes(tag.toLowerCase());
+        });
+      }
+
+      // `filters` is a JSON array of { field, value, negated } produced by
+      // Library.tsx's buildFieldFilters().
+      const filtersRaw = q.get('filters');
+      if (filtersRaw) {
+        try {
+          const parsed = JSON.parse(filtersRaw) as Array<{ field: string; value: string; negated?: boolean }>;
+          for (const flt of parsed) {
+            rows = rows.filter((b) => {
+              const hit = str(b, flt.field) === String(flt.value).toLowerCase();
+              return flt.negated ? !hit : hit;
+            });
+          }
+        } catch {
+          // A malformed filters param is a test bug; failing loudly beats
+          // silently returning the whole library.
+          return route.fulfill(jsonResponse({ error: 'invalid filters param' }, 400));
+        }
+      }
+
+      const sortBy = q.get('sort_by');
+      if (sortBy) {
+        const dir = q.get('sort_order') === 'desc' ? -1 : 1;
+        rows.sort((a, b) => str(a, sortBy).localeCompare(str(b, sortBy)) * dir);
+      }
+
+      const offset = parseInt(q.get('offset') || '0', 10);
+      const limit = parseInt(q.get('limit') || '12', 10);
       return route.fulfill(
         jsonResponse({
-          items: paginatedBooks,
-          count: mockState.books.length,
+          items: rows.slice(offset, offset + limit),
+          count: rows.length,
           offset,
           limit,
         })

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -267,6 +267,10 @@ export interface MockApiOptions {
   systemStatus?: Record<string, unknown>;
   authorDedup?: { groups: MockAuthorDedupGroup[]; needs_refresh?: boolean };
   seriesDedup?: { groups: MockSeriesDupGroup[]; total_series?: number };
+  /** Rows for GET /dedup/stats — the Dedup page fetches this on mount. */
+  dedupStats?: Array<{ entity_type: string; layer: string; status: string; count: number }>;
+  /** Rows for GET /dedup/candidates — also fetched on mount by the Dedup page. */
+  dedupCandidates?: unknown[];
   aiBackendsStatus?: {
     embedding_mode?: string;
     llm_mode?: string;
@@ -400,6 +404,8 @@ export async function setupMockApiRoutes(
     failures: options.failures || {},
     authorDedup: options.authorDedup || { groups: [] },
     seriesDedup: options.seriesDedup || { groups: [], total_series: 0 },
+    dedupStats: options.dedupStats || [],
+    dedupCandidates: options.dedupCandidates || [],
     aiBackendsStatus: {
       embedding_mode: 'disabled',
       llm_mode: 'disabled',
@@ -424,11 +430,39 @@ export async function setupMockApiRoutes(
     const method = request.method();
     console.log(`[Mock API] ${method} ${pathname}`);
 
-    const jsonResponse = (body: unknown, status = 200) => ({
-      status,
-      contentType: 'application/json',
-      body: JSON.stringify(body),
-    });
+    /**
+     * Serialise a mock response, adding the `{ data: ... }` envelope the real
+     * API returns.
+     *
+     * 80 endpoints in `src/services/api.ts` read `body.data`. Wave 2 (#2191)
+     * hand-wrapped eight of them and the specs covering those went green; the
+     * rest were never audited, and an unwrapped handler leaves `body.data`
+     * undefined so the page renders nothing and every assertion fails. That is
+     * the single biggest cause in the 146-failure backlog.
+     *
+     * Wrapping here rather than per-handler is safe because the envelope is
+     * ADDITIVE: `{ ...body, data: body }` keeps every top-level key, so a
+     * reader doing `body.items` and a reader doing `body.data.items` both work.
+     * `data` points at the pre-spread object, so there is no self-reference for
+     * JSON.stringify to choke on.
+     *
+     * Two deliberate exclusions:
+     *  - Arrays. Spreading an array into an object yields `{0: ..., 1: ...}`
+     *    and breaks any `body.map(...)` reader.
+     *  - Bodies that already carry a `data` key, so hand-wrapped handlers and
+     *    error payloads are left exactly as they are.
+     */
+    const jsonResponse = (body: unknown, status = 200) => {
+      const envelope =
+        body && typeof body === 'object' && !Array.isArray(body) && !('data' in body)
+          ? { ...(body as Record<string, unknown>), data: body }
+          : body;
+      return {
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(envelope),
+      };
+    };
 
     // Failure injection helpers
     const maybeTimeout = (failure: number | string | undefined) => {
@@ -813,6 +847,24 @@ export async function setupMockApiRoutes(
         items: filtered.slice(0, limit),
         total: filtered.length,
       }));
+    }
+
+    // Page-level data for the Dedup page (pages/BookDedup.tsx). These are NOT
+    // optional extras: the page fetches both on mount, above the tab content,
+    // so leaving them unhandled meant the page never rendered and every tab —
+    // including Authors, whose own endpoint was mocked correctly — failed with
+    // "element(s) not found". They were logged 27 times per run as
+    // "Unhandled endpoint" and that warning was the only visible symptom.
+    if (pathname === '/api/v1/dedup/stats' && method === 'GET') {
+      return route.fulfill(jsonResponse({ stats: mockState.dedupStats ?? [] }));
+    }
+    if (pathname === '/api/v1/dedup/candidates' && method === 'GET') {
+      const limit = parseInt(url.searchParams.get('limit') || '50', 10);
+      const offset = parseInt(url.searchParams.get('offset') || '0', 10);
+      const all = (mockState.dedupCandidates ?? []) as unknown[];
+      return route.fulfill(
+        jsonResponse({ candidates: all.slice(offset, offset + limit), total: all.length })
+      );
     }
 
     if (pathname === '/api/v1/audiobooks/duplicates' && method === 'GET') {


### PR DESCRIPTION
**Suite-wide: 99 failed / 185 passed → 89 failed / 195 passed.**
`library-browser` + `search-and-filter` together: **24 failed → 14 failed / 19 passed.**

## What was wrong

The `/api/v1/audiobooks` mock read **only `offset` and `limit`**, silently ignoring `search`, `filters`, `tag`, `library_state`, and `sort_by`/`sort_order`. Every search/filter/sort assertion in the suite failed in the most confusing way available: the request succeeded, the response looked fine, and the page showed **every book**.

It now honours all of them, with param names mirroring `api.ts` `getBooks()` exactly — and a note that adding a param there without adding it here makes tests silently over-match. A malformed `filters` payload returns **400** rather than quietly falling back to the whole library.

## Worth naming

This is the same failure mode your real API has — an unrecognised param returns all 44,874 books with HTTP 200. **A filter that is ignored is indistinguishable from a filter that matched everything.** The comment in the handler says so, next to the fail-closed work it relates to. Two layers, one lesson.

## What this PR deliberately does not fix

The four `sorts books by …` tests, filed as a `todo.d` fragment instead. They drive:

```ts
page.getByRole('combobox', { name: 'Sort by' })
```

**That control does not exist anywhere in the library UI.** No `Sort by` label in `FilterPanel`, `LibraryToolbar` or `SearchBar`. Sorting moved to the table view's column headers, which the default grid view doesn't show.

That's a rewrite against a different surface, not a selector tweak — and it carries a **product question** worth asking first: if sorting is genuinely unreachable from the default grid view, that should be raised rather than encoded into a test. The mock now handles `sort_by`/`sort_order` correctly, so the backend half is ready whenever the tests drive the real control.

No spec was deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp