### PR TITLE
docs: close out the CI e2e gate task [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.20.0 -->
+<!-- version: 10.21.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -14,7 +14,45 @@ into one of the curated sections below, is a normal direct edit.
 
 <!-- todo-insert-here -->
 
-- [ ] **Nothing runs the e2e suite automatically — wire it into CI.** Found
+- [x] **DONE 2026-08-09 — the e2e suite runs in CI and BLOCKS on every trigger.**
+      `continue-on-error: false`, `pull_request` trigger live with its paths filter
+      (#2258). A change that breaks the browser suite can no longer merge.
+
+      **Final state, measured on the real ubuntu runner — not locally:**
+
+      | configuration | result |
+      |---|---|
+      | chromium (PR path) | **272 passed / 0 failed / 8 skipped** |
+      | chromium + webkit | **544 passed / 0 failed / 16 skipped** |
+
+      Baseline was 146 failed / 138 passed of 288 chromium tests. 26 PRs,
+      #2224–#2258.
+
+      **The three sub-items in the original entry are all closed:**
+
+      1. ~~Establish the real number with a full-output run~~ — done; it was 146, not
+         the ~4 the fragment guessed.
+      2. ~~Triage the failures~~ — done, plus **eleven product regressions** found that
+         were not test problems (audit:
+         `docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md`).
+      3. ~~Flip `continue-on-error` off~~ — done, together with restoring the
+         `pull_request` trigger, exactly as the entry required.
+
+      **⚠️ The CI-only failures were ALL environmental, not product defects** — and two
+      were filed as product bugs before measurement said otherwise:
+      worker contention starving MUI transitions (`workers: 1` on CI), a shared 30s
+      timeout too tight for webkit (its own 60s budget), and visual goldens stored as
+      **Git LFS pointers** no runner could decode. That last one meant the visual test
+      could never have passed on CI, for either browser.
+
+      **🚨 "Green locally" ≠ green on CI.** The suite was 0-failing on macOS while CI
+      had 179 failures. `conclusion: success` on that workflow meant nothing while
+      `continue-on-error` was true. Dispatch
+      `gh workflow run e2e.yml --ref <branch> -f projects=chromium` and read the counts.
+
+      ---
+
+      **Original entry, for the record.** Found
       2026-08-08 while adding sidebar-filter coverage. `grep -rl
       "test-e2e\|test:e2e\|playwright test" .github/workflows/` returns
       **nothing**. The suite exists, is maintained (43 specs were repaired
@@ -70,7 +108,7 @@ into one of the curated sections below, is a normal direct edit.
       unless the server is un-bootstrapped. **Nothing was deleted or silently
       skipped.** Full audit with file:line evidence:
       `docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md`.
-      Sub-item 3 (flip `continue-on-error` off) remains — broken out below.
+      ✅ Sub-item 3 (flip `continue-on-error` off) is now DONE too — #2258.
 
       **The webkit tail was not what it looked like.** 3 of the 4 were a
       Playwright/webkit harness artifact, not a product defect: its synthesised

--- a/changelog.d/20260809_194500_close_out_ci_gate.md
+++ b/changelog.d/20260809_194500_close_out_ci_gate.md
@@ -1,0 +1,6 @@
+<!-- Docs/TODO-only close-out: marks the "wire the e2e suite into CI" task done
+     now that the suite blocks on every trigger, and records the final measured
+     state in the August roundup.
+
+     No product behaviour changed, so this fragment is intentionally all
+     comments and contributes nothing to CHANGELOG.md. -->

--- a/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: e7a3f109-52d8-4c6b-91f4-08b7c2d64e35 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -99,9 +99,18 @@ machine**. The causes were all environmental rather than product defects: image 
 stored in a way the build server could not read, and two browsers competing for two
 processor cores so aggressively that ordinary animations timed out.
 
-**The outcome that matters:** as of Aug 9 the tests **block** — a change that breaks the
-browser suite can no longer merge. That was the entire point, and until this month it was
-not true.
+**The outcome that matters:** as of Aug 9 the tests **block on every run** — a change
+that breaks the browser suite can no longer merge. Both browsers now pass completely:
+**544 tests, none failing.** That was the entire point, and until this month it was not
+true.
+
+Worth recording what the build-server failures turned out to be, because none of them
+were faults in the product and two were written up as such before the evidence came in:
+two browsers competing for two processor cores so hard that ordinary animations timed
+out; a time limit that was fine for one browser and too tight for the slower one; and
+image files stored in a way that meant the build server received a text placeholder
+instead of a picture. That last one had made a check impossible to pass on the build
+server since it was written.
 
 ---
 


### PR DESCRIPTION
## The task that started this is done

`TODO.md`'s *"Nothing runs the e2e suite automatically — wire it into CI"* entry is closed. The suite runs in CI and **blocks on every trigger** as of #2258.

| configuration | result (real ubuntu runner) |
|---|---|
| chromium — PR path | **272 passed / 0 failed / 8 skipped** |
| chromium + webkit | **544 passed / 0 failed / 16 skipped** |

Baseline: **146 failed / 138 passed** of 288 chromium tests. 26 PRs, #2224–#2258.

## All three sub-items closed, including the one that mattered most

1. **Establish the real number with a full-output run.** It was **146**, not the ~4 the fragment had estimated. The entry explicitly said *"do not guess it from the fragment above"* — and it was right to.
2. **Triage the failures.** Done, and it produced **eleven product regressions** that were not test problems.
3. **Flip `continue-on-error` off** — done, *together* with restoring the `pull_request` trigger, which the entry required be treated as a pair.

## Two things the original entry could not have known

**The CI-only failures were all environmental**, and two were filed as product bugs before measurement said otherwise:

| symptom | actual cause |
|---|---|
| 30s `locator.click` timeouts | worker contention starving MUI transitions |
| one persistent webkit failure per run | a shared 30s timeout too tight for the slower engine |
| "Could not decode expected image as PNG" | goldens stored as **Git LFS pointers** no runner could fetch |

**"Green locally" is not evidence.** The suite was 0-failing on macOS while CI had **179** failures, and `conclusion: success` on that workflow meant nothing while `continue-on-error` was `true`. The close-out records the command that gives a real answer.

## Also

Updates the August roundup with the both-engines-green result, plus a plain-language note on what the build-server failures actually were — written for someone who doesn't work on the code, since "the tests were broken on the build server for reasons unrelated to the product" is the part a reader would otherwise have to take on trust.

Docs/TODO-only; `changelog.d` fragment is intentionally all-comments.