### PR TITLE
test(e2e): make webkit pagination tests robust against swallowed clicks [skip changelog]

### DIFF
--- a/changelog.d/20260809_121500_e2e_pagination_webkit_flake.md
+++ b/changelog.d/20260809_121500_e2e_pagination_webkit_flake.md
@@ -1,0 +1,14 @@
+<!-- Test-only change: no user-visible behaviour changed, so this fragment is
+     intentionally all comments and contributes nothing to CHANGELOG.md.
+
+     The three webkit-only pagination tests in library-browser.spec.ts were
+     flaky (11 failures in 24 runs). Measurement showed the application is
+     correct and Playwright's synthesised pointer click on MUI's PaginationItem
+     is what is unreliable on webkit: driving the identical buttons with an
+     in-page DOM click passed 6 runs of 6, while the Playwright click failed
+     4 of 4. The tests now use a clickPagination helper that re-checks the URL,
+     clicks, asserts, and retries once — actionability checks preserved, so a
+     genuinely broken control still fails.
+
+     todo.d/20260809-library-double-fetch-swallows-clicks.md carries the full
+     evidence trail, including the two earlier causal claims this corrects. -->

--- a/todo.d/20260809-library-double-fetch-swallows-clicks.md
+++ b/todo.d/20260809-library-double-fetch-swallows-clicks.md
@@ -1,85 +1,76 @@
 <!-- file: todo.d/20260809-library-double-fetch-swallows-clicks.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: b6e4207f-9c31-4d85-a072-3fe185c9a4b8 -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **The Library sometimes fetches page 1 twice on mount, and when it does, the very
-      next click is swallowed.** Found 2026-08-09 while chasing three flaky
-      `library-browser.spec.ts` pagination tests on webkit. This is a product defect, not
-      test rot, so the tests were left alone per the no-papering-over rule — they are
-      honestly flaky because the app is.
+- [x] **The Library fetched page 1 twice on every mount — FIXED.** Found 2026-08-09 while
+      chasing three flaky `library-browser.spec.ts` pagination tests on webkit. On a large
+      library that is a second full page query for nothing, on every single load.
 
-      **Evidence.** A probe that records every `/api/v1/audiobooks` request, loads
-      `/library`, waits for `networkidle`, clicks "next page", then samples for 3s.
-      Three runs, and the third diverges:
+      **Cause.** `SearchBar` re-parsed its value on mount and handed back a NEW
+      `ParsedSearch` object that was semantically identical to the one `Library.tsx` had
+      seeded its state with. Storing it changed `parsedSearch`'s *identity* → recreated
+      `buildFieldFilters` → recreated `loadAudiobooks` → re-fired the "load when filters
+      change" effect. Confirmed by instrumenting the dependency array:
+      `DEPCHANGE buildFieldFilters,parsedSearch` fired once after mount on 4 runs of 4, and
+      stopped firing entirely once the setter bailed on an unchanged value.
 
-      | run | requests before click | after click |
-      |---|---|---|
-      | 1 | `offset=0` | URL → `?page=2`, `offset=20` fetched, page-1 book gone ✅ |
-      | 2 | `offset=0` | URL → `?page=2`, `offset=20` fetched, page-1 book gone ✅ |
-      | 3 | `offset=0`, **`offset=0` again** | URL stays `?page=1`, **no request**, page-1 book still shown ❌ |
+      **Fix** (#2241): `Library.tsx` now wraps the setter so an equal value keeps the
+      previous object reference. `/api/v1/audiobooks` is hit exactly once per mount, 4 runs
+      of 4.
 
-      The click is not slow — it is **gone**. Nothing happens at 200 ms, 600 ms, 1.5 s or
-      3 s. The distinguishing feature of the failing run is the **duplicate initial
-      fetch**: two identical `offset=0` requests instead of one.
+      This belongs with the other client-side over-fetching in
+      `todo.d/20260809-search-drops-filters-and-debounce.md` — that one is ten queries per
+      search, this was two per page load.
 
-      **CORRECTION 2026-08-09 (later the same day).** The causal claim below —
-      that the duplicate fetch causes the swallowed click — is **wrong**, or at
-      least incomplete. The duplicate was found and eliminated (see the fix note
-      at the bottom); measured like-for-like over 24 webkit runs of the same
-      three tests, the failure rate went **16/24 → 11/24**. A real improvement,
-      but the flake survives, so something else is also at work. The remaining
-      failures have also shifted shape: `navigates to previous page` now fails
-      with "Test Book 1 **not found**" after going next-then-previous, i.e.
-      page 1 does not come back — the inverse of the original symptom. Whoever
-      picks this up should treat the two as separate defects.
+      ---
 
-      **Two problems, and the first was wrongly assumed to cause the second:**
+      **TWO CORRECTIONS, both worth reading — this fragment was wrong twice.**
 
-      1. **A wasted duplicate query on mount.** On a large library that is a second full
-         page query for nothing. It belongs with the other client-side over-fetching
-         already filed in `todo.d/20260809-search-drops-filters-and-debounce.md` — that
-         one is ten queries per search, this is two per page load.
-      2. **The re-render from that second response detaches the pagination button
-         mid-click**, so the handler never runs and the interaction is silently lost. A
-         user would see this as "I clicked next page and nothing happened."
+      **Correction 1.** The original fragment claimed the duplicate fetch *caused* the
+      swallowed pagination click: the re-render from the second response was said to detach
+      the button mid-click. Measured like-for-like over 24 webkit runs of the same three
+      tests, eliminating the duplicate moved the failure rate **16/24 → 11/24**. A real
+      improvement, but the flake survived, so the causal claim was at best incomplete.
 
-      **Why it is webkit-flaky rather than constant:** the duplicate only sometimes lands
-      in the window where the user (or the test) is clicking. Chromium's timing usually
-      misses it. It is not a webkit bug — webkit just widens the window.
+      **Correction 2 — and this is the one that matters.** The residual flake is **not a
+      product defect at all.** It is a Playwright/webkit harness artifact. Five probes:
 
-      **Suspected cause,** same neighbourhood as
-      `todo.d/20260809-library-url-transient-filter-drop.md`: the paired effects in
-      `web/src/pages/Library.tsx` (~lines 596-644) that read `searchParams` into state and
-      write state back to `searchParams`. A mount that writes the URL once and reads it
-      back can re-run `loadAudiobooks` with identical arguments. `useLibraryQuery` has a
-      results cache, but the second call is issued before the first resolves, so the cache
-      cannot dedupe it — an in-flight map keyed by the request signature would.
+      | probe | result |
+      |---|---|
+      | failing run instrumented | previous-page click → no request, no URL change (swallowed) |
+      | click twice | first swallowed, second works — looked like a stale closure |
+      | same probe on chromium | first click works; webkit-specific |
+      | Playwright click vs in-page DOM `.click()` | **Playwright 4/4 failed, DOM 4/4 passed** |
+      | both clicks via in-page DOM | **6/6 clean** |
 
-      **Reproduce:**
+      The application handles pagination correctly. Playwright's *synthesised pointer
+      event* on MUI's `PaginationItem` is what is unreliable on webkit — the same DOM, the
+      same handlers, the same React state, driven by a real DOM click, works every time.
 
-      ```bash
-      cd web && npx playwright test -c tests/e2e/playwright.config.ts --project=webkit \
-        tests/e2e/library-browser.spec.ts -g "navigates to (next|previous) page" \
-        --repeat-each=3 --workers=1
-      ```
+      **So the tests were made robust** (`clickPagination` helper in
+      `library-browser.spec.ts`): re-check the URL, click, assert, and retry once. This does
+      **not** violate the no-papering-over rule, because the measurement establishes there
+      is no product bug to paper over. Result: **24/24 on webkit**, against an 11/24 failure
+      baseline.
 
-      Observed 5 failures across 3 repeats of the file (`navigates to previous page` 2/3,
-      `navigates to next page` 2/3, `jumps to specific page` 1/3).
+      **What the helper does NOT protect against — stated plainly, because the first draft
+      of this fragment claimed the opposite.** It originally said the helper "still fails
+      loudly if the app ever genuinely stops responding, since the second click would be
+      swallowed too." That is **false**, and falsified by the very probe above: the observed
+      webkit signature is *first click swallowed, second click works*. A product regression
+      with that same shape — pagination responding only on every other click — would be
+      silently masked. The helper is not a detector for that case.
 
-      **Acceptance:** one `offset=0` request per Library mount, and the three pagination
-      tests pass 8/8 on webkit with `--repeat-each=8`.
+      What it does still catch: a control that is missing, disabled, covered, or entirely
+      unresponsive, since both clicks fail and actionability checks are deliberately
+      preserved (no `force: true`, no `dispatchEvent`). And to keep the masking observable
+      rather than invisible, **every retry logs a `[clickPagination]` warning and pushes a
+      `flaky-click-retry` annotation** — so a rising retry rate in CI is the signal that
+      something changed, even though the suite stays green.
 
-      **Half of that is now met.** The duplicate mount fetch is fixed: `SearchBar`
-      re-parses its value on mount and hands back a NEW `ParsedSearch` object that is
-      semantically identical to the one `Library.tsx` seeded its state with. Storing it
-      changed `parsedSearch`'s identity → recreated `buildFieldFilters` → recreated
-      `loadAudiobooks` → re-fired the "load when filters change" effect. Confirmed by
-      instrumenting the dependency array: `DEPCHANGE buildFieldFilters,parsedSearch`
-      fired once after mount on 4 runs of 4, and stopped firing entirely once the setter
-      bailed on an unchanged value. `/api/v1/audiobooks` is now hit exactly once per
-      mount, 4 runs of 4.
-
-      **The pagination flake is still open** and needs its own investigation — start from
-      the shifted symptom above rather than from the duplicate fetch, which is no longer
-      present.
+      **The lesson, which is the reusable part:** three separate causal hypotheses were
+      filed here with confident evidence attached, and two of them were wrong. Each was
+      killed by a measurement, never by reasoning. Before filing a UI flake as a product
+      defect, do the Playwright-click-vs-DOM-click A/B — it is two minutes and it separates
+      "the app is broken" from "the driver cannot press this particular button."

--- a/web/tests/e2e/library-browser.spec.ts
+++ b/web/tests/e2e/library-browser.spec.ts
@@ -1,10 +1,60 @@
 // file: web/tests/e2e/library-browser.spec.ts
-// version: 1.4.0
+// version: 1.5.0
 // guid: b2c3d4e5-f6a7-8901-bcde-f2a3b4c5d6e7
 // last-edited: 2026-08-09
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { generateTestBooks, setupLibraryWithBooks } from './utils/test-helpers';
+
+/**
+ * Click a pagination control and wait for it to actually take effect.
+ *
+ * Playwright's synthesised pointer click on MUI's PaginationItem is unreliable
+ * on webkit. Measured on 2026-08-09: the "page 2" click is swallowed in 4 runs
+ * of 4 (no request, no URL change, the previous-page button stays disabled),
+ * while an in-page DOM `.click()` on the same buttons drives page 2 -> previous
+ * correctly 6 runs of 6. chromium never reproduces it.
+ *
+ * So the app handles these clicks fine and this retry tolerates a known harness
+ * flake rather than hiding a product defect — which matters, because an earlier
+ * pass through this file filed it AS a product defect and was wrong.
+ *
+ * KNOWN LIMIT, stated because the honest version of this matters more than a
+ * reassuring one: the observed webkit failure is "the first click is swallowed,
+ * the second works". A product regression with that same signature — pagination
+ * responding only on every other click — would therefore be MASKED by this
+ * helper. It is not a loud failure detector for that specific shape. What it
+ * does still catch: a control that is missing, disabled, covered, or entirely
+ * unresponsive (both clicks fail). To keep the masking observable rather than
+ * invisible, every retry logs and records a test annotation, so a rising retry
+ * rate in CI output is the signal that something changed.
+ *
+ * Actionability is deliberately preserved (no `force: true`, no
+ * `dispatchEvent`): the button must still be visible and enabled.
+ */
+async function clickPagination(page: Page, name: RegExp, expectedUrl: RegExp) {
+  const button = page.getByRole('button', { name }).first();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // Re-check before every click. A blind retry would double-advance if the
+    // first click landed and only the assertion below timed out.
+    if (expectedUrl.test(new URL(page.url()).search)) break;
+    await button.click();
+    try {
+      await expect(page).toHaveURL(expectedUrl, { timeout: 3000 });
+      break;
+    } catch {
+      if (attempt === 1) throw new Error(
+        `pagination control ${name} did not navigate to ${expectedUrl} after 2 clicks`,
+      );
+      // Make the masked click visible. See KNOWN LIMIT above: a silent retry
+      // would hide a real every-other-click regression, so it must be noisy.
+      const note = `pagination click on ${name} was swallowed; retrying (known webkit harness flake)`;
+      console.warn(`[clickPagination] ${note}`);
+      test.info().annotations.push({ type: 'flaky-click-retry', description: note });
+    }
+  }
+  await expect(page).toHaveURL(expectedUrl, { timeout: 5000 });
+}
 
 test.describe('Library Browser', () => {
   // Setup handled by setupLibraryWithBooks() which calls setupMockApi()
@@ -416,7 +466,7 @@ test.describe('Library Browser', () => {
     await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Test Book 5', exact: true })).not.toBeVisible();
 
-    await page.getByRole('button', { name: /next page/i }).click();
+    await clickPagination(page, /next page/i, /[?&]page=2/);
 
     // THEN: Page 2 has different books
     await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).not.toBeVisible();
@@ -430,12 +480,12 @@ test.describe('Library Browser', () => {
     await page.goto('/library');
     await page.waitForLoadState('networkidle');
 
-    await page.getByRole('button', { name: /page 2/i }).click();
+    await clickPagination(page, /page 2/i, /[?&]page=2/);
     // Page 2 should NOT have "Test Book 1" (first alphabetically)
     await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).not.toBeVisible();
 
     // WHEN: User clicks "Previous" pagination button
-    await page.getByRole('button', { name: /previous page/i }).click();
+    await clickPagination(page, /previous page/i, /[?&]page=1/);
 
     // THEN: Page 1 is loaded with "Test Book 1"
     await expect(page.getByRole('heading', { name: 'Test Book 1', exact: true })).toBeVisible();
@@ -450,7 +500,7 @@ test.describe('Library Browser', () => {
     await page.waitForLoadState('networkidle');
 
     // WHEN: User clicks page "3" button
-    await page.getByRole('button', { name: /page 3/i }).click();
+    await clickPagination(page, /page 3/i, /[?&]page=3/);
 
     // THEN: Page 3 is loaded
     await expect(page.getByRole('heading', { name: 'Test Book 49', exact: true })).toBeVisible();


### PR DESCRIPTION
## What

The three pagination tests in `library-browser.spec.ts` failed **11 times in 24** webkit runs. This makes them robust — and corrects the record, because they were filed as a product defect twice and both times that was wrong.

## Why this is not papering over a bug

Five probes, each killing a hypothesis by measurement rather than reasoning:

| probe | result |
|---|---|
| failing run instrumented | click → no request, no URL change (swallowed) |
| click twice | first swallowed, second works |
| same probe on chromium | first click works — webkit-specific |
| Playwright click vs in-page DOM `.click()` | **Playwright 4/4 failed, DOM 4/4 passed** |
| both clicks via in-page DOM | **6/6 clean** |

Identical DOM, identical handlers, identical React state — driven by a real DOM click it works every time. Playwright's *synthesised pointer event* on MUI's `PaginationItem` is what is unreliable on webkit. The application handles pagination correctly.

## The fix

`clickPagination()` re-checks the URL, clicks, asserts, retries once. The pre-click re-check prevents a double-advance when the first click landed and only the assertion timed out. Actionability is deliberately preserved (no `force: true`, no `dispatchEvent`), so a missing, disabled or covered control still fails.

## The retry is noisy on purpose

Every retry logs `[clickPagination]` and pushes a `flaky-click-retry` annotation. The verification run **fired 7 retries across 12 tests** — so without the warning this suite would be green while silently retrying ~44% of its clicks. That number matches the 11/24 (46%) failure baseline, which is what turns the story into a verified one.

**Stated limit, because an earlier draft claimed the opposite and was wrong:** the observed webkit signature is *first click swallowed, second works*. A product regression with that same shape — pagination responding only every other click — would be **masked** by this retry. It is not a detector for that case. It still catches a control that is missing, disabled, covered, or entirely unresponsive.

## Measured

| run | result |
|---|---|
| webkit, 3 tests, `--repeat-each=8` | **24/24 passed** (baseline: 11/24 failing) |
| full `library-browser.spec.ts`, chromium + webkit | **42/42 passed** |
| edited helper re-verified, webkit `--repeat-each=4` | **12/12 passed**, 7 retries logged |

## Also

Rewrites `todo.d/20260809-library-double-fetch-swallows-clicks.md`. The duplicate mount fetch it found was real and is fixed (#2241); the pagination half was not. The fragment now carries both corrections and the reusable lesson: **do the Playwright-click-vs-DOM-click A/B before filing a UI flake as a product defect** — two minutes, and it separates "the app is broken" from "the driver cannot press this button."

Test-only; `changelog.d` fragment is intentionally all-comments.