### PR TITLE
docs(e2e): close out the repair with the final measured state [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.19.0 -->
+<!-- version: 10.20.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -60,17 +60,32 @@ into one of the curated sections below, is a normal direct edit.
       2026-08-08 by the first-ever clean-environment run, immediately after
       wiring the suite into CI (#2202).
 
-      ✅ **DONE 2026-08-09 across 14 PRs (#2224–#2237).** Measured on merged
-      `main` from a clean worktree: **chromium 272 passed / 7 skipped / 0
-      failing**; webkit 268 / 7 / 4. The 7 skipped are `test.fixme` markers
-      attached to real product defects, so they report as *unexpected passes*
-      once fixed — nothing was deleted or silently skipped. The 4 webkit
-      failures are webkit-only pagination differences (3 `library-browser`,
-      1 `library-sidebar-filters`) and are NOT diagnosed. Full audit with
-      file:line evidence:
+      ✅ **DONE 2026-08-09 across 17 PRs (#2224–#2244).** Final measurement on
+      merged `main`: **552 passed / 0 failed / 16 skipped of 568**, exit 0,
+      **both browsers green**. (Intermediate state after the first 14 PRs was
+      chromium 272/7/0 and webkit 268/7/4; the webkit tail was closed by #2242
+      and #2244.) The 16 skips are 7 `test.fixme` markers × 2 browsers, each
+      attached to a real product defect so they report as *unexpected passes*
+      once fixed, plus a real-server bootstrap smoke test × 2 that skips itself
+      unless the server is un-bootstrapped. **Nothing was deleted or silently
+      skipped.** Full audit with file:line evidence:
       `docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md`.
-      Sub-items 3 (flip `continue-on-error` off) and the webkit tail remain —
-      broken out below.
+      Sub-item 3 (flip `continue-on-error` off) remains — broken out below.
+
+      **The webkit tail was not what it looked like.** 3 of the 4 were a
+      Playwright/webkit harness artifact, not a product defect: its synthesised
+      pointer click on MUI's `PaginationItem` failed 4/4 while an in-page DOM
+      click on the identical buttons passed 6/6. Fixed in #2242 (24/24 on
+      webkit, from an 11/24 failure baseline) with retries logged so the
+      masking stays visible. This had been filed as a product bug **twice**;
+      both claims are corrected on the record in
+      `todo.d/20260809-library-double-fetch-swallows-clicks.md`.
+
+      **The 4th is deliberately still open and NOT fixed** (1 occurrence in
+      1,136 executions, did not reproduce): `book-detail.spec.ts` purge flow.
+      It passes 6/6 in isolation, so there is no measurement establishing the
+      app is correct, and tolerating it in the test would be papering over an
+      unknown. See `todo.d/20260809-book-detail-purge-suite-only-flake.md`.
 
       **This contradicts what was believed on 2026-08-08 morning.** The
       executive summary

--- a/changelog.d/20260809_134500_e2e_green_closeout.md
+++ b/changelog.d/20260809_134500_e2e_green_closeout.md
@@ -1,0 +1,7 @@
+<!-- Docs-only close-out: updates TODO.md and the 2026-08-09 executive summary
+     to record the final measured state of the e2e repair -- 552 passed /
+     0 failed / 16 skipped of 568, exit 0, both browsers green, across 17 PRs
+     (#2224-#2244).
+
+     No user-visible behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md
+++ b/docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: 0d4f8a91-6c27-4e35-b8d0-51a97c3e2f46 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -78,12 +78,34 @@ are looking at. The one-click "use the value we found online" button on individu
 fields, gone. And two controls that a screen reader cannot describe at all, one of
 which is now the only route to four different actions.
 
+## Update, later the same day: the second browser is green too
+
+The four remaining failures in the second browser engine have been resolved, and the
+whole safety net now passes: **552 tests passing, none failing**, across both browsers.
+
+Three of the four turned out not to be faults in the product at all. The test software
+that pretends to be a person clicking was failing to press a button — the same button,
+in the same place, that works every time when pressed by other means. Establishing that
+took a direct comparison rather than an argument: pressed one way it failed four times
+out of four, pressed the other way it worked six times out of six. Those three tests now
+press the button in a way that works, and they announce it in the log every time they
+have to try twice, so if the situation ever changes it will be visible rather than
+quietly absorbed.
+
+This is worth stating because it had been recorded twice as a defect in the product,
+with confident-looking evidence attached both times, and both times that was wrong. The
+correction is now on the record next to the original claim rather than replacing it.
+
+The fourth failure happened once and has not happened again in over a thousand
+subsequent test runs. It has deliberately **not** been "fixed", because it passes
+whenever it is run on its own — which means nobody has yet established what was actually
+wrong, and changing the test to accept the behaviour would be assuming an answer. It is
+written up, with the frequency measured and the next step recorded, and left honest.
+
 ## What this means going forward
 
-The suite is green, and this time the number was measured the careful way and can
-be repeated: 272 passing, 0 failing, on a clean checkout. Four tests remain failing
-in a second browser engine and are honestly labelled as such rather than quietly
-excluded.
+The suite is green, and the number was measured the careful way and can be repeated:
+**552 passing, 0 failing**, on a clean checkout, across both browsers.
 
 Seven tests are deliberately marked as expected-to-fail, each one attached to a
 real defect above. They are not skipped or deleted — if someone fixes the


### PR DESCRIPTION
## Final state

**552 passed / 0 failed / 16 skipped of 568**, exit 0, both browsers, measured on merged `main`.

Baseline 2026-08-08: **146 failed / 138 passed** of 288 chromium tests. 17 PRs, #2224–#2244.

## What this corrects

The TODO entry recorded the intermediate state (chromium 272/7/0, webkit 268/7/4) and described the webkit tail as undiagnosed pagination differences. Both are now updated.

**3 of the 4 webkit failures were never a product defect.** Playwright's synthesised pointer click on MUI's `PaginationItem` is unreliable on webkit: it failed 4/4 while an in-page DOM click on the *identical* buttons passed 6/6. Fixed in #2242 — 24/24 on webkit against an 11/24 failure baseline — with every retry logged and annotated so the masking stays visible rather than silently absorbed. The verification run fired 7 retries across 12 tests, so without that logging the suite would be green while quietly retrying ~44% of its clicks.

That flake had been filed as a **product bug twice**, with confident evidence attached both times. Both claims are corrected on the record next to the originals rather than replacing them.

**The 4th is deliberately still open and NOT fixed.** 1 occurrence in 1,136 executions; did not reproduce; passes 6/6 in isolation. There is no measurement establishing the app is correct, so tolerating it in the test would be papering over an unknown — the exact shape the no-deleting/no-skipping rule exists to prevent.

## The 16 skips, spelled out

"Skipped" is precisely the word that hid the original four-month blind spot, so the close-out says what they are: **7 `test.fixme` markers × 2 browsers**, each attached to a real product defect so they report as *unexpected passes* the moment someone fixes them, plus **a real-server bootstrap smoke test × 2** that skips itself unless the server is un-bootstrapped.

Nothing was deleted or silently disabled.

## Files

- `TODO.md` — the triage entry updated with the final counts and both corrections
- `docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md` — plain-language update for the second browser going green

Docs-only; `changelog.d` fragment is intentionally all-comments.