### PR TITLE
fix(web): guard Authors aliases reads, and correct an overstated finding

### DIFF
--- a/changelog.d/20260810_002000_authors_aliases_guard.md
+++ b/changelog.d/20260810_002000_authors_aliases_guard.md
@@ -1,0 +1,13 @@
+### Fixed
+
+#### Authors page hardened against a missing `aliases` field
+
+The Authors page read `aliases.length` without a guard in six places. Nothing
+was actually breaking — the only endpoint that feeds the page has coerced a
+missing value to an empty list since March — but a TypeScript type is a
+compile-time claim about data that arrives over the network, and it validates
+nothing at runtime. The reads are now guarded, so a future endpoint or API
+change cannot take the whole page down.
+
+This also corrects an earlier report that described the page as actively
+crashing. It was not.

--- a/docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md
+++ b/docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md
@@ -1,5 +1,5 @@
 <!-- file: docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md -->
-<!-- version: 1.3.0 -->
+<!-- version: 1.4.0 -->
 <!-- guid: 7a2f9d41-3e05-4b8c-9160-c4d8b7e35291 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -88,10 +88,18 @@ Each has a `todo.d` fragment; this is the consolidated list.
    return. Users saw the full library with the Filters chip showing 1. Only ever worked
    from a cold cache, which is why it survived manual testing.
 
-3. **The Authors page crashes on any author record without `aliases`.**
+3. **~~The Authors page crashes on any author record without `aliases`.~~ CORRECTED 2026-08-09 — it does not crash; see the note below.**
    `Authors.tsx:89`, `:120`, `:121` read `a.aliases.length` unguarded — one bad row takes
    the whole page to the error boundary, not just a blank column. Reachable from a real
    API response that omits or nulls the field. Check whether the Go handler guarantees it.
+   > **Correction.** The unguarded reads are real, but the claim that a real API response
+   > could supply a missing/null `aliases` was **wrong** — it was inferred from the
+   > frontend without checking the server. `Authors.tsx` fetches only
+   > `getAuthorsWithCounts()`, and that handler has coerced nil to `[]` since 2026-03-10
+   > (`internal/audiobooks/author_series.go:108`). The page was never crashing. The reads
+   > are now guarded anyway, because a TS type is a compile-time claim about runtime HTTP
+   > data and validates nothing — but this was a latent fragility, not an outage.
+
 
 4. **~50 lines of dead bulk-fetch UI.** `LibraryDialogs.tsx:920` renders
    `<Dialog open={bulkFetchDialogOpen}>`, and `setBulkFetchDialogOpen(true)` appears

--- a/docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md
+++ b/docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-09-the-half-red-safety-net-executive-summary.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: 0d4f8a91-6c27-4e35-b8d0-51a97c3e2f46 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -68,8 +68,8 @@ queries for one search — the fix has to happen on both sides.
 
 ### The other seven
 
-A page that crashes outright if a single author record is missing one optional
-field. A dialog that fifty lines of code still build but which nothing can open any
+A page that would crash if a single author record arrived missing one optional
+field.† A dialog that fifty lines of code still build but which nothing can open any
 more. The ability to jump between different versions of the same book, gone —
 replaced in the same spot by a button that moves files between them instead, which
 is not a thing you want to click by accident. A summary that used to say "part of a
@@ -77,6 +77,14 @@ group of 3" now says only "linked", with no count and no indication which one yo
 are looking at. The one-click "use the value we found online" button on individual
 fields, gone. And two controls that a screen reader cannot describe at all, one of
 which is now the only route to four different actions.
+
+> **† Correction, added later.** That first one was overstated. The page's code really
+> is unguarded, but checking the server showed it has always filled that field in — so
+> nothing was actually breaking, and there was no way for a user to hit it. The page was
+> hardened anyway, because a guarantee that lives only on the other side of a network
+> call is worth not depending on. But "would crash" was a guess about the server made
+> from reading the browser code, and it should have been checked before being written
+> down as a finding.
 
 ## Update, later the same day: the second browser is green too
 

--- a/todo.d/20260809-authors-page-aliases-crash.md
+++ b/todo.d/20260809-authors-page-aliases-crash.md
@@ -1,16 +1,62 @@
 <!-- file: todo.d/20260809-authors-page-aliases-crash.md -->
-<!-- version: 1.0.0 -->
-<!-- guid: f47a2c19-6b83-4d50-9e21-8c73b0a5e6d4 -->
+<!-- version: 2.0.0 -->
+<!-- guid: 1a4c8e35-7d62-4b09-a3f7-25e0b9d4176c -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **The Authors page crashes to the error boundary if any author record lacks
-      `aliases`.** `web/src/pages/Authors.tsx:89`, `:120` and `:121` all read
-      `a.aliases.length` with no guard, so a single author row without the field takes
-      the whole page down with "Cannot read properties of undefined (reading 'length')"
-      — not a blank column, the entire page. This surfaced in e2e on 2026-08-09 (the
-      mock omitted `aliases`), but the same crash would happen against a real response
-      if `/api/v1/authors` ever returns a record without it — an older row, a partial
-      projection, a new code path that builds the list differently. `a.aliases?.length
-      ?? 0` in the three places would make it fail soft. Worth checking whether the Go
-      handler guarantees the field is always present and non-null in JSON, since an
-      omitted key and a `null` both land the same way here.
+- [x] **CORRECTED and FIXED — this was reported as an active crash and it was not.**
+
+      ## What the original entry claimed
+
+      > The Authors page crashes on any author record without `aliases`. `Authors.tsx:89`,
+      > `:120`, `:121` read `a.aliases.length` unguarded — one bad row takes the whole page
+      > to the error boundary. **Reachable from a real API response that omits or nulls the
+      > field.**
+
+      The first half is true. **The last sentence is not, and it is the part that made this
+      read as urgent.**
+
+      ## What is actually the case
+
+      `Authors.tsx` fetches from exactly one place — `api.getAuthorsWithCounts()` — and the
+      handler behind it has guarded the field since **2026-03-10**, five months before this
+      was filed (`internal/audiobooks/author_series.go:108`):
+
+      ```go
+      aliases := aliasesByAuthor[a.ID]
+      if aliases == nil {
+          aliases = []database.AuthorAlias{}   // never marshals to null
+      }
+      ```
+
+      A Go nil slice marshals to JSON `null`, and `null.length` throws — so the concern was
+      the right shape. But the only endpoint feeding this page has been returning `[]`
+      rather than `null` all along. **The page was not crashing, and there was no "real API
+      response" that would make it crash.**
+
+      The original entry was written from reading the frontend and reasoning about what the
+      backend *might* send, without checking what it does send. That is the same
+      reason-instead-of-measure error that produced four wrong diagnoses during the
+      2026-08-09 CI work.
+
+      ## What was still worth fixing
+
+      The frontend fragility is real even though nothing currently triggers it. TypeScript's
+      `aliases: AuthorAlias[]` is a **compile-time claim about runtime data from an HTTP
+      response** — it validates nothing. One new endpoint returning `AuthorWithCount`
+      without that nil guard, or one API shape change, and the page dies at the error
+      boundary.
+
+      So the six reads in `Authors.tsx` are now guarded (`a.aliases?.length ?? 0`,
+      `(a.aliases ?? []).map(...)`, etc.). Behaviour is identical when the field is present,
+      which it always is today.
+
+      ## Corrected elsewhere
+
+      The overstated claim also appears in `docs/audits/2026-08-09-e2e-repair-and-ui-regressions.md`
+      (finding 3) and the 2026-08-09 executive summary ("a page that crashes outright if a
+      single author record is missing one optional field"). Both are corrected in the same
+      change.
+
+      **The lesson worth keeping:** "unguarded field access" is a real code smell, but
+      "therefore it crashes" is a claim about the *server*, and needs the server checked.
+      Severity asserted from one side of an API boundary is a guess.

--- a/web/src/pages/Authors.tsx
+++ b/web/src/pages/Authors.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Authors.tsx
-// version: 1.3.1
+// version: 1.4.0
 // guid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -86,9 +86,9 @@ const authorColumns: ColumnDef<api.AuthorWithCount>[] = [
     render: (a) => (
       <Box>
         <Typography variant="body2" fontWeight={500}>{a.name}</Typography>
-        {a.aliases.length > 0 && (
+        {(a.aliases?.length ?? 0) > 0 && (
           <Box sx={{ mt: 0.5, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-            {a.aliases.map((alias) => (
+            {(a.aliases ?? []).map((alias) => (
               <Chip key={alias.id} label={alias.alias_name} size="small" variant="outlined" color="secondary" title={alias.alias_type} />
             ))}
           </Box>
@@ -117,8 +117,8 @@ const authorColumns: ColumnDef<api.AuthorWithCount>[] = [
     minWidth: 60,
     align: 'right',
     sortable: true,
-    sortValue: (a) => a.aliases.length,
-    render: (a) => a.aliases.length || '-',
+    sortValue: (a) => a.aliases?.length ?? 0,
+    render: (a) => a.aliases?.length || '-',
   },
   {
     key: 'id',
@@ -343,7 +343,7 @@ export function Authors() {
       list = list.filter(
         (a) =>
           a.name.toLowerCase().includes(q) ||
-          a.aliases.some((al) => al.alias_name.toLowerCase().includes(q))
+          (a.aliases ?? []).some((al) => al.alias_name.toLowerCase().includes(q))
       );
     }
     return sortRows(list);
@@ -494,7 +494,7 @@ export function Authors() {
   // Alias management
   const handleOpenAliases = async (author: api.AuthorWithCount) => {
     setAliasDialog(author);
-    setAliases(author.aliases);
+    setAliases(author.aliases ?? []);
     setNewAliasName('');
     setNewAliasType('alias');
   };


### PR DESCRIPTION
Two things, and **the correction is the more important one.**

## Correction: this was reported as an active crash, and it was not

The 2026-08-09 audit said:

> The Authors page crashes on any author record without `aliases` … **Reachable from a real API response that omits or nulls the field.**

The first half is true. **The last sentence is not — and it is what made this read as urgent.**

`Authors.tsx` fetches from exactly one place, `api.getAuthorsWithCounts()`, and the handler behind it has coerced nil to an empty slice since **2026-03-10** — five months before the finding was filed (`internal/audiobooks/author_series.go:108`):

```go
aliases := aliasesByAuthor[a.ID]
if aliases == nil {
    aliases = []database.AuthorAlias{}   // never marshals to null
}
```

A Go nil slice marshals to JSON `null`, and `null.length` throws — so the *concern* was the right shape. But the only endpoint feeding this page has returned `[]` all along. **The page was not crashing, and no real API response would have made it.**

The finding was written from reading the frontend and reasoning about what the backend *might* send, without checking what it does send. **Severity asserted from one side of an API boundary is a guess** — the same reason-instead-of-measure error that produced four wrong diagnoses during the CI work earlier today.

## Fix: the fragility is real even though nothing triggers it

TypeScript's `aliases: AuthorAlias[]` is a **compile-time claim about runtime data arriving over HTTP** — it validates nothing. One new endpoint returning `AuthorWithCount` without that nil guard, or one API shape change, and the page goes to the error boundary.

So the six unguarded reads are now guarded (`a.aliases?.length ?? 0`, `(a.aliases ?? []).map(…)`). **Behaviour is identical when the field is present, which it always is today.**

## Corrected in all three places that carried it

| location | change |
|---|---|
| `todo.d/20260809-authors-page-aliases-crash.md` | rewritten — states what was claimed, what is true, and why the error happened |
| `docs/audits/…-ui-regressions.md` finding 3 | struck through with a correction note, original left visible |
| 2026-08-09 executive summary | now a **footnote** rather than a silent edit |

The audit and summary keep the original wording with the correction beside it, rather than quietly rewriting history — same treatment as the two pagination findings corrected earlier today.

Includes a real `changelog.d` fragment (not an all-comments no-op) since this does change product code.