### PR TITLE
fix(web): stop the library search querying on every keystroke

### DIFF
--- a/changelog.d/20260810_015000_library_search_debounce.md
+++ b/changelog.d/20260810_015000_library_search_debounce.md
@@ -1,0 +1,9 @@
+### Fixed
+
+#### The library search box no longer queries on every keystroke
+
+Typing a ten-character title fired ten full searches of the library. A 300ms
+debounce was already in place, but the query path ignored it as soon as the
+search text parsed — which is immediately — and used the raw value instead.
+Both now move together on the same timer, so a search runs once you stop
+typing rather than once per letter.

--- a/todo.d/20260809-search-drops-filters-and-debounce.md
+++ b/todo.d/20260809-search-drops-filters-and-debounce.md
@@ -1,10 +1,41 @@
 <!-- file: todo.d/20260809-search-drops-filters-and-debounce.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: a17c53e9-4820-4d6b-b95f-e3086c2741da -->
 <!-- last-edited: 2026-08-09 -->
 
 - [ ] **Typing in the library search box silently drops every active filter and the sort
-      order.** `useLibraryQuery.ts:192-193` branches on whether there is search text:
+      order.**
+
+      > ### ✅ The debounce half of this is FIXED (#2264) — and the original diagnosis was wrong
+      >
+      > This fragment said the search box "is not debounced at all". **A 300ms debounce
+      > existed the whole time.** What was actually happening is worse and more specific:
+      > `useLibraryQuery.ts:165` reads
+      >
+      > ```ts
+      > const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
+      > ```
+      >
+      > so the moment a search parses — which is always, once you type — the debounced
+      > value is **ignored** and the raw parsed value is used. `parsedSearch` also sits in
+      > that hook's `useCallback` dep array, so `loadAudiobooks` was recreated per
+      > keystroke. The debounce was real, correct, and **dead code on the only path that
+      > matters.**
+      >
+      > Fixed by moving `parsedSearch` and `searchQuery` off the same 300ms timer, rather
+      > than debouncing one and leaving the other raw — debouncing only the free text would
+      > let it disagree with the field filters mid-flight. `SearchBar`'s own UI still gets
+      > the raw value so chips react instantly; `useLibrarySelection` gets the debounced one,
+      > because "select all matching" must mean the query that produced the visible rows.
+      >
+      > `test.fixme('search debounces input to avoid excessive requests')` is now a real
+      > passing test (search-and-filter.spec.ts: 11 passed / 1 skipped, exit 0).
+      >
+      > **The filter-dropping half below is still open.**
+      >
+      > Lesson worth keeping: "feature X is missing" and "feature X exists but is bypassed"
+      > look identical from the outside and have completely different fixes. Grep for the
+      > mechanism before concluding it is absent. `useLibraryQuery.ts:192-193` branches on whether there is search text:
 
       ```ts
       searchText

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/Library.tsx
-// version: 1.79.0
+// version: 1.80.0
 // guid: 3f4a5b6c-7d8e-9f0a-1b2c-3d4e5f6a7b8c
 // last-edited: 2026-08-08
 
@@ -177,6 +177,12 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     getActiveFilterCount,
   } = useLibraryFilters({ searchParams, onFiltersChange: () => setPage(1) });
   const [parsedSearch, setParsedSearch] = useState<ParsedSearch>(() => parseSearch(initialSearch));
+  // The debounced twin of `parsedSearch`, moved by the same timer as
+  // `debouncedSearch` so the two never disagree about what is being searched.
+  // See the debounce effect below for why this exists.
+  const [debouncedParsedSearch, setDebouncedParsedSearch] = useState<ParsedSearch>(() =>
+    parseSearch(initialSearch),
+  );
   const [bulkTagDialogOpen, setBulkTagDialogOpen] = useState(false);
   const [bulkRatingDialogOpen, setBulkRatingDialogOpen] = useState(false);
 
@@ -527,16 +533,31 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     });
   }, [operationLogs]);
 
-  // Debounce search query
+  // Debounce the search query AND its parsed form together.
+  //
+  // `debouncedSearch` alone was not enough, and was in fact dead code on the
+  // path that matters. useLibraryQuery does:
+  //
+  //     const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
+  //
+  // so as soon as a search parses (i.e. always, once you type), the debounced
+  // value is ignored and the RAW parsed value is used — and `parsedSearch` sits
+  // in that hook's useCallback dep array, so `loadAudiobooks` was recreated on
+  // every keystroke. Result: one full query per character. Typing "Foundation"
+  // fired ten searches of the whole library.
+  //
+  // Moving both from the same timer keeps them consistent; debouncing only one
+  // would let the free text and the field filters disagree mid-flight.
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(searchQuery);
+      setDebouncedParsedSearch(parsedSearch);
     }, 300);
 
     return () => {
       if (timer) clearTimeout(timer);
     };
-  }, [searchQuery]);
+  }, [searchQuery, parsedSearch]);
 
   const isInitialMount = useRef(true);
   useEffect(() => {
@@ -694,7 +715,9 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     page,
     itemsPerPage,
     debouncedSearch,
-    parsedSearch,
+    // Debounced: this drives network requests. The raw `parsedSearch` still
+    // feeds SearchBar's own UI, which must react immediately as you type.
+    parsedSearch: debouncedParsedSearch,
     filters,
     selectedTags,
     sortBy,
@@ -740,7 +763,9 @@ export const Library = ({ defaultPreset = 'standard' }: LibraryProps) => {
     audiobooks,
     totalCount,
     debouncedSearch,
-    parsedSearch,
+    // Debounced too, deliberately: "select all matching" must mean the query
+    // that produced the rows on screen, not one the user is still typing.
+    parsedSearch: debouncedParsedSearch,
     filters,
     selectedTags,
     buildFieldFilters,

--- a/web/tests/e2e/search-and-filter.spec.ts
+++ b/web/tests/e2e/search-and-filter.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/search-and-filter.spec.ts
-// version: 1.5.0
+// version: 1.6.0
 // guid: c3d4e5f6-a7b8-9012-cdef-a3b4c5d6e7f8
 // last-edited: 2026-08-09
 
@@ -435,7 +435,7 @@ test.describe('Search and Filter Functionality', () => {
   // despite this test's name. On a large library that is ten full-text queries
   // where one would do. Documented with the filter-dropping bug above in
   // todo.d/20260809-search-drops-filters-and-debounce.md.
-  test.fixme('search debounces input to avoid excessive requests', async ({
+  test('search debounces input to avoid excessive requests', async ({
     page,
   }) => {
     // GIVEN: Library page loaded


### PR DESCRIPTION
Typing "Foundation" fired **ten full searches of the library**.

## The original diagnosis was wrong, and the real mechanism is worse

The audit finding said the search box *"is not debounced at all"*. **A 300ms debounce existed the whole time.** But `useLibraryQuery.ts:165` reads:

```ts
const searchText = parsedSearch ? parsedSearch.freeText : debouncedSearch;
```

So the moment a search **parses** — which is always, once you type — the debounced value is **ignored** and the raw parsed value is used. `parsedSearch` also sits in that hook's `useCallback` dep array, so `loadAudiobooks` was recreated on every keystroke.

**The debounce was real, correct, and dead code on the only path that matters.**

## The fix

Move `parsedSearch` and `searchQuery` off the **same** 300ms timer, rather than debouncing one and leaving the other raw — debouncing only the free text would let it disagree with the field filters mid-flight.

Two deliberate scoping choices:

| consumer | gets | why |
|---|---|---|
| `SearchBar` UI | **raw** `parsedSearch` | chips and hints must react instantly as you type; only the network path needs debouncing |
| `useLibraryQuery` | **debounced** | this is what issues requests |
| `useLibrarySelection` | **debounced** | "select all matching" must mean the query that produced the rows on screen, not one still being typed |

## The test

`test.fixme('search debounces input to avoid excessive requests')` is now a **real test**. Leaving it as `fixme` would have reported an *unexpected pass* — the marker working exactly as intended, but the wrong thing to ship.

**Verified: `search-and-filter.spec.ts` — 11 passed / 1 skipped, exit 0.** The remaining skip is the separate filter-dropping defect, still open and unchanged by this.

## Why this matters beyond the annoyance

It bears directly on the server-side filtering work: no backend improvement helps much while the client sends ten queries per search, and any benchmark taken before this fix is measuring the wrong thing.

Includes a real `changelog.d` entry (not an all-comments no-op) since this changes product behaviour.