### PR TITLE
test(e2e): de-flake library-sidebar-filters on webkit; file the URL race it exposed

### DIFF
--- a/changelog.d/20260809_270000_e2e_sidebar_flake.md
+++ b/changelog.d/20260809_270000_e2e_sidebar_flake.md
@@ -1,0 +1,5 @@
+<!--
+No user-facing change: de-flakes tests/e2e/library-sidebar-filters.spec.ts on
+webkit and adds a skipped regression test for the URL race it exposed. No
+production code was touched.
+-->

--- a/todo.d/20260809-library-url-transient-filter-drop.md
+++ b/todo.d/20260809-library-url-transient-filter-drop.md
@@ -1,0 +1,47 @@
+<!-- file: todo.d/20260809-library-url-transient-filter-drop.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5a83f7d2-1e94-4c60-b7a5-92c0d4e83f17 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Library throws the sidebar filter out of the URL and puts it back, on every
+      click.** Sampling `location.search` every animation frame across a sidebar filter
+      click shows `web/src/pages/Library.tsx` passing through a state where the filter is
+      gone — reproduced 3 runs out of 3 with a standalone sampler:
+
+      ```
+      ?page=1                                 (initial)
+      ?search=read_status:finished            (click applies the filter)
+      ?page=1                                 <-- filter thrown away
+      ?search=read_status%3Afinished&page=1   (re-applied, settled)
+      ```
+
+      This is the same shape #2193 was supposed to have fixed. The comment on the
+      "survives the URL settling" test in
+      `web/tests/e2e/library-sidebar-filters.spec.ts` says the stuck guard "used to throw
+      the search away and restore a bare `page=1`". It still does — it just recovers now,
+      within a few frames, so nothing downstream ends up in the wrong state.
+
+      **Measured blast radius, so nobody re-derives it.** Exactly **one** request reaches
+      `/api/v1/audiobooks` after the click, and it carries the correct `filters` param.
+      The transient drop costs **no wasted query** and never sends the server the wrong
+      thing. The cost is confined to the URL and history: a spurious intermediate entry,
+      and a flicker for anything reading `searchParams` directly. That is why this is
+      filed rather than treated as urgent — but it is also why it should not be closed as
+      "works fine", because the URL is the app's shareable state and it is briefly wrong
+      on every single filter click.
+
+      **Likely location:** the two `useEffect`s in `Library.tsx` around lines 596-644 —
+      one reads `searchParams` into state, the other writes state back into
+      `searchParams`. The write effect rebuilds the param set from scratch
+      (`const params = new URLSearchParams()`), so any render where `searchQuery` has not
+      yet caught up emits a URL with no `search` at all. The `lastWrittenSearch` ref added
+      earlier guards against re-reading our own write, not against emitting an incomplete
+      one.
+
+      **Regression test already written**, skipped as `test.fixme` in
+      `library-sidebar-filters.spec.ts` ("the filter never disappears from the URL while
+      the effects settle"). It is `fixme` rather than `fail` on purpose: forced on it
+      fails 5 runs out of 8, so `test.fail()` would report a spurious "expected to fail
+      but passed" about a third of the time. The recipe to force it is in the comment
+      above the test. When the race is genuinely fixed it should pass 8/8 — flip it to a
+      normal test then.

--- a/web/tests/e2e/library-sidebar-filters.spec.ts
+++ b/web/tests/e2e/library-sidebar-filters.spec.ts
@@ -1,7 +1,7 @@
 // file: web/tests/e2e/library-sidebar-filters.spec.ts
-// version: 1.1.0
+// version: 1.2.0
 // guid: 3c9a71e5-84fd-4b26-a0d7-6f2e5b81c934
-// last-edited: 2026-08-08
+// last-edited: 2026-08-09
 
 import { test, expect, type Page, type Locator } from '@playwright/test';
 
@@ -98,8 +98,16 @@ test.describe('Library sidebar filters', () => {
     // Library.tsx re-encodes the colon and appends page=1 once its effects
     // settle. The filter must survive that rewrite — the stuck guard used to
     // throw the search away and restore a bare page=1.
-    await expect(page).toHaveURL(/[?&]search=read_status(%3A|:)in_progress/);
-    expect(new URL(page.url()).searchParams.get('search')).toBe('read_status:in_progress');
+    // Poll rather than read once. Library does NOT settle monotonically — it
+    // writes the search, then briefly rewrites a bare `page=1` with the search
+    // GONE, then writes the encoded form back (verified by sampling
+    // location.search every frame; see the fixme at the bottom of this file).
+    // A single synchronous read lands in that gap often enough to fail ~40% of
+    // webkit runs, and `toHaveURL` passing first does not help — it matches the
+    // pre-settle state and the gap opens after it.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('search'))
+      .toBe('read_status:in_progress');
   });
 
   test('clicking In Progress sends the filter to the server', async ({ page }) => {
@@ -128,7 +136,81 @@ test.describe('Library sidebar filters', () => {
     await clickSubItem(page, 'Finished');
 
     await expect(selectedSubItems(page)).toHaveText(['Finished']);
-    expect(new URL(page.url()).searchParams.get('search')).toBe('read_status:finished');
+    // Same transient-drop hazard as the In Progress test above — poll, do not
+    // read once. Waiting on the highlight is not a gate: the highlight and the
+    // search param are written by different effects.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('search'))
+      .toBe('read_status:finished');
+  });
+
+  // KNOWN DEFECT, deliberately not routed around. Sampling `location.search`
+  // every animation frame across a sidebar click shows Library.tsx passing
+  // through a state where it has THROWN THE FILTER AWAY, 3 runs out of 3:
+  //
+  //     ?page=1                                 (initial)
+  //     ?search=read_status:finished            (click applies the filter)
+  //     ?page=1                                 <-- filter gone
+  //     ?search=read_status%3Afinished&page=1   (re-applied, settled)
+  //
+  // This is the same shape the comment on the "survives the URL settling" test
+  // above describes as fixed by #2193 — the stuck guard "used to throw the
+  // search away and restore a bare page=1". It still happens; it just recovers
+  // now, so nothing downstream notices.
+  //
+  // Measured blast radius, so nobody re-derives it: exactly ONE request reaches
+  // /api/v1/audiobooks after the click and it carries the correct `filters`
+  // param — the transient drop costs no wasted query and never sends the server
+  // the wrong thing. The cost is confined to the URL and history: a spurious
+  // intermediate entry, and a flicker for anything reading searchParams
+  // directly. That is why this is filed rather than treated as urgent.
+  //
+  // Marked `fixme` (skipped, never executed) rather than `fail`. The race is
+  // real but not certain: forced on, this check fails **5 runs out of 8** on
+  // webkit. `test.fail()` would therefore report a spurious "expected to fail
+  // but passed" on roughly a third of runs, which is a worse signal than none.
+  // To reproduce deliberately:
+  //
+  //   sed -i '' "s/test.fixme('the filter never/test('the filter never/" \
+  //     tests/e2e/library-sidebar-filters.spec.ts
+  //   npx playwright test -c tests/e2e/playwright.config.ts --project=webkit \
+  //     tests/e2e/library-sidebar-filters.spec.ts -g "never disappears" \
+  //     --repeat-each=8 --workers=1
+  //
+  // When the race is actually fixed this should pass 8/8; flip it to a normal
+  // test at that point.
+  //
+  // See todo.d/20260809-library-url-transient-filter-drop.md.
+  test.fixme('the filter never disappears from the URL while the effects settle', async ({ page }) => {
+    await openLibrary(page);
+
+    await page.evaluate(() => {
+      const w = window as unknown as { __urls: string[] };
+      w.__urls = [];
+      const tick = () => {
+        w.__urls.push(location.search);
+        if (w.__urls.length < 3000) requestAnimationFrame(tick);
+      };
+      tick();
+    });
+
+    await clickSubItem(page, 'Finished');
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('search'))
+      .toBe('read_status:finished');
+
+    const samples: string[] = await page.evaluate(
+      () => (window as unknown as { __urls: string[] }).__urls
+    );
+    const firstSet = samples.findIndex((u) => u.includes('read_status'));
+    expect(firstSet, 'the filter should reach the URL at all').toBeGreaterThanOrEqual(0);
+    const droppedAfterBeingSet = samples
+      .slice(firstSet)
+      .filter((u) => !u.includes('read_status'));
+    expect(
+      droppedAfterBeingSet,
+      'once applied, the filter must never leave the URL again'
+    ).toEqual([]);
   });
 
   test('All Books clears the filter and takes the highlight back', async ({ page }) => {


### PR DESCRIPTION
The last webkit-only failures. `library-sidebar-filters.spec.ts`: **~40% flaky → 0 failures over 5 repeats**, on both browsers (30 passed / 5 skipped webkit, 18 passed / 3 skipped chromium).

## Three hypotheses tested and rejected

All by measurement, not reasoning — each one looked right:

1. **A race between the highlight effect and the URL effect.** Adding a retrying `toHaveURL` gate did **not** fix it; a different test failed instead.
2. **The URL being clobbered and left wrong.** Sampling every 100 ms for 4 s showed it perfectly stable.
3. **The mobile/permanent drawer duplication this file documents.** A probe showed the `:visible` scoping resolves to exactly 1 element, 3 runs of 3, and the click lands correctly every time.

## The actual cause

Sampling `location.search` every animation frame across the click — 3 of 3 runs, identical:

```
?page=1                                 initial
?search=read_status:finished            click applies the filter
?page=1                                 <-- filter thrown away
?search=read_status%3Afinished&page=1   re-applied, settled
```

**`Library.tsx` does not settle monotonically — it passes through a state with the filter gone.** That is why `toHaveURL` passing first didn't help: it matches the *pre*-settle state, and the gap opens after it. A single synchronous `new URL(page.url())` read lands in that gap often enough to flake webkit ~40% of the time while chromium's narrower window usually misses it.

**Test fix:** both sites now use `expect.poll`, which this file already uses for the All Books case.

## The defect is filed, not routed around

The transient drop is real, so per the no-papering-over rule it gets written up rather than quietly worked around — with its **measured** blast radius, because it's narrower than it first looks:

**Exactly one request reaches `/api/v1/audiobooks` after the click, carrying the correct `filters` param.** The drop costs no wasted query and never sends the server the wrong thing. The cost is confined to the URL and history — a spurious intermediate entry, and a flicker for anything reading `searchParams` directly. Filed rather than treated as urgent, but not closed as "works fine" either: the URL is the app's shareable state and it's briefly wrong on every filter click.

Likely location and a starting hypothesis are in `todo.d/20260809-library-url-transient-filter-drop.md` — the write effect rebuilds the param set from scratch, so any render where `searchQuery` hasn't caught up emits a URL with no `search` at all.

## The regression test is skipped on purpose

Included as `test.fixme`, not `test.fail`. Forced on, it fails **5 runs out of 8** — so `test.fail()` would report a spurious "expected to fail but passed" about a third of the time, which is a worse signal than none. The recipe to force it is in the comment above it; when the race is genuinely fixed it should pass 8/8 and can become a normal test.

I checked this rather than assuming: my first single forced run **passed**, which would have left a vacuously-green marker in the suite had I stopped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp