### PR TITLE
test(e2e): repair files-history mocks and stale assertions

### DIFF
--- a/changelog.d/20260809_120000_e2e_files_history.md
+++ b/changelog.d/20260809_120000_e2e_files_history.md
@@ -1,0 +1,4 @@
+<!--
+No user-facing change: this PR only repairs the Playwright e2e mocks and
+assertions for tests/e2e/files-history.spec.ts. No production code was touched.
+-->

--- a/todo.d/20260809-changelog-row-compare-affordance.md
+++ b/todo.d/20260809-changelog-row-compare-affordance.md
@@ -1,0 +1,24 @@
+<!-- file: todo.d/20260809-changelog-row-compare-affordance.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4b1f7c2e-9a83-4d16-b0e5-7c2a41d8f903 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Change Log rows lost their visible "Compare snapshot" affordance and are
+      mouse-only.** `web/src/components/ChangeLog.tsx:135-154` renders each entry as a
+      plain `<Box onClick={...}>` that fires `onCompareSnapshot` for `tag_write` /
+      `metadata_apply` entries. There is no `role`, no `tabIndex`, no keyboard
+      handler, and no label — the old "Compare snapshot" link that used to sit in the
+      row was removed. The flow itself still works end-to-end (verified in
+      `web/tests/e2e/files-history.spec.ts`: clicking the row does raise
+      `snapshot-comparison-banner` in the open format tray), so this is purely a
+      discoverability/accessibility gap, not a broken feature. Deciding what replaces
+      it is a product call: restore a visible link/button, or keep the row click and
+      give it `role="button"` + `tabIndex={0}` + Enter/Space activation + an
+      `aria-label`. Note the row already contains a Revert `<Button>` that calls
+      `stopPropagation`, so any keyboard handler has to not double-fire there.
+
+- [ ] **Dead `expanded` state in `TagComparison`.** `web/src/components/TagComparison.tsx:69`
+      is `useState(true)` and `setExpanded` is never called, so the `<Collapse in={expanded}>`
+      at line 249 is always open. Either drop the state and the `Collapse`, or wire up the
+      toggle that was evidently intended (the e2e suite still had a `tag-comparison-toggle`
+      testid assertion for it until 2026-08-09).

--- a/web/tests/e2e/files-history.spec.ts
+++ b/web/tests/e2e/files-history.spec.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/files-history.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: bd99e21f-38d1-4976-8ac2-43060c5fc17a
 
 import { expect, test } from '@playwright/test';
@@ -134,15 +134,43 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
       tagsData: typeof tags;
       changelogData: typeof changelog;
     }) => {
-      const jsonResponse = (body: unknown, status = 200) =>
-        new Response(JSON.stringify(body), {
+      // Adds the { data: ... } envelope the real API returns. This spec mocks
+      // by patching window.fetch rather than using page.route + setupMockApi,
+      // so it gets none of the shared handlers and needs its own copy.
+      // Additive — top-level keys are preserved, so both `body.x` and
+      // `body.data.x` readers work. Arrays and already-wrapped bodies are
+      // left alone.
+      const jsonResponse = (body: unknown, status = 200) => {
+        const envelope = Array.isArray(body)
+          ? { data: body }
+          : body && typeof body === 'object' && !('data' in body)
+            ? { ...(body as Record<string, unknown>), data: body }
+            : body;
+        return new Response(JSON.stringify(envelope), {
           status,
           headers: { 'Content-Type': 'application/json' },
         });
+      };
 
       const originalFetch = window.fetch.bind(window);
       window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input.url;
+
+        // Auth first. Without it the shim falls through to the real server,
+        // the auth check fails, and the app renders the LOGIN screen — so
+        // every assertion here was looking for a tab on a page that was never
+        // going to show it. api.getAuthStatus() reads body.data.
+        if (url.includes('/api/v1/auth/status')) {
+          return Promise.resolve(
+            jsonResponse({
+              has_users: true,
+              auth_enabled: false,
+              requires_auth: false,
+              authenticated: true,
+              user: { id: 'test-user', username: 'test', role: 'admin' },
+            })
+          );
+        }
 
         if (url.includes('/api/v1/health')) {
           return Promise.resolve(jsonResponse({ status: 'ok' }));
@@ -184,15 +212,25 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
           return Promise.resolve(jsonResponse({ versions: versionsData }));
         }
 
-        // Segments
+        // Segments (legacy). api.getBookSegments reads body.data, so a bare []
+        // would deserialise to undefined and crash the page on `.length`.
         if (url.includes('/segments')) {
           return Promise.resolve(jsonResponse([]));
         }
 
-        // External IDs
+        // Book files — the canonical endpoint BookDetail tries first. Without
+        // this branch the URL fell through to the book-detail catch-all below,
+        // which returned the book object; `result.files` was then undefined and
+        // the page fell back to /segments.
+        if (url.includes(`/api/v1/audiobooks/${injectedBookId}/files`)) {
+          return Promise.resolve(jsonResponse({ files: [], count: 0 }));
+        }
+
+        // External IDs. api.getBookExternalIDs reads the TOP-LEVEL body (no
+        // envelope) and destructures `external_ids` — not `ids`.
         if (url.includes('/external-ids')) {
           return Promise.resolve(
-            jsonResponse({ itunes_linked: false, total: 0, ids: [] })
+            jsonResponse({ itunes_linked: false, total: 0, external_ids: [] })
           );
         }
 
@@ -203,6 +241,7 @@ const setupRoutes = async (page: import('@playwright/test').Page) => {
           !url.includes('/versions') &&
           !url.includes('/changelog') &&
           !url.includes('/segments') &&
+          !url.includes('/files') &&
           !url.includes('/external-ids')
         ) {
           return Promise.resolve(jsonResponse(bookData));
@@ -254,24 +293,22 @@ test.describe('Files & History tab', () => {
     await expect(mp3Tray.getByText(/MP3/)).toBeVisible();
   });
 
-  test('tag comparison toggle and dropdown work', async ({ page }) => {
+  test('tag comparison table and dropdown render inside an open tray', async ({ page }) => {
     // Expand the M4B format tray
     const m4bTray = page.locator('[data-testid="format-tray-m4b"]');
     await m4bTray.click();
 
-    // Wait for tag comparison to load
-    const toggle = page.getByTestId('tag-comparison-toggle').first();
-    await expect(toggle).toBeVisible();
-
     // Should show key tag badges
     await expect(page.getByText(/\u2713 title/i).first()).toBeVisible();
 
-    // Click to expand full comparison
-    await toggle.click();
-
-    // Tag table should now be visible
-    await expect(page.getByText('File Value').first()).toBeVisible();
-    await expect(page.getByText('DB Value').first()).toBeVisible();
+    // There is no longer a collapse toggle — TagComparison's `expanded` state
+    // is initialised to true and never set, so the table is unconditionally
+    // rendered. The tray's own <Collapse> has no unmountOnExit, so these
+    // assertions must be toBeVisible(): the cells are in the DOM even while
+    // the tray is shut.
+    await expect(page.getByTestId('tag-comparison-select').first()).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'File', exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'DB', exact: true }).first()).toBeVisible();
   });
 
   test('change log section renders', async ({ page }) => {
@@ -288,7 +325,12 @@ test.describe('Files & History tab', () => {
     await expect(page.getByText(/Tags written/)).toBeVisible();
     await expect(page.getByText(/Imported from/)).toBeVisible();
 
-    // tag_write entry should have "Compare snapshot" link
-    await expect(page.getByText(/Compare snapshot/)).toBeVisible();
+    // The "Compare snapshot" link was replaced by making the whole tag_write
+    // row clickable, so drive the flow rather than looking for the old label:
+    // open the tray (which mounts TagComparison), click the row, and assert
+    // the comparison banner it is meant to trigger.
+    await page.locator('[data-testid="format-tray-m4b"]').click();
+    await page.getByText(/Tags written/).click();
+    await expect(page.getByTestId('snapshot-comparison-banner').first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Result

`files-history.spec.ts`: **4 failed → 0 failed, 4 passed** — **chromium only**. Webkit is not installed on this machine (`Executable doesn't exist at .../webkit-2336/pw_run.sh`), so these counts are not directly comparable to a full two-project suite baseline. No webkit-specific code paths were touched.

No production code changed. Test file + two fragments only.

## Three mock bugs, then two real drifts

Found by reading `test-results/*/error-context.md` DOM snapshots before hypothesising, not by reading the assertion text.

**1. Login screen.** The shim had no `/api/v1/auth/status` branch, so that request fell through to the real dev server, auth failed, and the app rendered the login page. Every assertion was looking for a tab on a page that was never going to show one. This spec mocks by patching `window.fetch` via `addInitScript` rather than `page.route` + `setupMockApi`, so it inherits none of the shared handlers — the same cause already fixed in `metadata-provenance` and `scan-import-organize`.

**2. Missing `{ data: ... }` envelope.** The local `jsonResponse` returned bare bodies, but ~80 call sites in `services/api.ts` read `body.data`. Added additively (top-level keys preserved, so both readers work). Top-level arrays are wrapped too: `getBookSegments` reads `body.data`, so a bare `[]` deserialised to `undefined` and crashed the page with `Cannot read properties of undefined (reading 'length')` — which is what the error boundary in the snapshot was showing.

**3. Wrong endpoint coverage.** `/audiobooks/<id>/files` had no branch and matched the book-detail catch-all, which returned the book object; `result.files` was then `undefined` so `BookDetail` fell back to the legacy segments endpoint. `/external-ids` returned `ids` where `getBookExternalIDs` destructures `external_ids`.

That took it to 2 failed / 2 passed. The last two were genuine UI drift:

- **`tag-comparison-toggle` no longer exists.** `TagComparison.tsx:69` initialises `expanded` to `true` and never calls `setExpanded`, so the table is unconditionally rendered. Row headers are `File`/`DB`, not `File Value`/`DB Value`. Test renamed and rewritten against the current UI. Kept `toBeVisible()` rather than presence checks because the tray's `<Collapse>` has no `unmountOnExit` — the cells are in the DOM before the tray is opened.
- **The "Compare snapshot" link was replaced by a whole-row click.** Instead of asserting on removed text, the test now drives the flow: open the tray, click the `tag_write` row, expect `snapshot-comparison-banner`. That passes, which confirms the compare-snapshot wiring (ChangeLog → BookDetailFilesTab → `compareSnapshotTs` → BookDetailVersionGroup → TagComparison) is intact end to end and only the visible affordance went missing.

## Why no source fix

The obvious "fix" was adding `role="button"` + an `aria-label` to the ChangeLog row so the old assertion would match. That would have meant deriving the label text from the stale test — the test would pass because both sides were changed to agree, not because anything was verified. Both drift findings are filed in `todo.d/` as product decisions instead, with root-cause file:line hints.

## Fragments

- `todo.d/20260809-changelog-row-compare-affordance.md` — the mouse-only/AT-invisible ChangeLog row, and the dead `setExpanded` state.
- `changelog.d/20260809_120000_e2e_files_history.md` — all-comments no-op; no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp