### PR TITLE
fix(web): stop the Library fetching page 1 twice on every mount

### DIFF
--- a/changelog.d/20260809_290000_library_duplicate_mount_fetch.md
+++ b/changelog.d/20260809_290000_library_duplicate_mount_fetch.md
@@ -1,0 +1,13 @@
+<!-- file: changelog.d/20260809_290000_library_duplicate_mount_fetch.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e2b71c68-40d5-4a93-8f17-c5904ab3e2d1 -->
+<!-- last-edited: 2026-08-09 -->
+
+### Fixed
+
+- **The Library asked the server for the same page of books twice every time you
+  opened it.** The search box re-parsed its (empty) contents on load and reported
+  a result that was identical to the one already held, which was enough to make
+  the page think its filters had changed and fetch everything a second time. On a
+  large library that is a full duplicate query on every visit. It now fetches
+  once.

--- a/todo.d/20260809-library-double-fetch-swallows-clicks.md
+++ b/todo.d/20260809-library-double-fetch-swallows-clicks.md
@@ -1,5 +1,5 @@
 <!-- file: todo.d/20260809-library-double-fetch-swallows-clicks.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: b6e4207f-9c31-4d85-a072-3fe185c9a4b8 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -23,7 +23,18 @@
       3 s. The distinguishing feature of the failing run is the **duplicate initial
       fetch**: two identical `offset=0` requests instead of one.
 
-      **Two problems, and the first probably causes the second:**
+      **CORRECTION 2026-08-09 (later the same day).** The causal claim below —
+      that the duplicate fetch causes the swallowed click — is **wrong**, or at
+      least incomplete. The duplicate was found and eliminated (see the fix note
+      at the bottom); measured like-for-like over 24 webkit runs of the same
+      three tests, the failure rate went **16/24 → 11/24**. A real improvement,
+      but the flake survives, so something else is also at work. The remaining
+      failures have also shifted shape: `navigates to previous page` now fails
+      with "Test Book 1 **not found**" after going next-then-previous, i.e.
+      page 1 does not come back — the inverse of the original symptom. Whoever
+      picks this up should treat the two as separate defects.
+
+      **Two problems, and the first was wrongly assumed to cause the second:**
 
       1. **A wasted duplicate query on mount.** On a large library that is a second full
          page query for nothing. It belongs with the other client-side over-fetching
@@ -58,3 +69,17 @@
 
       **Acceptance:** one `offset=0` request per Library mount, and the three pagination
       tests pass 8/8 on webkit with `--repeat-each=8`.
+
+      **Half of that is now met.** The duplicate mount fetch is fixed: `SearchBar`
+      re-parses its value on mount and hands back a NEW `ParsedSearch` object that is
+      semantically identical to the one `Library.tsx` seeded its state with. Storing it
+      changed `parsedSearch`'s identity → recreated `buildFieldFilters` → recreated
+      `loadAudiobooks` → re-fired the "load when filters change" effect. Confirmed by
+      instrumenting the dependency array: `DEPCHANGE buildFieldFilters,parsedSearch`
+      fired once after mount on 4 runs of 4, and stopped firing entirely once the setter
+      bailed on an unchanged value. `/api/v1/audiobooks` is now hit exactly once per
+      mount, 4 runs of 4.
+
+      **The pagination flake is still open** and needs its own investigation — start from
+      the shifted symptom above rather than from the duplicate fetch, which is no longer
+      present.

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -643,6 +643,24 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     localStorage.setItem(STORAGE_KEYS.LIBRARY_PAGE, page.toString());
   }, [filters, itemsPerPage, page, searchQuery, selectedTags, setSearchParams, sortBy, sortOrder, viewMode]);
 
+  // SearchBar re-parses its value on mount and hands back a NEW ParsedSearch
+  // object that is semantically identical to the one this state was seeded
+  // with. Storing it changed `parsedSearch`'s identity, which recreated
+  // `buildFieldFilters`, which recreated `loadAudiobooks`, which re-fired the
+  // "load when filters change" effect — a second, identical offset=0 request
+  // issued before the first had resolved. When that second response landed
+  // while the user was clicking, the re-render detached the pagination button
+  // mid-click and the click was silently lost.
+  //
+  // Bail out when the parsed value has not actually changed. Returning `prev`
+  // from the updater makes React skip the re-render entirely, so the identity
+  // chain never starts.
+  const handleParsedSearchChange = useCallback((next: ParsedSearch) => {
+    setParsedSearch((prev) =>
+      JSON.stringify(prev) === JSON.stringify(next) ? prev : next
+    );
+  }, []);
+
   const buildFieldFilters = useCallback(() => {
     const fieldFilters: Array<{ field: string; value: string; negated: boolean }> = [];
     if (filters.author) fieldFilters.push({ field: 'author', value: filters.author, negated: false });
@@ -1908,7 +1926,7 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
           onCancelLoad={handleCancelLoad}
           searchQuery={searchQuery}
           setSearchQuery={setSearchQuery}
-          setParsedSearch={setParsedSearch}
+          setParsedSearch={handleParsedSearchChange}
           viewMode={viewMode}
           setViewMode={setViewMode}
           sortBy={sortBy}


### PR DESCRIPTION
## The bug

`SearchBar` re-parses its value on mount and calls `onParsedSearchChange` with a **new** `ParsedSearch` object that is semantically identical to the one `Library.tsx` seeded its state with. Storing it changed `parsedSearch`'s identity → recreated `buildFieldFilters` → recreated `loadAudiobooks` → re-fired the "load when filters change" effect. Result: **a second, identical `offset=0` request, issued before the first had resolved.**

On a large library that's a full duplicate page query on every single visit.

`Library.tsx` now bails out of the state update when the parsed value hasn't actually changed — returning `prev` from the updater makes React skip the re-render, so the identity chain never starts.

**Verified by instrumenting the dependency array** rather than by inference: `DEPCHANGE buildFieldFilters,parsedSearch` fired once after mount on **4 runs of 4**, and reported no changes at all after the fix. `/api/v1/audiobooks` is now hit exactly once per mount, 4 of 4.

## What this does NOT do

Stated plainly, because `todo.d/20260809-library-double-fetch-swallows-clicks.md` — which I filed earlier today — guessed otherwise.

**It does not fix the three flaky webkit pagination tests.** That fragment claimed the duplicate fetch was what swallowed the next click. It is at most a contributor. Measured like-for-like, same command, 24 webkit runs each:

| | failed | passed |
|---|---|---|
| baseline | 16 | 8 |
| with this fix | **11** | **13** |

Better, not fixed. The surviving failures have also **changed shape** — `navigates to previous page` now fails with `Test Book 1` **not found** after next-then-previous (page 1 doesn't come back), the inverse of the original symptom. That strongly suggests the remainder is a separate defect, and the fragment has been corrected to say so rather than leaving a wrong causal claim on the record for the next person to build on.

## Verification

- **No test was changed** to accommodate any of this.
- chromium: **37 passed / 3 skipped** across `library-browser`, `library-sidebar-filters`, `search-and-filter`.
- Frontend unit tests: **108 passed** across 21 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp