### PR TITLE
test(e2e): repair the tail — diagnostics, import-paths, settings, library-enhancements

### DIFF
--- a/changelog.d/20260809_240000_e2e_settings_tail.md
+++ b/changelog.d/20260809_240000_e2e_settings_tail.md
@@ -1,0 +1,5 @@
+<!--
+No user-facing change: repairs the Playwright e2e specs for diagnostics,
+import-paths, settings-configuration and library-enhancements. No production
+code was touched.
+-->

--- a/web/tests/e2e/diagnostics.spec.ts
+++ b/web/tests/e2e/diagnostics.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/diagnostics.spec.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: f61968fd-c902-4c58-ac4d-9b9a3511fa92
 
 import { test, expect, type Page } from '@playwright/test';
@@ -249,7 +249,9 @@ test.describe('Diagnostics', () => {
       page.getByText('Same book in mp3 and m4b')
     ).toBeVisible({ timeout: 10000 });
 
-    await expect(page.getByText('Orphan track')).toBeVisible();
+    // getByText is case-insensitive substring by default, so this also matched
+    // the Deduplication card's blurb ("…books, orphan tracks, and missing…").
+    await expect(page.getByText('Orphan track', { exact: true })).toBeVisible();
     await expect(page.getByText('Narrator as author')).toBeVisible();
   });
 

--- a/web/tests/e2e/import-paths.spec.ts
+++ b/web/tests/e2e/import-paths.spec.ts
@@ -1,7 +1,7 @@
 // file: tests/e2e/import-paths.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8b
-// last-edited: 2026-02-04
+// last-edited: 2026-08-09
 
 import { test, expect } from '@playwright/test';
 import { setupMockApi } from './utils/test-helpers';
@@ -31,7 +31,10 @@ test.describe('Import paths workflows', () => {
         return route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ importPaths }),
+          // api.getImportPaths reads body.data.importPaths (api.ts:1764), so an
+          // un-enveloped body made body.data undefined and the call threw —
+          // the list stayed empty however many paths had been added.
+          body: JSON.stringify({ importPaths, data: { importPaths } }),
         });
       }
       if (route.request().method() === 'POST') {
@@ -51,7 +54,8 @@ test.describe('Import paths workflows', () => {
         return route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ importPath: created }),
+          // api.addImportPath reads body.data.importPath (api.ts:1779).
+          body: JSON.stringify({ importPath: created, data: { importPath: created } }),
         });
       }
       if (route.request().method() === 'DELETE') {
@@ -67,13 +71,16 @@ test.describe('Import paths workflows', () => {
       route.fulfill({
         status: 200,
         contentType: 'application/json',
+        // api.getSystemStatus returns body.data (api.ts:2070).
         body: JSON.stringify({
-          status: 'ok',
-          library: { book_count: 0, folder_count: 1, total_size: 0 },
-          import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
-          memory: {},
-          runtime: {},
-          operations: { recent: [] },
+          data: {
+            status: 'ok',
+            library: { book_count: 0, folder_count: 1, total_size: 0 },
+            import_paths: { book_count: 0, folder_count: 0, total_size: 0 },
+            memory: {},
+            runtime: {},
+            operations: { recent: [] },
+          },
         }),
       });
     });
@@ -89,6 +96,9 @@ test.describe('Import paths workflows', () => {
     ).toBeVisible();
 
     // Add import path
+    // Import-path management lives on the Settings "Paths" tab now, not the
+    // Library tab this test used to land on.
+    await page.getByRole('tab', { name: 'Paths' }).click();
     await page.getByRole('button', { name: 'Add Import Path' }).click();
     const dialog = page.getByRole('dialog', { name: /Add Import Path/i });
     const pathInput = dialog.getByPlaceholder('/path/to/downloads');

--- a/web/tests/e2e/library-enhancements.spec.ts
+++ b/web/tests/e2e/library-enhancements.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/library-enhancements.spec.ts
-// version: 1.0.0
+// version: 1.1.0
 // guid: e8f9a0b1-c2d3-4e5f-6a7b-8c9d0e1f2a3b
-// last-edited: 2026-03-22
+// last-edited: 2026-08-09
 
 import { test, expect, Page } from '@playwright/test';
 import {
@@ -381,7 +381,12 @@ test.describe('Tag Management', () => {
     await filtersBtn.click();
 
     // Verify the filter drawer is open
-    const drawer = page.locator('.MuiDrawer-paper');
+    // Three drawers are mounted (sidebar, filter, and one more), so a bare
+    // .MuiDrawer-paper is a strict-mode violation. Pick the filter one by a
+    // control only it contains.
+    const drawer = page
+      .locator('.MuiDrawer-paper')
+      .filter({ has: page.getByText('Library State') });
     await expect(drawer).toBeVisible({ timeout: 5000 });
 
     // Verify the "Tags" section exists

--- a/web/tests/e2e/settings-configuration.spec.ts
+++ b/web/tests/e2e/settings-configuration.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/settings-configuration.spec.ts
-// version: 1.2.1
+// version: 1.3.0
 // guid: ab83d28e-beb5-4288-821f-7bf82704f4b9
-// last-edited: 2026-04-30
+// last-edited: 2026-08-09
 
 import { test, expect, type Page } from '@playwright/test';
 import {
@@ -79,10 +79,15 @@ test.describe('Settings Configuration', () => {
 
     // Act + Assert
     await expect(page.getByText('Library Settings')).toBeVisible();
+    await expect(page.getByText('Scan Settings')).toBeVisible();
+
+    // Import paths moved off the Library tab onto their own "Paths" tab
+    // (PathsSettingsTab.tsx:108). The Library tab now just points at it — its
+    // copy reads "Import paths are configured in File Manager."
+    await page.getByRole('tab', { name: 'Paths' }).click();
     await expect(
       page.getByText('Import Paths (Watch Locations)')
     ).toBeVisible();
-    await expect(page.getByText('Scan Settings')).toBeVisible();
 
     await page.getByRole('tab', { name: 'Metadata' }).click();
     await expect(page.getByText('Metadata Settings')).toBeVisible();


### PR DESCRIPTION
**4 failures → 0**, 38 passed. Four different causes, no tests removed, no production code touched.

1. **`settings-configuration` and `import-paths` both assumed import-path management sits on the Settings Library tab.** It moved to its own **Paths** tab (`PathsSettingsTab.tsx:108`/`:229`) — the Library tab now just points at it, its copy reading *"Import paths are configured in File Manager."* Both tests click the tab first now.

2. **`import-paths` then still failed on a missing envelope.** Its stateful route mock returned `{ importPaths }` and `{ importPath }` un-enveloped, but `api.getImportPaths` and `api.addImportPath` read `body.data.importPaths` / `body.data.importPath` — so both threw and the list stayed empty however many paths were added. Its `/system/status` mock had the same gap. Same cause as #2224, #2226 and #2229; it keeps recurring in specs that mock inline rather than through `setupMockApi`.

3. **`diagnostics`:** `getByText('Orphan track')` also matched the Deduplication card's blurb ("…books, orphan tracks, and missing…"), because `getByText` does **case-insensitive substring** matching by default. Made it exact.

4. **`library-enhancements`:** a bare `.MuiDrawer-paper` resolved to three drawers. Scoped to the filter one by a control only it contains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp