### PR TITLE
docs: add July and August monthly executive-summary roundups [skip changelog]

### DIFF
--- a/changelog.d/20260809_185000_monthly_exec_summaries.md
+++ b/changelog.d/20260809_185000_monthly_exec_summaries.md
@@ -1,0 +1,6 @@
+<!-- Docs-only: adds the two monthly executive-summary roundups (July 12-31 and
+     August, month-in-progress) that the fragment-assembly system was never
+     built for. Consolidates 24 individual dated summaries.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/docs/executive-summaries/2026-07-31-july-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-07-31-july-monthly-roundup-executive-summary.md
@@ -1,0 +1,115 @@
+<!-- file: docs/executive-summaries/2026-07-31-july-monthly-roundup-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b3d95c27-4e18-4a70-8f52-6c19e0a4b7d3 -->
+<!-- last-edited: 2026-08-09 -->
+
+# Executive Summary: July 2026 Monthly Roundup (July 12–31)
+
+**Period covered:** 2026-07-12 through 2026-07-31.
+**Deliberately starts on July 12:** the earlier
+[June–July roundup](2026-07-04-monthly-roundup-executive-summary.md) covers 2026-06-05
+through 2026-07-11. This picks up where that one stops, so the two do not overlap.
+**Individual write-ups this consolidates:** the seventeen dated summaries in this
+directory from 2026-07-13 to 2026-07-30, linked inline below.
+
+Each theme groups an arc of related work rather than listing changes one by one, and is
+written for a reader who does not work on the code.
+
+---
+
+## The month in one paragraph
+
+July's second half was about **silent data loss**. Not crashes or visible errors — saves
+that quietly dropped fields, merges that quietly orphaned files, background jobs that
+quietly never ran, and dismissals that quietly came back. Most were found by looking
+rather than by being reported, which is the uncomfortable part: they had been happening
+for some time without anyone noticing. The month closed on a different note, with the
+first real writes into a live iTunes library and the groundwork for listening on a phone.
+
+---
+
+## 1. Edits that quietly threw data away
+
+The largest cluster of the month, and the most serious.
+
+**[Stopping silent author and series loss on book edits](2026-07-13-author-series-data-loss-executive-summary.md)** — several operations save a **lightweight copy** of a book that
+deliberately omits heavy fields for speed. The save routine protected most of those, but
+not author and series: editing a book through one of those paths **erased them**.
+
+**[Editing a book's author by ID left the old author name showing](2026-07-16-stale-author-on-id-edit-executive-summary.md)** — every book stores both a reference to its author
+and a saved copy of the name. They are supposed to agree. Changing one did not update the
+other, so the book pointed at the new author while still displaying the old one.
+
+**[Stopping wrong publication year and language](2026-07-13-metadata-year-language-corruption-executive-summary.md)** — there are two different "years" for an audiobook: when the
+*recording* was released, and when the *book* was first printed. For a classic those can
+be decades apart, and the wrong one was overwriting the right one.
+
+**[Maintenance tasks were only looking at part of the library](2026-07-16-whole-library-truncation-executive-summary.md)** — jobs that were supposed to sweep everything were
+silently stopping early. Anything past the cutoff was simply never processed, and nothing
+reported a partial run.
+
+## 2. Merges that lost files
+
+**[Preventing merged books from corrupting or disappearing](2026-07-13-merge-serialization-executive-summary.md)** · **[Stopping a split-book merge from orphaning audio files](2026-07-16-split-book-merge-orphan-executive-summary.md)** · **[Fixing how merging duplicate books handled iTunes links](2026-07-18-duplicate-merge-orphaned-itunes-links-executive-summary.md)**
+
+Three separate defects in the same area. Merging two records that the system believed were
+the same book could leave audio files attached to a record that no longer existed —
+present on disk, unreachable through the app. The iTunes variant is the same failure
+reaching into an externally-managed library.
+
+**[Deleted books no longer haunt work and version listings](2026-07-13-index-consistency-executive-summary.md)** — deleted books kept appearing in lists they should have left,
+because the deletion updated the record but not every index pointing at it.
+
+## 3. Background jobs that were not running
+
+**[The audio-fingerprinting job had been quietly failing every single restart](2026-07-17-fingerprint-backfill-silently-failing-executive-summary.md)**
+
+A job computes an audio "fingerprint" for each book — a signature of how the recording
+actually sounds, and the most reliable way to tell whether two books are genuinely the
+same. **It never ran.** Every restart it started, failed to load, and gave up without
+saying so. Duplicate detection had been working without its best evidence.
+
+**[Duplicates you dismissed kept coming back](2026-07-17-dismissed-duplicates-came-back-executive-summary.md)** — you review a suspected duplicate pair and say "no, these are
+different." The next scan put it back, as if you had never looked. Every review session
+started from scratch.
+
+**[The server was burning two CPU cores around the clock while doing nothing](2026-07-18-idle-server-burning-cpu-executive-summary.md)** — with no imports, no scans and nobody
+using the app, the machine sat at two cores of constant load. Separately the health check
+— the "are you alive?" probe monitoring tools poll — took **5.6 seconds** to answer.
+
+## 4. Duplicate detection got measurably better
+
+**[Duplicate-detection confidence reaches its target](2026-07-13-dedup-precision-executive-summary.md)** · **[Metadata lookups that no longer hammer or hang](2026-07-13-metadata-reliability-executive-summary.md)** · **[Closing two quiet failure gaps in cleanup actions](2026-07-16-apply-path-guard-hardening-executive-summary.md)**
+
+The system rates a pair of books using several independent clues at once — text
+similarity, audio fingerprints, durations, shared ISBNs. Tuning that combined rating
+reached its accuracy target this month.
+
+**[A quality sweep of 24 fixes cut the duplicate backlog by ~85%](2026-07-17-error-correction-wave-executive-summary.md)** (July 17–18) is the consolidated record of that push.
+
+## 5. Writing back to iTunes, and listening on a phone
+
+The month's forward-looking work, and a deliberate change of posture: from reading an
+iTunes library to **writing into it**.
+
+**[Making two-way iTunes sync safe to build](2026-07-24-itunes-2way-sync-p0-and-primitives-executive-summary.md)** — the safety work that had to exist first, given that the target is
+a library the user manages in another application.
+
+**[The first real write to your live iTunes library](2026-07-25-itunes-2way-sync-first-live-write-executive-summary.md)** — a single track, deliberately. The smallest possible real
+test of everything above.
+
+**[Listening to your library on your phone — the groundwork](2026-07-30-audiobook-app-sync-foundation-executive-summary.md)** — the beginnings of serving the library to a phone app.
+
+---
+
+## Themes worth carrying forward
+
+1. **The dangerous bugs were all silent.** Not one of the data-loss defects announced
+   itself. They were found by going and looking. That argues for more checks that verify
+   an operation did what it claimed, rather than that it returned without an error.
+2. **"Lightweight copy" is a recurring trap.** Several defects trace to the same shape: a
+   partial record saved over a complete one. It is fast, it is usually fine, and when it
+   is not, the missing fields are simply gone.
+3. **A job that fails at startup and continues is indistinguishable from a job with
+   nothing to do.** The fingerprint backfill went unnoticed for exactly that reason — the
+   same pattern that produced August's transcription-outage mislabelling.

--- a/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
@@ -1,0 +1,136 @@
+<!-- file: docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e7a3f109-52d8-4c6b-91f4-08b7c2d64e35 -->
+<!-- last-edited: 2026-08-09 -->
+
+# Executive Summary: August 2026 Monthly Roundup
+
+**Period covered:** 2026-08-01 through 2026-08-09 (**month in progress** — this is
+updated as work lands, not a closed record).
+**Individual write-ups this consolidates:** the seven dated summaries in this directory
+from 2026-08-04 to 2026-08-09, linked inline below.
+
+This is a monthly roundup rather than a single-change summary: each theme groups an arc
+of related work instead of listing changes one by one. Everything below is written for a
+reader who does not work on the code.
+
+---
+
+## The month in one paragraph
+
+August so far has been about **things that lied**. Not features that were missing —
+numbers, controls and safety checks that were present, looked fine, and were reporting
+something untrue. A running time that said 158 hours for a twelve-hour book. A library
+page that told a person with forty-four thousand books that they owned none. A review
+queue with 777 items where 762 said the same sentence. A test suite reporting green
+while half of it was broken. The work has largely been finding out which readings could
+be trusted, and fixing the ones that could not.
+
+---
+
+## 1. Numbers that were wrong
+
+**[Almost every audiobook was showing the wrong running time](2026-08-04-audiobook-running-times-executive-summary.md)** (Aug 4)
+
+Book lengths were nonsense — a twelve-hour book listed as **158 hours**, another at
+**294 hours** (twelve solid days), and in the other direction a seventy-eight-minute book
+listed as **4 minutes**. This was not cosmetic: running time is the number other things
+divide by, so wrong lengths quietly corrupted anything derived from them.
+
+**[Series that were really book numbers](2026-08-06-series-that-were-really-book-numbers-executive-summary.md)** (Aug 6)
+
+A series name is supposed to name the series. Many named the series *and* the book's
+position in it, jammed into one string — `Evil Genius: Book 4: Becoming the Apex
+Supervillain`. Every such book was its own one-book "series", so series that should have
+grouped a dozen books grouped one.
+
+**[The outage that marked the library broken — undone](2026-08-07-the-outage-that-marked-the-library-broken-executive-summary.md)** (Aug 7)
+
+On July 1st the machine that listens to audiobook openings was unreachable for about a
+day. Nothing was lost — but the system recorded the outage as if **every book it tried
+that day had personally failed**. Roughly **31,000 books, about three quarters of the
+library**, were marked "transcription failed" while being perfectly fine. This is the
+clearest example of the month's theme: an infrastructure problem written down as a
+property of the data.
+
+---
+
+## 2. Controls that did not do what they said
+
+**[A review queue you could not work](2026-08-06-a-review-queue-you-could-not-work-executive-summary.md)** (Aug 6)
+
+The library holds back anything it is unsure about, because guessing wrong can **merge
+six novels into one and delete five of them**. That queue had 777 items and **762 of them
+carried the identical sentence** — "flat folder shares a title but ordering is unclear."
+A queue where 98% of entries say the same thing is not a queue, it is a wall.
+
+**[Two controls that lied](2026-08-08-two-controls-that-lied-executive-summary.md)** (Aug 8)
+
+After any server restart the library page announced **"No Audiobooks Found"** — not
+"loading", not "cannot reach the server", but a plain statement that you owned nothing.
+Two decisions made it that bad: a failed request **threw away the books already on
+screen**, and the page could not distinguish "the request failed" from "there is
+genuinely nothing here." Those two arrive looking identical and only one has an honest
+answer.
+
+---
+
+## 3. The safety net, and the fact that it had stopped catching
+
+This is the longest thread of the month, and it reversed itself twice. That is worth
+reading as a sequence rather than a conclusion.
+
+**[The safety net that had stopped catching — restored](2026-08-08-the-safety-net-that-had-stopped-catching-executive-summary.md)** (Aug 8) reported that the automated browser tests
+were working again.
+
+**[The safety net that was still half on the floor](2026-08-09-the-half-red-safety-net-executive-summary.md)** (Aug 9) established that this was **wrong**. The suite had
+been checked with a command that hid most of its own output, against a server left
+running for hours. Measured properly: **146 of 288 tests failing.** Roughly half the net
+was still on the floor.
+
+All 146 were then fixed — but the genuinely valuable output was **eleven product
+regressions** the repair uncovered, including that **the library cannot be sorted from
+the UI at all**, that **typing in the search box silently discards every active filter**,
+and that the search box **is not debounced**, sending one full query per keystroke.
+
+**And then a third correction.** Even at zero failures locally, the suite was still
+failing on the build server — **179 failures there while showing zero on a developer
+machine**. The causes were all environmental rather than product defects: image files
+stored in a way the build server could not read, and two browsers competing for two
+processor cores so aggressively that ordinary animations timed out.
+
+**The outcome that matters:** as of Aug 9 the tests **block** — a change that breaks the
+browser suite can no longer merge. That was the entire point, and until this month it was
+not true.
+
+---
+
+## 4. Planning work: how search should be built
+
+Not a change to the product, but a decision document written this month at the owner's
+request, covering the options for search and their trade-offs.
+
+Its central finding is worth stating: **a full search engine already exists in the
+product and is running in production.** The problems people notice are almost entirely
+elsewhere — the search box discarding filters, the missing debounce, and one ordering bug
+where results are filtered *after* being cut into pages, which produces short pages and
+wrong totals.
+
+Two decisions were taken during the month: **sorting moves to the server**, and "the
+system should not suck" is the bar. A follow-up section analyses what that costs, and
+records an open question that has to be settled first — **the code disagrees with itself
+about how many books the library holds**, and the answer changes the design.
+
+---
+
+## Themes worth carrying into next month
+
+1. **A silent fallback is worse than a loud failure.** The transcription outage, the
+   empty library page, and the search index's "run without search if it cannot open"
+   behaviour are the same shape: something degrades, nothing says so, and the result is
+   indistinguishable from normal.
+2. **A measurement is only as good as the thing it ran against.** The test suite reported
+   green three separate ways this month — hidden output, a stale server, and a
+   developer machine that was not the build server. Each looked like evidence.
+3. **Being wrong on the record is fine; leaving it there is not.** Three summaries this
+   month correct earlier ones. That is the system working.


### PR DESCRIPTION
## Why these are hand-written

There are two executive-summary formats: a **unified monthly roundup** and the smaller per-change ones. The plan was to assemble monthlies from fragments the way `CHANGELOG.md` and `TODO.md` are assembled — **that was never built**, so the monthlies are written by hand. This adds the two that were missing.

Consolidates **24 individual dated summaries**:

| file | period | note |
|---|---|---|
| `2026-07-31-july-monthly-roundup` | July 12–31 | Starts on the 12th deliberately — the existing June–July roundup covers 06-05 → 07-11, so the two do not overlap |
| `2026-08-31-august-monthly-roundup` | August | Marked **month-in-progress**, not a closed record |

Both group by theme rather than listing changes, and are written for a reader who doesn't work on the code. Every internal link was checked to resolve.

## July's second half: silent data loss

Not crashes — saves that quietly dropped fields. Editing a book through certain paths **erased its author and series**. Merging duplicates could leave audio files attached to a record that no longer existed: present on disk, unreachable through the app. The audio-fingerprinting job **had failed at every single restart without saying so**, so duplicate detection had been running without its best evidence. Dismissed duplicates came back on the next scan, so every review session started from scratch.

The uncomfortable part, stated in the doc: most were found by looking, not by being reported.

It closes on a change of posture — the first real write into a live iTunes library, and the groundwork for phone playback.

## August so far: things that lied

A twelve-hour book listed at **158 hours**. A library page telling someone with **forty-four thousand books** that they owned none. A review queue where **762 of 777 items carried the identical sentence**. An outage recorded as if **31,000 books had personally failed**.

The test-suite thread is written as a **sequence rather than a conclusion**, because it reversed itself twice: reported restored, then measured at 146 of 288 failing, then found still failing on the build server while showing zero locally. That the record contains its own corrections is the part worth showing, so the roundup shows it rather than presenting only the final state.

## A theme both months share

> A job that fails at startup and continues is indistinguishable from a job with nothing to do.

July's fingerprint backfill and August's transcription-outage mislabelling are the same shape, and so is the search index's "run without search if it cannot open" behaviour noted in the design doc. Each roundup ends with that kind of carry-forward rather than a summary of itself.

Docs-only; `changelog.d` fragment is intentionally all-comments.