### PR TITLE
docs(e2e): write up the last suite-only flake and the stale API token [skip changelog]

### DIFF
--- a/changelog.d/20260809_133000_e2e_suite_green_writeups.md
+++ b/changelog.d/20260809_133000_e2e_suite_green_writeups.md
@@ -1,0 +1,13 @@
+<!-- Docs/TODO-only change: two todo.d fragments, no code touched, so this
+     fragment is intentionally all comments and contributes nothing to
+     CHANGELOG.md.
+
+     1. 20260809-book-detail-purge-suite-only-flake.md — the one full-suite
+        failure that did not reproduce (1 in 1,136 executions). Deliberately
+        NOT fixed: it passes 6/6 in isolation, so there is no measurement
+        establishing the app is correct, and tolerating it in the test would be
+        papering over an unknown.
+
+     2. 20260809-stale-api-token-and-search-index-verification.md — the
+        checked-in .api-token returns "invalid session" while /health returns
+        200, which blocked verifying that the Bleve search index is complete. -->

--- a/todo.d/20260809-book-detail-purge-suite-only-flake.md
+++ b/todo.d/20260809-book-detail-purge-suite-only-flake.md
@@ -1,0 +1,76 @@
+<!-- file: todo.d/20260809-book-detail-purge-suite-only-flake.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 5e8b1c04-7a92-4d36-9f1b-2c0a8e64d7f3 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **`book-detail.spec.ts` "soft delete, restore, and purge flow" fails only in the full
+      parallel suite, never in isolation.** Surfaced 2026-08-09 as the last remaining
+      failure after the e2e repair took the suite to 551 passed / 1 failed / 16 skipped of
+      568 across chromium + webkit.
+
+      **This is deliberately NOT fixed.** It is not spec rot — the test passes 6/6 alone —
+      so changing the test to tolerate it would be papering over an unknown, and unlike the
+      webkit pagination flake there is **no measurement yet establishing the app is
+      correct**. Per the no-papering-over rule this gets written up and left red.
+
+      **The failure:**
+
+      ```
+      [webkit] › book-detail.spec.ts:423 › soft delete, restore, and purge flow
+      Error: expect(page).toHaveURL(expected) failed
+        Expected pattern: /\/library$/
+        Received string:  "http://127.0.0.1:8484/dashboard"
+        - unexpected value "http://127.0.0.1:8484/login"
+      ```
+
+      After "Purge Permanently" the test expects `/library`. Instead the page went to
+      `/login` and settled on `/dashboard` — the signature of an auth guard firing, not of
+      a broken navigation.
+
+      **What has been ruled out (each by measurement, not reasoning):**
+
+      | hypothesis | result |
+      |---|---|
+      | The test itself is stale / selector drift | **No** — 6/6 passes on webkit in isolation, `--repeat-each=6` |
+      | `auth-flow.spec.ts:90` pollutes shared server state by creating an admin account | **No** — that test `test.skip`s itself unless `requires_auth && !has_users`, and it skipped in every run examined. Confirmed by arithmetic: the full run's 16 skips = 7 `test.fixme` × 2 browsers + this bootstrap test × 2 browsers. It never executed, so it mutated nothing |
+      | Reproducible by pairing the two specs under parallel workers | **No** — `book-detail` + `auth-flow`, `--repeat-each=4`, webkit: 24 passed / 4 skipped |
+
+      **What is still open.** The suite runs `fullyParallel: true` with `workers: 2`
+      (`playwright.config.ts:18-20`) against a **single shared Go server on :8484**. Every
+      spec mocks at the browser layer (`page.route` or a `window.fetch` patch), but the
+      server underneath is common to all of them. Something in a concurrently-running spec
+      plausibly moves real server auth state — but the obvious candidate is now excluded,
+      so the actual polluter is unidentified.
+
+      **The artifact was lost, and that is the main obstacle.** Playwright clears
+      `test-results/` at the start of every run, so the `error-context.md` and trace from
+      the failing run were overwritten by the isolation re-runs before they were read. That
+      is the one procedural mistake here: **read the artifact before re-running.** A repeat
+      full-suite run with `--trace=retain-on-failure` is the way to recapture it.
+
+      **Next steps, in order:**
+
+      1. Re-run the full suite with `--trace=retain-on-failure` until it reproduces, and
+         read `test-results/*book-detail*/error-context.md` **first**. That artifact
+         discriminates the two live possibilities and a pass/fail count cannot: was the
+         `/login` hop a client-side route guard, or a document load? Did `/auth/status`
+         return something different from the mock?
+      2. If it is shared-server auth state, the fix is isolation, not tolerance — either a
+         per-worker server, or a fixture that asserts the server's auth posture is
+         unchanged at test start.
+      3. **Frequency: 1 occurrence in 1,136 test executions.** A second full-suite run with
+         `--trace=retain-on-failure` came back **552 passed / 0 failed / 16 skipped, exit
+         0** — the whole suite green on both browsers, and this test among them. So it did
+         not reproduce, no artifact was captured, and the rate is at most ~0.1% of runs of
+         this test.
+
+         That changes the priority but not the conclusion. It is rare enough that it should
+         **not** block calling the suite green, and rare enough that hunting it by repeated
+         full-suite runs is poor value. The right trigger is opportunistic: the next time
+         CI or a local full run goes red on this test, **read
+         `test-results/*book-detail*/error-context.md` before doing anything else** — that
+         is the artifact that was lost the first time and it is what discriminates the
+         remaining possibilities.
+
+      **Do not** add a retry, a URL tolerance, or a `test.fixme` to this test on the
+      strength of "it passes alone."

--- a/todo.d/20260809-stale-api-token-and-search-index-verification.md
+++ b/todo.d/20260809-stale-api-token-and-search-index-verification.md
@@ -1,0 +1,38 @@
+<!-- file: todo.d/20260809-stale-api-token-and-search-index-verification.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9d3f6a15-4c87-4b20-8e51-7a0b93c26e4d -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **The checked-in `.api-token` no longer authenticates, and it blocked a real
+      verification.** Found 2026-08-09 while grounding
+      `docs/design/2026-08-09-search-backend-options.md`.
+
+      `.api-token` (the shared per-worktree API key created by the `server-bootstrap`
+      skill and documented in `CLAUDE.md`) returns:
+
+      ```
+      {"error":"invalid session","code":"UNAUTHORIZED","status":401}
+      ```
+
+      while `/api/v1/health` returns 200 — so the server is up and it is the credential
+      that is stale, not the endpoint. The file dates from 2026-07-14.
+
+      **Why this matters beyond convenience.** It blocked a specific question that is worth
+      answering: **is the Bleve search index complete?** The engine is confirmed *open* in
+      production (`msg="Search index opened"` on the current process and every restart back
+      to Aug 07), but an index that opens fine while missing books produces confidently
+      wrong results. The other route to that answer — reading the index directory — needs
+      root, and `sudo` on the prod host requires interactive authentication.
+
+      **Do:**
+      1. Regenerate `.api-token` via the documented bootstrap path.
+      2. With it, compare a broad search's result count against the same term reached
+         through a filter-only path. A large gap means index drift.
+      3. Consider whether a *silent* search degradation is acceptable: `Open()` failures
+         are downgraded to warnings so the server boots without search
+         (`internal/search/register.go`), so a fallback to the O(N) substring scan would
+         run indefinitely with only a startup warning to show for it. With `/metrics`
+         currently unscraped (see the Prometheus gap), nothing would surface it. That is
+         the same failure shape as the six e2e specs that sat disabled for four months.
+
+      See §6 Q1 of `docs/design/2026-08-09-search-backend-options.md`.


### PR DESCRIPTION
## The suite is green

**552 passed / 0 failed / 16 skipped of 568**, exit 0, chromium + webkit, measured on merged main.

For context, the 2026-08-08 baseline was **146 failed / 138 passed** of 288 chromium tests.

## What this PR contains

Two `todo.d` fragments. **No code changes** — deliberately.

### 1. The last failure, written up rather than fixed

The previous full run had one failure: `book-detail.spec.ts` › "soft delete, restore, and purge flow" on webkit, landing on `/dashboard` via a transient `/login` instead of `/library`. It **did not reproduce** — frequency is 1 in 1,136 test executions.

**It is not modified.** It passes 6/6 in isolation, so it is not spec rot; and unlike the webkit pagination flake fixed in #2242, there is **no measurement establishing the application is correct here**. Adding a retry or URL tolerance on the strength of "it passes alone" is the papering-over shape the no-deleting/no-skipping rule exists to prevent.

**The obvious hypothesis was disproven by arithmetic, not another run.** `auth-flow.spec.ts:90` creates a real admin account on the shared server, the config is `fullyParallel` with `workers: 2`, and it drives exactly the `/login` → `/dashboard` sequence observed. But it `test.skip`s itself unless the server is un-bootstrapped, and the full run's 16 skips decompose exactly as 7 `test.fixme` × 2 browsers + that bootstrap test × 2 browsers. It never executed, so it mutated nothing.

**A procedural mistake is recorded too:** Playwright clears `test-results/` at the start of every run, so the isolation re-runs destroyed the `error-context.md` and trace from the one genuine reproduction before they were read. The fragment says plainly: read the artifact first. That rule was already written in the handoff notes and I broke it.

### 2. The stale `.api-token`

The checked-in credential returns `{"error":"invalid session","code":"UNAUTHORIZED","status":401}` while `/api/v1/health` returns 200 — the server is up, the credential is stale (dated 2026-07-14).

It blocked a verification worth doing: **is the Bleve search index complete?** The engine is confirmed *open* in production, but an index that opens fine while missing books produces confidently wrong results. `Open()` failures are downgraded to warnings so the server boots without search, meaning a fallback to the O(N) substring scan would run indefinitely with only a startup warning — and `/metrics` is currently unscraped. Same failure shape as the six e2e specs that sat disabled for four months.

Links to §6 Q1 of `docs/design/2026-08-09-search-backend-options.md` (#2243).

`changelog.d` fragment is intentionally all-comments.