### PR TITLE
chore(todo): close the two async-warmup flaky-test items [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.22.0 -->
+<!-- version: 10.23.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -3926,7 +3926,7 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
 <!-- guid: 6f10b7e4-9c25-4d83-a0f6-14b7e29d3c05 -->
 <!-- last-edited: 2026-08-03 -->
 
-- [ ] **Flaky: `TestApplyPIDRepairSameFile`** (`internal/itunes`) failed
+- [x] **Flaky: `TestApplyPIDRepairSameFile`** (`internal/itunes`) failed
       `Minimal CI / Go Tests (short, race)` on PR #2126 — a PR that touches only
       `internal/server/server_maintenance_deps.go` and cannot affect the iTunes
       package.
@@ -3943,12 +3943,43 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
       how a real regression eventually gets waved through. Related:
       [[project_ci_gotests_intermittent_stalls]].
 
+      **CLOSED 2026-08-10. The "shared cause" guess was right.** This test builds
+      its store with `newRepairTestStore`, which was one of the three helpers
+      that skipped `WaitForWarmup`; its sibling flake used `newSyncPebbleStore`,
+      another of the three. That helper now carries the reason in a comment:
+      *"Without this the repair tests read back a book_file that is in Pebble but
+      missing from memdb."* Both helpers were fixed in #2131, and the underlying
+      write-loss was structurally eliminated in `587b2fd0` (2026-08-06) — writes
+      arriving during warmup are buffered and replayed before memdb publishes
+      (`memdb_pending.go`), so the window no longer drops anything.
+
+      **Evidence for closing** (gathered 2026-08-10):
+
+      - `make test-short` runs `go test ./... -short -race`, so this test executes
+        on every `Coverage Floor` and `Go Tests (short, race)` run. Neither this
+        test nor its sibling has a `testing.Short()` guard — checked, so the runs
+        below genuinely exercised them rather than skipping them.
+      - **50 completed `Continuous Integration` runs since `587b2fd0`, 0 failures**
+        (10 further runs cancelled by `cancel-in-progress`; those are evidence of
+        nothing either way and are not counted).
+      - The fix is covered by a 6-test acceptance suite,
+        `internal/database/memdb_warmup_writeloss_test.go`, which pins the
+        invariant in both directions (dropped create, phantom after dropped
+        delete, concurrent writers, buffer-overflow degrades loudly, Reset not
+        undone) and guards against vacuous passes by skipping when the warmup
+        window was too narrow to exercise.
+
+      **What is NOT claimed:** this particular flake was never reproduced red, and
+      its mechanism is inferred from the shared helper rather than observed. The
+      case rests on mechanism + fix + regression suite + streak, not on a
+      reproduction. If it recurs, reopen — do not re-run it.
+
 <!-- file: todo.d/2026-08-03-flaky-backfill-syncids-race-sanity.md -->
 <!-- version: 1.0.0 -->
 <!-- guid: 2e58c9a1-7b34-4f60-a812-3d90f6c47b25 -->
 <!-- last-edited: 2026-08-03 -->
 
-- [ ] **Flaky: `TestBackfillSyncIDsJob_ConcurrentRaceSanity`** (`internal/maintenance/jobs`)
+- [x] **Flaky: `TestBackfillSyncIDsJob_ConcurrentRaceSanity`** (`internal/maintenance/jobs`)
       failed the Coverage Floor gate on PR #2123, a PR that touches only
       `internal/server/middleware/absauth.go` and cannot affect this package.
       Verified as a flake, not a regression: **10 consecutive passes on the PR
@@ -4000,6 +4031,35 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
       `todo.d/2026-08-01-assignorphanvgs-offset-pagination.md`, which is about offset
       arithmetic over a swapping snapshot. Same underlying async-warmup design, two
       distinct failure modes; a fix should consider both.
+
+      **CLOSED 2026-08-10 — the green streak this item was waiting on has been
+      earned, and the cause is gone rather than merely quiet.**
+
+      `WaitForWarmup` in the three helpers (#2131) was the first half. The second
+      half landed in `587b2fd0` (2026-08-06): writes arriving during warmup are
+      now buffered and replayed before memdb publishes (`memdb_pending.go`), so
+      the lost-update window is structurally closed rather than avoided. The
+      `WaitForWarmup` doc comment records the demotion — it is *"no longer
+      required for CORRECTNESS"*, only for making tests deterministic about which
+      read path they exercise.
+
+      **Evidence** (gathered 2026-08-10):
+
+      - **50 completed `Continuous Integration` runs since `587b2fd0`, 0 failures.**
+        10 more were cancelled by `cancel-in-progress`; those prove nothing and are
+        excluded.
+      - Both this test and `TestBackfillSyncIDsJob_FreshLibrary` run under
+        `go test ./... -short -race` with no `testing.Short()` guard, so every one
+        of those runs actually executed them.
+      - `internal/database/memdb_warmup_writeloss_test.go` pins the invariant in
+        six shapes, including the mirror cases the original write-up did not
+        cover: phantom rows after a dropped delete, buffer overflow refusing to
+        publish and logging at ERROR, and Reset not being undone by an in-flight
+        warmup. It also guards against vacuous passes — each test skips rather
+        than passes when the warmup window closed before any write landed.
+
+      The open sibling item above (`TestApplyPIDRepairSameFile`) is closed on the
+      same evidence; its helper was one of the same three.
 
 <!-- file: todo.d/2026-08-02-bookfile-duplication-and-duration-units.md -->
 <!-- version: 1.0.0 -->

--- a/changelog.d/20260810_110000_close_warmup_flake_todos.md
+++ b/changelog.d/20260810_110000_close_warmup_flake_todos.md
@@ -1,0 +1,13 @@
+<!-- TODO.md bookkeeping only — no code, no behaviour change, so this fragment
+     is deliberately a no-op comment. See changelog.d/README.md.
+
+     Closes the two async-warmup flaky-test items (TestApplyPIDRepairSameFile,
+     TestBackfillSyncIDsJob_ConcurrentRaceSanity). Both entries asked to stay
+     open until a green CI streak earned closing them; that streak is now 50
+     completed Continuous Integration runs since 587b2fd0 with 0 failures, and
+     both tests run under `go test ./... -short -race` with no testing.Short()
+     guard, so those runs genuinely executed them.
+
+     The cause is gone rather than quiet: WaitForWarmup in the three test
+     helpers (#2131) plus buffered replay of warmup-window writes (587b2fd0,
+     memdb_pending.go), covered by a six-shape acceptance suite. -->


### PR DESCRIPTION
## Why now

Both entries explicitly said to stay open **until a green CI streak earned closing them**. That is the condition being satisfied here — and more importantly, the cause is *gone* rather than merely quiet.

## Mechanism (already fixed, recorded here for the close-out)

`NewPebbleStore` warms memdb in a goroutine and publishes only at the very end. While `mem()` is nil, every write's memdb write-through was silently dropped — reads stayed correct (they fall back to Pebble) but a test seeding books in that window left them in Pebble while the published memdb never saw them. `ListBookIDs` takes the memdb fast path, so those books were never enumerated and never got a syncID.

Fixed in two halves:

1. `WaitForWarmup` added to the three test helpers (#2131).
2. The window itself structurally closed in `587b2fd0` (2026-08-06): warmup-window writes are buffered and replayed before memdb publishes (`memdb_pending.go`). The `WaitForWarmup` doc comment records the demotion — it is now *"no longer required for CORRECTNESS"*.

**The "shared cause" guess in the `TestApplyPIDRepairSameFile` entry was right.** It builds its store with `newRepairTestStore`; the sibling flake used `newSyncPebbleStore` — two of the same three helpers.

## Evidence

| Check | Result |
|---|---|
| `Continuous Integration` runs since `587b2fd0` | **50 completed, 0 failures** |
| Cancelled runs in that window | 10 — excluded; a cancelled run is evidence of nothing |
| Do those runs execute these tests? | Yes — `make test-short` is `go test ./... -short -race`, and **neither test has a `testing.Short()` guard** (checked) |
| Regression coverage | `memdb_warmup_writeloss_test.go`, six shapes |
| Local sanity check | both pass **15× with `-race`**, exit 0 |

The regression suite is worth noting: it pins the invariant in both directions (dropped create; *phantom row* after a dropped delete), plus concurrent writers, buffer-overflow refusing to publish and logging at ERROR, and Reset not being undone by an in-flight warmup. It also guards against vacuous passes — each test **skips rather than passes** when the warmup window closed before any write landed.

## What is deliberately not claimed

- The local 15× run is a **sanity check, not evidence**. The original entries logged 10/10 and 25/25 local passes *while the flake was still live*, so local runs were never the discriminator.
- `TestApplyPIDRepairSameFile` was **never reproduced red**. Its mechanism is inferred from the shared helper, not observed. The case rests on mechanism + fix + regression suite + streak. The TODO entry states this.
- If either recurs, **reopen — do not re-run**. That is the failure mode both entries warned about.

## Scope

`TODO.md` bookkeeping only — no code, no behaviour change. 10.22.0 → 10.23.0; unchecked items 98 → 96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp