### PR TITLE
test(e2e): wait for the drawer backdrop before clicking through it [skip changelog]

### DIFF
--- a/changelog.d/20260809_175000_webkit_drawer_backdrop.md
+++ b/changelog.d/20260809_175000_webkit_drawer_backdrop.md
@@ -1,0 +1,4 @@
+<!-- Test-only change: waits for the filter drawer's modal backdrop to stop
+     being visible before clicking through it, fixing the last webkit failure
+     on CI. No product behaviour changed, so this fragment is intentionally
+     all comments and contributes nothing to CHANGELOG.md. -->

--- a/web/tests/e2e/scan-import-organize.spec.ts
+++ b/web/tests/e2e/scan-import-organize.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/scan-import-organize.spec.ts
-// version: 1.7.0
+// version: 1.8.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
 // last-edited: 2026-08-09
 
@@ -307,8 +307,33 @@ test.describe('Scan/Import/Organize Workflow', () => {
     await page.getByRole('button', { name: /filters/i }).click();
     await page.getByLabel('Library State').click();
     await page.getByRole('option', { name: 'Imported', exact: true }).click();
-    // Close filter drawer before interacting with main content
+    // Close the filter drawer, then WAIT for its modal backdrop to stop being
+    // visible, before touching anything behind it.
+    //
+    // Escape starts a close transition. Until it finishes, MUI's full-page
+    // backdrop is still in the DOM swallowing pointer events, so the Select All
+    // click lands on the backdrop and times out after 30s with
+    //   <div class="MuiBackdrop-root MuiModal-backdrop"> from
+    //   <div aria-hidden="true" class="MuiDrawer-root MuiDrawer-modal ...">
+    //   subtree intercepts pointer events
+    // chromium stopped failing once CI dropped to one worker (#2249); webkit is
+    // slower and kept failing, so this wait is required rather than belt-and-
+    // braces.
+    //
+    // The assertion shape is load-bearing and two obvious forms are both wrong:
+    //   toBeHidden()   -> strict-mode violation: Sidebar renders its content
+    //                     TWICE (temporary Drawer + permanent one), so the
+    //                     selector matches two nodes.
+    //   toHaveCount(0) -> never converges: MUI keeps the backdrop MOUNTED and
+    //                     merely hides it, so the count sits at 2 forever.
+    // Counting only the VISIBLE matches is correct for both: it tolerates any
+    // number of drawers and does not care whether MUI unmounts or hides.
     await page.keyboard.press('Escape');
+    await expect(
+      page
+        .locator('.MuiDrawer-modal .MuiBackdrop-root')
+        .filter({ visible: true }),
+    ).toHaveCount(0, { timeout: 15000 });
     await expect(page.getByText('Import Book 1')).toBeVisible();
     await page.getByLabel('Select All').click();
     await page.getByRole('button', { name: 'Organize Selected' }).click();


### PR DESCRIPTION
## The last failure on CI

`[webkit] scan-import-organize.spec.ts:259` — *complete workflow: add import path → scan → organize*.

After `Escape` closes the filter drawer, the `Select All` click times out at 30s because MUI's full-page modal backdrop is still intercepting pointer events:

```
<div class="MuiBackdrop-root MuiModal-backdrop"> from
<div aria-hidden="true" class="MuiDrawer-root MuiDrawer-modal MuiModal-root">
subtree intercepts pointer events
```

chromium stopped failing once CI dropped to one worker (#2249). **Webkit is slower and kept failing**, so this wait is required rather than belt-and-braces.

**This is not papering over a defect.** The app does close the drawer; the test already presses Escape to do it. The wait asserts the closed state before clicking through it — which is what the test always meant.

## The assertion shape is load-bearing

Two obvious forms are both wrong, and both were tried and disproven by measurement:

| shape | why it fails |
|---|---|
| `toBeHidden()` | **Strict-mode violation.** Sidebar renders its content twice (temporary Drawer + permanent one), so the selector matches 2 nodes |
| `toHaveCount(0)` | **Never converges.** MUI keeps the backdrop *mounted* and merely hides it — the count sits at 2 forever and the wait times out at 15s |

Counting only the **visible** matches is correct for both: it tolerates any number of drawers, and doesn't care whether MUI unmounts or hides.

## Judged on CI, deliberately

The local 2-CPU container is **not a valid oracle for webkit** — across four runs of this spec it produced four different failure signatures, including failures CI passes. So this is verified by a dispatched `chromium+webkit` run ([31337664325](https://github.com/falkcorp/audiobook-organizer/actions/runs/31337664325)) rather than locally.

**Baseline to beat: 543 passed / 1 failed / 16 skipped.**

## One thing deliberately not done

`prettier --check` flags this file — but **`main`'s version already fails it too**, prettier appears in no workflow, and the `format` script covers `src/**` only, not `tests/**`. Running `--write` would add **110 lines** of unrelated reformatting to satisfy a check that doesn't run. An earlier change in this session did exactly that to `test-helpers.ts` (965 lines) and had to be reverted, so the file is left with only the intended edit.

If this run is green, `continue-on-error` in the workflow becomes a plain `false` and the nightly blocks too.

Test-only; `changelog.d` fragment is intentionally all-comments.