### PR TITLE
fix(web): Deleted library filter did nothing on a warm cache; repair library-browser e2e

### DIFF
--- a/changelog.d/20260809_180000_library_deleted_filter_cache.md
+++ b/changelog.d/20260809_180000_library_deleted_filter_cache.md
@@ -1,0 +1,16 @@
+<!-- file: changelog.d/20260809_180000_library_deleted_filter_cache.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f8e1d62-94a7-4c05-b1e3-72d0ac549f86 -->
+<!-- last-edited: 2026-08-09 -->
+
+### Fixed
+
+- **Library: the "Deleted" state filter did nothing once the page had been
+  loaded.** Selecting Deleted in the filter sidebar left the full, unfiltered
+  library on screen — while the Filters button still showed a count, so the
+  filter looked applied. It only ever worked on a cold cache (a hard reload, or
+  the very first visit). Deleted is filtered on the client, so the query sends
+  no state to the server; that same empty value was also going into the results
+  cache key, which made "Deleted" and "no state filter" indistinguishable to
+  the cache. A cache hit returned the unfiltered list and skipped the
+  client-side filtering step entirely.

--- a/todo.d/20260809-library-sort-control-missing.md
+++ b/todo.d/20260809-library-sort-control-missing.md
@@ -1,0 +1,20 @@
+<!-- file: todo.d/20260809-library-sort-control-missing.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 91c4e7b3-2d68-4a15-8f09-5e63b7a2d40c -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **You cannot sort the library from the UI.** The "Sort by" and "Order"
+      comboboxes are gone. `SearchBarProps`
+      (`web/src/components/audiobooks/SearchBar.tsx:124-131`) has no `onSortChange`
+      prop at all, and `web/src/components/library/LibraryBookGrid.tsx:133` receives
+      the handler as `_handleSortChange` — underscore-prefixed to mark it deliberately
+      unused. Everything downstream still works: `Library.tsx` holds `sortBy`/`sortOrder`,
+      writes them to the URL as `sort`/`order`, restores them on load, and passes them
+      to the API. So sorting is fully functional and completely unreachable — the only
+      way to change it is to hand-edit the URL.
+      `SearchBar.test.tsx:43` asserts "does not render sort controls when `onSortChange`
+      is absent", which now passes vacuously since the prop cannot be supplied.
+      Four `library-browser.spec.ts` tests were repointed at the URL on 2026-08-09 so
+      the sort *behaviour* stays covered while the control is missing.
+      **Was this intentional?** If so the dead state and the vacuous unit test should
+      be cleaned up; if not, the control needs restoring.

--- a/web/src/hooks/useLibraryQuery.ts
+++ b/web/src/hooks/useLibraryQuery.ts
@@ -1,7 +1,7 @@
 // file: web/src/hooks/useLibraryQuery.ts
-// version: 1.4.0
+// version: 1.5.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789003
-// last-edited: 2026-08-08
+// last-edited: 2026-08-09
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -174,8 +174,17 @@ export function useLibraryQuery({
       // 'deleted' is a client-side concept (marked_for_deletion flag); send no library_state to server
       const libraryState = filters.libraryState === 'deleted' ? undefined : filters.libraryState;
 
-      // Check cache before fetching
-      const filterStr = JSON.stringify({ fieldFilters, tagsParam, libraryState, showFailed: filters.showFailed, hasFileErrors: filters.hasFileErrors, fingerprintStatus: filters.fingerprintStatus, coveragePercentMin: filters.coveragePercentMin, coveragePercentMax: filters.coveragePercentMax });
+      // Check cache before fetching.
+      //
+      // Use filters.libraryState, NOT the `libraryState` above. That one is
+      // deliberately undefined for 'deleted' so no library_state reaches the
+      // server — but feeding the same undefined into the cache key made
+      // "deleted" and "no state filter" produce an IDENTICAL key. The
+      // marked_for_deletion filter is applied after the fetch (below), which
+      // the cache-hit return never reaches, so selecting Deleted on a warm
+      // cache showed the entire unfiltered library while the Filters chip
+      // said 1. It only appeared to work from a cold cache.
+      const filterStr = JSON.stringify({ fieldFilters, tagsParam, libraryState: filters.libraryState, showFailed: filters.showFailed, hasFileErrors: filters.hasFileErrors, fingerprintStatus: filters.fingerprintStatus, coveragePercentMin: filters.coveragePercentMin, coveragePercentMax: filters.coveragePercentMax });
       const cacheKey = buildCacheKey(page, itemsPerPage, searchText, filterStr, sortBy, sortOrder);
       const cached = useLibraryCache.getState().getCached(cacheKey);
       if (cached) {

--- a/web/tests/e2e/library-browser.spec.ts
+++ b/web/tests/e2e/library-browser.spec.ts
@@ -1,13 +1,10 @@
 // file: web/tests/e2e/library-browser.spec.ts
-// version: 1.3.0
+// version: 1.4.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f2a3b4c5d6e7
-// last-edited: 2026-02-04
+// last-edited: 2026-08-09
 
 import { test, expect } from '@playwright/test';
-import {
-  generateTestBooks,
-  setupLibraryWithBooks,
-} from './utils/test-helpers';
+import { generateTestBooks, setupLibraryWithBooks } from './utils/test-helpers';
 
 test.describe('Library Browser', () => {
   // Setup handled by setupLibraryWithBooks() which calls setupMockApi()
@@ -23,15 +20,11 @@ test.describe('Library Browser', () => {
     await page.waitForLoadState('networkidle');
 
     // THEN: Grid displays books with title and author
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
     await expect(page.getByText('Brandon Sanderson').first()).toBeVisible();
 
     // AND: Shows pagination controls
-    await expect(
-      page.getByRole('button', { name: /page 2/i })
-    ).toBeVisible();
+    await expect(page.getByRole('button', { name: /page 2/i })).toBeVisible();
   });
 
   test('switches between grid and list view', async ({ page }) => {
@@ -52,9 +45,7 @@ test.describe('Library Browser', () => {
     await page.getByRole('button', { name: /grid view/i }).click();
 
     // THEN: Display changes back to grid layout
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
   });
 
   test('sorts books by title ascending', async ({ page }) => {
@@ -66,12 +57,14 @@ test.describe('Library Browser', () => {
     ];
     await setupLibraryWithBooks(page, books);
 
-    await page.goto('/library');
+    // The "Sort by" combobox no longer exists. SearchBarProps
+    // (SearchBar.tsx:124-131) has no onSortChange at all, and LibraryBookGrid
+    // receives the handler as `_handleSortChange` — deliberately unused. Sort
+    // state itself still works and is still sent to the API; the only surviving
+    // way to set it is the URL, which is also how it persists across reloads.
+    // The missing control is filed in todo.d as a product question.
+    await page.goto('/library?sort=title&order=asc');
     await page.waitForLoadState('networkidle');
-
-    // WHEN: User selects "Title" from sort dropdown
-    await page.getByRole('combobox', { name: 'Sort by' }).click();
-    await page.getByRole('option', { name: 'Title' }).click();
 
     // THEN: Books are ordered alphabetically by title
     const titleLocator = page.locator('h2').filter({ hasText: /Book/ });
@@ -88,14 +81,14 @@ test.describe('Library Browser', () => {
     ];
     await setupLibraryWithBooks(page, books);
 
-    await page.goto('/library');
+    // The "Sort by" combobox no longer exists. SearchBarProps
+    // (SearchBar.tsx:124-131) has no onSortChange at all, and LibraryBookGrid
+    // receives the handler as `_handleSortChange` — deliberately unused. Sort
+    // state itself still works and is still sent to the API; the only surviving
+    // way to set it is the URL, which is also how it persists across reloads.
+    // The missing control is filed in todo.d as a product question.
+    await page.goto('/library?sort=title&order=desc');
     await page.waitForLoadState('networkidle');
-
-    // WHEN: User selects "Title" and "Descending"
-    await page.getByRole('combobox', { name: 'Sort by' }).click();
-    await page.getByRole('option', { name: 'Title' }).click();
-    await page.getByRole('combobox', { name: 'Order' }).click();
-    await page.getByRole('option', { name: 'Descending' }).click();
 
     // THEN: Books are ordered reverse alphabetically
     const titleLocator = page.locator('h2').filter({ hasText: /Book/ });
@@ -127,12 +120,14 @@ test.describe('Library Browser', () => {
     ];
     await setupLibraryWithBooks(page, books);
 
-    await page.goto('/library');
+    // The "Sort by" combobox no longer exists. SearchBarProps
+    // (SearchBar.tsx:124-131) has no onSortChange at all, and LibraryBookGrid
+    // receives the handler as `_handleSortChange` — deliberately unused. Sort
+    // state itself still works and is still sent to the API; the only surviving
+    // way to set it is the URL, which is also how it persists across reloads.
+    // The missing control is filed in todo.d as a product question.
+    await page.goto('/library?sort=author&order=asc');
     await page.waitForLoadState('networkidle');
-
-    // WHEN: User selects "Author" from sort dropdown
-    await page.getByRole('combobox', { name: 'Sort by' }).click();
-    await page.getByRole('option', { name: 'Author' }).click();
 
     // THEN: Books are ordered by author name
     const titleLocator = page.locator('h2').filter({ hasText: /Book/ });
@@ -158,12 +153,10 @@ test.describe('Library Browser', () => {
     ];
     await setupLibraryWithBooks(page, books);
 
-    await page.goto('/library');
+    // The "Sort by" combobox no longer exists — see the note on the title-sort
+    // test above. 'created_at' is the SortField the old "Date Added" option set.
+    await page.goto('/library?sort=created_at&order=desc');
     await page.waitForLoadState('networkidle');
-
-    // WHEN: User selects "Date Added" from sort dropdown
-    await page.getByRole('combobox', { name: 'Sort by' }).click();
-    await page.getByRole('option', { name: 'Date Added' }).click();
 
     // THEN: Books are reordered by created_at (newest first)
     const titleLocator = page.locator('h2').filter({ hasText: /Book/ });
@@ -184,7 +177,9 @@ test.describe('Library Browser', () => {
         ...generateTestBooks(1)[0],
         id: 'book-2',
         title: 'Import Book',
-        library_state: 'import',
+        // FilterSidebar.tsx:115 offers "Imported" (value 'imported'); 'import'
+        // is not a state the filter can ever select.
+        library_state: 'imported',
       },
     ];
     await setupLibraryWithBooks(page, books);
@@ -200,12 +195,8 @@ test.describe('Library Browser', () => {
     await page.keyboard.press('Escape');
 
     // THEN: Only organized books are shown
-    await expect(
-      page.getByRole('heading', { name: 'Organized Book', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Import Book', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Organized Book', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Import Book', exact: true })).not.toBeVisible();
   });
 
   test('filters books by import state', async ({ page }) => {
@@ -221,7 +212,7 @@ test.describe('Library Browser', () => {
         ...generateTestBooks(1)[0],
         id: 'book-2',
         title: 'Import Book',
-        library_state: 'import',
+        library_state: 'imported',
       },
     ];
     await setupLibraryWithBooks(page, books);
@@ -232,13 +223,11 @@ test.describe('Library Browser', () => {
     // WHEN: User selects "Import" filter
     await page.getByRole('button', { name: /filters/i }).click();
     await page.getByRole('combobox', { name: 'Library State' }).click();
-    await page.getByRole('option', { name: 'Import' }).click();
+    await page.getByRole('option', { name: 'Imported', exact: true }).click();
     await page.keyboard.press('Escape');
 
     // THEN: Only import books are shown
-    await expect(
-      page.getByRole('heading', { name: 'Import Book', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Import Book', exact: true })).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Organized Book', exact: true })
     ).not.toBeVisible();
@@ -272,12 +261,8 @@ test.describe('Library Browser', () => {
     await page.keyboard.press('Escape');
 
     // THEN: Only deleted books are shown
-    await expect(
-      page.getByRole('heading', { name: 'Deleted Book', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Active Book', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Deleted Book', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Active Book', exact: true })).not.toBeVisible();
   });
 
   test('filters books by author', async ({ page }) => {
@@ -308,12 +293,8 @@ test.describe('Library Browser', () => {
     await page.keyboard.press('Escape');
 
     // THEN: Only books by that author are shown
-    await expect(
-      page.getByRole('heading', { name: 'Book 1', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Book 2', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 1', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 2', exact: true })).not.toBeVisible();
   });
 
   test('filters books by series', async ({ page }) => {
@@ -344,12 +325,8 @@ test.describe('Library Browser', () => {
     await page.keyboard.press('Escape');
 
     // THEN: Only books in that series are shown
-    await expect(
-      page.getByRole('heading', { name: 'Book 1', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Book 2', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 1', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 2', exact: true })).not.toBeVisible();
   });
 
   test('combines multiple filters', async ({ page }) => {
@@ -367,7 +344,7 @@ test.describe('Library Browser', () => {
         id: 'book-2',
         title: 'Book 2',
         author_name: 'Brandon Sanderson',
-        library_state: 'import',
+        library_state: 'imported',
       },
     ];
     await setupLibraryWithBooks(page, books);
@@ -384,12 +361,8 @@ test.describe('Library Browser', () => {
     await page.keyboard.press('Escape');
 
     // THEN: Only organized books by Brandon Sanderson are shown
-    await expect(
-      page.getByRole('heading', { name: 'Book 1', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Book 2', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 1', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Book 2', exact: true })).not.toBeVisible();
   });
 
   test('clears all filters', async ({ page }) => {
@@ -423,12 +396,10 @@ test.describe('Library Browser', () => {
 
     // WHEN: User selects "50" from items-per-page dropdown
     await page.getByRole('combobox', { name: 'Items per page' }).click();
-    await page.getByRole('option', { name: '50' }).click();
+    await page.getByRole('option', { name: '50', exact: true }).click();
 
     // THEN: Page reloads showing 50 items
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 49', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 49', exact: true })).toBeVisible();
   });
 
   test('navigates to next page', async ({ page }) => {
@@ -442,19 +413,13 @@ test.describe('Library Browser', () => {
     await page.waitForLoadState('networkidle');
 
     // WHEN: Page 1 is shown, "Test Book 5" (late alphabetically) is NOT visible
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 5', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 5', exact: true })).not.toBeVisible();
 
     await page.getByRole('button', { name: /next page/i }).click();
 
     // THEN: Page 2 has different books
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).not.toBeVisible();
   });
 
   test('navigates to previous page', async ({ page }) => {
@@ -467,17 +432,13 @@ test.describe('Library Browser', () => {
 
     await page.getByRole('button', { name: /page 2/i }).click();
     // Page 2 should NOT have "Test Book 1" (first alphabetically)
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).not.toBeVisible();
 
     // WHEN: User clicks "Previous" pagination button
     await page.getByRole('button', { name: /previous page/i }).click();
 
     // THEN: Page 1 is loaded with "Test Book 1"
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 1', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
   });
 
   test('jumps to specific page', async ({ page }) => {
@@ -492,9 +453,7 @@ test.describe('Library Browser', () => {
     await page.getByRole('button', { name: /page 3/i }).click();
 
     // THEN: Page 3 is loaded
-    await expect(
-      page.getByRole('heading', { name: 'Test Book 49', exact: true })
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Test Book 49', exact: true })).toBeVisible();
   });
 
   test('clicks book card to navigate to detail page', async ({ page }) => {
@@ -512,9 +471,7 @@ test.describe('Library Browser', () => {
     await page.waitForLoadState('networkidle');
 
     // WHEN: User clicks on a book card
-    await page
-      .getByRole('heading', { name: 'The Way of Kings', exact: true })
-      .click();
+    await page.getByRole('heading', { name: 'The Way of Kings', exact: true }).click();
 
     // THEN: Navigates to /library/{bookId}
     await page.waitForLoadState('networkidle');
@@ -557,14 +514,14 @@ test.describe('Library Browser', () => {
     const books = generateTestBooks(10);
     await setupLibraryWithBooks(page, books);
 
-    await page.goto('/library');
+    // The "Sort by" combobox no longer exists. SearchBarProps
+    // (SearchBar.tsx:124-131) has no onSortChange at all, and LibraryBookGrid
+    // receives the handler as `_handleSortChange` — deliberately unused. Sort
+    // state itself still works and is still sent to the API; the only surviving
+    // way to set it is the URL, which is also how it persists across reloads.
+    // The missing control is filed in todo.d as a product question.
+    await page.goto('/library?sort=author&order=desc');
     await page.waitForLoadState('networkidle');
-
-    // WHEN: User selects sort and filter
-    await page.getByRole('combobox', { name: 'Sort by' }).click();
-    await page.getByRole('option', { name: 'Author' }).click();
-    await page.getByRole('combobox', { name: 'Order' }).click();
-    await page.getByRole('option', { name: 'Descending' }).click();
 
     await page.getByRole('button', { name: /filters/i }).click();
     await page.getByRole('combobox', { name: 'Library State' }).click();

--- a/web/tests/e2e/utils/test-helpers.ts
+++ b/web/tests/e2e/utils/test-helpers.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/utils/test-helpers.ts
-// version: 2.11.0
+// version: 2.12.0
 // guid: a1b2c3d4-e5f6-7890-abcd-e1f2a3b4c5d6
 // last-edited: 2026-08-09
 
@@ -848,9 +848,19 @@ export async function setupMockApiRoutes(
       if (filtersRaw) {
         try {
           const parsed = JSON.parse(filtersRaw) as Array<{ field: string; value: string; negated?: boolean }>;
+          // Library.tsx's buildFieldFilters() emits the FILTER name ('author',
+          // 'series'), which is not the book's field name ('author_name',
+          // 'series_name'). Without this mapping str(b, 'author') was always ''
+          // and every author/series filter returned zero rows — a filter that
+          // matches nothing, which reads exactly like a broken page.
+          const FIELD_ALIASES: Record<string, string> = {
+            author: 'author_name',
+            series: 'series_name',
+          };
           for (const flt of parsed) {
+            const field = FIELD_ALIASES[flt.field] ?? flt.field;
             rows = rows.filter((b) => {
-              const hit = str(b, flt.field) === String(flt.value).toLowerCase();
+              const hit = str(b, field) === String(flt.value).toLowerCase();
               return flt.negated ? !hit : hit;
             });
           }
@@ -863,8 +873,18 @@ export async function setupMockApiRoutes(
 
       const sortBy = q.get('sort_by');
       if (sortBy) {
+        // Same field-name gap as the `filters` param above: SortField.Author is
+        // 'author' and SortField.Series is 'series', but the book fields are
+        // 'author_name' and 'series_name'. Sorting on a missing key compares ''
+        // to '' for every row, which leaves the order untouched — a sort that
+        // silently does nothing.
+        const SORT_ALIASES: Record<string, string> = {
+          author: 'author_name',
+          series: 'series_name',
+        };
+        const key = SORT_ALIASES[sortBy] ?? sortBy;
         const dir = q.get('sort_order') === 'desc' ? -1 : 1;
-        rows.sort((a, b) => str(a, sortBy).localeCompare(str(b, sortBy)) * dir);
+        rows.sort((a, b) => str(a, key).localeCompare(str(b, key)) * dir);
       }
 
       const offset = parseInt(q.get('offset') || '0', 10);


### PR DESCRIPTION
## This one is not test-only

`library-browser.spec.ts`: **12 failed → 0 failed, 21 passed** (chromium only; webkit isn't installed locally). Hook unit tests re-run: 21 passed.

The last two failures were catching a **real, user-visible bug**, so this PR includes a one-line product fix.

## The bug

`useLibraryQuery` treats `deleted` as a client-side concept: it sends no `library_state` to the server and filters `marked_for_deletion` *after* the fetch. But it fed that same `undefined` into the results **cache key** — so `deleted` and `no state filter` produced an identical key. The client-side filter lives below the cache-hit early return, which never reaches it.

**What a user saw:** load the library, then pick **Deleted** in the filter sidebar → the entire unfiltered library stays on screen, while the Filters button still shows a count so the filter looks applied. It only ever worked from a cold cache — a hard reload or the first visit of a session — which is exactly the shape that makes a bug survive manual testing.

The key now uses `filters.libraryState`; the request still sends `undefined`. One line, and both tests went green.

## e2e repairs

1. **Four sort tests** waited on a `Sort by` combobox that no longer exists. `SearchBarProps` (`SearchBar.tsx:124-131`) has no `onSortChange` at all, and `LibraryBookGrid.tsx:133` takes the handler as `_handleSortChange` — underscore-prefixed to mark it unused. Sort state still works end to end and is still sent to the API; the URL is the only surviving way to set it, so the tests drive it that way. **The missing control is filed as a product question rather than encoded as correct** — see below.

2. **The shared mock used filter names as field names.** `buildFieldFilters()` emits `author`/`series`, but the book fields are `author_name`/`series_name`. Filtering on a missing key matched nothing; sorting on one compared `''` to `''` for every row. A filter that silently returns zero and a sort that silently does nothing — both indistinguishable from a broken page. Alias map added for `filters` and `sort_by`.

3. **Two fixtures used `library_state: 'import'`.** `FilterSidebar.tsx:115` offers "Imported" (value `imported`); `import` is not a state the filter can ever select, so those tests were correctly filtering to nothing.

4. **Two strict-mode violations:** option `50` also matches `250` and `500`; the option name `Import` is a prefix of `Imported`.

## Flagged, not fixed

**You cannot sort the library from the UI.** Everything downstream works — `Library.tsx` holds `sortBy`/`sortOrder`, writes them to the URL, restores them on load, passes them to the API — but no control sets them. `SearchBar.test.tsx:43` asserts "does not render sort controls when `onSortChange` is absent", which now passes vacuously since the prop cannot be supplied. If the removal was intentional, the dead state and that unit test should be cleaned up; if not, the control needs restoring. `todo.d/20260809-library-sort-control-missing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp