### PR TITLE
ci(e2e): the browser suite now blocks on every trigger [skip changelog]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,11 +37,12 @@ name: E2E
 #   chromium (the PR path)   272 passed /  0 failed /  8 skipped   <- blocking
 #   chromium + webkit        543 passed /  1 failed / 16 skipped   <- not blocking
 #
-# Hence the conditional continue-on-error on the job: the configuration that is
-# PROVEN green blocks, and the one that is not stays advisory rather than being
-# handed a green light it has not earned. See
-# todo.d/20260809-webkit-scan-import-drawer-backdrop.md for the single
-# remaining webkit failure.
+# Both configurations are now green on the real runner, so the job blocks on
+# every trigger. The webkit tail was closed by giving webkit its own 60s
+# per-test budget (chromium keeps 30s): webkit had a POPULATION of tests
+# sitting close to the shared limit, and roughly one lost per run — two
+# consecutive runs scored an identical 543/1/16 while failing DIFFERENT tests
+# in different spec files.
 #
 on:
   pull_request:
@@ -87,21 +88,24 @@ jobs:
     # value is still real — the failures are now VISIBLE on every PR instead of
     # invisible for four months, which is the problem this job exists to solve.
     #
-    # BLOCKING on pull_request, advisory elsewhere.
+    # BLOCKING, on every trigger.
     #
-    # The PR path runs chromium only and was measured green on the real runner
-    # (272 passed / 0 failed / 8 skipped) before this was enabled, so it now
-    # blocks: a PR can no longer break the suite unnoticed, which is the whole
-    # point of this job.
+    # Measured on the real runner before this was made unconditional:
+    #   chromium (PR path)   272 passed / 0 failed /  8 skipped
+    #   chromium + webkit    544 passed / 0 failed / 16 skipped
     #
-    # The scheduled/dispatch path also runs webkit, where one test still fails
-    # (see the header comment). Making that blocking would attach a red gate to
-    # a known, tracked failure and teach people to ignore it — the exact
-    # dynamic this job exists to prevent. So it stays advisory until webkit is
-    # green, and then this expression becomes a plain `false`.
+    # This was `true` while the suite was ~50% red, then
+    # `${{ github.event_name != 'pull_request' }}` while chromium was green and
+    # webkit still had one failure per run. Both configurations are now green,
+    # so the exception is gone.
     #
-    # Do not flip it silently, and do not delete this job to make CI quiet.
-    continue-on-error: ${{ github.event_name != 'pull_request' }}
+    # Do not set this back to `true` to quiet a red run, and do not delete this
+    # job. A red result here means the browser suite is broken; that is the
+    # signal, not the problem. If the suite becomes unreliable rather than
+    # wrong, fix the reliability — the 2026-08-09 causes were worker
+    # contention, per-engine timeout budgets, and goldens stored as Git LFS
+    # pointers, none of which were product defects.
+    continue-on-error: false
     # A full two-engine run measured ~20 minutes locally; allow generous
     # headroom for a cold CI runner that must also build the Go binary.
     timeout-minutes: 45

--- a/changelog.d/20260809_191500_e2e_fully_blocking.md
+++ b/changelog.d/20260809_191500_e2e_fully_blocking.md
@@ -1,0 +1,6 @@
+<!-- CI change: the E2E workflow now blocks on every trigger
+     (continue-on-error: false), after both chromium and chromium+webkit were
+     measured green on the real runner.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
+++ b/todo.d/20260809-webkit-scan-import-drawer-backdrop.md
@@ -1,12 +1,37 @@
 <!-- file: todo.d/20260809-webkit-scan-import-drawer-backdrop.md -->
-<!-- version: 2.0.0 -->
+<!-- version: 3.0.0 -->
 <!-- guid: 4d20e8b7-1c63-49fa-85e0-7b3f9a06c214 -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **Webkit has a POPULATION of marginal tests on CI, not one broken one.** Retitled
-      after the original drawer failure was fixed and a *different* test failed in its
-      place. This is what keeps the *nightly* (chromium + webkit) advisory rather than
-      blocking. The PR path (chromium) is green and blocks as of 2026-08-09.
+- [x] **RESOLVED — webkit was marginal on TIMING, and its own 60s budget fixed the
+      class.** The nightly now blocks too; `continue-on-error` is a plain `false`.
+
+      **Final measurement on the real runner:**
+
+      | configuration | result |
+      |---|---|
+      | chromium (PR path) | **272 passed / 0 failed / 8 skipped** |
+      | chromium + webkit | **544 passed / 0 failed / 16 skipped** |
+
+      The fix was one line — `timeout: 60 * 1000` on the webkit project only, chromium
+      keeping 30s — and it was chosen as the *discriminating experiment* for the
+      population hypothesis rather than as a workaround. It came back green, so the
+      hypothesis is confirmed: webkit had several tests close to the shared 30s limit and
+      roughly one lost per run.
+
+      **Why this is headroom and not blindness:** a genuinely broken test does not finish
+      in 60s either. What changed is that a slow-but-correct one stopped being reported as
+      a failure. Chromium keeps the tighter budget because it had margin to spare once CI
+      dropped to one worker.
+
+      **Cheaper than the plan this fragment originally proposed.** It suggested three
+      measurement runs to characterise the failing set first; one config change answered
+      the same question and fixed it. Worth remembering: when a hypothesis implies a
+      one-line change, the change often IS the measurement.
+
+      ---
+
+      **Original entry, for the record.**
 
       ## The update that changes the shape of this problem
 


### PR DESCRIPTION
## `continue-on-error: false`

Measured on the real runner before flipping:

| configuration | result |
|---|---|
| chromium — PR path | **272 passed / 0 failed / 8 skipped** |
| chromium + webkit — nightly | **544 passed / 0 failed / 16 skipped** |

Both green, so the exception is gone.

The flag was `true` while the suite was ~50% red, then `${{ github.event_name != 'pull_request' }}` while chromium was green and webkit still lost one test per run. This removes the last conditional.

## How the webkit tail closed

Giving webkit its **own 60s per-test budget** while chromium keeps 30s (#2257).

The evidence that it was a *class* problem rather than N bugs: two consecutive both-engine runs scored an **identical 543/1/16 while failing different tests in different spec files.** A per-test fix moved nothing. That is what distinguishes a timing margin from separate defects, and it is why the one-line config change was chosen as the discriminating experiment rather than continuing to fix tests one at a time.

## Where this started

**Baseline, 2026-08-08 clean-environment run: 146 failed / 138 passed of 288 chromium tests.**

## None of the CI-only failures were product defects

Worth recording, because two were filed as product bugs and **both filings were wrong**:

| cause | what it actually was |
|---|---|
| 30s `locator.click` timeouts | **worker contention** — 2 browsers + the Go server on 2 cores starving MUI transitions |
| webkit's persistent single failure | a **shared timeout budget** too tight for the slower engine |
| "Could not decode expected image as PNG" | visual goldens stored as **Git LFS pointers** no runner could fetch |

## What a red run means now

The browser suite is broken. That is the signal, not the problem.

Do not set this back to `true` to quiet a red run, and do not delete the job — that is precisely how six specs sat disabled for four months and started this whole effort.

Closes out `todo.d/20260809-webkit-scan-import-drawer-backdrop.md`.

CI-only; `changelog.d` fragment is intentionally all-comments.