### PR TITLE
test(e2e): dedup-operations fully green — 78 failures down to 73 [skip changelog]

### DIFF
--- a/changelog.d/20260809_050000_e2e_dedup_operations.md
+++ b/changelog.d/20260809_050000_e2e_dedup_operations.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/web/tests/e2e/dedup-operations.spec.ts
+++ b/web/tests/e2e/dedup-operations.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/dedup-operations.spec.ts
-// version: 1.2.0
+// version: 1.3.0
 // guid: e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b
-// last-edited: 2026-06-23
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -42,6 +42,28 @@ const mixedGroups: MockAuthorDedupGroup[] = [
   },
 ];
 
+
+/**
+ * Opt into the legacy tabbed Dedup UI.
+ *
+ * /dedup was redesigned: it renders a unified candidate view, and the tabbed
+ * Books/Authors/Series UI these tests cover sits behind a "Legacy View" toggle
+ * persisted as sessionStorage.dedup_show_legacy. Without this, ?tab=authors
+ * renders the unified surface and every assertion fails with
+ * "element(s) not found".
+ *
+ * Must run BEFORE page.goto. Same fix as dedup.spec.ts.
+ */
+async function enableLegacyDedupView(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      sessionStorage.setItem('dedup_show_legacy', '1');
+    } catch {
+      /* storage disabled — the test fails loudly rather than silently */
+    }
+  });
+}
+
 async function setupDedupWithOperations(page: Page, opts: {
   groups?: MockAuthorDedupGroup[];
   activeOps?: Array<Record<string, unknown>>;
@@ -77,6 +99,7 @@ async function setupDedupWithOperations(page: Page, opts: {
 test.describe('Production Company Resolution', () => {
   test('Find Real Author button only appears on production company groups', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -88,6 +111,7 @@ test.describe('Production Company Resolution', () => {
 
   test('production company badge is distinguishable from other groups', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -122,12 +146,20 @@ test.describe('Production Company Resolution', () => {
       });
     });
 
+    await enableLegacyDedupView(page);
+
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
+    // Arm the waiter BEFORE clicking. waitForRequest only observes requests
+    // made after it is called, and the route above is mocked so the request
+    // fires and completes essentially instantly — a waiter set up after the
+    // click can never see it. Same race as dedup.spec.ts had.
+    const resolveRequest = page.waitForRequest(req => req.url().includes('/resolve-production'));
+
     await page.getByRole('button', { name: /find real author/i }).first().click();
-    // Wait for the API request rather than sleeping — avoids flakiness under load.
-    await page.waitForRequest(req => req.url().includes('/resolve-production'));
+
+    await resolveRequest;
     expect(resolveCallCount).toBeGreaterThan(0);
   });
 });
@@ -137,6 +169,7 @@ test.describe('Production Company Resolution', () => {
 test.describe('Dedup Operation Progress', () => {
   test('merge operation shows success feedback', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -148,6 +181,7 @@ test.describe('Dedup Operation Progress', () => {
 
   test('split operation shows feedback', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -182,6 +216,7 @@ test.describe('Scheduler Tasks for Dedup', () => {
 
   test('manual task trigger creates operation', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -212,6 +247,8 @@ test.describe('Dedup Error Handling', () => {
       });
     });
 
+    await enableLegacyDedupView(page);
+
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -220,6 +257,7 @@ test.describe('Dedup Error Handling', () => {
 
   test('handles merge failure gracefully', async ({ page }) => {
     await setupDedupWithOperations(page);
+    await enableLegacyDedupView(page);
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');
 
@@ -248,6 +286,8 @@ test.describe('Dedup Error Handling', () => {
         body: JSON.stringify({ error: 'Resolution failed' }),
       });
     });
+
+    await enableLegacyDedupView(page);
 
     await page.goto('/dedup?tab=authors');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
**`dedup-operations.spec.ts`: 8 failed → 0. All 10 pass, exit 0.**
**Suite-wide: 78 failed / 206 passed → 73 failed / 211 passed.**

Both causes were already diagnosed in `dedup.spec.ts` and transferred exactly:

1. **The "Legacy View" toggle.** `/dedup` renders the unified candidate view; the tabbed Books/Authors/Series UI these tests drive sits behind a toggle persisted as `sessionStorage.dedup_show_legacy`. Added `enableLegacyDedupView()` before all 9 navigations — **that alone took 8 failures to 1**.
2. **The `waitForRequest` race.** The waiter was armed *after* the click, and against a mocked route the request fires instantly, so it could never observe it. Waiter now armed first.

## Worth noting

This file cost a fraction of what the previous four did, because both causes were already known and written down. The per-file `todo.d` fragments are earning their keep — the expensive part is diagnosis, and it transfers.

Contrast with `transcode-and-counting` in the previous cycle, where nothing was known and two reasonable hypotheses both failed.

No spec deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp