### PR TITLE
docs(todo): transcode-and-counting — two hypotheses tested and rejected [skip changelog]

### DIFF
--- a/changelog.d/20260809_040000_e2e_batch_operations.md
+++ b/changelog.d/20260809_040000_e2e_batch_operations.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/changelog.d/20260809_043000_transcode_findings.md
+++ b/changelog.d/20260809_043000_transcode_findings.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Documentation only — no code changed.
+-->

--- a/todo.d/20260809_040000_batch_operations_remaining.md
+++ b/todo.d/20260809_040000_batch_operations_remaining.md
@@ -1,0 +1,34 @@
+- [ ] **8 remaining failures in `batch-operations.spec.ts`** (down from 11), and
+      a caution about how they were approached.
+
+      **Fixed (3):** the "N selected" chip is rendered TWICE in the tree, so
+      `getByText('1 selected')` was always a strict-mode violation. Assertions
+      now use `.first()` — the behaviour under test is that the count shows, not
+      how many places show it. *(If that duplication is itself unintended, it is
+      a UI question worth asking separately.)*
+
+      **Verified renames applied:** the toolbar button "Fetch Metadata" is now
+      **"Fetch Selected"**, and "Deselect All" is now **"Deselect"** — read off
+      the app's rendered accessible names, not guessed.
+
+      **⚠️ Trap, hit and recorded:** the confirm button INSIDE the "Bulk Fetch
+      Metadata" dialog is **still "Fetch Metadata"** (`LibraryDialogs.tsx`
+      renders `Fetching…` / `Fetch Metadata`). A blanket find-and-replace of
+      "Fetch Metadata" → "Fetch Selected" therefore breaks the dialog-scoped
+      references. Only the toolbar button was renamed. The spec now carries a
+      comment at that call site.
+
+      **Still failing (8):** `deselects all books`, the five bulk-fetch tests,
+      `batch updates metadata field`, and `disables batch operations when no
+      books selected`. The count did NOT move across three separate attempts
+      (chip fix, renames, dialog-scope correction), which means the remaining
+      cause has not actually been found yet — the failures are almost certainly
+      NOT more label drift.
+
+      **Do this next, and do it first:** open the Playwright DOM snapshot for
+      one bulk-fetch failure (`test-results/*/error-context.md`) and read what
+      is actually on the page at the moment of failure. Every real cause found
+      in this repair effort — the dedup page being redesigned behind a "Legacy
+      View" toggle, metadata-provenance rendering the LOGIN screen, the book
+      sub-resources returning the book object — was found that way, and every
+      wrong guess came from reasoning about what *should* be there instead.

--- a/todo.d/20260809_043000_transcode_counting_findings.md
+++ b/todo.d/20260809_043000_transcode_counting_findings.md
@@ -1,0 +1,36 @@
+- [ ] **`transcode-and-counting.spec.ts` (11 failures) — two hypotheses tested
+      and REJECTED. Read this before trying either again.**
+      Investigated 2026-08-09; no code shipped, because nothing that was tried
+      improved the count and one attempt made it worse.
+
+      **What the page actually shows** (from the Playwright DOM snapshot, which
+      is the only thing that has reliably told the truth in this effort): the
+      Dashboard renders normally but **every count is 0** — Library Books,
+      Import Path Books, Authors, Series.
+
+      **Rejected hypothesis 1 — missing `{ data: ... }` envelope on the specs'
+      inline `page.route` overrides.** Real in principle: these tests call
+      `route.fulfill` directly, bypassing `jsonResponse()` in test-helpers, and
+      `api.getSystemStatus()` reads `body.data`. Wrapping all 11 success
+      payloads changed the result by **zero**. The envelope is not what is
+      breaking this file.
+
+      **Rejected hypothesis 2 — the mock ignoring `is_primary_version`.**
+      Reasoning looked sound: `api.getBooks()` always sends
+      `is_primary_version=true`, `countBooksFiltered()` reads
+      `body.data?.count` from that same endpoint, and the fixture is exactly 2
+      primary + 1 non-primary against an expected count of 2. Teaching the mock
+      to honour the param took failures from **11 to 12** — a regression. It
+      was reverted. Do not re-apply without understanding why it hurt.
+
+      **The one solid lead:** "Library Books" does NOT come from
+      `/system/status`, which is what these tests mock. It comes from
+      `api.countBooksFiltered()` → `GET /audiobooks?...` → `body.data?.count`
+      (`services/api.ts:1058`). So a test that overrides `/system/status` to
+      control the dashboard count is mocking the wrong endpoint entirely. That
+      is worth confirming as the root cause before writing any more code.
+
+      **Method note.** Every real cause found in this repair effort came from
+      reading `test-results/*/error-context.md` and looking at what was on the
+      page. Every wrong guess — including both above — came from reasoning
+      about what should be there. Look first.

--- a/web/tests/e2e/batch-operations.spec.ts
+++ b/web/tests/e2e/batch-operations.spec.ts
@@ -36,6 +36,13 @@ async function getFirstBookLabel(page: Page): Promise<string> {
   return label || 'Select Test Book 1';
 }
 
+/**
+ * NOTE: the "N selected" chip is rendered TWICE in the tree, so a bare
+ * getByText('1 selected') is a strict-mode violation ("resolved to 2
+ * elements"). These assertions use .first() — the behaviour under test is that
+ * the count is displayed, not how many places display it. If the duplication
+ * is itself unintended, that is a UI question, not a test one.
+ */
 test.describe('Batch Operations', () => {
   // Setup handled by arrangeLibrary() → setupLibraryWithBooks() → setupMockApi()
   // (includes skipWelcomeWizard + mockEventSource + setupMockApiRoutes)
@@ -48,7 +55,7 @@ test.describe('Batch Operations', () => {
     await selectFirstBooks(page, 1);
 
     // Assert
-    await expect(page.getByText('1 selected')).toBeVisible();
+    await expect(page.getByText('1 selected').first()).toBeVisible();
   });
 
   test('selects multiple books with individual checkboxes', async ({
@@ -61,7 +68,7 @@ test.describe('Batch Operations', () => {
     await selectFirstBooks(page, 5);
 
     // Assert
-    await expect(page.getByText('5 selected')).toBeVisible();
+    await expect(page.getByText('5 selected').first()).toBeVisible();
   });
 
   test('selects all books on current page', async ({ page }) => {
@@ -72,7 +79,7 @@ test.describe('Batch Operations', () => {
     await page.getByLabel('Select All').click();
 
     // Assert
-    await expect(page.getByText('20 selected')).toBeVisible();
+    await expect(page.getByText('20 selected').first()).toBeVisible();
   });
 
   test('deselects all books', async ({ page }) => {
@@ -81,10 +88,10 @@ test.describe('Batch Operations', () => {
     await page.getByLabel('Select All').click();
 
     // Act
-    await page.getByRole('button', { name: 'Deselect All' }).click();
+    await page.getByRole('button', { name: 'Deselect' }).click();
 
     // Assert
-    await expect(page.getByText('0 selected')).toBeVisible();
+    await expect(page.getByText('0 selected').first()).toBeVisible();
   });
 
   test('selection persists across page navigation', async ({ page }) => {
@@ -108,7 +115,7 @@ test.describe('Batch Operations', () => {
 
     // Act
     await page
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
+      .getByRole('button', { name: 'Fetch Selected', exact: true })
       .click();
     await page
       .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
@@ -127,7 +134,7 @@ test.describe('Batch Operations', () => {
 
     // Act
     await page
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
+      .getByRole('button', { name: 'Fetch Selected', exact: true })
       .click();
     await page
       .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
@@ -155,7 +162,7 @@ test.describe('Batch Operations', () => {
 
     // Act
     await page
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
+      .getByRole('button', { name: 'Fetch Selected', exact: true })
       .click();
     await page
       .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
@@ -179,7 +186,7 @@ test.describe('Batch Operations', () => {
 
     // Act
     await page
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
+      .getByRole('button', { name: 'Fetch Selected', exact: true })
       .click();
     await page
       .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
@@ -204,7 +211,7 @@ test.describe('Batch Operations', () => {
 
     // Act
     await page
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
+      .getByRole('button', { name: 'Fetch Selected', exact: true })
       .click();
     await page
       .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
@@ -278,7 +285,7 @@ test.describe('Batch Operations', () => {
       page.getByRole('button', { name: 'Batch Edit' })
     ).toBeDisabled();
     await expect(
-      page.getByRole('button', { name: 'Fetch Metadata', exact: true })
+      page.getByRole('button', { name: 'Fetch Selected', exact: true })
     ).toBeDisabled();
   });
 


### PR DESCRIPTION
**No code shipped for this file.** Both things I tried failed to help and one made it worse, so the negative results are the only useful output.

## Rejected hypothesis 1 — missing `{ data: … }` envelope

Real in principle: these tests call `route.fulfill` directly, bypassing `jsonResponse()` in test-helpers, and `api.getSystemStatus()` reads `body.data`. Wrapping all 11 success payloads changed the count by **zero**.

## Rejected hypothesis 2 — mock ignoring `is_primary_version`

The reasoning looked genuinely sound:
- `api.getBooks()` always sends `is_primary_version=true`
- `countBooksFiltered()` reads `body.data?.count` from that same endpoint
- the fixture is exactly **2 primary + 1 non-primary**, against an expected count of **2**

Teaching the mock to honour the param took failures from **11 → 12**. A regression. Reverted rather than shipped. Do not re-apply without understanding why it hurt.

## The one solid lead, recorded for whoever picks this up

**"Library Books" does not come from `/system/status`** — which is exactly what these tests mock. It comes from `api.countBooksFiltered()` → `GET /audiobooks?…` → `body.data?.count` (`services/api.ts:1058`).

So a test overriding `/system/status` to control the dashboard count is mocking the wrong endpoint entirely. Worth confirming as the root cause before writing any more code against this file.

## Method note

Every real cause found in this whole repair effort came from reading `test-results/*/error-context.md` and looking at what was actually on the page. Every wrong guess — including both above — came from reasoning about what *should* be there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp