### PR TITLE
fix(build): add -timeout 25m to the two coverage targets that lacked it [skip changelog]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # file: Makefile
-# version: 2.15.3
+# version: 2.15.4
 # guid: c1d2e3f4-g5h6-7890-ijkl-m1234567890n
-# last-edited: 2026-07-16
+# last-edited: 2026-08-10
 
 BINARY := audiobook-organizer
 ROOT_DIR := $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
@@ -289,9 +289,18 @@ smoke-run-demo:
 	@bash scripts/run_demo_recording.sh
 
 ## coverage: Generate coverage report
+#
+# -timeout 25m on every `go test ./...` here is not decoration. Go's default
+# is 10m PER PACKAGE, and internal/server alone takes ~500s on an idle Mac.
+# Running packages in parallel (which `./...` does) makes them contend, and
+# a contended run tips past 600s and dies with "panic: test timed out" —
+# naming whichever test happened to be running, which looks like a real
+# failure in an unrelated test and sends you debugging the wrong thing.
+# Observed 2026-08-09. The other three ./... targets already had it; these
+# two did not.
 coverage:
 	@echo "📊 Generating coverage report..."
-	@go test ./... -coverprofile=coverage.out -covermode=atomic
+	@go test ./... -coverprofile=coverage.out -covermode=atomic -timeout 25m
 	@go tool cover -html=coverage.out -o coverage.html
 	@echo ""
 	@echo "Coverage summary:"
@@ -302,7 +311,7 @@ coverage:
 ## coverage-check: Verify coverage meets 30% threshold (full suite)
 coverage-check:
 	@echo "🎯 Checking coverage threshold..."
-	@go test ./... -coverprofile=coverage.out -covermode=atomic >/dev/null 2>&1
+	@go test ./... -coverprofile=coverage.out -covermode=atomic -timeout 25m >/dev/null 2>&1
 	@coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/%//'); \
 	echo "Coverage: $$coverage%"; \
 	if [ $$(echo "$$coverage < 30" | bc -l) -eq 1 ]; then \

--- a/changelog.d/20260810-makefile-coverage-timeout.md
+++ b/changelog.d/20260810-makefile-coverage-timeout.md
@@ -1,0 +1,14 @@
+<!-- file: changelog.d/20260810-makefile-coverage-timeout.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 7b2e5c81-94af-4d63-8e02-15c9a6f3d740 -->
+<!-- last-edited: 2026-08-10 -->
+
+### Fixed
+
+- `make coverage` and `make coverage-check` could die with
+  "panic: test timed out" on a slow or busy machine. Go's default test
+  timeout is 10 minutes per package and `internal/server` alone takes about
+  500 seconds; running packages in parallel makes them contend and tips it
+  over. The failure names whichever test happened to be running when the
+  clock expired, so it reads as a bug in an unrelated test. Both targets now
+  pass `-timeout 25m`, matching the three sibling targets that already did.


### PR DESCRIPTION
## The bug

Go's default test timeout is **10 minutes per package**. `internal/server` alone takes ~500s on an idle Mac, and `go test ./...` runs packages in parallel — so a contended run tips past 600s and dies with `panic: test timed out after 10m0s`.

The failure names **whichever test happened to be running** when the clock expired, so it reads as a real failure in an unrelated test.

## How it surfaced

During this session a run reported `TestUpdateConfigRejectsDatabaseType` as the culprit — after 0s of its own execution. Establishing that there was no regression cost a full baseline run against main:

| run | result |
|---|---|
| branch, `./internal/server/ ./internal/database/` together | **FAIL at 600.7s** (timeout) |
| main, `./internal/server/` alone | ok, 494.9s |
| branch, `./internal/server/` alone | ok, **507.8s** |

No regression — just two heavy packages contending.

## The fix

Three of the five `go test ./...` invocations already carried `-timeout 25m`, with the rationale documented on the `test` target (Makefile:161). `coverage` and `coverage-check` did not. Both now have it, plus a comment at the target so it isn't dropped again.

**CI was never exposed** — it runs `coverage-check-short`, which already had the flag. That's precisely why this survived: latent, not breaking.

## Verification

`make -n coverage` exit 0 · `make -n coverage-check` exit 0 · all 5 `./...` invocations now carry the flag.

Also in this firing: full Playwright suite re-verified against current main (post #2268/#2269) — **550 passed, 0 failed, 10 skipped, Playwright exit 0**, both engines, 7.0m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp