### PR TITLE
test(e2e): scan-import auth + library_state fixture — 73 failures down to 66 [skip changelog]

### DIFF
--- a/changelog.d/20260809_051500_e2e_scan_import.md
+++ b/changelog.d/20260809_051500_e2e_scan_import.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/changelog.d/20260809_054500_e2e_scan_import_auth.md
+++ b/changelog.d/20260809_054500_e2e_scan_import_auth.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Test-infrastructure only. No product behaviour changed.
+-->

--- a/todo.d/20260809_051500_scan_import_settings_tab.md
+++ b/todo.d/20260809_051500_scan_import_settings_tab.md
@@ -1,0 +1,30 @@
+- [ ] **`scan-import-organize.spec.ts` (7 failures) — Settings tab deep-link
+      fixed, but that was NOT the blocker. Count unchanged at 7.**
+      Investigated 2026-08-09.
+
+      **Applied and kept (correct, but insufficient):** the tests navigated to
+      `/settings` and immediately clicked "Add Import Path". Settings is tabbed
+      now and defaults to **Library**; the button is rendered by
+      `components/settings/PathsSettingsTab.tsx:229`, mounted from
+      `pages/Settings.tsx:832`, i.e. only when the **Paths** tab is active.
+      `tabFromHash()` (`Settings.tsx:96`) maps a URL hash to a tab index via
+      `TAB_KEYS`, so `'/settings#paths'` is the app's own supported deep link.
+      All four navigations now use it.
+
+      **It did not help — still 7 failures**, all still timing out on
+      `getByRole('button', { name: 'Add Import Path' })`. So the Paths tab is
+      not rendering, or the Settings page is not reaching a usable state at
+      all. The change is kept because it is verifiably more correct than
+      `/settings`, not because it fixed anything.
+
+      **Next step, and do this before writing any code:** capture the DOM for
+      one of these failures specifically. `test-results/` was dominated by
+      other tests' directories, so the Settings page snapshot was never
+      actually read — which, given that reading the snapshot has found every
+      real cause in this effort, is the obvious gap. Run just this spec and
+      open `test-results/<dir>/error-context.md` for the workflow test.
+
+      Candidates worth checking once the snapshot is in hand: whether Settings
+      renders an error boundary from an unmocked endpoint, whether it redirects
+      (auth), and whether the tab panel is lazily mounted such that the
+      hash-selected index is applied after the click is attempted.

--- a/web/tests/e2e/scan-import-organize.spec.ts
+++ b/web/tests/e2e/scan-import-organize.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/scan-import-organize.spec.ts
-// version: 1.5.0
+// version: 1.6.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-// last-edited: 2026-03-02
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -202,6 +202,14 @@ const setupScanWorkflow = async (page: Page, options: ScanMockOptions) => {
   }, options);
 };
 
+
+// NOTE: navigate to '/settings#paths', not '/settings'.
+//
+// Settings is tabbed and defaults to the Library tab; "Add Import Path" is
+// rendered only by the Paths tab (components/settings/PathsSettingsTab.tsx).
+// A bare /settings therefore never shows the button and the click times out.
+// tabFromHash() in pages/Settings.tsx maps the URL hash to a tab index, with
+// slugs in TAB_KEYS — '#paths' is the app's own supported deep link.
 test.describe('Scan/Import/Organize Workflow', () => {
   // Setup handled per-test by setupScanWorkflow() or setupLibraryWithBooks()
   // setupLibraryWithBooks() calls setupMockApi() which includes skipWelcomeWizard + mockEventSource
@@ -246,7 +254,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
     });
 
     // Act: add import path and scan
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/audiobooks');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -306,7 +314,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
   }) => {
     // Arrange
     await setupScanWorkflow(page, { scanBooks: [] });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/books');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -333,7 +341,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
         },
       ],
     });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/cancel');
     await page.getByRole('button', { name: 'Add Path' }).click();
@@ -369,7 +377,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
       ],
       scanErrors: ['Corrupt file: book2.m4b'],
     });
-    await page.goto('/settings');
+    await page.goto('/settings#paths');
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     await page.getByLabel('Folder Path').fill('/test/corrupt');
     await page.getByRole('button', { name: 'Add Path' }).click();

--- a/web/tests/e2e/scan-import-organize.spec.ts
+++ b/web/tests/e2e/scan-import-organize.spec.ts
@@ -40,11 +40,23 @@ const setupScanWorkflow = async (page: Page, options: ScanMockOptions) => {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ importPaths, libraryBooks }));
     };
 
-    const jsonResponse = (body: unknown, status = 200) =>
-      new Response(JSON.stringify(body), {
+    // Adds the { data: ... } envelope the real API returns. This spec mocks by
+    // patching window.fetch rather than using page.route + setupMockApi, so it
+    // gets none of the shared handlers and needs its own copy.
+    //
+    // Additive: `{ ...body, data: body }` keeps every top-level key, so readers
+    // using `body.items` and readers using `body.data.items` both work. Arrays
+    // and already-wrapped bodies are left alone.
+    const jsonResponse = (body: unknown, status = 200) => {
+      const envelope =
+        body && typeof body === 'object' && !Array.isArray(body) && !('data' in body)
+          ? { ...(body as Record<string, unknown>), data: body }
+          : body;
+      return new Response(JSON.stringify(envelope), {
         status,
         headers: { 'Content-Type': 'application/json' },
       });
+    };
 
     const originalFetch = window.fetch.bind(window);
     window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
@@ -59,6 +71,22 @@ const setupScanWorkflow = async (page: Page, options: ScanMockOptions) => {
       const pathname = urlObj.pathname;
       const body = typeof init?.body === 'string' ? init.body : '';
       const payload = body ? JSON.parse(body) : {};
+
+      // Auth first. Without it the shim falls through to the real server, the
+      // auth check fails, and every page renders the LOGIN screen — which is
+      // why these tests timed out looking for buttons that were never going to
+      // be there. api.getAuthStatus() reads body.data, so the envelope matters.
+      if (pathname === '/api/v1/auth/status') {
+        return Promise.resolve(
+          jsonResponse({
+            has_users: true,
+            auth_enabled: false,
+            requires_auth: false,
+            authenticated: true,
+            user: { id: 'test-user', username: 'test', role: 'admin' },
+          })
+        );
+      }
 
       if (pathname === '/api/v1/import-paths' && method === 'GET') {
         return Promise.resolve(jsonResponse({ importPaths }));
@@ -91,7 +119,7 @@ const setupScanWorkflow = async (page: Page, options: ScanMockOptions) => {
         }
         libraryBooks = libraryBooks.map((book) => ({
           ...book,
-          library_state: 'import',
+          library_state: 'imported',
         }));
         saveState();
         return Promise.resolve(
@@ -400,7 +428,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
       ...baseBook,
       id: 'import-1',
       title: 'Import Book 1',
-      library_state: 'import',
+      library_state: 'imported',
       marked_for_deletion: false,
       file_path: '/imports/import-book-1.m4b',
     };
@@ -448,7 +476,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
       ...baseBook,
       id: 'import-dup',
       title: 'Duplicate Book (Import)',
-      library_state: 'import',
+      library_state: 'imported',
       file_hash: 'dup-hash',
       file_path: '/imports/duplicate.m4b',
     };
@@ -498,7 +526,7 @@ test.describe('Scan/Import/Organize Workflow', () => {
       ...book,
       id: `import-${index + 1}`,
       title: `Import Book ${index + 1}`,
-      library_state: 'import',
+      library_state: 'imported',
       organize_error: index === 2 ? 'Disk full' : undefined,
     }));
     await setupLibraryWithBooks(page, books, {


### PR DESCRIPTION
**`scan-import-organize.spec.ts`: 7 failed → 3 failed / 4 passed.**
**Suite-wide: 73 failed / 211 passed → 66 failed / 218 passed.**

## The method mattered more than the fix

Last cycle I guessed at Settings tabs on this file and moved the count by **zero**. This cycle I did what that cycle's fragment told me to do first: run **only** this spec so its `error-context.md` isn't buried under other tests' directories, then read it.

The page was the **Login screen**. One look, root cause.

## Two causes

**No `/auth/status` handler.** Like `metadata-provenance`, this spec mocks by patching `window.fetch` via `addInitScript`, so it inherits none of `setupMockApi`'s shared handlers. Every page rendered Login, and the tests timed out waiting for buttons that were never going to exist. Its local `jsonResponse` also gained the `{ data: … }` envelope, additively, for the same reason.

**The fixture set `library_state: 'import'`.** The app tests `book.library_state === 'imported'` (`useLibrarySelection.ts:53`), and `'imported'` is what the real API returns. So "Organize Selected" stayed **disabled** — correctly, because nothing importable was actually selected.

## That second one is a class worth naming

The button wasn't broken. The selector wasn't stale. **The fixture described a state the app doesn't have, and the UI disabled itself exactly as designed.** Every symptom pointed at the button; the cause was three files away in test data.

3 failures remain. No spec deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp