### PR TITLE
test(e2e): repair batch-operations; drop tests for unreachable bulk-fetch dialog

### DIFF
--- a/changelog.d/20260809_150000_e2e_batch_ops.md
+++ b/changelog.d/20260809_150000_e2e_batch_ops.md
@@ -1,0 +1,5 @@
+<!--
+No user-facing change: this PR only repairs the Playwright e2e mocks and
+assertions for tests/e2e/batch-operations.spec.ts and fixes a shadowed branch in
+the shared mock dispatcher. No production code was touched.
+-->

--- a/todo.d/20260809-dead-bulk-fetch-dialog.md
+++ b/todo.d/20260809-dead-bulk-fetch-dialog.md
@@ -1,0 +1,30 @@
+<!-- file: todo.d/20260809-dead-bulk-fetch-dialog.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 2c9a6f31-7d04-48e5-a1b2-6f80e39c4a75 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Delete the unreachable "Bulk Fetch Metadata" dialog and its handler.**
+      `web/src/components/library/LibraryDialogs.tsx:920` renders
+      `<Dialog open={bulkFetchDialogOpen}>`, but `setBulkFetchDialogOpen(true)` appears
+      **nowhere** in `web/src` — the state is initialised to `false` at
+      `web/src/pages/Library.tsx:352` and is only ever set back to `false` (by
+      `handleCancelBulkFetch`). The dialog can never open. `handleBulkFetchMetadata`
+      (`Library.tsx:1218`), the `bulkFetchProgress` state, and the props threaded
+      through `LibraryDialogs` for them are reachable only from that dead dialog.
+      The flow it belonged to was replaced: **Fetch Selected** now calls
+      `batchFetchCandidates` and toasts "Click Review when complete", and a separate
+      **Review** button opens the candidates dialog once the cache is populated. Five
+      e2e tests covering the old synchronous progress dialog were deleted on
+      2026-08-09 rather than rewritten, since rewriting them against the new
+      async flow would be new coverage rather than repair. Removing the dead code is
+      a separate change from the e2e repair and was deliberately not bundled with it.
+
+- [ ] **Audit `setupMockApi` for more branches shadowed by earlier prefix catch-alls.**
+      `web/tests/e2e/utils/test-helpers.ts` had `pathname === '/api/v1/audiobooks/batch'`
+      sitting *below* `pathname.startsWith('/api/v1/audiobooks/') && method === 'POST'`,
+      so every batch update silently got the generic `{ message: 'OK' }` back and
+      Library's toast read "Updated metadata for 0 audiobooks." Fixed 2026-08-09 by
+      moving the specific branch above the prefix one, but the same ordering hazard
+      applies to every other `startsWith` catch-all in that dispatcher — a specific
+      branch placed after one is dead and fails silently rather than loudly. Worth one
+      pass to confirm no others are shadowed.

--- a/web/tests/e2e/batch-operations.spec.ts
+++ b/web/tests/e2e/batch-operations.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/batch-operations.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 5d6e7f80-9a0b-1c2d-3e4f-5a6b7c8d9e0f
-// last-edited: 2026-02-04
+// last-edited: 2026-08-09
 
 import { test, expect, type Locator, type Page } from '@playwright/test';
 import {
@@ -90,8 +90,11 @@ test.describe('Batch Operations', () => {
     // Act
     await page.getByRole('button', { name: 'Deselect' }).click();
 
-    // Assert
-    await expect(page.getByText('0 selected').first()).toBeVisible();
+    // Assert — BatchToolbar returns null at selectedCount === 0
+    // (BatchToolbar.tsx:48), so there is no "0 selected" chip to find. Its
+    // absence is what an empty selection looks like now.
+    await expect(page.getByRole('button', { name: 'Batch Edit' })).toHaveCount(0);
+    await expect(page.getByText(/\d+ selected/)).toHaveCount(0);
   });
 
   test('selection persists across page navigation', async ({ page }) => {
@@ -108,120 +111,26 @@ test.describe('Batch Operations', () => {
     await expect(page.getByLabel(firstLabel, { exact: true })).toBeChecked();
   });
 
-  test('bulk fetches metadata for selected books', async ({ page }) => {
-    // Arrange
-    await arrangeLibrary(page);
-    await selectFirstBooks(page, 3);
-
-    // Act
-    await page
-      .getByRole('button', { name: 'Fetch Selected', exact: true })
-      .click();
-    await page
-      .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
-      .click();
-
-    // Assert
-    await expect(page.getByText('3 / 3 completed')).toBeVisible();
-    await waitForToast(page, 'Metadata fetched for 3 books.');
-  });
-
-  test('monitors bulk fetch progress', async ({ page }) => {
-    // Arrange
-    await arrangeLibrary(page);
-    await page.getByLabel('Select All').click();
-
-    // Act
-    await page
-      .getByRole('button', { name: 'Fetch Selected', exact: true })
-      .click();
-    await page
-      .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
-      .click();
-
-    // Assert
-    const bulkDialog = page.getByRole('dialog', {
-      name: 'Bulk Fetch Metadata',
-    });
-    await expect(
-      bulkDialog.getByText('20 / 20 completed', { exact: true })
-    ).toBeVisible();
-    await expect(
-      bulkDialog.getByText('Test Book 1', { exact: true })
-    ).toBeVisible();
-  });
-
-  test('bulk fetch completes successfully and clears selection', async ({
-    page,
-  }) => {
-    // Arrange
-    await arrangeLibrary(page);
-    await selectFirstBooks(page, 1);
-
-    // Act
-    await page
-      .getByRole('button', { name: 'Fetch Selected', exact: true })
-      .click();
-    await page
-      .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
-      .click();
-
-    // Assert
-    await waitForToast(page, 'Metadata fetched for 1 books.');
-    await expect(page.getByText('0 selected', { exact: true })).toBeVisible();
-  });
-
-  test('bulk fetch handles partial failures', async ({ page }) => {
-    // Arrange
-    const books = generateTestBooks(10);
-    books[1].fetch_metadata_error = true;
-    books[3].fetch_metadata_error = true;
-    await setupLibraryWithBooks(page, books);
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
-    await selectFirstBooks(page, 5);
-
-    // Act
-    await page
-      .getByRole('button', { name: 'Fetch Selected', exact: true })
-      .click();
-    await page
-      .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
-      .click();
-
-    // Assert
-    await waitForToast(page, '3 succeeded, 2 failed.');
-    await expect(page.getByText('Metadata fetch failed').first()).toBeVisible();
-  });
-
-  test('cancels bulk fetch operation', async ({ page }) => {
-    // Arrange
-    const books = generateTestBooks(15).map((book) => ({
-      ...book,
-      fetch_metadata_delay_ms: 200,
-    }));
-    await setupLibraryWithBooks(page, books);
-    await page.goto('/library');
-    await page.waitForLoadState('networkidle');
-    await page.getByLabel('Select All').click();
-
-    // Act
-    await page
-      .getByRole('button', { name: 'Fetch Selected', exact: true })
-      .click();
-    await page
-      .getByRole('dialog', { name: 'Bulk Fetch Metadata' })
-      .getByRole('button', { name: 'Fetch Metadata', exact: true })
-      .click();
-    await page.getByRole('button', { name: 'Cancel' }).click();
-
-    // Assert
-    await waitForToast(page, 'Bulk fetch cancelled.');
-  });
+  // REMOVED 2026-08-09: the five 'bulk fetch' tests
+  //   - bulk fetches metadata for selected books
+  //   - monitors bulk fetch progress
+  //   - bulk fetch completes successfully and clears selection
+  //   - bulk fetch handles partial failures
+  //   - cancels bulk fetch operation
+  //
+  // All five drove a "Bulk Fetch Metadata" dialog with an in-dialog progress
+  // counter. That dialog is UNREACHABLE: LibraryDialogs.tsx:920 renders
+  // <Dialog open={bulkFetchDialogOpen}>, and setBulkFetchDialogOpen(true) does
+  // not appear anywhere in web/src — the state is initialised to false at
+  // Library.tsx:352 and only ever set back to false. handleBulkFetchMetadata
+  // (Library.tsx:1218) is reachable only from that dead dialog.
+  //
+  // The flow was replaced by an async one: "Fetch Selected" calls
+  // batchFetchCandidates, toasts "Click Review when complete", and a separate
+  // "Review" button opens the candidates dialog once the cache is populated.
+  // There is no synchronous progress dialog to assert on any more. Rewriting
+  // these against the new flow would be new coverage, not repair, so they are
+  // removed rather than rewritten. See todo.d/20260809-dead-bulk-fetch-dialog.md.
 
   test('batch updates metadata field for selected books', async ({ page }) => {
     // Arrange
@@ -273,20 +182,14 @@ test.describe('Batch Operations', () => {
     // Arrange
     await arrangeLibrary(page);
 
-    // Act
-    await page
-      .locator('span[aria-label="Select books first"]')
-      .filter({ hasText: 'Batch Edit' })
-      .hover();
-
-    // Assert
-    await expect(page.getByText('Select books first')).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Batch Edit' })
-    ).toBeDisabled();
+    // Assert — batch operations are no longer *disabled* on an empty
+    // selection, they are not rendered at all: BatchToolbar.tsx:48 returns
+    // null when selectedCount === 0, so the "Select books first" tooltip
+    // wrapper this test used to hover no longer exists.
+    await expect(page.getByRole('button', { name: 'Batch Edit' })).toHaveCount(0);
     await expect(
       page.getByRole('button', { name: 'Fetch Selected', exact: true })
-    ).toBeDisabled();
+    ).toHaveCount(0);
   });
 
   test('shows different batch actions based on selection state', async ({

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/utils/test-helpers.ts
-// version: 2.10.0
+// version: 2.11.0
 // guid: a1b2c3d4-e5f6-7890-abcd-e1f2a3b4c5d6
-// last-edited: 2026-08-08
+// last-edited: 2026-08-09
 
 import { Page } from '@playwright/test';
 
@@ -1481,14 +1481,23 @@ export async function setupMockApiRoutes(
       return route.fulfill(jsonResponse({ message: 'Deleted' }));
     }
 
+    // Batch operations. MUST stay above the generic
+    // startsWith('/api/v1/audiobooks/') POST handler below — '/audiobooks/batch'
+    // matches that prefix too, so this branch was unreachable and every batch
+    // update silently returned the generic { message: 'OK' } instead.
+    if (pathname === '/api/v1/audiobooks/batch' && method === 'POST') {
+      // Echo the real count. This was also hardcoded to 0, so Library's success
+      // toast always read "Updated metadata for 0 audiobooks."
+      let ids: unknown[] = [];
+      try { ids = (request.postDataJSON()?.ids as unknown[]) ?? []; } catch { /* ignore */ }
+      return route.fulfill(
+        jsonResponse({ message: 'Batch update complete', updated: ids.length, failed: 0 })
+      );
+    }
+
     if (pathname.startsWith('/api/v1/audiobooks/') && method === 'POST') {
       // Handle various POST sub-endpoints (fetch-metadata, parse-with-ai, versions, restore)
       return route.fulfill(jsonResponse({ message: 'OK', book: mockState.books[0] || {} }));
-    }
-
-    // Batch operations
-    if (pathname === '/api/v1/audiobooks/batch' && method === 'POST') {
-      return route.fulfill(jsonResponse({ message: 'Batch update complete', updated: 0 }));
     }
 
     // Metadata endpoints


### PR DESCRIPTION
## Result

`batch-operations.spec.ts`: **8 failed / 7 passed → 0 failed, 10 passed** — **chromium only** (webkit is not installed locally). Test count drops from 15 to 10 because five covered an unreachable dialog.

No production code changed. One shared-helper fix, one spec, two fragments.

## 1. Five tests drove a dialog that cannot open

`LibraryDialogs.tsx:920` renders `<Dialog open={bulkFetchDialogOpen}>`. **`setBulkFetchDialogOpen(true)` appears nowhere in `web/src`** — the state is initialised to `false` at `Library.tsx:352` and only ever set back to `false` by `handleCancelBulkFetch`. `handleBulkFetchMetadata` (`Library.tsx:1218`) and the `bulkFetchProgress` state are reachable only from it.

The flow was replaced by an async one: **Fetch Selected** calls `batchFetchCandidates` and toasts "Click Review when complete", and a separate **Review** button opens the candidates dialog once the cache is populated. There is no synchronous progress dialog left to assert against, so rewriting these would be new coverage rather than repair. Deleted, with an inline comment recording the evidence.

Note one of the five (`bulk fetch completes successfully and clears selection`) selected a single book, which also trips `disabled={selectedAudiobooksLength < 2}` on Fetch Selected — but it depended on the dead dialog regardless, so it goes with the rest.

**Removing the dead product code is filed as a separate task, not bundled here.**

## 2. Empty selection no longer renders anything to disable

`BatchToolbar.tsx:48` returns `null` when `selectedCount === 0`. So `deselects all books` was waiting for a "0 selected" chip that cannot exist, and `disables batch operations when no books selected` was hovering a `span[aria-label="Select books first"]` tooltip wrapper that is gone. Absence *is* the disable mechanism now; both rewritten to assert the toolbar isn't rendered. Intent preserved, so neither was deleted.

## 3. A shadowed branch in the shared mock (this one bites everything)

`batch updates metadata field` expected `Updated metadata for 3 audiobooks.` and got `0`. Two bugs stacked in `test-helpers.ts`:

- the `/api/v1/audiobooks/batch` handler hardcoded `updated: 0`, so the count could never match; **and**
- it sat *below* `pathname.startsWith('/api/v1/audiobooks/') && method === 'POST'`, which matches `/audiobooks/batch` too — so the branch was **unreachable** and every batch update silently got the generic `{ message: 'OK' }`.

Moved it above the catch-all and made it echo `ids.length`. This is the same shape as the `/files` fall-through fixed in #2226, and it fails *silently* rather than loudly, so I've filed one audit pass over the rest of that dispatcher.

## Suite state

Baseline snapshot was 66 failing specs across 17 files, captured at `4f24c1af` — which already included #2224 but not #2225 or #2226. Subtracting those (3 + 6) gives **57 before this PR**, and **49 after**. All counts chromium-only.

## Fragments

- `todo.d/20260809-dead-bulk-fetch-dialog.md` — the dead dialog, and the shadowed-branch audit.
- `changelog.d/20260809_150000_e2e_batch_ops.md` — all-comments no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp