### PR TITLE
docs: record the two shipped search fixes [skip changelog]

### DIFF
--- a/changelog.d/20260810_022500_aug_roundup_search_fixes.md
+++ b/changelog.d/20260810_022500_aug_roundup_search_fixes.md
@@ -1,0 +1,5 @@
+<!-- Docs-only: records the two shipped search fixes in the August executive
+     roundup and marks step 1 of the search plan done in the design doc.
+
+     No product behaviour changed by this commit, so this fragment is
+     intentionally all comments and contributes nothing to CHANGELOG.md. -->

--- a/docs/design/2026-08-09-search-backend-options.md
+++ b/docs/design/2026-08-09-search-backend-options.md
@@ -1,5 +1,5 @@
 <!-- file: docs/design/2026-08-09-search-backend-options.md -->
-<!-- version: 3.1.0 -->
+<!-- version: 3.2.0 -->
 <!-- guid: 4f1c8a72-6d93-4e05-b8a1-9c72e0f45d38 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -299,8 +299,19 @@ hand-written routes.
 
 ## 6. The plan
 
-1. **Client sends filters and `sort_by`; debounce the box.** Hours. Fixes the loudest
-   symptoms and stops them corrupting later measurements.
+1. ~~**Client sends filters and `sort_by`; debounce the box.**~~ ✅ **DONE 2026-08-10**
+   (#2264, #2265). Both turned out to be an existing mechanism being **bypassed**, not a
+   missing one:
+   - The 300ms debounce existed but `useLibraryQuery.ts:165` ignored it the moment the
+     search parsed (`parsedSearch ? parsedSearch.freeText : debouncedSearch`), and
+     `parsedSearch` was in the loader's dep array. Fixed by moving both off one timer.
+   - The filters were dropped by a **branch** — `searchBooksPage` sends four parameters,
+     `getBooks` sends all of them. Fixed by collapsing to one query path rather than
+     widening the narrow one, so a future filter cannot be wired into one branch and
+     forgotten in the other.
+
+   Both `test.fixme` markers in `search-and-filter.spec.ts` are now passing tests
+   (33 passed / 0 failed / 0 skipped).
 2. **A1 — push filters AND sort into the Bleve query**, so both apply *before* pagination.
    The one piece of real engineering; removes the full-set materialise and fixes §5.2.
    **⚠️ Blocked on index reconciliation** — see open item 3. Pushing filters into an index

--- a/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
+++ b/docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md
@@ -1,5 +1,5 @@
 <!-- file: docs/executive-summaries/2026-08-31-august-monthly-roundup-executive-summary.md -->
-<!-- version: 1.1.0 -->
+<!-- version: 1.2.0 -->
 <!-- guid: e7a3f109-52d8-4c6b-91f4-08b7c2d64e35 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -129,6 +129,36 @@ Two decisions were taken during the month: **sorting moves to the server**, and 
 system should not suck" is the bar. A follow-up section analyses what that costs, and
 records an open question that has to be settled first — **the code disagrees with itself
 about how many books the library holds**, and the answer changes the design.
+
+---
+
+## 5. Two search fixes that shipped
+
+Both were on the "this has to stop" list, and both turned out to be a mechanism that
+already existed being bypassed rather than a feature that was missing. Worth noting,
+because "it's not there" and "it's there but skipped" look identical from the outside and
+need completely different fixes.
+
+**Searching no longer throws away your filters.** Filter the library to Organized, search
+for an author, and you got matches from every state — while the Filters button still
+showed a count, so nothing looked wrong. The page was switching to a *different* request
+when you typed, and that request left the filters out. The server had always been able to
+search and filter together; it simply was not being asked to. Search now goes through the
+same request as everything else, which also means a filter added in future cannot be
+wired into one path and forgotten in the other.
+
+**The search box no longer asks the server a question per letter.** Typing a
+ten-character title fired ten full searches of the library. A delay was already in place
+and working — but the code that runs the search ignored it the instant the text was
+parsed, which is immediately. So the brake existed and was never connected. Both values
+now move on the same timer.
+
+These compound: before this, typing ten letters sent ten searches that each ignored your
+filters. That matters for the planned work to move filtering onto the server — no
+server-side improvement counts for much while the browser behaves like that, and any
+before/after measurement taken earlier was measuring the wrong thing.
+
+Two tests that had been marked "expected to fail" are now ordinary passing tests.
 
 ---
 


### PR DESCRIPTION
Post-task hygiene for #2264 and #2265. They close a tracked set and are user-visible, so they belong in the **current month's executive summary** as well as the design doc.

## August roundup

New §5, written for someone who does not work on the code, covering both fixes and why they compound: *before this, typing ten letters sent ten searches that each ignored your filters.*

Also corrects §3, which described the search box as **"not debounced"** — wrong about the mechanism.

## The theme both share, and why they're written up together

**Each was an existing mechanism being bypassed, not a missing feature.**

| | what was assumed | what was true |
|---|---|---|
| debounce | there isn't one | there is, and the query path ignores it the moment the text parses |
| filters | the server can't search + filter | it always could; the client switched to a request that omitted them |

*"It's not there"* and *"it's there but skipped"* look identical from the outside and need completely different fixes. Adding a second debounce, or teaching the server to filter, would each have been real work that fixed nothing.

## Design doc

Plan step 1 marked done, with both mechanisms recorded so the next person doesn't re-derive them — including why the filter fix collapsed the branch instead of widening `searchBooksPage`.

Docs-only; `changelog.d` fragment is intentionally all-comments.