### PR TITLE
docs(todo): refresh e2e progress — 66 failed / 218 passed, was 146 / 138 [skip changelog]

### DIFF
--- a/changelog.d/20260809_053000_e2e_progress.md
+++ b/changelog.d/20260809_053000_e2e_progress.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Status documentation only. No product behaviour changed.
+-->

--- a/todo.d/20260809_053000_e2e_progress_refresh.md
+++ b/todo.d/20260809_053000_e2e_progress_refresh.md
@@ -1,0 +1,58 @@
+- [ ] **E2E repair progress — measured 2026-08-09. Supersedes the stale
+      "146 failures across 22 files" triage.**
+
+      **Suite: 66 failed / 218 passed / 4 skipped of 288 chromium tests.**
+      Down from 146 failed / 138 passed. **80 fixed, 55%**, across 8 merged
+      PRs (#2211-#2221). No spec has been deleted or skipped.
+
+      **Fully green now:** `dedup` (was 26), `dedup-operations` (was 8).
+
+      **Current distribution:**
+
+        12  library-browser          3  unified-dedup-tab
+        11  transcode-and-counting   3  scan-import-organize
+         8  batch-operations         2  search-and-filter
+         6  version-management       2  error-handling
+         6  dynamic-ui-interactions  1  settings-configuration
+         4  metadata-provenance      1  library-enhancements
+         4  files-history            1  import-paths
+                                     1  diagnostics
+                                     1  auth-flow
+
+      **Untouched, and therefore the best value per hour:**
+      `version-management` (6), `dynamic-ui-interactions` (6),
+      `files-history` (4), `unified-dedup-tab` (3), plus the tail of 1s and 2s.
+      Files already worked have had their cheap causes taken; what remains in
+      them is harder.
+
+      **THE METHOD, which is the most transferable thing here.** Run ONLY the
+      spec you are fixing, so `test-results/` is not buried under other tests'
+      directories, then read `test-results/<dir>/error-context.md` BEFORE
+      forming a hypothesis. Every genuine cause in this effort was found that
+      way:
+
+      - `/dedup` redesigned, tabbed UI behind a "Legacy View" toggle
+      - `metadata-provenance` and `scan-import-organize` rendering the LOGIN
+        screen because their window.fetch shims never mocked /auth/status
+      - book sub-resources returning the BOOK object, crashing on `.length`
+      - a fixture saying `library_state: 'import'` where the app checks
+        `'imported'`, so a button disabled itself correctly
+
+      Every wasted cycle came from reasoning about what *should* be on the page.
+      Two whole cycles were spent that way on `transcode-and-counting` and the
+      first pass at `scan-import-organize`.
+
+      **Second lesson: scope fixes narrowly.** Three separate times a correct
+      fix applied too broadly made things worse — a blanket `getByLabel` →
+      `getByRole` sweep took one file from 5 failures to 7; a blanket
+      "Fetch Metadata" rename broke the dialog button, which was never renamed.
+      Verify each site rather than pattern-replacing.
+
+      **Known causes are recorded per file** in the other todo.d fragments,
+      including two hypotheses already tested and REJECTED for
+      `transcode-and-counting` — read those before retrying it.
+
+      **Two open questions that are arguably product issues, not test rot:**
+      whether the library is still sortable without switching views (the
+      "Sort by" control does not exist anywhere), and whether the "N selected"
+      chip rendering twice is intentional.


### PR DESCRIPTION
The triage entry still said **"146 failures across 22 files"** with the original distribution — stale enough to send someone at files that are already green.

## Current state, measured

**66 failed / 218 passed / 4 skipped of 288.** Down from 146 / 138. **80 fixed (55%)** across 8 merged PRs. No spec deleted or skipped.

**Fully green:** `dedup` (was 26), `dedup-operations` (was 8).

| | | | |
|---|---|---|---|
| 12 library-browser | 6 dynamic-ui-interactions | 3 scan-import-organize | 1 library-enhancements |
| 11 transcode-and-counting | 4 metadata-provenance | 2 search-and-filter | 1 import-paths |
| 8 batch-operations | 4 files-history | 2 error-handling | 1 diagnostics |
| 6 version-management | 3 unified-dedup-tab | 1 settings-configuration | 1 auth-flow |

**Best value per hour: the untouched files** — `version-management` (6), `dynamic-ui-interactions` (6), `files-history` (4), `unified-dedup-tab` (3), and the tail. Files already worked have had their cheap causes taken.

## The method, written down because it transfers better than any single fix

Run **only** the spec you're fixing so `test-results/` isn't buried under other tests' directories, then read `error-context.md` **before** forming a hypothesis. Every genuine cause found this way:

- `/dedup` redesigned, tabbed UI behind a "Legacy View" toggle
- two specs rendering the **Login** screen because their `window.fetch` shims never mocked `/auth/status`
- book sub-resources returning the **book object**, crashing on `.length`
- a fixture saying `library_state: 'import'` where the app checks `'imported'` — so a button disabled itself *correctly*

Two entire cycles were wasted reasoning about what *should* be on the page instead.

## Second lesson: scope fixes narrowly

Three separate times a **correct** fix applied too broadly made things worse — a blanket `getByLabel` → `getByRole` sweep took one file from 5 failures to **7**; a blanket "Fetch Metadata" rename broke a dialog button that was never renamed.

## Two open product questions

Flagged rather than answered: whether the library is still **sortable without switching views** (the "Sort by" control doesn't exist anywhere), and whether the **"N selected" chip rendering twice** is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp