### PR TITLE
feat(memdb): optional sorted indexes for library sort fields [skip changelog]

### DIFF
--- a/changelog.d/20260810-memdb-sorted-indexes.md
+++ b/changelog.d/20260810-memdb-sorted-indexes.md
@@ -1,0 +1,25 @@
+<!-- file: changelog.d/20260810-memdb-sorted-indexes.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: e93c17b0-5d84-4c26-a71f-08b6d3925fa4 -->
+<!-- last-edited: 2026-08-09 -->
+
+### Added
+
+- **Optional sorted indexes for the library list.** Sorting by anything other
+  than title currently disables pagination and materialises the entire
+  filtered set — all 366,916 books — to return 50 of them. Nine sort fields
+  (author, narrator, series, year, created_at, updated_at, duration,
+  file_size, bitrate) can now be given a memdb sorted index, turning that into
+  an ordered streaming walk the way title already works.
+
+  **Off by default.** Each index costs real memory, and this was measured
+  rather than estimated: at 100,000 books, enabling all nine took heap from
+  2,645 to 6,395 bytes per book (+142%), which extrapolates to **+1,312 MB**
+  at production scale, with inserts 2.8× slower. The design doc's estimate of
+  "tens of MB per sort field" was optimistic by roughly an order of magnitude,
+  because go-memdb's radix tree is immutable and path-copies nodes on every
+  insert, so cost tracks node count rather than key length.
+
+  With `enabled_sort_indexes` empty — the default — behaviour is exactly as
+  before. Enable fields individually once you know which sorts are actually
+  used, and re-measure warmup afterwards.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 // file: cmd/root.go
-// version: 1.14.0
+// version: 1.15.0
 // guid: 6a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
 // last-edited: 2026-07-01
 
@@ -482,6 +482,20 @@ func initConfig() {
 	}
 	if err := config.AppConfig.Validate(); err != nil {
 		fmt.Printf("Warning: configuration validation failed: %v\n", err)
+	}
+
+	// Select which library sort fields get a memdb sorted index. This MUST
+	// happen before any store is opened: memdbSchema() reads the enabled set
+	// once, when NewMemStore builds the schema. Doing it here — right after
+	// config load, in the single cobra.OnInitialize hook — covers every
+	// command that later calls initializeStore, rather than being repeated
+	// at each of the four call sites and eventually missed at one.
+	//
+	// Unknown names are warned about rather than ignored: a typo in config
+	// would otherwise silently leave a sort on the slow path with no
+	// indication why.
+	if unknown := database.SetEnabledSortIndexes(config.AppConfig.EnabledSortIndexes); len(unknown) > 0 {
+		fmt.Printf("Warning: unknown enabled_sort_indexes entries ignored: %v\n", unknown)
 	}
 }
 

--- a/docs/design/2026-08-09-search-backend-options.md
+++ b/docs/design/2026-08-09-search-backend-options.md
@@ -1,5 +1,5 @@
 <!-- file: docs/design/2026-08-09-search-backend-options.md -->
-<!-- version: 4.0.0 -->
+<!-- version: 4.1.0 -->
 <!-- guid: 4f1c8a72-6d93-4e05-b8a1-9c72e0f45d38 -->
 <!-- last-edited: 2026-08-09 -->
 
@@ -32,7 +32,7 @@ relevance, and answered on its own terms in §3 with numbers.
 | 3 | **Sorting moves to the backend, in Go.** Client-side sorting of paginated library slices is replaced. |
 | 4 | **"Not suck" is the bar** — the defects in §5 are not acceptable as permanent behaviour. |
 | 5 | **Index reconciliation: dirty-set + ticker, persisted to Pebble, adaptive batch.** ✅ **BUILT** — §7.3. Unblocks A1. |
-| 6 | **Sorted indexes for 9 fields:** author, narrator, series, created_at, updated_at, year, duration, file_size, bitrate. **Not** library_state/quality — low-cardinality, they are filters. §2.3. |
+| 6 | **Sorted indexes for 9 fields:** author, narrator, series, created_at, updated_at, year, duration, file_size, bitrate. **Not** library_state/quality — low-cardinality, they are filters. §2.3. ⚠️ **BUILT BUT DEFAULT-OFF** — the cost estimate this was decided on was ~10× optimistic; measured at **+1,312 MB** for all nine. Which to enable is re-opened, see §2.3. |
 | 7 | **Multi-user is REAL, not theoretical.** The per-user filter path stays and filter pushdown must be user-aware. This makes §5.2 harder, not easier — see §7.5. |
 
 ---
@@ -148,13 +148,38 @@ lowercase title per page load caused **340MB allocations per call and severe GC 
 
 ### 2.3 The fix: secondary sorted indexes
 
-A secondary index stores **keys and IDs, not books**. Sized against the measured 366,916
-books — short key + ID + tree overhead — expect **tens of MB per sort field** against
-~1.25 GB resident: low single-digit percent each. A bounded, predictable cost that
-**deletes an unbounded per-request allocation.**
-
 Each indexed field converts a full-set materialise-and-sort into the streaming walk that
-title already gets.
+title already gets. That part is right, and it is built.
+
+> ### ⚠️ Correction: this section's cost estimate was wrong by ~10×
+>
+> It previously read: *"A secondary index stores **keys and IDs, not books**… expect
+> **tens of MB per sort field** against ~1.25 GB resident: low single-digit percent
+> each."* **Decision 6 was taken on that basis. It does not hold.**
+>
+> Measured 2026-08-09 (`TestSortIndexCost`, 100,000 books, identical fixture both sides):
+>
+> | | without | all nine | delta |
+> |---|---|---|---|
+> | heap per book | 2,645 B | 6,395 B | **+142%** |
+> | at 366,916 books | 925.6 MB | 2,237.8 MB | **+1,312 MB** |
+> | insert 100K | 335 ms | 935 ms | **2.8× slower** |
+>
+> **~146 MB per sort key**, and that is a *lower* bound — the fixture leaves Author and
+> Series unset, so two of the six physical indexes hold a 1-byte "missing" key for
+> nearly every row.
+>
+> **Why the reasoning failed:** "keys and IDs, not books" is true, and led to sizing by
+> key length. But go-memdb is an **immutable** radix tree — every insert path-copies
+> nodes from root to leaf, so cost is dominated by node allocation (~417 B per book per
+> index) regardless of how short the key is. A short key is not a cheap key.
+>
+> **Consequence:** memdb is already ~1.25 GB resident with a 107.9 s warmup; all nine
+> roughly doubles it. The indexes therefore ship **opt-in and default-empty**
+> (`enabled_sort_indexes`), and which fields earn their memory is now an open decision
+> with real numbers attached — `todo.d/20260810-sort-index-memory-cost-decision.md`.
+> Nobody has measured which sorts users actually pick, so instrumenting `sort_by` for a
+> week is the cheapest way to answer it.
 
 #### What gets indexed, and what does not
 

--- a/internal/audiobooks/service_query.go
+++ b/internal/audiobooks/service_query.go
@@ -1,5 +1,5 @@
 // file: internal/audiobooks/service_query.go
-// version: 1.9.0
+// version: 1.10.0
 // guid: c5f9d4e3-f6a7-8b90-ac1d-2e3f4a5b6c7d
 // last-edited: 2026-07-18
 
@@ -38,11 +38,17 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 		f = filters[0]
 	}
 	hasSorting := f.SortBy != ""
-	// "title" sort can be pushed down to memdb (sorted radix index) — every
-	// other sort key still needs the heavy in-memory path. This is the
-	// dominant case (library page default), so the pushdown matters.
-	titleSortPushdownable := f.SortBy == "title"
-	heavySorting := hasSorting && !titleSortPushdownable
+	// Sorts backed by a memdb sorted index are pushed down and streamed;
+	// everything else still needs the heavy materialise-the-whole-set path.
+	//
+	// This used to be hardcoded as `f.SortBy == "title"`. It now asks the
+	// database package, because that is where the indexes are declared —
+	// with the hardcoded string, adding an index would have silently built a
+	// structure that nothing ever queried. Nine sort keys qualify today
+	// (author, narrator, series, year, created_at, updated_at, duration,
+	// file_size, bitrate, plus their alias spellings).
+	sortPushdownable := database.CanPushDownSort(f.SortBy)
+	heavySorting := hasSorting && !sortPushdownable
 	hasPerUser := len(f.PerUserFilters) > 0 && f.UserID != ""
 	hasFingerprintingFilters := f.FingerprintStatus != "" || f.CoveragePercentMin != nil || f.CoveragePercentMax != nil
 	// "Heavy" post-filters require fetching all rows to apply in Go.
@@ -51,7 +57,7 @@ func (svc *AudiobookService) GetAudiobooks(ctx context.Context, limit int, offse
 	// all 68K rows to satisfy ?is_primary_version=true was the prod
 	// "library spins forever" bug.
 	hasHeavyPostFilters := f.LibraryState != "" || f.Tag != "" || len(f.Tags) > 0 || len(f.FieldFilters) > 0 || hasPerUser || heavySorting || hasFingerprintingFilters
-	hasPostFilters := hasHeavyPostFilters || f.IsPrimaryVersion != nil || titleSortPushdownable
+	hasPostFilters := hasHeavyPostFilters || f.IsPrimaryVersion != nil || sortPushdownable
 
 	// When heavy post-filters are active, fetch all and filter in memory.
 	storeLimit := limit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // file: internal/config/config.go
-// version: 1.74.0
+// version: 1.75.0
 // guid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
 // last-edited: 2026-08-07
 
@@ -765,6 +765,34 @@ type Config struct {
 	// the up-to-10K sequential state reads per per-user-filtered request
 	// (spec Decision 11); NOT a feature flag. Default false = filters ON.
 	DisablePerUserSearchFilters bool `json:"disable_per_user_search_filters"`
+
+	// EnabledSortIndexes names the library sort fields that get a memdb
+	// sorted secondary index, turning "sort by X" from a
+	// materialise-the-whole-filtered-set-and-sort into a streaming walk.
+	//
+	// Recognised: author, narrator, series, year, created_at, updated_at,
+	// duration, file_size, bitrate. ("title" is always indexed and is not
+	// configurable.) Unknown names are ignored with a warning.
+	//
+	// ⚠️ DEFAULT IS EMPTY, AND THAT IS DELIBERATE. Each index costs real
+	// memory, measured rather than estimated at 100,000 books:
+	//
+	//	all nine enabled: 6,395 B/book vs 2,645 B/book — +142%
+	//	extrapolated to prod's 366,916 books: +1,312 MB
+	//	insert throughput: 2.8x slower
+	//
+	// That is ~146 MB per sort key, against a design-doc estimate of "tens
+	// of MB per field" — optimistic by roughly an order of magnitude,
+	// because go-memdb's radix tree is immutable and path-copies nodes on
+	// every insert, so cost tracks node count rather than key length.
+	//
+	// memdb is already ~1.25 GB resident with a 107.9s warmup, so enabling
+	// all nine roughly doubles it. Enable the fields that are actually
+	// sorted by, and measure warmup afterwards.
+	//
+	// Empty (the default) reproduces today's behaviour exactly: only title
+	// streams, everything else takes the existing heavy path.
+	EnabledSortIndexes []string `json:"enabled_sort_indexes" mapstructure:"enabled_sort_indexes"`
 }
 
 // mu guards AppConfig against concurrent writes.

--- a/internal/database/memdb_schema.go
+++ b/internal/database/memdb_schema.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_schema.go
-// version: 1.0.0
+// version: 1.1.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000002
 
 package database
@@ -41,12 +41,102 @@ const (
 	memIdxAliasName         = "alias_name"
 	memIdxHash              = "hash"
 	memIdxDelugeHash        = "deluge_hash"
+
+	// Sorted secondary indexes for the library list. Each turns a
+	// materialise-the-whole-filtered-set-and-sort into an ordered streaming
+	// walk, the way memIdxTitle already does for title. See
+	// memdb_sort_indexers.go for the key encoding and the field selection.
+	//
+	// Six physical indexes serve nine sort keys: duration/bitrate/file_size
+	// each have an alias spelling that maps to the same index.
+	memIdxSortAuthor    = "sort_author"
+	memIdxSortNarrator  = "sort_narrator"
+	memIdxSortSeries    = "sort_series"
+	memIdxSortYear      = "sort_year"
+	memIdxSortCreatedAt = "sort_created_at"
+	memIdxSortUpdatedAt = "sort_updated_at"
+	memIdxSortDuration  = "sort_duration"
+	memIdxSortBitrate   = "sort_bitrate"
+	memIdxSortFileSize  = "sort_file_size"
 )
 
 // memdbSchema returns the complete schema for the in-memory query layer.
 // PebbleDB remains source of truth; this schema is derived/rebuilt from Pebble
 // on startup and kept in sync via write-through.
 func memdbSchema() *memdb.DBSchema {
+	s := baseMemdbSchema()
+	// Sorted secondary indexes are attached conditionally: each costs real
+	// memory (~146 MB per key at prod scale — see config.EnabledSortIndexes),
+	// so they are opt-in rather than always-on. With none enabled this is a
+	// no-op and the schema is byte-for-byte what it was before they existed.
+	attachEnabledSortIndexes(s)
+	return s
+}
+
+// attachEnabledSortIndexes registers a sorted index on the books table for
+// each enabled sort field. Alias spellings collapse to one index.
+//
+// Indexers are attached here rather than in the schema literal so that the
+// enabled set is consulted exactly once, at schema-build time, and the
+// schema and CanPushDownSort can never disagree about which indexes exist.
+func attachEnabledSortIndexes(s *memdb.DBSchema) {
+	books := s.Tables[memTableBooks]
+	if books == nil {
+		return
+	}
+
+	// AllowMissing is deliberately NOT set on any of these: each indexer
+	// emits an explicit "missing" key for books without a value, so every
+	// book appears in every index. Letting rows be absent instead would
+	// silently drop them from the library page whenever that sort is
+	// selected — the failure titleSortIndex's comment documents.
+	all := map[string]*memdb.IndexSchema{
+		memIdxSortAuthor: {
+			Name:    memIdxSortAuthor,
+			Indexer: bookStringSortIndex{name: memIdxSortAuthor, get: bookAuthorSortValue},
+		},
+		memIdxSortNarrator: {
+			Name:    memIdxSortNarrator,
+			Indexer: bookStringSortIndex{name: memIdxSortNarrator, get: bookNarratorSortValue},
+		},
+		memIdxSortSeries: {
+			Name:    memIdxSortSeries,
+			Indexer: bookStringSortIndex{name: memIdxSortSeries, get: bookSeriesSortValue},
+		},
+		memIdxSortYear: {
+			Name:    memIdxSortYear,
+			Indexer: bookIntSortIndex{name: memIdxSortYear, get: bookYearSortValue},
+		},
+		memIdxSortCreatedAt: {
+			Name:    memIdxSortCreatedAt,
+			Indexer: bookIntSortIndex{name: memIdxSortCreatedAt, get: bookCreatedAtSortValue},
+		},
+		memIdxSortUpdatedAt: {
+			Name:    memIdxSortUpdatedAt,
+			Indexer: bookIntSortIndex{name: memIdxSortUpdatedAt, get: bookUpdatedAtSortValue},
+		},
+		memIdxSortDuration: {
+			Name:    memIdxSortDuration,
+			Indexer: bookIntSortIndex{name: memIdxSortDuration, get: bookDurationSortValue},
+		},
+		memIdxSortBitrate: {
+			Name:    memIdxSortBitrate,
+			Indexer: bookIntSortIndex{name: memIdxSortBitrate, get: bookBitrateSortValue},
+		},
+		memIdxSortFileSize: {
+			Name:    memIdxSortFileSize,
+			Indexer: bookIntSortIndex{name: memIdxSortFileSize, get: bookFileSizeSortValue},
+		},
+	}
+
+	for name := range enabledSortIndexNames() {
+		if idx, ok := all[name]; ok {
+			books.Indexes[name] = idx
+		}
+	}
+}
+
+func baseMemdbSchema() *memdb.DBSchema {
 	return &memdb.DBSchema{
 		Tables: map[string]*memdb.TableSchema{
 			memTableBooks: {

--- a/internal/database/memdb_sort_index_cost_test.go
+++ b/internal/database/memdb_sort_index_cost_test.go
@@ -1,0 +1,138 @@
+// file: internal/database/memdb_sort_index_cost_test.go
+// version: 1.0.0
+// guid: 6d0b3e57-41ac-4928-b3f6-8e17c2a95d10
+// last-edited: 2026-08-09
+//
+// Measures what the sorted secondary indexes cost, because "tens of MB per
+// field" was an estimate in the design doc and estimates are not measurements.
+//
+// Prod is 366,916 books with memdb warmup at 107.9s and ~1.25GB resident.
+// Adding nine indexes to that structure is a production-affecting change, so
+// the insert cost and the resident cost get measured on the same shape of
+// data before it ships, not after someone notices a slower boot.
+//
+// Run:
+//   go test ./internal/database/ -run TestSortIndexCost -v -count=1
+//
+// Compare against a tree without the indexes by running the identical file
+// there — the numbers only mean something as a delta.
+//
+// ⚠️ MEASURED RESULT, 2026-08-09 (100,000 books, same fixture both sides):
+//
+//	                    without      with 9 indexes    delta
+//	  heap per book     2,645 B      6,395 B           +142%
+//	  at 366,916 books  925.6 MB     2,237.8 MB        +1,312 MB
+//	  insert 100K       335 ms       935 ms            2.8x slower
+//
+// That is ~146 MB per sort key. The design doc estimated "tens of MB per
+// sort field" and was optimistic by roughly an order of magnitude.
+//
+// The reason is that go-memdb is an IMMUTABLE radix tree: every insert
+// path-copies nodes from root to leaf, so the per-index cost is dominated by
+// node allocation rather than key length — short keys do not make it cheap.
+//
+// This figure is a LOWER bound: the fixture leaves Author and Series unset,
+// so two of the six physical indexes are storing the 1-byte "missing" key
+// for nearly every row. A library with populated author/series data pays
+// more.
+//
+// Consequence: memdb is already ~1.25 GB resident with a 107.9s warmup.
+// Enabling all nine would push it past ~2.5 GB. That is a decision to take
+// with the number in hand, not on the estimate.
+
+package database
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// costBookCount is deliberately below prod's 366,916 so the test stays
+// usable in CI; the per-book cost is what extrapolates.
+const costBookCount = 100_000
+
+func TestSortIndexCost(t *testing.T) {
+	enableAllSortIndexes(t)
+	if testing.Short() {
+		t.Skip("cost measurement: not a correctness test, skipped in -short")
+	}
+
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	books := make([]Book, costBookCount)
+	for i := range books {
+		d := i % 100000
+		fs := int64(i) * 1024
+		br := 64 + (i % 256)
+		yr := 1900 + (i % 130)
+		created := base.Add(time.Duration(i) * time.Minute)
+		updated := base.Add(time.Duration(i*2) * time.Minute)
+		narrator := fmt.Sprintf("Narrator %06d", i%5000)
+		books[i] = Book{
+			ID:                   fmt.Sprintf("book-%08d", i),
+			Title:                fmt.Sprintf("Title %08d", i),
+			Narrator:             &narrator,
+			Duration:             &d,
+			FileSize:             &fs,
+			Bitrate:              &br,
+			AudiobookReleaseYear: &yr,
+			CreatedAt:            &created,
+			UpdatedAt:            &updated,
+		}
+	}
+
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+
+	// Settle the heap before the baseline reading so the fixture itself is
+	// not counted as index cost.
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	start := time.Now()
+	seedMemStore(t, m, books, nil, nil, nil)
+	insertTook := time.Since(start)
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// Both KeepAlives are load-bearing, and each was found by the delta
+	// coming out wrong:
+	//
+	//   - without KeepAlive(books) the delta is NEGATIVE (~-100MB): `books`
+	//     is dead once seedMemStore returns, so the GC between the two
+	//     readings frees the fixture that was live during the first one.
+	//   - without KeepAlive(m) the delta is ~ZERO: `m` is dead too, so the
+	//     entire memdb tree — the thing being measured — is collected before
+	//     the second reading.
+	//
+	// Go's GC collects from the last USE, not the end of scope, so a
+	// measurement bracketing an object's last use measures nothing.
+	runtime.KeepAlive(books)
+	runtime.KeepAlive(m)
+
+	heapDelta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	perBook := float64(heapDelta) / float64(costBookCount)
+
+	t.Logf("books inserted:      %d", costBookCount)
+	t.Logf("insert wall time:    %s (%.1f books/sec)",
+		insertTook.Round(time.Millisecond),
+		float64(costBookCount)/insertTook.Seconds())
+	t.Logf("heap delta:          %.1f MB", float64(heapDelta)/(1024*1024))
+	t.Logf("heap per book:       %.0f bytes", perBook)
+	t.Logf("extrapolated to prod (366,916 books): %.1f MB, insert %.1fs",
+		perBook*366916/(1024*1024),
+		insertTook.Seconds()*366916/float64(costBookCount))
+
+	// Sanity, not a threshold: a wildly wrong number means the measurement
+	// is broken rather than that the indexes are bad.
+	if heapDelta <= 0 {
+		t.Fatalf("heap delta %d is not positive — measurement is broken", heapDelta)
+	}
+}

--- a/internal/database/memdb_sort_indexers.go
+++ b/internal/database/memdb_sort_indexers.go
@@ -1,0 +1,355 @@
+// file: internal/database/memdb_sort_indexers.go
+// version: 1.0.0
+// guid: 5e7d1b94-08c6-4a32-bf51-9d2e6c0a374b
+// last-edited: 2026-08-09
+//
+// Sorted secondary indexes for the library list.
+//
+// WHY
+//
+// service_query.go:155 disables pagination whenever the sort is anything but
+// title:
+//
+//	if heavySorting { pdLimit, pdOffset = 0, 0 }   // fetch the FULL set
+//
+// That is deliberate — a sort applied after pagination only orders the rows
+// you already fetched, so it chose slow over wrong. But "slow" here means
+// materialising and sorting all 366,916 books to return 50 of them, on every
+// page load. memdb_reads.go:585 records the same shape costing 340MB of
+// allocations per call at 68K rows; at 366K it is worse.
+//
+// Title escapes this because it has a sorted index (memIdxTitle) that memdb
+// can walk in order, stopping at limit+offset. These indexers give the same
+// treatment to the fields the owner selected, converting each from a
+// full-set materialise-and-sort into a streaming walk.
+//
+// WHICH FIELDS, AND WHY NOT THE OTHERS
+//
+// Nine sort keys over six physical indexes (duration/bitrate/file_size each
+// have an alias key naming the same underlying value):
+//
+//	author, narrator, series      — identity; what a person browsing sorts by
+//	created_at, updated_at, year  — chronological
+//	duration, file_size, bitrate  — outlier-hunting and quality triage
+//
+// Deliberately NOT indexed: library_state and quality (low-cardinality —
+// sorting 366K books by a handful of distinct values yields a few enormous
+// runs in arbitrary internal order, which reads as unsorted; they belong on
+// the filter path), and genre/language/publisher/format/codec/edition/
+// sample_rate_hz (keep working via the existing materialise-and-sort; adding
+// one later is a schema entry plus a sortIndexForField line).
+//
+// KEY ENCODING — THE PART THAT HAS TO BE RIGHT
+//
+// memdb is a radix tree: it orders by BYTE comparison, not by value. A key
+// must therefore be encoded so that bytewise order equals semantic order.
+//
+//   - Every key starts with a PRESENCE byte: 0x00 present, 0x01 missing.
+//     Missing values thus sort after every present one in ascending order,
+//     matching titleSortIndex's intent ("~" sentinel) but without its edge:
+//     "~" is 0x7E, so a title beginning with any rune above U+007E would sort
+//     after the "no title" sentinel. A dedicated byte cannot collide.
+//   - Integers and times are big-endian uint64 in OFFSET-BINARY form
+//     (sign bit flipped). Two's-complement negatives have the high bit set,
+//     so raw big-endian bytes would sort every negative ABOVE every positive.
+//     Flipping the sign bit restores order. Times use UnixNano through the
+//     same path.
+//   - Strings are lowercased and null-terminated, per the memdb convention
+//     already used by titleSortIndex for prefix-iteration correctness.
+
+package database
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Presence markers. A single leading byte, so a missing value can never be
+// confused with a present one whatever the payload contains.
+const (
+	sortKeyPresent byte = 0x00
+	sortKeyMissing byte = 0x01
+)
+
+// encodeSortableInt64 renders v as an order-preserving big-endian key.
+//
+// The sign-bit flip is the load-bearing part: as raw two's-complement bytes,
+// -1 is 0xFFFF...FF and 1 is 0x0000...01, so a bytewise sort would place
+// every negative above every positive. XORing the high bit maps the signed
+// range onto the unsigned range monotonically.
+func encodeSortableInt64(v int64) []byte {
+	out := make([]byte, 1+8)
+	out[0] = sortKeyPresent
+	binary.BigEndian.PutUint64(out[1:], uint64(v)^(1<<63))
+	return out
+}
+
+// missingSortKey is the key for a book with no value for the indexed field.
+// Sorts after every present value in ascending order.
+func missingSortKey() []byte {
+	return []byte{sortKeyMissing}
+}
+
+// encodeSortableString lowercases and null-terminates, matching the existing
+// memdb string-index convention.
+func encodeSortableString(s string) []byte {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return missingSortKey()
+	}
+	out := make([]byte, 0, 1+len(s)+1)
+	out = append(out, sortKeyPresent)
+	out = append(out, s...)
+	return append(out, 0)
+}
+
+// bookStringSortIndex indexes a string-valued field extracted by get.
+// A nil/empty result becomes the missing key rather than being dropped from
+// the index — a book absent from the index vanishes from the library page
+// when sorting by that field, which is the bug titleSortIndex's comment
+// warns about.
+type bookStringSortIndex struct {
+	name string
+	get  func(*Book) string
+}
+
+func (ix bookStringSortIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	b, ok := obj.(*Book)
+	if !ok {
+		return false, nil, fmt.Errorf("%s: expected *Book, got %T", ix.name, obj)
+	}
+	return true, encodeSortableString(ix.get(b)), nil
+}
+
+func (ix bookStringSortIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("%s: expected 1 arg, got %d", ix.name, len(args))
+	}
+	s, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("%s: arg must be string, got %T", ix.name, args[0])
+	}
+	return encodeSortableString(s), nil
+}
+
+// bookIntSortIndex indexes a numeric field. get returns the value and
+// whether it is present, so a genuine zero (a 0-second duration) is
+// distinguishable from "unset" and sorts with the numbers rather than at the
+// end with the unknowns.
+type bookIntSortIndex struct {
+	name string
+	get  func(*Book) (int64, bool)
+}
+
+func (ix bookIntSortIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	b, ok := obj.(*Book)
+	if !ok {
+		return false, nil, fmt.Errorf("%s: expected *Book, got %T", ix.name, obj)
+	}
+	v, present := ix.get(b)
+	if !present {
+		return true, missingSortKey(), nil
+	}
+	return true, encodeSortableInt64(v), nil
+}
+
+func (ix bookIntSortIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("%s: expected 1 arg, got %d", ix.name, len(args))
+	}
+	switch v := args[0].(type) {
+	case int:
+		return encodeSortableInt64(int64(v)), nil
+	case int64:
+		return encodeSortableInt64(v), nil
+	case time.Time:
+		return encodeSortableInt64(v.UnixNano()), nil
+	default:
+		return nil, fmt.Errorf("%s: arg must be int, int64 or time.Time, got %T", ix.name, args[0])
+	}
+}
+
+// Field accessors. Each mirrors the comparator of the same name in
+// audiobooks/service_filtering.go, so an indexed sort and a materialised
+// sort agree. If a comparator there changes, the accessor here must change
+// with it or the two orders silently diverge.
+
+func bookAuthorSortValue(b *Book) string {
+	if b.Author != nil {
+		return b.Author.Name
+	}
+	return ""
+}
+
+func bookSeriesSortValue(b *Book) string {
+	if b.Series != nil {
+		return b.Series.Name
+	}
+	return ""
+}
+
+func bookNarratorSortValue(b *Book) string {
+	if b.Narrator != nil {
+		return *b.Narrator
+	}
+	return ""
+}
+
+// bookYearSortValue mirrors the "year" comparator: AudiobookReleaseYear
+// wins, PrintYear is the fallback, and a zero in the first is treated as
+// absent rather than as the year 0.
+func bookYearSortValue(b *Book) (int64, bool) {
+	if b.AudiobookReleaseYear != nil && *b.AudiobookReleaseYear != 0 {
+		return int64(*b.AudiobookReleaseYear), true
+	}
+	if b.PrintYear != nil && *b.PrintYear != 0 {
+		return int64(*b.PrintYear), true
+	}
+	return 0, false
+}
+
+func bookDurationSortValue(b *Book) (int64, bool) {
+	if b.Duration == nil {
+		return 0, false
+	}
+	return int64(*b.Duration), true
+}
+
+func bookBitrateSortValue(b *Book) (int64, bool) {
+	if b.Bitrate == nil {
+		return 0, false
+	}
+	return int64(*b.Bitrate), true
+}
+
+func bookFileSizeSortValue(b *Book) (int64, bool) {
+	if b.FileSize == nil {
+		return 0, false
+	}
+	return *b.FileSize, true
+}
+
+func bookCreatedAtSortValue(b *Book) (int64, bool) {
+	if b.CreatedAt == nil || b.CreatedAt.IsZero() {
+		return 0, false
+	}
+	return b.CreatedAt.UnixNano(), true
+}
+
+func bookUpdatedAtSortValue(b *Book) (int64, bool) {
+	if b.UpdatedAt == nil || b.UpdatedAt.IsZero() {
+		return 0, false
+	}
+	return b.UpdatedAt.UnixNano(), true
+}
+
+// sortIndexForField maps a sort_by key to the memdb index that can serve it
+// as an ordered walk. Keys absent from this map fall back to the existing
+// materialise-and-sort path, so adding an entry is the only step needed to
+// promote a field once its index exists.
+//
+// Alias keys (duration_seconds, bitrate_kbps, file_size_bytes) point at the
+// same index as their short form — one physical index, two spellings.
+// enabledSortIndexes holds the sort fields whose indexes are registered in
+// the schema. Empty by default, which reproduces pre-2026-08-09 behaviour
+// exactly: only title streams.
+//
+// A setter rather than reading config.AppConfig directly, because
+// internal/config already imports internal/database — reading config here
+// would be an import cycle. The dependency has to point this way.
+var (
+	enabledSortIndexesMu sync.RWMutex
+	enabledSortIndexes   = map[string]bool{}
+)
+
+// SetEnabledSortIndexes selects which sort fields get a memdb sorted index.
+// Returns any names that were not recognised, so the caller can warn rather
+// than silently ignoring a typo in config.
+//
+// ⚠️ MUST be called BEFORE the store opens. memdbSchema() reads this set
+// once, when NewMemStore builds the schema; calling it afterwards changes
+// which sorts claim to be pushdownable without changing which indexes exist,
+// and the query path would then ask memdb for an index that is not there.
+//
+// Each enabled field costs real memory — see EnabledSortIndexes in
+// internal/config for the measured figures (~146 MB per key at prod scale).
+func SetEnabledSortIndexes(fields []string) (unknown []string) {
+	enabledSortIndexesMu.Lock()
+	defer enabledSortIndexesMu.Unlock()
+
+	enabledSortIndexes = make(map[string]bool, len(fields))
+	for _, f := range fields {
+		f = strings.ToLower(strings.TrimSpace(f))
+		if f == "" {
+			continue
+		}
+		if _, ok := sortIndexForField[f]; !ok {
+			unknown = append(unknown, f)
+			continue
+		}
+		enabledSortIndexes[f] = true
+	}
+	return unknown
+}
+
+// sortIndexEnabled reports whether field's index is registered.
+func sortIndexEnabled(field string) bool {
+	enabledSortIndexesMu.RLock()
+	defer enabledSortIndexesMu.RUnlock()
+	return enabledSortIndexes[field]
+}
+
+// enabledSortIndexNames returns the distinct memdb index names to register.
+// Alias keys collapse: enabling both "duration" and "duration_seconds"
+// yields one index, not two.
+func enabledSortIndexNames() map[string]bool {
+	enabledSortIndexesMu.RLock()
+	defer enabledSortIndexesMu.RUnlock()
+
+	out := make(map[string]bool, len(enabledSortIndexes))
+	for field := range enabledSortIndexes {
+		if name, ok := sortIndexForField[field]; ok {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// CanPushDownSort reports whether sort_by=field can be served as an ordered
+// walk over a memdb index rather than by materialising the whole filtered set.
+//
+// Exported because the decision belongs to whoever owns the indexes, not to
+// the query service: audiobooks/service_query.go used to hardcode
+// `f.SortBy == "title"`, so adding an index here without editing that string
+// there would have built the index and never used it. Callers ask; they do
+// not maintain their own list.
+//
+// "title" is included even though it predates this map, so callers have one
+// question to ask instead of two.
+func CanPushDownSort(field string) bool {
+	if field == memIdxTitle {
+		return true
+	}
+	// Must consult the ENABLED set, not merely the known set: a field whose
+	// index was not registered has no index to walk, and claiming otherwise
+	// would send the query path to txn.Get with an unknown index name.
+	return sortIndexEnabled(field)
+}
+
+var sortIndexForField = map[string]string{
+	"author":           memIdxSortAuthor,
+	"narrator":         memIdxSortNarrator,
+	"series":           memIdxSortSeries,
+	"year":             memIdxSortYear,
+	"created_at":       memIdxSortCreatedAt,
+	"updated_at":       memIdxSortUpdatedAt,
+	"duration":         memIdxSortDuration,
+	"duration_seconds": memIdxSortDuration,
+	"bitrate":          memIdxSortBitrate,
+	"bitrate_kbps":     memIdxSortBitrate,
+	"file_size":        memIdxSortFileSize,
+	"file_size_bytes":  memIdxSortFileSize,
+}

--- a/internal/database/memdb_sort_indexers_test.go
+++ b/internal/database/memdb_sort_indexers_test.go
@@ -1,0 +1,391 @@
+// file: internal/database/memdb_sort_indexers_test.go
+// version: 1.0.0
+// guid: 2c8a6f31-9b07-4de5-a142-70e3d95cb864
+// last-edited: 2026-08-09
+//
+// Tests for the sorted secondary indexes.
+//
+// The high-value test here is TestSortIndexOrderMatchesComparator: the
+// indexed walk and the materialise-and-sort path must produce the SAME
+// order, because which one runs depends on whether a filter happened to be
+// active. If they diverge, "sort by duration" silently returns a different
+// order depending on unrelated query parameters — the kind of bug that is
+// nearly impossible to spot by hand.
+
+package database
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+	"time"
+)
+
+// enableAllSortIndexes turns on every sort index for the duration of a test
+// and restores the previous set afterwards. Required because the indexes are
+// opt-in: memdbSchema() reads the enabled set when the store is built, so
+// this must run BEFORE NewMemStore.
+func enableAllSortIndexes(t *testing.T) {
+	t.Helper()
+	fields := make([]string, 0, len(sortIndexForField))
+	for f := range sortIndexForField {
+		fields = append(fields, f)
+	}
+	if unknown := SetEnabledSortIndexes(fields); len(unknown) != 0 {
+		t.Fatalf("SetEnabledSortIndexes reported unknown fields %v for its own map", unknown)
+	}
+	t.Cleanup(func() { SetEnabledSortIndexes(nil) })
+}
+
+func TestEncodeSortableInt64_IsOrderPreserving(t *testing.T) {
+	// The whole point of the sign-bit flip. As raw two's-complement
+	// big-endian bytes, every negative would sort ABOVE every positive.
+	values := []int64{
+		-9223372036854775808, -1000000, -2, -1, 0, 1, 2, 1000000,
+		9223372036854775807,
+	}
+	for i := 1; i < len(values); i++ {
+		lo := encodeSortableInt64(values[i-1])
+		hi := encodeSortableInt64(values[i])
+		if bytes.Compare(lo, hi) >= 0 {
+			t.Errorf("encode(%d) should sort before encode(%d), got %x >= %x",
+				values[i-1], values[i], lo, hi)
+		}
+	}
+}
+
+func TestMissingSortsAfterEveryPresentValue(t *testing.T) {
+	missing := missingSortKey()
+
+	for _, v := range []int64{-9223372036854775808, -1, 0, 1, 9223372036854775807} {
+		if bytes.Compare(encodeSortableInt64(v), missing) >= 0 {
+			t.Errorf("present value %d must sort before missing", v)
+		}
+	}
+
+	// Strings too — including ones above "~" (0x7E), which is exactly the
+	// case the old "~" sentinel could not order correctly.
+	for _, s := range []string{"", "a", "zzz", "~tilde", "\u00e9clair", "\uffef"} {
+		enc := encodeSortableString(s)
+		if s == "" {
+			if !bytes.Equal(enc, missing) {
+				t.Errorf("empty string should encode to the missing key")
+			}
+			continue
+		}
+		if bytes.Compare(enc, missing) >= 0 {
+			t.Errorf("present string %q must sort before missing, got %x", s, enc)
+		}
+	}
+}
+
+func TestEncodeSortableString_CaseInsensitive(t *testing.T) {
+	// Mirrors the comparators, which all use strings.ToLower.
+	if !bytes.Equal(encodeSortableString("Asimov"), encodeSortableString("asimov")) {
+		t.Error("string sort key must be case-insensitive")
+	}
+	if bytes.Compare(encodeSortableString("Asimov"), encodeSortableString("banks")) >= 0 {
+		t.Error("Asimov should sort before banks case-insensitively")
+	}
+}
+
+func TestBookYearSortValue_MirrorsComparator(t *testing.T) {
+	// The "year" comparator prefers AudiobookReleaseYear, falls back to
+	// PrintYear, and treats a zero in the first as absent.
+	tests := []struct {
+		name        string
+		release     *int
+		print       *int
+		wantVal     int64
+		wantPresent bool
+	}{
+		{"release wins", ptrInt_mem(2001), ptrInt_mem(1999), 2001, true},
+		{"zero release falls back to print", ptrInt_mem(0), ptrInt_mem(1999), 1999, true},
+		{"nil release falls back to print", nil, ptrInt_mem(1999), 1999, true},
+		{"both absent", nil, nil, 0, false},
+		{"both zero is absent", ptrInt_mem(0), ptrInt_mem(0), 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &Book{AudiobookReleaseYear: tc.release, PrintYear: tc.print}
+			got, present := bookYearSortValue(b)
+			if got != tc.wantVal || present != tc.wantPresent {
+				t.Errorf("= (%d, %v), want (%d, %v)", got, present, tc.wantVal, tc.wantPresent)
+			}
+		})
+	}
+}
+
+func TestZeroValueIsPresentNotMissing(t *testing.T) {
+	// A 0-second duration is a real measurement (a broken file), not an
+	// unknown. It must sort with the numbers, not at the end with unknowns.
+	zero := 0
+	b := &Book{Duration: &zero}
+	v, present := bookDurationSortValue(b)
+	if !present || v != 0 {
+		t.Fatalf("explicit zero duration = (%d, %v), want (0, true)", v, present)
+	}
+
+	var nilDur *int
+	v, present = bookDurationSortValue(&Book{Duration: nilDur})
+	if present {
+		t.Fatalf("nil duration should be absent, got (%d, %v)", v, present)
+	}
+}
+
+// CanPushDownSort must track the ENABLED set, not the known set. If it said
+// true for a field whose index was never registered, the query path would
+// call txn.Get with an unknown index name and error at runtime.
+func TestCanPushDownSort_FollowsEnabledSet(t *testing.T) {
+	SetEnabledSortIndexes(nil)
+	t.Cleanup(func() { SetEnabledSortIndexes(nil) })
+
+	// Title is always indexed and is not configurable.
+	if !CanPushDownSort("title") {
+		t.Error("title must always be pushdownable")
+	}
+	for _, f := range []string{"author", "duration", "year"} {
+		if CanPushDownSort(f) {
+			t.Errorf("CanPushDownSort(%q) = true with nothing enabled — would query a missing index", f)
+		}
+	}
+
+	// Enabling one field must not enable its neighbours.
+	if unknown := SetEnabledSortIndexes([]string{"duration"}); len(unknown) != 0 {
+		t.Fatalf("unexpected unknown fields: %v", unknown)
+	}
+	if !CanPushDownSort("duration") {
+		t.Error("duration was enabled but is not pushdownable")
+	}
+	// Alias spelling shares the index but is a distinct key: it must be
+	// enabled explicitly, so that config says what it means.
+	if CanPushDownSort("duration_seconds") {
+		t.Error("duration_seconds should not be enabled by enabling duration")
+	}
+	if CanPushDownSort("author") {
+		t.Error("enabling duration must not enable author")
+	}
+}
+
+func TestCanPushDownSort(t *testing.T) {
+	enableAllSortIndexes(t)
+	// Indexed — must be pushdownable, or the index is built and never used.
+	for _, f := range []string{
+		"title", "author", "narrator", "series", "year",
+		"created_at", "updated_at", "duration", "file_size", "bitrate",
+		"duration_seconds", "bitrate_kbps", "file_size_bytes",
+	} {
+		if !CanPushDownSort(f) {
+			t.Errorf("CanPushDownSort(%q) = false, want true — index exists but is unused", f)
+		}
+	}
+	// Deliberately excluded. If one of these becomes true without an index
+	// being added, the query path will ask memdb for an index that is not
+	// in the schema.
+	for _, f := range []string{
+		"library_state", "quality", "genre", "language", "publisher",
+		"format", "codec", "edition", "sample_rate_hz", "", "nonsense",
+	} {
+		if CanPushDownSort(f) {
+			t.Errorf("CanPushDownSort(%q) = true, but no index is registered for it", f)
+		}
+	}
+}
+
+// Every sortIndexForField target must exist in the schema, or the query path
+// asks memdb for an unknown index and errors at runtime.
+func TestSortIndexNamesExistInSchema(t *testing.T) {
+	enableAllSortIndexes(t)
+	schema := memdbSchema()
+	books, ok := schema.Tables[memTableBooks]
+	if !ok {
+		t.Fatal("books table missing from schema")
+	}
+	for field, idxName := range sortIndexForField {
+		if _, ok := books.Indexes[idxName]; !ok {
+			t.Errorf("sort field %q maps to index %q, which is not in the schema",
+				field, idxName)
+		}
+	}
+	if _, ok := books.Indexes[memIdxTitle]; !ok {
+		t.Error("title index missing from schema")
+	}
+}
+
+// TestSortIndexOrderMatchesComparator is the important one. The indexed walk
+// and the in-memory comparator sort must agree; which path runs depends on
+// unrelated query parameters, so a divergence shows up as an order that
+// changes when you add a filter.
+func TestSortIndexOrderMatchesComparator(t *testing.T) {
+	enableAllSortIndexes(t)
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+
+	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	books := []Book{
+		{ID: "b1", Title: "One", Narrator: ptrString_mem("Zoe"), Duration: ptrInt_mem(300),
+			FileSize: ptrInt64_mem(9000), Bitrate: ptrInt_mem(128),
+			AudiobookReleaseYear: ptrInt_mem(2001), CreatedAt: &t1, UpdatedAt: &t2},
+		{ID: "b2", Title: "Two", Narrator: ptrString_mem("adam"), Duration: ptrInt_mem(100),
+			FileSize: ptrInt64_mem(100), Bitrate: ptrInt_mem(320),
+			AudiobookReleaseYear: ptrInt_mem(1999), CreatedAt: &t2, UpdatedAt: &t1},
+		// No values at all — must still appear, sorted last ascending.
+		{ID: "b3", Title: "Three"},
+		{ID: "b4", Title: "Four", Narrator: ptrString_mem("Mabel"), Duration: ptrInt_mem(0),
+			FileSize: ptrInt64_mem(0), Bitrate: ptrInt_mem(0),
+			PrintYear: ptrInt_mem(1888)},
+	}
+	seedMemStore(t, m, books, nil, nil, nil)
+
+	cases := []struct {
+		field string
+		key   func(*Book) (int64, bool)
+		str   func(*Book) string
+	}{
+		{field: "narrator", str: bookNarratorSortValue},
+		{field: "duration", key: bookDurationSortValue},
+		{field: "file_size", key: bookFileSizeSortValue},
+		{field: "bitrate", key: bookBitrateSortValue},
+		{field: "year", key: bookYearSortValue},
+		{field: "created_at", key: bookCreatedAtSortValue},
+		{field: "updated_at", key: bookUpdatedAtSortValue},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			got, err := m.GetBookSummaries(0, 0, BookSummaryFilter{
+				SortBy: tc.field, SortAscending: true,
+			})
+			if err != nil {
+				t.Fatalf("GetBookSummaries(%s): %v", tc.field, err)
+			}
+			if len(got) != len(books) {
+				t.Fatalf("indexed walk returned %d books, want %d — a book is "+
+					"missing from the %s index and would vanish from the library page",
+					len(got), len(books), tc.field)
+			}
+
+			// Independently compute the expected order from the same
+			// accessors, using a stable sort with the missing-last rule.
+			want := make([]Book, len(books))
+			copy(want, books)
+			sort.SliceStable(want, func(i, j int) bool {
+				if tc.str != nil {
+					a, b := encodeSortableString(tc.str(&want[i])), encodeSortableString(tc.str(&want[j]))
+					return bytes.Compare(a, b) < 0
+				}
+				av, ap := tc.key(&want[i])
+				bv, bp := tc.key(&want[j])
+				switch {
+				case !ap && !bp:
+					return false
+				case !ap:
+					return false // missing sorts last
+				case !bp:
+					return true
+				default:
+					return av < bv
+				}
+			})
+
+			for i := range want {
+				if got[i].ID != want[i].ID {
+					gotIDs := make([]string, len(got))
+					for k := range got {
+						gotIDs[k] = got[k].ID
+					}
+					wantIDs := make([]string, len(want))
+					for k := range want {
+						wantIDs[k] = want[k].ID
+					}
+					t.Fatalf("sort by %s:\n  indexed walk = %v\n  expected     = %v",
+						tc.field, gotIDs, wantIDs)
+				}
+			}
+		})
+	}
+}
+
+// A field that is KNOWN but NOT ENABLED must fall back to an unsorted walk,
+// not ask memdb for an index that was never registered.
+//
+// This caught a real bug during development: memdb_summaries.go mapped
+// straight through sortIndexForField (every known field) instead of checking
+// the enabled set, so `sort_by=duration` with duration disabled would have
+// called txn.Get with "sort_duration" — an index absent from the schema —
+// and failed the whole library query at runtime.
+func TestDisabledSortFieldFallsBackInsteadOfErroring(t *testing.T) {
+	SetEnabledSortIndexes(nil)
+	t.Cleanup(func() { SetEnabledSortIndexes(nil) })
+
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	books := []Book{
+		{ID: "b1", Title: "A", Duration: ptrInt_mem(30)},
+		{ID: "b2", Title: "B", Duration: ptrInt_mem(10)},
+	}
+	seedMemStore(t, m, books, nil, nil, nil)
+
+	got, err := m.GetBookSummaries(0, 0, BookSummaryFilter{
+		SortBy: "duration", SortAscending: true,
+	})
+	if err != nil {
+		t.Fatalf("disabled sort field must fall back, not error: %v", err)
+	}
+	if len(got) != len(books) {
+		t.Fatalf("fallback returned %d books, want %d", len(got), len(books))
+	}
+	// title stays available even with everything else disabled.
+	if _, err := m.GetBookSummaries(0, 0, BookSummaryFilter{
+		SortBy: "title", SortAscending: true,
+	}); err != nil {
+		t.Fatalf("title must always work: %v", err)
+	}
+}
+
+func TestSortIndexDescendingReversesAscending(t *testing.T) {
+	enableAllSortIndexes(t)
+	m, err := NewMemStore()
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	books := []Book{
+		{ID: "b1", Title: "A", Duration: ptrInt_mem(10)},
+		{ID: "b2", Title: "B", Duration: ptrInt_mem(30)},
+		{ID: "b3", Title: "C", Duration: ptrInt_mem(20)},
+		{ID: "b4", Title: "D"}, // missing
+	}
+	seedMemStore(t, m, books, nil, nil, nil)
+
+	asc, err := m.GetBookSummaries(0, 0, BookSummaryFilter{SortBy: "duration", SortAscending: true})
+	if err != nil {
+		t.Fatalf("asc: %v", err)
+	}
+	desc, err := m.GetBookSummaries(0, 0, BookSummaryFilter{SortBy: "duration", SortAscending: false})
+	if err != nil {
+		t.Fatalf("desc: %v", err)
+	}
+	if len(asc) != len(books) || len(desc) != len(books) {
+		t.Fatalf("asc=%d desc=%d, want %d each", len(asc), len(desc), len(books))
+	}
+	for i := range asc {
+		if asc[i].ID != desc[len(desc)-1-i].ID {
+			t.Fatalf("descending is not the reverse of ascending:\n asc=%v\n desc=%v",
+				ids(asc), ids(desc))
+		}
+	}
+}
+
+func ids(bs []BookSummary) []string {
+	out := make([]string, len(bs))
+	for i := range bs {
+		out[i] = bs[i].ID
+	}
+	return out
+}

--- a/internal/database/memdb_summaries.go
+++ b/internal/database/memdb_summaries.go
@@ -1,5 +1,5 @@
 // file: internal/database/memdb_summaries.go
-// version: 1.3.1
+// version: 1.4.0
 // guid: a1b2c3d4-mema-aaaa-aaaa-000000000008
 // last-edited: 2026-07-05
 
@@ -105,12 +105,29 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 		}
 		err error
 	)
+	// sortIdx is the sorted index serving this request, or "" when the sort
+	// cannot be streamed and the caller falls back to materialise-and-sort.
+	// title predates the generic map and keeps its own name.
+	//
+	// The enabled check is load-bearing: sortIndexForField lists every field
+	// that COULD be indexed, but indexes are opt-in, so mapping straight
+	// through it would hand txn.Get an index name that was never registered
+	// and error at runtime. sortIndexEnabled is the same predicate
+	// CanPushDownSort uses, so the query service and the store cannot
+	// disagree about which sorts stream.
+	sortIdx := ""
+	if f.SortBy == "title" {
+		sortIdx = memIdxTitle
+	} else if sortIndexEnabled(f.SortBy) {
+		sortIdx = sortIndexForField[f.SortBy]
+	}
+
 	switch {
-	case f.SortBy == "title":
+	case sortIdx != "":
 		if f.SortAscending {
-			iter, err = txn.Get(memTableBooks, memIdxTitle)
+			iter, err = txn.Get(memTableBooks, sortIdx)
 		} else {
-			iter, err = txn.GetReverse(memTableBooks, memIdxTitle)
+			iter, err = txn.GetReverse(memTableBooks, sortIdx)
 		}
 	case f.IsPrimaryVersion != nil:
 		iter, err = txn.Get(memTableBooks, memIdxIsPrimaryVersion, *f.IsPrimaryVersion)
@@ -121,8 +138,10 @@ func (m *MemStore) GetBookSummaries(limit, offset int, f BookSummaryFilter) ([]B
 		return nil, fmt.Errorf("memdb book_summaries scan: %w", err)
 	}
 
-	// When iterating by title, IsPrimary becomes an in-loop predicate.
-	primaryFilter := f.SortBy == "title" && f.IsPrimaryVersion != nil
+	// When iterating a sorted index, IsPrimary becomes an in-loop predicate:
+	// the ordered walk is the thing we need, and rejected rows are cheap to
+	// skip.
+	primaryFilter := sortIdx != "" && f.IsPrimaryVersion != nil
 	wantPrimary := false
 	if primaryFilter {
 		wantPrimary = *f.IsPrimaryVersion

--- a/todo.d/20260810-sort-index-memory-cost-decision.md
+++ b/todo.d/20260810-sort-index-memory-cost-decision.md
@@ -1,0 +1,73 @@
+<!-- file: todo.d/20260810-sort-index-memory-cost-decision.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 3f81a5d2-6e04-4b97-8c13-d29e0b7f461a -->
+<!-- last-edited: 2026-08-09 -->
+
+- [ ] **⚖️ DECIDE which sort indexes to enable — the design-doc cost estimate was ~10×
+      optimistic.** The machinery is built, tested and merged behind
+      `enabled_sort_indexes`, defaulting to empty (today's behaviour exactly). What is
+      left is choosing what to turn on, and that needs the real number rather than the
+      one the decision was originally made on.
+
+      ## What was decided, and on what basis
+
+      On 2026-08-09 the owner selected nine sort fields to index — author, narrator,
+      series, created_at, updated_at, year, duration, file_size, bitrate — from a design
+      doc that estimated **"tens of MB per sort field"** against ~1.25 GB resident, i.e.
+      "low single-digit percent each".
+
+      ## What it actually costs
+
+      Measured, 100,000 books, identical fixture on both sides
+      (`TestSortIndexCost`, `internal/database/memdb_sort_index_cost_test.go`):
+
+      | | without | all nine | delta |
+      |---|---|---|---|
+      | heap per book | 2,645 B | 6,395 B | **+142%** |
+      | at 366,916 books | 925.6 MB | 2,237.8 MB | **+1,312 MB** |
+      | insert 100K | 335 ms | 935 ms | **2.8× slower** |
+
+      That is **~146 MB per sort key**, not "tens of MB". memdb is already ~1.25 GB
+      resident with a 107.9 s warmup, so all nine roughly doubles it.
+
+      **And this is a LOWER bound.** The fixture leaves `Author` and `Series` unset, so
+      two of the six physical indexes store the 1-byte "missing" key for nearly every
+      row. A library with populated author/series data pays more than this.
+
+      ## Why the estimate was wrong
+
+      The doc reasoned that "a secondary index stores keys and IDs, not books", which is
+      true and led to sizing by key length. But go-memdb is an **immutable** radix tree:
+      every insert path-copies the nodes from root to leaf. Cost is dominated by node
+      allocation, so a short key is not a cheap key. Roughly 417 B per book per index
+      regardless of what the key contains.
+
+      ## The decision
+
+      Not "should we index" — the pagination-disabled full-set sort is genuinely bad.
+      It is **which fields earn ~146 MB each**, and there is no usage data to answer it:
+      nobody has measured which sorts real users pick. Options, cheapest first:
+
+      1. **Enable none for now** (current default). Costs nothing, changes nothing.
+      2. **Instrument first** — log `sort_by` values for a week, then enable only the
+         fields that actually appear. This is the option that replaces a guess with
+         evidence, and the instrumentation is small.
+      3. **Enable a chosen subset.** `created_at`/`updated_at` are the most likely to be
+         worth it ("what's new" is a real browsing pattern); the numeric triage fields
+         (duration/file_size/bitrate) are plausibly rare enough to leave on the slow path.
+      4. **Enable all nine** and accept ~2.5 GB resident. Only with headroom confirmed on
+         the host, and re-measure warmup — 107.9 s is already not short.
+
+      After enabling anything: re-measure warmup and RSS on prod, because the
+      extrapolation from 100K is linear-by-assumption and 366,916 is 3.7× further out.
+
+      ## Also worth knowing
+
+      `CanPushDownSort` consults the **enabled** set, not the known set, so a field that
+      is not indexed correctly falls back to the existing path instead of asking memdb
+      for an index that was never registered. `SetEnabledSortIndexes` must be called
+      before the store opens — it is, from the single `cobra.OnInitialize` hook in
+      `cmd/root.go`.
+
+      Related: `docs/design/2026-08-09-search-backend-options.md` §2.3 (which still
+      carries the old estimate in its prose and should be corrected to point here).


### PR DESCRIPTION
## ⚠️ Read the cost section before merging

This builds the sorted indexes decided on 2026-08-09, **but the estimate that decision was made on turns out to be ~10× optimistic.** They therefore ship **default-off**, and *which* fields to enable is re-opened as a decision with real numbers.

## The problem

Sorting the library by anything except title **disables pagination** and materialises the entire filtered set — all 366,916 books — to return 50 (`service_query.go`):

```go
pdLimit, pdOffset := limit, offset
if heavySorting { pdLimit, pdOffset = 0, 0 }   // fetch the FULL filtered set
```

Deliberate — a sort applied *after* pagination only orders rows you already fetched, so it chose slow over wrong. `memdb_reads.go:585` records the same shape costing **340MB of allocations per call** at 68K rows.

## What this adds

Nine sort keys over **six physical indexes** (duration/bitrate/file_size have alias spellings sharing one index): author, narrator, series, year, created_at, updated_at, duration, file_size, bitrate. Each converts materialise-and-sort into the streaming walk title already gets.

## 📊 The cost — measured, not estimated

`TestSortIndexCost`, 100,000 books, identical fixture on both sides:

| | without | all nine | delta |
|---|---|---|---|
| heap per book | 2,645 B | 6,395 B | **+142%** |
| at 366,916 books | 925.6 MB | 2,237.8 MB | **+1,312 MB** |
| insert 100K | 335 ms | 935 ms | **2.8× slower** |

**~146 MB per sort key**, against a design-doc estimate of "tens of MB per sort field". And it's a **lower bound** — the fixture leaves Author/Series unset, so two indexes hold a 1-byte "missing" key for nearly every row.

**Why the estimate was wrong:** the doc reasoned "an index stores keys and IDs, not books" and sized by key length. But go-memdb is an **immutable** radix tree — every insert path-copies nodes root-to-leaf, so cost is ~417 B/book/index dominated by node allocation. A short key is not a cheap key.

memdb is already ~1.25 GB resident with a 107.9 s warmup. All nine roughly doubles it.

## So: default-off

`enabled_sort_indexes` defaults to empty → **behaviour is byte-for-byte what it is today**, only title streams. Merging this changes nothing at runtime until someone opts in.

Decision deferred deliberately, with options costed, in `todo.d/20260810-sort-index-memory-cost-decision.md`. Nobody has measured which sorts users actually pick — instrumenting `sort_by` for a week is the cheapest way to answer it rather than guessing again.

## Correctness details that are load-bearing

- **Key encoding must make byte order equal semantic order** — memdb is a radix tree. Ints/times are big-endian **offset-binary** (sign bit flipped); raw two's-complement would sort every negative *above* every positive. Every key carries a leading **presence byte**, so "missing" sorts after all present values — `titleSortIndex`'s `"~"` sentinel (0x7E) can't do that for strings starting above U+007E.
- **No `AllowMissing`** on any index: each indexer emits an explicit missing key, so every book appears in every index. Absent rows would silently vanish from the library page under that sort — the failure `titleSortIndex`'s own comment warns about.
- **A real bug caught in development:** `memdb_summaries.go` first mapped through `sortIndexForField` (all *known* fields) rather than the *enabled* set, so `sort_by=duration` with duration disabled would have called `txn.Get` with an unregistered index name and failed the whole query. Both it and `CanPushDownSort` now consult the enabled set. Regression test: `TestDisabledSortFieldFallsBackInsteadOfErroring`.
- `CanPushDownSort` replaces a hardcoded `f.SortBy == "title"` in the query service — with the string, adding an index would have built a structure nothing queried.
- Accessors mirror `service_filtering.go`'s comparators one-for-one; `TestSortIndexOrderMatchesComparator` asserts indexed order == comparator order across 7 fields, because *which* path runs depends on unrelated query params.

## Tests

12 new tests + the measurement: encoding order-preservation (incl. int64 extremes), missing-sorts-last, zero-vs-absent, enabled-set behaviour, schema/map consistency, indexed-order-equals-comparator, desc-reverses-asc, disabled fallback.

`go build ./...` 0 · `go vet` 0 · database **258.4s exit 0** · audiobooks **20.9s exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp