### PR TITLE
fix(web): stop the edit dialog overwriting a book's publication year

### DIFF
--- a/changelog.d/20260810_024500_edit_dialog_year_isbn.md
+++ b/changelog.d/20260810_024500_edit_dialog_year_isbn.md
@@ -1,0 +1,12 @@
+### Fixed
+
+#### Editing a book no longer overwrites its original publication year
+
+The Edit Metadata dialog has a single "Year" box, which means the audiobook's
+release year. Saving wrote that value into the *original publication year* as
+well — so editing a 1937 novel with a 2010 audiobook could replace 1937 with
+2010, silently. The dialog has no publication-year field, so nothing there
+should ever have changed it; that write is removed.
+
+The Year, ISBN-10 and ISBN-13 boxes also rendered empty whatever was stored,
+and now show the current values.

--- a/todo.d/20260809-edit-dialog-blank-year-isbn.md
+++ b/todo.d/20260809-edit-dialog-blank-year-isbn.md
@@ -1,9 +1,9 @@
 <!-- file: todo.d/20260809-edit-dialog-blank-year-isbn.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: c8d31e47-5f92-4b60-a3d7-2094f6ba1c85 -->
 <!-- last-edited: 2026-08-09 -->
 
-- [ ] **Edit Metadata shows Year and ISBN-13 as empty boxes whatever is stored — and the
+- [x] **FIXED (#2267).** **Edit Metadata shows Year and ISBN-13 as empty boxes whatever is stored — and the
       obvious fix corrupts `print_year`.** `mapBookToAudiobook`
       (`web/src/pages/BookDetail.tsx:762`) builds the object handed to
       `MetadataEditDialog` and omits `year`, `isbn10` and `isbn13`. `genre` had the same
@@ -37,3 +37,32 @@
 
       `tests/e2e/metadata-provenance.spec.ts` carries a `test.fixme` covering this, so it
       will start failing (loudly, as an unexpected pass) the moment it is fixed.
+
+      > ### What it actually was — worse than a blank box
+      >
+      > The dialog has ONE "Year" box, declared as `audiobook_release_year` in
+      > `FIELD_TO_API`. But `handleEditSave` fed `updated.year` into **two** fields:
+      >
+      > ```ts
+      > audiobook_release_year: … || updated.year || …,
+      > print_year:             updated.year || book.print_year || undefined,
+      > ```
+      >
+      > `print_year` is when the **book** was first published; `audiobook_release_year` is
+      > when the **recording** came out — decades apart for a classic. So typing a year in
+      > that dialog silently replaced the original publication year with the audiobook's.
+      > Same corruption class as the 2026-07-13 write-up, still live on this path. The blank
+      > box masked it for *display* but not for *writes*.
+      >
+      > Fixed in the safe order: remove the bad write first (`print_year` is now
+      > preserve-only — the dialog has no print-year field, so nothing there should change
+      > it), which then makes seeding the box safe. Doing it the other way would have turned
+      > a latent corruption into one firing on every save.
+      >
+      > **And the blank box had a second, separate cause:** the e2e fixture supplied
+      > `year: 2024`, a field the Go API never emits (`bookcore.go:44-45` has `print_year`
+      > and `audiobook_release_year` only). The dialog was correctly reading
+      > `audiobook_release_year` and finding nothing. Mock rot, not app behaviour.
+      >
+      > `test.fixme('year and ISBN-13 populate in the edit dialog')` is now passing:
+      > metadata-provenance 13 passed / 0 failed / 0 skipped, exit 0.

--- a/web/src/pages/BookDetail.tsx
+++ b/web/src/pages/BookDetail.tsx
@@ -1,5 +1,5 @@
 // file: web/src/pages/BookDetail.tsx
-// version: 1.53.0
+// version: 1.54.0
 // guid: 4d2f7c6a-1b3e-4c5d-8f7a-9b0c1d2e3f4a
 // last-edited: 2026-08-09
 
@@ -771,6 +771,17 @@ export const BookDetail = () => {
     // payload handleEditSave builds, so populating it cannot change what a
     // save writes — it only stops the dialog lying about the current value.
     genre: current.genre,
+    // Year, ISBN-10 and ISBN-13 were omitted, so those boxes rendered empty
+    // whatever was stored. `year` maps to audiobook_release_year — see
+    // FIELD_TO_API below, which is the declared meaning of this field.
+    //
+    // Populating `year` was previously unsafe because handleEditSave did
+    //   print_year: updated.year || book.print_year
+    // i.e. ONE form box wrote TWO different semantic fields. That is fixed
+    // below (print_year is now preserve-only), so this is safe now.
+    year: current.audiobook_release_year,
+    isbn10: current.isbn10,
+    isbn13: current.isbn13,
     language: current.language,
     publisher: current.publisher,
     description: current.description,
@@ -834,7 +845,21 @@ export const BookDetail = () => {
         updated.year ||
         book.audiobook_release_year ||
         undefined,
-      print_year: updated.year || book.print_year || undefined,
+      // PRESERVE-ONLY. This used to be `updated.year || book.print_year`, which
+      // meant the dialog's single Year box wrote BOTH audiobook_release_year
+      // (its declared meaning, per FIELD_TO_API) AND print_year.
+      //
+      // Those are different facts: print_year is when the BOOK was first
+      // published, audiobook_release_year is when the RECORDING came out. For a
+      // classic they are decades apart. Typing a year here silently replaced
+      // the original publication year with the audiobook's — the same
+      // wrong-year corruption written up in the 2026-07-13 summary, still live
+      // on this path.
+      //
+      // The dialog has no print-year field (MetadataEditDialog renders one
+      // 'Year'), so there is nothing here that should change print_year.
+      // Removing the write removes a corruption path, not a feature.
+      print_year: book.print_year || undefined,
       isbn:
         updated.isbn13 ||
         updated.isbn10 ||

--- a/web/tests/e2e/metadata-provenance.spec.ts
+++ b/web/tests/e2e/metadata-provenance.spec.ts
@@ -1,5 +1,5 @@
 // file: tests/e2e/metadata-provenance.spec.ts
-// version: 2.2.0
+// version: 2.3.0
 // guid: 9a8b7c6d-5e4f-3d2c-1b0a-9f8e7d6c5b4a
 // last-edited: 2026-08-09
 
@@ -31,7 +31,11 @@ const createBookData = () => ({
   series_name: 'DB Series',
   series_number: 3,
   genre: 'Science Fiction',
-  year: 2024,
+  // `audiobook_release_year`, not `year`. The Go API emits print_year and
+  // audiobook_release_year (bookcore.go:44-45) and has NO `year` field, so a
+  // mock supplying one was describing a response that cannot happen — and the
+  // dialog, correctly reading audiobook_release_year, showed an empty box.
+  audiobook_release_year: 2024,
   language: 'en',
   publisher: 'Audible Studios',
   isbn10: '',
@@ -332,19 +336,16 @@ test.describe('MetadataEditDialog Provenance E2E', () => {
     await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
   });
 
-  // KNOWN BUG, deliberately not fixed here. mapBookToAudiobook (BookDetail.tsx:762)
-  // omits year, isbn10 and isbn13, so the Edit Metadata dialog shows those boxes
-  // empty whatever is stored. `genre` had the same problem and WAS fixed, because
-  // genre does not appear in the payload handleEditSave builds.
+  // FIXED. mapBookToAudiobook omitted year, isbn10 and isbn13, so those boxes
+  // rendered empty whatever was stored.
   //
-  // Year cannot be fixed the same way. The dialog seeds its Year box from
-  // audiobook.year, and handleEditSave computes
-  //   payload.print_year = updated.year || book.print_year
-  // so populating `year` from audiobook_release_year would silently overwrite
-  // print_year with the release year on every save, even when the user never
-  // touched the field. Fixing the display requires untangling that precedence
-  // first. See todo.d/20260809-edit-dialog-blank-year-isbn.md.
-  test.fixme('year and ISBN-13 populate in the edit dialog', async ({ page }) => {
+  // Populating `year` was previously unsafe: handleEditSave computed
+  //   print_year: updated.year || book.print_year
+  // so the dialog's single Year box wrote BOTH audiobook_release_year (its
+  // declared meaning per FIELD_TO_API) AND print_year — two different facts,
+  // decades apart for a classic. That write is now removed; print_year is
+  // preserve-only, so seeding the box is safe and the corruption path is gone.
+  test('year and ISBN-13 populate in the edit dialog', async ({ page }) => {
     await setupMockRoutes(page);
     await openEditDialog(page);
     await expect(page.getByRole('textbox', { name: 'Year', exact: true })).toHaveValue('2024');


### PR DESCRIPTION
Filed as *"the Year and ISBN boxes render empty."* The blank box was real — and it was **masking a live data-corruption path.**

## Typing a year replaced the book's publication year

The dialog has **one** "Year" box, declared as `audiobook_release_year` in `FIELD_TO_API`. `handleEditSave` fed `updated.year` into **two** fields:

```ts
audiobook_release_year: … || updated.year || …,
print_year:             updated.year || book.print_year || undefined,
```

`print_year` is when the **book** was first published. `audiobook_release_year` is when the **recording** came out. For a classic those are decades apart — a 1937 novel with a 2010 audiobook.

**So typing a year in that dialog silently replaced 1937 with 2010.** Same corruption class as the 2026-07-13 write-up, still live on this path. The blank box masked it for *display* but did nothing about *writes*.

## Fixed in the safe order

Remove the bad write first — `print_year` is now **preserve-only**, since the dialog has no print-year field and nothing there should change it — which then makes seeding the box safe.

**Reversed, this would have been actively harmful:** populating `year` first would have converted a latent corruption into one firing on *every* save. That is precisely why the previous pass left this alone and wrote it up rather than "fixing the display".

This removes an **accidental write, not a feature**.

## The blank box had a second, independent cause

The e2e fixture supplied `year: 2024` — a field the Go API **never emits**. `bookcore.go:44-45` has `print_year` and `audiobook_release_year` only. The dialog was correctly reading `audiobook_release_year` and finding nothing.

Mock rot, not app behaviour, so the fixture now describes a response that can actually occur. `mapBookToAudiobook` also carries `isbn10`/`isbn13`, which had the same omitted-field problem and no comparable write hazard.

## Verification

**`metadata-provenance`: 13 passed / 0 failed / 0 skipped, exit 0.**

`test.fixme('year and ISBN-13 populate in the edit dialog')` is now a real test — the **third of four** fixmes converted today (after the debounce in #2264 and filter-combining in #2265).

Includes a real `changelog.d` entry since this changes product behaviour.