### PR TITLE
ci(e2e): block PRs on the E2E suite, keep the nightly advisory [skip changelog]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,18 +27,26 @@
 
 name: E2E
 
-# NOTE: there is deliberately NO `pull_request` trigger yet. See the
-# continue-on-error comment on the job below — the suite is ~50% red, and a
+# The `pull_request` trigger is live as of 2026-08-09, and on that path the job
+# BLOCKS. It was withheld while the suite was ~50% red, because a
 # permanently-failing check on every PR is worse than no check: people learn to
 # ignore it, which is the same failure that let six specs rot for four months,
-# only louder. Restore the pull_request trigger (with the paths filter below,
-# kept here for whoever does it) at the same time as flipping
-# continue-on-error off.
+# only louder.
 #
-#  pull_request:
-#    branches: [main, master]
-#    paths: ['web/**', '**.go', 'go.mod', 'go.sum', '.github/workflows/e2e.yml']
+# Measured on the real runner before enabling it:
+#   chromium (the PR path)   272 passed /  0 failed /  8 skipped   <- blocking
+#   chromium + webkit        543 passed /  1 failed / 16 skipped   <- not blocking
+#
+# Hence the conditional continue-on-error on the job: the configuration that is
+# PROVEN green blocks, and the one that is not stays advisory rather than being
+# handed a green light it has not earned. See
+# todo.d/20260809-webkit-scan-import-drawer-backdrop.md for the single
+# remaining webkit failure.
+#
 on:
+  pull_request:
+    branches: [main, master]
+    paths: ['web/**', '**.go', 'go.mod', 'go.sum', '.github/workflows/e2e.yml']
   schedule:
     - cron: '17 5 * * *' # 05:17 UTC nightly, off the :00 stampede
   workflow_dispatch:
@@ -79,10 +87,21 @@ jobs:
     # value is still real — the failures are now VISIBLE on every PR instead of
     # invisible for four months, which is the problem this job exists to solve.
     #
-    # Flip continue-on-error off once the suite is actually green. That is
-    # tracked in TODO.md; do not flip it silently, and do not delete this job
-    # to make CI quiet.
-    continue-on-error: true
+    # BLOCKING on pull_request, advisory elsewhere.
+    #
+    # The PR path runs chromium only and was measured green on the real runner
+    # (272 passed / 0 failed / 8 skipped) before this was enabled, so it now
+    # blocks: a PR can no longer break the suite unnoticed, which is the whole
+    # point of this job.
+    #
+    # The scheduled/dispatch path also runs webkit, where one test still fails
+    # (see the header comment). Making that blocking would attach a red gate to
+    # a known, tracked failure and teach people to ignore it — the exact
+    # dynamic this job exists to prevent. So it stays advisory until webkit is
+    # green, and then this expression becomes a plain `false`.
+    #
+    # Do not flip it silently, and do not delete this job to make CI quiet.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     # A full two-engine run measured ~20 minutes locally; allow generous
     # headroom for a cold CI runner that must also build the Go binary.
     timeout-minutes: 45

--- a/changelog.d/20260809_174500_e2e_gate_blocking_on_pr.md
+++ b/changelog.d/20260809_174500_e2e_gate_blocking_on_pr.md
@@ -1,0 +1,8 @@
+<!-- CI change: restores the pull_request trigger on the E2E workflow and makes
+     the job BLOCKING on that path, after measuring the PR configuration green
+     on the real runner (272 passed / 0 failed / 8 skipped). continue-on-error
+     is now conditional so the both-engine nightly, which still has one webkit
+     failure, stays advisory rather than being handed a green light.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md
+++ b/todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md
@@ -1,9 +1,32 @@
 <!-- file: todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 6b2e9047-3d51-4a8c-b7f0-8e14c5920fda -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **Three linux-only e2e failures block flipping `continue-on-error` off.** Measured
+- [x] **RESOLVED — all three fixed; the PR gate now blocks.** Superseded by
+      `todo.d/20260809-webkit-scan-import-drawer-backdrop.md`, which tracks the single
+      remaining webkit failure. Kept for the causes, which were all different.
+
+      **Outcome 2026-08-09, measured on the real runner:**
+
+      | configuration | before | after |
+      |---|---|---|
+      | chromium (PR path) | 269 passed / 3 failed | **272 passed / 0 failed / 8 skipped** |
+      | chromium + webkit | not measured | **543 passed / 1 failed / 16 skipped** |
+
+      | # | blocker | resolution |
+      |---|---|---|
+      | 1 | missing linux visual golden | Generated for BOTH engines in the Playwright linux image (#2250, #2251). Also found the goldens were **Git LFS pointers** — `*.png filter=lfs` meant CI checked out a text pointer and Playwright reported "Could not decode expected image as PNG", so the test could never have passed on CI for either browser |
+      | 2 | `library-browser` click timeout | **Worker contention**, not a defect. `workers: 1` on CI (#2249) |
+      | 3 | `scan-import-organize` click timeout | Same cause; fixed on chromium by the same change. **Persists on webkit** → the successor fragment |
+
+      `pull_request` trigger restored and the job made blocking on that path;
+      `continue-on-error` is now conditional so the unproven both-engine configuration is
+      not handed a green light it has not earned.
+
+      ---
+
+      **Original entry, for the record.** Measured
       2026-08-09 by dispatching the E2E workflow against current `main` — not inferred
       from the nightly, which was stale.
 

--- a/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
+++ b/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
@@ -1,0 +1,71 @@
+<!-- file: todo.d/20260809-webkit-scan-import-drawer-backdrop.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 4d20e8b7-1c63-49fa-85e0-7b3f9a06c214 -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **One webkit test still fails on CI: the Drawer backdrop swallows the click after
+      Escape.** This is the only thing keeping the *nightly* (chromium + webkit) advisory
+      rather than blocking. The PR path (chromium) is green and blocks as of 2026-08-09.
+
+      **Measured on the real runner:**
+
+      | configuration | result |
+      |---|---|
+      | chromium (the PR path) | **272 passed / 0 failed / 8 skipped** |
+      | chromium + webkit | **543 passed / 1 failed / 16 skipped** |
+
+      The one failure: `[webkit] scan-import-organize.spec.ts:259` — *complete workflow: add
+      import path → scan → organize*. After `page.keyboard.press('Escape')` closes the
+      filter drawer, the `Select All` click times out at 30s because MUI's full-page modal
+      backdrop is still intercepting pointer events:
+
+      ```
+      <div class="MuiBackdrop-root MuiModal-backdrop"> from
+      <div aria-hidden="true" class="MuiDrawer-root MuiDrawer-modal MuiModal-root">
+      subtree intercepts pointer events
+      ```
+
+      `workers: 1` (#2249) fixed the identical failure on chromium. **Webkit is slower and
+      it persists there.**
+
+      ## 🚨 Read this before you start: the local container is NOT a valid oracle
+
+      The linux repro container (`<scratchpad>/linux-probe.sh`, `--cpus=2`) is **harsher
+      than the GitHub runner** and invents failures CI does not have. Across four runs of
+      the same spec it produced four different signatures:
+
+      | attempt | what failed |
+      |---|---|
+      | baseline | `:259` drawer backdrop (matches CI) |
+      | after `toHaveCount(0)` fix | `:259` **plus** `:386` "Cancel Scan" — a test CI passes |
+      | after re-run | `:259` plus `:390` |
+      | after visible-filter fix | `:259` failing **earlier**, on the Filters button itself |
+
+      Tuning against it is a treadmill — it was exited deliberately, not because the problem
+      was solved. **Iterate against a dispatched CI run, or a container with more CPU.**
+
+      ## Three assertion shapes already ruled out, by measurement
+
+      Do not re-try these:
+
+      | shape | why it fails |
+      |---|---|
+      | `expect(locator).toBeHidden()` | **Strict-mode violation.** Sidebar renders its content twice (temporary Drawer + permanent one), so the selector matches 2 nodes |
+      | `expect(locator).toHaveCount(0)` | **Never converges.** Count sits at 2 forever — MUI keeps the backdrop MOUNTED and merely hides it |
+      | `.filter({ visible: true })` + `toHaveCount(0)` | Failure moved earlier (to the Filters button) in the container; **unvalidated against CI**, so this one is "unproven", not "disproven" |
+
+      ## Suggested next steps
+
+      1. Re-test the `.filter({ visible: true })` variant **on CI**, not in the container.
+         It is the only shape that is semantically right for a hidden-not-unmounted
+         backdrop, and it was abandoned because of an unreliable oracle rather than
+         evidence against it.
+      2. If that is not enough, consider whether the test should dismiss the drawer by
+         clicking its close control rather than pressing Escape — a more deterministic
+         path than relying on a transition finishing.
+      3. **Do not add a blind retry.** The app does close the drawer; the wait is legitimate
+         and should assert the closed state, not paper over it.
+
+      **When this is green, `continue-on-error` in `.github/workflows/e2e.yml` becomes a
+      plain `false`** and the nightly blocks too. The conditional expression there exists
+      only because of this one test.


### PR DESCRIPTION
## The job can finally do what it was built for

This job exists so a PR cannot break the browser suite unnoticed. It could not do that while it had **no `pull_request` trigger** and `continue-on-error: true`. Both are now addressed — **but only where the evidence supports it.**

## Measured on the real runner before enabling

| configuration | result | blocking? |
|---|---|---|
| chromium — the PR path | **272 passed / 0 failed / 8 skipped** | **yes** |
| chromium + webkit — nightly | **543 passed / 1 failed / 16 skipped** | no |

```yaml
continue-on-error: ${{ github.event_name != 'pull_request' }}
```

Making the nightly blocking too would attach a red gate to a **known, tracked** failure, and people would learn to ignore it — the exact dynamic that let six specs rot for four months. A green light a configuration has not earned is worse than an honest amber one.

The workflow's own comment said the trigger and the flag *"go together."* They do here: the trigger is restored **and** that path blocks. The conditional isn't hedging — it scopes the guarantee to what was actually measured.

## How the three blockers were cleared

| blocker | cause | fix |
|---|---|---|
| missing linux visual golden | goldens existed only for `-darwin` | generated for **both** engines in the Playwright linux image (#2250, #2251) |
| goldens unreadable on CI | `*.png filter=lfs` → CI checked out **LFS pointer files**; Playwright reported "Could not decode expected image as PNG" | excluded the 3 goldens from LFS (#2250) |
| 2× linux click timeouts | **worker contention**, not a defect — 2 browsers + the Go server on 2 cores starve MUI's close transition | `workers: 1` on CI (#2249) |

The LFS one is worth noting: it meant the visual test could **never** have passed on CI, for either browser, with or without a correct golden. It only ever ran locally, where LFS's smudge filter hands you the real file.

## The one remaining failure, tracked honestly

`todo.d/20260809-webkit-scan-import-drawer-backdrop.md` covers `[webkit] scan-import-organize.spec.ts:259` — the Drawer backdrop still intercepting the `Select All` click after Escape, because webkit is slower than chromium.

It records **three assertion shapes already ruled out by measurement** so nobody re-tries them, and carries a warning I think is the most useful thing in it:

> **The local 2-CPU container is NOT a valid oracle for webkit.** Across four runs of the same spec it produced four different failure signatures, including failures CI passes. Iterate against a dispatched CI run instead.

I stopped tuning against that container deliberately rather than because the problem was solved, and said so.

Supersedes `todo.d/20260809-three-linux-only-e2e-failures-block-ci-gate.md`, which described a now-resolved state.

**When webkit is green, the expression becomes a plain `false`** and the nightly blocks too.

CI-only; `changelog.d` fragment is intentionally all-comments.