### PR TITLE
docs(search): record sorting-in-Go decision and the ABS API gaps [skip changelog]

### DIFF
--- a/changelog.d/20260809_150000_search_sorting_abs_gaps.md
+++ b/changelog.d/20260809_150000_search_sorting_abs_gaps.md
@@ -1,0 +1,7 @@
+<!-- Docs/TODO-only: records two owner decisions (sorting moves server-side into
+     Go; "not suck" is the bar for search) into the search design doc, and adds
+     two todo.d fragments -- the AudiobookShelf-API series/collections/playlists
+     gaps, and the server-side sorting work.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/docs/design/2026-08-09-search-backend-options.md
+++ b/docs/design/2026-08-09-search-backend-options.md
@@ -1,14 +1,75 @@
 <!-- file: docs/design/2026-08-09-search-backend-options.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 4f1c8a72-6d93-4e05-b8a1-9c72e0f45d38 -->
 <!-- last-edited: 2026-08-09 -->
 
 # Search backend — design options and trade-offs
 
-**Status:** decision document, nothing decided. Written 2026-08-09 at the owner's request.
+**Status:** decision document. **Two decisions now taken — see §0a.** The rest remains open.
+Written 2026-08-09 at the owner's request; updated the same day with the owner's answers.
 **Audience:** the owner, making a build-vs-buy-vs-keep call.
 **Companion reading:** `todo.d/20260809-search-drops-filters-and-debounce.md`,
 `docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md` (findings 10 and 11).
+
+---
+
+## 0a. Owner decisions, 2026-08-09
+
+Recorded verbatim in substance, because they close two of the ten questions in §6 and
+change what the recommendation is:
+
+> "I want the system to not suck and I want sorting replaced, and done by go."
+
+**Decision 1 — sorting moves to the backend, in Go. Client-side sorting is to be
+replaced, not supplemented.** This answers **Q9** and part of **Q3**.
+
+**Decision 2 — "not suck" is the bar.** Taken as: the three defects in §2 are not
+acceptable as permanent behaviour, and a fix that leaves search dropping filters or
+firing per keystroke does not count as done. This resolves **Q3** as *all of the above*
+rather than picking one of the five readings.
+
+### What that means concretely, checked against the code rather than assumed
+
+Sorting today is in three places, and only one of them is right:
+
+| where | what it does | verdict |
+|---|---|---|
+| `internal/audiobooks/service_filtering.go:130` `applySorting` | Go, server-side, sorts the full filtered set | **Correct — keep and extend.** This is already "done by Go" |
+| `web/src/components/common/ConfigurableTable.tsx:201` | `[...rows].sort(...)` on the client | **Broken by design — replace.** It sorts *the current page*, so on a paginated library it reorders the 50 rows you can see rather than the library. "Sort by title descending" gives you the wrong 50 books, correctly ordered among themselves |
+| `web/src/services/api.ts` `searchBooksPage` | sends no `sort_by` at all | **Broken — fix.** Any search silently drops the sort order (§2.1) |
+
+There are **15** client-side `.sort()` call sites in `web/src`. Most are legitimate —
+sorting a book's own file list by track number, ordering tag clouds by count, ranking
+metadata-search candidates by score. Those operate on complete, small, already-fetched
+sets and are not what this decision is about. **The one that must go is any sort over a
+paginated slice of the library**, because it is not a sort of the library at all.
+
+Two further points that follow directly and are not optional if the bar is "not suck":
+
+1. **A sort is only meaningful if it is applied before pagination.** This is the same
+   defect as §2.2 (filters applied after pagination) and wants the same fix. Sorting
+   server-side without also pushing the filters down would produce a correctly-sorted
+   page of the wrong rows.
+2. **There is currently no UI control to sort at all** (audit finding 1: `SearchBarProps`
+   has no `onSortChange`; `LibraryBookGrid.tsx:133` takes the handler as
+   `_handleSortChange`, underscore-prefixed to mark it unused). So "replace sorting" is
+   partly "build the control that was removed", not only "move the logic". The state and
+   URL plumbing still work end-to-end — only the affordance is missing.
+
+### Revised recommendation
+
+§7's order still holds, with sorting folded in rather than bolted on afterwards:
+
+1. **Fix §2.1 and §2.3** — client sends filters *and* `sort_by`; debounce the box. Hours.
+2. **Push filters AND sort into the Bleve query (Option A1)**, so both are applied before
+   pagination. This is the single piece of real engineering and it now covers sorting.
+3. **Delete the client-side library sort** (`ConfigurableTable` row sort, where it is used
+   for the library grid) and restore the sort control wired to the existing URL/state
+   plumbing.
+4. Re-evaluate the engine question only after that.
+
+**Not changed by these decisions:** the engine choice (§4) and the API-shape choice (§5).
+Sorting in Go is orthogonal to whether the engine stays Bleve, and orthogonal to GraphQL.
 
 ---
 
@@ -382,8 +443,8 @@ months.
 Engine choice at 10K books and 500K books is not the same choice. §1.1's full-scan fallback
 is tolerable at the low end and catastrophic at the high end.
 
-**Q3. What does "search is bad" actually mean to you, concretely?**
-These have completely different fixes and I do not want to guess:
+**Q3. ~~What does "search is bad" mean?~~ — ANSWERED 2026-08-09: "not suck", i.e. all of
+these, not a pick-one.** Left in full because the list is still the work breakdown:
 - (a) "I filter to Organized, type an author, and get results from every state" → §2.1, one hour.
 - (b) "It's slow / the UI stutters while typing" → §2.3, thirty minutes.
 - (c) "Page 2 of a filtered search is wrong or empty" → §2.2, the architectural one.
@@ -417,7 +478,10 @@ seconds, or minutes? Changes whether A1 can push filters into the index at all �
 index can be stale, filter pushdown can return *wrong* results rather than merely
 stale-ranked ones, which is a much higher bar.
 
-**Q9. Is relevance ranking wanted, or is deterministic ordering preferred?**
+**Q9. ~~Relevance ranking or deterministic ordering?~~ — PARTLY ANSWERED 2026-08-09:
+sorting is to be replaced and done in Go (see §0a).** The open remainder is narrow: when a
+user has NOT chosen a sort, should results come back in relevance order or a stable
+default? The original note still stands and is the reason it matters:
 Right now the fallback returns key order and Bleve returns score order — so **the ordering
 silently changes depending on which path serviced the query.** That alone may explain some
 "search is weird" reports.

--- a/todo.d/20260809-abs-series-collections-playlists.md
+++ b/todo.d/20260809-abs-series-collections-playlists.md
@@ -1,0 +1,95 @@
+<!-- file: todo.d/20260809-abs-series-collections-playlists.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 8f61b3d2-0a47-4e95-9c38-52e7b04af1d6 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **AudiobookShelf-compatible API: series are broken, and collections/playlists are
+      empty stubs.** Owner report 2026-08-09: *"series are broken on the audioshelf server
+      stuff, because all of them report zero books, and when you click on them they just
+      give you a random list of books… We need full collection support… Same with
+      playlists."* Root causes located in the code below — this is server-side, as the
+      owner suspected.
+
+      ## 1. Series report zero books and open the wrong list
+
+      `internal/server/handlers/abs/browse.go:464` `LibrarySeries` builds each series DTO
+      with:
+
+      ```go
+      "books":         []any{},          // <- ALWAYS EMPTY, hardcoded
+      "totalDuration": 0,                // <- likewise
+      "numBooks":      counts[s.ID],
+      ```
+
+      Two distinct defects, and they explain both halves of the report:
+
+      **(a) `books` is hardcoded empty.** The client is handed a series with no members.
+      "Click a series and get a random list of books" is the client doing something
+      reasonable with nothing — most ABS clients fall back to an unfiltered library query
+      when the series carries no items. The books are not random; they are *the library*.
+
+      **(b) `numBooks` comes from `GetAllSeriesBookCounts()`, whose error path is
+      silent:**
+
+      ```go
+      counts, err := h.library.GetAllSeriesBookCounts()
+      if err != nil {
+          // "not worth failing the page over; report 0 books rather than 500"
+          counts = map[int]int{}
+      }
+      ```
+
+      If that call errors, **every** series reports 0 — which is exactly the symptom.
+      The fallback is defensible as a design choice but it is **unobservable**: there is no
+      log line, so a total failure of the count query looks identical to a library with no
+      series members. Whatever the fix, add a `slog.Warn` here; a silent zero is how this
+      went unnoticed. (It is also possible the counts are keyed differently from `s.ID` —
+      check that before assuming the error path fired.)
+
+      **Do:** populate `books` (at minimum the item IDs/minified items the ABS schema
+      expects), fix or instrument the count path, and verify against a real client rather
+      than by reading the JSON — the two failure modes look the same from the payload.
+
+      ## 2. Collections are a stub
+
+      `internal/server/handlers/abs/handler.go:386`:
+
+      ```go
+      r.GET("/api/libraries/:libraryId/collections", auth, h.EmptyPage)
+      ```
+
+      The route exists and answers 200 with an empty page. Nothing behind it.
+
+      **Wanted** (owner): real collections — *"we may want to make a collection of scifi
+      books that don't have stupid characters"*. That is a **user-curated, arbitrary set**,
+      not a saved query: the membership rule ("no stupid characters") is a judgement the
+      user makes per book and cannot be expressed as a filter. So this needs persisted
+      membership, not a dynamic query.
+
+      Needs: storage for collection + ordered membership, CRUD endpoints, and the ABS
+      collection DTO shape on `GET /api/libraries/:id/collections` (and the single-collection
+      and add/remove-item endpoints the clients call).
+
+      ## 3. Playlists are the same stub
+
+      `internal/server/handlers/abs/handler.go:387` — also `h.EmptyPage`.
+
+      **Note the overlap:** `todo.d/20260805_214200_playlists_full_support.md` (already
+      folded into `TODO.md`) covers playlists broadly — import of `.m3u`/`.m3u8`, static and
+      **dynamic** (stored-query) playlists, and their value as grouping evidence. **This
+      item is narrower and additive:** whatever that work builds must also be *served over
+      the ABS API*, because today the endpoint returns empty regardless of what exists
+      internally. Do not duplicate the design — extend it with the API surface.
+
+      ## Shared design note
+
+      Collections and playlists are close cousins (an ordered set of items with a name) and
+      the ABS schema treats them similarly. Worth designing the storage once with a
+      discriminator rather than twice — but **check the ABS DTOs first**, because clients
+      distinguish them (playlists carry playback semantics, collections do not) and
+      returning the wrong shape produces exactly the class of silent client-side weirdness
+      seen in §1.
+
+      **Acceptance:** in a real ABS client — series show correct counts and open their own
+      books; a hand-made collection appears and lists its members; a playlist likewise.
+      Verified in the client, not by curling the endpoint.

--- a/todo.d/20260809-sorting-must-be-server-side-go.md
+++ b/todo.d/20260809-sorting-must-be-server-side-go.md
@@ -1,0 +1,50 @@
+<!-- file: todo.d/20260809-sorting-must-be-server-side-go.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3a95c7e1-6b20-4d84-a7f9-1e60b52cf483 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **Replace library sorting with server-side Go sorting.** Owner decision 2026-08-09:
+      *"I want the system to not suck and I want sorting replaced, and done by go."*
+      Recorded in full with the code evidence in §0a of
+      `docs/design/2026-08-09-search-backend-options.md`.
+
+      ## Where sorting lives today — three places, one of them correct
+
+      | where | what | verdict |
+      |---|---|---|
+      | `internal/audiobooks/service_filtering.go:130` `applySorting` | Go, server-side, over the full filtered set | **Correct.** Keep and extend |
+      | `web/src/components/common/ConfigurableTable.tsx:201` | `[...rows].sort(...)` on the client | **Replace.** Sorts the *current page* |
+      | `web/src/services/api.ts` `searchBooksPage` | sends no `sort_by` | **Fix.** Search drops the sort order entirely |
+
+      **Why the client-side one is broken by design, not merely misplaced:** it sorts the
+      rows already fetched. On a paginated library that is the 50 books you can see, not
+      the library. "Sort by title descending" hands you the *wrong 50 books*, correctly
+      ordered among themselves — which looks plausible, which is why it survives.
+
+      ## Scope carefully — not every client sort is wrong
+
+      There are **15** `.sort()` sites in `web/src`. Most are legitimate: a book's own file
+      list by track number (`BookDetailFilesTab.tsx:250`), tag clouds by count
+      (`TagCloud.tsx:76`), metadata candidates by score. Those sort complete, small,
+      already-fetched sets. **The rule is: a sort over a paginated slice of the library is
+      wrong; a sort over a complete set the client already holds is fine.**
+
+      ## Two things that must land with it
+
+      1. **Sort must be applied BEFORE pagination**, which is the same defect as filters
+         being applied after pagination (§2.2 of the design doc). Moving the sort to Go
+         without pushing it into the query would produce a correctly-sorted page of the
+         wrong rows — a subtler bug than the one being fixed.
+      2. **There is no sort control in the UI at all.** `SearchBarProps`
+         (`web/src/components/audiobooks/SearchBar.tsx:124-131`) has no `onSortChange`, and
+         `LibraryBookGrid.tsx:133` takes the handler as `_handleSortChange` —
+         underscore-prefixed to mark it deliberately unused. The state, URL round-trip and
+         API parameter all still work; only the affordance is missing. So "replace sorting"
+         is partly **restore the control**, not only move the logic.
+         `SearchBar.test.tsx:43` asserts the control is absent and now passes vacuously —
+         that assertion has to be inverted, or it will defend the bug.
+
+      **Acceptance:** choosing a sort reorders the whole library (verify by sorting
+      descending and checking page 1 holds the true last items, not the reversed first
+      page); the sort survives a search; `sort_by` appears on the request; no `.sort()`
+      remains over a paginated library slice.


### PR DESCRIPTION
## 1. Search doc updated in place (not replaced)

New **§0a** in `docs/design/2026-08-09-search-backend-options.md` recording the owner decision:

> "I want the system to not suck and I want sorting replaced, and done by go."

That closes **Q9** and resolves **Q3** as *all five readings*, not pick-one.

**Sorting today lives in three places and only one is right** — checked against the code, not assumed:

| where | what | verdict |
|---|---|---|
| `service_filtering.go:130` `applySorting` | Go, server-side, full filtered set | **Correct** — already "done by Go"; keep and extend |
| `ConfigurableTable.tsx:201` | `[...rows].sort(...)` client-side | **Broken by design** — sorts the *current page* |
| `api.ts` `searchBooksPage` | sends no `sort_by` | **Broken** — search drops the sort order |

The client-side one is not merely misplaced: it sorts the rows already fetched, so on a paginated library "sort by title descending" hands you **the wrong 50 books, correctly ordered among themselves**. That looks plausible, which is why it survives.

**Scoped deliberately.** There are 15 `.sort()` sites in `web/src` and most are legitimate — a book's own file list by track number, tag clouds by count, metadata candidates by score. The rule recorded is: *a sort over a paginated slice of the library is wrong; a sort over a complete set the client already holds is fine.*

Two consequences that must land with it: the sort has to be applied **before** pagination (same defect as filters-after-pagination, §2.2), and **there is no sort control in the UI at all** — `SearchBarProps` has no `onSortChange`, `LibraryBookGrid.tsx:133` takes it as `_handleSortChange`. So this is partly restoring a removed affordance, not only moving logic. `SearchBar.test.tsx:43` asserts the control is absent and now passes vacuously — that assertion will defend the bug unless inverted.

## 2. AudiobookShelf API — series broken, collections/playlists are stubs

Owner-reported; root causes located. **Server-side, as suspected.**

**Series** — `abs/browse.go:464` `LibrarySeries` hardcodes:

```go
"books":         []any{},   // ALWAYS EMPTY
"totalDuration": 0,
"numBooks":      counts[s.ID],
```

Every series is handed to the client with no members. The "random list of books" on click is the client falling back to an unfiltered library query — **the books are not random, they are the library.**

And `numBooks` comes from `GetAllSeriesBookCounts()` whose error path silently substitutes an empty map, so a total failure of that query is indistinguishable from a library with no series members. That needs a log line whatever else changes — a silent zero is how this went unnoticed.

**Collections and playlists** — `abs/handler.go:386-387` wire both to `h.EmptyPage`. The routes answer 200 with nothing behind them.

The collections ask ("scifi books that don't have stupid characters") is a **user-curated arbitrary set, not a saved query** — the membership rule is a per-book judgement and can't be expressed as a filter, so it needs persisted membership.

Notes the overlap with the existing playlists fragment (m3u import, dynamic playlists) and is explicitly **additive**: whatever that builds must also be served over the ABS API, since the endpoint returns empty regardless of internal state.

## 3. A fragment for the sorting work itself

With acceptance criteria that actually catch the page-vs-library bug: sort descending and check page 1 holds the true last items, not the reversed first page.

Docs/TODO-only; `changelog.d` fragment is intentionally all-comments.