### PR TITLE
test(e2e): fail the run when :8484 is serving a stale bundle [skip changelog]

### DIFF
--- a/changelog.d/20260809_140000_e2e_stale_server_guard.md
+++ b/changelog.d/20260809_140000_e2e_stale_server_guard.md
@@ -1,0 +1,8 @@
+<!-- Test-infrastructure change: adds web/tests/e2e/global-setup.ts, which fails
+     a local e2e run when :8484 is already serving a bundle older than the code
+     under test. No product behaviour changed, so this fragment is
+     intentionally all comments and contributes nothing to CHANGELOG.md.
+
+     Also adds a todo.d fragment recording the three linux-only e2e failures
+     that block making the CI gate blocking, measured by dispatching the
+     workflow against main rather than inferred from a stale nightly. -->

--- a/todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md
+++ b/todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md
@@ -1,0 +1,55 @@
+<!-- file: todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6b2e9047-3d51-4a8c-b7f0-8e14c5920fda -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Three linux-only e2e failures block flipping `continue-on-error` off.** Measured
+      2026-08-09 by dispatching the E2E workflow against current `main` — not inferred
+      from the nightly, which was stale.
+
+      **The numbers.** CI (ubuntu, chromium): **269 passed / 3 failed / 8 skipped of 280.**
+      The same suite locally (macOS, chromium): **272 passed / 8 skipped of 280, 0 failed.**
+      So exactly **3 failures exist only on linux.**
+
+      | # | test | symptom |
+      |---|---|---|
+      | 1 | `dynamic-ui-interactions.spec.ts:449` — Button loading states visual check | `A snapshot doesn't exist at …/scan-button-loading-chromium-linux.png` |
+      | 2 | `library-browser.spec.ts:382` — combines multiple filters | `locator.click: Test timeout of 30000ms exceeded` |
+      | 3 | `scan-import-organize.spec.ts:259` — complete workflow: add import path → scan → organize | `locator.click: Test timeout of 30000ms exceeded` |
+
+      **#2 and #3 are new information and the important part.** They pass on macOS and hang
+      on linux. That is the whole reason this measurement was worth taking: a suite that is
+      green locally is not evidence that CI is green, and this project has already been
+      burned once by exactly that inference. Do NOT assume they are "just CI slowness"
+      without looking — a 30s click timeout is a long time for a mocked page, and both are
+      `locator.click`, which is suspicious enough to be a shared cause.
+
+      **#1 is mechanical.** There are only two goldens in the repo, both `-darwin`
+      (`scan-button-loading-chromium-darwin.png`, `…-webkit-darwin.png`), and Playwright
+      fails rather than writes when `CI=true`. Generating a linux golden needs a container,
+      because `playwright.config.ts`'s `webServer` builds the Go binary and that needs CGO +
+      `libtag1-dev` — so it is a two-stage build (compile in a Go image, run in the official
+      Playwright image), not a one-liner. Alternatively let CI produce it once and upload it
+      as an artifact to be committed.
+
+      **Two workflow defects found while measuring, worth fixing in the same PR as the flip:**
+
+      1. **`conclusion: success` on this workflow means nothing.** `continue-on-error: true`
+         makes the job succeed no matter how many tests fail. Every nightly to date reports
+         green. Anyone glancing at the Actions tab would reasonably conclude the suite is
+         passing — this morning's nightly reported `success` with **179 failures**. That is
+         a green light attached to a red suite, which is the same shape as the incident this
+         work exists to prevent.
+      2. **The job name misreports what ran.** It renders
+         `E2E (chromium + webkit)` for any non-`pull_request` trigger, including a
+         `workflow_dispatch` with `projects=chromium`. The `projects` input *is* honoured by
+         the test step — only the label is wrong. A label that does not match what executed
+         is precisely how the 2026-08-08 false green was believed.
+
+      **Order of work:** fix #2 and #3 first (they are real and may share a cause), then
+      #1, then flip `continue-on-error: false` **and** restore the `pull_request` trigger in
+      the same change — the workflow comment is explicit that they go together, because a
+      non-blocking check people learn to ignore is worse than no check.
+
+      **Acceptance:** a dispatched run against `main` reports 280 passed / 0 failed for
+      chromium, and a PR touching `web/**` or `**.go` gets a blocking E2E check.

--- a/web/tests/e2e/global-setup.ts
+++ b/web/tests/e2e/global-setup.ts
@@ -1,0 +1,164 @@
+// file: tests/e2e/global-setup.ts
+// version: 1.0.0
+// guid: 2f7b4e91-8c05-4d63-a1f2-6b98e0c473da
+// last-edited: 2026-08-09
+
+import { execFileSync } from 'child_process';
+import { statSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '../../..');
+const PORT = 8484;
+
+/**
+ * Fail loudly when the suite is about to test a STALE server.
+ *
+ * `playwright.config.ts` sets `reuseExistingServer: !process.env.CI`, so a
+ * local run silently attaches to whatever is already listening on 8484 —
+ * including a server built from a bundle that predates the code under test.
+ *
+ * That is not hypothetical. On 2026-08-08 a local run reported 130 passed /
+ * 0 failed against an hours-old server, and the suite was in fact ~50% red;
+ * the real number (146 failed of 288) only surfaced once the server was
+ * killed first. The whole e2e repair effort exists because that kind of
+ * false green went unnoticed for four months.
+ *
+ * The documented workaround was "remember to run
+ * `ps -o lstart -p $(lsof -ti :8484)` first". Relying on a human to remember
+ * a manual check is what failed. This does it automatically.
+ *
+ * How it decides, in two steps — both matter:
+ *
+ *   1. Is this server one WE started? `webServer` and `globalSetup` overlap, so
+ *      a naive check flags Playwright's own server. Anything that started at or
+ *      after this process did is ours, and is skipped.
+ *   2. Otherwise it is a REUSED server. Compare when it started against when the
+ *      build artifacts were last written. A server that started before the
+ *      binary or the frontend bundle it is meant to be serving cannot be
+ *      running that code.
+ *
+ * Deliberately fails rather than auto-killing: the process on 8484 may be a
+ * dev server someone is using, and silently killing it would trade one
+ * surprise for another. The error says exactly what to run.
+ *
+ * No-ops under CI (nothing to reuse — the config always builds its own) and
+ * no-ops when nothing is listening.
+ */
+export default function globalSetup(): void {
+  if (process.env.CI) return;
+  if (process.env.E2E_SKIP_STALE_CHECK === '1') {
+    console.warn(
+      '[e2e] stale-server check disabled via E2E_SKIP_STALE_CHECK — you are responsible for what is on :8484',
+    );
+    return;
+  }
+
+  const pid = listeningPid();
+  if (pid === null) return; // nothing to reuse; webServer will build and start one
+
+  const startedAt = processStartTime(pid);
+  if (startedAt === null) return; // cannot determine; do not block the run on a guess
+
+  // Only a server that predates THIS Playwright process can be a reused one.
+  //
+  // This check is load-bearing and was learned the hard way: the first version
+  // of this guard compared the server against the build artifacts alone, and
+  // fired on Playwright's OWN freshly-started server (server 13:54:25, binary
+  // written 13:54:38) because `webServer` and `globalSetup` overlap. A guard
+  // that cries wolf on every clean run gets disabled within a day, which would
+  // have left the original hole open while looking like it was covered.
+  //
+  // `ps -o lstart` is truncated to whole seconds, so a server started 0.9s
+  // into our own lifetime reports as earlier than us. The epsilon absorbs that.
+  const ourStart = new Date(Date.now() - process.uptime() * 1000);
+  const TRUNCATION_EPSILON_MS = 2000;
+  if (startedAt.getTime() >= ourStart.getTime() - TRUNCATION_EPSILON_MS) {
+    return; // this run started it; nothing to be stale relative to
+  }
+
+  // The two things the server is meant to be serving. web/dist is what the Go
+  // binary embeds, so a frontend-only change with no rebuild is stale too.
+  const artifacts: Array<[string, string]> = [
+    ['Go binary', join(REPO_ROOT, 'audiobook-organizer')],
+    ['frontend bundle', join(REPO_ROOT, 'web/dist/index.html')],
+  ];
+
+  const staler: string[] = [];
+  for (const [label, path] of artifacts) {
+    let builtAt: Date;
+    try {
+      builtAt = statSync(path).mtime;
+    } catch {
+      continue; // not built here (e.g. fresh clone) — nothing to compare against
+    }
+    if (builtAt.getTime() > startedAt.getTime()) {
+      staler.push(
+        `  ${label}: built ${builtAt.toISOString()}, but the server started ${startedAt.toISOString()}`,
+      );
+    }
+  }
+
+  if (staler.length === 0) return;
+
+  throw new Error(
+    [
+      '',
+      `STALE SERVER on 127.0.0.1:${PORT} (pid ${pid}).`,
+      '',
+      'It started BEFORE the code it is supposed to be serving was built, so this',
+      'run would test an old bundle and report a green that means nothing. This is',
+      'the exact failure that hid a ~50% red suite on 2026-08-08.',
+      '',
+      ...staler,
+      '',
+      'Fix:',
+      `  kill -9 ${pid}`,
+      '',
+      'Then re-run. Playwright will build and start its own server.',
+      '',
+      'If you really do want to test against what is already running, set',
+      'E2E_SKIP_STALE_CHECK=1 — but then the result is only as trustworthy as',
+      'that server.',
+      '',
+    ].join('\n'),
+  );
+}
+
+/** PID listening on the e2e port, or null if nothing is. */
+function listeningPid(): number | null {
+  try {
+    const out = execFileSync('lsof', ['-ti', `:${PORT}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!out) return null;
+    // Multiple PIDs can share a port (forked workers). The first is enough:
+    // they are the same server, so any of them dates the run.
+    const pid = Number.parseInt(out.split('\n')[0], 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null; // lsof missing or nothing listening — both mean "no reuse"
+  }
+}
+
+/**
+ * When the process started, or null if it cannot be determined.
+ *
+ * `ps -o lstart=` is the portable-enough answer on macOS and Linux, and it is
+ * the same command the handoff notes told people to run by hand.
+ */
+function processStartTime(pid: number): Date | null {
+  try {
+    const raw = execFileSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (!raw) return null;
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  } catch {
+    return null;
+  }
+}

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/playwright.config.ts
-// version: 1.8.0
+// version: 1.9.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
 // last-edited: 2026-08-08
 
@@ -14,6 +14,11 @@ const DEMO_ARTIFACTS_DIR = join(__dirname, '../../..', 'demo_artifacts');
 
 export default defineConfig({
   testDir: '.',
+  // Fails the run if :8484 is already serving a bundle older than the code
+  // under test. `reuseExistingServer` below is what makes that possible, and a
+  // silently-reused stale server is what produced a false green on 2026-08-08
+  // while the suite was ~50% red. See global-setup.ts.
+  globalSetup: './global-setup.ts',
   timeout: 30 * 1000,
   fullyParallel: true,
   retries: 0,


### PR DESCRIPTION
## Why

`playwright.config.ts` sets `reuseExistingServer: !process.env.CI`, so a local run silently attaches to whatever is already listening on 8484 — including a server built from code that predates the tests under test.

That is not hypothetical. On 2026-08-08 a local run reported **130 passed / 0 failed** against an hours-old server. The suite was actually ~50% red; the real number (**146 failed of 288**) only surfaced once the server was killed first. The entire e2e repair effort exists because that class of false green went unnoticed for four months.

The documented mitigation was *"remember to run `ps -o lstart -p $(lsof -ti :8484)` first."* **Relying on a human to remember a manual check is exactly what failed.** This does it automatically.

## What it does

A `globalSetup` that compares the listening process's start time against the mtimes of the Go binary and the frontend bundle, and fails with the exact `kill` command if the server predates either.

- **Fails rather than auto-killing** — the process on 8484 may be a dev server someone is using; silently killing it trades one surprise for another.
- No-ops under CI (nothing to reuse) and when nothing is listening.
- `E2E_SKIP_STALE_CHECK=1` opts out, with a warning that names who owns the result.

## The first version was wrong, and testing caught it

Comparing the server against the build artifacts **alone** fired on Playwright's *own* freshly-started server — server `13:54:25`, binary written `13:54:38` — because `webServer` and `globalSetup` overlap.

That matters more than a normal bug: **a guard that cries wolf on every clean run gets disabled within a day**, which would leave the original hole open while looking like it was covered. Strictly worse than no guard.

The discriminator is now whether the server predates **this Playwright process**, with a 2s epsilon because `ps -o lstart` truncates to whole seconds.

**Verified both directions**, not just the happy path — testing only the passing case is what made the first version look fine:

| scenario | result |
|---|---|
| clean run, nothing listening | **exit 0, 1 passed** — no false positive |
| staged stale server (started first, artifacts touched after) | **exit 1, guard fires** |

## Also: the three linux-only failures, measured

A `todo.d` fragment records why `continue-on-error` still cannot be flipped. Measured by dispatching the workflow against `main` rather than inferring from the nightly (which was stale — it predates most of today's merges and reported 179 failures):

**CI chromium: 269 passed / 3 failed / 8 skipped of 280.** Locally: **272 passed / 0 failed / 8 skipped.** So exactly 3 failures exist only on linux:

1. `dynamic-ui-interactions.spec.ts:449` — missing `scan-button-loading-chromium-linux.png` (only `-darwin` goldens exist)
2. `library-browser.spec.ts:382` — `locator.click` timeout
3. `scan-import-organize.spec.ts:259` — `locator.click` timeout

**#2 and #3 are new information** — they pass on macOS and hang on linux, which is the whole reason the measurement was worth taking.

Two workflow defects are recorded alongside them: **`conclusion: success` on this workflow means nothing** while `continue-on-error: true` (this morning's nightly reported `success` with 179 failures), and **the job name misreports what ran** (`chromium + webkit` even for a chromium-only dispatch).

Test-infrastructure only; `changelog.d` fragment is intentionally all-comments.