### PR TITLE
ci(e2e): trustworthy merge gate, and one worker on CI [skip changelog]

### DIFF
--- a/changelog.d/20260809_154500_ci_gate_and_workers.md
+++ b/changelog.d/20260809_154500_ci_gate_and_workers.md
@@ -1,0 +1,7 @@
+<!-- CI/test-infrastructure change: adds scripts/gate-merge-pr.sh (a merge gate
+     that requires a positive green signal rather than an absence), and sets
+     Playwright to one worker on CI after measuring that two workers on a
+     2-CPU runner starve MUI transitions and produce false failures.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/scripts/gate-merge-pr.sh
+++ b/scripts/gate-merge-pr.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# file: scripts/gate-merge-pr.sh
+# version: 1.0.0
+# guid: 0c8f31a6-5d74-42be-9e07-b6a15f230cd8
+# last-edited: 2026-08-09
+#
+# Wait for a PR's CI to finish, then admin-merge it ONLY if every check passed.
+#
+# Why this exists as a script rather than a snippet people retype:
+#
+#   1. "pending is not passing." A wait that times out must NOT merge. PR #2202
+#      was merged on 2026-08-09 with its own E2E job still running, because the
+#      loop treated a timeout as success.
+#
+#   2. AN EMPTY CHECK ROLLUP ALSO REPORTS pending=0 AND fail=0. Immediately
+#      after `gh pr create`, GitHub has not registered the checks yet. A naive
+#      `pending==0 && fail==0` gate therefore merges a brand-new PR with ZERO
+#      checks run, and it looks exactly like a clean pass in the log. This was
+#      caught on 2026-08-09 by noticing a gate report `poll 1 pending=0` — that
+#      PR happened to be 40 minutes old so the merge was legitimate, but the
+#      same code one minute after `gh pr create` would have merged blind.
+#
+# Both are the same failure: inferring "green" from an absence rather than from
+# a positive result. The guards below require a POSITIVE signal — at least
+# MIN_CHECKS checks present AND all of them concluded successfully.
+#
+# Usage:
+#   scripts/gate-merge-pr.sh <pr-number> [max-polls] [sleep-seconds] [min-checks]
+#
+# Exit codes:
+#   0  merged
+#   1  usage / lookup error
+#   2  a check failed or was cancelled — NOT merged
+#   3  timed out while still pending — NOT merged
+#   4  PR left the OPEN state without us merging it
+set -euo pipefail
+
+PR="${1:?usage: gate-merge-pr.sh <pr-number> [max-polls] [sleep-seconds] [min-checks]}"
+MAX_POLLS="${2:-60}"
+SLEEP_SECONDS="${3:-45}"
+# Most PRs in this repo trigger ~20 checks. Requiring a handful to be present
+# before believing "0 pending" is what closes the empty-rollup hole; it is a
+# floor, not an exact count, so adding or removing a workflow will not break it.
+MIN_CHECKS="${4:-5}"
+
+for ((i = 1; i <= MAX_POLLS; i++)); do
+  json=$(gh pr view "$PR" --json state,statusCheckRollup 2>/dev/null) || {
+    echo "gate: could not read PR #$PR" >&2
+    exit 1
+  }
+
+  read -r state total pending failed cancelled <<<"$(
+    printf '%s' "$json" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+rollup = d.get("statusCheckRollup") or []
+pending = sum(1 for c in rollup if c.get("status") in ("QUEUED", "IN_PROGRESS", "PENDING", "WAITING"))
+failed = sum(1 for c in rollup if c.get("conclusion") in ("FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED"))
+cancelled = sum(1 for c in rollup if c.get("conclusion") == "CANCELLED")
+print(d.get("state"), len(rollup), pending, failed, cancelled)
+'
+  )"
+
+  echo "gate PR#$PR poll $i/$MAX_POLLS state=$state checks=$total pending=$pending fail=$failed cancelled=$cancelled"
+
+  if [[ "$state" != "OPEN" ]]; then
+    echo "gate: PR #$PR is $state — not merging here."
+    exit 4
+  fi
+
+  if ((failed > 0 || cancelled > 0)); then
+    echo "gate: $failed failed / $cancelled cancelled — NOT merging."
+    exit 2
+  fi
+
+  # The two positive conditions, both required.
+  if ((total >= MIN_CHECKS && pending == 0)); then
+    echo "gate: $total checks present, none pending, none failed — merging."
+    gh pr merge "$PR" --rebase --admin
+    # Verify rather than trust the exit code: report only what is true.
+    merged_at=$(gh pr view "$PR" --json mergedAt -q .mergedAt)
+    if [[ -z "$merged_at" || "$merged_at" == "null" ]]; then
+      echo "gate: merge command returned but PR is NOT merged." >&2
+      exit 1
+    fi
+    echo "gate: MERGED at $merged_at"
+    exit 0
+  fi
+
+  if ((total < MIN_CHECKS)); then
+    echo "gate: only $total checks registered (need >= $MIN_CHECKS) — checks are still appearing, waiting."
+  fi
+
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "gate: timed out after $MAX_POLLS polls with checks still pending — NOT merging." >&2
+exit 3

--- a/todo.d/20260809-mui-select-menu-does-not-close-on-linux.md
+++ b/todo.d/20260809-mui-select-menu-does-not-close-on-linux.md
@@ -1,81 +1,56 @@
 <!-- file: todo.d/20260809-mui-select-menu-does-not-close-on-linux.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: c47a0e63-91d8-4f52-bb06-3d5e28a71c9f -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **A MUI Select's menu does not close after choosing an option on the ubuntu CI
-      runner — suspected REAL defect, not test rot.** Found 2026-08-09. A workaround was
-      written, measured, and **reverted** because it did not work and the measurement
-      showed why.
+- [x] **RESOLVED — it was worker contention, not a defect.** This fragment previously
+      claimed "a MUI Select's menu does not close on the ubuntu runner — suspected REAL
+      defect". **That was wrong.** Kept rather than deleted, because the sequence of wrong
+      answers is the useful part.
 
-      **Do not "fix" this by changing the tests.** Two tests are red on linux because the
-      application (or MUI, on that environment) is not doing what it does on macOS.
+      ## What it actually was
 
-      ## The evidence, in the order it was obtained
+      Two chromium tests failed on ubuntu and passed on macOS, both 30s `locator.click`
+      timeouts with a MUI modal backdrop still intercepting pointer events. Measured in the
+      official Playwright linux image pinned to 2 CPUs:
 
-      **Round 1 — the symptom.** Two chromium tests time out on `locator.click` after 30s
-      on ubuntu while passing on macOS. The Playwright call log names the obstruction:
+      | configuration | result |
+      |---|---|
+      | `--workers=2` | `library-browser` + `scan-import` **FAIL** (3 separate runs) |
+      | `--workers=1` | **27 passed, 0 failed** |
 
-      ```
-      <div class="MuiBackdrop-root MuiModal-backdrop"> from
-      <div id="menu-" class="MuiPopover-root MuiMenu-root MuiModal-root">
-      subtree intercepts pointer events
-      ```
+      Two browser workers plus the Go server on two cores starve the close **transition**,
+      so the backdrop outlives any timeout worth setting. The menu does close; the machine
+      is simply too busy to animate it. **Neither the app nor the tests are wrong** — a real
+      user is not running two headless browsers on two pinned cores.
 
-      - `library-browser.spec.ts` — selects "Organized", then clicks the **Author** combobox
-      - `scan-import-organize.spec.ts` — selects "Imported", then clicks **Select All**
+      **Fix:** `workers: process.env.CI ? 1 : 2` in `playwright.config.ts`, with the
+      measurement recorded inline. Costs wall-clock (chromium ~4.5min → ~9min), which is the
+      right trade for a gate meant to block merges.
 
-      **Round 2 — the hypothesis, and it was wrong.** Read as a close-transition race: MUI
-      tears the backdrop down on a CSS transition, so a click issued in that window hits the
-      backdrop. A `waitForMenuClosed` helper was added at **all 18** option-selection sites
-      across 5 spec files, and verified locally (59 passed / 0 failed, exit 0).
+      ## Four wrong answers, and what killed each
 
-      **Round 3 — the measurement that killed it.** On CI the count stayed at **3 failed**;
-      the failures merely changed shape. Both now fail on the *new wait itself*:
+      Worth keeping, because every one of them looked well-evidenced at the time:
 
-      ```
-      Error: expect(locator).toBeHidden() failed
-      Locator: locator('.MuiPopover-root').first()
-      Received: visible
-      Timeout: 5000ms
-      14 × locator resolved to <div id="menu-" role="presentation"
-           class="MuiPopover-root MuiMenu-root MuiModal-root">
-             - unexpected value "visible"
-      ```
+      | # | hypothesis | killed by |
+      |---|---|---|
+      | 1 | MUI close-transition race → add `waitForMenuClosed` at all 18 option sites | CI: failure count unchanged at 3, failures merely moved to the new wait |
+      | 2 | The Selects are `multiple`, so the menu stays open by design | Reading `FilterSidebar.tsx` — they are single (`:143`, `:181`); the only `multiple` is `:222`, another control |
+      | 3 | **"The menu never closes on linux — suspected real defect"** (this fragment's original claim) | A probe in the linux image: menu gone in <500ms and the value lands ("Stormlight Archive") |
+      | 4 | The Drawer backdrop is the sole culprit → wait on `.MuiDrawer-modal` | Strict-mode violation — the sidebar renders twice, so the selector matched 2 nodes; and library-browser's blocker was the Select menu, a different overlay |
 
-      **The menu is still open five seconds after the option was clicked.** That is not a
-      transition; a MUI menu transition is ~200-300ms. And it fully re-explains round 1:
-      the backdrop blocks the next click for 30s because **the menu never closes**, not
-      because it is mid-animation.
+      **The lesson is about method, not MUI.** Every hypothesis came from reading a call log
+      and reasoning about what *should* follow. What finally settled it was changing one
+      variable and measuring: workers 2 → 1. The cheap discriminating experiment was
+      available from the beginning and was reached fourth.
 
-      ## Why this reads as a real defect
+      **Second lesson: build the repro before iterating.** Three of the four rounds cost a
+      ~6-minute CI cycle each because there was no way to run linux locally. Building that
+      (Go binary compiled in a `golang` container because CGO/`libtag` blocks
+      cross-compilation, then the official Playwright image) took one round and turned the
+      loop into seconds. It should have come first.
 
-      The Selects involved are **single**, not `multiple` — checked in
-      `web/src/components/audiobooks/FilterSidebar.tsx` (Series at :143, Language at :181;
-      the only `multiple` in the file is at :222, a different control). A single MUI Select
-      closes its menu on selection. On ubuntu it does not.
-
-      A menu that stays open for 5+ seconds after a click would be user-visible if it
-      happens on real hardware. Whether it does is the first thing to find out.
-
-      ## What was reverted and why
-
-      The `waitForMenuClosed` workaround and its 18 call sites are **not merged**. Two
-      reasons: it does not work, and merging it would have encoded "wait for a thing that
-      never happens" into 18 places. Also reverted: a `prettier --write` pass that
-      reformatted 965 lines of `test-helpers.ts` — unrelated churn that should never have
-      been in the change.
-
-      ## Next steps
-
-      1. **Determine whether this is the app, MUI, or the environment.** Cheapest
-         discriminator: a minimal page with one MUI Select, run on the ubuntu runner. If the
-         menu stays open there too, it is MUI/environment; if it closes, it is our code.
-      2. **Check whether `handleFilterChange` re-renders the Select in a way that cancels
-         the close.** `FilterSidebar.tsx` refetches on change; if the option list identity
-         changes mid-close on a slower machine, the menu may be re-created open. This is a
-         hypothesis, not a finding — the last two were wrong, so measure before believing it.
-      3. Only after the cause is known, decide whether the fix is product-side or test-side.
-
-      Blocks flipping `continue-on-error` off — see
-      `todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md`.
+      Runner script: `<scratchpad>/linux-probe.sh` — copies the tree in, `npm ci` inside
+      (the host `node_modules` is a symlink to another worktree full of darwin binaries),
+      starts the prebuilt binary, runs Playwright against it with `CI` unset so
+      `reuseExistingServer` attaches instead of trying to `go build`.

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/playwright.config.ts
-// version: 1.9.0
+// version: 1.10.0
 // guid: 7c8d9e0f-1a2b-3c4d-5e6f-7a8b9c0d1e2f
 // last-edited: 2026-08-08
 
@@ -22,7 +22,23 @@ export default defineConfig({
   timeout: 30 * 1000,
   fullyParallel: true,
   retries: 0,
-  workers: 2,
+  // One worker on CI, two locally.
+  //
+  // Measured 2026-08-09 in the official Playwright linux image, pinned to 2
+  // CPUs to approximate a runner:
+  //   workers=2 -> library-browser + scan-import FAIL (3 separate runs)
+  //   workers=1 -> 27 passed, 0 failed
+  // The failures were 30s `locator.click` timeouts with a MUI modal backdrop
+  // (Drawer in one case, Select menu in the other) still intercepting pointer
+  // events. Two browser workers plus the Go server on 2 cores starve the close
+  // TRANSITION, so the backdrop outlives any timeout worth setting. Neither the
+  // app nor the tests are wrong — a real user is not running two headless
+  // browsers on two pinned cores.
+  //
+  // The cost is wall-clock: chromium goes from ~4.5min to ~9min. That is the
+  // right trade for a gate that is supposed to block merges — a fast check
+  // people learn to distrust is worth less than a slow one they believe.
+  workers: process.env.CI ? 1 : 2,
   reporter: [
     ['list'],
     ['html', { outputFolder: 'playwright-report', open: 'never' }],


### PR DESCRIPTION
Two fixes, both about a green signal that could not be believed.

## 1. The merge gate had a hole I put there

The ad-hoc gate loop used across this session tested `pending==0 && fail==0`. **An empty check rollup satisfies that too.** Immediately after `gh pr create`, GitHub has not registered the checks yet — so the gate would merge a brand-new PR with **zero checks run**, and the log would read exactly like a clean pass.

Caught on #2248 by noticing `poll 1 pending=0`. That PR was ~40 minutes old and genuinely had 22 green checks, so the merge was legitimate — but the same code one minute after `gh pr create` would have merged blind.

Same family as the earlier incident where #2202 merged with its own E2E job still running: **inferring green from an absence rather than a positive result.**

`scripts/gate-merge-pr.sh` requires positives instead:

- at least `MIN_CHECKS` (default 5) checks **present**, AND none pending, AND none failed/cancelled
- distinct exit codes (`2` failed, `3` timed out, `4` not open) so a timeout can never be mistaken for success
- verifies `mergedAt` after merging rather than trusting the command's exit code

A floor rather than an exact count, so adding or removing a workflow doesn't break it.

*Testing it, I hit the pipeline trap the rules warn about: `./gate.sh | head` printed `EXIT=0` when the script had actually exited `4`. Re-read without the pipe. Noting it because it happened while testing the guard against exactly that mistake.*

## 2. One worker on CI

Measured in the official Playwright linux image, pinned to 2 CPUs to approximate a runner:

| configuration | result |
|---|---|
| `--workers=2` | `library-browser` + `scan-import` **FAIL** (3 separate runs) |
| `--workers=1` | **27 passed, 0 failed** |

The failures were 30s `locator.click` timeouts with a MUI modal backdrop still intercepting pointer events — a Drawer in one case, a Select menu in the other. Two browser workers plus the Go server on two cores starve the close **transition**, so the backdrop outlives any timeout worth setting.

**Neither the app nor the tests are wrong.** A real user is not running two headless browsers on two pinned cores. This is harness resource starvation.

Cost: chromium goes ~4.5min → ~9min. That is the right trade for a gate meant to block merges — a fast check people learn to distrust is worth less than a slow one they believe.

## Also: correcting a fragment that was wrong

`todo.d/20260809-mui-select-menu-does-not-close-on-linux.md` claimed this was a **suspected real product defect**. It was not. The fragment now records all four wrong hypotheses and what killed each:

| # | hypothesis | killed by |
|---|---|---|
| 1 | close-transition race → wait at all 18 option sites | CI: failure count unchanged, failures moved to the new wait |
| 2 | the Selects are `multiple` | reading `FilterSidebar.tsx` — they are single |
| 3 | **"the menu never closes — real defect"** | a linux probe: gone in <500ms, value lands |
| 4 | the Drawer backdrop is the sole culprit | strict-mode violation (sidebar renders twice) + library-browser's blocker was a different overlay |

The reusable part is the method failure: **the discriminating experiment (workers 2 → 1) was available from the start and was reached fourth.** Every hypothesis before it came from reading a call log and reasoning about what should follow.

Second lesson recorded: **build the repro before iterating.** Three rounds cost a ~6-minute CI cycle each because there was no way to run linux locally. Building that took one round and turned the loop into seconds.

CI/test-infrastructure only; `changelog.d` fragment is intentionally all-comments.