### PR TITLE
docs(search): the index silently drops updates — 56,537 in seven days [skip changelog]

### DIFF
--- a/changelog.d/20260810_012000_index_queue_drops.md
+++ b/changelog.d/20260810_012000_index_queue_drops.md
@@ -1,0 +1,8 @@
+<!-- Docs-only: records a measured production defect -- the search index worker
+     silently drops updates when its 1024-deep queue overflows (56,537 dropped
+     in seven days), with no retry or reconciliation. Marks index
+     reconciliation as a blocking prerequisite for pushing filters/sort into
+     Bleve, and closes the "is the index complete" open question with "no".
+
+     No code changed yet, so this fragment is intentionally all comments and
+     contributes nothing to CHANGELOG.md. -->

--- a/docs/design/2026-08-09-search-backend-options.md
+++ b/docs/design/2026-08-09-search-backend-options.md
@@ -1,5 +1,5 @@
 <!-- file: docs/design/2026-08-09-search-backend-options.md -->
-<!-- version: 3.0.0 -->
+<!-- version: 3.1.0 -->
 <!-- guid: 4f1c8a72-6d93-4e05-b8a1-9c72e0f45d38 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -260,6 +260,8 @@ hand-written routes.
    symptoms and stops them corrupting later measurements.
 2. **A1 — push filters AND sort into the Bleve query**, so both apply *before* pagination.
    The one piece of real engineering; removes the full-set materialise and fixes §5.2.
+   **⚠️ Blocked on index reconciliation** — see open item 3. Pushing filters into an index
+   that silently drops 56K updates a week converts a relevance problem into missing rows.
 3. **Secondary sorted indexes** (§2.3) for the fields that matter, sized against 366,916.
 4. **Delete the client-side library sort** and restore the missing sort control.
    `SearchBar.test.tsx:43` currently asserts the control is *absent* and passes vacuously —
@@ -285,10 +287,16 @@ SQLite3?" section and there is no sqlite dep in `go.mod`); an external search se
    §3.2a is worth. Not yet counted.
 2. **Which sort fields matter?** Each costs an index. Five exist; "all of them" is the
    expensive answer, and probably nobody sorts by publisher.
-3. **Index staleness tolerance.** Filter/sort pushdown promotes the Bleve index from a
-   *relevance* dependency to a **correctness** one. If it can lag, pushdown returns wrong
-   rows rather than merely mis-ranked ones. The index worker is async with a 1024-deep queue.
-4. **Is the index complete?** It opens; whether it holds every book is unverified — the
-   checked-in `.api-token` returns `invalid session` and the index directory is root-owned.
+3. **🔴 Index staleness — now a BLOCKING prerequisite, not a question.** Filter/sort
+   pushdown promotes the Bleve index from a *relevance* dependency to a **correctness**
+   one. Item 4 below measured the index dropping 56,537 updates in a week with no
+   reconciliation. Today that means stale ranking; after A1 it means **a book whose
+   `library_state` changed is absent from the correct filter and present in the wrong
+   one**, with no error shown. **Reconciliation has to land before step 2 of §6.**
+4. ~~Is the index complete?~~ **ANSWERED — NO.** Measured on prod 2026-08-10: the index
+   worker's 1024-deep queue overflows under bulk operations and **silently drops** the
+   overflow — **56,537 dropped operations in seven days** (Aug 03 and Aug 07). There is no
+   retry, no dirty-set and no re-sync, so a dropped update diverges the index from the DB
+   permanently. See `todo.d/20260810-search-index-queue-drops-silently.md`.
 5. **Per-user filters** — there is a `DisablePerUserSearchFilters` flag and a 10,000-row
    over-fetch window. If multi-user is theoretical, that path simplifies and §5.2 gets easier.

--- a/todo.d/20260810-search-index-queue-drops-silently.md
+++ b/todo.d/20260810-search-index-queue-drops-silently.md
@@ -1,0 +1,84 @@
+<!-- file: todo.d/20260810-search-index-queue-drops-silently.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 9e51d7a3-2c48-4b16-8f70-a3d19c6528b4 -->
+<!-- last-edited: 2026-08-10 -->
+
+- [ ] **🔴 The search index silently drops updates when its queue fills — 56,537 dropped
+      in seven days.** Measured on prod 2026-08-10 from `journalctl`. This is a
+      **blocking prerequisite** for pushing filters/sort into Bleve (design doc option
+      A1), and it changes the ordering of that plan.
+
+      ## The measurement
+
+      ```
+      level=WARN msg="search index queue full, dropped (delete)" bookID=01KXXVGZ90PS78ZWJZJY62EFCJ del=false
+      ```
+
+      | window | dropped index operations |
+      |---|---|
+      | last 7 days | **56,537** |
+      | days affected | Aug 03 and Aug 07 only |
+      | since the Aug 09 10:33 restart | 0 |
+
+      **The zero is not reassuring.** The queue is empty because the process restarted and
+      no bulk operation has run since. Both affected days were bulk-operation days; the
+      next scan, merge wave or dedup run refills it and drops again.
+
+      ## The mechanism
+
+      `internal/server/indexed_store.go:113-122` — a non-blocking send onto a 1024-deep
+      channel, with `default:` as the overflow branch:
+
+      ```go
+      select {
+      case s.indexQueue <- indexRequest{bookID: bookID, delete: del}:
+      default:
+          atomic.AddInt32(&s.indexWorkerBusy, -1)
+          slog.Warn("search index queue full, dropped (delete)", "bookID", bookID, "del", del)
+      }
+      ```
+
+      Dropping under pressure is a defensible choice — the alternative is blocking a write
+      path on the indexer. **What is not defensible is that nothing reconciles afterwards.**
+      A dropped update is lost permanently; there is no retry, no dirty-set, and no
+      periodic re-sync. The index diverges from the database and stays diverged until
+      something happens to rewrite that book.
+
+      Note the log message says `(delete)` while `del=false` — the label is wrong for the
+      upsert case, which makes the warning harder to interpret than it needs to be.
+
+      ## Why this blocks A1
+
+      Today a dropped update means **stale relevance** — a book ranks oddly or misses a
+      match. Bad, tolerable, invisible.
+
+      After A1 pushes filters and sort into the Bleve query, a dropped update means
+      **wrong rows**. A book whose `library_state` changed to `organized` but whose index
+      entry still says `imported` will be *absent from the Organized filter and present in
+      Imported*. The user sees a library that is missing books, with no error.
+
+      **This is the difference between an index that is a relevance dependency and one that
+      is a correctness dependency** — exactly the risk flagged as open item 3 in
+      `docs/design/2026-08-09-search-backend-options.md`, now with a measured failure rate
+      attached.
+
+      ## What to do, in order
+
+      1. **Make the drop visible.** A counter and a metric, not just a WARN that scrolls
+         past 56,537 times. Right now the only way to know is to grep journald.
+      2. **Reconcile.** Any of: a dirty-set of book IDs that failed to enqueue, drained on
+         a ticker; a periodic full re-index; or a generation counter per book compared
+         against the index on read. A dirty-set is the cheapest and matches the existing
+         "cached aggregates + dirty flag" idiom in this codebase.
+      3. **Then and only then**, push filters/sort into the index.
+      4. Fix the `(delete)` label while touching this.
+
+      **Do not size the queue bigger and call it fixed.** 1024 → 100,000 moves the
+      threshold; it does not add reconciliation. The bulk days dropped 56K operations,
+      which no reasonable buffer absorbs.
+
+      ## Also settles an open question
+
+      Open item 4 of the design doc asked whether the index is complete. **It is not**, and
+      now there is a mechanism and a number rather than a suspicion. The `.api-token` is
+      still stale, but this answer did not need it.


### PR DESCRIPTION
Found while trying to answer *"is the Bleve index complete?"* — open item 4 of the design doc. **It is not**, and the mechanism is worse than staleness.

## Measured on prod

```
level=WARN msg="search index queue full, dropped (delete)" bookID=… del=false
```

| window | dropped index operations |
|---|---|
| last 7 days | **56,537** |
| days affected | Aug 03 and Aug 07 — both bulk-operation days |
| since the Aug 09 10:33 restart | 0 |

**The zero is not reassuring.** The queue is empty because the process restarted and no bulk operation has run since. The next scan, merge wave or dedup run refills it.

## Mechanism

`internal/server/indexed_store.go:113-122` — a non-blocking send onto a 1024-deep channel with `default:` as the overflow branch:

```go
select {
case s.indexQueue <- indexRequest{bookID: bookID, delete: del}:
default:
    slog.Warn("search index queue full, dropped (delete)", "bookID", bookID, "del", del)
}
```

Dropping under pressure is **defensible** — blocking a write path on the indexer would be worse. **What is not defensible is that nothing reconciles afterwards.** No retry, no dirty-set, no periodic re-sync. A dropped update diverges the index from the database *permanently*, until something else happens to rewrite that book.

## Why this changes the plan

| | today | after A1 |
|---|---|---|
| a dropped update means | stale relevance — a book ranks oddly | **wrong rows** |

Concretely, after filters are pushed into the index: a book whose `library_state` changed to `organized` but whose index entry still says `imported` is **absent from the Organized filter and present in Imported**, with no error shown. The user sees a library missing books.

That is exactly the difference between an index that is a **relevance** dependency and one that is a **correctness** dependency — flagged as a question in the design doc, now with a measured failure rate attached.

**So index reconciliation is a blocking prerequisite for step 2 of the plan, not an open question.** The doc marks it as such; open item 4 is closed with "no".

## Ordering recorded

1. Make the drop **visible** — a metric, not a WARN that scrolls past 56,537 times.
2. **Reconcile** — a dirty-set drained on a ticker is cheapest and matches the existing "cached aggregates + dirty flag" idiom here.
3. *Then* push filters/sort into the index.
4. Fix the `(delete)` label, which reads wrong for the upsert case (`del=false`).

**Explicitly not a fix: sizing the queue bigger.** 1024 → 100,000 moves the threshold without adding reconciliation, and the bulk days dropped 56K operations — no reasonable buffer absorbs that.

Docs-only; no code changed yet. `changelog.d` fragment is intentionally all-comments.