### PR TITLE
docs(e2e): webkit's remaining failures are a population, not one bug [skip changelog]

### DIFF
--- a/changelog.d/20260809_181500_webkit_marginal_finding.md
+++ b/changelog.d/20260809_181500_webkit_marginal_finding.md
@@ -1,0 +1,7 @@
+<!-- Docs-only: records that webkit's remaining CI failures are a population of
+     marginal tests rather than one broken test -- the drawer fix worked and a
+     different test failed in its place, same score. Redirects the next person
+     away from chasing them one at a time.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
+++ b/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
@@ -1,11 +1,42 @@
 <!-- file: todo.d/20260809-webkit-scan-import-drawer-backdrop.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 4d20e8b7-1c63-49fa-85e0-7b3f9a06c214 -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **One webkit test still fails on CI: the Drawer backdrop swallows the click after
-      Escape.** This is the only thing keeping the *nightly* (chromium + webkit) advisory
-      rather than blocking. The PR path (chromium) is green and blocks as of 2026-08-09.
+- [ ] **Webkit has a POPULATION of marginal tests on CI, not one broken one.** Retitled
+      after the original drawer failure was fixed and a *different* test failed in its
+      place. This is what keeps the *nightly* (chromium + webkit) advisory rather than
+      blocking. The PR path (chromium) is green and blocks as of 2026-08-09.
+
+      ## The update that changes the shape of this problem
+
+      The drawer fix landed and **worked** — `scan-import-organize.spec.ts:259` passed on
+      CI. But the same both-engine run came back with an identical score and a different
+      casualty:
+
+      | run | result | which test failed |
+      |---|---|---|
+      | before the fix | 543 / 1 / 16 | `[webkit] scan-import-organize.spec.ts:259` |
+      | after the fix (#2253) | 543 / 1 / 16 | `[webkit] itunes-bidirectional-sync.spec.ts:121` |
+
+      Different spec file, so the fix cannot have caused it. **The conclusion: webkit under
+      CI has several tests sitting close to their timeouts, and roughly one loses per run.**
+      Fixing them individually is a treadmill — each fix is real, and the score does not
+      move.
+
+      **So do not chase individual webkit failures.** Find out why webkit is marginal as a
+      class:
+
+      1. **Measure the margin.** Dispatch the webkit suite on CI 3+ times and collect the
+         failing set. If it is large and varies run to run, this is systemic timing, not N
+         separate bugs.
+      2. **Consider a per-project timeout.** The config uses one 30s `timeout` for both
+         engines, but webkit is measurably slower here — chromium stopped failing at
+         `workers: 1` and webkit did not. A per-project override is a one-line change that
+         would settle whether headroom is all that is missing.
+      3. Only then decide whether individual tests need waits.
+
+      ## Original entry — the drawer case, now FIXED (#2253)
 
       **Measured on the real runner:**
 


### PR DESCRIPTION
## The drawer fix worked — and the score did not move

#2253 landed and did what it claimed: `scan-import-organize.spec.ts:259` passed on CI. But the same both-engine run came back with an identical score and a **different** casualty:

| run | result | which test failed |
|---|---|---|
| before #2253 | 543 / 1 / 16 | `[webkit] scan-import-organize.spec.ts:259` |
| after #2253 | 543 / 1 / 16 | `[webkit] itunes-bidirectional-sync.spec.ts:121` |

Different spec file, so the fix cannot have caused it.

## Why that matters more than the individual fix

**Webkit under CI has several tests sitting close to their timeouts, and roughly one loses per run.** That makes fixing them one at a time a treadmill — each fix is genuinely correct, and the number never moves. I would have kept going otherwise, and so would the next person.

So the fragment is retitled and redirected. The suggested next steps target the *class*, not the instances:

1. **Measure the margin** — dispatch webkit on CI 3+ times and collect the failing set. If it is large and varies run to run, this is systemic timing rather than N separate bugs.
2. **Try a per-project timeout** — the config uses a single 30s budget for both engines, but webkit is measurably slower here: chromium stopped failing at `workers: 1` and webkit did not. One line, and it would settle whether headroom is all that is missing.
3. Only then decide whether individual tests need waits.

## Scope

**This does not affect the PR gate**, which runs chromium only and blocks: **272 passed / 0 failed / 8 skipped** on the real runner. The nightly stays advisory via `continue-on-error: ${{ github.event_name != 'pull_request' }}` until webkit is green as a whole.

Docs-only; `changelog.d` fragment is intentionally all-comments.