### PR TITLE
docs(todo): record the fragment-assemble race that left a stale open task [skip changelog]

### DIFF
--- a/changelog.d/20260810_100000_todo_fragment_race.md
+++ b/changelog.d/20260810_100000_todo_fragment_race.md
@@ -1,0 +1,9 @@
+<!-- Documentation only — a todo.d fragment recording a process hazard found on
+     2026-08-10. No code, no behaviour change, so this fragment is deliberately
+     a no-op comment. See changelog.d/README.md.
+
+     assemble_todo.py consumes fragments (it git-rm's each one as it folds it
+     into TODO.md). If a fragment is filed and finished in separate PRs and an
+     assemble run lands between them, TODO.md keeps an open task for completed
+     work, and the finishing PR's own deletion of the fragment is a silent
+     no-op. Hit for real between PR #2272 and PR #2273; cleaned up in #2274. -->

--- a/todo.d/20260810-todo-fragment-assemble-race.md
+++ b/todo.d/20260810-todo-fragment-assemble-race.md
@@ -1,0 +1,47 @@
+- [ ] **A `todo.d` fragment assembled between the PR that files it and the PR
+      that finishes it leaves an open task in `TODO.md` for completed work.**
+      Hit for real on 2026-08-10; found only because `TODO.md` happened to be
+      re-read after the merge. Nothing reported it.
+
+      **Exact timeline** (`git log` on `main`):
+
+          04:25 EDT  a75b9ad2  PR #2272 adds
+                               todo.d/20260810-library-exhaustive-deps-…md
+          04:51 EDT  6658d1a8  assemble_todo.py folds it into TODO.md
+                               and `git rm`s the fragment  [skip ci]
+          05:12 EDT  a655753e  PR #2273 does the work and deletes the
+                               same fragment
+
+      Result: the fragment is gone, the work is done, and `TODO.md` carries an
+      unchecked `- [ ]` entry describing it — including instructions that PR
+      #2273 had just proven wrong. Cleaned up by hand in #2274.
+
+      **Why it is easy to miss.** `scripts/assemble_todo.py` *consumes*
+      fragments: `git_rm(fragments)` at `main()`'s end deletes each one as it
+      folds it in. So by the time the finishing PR merges, the fragment is
+      already gone from `main`, and that PR's own deletion of it is a silent
+      no-op. The absence of the fragment therefore proves nothing either way —
+      it looks identical whether the task was assembled or never existed.
+
+      The window is not narrow: 26 minutes here.
+
+      **A mechanical check is harder than it first looks.** The obvious one —
+      "if a PR deletes a `todo.d` fragment, require the matching `TODO.md`
+      entry to be checked off" — will not fire reliably, because after a rebase
+      the deletion may not be in the PR's diff at all (assemble already removed
+      the file upstream). And "flag any `- [ ]` entry whose
+      `<!-- file: todo.d/… -->` marker points at a missing fragment" matches
+      *every* assembled entry, since assemble always deletes. Both directions
+      are dead ends without knowing whether the work happened, which is not
+      derivable from the files.
+
+      **So the practical fix is a rule, not a script:** when a PR completes work
+      that had a `todo.d` fragment, `grep TODO.md` for it before merging and
+      check the entry off there if assemble got to it first. Worth adding to
+      `todo.d/README.md` and to the post-task hygiene list in `CLAUDE.md`,
+      beside the existing CHANGELOG/TODO/executive-summary triple.
+
+      **If a mechanical guard is wanted anyway,** the least-bad version is
+      probably a check on the *PR body*: PRs that say "closes the todo.d
+      fragment …" or delete a fragment must also touch `TODO.md`. That is a
+      heuristic, and it should be written as one rather than as a guarantee.


### PR DESCRIPTION
## What happened

`scripts/assemble_todo.py` **consumes** fragments — `git_rm(fragments)` deletes each one as it folds it into `TODO.md`. So if a fragment is filed in one PR and finished in another, and an assemble run lands between them, `TODO.md` keeps an unchecked entry for work that is already done — and the finishing PR's own deletion of the fragment is a silent no-op.

Real occurrence on 2026-08-10, in a **26-minute** window:

```
04:25 EDT  a75b9ad2  #2272 adds todo.d/20260810-library-exhaustive-deps-…md
04:51 EDT  6658d1a8  assemble_todo.py folds it into TODO.md and git-rm's it  [skip ci]
05:12 EDT  a655753e  #2273 does the work and deletes the same fragment
```

Net result: fragment gone, work done, `TODO.md` carrying an open `- [ ]` task — whose instructions #2273 had just proven wrong on two counts. Cleaned up by hand in #2274.

It was found only because `TODO.md` happened to be re-read after the merge. Nothing reported it, and nothing would have.

## Why it is easy to miss

The absence of the fragment proves nothing. Assemble always deletes fragments, so a missing fragment looks identical whether the task was assembled into `TODO.md` or never existed at all.

## Why I did not just add a CI check

Both obvious checks fail, and the fragment says so rather than shipping a guard that would give false comfort:

- **"If a PR deletes a `todo.d` fragment, require the matching `TODO.md` entry to be checked off."** Won't fire reliably — after a rebase the deletion may not be in the PR's diff at all, because assemble already removed the file upstream.
- **"Flag any `- [ ]` entry whose `<!-- file: todo.d/… -->` marker points at a missing fragment."** Matches *every* assembled entry, since assemble always deletes.

Both need to know whether the work actually happened, which is not derivable from the files. So the fragment proposes the process rule — grep `TODO.md` before merging a task-completing PR — and flags the heuristic PR-body check as a heuristic rather than a guarantee. That's a judgement call worth the owner's review; I'd rather file it honestly than ship a check that looks like coverage and isn't.

## Scope

Documentation only — one `todo.d` fragment plus a no-op `changelog.d` fragment. No code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp