### PR TITLE
test(e2e): scan-import Settings deep-link — correct, but count unchanged at 7 [skip changelog]

### DIFF
--- a/changelog.d/20260809_051500_e2e_scan_import.md
+++ b/changelog.d/20260809_051500_e2e_scan_import.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/todo.d/20260809_051500_scan_import_settings_tab.md
+++ b/todo.d/20260809_051500_scan_import_settings_tab.md
@@ -1,0 +1,30 @@
+- [ ] **`scan-import-organize.spec.ts` (7 failures) — Settings tab deep-link
+      fixed, but that was NOT the blocker. Count unchanged at 7.**
+      Investigated 2026-08-09.
+
+      **Applied and kept (correct, but insufficient):** the tests navigated to
+      `/settings` and immediately clicked "Add Import Path". Settings is tabbed
+      now and defaults to **Library**; the button is rendered by
+      `components/settings/PathsSettingsTab.tsx:229`, mounted from
+      `pages/Settings.tsx:832`, i.e. only when the **Paths** tab is active.
+      `tabFromHash()` (`Settings.tsx:96`) maps a URL hash to a tab index via
+      `TAB_KEYS`, so `'/settings#paths'` is the app's own supported deep link.
+      All four navigations now use it.
+
+      **It did not help — still 7 failures**, all still timing out on
+      `getByRole('button', { name: 'Add Import Path' })`. So the Paths tab is
+      not rendering, or the Settings page is not reaching a usable state at
+      all. The change is kept because it is verifiably more correct than
+      `/settings`, not because it fixed anything.
+
+      **Next step, and do this before writing any code:** capture the DOM for
+      one of these failures specifically. `test-results/` was dominated by
+      other tests' directories, so the Settings page snapshot was never
+      actually read — which, given that reading the snapshot has found every
+      real cause in this effort, is the obvious gap. Run just this spec and
+      open `test-results/<dir>/error-context.md` for the workflow test.
+
+      Candidates worth checking once the snapshot is in hand: whether Settings
+      renders an error boundary from an unmocked endpoint, whether it redirects
+      (auth), and whether the tab panel is lazily mounted such that the
+      hash-selected index is applied after the click is attempted.

--- a/web/tests/e2e/scan-import-organize.spec.ts
+++ b/web/tests/e2e/scan-import-organize.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/scan-import-organize.spec.ts
-// version: 1.5.0
+// version: 1.6.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-// last-edited: 2026-03-02
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -202,6 +202,14 @@ const setupScanWorkflow = async (page: Page, options: ScanMockOptions) => {
   }, options);
 };
 
+
+// NOTE: navigate to '/settings#paths', not '/settings'.
+//
+// Settings is tabbed and defaults to the Library tab; "Add Import Path" is
+// rendered only by the Paths tab (components/settings/PathsSettingsTab.tsx).
+// A bare /settings therefore never shows the button and the click times out.
+// tabFromHash() in pages/Settings.tsx maps the URL hash to a tab index, with
+// slugs in TAB_KEYS — '#paths' is the app's own supported deep link.
 test.describe('Scan/Import/Organize Workflow', () => {
   // Setup handled per-test by setupScanWorkflow() or setupLibraryWithBooks()
   // setupLibraryWithBooks() calls setupMockApi() which includes skipWelcomeWizard + mockEventSource
@@ -246,7 +254,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
     });
 
     // Act: add import path and scan
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/audiobooks');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -306,7 +314,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
   }) => {
     // Arrange
     await setupScanWorkflow(page, { scanBooks: [] });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/books');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -333,7 +341,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
         },
       ],
     });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/cancel');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -369,7 +377,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
       ],
       scanErrors: ['Corrupt file: book2.m4b'],
     });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/corrupt');
     await page.getByRole('button', { name: 'Add Path' }).click();


### PR DESCRIPTION
**Failure count unchanged: 7.** Shipping this labelled honestly rather than as a fix.

## What was applied, and why it's kept

The tests navigate to `/settings` and immediately click "Add Import Path". Settings is **tabbed** now and defaults to **Library**; that button is rendered by `PathsSettingsTab.tsx:229`, mounted from `Settings.tsx:832` — i.e. only when the **Paths** tab is active.

`tabFromHash()` (`Settings.tsx:96`) maps a URL hash to a tab index via `TAB_KEYS`, so **`/settings#paths` is the app's own supported deep link**. All four navigations now use it.

That is verifiably more correct than `/settings`. It just isn't what's breaking these tests — all 7 still time out on the same button.

## The gap I should have closed first

`test-results/` was dominated by *other* tests' directories, so **I never actually read the Settings page snapshot for these failures.** Given that reading the DOM snapshot has found every genuine cause in this effort — the dedup "Legacy View" toggle, metadata-provenance rendering **Login**, book sub-resources returning the book object — that's the obvious next move, and the fragment says so.

Candidates to check once the snapshot is in hand: an error boundary from an unmocked endpoint, an auth redirect, or the tab panel mounting lazily so the hash-selected index applies after the click is attempted.

No spec deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp