### PR TITLE
docs(todo): reproduce the GetBooksByVersionGroup partial-index under-report [skip changelog]

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.24.0 -->
+<!-- version: 10.25.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -3834,6 +3834,19 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
   Damage in the range 1..n-1 is the only damage that is invisible. The probe
   also confirmed the authoritative row still carried the right
   `VersionGroupID` throughout — the truth was present and simply not consulted.
+
+  **That third row also discriminates between the four fix directions**, and is
+  the most decision-relevant thing measured here. Because a fully-empty index
+  returns the correct set, direction 3 (rebuild `book:versiongroup:*`) is
+  *provably sufficient against the read path exactly as it stands* — it needs no
+  code change at all to a function that `metafetch` writes through, only a repair
+  run. Directions 1 and 4 change that read path's results; direction 2 fixes only
+  future writes. So the real question for the owner is narrower than four
+  options: **is a one-off prod repair enough, or does the read path also need to
+  stop trusting a non-empty index?** Anything that can drop index rows again
+  (or any group that acquires members through a path not tripping the
+  `VersionGroupID`-changed comparison) re-opens the hole, which argues for doing
+  3 now and 2 or 4 as the durable guard.
 
   Confirmed unaffected by memdb warmth: the enumeration reads `p.db` directly,
   so the repro does not depend on warmup timing.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 <!-- file: TODO.md -->
-<!-- version: 10.23.0 -->
+<!-- version: 10.24.0 -->
 <!-- guid: 8e7d5d79-394f-4c91-9c7c-fc4a3a4e84d2 -->
 <!-- last-edited: 2026-08-10 -->
 
@@ -3804,6 +3804,69 @@ deleted rather than rewritten, since the capabilities themselves are gone. Relat
      non-empty, not only when it changes (idempotent write).
   3. Add a repair op that rebuilds `book:versiongroup:*` from the Book rows, and
      run it once — existing groups are already affected.
+  4. *(added 2026-08-10)* **Read through memdb instead.**
+     `internal/database/memdb_schema.go:176` already declares
+     `memIdxVersionGroupID` over `Book.VersionGroupID`, memdb stores full
+     `*Book` values (`memdb_reads.go:606,622`), and `GetBooksByVersionGroup`
+     **never calls `p.mem()`** — it goes straight to Pebble. That index is
+     complete by construction and costs O(|group|), so it needs neither a
+     completeness heuristic (1) nor a backfill (3). Not adopted unreviewed: it
+     necessarily returns MORE members than today, and `metafetch`
+     (`service_apply.go:303`, `service_writeback.go:872`) enumerates siblings
+     through this call before writing to them. Returning the correct set is the
+     point, but it widens what those write paths touch, so it wants an owner's
+     eyes rather than an autonomous merge.
+
+  **REPRODUCED 2026-08-10** (deterministically, in a throwaway probe — see
+  "why this is not committed" below). Create two books in one group, then
+  `pebble.Delete` exactly ONE `book:versiongroup:<gid>:<id>` row, leaving both
+  authoritative `book:<id>` rows untouched:
+
+  | Index state | `GetBooksByVersionGroup` |
+  |---|---|
+  | both members indexed | **2** ✓ |
+  | **one** row dropped | **1** ✗ — the second book vanishes |
+  | **both** rows dropped | **2** ✓ — the documented fallback engages |
+
+  **Losing more index data produces a more correct answer.** That third row is
+  the crux: the `len(books) > 0` guard cannot distinguish "found everything"
+  from "found something", so an empty index is safe and a partial one is not.
+  Damage in the range 1..n-1 is the only damage that is invisible. The probe
+  also confirmed the authoritative row still carried the right
+  `VersionGroupID` throughout — the truth was present and simply not consulted.
+
+  Confirmed unaffected by memdb warmth: the enumeration reads `p.db` directly,
+  so the repro does not depend on warmup timing.
+
+  **Why this is not committed as a test yet.** It is red against `main`, and a
+  knowingly-red test on `main` is the same class of "green means nothing" defect
+  this backlog keeps turning up. It belongs in
+  `internal/database/pebble_store_index_consistency_test.go` — which already has
+  the `store.(*PebbleStore)` / `ps.db` raw-index pattern and the sibling
+  soft-delete cases — landing in the SAME PR as whichever fix direction is
+  chosen. Ready to paste:
+
+  ```go
+  vg := "VG0000000000000000000PROBE"
+  a, _ := store.CreateBook(&Book{Title: "Alpha", FilePath: "/probe/a.mp3", VersionGroupID: strPtr(vg)})
+  b, _ := store.CreateBook(&Book{Title: "Beta",  FilePath: "/probe/b.mp3", VersionGroupID: strPtr(vg)})
+  ps := store.(*PebbleStore)
+  // Simulate partial backfill: drop ONE member's index row.
+  _ = ps.db.Delete([]byte(fmt.Sprintf("book:versiongroup:%s:%s", vg, b.ID)), pebble.Sync)
+  got, _ := store.GetBooksByVersionGroup(vg)
+  if len(got) != 2 {
+      t.Errorf("live book %s absent from its own version-group listing: got %d %v", b.ID, len(got), titles(got))
+  }
+  _ = a
+  ```
+
+  Note `dbtest.AssertStoreInvariants` invariant (b) — "a LIVE book must be
+  discoverable by its own version-group listing" — is *already* exactly this
+  assertion and passes everywhere it is called. It cannot catch this: its
+  package doc states it uses only the exported Store surface and so "cannot see
+  raw secondary-index rows", meaning no caller has ever constructed a partial
+  index for it to inspect. The invariant was never wrong; nothing ever put it in
+  front of the failing state.
 
   **Also needs an invariant test**: after linking N books into a group and
   setting one primary, exactly one member must have `IsPrimaryVersion == true`.

--- a/changelog.d/20260810_120000_versiongroup_partial_index_repro.md
+++ b/changelog.d/20260810_120000_versiongroup_partial_index_repro.md
@@ -1,0 +1,15 @@
+<!-- TODO.md evidence only — no code, no behaviour change, so this fragment is
+     deliberately a no-op comment. See changelog.d/README.md.
+
+     Records a deterministic reproduction of the GetBooksByVersionGroup
+     under-report (open item, found in prod 2026-08-06). Dropping exactly ONE
+     book:versiongroup:<gid>:<id> row hides that member; dropping BOTH returns
+     both, because the len(books) > 0 guard only falls back on an EMPTY index.
+     Losing more index data produces a more correct answer.
+
+     No fix is included: the read path feeds metafetch's sibling-writeback
+     enumeration, and the entry asks for the fix direction to be chosen after
+     measuring how prevalent partial indexes are in prod — which needs prod
+     access. A fourth direction is added (memdb already carries a complete
+     VersionGroupID index that this function never consults). The test is left
+     uncommitted rather than committed red or skipped. -->


### PR DESCRIPTION
## Why

`GetBooksByVersionGroup` under-reports group membership — found in production 2026-08-06, still open. This PR does **not** fix it. It turns an unreproduced production report into a deterministic reproduction, which every proposed fix direction needs before it can be verified.

## Reproduced

Create two books in one version group, then `pebble.Delete` exactly **one** `book:versiongroup:<gid>:<id>` row, leaving both authoritative `book:<id>` rows untouched:

| Index state | `GetBooksByVersionGroup` |
|---|---|
| both members indexed | **2** ✓ |
| **one** row dropped | **1** ✗ — the second book vanishes |
| **both** rows dropped | **2** ✓ — the documented fallback engages |

**Losing more index data produces a more correct answer.** That third row is the crux. The guard is

```go
if len(books) > 0 { sortVersions(books); return books, nil }
// Fallback: full scan for groups whose index hasn't been backfilled yet
```

which cannot distinguish "found everything" from "found something". An empty index is safe; a partial one is not. Damage in the range `1..n-1` is the only damage that is invisible.

Two things the probe also established:

- The authoritative `book:<id>` row carried the correct `VersionGroupID` the whole time. The truth was present and simply not consulted.
- The repro does **not** depend on memdb warmup timing — the enumeration reads `p.db` directly.

## The control narrows the owner's decision

That third row is not a curiosity about the guard — it is the discriminating fact. Because a fully-empty index returns the **correct** set, direction **#3** (rebuild `book:versiongroup:*`) is *provably sufficient against the read path exactly as it stands*: no code change at all to a function `metafetch` writes through, only a repair run. Directions #1 and #4 change that path's results; #2 fixes only future writes.

So the question is narrower than four options: **is a one-off prod repair enough, or does the read path also need to stop trusting a non-empty index?** Anything that can drop index rows again — or any group acquiring members through a path that does not trip the `VersionGroupID`-changed comparison — re-opens the hole, which argues for #3 now and #2 or #4 as the durable guard.

## Why no fix here

The entry says "Fix directions (pick after measuring)", and the measurement it asks for — how prevalent partial indexes are in prod — needs prod access. The directions are not interchangeable: #2 alone leaves existing groups broken, #3 requires a prod run.

The read path also feeds `metafetch`'s sibling enumeration before writeback (`service_apply.go:303`, `service_writeback.go:872`). Any correct fix necessarily returns **more** members, which widens what those write paths touch. That is the intended outcome, not a side effect — but it is an owner's call, not an autonomous merge at 08:00.

A **fourth direction** is added for consideration: `memdb_schema.go:176` already declares `memIdxVersionGroupID` over `Book.VersionGroupID`, memdb stores full `*Book` values, and `GetBooksByVersionGroup` **never calls `p.mem()`**. That index is complete by construction and costs `O(|group|)` — it needs neither a completeness heuristic (#1) nor a backfill (#3).

## Why the test is not committed

It is red against `main`. Committing it red breaks CI; skipping it is the exact pattern this backlog exists to prevent — six spec files sat disabled for four months. So the ready-to-paste test and its intended home (`internal/database/pebble_store_index_consistency_test.go`, which already has the `store.(*PebbleStore)` / `ps.db` raw-index pattern and the sibling soft-delete cases) are recorded in the entry, to land in the **same PR as the chosen fix**.

## The invariant that already existed

`dbtest.AssertStoreInvariants` invariant (b) is *already* this exact assertion — "a LIVE book must be discoverable by its own version-group listing" — and passes at all 19 call sites. It cannot catch this. Its own package doc says it uses only the exported `Store` surface and therefore "cannot see raw secondary-index rows", so no caller has ever constructed a partial index for it to inspect.

The invariant was never wrong. Nothing ever put it in front of the failing state. That is the same shape as the five mechanisms found earlier this week that reported success while meaning nothing.

## Scope

`TODO.md` (evidence appended to the existing open entry; version 10.23.0 → 10.24.0) and a no-op changelog fragment. No code, no test, no behaviour change — suite counts unaffected. Last full e2e run on `main`: **556 passed / 0 failed / 8 skipped**.

The entry is edited directly rather than via a `todo.d` fragment because its fragment was already consumed into `TODO.md`; a new fragment would duplicate the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnjSNo2WizbcnrW4pXT2xp
