### PR TITLE
docs(todo): version-management relocated off book detail — spec needs a rewrite [skip changelog]

### DIFF
--- a/changelog.d/20260809_055000_version_mgmt_findings.md
+++ b/changelog.d/20260809_055000_version_mgmt_findings.md
@@ -1,0 +1,7 @@
+<!--
+Intentional no-op fragment. Per changelog.d/templates/new_fragment.md.j2:
+"Leave every section commented out for a release-note-only entry (no changelog
+line)."
+
+Documentation only — no code changed.
+-->

--- a/todo.d/20260809_055000_version_management_relocated.md
+++ b/todo.d/20260809_055000_version_management_relocated.md
@@ -1,0 +1,37 @@
+- [ ] **`version-management.spec.ts` (6 failures) — version management MOVED off
+      the book detail page. The spec needs a rewrite, not a selector tweak.**
+      Fully diagnosed 2026-08-09; no code changed, because the fix is a real
+      rewrite and a half-finished one is worse than none.
+
+      **What the tests do:** `openBookDetail()` navigates to `/library/<id>`
+      and each test then clicks `getByRole('button', { name: 'Manage
+      Versions' })` to open the linking UI.
+
+      **What the app does now:**
+
+      - `pages/BookDetail.tsx` does **not** import `VersionManagement` at all.
+        It renders `components/bookdetail/BookDetailVersionGroup.tsx`, which is
+        **read-only** — Bitrate, Duration, File, Origin, Path, Sample Rate,
+        Size. There is no link/unlink affordance on book detail.
+      - The interactive `VersionManagement` component is rendered from
+        `components/library/LibraryDialogs.tsx` and `pages/Library.tsx` — i.e.
+        from the **Library** page.
+      - "Manage Versions" is a **MenuItem inside the card's overflow menu**
+        (`components/audiobooks/AudiobookCard.tsx:336`), so its role is
+        `menuitem`, not `button`, and the menu must be opened first.
+
+      So the tests are driving a capability that page no longer has. The book
+      detail header still shows a "Version Group Linked" chip, which is why the
+      page *looks* right in the snapshot — it displays version state but cannot
+      change it.
+
+      **The rewrite:** point `openBookDetail()` (5 call sites) at `/library`,
+      open the target card's overflow menu, then click the **menuitem**
+      "Manage Versions". The dialog interactions after that point are likely
+      still valid, since `VersionManagement.tsx` itself was not replaced — only
+      relocated.
+
+      **Worth asking before doing it:** is losing version management from book
+      detail intentional? Managing versions of the book you are looking at is a
+      natural place for it, and it now requires going back to the library and
+      finding the card. That is a product question, not a test question.


### PR DESCRIPTION
**No code changed.** The fix here is a genuine rewrite, and a half-finished one at 5am is worse than none.

## What the tests do vs what the app does

The tests navigate to `/library/<id>` and click a **"Manage Versions" button**. But:

- `BookDetail.tsx` **no longer imports `VersionManagement`**. It renders `BookDetailVersionGroup.tsx`, which is **read-only** — Bitrate, Duration, File, Origin, Path, Sample Rate, Size. No link/unlink affordance exists on book detail.
- The interactive component now lives on the **Library** page, via `LibraryDialogs.tsx` / `Library.tsx`.
- "Manage Versions" is a **MenuItem inside the card's overflow menu** (`AudiobookCard.tsx:336`) — role `menuitem`, not `button`, and the menu must be opened first.

## Why this looked like selector rot

The book detail header still shows a **"Version Group Linked"** chip, so the page looks entirely correct in the DOM snapshot. It *displays* version state but can no longer *change* it. That's exactly the shape that makes a relocation read as a stale selector.

## The rewrite

Repoint `openBookDetail()` (5 call sites) at `/library`, open the target card's overflow menu, then click the **menuitem**. The dialog interactions after that point are probably still valid — `VersionManagement.tsx` wasn't replaced, only relocated.

## Worth asking first

**Is losing version management from book detail intentional?** Managing versions of the book you're currently looking at is a natural place for it, and it now requires going back to the library and finding the card. That's a product question, not a test question — so I'm flagging it rather than encoding the current behaviour into tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp