### PR TITLE
fix(web): searching no longer discards filters and sort order

### DIFF
--- a/changelog.d/20260810_020500_search_keeps_filters.md
+++ b/changelog.d/20260810_020500_search_keeps_filters.md
@@ -1,0 +1,12 @@
+### Fixed
+
+#### Searching no longer throws away your filters and sort order
+
+Typing in the library search box silently discarded every active filter and the
+chosen sort order. Filter to Organized, search for an author, and you would get
+matches from every state — while the Filters button still showed a count, so
+nothing looked wrong.
+
+The server had always supported searching and filtering together; the page was
+simply switching to a different request that left the filters out. Search now
+goes through the same request as everything else.

--- a/todo.d/20260809-search-drops-filters-and-debounce.md
+++ b/todo.d/20260809-search-drops-filters-and-debounce.md
@@ -1,10 +1,10 @@
 <!-- file: todo.d/20260809-search-drops-filters-and-debounce.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: a17c53e9-4820-4d6b-b95f-e3086c2741da -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **Typing in the library search box silently drops every active filter and the sort
-      order.**
+- [x] **FIXED — both halves.** Typing in the library search box silently dropped every
+      active filter and the sort order, and queried on every keystroke.
 
       > ### ✅ The debounce half of this is FIXED (#2264) — and the original diagnosis was wrong
       >
@@ -31,7 +31,35 @@
       > `test.fixme('search debounces input to avoid excessive requests')` is now a real
       > passing test (search-and-filter.spec.ts: 11 passed / 1 skipped, exit 0).
       >
-      > **The filter-dropping half below is still open.**
+      > ### ✅ The filter-dropping half is ALSO fixed (#2265)
+      >
+      > It was a **branch**, not a missing capability:
+      >
+      > ```ts
+      > searchText
+      >   ? api.searchBooksPage(searchText, itemsPerPage, offset, filters.showFailed, signal)
+      >   : api.getBooks(itemsPerPage, offset, { sortBy, sortOrder, tags, libraryState, filters, ... })
+      > ```
+      >
+      > Every option lived on the `getBooks` side only, so typing one character crossed to
+      > a call that sends four parameters — dropping `library_state`, tags, field filters
+      > and the sort order.
+      >
+      > **The server was never the problem.** `GetAudiobooks` applies the same post-filters
+      > on the search path (`service_query.go:226`); it was simply never told about them.
+      >
+      > Fixed by collapsing the branch rather than adding nine parameters to
+      > `searchBooksPage`: `getBooks` hits the same endpoint with the same
+      > `is_primary_version`, so it only needed a `search` option. **One code path now** —
+      > which also means a future filter cannot be added to one branch and forgotten in the
+      > other, which is exactly the class of bug this was.
+      >
+      > `searchBooksPage` had exactly one production caller (checked); it is now
+      > `@deprecated` with the reason rather than removed.
+      >
+      > `test.fixme('search works with other filters combined')` is a real passing test.
+      > Verified: search-and-filter + library-browser, **33 passed / 0 failed / 0 skipped,
+      > exit 0.**
       >
       > Lesson worth keeping: "feature X is missing" and "feature X exists but is bypassed"
       > look identical from the outside and have completely different fixes. Grep for the

--- a/web/src/hooks/useLibraryQuery.ts
+++ b/web/src/hooks/useLibraryQuery.ts
@@ -1,5 +1,5 @@
 // file: web/src/hooks/useLibraryQuery.ts
-// version: 1.5.0
+// version: 1.6.0
 // guid: d4e5f6a7-b8c9-0123-def0-123456789003
 // last-edited: 2026-08-09
 
@@ -198,22 +198,34 @@ export function useLibraryQuery({
         return;
       }
 
+      // ONE call, whether or not there is search text.
+      //
+      // This used to branch: with search it called api.searchBooksPage, which
+      // sends only search/limit/offset/show_quarantined. Every other option
+      // below — library_state, tags, field filters, AND the sort order — was
+      // dropped the moment you typed. Filter to Organized, search an author,
+      // and you got matches from every state with the Filters chip still
+      // showing its count.
+      //
+      // The server was never the problem: GetAudiobooks applies the same
+      // post-filters on the search path (service_query.go:226). It simply was
+      // not being told about them. getBooks hits the same endpoint, so passing
+      // `search` here is enough.
       const [page_, folders] = await Promise.all([
-        searchText
-          ? api.searchBooksPage(searchText, itemsPerPage, offset, filters.showFailed, controller.signal)
-          : api.getBooks(itemsPerPage, offset, {
-              sortBy,
-              sortOrder,
-              tags: tagsParam,
-              libraryState,
-              filters: fieldFilters.length > 0 ? JSON.stringify(fieldFilters) : undefined,
-              showFailed: filters.showFailed,
-              hasFileErrors: filters.hasFileErrors,
-              fingerprintStatus: filters.fingerprintStatus,
-              coveragePercentMin: filters.coveragePercentMin,
-              coveragePercentMax: filters.coveragePercentMax,
-              signal: controller.signal,
-            }),
+        api.getBooks(itemsPerPage, offset, {
+          search: searchText || undefined,
+          sortBy,
+          sortOrder,
+          tags: tagsParam,
+          libraryState,
+          filters: fieldFilters.length > 0 ? JSON.stringify(fieldFilters) : undefined,
+          showFailed: filters.showFailed,
+          hasFileErrors: filters.hasFileErrors,
+          fingerprintStatus: filters.fingerprintStatus,
+          coveragePercentMin: filters.coveragePercentMin,
+          coveragePercentMax: filters.coveragePercentMax,
+          signal: controller.signal,
+        }),
         api.getImportPaths(controller.signal),
       ]);
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,5 +1,5 @@
 // file: web/src/services/api.ts
-// version: 2.55.0
+// version: 2.56.0
 // guid: a0b1c2d3-e4f5-6789-abcd-ef0123456789
 // last-edited: 2026-08-06
 
@@ -934,6 +934,14 @@ export async function getBooks(
   limit = 100,
   offset = 0,
   options?: {
+    /**
+     * Free-text search. Sent as `search`, alongside every other option here.
+     *
+     * This exists so searching does not mean losing your filters. The old
+     * `searchBooksPage` sent ONLY search/limit/offset, so typing in the box
+     * silently dropped library_state, tags, field filters and the sort order.
+     */
+    search?: string;
     sortBy?: string;
     sortOrder?: string;
     tag?: string;
@@ -951,6 +959,7 @@ export async function getBooks(
   const params = new URLSearchParams();
   params.set('limit', String(limit));
   params.set('offset', String(offset));
+  if (options?.search) params.set('search', options.search);
   if (options?.sortBy) params.set('sort_by', options.sortBy);
   if (options?.sortOrder) params.set('sort_order', options.sortOrder);
   if (options?.tags && options.tags.length > 0) {
@@ -1020,6 +1029,18 @@ export async function searchBooks(query: string, limit = 50, showFailed = false)
   return data.items || [];
 }
 
+/**
+ * @deprecated Use `getBooks(limit, offset, { search, ...filters })` instead.
+ *
+ * This sends ONLY search/limit/offset/is_primary_version/show_quarantined, so
+ * every active filter and the sort order are silently discarded. That was the
+ * cause of "search an author while filtered to Organized and get results from
+ * every state, with the Filters chip still showing its count". `getBooks` hits
+ * the same endpoint and sends the full parameter set.
+ *
+ * Kept only because removing an exported symbol is a wider change than this
+ * fix warrants; it has no production callers.
+ */
 export async function searchBooksPage(
   query: string,
   limit = 50,

--- a/web/tests/e2e/search-and-filter.spec.ts
+++ b/web/tests/e2e/search-and-filter.spec.ts
@@ -1,5 +1,5 @@
 // file: web/tests/e2e/search-and-filter.spec.ts
-// version: 1.6.0
+// version: 1.7.0
 // guid: c3d4e5f6-a7b8-9012-cdef-a3b4c5d6e7f8
 // last-edited: 2026-08-09
 
@@ -326,7 +326,7 @@ test.describe('Search and Filter Functionality', () => {
   // Filters chip keeps showing its count. Same family as the Deleted-filter
   // cache bug fixed in #2230: a filter that silently does nothing.
   // See todo.d/20260809-search-drops-filters-and-debounce.md.
-  test.fixme('search works with other filters combined', async ({ page }) => {
+  test('search works with other filters combined', async ({ page }) => {
     // GIVEN: Library has organized and import books by same author
     const books = [
       {


### PR DESCRIPTION
Filter to Organized, search an author, and you got matches from **every** state — with the Filters chip still showing its count, so nothing looked wrong.

## The cause was a branch, not a missing capability

```ts
searchText
  ? api.searchBooksPage(searchText, itemsPerPage, offset, showFailed, signal)
  : api.getBooks(itemsPerPage, offset, { sortBy, sortOrder, tags, libraryState, filters, … })
```

Every option lives on the `getBooks` side only. **Type one character and you cross to a call that sends four parameters** — `library_state`, tags, field filters and the sort order all vanish.

**The server was never the problem.** `GetAudiobooks` applies the same post-filters on the search path (`service_query.go:226`). It simply was not being told about them.

## The fix: collapse the branch, don't widen it

The obvious move — add nine parameters to `searchBooksPage` — leaves two call paths that must be kept in step forever. `getBooks` already hits the same `/audiobooks` endpoint with the same `is_primary_version`, so it only needed a `search` option.

**There is now one query path.** That matters beyond this bug: a future filter can no longer be added to one branch and forgotten in the other, which is precisely the class of bug this was.

Checked before touching it: `searchBooksPage` had **exactly one** production caller; the other five references are test mocks. It is now `@deprecated` with the reason rather than deleted — removing an exported symbol is wider than this fix warrants.

## Verification

**`search-and-filter` + `library-browser`: 33 passed / 0 failed / 0 skipped, exit 0.**

`test.fixme('search works with other filters combined')` is now a real test. That is **both** fixmes in this spec converted — the debounce one landed in #2264 — so the spec has no skips left.

## Why these two together matter

They were the pair behind the "not suck" bar. They also compound: before this, typing a ten-character query sent **ten** searches that each **ignored your filters**. The backend-filtering work now has a client worth optimising for.

Includes a real `changelog.d` entry since this changes product behaviour.