### PR TITLE
test(e2e): repair dynamic-ui-interactions; drop tests for removed Compare tab

### DIFF
--- a/changelog.d/20260809_140000_e2e_dynamic_ui.md
+++ b/changelog.d/20260809_140000_e2e_dynamic_ui.md
@@ -1,0 +1,5 @@
+<!--
+No user-facing change: this PR only repairs the Playwright e2e mocks, removes two
+tests for a Book Detail tab that no longer exists, and masks an animated spinner
+in one visual-regression golden. No production code was touched.
+-->

--- a/todo.d/20260809-per-field-use-fetched-affordance.md
+++ b/todo.d/20260809-per-field-use-fetched-affordance.md
@@ -1,0 +1,30 @@
+<!-- file: todo.d/20260809-per-field-use-fetched-affordance.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8e3d1a47-52bc-4f09-91d6-3ab7c05e2f18 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Per-field "Use File" / "Use Fetched" one-click apply is gone from Book Detail
+      — confirm that was intended.** `web/src/pages/BookDetail.tsx:1014-1015` now renders
+      exactly two tabs (Info, Files & History). The old Tags/Compare tab listed every
+      metadata field as a row with one-click **Use File** and **Use Fetched** buttons,
+      each showing its own inline "Applying…" spinner while only that field's write was
+      in flight. Neither string appears anywhere in `web/src` today. Fetched values are
+      still *surfaced* — `MetadataEditDialog.tsx:188-198` labels a field's source as
+      "Fetched" and pre-fills from `fetched_value` — but applying one now means opening
+      the dialog and saving the whole form, so there is no way to accept a single fetched
+      field. Two e2e tests covering the old flow were deleted on 2026-08-09 rather than
+      left permanently skipped. If the loss was unintentional, this is the third
+      capability this session's e2e sweep has found missing from Book Detail (the others:
+      version management, and the Change Log "Compare snapshot" link — see
+      `todo.d/20260809-changelog-row-compare-affordance.md`).
+
+- [ ] **Visual-regression goldens exist only for darwin.**
+      `web/tests/e2e/dynamic-ui-interactions.spec.ts-snapshots/` holds
+      `scan-button-loading-chromium-darwin.png` and `-webkit-darwin.png` and nothing for
+      linux, so `Button loading states visual check` cannot pass on CI runners — it will
+      report a missing snapshot. The chromium-darwin golden was regenerated 2026-08-09
+      after the spinner was masked; the **webkit-darwin one is now stale** and could not
+      be regenerated locally because the webkit browser is not installed on this machine
+      (`npx playwright install webkit`). Either commit linux goldens generated in CI, or
+      scope this test to a single platform so it stops being a permanent red on the
+      nightly e2e workflow.

--- a/web/tests/e2e/dynamic-ui-interactions.spec.ts
+++ b/web/tests/e2e/dynamic-ui-interactions.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/dynamic-ui-interactions.spec.ts
-// version: 1.3.0
+// version: 1.4.0
 // guid: 9f8e7d6c-5b4a-3210-fedc-ba9876543210
-// last-edited: 2026-03-02
+// last-edited: 2026-08-09
 
 /**
  * E2E tests for dynamic UI interactions with in-place loading states
@@ -94,15 +94,44 @@ test.describe('Dynamic UI - BookDetail Page', () => {
             title: 'The Odyssey',
           }),
         });
+      } else if (url.includes('/segments')) {
+        // api.getBookSegments reads body.data. Without this branch the URL fell
+        // into the catch-all below and got the book object back, so `segments`
+        // became undefined and BookDetail crashed on `.length` — the page then
+        // rendered the error boundary and every tab/button assertion here was
+        // hunting on a page that had already died.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        });
+      } else if (url.includes('/external-ids')) {
+        // api.getBookExternalIDs reads the TOP-LEVEL body and destructures
+        // `external_ids` — no envelope here.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ external_ids: [], itunes_linked: false, total: 0 }),
+        });
+      } else if (/\/files(\?|$)/.test(url)) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: { files: [], count: 0 } }),
+        });
       } else {
+        // api.getBook reads body.data, so the book must be enveloped.
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify({
-            id: 'test-book-id',
-            title: 'The Odyssey',
-            author: 'Homer',
-            file_path: '/library/test.m4b',
+            data: {
+              id: 'test-book-id',
+              title: 'The Odyssey',
+              author: 'Homer',
+              author_name: 'Homer',
+              file_path: '/library/test.m4b',
+            },
           }),
         });
       }
@@ -152,47 +181,17 @@ test.describe('Dynamic UI - BookDetail Page', () => {
     await expect(page.getByRole('button', { name: /parse with ai/i })).toBeEnabled({ timeout: 10000 });
   });
 
-  test('Compare tab - Use Fetched button shows spinner', async ({ page }) => {
-    // Navigate to Compare tab
-    await page.getByRole('tab', { name: /tags/i }).click();
-    await page.waitForLoadState('networkidle');
-
-    // Find Use Fetched button for audiobook_release_year
-    const useFetchedButton = page
-      .getByRole('row', { name: /audiobook release year/i })
-      .getByRole('button', { name: /use fetched/i });
-
-    await expect(useFetchedButton).toBeVisible();
-
-    await useFetchedButton.click();
-
-    // Should show spinner and "Applying..." text
-    const applyingButton = page.getByRole('button', { name: /applying/i });
-    await expect(applyingButton).toBeVisible();
-    await expect(applyingButton).toBeDisabled();
-  });
-
-  test('Compare tab - other buttons remain clickable during action', async ({ page }) => {
-    await page.getByRole('tab', { name: /tags/i }).click();
-    await page.waitForLoadState('networkidle');
-
-    const row = page.getByRole('row', { name: /audiobook release year/i });
-    const useFetchedButton = row.getByRole('button', { name: /use fetched/i });
-
-    await useFetchedButton.click();
-
-    // After clicking, button shows "Applying..." and is disabled
-    const applyingButton = row.getByRole('button', { name: /applying/i });
-    await expect(applyingButton).toBeVisible();
-    await expect(applyingButton).toBeDisabled();
-
-    // But other buttons in different rows should still be clickable
-    const titleRow = page.getByRole('row', { name: /^title/i });
-    const titleUseFileButton = titleRow.getByRole('button', { name: /use file/i }).first();
-
-    // This button should NOT be disabled (it's for a different field)
-    await expect(titleUseFileButton).toBeEnabled();
-  });
+  // REMOVED 2026-08-09: 'Compare tab - Use Fetched button shows spinner' and
+  // 'Compare tab - other buttons remain clickable during action'.
+  //
+  // Both drove a "Tags"/Compare tab on BookDetail with a per-field row for each
+  // metadata field and one-click "Use File" / "Use Fetched" buttons that showed
+  // their own inline "Applying..." spinner. BookDetail now renders exactly two
+  // tabs (BookDetail.tsx:1014-1015, Info and Files & History), and neither
+  // "Use Fetched" nor "Use File" appears anywhere in web/src. Fetched values are
+  // still surfaced — MetadataEditDialog.tsx:188-198 shows them as a source label
+  // — but there is no per-field one-click apply and so no per-row busy state to
+  // assert on. See todo.d/20260809-per-field-use-fetched-affordance.md.
 
   test('No tab switching after fetch metadata', async ({ page }) => {
     // Start on Info tab
@@ -477,6 +476,14 @@ test.describe('Visual Regression - Button States', () => {
     await expect(loadingButton).toBeVisible();
 
     // Take screenshot of loading state
-    await expect(loadingButton).toHaveScreenshot('scan-button-loading.png');
+    // Mask the spinner. MUI's indeterminate CircularProgress animates both its
+    // rotation and its stroke-dasharray, and Playwright's animations:'disabled'
+    // freezes it at whichever frame it happened to reach — so the arc lands at a
+    // different phase run to run and the golden diffs by ~180px every time.
+    // Everything this check actually cares about (disabled styling, the
+    // "STARTING SCAN..." label, colours) is outside the spinner.
+    await expect(loadingButton).toHaveScreenshot('scan-button-loading.png', {
+      mask: [loadingButton.locator('.MuiCircularProgress-root')],
+    });
   });
 });

--- a/web/tests/e2e/dynamic-ui-interactions.spec.ts-snapshots/scan-button-loading-chromium-darwin.png
+++ b/web/tests/e2e/dynamic-ui-interactions.spec.ts-snapshots/scan-button-loading-chromium-darwin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b59617b526c5eca132ece58119c02606629a6c8067a18979a3ed6b74573dab6
-size 2687
+oid sha256:54080cfbf19d944d76db6096f3e2939e602d5c6e11cb2f6fbe2b0fe62afd3b31
+size 2341


### PR DESCRIPTION
## Result

`dynamic-ui-interactions.spec.ts`: **6 failed / 6 passed → 0 failed, 10 passed** — **chromium only** (webkit is not installed on this machine, so these counts are not comparable to a full two-project baseline). Test count drops from 12 to 10 because two tests covered a removed feature; see below.

No production code changed.

## 1. The same crash as files-history (5 of the 6)

The spec registers `**/api/v1/audiobooks/**` *after* `setupMockApi`, so its handler wins for every audiobooks sub-path — including `/segments`, `/files` and `/external-ids`, which it had no branches for. They fell into the catch-all, which returned a bare book object with no `{ data: ... }` envelope.

`api.getBook`, `api.getBookSegments` and `api.getBookFiles` all read `body.data`. So the book was `undefined`, segments came back `undefined`, and `BookDetail` crashed on `.length` — the DOM snapshot showed `Something went wrong / Cannot read properties of undefined (reading 'length')`. Every tab and button assertion in the file was searching a page that had already died.

Added `/segments`, `/files` and `/external-ids` branches and enveloped the catch-all book. `/external-ids` is the odd one out: `getBookExternalIDs` reads the **top-level** body and destructures `external_ids`, no envelope. That took it to 3 failed.

## 2. Two tests drove a tab that no longer exists

`Compare tab - Use Fetched button shows spinner` and `Compare tab - other buttons remain clickable during action` both started with `getByRole('tab', { name: /tags/i })`. `BookDetail.tsx:1014-1015` renders exactly two tabs now — Info and Files & History — and neither `Use Fetched` nor `Use File` appears anywhere in `web/src`.

Fetched values still exist (`MetadataEditDialog.tsx:188-198` labels a field's source as "Fetched" and pre-fills from `fetched_value`), but there is no per-field one-click apply, so there is no per-row busy state left to assert on. **Deleted both** rather than leave permanently-unskippable tests behind, with a comment in place pointing at the fragment.

This is the third Book Detail capability this e2e sweep has found missing (the others: version management, and the Change Log "Compare snapshot" link). All are on the flagged-questions list for you.

## 3. The visual-regression golden could never have been stable

`Button loading states visual check` screenshots MUI's indeterminate `CircularProgress`, which animates both its rotation and its `stroke-dasharray`. Playwright's `animations: 'disabled'` freezes it at whichever frame it reached, so the arc lands at a different phase run to run — ~180px of diff (0.03 ratio), every time. Re-baselining would just move the failure to the next run.

Masked the spinner and regenerated the golden. The disabled styling, the "STARTING SCAN…" label and the colours — everything the check is actually for — are all outside the mask.

**Two caveats filed in `todo.d`:** the `webkit-darwin` golden is now stale and I could not regenerate it (webkit isn't installed here), and there are **no linux goldens at all**, so this test cannot pass on a CI runner regardless. That is pre-existing, not introduced here, but it means the nightly e2e workflow has a permanent red until linux goldens are committed or the test is scoped to one platform.

## Fragments

- `todo.d/20260809-per-field-use-fetched-affordance.md` — the removed per-field apply, and the goldens problem.
- `changelog.d/20260809_140000_e2e_dynamic_ui.md` — all-comments no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp