### PR TITLE
fix(web): Edit Metadata showed an empty Genre box; repair metadata-provenance e2e

### DIFF
--- a/changelog.d/20260809_200000_edit_dialog_genre.md
+++ b/changelog.d/20260809_200000_edit_dialog_genre.md
@@ -1,0 +1,14 @@
+<!-- file: changelog.d/20260809_200000_edit_dialog_genre.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5b2a9c04-7e13-48d6-92f1-0a63cd84e7b2 -->
+<!-- last-edited: 2026-08-09 -->
+
+### Fixed
+
+- **Edit Metadata showed an empty Genre box even when the book had a genre.** The
+  dialog was being handed a copy of the book that never included the genre, so
+  the field always looked blank and there was no way to tell a book with no
+  genre from one whose genre simply wasn't being shown. Year and ISBN-13 have
+  the same problem and are tracked separately — fixing those safely needs a
+  related change to how the save path chooses between publication year and
+  audiobook release year.

--- a/todo.d/20260809-edit-dialog-blank-year-isbn.md
+++ b/todo.d/20260809-edit-dialog-blank-year-isbn.md
@@ -1,0 +1,39 @@
+<!-- file: todo.d/20260809-edit-dialog-blank-year-isbn.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: c8d31e47-5f92-4b60-a3d7-2094f6ba1c85 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Edit Metadata shows Year and ISBN-13 as empty boxes whatever is stored — and the
+      obvious fix corrupts `print_year`.** `mapBookToAudiobook`
+      (`web/src/pages/BookDetail.tsx:762`) builds the object handed to
+      `MetadataEditDialog` and omits `year`, `isbn10` and `isbn13`. `genre` had the same
+      problem and was fixed on 2026-08-09; the other three were deliberately left alone,
+      because they are not equally safe.
+
+      `genre` was safe because it does not appear in the payload `handleEditSave` builds,
+      so populating it cannot change what a save writes. **Year is not.** The dialog seeds
+      its Year box from `audiobook.year`, and `handleEditSave` computes:
+
+      ```ts
+      payload.print_year = updated.year || book.print_year;
+      ```
+
+      So mapping `year: current.audiobook_release_year` would make every save overwrite
+      `print_year` with the audiobook release year — on books the user never touched the
+      Year field of. Two genuinely different dates (`print_year`, the original
+      publication; `audiobook_release_year`, when the recording came out) collapsing into
+      one is silent metadata corruption across the library.
+
+      Fixing the display therefore means untangling that precedence first: decide which
+      date the dialog's single "Year" box represents, and have the save path write only
+      that one. `Audiobook` already carries `print_year` and `audiobook_release_year` as
+      separate fields (`web/src/types/index.ts:16-17`) alongside the legacy `year`, so
+      the type is not the obstacle.
+
+      ISBN is a smaller version of the same shape: the payload does
+      `isbn: updated.isbn13 || updated.isbn10 || book.isbn`, which currently falls through
+      to `book.isbn` precisely *because* the mapped object has neither. Populating them
+      changes which field wins.
+
+      `tests/e2e/metadata-provenance.spec.ts` carries a `test.fixme` covering this, so it
+      will start failing (loudly, as an unexpected pass) the moment it is fixed.

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -1,7 +1,7 @@
 // file: web/src/pages/BookDetail.tsx
-// version: 1.52.1
+// version: 1.53.0
 // guid: 4d2f7c6a-1b3e-4c5d-8f7a-9b0c1d2e3f4a
-// last-edited: 2026-08-07
+// last-edited: 2026-08-09
 
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -766,6 +766,11 @@ export const BookDetail = () => {
     narrator: current.narrator,
     series: current.series_name,
     series_number: current.series_position,
+    // Genre was missing, so the Edit Metadata dialog rendered an empty Genre
+    // box no matter what was stored. Safe to add: `genre` is not part of the
+    // payload handleEditSave builds, so populating it cannot change what a
+    // save writes — it only stops the dialog lying about the current value.
+    genre: current.genre,
     language: current.language,
     publisher: current.publisher,
     description: current.description,

--- a/web/tests/e2e/metadata-provenance.spec.ts
+++ b/web/tests/e2e/metadata-provenance.spec.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/metadata-provenance.spec.ts
-// version: 2.1.0
+// version: 2.2.0
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
 // last-edited: 2026-08-09
 
@@ -323,14 +323,32 @@ test.describe('MetadataEditDialog Provenance E2E', () => {
     await expect(page.getByRole('textbox', { name: 'Narrator', exact: true })).toHaveValue('User Override Narrator');
     await expect(page.getByRole('textbox', { name: 'Series', exact: true })).toHaveValue('DB Series');
     await expect(page.getByRole('textbox', { name: 'Genre', exact: true })).toHaveValue('Science Fiction');
-    await expect(page.getByRole('textbox', { name: 'Year', exact: true })).toHaveValue('2024');
     await expect(page.getByRole('textbox', { name: 'Language', exact: true })).toHaveValue('en');
     await expect(page.getByRole('textbox', { name: 'Publisher', exact: true })).toHaveValue('Audible Studios');
-    await expect(page.getByRole('textbox', { name: 'ISBN-13', exact: true })).toHaveValue('978-1234567890');
+    // Year and ISBN-13 are covered by the fixme below — they are still blank.
 
     // Verify Cancel and Save buttons
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
+  });
+
+  // KNOWN BUG, deliberately not fixed here. mapBookToAudiobook (BookDetail.tsx:762)
+  // omits year, isbn10 and isbn13, so the Edit Metadata dialog shows those boxes
+  // empty whatever is stored. `genre` had the same problem and WAS fixed, because
+  // genre does not appear in the payload handleEditSave builds.
+  //
+  // Year cannot be fixed the same way. The dialog seeds its Year box from
+  // audiobook.year, and handleEditSave computes
+  //   payload.print_year = updated.year || book.print_year
+  // so populating `year` from audiobook_release_year would silently overwrite
+  // print_year with the release year on every save, even when the user never
+  // touched the field. Fixing the display requires untangling that precedence
+  // first. See todo.d/20260809-edit-dialog-blank-year-isbn.md.
+  test.fixme('year and ISBN-13 populate in the edit dialog', async ({ page }) => {
+    await setupMockRoutes(page);
+    await openEditDialog(page);
+    await expect(page.getByRole('textbox', { name: 'Year', exact: true })).toHaveValue('2024');
+    await expect(page.getByRole('textbox', { name: 'ISBN-13', exact: true })).toHaveValue('978-1234567890');
   });
 
   test('locked fields show orange lock icon, unlocked show grey open lock', async ({ page }) => {
@@ -339,35 +357,37 @@ test.describe('MetadataEditDialog Provenance E2E', () => {
 
     // Narrator has override_locked: true in field-states
     // Find the lock icon near the Narrator field - it should be a closed lock (LockIcon)
-    const narratorField = page.getByLabel('Narrator');
-    const narratorContainer = narratorField.locator('..').locator('..');
-    // The lock button is a sibling before the text field wrapper
-    const narratorLockButton = narratorContainer.locator('button').first();
-    // Locked field should have the Lock icon (not LockOpen)
-    await expect(narratorLockButton.locator('[data-testid="LockIcon"]')).toBeVisible();
-
-    // Title has override_locked: false - should show open lock
-    const titleField = page.getByRole('textbox', { name: 'Title *', exact: true });
-    const titleContainer = titleField.locator('..').locator('..');
-    const titleLockButton = titleContainer.locator('button').first();
-    await expect(titleLockButton.locator('[data-testid="LockOpenIcon"]')).toBeVisible();
+    // MetadataEditDialog.tsx:229 puts the state straight into the button's
+    // accessible name — "Unlock <label>" when locked, "Lock <label>" when not.
+    // Asserting on that beats walking two levels up the DOM to find an icon,
+    // which is what broke when the field markup changed.
+    await expect(
+      page.getByRole('button', { name: 'Unlock Narrator', exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Lock Title *', exact: true })
+    ).toBeVisible();
   });
 
   test('editing a field automatically locks it (auto-lock on edit)', async ({ page }) => {
     await setupMockRoutes(page);
     await openEditDialog(page);
 
-    // Title starts unlocked
-    const titleField = page.getByLabel('Title *');
-    const titleContainer = titleField.locator('..').locator('..');
-    const titleLockButton = titleContainer.locator('button').first();
-    await expect(titleLockButton.locator('[data-testid="LockOpenIcon"]')).toBeVisible();
+    // getByLabel('Title *') is ambiguous — it matches the input AND the lock
+    // button, whose aria-label is "Lock Title *".
+    const titleField = page.getByRole('textbox', { name: 'Title *', exact: true });
 
-    // Edit the title field
+    // Title starts unlocked, so its button offers to Lock it.
+    await expect(
+      page.getByRole('button', { name: 'Lock Title *', exact: true })
+    ).toBeVisible();
+
     await titleField.fill('Modified Title');
 
-    // Now the lock should be closed (auto-locked because dirty)
-    await expect(titleLockButton.locator('[data-testid="LockIcon"]')).toBeVisible();
+    // Editing auto-locks, so the button now offers to Unlock.
+    await expect(
+      page.getByRole('button', { name: 'Unlock Title *', exact: true })
+    ).toBeVisible();
 
     // Source label should show "Manual override"
     await expect(page.getByText('Source: Manual override').first()).toBeVisible();
@@ -433,11 +453,11 @@ test.describe('MetadataEditDialog Provenance E2E', () => {
     await yearField.fill('not-a-number');
 
     // Should show year error
-    await expect(page.getByText('Year must be a number')).toBeVisible();
+    await expect(page.getByText('Year must be a number').first()).toBeVisible();
 
     // Attempting to save should show error
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Year must be a number')).toBeVisible();
+    await expect(page.getByText('Year must be a number').first()).toBeVisible();
 
     // Dialog should still be open (save was blocked)
     await expect(page.getByRole('dialog')).toBeVisible();


### PR DESCRIPTION
`metadata-provenance.spec.ts`: **4 failed → 0 failed, 12 passed, 1 skipped** (chromium only). Page unit tests re-run: 87 passed.

## The bug

`mapBookToAudiobook` (`BookDetail.tsx:762`) builds the object handed to `MetadataEditDialog`, and it omitted `genre`. So **the Genre box rendered blank whatever was stored** — a book with no genre looked identical to one whose genre simply wasn't being passed through.

Safe to fix in isolation: `genre` does not appear in the payload `handleEditSave` builds, so populating it cannot change what a save writes. It only stops the dialog lying about the current value.

## What I deliberately did *not* fix

`year`, `isbn10` and `isbn13` are missing from the same mapping, with the same blank-box symptom — but they are **not** equally safe. The dialog seeds its Year box from `audiobook.year`, and `handleEditSave` computes:

```ts
payload.print_year = updated.year || book.print_year;
```

So mapping `year` from `audiobook_release_year` would make **every save overwrite `print_year` with the audiobook release year** — including on books whose Year field the user never touched. Those are two genuinely different dates (original publication vs. when the recording came out) and collapsing them would be silent metadata corruption across the library.

Fixing the display needs that precedence untangled first: decide which date the single "Year" box represents and have the save path write only that one. `Audiobook` already carries `print_year` and `audiobook_release_year` separately, so the type isn't the obstacle.

ISBN is a smaller version of the same shape — the payload does `isbn: updated.isbn13 || updated.isbn10 || book.isbn`, which falls through to `book.isbn` *because* the mapped object has neither.

Covered by a `test.fixme`, so it fails loudly as an unexpected pass the moment someone fixes it. Details in `todo.d/20260809-edit-dialog-blank-year-isbn.md`.

## e2e repairs

1. **Two lock-state assertions walked two levels up the DOM** from a field to find an icon, and the field markup changed underneath them. `MetadataEditDialog.tsx:229` puts the state directly into the button's accessible name — `Lock <label>` when unlocked, `Unlock <label>` when locked — so both now assert on that instead. More robust and more readable.
2. **`getByLabel('Title *')` is ambiguous:** it matches the input *and* the lock button, whose aria-label is `Lock Title *`. Switched to `getByRole('textbox')`.
3. **`Year must be a number` renders twice**, once in an alert and once as field helper text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp